### PR TITLE
fix(dashboard): wire /audit page to /api/audit (DASH-201)

### DIFF
--- a/apps/dashboard/app/api/audit/route.ts
+++ b/apps/dashboard/app/api/audit/route.ts
@@ -1,0 +1,31 @@
+/**
+ * /api/audit — proxy for the orchestrator's /audit endpoint.
+ *
+ * DASH-201: the dashboard's /audit and /audit/[entityKind]/[entityId]
+ * pages historically fetched /api/events, which returned ConductorEvent
+ * envelopes (`type`, `payload`, `occurred_at`) but the page typed them
+ * as AuditEntry (`actor`, `action`, `entityKind`, `entityId`, `before`,
+ * `after`, `projectId`, `createdAt`). The shape mismatch made the page
+ * empty in practice. This proxy forwards to the real /audit route.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function GET(request: NextRequest) {
+  const params = new URLSearchParams();
+  for (const [k, v] of request.nextUrl.searchParams.entries()) {
+    params.set(k, v);
+  }
+  const qs = params.toString();
+  const url = qs ? `${CONDUCTOR_URL}/audit?${qs}` : `${CONDUCTOR_URL}/audit`;
+
+  try {
+    const res = await fetch(url, { next: { revalidate: 0 } });
+    if (!res.ok) return NextResponse.json([], { status: 200 });
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json([], { status: 200 });
+  }
+}

--- a/apps/dashboard/app/audit/[entityKind]/[entityId]/page.tsx
+++ b/apps/dashboard/app/audit/[entityKind]/[entityId]/page.tsx
@@ -20,7 +20,7 @@ export default function EntityAuditPage({ params }: { params: { entityKind: stri
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('/api/events')
+    fetch('/api/audit')
       .then(r => r.json())
       .then((data: unknown) => {
         if (Array.isArray(data)) {

--- a/apps/dashboard/app/audit/page.tsx
+++ b/apps/dashboard/app/audit/page.tsx
@@ -30,8 +30,8 @@ function AuditContent() {
 
   useEffect(() => {
     setLoading(true);
-    // Fetch from events endpoint as proxy for audit log
-    fetch('/api/events')
+    // Fetch from /api/audit (proxy to orchestrator /audit, returns AuditEntry shape — DASH-201)
+    fetch('/api/audit')
       .then(r => r.json())
       .then((data: unknown) => {
         if (Array.isArray(data)) {


### PR DESCRIPTION
## Summary
DASH-201 from the gap analysis. The `/audit` and `/audit/[entityKind]/[entityId]` pages fetched `/api/events` (which returns ConductorEvent envelopes) but the pages typed rows as AuditEntry — a shape mismatch that emptied the page in practice.

## Fix
1. New `/api/audit` proxy forwards to `{CONDUCTOR_URL}/audit`.
2. Both audit pages now call `/api/audit`.

## Verification
```
GET localhost:7776/audit?limit=2 → AuditEntry[] (shape verified)
```

## Refs
caia-dashboard-gap-analysis-2026-04-28.md (DASH-201)