### PR TITLE
fix(dashboard): align WS consumer to ConductorEvent envelope (DASH-101)

### DIFF
--- a/apps/dashboard/hooks/useWebSocket.ts
+++ b/apps/dashboard/hooks/useWebSocket.ts
@@ -1,12 +1,80 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 
+/**
+ * Normalized WS event shape consumed by dashboard pages.
+ *
+ * The orchestrator ships canonical `ConductorEvent` envelopes over WS where
+ * the discriminating field is `type` (and timestamp lives in `occurred_at`,
+ * project in `project_slug`). The dashboard's hooks/components were originally
+ * written against an older shape using `kind` / `ts` / `projectId`, so
+ * `parseWsMessage` adapts the canonical shape to the legacy one. The
+ * connection ack `{kind:'connected'}` is filtered out.
+ *
+ * The `type` field is also preserved so newer code can read it directly.
+ */
 export interface WsEvent {
+  /** Alias of `type` for legacy consumers (`task.completed`, etc.). */
   kind: string;
+  /** Canonical event-type string from the events taxonomy. */
+  type?: string;
   id?: string;
   projectId?: string;
   payload?: unknown;
   ts: string;
+}
+
+/** Shape a WS payload with at least one of the expected discriminators. */
+interface IncomingMessage {
+  kind?: string;
+  type?: string;
+  id?: string;
+  project_slug?: string;
+  projectId?: string;
+  payload?: unknown;
+  occurred_at?: string;
+  ts?: string;
+}
+
+/**
+ * Pure parser exposed for unit tests. Returns `null` for connection acks
+ * and unparseable input, otherwise a normalized `WsEvent`.
+ */
+export function parseWsMessage(raw: string): WsEvent | null {
+  let data: IncomingMessage;
+  try {
+    data = JSON.parse(raw) as IncomingMessage;
+  } catch {
+    return null;
+  }
+
+  // Connection ack — server sends {kind:'connected', ts}
+  if (data.kind === 'connected') return null;
+
+  // Canonical ConductorEvent envelope (field: type)
+  if (typeof data.type === 'string') {
+    return {
+      kind: data.type,
+      type: data.type,
+      id: data.id,
+      projectId: data.project_slug ?? data.projectId,
+      payload: data.payload,
+      ts: data.occurred_at ?? data.ts ?? new Date().toISOString(),
+    };
+  }
+
+  // Legacy WS-only envelope (field: kind)
+  if (typeof data.kind === 'string') {
+    return {
+      kind: data.kind,
+      id: data.id,
+      projectId: data.projectId,
+      payload: data.payload,
+      ts: data.ts ?? new Date().toISOString(),
+    };
+  }
+
+  return null;
 }
 
 export function useWebSocket(url: string) {
@@ -29,12 +97,8 @@ export function useWebSocket(url: string) {
         };
         ws.onerror = () => ws.close();
         ws.onmessage = (msg) => {
-          try {
-            const data = JSON.parse(msg.data as string) as WsEvent;
-            if (data.kind !== 'connected') {
-              setLastEvent(data);
-            }
-          } catch { /* ignore parse errors */ }
+          const evt = parseWsMessage(msg.data as string);
+          if (evt) setLastEvent(evt);
         };
       } catch {
         reconnectTimer = setTimeout(connect, 3000);

--- a/apps/orchestrator/tests/ws/envelope-shape.test.ts
+++ b/apps/orchestrator/tests/ws/envelope-shape.test.ts
@@ -1,0 +1,76 @@
+/**
+ * DASH-101 — guard the WS-envelope contract.
+ *
+ * The dashboard's `useWebSocket` hook (in `apps/dashboard/hooks/useWebSocket.ts`)
+ * normalizes incoming WS messages assuming the orchestrator emits canonical
+ * `ConductorEvent` envelopes with a `type` discriminator. Several dashboard
+ * pages and the layout's nav-badge logic depend on that field. This test
+ * pins the contract: a live WS server must serialize events with `type`
+ * (not the older `kind`) so the dashboard never silently drops messages.
+ */
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import WebSocket from 'ws';
+import { eventBus } from '../../src/events/bus-adapter';
+import { attachWsServer } from '../../src/ws/index';
+
+describe('WS envelope shape (DASH-101)', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll((done) => {
+    server = http.createServer((_req, res) => { res.writeHead(404); res.end(); });
+    attachWsServer(server);
+    server.listen(0, () => {
+      port = (server.address() as AddressInfo).port;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('sends a {kind:connected} ack on open and ConductorEvent envelopes (with `type`) for published events', (done) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/events`);
+    const received: unknown[] = [];
+
+    ws.on('message', (raw) => {
+      const data = JSON.parse(raw.toString()) as Record<string, unknown>;
+      received.push(data);
+
+      // First message: connection ack.
+      if (received.length === 1) {
+        expect(data.kind).toBe('connected');
+        // Once the connection ack is received, publish a real event.
+        eventBus.publish({
+          type: 'task.created',
+          actor: 'user',
+          entity_id: 'tsk_dash101',
+          payload: { task_id: 'tsk_dash101', title: 'envelope-shape-test' },
+        });
+        return;
+      }
+
+      // Second message: real ConductorEvent envelope.
+      try {
+        // The discriminator MUST be `type` (DASH-101). If the server were to
+        // emit `kind` instead, the dashboard's `useWebSocket` would treat
+        // every event as the connection ack and drop it.
+        expect(data.type).toBe('task.created');
+        expect(data.actor).toBe('user');
+        expect(data.entity_id).toBe('tsk_dash101');
+        expect(data.payload).toMatchObject({ task_id: 'tsk_dash101' });
+        // `kind` must NOT be set on real events (would collide with the ack).
+        expect(data.kind).toBeUndefined();
+        ws.close();
+        done();
+      } catch (err) {
+        ws.close();
+        done(err as Error);
+      }
+    });
+
+    ws.on('error', (err) => done(err));
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary
DASH-101 from the gap analysis. The orchestrator's WS server ships canonical `ConductorEvent` envelopes with `type` as the discriminator, but the dashboard's `useWebSocket` hook was reading `data.kind` — so every real-time event was silently dropped on every subscribed page (timeline, task-runs, layout nav badges).

## Fix
- `useWebSocket` now parses payloads through a new `parseWsMessage` helper that normalizes `ConductorEvent` (`type`, `occurred_at`, `project_slug`) into the legacy `WsEvent` shape (`kind`, `ts`, `projectId`) while still filtering the `{kind:'connected'}` ack
- The `type` field is preserved so newer consumers can read it directly
- No consumer code changes — backward compatible
- Adds `apps/orchestrator/tests/ws/envelope-shape.test.ts` to pin the server-side contract: a live WS server must emit an envelope with `type` (not `kind`) for real events

## Tests
```
PASS tests/ws/envelope-shape.test.ts
  WS envelope shape (DASH-101)
    ✓ sends a {kind:connected} ack on open and ConductorEvent envelopes (with type) for published events (12 ms)
```

## Refs
caia-dashboard-gap-analysis-2026-04-28.md (DASH-101)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved WebSocket message parsing to standardize event handling and ensure consistent data normalization across different message formats.

* **Tests**
  * Added automated contract testing for WebSocket event envelopes to validate data integrity and proper message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->