### PR TITLE
feat(dashboard,orchestrator): Phase-1 journey live timeline (GATE-4-01)

### DIFF
--- a/apps/dashboard/app/api/prompts/[id]/phase1/route.ts
+++ b/apps/dashboard/app/api/prompts/[id]/phase1/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Dashboard API proxy: GET /api/prompts/:id/phase1
+ *
+ * Forwards to the orchestrator's GATE-4-01 endpoint that surfaces every
+ * Phase-1 surface for the journey page (pipeline stages, stories,
+ * buckets, BA agent-collab thread, Phase-1 events). The dashboard polls
+ * this once on load and refetches when a Phase-1 WS event arrives.
+ */
+import { NextResponse } from 'next/server';
+
+const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }): Promise<NextResponse> {
+  const id = params.id;
+  try {
+    const upstream = await fetch(`${ORCHESTRATOR_URL}/prompts/${encodeURIComponent(id)}/phase1`, {
+      cache: 'no-store',
+    });
+    if (!upstream.ok) {
+      return NextResponse.json(
+        { error: `Upstream ${upstream.status}` },
+        { status: upstream.status },
+      );
+    }
+    const data = await upstream.json() as unknown;
+    return NextResponse.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/prompts/[id]/journey/page.tsx
+++ b/apps/dashboard/app/prompts/[id]/journey/page.tsx
@@ -1,8 +1,20 @@
 'use client';
-import { useEffect, useState } from 'react';
+/**
+ * Prompt journey page (extended for Gate 4).
+ *
+ * Renders the original journey summary (timing, status distribution,
+ * descendants) plus a live Phase-1 timeline. Subscribes to the WS bus
+ * and refetches the Phase-1 payload whenever a Phase-1 event arrives
+ * for this prompt — that gives the user a live view of every stage
+ * as it happens, end-to-end (PO → BA → Task Manager → bucket placed).
+ */
+import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useWebSocket } from '../../../../hooks/useWebSocket';
+import { Phase1Timeline, type Phase1Payload } from '../../../../components/Phase1Timeline';
 
 const API = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:7776';
+const WS_URL = process.env['NEXT_PUBLIC_WS_URL'] ?? 'ws://localhost:7776/events';
 
 interface Journey {
   promptId: string;
@@ -31,6 +43,9 @@ const STATUS_COLOR: Record<string, string> = {
   answered: '#16a34a', failed: '#dc2626',
   queued: '#9ca3af', running: '#2563eb', completed: '#16a34a',
   blocked: '#f59e0b', done: '#16a34a', pending: '#9ca3af',
+  ingested: '#6b7280', scaffolded: '#3182ce',
+  po_decomposed: '#805ad5', ba_enriched: '#dd6b20',
+  bucket_placed: '#38a169', ready_for_pickup: '#16a34a',
 };
 
 function ms(v?: number | null): string {
@@ -40,20 +55,63 @@ function ms(v?: number | null): string {
   return `${(v / 60_000).toFixed(1)}m`;
 }
 
+/**
+ * Phase-1 event prefixes that should trigger a refetch of /phase1.
+ * Listed explicitly so that unrelated tab-traffic never wakes this page up.
+ */
+const PHASE1_TRIGGERS = [
+  'pipeline.stage.advanced',
+  'po-agent.',
+  'ba-agent.',
+  'task-scheduler.',
+  'ticket.',
+  'scaffolder.team.assembled',
+  'prompt.ingested',
+  'prompt.status_changed',
+];
+
+function isPhase1EventType(type: string | undefined): boolean {
+  if (!type) return false;
+  return PHASE1_TRIGGERS.some((p) => type === p || type.startsWith(p));
+}
+
 export default function PromptJourneyPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const [journey, setJourney] = useState<Journey | null>(null);
+  const [phase1, setPhase1] = useState<Phase1Payload | null>(null);
   const [loading, setLoading] = useState(true);
+  const { lastEvent, connected } = useWebSocket(WS_URL);
 
-  useEffect(() => {
-    fetch(`${API}/prompts/${id}/journey`)
-      .then(r => r.json())
-      .then((d: Journey) => {
-        setJourney(d);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
+  const refetch = useCallback(async () => {
+    const [j, p] = await Promise.all([
+      fetch(`${API}/prompts/${id}/journey`).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+      fetch(`/api/prompts/${id}/phase1`).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+    ]);
+    if (j) setJourney(j as Journey);
+    if (p) setPhase1(p as Phase1Payload);
+    setLoading(false);
   }, [id]);
+
+  useEffect(() => { void refetch(); }, [refetch]);
+
+  // Live refetch: when a Phase-1 event arrives whose correlation_id
+  // matches this prompt (or a per-story sub-correlation), refetch.
+  useEffect(() => {
+    if (!lastEvent) return;
+    if (!isPhase1EventType(lastEvent.type ?? lastEvent.kind)) return;
+    // Some events arrive without an explicit correlationId on the
+    // legacy envelope. The orchestrator stamps it for Phase 1, so we
+    // can be strict here.
+    const corrCandidate = (lastEvent.payload as Record<string, unknown> | undefined)?.['correlationId']
+      ?? (lastEvent.payload as Record<string, unknown> | undefined)?.['correlation_id']
+      ?? (lastEvent as unknown as Record<string, unknown>)['correlationId']
+      ?? (lastEvent as unknown as Record<string, unknown>)['correlation_id'];
+    const promptCorr = phase1?.prompt.correlationId ?? id;
+    const matches = !corrCandidate ||
+      corrCandidate === promptCorr ||
+      (typeof corrCandidate === 'string' && corrCandidate.startsWith(`${promptCorr}::`));
+    if (matches) void refetch();
+  }, [lastEvent, refetch, phase1?.prompt.correlationId, id]);
 
   if (loading) return <div style={{ color: '#718096', padding: 32 }}>Loading…</div>;
   if (!journey) return (
@@ -64,22 +122,39 @@ export default function PromptJourneyPage({ params }: { params: { id: string } }
   );
 
   const statusEntries = Object.entries(journey.countByStatus).sort((a, b) => b[1] - a[1]);
-  const maxCount = Math.max(...statusEntries.map(e => e[1]), 1);
+  const maxCount = Math.max(...statusEntries.map((e) => e[1]), 1);
 
   return (
     <div style={{ padding: 20, fontFamily: 'system-ui', fontSize: 14 }}>
-      {/* Breadcrumbs */}
       <div style={{ color: '#6b7280', fontSize: 12, marginBottom: 12 }}>
         <Link href="/prompts" style={{ color: '#6b7280' }}>Prompts</Link>
         {' → '}
         <Link href={`/prompts/${id}`} style={{ color: '#6b7280' }}>{id.slice(0, 20)}</Link>
         {' → '}
         Journey
+        <span style={{ marginLeft: 12, color: connected ? '#68d391' : '#fc8181' }}>
+          {connected ? '● live' : '○ reconnecting…'}
+        </span>
       </div>
 
       <h2 style={{ marginBottom: 20 }}>Prompt Journey — #{id.slice(0, 14)}</h2>
 
-      {/* Timing stats */}
+      {/* Phase 1 panel — the meat of Gate 4 */}
+      {phase1 && (
+        <div
+          data-testid="phase1-panel"
+          style={{
+            background: '#0f1117',
+            border: '1px solid #2d3748',
+            borderRadius: 8,
+            padding: 18,
+            marginBottom: 28,
+          }}
+        >
+          <Phase1Timeline data={phase1} />
+        </div>
+      )}
+
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12, marginBottom: 28 }}>
         {[
           ['Status', journey.status],
@@ -98,7 +173,6 @@ export default function PromptJourneyPage({ params }: { params: { id: string } }
         ))}
       </div>
 
-      {/* Descendant breakdown */}
       <h3 style={{ marginBottom: 12 }}>Descendants by type</h3>
       <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 28 }}>
         {Object.entries(journey.descendants).filter(([k]) => k !== 'total').map(([type, cnt]) => (
@@ -109,7 +183,6 @@ export default function PromptJourneyPage({ params }: { params: { id: string } }
         ))}
       </div>
 
-      {/* Status distribution heatmap bar */}
       {statusEntries.length > 0 && (
         <>
           <h3 style={{ marginBottom: 12 }}>Status distribution</h3>
@@ -132,10 +205,9 @@ export default function PromptJourneyPage({ params }: { params: { id: string } }
         </>
       )}
 
-      {/* Sankey-style status flow (text representation) */}
       <h3 style={{ marginBottom: 12 }}>Status journey (lifecycle)</h3>
       <div style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: 8, padding: 16, fontFamily: 'monospace', fontSize: 12, color: '#374151' }}>
-        <div>Prompt: received → analyzing → decomposed → answered | failed</div>
+        <div>Phase 1: ingested → scaffolded → po_decomposed → ba_enriched → bucket_placed → ready_for_pickup</div>
         <div style={{ marginTop: 8 }}>Task: queued → ready → dispatched → running → gate_pending → gate_passed → sentinel_pending → sentinel_passed → done</div>
         <div style={{ marginTop: 8, color: '#9ca3af' }}>Side branches: gate_failed → rework_queued → ready | sentinel_flagged → bug_filed | paused | blocked | cancelled</div>
       </div>

--- a/apps/dashboard/components/Phase1Timeline.tsx
+++ b/apps/dashboard/components/Phase1Timeline.tsx
@@ -1,0 +1,283 @@
+'use client';
+/**
+ * Phase 1 timeline component (GATE-4-01).
+ *
+ * Renders a vertical timeline of the canonical Phase-1 stages
+ * (ingested → scaffolded → po_decomposed → ba_enriched →
+ *  bucket_placed → ready_for_pickup) with per-stage status pulled
+ * from `prompt_pipeline_stages` rows on the prompt's `/phase1` payload.
+ *
+ * Each stage carries its own evidence summary (story count, ticket
+ * count, bucket counts, BA collab counts) so the user can see at a
+ * glance which stage produced what. Live updates land via the
+ * journey page's WS subscription — when a Phase-1 event arrives the
+ * page refetches and feeds the new payload here.
+ */
+import Link from 'next/link';
+
+export const PHASE1_STAGES = [
+  { key: 'ingested', label: 'Ingested', icon: '📥', actor: 'api' },
+  { key: 'scaffolded', label: 'Scaffolded', icon: '🏗️', actor: 'scaffolder' },
+  { key: 'po_decomposed', label: 'PO Decomposed', icon: '📐', actor: 'po-agent' },
+  { key: 'ba_enriched', label: 'BA Enriched', icon: '🤝', actor: 'ba-agent' },
+  { key: 'bucket_placed', label: 'Bucket Placed', icon: '🗂️', actor: 'task-scheduler' },
+  { key: 'ready_for_pickup', label: 'Ready for Pickup', icon: '🟢', actor: 'task-scheduler' },
+] as const;
+
+type StageKey = typeof PHASE1_STAGES[number]['key'];
+
+export interface Phase1Story {
+  id: string;
+  title: string;
+  kind: string;
+  status: string;
+  bucketId: string | null;
+  templateVersion: string;
+  templateValidationStatus: string;
+  acceptanceCriteriaCount: number;
+  enrichedAt: number | null;
+  updatedAt: number | null;
+}
+
+export interface Phase1Bucket {
+  id: string;
+  kind: string;
+  domainSlug: string | null;
+  sequenceIndex: number | null;
+  status: string;
+  createdAt: number;
+  storyIds: string[];
+}
+
+export interface Phase1AgentMessage {
+  id: string;
+  fromAgent: string;
+  toAgent: string;
+  messageType: string;
+  correlationId: string;
+  status: string;
+  createdAt: number;
+  processedAt: number | null;
+  expectedReplyBy: number | null;
+  repliedAt: number | null;
+  parentMessageId: string | null;
+  payload: unknown;
+}
+
+export interface Phase1Stage {
+  id: string;
+  stage: string;
+  entityKind: string | null;
+  entityId: string | null;
+  enteredAt: number;
+  durationMs: number | null;
+  metadata: string | null;
+}
+
+export interface Phase1Event {
+  id: string;
+  type: string;
+  actor: string;
+  occurredAt: string;
+  correlationId: string;
+  entityType: string | null;
+  entityId: string | null;
+  payload: unknown;
+  severity: string;
+}
+
+export interface Phase1Payload {
+  prompt: { id: string; body: string; receivedAt: string; correlationId: string; status: string };
+  pipelineStages: Phase1Stage[];
+  stories: Phase1Story[];
+  buckets: Phase1Bucket[];
+  agentMessages: Phase1AgentMessage[];
+  phase1Events: Phase1Event[];
+}
+
+function fmtMs(v: number | null | undefined): string {
+  if (v == null) return '—';
+  if (v < 1000) return `${v}ms`;
+  if (v < 60_000) return `${(v / 1000).toFixed(1)}s`;
+  return `${(v / 60_000).toFixed(1)}m`;
+}
+
+function fmtTime(epochMs: number): string {
+  return new Date(epochMs).toLocaleTimeString();
+}
+
+function stageEvidence(key: StageKey, p: Phase1Payload): string {
+  switch (key) {
+    case 'ingested':
+      return p.prompt.body ? `${p.prompt.body.slice(0, 80)}${p.prompt.body.length > 80 ? '…' : ''}` : '';
+    case 'scaffolded':
+      return 'context broadcast to activated agents';
+    case 'po_decomposed':
+      return `${p.stories.length} stor${p.stories.length === 1 ? 'y' : 'ies'} produced`;
+    case 'ba_enriched': {
+      const valid = p.stories.filter((s) => s.templateValidationStatus === 'valid').length;
+      const reqs = p.agentMessages.filter((m) => m.messageType === 'input-requested').length;
+      const reps = p.agentMessages.filter((m) => m.messageType === 'input-received').length;
+      return `${valid}/${p.stories.length} valid · ${reps}/${reqs} consultant replies`;
+    }
+    case 'bucket_placed': {
+      const seq = p.buckets.filter((b) => b.kind === 'sequential').length;
+      const par = p.buckets.filter((b) => b.kind === 'parallel').length;
+      return `${seq} sequential · ${par} parallel`;
+    }
+    case 'ready_for_pickup': {
+      const placed = p.stories.filter((s) => s.bucketId).length;
+      return `${placed} ticket${placed === 1 ? '' : 's'} ready for executor`;
+    }
+  }
+}
+
+export function Phase1Timeline({ data }: { data: Phase1Payload }) {
+  const stagesByKey = new Map<string, Phase1Stage>();
+  for (const s of data.pipelineStages) stagesByKey.set(s.stage, s);
+
+  return (
+    <div data-testid="phase1-timeline">
+      <h3 style={{ margin: '0 0 12px', color: '#e2e8f0', fontSize: 16 }}>Phase 1 pipeline</h3>
+      <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {PHASE1_STAGES.map((stage, idx) => {
+          const row = stagesByKey.get(stage.key);
+          const reached = !!row;
+          const last = idx === PHASE1_STAGES.length - 1;
+          const dot = reached ? '#68d391' : '#4a5568';
+          const text = reached ? '#e2e8f0' : '#718096';
+          return (
+            <li
+              key={stage.key}
+              data-testid={`phase1-stage-${stage.key}`}
+              data-stage-reached={reached ? 'true' : 'false'}
+              style={{ position: 'relative', paddingLeft: 32, paddingBottom: last ? 0 : 18 }}
+            >
+              {!last && (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    position: 'absolute', left: 11, top: 24, bottom: -6, width: 2,
+                    background: reached ? '#2f855a' : '#2d3748',
+                  }}
+                />
+              )}
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute', left: 4, top: 4, width: 16, height: 16,
+                  borderRadius: '50%', background: dot, border: '2px solid #1a1f2e',
+                }}
+              />
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 14, fontWeight: 600, color: text }}>
+                  {stage.icon} {stage.label}
+                </span>
+                <span style={{ fontSize: 11, color: '#718096' }}>{stage.actor}</span>
+                {row && (
+                  <>
+                    <span style={{ fontSize: 11, color: '#a0aec0', fontFamily: 'monospace' }}>
+                      {fmtTime(row.enteredAt)}
+                    </span>
+                    {row.durationMs != null && (
+                      <span style={{ fontSize: 11, color: '#718096' }}>
+                        +{fmtMs(row.durationMs)}
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
+              <div style={{ fontSize: 12, color: text, marginTop: 4 }}>
+                {reached ? stageEvidence(stage.key, data) : 'pending'}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {data.stories.length > 0 && (
+        <div style={{ marginTop: 24 }}>
+          <h4 style={{ margin: '0 0 8px', color: '#e2e8f0', fontSize: 14 }}>
+            Stories ({data.stories.length})
+          </h4>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 8 }}>
+            {data.stories.map((s) => (
+              <div
+                key={s.id}
+                data-testid={`phase1-story-${s.id}`}
+                style={{
+                  background: '#1a1f2e',
+                  border: '1px solid #2d3748',
+                  borderRadius: 6,
+                  padding: '10px 12px',
+                  fontSize: 12,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                  <Link href={`/stories?id=${encodeURIComponent(s.id)}`} style={{ color: '#90cdf4', textDecoration: 'none', fontWeight: 600 }}>
+                    {s.title}
+                  </Link>
+                  <span style={{
+                    fontSize: 10,
+                    padding: '1px 6px',
+                    borderRadius: 3,
+                    background: s.templateValidationStatus === 'valid' ? '#2f855a'
+                              : s.templateValidationStatus === 'invalid' ? '#c53030' : '#4a5568',
+                    color: '#fff',
+                  }}>{s.templateValidationStatus}</span>
+                </div>
+                <div style={{ color: '#a0aec0', fontSize: 11 }}>
+                  {s.kind} · {s.acceptanceCriteriaCount} AC{s.bucketId ? ` · bucket ${s.bucketId.slice(0, 14)}` : ''}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {data.buckets.length > 0 && (
+        <div style={{ marginTop: 20 }}>
+          <h4 style={{ margin: '0 0 8px', color: '#e2e8f0', fontSize: 14 }}>
+            Buckets ({data.buckets.length})
+          </h4>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {data.buckets.map((b) => (
+              <div
+                key={b.id}
+                data-testid={`phase1-bucket-${b.id}`}
+                style={{
+                  background: b.kind === 'sequential' ? '#2c2410' : '#10202c',
+                  border: `1px solid ${b.kind === 'sequential' ? '#f6ad55' : '#63b3ed'}33`,
+                  borderRadius: 6,
+                  padding: '8px 12px',
+                  fontSize: 12,
+                  minWidth: 180,
+                }}
+              >
+                <div style={{ color: b.kind === 'sequential' ? '#f6ad55' : '#63b3ed', fontWeight: 600 }}>
+                  {b.kind} {b.domainSlug ? `· ${b.domainSlug}` : '· pool'}
+                </div>
+                <div style={{ color: '#a0aec0', marginTop: 2 }}>
+                  {b.storyIds.length} ticket{b.storyIds.length === 1 ? '' : 's'} · {b.status}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {data.agentMessages.length > 0 && (
+        <div style={{ marginTop: 20 }} data-testid="phase1-collab-teaser">
+          <h4 style={{ margin: '0 0 8px', color: '#e2e8f0', fontSize: 14 }}>
+            BA collaboration ({data.agentMessages.length} message{data.agentMessages.length === 1 ? '' : 's'})
+          </h4>
+          <div style={{ color: '#a0aec0', fontSize: 12 }}>
+            {data.agentMessages.filter((m) => m.messageType === 'input-requested').length} inputRequest
+            {' · '}
+            {data.agentMessages.filter((m) => m.messageType === 'input-received').length} inputReceived
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/orchestrator/src/api/routes/prompts.ts
+++ b/apps/orchestrator/src/api/routes/prompts.ts
@@ -1,7 +1,7 @@
 import type { Hono } from 'hono';
 import { eq, desc, asc, sql, gte } from 'drizzle-orm';
 import type { Db } from '../../db/connection';
-import { prompts, events, promptPipelineStages, requirements, stories, tasks as dbTasks, taskRuns, dedupResults, entityLabels } from '../../db/schema';
+import { prompts, events, promptPipelineStages, requirements, stories, tasks as dbTasks, taskRuns, dedupResults, entityLabels, taskBuckets, agentMessages } from '../../db/schema';
 import { eventBus } from '../../events/bus-adapter';
 import { nanoid } from 'nanoid';
 import {
@@ -371,5 +371,203 @@ export function registerPromptsRoutes(app: Hono, db: Db): void {
       .limit(1)
       .all();
     return result ? c.json(result) : c.json({ decision: 'unchecked' });
+  });
+
+  // GET /prompts/:id/phase1 — Phase-1 dashboard payload (GATE-4-01).
+  //
+  // Returns everything the dashboard's `/prompts/[id]/journey` page needs to
+  // render the full Phase-1 timeline live:
+  //
+  //   - prompt: id/body/correlationId/status/receivedAt
+  //   - pipelineStages: every transition row (ingested → ready_for_pickup),
+  //                     ordered by enteredAt, including epoch-ms timestamps
+  //                     and durationMs back-fills
+  //   - stories: the rows produced by PO + BA, with template validation
+  //              status, bucket linkage and a parsed acceptance-criteria
+  //              count for the timeline summary
+  //   - buckets: every task_bucket row for this prompt (sequential per
+  //              domain + the parallel pool), each with a stories[] list
+  //              of story ids placed into it (so the dashboard's bucket
+  //              viz / journey page knows which bucket landed which ticket)
+  //   - agentMessages: BA cross-agent input requests + replies (filtered
+  //                    by the per-story sub-correlation prefix), sorted by
+  //                    createdAt — surfaces the BA collaboration thread
+  //   - phase1Events: every Phase-1 event correlated to this prompt or to
+  //                   a sub-correlation `${correlationId}::*`, ordered by
+  //                   occurredAt; the WS-driven page uses these to drive
+  //                   stage timestamps and the BA inspector
+  //
+  // The endpoint is read-only and has no side effects. The dashboard polls
+  // it once on load and refetches when a Phase-1 WS event arrives — that
+  // gives the live update without keeping a long-running query open.
+  app.get('/prompts/:id/phase1', (c) => {
+    const promptId = c.req.param('id');
+    const prompt = db.select().from(prompts).where(eq(prompts.id, promptId)).get();
+    if (!prompt) return c.json({ error: 'not found' }, 404);
+
+    const pipelineStages = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, promptId))
+      .orderBy(asc(promptPipelineStages.enteredAt))
+      .all();
+
+    const storyRows = db
+      .select()
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .orderBy(asc(stories.ordinal))
+      .all();
+
+    function safeAcCount(raw: string | null | undefined): number {
+      if (!raw) return 0;
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.length : 0;
+      } catch { return 0; }
+    }
+
+    const storiesNode = storyRows.map((s) => ({
+      id: s.id,
+      title: s.title,
+      kind: s.kind,
+      status: s.status,
+      bucketId: s.bucketId,
+      templateVersion: s.templateVersion,
+      templateValidationStatus: s.templateValidationStatus,
+      acceptanceCriteriaCount: safeAcCount(s.acceptanceCriteriaJson),
+      enrichedAt: s.enrichedAt,
+      updatedAt: s.updatedAt,
+    }));
+
+    const bucketRows = db
+      .select()
+      .from(taskBuckets)
+      .where(eq(taskBuckets.promptId, promptId))
+      .orderBy(asc(taskBuckets.createdAt))
+      .all();
+
+    // Group story ids by bucket for quick rendering.
+    const storiesByBucket = new Map<string, string[]>();
+    for (const s of storyRows) {
+      if (!s.bucketId) continue;
+      const arr = storiesByBucket.get(s.bucketId) ?? [];
+      arr.push(s.id);
+      storiesByBucket.set(s.bucketId, arr);
+    }
+
+    const bucketsNode = bucketRows.map((b) => ({
+      id: b.id,
+      kind: b.kind,
+      domainSlug: b.domainSlug,
+      sequenceIndex: b.sequenceIndex,
+      status: b.status,
+      createdAt: b.createdAt,
+      storyIds: storiesByBucket.get(b.id) ?? [],
+    }));
+
+    // BA collaboration messages — the BA agent uses sub-correlation
+    // ids of shape `${promptCorrelationId}::${storyId}`. We capture rows
+    // whose correlationId equals the prompt's correlation OR starts with
+    // that prefix to surface every per-story exchange. SQLite has no
+    // native LIKE on bound params, so we pull a wider set and filter in
+    // memory — agent_messages is small per-prompt.
+    const allMsgs = db
+      .select()
+      .from(agentMessages)
+      .orderBy(asc(agentMessages.createdAt))
+      .all();
+    const messages = allMsgs.filter((m) =>
+      m.correlationId === prompt.correlationId ||
+      m.correlationId?.startsWith(`${prompt.correlationId}::`),
+    );
+
+    // Phase-1 event types (subset of the canonical taxonomy that drives
+    // dashboard updates). We do NOT introduce new event types here —
+    // these all come from existing emitters per Gate 3.
+    const PHASE1_TYPES = new Set([
+      'prompt.ingested',
+      'prompt.received',
+      'prompt.status_changed',
+      'scaffolder.team.assembled',
+      'po-agent.decomposition.complete',
+      'ba-agent.input-requested',
+      'ba-agent.input-received',
+      'ba-agent.enrichment.complete',
+      'task-scheduler.bucket-placed',
+      'task-scheduler.scheduling.complete',
+      'ticket.draft',
+      'ticket.po-decomposed',
+      'ticket.ba-enriching',
+      'ticket.ba-complete',
+      'ticket.ready-for-pickup',
+      'pipeline.stage.advanced',
+    ]);
+
+    // Pull events under the prompt correlation OR any sub-correlation
+    // (`::storyId`). Same filter as above — load-then-filter is fine for
+    // per-prompt cardinality.
+    const allEvents = db
+      .select()
+      .from(events)
+      .orderBy(asc(events.occurredAt))
+      .all();
+    const phase1Events = allEvents
+      .filter((e) =>
+        PHASE1_TYPES.has(e.type) &&
+        (e.correlationId === prompt.correlationId ||
+         e.correlationId?.startsWith(`${prompt.correlationId}::`)),
+      )
+      .map((e) => {
+        let payload: unknown = null;
+        try { payload = JSON.parse(e.payloadJson); } catch { /* ignore */ }
+        return {
+          id: e.id,
+          type: e.type,
+          actor: e.actor,
+          occurredAt: e.occurredAt,
+          correlationId: e.correlationId,
+          entityType: e.entityType,
+          entityId: e.entityId,
+          payload,
+          severity: e.severity,
+        };
+      });
+
+    return c.json({
+      prompt: {
+        id: prompt.id,
+        body: prompt.body,
+        receivedAt: prompt.receivedAt,
+        correlationId: prompt.correlationId,
+        status: prompt.status,
+      },
+      pipelineStages: pipelineStages.map((s) => ({
+        id: s.id,
+        stage: s.stage,
+        entityKind: s.entityKind,
+        entityId: s.entityId,
+        enteredAt: s.enteredAt,
+        durationMs: s.durationMs,
+        metadata: s.metadata,
+      })),
+      stories: storiesNode,
+      buckets: bucketsNode,
+      agentMessages: messages.map((m) => ({
+        id: m.id,
+        fromAgent: m.fromAgent,
+        toAgent: m.toAgent,
+        messageType: m.messageType,
+        correlationId: m.correlationId,
+        status: m.status,
+        createdAt: m.createdAt,
+        processedAt: m.processedAt,
+        expectedReplyBy: m.expectedReplyBy,
+        repliedAt: m.repliedAt,
+        parentMessageId: m.parentMessageId,
+        payload: (() => { try { return JSON.parse(m.payload); } catch { return m.payload; } })(),
+      })),
+      phase1Events,
+    });
   });
 }

--- a/apps/orchestrator/tests/api/gate4-phase1-route.test.ts
+++ b/apps/orchestrator/tests/api/gate4-phase1-route.test.ts
@@ -1,0 +1,203 @@
+/**
+ * GATE-4-01 — guard the /prompts/:id/phase1 contract.
+ *
+ * The dashboard's `/prompts/[id]/journey` page consumes this endpoint to
+ * render the live Phase-1 timeline: pipeline-stage transitions, stories
+ * (with template/bucket linkage), bucket placement, BA agent-collab
+ * thread, and the Phase-1 event subset filtered to the prompt's
+ * correlation id (and any per-story sub-correlation `${corr}::${storyId}`).
+ *
+ * The endpoint is read-only; this test seeds the data the Phase-1
+ * pipeline would have written and asserts the full envelope shape.
+ */
+import { Hono } from 'hono';
+import { resetDb, getDb, runMigrations, getSqliteRaw } from '../../src/db/connection';
+import { registerPromptsRoutes } from '../../src/api/routes/prompts';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+interface Phase1Response {
+  prompt: { id: string; body: string; correlationId: string; status: string; receivedAt: string };
+  pipelineStages: Array<{ stage: string; enteredAt: number; durationMs: number | null }>;
+  stories: Array<{ id: string; title: string; bucketId: string | null; templateValidationStatus: string; acceptanceCriteriaCount: number }>;
+  buckets: Array<{ id: string; kind: string; domainSlug: string | null; storyIds: string[] }>;
+  agentMessages: Array<{ id: string; fromAgent: string; toAgent: string; messageType: string; correlationId: string }>;
+  phase1Events: Array<{ id: string; type: string; correlationId: string }>;
+}
+
+describe('GATE-4-01 GET /prompts/:id/phase1', () => {
+  let app: Hono;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-gate4-phase1-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+    resetDb();
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+    app = new Hono();
+    registerPromptsRoutes(app, db);
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    delete process.env.CONDUCTOR_DB_PATH;
+  });
+
+  it('returns 404 for an unknown prompt', async () => {
+    const res = await app.request('/prompts/prm_missing/phase1');
+    expect(res.status).toBe(404);
+  });
+
+  it('assembles every Phase-1 surface in one envelope', async () => {
+    const sqlite = getSqliteRaw();
+    const now = new Date().toISOString();
+    const correlationId = 'cor_phase1_test';
+
+    sqlite.prepare(
+      "INSERT INTO prompts (id, body, received_at, received_via, status, correlation_id, hash) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run('prm_p1', 'add user login', now, 'api', 'ready_for_pickup', correlationId, 'h1');
+
+    // Pipeline stages — the full Phase-1 sequence with monotonically
+    // increasing enteredAt so the ordering assertion is meaningful.
+    const stagesSeq = ['ingested', 'scaffolded', 'po_decomposed', 'ba_enriched', 'bucket_placed', 'ready_for_pickup'];
+    let t = Date.now() - 60_000;
+    for (const stage of stagesSeq) {
+      sqlite.prepare(
+        "INSERT INTO prompt_pipeline_stages (id, prompt_id, stage, entity_kind, entity_id, entered_at) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run(`pps_${stage}`, 'prm_p1', stage, 'prompt', 'prm_p1', t);
+      t += 5_000;
+    }
+
+    // Buckets — one parallel + one sequential domain bucket.
+    sqlite.prepare(
+      "INSERT INTO task_buckets (id, kind, domain_slug, prompt_id, created_at, sequence_index, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run('tb_parallel', 'parallel', null, 'prm_p1', Date.now(), null, 'open');
+    sqlite.prepare(
+      "INSERT INTO task_buckets (id, kind, domain_slug, prompt_id, created_at, sequence_index, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run('tb_seq_auth', 'sequential', 'auth', 'prm_p1', Date.now(), 0, 'open');
+
+    // Two stories — one in the parallel pool, one in the sequential auth bucket.
+    sqlite.prepare(
+      "INSERT INTO stories (id, kind, title, description, expected_behavior, acceptance_criteria_json, verification_plan_json, depends_on_json, domain_slugs_json, status, created_at, root_prompt_id, agent_contributions_json, bucket_id, template_version, template_validation_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      'sty_login_form',
+      'story',
+      'login form UI',
+      '',
+      '',
+      '["AC1","AC2","AC3"]',
+      '[]',
+      '[]',
+      '["ui-frontend"]',
+      'pending',
+      now,
+      'prm_p1',
+      '{}',
+      'tb_parallel',
+      'v1',
+      'valid',
+    );
+    sqlite.prepare(
+      "INSERT INTO stories (id, kind, title, description, expected_behavior, acceptance_criteria_json, verification_plan_json, depends_on_json, domain_slugs_json, status, created_at, root_prompt_id, agent_contributions_json, bucket_id, template_version, template_validation_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      'sty_oauth_callback',
+      'story',
+      'oauth callback',
+      '',
+      '',
+      '["AC1","AC2","AC3","AC4"]',
+      '[]',
+      '[]',
+      '["auth"]',
+      'pending',
+      now,
+      'prm_p1',
+      '{}',
+      'tb_seq_auth',
+      'v1',
+      'valid',
+    );
+
+    // BA collaboration messages — under a per-story sub-correlation.
+    const subCorr = `${correlationId}::sty_login_form`;
+    sqlite.prepare(
+      "INSERT INTO agent_messages (id, from_agent, to_agent, message_type, correlation_id, payload, status, created_at, parent_message_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run('am_req_1', 'ba-agent', 'ui-agent', 'input-requested', subCorr, '{"section":"ui"}', 'replied', Date.now() - 10_000, null);
+    sqlite.prepare(
+      "INSERT INTO agent_messages (id, from_agent, to_agent, message_type, correlation_id, payload, status, created_at, parent_message_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run('am_resp_1', 'ui-agent', 'ba-agent', 'input-received', subCorr, '{"ok":true}', 'processed', Date.now() - 5_000, 'am_req_1');
+
+    // Phase-1 events — at the prompt correlation and at a sub-correlation.
+    const ev = (id: string, type: string, corr: string) => sqlite.prepare(
+      "INSERT INTO events (id, type, occurred_at, actor, correlation_id, entity_type, entity_id, payload_json, metadata_json, severity) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(id, type, new Date().toISOString(), 'system', corr, 'prompt', 'prm_p1', '{}', '{}', 'info');
+    ev('e_ingested', 'pipeline.stage.advanced', correlationId);
+    ev('e_po_dec', 'po-agent.decomposition.complete', correlationId);
+    ev('e_ba_in', 'ba-agent.input-requested', subCorr);
+    ev('e_ba_out', 'ba-agent.input-received', subCorr);
+    ev('e_ba_done', 'ba-agent.enrichment.complete', correlationId);
+    ev('e_bucket', 'task-scheduler.bucket-placed', correlationId);
+    ev('e_ready', 'ticket.ready-for-pickup', correlationId);
+    // An unrelated event under a different correlation must NOT appear.
+    ev('e_other', 'task.created', 'cor_unrelated');
+
+    const res = await app.request('/prompts/prm_p1/phase1');
+    expect(res.status).toBe(200);
+    const body = await res.json() as Phase1Response;
+
+    // Prompt header
+    expect(body.prompt.id).toBe('prm_p1');
+    expect(body.prompt.correlationId).toBe(correlationId);
+    expect(body.prompt.status).toBe('ready_for_pickup');
+
+    // Pipeline stages: full sequence in order
+    expect(body.pipelineStages.map((s) => s.stage)).toEqual(stagesSeq);
+
+    // Stories: both present, ac counts honored, bucket linkage present
+    expect(body.stories.length).toBe(2);
+    const formStory = body.stories.find((s) => s.id === 'sty_login_form')!;
+    expect(formStory.bucketId).toBe('tb_parallel');
+    expect(formStory.acceptanceCriteriaCount).toBe(3);
+    expect(formStory.templateValidationStatus).toBe('valid');
+    const oauthStory = body.stories.find((s) => s.id === 'sty_oauth_callback')!;
+    expect(oauthStory.bucketId).toBe('tb_seq_auth');
+    expect(oauthStory.acceptanceCriteriaCount).toBe(4);
+
+    // Buckets: both present with their story ids back-linked
+    expect(body.buckets.length).toBe(2);
+    const parallel = body.buckets.find((b) => b.id === 'tb_parallel')!;
+    expect(parallel.kind).toBe('parallel');
+    expect(parallel.storyIds).toEqual(['sty_login_form']);
+    const seq = body.buckets.find((b) => b.id === 'tb_seq_auth')!;
+    expect(seq.kind).toBe('sequential');
+    expect(seq.domainSlug).toBe('auth');
+    expect(seq.storyIds).toEqual(['sty_oauth_callback']);
+
+    // Agent messages: both BA collab rows surfaced; reply linked
+    expect(body.agentMessages.length).toBe(2);
+    expect(body.agentMessages[0].id).toBe('am_req_1');
+    expect(body.agentMessages[1].id).toBe('am_resp_1');
+
+    // Phase-1 events: only the seven correlated ones (incl. sub-corr),
+    // never the cor_unrelated row.
+    const eventTypes = body.phase1Events.map((e) => e.type);
+    expect(eventTypes).toContain('pipeline.stage.advanced');
+    expect(eventTypes).toContain('po-agent.decomposition.complete');
+    expect(eventTypes).toContain('ba-agent.input-requested');
+    expect(eventTypes).toContain('ba-agent.input-received');
+    expect(eventTypes).toContain('ba-agent.enrichment.complete');
+    expect(eventTypes).toContain('task-scheduler.bucket-placed');
+    expect(eventTypes).toContain('ticket.ready-for-pickup');
+    expect(eventTypes).not.toContain('task.created');
+    // All correlations either match the prompt's or have its prefix.
+    for (const e of body.phase1Events) {
+      expect(
+        e.correlationId === correlationId ||
+        e.correlationId.startsWith(`${correlationId}::`),
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Batch 1 of Gate 4 — make every Phase 1 pipeline event visible on the CAIA dashboard in real time.

## What this PR does

The dashboard's `/prompts/[id]/journey` page now renders a live, end-to-end Phase-1 timeline (`ingested → scaffolded → po_decomposed → ba_enriched → bucket_placed → ready_for_pickup`) with per-stage evidence and refetches on every Phase-1 WS event.

## Changes

**Orchestrator**
- New endpoint `GET /prompts/:id/phase1` that returns the prompt header, every `prompt_pipeline_stages` row, every story with template/bucket linkage and AC count, every `task_buckets` row back-linked to its placed story ids, the BA `agent_messages` thread (filtered by promptCorrelation OR sub-correlation `${corr}::${storyId}`), and every Phase-1 event correlated to the prompt or any sub-correlation. Read-only, no side effects.

**Dashboard**
- API proxy `/api/prompts/[id]/phase1` (no caching).
- New `Phase1Timeline` component — vertical timeline of the canonical 6 stages with evidence summaries plus stories, buckets and BA-collab teaser cards.
- Journey page subscribes to the WS bus via `useWebSocket`. On any Phase-1 event whose correlation_id matches the prompt (or sub-correlation), it calls `refetch()`. Only Phase-1 event prefixes wake it up — unrelated traffic is ignored.

**No new event types** — every event subscribed to already exists per Gate 3 (taxonomy registry.yaml + index.ts).

## Tests

`tests/api/gate4-phase1-route.test.ts` (2 cases): 404 path and full envelope-shape assertion. Seeds prompt + 6 pipeline stages + 2 buckets + 2 stories + 2 agent_messages + 7 events (one under an unrelated correlation that must be filtered out) and verifies every surface is populated correctly with story-by-bucket back-linking and sub-correlation matching.

Existing suites still green:
- `phase1-e2e.test.ts` — Gate 3 verification gate (1/1)
- `ws/envelope-shape.test.ts` — DASH-101 contract (1/1)
- orchestrator + dashboard `tsc --noEmit` clean

## Per the Gate 4 directive

Batch 1 deliverables (event-type subscription + prompt journey visualization) are complete. Bucket visualization, bundle viewer, BA agent-collab inspector, pipeline metrics and the Gate 4 E2E test land in the next 3 batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Phase 1 pipeline visualization showing detailed stage progression with entry times and durations.
  * Introduced real-time updates via websocket for live status tracking.
  * Added live connectivity indicator for monitoring.
  * Enhanced journey display with stories, task buckets, and collaboration metrics.

* **Tests**
  * Added comprehensive integration tests for Phase 1 endpoint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->