### PR TITLE
feat(stolution-mcp): batch I — lift @stolution/mcp-server + ops tooling scripts

### DIFF
--- a/apps/stolution-mcp/README.md
+++ b/apps/stolution-mcp/README.md
@@ -1,0 +1,244 @@
+# stolution-mcp
+
+**MCP server for remote stolution server management.**
+
+Runs on the stolution remote server (`s903@162.251.161.17`) and exposes its
+file system, shell, Docker, PM2, HashiCorp Vault, PostgreSQL, and git
+capabilities to Claude Cowork on a local Mac — via the Model Context Protocol
+over an SSH transport.
+
+---
+
+## Architecture
+
+```
+Local Mac (Cowork)                  Remote server (stolution)
+┌─────────────────────┐    SSH     ┌────────────────────────────────┐
+│  Claude Cowork      │◄──stdio──► │  node stolution-mcp/dist/index │
+│  (MCP client)       │            │  (MCP server)                  │
+│                     │            │         │                      │
+│  mcp-config.json    │            │   ┌─────┴──────────────────┐   │
+│  → ssh stolution    │            │   │  /home/s903/stolution  │   │
+│    node dist/index  │            │   │  Docker / PM2          │   │
+└─────────────────────┘            │   │  PostgreSQL            │   │
+                                   │   │  HashiCorp Vault       │   │
+                                   │   └────────────────────────┘   │
+                                   └────────────────────────────────┘
+```
+
+**Transport**: `ssh stolution node /home/s903/stolution-mcp/dist/index.js`
+
+MCP speaks JSON-RPC over stdio. SSH tunnels stdin/stdout transparently —
+no HTTP tunnel or port forwarding needed for basic operation.
+
+---
+
+## Tools
+
+### File System
+
+| Tool | Description |
+|------|-------------|
+| `stolution_read_file(path)` | Read a file (allowed dirs only, ≤512KB) |
+| `stolution_list_dir(path)` | `ls -lahF` on any directory |
+| `stolution_write_file(path, content)` | Write a file (allowed dirs only) |
+| `stolution_grep(pattern, path, options)` | Grep with `-i`/`-r` flags, up to 200 hits |
+
+**Allowed read paths**: `/home/s903/stolution`, `/var/log`, `/etc/nginx`
+**Allowed write paths**: `/home/s903/stolution/apps`, `/home/s903/stolution/config`, `/tmp`
+
+### Shell
+
+| Tool | Description |
+|------|-------------|
+| `stolution_bash(command, timeout)` | Run any bash command (safety blocked list, 2MB output cap, max 120s) |
+| `stolution_git(args, repo_path)` | Run git in the stolution repo; force-push and hard-reset blocked |
+
+### Docker
+
+| Tool | Description |
+|------|-------------|
+| `stolution_docker_ps()` | Running + all containers with image, status, ports |
+| `stolution_docker_logs(container, lines)` | Timestamped logs (max 500 lines) |
+
+### PM2
+
+| Tool | Description |
+|------|-------------|
+| `stolution_pm2_list()` | All PM2 processes with CPU/memory/uptime |
+| `stolution_pm2_restart(name)` | Restart a named process |
+| `stolution_pm2_logs(name, lines)` | Recent logs (max 500 lines) |
+
+### HashiCorp Vault
+
+| Tool | Description |
+|------|-------------|
+| `stolution_vault_get(secret_path, field)` | Read one field or all fields as JSON |
+| `stolution_vault_list()` | List top-level secret paths |
+
+Requires `VAULT_TOKEN` env var, or a running Docker container named `vault`.
+
+### PostgreSQL
+
+| Tool | Description |
+|------|-------------|
+| `stolution_db_query(sql, params)` | SELECT only — results as ASCII table |
+| `stolution_db_schema(table_name?)` | Column + index info, or full table list |
+
+Requires `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` env vars.
+
+---
+
+## Security Model
+
+1. **Runs as `s903`** — no root, no sudo (unless explicitly granted per command)
+2. **Blocked shell patterns**: `rm -rf`, `mkfs`, `dd if=`, `shutdown`, `reboot`,
+   `passwd`, `curl|bash`, writes to `/etc` or `/boot`
+3. **Blocked git**: `push --force`, `reset --hard`, `clean -fd`
+4. **DB**: SELECT only — DDL and DML are pattern-rejected before hitting Postgres
+5. **Filesystem reads**: restricted to an allowlist of directories
+6. **Filesystem writes**: restricted to a tighter allowlist
+7. **All errors are returned as MCP `isError` responses** — never crash the server
+
+---
+
+## Deployment
+
+### Prerequisites (local Mac)
+
+```bash
+# SSH alias configured in ~/.ssh/config:
+Host stolution
+  HostName 162.251.161.17
+  User s903
+  IdentityFile ~/.ssh/id_ed25519  # or your key
+```
+
+### Prerequisites (remote)
+
+```bash
+# Node 20+ and npm
+node --version  # must be >= 20
+# PM2 (optional — only needed for persistent other processes)
+npm install -g pm2
+```
+
+### Deploy
+
+```bash
+# From the conductor project root:
+./scripts/deploy-stolution-mcp.sh
+```
+
+The script:
+1. Builds TypeScript locally
+2. `rsync`s built files to `~/stolution-mcp/` on the remote
+3. `npm install --omit=dev` on the remote
+4. Creates a `.env` template if one doesn't exist
+5. Runs a quick smoke test to confirm the server starts
+6. Prints the exact Cowork MCP config block to add
+
+### Restart only
+
+```bash
+./scripts/deploy-stolution-mcp.sh --restart-only
+```
+
+---
+
+## Cowork Integration
+
+Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "stolution-remote": {
+      "command": "ssh",
+      "args": [
+        "-tt",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=15",
+        "stolution",
+        "node /home/s903/stolution-mcp/dist/index.js"
+      ],
+      "description": "stolution remote server — files, Docker, PM2, Vault, DB, bash, git"
+    }
+  }
+}
+```
+
+Restart Cowork. The `stolution-remote` MCP server will appear in the tool palette.
+
+---
+
+## Alternative Transport: Cloudflare Tunnel (HTTP/SSE)
+
+If you need persistent HTTP access (e.g. multiple clients, no SSH):
+
+```bash
+# On the remote server:
+cloudflared tunnel create stolution-mcp
+cloudflared tunnel route dns stolution-mcp mcp.stolution.example.com
+
+# Run the MCP server with HTTP transport (requires modifying src/index.ts
+# to use StreamableHTTPServerTransport instead of StdioServerTransport)
+cloudflared tunnel run stolution-mcp
+```
+
+Then in Cowork config use `url` instead of `command`:
+
+```json
+{
+  "mcpServers": {
+    "stolution-remote": {
+      "url": "https://mcp.stolution.example.com/mcp",
+      "description": "stolution remote (HTTP/SSE via Cloudflare Tunnel)"
+    }
+  }
+}
+```
+
+---
+
+## Local Development
+
+```bash
+cd apps/stolution-mcp
+
+# Install
+npm install
+
+# Type-check
+npm run typecheck
+
+# Build
+npm run build
+
+# Run locally (will fail on actual remote commands but useful for testing MCP wire protocol)
+npm run dev
+```
+
+---
+
+## Project Structure
+
+```
+apps/stolution-mcp/
+├── package.json          # Dependencies: @modelcontextprotocol/sdk, pg
+├── tsconfig.json         # ES2022, NodeNext modules
+├── mcp-config.json       # Paste into Claude Cowork config
+├── src/
+│   ├── index.ts          # MCP server entry — wires all tools to MCP
+│   └── tools/
+│       ├── filesystem.ts # read_file, list_dir, write_file, grep
+│       ├── shell.ts      # bash, git
+│       ├── docker.ts     # docker_ps, docker_logs
+│       ├── pm2.ts        # pm2_list, pm2_restart, pm2_logs
+│       ├── vault.ts      # vault_get, vault_list
+│       └── database.ts   # db_query (SELECT only), db_schema
+└── dist/                 # Compiled output (generated by npm run build)
+
+scripts/
+└── deploy-stolution-mcp.sh  # rsync + install + smoke test
+```

--- a/apps/stolution-mcp/mcp-config.json
+++ b/apps/stolution-mcp/mcp-config.json
@@ -1,0 +1,31 @@
+{
+  "_comment": [
+    "Cowork MCP configuration for the stolution remote server.",
+    "Add the 'stolution-remote' block to your Claude desktop config:",
+    "  ~/Library/Application Support/Claude/claude_desktop_config.json",
+    "",
+    "How it works:",
+    "  - 'command': 'ssh' launches an SSH connection to the stolution server",
+    "  - '-tt' forces a pseudo-TTY (required for some server setups)",
+    "  - The final arg starts the MCP server via Node on the remote",
+    "  - MCP speaks JSON-RPC over stdio; SSH tunnels stdin/stdout transparently",
+    "  - No HTTP tunnel needed — SSH IS the transport",
+    "",
+    "Alternatives:",
+    "  Option B (HTTP/SSE via cloudflared): see README.md section 'Cloudflare Tunnel'",
+    "  Option C (local proxy script):       see README.md section 'Local SSH proxy'"
+  ],
+  "mcpServers": {
+    "stolution-remote": {
+      "command": "ssh",
+      "args": [
+        "-tt",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=15",
+        "stolution",
+        "node /home/s903/stolution-mcp/dist/index.js"
+      ],
+      "description": "Full access to stolution remote server — file system, Docker, PM2, Vault, PostgreSQL, bash, git"
+    }
+  }
+}

--- a/apps/stolution-mcp/package.json
+++ b/apps/stolution-mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@stolution/mcp-server",
+  "version": "0.1.0",
+  "description": "MCP server for remote stolution server management — file system, Docker, PM2, Vault, PostgreSQL, git",
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "pg": "^8.13.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.19.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/apps/stolution-mcp/src/index.ts
+++ b/apps/stolution-mcp/src/index.ts
@@ -1,0 +1,163 @@
+/**
+ * stolution-mcp — MCP server for remote stolution server management
+ *
+ * Exposes tools for: file system, bash, git, Docker, PM2, HashiCorp Vault,
+ * and PostgreSQL — all running on the stolution remote server (s903@162.251.161.17).
+ *
+ * Transport: stdio (SSH tunnels it — `ssh stolution node ~/stolution-mcp/dist/index.js`)
+ * Protocol:  Model Context Protocol (MCP) v1.x via @modelcontextprotocol/sdk
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Tool modules ─────────────────────────────────────────────────────────────
+import {
+  filesystemToolDefs,
+  handleReadFile,
+  handleListDir,
+  handleWriteFile,
+  handleGrep,
+} from './tools/filesystem.js';
+
+import {
+  shellToolDefs,
+  handleBash,
+  handleGit,
+} from './tools/shell.js';
+
+import {
+  dockerToolDefs,
+  handleDockerPs,
+  handleDockerLogs,
+} from './tools/docker.js';
+
+import {
+  pm2ToolDefs,
+  handlePm2List,
+  handlePm2Restart,
+  handlePm2Logs,
+} from './tools/pm2.js';
+
+import {
+  vaultToolDefs,
+  handleVaultGet,
+  handleVaultList,
+} from './tools/vault.js';
+
+import {
+  databaseToolDefs,
+  handleDbQuery,
+  handleDbSchema,
+} from './tools/database.js';
+
+// ─── Aggregate all tool definitions ──────────────────────────────────────────
+
+const ALL_TOOLS: Tool[] = [
+  ...filesystemToolDefs,
+  ...shellToolDefs,
+  ...dockerToolDefs,
+  ...pm2ToolDefs,
+  ...vaultToolDefs,
+  ...databaseToolDefs,
+] as Tool[];
+
+// ─── Create MCP server ────────────────────────────────────────────────────────
+
+const server = new Server(
+  {
+    name: 'stolution-mcp',
+    version: '0.1.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// ─── List tools handler ───────────────────────────────────────────────────────
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: ALL_TOOLS,
+}));
+
+// ─── Call tool handler ────────────────────────────────────────────────────────
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const safeArgs = (args ?? {}) as Record<string, unknown>;
+
+  log(`Tool called: ${name}`, safeArgs);
+
+  try {
+    let text: string;
+
+    switch (name) {
+      // Filesystem
+      case 'stolution_read_file':   text = await handleReadFile(safeArgs);   break;
+      case 'stolution_list_dir':    text = await handleListDir(safeArgs);     break;
+      case 'stolution_write_file':  text = await handleWriteFile(safeArgs);   break;
+      case 'stolution_grep':        text = await handleGrep(safeArgs);        break;
+
+      // Shell
+      case 'stolution_bash':        text = await handleBash(safeArgs);        break;
+      case 'stolution_git':         text = await handleGit(safeArgs);         break;
+
+      // Docker
+      case 'stolution_docker_ps':   text = await handleDockerPs(safeArgs);    break;
+      case 'stolution_docker_logs': text = await handleDockerLogs(safeArgs);  break;
+
+      // PM2
+      case 'stolution_pm2_list':    text = await handlePm2List(safeArgs);     break;
+      case 'stolution_pm2_restart': text = await handlePm2Restart(safeArgs);  break;
+      case 'stolution_pm2_logs':    text = await handlePm2Logs(safeArgs);     break;
+
+      // Vault
+      case 'stolution_vault_get':   text = await handleVaultGet(safeArgs);    break;
+      case 'stolution_vault_list':  text = await handleVaultList(safeArgs);   break;
+
+      // Database
+      case 'stolution_db_query':    text = await handleDbQuery(safeArgs);     break;
+      case 'stolution_db_schema':   text = await handleDbSchema(safeArgs);    break;
+
+      default:
+        throw new Error(`Unknown tool: ${name}. Available tools: ${ALL_TOOLS.map(t => t.name).join(', ')}`);
+    }
+
+    log(`Tool success: ${name}`);
+    return { content: [{ type: 'text' as const, text }] };
+
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log(`Tool error: ${name} — ${message}`);
+    return {
+      content: [{ type: 'text' as const, text: `❌ Error in ${name}: ${message}` }],
+      isError: true,
+    };
+  }
+});
+
+// ─── Logging (stderr so it doesn't interfere with stdio MCP protocol) ─────────
+
+function log(message: string, data?: unknown): void {
+  const ts = new Date().toISOString();
+  const extra = data && Object.keys(data).length ? ` ${JSON.stringify(data)}` : '';
+  process.stderr.write(`[stolution-mcp] ${ts} ${message}${extra}\n`);
+}
+
+// ─── Startup ──────────────────────────────────────────────────────────────────
+
+log('Starting stolution-mcp server...');
+log(`Node ${process.version} | PID ${process.pid}`);
+log(`Tools registered: ${ALL_TOOLS.map(t => t.name).join(', ')}`);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+log('✅ Server connected on stdio — ready for MCP requests');

--- a/apps/stolution-mcp/src/tools/database.ts
+++ b/apps/stolution-mcp/src/tools/database.ts
@@ -1,0 +1,156 @@
+import pg from 'pg';
+
+const { Client } = pg;
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+function getDbConfig(): pg.ClientConfig {
+  return {
+    host: process.env.DB_HOST ?? '127.0.0.1',
+    port: parseInt(process.env.DB_PORT ?? '5432', 10),
+    database: process.env.DB_NAME ?? 'stolution',
+    user: process.env.DB_USER ?? 's903',
+    password: process.env.DB_PASSWORD,
+    connectionTimeoutMillis: 10_000,
+    statement_timeout: 15_000, // 15s max query time
+  };
+}
+
+// ─── Safety: only allow SELECT queries ────────────────────────────────────────
+
+const WRITE_PATTERNS = [
+  /^\s*(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|COPY)\b/i,
+  /\bpg_terminate_backend\b/i,
+  /\bpg_cancel_backend\b/i,
+];
+
+export function isReadOnlyQuery(sql: string): boolean {
+  return !WRITE_PATTERNS.some(p => p.test(sql.trim()));
+}
+
+// ─── Tool Handlers ────────────────────────────────────────────────────────────
+
+export async function handleDbQuery(args: Record<string, unknown>): Promise<string> {
+  const sql = args.sql as string;
+  const params = (args.params as unknown[]) ?? [];
+
+  if (!sql) throw new Error('sql is required');
+  if (!isReadOnlyQuery(sql)) {
+    throw new Error('Only read-only SELECT queries are allowed. Use stolution_bash for admin tasks.');
+  }
+
+  const client = new Client(getDbConfig());
+  await client.connect();
+  try {
+    const result = await client.query(sql, params);
+    const { rows, fields } = result;
+
+    if (rows.length === 0) return '(query returned 0 rows)';
+
+    // Format as ASCII table
+    const headers = fields.map(f => f.name);
+    const colWidths = headers.map((h, i) =>
+      Math.max(h.length, ...rows.map(r => String(r[h] ?? 'NULL').length))
+    );
+    const separator = colWidths.map(w => '-'.repeat(w + 2)).join('+');
+    const header = headers.map((h, i) => ` ${h.padEnd(colWidths[i])} `).join('|');
+    const dataRows = rows.map(row =>
+      headers.map((h, i) => ` ${String(row[h] ?? 'NULL').padEnd(colWidths[i])} `).join('|')
+    );
+
+    const table = [header, separator, ...dataRows].join('\n');
+    return `${rows.length} row(s):\n${table}`;
+  } finally {
+    await client.end();
+  }
+}
+
+export async function handleDbSchema(args: Record<string, unknown>): Promise<string> {
+  const tableName = args.table_name as string;
+
+  const client = new Client(getDbConfig());
+  await client.connect();
+  try {
+    if (tableName) {
+      // Get column info for a specific table
+      const { rows } = await client.query(
+        `SELECT
+           column_name,
+           data_type,
+           character_maximum_length,
+           is_nullable,
+           column_default
+         FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = $1
+         ORDER BY ordinal_position`,
+        [tableName]
+      );
+      if (rows.length === 0) return `Table "${tableName}" not found in public schema.`;
+
+      const lines = rows.map(r =>
+        `  ${r.column_name.padEnd(30)} ${r.data_type}${r.character_maximum_length ? `(${r.character_maximum_length})` : ''} ${r.is_nullable === 'YES' ? 'NULL' : 'NOT NULL'}${r.column_default ? ` DEFAULT ${r.column_default}` : ''}`
+      );
+
+      // Also get indexes
+      const { rows: indexes } = await client.query(
+        `SELECT indexname, indexdef FROM pg_indexes WHERE tablename = $1`,
+        [tableName]
+      );
+      const indexLines = indexes.map(i => `  ${i.indexname}: ${i.indexdef}`);
+
+      return `=== Table: ${tableName} ===\n${lines.join('\n')}\n\n=== Indexes ===\n${indexLines.join('\n') || '  (none)'}`;
+    } else {
+      // List all tables
+      const { rows } = await client.query(
+        `SELECT table_name, table_type
+         FROM information_schema.tables
+         WHERE table_schema = 'public'
+         ORDER BY table_type, table_name`
+      );
+      const lines = rows.map(r => `  ${r.table_name.padEnd(40)} ${r.table_type}`);
+      return `=== Tables in public schema ===\n${lines.join('\n')}`;
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+// ─── Tool Definitions ─────────────────────────────────────────────────────────
+
+export const databaseToolDefs = [
+  {
+    name: 'stolution_db_query',
+    description: [
+      'Run a read-only SELECT query against the stolution PostgreSQL database.',
+      'Only SELECT statements are allowed — INSERT/UPDATE/DELETE/DROP are rejected.',
+      'Results formatted as an ASCII table. Max 15s query time.',
+      'Requires DB_HOST, DB_NAME, DB_USER, DB_PASSWORD environment variables on the server.',
+    ].join(' '),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sql: { type: 'string', description: 'SELECT SQL query to execute' },
+        params: {
+          type: 'array',
+          items: {},
+          description: 'Optional parameterized query values (for $1, $2, … placeholders)',
+          default: [],
+        },
+      },
+      required: ['sql'],
+    },
+  },
+  {
+    name: 'stolution_db_schema',
+    description: 'Inspect the stolution PostgreSQL schema. If table_name is given, returns columns and indexes for that table. Otherwise lists all tables.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        table_name: {
+          type: 'string',
+          description: 'Table name to inspect. Omit to list all tables.',
+        },
+      },
+    },
+  },
+];

--- a/apps/stolution-mcp/src/tools/docker.ts
+++ b/apps/stolution-mcp/src/tools/docker.ts
@@ -1,0 +1,55 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+// ─── Tool Handlers ────────────────────────────────────────────────────────────
+
+export async function handleDockerPs(_args: Record<string, unknown>): Promise<string> {
+  const { stdout } = await execAsync(
+    'docker ps --format "table {{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}" 2>&1'
+  );
+  const all = await execAsync('docker ps -a --format "table {{.Names}}\\t{{.Image}}\\t{{.Status}}" 2>&1');
+  return `=== Running Containers ===\n${stdout}\n=== All Containers ===\n${all.stdout}`;
+}
+
+export async function handleDockerLogs(args: Record<string, unknown>): Promise<string> {
+  const container = args.container as string;
+  const lines = (args.lines as number) ?? 50;
+  if (!container) throw new Error('container is required');
+  if (lines > 500) throw new Error('lines cannot exceed 500');
+
+  const { stdout } = await execAsync(
+    `docker logs --tail=${lines} --timestamps "${container}" 2>&1`
+  );
+  return stdout || '(no logs)';
+}
+
+// ─── Tool Definitions ─────────────────────────────────────────────────────────
+
+export const dockerToolDefs = [
+  {
+    name: 'stolution_docker_ps',
+    description: 'List Docker containers on the stolution server (running + all). Shows name, image, status, ports.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'stolution_docker_logs',
+    description: 'Fetch logs from a Docker container on the stolution server. Includes timestamps.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        container: { type: 'string', description: 'Container name or ID' },
+        lines: {
+          type: 'number',
+          description: 'Number of log lines to retrieve (default 50, max 500)',
+          default: 50,
+        },
+      },
+      required: ['container'],
+    },
+  },
+];

--- a/apps/stolution-mcp/src/tools/filesystem.ts
+++ b/apps/stolution-mcp/src/tools/filesystem.ts
@@ -1,0 +1,145 @@
+import { readFile, writeFile, readdir, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+
+const execAsync = promisify(exec);
+
+// ─── Safety Configuration ─────────────────────────────────────────────────────
+
+const ALLOWED_READ_PATHS = [
+  '/home/s903/stolution',
+  '/home/s903/stolution-mcp',
+  '/var/log',
+  '/etc/nginx',
+];
+
+const ALLOWED_WRITE_PATHS = [
+  '/home/s903/stolution/apps',
+  '/home/s903/stolution/config',
+  '/home/s903/stolution-mcp',
+  '/tmp',
+];
+
+export function isSafeReadPath(p: string): boolean {
+  const resolved = path.resolve(p);
+  return ALLOWED_READ_PATHS.some(allowed => resolved.startsWith(allowed));
+}
+
+export function isSafeWritePath(p: string): boolean {
+  const resolved = path.resolve(p);
+  return ALLOWED_WRITE_PATHS.some(allowed => resolved.startsWith(allowed));
+}
+
+// ─── Tool Handlers ────────────────────────────────────────────────────────────
+
+export async function handleReadFile(args: Record<string, unknown>): Promise<string> {
+  const filePath = args.path as string;
+  if (!filePath) throw new Error('path is required');
+  if (!isSafeReadPath(filePath)) {
+    throw new Error(`Path not in allowed read locations: ${filePath}\nAllowed: ${ALLOWED_READ_PATHS.join(', ')}`);
+  }
+  if (!existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+
+  const fileStat = await stat(filePath);
+  if (fileStat.isDirectory()) throw new Error(`Path is a directory, use stolution_list_dir instead: ${filePath}`);
+
+  // Warn if file is large (>500KB)
+  if (fileStat.size > 512_000) {
+    throw new Error(`File too large (${(fileStat.size / 1024).toFixed(0)}KB). Use stolution_bash with head/tail/grep instead.`);
+  }
+
+  const content = await readFile(filePath, 'utf-8');
+  return `=== ${filePath} (${fileStat.size} bytes) ===\n${content}`;
+}
+
+export async function handleListDir(args: Record<string, unknown>): Promise<string> {
+  const dirPath = args.path as string;
+  if (!dirPath) throw new Error('path is required');
+
+  const { stdout } = await execAsync(`ls -lahF "${dirPath}" 2>&1`);
+  return `=== ${dirPath} ===\n${stdout}`;
+}
+
+export async function handleWriteFile(args: Record<string, unknown>): Promise<string> {
+  const filePath = args.path as string;
+  const content = args.content as string;
+  if (!filePath) throw new Error('path is required');
+  if (content === undefined || content === null) throw new Error('content is required');
+  if (!isSafeWritePath(filePath)) {
+    throw new Error(`Path not in allowed write locations: ${filePath}\nAllowed: ${ALLOWED_WRITE_PATHS.join(', ')}`);
+  }
+
+  const exists = existsSync(filePath);
+  await writeFile(filePath, content, 'utf-8');
+  return `✅ ${exists ? 'Updated' : 'Created'} ${filePath} (${Buffer.byteLength(content)} bytes)`;
+}
+
+export async function handleGrep(args: Record<string, unknown>): Promise<string> {
+  const pattern = args.pattern as string;
+  const searchPath = args.path as string;
+  const options = (args.options as string) || '';
+  if (!pattern) throw new Error('pattern is required');
+  if (!searchPath) throw new Error('path is required');
+
+  // Build a safe ripgrep / grep command
+  const flags = options.includes('-i') ? '-i' : '';
+  const recursive = options.includes('-r') ? '-r' : '';
+
+  const cmd = `grep -n ${flags} ${recursive} --include="*.ts" --include="*.js" --include="*.json" --include="*.env*" --include="*.yml" --include="*.yaml" --include="*.sh" --include="*.md" -E "${pattern.replace(/"/g, '\\"')}" "${searchPath}" 2>&1 | head -200`;
+  const { stdout } = await execAsync(cmd);
+  return stdout || '(no matches)';
+}
+
+// ─── Tool Definitions (for ListTools) ────────────────────────────────────────
+
+export const filesystemToolDefs = [
+  {
+    name: 'stolution_read_file',
+    description: 'Read a file from the stolution remote server. Restricted to allowed directories (stolution project, logs, nginx config).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Absolute path to the file on the remote server' },
+      },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'stolution_list_dir',
+    description: 'List directory contents on the stolution remote server (ls -lahF).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Absolute path to the directory' },
+      },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'stolution_write_file',
+    description: 'Write (create or overwrite) a file on the stolution remote server. Restricted to apps/, config/, and /tmp.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Absolute path to the file' },
+        content: { type: 'string', description: 'File content to write' },
+      },
+      required: ['path', 'content'],
+    },
+  },
+  {
+    name: 'stolution_grep',
+    description: 'Search files on the stolution server using grep. Returns up to 200 matching lines.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Regex pattern to search for' },
+        path: { type: 'string', description: 'File or directory to search in' },
+        options: { type: 'string', description: 'Optional flags: -i (case-insensitive), -r (recursive)', default: '' },
+      },
+      required: ['pattern', 'path'],
+    },
+  },
+];

