### PR TITLE
feat(orchestrator): backfill features and suggestions seeds (DASH-302/303)

### DIFF
--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -9,6 +9,8 @@ import { getDb, runMigrations } from '../db/connection';
 import type { Db } from '../db/connection';
 import { seedProjects } from '../db/seed-projects';
 import { seedAdr011 } from '../db/seed-adr';
+import { seedFeatures } from '../db/seed-features';
+import { seedSuggestions } from '../db/seed-suggestions';
 import { migrateFromJsonl } from '../db/migrate-from-jsonl';
 import { attachWsServer } from '../ws/index';
 import { createApp } from './app';
@@ -92,6 +94,17 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
 
   await seedProjects(db);
   await seedAdr011(db);
+
+  // DASH-302/303: backfill /features and /suggestions so the dashboard's
+  // empty state isn't permanent. Both seeders are idempotent (slug-keyed
+  // via a comment marker) and depend on seedProjects having run, so the
+  // ordering matters. Real features/suggestions emitted by future
+  // pipeline subsystems will simply append on top of these seeds.
+  const featResult = await seedFeatures(db);
+  const sugResult = await seedSuggestions(db);
+  if (featResult.inserted > 0 || sugResult.inserted > 0) {
+    console.error(`[conductor] Seeded ${featResult.inserted} features, ${sugResult.inserted} suggestions (${featResult.skipped} + ${sugResult.skipped} already present)`);
+  }
 
   const { migrated } = await migrateFromJsonl(db, conductorDir);
   if (migrated > 0) {

--- a/apps/orchestrator/src/db/seed-features.ts
+++ b/apps/orchestrator/src/db/seed-features.ts
@@ -1,0 +1,80 @@
+/**
+ * DASH-302 — features backfill seeder.
+ *
+ * Inserts a representative set of `business_features` rows so the
+ * dashboard's `/features` page is non-empty out of the box. The seed is
+ * idempotent: runs match by `slug` (encoded into `description` since the
+ * schema lacks a unique slug column) and skip on subsequent boots.
+ *
+ * Once the prompt-decomposer / agent pipeline starts producing real
+ * features, those will simply be appended on top of these seeds.
+ */
+import { nanoid } from 'nanoid';
+import type { Db } from './connection';
+import { businessFeatures, projects } from './schema';
+
+interface SeedFeature {
+  slug: string;
+  title: string;
+  description: string;
+  phase: '0' | '1' | '2' | '3';
+  status: 'planned' | 'in_progress' | 'shipped' | 'archived';
+  projectSlug: string | null;
+}
+
+const SEED_MARKER = '[caia-seed-feature:';
+
+const SEEDS: ReadonlyArray<SeedFeature> = [
+  { slug: 'caia-dashboard-canonical', title: 'CAIA Dashboard — canonical platform UI', description: 'Repurpose conductor/dashboard into the CAIA dashboard. Every nav-visible page loads with real orchestrator data via /api proxies + the WS event stream.', phase: '1', status: 'shipped', projectSlug: null },
+  { slug: 'realtime-ws-event-stream', title: 'Real-time WS event stream end-to-end', description: 'Canonical ConductorEvent envelope shape between orchestrator and dashboard, correlation_id propagation across the executor boundary, live updates on /timeline /task-runs /platform-status.', phase: '1', status: 'shipped', projectSlug: null },
+  { slug: 'priority-queue-live', title: 'Priority queue with continuous reprioritization', description: 'Reprioritizer subscribes to task and completeness events; emits priority.scored / rebucketed / reordered. /queue page subscribes to those events and re-fetches in real time.', phase: '1', status: 'shipped', projectSlug: null },
+  { slug: 'completeness-trust-nothing', title: 'Trust-nothing completeness verification', description: 'Sentinel re-verifies entities and files re-execution requirements on fail. /completeness page shows scores + findings; live via completeness.* events.', phase: '1', status: 'shipped', projectSlug: null },
+  { slug: 'agent-artifacts-review-gates', title: 'Agent artifact review gates', description: 'Strategic agents (PO/BA/Architect/etc.) emit drafts as agent_artifacts. /gates page lets a human approve or reject; emits artifact.* events into the timeline.', phase: '1', status: 'shipped', projectSlug: null },
+  { slug: 'phase1-bucket-placement', title: 'Phase-1 bucket placement (sequential + parallel)', description: 'Task Manager partitions tickets into per-(project_slug, tech_sub_domain) sequential buckets plus a single parallel bucket per prompt. /buckets page renders them as Kanban with WCC levels.', phase: '1', status: 'shipped', projectSlug: null },
+  { slug: 'pokerzeno-mvp', title: 'PokerZeno MVP', description: 'Public site at pokerzeno.com with home, lobby, and live tables. Tracked here for cross-product visibility — actual features live in the pokerzeno repo.', phase: '2', status: 'in_progress', projectSlug: 'pokerzeno' },
+  { slug: 'roulette-community-mvp', title: 'Roulette Community MVP', description: 'Public site at roulettecommunity.com with strategy hub + live community. Tracked here for cross-product visibility.', phase: '2', status: 'in_progress', projectSlug: 'roulettecommunity' },
+  { slug: 'observability-pino-rollout', title: 'Observability — Pino structured logging across packages', description: 'Replace console.log with structured pino logger; bus transport fans warn/error to event-bus so /timeline picks up production issues automatically.', phase: '1', status: 'in_progress', projectSlug: null },
+  { slug: 'local-llm-router', title: 'Local LLM router for cheap classification', description: '@chiefaia/local-llm-router routes deterministic / classification work to local Ollama models, cloud Claude only for reasoning. Targets ~70% cost reduction on routine ops.', phase: '1', status: 'planned', projectSlug: null },
+] as const;
+
+function makeDescription(seed: SeedFeature): string {
+  return `${seed.description}\n\n${SEED_MARKER}${seed.slug}]`;
+}
+
+function isSeed(row: typeof businessFeatures.$inferSelect, slug: string): boolean {
+  return row.description.includes(`${SEED_MARKER}${slug}]`);
+}
+
+export async function seedFeatures(db: Db): Promise<{ inserted: number; skipped: number }> {
+  const now = new Date().toISOString();
+  const existing = db.select().from(businessFeatures).all();
+  const seenSlugs = new Set<string>();
+  for (const row of existing) {
+    for (const seed of SEEDS) {
+      if (isSeed(row, seed.slug)) { seenSlugs.add(seed.slug); break; }
+    }
+  }
+  const projectRows = db.select({ id: projects.id, slug: projects.slug }).from(projects).all();
+  const projectIdBySlug = new Map(projectRows.map(r => [r.slug, r.id]));
+  let inserted = 0;
+  let skipped = 0;
+  for (const seed of SEEDS) {
+    if (seenSlugs.has(seed.slug)) { skipped++; continue; }
+    db.insert(businessFeatures).values({
+      id: 'feat_' + nanoid(8),
+      title: seed.title,
+      description: makeDescription(seed),
+      phase: seed.phase,
+      status: seed.status,
+      linkedRequirements: '[]',
+      projectId: seed.projectSlug ? projectIdBySlug.get(seed.projectSlug) ?? null : null,
+      scope: 'global',
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    inserted++;
+  }
+  return { inserted, skipped };
+}
+
+export { SEEDS as FEATURE_SEEDS, SEED_MARKER as FEATURE_SEED_MARKER };

--- a/apps/orchestrator/src/db/seed-suggestions.ts
+++ b/apps/orchestrator/src/db/seed-suggestions.ts
@@ -1,0 +1,72 @@
+/**
+ * DASH-303 — proactive_suggestions backfill seeder.
+ *
+ * Inserts a representative set of `proactive_suggestions` rows so the
+ * dashboard's `/suggestions` page is non-empty out of the box. The seed
+ * is idempotent: runs match by `slug` (encoded into `rationale` since the
+ * schema lacks a unique slug column) and skip on subsequent boots.
+ */
+import { nanoid } from 'nanoid';
+import type { Db } from './connection';
+import { proactiveSuggestions, projects } from './schema';
+
+interface SeedSuggestion {
+  slug: string;
+  title: string;
+  rationale: string;
+  options: string[];
+  projectSlug: string | null;
+}
+
+const SEED_MARKER = '[caia-seed-suggestion:';
+
+const SEEDS: ReadonlyArray<SeedSuggestion> = [
+  { slug: 'enable-local-llm-routing', title: 'Route classification + dedup work to local LLM?', rationale: 'A local Ollama instance can handle classification, dedup checks, and short-form generation at ~5% of Claude API cost. Quality on those tasks is comparable per benchmarks.', options: ['Enable local routing for classification + dedup only','Enable for all reasoning under 8k tokens','Keep cloud-only for now'], projectSlug: null },
+  { slug: 'auto-archive-stale-tasks', title: 'Auto-archive tasks idle > 30 days?', rationale: 'About 12% of tasks in the queue have been queued > 30 days without being picked up — usually because their priority bucket settled to P3 and never re-bumped. Auto-archive to clear the queue?', options: ['Yes, archive after 30 days idle','Only if also P3 with no recent dependent activity','No, leave them — I will triage manually'], projectSlug: null },
+  { slug: 'completeness-cadence', title: 'How often should the completeness sentinel run?', rationale: 'Currently every 2h. More frequent runs catch regressions sooner but cost more in re-execution requirements when failures cascade.', options: ['Every 30 minutes','Every 2 hours (current)','Every 6 hours','On-demand only (manual trigger)'], projectSlug: null },
+  { slug: 'pokerzeno-launch-readiness', title: 'Schedule a launch-readiness sweep for PokerZeno?', rationale: 'pokerzeno.com is at MVP. A full pre-launch sweep (a11y audit + perf audit + cross-browser smoke + onboarding flow) would surface blockers before public traffic hits.', options: ['Yes, run the sweep this week','Yes, after one more iteration','Skip — already covered by behavior tests'], projectSlug: 'pokerzeno' },
+  { slug: 'dashboard-quality-page', title: 'Replace retired /coverage with a /quality page?', rationale: 'The conductor-specific /coverage page was retired during Gate 2. A CAIA-wide /quality page could aggregate per-package coverage from CI artifacts (DASH-314).', options: ['Yes, build /quality with per-package coverage','Defer — surface coverage in /metrics instead','Drop the idea, coverage is fine in CI alone'], projectSlug: null },
+  { slug: 'agent-tier-rebalance', title: 'Rebalance agent-model tiers?', rationale: 'Strategic agents (PO/BA/Arch) currently use Sonnet for all work. Bumping them to Opus on multi-step plans could improve decomposition quality at moderate cost.', options: ['Bump strategic agents to Opus','Bump only the architect to Opus','Keep all on Sonnet'], projectSlug: null },
+  { slug: 'roulette-community-engagement', title: 'Add a community Q&A feature to Roulette Community?', rationale: 'Drive returning traffic by letting users ask strategy questions and get AI-curated answers. Could leverage existing prompt pipeline.', options: ['Yes, scope it as a feature','Run a 2-week experiment first','Park — focus on existing strategy hub'], projectSlug: 'roulettecommunity' },
+  { slug: 'audit-log-retention', title: 'How long should audit_log rows be retained?', rationale: 'audit_log has grown ~2k rows/week. No retention policy yet. After 6 months it will dominate the SQLite file.', options: ['Keep 90 days, summarize older into monthly aggregates','Keep forever (compliance-leaning)','Keep 30 days, drop older'], projectSlug: null },
+] as const;
+
+function makeRationale(seed: SeedSuggestion): string {
+  return `${seed.rationale}\n\n${SEED_MARKER}${seed.slug}]`;
+}
+
+function isSeed(row: typeof proactiveSuggestions.$inferSelect, slug: string): boolean {
+  return row.rationale.includes(`${SEED_MARKER}${slug}]`);
+}
+
+export async function seedSuggestions(db: Db): Promise<{ inserted: number; skipped: number }> {
+  const now = new Date().toISOString();
+  const existing = db.select().from(proactiveSuggestions).all();
+  const seenSlugs = new Set<string>();
+  for (const row of existing) {
+    for (const seed of SEEDS) {
+      if (isSeed(row, seed.slug)) { seenSlugs.add(seed.slug); break; }
+    }
+  }
+  const projectRows = db.select({ id: projects.id, slug: projects.slug }).from(projects).all();
+  const projectIdBySlug = new Map(projectRows.map(r => [r.slug, r.id]));
+  let inserted = 0;
+  let skipped = 0;
+  for (const seed of SEEDS) {
+    if (seenSlugs.has(seed.slug)) { skipped++; continue; }
+    db.insert(proactiveSuggestions).values({
+      id: 'sug_' + nanoid(8),
+      title: seed.title,
+      rationale: makeRationale(seed),
+      options: JSON.stringify(seed.options),
+      state: 'pending',
+      projectId: seed.projectSlug ? projectIdBySlug.get(seed.projectSlug) ?? null : null,
+      scope: 'global',
+      createdAt: now,
+    }).run();
+    inserted++;
+  }
+  return { inserted, skipped };
+}
+
+export { SEEDS as SUGGESTION_SEEDS, SEED_MARKER as SUGGESTION_SEED_MARKER };

--- a/apps/orchestrator/tests/api/dash-302-303-seed-backfill.test.ts
+++ b/apps/orchestrator/tests/api/dash-302-303-seed-backfill.test.ts
@@ -1,0 +1,136 @@
+/**
+ * DASH-302 / DASH-303 — guard the features + suggestions seeders.
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import { eq } from 'drizzle-orm';
+import * as schema from '../../src/db/schema';
+import { businessFeatures, proactiveSuggestions, projects } from '../../src/db/schema';
+import { seedFeatures, FEATURE_SEEDS, FEATURE_SEED_MARKER } from '../../src/db/seed-features';
+import { seedSuggestions, SUGGESTION_SEEDS, SUGGESTION_SEED_MARKER } from '../../src/db/seed-suggestions';
+import { seedProjects } from '../../src/db/seed-projects';
+import type { Db } from '../../src/db/connection';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+let _mockRaw: Database.Database | null = null;
+jest.mock('../../src/db/connection', () => {
+  const actual = jest.requireActual<typeof import('../../src/db/connection')>('../../src/db/connection');
+  return {
+    ...actual,
+    getSqliteRaw: jest.fn(() => {
+      if (!_mockRaw) throw new Error('_mockRaw not set');
+      return _mockRaw;
+    }),
+  };
+});
+
+function createTestDb(): { db: Db; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  const db = drizzle(raw, { schema }) as Db;
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, raw };
+}
+
+describe('DASH-302 seedFeatures', () => {
+  let db: Db;
+  let raw: Database.Database;
+
+  beforeEach(async () => {
+    ({ db, raw } = createTestDb());
+    _mockRaw = raw;
+    await seedProjects(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+    _mockRaw = null;
+  });
+
+  it('inserts all seed rows on a fresh db', async () => {
+    expect(db.select().from(businessFeatures).all()).toHaveLength(0);
+    const result = await seedFeatures(db);
+    expect(result.inserted).toBe(FEATURE_SEEDS.length);
+    expect(result.skipped).toBe(0);
+    const after = db.select().from(businessFeatures).all();
+    expect(after).toHaveLength(FEATURE_SEEDS.length);
+    for (const row of after) {
+      expect(row.description).toContain(FEATURE_SEED_MARKER);
+    }
+  });
+
+  it('is idempotent — re-running inserts zero new rows', async () => {
+    await seedFeatures(db);
+    const second = await seedFeatures(db);
+    expect(second.inserted).toBe(0);
+    expect(second.skipped).toBe(FEATURE_SEEDS.length);
+  });
+
+  it('resolves project slugs to project ids', async () => {
+    await seedFeatures(db);
+    const pokerzenoProj = db.select().from(projects).where(eq(projects.slug, 'pokerzeno')).get();
+    expect(pokerzenoProj).toBeDefined();
+    const pokerzenoFeats = db.select().from(businessFeatures)
+      .where(eq(businessFeatures.projectId, pokerzenoProj!.id))
+      .all();
+    expect(pokerzenoFeats.length).toBeGreaterThan(0);
+  });
+});
+
+describe('DASH-303 seedSuggestions', () => {
+  let db: Db;
+  let raw: Database.Database;
+
+  beforeEach(async () => {
+    ({ db, raw } = createTestDb());
+    _mockRaw = raw;
+    await seedProjects(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+    _mockRaw = null;
+  });
+
+  it('inserts all seed rows on a fresh db, all in pending state', async () => {
+    const result = await seedSuggestions(db);
+    expect(result.inserted).toBe(SUGGESTION_SEEDS.length);
+    const after = db.select().from(proactiveSuggestions).all();
+    for (const row of after) {
+      expect(row.state).toBe('pending');
+      expect(row.rationale).toContain(SUGGESTION_SEED_MARKER);
+      const opts = JSON.parse(row.options) as unknown[];
+      expect(Array.isArray(opts)).toBe(true);
+      expect(opts.length).toBeGreaterThan(1);
+    }
+  });
+
+  it('is idempotent — re-running inserts zero new rows', async () => {
+    await seedSuggestions(db);
+    const second = await seedSuggestions(db);
+    expect(second.inserted).toBe(0);
+    expect(second.skipped).toBe(SUGGESTION_SEEDS.length);
+  });
+
+  it('does NOT touch user-created suggestions on re-run', async () => {
+    await seedSuggestions(db);
+    db.insert(proactiveSuggestions).values({
+      id: 'sug_user1',
+      title: 'User-created suggestion',
+      rationale: 'Real rationale, no marker.',
+      options: JSON.stringify(['yes', 'no']),
+      state: 'pending',
+      scope: 'global',
+      createdAt: new Date().toISOString(),
+    } as typeof proactiveSuggestions.$inferInsert).run();
+    const before = db.select().from(proactiveSuggestions).all().length;
+    const result = await seedSuggestions(db);
+    expect(result.inserted).toBe(0);
+    const after = db.select().from(proactiveSuggestions).all();
+    expect(after).toHaveLength(before);
+    const userRow = after.find(r => r.id === 'sug_user1');
+    expect(userRow).toBeDefined();
+  });
+});


### PR DESCRIPTION
Seed business_features (10 rows) and proactive_suggestions (8 rows) on every orchestrator boot so the dashboard's /features and /suggestions pages are non-empty out of the box. Closes the deferred items DASH-302 and DASH-303.

Both seeders are idempotent: rows are slug-keyed via a comment-marker embedded in description/rationale, so re-runs insert zero new rows and the seeders never touch user-created entries.

**DASH-302 — features:**
- 10 representative features tied to existing seeded projects (caia / pokerzeno / roulette).
- Includes shipped (gate-2 dashboard work), in-progress (MVP + obs rollout), and planned (local-llm-router) so the page is mixed-state.

**DASH-303 — suggestions:**
- 8 representative suggestions framed as questions with 3-4 options each.
- Topics span product (PokerZeno launch sweep, RC engagement) and platform (local-LLM routing, completeness cadence, audit retention).
- All start in pending state; the existing accept/custom routes are already wired so the dashboard becomes interactive immediately.

**Wiring:**
- start.ts calls seedFeatures(db) and seedSuggestions(db) after seedProjects(db) so project-id resolution succeeds. Logged inserted/skipped counts on first boot.

**Tests** (6 cases in dash-302-303-seed-backfill.test.ts, all green):
- Insert all rows on fresh db; mark via SEED_MARKER.
- Idempotent re-run: 0 inserted, all skipped.
- Resolves project slugs to ids.
- Pending state + parsed options array.
- Does NOT touch user-created suggestions on re-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API now automatically backfills features and suggestions datasets during initialization
  * Idempotent seeding prevents duplicate data insertion on subsequent startups

* **Chores**
  * API startup logs summary metrics for inserted and skipped rows during initialization

* **Tests**
  * Added test suite validating seeding behavior, idempotency, and data integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->