### PR TITLE
feat(dashboard): batch H — 5 missing pages + agents page + agents API + drift fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ out/
 *.tsbuildinfo
 
 # Test outputs
+# Ignore coverage build artifacts but allow the dashboard /coverage route
 coverage/
+!apps/dashboard/app/coverage/
 .nyc_output/
 playwright-report/
 test-results/

--- a/apps/dashboard/app/agents/page.tsx
+++ b/apps/dashboard/app/agents/page.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+/**
+ * Agent Status Panel — /agents
+ *
+ * Displays all 24 CAIA agents in a responsive grid:
+ *  - Name, tier, status badge, last activity timestamp
+ *  - Click any card to expand recent inter-agent messages
+ *  - Real-time updates via Server-Sent Events on the /events SSE stream
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface Agent {
+  id: string;
+  name: string;
+  displayName: string;
+  tier: string;
+  status: 'registered' | 'active' | 'disabled' | 'error';
+  description: string;
+  modelRecommendation: string;
+  lastHeartbeat: number | null;
+  capabilities: string[];
+  updatedAt: number;
+}
+
+interface AgentMessage {
+  id: string;
+  fromAgent: string;
+  toAgent: string;
+  messageType: string;
+  correlationId: string;
+  payload: string;
+  status: string;
+  createdAt: number;
+}
+
+interface AgentDetail extends Agent {
+  recentMessages: AgentMessage[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const STATUS_COLOR: Record<string, string> = {
+  active:     'bg-green-500',
+  registered: 'bg-blue-400',
+  error:      'bg-red-500',
+  disabled:   'bg-gray-500',
+};
+
+const TIER_LABEL: Record<string, string> = {
+  strategic:   'T1 Strategic',
+  planning:    'T2 Planning',
+  engineering: 'T3 Engineering',
+  quality:     'T4 Quality',
+  growth:      'T5 Growth',
+  maintenance: 'T6 Maintenance',
+};
+
+function timeAgo(ts: number | null): string {
+  if (!ts) return 'never';
+  const diff = Date.now() - ts;
+  if (diff < 60_000)  return `${Math.round(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  return `${Math.round(diff / 3_600_000)}h ago`;
+}
+
+// ─── Components ──────────────────────────────────────────────────────────────
+
+function AgentCard({
+  agent,
+  selected,
+  onClick,
+}: {
+  agent: Agent;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        text-left w-full rounded-xl border p-4 transition-all
+        ${selected
+          ? 'border-blue-500 bg-blue-900/20 ring-1 ring-blue-500'
+          : 'border-gray-700 bg-gray-800/60 hover:border-gray-500 hover:bg-gray-800'
+        }
+      `}
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-mono text-xs text-gray-400">{agent.name}</span>
+        <span className={`inline-block h-2 w-2 rounded-full ${STATUS_COLOR[agent.status] ?? 'bg-gray-500'}`} />
+      </div>
+
+      <p className="font-semibold text-sm text-white truncate">{agent.displayName}</p>
+
+      <div className="mt-2 flex items-center gap-2">
+        <span className="rounded bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300">
+          {TIER_LABEL[agent.tier] ?? agent.tier}
+        </span>
+        <span className="rounded bg-gray-700 px-1.5 py-0.5 text-xs text-gray-300 capitalize">
+          {agent.status}
+        </span>
+      </div>
+
+      <p className="mt-1.5 text-xs text-gray-500">
+        Active: {timeAgo(agent.lastHeartbeat)}
+      </p>
+    </button>
+  );
+}
+
+function MessageRow({ msg }: { msg: AgentMessage }) {
+  let payloadPreview = '';
+  try { payloadPreview = JSON.stringify(JSON.parse(msg.payload)).slice(0, 120); } catch { payloadPreview = msg.payload.slice(0, 120); }
+
+  return (
+    <div className="rounded bg-gray-800 px-3 py-2 text-xs">
+      <div className="flex items-center gap-2 text-gray-400 mb-0.5">
+        <span className="font-mono">{msg.fromAgent}</span>
+        <span>→</span>
+        <span className="font-mono">{msg.toAgent}</span>
+        <span className="ml-auto text-gray-600">{timeAgo(msg.createdAt)}</span>
+      </div>
+      <div className="text-gray-300 font-mono truncate">{payloadPreview}</div>
+    </div>
+  );
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export default function AgentsPage() {
+  const [agents, setAgents]       = useState<Agent[]>([]);
+  const [selected, setSelected]   = useState<AgentDetail | null>(null);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState<string | null>(null);
+  const [filter, setFilter]       = useState<string>('');
+
+  // ── Fetch agent list ───────────────────────────────────────────────────────
+  const fetchAgents = useCallback(async () => {
+    try {
+      const res  = await fetch('/api/agents');
+      const data = await res.json() as { agents?: Agent[] };
+      if (data.agents) setAgents(data.agents);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load agents');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // ── Fetch agent detail on selection ───────────────────────────────────────
+  const fetchDetail = useCallback(async (name: string) => {
+    try {
+      const res  = await fetch(`/api/agents/${name}`);
+      const data = await res.json() as AgentDetail & { recentMessages?: AgentMessage[] };
+      setSelected({ ...data, recentMessages: data.recentMessages ?? [] });
+    } catch { /* keep previous selection */ }
+  }, []);
+
+  // ── SSE real-time updates ──────────────────────────────────────────────────
+  useEffect(() => {
+    fetchAgents().catch(() => {/* ignore */});
+
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (e: MessageEvent) => {
+      try {
+        const event = JSON.parse(e.data as string) as { type: string; payload: { agentName?: string } };
+        // Refresh agent list on any agent-related event
+        if (
+          event.type.startsWith('testing-agent.') ||
+          event.type.startsWith('release-agent.')  ||
+          event.type.startsWith('ba-agent.')        ||
+          event.type.startsWith('scaffolder.')
+        ) {
+          fetchAgents().catch(() => {/* ignore */});
+          if (selected && event.payload?.agentName === selected.name) {
+            fetchDetail(selected.name).catch(() => {/* ignore */});
+          }
+        }
+      } catch { /* ignore malformed SSE */ }
+    };
+    es.onerror = () => es.close();
+
+    // Also poll every 15 s as a fallback
+    const poll = setInterval(() => { fetchAgents().catch(() => {/* ignore */}); }, 15_000);
+
+    return () => { es.close(); clearInterval(poll); };
+  }, [fetchAgents, fetchDetail, selected]);
+
+  // ── Filtering ──────────────────────────────────────────────────────────────
+  const displayed = filter
+    ? agents.filter(a =>
+        a.name.includes(filter) ||
+        a.displayName.toLowerCase().includes(filter.toLowerCase()) ||
+        a.tier.includes(filter) ||
+        a.status.includes(filter),
+      )
+    : agents;
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <div className="min-h-screen bg-gray-950 text-white p-6">
+      {/* Page header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Agent Status</h1>
+          <p className="text-sm text-gray-400 mt-0.5">
+            {agents.length} agents registered · real-time updates via SSE
+          </p>
+        </div>
+
+        <input
+          type="search"
+          placeholder="Filter by name, tier, status…"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className="rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500 w-64"
+        />
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-700 bg-red-950/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex gap-6">
+        {/* Agent grid */}
+        <div className="flex-1">
+          {loading ? (
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+              {Array.from({ length: 12 }).map((_, i) => (
+                <div key={i} className="h-28 rounded-xl border border-gray-700 bg-gray-800/40 animate-pulse" />
+              ))}
+            </div>
+          ) : displayed.length === 0 ? (
+            <p className="text-gray-500 text-sm">No agents match your filter.</p>
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+              {displayed.map(agent => (
+                <AgentCard
+                  key={agent.id}
+                  agent={agent}
+                  selected={selected?.name === agent.name}
+                  onClick={() => {
+                    if (selected?.name === agent.name) {
+                      setSelected(null);
+                    } else {
+                      fetchDetail(agent.name).catch(() => {/* ignore */});
+                    }
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Detail panel */}
+        {selected && (
+          <div className="w-80 shrink-0 rounded-xl border border-gray-700 bg-gray-900 p-4 self-start sticky top-6">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="font-semibold text-sm">{selected.displayName}</h2>
+              <button
+                onClick={() => setSelected(null)}
+                className="text-gray-500 hover:text-white text-lg leading-none"
+              >
+                ×
+              </button>
+            </div>
+
+            <p className="text-xs text-gray-400 mb-3">{selected.description}</p>
+
+            <div className="space-y-1 text-xs text-gray-400 mb-4">
+              <div><span className="text-gray-600">Tier:</span> {TIER_LABEL[selected.tier] ?? selected.tier}</div>
+              <div><span className="text-gray-600">Model:</span> {selected.modelRecommendation}</div>
+              <div><span className="text-gray-600">Status:</span> <span className="capitalize">{selected.status}</span></div>
+              <div><span className="text-gray-600">Last heartbeat:</span> {timeAgo(selected.lastHeartbeat)}</div>
+            </div>
+
+            {selected.capabilities.length > 0 && (
+              <div className="mb-4">
+                <p className="text-xs text-gray-600 mb-1">Capabilities</p>
+                <div className="flex flex-wrap gap-1">
+                  {selected.capabilities.map(cap => (
+                    <span key={cap} className="rounded bg-gray-800 px-1.5 py-0.5 text-xs text-gray-300">
+                      {cap}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <p className="text-xs text-gray-600 mb-2">Recent messages</p>
+              {selected.recentMessages.length === 0 ? (
+                <p className="text-xs text-gray-600">No messages yet.</p>
+              ) : (
+                <div className="space-y-1.5 max-h-64 overflow-y-auto">
+                  {selected.recentMessages.map(msg => (
+                    <MessageRow key={msg.id} msg={msg} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/app/api/agents/route.ts
+++ b/apps/dashboard/app/api/agents/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Dashboard API proxy: GET /api/agents
+ * Forwards to the Conductor orchestrator's agent registry endpoint.
+ */
+
+import { NextResponse } from 'next/server';
+
+const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const tier   = searchParams.get('tier')   ?? '';
+  const status = searchParams.get('status') ?? '';
+
+  const qs = new URLSearchParams();
+  if (tier)   qs.set('tier',   tier);
+  if (status) qs.set('status', status);
+
+  try {
+    const upstream = await fetch(
+      `${ORCHESTRATOR_URL}/agents${qs.size ? `?${qs.toString()}` : ''}`,
+      { next: { revalidate: 10 } },  // ISR — refresh every 10 s
+    );
+
+    if (!upstream.ok) {
+      return NextResponse.json(
+        { error: `Upstream error ${upstream.status}` },
+        { status: upstream.status },
+      );
+    }
+
+    const data = await upstream.json() as unknown;
+    return NextResponse.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/coverage/page.tsx
+++ b/apps/dashboard/app/coverage/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+const API = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:7776';
+const COVERAGE_URL = '/reports/coverage/coverage-summary.json';
+
+interface FileSummary {
+  lines: { total: number; covered: number; pct: number };
+  functions: { total: number; covered: number; pct: number };
+  branches: { total: number; covered: number; pct: number };
+  statements: { total: number; covered: number; pct: number };
+}
+
+type CoverageSummary = Record<string, FileSummary>;
+
+function pctColor(pct: number): string {
+  if (pct >= 95) return '#16a34a';
+  if (pct >= 80) return '#d97706';
+  return '#dc2626';
+}
+
+function PctBar({ pct }: { pct: number }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ width: 80, background: '#f3f4f6', height: 8, borderRadius: 4, overflow: 'hidden' }}>
+        <div style={{ width: `${pct}%`, height: '100%', background: pctColor(pct), borderRadius: 4 }} />
+      </div>
+      <span style={{ fontSize: 11, color: pctColor(pct), fontWeight: 600, minWidth: 36 }}>{pct.toFixed(1)}%</span>
+    </div>
+  );
+}
+
+export default function CoveragePage() {
+  const [summary, setSummary] = useState<CoverageSummary | null>(null);
+  const [filter, setFilter] = useState('');
+  const [sortBy, setSortBy] = useState<'file' | 'lines'>('lines');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    // Try to load from local Next.js public dir, fall back to API proxy
+    fetch(COVERAGE_URL)
+      .then(r => { if (!r.ok) throw new Error('not found'); return r.json() as Promise<CoverageSummary>; })
+      .then(d => { setSummary(d); setLoading(false); })
+      .catch(() => {
+        setError('No coverage report found. Run: npm test -- --coverage');
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return <div style={{ padding: 20, color: '#9ca3af' }}>Loading coverage report…</div>;
+
+  if (error) {
+    return (
+      <div style={{ padding: 20, fontFamily: 'system-ui' }}>
+        <h2>Coverage</h2>
+        <div style={{ background: '#fff7ed', border: '1px solid #fed7aa', borderRadius: 8, padding: 16, color: '#92400e' }}>
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  const total = summary?.['total'];
+  const files = Object.entries(summary ?? {})
+    .filter(([f]) => f !== 'total' && f.endsWith('.ts') && !f.endsWith('.d.ts'))
+    .filter(([f]) => !filter || f.toLowerCase().includes(filter.toLowerCase()))
+    .sort((a, b) => sortBy === 'file' ? a[0].localeCompare(b[0]) : a[1].lines.pct - b[1].lines.pct);
+
+  return (
+    <div style={{ padding: 20, fontFamily: 'system-ui', fontSize: 14 }}>
+      <h2 style={{ marginBottom: 4 }}>Coverage</h2>
+      <p style={{ color: '#6b7280', fontSize: 13, marginBottom: 16 }}>
+        Per-file coverage from the latest test run.
+      </p>
+
+      {total && (
+        <div style={{ display: 'flex', gap: 20, marginBottom: 20, flexWrap: 'wrap' }}>
+          {(['statements', 'branches', 'functions', 'lines'] as const).map(k => (
+            <div key={k} style={{ border: '1px solid #e5e7eb', borderRadius: 8, padding: '10px 16px', minWidth: 120 }}>
+              <div style={{ fontSize: 11, color: '#9ca3af', marginBottom: 4, textTransform: 'capitalize' }}>{k}</div>
+              <PctBar pct={total[k].pct} />
+              <div style={{ fontSize: 11, color: '#9ca3af', marginTop: 2 }}>{total[k].covered}/{total[k].total}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        <input
+          placeholder="Filter files…"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          style={{ flex: 1, padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: 6, fontSize: 12 }}
+        />
+        <select
+          value={sortBy}
+          onChange={e => setSortBy(e.target.value as 'file' | 'lines')}
+          style={{ padding: '6px 10px', border: '1px solid #d1d5db', borderRadius: 6, fontSize: 12 }}
+        >
+          <option value="lines">Sort by coverage</option>
+          <option value="file">Sort by file</option>
+        </select>
+      </div>
+
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+        <thead>
+          <tr style={{ background: '#f9fafb', borderBottom: '2px solid #e5e7eb' }}>
+            <th style={{ padding: '6px 10px', textAlign: 'left' }}>File</th>
+            <th style={{ padding: '6px 10px', textAlign: 'left', width: 120 }}>Lines</th>
+            <th style={{ padding: '6px 10px', textAlign: 'left', width: 120 }}>Functions</th>
+            <th style={{ padding: '6px 10px', textAlign: 'left', width: 120 }}>Branches</th>
+          </tr>
+        </thead>
+        <tbody>
+          {files.map(([file, data]) => (
+            <tr key={file} style={{ borderBottom: '1px solid #f3f4f6', background: data.lines.pct < 80 ? '#fff5f5' : undefined }}>
+              <td style={{ padding: '5px 10px', fontFamily: 'monospace', fontSize: 11, color: '#374151', maxWidth: 400 }}>
+                {file.replace(/^.*conductor\//g, '')}
+              </td>
+              <td style={{ padding: '5px 10px' }}><PctBar pct={data.lines.pct} /></td>
+              <td style={{ padding: '5px 10px' }}><PctBar pct={data.functions.pct} /></td>
+              <td style={{ padding: '5px 10px' }}><PctBar pct={data.branches.pct} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {files.length === 0 && filter && (
+        <div style={{ textAlign: 'center', padding: 20, color: '#9ca3af' }}>No files match "{filter}"</div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/app/gates/page.tsx
+++ b/apps/dashboard/app/gates/page.tsx
@@ -1,0 +1,432 @@
+'use client';
+import { useState, useCallback, useEffect } from 'react';
+import Link from 'next/link';
+import { HumanGateModal } from '../../components/HumanGateModal';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface AgentArtifact {
+  id: string;
+  agentName: string;
+  artifactType: string;
+  promptId?: string | null;
+  requirementId?: string | null;
+  content: string;
+  contentType: string;
+  status: string;
+  createdAt: number;
+}
+
+interface ArtifactsResponse {
+  artifacts: AgentArtifact[];
+  total: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function artifactTypeToGate(
+  artifactType: string
+): 'architecture-plan' | 'backlog-review' | 'design-review' | 'testing-approval' | 'release-approval' {
+  if (artifactType.includes('architecture')) return 'architecture-plan';
+  if (artifactType.includes('backlog') || artifactType.includes('requirement')) return 'backlog-review';
+  if (artifactType.includes('design') || artifactType.includes('wireframe') || artifactType.includes('ux')) return 'design-review';
+  if (artifactType.includes('test') || artifactType.includes('qa')) return 'testing-approval';
+  if (artifactType.includes('release') || artifactType.includes('deploy')) return 'release-approval';
+  return 'architecture-plan';
+}
+
+function contentTypeToArtifactType(contentType: string): 'markdown' | 'json' | 'text' {
+  if (contentType.includes('json')) return 'json';
+  if (contentType.includes('markdown') || contentType.includes('md')) return 'markdown';
+  return 'text';
+}
+
+function gateLabel(artifactType: string): string {
+  const map: Record<string, string> = {
+    'architecture-plan': '🏗️ Architecture Plan',
+    'api-spec':          '📡 API Specification',
+    'db-schema':         '🗄️ Database Schema',
+    'wireframe':         '🎨 Wireframe / Design',
+    'test-plan':         '🧪 Test Plan',
+    'deployment-config': '🚀 Deployment Config',
+    'release-report':    '📦 Release Report',
+  };
+  return map[artifactType] ?? `📄 ${artifactType.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`;
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyGates() {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        color: '#718096',
+        padding: 48,
+      }}
+    >
+      <span style={{ fontSize: 48 }}>◈</span>
+      <div style={{ fontSize: 16, fontWeight: 600, color: '#a0aec0' }}>No pending reviews</div>
+      <div style={{ fontSize: 13, color: '#4a5568', textAlign: 'center', maxWidth: 340 }}>
+        When an AI agent produces an artifact that needs human approval before the pipeline continues, it will appear here.
+      </div>
+      <Link
+        href="/pipeline"
+        style={{
+          marginTop: 8,
+          fontSize: 13,
+          color: '#63b3ed',
+          textDecoration: 'none',
+          border: '1px solid #2d3748',
+          borderRadius: 6,
+          padding: '6px 14px',
+          background: '#1a1f2e',
+        }}
+      >
+        View Pipeline →
+      </Link>
+    </div>
+  );
+}
+
+// ─── Gate card ────────────────────────────────────────────────────────────────
+
+interface GateCardProps {
+  artifact: AgentArtifact;
+  onReview: (artifact: AgentArtifact) => void;
+}
+
+function GateCard({ artifact, onReview }: GateCardProps) {
+  const promptPreview = artifact.promptId ? `Prompt: ${artifact.promptId.slice(0, 16)}…` : null;
+  const label = gateLabel(artifact.artifactType);
+
+  return (
+    <div
+      style={{
+        background: '#1a1f2e',
+        border: '1px solid #2d3748',
+        borderLeft: '4px solid #f6ad55',
+        borderRadius: 8,
+        padding: '14px 18px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        transition: 'border-color 0.15s',
+      }}
+      onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.borderColor = '#4a5568'; }}
+      onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.borderColor = '#2d3748'; }}
+    >
+      {/* Left: info */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: '#f6ad55',
+              background: '#f6ad5522',
+              border: '1px solid #f6ad5544',
+              borderRadius: 10,
+              padding: '1px 7px',
+            }}
+          >
+            Awaiting Review
+          </span>
+          <span style={{ fontSize: 11, color: '#718096' }}>{relativeTime(artifact.createdAt)}</span>
+        </div>
+
+        <div style={{ fontSize: 15, fontWeight: 600, color: '#f0f4f8', marginBottom: 2 }}>
+          {label}
+        </div>
+
+        <div style={{ fontSize: 12, color: '#a0aec0' }}>
+          Agent: <span style={{ color: '#e2e8f0' }}>{artifact.agentName}</span>
+          {promptPreview && (
+            <span style={{ marginLeft: 12, color: '#718096' }}>{promptPreview}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Right: action */}
+      <button
+        onClick={() => onReview(artifact)}
+        style={{
+          background: '#2b4a6a',
+          color: '#90cdf4',
+          border: '1px solid #3a6f9f',
+          borderRadius: 7,
+          padding: '8px 16px',
+          fontSize: 13,
+          fontWeight: 600,
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+          transition: 'background 0.15s',
+        }}
+        onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = '#2d5a7a'; }}
+        onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = '#2b4a6a'; }}
+      >
+        Review →
+      </button>
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function GatesPage() {
+  const [artifacts, setArtifacts] = useState<AgentArtifact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<AgentArtifact | null>(null);
+  const [toast, setToast] = useState<{ text: string; color: string } | null>(null);
+
+  const showToast = useCallback((text: string, color: string) => {
+    setToast({ text, color });
+    setTimeout(() => setToast(null), 4000);
+  }, []);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agents/artifacts?status=draft');
+      if (!res.ok) throw new Error('Failed to fetch');
+      const data = await res.json() as ArtifactsResponse;
+      setArtifacts(data.artifacts ?? []);
+      setError(null);
+    } catch {
+      setError('Could not load pending gates.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const timer = setInterval(() => void load(), 15_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  const handleApprove = useCallback(async () => {
+    if (!selected) return;
+    try {
+      await fetch(`/api/agents/artifacts/${selected.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'approved' }),
+      });
+      setArtifacts(prev => prev.filter(a => a.id !== selected.id));
+      showToast('✅ Artifact approved — pipeline continues.', '#68d391');
+    } catch {
+      showToast('⚠️ Approval recorded locally.', '#f6ad55');
+      setArtifacts(prev => prev.filter(a => a.id !== selected.id));
+    }
+    setSelected(null);
+  }, [selected, showToast]);
+
+  const handleRequestChanges = useCallback(async (feedback: string) => {
+    if (!selected) return;
+    try {
+      await fetch(`/api/agents/artifacts/${selected.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'superseded', feedback }),
+      });
+      setArtifacts(prev => prev.filter(a => a.id !== selected.id));
+      showToast('↩ Feedback sent — the agent will revise its output.', '#f6ad55');
+    } catch {
+      showToast('⚠️ Feedback noted locally.', '#718096');
+      setArtifacts(prev => prev.filter(a => a.id !== selected.id));
+    }
+    setSelected(null);
+  }, [selected, showToast]);
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 0, minHeight: '100%' }}>
+        {/* Header */}
+        <div style={{ marginBottom: 24 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#f0f4f8' }}>
+              ◈ Review Gates
+            </h1>
+            {!loading && (
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 700,
+                  background: artifacts.length > 0 ? '#7b341e' : '#1a3320',
+                  color: artifacts.length > 0 ? '#fbd38d' : '#68d391',
+                  borderRadius: 10,
+                  padding: '2px 10px',
+                  border: `1px solid ${artifacts.length > 0 ? '#f6ad5544' : '#68d39144'}`,
+                }}
+              >
+                {artifacts.length > 0 ? `${artifacts.length} pending` : 'All clear'}
+              </span>
+            )}
+            <button
+              onClick={() => void load()}
+              style={{
+                marginLeft: 'auto',
+                background: '#2d3748',
+                color: '#a0aec0',
+                border: '1px solid #4a5568',
+                borderRadius: 6,
+                padding: '5px 12px',
+                fontSize: 12,
+                cursor: 'pointer',
+              }}
+            >
+              ↺ Refresh
+            </button>
+          </div>
+          <div style={{ fontSize: 13, color: '#718096', marginTop: 4 }}>
+            AI agents await your approval at these 5 mandatory pipeline gates before continuing.
+          </div>
+        </div>
+
+        {/* Gate type legend */}
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+          {(['architecture-plan', 'backlog-review', 'design-review', 'testing-approval', 'release-approval'] as const).map(g => {
+            const labels = {
+              'architecture-plan':  '🏗️ Architecture',
+              'backlog-review':     '📋 Backlog',
+              'design-review':      '🎨 Design',
+              'testing-approval':   '🧪 Testing',
+              'release-approval':   '🚀 Release',
+            };
+            return (
+              <span
+                key={g}
+                style={{
+                  fontSize: 11,
+                  color: '#718096',
+                  background: '#1a1f2e',
+                  border: '1px solid #2d3748',
+                  borderRadius: 10,
+                  padding: '3px 10px',
+                }}
+              >
+                {labels[g]}
+              </span>
+            );
+          })}
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {[1, 2, 3].map(i => (
+              <div
+                key={i}
+                style={{
+                  height: 72,
+                  background: 'linear-gradient(90deg, #1a1f2e 25%, #242b3d 50%, #1a1f2e 75%)',
+                  backgroundSize: '200% 100%',
+                  borderRadius: 8,
+                  border: '1px solid #2d3748',
+                  animation: 'shimmer 1.5s infinite',
+                }}
+              />
+            ))}
+          </div>
+        ) : error ? (
+          <div
+            style={{
+              padding: 24,
+              background: '#3d1515',
+              border: '1px solid #742a2a',
+              borderRadius: 8,
+              color: '#fc8181',
+              fontSize: 14,
+              textAlign: 'center',
+            }}
+          >
+            {error}{' '}
+            <button
+              onClick={() => void load()}
+              style={{ background: 'none', border: 'none', color: '#90cdf4', cursor: 'pointer', textDecoration: 'underline', fontSize: 13 }}
+            >
+              Retry
+            </button>
+          </div>
+        ) : artifacts.length === 0 ? (
+          <EmptyGates />
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {artifacts.map(artifact => (
+              <GateCard
+                key={artifact.id}
+                artifact={artifact}
+                onReview={setSelected}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Modal */}
+      {selected && (
+        <HumanGateModal
+          gate={artifactTypeToGate(selected.artifactType)}
+          agentName={selected.agentName}
+          artifactContent={selected.content}
+          artifactType={contentTypeToArtifactType(selected.contentType)}
+          onApprove={handleApprove}
+          onRequestChanges={handleRequestChanges}
+          onDismiss={() => setSelected(null)}
+        />
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 24,
+            right: 24,
+            zIndex: 9999,
+            background: '#1a1f2e',
+            color: toast.color,
+            border: `1px solid ${toast.color}55`,
+            borderRadius: 8,
+            padding: '12px 18px',
+            fontSize: 13,
+            fontWeight: 500,
+            boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+            animation: 'slideInToast 0.2s ease',
+          }}
+          aria-live="polite"
+        >
+          {toast.text}
+        </div>
+      )}
+
+      <style>{`
+        @keyframes shimmer {
+          0% { background-position: -200% 0; }
+          100% { background-position: 200% 0; }
+        }
+        @keyframes slideInToast {
+          from { opacity: 0; transform: translateY(8px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/apps/dashboard/app/pipeline/page.tsx
+++ b/apps/dashboard/app/pipeline/page.tsx
@@ -1,0 +1,878 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+import useSWR from 'swr';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Prompt {
+  id: string;
+  body: string;
+  receivedAt: string;
+  status: string;
+  elapsedMs?: number | null;
+}
+
+interface PromptsResponse {
+  prompts: Prompt[];
+}
+
+interface PipelineTaskRun {
+  id: string;
+  runIndex?: number;
+  durationMs?: number | null;
+  tokensIn?: number | null;
+  tokensOut?: number | null;
+  filesChanged?: number | null;
+  toolCallSummary?: Record<string, number> | null;
+  status?: string;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+}
+
+interface PipelineCompletenessCheck {
+  id: string;
+  passed: boolean;
+  criticalFindings?: number | null;
+  summary?: string | null;
+  checkedAt?: string | null;
+}
+
+interface PipelineTask {
+  id: string;
+  title: string;
+  status: string;
+  createdAt?: string | null;
+  completedAt?: string | null;
+  taskRuns?: PipelineTaskRun[];
+  completenessChecks?: PipelineCompletenessCheck[];
+}
+
+interface PipelineStory {
+  id: string;
+  title: string;
+  status?: string;
+  tasks?: PipelineTask[];
+}
+
+interface PipelineRequirement {
+  id: string;
+  title: string;
+  status: string;
+  stateHistory?: string[];
+  createdAt?: string | null;
+  stories?: PipelineStory[];
+}
+
+interface PipelineData {
+  promptId: string;
+  promptBody: string;
+  promptReceivedAt: string;
+  promptStatus: string;
+  requirements?: PipelineRequirement[];
+  totalDurationMs?: number | null;
+  totalTokensIn?: number | null;
+  totalTokensOut?: number | null;
+  totalFilesChanged?: number | null;
+  overallStatus?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const fetcher = (url: string) =>
+  fetch(url).then(async r => {
+    if (!r.ok) throw Object.assign(new Error('fetch error'), { status: r.status });
+    return r.json();
+  });
+
+function relativeTime(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+function formatDuration(ms: number | null | undefined): string {
+  if (ms == null) return '—';
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.floor((ms % 60_000) / 1_000);
+  return `${m}m ${s}s`;
+}
+
+function formatTokens(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return n.toLocaleString();
+}
+
+function promptStatusDot(status: string): { color: string; label: string } {
+  switch (status) {
+    case 'answered':
+    case 'completed':
+    case 'done':
+      return { color: '#48bb78', label: 'done' };
+    case 'analyzing':
+    case 'decomposed':
+    case 'running':
+      return { color: '#ecc94b', label: 'running' };
+    case 'failed':
+      return { color: '#f56565', label: 'failed' };
+    default:
+      return { color: '#718096', label: 'pending' };
+  }
+}
+
+function overallStatusBadge(status: string | undefined): { bg: string; text: string; emoji: string } {
+  switch ((status ?? '').toLowerCase()) {
+    case 'completed':
+    case 'done':
+    case 'answered':
+      return { bg: '#276749', text: '#9ae6b4', emoji: '✅' };
+    case 'running':
+    case 'analyzing':
+    case 'decomposed':
+      return { bg: '#2b6cb0', text: '#bee3f8', emoji: '🔄' };
+    case 'failed':
+      return { bg: '#742a2a', text: '#fed7d7', emoji: '❌' };
+    default:
+      return { bg: '#2d3748', text: '#a0aec0', emoji: '⏳' };
+  }
+}
+
+function taskStatusColor(status: string): string {
+  switch (status?.toLowerCase()) {
+    case 'completed': case 'done': return '#48bb78';
+    case 'running': return '#4299e1';
+    case 'failed': return '#f56565';
+    case 'blocked': return '#ed8936';
+    default: return '#718096';
+  }
+}
+
+function copyToClipboard(text: string) {
+  void navigator.clipboard.writeText(text).catch(() => {});
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function SkeletonRow({ width = '100%' }: { width?: string }) {
+  return (
+    <div
+      style={{
+        height: 16,
+        width,
+        background: 'linear-gradient(90deg, #2d3748 25%, #3a4a5c 50%, #2d3748 75%)',
+        backgroundSize: '200% 100%',
+        borderRadius: 4,
+        animation: 'shimmer 1.5s infinite',
+        marginBottom: 8,
+      }}
+    />
+  );
+}
+
+// ─── Pipeline Waterfall Nodes ─────────────────────────────────────────────────
+
+function NodeConnector({ label }: { label?: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', marginLeft: 20, padding: '2px 0' }}>
+      <div style={{ width: 2, height: 8, background: '#4a5568' }} />
+      {label && (
+        <span style={{ fontSize: 11, color: '#718096', fontFamily: 'monospace', padding: '1px 6px' }}>
+          ↓ {label}
+        </span>
+      )}
+      <div style={{ width: 2, height: 8, background: '#4a5568' }} />
+    </div>
+  );
+}
+
+function NodeCard({
+  borderColor,
+  children,
+}: {
+  borderColor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        background: '#2d3748',
+        border: '1px solid #4a5568',
+        borderLeft: `4px solid ${borderColor}`,
+        borderRadius: 8,
+        padding: '12px 16px',
+        marginBottom: 2,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function EntityLabel({ text, color }: { text: string; color: string }) {
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase' as const,
+        fontWeight: 700,
+        color,
+        marginBottom: 4,
+        display: 'block',
+      }}
+    >
+      {text}
+    </span>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const color = taskStatusColor(status);
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        color,
+        background: color + '22',
+        border: `1px solid ${color}55`,
+        borderRadius: 10,
+        padding: '1px 7px',
+        marginLeft: 6,
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.05em',
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+function IdChip({ id }: { id: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <span
+      title="Click to copy"
+      onClick={() => {
+        copyToClipboard(id);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+      style={{
+        fontFamily: 'monospace',
+        fontSize: 10,
+        color: copied ? '#68d391' : '#718096',
+        cursor: 'pointer',
+        marginLeft: 8,
+        background: '#1a202c',
+        padding: '1px 5px',
+        borderRadius: 3,
+      }}
+    >
+      {copied ? '✓ copied' : id.slice(0, 12)}
+    </span>
+  );
+}
+
+// ─── Task Run Card ────────────────────────────────────────────────────────────
+
+function TaskRunNode({ run, index }: { run: PipelineTaskRun; index: number }) {
+  const isDone = run.status === 'completed' || run.status === 'done';
+  const isFailed = run.status === 'failed';
+  const borderColor = isFailed ? '#f56565' : isDone ? '#48bb78' : '#ed8936';
+
+  const toolCalls = run.toolCallSummary
+    ? Object.entries(run.toolCallSummary)
+        .map(([tool, count]) => `${tool}(${count})`)
+        .join(' ')
+    : null;
+
+  return (
+    <div style={{ marginLeft: 24 }}>
+      <NodeCard borderColor={borderColor}>
+        <EntityLabel text="Task Run" color={borderColor} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' as const, marginBottom: 4 }}>
+          <span style={{ fontSize: 13, color: '#e2e8f0', fontWeight: 500 }}>
+            Run #{index + 1}
+          </span>
+          <IdChip id={run.id} />
+          {run.status && <StatusPill status={run.status} />}
+        </div>
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' as const }}>
+          {run.durationMs != null && (
+            <span style={{ fontSize: 12, color: '#a0aec0' }}>⏱ {formatDuration(run.durationMs)}</span>
+          )}
+          {(run.tokensIn != null || run.tokensOut != null) && (
+            <span style={{ fontSize: 12, color: '#a0aec0' }}>
+              🔢 {formatTokens(run.tokensIn)} in / {formatTokens(run.tokensOut)} out
+            </span>
+          )}
+          {run.filesChanged != null && run.filesChanged > 0 && (
+            <span style={{ fontSize: 12, color: '#a0aec0' }}>📁 {run.filesChanged} files</span>
+          )}
+        </div>
+        {toolCalls && (
+          <div style={{ fontSize: 11, color: '#718096', marginTop: 4, fontFamily: 'monospace' }}>
+            Tool calls: {toolCalls}
+          </div>
+        )}
+      </NodeCard>
+    </div>
+  );
+}
+
+// ─── Completeness Check Card ──────────────────────────────────────────────────
+
+function CompletenessNode({ check }: { check: PipelineCompletenessCheck }) {
+  const color = check.passed ? '#48bb78' : '#f56565';
+  return (
+    <div style={{ marginLeft: 24 }}>
+      <NodeCard borderColor={color}>
+        <EntityLabel text="Completeness Check" color={color} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' as const }}>
+          <span style={{ fontSize: 13, color, fontWeight: 600 }}>
+            {check.passed ? '✓ PASSED' : '✗ FAILED'}
+          </span>
+          <IdChip id={check.id} />
+          {check.criticalFindings != null && (
+            <span style={{ fontSize: 12, color: '#a0aec0' }}>
+              — {check.criticalFindings} critical finding{check.criticalFindings !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+        {check.summary && (
+          <div style={{ fontSize: 12, color: '#a0aec0', marginTop: 4 }}>{check.summary}</div>
+        )}
+      </NodeCard>
+    </div>
+  );
+}
+
+// ─── Task Card ────────────────────────────────────────────────────────────────
+
+function TaskNode({ task }: { task: PipelineTask }) {
+  const [expanded, setExpanded] = useState(true);
+  const color = '#38b2ac';
+
+  const runs = task.taskRuns ?? [];
+  const completeness = task.completenessChecks ?? [];
+
+  return (
+    <div style={{ marginLeft: 24 }}>
+      <NodeCard borderColor={color}>
+        <EntityLabel text="Task" color={color} />
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', flexWrap: 'wrap' as const }}
+          onClick={() => setExpanded(e => !e)}
+        >
+          <span style={{ fontSize: 12, color: '#718096' }}>{expanded ? '▾' : '▸'}</span>
+          <span style={{ fontSize: 13, color: '#e2e8f0', fontWeight: 500, flex: 1 }}>{task.title}</span>
+          <IdChip id={task.id} />
+          <StatusPill status={task.status} />
+        </div>
+      </NodeCard>
+
+      {expanded && (runs.length > 0 || completeness.length > 0) && (
+        <div>
+          {runs.map((run, i) => (
+            <div key={run.id}>
+              <NodeConnector label={i === 0 ? undefined : `re-run #${i + 1}`} />
+              <TaskRunNode run={run} index={i} />
+            </div>
+          ))}
+          {completeness.map(check => (
+            <div key={check.id}>
+              <NodeConnector />
+              <CompletenessNode check={check} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Story Card ───────────────────────────────────────────────────────────────
+
+function StoryNode({ story }: { story: PipelineStory }) {
+  const [expanded, setExpanded] = useState(true);
+  const color = '#667eea';
+  const tasks = story.tasks ?? [];
+
+  return (
+    <div style={{ marginLeft: 24 }}>
+      <NodeCard borderColor={color}>
+        <EntityLabel text="Story" color={color} />
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: tasks.length > 0 ? 'pointer' : 'default', flexWrap: 'wrap' as const }}
+          onClick={() => tasks.length > 0 && setExpanded(e => !e)}
+        >
+          {tasks.length > 0 && <span style={{ fontSize: 12, color: '#718096' }}>{expanded ? '▾' : '▸'}</span>}
+          <span style={{ fontSize: 13, color: '#e2e8f0', fontWeight: 500, flex: 1 }}>{story.title}</span>
+          <IdChip id={story.id} />
+          {story.status && <StatusPill status={story.status} />}
+        </div>
+      </NodeCard>
+
+      {expanded && tasks.length > 0 && (
+        <div>
+          {tasks.map((task, i) => (
+            <div key={task.id}>
+              {i > 0 && <NodeConnector />}
+              <TaskNode task={task} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Requirement Card ─────────────────────────────────────────────────────────
+
+function RequirementNode({ req }: { req: PipelineRequirement }) {
+  const [expanded, setExpanded] = useState(true);
+  const color = '#9f7aea';
+  const stories = req.stories ?? [];
+
+  const stateHistory = req.stateHistory ?? [];
+
+  return (
+    <div>
+      <NodeCard borderColor={color}>
+        <EntityLabel text="Requirement" color={color} />
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: stories.length > 0 ? 'pointer' : 'default', flexWrap: 'wrap' as const }}
+          onClick={() => stories.length > 0 && setExpanded(e => !e)}
+        >
+          {stories.length > 0 && <span style={{ fontSize: 12, color: '#718096' }}>{expanded ? '▾' : '▸'}</span>}
+          <span style={{ fontSize: 13, color: '#e2e8f0', fontWeight: 500, flex: 1 }}>{req.title}</span>
+          <IdChip id={req.id} />
+          <StatusPill status={req.status} />
+        </div>
+        {stateHistory.length > 0 && (
+          <div style={{ display: 'flex', gap: 4, marginTop: 6, flexWrap: 'wrap' as const }}>
+            {stateHistory.map((state, i) => (
+              <span
+                key={i}
+                style={{
+                  fontSize: 10,
+                  color: '#a0aec0',
+                  background: '#1a202c',
+                  border: '1px solid #4a5568',
+                  borderRadius: 10,
+                  padding: '1px 7px',
+                }}
+              >
+                {state}
+              </span>
+            ))}
+          </div>
+        )}
+      </NodeCard>
+
+      {expanded && stories.length > 0 && (
+        <div>
+          {stories.map((story, i) => (
+            <div key={story.id}>
+              <NodeConnector />
+              <StoryNode story={story} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Prompt Node ─────────────────────────────────────────────────────────────
+
+function PromptNode({ data }: { data: PipelineData }) {
+  const color = '#4299e1';
+  return (
+    <NodeCard borderColor={color}>
+      <EntityLabel text="Prompt" color={color} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' as const, marginBottom: 6 }}>
+        <IdChip id={data.promptId} />
+        {data.promptStatus && <StatusPill status={data.promptStatus} />}
+        <span style={{ fontSize: 11, color: '#718096', marginLeft: 'auto' }}>
+          {new Date(data.promptReceivedAt).toLocaleString()}
+        </span>
+      </div>
+      <div style={{ fontSize: 14, color: '#e2e8f0', lineHeight: 1.5 }}>
+        &ldquo;{data.promptBody}&rdquo;
+      </div>
+    </NodeCard>
+  );
+}
+
+// ─── Summary Bar ──────────────────────────────────────────────────────────────
+
+function SummaryBar({ data }: { data: PipelineData }) {
+  const badge = overallStatusBadge(data.overallStatus ?? data.promptStatus);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+        alignItems: 'center',
+        flexWrap: 'wrap' as const,
+        background: '#2d3748',
+        border: '1px solid #4a5568',
+        borderRadius: 8,
+        padding: '10px 16px',
+        marginBottom: 16,
+        fontSize: 13,
+        color: '#e2e8f0',
+      }}
+    >
+      {data.totalDurationMs != null && (
+        <span>⏱ Total: <strong>{formatDuration(data.totalDurationMs)}</strong></span>
+      )}
+      {(data.totalTokensIn != null || data.totalTokensOut != null) && (
+        <span>
+          🔢 <strong>{formatTokens(data.totalTokensIn)}</strong> in / <strong>{formatTokens(data.totalTokensOut)}</strong> out tokens
+        </span>
+      )}
+      {data.totalFilesChanged != null && data.totalFilesChanged > 0 && (
+        <span>📁 <strong>{data.totalFilesChanged}</strong> files</span>
+      )}
+      <span style={{ marginLeft: 'auto' }}>
+        Status:{' '}
+        <span
+          style={{
+            background: badge.bg,
+            color: badge.text,
+            borderRadius: 10,
+            padding: '2px 10px',
+            fontWeight: 700,
+            fontSize: 12,
+          }}
+        >
+          {badge.emoji} {(data.overallStatus ?? data.promptStatus ?? 'unknown').toUpperCase()}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+// ─── Pipeline Detail Panel ────────────────────────────────────────────────────
+
+function PipelineDetail({ promptId }: { promptId: string }) {
+  const { data, error, isLoading } = useSWR<PipelineData>(
+    `/api/prompts/${promptId}/pipeline`,
+    fetcher,
+    { refreshInterval: 5_000, shouldRetryOnError: false }
+  );
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: 24 }}>
+        <SkeletonRow width="60%" />
+        <SkeletonRow width="90%" />
+        <SkeletonRow width="40%" />
+        <SkeletonRow width="75%" />
+        <SkeletonRow width="55%" />
+      </div>
+    );
+  }
+
+  // 404 — pipeline data not yet built
+  if (error?.status === 404) {
+    return (
+      <div style={{ padding: 32, textAlign: 'center' as const, color: '#a0aec0', fontSize: 14 }}>
+        <div style={{ fontSize: 32, marginBottom: 12 }}>🔗</div>
+        Pipeline data not yet available for this prompt.
+      </div>
+    );
+  }
+
+  // 503 / network error
+  if (error) {
+    return (
+      <div style={{ padding: 32, textAlign: 'center' as const }}>
+        <div style={{ color: '#f56565', marginBottom: 12, fontSize: 14 }}>
+          Failed to load pipeline data.
+        </div>
+        <button
+          onClick={() => window.location.reload()}
+          style={{
+            background: '#2d3748',
+            color: '#e2e8f0',
+            border: '1px solid #4a5568',
+            borderRadius: 6,
+            padding: '8px 16px',
+            cursor: 'pointer',
+            fontSize: 13,
+          }}
+        >
+          ↺ Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div style={{ padding: 32, textAlign: 'center' as const, color: '#718096', fontSize: 14 }}>
+        No data returned.
+      </div>
+    );
+  }
+
+  const requirements = data.requirements ?? [];
+
+  return (
+    <div style={{ padding: '0 24px 24px' }}>
+      <SummaryBar data={data} />
+
+      {/* Waterfall */}
+      <div style={{ display: 'flex', flexDirection: 'column' as const }}>
+        <PromptNode data={data} />
+
+        {requirements.length === 0 && (
+          <div style={{ marginTop: 16, padding: 16, color: '#718096', fontSize: 13, textAlign: 'center' as const }}>
+            <NodeConnector label="pending" />
+            <div style={{ color: '#a0aec0' }}>No requirements decomposed yet.</div>
+          </div>
+        )}
+
+        {requirements.map((req, i) => (
+          <div key={req.id}>
+            <NodeConnector label={i === 0 ? undefined : undefined} />
+            <RequirementNode req={req} />
+          </div>
+        ))}
+
+        {/* Show linkage pending message if no promptId in data */}
+        {!data.promptId && (
+          <div
+            style={{
+              marginTop: 16,
+              padding: 16,
+              color: '#718096',
+              fontSize: 13,
+              background: '#2d3748',
+              borderRadius: 8,
+              border: '1px solid #4a5568',
+              textAlign: 'center' as const,
+            }}
+          >
+            Pipeline linkage pending — this prompt was processed before pipeline tracking was enabled.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Left Panel: Prompt List ──────────────────────────────────────────────────
+
+function PromptList({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const { data, isLoading } = useSWR<PromptsResponse>(
+    '/api/prompts?limit=50',
+    fetcher,
+    { refreshInterval: 10_000 }
+  );
+
+  const prompts = data?.prompts ?? [];
+
+  // Auto-select most recent on first load
+  const didAutoSelect = useRef(false);
+  useEffect(() => {
+    if (!didAutoSelect.current && prompts.length > 0 && !selectedId) {
+      didAutoSelect.current = true;
+      onSelect(prompts[0]!.id);
+    }
+  }, [prompts, selectedId, onSelect]);
+
+  if (isLoading && prompts.length === 0) {
+    return (
+      <div style={{ padding: 16 }}>
+        {[1, 2, 3, 4, 5].map(i => (
+          <div key={i} style={{ marginBottom: 8 }}>
+            <SkeletonRow width="80%" />
+            <SkeletonRow width="55%" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (prompts.length === 0) {
+    return (
+      <div style={{ padding: 24, textAlign: 'center' as const, color: '#718096', fontSize: 13 }}>
+        No prompts found.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {prompts.map(p => {
+        const { color: dotColor } = promptStatusDot(p.status);
+        const isSelected = p.id === selectedId;
+        const truncated = p.body.length > 90 ? p.body.slice(0, 90) + '…' : p.body;
+
+        return (
+          <div
+            key={p.id}
+            onClick={() => onSelect(p.id)}
+            style={{
+              padding: '10px 14px',
+              cursor: 'pointer',
+              background: isSelected ? '#3a4a5c' : 'transparent',
+              borderLeft: isSelected ? '3px solid #4299e1' : '3px solid transparent',
+              borderBottom: '1px solid #2d3748',
+              transition: 'background 0.1s',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: dotColor,
+                  flexShrink: 0,
+                }}
+                title={p.status}
+              />
+              <span style={{ fontSize: 11, color: '#718096', flex: 1, textAlign: 'right' as const }}>
+                {relativeTime(p.receivedAt)}
+              </span>
+            </div>
+            <div
+              style={{
+                fontSize: 13,
+                color: isSelected ? '#e2e8f0' : '#a0aec0',
+                lineHeight: 1.4,
+                wordBreak: 'break-word' as const,
+                marginBottom: 6,
+              }}
+            >
+              {truncated}
+            </div>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <span
+                style={{
+                  fontSize: 10,
+                  color: '#718096',
+                  background: '#1a202c',
+                  border: '1px solid #4a5568',
+                  borderRadius: 10,
+                  padding: '1px 6px',
+                }}
+              >
+                {p.status}
+              </span>
+              {p.elapsedMs != null && (
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: '#718096',
+                    background: '#1a202c',
+                    border: '1px solid #4a5568',
+                    borderRadius: 10,
+                    padding: '1px 6px',
+                  }}
+                >
+                  {formatDuration(p.elapsedMs)}
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function PipelinePage() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  return (
+    <>
+      <style>{`
+        @keyframes shimmer {
+          0% { background-position: -200% 0; }
+          100% { background-position: 200% 0; }
+        }
+      `}</style>
+
+      <div
+        style={{
+          display: 'flex',
+          height: '100%',
+          overflow: 'hidden',
+          gap: 0,
+          margin: -24, // cancel parent padding so we control it
+        }}
+      >
+        {/* Left panel */}
+        <div
+          style={{
+            width: 320,
+            flexShrink: 0,
+            borderRight: '1px solid #2d3748',
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <div
+            style={{
+              padding: '16px 14px 12px',
+              borderBottom: '1px solid #2d3748',
+              flexShrink: 0,
+            }}
+          >
+            <h1 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#f0f4f8' }}>
+              ⇢ Pipeline
+            </h1>
+            <div style={{ fontSize: 12, color: '#718096', marginTop: 4 }}>
+              Select a prompt to trace its pipeline
+            </div>
+          </div>
+
+          <PromptList selectedId={selectedId} onSelect={setSelectedId} />
+        </div>
+
+        {/* Right panel */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '24px 0 0' }}>
+          {selectedId ? (
+            <PipelineDetail key={selectedId} promptId={selectedId} />
+          ) : (
+            <div
+              style={{
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#718096',
+                fontSize: 15,
+                flexDirection: 'column',
+                gap: 8,
+              }}
+            >
+              <span style={{ fontSize: 32 }}>⇢</span>
+              <span>Select a prompt to see its full pipeline</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/app/platform-status/page.tsx
+++ b/apps/dashboard/app/platform-status/page.tsx
@@ -1,0 +1,562 @@
+'use client';
+import { useEffect, useState, useRef, useCallback } from 'react';
+import Link from 'next/link';
+import { useEventStream } from '../../hooks/useEventStream';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface PlatformStats {
+  totalPrompts: number;
+  activeTasks: number;
+  blockedTasks: number;
+  completedToday: number;
+  avgTaskDurationMs: number;
+  queueDepth: number;
+  lastUpdated: number;
+}
+
+interface TaskRun {
+  id: number;
+  sessionId: string;
+  title: string;
+  kind: string;
+  status: string;
+  projectSlug?: string;
+  startedAt: string;
+  lastActivityAt: string;
+  endedAt?: string;
+  turnCount: number;
+  subtask_progress: { done: number; total: number };
+}
+
+interface PipelineEvent {
+  id: number;
+  ts: string;
+  stage: string;
+  entityKind?: string;
+  entityId?: string;
+  promptText?: string;
+  promptId?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmt(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 3600000) return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`;
+  return `${Math.floor(ms / 3600000)}h ${Math.floor((ms % 3600000) / 60000)}m`;
+}
+
+function relativeTime(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  if (diff < 60000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  return `${Math.floor(diff / 86400000)}d ago`;
+}
+
+function useLiveTimer(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick(t => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return tick;
+}
+
+function durationSince(ts: string): string {
+  return fmt(Date.now() - new Date(ts).getTime());
+}
+
+const STAGE_COLORS: Record<string, { bg: string; color: string }> = {
+  ingested:             { bg: '#2d3748', color: '#a0aec0' },
+  requirement_created:  { bg: '#1a2744', color: '#63b3ed' },
+  story_decomposed:     { bg: '#2a1f4a', color: '#b794f4' },
+  task_queued:          { bg: '#3d2a00', color: '#f6ad55' },
+  task_running:         { bg: '#1a3350', color: '#90cdf4' },
+  task_completed:       { bg: '#1a3320', color: '#68d391' },
+  verified:             { bg: '#1a3320', color: '#68d391' },
+  failed:               { bg: '#3d1515', color: '#fc8181' },
+};
+
+const ENTITY_ICONS: Record<string, string> = {
+  prompt: '✦',
+  requirement: '📝',
+  story: '🌳',
+  task: '📋',
+  task_run: '📡',
+  completeness: '✅',
+};
+
+// ─── KPI Card ─────────────────────────────────────────────────────────────────
+
+interface KpiCardProps {
+  label: string;
+  value: string | number;
+  subtitle?: string;
+  status?: 'ok' | 'warn' | 'crit';
+}
+
+function KpiCard({ label, value, subtitle, status = 'ok' }: KpiCardProps) {
+  const borderColor = status === 'crit' ? '#fc8181' : status === 'warn' ? '#f6ad55' : '#68d391';
+  const valueColor = status === 'crit' ? '#fc8181' : status === 'warn' ? '#f6ad55' : '#f0f4f8';
+  return (
+    <div style={{
+      background: '#1a1f2e',
+      border: `1px solid #2d3748`,
+      borderTop: `3px solid ${borderColor}`,
+      borderRadius: 8,
+      padding: '16px 20px',
+      flex: 1,
+      minWidth: 120,
+    }}>
+      <div style={{ fontSize: 28, fontWeight: 700, color: valueColor, lineHeight: 1 }}>{value}</div>
+      <div style={{ fontSize: 12, color: '#718096', marginTop: 6 }}>{label}</div>
+      {subtitle && <div style={{ fontSize: 11, color: '#4a5568', marginTop: 2 }}>{subtitle}</div>}
+    </div>
+  );
+}
+
+// ─── Pipeline Activity Feed ────────────────────────────────────────────────────
+
+function PipelineActivityFeed({ events }: { events: PipelineEvent[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    if (!paused && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [events, paused]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+        <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: '#f0f4f8' }}>⚡ Live Pipeline Activity</h2>
+        <span style={{ fontSize: 11, color: '#718096', marginLeft: 'auto' }}>
+          {paused ? '⏸ paused' : `${events.length} events`}
+        </span>
+      </div>
+      <div
+        ref={scrollRef}
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 3,
+          padding: '4px 0',
+        }}
+        aria-label="Pipeline activity feed"
+        aria-live="polite"
+      >
+        {events.length === 0 && (
+          <div style={{ color: '#4a5568', fontSize: 13, padding: '20px 0', textAlign: 'center' }}>
+            Waiting for pipeline events…
+          </div>
+        )}
+        {events.map(ev => {
+          const stageCfg = STAGE_COLORS[ev.stage] ?? { bg: '#2d3748', color: '#a0aec0' };
+          const entityIcon = ev.entityKind ? (ENTITY_ICONS[ev.entityKind] ?? '○') : '○';
+          return (
+            <div key={ev.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '5px 8px', borderRadius: 4, background: '#111520' }}>
+              <span style={{ fontSize: 10, color: '#4a5568', whiteSpace: 'nowrap', flexShrink: 0, fontFamily: 'monospace', marginTop: 1 }}>
+                {new Date(ev.ts).toLocaleTimeString()}
+              </span>
+              <span
+                style={{
+                  background: stageCfg.bg,
+                  color: stageCfg.color,
+                  fontSize: 9,
+                  padding: '1px 5px',
+                  borderRadius: 8,
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
+                  fontWeight: 600,
+                  marginTop: 1,
+                }}
+              >
+                {ev.stage.replace(/_/g, ' ')}
+              </span>
+              <span style={{ fontSize: 12, color: '#718096', flexShrink: 0 }}>{entityIcon}</span>
+              {ev.entityId && (
+                <span style={{ fontSize: 10, color: '#4a5568', fontFamily: 'monospace', flexShrink: 0, whiteSpace: 'nowrap' }}>
+                  {ev.entityId.slice(0, 12)}
+                </span>
+              )}
+              {ev.promptText && (
+                <span style={{ fontSize: 11, color: '#a0aec0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                  {ev.promptText.slice(0, 60)}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Task Bucket Distribution ─────────────────────────────────────────────────
+
+interface TaskBucketProps {
+  tasks: Array<{ id: string; title: string; status: string; dependsOn: string[] | string; createdAt: string }>;
+}
+
+function isSeq(t: { dependsOn: string[] | string }): boolean {
+  const d = t.dependsOn;
+  if (Array.isArray(d)) return d.length > 0;
+  if (typeof d === 'string') { try { return (JSON.parse(d) as unknown[]).length > 0; } catch { return false; } }
+  return false;
+}
+
+const STATUS_DOT: Record<string, string> = {
+  queued: '○', running: '▶', done: '✓', failed: '✗', blocked: '!', cancelled: '−',
+};
+const STATUS_DOT_COLOR: Record<string, string> = {
+  queued: '#718096', running: '#63b3ed', done: '#68d391', failed: '#fc8181', blocked: '#f6ad55', cancelled: '#718096',
+};
+
+function TaskBucketPanel({ tasks }: TaskBucketProps) {
+  const sequential = tasks.filter(isSeq);
+  const parallel = tasks.filter(t => !isSeq(t));
+
+  function TaskMini({ t }: { t: typeof tasks[0] }) {
+    return (
+      <Link href={`/tasks/${t.id}`} style={{ textDecoration: 'none' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 6px', borderRadius: 4, background: '#111520' }}>
+          <span style={{ fontSize: 12, color: STATUS_DOT_COLOR[t.status] ?? '#718096', flexShrink: 0 }}>
+            {STATUS_DOT[t.status] ?? '○'}
+          </span>
+          <span style={{ fontSize: 12, color: '#d1d5db', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+            {t.title.slice(0, 44)}
+          </span>
+          <span style={{ fontSize: 10, color: '#4a5568', whiteSpace: 'nowrap', flexShrink: 0 }}>
+            {relativeTime(t.createdAt)}
+          </span>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: '#f0f4f8' }}>📦 Task Buckets</h2>
+
+      {/* Sequential */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+          <span style={{ fontSize: 14 }}>🔗</span>
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#63b3ed' }}>Sequential</span>
+          <span style={{ fontSize: 11, background: '#1a2744', color: '#63b3ed', borderRadius: 10, padding: '1px 7px' }}>
+            {sequential.length}
+          </span>
+          <Link href="/tasks?bucket=sequential" style={{ fontSize: 11, color: '#4a5568', marginLeft: 'auto', textDecoration: 'none' }}>
+            See all →
+          </Link>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {sequential.slice(0, 5).map(t => <TaskMini key={t.id} t={t} />)}
+          {sequential.length === 0 && <div style={{ fontSize: 12, color: '#4a5568', padding: '4px 6px' }}>No sequential tasks</div>}
+        </div>
+      </div>
+
+      {/* Parallel */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+          <span style={{ fontSize: 14 }}>⚡</span>
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#68d391' }}>Parallel</span>
+          <span style={{ fontSize: 11, background: '#1a3320', color: '#68d391', borderRadius: 10, padding: '1px 7px' }}>
+            {parallel.length}
+          </span>
+          <Link href="/tasks?bucket=parallel" style={{ fontSize: 11, color: '#4a5568', marginLeft: 'auto', textDecoration: 'none' }}>
+            See all →
+          </Link>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {parallel.slice(0, 5).map(t => <TaskMini key={t.id} t={t} />)}
+          {parallel.length === 0 && <div style={{ fontSize: 12, color: '#4a5568', padding: '4px 6px' }}>No parallel tasks</div>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Active Task Runs Table ────────────────────────────────────────────────────
+
+function ActiveTaskRunsTable({ runs, tick }: { runs: TaskRun[]; tick: number }) {
+  void tick; // used to force re-render every second
+  return (
+    <div>
+      <h2 style={{ margin: '0 0 12px', fontSize: 15, fontWeight: 700, color: '#f0f4f8' }}>
+        ▶ Active Task Runs
+        {runs.length > 0 && (
+          <span style={{ fontSize: 12, background: '#1a3350', color: '#90cdf4', borderRadius: 10, padding: '1px 8px', marginLeft: 10, fontWeight: 400 }}>
+            {runs.length} running
+          </span>
+        )}
+      </h2>
+      {runs.length === 0 ? (
+        <div style={{ color: '#4a5568', padding: '24px 0', textAlign: 'center', fontSize: 14 }}>
+          No tasks currently running — queue is idle
+        </div>
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid #2d3748' }}>
+                {['Task', 'Stage', 'Duration', 'Turns', 'Progress', ''].map(h => (
+                  <th key={h} style={{ padding: '6px 10px', textAlign: 'left', color: '#718096', fontWeight: 500, fontSize: 11, whiteSpace: 'nowrap' }}>
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map(run => {
+                const duration = durationSince(run.startedAt);
+                const prog = run.subtask_progress;
+                const pct = prog.total > 0 ? Math.round((prog.done / prog.total) * 100) : 0;
+
+                return (
+                  <tr
+                    key={run.sessionId}
+                    style={{
+                      borderBottom: '1px solid #1a1f2e',
+                      animation: 'pulse-running 2s infinite',
+                    }}
+                  >
+                    <td style={{ padding: '8px 10px', maxWidth: 280 }}>
+                      <Link href={`/task-runs/${run.sessionId}`} style={{ color: '#f0f4f8', textDecoration: 'none' }}>
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'block' }}>
+                          {run.title}
+                        </span>
+                      </Link>
+                    </td>
+                    <td style={{ padding: '8px 10px', whiteSpace: 'nowrap' }}>
+                      <span style={{ background: '#1a3350', color: '#90cdf4', fontSize: 10, padding: '2px 6px', borderRadius: 8 }}>
+                        executing
+                      </span>
+                    </td>
+                    <td style={{ padding: '8px 10px', color: '#63b3ed', fontFamily: 'monospace', whiteSpace: 'nowrap' }}>
+                      {duration}
+                    </td>
+                    <td style={{ padding: '8px 10px', color: '#718096', whiteSpace: 'nowrap' }}>
+                      {run.turnCount}
+                    </td>
+                    <td style={{ padding: '8px 10px' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <div style={{ width: 60, height: 5, background: '#2d3748', borderRadius: 3, overflow: 'hidden', flexShrink: 0 }}>
+                          <div style={{ width: `${pct}%`, height: '100%', background: '#63b3ed' }} />
+                        </div>
+                        {prog.total > 0 && (
+                          <span style={{ fontSize: 10, color: '#718096', whiteSpace: 'nowrap' }}>
+                            {prog.done}/{prog.total}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td style={{ padding: '8px 10px' }}>
+                      <Link href={`/task-runs/${run.sessionId}`} style={{ fontSize: 11, color: '#63b3ed', textDecoration: 'none' }}>
+                        View →
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Page ─────────────────────────────────────────────────────────────────
+
+export default function PlatformStatusPage() {
+  const { lastEvent, connected } = useEventStream();
+  const tick = useLiveTimer();
+
+  const [stats, setStats] = useState<PlatformStats>({
+    totalPrompts: 0, activeTasks: 0, blockedTasks: 0,
+    completedToday: 0, avgTaskDurationMs: 0, queueDepth: 0, lastUpdated: 0,
+  });
+  const [activeRuns, setActiveRuns] = useState<TaskRun[]>([]);
+  const [allTasks, setAllTasks] = useState<Array<{ id: string; title: string; status: string; dependsOn: string[] | string; createdAt: string }>>([]);
+  const [pipelineEvents, setPipelineEvents] = useState<PipelineEvent[]>([]);
+  const eventIdRef = useRef(0);
+
+  // Fetch stats (every 30s)
+  const loadStats = useCallback(async () => {
+    try {
+      const res = await fetch('/api/platform-stats');
+      if (res.ok) setStats(await res.json() as PlatformStats);
+    } catch { /* ignore */ }
+  }, []);
+
+  // Fetch active runs (every 10s)
+  const loadActiveRuns = useCallback(async () => {
+    try {
+      const res = await fetch('/api/task-runs/active');
+      if (res.ok) {
+        const data = await res.json() as TaskRun[];
+        setActiveRuns(Array.isArray(data) ? data : []);
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  // Fetch all tasks for bucket view (every 10s)
+  const loadTasks = useCallback(async () => {
+    try {
+      const res = await fetch('/api/tasks');
+      if (res.ok) {
+        const data = await res.json() as Array<{ id: string; title: string; status: string; dependsOn: string[] | string; createdAt: string }>;
+        setAllTasks(Array.isArray(data) ? data : []);
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => {
+    void loadStats();
+    void loadActiveRuns();
+    void loadTasks();
+    const statsTimer = setInterval(() => void loadStats(), 30000);
+    const runsTimer = setInterval(() => { void loadActiveRuns(); void loadTasks(); }, 10000);
+    return () => { clearInterval(statsTimer); clearInterval(runsTimer); };
+  }, [loadStats, loadActiveRuns, loadTasks]);
+
+  // Collect pipeline events from WS
+  useEffect(() => {
+    if (!lastEvent) return;
+    if (lastEvent.kind === 'pipeline.stage.advanced') {
+      const payload = lastEvent.payload as Record<string, unknown> | undefined;
+      const ev: PipelineEvent = {
+        id: ++eventIdRef.current,
+        ts: lastEvent.ts ?? new Date().toISOString(),
+        stage: (payload?.['stage'] as string | undefined) ?? 'unknown',
+        entityKind: payload?.['entityKind'] as string | undefined,
+        entityId: payload?.['entityId'] as string | undefined,
+        promptText: payload?.['promptText'] as string | undefined,
+        promptId: payload?.['promptId'] as string | undefined,
+      };
+      setPipelineEvents(prev => [...prev.slice(-49), ev]);
+    }
+
+    // Update active runs on task_run events
+    if (lastEvent.kind.startsWith('task_run.')) {
+      const payload = lastEvent.payload as TaskRun | undefined;
+      if (payload?.sessionId) {
+        setActiveRuns(prev => {
+          if (payload.status === 'running') {
+            const idx = prev.findIndex(r => r.sessionId === payload.sessionId);
+            if (idx >= 0) {
+              const next = [...prev];
+              next[idx] = { ...prev[idx], ...payload };
+              return next;
+            }
+            return [payload, ...prev];
+          }
+          // Remove non-running
+          return prev.filter(r => r.sessionId !== payload.sessionId);
+        });
+      }
+    }
+
+    // Update stats on relevant events
+    if (lastEvent.kind.startsWith('task.') || lastEvent.kind.startsWith('prompt.')) {
+      void loadStats();
+    }
+  }, [lastEvent, loadStats]);
+
+  const kpiStatus = (val: number, warnAt: number, critAt: number): 'ok' | 'warn' | 'crit' =>
+    val >= critAt ? 'crit' : val >= warnAt ? 'warn' : 'ok';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20, minHeight: '100%' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#f0f4f8' }}>⬡ Platform Status</h1>
+        <span style={{ fontSize: 12, color: connected ? '#68d391' : '#fc8181' }}>
+          {connected ? '● live' : '○ reconnecting…'}
+        </span>
+        {stats.lastUpdated > 0 && (
+          <span style={{ fontSize: 11, color: '#4a5568', marginLeft: 'auto' }}>
+            Updated {relativeTime(new Date(stats.lastUpdated).toISOString())}
+          </span>
+        )}
+      </div>
+
+      {/* KPI Cards row */}
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        <KpiCard label="Total Prompts" value={stats.totalPrompts} />
+        <KpiCard
+          label="Active Tasks"
+          value={stats.activeTasks}
+          status={kpiStatus(stats.activeTasks, 10, 20)}
+        />
+        <KpiCard
+          label="Blocked Tasks"
+          value={stats.blockedTasks}
+          status={kpiStatus(stats.blockedTasks, 3, 8)}
+        />
+        <KpiCard
+          label="Done Today"
+          value={stats.completedToday}
+          status={stats.completedToday > 0 ? 'ok' : 'warn'}
+        />
+        <KpiCard
+          label="Avg Task Duration"
+          value={stats.avgTaskDurationMs > 0 ? fmt(stats.avgTaskDurationMs) : '—'}
+        />
+        <KpiCard
+          label="Queue Depth"
+          value={stats.queueDepth}
+          status={kpiStatus(stats.queueDepth, 20, 50)}
+        />
+      </div>
+
+      {/* Middle row: pipeline feed + bucket distribution */}
+      <div style={{ display: 'flex', gap: 16, minHeight: 320 }}>
+        {/* Pipeline Activity (60%) */}
+        <div style={{
+          flex: '0 0 60%',
+          background: '#1a1f2e',
+          border: '1px solid #2d3748',
+          borderRadius: 8,
+          padding: '16px',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}>
+          <PipelineActivityFeed events={pipelineEvents} />
+        </div>
+
+        {/* Bucket Distribution (40%) */}
+        <div style={{
+          flex: '0 0 calc(40% - 16px)',
+          background: '#1a1f2e',
+          border: '1px solid #2d3748',
+          borderRadius: 8,
+          padding: '16px',
+          overflowY: 'auto',
+        }}>
+          <TaskBucketPanel tasks={allTasks} />
+        </div>
+      </div>
+
+      {/* Bottom row: active task runs */}
+      <div style={{
+        background: '#1a1f2e',
+        border: '1px solid #2d3748',
+        borderRadius: 8,
+        padding: '16px',
+      }}>
+        <ActiveTaskRunsTable runs={activeRuns} tick={tick} />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/app/submit/page.tsx
+++ b/apps/dashboard/app/submit/page.tsx
@@ -1,0 +1,876 @@
+'use client';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Project {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  color?: string | null;
+  icon?: string | null;
+}
+
+interface SubmitResponse {
+  prompt_id?: string;
+  correlation_id?: string;
+  error?: string;
+}
+
+// ─── Inline classifier ────────────────────────────────────────────────────────
+// Lightweight client-side classification — no network call needed.
+
+const REQUEST_TYPES = [
+  {
+    id: 'new-project',
+    label: 'New Project',
+    emoji: '🟦',
+    color: '#63b3ed',
+    bg: '#1a2744',
+    keywords: ['new project', 'create project', 'start project', 'build a new', 'from scratch', 'greenfield'],
+  },
+  {
+    id: 'new-feature',
+    label: 'New Feature',
+    emoji: '🟦',
+    color: '#9f7aea',
+    bg: '#2d1f4a',
+    keywords: ['add', 'implement', 'feature', 'create', 'build', 'integrate', 'support', 'allow', 'enable'],
+  },
+  {
+    id: 'bug-fix',
+    label: 'Bug Fix',
+    emoji: '🔴',
+    color: '#fc8181',
+    bg: '#3d1515',
+    keywords: ['fix', 'bug', 'broken', 'issue', 'error', 'not working', 'failing', 'wrong', 'incorrect', 'crash', 'regression'],
+  },
+  {
+    id: 'refactor',
+    label: 'Refactor',
+    emoji: '🔵',
+    color: '#68d391',
+    bg: '#1a3320',
+    keywords: ['refactor', 'restructure', 'clean up', 'rewrite', 'reorganize', 'simplify', 'extract', 'move'],
+  },
+  {
+    id: 'performance',
+    label: 'Performance',
+    emoji: '⚡',
+    color: '#f6ad55',
+    bg: '#3d2a00',
+    keywords: ['performance', 'speed', 'optimize', 'slow', 'faster', 'latency', 'throughput', 'cache', 'efficient'],
+  },
+  {
+    id: 'security',
+    label: 'Security',
+    emoji: '🔒',
+    color: '#fc8181',
+    bg: '#3d1515',
+    keywords: ['security', 'auth', 'permission', 'vulnerability', 'exploit', 'xss', 'csrf', 'injection', 'encrypt', 'token'],
+  },
+  {
+    id: 'content',
+    label: 'Content / Docs',
+    emoji: '📝',
+    color: '#a0aec0',
+    bg: '#2d3748',
+    keywords: ['documentation', 'docs', 'content', 'copy', 'text', 'readme', 'changelog', 'write'],
+  },
+] as const;
+
+const DOMAIN_PATTERNS: Array<{ name: string; keywords: string[] }> = [
+  { name: 'Authentication & Authorization',  keywords: ['auth', 'login', 'oauth', 'jwt', 'session', 'permission', 'role', 'user', 'sign in', 'sign up'] },
+  { name: 'Data & Storage',                  keywords: ['database', 'db', 'schema', 'sql', 'migration', 'storage', 'redis', 'cache', 'file', 'upload', 's3'] },
+  { name: 'API & Integrations',              keywords: ['api', 'endpoint', 'rest', 'graphql', 'webhook', 'integration', 'third-party', 'fetch', 'request'] },
+  { name: 'UI & Frontend',                   keywords: ['ui', 'frontend', 'component', 'page', 'design', 'css', 'style', 'layout', 'react', 'modal', 'form', 'button'] },
+  { name: 'DevOps & Infrastructure',         keywords: ['deploy', 'ci', 'cd', 'docker', 'kubernetes', 'cloud', 'server', 'infra', 'pipeline', 'build', 'scale'] },
+  { name: 'Testing & Quality',               keywords: ['test', 'testing', 'coverage', 'unit test', 'e2e', 'playwright', 'jest', 'quality', 'qa'] },
+  { name: 'Performance & Optimization',      keywords: ['performance', 'speed', 'optimize', 'cache', 'slow', 'latency', 'profil'] },
+  { name: 'Security',                        keywords: ['security', 'vulnerability', 'encrypt', 'xss', 'injection', 'audit'] },
+  { name: 'Analytics & Reporting',           keywords: ['analytics', 'metrics', 'report', 'dashboard', 'chart', 'track', 'event', 'insight'] },
+];
+
+function classifyText(text: string): {
+  requestType: typeof REQUEST_TYPES[number] | null;
+  domain: string | null;
+} {
+  if (text.length < 8) return { requestType: null, domain: null };
+
+  const lower = text.toLowerCase();
+
+  // Detect request type (score-based)
+  let bestType: typeof REQUEST_TYPES[number] = REQUEST_TYPES[1]; // default: new-feature
+  let bestScore = 0;
+  for (const type of REQUEST_TYPES) {
+    const score = type.keywords.filter(k => lower.includes(k)).length;
+    if (score > bestScore) { bestScore = score; bestType = type; }
+  }
+  const requestType = bestScore > 0 ? bestType : REQUEST_TYPES[1];
+
+  // Detect domain
+  let bestDomain: string | null = null;
+  let bestDomainScore = 0;
+  for (const d of DOMAIN_PATTERNS) {
+    const score = d.keywords.filter(k => lower.includes(k)).length;
+    if (score > bestDomainScore) { bestDomainScore = score; bestDomain = d.name; }
+  }
+
+  return { requestType, domain: bestDomainScore > 0 ? bestDomain : null };
+}
+
+// ─── Agent team tiers ─────────────────────────────────────────────────────────
+
+interface AgentTier {
+  tier: string;
+  agents: Array<{ name: string; abbr: string; color: string }>;
+}
+
+const AGENT_TIERS: AgentTier[] = [
+  {
+    tier: 'Strategic',
+    agents: [
+      { name: 'Enterprise Architect', abbr: 'EA', color: '#63b3ed' },
+      { name: 'Product Owner', abbr: 'PO', color: '#9f7aea' },
+    ],
+  },
+  {
+    tier: 'Planning',
+    agents: [
+      { name: 'Business Analyst', abbr: 'BA', color: '#f6ad55' },
+      { name: 'UX Researcher', abbr: 'UX', color: '#fc8181' },
+      { name: 'Sprint Scheduler', abbr: 'SS', color: '#68d391' },
+    ],
+  },
+  {
+    tier: 'Engineering',
+    agents: [
+      { name: 'Lead Developer', abbr: 'LD', color: '#4299e1' },
+      { name: 'Backend Engineer', abbr: 'BE', color: '#38b2ac' },
+      { name: 'Frontend Engineer', abbr: 'FE', color: '#667eea' },
+    ],
+  },
+  {
+    tier: 'Quality',
+    agents: [
+      { name: 'QA Engineer', abbr: 'QA', color: '#48bb78' },
+      { name: 'Security Reviewer', abbr: 'SR', color: '#fc8181' },
+    ],
+  },
+];
+
+function getActiveAgents(requestType: string | null): Set<string> {
+  const active = new Set<string>(['EA', 'PO']); // always active
+
+  if (!requestType || requestType === 'content') return active;
+
+  if (requestType === 'new-project') {
+    return new Set(['EA', 'PO', 'BA', 'UX', 'SS', 'LD', 'BE', 'FE', 'QA', 'SR']);
+  }
+  if (requestType === 'new-feature') {
+    return new Set(['EA', 'PO', 'BA', 'UX', 'SS', 'LD', 'BE', 'FE', 'QA']);
+  }
+  if (requestType === 'bug-fix') {
+    return new Set(['EA', 'PO', 'BE', 'FE', 'QA']);
+  }
+  if (requestType === 'refactor') {
+    return new Set(['EA', 'PO', 'BA', 'LD', 'BE', 'FE', 'QA']);
+  }
+  if (requestType === 'performance') {
+    return new Set(['EA', 'PO', 'LD', 'BE', 'QA']);
+  }
+  if (requestType === 'security') {
+    return new Set(['EA', 'PO', 'LD', 'BE', 'QA', 'SR']);
+  }
+
+  return active;
+}
+
+// ─── Progress panel ───────────────────────────────────────────────────────────
+
+const AGENT_STEPS = [
+  { delay: 0,    label: '🔵 Scaffolder',         msg: 'assembling your AI team...' },
+  { delay: 1200, label: '🟣 PO Agent',            msg: 'decomposing requirements...' },
+  { delay: 2500, label: '🟡 Business Analyst',    msg: 'mapping acceptance criteria...' },
+  { delay: 3800, label: '🏗️ Enterprise Architect', msg: 'designing system architecture...' },
+  { delay: 5200, label: '📋 Sprint Scheduler',    msg: 'planning story & task breakdown...' },
+];
+
+function ProgressPanel({ promptId }: { promptId: string }) {
+  const router = useRouter();
+  const [visibleSteps, setVisibleSteps] = useState<number[]>([]);
+  const [showLink, setShowLink] = useState(false);
+
+  useEffect(() => {
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    AGENT_STEPS.forEach((step, i) => {
+      timers.push(setTimeout(() => {
+        setVisibleSteps(prev => [...prev, i]);
+      }, step.delay));
+    });
+
+    timers.push(setTimeout(() => setShowLink(true), 3000));
+
+    // Auto-redirect after 5s
+    const redirectTimer = setTimeout(() => {
+      router.push(`/pipeline?promptId=${promptId}`);
+    }, 5000);
+
+    return () => {
+      timers.forEach(clearTimeout);
+      clearTimeout(redirectTimer);
+    };
+  }, [promptId, router]);
+
+  return (
+    <div
+      style={{
+        marginTop: 24,
+        background: '#1a1f2e',
+        border: '1px solid #2d3748',
+        borderLeft: '4px solid #68d391',
+        borderRadius: 10,
+        padding: '18px 20px',
+        animation: 'fadeSlideIn 0.3s ease',
+      }}
+    >
+      <div style={{ fontSize: 14, fontWeight: 700, color: '#68d391', marginBottom: 14 }}>
+        ✅ Submitted — Your AI team is assembling
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {AGENT_STEPS.map((step, i) => (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              opacity: visibleSteps.includes(i) ? 1 : 0.25,
+              transition: 'opacity 0.4s ease',
+              fontSize: 13,
+              color: '#e2e8f0',
+            }}
+          >
+            <span style={{ fontWeight: 600, minWidth: 160 }}>{step.label}</span>
+            <span style={{ color: '#718096' }}>— {step.msg}</span>
+            {visibleSteps.includes(i) && (
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: '#68d391',
+                  flexShrink: 0,
+                  animation: 'pulseGreen 1.5s infinite',
+                }}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {showLink && (
+        <div style={{ marginTop: 16, borderTop: '1px solid #2d3748', paddingTop: 14 }}>
+          <Link
+            href={`/pipeline?promptId=${promptId}`}
+            style={{
+              color: '#90cdf4',
+              textDecoration: 'none',
+              fontSize: 13,
+              fontWeight: 600,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            View full pipeline →
+          </Link>
+          <span style={{ fontSize: 12, color: '#4a5568', marginLeft: 12 }}>
+            (auto-redirecting in a moment…)
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Priority slider ──────────────────────────────────────────────────────────
+
+const PRIORITIES = ['low', 'normal', 'high', 'critical'] as const;
+type Priority = typeof PRIORITIES[number];
+
+const PRIORITY_STYLE: Record<Priority, { color: string; label: string }> = {
+  low:      { color: '#718096', label: '🔵 Low' },
+  normal:   { color: '#63b3ed', label: '⚪ Normal' },
+  high:     { color: '#f6ad55', label: '🟡 High' },
+  critical: { color: '#fc8181', label: '🔴 Critical' },
+};
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function SubmitPage() {
+  const router = useRouter();
+
+  // Form state
+  const [text, setText] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [priority, setPriority] = useState<Priority>('normal');
+  const [skipDecomposition, setSkipDecomposition] = useState(false);
+  const [notifyOnComplete, setNotifyOnComplete] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [promptId, setPromptId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Data
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [classification, setClassification] = useState<ReturnType<typeof classifyText> | null>(null);
+
+  // Refs
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load projects
+  useEffect(() => {
+    fetch('/api/projects')
+      .then(r => r.json())
+      .then((data: unknown) => {
+        if (Array.isArray(data)) setProjects(data as Project[]);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Auto-grow textarea
+  const growTextarea = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(Math.max(el.scrollHeight, 200), 400) + 'px';
+  }, []);
+
+  // Debounced classification
+  const handleTextChange = useCallback((val: string) => {
+    setText(val);
+    growTextarea();
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setClassification(val.length >= 8 ? classifyText(val) : null);
+    }, 500);
+  }, [growTextarea]);
+
+  // Cmd/Ctrl+Enter to submit
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !submitting && !submitted && text.trim()) {
+        void handleSubmit();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  });
+
+  const handleSubmit = useCallback(async () => {
+    if (!text.trim() || submitting || submitted) return;
+    setSubmitting(true);
+    setErrorMsg(null);
+
+    try {
+      const res = await fetch('/api/prompts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: text.trim(),
+          projectId: projectId || undefined,
+          priority,
+          source: 'dashboard',
+          skipDecomposition,
+        }),
+      });
+
+      const data = await res.json() as SubmitResponse;
+      if (!res.ok || data.error) throw new Error(data.error ?? 'Submission failed');
+
+      setPromptId(data.prompt_id ?? null);
+      setSubmitted(true);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [text, projectId, priority, skipDecomposition, submitting, submitted]);
+
+  const activeAgents = getActiveAgents(classification?.requestType?.id ?? null);
+  const activeProjects = projects.filter(p => p.status === 'active');
+
+  return (
+    <>
+      <style>{`
+        @keyframes fadeSlideIn {
+          from { opacity: 0; transform: translateY(12px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes pulseGreen {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+        .submit-btn:hover:not(:disabled) {
+          background: #2a4a7f !important;
+          transform: translateY(-1px);
+          box-shadow: 0 4px 12px rgba(66,153,225,0.3);
+        }
+        .submit-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+        .toggle-track {
+          transition: background 0.2s;
+        }
+        select:focus, textarea:focus {
+          outline: none;
+        }
+      `}</style>
+
+      <div
+        style={{
+          maxWidth: 800,
+          margin: '0 auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0,
+          padding: '8px 0 48px',
+        }}
+      >
+        {/* ── Header ────────────────────────────────────── */}
+        <div style={{ marginBottom: 32, textAlign: 'center' }}>
+          <div style={{ fontSize: 32, marginBottom: 8 }}>✦</div>
+          <h1
+            style={{
+              margin: '0 0 6px',
+              fontSize: 26,
+              fontWeight: 700,
+              color: '#f0f4f8',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            Chief AI Agent
+          </h1>
+          <p style={{ margin: 0, fontSize: 14, color: '#718096', lineHeight: 1.5 }}>
+            Submit a requirement, feature, or idea — your AI team will handle the rest.
+          </p>
+        </div>
+
+        {/* ── Main form card ─────────────────────────────── */}
+        <div
+          style={{
+            background: '#1a1f2e',
+            border: '1px solid #2d3748',
+            borderRadius: 12,
+            padding: '24px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 20,
+          }}
+        >
+          {/* Project selector */}
+          {activeProjects.length > 0 && (
+            <div>
+              <label
+                htmlFor="project-select"
+                style={{ display: 'block', fontSize: 12, fontWeight: 600, color: '#a0aec0', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.06em' }}
+              >
+                Project (optional)
+              </label>
+              <select
+                id="project-select"
+                value={projectId}
+                onChange={e => setProjectId(e.target.value)}
+                disabled={submitted}
+                style={{
+                  width: '100%',
+                  background: '#111520',
+                  color: '#e2e8f0',
+                  border: '1px solid #2d3748',
+                  borderRadius: 7,
+                  padding: '9px 12px',
+                  fontSize: 13,
+                  cursor: 'pointer',
+                  appearance: 'none',
+                  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23718096' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E")`,
+                  backgroundRepeat: 'no-repeat',
+                  backgroundPosition: 'right 12px center',
+                  paddingRight: 32,
+                }}
+                onFocus={e => { e.target.style.borderColor = '#4299e1'; }}
+                onBlur={e => { e.target.style.borderColor = '#2d3748'; }}
+              >
+                <option value="">No project (global)</option>
+                {activeProjects.map(p => (
+                  <option key={p.id} value={p.id}>
+                    {p.icon ? `${p.icon} ` : ''}{p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Text area */}
+          <div>
+            <label
+              htmlFor="prompt-text"
+              style={{ display: 'block', fontSize: 12, fontWeight: 600, color: '#a0aec0', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.06em' }}
+            >
+              Requirement / Idea
+            </label>
+            <div style={{ position: 'relative' }}>
+              <textarea
+                id="prompt-text"
+                ref={textareaRef}
+                value={text}
+                onChange={e => handleTextChange(e.target.value)}
+                placeholder="Describe what you want to build. Be as detailed or as brief as you like — your AI team will ask clarifying questions if needed."
+                disabled={submitted}
+                style={{
+                  width: '100%',
+                  minHeight: 200,
+                  height: 200,
+                  maxHeight: 400,
+                  background: '#111520',
+                  border: '1px solid #2d3748',
+                  borderRadius: 8,
+                  color: '#e2e8f0',
+                  fontSize: 14,
+                  lineHeight: 1.7,
+                  padding: '14px 16px',
+                  resize: 'none',
+                  fontFamily: 'system-ui, -apple-system, sans-serif',
+                  boxSizing: 'border-box',
+                  transition: 'border-color 0.15s',
+                }}
+                onFocus={e => { e.target.style.borderColor = '#4299e1'; }}
+                onBlur={e => { e.target.style.borderColor = '#2d3748'; }}
+              />
+              {/* Character count */}
+              <span
+                style={{
+                  position: 'absolute',
+                  bottom: 10,
+                  right: 12,
+                  fontSize: 11,
+                  color: text.length > 3000 ? '#fc8181' : '#4a5568',
+                  pointerEvents: 'none',
+                  userSelect: 'none',
+                }}
+              >
+                {text.length.toLocaleString()} characters
+              </span>
+            </div>
+            <div style={{ fontSize: 11, color: '#4a5568', marginTop: 4, textAlign: 'right' }}>
+              Tip: Cmd+Enter to submit
+            </div>
+          </div>
+
+          {/* Classification badge */}
+          {classification && (
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap', animation: 'fadeSlideIn 0.25s ease' }}>
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: classification.requestType?.color ?? '#a0aec0',
+                  background: (classification.requestType?.bg ?? '#2d3748'),
+                  border: `1px solid ${(classification.requestType?.color ?? '#718096')}44`,
+                  borderRadius: 10,
+                  padding: '3px 10px',
+                }}
+              >
+                {classification.requestType?.emoji} {classification.requestType?.label ?? 'Unknown'}
+              </span>
+              {classification.domain && (
+                <span style={{ fontSize: 12, color: '#718096' }}>
+                  Domain: <span style={{ color: '#a0aec0', fontWeight: 500 }}>{classification.domain}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Agent team preview */}
+          {text.length >= 20 && (
+            <div style={{ animation: 'fadeSlideIn 0.3s ease' }}>
+              <div style={{ fontSize: 12, fontWeight: 600, color: '#a0aec0', marginBottom: 10, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                Agent Team
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {AGENT_TIERS.map(tier => (
+                  <div key={tier.tier} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 11, color: '#4a5568', minWidth: 80, fontWeight: 500 }}>
+                      {tier.tier}
+                    </span>
+                    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                      {tier.agents.map(agent => {
+                        const isActive = activeAgents.has(agent.abbr);
+                        return (
+                          <span
+                            key={agent.abbr}
+                            title={agent.name}
+                            style={{
+                              fontSize: 11,
+                              fontWeight: 600,
+                              color: isActive ? agent.color : '#4a5568',
+                              background: isActive ? agent.color + '1a' : '#1a1f2e',
+                              border: `1px solid ${isActive ? agent.color + '44' : '#2d3748'}`,
+                              borderRadius: 6,
+                              padding: '3px 8px',
+                              transition: 'all 0.2s',
+                              opacity: isActive ? 1 : 0.4,
+                            }}
+                          >
+                            {agent.abbr}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Advanced options */}
+          <div>
+            <button
+              onClick={() => setShowAdvanced(v => !v)}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: '#718096',
+                cursor: 'pointer',
+                fontSize: 12,
+                fontWeight: 500,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: 0,
+              }}
+            >
+              <span style={{ transition: 'transform 0.2s', transform: showAdvanced ? 'rotate(90deg)' : 'none' }}>▸</span>
+              Advanced options
+            </button>
+
+            {showAdvanced && (
+              <div
+                style={{
+                  marginTop: 14,
+                  padding: '16px',
+                  background: '#111520',
+                  border: '1px solid #2d3748',
+                  borderRadius: 8,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 16,
+                  animation: 'fadeSlideIn 0.2s ease',
+                }}
+              >
+                {/* Priority slider */}
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: '#a0aec0', marginBottom: 10, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                    Priority — <span style={{ color: PRIORITY_STYLE[priority].color }}>{PRIORITY_STYLE[priority].label}</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    {PRIORITIES.map(p => (
+                      <button
+                        key={p}
+                        onClick={() => setPriority(p)}
+                        style={{
+                          flex: 1,
+                          padding: '6px 0',
+                          borderRadius: 6,
+                          border: `1px solid ${priority === p ? PRIORITY_STYLE[p].color + '88' : '#2d3748'}`,
+                          background: priority === p ? PRIORITY_STYLE[p].color + '22' : '#1a1f2e',
+                          color: priority === p ? PRIORITY_STYLE[p].color : '#718096',
+                          fontSize: 12,
+                          fontWeight: priority === p ? 700 : 400,
+                          cursor: 'pointer',
+                          transition: 'all 0.15s',
+                          textTransform: 'capitalize',
+                        }}
+                      >
+                        {p}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Skip decomposition toggle */}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <div>
+                    <div style={{ fontSize: 13, color: '#e2e8f0', fontWeight: 500 }}>
+                      Skip AI decomposition
+                    </div>
+                    <div style={{ fontSize: 11, color: '#718096', marginTop: 2 }}>
+                      Create a single task directly instead of decomposing into requirements and stories
+                    </div>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={skipDecomposition}
+                    onClick={() => setSkipDecomposition(v => !v)}
+                    className="toggle-track"
+                    style={{
+                      width: 40,
+                      height: 22,
+                      borderRadius: 11,
+                      border: 'none',
+                      background: skipDecomposition ? '#4299e1' : '#2d3748',
+                      cursor: 'pointer',
+                      padding: 2,
+                      display: 'flex',
+                      alignItems: 'center',
+                      flexShrink: 0,
+                      marginLeft: 16,
+                      transition: 'background 0.2s',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: '50%',
+                        background: '#f0f4f8',
+                        display: 'block',
+                        transform: skipDecomposition ? 'translateX(18px)' : 'translateX(0)',
+                        transition: 'transform 0.2s',
+                      }}
+                    />
+                  </button>
+                </div>
+
+                {/* Notify toggle */}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <div>
+                    <div style={{ fontSize: 13, color: '#e2e8f0', fontWeight: 500 }}>
+                      Notify me on completion
+                    </div>
+                    <div style={{ fontSize: 11, color: '#718096', marginTop: 2 }}>
+                      Coming soon — send a notification when this prompt is fully processed
+                    </div>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={notifyOnComplete}
+                    onClick={() => setNotifyOnComplete(v => !v)}
+                    disabled
+                    className="toggle-track"
+                    style={{
+                      width: 40,
+                      height: 22,
+                      borderRadius: 11,
+                      border: 'none',
+                      background: '#2d3748',
+                      cursor: 'not-allowed',
+                      padding: 2,
+                      display: 'flex',
+                      alignItems: 'center',
+                      flexShrink: 0,
+                      marginLeft: 16,
+                      opacity: 0.4,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: '50%',
+                        background: '#f0f4f8',
+                        display: 'block',
+                        transform: 'translateX(0)',
+                      }}
+                    />
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Error */}
+          {errorMsg && (
+            <div
+              style={{
+                padding: '10px 14px',
+                background: '#3d1515',
+                border: '1px solid #742a2a',
+                borderRadius: 7,
+                color: '#fc8181',
+                fontSize: 13,
+              }}
+              role="alert"
+            >
+              ❌ {errorMsg}
+            </div>
+          )}
+
+          {/* Submit button */}
+          {!submitted && (
+            <button
+              className="submit-btn"
+              onClick={() => void handleSubmit()}
+              disabled={submitting || !text.trim() || submitted}
+              style={{
+                width: '100%',
+                padding: '14px 24px',
+                background: text.trim() ? '#1a3a7f' : '#2d3748',
+                color: text.trim() ? '#90cdf4' : '#4a5568',
+                border: `1px solid ${text.trim() ? '#2a5aaf' : '#2d3748'}`,
+                borderRadius: 9,
+                fontSize: 15,
+                fontWeight: 700,
+                cursor: text.trim() && !submitting ? 'pointer' : 'not-allowed',
+                transition: 'all 0.15s',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 10,
+                letterSpacing: '-0.01em',
+              }}
+              aria-label="Submit to your AI team"
+            >
+              {submitting ? (
+                <>
+                  <span
+                    style={{
+                      width: 16,
+                      height: 16,
+                      border: '2px solid #4299e144',
+                      borderTop: '2px solid #63b3ed',
+                      borderRadius: '50%',
+                      animation: 'spin 0.7s linear infinite',
+                      display: 'inline-block',
+                      flexShrink: 0,
+                    }}
+                  />
+                  Submitting to your AI team…
+                </>
+              ) : (
+                'Submit to your AI team →'
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* ── Success: progress panel ─────────────────────── */}
+        {submitted && promptId && (
+          <ProgressPanel promptId={promptId} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/components/HumanGateModal.tsx
+++ b/apps/dashboard/components/HumanGateModal.tsx
@@ -1,0 +1,423 @@
+'use client';
+import { useState, useEffect, useRef } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type GateKind =
+  | 'architecture-plan'
+  | 'backlog-review'
+  | 'design-review'
+  | 'testing-approval'
+  | 'release-approval';
+
+type ArtifactType = 'markdown' | 'json' | 'text';
+
+export interface HumanGateModalProps {
+  gate: GateKind;
+  agentName: string;
+  artifactContent: string;
+  artifactType: ArtifactType;
+  onApprove: () => void;
+  onRequestChanges: (feedback: string) => void;
+  onDismiss: () => void;
+}
+
+// ─── Gate config ──────────────────────────────────────────────────────────────
+
+const GATE_LABELS: Record<GateKind, { label: string; icon: string; color: string }> = {
+  'architecture-plan':  { label: 'Architecture Plan Review',  icon: '🏗️', color: '#63b3ed' },
+  'backlog-review':     { label: 'Backlog Review',            icon: '📋', color: '#9f7aea' },
+  'design-review':      { label: 'Design Review',             icon: '🎨', color: '#f6ad55' },
+  'testing-approval':   { label: 'Testing Approval',          icon: '🧪', color: '#68d391' },
+  'release-approval':   { label: 'Release Approval',          icon: '🚀', color: '#fc8181' },
+};
+
+// ─── Artifact renderer ────────────────────────────────────────────────────────
+
+function ArtifactRenderer({
+  content,
+  type,
+}: {
+  content: string;
+  type: ArtifactType;
+}) {
+  if (type === 'json') {
+    let formatted = content;
+    try {
+      formatted = JSON.stringify(JSON.parse(content), null, 2);
+    } catch { /* leave as-is */ }
+    return (
+      <pre
+        style={{
+          margin: 0,
+          padding: '16px',
+          fontFamily: 'monospace',
+          fontSize: 12,
+          lineHeight: 1.6,
+          color: '#e2e8f0',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          background: '#111520',
+          borderRadius: 6,
+          border: '1px solid #2d3748',
+          overflowY: 'auto',
+          maxHeight: 360,
+        }}
+      >
+        {formatted}
+      </pre>
+    );
+  }
+
+  if (type === 'markdown') {
+    // Lightweight markdown rendering (no external dep)
+    const lines = content.split('\n');
+    return (
+      <div
+        style={{
+          background: '#111520',
+          border: '1px solid #2d3748',
+          borderRadius: 6,
+          padding: '16px',
+          maxHeight: 360,
+          overflowY: 'auto',
+          fontSize: 13,
+          lineHeight: 1.7,
+          color: '#d1d5db',
+        }}
+      >
+        {lines.map((line, i) => {
+          if (line.startsWith('### '))
+            return <h3 key={i} style={{ margin: '12px 0 4px', color: '#f0f4f8', fontSize: 14 }}>{line.slice(4)}</h3>;
+          if (line.startsWith('## '))
+            return <h2 key={i} style={{ margin: '16px 0 6px', color: '#90cdf4', fontSize: 15, borderBottom: '1px solid #2d3748', paddingBottom: 4 }}>{line.slice(3)}</h2>;
+          if (line.startsWith('# '))
+            return <h1 key={i} style={{ margin: '0 0 12px', color: '#90cdf4', fontSize: 17 }}>{line.slice(2)}</h1>;
+          if (line.startsWith('- ') || line.startsWith('* '))
+            return <div key={i} style={{ paddingLeft: 16, display: 'flex', gap: 6 }}><span style={{ color: '#4a5568', flexShrink: 0 }}>•</span><span>{line.slice(2)}</span></div>;
+          if (line.startsWith('```'))
+            return <div key={i} style={{ fontFamily: 'monospace', background: '#0d111c', padding: '2px 8px', fontSize: 12, color: '#68d391' }}>{line}</div>;
+          if (line.trim() === '')
+            return <div key={i} style={{ height: 8 }} />;
+          return <p key={i} style={{ margin: '2px 0' }}>{line}</p>;
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        background: '#111520',
+        border: '1px solid #2d3748',
+        borderRadius: 6,
+        padding: '16px',
+        maxHeight: 360,
+        overflowY: 'auto',
+        fontSize: 13,
+        lineHeight: 1.7,
+        color: '#d1d5db',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+      }}
+    >
+      {content}
+    </div>
+  );
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+export function HumanGateModal({
+  gate,
+  agentName,
+  artifactContent,
+  artifactType,
+  onApprove,
+  onRequestChanges,
+  onDismiss,
+}: HumanGateModalProps) {
+  const [mode, setMode] = useState<'review' | 'feedback'>('review');
+  const [feedback, setFeedback] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const gateCfg = GATE_LABELS[gate];
+
+  // Close on Escape
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onDismiss]);
+
+  // Trap focus
+  useEffect(() => {
+    overlayRef.current?.focus();
+  }, []);
+
+  const handleApprove = async () => {
+    setSubmitting(true);
+    onApprove();
+  };
+
+  const handleRequestChanges = async () => {
+    if (!feedback.trim()) return;
+    setSubmitting(true);
+    onRequestChanges(feedback.trim());
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      tabIndex={-1}
+      onClick={e => { if (e.target === e.currentTarget) onDismiss(); }}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.72)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 10000,
+        padding: 24,
+      }}
+      aria-modal="true"
+      role="dialog"
+      aria-label={`Human review gate: ${gateCfg.label}`}
+    >
+      <div
+        style={{
+          background: '#1a1f2e',
+          border: `1px solid ${gateCfg.color}44`,
+          borderTop: `3px solid ${gateCfg.color}`,
+          borderRadius: 12,
+          width: '100%',
+          maxWidth: 680,
+          maxHeight: '90vh',
+          display: 'flex',
+          flexDirection: 'column',
+          boxShadow: `0 24px 64px rgba(0,0,0,0.6), 0 0 0 1px ${gateCfg.color}22`,
+          overflow: 'hidden',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: '16px 20px',
+            borderBottom: '1px solid #2d3748',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 12,
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontSize: 24 }}>{gateCfg.icon}</span>
+          <div style={{ flex: 1 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: '0.1em',
+                  textTransform: 'uppercase',
+                  color: gateCfg.color,
+                  background: gateCfg.color + '22',
+                  padding: '2px 8px',
+                  borderRadius: 10,
+                  border: `1px solid ${gateCfg.color}44`,
+                }}
+              >
+                Human Review Required
+              </span>
+            </div>
+            <h2 style={{ margin: 0, fontSize: 17, fontWeight: 700, color: '#f0f4f8' }}>
+              {gateCfg.label}
+            </h2>
+            <div style={{ fontSize: 12, color: '#718096', marginTop: 2 }}>
+              Produced by: <span style={{ color: '#a0aec0', fontWeight: 500 }}>{agentName}</span>
+            </div>
+          </div>
+          <button
+            onClick={onDismiss}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#718096',
+              cursor: 'pointer',
+              fontSize: 18,
+              padding: 4,
+              lineHeight: 1,
+              borderRadius: 4,
+            }}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '16px 20px' }}>
+          {mode === 'review' ? (
+            <>
+              <div style={{ fontSize: 12, color: '#718096', marginBottom: 8, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                Artifact — {artifactType.toUpperCase()}
+              </div>
+              <ArtifactRenderer content={artifactContent} type={artifactType} />
+
+              <div
+                style={{
+                  marginTop: 16,
+                  padding: '10px 14px',
+                  background: '#0f1117',
+                  border: '1px solid #2d3748',
+                  borderRadius: 6,
+                  fontSize: 12,
+                  color: '#718096',
+                }}
+              >
+                💡 Review the artifact above. Approve to let the pipeline continue, or request changes to send feedback back to the agent.
+              </div>
+            </>
+          ) : (
+            <>
+              <div style={{ fontSize: 13, color: '#a0aec0', marginBottom: 10 }}>
+                Describe what needs to change. The <strong style={{ color: '#e2e8f0' }}>{agentName}</strong> will receive this feedback and revise its output.
+              </div>
+              <textarea
+                value={feedback}
+                onChange={e => setFeedback(e.target.value)}
+                placeholder="E.g. The architecture is missing a caching layer. Please add Redis between the API and the database, and explain the cache invalidation strategy..."
+                autoFocus
+                style={{
+                  width: '100%',
+                  minHeight: 140,
+                  background: '#111520',
+                  border: '1px solid #4a5568',
+                  borderRadius: 6,
+                  color: '#e2e8f0',
+                  fontSize: 13,
+                  padding: '10px 12px',
+                  resize: 'vertical',
+                  fontFamily: 'system-ui, -apple-system, sans-serif',
+                  lineHeight: 1.6,
+                  boxSizing: 'border-box',
+                  outline: 'none',
+                }}
+                onFocus={e => { e.target.style.borderColor = '#63b3ed'; }}
+                onBlur={e => { e.target.style.borderColor = '#4a5568'; }}
+              />
+              <div style={{ fontSize: 11, color: '#4a5568', marginTop: 6, textAlign: 'right' }}>
+                {feedback.length} characters
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: '14px 20px',
+            borderTop: '1px solid #2d3748',
+            display: 'flex',
+            gap: 10,
+            alignItems: 'center',
+            flexShrink: 0,
+            background: '#141821',
+          }}
+        >
+          {mode === 'review' ? (
+            <>
+              <button
+                onClick={handleApprove}
+                disabled={submitting}
+                style={{
+                  background: '#276749',
+                  color: '#9ae6b4',
+                  border: '1px solid #276749',
+                  borderRadius: 7,
+                  padding: '9px 20px',
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: submitting ? 'not-allowed' : 'pointer',
+                  opacity: submitting ? 0.6 : 1,
+                  transition: 'opacity 0.15s',
+                }}
+              >
+                {submitting ? 'Approving…' : '✓ Approve & Continue'}
+              </button>
+              <button
+                onClick={() => setMode('feedback')}
+                disabled={submitting}
+                style={{
+                  background: '#7b341e',
+                  color: '#fbd38d',
+                  border: '1px solid #7b341e',
+                  borderRadius: 7,
+                  padding: '9px 20px',
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  opacity: submitting ? 0.6 : 1,
+                }}
+              >
+                ↩ Request Changes
+              </button>
+              <button
+                onClick={onDismiss}
+                style={{
+                  marginLeft: 'auto',
+                  background: 'none',
+                  color: '#718096',
+                  border: '1px solid #2d3748',
+                  borderRadius: 7,
+                  padding: '9px 16px',
+                  fontSize: 13,
+                  cursor: 'pointer',
+                }}
+              >
+                Dismiss
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => setMode('review')}
+                style={{
+                  background: '#2d3748',
+                  color: '#a0aec0',
+                  border: '1px solid #4a5568',
+                  borderRadius: 7,
+                  padding: '9px 16px',
+                  fontSize: 13,
+                  cursor: 'pointer',
+                }}
+              >
+                ← Back
+              </button>
+              <button
+                onClick={handleRequestChanges}
+                disabled={submitting || !feedback.trim()}
+                style={{
+                  background: '#7b341e',
+                  color: '#fbd38d',
+                  border: '1px solid #7b341e',
+                  borderRadius: 7,
+                  padding: '9px 20px',
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: (submitting || !feedback.trim()) ? 'not-allowed' : 'pointer',
+                  opacity: (submitting || !feedback.trim()) ? 0.5 : 1,
+                }}
+              >
+                {submitting ? 'Sending…' : '↩ Send Feedback to Agent'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/hooks/useEventStream.ts
+++ b/apps/dashboard/hooks/useEventStream.ts
@@ -1,0 +1,87 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export interface WsEvent {
+  kind: string;
+  id?: string;
+  projectId?: string;
+  payload?: unknown;
+  ts: string;
+}
+
+type EventListener = (event: WsEvent) => void;
+type ConnectedListener = (connected: boolean) => void;
+
+// ─── Module-level singleton ───────────────────────────────────────────────────
+let _ws: WebSocket | null = null;
+let _connected = false;
+let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+const _eventListeners = new Set<EventListener>();
+const _connectedListeners = new Set<ConnectedListener>();
+
+function notifyConnected(state: boolean) {
+  _connected = state;
+  _connectedListeners.forEach(fn => fn(state));
+}
+
+function notifyEvent(event: WsEvent) {
+  _eventListeners.forEach(fn => fn(event));
+}
+
+function connectSingleton(url: string) {
+  if (_ws && (_ws.readyState === WebSocket.CONNECTING || _ws.readyState === WebSocket.OPEN)) return;
+
+  try {
+    _ws = new WebSocket(url);
+
+    _ws.onopen = () => notifyConnected(true);
+
+    _ws.onclose = () => {
+      notifyConnected(false);
+      _ws = null;
+      if (_reconnectTimer) clearTimeout(_reconnectTimer);
+      _reconnectTimer = setTimeout(() => connectSingleton(url), 3000);
+    };
+
+    _ws.onerror = () => _ws?.close();
+
+    _ws.onmessage = (msg) => {
+      try {
+        const data = JSON.parse(msg.data as string) as WsEvent;
+        if (data.kind !== 'connected') {
+          notifyEvent(data);
+        }
+      } catch { /* ignore parse errors */ }
+    };
+  } catch {
+    _reconnectTimer = setTimeout(() => connectSingleton(url), 3000);
+  }
+}
+
+const WS_URL = 'ws://localhost:7776/events';
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+export function useEventStream() {
+  const [lastEvent, setLastEvent] = useState<WsEvent | null>(null);
+  const [connected, setConnected] = useState(_connected);
+
+  useEffect(() => {
+    connectSingleton(WS_URL);
+
+    const onEvent: EventListener = (e) => setLastEvent(e);
+    const onConnected: ConnectedListener = (c) => setConnected(c);
+
+    _eventListeners.add(onEvent);
+    _connectedListeners.add(onConnected);
+
+    // Sync initial state
+    setConnected(_connected);
+
+    return () => {
+      _eventListeners.delete(onEvent);
+      _connectedListeners.delete(onConnected);
+    };
+  }, []);
+
+  return { lastEvent, connected };
+}


### PR DESCRIPTION
Lift batch H from conductor archive (commit 71a02a6).

## New pages

| Route | Source | Lines |
|---|---|---|
| /coverage | dashboard/app/coverage/page.tsx | 162 |
| /gates | dashboard/app/gates/page.tsx | 415 |
| /pipeline | dashboard/app/pipeline/page.tsx | 762 |
| /platform-status | dashboard/app/platform-status/page.tsx | 624 |
| /submit | dashboard/app/submit/page.tsx | 879 |
| /agents | apps/dashboard/app/agents/page.tsx | 314 |
| /api/agents (proxy) | apps/dashboard/app/api/agents/route.ts | 38 |

All 7 routes register and build cleanly under Next.js 14.

## Drift fixes (Section 1.11 audit)

| File | Why missing |
|---|---|
| `apps/dashboard/components/HumanGateModal.tsx` (423 lines) | Referenced by `/gates` page; was missing in CAIA's components/ (17 → 18) |
| `apps/dashboard/hooks/useEventStream.ts` (87 lines) | Referenced by `/platform-status` page; was missing in CAIA's hooks/ (2 → 3) |

## .gitignore fix

The root `.gitignore` rule `coverage/` (intended for test-output dirs) was silently ignoring `apps/dashboard/app/coverage/` — the application route for the dashboard's coverage page. Added `!apps/dashboard/app/coverage/` negation. Test-artifact `coverage/` directories still ignored everywhere else.

## Verification

- `pnpm --filter @caia-app/dashboard build` — clean Next.js production build
- All 7 new routes appear in the build output (sizes shown above)
- `pnpm build` — 27/27 turbo tasks pass

## Source-of-truth

Per matrix Section 1.1 + 1.11 Batch H.