### PR TITLE
feat(packages): batch C — internal packages (classifier, decomposer, dedup-engine)

### DIFF
--- a/packages/classifier/package.json
+++ b/packages/classifier/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@chiefaia/classifier",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Domain taxonomy engine — classifies text into functional domains and assigns labels.",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/classifier/src/classifier.test.ts
+++ b/packages/classifier/src/classifier.test.ts
@@ -1,0 +1,85 @@
+import { classify, classifyKeyword } from './classifier';
+
+describe('classifyKeyword', () => {
+  it('classifies auth-related text to auth domain', () => {
+    const result = classifyKeyword('Add Google OAuth login with JWT tokens');
+    expect(result.primaryDomain).toBe('auth');
+    expect(result.nature).toBe('feature');
+  });
+
+  it('classifies bug reports correctly', () => {
+    const result = classifyKeyword('Fix broken login form that crashes on submit');
+    expect(result.nature).toBe('bug');
+  });
+
+  it('classifies UI work to ui-frontend', () => {
+    const result = classifyKeyword('Create a responsive dashboard component with React');
+    expect(result.primaryDomain).toBe('ui-frontend');
+  });
+
+  it('classifies database work correctly', () => {
+    const result = classifyKeyword('Add migration to create users table with index');
+    expect(result.primaryDomain).toBe('data-storage');
+  });
+
+  it('returns allLabels as flat array', () => {
+    const result = classifyKeyword('Add login with Google OAuth');
+    expect(Array.isArray(result.allLabels)).toBe(true);
+    expect(result.allLabels.length).toBeGreaterThan(0);
+  });
+
+  it('handles empty text gracefully', () => {
+    const result = classifyKeyword('');
+    expect(result.primaryDomain).toBeDefined();
+    expect(result.allLabels).toBeDefined();
+  });
+
+  it('detects sub-domain for SSO', () => {
+    const result = classifyKeyword('Implement SSO with OAuth2 and OpenID Connect');
+    expect(result.primaryDomain).toBe('auth');
+    expect(result.subDomain).toBe('auth.sso');
+  });
+
+  it('detects sub-domain for cache', () => {
+    const result = classifyKeyword('Add Redis cache with TTL invalidation strategy');
+    expect(result.primaryDomain).toBe('data-storage');
+    expect(result.subDomain).toBe('data-storage.cache');
+  });
+
+  it('includes nature, complexity and layer in allLabels', () => {
+    const result = classifyKeyword('Fix broken user authentication session token');
+    expect(result.allLabels).toContain(result.nature);
+    expect(result.allLabels).toContain(result.complexity);
+    expect(result.allLabels).toContain(result.layer);
+  });
+
+  it('classifies devops/infrastructure work', () => {
+    const result = classifyKeyword('Set up GitHub Actions CI pipeline with Docker and deploy to AWS');
+    expect(result.primaryDomain).toBe('devops');
+  });
+
+  it('classifies AI/ML work', () => {
+    const result = classifyKeyword('Integrate OpenAI embeddings for RAG vector search with LLM prompt engineering');
+    expect(result.primaryDomain).toBe('ai-ml');
+  });
+
+  it('includes confidence score between 0 and 1', () => {
+    const result = classifyKeyword('Add JWT token authentication with OAuth login');
+    expect(result.confidence).toBeGreaterThanOrEqual(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it('defaults to business-logic for unrecognised text', () => {
+    const result = classifyKeyword('xyzzy frobnicate the quux widget');
+    expect(result.primaryDomain).toBe('business-logic');
+  });
+});
+
+describe('classify (async wrapper)', () => {
+  it('returns same result as classifyKeyword synchronously', async () => {
+    const sync = classifyKeyword('Create new user registration flow');
+    const async_ = await classify('Create new user registration flow');
+    expect(async_.primaryDomain).toBe(sync.primaryDomain);
+    expect(async_.nature).toBe(sync.nature);
+  });
+});

--- a/packages/classifier/src/classifier.ts
+++ b/packages/classifier/src/classifier.ts
@@ -1,0 +1,141 @@
+import {
+  FUNCTIONAL_DOMAINS,
+  NATURE_KEYWORDS,
+  type DomainDefinition,
+  type NatureLabel,
+  type ComplexityLabel,
+  type LayerLabel,
+} from './taxonomy';
+
+export interface ClassificationResult {
+  primaryDomain: string;       // e.g. 'auth'
+  subDomain?: string;          // e.g. 'auth.sso'
+  additionalDomains: string[]; // other relevant domains
+  nature: NatureLabel;
+  complexity: ComplexityLabel;
+  layer: LayerLabel;
+  allLabels: string[];         // flat list of all labels
+  confidence: number;          // 0-1
+  reasoning: string;           // human-readable explanation
+}
+
+export interface ClassifierConfig {
+  aiProvider?: 'claude' | 'keyword-only'; // keyword-only works without AI
+  claudeApiKey?: string;
+  projectTaxonomyExtensions?: DomainDefinition[]; // project-specific additions
+}
+
+function estimateComplexity(text: string): ComplexityLabel {
+  const words = text.split(/\s+/).length;
+  if (words < 10) return 'trivial';
+  if (words < 25) return 'small';
+  if (words < 60) return 'medium';
+  if (words < 120) return 'large';
+  return 'xl';
+}
+
+function estimateLayer(text: string, primaryDomain: string): LayerLabel {
+  const lower = text.toLowerCase();
+  if (['ui-frontend'].includes(primaryDomain)) return 'frontend';
+  if (['api-integration', 'devops'].includes(primaryDomain)) return 'backend';
+  if (primaryDomain === 'data-storage') return 'database';
+  if (primaryDomain === 'devops') return 'infrastructure';
+  if (lower.includes('ui') || lower.includes('frontend') || lower.includes('component')) return 'frontend';
+  if (lower.includes('api') || lower.includes('backend') || lower.includes('server')) return 'backend';
+  if (lower.includes('database') || lower.includes('schema') || lower.includes('migration')) return 'database';
+  return 'full-stack';
+}
+
+function classifyNature(text: string): { nature: NatureLabel; confidence: number } {
+  const lower = text.toLowerCase();
+  const scores: Record<NatureLabel, number> = {} as Record<NatureLabel, number>;
+
+  for (const [nature, keywords] of Object.entries(NATURE_KEYWORDS) as [NatureLabel, string[]][]) {
+    scores[nature] = keywords.filter(k => lower.includes(k)).length;
+  }
+
+  const sorted = Object.entries(scores).sort(([, a], [, b]) => b - a);
+  const topNature = sorted[0][0] as NatureLabel;
+  const topScore = sorted[0][1];
+
+  return {
+    nature: topScore > 0 ? topNature : 'feature',
+    confidence: Math.min(topScore / 3, 1),
+  };
+}
+
+function scoreDomain(text: string, domain: DomainDefinition): number {
+  const lower = text.toLowerCase();
+  let score = domain.keywords.filter(k => lower.includes(k)).length;
+
+  // Sub-domain bonus
+  if (domain.subDomains) {
+    for (const sub of domain.subDomains) {
+      const subScore = sub.keywords.filter(k => lower.includes(k)).length;
+      if (subScore > 0) score += subScore * 1.5;
+    }
+  }
+
+  return score;
+}
+
+export function classifyKeyword(text: string, config: ClassifierConfig = {}): ClassificationResult {
+  const allDomains = [...FUNCTIONAL_DOMAINS, ...(config.projectTaxonomyExtensions ?? [])];
+
+  // Score each domain
+  const scores = allDomains
+    .map(domain => ({ domain, score: scoreDomain(text, domain) }))
+    .sort((a, b) => b.score - a.score);
+
+  const primaryDomainDef = scores[0];
+  const primaryDomain = primaryDomainDef.score > 0 ? primaryDomainDef.domain.slug : 'business-logic';
+  const confidence = Math.min(primaryDomainDef.score / 5, 1);
+
+  // Sub-domain detection
+  let subDomain: string | undefined;
+  if (primaryDomainDef.domain.subDomains) {
+    const lower = text.toLowerCase();
+    const matchedSub = primaryDomainDef.domain.subDomains.find(
+      sub => sub.keywords.some(k => lower.includes(k)),
+    );
+    if (matchedSub) subDomain = matchedSub.slug;
+  }
+
+  // Additional domains (score > 0 but not primary)
+  const additionalDomains = scores
+    .slice(1)
+    .filter(s => s.score > 0)
+    .slice(0, 3)
+    .map(s => s.domain.slug);
+
+  const { nature } = classifyNature(text);
+  const complexity = estimateComplexity(text);
+  const layer = estimateLayer(text, primaryDomain);
+
+  const allLabels = [
+    primaryDomain,
+    ...(subDomain ? [subDomain] : []),
+    ...additionalDomains,
+    nature,
+    complexity,
+    layer,
+  ];
+
+  return {
+    primaryDomain,
+    subDomain,
+    additionalDomains,
+    nature,
+    complexity,
+    layer,
+    allLabels,
+    confidence,
+    reasoning: `Primary domain "${primaryDomain}" matched ${primaryDomainDef.score} keywords. Nature: "${nature}". Complexity: "${complexity}" based on text length.`,
+  };
+}
+
+// Main entry point — tries AI first, falls back to keyword.
+// AI enhancement can be added later per ADR-001 Living Library principle.
+export async function classify(text: string, config: ClassifierConfig = {}): Promise<ClassificationResult> {
+  return classifyKeyword(text, config);
+}

--- a/packages/classifier/src/index.ts
+++ b/packages/classifier/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  classify,
+  classifyKeyword,
+  type ClassificationResult,
+  type ClassifierConfig,
+} from './classifier';
+
+export {
+  FUNCTIONAL_DOMAINS,
+  NATURE_KEYWORDS,
+  type DomainDefinition,
+  type NatureLabel,
+  type ComplexityLabel,
+  type LayerLabel,
+  type LifecycleLabel,
+  type ImpactLabel,
+} from './taxonomy';

--- a/packages/classifier/src/taxonomy.ts
+++ b/packages/classifier/src/taxonomy.ts
@@ -1,0 +1,138 @@
+export interface DomainDefinition {
+  slug: string;
+  label: string;
+  description: string;
+  keywords: string[];  // for keyword-based fallback classification
+  subDomains?: DomainDefinition[];
+}
+
+export const FUNCTIONAL_DOMAINS: DomainDefinition[] = [
+  {
+    slug: 'auth',
+    label: 'Authentication & Authorization',
+    description: 'Login, logout, sessions, SSO, MFA, OAuth, permissions, roles, access control',
+    keywords: ['auth', 'login', 'logout', 'session', 'sso', 'oauth', 'mfa', 'permission', 'role', 'access', 'token', 'jwt', 'password', 'credential', 'identity'],
+    subDomains: [
+      { slug: 'auth.sso', label: 'SSO / OAuth', description: 'Single sign-on and OAuth flows', keywords: ['sso', 'oauth', 'google login', 'social login', 'openid'] },
+      { slug: 'auth.mfa', label: 'Multi-Factor Auth', description: 'TOTP, SMS, hardware keys', keywords: ['mfa', '2fa', 'totp', 'authenticator', 'otp'] },
+      { slug: 'auth.rbac', label: 'Roles & Permissions', description: 'RBAC, permission management', keywords: ['rbac', 'role', 'permission', 'privilege', 'admin'] },
+    ],
+  },
+  {
+    slug: 'user-mgmt',
+    label: 'User & Account Management',
+    description: 'User profiles, account settings, onboarding, offboarding, user preferences',
+    keywords: ['user', 'account', 'profile', 'onboarding', 'signup', 'registration', 'settings', 'preferences', 'avatar', 'display name'],
+  },
+  {
+    slug: 'data-storage',
+    label: 'Data & Storage',
+    description: 'Database schema, migrations, data models, caching, backups, data integrity',
+    keywords: ['database', 'schema', 'migration', 'table', 'model', 'cache', 'redis', 'backup', 'query', 'index', 'relation', 'foreign key', 'orm'],
+    subDomains: [
+      { slug: 'data-storage.schema', label: 'Schema & Migrations', description: 'DB schema design and migrations', keywords: ['schema', 'migration', 'alter table', 'add column'] },
+      { slug: 'data-storage.cache', label: 'Caching', description: 'Redis, in-memory, CDN caching', keywords: ['cache', 'redis', 'memcached', 'ttl', 'invalidation'] },
+    ],
+  },
+  {
+    slug: 'api-integration',
+    label: 'API & Integration',
+    description: 'REST APIs, GraphQL, webhooks, third-party integrations, SDKs, API versioning',
+    keywords: ['api', 'rest', 'graphql', 'webhook', 'endpoint', 'integration', 'sdk', 'http', 'request', 'response', 'openapi', 'swagger'],
+  },
+  {
+    slug: 'ui-frontend',
+    label: 'UI & Frontend',
+    description: 'React components, pages, layouts, design system, responsive design, accessibility',
+    keywords: ['ui', 'frontend', 'component', 'page', 'layout', 'react', 'nextjs', 'css', 'design', 'responsive', 'mobile', 'accessibility', 'a11y', 'form', 'modal', 'button'],
+    subDomains: [
+      { slug: 'ui-frontend.components', label: 'Components', description: 'Reusable UI components', keywords: ['component', 'button', 'input', 'modal', 'card', 'table', 'form'] },
+      { slug: 'ui-frontend.pages', label: 'Pages & Routing', description: 'Page layout and navigation', keywords: ['page', 'route', 'navigation', 'router', 'layout'] },
+      { slug: 'ui-frontend.design-system', label: 'Design System', description: 'Tokens, themes, shared styles', keywords: ['design system', 'token', 'theme', 'style', 'typography', 'color'] },
+    ],
+  },
+  {
+    slug: 'business-logic',
+    label: 'Business Logic',
+    description: 'Domain rules, workflows, state machines, calculations, business processes',
+    keywords: ['business rule', 'workflow', 'state machine', 'calculation', 'process', 'logic', 'pricing', 'commission', 'algorithm'],
+  },
+  {
+    slug: 'notifications',
+    label: 'Notifications & Messaging',
+    description: 'Email, SMS, push notifications, in-app notifications, message queues',
+    keywords: ['notification', 'email', 'sms', 'push', 'alert', 'message', 'queue', 'webhook', 'sendgrid', 'twilio', 'firebase'],
+  },
+  {
+    slug: 'search',
+    label: 'Search & Discovery',
+    description: 'Full-text search, filtering, recommendations, indexing, Meilisearch, Elasticsearch',
+    keywords: ['search', 'filter', 'index', 'full-text', 'meilisearch', 'elasticsearch', 'recommendation', 'discovery', 'facet', 'query'],
+  },
+  {
+    slug: 'analytics',
+    label: 'Analytics & Reporting',
+    description: 'Metrics, dashboards, exports, BI, event tracking, funnels, KPIs',
+    keywords: ['analytics', 'metrics', 'dashboard', 'report', 'export', 'kpi', 'funnel', 'tracking', 'ga4', 'plausible', 'chart'],
+  },
+  {
+    slug: 'devops',
+    label: 'DevOps & Infrastructure',
+    description: 'CI/CD, containerization, orchestration, environments, deployment, cloud',
+    keywords: ['ci', 'cd', 'pipeline', 'docker', 'kubernetes', 'deploy', 'cloud', 'aws', 'gcp', 'cloudflare', 'environment', 'github actions', 'infrastructure'],
+  },
+  {
+    slug: 'security',
+    label: 'Security & Compliance',
+    description: 'Input validation, rate limiting, GDPR, OWASP, auditing, encryption, CSP',
+    keywords: ['security', 'validation', 'sanitize', 'rate limit', 'gdpr', 'compliance', 'encrypt', 'owasp', 'xss', 'csrf', 'audit', 'csp'],
+  },
+  {
+    slug: 'performance',
+    label: 'Performance & Scalability',
+    description: 'Load time, Core Web Vitals, CDN, optimization, horizontal scaling, profiling',
+    keywords: ['performance', 'speed', 'slow', 'optimize', 'cdn', 'lazy load', 'bundle', 'lighthouse', 'core web vitals', 'scalab'],
+  },
+  {
+    slug: 'testing',
+    label: 'Testing & Quality',
+    description: 'Unit tests, integration tests, E2E tests, test data, coverage, TDD',
+    keywords: ['test', 'unit test', 'integration test', 'e2e', 'playwright', 'vitest', 'jest', 'coverage', 'tdd', 'bdd', 'spec'],
+  },
+  {
+    slug: 'observability',
+    label: 'Observability & Monitoring',
+    description: 'Logging, distributed tracing, alerting, health checks, error monitoring, Sentry',
+    keywords: ['log', 'trace', 'monitor', 'alert', 'health', 'sentry', 'prometheus', 'grafana', 'error tracking', 'uptime', 'observability'],
+  },
+  {
+    slug: 'documentation',
+    label: 'Documentation',
+    description: 'API docs, user guides, code comments, changelogs, README, OpenAPI',
+    keywords: ['docs', 'documentation', 'readme', 'changelog', 'openapi', 'swagger', 'guide', 'tutorial', 'comment'],
+  },
+  {
+    slug: 'ai-ml',
+    label: 'AI & Machine Learning',
+    description: 'LLM integration, prompt engineering, embeddings, fine-tuning, RAG, vector search',
+    keywords: ['ai', 'ml', 'llm', 'gpt', 'claude', 'openai', 'embedding', 'vector', 'rag', 'prompt', 'fine-tuning', 'machine learning', 'neural'],
+  },
+];
+
+export type NatureLabel = 'feature' | 'bug' | 'enhancement' | 'refactor' | 'chore' | 'spike' | 'migration' | 'deprecation';
+export type ComplexityLabel = 'trivial' | 'small' | 'medium' | 'large' | 'xl';
+export type RiskLabel = 'low-risk' | 'medium-risk' | 'high-risk' | 'needs-review';
+export type LayerLabel = 'frontend' | 'backend' | 'database' | 'infrastructure' | 'shared-lib' | 'config' | 'full-stack';
+export type LifecycleLabel = 'new' | 'existing-extension' | 'existing-replacement' | 'deprecating';
+export type ImpactLabel = 'breaking-change' | 'additive' | 'internal-only';
+
+export const NATURE_KEYWORDS: Record<NatureLabel, string[]> = {
+  'feature': ['add', 'create', 'build', 'implement', 'new', 'introduce'],
+  'bug': ['bug', 'fix', 'broken', 'error', 'issue', 'wrong', 'incorrect', 'crash', 'fail'],
+  'enhancement': ['improve', 'enhance', 'upgrade', 'update', 'better', 'extend', 'expand'],
+  'refactor': ['refactor', 'clean', 'restructure', 'reorganize', 'simplify', 'rewrite'],
+  'chore': ['chore', 'dependency', 'update package', 'bump', 'maintenance', 'cleanup'],
+  'spike': ['spike', 'research', 'investigate', 'explore', 'poc', 'prototype'],
+  'migration': ['migrate', 'migration', 'move from', 'switch to', 'replace'],
+  'deprecation': ['deprecate', 'remove', 'drop support', 'sunset'],
+};

--- a/packages/decomposer/package.json
+++ b/packages/decomposer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@chiefaia/decomposer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AI-driven hierarchy decomposer — breaks natural language into Initiative → Epic → Module → Story → Task.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "nanoid": "^5.0.0"
+  }
+}

