### PR TITLE
feat(orchestrator): add blocker/question/requirement writers + events (DASH-205/206/207)

### DIFF
--- a/apps/orchestrator/src/api/routes/legacy.ts
+++ b/apps/orchestrator/src/api/routes/legacy.ts
@@ -3,6 +3,11 @@ import { eq } from 'drizzle-orm';
 import type { Db } from '../../db/connection';
 import { requirements, blockers, questions, tasks } from '../../db/schema';
 import { getEntityIdsForDomains } from './domains';
+import { eventBus } from '../../events/bus-adapter';
+
+function genId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
 
 function parseJson<T>(s: string | null | undefined): T {
   if (!s) return [] as unknown as T;
@@ -124,5 +129,194 @@ export function registerLegacyRoutes(app: Hono, db: Db): void {
       qRows = qRows.filter(r => r.projectId === projectId);
     }
     return c.json({ openBlockers: blkRows.length, openQuestions: qRows.length });
+  });
+
+  // ─── Writers (DASH-205/206/207) ─────────────────────────────────────────
+  // POST /blockers — create a new blocker (proxy already POSTs; backend was read-only)
+  app.post('/blockers', async (c) => {
+    const body = await c.req.json() as Partial<typeof blockers.$inferInsert>;
+    if (!body.title) return c.json({ error: 'title is required' }, 400);
+    const now = new Date().toISOString();
+    const row: typeof blockers.$inferInsert = {
+      id: body.id ?? genId('blk'),
+      title: body.title,
+      severity: body.severity ?? 'normal',
+      kind: body.kind ?? 'info',
+      description: body.description ?? '',
+      resolutionSteps: body.resolutionSteps ?? '[]',
+      approvalButton: body.approvalButton ?? null,
+      links: body.links ?? '[]',
+      state: body.state ?? 'open',
+      requirementId: body.requirementId ?? null,
+      taskId: body.taskId ?? null,
+      resolvedAt: body.resolvedAt ?? null,
+      resolvedBy: body.resolvedBy ?? null,
+      resolutionNote: body.resolutionNote ?? null,
+      projectId: body.projectId ?? null,
+      scope: body.scope ?? 'global',
+      createdAt: body.createdAt ?? now,
+      rootPromptId: body.rootPromptId ?? null,
+      parentEntityType: body.parentEntityType ?? null,
+      parentEntityId: body.parentEntityId ?? null,
+    };
+    db.insert(blockers).values(row).run();
+    eventBus.publish({
+      type: 'blocker.created',
+      actor: 'api',
+      entity_type: 'blocker',
+      entity_id: row.id,
+      payload: { blocker_id: row.id, title: row.title, severity: row.severity, kind: row.kind },
+    });
+    return c.json(row, 201);
+  });
+
+  // POST /blockers/:id/resolve — flip to resolved + emit event
+  app.post('/blockers/:id/resolve', async (c) => {
+    const id = c.req.param('id');
+    const body = await c.req.json().catch(() => ({})) as { resolution_note?: string; resolved_by?: string };
+    const existing = db.select().from(blockers).where(eq(blockers.id, id)).get();
+    if (!existing) return c.json({ error: 'Not found' }, 404);
+    if (existing.state === 'resolved') return c.json({ ...existing, alreadyResolved: true });
+
+    const now = new Date().toISOString();
+    db.update(blockers).set({
+      state: 'resolved',
+      resolvedAt: now,
+      resolvedBy: body.resolved_by ?? 'api',
+      resolutionNote: body.resolution_note ?? null,
+    }).where(eq(blockers.id, id)).run();
+
+    eventBus.publish({
+      type: 'blocker.resolved',
+      actor: 'api',
+      entity_type: 'blocker',
+      entity_id: id,
+      payload: {
+        blocker_id: id,
+        resolved_by: body.resolved_by ?? 'api',
+        resolution_note: body.resolution_note ?? null,
+      },
+    });
+
+    const updated = db.select().from(blockers).where(eq(blockers.id, id)).get();
+    return c.json(updated);
+  });
+
+  // POST /questions — create a new question
+  app.post('/questions', async (c) => {
+    const body = await c.req.json() as Partial<typeof questions.$inferInsert>;
+    if (!body.title) return c.json({ error: 'title is required' }, 400);
+    const now = new Date().toISOString();
+    const row: typeof questions.$inferInsert = {
+      id: body.id ?? genId('qst'),
+      title: body.title,
+      priority: body.priority ?? 'normal',
+      context: body.context ?? '',
+      recommendations: body.recommendations ?? '[]',
+      customAnswerPlaceholder: body.customAnswerPlaceholder ?? null,
+      state: body.state ?? 'open',
+      requirementId: body.requirementId ?? null,
+      taskId: body.taskId ?? null,
+      answer: body.answer ?? null,
+      answeredAt: body.answeredAt ?? null,
+      projectId: body.projectId ?? null,
+      scope: body.scope ?? 'global',
+      createdAt: body.createdAt ?? now,
+      rootPromptId: body.rootPromptId ?? null,
+      parentEntityType: body.parentEntityType ?? null,
+      parentEntityId: body.parentEntityId ?? null,
+    };
+    db.insert(questions).values(row).run();
+    eventBus.publish({
+      type: 'question.created',
+      actor: 'api',
+      entity_type: 'question',
+      entity_id: row.id,
+      payload: { question_id: row.id, title: row.title, priority: row.priority },
+    });
+    return c.json(row, 201);
+  });
+
+  // POST /questions/:id/answer — record an answer + emit event
+  app.post('/questions/:id/answer', async (c) => {
+    const id = c.req.param('id');
+    const body = await c.req.json().catch(() => ({})) as { answer?: unknown };
+    if (body.answer == null) return c.json({ error: 'answer is required' }, 400);
+    const existing = db.select().from(questions).where(eq(questions.id, id)).get();
+    if (!existing) return c.json({ error: 'Not found' }, 404);
+
+    const now = new Date().toISOString();
+    const answerJson = typeof body.answer === 'string' ? body.answer : JSON.stringify(body.answer);
+
+    db.update(questions).set({
+      answer: answerJson,
+      answeredAt: now,
+      state: 'answered',
+    }).where(eq(questions.id, id)).run();
+
+    eventBus.publish({
+      type: 'question.answered',
+      actor: 'api',
+      entity_type: 'question',
+      entity_id: id,
+      payload: { question_id: id, answer_summary: typeof body.answer === 'string' ? body.answer.slice(0, 200) : '<json>' },
+    });
+
+    const updated = db.select().from(questions).where(eq(questions.id, id)).get();
+    return c.json(updated);
+  });
+
+  // GET /questions/:id — fetch single question
+  app.get('/questions/:id', (c) => {
+    const row = db.select().from(questions).where(eq(questions.id, c.req.param('id'))).get();
+    if (!row) return c.json({ error: 'Not found' }, 404);
+    return c.json({ ...row, recommendations: parseJson(row.recommendations), answer: row.answer ? parseJson(row.answer) : undefined });
+  });
+
+  // PATCH /questions/:id — update fields
+  app.patch('/questions/:id', async (c) => {
+    const id = c.req.param('id');
+    const body = await c.req.json() as Partial<typeof questions.$inferInsert>;
+    const existing = db.select().from(questions).where(eq(questions.id, id)).get();
+    if (!existing) return c.json({ error: 'Not found' }, 404);
+    db.update(questions).set(body).where(eq(questions.id, id)).run();
+    const updated = db.select().from(questions).where(eq(questions.id, id)).get();
+    return c.json(updated);
+  });
+
+  // POST /requirements — create new requirement (proxy already POSTs; backend was read-only)
+  app.post('/requirements', async (c) => {
+    const body = await c.req.json() as Partial<typeof requirements.$inferInsert>;
+    if (!body.title) return c.json({ error: 'title is required' }, 400);
+    const now = new Date().toISOString();
+    const row: typeof requirements.$inferInsert = {
+      id: body.id ?? genId('req'),
+      title: body.title,
+      description: body.description ?? '',
+      state: body.state ?? 'captured',
+      priority: body.priority ?? 3,
+      labels: body.labels ?? '[]',
+      targetProject: body.targetProject ?? null,
+      estimatedFiles: body.estimatedFiles ?? '[]',
+      dependsOn: body.dependsOn ?? '[]',
+      linkedTaskIds: body.linkedTaskIds ?? '[]',
+      spec: body.spec ?? null,
+      projectId: body.projectId ?? null,
+      scope: body.scope ?? 'global',
+      createdAt: body.createdAt ?? now,
+      updatedAt: body.updatedAt ?? now,
+      rootPromptId: body.rootPromptId ?? null,
+      parentEntityType: body.parentEntityType ?? null,
+      parentEntityId: body.parentEntityId ?? null,
+    };
+    db.insert(requirements).values(row).run();
+    eventBus.publish({
+      type: 'requirement.created',
+      actor: 'api',
+      entity_type: 'requirement',
+      entity_id: row.id,
+      payload: { requirement_id: row.id, title: row.title, state: row.state, priority: row.priority },
+    });
+    return c.json(row, 201);
   });
 }

