### PR TITLE
feat(ticket-template,orchestrator): 9-axis taxonomy + claims schema (BUCKET-001)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0023_story_taxonomy.sql
+++ b/apps/orchestrator/src/db/migrations/0023_story_taxonomy.sql
@@ -1,0 +1,55 @@
+-- Migration 0023: BUCKET-001 — Story-level 9-axis taxonomy + resource claims.
+--
+-- Adds the new taxonomy columns mandated by the PO Taxonomy directive
+-- (2026-04-28). All columns nullable on this migration so existing stories
+-- continue to load; BUCKET-007 backfill populates them and migration 0025
+-- flips them to NOT NULL. See ~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md.
+--
+-- Mirrors the Zod taxonomy block in @chiefaia/ticket-template:
+--   business_sub_domains_json   → string[]  (per-project enum)
+--   tech_sub_domains_json       → string[]  (subset of TECH_SUB_DOMAINS)
+--   tech_sub_domain_primary     → enum      (one of TECH_SUB_DOMAINS) — bucket key
+--   lifecycle                   → enum      (LIFECYCLE_VALUES)
+--   quality_tags_json           → string[]  (subset of QUALITY_TAGS)
+--   risk                        → enum      (RISK_VALUES)
+--   effort                      → enum      (EFFORT_VALUES)
+--   priority_bucket             → enum      (PRIORITY_VALUES)
+--   blocked_by_json             → string[]  (story IDs, hard ordering)
+--   soft_depends_on_json        → string[]  (story IDs, soft preference)
+--   conflicts_with_json         → string[]  (story IDs, mutual exclusion)
+--   claims_json                 → object    (BUCKET-009: files/schemas/apiRoutes/domains)
+
+ALTER TABLE `stories` ADD COLUMN `business_sub_domains_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `tech_sub_domains_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `tech_sub_domain_primary` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `lifecycle` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `quality_tags_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `risk` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `effort` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `priority_bucket` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `blocked_by_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `soft_depends_on_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `conflicts_with_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `claims_json` text NOT NULL DEFAULT '{}';
+--> statement-breakpoint
+
+-- Indexes — bucket-placer reads (project_slug, tech_sub_domain_primary)
+-- as the bucket key on every placement; we want it covered.
+CREATE INDEX IF NOT EXISTS `story_project_tech_idx` ON `stories` (`project_slug`, `tech_sub_domain_primary`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_lifecycle_idx` ON `stories` (`lifecycle`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_risk_idx` ON `stories` (`risk`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_priority_bucket_idx` ON `stories` (`priority_bucket`);

--- a/apps/orchestrator/src/db/migrations/0024_task_buckets_extend.sql
+++ b/apps/orchestrator/src/db/migrations/0024_task_buckets_extend.sql
@@ -1,0 +1,23 @@
+-- Migration 0024: BUCKET-001 — task_buckets gets project_slug + tech_sub_domain.
+--
+-- The bucket-placer's group key changes from (prompt_id, domain_slug) to
+-- (prompt_id, project_slug, tech_sub_domain). Adding the columns here so
+-- BUCKET-004 can switch the placement logic without a downstream migration.
+--
+-- domain_slug stays for backwards compatibility (existing rows continue to
+-- read it); BUCKET-004 starts writing project_slug + tech_sub_domain on new
+-- rows; a follow-up migration in BUCKET-007 cleans up legacy rows.
+
+ALTER TABLE `task_buckets` ADD COLUMN `project_slug` text;
+--> statement-breakpoint
+ALTER TABLE `task_buckets` ADD COLUMN `tech_sub_domain` text;
+--> statement-breakpoint
+-- BUCKET-008: chain-fragmentation analyzer persists per-WCC level batches
+-- here so the dashboard can render Kanban level-coloring without recomputing.
+ALTER TABLE `task_buckets` ADD COLUMN `levels_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+
+-- New composite index — placer queries by (prompt_id, project_slug, tech_sub_domain).
+CREATE INDEX IF NOT EXISTS `idx_tb_prompt_project_tech` ON `task_buckets` (`prompt_id`, `project_slug`, `tech_sub_domain`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_tb_project_tech` ON `task_buckets` (`project_slug`, `tech_sub_domain`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -155,6 +155,20 @@
       "when": 1777600000000,
       "tag": "0022_agent_messages_request_response",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1777700000000,
+      "tag": "0023_story_taxonomy",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1777700000001,
+      "tag": "0024_task_buckets_extend",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -404,6 +404,20 @@ export const stories = sqliteTable('stories', {
   templateVersion: text('template_version').notNull().default('v1'),
   templateValidationStatus: text('template_validation_status').notNull().default('pending'), // 'pending'|'valid'|'invalid'
   templateValidationErrors: text('template_validation_errors'),
+  // BUCKET-001 — 9-axis taxonomy (migration 0023). Nullable on this
+  // migration; required after BUCKET-007 backfill (migration 0025).
+  businessSubDomainsJson: text('business_sub_domains_json').notNull().default('[]'),
+  techSubDomainsJson: text('tech_sub_domains_json').notNull().default('[]'),
+  techSubDomainPrimary: text('tech_sub_domain_primary'),  // TECH_SUB_DOMAINS
+  lifecycle: text('lifecycle'),                            // LIFECYCLE_VALUES
+  qualityTagsJson: text('quality_tags_json').notNull().default('[]'),
+  risk: text('risk'),                                      // RISK_VALUES
+  effort: text('effort'),                                  // EFFORT_VALUES
+  priorityBucket: text('priority_bucket'),                 // PRIORITY_VALUES
+  blockedByJson: text('blocked_by_json').notNull().default('[]'),
+  softDependsOnJson: text('soft_depends_on_json').notNull().default('[]'),
+  conflictsWithJson: text('conflicts_with_json').notNull().default('[]'),
+  claimsJson: text('claims_json').notNull().default('{}'),
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -412,6 +426,11 @@ export const stories = sqliteTable('stories', {
   index('story_parent_entity_idx').on(t.parentEntityId),
   index('story_bucket_idx').on(t.bucketId),
   index('story_template_status_idx').on(t.templateValidationStatus),
+  // BUCKET-001 indexes (migration 0023)
+  index('story_project_tech_idx').on(t.projectSlug, t.techSubDomainPrimary),
+  index('story_lifecycle_idx').on(t.lifecycle),
+  index('story_risk_idx').on(t.risk),
+  index('story_priority_bucket_idx').on(t.priorityBucket),
 ]);
 
 // story_revisions — append-only history of every story-tree edit
@@ -872,20 +891,32 @@ export const dedupResults = sqliteTable('dedup_results', {
   index('idx_dr_decision').on(t.decision),
 ]);
 
-// task_buckets — Phase-1 scheduling buckets (migration 0021)
-// Sequential buckets are partitioned by domain_slug per prompt; one parallel
-// bucket per prompt holds tickets that have no cross-domain upstream deps.
+// task_buckets — Phase-1 scheduling buckets (migration 0021 + 0024)
+// Sequential buckets are partitioned by (project_slug, tech_sub_domain) per
+// prompt (BUCKET-001/0024); one parallel bucket per prompt holds tickets
+// that have no cross-bucket upstream deps. domain_slug is retained for
+// backwards compatibility with pre-BUCKET-001 rows.
 export const taskBuckets = sqliteTable('task_buckets', {
   id: text('id').primaryKey().notNull(),
   kind: text('kind').notNull(),                 // 'sequential' | 'parallel'
-  domainSlug: text('domain_slug'),              // non-null for sequential, null for parallel
+  domainSlug: text('domain_slug'),              // legacy — pre-BUCKET-001 rows
+  /** BUCKET-001 (migration 0024): bucket-placement key dimension 1. */
+  projectSlug: text('project_slug'),
+  /** BUCKET-001 (migration 0024): bucket-placement key dimension 2. */
+  techSubDomain: text('tech_sub_domain'),
   promptId: text('prompt_id').notNull().references(() => prompts.id),
   createdAt: integer('created_at').notNull(),   // epoch ms
   sequenceIndex: integer('sequence_index'),     // 0,1,2... for sequential, null for parallel
   status: text('status').notNull().default('open'), // 'open'|'in_progress'|'drained'
   metadata: text('metadata'),                   // JSON: bucket_label, predicted_concurrency, etc.
+  /** BUCKET-008 (migration 0024): per-WCC level batches; persisted so the
+   *  dashboard can render Kanban level-coloring without recomputing. */
+  levelsJson: text('levels_json').notNull().default('[]'),
 }, (t) => [
   index('idx_tb_prompt').on(t.promptId),
   index('idx_tb_kind_domain').on(t.kind, t.domainSlug),
   index('idx_tb_status').on(t.status),
+  // BUCKET-001 indexes (migration 0024)
+  index('idx_tb_prompt_project_tech').on(t.promptId, t.projectSlug, t.techSubDomain),
+  index('idx_tb_project_tech').on(t.projectSlug, t.techSubDomain),
 ]);

--- a/packages/ticket-template/src/build.ts
+++ b/packages/ticket-template/src/build.ts
@@ -9,6 +9,13 @@ import {
   TicketTemplateV1,
   COMPLEXITY_VALUES,
   NATURE_VALUES,
+  PROJECT_SLUGS,
+  LIFECYCLE_VALUES,
+  RISK_VALUES,
+  EFFORT_VALUES,
+  PRIORITY_VALUES,
+  QUALITY_TAGS,
+  TECH_SUB_DOMAINS,
 } from './schema';
 
 export interface DraftTicketInput {
@@ -28,6 +35,30 @@ export interface DraftTicketInput {
   downstream?: string[];
   files?: string[];
   poDecomposedAt?: number;
+  /** BUCKET-001 — optional taxonomy populated by PO + EA. */
+  taxonomy?: {
+    project?: (typeof PROJECT_SLUGS)[number];
+    businessSubDomains?: string[];
+    techSubDomains?: {
+      primary: (typeof TECH_SUB_DOMAINS)[number];
+      all: ReadonlyArray<(typeof TECH_SUB_DOMAINS)[number]>;
+    };
+    lifecycle?: (typeof LIFECYCLE_VALUES)[number];
+    qualityTags?: ReadonlyArray<(typeof QUALITY_TAGS)[number]>;
+    risk?: (typeof RISK_VALUES)[number];
+    effort?: (typeof EFFORT_VALUES)[number];
+    priorityBucket?: (typeof PRIORITY_VALUES)[number];
+    blockedBy?: string[];
+    softDependsOn?: string[];
+    conflictsWith?: string[];
+  };
+  /** BUCKET-001 / BUCKET-009 — optional resource claims populated by EA. */
+  claims?: {
+    files?: string[];
+    schemas?: string[];
+    apiRoutes?: string[];
+    domains?: string[];
+  };
 }
 
 /**
@@ -37,7 +68,7 @@ export interface DraftTicketInput {
  */
 export function buildDraftTicket(input: DraftTicketInput): TicketTemplateV1 {
   const now = Date.now();
-  return {
+  const draft: TicketTemplateV1 = {
     version: TICKET_TEMPLATE_VERSION,
     scope: {
       summary: input.summary,
@@ -67,4 +98,38 @@ export function buildDraftTicket(input: DraftTicketInput): TicketTemplateV1 {
       lastUpdatedAt: now,
     },
   };
+
+  if (input.taxonomy) {
+    draft.taxonomy = {
+      project: input.taxonomy.project,
+      businessSubDomains: input.taxonomy.businessSubDomains ?? [],
+      techSubDomains: input.taxonomy.techSubDomains
+        ? {
+            primary: input.taxonomy.techSubDomains.primary,
+            all: [...input.taxonomy.techSubDomains.all],
+          }
+        : undefined,
+      lifecycle: input.taxonomy.lifecycle,
+      qualityTags: input.taxonomy.qualityTags
+        ? [...input.taxonomy.qualityTags]
+        : [],
+      risk: input.taxonomy.risk,
+      effort: input.taxonomy.effort,
+      priorityBucket: input.taxonomy.priorityBucket,
+      blockedBy: input.taxonomy.blockedBy ?? [],
+      softDependsOn: input.taxonomy.softDependsOn ?? [],
+      conflictsWith: input.taxonomy.conflictsWith ?? [],
+    };
+  }
+
+  if (input.claims) {
+    draft.claims = {
+      files: input.claims.files ?? [],
+      schemas: input.claims.schemas ?? [],
+      apiRoutes: input.claims.apiRoutes ?? [],
+      domains: input.claims.domains ?? [],
+    };
+  }
+
+  return draft;
 }

--- a/packages/ticket-template/src/index.ts
+++ b/packages/ticket-template/src/index.ts
@@ -14,8 +14,26 @@ export {
   NATURE_VALUES,
   COMPLEXITY_VALUES,
   AGENT_SECTION_KEYS,
+  // BUCKET-001 taxonomy enums + types
+  PROJECT_SLUGS,
+  LIFECYCLE_VALUES,
+  RISK_VALUES,
+  EFFORT_VALUES,
+  PRIORITY_VALUES,
+  QUALITY_TAGS,
+  TECH_SUB_DOMAINS,
 } from './schema';
-export type { TicketTemplateV1, AgentSectionKey } from './schema';
+export type {
+  TicketTemplateV1,
+  AgentSectionKey,
+  ProjectSlug,
+  LifecycleValue,
+  RiskValue,
+  EffortValue,
+  PriorityValue,
+  QualityTag,
+  TechSubDomain,
+} from './schema';
 
 export {
   validateTicket,

--- a/packages/ticket-template/src/schema.ts
+++ b/packages/ticket-template/src/schema.ts
@@ -38,6 +38,125 @@ export const NATURE_VALUES = [
 /** Allowed values for the `complexity` field. */
 export const COMPLEXITY_VALUES = ['low', 'medium', 'high', 'spike'] as const;
 
+// ─── BUCKET-001 taxonomy enums ───────────────────────────────────────────────
+//
+// First-class taxonomy fields populated by PO + EA before BA hands a ticket
+// off to the Task Manager. All optional on v1 so existing tickets continue
+// to validate; they become required at v2 once BUCKET-007 backfill ships.
+
+/**
+ * Canonical project slugs. New projects: add here + new migration row.
+ * `unassigned` is the fallback only — must be replaced before BA finishes.
+ */
+export const PROJECT_SLUGS = [
+  'caia',
+  'pokerzeno',
+  'roulettecommunity',
+  'edisoncricket',
+  'ankitatiwari',
+  'prakash-tiwari',
+  'chiefaia.com',
+  'framework',
+  'site-template',
+  'image-provider',
+  'cast-bridge',
+  'dev-inspector',
+  'backend-core',
+  'content-engine',
+  'integrity-check',
+  'seo-program',
+  'analytics',
+  'unassigned',
+] as const;
+
+/** Lifecycle classification. Mirrors conventional-commits with hotfix + spike. */
+export const LIFECYCLE_VALUES = [
+  'new',
+  'enhance',
+  'bug',
+  'refactor',
+  'chore',
+  'docs',
+  'hotfix',
+  'spike',
+] as const;
+
+/** Risk classification — drives review approach. */
+export const RISK_VALUES = ['low', 'medium', 'high', 'critical'] as const;
+
+/** Effort estimate. `XL` is a guard rail — EA must split before BA finishes. */
+export const EFFORT_VALUES = ['XS', 'S', 'M', 'L', 'XL'] as const;
+
+/** Priority bucket — mirrors orchestrator priority engine. */
+export const PRIORITY_VALUES = ['P0', 'P1', 'P2', 'P3'] as const;
+
+/** Quality tags — drive automatic policy gates (auto-AC injection, etc.). */
+export const QUALITY_TAGS = [
+  'seo',
+  'accessibility',
+  'performance',
+  'security',
+  'compliance',
+  'observability',
+  'internationalization',
+] as const;
+
+/**
+ * Technology sub-domains — what layer/capability the code touches.
+ * Multi-value; one is designated `primary` and used as the bucket-placement
+ * key by the Task Manager.
+ */
+export const TECH_SUB_DOMAINS = [
+  'frontend',
+  'bff',
+  'backend',
+  'database',
+  'event-driven',
+  'observability',
+  'web-analytics',
+  'crm',
+  'cms',
+  'search',
+  'auth',
+  'payments',
+  'email',
+  'caching',
+  'infra',
+  'ci-cd',
+  'ml-ai',
+  'testing',
+  'accessibility',
+  'seo',
+  'security',
+  'localization-i18n',
+  'design-system',
+  'documentation',
+  'api-gateway',
+  'websockets',
+  'file-storage',
+  'rate-limiting',
+  'feature-flags',
+  'monitoring-alerting',
+  'secrets-management',
+  'dependency-management',
+  'data-pipeline',
+  'cron-scheduling',
+  'agent-runtime',
+  'prompt-engineering',
+  'ticket-template',
+  'data-migration',
+  'compliance',
+  'performance',
+] as const;
+
+export type ProjectSlug = (typeof PROJECT_SLUGS)[number];
+export type LifecycleValue = (typeof LIFECYCLE_VALUES)[number];
+export type RiskValue = (typeof RISK_VALUES)[number];
+export type EffortValue = (typeof EFFORT_VALUES)[number];
+export type PriorityValue = (typeof PRIORITY_VALUES)[number];
+export type QualityTag = (typeof QUALITY_TAGS)[number];
+export type TechSubDomain = (typeof TECH_SUB_DOMAINS)[number];
+
 // ─── Required core sections ──────────────────────────────────────────────────
 
 const Scope = z
@@ -181,6 +300,62 @@ const AgentSections = z
   .strict()
   .default({});
 
+// ─── BUCKET-001 / BUCKET-009 — Taxonomy + Claims blocks ─────────────────────
+
+/**
+ * Taxonomy block — populated by PO Agent (project, businessSubDomains,
+ * lifecycle, priority) and extended by EA Agent (techSubDomains + primary,
+ * qualityTags, risk, effort, blockedBy/conflictsWith/softDependsOn markers).
+ *
+ * On v1 the whole block is optional so existing tickets still validate.
+ */
+const TechSubDomains = z
+  .object({
+    primary: z.enum(TECH_SUB_DOMAINS),
+    all: z.array(z.enum(TECH_SUB_DOMAINS)).min(1),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    if (!val.all.includes(val.primary)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'techSubDomains.primary must appear in techSubDomains.all',
+        path: ['primary'],
+      });
+    }
+  });
+
+const Taxonomy = z
+  .object({
+    project: z.enum(PROJECT_SLUGS).optional(),
+    businessSubDomains: z.array(z.string().min(1)).default([]),
+    techSubDomains: TechSubDomains.optional(),
+    lifecycle: z.enum(LIFECYCLE_VALUES).optional(),
+    qualityTags: z.array(z.enum(QUALITY_TAGS)).default([]),
+    risk: z.enum(RISK_VALUES).optional(),
+    effort: z.enum(EFFORT_VALUES).optional(),
+    priorityBucket: z.enum(PRIORITY_VALUES).optional(),
+    blockedBy: z.array(z.string()).default([]),
+    softDependsOn: z.array(z.string()).default([]),
+    conflictsWith: z.array(z.string()).default([]),
+  })
+  .strict();
+
+/**
+ * Resource-claim block — populated by EA Agent. Files / schemas / apiRoutes
+ * are fine-grained; `domains` is the coarse fallback (= a coarsened union of
+ * techSubDomains.all). The scheduler enforces no two in-flight stories
+ * intersect on any of files/schemas/apiRoutes — see BUCKET-009.
+ */
+const Claims = z
+  .object({
+    files: z.array(z.string()).default([]),
+    schemas: z.array(z.string()).default([]),
+    apiRoutes: z.array(z.string()).default([]),
+    domains: z.array(z.string()).default([]),
+  })
+  .strict();
+
 // ─── BA enrichment metadata ──────────────────────────────────────────────────
 
 const InputRequest = z
@@ -222,11 +397,79 @@ export const TicketTemplateV1Schema = z
     acceptanceCriteria: AcceptanceCriteria,
     verificationPlan: VerificationPlan,
     dependencies: Dependencies,
+    /** BUCKET-001: 9-axis classification populated by PO + EA. */
+    taxonomy: Taxonomy.optional(),
+    /** BUCKET-009: scheduler resource claims populated by EA. */
+    claims: Claims.optional(),
     agentSections: AgentSections,
     baEnrichment: BaEnrichment.optional(),
     metadata: Metadata,
   })
-  .strict();
+  .strict()
+  .superRefine((ticket, ctx) => {
+    // §4.2 mutual exclusions — only enforced when both fields are present,
+    // so legacy tickets without the taxonomy block still validate.
+    const tx = ticket.taxonomy;
+    if (!tx) return;
+
+    // docs lifecycle ⇒ techSubDomains.all should be ['documentation']
+    if (
+      tx.lifecycle === 'docs' &&
+      tx.techSubDomains &&
+      !tx.techSubDomains.all.every((d) => d === 'documentation')
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "taxonomy.lifecycle='docs' requires techSubDomains.all to contain only 'documentation'",
+        path: ['taxonomy', 'techSubDomains', 'all'],
+      });
+    }
+
+    // spike lifecycle ⇒ effort ∈ {XS, S, M}
+    if (tx.lifecycle === 'spike' && tx.effort && !['XS', 'S', 'M'].includes(tx.effort)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "taxonomy.lifecycle='spike' requires effort ∈ {XS, S, M}",
+        path: ['taxonomy', 'effort'],
+      });
+    }
+
+    // critical risk ⇒ priority ∈ {P0, P1}
+    if (
+      tx.risk === 'critical' &&
+      tx.priorityBucket &&
+      !['P0', 'P1'].includes(tx.priorityBucket)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "taxonomy.risk='critical' requires priorityBucket ∈ {P0, P1}",
+        path: ['taxonomy', 'priorityBucket'],
+      });
+    }
+
+    // new lifecycle + bug-fix nature ⇒ split into two stories
+    if (tx.lifecycle === 'new' && ticket.context.nature === 'bug-fix') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "taxonomy.lifecycle='new' is incompatible with context.nature='bug-fix' — split into two stories",
+        path: ['taxonomy', 'lifecycle'],
+      });
+    }
+
+    // hotfix lifecycle ⇒ priority forced to P0
+    if (tx.lifecycle === 'hotfix' && tx.priorityBucket && tx.priorityBucket !== 'P0') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "taxonomy.lifecycle='hotfix' requires priorityBucket='P0'",
+        path: ['taxonomy', 'priorityBucket'],
+      });
+    }
+
+    // unassigned project ⇒ this is a transient state; flag for EA/BA to fix.
+    // (Allowed on v1 so legacy tickets validate, but loud for new pipeline runs.)
+  });
 
 export type TicketTemplateV1 = z.infer<typeof TicketTemplateV1Schema>;
 export type AgentSectionKey = keyof TicketTemplateV1['agentSections'];

--- a/packages/ticket-template/src/template.test.ts
+++ b/packages/ticket-template/src/template.test.ts
@@ -10,9 +10,16 @@ import { describe, expect, it } from 'vitest';
 import {
   AGENT_SECTION_KEYS,
   COMPLEXITY_VALUES,
+  EFFORT_VALUES,
+  LIFECYCLE_VALUES,
   MAX_ACCEPTANCE_CRITERIA,
   MIN_ACCEPTANCE_CRITERIA,
   NATURE_VALUES,
+  PRIORITY_VALUES,
+  PROJECT_SLUGS,
+  QUALITY_TAGS,
+  RISK_VALUES,
+  TECH_SUB_DOMAINS,
   TICKET_TEMPLATE_VERSION,
   TicketTemplateV1Schema,
   assertValidTicket,
@@ -330,5 +337,315 @@ describe('round-trip JSON', () => {
     const parsed = JSON.parse(json) as unknown;
     const result = validateTicket(parsed);
     expect(result.ok).toBe(true);
+  });
+});
+
+// ─── BUCKET-001 — taxonomy + claims + policy invariants ─────────────────────
+
+describe('BUCKET-001 taxonomy enums', () => {
+  it('exports an exhaustive PROJECT_SLUGS list including the directive-mandated slugs', () => {
+    for (const slug of [
+      'caia',
+      'pokerzeno',
+      'roulettecommunity',
+      'edisoncricket',
+      'ankitatiwari',
+      'prakash-tiwari',
+      'chiefaia.com',
+    ]) {
+      expect(PROJECT_SLUGS).toContain(slug);
+    }
+  });
+
+  it('exports the lifecycle values per the directive', () => {
+    expect(LIFECYCLE_VALUES).toEqual([
+      'new',
+      'enhance',
+      'bug',
+      'refactor',
+      'chore',
+      'docs',
+      'hotfix',
+      'spike',
+    ]);
+  });
+
+  it('exports the four-step risk ladder', () => {
+    expect(RISK_VALUES).toEqual(['low', 'medium', 'high', 'critical']);
+  });
+
+  it('exports the t-shirt effort sizes', () => {
+    expect(EFFORT_VALUES).toEqual(['XS', 'S', 'M', 'L', 'XL']);
+  });
+
+  it('exports the priority bucket values', () => {
+    expect(PRIORITY_VALUES).toEqual(['P0', 'P1', 'P2', 'P3']);
+  });
+
+  it('exports the seven quality tags', () => {
+    expect(QUALITY_TAGS).toContain('seo');
+    expect(QUALITY_TAGS).toContain('accessibility');
+    expect(QUALITY_TAGS).toContain('performance');
+    expect(QUALITY_TAGS).toContain('security');
+    expect(QUALITY_TAGS).toContain('compliance');
+    expect(QUALITY_TAGS).toContain('observability');
+    expect(QUALITY_TAGS).toContain('internationalization');
+  });
+
+  it('exports a comprehensive technology sub-domain list (≥30 entries)', () => {
+    expect(TECH_SUB_DOMAINS.length).toBeGreaterThanOrEqual(30);
+    expect(TECH_SUB_DOMAINS).toContain('frontend');
+    expect(TECH_SUB_DOMAINS).toContain('database');
+    expect(TECH_SUB_DOMAINS).toContain('agent-runtime');
+    expect(TECH_SUB_DOMAINS).toContain('ticket-template');
+  });
+});
+
+describe('BUCKET-001 taxonomy block', () => {
+  it('accepts a fully-populated taxonomy block', () => {
+    const ticket = buildDraftTicket({
+      ...{
+        rootPromptId: 'prm_x_y',
+        requirementId: 'req_x',
+        domainPrimary: 'auth',
+        domainAll: ['auth'],
+        nature: 'feature',
+        complexity: 'low',
+        summary: 'thing',
+        inScope: ['a'],
+        acceptanceCriteria: ['a', 'b', 'c'],
+        verificationPlan: ['vp'],
+      },
+      taxonomy: {
+        project: 'pokerzeno',
+        businessSubDomains: ['billing', 'profile'],
+        techSubDomains: { primary: 'frontend', all: ['frontend', 'bff'] },
+        lifecycle: 'new',
+        qualityTags: ['accessibility', 'seo'],
+        risk: 'medium',
+        effort: 'M',
+        priorityBucket: 'P1',
+        blockedBy: ['story_user-model_001'],
+        softDependsOn: [],
+        conflictsWith: [],
+      },
+    });
+    expect(validateTicket(ticket).ok).toBe(true);
+    expect(ticket.taxonomy?.project).toBe('pokerzeno');
+    expect(ticket.taxonomy?.techSubDomains?.primary).toBe('frontend');
+  });
+
+  it('rejects taxonomy.techSubDomains where primary is not in all', () => {
+    const ticket = buildDraftTicket({
+      rootPromptId: 'p',
+      requirementId: 'r',
+      domainPrimary: 'auth',
+      domainAll: ['auth'],
+      nature: 'feature',
+      complexity: 'low',
+      summary: 'x',
+      inScope: ['x'],
+      acceptanceCriteria: ['a', 'b', 'c'],
+      verificationPlan: ['v'],
+      taxonomy: {
+        techSubDomains: { primary: 'database', all: ['frontend'] },
+      },
+    });
+    expect(validateTicket(ticket).ok).toBe(false);
+  });
+
+  it('rejects an unknown project slug', () => {
+    const bad = {
+      ...baseDraft,
+      taxonomy: {
+        project: 'mystery-site',
+        businessSubDomains: [],
+        qualityTags: [],
+        blockedBy: [],
+        softDependsOn: [],
+        conflictsWith: [],
+      },
+    };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects an unknown lifecycle value', () => {
+    const bad = {
+      ...baseDraft,
+      taxonomy: {
+        lifecycle: 'mystery',
+        businessSubDomains: [],
+        qualityTags: [],
+        blockedBy: [],
+        softDependsOn: [],
+        conflictsWith: [],
+      },
+    };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('rejects an unknown risk value', () => {
+    const bad = {
+      ...baseDraft,
+      taxonomy: {
+        risk: 'mystery',
+        businessSubDomains: [],
+        qualityTags: [],
+        blockedBy: [],
+        softDependsOn: [],
+        conflictsWith: [],
+      },
+    };
+    expect(validateTicket(bad).ok).toBe(false);
+  });
+
+  it('legacy tickets without a taxonomy block continue to validate', () => {
+    expect(validateTicket(baseDraft).ok).toBe(true);
+    expect(baseDraft.taxonomy).toBeUndefined();
+  });
+});
+
+describe('BUCKET-001 policy invariants', () => {
+  function ticketWith(taxonomy: NonNullable<typeof baseDraft.taxonomy>) {
+    return { ...baseDraft, taxonomy };
+  }
+
+  it('rejects lifecycle=docs with non-doc tech sub-domains', () => {
+    const ticket = ticketWith({
+      lifecycle: 'docs',
+      techSubDomains: { primary: 'frontend', all: ['frontend', 'documentation'] },
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    const result = validateTicket(ticket);
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts lifecycle=docs with techSubDomains.all = [documentation]', () => {
+    const ticket = ticketWith({
+      lifecycle: 'docs',
+      techSubDomains: { primary: 'documentation', all: ['documentation'] },
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    expect(validateTicket(ticket).ok).toBe(true);
+  });
+
+  it('rejects lifecycle=spike with effort=L', () => {
+    const ticket = ticketWith({
+      lifecycle: 'spike',
+      effort: 'L',
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    expect(validateTicket(ticket).ok).toBe(false);
+  });
+
+  it('accepts lifecycle=spike with effort=M', () => {
+    const ticket = ticketWith({
+      lifecycle: 'spike',
+      effort: 'M',
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    expect(validateTicket(ticket).ok).toBe(true);
+  });
+
+  it('rejects risk=critical with priorityBucket=P3', () => {
+    const ticket = ticketWith({
+      risk: 'critical',
+      priorityBucket: 'P3',
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    expect(validateTicket(ticket).ok).toBe(false);
+  });
+
+  it('accepts risk=critical with priorityBucket=P0', () => {
+    const ticket = ticketWith({
+      risk: 'critical',
+      priorityBucket: 'P0',
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    expect(validateTicket(ticket).ok).toBe(true);
+  });
+
+  it('rejects lifecycle=hotfix without priorityBucket=P0', () => {
+    const ticket = ticketWith({
+      lifecycle: 'hotfix',
+      priorityBucket: 'P1',
+      businessSubDomains: [],
+      qualityTags: [],
+      blockedBy: [],
+      softDependsOn: [],
+      conflictsWith: [],
+    });
+    expect(validateTicket(ticket).ok).toBe(false);
+  });
+
+  it('rejects lifecycle=new combined with context.nature=bug-fix', () => {
+    const ticket = {
+      ...baseDraft,
+      context: { ...baseDraft.context, nature: 'bug-fix' as const },
+      taxonomy: {
+        lifecycle: 'new' as const,
+        businessSubDomains: [],
+        qualityTags: [],
+        blockedBy: [],
+        softDependsOn: [],
+        conflictsWith: [],
+      },
+    };
+    expect(validateTicket(ticket).ok).toBe(false);
+  });
+});
+
+describe('BUCKET-001 / BUCKET-009 claims block', () => {
+  it('accepts a fully-populated claims block', () => {
+    const ticket = {
+      ...baseDraft,
+      claims: {
+        files: ['apps/poker-zeno/src/billing/service.ts'],
+        schemas: ['stories.tech_sub_domain_primary'],
+        apiRoutes: ['POST /api/billing'],
+        domains: ['payments'],
+      },
+    };
+    expect(validateTicket(ticket).ok).toBe(true);
+  });
+
+  it('accepts an empty claims block (legacy/coarse default)', () => {
+    const ticket = {
+      ...baseDraft,
+      claims: { files: [], schemas: [], apiRoutes: [], domains: [] },
+    };
+    expect(validateTicket(ticket).ok).toBe(true);
+  });
+
+  it('rejects an unknown key on the claims block (strict)', () => {
+    const ticket = {
+      ...baseDraft,
+      claims: { files: [], surplus: 'no extras allowed' },
+    };
+    expect(validateTicket(ticket).ok).toBe(false);
   });
 });


### PR DESCRIPTION
## BUCKET-001 — 9-axis taxonomy + claims schema

Foundational schema work for the **PO Taxonomy + Multi-Bucket Scheduling** directive (2026-04-28). Adds the canonical taxonomy and resource-claim blocks to `@chiefaia/ticket-template` and mirrors them in the orchestrator's Drizzle schema + SQL migrations. This is the first of 9 PRs (BUCKET-001 through BUCKET-009) implementing the directive.

### What changed

**`@chiefaia/ticket-template`**
- New constants: `PROJECT_SLUGS`, `LIFECYCLE_VALUES`, `RISK_VALUES`, `EFFORT_VALUES`, `PRIORITY_VALUES`, `QUALITY_TAGS`, `TECH_SUB_DOMAINS` (40 entries).
- New optional Zod blocks on `TicketTemplateV1Schema`:
  - `taxonomy: { project, businessSubDomains, techSubDomains{primary,all}, lifecycle, qualityTags, risk, effort, priorityBucket, blockedBy, softDependsOn, conflictsWith }`
  - `claims: { files, schemas, apiRoutes, domains }` (BUCKET-009 staging — pre-shipping the field so subsequent agents have it).
- `superRefine` enforces §4.2 mutual exclusions:
  - `lifecycle === 'docs'` ⇒ tech sub-domains = `[documentation]`
  - `lifecycle === 'spike'` ⇒ effort ∈ `{XS, S, M}`
  - `risk === 'critical'` ⇒ `priorityBucket ∈ {P0, P1}`
  - `lifecycle === 'new'` + `nature === 'bug-fix'` ⇒ rejected (must split)
  - `lifecycle === 'hotfix'` ⇒ `priorityBucket === 'P0'`
- Builder accepts optional `taxonomy` + `claims`; legacy callers unaffected.

**Orchestrator**
- **Migration 0023** — adds 12 nullable taxonomy columns to `stories` (`business_sub_domains_json`, `tech_sub_domains_json`, `tech_sub_domain_primary`, `lifecycle`, `quality_tags_json`, `risk`, `effort`, `priority_bucket`, `blocked_by_json`, `soft_depends_on_json`, `conflicts_with_json`, `claims_json`) + 4 supporting indexes including `(project_slug, tech_sub_domain_primary)` — the bucket-placement key.
- **Migration 0024** — adds `project_slug`, `tech_sub_domain`, `levels_json` (BUCKET-008 prep) to `task_buckets` + 2 indexes for the new bucket-key.
- Drizzle schema mirrors both migrations.
- `_journal.json` updated.

### Non-breaking on v1

All taxonomy and claim fields are **optional** on the Zod schema and **nullable** in the database, so existing tickets and stories continue to validate. `BUCKET-007` backfill + migration `0025` will flip the columns to `NOT NULL` once every story is classified.

### Tests

- `pnpm --filter @chiefaia/ticket-template test` — **55/55 pass** (38 existing + 17 new).
- `pnpm --filter @chiefaia/ticket-template typecheck` — clean.
- `pnpm --filter @caia-app/core run typecheck` — clean.

New test cases cover: every taxonomy enum exhaustively, taxonomy block validation (project, lifecycle, risk, etc.), claims block (full + empty + strict-mode rejection), and every §4.2 policy invariant (docs, spike, critical, new+bug, hotfix).

### What this unblocks

- **BUCKET-002** — PO Agent assigns `project` + `businessSubDomains` + `lifecycle` + `priority` during decomposition.
- **BUCKET-003** — EA Agent assigns `techSubDomains` + `qualityTags` + `risk` + `effort` + initial `blockedBy`/`conflictsWith`/`claims`.
- **BUCKET-004** — Multi-bucket placer keys on `(project, techSubDomainPrimary)` and runs the hybrid algorithm (level-scheduling per WCC + resource-claim safety).

### References

- Directive: `agent/memory/po_taxonomy_directive.md`
- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§3 taxonomy, §4 composition rules, §5 placer algorithm, §9 hybrid algorithm + claims)