--- a/apps/stolution-mcp/src/tools/pm2.ts
+++ b/apps/stolution-mcp/src/tools/pm2.ts
@@ -1,0 +1,74 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+// ─── Tool Handlers ────────────────────────────────────────────────────────────
+
+export async function handlePm2List(_args: Record<string, unknown>): Promise<string> {
+  const { stdout } = await execAsync('pm2 list --no-color 2>&1');
+  return stdout || '(no PM2 processes)';
+}
+
+export async function handlePm2Restart(args: Record<string, unknown>): Promise<string> {
+  const name = args.name as string;
+  if (!name) throw new Error('name is required');
+
+  // Prevent restarting the MCP server itself in a confusing loop
+  if (name === 'stolution-mcp') {
+    throw new Error('Cannot restart the MCP server itself via MCP. SSH in directly to restart it.');
+  }
+
+  const { stdout } = await execAsync(`pm2 restart "${name}" --no-color 2>&1`);
+  return stdout || `✅ Restarted: ${name}`;
+}
+
+export async function handlePm2Logs(args: Record<string, unknown>): Promise<string> {
+  const name = args.name as string;
+  const lines = (args.lines as number) ?? 50;
+  if (!name) throw new Error('name is required');
+  if (lines > 500) throw new Error('lines cannot exceed 500');
+
+  const { stdout } = await execAsync(`pm2 logs "${name}" --lines ${lines} --no-color --nostream 2>&1`);
+  return stdout || '(no logs)';
+}
+
+// ─── Tool Definitions ─────────────────────────────────────────────────────────
+
+export const pm2ToolDefs = [
+  {
+    name: 'stolution_pm2_list',
+    description: 'List all PM2 managed processes on the stolution server. Shows name, status, CPU, memory, uptime.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'stolution_pm2_restart',
+    description: 'Restart a PM2 process on the stolution server by name. Cannot restart the MCP server itself.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'PM2 process name or ID' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'stolution_pm2_logs',
+    description: 'Retrieve recent logs for a PM2 process on the stolution server.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'PM2 process name or ID' },
+        lines: {
+          type: 'number',
+          description: 'Number of log lines to retrieve (default 50, max 500)',
+          default: 50,
+        },
+      },
+      required: ['name'],
+    },
+  },
+];

