### PR TITLE
feat(orchestrator): close /agents/artifacts CRUD + emit artifact.* events (DASH-204)

### DIFF
--- a/apps/orchestrator/src/api/routes/agents.ts
+++ b/apps/orchestrator/src/api/routes/agents.ts
@@ -16,6 +16,7 @@ import {
 } from '../../db/schema';
 import { runTestingAgent } from '../../agents/testing-agent';
 import { runReleaseAgent } from '../../agents/release-agent';
+import { eventBus } from '../../events/bus-adapter';
 
 // @no-events — route registration wrapper
 export function registerAgentRoutes(app: Hono, db: Db): void {
@@ -231,7 +232,78 @@ export function registerAgentRoutes(app: Hono, db: Db): void {
       createdAt: Date.now(),
     }).run();
 
+    eventBus.publish({
+      type: 'artifact.draft_filed',
+      actor: 'api',
+      entity_type: 'agent_artifact',
+      entity_id: id,
+      payload: {
+        artifact_id: id,
+        agent_name: body.agentName,
+        artifact_type: body.artifactType,
+        prompt_id: body.promptId ?? null,
+      },
+    });
+
     return c.json({ artifact_id: id }, 201);
+  });
+
+  // ─── GET /agents/artifacts/:id — single artifact (DASH-204) ───────────────
+  app.get('/agents/artifacts/:id', (c) => {
+    const id = c.req.param('id');
+    const row = db.select().from(agentArtifacts).where(eq(agentArtifacts.id, id)).get();
+    if (!row) return c.json({ error: 'Not found' }, 404);
+    return c.json(row);
+  });
+
+  // ─── PATCH /agents/artifacts/:id — approve / reject / supersede (DASH-204)
+  // Used by /gates page when reviewer clicks Approve / Request Changes.
+  app.patch('/agents/artifacts/:id', async (c) => {
+    const id = c.req.param('id');
+    const body = await c.req.json().catch(() => ({})) as { status?: string; feedback?: string };
+    const existing = db.select().from(agentArtifacts).where(eq(agentArtifacts.id, id)).get();
+    if (!existing) return c.json({ error: 'Not found' }, 404);
+
+    const validStatuses = new Set(['draft', 'approved', 'rejected', 'superseded']);
+    if (body.status !== undefined && !validStatuses.has(body.status)) {
+      return c.json({ error: 'invalid status' }, 400);
+    }
+
+    const updates: Partial<typeof agentArtifacts.$inferInsert> = {};
+    if (body.status !== undefined) updates.status = body.status;
+
+    if (Object.keys(updates).length > 0) {
+      db.update(agentArtifacts).set(updates).where(eq(agentArtifacts.id, id)).run();
+    }
+
+    if (body.status === 'approved') {
+      eventBus.publish({
+        type: 'artifact.approved',
+        actor: 'api',
+        entity_type: 'agent_artifact',
+        entity_id: id,
+        payload: { artifact_id: id, agent_name: existing.agentName, artifact_type: existing.artifactType },
+      });
+    } else if (body.status === 'rejected') {
+      eventBus.publish({
+        type: 'artifact.rejected',
+        actor: 'api',
+        entity_type: 'agent_artifact',
+        entity_id: id,
+        payload: { artifact_id: id, feedback: body.feedback ?? null },
+      });
+    } else if (body.status === 'superseded') {
+      eventBus.publish({
+        type: 'artifact.superseded',
+        actor: 'api',
+        entity_type: 'agent_artifact',
+        entity_id: id,
+        payload: { artifact_id: id, feedback: body.feedback ?? null },
+      });
+    }
+
+    const updated = db.select().from(agentArtifacts).where(eq(agentArtifacts.id, id)).get();
+    return c.json(updated);
   });
 
   // ─── GET /agents/system-prompts/:agentName — all versions for an agent ───

