### PR TITLE
fix(executor): stamp correlation_id on lifecycle events (DASH-107)

### DIFF
--- a/apps/executor/completion-hook.ts
+++ b/apps/executor/completion-hook.ts
@@ -151,8 +151,8 @@ export async function handleCompletion(
     await markTaskDone(handle.taskId, parsed.sessionId);
 
     // Legacy events (retained for existing consumers)
-    await publishEvent('task.completed', { task_id: handle.taskId, duration_ms: durationMs, result_summary: parsed.summary });
-    await publishEvent('worker.completed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? 0, turn_count: parsed.turnCount });
+    await publishEvent('task.completed', { task_id: handle.taskId, duration_ms: durationMs, result_summary: parsed.summary }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
+    await publishEvent('worker.completed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? 0, turn_count: parsed.turnCount }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
 
     // Per-tool-call events (fire-and-forget — no await)
     for (const tc of rich.toolCalls) {
@@ -283,8 +283,8 @@ export async function handleCompletion(
     );
 
     // Legacy events (retained for existing consumers)
-    await publishEvent('task.failed', { task_id: handle.taskId, failure_reason: reason, attempt_n: newAttemptCount });
-    await publishEvent('worker.failed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? -1, failure_reason: reason });
+    await publishEvent('task.failed', { task_id: handle.taskId, failure_reason: reason, attempt_n: newAttemptCount }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
+    await publishEvent('worker.failed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? -1, failure_reason: reason }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
 
     // Structured failure event
     await publishEvent('executor.task.failed', {

--- a/apps/executor/dispatcher.ts
+++ b/apps/executor/dispatcher.ts
@@ -249,17 +249,15 @@ export async function dispatch(
 
   const executorRunId = await registerExecutorRun(task.id, pid, worktreePath, attemptN);
 
-  // Emit worker.spawned via API
-  try {
-    await fetch(`${API_BASE}/events`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        type: 'worker.spawned', actor: 'executor',
-        payload: { executor_run_id: executorRunId, task_id: task.id, pid, worktree_path: worktreePath },
-      }),
-    });
-  } catch { /* non-fatal */ }
+  // Emit worker.spawned via API.
+  // DASH-107: stamp correlation_id (task.rootPromptId) and entity attribution
+  // so /prompts/:id/journey can attribute the spawned worker to the originating
+  // prompt across the executor → worker boundary.
+  await publishEvent(
+    'worker.spawned',
+    { executor_run_id: executorRunId, task_id: task.id, pid, worktree_path: worktreePath },
+    { correlationId: task.rootPromptId ?? null, entityType: 'task', entityId: task.id },
+  );
 
   // Emit structured pick-up event for observability pipeline
   await publishEvent('executor.task.picked_up', {
@@ -270,7 +268,7 @@ export async function dispatch(
     worktreePath,
     model,
     attemptN,
-  });
+  }, { correlationId: task.rootPromptId ?? null, entityType: 'task', entityId: task.id });
 
   return {
     taskId: task.id,

--- a/apps/executor/publish-event.ts
+++ b/apps/executor/publish-event.ts
@@ -4,19 +4,44 @@
  * Emits structured events to the orchestrator's /events endpoint.
  * Never throws — all errors are swallowed so event publishing can never
  * crash the executor process.
+ *
+ * DASH-107: events stamped via this helper now propagate `correlation_id`
+ * (the originating prompt's id, threaded through the executor boundary)
+ * plus `entity_type` / `entity_id` so the orchestrator can attribute
+ * downstream events to a task. /prompts/:id/journey and
+ * /prompts/:id/events?correlation_id=... need this to build a complete
+ * trace across the executor → worker hop.
  */
 
 const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
 
+export interface PublishEventOpts {
+  /** Originating prompt id; usually `task.rootPromptId`. May be `'untraced'`. */
+  correlationId?: string | null;
+  /** Entity type for attribution, e.g. `'task'`. */
+  entityType?: string;
+  /** Entity id for attribution, e.g. the task id. */
+  entityId?: string;
+}
+
 export async function publishEvent(
   type: string,
   payload: Record<string, unknown>,
+  opts: PublishEventOpts = {},
 ): Promise<void> {
   try {
     await fetch(`${ORCHESTRATOR_URL}/events`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type, actor: 'executor', payload, timestamp: Date.now() }),
+      body: JSON.stringify({
+        type,
+        actor: 'executor',
+        payload,
+        timestamp: Date.now(),
+        correlation_id: opts.correlationId ?? undefined,
+        entity_type: opts.entityType,
+        entity_id: opts.entityId,
+      }),
     });
   } catch (err) {
     // Never let event publishing crash the executor

--- a/apps/orchestrator/tests/api/dash-107-correlation.test.ts
+++ b/apps/orchestrator/tests/api/dash-107-correlation.test.ts
@@ -1,0 +1,110 @@
+/**
+ * DASH-107 — guard the executor's correlation_id propagation.
+ *
+ * Before DASH-107, four lifecycle events emitted by the executor
+ * (`task.completed`, `task.failed`, `worker.completed`, `worker.failed`)
+ * plus `worker.spawned` from the dispatcher crossed the executor boundary
+ * without `correlation_id`. As a result, `/prompts/:id/journey` undercounted
+ * events and `/prompts/:id/events?correlation_id=...` returned an
+ * incomplete trace.
+ *
+ * The fix: every executor publishEvent call now passes a `correlationId`
+ * (the originating prompt id, threaded via `task.rootPromptId`) plus
+ * `entity_type='task'` and `entity_id=<taskId>` so the orchestrator can
+ * persist the join.
+ *
+ * This test pins the contract end-to-end: a POST /events with
+ * `correlation_id` + `entity_type` + `entity_id` is persisted such that
+ * `/events?correlation_id=...` returns the row, and the public events
+ * endpoint exposes the correlation_id field.
+ */
+import { Hono } from 'hono';
+import { resetDb, getDb, runMigrations } from '../../src/db/connection';
+import { registerEventsRoutes } from '../../src/api/routes/events';
+import { wireEventBus } from '../../src/events/bus-adapter';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+describe('DASH-107 correlation_id propagation through /events', () => {
+  let app: Hono;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-dash107-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+    resetDb();
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+    wireEventBus(db);
+    app = new Hono();
+    registerEventsRoutes(app, db);
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    delete process.env.CONDUCTOR_DB_PATH;
+  });
+
+  it('persists correlation_id from executor lifecycle events and returns them via /events', async () => {
+    // Simulate the 5 executor-emitted events that DASH-107 fixed
+    const promptId = 'prm_dash107_test';
+    const taskId = 'tsk_dash107_test';
+    const types = [
+      'worker.spawned',
+      'task.completed',
+      'task.failed',
+      'worker.completed',
+      'worker.failed',
+    ];
+
+    for (const type of types) {
+      const res = await app.request('/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type,
+          actor: 'executor',
+          payload: { task_id: taskId },
+          correlation_id: promptId,
+          entity_type: 'task',
+          entity_id: taskId,
+        }),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // Filter by correlation_id — should return all 5
+    const filtered = await app.request(`/events?correlation_id=${promptId}`);
+    expect(filtered.status).toBe(200);
+    const filteredBody = await filtered.json() as { events: Array<{ type: string; correlation_id: string | null }>; total: number };
+    expect(filteredBody.events.length).toBe(5);
+    expect(filteredBody.total).toBe(5);
+    for (const e of filteredBody.events) {
+      expect(e.correlation_id).toBe(promptId);
+      expect(types).toContain(e.type);
+    }
+  });
+
+  it('events emitted WITHOUT correlation_id are not surfaced when filtering by correlation_id', async () => {
+    const promptId = 'prm_no_match';
+    // Pre-fix regression: emit events with no correlation_id
+    for (const type of ['task.completed', 'worker.completed']) {
+      await app.request('/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type,
+          actor: 'executor',
+          payload: { task_id: 'tsk_orphan' },
+        }),
+      });
+    }
+    const res = await app.request(`/events?correlation_id=${promptId}`);
+    const body = await res.json() as { events: unknown[]; total: number };
+    expect(body.events.length).toBe(0);
+    expect(body.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
DASH-107 from the gap analysis. The executor process emits 5 lifecycle events that previously crossed the orchestrator boundary without `correlation_id`, so `/prompts/:id/journey` undercounted events and `/prompts/:id/events?correlation_id=...` returned an incomplete trace.

Affected events:
- `apps/executor/dispatcher.ts` → `worker.spawned`
- `apps/executor/completion-hook.ts` → `task.completed`, `task.failed`, `worker.completed`, `worker.failed`

## Fix
1. `publish-event.ts` extends the helper signature with optional `PublishEventOpts` ({`correlationId`, `entityType`, `entityId`}). Purely additive — orchestrator already persists these fields.
2. `dispatcher.ts` converts the raw fetch for `worker.spawned` to `publishEvent` and stamps it with `correlationId: task.rootPromptId` plus `entity_type='task' / entity_id=task.id`. Same opts on `executor.task.picked_up`.
3. `completion-hook.ts` passes the same opts on the 4 legacy lifecycle emits.

For tasks that didn't originate from a prompt the DB carries the sentinel `'untraced'` (migration 0014); propagated as-is.

## Tests
```
PASS tests/api/dash-107-correlation.test.ts
  DASH-107 correlation_id propagation through /events
    ✓ persists correlation_id from executor lifecycle events and returns them via /events
    ✓ events emitted WITHOUT correlation_id are not surfaced when filtering by correlation_id
```

## Note on overlap with #60
This PR also includes a fix to `0016_backfill_root_prompt_id.sql` (drizzle migrator failed because the first chunk was comments-only). The same fix is in #60 (DASH-208/209/210). Whichever lands first makes the other trivially mergable.

## Refs
caia-dashboard-gap-analysis-2026-04-28.md (DASH-107)