### PR TITLE
feat(orchestrator): emit task.resumed + pipeline lifecycle + executor.heartbeat (DASH-103/104/105/106)

### DIFF
--- a/apps/orchestrator/src/agents/pipeline-stages.ts
+++ b/apps/orchestrator/src/agents/pipeline-stages.ts
@@ -101,4 +101,34 @@ export function advancePipelineStage(input: AdvanceStageInput, db: Db): void {
       durationFromStartMs: durationMs,
     },
   });
+
+  // DASH-104: emit canonical decompose lifecycle events at the relevant
+  // stage transitions. `pipeline.decompose_started` fires when the prompt
+  // enters the scaffolded stage (decomposer is about to run); the matching
+  // `pipeline.decompose_completed` fires when it reaches po_decomposed.
+  // Subscribers can pair the two by `correlation_id` (= prompt id).
+  if (input.stage === 'scaffolded') {
+    eventBus.publish({
+      type: 'pipeline.decompose_started',
+      actor: 'system',
+      correlation_id: input.correlationId,
+      entity_type: 'prompt',
+      entity_id: input.promptId,
+      payload: {
+        promptId: input.promptId,
+      },
+    });
+  } else if (input.stage === 'po_decomposed') {
+    eventBus.publish({
+      type: 'pipeline.decompose_completed',
+      actor: 'system',
+      correlation_id: input.correlationId,
+      entity_type: 'prompt',
+      entity_id: input.promptId,
+      payload: {
+        promptId: input.promptId,
+        durationMs: durationMs ?? undefined,
+      },
+    });
+  }
 }

