### PR TITLE
fix(ci): set distinct outDir for story-backfiller and task-run-poller tsconfigs

### DIFF
--- a/apps/story-backfiller/tsconfig.json
+++ b/apps/story-backfiller/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": false,
-    "outDir": ".",
+    "outDir": "./dist",
     "rootDir": "."
   },
   "include": ["index.ts"]

--- a/apps/task-run-poller/tsconfig.json
+++ b/apps/task-run-poller/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "outDir": ".",
+    "outDir": "./dist",
     "rootDir": ".",
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Why

`pnpm build` has been failing in CI for ~3 days, blocking PR #43 (consolidation) and PR #44 (vendor packages).

The `story-backfiller` and `task-run-poller` daemons (vendored from the conductor repo as part of the monorepo consolidation) have tsconfigs with `outDir: "."` and `rootDir: "."`. When `outDir` falls inside the source directory, `tsc` auto-excludes `outDir` from the input set — leaving the `include` array (`["index.ts"]`) effectively empty:

```
TS18003: No inputs were found in config file 'apps/story-backfiller/tsconfig.json'.
Specified 'include' paths were '["index.ts"]' and 'exclude' paths were
'[".../apps/story-backfiller"]'.
```

## What

Emit to `./dist` (already gitignored). Source layout unchanged.

## Verification

```bash
cd apps/story-backfiller && npx tsc --noEmit  # exit 0
cd apps/task-run-poller  && npx tsc --noEmit  # exit 0
```

## Scope note

This PR is tightly scoped to TS18003. `pnpm build` still fails after this fix on `@caia-app/executor` and `@caia-app/orchestrator-middleware` because their tsconfigs extend `../../tsconfig.json` which doesn't exist in this monorepo (the root file is `tsconfig.base.json`). `executor/tsconfig.json` also sets an invalid `ignoreDeprecations: "6.0"` (only `"5.0"` is accepted). Those issues come from the same consolidation vendoring and are reported separately for follow-up.