### PR TITLE
feat(phase1): ticket state machine + bundle endpoint + pipeline stages (PHASE1-04)

### DIFF
--- a/apps/orchestrator/src/agents/ba-agent.ts
+++ b/apps/orchestrator/src/agents/ba-agent.ts
@@ -46,6 +46,7 @@ import {
   type ResponderInput,
   selectConsultants,
 } from './domain-responders';
+import { advancePipelineStage } from './pipeline-stages';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -354,6 +355,17 @@ export async function runBAAgent(
     try {
       const title = story.title;
       const description = story.description ?? '';
+
+      // Ticket state: ba-enriching (BA owns this story now).
+      eventBus.publish({
+        type: 'ticket.ba-enriching',
+        actor: 'ba-agent',
+        correlation_id: correlationId,
+        entity_type: 'story',
+        entity_id: story.id,
+        payload: { storyId: story.id, promptId, correlationId },
+      });
+
       const acceptanceCriteria = generateAcceptanceCriteria({ title, description });
       const implNotes = generateImplementationNotes({ title, description });
       const classification = classifyKeyword(`${title} ${description}`);
@@ -455,10 +467,38 @@ export async function runBAAgent(
         withCriteriaCount++;
         totalCriteria += acceptanceCriteria.length;
       }
+
+      // Ticket state: ba-complete (template validated, sections persisted).
+      eventBus.publish({
+        type: 'ticket.ba-complete',
+        actor: 'ba-agent',
+        correlation_id: correlationId,
+        entity_type: 'story',
+        entity_id: story.id,
+        payload: {
+          storyId: story.id,
+          promptId,
+          correlationId,
+          validationStatus: status,
+          sectionsPopulated: Object.keys(collab.agentSections),
+        },
+      });
     } catch {
       // Non-fatal — continue enriching remaining stories.
     }
   }