--- a/apps/orchestrator/src/api/routes/executor.ts
+++ b/apps/orchestrator/src/api/routes/executor.ts
@@ -313,6 +313,7 @@ export function registerExecutorRoutes(app: Hono, db: Db): void {
   app.post('/executor/tasks/:id/unpause', async (c) => {
     const { id } = c.req.param();
     const body = await c.req.json<Record<string, unknown>>().catch(() => ({} as Record<string, unknown>));
+    const before = db.select().from(tasks).where(eq(tasks.id, id)).get();
     const update: Record<string, unknown> = { paused: false, pauseReason: null };
     if (body['reset_attempts']) update['attemptCount'] = 0;
     db.update(tasks)
@@ -320,6 +321,18 @@ export function registerExecutorRoutes(app: Hono, db: Db): void {
       .where(eq(tasks.id, id))
       .run();
     bus.push({ kind: 'task.unpaused', id, payload: {}, ts: now() });
+    // DASH-103: emit canonical task.resumed event (paired with task.paused on
+    // PATCH /tasks/:id) so dashboard subscribers can track the full pause /
+    // resume lifecycle from a single event stream.
+    if (before?.paused) {
+      eventBus.publish({
+        type: 'task.resumed',
+        actor: 'executor',
+        entity_type: 'task',
+        entity_id: id,
+        payload: { task_id: id, reset_attempts: Boolean(body['reset_attempts']) },
+      });
+    }
     return c.json({ ok: true });
   });
 

--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -1,7 +1,12 @@
 import { serve } from '@hono/node-server';
 import type { ServerType } from '@hono/node-server';
 import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { eq, and, count } from 'drizzle-orm';
 import { getDb, runMigrations } from '../db/connection';
+import type { Db } from '../db/connection';
 import { seedProjects } from '../db/seed-projects';
 import { seedAdr011 } from '../db/seed-adr';
 import { migrateFromJsonl } from '../db/migrate-from-jsonl';
@@ -9,8 +14,74 @@ import { attachWsServer } from '../ws/index';
 import { createApp } from './app';
 import { wireEventBus, eventBus } from '../events/bus-adapter';
 import { subscribeToEvents as subscribePriorityEvents, scoreAll } from '../prioritization/reprioritizer';
+import { tasks, executorRuns } from '../db/schema';
 
 const HTTP_PORT = parseInt(process.env['CONDUCTOR_HTTP_PORT'] ?? '7776', 10);
+
+// DASH-106: heartbeat cadence. 5s matches the gap-analysis spec and gives
+// the dashboard a "live" signal without flooding the WS. Disable in tests
+// or local dev with CAIA_HEARTBEAT_DISABLED=1 if needed.
+const HEARTBEAT_INTERVAL_MS = parseInt(process.env['CAIA_HEARTBEAT_INTERVAL_MS'] ?? '5000', 10);
+const HEARTBEAT_DISABLED = process.env['CAIA_HEARTBEAT_DISABLED'] === '1';
+const DAEMON_HEARTBEAT_FILE = path.join(os.homedir(), '.conductor', 'executor.heartbeat');
+
+interface DaemonHeartbeat {
+  at: string;
+  pid: number;
+  running: number;
+  queued: number;
+}
+
+function readDaemonHeartbeat(): DaemonHeartbeat | null {
+  try {
+    const raw = fs.readFileSync(DAEMON_HEARTBEAT_FILE, 'utf8');
+    return JSON.parse(raw) as DaemonHeartbeat;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * DASH-106: emit `executor.heartbeat` at a fixed cadence. Reads counts from
+ * the orchestrator's own DB (so the event is meaningful even when the
+ * external daemon is down) and merges in the daemon's heartbeat file when
+ * present (so the dashboard can tell daemon-alive from orchestrator-alive).
+ * The event is `severity: 'debug'` per taxonomy — chatty by design but
+ * cheap to filter out.
+ */
+export function emitExecutorHeartbeat(db: Db): void {
+  try {
+    const runningRow = db.select({ c: count() })
+      .from(executorRuns)
+      .where(eq(executorRuns.status, 'running'))
+      .get();
+    const running = runningRow?.c ?? 0;
+
+    const queuedRow = db.select({ c: count() })
+      .from(tasks)
+      .where(and(eq(tasks.status, 'queued'), eq(tasks.paused, false)))
+      .get();
+    const queued = queuedRow?.c ?? 0;
+
+    const daemon = readDaemonHeartbeat();
+
+    eventBus.publish({
+      type: 'executor.heartbeat',
+      actor: 'system',
+      severity: 'debug',
+      payload: {
+        pid: daemon?.pid ?? null,
+        active_workers: running,
+        queued_tasks: queued,
+        daemon_alive: daemon !== null,
+        last_daemon_heartbeat_at: daemon?.at ?? null,
+      },
+    });
+  } catch (err) {
+    // Heartbeat is best-effort observability — never crash the server over it.
+    console.error('[caia] executor.heartbeat emit failed:', err);
+  }
+}
 
 export async function startApiServer(conductorDir?: string): Promise<{ stop: () => void }> {
   runMigrations();
@@ -45,10 +116,19 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
     payload: { component: 'conductor-api', version: '0.1.0', port: HTTP_PORT },
   });
 
+  // DASH-106: start the executor.heartbeat ticker. unref() so it doesn't
+  // hold the event loop open during graceful shutdown / Ctrl-C.
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  if (!HEARTBEAT_DISABLED) {
+    heartbeatTimer = setInterval(() => emitExecutorHeartbeat(db), HEARTBEAT_INTERVAL_MS);
+    heartbeatTimer.unref?.();
+  }
+
   console.error(`[conductor] API + WS listening on port ${HTTP_PORT}`);
 
   return {
     stop: () => {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
       eventBus.publish({ type: 'system.shutdown', actor: 'system', payload: { component: 'conductor-api', reason: 'stop()' } });
       server.close();
     },

--- a/apps/orchestrator/src/prompts/manager.ts
+++ b/apps/orchestrator/src/prompts/manager.ts
@@ -73,6 +73,23 @@ export function createPrompt(db: Db, params: CreatePromptParams): Prompt {
     },
   });
 
+  // DASH-104: emit canonical pipeline lifecycle event alongside the
+  // domain-specific prompt.received. pipeline.started fires once per new
+  // prompt and pairs with pipeline.completed / pipeline.failed in
+  // updatePromptStatus, giving the dashboard a coarse-grained signal
+  // independent of the fine-grained pipeline.stage.advanced stream.
+  eventBus.publish({
+    type: 'pipeline.started',
+    actor: 'mcp',
+    correlation_id: id,
+    entity_type: 'prompt',
+    entity_id: id,
+    payload: {
+      promptId: id,
+      receivedVia: row.receivedVia,
+    },
+  });
+
   return row as Prompt;
 }
 