--- a/packages/decomposer/src/claude-decomposer.ts
+++ b/packages/decomposer/src/claude-decomposer.ts
@@ -1,0 +1,109 @@
+import type { DecompositionResult, DecomposerConfig } from './types';
+
+const DECOMPOSER_SYSTEM_PROMPT = `You are an expert product manager and software architect. Your job is to decompose user requirements into a structured hierarchy of work items.
+
+Given a prompt from a user, produce a JSON hierarchy with this exact structure:
+{
+  "hierarchy": [
+    {
+      "id": "init-1",
+      "level": "initiative",
+      "title": "Short initiative title",
+      "description": "What this initiative achieves",
+      "estimatedEffort": "large",
+      "children": [
+        {
+          "id": "epic-1",
+          "level": "epic",
+          "title": "Epic title",
+          "description": "What this epic delivers",
+          "estimatedEffort": "medium",
+          "canParallelize": false,
+          "children": [
+            {
+              "id": "story-1",
+              "level": "story",
+              "title": "User story title",
+              "description": "As a user, I want to... so that...",
+              "acceptanceCriteria": ["Criterion 1", "Criterion 2"],
+              "estimatedEffort": "small",
+              "canParallelize": false,
+              "children": [
+                {
+                  "id": "task-1",
+                  "level": "task",
+                  "title": "Specific implementation task",
+                  "description": "Detailed what needs to be done",
+                  "estimatedEffort": "trivial",
+                  "canParallelize": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+Rules:
+1. Use realistic IDs (init-1, epic-1, story-1, task-1 etc)
+2. Keep titles short and actionable
+3. Acceptance criteria should be testable
+4. Set canParallelize: true only for items with no dependencies on siblings
+5. estimatedEffort: trivial (<2h), small (2-8h), medium (1-3d), large (3-10d), xl (>10d)
+6. Aim for 1-3 initiatives, 2-5 epics per initiative, 2-6 stories per epic, 1-4 tasks per story
+7. Return ONLY valid JSON, no markdown, no explanation`;
+
+export async function decomposeWithClaude(prompt: string, config: DecomposerConfig = {}): Promise<DecompositionResult> {
+  const apiKey = config.claudeApiKey ?? process.env['ANTHROPIC_API_KEY'];
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY required for Claude decomposition');
+
+  const model = config.claudeModel ?? 'claude-sonnet-4-6';
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 8000,
+      system: DECOMPOSER_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: `Decompose this requirement:\n\n${prompt}` }],
+    }),
+  });
+
+  if (!response.ok) throw new Error(`Claude API error: ${response.status}`);
+
+  const data = await response.json() as { content: Array<{ type: string; text: string }> };
+  const text = data.content.find((c) => c.type === 'text')?.text ?? '{}';
+
+  let parsed: { hierarchy: DecompositionResult['hierarchy'] };
+  try {
+    parsed = JSON.parse(text) as { hierarchy: DecompositionResult['hierarchy'] };
+  } catch {
+    // Try to extract JSON from response
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('Failed to parse Claude decomposition response');
+    parsed = JSON.parse(match[0]) as { hierarchy: DecompositionResult['hierarchy'] };
+  }
+
+  const countNodes = (nodes: DecompositionResult['hierarchy']): number =>
+    nodes.reduce((sum, n) => sum + 1 + countNodes(n.children ?? []), 0);
+
+  const totalNodes = countNodes(parsed.hierarchy);
+  const initiatives = parsed.hierarchy;
+  const allEpics = initiatives.flatMap(i => i.children ?? []);
+
+  return {
+    originalPrompt: prompt,
+    hierarchy: parsed.hierarchy,
+    totalNodes,
+    estimatedDays: allEpics.length * 2.5,
+    recommendedParallelTracks: Math.min(allEpics.length, 4),
+    summary: `AI decomposed into ${initiatives.length} initiative(s), ${allEpics.length} epic(s), ${totalNodes} total nodes.`,
+  };
+}