--- a/apps/orchestrator/tests/api/dash-205-207-writers.test.ts
+++ b/apps/orchestrator/tests/api/dash-205-207-writers.test.ts
@@ -1,0 +1,158 @@
+/**
+ * DASH-205 / DASH-206 / DASH-207 — guard the new write handlers in
+ * legacy.ts plus the events emitted by them.
+ *
+ * Routes tested:
+ *   POST /blockers, POST /blockers/:id/resolve
+ *   POST /questions, POST /questions/:id/answer, GET /questions/:id, PATCH /questions/:id
+ *   POST /requirements
+ *
+ * Each writer must:
+ *   1. Persist the row.
+ *   2. Emit the matching domain event (blocker.created, blocker.resolved,
+ *      question.created, question.answered, requirement.created).
+ *   3. Return the persisted row.
+ */
+import { Hono } from 'hono';
+import { resetDb, getDb, runMigrations } from '../../src/db/connection';
+import { registerLegacyRoutes } from '../../src/api/routes/legacy';
+import { wireEventBus } from '../../src/events/bus-adapter';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+describe('DASH-205/206/207 writers', () => {
+  let app: Hono;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-dash205-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+    resetDb();
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+    wireEventBus(db);
+    app = new Hono();
+    registerLegacyRoutes(app, db);
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    delete process.env.CONDUCTOR_DB_PATH;
+  });
+
+  describe('DASH-205 POST /blockers/:id/resolve', () => {
+    it('flips state→resolved, persists fields, emits blocker.resolved', async () => {
+      const created = await app.request('/blockers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Test blocker', severity: 'high' }),
+      });
+      expect(created.status).toBe(201);
+      const blkRow = await created.json() as { id: string; state: string };
+      expect(blkRow.state).toBe('open');
+
+      const resolved = await app.request(`/blockers/${blkRow.id}/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ resolution_note: 'fixed by claude', resolved_by: 'claude-orchestrator' }),
+      });
+      expect(resolved.status).toBe(200);
+      const updated = await resolved.json() as { state: string; resolutionNote: string; resolvedBy: string };
+      expect(updated.state).toBe('resolved');
+      expect(updated.resolutionNote).toBe('fixed by claude');
+      expect(updated.resolvedBy).toBe('claude-orchestrator');
+
+      // Event was emitted
+      const events = eventBus.replay({ correlationId: undefined, limit: 50 });
+      const types = events.map(e => e.type);
+      expect(types).toContain('blocker.created');
+      expect(types).toContain('blocker.resolved');
+    });
+
+    it('returns 404 for unknown blocker id', async () => {
+      const res = await app.request('/blockers/blk_does_not_exist/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DASH-206 question writers', () => {
+    it('POST creates → POST /answer flips state → GET single returns it', async () => {
+      const created = await app.request('/questions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Should we ship?', priority: 'high' }),
+      });
+      expect(created.status).toBe(201);
+      const q = await created.json() as { id: string; state: string };
+      expect(q.state).toBe('open');
+
+      const answered = await app.request(`/questions/${q.id}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answer: 'yes' }),
+      });
+      expect(answered.status).toBe(200);
+      const aBody = await answered.json() as { state: string; answer: string };
+      expect(aBody.state).toBe('answered');
+      expect(aBody.answer).toBe('yes');
+
+      const single = await app.request(`/questions/${q.id}`);
+      expect(single.status).toBe(200);
+
+      const events = eventBus.replay({ correlationId: undefined, limit: 50 });
+      const types = events.map(e => e.type);
+      expect(types).toContain('question.created');
+      expect(types).toContain('question.answered');
+    });
+
+    it('PATCH updates fields without emitting question.answered', async () => {
+      const created = await app.request('/questions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'patch me' }),
+      });
+      const q = await created.json() as { id: string };
+      const patched = await app.request(`/questions/${q.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ priority: 'critical' }),
+      });
+      expect(patched.status).toBe(200);
+      const pBody = await patched.json() as { priority: string };
+      expect(pBody.priority).toBe('critical');
+    });
+  });
+
+  describe('DASH-207 POST /requirements + POST /blockers', () => {
+    it('POST /requirements persists row + emits requirement.created', async () => {
+      const res = await app.request('/requirements', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Req via API', description: 'test' }),
+      });
+      expect(res.status).toBe(201);
+      const row = await res.json() as { id: string; title: string; state: string };
+      expect(row.title).toBe('Req via API');
+      expect(row.state).toBe('captured');
+
+      const events = eventBus.replay({ correlationId: undefined, limit: 50 });
+      expect(events.map(e => e.type)).toContain('requirement.created');
+    });
+
+    it('rejects POST /blockers without a title', async () => {
+      const res = await app.request('/blockers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -321,7 +321,11 @@ export type EventType =
   | 'task-scheduler.scheduling.complete'
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   | 'testing-agent.validation.complete'
-  | 'release-agent.report.ready';
+  | 'release-agent.report.ready'
+  // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
+  | 'blocker.created' | 'blocker.resolved'
+  | 'question.created' | 'question.answered'
+  | 'requirement.created';
 
 /** Default severity for each event type */
 export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
@@ -376,6 +380,12 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   'testing-agent.validation.complete': 'info',
   'release-agent.report.ready': 'info',
+  // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
+  'blocker.created': 'warning',
+  'blocker.resolved': 'info',
+  'question.created': 'info',
+  'question.answered': 'info',
+  'requirement.created': 'info',
 };
 
 /** All valid event type strings from the registry */


### PR DESCRIPTION
## Summary
DASH-205 / DASH-206 / DASH-207 from the gap analysis — three closely-related backend writers grouped into one PR per the standing flow's "tightly-related groups" allowance.

## Routes
- `POST /blockers`, `POST /blockers/:id/resolve` (DASH-205)
- `POST /questions`, `POST /questions/:id/answer`, `GET /questions/:id`, `PATCH /questions/:id` (DASH-206)
- `POST /requirements` (DASH-207)

## Events (added to events-taxonomy-internal)
- `blocker.created`, `blocker.resolved`
- `question.created`, `question.answered`
- `requirement.created`

## Tests
```
PASS tests/api/dash-205-207-writers.test.ts (6/6)
```

Refs: caia-dashboard-gap-analysis-2026-04-28.md (DASH-205, 206, 207)