### PR TITLE
feat(phase1): @chiefaia/ticket-template + task_buckets table (PHASE1-01)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0021_task_buckets_ticket_template.sql
+++ b/apps/orchestrator/src/db/migrations/0021_task_buckets_ticket_template.sql
@@ -1,0 +1,43 @@
+-- Migration 0021: Phase 1 ticket-template & scheduling-bucket tables.
+--
+-- Two concerns shipped together because they form one contract:
+--   1. task_buckets — the scheduling-bucket entity (sequential-per-domain
+--      and one parallel bucket per prompt) into which the Task Manager
+--      places enriched tickets.
+--   2. stories.* additions — columns that hold the ticket-template payload,
+--      bucket assignment, template version + validation status, so the
+--      executor can read a self-contained ticket.
+
+-- ─── task_buckets ───────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS `task_buckets` (
+  `id` text PRIMARY KEY NOT NULL,                 -- e.g. 'bkt_seq_auth_001', 'bkt_par_<prompt>'
+  `kind` text NOT NULL,                           -- 'sequential' | 'parallel'
+  `domain_slug` text,                             -- non-null for sequential, null for parallel
+  `prompt_id` text NOT NULL REFERENCES `prompts`(`id`),
+  `created_at` integer NOT NULL,                  -- epoch ms
+  `sequence_index` integer,                       -- 0,1,2... for sequential buckets; null for parallel
+  `status` text NOT NULL DEFAULT 'open',          -- 'open' | 'in_progress' | 'drained'
+  `metadata` text                                 -- JSON: bucket_label, predicted_concurrency, etc.
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tb_prompt` ON `task_buckets` (`prompt_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tb_kind_domain` ON `task_buckets` (`kind`, `domain_slug`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tb_status` ON `task_buckets` (`status`);
+--> statement-breakpoint
+
+-- ─── stories: ticket-template + bucket linkage ─────────────────────────────
+ALTER TABLE `stories` ADD COLUMN `agent_contributions_json` text NOT NULL DEFAULT '{}';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `bucket_id` text REFERENCES `task_buckets`(`id`);
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `template_version` text NOT NULL DEFAULT 'v1';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `template_validation_status` text NOT NULL DEFAULT 'pending';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `template_validation_errors` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_bucket_idx` ON `stories` (`bucket_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_template_status_idx` ON `stories` (`template_validation_status`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777400000000,
       "tag": "0020_dash_208_210_repair",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1777500000000,
+      "tag": "0021_task_buckets_ticket_template",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -398,12 +398,20 @@ export const stories = sqliteTable('stories', {
   implementationNotes: text('implementation_notes'),
   updatedAt: integer('updated_at'),
   enrichedAt: integer('enriched_at'),
+  // Phase-1 ticket-template + bucket linkage (migration 0021)
+  agentContributionsJson: text('agent_contributions_json').notNull().default('{}'),
+  bucketId: text('bucket_id'),
+  templateVersion: text('template_version').notNull().default('v1'),
+  templateValidationStatus: text('template_validation_status').notNull().default('pending'), // 'pending'|'valid'|'invalid'
+  templateValidationErrors: text('template_validation_errors'),
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
   index('story_kind_idx').on(t.kind),
   index('story_root_prompt_idx').on(t.rootPromptId),
   index('story_parent_entity_idx').on(t.parentEntityId),
+  index('story_bucket_idx').on(t.bucketId),
+  index('story_template_status_idx').on(t.templateValidationStatus),
 ]);
 
 // story_revisions — append-only history of every story-tree edit
@@ -853,4 +861,22 @@ export const dedupResults = sqliteTable('dedup_results', {
 }, (t) => [
   index('idx_dr_entity').on(t.entityKind, t.entityId),
   index('idx_dr_decision').on(t.decision),
+]);
+
+// task_buckets — Phase-1 scheduling buckets (migration 0021)
+// Sequential buckets are partitioned by domain_slug per prompt; one parallel
+// bucket per prompt holds tickets that have no cross-domain upstream deps.
+export const taskBuckets = sqliteTable('task_buckets', {
+  id: text('id').primaryKey().notNull(),
+  kind: text('kind').notNull(),                 // 'sequential' | 'parallel'
+  domainSlug: text('domain_slug'),              // non-null for sequential, null for parallel
+  promptId: text('prompt_id').notNull().references(() => prompts.id),
+  createdAt: integer('created_at').notNull(),   // epoch ms
+  sequenceIndex: integer('sequence_index'),     // 0,1,2... for sequential, null for parallel
+  status: text('status').notNull().default('open'), // 'open'|'in_progress'|'drained'
+  metadata: text('metadata'),                   // JSON: bucket_label, predicted_concurrency, etc.
+}, (t) => [
+  index('idx_tb_prompt').on(t.promptId),
+  index('idx_tb_kind_domain').on(t.kind, t.domainSlug),
+  index('idx_tb_status').on(t.status),
 ]);

--- a/apps/orchestrator/tests/db/task-buckets-ticket-template.test.ts
+++ b/apps/orchestrator/tests/db/task-buckets-ticket-template.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Migration 0021 smoke tests — task_buckets table + stories ticket-template
+ * additions. Verifies the migration applies cleanly to a fresh in-memory DB
+ * and the new schema is functional.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import {
+  prompts,
+  stories,
+  taskBuckets,
+} from '../../src/db/schema';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedPrompt(db: ReturnType<typeof createTestDb>, id: string) {
+  db.insert(prompts)
+    .values({
+      id,
+      body: 'implement a user login feature',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: `cor_${id}`,
+      hash: `hash_${id}`,
+      status: 'received',
+    })
+    .run();
+}
+
+describe('migration 0021: task_buckets', () => {
+  it('creates the task_buckets table and inserts a sequential bucket', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_test1');
+    db.insert(taskBuckets)
+      .values({
+        id: 'bkt_seq_auth_001',
+        kind: 'sequential',
+        domainSlug: 'auth',
+        promptId: 'prm_test1',
+        createdAt: Date.now(),
+        sequenceIndex: 0,
+        status: 'open',
+      })
+      .run();
+
+    const rows = db.select().from(taskBuckets).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe('sequential');
+    expect(rows[0]!.domainSlug).toBe('auth');
+    expect(rows[0]!.sequenceIndex).toBe(0);
+    expect(rows[0]!.status).toBe('open');
+  });
+
+  it('allows a parallel bucket with null domain_slug + null sequence_index', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_test2');
+    db.insert(taskBuckets)
+      .values({
+        id: 'bkt_par_prm_test2',
+        kind: 'parallel',
+        domainSlug: null,
+        promptId: 'prm_test2',
+        createdAt: Date.now(),
+        sequenceIndex: null,
+        status: 'open',
+      })
+      .run();
+
+    const row = db
+      .select()
+      .from(taskBuckets)
+      .where(eq(taskBuckets.id, 'bkt_par_prm_test2'))
+      .get();
+    expect(row).toBeDefined();
+    expect(row!.kind).toBe('parallel');
+    expect(row!.domainSlug).toBeNull();
+    expect(row!.sequenceIndex).toBeNull();
+  });
+
+  it('enforces foreign key from task_buckets.prompt_id → prompts.id', () => {
+    const db = createTestDb();
+    // No prompt seeded — insert should fail FK if FKs are enabled.
+    // In WAL/in-memory mode FKs may or may not be on by default; the column
+    // existence + reference declaration is what we assert here. Insert with
+    // a real prompt to confirm acceptance.
+    seedPrompt(db, 'prm_fk');
+    expect(() =>
+      db
+        .insert(taskBuckets)
+        .values({
+          id: 'bkt_fk_ok',
+          kind: 'sequential',
+          domainSlug: 'general',
+          promptId: 'prm_fk',
+          createdAt: Date.now(),
+          sequenceIndex: 0,
+          status: 'open',
+        })
+        .run(),
+    ).not.toThrow();
+  });
+
+  it('supports the open → in_progress → drained status lifecycle', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_lc');
+    db.insert(taskBuckets)
+      .values({
+        id: 'bkt_lc',
+        kind: 'sequential',
+        domainSlug: 'auth',
+        promptId: 'prm_lc',
+        createdAt: Date.now(),
+        sequenceIndex: 0,
+        status: 'open',
+      })
+      .run();
+
+    db.update(taskBuckets)
+      .set({ status: 'in_progress' })
+      .where(eq(taskBuckets.id, 'bkt_lc'))
+      .run();
+    db.update(taskBuckets)
+      .set({ status: 'drained' })
+      .where(eq(taskBuckets.id, 'bkt_lc'))
+      .run();
+
+    const row = db.select().from(taskBuckets).where(eq(taskBuckets.id, 'bkt_lc')).get();
+    expect(row!.status).toBe('drained');
+  });
+});
+
+describe('migration 0021: stories ticket-template columns', () => {
+  it('default-populates the new ticket-template columns', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_tt');
+    db.insert(stories)
+      .values({
+        id: 'story_tt_1',
+        kind: 'story',
+        title: 'Login form',
+        rootPromptId: 'prm_tt',
+        createdAt: nowIso(),
+      })
+      .run();
+
+    const row = db.select().from(stories).where(eq(stories.id, 'story_tt_1')).get();
+    expect(row).toBeDefined();
+    expect(row!.agentContributionsJson).toBe('{}');
+    expect(row!.bucketId).toBeNull();
+    expect(row!.templateVersion).toBe('v1');
+    expect(row!.templateValidationStatus).toBe('pending');
+    expect(row!.templateValidationErrors).toBeNull();
+  });
+
+  it('persists a non-trivial agentContributionsJson payload round-trip', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_payload');
+    const payload = JSON.stringify({
+      version: 'v1',
+      scope: { summary: 'OAuth login', inScope: ['google'], outOfScope: [] },
+      agentSections: { architecture: { contributedBy: 'ea-agent', contributedAt: 1700000000000 } },
+    });
+    db.insert(stories)
+      .values({
+        id: 'story_payload',
+        kind: 'story',
+        title: 'OAuth',
+        rootPromptId: 'prm_payload',
+        agentContributionsJson: payload,
+        templateValidationStatus: 'valid',
+        createdAt: nowIso(),
+      })
+      .run();
+
+    const row = db.select().from(stories).where(eq(stories.id, 'story_payload')).get();
+    expect(row!.agentContributionsJson).toBe(payload);
+    expect(row!.templateValidationStatus).toBe('valid');
+  });
+
+  it('allows linking a story to a task_buckets row via bucketId', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_link');
+    db.insert(taskBuckets)
+      .values({
+        id: 'bkt_link_001',
+        kind: 'sequential',
+        domainSlug: 'auth',
+        promptId: 'prm_link',
+        createdAt: Date.now(),
+        sequenceIndex: 0,
+        status: 'open',
+      })
+      .run();
+    db.insert(stories)
+      .values({
+        id: 'story_link_1',
+        kind: 'story',
+        title: 'Bucketed story',
+        rootPromptId: 'prm_link',
+        bucketId: 'bkt_link_001',
+        createdAt: nowIso(),
+      })
+      .run();
+
+    const row = db.select().from(stories).where(eq(stories.id, 'story_link_1')).get();
+    expect(row!.bucketId).toBe('bkt_link_001');
+  });
+
+  it('captures validation errors as JSON in templateValidationErrors', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_err');
+    const errors = JSON.stringify([
+      { path: 'acceptanceCriteria', message: 'too few', code: 'too_small' },
+    ]);
+    db.insert(stories)
+      .values({
+        id: 'story_err',
+        kind: 'story',
+        title: 'Bad story',
+        rootPromptId: 'prm_err',
+        templateValidationStatus: 'invalid',
+        templateValidationErrors: errors,
+        createdAt: nowIso(),
+      })
+      .run();
+
+    const row = db.select().from(stories).where(eq(stories.id, 'story_err')).get();
+    expect(row!.templateValidationStatus).toBe('invalid');
+    expect(row!.templateValidationErrors).toBe(errors);
+  });
+});

--- a/packages/ticket-template/README.md
+++ b/packages/ticket-template/README.md
@@ -1,0 +1,44 @@
+# @chiefaia/ticket-template
+
+The strict, Zod-validated **ticket template (v1)** for the CAIA Phase 1 agent
+pipeline. It is the contract that every agent (PO, BA, EA, DBA, BFF, UI,
+Security, Testing, Release, Observability) writes into and that the executor
+reads out of.
+
+## Why a strict template
+
+Without a contract, every agent invents its own shape, and the executor cannot
+trust the bundle handed to it. The template enforces:
+
+1. **Required sections** every ticket must have (`scope`, `context`,
+   `acceptanceCriteria`, `verificationPlan`, `dependencies`).
+2. **Optional per-agent sections** that domain agents fill during BA enrichment
+   (`agentSections.architecture`, `.database`, `.api`, `.ui`, `.security`,
+   `.testing`, `.release`, `.observability`).
+3. **Bounded counts** — at least 3 and at most 10 acceptance criteria so
+   tickets stay actionable but specific.
+4. **Audit fields** — every contributed section must record the agent that
+   produced it and a timestamp.
+
+## Usage
+
+```ts
+import {
+  TicketTemplateV1Schema,
+  validateTicket,
+  TICKET_TEMPLATE_VERSION,
+} from '@chiefaia/ticket-template';
+
+const result = validateTicket(payload);
+if (!result.ok) {
+  // result.errors is a flat list of field-level Zod issues
+  throw new Error(`ticket invalid: ${JSON.stringify(result.errors)}`);
+}
+// result.value is the parsed, typed TicketTemplateV1
+```
+
+## Versioning
+
+Tickets carry `version: 'v1'`. Future breaking changes ship as `v2`, and
+`templateVersion` on the `stories` row tells the validator which schema to
+apply.

--- a/packages/ticket-template/package.json
+++ b/packages/ticket-template/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@chiefaia/ticket-template",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Strict, Zod-validated ticket template (v1) — the contract between Phase 1 agents (PO, BA, EA, DBA, BFF, UI, Security, Testing, Release) and the executor.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/ticket-template/src/build.ts
+++ b/packages/ticket-template/src/build.ts
@@ -1,0 +1,70 @@
+/**
+ * Builder helpers — small utilities to construct partial tickets in a
+ * structured way as the pipeline progresses (PO creates the skeleton, BA
+ * fills sections, etc.) without having to remember the entire schema.
+ */
+
+import {
+  TICKET_TEMPLATE_VERSION,
+  TicketTemplateV1,
+  COMPLEXITY_VALUES,
+  NATURE_VALUES,
+} from './schema';
+
+export interface DraftTicketInput {
+  rootPromptId: string;
+  requirementId: string;
+  parentEpic?: string;
+  domainPrimary: string;
+  domainAll: string[];
+  nature: (typeof NATURE_VALUES)[number];
+  complexity: (typeof COMPLEXITY_VALUES)[number];
+  summary: string;
+  inScope: string[];
+  outOfScope?: string[];
+  acceptanceCriteria: string[];
+  verificationPlan: string[];
+  upstream?: string[];
+  downstream?: string[];
+  files?: string[];
+  poDecomposedAt?: number;
+}
+
+/**
+ * Build a draft ticket payload from the minimum required inputs the PO
+ * agent has after decomposition. Returns a fully-typed TicketTemplateV1
+ * with empty `agentSections` ready for BA to enrich.
+ */
+export function buildDraftTicket(input: DraftTicketInput): TicketTemplateV1 {
+  const now = Date.now();
+  return {
+    version: TICKET_TEMPLATE_VERSION,
+    scope: {
+      summary: input.summary,
+      inScope: input.inScope,
+      outOfScope: input.outOfScope ?? [],
+    },
+    context: {
+      rootPromptId: input.rootPromptId,
+      requirementId: input.requirementId,
+      parentEpic: input.parentEpic,
+      domainPrimary: input.domainPrimary,
+      domainAll: input.domainAll,
+      nature: input.nature,
+      complexity: input.complexity,
+    },
+    acceptanceCriteria: input.acceptanceCriteria,
+    verificationPlan: input.verificationPlan,
+    dependencies: {
+      upstream: input.upstream ?? [],
+      downstream: input.downstream ?? [],
+      files: input.files ?? [],
+    },
+    agentSections: {},
+    metadata: {
+      templateVersion: TICKET_TEMPLATE_VERSION,
+      poDecomposedAt: input.poDecomposedAt ?? now,
+      lastUpdatedAt: now,
+    },
+  };
+}

--- a/packages/ticket-template/src/index.ts
+++ b/packages/ticket-template/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public entry point for @chiefaia/ticket-template.
+ *
+ * Re-exports the v1 schema, types, validation helpers, builder, and
+ * constants. Add future versions (v2 etc.) as parallel exports — never
+ * mutate v1.
+ */
+
+export {
+  TicketTemplateV1Schema,
+  TICKET_TEMPLATE_VERSION,
+  MIN_ACCEPTANCE_CRITERIA,
+  MAX_ACCEPTANCE_CRITERIA,
+  NATURE_VALUES,
+  COMPLEXITY_VALUES,
+  AGENT_SECTION_KEYS,
+} from './schema';
+export type { TicketTemplateV1, AgentSectionKey } from './schema';
+
+export {
+  validateTicket,
+  isValidTicket,
+  assertValidTicket,
+} from './validate';
+export type { ValidationError, ValidationResult } from './validate';
+
+export { buildDraftTicket } from './build';
+export type { DraftTicketInput } from './build';

--- a/packages/ticket-template/src/schema.ts
+++ b/packages/ticket-template/src/schema.ts
@@ -1,0 +1,244 @@
+/**
+ * @chiefaia/ticket-template — TicketTemplateV1
+ *
+ * The canonical, Zod-validated shape of a Phase-1 pipeline ticket. Every agent
+ * in the pipeline reads from and writes into this shape; the validator
+ * enforces the contract before BA can hand a ticket to the Task Manager.
+ *
+ * Field-level rationale and counts are documented inline so the schema itself
+ * is the spec — no parallel doc to drift from.
+ */
+
+import { z } from 'zod';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const TICKET_TEMPLATE_VERSION = 'v1' as const;
+
+/** Minimum acceptance-criteria count for a valid ticket. */
+export const MIN_ACCEPTANCE_CRITERIA = 3;
+/** Maximum acceptance-criteria count for a valid ticket (avoid story bloat). */
+export const MAX_ACCEPTANCE_CRITERIA = 10;
+
+/**
+ * Allowed values for the `nature` field — captures the kind of work the
+ * ticket represents. Mirrors `@chiefaia/classifier` taxonomy.
+ */
+export const NATURE_VALUES = [
+  'feature',
+  'bug-fix',
+  'refactor',
+  'performance',
+  'security',
+  'content',
+  'infra',
+  'docs',
+] as const;
+
+/** Allowed values for the `complexity` field. */
+export const COMPLEXITY_VALUES = ['low', 'medium', 'high', 'spike'] as const;
+
+// ─── Required core sections ──────────────────────────────────────────────────
+
+const Scope = z
+  .object({
+    summary: z.string().min(1, 'summary is required'),
+    inScope: z.array(z.string().min(1)).min(1, 'inScope must list ≥1 item'),
+    outOfScope: z.array(z.string()).default([]),
+  })
+  .strict();
+
+const Context = z
+  .object({
+    rootPromptId: z.string().min(1),
+    requirementId: z.string().min(1),
+    parentEpic: z.string().optional(),
+    domainPrimary: z.string().min(1),
+    domainAll: z.array(z.string().min(1)).min(1),
+    nature: z.enum(NATURE_VALUES),
+    complexity: z.enum(COMPLEXITY_VALUES),
+  })
+  .strict();
+
+const AcceptanceCriteria = z
+  .array(z.string().min(1))
+  .min(MIN_ACCEPTANCE_CRITERIA, `at least ${MIN_ACCEPTANCE_CRITERIA} acceptance criteria required`)
+  .max(MAX_ACCEPTANCE_CRITERIA, `at most ${MAX_ACCEPTANCE_CRITERIA} acceptance criteria allowed`);
+
+const VerificationPlan = z
+  .array(z.string().min(1))
+  .min(1, 'verificationPlan must list ≥1 step');
+
+const Dependencies = z
+  .object({
+    upstream: z.array(z.string()).default([]),
+    downstream: z.array(z.string()).default([]),
+    files: z.array(z.string()).default([]),
+  })
+  .strict();
+
+// ─── Per-agent sections (all optional, populated by BA collaboration) ────────
+
+const ContributedFields = {
+  contributedBy: z.string().min(1),
+  contributedAt: z.number().int().nonnegative(),
+};
+
+const ArchitectureSection = z
+  .object({
+    ...ContributedFields,
+    adrReferences: z.array(z.string()).default([]),
+    constraints: z.array(z.string()).default([]),
+    notes: z.string().default(''),
+  })
+  .strict();
+
+const DatabaseSection = z
+  .object({
+    ...ContributedFields,
+    schemaChanges: z.array(z.string()).default([]),
+    migrationPath: z.string().optional(),
+    reversibility: z.enum(['reversible', 'irreversible', 'partial']).default('reversible'),
+    indexImpact: z.string().default(''),
+  })
+  .strict();
+
+const ApiRoute = z
+  .object({
+    method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+    path: z.string().min(1),
+    requestSchema: z.string().optional(),
+    responseSchema: z.string().optional(),
+  })
+  .strict();
+
+const ApiSection = z
+  .object({
+    ...ContributedFields,
+    routes: z.array(ApiRoute).default([]),
+    errorContract: z.string().default(''),
+  })
+  .strict();
+
+const UISection = z
+  .object({
+    ...ContributedFields,
+    components: z.array(z.string()).default([]),
+    designSystemPattern: z.string().default(''),
+    accessibilityRequirements: z.array(z.string()).default([]),
+  })
+  .strict();
+
+const SecuritySection = z
+  .object({
+    ...ContributedFields,
+    threatModel: z.array(z.string()).default([]),
+    requiredHeaders: z.array(z.string()).default([]),
+    authzNotes: z.string().default(''),
+  })
+  .strict();
+
+const TestingSection = z
+  .object({
+    ...ContributedFields,
+    unitTestPaths: z.array(z.string()).default([]),
+    integrationTestPaths: z.array(z.string()).default([]),
+    behaviorTestPath: z.string().optional(),
+    coverageTarget: z.number().min(0).max(1).default(0.8),
+  })
+  .strict();
+
+const ReleaseSection = z
+  .object({
+    ...ContributedFields,
+    featureFlag: z.string().optional(),
+    rolloutPlan: z.string().default(''),
+    rollbackPlan: z.string().default(''),
+  })
+  .strict();
+
+const ObservabilitySection = z
+  .object({
+    ...ContributedFields,
+    metrics: z.array(z.string()).default([]),
+    traces: z.array(z.string()).default([]),
+    logs: z.array(z.string()).default([]),
+    alertRules: z.array(z.string()).default([]),
+  })
+  .strict();
+
+const AgentSections = z
+  .object({
+    architecture: ArchitectureSection.optional(),
+    database: DatabaseSection.optional(),
+    api: ApiSection.optional(),
+    ui: UISection.optional(),
+    security: SecuritySection.optional(),
+    testing: TestingSection.optional(),
+    release: ReleaseSection.optional(),
+    observability: ObservabilitySection.optional(),
+  })
+  .strict()
+  .default({});
+
+// ─── BA enrichment metadata ──────────────────────────────────────────────────
+
+const InputRequest = z
+  .object({
+    agent: z.string().min(1),
+    correlationId: z.string().min(1),
+    status: z.enum(['pending', 'replied', 'timed_out']),
+    expectedReplyBy: z.number().int().nonnegative().optional(),
+    repliedAt: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+const BaEnrichment = z
+  .object({
+    enrichedBy: z.string().min(1),
+    enrichedAt: z.number().int().nonnegative(),
+    inputsRequested: z.array(InputRequest).default([]),
+    completenessChecksPassed: z.boolean(),
+    notes: z.string().default(''),
+  })
+  .strict();
+
+// ─── Top-level template ──────────────────────────────────────────────────────
+
+const Metadata = z
+  .object({
+    templateVersion: z.literal(TICKET_TEMPLATE_VERSION),
+    poDecomposedAt: z.number().int().nonnegative().optional(),
+    baEnrichedAt: z.number().int().nonnegative().optional(),
+    lastUpdatedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const TicketTemplateV1Schema = z
+  .object({
+    version: z.literal(TICKET_TEMPLATE_VERSION),
+    scope: Scope,
+    context: Context,
+    acceptanceCriteria: AcceptanceCriteria,
+    verificationPlan: VerificationPlan,
+    dependencies: Dependencies,
+    agentSections: AgentSections,
+    baEnrichment: BaEnrichment.optional(),
+    metadata: Metadata,
+  })
+  .strict();
+
+export type TicketTemplateV1 = z.infer<typeof TicketTemplateV1Schema>;
+export type AgentSectionKey = keyof TicketTemplateV1['agentSections'];
+
+/** All section keys an agent can contribute to. Useful for iteration. */
+export const AGENT_SECTION_KEYS = [
+  'architecture',
+  'database',
+  'api',
+  'ui',
+  'security',
+  'testing',
+  'release',
+  'observability',
+] as const satisfies readonly AgentSectionKey[];

--- a/packages/ticket-template/src/template.test.ts
+++ b/packages/ticket-template/src/template.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Behavioural tests for the v1 ticket template — schema, validator, builder.
+ *
+ * These tests double as the spec: anything not covered here is not part of
+ * the contract. When v2 ships, copy this file to template-v2.test.ts and
+ * keep both passing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_SECTION_KEYS,
+  COMPLEXITY_VALUES,
+  MAX_ACCEPTANCE_CRITERIA,
+  MIN_ACCEPTANCE_CRITERIA,
+  NATURE_VALUES,
+  TICKET_TEMPLATE_VERSION,
+  TicketTemplateV1Schema,
+  assertValidTicket,
+  buildDraftTicket,
+  isValidTicket,
+  validateTicket,
+} from './index';
+
+const ts = 1_700_000_000_000; // deterministic timestamp
+
+const baseDraft = buildDraftTicket({
+  rootPromptId: 'prm_abc12345_0123456789abcdef',
+  requirementId: 'req_001',
+  parentEpic: 'epic_auth_001',
+  domainPrimary: 'auth',
+  domainAll: ['auth', 'api-integration'],
+  nature: 'feature',
+  complexity: 'medium',
+  summary: 'Implement OAuth2 login.',
+  inScope: ['Google OAuth2', 'Session token issuance'],
+  outOfScope: ['Account merging'],
+  acceptanceCriteria: [
+    'User can log in via Google',
+    'Session token returned on success',
+    'Failed logins surface a clear error message',
+  ],
+  verificationPlan: ['pnpm test:integration auth-oauth2'],
+  upstream: ['story_user-model_001'],
+  files: ['src/auth/oauth.ts'],
+  poDecomposedAt: ts,
+});
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('exports the v1 version literal', () => {
+    expect(TICKET_TEMPLATE_VERSION).toBe('v1');
+  });
+
+  it('locks acceptance-criteria bounds', () => {
+    expect(MIN_ACCEPTANCE_CRITERIA).toBe(3);
+    expect(MAX_ACCEPTANCE_CRITERIA).toBe(10);
+  });
+
+  it('exposes the canonical nature and complexity sets', () => {
+    expect(NATURE_VALUES).toContain('feature');
+    expect(NATURE_VALUES).toContain('bug-fix');
+    expect(COMPLEXITY_VALUES).toEqual(['low', 'medium', 'high', 'spike']);
+  });
+
+  it('exposes every per-agent section key', () => {
+    expect(AGENT_SECTION_KEYS).toEqual([
+      'architecture',
+      'database',
+      'api',
+      'ui',
+      'security',
+      'testing',
+      'release',
+      'observability',
+    ]);
+  });
+});
+
+// ─── Builder + happy-path validation ─────────────────────────────────────────
+
+describe('buildDraftTicket', () => {
+  it('builds a structurally valid v1 ticket from minimum PO inputs', () => {
+    const result = validateTicket(baseDraft);
+    expect(result.ok).toBe(true);
+  });
+
+  it('seeds empty agentSections so BA can fill them later', () => {
+    expect(baseDraft.agentSections).toEqual({});
+  });
+
+  it('stamps metadata.templateVersion to the package version literal', () => {
+    expect(baseDraft.metadata.templateVersion).toBe(TICKET_TEMPLATE_VERSION);
+  });
+
+  it('preserves the supplied poDecomposedAt timestamp', () => {
+    expect(baseDraft.metadata.poDecomposedAt).toBe(ts);
+  });
+
+  it('defaults outOfScope, downstream, and files when omitted', () => {
+    const minimal = buildDraftTicket({
+      rootPromptId: 'prm_x_y',
+      requirementId: 'req_x',
+      domainPrimary: 'auth',
+      domainAll: ['auth'],
+      nature: 'feature',
+      complexity: 'low',
+      summary: 'thing',
+      inScope: ['a'],
+      acceptanceCriteria: ['a', 'b', 'c'],
+      verificationPlan: ['vp'],
+    });
+    expect(minimal.scope.outOfScope).toEqual([]);
+    expect(minimal.dependencies.downstream).toEqual([]);
+    expect(minimal.dependencies.files).toEqual([]);
+  });
+});
+
+// ─── Required-section enforcement ────────────────────────────────────────────
+
+describe('required sections', () => {
+  it('rejects a ticket with fewer than MIN acceptance criteria', () => {
+    const bad = { ...baseDraft, acceptanceCriteria: ['only one'] };
+    const result = validateTicket(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const errs = result.errors.filter((e) => e.path === 'acceptanceCriteria');
+      expect(errs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects a ticket with more than MAX acceptance criteria', () => {
+    const tooMany = Array.from({ length: MAX_ACCEPTANCE_CRITERIA + 1 }, (_, i) => `ac-${i}`);
+    const bad = { ...baseDraft, acceptanceCriteria: tooMany };
+    const result = validateTicket(bad);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a ticket with empty inScope', () => {
+    const bad = { ...baseDraft, scope: { ...baseDraft.scope, inScope: [] } };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects a ticket with empty verificationPlan', () => {
+    const bad = { ...baseDraft, verificationPlan: [] };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects a ticket missing context.rootPromptId', () => {
+    const bad = {
+      ...baseDraft,
+      context: { ...baseDraft.context, rootPromptId: '' },
+    };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects an unknown nature value', () => {
+    const bad = { ...baseDraft, context: { ...baseDraft.context, nature: 'mystery' } };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects an unknown complexity value', () => {
+    const bad = { ...baseDraft, context: { ...baseDraft.context, complexity: 'epic' } };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects an unknown top-level key (strict mode)', () => {
+    const bad = { ...baseDraft, surplus: 'no extra fields allowed' };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+});
+
+// ─── Per-agent sections ──────────────────────────────────────────────────────
+
+describe('agent sections', () => {
+  it('accepts a fully-populated architecture section', () => {
+    const enriched = {
+      ...baseDraft,
+      agentSections: {
+        architecture: {
+          contributedBy: 'ea-agent',
+          contributedAt: ts,
+          adrReferences: ['ADR-0003'],
+          constraints: ['Stateless JWT only'],
+          notes: 'OAuth tokens never stored server-side.',
+        },
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(true);
+  });
+
+  it('rejects an agent section missing contributedBy', () => {
+    const enriched = {
+      ...baseDraft,
+      agentSections: {
+        architecture: { contributedAt: ts, adrReferences: [], constraints: [], notes: '' },
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(false);
+  });
+
+  it('rejects an agent section with negative contributedAt', () => {
+    const enriched = {
+      ...baseDraft,
+      agentSections: {
+        api: {
+          contributedBy: 'bff-agent',
+          contributedAt: -5,
+          routes: [],
+          errorContract: '',
+        },
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(false);
+  });
+
+  it('rejects an api route with an unknown method', () => {
+    const enriched = {
+      ...baseDraft,
+      agentSections: {
+        api: {
+          contributedBy: 'bff-agent',
+          contributedAt: ts,
+          routes: [{ method: 'TRACE', path: '/x' }],
+          errorContract: '',
+        },
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(false);
+  });
+
+  it('accepts a testing section with default coverage target', () => {
+    const enriched = {
+      ...baseDraft,
+      agentSections: {
+        testing: {
+          contributedBy: 'testing-agent',
+          contributedAt: ts,
+          unitTestPaths: ['src/auth/oauth.test.ts'],
+          integrationTestPaths: [],
+        },
+      },
+    };
+    const result = validateTicket(enriched);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.agentSections.testing?.coverageTarget).toBe(0.8);
+    }
+  });
+
+  it('rejects a testing coverageTarget out of [0,1]', () => {
+    const enriched = {
+      ...baseDraft,
+      agentSections: {
+        testing: {
+          contributedBy: 'testing-agent',
+          contributedAt: ts,
+          coverageTarget: 1.5,
+        },
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(false);
+  });
+});
+
+// ─── BA enrichment metadata ─────────────────────────────────────────────────
+
+describe('baEnrichment block', () => {
+  it('accepts a fully-populated BA enrichment block', () => {
+    const enriched = {
+      ...baseDraft,
+      baEnrichment: {
+        enrichedBy: 'ba-agent',
+        enrichedAt: ts,
+        inputsRequested: [
+          { agent: 'ea-agent', correlationId: 'cor-1', status: 'replied', repliedAt: ts },
+        ],
+        completenessChecksPassed: true,
+        notes: 'all sections present',
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(true);
+  });
+
+  it('rejects an unknown inputsRequested status', () => {
+    const enriched = {
+      ...baseDraft,
+      baEnrichment: {
+        enrichedBy: 'ba-agent',
+        enrichedAt: ts,
+        inputsRequested: [{ agent: 'ea-agent', correlationId: 'cor-1', status: 'maybe' }],
+        completenessChecksPassed: false,
+      },
+    };
+    expect(validateTicket(enriched).ok).toBe(false);
+  });
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+describe('helper exports', () => {
+  it('isValidTicket returns true for a valid draft', () => {
+    expect(isValidTicket(baseDraft)).toBe(true);
+  });
+
+  it('isValidTicket returns false for garbage', () => {
+    expect(isValidTicket({ foo: 'bar' })).toBe(false);
+  });
+
+  it('assertValidTicket throws with field-level summary on invalid input', () => {
+    expect(() => assertValidTicket({ foo: 'bar' })).toThrow(/ticket-template: invalid payload/);
+  });
+
+  it('assertValidTicket returns the typed payload on valid input', () => {
+    const value = assertValidTicket(baseDraft);
+    expect(value.context.domainPrimary).toBe('auth');
+  });
+
+  it('TicketTemplateV1Schema is exported and parseable', () => {
+    const parsed = TicketTemplateV1Schema.safeParse(baseDraft);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+// ─── Round-trip JSON ─────────────────────────────────────────────────────────
+
+describe('round-trip JSON', () => {
+  it('serialises and deserialises a valid ticket without loss', () => {
+    const json = JSON.stringify(baseDraft);
+    const parsed = JSON.parse(json) as unknown;
+    const result = validateTicket(parsed);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/ticket-template/src/validate.ts
+++ b/packages/ticket-template/src/validate.ts
@@ -1,0 +1,67 @@
+/**
+ * Validation helpers — wrap Zod parse errors into a flat, JSON-serialisable
+ * shape so consumers (route handlers, agents, the dashboard) can surface
+ * field-level validation errors consistently.
+ */
+
+import { z } from 'zod';
+import { TicketTemplateV1, TicketTemplateV1Schema } from './schema';
+
+export interface ValidationError {
+  /** Dotted path into the ticket payload (e.g. `acceptanceCriteria` or `agentSections.api.routes.0.method`). */
+  path: string;
+  /** Human-readable Zod message. */
+  message: string;
+  /** Zod issue code (e.g. `too_small`, `invalid_type`). */
+  code: string;
+}
+
+export type ValidationResult =
+  | { ok: true; value: TicketTemplateV1 }
+  | { ok: false; errors: ValidationError[] };
+
+function flattenIssues(error: z.ZodError): ValidationError[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.length > 0 ? issue.path.join('.') : '<root>',
+    message: issue.message,
+    code: issue.code,
+  }));
+}
+
+/**
+ * Validate a candidate ticket payload against the v1 schema.
+ *
+ * Returns a discriminated union — `ok: true` on success with the typed
+ * payload, or `ok: false` with a flat list of field-level errors.
+ */
+export function validateTicket(payload: unknown): ValidationResult {
+  const parsed = TicketTemplateV1Schema.safeParse(payload);
+  if (parsed.success) {
+    return { ok: true, value: parsed.data };
+  }
+  return { ok: false, errors: flattenIssues(parsed.error) };
+}
+
+/**
+ * Convenience predicate — true if a payload is structurally valid.
+ * Use {@link validateTicket} when you need the parsed value or errors.
+ */
+export function isValidTicket(payload: unknown): boolean {
+  return TicketTemplateV1Schema.safeParse(payload).success;
+}
+
+/**
+ * Throws a descriptive error if the payload is invalid; returns the typed
+ * payload otherwise. Useful at agent boundaries where invariants must hold.
+ */
+export function assertValidTicket(payload: unknown): TicketTemplateV1 {
+  const result = validateTicket(payload);
+  if (!result.ok) {
+    const summary = result.errors
+      .slice(0, 5)
+      .map((e) => `${e.path}: ${e.message}`)
+      .join('; ');
+    throw new Error(`ticket-template: invalid payload — ${summary}`);
+  }
+  return result.value;
+}

--- a/packages/ticket-template/tsconfig.json
+++ b/packages/ticket-template/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,6 +901,22 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/ticket-template:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/tracing:
     dependencies:
       '@opentelemetry/api':


### PR DESCRIPTION
## Gate 3 Phase-1 pipeline — PR 1/N

Foundation for the Phase-1 agent pipeline contract. Subsequent PRs (BA cross-agent collaboration, ticket state machine, bucket-placement decider, getTicketBundle endpoint, phase1-e2e test) build on this.

## What this adds

### `packages/ticket-template` (new private workspace package)
- `TicketTemplateV1Schema` — strict Zod schema with required sections (`scope`, `context`, `acceptanceCriteria`, `verificationPlan`, `dependencies`) and audited per-agent sections (architecture, database, api, ui, security, testing, release, observability).
- Bounded acceptance-criteria count: `[MIN_ACCEPTANCE_CRITERIA=3, MAX_ACCEPTANCE_CRITERIA=10]` so tickets stay actionable.
- Strict mode (no surplus keys) and per-section `contributedBy` + `contributedAt` audit fields.
- `validateTicket` / `isValidTicket` / `assertValidTicket` helpers returning flat field-level errors.
- `buildDraftTicket` builder so PO agent has a typed factory after decomposition.

### `migration 0021_task_buckets_ticket_template.sql`
- New `task_buckets` table:
  - `kind` ∈ {`sequential`, `parallel`}
  - `domain_slug` nullable (non-null for sequential; null for the parallel bucket)
  - `sequence_index` orders sequential buckets
  - status lifecycle `open → in_progress → drained`
  - FK to `prompts.id`
  - Indexes on `prompt_id`, `(kind, domain_slug)`, `status`
- `stories` table additions:
  - `agent_contributions_json` (TicketTemplateV1 payload)
  - `bucket_id` FK to `task_buckets`
  - `template_version` (default `v1`)
  - `template_validation_status` (`pending`/`valid`/`invalid`)
  - `template_validation_errors` (flat JSON of Zod issues)
  - Indexes on `bucket_id`, `template_validation_status`

### Drizzle schema + migration journal
- `taskBuckets` exported from `schema.ts`
- `stories` columns added in TS to mirror the migration
- `meta/_journal.json` updated to entry idx 20

## Tests

- **31/31** vitest cases on `@chiefaia/ticket-template` (builder, every required section, every per-agent section, baEnrichment metadata, strict-mode rejection of unknown keys, AC count bounds, JSON round-trip).
- **8/8** jest migration smoke tests covering: sequential bucket insert, parallel bucket with null domain/sequence, FK acceptance, lifecycle, default-population of new story columns, agentContributionsJson round-trip, story↔bucket link, validation-error JSON round-trip.
- Re-ran existing `db/schema`, `db/dash-208-210-repair`, `db/projects` suites: 27/27 still green.
- `apps/orchestrator pnpm typecheck`: clean.
- `@chiefaia/ticket-template pnpm typecheck`: clean.

## Out of scope (follow-up PRs)

- Wiring agents (PO/BA/Task Scheduler) to read/write the template — next PR.
- BA cross-agent collaboration protocol on `agent_messages` — next PR.
- `task-scheduler.bucket-placed` event + bucket-placement decider — next PR.
- `getTicketBundle` endpoint, ticket state machine, phase1-e2e test — subsequent PRs.

This PR is the structural contract; everything else builds on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ticket template system with strict validation and versioning for inter-agent communication
  * Task scheduling buckets to organize and manage ticket workflows
  * Agent contribution tracking for recording contributor metadata and section ownership

* **Tests**
  * Added comprehensive test coverage for ticket template validation and database schema updates

* **Documentation**
  * Added ticket template documentation including schema specifications, validation rules, and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->