### PR TITLE
fix(orchestrator): repair pulse_runs + missing behavior/build tables (DASH-208/209/210)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0013_pulse.sql
+++ b/apps/orchestrator/src/db/migrations/0013_pulse.sql
@@ -1,7 +1,13 @@
 -- Migration 0013: Pipeline Pulse — health-check run tracking
 -- One row per `conductor pulse` invocation. Stores all 3-layer results.
+--
+-- NOTE (DASH-208/209/210): made idempotent so that downstream migration 0015
+-- can repair databases where `pulse_runs` was created with a divergent schema
+-- by older code paths. With CREATE TABLE IF NOT EXISTS this migration is a
+-- no-op on those DBs; 0015 then drops and rebuilds the table to the canonical
+-- shape. On a fresh DB this still creates the table on first run.
 
-CREATE TABLE `pulse_runs` (
+CREATE TABLE IF NOT EXISTS `pulse_runs` (
   `id` text PRIMARY KEY NOT NULL,
   `ran_at` text NOT NULL,
   `outcome` text NOT NULL,
@@ -13,6 +19,6 @@ CREATE TABLE `pulse_runs` (
   `duration_ms` integer NOT NULL DEFAULT 0
 );
 --> statement-breakpoint
-CREATE INDEX `pulse_runs_ran_at_idx` ON `pulse_runs` (`ran_at` DESC);
+CREATE INDEX IF NOT EXISTS `pulse_runs_ran_at_idx` ON `pulse_runs` (`ran_at` DESC);
 --> statement-breakpoint
-CREATE INDEX `pulse_runs_outcome_idx` ON `pulse_runs` (`outcome`);
+CREATE INDEX IF NOT EXISTS `pulse_runs_outcome_idx` ON `pulse_runs` (`outcome`);

--- a/apps/orchestrator/src/db/migrations/0016_backfill_root_prompt_id.sql
+++ b/apps/orchestrator/src/db/migrations/0016_backfill_root_prompt_id.sql
@@ -10,7 +10,6 @@
 -- Tasks whose parent entity is a requirement inherit its root_prompt_id.
 -- Tasks default root_prompt_id to 'untraced'; treat both NULL and 'untraced'
 -- as candidates for backfill.
---> statement-breakpoint
 UPDATE tasks
 SET root_prompt_id = (
   SELECT r.root_prompt_id

--- a/apps/orchestrator/src/db/migrations/0020_dash_208_210_repair.sql
+++ b/apps/orchestrator/src/db/migrations/0020_dash_208_210_repair.sql
@@ -1,0 +1,161 @@
+-- Migration 0015 — DASH-208/209/210 schema repair
+--
+-- Three dashboard endpoints (`/behavior-tests*`, `/builds`, `/pulse/*`) were
+-- returning HTTP 500. Root cause is a divergent state between the drizzle
+-- schema and dev/prod databases:
+--
+--   1. `pulse_runs` was created by an older code path (in pipeline-pulse)
+--      with the legacy schema `(run_id PK, raw_json blob, ...)` instead of
+--      the canonical drizzle schema `(id PK, canary_id, canary_elapsed_ms,
+--      checks_json, invariants_json, heals_json, ...)`. Every
+--      `db.select().from(pulseRuns)` query then hit a "no such column: id"
+--      error. We DROP and recreate to match drizzle exactly. The few rows
+--      that may live there are short-lived health-check ticks; data loss
+--      is acceptable.
+--
+--   2. `behavior_tests`, `behavior_test_runs`, `behavior_test_failures`
+--      were marked applied in `__drizzle_migrations` (idx 5) but the
+--      tables were dropped from some dev/staging databases. We CREATE
+--      TABLE IF NOT EXISTS so this migration is a no-op on databases
+--      where the tables already exist (matching schema).
+--
+--   3. `build_runs`, `build_steps`, `build_retries` — same situation as
+--      (2), via migration 0009. Same fix.
+--
+-- This migration is idempotent: safe to run on a fresh CI database (where
+-- migrations 0005, 0009, 0013 already created the tables — the IF NOT
+-- EXISTS clauses make this a no-op for them, and the pulse_runs DROP/
+-- recreate is a roundtrip with no logical effect).
+
+DROP TABLE IF EXISTS `pulse_runs`;
+--> statement-breakpoint
+CREATE TABLE `pulse_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `ran_at` text NOT NULL,
+  `outcome` text NOT NULL,
+  `canary_id` text,
+  `canary_elapsed_ms` integer,
+  `checks_json` text NOT NULL DEFAULT '[]',
+  `invariants_json` text NOT NULL DEFAULT '[]',
+  `heals_json` text NOT NULL DEFAULT '[]',
+  `duration_ms` integer NOT NULL DEFAULT 0
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `pulse_runs_ran_at_idx` ON `pulse_runs` (`ran_at` DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `pulse_runs_outcome_idx` ON `pulse_runs` (`outcome`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `behavior_tests` (
+  `id` text PRIMARY KEY NOT NULL,
+  `name` text NOT NULL,
+  `feature` text NOT NULL,
+  `scope` text NOT NULL,
+  `project_slug` text,
+  `domain_slugs` text NOT NULL DEFAULT '[]',
+  `source_path` text,
+  `first_seen_at` text NOT NULL,
+  `last_seen_at` text NOT NULL,
+  `expected_behavior` text NOT NULL DEFAULT '',
+  `layout_contract` text,
+  `notes` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `bt_name_feature_idx` ON `behavior_tests` (`name`, `feature`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bt_project_idx` ON `behavior_tests` (`project_slug`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bt_feature_idx` ON `behavior_tests` (`feature`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `behavior_test_runs` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `test_id` text NOT NULL,
+  `run_at` text NOT NULL,
+  `duration_ms` integer,
+  `status` text NOT NULL DEFAULT 'skip',
+  `evidence_url` text,
+  `failure_excerpt` text,
+  `git_sha` text,
+  `ci` integer NOT NULL DEFAULT 0,
+  FOREIGN KEY (`test_id`) REFERENCES `behavior_tests`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `btr_test_idx` ON `behavior_test_runs` (`test_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `btr_run_at_idx` ON `behavior_test_runs` (`run_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `btr_status_idx` ON `behavior_test_runs` (`status`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `behavior_test_failures` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `test_run_id` integer NOT NULL,
+  `conductor_blocker_id` text,
+  `kind` text NOT NULL DEFAULT 'regression',
+  `message` text NOT NULL DEFAULT '',
+  `stack_excerpt` text,
+  FOREIGN KEY (`test_run_id`) REFERENCES `behavior_test_runs`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `btf_run_idx` ON `behavior_test_failures` (`test_run_id`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `build_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `trigger` text NOT NULL DEFAULT 'user',
+  `git_sha` text,
+  `branch` text,
+  `changed_files_json` text NOT NULL DEFAULT '[]',
+  `status` text NOT NULL DEFAULT 'running',
+  `outcome` text,
+  `started_at` text NOT NULL,
+  `ended_at` text,
+  `duration_ms` integer,
+  `steps_total` integer NOT NULL DEFAULT 0,
+  `steps_failed` integer NOT NULL DEFAULT 0,
+  `error_signature` text,
+  `metadata_json` text NOT NULL DEFAULT '{}'
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `br_status_idx` ON `build_runs` (`status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `br_started_idx` ON `build_runs` (`started_at` DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `br_git_sha_idx` ON `build_runs` (`git_sha`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `build_steps` (
+  `id` text PRIMARY KEY NOT NULL,
+  `build_run_id` text NOT NULL REFERENCES `build_runs`(`id`),
+  `step_name` text NOT NULL,
+  `command` text NOT NULL,
+  `step_order` integer NOT NULL DEFAULT 0,
+  `status` text NOT NULL DEFAULT 'running',
+  `exit_code` integer,
+  `started_at` text NOT NULL,
+  `ended_at` text,
+  `duration_ms` integer,
+  `stdout_tail` text,
+  `stderr_tail` text,
+  `error_signature` text,
+  `max_rss_bytes` integer
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bs_run_idx` ON `build_steps` (`build_run_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bs_status_idx` ON `build_steps` (`status`);
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `build_retries` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `build_run_id` text NOT NULL REFERENCES `build_runs`(`id`),
+  `build_step_id` text NOT NULL REFERENCES `build_steps`(`id`),
+  `attempt_n` integer NOT NULL DEFAULT 1,
+  `exit_code` integer,
+  `started_at` text NOT NULL,
+  `ended_at` text,
+  `error_signature` text
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bret_run_idx` ON `build_retries` (`build_run_id`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1746400000000,
       "tag": "0019_entity_labels",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1777400000000,
+      "tag": "0020_dash_208_210_repair",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/tests/db/dash-208-210-repair.test.ts
+++ b/apps/orchestrator/tests/db/dash-208-210-repair.test.ts
@@ -1,0 +1,111 @@
+/**
+ * DASH-208/209/210 — guard the schema-repair migration.
+ *
+ * The /behavior-tests*, /builds, and /pulse/* routes were returning HTTP 500
+ * because three drizzle-defined tables either didn't exist (behavior_tests*,
+ * build_runs*) or had a divergent schema (`pulse_runs` was created by an
+ * older code path with `run_id PK` and a `raw_json` blob instead of the
+ * canonical `id PK / canary_id / canary_elapsed_ms / checks_json /
+ * invariants_json / heals_json` shape).
+ *
+ * Migration 0020 reconciles all three. This test pins:
+ *   1. running migrations on a pre-existing DB that already has a wrongly-
+ *      shaped pulse_runs table succeeds (no "table already exists" error);
+ *   2. after migration, every drizzle table the failing routes touch can be
+ *      queried without throwing a "no such column" error.
+ */
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { resetDb, getDb, runMigrations } from '../../src/db/connection';
+import { behaviorTests, behaviorTestRuns, behaviorTestFailures, buildRuns, buildSteps, buildRetries, pulseRuns } from '../../src/db/schema';
+import { desc } from 'drizzle-orm';
+
+describe('DASH-208/209/210 schema repair (migration 0020)', () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-dash-repair-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    resetDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  });
+
+  it('applies cleanly to a fresh database and creates all repaired tables', () => {
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+
+    // Each of these would have thrown SqliteError("no such table") or
+    // ("no such column: id") before the repair migration.
+    expect(db.select().from(behaviorTests).all()).toEqual([]);
+    expect(db.select().from(behaviorTestRuns).all()).toEqual([]);
+    expect(db.select().from(behaviorTestFailures).all()).toEqual([]);
+    expect(db.select().from(buildRuns).all()).toEqual([]);
+    expect(db.select().from(buildSteps).all()).toEqual([]);
+    expect(db.select().from(buildRetries).all()).toEqual([]);
+    expect(db.select().from(pulseRuns).orderBy(desc(pulseRuns.ranAt)).all()).toEqual([]);
+  });
+
+  it('repairs a database whose pulse_runs was created with the divergent legacy schema', () => {
+    // Simulate the dev/staging reality: pulse_runs already exists with the
+    // older pipeline-pulse schema (run_id PK + raw_json blob).
+    const sqlite = new Database(dbPath);
+    sqlite.exec(`
+      CREATE TABLE pulse_runs (
+        run_id TEXT PRIMARY KEY,
+        ran_at TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        duration_ms INTEGER,
+        triggered_by TEXT,
+        raw_json TEXT,
+        notes TEXT
+      );
+      INSERT INTO pulse_runs (run_id, ran_at, outcome, duration_ms, triggered_by, raw_json)
+      VALUES ('pulse_pre', '2026-04-01T00:00:00Z', 'PASSING', 100, 'legacy', '{}');
+    `);
+    sqlite.close();
+
+    // Migrations must apply cleanly — 0013 is now CREATE TABLE IF NOT EXISTS
+    // (no-op here), and 0015 drops + recreates with the correct schema.
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+
+    // Drizzle-shape select would fail with "no such column: id" against the
+    // legacy schema; this confirms the column rebuild succeeded.
+    const rows = db.select().from(pulseRuns).orderBy(desc(pulseRuns.ranAt)).all();
+    expect(rows).toEqual([]);
+
+    // Verify the new schema is present by inserting a canonical row.
+    db.insert(pulseRuns).values({
+      id: 'pulse_after',
+      ranAt: '2026-04-28T00:00:00Z',
+      outcome: 'PASSING',
+      canaryId: 'canary_x',
+      canaryElapsedMs: 1234,
+      checksJson: '[]',
+      invariantsJson: '[]',
+      healsJson: '[]',
+      durationMs: 1234,
+    }).run();
+
+    const all = db.select().from(pulseRuns).all();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.id).toBe('pulse_after');
+    expect(all[0]?.canaryId).toBe('canary_x');
+  });
+
+  it('is idempotent: re-running migrations on a repaired database is a no-op', () => {
+    runMigrations(dbPath);
+    resetDb();
+    // Second run should not throw.
+    expect(() => runMigrations(dbPath)).not.toThrow();
+    const db = getDb(dbPath);
+    expect(db.select().from(pulseRuns).all()).toEqual([]);
+    expect(db.select().from(behaviorTests).all()).toEqual([]);
+    expect(db.select().from(buildRuns).all()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
DASH-208/209/210 from the gap analysis. Five dashboard pages (`/tests`, `/tests/[id]`, `/builds`, `/builds/[id]`, `/health/pulse`) were fully broken because three orchestrator endpoints returned HTTP 500.

## Diagnosis
Three drizzle-defined tables either didn't exist or had a divergent schema:

1. **pulse_runs** — created by an older code path with legacy schema `(run_id PK, raw_json blob, ...)` instead of the canonical `(id PK, canary_id, canary_elapsed_ms, checks_json, invariants_json, heals_json, duration_ms)`. Every `db.select().from(pulseRuns)` then hit "no such column: id".

2. **behavior_tests / behavior_test_runs / behavior_test_failures** — marked applied in `__drizzle_migrations` (idx 5) but the tables had been dropped from some dev/staging DBs.

3. **build_runs / build_steps / build_retries** — same situation as (2), via migration 0009.

Plus an unrelated regression in main:

4. **0016_backfill_root_prompt_id.sql** — drizzle's better-sqlite3 migrator splits on `--> statement-breakpoint` and the first chunk before the first separator was comments-only, which throws `RangeError: The supplied SQL string contains no statements`. Removed the leading separator so the comment header is part of the first UPDATE chunk (sqlite tolerates leading comments fine).

## Fix
- New migration `0020_dash_208_210_repair.sql` that DROPs the divergent `pulse_runs` and rebuilds it to the canonical shape, and creates the missing behavior/build tables with `CREATE TABLE IF NOT EXISTS`.
- `0013_pulse.sql` made idempotent (`CREATE TABLE IF NOT EXISTS`) so it can't conflict with an existing table on a dirty DB; on fresh CI databases the chain still produces identical output.
- `0016_backfill_root_prompt_id.sql` — fix dead-on-arrival migrator failure (separate latent bug surfaced by this test).

## Verification
```
PASS tests/db/dash-208-210-repair.test.ts
  DASH-208/209/210 schema repair (migration 0020)
    ✓ applies cleanly to a fresh database and creates all repaired tables (52 ms)
    ✓ repairs a database whose pulse_runs was created with the divergent legacy schema (26 ms)
    ✓ is idempotent: re-running migrations on a repaired database is a no-op (30 ms)
```

Local against a copy of `~/.conductor/db.sqlite`:
```
GET /behavior-tests              → 200 []
GET /behavior-tests/coverage     → 200 {total:0,...}
GET /builds                      → 200 {builds:[],total:0}
GET /pulse/runs                  → 200 {runs:[],total:0}
GET /pulse/stats                 → 200 {latest:null,runs:[],...}
GET /behavior-tests/missing/runs → 404 (correct — was 500)
GET /builds/missing              → 404 (correct — was 500)
GET /pulse/runs/missing          → 404 (correct — was 500)
```

## Refs
caia-dashboard-gap-analysis-2026-04-28.md (DASH-208, DASH-209, DASH-210)