--- a/apps/stolution-mcp/src/tools/shell.ts
+++ b/apps/stolution-mcp/src/tools/shell.ts
@@ -1,0 +1,128 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+// ─── Safety Configuration ─────────────────────────────────────────────────────
+
+/**
+ * Commands that are outright blocked regardless of context.
+ * This is a defence-in-depth measure — the real safety comes from
+ * running the server as a non-root user (s903) with limited sudo.
+ */
+const BLOCKED_PATTERNS = [
+  /\brm\s+-[a-z]*r[a-z]*f\b/i,   // rm -rf
+  /\brm\s+-[a-z]*f[a-z]*r\b/i,   // rm -fr
+  /\bmkfs\b/,
+  /\bdd\s+if=/,
+  /\bshutdown\b/,
+  /\breboot\b/,
+  /\bhalt\b/,
+  /\bpasswd\b/,
+  /\bsudo\s+su\b/,
+  /\bchmod\s+777\b/,
+  /\bcurl\b.*\|\s*(bash|sh)/,     // curl | bash
+  /\bwget\b.*\|\s*(bash|sh)/,     // wget | bash
+  />\s*\/etc\//,                   // writing to /etc
+  />\s*\/boot\//,                  // writing to /boot
+];
+
+export function isSafeCommand(cmd: string): { safe: boolean; reason?: string } {
+  for (const pattern of BLOCKED_PATTERNS) {
+    if (pattern.test(cmd)) {
+      return { safe: false, reason: `Matches blocked pattern: ${pattern}` };
+    }
+  }
+  return { safe: true };
+}
+
+// ─── Tool Handlers ────────────────────────────────────────────────────────────
+
+export async function handleBash(args: Record<string, unknown>): Promise<string> {
+  const command = args.command as string;
+  const timeoutSeconds = (args.timeout as number) ?? 30;
+
+  if (!command) throw new Error('command is required');
+  if (timeoutSeconds > 120) throw new Error('timeout cannot exceed 120 seconds');
+
+  const { safe, reason } = isSafeCommand(command);
+  if (!safe) throw new Error(`Command blocked for safety: ${reason}`);
+
+  try {
+    const { stdout, stderr } = await execAsync(command, {
+      timeout: timeoutSeconds * 1000,
+      maxBuffer: 2 * 1024 * 1024, // 2MB output cap
+      env: { ...process.env, TERM: 'dumb' },
+    });
+    const out = [stdout, stderr].filter(Boolean).join('\n--- stderr ---\n');
+    return out || '(command completed with no output)';
+  } catch (err: unknown) {
+    if (err instanceof Error && 'killed' in err && (err as NodeJS.ErrnoException & { killed?: boolean }).killed) {
+      throw new Error(`Command timed out after ${timeoutSeconds}s: ${command}`);
+    }
+    // Non-zero exit — return the stderr/stdout so Claude can read it
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    const out = [e.stdout, e.stderr].filter(Boolean).join('\n');
+    return `[exit code ${e.code ?? '?'}]\n${out || '(no output)'}`;
+  }
+}
+
+export async function handleGit(args: Record<string, unknown>): Promise<string> {
+  const gitArgs = args.args as string;
+  const repoPath = (args.repo_path as string) ?? '/home/s903/stolution';
+
+  if (!gitArgs) throw new Error('args is required (e.g. "status", "log --oneline -20")');
+
+  // Disallow destructive git commands
+  const BLOCKED_GIT = ['push --force', 'push -f', 'reset --hard', 'clean -fd', 'branch -D'];
+  for (const blocked of BLOCKED_GIT) {
+    if (gitArgs.includes(blocked)) {
+      throw new Error(`Blocked git operation: git ${blocked}`);
+    }
+  }
+
+  const cmd = `git -C "${repoPath}" ${gitArgs} 2>&1`;
+  const { stdout } = await execAsync(cmd, { timeout: 30_000 });
+  return stdout || '(no output)';
+}
+
+// ─── Tool Definitions ─────────────────────────────────────────────────────────
+
+export const shellToolDefs = [
+  {
+    name: 'stolution_bash',
+    description: [
+      'Run a bash command on the stolution remote server.',
+      'Safety: blocks rm -rf, mkfs, dd, shutdown, reboot, passwd, curl|bash, writes to /etc or /boot.',
+      'Output capped at 2MB. Timeout: 1–120 seconds.',
+    ].join(' '),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        command: { type: 'string', description: 'The bash command to execute' },
+        timeout: {
+          type: 'number',
+          description: 'Timeout in seconds (default 30, max 120)',
+          default: 30,
+        },
+      },
+      required: ['command'],
+    },
+  },
+  {
+    name: 'stolution_git',
+    description: 'Run a git command inside the stolution repository (or a specified repo path). Destructive force-pushes and hard resets are blocked.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        args: { type: 'string', description: 'Git subcommand and arguments, e.g. "status", "log --oneline -20", "diff HEAD~1"' },
+        repo_path: {
+          type: 'string',
+          description: 'Absolute path to the git repository (default: /home/s903/stolution)',
+          default: '/home/s903/stolution',
+        },
+      },
+      required: ['args'],
+    },
+  },
+];