+
+  // Advance the prompt-level pipeline stage once every story has been
+  // enriched (or attempted). Subsequent reruns will append a new row.
+  advancePipelineStage(
+    {
+      promptId,
+      stage: 'ba_enriched',
+      correlationId,
+      metadata: { enrichedCount, ticketsValid, ticketsInvalid },
+    },
+    db,
+  );
 
   eventBus.publish({
     type: 'ba-agent.enrichment.complete',

--- a/apps/orchestrator/src/agents/pipeline-stages.ts
+++ b/apps/orchestrator/src/agents/pipeline-stages.ts
@@ -1,0 +1,104 @@
+/**
+ * Pipeline-stage advancement helper.
+ *
+ * Phase 1 advances every prompt through this canonical sequence:
+ *
+ *   ingested → scaffolded → po_decomposed → ba_enriched → bucket_placed
+ *   → ready_for_pickup
+ *
+ * Each transition is recorded in `prompt_pipeline_stages` (one row per
+ * advancement, with epoch-ms `enteredAt`) and reflected on
+ * `prompts.status` so consumers (the dashboard, the E2E test) can poll a
+ * single field. A `pipeline.stage.advanced` event is emitted alongside
+ * each transition so subscribers can track progression in real time.
+ */
+
+import { nanoid } from 'nanoid';
+import { eq, desc } from 'drizzle-orm';
+import { eventBus } from '../events/bus-adapter';
+import type { Db } from '../db/connection';
+import { promptPipelineStages, prompts } from '../db/schema';
+
+export const PIPELINE_STAGE_ORDER = [
+  'received',
+  'ingested',
+  'scaffolded',
+  'po_decomposed',
+  'ba_enriched',
+  'bucket_placed',
+  'ready_for_pickup',
+] as const;
+
+export type PipelineStage = (typeof PIPELINE_STAGE_ORDER)[number];
+
+export interface AdvanceStageInput {
+  promptId: string;
+  stage: PipelineStage;
+  correlationId: string;
+  entityKind?: string;
+  entityId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Insert a pipeline-stage row, mirror the stage onto `prompts.status`, and
+ * fire `pipeline.stage.advanced`. Idempotent on the row insert (uses unique
+ * id), but a stage may legitimately re-advance if a prompt re-runs the
+ * pipeline; in that case a new row is appended.
+ */
+export function advancePipelineStage(input: AdvanceStageInput, db: Db): void {
+  const now = Date.now();
+
+  // Compute durationMs from previous stage row (if any) — observability nicety.
+  const previous = db
+    .select()
+    .from(promptPipelineStages)
+    .where(eq(promptPipelineStages.promptId, input.promptId))
+    .orderBy(desc(promptPipelineStages.enteredAt))
+    .limit(1)
+    .get();
+  const durationMs = previous ? now - previous.enteredAt : undefined;
+
+  // Mark the previous stage row's durationMs once we know it.
+  if (previous && previous.durationMs == null) {
+    db.update(promptPipelineStages)
+      .set({ durationMs })
+      .where(eq(promptPipelineStages.id, previous.id))
+      .run();
+  }
+
+  db.insert(promptPipelineStages)
+    .values({
+      id: `pps_${nanoid(10)}`,
+      promptId: input.promptId,
+      stage: input.stage,
+      entityKind: input.entityKind ?? 'prompt',
+      entityId: input.entityId ?? input.promptId,
+      enteredAt: now,
+      metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+    })
+    .run();
+
+  // Mirror onto prompts.status so a single-field poll is enough for E2E +
+  // dashboards. We don't enforce monotonicity here — the pipeline itself
+  // is responsible for not regressing.
+  db.update(prompts)
+    .set({ status: input.stage })
+    .where(eq(prompts.id, input.promptId))
+    .run();
+
+  eventBus.publish({
+    type: 'pipeline.stage.advanced',
+    actor: 'system',
+    correlation_id: input.correlationId,
+    entity_type: 'prompt',
+    entity_id: input.promptId,
+    payload: {
+      promptId: input.promptId,
+      stage: input.stage,
+      entityKind: input.entityKind ?? 'prompt',
+      entityId: input.entityId ?? input.promptId,
+      durationFromStartMs: durationMs,
+    },
+  });
+}

--- a/apps/orchestrator/src/agents/po-agent.ts
+++ b/apps/orchestrator/src/agents/po-agent.ts
@@ -10,11 +10,13 @@
  */
 
 import { nanoid } from 'nanoid';
+import { eq } from 'drizzle-orm';
 import { classifyKeyword } from '@chiefaia/classifier';
 import { decompose } from '@chiefaia/decomposer';
 import { eventBus } from '../events/bus-adapter';
 import { getDb } from '../db/connection';
 import { requirements, stories } from '../db/schema';
+import { advancePipelineStage } from './pipeline-stages';
 
 // Logger shim — replaced at runtime by the real pino logger if available
 const logger = {
@@ -103,6 +105,16 @@ export async function runPOAgent(
             createdAt: now,
           }).run();
           storiesCreated++;
+
+          // Ticket state: draft (story exists, no enrichment yet).
+          eventBus.publish({
+            type: 'ticket.draft',
+            actor: 'po-agent',
+            correlation_id: correlationId,
+            entity_type: 'story',
+            entity_id: storyDbId,
+            payload: { storyId: storyDbId, promptId, correlationId, requirementId: reqId },
+          });
         } catch (err) {
           logger.warn({ err, storyDbId }, 'PO Agent: story insert skipped (may already exist)');
         }
@@ -127,6 +139,38 @@ export async function runPOAgent(
       primaryDomain: classification.primaryDomain,
     },
   });
