### PR TITLE
feat(lift): batch A — quick wins from conductor archive

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,117 @@
+# .gitleaks.toml — Conductor secrets scan rules
+# Extends gitleaks defaults; add project-specific patterns below.
+title = "Conductor Gitleaks Config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key"
+regex = '''sk-ant-api03-[a-zA-Z0-9\-_]{93}'''
+keywords = ["sk-ant-"]
+tags = ["anthropic", "key"]
+
+[[rules]]
+id = "openai-api-key"
+description = "OpenAI API key"
+regex = '''sk-[a-zA-Z0-9]{48}'''
+keywords = ["sk-"]
+tags = ["openai", "key"]
+
+[[rules]]
+id = "cloudflare-global-api-key"
+description = "Cloudflare Global API Key"
+regex = '''(?i)(CF_API_KEY|X-Auth-Key)[=\s:"\'']+([0-9a-f]{37})'''
+keywords = ["CF_API_KEY", "X-Auth-Key"]
+tags = ["cloudflare", "key"]
+
+[[rules]]
+id = "cloudflare-api-token"
+description = "Cloudflare scoped API token"
+regex = '''(?i)(CF_API_TOKEN|CLOUDFLARE_API_TOKEN)[=\s:"\'']+([a-zA-Z0-9\-_]{40})'''
+keywords = ["CF_API_TOKEN", "CLOUDFLARE_API_TOKEN"]
+tags = ["cloudflare", "token"]
+
+[[rules]]
+id = "ga4-service-account"
+description = "GA4 / GCP service account JSON credential shape"
+regex = '''"type"\s*:\s*"service_account"'''
+keywords = ["service_account"]
+tags = ["gcp", "ga4", "service-account"]
+
+[[rules]]
+id = "stripe-live-secret"
+description = "Stripe live secret key"
+regex = '''sk_live_[a-zA-Z0-9]{24,99}'''
+keywords = ["sk_live_"]
+tags = ["stripe", "key"]
+
+[[rules]]
+id = "stripe-restricted-key"
+description = "Stripe restricted key"
+regex = '''rk_live_[a-zA-Z0-9]{24,99}'''
+keywords = ["rk_live_"]
+tags = ["stripe", "key"]
+
+[[rules]]
+id = "sendgrid-api-key"
+description = "SendGrid API key"
+regex = '''SG\.[a-zA-Z0-9\-_]{22}\.[a-zA-Z0-9\-_]{43}'''
+keywords = ["SG."]
+tags = ["sendgrid", "key"]
+
+[[rules]]
+id = "github-pat-classic"
+description = "GitHub Personal Access Token (classic)"
+regex = '''ghp_[a-zA-Z0-9]{36}'''
+keywords = ["ghp_"]
+tags = ["github", "pat"]
+
+[[rules]]
+id = "github-pat-fine-grained"
+description = "GitHub fine-grained PAT"
+regex = '''github_pat_[a-zA-Z0-9_]{82}'''
+keywords = ["github_pat_"]
+tags = ["github", "pat"]
+
+[[rules]]
+id = "cloudinary-url"
+description = "Cloudinary API URL with credentials"
+regex = '''cloudinary://[a-zA-Z0-9_\-]+:[a-zA-Z0-9_\-]+@[a-zA-Z0-9_\-]+'''
+keywords = ["cloudinary://"]
+tags = ["cloudinary", "url"]
+
+[[rules]]
+id = "pixabay-api-key"
+description = "Pixabay API key"
+regex = '''(?i)(PIXABAY_KEY|PIXABAY_API)[=\s:"\'']+([0-9]{7}-[a-f0-9]{32})'''
+keywords = ["PIXABAY_KEY", "PIXABAY_API"]
+tags = ["pixabay", "key"]
+
+[allowlist]
+description = "Test fixtures, example files, and known-safe patterns"
+regexes = [
+  '''sk-ant-EXAMPLE''',
+  '''sk-test-''',
+  '''sk_test_''',
+  '''rk_test_''',
+  '''SG\.EXAMPLE''',
+  '''ghp_EXAMPLE''',
+  '''github_pat_EXAMPLE''',
+  '''cloudinary://example''',
+  '''YOUR_API_KEY''',
+  '''PLACEHOLDER''',
+  '''<your-''',
+  '''INSERT_HERE''',
+]
+paths = [
+  '''.gitleaks.toml''',
+  '''tests/fixtures/.*''',
+  '''__fixtures__/.*''',
+  '''\.example$''',
+  '''\.sample$''',
+  '''README\.md''',
+  '''CHANGELOG\.md''',
+  '''docs/.*\.md''',
+]

--- a/apps/completeness-sentinel/plist/com.conductor.completeness-sentinel.plist
+++ b/apps/completeness-sentinel/plist/com.conductor.completeness-sentinel.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.conductor.completeness-sentinel</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/node</string>
+        <string>/Users/MAC/Documents/projects/plugins/completeness-sentinel/dist/daemon.cjs</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CONDUCTOR_API</key>
+        <string>http://localhost:7776</string>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+        <key>CONDUCTOR_PROJECT_ROOT</key>
+        <string>/Users/MAC/Documents/projects</string>
+    </dict>
+    <key>StartInterval</key>
+    <integer>7200</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/conductor-completeness-sentinel.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/conductor-completeness-sentinel.err</string>
+</dict>
+</plist>

--- a/apps/orchestrator/tests/dashboard/health.test.ts
+++ b/apps/orchestrator/tests/dashboard/health.test.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as http from 'http';
+import { Conductor } from '../../src/index';
+import { createHealthServer } from '../../src/http/health';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'conductor-dash-'));
+}
+
+function httpGet(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      let body = '';
+      res.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => { req.destroy(); reject(new Error('timeout')); });
+  });
+}
+
+describe('HTTP Health Server', () => {
+  let tmpDir: string;
+  let conductor: Conductor;
+  let server: http.Server;
+  const PORT = 17778;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir();
+    conductor = new Conductor(tmpDir);
+    await conductor.init();
+    server = createHealthServer(conductor, PORT);
+    await new Promise<void>(resolve => server.listen(PORT, resolve));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    await conductor.shutdown?.();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('GET /health', () => {
+    it('returns correct shape when conductor is up', async () => {
+      const res = await httpGet(`http://localhost:${PORT}/health`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as Record<string, unknown>;
+      expect(data['ok']).toBe(true);
+      expect(typeof data['uptime']).toBe('number');
+      expect(data['uptime']).toBeGreaterThanOrEqual(0);
+      expect('lastEvent' in data).toBe(true);
+      expect(typeof data['pendingTasks']).toBe('number');
+    });
+
+    it('returns pendingTasks count correctly', async () => {
+      await conductor.add({ title: 'Task 1', cwd: '/tmp', files: ['src/a.ts'] });
+      await conductor.add({ title: 'Task 2', cwd: '/tmp', files: ['src/b.ts'] });
+
+      const res = await httpGet(`http://localhost:${PORT}/health`);
+      const data = JSON.parse(res.body) as Record<string, unknown>;
+      expect(data['pendingTasks']).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('GET /status', () => {
+    it('returns full ConductorState', async () => {
+      const res = await httpGet(`http://localhost:${PORT}/status`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as Record<string, unknown>;
+      expect(data['tasks']).toBeDefined();
+      expect(data['events']).toBeDefined();
+      expect('lastEventId' in data).toBe(true);
+    });
+  });
+
+  describe('GET /tasks', () => {
+    it('returns task array', async () => {
+      await conductor.add({ title: 'Dash task', cwd: '/tmp', files: ['src/dash.ts'] });
+      const res = await httpGet(`http://localhost:${PORT}/tasks`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as unknown[];
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it('returns empty array when no tasks', async () => {
+      const res = await httpGet(`http://localhost:${PORT}/tasks`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as unknown[];
+      expect(Array.isArray(data)).toBe(true);
+    });
+  });
+
+  describe('GET /events', () => {
+    it('returns events array', async () => {
+      await conductor.add({ title: 'Event task', cwd: '/tmp', files: ['src/ev.ts'] });
+      const res = await httpGet(`http://localhost:${PORT}/events`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as unknown[];
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBeGreaterThan(0);
+    });
+
+    it('supports since query param', async () => {
+      await conductor.add({ title: 'Event A', cwd: '/tmp', files: ['src/ea.ts'] });
+      const state = conductor.status();
+      const lastId = state.lastEventId;
+      await conductor.add({ title: 'Event B', cwd: '/tmp', files: ['src/eb.ts'] });
+
+      const res = await httpGet(`http://localhost:${PORT}/events?since=${lastId}`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as unknown[];
+      expect(Array.isArray(data)).toBe(true);
+      // Should only include events after lastId
+      expect(data.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('GET /dag', () => {
+    it('returns dag with nodes and edges', async () => {
+      const res = await httpGet(`http://localhost:${PORT}/dag`);
+      expect(res.status).toBe(200);
+      const data = JSON.parse(res.body) as Record<string, unknown>;
+      expect(Array.isArray(data['nodes'])).toBe(true);
+      expect(Array.isArray(data['edges'])).toBe(true);
+    });
+  });
+
+  describe('404 handling', () => {
+    it('returns 404 for unknown routes', async () => {
+      const res = await httpGet(`http://localhost:${PORT}/unknown-route`);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/docs/legacy-conductor-reports/BACKEND-V2-2026-04-20.md
+++ b/docs/legacy-conductor-reports/BACKEND-V2-2026-04-20.md
@@ -1,0 +1,327 @@
+# Conductor Backend v2 — Implementation Report
+**Date:** 2026-04-20 (completed 2026-04-21T00:30:58Z)
+**Status:** COMPLETE — 296/296 tests pass (237 existing + 59 new)
+
+---
+
+## Summary
+
+Conductor evolved from JSONL-based event sourcing to a proper application with SQLite (Drizzle ORM), REST + WebSocket API (Hono), real-time dashboard push, and new first-class concepts: Projects, ADRs, Business Features, Proactive Suggestions, Timeline, and Audit Log. All existing functionality preserved.
+
+---
+
+## Schema — 10 tables in `src/db/schema.ts`
+
+| Table | Purpose | Key additions |
+|---|---|---|
+| `projects` | First-class project registry | slug (unique), kind, color, icon, liveUrl |
+| `requirements` | Mirror of JSONL + SQL queries | + projectId, scope |
+| `tasks` | Mirror of JSONL + SQL queries | + projectId, scope |
+| `blockers` | Mirror of JSONL + SQL queries | + projectId, scope |
+| `questions` | Mirror of JSONL + SQL queries | + projectId, scope |
+| `adrs` | Architecture Decision Records | number (auto-inc), status, context, decision |
+| `business_features` | Roadmap features | phase (1/2/3/icebox), linkedRequirements |
+| `proactive_suggestions` | AI-initiated suggestions | options (JSON), state, acceptedOption |
+| `timeline_events` | Append-only activity log | kind, actor, summary, subjectKind/subjectId |
+| `audit_log` | Every mutation before/after | actor, action, entityKind, entityId |
+
+Every user-facing table has nullable `projectId` FK + `scope` (`global|site|plugin`) + indexes.
+
+`timeline_events` additional indexes: `(actor, created_at)`, `(subject_kind, subject_id, created_at)`.
+
+---
+
+## Migrations (2 files, `src/db/migrations/`)
+
+| File | Lines | Purpose |
+|---|---|---|
+| `0000_optimal_risque.sql` | 183 | Full schema (all 10 tables + indexes) |
+| `0001_timeline_enrich.sql` | 6 | Adds `actor`, `summary` + 2 indexes to `timeline_events` |
+
+Auto-run on startup via `runMigrations()`.
+
+---
+
+## New Source Files
+
+**DB Layer (`src/db/`):**
+`schema.ts` · `connection.ts` (+ `getSqliteRaw()` for FTS5) · `seed-projects.ts` (12 projects) · `seed-adr.ts` (ADR-011) · `migrate-from-jsonl.ts` (idempotent)
+
+**API Layer (`src/api/routes/`):**
+`projects.ts` · `adrs.ts` · `features.ts` · `suggestions.ts` · `timeline.ts` · `audit.ts` · `metrics.ts` · `legacy.ts` (backward-compat proxies)
+
+**WebSocket (`src/ws/`):**
+`bus.ts` (typed EventBus) · `index.ts` (`attachWsServer`)
+
+---
+
+## API Endpoints
+
+**New endpoints (all accept `?projectId=`):**
+```
+GET/POST /projects, GET/PUT /projects/:id
+GET/POST /adrs, GET/PUT /adrs/:id
+GET/POST /features, PUT /features/:id
+GET/POST /suggestions, POST /suggestions/:id/accept|custom
+GET      /timeline   ?since&until&kind(glob)&actor&projectId&subject&cursor&search&limit&export=csv
+POST     /timeline
+GET      /audit      ?entityKind&entityId&projectId
+GET      /metrics    ?projectId
+GET      /health     → { ok, db: 'connected', schema: 'v2' }
+ws://localhost:7776/events
+```
+
+**Preserved (same shape):** `/requirements` · `/blockers` · `/questions` · `/tasks` · `/counts`
+
+---
+
+## Timeline Features
+
+- Cursor-based pagination (`?cursor=<id>`, returns `{ events, nextCursor }`)
+- Full-text search (`?search=<q>`) via FTS5 virtual table + triggers
+- `?export=csv` downloads current filter as CSV
+- `actor` field: `ai|user|system|hook|watchdog|pump`
+- `summary` field: pre-rendered human-readable one-liner
+- Kind glob filter: `?kind=blocker.*` matches all blocker events
+- Per-entity mini-timeline: `?subject=<id>`
+
+---
+
+## 15 New MCP Tools
+
+`adr_create/list/update` · `feature_create/list/update` · `suggestion_create/list/drain` · `timeline_append/query` · `audit_query` · `metrics_snapshot` · `project_list/create`
+
+All 25 original tools unchanged.
+
+---
+
+## Seeded Data (on first startup)
+
+**12 Projects:** PokerZeno · Roulette Community · Conductor · Image Provider · Cast Bridge · DevInspector · Analytics · Backend Core · Content Engine · SEO Program · Integrity Check · PokerZeno Framework
+
+**1 ADR:** ADR-011 (Conductor Backend Evolution to SQLite + Hono + WebSocket, accepted)
+
+---
+
+## JSONL → SQLite Migration
+
+`src/db/migrate-from-jsonl.ts` — reads `~/.conductor/*.snapshot.json`, upserts SQLite (idempotent).
+
+Project inference order:
+1. `targetProject` string → slug/name match
+2. File path globs (`poker-zeno/*` → pokerzeno, etc.)
+3. Title/description keyword match (14 mappings)
+4. Fallback: `projectId = null`, `scope = global`
+
+---
+
+## Dashboard — Full App Router Routing
+
+`localhost:7777` now uses Next.js App Router with 30+ routes.
+
+**Key routes:**
+```
+/                   → redirects to /timeline
+/timeline           → live activity feed (DEFAULT LANDING)
+/projects           → project grid
+/projects/:slug     → per-project overview + metrics bar
+/projects/:slug/requirements|blockers|questions|tasks|timeline
+/tasks/:id · /requirements/:id · /blockers/:id · /questions/:id
+/adrs · /adrs/:number
+/features · /features/:id
+/suggestions
+/audit · /audit/:entityKind/:entityId
+/metrics
+/settings
+```
+
+**URL-backed filters:** `?project=slug` · `?state=` · `?actor=` · `?kind=prefix*` · `?search=q` · `?since=ISO` · `?until=ISO` · `?cursor=id`
+
+Back-button works. Bookmarks are meaningful (`/projects/pokerzeno/blockers?state=open`).
+
+**Timeline tab UX:**
+- Reverse-chronological infinite scroll (IntersectionObserver, 50/page)
+- WS live stream — new events prepend with 2s highlight flash
+- Actor emoji: 🤖 AI · 👤 User · ⚙️ System · ⏰ Pump · 🩺 Watchdog · 🪝 Hook
+- Kind-color badges per category
+- Subject links → entity detail page
+- Filter bar: actor · kind · full-text search · clear-all
+- CSV export button
+
+**Unseen badge system:**
+- Per-tab counts in `localStorage` (`conductor.unseenCount.<tab>`)
+- WS `kind` → tab mapping fires increment on non-active tabs
+- Navigate to tab → clear counter + update `lastSeenAt`
+- Red number badge on sidebar nav items
+- `document.title` = `Conductor (N)` when N > 0
+- Favicon canvas overlay: red dot when unseen > 0
+- `aria-label="N unseen updates in Blockers"` on all tab links
+
+---
+
+## Test Results
+
+```
+Test Suites: 22 passed, 22 total
+Tests:       296 passed, 296 total  (237 existing + 59 new)
+Time:        6.776s
+```
+
+**New test files:**
+
+| File | Tests |
+|---|---|
+| `tests/db/schema.test.ts` | 15 — all 10 tables, FK, unique constraints |
+| `tests/db/projects.test.ts` | 9 — seed, CRUD, slug uniqueness |
+| `tests/db/migrate-from-jsonl.test.ts` | 7 — migration, idempotency, project inference |
+| `tests/api/routes.test.ts` | 24 — every Hono route |
+| `tests/ws/events.test.ts` | 4 — EventBus fan-out, WS delivery |
+
+---
+
+## Backward Compatibility
+
+| Check | Status |
+|---|---|
+| `src/http/health.ts` unmodified | ✅ |
+| All JSONL managers unmodified | ✅ |
+| `src/mcp/server.ts` — only swapped HTTP server + added tools | ✅ |
+| 237 original tests pass | ✅ 296/296 green |
+| Legacy routes same shape | ✅ `routes/legacy.ts` |
+
+---
+
+## Cloud-Swap Runbook
+
+### SQLite → PostgreSQL
+1. `npm install postgres`
+2. In `src/db/connection.ts`: swap `better-sqlite3` driver → `postgres-js` driver (same Drizzle schema)
+3. Set `CONDUCTOR_DB_URL=postgresql://user:pass@host/conductor`
+4. `drizzle-kit migrate` — same migration files, dialect-aware
+
+### Hono → Cloudflare Workers
+- Remove `@hono/node-server`, export `{ fetch: app.fetch }` — zero route changes
+- Same `createApp()`, same all routes
+
+### WS → Durable Objects
+- Replace `attachWsServer()` with Durable Object broadcast
+- `bus.push()` → DO message; clients reconnect to same `/events` path
+
+---
+
+## Summary
+
+Successfully implemented the additive SQLite + Hono + WebSocket backend evolution for Conductor.
+No existing files were modified except `src/mcp/server.ts` (swap HTTP server + new tool handlers).
+All 237 pre-existing tests continue to pass, and 59 new tests were added.
+
+---
+
+## Schema Files Created
+
+| File | Purpose |
+|------|---------|
+| `src/db/schema.ts` | 10-table Drizzle schema (projects, requirements, tasks, blockers, questions, adrs, business_features, proactive_suggestions, timeline_events, audit_log) |
+| `src/db/connection.ts` | Singleton DB connection, WAL mode, FK enforcement, migration runner |
+| `src/db/migrations/0000_optimal_risque.sql` | Auto-generated SQL migration for all 10 tables |
+| `src/db/seed-projects.ts` | Seeds 12 initial projects (pokerzeno, roulettecommunity, conductor, 8 plugins, 1 framework) |
+| `src/db/seed-adr.ts` | Seeds ADR-011 (this migration itself) |
+| `src/db/migrate-from-jsonl.ts` | Idempotent JSONL→SQLite migration with project inference |
+| `drizzle.config.ts` | Drizzle Kit configuration pointing to `~/.conductor/db.sqlite` |
+
+## API Layer
+
+| File | Routes |
+|------|--------|
+| `src/api/app.ts` | Hono app factory, CORS, route registration |
+| `src/api/start.ts` | Startup: migrations → seed → migrate JSONL → serve + WS attach |
+| `src/api/routes/projects.ts` | GET/POST /projects, GET/PUT /projects/:id |
+| `src/api/routes/adrs.ts` | GET/POST /adrs, GET/PUT /adrs/:id (auto-number) |
+| `src/api/routes/features.ts` | GET/POST /features, GET/PUT /features/:id |
+| `src/api/routes/suggestions.ts` | GET/POST /suggestions, POST /:id/accept, POST /:id/custom |
+| `src/api/routes/timeline.ts` | GET/POST /timeline |
+| `src/api/routes/audit.ts` | GET /audit |
+| `src/api/routes/metrics.ts` | GET /metrics (integration health, task completion, bypass count, avg resolution time) |
+| `src/api/routes/legacy.ts` | GET /requirements, /blockers, /questions, /tasks, /counts (backward compat) |
+
+## WebSocket Layer
+
+| File | Purpose |
+|------|---------|
+| `src/ws/bus.ts` | In-process EventEmitter bus with typed `ConductorWsEvent` |
+| `src/ws/index.ts` | WebSocket server at `ws://:7776/events`, fans out bus events to all connected clients |
+
+## MCP Server Changes
+
+`src/mcp/server.ts` was updated to:
+- Remove `createHealthServer` + raw `http` startup — replaced with `startApiServer()`
+- Add 16 new MCP tool definitions: `adr_create`, `adr_list`, `adr_update`, `feature_create`, `feature_list`, `feature_update`, `suggestion_create`, `suggestion_list`, `suggestion_drain`, `timeline_append`, `timeline_query`, `audit_query`, `metrics_snapshot`, `project_list`, `project_create`
+- All new tool handlers use direct Drizzle queries (no internal HTTP)
+
+## Dashboard Updates
+
+New components:
+- `dashboard/components/AdrsList.tsx` — searchable ADR browser with expand-in-place detail
+- `dashboard/components/FeaturesBoard.tsx` — 4-column kanban by phase (1/2/3/icebox)
+- `dashboard/components/SuggestionsPanel.tsx` — pending/resolved suggestions, accept + custom answer
+- `dashboard/components/TimelineFeed.tsx` — activity feed with live WS events highlighted
+- `dashboard/components/MetricsDashboard.tsx` — 5 metric cards with gauge bars
+- `dashboard/components/ProjectsManager.tsx` — grouped project browser (by kind)
+- `dashboard/components/ProjectSelector.tsx` — filter chips for project scoping
+
+New hook:
+- `dashboard/hooks/useWebSocket.ts` — auto-reconnecting WS hook, keeps last 100 events
+
+New API proxy routes:
+- `dashboard/app/api/projects/route.ts`
+- `dashboard/app/api/adrs/route.ts`
+- `dashboard/app/api/features/route.ts`
+- `dashboard/app/api/suggestions/route.ts`
+- `dashboard/app/api/timeline/route.ts`
+- `dashboard/app/api/metrics/route.ts`
+
+`dashboard/app/page.tsx` updated: 6 new tabs (ADRs, Features, Suggestions, Timeline, Metrics, Projects), WS connection indicator, project selector chip bar.
+
+## Test Counts
+
+| Suite | Tests | Status |
+|-------|-------|--------|
+| tests/db/schema.test.ts | 15 new | PASS |
+| tests/db/projects.test.ts | 9 new | PASS |
+| tests/db/migrate-from-jsonl.test.ts | 7 new | PASS |
+| tests/api/routes.test.ts | 24 new | PASS |
+| tests/ws/events.test.ts | 4 new | PASS |
+| All 17 pre-existing suites | 237 existing | PASS |
+| **Total** | **296** | **ALL PASS** |
+
+## Backward-Compatibility Verification
+
+- `src/http/health.ts` — unchanged, all existing tests importing `createHealthServer` still pass
+- JSONL managers (requirements, blockers, questions) — unchanged
+- Conductor core state manager — unchanged
+- Existing 17 test suites — all 237 tests pass
+
+## Cloud-Swap Runbook
+
+To swap from SQLite to PostgreSQL:
+
+1. Install `drizzle-orm` postgres driver: `npm install drizzle-orm/node-postgres pg @types/pg`
+2. Update `drizzle.config.ts`: change `dialect: 'sqlite'` to `dialect: 'postgresql'`
+3. Update `src/db/connection.ts`: swap `better-sqlite3` import for `pg` and `drizzle-orm/node-postgres`
+4. Set `CONDUCTOR_DB_URL=postgres://user:pass@host:5432/conductor`
+5. Run `npx drizzle-kit push` to apply schema to Postgres
+6. JSONL migration script works unchanged (reads files, writes to DB via same Drizzle API)
+
+To deploy Hono to Cloudflare Workers:
+1. The `createApp(db)` function is Workers-compatible (Hono's fetch interface)
+2. Replace `@hono/node-server` serve call with Workers `export default { fetch: app.fetch }`
+3. Use Cloudflare D1 as the SQLite backend: swap `better-sqlite3` for `@cloudflare/d1`
+
+## npm test Output
+
+```
+Test Suites: 22 passed, 22 total
+Tests:       296 passed, 296 total
+Snapshots:   0 total
+Time:        7.753 s
+```

--- a/docs/legacy-conductor-reports/BLOCKERS-QUESTIONS-2026-04-20.md
+++ b/docs/legacy-conductor-reports/BLOCKERS-QUESTIONS-2026-04-20.md
@@ -1,0 +1,245 @@
+# Blockers & Questions — Implementation Report
+**Date:** 2026-04-20  
+**Build:** ✅ green  
+**Tests:** 237 passed (182 existing + 55 new), 0 failed
+
+---
+
+## 1. Overview
+
+Two first-class concepts added to Conductor: **Blockers** (action items on the user) and **Questions/Clarifications** (input needed before work can continue). Both surface in the dashboard as dedicated kanban tabs with zero-friction resolution.
+
+---
+
+## 2. Schema
+
+### Blocker
+
+```
+~/.conductor/blockers.jsonl         ← append-only event log
+~/.conductor/blockers.snapshot.json ← materialized state
+```
+
+Event types: `BLOCKER_CREATED` · `BLOCKER_RESOLVED` · `BLOCKER_CANCELLED` · `BLOCKER_SNAPSHOT_REBUILT`
+
+**States:** `open → resolved | cancelled`  
+**ID prefix:** `blk_XXXX`
+
+Fields: `id, title, createdAt, state, severity (critical|high|normal|low), kind (approval|credentials|dns|external-setup|info|decision), description, resolutionSteps[], approvalButton?, links?, requirementId?, taskId?, resolvedAt?, resolvedBy?, resolutionNote?`
+
+### Question
+
+```
+~/.conductor/questions.jsonl         ← append-only event log
+~/.conductor/questions.snapshot.json ← materialized state
+```
+
+Event types: `QUESTION_CREATED` · `QUESTION_ANSWERED` · `QUESTION_CANCELLED` · `QUESTION_SNAPSHOT_REBUILT`
+
+**States:** `open → answered | cancelled`  
+**ID prefix:** `qst_XXXX`
+
+Fields: `id, title, createdAt, state, priority (urgent|normal|nice-to-have), context, recommendations[]{id,label,rationale,isDefault?}, customAnswerPlaceholder?, requirementId?, taskId?, answeredAt?, answer?{kind,recommendationId?,customText?}`
+
+---
+
+## 3. File List
+
+### New source files (16)
+
+```
+src/blockers/types.ts
+src/blockers/state-machine.ts
+src/blockers/manager.ts
+src/questions/types.ts
+src/questions/state-machine.ts
+src/questions/manager.ts
+src/mcp/seed.ts
+dashboard/components/BlockersKanban.tsx
+dashboard/components/QuestionsKanban.tsx
+dashboard/app/api/blockers/route.ts
+dashboard/app/api/blockers/[id]/route.ts
+dashboard/app/api/blockers/[id]/resolve/route.ts
+dashboard/app/api/questions/route.ts
+dashboard/app/api/questions/[id]/route.ts
+dashboard/app/api/questions/[id]/answer/route.ts
+dashboard/app/api/counts/route.ts
+```
+
+### New test files (5)
+
+```
+tests/blockers/state-machine.test.ts    — 13 tests
+tests/blockers/approval-payload.test.ts — 6 tests
+tests/questions/state-machine.test.ts   — 13 tests
+tests/questions/custom-answer.test.ts   — 10 tests
+tests/mcp/drain.test.ts                 — 10 tests (5 blocker + 5 question)
+```
+
+### Modified files (4)
+
+```
+src/http/health.ts            — added /blockers, /questions, /counts endpoints
+src/mcp/server.ts             — added 8 MCP tools, wired BlockersManager + QuestionsManager
+dashboard/app/page.tsx        — added 🚨 Blockers + ❓ Questions tabs, count badges
+templates/CLAUDE.md           — added blocker_drain + question_drain to heartbeat protocol
+```
+
+---
+
+## 4. Test Counts
+
+| Suite | Tests |
+|-------|-------|
+| blockers/state-machine | 13 |
+| blockers/approval-payload | 6 |
+| questions/state-machine | 13 |
+| questions/custom-answer | 10 |
+| mcp/drain | 10 (5 blocker + 5 question) |
+| **New total** | **52** |
+| Existing suite | 182 |
+| **Grand total** | **237** ✅ |
+
+---
+
+## 5. Seed Data Loaded
+
+Seeded on MCP server startup (idempotent — checks by title before creating):
+
+| Type | Title | State |
+|------|-------|-------|
+| Blocker | Add DNS CNAME for roulettecommunity.com | open |
+| Blocker | Create 2 GA4 Properties in Google Analytics | open |
+| Blocker | Enable Cloudflare R2 in dashboard (one-time) | **resolved** (historical) |
+| Question | Conductor auto-kill of stalled tasks — enable by default or keep opt-in? | open (3 recommendations) |
+| Question | Pixabay pending approval — proceed with Unsplash+Pexels only, or wait? | open (2 recommendations) |
+
+---
+
+## 6. MCP Tool List
+
+| Tool | Description |
+|------|-------------|
+| `blocker_create` | Create blocker, fire macOS notification |
+| `blocker_list` | List blockers, optional state filter |
+| `blocker_resolve` | Resolve a blocker (also callable from dashboard) |
+| `blocker_drain` | Return+clear newly-resolved blockers since last call |
+| `question_create` | Create question, fire macOS notification |
+| `question_list` | List questions, optional state filter |
+| `question_answer` | Submit answer (also callable from dashboard) |
+| `question_drain` | Return+clear newly-answered questions since last call |
+
+### Example curl calls
+
+```bash
+# Create a blocker
+curl -s -X POST http://localhost:7776/blockers \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "Enable Stripe webhooks",
+    "severity": "high",
+    "kind": "external-setup",
+    "description": "Stripe webhook endpoint must be registered in the Stripe dashboard.",
+    "resolutionSteps": [
+      {"order":1,"instruction":"Go to dashboard.stripe.com → Webhooks → Add endpoint","verification":"Endpoint shows status Active"}
+    ]
+  }'
+
+# List open blockers
+curl -s 'http://localhost:7776/blockers?state=open'
+
+# Resolve a blocker
+curl -s -X POST http://localhost:7776/blockers/blk_XXXX/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"note":"Done — webhook registered"}'
+
+# Create a question
+curl -s -X POST http://localhost:7776/questions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "Which CDN?",
+    "priority": "normal",
+    "context": "We need to pick a CDN for image delivery.",
+    "recommendations": [
+      {"id":"rec_A","label":"Cloudflare","rationale":"Already in our account","isDefault":true},
+      {"id":"rec_B","label":"Fastly","rationale":"Better analytics"}
+    ]
+  }'
+
+# Submit a recommendation answer
+curl -s -X POST http://localhost:7776/questions/qst_XXXX/answer \
+  -H 'Content-Type: application/json' \
+  -d '{"kind":"accepted-recommendation","recommendationId":"rec_A"}'
+
+# Submit a custom answer
+curl -s -X POST http://localhost:7776/questions/qst_XXXX/answer \
+  -H 'Content-Type: application/json' \
+  -d '{"kind":"custom","customText":"Use Bunny CDN for better price/performance"}'
+
+# Count badges (for dashboard header)
+curl -s http://localhost:7776/counts
+# → {"openBlockers":2,"openQuestions":2}
+```
+
+---
+
+## 7. Orchestrator Integration (Heartbeat)
+
+`templates/CLAUDE.md` updated. On **every heartbeat**:
+
+```typescript
+// After notification_drain(), before requirement_pickup_next():
+
+const blockerDrain = await conductor_mcp.blocker_drain();
+for (const { blocker, approvalPayload } of blockerDrain.resolvedBlockers) {
+  // Surface resolution to user; use approvalPayload to resume paused work
+}
+
+const questionDrain = await conductor_mcp.question_drain();
+for (const { question } of questionDrain.answeredQuestions) {
+  // Surface answer to user; use question.answer to continue paused decision path
+}
+```
+
+**Loop closed:** user clicks "Approve" or "Submit answer" in dashboard → HTTP route hits `blockersManager.resolve()` / `questionsManager.answer()` → item added to `pendingDrain` in-memory queue → next heartbeat calls `blocker_drain()` / `question_drain()` → orchestrator receives resolution → work resumes automatically.
+
+---
+
+## 8. Dashboard
+
+**URL:** http://localhost:7777
+
+Two new tabs added alongside Tasks and Requirements:
+
+- **🚨 Blockers** — three-column kanban (Open / Resolved / Cancelled)
+  - Card: severity badge, kind badge, description, resolution steps accordion, approval button (one-click resolve), links, manual resolve with note
+  - Empty state: "Nothing waiting for you right now — Conductor is running autonomously."
+  - Count badge in header (red, visible from any tab): `2`
+
+- **❓ Questions** — three-column kanban (Open / Answered / Cancelled)
+  - Card: priority badge, context block, recommendation radio list with rationale, custom textarea, Submit button
+  - Default recommendation highlighted
+  - Once answered: card moves to Answered column with answer summary
+  - Empty state friendly message
+
+**A11y:**
+- `role="tablist"` + `role="tab"` + `aria-selected` + `aria-controls` on nav
+- `role="tabpanel"` + `id` on panels
+- `aria-live="polite"` on count badges
+- Resolution animation respects `prefers-reduced-motion`
+
+**Resolution animation:** CSS `@keyframes confetti-pop` — card scales 1 → 1.15 → 1 on resolve/answer, then flies to resolved column after 500ms. Disabled when `prefers-reduced-motion: reduce`.
+
+---
+
+## 9. Native Notifications
+
+When `blocker_create` or `question_create` is called (via MCP or HTTP):
+
+```
+Title:    PokerZeno Conductor
+Subtitle: Blocker needs you  (or: Question for you)
+Body:     <item title>
+```
+
+Implemented via `osascript`; best-effort — silently ignores errors.

--- a/docs/legacy-conductor-reports/CONDUCTOR-EXT-2026-04-20.md
+++ b/docs/legacy-conductor-reports/CONDUCTOR-EXT-2026-04-20.md
@@ -1,0 +1,197 @@
+# Conductor Requirements Management Extension
+**Date:** 2026-04-20
+**Status:** COMPLETE — all tests green, TypeScript clean
+
+---
+
+## Summary
+
+Extended Conductor with a full Requirements Management layer enabling a fully autonomous requirement-to-execution pipeline. Users describe requirements casually; the system refines, specs, queues, spawns, and notifies — without ever blocking for user approval.
+
+---
+
+## Modules Added
+
+### `src/requirements/`
+| File | Purpose |
+|------|---------|
+| `types.ts` | `Requirement`, `RequirementState`, `RequirementEvent`, `RequirementsState`, `PumpTickResult`, `ListRequirementsFilter` interfaces |
+| `state-machine.ts` | `VALID_TRANSITIONS` map + `canTransition()` / `assertTransition()` guards |
+| `manager.ts` | `RequirementsManager` class — event-sourced CRUD, state machine enforcement, cycle detection, snapshot + JSONL persistence |
+| `migrate.ts` | `migrateFromBacklog()` — seeds requirements from `.auto-memory/backlog/*.md` BL-* files |
+
+### `src/notifications/`
+| File | Purpose |
+|------|---------|
+| `index.ts` | `NotificationQueue` — enqueue/drain, macOS `osascript` native notifications, graceful file-log fallback, module-level singleton |
+
+### `src/pump/`
+| File | Purpose |
+|------|---------|
+| `index.ts` | `PumpEngine` — `tick()` selects highest-priority eligible requirement (deps done + no file conflicts), claims it, builds task prompt, enqueues started notification. `onTaskCompleted()` marks done. |
+
+---
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `src/mcp/server.ts` | +12 new MCP tools (10 requirement tools + 2 notification tools + pump tick); initializes `RequirementsManager`, `NotificationQueue`, `PumpEngine` alongside `Conductor` |
+| `src/http/health.ts` | +6 REST endpoints: `GET/POST /requirements`, `GET/PUT /requirements/:id`, `POST /requirements/:id/state`, `POST /requirements/:id/notes` |
+| `dashboard/app/page.tsx` | Added tabbed navigation (Tasks / Requirements); imports `RequirementsKanban` |
+| `dashboard/components/RequirementsKanban.tsx` | **New** — kanban board with 9 state columns, drag-drop, detail drawer, create-new modal, filter chips, auto-refresh 3s |
+| `dashboard/app/api/requirements/route.ts` | **New** — Next.js proxy route for requirements CRUD |
+| `templates/CLAUDE.md` | Added Requirements Management section: on-every-turn protocol, capture instructions, "never block on approvals" rule, MCP tool reference |
+
+---
+
+## Persistence
+
+| File | What it stores |
+|------|---------------|
+| `~/.conductor/requirements.jsonl` | Append-only event log for all requirement mutations |
+| `~/.conductor/requirements.snapshot.json` | Materialized state — fast load on startup |
+| `~/.conductor/backups/requirements-YYYY-MM-DD.json` | Daily automatic backup |
+
+---
+
+## New MCP Tools (12 total)
+
+| Tool | Description |
+|------|-------------|
+| `requirement_capture` | Capture requirement from casual description → `req_XXXX` |
+| `requirement_refine` | Update description, spec, files, labels, priority |
+| `requirement_set_state` | Enforce valid transitions (throws on illegal transition) |
+| `requirement_add_dependency` | Cycle-checked dependency between requirements |
+| `requirement_list` | Filter by state/priority/labels |
+| `requirement_show` | Full detail for one requirement |
+| `requirement_pickup_next` | Claim highest-priority eligible `ready` requirement → `executing` |
+| `requirement_mark_done` | Move `executing`/`verifying` → `done` |
+| `notification_enqueue` | Push to queue + fire native macOS notification |
+| `notification_drain` | Return + clear pending chat notifications (call on every heartbeat) |
+| `conductor_pump_tick` | Single pump cycle: pick + claim + return prompt + cwd |
+
+---
+
+## Test Results
+
+```
+Test Suites: 12 passed, 12 total
+Tests:       182 passed, 182 total
+  ├── Existing (82)  — core, mcp, hook, dashboard — ALL STILL PASS
+  └── New (100):
+      ├── requirements/state-machine.test.ts  — 25 tests
+      ├── requirements/dependency.test.ts     — 11 tests
+      ├── requirements/manager.test.ts        — 28 tests
+      ├── pump/tick.test.ts                   — 16 tests
+      ├── notifications/enqueue-drain.test.ts — 16 tests
+      └── e2e/capture-to-done.test.ts         —  4 tests
+```
+
+---
+
+## Requirement State Machine
+
+```
+                                  ┌──────────────────────────┐
+captured ──► refining ──► specced ──► ready ──► executing ──► verifying ──► done
+    ▲             │                    │            │
+    └─────────────┘         cancelled ◄┴────────────┘
+                                                   │
+                                                blocked ──► ready
+```
+
+Valid transitions enforce invariants — `assertTransition()` throws with exact message including allowed next states.
+
+---
+
+## Example: Full Capture → Done Flow
+
+```typescript
+// 1. User says "I need login with email + password"
+const req = await requirement_capture({
+  title: "User authentication",
+  description: "Users need to log in with email and password",
+  targetProject: "~/projects/my-app",
+  labels: ["backend", "auth"],
+  priority: 2,
+});
+// → { id: "req_A7b3Xk2c", state: "captured", ... }
+
+// 2. Orchestrator refines it
+await requirement_refine(req.id, {
+  estimatedFiles: ["src/auth/**", "src/api/login.ts"],
+  spec: {
+    goals: ["JWT-based login", "bcrypt password hashing"],
+    nonGoals: ["OAuth", "SSO"],
+    acceptanceCriteria: [
+      "POST /auth/login returns JWT",
+      "Invalid credentials return 401",
+    ],
+    notes: "Use existing User model",
+  },
+});
+
+// 3. Advance to ready (or orchestrator does this automatically)
+await requirement_set_state(req.id, "refining");
+await requirement_set_state(req.id, "specced");
+await requirement_set_state(req.id, "ready");
+
+// 4. Heartbeat fires → pump tick claims it
+const tick = await conductor_pump_tick();
+// → { picked: { id: "req_A7b3Xk2c", state: "executing" }, prompt: "...", cwd: "~/projects/my-app" }
+
+// 5. Spawn code task with tick.prompt in tick.cwd
+const taskId = await start_code_task({ prompt: tick.prompt, cwd: tick.cwd });
+
+// 6. [Native notification fires]: "Requirement 'User authentication' started"
+// [Chat notification via drain]: same message
+
+// 7. Task completes → mark done
+await requirement_mark_done(req.id);
+// → [Native + chat notification]: "Requirement 'User authentication' done"
+```
+
+---
+
+## Dashboard
+
+The Requirements tab at `localhost:7777` provides:
+- **9-column Kanban** board (one column per state), color-coded
+- **Drag-drop** cards between columns to trigger state transitions
+- **Detail drawer** — click any card to see description, spec, AC, notes, linked tasks, dependencies
+- **Create modal** — "New Requirement" button captures title, description, project, priority, labels
+- **Filter chips** — narrow view to single state with live counts
+- **Auto-refresh** every 3 seconds
+
+---
+
+## Pump Autonomy Engine
+
+`PumpEngine.tick()` runs this atomic selection cycle:
+1. List all `ready` requirements, filtered to those with all `dependsOn` in `done` state
+2. Exclude any with `estimatedFiles` that overlap (via picomatch) with currently `executing` requirements
+3. Sort by `priority` (1=highest) then `capturedAt` (oldest first)
+4. Claim the first eligible one → set state to `executing`
+5. Build self-contained task prompt (includes spec, AC, files, conductor tag)
+6. Return `{ picked, prompt, cwd }` to caller for spawning
+7. Enqueue `started` native + chat notification
+
+The orchestrator calls `conductor_pump_tick()` on every heartbeat and every user turn. No human approval needed.
+
+---
+
+## Heartbeat Integration
+
+The existing `orchestrator-heartbeat-15min` scheduled task fires → orchestrator session receives notification → calls two tools:
+1. `notification_drain()` — surface any queued notifications to user
+2. `conductor_pump_tick()` — if a requirement is ready, get prompt + spawn task
+
+No changes to the heartbeat scheduled task itself. The orchestrator-side logic is documented in `templates/CLAUDE.md`.
+
+---
+
+## Migration
+
+`src/requirements/migrate.ts` exports `migrateFromBacklog(backlogDir, reqManager)`.
+Reads `BL-*.md` files, parses YAML frontmatter (`status`, `priority`, `labels`, `title`), maps legacy statuses (`backlog`→`captured`, `complete`→`done`), extracts Goals/Acceptance Criteria/Files sections. No `.auto-memory/backlog/` directory found at migration time — no records seeded, but the module is ready for future use.

--- a/docs/legacy-conductor-reports/RUNAWAY-TABS-FIX-2026-04-20.md
+++ b/docs/legacy-conductor-reports/RUNAWAY-TABS-FIX-2026-04-20.md
@@ -1,0 +1,74 @@
+# Runaway Browser Tabs — Root Cause & Fix (2026-04-20)
+
+## Culprit
+
+Two separate `sendNativeNotification` methods were calling `execSync('open "http://localhost:7777/..."')` **every time** a question or blocker was raised. Each call opened a new browser tab.
+
+| File | Line | URL opened |
+|------|------|-----------|
+| `src/questions/manager.ts` | 246 | `http://localhost:7777/?tab=questions#<id>` |
+| `src/blockers/manager.ts` | 248 | `http://localhost:7777/?tab=blockers#<id>` |
+
+Pattern: both had this structure inside `sendNativeNotification`:
+
+```ts
+// Step 1 — toast (correct)
+execSync(`osascript -e 'display notification ...'`, ...);
+
+// Step 2 — browser tab (THE BUG)
+execSync(`open "http://localhost:7777/?tab=..."`, ...);
+```
+
+Any pump tick that created/updated a question or blocker fired `sendNativeNotification`, which spawned a new tab. With rapid agent activity this floods Chrome with 20–50+ tabs.
+
+## Fix Applied
+
+Removed the `open` call from both `sendNativeNotification` methods. The `osascript display notification` toast remains — it tells the user something needs attention without opening a tab.
+
+**`src/questions/manager.ts`** — removed:
+```ts
+try {
+  execSync(`open "http://localhost:7777/?tab=questions#${id}"`, {
+    timeout: 3000, stdio: 'ignore',
+  });
+} catch {
+  // best-effort
+}
+```
+
+**`src/blockers/manager.ts`** — removed:
+```ts
+try {
+  // best-effort: open dashboard at blockers tab
+  execSync(`open "http://localhost:7777/?tab=blockers#${id}"`, {
+    timeout: 3000, stdio: 'ignore',
+  });
+} catch {
+  // best-effort
+}
+```
+
+The compiled `dist/` files reflect the fix (TypeScript emitted despite unrelated errors in `server.ts`).
+
+## Immediate Remediation
+
+- Closed all `localhost:7777` Chrome tabs via `osascript close tab` command.
+- No Playwright or Chromium processes were running at time of fix.
+- No LaunchAgents or scheduled tasks contained `open http://localhost:7777` calls.
+  - `com.conductor.mcp.plist` exists but was not loaded; its `ProgramArguments` only runs `node dist/cli/index.js mcp` — no URL opening.
+
+## Verification
+
+The conductor MCP runs on-demand (no persistent process between invocations), so a live notification loop test was not possible in this session. To verify manually:
+
+```bash
+# Start conductor (if dashboard is running)
+curl -X POST http://localhost:7776/notifications/enqueue \
+  -H "Content-Type: application/json" \
+  -d '{"requirementId":"test","kind":"started","message":"test"}'
+# Repeat 10x — confirm ZERO new browser tabs open
+```
+
+## Other Recurring Triggers Found
+
+None. The two manager files were the sole source.

--- a/docs/legacy-conductor-reports/SEED-2026-04-20.md
+++ b/docs/legacy-conductor-reports/SEED-2026-04-20.md
@@ -1,0 +1,171 @@
+# SEED-2026-04-20 — Audit Gap Requirements Seeded
+
+**Date:** 2026-04-20  
+**Source audit:** `/Users/MAC/Documents/projects/audit-2026-04-20.md`  
+**Conductor HTTP:** `http://localhost:7776`  
+**Dashboard:** `http://localhost:7777`
+
+---
+
+## Build & Restart
+
+The requirements extension was present in source (`src/requirements/`, `src/pump/`, `src/notifications/`) but had **not been compiled**. `dist/` contained only the pre-extension build.
+
+Actions taken:
+1. `npm run build` — compiled TypeScript in `/Users/MAC/Documents/projects/conductor`
+2. Killed old MCP server (PID 9640, no requirements support)
+3. Started new MCP server: `node dist/cli/index.js mcp` (PID 45864 → new PID 45864)
+4. Started dashboard: `cd dashboard && npm run dev` on port 7777
+
+---
+
+## Seeded Requirements (33 total)
+
+### Missing items (14) — Priority 1
+
+| req_id | title | track | target | priority | state |
+|--------|-------|-------|--------|----------|-------|
+| req_qRODJvW5 | Cloudflare Web Analytics — PokerZeno | track-5 | poker-zeno | 1 | **executing** |
+| req_WViewwHF | Cloudflare Web Analytics — Roulette | track-5 | roulette-community | 1 | ready |
+| req_OVkDg-_x | 100dvh on PokerZeno play page | track-1 | poker-zeno | 1 | ready |
+| req_Fn65s2rp | Shuffle visual animation — PokerZeno | track-1 | poker-zeno | 1 | ready |
+| req_PYfoGXkd | Deal animation per card — PokerZeno | track-1 | poker-zeno | 1 | ready |
+| req_-yl8FEVj | Between-hands visual transitions — PokerZeno | track-1 | poker-zeno | 1 | ready |
+| req_9UFLHocO | JSON-LD Article schema — PokerZeno | track-5 | poker-zeno | 1 | ready |
+| req_2mGorIYR | JSON-LD Course schema — PokerZeno | track-5 | poker-zeno | 1 | ready |
+| req_MevWc4JE | JSON-LD Product schema — PokerZeno | track-5 | poker-zeno | 1 | ready |
+| req_LS7QBgMw | JSON-LD Event schema — PokerZeno | track-5 | poker-zeno | 1 | ready |
+| req_4juukMtx | game-icons npm package — both sites | track-3 | both | 1 | ready |
+| req_9mSDuLPX | Footer image background — both sites | track-3 | both | 1 | ready |
+| req_9LN8nbxP | /cast/[roomId] route — both sites | track-6 | both | 1 | ready |
+| req_v8FjCMS_ | Conductor dashboard — port 7777 | track-9 | conductor | 1 | ready |
+
+### Partial items (17) — Priority 2/3
+
+| req_id | title | track | target | priority | state |
+|--------|-------|-------|--------|----------|-------|
+| req_rkJ2RW-i | Chip throw visual animation — PokerZeno | track-1 | poker-zeno | 2 | ready |
+| req_9mIgLNl5 | Pot chip cluster grow animation — PokerZeno | track-1 | poker-zeno | 2 | ready |
+| req_qCk-edga | Street reveals 3D flip animation — PokerZeno | track-1 | poker-zeno | 2 | ready |
+| req_rDn_X2nE | Random cheer selection — PokerZeno | track-1 | poker-zeno | 2 | ready |
+| req_vtltJvzu | Per-action chip visual — PokerZeno | track-1 | poker-zeno | 2 | ready |
+| req_cjdNIK2J | Spin timing variable range — Roulette | track-2 | roulette-community | 2 | ready |
+| req_6wsAItKE | Chip stack settle sound — Roulette (file-backed) | track-2 | roulette-community | 2 | ready |
+| req_CMMCyX0_ | Wheel spin whirr sound — Roulette (file-backed) | track-2 | roulette-community | 2 | ready |
+| req_ItGQkKh9 | Ball rolling whoosh sound — Roulette (dedicated cue) | track-2 | roulette-community | 2 | ready |
+| req_9D3sWNd_ | Ball ticking rate-change — Roulette | track-2 | roulette-community | 2 | ready |
+| req_1QNiCgjw | Ball drop thunk sound — Roulette (richer synthesis) | track-2 | roulette-community | 2 | ready |
+| req_pVf2LpJ4 | Dealer voice number announcements — Roulette | track-2 | roulette-community | 2 | ready |
+| req_WSn9l7L8 | Section color variety — PokerZeno homepage | track-3 | poker-zeno | 2 | ready |
+| req_Qc73C2re | Hover lift cards broadly applied — PokerZeno | track-3 | poker-zeno | 2 | ready |
+| req_ta5ygN-s | Tailwind token royal-gold (hyphen) — PokerZeno | track-4 | poker-zeno | 2 | ready |
+| req_503uwCP1 | Tailwind token royal-gold (hyphen) — Roulette | track-4 | roulette-community | 2 | ready |
+| req_D8VVnBQQ | Per-page metadata missing — PokerZeno publications/submit | track-5 | poker-zeno | 3 | ready |
+
+### Check-failed items (2) — Priority 2
+
+| req_id | title | track | target | priority | state |
+|--------|-------|-------|--------|----------|-------|
+| req_MjYLQQaa | Old #D4AF37 color in motifs.tsx — PokerZeno | track-4 | poker-zeno | 2 | ready |
+| req_01mkyg1q | JSON-LD Product usage in Roulette shop pages — verify | track-5 | roulette-community | 2 | ready |
+
+---
+
+## Ingestion Verification
+
+```
+GET /requirements?state=ready  → 32  (after first pump tick claimed 1)
+GET /requirements?state=executing → 1
+GET /requirements               → 33 total
+```
+
+Spot-checks (3 random entries verified):
+- `req_qRODJvW5` — state: ready→executing, priority: 1, labels: [audit-gap, seo, analytics, track-5], spec.goals populated ✓
+- `req_pVf2LpJ4` — state: ready, priority: 2, labels: [audit-gap, audio, play, track-2] ✓
+- `req_MjYLQQaa` — state: ready, priority: 2, spec.acceptanceCriteria: ["grep -r D4AF37 src/ returns no results", ...] ✓
+
+---
+
+## First Pump Tick
+
+**Note:** The HTTP endpoint `/pump/tick` does not exist — pump tick is exposed as MCP tool `conductor_pump_tick` only. Pump logic was executed via HTTP state transition.
+
+**Picked:** `req_qRODJvW5`  
+**Title:** Cloudflare Web Analytics — PokerZeno  
+**Priority:** 1 (highest)  
+**CWD:** `~/Documents/projects/poker-zeno`  
+**State after tick:** `executing`
+
+**Generated task prompt:**
+```
+# Conductor Task
+
+**Requirement:** Cloudflare Web Analytics — PokerZeno
+**Project:** ~/Documents/projects/poker-zeno
+
+## Description
+Cloudflare Web Analytics beacon missing from PokerZeno. No cfbeacon or 
+cloudflareinsights script found anywhere in src/. Audit evidence: T5-R19 
+missing — grep for cfbeacon/cloudflareinsights returned no results.
+
+## Goals
+- Add Cloudflare Web Analytics beacon to PokerZeno
+- Enable real-user monitoring via Cloudflare
+
+## Acceptance Criteria
+- <script defer ...cloudflareinsights...> present in layout.tsx
+- cfbeacon token configured via env var NEXT_PUBLIC_CF_BEACON_TOKEN
+- Analytics visible in Cloudflare dashboard
+
+## Notes
+Add to layout.tsx <head> via Next.js Script component. Token from env var.
+
+[CONDUCTOR:req_id=req_qRODJvW5]
+```
+
+To spawn the code task (run in your orchestrator session):
+```
+start_code_task({ prompt: <above>, cwd: "~/Documents/projects/poker-zeno" })
+```
+
+---
+
+## Notification Test
+
+| Method | Result |
+|--------|--------|
+| `POST /notifications/enqueue` (HTTP) | **404** — endpoint not in HTTP server, MCP-only |
+| `osascript display notification` | ✓ macOS notification fired successfully |
+
+Notification content: `"Requirement req_qRODJvW5 (Cloudflare Web Analytics — PokerZeno) started executing. Autonomous pump test."` with title `"Conductor Pump"`.
+
+**Note:** The `notification_enqueue` MCP tool in `src/mcp/server.ts:251` and `POST /notifications/enqueue` HTTP route are NOT registered in `src/http/health.ts`. To trigger notifications via HTTP, add a route in `health.ts` forwarding to `NotificationQueue`. Native macOS notifications via `osascript` work as a stopgap.
+
+---
+
+## Final State
+
+```
+ready:     32
+executing:  1  (req_qRODJvW5 — Cloudflare Web Analytics PokerZeno)
+total:     33
+```
+
+```
+POST /requirements GET /requirements GET /requirements?state=ready
+  → 33 created   → 33 total         → 32 (1 executing)
+```
+
+Dashboard: http://localhost:7777 — Conductor Dashboard (Next.js) ✓ HTTP 200
+
+---
+
+## Gap Notes
+
+1. **`/pump/tick` HTTP endpoint missing** — `conductor_pump_tick` is MCP-only. Consider adding `POST /pump/tick` to `src/http/health.ts` for non-MCP callers.
+2. **`/notifications/enqueue` HTTP endpoint missing** — `notification_enqueue` is MCP-only. Consider adding `POST /notifications/enqueue` to `src/http/health.ts`.
+3. **Extension not compiled** — `npm run build` had to be run manually before seeding. Consider wiring into a startup script or CI.
+
+---
+
+*Generated by Conductor seed task — 2026-04-20*

--- a/docs/legacy-conductor-reports/SEED-LIVE-STATE-2026-04-20.md
+++ b/docs/legacy-conductor-reports/SEED-LIVE-STATE-2026-04-20.md
@@ -1,0 +1,119 @@
+# Conductor Live-State Seed Report
+**Date:** 2026-04-21T00:02:41Z  
+**Seeded by:** Claude Code (auto-session)
+
+---
+
+## Summary
+
+| Table        | Before | After (active) |
+|--------------|--------|----------------|
+| Requirements | 33     | 53 (total)     |
+| Blockers     | 0      | 5 (4 open, 1 resolved) |
+| Questions    | 0      | 6 (all open)   |
+
+---
+
+## Root cause of missing data
+
+The conductor MCP process (PID 45864) had started at **18:32** from a dist that predated the blockers/questions code (dist rebuilt at **19:42**). The server passed `undefined` for `blockersManager`/`questionsManager` to the HTTP handler, causing all `/blockers` and `/questions` requests to fall through to `404 Not found`.
+
+**Fix:** seeded data directly via manager modules → killed stale process → started fresh server (PID 59404) → verified all endpoints return correct data.
+
+---
+
+## Requirements created (20 track-level)
+
+### Done (12)
+| ID | Title |
+|----|-------|
+| req_elb9XW6Z | Style + Content overhaul |
+| req_FFoT8PAf | PokerZeno Play v4 |
+| req_6FvqbQ94 | Roulette Play v3 respawn |
+| req_RieNkPkf | SEO program clean respawn |
+| req_mCQcX-83 | Gameplay E2E tests + fixes |
+| req_EPfLoGEs | Backend architecture v1 package |
+| req_AqXwS_Ie | Cast-bridge v1 package |
+| req_jAkBMCWf | Accessibility WCAG 2.1 AA pass |
+| req_35GymLLQ | Link + action integrity sweep |
+| req_8mmaomQM | GA4 analytics integration (code) |
+| req_Vg0-MCRl | Conductor requirements + autopump seed |
+| req_fwtk8sik | Conductor blockers + questions tables |
+
+### Executing (4)
+| ID | Title |
+|----|-------|
+| req_MWVv5LA_ | DevInspector package |
+| req_YNXYQary | Media enrichment pass |
+| req_9eQmO4sS | Content engine + initial seed |
+| req_miqYc99D | Repo framework scaffold |
+
+### Blocked (3)
+| ID | Title |
+|----|-------|
+| req_dIEzbSjd | Google Analytics activation |
+| req_KlIVvl0Q | DNS activation for roulettecommunity.com |
+| req_JPSyCUKI | GitHub repo push (5 repos) |
+
+### Captured (1)
+| ID | Title |
+|----|-------|
+| req_DoL3QRSy | Conductor backend evolution (SQLite + WS + new tabs) |
+
+---
+
+## Blockers created (5)
+
+| ID | Title | State | Severity |
+|----|-------|-------|----------|
+| blk_aqlJWCzk | Add DNS CNAME records for roulettecommunity.com | open | high |
+| blk_b-SURrjO | Create 2 GA4 Properties + paste Measurement IDs | open | high |
+| blk_Fw4o2PXw | Authenticate GitHub CLI so 5 repos can be pushed | open | high |
+| blk_SKOUyHSi | Pixabay API approval pending | open | low |
+| blk_TY3x9ASQ | Enable Cloudflare R2 in dashboard (one-time) | resolved | normal |
+
+---
+
+## Questions created (6)
+
+| ID | Title | Priority |
+|----|-------|----------|
+| qst_T-CoDGR5 | Conductor backend: Drizzle vs Prisma vs Kysely for SQLite? | normal |
+| qst_gBPyuTQC | SQLite file location for Conductor DB? | normal |
+| qst_B-9hFlU3 | Conductor API auth strategy (local + cloud)? | normal |
+| qst_n33E3_hn | Pixabay pending — ship with Unsplash+Pexels only, or wait? | normal |
+| qst_O_dwoEYh | Conductor pump auto-kill of stalled tasks — enable by default? | normal |
+| qst_hZzWzS97 | GitHub username for new repos? | urgent |
+
+---
+
+## Final /counts output
+
+```json
+{"openBlockers":4,"openQuestions":6}
+```
+
+---
+
+## Requirements by state (full breakdown)
+
+| State | Count |
+|-------|-------|
+| done | 12 |
+| executing | 5 |
+| ready | 32 |
+| blocked | 3 |
+| captured | 1 |
+| **Total** | **53** |
+
+---
+
+## Seed.ts fix
+
+Updated `/src/mcp/seed.ts` (and rebuilt dist) to guard against duplicate creation on server restart — all 4 affected checks now test against both the old title and the new canonical title.
+
+---
+
+## Dashboard
+
+Open: http://localhost:7777

--- a/docs/legacy-conductor-reports/caia-agent-team-architecture.md
+++ b/docs/legacy-conductor-reports/caia-agent-team-architecture.md
@@ -1,0 +1,1112 @@
+# CAIA Agent Team Architecture
+
+**Version:** 1.0  
+**Date:** 2026-04-27  
+**Status:** Design Proposal
+
+---
+
+## 1. Overview
+
+This document defines the full agent team architecture for the CAIA platform. CAIA operates a hierarchy of 25 specialised agents arranged across 6 tiers. Each agent has a clearly defined role, input/output interface, and communication protocol. Together they form a coordinated pipeline that ingests, classifies, deduplicates, enriches, and serves enterprise knowledge at scale.
+
+---
+
+## 2. Agent Tier Structure
+
+```
+Tier 0 — Orchestration
+  └─ Conductor Agent (1)
+
+Tier 1 — Ingestion
+  ├─ Ingest Agent (1)
+  ├─ Scraper Agent (1)
+  └─ Connector Agent (1)
+
+Tier 2 — Processing
+  ├─ Chunker Agent (1)
+  ├─ Classifier Agent (1)
+  ├─ Dedup Agent (1)
+  ├─ OCR Agent (1)
+  └─ Normaliser Agent (1)
+
+Tier 3 — Enrichment
+  ├─ Embedder Agent (1)
+  ├─ Metadata Agent (1)
+  ├─ Entity Extractor Agent (1)
+  ├─ Summariser Agent (1)
+  └─ Linker Agent (1)
+
+Tier 4 — Knowledge
+  ├─ Indexer Agent (1)
+  ├─ Knowledge Graph Agent (1)
+  └─ Archivist Agent (1)
+
+Tier 5 — Serving
+  ├─ Query Agent (1)
+  ├─ Retrieval Agent (1)
+  ├─ Synthesiser Agent (1)
+  ├─ Citation Agent (1)
+  └─ Compliance Agent (1)
+
+Tier 6 — Infrastructure
+  ├─ Monitor Agent (1)
+  ├─ Scaffolder Agent (1)
+  └─ Audit Agent (1)
+```
+
+**Total: 25 agents across 6 tiers** (Tier 0 + Tiers 1–6 = 7 levels; numbered 0–6 for consistency with inter-agent routing).
+
+---
+
+## 3. Scaffolder Agent Design
+
+The Scaffolder Agent is the bootstrap component of the CAIA system. It is responsible for provisioning new CAIA deployments, registering agent instances, wiring inter-agent communication channels, and ensuring that all infrastructure dependencies are available before any other agent is started.
+
+### 3.1 Responsibilities
+
+- **Schema migration** — runs pending SQLite migrations (including sqlite-vec extension loading) before any agent starts.
+- **Agent registration** — populates the agent registry (§4) with all 25 agents' metadata on first boot.
+- **Channel initialisation** — creates message queues and pub/sub topics in the configured transport layer.
+- **Health gate** — polls each agent's `/health` endpoint after startup; holds back routing until all Tier 1–4 agents report `ok`.
+- **Config injection** — reads `CAIA_CONFIG` environment variables and distributes domain-specific config to each agent via a one-time `configure` message.
+- **Graceful shutdown** — on `SIGTERM`, sends a `drain` signal to all agents in reverse tier order, waits for in-flight messages to complete, then sends `stop`.
+
+### 3.2 Scaffolder Startup Sequence
+
+```
+1. Load env → validate required vars
+2. Connect to SQLite → run migrations → load sqlite-vec
+3. Populate agent registry (upsert)
+4. Start infrastructure agents (Tier 6: Monitor, Audit)
+5. Start knowledge agents (Tier 4: Indexer, Graph, Archivist)
+6. Start enrichment agents (Tier 3)
+7. Start processing agents (Tier 2)
+8. Start ingestion agents (Tier 1)
+9. Start serving agents (Tier 5)
+10. Start orchestration agent (Tier 0: Conductor)
+11. Health gate — poll all agents, retry 3× with 2s backoff
+12. Emit `system.ready` event → Conductor begins accepting work
+```
+
+### 3.3 Scaffolder Input/Output
+
+**Input:** Environment variables + `scaffolder.config.json`
+
+**Output:**
+- Populated agent registry
+- Initialised message channels
+- `system.ready` event on the event bus
+- Scaffolder health log written to `logs/scaffolder-boot.jsonl`
+
+---
+
+## 4. Inter-Agent Communication Protocol
+
+### 4.1 Transport
+
+All inter-agent messages are transported over an **in-process event bus** (for single-node deployments) or **Redis Streams** (for multi-node deployments). The protocol is transport-agnostic; agents communicate via a common message envelope.
+
+### 4.2 Message Envelope Schema
+
+```typescript
+interface CAIAMessage<T = unknown> {
+  /** UUID v7 — monotonically sortable */
+  id: string;
+  /** Dot-separated routing key: e.g. "ingest.document.received" */
+  topic: string;
+  /** Sending agent identifier */
+  from: AgentId;
+  /** Target agent identifier (null = broadcast) */
+  to: AgentId | null;
+  /** Correlation ID for tracing a request/response pair */
+  correlationId: string | null;
+  /** ISO 8601 timestamp */
+  sentAt: string;
+  /** Time-to-live in milliseconds (0 = no expiry) */
+  ttlMs: number;
+  /** Message priority: 0 (lowest) – 9 (highest) */
+  priority: number;
+  /** Domain-specific payload */
+  payload: T;
+  /** Optional metadata for routing and observability */
+  meta: {
+    traceId: string;
+    spanId: string;
+    retryCount: number;
+    sourceSessionId?: string;
+  };
+}
+```
+
+### 4.3 Topic Naming Convention
+
+Topics follow a three-part `{domain}.{entity}.{event}` pattern:
+
+| Topic | Published by | Consumed by |
+|---|---|---|
+| `ingest.document.received` | Ingest, Scraper, Connector | Chunker |
+| `ingest.document.failed` | Ingest, Scraper, Connector | Monitor, Audit |
+| `chunk.created` | Chunker | Classifier, OCR, Normaliser |
+| `chunk.classified` | Classifier | Dedup, Embedder |
+| `chunk.deduplicated` | Dedup | Embedder, Metadata |
+| `chunk.embedded` | Embedder | Indexer, Linker |
+| `document.enriched` | Metadata, Entity Extractor | Knowledge Graph |
+| `document.indexed` | Indexer | Conductor |
+| `query.received` | Query | Retrieval |
+| `retrieval.completed` | Retrieval | Synthesiser, Citation |
+| `response.ready` | Synthesiser | Conductor |
+| `system.ready` | Scaffolder | Conductor |
+| `system.health` | Monitor | All agents (broadcast) |
+| `audit.event` | All agents | Audit |
+
+### 4.4 Request-Reply Pattern
+
+For synchronous-style operations (e.g. health checks, config queries), agents use the **request-reply** pattern:
+
+1. Requester publishes a message with a unique `correlationId` and `replyTo` topic.
+2. Responder processes the request and publishes a reply to the `replyTo` topic with the same `correlationId`.
+3. Requester subscribes to its `replyTo` topic filtered by `correlationId`; times out after `ttlMs`.
+
+### 4.5 Backpressure & Flow Control
+
+- Each agent exposes a `capacity` property (0.0–1.0) updated every 5 seconds.
+- The Conductor reads capacity before dispatching; if a target agent reports capacity ≥ 0.9, the message is held in a local buffer for up to 10 seconds before re-attempting.
+- If capacity remains ≥ 0.9 for > 30 seconds, the Conductor emits a `system.congestion` alert to the Monitor Agent.
+
+---
+
+## 5. Agent Registry Schema
+
+The agent registry is the authoritative catalogue of all registered agents. It is stored in the `agent_registry` table in the CAIA SQLite database and kept in-memory by the Conductor.
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_registry (
+  agent_id          TEXT PRIMARY KEY,   -- e.g. 'embedder-01'
+  agent_type        TEXT NOT NULL,      -- e.g. 'EmbedderAgent'
+  tier              INTEGER NOT NULL,   -- 0–6
+  status            TEXT NOT NULL DEFAULT 'stopped',
+                                        -- 'starting' | 'ok' | 'degraded' | 'stopped' | 'error'
+  version           TEXT NOT NULL,      -- semver e.g. '1.0.0'
+  host              TEXT,               -- hostname or pod name
+  port              INTEGER,            -- HTTP health port
+  subscribed_topics TEXT NOT NULL,      -- JSON array of topic strings
+  published_topics  TEXT NOT NULL,      -- JSON array of topic strings
+  capabilities      TEXT NOT NULL,      -- JSON object of feature flags
+  config_hash       TEXT,               -- SHA-256 of injected config
+  last_heartbeat_at TEXT,               -- ISO 8601
+  registered_at     TEXT NOT NULL,
+  metadata          TEXT                -- JSON blob for agent-specific data
+);
+```
+
+### 5.1 Example Registry Entries
+
+```json
+[
+  {
+    "agent_id": "conductor-01",
+    "agent_type": "ConductorAgent",
+    "tier": 0,
+    "status": "ok",
+    "version": "1.0.0",
+    "subscribed_topics": ["system.ready", "document.indexed", "response.ready", "system.congestion"],
+    "published_topics": ["ingest.document.received", "query.received"],
+    "capabilities": { "orchestration": true, "routing": true }
+  },
+  {
+    "agent_id": "embedder-01",
+    "agent_type": "EmbedderAgent",
+    "tier": 3,
+    "status": "ok",
+    "version": "1.0.0",
+    "subscribed_topics": ["chunk.deduplicated", "chunk.classified"],
+    "published_topics": ["chunk.embedded"],
+    "capabilities": { "modelId": "text-embedding-3-small", "dimensions": 1536, "batchSize": 100 }
+  },
+  {
+    "agent_id": "scaffolder-01",
+    "agent_type": "ScaffolderAgent",
+    "tier": 6,
+    "status": "ok",
+    "version": "1.0.0",
+    "subscribed_topics": [],
+    "published_topics": ["system.ready"],
+    "capabilities": { "migration": true, "healthGate": true, "gracefulShutdown": true }
+  }
+]
+```
+
+---
+
+## 6. All 25 Agents — I/O Interfaces
+
+### Tier 0 — Orchestration
+
+#### 6.1 Conductor Agent
+- **Input:** `system.ready`, `document.indexed`, `response.ready`, `system.congestion`, external API requests
+- **Output:** `ingest.document.received` (dispatch to ingestion), `query.received` (dispatch to serving), orchestration commands to individual agents
+- **Key responsibilities:** Workflow state machine, capacity-aware routing, SLA enforcement
+
+---
+
+### Tier 1 — Ingestion
+
+#### 6.2 Ingest Agent
+- **Input:** HTTP multipart file uploads, S3/GCS event notifications, FTP drop triggers
+- **Output:** `ingest.document.received` with raw document bytes + source metadata
+- **Key responsibilities:** File type detection (MIME sniffing), virus scan trigger, initial metadata extraction (filename, size, source system)
+
+#### 6.3 Scraper Agent
+- **Input:** URL lists from Conductor, sitemap.xml feeds, RSS/Atom feeds
+- **Output:** `ingest.document.received` with scraped HTML/text + URL provenance
+- **Key responsibilities:** Politeness (robots.txt, crawl delay), JS rendering via headless browser, content extraction (readability algorithm)
+
+#### 6.4 Connector Agent
+- **Input:** Connector configuration messages from Conductor (Slack, SharePoint, Google Drive, Confluence, Salesforce, Jira, etc.)
+- **Output:** `ingest.document.received` with document payload + connector source metadata
+- **Key responsibilities:** OAuth token management, incremental sync (delta fetch), connector health monitoring, rate limit compliance
+
+---
+
+### Tier 2 — Processing
+
+#### 6.5 Chunker Agent
+- **Input:** `ingest.document.received`
+- **Output:** `chunk.created` (one message per chunk)
+- **Key responsibilities:** Semantic chunking (sentence boundary detection, heading-aware splitting), configurable chunk size (default 512 tokens, overlap 64), parent document ID propagation
+
+#### 6.6 Classifier Agent
+- **Input:** `chunk.created`
+- **Output:** `chunk.classified` with domain taxonomy result
+- **Key responsibilities:** Domain + subdomain classification, confidence scoring, multi-label classification for cross-domain content
+
+#### 6.7 Dedup Agent
+- **Input:** `chunk.classified`
+- **Output:** `chunk.deduplicated` (action: commit/merge/review), `dedup.review.queued`
+- **Key responsibilities:** Three-layer dedup funnel (L1 hash, L2 SimHash/MinHash, L3 semantic), decision matrix application, review queue management
+
+#### 6.8 OCR Agent
+- **Input:** `chunk.created` where chunk source is image/PDF-scan
+- **Output:** `chunk.created` (re-emitted with extracted text replacing image bytes)
+- **Key responsibilities:** Tesseract/cloud OCR integration, language detection, confidence filtering, image pre-processing (deskew, denoise)
+
+#### 6.9 Normaliser Agent
+- **Input:** `chunk.created`
+- **Output:** `chunk.created` (re-emitted with normalised content)
+- **Key responsibilities:** Unicode NFC normalisation, whitespace normalisation, language detection, character encoding correction, PII redaction (configurable)
+
+---
+
+### Tier 3 — Enrichment
+
+#### 6.10 Embedder Agent
+- **Input:** `chunk.deduplicated` (action: commit), `chunk.classified`
+- **Output:** `chunk.embedded` with 1536-dim Float32Array embedding
+- **Key responsibilities:** Batch embedding generation, model selection by domain, embedding cache (LRU), retry on rate limit
+
+#### 6.11 Metadata Agent
+- **Input:** `chunk.deduplicated`
+- **Output:** `document.enriched` with structured metadata
+- **Key responsibilities:** Author extraction, date parsing, document title inference, language tagging, reading-level scoring, word count, document structure detection (sections, tables, figures)
+
+#### 6.12 Entity Extractor Agent
+- **Input:** `chunk.deduplicated`
+- **Output:** `document.enriched` with named entity annotations
+- **Key responsibilities:** NER (persons, organisations, locations, dates, monetary values, legal citations), domain-specific entity types per taxonomy, entity normalisation and coreference resolution
+
+#### 6.13 Summariser Agent
+- **Input:** `document.enriched`
+- **Output:** `document.enriched` (updated with summary fields)
+- **Key responsibilities:** Abstractive summarisation (one-sentence, one-paragraph, executive summary variants), domain-prompt-guided summarisation for accuracy in technical domains
+
+#### 6.14 Linker Agent
+- **Input:** `chunk.embedded`
+- **Output:** `document.enriched` with cross-document link candidates
+- **Key responsibilities:** Citation detection, cross-reference resolution (document to document), external source linking (DOI, Westlaw, PubMed IDs), internal link graph construction
+
+---
+
+### Tier 4 — Knowledge
+
+#### 6.15 Indexer Agent
+- **Input:** `chunk.embedded`, `document.enriched`
+- **Output:** `document.indexed`
+- **Key responsibilities:** Write embeddings to sqlite-vec virtual table, write BM25 inverted index entries, update FTS5 full-text search index, maintain domain-partitioned indexes
+
+#### 6.16 Knowledge Graph Agent
+- **Input:** `document.enriched` (with entities + links)
+- **Output:** Updated knowledge graph nodes and edges (internal event: `graph.updated`)
+- **Key responsibilities:** Entity deduplication in graph, relationship inference, graph schema enforcement, Cypher-compatible query interface
+
+#### 6.17 Archivist Agent
+- **Input:** `document.indexed`
+- **Output:** Archive confirmation events; tiered storage placement decisions
+- **Key responsibilities:** Hot/warm/cold storage tiering based on access frequency, compression of cold documents, version history maintenance, GDPR/retention-policy enforcement (scheduled deletion)
+
+---
+
+### Tier 5 — Serving
+
+#### 6.18 Query Agent
+- **Input:** User query (text + optional filters from API/UI)
+- **Output:** `query.received` with parsed query intent, domain filter, date range, provenance filter
+- **Key responsibilities:** Query parsing and expansion, intent classification, filter extraction, query rewriting for retrieval optimisation
+
+#### 6.19 Retrieval Agent
+- **Input:** `query.received`
+- **Output:** `retrieval.completed` with ranked list of chunk candidates (hybrid BM25 + vector)
+- **Key responsibilities:** Hybrid retrieval (dense + sparse fusion via Reciprocal Rank Fusion), domain-scoped index selection, re-ranking (cross-encoder), result deduplication
+
+#### 6.20 Synthesiser Agent
+- **Input:** `retrieval.completed`
+- **Output:** `response.ready` with generated answer
+- **Key responsibilities:** Grounded answer generation (RAG), source attribution in generated text, hallucination mitigation (faithfulness checking against retrieved chunks), streaming response support
+
+#### 6.21 Citation Agent
+- **Input:** `retrieval.completed`, `response.ready`
+- **Output:** Citation-annotated response with structured references
+- **Key responsibilities:** In-text citation insertion, reference list formatting (APA, MLA, Bluebook, Vancouver styles), citation verification against retrieved source metadata
+
+#### 6.22 Compliance Agent
+- **Input:** `response.ready`
+- **Output:** Compliance-cleared response or `compliance.blocked` event
+- **Key responsibilities:** Domain-specific content filters (HIPAA, GDPR, legal privilege), output redaction, access-control enforcement (user → domain permissions), audit log emission for regulated responses
+
+---
+
+### Tier 6 — Infrastructure
+
+#### 6.23 Monitor Agent
+- **Input:** Heartbeat events from all agents, `system.health` polls, `ingest.document.failed` events, `system.congestion` alerts
+- **Output:** Dashboard metrics (Prometheus format), alert events, `system.health` broadcast
+- **Key responsibilities:** Latency/throughput/error-rate metrics per agent, alerting on SLA breach, dead-letter queue monitoring, resource utilisation tracking
+
+#### 6.24 Scaffolder Agent
+- **Input:** Boot environment (env vars, config file)
+- **Output:** `system.ready`, populated agent registry, initialised channels
+- **Key responsibilities:** See §3 for full design
+
+#### 6.25 Audit Agent
+- **Input:** `audit.event` from all agents
+- **Output:** Immutable audit log (append-only JSONL), compliance reports
+- **Key responsibilities:** Tamper-evident event logging, who-accessed-what-when tracking, data lineage recording, export for regulatory audit
+
+---
+
+## 7. Three Workflow Scenarios
+
+### 7.1 Scenario A — Batch Document Ingestion
+
+**Trigger:** An Operations administrator uploads a ZIP file of 500 legal contracts via the admin API.
+
+```
+1. [Ingest Agent]
+   ← HTTP multipart upload (ZIP)
+   → Extracts 500 files, emits 500x `ingest.document.received`
+
+2. [Conductor Agent]
+   ← 500x `ingest.document.received`
+   → Checks Chunker capacity; batches into groups of 50; dispatches
+
+3. [OCR Agent]  (parallel, for scanned PDFs only)
+   ← `chunk.created` where mime=image/pdf-scan
+   → Runs OCR; re-emits `chunk.created` with text content
+
+4. [Normaliser Agent]  (parallel)
+   ← `chunk.created`
+   → Normalises text; re-emits `chunk.created`
+
+5. [Chunker Agent]
+   ← `ingest.document.received`
+   → Splits each contract into semantic chunks (~8 chunks/doc = ~4000 chunks)
+   → Emits 4000x `chunk.created`
+
+6. [Classifier Agent]
+   ← 4000x `chunk.created`
+   → Classifies each: domain=legal, subdomain=contracts (confidence ~0.94)
+   → Emits 4000x `chunk.classified`
+
+7. [Dedup Agent]
+   ← 4000x `chunk.classified`
+   → L1: 12 exact duplicates found → auto-merged
+   → L2: 3 near-duplicates flagged → human review queue
+   → L3: 0 semantic duplicates above threshold
+   → Emits 3985x `chunk.deduplicated` (action: commit)
+
+8. [Embedder Agent]  (parallel)
+   ← 3985x `chunk.deduplicated`
+   → Generates 1536-dim embeddings in batches of 100
+   → Emits 3985x `chunk.embedded`
+
+9. [Metadata Agent], [Entity Extractor Agent], [Summariser Agent]  (parallel)
+   ← `chunk.deduplicated`
+   → Emits `document.enriched` events per document
+
+10. [Linker Agent]
+    ← `chunk.embedded`
+    → Finds 47 cross-document citation links
+    → Emits `document.enriched` with link graph updates
+
+11. [Indexer Agent]
+    ← `chunk.embedded` + `document.enriched`
+    → Writes to sqlite-vec, BM25, FTS5 indexes
+    → Emits 500x `document.indexed`
+
+12. [Knowledge Graph Agent]
+    ← `document.enriched`
+    → Adds 1,240 entity nodes; 3,891 relationship edges
+
+13. [Archivist Agent]
+    ← `document.indexed`
+    → Places all 500 documents in "hot" storage tier
+
+14. [Conductor Agent]
+    ← 500x `document.indexed`
+    → Updates ingestion job status to COMPLETE; notifies administrator
+
+15. [Audit Agent]  (continuous)
+    ← `audit.event` from every step
+    → Appends 8,247 audit log entries
+
+Total pipeline latency (500 docs): ~4 min 30 sec (parallelised)
+```
+
+---
+
+### 7.2 Scenario B — Real-Time Knowledge Query
+
+**Trigger:** A legal analyst submits the query: *"What are the indemnification limits in our MSAs with cloud vendors signed after 2024?"*
+
+```
+1. [Query Agent]
+   ← User query text + user_id + domain_context=legal
+   → Parses intent: retrieval_type=clause_search
+   → Extracts filters: domain=legal, subdomain=contracts, date_after=2024-01-01
+   → Expands query: adds synonyms ["indemnification", "indemnity", "liability cap", "limitation of liability"]
+   → Emits `query.received` with structured query + filter set
+
+2. [Retrieval Agent]
+   ← `query.received`
+   → Dense retrieval: ANN search over legal/contracts index → top 40 chunks
+   → Sparse retrieval: BM25 search with expanded terms → top 40 chunks
+   → RRF fusion → top 20 candidates
+   → Cross-encoder re-ranking → top 10 final chunks
+   → Emits `retrieval.completed` with 10 ranked chunks
+
+3. [Citation Agent]  (parallel with Synthesiser)
+   ← `retrieval.completed`
+   → Prepares structured citation metadata for each of the 10 chunks
+
+4. [Synthesiser Agent]
+   ← `retrieval.completed`
+   → Generates grounded answer citing specific clause text from retrieved chunks
+   → Faithfulness check: verifies all claims are attributable to retrieved context
+   → Streams answer tokens to response buffer
+   → Emits `response.ready`
+
+5. [Compliance Agent]
+   ← `response.ready`
+   → Checks: user has `legal:read` permission ✓
+   → Checks: no privileged communication markers in retrieved chunks ✓
+   → Clears response; emits compliance-cleared `response.ready`
+
+6. [Citation Agent]
+   ← `response.ready` + citation metadata
+   → Injects in-text citation markers [1], [2], …
+   → Formats reference list in Bluebook style (legal domain default)
+   → Emits final response with citations
+
+7. [Conductor Agent]
+   ← Final response
+   → Returns to API caller; streams to analyst's UI
+
+8. [Audit Agent]
+   ← All `audit.event` messages from this chain
+   → Records: who queried, what was retrieved, what was returned, compliance decision
+
+Total query latency: ~1.8 seconds (P95)
+```
+
+---
+
+### 7.3 Scenario C — Connector Sync (Confluence Integration)
+
+**Trigger:** Scheduled daily sync of a Confluence space containing 3,200 pages.
+
+```
+1. [Conductor Agent]
+   → Triggers Connector Agent with Confluence connector config (scheduled job)
+
+2. [Connector Agent]
+   ← Connector config (space key, OAuth token, last_sync_at cursor)
+   → Calls Confluence API: GET /rest/api/content?spaceKey=ENG&lastModified>{cursor}
+   → Finds 47 modified pages since last sync
+   → Fetches full page content for 47 pages
+   → Emits 47x `ingest.document.received` with Confluence metadata (page ID, author, version, labels)
+   → Updates sync cursor to current timestamp
+
+3. [Chunker Agent]
+   ← 47x `ingest.document.received`
+   → Splits Confluence pages (heading-aware chunking respecting Confluence macro boundaries)
+   → Emits ~320x `chunk.created`
+
+4. [Classifier Agent]
+   ← 320x `chunk.created`
+   → 280 chunks: domain=engineering (software, infrastructure)
+   → 32 chunks: domain=product (prd, specs)
+   → 8 chunks: domain=general
+   → Emits 320x `chunk.classified`
+
+5. [Dedup Agent]
+   ← 320x `chunk.classified`
+   → L1: 15 exact matches (pages re-saved without changes) → merged
+   → L2: 8 near-duplicates (page version bumps with minor edits) → expert review
+   → L3: 2 semantic near-duplicates (same content, different formatting) → expert review
+   → Emits 295x `chunk.deduplicated` (action: commit)
+
+6. [Embedder Agent], [Metadata Agent], [Entity Extractor Agent]  (parallel)
+   ← 295x `chunk.deduplicated`
+   → Full enrichment pipeline
+
+7. [Indexer Agent]
+   → Updates existing index entries for modified chunks (upsert by document_id + chunk_index)
+   → Emits 47x `document.indexed`
+
+8. [Archivist Agent]
+   → Previous versions of modified documents moved to version history
+   → New versions placed in hot storage
+
+9. [Monitor Agent]
+   → Records sync job metrics: 47 docs processed, 15 exact dedup, 10 expert review queued
+   → No SLA breach detected
+
+10. [Conductor Agent]
+    ← 47x `document.indexed`
+    → Marks Confluence sync job COMPLETE; schedules next run in 24 hours
+    → Notifies any subscribed users of knowledge base update
+
+Total sync latency (47 modified pages): ~45 seconds
+```
+
+---
+
+## 8. Full Specifications — 10 Key Agents
+
+### 8.1 Conductor Agent (Tier 0)
+
+**Purpose:** Central orchestrator; owns workflow state machines and routes messages between tiers.
+
+**Technology:** Node.js, TypeScript, in-memory state machine (XState v5)
+
+**Input Interface:**
+```typescript
+interface ConductorInput {
+  // External API
+  ingestRequest: {
+    sourceType: 'upload' | 'url' | 'connector';
+    payload: Buffer | string | ConnectorConfig;
+    requesterId: string;
+    priority?: number;
+  };
+  queryRequest: {
+    query: string;
+    userId: string;
+    domainFilter?: DomainKey[];
+    dateRange?: { from?: string; to?: string };
+  };
+  // Internal events
+  systemReady: SystemReadyEvent;
+  documentIndexed: DocumentIndexedEvent;
+  responseReady: ResponseReadyEvent;
+  systemCongestion: CongestionEvent;
+}
+```
+
+**Output Interface:**
+```typescript
+interface ConductorOutput {
+  dispatchedMessages: CAIAMessage[];
+  workflowStateUpdates: WorkflowState[];
+  apiResponse: { jobId: string; status: string; estimatedCompletionMs?: number };
+}
+```
+
+**SLAs:** Dispatch latency < 50 ms; workflow state persistence within 100 ms of event receipt.
+
+**Failure handling:** Dead-letter queue for undeliverable dispatches; exponential backoff with 3 retries; Conductor emits `audit.event` on every retry.
+
+---
+
+### 8.2 Ingest Agent (Tier 1)
+
+**Purpose:** First point of contact for all file-based document ingestion.
+
+**Technology:** Node.js, Multer (file handling), file-type (MIME detection), ClamAV integration
+
+**Input Interface:**
+```typescript
+interface IngestInput {
+  source: 'http_upload' | 's3_event' | 'ftp_drop';
+  files: Array<{
+    buffer: Buffer;
+    originalName: string;
+    mimeType: string;
+    sizeBytes: number;
+  }>;
+  sourceMetadata: {
+    uploaderId: string;
+    uploadedAt: string;
+    bucketOrPath?: string;
+  };
+}
+```
+
+**Output Interface:**
+```typescript
+interface IngestOutput {
+  topic: 'ingest.document.received';
+  payload: {
+    documentId: string;       // UUID v7
+    rawContent: Buffer;
+    mimeType: string;
+    filename: string;
+    sizeBytes: number;
+    sourceSystem: string;
+    sourceUrl?: string;
+    provenanceTier: number;
+    ingestedAt: string;
+  };
+}
+```
+
+**Throughput:** Up to 200 documents/sec (horizontal scaling).
+
+**Failure handling:** Virus scan failure → quarantine queue; unsupported MIME type → `ingest.document.failed` with reason.
+
+---
+
+### 8.3 Chunker Agent (Tier 2)
+
+**Purpose:** Splits raw documents into semantically coherent chunks for downstream processing.
+
+**Technology:** Node.js, LangChain `RecursiveCharacterTextSplitter`, custom heading-aware splitter for HTML/Markdown/PDF
+
+**Input Interface:**
+```typescript
+interface ChunkerInput {
+  topic: 'ingest.document.received';
+  payload: {
+    documentId: string;
+    rawContent: Buffer;
+    mimeType: string;
+    provenanceTier: number;
+  };
+}
+```
+
+**Output Interface:**
+```typescript
+interface ChunkerOutput {
+  topic: 'chunk.created';
+  payload: {
+    chunkId: string;          // UUID v7
+    documentId: string;       // Parent document ID
+    chunkIndex: number;       // 0-based position
+    totalChunks: number;
+    content: string;          // Normalised plain text
+    tokenCount: number;
+    headingPath: string[];    // Breadcrumb of headings above this chunk
+    pageNumbers?: number[];   // For PDF sources
+    provenanceTier: number;
+  };
+}
+```
+
+**Configuration:**
+- Default chunk size: 512 tokens (configurable 128–2048)
+- Overlap: 64 tokens (configurable 0–256)
+- Splitter strategy: `['heading', 'paragraph', 'sentence', 'word', 'character']` cascade
+
+**Failure handling:** Documents that cannot be chunked (binary, corrupt) → `ingest.document.failed`.
+
+---
+
+### 8.4 Classifier Agent (Tier 2)
+
+**Purpose:** Assigns domain taxonomy classification to each chunk.
+
+**Technology:** Node.js, HTTP client to CAIA classifier microservice (internally backed by a fine-tuned text classification model)
+
+**Input Interface:**
+```typescript
+interface ClassifierInput {
+  topic: 'chunk.created';
+  payload: {
+    chunkId: string;
+    documentId: string;
+    content: string;
+    headingPath: string[];
+  };
+}
+```
+
+**Output Interface:**
+```typescript
+interface ClassifierOutput {
+  topic: 'chunk.classified';
+  payload: {
+    chunkId: string;
+    documentId: string;
+    content: string;
+    classification: ClassificationResult;  // See §8 of taxonomy doc
+    provenanceTier: number;
+  };
+}
+```
+
+**Performance:** Batch size 64 chunks per API call; P95 latency < 200 ms per batch; fallback to `general` domain if confidence < 0.5.
+
+**Failure handling:** Classifier service unavailable → retry 3× with 1 s backoff; emit `chunk.classified` with `domain=general, confidence=0` after exhausted retries.
+
+---
+
+### 8.5 Dedup Agent (Tier 2)
+
+**Purpose:** Runs the three-layer deduplication funnel (see dedup architecture document for full specification).
+
+**Technology:** Node.js, better-sqlite3, sqlite-vec, custom MinHash/SimHash implementations
+
+**Input Interface:**
+```typescript
+interface DedupInput {
+  topic: 'chunk.classified';
+  payload: {
+    chunkId: string;
+    documentId: string;
+    content: string;
+    classification: ClassificationResult;
+    provenanceTier: number;
+    embedding?: Float32Array;  // If pre-computed by an upstream embedder (optional fast path)
+  };
+}
+```
+
+**Output Interface:**
+```typescript
+interface DedupOutput {
+  topic: 'chunk.deduplicated';
+  payload: {
+    chunkId: string;
+    documentId: string;
+    content: string;
+    classification: ClassificationResult;
+    provenanceTier: number;
+    dedupResult: DedupResult;  // See caia-dedup TypeScript API
+  };
+}
+```
+
+**Throughput:** ~200 chunks/sec (L1+L2 only); ~20 chunks/sec (including L3 with ANN).
+
+---
+
+### 8.6 Embedder Agent (Tier 3)
+
+**Purpose:** Generates dense vector embeddings for committed chunks.
+
+**Technology:** Node.js, OpenAI `text-embedding-3-small` (default) or local `nomic-embed-text` (air-gapped deployments)
+
+**Input Interface:**
+```typescript
+interface EmbedderInput {
+  topic: 'chunk.deduplicated';
+  payload: {
+    chunkId: string;
+    content: string;
+    classification: ClassificationResult;
+    provenanceTier: number;
+  };
+}
+```
+
+**Output Interface:**
+```typescript
+interface EmbedderOutput {
+  topic: 'chunk.embedded';
+  payload: {
+    chunkId: string;
+    documentId: string;
+    embedding: Float32Array;   // 1536-dim
+    modelId: string;
+    embeddedAt: string;
+  };
+}
+```
+
+**Performance:** Batch size 100; rate limit aware (OpenAI: 1M tokens/min); LRU cache for repeated content (128 MB cache).
+
+---
+
+### 8.7 Retrieval Agent (Tier 5)
+
+**Purpose:** Executes hybrid retrieval over the CAIA knowledge store in response to user queries.
+
+**Technology:** Node.js, better-sqlite3, sqlite-vec (ANN), SQLite FTS5 (BM25), cross-encoder re-ranker
+
+**Input Interface:**
+```typescript
+interface RetrievalInput {
+  topic: 'query.received';
+  payload: {
+    queryId: string;
+    queryText: string;
+    queryEmbedding: Float32Array;
+    expandedTerms: string[];
+    domainFilter?: DomainKey[];
+    provenanceTierMax?: number;
+    dateAfter?: string;
+    dateBefore?: string;
+    topK?: number;            // Default: 10
+    userId: string;
+  };
+}
+```
+
+**Output Interface:**
+```typescript
+interface RetrievalOutput {
+  topic: 'retrieval.completed';
+  payload: {
+    queryId: string;
+    candidates: Array<{
+      chunkId: string;
+      documentId: string;
+      content: string;
+      domain: DomainKey;
+      subdomain: string;
+      rrfScore: number;       // Reciprocal Rank Fusion score
+      denseScore: number;     // Cosine similarity
+      sparseScore: number;    // BM25 score
+      rerankScore: number;    // Cross-encoder score
+      provenanceTier: number;
+      documentTitle: string;
+      sourceUrl?: string;
+      pageNumbers?: number[];
+    }>;
+    retrievalStats: {
+      denseHits: number;
+      sparseHits: number;
+      fusedCount: number;
+      rerankedCount: number;
+      latencyMs: number;
+    };
+  };
+}
+```
+
+**Performance:** P50 < 800 ms; P95 < 2 s; P99 < 5 s (over 1M vectors, 10M BM25 terms).
+
+---
+
+### 8.8 Synthesiser Agent (Tier 5)
+
+**Purpose:** Generates grounded, attributed answers from retrieved context.
+
+**Technology:** Node.js, Anthropic Claude API (`claude-sonnet-4-6`), streaming SSE to response buffer
+
+**Input Interface:**
+```typescript
+interface SynthesiserInput {
+  topic: 'retrieval.completed';
+  payload: RetrievalOutput['payload'];
+  originalQuery: string;
+  domainContext: DomainKey;
+  responseFormat: 'prose' | 'bullet_points' | 'table' | 'structured_json';
+}
+```
+
+**Output Interface:**
+```typescript
+interface SynthesiserOutput {
+  topic: 'response.ready';
+  payload: {
+    queryId: string;
+    answer: string;
+    answerFormat: string;
+    faithfulnessScore: number;   // 0.0–1.0 (proportion of claims attributable to context)
+    usedChunkIds: string[];      // Chunks actually cited in the answer
+    generationModelId: string;
+    inputTokens: number;
+    outputTokens: number;
+    latencyMs: number;
+  };
+}
+```
+
+**Faithfulness checking:** After generation, each claim in the answer is verified against the retrieved chunks using a lightweight entailment model; if faithfulness < 0.85, the answer is regenerated with a stricter prompt.
+
+---
+
+### 8.9 Compliance Agent (Tier 5)
+
+**Purpose:** Enforces access control, domain-specific content policies, and regulatory compliance on all outgoing responses.
+
+**Technology:** Node.js, rule engine (JSON-rules-engine), integration with CAIA RBAC service
+
+**Input Interface:**
+```typescript
+interface ComplianceInput {
+  topic: 'response.ready';
+  payload: SynthesiserOutput['payload'];
+  userId: string;
+  userPermissions: string[];       // e.g. ['legal:read', 'finance:read']
+  domainFilter: DomainKey[];
+  retrievedChunkMetadata: Array<{
+    chunkId: string;
+    domain: DomainKey;
+    hasPrivilegedMarker: boolean;
+    retentionPolicy: string;
+  }>;
+}
+```
+
+**Output Interface:**
+```typescript
+interface ComplianceOutput {
+  // On pass:
+  topic: 'response.ready';       // Re-emitted with compliance metadata attached
+  payload: {
+    // All original Synthesiser fields plus:
+    complianceCleared: true;
+    complianceRules: string[];   // Rules evaluated
+    redactedSections?: string[]; // Sections redacted (if any)
+    auditReference: string;      // Audit log entry ID
+  };
+  // On block:
+  // topic: 'compliance.blocked'
+  // payload: { queryId, reason, blockedRules }
+}
+```
+
+**Rules evaluated (examples):**
+- User has `{domain}:read` permission for every domain in response
+- No chunks with `hasPrivilegedMarker=true` included without `legal-privilege:read` permission
+- HIPAA: PHI not returned to users without `hipaa_trained=true` attribute
+- GDPR: Data subject information not returned for users in restricted regions
+
+---
+
+### 8.10 Monitor Agent (Tier 6)
+
+**Purpose:** Platform-wide observability: metrics collection, alerting, and health broadcasting.
+
+**Technology:** Node.js, prom-client (Prometheus metrics), Grafana-compatible dashboard spec
+
+**Input Interface:**
+```typescript
+interface MonitorInput {
+  // Continuous subscription to:
+  heartbeatEvents: HeartbeatEvent[];          // topic: 'system.heartbeat'
+  documentFailedEvents: DocumentFailedEvent[]; // topic: 'ingest.document.failed'
+  congestionEvents: CongestionEvent[];         // topic: 'system.congestion'
+  auditEvents: AuditEvent[];                   // topic: 'audit.event' (sampled 10%)
+}
+```
+
+**Output Interface:**
+```typescript
+interface MonitorOutput {
+  // Prometheus metrics endpoint (HTTP GET /metrics)
+  metrics: {
+    caia_documents_ingested_total: Counter;
+    caia_documents_failed_total: Counter;
+    caia_dedup_actions_total: Counter;        // labels: action, layer
+    caia_query_latency_seconds: Histogram;
+    caia_agent_capacity: Gauge;               // labels: agent_id
+    caia_queue_depth: Gauge;                  // labels: topic
+    caia_embedding_latency_seconds: Histogram;
+  };
+  // Broadcast health event every 30 seconds
+  systemHealthBroadcast: {
+    topic: 'system.health';
+    payload: {
+      timestamp: string;
+      overallStatus: 'ok' | 'degraded' | 'critical';
+      agentStatuses: Record<AgentId, 'ok' | 'degraded' | 'stopped' | 'error'>;
+      queueDepths: Record<string, number>;
+    };
+  };
+}
+```
+
+**Alerting rules:**
+- Agent capacity > 0.9 for > 30 s → `WARNING: Agent congestion`
+- `ingest.document.failed` rate > 5% over 5 min → `ERROR: Ingestion failure spike`
+- Query P95 latency > 5 s over 10 min → `WARNING: Query SLA breach`
+- Any agent heartbeat missing for > 60 s → `CRITICAL: Agent unresponsive`
+
+---
+
+## 9. Agent Registry Bootstrap Configuration
+
+The following is the full `scaffolder.config.json` used to bootstrap all 25 agents:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "agents": [
+    { "agentType": "ConductorAgent",       "tier": 0, "instances": 1 },
+    { "agentType": "IngestAgent",          "tier": 1, "instances": 1 },
+    { "agentType": "ScraperAgent",         "tier": 1, "instances": 1 },
+    { "agentType": "ConnectorAgent",       "tier": 1, "instances": 1 },
+    { "agentType": "ChunkerAgent",         "tier": 2, "instances": 1 },
+    { "agentType": "ClassifierAgent",      "tier": 2, "instances": 1 },
+    { "agentType": "DedupAgent",           "tier": 2, "instances": 1 },
+    { "agentType": "OCRAgent",             "tier": 2, "instances": 1 },
+    { "agentType": "NormaliserAgent",      "tier": 2, "instances": 1 },
+    { "agentType": "EmbedderAgent",        "tier": 3, "instances": 1 },
+    { "agentType": "MetadataAgent",        "tier": 3, "instances": 1 },
+    { "agentType": "EntityExtractorAgent", "tier": 3, "instances": 1 },
+    { "agentType": "SummariserAgent",      "tier": 3, "instances": 1 },
+    { "agentType": "LinkerAgent",          "tier": 3, "instances": 1 },
+    { "agentType": "IndexerAgent",         "tier": 4, "instances": 1 },
+    { "agentType": "KnowledgeGraphAgent",  "tier": 4, "instances": 1 },
+    { "agentType": "ArchivistAgent",       "tier": 4, "instances": 1 },
+    { "agentType": "QueryAgent",           "tier": 5, "instances": 1 },
+    { "agentType": "RetrievalAgent",       "tier": 5, "instances": 1 },
+    { "agentType": "SynthesiserAgent",     "tier": 5, "instances": 1 },
+    { "agentType": "CitationAgent",        "tier": 5, "instances": 1 },
+    { "agentType": "ComplianceAgent",      "tier": 5, "instances": 1 },
+    { "agentType": "MonitorAgent",         "tier": 6, "instances": 1 },
+    { "agentType": "ScaffolderAgent",      "tier": 6, "instances": 1 },
+    { "agentType": "AuditAgent",           "tier": 6, "instances": 1 }
+  ],
+  "transport": {
+    "type": "in-process",
+    "redisUrl": null
+  },
+  "database": {
+    "path": "./caia.db",
+    "sqliteVecExtension": "./node_modules/sqlite-vec/sqlite-vec.so"
+  }
+}
+```
+
+---
+
+## 10. Open Questions
+
+1. **Horizontal scaling:** Which agents are stateless and can scale horizontally without coordination? (Candidates: Embedder, Classifier, Normaliser, OCR.) Stateful agents (Dedup, Indexer, Knowledge Graph) require leader-election or shard assignment.
+
+2. **Agent versioning:** When a new version of an agent is deployed, how are in-flight messages handled? Is the old agent instance drained before shutdown, or do we allow concurrent old/new agent versions?
+
+3. **Cross-agent transactions:** The Dedup → Indexer pipeline requires atomicity (a chunk should not be indexed if dedup fails). Should we implement a two-phase commit or accept eventual consistency with compensating events?
+
+4. **Knowledge Graph Agent storage:** The current design uses SQLite for the KG. At what document scale should we migrate to a dedicated graph database (e.g. Apache AGE on Postgres, or Memgraph)?
+
+5. **Synthesiser model selection:** Should the Synthesiser select different LLMs based on domain (e.g. a legal-fine-tuned model for `legal` domain queries)? What is the routing logic and fallback?
+
+---
+
+*End of CAIA Agent Team Architecture — v1.0*

--- a/docs/legacy-conductor-reports/caia-domain-taxonomy-and-dedup-architecture.md
+++ b/docs/legacy-conductor-reports/caia-domain-taxonomy-and-dedup-architecture.md
@@ -1,0 +1,764 @@
+# CAIA Domain Taxonomy & Dedup Architecture
+
+**Version:** 1.0  
+**Date:** 2026-04-27  
+**Status:** Design Proposal
+
+---
+
+## 1. Overview
+
+This document defines the canonical 16-domain taxonomy for CAIA content classification and the three-layer deduplication engine architecture. Together they form the foundation for ingesting, classifying, deduplicating, and routing content across the CAIA platform.
+
+---
+
+## 2. Full 16-Domain Taxonomy
+
+### 2.1 Domain Definitions
+
+The CAIA taxonomy organises all ingestable content into 16 top-level domains. Each domain owns a set of sub-domains that narrow classification to the level of specificity required for routing and retrieval.
+
+| # | Domain Key | Display Name | Description |
+|---|---|---|---|
+| 1 | `legal` | Legal | Contracts, legislation, case law, compliance frameworks |
+| 2 | `finance` | Finance | Accounting, financial statements, investment instruments, tax |
+| 3 | `medical` | Medical & Health | Clinical notes, drug information, medical research, patient care |
+| 4 | `engineering` | Engineering & Technical | Software, hardware, architecture, systems design |
+| 5 | `science` | Science & Research | Academic papers, lab data, experimental results |
+| 6 | `hr` | Human Resources | Policies, job descriptions, onboarding, performance |
+| 7 | `sales` | Sales & CRM | Proposals, pipelines, customer communications |
+| 8 | `marketing` | Marketing | Campaigns, brand guidelines, content calendars, analytics |
+| 9 | `operations` | Operations | Runbooks, SOPs, incident reports, supply chain |
+| 10 | `product` | Product Management | PRDs, roadmaps, user stories, acceptance criteria |
+| 11 | `education` | Education & Training | Curricula, course materials, assessments, certifications |
+| 12 | `real_estate` | Real Estate | Property listings, lease agreements, valuations, zoning |
+| 13 | `government` | Government & Policy | Regulations, public records, government reports |
+| 14 | `media` | Media & Publishing | News articles, editorial content, scripts, transcripts |
+| 15 | `logistics` | Logistics & Supply Chain | Shipping, inventory, route optimisation, vendor data |
+| 16 | `general` | General / Uncategorised | Catch-all for content that does not fit any specific domain |
+
+### 2.2 Sub-Domain Hierarchy
+
+Each top-level domain expands into sub-domains as follows:
+
+#### `legal`
+- `contracts` — NDAs, MSAs, SOWs, employment agreements
+- `compliance` — GDPR, SOC 2, HIPAA, ISO frameworks
+- `litigation` — case law, court filings, arbitration records
+- `ip` — patents, trademarks, copyright documents
+- `regulatory` — SEC filings, environmental regulations
+
+#### `finance`
+- `accounting` — balance sheets, income statements, audits
+- `tax` — corporate tax, VAT, transfer pricing documents
+- `investment` — prospectuses, term sheets, cap tables
+- `banking` — loan agreements, credit facilities, treasury docs
+- `reporting` — quarterly reports, board packs, KPI dashboards
+
+#### `medical`
+- `clinical` — clinical notes, discharge summaries, orders
+- `pharma` — drug monographs, trial data, formularies
+- `imaging` — radiology reports, DICOM metadata
+- `research` — systematic reviews, meta-analyses, IRB protocols
+- `insurance` — prior auth, claims, EOBs
+
+#### `engineering`
+- `software` — source code, API docs, architecture diagrams
+- `hardware` — schematics, BOM, test reports
+- `infrastructure` — network diagrams, cloud configs, IaC
+- `security` — threat models, pentest reports, CVE advisories
+- `qa` — test plans, bug reports, coverage reports
+
+#### `science`
+- `biology` — genomics, proteomics, ecology studies
+- `chemistry` — synthesis protocols, material safety data
+- `physics` — experimental data, simulation results
+- `data_science` — datasets, notebooks, model cards
+- `environmental` — climate data, emissions reports
+
+#### `hr`
+- `policy` — employee handbooks, code of conduct
+- `recruitment` — job postings, interview guides, offer letters
+- `performance` — reviews, OKRs, PIPs
+- `benefits` — health plans, pension documents
+- `onboarding` — orientation materials, checklists
+
+#### `sales`
+- `proposals` — RFP responses, SOWs, quotes
+- `contracts` — customer agreements, renewals
+- `pipeline` — deal summaries, forecast reports
+- `enablement` — battle cards, objection handling guides
+- `crm_data` — account records, contact histories
+
+#### `marketing`
+- `campaigns` — briefs, ad copy, creative assets metadata
+- `brand` — brand guidelines, tone of voice documents
+- `content` — blog posts, whitepapers, case studies
+- `analytics` — performance reports, attribution data
+- `events` — conference materials, webinar scripts
+
+#### `operations`
+- `runbooks` — incident playbooks, escalation procedures
+- `sop` — standard operating procedures
+- `vendor` — supplier contracts, SLAs, vendor assessments
+- `facilities` — office management, maintenance logs
+- `quality` — ISO audit reports, corrective action records
+
+#### `product`
+- `prd` — product requirements documents
+- `roadmap` — feature roadmaps, release plans
+- `research` — user research, usability studies
+- `specs` — technical specifications, API contracts
+- `feedback` — customer feedback, NPS data
+
+#### `education`
+- `curriculum` — course outlines, learning objectives
+- `materials` — lecture notes, slides, textbooks
+- `assessment` — exams, rubrics, grading guides
+- `certification` — professional certifications, accreditation docs
+- `elearning` — SCORM packages, LMS exports
+
+#### `real_estate`
+- `listings` — property descriptions, MLS data
+- `legal` — title deeds, lease agreements, purchase contracts
+- `valuation` — appraisal reports, comparables analysis
+- `zoning` — planning permissions, zoning maps
+- `management` — maintenance records, tenant communications
+
+#### `government`
+- `legislation` — bills, acts, statutory instruments
+- `policy` — government white papers, consultation documents
+- `records` — FOIA responses, public notices
+- `procurement` — RFP/RFQ/RFI documents, award notices
+- `defence` — unclassified military doctrines, procurement specs
+
+#### `media`
+- `news` — articles, press releases, wire copy
+- `editorial` — opinion pieces, longform features
+- `broadcast` — scripts, transcripts, closed captions
+- `social` — social media exports, community guidelines
+- `publishing` — book manuscripts, journal articles
+
+#### `logistics`
+- `shipping` — bills of lading, shipping manifests, customs docs
+- `inventory` — stock records, warehouse management exports
+- `routing` — route optimisation plans, carrier schedules
+- `vendor` — freight contracts, 3PL agreements
+- `returns` — reverse logistics, RMA documentation
+
+#### `general`
+- `miscellaneous` — truly uncategorised content
+- `multilingual` — content awaiting language detection
+- `legacy` — migrated content with unknown origin
+
+---
+
+## 3. Domain Taxonomy JSON Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://caia.internal/schemas/domain-taxonomy/v1",
+  "title": "CAIADomainTaxonomy",
+  "type": "object",
+  "required": ["domain", "subdomain", "confidence", "version"],
+  "properties": {
+    "domain": {
+      "type": "string",
+      "enum": [
+        "legal", "finance", "medical", "engineering", "science",
+        "hr", "sales", "marketing", "operations", "product",
+        "education", "real_estate", "government", "media",
+        "logistics", "general"
+      ],
+      "description": "Top-level domain classification"
+    },
+    "subdomain": {
+      "type": "string",
+      "description": "Sub-domain within the top-level domain"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Classification confidence score (0.0–1.0)"
+    },
+    "secondary_domains": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["domain", "confidence"],
+        "properties": {
+          "domain": { "type": "string" },
+          "subdomain": { "type": "string" },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+        }
+      },
+      "description": "Up to 3 secondary domain matches for cross-domain content"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+$",
+      "description": "Taxonomy schema version used for classification"
+    },
+    "classified_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "classifier_model": {
+      "type": "string",
+      "description": "Identifier of the model or rule set that produced this classification"
+    }
+  }
+}
+```
+
+### 3.1 Example Classification Record
+
+```json
+{
+  "domain": "legal",
+  "subdomain": "contracts",
+  "confidence": 0.94,
+  "secondary_domains": [
+    { "domain": "finance", "subdomain": "banking", "confidence": 0.31 }
+  ],
+  "version": "1.0",
+  "classified_at": "2026-04-27T18:00:00Z",
+  "classifier_model": "caia-domain-classifier-v1"
+}
+```
+
+---
+
+## 4. Deduplication Engine — Three-Layer Funnel
+
+The dedup engine processes every ingested document through three sequential layers before it is committed to the knowledge store. Each layer eliminates a different class of duplicate at increasing computational cost.
+
+```
+Ingest Queue
+     │
+     ▼
+┌────────────────────────────────────────┐
+│  LAYER 1: Exact Hash Match             │  ~0ms  (DB lookup)
+│  SHA-256 fingerprint comparison        │
+└────────────────────────────────────────┘
+     │ pass-through (no exact match)
+     ▼
+┌────────────────────────────────────────┐
+│  LAYER 2: Near-Duplicate Detection     │  ~5ms  (MinHash / LSH)
+│  SimHash + MinHash Locality-Sensitive  │
+│  Hashing, Jaccard similarity ≥ 0.85   │
+└────────────────────────────────────────┘
+     │ pass-through (no near-duplicate)
+     ▼
+┌────────────────────────────────────────┐
+│  LAYER 3: Semantic Dedup               │  ~50ms (vector similarity)
+│  Embedding cosine similarity ≥ 0.92   │
+│  via sqlite-vec ANN index              │
+└────────────────────────────────────────┘
+     │ pass-through (semantically unique)
+     ▼
+Knowledge Store (committed)
+```
+
+### 4.1 Layer 1 — Exact Hash Match
+
+**Mechanism:** SHA-256 hash of the normalised document body (after stripping whitespace, metadata headers, and conversion to UTF-8 NFC form).
+
+**Storage:** Hash → document_id lookup in a dedicated `content_hashes` table (B-tree indexed).
+
+**Action on match:** Merge provenance metadata into the existing record; discard the incoming document body. Increment `ingestion_count` on the canonical record.
+
+**Cost:** Single indexed DB read, < 1 ms.
+
+**False positive rate:** Cryptographically negligible (2⁻²⁵⁶).
+
+### 4.2 Layer 2 — Near-Duplicate Detection
+
+**Mechanism:** Two complementary algorithms run in parallel:
+
+1. **SimHash (64-bit)** — Charikar's algorithm over 3-gram token shingles. Hamming distance ≤ 3 bits flags a near-duplicate.
+2. **MinHash with LSH** — 128-permutation MinHash; 8 LSH bands of 16 rows each. Candidates with Jaccard similarity ≥ 0.85 are flagged.
+
+**Storage:** SimHash signatures in a `simhash_index` column (integer, B-tree). MinHash band keys in a `minhash_bands` table partitioned by band number.
+
+**Action on match:** Route to a human-review queue if similarity is in [0.85, 0.95); auto-merge if ≥ 0.95. The older or higher-provenance-scored document is kept as canonical.
+
+**Cost:** ~5 ms per document for combined LSH lookup.
+
+**False negative rate (missed duplicates):** < 2% at the 0.85 threshold with 128 permutations.
+
+### 4.3 Layer 3 — Semantic Deduplication
+
+**Mechanism:** Dense vector embedding (1536-dim) compared against existing corpus embeddings using Approximate Nearest Neighbour (ANN) search via sqlite-vec.
+
+**Threshold:** Cosine similarity ≥ 0.92 triggers a dedup candidate; the decision matrix (§5) determines final action.
+
+**Storage:** Vectors stored in sqlite-vec virtual table (see §6).
+
+**Action on match:** If similarity is in [0.92, 0.97), route to domain-expert review. If ≥ 0.97, auto-merge with the canonical record, appending the new document's unique metadata as a provenance annotation.
+
+**Cost:** ~50 ms per document (ANN search over 1 M vectors with HNSW index, 32 ef-search).
+
+---
+
+## 5. Decision Matrix
+
+The decision matrix governs the final action taken when a candidate duplicate is identified. It combines the similarity score, the layer that detected the match, and the document's provenance tier.
+
+| Detection Layer | Similarity Range | Provenance Equal | Provenance Higher (incoming) | Provenance Lower (incoming) |
+|---|---|---|---|---|
+| L1 — Exact | 1.0 | Merge metadata | Merge metadata | Merge metadata |
+| L2 — Near-dup | ≥ 0.95 | Auto-merge, keep older | Auto-merge, keep incoming | Auto-merge, keep existing |
+| L2 — Near-dup | [0.85, 0.95) | Human review | Human review | Human review |
+| L3 — Semantic | ≥ 0.97 | Auto-merge, keep older | Auto-merge, keep incoming | Auto-merge, keep existing |
+| L3 — Semantic | [0.92, 0.97) | Domain-expert review | Domain-expert review | Domain-expert review |
+| None | < threshold | **Commit as new** | **Commit as new** | **Commit as new** |
+
+### 5.1 Provenance Tiers
+
+Provenance tiers rank document sources for conflict resolution:
+
+| Tier | Label | Examples |
+|---|---|---|
+| 1 | Primary Source | Regulatory body, official government publication, court record |
+| 2 | Authoritative Secondary | Peer-reviewed journal, audited financial statement |
+| 3 | Verified Internal | Company-signed contracts, audited internal docs |
+| 4 | Unverified Internal | Draft documents, email attachments |
+| 5 | External Unverified | Web scraped content, user-uploaded documents |
+
+---
+
+## 6. sqlite-vec Recommendation
+
+### 6.1 Why sqlite-vec
+
+sqlite-vec is recommended as the vector store layer for CAIA's dedup and retrieval pipeline for the following reasons:
+
+- **Embedded architecture** — runs in-process with the CAIA Node.js runtime; no separate vector DB service to manage or scale.
+- **HNSW index** — supports Hierarchical Navigable Small World graph indexing for sub-linear ANN search at production scale.
+- **Portability** — the vector store travels with the SQLite database file; trivial to snapshot, replicate, and test.
+- **SQLite ecosystem** — joins with relational metadata, provenance tables, and domain classification records in a single query.
+- **Open source** — MIT-licensed; no vendor lock-in.
+
+### 6.2 Schema
+
+```sql
+-- Enable sqlite-vec extension
+SELECT load_extension('./node_modules/sqlite-vec/sqlite-vec.so');
+
+-- Main document store
+CREATE TABLE IF NOT EXISTS documents (
+  id            TEXT PRIMARY KEY,  -- UUID v7
+  domain        TEXT NOT NULL,
+  subdomain     TEXT,
+  content_hash  TEXT NOT NULL,     -- SHA-256 hex
+  simhash       INTEGER,           -- 64-bit SimHash
+  content       TEXT,
+  provenance_tier INTEGER DEFAULT 5,
+  ingestion_count INTEGER DEFAULT 1,
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL
+);
+
+-- sqlite-vec virtual table for embeddings
+CREATE VIRTUAL TABLE IF NOT EXISTS document_embeddings USING vec0(
+  document_id TEXT PRIMARY KEY,
+  embedding   FLOAT[1536]
+);
+
+-- Near-duplicate band index (Layer 2 MinHash LSH)
+CREATE TABLE IF NOT EXISTS minhash_bands (
+  band_id     INTEGER NOT NULL,   -- 0..7
+  band_key    TEXT NOT NULL,      -- hex of band's row hashes
+  document_id TEXT NOT NULL,
+  PRIMARY KEY (band_id, band_key, document_id)
+);
+
+-- Content hash index (Layer 1)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_hash ON documents(content_hash);
+
+-- SimHash index (Layer 2)
+CREATE INDEX IF NOT EXISTS idx_simhash ON documents(simhash);
+```
+
+### 6.3 ANN Query Example
+
+```typescript
+// Find semantic near-duplicates for an incoming embedding
+const candidates = await db.all(`
+  SELECT
+    d.id,
+    d.domain,
+    d.provenance_tier,
+    vec_distance_cosine(de.embedding, ?) AS distance
+  FROM document_embeddings de
+  JOIN documents d ON d.id = de.document_id
+  WHERE de.embedding MATCH ?
+    AND k = 20
+  ORDER BY distance ASC
+`, [embeddingBuffer, embeddingBuffer]);
+
+const duplicates = candidates.filter(c => (1 - c.distance) >= 0.92);
+```
+
+---
+
+## 7. Edge Cases
+
+### 7.1 Cross-Domain Duplicates
+
+**Scenario:** The same document (e.g. a contract with financial schedules) is submitted through two different domain ingestion pipelines — once via the `legal` pipeline and once via `finance`.
+
+**Handling:**
+- Layer 1 (exact hash) will catch this before domain routing matters.
+- If caught at Layer 2 or 3, the decision matrix resolves on provenance tier; domain metadata is merged into the canonical record's `secondary_domains` field.
+- The document is stored once; both domain indexes point to the same canonical id.
+
+### 7.2 Version Updates (Genuine Updates, Not Duplicates)
+
+**Scenario:** A v2 of an NDA is submitted; it is 92% similar to v1 but represents a genuine legal revision.
+
+**Handling:**
+- Layer 3 will flag it at the [0.92, 0.97) range, routing to domain-expert review.
+- The review UI displays a diff and asks: "Is this a new version or a duplicate?"
+- If confirmed as a new version: create a new record, link to the prior version via `supersedes_id` FK, and do not merge.
+- If confirmed as a duplicate: merge per the decision matrix.
+
+### 7.3 Translations
+
+**Scenario:** The same document exists in English and French.
+
+**Handling:**
+- Normalised text hashes will differ (L1 miss).
+- Token-based SimHash will differ significantly (L2 miss at the 0.85 Jaccard threshold).
+- Cross-lingual embeddings (e.g. multilingual-e5-large) will produce high cosine similarity (≥ 0.92), triggering L3.
+- The decision matrix routes to expert review. The reviewer marks them as translation pairs; both are retained with a `translation_of` link rather than merged.
+
+### 7.4 Template Instances
+
+**Scenario:** 500 near-identical contracts generated from the same template; each has unique names and dates.
+
+**Handling:**
+- L1 will miss (content differs).
+- L2 SimHash will likely detect high similarity (Hamming distance ≤ 3). Jaccard on 3-grams may be ≥ 0.85.
+- Each contract is a genuine independent document; they should NOT be merged.
+- **Solution:** Template detection pre-pass before the dedup funnel. If the document matches a registered template fingerprint, skip L2/L3 dedup and commit directly. The template registry is maintained by the Operations team.
+
+### 7.5 Chunked Ingestion
+
+**Scenario:** A 400-page legal brief is ingested as 80 x 5-page chunks for processing; each chunk is also re-submitted later as part of a different workflow.
+
+**Handling:**
+- Chunk-level dedup via L1 hash of each chunk.
+- Parent document ID is tracked via `parent_document_id` on each chunk record.
+- Re-submitted chunks match at L1; provenance metadata is updated.
+- The parent document's `ingestion_count` is not inflated by chunk re-ingestion.
+
+### 7.6 OCR Noise Variability
+
+**Scenario:** Two scans of the same physical document produce slightly different OCR outputs due to scan quality.
+
+**Handling:**
+- L1 hash will differ.
+- L2 SimHash Hamming distance may be > 3 due to character substitution noise.
+- L3 semantic embeddings are robust to OCR noise at the sentence level; similarity will typically land in [0.92, 0.99], triggering the dedup funnel correctly.
+- Recommendation: Pre-process with OCR confidence filtering; re-run OCR with enhanced resolution before ingestion if confidence < 0.80.
+
+---
+
+## 8. Open-Source Package TypeScript APIs
+
+### 8.1 `caia-classifier` — Domain Classification Package
+
+```typescript
+/**
+ * caia-classifier
+ * Domain taxonomy classification for CAIA content pipelines.
+ */
+
+export type DomainKey =
+  | 'legal' | 'finance' | 'medical' | 'engineering' | 'science'
+  | 'hr' | 'sales' | 'marketing' | 'operations' | 'product'
+  | 'education' | 'real_estate' | 'government' | 'media'
+  | 'logistics' | 'general';
+
+export interface ClassificationResult {
+  domain: DomainKey;
+  subdomain: string;
+  confidence: number;
+  secondaryDomains: Array<{
+    domain: DomainKey;
+    subdomain: string;
+    confidence: number;
+  }>;
+  classifiedAt: Date;
+  classifierModel: string;
+}
+
+export interface ClassifierOptions {
+  /** Minimum confidence threshold to accept a classification. Default: 0.6 */
+  minConfidence?: number;
+  /** Maximum secondary domains to return. Default: 3 */
+  maxSecondaryDomains?: number;
+  /** Model identifier override */
+  modelId?: string;
+  /** Timeout in milliseconds. Default: 5000 */
+  timeoutMs?: number;
+}
+
+export interface ClassifierClient {
+  /**
+   * Classify a single text document.
+   */
+  classify(text: string, options?: ClassifierOptions): Promise<ClassificationResult>;
+
+  /**
+   * Classify multiple documents in a single batch request.
+   * Returns results in the same order as inputs.
+   */
+  classifyBatch(
+    texts: string[],
+    options?: ClassifierOptions
+  ): Promise<ClassificationResult[]>;
+
+  /**
+   * Check whether the classifier service is healthy.
+   */
+  healthCheck(): Promise<{ status: 'ok' | 'degraded' | 'unavailable'; latencyMs: number }>;
+}
+
+export interface ClassifierConfig {
+  /** Base URL of the CAIA classifier service */
+  serviceUrl: string;
+  /** API key for authentication */
+  apiKey: string;
+  /** Default options applied to all requests */
+  defaultOptions?: ClassifierOptions;
+}
+
+/**
+ * Create a new ClassifierClient instance.
+ *
+ * @example
+ * ```typescript
+ * import { createClassifier } from 'caia-classifier';
+ *
+ * const classifier = createClassifier({
+ *   serviceUrl: 'https://classifier.caia.internal',
+ *   apiKey: process.env.CAIA_API_KEY!,
+ * });
+ *
+ * const result = await classifier.classify(documentText);
+ * console.log(result.domain, result.subdomain, result.confidence);
+ * ```
+ */
+export declare function createClassifier(config: ClassifierConfig): ClassifierClient;
+
+/**
+ * Utility: Retrieve the full taxonomy tree as a nested object.
+ */
+export declare function getTaxonomy(): Record<DomainKey, string[]>;
+
+/**
+ * Utility: Validate whether a given domain/subdomain pair is valid.
+ */
+export declare function isValidDomainPair(domain: string, subdomain: string): boolean;
+```
+
+### 8.2 `caia-dedup` — Deduplication Engine Package
+
+```typescript
+/**
+ * caia-dedup
+ * Three-layer deduplication engine for CAIA content pipelines.
+ */
+
+import type { Database } from 'better-sqlite3';
+
+export type DedupAction =
+  | 'commit'         // No duplicate found — commit as new document
+  | 'auto_merge'     // High-confidence duplicate — merge automatically
+  | 'review_human'   // Near-duplicate — route to human review queue
+  | 'review_expert'; // Semantic near-duplicate — route to domain-expert review
+
+export type DetectionLayer = 'none' | 'layer1_exact' | 'layer2_near' | 'layer3_semantic';
+
+export interface DedupResult {
+  action: DedupAction;
+  layer: DetectionLayer;
+  /** Similarity score at the layer that detected the match (0.0–1.0). Null if action is 'commit'. */
+  similarity: number | null;
+  /** ID of the canonical document if a duplicate was detected. */
+  canonicalId: string | null;
+  /** Processing time in milliseconds per layer */
+  timings: {
+    layer1Ms: number;
+    layer2Ms: number;
+    layer3Ms: number;
+    totalMs: number;
+  };
+}
+
+export interface IncomingDocument {
+  /** Unique identifier for this ingestion event */
+  id: string;
+  /** Normalised plain-text content (UTF-8 NFC, whitespace-stripped) */
+  content: string;
+  /** Pre-computed 1536-dim embedding vector */
+  embedding: Float32Array;
+  /** Provenance tier (1 = highest authority, 5 = lowest) */
+  provenanceTier: 1 | 2 | 3 | 4 | 5;
+  /** Domain classification result */
+  domain: string;
+  subdomain?: string;
+}
+
+export interface DedupEngineOptions {
+  /** Jaccard similarity threshold for Layer 2 auto-merge. Default: 0.95 */
+  l2AutoMergeThreshold?: number;
+  /** Jaccard similarity threshold for Layer 2 human review. Default: 0.85 */
+  l2ReviewThreshold?: number;
+  /** Cosine similarity threshold for Layer 3 auto-merge. Default: 0.97 */
+  l3AutoMergeThreshold?: number;
+  /** Cosine similarity threshold for Layer 3 expert review. Default: 0.92 */
+  l3ReviewThreshold?: number;
+  /** Number of MinHash permutations. Default: 128 */
+  minHashPermutations?: number;
+  /** Number of LSH bands. Default: 8 */
+  lshBands?: number;
+  /** ANN search ef parameter for HNSW. Default: 32 */
+  hnswEfSearch?: number;
+  /** Max ANN candidates to retrieve before filtering. Default: 20 */
+  annTopK?: number;
+}
+
+export interface DedupEngine {
+  /**
+   * Run an incoming document through the full three-layer dedup funnel.
+   * Does NOT commit the document — call commitDocument() after inspecting the result.
+   */
+  check(doc: IncomingDocument): Promise<DedupResult>;
+
+  /**
+   * Commit a document to the knowledge store after a 'commit' dedup result.
+   * Throws if the document was already committed or if action !== 'commit'.
+   */
+  commitDocument(doc: IncomingDocument): Promise<{ id: string }>;
+
+  /**
+   * Merge an incoming document's metadata into an existing canonical record.
+   * Call this when action is 'auto_merge'.
+   */
+  mergeIntoCanonical(
+    incomingId: string,
+    canonicalId: string,
+    incomingDoc: IncomingDocument
+  ): Promise<void>;
+
+  /**
+   * Retrieve dedup queue items pending review.
+   */
+  getPendingReview(options?: {
+    type?: 'human' | 'expert';
+    domain?: string;
+    limit?: number;
+  }): Promise<ReviewQueueItem[]>;
+
+  /**
+   * Resolve a review queue item.
+   */
+  resolveReview(
+    reviewId: string,
+    resolution: 'merge' | 'keep_both' | 'keep_incoming' | 'translation' | 'version'
+  ): Promise<void>;
+}
+
+export interface ReviewQueueItem {
+  reviewId: string;
+  type: 'human' | 'expert';
+  incomingDocumentId: string;
+  canonicalDocumentId: string;
+  similarity: number;
+  layer: DetectionLayer;
+  domain: string;
+  createdAt: Date;
+}
+
+export interface DedupEngineConfig {
+  /** better-sqlite3 Database instance (must have sqlite-vec loaded) */
+  db: Database;
+  options?: DedupEngineOptions;
+}
+
+/**
+ * Create a DedupEngine instance backed by the provided SQLite database.
+ *
+ * @example
+ * ```typescript
+ * import Database from 'better-sqlite3';
+ * import { createDedupEngine } from 'caia-dedup';
+ *
+ * const db = new Database('./caia.db');
+ * db.loadExtension('./sqlite-vec.so');
+ *
+ * const engine = createDedupEngine({ db });
+ *
+ * const result = await engine.check({
+ *   id: 'doc-123',
+ *   content: normalisedText,
+ *   embedding: new Float32Array(embeddingVector),
+ *   provenanceTier: 3,
+ *   domain: 'legal',
+ *   subdomain: 'contracts',
+ * });
+ *
+ * if (result.action === 'commit') {
+ *   await engine.commitDocument(doc);
+ * } else if (result.action === 'auto_merge') {
+ *   await engine.mergeIntoCanonical(doc.id, result.canonicalId!, doc);
+ * }
+ * ```
+ */
+export declare function createDedupEngine(config: DedupEngineConfig): DedupEngine;
+
+/**
+ * Utility: Compute the SHA-256 hash of normalised content.
+ */
+export declare function computeContentHash(content: string): string;
+
+/**
+ * Utility: Compute a 64-bit SimHash of tokenised content.
+ */
+export declare function computeSimHash(tokens: string[]): bigint;
+
+/**
+ * Utility: Compute MinHash signature for LSH band construction.
+ */
+export declare function computeMinHash(
+  tokens: string[],
+  numPermutations?: number
+): Uint32Array;
+
+/**
+ * Utility: Compute Jaccard similarity from two MinHash signatures.
+ */
+export declare function jaccardFromMinHash(a: Uint32Array, b: Uint32Array): number;
+```
+
+---
+
+## 9. Open Questions
+
+1. **Multilingual embeddings:** Should the L3 semantic dedup use a monolingual or multilingual embedding model? Multilingual models (e.g. multilingual-e5-large) enable cross-lingual dedup but have higher false-positive rates for topically similar but substantively different content.
+
+2. **Chunked vs. whole-document dedup:** Should dedup run at the chunk level, the document level, or both? Chunk-level is more granular but increases vector store size significantly.
+
+3. **Review SLA:** What is the acceptable time-to-resolution for items in the human/expert review queue? This determines the required reviewer capacity.
+
+4. **Template registry ownership:** Which team maintains the template registry used to short-circuit dedup for template-generated documents?
+
+---
+
+*End of CAIA Domain Taxonomy & Dedup Architecture — v1.0*

--- a/docs/legacy-conductor-reports/caia-execution-plan.md
+++ b/docs/legacy-conductor-reports/caia-execution-plan.md
@@ -1,0 +1,743 @@
+# CAIA Platform: Dependency-Aware Fastest-Path Execution Plan
+
+**Generated:** 2026-04-27  
+**Horizon:** 24 weeks (12 × 2-week sprints) — ends 2026-10-11  
+**Based on:** `caia-platform-architecture-proposal.md` + codebase audit + PR #43 blocker analysis
+
+---
+
+## ⚡ DO THIS RIGHT NOW (TODAY, 2026-04-27)
+
+**Fix PR #43 CI failures.** Every single item in this plan is blocked until CI is green. Zero other work has leverage until the monorepo is in a deployable, clean state. Open the failing checks, fix typecheck/lint/test errors, push, and watch CI go green. Do not start any new feature work until the PR is merged.
+
+**Also today (manual, < 5 minutes):** Disable 4 Cowork connectors in Cowork Settings UI — Kapture, Chrome Control, Notes, osascript. This is a one-time cleanup that removes background noise.
+
+---
+
+## Table of Contents
+
+1. [Dependency Graph Analysis](#part-1-dependency-graph-analysis)
+2. [Critical Path](#part-2-critical-path)
+3. [Parallel Track Identification](#part-3-parallel-track-identification)
+4. [Sprint-by-Sprint Execution Plan](#part-4-sprint-by-sprint-execution-plan)
+5. [Test-Fix-Commit Protocol](#part-5-test-fix-commit-protocol)
+6. [Risk Register](#part-6-risk-register)
+7. [Success Metrics](#part-7-success-metrics)
+8. [ASCII Gantt Chart](#appendix-ascii-gantt-chart)
+
+---
+
+## Part 1: Dependency Graph Analysis
+
+### 1.1 All Discrete Work Items
+
+#### Infrastructure & Foundation
+
+| ID | Work Item | Status | Effort | Blocking Items |
+|----|-----------|--------|--------|----------------|
+| F-01 | Fix PR #43 CI (typecheck / lint / test / build) | 🚨 BLOCKER | S | Everything |
+| F-02 | Disable 4 Cowork connectors (manual UI step) | 🚨 BLOCKER | XS | Cowork stability |
+| F-03 | Verify monorepo structure post-merge (all imports, builds, paths) | Foundation | S | Depends on F-01 |
+| F-04 | Add `initiative` to `stories.kind` enum (migration 0017) | Foundation | XS | Depends on F-01 |
+| F-05 | Add `enriched_spec_json` + `parallel_batch` columns (migration 0017b) | Foundation | XS | Depends on F-01 |
+| F-06 | Add `pull_requests` table (migration 0018) | Foundation | XS | Depends on F-01 |
+| F-07 | Add `deployments` table (migration 0019) | Foundation | XS | Depends on F-01 |
+| F-08 | Add `acceptance_reviews` table (migration 0020) | Foundation | XS | Depends on F-01 |
+| F-09 | Add `releases` table (migration 0021) | Foundation | XS | Depends on F-01 |
+| F-10 | Add `routing_decision` + `local_model` cols to `executor_runs` (migration 0022) | Foundation | XS | Depends on F-01 |
+| F-11 | Extend events-taxonomy: 14 new event types (clarification, dag, pr, deploy, acceptance, release, prompt.completed) | Foundation | S | Depends on F-01 |
+| F-12 | Executor streaming: POST outputLines to `/task-runs/{id}/output` as they arrive | Foundation | S | Depends on F-01 |
+| F-13 | Add `GET /task-runs/{id}/stream` SSE endpoint in Hono | Foundation | S | Depends on F-12 |
+| F-14 | Add `GET /events/stream` SSE endpoint for event feed | Foundation | S | Depends on F-01 |
+| F-15 | Test coverage gate ≥ 80% on event-bus, events-taxonomy, prioritization, orchestrator-middleware | Foundation | M | Depends on F-01 |
+| F-16 | Add `github_token` + `cloudflare_token` fields to `projects` table; encrypt at rest | Foundation | S | Depends on F-01 |
+| F-17 | Add `build_commands` JSON config to `projects` table | Foundation | XS | Depends on F-01 |
+| F-18 | Turso/libSQL support: `DATABASE_URL` env var, libSQL client adapter | Foundation | S | Can defer to Sprint 8 |
+
+#### Core Pipeline Utilities
+
+| ID | Work Item | Status | Effort | Key Dependencies |
+|----|-----------|--------|--------|-----------------|
+| P-01 | `@caia/clarifier` — AI question generator + clarity scorer | Missing | M | F-01, F-11 |
+| P-02 | `@caia/decomposer` — 2-phase AI decomposer (Initiative→Epic→Module + Stories) | Missing | L | F-01, F-04, F-11 |
+| P-03 | `@caia/enricher` — Per-story AI spec generator (file paths, function sigs, test cases) | Missing | M | P-02 |
+| P-04 | `@caia/dag-analyzer` — Kahn's algorithm DAG + file-overlap detection + parallel batches | Missing | M | P-02, F-05 |
+| P-05 | Story→Task Bridge — creates Tasks from Stories post-DAG with full dependency linkage | Missing | S | P-04 |
+| P-06 | `@caia/scheduler` completion — bridge from Stories to executor queue | Partial | S | P-05 |
+| P-07 | `@caia/worktree-manager` extraction — extract from executor/dispatcher.ts to standalone package | Partial | S | F-01 |
+| P-08 | `@caia/pr-manager` — GitHub PR creation, AI review, diff summary, status tracking | Missing | M | F-06, F-16, P-07 |
+| P-09 | `@caia/test-runner` — Auto-run Vitest/Playwright on task.completed; update behavior registry | Partial | M | P-08 |
+| P-10 | `@caia/build-verifier` — Auto-run build pipeline; AI error diagnosis on failure | Partial | M | P-09 |
+| P-11 | `@caia/deployment-manager` — Cloudflare Pages staging deploy, health verify | Missing | M | F-07, F-16, P-10 |
+| P-12 | `@caia/acceptance-gate` — Staging notify + human decision API + event emit | Missing | M | F-08, P-11 |
+| P-13 | `@caia/release-manager` — Merge PR, production deploy, tag release | Missing | S | F-09, P-12 |
+| P-14 | `@caia/observability-closeout` — Final metrics, cost summary, prompt.completed event | Partial | S | P-13 |
+| P-15 | `@caia/local-llm-router` — Ollama routing policy, cost-budget gating, domain exclusions | Partial | L | F-10, P-02, P-03 |
+| P-16 | Ollama tool execution loop — bash/file I/O via local LLM API (replaces claude --print) | Missing | L | P-15 |
+| P-17 | BullMQ mode for executor queue (behind `EXECUTOR_QUEUE=bullmq` flag) | Missing | M | F-01 |
+| P-18 | NATS inter-process event transport (EventTransport abstraction) | Missing | M | F-01 |
+
+#### Dashboard Views
+
+| ID | Work Item | Status | Effort | Key Dependencies |
+|----|-----------|--------|--------|-----------------|
+| D-01 | Prompt Submission view — rich text, project selector, priority hint, cost estimate | Skeleton | S | F-01 |
+| D-02 | Prompt Waterfall view — accordion Initiative→Epic→Module→Story→Task→Subtask + real-time | Skeleton | M | P-02, F-12, F-13 |
+| D-03 | Task Detail view — spec, execution history, file changes, raw output, re-run controls | Skeleton | S | F-01 |
+| D-04 | Live Execution view — real-time output stream, subtask list, tool calls, kill button | Skeleton | M | F-12, F-13 |
+| D-05 | Test Results view — pass/fail history, flake detection, run trigger, failure excerpts | Skeleton | S | P-09 |
+| D-06 | Build Status view — step-by-step output, retry controls, AI error diagnosis display | Skeleton | S | P-10 |
+| D-07 | Deployment Status view — staging/prod URLs, status, rollback button | Missing | S | P-11 |
+| D-08 | Human Acceptance Review view — staging preview, criteria checklist, approve/reject | Missing | M | P-12 |
+| D-09 | Notifications panel — bell icon, in-app + webhook on staging ready | Missing | S | P-11 |
+| D-10 | Settings page — GitHub token, Cloudflare token, executor config, build commands | Skeleton | S | F-16, F-17 |
+| D-11 | Observability dashboard completion — cost breakdown by model, throughput, 30-day trend | Partial | S | P-14, P-15 |
+| D-12 | Prompt History / full-text search | Missing | S | F-01 |
+| D-13 | Mobile-responsive layout for waterfall + acceptance views | Missing | S | D-02, D-08 |
+| D-14 | Keyboard shortcuts — submit, navigate, approve/reject | Missing | XS | D-01, D-08 |
+
+#### Domain Taxonomy & Dedup (from domain taxonomy architecture doc)
+
+| ID | Work Item | Status | Effort | Key Dependencies |
+|----|-----------|--------|--------|-----------------|
+| T-01 | Domain taxonomy baseline — canonical domain list, slug definitions, ownership rules | Missing | S | F-01 |
+| T-02 | Domain classifier utility — assigns stories to domains using AI + rule-based fallback | Missing | M | T-01, P-02 |
+| T-03 | Dedup engine — story-level semantic deduplication before scheduling | Missing | M | P-02, T-02 |
+| T-04 | Dedup dashboard view — surfacing near-duplicate stories for human review | Missing | S | T-03 |
+| T-05 | Domain heatmap integration in dashboard (file heat map already exists) | Partial | S | T-02 |
+| T-06 | Lock contracts system — design standards, brand rules enforcement in decomposer | Missing | M | P-02, T-01 |
+
+#### Agent Team (from agent team architecture doc)
+
+| ID | Work Item | Status | Effort | Key Dependencies |
+|----|-----------|--------|--------|-----------------|
+| A-01 | Agent Registry — central registry of agent capabilities, tools, prompts, versions | Missing | M | F-01 |
+| A-02 | Agent Scaffolder — CLI + template generator for new agents following standard conventions | Missing | M | A-01 |
+| A-03 | Tier 0 — Coordinator Agent (routes prompts to right tier, manages handoffs) | Missing | M | A-01, P-02 |
+| A-04 | Tier 1 — Product Owner Agent (refines requirements, generates acceptance criteria) | Missing | M | A-01, A-03 |
+| A-05 | Tier 1 — Business Analyst Agent (domain modeling, data flow analysis, edge cases) | Missing | M | A-01, A-03 |
+| A-06 | Tier 1 — Architect Agent (technical design, ADR drafting, stack decisions) | Missing | L | A-01, A-03 |
+| A-07 | Tier 2 — Developer Agent (story execution, tool orchestration, self-checking) | Partial | M | A-01, P-02 |
+| A-08 | Tier 2 — Test Engineer Agent (writes and runs test suites, interprets failures) | Missing | M | A-01, P-09 |
+| A-09 | Tier 2 — Code Reviewer Agent (PR review, acceptance criteria coverage, risk flags) | Missing | M | A-01, P-08 |
+| A-10 | Tier 3 — QA Agent (E2E test authoring, regression triage) | Missing | M | A-01, A-08 |
+| A-11 | Tier 3 — Security Agent (OWASP checks, secret scanning, auth review) | Missing | M | A-01 |
+| A-12 | Tier 3 — Performance Agent (load test design, bottleneck identification) | Missing | L | A-01 |
+| A-13 | Tier 4 — Deploy Agent (orchestrates deployment-manager, verifies health) | Missing | M | A-01, P-11 |
+| A-14 | Tier 4 — Monitor Agent (watches pulse runs, escalates anomalies) | Missing | M | A-01 |
+| A-15 | Tier 5 — Meta/Coach Agent (improves agent prompts based on outcomes, token analysis) | Missing | L | A-01, all others |
+| A-16 | Agent-to-agent communication protocol (event-bus mediated, no direct calls) | Missing | M | A-01, F-11 |
+| A-17 | Agent evaluation harness — 3 example inputs per agent, output schema validation | Missing | M | A-01 |
+
+#### Open-Source Extraction
+
+| ID | Work Item | Status | Effort | Key Dependencies |
+|----|-----------|--------|--------|-----------------|
+| O-01 | Extract `@caia/event-bus` as standalone (parameterize ConductorEvent type) | Done (published) | S | Stable in prod first |
+| O-02 | Extract `@caia/task-dag` (clean up for standalone; zero CAIA deps) | Missing | S | P-04 stable |
+| O-03 | Extract `@caia/claude-executor` (injectable hooks, no CAIA API calls) | Partial | M | P-07, all exec stable |
+| O-04 | Extract `@caia/pipeline-pulse` (injectable check implementations) | Partial | S | Stable in prod |
+| O-05 | Extract `@caia/completeness-sentinel` (clean config interface) | Done (published) | S | Already external |
+| O-06 | Extract `@caia/requirement-decomposer` (generalize schema) | Missing | L | P-02 stable in prod |
+
+---
+
+### 1.2 Classification: Critical Path / Parallel / Blocked
+
+| Classification | Items |
+|---|---|
+| **Critical Path** | F-01 → F-03→F-04→F-05→F-11 → P-02 → P-03 → P-04 → P-05 → P-06 → P-09 → P-10 → P-08 → P-11 → P-12 → P-13 → P-14 |
+| **Parallel Eligible (start after F-01)** | F-06 through F-17, P-01, P-07, P-17, P-18, D-01, T-01, A-01 |
+| **Parallel Eligible (start after P-02)** | P-03 + P-04 simultaneously, T-02, T-06, A-03 |
+| **Blocked (on Critical Path items)** | P-08 (needs F-06, F-16), P-11 (needs P-10), P-12 (needs P-11), A-04→A-15 (need A-01) |
+| **Deferred (Phase 6+)** | P-15, P-16, O-01 through O-06 |
+
+---
+
+## Part 2: Critical Path
+
+The critical path is the single longest sequential chain that determines the earliest possible completion date for a fully automated prompt-to-deploy pipeline.
+
+```
+Fix PR #43 CI
+    ↓
+Monorepo verification + Foundation migrations (F-03 → F-04, F-05, F-11)
+    ↓
+@caia/decomposer (Phase 1 Sonnet call + Phase 2 parallel story generation) [LONGEST SINGLE ITEM]
+    ↓
+@caia/enricher (parallel Haiku/Sonnet calls per Story)
+    ↓
+@caia/dag-analyzer (topological sort + file overlap detection)
+    ↓
+Story→Task Bridge + @caia/scheduler completion
+    ↓
+@caia/test-runner (post-execution test automation)
+    ↓
+@caia/build-verifier (post-test build verification)
+    ↓
+@caia/pr-manager (GitHub PR creation + AI review)
+    ↓
+@caia/deployment-manager (Cloudflare Pages staging deploy)
+    ↓
+@caia/acceptance-gate (human decision API + dashboard view)
+    ↓
+@caia/release-manager (merge + production deploy)
+    ↓
+@caia/observability-closeout (metrics + prompt.completed)
+    ↓
+FIRST FULLY AUTOMATED PROMPT → DEPLOYED FEATURE
+```
+
+**Estimated critical path duration: 18–20 weeks** (assuming F-01 fixed in week 1).
+
+**The decomposer (P-02) is the single most critical item on the path.** It unlocks everything downstream and has the highest implementation risk. All efforts to parallelise work elsewhere are secondary to shipping P-02.
+
+---
+
+## Part 3: Parallel Track Identification
+
+### Track A — Core Pipeline (Critical Path)
+The main artery. All other tracks feed into or support this one.
+
+Items: F-01 → F-03..F-11 → P-02 → P-03 → P-04 → P-05 → P-06 → P-09 → P-10 → P-08 → P-11 → P-12 → P-13 → P-14
+
+### Track B — Domain Taxonomy + Classifier + Dedup
+Can start in Sprint 2 (after F-01 merged). Produces the domain taxonomy that feeds into P-02's project context. A 9-week effort running in parallel with the core pipeline.
+
+Items: T-01 → T-02 → T-03 → T-04 → T-05 → T-06
+
+### Track C — Dashboard Enhancements
+Runs continuously. Each dashboard view unblocks as its data source becomes available. Can start immediately after F-01.
+
+Items: D-01 → D-03 → D-10 → D-12 → D-02 (needs P-02) → D-04 (needs F-12) → D-05 (needs P-09) → D-06 (needs P-10) → D-07 (needs P-11) → D-08 (needs P-12) → D-09 → D-11 → D-13 → D-14
+
+### Track D — Agent Team Infrastructure
+Starts after F-01 and begins once the orchestration model (P-02) is working. Adds the multi-agent layer on top of the pipeline.
+
+Items: A-01 → A-02 → A-16 → A-03 → A-04 → A-05 → A-06 → A-07 → A-08 → A-09 → A-10 → A-11 → A-12 → A-13 → A-14 → A-15 → A-17
+
+### Track E — Testing Infrastructure, Local LLM, Open Source
+Runs in the final 8 weeks. Requires a working end-to-end pipeline as its foundation.
+
+Items: P-17 → P-18 → P-15 → P-16 → O-01..O-06
+
+---
+
+## Part 4: Sprint-by-Sprint Execution Plan
+
+### Sprint 1 — 2026-04-27 to 2026-05-10
+**Theme: UNBLOCK EVERYTHING — Fix CI, harden foundation**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **F-01: Fix PR #43 CI** | A | S | None | F-02 | Human + Claude Code | All CI checks (Build, Test, Lint, Typecheck) green. PR merged to main. | All pre-existing tests pass | git push → CI green → merge |
+| **F-02: Disable 4 Cowork connectors** | Ops | XS | None | F-01 | Human (manual UI) | Kapture, Chrome Control, Notes, osascript disabled in Cowork Settings. | N/A | N/A (UI action) |
+| **F-03: Monorepo post-merge verification** | A | S | F-01 | F-04..F-11 | Claude Code | `pnpm build` exits 0 from root. All packages resolve. No phantom imports. | `pnpm typecheck && pnpm test` from root pass | git commit "chore: post-merge monorepo cleanup" |
+| **F-04: Migration 0017 — `initiative` kind** | A | XS | F-01 | F-05..F-11 | Claude Code | Drizzle push succeeds. `stories.kind` accepts 'initiative'. Backfill runs on empty set (no existing initiatives). | Drizzle schema test | git commit "feat(db): add initiative kind to stories" |
+| **F-05: Migration 0017b — `enriched_spec_json`, `parallel_batch`** | A | XS | F-01 | F-04 | Claude Code | Columns added to `stories`. Old rows default to null. Drizzle push clean. | Schema integrity test | git commit "feat(db): story enrichment columns" |
+| **F-11: Extend events-taxonomy (14 new types)** | A | S | F-01 | F-04 | Claude Code | All 14 new types in `registry.yaml` + TypeScript type definitions. Existing event consumers compile without changes. | `pnpm typecheck` on events-taxonomy passes | git commit "feat(events): add pipeline stage event types" + `pnpm publish` `@caia/events-taxonomy` v bump |
+| **F-06..F-10: Migrations 0018-0022** | A | S | F-01 | F-04, F-11 | Claude Code | All 5 migrations run cleanly. Drizzle push succeeds. Schemas match appendix A specs. | Drizzle schema test for each | git commit "feat(db): pr/deployment/acceptance/release/llm tables" |
+| **D-01: Prompt Submission view** | C | S | F-01 | D-03 | Claude Code | `/prompts/new` renders, validates input, POSTs to API, redirects to prompt detail. Handles error state. Character count live. | Component render test + API integration test | git commit "feat(dashboard): prompt submission view" |
+| **D-03: Task Detail view** | C | S | F-01 | D-01 | Claude Code | `/tasks/[id]` renders all fields. Re-run button works. Edit notes inline editor saves. | Render test + mock data fixture | git commit "feat(dashboard): task detail view completion" |
+
+**Sprint 1 Success Gate:** PR #43 merged, CI green, root `pnpm build` clean, all 6 migrations applied, events-taxonomy published.
+
+---
+
+### Sprint 2 — 2026-05-11 to 2026-05-24
+**Theme: FOUNDATIONS COMPLETE — Executor streaming, settings, domain taxonomy begins**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **F-12: Executor streaming — POST outputLines** | A | S | F-01 | F-13, F-14 | Claude Code | Executor POSTs each output line to `/task-runs/{id}/output` as it arrives (not at completion). API stores in `task_run_output_lines` table. | Integration test: run a real short task, verify lines arrive before completion event | git commit "feat(executor): stream output lines to API" |
+| **F-13: SSE endpoint `GET /task-runs/{id}/stream`** | A | S | F-12 | F-14 | Claude Code | Endpoint streams `outputLines` as `data:` SSE events. Client EventSource reconnects on drop. | SSE integration test | git commit "feat(api): task-run SSE stream endpoint" |
+| **F-14: SSE endpoint `GET /events/stream`** | A | S | F-01 | F-12 | Claude Code | Endpoint streams all bus events filtered by optional `type` query param. | SSE integration test | git commit "feat(api): event stream SSE endpoint" |
+| **F-15: Test coverage gate ≥ 80%** | A | M | F-01 | F-12..F-14 | Claude Code | Vitest coverage report shows ≥ 80% on event-bus, events-taxonomy, prioritization packages. Enforced via `gate:coverage` script in CI. | Coverage report artifact in CI | git commit "test: enforce 80% coverage gate on core packages" |
+| **F-16: GitHub + Cloudflare token fields in projects** | A | S | F-01 | F-17 | Claude Code | `projects` table has `github_token_encrypted`, `cloudflare_api_token_encrypted` columns. Settings API encrypts/decrypts with `ENCRYPTION_KEY` env var. | Encryption round-trip test | git commit "feat(db): project credential storage" |
+| **F-17: `build_commands` config in projects** | A | XS | F-01 | F-16 | Claude Code | `projects.build_commands` JSON column. Default: `[{name:"typecheck",cmd:"pnpm typecheck"},{name:"test",cmd:"pnpm test"},{name:"build",cmd:"pnpm build"}]` | Schema test | git commit "feat(db): per-project build commands" |
+| **P-07: Extract `@caia/worktree-manager`** | A | S | F-01 | F-12..F-17 | Claude Code | `packages/worktree-manager/` package. `createWorktree`, `cleanupWorktree`, `listWorktrees` extracted from `apps/executor/dispatcher.ts`. Executor imports from package. | Unit tests for create/cleanup lifecycle | git commit + `pnpm publish` `@caia/worktree-manager` |
+| **T-01: Domain taxonomy baseline** | B | S | F-01 | F-12..P-07 | Human + Claude Code | `domains` table populated with canonical domain list + slugs + ownership rules. CLAUDE.md in orchestrator updated with domain taxonomy reference. | Domain slug uniqueness test | git commit "feat(domains): canonical taxonomy v1" |
+| **D-10: Settings page** | C | S | F-16, F-17 | D-01 | Claude Code | `/settings` page renders project config form. GitHub token field saves/loads (masked). Build commands editable JSON. Cloudflare token field. | Form submit test | git commit "feat(dashboard): settings page" |
+| **A-01: Agent Registry** | D | M | F-01 | T-01 | Claude Code | `packages/agent-registry/` package. Schema: `agents` table with id, name, tier, system_prompt, tools[], version, created_at. CRUD API at `/agents`. Type-safe `AgentManifest` interface. | Unit tests for registry CRUD | git commit + `pnpm publish` `@caia/agent-registry` |
+
+**Sprint 2 Success Gate:** Executor streams output in real-time. F-15 coverage gate enforced in CI. Agent registry published.
+
+---
+
+### Sprint 3 — 2026-05-25 to 2026-06-07
+**Theme: THE DECOMPOSER — the most important two weeks in the roadmap**
+
+The decomposer is the single hardest and most valuable item. Deserves a full sprint. Do not split focus.
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **P-02: `@caia/decomposer` Phase 1** | A | L | F-04, F-05, F-11 | T-02 starts | Claude Code | Phase 1: given a prompt + project context, Sonnet call returns structured JSON with Initiative + Epics + Modules. JSON conforms to `DecompositionTree` schema (JSON Schema validation). All nodes written to `stories` table with `rootPromptId`. `story.created` emitted per node. | Eval suite: 5 representative prompts decomposed. Assert: ≥ 1 Initiative, ≥ 2 Epics, ≥ 3 Modules per complex prompt. Schema validation 100%. | git commit "feat(decomposer): phase 1 initiative+epic+module" |
+| **P-02: `@caia/decomposer` Phase 2** | A | L | P-02 Phase 1 | T-02 | Claude Code | Phase 2: parallel Sonnet/Haiku calls — one per Module — produce Stories. Each Story has: title, description, expectedBehavior, acceptanceCriteria[], verificationPlan[], estimatedFiles[], dependsOn[], domainSlug. Leaf stories written to `stories` table. `pipeline.decompose_completed` emitted. | Eval suite expanded to 10 prompts. Assert: Stories have all required fields (100%), estimatedFiles non-empty (90%), domainSlug resolves to a valid domain (80%). Decomposition completes in < 60 seconds. | git commit "feat(decomposer): phase 2 parallel story generation" + `pnpm publish` `@caia/decomposer` |
+| **T-02: Domain classifier** | B | M | T-01, P-02 | P-02 | Claude Code | Given a Story title + description + estimatedFiles[], classifier assigns `domainSlug`. Two modes: AI (Haiku) + rule-based fallback (file path prefix matching). 85%+ accuracy on 20 manually-labeled test stories. | 20-story labeled test set. Classifier accuracy ≥ 85%. | git commit "feat(classifier): domain assignment utility" |
+| **A-02: Agent Scaffolder** | D | M | A-01 | P-02 | Claude Code | `packages/agent-scaffolder/` CLI: `pnpm agent:new --name=<name> --tier=<0-5>` generates: system prompt template, manifest file, eval fixture dir, package.json stub. Registers agent in registry on create. | Scaffolder creates valid manifest. Agent passes typecheck. | git commit + `pnpm publish` `@caia/agent-scaffolder` |
+
+**Sprint 3 Success Gate:** A prompt submitted to the API results in a full Initiative→Epic→Module→Story tree in the `stories` table. Eval suite green on 10 prompts.
+
+---
+
+### Sprint 4 — 2026-06-08 to 2026-06-21
+**Theme: ENRICHMENT + DAG — turn stories into actionable specs**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **P-03: `@caia/enricher`** | A | M | P-02 | P-04, P-01 | Claude Code | Subscribes to `pipeline.decompose_completed`. For each leaf Story: calls Claude (Haiku for trivial/simple, Sonnet for moderate/complex based on `estimatedComplexity`). Output stored in `stories.enriched_spec_json`. Fields: implementationNotes, fileChanges[], testCases[], dependenciesRequired[], recommendedModel. All stories enriched before emitting `story.enrichment_completed`. | Enrichment produces non-empty `fileChanges` for 95% of stories. `recommendedModel` set for 100% of stories. | git commit + `pnpm publish` `@caia/enricher` |
+| **P-04: `@caia/dag-analyzer`** | A | M | P-02, F-05 | P-03, P-01 | Claude Code | Implements Kahn's algorithm on `stories.dependsOn[]`. Detects file-overlap implicit dependencies (two stories touching the same file → story with create/schema change goes first). Validates: no cycles (halts with `pipeline.dag_error` if found). Writes `stories.parallel_batch` (integer, 0-indexed topological level). Emits `pipeline.dag_computed`. | Cycle detection test (inject known cycle, assert error). Parallel batch assignment test (known DAG, assert batches). File overlap test. | git commit + `pnpm publish` `@caia/dag-analyzer` |
+| **P-05 + P-06: Story→Task Bridge + Scheduler completion** | A | S | P-04 | P-03 | Claude Code | After `pipeline.dag_computed`: for each leaf Story, creates a `tasks` row with: `title`, `notes` (enriched spec JSON), `declaredFiles`, `dependsOn`, `priorityBucket`, `positionOrdinal`, `rootPromptId`, `domainSlug`. Links to parent story via `storyId` FK. Emits `task.created` + `task.queued` per task. Executor picks up queued tasks on next poll. | Integration test: decompose sample prompt → verify task count matches story count, all priority buckets set, all dependsOn chains valid. | git commit "feat(pipeline): story-task bridge + scheduler wiring" |
+| **P-01: `@caia/clarifier`** | A | M | F-11 | P-03, P-04 | Claude Code | Subscribes to `prompt.ingested`. Computes `clarityScore` (0–1) via Haiku. If `score < 0.85`: generates up to 5 targeted questions (priority: critical/normal/optional). Writes to `questions` table. Emits `prompt.clarification_started`. On all critical questions answered (or `canSkip: true`): emits `prompt.clarification_completed` which triggers decomposer. | Clarity score test: unambiguous prompt → score > 0.85 (skips). Ambiguous prompt → score < 0.85, generates questions. | git commit + `pnpm publish` `@caia/clarifier` |
+| **T-03: Dedup engine** | B | M | P-02, T-02 | P-03 | Claude Code | Before scheduling, scan new stories against existing completed stories for semantic duplicates (cosine similarity on embeddings via Haiku). Flag near-duplicates (similarity > 0.85) with `duplicate_of` reference. Emit `story.duplicate_flagged`. | Dedup test: submit same requirement twice, second run flags stories as duplicates. | git commit "feat(dedup): semantic story deduplication" |
+| **D-02: Prompt Waterfall view — Phase 1** | C | M | P-02 | P-03 | Claude Code | `/prompts/[id]` renders: header card, pipeline stage progress bar, accordion tree (Initiative→Epic→Module→Story). Static data (no real-time yet). Uses `/prompts/:id/pipeline` API. | Render test with fixture data covering all hierarchy levels. Empty state handled. Error state handled. | git commit "feat(dashboard): prompt waterfall accordion tree" |
+| **A-03: Coordinator Agent** | D | M | A-01, A-02 | P-03 | Claude Code | Tier 0 agent: receives a prompt classification signal, routes to the right tier-1 agent (PO/BA/Architect) based on prompt type. System prompt written + evaluated against 3 representative inputs. Registered in agent-registry. | 3 eval fixtures pass. Agent returns valid `AgentHandoff` schema. | git commit "feat(agents): coordinator agent tier-0" |
+
+**Sprint 4 Success Gate:** Full pipeline from `prompt.ingested` → clarification → decomposition → enrichment → DAG → tasks queued. Executor can pick up and run these tasks. End-to-end: submit a prompt, get running tasks.
+
+---
+
+### Sprint 5 — 2026-06-22 to 2026-07-05
+**Theme: EXECUTION LOOP CLOSED — first prompt runs tasks end-to-end**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **Integration test: full prompt→tasks pipeline** | A | S | P-01..P-06 | P-09 starts | Human + Claude Code | Submit a real test prompt. Verify: clarification check runs, decomposition produces valid tree, enrichment completes, DAG computed with batches, tasks created and queued, executor picks up and starts first batch. All events emitted in correct order. | End-to-end integration test in `apps/orchestrator/test/e2e/` | git commit "test(e2e): prompt to task execution pipeline" |
+| **P-09: `@caia/test-runner`** | A | M | P-08 scaffolding (partial — doesn't need full PR yet) | P-10 | Claude Code | Daemon subscribes to `task.completed`. Runs `vitest run --reporter=json --related <changedFiles>`. Parses JSON output. Updates `behavior_test_runs`. Creates blocker entries for failures. Flake detection: re-run failing tests ≤ 2 times; classify as `flake` if inconsistent. Emits `pipeline.tests_completed` (all pass) or `pipeline.tests_failed`. | Test runner runs on sample project with known test suite. Passes/fails/skips counted correctly. Flake classifier correctly identifies non-deterministic test (mock timer). | git commit + `pnpm publish` `@caia/test-runner` |
+| **P-10: `@caia/build-verifier`** | A | M | P-09 | P-08 | Claude Code | Subscribes to `pipeline.tests_completed`. Runs configured build commands from `projects.build_commands` in sequence. Captures stdout/stderr per step. Persists to `build_runs`/`build_steps`. On failure: calls Claude Sonnet to diagnose error signature, creates a fix task via `POST /tasks`. Emits `build.completed` (pass) or `build.failed`. | Build verifier runs against a project with a known passing build. Also: inject a type error, verify Sonnet diagnoses it and creates a fix task. | git commit + `pnpm publish` `@caia/build-verifier` |
+| **D-04: Live Execution view** | C | M | F-12, F-13 | P-09, P-10 | Claude Code | `/tasks/[id]/live` renders: terminal-style output stream (auto-scroll), subtask checklist, current tool call, files touched, turn counter, kill button. Connects to SSE stream endpoint. | SSE connection test. Kill button sends SIGTERM and updates status. | git commit "feat(dashboard): live execution view" |
+| **D-05: Test Results view** | C | S | P-09 | D-06 | Claude Code | `/tests` renders behavior test registry: pass/fail history, flake badge, run trigger button, failure excerpts. Filter by project/scope/status. | Render test with fixture data. Run trigger fires correct API call. | git commit "feat(dashboard): test results view" |
+| **T-04: Dedup dashboard view** | B | S | T-03 | T-05 | Claude Code | Dashboard panel showing near-duplicate story pairs with similarity score. Human can dismiss (keep both) or merge (mark one as `superseded`). | Render test. Dismiss + merge actions update DB correctly. | git commit "feat(dashboard): dedup review panel" |
+| **A-04: Product Owner Agent** | D | M | A-01, A-03 | A-05 | Claude Code | Tier 1 agent: refines vague requirements, generates detailed acceptance criteria, identifies scope boundaries. Integrates with clarifier output. 3 eval fixtures pass. | 3 eval fixtures | git commit "feat(agents): product owner agent tier-1" |
+| **A-05: Business Analyst Agent** | D | M | A-01, A-03 | A-04 | Claude Code | Tier 1 agent: domain modeling, data flow analysis, edge case identification, constraint documentation. 3 eval fixtures pass. | 3 eval fixtures | git commit "feat(agents): business analyst agent tier-1" |
+
+**Sprint 5 Success Gate:** A real prompt flows all the way to task execution AND test runner runs automatically after. Tests are reported in the dashboard.
+
+---
+
+### Sprint 6 — 2026-07-06 to 2026-07-19
+**Theme: QUALITY GATES — build verification, hardening, streaming complete**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **Build verification integration + hardening** | A | S | P-10 | P-08 | Claude Code | Build verifier integrated into pipeline. Pulse check added for build verifier health. Auto-fix task creation for type errors tested with real failures. | Pulse check passes. Auto-fix task created for injected error. | git commit "feat(pulse): build verifier health check" |
+| **D-06: Build Status view** | C | S | P-10 | D-07 | Claude Code | `/builds` renders step-by-step output, retry controls, AI error diagnosis display, duration per step. | Render test. Retry button fires API. | git commit "feat(dashboard): build status view" |
+| **D-02 Part 2: Waterfall real-time updates** | C | M | F-13, F-14 | D-04 | Claude Code | Prompt waterfall connects to SSE `/events/stream` filtered by `correlationId`. Active executing nodes show pulsing indicator. Live subtask list updates. | SSE integration test: events arrive, nodes update without page reload. | git commit "feat(dashboard): waterfall real-time via SSE" |
+| **T-05: Domain heatmap integration** | B | S | T-02 | T-06 | Claude Code | File heatmap in observability dashboard now shows domain overlay — which domains are changing most frequently per sprint. | Render test with fixture data. | git commit "feat(dashboard): domain heatmap overlay" |
+| **T-06: Lock contracts system** | B | M | P-02, T-01 | T-05 | Claude Code | `lock_contracts` table: id, domain, rule, severity (block/warn), created_by. API: `GET/POST /lock-contracts`. Decomposer reads active contracts as project context. Contract violations flagged in decomposition output. | Lock contract violation detected in decomposer test prompt. API CRUD tests. | git commit "feat(lock-contracts): design rules enforcement" |
+| **A-06: Architect Agent** | D | L | A-01, A-03 | A-08 | Claude Code | Tier 1 agent: produces ADR drafts, stack decisions, component boundary analysis, dependency tree for new features. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): architect agent tier-1" |
+| **A-16: Agent-to-agent communication protocol** | D | M | A-01, F-11 | A-06 | Claude Code | Agents communicate via event bus only (no direct function calls). Protocol: `agent.handoff_requested`, `agent.handoff_completed`, `agent.blocked`. Each handoff carries: from_agent, to_agent, context_payload, correlation_id. | Round-trip handoff test: Coordinator → PO Agent → BA Agent. Events appear in timeline. | git commit "feat(agents): event-bus mediated handoff protocol" |
+
+**Sprint 6 Success Gate:** Build failures create auto-fix tasks. Waterfall view updates in real-time. Lock contracts block invalid decompositions.
+
+---
+
+### Sprint 7 — 2026-07-20 to 2026-08-02
+**Theme: GITHUB INTEGRATION — PR creation closes the execution loop**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **P-08: `@caia/pr-manager`** | A | M | F-06, F-16, P-07 | P-11 scaffolding | Claude Code | Subscribes to `build.completed`. Pushes worktree branch: `git push origin HEAD:refs/heads/task-{taskId}`. Creates GitHub PR via `@octokit/rest` with auto-generated description (story title + acceptance criteria + changed files + execution summary). Runs AI review (Sonnet reads diff → structured review JSON → posted as PR comments). Tracks PR in `pull_requests` table. Emits `pr.created`. Exponential backoff on GitHub API rate limit. | PR creation: mock `@octokit/rest`, verify PR body format. AI review: mock Sonnet, verify comments posted. Rate limit retry test. | git commit + `pnpm publish` `@caia/pr-manager` |
+| **GitHub integration configuration** | A | S | F-16, P-08 | P-08 | Human + Claude Code | `GITHUB_TOKEN` env var wired. Repository URL in projects table for test project. Settings page shows GitHub connection status (✓ Connected / ✗ Not configured). | OAuth token validation API test | git commit "feat(settings): github integration status" |
+| **A-07 hardening: Developer Agent** | D | M | A-01, P-02 | P-08 | Claude Code | Existing executor upgraded with agent-registry-registered Developer Agent manifest. System prompt: includes project context, lock contracts, acceptance criteria, enriched spec. Self-checking: after execution, verifies acceptance criteria coverage. 3 eval fixtures. | 3 eval fixtures passing. Self-check catches a deliberately incomplete implementation. | git commit "feat(agents): developer agent v2 with self-check" |
+| **A-08: Test Engineer Agent** | D | M | A-01, P-09 | A-09 | Claude Code | Tier 2 agent: writes test suites for new features based on acceptance criteria. Interprets test failures and proposes fixes. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): test engineer agent tier-2" |
+| **A-09: Code Reviewer Agent** | D | M | A-01, P-08 | A-08 | Claude Code | Tier 2 agent: reviews PRs against acceptance criteria, flags risks, generates structured review JSON. Powers `@caia/pr-manager`'s AI review step. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): code reviewer agent tier-2" |
+| **D-12: Prompt History / full-text search** | C | S | F-01 | D-07 | Claude Code | Search bar on `/prompts` does FTS on `prompts.body` + story titles. Results highlight matching text. Cursor-based pagination. | Search returns correct results for keyword. Empty query returns recent prompts. | git commit "feat(dashboard): full-text prompt search" |
+
+**Sprint 7 Success Gate:** A completed task automatically creates a GitHub PR with AI review comments. PR visible in dashboard linked to the prompt.
+
+---
+
+### Sprint 8 — 2026-08-03 to 2026-08-16
+**Theme: STAGING DEPLOYMENT — close the automated pipeline through staging**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **P-11: `@caia/deployment-manager`** | A | M | F-07, F-16, P-10 | P-12 | Claude Code | Subscribes to `pr.created`. Runs `wrangler pages deploy <artifact-path> --project-name=<name> --branch=staging`. Polls for deployment status. On live: verifies staging URL returns HTTP 200. Captures `stagingUrl`. Records in `deployments` table. Emits `deployment.completed`. Uses `DeploymentProvider` interface (supports Cloudflare Pages now, extensible to GCP/Railway). | Deployment mock: mock `wrangler` CLI, verify command construction. Health check: mock HTTP, verify 200 and non-200 cases. | git commit + `pnpm publish` `@caia/deployment-manager` |
+| **Cloudflare Pages configuration** | A | S | F-16, P-11 | P-11 | Human + Claude Code | Cloudflare API token added to test project. Wrangler installed in executor environment. Staging project created in Cloudflare dashboard (one-time manual step per target project). | Wrangler auth test | git commit "feat(deploy): cloudflare pages wrangler integration" |
+| **F-18: Turso/libSQL support** | A | S | F-01 | P-11 | Claude Code | `DATABASE_URL` env var. If starts with `libsql://`: use `@libsql/client`. Else: use `better-sqlite3`. Drizzle config switches adapter. Zero schema changes. | Turso connection test (use Turso free tier). Existing tests still pass on SQLite. | git commit "feat(db): turso/libsql support" |
+| **D-07: Deployment Status view** | C | S | P-11 | D-08 | Claude Code | `/deployments` renders table: prompt, project, environment, URL, status badge, deployed-at, PR link. Rollback button (sends revert + redeploy). "Open staging URL" link. | Render test. Rollback fires correct API. | git commit "feat(dashboard): deployment status view" |
+| **D-09: Notifications panel** | C | S | P-11 | D-08 | Claude Code | Bell icon top-right with unread count. Notifications created on: staging ready, task failure, build failure. Optional webhook config (Slack URL). | Notification created on `deployment.completed`. Webhook payload test. | git commit "feat(dashboard): notifications panel + webhook" |
+| **A-10: QA Agent** | D | M | A-01, A-08 | A-11 | Claude Code | Tier 3 agent: E2E test authoring using Playwright, regression triage. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): qa agent tier-3" |
+| **A-11: Security Agent** | D | M | A-01 | A-10 | Claude Code | Tier 3 agent: OWASP checks, secret scanning (no secrets committed), auth/authz review. Runs on every PR diff. 3 eval fixtures. | 3 eval fixtures. Secret detection catches injected dummy secret. | git commit "feat(agents): security agent tier-3" |
+
+**Sprint 8 Success Gate:** A completed build is automatically deployed to Cloudflare Pages staging. Staging URL appears in the dashboard with a notification.
+
+---
+
+### Sprint 9 — 2026-08-17 to 2026-08-30
+**Theme: HUMAN GATE + RELEASE — first fully automated prompt→production cycle**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **P-12: `@caia/acceptance-gate`** | A | M | F-08, P-11 | P-13 | Claude Code | Subscribes to `deployment.completed`. Calls Claude Sonnet to generate acceptance report (what changed, criteria provably met, criteria needing manual check). Creates notification. Waits for human decision via `POST /prompts/:id/accept` or `/reject`. On accept: emits `human.acceptance_granted`. On reject: emits `human.acceptance_rejected` → re-queues failed acceptance criteria as new stories. On `approved_with_changes`: emits grant + creates follow-up stories. | Acceptance report generation test. Accept/reject API test. Re-queue-on-reject: verify new stories created with correct parent linkage. | git commit + `pnpm publish` `@caia/acceptance-gate` |
+| **P-13: `@caia/release-manager`** | A | S | F-09, P-12 | P-14 | Claude Code | Subscribes to `human.acceptance_granted`. Merges PR via GitHub API (`octokit.pulls.merge`). Triggers production Cloudflare Pages deploy. Verifies production health (HTTP 200 on production URL). Tags release: `v<semver>-prompt-<promptId>`. Records in `releases` table. Emits `release.completed`. | Merge mock: verify merge commit captured. Release tag format test. Production health check test. | git commit + `pnpm publish` `@caia/release-manager` |
+| **P-14: `@caia/observability-closeout`** | A | S | P-13 | P-12 | Claude Code | Subscribes to `release.completed`. Computes: totalDurationMs, totalCostUsd (sum of `executor_runs.cost_usd`), totalTokens, filesChanged, storiesDelivered, stagesCompleted. Writes to `prompt_pipeline_stages` (all stages closed). Emits `prompt.completed`. | Closeout computes correct totals against fixture data. `prompt.completed` event emitted. | git commit + `pnpm publish` `@caia/observability-closeout` |
+| **D-08: Human Acceptance Review view** | C | M | P-12 | P-13 | Claude Code | `/prompts/[id]/review` renders: staging URL with iframe preview (configurable), PR diff summary, acceptance criteria checklist (provably met / manual check / failed), AI acceptance report, test results summary, build status, cost incurred. Approve / Reject with feedback / Approve with changes buttons. | Render test. Approve fires `POST /prompts/:id/accept`. Reject opens feedback textarea and fires `/reject`. | git commit "feat(dashboard): human acceptance review view" |
+| **🎯 MILESTONE: First fully automated prompt→production run** | A | — | P-12, P-13, P-14, D-08 | — | Human | Submit a real (non-trivial) prompt. Observe: clarification → decomposition → enrichment → dag → tasks → execution → test → build → PR → staging → human approval → production. Total time < 2 hours. Zero manual steps except the approve button. | End-to-end integration test (CI-safe mock for deploy/PR steps) | Document the run in a MILESTONE-2026-08.md report |
+| **A-13: Deploy Agent** | D | M | A-01, P-11 | A-14 | Claude Code | Tier 4 agent: orchestrates deployment-manager, verifies deployment health, escalates on timeout. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): deploy agent tier-4" |
+| **A-14: Monitor Agent** | D | M | A-01 | A-13 | Claude Code | Tier 4 agent: watches pulse runs, escalates anomalies to notifications, proposes auto-heal actions. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): monitor agent tier-4" |
+
+**Sprint 9 Success Gate: 🏆 MVP. A human submits a prompt and a feature is live in production with zero manual intervention except the approve button. This is the platform's north star.**
+
+---
+
+### Sprint 10 — 2026-08-31 to 2026-09-13
+**Theme: DASHBOARD COMPLETION + POLISH**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **D-11: Observability dashboard — cost by model** | C | S | P-14 | D-13 | Claude Code | Cost breakdown chart: Haiku/Sonnet/Opus/Local per day. 30-day cost trend line. Monthly projection (linear extrapolation). | Render test with fixture cost data. | git commit "feat(dashboard): cost breakdown by model" |
+| **D-13: Mobile-responsive layout** | C | S | D-02, D-08 | D-14 | Claude Code | Waterfall view + acceptance view render correctly on 375px viewport. No horizontal scroll. Accordion tree collapses to compact mode on mobile. | Playwright mobile viewport test. | git commit "feat(dashboard): mobile responsive layout" |
+| **D-14: Keyboard shortcuts** | C | XS | D-01, D-08 | D-13 | Claude Code | `Cmd+Enter` submits prompt. `J/K` navigates stories in waterfall. `A` approves, `R` rejects (on review view). Shortcuts shown in tooltips. | Keyboard interaction test. | git commit "feat(dashboard): keyboard shortcuts" |
+| **P-17: BullMQ mode** | E | M | F-01 | P-18 | Claude Code | `EXECUTOR_QUEUE=bullmq` enables BullMQ worker. Upstash Redis connection via `REDIS_URL`. Jobs have priority, TTL, retry backoff. Polling mode retained as default. | BullMQ mode integration test: enqueue + process + complete job. | git commit "feat(executor): bullmq queue mode" |
+| **P-18: NATS inter-process event transport** | E | M | F-01 | P-17 | Claude Code | `EventTransport` abstraction added to `@caia/event-bus`. `NatsEventTransport` implementation: publishes to NATS JetStream, subscribes via NATS consumer. In-process `EventEmitter` retained as default. | NATS transport round-trip test. Existing in-process tests still pass. | git commit + version bump `@caia/event-bus` |
+| **A-17: Agent evaluation harness** | D | M | A-01, all agents | A-15 | Claude Code | `packages/agent-eval/` package: runs each registered agent against its 3 eval fixtures, validates output conforms to schema, reports pass/fail. CI step: `pnpm agent:eval` runs harness. | All 15 agents pass their 3 eval fixtures. | git commit + `pnpm publish` `@caia/agent-eval` |
+| **A-12: Performance Agent** | D | L | A-01 | A-15 | Claude Code | Tier 3 agent: load test design, bottleneck identification, query performance analysis. 3 eval fixtures. | 3 eval fixtures | git commit "feat(agents): performance agent tier-3" |
+
+---
+
+### Sprint 11 — 2026-09-14 to 2026-09-27
+**Theme: LOCAL LLM + AGENT TEAM COMPLETION**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **P-15: `@caia/local-llm-router`** | E | L | F-10, P-02, P-03 | P-16 | Claude Code | Routing policy: budget-based, complexity-based, domain-exclusion-based. Config via Settings page. Routes to Ollama `http://localhost:11434/v1`. Records `routing_decision` + `local_model` in `executor_runs`. Falls back to Claude if local is unavailable. | Routing policy tests: budget-exceeded → local, security domain → Claude always, complexity < 0.4 → local. | git commit + `pnpm publish` `@caia/local-llm-router` |
+| **P-16: Ollama tool execution loop** | E | L | P-15 | A-15 | Claude Code | When `routing_decision = 'local'`: invokes Ollama OpenAI-compatible API. Implements tool execution loop: send prompt → parse tool calls → execute tools (bash, file read/write) → send results → loop until `[result]` marker. Tested on `qwen2.5-coder:7b`. | Tool loop test: verify bash execution works, file write works, result marker terminates loop. Quality check: qwen2.5 solves a sample boilerplate task. | git commit "feat(executor): ollama tool execution loop" |
+| **A-15: Meta/Coach Agent** | D | L | A-01, A-17 | P-16 | Claude Code | Tier 5 agent: analyzes eval scores + token usage + task success rates. Proposes system prompt improvements for underperforming agents. Runs weekly as a scheduled task. 3 eval fixtures. | Coach agent produces improvement suggestions for a deliberately degraded agent prompt. | git commit "feat(agents): meta coach agent tier-5" |
+| **A-16 hardening: Communication protocol v2** | D | S | A-16 v1 | A-15 | Claude Code | Add `agent.error` + `agent.retry_requested` events. Coordinator handles retry routing. Circuit breaker: if agent fails 3× on same input, escalate to human. | Retry loop test. Circuit breaker fires after 3 failures. | git commit "feat(agents): handoff protocol v2 with circuit breaker" |
+| **Cost dashboard + 40% reduction target** | E | S | P-14, P-15 | P-16 | Human + Claude Code | Settings page shows current month cost, projected month cost, savings from local LLM routing (actual vs if-all-Claude). Alert threshold configurable. | Savings calculation test. | git commit "feat(dashboard): llm cost savings tracker" |
+
+---
+
+### Sprint 12 — 2026-09-28 to 2026-10-11
+**Theme: OPEN SOURCE EXTRACTION + FINAL POLISH**
+
+| Work Item | Track | Effort | Dependencies | Parallel With | Owner | Definition of Done | Tests Required | Commit/Publish |
+|-----------|-------|--------|-------------|---------------|-------|-------------------|----------------|----------------|
+| **O-02: Extract `@caia/task-dag`** | E | S | P-04 stable | O-03 | Claude Code | `packages/task-dag/` — zero CAIA dependencies. Generic TypeScript DAG: `build`, `validate`, `topologicalSort`, `criticalPath`. Public API via JSDoc. README with standalone example. | All DAG tests pass with no CAIA imports. | `pnpm publish` `@caia/task-dag` standalone |
+| **O-03: Extract `@caia/claude-executor`** | E | M | P-07, full exec stable | O-04 | Claude Code | Injectable hooks: `onTaskComplete`, `promptBuilder`, `onOutputLine`. No CAIA API calls in core. README + standalone example (50-line demo). | Standalone example runs with no monorepo dependencies. | `pnpm publish` `@caia/claude-executor` standalone |
+| **O-04: Extract `@caia/pipeline-pulse`** | E | S | Stable in prod | O-06 | Claude Code | Injectable check implementations. Standalone: `createPulse({ checks: [...], canary: () => ... })`. | Standalone example runs. | `pnpm publish` `@caia/pipeline-pulse` standalone |
+| **O-06: `@caia/requirement-decomposer` extraction begins** | E | L | P-02 stable in prod | O-02..O-04 | Claude Code | Parameterize hierarchy schema (Initiative/Epic/Module/Story ← generic level names). Separate CAIA-specific context from core decomposer logic. README drafted. | Core decomposer tests pass with generic schema. Apache 2.0 LICENSE. | git commit "feat(oss): requirement-decomposer extraction" (publish in Sprint 13 if needed) |
+| **Platform documentation** | E | M | All above | O-06 | Claude Code | `docs/` directory: Getting Started, Architecture Overview, Utility Catalogue, API Reference, Agent Team Reference, Plugin Development Guide. | Docs build via `pnpm docs:build`. All links resolve. | git commit "docs: platform documentation v1" |
+| **Final end-to-end performance audit** | E | S | All above | O-06 | Human + Claude Code | Run 3 prompts end-to-end. Measure: wall-clock from submit to production. Target: < 2 hours. Cost per prompt: measure actual vs target. Token usage by phase. | Benchmark results saved to `reports/performance-baseline.md` | git commit "docs: performance baseline report" |
+
+---
+
+## Part 5: Test-Fix-Commit Protocol
+
+Every implementation task in this plan follows this exact protocol — no exceptions.
+
+### Standard Protocol (every task)
+
+```
+1. IMPLEMENT
+   Write the code. Follow ADRs strictly:
+   - Living Library: if reusable logic appears, extract to package FIRST
+   - Code Purity: apps contain ONLY custom business logic
+   - Event-First: every state change emits an event
+   - Agent-First: AI logic lives in agents, not route handlers
+
+2. TYPECHECK
+   pnpm typecheck
+   → Fix ALL errors before proceeding. Zero tolerance.
+   → If error is in a dependency, fix the dependency, bump its version, update imports.
+
+3. TEST
+   pnpm test (run relevant test file(s) first, then full suite)
+   → Fix ALL failures. Do not skip or comment out failing tests.
+   → If a test is wrong (testing the wrong thing), fix the test AND verify the fix is sound.
+
+4. COMMIT
+   git add -A
+   git commit -m "<scope>(<package>): <imperative description>"
+   Examples:
+     feat(decomposer): add phase 2 parallel story generation
+     fix(executor): handle SIGTERM during active worktree
+     chore(db): migration 0018 pull_requests table
+
+5. PUSH
+   git push origin <branch>
+
+6. IF NEW PACKAGE:
+   a. Update package.json version (semver)
+   b. pnpm changeset (describe the change)
+   c. pnpm publish --access public
+   d. Verify package appears on npm: npm info @caia/<name>
+
+7. IF PR:
+   a. Open PR against main
+   b. Wait for ALL CI checks to pass (Build ✓, Test ✓, Lint ✓, Typecheck ✓)
+   c. Do not merge with failing checks. Fix first.
+   d. If CI fails on something unrelated to your change: fix it anyway (T-F-C applies to CI too)
+
+8. UPDATE DOCS
+   If observable behavior changed:
+   - Update CLAUDE.md if Claude Code agents need to know about it
+   - Update relevant API documentation
+   - Update any architecture docs that reference the changed component
+```
+
+### Definition of Done: By Category
+
+**New utility package (`@caia/*`):**
+- `pnpm typecheck` passes with zero errors
+- Unit test coverage ≥ 80% on the package
+- Published to npm (`npm info @caia/<name>` returns correct version)
+- README.md with: purpose, installation, basic usage example, event contracts
+- Registered in `CLAUDE.md` package catalogue
+
+**New agent:**
+- System prompt committed in `packages/agent-registry/agents/<name>/system-prompt.md`
+- 3 eval fixtures in `packages/agent-registry/agents/<name>/evals/` (input.json + expected-output.json)
+- `pnpm agent:eval --agent=<name>` passes all 3 fixtures
+- Output schema validated (JSON Schema or Zod)
+- Agent registered in agent-registry table with correct tier
+
+**New dashboard page/route:**
+- Renders without errors in both empty state and populated state
+- Handles API error state (shows error message, not blank/crashed)
+- Added to sidebar navigation
+- Keyboard navigation works (Tab through interactive elements)
+- Render test passing in `dashboard/__tests__/`
+
+**New API endpoint:**
+- Returns correct JSON shape for success case
+- Returns correct HTTP status codes for error cases (400, 404, 500)
+- TypeScript request/response types defined and exported
+- Added to API documentation
+- Integration test covering success + at least one error case
+
+**Database migration:**
+- Migration file committed in `src/db/migrations/`
+- `pnpm drizzle-kit push` runs cleanly on empty DB
+- Backfill script run if existing rows need updating
+- `pnpm drizzle-kit generate` produces no unexpected changes after push
+- Migration is reversible (down migration documented in comments)
+
+---
+
+## Part 6: Risk Register
+
+| # | Risk | Probability | Impact | Mitigation |
+|---|------|-------------|--------|------------|
+| R-01 | **PR #43 CI fix takes > 3 days** — monorepo structure issues are deeper than expected | Medium | Critical | Time-box to 2 days. If stuck: revert to last green commit, cherry-pick known-good changes incrementally. Do not let this drag beyond day 3. |
+| R-02 | **@caia/decomposer output quality insufficient** — structured JSON output has hallucinations, missing fields, or incoherent story trees | High | Critical | Mitigate with: (1) JSON Schema enforcement via Anthropic structured output API, (2) Zod validation post-response with re-try on failure (max 2 retries), (3) eval suite of 10 prompts scored before Sprint 3 exits, (4) human "looks right?" gate before first real execution run. Accept that Sprint 3 may extend by 3 days if quality is insufficient. |
+| R-03 | **Agent-to-agent communication latency/reliability** — multi-agent handoffs introduce cascading delays or dropped events | Medium | High | All agent communication is event-bus-mediated (not real-time RPC). Events are persisted — no message loss. Circuit breaker pattern (3 failures → escalate to human) prevents infinite retry loops. Start with synchronous chains before enabling parallel handoffs. |
+| R-04 | **Token costs exceed budget before platform is self-sustaining** | Medium | High | (1) Local LLM routing for low-complexity tasks (Sprint 11) targets 40-60% cost reduction, (2) Per-prompt cost tracking from Sprint 9 milestone gives budget visibility, (3) Hard monthly limit in `@caia/local-llm-router` policy forces fallback to local above threshold, (4) Decomposer caching: identical prompt hashes (10s window) skip re-decomposition. |
+| R-05 | **Local LLM quality insufficient for delegated tasks** | High | Medium | (1) Quality feedback loop: record `resultOk` per local task; auto-escalate to Claude if local success rate < 70% on a task type, (2) Never route security/architecture/complex-refactor tasks to local (domain exclusion list), (3) Roll out local LLM to boilerplate-only tasks first (migration files, barrel exports), (4) Monitor completeness sentinel findings on local vs Claude tasks. |
+| R-06 | **GitHub API rate limits block high-throughput PR creation** | Low | Medium | Implement exponential backoff in `@caia/pr-manager`. Use GitHub App authentication (higher rate limit: 5,000/hour vs 60/hour for PAT). Batch PR operations where possible. |
+| R-07 | **Cloudflare Pages wrangler deploy fails silently** | Low | Medium | Add timeout (5 min) + retry (2×) in deployment-manager. Verify deployment via health check, not just wrangler exit code. Pulse check includes a synthetic staging deployment. |
+| R-08 | **Monorepo CI becomes slow as packages accumulate** | Medium | Medium | (1) Turborepo remote cache enabled from Sprint 2, (2) Affected-only builds in CI (`turbo run build --filter=...[HEAD^1]`), (3) Max CI time threshold: if any job exceeds 10 min, investigate and fix before next sprint. |
+| R-09 | **Story→Task bridge creates incorrect dependency chains** — circular or missing deps cause tasks to never be scheduled | Medium | High | (1) Cycle detection in `@caia/dag-analyzer` with explicit `pipeline.dag_error` halt, (2) Integration test verifies dependency chains on 3 known prompt shapes before Sprint 4 exits, (3) Dashboard DAG view (`DagView` component) shows the computed graph for human verification before first execution. |
+| R-10 | **Database SQLite write contention under multiple concurrent agents** | Medium | Low (single user) / High (multi-user) | (1) Single-user mode: SQLite WAL mode, acceptable, (2) Multi-user: migrate to Turso (Sprint 8, F-18), (3) BullMQ queue (Sprint 10, P-17) moves task dispatching off SQLite hot path. |
+| R-11 | **Decomposer LLM cost spike** — a single complex prompt spawns 50+ stories × enrichment calls | Medium | Medium | Hard cap: `maxStoryCount: 50` in decomposer config (configurable). If exceeded: decompose to Module level only, require human confirmation before Phase 2. Cost estimate shown in Prompt Submission view before submit. |
+| R-12 | **The two missing architecture reports** — `caia-domain-taxonomy-and-dedup-architecture.md` and `caia-agent-team-architecture.md` were not found in the reports directory | High | Medium | This plan incorporates the available information from the one existing report + the prompt context. Before Sprint 4 begins: write the missing two reports (or confirm the information in this plan is correct) to ensure Track B (domain taxonomy, 9-week plan) and Track D (25 agents, 6 tiers) are accurately spec'd. |
+
+---
+
+## Part 7: Success Metrics
+
+### Phase 1 Complete (end of Sprint 2) when:
+- PR #43 merged, CI green on main
+- `pnpm build` passes from monorepo root with zero errors
+- All 6 migrations (0017–0022) applied cleanly
+- `@caia/events-taxonomy` published with 14 new event types
+- Executor streams output in real-time (SSE endpoint live)
+- Test coverage ≥ 80% on event-bus, events-taxonomy, prioritization packages
+- `@caia/agent-registry` published and accepting agent manifests
+
+### Phase 2 Complete (end of Sprint 4) when:
+- A prompt submitted to `POST /prompts` triggers the full clarification → decomposition → enrichment → DAG → task-queue pipeline automatically
+- Decomposer eval suite: 10 prompts, all produce valid trees (no crashes, all stories have required fields)
+- DAG analyzer detects cycles in injected test case
+- Task queue is populated and executor picks up tasks
+- Prompt Waterfall dashboard shows full accordion tree
+
+### Phase 3 Complete (end of Sprint 6) when:
+- Task execution automatically triggers test runner
+- Test failures create blocker entries visible in dashboard
+- Build verification runs automatically after tests pass
+- Build failures spawn auto-fix tasks via Claude Sonnet
+- Live Execution view streams output in real-time
+- Lock contracts block invalid decompositions
+
+### Phase 4 Complete (end of Sprint 8) when:
+- A completed, verified build automatically creates a GitHub PR with AI review comments
+- The PR automatically triggers a Cloudflare Pages staging deployment
+- Staging URL appears in the dashboard with a notification
+- Deployment Status view operational
+
+### Platform MVP Complete (end of Sprint 9) when:
+- **Human submits prompt → working feature deployed to staging in < 2 hours with zero manual intervention** (except the approve button and one-time project setup)
+- 5 required human gates function correctly: (1) clarification questions, (2) decomposition confirmation for large trees, (3) DAG review, (4) human acceptance review, (5) approve/reject
+- `prompt.completed` event emitted with accurate cost/duration/files metrics
+- End-to-end run successfully documented with real prompt
+
+### Phase 5 Complete (end of Sprint 10) when:
+- All 14 dashboard views implemented and passing render tests
+- Mobile layout works on 375px viewport
+- Cost breakdown dashboard shows Haiku/Sonnet/Opus split
+- Notification panel delivers in-app alerts on staging ready
+
+### Phase 6 Complete (end of Sprint 11) when:
+- `@caia/local-llm-router` routes boilerplate tasks to Ollama `qwen2.5-coder:7b`
+- Local task success rate ≥ 70% on boilerplate task type
+- Cost dashboard shows ≥ 30% cost reduction from local routing (measured over 20 prompts)
+- All 15+ agents registered, evaluated, and passing eval harness
+
+### Phase 7 / Open Source Ready (end of Sprint 12) when:
+- `@caia/task-dag`, `@caia/claude-executor`, `@caia/pipeline-pulse` published as standalone packages
+- Each has a README with standalone example that runs without CAIA monorepo
+- `@caia/requirement-decomposer` extraction in progress
+- Platform documentation complete (`docs/`)
+- Performance baseline: average prompt-to-production time measured and documented
+
+---
+
+## Appendix: ASCII Gantt Chart
+
+```
+CAIA Platform Build — 24-Week Overview
+Week:  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+       |  |  |  |  |  |  |  |  |  |   |  |  |  |  |  |  |  |  |  |  |  |  |  |
+Sprint:   S1          S2          S3          S4          S5          S6
+       |-----|  |-----|  |-----|  |-----|  |-----|  |-----|
+       Apr27-May10  May11-May24  ...         ...          Sep28-Oct11
+
+TRACK A — CRITICAL PATH
+PR #43 Fix        [==]
+Foundation        [====]
+Decomposer             [=====]
+Enricher+DAG                [=====]
+Bridge+Sched                     [=]
+Test+Build Runner                    [======]
+PR Manager                                 [===]
+Deploy Manager                                 [====]
+Accept+Release                                     [====]
+Observability                                          [=]
+🏆 MVP                                                  ^
+
+TRACK B — DOMAIN TAXONOMY (9 weeks)
+Taxonomy Baseline    [=]
+Domain Classifier        [====]
+Dedup Engine                  [====]
+Lock Contracts                    [====]
+Dedup Dashboard                        [==]
+                   Wk2                          Wk11
+
+TRACK C — DASHBOARD (continuous)
+Prompt Submit+Task [==]
+Settings+Search        [==]
+Waterfall P1                [===]
+Live Execution                   [==]
+Tests+Builds                          [==]
+Deploy+Notifs                              [==]
+Acceptance View                                [==]
+Polish+Mobile                                      [====]
+
+TRACK D — AGENT TEAM (starts Wk2)
+Registry+Scaffolder  [===]
+Coordinator               [=]
+PO+BA+Architect               [=====]
+Dev+Test+Review Agents              [======]
+QA+Security+Perf                          [======]
+Deploy+Monitor                                 [===]
+Meta Coach                                          [===]
+Eval Harness                                     [===]
+
+TRACK E — INFRA + LOCAL LLM + OSS (starts Wk18)
+BullMQ+NATS                                       [===]
+Local LLM Router                                       [===]
+Ollama Tool Loop                                           [===]
+OSS Extraction                                                 [====]
+Docs+Polish                                                        [=]
+
+LEGEND: [=] = 1 sprint of work  ^ = milestone
+```
+
+```
+Detailed Sprint Map:
+┌────────────────────────────────────────────────────────────────────────────┐
+│ SPRINT 1  Apr27-May10  FIX CI / FOUNDATIONS                                │
+│  ▶ F-01 PR #43 FIX (🚨 BLOCKER)   ▶ F-02 Disable connectors               │
+│  ▶ F-03 Monorepo verify            ▶ F-04..F-10 Migrations 0017-0022       │
+│  ▶ F-11 Events taxonomy ext        ▶ D-01 Prompt Submit  ▶ D-03 Task Detail│
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 2  May11-May24  FOUNDATIONS COMPLETE                                │
+│  ▶ F-12 Executor streaming         ▶ F-13 SSE task stream                  │
+│  ▶ F-14 SSE event stream           ▶ F-15 Coverage gate 80%               │
+│  ▶ F-16/17 Project credentials     ▶ P-07 Worktree manager extract         │
+│  ▶ T-01 Domain taxonomy            ▶ D-10 Settings page  ▶ A-01 Registry   │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 3  May25-Jun07  🔑 THE DECOMPOSER                                   │
+│  ▶ P-02 @caia/decomposer Phase 1+2 (FULL SPRINT FOCUS)                     │
+│  ▶ T-02 Domain classifier          ▶ A-02 Agent scaffolder                  │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 4  Jun08-Jun21  ENRICHMENT + DAG + PIPELINE WIRED                  │
+│  ▶ P-03 @caia/enricher             ▶ P-04 @caia/dag-analyzer               │
+│  ▶ P-05/P-06 Story-Task bridge     ▶ P-01 @caia/clarifier                  │
+│  ▶ T-03 Dedup engine               ▶ D-02 Waterfall P1   ▶ A-03 Coordinator│
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 5  Jun22-Jul05  EXECUTION LOOP CLOSED                               │
+│  ▶ E2E integration test            ▶ P-09 @caia/test-runner                │
+│  ▶ P-10 @caia/build-verifier       ▶ D-04 Live Execution                   │
+│  ▶ D-05 Test Results               ▶ T-04 Dedup dashboard                  │
+│  ▶ A-04 PO Agent                   ▶ A-05 BA Agent                         │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 6  Jul06-Jul19  QUALITY GATES + HARDENING                           │
+│  ▶ Build verifier integration      ▶ D-06 Build Status                     │
+│  ▶ D-02 Waterfall real-time        ▶ T-05 Domain heatmap                   │
+│  ▶ T-06 Lock contracts             ▶ A-06 Architect Agent                  │
+│  ▶ A-16 Handoff protocol           │                                        │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 7  Jul20-Aug02  GITHUB INTEGRATION                                  │
+│  ▶ P-08 @caia/pr-manager           ▶ GitHub config                          │
+│  ▶ A-07 Developer Agent v2         ▶ A-08 Test Engineer Agent               │
+│  ▶ A-09 Code Reviewer Agent        ▶ D-12 Prompt search                    │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 8  Aug03-Aug16  STAGING DEPLOYMENT                                  │
+│  ▶ P-11 @caia/deployment-manager   ▶ Cloudflare config                     │
+│  ▶ F-18 Turso/libSQL               ▶ D-07 Deployment view                  │
+│  ▶ D-09 Notifications              ▶ A-10 QA Agent  ▶ A-11 Security Agent  │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 9  Aug17-Aug30  🏆 MVP — HUMAN GATE + PRODUCTION RELEASE            │
+│  ▶ P-12 @caia/acceptance-gate      ▶ P-13 @caia/release-manager            │
+│  ▶ P-14 @caia/observability-closeout ▶ D-08 Acceptance Review              │
+│  ▶ 🎯 FIRST AUTOMATED PROMPT→PRODUCTION RUN                                │
+│  ▶ A-13 Deploy Agent               ▶ A-14 Monitor Agent                    │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 10  Aug31-Sep13  DASHBOARD + INFRA                                  │
+│  ▶ D-11 Cost dashboard             ▶ D-13 Mobile layout                    │
+│  ▶ D-14 Keyboard shortcuts         ▶ P-17 BullMQ mode                      │
+│  ▶ P-18 NATS transport             ▶ A-17 Eval harness  ▶ A-12 Perf Agent  │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 11  Sep14-Sep27  LOCAL LLM + AGENT COMPLETION                       │
+│  ▶ P-15 @caia/local-llm-router     ▶ P-16 Ollama tool loop                 │
+│  ▶ A-15 Meta Coach Agent           ▶ A-16 Handoff protocol v2              │
+│  ▶ Cost savings dashboard          │                                        │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SPRINT 12  Sep28-Oct11  OPEN SOURCE + DOCS + POLISH                        │
+│  ▶ O-02 @caia/task-dag             ▶ O-03 @caia/claude-executor             │
+│  ▶ O-04 @caia/pipeline-pulse       ▶ O-06 decomposer extraction begins     │
+│  ▶ Platform docs                   ▶ Performance baseline audit             │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Quick Reference: What's Next (Priority Order)
+
+Given today is 2026-04-27, here is the exact priority order for the next 5 working days:
+
+1. **TODAY:** Open PR #43. Read the failing CI check logs. Fix typecheck/lint/test errors. Push. Watch CI. If green: merge.
+2. **TODAY (5 min):** Disable Kapture, Chrome Control, Notes, osascript in Cowork Settings.
+3. **After PR #43 merges:** Run `pnpm build` from monorepo root. Fix any residual import errors.
+4. **Day 2-3:** Apply migrations F-04 through F-10. Extend events-taxonomy (F-11). Publish `@caia/events-taxonomy`.
+5. **Day 3-5:** Begin F-12 (executor streaming) and D-01 (prompt submission view) in parallel.
+
+**The decomposer (P-02) is the single most impactful item on the entire roadmap.** Every sprint before it is clearing the runway. Everything after it builds the landing gear.
+
+---
+
+*This plan was generated 2026-04-27. Dates are fixed to today's date and should be updated if Sprint 1 start is delayed. The critical path assumes PR #43 is fixed within Sprint 1 (by May 10 at latest). A delay beyond May 10 shifts every subsequent sprint date by the same amount.*

--- a/docs/legacy-conductor-reports/caia-platform-architecture-proposal.md
+++ b/docs/legacy-conductor-reports/caia-platform-architecture-proposal.md
@@ -1,0 +1,1848 @@
+# CAIA Platform: Comprehensive Architecture Proposal
+
+**Document Status:** Draft v1.0  
+**Author:** Synthesized from codebase audit + platform vision  
+**Date:** April 27, 2026  
+**Repository:** `github.com/prakashgbid/caia`  
+**Predecessor:** `github.com/prakashgbid/conductor` (archived 2026-04-25, consolidated into CAIA monorepo)
+
+---
+
+## Executive Summary
+
+CAIA (Chief AI Agent) is an opinionated, AI-native software factory: a platform that accepts a natural-language requirement and produces a running, deployed, tested feature with minimal human involvement. This document provides the canonical architecture reference for the full platform — from terminology definitions through implementation phases — grounded in an audit of the existing `conductor` codebase that has been consolidated into the CAIA monorepo.
+
+The platform is meaningfully more built than most "AI coding agent" projects: a real event bus with SQLite persistence exists, a working executor that spawns `claude --print` in git worktrees exists, a priority scoring engine exists, health-check infrastructure (pipeline-pulse) exists, and a Next.js dashboard with ~20 route pages exists. The gaps are specific and closeable: a true multi-level AI decomposer, a PR/merge pipeline, deployment integration, a human acceptance gate, and local LLM routing are the primary missing pieces.
+
+The recommendation is to treat the existing codebase as a solid foundation, not a rewrite candidate. The architecture described here extends and formalises what exists.
+
+---
+
+## Table of Contents
+
+1. [Vision Clarification & Terminology](#section-1-vision-clarification--terminology)
+2. [Current State Audit](#section-2-current-state-audit)
+3. [Full Pipeline Architecture](#section-3-full-pipeline-architecture)
+4. [Utility Catalogue](#section-4-utility-catalogue)
+5. [Dashboard Specification](#section-5-dashboard-specification)
+6. [Technology Stack Decisions](#section-6-technology-stack-decisions)
+7. [Local LLM Strategy](#section-7-local-llm-strategy)
+8. [Gap Analysis — Vision vs Current State](#section-8-gap-analysis--vision-vs-current-state)
+9. [Implementation Phases](#section-9-implementation-phases)
+10. [Open Source Strategy](#section-10-open-source-strategy)
+
+---
+
+## Section 1: Vision Clarification & Terminology
+
+### 1.1 The Canonical Hierarchy
+
+CAIA decomposes human intent into a strict six-level hierarchy. Each level has a precise definition, scope, and decomposition trigger. Every node in this hierarchy is stored in the `stories` table with a `kind` discriminant; the schema already supports this model.
+
+#### Level 0 — Prompt (root)
+
+A **Prompt** is the raw user input that initiates a pipeline run. It is a natural-language description of an intent, not yet structured. Prompts are stored in the `prompts` table and given a `correlation_id` that flows through every downstream entity for full lineage tracing.
+
+- **Scope:** one user submission
+- **Examples:** "Add a dark mode toggle to the settings page", "Build a Stripe billing integration with seat-based pricing"
+- **Lifecycle:** `received → analyzing → decomposed → answered | failed`
+- **Decomposition trigger:** successful ingestion + optional clarification round-trip
+
+#### Level 1 — Initiative
+
+An **Initiative** is the highest-level strategic grouping of work. It maps to a product milestone or capability area. A single Prompt typically produces one Initiative; a complex Prompt may produce multiple if it spans unrelated domains.
+
+- **Scope:** weeks to months of work; multiple teams in a human organization
+- **Decomposition criteria:** the requirement is too large to estimate or execute as a single unit; it has multiple independent value-delivery moments
+- **Examples:** "Billing & Subscription System", "Authentication & User Management", "Real-time Collaboration Features"
+- **Max size heuristic:** more than 5 Epics
+
+#### Level 2 — Epic
+
+An **Epic** is a coherent slice of an Initiative that delivers a discrete, user-visible or system-observable capability. It must be independently deployable to staging for human review.
+
+- **Scope:** days to 1–2 weeks of AI execution
+- **Decomposition criteria:** the Epic has more than 3 Modules, or its acceptance criteria span more than one deployment target
+- **Examples:** "Stripe Customer Portal Integration", "JWT Authentication Middleware", "WebSocket Presence System"
+- **Max size heuristic:** 3–6 Modules; if more, split the Epic
+
+#### Level 3 — Module
+
+A **Module** is a self-contained functional block within an Epic — typically one backend service, one frontend feature section, or one infrastructure component. A Module maps to a named domain in the `domains` table.
+
+- **Scope:** hours to 1 day of AI execution
+- **Decomposition criteria:** the Module's implementation touches more than 2 distinct layers (e.g. DB + API + UI) or more than ~10 files
+- **Examples:** "Stripe Webhook Handler", "Subscription Status UI Component", "Billing Database Schema"
+- **Max size heuristic:** 3–8 Stories
+
+#### Level 4 — Story
+
+A **Story** is an atomic, implementable unit of work that can be assigned to a single AI coding agent session. It has explicit acceptance criteria and a verification plan. This is the primary unit that the executor dispatches.
+
+- **Scope:** 20 minutes to 2 hours of AI execution; typically 1–8 files changed
+- **Decomposition criteria:** if a Story requires more than 8 file changes, or more than 2 tool capability types (e.g. both DB schema change and E2E test writing), it should be split
+- **Examples:** "Create `webhook_events` table migration", "Implement `POST /webhooks/stripe` route with signature verification", "Add SubscriptionBadge component to Profile page"
+- **Must have:** at least 1 verifiable acceptance criterion, at least 1 verification plan step
+
+#### Level 5 — Task
+
+A **Task** is an implementation step within a Story, typically corresponding to one git commit's worth of work. Tasks are auto-generated by the executing agent during Story execution and tracked via the `task_subtasks` table.
+
+- **Scope:** 5–30 minutes; typically 1–3 files
+- **Examples:** "Create migration file `0042_stripe_events.sql`", "Write unit tests for signature verification", "Add `useSubscription` hook"
+- **Note:** Tasks are usually generated autonomously by the agent, not pre-planned by the decomposer
+
+#### Level 6 — Subtask
+
+A **Subtask** is a granular action within a Task — a single tool call cluster or one discrete operation. Subtasks are ephemeral: they live in the `task_subtasks` table during execution but are not persisted as independent entities after completion. They are used for real-time execution visibility.
+
+- **Scope:** seconds to minutes; one logical action
+- **Examples:** "Run `npx drizzle-kit generate`", "Write function `verifyStripeSignature`", "Run `vitest run src/webhooks`"
+
+---
+
+### 1.2 Hierarchy Decomposition Criteria Summary
+
+| Level | Created By | Typical Duration | Files Touched | Human-Visible Result |
+|-------|-----------|-----------------|---------------|---------------------|
+| Prompt | Human | N/A | N/A | Submission |
+| Initiative | AI Decomposer | Weeks | Hundreds | Product milestone |
+| Epic | AI Decomposer | Days | 30–100 | Deployable feature |
+| Module | AI Decomposer | Hours | 10–30 | Domain subsystem |
+| Story | AI Decomposer | 20min–2h | 1–8 | Verifiable change |
+| Task | Executing Agent | 5–30min | 1–3 | Git commit |
+| Subtask | Executing Agent | Seconds | 1 | Tool call |
+
+---
+
+### 1.3 Pipeline Stage Definitions
+
+A **pipeline stage** is a named, observable state that a Prompt passes through from submission to production release. Each stage has explicit entry/exit criteria, emits events, and is tracked in the `prompt_pipeline_stages` table.
+
+| Stage | Entry Criteria | Exit Criteria |
+|-------|---------------|--------------|
+| `ingested` | POST /prompts received | Prompt written to DB, `prompt.ingested` event emitted |
+| `clarifying` | Ambiguity detected by AI | All clarification questions answered by user |
+| `decomposing` | Clarification complete (or skipped) | Full hierarchy tree written to `stories` table |
+| `enriching` | Decomposition complete | All Stories have acceptance criteria + verification plans |
+| `scheduling` | Enrichment complete | DAG computed, all Stories assigned buckets + ordinals |
+| `executing` | At least one Story is queued | All Stories in terminal state |
+| `pr_open` | First Story completed | PR created against main branch |
+| `testing` | PR created | All tests passing in CI |
+| `build_verified` | Tests pass | Local/CI build exits 0 |
+| `staging_deployed` | Build verified | Feature visible at staging URL |
+| `human_review` | Staging deployed | Human approves or rejects |
+| `released` | Human approves | Merged to main, production deployed |
+| `closed` | Production deployed | All events closed, metrics captured |
+
+---
+
+### 1.4 The Utility / Module / Plugin Model
+
+**Utility:** A single-responsibility process or library with a defined input type, output type, and event contract. A utility has no knowledge of other utilities. It reads from and writes to the event bus, the API, or both. Examples: `@caia/decomposer`, `@caia/scheduler`, `@caia/executor`.
+
+**Module (platform sense, not hierarchy sense):** A combination of two or more utilities that together implement a pipeline stage. A Module has its own configuration surface and lifecycle (start, stop, health). Example: The "Execution Module" combines the Scheduler, the Executor, the Worktree Manager, and the Circuit Breaker.
+
+**Plugin:** A distributable bundle of one or more utilities + configuration that extends CAIA for a specific domain. Plugins are installed via the Claude Code / Cowork plugin registry. Example: `caia-plugin-cloudflare` adds the Cloudflare deployment utility and a dashboard panel. Plugins declare their event subscriptions and API routes in a manifest.
+
+---
+
+## Section 2: Current State Audit
+
+### 2.1 What Exists (Confirmed by Codebase Inspection)
+
+The following components were verified by reading source files in `~/Documents/projects/conductor/` (now consolidated into the CAIA monorepo).
+
+#### Core Infrastructure
+
+**Event Bus** (`packages/event-bus/index.ts`)  
+Fully implemented. Uses Node.js `EventEmitter` with picomatch glob subscriptions. Dual-path: in-process emit + SQLite persistence via an injected `EventDb` interface. Supports replay, correlation IDs, causation IDs, OpenTelemetry trace/span IDs. The `events` table (migration 0008) stores all events. The bus is wired at startup via `src/events/bus-adapter.ts`. **Status: Production-ready.**
+
+**Events Taxonomy** (`packages/events-taxonomy/index.ts` + `registry.yaml`)  
+Fully implemented. Canonical TypeScript types for all event types, actors, payloads, and severity levels. Covers: pipeline, story, task, executor, worker, behavior-test, completeness, backup, user, system, prompt events. **Status: Production-ready; extend as new stages are added.**
+
+**Database** (`src/db/schema.ts`, 15 migrations)  
+SQLite via Drizzle ORM. The schema is comprehensive: `projects`, `requirements`, `tasks`, `stories`, `blockers`, `questions`, `events`, `task_runs`, `executor_runs`, `build_runs`, `behavior_tests`, `completeness_runs`, `prompts`, `prompt_pipeline_stages`, `priority_audit`, `pulse_runs`. The `stories` table already supports the full hierarchy (`kind` ∈ `epic|story|sub_story|task|sub_task|todo`). **Status: Solid; needs `initiatives` support added to `kind` enum and migration.**
+
+**Logger** (`packages/logger/index.ts`)  
+Implemented. Pino-based structured logger. **Status: Production-ready.**
+
+**Test Kit** (`packages/test-kit/index.ts`)  
+Implemented. Test utilities and mocks for the event bus and DB. **Status: Usable; extend as new utilities are added.**
+
+#### API Layer
+
+**Hono API Server** (`src/api/app.ts`, `src/api/routes/`)  
+Implemented. 20+ route files:
+- `prompts.ts` — prompt CRUD, pipeline visualization, journey view, events by correlation_id
+- `stories.ts` — full story tree CRUD with revision history
+- `tasks.ts` (inferred from schema) — task lifecycle
+- `executor.ts` — executor config, runs, task status transitions
+- `events.ts` — event query and replay
+- `pulse.ts` — health check runs
+- `builds.ts` — build run tracking
+- `behavior-tests.ts` — behavioral test registry
+- `timeline.ts` — timeline events
+- `priority.ts` — priority scoring and bucket assignment
+- `features.ts`, `adrs.ts`, `audit.ts`, `domains.ts`, `suggestions.ts`, `metrics.ts`, `legacy.ts`
+
+**Status: Comprehensive. Missing: `/decompose`, `/clarify`, `/deploy`, `/accept` routes.**
+
+#### Execution Pipeline
+
+**Executor Daemon** (`apps/executor/executor-daemon.ts`)  
+Fully implemented. Poll-based daemon: every `pollIntervalMs` it runs a scheduler → dispatcher → monitor cycle. Supports:
+- Configurable concurrency (`maxConcurrent`, `maxPerDomainConcurrent`)
+- Circuit breaker (`circuitBreakerThreshold`)
+- Git worktree lifecycle per task (create on dispatch, cleanup on completion)
+- `claude --print --output-format json --permission-mode bypassPermissions` invocation
+- Tiered model routing: Haiku for canary/trivial, Sonnet default, Opus for architecture keywords
+- PID-based crash recovery on restart
+- Drain mode (EXECUTOR_DRAIN_LIMIT)
+
+**Status: Functional and production-grade. Missing: streaming output to dashboard in real-time.**
+
+**Dispatcher** (`apps/executor/dispatcher.ts`)  
+Fully implemented. Creates git worktrees, builds prompts, spawns `claude -p`, captures output lines, parses `[result] DONE/FAILED` markers and JSON cost/turn metadata. Registers executor runs in the DB. **Status: Production-ready.**
+
+**Scheduler** (`apps/executor/scheduler.ts`)  
+Implemented (inferred from daemon usage). Enforces `maxConcurrent`, `maxPerDomainConcurrent`, dependency ordering (via `dependsOn`). **Status: Functional; could benefit from true DAG topological sort.**
+
+**Priority Scoring** (`src/prioritization/scorer.ts`, `bucketer.ts`, `placer.ts`, `reprioritizer.ts`)  
+Fully implemented. Composite 0-100 scorer with 7 weighted dimensions: urgency (25%), blast_radius (20%), user_visible (15%), risk_if_delayed (15%), domain_criticality (15%), confidence (10%), effort_inverse (10%). Assigns to buckets P0–P3. Subscribes to events for automatic re-prioritization. **Status: Production-ready.**
+
+**Pump Engine** (`src/pump/index.ts`)  
+Implemented. The legacy dispatch loop for `requirements` (pre-task model): selects eligible requirements by priority bucket + file-overlap conflict detection, builds prompts, transitions state. **Status: Legacy path; superseded by the executor daemon for task-level execution. Retain for requirement-level orchestration.**
+
+#### Decomposition (Partial)
+
+**Story Backfiller** (`apps/story-backfiller/index.ts`)  
+Partially implemented. A daily cron that scans requirements with no story decomposition and creates a single `epic` node for each. This is a stub — it creates a one-level tree (just an Epic) with boilerplate acceptance criteria. It does **not** perform AI decomposition into Module→Story→Task levels. **Status: Placeholder. The real AI decomposer is the #1 missing piece.**
+
+#### Quality & Observability
+
+**Pipeline Pulse** (`apps/pipeline-pulse/src/pulse.ts`)  
+Fully implemented. Three-layer health check: synthetic canary (dispatches a real Haiku task), state-checksum invariants, and 15 micro-probes in parallel. Auto-heals on known failure signatures. Outcomes: PASSING | DEGRADED | CRITICAL | AUTO-HEALED. **Status: Production-ready.**
+
+**Completeness Sentinel** (`apps/completeness-sentinel/`)  
+Implemented (daemon in a separate plugin directory `~/Documents/projects/plugins/completeness-sentinel/`). Runs completeness checks on entities: `file_exists`, `url_200`, `test_pass`, `commit_sha`, `behavior_test`. Stores findings in `completeness_runs` + `completeness_findings`. **Status: Production-ready.**
+
+**Orchestrator Middleware** (`apps/orchestrator-middleware/src/`)  
+Fully implemented. Enforces: TRACE-001 (prompt ordering), TASK-001 (task_run acknowledgement TTL), AUTON-001/002/006/007/008 (banned phrases in outbound messages — prevents agents from saying things like "I'll just...", "simply", etc. that indicate autonomy bypass). **Status: Production-ready for single-agent use; extend for multi-agent orchestration.**
+
+#### Dashboard
+
+**Next.js Dashboard** (`dashboard/`)  
+Partially implemented. 20+ route directories exist: `timeline`, `prompts`, `tasks`, `stories`, `queue`, `pipeline`, `events`, `builds`, `tests`, `observability`, `requirements`, `blockers`, `questions`, `features`, `adrs`, `domains`, `settings`, `reports`, `coverage`, `audit`. Components include: `TimelineFeed`, `TaskTable`, `RequirementsKanban`, `BlockersKanban`, `DagView`, `EventLog`, `HealthPanel`, `MetricsDashboard`, `FileHeatMap`. **Status: Substantial but incomplete. Most views exist in skeleton or minimal form; the prompt-to-pipeline waterfall drill-down is missing.**
+
+---
+
+### 2.2 What Is Missing (Gaps)
+
+1. **AI Hierarchy Decomposer** — The most critical gap. No component uses Claude to decompose a Prompt into the full Initiative→Epic→Module→Story tree with enriched acceptance criteria.
+2. **Requirement Clarifier** — The `questions` table and `QuestionsKanban` UI exist, but there is no AI agent that proactively generates and asks clarifying questions before decomposition.
+3. **PR Creator & Manager** — No component creates GitHub PRs, runs reviews, or manages merge state.
+4. **Deployment Manager** — No component triggers Cloudflare Pages or GCP deployments.
+5. **Human Acceptance Gate** — No structured flow for a user to review staging, approve, and trigger production release.
+6. **Release Manager** — No component handles the merge → production deploy → observability-closeout flow.
+7. **Full Build Verification** — The `build_runs` table and schema exist; a `build-runner.sh` script is referenced in `package.json`; but the build verifier is not integrated into the pipeline as an automatic step.
+8. **Test Runner Integration** — Behavior tests are tracked in the DB; there is a `behavior-runner` actor in the taxonomy; but no daemon automatically runs the test suite after task completion.
+9. **Streaming Execution Output** — The executor captures `outputLines` from `claude --print` but there is no mechanism to stream these line-by-line to the dashboard in real-time.
+10. **Local LLM Router** — Model selection exists (`selectModel()` in `dispatcher.ts`), but only routes between Claude models. No Ollama/local LLM integration.
+11. **Initiative-level hierarchy node** — The `stories` table `kind` enum does not include `initiative`. The decomposer will need this.
+12. **DAG Dependency Analyzer** — `dependsOn` fields exist on both `stories` and `tasks`, but no utility builds the full directed acyclic graph, validates it for cycles, or computes the critical path.
+
+---
+
+## Section 3: Full Pipeline Architecture
+
+Each stage is defined with its complete contract. The `current_status` field reflects the April 2026 codebase state.
+
+---
+
+### Stage 1: Prompt Ingestion
+
+**Name:** `prompt.ingestion`  
+**Purpose:** Accept and durably record a user's raw requirement text; assign a correlation ID; begin lineage tracking.
+
+**Input Contract:**
+```typescript
+interface PromptIngestionInput {
+  body: string;           // raw requirement text, 10–10,000 chars
+  receivedVia: 'chat' | 'api' | 'cli' | 'scheduled-task';
+  userId?: string;
+  sessionId?: string;
+  metadata?: {
+    projectId?: string;   // target project slug
+    labels?: string[];
+    priority?: 'p0' | 'p1' | 'p2' | 'p3';
+  };
+}
+```
+
+**Output Contract:**
+```typescript
+interface PromptIngestionOutput {
+  promptId: string;        // e.g. "prm_abc123"
+  correlationId: string;   // UUID flowing through all descendants
+  hash: string;            // sha256 of body — used for idempotency (10s window)
+  status: 'received';
+}
+```
+
+**Trigger:** HTTP POST `/prompts` or dashboard form submission.  
+**Events Emitted:** `prompt.ingested` (actor: `api`)  
+**AI Involvement:** None.  
+**Human Touchpoints:** The user submits the prompt. No other human involvement at this stage.  
+**Current Status:** ✅ **Fully implemented.** `src/api/routes/prompts.ts` implements the POST endpoint; `src/prompts/manager.ts` handles creation with hash deduplication; pipeline stage `ingested` is inserted; `prompt.ingested` event is published.
+
+---
+
+### Stage 2: Requirement Clarification
+
+**Name:** `prompt.clarification`  
+**Purpose:** Use AI to detect ambiguity, missing context, or contradictions in the prompt; surface targeted questions; wait for user answers before proceeding to decomposition.
+
+**Input Contract:**
+```typescript
+interface ClarificationInput {
+  promptId: string;
+  promptBody: string;
+  projectContext: {
+    techStack: string[];      // e.g. ["Next.js", "Cloudflare Pages", "SQLite/Drizzle"]
+    existingDomains: string[];
+    recentChanges: string[];  // last 5 merged PRs
+  };
+}
+```
+
+**Output Contract:**
+```typescript
+interface ClarificationOutput {
+  questions: Array<{
+    id: string;
+    priority: 'critical' | 'normal' | 'optional';
+    text: string;
+    recommendations: string[];  // suggested answers
+    customAnswerPlaceholder?: string;
+  }>;
+  clarityScore: number;  // 0-1; if > 0.85, skip clarification
+  canSkip: boolean;
+}
+```
+
+**Trigger:** Automatic after `prompt.ingested` event if `clarityScore < 0.85`.  
+**Events Emitted:** `prompt.clarification_started`, `prompt.clarification_completed`  
+**AI Involvement:** Claude Haiku — fast, cheap. Prompt: analyze the requirement against the project's tech stack and recent history, produce up to 5 targeted questions. System prompt includes project context, domain taxonomy, and example good/bad requirements.  
+**Human Touchpoints:** User answers questions in the dashboard. Questions with `priority: 'optional'` can be skipped.  
+**Current Status:** ⚠️ **Partial.** The `questions` table, state machine (`src/questions/`), and `QuestionsKanban` UI exist. The AI clarifier agent that generates questions from a prompt does **not** exist. The `questions` system was designed for agent-generated questions during execution, not pre-decomposition clarification. Needs: a `@caia/clarifier` utility.
+
+---
+
+### Stage 3: Hierarchy Decomposition
+
+**Name:** `prompt.decomposition`  
+**Purpose:** Use AI to decompose the (clarified) requirement into the full Initiative→Epic→Module→Story tree; write all nodes to the `stories` table with parent linkage; ensure every Story has title, description, and estimated files.
+
+**Input Contract:**
+```typescript
+interface DecompositionInput {
+  promptId: string;
+  promptBody: string;
+  clarificationAnswers: Record<string, string>;  // questionId → answer
+  projectContext: {
+    techStack: string[];
+    domains: Domain[];
+    lockContracts: LockContract[];  // design standards, brand rules, etc.
+    recentStories: Story[];         // last 20 completed stories for style reference
+  };
+  maxDepth: 'initiative' | 'epic' | 'module' | 'story';  // configurable; default 'story'
+}
+```
+
+**Output Contract:**
+```typescript
+interface DecompositionOutput {
+  rootInitiativeId: string;
+  treeNodeCount: number;
+  storyCount: number;     // leaf stories ready for enrichment
+  durationMs: number;
+  tokenUsage: { input: number; output: number };
+}
+// Side effect: all nodes written to `stories` table with rootPromptId linkage
+```
+
+**Trigger:** `prompt.clarification_completed` event (or `prompt.ingested` if clarification is skipped).  
+**Events Emitted:** `pipeline.decompose_started`, `pipeline.decompose_completed`, `story.created` (per node)  
+**AI Involvement:** Claude Sonnet — balanced quality/cost for structured output. Two-phase approach:
+1. **Phase 1 (Sonnet):** Produce the Initiative + Epics + Modules in a single structured JSON response. Prompt: "Given this requirement and project context, produce a complete hierarchical decomposition. Output JSON conforming to DecompositionTree schema. Think step by step about dependencies before outputting."
+2. **Phase 2 (parallel Sonnet calls, one per Module):** Produce Stories for each Module. This parallelism is the key to fast decomposition.  
+
+Structured output (JSON mode) is mandatory to ensure parseable responses. Each Story must include: `title`, `description`, `expectedBehavior`, `acceptanceCriteria[]`, `verificationPlan[]`, `estimatedFiles[]`, `dependsOn[]`, `domainSlug`.
+
+**Human Touchpoints:** Optional. If `storyCount > 50` or the decomposition confidence is low, present the tree to the user for a "looks right?" confirmation before proceeding to execution.  
+**Current Status:** ❌ **Missing.** The `story-backfiller` is a stub that creates a single flat Epic node with boilerplate criteria. The real multi-level AI decomposer is the platform's most critical missing piece.
+
+---
+
+### Stage 4: Task Enrichment
+
+**Name:** `story.enrichment`  
+**Purpose:** For each leaf Story, use AI to generate detailed implementation specifications: exact file paths, function signatures, test cases, implementation notes. Enrichment turns a Story title into an actionable engineering brief.
+
+**Input Contract:**
+```typescript
+interface EnrichmentInput {
+  storyId: string;
+  story: {
+    title: string;
+    description: string;
+    acceptanceCriteria: string[];
+    estimatedFiles: string[];
+    domainSlug: string;
+  };
+  projectContext: {
+    existingFileTree: string;  // relevant subtree
+    lockContracts: LockContract[];
+    relatedStories: Story[];   // sibling stories in same Module
+  };
+}
+```
+
+**Output Contract:**
+```typescript
+interface EnrichmentOutput {
+  storyId: string;
+  enrichedSpec: {
+    implementationNotes: string;
+    fileChanges: Array<{
+      path: string;
+      operation: 'create' | 'modify' | 'delete';
+      description: string;
+    }>;
+    testCases: string[];
+    dependenciesRequired: string[];  // npm packages, etc.
+    estimatedComplexity: 'trivial' | 'simple' | 'moderate' | 'complex';
+    recommendedModel: 'haiku' | 'sonnet' | 'opus' | 'local';
+  };
+}
+```
+
+**Trigger:** `pipeline.decompose_completed` event; all Stories enriched in parallel.  
+**Events Emitted:** `story.updated` (fields: enriched_spec)  
+**AI Involvement:** Claude Haiku for trivial/simple stories; Sonnet for moderate/complex. System prompt includes project file tree, code style examples, and lock contracts. The enricher's primary value is mapping abstract story descriptions to concrete file paths and function signatures that the executing agent will actually use.  
+**Human Touchpoints:** None in the automated path. Users can edit enrichment via the dashboard before execution begins.  
+**Current Status:** ❌ **Missing.** Stories are currently created with minimal metadata. No enrichment utility exists.
+
+---
+
+### Stage 5: Dependency Analysis
+
+**Name:** `story.dependency_analysis`  
+**Purpose:** Build the directed acyclic graph (DAG) of Story dependencies; validate for cycles; identify the critical path; classify Stories as `sequential` (blocked by a predecessor) or `parallel` (can execute concurrently).
+
+**Input Contract:**
+```typescript
+interface DependencyAnalysisInput {
+  promptId: string;
+  stories: Array<{
+    id: string;
+    dependsOn: string[];      // explicit story IDs
+    estimatedFiles: string[]; // for implicit file-overlap detection
+    domainSlug: string;
+    estimatedComplexity: string;
+  }>;
+}
+```
+
+**Output Contract:**
+```typescript
+interface DependencyAnalysisOutput {
+  dag: {
+    nodes: string[];
+    edges: Array<{ from: string; to: string; kind: 'explicit' | 'file_overlap' | 'domain_sequence' }>;
+  };
+  criticalPath: string[];          // ordered list of story IDs on longest path
+  parallelBatches: string[][];     // topological levels: batch[0] can all start at once, etc.
+  cyclesDetected: Array<string[]>; // should be empty; pipeline halts if not
+  estimatedWallClockMs: number;    // if all parallel batches run at max concurrency
+}
+```
+
+**Trigger:** `story.enrichment_completed` (all Stories enriched for a prompt).  
+**Events Emitted:** `pipeline.dag_computed`  
+**AI Involvement:** None for DAG construction (pure graph algorithm). Optional: Claude Haiku for detecting semantic dependencies that aren't expressed in explicit `dependsOn` fields — e.g. "Story B modifies a schema that Story A also reads" even if B doesn't list A in `dependsOn`.  
+**Human Touchpoints:** The DAG is visualized in the dashboard (`DagView` component already exists). Users can add or remove edges before scheduling begins.  
+**Current Status:** ⚠️ **Partial.** `dependsOn` fields exist on `stories` and `tasks`. The scheduler uses `dependsOn` for task-level sequencing. No utility builds the full cross-story DAG, validates it, or computes parallel batches. The `DagView` component exists in the dashboard but may not have full data to render.
+
+---
+
+### Stage 6: Scheduling
+
+**Name:** `story.scheduling`  
+**Purpose:** Assign each Story a priority bucket (P0–P3), position ordinal within its bucket, and execution slot (sequential batch number). Feed the result to the executor queue.
+
+**Input Contract:**
+```typescript
+interface SchedulingInput {
+  promptId: string;
+  dag: DependencyAnalysisOutput;
+  stories: Array<{
+    id: string;
+    domainSlug: string;
+    estimatedComplexity: string;
+    userPriority?: number;  // explicit override from metadata
+  }>;
+  executorConfig: {
+    maxConcurrent: number;
+    maxPerDomainConcurrent: number;
+  };
+}
+```
+
+**Output Contract:**
+```typescript
+// Side effect: all Stories have tasks created in the `tasks` table with
+// priorityBucket, positionOrdinal, dependsOn set correctly.
+interface SchedulingOutput {
+  tasksCreated: number;
+  estimatedStartOrder: Array<{ taskId: string; batchN: number; canStartAt: string }>;
+}
+```
+
+**Trigger:** `pipeline.dag_computed` event.  
+**Events Emitted:** `task.created` (per task), `task.queued` (per task)  
+**AI Involvement:** None. The priority scorer (`src/prioritization/scorer.ts`) is a pure function, not AI.  
+**Human Touchpoints:** Users can re-prioritize individual tasks via the dashboard before execution begins.  
+**Current Status:** ✅ **Substantially implemented.** Priority scoring, bucket assignment, and ordinal placement all exist. The executor scheduler enforces concurrency limits. **Gap:** no utility that, upon `pipeline.dag_computed`, automatically creates tasks from stories and sets their full dependency graph.
+
+---
+
+### Stage 7: Execution
+
+**Name:** `task.execution`  
+**Purpose:** For each queued, unblocked Task, spawn a `claude --print` process in a dedicated git worktree; monitor for completion or stall; capture output; update task status.
+
+**Input Contract:**
+```typescript
+interface ExecutionInput {
+  taskId: string;
+  title: string;
+  cwd: string;              // project root
+  notes: string | null;     // enriched spec as JSON
+  declaredFiles: string[];
+  domainSlug: string | null;
+  rootPromptId: string | null;
+  attemptCount: number;
+}
+```
+
+**Output Contract:**
+```typescript
+interface ExecutionOutput {
+  executorRunId: number;
+  sessionId: string | null;  // Claude session ID from JSON output
+  resultOk: boolean;
+  summary: string;           // "[result] DONE: ..." or "[result] FAILED: ..."
+  durationMs: number;
+  costUsd: number | null;
+  turnCount: number | null;
+  filesChanged: string[];
+  worktreePath: string;      // for PR creation
+}
+```
+
+**Trigger:** Task in `queued` state with all `dependsOn` tasks in `completed` state; executor daemon poll tick.  
+**Events Emitted:** `worker.spawned`, `executor.task.picked_up`, `task.started`, `task.completed` | `task.failed`  
+**AI Involvement:** Claude Haiku / Sonnet / Opus — selected by `selectModel()` based on task complexity signals. The executing agent has full tool access: bash, file read/write, web fetch. The agent operates autonomously within the worktree; the orchestrator middleware enforces banned phrases and autonomy constraints.  
+**Human Touchpoints:** Users can pause individual tasks from the dashboard. Blockers generated during execution surface as `blockers` table entries and appear in the `BlockersKanban` UI.  
+**Current Status:** ✅ **Fully implemented.** The executor daemon, dispatcher, monitor, circuit breaker, and completion hook all exist and are functional.
+
+---
+
+### Stage 8: PR Creation & Review
+
+**Name:** `task.pr_creation`  
+**Purpose:** After a Task (or all Tasks in a Story/Module) completes, create a GitHub pull request from the worktree branch against the project's main branch; run automated checks; post review comments.
+
+**Input Contract:**
+```typescript
+interface PRCreationInput {
+  taskId: string;
+  worktreePath: string;
+  projectRepoUrl: string;    // e.g. "github.com/prakashgbid/myapp"
+  baseBranch: string;        // typically "main"
+  storyTitle: string;
+  storyAcceptanceCriteria: string[];
+  filesChanged: string[];
+  resultSummary: string;     // from executor output
+  rootPromptId: string;
+}
+```
+
+**Output Contract:**
+```typescript
+interface PRCreationOutput {
+  prNumber: number;
+  prUrl: string;
+  headBranch: string;
+  reviewChecks: Array<{
+    name: string;
+    status: 'pass' | 'fail' | 'warning';
+    message: string;
+  }>;
+}
+```
+
+**Trigger:** `task.completed` event with `resultOk: true`.  
+**Events Emitted:** `pr.created`, `pr.review_started`, `pr.review_completed`  
+**AI Involvement:** Claude Sonnet for automated PR review: reads the diff, checks acceptance criteria coverage, flags potential issues, generates the PR description. The review is additive (comments on the PR) and does not block merge automatically.  
+**Human Touchpoints:** Human can review the PR diff in the CAIA dashboard (linked to GitHub) or directly on GitHub. The PR is not merged automatically — it waits for the Human Acceptance Gate (Stage 12).  
+**Current Status:** ❌ **Missing.** No PR creation utility exists. The GitHub API integration is absent. This is a P0 gap for the full vision.
+
+---
+
+### Stage 9: Testing
+
+**Name:** `task.testing`  
+**Purpose:** Run the project's unit test suite and E2E behavioral tests against the changes in the worktree; update the behavior test registry; surface failures as blockers.
+
+**Input Contract:**
+```typescript
+interface TestingInput {
+  taskId: string;
+  worktreePath: string;
+  projectCwd: string;
+  changedFiles: string[];
+  testFramework: 'vitest' | 'jest' | 'playwright';
+  testScope: 'affected' | 'full';  // 'affected' uses file→test mapping
+}
+```
+
+**Output Contract:**
+```typescript
+interface TestingOutput {
+  passed: number;
+  failed: number;
+  skipped: number;
+  duration: number;
+  failures: Array<{
+    testId: string;
+    testName: string;
+    failureExcerpt: string;
+    kind: 'regression' | 'new-bug' | 'flake';
+  }>;
+  behaviorTestUpdates: Array<{
+    testId: string;
+    status: 'pass' | 'fail' | 'new';
+  }>;
+}
+```
+
+**Trigger:** `pr.created` event.  
+**Events Emitted:** `behavior_test.passed` | `behavior_test.failed` (per test), `pipeline.tests_completed`  
+**AI Involvement:** Claude Haiku for flake detection (re-runs failing tests and classifies them). Claude Sonnet is invoked when a test fails due to a code change: it reads the failing test, reads the changed code, and proposes a fix — which is dispatched as a new task.  
+**Human Touchpoints:** Test failures surface in the `Tests` dashboard view. Users can mark a test as "known flake" or "expected failure" to unblock the pipeline.  
+**Current Status:** ⚠️ **Partial.** The behavior test registry (`behavior_tests`, `behavior_test_runs`, `behavior_test_failures` tables), the `behavior-runner` actor in taxonomy, and the `Tests` dashboard route all exist. No daemon automatically runs the test suite after task completion. The `behavior-runner` is referenced in the taxonomy but not implemented as a runnable service.
+
+---
+
+### Stage 10: Build Verification
+
+**Name:** `build.verification`  
+**Purpose:** Run the project's full build pipeline (lint, typecheck, bundle) in the worktree to confirm the changes compile and produce a deployable artifact without errors.
+
+**Input Contract:**
+```typescript
+interface BuildVerificationInput {
+  worktreePath: string;
+  projectCwd: string;
+  buildCommands: Array<{ name: string; command: string; }>;
+  gitSha: string;
+  branch: string;
+}
+```
+
+**Output Contract:**
+```typescript
+interface BuildVerificationOutput {
+  buildRunId: string;
+  status: 'pass' | 'fail';
+  steps: Array<{
+    name: string;
+    exitCode: number;
+    durationMs: number;
+    stdoutTail: string;
+    stderrTail: string;
+  }>;
+  artifactPath?: string;  // path to built output for deployment
+  errorSignature?: string;
+}
+```
+
+**Trigger:** `pipeline.tests_completed` with all tests passing.  
+**Events Emitted:** `build.started`, `build.completed` | `build.failed`  
+**AI Involvement:** Claude Sonnet is invoked when a build fails: it reads the error output, identifies the root cause, and either (a) spawns a fix task or (b) escalates as a blocker. Build failures due to type errors are auto-fixable; failures due to missing dependencies or configuration issues escalate.  
+**Human Touchpoints:** Build failures surface in the `Builds` dashboard view. Users can inspect step-by-step output.  
+**Current Status:** ⚠️ **Partial.** The `build_runs`, `build_steps`, `build_retries` tables exist (migration 0009). A `build-runner.sh` script is referenced in `package.json` scripts. The `Builds` dashboard route exists. No daemon automatically triggers builds as part of the pipeline after testing.
+
+---
+
+### Stage 11: Deployment
+
+**Name:** `build.deployment`  
+**Purpose:** Deploy the verified build artifact to the staging environment (Cloudflare Pages or GCP Cloud Run); verify the deployment is live and the feature URL returns HTTP 200; capture the staging URL for human review.
+
+**Input Contract:**
+```typescript
+interface DeploymentInput {
+  buildRunId: string;
+  artifactPath: string;
+  target: 'cloudflare-pages' | 'gcp-cloud-run' | 'custom';
+  environment: 'staging' | 'production';
+  projectSlug: string;
+  gitSha: string;
+  branch: string;
+}
+```
+
+**Output Contract:**
+```typescript
+interface DeploymentOutput {
+  deploymentId: string;
+  stagingUrl: string;
+  status: 'live' | 'failed' | 'timeout';
+  durationMs: number;
+  healthCheckResult: {
+    url: string;
+    statusCode: number;
+    responseMs: number;
+  };
+}
+```
+
+**Trigger:** `build.completed` with `status: 'pass'`.  
+**Events Emitted:** `deployment.started`, `deployment.completed` | `deployment.failed`  
+**AI Involvement:** None for the deployment action itself. Claude Haiku is used for post-deployment health verification: fetch the staging URL, compare the rendered HTML against the story's expected behavior, and flag visual or functional regressions.  
+**Human Touchpoints:** Users are notified (via dashboard notification + optional email/Slack) when staging is ready for review.  
+**Current Status:** ❌ **Missing.** No deployment utility exists. Cloudflare Pages and GCP integrations are referenced in the vision but absent from the codebase.
+
+---
+
+### Stage 12: Human Acceptance
+
+**Name:** `human.acceptance`  
+**Purpose:** Present the deployed staging feature to the human for review; collect explicit approval or rejection with optional feedback; gate the production release.
+
+**Input Contract:**
+```typescript
+interface HumanAcceptanceInput {
+  promptId: string;
+  stagingUrl: string;
+  prUrl: string;
+  changedFiles: string[];
+  acceptanceCriteria: string[];
+  aiReviewSummary: string;
+  testResults: { passed: number; failed: number; };
+  buildStatus: 'pass';
+}
+```
+
+**Output Contract:**
+```typescript
+interface HumanAcceptanceOutput {
+  decision: 'approved' | 'rejected' | 'approved_with_changes';
+  feedback?: string;
+  changesRequested?: Array<{ criterion: string; note: string }>;
+  decidedAt: string;
+  decidedBy: string;
+}
+```
+
+**Trigger:** `deployment.completed` with `status: 'live'`.  
+**Events Emitted:** `human.acceptance_requested`, `human.acceptance_granted` | `human.acceptance_rejected`  
+**AI Involvement:** None at the decision point. Before surfacing to the human, Claude Sonnet generates an "acceptance report": a structured summary of what changed, which acceptance criteria are provably met (via test results and file evidence), and which require manual verification.  
+**Human Touchpoints:** The primary human touchpoint in the pipeline. The `Human Acceptance Review` dashboard view (see Section 5) presents: staging URL, PR diff link, acceptance criteria checklist, AI review summary, approve/reject buttons.  
+**Current Status:** ❌ **Missing.** No acceptance gate UI or backend flow exists.
+
+---
+
+### Stage 13: Production Release
+
+**Name:** `release.production`  
+**Purpose:** Merge the approved PR to the main branch; trigger the production deployment pipeline; verify production is live; tag the release.
+
+**Input Contract:**
+```typescript
+interface ReleaseInput {
+  prNumber: number;
+  prUrl: string;
+  projectRepoUrl: string;
+  acceptanceDecision: 'approved' | 'approved_with_changes';
+  deployTarget: 'cloudflare-pages' | 'gcp-cloud-run';
+}
+```
+
+**Output Contract:**
+```typescript
+interface ReleaseOutput {
+  mergeCommitSha: string;
+  productionUrl: string;
+  releaseTag: string;      // e.g. "v1.4.2-prompt-prm_abc123"
+  deploymentId: string;
+  status: 'live' | 'rollback';
+}
+```
+
+**Trigger:** `human.acceptance_granted` event.  
+**Events Emitted:** `release.started`, `release.completed` | `release.failed`  
+**AI Involvement:** None for the merge/deploy action. Claude Haiku for generating the release tag description.  
+**Human Touchpoints:** None. This stage is fully automated after human approval.  
+**Current Status:** ❌ **Missing.**
+
+---
+
+### Stage 14: Observability Closeout
+
+**Name:** `prompt.closeout`  
+**Purpose:** Mark the originating Prompt as completed; compute cost/performance metrics for the full pipeline run; update the prompt_pipeline_stages table to terminal state; emit the final summary event.
+
+**Input Contract:**
+```typescript
+interface CloseoutInput {
+  promptId: string;
+  releaseOutput: ReleaseOutput;
+  pipelineStartedAt: string;
+}
+```
+
+**Output Contract:**
+```typescript
+interface CloseoutOutput {
+  promptId: string;
+  totalDurationMs: number;
+  totalCostUsd: number;
+  totalTokens: { input: number; output: number };
+  stagesCompleted: string[];
+  storiesDelivered: number;
+  filesChanged: string[];
+  productionUrl: string;
+}
+```
+
+**Trigger:** `release.completed` event.  
+**Events Emitted:** `prompt.completed` (the terminal event for a prompt's lifecycle)  
+**AI Involvement:** None.  
+**Human Touchpoints:** The Prompt Detail view updates to show the final summary card.  
+**Current Status:** ⚠️ **Partial.** The `prompt_pipeline_stages` table and stage-tracking infrastructure exist. No closeout utility computes and persists the final metrics, and the `prompt.completed` event type does not exist in the taxonomy yet.
+
+---
+
+## Section 4: Utility Catalogue
+
+Each utility is the deployable unit of CAIA's plugin architecture. Utilities communicate exclusively via the event bus or the CAIA API — never direct function calls across process boundaries.
+
+---
+
+### `@caia/ingester`
+**Responsibility:** Accept prompt submissions from the GUI, CLI, or API; deduplicate; write to `prompts` table; emit `prompt.ingested`.  
+**Input:** `PromptIngestionInput`  
+**Output:** `PromptIngestionOutput`  
+**Exists?** Yes — `src/api/routes/prompts.ts` + `src/prompts/manager.ts`  
+**AI Model:** None  
+**Open-Source Viability:** High — generic prompt intake with deduplication and correlation ID assignment is universally useful  
+
+---
+
+### `@caia/clarifier`
+**Responsibility:** Given a prompt and project context, use AI to generate targeted clarifying questions; present to user; collect answers; emit completion.  
+**Input:** `ClarificationInput`  
+**Output:** `ClarificationOutput`  
+**Exists?** No — the `questions` table and UI exist, but the AI clarification agent does not  
+**AI Model:** Claude Haiku (fast question generation); Claude Sonnet for complex ambiguity analysis  
+**Open-Source Viability:** High — question generation from ambiguous requirements is universally applicable  
+
+---
+
+### `@caia/decomposer`
+**Responsibility:** The most complex utility. Takes a clarified prompt, runs a two-phase AI decomposition (Initiative+Epic+Module in phase 1; Stories in parallel in phase 2); writes the full tree to `stories`; emits `story.created` per node.  
+**Input:** `DecompositionInput`  
+**Output:** `DecompositionOutput`  
+**Exists?** No (the `story-backfiller` is a placeholder, not a real decomposer)  
+**AI Model:** Claude Sonnet for phase 1; parallel Claude Sonnet/Haiku for phase 2 stories  
+**Open-Source Viability:** Very high — this is the central value-add of any AI engineering platform  
+**Implementation Notes:**
+- Use Anthropic structured output (JSON schema enforcement) to guarantee parseable responses
+- Phase 2 parallelism: spawn one API call per Module concurrently using `Promise.all`
+- Include chain-of-thought reasoning step ("first, identify the major capability areas; then, for each area, identify the independent modules...")
+- The system prompt must include: project file tree, domain taxonomy, lock contracts, example well-formed stories from the existing `stories` table
+
+---
+
+### `@caia/enricher`
+**Responsibility:** For each leaf Story, use AI to expand the description into a detailed implementation brief: exact file paths, function signatures, test cases, dependency requirements, and model recommendation.  
+**Input:** `EnrichmentInput`  
+**Output:** `EnrichmentOutput`  
+**Exists?** No  
+**AI Model:** Claude Haiku for `estimatedComplexity: 'trivial' | 'simple'`; Claude Sonnet for `'moderate' | 'complex'`  
+**Open-Source Viability:** Medium — useful but tightly coupled to CAIA's story schema  
+
+---
+
+### `@caia/dag-analyzer`
+**Responsibility:** Build the DAG from story `dependsOn` fields plus file-overlap detection; validate for cycles; compute parallel batches; estimate wall-clock duration.  
+**Input:** `DependencyAnalysisInput`  
+**Output:** `DependencyAnalysisOutput`  
+**Exists?** No (partial: `dependsOn` fields exist; the `DagView` component exists)  
+**AI Model:** None for DAG construction (Kahn's algorithm). Optional: Claude Haiku for semantic dependency inference.  
+**Open-Source Viability:** Very high — a standalone TypeScript DAG library for AI task orchestration is broadly useful  
+
+---
+
+### `@caia/scheduler`
+**Responsibility:** Given the DAG output, create Tasks in the DB with correct priority scores, bucket assignments, ordinals, and dependency linkage; feed the executor queue.  
+**Input:** `SchedulingInput`  
+**Output:** `SchedulingOutput`  
+**Exists?** Partially — `src/prioritization/` (scorer, bucketer, placer, reprioritizer) all exist; what's missing is the bridge from Stories to Tasks  
+**AI Model:** None  
+**Open-Source Viability:** Medium — the priority scoring logic is opinionated and domain-specific  
+
+---
+
+### `@caia/worktree-manager`
+**Responsibility:** Create and destroy git worktrees for task execution; manage the worktree namespace; handle cleanup after PR creation.  
+**Input:** `{ taskId: string; config: DispatchConfig }`  
+**Output:** `{ worktreePath: string }`  
+**Exists?** Yes — embedded in `apps/executor/dispatcher.ts` (`createWorktree`, `cleanupWorktree`). Should be extracted to a standalone utility.  
+**AI Model:** None  
+**Open-Source Viability:** High — `@caia/worktree-manager` as a standalone package is useful for any git-based AI agent framework  
+
+---
+
+### `@caia/executor`
+**Responsibility:** The execution engine. Manages the full lifecycle of spawning `claude --print` processes: prompt building, model selection, process spawning, output capture, completion detection, retry logic, circuit breaking.  
+**Input:** `ExecutionInput`  
+**Output:** `ExecutionOutput`  
+**Exists?** Yes — `apps/executor/` (daemon, dispatcher, scheduler, monitor, completion-hook, breaker). Production-grade.  
+**AI Model:** Claude Haiku / Sonnet / Opus — selected by `selectModel()` based on task signals  
+**Open-Source Viability:** Very high — a production-grade Claude Code executor with circuit breaking and worktree management is the most reusable component in the platform  
+
+---
+
+### `@caia/pr-manager`
+**Responsibility:** Create GitHub PRs from completed worktrees; run AI-powered code review; post review comments; track PR status; handle merge conflicts.  
+**Input:** `PRCreationInput`  
+**Output:** `PRCreationOutput`  
+**Exists?** No  
+**AI Model:** Claude Sonnet for PR review and description generation  
+**Open-Source Viability:** High — standalone GitHub PR management for AI agents is broadly needed. Depends on: `@octokit/rest` (or GitHub's native API)  
+**Implementation Notes:**
+- Use `git push origin HEAD:refs/heads/task-{taskId}` from the worktree
+- Create PR via GitHub API with auto-generated description including: story link, acceptance criteria, changed files, AI execution summary
+- Run review: fetch diff, construct prompt, get structured review JSON, post as PR comments
+- Track status in a `pull_requests` table (new migration needed)
+
+---
+
+### `@caia/test-runner`
+**Responsibility:** Run the project's test suite (Vitest unit tests + Playwright E2E) scoped to changed files; update the behavior test registry; surface failures as blockers; optionally spawn fix tasks.  
+**Input:** `TestingInput`  
+**Output:** `TestingOutput`  
+**Exists?** Partial — behavior test registry and tables exist; no runner daemon  
+**AI Model:** Claude Haiku for flake detection; Claude Sonnet for test failure root cause analysis and fix generation  
+**Open-Source Viability:** Medium — useful but tightly coupled to Vitest/Playwright  
+
+---
+
+### `@caia/build-verifier`
+**Responsibility:** Run the project's build pipeline in the worktree; capture step-by-step output; persist to `build_runs`/`build_steps`; trigger AI-powered error diagnosis on failure.  
+**Input:** `BuildVerificationInput`  
+**Output:** `BuildVerificationOutput`  
+**Exists?** Partial — schema exists; `build-runner.sh` referenced; no daemon integration  
+**AI Model:** Claude Sonnet for build failure diagnosis  
+**Open-Source Viability:** High — a build verification daemon with AI error diagnosis is broadly useful  
+
+---
+
+### `@caia/deployment-manager`
+**Responsibility:** Deploy build artifacts to Cloudflare Pages (static sites/Next.js) or GCP Cloud Run (APIs/services); verify deployment health; capture staging URL.  
+**Input:** `DeploymentInput`  
+**Output:** `DeploymentOutput`  
+**Exists?** No  
+**AI Model:** None for deployment actions. Claude Haiku for post-deployment health verification.  
+**Open-Source Viability:** Medium — too opinionated to Cloudflare/GCP to be universally applicable; best as a plugin  
+**Implementation Notes:**
+- Cloudflare Pages: use `wrangler pages deploy <artifact-path> --project-name=<name> --branch=staging`
+- GCP Cloud Run: use `gcloud run deploy <service> --image=<image> --region=<region>`
+- Abstract via a `DeploymentProvider` interface so additional providers (Vercel, Railway, Fly.io) can be added
+
+---
+
+### `@caia/acceptance-gate`
+**Responsibility:** When staging is live, notify the human; present the acceptance review view; collect approve/reject decision; persist the outcome; trigger release or re-execution.  
+**Input:** `HumanAcceptanceInput`  
+**Output:** `HumanAcceptanceOutput`  
+**Exists?** No  
+**AI Model:** Claude Sonnet for the pre-review acceptance report generation  
+**Open-Source Viability:** Medium — the UX pattern is useful but the data model is CAIA-specific  
+
+---
+
+### `@caia/release-manager`
+**Responsibility:** Merge approved PRs to main; trigger production deployment; verify production health; tag the release; notify stakeholders.  
+**Input:** `ReleaseInput`  
+**Output:** `ReleaseOutput`  
+**Exists?** No  
+**AI Model:** Claude Haiku for release tag description  
+**Open-Source Viability:** Medium — useful for any AI-driven CD pipeline  
+
+---
+
+### `@caia/event-bus`
+**Responsibility:** Dual-path event delivery: in-process `EventEmitter` with picomatch glob subscriptions + SQLite outbox for persistence and replay. The central nervous system of the platform.  
+**Input:** `Omit<ConductorEvent, 'id' | 'occurred_at' | 'severity'>`  
+**Output:** `ConductorEvent`  
+**Exists?** Yes — `packages/event-bus/index.ts`. Production-ready.  
+**AI Model:** None  
+**Open-Source Viability:** Very high — a typed, SQLite-backed, glob-subscribed event bus for Node.js is broadly useful. Depends on: `better-sqlite3`, `picomatch`  
+
+---
+
+### `@caia/timeline-recorder`
+**Responsibility:** Subscribe to all events; write human-readable timeline entries to `timeline_events`; power the `TimelineFeed` dashboard component.  
+**Input:** Any `ConductorEvent`  
+**Output:** `TimelineEvent` rows in DB  
+**Exists?** Yes — `timeline_events` table and `TimelineFeed` component exist. The recorder logic is distributed across route handlers.  
+**AI Model:** None  
+**Open-Source Viability:** Medium  
+
+---
+
+### `@caia/completeness-verifier`
+**Responsibility:** Periodically verify that completed stories/tasks have actual evidence of completion: file exists, URL returns 200, test passes, commit SHA exists. Surface failures as completeness findings.  
+**Input:** Scheduled trigger or `task.completed` event  
+**Output:** `CompletenessRun` records with per-check findings  
+**Exists?** Yes — implemented as a plugin in `~/Documents/projects/plugins/completeness-sentinel/`  
+**AI Model:** None  
+**Open-Source Viability:** High — completeness verification for AI-generated work is a universally needed quality gate  
+
+---
+
+### `@caia/observability-monitor`
+**Responsibility:** Three-layer health check (synthetic canary + state invariants + micro-probes); auto-heal on known failure signatures; persist results to `pulse_runs`.  
+**Input:** Scheduled trigger (configurable cron) or on-demand CLI  
+**Output:** `PulseResult` with `PASSING | DEGRADED | CRITICAL | AUTO-HEALED` outcome  
+**Exists?** Yes — `apps/pipeline-pulse/`. Production-ready.  
+**AI Model:** None (uses real task execution as canary)  
+**Open-Source Viability:** Very high — a multi-layer pipeline health monitor with auto-healing is independently useful  
+
+---
+
+### `@caia/local-llm-router`
+**Responsibility:** Intercept model selection decisions; route tasks to local LLMs (via Ollama) when task complexity, cost budget, or user preference indicates this is appropriate; fall back to Claude when local quality is insufficient.  
+**Input:** `DispatchTask` + routing policy config  
+**Output:** `{ endpoint: string; model: string; apiKey?: string }`  
+**Exists?** Partial — `selectModel()` in `dispatcher.ts` already routes between Claude model tiers. No Ollama integration.  
+**AI Model:** N/A — this utility is the router, not the model  
+**Open-Source Viability:** High — a Claude-compatible local LLM router with policy-based routing is broadly useful  
+
+---
+
+## Section 5: Dashboard Specification
+
+The dashboard is the primary human interface. All human interaction with the platform happens here — zero terminal required.
+
+### 5.1 Prompt Submission View
+
+**Route:** `/prompts/new`  
+**Purpose:** Accept new requirements and initiate the pipeline.  
+
+**Key Data Shown:**
+- Large rich text area (supports markdown) for the requirement body
+- Project selector dropdown (from `projects` table)
+- Priority hint (P0–P3) with tooltip explaining each level
+- Labels multi-select (from existing label set)
+- "Advanced" collapse: `receivedVia` mode, metadata JSON override
+- Character count and estimated cost indicator (tokens × rate)
+- Recent prompts list (last 5) for reference
+
+**Interactions:**
+- Submit button → POST `/prompts` → redirect to Prompt Detail view
+- "Save as Draft" → persists without submitting
+- Keyboard shortcut: `Cmd+Enter` to submit
+
+**Real-time vs Static:** Static form; real-time updates to cost estimate as user types (token estimation in client).
+
+---
+
+### 5.2 Prompt List View
+
+**Route:** `/prompts`  
+**Purpose:** Overview of all submitted prompts with their current pipeline status.
+
+**Key Data Shown:**
+- Table/card list: prompt excerpt (first 100 chars), status badge, project, submitted timestamp, elapsed time, story count, task count, cost (USD)
+- Status filter tabs: All | Received | Analyzing | Executing | Staging | Completed | Failed
+- Search bar (full-text on prompt body)
+- Pagination with cursor
+
+**Interactions:**
+- Click row → Prompt Detail view
+- Quick actions: Cancel, Re-run (from failed state)
+
+**Real-time:** Status badges update via WebSocket `conductor:event` stream. Elapsed time ticks in real-time.
+
+---
+
+### 5.3 Prompt Detail / Pipeline Waterfall View
+
+**Route:** `/prompts/[id]`  
+**Purpose:** The core visualization — drill-down from prompt to every sub-entity in the hierarchy.
+
+**Key Data Shown:**
+- Header card: prompt body, status, project, timestamps, cost, token usage
+- Pipeline stage progress bar (horizontal waterfall): `ingested → clarifying → decomposing → scheduling → executing → staging → review → released`
+- Each stage shows: elapsed time, current status, events count
+- **Accordion hierarchy tree:** Initiative → Epic → Module → Story → Task → Subtask
+  - Each level is collapsible/expandable
+  - Each node shows: title, status badge, duration, assigned domain, model used
+  - Color coding: grey (pending) → blue (executing) → green (completed) → red (failed)
+- Events timeline (collapsible panel at bottom): all events with `correlationId = promptId`
+- Summary statistics: total cost, total tokens, wall-clock time, files changed, tests run
+
+**Interactions:**
+- Click any node → open Task Detail (side panel or route)
+- Approve/Reject button (visible only when `status = staging_deployed`)
+- "Force re-run story" button on failed Stories
+- Expand All / Collapse All controls
+
+**Real-time:** Entire tree updates via WebSocket. Active executing nodes show a pulsing indicator and live subtask list.
+
+---
+
+### 5.4 Task Detail View
+
+**Route:** `/tasks/[id]`  
+**Purpose:** Full detail for a single task including spec, execution timeline, tool calls, file changes.
+
+**Key Data Shown:**
+- Title, description, notes (enriched spec)
+- Status, priority bucket, attempt count, model used
+- Acceptance criteria checklist (checked off as evidence is found)
+- Verification plan steps
+- Declared files → Actual files changed (diff)
+- Execution history: list of `executor_runs` for this task, each with duration, cost, exit code
+- Status transition history (from `task_status_transitions`)
+- Events list (filtered by `entity_id = taskId`)
+- Raw Claude output (collapsible, syntax highlighted)
+
+**Interactions:**
+- "Re-run" button → dispatches a new executor run
+- "Pause / Resume" toggle
+- "Edit notes" inline editor for enriched spec
+- View worktree diff button → opens PR diff or local git diff
+
+**Real-time:** Live output stream during execution (line-by-line from executor's `outputLines`).
+
+---
+
+### 5.5 Execution Live View
+
+**Route:** `/tasks/[id]/live`  
+**Purpose:** Real-time view of a running task — tool calls, file changes, subtask progress.
+
+**Key Data Shown:**
+- Live terminal-style output stream (monospace, auto-scroll)
+- Subtask checklist (updating in real-time from `task_subtasks`)
+- Current tool call (e.g. "bash: running `vitest run`")
+- Files touched so far
+- Turn counter, token counter, elapsed timer
+
+**Interactions:**
+- "Kill Task" button (immediate SIGTERM to the process)
+- Pause (sends SIGSTOP — for debugging only)
+- Copy full output to clipboard
+
+**Real-time:** SSE or WebSocket stream from the executor's stdout capture. This requires the executor to forward `outputLines` to a streaming endpoint as they arrive, not just at completion.
+
+---
+
+### 5.6 Test Results View
+
+**Route:** `/tests`  
+**Purpose:** Registry of all behavior tests with pass/fail history.
+
+**Key Data Shown:**
+- Table: test name, feature, scope, project, last run status, pass rate (last 30 runs), first seen, last seen
+- Filter by: project, feature, scope, status
+- Failure heat map: which tests fail most often, correlated with which domains
+
+**Interactions:**
+- Click test → test detail (all runs, failure excerpts, linked blockers)
+- "Run all" button → triggers test runner for selected project
+- Mark as flake / mark as expected failure
+
+**Real-time:** Static with manual refresh; test run status updates via WebSocket when a run is in progress.
+
+---
+
+### 5.7 Deployment Status View
+
+**Route:** `/deployments`  
+**Purpose:** Overview of all staging and production deployments.
+
+**Key Data Shown:**
+- Table: prompt ID, project, environment, URL, status (live/failed/timeout), deployed at, by (PR #)
+- Latest staging URL per project (quick "preview" link)
+- Deployment duration trend chart
+
+**Interactions:**
+- Click "Open staging URL" → opens in new tab
+- "Rollback" button on production deployments (triggers revert + re-deploy)
+- "Promote to production" shortcut (for cases where human acceptance was done externally)
+
+**Real-time:** Status updates via WebSocket. Active deployments show a progress indicator.
+
+---
+
+### 5.8 Human Acceptance Review View
+
+**Route:** `/prompts/[id]/review`  
+**Purpose:** The human gate. Everything a reviewer needs to approve or reject a staged feature.
+
+**Key Data Shown:**
+- Staging URL with embedded preview frame (optional, configurable)
+- "Open in new tab" link
+- PR diff summary: files changed, additions, deletions, link to GitHub PR
+- Acceptance criteria checklist: each criterion with status (provably met by test evidence / requires manual check / failed)
+- AI acceptance report: Sonnet's structured analysis of what was built vs what was requested
+- Test results summary: N passed, N failed
+- Build status badge
+- Cost incurred for this prompt
+
+**Interactions:**
+- **Approve** button → `human.acceptance_granted` event → triggers Stage 13
+- **Reject with feedback** → text area for feedback → `human.acceptance_rejected` → re-queue affected stories
+- **Approve with changes** → approve but create follow-up stories for outstanding items
+- Individual criterion override: "Mark as met" / "Mark as failed"
+
+**Real-time:** Static once opened (snapshot of the staged build). Notifies user if the staging environment goes down while reviewing.
+
+---
+
+### 5.9 System Health / Observability Dashboard
+
+**Route:** `/observability`  
+**Purpose:** Real-time system health monitoring for CAIA platform operators.
+
+**Key Data Shown:**
+- Pulse run history: last 20 runs, outcome (PASSING/DEGRADED/CRITICAL/AUTO-HEALED), duration
+- Check results grid: 15 named checks × last N runs, color-coded
+- Executor status: active workers, queued tasks, circuit breaker states per domain
+- Event stream: last 50 events with type, actor, severity
+- Metrics: API response times (p50/p95/p99), task throughput (tasks/hour), cost/hour
+- Completeness sentinel: last run, score distribution across entities
+- DB size and backup status
+
+**Interactions:**
+- "Run pulse now" button → on-demand health check
+- "Reset circuit breaker" button per domain
+- "Enable/disable executor" toggle
+- Alert configuration: threshold settings for DEGRADED → notification
+
+**Real-time:** All panels update via WebSocket. Pulse outcomes update immediately. Executor worker count ticks every 10s.
+
+---
+
+## Section 6: Technology Stack Decisions
+
+### 6.1 Frontend Framework: Next.js 14 — Keep
+
+**Decision:** Retain Next.js 14 (App Router).  
+**Rationale:** The dashboard already has 20+ route directories with significant component work. Next.js App Router's server components enable efficient data fetching without client-side boilerplate. The framework is mature, well-supported, and aligned with Cloudflare Pages deployment (via `@cloudflare/next-on-pages`). A migration to another framework (Remix, SvelteKit) would cost 4–6 weeks with no user-facing benefit.  
+**Action needed:** Ensure the dashboard is deployed via `@cloudflare/next-on-pages` worker rather than Node.js server for production.
+
+---
+
+### 6.2 Realtime: Upgrade from WebSocket to Hybrid SSE + WebSocket
+
+**Decision:** Retain WebSocket for bidirectional communication (executor live output, user actions). Add Server-Sent Events (SSE) for unidirectional broadcast (event feeds, status updates).  
+**Rationale:** The current `src/ws/` WebSocket bus works for in-process event forwarding. However, SSE is simpler to implement for read-only streams, has better proxy/CDN support, and automatically reconnects. The split:
+- **WebSocket:** Execution live view (high-frequency, bidirectional)
+- **SSE:** Event feed, pipeline status updates, notification panel (lower frequency, read-only)
+
+**Implementation:** Add `GET /events/stream` SSE endpoint in Hono. Subscribe to the event bus in-process and forward events as `data:` lines. The Next.js dashboard uses `EventSource` for SSE and existing WebSocket client for execution.
+
+---
+
+### 6.3 Database: SQLite for Single-User; Migrate to Turso for Multi-User
+
+**Decision:** Retain SQLite/Drizzle for single-user/local deployments. Add [Turso](https://turso.tech) (libSQL) as the multi-user/cloud tier.  
+**Rationale:** SQLite is excellent for local development and single-user operation — zero-latency, zero-ops, no connection pool. At multi-user or cloud-hosted scale, SQLite's write serialization becomes a bottleneck. Turso provides libSQL-compatible SQLite with distributed reads and is a drop-in swap for `better-sqlite3` via `@libsql/client`. Drizzle ORM already supports libSQL.  
+**Migration path:** Add `DATABASE_URL` env var. If `DATABASE_URL` starts with `libsql://`, use `@libsql/client`; otherwise use `better-sqlite3`. The Drizzle schema requires zero changes.  
+**Action:** No migration needed now. Add Turso support in Phase 4 when multi-user is required.
+
+---
+
+### 6.4 Task Queue: Upgrade from Polling to BullMQ
+
+**Decision:** Migrate from polling to [BullMQ](https://docs.bullmq.io/) (Redis-backed) for the execution queue in production deployments.  
+**Rationale:** The current executor daemon polls `GET /tasks?status=queued` every 10 seconds. This is fine for single-machine, low-throughput use. It breaks for: multiple executor instances, task retries with backoff, rate limiting, job prioritization with Redis sorted sets, and delayed/scheduled execution. BullMQ is the Node.js standard for these requirements.  
+**Migration plan:**
+1. Retain the polling executor as the "lite" mode (default for local/single-user)
+2. Add BullMQ mode behind a feature flag (`EXECUTOR_QUEUE=bullmq`)
+3. The `@caia/scheduler` utility publishes to a BullMQ queue instead of updating task status directly
+4. The executor daemon becomes a BullMQ worker
+5. Redis is required in BullMQ mode — recommend [Upstash Redis](https://upstash.com/) for serverless deployments
+
+**Action:** Plan for Phase 3 (after core pipeline works end-to-end).
+
+---
+
+### 6.5 Local LLM Stack: Ollama with Qwen2.5-Coder
+
+**Decision:** Use [Ollama](https://ollama.ai/) as the local LLM runtime. Primary model: `qwen2.5-coder:7b` for code tasks; `phi4:14b` for reasoning tasks.  
+**Rationale:** Ollama is the de-facto standard for local model serving on macOS (the user's platform). It supports Apple Silicon Metal acceleration, has a well-maintained API compatible with the OpenAI spec, and supports all leading open models. The `qwen2.5-coder` series is the strongest open model for code generation tasks as of 2026, outperforming older CodeLlama variants on most benchmarks. `phi4:14b` (Microsoft, 14B parameters) is excellent for analytical tasks like dependency analysis and requirement clarification.  
+**Hardware:** Qwen2.5-Coder:7B requires ~8GB VRAM (runs well on M2 Pro and above). The 14B variant needs ~16GB unified memory (M2 Max / M3 Pro minimum).
+
+---
+
+### 6.6 Testing Framework: Vitest + Playwright — Keep
+
+**Decision:** Retain Vitest for unit/integration tests and Playwright for E2E.  
+**Rationale:** Both are already configured. Vitest is the modern Jest replacement with native TypeScript support and significantly faster hot-reload. Playwright is the standard for E2E testing with excellent component testing support. No migration value.  
+**Action:** Ensure the test runner utility (`@caia/test-runner`) invokes `vitest run --reporter=json` for machine-readable output and `playwright test --reporter=json` for E2E results.
+
+---
+
+### 6.7 Deployment Targets: Cloudflare Pages + GCP Cloud Run — Confirm with additions
+
+**Decision:** Cloudflare Pages for frontend (Next.js dashboard + static sites); GCP Cloud Run for backend services (CAIA API, executor daemon, auxiliary daemons).  
+**Rationale:** Cloudflare Pages has first-class Next.js support via `@cloudflare/next-on-pages`. It provides a CDN-backed deployment with zero cold starts for the dashboard. GCP Cloud Run provides serverless container execution with automatic scaling to zero — ideal for the CAIA API server which needs persistent WebSocket connections (use Cloud Run's minimum instance = 1 setting).  
+**Additional target:** Add Railway.app as an alternative to GCP for teams that want simpler ops. The `DeploymentProvider` interface in `@caia/deployment-manager` should abstract over both.
+
+---
+
+### 6.8 Monorepo Tooling: pnpm + Turborepo — Keep and Formalise
+
+**Decision:** Retain pnpm workspaces + Turborepo.  
+**Rationale:** The conductor repo uses npm (single package). As CAIA consolidates into a monorepo (`github.com/prakashgbid/caia`), pnpm workspaces + Turborepo are the correct choice for managing the multi-package structure with build caching. Turborepo's remote cache (Vercel or self-hosted) will dramatically speed up CI builds.  
+**Workspace structure recommendation:**
+```
+caia/
+  apps/
+    dashboard/          # Next.js dashboard
+    api-server/         # Hono API + event bus
+    executor/           # Executor daemon
+    pipeline-pulse/     # Health monitor
+    story-backfiller/   # (replace with @caia/decomposer)
+    orchestrator-middleware/
+    completeness-sentinel/
+    db-backup/
+    task-run-poller/
+  packages/
+    event-bus/          # @caia/event-bus
+    events-taxonomy/    # @caia/events-taxonomy
+    logger/             # @caia/logger
+    test-kit/           # @caia/test-kit
+    decomposer/         # @caia/decomposer (new)
+    dag-analyzer/       # @caia/dag-analyzer (new)
+    pr-manager/         # @caia/pr-manager (new)
+    deployment-manager/ # @caia/deployment-manager (new)
+    local-llm-router/   # @caia/local-llm-router (new)
+```
+
+---
+
+### 6.9 Event Bus: Upgrade Path for Multi-Process
+
+**Decision:** Retain in-process EventEmitter for single-process deployments; upgrade to NATS (or Redis Pub/Sub) for multi-process.  
+**Rationale:** The current bus is excellent but single-process. When the executor, API server, and auxiliary daemons are separate processes (the target architecture), events emitted in the executor don't reach WebSocket subscribers in the API server process without an inter-process transport. NATS is the right upgrade:
+- Lightweight (single ~25MB binary)
+- JetStream for at-least-once delivery and event replay (replacing the SQLite outbox for inter-process delivery)
+- Native fan-out matching the picomatch glob pattern
+- The `EventDb` interface in `@caia/event-bus` can be swapped for a NATS JetStream adapter
+
+**Migration path:** The `EventBus` already has an injectable `EventDb` interface. Adding an `EventTransport` abstraction alongside it allows swapping the in-process emit for NATS publish without changing subscriber code.
+
+---
+
+## Section 7: Local LLM Strategy
+
+### 7.1 Task Classification for Local vs Claude
+
+The routing decision between local LLM and Claude is primarily a function of task complexity and required output quality. The following framework governs routing:
+
+#### Must Use Claude
+
+These task types require the full capability of Claude Sonnet or Opus. Using a local model here produces unacceptably degraded output:
+
+- **AI Hierarchy Decomposition** (`@caia/decomposer`): Complex multi-level reasoning, understanding implicit dependencies, respecting project conventions. Requires Claude Sonnet.
+- **Novel multi-file code generation**: Writing code that spans multiple files with coherent shared state, non-trivial business logic, or complex async patterns. Requires Claude Sonnet.
+- **Architecture decisions and ADRs**: Strategic technical decisions require deep reasoning and broad knowledge. Requires Claude Sonnet or Opus.
+- **Complex refactors**: Any task touching more than 5 files with inter-dependent changes. Requires Claude Sonnet.
+- **Security-sensitive code**: Authentication, authorization, cryptography, data sanitization. Requires Claude Sonnet.
+- **Test failure root cause analysis**: Debugging complex multi-layered failures. Requires Claude Sonnet.
+
+#### Good Candidates for Local LLM
+
+These task types produce acceptable quality from local models and run at significantly lower cost and latency:
+
+- **Requirement clarification question generation** (`@caia/clarifier`): Generating 3–5 structured questions from a prompt. Phi4:14b handles this well.
+- **Task enrichment for trivial/simple stories**: Expanding a story title into file paths and function stubs for well-understood patterns. Qwen2.5-Coder:7b.
+- **Boilerplate code generation**: CRUD routes, migration files, interface definitions, barrel exports. Qwen2.5-Coder:7b.
+- **Rename-only tasks**: File renames, variable renames, string find-and-replace. Qwen2.5-Coder:7b (or Haiku).
+- **Test generation for simple functions**: Writing unit tests for pure functions with known inputs/outputs. Qwen2.5-Coder:7b.
+- **Simple summarization**: Generating PR descriptions, commit messages, timeline summaries. Phi4:14b.
+- **Dependency analysis semantic inference**: Detecting file-overlap dependencies (not requiring deep code understanding). Qwen2.5-Coder:7b.
+- **Build error classification**: Classifying a build error as "type error", "missing import", "configuration error". Phi4:14b.
+
+### 7.2 Recommended Local Models (2026)
+
+| Model | Size | Hardware Required | Best For | Quality vs Sonnet |
+|-------|------|------------------|----------|------------------|
+| `qwen2.5-coder:7b` | 7B, ~5GB | M2 Pro (8GB+) | Code generation, boilerplate | 70-75% |
+| `qwen2.5-coder:14b` | 14B, ~10GB | M2 Max (16GB+) | Complex code, moderate refactors | 80-85% |
+| `phi4:14b` | 14B, ~10GB | M2 Max (16GB+) | Reasoning, analysis, summaries | 80% for reasoning |
+| `deepseek-coder-v2:16b` | 16B, ~12GB | M2 Max (16GB+) | Code analysis, review | 82% |
+| `codestral:22b` | 22B, ~16GB | M3 Max (24GB+) | Production-quality code gen | 88% |
+
+**Recommendation for the target hardware (Mac with M-series):**
+- Default config: `qwen2.5-coder:7b` (fast, fits M2 Pro)
+- High-quality config: `qwen2.5-coder:14b` + `phi4:14b` (M2 Max or better)
+
+### 7.3 Routing Logic
+
+The `@caia/local-llm-router` utility implements a policy-based routing decision:
+
+```typescript
+interface RoutingPolicy {
+  // Budget controls
+  monthlyCostLimitUsd: number;
+  currentMonthCostUsd: number;
+  
+  // Quality thresholds
+  minQualityForLocalLLM: 0.7;  // tasks below this complexity threshold go local
+  
+  // User preferences
+  preferLocalWhenAvailable: boolean;
+  alwaysUseClaudeForDomains: string[];  // e.g. ['security', 'data-backend']
+}
+
+function routeTask(task: DispatchTask, policy: RoutingPolicy): RoutingDecision {
+  // Explicit override wins
+  if (task.notes?.model === 'claude') return { type: 'claude', model: selectClaudeModel(task) };
+  if (task.notes?.model === 'local') return { type: 'local', model: 'qwen2.5-coder:7b' };
+  
+  // Security-sensitive domains always use Claude
+  if (policy.alwaysUseClaudeForDomains.includes(task.domainSlug)) 
+    return { type: 'claude', model: 'claude-sonnet-4-6' };
+  
+  // Budget exceeded → route everything possible to local
+  if (policy.currentMonthCostUsd >= policy.monthlyCostLimitUsd)
+    return localIfCapable(task) ?? { type: 'claude', model: 'claude-haiku-4-5-20251001' };
+  
+  // Complexity-based routing
+  const complexity = estimateComplexity(task);
+  if (complexity < 0.4 && policy.preferLocalWhenAvailable)
+    return { type: 'local', model: complexity < 0.2 ? 'qwen2.5-coder:7b' : 'qwen2.5-coder:14b' };
+  
+  return { type: 'claude', model: selectClaudeModel(task) };
+}
+```
+
+### 7.4 Integration Pattern
+
+The local LLM integrates as a drop-in replacement via the Ollama API's OpenAI-compatible endpoint:
+
+- Ollama exposes `http://localhost:11434/v1` (OpenAI-compatible)
+- The `@caia/executor` replaces `claude --print` with a direct API call when routing to local
+- Response is normalized to the same `ExecutionOutput` interface
+- The `[result] DONE/FAILED` protocol is identical — the prompt template is unchanged
+- Cost tracking: local model runs have `costUsd = 0` in `executor_runs`
+
+**Constraint:** Local LLMs cannot use the Claude Code tool (`claude --print`) and cannot access `claude`'s built-in tools (bash, file I/O). Local model execution must use the Anthropic-compatible tool-use API via the SDK, with CAIA-provided tool implementations. This is a significant integration lift — recommend implementing local LLM support after the core pipeline is working end-to-end (Phase 6).
+
+---
+
+## Section 8: Gap Analysis — Vision vs Current State
+
+| Component | Vision | Current State | Gap Size | Priority |
+|-----------|--------|---------------|----------|----------|
+| Prompt intake GUI | Rich text area with options, project selector, priority hint | Route `/prompts/new` may exist as skeleton | Medium | P0 |
+| AI Hierarchy Decomposer | Full Initiative→Epic→Module→Story tree from single prompt | `story-backfiller`: creates 1 flat Epic per requirement, no AI | **Large** | **P0** |
+| Requirement Clarifier | AI proactively asks clarifying questions before decomposition | Questions table + kanban exist; no AI clarifier agent | Medium | P1 |
+| Task Enrichment | Detailed specs with file paths, function signatures, test cases | No enricher; stories created with minimal metadata | Large | P1 |
+| Dependency Analysis (DAG) | Full DAG with cycle detection, parallel batches, critical path | `dependsOn` fields exist; no DAG utility | Medium | P1 |
+| Story→Task Bridge | Scheduler creates Tasks from Stories after decomposition | Manual task creation only; no automatic Story→Task bridge | Large | P0 |
+| Executor | Spawns Claude Code workers with worktrees, circuit breaking | Fully implemented and production-grade | None | — |
+| Priority Scoring | Multi-dimensional composite scorer (0-100) | Fully implemented (7 dimensions, P0-P3 buckets) | None | — |
+| PR Creation | GitHub PR from worktree, AI review, status tracking | **Missing** | **Large** | **P1** |
+| Test Runner | Auto-run Vitest + Playwright after task completion | Tables exist; no runner daemon | Medium | P1 |
+| Build Verification | Auto-run build pipeline, AI error diagnosis | Schema + script exist; not integrated into pipeline | Medium | P1 |
+| Deployment (Staging) | Cloudflare Pages / GCP deploy, health verify | **Missing** | **Large** | **P2** |
+| Human Acceptance Gate | Structured review UI, approve/reject, re-queue on reject | **Missing** | **Large** | **P2** |
+| Production Release | Merge PR, production deploy, tag release | **Missing** | **Large** | **P2** |
+| Observability Closeout | Final metrics, cost summary, prompt marked completed | Partial: stage tracking exists; no closeout utility | Small | P3 |
+| Event Bus | Typed, persisted, glob-subscribed, replay-capable | Fully implemented | None | — |
+| Timeline Recorder | Human-readable activity feed | Tables + component exist | None | — |
+| Completeness Verifier | File/URL/test evidence checks on completed work | Implemented as external plugin | None | — |
+| Pipeline Pulse | 3-layer health check with auto-heal | Fully implemented | None | — |
+| Orchestrator Middleware | Banned phrases, prompt tracing, task-run acknowledgement | Fully implemented | None | — |
+| Local LLM Router | Policy-based Claude vs local routing, Ollama integration | Partial: Claude model routing exists; no Ollama | Large | P3 |
+| Streaming Execution Output | Live tool calls + output in dashboard | Output captured at end only; no real-time streaming | Medium | P2 |
+| Dashboard: Prompt Waterfall | Full accordion drill-down from prompt to subtask | Route + API (`/prompts/[id]/pipeline`) exist; UI incomplete | Medium | P1 |
+| Dashboard: Acceptance Review | Staging preview, criteria checklist, approve/reject | Missing | Large | P2 |
+| Dashboard: Live Execution | Real-time output stream, subtask list, tool calls | Skeleton exists; no live data | Medium | P2 |
+| GitHub Integration | PR creation, status tracking, merge | **Missing** | **Large** | **P1** |
+| Cloudflare/GCP Deploy | Automated deployment to staging + production | **Missing** | **Large** | **P2** |
+| Multi-user Support | Multiple users, per-user cost tracking, access control | Single-user SQLite; no auth | Large | P4 |
+| Local LLM (Ollama) | Route tasks to local models; cost reduction | No Ollama integration | Large | P3 |
+
+---
+
+## Section 9: Implementation Phases
+
+### Phase 1: Foundation Hardening (Weeks 1–3)
+
+**Goal:** Everything that exists must be solid, tested, and documented before building on top. Close technical debt before adding features.
+
+**Deliverables:**
+1. **Monorepo migration:** Confirm all `conductor` code is correctly placed in the CAIA monorepo at `apps/orchestrator/` and `packages/`. Verify all imports and builds pass.
+2. **`stories` table: add `initiative` kind:** Migrate the `kind` enum to include `initiative`. Add the `prompt_pipeline_stages` tracking for all 14 pipeline stages defined in Section 3.
+3. **Event taxonomy extension:** Add missing event types: `prompt.clarification_started/completed`, `pipeline.dag_computed`, `pr.created/merged`, `deployment.started/completed`, `human.acceptance_requested/granted/rejected`, `release.completed`, `prompt.completed`.
+4. **Test coverage gate:** Ensure unit test coverage ≥ 80% on `packages/event-bus`, `packages/events-taxonomy`, `src/prioritization/`, `apps/orchestrator-middleware/`. Enforce via the existing `gate:coverage` script.
+5. **API contract documentation:** Document all existing `/prompts`, `/stories`, `/tasks`, `/executor` routes with TypeScript request/response types. This becomes the contract for the new utilities.
+6. **Executor streaming:** Modify `apps/executor/dispatcher.ts` to POST `outputLines` to `POST /task-runs/{id}/output` as they arrive. Add SSE endpoint `GET /task-runs/{id}/stream` in the API server. This unblocks the Live Execution dashboard view.
+
+**Dependencies:** None.  
+**Risk:** Monorepo migration may surface hidden import issues. Run full build + test suite before marking complete.
+
+---
+
+### Phase 2: Core Pipeline — Ingestion Through Scheduling (Weeks 4–7)
+
+**Goal:** A user can submit a prompt and get a fully decomposed, enriched, scheduled task queue without any manual intervention.
+
+**Deliverables:**
+1. **`@caia/clarifier` utility:** AI-powered question generation. Subscribe to `prompt.ingested`, classify clarity score, generate questions if `score < 0.85`. Surface questions in the `QuestionsKanban` dashboard. Emit `prompt.clarification_completed` when all critical questions are answered (or immediately if `canSkip: true`).
+2. **`@caia/decomposer` utility:** The flagship new component. Two-phase decomposition: Initiative+Epic+Module (phase 1, single Sonnet call) followed by Stories per Module (phase 2, parallel Haiku/Sonnet calls). Use Anthropic's structured output API. Write all nodes to `stories` table with `rootPromptId` linkage. Emit `pipeline.decompose_completed`.
+3. **`@caia/enricher` utility:** Subscribe to `pipeline.decompose_completed`. For each leaf Story, call Claude (Haiku/Sonnet by complexity) to produce the detailed implementation spec. Store enriched spec in `stories.description` + a new `enriched_spec_json` column.
+4. **`@caia/dag-analyzer` utility:** Implement Kahn's algorithm for topological sort of the story DAG. Detect file-overlap implicit dependencies. Validate no cycles. Write `parallel_batch` assignments to a new `stories.parallel_batch` column. Emit `pipeline.dag_computed`.
+5. **Story→Task Bridge:** After `pipeline.dag_computed`, automatically create `tasks` rows from `stories` leaf nodes with correct `dependsOn`, `priorityBucket`, `positionOrdinal`, `rootPromptId` linkage. This is the connection between the decomposition world (stories) and the execution world (tasks).
+6. **Dashboard: Prompt Waterfall:** Complete the `/prompts/[id]` accordion drill-down view. Wire it to the existing `/prompts/:id/pipeline` API endpoint. Add real-time WebSocket updates.
+
+**Dependencies:** Phase 1 complete.  
+**Risk:** Decomposer output quality is the highest risk. Mitigate with extensive prompt engineering and structured output schema validation. Build an evaluation suite of 10 representative prompts and score decomposition quality before shipping.
+
+---
+
+### Phase 3: Execution Hardening & Testing Automation (Weeks 8–11)
+
+**Goal:** Close the execution loop: tasks run, tests run automatically after completion, build is verified, results are surfaced clearly.
+
+**Deliverables:**
+1. **BullMQ task queue (optional):** Add BullMQ mode behind `EXECUTOR_QUEUE=bullmq` flag. Retain polling as default. This enables multiple executor instances and proper retry backoff.
+2. **`@caia/test-runner` daemon:** Subscribe to `task.completed`. Identify affected test files using vitest's `--related` flag scoped to `filesChanged`. Run tests. Parse JSON results. Update `behavior_test_runs`. Create blockers for failures. Emit `pipeline.tests_completed`.
+3. **`@caia/build-verifier` daemon:** Subscribe to `pipeline.tests_completed` (if tests pass). Run the configured build command sequence. Capture step output. Persist to `build_runs`/`build_steps`. On failure: invoke Claude Sonnet for diagnosis, create a fix task. Emit `build.completed`.
+4. **Streaming execution output (Phase 2 follow-through):** Complete the Live Execution dashboard view with real-time output and subtask list.
+5. **Dashboard: Test Results view:** Complete the `/tests` route with pass/fail history, flake detection, and the run trigger button.
+6. **Dashboard: Builds view:** Complete the `/builds` route with step-by-step output, retry controls, and AI error diagnosis display.
+7. **Pulse improvements:** Add new pulse checks for: decomposer health (can it decompose a sample prompt?), test runner health (can it run a canary test?), build verifier health.
+
+**Dependencies:** Phase 2 complete.  
+**Risk:** Test runner false failures (flaky tests blocking pipeline). Implement the flake classifier early. Also: build commands vary per project — make the build step config driven (stored in `projects` table).
+
+---
+
+### Phase 4: Deployment & Human Acceptance (Weeks 12–15)
+
+**Goal:** A fully automated path from passing tests to a live staging URL ready for human review.
+
+**Deliverables:**
+1. **`@caia/pr-manager` utility:** Subscribe to `build.completed`. Push the worktree branch to GitHub. Create a PR with AI-generated description. Run AI code review (Claude Sonnet). Post review comments. Track PR status in a new `pull_requests` table. Emit `pr.created`.
+2. **GitHub integration:** Configure `@octokit/rest`. Add `github_token` to the project settings (stored encrypted). Add the repository URL to the `projects` table.
+3. **`@caia/deployment-manager` utility:** Subscribe to `pr.created`. Deploy the worktree build to Cloudflare Pages (staging environment). Verify deployment health. Emit `deployment.completed`.
+4. **`@caia/acceptance-gate` utility:** Subscribe to `deployment.completed`. Trigger Claude Sonnet to generate the acceptance report. Create a notification. Wait for human decision via `POST /prompts/:id/accept` or `/reject`. Emit `human.acceptance_granted` or `human.acceptance_rejected`.
+5. **`@caia/release-manager` utility:** Subscribe to `human.acceptance_granted`. Merge the PR via GitHub API. Trigger production deployment via Cloudflare Pages. Verify production health. Emit `release.completed`.
+6. **Dashboard: Human Acceptance view:** Complete the `/prompts/[id]/review` route with staging preview, acceptance criteria checklist, approve/reject buttons.
+7. **Dashboard: Deployment Status view:** Complete the `/deployments` route.
+8. **Observability Closeout:** On `release.completed`, compute final metrics and mark the prompt as `completed`. Emit `prompt.completed`.
+9. **Database: Turso libSQL support:** Add `DATABASE_URL` env var support with `@libsql/client`. Enables cloud-hosted CAIA instances.
+
+**Dependencies:** Phase 3 complete.  
+**Risk:** GitHub API rate limits for prolific prompt runs. Implement exponential backoff in `@caia/pr-manager`. Also: Cloudflare Pages project setup must be done once per target project — add to the project onboarding flow.
+
+---
+
+### Phase 5: Dashboard Completion (Weeks 16–18)
+
+**Goal:** The dashboard is fully functional for all pipeline stages. A non-technical user can track, review, and control the full pipeline without touching a terminal.
+
+**Deliverables:**
+1. Complete all incomplete dashboard views from Section 5.
+2. **Notification system:** Add a notification panel (bell icon, top-right). When staging is ready, send an in-app notification and optional email/Slack webhook. Uses the `notifications/index.ts` system that already exists.
+3. **Settings page completion:** Project configuration (GitHub token, Cloudflare token, GCP credentials, executor settings, build commands).
+4. **Mobile-responsive layout:** Ensure the prompt waterfall and observability views work on tablet/mobile for reviewing from staging.
+5. **Keyboard shortcuts:** Power-user shortcuts for common actions (submit prompt, navigate between stages, approve/reject).
+6. **Prompt history:** Full-text search across all prompts and their descendants.
+
+**Dependencies:** Phases 1–4 complete (all data sources must exist for the views to render).  
+**Risk:** Low. This is UI polish work with known data shapes. Primary risk is design inconsistency — recommend using a design system (shadcn/ui, already referenced in the artifact system) consistently.
+
+---
+
+### Phase 6: Local LLM Integration (Weeks 19–21)
+
+**Goal:** Reduce Claude API costs by 40–60% by routing appropriate tasks to local Ollama models.
+
+**Deliverables:**
+1. **`@caia/local-llm-router` utility:** Implement the routing policy from Section 7. Configuration via the Settings page (monthly budget, prefer-local toggle, domain exclusions).
+2. **Ollama integration in executor:** When the router returns `{ type: 'local' }`, invoke the Ollama OpenAI-compatible API with CAIA's tool implementations (bash, file read/write) instead of `claude --print`.
+3. **Tool implementation for local LLMs:** Implement a lightweight tool execution loop: send prompt to Ollama API, parse tool calls, execute tools, send results back, loop until `[result]` marker. This is the non-trivial part — it's reimplementing what `claude --print` does internally.
+4. **Cost dashboard:** Add cost breakdown by model (Claude Haiku/Sonnet/Opus vs local) to the Observability dashboard. Show 30-day cost trend and monthly projection.
+5. **Quality feedback loop:** After each local LLM task, record `resultOk` and `completenessScore`. If local model success rate on a task type drops below 70%, automatically escalate to Claude next time.
+
+**Dependencies:** Phase 4 complete (full pipeline working; cost data available).  
+**Risk:** Local LLM tool execution is complex to implement correctly. The tool calling API behavior differs between models. Recommend starting with a subset of tool-safe tasks (bash exec, file write) before enabling for all task types.
+
+---
+
+### Phase 7: Open-Source Extraction (Weeks 22–24)
+
+**Goal:** Extract the most universally useful utilities as standalone, independently publishable npm packages.
+
+**Deliverables:**
+See Section 10 for the full extraction plan. Each extraction involves:
+1. Remove CAIA-specific dependencies from the utility's core logic
+2. Define a clean public API with no internal DB or event bus coupling
+3. Add comprehensive documentation (README + JSDoc)
+4. Set up independent CI/CD for the package
+5. Publish to npm under `@caia/` scope
+
+**Dependencies:** Phase 5 complete (utilities must be stable before extraction).
+
+---
+
+## Section 10: Open Source Strategy
+
+The following utilities have the highest potential as independently useful open-source packages. Viability is assessed on: (1) generality beyond CAIA's specific use case, (2) minimal external dependencies, (3) completeness of the abstraction.
+
+---
+
+### `@caia/event-bus`
+
+**Package name:** `@caia/event-bus`  
+**Problem it solves:** A typed, durable, glob-subscribed event bus for Node.js applications. Most applications either use basic EventEmitter (no persistence, no typed events) or heavy message brokers (Kafka, RabbitMQ — massive operational overhead). `@caia/event-bus` fills the middle ground: in-process delivery with SQLite durability, at essentially zero operational cost.  
+**Dependencies to shed:** The event type and payload types (which are CAIA-specific) must be parameterized. The `ConductorEvent` type becomes a generic `Event<T>`. The `EventDb` interface is already clean.  
+**Standalone interface:**
+```typescript
+// @caia/event-bus (standalone)
+import { createEventBus } from '@caia/event-bus';
+const bus = createEventBus<MyEventRegistry>({ dbPath: './events.sqlite' });
+bus.publish({ type: 'user.created', payload: { id: '123' }, actor: 'api' });
+bus.subscribe('user.*', (event) => console.log(event));
+```
+**Licensing:** MIT  
+**Estimated extraction effort:** 1 week  
+
+---
+
+### `@caia/executor`
+
+**Package name:** `@caia/claude-executor`  
+**Problem it solves:** A production-grade executor for `claude --print` (Claude Code headless mode) with: git worktree lifecycle management, circuit breaking on consecutive failures, tiered model selection (Haiku/Sonnet/Opus by task complexity), crash recovery on restart, and structured output parsing. No existing package provides this — every team building on Claude Code reinvents it.  
+**Dependencies to shed:** Remove CAIA API calls (replace with injected callbacks). The DB registration (`registerExecutorRun`) becomes an optional hook. The prompt builder should be injectable.  
+**Standalone interface:**
+```typescript
+// @caia/claude-executor (standalone)
+import { ClaudeExecutor } from '@caia/claude-executor';
+const executor = new ClaudeExecutor({
+  worktreeBaseDir: '~/.claude/worktrees',
+  maxConcurrent: 3,
+  circuitBreakerThreshold: 3,
+  onTaskComplete: async (result) => { /* your handler */ },
+});
+executor.dispatch({ id: 'task-1', title: 'Add login button', cwd: '/my/project', prompt: '...' });
+```
+**Licensing:** MIT  
+**Estimated extraction effort:** 2 weeks  
+
+---
+
+### `@caia/dag-analyzer`
+
+**Package name:** `@caia/task-dag`  
+**Problem it solves:** Build, validate, and schedule a directed acyclic graph of AI tasks. Given a list of tasks with `dependsOn` references, produce topological batches for maximum parallelism, detect cycles, and compute the critical path. Broadly useful for any multi-agent workflow orchestration.  
+**Dependencies to shed:** Zero external dependencies except TypeScript types. The file-overlap detection is CAIA-specific and should be moved to an extension point.  
+**Licensing:** MIT  
+**Estimated extraction effort:** 1 week  
+
+---
+
+### `@caia/decomposer`
+
+**Package name:** `@caia/requirement-decomposer`  
+**Problem it solves:** Given a natural-language software requirement and project context, use Claude to produce a structured, hierarchical breakdown into independently executable work units. Solves the hardest problem in AI-driven development automation.  
+**Dependencies to shed:** The decomposer's output schema (Initiative/Epic/Module/Story) needs to be parameterized for other hierarchical frameworks (e.g. Jira epics/stories/tasks). The project context interface needs generalization.  
+**Licensing:** Apache 2.0 (more appropriate for commercial use — encourages adoption while maintaining attribution)  
+**Estimated extraction effort:** 3 weeks (after the utility is stable in CAIA)  
+
+---
+
+### `@caia/observability-monitor`
+
+**Package name:** `@caia/pipeline-pulse`  
+**Problem it solves:** A three-layer health monitoring system for AI-driven pipelines: synthetic canary (end-to-end task execution), state invariant checks (db consistency), and micro-probes (per-stage health). Includes auto-healing for common failure modes. Currently no standard exists for monitoring AI coding agent pipelines.  
+**Dependencies to shed:** The specific check implementations (which hit CAIA's API endpoints) must be made injectable. The canary implementation (which dispatches a real Claude task) must be abstracted.  
+**Licensing:** MIT  
+**Estimated extraction effort:** 2 weeks  
+
+---
+
+### `@caia/completeness-verifier`
+
+**Package name:** `@caia/completeness-sentinel`  
+**Problem it solves:** Verify that AI-generated work is actually complete, not just "completed" in status. Checks: file exists at declared path, URL returns expected status code, test passes, commit SHA is reachable. Prevents the common failure mode of AI agents marking tasks done without evidence.  
+**Dependencies to shed:** Already exists as a semi-independent plugin. Needs a clean configuration interface.  
+**Licensing:** MIT  
+**Estimated extraction effort:** 1 week  
+
+---
+
+### Open-Source Ecosystem Positioning
+
+The recommended sequencing for open-sourcing:
+
+1. **First:** `@caia/event-bus` and `@caia/task-dag` — lowest coupling, immediately useful to the Node.js AI agent community
+2. **Second:** `@caia/claude-executor` — highest impact; solves a universal problem for Claude Code users
+3. **Third:** `@caia/pipeline-pulse` and `@caia/completeness-sentinel` — operational utilities that complement the executor
+4. **Last:** `@caia/requirement-decomposer` — most powerful but most opinionated; wait until the decomposer is proven in production
+
+Each open-source package should be published with:
+- A companion blog post explaining the problem and design decisions
+- A minimal standalone example (not requiring the full CAIA platform)
+- Clear contribution guidelines
+- A link back to the CAIA platform as the reference implementation
+
+---
+
+## Appendix A: Database Migration Roadmap
+
+The following new migrations are required beyond the existing 15:
+
+| Migration | Purpose |
+|-----------|---------|
+| `0016_initiative_kind.sql` | Add `initiative` to `stories.kind` enum |
+| `0017_story_enrichment.sql` | Add `enriched_spec_json` and `parallel_batch` columns to `stories` |
+| `0018_pull_requests.sql` | New `pull_requests` table for PR tracking |
+| `0019_deployments.sql` | New `deployments` table for staging/production deployment records |
+| `0020_acceptance_reviews.sql` | New `acceptance_reviews` table for human review decisions |
+| `0021_releases.sql` | New `releases` table for production release records |
+| `0022_local_llm_routing.sql` | Add `routing_decision` and `local_model` columns to `executor_runs` |
+
+---
+
+## Appendix B: Event Taxonomy Extensions
+
+New events to add to `packages/events-taxonomy/registry.yaml`:
+
+```yaml
+# Clarification
+- type: prompt.clarification_started
+  severity: info
+  actor: [clarifier]
+  payload: [prompt_id, clarity_score, question_count]
+
+- type: prompt.clarification_completed
+  severity: info
+  actor: [clarifier, user]
+  payload: [prompt_id, answers_count]
+
+# DAG
+- type: pipeline.dag_computed
+  severity: info
+  actor: [dag-analyzer]
+  payload: [prompt_id, story_count, parallel_batch_count, critical_path_length]
+
+# PR
+- type: pr.created
+  severity: info
+  actor: [pr-manager]
+  payload: [pr_number, pr_url, task_id, head_branch, review_passed]
+
+- type: pr.merged
+  severity: info
+  actor: [release-manager]
+  payload: [pr_number, merge_commit_sha, merged_by]
+
+# Deployment
+- type: deployment.started
+  severity: info
+  actor: [deployment-manager]
+  payload: [deployment_id, environment, target, project_slug]
+
+- type: deployment.completed
+  severity: info
+  actor: [deployment-manager]
+  payload: [deployment_id, staging_url, duration_ms, health_check_status_code]
+
+- type: deployment.failed
+  severity: error
+  actor: [deployment-manager]
+  payload: [deployment_id, environment, error]
+
+# Human Acceptance
+- type: human.acceptance_requested
+  severity: info
+  actor: [acceptance-gate]
+  payload: [prompt_id, staging_url, pr_url]
+
+- type: human.acceptance_granted
+  severity: info
+  actor: [user]
+  payload: [prompt_id, decided_by, feedback]
+
+- type: human.acceptance_rejected
+  severity: warning
+  actor: [user]
+  payload: [prompt_id, decided_by, feedback, requeue_story_ids]
+
+# Release
+- type: release.started
+  severity: info
+  actor: [release-manager]
+  payload: [prompt_id, pr_number]
+
+- type: release.completed
+  severity: info
+  actor: [release-manager]
+  payload: [prompt_id, merge_commit_sha, production_url, release_tag]
+
+# Prompt completion
+- type: prompt.completed
+  severity: info
+  actor: [system]
+  payload: [prompt_id, total_duration_ms, total_cost_usd, stories_delivered, files_changed_count]
+```
+
+---
+
+## Appendix C: Recommended Third-Party Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@octokit/rest` | ^20.0 | GitHub PR creation and management |
+| `@libsql/client` | ^0.6 | Turso libSQL multi-user DB |
+| `bullmq` | ^5.0 | Redis-backed task queue (optional) |
+| `ioredis` | ^5.0 | Redis client for BullMQ |
+| `@cloudflare/next-on-pages` | ^1.0 | Dashboard deployment to Cloudflare Pages |
+| `wrangler` | ^3.0 | Cloudflare Pages CLI for deployment |
+| `@google-cloud/run` | ^0.9 | GCP Cloud Run deployment API |
+| `nats` | ^2.0 | NATS messaging (for multi-process event bus) |
+| `zod` | ^3.0 | Runtime schema validation for AI outputs |
+| `ai` | ^3.0 | Vercel AI SDK (unified interface for Claude + Ollama) |
+
+---
+
+*This document is authoritative for the CAIA platform architecture as of April 2026. It should be updated as implementation decisions are made and phases are completed. All section numbers, utility names, and event types defined here are canonical — use them consistently across code, documentation, and team communication.*

--- a/docs/legacy-conductor-reports/enforcement-hardening-summary.md
+++ b/docs/legacy-conductor-reports/enforcement-hardening-summary.md
@@ -1,0 +1,171 @@
+# Enforcement Hardening Summary
+
+**Branch:** `enforce/memory-hardening-v1`  
+**Date:** 2026-04-22T06:09:49Z  
+**Build:** 2–4h implementation pass converting memory rules → mechanical guardrails
+
+---
+
+## Numbers
+
+| Metric | Count |
+|--------|-------|
+| Total rules inventoried | 357 |
+| Converted to mechanical enforcement | 47 |
+| Tagged advisory (judgment-based) | 98 |
+| Enforcement gaps documented | 212 |
+| Violations found during implementation | 2 (P0 blockers filed) |
+| New gates added to build-runner | 3 |
+| New pre-commit gate additions | 2 |
+| Contract tests written | 69 |
+| Contract test files | 5 |
+| Dashboard page created | 1 (`/enforcement`) |
+| CI workflow created | 1 (`gate:memory-rule-enforceable`) |
+| DB migration created | 1 (0013) |
+
+---
+
+## Violations Found During Implementation (K=2)
+
+### V-001 — DOM-001 Trigger Blocked 53 Tests (P0 BLOCKER)
+- **Rule:** DOM-001 — every entity must have domain tags
+- **Violation:** 53 existing test fixtures insert tasks without `domain_slug`
+- **Action:** DOM-001 DB trigger deferred; blocker `BL-DOM001-FIXTURE-BACKFILL` filed
+- **Deferred enforcement:** test fixture backfill required across 6 test files
+
+### V-002 — HEALTH-009 NOT NULL Too Aggressive (P0 BLOCKER)
+- **Rule:** HEALTH-009 — zero tasks with null `root_prompt_id`
+- **Violation:** `executor-routes.test.ts` + `priority-routes.test.ts` (29 fixtures) insert tasks without `root_prompt_id`
+- **Action:** Downgraded from NOT NULL to DEFAULT 'untraced'; partial enforcement
+- **Partial enforcement:** `schema.ts` `.default('untraced')` ensures new ORM inserts get the default; NOT NULL deferred until test backfill
+
+---
+
+## New Enforcement Mechanisms
+
+### Pre-commit Hook Additions (`.githooks/pre-commit`)
+
+| Gate | Rule | What it checks |
+|------|------|----------------|
+| `gate:no-env-writes` | SEC-052 | Blocks staging `.env*` files |
+| `gate:decision-autonomy` | AUTON-001 | Scans staged TS/JS for banned phrases in string literals |
+
+### Build-Runner Gates Added (`scripts/build-runner.sh`)
+
+| Gate | Rule | Status |
+|------|------|--------|
+| `gate:supply-chain` | SEC-050 | Active — `npm audit --production --audit-level=high` |
+| `gate:a11y` | ACCESS-035 | Stub — requires `@axe-core/playwright` install to activate |
+| `gate:brand-lock` | POKE-001 | Stub — activates in pokerzeno repo |
+
+### Runtime Middleware (`apps/orchestrator-middleware/`)
+
+New package with three enforcement modules:
+
+| Module | Rules | What it enforces |
+|--------|-------|-----------------|
+| `banned-phrases.ts` | AUTON-001/002/006/007/008 | Scans outbound messages for 12 forbidden patterns |
+| `task-run-logger.ts` | TASK-001/002/003/004 | Tracks task spawns, detects missing `task_run_record` calls |
+| `prompt-creator.ts` | TRACE-001/002/003/009 | Ensures `prompt_create` is called before decomposition; deduplicates by hash within 10s |
+
+Exports `createOrchestrationGuard()` factory combining all three.
+
+### DB Migration (`src/db/migrations/0013_health009_dom001.sql`)
+
+- Backfills `tasks.root_prompt_id = 'untraced'` for all NULL rows
+- Rebuilds tasks table with `root_prompt_id TEXT DEFAULT 'untraced'` (HEALTH-009 partial)
+- Recreates all 6 task indexes
+- DOM-001 trigger deferred (see V-001 above)
+
+**Schema change:** `src/db/schema.ts` — added `.default('untraced')` to `rootPromptId` field so Drizzle ORM uses the default on new inserts.
+
+### Contract Tests (`tests/contracts/`)
+
+| File | Contract | Tests |
+|------|----------|-------|
+| `banned-phrases.contract.test.ts` | AUTON-001/002/006/007/008 | 19 |
+| `task-run-logger.contract.test.ts` | TASK-001 | 10 |
+| `prompt-creator.contract.test.ts` | TRACE-001/002/003 | 14 |
+| `pre-commit-gate.contract.test.ts` | SEC-052 | 16 |
+| `orchestration-guard.contract.test.ts` | Integration | 10 |
+| **Total** | | **69 tests** |
+
+All 69 tests pass. Full suite: **535/535 pass**.
+
+### Enforcement Dashboard (`dashboard/app/enforcement/`)
+
+New page at `/enforcement` showing:
+- KPI cards: total / enforced / advisory / gap / violations-7d
+- Mechanism breakdown bar chart
+- Most-violated rule leaderboard
+- Searchable/filterable full rule table with status badges
+
+Added to dashboard nav (`dashboard/app/layout.tsx`).
+
+### CI Meta-Enforcement (`.github/workflows/memory-rule-enforceable.yml`)
+
+Runs on every PR touching `.auto-memory/**/*.md`:
+1. Extracts new rule lines containing imperative keywords
+2. Fails merge if `reports/memory-rule-inventory.md` was not updated
+3. Fails merge if `advisory: true` is set without `advisory_reason`
+
+Local script: `scripts/check-memory-rule-enforceable.sh`
+
+### Advisory Tagging
+
+Two fully-advisory memory files tagged:
+- `away_mode.md` — `advisory: true` (operational tone/silence protocol)
+- `learnings.md` — `advisory: true` (operational judgment learnings, no static analysis possible)
+
+---
+
+## Rule Inventory
+
+Full inventory at `reports/memory-rule-inventory.md`
+
+**By mechanism:**
+
+| Mechanism | Count |
+|-----------|-------|
+| build-runner-gate | 14 |
+| pre-commit-hook | 6 |
+| runtime-middleware | 8 |
+| db-constraint | 2 (partial) |
+| contract-test | 5 |
+| daemon | 4 |
+| advisory | 98 |
+| gap (implementation deferred) | 212 |
+
+**By source file (top gaps):**
+
+| File | Total | Enforced | Advisory | Gap |
+|------|-------|----------|----------|-----|
+| accessibility_lock.md | 45 | 1 | 0 | 44 |
+| secrets_hyper_security.md | 55 | 8 | 0 | 47 |
+| pipeline_pulse_utility.md | 40 | 0 | 40 | 0 |
+| learnings.md | 53 | 0 | 53 | 0 |
+| away_mode.md | 12 | 0 | 12 | 0 |
+| decision_autonomy.md | 11 | 4 | 1 | 6 |
+| task_run_log_protocol.md | 12 | 4 | 0 | 8 |
+| prompt_traceability.md | 9 | 3 | 0 | 6 |
+
+---
+
+## Dashboard
+
+`/enforcement` page available when dashboard is running at `http://localhost:7777/enforcement`.
+
+No screenshot path available (dashboard not running in this session).
+
+---
+
+## New Gates List
+
+```
+gate:no-env-writes     (pre-commit)
+gate:decision-autonomy (pre-commit)
+gate:supply-chain      (build-runner, active)
+gate:a11y              (build-runner, stub — activate with axe-core)
+gate:brand-lock        (build-runner, stub — activates in pokerzeno repo)
+gate:memory-rule-enforceable (CI — runs on .auto-memory PR changes)
+```

--- a/docs/legacy-conductor-reports/memory-rule-inventory.md
+++ b/docs/legacy-conductor-reports/memory-rule-inventory.md
@@ -1,0 +1,519 @@
+# Memory Rule Inventory
+Generated: 2026-04-22
+Total rules: 357
+Mechanically enforced: 42
+Advisory: 67
+Gap (needs new enforcement): 248
+
+---
+
+## Legend
+
+| Column | Meaning |
+|--------|---------|
+| `rule_id` | Unique identifier for the rule |
+| `memory_file` | Source memory/rule file the rule originates from |
+| `rule_text` | The full rule statement |
+| `current_enforcement` | What already exists in the codebase that enforces this rule |
+| `enforcement_gap` | What is missing or incomplete |
+| `proposed_mechanism` | The type of enforcement needed: `pre-commit-hook`, `build-runner-gate`, `eslint-rule`, `db-constraint`, `runtime-middleware`, `contract-test`, `daemon`, or `advisory` |
+| `proposed_implementation` | One-line description of the concrete change needed |
+
+---
+
+## Enforcement Status Key
+
+- **ENFORCED** — rule is actively blocked/checked by an existing automated mechanism
+- **PARTIAL** — some enforcement exists but does not fully cover the rule
+- **NONE** — no automated enforcement exists today
+- **ADVISORY** — rule requires runtime AI judgment; mechanical enforcement is not feasible
+
+---
+
+## Rules by Memory File
+
+### ACCESS — Accessibility Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| ACCESS-001 | memory/accessibility.md | WCAG 2.2 Level AA is the minimum standard on every page. | NONE | No axe-core or Lighthouse check in CI | build-runner-gate | Add `gate:a11y` step in build-runner.sh that runs axe-core via Playwright on all top-level routes |
+| ACCESS-002 | memory/accessibility.md | Aim for WCAG 2.2 Level AAA where possible. | NONE | No AAA audit in CI | advisory | Document AAA targets in checklist; enforce AA mechanically (see ACCESS-001) |
+| ACCESS-003 | memory/accessibility.md | Lighthouse Accessibility score must be ≥ 95 on every top-level route. | NONE | No Lighthouse CI step | build-runner-gate | Add Lighthouse CI step in `gate:a11y` that asserts score ≥ 95 per route |
+| ACCESS-004 | memory/accessibility.md | Axe-core automated audit must report zero critical or serious violations per page. | NONE | No axe-core step in build-runner.sh | build-runner-gate | Run `@axe-core/playwright` in `gate:a11y`; fail if any critical/serious violation found |
+| ACCESS-005 | memory/accessibility.md | Every page must have one h1 element. | NONE | No structural HTML check in CI | build-runner-gate | Add DOM assertion in Playwright a11y suite checking single h1 per page |
+| ACCESS-006 | memory/accessibility.md | Every page must use semantic HTML with proper header/main/nav/footer/section tags. | NONE | No semantic HTML lint rule | eslint-rule | Add eslint-plugin-jsx-a11y rule requiring semantic structure; add to `gate:a11y` check |
+| ACCESS-007 | memory/accessibility.md | Every interactive element must be reachable via Tab key and activatable via Enter/Space. | NONE | No keyboard-nav test in CI | contract-test | Add Playwright keyboard-nav test suite asserting tab/enter/space on all interactive elements |
+| ACCESS-008 | memory/accessibility.md | Every page must have a skip-to-content link at the top. | NONE | No skip-link assertion in CI | build-runner-gate | Assert presence of `#skip-to-content` link in `gate:a11y` Playwright suite |
+| ACCESS-009 | memory/accessibility.md | Every image must have alt text — descriptive when content, empty when decorative, never missing. | NONE | No alt-text lint or CI check | eslint-rule | Enable `jsx-a11y/alt-text` ESLint rule at error level |
+| ACCESS-010 | memory/accessibility.md | All custom controls must have ARIA roles and labels. | NONE | No ARIA audit in CI | build-runner-gate | Covered by axe-core in `gate:a11y`; add specific aria-role/label checks |
+| ACCESS-011 | memory/accessibility.md | Modals must have role="dialog" + aria-modal="true" + focus trap. | NONE | No modal ARIA check | eslint-rule | Add eslint-plugin-jsx-a11y dialog check; add Playwright focus-trap assertion |
+| ACCESS-012 | memory/accessibility.md | Toggles must have aria-pressed attribute. | NONE | No aria-pressed lint | eslint-rule | Enable `jsx-a11y/aria-proptypes` ESLint rule to enforce aria-pressed on toggles |
+| ACCESS-013 | memory/accessibility.md | Tabs must implement the full WAI-ARIA tab pattern. | NONE | No tab pattern contract test | contract-test | Add Playwright test asserting WAI-ARIA tablist/tab/tabpanel roles and keyboard navigation |
+| ACCESS-014 | memory/accessibility.md | Color contrast must be minimum 4.5:1 for normal text, 3:1 for large text and UI components. | NONE | No contrast check in CI | build-runner-gate | Run color-contrast-checker in `gate:a11y`; fail on any below-threshold combination |
+| ACCESS-015 | memory/accessibility.md | Contrast must be verified against both light and dark themes. | NONE | No multi-theme contrast check | build-runner-gate | Run `gate:a11y` contrast check with `data-theme=light` and `data-theme=dark` both |
+| ACCESS-016 | memory/accessibility.md | Must respect prefers-reduced-motion — disable non-essential animations. | NONE | No reduced-motion media query check | eslint-rule | Add ESLint/stylelint rule requiring `prefers-reduced-motion` alternatives for all CSS animations |
+| ACCESS-017 | memory/accessibility.md | Every input must have a label for or aria-label / aria-labelledby. | NONE | No label lint rule enforced | eslint-rule | Enable `jsx-a11y/label-has-associated-control` ESLint rule at error level |
+| ACCESS-018 | memory/accessibility.md | Form errors must be announced via aria-live or role="alert". | NONE | No error-announcement test | contract-test | Add Playwright test asserting error messages appear in aria-live or role="alert" regions |
+| ACCESS-019 | memory/accessibility.md | Videos must have captions or be decorative/muted with aria-hidden="true". | NONE | No video caption check | build-runner-gate | Add static analysis step scanning video elements for track[kind=captions] or aria-hidden |
+| ACCESS-020 | memory/accessibility.md | Audio must have transcripts. | NONE | No audio transcript check | advisory | Document in PR checklist; no reliable static enforcement mechanism |
+| ACCESS-021 | memory/accessibility.md | Game-state changes must use aria-live regions. | NONE | No game-state aria-live test | contract-test | Add Playwright test asserting game-state elements are wrapped in aria-live regions |
+| ACCESS-022 | memory/accessibility.md | html lang="en" must be explicit. | NONE | No lang attribute check | eslint-rule | Add `jsx-a11y/html-has-lang` ESLint rule at error level |
+| ACCESS-023 | memory/accessibility.md | Language switches are required for any non-English content. | NONE | No lang-switch check | advisory | Document in PR template; non-English content is rare; advisory until needed |
+| ACCESS-024 | memory/accessibility.md | Layouts must function up to 200% browser zoom without horizontal scroll. | NONE | No zoom test in CI | contract-test | Add Playwright test setting viewport zoom to 200% and asserting no horizontal scrollbar |
+| ACCESS-025 | memory/accessibility.md | Interactive elements must have minimum 44x44 CSS px touch target size. | NONE | No touch-target size check | build-runner-gate | Add Playwright assertion measuring bounding boxes of all interactive elements in `gate:a11y` |
+| ACCESS-026 | memory/accessibility.md | Never rely on color alone for state cues — pair color with icon/text/pattern. | NONE | No color-only state check | advisory | Enforce via code-review checklist and POKE-007; no reliable static check |
+| ACCESS-027 | memory/accessibility.md | Do not use placeholder as label. | NONE | No placeholder-as-label lint | eslint-rule | Enable `jsx-a11y/label-has-associated-control` and `jsx-a11y/no-placeholder-label` ESLint rules |
+| ACCESS-028 | memory/accessibility.md | Hole cards in PokerZeno /play must be readable via keyboard. | NONE | No poker-specific keyboard test | contract-test | Add Playwright keyboard test for /play route asserting hole card accessibility |
+| ACCESS-029 | memory/accessibility.md | PokerZeno action bar must be fully keyboard-operable. | NONE | No action-bar keyboard test | contract-test | Add Playwright keyboard navigation test targeting action bar buttons in /play |
+| ACCESS-030 | memory/accessibility.md | Pot size, stack sizes, community cards must all be in aria-live regions. | NONE | No aria-live region assertion | contract-test | Add Playwright test asserting pot/stack/community card DOM nodes have aria-live attribute |
+| ACCESS-031 | memory/accessibility.md | Voice callouts must be additive to screen reader, not a replacement. | NONE | No voice-callout isolation check | advisory | Enforce via code-review; voice callouts are not yet implemented |
+| ACCESS-032 | memory/accessibility.md | Every bet zone in RouletteCommunity /play must be a real button with aria-label. | NONE | No bet-zone button check | contract-test | Add Playwright test asserting all bet zones are `<button>` elements with aria-label |
+| ACCESS-033 | memory/accessibility.md | Wheel spin result must announce winning number via aria-live="assertive". | NONE | No spin-result announcement test | contract-test | Add Playwright test asserting spin-result element has aria-live="assertive" |
+| ACCESS-034 | memory/accessibility.md | History column must be readable via screen reader and marked as role="log". | NONE | No history role="log" assertion | contract-test | Add Playwright test asserting history container has role="log" attribute |
+| ACCESS-035 | memory/accessibility.md | Must run axe-core on every route via Playwright. Any violation fails CI. | NONE | No axe-core step in build-runner.sh | build-runner-gate | Add `gate:a11y` step in build-runner.sh that runs Playwright + axe-core across all routes |
+| ACCESS-036 | memory/accessibility.md | Lighthouse a11y score must be measured on every deploy for each route. | NONE | No Lighthouse step in CI | build-runner-gate | Add Lighthouse CI node in `gate:a11y` step; report per-route score and fail below 95 |
+| ACCESS-037 | memory/accessibility.md | Every spec.ts testing a user flow must assert no axe violations mid-flow. | NONE | No mid-flow axe assertion requirement | contract-test | Add ESLint rule or test-kit helper requiring `expectNoAxeViolations()` call in every user-flow spec |
+| ACCESS-038 | memory/accessibility.md | Must have a Playwright test that uses only keyboard to complete the full flow. | NONE | No keyboard-only full-flow test | contract-test | Add `keyboard-flow.spec.ts` Playwright test that navigates entire flow without mouse |
+| ACCESS-039 | memory/accessibility.md | Must have a Playwright test that reads aria-live regions at key events. | NONE | No aria-live region event test | contract-test | Add `aria-live.spec.ts` asserting aria-live regions receive correct announcements at key events |
+| ACCESS-040 | memory/accessibility.md | Must run a build-time check for low-contrast text using color-contrast-checker. | NONE | No contrast-checker in build-runner.sh | build-runner-gate | Add color-contrast-checker CLI invocation in `gate:a11y` step |
+| ACCESS-041 | memory/accessibility.md | Every code task touching UI must include an a11y check step in its plan. | NONE | No task-plan validation for a11y | runtime-middleware | Add MCP tool validation: tasks with `declared_files` matching UI paths must include a11y step keyword |
+| ACCESS-042 | memory/accessibility.md | Every new component must include ARIA + keyboard support at creation time. | NONE | No component creation gating | advisory | Enforce via PR checklist; no reliable static check for "new component" detection |
+| ACCESS-043 | memory/accessibility.md | Any theme change must re-verify contrast across both themes. | NONE | No theme-change-triggered contrast re-check | advisory | Enforce via POKE-007 lock and PR checklist; no automated theme-change detection |
+| ACCESS-044 | memory/accessibility.md | Animations must have prefers-reduced-motion alternatives from day one. | NONE | No animation/motion lint | eslint-rule | Add stylelint rule requiring `@media (prefers-reduced-motion)` block for every animation |
+| ACCESS-045 | memory/accessibility.md | A task that ships UI changes without a11y verification will be flagged as a defect. | NONE | No post-completion a11y verification hook | daemon | Add completeness sentinel check: if task touched UI files, verify a11y gate ran and passed |
+
+---
+
+### AWAY — Operational Orchestrator Tone Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| AWAY-001 | memory/away-mode.md | Never send chat messages to user unless production is actively burning. | NONE | No message-suppression filter in outbound path | runtime-middleware | Outbound message middleware checks severity; blocks non-critical SendUserMessage calls |
+| AWAY-002 | memory/away-mode.md | All decisions must be made autonomously. | NONE | No enforcement; runtime AI judgment | advisory | Enforced by AUTON-001 to AUTON-012 scanner (see AUTON-010) |
+| AWAY-003 | memory/away-mode.md | Do not make access requests. Assume every permission is granted. | NONE | No access-request filter | advisory | Claude Code settings.local.json wildcards serve as practical enforcement |
+| AWAY-004 | memory/away-mode.md | All unresolved questions must be logged to conductor's questions table. | NONE | No questions-table write enforcement | runtime-middleware | Add MCP server middleware asserting question-shaped responses write to questions table |
+| AWAY-005 | memory/away-mode.md | All real blockers must go to blockers table with enough context. | NONE | No blocker-table write enforcement | runtime-middleware | Add MCP server middleware asserting blocker-shaped responses write to blockers table |
+| AWAY-006 | memory/away-mode.md | Heartbeat continues internally but do not post SendUserMessage on every heartbeat. | NONE | No heartbeat-message suppression | daemon | Heartbeat daemon filters outbound messages; only posts on anomaly |
+| AWAY-007 | memory/away-mode.md | Factory stays on — executor daemon runs, completeness sentinel runs every 2h. | PARTIAL | Executor daemon exists; sentinel daemon referenced in completion-hook | Gap: no cron/launchd config verified | daemon | Verify and document launchd plist for sentinel at 2h cadence |
+| AWAY-008 | memory/away-mode.md | Next-task queue must drain autonomously. | PARTIAL | Executor dispatcher + completion-hook re-queue on failure | Gap: no queue-drain monitoring alert | daemon | Add QUEUE-001 probe that alerts if queue stalls for >30min with no task completions |
+| AWAY-009 | memory/away-mode.md | Never ask "Should I do A or B?" — decide instead. | NONE | No phrase scanner running | daemon | AUTON-010 nightly scanner covers this (see AUTON-010) |
+| AWAY-010 | memory/away-mode.md | Never respond with "Please approve" — assume approval. | NONE | No phrase scanner running | daemon | AUTON-010 nightly scanner covers this (see AUTON-010) |
+| AWAY-011 | memory/away-mode.md | Never wait on user — always decide. | NONE | Runtime AI judgment required | advisory | Covered by AUTON nightly phrase scanner |
+| AWAY-012 | memory/away-mode.md | Never bounce tiebreak questions to user. | NONE | Runtime AI judgment required | advisory | Covered by AUTON nightly phrase scanner |
+
+---
+
+### AUTON — Autonomy Enforcement Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| AUTON-001 | memory/autonomy.md | Orchestrator must never ask the user a path-forward question. | NONE | No banned phrase scanner exists yet | daemon | Implement nightly job scanning outbound_messages for path-forward question patterns |
+| AUTON-002 | memory/autonomy.md | If the draft asks "should I / want me to / confirm / proceed / A or B", it must be rejected. | NONE | No draft-validation step before send | daemon | Pre-send middleware rejects SendUserMessage calls containing banned phrases |
+| AUTON-003 | memory/autonomy.md | Execute the decision immediately. | NONE | Runtime AI judgment | advisory | Covered by nightly phrase scanner catching failures after the fact |
+| AUTON-004 | memory/autonomy.md | Rewrite the message as "Decided: choice. Rationale: one sentence. In flight: action taken." | NONE | No message-format enforcer | runtime-middleware | Add outbound message format validator that checks for Decided/Rationale/In-flight structure |
+| AUTON-005 | memory/autonomy.md | May ask the user a question ONLY when irreversible production impact or contradicts a locked contract. | NONE | Exception criteria require judgment | advisory | Document exception criteria in MCP tool description; nightly scanner flags violations |
+| AUTON-006 | memory/autonomy.md | Do not end with "Want me to X or Y?" | NONE | No phrase scanner running | daemon | Add "Want me to" to banned-phrase list in nightly scanner |
+| AUTON-007 | memory/autonomy.md | Do not end with "Let me know if you'd like me to..." | NONE | No phrase scanner running | daemon | Add "Let me know if you'd like" to banned-phrase list in nightly scanner |
+| AUTON-008 | memory/autonomy.md | Do not end with "Ready when you are." | NONE | No phrase scanner running | daemon | Add "Ready when you are" to banned-phrase list in nightly scanner |
+| AUTON-009 | memory/autonomy.md | Every SendUserMessage must be logged to conductor outbound_messages. | NONE | No outbound_messages table or middleware | runtime-middleware | Create outbound_messages table; wrap MCP SendUserMessage tool to write every call |
+| AUTON-010 | memory/autonomy.md | A nightly job must scan for messages containing forbidden patterns. | NONE | No nightly scanner job exists | daemon | Create nightly cron job that runs banned-phrase scan on outbound_messages table |
+| AUTON-011 | memory/autonomy.md | Each violation becomes a conductor blocker tagged self-regression with the exact phrase. | NONE | No auto-blocker creation from scanner | daemon | Nightly scanner creates blocker record tagged self-regression for each violation found |
+
+---
+
+### BEHAV — Behavior Test Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| BEHAV-001 | memory/behavior.md | No feature ships without a behavior test. | PARTIAL | gate:publish exists per rule; build-runner enforces test step | Gap: no specific check that a behavior test file accompanies every feature file | build-runner-gate | Add `gate:behavior` step verifying every new src file has a corresponding .spec or .behavior.ts file |
+| BEHAV-002 | memory/behavior.md | Pre-publish gate is mandatory. npm run gate:publish must pass. | PARTIAL | build-runner.sh runs tests but `gate:publish` is not an explicit named step | Gap: `gate:publish` is not verified as a distinct step in build-runner.sh | build-runner-gate | Add explicit `gate:publish` step in build-runner.sh after existing test step |
+| BEHAV-003 | memory/behavior.md | Do not merge a red gate. | PARTIAL | build-runner.sh aborts on first failed gate step | Gap: no GitHub branch protection rule enforcing this in PR merges | build-runner-gate | Ensure `gate:no-secrets` and all gate steps are required status checks in GitHub branch protection |
+| BEHAV-004 | memory/behavior.md | Tests must target outcomes, not selectors. | NONE | No lint rule preventing selector-based assertions | eslint-rule | Add ESLint rule warning on direct DOM selector use (querySelector, getByRole exceptions allowed) in test files |
+| BEHAV-005 | memory/behavior.md | Only data-test-id on explicit contract surfaces is acceptable DOM coupling. | NONE | No lint rule enforcing data-test-id usage policy | eslint-rule | Add custom ESLint rule allowing `data-test-id` in tests but flagging other DOM selector patterns |
+| BEHAV-006 | memory/behavior.md | When a test fails after a "small update", the update is too big. | NONE | Advisory; requires human judgment on commit size | advisory | Enforce indirectly via atomic commit policy and small PR rules |
+| BEHAV-007 | memory/behavior.md | Flaky tests must be flagged, not ignored. Three consecutive different outcomes auto-files a blocker. | NONE | No flaky-test detector | daemon | Add test-runner wrapper that tracks per-test outcomes across runs; auto-files blocker on 3 differing results |
+
+---
+
+### CMPLT — Completeness Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| CMPLT-001 | memory/completeness.md | No code task starts without a story tree. | NONE | No pre-start validation in executor | runtime-middleware | Executor dispatcher checks task has linked story node before spawning worker |
+| CMPLT-002 | memory/completeness.md | Every leaf must carry expected_behavior, acceptance_criteria, verification_plan, and behavior_test_skeleton. | NONE | No leaf-validation before execution | runtime-middleware | Executor pre-spawn check validates required story leaf fields are non-null |
+| CMPLT-003 | memory/completeness.md | An implementing session must receive leaf-level to-dos, not the epic. | NONE | No prompt scoping enforcement | runtime-middleware | Dispatcher prompt builder must refuse to include epic-level nodes; only leaf nodes allowed |
+| CMPLT-004 | memory/completeness.md | Empty shells become impossible because every populated region is its own sub-task. | NONE | Derived from CMPLT-002; no independent check | advisory | Enforced structurally if CMPLT-002 leaf-validation is implemented |
+| CMPLT-005 | memory/completeness.md | Completeness sentinel must run every 2 hours. | PARTIAL | Sentinel daemon referenced in completion-hook.ts | Gap: no verified 2h cron schedule | daemon | Add launchd plist or cron entry ensuring sentinel runs on 2h schedule; log run_count to DB |
+| CMPLT-006 | memory/completeness.md | On failure, flag entity unverified, write a completeness_finding, auto-create a re-execution task. | PARTIAL | Completion-hook.ts references sentinel invocation | Gap: completeness_finding table and auto-task creation not verified | daemon | Verify completeness_findings table exists; ensure sentinel writes finding + creates task on failure |
+| CMPLT-007 | memory/completeness.md | Sentinel must never edit code — only flag + queue. | NONE | No write-permission restriction on sentinel process | runtime-middleware | Sentinel daemon runs with read-only filesystem permissions; can only call Conductor API |
+| CMPLT-008 | memory/completeness.md | When user gives a new directive, run story_decompose first. | NONE | No pre-decompose gate in MCP server | runtime-middleware | MCP tool handler for new directives calls story_decompose before queuing any task |
+| CMPLT-009 | memory/completeness.md | Before declaring anything "done", wait for next sentinel run OR invoke completeness_run on demand. | NONE | No done-gating on sentinel confirmation | runtime-middleware | Executor completion hook requires sentinel score=100% before marking task done (see EXEC-007) |
+| CMPLT-010 | memory/completeness.md | When auditing backlog, filter entity.status=unverified. | NONE | No backlog audit default filter | advisory | Document in CLI help; backlog query default should include status filter |
+| CMPLT-011 | memory/completeness.md | When a re-execution task surfaces, the implementer must read the original story node + findings. | NONE | No prompt injection for re-execution context | runtime-middleware | Dispatcher detects re-execution tasks and injects original story node + completeness_findings into prompt |
+| CMPLT-012 | memory/completeness.md | If the user asks for a non-trivial feature, the FIRST step is story_decompose. | NONE | No pre-execution story_decompose enforcement | runtime-middleware | MCP instruction-handler wrapper calls story_decompose before any task creation for multi-step features |
+| CMPLT-013 | memory/completeness.md | If there's ambiguity at a leaf, ask the user to clarify that leaf specifically. | NONE | Runtime AI judgment required | advisory | Exception case under AUTON-005; scoped question is allowed when leaf criteria are ambiguous |
+| CMPLT-014 | memory/completeness.md | Implementation must only begin after the tree is in stories table and all leaves have acceptance criteria. | NONE | No tree-completeness check before execution | runtime-middleware | Executor pre-spawn validates all leaves of task's story tree have acceptance_criteria set |
+
+---
+
+### AUTON (autonomy) sub-rules already listed above. Continuing with DOM.
+
+### DOM — Domain Taxonomy Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| DOM-001 | memory/domain-taxonomy.md | Every requirement, blocker, question, ADR, feature, suggestion, and timeline entry must carry one or more domain tags. | PARTIAL | gate:events-taxonomy in build-runner.sh partially checks event types | Gap: no DB-level NOT NULL constraint on domain_tags for tasks/blockers/questions | db-constraint | Add NOT NULL constraint with non-empty default check on domain_slug/tags columns for tasks, blockers, questions |
+| DOM-002 | memory/domain-taxonomy.md | When a new entity is created in Conductor, tag it with a domain. | NONE | No creation-time domain validation in API | runtime-middleware | API POST handlers for tasks/blockers/questions reject requests missing domain_tags field |
+| DOM-003 | memory/domain-taxonomy.md | When a new plugin is added, it becomes its own domain. | NONE | No plugin-registration enforcement | advisory | Document in plugin creation checklist; enforce DOM-005 for new plugins |
+| DOM-004 | memory/domain-taxonomy.md | When adding a new dimension, append to the domain set and seed it in the DB. | NONE | No domain-set validation | db-constraint | Add domain_taxonomy table with seeded values; foreign key on entity domain_slug columns |
+| DOM-005 | memory/domain-taxonomy.md | When creating a new plugin package, add its slug to the domain taxonomy AND seed it in the DB in the same PR. | NONE | No PR-level domain seed check | build-runner-gate | Add `gate:domain-taxonomy` step that validates new packages/ dirs have a seed entry in domain_taxonomy table |
+| DOM-006 | memory/domain-taxonomy.md | When adding a new product concern, append it to the taxonomy and seed file. | NONE | No taxonomy completeness check | db-constraint | Domain taxonomy table foreign key prevents entity creation with unknown domain slug |
+| DOM-007 | memory/domain-taxonomy.md | Domain chips on the dashboard must use color AND icon, not color alone. | NONE | No UI visual-property lint | advisory | Enforce via POKE-007 lock and code-review checklist; no reliable static check |
+
+---
+
+### ENFORCE — Observability and Coverage Enforcement Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| ENFORCE-001 | memory/enforce.md | Every exported function that crosses a module boundary MUST either emit an event OR be annotated @no-events. | ENFORCED | gate:observability in build-runner.sh runs check-observability.ts which greps for missing annotations | None — fully enforced when gate passes | build-runner-gate | Already implemented; verify check-observability.ts covers all boundary signatures |
+| ENFORCE-002 | memory/enforce.md | Must have a unit test expectEventEmitted that proves the event is emitted. | PARTIAL | gate:observability checks annotation presence | Gap: does not verify a corresponding expectEventEmitted test exists | build-runner-gate | Extend check-observability.ts to cross-reference test files for expectEventEmitted assertion |
+| ENFORCE-003 | memory/enforce.md | The build's gate:observability step must grep for exported fns missing either condition and fail. | ENFORCED | gate:observability step exists in build-runner.sh and calls check-observability.ts | None | build-runner-gate | Already implemented |
+| ENFORCE-004 | memory/enforce.md | Every I/O function MUST emit a Pino log line with correlation_id, actor, stage, entity_id fields. | PARTIAL | gate:observability checks-observability.ts exists | Gap: field-level validation (correlation_id, actor, stage, entity_id) not verified | build-runner-gate | Extend check-observability.ts to parse log call arguments and verify required fields present |
+| ENFORCE-005 | memory/enforce.md | Must have a unit test expectLogEmitted that proves the log was written with right fields. | PARTIAL | gate:observability checks annotations | Gap: does not verify expectLogEmitted test presence | build-runner-gate | Extend check-observability.ts to assert corresponding expectLogEmitted in test files |
+| ENFORCE-006 | memory/enforce.md | OR be annotated @no-logs with justification. | PARTIAL | check-observability.ts looks for @no-events annotation | Gap: @no-logs annotation may not be checked separately | build-runner-gate | Add @no-logs annotation check to check-observability.ts alongside @no-events |
+| ENFORCE-007 | memory/enforce.md | Coverage target is 100% statements, branches, lines on src/ and apps/. | ENFORCED | gate:coverage in build-runner.sh runs check-coverage-delta.ts | None — gate exists | build-runner-gate | Already implemented; verify 100% thresholds are set in jest.config.ts |
+| ENFORCE-008 | memory/enforce.md | Exclusions: TypeScript type-only files, barrel re-exports, *.d.ts, generated migrations, fixture files. | PARTIAL | gate:coverage exists | Gap: exclusion patterns may not be fully configured in jest.config.ts | build-runner-gate | Verify jest.config.ts `coveragePathIgnorePatterns` includes all listed exclusions |
+| ENFORCE-009 | memory/enforce.md | Every file CHANGED in a PR must be at 100% coverage AFTER the change. | PARTIAL | check-coverage-delta.ts is a delta checker | Gap: verify it compares changed files only against 100% threshold | build-runner-gate | Verify check-coverage-delta.ts reads `git diff --name-only` and asserts 100% on changed files only |
+| ENFORCE-010 | memory/enforce.md | Unchanged files can stay below while climbing toward full coverage. | PARTIAL | check-coverage-delta.ts intent aligns with this | Gap: verify unchanged files are excluded from strict 100% check | build-runner-gate | Verify check-coverage-delta.ts does not apply 100% threshold to files absent from git diff |
+| ENFORCE-011 | memory/enforce.md | Gate order in CI: lint → build → unit → coverage → observability → behavior → events-taxonomy. | PARTIAL | build-runner.sh defines step order | Gap: behavior gate is not an explicit step in build-runner.sh | build-runner-gate | Add `gate:behavior` step to build-runner.sh in correct position after coverage |
+| ENFORCE-012 | memory/enforce.md | Unit tests enforce architecture properties. | NONE | No architecture-property unit test enforcement | contract-test | Add architecture unit tests (e.g., using dependency-cruiser) asserting module boundary rules |
+| ENFORCE-013 | memory/enforce.md | Behavior tests enforce user-visible outcomes. | PARTIAL | Playwright config exists | Gap: no explicit CI step running Playwright behavior tests | build-runner-gate | Add `gate:behavior` step in build-runner.sh that runs Playwright test suite |
+| ENFORCE-014 | memory/enforce.md | Both unit and behavior tests are mandatory. | PARTIAL | Unit tests run in build-runner.sh | Gap: behavior tests not a mandatory gate step | build-runner-gate | Enforce via ENFORCE-011 gate ordering with behavior gate as required step |
+
+---
+
+### EXEC — Executor Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| EXEC-001 | memory/executor.md | Executor daemon starts DISABLED by default. User must explicitly run conductor exec start. | ENFORCED | executor_config table has `enabled` column defaulting to false; DB schema enforced | None | db-constraint | Already implemented via schema default |
+| EXEC-002 | memory/executor.md | Default max_concurrent=3; max_per_site_concurrent=1. | ENFORCED | executor_config schema: max_concurrent defaults to 3, max_per_domain_concurrent defaults to 1 | None | db-constraint | Already implemented via schema defaults |
+| EXEC-003 | memory/executor.md | Unmet deps → task stays blocked. All deps done → task flips to ready. | NONE | No dep-resolution logic verified in executor | runtime-middleware | Verify executor polling loop checks dependsOn field and only promotes tasks with all deps completed |
+| EXEC-004 | memory/executor.md | Every state change must hit executor_runs + task_attempts + audit_log + timeline. | PARTIAL | dispatcher.ts registers executor runs; task_attempts table exists | Gap: audit_log and timeline writes not verified for every state change | runtime-middleware | Add audit_log and timeline write calls to all task state-change code paths in dispatcher and completion-hook |
+| EXEC-005 | memory/executor.md | Each worker gets its own git worktree. Auto-merge only when gate + sentinel both green. | ENFORCED | dispatcher.ts creates unique worktree per task via `git worktree add` | Gap: auto-merge gating on sentinel not verified | runtime-middleware | Verify completion-hook requires both gate:publish pass and sentinel score=100 before merging worktree |
+| EXEC-006 | memory/executor.md | 3 consecutive failures → auto-paused, blocker filed for human review. | ENFORCED | completion-hook.ts calls checkAndBreak with circuitBreakerThreshold; executor_config defaults threshold to 3 | None | runtime-middleware | Already implemented |
+| EXEC-007 | memory/executor.md | No task marks done unless gate:publish passes AND completeness sentinel score = 100%. | NONE | completion-hook marks tasks done but sentinel score check not verified | runtime-middleware | Add sentinel score check in completion-hook before calling markTaskDone |
+| EXEC-008 | memory/executor.md | If validation passes → conductor exec install-launchd → 24/7. | NONE | No install-launchd command verified in CLI | runtime-middleware | Verify `conductor exec install-launchd` CLI command exists and correctly installs daemon plist |
+| EXEC-009 | memory/executor.md | If validation fails → pause, file blocker, escalate. Do NOT proceed to 24/7 on a broken pipeline. | NONE | No validation-failure pause path before install-launchd | runtime-middleware | Add pre-install validation step in `conductor exec install-launchd` that runs full pipeline check first |
+| EXEC-010 | memory/executor.md | Every user instruction: (1) call story_decompose, (2) leaves queue as ready, (3) executor picks up autonomously. | NONE | No instruction-to-story_decompose pipeline enforced | runtime-middleware | MCP instruction handler wraps all incoming instructions in story_decompose call before task creation |
+| EXEC-011 | memory/executor.md | Every instruction is treated as durable: the pipeline is the contract, chat is ephemeral. | NONE | No durability check on instruction ingestion | runtime-middleware | All instructions written to prompts table before any processing begins (see TRACE-001) |
+| EXEC-012 | memory/executor.md | Orchestrator must not manually start_code_task for each leaf anymore. | NONE | No prohibition on direct start_code_task calls | runtime-middleware | Deprecate or guard direct start_code_task calls; route all task creation through executor queue |
+
+---
+
+### HEALTH — Pipeline Health Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| HEALTH-001 | memory/health.md | Orchestrator must continuously verify the factory pipeline is healthy. | NONE | No health-check daemon verified | daemon | Implement health probe daemon that runs every 5 minutes and checks all 7 KPIs |
+| HEALTH-002 | memory/health.md | On every heartbeat tick (~5 min): query conductor for 7 KPIs. | NONE | No heartbeat health query implemented | daemon | Add 5-minute cron health probe querying tasks, blockers, events, build_runs tables |
+| HEALTH-003 | memory/health.md | Any anomaly → file a blocker with severity=critical, tag pipeline-health. | NONE | No anomaly-to-blocker creation | daemon | Health probe daemon calls /blockers API on any KPI threshold breach |
+| HEALTH-004 | memory/health.md | Anomalies aggregated into a daily /reports/pipeline-health dashboard card. | NONE | No daily health report generation | daemon | Add daily cron that queries blockers tagged pipeline-health and writes report to /reports/ |
+| HEALTH-005 | memory/health.md | One hourly scheduled health probe runs regardless of heartbeat state. | NONE | No hourly independent health probe | daemon | Add separate hourly cron entry in launchd plist for health probe independent of heartbeat |
+| HEALTH-006 | memory/health.md | On any anomaly, orchestrator writes to system.warning event with severity=critical immediately. | NONE | No system.warning event emission in health probe | daemon | Health probe emits system.warning event via /events API on any KPI breach |
+| HEALTH-007 | memory/health.md | Task throughput must be ≥ 1 done / hour during active build periods. | NONE | No throughput KPI check | daemon | Health probe queries tasks completed in last hour; breaches threshold if < 1 during active periods |
+| HEALTH-008 | memory/health.md | P95 time from prompt → all descendants done ≤ 24h. | NONE | No P95 latency check | daemon | Health probe calculates P95 prompt-to-completion time from prompts + tasks tables |
+| HEALTH-009 | memory/health.md | Zero tasks with null root_prompt_id. | NONE | root_prompt_id is nullable in schema (text('root_prompt_id') without .notNull()) | db-constraint | Add .notNull() constraint to tasks.root_prompt_id column in DB schema and migrate |
+| HEALTH-010 | memory/health.md | Zero stories un-decomposed for >24h after creation. | NONE | No stale-story check | daemon | Health probe queries stories table for nodes with status=created older than 24h |
+| HEALTH-011 | memory/health.md | Event emission rate within 30% of trailing 24h average. | NONE | No event-rate anomaly detection | daemon | Health probe computes last-hour event count vs. 24h rolling average; alerts on >30% deviation |
+| HEALTH-012 | memory/health.md | Build-runner success rate ≥ 90% over 24h rolling. | NONE | No build success-rate check | daemon | Health probe queries build_runs table for 24h success rate; files blocker if < 90% |
+| HEALTH-013 | memory/health.md | Completeness sentinel run count ≥ 12 per 24h. | NONE | No sentinel run-count tracking | daemon | Health probe counts sentinel_runs in last 24h; files blocker if < 12 |
+| HEALTH-014 | memory/health.md | Only report to user when KPI trips. Keep heartbeat noise to zero. | NONE | No message-suppression on green health | daemon | Health probe daemon only calls SendUserMessage when a KPI threshold is breached |
+| HEALTH-015 | memory/health.md | At most one consolidated health summary per day if everything is green. | NONE | No green-day summary consolidation | daemon | Health probe daemon batches green-day findings into single daily digest message |
+
+---
+
+### L — Operational Learnings
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| L-001 | memory/learnings.md | Poll every 5 minutes while ANY session is running, not 30. | NONE | No 5-min poll enforcement | advisory | executor_config.poll_interval_ms default is 10000ms; update default to 300000ms when sessions active |
+| L-002 | memory/learnings.md | If turn count hasn't changed across 3 consecutive 5-min polls, assume stall and nudge. | NONE | No stall-detection logic verified | daemon | Add stall detector in executor monitor: 3 polls with same turn_count triggers nudge or respawn |
+| L-003 | memory/learnings.md | "Don't ask questions" does NOT mean "don't monitor." | NONE | Advisory | advisory | No mechanical enforcement possible |
+| L-004 | memory/learnings.md | Monitoring surfaces blockers that can be resolved autonomously. | NONE | Advisory | advisory | Covered by HEALTH daemon implementation |
+| L-005 | memory/learnings.md | When 2+ parallel tasks are live, run periodic reconcile. | NONE | No multi-task reconcile loop | daemon | Executor monitor runs reconcile step when active_workers > 1 to detect cross-task conflicts |
+| L-006 | memory/learnings.md | After parallel edits, clear .next/ and restart dev server. | NONE | Advisory; project-specific | advisory | Document in executor task prompt template |
+| L-007 | memory/learnings.md | Every deployment checklist: verify curl -sI returns 200 AND content is correct. | NONE | No post-deploy health check | contract-test | Add post-deploy smoke test step in build-runner.sh that curls key routes and asserts 200 + content |
+| L-008 | memory/learnings.md | Dev-server-up is not dev-server-serving-correct-content. | NONE | Advisory | advisory | Covered by L-007 content verification |
+| L-009 | memory/learnings.md | When a hook is blocking, enumerate ALL files in hooks dir. | NONE | Advisory; operational procedure | advisory | No mechanical enforcement possible |
+| L-010 | memory/learnings.md | Check settings.json for the full matcher list. | NONE | Advisory | advisory | No mechanical enforcement possible |
+| L-011 | memory/learnings.md | Apply passthrough fix to EVERY hook that matches. | NONE | Advisory | advisory | No mechanical enforcement possible |
+| L-012 | memory/learnings.md | For any new cloud-provider integration, verify the API exists for the specific operation. | NONE | Advisory | advisory | Document in integration PR checklist |
+| L-013 | memory/learnings.md | Do not promise autonomous automation if a dashboard click is required. | NONE | Advisory | advisory | No mechanical enforcement possible |
+| L-014 | memory/learnings.md | For any Claude Code project, proactively install wildcard permissions in .claude/settings.local.json. | NONE | Advisory; project setup | advisory | Document in project init checklist |
+| L-015 | memory/learnings.md | Install permissions at project creation time, not after complaint. | NONE | Advisory | advisory | Document in project init checklist |
+| L-016 | memory/learnings.md | After any failure, add a new learning entry to this file. | NONE | Advisory; process rule | advisory | No mechanical enforcement possible |
+| L-017 | memory/learnings.md | Read this file at the start of every new conversation. | NONE | Advisory; session startup rule | advisory | Add to session context priming prompt |
+| L-018 | memory/learnings.md | No user-visible link may lead to 404/error. No button may do nothing when clicked. | NONE | No broken-link or dead-button check in CI | build-runner-gate | Add npm run integrity step in build-runner.sh that crawls all routes for broken links and dead buttons |
+| L-019 | memory/learnings.md | Both sites have npm run integrity that crawls all routes and scans interactive elements. | NONE | No integrity check in build-runner.sh | build-runner-gate | Add `gate:integrity` step in build-runner.sh running npm run integrity on all site targets |
+| L-020 | memory/learnings.md | Build fails if integrity fails. | NONE | No integrity gate in build-runner.sh | build-runner-gate | Make `gate:integrity` step in build-runner.sh abort on non-zero exit |
+| L-021 | memory/learnings.md | Playwright test walks the site, clicks every discoverable interactive element. | NONE | No full-site Playwright click walk | contract-test | Add Playwright site-walk spec that discovers and clicks all interactive elements, asserts no errors |
+| L-022 | memory/learnings.md | Zero tolerance for broken links — the build blocks. | NONE | No link-checker gate | build-runner-gate | Add `gate:integrity` step (see L-019) that includes broken-link check |
+| L-023 | memory/learnings.md | Within each site, no image may appear on two different reference points. | NONE | No image-deduplication check | build-runner-gate | Add image-slot deduplication validator in enrichment pipeline that fails on duplicate slot assignments |
+| L-024 | memory/learnings.md | Every section/article/page gets a unique image. | NONE | No unique-image enforcement | build-runner-gate | Add `gate:content` step checking image slot assignments for duplicates across routes |
+| L-025 | memory/learnings.md | During enrichment, assign images by slot key, not by query reuse. | NONE | Advisory; enrichment implementation detail | advisory | Document in enrichment pipeline code comments |
+| L-026 | memory/learnings.md | Validation sweep at end of every enrichment pass. | NONE | No post-enrichment validation step | daemon | Add post-enrichment validation step to enrichment pipeline that checks uniqueness + age-safety |
+| L-027 | memory/learnings.md | Any image depicting a person must show only clearly-adult (21+) individuals. | NONE | No age-safety filter in image pipeline | build-runner-gate | Add age-safety validation step in image-acquisition pipeline that rejects person-containing images flagged as minor |
+| L-028 | memory/learnings.md | No kids, teenagers, or family-with-children imagery. | NONE | No imagery content filter | build-runner-gate | Extend age-safety filter (L-027) to reject family-with-children images |
+| L-029 | memory/learnings.md | Every image-acquisition pass MUST include an age-safety filter. | NONE | No age-safety filter in image provider | build-runner-gate | Add mandatory age-safety filter to image-provider utility as non-bypassable middleware |
+| L-030 | memory/learnings.md | For person-containing images, a secondary visual check: reject if anyone appears under 21. | NONE | No secondary visual check | advisory | Document in image acquisition procedure; automated age-detection requires external API |
+| L-031 | memory/learnings.md | When unsure, prefer non-person imagery. | NONE | Advisory | advisory | Document in image-provider default behavior |
+| L-032 | memory/learnings.md | Any existing site imagery discovered to contain minors → remove immediately. | NONE | No imagery audit for existing content | advisory | Run one-time audit; document in operational runbook |
+| L-033 | memory/learnings.md | Bake age-safety into the image-provider utility's validation pipeline as mandatory filter. | NONE | No age-safety filter exists | build-runner-gate | Implement age-safety validation in image-provider; gate:content checks filter is present |
+| L-034 | memory/learnings.md | A task's "done" is a hypothesis. Before relaying done to user, run independent verification. | NONE | No independent verification step before done-relay | runtime-middleware | Completion-hook runs verification step (curl, test) before marking task done and messaging user |
+| L-035 | memory/learnings.md | Open the live app in a browser, walk through the original requirement list. | NONE | Advisory; manual verification | advisory | Covered mechanically by L-007 post-deploy smoke test |
+| L-036 | memory/learnings.md | For any track with >10 requirements, the DoD includes a traceability matrix. | NONE | No traceability matrix check | advisory | Document in task template; no static enforcement for requirement count threshold |
+| L-037 | memory/learnings.md | Cross-task feature coverage: track A completion doesn't confirm unless explicitly verified. | NONE | Advisory | advisory | Covered by completeness sentinel independent verification |
+| L-038 | memory/learnings.md | When an audit finds gaps, open a follow-up task with specific unchecked items. | NONE | Advisory | advisory | No mechanical enforcement possible |
+| L-039 | memory/learnings.md | User is on East Coast (EST/EDT). All human-facing timestamps use ET. | NONE | Advisory; formatting preference | advisory | No mechanical enforcement; document in timestamp utility |
+| L-040 | memory/learnings.md | Prefix timestamps with "PM EST" / "AM EST". | NONE | Advisory; formatting preference | advisory | No mechanical enforcement; document in timestamp utility |
+| L-041 | memory/learnings.md | When writing "Heartbeat at HH:MM" use the user's local time. | NONE | Advisory; formatting preference | advisory | No mechanical enforcement; document in heartbeat message template |
+| L-042 | memory/learnings.md | Never tell a child task to write to /sessions/*/mnt/.auto-memory/ — it won't land in orchestrator's view. | NONE | No path-restriction in task prompts | runtime-middleware | Dispatcher prompt builder strips any instruction to write to /sessions/*/mnt/.auto-memory/ paths |
+| L-043 | memory/learnings.md | Route task reports to absolute HOST paths like /Users/MAC/Documents/projects/<project>/reports/*.md. | NONE | No report-path enforcement | runtime-middleware | Dispatcher prompt template explicitly instructs host-path report routing |
+| L-044 | memory/learnings.md | Request task to echo report content in its transcript [result] line. | NONE | No [result] echo enforcement in prompts | runtime-middleware | Dispatcher prompt builder includes instruction to echo report content in [result] line |
+| L-045 | memory/learnings.md | When consolidating backlog, treat "report was written" only as proven when verified via ls. | NONE | Advisory; verification procedure | advisory | No mechanical enforcement possible |
+| L-046 | memory/learnings.md | On overloaded_error or similar transient 5xx, first attempt to resume via send_message. | NONE | No transient-error resume logic verified | runtime-middleware | Executor monitor adds retry-via-send_message path before respawn on 5xx errors |
+| L-047 | memory/learnings.md | Only respawn if the resume message also hits the same error twice in a row. | NONE | No double-check before respawn | runtime-middleware | Executor monitor tracks error count per session; respawns only after 2 consecutive same errors |
+| L-048 | memory/learnings.md | Always include BL-<TASK>-PAUSED.md write-instruction as a fallback. | NONE | No paused-task fallback write in prompts | runtime-middleware | Dispatcher prompt includes BL-{taskId}-PAUSED.md write as last-resort fallback instruction |
+| L-049 | memory/learnings.md | When ANY task is running, post a proactive status update every ~15 minutes. | NONE | No 15-minute status-update daemon | daemon | Add 15-minute cron job that posts status update when active_workers > 0 |
+| L-050 | memory/learnings.md | Silence for >15 min while tracks are live is a signal failure. | NONE | No silence-detection check | daemon | Status daemon checks last outbound message timestamp; posts alert if > 15 min with live workers |
+| L-051 | memory/learnings.md | Use schedule skill when available; otherwise piggy-back on task-completion events. | NONE | Advisory; scheduling preference | advisory | Covered by daemon implementations above |
+| L-052 | memory/learnings.md | Every 15 min, send a one-screen status: each track's turn count + delta + state + blockers. | NONE | No 15-min structured status message | daemon | 15-min status daemon formats turn_count delta + state + blockers per active track |
+| L-053 | memory/learnings.md | If no tasks are running, cadence pauses. | NONE | No idle-suppression for status daemon | daemon | Status daemon checks active_workers == 0 and skips posting when idle |
+
+---
+
+### OBS — Observability Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| OBS-001 | memory/observability.md | Every state change must emit a structured event through a durable bus. | PARTIAL | gate:observability checks event emission annotations | Gap: not all state changes have verified event emission | build-runner-gate | Extend gate:observability to scan all state-machine transitions and verify event.emit call present |
+| OBS-002 | memory/observability.md | Every module must emit structured JSON logs with correlation/trace IDs. | PARTIAL | gate:observability checks @no-logs and log calls | Gap: field-level validation (correlation_id) not verified | build-runner-gate | Extend check-observability.ts to assert log calls include correlation_id field |
+| OBS-003 | memory/observability.md | No silent state changes. If it matters, emit an event. | PARTIAL | gate:observability annotation check | Gap: "if it matters" requires judgment; annotation-only check is incomplete | build-runner-gate | Same as OBS-001; gate:observability coverage of all state change paths |
+| OBS-004 | memory/observability.md | Every function that crosses a module boundary must open an OTel span. | NONE | No OTel span check in gate:observability | build-runner-gate | Add OTel span annotation requirement to check-observability.ts for module-boundary functions |
+| OBS-005 | memory/observability.md | Every log line must include correlation_id. | PARTIAL | gate:observability checks log calls | Gap: correlation_id field presence not verified at log-call level | build-runner-gate | Extend check-observability.ts to parse Pino log call signatures and assert correlation_id argument |
+| OBS-006 | memory/observability.md | Every error must be both logged AND event-emitted with severity=error. | NONE | No error dual-emit check | build-runner-gate | Add error-handling pattern check to check-observability.ts: catch blocks must have log + emit calls |
+| OBS-007 | memory/observability.md | Every DB write must have a corresponding event in the same transaction. | NONE | No DB-write event co-emission check | build-runner-gate | Add check-observability.ts rule: every db.insert/update call must be accompanied by event.emit in same scope |
+| OBS-008 | memory/observability.md | Events are append-only. Never update or delete an event row. | NONE | No immutability check on events table | db-constraint | Add DB trigger or application-level guard preventing UPDATE/DELETE on events table |
+| OBS-009 | memory/observability.md | Every build invocation must run under an instrumentation wrapper. | ENFORCED | build-runner.sh wraps all build invocations with event emission and step tracking | None | build-runner-gate | Already implemented |
+| OBS-010 | memory/observability.md | Every npm run build, gate:* script, test invocation goes through build-runner wrapper. | PARTIAL | build-runner.sh wraps npm steps | Gap: direct npm invocations outside build-runner.sh are not gated | build-runner-gate | Add pre-script hooks in package.json that require BUILD_RUN_ID env var for build and gate commands |
+| OBS-011 | memory/observability.md | The wrapper must assign a build_run_id (ULID) at invocation. | ENFORCED | build-runner.sh assigns BUILD_RUN_ID at start | None | build-runner-gate | Already implemented |
+| OBS-012 | memory/observability.md | The wrapper must emit build.started event with command, args, cwd, trigger, git SHA. | ENFORCED | build-runner.sh emits build.started with trigger, git SHA, branch, changed_files | None | build-runner-gate | Already implemented |
+| OBS-013 | memory/observability.md | For each pipeline step, emit build.step_started with step name + order. | ENFORCED | build-runner.sh emits build.step_started in run_step() for each step | None | build-runner-gate | Already implemented |
+| OBS-014 | memory/observability.md | Run the step, capture stdout + stderr + exit code + duration + max RSS. | PARTIAL | build-runner.sh captures stdout+stderr+exit code+duration | Gap: max RSS is not captured | build-runner-gate | Add `/usr/bin/time -v` or similar to capture max RSS for each build step |
+| OBS-015 | memory/observability.md | Emit build.step_completed OR build.step_failed. | ENFORCED | build-runner.sh emits build.step_completed or build.step_failed in run_step() | None | build-runner-gate | Already implemented |
+| OBS-016 | memory/observability.md | On failure, extract the error signature and file as a structured finding. | PARTIAL | build-runner.sh extracts error_signature from log | Gap: file extraction not implemented, only error pattern | build-runner-gate | Extend run_step() in build-runner.sh to parse error output for filename:line and include in step failure payload |
+| OBS-017 | memory/observability.md | Emit build.completed OR build.aborted at end. | ENFORCED | build-runner.sh emits build.completed or build.aborted at end | None | build-runner-gate | Already implemented |
+| OBS-018 | memory/observability.md | Every Pino log line emitted DURING a build step must carry build_run_id + build_step_id. | NONE | No log-line enrichment with build context | build-runner-gate | Pass BUILD_RUN_ID + step_id as env vars; Pino child logger must include these fields |
+| OBS-019 | memory/observability.md | gate:publish wrapper itself runs under build-runner. | NONE | gate:publish not an explicit step in build-runner.sh | build-runner-gate | Add `gate:publish` as a named step in build-runner.sh run_step() calls |
+| OBS-020 | memory/observability.md | Circuit-breaker logic: if same gate step flakes 3x within 24h, auto-file testing-qa blocker. | NONE | No per-step flakiness tracking | daemon | Add gate-step failure tracker: query build_step records for same step_name failing 3x in 24h; auto-file blocker |
+
+---
+
+### POKE — PokerZeno Brand Lock Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| POKE-001 | memory/pokerzeno-brand.md | This is the authoritative design direction for PokerZeno. Apply, do not rewrite without explicit user unlock. | NONE | No brand-lock gate in build-runner.sh | advisory | Enforced by POKE-019 acceptance criteria requirement and code review |
+| POKE-002 | memory/pokerzeno-brand.md | All other colors (velvet, obsidian, emerald) are REMOVED from primary use. | NONE | No banned-color token check | build-runner-gate | Add `gate:brand` step in build-runner.sh checking tailwind.config for banned color names |
+| POKE-003 | memory/pokerzeno-brand.md | User picks theme via theme switcher; no third theme. | NONE | No theme-count check | build-runner-gate | Add `gate:brand` assertion counting theme definitions; fail if > 2 themes found |
+| POKE-004 | memory/pokerzeno-brand.md | No third-party icon libraries beyond card shapes for primary brand iconography. | NONE | No icon-library import check | eslint-rule | Add ESLint rule flagging icon-library imports (heroicons, fontawesome etc.) in brand-level components |
+| POKE-005 | memory/pokerzeno-brand.md | lucide-react is fine for utility UI chrome but NOT for brand-level decoration. | NONE | No lucide-react scope enforcement | eslint-rule | Add ESLint rule warning on lucide-react usage in brand-level decoration contexts |
+| POKE-006 | memory/pokerzeno-brand.md | LOCKED — Do not rewrite pages, rearrange sections, or restructure. | NONE | No page-structure change detection | build-runner-gate | Add `gate:brand` step using AST diff to detect page-level section restructuring in poker-zeno routes |
+| POKE-007 | memory/pokerzeno-brand.md | Brand lock is purely theme/color/iconography swap — text, layout, components remain as-is. | NONE | No layout-change detection | advisory | Enforced via POKE-006 page-structure gate and code review |
+| POKE-008 | memory/pokerzeno-brand.md | Read this file before making any visual change to PokerZeno. | NONE | No pre-task file-read requirement | runtime-middleware | Executor task prompt for poker-zeno files includes instruction to read brand-lock file first |
+| POKE-009 | memory/pokerzeno-brand.md | Reference tokens by their lock names (white, black, red, silver, gold, platinum, ruby). | NONE | No token-name validation | build-runner-gate | Add `gate:brand` check verifying tailwind tokens use only approved lock names |
+| POKE-010 | memory/pokerzeno-brand.md | Update tailwind.config tokens to match exact hexes. | NONE | No hex-value validation for brand tokens | build-runner-gate | Add `gate:brand` step asserting token hex values match locked values in brand-lock spec |
+| POKE-011 | memory/pokerzeno-brand.md | Never introduce new primary colors without explicit user unlock. | NONE | No new-color detection | build-runner-gate | Add `gate:brand` step diffing tailwind.config against approved color set |
+| POKE-012 | memory/pokerzeno-brand.md | Never swap the brand iconography for generic/stock icons. | NONE | No iconography swap detection | build-runner-gate | Add `gate:brand` step checking SVG/icon references in poker-zeno routes against approved icon list |
+| POKE-013 | memory/pokerzeno-brand.md | Two-theme toggle (bright/dark) is a must-have wherever theming applies. | NONE | No theme-toggle presence check | contract-test | Add Playwright test asserting theme toggle component exists and switches between exactly 2 themes |
+| POKE-014 | memory/pokerzeno-brand.md | Do not reintroduce velvet, obsidian, emerald as dominant colors. | NONE | No banned-color scan | build-runner-gate | gate:brand scans CSS/tailwind for banned color names (velvet, obsidian, emerald) |
+| POKE-015 | memory/pokerzeno-brand.md | Do not add a third theme. | NONE | No theme-count guard | build-runner-gate | gate:brand counts theme definitions; fails on > 2 (see POKE-003) |
+| POKE-016 | memory/pokerzeno-brand.md | Do not use yellow-leaning gold (#D4AF37). | NONE | No specific hex ban | build-runner-gate | gate:brand scans for literal #D4AF37 in CSS/tailwind files |
+| POKE-017 | memory/pokerzeno-brand.md | Do not use third-party decorative iconography in place of card-based iconography. | NONE | No decorative icon check | build-runner-gate | gate:brand checks for third-party decorative icon usage in brand-level slots |
+| POKE-018 | memory/pokerzeno-brand.md | Do not rewrite content, page structure, or layout under the banner of "brand update." | NONE | No content/layout preservation check | build-runner-gate | gate:brand uses git diff to detect non-token changes in poker-zeno route files during brand tasks |
+| POKE-019 | memory/pokerzeno-brand.md | Any Conductor requirement touching poker-zeno files must confirm compliance with this lock in acceptance criteria. | NONE | No acceptance-criteria validation for brand compliance | runtime-middleware | Executor pre-spawn check: tasks with poker-zeno in declared_files must have brand-lock compliance in acceptance_criteria |
+
+---
+
+### PRIOR — Prioritization Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| PRIOR-001 | memory/prioritization.md | Every new task gets a priority score, a bucket, and a precise queue position automatically. | NONE | No auto-priority assignment on task creation | runtime-middleware | Task creation API endpoint calls prioritizer on every new task before inserting into DB |
+| PRIOR-002 | memory/prioritization.md | No human tiebreak needed. | NONE | Advisory; relies on deterministic priority algorithm | advisory | Enforced indirectly by PRIOR-001 auto-priority assignment |
+| PRIOR-003 | memory/prioritization.md | Tasks ≥90 score or hard-blocks >5 other tasks go to P0. Pauses in-flight non-P0 work, slots at position 1. | NONE | No P0 escalation logic in executor | runtime-middleware | Executor monitor checks priority score after each reprioritization; pauses non-P0 workers if P0 task arrives |
+| PRIOR-004 | memory/prioritization.md | When a user instruction arrives, decompose it and announce WHERE IT LANDED — not ask where it should land. | NONE | No post-decompose landing announcement | runtime-middleware | Instruction handler sends queue-position announcement after story_decompose + priority assignment |
+
+---
+
+### QUEUE — Queue Drain Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| QUEUE-001 | memory/queue.md | Every 15 min, a scheduled task must probe the conductor queue. | NONE | No 15-min queue probe | daemon | Add 15-min cron job probing tasks table for queued+ready count |
+| QUEUE-002 | memory/queue.md | Silent if queue has tasks. | NONE | No silence logic in queue probe | daemon | Queue probe suppresses SendUserMessage if queued_count > 0 |
+| QUEUE-003 | memory/queue.md | If zero: proactive SendUserMessage with specific copy. | NONE | No zero-queue notification | daemon | Queue probe sends "Queue empty — all tasks complete. Awaiting new instructions." on zero count |
+| QUEUE-004 | memory/queue.md | If running tasks alongside zero queued+ready: adjust message to note in-flight count. | NONE | No in-flight-aware zero-queue message | daemon | Queue probe includes active_worker count in message when queued=0 but workers still running |
+
+---
+
+### SEC — Security Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| SEC-001 | memory/security.md | Secrets live only in Vault. Apps never talk to Vault directly. | NONE | No vault-direct-access check in code | build-runner-gate | Add gate:secrets-architecture scan for direct Vault API calls outside the secrets-broker package |
+| SEC-002 | memory/security.md | Workers and Next.js API routes must fetch at runtime, never bake at build-time. | NONE | No build-time secret bake detection | build-runner-gate | gate:no-secrets and gate:supply-chain together check for build-time secret inlining |
+| SEC-003 | memory/security.md | Static HTML must never contain a secret. | NONE | No static HTML secret scan | build-runner-gate | Add post-build scan of dist/ static HTML files using gitleaks patterns |
+| SEC-004 | memory/security.md | Every vault fetch must emit vault.secret_accessed to the event bus. | NONE | No vault fetch event emission enforcement | build-runner-gate | Add check-observability.ts rule: vault fetch calls must be accompanied by event emission |
+| SEC-005 | memory/security.md | Every commit runs gitleaks + trufflehog-verified pre-commit + CI; any match blocks merge. | ENFORCED | .githooks/pre-commit runs gitleaks + trufflehog; gate:no-secrets in build-runner.sh | None | pre-commit-hook | Already implemented |
+| SEC-006 | memory/security.md | Every key has a documented rotation SLA. | NONE | No rotation SLA documentation check | advisory | Document rotation SLA in vault metadata; no automated check feasible |
+| SEC-007 | memory/security.md | A leak triggers the 60-minute breach runbook. | NONE | Advisory; operational procedure | advisory | Document in runbooks/secret-breach.md |
+| SEC-008 | memory/security.md | Pillar 0 — Zero secrets at rest. gitleaks + trufflehog pre-commit hook + CI. | ENFORCED | .githooks/pre-commit + gate:no-secrets in build-runner.sh | None | pre-commit-hook | Already implemented |
+| SEC-009 | memory/security.md | gate:no-secrets step in build-runner.sh. | ENFORCED | gate:no-secrets is step 0 in build-runner.sh | None | build-runner-gate | Already implemented |
+| SEC-010 | memory/security.md | Historical scan run once per repo; any historical leak triggers immediate rotation. | NONE | No historical scan run confirmed | build-runner-gate | Add one-time historical scan step to CI bootstrap; log result to DB |
+| SEC-011 | memory/security.md | Pillar 1 — Central Vault is single source of truth. | NONE | Advisory; infrastructure requirement | advisory | Document in architecture ADR |
+| SEC-012 | memory/security.md | Vault is versioned, soft-delete, purge after 30 days. | NONE | Advisory; Vault configuration | advisory | Document in vault setup runbook |
+| SEC-013 | memory/security.md | Pillar 2 — Machine identity + short-lived credentials. AppRole for services. | NONE | Advisory; infrastructure setup | advisory | Document in identity management ADR |
+| SEC-014 | memory/security.md | OIDC for GitHub Actions → Vault (no long-lived PATs in CI secrets). | NONE | No CI PAT check | build-runner-gate | Add gate:supply-chain check for long-lived PAT patterns in CI config files |
+| SEC-015 | memory/security.md | JWT for Cloudflare Workers. | NONE | Advisory; infrastructure config | advisory | Document in deployment runbook |
+| SEC-016 | memory/security.md | Token TTL ≤ 15 minutes, renewable, IP-bound where possible. | NONE | Advisory; Vault policy configuration | advisory | Document in Vault policy files |
+| SEC-017 | memory/security.md | Pillar 3 — Envelope encryption + HSM-backed root. Vault sealed by Shamir 3-of-5. | NONE | Advisory; infrastructure setup | advisory | Document in security architecture ADR |
+| SEC-018 | memory/security.md | Future: GCP Cloud HSM or AWS CloudHSM as auto-unseal provider. | NONE | Advisory; future infrastructure | advisory | Track as a future ADR |
+| SEC-019 | memory/security.md | Pillar 4 — Broker pattern. Apps never talk to Vault directly. | NONE | No broker-only access enforcement in code | build-runner-gate | Add gate:secrets-architecture scan ensuring only secrets-broker package contains vault client code |
+| SEC-020 | memory/security.md | @plugins/secrets-broker validates caller via mTLS or signed JWT. | NONE | No mTLS/JWT validation check | contract-test | Add integration test asserting secrets-broker rejects unauthenticated callers |
+| SEC-021 | memory/security.md | Broker is the only identity with broad vault policies. | NONE | Advisory; Vault policy assignment | advisory | Document in vault policy configuration |
+| SEC-022 | memory/security.md | Pillar 5 — Runtime fetch, never build-time bake. Workers fetch on cold-start. | NONE | No runtime-fetch enforcement check | build-runner-gate | Extend gate:no-secrets to scan worker entrypoints for hardcoded env var assignments at module level |
+| SEC-023 | memory/security.md | Next.js API routes: same runtime fetch pattern. | NONE | No API route secret-fetch pattern check | build-runner-gate | Extend gate:no-secrets to scan Next.js API routes for build-time secret references |
+| SEC-024 | memory/security.md | Build-time inlining of secrets into static bundles is a hard fail in CI. | PARTIAL | gate:no-secrets scans source | Gap: post-build dist/ static bundles are not scanned | build-runner-gate | Add post-build scan of built artifacts in gate:no-secrets step |
+| SEC-025 | memory/security.md | Pillar 6 — Least-privilege IAM. GCP SA scoped per property. | NONE | Advisory; GCP IAM configuration | advisory | Document in IAM policy runbook |
+| SEC-026 | memory/security.md | Cloudflare tokens scoped to single zone + minimum permission. | NONE | Advisory; Cloudflare configuration | advisory | Document in deployment runbook |
+| SEC-027 | memory/security.md | GitHub fine-grained PAT scoped to specific repos. | NONE | Advisory; GitHub settings | advisory | Document in repository access policy |
+| SEC-028 | memory/security.md | Every key's scope + blast-radius documented in vault metadata. | NONE | Advisory; vault metadata | advisory | Document in vault key provisioning runbook |
+| SEC-029 | memory/security.md | Pillar 7 — Rotation SLAs. High-value keys: 30d. | NONE | Advisory; operational SLA | advisory | Enforced by secret.rotation_due event when SEC-033 is implemented |
+| SEC-030 | memory/security.md | Medium (billing APIs): 90d. | NONE | Advisory | advisory | Covered by SEC-033 rotation scheduler |
+| SEC-031 | memory/security.md | Low (read-only public APIs): 180d. | NONE | Advisory | advisory | Covered by SEC-033 rotation scheduler |
+| SEC-032 | memory/security.md | Emergency rotation on any anomaly. | NONE | Advisory; operational procedure | advisory | Document in breach runbook |
+| SEC-033 | memory/security.md | Rotation scheduler task emits secret.rotation_due events when threshold is crossed. | NONE | No rotation scheduler task | daemon | Implement rotation_scheduler daemon that emits secret.rotation_due when key age exceeds SLA |
+| SEC-034 | memory/security.md | Pillar 8 — Every vault fetch emits vault.secret_accessed with caller identity. | NONE | No vault fetch event emission in secrets-broker | build-runner-gate | Extend check-observability.ts to require vault.secret_accessed event call alongside vault fetch calls |
+| SEC-035 | memory/security.md | Alerts: access pattern deviation, cross-environment access, unexpected IP. | NONE | No access-pattern monitoring | daemon | Implement vault access anomaly detector querying secret_accessed events for pattern deviations |
+| SEC-036 | memory/security.md | Grafana dashboard /security/secrets shows realtime access + rotation status. | NONE | No Grafana dashboard for secrets | advisory | Track as infrastructure task; requires Grafana deployment |
+| SEC-037 | memory/security.md | Pillar 9 — gitleaks + trufflehog in .githooks/pre-commit. | ENFORCED | .githooks/pre-commit runs both gitleaks and trufflehog | None | pre-commit-hook | Already implemented |
+| SEC-038 | memory/security.md | GitHub Actions runs same on every PR + push. | ENFORCED | gate:no-secrets in build-runner.sh covers CI; GitHub Actions workflow uses same gate | None | build-runner-gate | Already implemented |
+| SEC-039 | memory/security.md | Findings fail merge-gate. | ENFORCED | gate:no-secrets is step 0 in build-runner.sh with set -e; aborts on finding | None | build-runner-gate | Already implemented |
+| SEC-040 | memory/security.md | Historical baseline scanned once per repo. | NONE | No historical scan confirmed as run | advisory | Run `gitleaks detect --source .` once on repo; document result |
+| SEC-041 | memory/security.md | Pillar 10 — Broker needs credentials. Bootstrap via 1Password → env var at deploy → exchanged for short-lived token. | NONE | Advisory; bootstrap ceremony | advisory | Document in broker deployment runbook |
+| SEC-042 | memory/security.md | Bootstrap ceremony documented. | NONE | Advisory; documentation | advisory | Document in runbooks/broker-bootstrap.md |
+| SEC-043 | memory/security.md | Pillar 11 — 60-minute breach runbook at ~/Documents/runbooks/secret-breach.md. | NONE | Advisory; runbook existence | advisory | Verify runbook file exists; create if missing |
+| SEC-044 | memory/security.md | Per-provider rotation commands documented. | NONE | Advisory; documentation | advisory | Document per-provider rotation in breach runbook |
+| SEC-045 | memory/security.md | Persistence-sweep checklist documented. | NONE | Advisory; documentation | advisory | Document in breach runbook |
+| SEC-046 | memory/security.md | Forensics steps documented. | NONE | Advisory; documentation | advisory | Document in breach runbook |
+| SEC-047 | memory/security.md | Notification rules documented. | NONE | Advisory; documentation | advisory | Document in breach runbook |
+| SEC-048 | memory/security.md | Pillar 12 — Pin every npm/pip dep. | NONE | No dep-pinning check in CI | build-runner-gate | Add `gate:supply-chain` step checking package-lock.json for unpinned ranges |
+| SEC-049 | memory/security.md | npm audit --production + socket.dev or snyk in CI. | NONE | No npm audit step in build-runner.sh | build-runner-gate | Add gate:supply-chain step running npm audit --production and failing on high/critical |
+| SEC-050 | memory/security.md | gate:supply-chain in build-runner. | NONE | gate:supply-chain is not a step in build-runner.sh | build-runner-gate | Add `gate:supply-chain` step to build-runner.sh (npm audit + dep pinning check) |
+| SEC-051 | memory/security.md | Compromised dep could exfil secrets at runtime. | NONE | Advisory; rationale for SEC-048/049 | advisory | No independent enforcement; covered by SEC-048 and SEC-049 |
+| SEC-052 | memory/security.md | Any code task that writes to .env* or commits credential-shaped strings must be auto-blocked. | NONE | No .env write detection in task execution | pre-commit-hook | Add pre-commit hook rule blocking any staged .env* file; add executor task-completion check for credential-shaped strings in diff |
+| SEC-053 | memory/security.md | Any new key provisioning must first land in Vault, then app fetches via broker. | NONE | Advisory; key provisioning procedure | advisory | Document in key provisioning runbook |
+| SEC-054 | memory/security.md | Any rotation event emits secret.rotated to the event bus. | NONE | No rotation event emission | runtime-middleware | Add event emission to rotation scheduler: emit secret.rotated after successful rotation |
+| SEC-055 | memory/security.md | On any system.warning tagged secret-adjacent, circuit breaker pauses the originating task. | NONE | No secret-adjacent warning handler | runtime-middleware | Add system.warning event handler in executor that pauses originating task when tag includes secret-adjacent |
+
+---
+
+### TASK — Task Run Record Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| TASK-001 | memory/task-run.md | Every start_code_task or start_task call must be immediately followed by task_run_record. | NONE | task_run_record MCP tool exists but no enforcement of call sequence | runtime-middleware | Add MCP middleware asserting task_run_record is called within 5s of any start_code_task call |
+| TASK-002 | memory/task-run.md | No exceptions. | NONE | No enforcement | runtime-middleware | Same as TASK-001; zero-tolerance enforcement in MCP middleware |
+| TASK-003 | memory/task-run.md | When detecting a stall and respawning, call task_run_record with respawn_of_session_id. | NONE | No respawn tracking enforcement | runtime-middleware | Executor respawn path in completion-hook must call task_run_record with respawn_of_session_id |
+| TASK-004 | memory/task-run.md | Both sides of the respawn link must be recorded. | NONE | No bidirectional respawn link | runtime-middleware | task_run_record call on respawn writes both original session_id and new session_id linkage |
+| TASK-005 | memory/task-run.md | When a child task completes a meaningful unit, call task_run_subtask_upsert. | NONE | No subtask upsert enforcement | runtime-middleware | Executor completion hook calls task_run_subtask_upsert when task completes a sub-unit |
+| TASK-006 | memory/task-run.md | Include this instruction in every new task prompt. | NONE | No subtask upsert instruction in dispatcher prompt | runtime-middleware | Dispatcher prompt builder includes task_run_subtask_upsert instruction for every new task |
+| TASK-007 | memory/task-run.md | Tag every task_run with the domains it touches. | NONE | No domain tagging in task_run_record calls | runtime-middleware | Executor passes domain_slug from task to task_run_record call |
+| TASK-008 | memory/task-run.md | Scope to poker-zeno, roulette-community, conductor, plugins as appropriate. | NONE | No scope enforcement | runtime-middleware | domain_slug column in task_run records populated from task.domain_slug |
+| TASK-009 | memory/task-run.md | When a task reports done, call task_run_update with status='completed'. | NONE | No task_run_update enforcement | runtime-middleware | completion-hook must call task_run_update after marking task done |
+| TASK-010 | memory/task-run.md | On failure, status='failed', result_ok=false. | NONE | No failed task_run_update enforcement | runtime-middleware | completion-hook must call task_run_update with status=failed on failure path |
+| TASK-011 | memory/task-run.md | The poller is a safety net: apps/task-run-poller daemon scans local session JSONLs every 30s. | PARTIAL | task_run_record MCP tool exists; poller concept referenced | Gap: no verified task-run-poller daemon implementation found | daemon | Verify or implement apps/task-run-poller daemon that scans session JSONLs every 30s for missed task_run_record calls |
+| TASK-012 | memory/task-run.md | Do not rely on poller as the primary — use the MCP tools at the moment of spawn. | NONE | No enforcement of MCP-first approach | runtime-middleware | Same as TASK-001; MCP middleware enforces immediate task_run_record at spawn time |
+
+---
+
+### TRACE — Prompt Trace Rules
+
+| rule_id | memory_file | rule_text | current_enforcement | enforcement_gap | proposed_mechanism | proposed_implementation |
+|---------|-------------|-----------|--------------------|-----------------|--------------------|------------------------|
+| TRACE-001 | memory/trace.md | The first action on receiving any user prompt is prompt_create. Before analysis, before decomposition, before any LLM call. | NONE | No middleware enforcing prompt_create as first action | runtime-middleware | Add MCP server middleware: all incoming tool calls check prompt_id is set; first call must be prompt_create |
+| TRACE-002 | memory/trace.md | The prompt must be persisted synchronously. | NONE | No synchronous persistence check | runtime-middleware | prompt_create MCP tool uses synchronous DB write; middleware blocks if prompt not found in DB before proceeding |
+| TRACE-003 | memory/trace.md | The returned prompt_id threads through every downstream action as root_prompt_id and correlation_id. | NONE | root_prompt_id exists as nullable column; no threading enforcement | runtime-middleware | MCP server middleware passes prompt_id as context through all downstream tool calls |
+| TRACE-004 | memory/trace.md | Steps: (1) call prompt_create synchronously, (2) receive prompt_id, (3) all subsequent tool calls thread correlation_id. | NONE | No step sequence enforcement | runtime-middleware | Same as TRACE-001/003; MCP session context tracks prompt_id and injects into all subsequent calls |
+| TRACE-005 | memory/trace.md | Call story_decompose with root_prompt_id=prompt_id. | NONE | No root_prompt_id injection into story_decompose | runtime-middleware | story_decompose MCP tool handler requires root_prompt_id parameter; rejects if missing |
+| TRACE-006 | memory/trace.md | Every leaf the decomposer produces must inherit root_prompt_id=prompt_id. | NONE | No leaf root_prompt_id inheritance enforcement | runtime-middleware | story_decompose propagates root_prompt_id to all generated leaf nodes in stories table |
+| TRACE-007 | memory/trace.md | When responding to user, emit prompt.responded event. | NONE | No prompt.responded event emission | runtime-middleware | MCP SendUserMessage wrapper emits prompt.responded event with correlation_id |
+| TRACE-008 | memory/trace.md | When all descendants reach done, emit prompt.completed event + compute elapsed_ms. | NONE | No prompt.completed event emission | daemon | Add prompt-completion tracker daemon: queries descendants of each prompt; emits prompt.completed when all done |
+| TRACE-009 | memory/trace.md | No exceptions. Mechanical. | NONE | Advisory emphasis for TRACE-001 through TRACE-008 | runtime-middleware | Enforced by implementing TRACE-001 through TRACE-008 middleware |
+
+---
+
+## Summary by Proposed Mechanism
+
+| Mechanism | Rule Count |
+|-----------|-----------|
+| build-runner-gate | 89 |
+| runtime-middleware | 71 |
+| daemon | 52 |
+| advisory | 98 |
+| eslint-rule | 17 |
+| contract-test | 20 |
+| db-constraint | 7 |
+| pre-commit-hook | 3 |
+| **Total** | **357** |
+
+---
+
+## Currently Enforced Rules (42)
+
+| rule_id | Enforcing Mechanism |
+|---------|---------------------|
+| SEC-005 | .githooks/pre-commit (gitleaks + trufflehog) + gate:no-secrets |
+| SEC-008 | .githooks/pre-commit |
+| SEC-009 | build-runner.sh gate:no-secrets step 0 |
+| SEC-037 | .githooks/pre-commit |
+| SEC-038 | build-runner.sh + CI |
+| SEC-039 | build-runner.sh abort on gate:no-secrets failure |
+| ENFORCE-001 | build-runner.sh gate:observability |
+| ENFORCE-003 | build-runner.sh gate:observability |
+| ENFORCE-007 | build-runner.sh gate:coverage |
+| EXEC-001 | executor_config.enabled defaults to false in DB schema |
+| EXEC-002 | executor_config.max_concurrent=3, max_per_domain_concurrent=1 defaults in DB schema |
+| EXEC-006 | completion-hook.ts checkAndBreak + executor_config.circuit_breaker_threshold=3 |
+| EXEC-005 | dispatcher.ts git worktree per task |
+| OBS-009 | build-runner.sh wraps all build invocations |
+| OBS-011 | build-runner.sh assigns BUILD_RUN_ID |
+| OBS-012 | build-runner.sh emits build.started |
+| OBS-013 | build-runner.sh emits build.step_started per step |
+| OBS-015 | build-runner.sh emits build.step_completed/failed |
+| OBS-017 | build-runner.sh emits build.completed/aborted |
+
+---
+
+## Top Priority Gaps (Highest Leverage, Lowest Effort)
+
+1. **HEALTH-009** — Add `.notNull()` to `tasks.root_prompt_id` in schema: single-line DB schema change, prevents null root traces permanently.
+2. **TRACE-001/002/003** — MCP middleware enforcing prompt_create as first action: blocks all orphaned task creation with no prompt ancestry.
+3. **TASK-001/TASK-002** — MCP middleware asserting task_run_record within 5s of spawn: closes the largest audit trail gap.
+4. **AUTON-009/AUTON-010** — outbound_messages table + nightly phrase scanner: catches autonomy regressions automatically.
+5. **DOM-001/DOM-002** — API validation requiring domain_tags on entity creation: prevents untagged entity accumulation.
+6. **SEC-050** — Add `gate:supply-chain` to build-runner.sh: one new step in existing gate pipeline.
+7. **ACCESS-035** — Add `gate:a11y` to build-runner.sh: one new step that covers ACCESS-001 through ACCESS-040 in batch.

--- a/docs/legacy-conductor-reports/secrets-hyper-security-deployment.md
+++ b/docs/legacy-conductor-reports/secrets-hyper-security-deployment.md
@@ -1,0 +1,151 @@
+# Secrets Hyper-Security P0 Deployment Report
+**Generated:** 2026-04-22T01:15:00Z  
+**root_prompt_id:** rp_shsec_42f81bb0  
+**Deployed by:** secrets-hyper-security-deploy (autonomous, away mode)
+
+---
+
+## 1. Repos Deployed
+
+| Repo | Status | Commit SHA | Pre-commit Hook | CI Workflow | gate:no-secrets |
+|------|--------|------------|-----------------|-------------|-----------------|
+| conductor | ✅ Deployed | `d6e29c2` | ✅ | ✅ | ✅ + build-runner.sh |
+| pokerzeno | ✅ Deployed | `0ab43a3` | ✅ | ✅ | ✅ |
+| roulettecommunity | ✅ Deployed | `6436fbe` | ✅ | ✅ | ✅ |
+| stolution | ✅ Deployed (branch: cci-sec/secrets-hyper-security-gates) | `c21ff79c` | ✅ | ✅ | — (pnpm ecosystem, script not added) |
+| edisoncricket | ❌ NOT FOUND | — | — | — | — |
+
+> **edisoncricket:** No local directory or git remote found anywhere under `/Users/MAC/Documents/projects/`. No GitHub remote matching `edisoncricket` was discovered. Action: provide the local path or GitHub URL when back.
+
+---
+
+## 2. Tools Installed
+
+| Tool | Version | Location |
+|------|---------|----------|
+| gitleaks | 8.30.1 (≥ v8.18 ✓) | `/opt/homebrew/bin/gitleaks` (Mac) |
+| trufflehog | 3.95.2 | `/opt/homebrew/bin/trufflehog` (Mac) |
+| gitleaks | 8.30.1 | `~/bin/gitleaks` (stolution Linux x86_64) |
+| trufflehog | 3.95.2 | `~/bin/trufflehog` (stolution Linux x86_64) |
+
+---
+
+## 3. Gates Deployed Per Repo
+
+Each repo received:
+- **`.gitleaks.toml`** — 12 custom provider rules: Anthropic, OpenAI, Cloudflare (global + scoped), GA4 service account, Stripe live/restricted, SendGrid, GitHub PAT (classic + fine-grained), Cloudinary URL, Pixabay. Plus allowlist for test fixtures, example files, `.gitignore` patterns.
+- **`.githooks/pre-commit`** — runs `gitleaks protect --staged --no-banner --redact` + `trufflehog git file://. --since-commit HEAD~1 --only-verified --fail`. Chmod +x. `git config core.hooksPath .githooks` set.
+- **`.github/workflows/secrets-scan.yml`** — 4 steps: gitleaks-action@v2, trufflehog verified-only diff, bundle-bake detector (scans `dist/out/.next/static/public` after build), npm audit + optional socket scan.
+- **`gate:no-secrets` npm script** — `gitleaks detect + trufflehog verified-only` (conductor/pokerzeno/roulettecommunity).
+- **`build-runner.sh` step 0** (conductor only) — `gate:no-secrets` runs before typecheck; blocks build on any finding.
+
+---
+
+## 4. Historical Scan Results
+
+| Repo | Commits | Bytes Scanned | Raw Findings | Verified-Live | Rotated | Status |
+|------|---------|---------------|--------------|---------------|---------|--------|
+| conductor | 14 | 1.86 MB | 0 | 0 | — | ✅ CLEAN |
+| pokerzeno | 7 | 1.26 MB | 0 | 0 | — | ✅ CLEAN |
+| roulettecommunity | 6 | 1.43 MB | 0 | 0 | — | ✅ CLEAN |
+| stolution | 1,671 | 118.48 MB | 289 (raw) | 1 | ❌ (see below) | ⚠️ ACTION NEEDED |
+
+### Stolution Finding Classification
+
+| Finding | Rule | File | Commits | Status | Action |
+|---------|------|------|---------|--------|--------|
+| `ghp_[REDACTED]` GitHub Classic PAT | github-pat | docker-compose.dev.yml | c9f7819920, 10bdfb2b9b, 14ace1b6bc, 61df4c8c5d, 6683912c48 | **ACTIVE** | ❌ ROTATE MANUALLY (see blocker blk_TLCUfuao) |
+| SSL private keys (4 files) | private-key | config/nginx/ssl/*, config/postgres/ssl/ | e945a0b727 | Self-signed — no CA revocation | ⚠️ Regenerate (see blocker blk_fssRfa) |
+| `.next.backup.root` build cache | generic-api-key | apps/web/.next.backup.root/ | da88ba9a33 | False positive — public Firebase key baked in | ⚠️ Remove from git history (blocker blk_MTQTtf5M) |
+| Firebase GCP API key `AIzaSy...` | gcp-api-key | apps/web/src/utils/Firebase.ts, firebase-messaging-sw.js | 0256d75fb2, e945a0b727 | **PUBLIC CLIENT KEY** (by design) | ✅ Added to allowlist |
+| Atlassian JIRA token `ATATT3[REDACTED]` | atlassian-api-token | config/claude-dotfiles/agents/jira-connect/ | f32b565424, 2a37bf8385, bbda5bad69 | **EXPIRED** — verified via API 2026-04-22 | ✅ Added to allowlist |
+| JWT tokens (6) | jwt | build cache + JWTContext.tsx test fixture | e945a0b727 | Test fixture / build artifact | ✅ Allowlisted via path |
+| hashicorp-tf-password (1) | hashicorp-tf-password | infrastructure/k8s/terraform/modules/ | a170be6377 | Commit no longer on HEAD — historical artifact | ℹ️ Low risk, old commit |
+| Generic API keys (248) | generic-api-key | test files, seed files, build cache | various | False positives — test data + build artifacts | ✅ Allowlisted via path |
+
+---
+
+## 5. Key Rotation Outcomes
+
+| Secret | Provider | Rotation Method | Outcome |
+|--------|----------|-----------------|---------|
+| `ghp_WPWZy...` GitHub Classic PAT | GitHub | `DELETE /user/personal-access-tokens/{id}` | **BLOCKED** — Classic PATs have no programmatic revocation API. Manual action required. |
+| Atlassian JIRA token `ATATT3...` | Atlassian | API check | Verified EXPIRED — no rotation needed |
+| SSL private keys | self-signed CA | openssl key generation | Rotation is server-side; new keys can be generated without external API |
+
+### URGENT: GitHub PAT Manual Rotation Required
+```
+Token: ghp_[REDACTED — stored in conductor blocker blk_TLCUfuao description]
+Owner: login=prakashgbid (verified active 2026-04-22T01:10:00Z)
+Location: stolution git history — docker-compose.dev.yml
+Action: https://github.com/settings/tokens → find + delete this token
+Then: create new fine-grained PAT with minimal scopes, store in vault
+```
+
+---
+
+## 6. Conductor Blockers Filed
+
+| Blocker ID | Severity | Title |
+|-----------|---------|-------|
+| `blk_TLCUfuao` | critical | P0: LIVE GitHub PAT exposed in stolution git history — ROTATE NOW |
+| `blk_fssRfa` | high | P1: Self-signed SSL private keys committed to stolution git history — regenerate |
+| `blk_MTQTtf5M` | high | P1: .next.backup.root build cache committed to stolution git — remove from history |
+
+---
+
+## 7. Conductor P1–P3 Tasks Filed (via sqlite3 fallback — conductor offline)
+
+| Task ID | Priority | Title |
+|---------|---------|-------|
+| `tsk_Bi0jqsT` | P1 | Pillar 6: Least-privilege token audit |
+| `tsk_XkrZvYep` | P1 | Pillar 7: Automated secret rotation scheduler |
+| `tsk_CQIKtA6V` | P1 | Pillar 8: vault.secret_accessed events + Grafana dashboard |
+| `tsk_opeEbuIS` | P2 | Pillar 2: AppRole + OIDC CI authentication |
+| `tsk_HyKumgau` | P2 | Pillar 5: Bundle-bake detector enforcement + CI metric |
+| `tsk_cglxQJ20` | P2 | Pillar 12: Supply-chain gate in conductor build-runner |
+| `tsk_d5R22m2` | P3 | Pillar 3: HSM-backed vault unseal evaluation |
+| `tsk_0eRVhS` | P3 | Pillar 10: Bootstrap ceremony documentation |
+
+---
+
+## 8. Baseline Events Emitted (→ ~/.conductor/events.jsonl)
+
+```
+secret.baseline_established — conductor     (0 findings, gitleaks@8.30.1)
+secret.baseline_established — pokerzeno     (0 findings, gitleaks@8.30.1)
+secret.baseline_established — roulettecommunity (0 findings, gitleaks@8.30.1)
+secret.baseline_established — stolution     (289 raw findings, 1 verified-live, blockers filed)
+```
+
+---
+
+## 9. Bonus Fix Applied
+
+**pokerzeno + roulettecommunity `.gitignore` gap closed:** `.env.production` files were present in both repos but NOT covered by `.gitignore`. Added `.env.production` to both `.gitignore` files (committed in the same P0 commit). This closes a potential accidental secret commit vector.
+
+---
+
+## 10. Runbook
+
+Written at: `/Users/MAC/Documents/runbooks/secret-breach.md`
+
+Covers: T+0 confirm/rotate, T+15 vault update/broker restart, T+30 audit forensics, T+45 blast-radius analysis, T+60 notify. Per-provider rotation commands for all 10 providers.
+
+---
+
+## 11. What Was NOT Done (Requires Follow-Up)
+
+| Item | Reason | Next Step |
+|------|--------|-----------|
+| edisoncricket deployment | Repo not found locally | Provide path or GitHub URL |
+| GitHub PAT revocation | Classic PAT — no programmatic revocation API | Manual: github.com/settings/tokens |
+| SSL key regeneration | Requires stolution server restart | Run via runbooks/secret-breach.md → Self-signed keys section |
+| .next.backup.root git history cleanup | Requires git-filter-repo + force-push (destructive) | Blocker blk_MTQTtf5M |
+| stolution `pnpm gate:no-secrets` script | Stolution uses pnpm with different script structure | Add in a follow-up PR: "gate:no-secrets": "gitleaks detect --source . --config .gitleaks.toml --no-banner --redact && trufflehog git file://. --only-verified --fail --no-update" |
+| conductor MCP prompt_create | Tool not in conductor MCP schema (tools: conductor_add/start/complete/fail/status/dag/list/query) | Used sqlite3 fallback — tasks are in DB |
+| P1–P3 task prioritization engine slot | Conductor offline | Tasks are queued, will be prioritized when conductor restarts |
+
+---
+
+*Deployment complete. Root prompt: rp_shsec_42f81bb0 | Pillars deployed: P0 (Pillar 0, 9, 11) across 4/5 repos.*

--- a/docs/legacy-conductor-reports/stolution-codebase-analysis.md
+++ b/docs/legacy-conductor-reports/stolution-codebase-analysis.md
@@ -1,0 +1,431 @@
+# Stolution Codebase Analysis
+**Date:** April 28, 2026  
+**Purpose:** Strategic analysis to inform CAIA feature development for Stolution  
+**Codebase:** `~/Documents/projects/stolution-fix/`
+
+---
+
+## 1. Full Project Structure
+
+### Top-Level Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `apps/api` | NestJS backend API (port 3001) |
+| `apps/web` | Next.js production frontend (port 3000) |
+| `apps/web-dev` | Next.js development instance (port 3004 / 8081) |
+| `ai-search` | Elasticsearch integration & AI search services |
+| `ai` | Python-based AI services (anomaly detection, embeddings, query parsing) |
+| `config` | Nginx, SSL, Prometheus monitoring configs |
+| `docs` | 30+ architectural documentation files |
+| `scripts` | Data processing and ETL scripts |
+| `monitoring` | Grafana, Prometheus, alerting setup |
+
+### Services Map
+
+| Service | Framework | Port | Purpose |
+|---------|-----------|------|---------|
+| API | NestJS 10.3 | 3001 | Main backend — TypeORM + PostgreSQL |
+| Web (prod) | Next.js 14.2 | 3000 | Production frontend (PM2) |
+| Web (dev) | Next.js 14.2 | 8081 | Development frontend |
+| PostgreSQL | Docker | 5432 | Main database (115GB+) |
+| Meilisearch | Docker | 7700 | Full-text search engine (201GB index) |
+| Redis | Docker | 6379 | Cache & job queues |
+| Nginx | Docker | 80/443 | Reverse proxy with SSL |
+| Elasticsearch | Docker | 9200 | Optional fallback search |
+
+### CI/CD Pipeline
+
+- **`develop` branch** → Auto-runs dev-checks on PR, auto-merges on success
+- **`qa` branch** → Full test suite (lint, build, E2E, accessibility, Playwright)
+- **`main` branch** → Production deploy, triggered by nightly release (2 AM UTC)
+- **Deployment target:** PM2 on remote server at `162.251.161.17` (user `s903`)
+- **Quality gates:** CC Guardrails (pre-commit), ESLint, TypeScript, Prettier, security audits
+- **Protected files:** `.github/workflows/*`, `.husky/*`, `.eslintrc*`, `.prettierrc*`
+
+---
+
+## 2. Data Layer (Most Important)
+
+### Database: PostgreSQL 15 with PostGIS
+
+**Primary tables:**
+
+| Table | Records | Purpose |
+|-------|---------|---------|
+| `imported_businesses` | 76.26M | Master store directory, partitioned by state |
+| `chain_brands` | ~4,300 | Chain store brand summary (All The Places data, Wikidata-linked) |
+| `chain_locations` | ~2.6M | Chain/franchise locations with OSM tags |
+| `search_categories` | ~50 | Search category hierarchy with icons/colors |
+| `products` | Millions | Product catalog per business |
+| `deals` | Hundreds K | Store deals, coupons, promotions |
+
+### Business Record Fields (`imported_businesses`)
+
+```
+Core:      id, name, category, category_sector, phone, website, email
+Location:  address, city, state, zip, latitude, longitude, geometry (PostGIS)
+Hours:     is_24_7, opens_at, closes_at, regular_hours
+Status:    is_hiring, is_seeking_partner, is_for_sale, is_closing_soon
+Offerings: has_deals, has_coupons, has_events, has_rewards, has_sharing_space
+Counts:    deals_count, coupons_count, events_count, rewards_count
+Metadata:  created_at, updated_at, import_run
+```
+
+### Data Sources
+
+1. **All The Places** — 4,300+ chain brands + 20M+ global locations (Wikidata-linked)
+2. **Government data** — Business registers, SBA lists
+3. **Web scraping** — Custom infrastructure (Playwright, residential proxies, CAPTCHA solving)
+4. **Business websites** — Direct imports
+5. **Historical imports** — Yelp, Google Maps data (partially)
+
+**Key fact:** Self-scraping infrastructure costs ~$5.5K/yr vs. $374K/yr for third-party APIs (documented in `DATA_ACQUISITION_INFRASTRUCTURE.md`).
+
+### Search Infrastructure
+
+| System | Role | Status |
+|--------|------|--------|
+| **Meilisearch** | Primary full-text search | ✅ 201GB index, facets, filters, sorting — live |
+| **Elasticsearch** | Optional fallback / semantic | ⚠️ Configured, fallback-only |
+| **PostgreSQL fulltext** | `tsvector` with English unaccent | ✅ Available |
+| **PostGIS** | Geographic / distance queries | ✅ Spatial indexes in place |
+| **pgvector** | Semantic embeddings | ❌ Planned, not deployed |
+
+### ETL / Data Ingestion
+
+- `/scripts/` — Data processing scripts
+- `/apps/api/src/database/migrations/` — 9 numbered migrations (filters, NAICS codes, demographics, chains, products, categories)
+- Mock data seeder: generates 100K–10M synthetic users for testing
+- `data-import.controller.ts` — Admin-facing ETL pipeline management
+- Incremental Meilisearch refresh strategy: planned but not automated
+
+### Critical Indexes
+
+- State / city / zip for location queries
+- `category_sector` for NAICS filtering
+- Boolean fields: `is_24_7`, `is_hiring`, `has_deals`
+- PostGIS spatial indexes for distance queries
+- Full-text search indexes on `name`, `category`, `description`
+
+---
+
+## 3. API Layer — Built vs. Missing
+
+### Built Controllers (NestJS)
+
+| Module | Controller | Endpoints | Status |
+|--------|-----------|-----------|--------|
+| Businesses | `businesses.controller.ts` | GET / (filtered), GET :id, POST, PATCH, DELETE, PATCH :id/hours | ✅ Core built |
+| Search | `search.controller.ts` | Global search, categories, featured categories | ✅ Built |
+| Meilisearch | `business-search.controller.ts` | Dedicated Meilisearch-backed search | ✅ Built |
+| Auth | `auth.controller.ts` | Login, register, JWT | ✅ Built |
+| Users | `users.controller.ts` | User CRUD, profiles | ✅ Built |
+| Products | `products.controller.ts` | Product CRUD per business | ✅ Built |
+| Deals | `deals.controller.ts` | Deal/coupon management | ✅ Built |
+| Jobs | Mock jobs controller | Job posting + search | ⚠️ Mock data only |
+| Chat | `chat.controller.ts` | Real-time messaging (Socket.io) | ✅ Built |
+| Business Claims | `business-claims.controller.ts` | Ownership verification | ✅ Built (incomplete integration) |
+| CMS | `cms.controller.ts` | Content management | ✅ Built |
+| Files | `files.controller.ts` | File upload/storage | ✅ Built |
+| Location | `location.controller.ts` | Zipcode lookup, geolocation | ✅ Built |
+| Notifications | `notifications.controller.ts` | Real-time notifications | ✅ Built |
+| Reviews | `reviews.controller.ts` | Review/rating system | ✅ Built |
+| Events | `events.controller.ts` | Event management | ✅ Built |
+| Data Import | `data-import.controller.ts` | ETL pipeline admin | ✅ Built |
+| Metrics | `metrics.controller.ts` | Prometheus metrics | ✅ Built |
+| API Status | `api-status.controller.ts` | Health checks + admin dashboard | ✅ Built |
+| Landing | `landing.controller.ts` | Static marketing content | ✅ Built |
+
+### Authentication
+
+- ✅ JWT-based (passport-jwt) + Local strategy
+- ✅ Firebase Admin for mobile push notifications
+- ✅ Global `JwtAuthGuard` protecting routes
+- ✅ `@CurrentUser()` decorator for extracting user from token
+
+### Location Filtering
+
+- ✅ `X-Zipcode` header (required globally)
+- ✅ `X-Distance-Miles` header (optional, default 25 miles)
+- ✅ `@LocationContext` decorator provides location object to controllers
+- ✅ `@SkipLocationFilter()` for endpoints that opt out
+
+### API Design Patterns
+
+- Swagger/OpenAPI fully documented at `/docs`
+- URI-based versioning: `/api/v1/...`
+- Global validation pipe with class-validator & class-transformer
+- Response compression (gzip)
+- CORS: `localhost:3000`, `localhost:8081`, `*.vercel.app`
+- Helmet security headers
+- Global error handling via exception filters
+
+### What's Missing / Incomplete
+
+| Gap | Impact |
+|----|--------|
+| ❌ Admin panel (AdminJS disabled) | No moderation capability |
+| ❌ Rate limiting / DDoS protection | Critical for public-facing scale |
+| ❌ Response pagination on list endpoints | Unbounded queries risk memory exhaustion |
+| ❌ Email notifications (not integrated) | No user lifecycle emails |
+| ❌ Analytics (GA4, Sentry not deployed) | Blind to user behavior |
+| ❌ Monetization layer (adSense, premium features) | No revenue path |
+| ⚠️ Business claim integration | Controller exists, UI connection incomplete |
+| ⚠️ Redis caching | Infrastructure ready, `SearchCacheService` not implemented |
+| ⚠️ BullMQ job queues | Infrastructure ready, not wired for imports |
+| ⚠️ Semantic search (pgvector) | Planned, not deployed |
+| ⚠️ Multi-language support | Infrastructure present, not connected |
+
+---
+
+## 4. Frontend — Built vs. Missing
+
+### Pages / Routes (Next.js 14.2)
+
+| Route | Status | Purpose |
+|-------|--------|---------|
+| `/`, `/home-v2` | ✅ Built | Homepage with featured businesses |
+| `/dashboard/*` | ✅ Built (30+ sub-routes) | Business owner + job seeker dashboard |
+| `/auth/login`, `/register` | ✅ Built | Authentication flows |
+| `/auth/reset-password`, `/verify-code` | ✅ Built | Password recovery |
+| `/business/*` | ✅ Built | Public business profiles + editing |
+| `/career/*`, `/job*` | ✅ Built | Job listings + applications |
+| `/deals*` | ✅ Built | Deal/coupon browsing |
+| `/articles/*` | ✅ Built | Blog content |
+| `/search` | ✅ Built | Search results (partial filter UI) |
+| `/help-center` | ✅ Built | FAQ/support |
+| `/about-us`, `/contact-us`, `/founder` | ✅ Built | Static marketing pages |
+| `/coming-soon` | ✅ Built | Teaser pages |
+| Legal pages | ✅ Built | Privacy, CCPA, DMCA, cookie policy |
+
+### UI Stack
+
+- Material-UI v5.10 with custom theme + Emotion styling
+- Mapbox GL for maps
+- FullCalendar for appointments
+- Redux + Redux Toolkit for state
+- Framer Motion for animations
+- i18next configured (not fully integrated)
+- Firebase Auth for push notifications
+- Mock data provider for backend-less testing
+
+### Dashboard Sections
+
+- `@dashboard/general` — Overview dashboard
+- `@dashboard/business-profile` — Business management
+- `@dashboard/job-seeker` — Job search & applications
+- `@dashboard/deals` — Deal creation/management
+- `@dashboard/chat` — Real-time messaging UI
+- `@dashboard/calendar` — Appointment scheduling
+- Store public pages — Consumer-facing business listing pages
+
+### What's Missing / Incomplete
+
+| Gap | Impact |
+|----|--------|
+| ❌ Mobile app | Web-only; no iOS/Android |
+| ❌ Payment/checkout UI | Stripe not integrated |
+| ❌ Seller onboarding flow | Business registration incomplete |
+| ⚠️ Search filter UI | Facet filters disconnected from Meilisearch |
+| ⚠️ Distance display in results | Headers work, UI display missing |
+| ⚠️ Category-based browsing on homepage | API works, UI incomplete |
+| ⚠️ Review/ratings UI | Backend exists, components incomplete |
+| ⚠️ Real-time notification UI | Socket.io ready, UI not integrated |
+| ⚠️ Multi-language UI | i18n configured, translations not populated |
+| ⚠️ Analytics tracking | GA4 placeholder not connected |
+| ⚠️ WCAG accessibility | A11y project exists, incomplete |
+
+---
+
+## 5. CLAUDE.md & Planning Docs
+
+### Development Context (from CLAUDE.md)
+
+- All dev happens on remote server: `162.251.161.17` SSH as `s903`
+- Production code at `/home/s903/stolution/`
+- Database: `ssh stolution "docker exec -it stolution-postgres psql..."`
+- Pre-commit hooks: CC Guardrails (blocks `eslint-disable`, `@ts-ignore`, `TODO`, `console.log`), formatting, linting, types, secret scanning
+
+### Master Strategic Roadmap
+
+**P0 — Critical (build toward 1M visitors/day):**
+1. Cloud Migration — 60% done (moving to Hetzner)
+2. Search Enhancement — 40% done (Redis caching, semantic search, pgvector)
+3. Database Optimization — 45% done (query perf, connection pooling, materialized views)
+4. Cybersecurity & Compliance — 20% done (SOC2, HIPAA, GDPR)
+5. SEO & Content Strategy — 25% done (sitemap, structured data)
+6. Legal & Compliance — 40% done
+
+**P1 — High:**
+- Backend Architecture — 50% (BullMQ, WebSocket, event-driven)
+- Frontend Architecture — 30% (component library, micro-frontends)
+- Analytics & Business Intelligence — 15%
+- Marketing & Promotion — 10%
+- Customer Support — 5%
+
+**P2 — Medium:**
+- Monetization Strategy — 75% designed (freemium model planned)
+- Mobile App — 0%
+- Partnership & B2B — 30%
+- Community Building — 10%
+
+### Traffic Growth Targets
+
+| Milestone | Daily Visitors | Monthly |
+|-----------|---------------|---------|
+| Month 1 | 1,000 | 30,000 |
+| Month 6 | 100,000 | 3M |
+| Month 12 | 1,000,000 | 30M |
+
+### Key Architecture Docs in `/docs`
+
+- `EVENT_DRIVEN_ARCHITECTURE.md` — Event sourcing, outbox pattern, TypeORM subscribers
+- `ADVANCED_SEARCH_OPTIMIZATION.md` — Query caching, facet analysis, semantic search plan
+- `DATABASE_ARCHITECTURE_ANALYSIS.md` — Schema analysis, partitioning strategy
+- `MASTER_DATA_SOURCES_DIRECTORY.md` — All data sources (government, APIs, scraping)
+- `DATA_ACQUISITION_INFRASTRUCTURE.md` — Self-scraping cost analysis ($5.5K/yr vs $374K API)
+- `GO_LIVE_CLOUD_MIGRATION_PLAN.md` — Migration checklist & timeline
+- `MASTER_CATALOGUE_ARCHITECTURE.md` — Product catalog unified schema
+
+---
+
+## 6. Gap Analysis
+
+### What IS Working End-to-End
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Store directory search | ✅ | Meilisearch indexing + location filtering operational |
+| Store detail pages | ✅ | Public business profiles visible |
+| Business CRUD | ✅ | Owners can create/edit businesses |
+| Authentication | ✅ | JWT + Firebase working |
+| Deal management | ✅ | Deals/coupons created per business |
+| Real-time chat infrastructure | ✅ | Socket.io ready |
+| Job posting (mock) | ⚠️ | Mock data only |
+| Admin/CMS | ⚠️ | AdminJS disabled, partially built |
+
+### The Critical Gap: Consumer Discovery Flow is Broken
+
+The platform has 76M+ store records but the **search → discovery → trust** pipeline is incomplete:
+
+1. **Search filter UI** is disconnected from Meilisearch facets (backend works, frontend doesn't use it)
+2. **Distance sorting** headers exist, but no distance display in search results
+3. **Category browsing** on homepage is incomplete
+4. **No business quality scoring** — 76M records with no way to rank "good" vs. "bad" listings
+5. **Claim system** not connected — unverified vs. verified businesses are indistinguishable
+
+### Single Most Impactful Thing to Build First
+
+**🎯 Complete the Search + Discovery Pipeline**
+
+This is the critical path because:
+- 76M store records are useless without discoverable search
+- SEO traffic (the primary growth driver for local search) depends on well-structured, discoverable content
+- Business verification and quality signals are prerequisites for trust
+- Everything downstream (monetization, premium placement, analytics) depends on users actually finding stores
+
+### Dependency Order for Feature Development
+
+```
+TIER 0 — Foundational (build first)
+  1. Complete Search UI
+     ├─ Dynamic facet filters wired to Meilisearch
+     ├─ Distance-based sorting + distance display in results
+     ├─ Category landing pages (city + category combos for SEO)
+     └─ Search analytics (log popular queries)
+
+  2. Business Quality + Trust Signals
+     ├─ Relevance scoring (claimed, reviews, recent activity)
+     ├─ Business claim verification flow (UI connection)
+     ├─ Review/rating aggregation display
+     └─ Verified badge / unverified distinction
+
+  3. Infrastructure Quick Wins
+     ├─ Implement SearchCacheService (Redis) — ~73% faster search
+     ├─ Add pagination to all list endpoints
+     └─ Rate limiting / basic DDoS protection
+
+TIER 1 — Revenue + Growth (next 2 months)
+  4. SEO Optimization
+     ├─ Canonical URLs for every business page
+     ├─ Structured data (schema.org LocalBusiness)
+     ├─ XML sitemap (76M+ pages, incremental)
+     └─ Open Graph meta tags
+
+  5. Admin Dashboard
+     ├─ Business moderation queue
+     ├─ Data quality monitoring
+     └─ Manual ranking adjustments
+
+  6. Monetization Layer
+     ├─ Featured/sponsored listings
+     ├─ Premium placement in search results
+     └─ Business subscription tiers
+
+TIER 2 — Scale + Intelligence (2–4 months)
+  7. Analytics & Insights
+     ├─ Google Analytics 4 integration
+     ├─ Conversion tracking
+     └─ Query analytics dashboard
+
+  8. Personalization Engine
+     ├─ Saved favorites, search history
+     ├─ Recommendations (similar stores, trending nearby)
+     └─ A/B testing framework
+
+TIER 3 — Advanced (4–6 months)
+  9. Semantic Search (pgvector)
+     ├─ Business embedding generation
+     └─ Hybrid keyword + semantic search
+
+  10. Mobile App (iOS / Android)
+
+  11. B2B / API Layer
+      ├─ Public API for third-party integrations
+      └─ White-label solution
+```
+
+### Infrastructure Readiness Assessment
+
+| Component | State | Bottleneck |
+|-----------|-------|-----------|
+| Database | PostgreSQL 115GB, 76M rows, partitioned | ✅ Ready for scale |
+| Search | Meilisearch 201GB index | ✅ Ready for scale |
+| Caching | Redis configured | ⚠️ `SearchCacheService` not implemented |
+| API pagination | NestJS endpoints | ❌ Unbounded queries — must fix |
+| Job queues | BullMQ infrastructure ready | ⚠️ Not wired for data imports |
+| Rate limiting | Not implemented | ❌ Must add before traffic scale |
+| Real-time | Socket.io ready | ⚠️ Not integrated with business updates |
+| Monitoring | Prometheus + Grafana configured | ⚠️ Not actively monitoring API |
+
+### Quick Wins (Low Effort, High Impact)
+
+1. **Implement `SearchCacheService` (Redis)** — ~73% faster search
+2. **Add pagination to all list endpoints** — Prevents memory exhaustion at scale
+3. **Complete business claim verification UI** — Builds user trust
+4. **Add review aggregation display** — Social proof for store listings
+5. **Create category + city landing pages** — SEO foundation for organic traffic
+
+### What NOT to Build Yet
+
+- Mobile app (Tier 3) — Web is sufficient; core search needs to work first
+- Semantic search (Tier 3) — Good keyword search is fine; skip pgvector for now
+- Community features — No user base yet; premature investment
+- Advanced B2B features — Core consumer product must exist first
+
+---
+
+## Summary
+
+**Stolution is a marketplace skeleton with excellent data and infrastructure but an incomplete consumer-facing product.**
+
+The platform has:
+- ✅ 76M+ store records in a well-structured, indexed database
+- ✅ A 201GB Meilisearch index ready for full-text search
+- ✅ 20+ NestJS API modules covering nearly every marketplace feature
+- ✅ 30+ Next.js pages for the complete user journey
+
+But the critical **search → discovery → trust** flow is not fully wired. Search facet filters are disconnected from the backend, distance sorting doesn't display in results, and there's no business quality/verification system to differentiate legitimate stores from stale records.
+
+**To make Stolution immediately useful:** wire up the search UI filters, build the category/city landing pages, implement business verification, add review aggregation, and add Redis caching. These 5 items — combined with 76M+ existing store records — would create a functional, searchable neighborhood commerce directory capable of driving early SEO traffic and hitting Month 1 goals.


### PR DESCRIPTION
Lift batch A from conductor archive (commit 71a02a6 on archive/conductor-claude-exec-token-phase2-2026-04-28).

## Items lifted

- **LIFT-001** `apps/completeness-sentinel/plist/com.conductor.completeness-sentinel.plist` — daemon plist that was missing in CAIA.
- **LIFT-002** `apps/orchestrator/tests/dashboard/health.test.ts` — HTTP health-server test.
- **LIFT-004** `.gitleaks.toml` — root-level secret-scan config referenced by `apps/orchestrator/.github/workflows/secrets-scan.yml`.
- **LIFT-005** `apps/pipeline-pulse/README.md` — already identical, no-op.
- **LIFT-006** `docs/legacy-conductor-reports/` — 13 conductor reports (architecture proposal, execution plan, agent team architecture, domain taxonomy, memory inventory, etc.).
- **LIFT-007** `docs/legacy-conductor-reports/stolution-codebase-analysis.md` — sourced from local conductor working tree; never committed to archive branches.

## Skip

- **LIFT-003** (`apps/executor/dispatcher.test.ts`) — depends on LIFT-008 (Batch B Phase-2 dispatcher).
- **LIFT-013** (`@chiefaia/local-llm-router`) — handled by separate parallel task.

## Risk

Low. All items are docs, plist, or test file. Orchestrator tests are currently stubbed in `package.json` ("TODO: orchestrator jest config has stale module paths post-consolidation") and will be re-enabled in Batch J. The new test file lands in the right path for that cleanup.

## Source-of-truth

Per matrix at `~/Documents/projects/reports/conductor-to-caia-capability-matrix-2026-04-28.md` (sections 1.1, 1.8, 1.11, 1.13, 1.16).