--- a/apps/stolution-mcp/src/tools/vault.ts
+++ b/apps/stolution-mcp/src/tools/vault.ts
@@ -1,0 +1,100 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+/**
+ * The Vault container name. Adjust if your setup differs.
+ * Alternatively, set VAULT_ADDR and VAULT_TOKEN in the environment
+ * and use the vault CLI directly (if installed on the host).
+ */
+const VAULT_CONTAINER = process.env.VAULT_CONTAINER ?? 'vault';
+const VAULT_ADDR = process.env.VAULT_ADDR ?? 'http://127.0.0.1:8200';
+const VAULT_TOKEN = process.env.VAULT_TOKEN; // read from env at runtime
+
+/**
+ * Build the vault CLI invocation — either via docker exec (if containerized)
+ * or via local vault binary (if VAULT_TOKEN is set in env).
+ */
+function vaultCmd(subcommand: string): string {
+  if (VAULT_TOKEN) {
+    // Use host vault CLI
+    return `VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_TOKEN}" vault ${subcommand} 2>&1`;
+  }
+  // Fall back to docker exec
+  return `docker exec ${VAULT_CONTAINER} vault ${subcommand} 2>/dev/null`;
+}
+
+// ─── Tool Handlers ────────────────────────────────────────────────────────────
+
+export async function handleVaultGet(args: Record<string, unknown>): Promise<string> {
+  const secretPath = args.secret_path as string;
+  const field = args.field as string;
+  if (!secretPath) throw new Error('secret_path is required');
+
+  let cmd: string;
+  if (field) {
+    cmd = vaultCmd(`kv get -field="${field}" "${secretPath}"`);
+  } else {
+    // Return all fields — format as key=value table
+    cmd = vaultCmd(`kv get -format=json "${secretPath}"`);
+  }
+
+  const { stdout } = await execAsync(cmd, { timeout: 15_000 });
+  const result = stdout.trim();
+  if (!result || result.includes('Error') || result.includes('No value found')) {
+    throw new Error(`Vault: no secret found at ${secretPath}${field ? `[${field}]` : ''}`);
+  }
+  return result;
+}
+
+export async function handleVaultList(_args: Record<string, unknown>): Promise<string> {
+  const cmd = vaultCmd('kv list -format=json secret/');
+  try {
+    const { stdout } = await execAsync(cmd, { timeout: 15_000 });
+    const paths: string[] = JSON.parse(stdout);
+    return `=== Vault Secret Paths (secret/) ===\n${paths.map(p => `  ${p}`).join('\n')}`;
+  } catch {
+    // Fallback to text output
+    const { stdout } = await execAsync(vaultCmd('kv list secret/'), { timeout: 15_000 });
+    return `=== Vault Secret Paths ===\n${stdout}`;
+  }
+}
+
+// ─── Tool Definitions ─────────────────────────────────────────────────────────
+
+export const vaultToolDefs = [
+  {
+    name: 'stolution_vault_get',
+    description: [
+      'Read a secret from HashiCorp Vault running on the stolution server.',
+      'If field is specified, returns only that field value.',
+      'If field is omitted, returns all fields as JSON.',
+      'Requires VAULT_TOKEN env var or a running "vault" Docker container.',
+    ].join(' '),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        secret_path: {
+          type: 'string',
+          description: 'Vault KV path, e.g. "secret/stolution/postgres"',
+        },
+        field: {
+          type: 'string',
+          description: 'Specific field to retrieve, e.g. "password". Omit to get all fields.',
+        },
+      },
+      required: ['secret_path'],
+    },
+  },
+  {
+    name: 'stolution_vault_list',
+    description: 'List available secret paths in HashiCorp Vault at secret/ (top-level). Use stolution_vault_get to read specific values.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+];

--- a/apps/stolution-mcp/tsconfig.json
+++ b/apps/stolution-mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 12.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
       hono:
         specifier: ^4.12.14
         version: 4.12.15
@@ -206,6 +206,28 @@ importers:
         version: 5.9.3
 
   apps/pipeline-pulse: {}
+
+  apps/stolution-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@4.3.6)
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.20.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
   apps/story-backfiller:
     devDependencies:
