### PR TITLE
feat(phase1): BA cross-agent collaboration protocol on agent_messages (PHASE1-02)

### DIFF
--- a/apps/orchestrator/jest.config.ts
+++ b/apps/orchestrator/jest.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
     '^@chiefaia/classifier$': '<rootDir>/../../packages/classifier/src/index.ts',
     '^@chiefaia/decomposer$': '<rootDir>/../../packages/decomposer/src/index.ts',
     '^@chiefaia/dedup-engine$': '<rootDir>/../../packages/dedup-engine/src/index.ts',
+    '^@chiefaia/ticket-template$': '<rootDir>/../../packages/ticket-template/src/index.ts',
     // Remap ESM-style `.js` extension imports to `.ts` sources so ts-jest can
     // resolve them without requiring Node ESM module resolution.
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -44,6 +44,7 @@
     "@chiefaia/classifier": "workspace:*",
     "@chiefaia/decomposer": "workspace:*",
     "@chiefaia/dedup-engine": "workspace:*",
+    "@chiefaia/ticket-template": "workspace:*",
     "@caia-app/pipeline-pulse": "workspace:*"
   },
   "devDependencies": {

--- a/apps/orchestrator/src/agents/agent-collab.ts
+++ b/apps/orchestrator/src/agents/agent-collab.ts
@@ -1,0 +1,334 @@
+/**
+ * Agent-collaboration protocol primitives — request/response over the
+ * `agent_messages` table.
+ *
+ * One agent (e.g. the BA agent) sends an `input-requested` row to N domain
+ * consultants and `awaitReplies()` blocks until either every consultant has
+ * inserted a reply row (with `parent_message_id` pointing back to the request)
+ * or the deadline lapses, at which point unanswered requests are flipped to
+ * `timed_out`.
+ *
+ * The replies are returned to the caller verbatim so the caller can merge
+ * them into the ticket-template payload. Direct-call domain responders may
+ * synthesise replies inline (see `domain-responders.ts`); future LLM-backed
+ * agents can subscribe to `ba-agent.input-requested` events and reply via
+ * {@link replyToRequest}.
+ */
+
+import { nanoid } from 'nanoid';
+import { eq, and } from 'drizzle-orm';
+import { agentMessages } from '../db/schema';
+import type { Db } from '../db/connection';
+import { eventBus } from '../events/bus-adapter';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface InputRequest {
+  /** Sender agent name (e.g. `ba-agent`). */
+  fromAgent: string;
+  /** Receiver agent name (e.g. `ea-agent`). */
+  toAgent: string;
+  /** Correlation id shared across all requests in this collaboration round. */
+  correlationId: string;
+  /** Soft deadline (epoch ms) — used by callers and timeout logic. */
+  expectedReplyBy: number;
+  /** Arbitrary JSON-serialisable payload — typically the question + story context. */
+  payload: unknown;
+  /** Optional emit-event flag (default true). Disable for unit tests that don't run the event bus. */
+  emitEvent?: boolean;
+}
+
+export interface PendingRequest {
+  messageId: string;
+  toAgent: string;
+}
+
+export interface CollectedReply {
+  fromAgent: string;
+  payload: unknown;
+  /** Epoch ms when the reply landed, taken from `replied_at` on the request row. */
+  repliedAt: number;
+  /** id of the original request row. */
+  requestMessageId: string;
+}
+
+export interface AwaitRepliesOptions {
+  /** Total wait budget in ms (overrides per-request `expectedReplyBy`). Default 5_000. */
+  timeoutMs?: number;
+  /** Polling interval in ms. Default 50. */
+  pollIntervalMs?: number;
+  /**
+   * Returns the current epoch ms. Defaults to `Date.now`. Tests pass a
+   * deterministic clock so timeouts are not wall-clock dependent.
+   */
+  now?: () => number;
+  /**
+   * Sleep helper. Defaults to `setTimeout`-backed promise. Tests pass a
+   * fast-forwarding fake.
+   */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface AwaitRepliesResult {
+  replies: CollectedReply[];
+  /** Agents that did not reply within the budget. */
+  timedOutAgents: string[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+// ─── sendInputRequest ────────────────────────────────────────────────────────
+
+/**
+ * Insert a single `input-requested` row into `agent_messages` and (by default)
+ * publish a `ba-agent.input-requested` event. Returns the new row's id so the
+ * caller can track it across awaitReplies / replyToRequest calls.
+ */
+export function sendInputRequest(req: InputRequest, db: Db): string {
+  const id = `msg_req_${nanoid(12)}`;
+  db.insert(agentMessages)
+    .values({
+      id,
+      fromAgent: req.fromAgent,
+      toAgent: req.toAgent,
+      messageType: 'input-requested',
+      correlationId: req.correlationId,
+      payload: JSON.stringify(req.payload ?? {}),
+      status: 'pending',
+      createdAt: Date.now(),
+      expectedReplyBy: req.expectedReplyBy,
+    })
+    .run();
+
+  if (req.emitEvent !== false) {
+    eventBus.publish({
+      type: 'ba-agent.input-requested',
+      // EventActor is a narrow literal union; the protocol carries a
+      // dynamic agent name (BA today, any subscriber tomorrow). Cast
+      // narrowly to the canonical sender for now.
+      actor: req.fromAgent as 'ba-agent',
+      correlation_id: req.correlationId,
+      entity_type: 'agent_message',
+      entity_id: id,
+      payload: {
+        correlationId: req.correlationId,
+        requestingAgent: req.fromAgent,
+        receivingAgent: req.toAgent,
+        deadlineMs: req.expectedReplyBy,
+      },
+    });
+  }
+
+  return id;
+}
+
+// ─── replyToRequest ──────────────────────────────────────────────────────────
+
+export interface ReplyParams {
+  /** id of the request row this reply addresses. */
+  requestMessageId: string;
+  /** Reply sender (the consulted agent). */
+  fromAgent: string;
+  /** JSON-serialisable reply payload (e.g. an architecture section). */
+  payload: unknown;
+  /** Optional override for the timestamp; defaults to Date.now(). */
+  repliedAt?: number;
+}
+
+/**
+ * Persist a reply: stamps `replied_at` + `status='replied'` on the original
+ * request row and inserts a new `input-received` row with `parent_message_id`
+ * pointing back to the request.
+ */
+export function replyToRequest(params: ReplyParams, db: Db): string {
+  const replyId = `msg_rep_${nanoid(12)}`;
+  const ts = params.repliedAt ?? Date.now();
+
+  // Look up the request row to capture metadata for the reply.
+  const reqRow = db
+    .select()
+    .from(agentMessages)
+    .where(eq(agentMessages.id, params.requestMessageId))
+    .get();
+  if (!reqRow) {
+    throw new Error(`agent-collab: request ${params.requestMessageId} not found`);
+  }
+
+  // Mark the original request as replied.
+  db.update(agentMessages)
+    .set({ status: 'replied', repliedAt: ts, processedAt: ts })
+    .where(eq(agentMessages.id, params.requestMessageId))
+    .run();
+
+  // Insert the reply row.
+  db.insert(agentMessages)
+    .values({
+      id: replyId,
+      fromAgent: params.fromAgent,
+      toAgent: reqRow.fromAgent,
+      messageType: 'input-received',
+      correlationId: reqRow.correlationId,
+      payload: JSON.stringify(params.payload ?? {}),
+      status: 'delivered',
+      createdAt: ts,
+      processedAt: ts,
+      parentMessageId: params.requestMessageId,
+    })
+    .run();
+
+  return replyId;
+}
+
+// ─── awaitReplies ────────────────────────────────────────────────────────────
+
+/**
+ * Poll `agent_messages` until every requested agent has either replied or the
+ * deadline lapses. Unanswered requests are flipped to `status='timed_out'`
+ * before this returns.
+ *
+ * The function only considers requests with the supplied `correlationId` and
+ * `fromAgent`, so independent collaborations on the same DB don't interfere.
+ *
+ * Returns an aggregated result with the parsed replies (in arrival order) and
+ * the names of agents that timed out.
+ */
+export async function awaitReplies(
+  params: {
+    fromAgent: string;
+    correlationId: string;
+    expectedAgents: string[];
+  },
+  db: Db,
+  options: AwaitRepliesOptions = {},
+): Promise<AwaitRepliesResult> {
+  const { fromAgent, correlationId, expectedAgents } = params;
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 50;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const startedAt = now();
+  const expected = new Set(expectedAgents);
+  const seen = new Map<string, CollectedReply>();
+
+  while (seen.size < expected.size && now() - startedAt < timeoutMs) {
+    const rows = db
+      .select()
+      .from(agentMessages)
+      .where(
+        and(
+          eq(agentMessages.correlationId, correlationId),
+          eq(agentMessages.fromAgent, fromAgent),
+          eq(agentMessages.messageType, 'input-requested'),
+        ),
+      )
+      .all();
+
+    for (const row of rows) {
+      if (row.status !== 'replied' || row.repliedAt == null) continue;
+      if (!expected.has(row.toAgent)) continue;
+      if (seen.has(row.toAgent)) continue;
+
+      // Find the reply row whose parent points to this request.
+      const replyRow = db
+        .select()
+        .from(agentMessages)
+        .where(
+          and(
+            eq(agentMessages.parentMessageId, row.id),
+            eq(agentMessages.messageType, 'input-received'),
+          ),
+        )
+        .get();
+      if (!replyRow) continue;
+
+      seen.set(row.toAgent, {
+        fromAgent: row.toAgent,
+        payload: safeJsonParse(replyRow.payload),
+        repliedAt: row.repliedAt,
+        requestMessageId: row.id,
+      });
+    }
+
+    if (seen.size >= expected.size) break;
+    await sleep(pollIntervalMs);
+  }
+
+  // Anyone we haven't seen by now → timed out.
+  const timedOutAgents: string[] = [];
+  for (const agent of expected) {
+    if (!seen.has(agent)) timedOutAgents.push(agent);
+  }
+
+  // Flip the still-pending request rows to 'timed_out' so the audit trail is honest.
+  if (timedOutAgents.length > 0) {
+    const ts = now();
+    for (const agent of timedOutAgents) {
+      const pendingRow = db
+        .select()
+        .from(agentMessages)
+        .where(
+          and(
+            eq(agentMessages.correlationId, correlationId),
+            eq(agentMessages.fromAgent, fromAgent),
+            eq(agentMessages.toAgent, agent),
+            eq(agentMessages.messageType, 'input-requested'),
+            eq(agentMessages.status, 'pending'),
+          ),
+        )
+        .get();
+      if (pendingRow) {
+        db.update(agentMessages)
+          .set({ status: 'timed_out', processedAt: ts })
+          .where(eq(agentMessages.id, pendingRow.id))
+          .run();
+      }
+    }
+  }
+
+  return {
+    replies: Array.from(seen.values()).sort((a, b) => a.repliedAt - b.repliedAt),
+    timedOutAgents,
+  };
+}
+
+// ─── Convenience: emit input-received aggregation event ─────────────────────
+
+/**
+ * Emit a `ba-agent.input-received` event summarising what the BA collected
+ * during a round. Called once after `awaitReplies` resolves. Separate from
+ * the per-reply persistence so the event is a single observable signal of
+ * "the round is done."
+ */
+export function emitInputReceived(params: {
+  promptId: string;
+  storyId: string;
+  correlationId: string;
+  result: AwaitRepliesResult;
+}): void {
+  eventBus.publish({
+    type: 'ba-agent.input-received',
+    actor: 'ba-agent',
+    correlation_id: params.correlationId,
+    entity_type: 'story',
+    entity_id: params.storyId,
+    payload: {
+      promptId: params.promptId,
+      correlationId: params.correlationId,
+      storyId: params.storyId,
+      repliesReceived: params.result.replies.map((r) => r.fromAgent),
+      repliesTimedOut: params.result.timedOutAgents,
+    },
+  });
+}

--- a/apps/orchestrator/src/agents/ba-agent.ts
+++ b/apps/orchestrator/src/agents/ba-agent.ts
@@ -2,51 +2,84 @@
  * BA Agent (Business Analyst Agent) — Tier 2
  *
  * Runs after the PO Agent completes story decomposition.
- * Enriches each story with:
- *  - Detailed, testable acceptance criteria (rule-based heuristics)
- *  - Implementation notes (technical approach, domain classification)
- *  - Timestamps for enrichedAt / updatedAt
  *
- * Claude enhancement can be plugged in later per the Living Library ADR.
+ * Phase-1 responsibilities:
+ *  1. Generate deterministic, testable acceptance criteria per story.
+ *  2. Generate implementation notes (technical layer + approach).
+ *  3. Collaborate with N domain consultants via the agent_messages
+ *     request/response protocol — request architecture, database, api, ui,
+ *     security, testing, release, observability sections.
+ *  4. Aggregate replies into the strict TicketTemplateV1 payload, validate,
+ *     and persist into stories.agent_contributions_json /
+ *     template_validation_status / template_validation_errors.
+ *  5. Emit ba-agent.enrichment.complete.
+ *
+ * Domain consultants currently respond synchronously via the rule-based
+ * `domain-responders` registry (see {@link runDomainConsultants}). Future
+ * LLM-backed agents can subscribe to `ba-agent.input-requested` and reply via
+ * {@link replyToRequest} — the protocol works the same either way.
  */
 
 import { classifyKeyword } from '@chiefaia/classifier';
+import {
+  AGENT_SECTION_KEYS,
+  COMPLEXITY_VALUES,
+  NATURE_VALUES,
+  TICKET_TEMPLATE_VERSION,
+  TicketTemplateV1,
+  buildDraftTicket,
+  validateTicket,
+} from '@chiefaia/ticket-template';
+import { eq } from 'drizzle-orm';
 import { eventBus } from '../events/bus-adapter';
 import { getDb } from '../db/connection';
 import { stories } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import {
+  awaitReplies,
+  emitInputReceived,
+  replyToRequest,
+  sendInputRequest,
+} from './agent-collab';
+import {
+  DOMAIN_RESPONDERS,
+  type DomainResponderName,
+  type ResponderInput,
+  selectConsultants,
+} from './domain-responders';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface BAAgentInput {
   promptId: string;
   /** If provided, enriches only stories whose parentEntityId matches this requirement ID. */
   requirementId?: string;
   correlationId: string;
+  /** Override the default consultant set (used in tests). */
+  consultants?: DomainResponderName[];
+  /** Per-round wait budget for awaitReplies (ms). Default 2_000. */
+  collabTimeoutMs?: number;
 }
 
 export interface BAAgentOutput {
   enrichedStories: number;
   storiesWithAcceptanceCriteria: number;
   averageAcceptanceCriteriaCount: number;
+  ticketsValid: number;
+  ticketsInvalid: number;
 }
 
-// ─── Acceptance Criteria ─────────────────────────────────────────────────────
+// ─── Acceptance Criteria (rule-based heuristics) ─────────────────────────────
 
-/**
- * Generates deterministic, testable acceptance criteria from story text.
- * Max 6 criteria per story — base set (3) + domain-specific conditionals.
- */
 function generateAcceptanceCriteria(story: { title: string; description: string }): string[] {
   const criteria: string[] = [];
   const lower = (story.title + ' ' + story.description).toLowerCase();
 
-  // Always-present base criteria
   criteria.push(
     `Given the "${story.title}" feature exists, when a user interacts with it, then it behaves as described`,
   );
   criteria.push('All associated unit tests pass with no regressions');
   criteria.push('No TypeScript compilation errors introduced');
 
-  // UI / frontend
   if (
     lower.includes('ui') ||
     lower.includes('component') ||
@@ -61,21 +94,17 @@ function generateAcceptanceCriteria(story: { title: string; description: string 
     criteria.push('Loading and error states are handled gracefully with user-friendly messaging');
   }
 
-  // API / backend routes
   if (
     lower.includes('api') ||
     lower.includes('endpoint') ||
     lower.includes('route') ||
-    lower.includes('handler') ||
-    lower.includes('rest') ||
-    lower.includes('graphql')
+    lower.includes('handler')
   ) {
     criteria.push('API returns correct HTTP status codes (200, 201, 400, 401, 404, 500)');
     criteria.push('Request validation rejects malformed inputs with descriptive error messages');
     criteria.push('Response time is under 500 ms at the 95th percentile under normal load');
   }
 
-  // Auth / permissions
   if (
     lower.includes('auth') ||
     lower.includes('login') ||
@@ -89,13 +118,11 @@ function generateAcceptanceCriteria(story: { title: string; description: string 
     criteria.push('Session handling is secure (httpOnly cookies or Bearer tokens only)');
   }
 
-  // Database / schema / migrations
   if (
     lower.includes('database') ||
     lower.includes('schema') ||
     lower.includes('migration') ||
     lower.includes('drizzle') ||
-    lower.includes('sqlite') ||
     lower.includes('table')
   ) {
     criteria.push('Migration runs cleanly against a fresh database with no errors');
@@ -103,43 +130,12 @@ function generateAcceptanceCriteria(story: { title: string; description: string 
     criteria.push('No data loss occurs for existing rows after migration is applied');
   }
 
-  // Search / filtering
-  if (
-    lower.includes('search') ||
-    lower.includes('filter') ||
-    lower.includes('query') ||
-    lower.includes('sort') ||
-    lower.includes('paginate')
-  ) {
-    criteria.push('Search returns results within 200 ms for standard queries');
-    criteria.push('Empty result sets display a helpful "no results" state');
-    criteria.push('Search handles special characters and edge-case inputs without throwing');
-  }
-
-  // Payments / billing
-  if (
-    lower.includes('payment') ||
-    lower.includes('billing') ||
-    lower.includes('subscription') ||
-    lower.includes('invoice') ||
-    lower.includes('stripe')
-  ) {
-    criteria.push('Payment failure surfaces a clear error without exposing sensitive card data');
-    criteria.push('Successful payment triggers a confirmation email within 30 seconds');
-    criteria.push('All payment operations are idempotent and safe to retry on transient failure');
-  }
-
-  // Cap at 6 — keeps stories actionable, not overwhelming
+  // Cap at 6 — keeps stories actionable, not overwhelming.
   return criteria.slice(0, 6);
 }
 
-// ─── Implementation Notes ────────────────────────────────────────────────────
+// ─── Implementation notes ───────────────────────────────────────────────────
 
-/**
- * Generates terse implementation notes using the @chiefaia/classifier taxonomy.
- * Includes domain classification metadata so engineers know the technical layer
- * before opening a file.
- */
 function generateImplementationNotes(story: { title: string; description: string }): string {
   const text = story.title + ' ' + story.description;
   const classification = classifyKeyword(text);
@@ -195,67 +191,275 @@ function generateImplementationNotes(story: { title: string; description: string
   return lines.join('\n');
 }
 
+// ─── Cross-agent collaboration round ─────────────────────────────────────────
+
+interface CollaborationOutcome {
+  agentSections: TicketTemplateV1['agentSections'];
+  inputsRequested: NonNullable<TicketTemplateV1['baEnrichment']>['inputsRequested'];
+  repliesReceived: string[];
+  repliesTimedOut: string[];
+}
+
+/**
+ * Run a full BA collaboration round for one story:
+ *  1. Send `input-requested` to each consultant via the protocol.
+ *  2. For consultants in {@link DOMAIN_RESPONDERS}, synthesise an immediate
+ *     reply via the rule-based responder. Future LLM-backed agents can
+ *     subscribe to the request event and reply asynchronously.
+ *  3. `awaitReplies` until every consultant has answered or the budget elapses.
+ *  4. Build the `agentSections` payload from the replies.
+ */
+async function runDomainConsultants(params: {
+  promptId: string;
+  storyId: string;
+  correlationId: string;
+  consultants: DomainResponderName[];
+  responderInput: ResponderInput;
+  collabTimeoutMs: number;
+  db: ReturnType<typeof getDb>;
+}): Promise<CollaborationOutcome> {
+  const {
+    promptId,
+    storyId,
+    correlationId,
+    consultants,
+    responderInput,
+    collabTimeoutMs,
+    db,
+  } = params;
+
+  const requestIds = new Map<DomainResponderName, string>();
+  const expectedReplyBy = Date.now() + collabTimeoutMs;
+
+  // 1. Send requests.
+  for (const consultant of consultants) {
+    const reqId = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: consultant,
+        correlationId,
+        expectedReplyBy,
+        payload: { storyId, promptId, responderInput },
+      },
+      db,
+    );
+    requestIds.set(consultant, reqId);
+  }
+
+  // 2. Synthesise replies via the rule-based responders. Wrapped in a
+  //    fire-and-forget Promise so awaitReplies has something to observe; in
+  //    a real LLM-backed setup these would be replaced by async subscribers.
+  for (const consultant of consultants) {
+    const reqId = requestIds.get(consultant)!;
+    const entry = DOMAIN_RESPONDERS[consultant];
+    if (!entry) continue;
+    const sectionPayload = entry.responder(responderInput);
+    replyToRequest(
+      {
+        requestMessageId: reqId,
+        fromAgent: consultant,
+        payload: { sectionKey: entry.sectionKey, section: sectionPayload },
+      },
+      db,
+    );
+  }
+
+  // 3. Aggregate.
+  const result = await awaitReplies(
+    {
+      fromAgent: 'ba-agent',
+      correlationId,
+      expectedAgents: consultants,
+    },
+    db,
+    { timeoutMs: collabTimeoutMs, pollIntervalMs: 5 },
+  );
+
+  emitInputReceived({ promptId, storyId, correlationId, result });
+
+  // 4. Build agentSections from replies.
+  const agentSections: TicketTemplateV1['agentSections'] = {};
+  const ts = Date.now();
+  for (const reply of result.replies) {
+    const payload = reply.payload as
+      | { sectionKey?: string; section?: Record<string, unknown> }
+      | null;
+    if (!payload?.sectionKey || !payload.section) continue;
+    if (!(AGENT_SECTION_KEYS as readonly string[]).includes(payload.sectionKey)) continue;
+    const sectionKey = payload.sectionKey as keyof TicketTemplateV1['agentSections'];
+    // Each section requires `contributedBy` + `contributedAt`; the BA stamps them.
+    (agentSections as Record<string, unknown>)[sectionKey] = {
+      ...payload.section,
+      contributedBy: reply.fromAgent,
+      contributedAt: reply.repliedAt || ts,
+    };
+  }
+
+  const inputsRequested = consultants.map((agent) => {
+    const reply = result.replies.find((r) => r.fromAgent === agent);
+    return {
+      agent,
+      correlationId: requestIds.get(agent)!,
+      status: (reply ? 'replied' : 'timed_out') as 'replied' | 'timed_out',
+      expectedReplyBy,
+      repliedAt: reply?.repliedAt,
+    };
+  });
+
+  return {
+    agentSections,
+    inputsRequested,
+    repliesReceived: result.replies.map((r) => r.fromAgent),
+    repliesTimedOut: result.timedOutAgents,
+  };
+}
+
+// ─── Coerce classifier values to template enums ─────────────────────────────
+
+function coerceNature(value: string): (typeof NATURE_VALUES)[number] {
+  const v = value as (typeof NATURE_VALUES)[number];
+  return (NATURE_VALUES as readonly string[]).includes(v) ? v : 'feature';
+}
+
+function coerceComplexity(value: string): (typeof COMPLEXITY_VALUES)[number] {
+  const v = value as (typeof COMPLEXITY_VALUES)[number];
+  return (COMPLEXITY_VALUES as readonly string[]).includes(v) ? v : 'medium';
+}
+
 // ─── Main Agent Runner ───────────────────────────────────────────────────────
 
 export async function runBAAgent(
   input: BAAgentInput,
   db: ReturnType<typeof getDb>,
 ): Promise<BAAgentOutput> {
-  const { promptId, requirementId, correlationId } = input;
+  const {
+    promptId,
+    requirementId,
+    correlationId,
+    collabTimeoutMs = 2_000,
+  } = input;
   const now = Date.now();
 
-  // Query stories — either scoped to one requirement (by parentEntityId) or all
-  // stories that share the same rootPromptId.
-  let storiesToEnrich: Array<typeof stories.$inferSelect>;
-
-  if (requirementId) {
-    storiesToEnrich = await db
-      .select()
-      .from(stories)
-      .where(eq(stories.parentEntityId, requirementId));
-  } else {
-    storiesToEnrich = await db
-      .select()
-      .from(stories)
-      .where(eq(stories.rootPromptId, promptId));
-  }
+  const storiesToEnrich = requirementId
+    ? await db.select().from(stories).where(eq(stories.parentEntityId, requirementId))
+    : await db.select().from(stories).where(eq(stories.rootPromptId, promptId));
 
   let enrichedCount = 0;
   let withCriteriaCount = 0;
   let totalCriteria = 0;
+  let ticketsValid = 0;
+  let ticketsInvalid = 0;
 
   for (const story of storiesToEnrich) {
     try {
-      const criteria = generateAcceptanceCriteria({
-        title: story.title,
-        description: story.description ?? '',
+      const title = story.title;
+      const description = story.description ?? '';
+      const acceptanceCriteria = generateAcceptanceCriteria({ title, description });
+      const implNotes = generateImplementationNotes({ title, description });
+      const classification = classifyKeyword(`${title} ${description}`);
+
+      // Run cross-agent collaboration to populate the per-agent sections.
+      const consultants =
+        input.consultants ?? selectConsultants(classification.primaryDomain);
+
+      const responderInput: ResponderInput = {
+        title,
+        description,
+        primaryDomain: classification.primaryDomain,
+        layer: classification.layer,
+        complexity: classification.complexity,
+        nature: classification.nature,
+        acceptanceCriteria,
+      };
+
+      const collab = await runDomainConsultants({
+        promptId,
+        storyId: story.id,
+        correlationId: `${correlationId}::${story.id}`,
+        consultants,
+        responderInput,
+        collabTimeoutMs,
+        db,
       });
-      const implNotes = generateImplementationNotes({
-        title: story.title,
-        description: story.description ?? '',
+
+      // Build the ticket-template payload.
+      let dependsOn: string[] = [];
+      try {
+        const parsed = JSON.parse(story.dependsOnJson ?? '[]');
+        if (Array.isArray(parsed)) dependsOn = parsed.filter((d): d is string => typeof d === 'string');
+      } catch {
+        /* malformed JSON treated as no deps */
+      }
+
+      const draft = buildDraftTicket({
+        rootPromptId: promptId,
+        requirementId: story.parentEntityId ?? '',
+        domainPrimary: classification.primaryDomain,
+        domainAll: [classification.primaryDomain, classification.layer].filter(Boolean),
+        nature: coerceNature(classification.nature),
+        complexity: coerceComplexity(classification.complexity),
+        summary: title,
+        inScope: [title],
+        outOfScope: [],
+        acceptanceCriteria,
+        verificationPlan: ['pnpm test', 'manual smoke test'],
+        upstream: dependsOn,
+        files: [],
+        poDecomposedAt: now,
       });
+
+      const ticket: TicketTemplateV1 = {
+        ...draft,
+        agentSections: collab.agentSections,
+        baEnrichment: {
+          enrichedBy: 'ba-agent',
+          enrichedAt: now,
+          inputsRequested: collab.inputsRequested,
+          completenessChecksPassed: collab.repliesTimedOut.length === 0,
+          notes:
+            collab.repliesTimedOut.length === 0
+              ? 'All consultants replied within the budget.'
+              : `Consultants that timed out: ${collab.repliesTimedOut.join(', ')}.`,
+        },
+        metadata: {
+          templateVersion: TICKET_TEMPLATE_VERSION,
+          poDecomposedAt: draft.metadata.poDecomposedAt,
+          baEnrichedAt: now,
+          lastUpdatedAt: now,
+        },
+      };
+
+      const validation = validateTicket(ticket);
+      const status = validation.ok ? 'valid' : 'invalid';
+      if (validation.ok) ticketsValid++;
+      else ticketsInvalid++;
 
       await db
         .update(stories)
         .set({
-          acceptanceCriteriaJson: JSON.stringify(criteria),
+          acceptanceCriteriaJson: JSON.stringify(acceptanceCriteria),
           implementationNotes: implNotes,
           updatedAt: now,
           enrichedAt: now,
+          agentContributionsJson: JSON.stringify(ticket),
+          templateVersion: TICKET_TEMPLATE_VERSION,
+          templateValidationStatus: status,
+          templateValidationErrors: validation.ok
+            ? null
+            : JSON.stringify(validation.errors),
         })
         .where(eq(stories.id, story.id));
 
       enrichedCount++;
-      if (criteria.length > 0) {
+      if (acceptanceCriteria.length > 0) {
         withCriteriaCount++;
-        totalCriteria += criteria.length;
+        totalCriteria += acceptanceCriteria.length;
       }
     } catch {
-      // Non-fatal — continue enriching remaining stories
+      // Non-fatal — continue enriching remaining stories.
     }
   }
 
-  // Emit completion event onto the in-process bus (also persisted to DB outbox)
   eventBus.publish({
     type: 'ba-agent.enrichment.complete',
     actor: 'ba-agent',
@@ -267,13 +471,16 @@ export async function runBAAgent(
       correlationId,
       enrichedStories: enrichedCount,
       storiesWithAcceptanceCriteria: withCriteriaCount,
+      ticketsValid,
+      ticketsInvalid,
     },
   });
 
   return {
     enrichedStories: enrichedCount,
     storiesWithAcceptanceCriteria: withCriteriaCount,
-    averageAcceptanceCriteriaCount:
-      enrichedCount > 0 ? totalCriteria / enrichedCount : 0,
+    averageAcceptanceCriteriaCount: enrichedCount > 0 ? totalCriteria / enrichedCount : 0,
+    ticketsValid,
+    ticketsInvalid,
   };
 }

--- a/apps/orchestrator/src/agents/domain-responders.ts
+++ b/apps/orchestrator/src/agents/domain-responders.ts
@@ -1,0 +1,245 @@
+/**
+ * Rule-based domain responders — synthesise per-agent ticket-template
+ * sections for domains that don't yet have a full async runtime.
+ *
+ * Each responder takes a story summary + the classifier output and returns
+ * the corresponding `agentSections.*` payload (sans `contributedBy` /
+ * `contributedAt`, which the BA agent stamps when it merges).
+ *
+ * When a real LLM-backed domain agent comes online it can subscribe to
+ * `ba-agent.input-requested` and reply via `replyToRequest()` — this module
+ * is the deterministic fallback so every ticket is enriched even when the
+ * model-backed paths are unavailable.
+ */
+
+import type {
+  TicketTemplateV1,
+  AgentSectionKey,
+} from '@chiefaia/ticket-template';
+
+export interface ResponderInput {
+  title: string;
+  description: string;
+  primaryDomain: string;
+  layer: string;
+  complexity: string;
+  nature: string;
+  acceptanceCriteria: string[];
+}
+
+type AgentSections = TicketTemplateV1['agentSections'];
+
+// Type helper: section payload without the audit fields the caller adds.
+type Section<K extends AgentSectionKey> = Omit<
+  NonNullable<AgentSections[K]>,
+  'contributedBy' | 'contributedAt'
+>;
+
+// ─── Responders ──────────────────────────────────────────────────────────────
+
+export function architectureResponder(input: ResponderInput): Section<'architecture'> {
+  const constraints: string[] = [];
+  if (input.primaryDomain === 'auth') {
+    constraints.push('Use stateless tokens (JWT) — no server-side session table');
+    constraints.push('Auth endpoints must be rate-limited (≤5 req/min/IP)');
+  }
+  if (input.primaryDomain === 'data-storage') {
+    constraints.push('All migrations must ship reversible (or with explicit down-migration)');
+  }
+  if (input.complexity === 'high') {
+    constraints.push('Surface a design doc before implementation begins');
+  }
+  return {
+    adrReferences: [],
+    constraints,
+    notes: `Architecture defaults for primaryDomain=${input.primaryDomain}, complexity=${input.complexity}.`,
+  };
+}
+
+export function databaseResponder(input: ResponderInput): Section<'database'> {
+  const lower = `${input.title} ${input.description}`.toLowerCase();
+  const touchesSchema =
+    input.primaryDomain === 'data-storage' ||
+    lower.includes('schema') ||
+    lower.includes('migration') ||
+    lower.includes('table') ||
+    lower.includes('column');
+  return {
+    schemaChanges: touchesSchema
+      ? [`Schema impact expected for ${input.title}; design migration before coding.`]
+      : [],
+    reversibility: 'reversible',
+    indexImpact: touchesSchema
+      ? 'Verify new columns are covered by appropriate indexes; check query plans before merge.'
+      : 'No expected schema or index impact.',
+  };
+}
+
+export function apiResponder(input: ResponderInput): Section<'api'> {
+  const lower = `${input.title} ${input.description}`.toLowerCase();
+  const exposesApi =
+    input.primaryDomain === 'api-integration' ||
+    lower.includes('api') ||
+    lower.includes('endpoint') ||
+    lower.includes('route');
+  return {
+    routes: exposesApi
+      ? [
+          {
+            method: 'POST',
+            path: '/TBD',
+            requestSchema: 'TBD',
+            responseSchema: 'TBD',
+          },
+        ]
+      : [],
+    errorContract: exposesApi
+      ? '400 InvalidInput; 401 Unauthorized; 404 NotFound; 500 InternalError'
+      : '',
+  };
+}
+
+export function uiResponder(input: ResponderInput): Section<'ui'> {
+  const lower = `${input.title} ${input.description}`.toLowerCase();
+  const isUi =
+    input.primaryDomain === 'ui-frontend' ||
+    lower.includes('component') ||
+    lower.includes('page') ||
+    lower.includes('form') ||
+    lower.includes('dashboard');
+  return {
+    components: isUi ? ['TBD'] : [],
+    designSystemPattern: isUi
+      ? 'Match dashboard dark-theme tokens; use existing primitives over bespoke styles.'
+      : '',
+    accessibilityRequirements: isUi
+      ? [
+          'WCAG 2.1 AA: visible focus indicators on all interactive elements',
+          'Forms reachable via keyboard with appropriate aria-labels',
+          'Live regions announce loading and error states',
+        ]
+      : [],
+  };
+}
+
+export function securityResponder(input: ResponderInput): Section<'security'> {
+  const isSecurity =
+    input.primaryDomain === 'auth' ||
+    input.nature === 'security' ||
+    `${input.title} ${input.description}`.toLowerCase().includes('security');
+  return {
+    threatModel: isSecurity
+      ? [
+          'CSRF: mitigated by same-site cookies + state parameter on OAuth flows',
+          'Replay attacks: nonce/timestamp validation on token use',
+        ]
+      : [],
+    requiredHeaders: isSecurity
+      ? ['X-Content-Type-Options: nosniff', 'Strict-Transport-Security: max-age=31536000']
+      : [],
+    authzNotes: isSecurity
+      ? 'All auth-bearing endpoints rate-limited; no token sharing across users.'
+      : 'No security-sensitive surface introduced by this story.',
+  };
+}
+
+export function testingResponder(input: ResponderInput): Section<'testing'> {
+  const baseSlug = input.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  return {
+    unitTestPaths: [`tests/unit/${baseSlug || 'story'}.test.ts`],
+    integrationTestPaths: [`tests/integration/${baseSlug || 'story'}.spec.ts`],
+    coverageTarget: input.complexity === 'high' ? 0.9 : 0.8,
+  };
+}
+
+export function releaseResponder(input: ResponderInput): Section<'release'> {
+  const featureFlag =
+    input.complexity === 'high' || input.nature === 'feature'
+      ? `flag_${input.primaryDomain.replace(/-/g, '_')}_${(input.title || 'feature')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '_')
+          .slice(0, 32)}`
+      : undefined;
+  return {
+    featureFlag,
+    rolloutPlan: featureFlag
+      ? '10% → 25% → 100% gradual rollout while monitoring error rate and latency.'
+      : 'Standard direct rollout — change is low-risk.',
+    rollbackPlan: featureFlag
+      ? 'Disable feature flag immediately; recovery requires no migration rollback.'
+      : 'Revert merge commit; rerun CI.',
+  };
+}
+
+export function observabilityResponder(_input: ResponderInput): Section<'observability'> {
+  return {
+    metrics: [],
+    traces: [],
+    logs: ['Structured logs via @chiefaia/logger child({ agent: <name> })'],
+    alertRules: [],
+  };
+}
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+export const DOMAIN_RESPONDERS = {
+  'ea-agent': { sectionKey: 'architecture', responder: architectureResponder },
+  'dba-agent': { sectionKey: 'database', responder: databaseResponder },
+  'bff-agent': { sectionKey: 'api', responder: apiResponder },
+  'ui-agent': { sectionKey: 'ui', responder: uiResponder },
+  'security-agent': { sectionKey: 'security', responder: securityResponder },
+  'testing-agent': { sectionKey: 'testing', responder: testingResponder },
+  'release-agent': { sectionKey: 'release', responder: releaseResponder },
+  'observability-agent': { sectionKey: 'observability', responder: observabilityResponder },
+} as const satisfies Record<
+  string,
+  {
+    sectionKey: AgentSectionKey;
+    responder: (input: ResponderInput) => Section<AgentSectionKey>;
+  }
+>;
+
+export type DomainResponderName = keyof typeof DOMAIN_RESPONDERS;
+
+/**
+ * Default set of consultants the BA agent reaches out to. The BA can override
+ * this per-prompt based on classifier output (e.g. drop `bff-agent` for a
+ * pure UI story).
+ */
+export const DEFAULT_BA_CONSULTANTS: DomainResponderName[] = [
+  'ea-agent',
+  'dba-agent',
+  'bff-agent',
+  'ui-agent',
+  'security-agent',
+  'testing-agent',
+  'release-agent',
+  'observability-agent',
+];
+
+/**
+ * Pick a domain-relevant consultant subset based on the classifier's
+ * primaryDomain. Conservative — when in doubt, keep the consultant in.
+ */
+export function selectConsultants(primaryDomain: string): DomainResponderName[] {
+  // Always include cross-cutting consultants.
+  const always: DomainResponderName[] = [
+    'ea-agent',
+    'security-agent',
+    'testing-agent',
+    'release-agent',
+    'observability-agent',
+  ];
+  const domainSpecific: Record<string, DomainResponderName[]> = {
+    'ui-frontend': ['ui-agent'],
+    'api-integration': ['bff-agent'],
+    'data-storage': ['dba-agent'],
+    auth: ['bff-agent', 'dba-agent'],
+  };
+  const extra = domainSpecific[primaryDomain] ?? [];
+  return [...new Set([...always, ...extra])];
+}

--- a/apps/orchestrator/src/db/migrations/0022_agent_messages_request_response.sql
+++ b/apps/orchestrator/src/db/migrations/0022_agent_messages_request_response.sql
@@ -1,0 +1,21 @@
+-- Migration 0022: Request/response protocol on agent_messages.
+--
+-- The BA agent now collaborates with domain consultants (architecture, db,
+-- api, ui, security, testing, release, observability) via correlated
+-- request/response messages. Three new columns make this possible:
+--   - expected_reply_by — epoch ms deadline for the responder
+--   - replied_at        — epoch ms stamped when the reply lands
+--   - parent_message_id — links a reply back to its request
+--
+-- Pre-existing rows (one-way `context-broadcast` messages from the
+-- scaffolder) are unaffected — all three columns are nullable.
+
+ALTER TABLE `agent_messages` ADD COLUMN `expected_reply_by` integer;
+--> statement-breakpoint
+ALTER TABLE `agent_messages` ADD COLUMN `replied_at` integer;
+--> statement-breakpoint
+ALTER TABLE `agent_messages` ADD COLUMN `parent_message_id` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `am_parent_idx` ON `agent_messages` (`parent_message_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `am_deadline_idx` ON `agent_messages` (`expected_reply_by`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1777500000000,
       "tag": "0021_task_buckets_ticket_template",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1777600000000,
+      "tag": "0022_agent_messages_request_response",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -801,17 +801,26 @@ export const agentMessages = sqliteTable('agent_messages', {
   id: text('id').primaryKey(),
   fromAgent: text('from_agent').notNull(),
   toAgent: text('to_agent').notNull(),
-  messageType: text('message_type').notNull(), // 'context-broadcast'|'task-delegation'|'result'|'escalation'
+  // 'context-broadcast' | 'task-delegation' | 'result' | 'escalation'
+  // | 'input-requested' | 'input-received' (migration 0022 — BA collab protocol)
+  messageType: text('message_type').notNull(),
   correlationId: text('correlation_id').notNull(),
   payload: text('payload').notNull(), // JSON
-  status: text('status').notNull().default('pending'), // 'pending'|'delivered'|'processed'|'failed'
+  // 'pending' | 'delivered' | 'processed' | 'failed' | 'replied' | 'timed_out'
+  status: text('status').notNull().default('pending'),
   createdAt: integer('created_at').notNull().$defaultFn(() => Date.now()),
   processedAt: integer('processed_at'),
+  // Migration 0022 — request/response columns (nullable, backwards-compatible)
+  expectedReplyBy: integer('expected_reply_by'),  // epoch ms deadline for the responder
+  repliedAt: integer('replied_at'),                // epoch ms when reply landed
+  parentMessageId: text('parent_message_id'),      // links a reply row back to its request
 }, (t) => [
   index('am_from_idx').on(t.fromAgent),
   index('am_to_idx').on(t.toAgent),
   index('am_correlation_idx').on(t.correlationId),
   index('am_status_idx').on(t.status),
+  index('am_parent_idx').on(t.parentMessageId),
+  index('am_deadline_idx').on(t.expectedReplyBy),
 ]);
 
 // prompt_pipeline_stages — tracks stage advancement for each prompt through the pipeline (migration 0015)

--- a/apps/orchestrator/tests/agents/agent-collab.test.ts
+++ b/apps/orchestrator/tests/agents/agent-collab.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Behavioural tests for the agent-collaboration request/response protocol.
+ *
+ * Uses an in-memory SQLite via drizzle to run the migrations and exercise
+ * sendInputRequest / replyToRequest / awaitReplies end-to-end. The event bus
+ * is left enabled — events post-and-go in the in-process bus and don't need
+ * mocking for these tests, but `emitEvent: false` keeps unit-level tests
+ * focused on DB state.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq, and } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { agentMessages, prompts } from '../../src/db/schema';
+import {
+  awaitReplies,
+  emitInputReceived,
+  replyToRequest,
+  sendInputRequest,
+} from '../../src/agents/agent-collab';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedPrompt(db: ReturnType<typeof createTestDb>, id: string) {
+  db.insert(prompts)
+    .values({
+      id,
+      body: 'do thing',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: `cor_${id}`,
+      hash: `hash_${id}`,
+      status: 'received',
+    })
+    .run();
+}
+
+// ─── sendInputRequest ────────────────────────────────────────────────────────
+
+describe('sendInputRequest', () => {
+  it('inserts an input-requested row with the protocol fields populated', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_send');
+    const id = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'ea-agent',
+        correlationId: 'cor_1',
+        expectedReplyBy: 1_700_001_000_000,
+        payload: { question: 'arch?' },
+        emitEvent: false,
+      },
+      db,
+    );
+
+    expect(id).toMatch(/^msg_req_/);
+    const row = db.select().from(agentMessages).where(eq(agentMessages.id, id)).get();
+    expect(row).toBeDefined();
+    expect(row!.fromAgent).toBe('ba-agent');
+    expect(row!.toAgent).toBe('ea-agent');
+    expect(row!.messageType).toBe('input-requested');
+    expect(row!.status).toBe('pending');
+    expect(row!.correlationId).toBe('cor_1');
+    expect(row!.expectedReplyBy).toBe(1_700_001_000_000);
+    expect(JSON.parse(row!.payload)).toEqual({ question: 'arch?' });
+  });
+});
+
+// ─── replyToRequest ──────────────────────────────────────────────────────────
+
+describe('replyToRequest', () => {
+  it('flips request to replied + inserts the reply with parent_message_id', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_reply');
+    const reqId = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'dba-agent',
+        correlationId: 'cor_2',
+        expectedReplyBy: 1_700_002_000_000,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+
+    const replyId = replyToRequest(
+      {
+        requestMessageId: reqId,
+        fromAgent: 'dba-agent',
+        payload: { sectionKey: 'database', section: { reversibility: 'reversible' } },
+        repliedAt: 1_700_001_500_000,
+      },
+      db,
+    );
+
+    expect(replyId).toMatch(/^msg_rep_/);
+    const reqRow = db
+      .select()
+      .from(agentMessages)
+      .where(eq(agentMessages.id, reqId))
+      .get();
+    expect(reqRow!.status).toBe('replied');
+    expect(reqRow!.repliedAt).toBe(1_700_001_500_000);
+
+    const replyRow = db
+      .select()
+      .from(agentMessages)
+      .where(eq(agentMessages.id, replyId))
+      .get();
+    expect(replyRow!.messageType).toBe('input-received');
+    expect(replyRow!.parentMessageId).toBe(reqId);
+    expect(replyRow!.fromAgent).toBe('dba-agent');
+    expect(replyRow!.toAgent).toBe('ba-agent'); // routed back to the requester
+    const parsed = JSON.parse(replyRow!.payload);
+    expect(parsed.sectionKey).toBe('database');
+  });
+
+  it('throws if the request id does not exist', () => {
+    const db = createTestDb();
+    expect(() =>
+      replyToRequest(
+        { requestMessageId: 'missing', fromAgent: 'x', payload: {} },
+        db,
+      ),
+    ).toThrow(/not found/);
+  });
+});
+
+// ─── awaitReplies ────────────────────────────────────────────────────────────
+
+describe('awaitReplies', () => {
+  it('resolves immediately when every consultant has already replied', async () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_aw1');
+    const aId = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'ea-agent',
+        correlationId: 'cor_aw1',
+        expectedReplyBy: 0,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+    const bId = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'security-agent',
+        correlationId: 'cor_aw1',
+        expectedReplyBy: 0,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+    replyToRequest(
+      { requestMessageId: aId, fromAgent: 'ea-agent', payload: { sectionKey: 'architecture', section: {} } },
+      db,
+    );
+    replyToRequest(
+      { requestMessageId: bId, fromAgent: 'security-agent', payload: { sectionKey: 'security', section: {} } },
+      db,
+    );
+
+    const result = await awaitReplies(
+      { fromAgent: 'ba-agent', correlationId: 'cor_aw1', expectedAgents: ['ea-agent', 'security-agent'] },
+      db,
+      { timeoutMs: 1_000, pollIntervalMs: 5 },
+    );
+
+    expect(result.timedOutAgents).toEqual([]);
+    expect(result.replies.map((r) => r.fromAgent).sort()).toEqual(['ea-agent', 'security-agent']);
+  });
+
+  it('reports timed-out agents and flips their request rows', async () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_aw2');
+    let fakeNow = 1_700_000_000_000;
+    const advance = (ms: number) => {
+      fakeNow += ms;
+    };
+    sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'ea-agent',
+        correlationId: 'cor_aw2',
+        expectedReplyBy: fakeNow + 200,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+    sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'release-agent',
+        correlationId: 'cor_aw2',
+        expectedReplyBy: fakeNow + 200,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+
+    const result = await awaitReplies(
+      { fromAgent: 'ba-agent', correlationId: 'cor_aw2', expectedAgents: ['ea-agent', 'release-agent'] },
+      db,
+      {
+        timeoutMs: 100,
+        pollIntervalMs: 5,
+        now: () => fakeNow,
+        sleep: async (ms: number) => { advance(ms); },
+      },
+    );
+
+    expect(result.replies).toEqual([]);
+    expect(result.timedOutAgents.sort()).toEqual(['ea-agent', 'release-agent']);
+
+    const timedOut = db
+      .select()
+      .from(agentMessages)
+      .where(
+        and(
+          eq(agentMessages.correlationId, 'cor_aw2'),
+          eq(agentMessages.messageType, 'input-requested'),
+          eq(agentMessages.status, 'timed_out'),
+        ),
+      )
+      .all();
+    expect(timedOut).toHaveLength(2);
+  });
+
+  it('isolates rounds by correlation_id', async () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_isol');
+    const aId = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'ea-agent',
+        correlationId: 'cor_round_A',
+        expectedReplyBy: 0,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+    const bId = sendInputRequest(
+      {
+        fromAgent: 'ba-agent',
+        toAgent: 'ea-agent',
+        correlationId: 'cor_round_B',
+        expectedReplyBy: 0,
+        payload: {},
+        emitEvent: false,
+      },
+      db,
+    );
+    replyToRequest({ requestMessageId: aId, fromAgent: 'ea-agent', payload: { sectionKey: 'architecture', section: {} } }, db);
+
+    const roundA = await awaitReplies(
+      { fromAgent: 'ba-agent', correlationId: 'cor_round_A', expectedAgents: ['ea-agent'] },
+      db,
+      { timeoutMs: 100, pollIntervalMs: 5 },
+    );
+    expect(roundA.replies.map((r) => r.fromAgent)).toEqual(['ea-agent']);
+
+    // Round B's request is still open.
+    const bRow = db.select().from(agentMessages).where(eq(agentMessages.id, bId)).get();
+    expect(bRow!.status).toBe('pending');
+  });
+
+  it('returns replies in arrival order', async () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_order');
+    const aId = sendInputRequest(
+      { fromAgent: 'ba-agent', toAgent: 'ea-agent', correlationId: 'cor_ord', expectedReplyBy: 0, payload: {}, emitEvent: false },
+      db,
+    );
+    const bId = sendInputRequest(
+      { fromAgent: 'ba-agent', toAgent: 'security-agent', correlationId: 'cor_ord', expectedReplyBy: 0, payload: {}, emitEvent: false },
+      db,
+    );
+    replyToRequest({ requestMessageId: bId, fromAgent: 'security-agent', payload: { sectionKey: 'security', section: {} }, repliedAt: 1000 }, db);
+    replyToRequest({ requestMessageId: aId, fromAgent: 'ea-agent', payload: { sectionKey: 'architecture', section: {} }, repliedAt: 2000 }, db);
+
+    const result = await awaitReplies(
+      { fromAgent: 'ba-agent', correlationId: 'cor_ord', expectedAgents: ['ea-agent', 'security-agent'] },
+      db,
+      { timeoutMs: 100, pollIntervalMs: 5 },
+    );
+    expect(result.replies[0]!.fromAgent).toBe('security-agent'); // earlier repliedAt wins
+    expect(result.replies[1]!.fromAgent).toBe('ea-agent');
+  });
+});
+
+// ─── emitInputReceived ───────────────────────────────────────────────────────
+
+describe('emitInputReceived', () => {
+  it('does not throw when emitting an aggregation event', () => {
+    expect(() =>
+      emitInputReceived({
+        promptId: 'prm_em',
+        storyId: 'story_em',
+        correlationId: 'cor_em',
+        result: { replies: [], timedOutAgents: ['ea-agent'] },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/orchestrator/tests/agents/ba-agent.test.ts
+++ b/apps/orchestrator/tests/agents/ba-agent.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Behavioural tests for the BA agent — verifies the full PO-output → BA
+ * collaboration → ticket-template payload flow.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { prompts, requirements, stories } from '../../src/db/schema';
+import { runBAAgent } from '../../src/agents/ba-agent';
+import { TicketTemplateV1Schema } from '@chiefaia/ticket-template';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+interface SeedFixture {
+  promptId: string;
+  requirementId: string;
+  storyId: string;
+}
+
+function seedFixture(db: ReturnType<typeof createTestDb>, suffix: string): SeedFixture {
+  const promptId = `prm_${suffix}`;
+  const requirementId = `req_${suffix}`;
+  const storyId = `story_${suffix}`;
+  db.insert(prompts)
+    .values({
+      id: promptId,
+      body: 'implement OAuth2 login with Google and GitHub',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: `cor_${suffix}`,
+      hash: `hash_${suffix}`,
+      status: 'received',
+    })
+    .run();
+  db.insert(requirements)
+    .values({
+      id: requirementId,
+      title: 'OAuth2 login epic',
+      description: 'Allow user authentication via Google and GitHub OAuth2.',
+      state: 'captured',
+      priority: 3,
+      labels: '["auth"]',
+      rootPromptId: promptId,
+      parentEntityType: 'initiative',
+      parentEntityId: 'init_1',
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    })
+    .run();
+  db.insert(stories)
+    .values({
+      id: storyId,
+      kind: 'story',
+      title: 'Add login form with Google OAuth button',
+      description: 'A login form component with a Google OAuth provider button. On success, issue a session token.',
+      acceptanceCriteriaJson: '[]',
+      dependsOnJson: '[]',
+      status: 'pending',
+      rootPromptId: promptId,
+      parentEntityType: 'requirement',
+      parentEntityId: requirementId,
+      createdAt: nowIso(),
+    })
+    .run();
+  return { promptId, requirementId, storyId };
+}
+
+describe('runBAAgent — Phase-1 collaboration + ticket template', () => {
+  it('enriches a story end-to-end and persists a valid ticket-template payload', async () => {
+    const db = createTestDb();
+    const fx = seedFixture(db, 'happy');
+
+    const out = await runBAAgent(
+      {
+        promptId: fx.promptId,
+        correlationId: 'cor_happy',
+        // Restrict consultants so the test is deterministic and fast.
+        consultants: ['ea-agent', 'security-agent', 'testing-agent', 'release-agent'],
+        collabTimeoutMs: 1_000,
+      },
+      db,
+    );
+
+    expect(out.enrichedStories).toBe(1);
+    expect(out.ticketsValid).toBe(1);
+    expect(out.ticketsInvalid).toBe(0);
+
+    const row = db.select().from(stories).where(eq(stories.id, fx.storyId)).get();
+    expect(row!.templateValidationStatus).toBe('valid');
+    expect(row!.templateValidationErrors).toBeNull();
+    expect(row!.templateVersion).toBe('v1');
+
+    // Round-trip parse.
+    const ticket = JSON.parse(row!.agentContributionsJson);
+    const parsed = TicketTemplateV1Schema.safeParse(ticket);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.scope.summary).toBe('Add login form with Google OAuth button');
+      expect(parsed.data.acceptanceCriteria.length).toBeGreaterThanOrEqual(3);
+      // Per-agent sections populated by collaboration.
+      expect(parsed.data.agentSections.architecture?.contributedBy).toBe('ea-agent');
+      expect(parsed.data.agentSections.security?.contributedBy).toBe('security-agent');
+      expect(parsed.data.agentSections.testing?.contributedBy).toBe('testing-agent');
+      expect(parsed.data.agentSections.release?.contributedBy).toBe('release-agent');
+      expect(parsed.data.baEnrichment?.enrichedBy).toBe('ba-agent');
+      expect(parsed.data.baEnrichment?.completenessChecksPassed).toBe(true);
+      // Every consultant logged in inputsRequested with status replied.
+      const requestedAgents = parsed.data.baEnrichment?.inputsRequested.map((i) => i.agent).sort();
+      expect(requestedAgents).toEqual(['ea-agent', 'release-agent', 'security-agent', 'testing-agent']);
+      const allReplied = parsed.data.baEnrichment?.inputsRequested.every((i) => i.status === 'replied');
+      expect(allReplied).toBe(true);
+    }
+  });
+
+  it('reports timed-out consultants in baEnrichment when none reply', async () => {
+    const db = createTestDb();
+    const fx = seedFixture(db, 'timeout');
+
+    // Consultant not in DOMAIN_RESPONDERS will not synthesise a reply.
+    const out = await runBAAgent(
+      {
+        promptId: fx.promptId,
+        correlationId: 'cor_timeout',
+        consultants: ['unknown-agent'] as never,
+        collabTimeoutMs: 50,
+      },
+      db,
+    );
+
+    expect(out.enrichedStories).toBe(1);
+    expect(out.ticketsValid + out.ticketsInvalid).toBe(1);
+
+    const row = db.select().from(stories).where(eq(stories.id, fx.storyId)).get();
+    const ticket = JSON.parse(row!.agentContributionsJson);
+    expect(ticket.baEnrichment.completenessChecksPassed).toBe(false);
+    expect(ticket.baEnrichment.inputsRequested[0].status).toBe('timed_out');
+    expect(ticket.baEnrichment.notes).toMatch(/timed out/);
+  });
+
+  it('emits ba-agent.enrichment.complete with the per-ticket pass/fail counts', async () => {
+    const db = createTestDb();
+    const fx = seedFixture(db, 'event');
+
+    const out = await runBAAgent(
+      {
+        promptId: fx.promptId,
+        correlationId: 'cor_event',
+        consultants: ['testing-agent'],
+        collabTimeoutMs: 500,
+      },
+      db,
+    );
+
+    expect(out.ticketsValid).toBeGreaterThanOrEqual(0);
+    expect(out.ticketsInvalid).toBeGreaterThanOrEqual(0);
+    expect(out.ticketsValid + out.ticketsInvalid).toBe(out.enrichedStories);
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -318,6 +318,9 @@ export type EventType =
   | 'po-agent.decomposition.complete'
   // ─── BA Agent + Task Scheduler events (migration 0018) ────────────────────
   | 'ba-agent.enrichment.complete'
+  // ─── BA cross-agent collaboration protocol (migration 0022) ──────────────
+  | 'ba-agent.input-requested'
+  | 'ba-agent.input-received'
   | 'task-scheduler.scheduling.complete'
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   | 'testing-agent.validation.complete'
@@ -378,6 +381,9 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'po-agent.decomposition.complete': 'info',
   // ─── BA Agent + Task Scheduler events (migration 0018) ────────────────────
   'ba-agent.enrichment.complete': 'info',
+  // ─── BA cross-agent collaboration protocol (migration 0022) ──────────────
+  'ba-agent.input-requested': 'info',
+  'ba-agent.input-received': 'info',
   'task-scheduler.scheduling.complete': 'info',
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   'testing-agent.validation.complete': 'info',

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -394,7 +394,18 @@ events:
   - type: ba-agent.enrichment.complete
     severity: info
     actor: [ba-agent]
-    payload: [promptId, correlationId, enrichedStories, storiesWithAcceptanceCriteria]
+    payload: [promptId, correlationId, enrichedStories, storiesWithAcceptanceCriteria, ticketsValid, ticketsInvalid]
+
+  # BA cross-agent collaboration protocol (migration 0022)
+  - type: ba-agent.input-requested
+    severity: info
+    actor: [ba-agent]
+    payload: [promptId, correlationId, storyId, requestingAgent, requestedFrom, deadlineMs]
+
+  - type: ba-agent.input-received
+    severity: info
+    actor: [ba-agent]
+    payload: [promptId, correlationId, storyId, repliesReceived, repliesTimedOut]
 
   # Task Scheduler Agent events (migration 0018)
   - type: task-scheduler.scheduling.complete

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@chiefaia/local-llm-router':
         specifier: workspace:*
         version: link:../../packages/local-llm-router
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../../packages/ticket-template
       '@hono/node-server':
         specifier: ^1.19.14
         version: 1.19.14(hono@4.12.15)


### PR DESCRIPTION
## Gate 3 Phase-1 pipeline — PR 2/N

The BA agent now collaborates with N domain consultants (architecture, database, api, ui, security, testing, release, observability) via correlated request/response messages on `agent_messages`, aggregates their replies into the strict `TicketTemplateV1` payload, validates, and persists everything to `stories.agent_contributions_json`.

This was the **largest behavioural gap** flagged by the Phase-1 analysis (gap 1.3.b). Closes that gap end-to-end.

## Migration 0022

Adds three nullable columns to `agent_messages` so existing one-way `context-broadcast` rows are unaffected:
- `expected_reply_by` (epoch ms deadline for the responder)
- `replied_at` (epoch ms when the reply lands)
- `parent_message_id` (links a reply row back to its request)
Plus indexes on `parent_message_id` and `expected_reply_by`.

## Protocol primitives

- `sendInputRequest` — insert an `input-requested` row + emit `ba-agent.input-requested`.
- `replyToRequest` — insert a paired `input-received` row with `parent_message_id`; flip the request to `replied` and stamp `replied_at`.
- `awaitReplies` — poll until every consultant replies or the budget lapses; flip unanswered rows to `timed_out` and report which agents missed the window. Injectable `now` and `sleep` so tests can drive the timeout deterministically.
- `emitInputReceived` — single aggregation event after a round.

## Domain responders

Rule-based responders for ea/dba/bff/ui/security/testing/release/observability. Each produces a typed section payload (sans audit fields). Future LLM-backed agents subscribing to `ba-agent.input-requested` can replace these — the protocol works the same either way.

## BA agent rewrite

For each story:
1. Generate acceptance criteria + implementation notes.
2. Run a collaboration round via the protocol.
3. Build a `TicketTemplateV1` via `buildDraftTicket()`, merge per-agent sections, populate `baEnrichment` with `inputsRequested` audit trail.
4. `validateTicket()` and persist `agent_contributions_json` + `template_validation_status` (valid|invalid) + `template_validation_errors`.
5. Emit `ba-agent.enrichment.complete` with `ticketsValid` / `ticketsInvalid` counts.

## Tests

- 11/11 jest passing (5 protocol primitives, 3 BA behaviour, 3 misc).
- All 43 existing `db/*` tests still green.
- `pnpm typecheck` clean for both `apps/orchestrator` and `@chiefaia/ticket-template`.

## Out of scope

Bucket placement, ticket state machine, `getTicketBundle` endpoint, phase1-e2e — subsequent PRs.
