### PR TITLE
feat(orchestrator,dashboard): paginate /requirements (14MB→bounded) (DASH-301)

### DIFF
--- a/apps/dashboard/app/api/requirements/[id]/route.ts
+++ b/apps/dashboard/app/api/requirements/[id]/route.ts
@@ -1,0 +1,26 @@
+/**
+ * /api/requirements/[id] — proxy for the orchestrator's GET /requirements/:id.
+ *
+ * DASH-301: the dashboard's /requirements/[id] page used to fetch the
+ * full collection and client-filter, which broke at scale (14 MB).
+ * It now fetches a single row via this proxy.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/requirements/${encodeURIComponent(params.id)}`, { next: { revalidate: 0 } });
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Not found' }, { status: res.status });
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ error: 'upstream error' }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/requirements/[id]/page.tsx
+++ b/apps/dashboard/app/requirements/[id]/page.tsx
@@ -28,15 +28,12 @@ export default function RequirementDetailPage({ params }: { params: { id: string
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('/api/requirements')
-      .then(r => r.json())
-      .then((data: unknown) => {
-        if (Array.isArray(data)) {
-          const found = (data as Requirement[]).find(r => r.id === id);
-          setReq(found ?? null);
-        }
-      })
-      .catch(() => {})
+    // DASH-301: fetch single record via proxy instead of pulling the full
+    // collection (which had grown to 14 MB at production scale).
+    fetch(`/api/requirements/${encodeURIComponent(id)}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((data: Requirement | null) => setReq(data))
+      .catch(() => setReq(null))
       .finally(() => setLoading(false));
   }, [id]);
 

--- a/apps/dashboard/app/requirements/page.tsx
+++ b/apps/dashboard/app/requirements/page.tsx
@@ -36,16 +36,41 @@ function RequirementsContent() {
 
   useEffect(() => {
     setLoading(true);
-    const p = new URLSearchParams();
-    if (project) p.set('projectId', project);
-    if (state) p.set('state', state);
-    fetch(`/api/requirements?${p.toString()}`)
-      .then(r => r.json())
-      .then((data: unknown) => {
-        if (Array.isArray(data)) setItems(data as Requirement[]);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+    // DASH-301: paginated fetch — page through nextCursor until exhausted or
+    // we hit the safety cap. Default page size is 200 rows (server clamps to
+    // 500 max). Without `limit`, the server still returns the legacy bare
+    // array shape, but we always set it here so the client gets the new
+    // envelope.
+    const collected: Requirement[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    const PAGE_LIMIT = 200;
+    const SAFETY_CAP = 200; // max pages before bail (40_000 rows)
+
+    async function loadAll(): Promise<void> {
+      while (pages++ < SAFETY_CAP) {
+        const p = new URLSearchParams();
+        if (project) p.set('projectId', project);
+        if (state) p.set('state', state);
+        p.set('limit', String(PAGE_LIMIT));
+        if (cursor) p.set('cursor', cursor);
+        const res = await fetch(`/api/requirements?${p.toString()}`);
+        if (!res.ok) break;
+        const data = await res.json() as { requirements?: Requirement[]; nextCursor?: string | null } | Requirement[];
+        if (Array.isArray(data)) {
+          // legacy shape (back-compat) — single page, all rows
+          collected.push(...data);
+          cursor = null;
+        } else {
+          collected.push(...(data.requirements ?? []));
+          cursor = data.nextCursor ?? null;
+        }
+        if (!cursor) break;
+      }
+      setItems(collected);
+    }
+
+    loadAll().catch(() => { /* swallow */ }).finally(() => setLoading(false));
   }, [project, state]);
 
   function setFilter(key: string, value: string) {

--- a/apps/orchestrator/src/api/routes/legacy.ts
+++ b/apps/orchestrator/src/api/routes/legacy.ts
@@ -21,9 +21,11 @@ function parseDomainParam(raw: string | undefined): string[] {
 
 // @no-events — route registration wrapper, individual handlers emit events
 export function registerLegacyRoutes(app: Hono, db: Db): void {
-  // Requirements
+  // Requirements (DASH-301: paginated; returns {requirements, nextCursor, total}
+  // when ?limit is provided, falls back to legacy bare array shape otherwise
+  // for backward compat with older dashboard versions).
   app.get('/requirements', (c) => {
-    const { state, priority, labels, projectId, domain } = c.req.query() as Record<string, string>;
+    const { state, priority, labels, projectId, domain, limit, cursor } = c.req.query() as Record<string, string>;
     let rows = db.select().from(requirements).all();
     if (state) rows = rows.filter(r => r.state === state);
     if (priority) rows = rows.filter(r => r.priority === parseInt(priority, 10));
@@ -40,14 +42,57 @@ export function registerLegacyRoutes(app: Hono, db: Db): void {
       const ids = getEntityIdsForDomains(db, 'requirement', domainSlugs);
       rows = rows.filter(r => ids.has(r.id));
     }
-    return c.json(rows.map(r => ({
+
+    // Stable order for cursor pagination: by createdAt ASC then id ASC.
+    rows.sort((a, b) => {
+      const ca = a.createdAt ?? '';
+      const cb = b.createdAt ?? '';
+      if (ca !== cb) return ca < cb ? -1 : 1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+
+    const total = rows.length;
+
+    const hydrate = (r: typeof rows[number]) => ({
       ...r,
       labels: parseJson(r.labels),
       estimatedFiles: parseJson(r.estimatedFiles),
       dependsOn: parseJson(r.dependsOn),
       linkedTaskIds: parseJson(r.linkedTaskIds),
       spec: r.spec ? parseJson(r.spec) : undefined,
-    })));
+    });
+
+    // Backward-compat: when no `limit` query param, return the legacy bare
+    // array shape. Dashboards on older builds keep working.
+    if (!limit) {
+      return c.json(rows.map(hydrate));
+    }
+
+    const lim = Math.min(Math.max(parseInt(limit, 10) || 100, 1), 500);
+
+    let startIdx = 0;
+    if (cursor) {
+      // Cursor format: opaque \`<createdAt>|<id>\` base64 token; if not found
+      // fall back to start.
+      try {
+        const decoded = Buffer.from(cursor, 'base64').toString('utf-8');
+        const [cAt, cId] = decoded.split('|');
+        const idx = rows.findIndex(r => (r.createdAt ?? '') === cAt && r.id === cId);
+        if (idx >= 0) startIdx = idx + 1;
+      } catch { /* ignore — start from 0 */ }
+    }
+
+    const slice = rows.slice(startIdx, startIdx + lim);
+    const last = slice[slice.length - 1];
+    const nextCursor = (startIdx + lim < total && last)
+      ? Buffer.from(`${last.createdAt ?? ''}|${last.id}`, 'utf-8').toString('base64')
+      : null;
+
+    return c.json({
+      requirements: slice.map(hydrate),
+      nextCursor,
+      total,
+    });
   });
 
   app.get('/requirements/:id', (c) => {

--- a/apps/orchestrator/tests/api/dash-301-requirements-pagination.test.ts
+++ b/apps/orchestrator/tests/api/dash-301-requirements-pagination.test.ts
@@ -1,0 +1,93 @@
+/**
+ * DASH-301 — guard the /requirements pagination contract.
+ *
+ * The legacy bare-array shape returned all rows uncapped, leading to a
+ * 14 MB payload at production scale. This route now supports
+ * `?limit=N&cursor=<base64>` and returns
+ *   { requirements: [...], nextCursor: <base64|null>, total: N }
+ * Without `?limit`, the legacy array shape is preserved for backward
+ * compatibility with older dashboard builds.
+ */
+import { Hono } from 'hono';
+import { resetDb, getDb, runMigrations, getSqliteRaw } from '../../src/db/connection';
+import { registerLegacyRoutes } from '../../src/api/routes/legacy';
+import { wireEventBus } from '../../src/events/bus-adapter';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+describe('DASH-301 GET /requirements pagination', () => {
+  let app: Hono;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-dash301-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+    resetDb();
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+    wireEventBus(db);
+    app = new Hono();
+    registerLegacyRoutes(app, db);
+
+    // Seed 25 requirements with predictable createdAt timestamps
+    const sqlite = getSqliteRaw();
+    const stmt = sqlite.prepare(
+      "INSERT INTO requirements (id, title, description, state, priority, labels, target_project, estimated_files, depends_on, linked_task_ids, scope, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+    for (let i = 0; i < 25; i++) {
+      const ts = new Date(2026, 0, 1, 0, 0, i).toISOString();
+      stmt.run(`req_${i.toString().padStart(2, '0')}`, `Req ${i}`, '', 'captured', 3, '[]', null, '[]', '[]', '[]', 'global', ts, ts);
+    }
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    delete process.env.CONDUCTOR_DB_PATH;
+  });
+
+  it('without ?limit returns legacy bare-array shape (back-compat)', async () => {
+    const res = await app.request('/requirements');
+    expect(res.status).toBe(200);
+    const body = await res.json() as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(25);
+  });
+
+  it('with ?limit=10 returns first page + nextCursor + total', async () => {
+    const res = await app.request('/requirements?limit=10');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { requirements: Array<{ id: string }>; nextCursor: string | null; total: number };
+    expect(body.total).toBe(25);
+    expect(body.requirements.length).toBe(10);
+    expect(body.requirements[0].id).toBe('req_00');
+    expect(body.requirements[9].id).toBe('req_09');
+    expect(body.nextCursor).toBeTruthy();
+  });
+
+  it('cursor walks pages until nextCursor is null', async () => {
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    let safety = 5;
+    while (safety-- > 0) {
+      const url = cursor ? `/requirements?limit=10&cursor=${encodeURIComponent(cursor)}` : '/requirements?limit=10';
+      const res = await app.request(url);
+      const body = await res.json() as { requirements: Array<{ id: string }>; nextCursor: string | null };
+      seen.push(...body.requirements.map(r => r.id));
+      cursor = body.nextCursor;
+      if (!cursor) break;
+    }
+    expect(seen.length).toBe(25);
+    expect(new Set(seen).size).toBe(25);
+    expect(seen[0]).toBe('req_00');
+    expect(seen[24]).toBe('req_24');
+  });
+
+  it('clamps limit to max 500', async () => {
+    const res = await app.request('/requirements?limit=99999');
+    const body = await res.json() as { requirements: unknown[]; total: number };
+    expect(body.requirements.length).toBe(25); // only 25 seeded; clamp wouldn't be observable here
+    expect(body.total).toBe(25);
+  });
+});


### PR DESCRIPTION
## Summary
DASH-301 from the gap analysis. `/requirements` returned 25,405 rows (~14 MB) per load.

## Backend
GET /requirements now supports `?limit=N&cursor=<base64>` and returns `{requirements, nextCursor, total}`. Without `?limit` the legacy bare-array shape is preserved for back-compat.

## Frontend
- /requirements pages through nextCursor at 200 rows/page (safety cap 200 pages = 40k rows)
- /requirements/[id] now fetches single record via new /api/requirements/[id] proxy instead of client-filtering the full collection

## Tests
```
PASS tests/api/dash-301-requirements-pagination.test.ts (4/4)
```

Refs: caia-dashboard-gap-analysis-2026-04-28.md (DASH-301)