+
+  // 5. Advance pipeline stage and emit per-story `ticket.po-decomposed`.
+  advancePipelineStage(
+    {
+      promptId,
+      stage: 'po_decomposed',
+      correlationId,
+      metadata: { requirementsCreated, storiesCreated, primaryDomain: classification.primaryDomain },
+    },
+    db,
+  );
+
+  // Emit ticket.po-decomposed for every story that exists under this prompt.
+  try {
+    const allStoriesForPrompt = db
+      .select({ id: stories.id })
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .all();
+    for (const s of allStoriesForPrompt) {
+      eventBus.publish({
+        type: 'ticket.po-decomposed',
+        actor: 'po-agent',
+        correlation_id: correlationId,
+        entity_type: 'story',
+        entity_id: s.id,
+        payload: { storyId: s.id, promptId, correlationId, requirementsCreated },
+      });
+    }
+  } catch {
+    /* non-fatal — ticket events are observability */
+  }
 
   return {
     promptId,

--- a/apps/orchestrator/src/agents/task-scheduler.ts
+++ b/apps/orchestrator/src/agents/task-scheduler.ts
@@ -16,6 +16,7 @@ import { getDb } from '../db/connection';
 import { tasks } from '../db/schema';
 import { eq } from 'drizzle-orm';
 import { placeStoriesInBuckets, type BucketPlacement } from './bucket-placer';
+import { advancePipelineStage } from './pipeline-stages';
 
 export interface SchedulerInput {
   promptId: string;
@@ -149,6 +150,51 @@ export async function runTaskScheduler(
   // bucket per prompt. Tickets are scheduled before tasks so the executor
   // can pick up enriched stories even when no tasks have been spawned yet.
   const placement = placeStoriesInBuckets({ promptId, correlationId }, db);
+
+  // Advance prompt-level pipeline stage to bucket_placed.
+  if (placement.placements.length > 0) {
+    advancePipelineStage(
+      {
+        promptId,
+        stage: 'bucket_placed',
+        correlationId,
+        metadata: {
+          sequentialBucketsCreated: placement.sequentialBucketsCreated,
+          parallelBucketSize: placement.parallelBucketSize,
+        },
+      },
+      db,
+    );
+
+    // Per-story ticket lifecycle event: ready-for-pickup.
+    for (const p of placement.placements) {
+      eventBus.publish({
+        type: 'ticket.ready-for-pickup',
+        actor: 'task-scheduler',
+        correlation_id: correlationId,
+        entity_type: 'story',
+        entity_id: p.storyId,
+        payload: {
+          storyId: p.storyId,
+          promptId,
+          correlationId,
+          bucketId: p.bucketId,
+          bucketKind: p.bucketKind,
+        },
+      });
+    }
+
+    // Advance to ready_for_pickup once every story has a bucket assignment.
+    advancePipelineStage(
+      {
+        promptId,
+        stage: 'ready_for_pickup',
+        correlationId,
+        metadata: { totalStoriesPlaced: placement.placements.length },
+      },
+      db,
+    );
+  }
 
   // Then schedule tasks (executor work-items) using the existing
   // topological-sort logic — task-level scheduling complements story-level

--- a/apps/orchestrator/src/api/routes/stories.ts
+++ b/apps/orchestrator/src/api/routes/stories.ts
@@ -13,6 +13,7 @@ import {
 } from '../../db/schema';
 import { bus } from '../../ws/bus';
 import { eventBus } from '../../events/bus-adapter';
+import { getTicketBundle } from '../ticket-bundle';
 
 function sha256(s: string): string {
   return createHash('sha256').update(s).digest('hex');
@@ -63,6 +64,17 @@ export function registerStoriesRoutes(app: Hono, db: Db): void {
       .orderBy(desc(storyRevisions.version))
       .all();
     return c.json(revs);
+  });
+
+  // GET /stories/:id/bundle — Phase-1 self-contained ticket bundle: story
+  // row + parsed TicketTemplateV1 (validated) + linked requirement + bucket
+  // + entity_labels + dependency / dependent id lists. Read-only, used by
+  // the executor and the phase1-e2e acceptance test.
+  app.get('/stories/:id/bundle', (c) => {
+    const id = c.req.param('id');
+    const bundle = getTicketBundle(db, id);
+    if (!bundle) return c.json({ error: 'not found' }, 404);
+    return c.json(bundle);
   });
 
   // POST /stories — transactional: story + revision_v1 + timeline

--- a/apps/orchestrator/src/api/ticket-bundle.ts
+++ b/apps/orchestrator/src/api/ticket-bundle.ts
@@ -1,0 +1,238 @@
+/**
+ * Ticket bundle assembler — returns the self-contained payload an executor
+ * needs to pick up a story without further DB queries.
+ *
+ * Bundle = story row + parsed TicketTemplateV1 (validated) + linked
+ * requirement row + bucket row + entity_label set + dependency / dependent
+ * id lists.
+ *
+ * Used by `GET /stories/:id/bundle` (see api/routes/stories.ts) and by the
+ * Phase 1 E2E test to assert the pipeline produced a valid, complete
+ * ticket end-to-end.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import {
+  TicketTemplateV1Schema,
+  type TicketTemplateV1,
+} from '@chiefaia/ticket-template';
+import type { Db } from '../db/connection';
+import {
+  entityLabels,
+  prompts,
+  requirements,
+  stories,
+  taskBuckets,
+} from '../db/schema';
+
+export interface TicketBundle {
+  story: {
+    id: string;
+    title: string;
+    description: string;
+    status: string;
+    rootPromptId: string | null;
+    parentEntityId: string | null;
+    parentEntityType: string | null;
+    bucketId: string | null;
+    templateVersion: string;
+    templateValidationStatus: string;
+    templateValidationErrors: unknown[] | null;
+    enrichedAt: number | null;
+    updatedAt: number | null;
+  };
+  ticket: TicketTemplateV1 | null;
+  ticketParseError: string | null;
+  prompt: {
+    id: string;
+    body: string;
+    receivedAt: string;
+    correlationId: string;
+    status: string;
+  } | null;
+  requirement: {
+    id: string;
+    title: string;
+    description: string;
+    state: string;
+  } | null;
+  bucket: {
+    id: string;
+    kind: 'sequential' | 'parallel';
+    domainSlug: string | null;
+    sequenceIndex: number | null;
+    status: string;
+  } | null;
+  labels: Array<{
+    labelSlug: string;
+    labelType: string;
+    confidence: number;
+    source: string;
+  }>;
+  dependencies: {
+    upstream: string[];
+    downstream: string[];
+  };
+}
+
+function safeParseStringArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((d): d is string => typeof d === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseTicket(raw: string | null | undefined): {
+  ticket: TicketTemplateV1 | null;
+  parseError: string | null;
+} {
+  if (!raw) return { ticket: null, parseError: 'agent_contributions_json is empty' };
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    return { ticket: null, parseError: `JSON.parse failed: ${(err as Error).message}` };
+  }
+  // Empty `{}` is a valid stub and not an error — return null without an error.
+  if (
+    json &&
+    typeof json === 'object' &&
+    !Array.isArray(json) &&
+    Object.keys(json as Record<string, unknown>).length === 0
+  ) {
+    return { ticket: null, parseError: null };
+  }
+  const result = TicketTemplateV1Schema.safeParse(json);
+  if (result.success) return { ticket: result.data, parseError: null };
+  const summary = result.error.issues
+    .slice(0, 3)
+    .map((i) => `${i.path.join('.')}: ${i.message}`)
+    .join('; ');
+  return { ticket: null, parseError: `schema validation failed: ${summary}` };
+}
+
+function parseValidationErrors(raw: string | null | undefined): unknown[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Assemble the full bundle for a story id. Returns null if the story does
+ * not exist.
+ */
+export function getTicketBundle(
+  db: Db,
+  storyId: string,
+): TicketBundle | null {
+  const story = db.select().from(stories).where(eq(stories.id, storyId)).get();
+  if (!story) return null;
+
+  const promptRow = story.rootPromptId
+    ? db.select().from(prompts).where(eq(prompts.id, story.rootPromptId)).get()
+    : undefined;
+
+  const requirementRow =
+    story.parentEntityType === 'requirement' && story.parentEntityId
+      ? db
+          .select()
+          .from(requirements)
+          .where(eq(requirements.id, story.parentEntityId))
+          .get()
+      : undefined;
+
+  const bucketRow = story.bucketId
+    ? db.select().from(taskBuckets).where(eq(taskBuckets.id, story.bucketId)).get()
+    : undefined;
+
+  const labels = db
+    .select({
+      labelSlug: entityLabels.labelSlug,
+      labelType: entityLabels.labelType,
+      confidence: entityLabels.confidence,
+      source: entityLabels.source,
+    })
+    .from(entityLabels)
+    .where(
+      and(
+        eq(entityLabels.entityKind, 'story'),
+        eq(entityLabels.entityId, storyId),
+      ),
+    )
+    .all();
+
+  // Compute downstream stories (reverse dependency lookup).
+  const upstream = safeParseStringArray(story.dependsOnJson);
+  const downstream: string[] = [];
+  if (story.rootPromptId) {
+    const sibling = db
+      .select({ id: stories.id, dependsOnJson: stories.dependsOnJson })
+      .from(stories)
+      .where(eq(stories.rootPromptId, story.rootPromptId))
+      .all();
+    for (const s of sibling) {
+      if (s.id === storyId) continue;
+      const sUp = safeParseStringArray(s.dependsOnJson);
+      if (sUp.includes(storyId)) downstream.push(s.id);
+    }
+  }
+
+  const { ticket, parseError } = parseTicket(story.agentContributionsJson);
+
+  return {
+    story: {
+      id: story.id,
+      title: story.title,
+      description: story.description ?? '',
+      status: story.status,
+      rootPromptId: story.rootPromptId,
+      parentEntityId: story.parentEntityId,
+      parentEntityType: story.parentEntityType,
+      bucketId: story.bucketId,
+      templateVersion: story.templateVersion,
+      templateValidationStatus: story.templateValidationStatus,
+      templateValidationErrors: parseValidationErrors(story.templateValidationErrors),
+      enrichedAt: story.enrichedAt,
+      updatedAt: story.updatedAt,
+    },
+    ticket,
+    ticketParseError: parseError,
+    prompt: promptRow
+      ? {
+          id: promptRow.id,
+          body: promptRow.body,
+          receivedAt: promptRow.receivedAt,
+          correlationId: promptRow.correlationId,
+          status: promptRow.status,
+        }
+      : null,
+    requirement: requirementRow
+      ? {
+          id: requirementRow.id,
+          title: requirementRow.title,
+          description: requirementRow.description,
+          state: requirementRow.state,
+        }
+      : null,
+    bucket: bucketRow
+      ? {
+          id: bucketRow.id,
+          kind: bucketRow.kind as 'sequential' | 'parallel',
+          domainSlug: bucketRow.domainSlug,
+          sequenceIndex: bucketRow.sequenceIndex,
+          status: bucketRow.status,
+        }
+      : null,
+    labels,
+    dependencies: { upstream, downstream },
+  };
+}

--- a/apps/orchestrator/tests/agents/pipeline-stages.test.ts
+++ b/apps/orchestrator/tests/agents/pipeline-stages.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Behavioural tests for the pipeline-stage advancement helper. Verifies
+ * that each call:
+ *   - inserts a row into prompt_pipeline_stages
+ *   - mirrors the stage onto prompts.status
+ *   - back-fills durationMs on the previous row
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq, asc } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { promptPipelineStages, prompts } from '../../src/db/schema';
+import {
+  PIPELINE_STAGE_ORDER,
+  advancePipelineStage,
+} from '../../src/agents/pipeline-stages';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedPrompt(db: ReturnType<typeof createTestDb>, id: string) {
+  db.insert(prompts)
+    .values({
+      id,
+      body: 'thing',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: `cor_${id}`,
+      hash: `hash_${id}`,
+      status: 'received',
+    })
+    .run();
+}
+
+describe('PIPELINE_STAGE_ORDER', () => {
+  it('locks the canonical Phase-1 progression', () => {
+    expect([...PIPELINE_STAGE_ORDER]).toEqual([
+      'received',
+      'ingested',
+      'scaffolded',
+      'po_decomposed',
+      'ba_enriched',
+      'bucket_placed',
+      'ready_for_pickup',
+    ]);
+  });
+});
+
+describe('advancePipelineStage', () => {
+  it('inserts a new row and mirrors the stage onto prompts.status', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_a');
+
+    advancePipelineStage(
+      { promptId: 'prm_a', stage: 'po_decomposed', correlationId: 'cor_a' },
+      db,
+    );
+
+    const rows = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, 'prm_a'))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.stage).toBe('po_decomposed');
+    expect(rows[0]!.entityKind).toBe('prompt');
+    expect(rows[0]!.entityId).toBe('prm_a');
+
+    const promptRow = db
+      .select()
+      .from(prompts)
+      .where(eq(prompts.id, 'prm_a'))
+      .get();
+    expect(promptRow!.status).toBe('po_decomposed');
+  });
+
+  it('back-fills durationMs on the previous row when a new stage advances', async () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_b');
+
+    advancePipelineStage(
+      { promptId: 'prm_b', stage: 'ingested', correlationId: 'cor_b' },
+      db,
+    );
+
+    // Wait a hair so the second stage's enteredAt is after the first.
+    await new Promise((r) => setTimeout(r, 5));
+
+    advancePipelineStage(
+      { promptId: 'prm_b', stage: 'scaffolded', correlationId: 'cor_b' },
+      db,
+    );
+
+    const rows = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, 'prm_b'))
+      .orderBy(asc(promptPipelineStages.enteredAt))
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.stage).toBe('ingested');
+    expect(rows[1]!.stage).toBe('scaffolded');
+    // Previous row gets durationMs filled.
+    expect(rows[0]!.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('persists supplied metadata as JSON', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_meta');
+    advancePipelineStage(
+      {
+        promptId: 'prm_meta',
+        stage: 'ba_enriched',
+        correlationId: 'cor_meta',
+        metadata: { ticketsValid: 3, ticketsInvalid: 0 },
+      },
+      db,
+    );
+    const row = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, 'prm_meta'))
+      .get();
+    expect(row!.metadata).toBeTruthy();
+    const parsed = JSON.parse(row!.metadata!);
+    expect(parsed.ticketsValid).toBe(3);
+  });
+
+  it('progresses a prompt through every Phase-1 stage', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_full');
+    for (const stage of [
+      'ingested',
+      'scaffolded',
+      'po_decomposed',
+      'ba_enriched',
+      'bucket_placed',
+      'ready_for_pickup',
+    ] as const) {
+      advancePipelineStage(
+        { promptId: 'prm_full', stage, correlationId: 'cor_full' },
+        db,
+      );
+    }
+    const rows = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, 'prm_full'))
+      .orderBy(asc(promptPipelineStages.enteredAt))
+      .all();
+    expect(rows.map((r) => r.stage)).toEqual([
+      'ingested',
+      'scaffolded',
+      'po_decomposed',
+      'ba_enriched',
+      'bucket_placed',
+      'ready_for_pickup',
+    ]);
+    const promptRow = db
+      .select()
+      .from(prompts)
+      .where(eq(prompts.id, 'prm_full'))
+      .get();
+    expect(promptRow!.status).toBe('ready_for_pickup');
+  });
+});

