### PR TITLE
feat(analytics,dev-inspector): publish to npm registry (PHASE3-PUBLISH)

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@chiefaia/analytics",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.1.1",
   "description": "Shared GA4 analytics, consent management, and event taxonomy for Pokerzeno sites",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "sideEffects": false,
+  "files": [
+    "src",
+    "tsconfig.json"
+  ],
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
@@ -30,7 +33,6 @@
   },
   "license": "UNLICENSED",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
     "access": "public"
   }
 }

--- a/packages/dev-inspector/package.json
+++ b/packages/dev-inspector/package.json
@@ -1,11 +1,15 @@
 {
   "name": "@chiefaia/dev-inspector",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.1.1",
   "description": "Dev-only React element inspector: hover outline, stable fiber IDs, click-to-copy",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "sideEffects": false,
+  "files": [
+    "src",
+    "tsconfig.json",
+    "tsconfig.build.json"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
@@ -39,7 +43,6 @@
   },
   "license": "UNLICENSED",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
     "access": "public"
   }
 }


### PR DESCRIPTION
## Why

Track 3 vendor consolidation (PR #7 + #8 chain) moved `@chiefaia/analytics` and `@chiefaia/dev-inspector` into the CAIA monorepo as private workspace packages. The consumer sites (`pokerzeno`, `roulettecommunity`) reference them via `file:../caia/packages/*`, which breaks CI on every branch — the CI runners do not co-locate `caia` as a sibling, so `npm install` produces unresolved imports and `next build` errors with `Module not found: Can't resolve '@chiefaia/analytics'`.

Affects all branches in both consuming repos.

## What

Make both packages publishable, following the existing pattern used by the 9 already-published `@chiefaia/*` packages (cli, logger, errors, test-kit, metrics, tracing, config, secrets, events) which all live on npmjs.org public registry.

  - Remove `"private": true`
  - Drop the `publishConfig.registry: https://npm.pkg.github.com` override (defaults to npmjs.org)
  - Bump `0.1.0` → `0.1.1`
  - Add explicit `files` allowlist (`src/` + `tsconfig*.json`)

Consumers use `transpilePackages: ['@chiefaia/dev-inspector', '@chiefaia/analytics']` in `next.config.js`, so shipping TS source rather than compiled JS works without changes on their side.

## How publishing works

`.github/workflows/release.yml` runs on every push to `main`. It calls `changesets/action`, which:
- Sees no changesets present → does **not** open a Version Packages PR
- Falls through to `pnpm release` = `turbo run build && changeset publish`
- `changeset publish` walks workspace packages, finds `@chiefaia/analytics@0.1.1` and `@chiefaia/dev-inspector@0.1.1` are not on the registry → publishes them with `NPM_TOKEN`

## Verification

- `npm pack --dry-run` produces clean tarballs (20 files / 25 files respectively, includes `src/` + `tsconfig*.json`)
- `pnpm install` is a no-op (lockfile unchanged — workspace package version bumps don't affect resolution)
- The build/test workflow (`ci.yml`) is independent and stays green

## Follow-ups

Two consumer PRs will switch from `file:../caia/packages/*` to `@chiefaia/analytics@^0.1.1` and `@chiefaia/dev-inspector@^0.1.1` once published:

- `prakashgbid/pokerzeno` — fix CI on `master` + all branches
- `prakashgbid/roulettecommunity` — same

Both consumer READMEs will be updated: sibling `caia` checkout no longer required for development.