### PR TITLE
feat(phase1): Task Manager bucket placement decider (PHASE1-03)

### DIFF
--- a/apps/orchestrator/src/agents/bucket-placer.ts
+++ b/apps/orchestrator/src/agents/bucket-placer.ts
@@ -1,0 +1,378 @@
+/**
+ * Bucket placement decider — assigns enriched stories (tickets) into either:
+ *   • a sequential-per-domain bucket, when the story has cross-domain
+ *     upstream dependencies (or when the prompt-level bucket plan calls for
+ *     domain-bounded sequencing), or
+ *   • a parallel bucket, when the story has no cross-domain upstream
+ *     dependencies and can run alongside other independent stories.
+ *
+ * Buckets are scoped per prompt: each prompt gets its own set of sequential
+ * buckets (one per active domain) and at most one parallel bucket.
+ *
+ * The decider reads:
+ *   • `stories.dependsOnJson` — story-level dependency graph
+ *   • `entity_labels` (label_type='domain') — primary domain per story
+ *
+ * It writes:
+ *   • `task_buckets` — creates / re-uses bucket rows for the prompt
+ *   • `stories.bucket_id` — links each story to its bucket
+ *   • One `task-scheduler.bucket-placed` event per story
+ *   • One `task-scheduler.scheduling.complete` event after the round
+ */
+
+import { eq, and } from 'drizzle-orm';
+import { eventBus } from '../events/bus-adapter';
+import type { Db } from '../db/connection';
+import { entityLabels, stories, taskBuckets } from '../db/schema';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface PlacementInput {
+  promptId: string;
+  correlationId: string;
+}
+
+export interface BucketPlacement {
+  storyId: string;
+  bucketId: string;
+  bucketKind: 'sequential' | 'parallel';
+  domainSlug: string | null;
+  positionInBucket: number;
+}
+
+export interface PlacementOutput {
+  promptId: string;
+  placements: BucketPlacement[];
+  sequentialBucketsCreated: number;
+  parallelBucketSize: number;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function safeParseStringArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((d): d is string => typeof d === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read the primary domain for a story. Tries entity_labels first (label_type
+ * = 'domain', highest confidence wins), falls back to the first entry in
+ * `domain_slugs_json`, then to the literal 'general'.
+ */
+function readPrimaryDomain(db: Db, storyId: string, domainSlugsJson: string): string {
+  const labels = db
+    .select()
+    .from(entityLabels)
+    .where(
+      and(
+        eq(entityLabels.entityKind, 'story'),
+        eq(entityLabels.entityId, storyId),
+        eq(entityLabels.labelType, 'domain'),
+      ),
+    )
+    .all();
+  if (labels.length > 0) {
+    // Highest-confidence domain label wins; ties broken by createdAt asc.
+    const sorted = [...labels].sort(
+      (a, b) => (b.confidence ?? 0) - (a.confidence ?? 0) || a.createdAt - b.createdAt,
+    );
+    return sorted[0]!.labelSlug;
+  }
+  const fallback = safeParseStringArray(domainSlugsJson)[0];
+  return fallback ?? 'general';
+}
+
+/** Format a sequential-bucket id once we know the domain + sequence index. */
+function sequentialBucketId(domainSlug: string, sequenceIndex: number): string {
+  return `bkt_seq_${domainSlug}_${sequenceIndex.toString().padStart(3, '0')}`;
+}
+
+function parallelBucketId(promptId: string): string {
+  return `bkt_par_${promptId}`;
+}
+
+// ─── Topological sort (Kahn's algorithm, reused) ─────────────────────────────
+
+function topologicallySort(
+  ids: string[],
+  deps: Map<string, string[]>,
+): string[] {
+  const nodeSet = new Set(ids);
+  const inDegree = new Map<string, number>();
+  for (const id of ids) {
+    const upstream = (deps.get(id) ?? []).filter((d) => nodeSet.has(d));
+    inDegree.set(id, upstream.length);
+  }
+
+  const visited = new Set<string>();
+  const order: string[] = [];
+  let frontier = ids.filter((id) => (inDegree.get(id) ?? 0) === 0);
+  while (frontier.length > 0) {
+    frontier.sort();
+    for (const id of frontier) {
+      if (visited.has(id)) continue;
+      order.push(id);
+      visited.add(id);
+    }
+    const next: string[] = [];
+    for (const id of ids) {
+      if (visited.has(id)) continue;
+      const unresolved = (deps.get(id) ?? []).filter(
+        (d) => nodeSet.has(d) && !visited.has(d),
+      );
+      if (unresolved.length === 0) next.push(id);
+    }
+    frontier = [...new Set(next)];
+  }
+  // Append any orphans (cycle members) in stable id order.
+  for (const id of ids) if (!visited.has(id)) order.push(id);
+  return order;
+}
+
+// ─── Bucket lookup / creation ────────────────────────────────────────────────
+
+function findOrCreateSequentialBucket(
+  db: Db,
+  promptId: string,
+  domainSlug: string,
+): {
+  id: string;
+  sequenceIndex: number;
+  created: boolean;
+} {
+  const existing = db
+    .select()
+    .from(taskBuckets)
+    .where(
+      and(
+        eq(taskBuckets.promptId, promptId),
+        eq(taskBuckets.kind, 'sequential'),
+        eq(taskBuckets.domainSlug, domainSlug),
+      ),
+    )
+    .get();
+  if (existing) {
+    return { id: existing.id, sequenceIndex: existing.sequenceIndex ?? 0, created: false };
+  }
+
+  // Determine the next sequence_index by scanning all sequential buckets for
+  // this prompt — keeps ordering deterministic across domains.
+  const allSeq = db
+    .select()
+    .from(taskBuckets)
+    .where(
+      and(eq(taskBuckets.promptId, promptId), eq(taskBuckets.kind, 'sequential')),
+    )
+    .all();
+  const maxIdx = allSeq.reduce(
+    (acc, b) => Math.max(acc, b.sequenceIndex ?? -1),
+    -1,
+  );
+  const nextIdx = maxIdx + 1;
+  const id = sequentialBucketId(domainSlug, nextIdx);
+  db.insert(taskBuckets)
+    .values({
+      id,
+      kind: 'sequential',
+      domainSlug,
+      promptId,
+      createdAt: Date.now(),
+      sequenceIndex: nextIdx,
+      status: 'open',
+    })
+    .run();
+  return { id, sequenceIndex: nextIdx, created: true };
+}
+
+function findOrCreateParallelBucket(
+  db: Db,
+  promptId: string,
+): { id: string; created: boolean } {
+  const id = parallelBucketId(promptId);
+  const existing = db
+    .select()
+    .from(taskBuckets)
+    .where(eq(taskBuckets.id, id))
+    .get();
+  if (existing) return { id: existing.id, created: false };
+  db.insert(taskBuckets)
+    .values({
+      id,
+      kind: 'parallel',
+      domainSlug: null,
+      promptId,
+      createdAt: Date.now(),
+      sequenceIndex: null,
+      status: 'open',
+    })
+    .run();
+  return { id, created: true };
+}
+
+// ─── Main entry point ────────────────────────────────────────────────────────
+
+/**
+ * Place every story under the supplied prompt into the correct bucket.
+ *
+ * Returns the placement list plus aggregate counts. Idempotent: re-running
+ * for the same prompt re-uses existing buckets (sequential bucket per
+ * domain + at most one parallel bucket) and updates story.bucket_id.
+ */
+export function placeStoriesInBuckets(
+  input: PlacementInput,
+  db: Db,
+): PlacementOutput {
+  const { promptId, correlationId } = input;
+
+  const allStories = db
+    .select()
+    .from(stories)
+    .where(eq(stories.rootPromptId, promptId))
+    .all();
+  if (allStories.length === 0) {
+    return {
+      promptId,
+      placements: [],
+      sequentialBucketsCreated: 0,
+      parallelBucketSize: 0,
+    };
+  }
+
+  // 1. Compute primary domain for every story.
+  const storyDomain = new Map<string, string>();
+  for (const story of allStories) {
+    storyDomain.set(story.id, readPrimaryDomain(db, story.id, story.domainSlugsJson ?? '[]'));
+  }
+
+  // 2. Build dependency graph from stories.dependsOnJson.
+  const depGraph = new Map<string, string[]>();
+  for (const story of allStories) {
+    depGraph.set(story.id, safeParseStringArray(story.dependsOnJson));
+  }
+
+  // 3. Decide bucket kind for each story per the Phase-1 directive:
+  //    a story goes to a sequential-per-domain bucket iff at least one of
+  //    its upstream stories sits in a *different* primary domain. Otherwise
+  //    (no upstream, or only same-domain upstream) it goes to the prompt's
+  //    single parallel bucket; the executor still honours intra-bucket
+  //    dependsOn ordering for same-domain dependencies.
+  const placements: BucketPlacement[] = [];
+  const sequentialDomainsTouched = new Set<string>();
+  let parallelCount = 0;
+
+  // Buffer placements per bucket so we can topologically sort within each
+  // sequential bucket before persisting positions.
+  const sequentialMembers = new Map<string, string[]>();
+  const parallelMembers: string[] = [];
+
+  for (const story of allStories) {
+    const myDomain = storyDomain.get(story.id) ?? 'general';
+    const upstream = depGraph.get(story.id) ?? [];
+    const inPrompt = upstream.filter((id) => storyDomain.has(id));
+
+    const hasCrossDomainUpstream = inPrompt.some(
+      (upId) => (storyDomain.get(upId) ?? 'general') !== myDomain,
+    );
+
+    if (hasCrossDomainUpstream) {
+      const list = sequentialMembers.get(myDomain) ?? [];
+      list.push(story.id);
+      sequentialMembers.set(myDomain, list);
+      sequentialDomainsTouched.add(myDomain);
+    } else {
+      // No upstream stories within this prompt — eligible for parallel bucket.
+      parallelMembers.push(story.id);
+    }
+  }
+
+  // 4. Materialise sequential buckets and persist placements (sorted topo).
+  let sequentialBucketsCreated = 0;
+  for (const [domain, ids] of sequentialMembers) {
+    const sortedIds = topologicallySort(ids, depGraph);
+    const { id: bucketId, sequenceIndex, created } = findOrCreateSequentialBucket(
+      db,
+      promptId,
+      domain,
+    );
+    if (created) sequentialBucketsCreated++;
+
+    for (let i = 0; i < sortedIds.length; i++) {
+      const storyId = sortedIds[i]!;
+      db.update(stories).set({ bucketId }).where(eq(stories.id, storyId)).run();
+      placements.push({
+        storyId,
+        bucketId,
+        bucketKind: 'sequential',
+        domainSlug: domain,
+        positionInBucket: i,
+      });
+      eventBus.publish({
+        type: 'task-scheduler.bucket-placed',
+        actor: 'task-scheduler',
+        correlation_id: correlationId,
+        entity_type: 'story',
+        entity_id: storyId,
+        payload: {
+          promptId,
+          correlationId,
+          storyId,
+          bucketId,
+          bucketKind: 'sequential',
+          domainSlug: domain,
+          positionInBucket: i,
+          sequenceIndex,
+        },
+      });
+    }
+  }
+
+  // 5. Materialise the parallel bucket if any story qualifies.
+  if (parallelMembers.length > 0) {
+    const { id: bucketId } = findOrCreateParallelBucket(db, promptId);
+    parallelCount = parallelMembers.length;
+    // Stable ordering inside the parallel bucket is unnecessary, but assigning
+    // a deterministic positionInBucket aids debugging / dashboard rendering.
+    parallelMembers.sort();
+    for (let i = 0; i < parallelMembers.length; i++) {
+      const storyId = parallelMembers[i]!;
+      db.update(stories).set({ bucketId }).where(eq(stories.id, storyId)).run();
+      placements.push({
+        storyId,
+        bucketId,
+        bucketKind: 'parallel',
+        domainSlug: null,
+        positionInBucket: i,
+      });
+      eventBus.publish({
+        type: 'task-scheduler.bucket-placed',
+        actor: 'task-scheduler',
+        correlation_id: correlationId,
+        entity_type: 'story',
+        entity_id: storyId,
+        payload: {
+          promptId,
+          correlationId,
+          storyId,
+          bucketId,
+          bucketKind: 'parallel',
+          domainSlug: null,
+          positionInBucket: i,
+        },
+      });
+    }
+  }
+
+  return {
+    promptId,
+    placements,
+    sequentialBucketsCreated,
+    parallelBucketSize: parallelCount,
+  };
+}

--- a/apps/orchestrator/src/agents/task-scheduler.ts
+++ b/apps/orchestrator/src/agents/task-scheduler.ts
@@ -15,6 +15,7 @@ import { eventBus } from '../events/bus-adapter';
 import { getDb } from '../db/connection';
 import { tasks } from '../db/schema';
 import { eq } from 'drizzle-orm';
+import { placeStoriesInBuckets, type BucketPlacement } from './bucket-placer';
 
 export interface SchedulerInput {
   promptId: string;
@@ -27,6 +28,12 @@ export interface SchedulerOutput {
   parallelBuckets: string[][];  // sub-groups that can run concurrently per level
   totalTasks: number;
   estimatedWallclockHours: number;
+  /** Story-level bucket placements written to task_buckets + stories.bucket_id. */
+  storyPlacements: BucketPlacement[];
+  /** New sequential buckets created in this run (re-uses existing ones for the prompt). */
+  sequentialBucketsCreated: number;
+  /** Number of stories placed into the prompt's parallel bucket. */
+  parallelBucketSize: number;
 }
 
 // ─── Dependency Graph ─────────────────────────────────────────────────────────
@@ -137,19 +144,47 @@ export async function runTaskScheduler(
 ): Promise<SchedulerOutput> {
   const { promptId, correlationId } = input;
 
-  // Fetch all tasks for this prompt directly via rootPromptId
+  // Phase 1: place enriched stories (tickets) into task_buckets first. This
+  // is the directive's bucket model: sequential-per-domain + 1 parallel
+  // bucket per prompt. Tickets are scheduled before tasks so the executor
+  // can pick up enriched stories even when no tasks have been spawned yet.
+  const placement = placeStoriesInBuckets({ promptId, correlationId }, db);
+
+  // Then schedule tasks (executor work-items) using the existing
+  // topological-sort logic — task-level scheduling complements story-level
+  // bucket placement.
   const allTasks = await db
     .select()
     .from(tasks)
     .where(eq(tasks.rootPromptId, promptId));
 
   if (allTasks.length === 0) {
+    eventBus.publish({
+      type: 'task-scheduler.scheduling.complete',
+      actor: 'task-scheduler',
+      correlation_id: correlationId,
+      entity_type: 'prompt',
+      entity_id: promptId,
+      payload: {
+        promptId,
+        correlationId,
+        totalTasks: 0,
+        sequentialCount: 0,
+        parallelBucketCount: 0,
+        estimatedWallclockHours: 0,
+        sequentialBucketsCreated: placement.sequentialBucketsCreated,
+        parallelBucketSize: placement.parallelBucketSize,
+      },
+    });
     return {
       promptId,
       sequentialTasks: [],
       parallelBuckets: [],
       totalTasks: 0,
       estimatedWallclockHours: 0,
+      storyPlacements: placement.placements,
+      sequentialBucketsCreated: placement.sequentialBucketsCreated,
+      parallelBucketSize: placement.parallelBucketSize,
     };
   }
 
@@ -182,6 +217,8 @@ export async function runTaskScheduler(
       sequentialCount: sequential.length,
       parallelBucketCount: parallelBuckets.length,
       estimatedWallclockHours,
+      sequentialBucketsCreated: placement.sequentialBucketsCreated,
+      parallelBucketSize: placement.parallelBucketSize,
     },
   });
 
@@ -191,5 +228,8 @@ export async function runTaskScheduler(
     parallelBuckets,
     totalTasks: allTasks.length,
     estimatedWallclockHours,
+    storyPlacements: placement.placements,
+    sequentialBucketsCreated: placement.sequentialBucketsCreated,
+    parallelBucketSize: placement.parallelBucketSize,
   };
 }

--- a/apps/orchestrator/tests/agents/bucket-placer.test.ts
+++ b/apps/orchestrator/tests/agents/bucket-placer.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Behavioural tests for the bucket-placement decider.
+ *
+ * Per the Phase-1 directive:
+ *   - A story goes to a sequential-per-domain bucket iff at least one of
+ *     its upstream stories has a *different* primary domain.
+ *   - Otherwise (no upstream OR only same-domain upstream) it goes to the
+ *     prompt's single parallel bucket. Intra-bucket ordering is enforced
+ *     by the executor honouring dependsOn within the bucket.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { entityLabels, prompts, stories, taskBuckets } from '../../src/db/schema';
+import { placeStoriesInBuckets } from '../../src/agents/bucket-placer';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedPrompt(db: ReturnType<typeof createTestDb>, id: string) {
+  db.insert(prompts)
+    .values({
+      id,
+      body: 'thing',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: `cor_${id}`,
+      hash: `hash_${id}`,
+      status: 'received',
+    })
+    .run();
+}
+
+function seedStory(
+  db: ReturnType<typeof createTestDb>,
+  args: { id: string; promptId: string; deps?: string[]; domains?: string[] },
+) {
+  db.insert(stories)
+    .values({
+      id: args.id,
+      kind: 'story',
+      title: args.id,
+      description: '',
+      dependsOnJson: JSON.stringify(args.deps ?? []),
+      domainSlugsJson: JSON.stringify(args.domains ?? []),
+      status: 'pending',
+      rootPromptId: args.promptId,
+      createdAt: nowIso(),
+    })
+    .run();
+}
+
+function seedDomainLabel(
+  db: ReturnType<typeof createTestDb>,
+  storyId: string,
+  domain: string,
+) {
+  db.insert(entityLabels)
+    .values({
+      id: `lbl_${storyId}_${domain}`,
+      entityKind: 'story',
+      entityId: storyId,
+      labelSlug: domain,
+      labelType: 'domain',
+      confidence: 0.95,
+      source: 'classifier',
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+// ─── Parallel placement ─────────────────────────────────────────────────────
+
+describe('placeStoriesInBuckets — parallel bucket', () => {
+  it('places stories with no upstream deps into the parallel bucket', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_par');
+    seedStory(db, { id: 'story_a', promptId: 'prm_par' });
+    seedStory(db, { id: 'story_b', promptId: 'prm_par' });
+    seedDomainLabel(db, 'story_a', 'auth');
+    seedDomainLabel(db, 'story_b', 'ui-frontend');
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_par', correlationId: 'cor_par' },
+      db,
+    );
+
+    expect(result.placements).toHaveLength(2);
+    expect(result.parallelBucketSize).toBe(2);
+    expect(result.sequentialBucketsCreated).toBe(0);
+    for (const placement of result.placements) {
+      expect(placement.bucketKind).toBe('parallel');
+      expect(placement.domainSlug).toBeNull();
+      expect(placement.bucketId).toBe('bkt_par_prm_par');
+    }
+  });
+
+  it('places same-domain dependents into the parallel bucket (no cross-domain edge)', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_same');
+    seedStory(db, { id: 's1', promptId: 'prm_same' });
+    seedStory(db, { id: 's2', promptId: 'prm_same', deps: ['s1'] });
+    seedStory(db, { id: 's3', promptId: 'prm_same', deps: ['s2'] });
+    seedDomainLabel(db, 's1', 'auth');
+    seedDomainLabel(db, 's2', 'auth');
+    seedDomainLabel(db, 's3', 'auth');
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_same', correlationId: 'cor_same' },
+      db,
+    );
+    expect(result.sequentialBucketsCreated).toBe(0);
+    expect(result.parallelBucketSize).toBe(3);
+    for (const p of result.placements) {
+      expect(p.bucketKind).toBe('parallel');
+      expect(p.bucketId).toBe('bkt_par_prm_same');
+    }
+  });
+});
+
+// ─── Sequential placement (cross-domain edges) ──────────────────────────────
+
+describe('placeStoriesInBuckets — sequential bucket', () => {
+  it('places a cross-domain dependent into a sequential bucket for its primary domain', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_xd');
+    seedStory(db, { id: 'auth_a', promptId: 'prm_xd' });
+    seedStory(db, { id: 'ui_a', promptId: 'prm_xd', deps: ['auth_a'] });
+    seedDomainLabel(db, 'auth_a', 'auth');
+    seedDomainLabel(db, 'ui_a', 'ui-frontend');
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_xd', correlationId: 'cor_xd' },
+      db,
+    );
+
+    expect(result.sequentialBucketsCreated).toBe(1);
+    expect(result.parallelBucketSize).toBe(1); // auth_a has no upstream → parallel
+    const uiPlacement = result.placements.find((p) => p.storyId === 'ui_a')!;
+    expect(uiPlacement.bucketKind).toBe('sequential');
+    expect(uiPlacement.domainSlug).toBe('ui-frontend');
+    expect(uiPlacement.bucketId).toBe('bkt_seq_ui-frontend_000');
+  });
+
+  it('partitions cross-domain dependents into separate sequential buckets', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_xd2');
+    seedStory(db, { id: 'auth_a', promptId: 'prm_xd2' });
+    seedStory(db, { id: 'data_a', promptId: 'prm_xd2', deps: ['auth_a'] });
+    seedStory(db, { id: 'ui_a', promptId: 'prm_xd2', deps: ['data_a'] });
+    seedDomainLabel(db, 'auth_a', 'auth');
+    seedDomainLabel(db, 'data_a', 'data-storage');
+    seedDomainLabel(db, 'ui_a', 'ui-frontend');
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_xd2', correlationId: 'cor_xd2' },
+      db,
+    );
+
+    expect(result.sequentialBucketsCreated).toBe(2);
+    const dataPlacement = result.placements.find((p) => p.storyId === 'data_a')!;
+    const uiPlacement = result.placements.find((p) => p.storyId === 'ui_a')!;
+    expect(dataPlacement.domainSlug).toBe('data-storage');
+    expect(uiPlacement.domainSlug).toBe('ui-frontend');
+    expect(dataPlacement.bucketId).not.toBe(uiPlacement.bucketId);
+  });
+
+  it('topologically orders multiple cross-domain dependents within one bucket', () => {
+    // Two ui-frontend stories both depending on different auth-domain
+    // upstreams; the second ui depends on the first ui too. They must
+    // share one sequential ui-frontend bucket and be ordered correctly.
+    const db = createTestDb();
+    seedPrompt(db, 'prm_topo');
+    seedStory(db, { id: 'auth_x', promptId: 'prm_topo' });
+    seedStory(db, { id: 'auth_y', promptId: 'prm_topo' });
+    seedStory(db, { id: 'ui_p', promptId: 'prm_topo', deps: ['auth_x'] });
+    seedStory(db, { id: 'ui_q', promptId: 'prm_topo', deps: ['auth_y', 'ui_p'] });
+    seedDomainLabel(db, 'auth_x', 'auth');
+    seedDomainLabel(db, 'auth_y', 'auth');
+    seedDomainLabel(db, 'ui_p', 'ui-frontend');
+    seedDomainLabel(db, 'ui_q', 'ui-frontend');
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_topo', correlationId: 'cor_topo' },
+      db,
+    );
+
+    const uiPlacements = result.placements
+      .filter((p) => p.bucketKind === 'sequential' && p.domainSlug === 'ui-frontend')
+      .sort((a, b) => a.positionInBucket - b.positionInBucket);
+    expect(uiPlacements.map((p) => p.storyId)).toEqual(['ui_p', 'ui_q']);
+    expect(uiPlacements[0]!.bucketId).toBe(uiPlacements[1]!.bucketId);
+  });
+});
+
+// ─── Persistence ────────────────────────────────────────────────────────────
+
+describe('placeStoriesInBuckets — persistence', () => {
+  it('writes bucket_id back onto every story row', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_persist');
+    seedStory(db, { id: 'sx', promptId: 'prm_persist' });
+    seedDomainLabel(db, 'sx', 'auth');
+
+    placeStoriesInBuckets(
+      { promptId: 'prm_persist', correlationId: 'cor_persist' },
+      db,
+    );
+
+    const row = db.select().from(stories).where(eq(stories.id, 'sx')).get();
+    expect(row!.bucketId).toBe('bkt_par_prm_persist');
+  });
+
+  it('creates the sequential task_buckets row when cross-domain edge exists', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_scope');
+    seedStory(db, { id: 's_a', promptId: 'prm_scope' });
+    seedStory(db, { id: 's_b', promptId: 'prm_scope', deps: ['s_a'] });
+    seedDomainLabel(db, 's_a', 'data-storage');
+    seedDomainLabel(db, 's_b', 'auth'); // cross-domain edge → s_b sequential
+
+    placeStoriesInBuckets(
+      { promptId: 'prm_scope', correlationId: 'cor_scope' },
+      db,
+    );
+
+    const buckets = db
+      .select()
+      .from(taskBuckets)
+      .where(eq(taskBuckets.promptId, 'prm_scope'))
+      .all();
+
+    const seq = buckets.find((b) => b.kind === 'sequential');
+    const par = buckets.find((b) => b.kind === 'parallel');
+    expect(seq).toBeDefined();
+    expect(seq!.domainSlug).toBe('auth');
+    expect(seq!.status).toBe('open');
+    expect(seq!.sequenceIndex).toBe(0);
+    expect(par).toBeDefined();
+    expect(par!.domainSlug).toBeNull();
+  });
+
+  it('falls back to domain_slugs_json when no entity_labels row exists', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_fb');
+    seedStory(db, {
+      id: 's_fb_1',
+      promptId: 'prm_fb',
+      domains: ['custom-fallback'],
+    });
+    seedStory(db, {
+      id: 's_fb_2',
+      promptId: 'prm_fb',
+      domains: ['other-domain'],
+      deps: ['s_fb_1'],
+    });
+    // No entityLabels seeded — fall through to domain_slugs_json.
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_fb', correlationId: 'cor_fb' },
+      db,
+    );
+
+    // Cross-domain edge between 'custom-fallback' and 'other-domain' →
+    // s_fb_2 lands in sequential bucket for 'other-domain'.
+    expect(result.sequentialBucketsCreated).toBe(1);
+    const sb2 = result.placements.find((p) => p.storyId === 's_fb_2')!;
+    expect(sb2.bucketKind).toBe('sequential');
+    expect(sb2.domainSlug).toBe('other-domain');
+  });
+
+  it('falls back to "general" when neither labels nor domain_slugs are set', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_general');
+    seedStory(db, { id: 's_gen_1', promptId: 'prm_general' });
+    seedStory(db, { id: 's_gen_2', promptId: 'prm_general', deps: ['s_gen_1'] });
+
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_general', correlationId: 'cor_general' },
+      db,
+    );
+    // Both default to 'general' — no cross-domain edge — both parallel.
+    expect(result.sequentialBucketsCreated).toBe(0);
+    expect(result.parallelBucketSize).toBe(2);
+  });
+});
+
+// ─── Idempotency ────────────────────────────────────────────────────────────
+
+describe('placeStoriesInBuckets — idempotency', () => {
+  it('does not create duplicate sequential buckets when re-run for the same prompt', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_idem');
+    seedStory(db, { id: 's_i_1', promptId: 'prm_idem' });
+    seedStory(db, { id: 's_i_2', promptId: 'prm_idem', deps: ['s_i_1'] });
+    seedDomainLabel(db, 's_i_1', 'auth');
+    seedDomainLabel(db, 's_i_2', 'ui-frontend'); // cross-domain edge
+
+    const first = placeStoriesInBuckets(
+      { promptId: 'prm_idem', correlationId: 'cor_idem' },
+      db,
+    );
+    expect(first.sequentialBucketsCreated).toBe(1);
+
+    const second = placeStoriesInBuckets(
+      { promptId: 'prm_idem', correlationId: 'cor_idem' },
+      db,
+    );
+    expect(second.sequentialBucketsCreated).toBe(0); // re-used existing bucket
+
+    const sequentialBuckets = db
+      .select()
+      .from(taskBuckets)
+      .where(
+        eq(taskBuckets.promptId, 'prm_idem'),
+      )
+      .all()
+      .filter((b) => b.kind === 'sequential');
+    expect(sequentialBuckets).toHaveLength(1);
+  });
+});
+
+// ─── Empty input ────────────────────────────────────────────────────────────
+
+describe('placeStoriesInBuckets — empty', () => {
+  it('returns zero placements when the prompt has no stories', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_empty');
+    const result = placeStoriesInBuckets(
+      { promptId: 'prm_empty', correlationId: 'cor_empty' },
+      db,
+    );
+    expect(result.placements).toEqual([]);
+    expect(result.sequentialBucketsCreated).toBe(0);
+    expect(result.parallelBucketSize).toBe(0);
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -322,6 +322,8 @@ export type EventType =
   | 'ba-agent.input-requested'
   | 'ba-agent.input-received'
   | 'task-scheduler.scheduling.complete'
+  // ─── Task Scheduler bucket placement (migration 0021) ────────────────────
+  | 'task-scheduler.bucket-placed'
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   | 'testing-agent.validation.complete'
   | 'release-agent.report.ready'
@@ -385,6 +387,8 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'ba-agent.input-requested': 'info',
   'ba-agent.input-received': 'info',
   'task-scheduler.scheduling.complete': 'info',
+  // ─── Task Scheduler bucket placement (migration 0021) ────────────────────
+  'task-scheduler.bucket-placed': 'info',
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   'testing-agent.validation.complete': 'info',
   'release-agent.report.ready': 'info',

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -411,4 +411,10 @@ events:
   - type: task-scheduler.scheduling.complete
     severity: info
     actor: [task-scheduler]
-    payload: [promptId, correlationId, totalTasks, sequentialCount, parallelBucketCount, estimatedWallclockHours]
+    payload: [promptId, correlationId, totalTasks, sequentialCount, parallelBucketCount, estimatedWallclockHours, sequentialBucketsCreated, parallelBucketSize]
+
+  # Task Scheduler bucket placement (migration 0021)
+  - type: task-scheduler.bucket-placed
+    severity: info
+    actor: [task-scheduler]
+    payload: [promptId, correlationId, storyId, bucketId, bucketKind, domainSlug, positionInBucket]


### PR DESCRIPTION
## Gate 3 Phase-1 pipeline — PR 3/N

Closes Phase-1 analysis gap 1.5 (Task Manager bucket placement). Enriched stories are now placed into `task_buckets` per the directive's bucket model — sequential-per-domain + 1 parallel bucket per prompt — with one `task-scheduler.bucket-placed` event per story and aggregate counts on the `task-scheduler.scheduling.complete` summary.

## New module — `apps/orchestrator/src/agents/bucket-placer.ts`

`placeStoriesInBuckets({ promptId, correlationId }, db)`:
- Reads primary domain from `entity_labels` (label_type='domain', highest confidence wins; ties → earliest `createdAt`). Falls back to first entry in `stories.domain_slugs_json`, then literal `'general'`.
- Builds a story-level dependency graph from `stories.depends_on_json`.
- Per the directive's pseudocode: a story goes to a sequential-per-domain bucket iff at least one upstream sits in a *different* primary domain. Otherwise (no upstream OR same-domain only) → the prompt's single parallel bucket. Intra-bucket ordering is enforced by the executor honouring `dependsOn`.
- Topologically sorts (Kahn) stories within sequential buckets, writes `positionInBucket`.
- Idempotent: re-runs for the same prompt re-use existing sequential-per-domain and parallel buckets. Bucket ids follow `bkt_seq_<domain>_NNN` / `bkt_par_<promptId>`.
- Persists `stories.bucket_id` and emits `task-scheduler.bucket-placed` per story.

## `task-scheduler.ts` integration

`runTaskScheduler` now calls `placeStoriesInBuckets` first, then runs the existing task-level topological scheduling. Output extended with `storyPlacements`, `sequentialBucketsCreated`, `parallelBucketSize`.

## Event taxonomy

- New: `task-scheduler.bucket-placed` (payload: promptId, correlationId, storyId, bucketId, bucketKind, domainSlug, positionInBucket).
- Extended: `task-scheduler.scheduling.complete` payload now carries `sequentialBucketsCreated` and `parallelBucketSize`.

## Tests

11/11 jest cases on `bucket-placer`:
- Parallel bucket: no upstream; same-domain dependents (no cross-domain edge).
- Sequential: cross-domain dependent → sequential bucket for its primary domain; multiple cross-domain edges → multiple buckets; topological ordering inside one bucket.
- Persistence: `bucket_id` written back; sequential row created with correct `domain_slug` + `sequenceIndex=0`; fallback to `domain_slugs_json`; fallback to `general`.
- Idempotency: re-run does not duplicate sequential buckets.
- Empty input.

Combined Phase-1 suites (bucket-placer + task-buckets-ticket-template + agent-collab + ba-agent + db/*): **65/65 green**. `pnpm typecheck` clean.

## Out of scope

- Ticket state machine events (`ticket.*`).
- `GET /stories/:id/bundle` endpoint.
- Phase-1 E2E test.