--- a/apps/orchestrator/tests/api/dash-204-agent-artifacts.test.ts
+++ b/apps/orchestrator/tests/api/dash-204-agent-artifacts.test.ts
@@ -1,0 +1,132 @@
+/**
+ * DASH-204 — guard the /agents/artifacts CRUD + events.
+ *
+ * The dashboard's /gates page uses these routes to surface and act on
+ * agent artifacts (architecture-plan, backlog-review, etc.):
+ *   GET    /agents/artifacts?status=draft
+ *   GET    /agents/artifacts/:id
+ *   POST   /agents/artifacts
+ *   PATCH  /agents/artifacts/:id   {status: 'approved'|'rejected'|'superseded'}
+ *
+ * Each artifact lifecycle event must reach the event bus so the layout's
+ * review-gates badge and any future timeline subscribers can update live.
+ */
+import { Hono } from 'hono';
+import { resetDb, getDb, runMigrations } from '../../src/db/connection';
+import { registerAgentRoutes } from '../../src/api/routes/agents';
+import { wireEventBus } from '../../src/events/bus-adapter';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+describe('DASH-204 /agents/artifacts CRUD', () => {
+  let app: Hono;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-dash204-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+    resetDb();
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+    wireEventBus(db);
+    app = new Hono();
+    registerAgentRoutes(app, db);
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    delete process.env.CONDUCTOR_DB_PATH;
+  });
+
+  it('POST creates → emits artifact.draft_filed → GET /:id returns it', async () => {
+    const created = await app.request('/agents/artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentName: 'po-agent',
+        artifactType: 'backlog-review',
+        content: '{"items":[]}',
+        // promptId omitted to avoid FK constraint in test
+      }),
+    });
+    expect(created.status).toBe(201);
+    const { artifact_id } = await created.json() as { artifact_id: string };
+    expect(artifact_id).toMatch(/^art-/);
+
+    const single = await app.request(`/agents/artifacts/${artifact_id}`);
+    expect(single.status).toBe(200);
+    const row = await single.json() as { id: string; status: string; agentName: string };
+    expect(row.id).toBe(artifact_id);
+    expect(row.status).toBe('draft');
+    expect(row.agentName).toBe('po-agent');
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 50 });
+    expect(events.map(e => e.type)).toContain('artifact.draft_filed');
+  });
+
+  it('PATCH status=approved → emits artifact.approved + persists', async () => {
+    const created = await app.request('/agents/artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentName: 'po', artifactType: 't', content: '{}' }),
+    });
+    const { artifact_id } = await created.json() as { artifact_id: string };
+
+    const patched = await app.request(`/agents/artifacts/${artifact_id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'approved' }),
+    });
+    expect(patched.status).toBe(200);
+    const updated = await patched.json() as { status: string };
+    expect(updated.status).toBe('approved');
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 50 });
+    expect(events.map(e => e.type)).toContain('artifact.approved');
+  });
+
+  it('PATCH status=superseded → emits artifact.superseded with feedback', async () => {
+    const created = await app.request('/agents/artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentName: 'po', artifactType: 't', content: '{}' }),
+    });
+    const { artifact_id } = await created.json() as { artifact_id: string };
+
+    const patched = await app.request(`/agents/artifacts/${artifact_id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'superseded', feedback: 'try again' }),
+    });
+    expect(patched.status).toBe(200);
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 50 });
+    const supersededEvent = events.find(e => e.type === 'artifact.superseded');
+    expect(supersededEvent).toBeDefined();
+    expect((supersededEvent!.payload as { feedback?: string }).feedback).toBe('try again');
+  });
+
+  it('rejects PATCH with an invalid status', async () => {
+    const created = await app.request('/agents/artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentName: 'po', artifactType: 't', content: '{}' }),
+    });
+    const { artifact_id } = await created.json() as { artifact_id: string };
+
+    const patched = await app.request(`/agents/artifacts/${artifact_id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'banana' }),
+    });
+    expect(patched.status).toBe(400);
+  });
+
+  it('GET /:id returns 404 for unknown id', async () => {
+    const res = await app.request('/agents/artifacts/art-does-not-exist');
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -325,7 +325,9 @@ export type EventType =
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
-  | 'requirement.created';
+  | 'requirement.created'
+  // ─── Agent artifacts (DASH-204) ───────────────────────────────────────────
+  | 'artifact.draft_filed' | 'artifact.approved' | 'artifact.rejected' | 'artifact.superseded';
 
 /** Default severity for each event type */
 export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
@@ -386,6 +388,11 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'question.created': 'info',
   'question.answered': 'info',
   'requirement.created': 'info',
+  // ─── Agent artifacts (DASH-204) ───────────────────────────────────────────
+  'artifact.draft_filed': 'info',
+  'artifact.approved': 'info',
+  'artifact.rejected': 'warning',
+  'artifact.superseded': 'warning',
 };
 
 /** All valid event type strings from the registry */


### PR DESCRIPTION
## Summary
DASH-204 from the gap analysis. The `/gates` page expected:
- `GET /agents/artifacts/:id` (single fetch)
- `PATCH /agents/artifacts/:id` (approve/reject/supersede)

Both were missing. POST also wasn't emitting events.

## Adds
- 2 new routes (`GET` and `PATCH` on `/agents/artifacts/:id`)
- 4 new events in `events-taxonomy-internal`: `artifact.draft_filed`, `artifact.approved`, `artifact.rejected`, `artifact.superseded`
- POST now emits `artifact.draft_filed`
- PATCH validates status enum and emits the matching lifecycle event with feedback text in payload

## Tests
```
PASS tests/api/dash-204-agent-artifacts.test.ts (5/5)
```

Refs: caia-dashboard-gap-analysis-2026-04-28.md (DASH-204)