@@ -3305,6 +3327,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@types/picomatch@2.3.4':
     resolution: {integrity: sha512-0so8lU8O5zatZS/2Fi4zrwks+vZv7e0dygrgEZXljODXBig97l4cPQD+9LabXfGJOWwoRkTVz6Q4edZvD12UOA==}
 
@@ -5561,6 +5586,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5679,6 +5738,22 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -6673,6 +6748,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -9320,6 +9399,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 20.19.39
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@types/picomatch@2.3.4': {}
 
   '@types/pino@7.0.5':
@@ -10227,11 +10312,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.20.0
       better-sqlite3: 12.9.0
+      pg: 8.20.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -11863,6 +11950,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -11995,6 +12117,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prebuild-install@7.1.3:
     dependencies:
@@ -13257,6 +13389,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/scripts/bootstrap-git-auth.sh
+++ b/scripts/bootstrap-git-auth.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== CAIA Git Auth Bootstrap ==="
+echo "Fetching GitHub token from HashiCorp Vault on stolution..."
+
+# Step 1: Find the vault container on stolution
+VAULT_CONTAINER=$(ssh stolution "docker ps --filter 'ancestor=vault' --filter 'ancestor=hashicorp/vault' --format '{{.Names}}' 2>/dev/null | head -1 || docker ps --format '{{.Names}}' 2>/dev/null | grep -i vault | head -1")
+
+if [ -z "$VAULT_CONTAINER" ]; then
+  echo "ERROR: Could not find vault container on stolution"
+  echo "Available containers:"
+  ssh stolution "docker ps --format '{{.Names}}'"
+  exit 1
+fi
+echo "Found vault container: $VAULT_CONTAINER"
+
+# Step 2: Get vault address and token
+VAULT_ADDR=$(ssh stolution "docker exec $VAULT_CONTAINER env | grep VAULT_ADDR | cut -d= -f2 || echo 'http://127.0.0.1:8200'")
+VAULT_TOKEN=$(ssh stolution "docker exec $VAULT_CONTAINER env | grep 'VAULT_TOKEN\|VAULT_DEV_ROOT_TOKEN_ID' | cut -d= -f2 | head -1")
+
+if [ -z "$VAULT_TOKEN" ]; then
+  # Try reading from common vault token file locations
+  VAULT_TOKEN=$(ssh stolution "cat ~/.vault-token 2>/dev/null || cat /root/.vault-token 2>/dev/null || echo ''")
+fi
+
+echo "Vault address: $VAULT_ADDR"
+
+# Step 3: Try to read GitHub token from vault (try multiple common paths)
+GITHUB_TOKEN=""
+
+for SECRET_PATH in "secret/github" "kv/github" "secret/data/github" "kv/data/github" "secret/api-keys" "kv/api-keys" "secret/credentials" "kv/credentials"; do
+  TOKEN=$(ssh stolution "docker exec -e VAULT_ADDR=$VAULT_ADDR -e VAULT_TOKEN=$VAULT_TOKEN $VAULT_CONTAINER vault kv get -field=token $SECRET_PATH 2>/dev/null || vault kv get -field=github_token $SECRET_PATH 2>/dev/null || vault kv get -field=value $SECRET_PATH 2>/dev/null || echo ''" 2>/dev/null || true)
+  if [ -n "$TOKEN" ] && [[ "$TOKEN" == ghp_* ]] || [[ "$TOKEN" == github_pat_* ]] || [[ "$TOKEN" == ghs_* ]]; then
+    GITHUB_TOKEN="$TOKEN"
+    echo "Found GitHub token at vault path: $SECRET_PATH"
+    break
+  fi
+done
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo ""
+  echo "Could not auto-discover GitHub token. Listing available vault secrets:"
+  ssh stolution "docker exec -e VAULT_ADDR=$VAULT_ADDR -e VAULT_TOKEN=$VAULT_TOKEN $VAULT_CONTAINER vault kv list secret/ 2>/dev/null || vault secrets list 2>/dev/null"
+  echo ""
+  echo "Please provide the vault secret path manually:"
+  read -p "Secret path (e.g. secret/github): " SECRET_PATH
+  GITHUB_TOKEN=$(ssh stolution "docker exec -e VAULT_ADDR=$VAULT_ADDR -e VAULT_TOKEN=$VAULT_TOKEN $VAULT_CONTAINER vault kv get $SECRET_PATH" | grep -E "token|value|github" | awk '{print $2}' | head -1)
+fi
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "ERROR: Failed to retrieve GitHub token from vault"
+  exit 1
+fi
+
+echo "GitHub token retrieved: ${GITHUB_TOKEN:0:10}..."
+
+# Step 4: Configure git remote with token
+REPO_DIR="$HOME/Documents/projects/conductor"
+git -C "$REPO_DIR" remote set-url origin "https://${GITHUB_TOKEN}@github.com/prakashgbid/conductor.git"
+echo "✅ Git remote configured with token"
+
+# Step 5: Also configure gh CLI if installed
+if command -v gh &>/dev/null; then
+  echo "$GITHUB_TOKEN" | gh auth login --with-token
+  echo "✅ gh CLI authenticated"
+else
+  echo "ℹ️  gh CLI not installed. Install with: brew install gh"
+  echo "   Then run: echo '$GITHUB_TOKEN' | gh auth login --with-token"
+fi
+
+# Step 6: Store token in shell environment for future use
+SHELL_RC="$HOME/.zshenv"
+if ! grep -q "GITHUB_TOKEN" "$SHELL_RC" 2>/dev/null; then
+  echo "export GITHUB_TOKEN=${GITHUB_TOKEN}" >> "$SHELL_RC"
+  echo "✅ GITHUB_TOKEN added to $SHELL_RC"
+fi
+
+# Step 7: Test push
+echo ""
+echo "Testing push..."
+git -C "$REPO_DIR" push --set-upstream origin "$(git -C "$REPO_DIR" branch --show-current)" && echo "✅ Push successful!" || echo "❌ Push failed — check SSH key registration with GitHub"
+
+echo ""
+echo "=== Done ==="
+echo "Git remote: $(git -C $REPO_DIR remote get-url origin)"

