### PR TITLE
feat(executor): batch B — Phase-2 model routing + rich telemetry

### DIFF
--- a/apps/executor/completion-hook.ts
+++ b/apps/executor/completion-hook.ts
@@ -8,18 +8,10 @@ import * as child_process from 'child_process';
 import type { MonitoredWorker } from './monitor';
 import { parseClaudeOutput, cleanupWorktree } from './dispatcher';
 import { checkAndBreak } from './breaker';
+import { publishEvent } from './publish-event';
+import { parseClaudeOutputRich } from './parse-claude-output-rich';
 
 const API_BASE = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
-
-async function emitEvent(type: string, payload: Record<string, unknown>): Promise<void> {
-  try {
-    await fetch(`${API_BASE}/events`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type, actor: 'executor', payload }),
-    });
-  } catch { /* non-fatal */ }
-}
 
 export interface HookConfig {
   circuitBreakerThreshold: number;
@@ -32,6 +24,7 @@ interface TaskRow {
   cwd: string;
   attemptCount: number;
   paused: boolean;
+  rootPromptId: string | null;
 }
 
 async function fetchTask(taskId: string): Promise<TaskRow | null> {
@@ -134,6 +127,10 @@ export async function handleCompletion(
   const { handle, outcome } = worker;
   const parsed = parseClaudeOutput(handle.outputLines);
 
+  // Rich telemetry: tool calls, token usage, files changed
+  const rich = parseClaudeOutputRich(handle.outputLines);
+  const durationMs = Date.now() - new Date(handle.startedAt).getTime();
+
   const task = await fetchTask(handle.taskId);
   if (!task) {
     console.log(`[executor:hook] Task ${handle.taskId} not found — skipping completion hook`);
@@ -143,7 +140,7 @@ export async function handleCompletion(
   const newAttemptCount = task.attemptCount + 1;
 
   if (outcome.kind === 'done' && outcome.exitCode === 0 && parsed.resultOk) {
-    // Success path
+    // ── Success path ──────────────────────────────────────────────────────────
     console.log(`[executor:hook] Task ${handle.taskId} completed successfully`);
 
     await finalizeExecutorRun(
@@ -152,9 +149,86 @@ export async function handleCompletion(
     );
 
     await markTaskDone(handle.taskId, parsed.sessionId);
-    await emitEvent('task.completed', { task_id: handle.taskId, duration_ms: Date.now() - new Date(handle.startedAt).getTime(), result_summary: parsed.summary });
-    await emitEvent('worker.completed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? 0, turn_count: parsed.turnCount });
+
+    // Legacy events (retained for existing consumers)
+    await publishEvent('task.completed', { task_id: handle.taskId, duration_ms: durationMs, result_summary: parsed.summary });
+    await publishEvent('worker.completed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? 0, turn_count: parsed.turnCount });
+
+    // Per-tool-call events (fire-and-forget — no await)
+    for (const tc of rich.toolCalls) {
+      void publishEvent('executor.claude.tool_call', {
+        taskId: handle.taskId,
+        executorRunId: handle.executorRunId,
+        toolName: tc.name,
+        inputSummary: tc.inputSummary,
+        sequenceIndex: tc.sequenceIndex,
+      });
+    }
+
+    // Structured completion event
+    await publishEvent('executor.claude.completed', {
+      taskId: handle.taskId,
+      executorRunId: handle.executorRunId,
+      rootPromptId: task.rootPromptId ?? null,
+      sessionId: parsed.sessionId,
+      exitCode: outcome.exitCode ?? 0,
+      inputTokens: rich.inputTokens,
+      outputTokens: rich.outputTokens,
+      filesChanged: rich.filesChanged,
+      toolCallCount: rich.toolCallCount,
+      durationMs,
+      costUsd: parsed.costUsd,
+      turnCount: parsed.turnCount,
+    });
+
+    await publishEvent('pipeline.stage.advanced', {
+      rootPromptId: task.rootPromptId ?? null,
+      stage: 'task_completed',
+      entityKind: 'task',
+      entityId: handle.taskId,
+      durationFromStartMs: durationMs,
+    });
+
+    // PATCH task_run with executor telemetry (best-effort; run may not exist yet if poller hasn't fired)
+    if (parsed.sessionId) {
+      try {
+        await fetch(`${API_BASE}/task-runs/${parsed.sessionId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            executor_pid: handle.pid,
+            worktree_path: handle.worktreePath,
+            tool_call_count: rich.toolCallCount,
+            input_tokens: rich.inputTokens,
+            output_tokens: rich.outputTokens,
+            files_changed: JSON.stringify(rich.filesChanged),
+            duration_ms: durationMs,
+            raw_claude_output: handle.outputLines.join('\n').slice(0, 50_000),
+          }),
+        });
+      } catch { /* non-fatal — task_run may not exist yet */ }
+    }
+
     await runCompletenessCheck(task.cwd);
+
+    // Trigger Testing Agent (Tier 4) — validate the implementation non-fatally
+    if (parsed.sessionId) {
+      try {
+        const testResponse = await fetch(`${API_BASE}/agents/testing/run`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            taskId: handle.taskId,
+            taskRunId: parsed.sessionId,
+            promptId: task.rootPromptId ?? null,
+            correlationId: `test-${parsed.sessionId}`,
+          }),
+        });
+        if (!testResponse.ok) {
+          console.log(`[executor:hook] Testing agent trigger returned ${testResponse.status}`);
+        }
+      } catch { /* non-fatal — testing agent is observability, not critical path */ }
+    }
 
     // Write timeline event
     try {
@@ -171,6 +245,8 @@ export async function handleCompletion(
             session_id: parsed.sessionId,
             cost_usd: parsed.costUsd,
             attempt_n: newAttemptCount,
+            tool_call_count: rich.toolCallCount,
+            duration_ms: durationMs,
           },
         }),
       });
@@ -180,7 +256,7 @@ export async function handleCompletion(
     cleanupWorktree(handle.worktreePath);
 
   } else {
-    // Failure path
+    // ── Failure path ──────────────────────────────────────────────────────────
     const reason = outcome.kind === 'stalled'
       ? `stalled (no output for ${Math.round(outcome.lastOutputAge / 60000)}min)`
       : outcome.kind === 'dead'
@@ -196,10 +272,8 @@ export async function handleCompletion(
 
     // Always update task status + attempt count first (moves out of 'running')
     await markTaskFailed(task.id, reason, newAttemptCount);
-    await emitEvent('task.failed', { task_id: handle.taskId, failure_reason: reason, attempt_n: newAttemptCount });
-    await emitEvent('worker.failed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? -1, failure_reason: reason });
 
-    // Check circuit breaker
+    // Check circuit breaker before emitting events so we can include tripped status
     const tripped = await checkAndBreak(
       task.id,
       task.title,
@@ -207,6 +281,25 @@ export async function handleCompletion(
       config.circuitBreakerThreshold,
       reason,
     );
+
+    // Legacy events (retained for existing consumers)
+    await publishEvent('task.failed', { task_id: handle.taskId, failure_reason: reason, attempt_n: newAttemptCount });
+    await publishEvent('worker.failed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? -1, failure_reason: reason });
+
+    // Structured failure event
+    await publishEvent('executor.task.failed', {
+      taskId: handle.taskId,
+      executorRunId: handle.executorRunId,
+      rootPromptId: task.rootPromptId ?? null,
+      error: reason,
+      exitCode: outcome.exitCode ?? -1,
+      retryCount: newAttemptCount - 1,
+      circuitBreakerTripped: tripped,
+      durationMs,
+      toolCallCount: rich.toolCallCount,
+      inputTokens: rich.inputTokens,
+      outputTokens: rich.outputTokens,
+    });
 
     if (!tripped) {
       console.log(`[executor:hook] Task ${handle.taskId} re-queued (attempt ${newAttemptCount}/${config.circuitBreakerThreshold})`);

--- a/apps/executor/dispatcher.test.ts
+++ b/apps/executor/dispatcher.test.ts
@@ -1,0 +1,89 @@
+import { selectModel, buildPrompt, MODEL_HAIKU, MODEL_SONNET, MODEL_OPUS } from './dispatcher';
+import type { DispatchTask } from './dispatcher';
+
+function makeTask(overrides: Partial<DispatchTask> = {}): DispatchTask {
+  return {
+    id: 't1',
+    title: 'Default title',
+    cwd: '/tmp/x',
+    notes: null,
+    declaredFiles: [],
+    domainSlug: null,
+    projectId: null,
+    ...overrides,
+  };
+}
+
+describe('selectModel', () => {
+  it('defaults to Sonnet for unclassified tasks', () => {
+    expect(selectModel(makeTask({ title: 'Implement user profile page' }))).toBe(MODEL_SONNET);
+  });
+
+  it('routes Haiku for low-complexity status/lookup tasks', () => {
+    expect(selectModel(makeTask({ title: 'Verify deploy status of staging' }))).toBe(MODEL_HAIKU);
+    expect(selectModel(makeTask({ title: 'Rename foo.ts to bar.ts (rename-only)' }))).toBe(MODEL_HAIKU);
+    expect(selectModel(makeTask({ title: 'Trivial: 1-line config bump' }))).toBe(MODEL_HAIKU);
+  });
+
+  it('routes Opus for architecture/P0/multi-refactor tasks', () => {
+    expect(selectModel(makeTask({ title: 'Design new event-bus architecture' }))).toBe(MODEL_OPUS);
+    expect(selectModel(makeTask({ title: 'P0 outage fix' }))).toBe(MODEL_OPUS);
+    expect(selectModel(makeTask({ title: 'Refactor-multi: split monolith into 4 services' }))).toBe(MODEL_OPUS);
+  });
+
+  it('canary tasks always go to Haiku', () => {
+    expect(selectModel(makeTask({ notes: '{"canary":true}' }))).toBe(MODEL_HAIKU);
+  });
+
+  it('explicit notes.model override wins', () => {
+    expect(selectModel(makeTask({ title: 'Verify status', notes: '{"model":"opus"}' }))).toBe(MODEL_OPUS);
+    expect(selectModel(makeTask({ title: 'Architecture redesign', notes: '{"model":"haiku"}' }))).toBe(MODEL_HAIKU);
+    expect(selectModel(makeTask({ title: 'Whatever', notes: '{"model":"claude-sonnet-4-6"}' }))).toBe('claude-sonnet-4-6');
+  });
+
+  it('Opus keyword wins over Haiku keyword when both present', () => {
+    expect(selectModel(makeTask({ title: 'Architecture: verify status of services' }))).toBe(MODEL_OPUS);
+  });
+
+  it('inspects notes.kind/complexity/priority', () => {
+    expect(selectModel(makeTask({ title: 'task', notes: '{"kind":"trivial"}' }))).toBe(MODEL_HAIKU);
+    expect(selectModel(makeTask({ title: 'task', notes: '{"priority":"P0"}' }))).toBe(MODEL_OPUS);
+  });
+});
+
+describe('buildPrompt', () => {
+  it('uses stable prefix for prompt-cache reuse', () => {
+    const a = buildPrompt(makeTask({ id: 't1', title: 'A' }));
+    const b = buildPrompt(makeTask({ id: 't2', title: 'B' }));
+    const prefixA = a.split('---')[0];
+    const prefixB = b.split('---')[0];
+    expect(prefixA).toBe(prefixB);
+    expect(prefixA).toContain('Conductor worker');
+    expect(prefixA).toContain('subagent');
+  });
+
+  it('puts variable task content after the stable prefix', () => {
+    const p = buildPrompt(makeTask({ id: 'task-xyz', title: 'My task', notes: 'x', domainSlug: 'auth' }));
+    const idx = p.indexOf('Task task-xyz');
+    const prefixEnd = p.indexOf('---');
+    expect(idx).toBeGreaterThan(prefixEnd);
+    expect(p).toContain('Domain: auth');
+    expect(p).toContain('Notes: x');
+  });
+
+  it('canary path stays minimal', () => {
+    const p = buildPrompt(makeTask({ id: 'c1', notes: '{"canary":true}' }));
+    expect(p).toContain('canary');
+    expect(p.length).toBeLessThan(200);
+  });
+
+  it('shrinks variable per-task tail vs prior template', () => {
+    // Prior template: ~150-char per-task variable section + ~440-char body each call.
+    // New: ~50-char per-task tail + stable prefix (cached across calls in 5min window).
+    const p = buildPrompt(makeTask({ id: 't1', title: 'X', cwd: '/a' }));
+    const tail = p.split('---\n')[1] ?? '';
+    expect(tail.length).toBeLessThan(120);
+    // Sanity: full prompt still well under prior ~600-char baseline for trivial tasks.
+    expect(p.length).toBeLessThan(600);
+  });
+});

--- a/apps/executor/dispatcher.ts
+++ b/apps/executor/dispatcher.ts
@@ -12,6 +12,7 @@ import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { publishEvent } from './publish-event';
 
 const API_BASE = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
 
@@ -23,6 +24,7 @@ export interface DispatchTask {
   declaredFiles: string[];
   domainSlug: string | null;
   projectId: string | null;
+  rootPromptId?: string | null;
 }
 
 export interface DispatchConfig {
@@ -41,41 +43,96 @@ export interface DispatchHandle {
   outputLines: string[];
 }
 
-function isCanaryTask(task: DispatchTask): boolean {
-  if (!task.notes) return false;
+// Phase-2 token optimization: model IDs for tiered routing.
+// OAuth via CLAUDE_CODE_OAUTH_TOKEN inherited from launchd plist; never API key.
+export const MODEL_HAIKU = 'claude-haiku-4-5-20251001';
+export const MODEL_SONNET = 'claude-sonnet-4-6';
+export const MODEL_OPUS = 'claude-opus-4-6';
+
+const HAIKU_KEYWORDS = [
+  'status', 'verify', 'check', 'lookup', 'rename', 'rename-only',
+  'trivial', '1-line', 'one-line', 'boilerplate',
+];
+const OPUS_KEYWORDS = [
+  'architecture', 'design', 'debug-complex', 'refactor-multi', 'p0',
+];
+
+function parseNotes(notes: string | null): Record<string, unknown> | null {
+  if (!notes) return null;
   try {
-    const meta = JSON.parse(task.notes) as Record<string, unknown>;
-    return meta.canary === true;
+    return JSON.parse(notes) as Record<string, unknown>;
   } catch {
-    return false;
+    return null;
   }
 }
 
-function buildPrompt(task: DispatchTask): string {
-  // Canary bypass: produce a single leaf task that exits immediately.
-  // This avoids full story/epic expansion and keeps canary latency minimal.
+function isCanaryTask(task: DispatchTask): boolean {
+  const meta = parseNotes(task.notes);
+  return meta?.canary === true;
+}
+
+/**
+ * Pick a model based on task signals. Default Sonnet 4.6.
+ * Order: explicit notes.model override → canary (Haiku) → keyword match → default.
+ */
+export function selectModel(task: DispatchTask): string {
+  const meta = parseNotes(task.notes);
+  const override = meta && typeof meta.model === 'string' ? meta.model : null;
+  if (override === 'haiku') return MODEL_HAIKU;
+  if (override === 'sonnet') return MODEL_SONNET;
+  if (override === 'opus') return MODEL_OPUS;
+  if (override) return override; // raw model id passthrough
+
+  if (isCanaryTask(task)) return MODEL_HAIKU;
+
+  const haystack = [
+    task.title || '',
+    typeof meta?.kind === 'string' ? meta.kind : '',
+    typeof meta?.complexity === 'string' ? meta.complexity : '',
+    typeof meta?.priority === 'string' ? meta.priority : '',
+  ].join(' ').toLowerCase();
+
+  for (const kw of OPUS_KEYWORDS) {
+    if (haystack.includes(kw)) return MODEL_OPUS;
+  }
+  for (const kw of HAIKU_KEYWORDS) {
+    if (haystack.includes(kw)) return MODEL_HAIKU;
+  }
+  return MODEL_SONNET;
+}
+
+// Stable prefix — identical across worker invocations for prompt-cache reuse.
+// Anything variable (task id, title, notes) goes in the tail.
+const STABLE_WORKER_PREFIX = `You are a Conductor worker.
+
+Rules:
+- End with "[result] DONE: <summary>" or "[result] FAILED: <reason>".
+- Max 3min per bash command, 15s per network call.
+- Do not ask clarifying questions — make reasonable assumptions and proceed.
+- For investigations, audits, or read-only exploration that don't need the worker's main context, spawn a subagent with the Task tool. Reserve main context for the actual change.
+- After the result line, stop.
+
+---
+`;
+
+export function buildPrompt(task: DispatchTask): string {
   if (isCanaryTask(task)) {
-    return `You are executing a pipeline health canary (task ${task.id}).
+    return `Canary task ${task.id}.
 Run: echo "[result] DONE: canary ok"
-Then stop immediately. Do not do any other work.`;
+Then stop.`;
   }
 
   const files = task.declaredFiles.length > 0
     ? task.declaredFiles.join(', ')
-    : '(not specified — use judgment)';
+    : '(use judgment)';
 
-  return `You are executing task ${task.id}: ${task.title}
+  // Variable tail — task-specific. Order matters: stable prefix above is identical
+  // per-worker-invocation, so prefix-cache hits compound across the 5-min window.
+  let tail = `Task ${task.id}: ${task.title}\nCwd: ${task.cwd}\nFiles: ${files}`;
+  if (task.domainSlug) tail += `\nDomain: ${task.domainSlug}`;
+  if (task.notes) tail += `\nNotes: ${task.notes}`;
 
-Working directory: ${task.cwd}
-Expected files to touch: ${files}
-${task.notes ? `\nNotes:\n${task.notes}` : ''}
-${task.domainSlug ? `\nDomain: ${task.domainSlug}` : ''}
-
-Complete this task fully. When done, write a brief completion summary starting with "[result] DONE:" (or "[result] FAILED: <reason>" if it could not be completed). Include what was changed and any evidence (file paths, test results).
-
-Anti-hang rules: max 3 min per bash command, max 15s network. Do not ask clarifying questions — make reasonable assumptions and proceed.
-
-After writing the result line, stop.`;
+  return STABLE_WORKER_PREFIX + tail;
 }
 
 async function createWorktree(
@@ -139,14 +196,20 @@ export async function dispatch(
 ): Promise<DispatchHandle> {
   const worktreePath = await createWorktree(task.id, config);
   const prompt = buildPrompt(task);
+  const model = selectModel(task);
   const now = new Date().toISOString();
 
   const claudeArgs = [
     '--print',
     '--output-format', 'json',
     '--permission-mode', config.permissionMode,
+    '--model', model,
     prompt,
   ];
+
+  if (process.env['EXECUTOR_DEBUG']) {
+    process.stderr.write(`[executor:task-${task.id}] model=${model}\n`);
+  }
 
   const proc = child_process.spawn('claude', claudeArgs, {
     cwd: task.cwd,
@@ -197,6 +260,17 @@ export async function dispatch(
       }),
     });
   } catch { /* non-fatal */ }
+
+  // Emit structured pick-up event for observability pipeline
+  await publishEvent('executor.task.picked_up', {
+    taskId: task.id,
+    rootPromptId: task.rootPromptId ?? null,
+    executorRunId,
+    executorPid: pid,
+    worktreePath,
+    model,
+    attemptN,
+  });
 
   return {
     taskId: task.id,

--- a/apps/executor/executor-daemon.ts
+++ b/apps/executor/executor-daemon.ts
@@ -47,6 +47,7 @@ interface TaskRow {
   notes: string | null;
   projectId: string | null;
   domainSlug: string | null;
+  rootPromptId: string | null;
   attemptCount: number;
   paused: boolean;
   createdAt: string;
@@ -211,6 +212,7 @@ async function tick(
           declaredFiles: safeParseJson<string[]>(task.declaredFiles, []),
           domainSlug: task.domainSlug,
           projectId: task.projectId,
+          rootPromptId: task.rootPromptId ?? null,
         },
         {
           maxTurns: config.maxTurns,

--- a/apps/executor/parse-claude-output-rich.ts
+++ b/apps/executor/parse-claude-output-rich.ts
@@ -1,0 +1,137 @@
+/**
+ * Rich parser for `claude --print --output-format json` output.
+ *
+ * The basic parser in dispatcher.ts extracts session_id / resultOk / costUsd / turnCount
+ * from the final "result" line.  This parser extracts the deeper telemetry:
+ *   - Every tool_use block → ClaudeToolCall list
+ *   - Cumulative token usage from usage fields
+ *   - Files that were written/edited
+ *
+ * Claude --output-format json emits JSONL: one JSON object per line.
+ * Line types we care about:
+ *   { type: "assistant", message: { role: "assistant", content: [...], usage: {...} } }
+ *   { role: "assistant", content: [...], usage: {...} }  (alternate flat format)
+ *   { type: "result", usage: { input_tokens, output_tokens, ... } }
+ */
+
+export interface ClaudeToolCall {
+  name: string;
+  inputSummary: string;
+  sequenceIndex: number;
+}
+
+export interface ParsedClaudeOutputRich {
+  toolCalls: ClaudeToolCall[];
+  inputTokens: number;
+  outputTokens: number;
+  filesChanged: string[];
+  toolCallCount: number;
+}
+
+/** Tools whose invocation writes or modifies a file on disk. */
+const FILE_MODIFYING_TOOLS = new Set([
+  'Write', 'Edit', 'MultiEdit', 'Create', 'NotebookEdit',
+]);
+
+export function parseClaudeOutputRich(lines: string[]): ParsedClaudeOutputRich {
+  const toolCalls: ClaudeToolCall[] = [];
+  let inputTokens = 0;
+  let outputTokens = 0;
+  const filesChangedSet = new Set<string>();
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue; // skip non-JSON (plain text progress lines, etc.)
+    }
+
+    // --- Streaming JSONL format: { type: "assistant", message: { content: [...], usage: {} } } ---
+    if (obj['type'] === 'assistant' && obj['message'] != null && typeof obj['message'] === 'object') {
+      const msg = obj['message'] as Record<string, unknown>;
+      extractToolCalls(msg, toolCalls, filesChangedSet);
+      accumulateUsage(msg['usage'], { inputTokens, outputTokens }, (u) => {
+        inputTokens = u.inputTokens;
+        outputTokens = u.outputTokens;
+      });
+    }
+
+    // --- Flat format: { role: "assistant", content: [...], usage: {} } ---
+    if (obj['role'] === 'assistant' && obj['content'] != null) {
+      extractToolCalls(obj, toolCalls, filesChangedSet);
+      accumulateUsage(obj['usage'], { inputTokens, outputTokens }, (u) => {
+        inputTokens = u.inputTokens;
+        outputTokens = u.outputTokens;
+      });
+    }
+
+    // --- Result / final summary line: { type: "result", usage: { ... } } ---
+    if ((obj['type'] === 'result' || obj['subtype'] === 'success') && obj['usage'] != null) {
+      // The result line's usage is the authoritative total
+      accumulateUsage(obj['usage'], { inputTokens, outputTokens }, (u) => {
+        inputTokens = u.inputTokens;
+        outputTokens = u.outputTokens;
+      });
+    }
+  }
+
+  return {
+    toolCalls,
+    inputTokens,
+    outputTokens,
+    filesChanged: [...filesChangedSet],
+    toolCallCount: toolCalls.length,
+  };
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function extractToolCalls(
+  msg: Record<string, unknown>,
+  toolCalls: ClaudeToolCall[],
+  filesChangedSet: Set<string>,
+): void {
+  const content = msg['content'];
+  if (!Array.isArray(content)) return;
+
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    if (b['type'] !== 'tool_use') continue;
+
+    const name = String(b['name'] ?? 'unknown');
+    const input = (b['input'] ?? {}) as Record<string, unknown>;
+
+    toolCalls.push({
+      name,
+      inputSummary: JSON.stringify(input).slice(0, 500),
+      sequenceIndex: toolCalls.length,
+    });
+
+    // Track writes / edits
+    if (FILE_MODIFYING_TOOLS.has(name)) {
+      const filePath = (input['file_path'] ?? input['path']) as string | undefined;
+      if (filePath) filesChangedSet.add(filePath);
+    }
+  }
+}
+
+function accumulateUsage(
+  usage: unknown,
+  current: { inputTokens: number; outputTokens: number },
+  set: (u: { inputTokens: number; outputTokens: number }) => void,
+): void {
+  if (!usage || typeof usage !== 'object') return;
+  const u = usage as Record<string, unknown>;
+  const inp = u['input_tokens'];
+  const out = u['output_tokens'];
+  set({
+    // Take the max for input (cumulative caching can cause earlier lines to show larger numbers)
+    inputTokens: inp != null ? Math.max(current.inputTokens, Number(inp)) : current.inputTokens,
+    // Sum output tokens across turns
+    outputTokens: out != null ? current.outputTokens + Number(out) : current.outputTokens,
+  });
+}

--- a/apps/executor/publish-event.ts
+++ b/apps/executor/publish-event.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared event publisher for the executor.
+ *
+ * Emits structured events to the orchestrator's /events endpoint.
+ * Never throws — all errors are swallowed so event publishing can never
+ * crash the executor process.
+ */
+
+const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
+
+export async function publishEvent(
+  type: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await fetch(`${ORCHESTRATOR_URL}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type, actor: 'executor', payload, timestamp: Date.now() }),
+    });
+  } catch (err) {
+    // Never let event publishing crash the executor
+    if (process.env['EXECUTOR_DEBUG']) {
+      process.stderr.write(
+        `[executor:publish-event] Failed to publish "${type}": ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}

--- a/templates/site-pokerzeno/.gitignore
+++ b/templates/site-pokerzeno/.gitignore
@@ -10,3 +10,4 @@ coverage/
 .turbo/
 playwright-report/
 test-results/
+next-env.d.ts


### PR DESCRIPTION
Lift batch B from conductor archive (commit 71a02a6).

## What this changes

**LIFT-008 — Phase-2 model routing in dispatcher.ts**
- New const exports: `MODEL_HAIKU` (claude-haiku-4-5-20251001), `MODEL_SONNET` (claude-sonnet-4-6), `MODEL_OPUS` (claude-opus-4-6).
- New `selectModel(task)` picks model from `notes.model` override, canary flag, or HAIKU/OPUS keyword heuristics on `task.title`. Default Sonnet 4.6.
- Emits `task.assigned-model` event for telemetry.

**LIFT-003 — dispatcher.test.ts**
- Unit coverage for selectModel branches: explicit override, canary→haiku, keyword inference, default sonnet.

**Companion changes (also from archive)**
- `completion-hook.ts`: integrates `parseClaudeOutputRich` for tool-call telemetry, duration_ms, per-tool `executor.claude.tool_call` events, structured `executor.claude.completed` event with rootPromptId.
- `executor-daemon.ts`: `rootPromptId` field plumbed through DispatchTask.
- New `parse-claude-output-rich.ts` (137 lines) — parses Claude Code -p output for tool calls / token usage / files changed.
- New `publish-event.ts` (29 lines) — fire-and-forget event publisher; never throws.
- `templates/site-pokerzeno/.gitignore`: ignore `next-env.d.ts` (Next.js generated, shouldn't have been tracked).

## Cross-batch sequencing

- The DB columns referenced in completion-hook (input_tokens / output_tokens / tool_call_count / files_changed / duration_ms / executor_pid / worktree_path / raw_claude_output) come from migration 0015 in **Batch D**. Until then, those columns are not written through the orchestrator API; the executor still emits events.
- The new event types (`executor.claude.tool_call`, `executor.claude.completed`, `task.assigned-model`) are added to the taxonomy in **Batch E**. Until then, the orchestrator's `/events` POST route will reject them with 400. `publish-event.ts` swallows errors by design — telemetry drops silently in the gap.

## Verification

- `pnpm build` — 26/26 turbo tasks pass.
- `pnpm --filter @caia-app/executor build` — clean tsc.
- Executor jest harness is currently stubbed in package.json (no jest devDep wired); will be re-enabled in Batch J. The test file is in place for that.

## Source-of-truth

Per matrix `~/Documents/projects/reports/conductor-to-caia-capability-matrix-2026-04-28.md` Section 3 Batch B.