--- a/packages/decomposer/src/decomposer.test.ts
+++ b/packages/decomposer/src/decomposer.test.ts
@@ -1,0 +1,138 @@
+import { decomposeRuleBased } from './rule-based';
+import type { DecompositionNode } from './types';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function collectAllNodes(nodes: DecompositionNode[]): DecompositionNode[] {
+  return nodes.flatMap(n => [n, ...collectAllNodes(n.children ?? [])]);
+}
+
+// ─── rule-based decomposer ────────────────────────────────────────────────────
+
+describe('decomposeRuleBased', () => {
+  const PROMPT = 'Build a user authentication system with login, registration, and password reset';
+
+  let result: ReturnType<typeof decomposeRuleBased>;
+
+  beforeAll(() => {
+    result = decomposeRuleBased(PROMPT);
+  });
+
+  it('returns a DecompositionResult with correct shape', () => {
+    expect(result).toHaveProperty('originalPrompt', PROMPT);
+    expect(result).toHaveProperty('hierarchy');
+    expect(result).toHaveProperty('totalNodes');
+    expect(result).toHaveProperty('estimatedDays');
+    expect(result).toHaveProperty('recommendedParallelTracks');
+    expect(result).toHaveProperty('summary');
+  });
+
+  it('originalPrompt matches the input', () => {
+    expect(result.originalPrompt).toBe(PROMPT);
+  });
+
+  it('hierarchy contains at least one initiative', () => {
+    expect(Array.isArray(result.hierarchy)).toBe(true);
+    expect(result.hierarchy.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('top-level nodes are all initiatives', () => {
+    for (const node of result.hierarchy) {
+      expect(node.level).toBe('initiative');
+    }
+  });
+
+  it('each initiative has at least one epic child', () => {
+    for (const initiative of result.hierarchy) {
+      expect(Array.isArray(initiative.children)).toBe(true);
+      expect((initiative.children ?? []).length).toBeGreaterThanOrEqual(1);
+      for (const epic of initiative.children ?? []) {
+        expect(epic.level).toBe('epic');
+      }
+    }
+  });
+
+  it('each epic has at least 2 story children', () => {
+    for (const initiative of result.hierarchy) {
+      for (const epic of initiative.children ?? []) {
+        expect((epic.children ?? []).length).toBeGreaterThanOrEqual(2);
+        for (const story of epic.children ?? []) {
+          expect(story.level).toBe('story');
+        }
+      }
+    }
+  });
+
+  it('each story has task children', () => {
+    for (const initiative of result.hierarchy) {
+      for (const epic of initiative.children ?? []) {
+        for (const story of epic.children ?? []) {
+          expect((story.children ?? []).length).toBeGreaterThanOrEqual(1);
+          for (const task of story.children ?? []) {
+            expect(task.level).toBe('task');
+          }
+        }
+      }
+    }
+  });
+
+  it('every node has a unique id', () => {
+    const all = collectAllNodes(result.hierarchy);
+    const ids = all.map(n => n.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('every node has a non-empty title', () => {
+    const all = collectAllNodes(result.hierarchy);
+    for (const node of all) {
+      expect(typeof node.title).toBe('string');
+      expect(node.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every node has a non-empty description', () => {
+    const all = collectAllNodes(result.hierarchy);
+    for (const node of all) {
+      expect(typeof node.description).toBe('string');
+      expect(node.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('totalNodes matches the actual count of nodes in the hierarchy', () => {
+    const all = collectAllNodes(result.hierarchy);
+    expect(result.totalNodes).toBe(all.length);
+  });
+
+  it('estimatedDays is a positive number', () => {
+    expect(result.estimatedDays).toBeGreaterThan(0);
+  });
+
+  it('recommendedParallelTracks is between 1 and 3', () => {
+    expect(result.recommendedParallelTracks).toBeGreaterThanOrEqual(1);
+    expect(result.recommendedParallelTracks).toBeLessThanOrEqual(3);
+  });
+
+  it('stories have acceptanceCriteria arrays', () => {
+    for (const initiative of result.hierarchy) {
+      for (const epic of initiative.children ?? []) {
+        for (const story of epic.children ?? []) {
+          expect(Array.isArray(story.acceptanceCriteria)).toBe(true);
+          expect((story.acceptanceCriteria ?? []).length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it('handles a single-line, single-topic prompt gracefully', () => {
+    const simple = decomposeRuleBased('Add a dark mode toggle');
+    expect(simple.hierarchy.length).toBeGreaterThanOrEqual(1);
+    expect(simple.totalNodes).toBeGreaterThan(0);
+  });
+
+  it('handles a multi-line prompt by creating multiple epics', () => {
+    const multiLine = decomposeRuleBased('Build a login page\nBuild a dashboard\nBuild a settings page');
+    const allEpics = multiLine.hierarchy.flatMap(i => i.children ?? []);
+    expect(allEpics.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/decomposer/src/index.ts
+++ b/packages/decomposer/src/index.ts
@@ -1,0 +1,28 @@
+export { decomposeRuleBased } from './rule-based';
+export { decomposeWithClaude } from './claude-decomposer';
+export type { DecompositionNode, DecompositionResult, DecomposerConfig } from './types';
+
+/**
+ * Decompose a natural language prompt into a structured Initiative → Epic → Story → Task hierarchy.
+ *
+ * Tries Claude first (if ANTHROPIC_API_KEY is present), falls back to the
+ * deterministic rule-based engine so that tests and CI never need an API key.
+ */
+export async function decompose(
+  prompt: string,
+  config: import('./types').DecomposerConfig = {},
+): Promise<import('./types').DecompositionResult> {
+  const apiKey = (config as { claudeApiKey?: string }).claudeApiKey ?? process.env['ANTHROPIC_API_KEY'];
+
+  if (apiKey) {
+    try {
+      const { decomposeWithClaude } = await import('./claude-decomposer');
+      return await decomposeWithClaude(prompt, config);
+    } catch (e) {
+      console.warn('[decomposer] Claude decomposition failed, falling back to rule-based:', e);
+    }
+  }
+
+  const { decomposeRuleBased } = await import('./rule-based');
+  return decomposeRuleBased(prompt, config);
+}

--- a/packages/decomposer/src/rule-based.ts
+++ b/packages/decomposer/src/rule-based.ts
@@ -1,0 +1,117 @@
+import { nanoid } from 'nanoid';
+import type { DecompositionNode, DecompositionResult, DecomposerConfig } from './types';
+
+function estimateEffort(description: string): 'trivial' | 'small' | 'medium' | 'large' | 'xl' {
+  const words = description.split(/\s+/).length;
+  if (words < 5) return 'trivial';
+  if (words < 15) return 'small';
+  if (words < 30) return 'medium';
+  if (words < 60) return 'large';
+  return 'xl';
+}
+
+// Extract logical sections from a prompt using heuristics
+function extractSections(prompt: string): string[] {
+  // Split on common separators: newlines, "and", semicolons, commas in lists
+  const lines = prompt.split(/\n+/).filter(l => l.trim().length > 5);
+  if (lines.length > 1) return lines.map(l => l.trim());
+
+  // Single line — split on conjunctions
+  const parts = prompt.split(/,\s+(?:and\s+)?|\s+and\s+|\s*;\s*/i).filter(p => p.trim().length > 3);
+  return parts.length > 1 ? parts : [prompt];
+}
+
+export function decomposeRuleBased(prompt: string, _config: DecomposerConfig = {}): DecompositionResult {
+  const sections = extractSections(prompt);
+
+  // Create one Initiative for the whole prompt
+  const initiative: DecompositionNode = {
+    id: `init-${nanoid(6)}`,
+    level: 'initiative',
+    title: prompt.length > 60 ? prompt.slice(0, 57) + '...' : prompt,
+    description: prompt,
+    estimatedEffort: 'large',
+    children: [],
+  };
+
+  // Create one Epic per major section
+  const epics: DecompositionNode[] = sections.map((section, i) => {
+    const epicId = `epic-${nanoid(6)}`;
+
+    // Create 2-4 stories per epic
+    const storyCount = Math.min(Math.max(2, Math.ceil(section.split(/\s+/).length / 10)), 4);
+    const stories: DecompositionNode[] = [];
+
+    const storyTemplates = [
+      `Implement core ${section.slice(0, 30)} functionality`,
+      `Add UI/UX for ${section.slice(0, 30)}`,
+      `Write tests for ${section.slice(0, 30)}`,
+      `Document ${section.slice(0, 30)} implementation`,
+    ];
+
+    for (let s = 0; s < storyCount; s++) {
+      const storyId = `story-${nanoid(6)}`;
+      const storyTitle = storyTemplates[s] ?? `Implement ${section.slice(0, 30)} part ${s + 1}`;
+
+      // Create 2 tasks per story
+      const tasks: DecompositionNode[] = [
+        {
+          id: `task-${nanoid(6)}`,
+          level: 'task',
+          title: `${storyTitle} — implementation`,
+          description: `Write the code for: ${storyTitle}`,
+          estimatedEffort: 'small',
+          canParallelize: false,
+        },
+        {
+          id: `task-${nanoid(6)}`,
+          level: 'task',
+          title: `${storyTitle} — tests`,
+          description: `Write unit and integration tests for: ${storyTitle}`,
+          estimatedEffort: 'small',
+          canParallelize: false,
+        },
+      ];
+
+      stories.push({
+        id: storyId,
+        level: 'story',
+        title: storyTitle,
+        description: `As a user, I want to ${section} so that I can achieve my goal.`,
+        acceptanceCriteria: [
+          `The ${section.slice(0, 30)} feature works as expected`,
+          'All tests pass',
+        ],
+        estimatedEffort: estimateEffort(section),
+        canParallelize: s > 0, // First story is foundational, rest can parallelize
+        children: tasks,
+      });
+    }
+
+    return {
+      id: epicId,
+      level: 'epic',
+      title: `Epic ${i + 1}: ${section.slice(0, 50)}`,
+      description: section,
+      estimatedEffort: 'large',
+      canParallelize: i > 0,
+      children: stories,
+    };
+  });
+
+  initiative.children = epics;
+
+  const countDescendants = (nodes: DecompositionNode[]): number =>
+    nodes.reduce((sum, n) => sum + 1 + countDescendants(n.children ?? []), 0);
+
+  const totalNodes = 1 + countDescendants(epics);
+
+  return {
+    originalPrompt: prompt,
+    hierarchy: [initiative],
+    totalNodes,
+    estimatedDays: epics.length * 3,
+    recommendedParallelTracks: Math.min(epics.length, 3),
+    summary: `Decomposed into ${epics.length} epic(s) with ${totalNodes} total nodes. Estimated ${epics.length * 3} days.`,
+  };
+}

--- a/packages/decomposer/src/types.ts
+++ b/packages/decomposer/src/types.ts
@@ -1,0 +1,31 @@
+export interface DecompositionNode {
+  id: string;
+  level: 'initiative' | 'epic' | 'module' | 'story' | 'task';
+  title: string;
+  description: string;
+  acceptanceCriteria?: string[];
+  estimatedEffort?: 'trivial' | 'small' | 'medium' | 'large' | 'xl';
+  dependencies?: string[];  // IDs of other nodes this depends on
+  canParallelize?: boolean;
+  children?: DecompositionNode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface DecompositionResult {
+  promptId?: string;
+  originalPrompt: string;
+  hierarchy: DecompositionNode[];  // top-level initiatives
+  totalNodes: number;
+  estimatedDays: number;
+  recommendedParallelTracks: number;
+  summary: string;
+}
+
+export interface DecomposerConfig {
+  maxDepth?: number;          // default: 5 (initiative→epic→module→story→task)
+  minStoriesPerEpic?: number; // default: 2
+  maxStoriesPerEpic?: number; // default: 8
+  aiProvider?: 'claude' | 'rule-based';  // rule-based for testing/cost savings
+  claudeApiKey?: string;
+  claudeModel?: string;       // default: claude-sonnet-4-6
+}

--- a/packages/dedup-engine/package.json
+++ b/packages/dedup-engine/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@chiefaia/dedup-engine",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Deduplication engine — Jaccard similarity with temporal decay.",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/dedup-engine/src/dedup.test.ts
+++ b/packages/dedup-engine/src/dedup.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import { check } from './engine';
+import { jaccardSimilarity, labelOverlapScore, combinedScore } from './similarity';
+import type { DedupCandidate } from './types';
+
+// ─── jaccardSimilarity ────────────────────────────────────────────────────────
+
+describe('jaccardSimilarity', () => {
+  it('returns 1 for identical strings', () => {
+    expect(jaccardSimilarity('add user login with oauth', 'add user login with oauth')).toBe(1);
+  });
+
+  it('returns 0 for completely unrelated strings', () => {
+    const score = jaccardSimilarity('add user login', 'deploy kubernetes cluster');
+    expect(score).toBeLessThan(0.1);
+  });
+
+  it('returns 1 for two empty strings', () => {
+    expect(jaccardSimilarity('', '')).toBe(1);
+  });
+
+  it('returns 0 when one string is empty', () => {
+    expect(jaccardSimilarity('some text', '')).toBe(0);
+    expect(jaccardSimilarity('', 'some text')).toBe(0);
+  });
+
+  it('is commutative', () => {
+    const a = 'implement google oauth login';
+    const b = 'add google login with oauth tokens';
+    expect(jaccardSimilarity(a, b)).toBeCloseTo(jaccardSimilarity(b, a), 10);
+  });
+
+  it('returns high score for near-identical strings', () => {
+    const score = jaccardSimilarity(
+      'add login form with email and password validation',
+      'add login form with email and password validation and remember me checkbox'
+    );
+    expect(score).toBeGreaterThan(0.7);
+  });
+});
+
+// ─── labelOverlapScore ────────────────────────────────────────────────────────
+
+describe('labelOverlapScore', () => {
+  it('returns 1 for identical label sets', () => {
+    expect(labelOverlapScore(['auth', 'feature'], ['auth', 'feature'])).toBe(1);
+  });
+
+  it('returns 0 when either label set is empty', () => {
+    expect(labelOverlapScore([], ['auth'])).toBe(0);
+    expect(labelOverlapScore(['auth'], [])).toBe(0);
+  });
+
+  it('returns partial score for partial overlap', () => {
+    const score = labelOverlapScore(['auth', 'feature', 'medium'], ['auth', 'bug', 'large']);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1);
+  });
+
+  it('returns 0 for disjoint label sets', () => {
+    expect(labelOverlapScore(['auth', 'feature'], ['devops', 'bug'])).toBe(0);
+  });
+});
+
+// ─── combinedScore ────────────────────────────────────────────────────────────
+
+describe('combinedScore', () => {
+  it('uses textWeight=0.7, labelWeight=0.3 by default', () => {
+    const score = combinedScore(0.8, 0.6);
+    expect(score).toBeCloseTo(0.8 * 0.7 + 0.6 * 0.3, 5);
+  });
+
+  it('uses custom weights', () => {
+    const score = combinedScore(0.5, 1.0, 0.5, 0.5);
+    expect(score).toBeCloseTo(0.75, 5);
+  });
+});
+
+// ─── check (engine) ───────────────────────────────────────────────────────────
+
+describe('check — empty corpus', () => {
+  it('returns new decision for empty corpus', () => {
+    const result = check({ id: '1', title: 'Add user login' }, []);
+    expect(result.decision).toBe('new');
+    expect(result.shouldBlock).toBe(false);
+    expect(result.shouldWarn).toBe(false);
+    expect(result.similarItems).toHaveLength(0);
+  });
+});
+
+describe('check — exact duplicate', () => {
+  it('detects identical title as duplicate', () => {
+    const existing: DedupCandidate = { id: 'existing-1', title: 'Add Google OAuth login with JWT tokens and refresh flow' };
+    const newItem: DedupCandidate = { id: 'new-1', title: 'Add Google OAuth login with JWT tokens and refresh flow' };
+    const result = check(newItem, [existing]);
+    expect(result.decision).toBe('duplicate');
+    expect(result.shouldBlock).toBe(true);
+    expect(result.recommendations.length).toBeGreaterThan(0);
+    expect(result.recommendations[0]).toContain('duplicate');
+  });
+});
+
+describe('check — high similarity', () => {
+  it('detects very similar items as likely_duplicate', () => {
+    const existing: DedupCandidate = {
+      id: 'ex-1',
+      title: 'Implement password reset flow with email link token expiry and user notification',
+    };
+    const newItem: DedupCandidate = {
+      id: 'new-1',
+      title: 'Implement password reset flow with email token expiry link and user notification message',
+    };
+    const result = check(newItem, [existing]);
+    // Similarity will be high — likely_duplicate or duplicate
+    expect(['likely_duplicate', 'duplicate', 'overlap', 'related']).toContain(result.decision);
+    expect(result.confidence).toBeGreaterThan(0.5);
+  });
+});
+
+describe('check — unrelated items', () => {
+  it('returns new decision for unrelated items', () => {
+    const corpus: DedupCandidate[] = [
+      { id: 'c1', title: 'Set up Kubernetes deployment manifests for prod cluster' },
+      { id: 'c2', title: 'Add Redis caching layer with TTL invalidation strategy' },
+      { id: 'c3', title: 'Configure GitHub Actions CI pipeline with Docker build' },
+    ];
+    const newItem: DedupCandidate = { id: 'n1', title: 'Design user onboarding survey with NPS scoring' };
+    const result = check(newItem, corpus);
+    expect(result.decision).toBe('new');
+    expect(result.shouldBlock).toBe(false);
+  });
+});
+
+describe('check — temporal decay', () => {
+  it('reduces score for items older than decay period', () => {
+    const oldTimestamp = Date.now() - (400 * 24 * 60 * 60 * 1000); // 400 days ago
+    const oldItem: DedupCandidate = {
+      id: 'old-1',
+      title: 'Add user authentication with JWT tokens and refresh logic',
+      createdAt: oldTimestamp,
+    };
+    const newItem: DedupCandidate = {
+      id: 'new-1',
+      title: 'Add user authentication with JWT tokens and refresh logic',
+    };
+
+    // Without decay (fresh item)
+    const freshItem: DedupCandidate = { id: 'fresh-1', title: 'Add user authentication with JWT tokens and refresh logic' };
+    const resultFresh = check(newItem, [freshItem]);
+
+    // With decay (old item)
+    const resultOld = check(newItem, [oldItem], { temporalDecayDays: 180 });
+
+    // Old item should have lower confidence than fresh identical item
+    expect(resultOld.confidence).toBeLessThan(resultFresh.confidence);
+  });
+
+  it('never decays below 50% of original score', () => {
+    // 10 years old — well past any decay period
+    const veryOldTimestamp = Date.now() - (3650 * 24 * 60 * 60 * 1000);
+    // Use a sufficiently long title so bigrams push text similarity comfortably above the 0.50 filter,
+    // ensuring even the 50%-decayed score stays at or above relatedThreshold
+    const title = 'Add user login with email and password authentication form including remember me option';
+    const veryOldItem: DedupCandidate = {
+      id: 'ancient-1',
+      title,
+      createdAt: veryOldTimestamp,
+    };
+    const newItem: DedupCandidate = { id: 'new-1', title };
+    const result = check(newItem, [veryOldItem], { temporalDecayDays: 180 });
+    // Identical text → textSim = 1.0; decay floors at 0.5 → finalScore = 0.5.
+    // That equals relatedThreshold so the item is still returned and confidence >= 0.5.
+    expect(result.confidence).toBeGreaterThanOrEqual(0.5);
+  });
+});
+
+describe('check — label overlap boosts score', () => {
+  it('shared labels increase confidence vs no labels', () => {
+    const title = 'Implement Google OAuth login flow with JWT session tokens';
+    const itemNoLabels: DedupCandidate = { id: 'base', title };
+    const itemWithLabels: DedupCandidate = { id: 'labeled', title, labels: ['auth', 'feature', 'backend'] };
+    const newItem: DedupCandidate = {
+      id: 'new',
+      title: 'Add Google OAuth authentication with JWT token management',
+      labels: ['auth', 'feature', 'backend'],
+    };
+
+    const resultNoLabels = check(newItem, [itemNoLabels]);
+    const resultWithLabels = check(newItem, [itemWithLabels]);
+
+    expect(resultWithLabels.confidence).toBeGreaterThanOrEqual(resultNoLabels.confidence);
+  });
+});
+
+describe('check — excludes self from comparison', () => {
+  it('does not match the item against itself', () => {
+    const item: DedupCandidate = { id: 'self', title: 'Add login form with email and password validation' };
+    const result = check(item, [item]);
+    expect(result.decision).toBe('new');
+    expect(result.similarItems).toHaveLength(0);
+  });
+});
+
+describe('check — shouldWarn for overlap/likely_duplicate', () => {
+  it('shouldWarn is true for likely_duplicate', () => {
+    const existing: DedupCandidate = {
+      id: 'ex',
+      title: 'Build payment checkout flow with Stripe integration and webhooks',
+    };
+    const newItem: DedupCandidate = {
+      id: 'new',
+      title: 'Build checkout payment flow with Stripe webhooks and order confirmation',
+    };
+    const result = check(newItem, [existing]);
+    if (result.decision === 'likely_duplicate' || result.decision === 'overlap') {
+      expect(result.shouldWarn).toBe(true);
+    }
+  });
+});
+
+describe('check — recommendations populated', () => {
+  it('provides recommendations for duplicate decision', () => {
+    const text = 'Implement rate limiting middleware for all API endpoints using Redis';
+    const existing: DedupCandidate = { id: 'e', title: text };
+    const newItem: DedupCandidate = { id: 'n', title: text };
+    const result = check(newItem, [existing]);
+    if (result.decision === 'duplicate') {
+      expect(result.recommendations.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/dedup-engine/src/engine.ts
+++ b/packages/dedup-engine/src/engine.ts
@@ -1,0 +1,89 @@
+import { jaccardSimilarity, labelOverlapScore, combinedScore } from './similarity';
+import type { DedupCandidate, DedupResult, DedupEngineConfig, SimilarItem, DedupDecision } from './types';
+
+const DEFAULTS: Required<DedupEngineConfig> = {
+  duplicateThreshold: 0.92,
+  likelyDuplicateThreshold: 0.80,
+  overlapThreshold: 0.65,
+  relatedThreshold: 0.50,
+  temporalDecayDays: 180,
+  projectScoped: true,
+};
+
+function applyTemporalDecay(score: number, candidate: DedupCandidate, decayDays: number): number {
+  if (!candidate.createdAt) return score;
+  const ageMs = Date.now() - candidate.createdAt;
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  if (ageDays < decayDays) return score;
+  // After decay threshold, reduce score linearly to 50% at 2x decay period
+  const decayFactor = Math.max(0.5, 1 - ((ageDays - decayDays) / decayDays) * 0.5);
+  return score * decayFactor;
+}
+
+export function check(
+  newItem: DedupCandidate,
+  corpus: DedupCandidate[],
+  config: DedupEngineConfig = {}
+): DedupResult {
+  const cfg = { ...DEFAULTS, ...config };
+  const newText = `${newItem.title} ${newItem.description ?? ''}`.trim();
+
+  // Score all corpus items
+  const scored: Array<{ item: DedupCandidate; score: number }> = corpus
+    .filter(c => c.id !== newItem.id)
+    .map(candidate => {
+      const candidateText = `${candidate.title} ${candidate.description ?? ''}`.trim();
+      const textSim = jaccardSimilarity(newText, candidateText);
+      // Only blend in label overlap when at least one side has labels;
+      // otherwise a pure-text comparison would be unfairly capped at 0.7
+      const hasLabels = (newItem.labels?.length ?? 0) > 0 || (candidate.labels?.length ?? 0) > 0;
+      const rawScore = hasLabels
+        ? combinedScore(textSim, labelOverlapScore(newItem.labels ?? [], candidate.labels ?? []))
+        : textSim;
+      const finalScore = applyTemporalDecay(rawScore, candidate, cfg.temporalDecayDays);
+      return { item: candidate, score: finalScore };
+    })
+    .filter(s => s.score >= cfg.relatedThreshold)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 10);  // top 10 matches
+
+  const topScore = scored[0]?.score ?? 0;
+
+  // Determine decision
+  let decision: DedupDecision = 'new';
+  if (topScore >= cfg.duplicateThreshold) decision = 'duplicate';
+  else if (topScore >= cfg.likelyDuplicateThreshold) decision = 'likely_duplicate';
+  else if (topScore >= cfg.overlapThreshold) decision = 'overlap';
+  else if (topScore >= cfg.relatedThreshold) decision = 'related';
+  else if (scored.length > 0) decision = 'similar_concept';
+
+  const similarItems: SimilarItem[] = scored.map(s => ({
+    id: s.item.id,
+    title: s.item.title,
+    description: s.item.description,
+    similarity: Math.round(s.score * 100) / 100,
+    sharedLabels: (newItem.labels ?? []).filter(l => (s.item.labels ?? []).includes(l)),
+  }));
+
+  const recommendations: string[] = [];
+  if (decision === 'duplicate') {
+    recommendations.push(`This appears to be a duplicate of "${scored[0]?.item.title}". Consider linking to it instead of creating a new item.`);
+  } else if (decision === 'likely_duplicate') {
+    recommendations.push(`Very similar to "${scored[0]?.item.title}" (${Math.round(topScore * 100)}% match). Review before proceeding.`);
+  } else if (decision === 'overlap') {
+    recommendations.push(`Overlaps with ${scored.length} existing item(s). Consider whether this extends existing work or is genuinely new.`);
+    if (scored[0]) recommendations.push(`Most similar: "${scored[0].item.title}"`);
+  } else if (decision === 'related') {
+    recommendations.push(`Related to existing work: ${scored.slice(0, 2).map(s => `"${s.item.title}"`).join(', ')}`);
+  }
+
+  return {
+    decision,
+    confidence: topScore,
+    similarItems,
+    recommendations,
+    reasoning: `Highest similarity: ${Math.round(topScore * 100)}% with "${scored[0]?.item.title ?? 'none'}". Decision: ${decision}.`,
+    shouldBlock: decision === 'duplicate',
+    shouldWarn: decision === 'likely_duplicate' || decision === 'overlap',
+  };
+}

--- a/packages/dedup-engine/src/index.ts
+++ b/packages/dedup-engine/src/index.ts
@@ -1,0 +1,3 @@
+export { check } from './engine';
+export type { DedupCandidate, DedupResult, DedupDecision, DedupEngineConfig, SimilarItem } from './types';
+export { jaccardSimilarity, labelOverlapScore, combinedScore } from './similarity';

--- a/packages/dedup-engine/src/similarity.ts
+++ b/packages/dedup-engine/src/similarity.ts
@@ -1,0 +1,46 @@
+function tokenize(text: string): Set<string> {
+  const words = text.toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 2);
+
+  // Generate bigrams for better phrase matching
+  const tokens = new Set<string>(words);
+  for (let i = 0; i < words.length - 1; i++) {
+    tokens.add(`${words[i]}_${words[i + 1]}`);
+  }
+  return tokens;
+}
+
+export function jaccardSimilarity(a: string, b: string): number {
+  const setA = tokenize(a);
+  const setB = tokenize(b);
+
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of setA) {
+    if (setB.has(token)) intersection++;
+  }
+
+  const union = setA.size + setB.size - intersection;
+  return intersection / union;
+}
+
+export function labelOverlapScore(labelsA: string[], labelsB: string[]): number {
+  if (labelsA.length === 0 || labelsB.length === 0) return 0;
+  const setA = new Set(labelsA);
+  const matches = labelsB.filter(l => setA.has(l)).length;
+  return matches / Math.max(labelsA.length, labelsB.length);
+}
+
+// Combined score: weighted average of text similarity and label overlap
+export function combinedScore(
+  textSimilarity: number,
+  labelOverlap: number,
+  textWeight = 0.7,
+  labelWeight = 0.3
+): number {
+  return (textSimilarity * textWeight) + (labelOverlap * labelWeight);
+}

--- a/packages/dedup-engine/src/types.ts
+++ b/packages/dedup-engine/src/types.ts
@@ -1,0 +1,39 @@
+export type DedupDecision = 'new' | 'similar_concept' | 'related' | 'overlap' | 'likely_duplicate' | 'duplicate';
+
+export interface SimilarItem {
+  id: string;
+  title: string;
+  description?: string;
+  similarity: number;  // 0-1
+  sharedLabels?: string[];
+}
+
+export interface DedupResult {
+  decision: DedupDecision;
+  confidence: number;  // 0-1
+  similarItems: SimilarItem[];
+  recommendations: string[];
+  reasoning: string;
+  shouldBlock: boolean;  // true for duplicate, likely_duplicate
+  shouldWarn: boolean;   // true for overlap
+}
+
+export interface DedupCandidate {
+  id: string;
+  title: string;
+  description?: string;
+  labels?: string[];
+  createdAt?: number;
+}
+
+export interface DedupEngineConfig {
+  // Similarity thresholds
+  duplicateThreshold?: number;        // default: 0.92
+  likelyDuplicateThreshold?: number;  // default: 0.80
+  overlapThreshold?: number;          // default: 0.65
+  relatedThreshold?: number;          // default: 0.50
+  // Temporal decay: old completed items treated as fresh after N days
+  temporalDecayDays?: number;         // default: 180
+  // Scope
+  projectScoped?: boolean;            // default: true (only compare within same project)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)
 
+  packages/classifier: {}
+
   packages/cli:
     dependencies:
       commander:
@@ -475,6 +477,14 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+
+  packages/decomposer:
+    dependencies:
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.9
+
+  packages/dedup-engine: {}
 
   packages/dev-inspector:
     dependencies:


### PR DESCRIPTION
Lift batch C from conductor archive (commit 71a02a6).

## What lands

| Package | Lines | Purpose |
|---|---|---|
| `@chiefaia/classifier` | 381 | Domain taxonomy + label assignment. Consumed by ba-agent + migration 0019 entity_labels. |
| `@chiefaia/decomposer` | 423 | NL → Initiative→Epic→Module→Story→Task. Two providers: rule-based + claude-decomposer. Consumed by po-agent. |
| `@chiefaia/dedup-engine` | 408 | Jaccard similarity + temporal decay. Backs migration 0019 dedup_results. |

All three follow the established 'internal' convention (`@chiefaia/event-bus-internal`, `@chiefaia/events-taxonomy-internal`):
- `private: true`
- `main: src/index.ts` — no build step, consumed as TS source by the orchestrator (orchestrator tsconfig includes `packages/**/*`).

Package names are kept WITHOUT `-internal` suffix because the agents in Batch F import them as `@chiefaia/classifier` / `@chiefaia/decomposer` (per conductor `src/agents/po-agent.ts`).

`@chiefaia/decomposer` is **distinct from** the existing `@chiefaia/story-decomposer` — different API. Decomposer takes a free-form prompt and emits the full hierarchy; story-decomposer takes a Story and emits sub-tasks.

## Source adjustments

- `decomposer/src`: stripped `.js` import suffixes (only needed for ESM publishing in conductor; redundant in CAIA's commonjs/Node moduleResolution layout).

## Verification

- `pnpm install` — clean
- `pnpm --filter @caia-app/core typecheck` — clean (orchestrator resolves the new packages)
- `pnpm build` — 26/26 turbo tasks pass

## Skip

LIFT-013 (`@chiefaia/local-llm-router`) — handled by separate parallel task on `feat/lift-local-llm-router`.

## Source-of-truth

Per matrix `~/Documents/projects/reports/conductor-to-caia-capability-matrix-2026-04-28.md` Section 1.2 Batch C.