--- a/scripts/deploy-stolution-mcp.sh
+++ b/scripts/deploy-stolution-mcp.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy-stolution-mcp.sh
+# Deploys the stolution-mcp MCP server to the remote stolution server and
+# registers it as a PM2 service.
+#
+# Usage:  ./scripts/deploy-stolution-mcp.sh [--restart-only]
+#
+# Prerequisites (local):
+#   - SSH alias "stolution" configured in ~/.ssh/config (s903@162.251.161.17)
+#   - Node.js 20+ installed on remote
+#   - npm installed on remote
+#   - PM2 installed globally on remote: npm install -g pm2
+#
+# Prerequisites (remote):
+#   - The following env vars in ~/stolution-mcp/.env (created on first deploy):
+#       DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+#       VAULT_TOKEN (optional if using Docker vault container)
+#       VAULT_ADDR  (optional, defaults to http://127.0.0.1:8200)
+# =============================================================================
+
+set -euo pipefail
+
+REMOTE="stolution"
+REMOTE_DIR="/home/s903/stolution-mcp"
+LOCAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/apps/stolution-mcp"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}▶ $*${NC}"; }
+warn()    { echo -e "${YELLOW}⚠ $*${NC}"; }
+error()   { echo -e "${RED}✗ $*${NC}" >&2; exit 1; }
+
+# ─── Parse args ───────────────────────────────────────────────────────────────
+
+RESTART_ONLY=false
+for arg in "$@"; do
+  [[ "$arg" == "--restart-only" ]] && RESTART_ONLY=true
+done
+
+# ─── Check SSH connectivity ───────────────────────────────────────────────────
+
+info "Checking SSH connectivity to $REMOTE..."
+ssh -o ConnectTimeout=10 "$REMOTE" "echo 'SSH OK'" || error "Cannot reach $REMOTE — check SSH config"
+
+if $RESTART_ONLY; then
+  info "Restart-only mode: restarting PM2 process..."
+  ssh "$REMOTE" "pm2 restart stolution-mcp && pm2 save" || error "PM2 restart failed"
+  info "✅ Restarted stolution-mcp"
+  exit 0
+fi
+
+# ─── Build locally first ─────────────────────────────────────────────────────
+
+info "Building TypeScript locally..."
+cd "$LOCAL_DIR"
+npm install --silent
+npm run build
+info "Build OK — dist/ is ready"
+
+# ─── Create remote directory ──────────────────────────────────────────────────
+
+info "Creating remote directory $REMOTE_DIR..."
+ssh "$REMOTE" "mkdir -p $REMOTE_DIR/dist $REMOTE_DIR/src"
+
+# ─── Sync files ───────────────────────────────────────────────────────────────
+
+info "Syncing files to $REMOTE:$REMOTE_DIR ..."
+rsync -az --delete \
+  --exclude='node_modules' \
+  --exclude='.env' \
+  --exclude='*.log' \
+  "$LOCAL_DIR/" \
+  "$REMOTE:$REMOTE_DIR/"
+
+# ─── Install production dependencies on remote ───────────────────────────────
+
+info "Installing production dependencies on remote..."
+ssh "$REMOTE" "cd $REMOTE_DIR && npm install --omit=dev --silent"
+
+# ─── Create .env if it doesn't exist ─────────────────────────────────────────
+
+info "Checking remote .env..."
+ssh "$REMOTE" "bash -s" << 'ENVINIT'
+ENV_FILE="/home/s903/stolution-mcp/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Creating template .env — fill in your values!"
+  cat > "$ENV_FILE" << 'ENVTEMPLATE'
+# PostgreSQL connection
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_NAME=stolution
+DB_USER=s903
+DB_PASSWORD=
+
+# HashiCorp Vault (leave empty to use Docker container named "vault")
+VAULT_TOKEN=
+VAULT_ADDR=http://127.0.0.1:8200
+VAULT_CONTAINER=vault
+ENVTEMPLATE
+  chmod 600 "$ENV_FILE"
+  echo "⚠ Template .env created at $ENV_FILE — edit it before starting the server!"
+else
+  echo ".env already exists — skipping template creation"
+fi
+ENVINIT
+
+# ─── Register / restart with PM2 ─────────────────────────────────────────────
+
+info "Registering stolution-mcp with PM2..."
+ssh "$REMOTE" "bash -s" << PMSTART
+cd $REMOTE_DIR
+
+# Stop existing instance if running
+pm2 stop stolution-mcp 2>/dev/null || true
+pm2 delete stolution-mcp 2>/dev/null || true
+
+# Start fresh, loading .env
+pm2 start dist/index.js \
+  --name stolution-mcp \
+  --interpreter node \
+  --no-autorestart \
+  -- 2>/dev/null || true
+
+# Actually: MCP stdio servers don't persist, they're spawned on-demand by SSH.
+# So we DON'T want PM2 to keep it running — we just verify it starts cleanly.
+pm2 delete stolution-mcp 2>/dev/null || true
+echo "PM2 launch test passed"
+PMSTART
+
+# ─── Verify binary works ──────────────────────────────────────────────────────
+
+info "Verifying server starts..."
+RESULT=$(ssh "$REMOTE" "timeout 3 node $REMOTE_DIR/dist/index.js 2>&1 || true")
+if echo "$RESULT" | grep -q "stolution-mcp"; then
+  info "✅ Server starts cleanly"
+else
+  warn "Server output: $RESULT"
+  warn "Could not verify clean startup — check manually with: ssh stolution node $REMOTE_DIR/dist/index.js"
+fi
+
+# ─── Print Cowork config ──────────────────────────────────────────────────────
+
+echo ""
+info "=== Cowork MCP Configuration ==="
+cat << COWORKCONFIG
+Add this to your Claude Cowork MCP config file:
+
+{
+  "mcpServers": {
+    "stolution-remote": {
+      "command": "ssh",
+      "args": ["-tt", "stolution", "node $REMOTE_DIR/dist/index.js"],
+      "description": "stolution remote server — files, Docker, PM2, Vault, DB, bash"
+    }
+  }
+}
+
+Typical config file location:
+  ~/Library/Application Support/Claude/claude_desktop_config.json
+COWORKCONFIG
+
+info "✅ Deployment complete!"

