### PR TITLE
feat(dashboard,orchestrator): ticket bundle viewer + BA collab inspector (GATE-4-03)

### DIFF
--- a/apps/dashboard/app/api/stories/[id]/bundle/route.ts
+++ b/apps/dashboard/app/api/stories/[id]/bundle/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Dashboard API proxy: GET /api/stories/:id/bundle
+ *
+ * Forwards to the orchestrator's GET /stories/:id/bundle endpoint
+ * (the Phase-1 self-contained ticket bundle introduced in PR #75).
+ * Used by the story-detail page to render the strict TicketTemplateV1
+ * sections (GATE-4-03).
+ */
+import { NextResponse } from 'next/server';
+
+const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    const upstream = await fetch(
+      `${ORCHESTRATOR_URL}/stories/${encodeURIComponent(params.id)}/bundle`,
+      { cache: 'no-store' },
+    );
+    if (!upstream.ok) return NextResponse.json({ error: `Upstream ${upstream.status}` }, { status: upstream.status });
+    const data = await upstream.json() as unknown;
+    return NextResponse.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/buckets/page.tsx
+++ b/apps/dashboard/app/buckets/page.tsx
@@ -195,7 +195,9 @@ function BucketDetailPanel({ id }: { id: string }) {
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
               <span style={{ color: '#a0aec0', fontSize: 11 }}>#{s.ordinal}</span>
-              <span style={{ color: '#e2e8f0', fontWeight: 600 }}>{s.title}</span>
+              <Link href={`/stories/${encodeURIComponent(s.id)}`} style={{ color: '#e2e8f0', fontWeight: 600, textDecoration: 'none' }}>
+                {s.title}
+              </Link>
               <ValidityPill status={s.templateValidationStatus} />
             </div>
             <div style={{ color: '#718096', fontSize: 11 }}>

--- a/apps/dashboard/app/stories/[id]/page.tsx
+++ b/apps/dashboard/app/stories/[id]/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+/**
+ * Story detail page (GATE-4-03).
+ *
+ * Surfaces the self-contained ticket bundle (`GET /stories/:id/bundle`)
+ * via `TicketBundleViewer` and the per-story BA agent-collab thread
+ * (filtered out of the prompt's `/phase1` agentMessages payload by
+ * sub-correlation `${promptCorrelationId}::${storyId}`) via
+ * `BACollabInspector`. Live-refreshes when a Phase-1 event for this
+ * story (or its parent prompt) arrives on the WS bus.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useWebSocket } from '../../../hooks/useWebSocket';
+import { TicketBundleViewer, type TicketBundle } from '../../../components/TicketBundleViewer';
+import { BACollabInspector, type AgentMessage } from '../../../components/BACollabInspector';
+
+const WS_URL = process.env['NEXT_PUBLIC_WS_URL'] ?? 'ws://localhost:7776/events';
+
+const PHASE1_TRIGGERS = [
+  'pipeline.stage.advanced',
+  'po-agent.', 'ba-agent.', 'task-scheduler.', 'ticket.', 'scaffolder.team.assembled',
+  'prompt.ingested', 'prompt.status_changed', 'story.',
+];
+
+function isPhase1EventType(type: string | undefined): boolean {
+  if (!type) return false;
+  return PHASE1_TRIGGERS.some((p) => type === p || type.startsWith(p));
+}
+
+interface PromptPhase1Payload {
+  prompt: { id: string; correlationId: string };
+  agentMessages: AgentMessage[];
+}
+
+export default function StoryDetailPage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const [bundle, setBundle] = useState<TicketBundle | null>(null);
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { lastEvent, connected } = useWebSocket(WS_URL);
+
+  const refetch = useCallback(async () => {
+    setErr(null);
+    try {
+      const res = await fetch(`/api/stories/${id}/bundle`, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`bundle HTTP ${res.status}`);
+      const b = await res.json() as TicketBundle;
+      setBundle(b);
+      // Pull the prompt's phase1 payload to get the BA collab thread
+      // for this story (sub-correlation matching).
+      if (b.prompt?.id) {
+        const r2 = await fetch(`/api/prompts/${b.prompt.id}/phase1`, { cache: 'no-store' });
+        if (r2.ok) {
+          const p = await r2.json() as PromptPhase1Payload;
+          // Filter to messages whose correlationId targets this story.
+          const subCorrSuffix = `::${id}`;
+          const filtered = p.agentMessages.filter((m) =>
+            m.correlationId === p.prompt.correlationId ||
+            m.correlationId.endsWith(subCorrSuffix),
+          );
+          setMessages(filtered);
+        }
+      }
+    } catch (e) {
+      setErr(String((e as Error)?.message ?? e));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { void refetch(); }, [refetch]);
+
+  useEffect(() => {
+    if (!lastEvent) return;
+    if (!isPhase1EventType(lastEvent.type ?? lastEvent.kind)) return;
+    // Only refetch if the event entity is this story or its prompt.
+    const evCorr = (lastEvent as unknown as Record<string, unknown>)['correlationId']
+      ?? (lastEvent.payload as Record<string, unknown> | undefined)?.['correlationId']
+      ?? (lastEvent.payload as Record<string, unknown> | undefined)?.['correlation_id'];
+    const promptCorr = bundle?.prompt?.correlationId;
+    const evEntityId = (lastEvent.payload as Record<string, unknown> | undefined)?.['storyId']
+      ?? (lastEvent.payload as Record<string, unknown> | undefined)?.['story_id']
+      ?? (lastEvent.payload as Record<string, unknown> | undefined)?.['entityId'];
+    const matches =
+      evEntityId === id ||
+      (typeof evCorr === 'string' && promptCorr && (evCorr === promptCorr || evCorr.startsWith(`${promptCorr}::`)));
+    if (matches) void refetch();
+  }, [lastEvent, bundle?.prompt?.correlationId, id, refetch]);
+
+  if (loading) return <div style={{ color: '#718096', padding: 24 }}>Loading bundle…</div>;
+  if (err) return <div style={{ color: '#fc8181', padding: 24 }}>Failed to load: {err}</div>;
+  if (!bundle) return <div style={{ color: '#fc8181', padding: 24 }}>Story not found.</div>;
+
+  return (
+    <div style={{ padding: 20 }}>
+      <div style={{ color: '#6b7280', fontSize: 12, marginBottom: 12 }}>
+        <Link href="/stories" style={{ color: '#6b7280' }}>Stories</Link>
+        {' → '}
+        Story {id.slice(0, 14)}
+        <span style={{ marginLeft: 12, color: connected ? '#68d391' : '#fc8181' }}>
+          {connected ? '● live' : '○ reconnecting…'}
+        </span>
+      </div>
+
+      <TicketBundleViewer bundle={bundle} />
+
+      <div style={{ marginTop: 24 }}>
+        <h3 style={{ margin: '0 0 8px', color: '#e2e8f0', fontSize: 16 }}>BA collaboration</h3>
+        <BACollabInspector
+          messages={messages}
+          emptyHint="No BA agent_messages for this story yet — the BA agent has not started enriching this ticket."
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/BACollabInspector.tsx
+++ b/apps/dashboard/components/BACollabInspector.tsx
@@ -1,0 +1,187 @@
+'use client';
+/**
+ * BA agent-collab inspector (GATE-4-03).
+ *
+ * Renders a request/response thread of `agent_messages` rows from the
+ * BA cross-agent collaboration protocol (PR #72 / PHASE1-02). For each
+ * input-requested → input-received pair the inspector shows:
+ *   - the requesting agent (always the BA agent in Phase 1) and the
+ *     consultant it asked
+ *   - the request payload (section name, deadline)
+ *   - whether the consultant replied (and how long it took) or timed out
+ *   - the reply payload, JSON-pretty-printed and collapsible
+ *
+ * Useful for debugging incomplete tickets — at a glance you can see
+ * which consultant didn't reply or replied with malformed data, and
+ * therefore why the ticket failed to validate.
+ */
+import { useMemo, useState } from 'react';
+
+export interface AgentMessage {
+  id: string;
+  fromAgent: string;
+  toAgent: string;
+  messageType: string;
+  correlationId: string;
+  status: string;
+  createdAt: number;
+  processedAt: number | null;
+  expectedReplyBy: number | null;
+  repliedAt: number | null;
+  parentMessageId: string | null;
+  payload: unknown;
+}
+
+interface ThreadEntry {
+  request: AgentMessage;
+  reply: AgentMessage | null;
+  timedOut: boolean;
+  durationMs: number | null;
+}
+
+function fmtMs(v: number | null | undefined): string {
+  if (v == null) return '—';
+  if (v < 1000) return `${v}ms`;
+  if (v < 60_000) return `${(v / 1000).toFixed(1)}s`;
+  return `${(v / 60_000).toFixed(1)}m`;
+}
+
+function buildThreads(messages: AgentMessage[]): ThreadEntry[] {
+  const requests = messages.filter((m) => m.messageType === 'input-requested');
+  const replyByParent = new Map<string, AgentMessage>();
+  for (const m of messages) {
+    if (m.messageType === 'input-received' && m.parentMessageId) {
+      replyByParent.set(m.parentMessageId, m);
+    }
+  }
+  return requests.map((req) => {
+    const reply = replyByParent.get(req.id) ?? null;
+    const timedOut = !reply && req.status === 'timed_out';
+    const durationMs = reply ? reply.createdAt - req.createdAt : null;
+    return { request: req, reply, timedOut, durationMs };
+  });
+}
+
+function PayloadView({ payload }: { payload: unknown }) {
+  const [expanded, setExpanded] = useState(false);
+  const text = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+  const truncated = text.length > 400;
+  const display = expanded || !truncated ? text : `${text.slice(0, 400)}…`;
+  return (
+    <pre style={{
+      margin: '6px 0 0',
+      padding: 8,
+      background: '#0f1117',
+      border: '1px solid #2d3748',
+      borderRadius: 4,
+      color: '#cbd5e0',
+      fontSize: 11,
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-all',
+    }}>
+      {display}
+      {truncated && (
+        <button
+          onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+          style={{
+            display: 'block', marginTop: 6,
+            background: 'none', border: 'none', color: '#63b3ed',
+            cursor: 'pointer', fontSize: 11, padding: 0,
+          }}
+        >
+          {expanded ? 'collapse' : 'show full'}
+        </button>
+      )}
+    </pre>
+  );
+}
+
+function StatusPill({ entry }: { entry: ThreadEntry }) {
+  if (entry.reply) {
+    return <span style={{ background: '#2f855a', color: '#fff', padding: '2px 6px', borderRadius: 3, fontSize: 10 }}>
+      replied · {fmtMs(entry.durationMs)}
+    </span>;
+  }
+  if (entry.timedOut) {
+    return <span style={{ background: '#c53030', color: '#fff', padding: '2px 6px', borderRadius: 3, fontSize: 10 }}>
+      timed out
+    </span>;
+  }
+  return <span style={{ background: '#dd6b20', color: '#fff', padding: '2px 6px', borderRadius: 3, fontSize: 10 }}>
+    pending
+  </span>;
+}
+
+export function BACollabInspector({
+  messages,
+  emptyHint,
+}: {
+  messages: AgentMessage[];
+  emptyHint?: string;
+}) {
+  const threads = useMemo(() => buildThreads(messages), [messages]);
+
+  if (threads.length === 0) {
+    return (
+      <div data-testid="ba-collab-empty" style={{ color: '#718096', fontSize: 12, fontStyle: 'italic' }}>
+        {emptyHint ?? 'No BA collaboration messages for this scope.'}
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="ba-collab-inspector">
+      <div style={{ color: '#a0aec0', fontSize: 12, marginBottom: 8 }}>
+        {threads.length} request{threads.length === 1 ? '' : 's'}
+        {' · '}
+        {threads.filter((t) => t.reply).length} replied
+        {threads.filter((t) => t.timedOut).length > 0 && (
+          <> · <span style={{ color: '#fc8181' }}>{threads.filter((t) => t.timedOut).length} timed out</span></>
+        )}
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {threads.map((t) => (
+          <li
+            key={t.request.id}
+            data-testid={`ba-collab-thread-${t.request.id}`}
+            data-thread-status={t.reply ? 'replied' : (t.timedOut ? 'timed-out' : 'pending')}
+            style={{
+              background: '#1a1f2e',
+              border: '1px solid #2d3748',
+              borderRadius: 6,
+              padding: '10px 12px',
+              marginBottom: 8,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+              <span style={{ color: '#90cdf4', fontWeight: 600, fontSize: 12 }}>
+                {t.request.fromAgent}
+              </span>
+              <span style={{ color: '#a0aec0', fontSize: 11 }}>→</span>
+              <span style={{ color: '#f6ad55', fontWeight: 600, fontSize: 12 }}>
+                {t.request.toAgent}
+              </span>
+              <StatusPill entry={t} />
+              <span style={{ marginLeft: 'auto', color: '#718096', fontSize: 10, fontFamily: 'monospace' }}>
+                {new Date(t.request.createdAt).toLocaleTimeString()}
+              </span>
+            </div>
+            <div style={{ color: '#a0aec0', fontSize: 11, marginTop: 4 }}>
+              corr <code>{t.request.correlationId}</code>
+            </div>
+            <div style={{ marginTop: 6 }}>
+              <div style={{ fontSize: 11, color: '#a0aec0' }}>request</div>
+              <PayloadView payload={t.request.payload} />
+            </div>
+            {t.reply && (
+              <div style={{ marginTop: 6 }}>
+                <div style={{ fontSize: 11, color: '#a0aec0' }}>reply ({t.reply.fromAgent})</div>
+                <PayloadView payload={t.reply.payload} />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/dashboard/components/Phase1Timeline.tsx
+++ b/apps/dashboard/components/Phase1Timeline.tsx
@@ -214,7 +214,7 @@ export function Phase1Timeline({ data }: { data: Phase1Payload }) {
                 }}
               >
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-                  <Link href={`/stories?id=${encodeURIComponent(s.id)}`} style={{ color: '#90cdf4', textDecoration: 'none', fontWeight: 600 }}>
+                  <Link href={`/stories/${encodeURIComponent(s.id)}`} style={{ color: '#90cdf4', textDecoration: 'none', fontWeight: 600 }}>
                     {s.title}
                   </Link>
                   <span style={{

--- a/apps/dashboard/components/TicketBundleViewer.tsx
+++ b/apps/dashboard/components/TicketBundleViewer.tsx
@@ -1,0 +1,270 @@
+'use client';
+/**
+ * Ticket bundle viewer (GATE-4-03).
+ *
+ * Renders the self-contained payload returned by the orchestrator's
+ * GET /stories/:id/bundle (PR #75 / PHASE1-04). Surfaces every section
+ * of TicketTemplateV1 (scope, context, acceptanceCriteria,
+ * verificationPlan, dependencies, agentSections, baEnrichment) plus
+ * the linked prompt + requirement + bucket + entity-label set + the
+ * upstream/downstream dependency lists.
+ *
+ * If the ticket failed Zod validation, the parseError is surfaced
+ * verbatim so the user can see exactly which BA enrichment field
+ * tripped the validator. The story.templateValidationErrors column
+ * (the BA's own `validateTicket()` output) is also shown for
+ * completeness.
+ */
+import Link from 'next/link';
+
+export interface TicketBundle {
+  story: {
+    id: string;
+    title: string;
+    description: string;
+    status: string;
+    rootPromptId: string | null;
+    parentEntityId: string | null;
+    parentEntityType: string | null;
+    bucketId: string | null;
+    templateVersion: string;
+    templateValidationStatus: string;
+    templateValidationErrors: unknown[] | null;
+    enrichedAt: number | null;
+    updatedAt: number | null;
+  };
+  ticket: TicketTemplateV1Like | null;
+  ticketParseError: string | null;
+  prompt: { id: string; body: string; receivedAt: string; correlationId: string; status: string } | null;
+  requirement: { id: string; title: string; description: string; state: string } | null;
+  bucket: { id: string; kind: 'sequential' | 'parallel'; domainSlug: string | null; sequenceIndex: number | null; status: string } | null;
+  labels: Array<{ labelSlug: string; labelType: string; confidence: number; source: string }>;
+  dependencies: { upstream: string[]; downstream: string[] };
+}
+
+interface AgentSectionLike {
+  contributedBy: string;
+  contributedAt: number;
+  [k: string]: unknown;
+}
+
+export interface TicketTemplateV1Like {
+  scope: { summary: string; inScope: string[]; outOfScope: string[] };
+  context: {
+    rootPromptId: string;
+    requirementId: string;
+    parentEpic?: string;
+    domainPrimary: string;
+    domainAll: string[];
+    nature: string;
+    complexity: string;
+  };
+  acceptanceCriteria: string[];
+  verificationPlan: string[];
+  dependencies: { upstream: string[]; downstream: string[]; files: string[] };
+  agentSections: Record<string, AgentSectionLike | undefined>;
+  baEnrichment?: {
+    enrichedBy: string;
+    enrichedAt: number;
+    inputsRequested?: Array<{ agent: string; correlationId: string; status: string; expectedReplyBy?: number; repliedAt?: number }>;
+  };
+}
+
+function StatusPill({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    valid: '#2f855a',
+    invalid: '#c53030',
+    pending: '#dd6b20',
+  };
+  return <span style={{ background: map[status] ?? '#4a5568', color: '#fff', padding: '2px 8px', borderRadius: 4, fontSize: 11 }}>{status}</span>;
+}
+
+function Section({ title, children, testId }: { title: string; children: React.ReactNode; testId?: string }) {
+  return (
+    <div data-testid={testId} style={{ marginTop: 16 }}>
+      <h4 style={{ margin: '0 0 6px', color: '#e2e8f0', fontSize: 13 }}>{title}</h4>
+      <div style={{ background: '#1a1f2e', border: '1px solid #2d3748', borderRadius: 6, padding: '10px 12px', color: '#cbd5e0', fontSize: 12 }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function StringList({ items, empty }: { items: string[] | undefined; empty?: string }) {
+  if (!items || items.length === 0) return <span style={{ color: '#4a5568', fontStyle: 'italic' }}>{empty ?? '—'}</span>;
+  return (
+    <ul style={{ margin: 0, paddingLeft: 18 }}>
+      {items.map((s, i) => <li key={i}>{s}</li>)}
+    </ul>
+  );
+}
+
+function KV({ k, v }: { k: string; v: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '2px 0' }}>
+      <span style={{ color: '#a0aec0', minWidth: 110, flexShrink: 0 }}>{k}</span>
+      <span style={{ color: '#e2e8f0', flex: 1, wordBreak: 'break-word' }}>{v}</span>
+    </div>
+  );
+}
+
+export function TicketBundleViewer({ bundle }: { bundle: TicketBundle }) {
+  const { story, ticket, ticketParseError, prompt, requirement, bucket, labels, dependencies } = bundle;
+
+  return (
+    <div data-testid="ticket-bundle-viewer">
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, flexWrap: 'wrap', marginBottom: 12 }}>
+        <h2 style={{ margin: 0, color: '#e2e8f0', fontSize: 20 }}>{story.title}</h2>
+        <StatusPill status={story.templateValidationStatus} />
+        <span style={{ color: '#a0aec0', fontSize: 11 }}>template {story.templateVersion}</span>
+        {bucket && (
+          <Link href={`/buckets`} style={{ color: '#90cdf4', fontSize: 12 }}>
+            {bucket.kind === 'sequential' ? `📤 ${bucket.domainSlug ?? 'seq'}#${bucket.sequenceIndex ?? 0}` : '🟦 parallel pool'}
+          </Link>
+        )}
+      </div>
+
+      {/* Linked entities */}
+      <Section title="Linked entities" testId="bundle-linked">
+        <KV k="story" v={<code>{story.id}</code>} />
+        {prompt && (
+          <KV
+            k="prompt"
+            v={<Link href={`/prompts/${prompt.id}/journey`} style={{ color: '#90cdf4' }}>
+              {prompt.id} — {prompt.body.slice(0, 80)}{prompt.body.length > 80 ? '…' : ''}
+            </Link>}
+          />
+        )}
+        {requirement && (
+          <KV
+            k="requirement"
+            v={<Link href={`/requirements/${requirement.id}`} style={{ color: '#90cdf4' }}>
+              {requirement.title}
+            </Link>}
+          />
+        )}
+        {bucket && <KV k="bucket" v={<code>{bucket.id}</code>} />}
+        <KV k="status" v={story.status} />
+      </Section>
+
+      {/* Validation status */}
+      {(ticketParseError || (story.templateValidationErrors && story.templateValidationErrors.length > 0)) && (
+        <Section title="Validation issues" testId="bundle-validation-errors">
+          {ticketParseError && (
+            <div style={{ color: '#fc8181', fontSize: 12, marginBottom: 6 }}>
+              <strong>Parse error:</strong> {ticketParseError}
+            </div>
+          )}
+          {story.templateValidationErrors && story.templateValidationErrors.length > 0 && (
+            <pre style={{ margin: 0, color: '#fc8181', fontSize: 11, whiteSpace: 'pre-wrap' }}>
+              {JSON.stringify(story.templateValidationErrors, null, 2)}
+            </pre>
+          )}
+        </Section>
+      )}
+
+      {/* If we have a parsed ticket, render every TicketTemplateV1 section */}
+      {ticket && (
+        <>
+          <Section title="Scope" testId="bundle-scope">
+            <KV k="summary" v={ticket.scope.summary} />
+            <KV k="inScope" v={<StringList items={ticket.scope.inScope} />} />
+            <KV k="outOfScope" v={<StringList items={ticket.scope.outOfScope} />} />
+          </Section>
+
+          <Section title="Context" testId="bundle-context">
+            <KV k="rootPromptId" v={<code>{ticket.context.rootPromptId}</code>} />
+            <KV k="requirementId" v={<code>{ticket.context.requirementId}</code>} />
+            {ticket.context.parentEpic && <KV k="parentEpic" v={<code>{ticket.context.parentEpic}</code>} />}
+            <KV k="domainPrimary" v={ticket.context.domainPrimary} />
+            <KV k="domainAll" v={(ticket.context.domainAll ?? []).join(', ')} />
+            <KV k="nature" v={ticket.context.nature} />
+            <KV k="complexity" v={ticket.context.complexity} />
+          </Section>
+
+          <Section title={`Acceptance criteria (${ticket.acceptanceCriteria.length})`} testId="bundle-ac">
+            <StringList items={ticket.acceptanceCriteria} />
+          </Section>
+
+          <Section title="Verification plan" testId="bundle-verification">
+            <StringList items={ticket.verificationPlan} />
+          </Section>
+
+          <Section title="Ticket dependencies" testId="bundle-dependencies">
+            <KV k="upstream" v={<StringList items={ticket.dependencies.upstream} empty="none" />} />
+            <KV k="downstream" v={<StringList items={ticket.dependencies.downstream} empty="none" />} />
+            <KV k="files" v={<StringList items={ticket.dependencies.files} empty="none" />} />
+          </Section>
+
+          {/* Agent contribution sections — show only the populated ones */}
+          {Object.entries(ticket.agentSections ?? {}).map(([key, sec]) => sec ? (
+            <Section key={key} title={`Agent section · ${key}`} testId={`bundle-agent-${key}`}>
+              <KV k="contributedBy" v={sec.contributedBy} />
+              <KV k="contributedAt" v={sec.contributedAt ? new Date(sec.contributedAt).toLocaleString() : '—'} />
+              {Object.entries(sec)
+                .filter(([k]) => k !== 'contributedBy' && k !== 'contributedAt')
+                .map(([k, v]) => (
+                  <KV
+                    key={k}
+                    k={k}
+                    v={Array.isArray(v) ? <StringList items={v as string[]} empty="—" />
+                      : typeof v === 'object' ? <code>{JSON.stringify(v)}</code>
+                      : String(v ?? '—')}
+                  />
+                ))}
+            </Section>
+          ) : null)}
+
+          {ticket.baEnrichment && (
+            <Section title="BA enrichment" testId="bundle-ba-enrichment">
+              <KV k="enrichedBy" v={ticket.baEnrichment.enrichedBy} />
+              <KV k="enrichedAt" v={new Date(ticket.baEnrichment.enrichedAt).toLocaleString()} />
+              <KV
+                k="inputsRequested"
+                v={(ticket.baEnrichment.inputsRequested ?? []).length === 0
+                  ? '—'
+                  : <ul style={{ margin: 0, paddingLeft: 18 }}>
+                      {(ticket.baEnrichment.inputsRequested ?? []).map((req, i) => (
+                        <li key={i}>
+                          {req.agent} → <code>{req.status}</code>
+                          {req.repliedAt && ` (${new Date(req.repliedAt).toLocaleTimeString()})`}
+                        </li>
+                      ))}
+                    </ul>}
+              />
+            </Section>
+          )}
+        </>
+      )}
+
+      {/* Bundle-level dependency mirrors (independent of parsed ticket) */}
+      <Section title="Bundle dependencies" testId="bundle-bundle-deps">
+        <KV k="upstream stories" v={<StringList items={dependencies.upstream} empty="none" />} />
+        <KV k="downstream stories" v={<StringList items={dependencies.downstream} empty="none" />} />
+      </Section>
+
+      {/* Labels */}
+      <Section title="Entity labels" testId="bundle-labels">
+        {labels.length === 0 ? (
+          <span style={{ color: '#4a5568', fontStyle: 'italic' }}>none</span>
+        ) : (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {labels.map((l, i) => (
+              <span
+                key={`${l.labelSlug}-${i}`}
+                style={{
+                  background: '#2d3748', color: '#e2e8f0',
+                  padding: '2px 8px', borderRadius: 12, fontSize: 11,
+                }}
+                title={`${l.labelType} (${(l.confidence * 100).toFixed(0)}% from ${l.source})`}
+              >
+                {l.labelType}: {l.labelSlug}
+              </span>
+            ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/apps/orchestrator/tests/api/gate4-bundle-route.test.ts
+++ b/apps/orchestrator/tests/api/gate4-bundle-route.test.ts
@@ -1,0 +1,94 @@
+/**
+ * GATE-4-03 — guard the GET /stories/:id/bundle route exposure.
+ *
+ * The dashboard's story-detail page (TicketBundleViewer) consumes this
+ * route via the `/api/stories/:id/bundle` proxy. The bundle assembler
+ * itself is covered by `tests/api/ticket-bundle.test.ts`; this test
+ * pins the route — Hono handler + 404 + JSON envelope — so the
+ * dashboard's contract is enforceable from CI.
+ */
+import { Hono } from 'hono';
+import { resetDb, getDb, runMigrations, getSqliteRaw } from '../../src/db/connection';
+import { registerStoriesRoutes } from '../../src/api/routes/stories';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+interface BundleBody {
+  story: { id: string; title: string; templateValidationStatus: string };
+  ticket: unknown;
+  ticketParseError: string | null;
+  prompt: { id: string; body: string } | null;
+  bucket: { id: string; kind: string } | null;
+  labels: Array<{ labelSlug: string; labelType: string }>;
+  dependencies: { upstream: string[]; downstream: string[] };
+}
+
+describe('GATE-4-03 GET /stories/:id/bundle', () => {
+  let app: Hono;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `caia-gate4-bundle-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+    resetDb();
+    runMigrations(dbPath);
+    const db = getDb(dbPath);
+    app = new Hono();
+    registerStoriesRoutes(app, db);
+
+    const sqlite = getSqliteRaw();
+    const now = new Date().toISOString();
+
+    sqlite.prepare(
+      "INSERT INTO prompts (id, body, received_at, received_via, status, correlation_id, hash) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run('prm_bundle_route', 'add login', now, 'api', 'ready_for_pickup', 'cor_bundle_route', 'h');
+
+    sqlite.prepare(
+      "INSERT INTO task_buckets (id, kind, domain_slug, prompt_id, created_at, sequence_index, status) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run('bkt_seq_auth', 'sequential', 'auth', 'prm_bundle_route', Date.now(), 0, 'open');
+
+    // Empty agentContributionsJson `{}` — bundle returns ticket=null without parse error.
+    sqlite.prepare(
+      "INSERT INTO stories (id, kind, title, ordinal, description, expected_behavior, acceptance_criteria_json, verification_plan_json, depends_on_json, domain_slugs_json, status, created_at, root_prompt_id, agent_contributions_json, bucket_id, template_version, template_validation_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run('sty_bundled', 'story', 'login form ticket', 0, '', '', '[]', '[]', '[]', '["ui-frontend"]', 'pending', now, 'prm_bundle_route', '{}', 'bkt_seq_auth', 'v1', 'pending');
+
+    // Entity labels — surfaced on the bundle.
+    sqlite.prepare(
+      "INSERT INTO entity_labels (id, entity_kind, entity_id, label_slug, label_type, confidence, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run('el_1', 'story', 'sty_bundled', 'auth', 'domain', 0.9, 'classifier', Date.now());
+    sqlite.prepare(
+      "INSERT INTO entity_labels (id, entity_kind, entity_id, label_slug, label_type, confidence, source, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run('el_2', 'story', 'sty_bundled', 'feature', 'nature', 0.8, 'classifier', Date.now());
+  });
+
+  afterEach(() => {
+    resetDb();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    delete process.env.CONDUCTOR_DB_PATH;
+  });
+
+  it('returns 404 for an unknown story', async () => {
+    const res = await app.request('/stories/sty_does_not_exist/bundle');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the self-contained bundle envelope', async () => {
+    const res = await app.request('/stories/sty_bundled/bundle');
+    expect(res.status).toBe(200);
+    const body = await res.json() as BundleBody;
+    expect(body.story.id).toBe('sty_bundled');
+    expect(body.story.title).toBe('login form ticket');
+    expect(body.story.templateValidationStatus).toBe('pending');
+    expect(body.prompt?.id).toBe('prm_bundle_route');
+    expect(body.bucket?.id).toBe('bkt_seq_auth');
+    expect(body.bucket?.kind).toBe('sequential');
+    // Empty `{}` agentContributionsJson — assembler treats as a stub.
+    expect(body.ticket).toBeNull();
+    expect(body.ticketParseError).toBeNull();
+    // Labels (2) and dependency-mirror lists (empty here)
+    expect(body.labels.length).toBe(2);
+    expect(body.dependencies.upstream).toEqual([]);
+    expect(body.dependencies.downstream).toEqual([]);
+  });
+});


### PR DESCRIPTION
Batch 3 of Gate 4 — surface the self-contained Phase-1 ticket bundle and the per-story BA agent-collab thread on a new story-detail page.

## What this PR does

New \`/stories/[id]\` route that fetches \`/api/stories/:id/bundle\` and renders:

1. **TicketBundleViewer** — every TicketTemplateV1 section: scope, context, acceptanceCriteria, verificationPlan, dependencies, agentSections (per agent), baEnrichment. Also: linked prompt + requirement + bucket, entity_label set, upstream/downstream dependency mirrors. When BA enrichment fails Zod validation, both the parseError and templateValidationErrors are surfaced so users see exactly which field tripped the validator.
2. **BACollabInspector** — per-story request/response thread filtered out of the prompt-level agent_messages payload by sub-correlation `${promptCorrelationId}::${storyId}`. Each row shows from→to, payload (collapsible), status (replied / timed-out / pending) and round-trip duration. Useful for debugging incomplete tickets.

## Changes

**Dashboard**
- \`/stories/[id]/page.tsx\` (new) — story-detail page with both viewers.
- \`/api/stories/[id]/bundle/route.ts\` (new) — proxy to orchestrator.
- \`components/TicketBundleViewer.tsx\` (new) — section-by-section bundle renderer.
- \`components/BACollabInspector.tsx\` (new) — request/response thread renderer (reusable).
- Existing surfaces now link to story-detail:
  - \`Phase1Timeline\` story chips → \`/stories/[id]\`
  - \`/buckets\` detail-rail story rows → \`/stories/[id]\`

**No new orchestrator endpoints** — this batch only adds tests against existing routes (`GET /stories/:id/bundle` from PR #75). The dashboard now has a complete view of what the executor would receive.

## Tests

\`tests/api/gate4-bundle-route.test.ts\` (2 cases): 404 path and the full bundle envelope (story, prompt, bucket, labels, dependencies) for a stub story.

Existing suites still green (27/27 — Gate 4 plus Gate 3 sweep):
- \`gate4-phase1-route\`, \`gate4-buckets-routes\`, \`gate4-bundle-route\`
- \`phase1-e2e\` (Gate 3 verification gate)
- \`ws/envelope-shape\` (DASH-101 contract)
- \`agents/bucket-placer\`
- \`api/ticket-bundle\`
- orchestrator + dashboard \`tsc --noEmit\` clean