@@ -115,6 +132,38 @@ export function updatePromptStatus(db: Db, id: string, status: PromptStatus): Pr
       elapsed_ms: patch.elapsedMs ?? undefined,
     },
   });
+
+  // DASH-104: emit pipeline.completed / pipeline.failed when the prompt
+  // reaches a terminal status, giving the dashboard a coarse-grained
+  // outcome signal that pairs with the pipeline.started fired at
+  // creation time.
+  if (status === 'answered') {
+    eventBus.publish({
+      type: 'pipeline.completed',
+      actor: 'mcp',
+      correlation_id: existing.correlationId,
+      entity_type: 'prompt',
+      entity_id: id,
+      payload: {
+        promptId: id,
+        elapsed_ms: patch.elapsedMs ?? undefined,
+      },
+    });
+  } else if (status === 'failed') {
+    eventBus.publish({
+      type: 'pipeline.failed',
+      actor: 'mcp',
+      correlation_id: existing.correlationId,
+      entity_type: 'prompt',
+      entity_id: id,
+      severity: 'error',
+      payload: {
+        promptId: id,
+        elapsed_ms: patch.elapsedMs ?? undefined,
+        from_status: existing.status,
+      },
+    });
+  }
 
   return db.select().from(prompts).where(eq(prompts.id, id)).get() as Prompt;
 }