--- a/apps/orchestrator/tests/api/ticket-bundle.test.ts
+++ b/apps/orchestrator/tests/api/ticket-bundle.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Behavioural tests for getTicketBundle — the self-contained ticket bundle
+ * assembler used by GET /stories/:id/bundle and the phase1-e2e test.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import {
+  entityLabels,
+  prompts,
+  requirements,
+  stories,
+  taskBuckets,
+} from '../../src/db/schema';
+import { TicketTemplateV1Schema, buildDraftTicket } from '@chiefaia/ticket-template';
+import { getTicketBundle } from '../../src/api/ticket-bundle';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedFixture(db: ReturnType<typeof createTestDb>) {
+  const promptId = 'prm_bundle';
+  const requirementId = 'req_bundle';
+  const storyId = 'story_bundle_main';
+  const upstreamStoryId = 'story_bundle_upstream';
+  const downstreamStoryId = 'story_bundle_downstream';
+  const bucketId = 'bkt_seq_auth_000';
+
+  db.insert(prompts)
+    .values({
+      id: promptId,
+      body: 'login',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: 'cor_bundle',
+      hash: 'h_bundle',
+      status: 'ready_for_pickup',
+    })
+    .run();
+
+  db.insert(requirements)
+    .values({
+      id: requirementId,
+      title: 'Login epic',
+      description: 'epic',
+      state: 'captured',
+      priority: 3,
+      labels: '[]',
+      rootPromptId: promptId,
+      parentEntityType: 'initiative',
+      parentEntityId: 'init_1',
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    })
+    .run();
+
+  db.insert(taskBuckets)
+    .values({
+      id: bucketId,
+      kind: 'sequential',
+      domainSlug: 'auth',
+      promptId,
+      createdAt: Date.now(),
+      sequenceIndex: 0,
+      status: 'open',
+    })
+    .run();
+
+  // Build a valid ticket and store it as agent_contributions_json.
+  const draft = buildDraftTicket({
+    rootPromptId: promptId,
+    requirementId,
+    domainPrimary: 'auth',
+    domainAll: ['auth', 'api-integration'],
+    nature: 'feature',
+    complexity: 'medium',
+    summary: 'Add OAuth login',
+    inScope: ['Google OAuth'],
+    acceptanceCriteria: ['ac1', 'ac2', 'ac3'],
+    verificationPlan: ['pnpm test'],
+    upstream: [upstreamStoryId],
+  });
+  const ticket = {
+    ...draft,
+    agentSections: {
+      architecture: {
+        contributedBy: 'ea-agent',
+        contributedAt: Date.now(),
+        adrReferences: [],
+        constraints: [],
+        notes: 'arch notes',
+      },
+    },
+    baEnrichment: {
+      enrichedBy: 'ba-agent',
+      enrichedAt: Date.now(),
+      inputsRequested: [],
+      completenessChecksPassed: true,
+      notes: '',
+    },
+  };
+
+  db.insert(stories)
+    .values({
+      id: upstreamStoryId,
+      kind: 'story',
+      title: 'Upstream story',
+      description: '',
+      dependsOnJson: '[]',
+      status: 'pending',
+      rootPromptId: promptId,
+      createdAt: nowIso(),
+    })
+    .run();
+
+  db.insert(stories)
+    .values({
+      id: storyId,
+      kind: 'story',
+      title: 'OAuth login story',
+      description: 'Implement OAuth login.',
+      acceptanceCriteriaJson: '[]',
+      dependsOnJson: JSON.stringify([upstreamStoryId]),
+      status: 'pending',
+      rootPromptId: promptId,
+      parentEntityType: 'requirement',
+      parentEntityId: requirementId,
+      createdAt: nowIso(),
+      bucketId,
+      templateVersion: 'v1',
+      templateValidationStatus: 'valid',
+      templateValidationErrors: null,
+      agentContributionsJson: JSON.stringify(ticket),
+      enrichedAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    .run();
+
+  // Downstream story depends on the main one.
+  db.insert(stories)
+    .values({
+      id: downstreamStoryId,
+      kind: 'story',
+      title: 'Downstream story',
+      description: '',
+      dependsOnJson: JSON.stringify([storyId]),
+      status: 'pending',
+      rootPromptId: promptId,
+      createdAt: nowIso(),
+    })
+    .run();
+
+  db.insert(entityLabels)
+    .values({
+      id: 'lbl_main_auth',
+      entityKind: 'story',
+      entityId: storyId,
+      labelSlug: 'auth',
+      labelType: 'domain',
+      confidence: 0.95,
+      source: 'classifier',
+      createdAt: Date.now(),
+    })
+    .run();
+
+  return { promptId, requirementId, storyId, upstreamStoryId, downstreamStoryId, bucketId };
+}
+
+describe('getTicketBundle', () => {
+  it('returns null for an unknown story id', () => {
+    const db = createTestDb();
+    expect(getTicketBundle(db, 'missing')).toBeNull();
+  });
+
+  it('returns a fully-populated bundle for a placed, enriched story', () => {
+    const db = createTestDb();
+    const fx = seedFixture(db);
+    const bundle = getTicketBundle(db, fx.storyId)!;
+    expect(bundle).toBeTruthy();
+
+    expect(bundle.story.id).toBe(fx.storyId);
+    expect(bundle.story.bucketId).toBe(fx.bucketId);
+    expect(bundle.story.templateValidationStatus).toBe('valid');
+    expect(bundle.ticket).not.toBeNull();
+    expect(bundle.ticketParseError).toBeNull();
+
+    // Linked entities
+    expect(bundle.prompt?.id).toBe(fx.promptId);
+    expect(bundle.requirement?.id).toBe(fx.requirementId);
+    expect(bundle.bucket?.id).toBe(fx.bucketId);
+    expect(bundle.bucket?.kind).toBe('sequential');
+    expect(bundle.bucket?.domainSlug).toBe('auth');
+
+    // Labels
+    expect(bundle.labels).toHaveLength(1);
+    expect(bundle.labels[0]!.labelSlug).toBe('auth');
+
+    // Dependencies
+    expect(bundle.dependencies.upstream).toEqual([fx.upstreamStoryId]);
+    expect(bundle.dependencies.downstream).toEqual([fx.downstreamStoryId]);
+  });
+
+  it('round-trips the embedded ticket through TicketTemplateV1Schema', () => {
+    const db = createTestDb();
+    const fx = seedFixture(db);
+    const bundle = getTicketBundle(db, fx.storyId)!;
+    const parsed = TicketTemplateV1Schema.safeParse(bundle.ticket);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('returns ticket=null with a parse error when agent_contributions_json is malformed', () => {
+    const db = createTestDb();
+    const fx = seedFixture(db);
+    db.update(stories)
+      .set({ agentContributionsJson: '{not json' })
+      .where(eq(stories.id, fx.storyId))
+      .run();
+    const bundle = getTicketBundle(db, fx.storyId)!;
+    expect(bundle.ticket).toBeNull();
+    expect(bundle.ticketParseError).toMatch(/JSON\.parse failed/);
+  });
+
+  it('returns ticket=null with no parse error when agent_contributions_json is the default {}', () => {
+    const db = createTestDb();
+    db.insert(prompts)
+      .values({
+        id: 'prm_empty',
+        body: 'x',
+        receivedAt: nowIso(),
+        receivedVia: 'api',
+        correlationId: 'cor_empty',
+        hash: 'h_empty',
+        status: 'received',
+      })
+      .run();
+    db.insert(stories)
+      .values({
+        id: 'story_empty',
+        kind: 'story',
+        title: 'Bare story',
+        description: '',
+        rootPromptId: 'prm_empty',
+        createdAt: nowIso(),
+      })
+      .run();
+    const bundle = getTicketBundle(db, 'story_empty')!;
+    expect(bundle.ticket).toBeNull();
+    expect(bundle.ticketParseError).toBeNull();
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -324,6 +324,12 @@ export type EventType =
   | 'task-scheduler.scheduling.complete'
   // ─── Task Scheduler bucket placement (migration 0021) ────────────────────
   | 'task-scheduler.bucket-placed'
+  // ─── Ticket state machine (migration 0021 ticket_template lifecycle) ────
+  | 'ticket.draft'
+  | 'ticket.po-decomposed'
+  | 'ticket.ba-enriching'
+  | 'ticket.ba-complete'
+  | 'ticket.ready-for-pickup'
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   | 'testing-agent.validation.complete'
   | 'release-agent.report.ready'
@@ -389,6 +395,12 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'task-scheduler.scheduling.complete': 'info',
   // ─── Task Scheduler bucket placement (migration 0021) ────────────────────
   'task-scheduler.bucket-placed': 'info',
+  // ─── Ticket state machine (migration 0021 ticket_template lifecycle) ────
+  'ticket.draft': 'info',
+  'ticket.po-decomposed': 'info',
+  'ticket.ba-enriching': 'info',
+  'ticket.ba-complete': 'info',
+  'ticket.ready-for-pickup': 'info',
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   'testing-agent.validation.complete': 'info',
   'release-agent.report.ready': 'info',

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -418,3 +418,29 @@ events:
     severity: info
     actor: [task-scheduler]
     payload: [promptId, correlationId, storyId, bucketId, bucketKind, domainSlug, positionInBucket]
+
+  # Ticket state machine (migration 0021 ticket_template lifecycle)
+  - type: ticket.draft
+    severity: info
+    actor: [po-agent]
+    payload: [storyId, promptId, correlationId, requirementId]
+
+  - type: ticket.po-decomposed
+    severity: info
+    actor: [po-agent]
+    payload: [storyId, promptId, correlationId, requirementsCreated]
+
+  - type: ticket.ba-enriching
+    severity: info
+    actor: [ba-agent]
+    payload: [storyId, promptId, correlationId]
+
+  - type: ticket.ba-complete
+    severity: info
+    actor: [ba-agent]
+    payload: [storyId, promptId, correlationId, validationStatus, sectionsPopulated]
+
+  - type: ticket.ready-for-pickup
+    severity: info
+    actor: [task-scheduler]
+    payload: [storyId, promptId, correlationId, bucketId, bucketKind]


### PR DESCRIPTION
## Gate 3 Phase-1 pipeline — PR 4/N

Closes Phase-1 analysis gaps 1.4.c (ticket state machine) and 1.4.b (self-contained ticket bundle). The pipeline now advances every prompt through a canonical seven-stage sequence and exposes a single endpoint that returns the full ticket payload an executor needs.

## New module — `apps/orchestrator/src/agents/pipeline-stages.ts`

`PIPELINE_STAGE_ORDER` locks the canonical sequence: `received → ingested → scaffolded → po_decomposed → ba_enriched → bucket_placed → ready_for_pickup`.

`advancePipelineStage()`:
- inserts a row in `prompt_pipeline_stages` with epoch-ms `enteredAt`
- back-fills the previous row's `durationMs` (observability nicety)
- mirrors the stage onto `prompts.status` so a single-field poll is enough
- emits `pipeline.stage.advanced`

## Agent integration

- **po-agent**: emits `ticket.draft` per inserted story; advances pipeline to `po_decomposed`; emits `ticket.po-decomposed` per story.
- **ba-agent**: emits `ticket.ba-enriching` before each story's collab round; emits `ticket.ba-complete` after persisting the validated template; advances pipeline to `ba_enriched` once all stories are done.
- **task-scheduler**: when bucket placements exist, advances to `bucket_placed`, emits one `ticket.ready-for-pickup` per placement, then advances to `ready_for_pickup`.

## Bundle assembler + endpoint

`apps/orchestrator/src/api/ticket-bundle.ts` exposes `getTicketBundle()` — the self-contained payload an executor needs:
- story row (with template metadata)
- the parsed `TicketTemplateV1` (or `null` + parseError for malformed)
- linked prompt + requirement + bucket rows
- entity_labels for the story
- upstream + downstream story id lists

`apps/orchestrator/src/api/routes/stories.ts` exposes `GET /stories/:id/bundle` returning the bundle (or 404).

## Event taxonomy

Five new ticket-state events:
- `ticket.draft` (po-agent)
- `ticket.po-decomposed` (po-agent)
- `ticket.ba-enriching` (ba-agent)
- `ticket.ba-complete` (ba-agent)
- `ticket.ready-for-pickup` (task-scheduler)

Added to both `registry.yaml` and `packages/events-taxonomy-internal/index.ts`.

## Tests

- **pipeline-stages.test.ts** — 5 cases (canonical order locked; row insert + status mirror; durationMs back-fill; metadata round-trip; full progression).
- **ticket-bundle.test.ts** — 5 cases (404 on unknown id; full populated bundle; Zod round-trip on embedded ticket; malformed JSON path; default `'{}'` path returns null without parseError).

Combined Phase-1 suites: **75/75 green**. `apps/orchestrator pnpm typecheck` clean.

## Out of scope

- `tests/phase1-e2e.spec.ts` end-to-end acceptance test — next PR (the verification gate).
- `caia/docs/phase1-pipeline.md` — final docs PR.