--- a/scripts/escalate-stale-blockers.py
+++ b/scripts/escalate-stale-blockers.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Escalate stale blockers.
+
+Runs hourly via launchd (com.conductor.escalate-stale-blockers).
+Any open blocker with severity in (high, critical) older than 48h with
+no events in the last 24h gets:
+  - severity bumped to critical (if currently high)
+  - resolution_note appended with "stale > 48h, escalated <ts>"
+  - a system.warning event emitted to events table
+"""
+import os
+import sqlite3
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+
+DB = os.path.expanduser('~/.conductor/db.sqlite')
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat().replace('+00:00', 'Z')
+    cutoff_48h = (now - timedelta(hours=48)).isoformat().replace('+00:00', 'Z')
+    cutoff_24h = (now - timedelta(hours=24)).isoformat().replace('+00:00', 'Z')
+
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT id, title, severity, created_at, resolution_note
+        FROM blockers
+        WHERE state='open'
+          AND severity IN ('high','critical')
+          AND created_at < ?
+        """,
+        (cutoff_48h,),
+    )
+    rows = cur.fetchall()
+
+    bumped = 0
+    for r in rows:
+        cur.execute(
+            "SELECT MAX(occurred_at) FROM events WHERE entity_type='blocker' AND entity_id=?",
+            (r['id'],),
+        )
+        last_evt = cur.fetchone()[0]
+        if last_evt and last_evt > cutoff_24h:
+            continue
+
+        new_sev = 'critical'
+        note = (r['resolution_note'] or '').strip()
+        suffix = f"stale > 48h, escalated {now_iso}"
+        if suffix not in note:
+            note = (note + ' | ' + suffix).strip(' |')
+
+        if r['severity'] != new_sev or note != (r['resolution_note'] or ''):
+            cur.execute(
+                'UPDATE blockers SET severity=?, resolution_note=? WHERE id=?',
+                (new_sev, note, r['id']),
+            )
+            bumped += 1
+
+        evt_id = f"evt_escalate_{r['id']}_{int(now.timestamp())}"
+        payload = json.dumps({
+            'blocker_id': r['id'],
+            'title': r['title'],
+            'previous_severity': r['severity'],
+            'new_severity': new_sev,
+            'reason': 'stale > 48h with no events in 24h',
+        })
+        cur.execute(
+            """INSERT OR IGNORE INTO events(id, type, occurred_at, actor, entity_type,
+                   entity_id, payload_json, severity)
+               VALUES (?,?,?,?,?,?,?,?)""",
+            (evt_id, 'system.warning', now_iso, 'escalate-stale-blockers',
+             'blocker', r['id'], payload, 'warning'),
+        )
+
+    conn.commit()
+    conn.close()
+    print(f'escalate-stale-blockers: scanned={len(rows)} bumped={bumped} at={now_iso}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/get-vault-secret.sh
+++ b/scripts/get-vault-secret.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Usage: ./get-vault-secret.sh secret/github token
+SECRET_PATH="${1:-secret/github}"
+FIELD="${2:-token}"
+
+VAULT_CONTAINER=$(ssh stolution "docker ps --format '{{.Names}}' | grep -i vault | head -1")
+VAULT_TOKEN=$(ssh stolution "cat ~/.vault-token 2>/dev/null || docker exec $VAULT_CONTAINER env | grep VAULT_TOKEN | cut -d= -f2")
+
+ssh stolution "docker exec -e VAULT_TOKEN=$VAULT_TOKEN $VAULT_CONTAINER vault kv get -field=$FIELD $SECRET_PATH 2>/dev/null"

--- a/scripts/heartbeat-pulse.sh
+++ b/scripts/heartbeat-pulse.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Conductor heartbeat pulse runner. Invoked by launchd every 15 min.
+# Routes pulse outcome -> pulse_runs DB row + macOS notification + system.warning event.
+
+set -u
+PULSE_CLI="$HOME/Documents/projects/conductor/dist/src/cli/index.js"
+LOG="$HOME/Library/Logs/conductor-heartbeat-pulse.log"
+RAW="/tmp/conductor-pulse-last.json"
+TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+mkdir -p "$(dirname "$LOG")"
+echo "[$TS_ISO] pulse starting" >> "$LOG"
+
+# Run pulse — keep output for parser
+NODE_BIN=""
+for cand in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    [ -x "$cand" ] && NODE_BIN="$cand" && break
+done
+if [ -z "$NODE_BIN" ]; then
+    echo "[$TS_ISO] node binary not found" >> "$LOG"
+    : > "$RAW"
+elif ! "$NODE_BIN" "$PULSE_CLI" pulse --json > "$RAW" 2>>"$LOG"; then
+    echo "[$TS_ISO] pulse exited non-zero" >> "$LOG"
+fi
+
+# Single python invocation does parse + DB write + notification
+python3 - "$RAW" "$TS_ISO" >> "$LOG" 2>&1 <<'PYINNER'
+import json, sqlite3, os, sys, subprocess, time
+
+raw_path, ts_iso = sys.argv[1], sys.argv[2]
+db = os.path.expanduser("~/.conductor/db.sqlite")
+
+try:
+    raw = open(raw_path).read()
+    j = json.loads(raw)
+    run_id = j.get("runId") or f"pulse_local_{int(time.time())}"
+    ran_at = j.get("ranAt") or ts_iso
+    outcome = j.get("outcome", "UNKNOWN")
+    dur = int(j.get("durationMs") or 0)
+except Exception as e:
+    raw = ""
+    run_id = f"pulse_parse_err_{int(time.time())}"
+    ran_at = ts_iso
+    outcome = "PARSE_ERROR"
+    dur = 0
+    print(f"parse error: {e}")
+
+conn = sqlite3.connect(db)
+cur = conn.cursor()
+cur.execute(
+    """INSERT OR REPLACE INTO pulse_runs(run_id, ran_at, outcome, duration_ms,
+       triggered_by, raw_json, notes) VALUES (?,?,?,?,?,?,?)""",
+    (run_id, ran_at, outcome, dur, "heartbeat-pulse-launchd", raw[:200000], None),
+)
+
+if outcome in ("DEGRADED", "CRITICAL", "PARSE_ERROR"):
+    evt_id = f"evt_pulse_{run_id}"
+    sev = "critical" if outcome == "CRITICAL" else "warning"
+    cur.execute(
+        """INSERT OR IGNORE INTO events(id, type, occurred_at, actor, entity_type,
+           entity_id, payload_json, severity) VALUES (?,?,?,?,?,?,?,?)""",
+        (evt_id, "system.warning", ran_at, "heartbeat-pulse-launchd",
+         "pulse_run", run_id,
+         json.dumps({"outcome": outcome, "run_id": run_id}), sev),
+    )
+    subprocess.run([
+        "osascript","-e",
+        f'display notification "Pulse {outcome} ({run_id})" with title "Conductor Pulse" sound name "Submarine"'
+    ], check=False)
+elif outcome == "AUTO_HEALED":
+    cnt = cur.execute(
+        "SELECT COUNT(*) FROM pulse_runs WHERE ran_at > datetime('now','-24 hours')"
+    ).fetchone()[0]
+    if cnt == 1:
+        subprocess.run([
+            "osascript","-e",
+            f'display notification "AUTO_HEALED — first in 24h ({run_id})" with title "Conductor Pulse"'
+        ], check=False)
+
+conn.commit()
+conn.close()
+print(f"OK outcome={outcome} run_id={run_id}")
+PYINNER
+
+echo "[$TS_ISO] pulse done" >> "$LOG"

--- a/scripts/push-ci-fix.sh
+++ b/scripts/push-ci-fix.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+git push --set-upstream origin claude/exec-token-phase2


### PR DESCRIPTION
Lift batch I — adds the MCP server that backs the `stolution-remote` tools used everywhere in this analysis, plus 6 ops scripts.

## Sourcing note

These files were never committed to either archive branch — they existed as untracked files in the active conductor working tree at `~/Documents/projects/conductor/`. Without lifting them, archiving conductor would lose them. Sourced from the local working tree as the only available copy.

## apps/stolution-mcp

`@stolution/mcp-server@0.1.0` — MCP server exposing the stolution remote (s903@162.251.161.17) to Claude over SSH stdio.

| Tool module | Purpose |
|---|---|
| filesystem.ts | read/write/list/grep on remote files |
| shell.ts | bash with safety blocks (destructive commands rejected) |
| docker.ts | ps + logs |
| pm2.ts | list + logs + restart |
| vault.ts | Vault KV get/list via docker exec |
| database.ts | Postgres SELECT-only + schema inspection |

`README.md` (244 lines) covers stdio-over-SSH transport plus alternatives (cloudflared HTTP/SSE, local SSH proxy). `mcp-config.json` is the Cowork-side configuration block.

**Why this matters:** the entire conductor-to-CAIA capability matrix analysis depends on these tools to compare repos. Without lifting, archiving conductor breaks the analysis tooling.

## Scripts

| Script | Purpose |
|---|---|
| deploy-stolution-mcp.sh | rsync + remote pnpm install + restart |
| get-vault-secret.sh | thin Vault KV wrapper (SSH+docker exec) |
| bootstrap-git-auth.sh | retrieves GitHub PAT from Vault, configures `gh auth` |
| heartbeat-pulse.sh | health-check loop emitting pulse events |
| escalate-stale-blockers.py | finds blockers past SLA, escalates |
| push-ci-fix.sh | commit + push to current branch (CI-fix one-liner) |

## Verification

- `pnpm install` — clean
- `pnpm --filter @stolution/mcp-server typecheck` — clean
- `pnpm build` — 28/28 turbo tasks pass (was 27 before this PR)

## Source-of-truth

Per matrix Section 1.1 + 1.7 + 1.15 Batch I.
