### PR TITLE
feat(orchestrator,dashboard): close out p2 polish bundle (DASH-308/309/313/314/315)

### DIFF
--- a/apps/dashboard/app/api/executor/config/route.ts
+++ b/apps/dashboard/app/api/executor/config/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const res = await fetch(`${CONDUCTOR_URL}/executor/config`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'unreachable' }, { status: 502 });
+  }
+}
+
+export async function GET() {
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/executor/config`, { next: { revalidate: 0 } });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'unreachable' }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/api/executor/pause/route.ts
+++ b/apps/dashboard/app/api/executor/pause/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function POST() {
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/executor/pause`, { method: 'POST' });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'unreachable' }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/api/executor/resume/route.ts
+++ b/apps/dashboard/app/api/executor/resume/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function POST() {
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/executor/resume`, { method: 'POST' });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'unreachable' }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/api/executor/status/route.ts
+++ b/apps/dashboard/app/api/executor/status/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function GET() {
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/executor/status`, { next: { revalidate: 0 } });
+    if (!res.ok) return NextResponse.json(null, { status: 200 });
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json(null, { status: 200 });
+  }
+}

--- a/apps/dashboard/app/dag/page.tsx
+++ b/apps/dashboard/app/dag/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+import useSWR from 'swr';
+import { DagView } from '../../components/DagView';
+
+/**
+ * DASH-309 — task-dependency DAG view.
+ *
+ * Reads from the orchestrator's GET /dag endpoint (added in this PR) and
+ * renders via the existing DagView component (mermaid + edge list). SWR
+ * polls every 30 s so the graph reflects priority/status changes without
+ * needing a fresh page load.
+ */
+const fetcher = (url: string) => fetch(url).then(r => r.json());
+
+interface DagData {
+  nodes: Array<{ id: string; title: string; status: string }>;
+  edges: Array<{ from: string; to: string }>;
+}
+
+export default function DagPage() {
+  const { data, isLoading } = useSWR<DagData>('/api/dag', fetcher, { refreshInterval: 30000 });
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 24 }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#f0f4f8' }}>
+          🕸️ Task Dependency Graph
+        </h1>
+        <span style={{ color: '#718096', fontSize: 13 }}>
+          {isLoading ? 'loading…' : `${data?.nodes?.length ?? 0} tasks · ${data?.edges?.length ?? 0} edges`}
+        </span>
+      </div>
+      <DagView dag={data} />
+      <div style={{ marginTop: 16, fontSize: 12, color: '#718096' }}>
+        Edges: <code>tasks.depends_on</code> → task.id. Use <code>?root=&lt;id&gt;</code> on the API for the connected cone.
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -35,13 +35,18 @@ const NAV_ITEMS = [
   { path: '/builds', label: 'Builds', icon: '🔨', tabKey: 'builds' },
   { path: '/observability/health', label: 'Obs. Health', icon: '👁', tabKey: 'obs_health' },
   { path: '/health/pulse', label: 'Pulse', icon: '💚', tabKey: 'pulse' },
+  { path: '/dag', label: 'Dependency Graph', icon: '🕸️', tabKey: 'dag' },
+  { path: '/quality', label: 'Quality', icon: '📊', tabKey: 'quality' },
   // /coverage retired from nav: conductor-specific Jest/Istanbul artifact
-  //   path. Replace with a CAIA-wide /quality page (DASH-314) once per-package
-  //   coverage aggregation is in place.
+  //   path. Replaced by the new /quality page above (DASH-314 Phase 1 —
+  //   surfaces orchestrator-wide quality signals; Phase 2 will add
+  //   per-package coverage from CI artifacts).
   // { path: '/coverage', label: 'Coverage', icon: '🎯', tabKey: 'coverage' },
   // /enforcement retired from nav: page is currently mocked (no
-  //   enforcement_rules table or backend route). Re-enable when DASH-308
-  //   ships the real backend.
+  //   enforcement_rules table or backend route). DASH-308 explicitly
+  //   defers the real backend (P2, large effort, out-of-MVP per gap
+  //   analysis). The route still works if hit directly. Re-enable this
+  //   nav entry when the enforcement_rules table + handlers ship.
   // { path: '/enforcement', label: 'Enforcement', icon: '🛡️', tabKey: 'enforcement' },
   { path: '/settings', label: 'Settings', icon: '⚙️', tabKey: 'settings' },
 ] as const;

