### PR TITLE
feat(db): batch D — migrations 0015–0019 + schema additions + agents seed

### DIFF
--- a/apps/orchestrator/src/db/migrations/0015_event_pipeline_foundation.sql
+++ b/apps/orchestrator/src/db/migrations/0015_event_pipeline_foundation.sql
@@ -1,0 +1,37 @@
+-- Migration 0015: Event pipeline foundation
+-- Adds telemetry columns to task_runs for executor observability.
+-- Creates prompt_pipeline_stages for end-to-end prompt lineage tracking.
+
+-- ─── task_runs: executor telemetry columns ───────────────────────────────────
+ALTER TABLE `task_runs` ADD COLUMN `executor_pid` integer;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `worktree_path` text;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `tool_call_count` integer DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `input_tokens` integer DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `output_tokens` integer DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `files_changed` text DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `duration_ms` integer;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD COLUMN `raw_claude_output` text;
+
+--> statement-breakpoint
+-- ─── prompt_pipeline_stages ──────────────────────────────────────────────────
+CREATE TABLE `prompt_pipeline_stages` (
+  `id`           text    PRIMARY KEY NOT NULL,
+  `prompt_id`    text    NOT NULL REFERENCES `prompts`(`id`),
+  `stage`        text    NOT NULL,
+  `entity_kind`  text,
+  `entity_id`    text,
+  `entered_at`   integer NOT NULL,
+  `duration_ms`  integer,
+  `metadata`     text
+);
+--> statement-breakpoint
+CREATE INDEX `pps_prompt_idx` ON `prompt_pipeline_stages` (`prompt_id`);
+--> statement-breakpoint
+CREATE INDEX `pps_stage_idx`  ON `prompt_pipeline_stages` (`stage`);

--- a/apps/orchestrator/src/db/migrations/0016_backfill_root_prompt_id.sql
+++ b/apps/orchestrator/src/db/migrations/0016_backfill_root_prompt_id.sql
@@ -1,0 +1,68 @@
+-- Migration 0016: Best-effort backfill of root_prompt_id
+-- Only updates records where the link is deterministically derivable
+-- via parent_entity_type / parent_entity_id foreign-key pattern.
+--
+-- Note: requirements.root_prompt_id has no deterministic source to derive from
+-- (no direct prompt FK exists on the requirements table), so requirements rows
+-- are left for the application to populate when creating new records.
+
+-- ─── 1. Propagate from requirements to tasks ─────────────────────────────────
+-- Tasks whose parent entity is a requirement inherit its root_prompt_id.
+-- Tasks default root_prompt_id to 'untraced'; treat both NULL and 'untraced'
+-- as candidates for backfill.
+--> statement-breakpoint
+UPDATE tasks
+SET root_prompt_id = (
+  SELECT r.root_prompt_id
+  FROM requirements r
+  WHERE r.id = tasks.parent_entity_id
+)
+WHERE (tasks.root_prompt_id IS NULL OR tasks.root_prompt_id = 'untraced')
+  AND tasks.parent_entity_type = 'requirement'
+  AND tasks.parent_entity_id IS NOT NULL
+  AND (
+    SELECT r.root_prompt_id
+    FROM requirements r
+    WHERE r.id = tasks.parent_entity_id
+  ) IS NOT NULL;
+
+-- ─── 2. Propagate from tasks to task_runs ────────────────────────────────────
+-- task_runs whose parent entity is a task inherit its root_prompt_id.
+--> statement-breakpoint
+UPDATE task_runs
+SET root_prompt_id = (
+  SELECT t.root_prompt_id
+  FROM tasks t
+  WHERE t.id = task_runs.parent_entity_id
+)
+WHERE task_runs.root_prompt_id IS NULL
+  AND task_runs.parent_entity_type = 'task'
+  AND task_runs.parent_entity_id IS NOT NULL
+  AND (
+    SELECT t.root_prompt_id
+    FROM tasks t
+    WHERE t.id = task_runs.parent_entity_id
+  ) IS NOT NULL
+  AND (
+    SELECT t.root_prompt_id
+    FROM tasks t
+    WHERE t.id = task_runs.parent_entity_id
+  ) != 'untraced';
+
+-- ─── 3. Propagate from requirements to task_runs (direct parent link) ────────
+-- task_runs whose parent entity is directly a requirement.
+--> statement-breakpoint
+UPDATE task_runs
+SET root_prompt_id = (
+  SELECT r.root_prompt_id
+  FROM requirements r
+  WHERE r.id = task_runs.parent_entity_id
+)
+WHERE task_runs.root_prompt_id IS NULL
+  AND task_runs.parent_entity_type = 'requirement'
+  AND task_runs.parent_entity_id IS NOT NULL
+  AND (
+    SELECT r.root_prompt_id
+    FROM requirements r
+    WHERE r.id = task_runs.parent_entity_id
+  ) IS NOT NULL;