--- a/apps/orchestrator/tests/api/dash-103-104-106-emissions.test.ts
+++ b/apps/orchestrator/tests/api/dash-103-104-106-emissions.test.ts
@@ -1,0 +1,230 @@
+/**
+ * DASH-103 / DASH-104 / DASH-106 — guard the new event emissions added to
+ * the orchestrator.
+ *
+ *   DASH-103: task.resumed when a paused task is unpaused
+ *   DASH-104: pipeline.started on prompt creation,
+ *             pipeline.completed when a prompt → answered,
+ *             pipeline.failed when a prompt → failed,
+ *             pipeline.decompose_started + pipeline.decompose_completed
+ *               at the matching pipeline-stage transitions
+ *   DASH-106: executor.heartbeat synthetic event with active_workers /
+ *             queued_tasks / daemon_alive payload
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import { Hono } from 'hono';
+import * as schema from '../../src/db/schema';
+import { tasks } from '../../src/db/schema';
+import { registerExecutorRoutes } from '../../src/api/routes/executor';
+import { wireEventBus } from '../../src/events/bus-adapter';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import { createPrompt, updatePromptStatus } from '../../src/prompts/manager';
+import { advancePipelineStage } from '../../src/agents/pipeline-stages';
+import { emitExecutorHeartbeat } from '../../src/api/start';
+import type { Db } from '../../src/db/connection';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+let _mockRaw: Database.Database | null = null;
+jest.mock('../../src/db/connection', () => {
+  const actual = jest.requireActual<typeof import('../../src/db/connection')>('../../src/db/connection');
+  return {
+    ...actual,
+    getSqliteRaw: jest.fn(() => {
+      if (!_mockRaw) throw new Error('_mockRaw not set');
+      return _mockRaw;
+    }),
+  };
+});
+
+function createTestDb(): { db: Db; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  const db = drizzle(raw, { schema }) as Db;
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, raw };
+}
+
+describe('DASH-103 task.resumed', () => {
+  let db: Db;
+  let raw: Database.Database;
+  let app: Hono;
+
+  beforeEach(() => {
+    ({ db, raw } = createTestDb());
+    _mockRaw = raw;
+    wireEventBus(db);
+    app = new Hono();
+    registerExecutorRoutes(app, db);
+  });
+
+  afterEach(() => {
+    raw.close();
+    _mockRaw = null;
+  });
+
+  it('POST /executor/tasks/:id/unpause emits task.resumed when the task was paused', async () => {
+    const id = 'tsk_dash103_resumed';
+    db.insert(tasks).values({
+      id,
+      title: 'paused task',
+      status: 'queued',
+      paused: true,
+      pauseReason: 'Manual pause',
+      cwd: '/',
+      declaredFiles: '[]',
+      dependsOn: '[]',
+      attemptCount: 0,
+      createdAt: new Date().toISOString(),
+    } as typeof tasks.$inferInsert).run();
+
+    const before = eventBus.replay({ correlationId: undefined, limit: 200 }).length;
+    const res = await app.request(`/executor/tasks/${id}/unpause`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reset_attempts: true }),
+    });
+    expect(res.status).toBe(200);
+
+    const after = eventBus.replay({ correlationId: undefined, limit: 200 });
+    const newOnes = after.slice(0, after.length - before);
+    const ev = newOnes.find(e => e.type === 'task.resumed');
+    expect(ev).toBeDefined();
+    expect(ev!.entity_id).toBe(id);
+    expect((ev!.payload as Record<string, unknown>)['reset_attempts']).toBe(true);
+  });
+
+  it('does NOT emit task.resumed if the task was already not paused', async () => {
+    const id = 'tsk_dash103_noop';
+    db.insert(tasks).values({
+      id,
+      title: 'already running',
+      status: 'queued',
+      paused: false,
+      cwd: '/',
+      declaredFiles: '[]',
+      dependsOn: '[]',
+      attemptCount: 0,
+      createdAt: new Date().toISOString(),
+    } as typeof tasks.$inferInsert).run();
+
+    const before = eventBus.replay({ correlationId: undefined, limit: 200 }).length;
+    const res = await app.request(`/executor/tasks/${id}/unpause`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(200);
+
+    const after = eventBus.replay({ correlationId: undefined, limit: 200 });
+    const newOnes = after.slice(0, after.length - before);
+    expect(newOnes.map(e => e.type)).not.toContain('task.resumed');
+  });
+});
+
+describe('DASH-104 pipeline lifecycle', () => {
+  let db: Db;
+  let raw: Database.Database;
+
+  beforeEach(() => {
+    ({ db, raw } = createTestDb());
+    _mockRaw = raw;
+    wireEventBus(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+    _mockRaw = null;
+  });
+
+  it('createPrompt → updatePromptStatus(answered) emits pipeline.started + pipeline.completed', () => {
+    const before = eventBus.replay({ correlationId: undefined, limit: 200 }).length;
+    const p = createPrompt(db, { body: 'hello world dash-104' });
+    updatePromptStatus(db, p.id, 'answered');
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 200 });
+    const newOnes = events.slice(0, events.length - before);
+    const types = newOnes.map(e => e.type);
+    expect(types).toContain('pipeline.started');
+    expect(types).toContain('pipeline.completed');
+  });
+
+  it('updatePromptStatus(failed) emits pipeline.failed with severity error', () => {
+    const before = eventBus.replay({ correlationId: undefined, limit: 200 }).length;
+    const p = createPrompt(db, { body: 'will fail dash-104' });
+    updatePromptStatus(db, p.id, 'failed');
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 200 });
+    const newOnes = events.slice(0, events.length - before);
+    const failedEv = newOnes.find(e => e.type === 'pipeline.failed');
+    expect(failedEv).toBeDefined();
+    expect(failedEv!.severity).toBe('error');
+  });
+
+  it('advancePipelineStage emits pipeline.decompose_started/completed at the right transitions', () => {
+    const p = createPrompt(db, { body: 'decompose dash-104' });
+    const before = eventBus.replay({ correlationId: undefined, limit: 200 }).length;
+
+    advancePipelineStage({ promptId: p.id, stage: 'scaffolded', correlationId: p.correlationId }, db);
+    advancePipelineStage({ promptId: p.id, stage: 'po_decomposed', correlationId: p.correlationId }, db);
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 200 });
+    const newOnes = events.slice(0, events.length - before);
+    const types = newOnes.map(e => e.type);
+    expect(types).toContain('pipeline.decompose_started');
+    expect(types).toContain('pipeline.decompose_completed');
+  });
+});
+
+describe('DASH-106 executor.heartbeat', () => {
+  let db: Db;
+  let raw: Database.Database;
+
+  beforeEach(() => {
+    ({ db, raw } = createTestDb());
+    _mockRaw = raw;
+    wireEventBus(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+    _mockRaw = null;
+  });
+
+  it('emitExecutorHeartbeat publishes executor.heartbeat with the expected payload shape', () => {
+    db.insert(tasks).values({
+      id: 'tsk_dash106_q',
+      title: 'queued task',
+      status: 'queued',
+      paused: false,
+      cwd: '/',
+      declaredFiles: '[]',
+      dependsOn: '[]',
+      attemptCount: 0,
+      createdAt: new Date().toISOString(),
+    } as typeof tasks.$inferInsert).run();
+
+    const before = eventBus.replay({ correlationId: undefined, limit: 200 }).length;
+    emitExecutorHeartbeat(db);
+
+    const events = eventBus.replay({ correlationId: undefined, limit: 200 });
+    const newOnes = events.slice(0, events.length - before);
+    const hb = newOnes.find(e => e.type === 'executor.heartbeat');
+    expect(hb).toBeDefined();
+
+    const p = hb!.payload as Record<string, unknown>;
+    expect(p['active_workers']).toBe(0);
+    expect(p['queued_tasks']).toBe(1);
+    expect(typeof p['daemon_alive']).toBe('boolean');
+    expect('pid' in p).toBe(true);
+    expect(hb!.severity).toBe('debug');
+  });
+
+  it('heartbeat tolerates DB errors and never throws', () => {
+    // close the raw db underneath — heartbeat should swallow the error
+    raw.close();
+    expect(() => emitExecutorHeartbeat(db)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Light up dead taxonomy event types so the dashboard's WS feed reflects more of the orchestrator's internal state. Closes the deferred items DASH-103 / DASH-104 / DASH-105 / DASH-106 from the Gate 2 dashboard rollout.

**DASH-103 — task.resumed:**
- POST /executor/tasks/:id/unpause now publishes `task.resumed` when the task was previously paused, paired with the existing `task.paused` emission on PATCH /tasks/:id.

**DASH-104 — pipeline lifecycle:**
- `createPrompt()` emits `pipeline.started` alongside `prompt.received`.
- `updatePromptStatus()` emits `pipeline.completed` (status -> answered) or `pipeline.failed` with severity=error (status -> failed).
- `advancePipelineStage()` emits `pipeline.decompose_started` when the prompt enters the scaffolded stage and `pipeline.decompose_completed` on po_decomposed (with durationMs).
- Existing `pipeline.stage.advanced` + `prompt.*` emissions unchanged — consumers can choose coarse (`pipeline.*`) or fine-grained (`stage.*`) signals.

**DASH-105 — priority.scored/rebucketed/reordered:**
Already emitted by the reprioritizer (verified, no changes needed). The vocabulary contract test in `dash-304-queue-events.test.ts` (#83) pins it.

**DASH-106 — executor.heartbeat:**
- New `emitExecutorHeartbeat(db)` helper publishes `executor.heartbeat` every 5s with `{pid, active_workers, queued_tasks, daemon_alive, last_daemon_heartbeat_at}`. active_workers + queued_tasks come from the orchestrator DB; daemon_alive + pid come from the executor daemon's heartbeat file.
- Cadence configurable via `CAIA_HEARTBEAT_INTERVAL_MS` (default 5000).
- Disable in tests with `CAIA_HEARTBEAT_DISABLED=1`; timer is unref'd so it never holds the event loop open during graceful exit.
- severity: 'debug' per taxonomy — chatty by design but cheap to filter.

**Tests** (7 new cases in `dash-103-104-106-emissions.test.ts`, all green):
- task.resumed fires (paused -> unpaused) and is silent when not paused
- pipeline.started + pipeline.completed across createPrompt -> answered
- pipeline.failed carries severity=error
- pipeline.decompose_started/completed at scaffolded -> po_decomposed
- executor.heartbeat payload shape (active_workers/queued_tasks)
- heartbeat tolerates DB errors without throwing

Stack: pnpm jest tests/api/dash --silent -> 28 tests pass on this branch (DASH-304/305 tests land via #83).