--- a/apps/dashboard/app/quality/page.tsx
+++ b/apps/dashboard/app/quality/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+import useSWR from 'swr';
+
+/**
+ * DASH-314 — Quality dashboard (replaces retired conductor-specific
+ * /coverage page).
+ *
+ * Aggregates orchestrator-level quality signals into a single view:
+ *   - completeness summary (passing / failing entities, overall score)
+ *   - completeness findings count by severity
+ *   - test runs (behavior_tests if any) — currently a TODO until
+ *     CI emits per-package coverage artifacts (DASH-314 Phase 2)
+ *   - blocked tasks count
+ *
+ * The conductor-only `/coverage` page (which read a Jest/Istanbul
+ * coverage-summary.json from `dashboard/public/reports/coverage/`) is
+ * not appropriate at a CAIA-wide level — per-package coverage from CI
+ * artifacts is a separate workstream tracked by DASH-314 Phase 2.
+ */
+const fetcher = (url: string) => fetch(url).then(r => r.json());
+
+interface CompletenessSummary {
+  total: number;
+  passing: number;
+  failing: number;
+}
+interface Finding {
+  severity: string;
+}
+interface Metrics {
+  totalTasks: number;
+  completedTasks: number;
+  totalRequirements: number;
+  openBlockers: number;
+}
+
+function StatCard({ label, value, color }: { label: string; value: number | string; color?: string }) {
+  return (
+    <div style={{
+      background: '#1a1f2e', border: '1px solid #2d3748', borderRadius: 8,
+      padding: 20, textAlign: 'center',
+    }}>
+      <div style={{ fontSize: 32, fontWeight: 700, color: color ?? '#e2e8f0' }}>{value}</div>
+      <div style={{ fontSize: 12, color: '#718096', marginTop: 4 }}>{label}</div>
+    </div>
+  );
+}
+
+export default function QualityPage() {
+  const { data: summary } = useSWR<CompletenessSummary>(
+    '/api/completeness-summary-proxy', fetcher, { refreshInterval: 60000 }
+  );
+  const { data: findings } = useSWR<Finding[]>(
+    '/api/completeness-findings-proxy', fetcher, { refreshInterval: 60000 }
+  );
+  const { data: metrics } = useSWR<Metrics>('/api/metrics', fetcher, { refreshInterval: 60000 });
+
+  const overallScore = summary && summary.total > 0
+    ? Math.round((summary.passing / summary.total) * 100) : 0;
+  const completionPct = metrics && metrics.totalTasks > 0
+    ? Math.round((metrics.completedTasks / metrics.totalTasks) * 100) : 0;
+
+  const findingsBySeverity = (findings ?? []).reduce<Record<string, number>>((acc, f) => {
+    acc[f.severity] = (acc[f.severity] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 24 }}>
+        <h1 style={{ margin: 0, fontSize: 24, color: '#90cdf4' }}>📊 Quality</h1>
+        <span style={{ color: '#718096', fontSize: 14 }}>
+          orchestrator-wide quality signals
+        </span>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 16, marginBottom: 24 }}>
+        <StatCard
+          label="Completeness Score"
+          value={summary ? `${overallScore}%` : '—'}
+          color={overallScore >= 80 ? '#68d391' : overallScore >= 50 ? '#f6ad55' : '#fc8181'}
+        />
+        <StatCard label="Passing Entities" value={summary?.passing ?? '—'} color="#68d391" />
+        <StatCard label="Failing Entities" value={summary?.failing ?? '—'} color="#fc8181" />
+        <StatCard
+          label="Task Completion"
+          value={metrics ? `${completionPct}%` : '—'}
+          color={completionPct >= 50 ? '#68d391' : '#f6ad55'}
+        />
+        <StatCard label="Open Blockers" value={metrics?.openBlockers ?? '—'} color="#fc8181" />
+      </div>
+
+      <div style={{ background: '#1a1f2e', border: '1px solid #2d3748', borderRadius: 8, padding: 16, marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, color: '#e2e8f0', margin: '0 0 12px' }}>Findings by severity</h2>
+        <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+          {(['critical', 'warning', 'info'] as const).map(sev => (
+            <div key={sev}>
+              <span style={{
+                background: sev === 'critical' ? '#fc8181' : sev === 'warning' ? '#f6ad55' : '#68d391',
+                color: '#1a202c',
+                borderRadius: 4, padding: '2px 8px', fontSize: 11, fontWeight: 700,
+                textTransform: 'uppercase', marginRight: 8,
+              }}>{sev}</span>
+              <span style={{ color: '#e2e8f0', fontSize: 14, fontWeight: 600 }}>
+                {findingsBySeverity[sev] ?? 0}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ background: '#1a1f2e', border: '1px solid #2d3748', borderRadius: 8, padding: 16, color: '#a0aec0', fontSize: 13 }}>
+        <strong style={{ color: '#90cdf4' }}>Phase 2 (planned):</strong> per-package coverage from
+        CI artifacts (replaces the retired conductor-specific <code>/coverage</code> page). Until CI
+        emits coverage-summary.json artifacts that aggregate across the workspace, this page
+        surfaces orchestrator-wide quality signals only.
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/app/settings/page.tsx
+++ b/apps/dashboard/app/settings/page.tsx
@@ -1,19 +1,196 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+/**
+ * DASH-313 — Real settings page.
+ *
+ * Reads orchestrator config from `/api/executor/status` (which embeds
+ * the executor_config singleton + daemon liveness) and lets the user
+ * toggle pause/resume + adjust max_concurrent / circuit_breaker_threshold
+ * via PATCH /api/executor/config.
+ *
+ * Backend wiring (apps/orchestrator/src/api/routes/executor.ts):
+ *   POST /executor/pause | /executor/resume   — flips enabled
+ *   PATCH /executor/config                    — accepts max_concurrent,
+ *                                               circuit_breaker_threshold,
+ *                                               poll_interval_ms, max_turns
+ */
+
+interface ExecutorStatus {
+  enabled: boolean;
+  daemon_alive: boolean;
+  daemon_pid: number | null;
+  last_heartbeat_at: string | null;
+  running: number;
+  queued: number;
+  paused: number;
+  completed_24h: number;
+  config: {
+    enabled: boolean;
+    maxConcurrent: number;
+    circuitBreakerThreshold: number;
+    pollIntervalMs: number;
+    maxTurns: number;
+  };
+}
+
 export default function SettingsPage() {
+  const [status, setStatus] = useState<ExecutorStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [maxConcurrent, setMaxConcurrent] = useState<number>(3);
+  const [breakerThreshold, setBreakerThreshold] = useState<number>(3);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/executor/status');
+      if (res.ok) {
+        const data = await res.json() as ExecutorStatus;
+        setStatus(data);
+        if (data.config) {
+          setMaxConcurrent(data.config.maxConcurrent);
+          setBreakerThreshold(data.config.circuitBreakerThreshold);
+        }
+      }
+    } catch { /* silent */ }
+    setLoading(false);
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  const togglePauseResume = async () => {
+    if (!status) return;
+    setBusy(true);
+    try {
+      const path = status.enabled ? '/api/executor/pause' : '/api/executor/resume';
+      await fetch(path, { method: 'POST' });
+      setStatusMsg(status.enabled ? 'Executor paused' : 'Executor resumed');
+      await load();
+    } finally { setBusy(false); }
+  };
+
+  const saveConfig = async () => {
+    setBusy(true);
+    try {
+      await fetch('/api/executor/config', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          max_concurrent: maxConcurrent,
+          circuit_breaker_threshold: breakerThreshold,
+        }),
+      });
+      setStatusMsg('Config saved');
+      await load();
+    } finally { setBusy(false); }
+  };
+
   return (
     <div>
       <h1 style={{ margin: '0 0 16px', fontSize: 22, fontWeight: 700, color: '#f0f4f8' }}>⚙️ Settings</h1>
-      <p style={{ color: '#718096', fontSize: 14 }}>Configuration options coming soon.</p>
-      <div style={{ marginTop: 24, background: '#1a1f2e', borderRadius: 8, padding: 16, border: '1px solid #2d3748', maxWidth: 480 }}>
-        <div style={{ fontSize: 12, color: '#718096', marginBottom: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Backend</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontSize: 13, color: '#a0aec0' }}>API URL</span>
-          <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#63b3ed', marginLeft: 'auto' }}>http://localhost:7776</span>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
-          <span style={{ fontSize: 13, color: '#a0aec0' }}>WebSocket</span>
-          <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#63b3ed', marginLeft: 'auto' }}>ws://localhost:7776/events</span>
-        </div>
-      </div>
+
+      {loading ? (
+        <p style={{ color: '#718096' }}>Loading executor status…</p>
+      ) : !status ? (
+        <p style={{ color: '#fc8181' }}>Could not reach orchestrator. Is the API up at <code>localhost:7776</code>?</p>
+      ) : (
+        <>
+          {/* Backend connection card */}
+          <div style={{ marginBottom: 20, background: '#1a1f2e', borderRadius: 8, padding: 16, border: '1px solid #2d3748', maxWidth: 600 }}>
+            <div style={{ fontSize: 12, color: '#718096', marginBottom: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Backend</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 13, color: '#a0aec0' }}>API URL</span>
+              <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#63b3ed', marginLeft: 'auto' }}>http://localhost:7776</span>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
+              <span style={{ fontSize: 13, color: '#a0aec0' }}>WebSocket</span>
+              <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#63b3ed', marginLeft: 'auto' }}>ws://localhost:7776/events</span>
+            </div>
+          </div>
+
+          {/* Executor controls */}
+          <div data-test-region="executor-controls" style={{ marginBottom: 20, background: '#1a1f2e', borderRadius: 8, padding: 16, border: '1px solid #2d3748', maxWidth: 600 }}>
+            <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16 }}>
+              <span style={{ fontSize: 12, color: '#718096', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Executor</span>
+              <span style={{ marginLeft: 'auto', fontSize: 11, color: status.daemon_alive ? '#68d391' : '#fc8181' }}>
+                {status.daemon_alive ? `● daemon alive (pid ${status.daemon_pid})` : '○ daemon dead'}
+              </span>
+            </div>
+
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 16 }}>
+              <span style={{ fontSize: 13, color: '#a0aec0' }}>State</span>
+              <span style={{
+                marginLeft: 'auto', fontSize: 12, fontWeight: 700, padding: '4px 10px', borderRadius: 4,
+                background: status.enabled ? '#22543d' : '#742a2a', color: status.enabled ? '#9ae6b4' : '#feb2b2',
+              }}>{status.enabled ? 'RUNNING' : 'PAUSED'}</span>
+              <button
+                onClick={togglePauseResume}
+                disabled={busy}
+                aria-label={status.enabled ? 'Pause executor' : 'Resume executor'}
+                style={{
+                  background: status.enabled ? '#742a2a' : '#22543d', border: 'none', color: '#e2e8f0',
+                  borderRadius: 4, padding: '6px 14px', fontSize: 12, fontWeight: 600,
+                  cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.5 : 1,
+                }}
+              >
+                {status.enabled ? 'Pause' : 'Resume'}
+              </button>
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <label htmlFor="max-concurrent" style={{ fontSize: 13, color: '#a0aec0', display: 'block', marginBottom: 4 }}>
+                Max concurrent workers: <strong style={{ color: '#e2e8f0' }}>{maxConcurrent}</strong>
+              </label>
+              <input
+                id="max-concurrent"
+                type="range" min={1} max={10} step={1}
+                value={maxConcurrent}
+                onChange={e => setMaxConcurrent(parseInt(e.target.value, 10))}
+                style={{ width: '100%' }}
+              />
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <label htmlFor="breaker-threshold" style={{ fontSize: 13, color: '#a0aec0', display: 'block', marginBottom: 4 }}>
+                Circuit-breaker threshold (consecutive failures): <strong style={{ color: '#e2e8f0' }}>{breakerThreshold}</strong>
+              </label>
+              <input
+                id="breaker-threshold"
+                type="range" min={1} max={10} step={1}
+                value={breakerThreshold}
+                onChange={e => setBreakerThreshold(parseInt(e.target.value, 10))}
+                style={{ width: '100%' }}
+              />
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <button
+                onClick={saveConfig}
+                disabled={busy}
+                style={{
+                  background: '#2b6cb0', border: 'none', color: '#e2e8f0',
+                  borderRadius: 4, padding: '6px 14px', fontSize: 12, fontWeight: 600,
+                  cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.5 : 1,
+                }}
+              >Save config</button>
+              {statusMsg && <span style={{ color: '#68d391', fontSize: 11 }}>{statusMsg}</span>}
+            </div>
+          </div>
+
+          {/* Live counters */}
+          <div style={{ background: '#1a1f2e', borderRadius: 8, padding: 16, border: '1px solid #2d3748', maxWidth: 600 }}>
+            <div style={{ fontSize: 12, color: '#718096', marginBottom: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Live counters</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, fontSize: 13 }}>
+              <div><div style={{ color: '#a0aec0' }}>Running</div><div style={{ fontSize: 18, color: '#e2e8f0', fontWeight: 700 }}>{status.running}</div></div>
+              <div><div style={{ color: '#a0aec0' }}>Queued</div><div style={{ fontSize: 18, color: '#e2e8f0', fontWeight: 700 }}>{status.queued}</div></div>
+              <div><div style={{ color: '#a0aec0' }}>Paused</div><div style={{ fontSize: 18, color: '#f6ad55', fontWeight: 700 }}>{status.paused}</div></div>
+              <div><div style={{ color: '#a0aec0' }}>Done 24h</div><div style={{ fontSize: 18, color: '#68d391', fontWeight: 700 }}>{status.completed_24h}</div></div>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/hooks/useEventStream.ts
+++ b/apps/dashboard/hooks/useEventStream.ts
@@ -1,13 +1,22 @@
 'use client';
+/**
+ * DASH-315 — singleton-WS event stream consolidated onto parseWsMessage.
+ *
+ * Before this rewrite, useEventStream and useWebSocket implemented two
+ * different message-shape parsers (one assumed `data.kind`, the other
+ * `parseWsMessage` from useWebSocket.ts handled both legacy `kind` and
+ * canonical `type` envelopes). The duplication caused subtle bugs
+ * (DASH-101: layout badges silently dropping events emitted with `type`).
+ *
+ * This module now delegates parsing to `parseWsMessage` and re-exports
+ * the same `WsEvent` shape, with the only meaningful difference being
+ * that this hook maintains a process-singleton WebSocket so multiple
+ * components can share one connection.
+ */
 import { useEffect, useState } from 'react';
+import { parseWsMessage, type WsEvent } from './useWebSocket';
 
-export interface WsEvent {
-  kind: string;
-  id?: string;
-  projectId?: string;
-  payload?: unknown;
-  ts: string;
-}
+export type { WsEvent } from './useWebSocket';
 
 type EventListener = (event: WsEvent) => void;
 type ConnectedListener = (connected: boolean) => void;
@@ -46,12 +55,8 @@ function connectSingleton(url: string) {
     _ws.onerror = () => _ws?.close();
 
     _ws.onmessage = (msg) => {
-      try {
-        const data = JSON.parse(msg.data as string) as WsEvent;
-        if (data.kind !== 'connected') {
-          notifyEvent(data);
-        }
-      } catch { /* ignore parse errors */ }
+      const evt = parseWsMessage(msg.data as string);
+      if (evt) notifyEvent(evt);
     };
   } catch {
     _reconnectTimer = setTimeout(() => connectSingleton(url), 3000);
@@ -74,7 +79,6 @@ export function useEventStream() {
     _eventListeners.add(onEvent);
     _connectedListeners.add(onConnected);
 
-    // Sync initial state
     setConnected(_connected);
 
     return () => {

--- a/apps/orchestrator/src/api/app.ts
+++ b/apps/orchestrator/src/api/app.ts
@@ -24,6 +24,7 @@ import { registerStatsRoutes } from './routes/stats';
 import { registerAgentRoutes } from './routes/agents';
 import { registerBucketsRoutes } from './routes/buckets';
 import { registerMetricsPhase1Routes } from './routes/metrics-phase1';
+import { registerDagRoutes } from './routes/dag';
 import { promRegistry, httpRequestsTotal } from '../metrics/prometheus';
 
 export function createApp(db: Db): Hono {
@@ -71,6 +72,7 @@ export function createApp(db: Db): Hono {
   registerAgentRoutes(app, db);
   registerBucketsRoutes(app, db);
   registerMetricsPhase1Routes(app, db);
+  registerDagRoutes(app, db);
 
   return app;
 }

--- a/apps/orchestrator/src/api/routes/dag.ts
+++ b/apps/orchestrator/src/api/routes/dag.ts
@@ -1,0 +1,64 @@
+import type { Hono } from 'hono';
+import type { Db } from '../../db/connection';
+import { tasks } from '../../db/schema';
+
+/**
+ * DASH-309 — GET /dag
+ *
+ * Builds a tasks-DAG view ({nodes, edges}) from the `tasks.depends_on` JSON
+ * column. Used by the dashboard's `/dag` page (`DagView.tsx` component).
+ *
+ * Each row's `dependsOn` is a stringified JSON array of upstream task ids;
+ * the route emits one edge per `dep -> task.id` pair. Filters:
+ *   - root=<task_id> — restrict to the dependency cone reachable from `root`
+ *     (BFS over edges in either direction). Useful for very large queues.
+ *
+ * Terminal-status tasks (done/completed/failed/cancelled) are included so
+ * upstream history is visible — the consumer can filter client-side.
+ */
+// @no-events — read-only view, individual handlers do not emit events
+export function registerDagRoutes(app: Hono, db: Db): void {
+  app.get('/dag', (c) => {
+    const root = c.req.query('root');
+
+    const all = db.select({
+      id: tasks.id,
+      title: tasks.title,
+      status: tasks.status,
+      dependsOn: tasks.dependsOn,
+    }).from(tasks).all();
+
+    const nodes = all.map(t => ({ id: t.id, title: t.title, status: t.status }));
+
+    const edges: Array<{ from: string; to: string }> = [];
+    for (const t of all) {
+      let deps: string[] = [];
+      try { deps = JSON.parse(t.dependsOn) as string[]; } catch { deps = []; }
+      for (const dep of deps) {
+        edges.push({ from: dep, to: t.id });
+      }
+    }
+
+    if (!root) return c.json({ nodes, edges });
+
+    // BFS in both directions from `root` — collect connected ids.
+    const reachable = new Set<string>([root]);
+    const queue = [root];
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      for (const e of edges) {
+        if (e.from === cur && !reachable.has(e.to)) {
+          reachable.add(e.to); queue.push(e.to);
+        }
+        if (e.to === cur && !reachable.has(e.from)) {
+          reachable.add(e.from); queue.push(e.from);
+        }
+      }
+    }
+
+    return c.json({
+      nodes: nodes.filter(n => reachable.has(n.id)),
+      edges: edges.filter(e => reachable.has(e.from) && reachable.has(e.to)),
+    });
+  });
+}

--- a/apps/orchestrator/tests/api/dash-309-dag.test.ts
+++ b/apps/orchestrator/tests/api/dash-309-dag.test.ts
@@ -1,0 +1,117 @@
+/**
+ * DASH-309 — guard the GET /dag route.
+ *
+ * The dashboard's /dag page (in apps/dashboard/app/dag/page.tsx) renders
+ * a mermaid graph from this endpoint. Contract pinned here:
+ *   - returns { nodes: {id,title,status}[], edges: {from,to}[] }
+ *   - edges built from tasks.depends_on JSON arrays
+ *   - root=<id> filter does a bidirectional BFS
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import { Hono } from 'hono';
+import * as schema from '../../src/db/schema';
+import { tasks } from '../../src/db/schema';
+import { registerDagRoutes } from '../../src/api/routes/dag';
+import type { Db } from '../../src/db/connection';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+let _mockRaw: Database.Database | null = null;
+jest.mock('../../src/db/connection', () => {
+  const actual = jest.requireActual<typeof import('../../src/db/connection')>('../../src/db/connection');
+  return {
+    ...actual,
+    getSqliteRaw: jest.fn(() => {
+      if (!_mockRaw) throw new Error('_mockRaw not set');
+      return _mockRaw;
+    }),
+  };
+});
+
+function createTestDb(): { db: Db; raw: Database.Database } {
+  const raw = new Database(':memory:');
+  const db = drizzle(raw, { schema }) as Db;
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, raw };
+}
+
+function makeTask(id: string, deps: string[] = []): typeof tasks.$inferInsert {
+  return {
+    id, title: `Task ${id}`, status: 'queued', cwd: '/',
+    declaredFiles: '[]', dependsOn: JSON.stringify(deps),
+    paused: false, attemptCount: 0,
+    createdAt: new Date().toISOString(),
+  } as typeof tasks.$inferInsert;
+}
+
+describe('DASH-309 GET /dag', () => {
+  let db: Db;
+  let raw: Database.Database;
+  let app: Hono;
+
+  beforeEach(() => {
+    ({ db, raw } = createTestDb());
+    _mockRaw = raw;
+    app = new Hono();
+    registerDagRoutes(app, db);
+  });
+
+  afterEach(() => {
+    raw.close();
+    _mockRaw = null;
+  });
+
+  it('returns empty arrays when there are no tasks', async () => {
+    const res = await app.request('/dag');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { nodes: unknown[]; edges: unknown[] };
+    expect(body.nodes).toEqual([]);
+    expect(body.edges).toEqual([]);
+  });
+
+  it('builds nodes + edges from tasks.depends_on', async () => {
+    db.insert(tasks).values(makeTask('a')).run();
+    db.insert(tasks).values(makeTask('b', ['a'])).run();
+    db.insert(tasks).values(makeTask('c', ['a', 'b'])).run();
+
+    const res = await app.request('/dag');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { nodes: Array<{ id: string }>; edges: Array<{ from: string; to: string }> };
+    expect(body.nodes).toHaveLength(3);
+    expect(body.edges).toHaveLength(3);
+    expect(body.edges).toEqual(expect.arrayContaining([
+      { from: 'a', to: 'b' },
+      { from: 'a', to: 'c' },
+      { from: 'b', to: 'c' },
+    ]));
+  });
+
+  it('?root=<id> restricts to the connected cone (BFS in both directions)', async () => {
+    // Two disconnected components: a→b→c, and x→y
+    db.insert(tasks).values(makeTask('a')).run();
+    db.insert(tasks).values(makeTask('b', ['a'])).run();
+    db.insert(tasks).values(makeTask('c', ['b'])).run();
+    db.insert(tasks).values(makeTask('x')).run();
+    db.insert(tasks).values(makeTask('y', ['x'])).run();
+
+    const res = await app.request('/dag?root=b');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { nodes: Array<{ id: string }>; edges: unknown[] };
+    const ids = body.nodes.map(n => n.id).sort();
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+
+  it('skips edges that reference non-existent task ids gracefully', async () => {
+    db.insert(tasks).values(makeTask('a', ['ghost'])).run();
+    const res = await app.request('/dag');
+    expect(res.status).toBe(200);
+    const body = await res.json() as { nodes: Array<{ id: string }>; edges: Array<{ from: string; to: string }> };
+    // The ghost edge is still emitted (DAG view shows hanging edges) but
+    // there's only one real node.
+    expect(body.nodes.map(n => n.id)).toEqual(['a']);
+    expect(body.edges).toEqual([{ from: 'ghost', to: 'a' }]);
+  });
+});


### PR DESCRIPTION
Close out the deferred P2 polish items from the gap analysis. Five DASH IDs in one PR — they're tightly-related fit-and-finish work and share no overlapping files.

**DASH-309 — GET /dag + /dag page:**
- New `apps/orchestrator/src/api/routes/dag.ts` builds `{nodes, edges}` from `tasks.depends_on`; supports `?root=<id>` bidirectional BFS for large queues.
- New `apps/dashboard/app/dag/page.tsx` wraps the existing `DagView` component with SWR 30s refresh.
- Nav entry added. Tests in `dash-309-dag.test.ts` (4 cases, all green).

**DASH-313 — Real /settings page:**
- Replaces placeholder at `apps/dashboard/app/settings/page.tsx` with executor-config UI: pause/resume button, `max_concurrent` slider, circuit-breaker-threshold slider, save button, live counters (running/queued/paused/done-24h).
- Reads `/api/executor/status`, writes via `/api/executor/config` (PATCH) and `/api/executor/pause | /resume` (POST). Four new dashboard API proxy routes added to wire to existing orchestrator endpoints.

**DASH-314 — /quality page (replaces retired /coverage):**
- New `apps/dashboard/app/quality/page.tsx` aggregates orchestrator-wide quality signals: completeness score, passing/failing entities, task completion %, open blockers, findings by severity.
- Phase 2 (per-package coverage from CI artifacts) is explicitly noted as future work — that requires a CI workflow change which is out of scope.
- Nav entry added; `/coverage` retirement comment in `layout.tsx` updated to point at the new `/quality` page.

**DASH-315 — Hook consolidation (useEventStream + useWebSocket):**
- `apps/dashboard/hooks/useEventStream.ts` now delegates parsing to `parseWsMessage` from `useWebSocket.ts`. Eliminates the duplicate message parser that originally caused the DASH-101 envelope-shape bug. Preserves the singleton-WS behavior so multiple components share one connection.

**DASH-308 — /enforcement deferral (no code change):**
- Retirement comment in `layout.tsx` is updated with explicit language: "DASH-308 explicitly defers the real backend (P2, large effort, out-of-MVP per gap analysis)". The route still works if hit directly; the page is mocked and stays out of nav until the `enforcement_rules` table + handlers ship.

**DoD:**
- TypeScript clean (`tsc --noEmit` on dashboard).
- 4 new jest cases pass (`dash-309-dag.test.ts`).
- No nav additions beyond `/dag` + `/quality`.
- No scope creep beyond the deferred items.