--- a/apps/orchestrator/src/db/migrations/0017_agent_registry.sql
+++ b/apps/orchestrator/src/db/migrations/0017_agent_registry.sql
@@ -1,0 +1,80 @@
+-- Migration 0017: Agent Registry, System Prompts, Artifacts, Inter-agent Messages
+-- Part of the CAIA (Conductor AI Agent) architecture
+
+CREATE TABLE IF NOT EXISTS `agent_registry` (
+  `id` text PRIMARY KEY NOT NULL,
+  `name` text NOT NULL UNIQUE,
+  `display_name` text NOT NULL,
+  `tier` text NOT NULL,
+  `description` text NOT NULL,
+  `version` text NOT NULL DEFAULT '0.1.0',
+  `status` text NOT NULL DEFAULT 'registered',
+  `endpoint_url` text,
+  `model_recommendation` text NOT NULL,
+  `capabilities` text NOT NULL DEFAULT '[]',
+  `tool_manifest` text NOT NULL DEFAULT '[]',
+  `trigger_events` text NOT NULL DEFAULT '[]',
+  `input_schema` text,
+  `output_schema` text,
+  `system_prompt_id` text,
+  `last_heartbeat` integer,
+  `metadata` text,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ar_tier_idx` ON `agent_registry` (`tier`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ar_status_idx` ON `agent_registry` (`status`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_system_prompts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `agent_name` text NOT NULL,
+  `version` text NOT NULL,
+  `prompt_text` text NOT NULL,
+  `is_active` integer NOT NULL DEFAULT 1,
+  `created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `asp_agent_idx` ON `agent_system_prompts` (`agent_name`, `is_active`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_artifacts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `agent_name` text NOT NULL,
+  `artifact_type` text NOT NULL,
+  `prompt_id` text REFERENCES `prompts`(`id`),
+  `requirement_id` text,
+  `content` text NOT NULL,
+  `content_type` text NOT NULL DEFAULT 'application/json',
+  `status` text NOT NULL DEFAULT 'draft',
+  `created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `aa_agent_idx` ON `agent_artifacts` (`agent_name`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `aa_prompt_idx` ON `agent_artifacts` (`prompt_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `aa_type_idx` ON `agent_artifacts` (`artifact_type`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `agent_messages` (
+  `id` text PRIMARY KEY NOT NULL,
+  `from_agent` text NOT NULL,
+  `to_agent` text NOT NULL,
+  `message_type` text NOT NULL,
+  `correlation_id` text NOT NULL,
+  `payload` text NOT NULL,
+  `status` text NOT NULL DEFAULT 'pending',
+  `created_at` integer NOT NULL,
+  `processed_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `am_from_idx` ON `agent_messages` (`from_agent`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `am_to_idx` ON `agent_messages` (`to_agent`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `am_correlation_idx` ON `agent_messages` (`correlation_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `am_status_idx` ON `agent_messages` (`status`);

--- a/apps/orchestrator/src/db/migrations/0018_story_enrichment.sql
+++ b/apps/orchestrator/src/db/migrations/0018_story_enrichment.sql
@@ -1,0 +1,8 @@
+-- Migration 0018: Story Enrichment columns for BA Agent
+-- Adds implementation_notes, updated_at, enriched_at to the stories table
+
+ALTER TABLE `stories` ADD COLUMN `implementation_notes` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `updated_at` integer;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `enriched_at` integer;

--- a/apps/orchestrator/src/db/migrations/0019_entity_labels.sql
+++ b/apps/orchestrator/src/db/migrations/0019_entity_labels.sql
@@ -1,0 +1,39 @@
+-- Migration 0019: Entity Labels + Dedup Results
+-- entity_labels: domain taxonomy labels applied to any entity
+-- dedup_results: deduplication check outcomes
+
+CREATE TABLE IF NOT EXISTS `entity_labels` (
+  `id` text PRIMARY KEY NOT NULL,
+  `entity_kind` text NOT NULL,
+  `entity_id` text NOT NULL,
+  `label_slug` text NOT NULL,
+  `label_type` text NOT NULL,
+  `confidence` real NOT NULL DEFAULT 1.0,
+  `source` text NOT NULL DEFAULT 'classifier',
+  `created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_el_entity` ON `entity_labels` (`entity_kind`, `entity_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_el_label` ON `entity_labels` (`label_slug`);
+--> statement-breakpoint
+CREATE INDEX `idx_el_type` ON `entity_labels` (`label_type`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `dedup_results` (
+  `id` text PRIMARY KEY NOT NULL,
+  `entity_kind` text NOT NULL,
+  `entity_id` text NOT NULL,
+  `checked_at` integer NOT NULL,
+  `decision` text NOT NULL,
+  `similarity_score` real NOT NULL DEFAULT 0,
+  `similar_entities` text NOT NULL DEFAULT '[]',
+  `recommendations` text NOT NULL DEFAULT '[]',
+  `resolved_action` text,
+  `resolved_at` integer,
+  `created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_dr_entity` ON `dedup_results` (`entity_kind`, `entity_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_dr_decision` ON `dedup_results` (`decision`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -99,6 +99,41 @@
       "when": 1776729970214,
       "tag": "0014_health009_dom001",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1746000000000,
+      "tag": "0015_event_pipeline_foundation",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1746100000000,
+      "tag": "0016_backfill_root_prompt_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1746200000000,
+      "tag": "0017_agent_registry",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1746300000000,
+      "tag": "0018_story_enrichment",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1746400000000,
+      "tag": "0019_entity_labels",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -274,6 +274,14 @@ export const taskRuns = sqliteTable('task_runs', {
   rootPromptId: text('root_prompt_id'),
   parentEntityType: text('parent_entity_type'),
   parentEntityId: text('parent_entity_id'),
+  executorPid: integer('executor_pid'),
+  worktreePath: text('worktree_path'),
+  toolCallCount: integer('tool_call_count').default(0),
+  inputTokens: integer('input_tokens').default(0),
+  outputTokens: integer('output_tokens').default(0),
+  filesChanged: text('files_changed').default('[]'),
+  durationMs: integer('duration_ms'),
+  rawClaudeOutput: text('raw_claude_output'),
 }, (t) => [
   index('tr_status_idx').on(t.status),
   index('tr_started_idx').on(t.startedAt),
@@ -386,6 +394,10 @@ export const stories = sqliteTable('stories', {
   rootPromptId: text('root_prompt_id'),
   parentEntityType: text('parent_entity_type'),
   parentEntityId: text('parent_entity_id'),
+  // BA Agent enrichment columns (migration 0018)
+  implementationNotes: text('implementation_notes'),
+  updatedAt: integer('updated_at'),
+  enrichedAt: integer('enriched_at'),
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -719,4 +731,126 @@ export const pulseRuns = sqliteTable('pulse_runs', {
 }, (t) => [
   index('pulse_runs_ran_at_idx').on(t.ranAt),
   index('pulse_runs_outcome_idx').on(t.outcome),
+]);
+
+// agent_registry — canonical registry of all CAIA agents (migration 0017)
+export const agentRegistry = sqliteTable('agent_registry', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull().unique(),
+  displayName: text('display_name').notNull(),
+  tier: text('tier').notNull(), // 'strategic'|'planning'|'engineering'|'quality'|'growth'|'maintenance'
+  description: text('description').notNull(),
+  version: text('version').notNull().default('0.1.0'),
+  status: text('status').notNull().default('registered'), // 'registered'|'active'|'disabled'|'error'
+  endpointUrl: text('endpoint_url'),
+  modelRecommendation: text('model_recommendation').notNull(), // 'opus'|'sonnet'|'haiku'|'local'
+  capabilities: text('capabilities').notNull().default('[]'), // JSON array
+  toolManifest: text('tool_manifest').notNull().default('[]'), // JSON array
+  triggerEvents: text('trigger_events').notNull().default('[]'), // JSON array
+  inputSchema: text('input_schema'),
+  outputSchema: text('output_schema'),
+  systemPromptId: text('system_prompt_id'),
+  lastHeartbeat: integer('last_heartbeat'),
+  metadata: text('metadata'), // JSON
+  createdAt: integer('created_at').notNull().$defaultFn(() => Date.now()),
+  updatedAt: integer('updated_at').notNull().$defaultFn(() => Date.now()),
+}, (t) => [
+  index('ar_tier_idx').on(t.tier),
+  index('ar_status_idx').on(t.status),
+]);
+
+// agent_system_prompts — versioned system prompts for each agent (migration 0017)
+export const agentSystemPrompts = sqliteTable('agent_system_prompts', {
+  id: text('id').primaryKey(),
+  agentName: text('agent_name').notNull(),
+  version: text('version').notNull(),
+  promptText: text('prompt_text').notNull(),
+  isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+  createdAt: integer('created_at').notNull().$defaultFn(() => Date.now()),
+}, (t) => [
+  index('asp_agent_idx').on(t.agentName, t.isActive),
+]);
+
+// agent_artifacts — outputs produced by agents (migration 0017)
+export const agentArtifacts = sqliteTable('agent_artifacts', {
+  id: text('id').primaryKey(),
+  agentName: text('agent_name').notNull(),
+  artifactType: text('artifact_type').notNull(), // 'architecture-plan'|'api-spec'|'db-schema'|'wireframe'|'test-plan'|'deployment-config'
+  promptId: text('prompt_id').references(() => prompts.id),
+  requirementId: text('requirement_id'),
+  content: text('content').notNull(), // JSON or markdown
+  contentType: text('content_type').notNull().default('application/json'),
+  status: text('status').notNull().default('draft'), // 'draft'|'approved'|'superseded'
+  createdAt: integer('created_at').notNull().$defaultFn(() => Date.now()),
+}, (t) => [
+  index('aa_agent_idx').on(t.agentName),
+  index('aa_prompt_idx').on(t.promptId),
+  index('aa_type_idx').on(t.artifactType),
+]);
+
+// agent_messages — inter-agent communication log (migration 0017)
+export const agentMessages = sqliteTable('agent_messages', {
+  id: text('id').primaryKey(),
+  fromAgent: text('from_agent').notNull(),
+  toAgent: text('to_agent').notNull(),
+  messageType: text('message_type').notNull(), // 'context-broadcast'|'task-delegation'|'result'|'escalation'
+  correlationId: text('correlation_id').notNull(),
+  payload: text('payload').notNull(), // JSON
+  status: text('status').notNull().default('pending'), // 'pending'|'delivered'|'processed'|'failed'
+  createdAt: integer('created_at').notNull().$defaultFn(() => Date.now()),
+  processedAt: integer('processed_at'),
+}, (t) => [
+  index('am_from_idx').on(t.fromAgent),
+  index('am_to_idx').on(t.toAgent),
+  index('am_correlation_idx').on(t.correlationId),
+  index('am_status_idx').on(t.status),
+]);
+
+// prompt_pipeline_stages — tracks stage advancement for each prompt through the pipeline (migration 0015)
+export const promptPipelineStages = sqliteTable('prompt_pipeline_stages', {
+  id: text('id').primaryKey(),
+  promptId: text('prompt_id').notNull().references(() => prompts.id),
+  stage: text('stage').notNull(), // ingested|requirement_created|story_decomposed|task_queued|task_running|task_completed|verified
+  entityKind: text('entity_kind'),
+  entityId: text('entity_id'),
+  enteredAt: integer('entered_at').notNull(),
+  durationMs: integer('duration_ms'),
+  metadata: text('metadata'), // JSON
+}, (t) => [
+  index('pps_prompt_idx').on(t.promptId),
+  index('pps_stage_idx').on(t.stage),
+]);
+
+// entity_labels — domain taxonomy labels applied to any entity (migration 0019)
+export const entityLabels = sqliteTable('entity_labels', {
+  id: text('id').primaryKey().notNull(),
+  entityKind: text('entity_kind').notNull(), // 'prompt'|'requirement'|'story'|'task'
+  entityId: text('entity_id').notNull(),
+  labelSlug: text('label_slug').notNull(),   // e.g. 'auth', 'ui-frontend', 'feature', 'medium'
+  labelType: text('label_type').notNull(),   // 'domain'|'nature'|'complexity'|'layer'|'lifecycle'
+  confidence: real('confidence').notNull().default(1.0),
+  source: text('source').notNull().default('classifier'), // 'classifier'|'human'|'ai'
+  createdAt: integer('created_at').notNull(),
+}, (t) => [
+  index('idx_el_entity').on(t.entityKind, t.entityId),
+  index('idx_el_label').on(t.labelSlug),
+  index('idx_el_type').on(t.labelType),
+]);
+
+// dedup_results — deduplication check results (migration 0019)
+export const dedupResults = sqliteTable('dedup_results', {
+  id: text('id').primaryKey().notNull(),
+  entityKind: text('entity_kind').notNull(),
+  entityId: text('entity_id').notNull(),
+  checkedAt: integer('checked_at').notNull(),
+  decision: text('decision').notNull(), // 'new'|'similar_concept'|'related'|'overlap'|'likely_duplicate'|'duplicate'
+  similarityScore: real('similarity_score').notNull().default(0),
+  similarEntities: text('similar_entities').notNull().default('[]'), // JSON array of {id, score, title}
+  recommendations: text('recommendations').notNull().default('[]'),  // JSON array of recommendation strings
+  resolvedAction: text('resolved_action'),  // 'proceed'|'merge'|'enhancement_of'|'override'
+  resolvedAt: integer('resolved_at'),
+  createdAt: integer('created_at').notNull(),
+}, (t) => [
+  index('idx_dr_entity').on(t.entityKind, t.entityId),
+  index('idx_dr_decision').on(t.decision),
 ]);

--- a/apps/orchestrator/src/db/seeds/agents.ts
+++ b/apps/orchestrator/src/db/seeds/agents.ts
@@ -1,0 +1,610 @@
+/**
+ * CAIA Agent Registry Seed
+ * Seeds all 24 agents and system prompts for the top 5 agents.
+ * Run via: npx tsx src/db/seeds/agents.ts
+ */
+
+import { getDb } from '../connection';
+import { agentRegistry, agentSystemPrompts } from '../schema';
+
+const now = Date.now();
+
+interface AgentSeedRow {
+  id: string;
+  name: string;
+  displayName: string;
+  tier: string;
+  description: string;
+  modelRecommendation: string;
+  capabilities: string[];
+  triggerEvents: string[];
+}
+
+const AGENTS: AgentSeedRow[] = [
+  {
+    id: 'scaffolder',
+    name: 'scaffolder',
+    displayName: 'Scaffolder Agent',
+    tier: 'strategic',
+    description: 'Entry point for all new projects and features. Assembles the agent team, broadcasts context, manages sequencing.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['project-initialization', 'agent-assembly', 'context-broadcast', 'team-sequencing'],
+    triggerEvents: ['prompt.ingested'],
+  },
+  {
+    id: 'po-agent',
+    name: 'po-agent',
+    displayName: 'Product Owner Agent',
+    tier: 'strategic',
+    description: 'Decomposes prompts into Initiative→Epic→Module→Story hierarchy. Manages backlog prioritization.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['hierarchy-decomposition', 'backlog-management', 'prioritization'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'ba-agent',
+    name: 'ba-agent',
+    displayName: 'Business Analyst Agent',
+    tier: 'planning',
+    description: 'Enriches stories with acceptance criteria, functional specs, implementation detail, and domain labels.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['story-enrichment', 'acceptance-criteria', 'functional-specs'],
+    triggerEvents: ['po-agent.decomposition.complete'],
+  },
+  {
+    id: 'ux-agent',
+    name: 'ux-agent',
+    displayName: 'UX Designer Agent',
+    tier: 'planning',
+    description: 'Produces wireframes, user flows, design specs, and accessibility requirements.',
+    modelRecommendation: 'opus',
+    capabilities: ['wireframe-generation', 'user-flow-design', 'design-spec'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'task-scheduler',
+    name: 'task-scheduler',
+    displayName: 'Task Scheduler Agent',
+    tier: 'planning',
+    description: 'Builds dependency DAG, assigns sequential vs parallel buckets, sets priority order.',
+    modelRecommendation: 'haiku',
+    capabilities: ['dependency-analysis', 'dag-construction', 'priority-scheduling'],
+    triggerEvents: ['ba-agent.enrichment.complete'],
+  },
+  {
+    id: 'domain-classifier',
+    name: 'domain-classifier',
+    displayName: 'Domain Classifier Agent',
+    tier: 'planning',
+    description: 'Assigns domain taxonomy labels to requirements and stories. Runs dedup checks.',
+    modelRecommendation: 'haiku',
+    capabilities: ['domain-classification', 'dedup-detection', 'reuse-recommendation'],
+    triggerEvents: ['prompt.ingested'],
+  },
+  {
+    id: 'developer-agent',
+    name: 'developer-agent',
+    displayName: 'Developer Agent (Claude Code)',
+    tier: 'engineering',
+    description: 'Primary code execution agent. Implements tasks via Claude Code in git worktrees.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['code-implementation', 'git-operations', 'test-execution'],
+    triggerEvents: ['task.queued'],
+  },
+  {
+    id: 'dba-agent',
+    name: 'dba-agent',
+    displayName: 'DBA Agent',
+    tier: 'engineering',
+    description: 'Designs schema, writes migrations, optimizes queries, manages data models.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['schema-design', 'migration-writing', 'query-optimization'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'testing-agent',
+    name: 'testing-agent',
+    displayName: 'Testing Agent',
+    tier: 'quality',
+    description: 'Writes TDD unit tests, E2E tests, BDD/feature tests. Validates functionality against acceptance criteria.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['unit-testing', 'e2e-testing', 'bdd-testing', 'test-data-management'],
+    triggerEvents: ['task.completed'],
+  },
+  {
+    id: 'release-agent',
+    name: 'release-agent',
+    displayName: 'Release Agent',
+    tier: 'quality',
+    description: 'Manages CI/CD pipelines, deployment gates, versioning, changelogs, rollback plans.',
+    modelRecommendation: 'haiku',
+    capabilities: ['ci-cd-management', 'deployment-gating', 'versioning', 'changelog-generation'],
+    triggerEvents: ['testing-agent.tests.passed'],
+  },
+  {
+    id: 'observability-agent',
+    name: 'observability-agent',
+    displayName: 'Observability Agent',
+    tier: 'engineering',
+    description: 'Implements logging, tracing, alerting, and health checks across all services.',
+    modelRecommendation: 'haiku',
+    capabilities: ['logging-setup', 'tracing', 'alerting', 'health-checks'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'security-agent',
+    name: 'security-agent',
+    displayName: 'Security Agent',
+    tier: 'quality',
+    description: 'Reviews code for security vulnerabilities, checks compliance, validates input handling.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['security-review', 'vulnerability-scanning', 'compliance-check'],
+    triggerEvents: ['task.completed'],
+  },
+  {
+    id: 'ea-agent',
+    name: 'ea-agent',
+    displayName: 'Enterprise Architect Agent',
+    tier: 'strategic',
+    description: 'Translates business vision into technical initiatives, produces ADRs, makes platform decisions.',
+    modelRecommendation: 'opus',
+    capabilities: ['architecture-design', 'adr-production', 'platform-decision'],
+    triggerEvents: ['prompt.ingested'],
+  },
+  {
+    id: 'platform-agent',
+    name: 'platform-agent',
+    displayName: 'Platform Agent',
+    tier: 'engineering',
+    description: 'Provisions infrastructure, sets up environments, manages access tokens, configures integrations.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['infrastructure-provisioning', 'environment-setup', 'access-management'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'bff-agent',
+    name: 'bff-agent',
+    displayName: 'BFF Agent',
+    tier: 'engineering',
+    description: 'Designs API contracts, manages routes, defines backend-for-frontend layer.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['api-design', 'route-management', 'contract-definition'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'ui-agent',
+    name: 'ui-agent',
+    displayName: 'UI Agent',
+    tier: 'engineering',
+    description: 'Implements component architecture, design system, responsive layouts, accessibility.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['component-architecture', 'design-system', 'responsive-layout', 'accessibility'],
+    triggerEvents: ['ux-agent.design.complete'],
+  },
+  {
+    id: 'event-manager-agent',
+    name: 'event-manager-agent',
+    displayName: 'Event Manager Agent',
+    tier: 'engineering',
+    description: 'Sets up and enforces event-driven architecture patterns across services.',
+    modelRecommendation: 'haiku',
+    capabilities: ['event-architecture', 'event-taxonomy', 'event-enforcement'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'cms-agent',
+    name: 'cms-agent',
+    displayName: 'CMS Agent',
+    tier: 'engineering',
+    description: 'Handles content modeling, CMS integration, and content API setup.',
+    modelRecommendation: 'haiku',
+    capabilities: ['content-modeling', 'cms-integration', 'content-api'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'analytics-agent',
+    name: 'analytics-agent',
+    displayName: 'Web Analytics Agent',
+    tier: 'growth',
+    description: 'Sets up GA4/Plausible, instruments event tracking, configures funnel analytics.',
+    modelRecommendation: 'haiku',
+    capabilities: ['analytics-setup', 'event-tracking', 'funnel-instrumentation'],
+    triggerEvents: ['platform-agent.setup.complete'],
+  },
+  {
+    id: 'data-agent',
+    name: 'data-agent',
+    displayName: 'Data Analytics Agent',
+    tier: 'growth',
+    description: 'Builds data pipelines, reporting, dashboards, KPI tracking.',
+    modelRecommendation: 'sonnet',
+    capabilities: ['data-pipeline', 'reporting', 'kpi-tracking'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'crm-agent',
+    name: 'crm-agent',
+    displayName: 'CRM Agent',
+    tier: 'growth',
+    description: 'Integrates CRM, manages lead flows, customer data pipelines.',
+    modelRecommendation: 'haiku',
+    capabilities: ['crm-integration', 'lead-management', 'customer-data'],
+    triggerEvents: ['scaffolder.team.assembled'],
+  },
+  {
+    id: 'seo-agent',
+    name: 'seo-agent',
+    displayName: 'SEO Agent',
+    tier: 'growth',
+    description: 'Handles technical SEO, structured data, sitemap, performance budgets.',
+    modelRecommendation: 'haiku',
+    capabilities: ['technical-seo', 'structured-data', 'sitemap', 'performance-budget'],
+    triggerEvents: ['release-agent.deploy.staging'],
+  },
+  {
+    id: 'maintenance-agent',
+    name: 'maintenance-agent',
+    displayName: 'Maintenance Agent',
+    tier: 'maintenance',
+    description: 'Updates dependencies, patches security issues, fixes performance regressions.',
+    modelRecommendation: 'haiku',
+    capabilities: ['dependency-updates', 'security-patches', 'performance-fixes'],
+    triggerEvents: ['scheduled.weekly'],
+  },
+  {
+    id: 'docs-agent',
+    name: 'docs-agent',
+    displayName: 'Documentation Agent',
+    tier: 'maintenance',
+    description: 'Writes API docs, READMEs, changelogs, user guides, and code comments.',
+    modelRecommendation: 'haiku',
+    capabilities: ['api-docs', 'readme-writing', 'changelog', 'user-guides'],
+    triggerEvents: ['task.completed'],
+  },
+];
+
+// System prompts for the top 5 agents — detailed, production-quality
+const SYSTEM_PROMPTS: Array<{ agentName: string; version: string; promptText: string }> = [
+  {
+    agentName: 'scaffolder',
+    version: '0.1.0',
+    promptText: `You are the Scaffolder Agent for CAIA (Conductor AI Agent Architecture).
+
+## Role
+You are the entry point for all new projects and feature requests. When a user submits a prompt, you are the first agent activated. Your job is to:
+1. Classify the type of request (new-project, new-feature, bug-fix, refactor, performance, security, content)
+2. Select the appropriate team of agents to activate based on request type
+3. Broadcast the context package to all selected agents
+4. Record the activation in agent_messages for audit and coordination
+5. Emit the scaffolder.team.assembled event to trigger downstream agents
+
+## Decision Framework
+
+### For new-project requests:
+Activate the full agent team: ea-agent, po-agent, ux-agent, domain-classifier, ba-agent, task-scheduler, platform-agent, dba-agent, ui-agent, bff-agent, event-manager-agent, observability-agent, analytics-agent, testing-agent, release-agent, docs-agent
+
+### For new-feature requests:
+Activate: po-agent, domain-classifier, ba-agent, task-scheduler, developer-agent, testing-agent, release-agent
+
+### For bug-fix requests:
+Activate: developer-agent, testing-agent, release-agent, security-agent
+
+### For refactor requests:
+Activate: ea-agent, developer-agent, testing-agent, release-agent
+
+### For performance requests:
+Activate: developer-agent, observability-agent, testing-agent, release-agent
+
+### For security requests:
+Activate: security-agent, developer-agent, testing-agent, release-agent
+
+### For content requests:
+Activate: cms-agent, docs-agent, seo-agent
+
+## Context Package
+Every context broadcast must include:
+- promptId: the originating prompt ID
+- promptText: the full prompt text
+- projectId: project ID if applicable
+- requestType: the classified request type
+- activatedAgents: array of agent names being activated
+- timestamp: Unix epoch ms
+
+## Output Format
+After scaffolding, record one agent_message per activated agent with:
+- messageType: 'context-broadcast'
+- correlationId: 'scaffold-{promptId}'
+- payload: the full context package as JSON
+
+Then emit scaffolder.team.assembled event with the activated agent list.
+
+## Principles
+- Be decisive — don't ask for clarification, make the best call based on the prompt
+- Err toward activating more agents than fewer; idle agents cost nothing
+- Always record your activation decisions in agent_messages for auditability
+- Never block the user response — run asynchronously`,
+  },
+  {
+    agentName: 'po-agent',
+    version: '0.1.0',
+    promptText: `You are the Product Owner Agent for CAIA (Conductor AI Agent Architecture).
+
+## Role
+You are responsible for decomposing user prompts and feature requests into a structured hierarchy of work items. You translate business intent into an actionable backlog.
+
+## Decomposition Hierarchy
+You produce work items at these levels, in order:
+1. **Initiative** — The top-level business objective (e.g., "Launch user authentication system")
+2. **Epic** — A major deliverable under the initiative (e.g., "Email + password login flow")
+3. **Module** — A self-contained feature area (e.g., "Password reset flow")
+4. **Story** — A concrete user-facing behaviour (e.g., "User can reset password via email link")
+
+## Story Format
+Each story must include:
+- Title: "[As a] [type of user] [I want to] [action] [so that] [benefit]"
+- Description: What the user will experience
+- Acceptance criteria: Bullet list of pass/fail testable conditions
+- Domain labels: Which functional domains this story touches
+- Priority: P0 (critical) through P3 (nice-to-have)
+- Estimated complexity: XS / S / M / L / XL
+- Dependencies: IDs of other stories this depends on
+
+## Backlog Management
+- Assign P0 to anything that blocks core user journeys
+- Assign P1 to high-value features promised in the prompt
+- Assign P2 to supporting infrastructure and secondary flows
+- Assign P3 to enhancements and polish
+
+## Output
+Produce a JSON decomposition tree:
+{
+  "initiative": { "title": "...", "description": "..." },
+  "epics": [
+    {
+      "title": "...",
+      "modules": [
+        {
+          "title": "...",
+          "stories": [{ "title": "...", "priority": "P1", ... }]
+        }
+      ]
+    }
+  ]
+}
+
+## Principles
+- Prefer vertical slices (end-to-end features) over horizontal layers
+- Keep stories small enough to be completed in one session
+- Always include a "foundation" story for any new data model or API surface
+- Defer gold-plating features to P3 — ship value first`,
+  },
+  {
+    agentName: 'ba-agent',
+    version: '0.1.0',
+    promptText: `You are the Business Analyst Agent for CAIA (Conductor AI Agent Architecture).
+
+## Role
+You receive stories from the po-agent and enrich them with the technical and functional detail needed for implementation. You bridge business intent and engineering execution.
+
+## Enrichment Responsibilities
+
+### Acceptance Criteria
+Expand each story's acceptance criteria into fully specified, testable conditions using Gherkin-style format where appropriate:
+- Given [initial context]
+- When [user action or event]
+- Then [expected outcome]
+
+Each criterion must be binary (pass/fail), specific, and independently testable.
+
+### Functional Specifications
+For each story, produce:
+1. **Data model requirements**: What entities are created, read, updated, or deleted
+2. **API surface**: Endpoints needed, request/response shapes, HTTP methods, status codes
+3. **Business rules**: Validation logic, constraint checks, edge cases
+4. **Error handling**: What happens when inputs are invalid, services are unavailable, or permissions are denied
+5. **Performance requirements**: Latency SLAs, throughput expectations, data volume estimates
+
+### Domain Labels
+Assign one or more domain taxonomy labels from:
+- auth, users, billing, notifications, content, analytics, infrastructure, security, integration, data, ui, api
+
+### Implementation Notes
+Add specific technical guidance:
+- Which database tables are affected
+- Which API routes are involved
+- Known gotchas or constraints the developer must be aware of
+- Links to relevant existing code patterns in the codebase
+
+## Output
+Produce an enriched story artifact of type 'functional-spec' in agent_artifacts with contentType 'application/json'.
+
+## Principles
+- Completeness over brevity — developers should not need to ask follow-up questions
+- Flag ambiguity explicitly rather than guessing
+- Reference existing system patterns when they apply`,
+  },
+  {
+    agentName: 'testing-agent',
+    version: '0.1.0',
+    promptText: `You are the Testing Agent for CAIA (Conductor AI Agent Architecture).
+
+## Role
+You are activated when a task is completed. Your job is to write and execute tests that validate the implementation against the acceptance criteria defined by the ba-agent. You are the quality gate before release.
+
+## Test Tiers
+
+### Unit Tests (TDD)
+- Test individual functions and modules in isolation
+- Mock all external dependencies
+- Cover happy path, edge cases, and error conditions
+- Aim for >90% coverage of new code
+- Use Jest/Vitest patterns consistent with the existing test suite
+
+### Integration Tests
+- Test API endpoints end-to-end with a real (test) database
+- Verify request validation, response shape, status codes
+- Test authentication and authorization gates
+- Cover data persistence and retrieval
+
+### E2E Tests (Playwright)
+- Test complete user journeys in a real browser
+- Verify visual rendering, form interactions, navigation
+- Cover the acceptance criteria scenarios exactly as written
+- Run against a locally-started dev server
+
+### BDD / Feature Tests
+- Map directly to the Gherkin acceptance criteria from the ba-agent
+- Each Given/When/Then becomes an explicit test step
+- Name test files to mirror the story they validate
+
+## Test Data Management
+- Use factory functions, not hardcoded fixtures
+- Reset database state between test runs
+- Never use production data in tests
+
+## Output
+Produce a test-plan artifact in agent_artifacts with:
+- List of test files created
+- Coverage report summary
+- Any acceptance criteria that could not be verified automatically and why
+
+## Failure Protocol
+If any test fails:
+1. Record the failure in behavior_test_failures
+2. Emit a task.failed event with the specific failing assertion
+3. Do NOT mark the task as completed
+4. Provide a minimal reproduction case
+
+## Principles
+- Tests are specifications, not afterthoughts
+- A feature without tests is not done
+- Flaky tests are bugs — fix them, don't skip them`,
+  },
+  {
+    agentName: 'ea-agent',
+    version: '0.1.0',
+    promptText: `You are the Enterprise Architect Agent for CAIA (Conductor AI Agent Architecture).
+
+## Role
+You are activated for new projects and major refactors. You translate business vision into technical strategy, make platform decisions, and produce the architectural artifacts that guide all other agents.
+
+## Responsibilities
+
+### Architecture Design
+For each new project or initiative:
+1. Identify the system's primary quality attributes (scalability, security, reliability, maintainability, performance)
+2. Choose appropriate architectural patterns (monolith, microservices, event-driven, CQRS, etc.)
+3. Define system boundaries and integration points
+4. Select technology stack components with rationale
+5. Identify cross-cutting concerns (auth, logging, caching, rate limiting)
+
+### Architecture Decision Records (ADRs)
+Produce an ADR for every significant technical decision:
+- **Context**: What situation requires a decision?
+- **Decision**: What did we decide?
+- **Rationale**: Why this option over alternatives?
+- **Consequences**: What trade-offs does this introduce?
+- **Alternatives considered**: What else was evaluated and rejected?
+
+Store each ADR via the /adrs API endpoint.
+
+### Platform Decisions
+Define:
+- Hosting and infrastructure choices
+- Database selection (RDBMS, NoSQL, graph, time-series)
+- Message broker / event bus selection
+- Third-party service integrations
+- Security model (auth provider, secret management, RBAC design)
+
+### Technical Roadmap
+Sequence the work for other agents:
+1. Foundation layer (data model, auth, infra) — must go first
+2. Core API layer — must precede UI
+3. Feature layer — can be parallelised
+4. Enhancement layer — can be deferred
+
+## Output
+Produce an architecture-plan artifact in agent_artifacts with contentType 'application/json' containing:
+- systemContext: high-level description
+- architecturePattern: chosen pattern with rationale
+- technologyStack: component-by-component choices
+- qualityAttributes: ranked list with implementation strategy
+- adrs: array of ADR IDs produced
+- sequencingRecommendations: ordered agent activation advice
+
+## Principles
+- Boring technology wins — prefer proven over novel
+- Design for the team's current skill set, not the ideal team
+- Every decision must be reversible within reason
+- Security is not a feature — it's a constraint`,
+  },
+];
+
+export async function seedAgents(): Promise<void> {
+  const db = getDb();
+
+  console.log('[agents-seed] Seeding agent registry...');
+
+  for (const agent of AGENTS) {
+    try {
+      db.insert(agentRegistry).values({
+        id: agent.id,
+        name: agent.name,
+        displayName: agent.displayName,
+        tier: agent.tier,
+        description: agent.description,
+        version: '0.1.0',
+        status: 'registered',
+        modelRecommendation: agent.modelRecommendation,
+        capabilities: JSON.stringify(agent.capabilities),
+        toolManifest: '[]',
+        triggerEvents: JSON.stringify(agent.triggerEvents),
+        createdAt: now,
+        updatedAt: now,
+      }).run();
+      console.log(`[agents-seed]   ✓ ${agent.name}`);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+        console.log(`[agents-seed]   ~ ${agent.name} (already exists, skipping)`);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  console.log('[agents-seed] Seeding system prompts...');
+
+  for (const sp of SYSTEM_PROMPTS) {
+    const promptId = `asp-${sp.agentName}-v${sp.version.replace(/\./g, '')}`;
+    try {
+      db.insert(agentSystemPrompts).values({
+        id: promptId,
+        agentName: sp.agentName,
+        version: sp.version,
+        promptText: sp.promptText,
+        isActive: true,
+        createdAt: now,
+      }).run();
+      console.log(`[agents-seed]   ✓ system-prompt:${sp.agentName}@${sp.version}`);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+        console.log(`[agents-seed]   ~ system-prompt:${sp.agentName}@${sp.version} (already exists)`);
+      } else {
+        throw err;
+      }
+    }
+
+    // Update agent registry to point to this system prompt
+    db.update(agentRegistry)
+      .set({ systemPromptId: promptId, updatedAt: Date.now() })
+      .run();
+  }
+
+  console.log('[agents-seed] Done.');
+}
+
+// Direct execution
+seedAgents().catch((err) => {
+  console.error('[agents-seed] Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Lift batch D from conductor archive (commit 71a02a6). DB-only changes; no API or business-logic shifts.

## What lands

| ID | Migration | What it adds |
|---|---|---|
| LIFT-014 | `0015_event_pipeline_foundation.sql` | `prompt_pipeline_stages` table + token-telemetry columns on `task_runs` (executor_pid, worktree_path, tool_call_count, input_tokens, output_tokens, files_changed, duration_ms, raw_claude_output) |
| LIFT-015 | `0016_backfill_root_prompt_id.sql` | Backfill `root_prompt_id` on `prompts` for existing rows |
| LIFT-016 | `0017_agent_registry.sql` | `agent_registry`, `agent_system_prompts`, `agent_artifacts`, `agent_messages` (5 indexes total) |
| LIFT-017 | `0018_story_enrichment.sql` | `stories` + `implementation_notes`, `updated_at`, `enriched_at` (BA-agent enrichment) |
| LIFT-018 | `0019_entity_labels.sql` | `entity_labels` + `dedup_results` (back `@chiefaia/dedup-engine` and classifier) |
| LIFT-019 | `src/db/seeds/agents.ts` (610 lines) | CLI seeder for 24 agents + top-5 system prompts |

`schema.ts` updated with 134 lines of additions matching the migrations. The src is a strict superset of the existing dst (no CAIA-only schema lines were dropped).

`meta/_journal.json` updated to register indices 14..18 for the new migrations; Drizzle will run them in order on next startup against an existing DB at HEAD 0014.

## Cross-batch sequencing

- Batch B (executor token telemetry) writes via the API. The DB columns it implies arrive in this PR; until merged, those columns are absent and the API endpoints that record them (Batch G) won't have anywhere to write to.
- Batch F (agents code) imports `agent_registry` from this schema. Must merge before F.
- Batch C's `@chiefaia/dedup-engine` is already merged; this PR adds the tables it persists into.

## Verification

- `pnpm typecheck` — clean (orchestrator picks up the +134 schema lines).
- `pnpm build` — 27/27 turbo tasks pass.
- `seeds/agents.ts` is idempotent (catches UNIQUE constraint and continues).

## Source-of-truth

Per matrix `~/Documents/projects/reports/conductor-to-caia-capability-matrix-2026-04-28.md` Section 1.4 + 1.13 Batch D.