### PR TITLE
feat(local-llm-router): model catalog + 14B-class model support (LAI-001)

### DIFF
--- a/packages/local-llm-router/README.md
+++ b/packages/local-llm-router/README.md
@@ -51,6 +51,33 @@ Unknown task types default to Claude Sonnet for safety.
 
 The adapter pins IPv4 explicitly because on macOS `localhost` often resolves to `::1` first, and a stray IPv6 listener (e.g., an SSH tunnel) on port 11434 will silently route requests to the wrong daemon.
 
+## Model catalog (LAI-001)
+
+`MODEL_CATALOG` is the typed registry of every local model the router knows about — parameter count, runtime RAM, on-disk size, role, and the right endpoint to call. It does **not** drive routing decisions on its own; LAI-005 wires roles into rules.
+
+To pull the catalog's recommended set on an M1 Pro 16GB:
+
+```bash
+ollama pull qwen2.5-coder:7b      # baseline coder (already in use)
+ollama pull llama3.1:8b           # baseline generalist (already in use)
+ollama pull qwen2.5-coder:14b     # bigger coder for multi-file edits
+ollama pull qwen3:14b             # 14B-class generalist (chat + think:false)
+ollama pull phi4                  # math/STEM specialist
+ollama pull nomic-embed-text      # embeddings for RAG / cache
+```
+
+Caveat — Qwen3 emits chain-of-thought tokens by default. Always call it via `/api/chat` with `think: false` (or prefix prompts with `/no_think`); calling `/api/generate` returns empty responses.
+
+### Benchmarking
+
+Run every catalog model that's pulled against a small classification fixture and print latency + tokens/sec:
+
+```bash
+pnpm --filter @chiefaia/local-llm-router run bench
+```
+
+The script silently skips models that aren't pulled, so it's safe to run on any machine.
+
 ## Testing
 
 ```bash

--- a/packages/local-llm-router/package.json
+++ b/packages/local-llm-router/package.json
@@ -26,7 +26,7 @@
     "@chiefaia/tsconfig": "workspace:*",
     "@chiefaia/vitest-config": "workspace:*",
     "@types/node": "^20",
-    "ts-node": "^10.9.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
   },

--- a/packages/local-llm-router/package.json
+++ b/packages/local-llm-router/package.json
@@ -18,13 +18,15 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint src",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "bench": "TS_NODE_PROJECT=tsconfig.bench.json TS_NODE_TRANSPILE_ONLY=1 ts-node --transpile-only scripts/benchmark-catalog.ts"
   },
   "devDependencies": {
     "@chiefaia/eslint-config": "workspace:*",
     "@chiefaia/tsconfig": "workspace:*",
     "@chiefaia/vitest-config": "workspace:*",
     "@types/node": "^20",
+    "ts-node": "^10.9.0",
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
   },

--- a/packages/local-llm-router/scripts/benchmark-catalog.ts
+++ b/packages/local-llm-router/scripts/benchmark-catalog.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env ts-node
+// Benchmark every catalog model against a small classification fixture and
+// print a comparison table (latency, eval count, tok/s, response sample).
+//
+// Usage:
+//   pnpm --filter @chiefaia/local-llm-router run bench
+//   OLLAMA_BASE_URL=http://127.0.0.1:11434 \
+//     npx ts-node --esm scripts/benchmark-catalog.ts
+//
+// Models are skipped silently when not pulled locally so the script is safe
+// to run on any machine — it'll just benchmark whatever is available.
+//
+// This is part of LAI-001 (pull better models). LAI-005 (routing-rule
+// enrichment) extends the fixture with task-specific prompts and quality
+// scoring against a Claude-baseline.
+
+import { MODEL_CATALOG, type LocalModel } from '../src/model-catalog';
+
+const OLLAMA_BASE_URL =
+  process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+
+const FIXTURE_PROMPT =
+  'Reply with a single word — the most likely domain for "user signs in with email": auth, ui, payments, or other.';
+
+interface BenchResult {
+  tag: string;
+  role: string;
+  endpoint: string;
+  durationMs: number;
+  evalCount: number;
+  tokensPerSec: number;
+  response: string;
+  ok: boolean;
+  error?: string;
+}
+
+interface OllamaModelEntry {
+  name: string;
+}
+interface OllamaTagsResponse {
+  models?: OllamaModelEntry[];
+}
+interface OllamaGenerateResponse {
+  response: string;
+  total_duration?: number;
+  eval_count?: number;
+}
+interface OllamaChatResponse {
+  message?: { content?: string };
+  total_duration?: number;
+  eval_count?: number;
+}
+interface OllamaEmbeddingsResponse {
+  embedding: number[];
+}
+
+async function pulledModelTags(): Promise<Set<string>> {
+  const res = await fetch(`${OLLAMA_BASE_URL}/api/tags`);
+  if (!res.ok) throw new Error(`/api/tags returned ${res.status}`);
+  const data = (await res.json()) as OllamaTagsResponse;
+  return new Set((data.models ?? []).map((m) => m.name));
+}
+
+async function benchGenerate(model: LocalModel): Promise<BenchResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: model.tag,
+        prompt: FIXTURE_PROMPT,
+        stream: false,
+        options: { num_predict: 30, temperature: 0 },
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
+    if (!res.ok) {
+      return resultFromError(model, Date.now() - start, `HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as OllamaGenerateResponse;
+    return resultFromOk(
+      model,
+      Date.now() - start,
+      data.eval_count ?? 0,
+      data.response.trim(),
+    );
+  } catch (err) {
+    return resultFromError(model, Date.now() - start, String(err));
+  }
+}
+
+async function benchChatNoThink(model: LocalModel): Promise<BenchResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: model.tag,
+        messages: [{ role: 'user', content: FIXTURE_PROMPT }],
+        stream: false,
+        // Suppresses Qwen3's chain-of-thought; harmless for non-think models.
+        think: false,
+        options: { num_predict: 30, temperature: 0 },
+      }),
+      signal: AbortSignal.timeout(120_000),
+    });
+    if (!res.ok) {
+      return resultFromError(model, Date.now() - start, `HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as OllamaChatResponse;
+    return resultFromOk(
+      model,
+      Date.now() - start,
+      data.eval_count ?? 0,
+      (data.message?.content ?? '').trim(),
+    );
+  } catch (err) {
+    return resultFromError(model, Date.now() - start, String(err));
+  }
+}
+
+async function benchEmbeddings(model: LocalModel): Promise<BenchResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(`${OLLAMA_BASE_URL}/api/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: model.tag,
+        prompt: FIXTURE_PROMPT,
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!res.ok) {
+      return resultFromError(model, Date.now() - start, `HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as OllamaEmbeddingsResponse;
+    return resultFromOk(
+      model,
+      Date.now() - start,
+      data.embedding.length,
+      `dim=${data.embedding.length}`,
+    );
+  } catch (err) {
+    return resultFromError(model, Date.now() - start, String(err));
+  }
+}
+
+function resultFromOk(
+  model: LocalModel,
+  durationMs: number,
+  evalCount: number,
+  response: string,
+): BenchResult {
+  const seconds = durationMs / 1000;
+  return {
+    tag: model.tag,
+    role: model.role,
+    endpoint: model.endpoint,
+    durationMs,
+    evalCount,
+    tokensPerSec: seconds > 0 ? evalCount / seconds : 0,
+    response: response.slice(0, 60),
+    ok: true,
+  };
+}
+
+function resultFromError(
+  model: LocalModel,
+  durationMs: number,
+  error: string,
+): BenchResult {
+  return {
+    tag: model.tag,
+    role: model.role,
+    endpoint: model.endpoint,
+    durationMs,
+    evalCount: 0,
+    tokensPerSec: 0,
+    response: '',
+    ok: false,
+    error,
+  };
+}
+
+async function main(): Promise<void> {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[bench] OLLAMA_BASE_URL=${OLLAMA_BASE_URL}, fixture="${FIXTURE_PROMPT}"`,
+  );
+
+  let pulled: Set<string>;
+  try {
+    pulled = await pulledModelTags();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[bench] could not reach Ollama at ${OLLAMA_BASE_URL}: ${String(err)}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const results: BenchResult[] = [];
+  for (const model of MODEL_CATALOG) {
+    if (!pulled.has(model.tag) && !pulled.has(`${model.tag}:latest`)) {
+      // eslint-disable-next-line no-console
+      console.log(`[bench] skipping ${model.tag} (not pulled)`);
+      continue;
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[bench] running ${model.tag} via ${model.endpoint} ...`);
+    let result: BenchResult;
+    if (model.endpoint === 'chat') {
+      result = await benchChatNoThink(model);
+    } else if (model.endpoint === 'embeddings') {
+      result = await benchEmbeddings(model);
+    } else {
+      result = await benchGenerate(model);
+    }
+    results.push(result);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('\n=== Benchmark results ===');
+  // eslint-disable-next-line no-console
+  console.log(
+    'tag'.padEnd(24) +
+      'role'.padEnd(14) +
+      'endpoint'.padEnd(12) +
+      'ms'.padStart(7) +
+      'tok'.padStart(6) +
+      'tok/s'.padStart(8) +
+      '  response',
+  );
+  for (const r of results) {
+    const line =
+      r.tag.padEnd(24) +
+      r.role.padEnd(14) +
+      r.endpoint.padEnd(12) +
+      String(r.durationMs).padStart(7) +
+      String(r.evalCount).padStart(6) +
+      r.tokensPerSec.toFixed(1).padStart(8) +
+      '  ' +
+      (r.ok ? r.response : `ERR: ${r.error ?? 'unknown'}`);
+    // eslint-disable-next-line no-console
+    console.log(line);
+  }
+}
+
+main().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/local-llm-router/src/index.ts
+++ b/packages/local-llm-router/src/index.ts
@@ -4,6 +4,13 @@ export { route, __setAdapters } from './router.js';
 export { OllamaAdapter } from './ollama-adapter.js';
 export { ClaudeAdapter } from './claude-adapter.js';
 export { getRoute, ROUTING_RULES, COST_ANALYSIS } from './routing-config.js';
+export {
+  MODEL_CATALOG,
+  getModel,
+  modelsByRole,
+  totalRuntimeRamGB,
+  M1_PRO_USABLE_MODEL_RAM_GB,
+} from './model-catalog.js';
 export type {
   LLMProvider,
   LLMRequest,
@@ -12,3 +19,8 @@ export type {
 } from './types.js';
 
 export type { RoutingRule } from './routing-config.js';
+export type {
+  LocalModel,
+  ModelRole,
+  EndpointKind,
+} from './model-catalog.js';

--- a/packages/local-llm-router/src/model-catalog.ts
+++ b/packages/local-llm-router/src/model-catalog.ts
@@ -1,0 +1,185 @@
+// Model catalog for @chiefaia/local-llm-router (LAI-001)
+//
+// A typed registry of every local Ollama model the router knows about, with
+// the metadata needed to pick the right one for a given task: parameter
+// count, runtime RAM at Q4_K_M, on-disk size, role, and whether the chat or
+// generate endpoint is preferred.
+//
+// This module is purely informational — it does NOT change routing decisions.
+// LAI-005 (routing-rule enrichment) will use this catalog to add new task
+// types backed by 14B-class models.
+
+export type ModelRole =
+  /** Strong general-purpose chat / instruction following */
+  | 'generalist'
+  /** Specialized for code generation / completion */
+  | 'coder'
+  /** Optimized for math / STEM / reasoning chains */
+  | 'reasoning'
+  /** Long-context (>=64k tokens) */
+  | 'long-context'
+  /** Generates text embeddings, not text completions */
+  | 'embeddings';
+
+export type EndpointKind =
+  /** /api/generate — flat text completion */
+  | 'generate'
+  /** /api/chat — message-based, supports `think:false` for Qwen3 */
+  | 'chat'
+  /** /api/embeddings */
+  | 'embeddings';
+
+export interface LocalModel {
+  /** Ollama tag, e.g. "qwen3:14b" */
+  tag: string;
+  /** Approximate parameter count (e.g. "14B", "137M") */
+  params: string;
+  /**
+   * Approximate runtime RAM at Q4_K_M, in GB. Used to budget concurrent loads
+   * on a 16GB M1 Pro (usable model RAM ≈ 10–12 GB after OS overhead).
+   */
+  runtimeRamGB: number;
+  /** Approximate on-disk size in GB (Q4_K_M unless noted) */
+  diskSizeGB: number;
+  /** What this model is good at */
+  role: ModelRole;
+  /** Which Ollama endpoint to use for best results */
+  endpoint: EndpointKind;
+  /**
+   * For Qwen3 family: whether the model emits "thinking" tokens by default.
+   * When true, callers should use the chat endpoint with `think:false`
+   * (or include `/no_think` in the prompt) to suppress the chain of thought
+   * and reduce wall-clock latency.
+   */
+  emitsThinkingByDefault?: boolean;
+  /** One-line summary of why we keep this model in the catalog */
+  notes: string;
+}
+
+/**
+ * Models known to the router. Order is loosely "smallest to largest within role".
+ *
+ * To add a model: pull it (`ollama pull <tag>`), verify it loads with a
+ * smoke prompt, measure runtime RAM via `ollama ps`, then add an entry here.
+ */
+export const MODEL_CATALOG: readonly LocalModel[] = [
+  // ─── coders ───────────────────────────────────────────────────────────────
+  {
+    tag: 'qwen2.5-coder:7b',
+    params: '7B',
+    runtimeRamGB: 4.5,
+    diskSizeGB: 4.7,
+    role: 'coder',
+    endpoint: 'generate',
+    notes:
+      'Default low-latency coder. Strong on HumanEval (88%); used as the ' +
+      'fast path for classification, dedup, and small enrichment tasks.',
+  },
+  {
+    tag: 'qwen2.5-coder:14b',
+    params: '14B',
+    runtimeRamGB: 8.5,
+    diskSizeGB: 9.0,
+    role: 'coder',
+    endpoint: 'generate',
+    notes:
+      'Bigger coder. Marginal gain on HumanEval over the 7B variant; reach ' +
+      'for it on multi-file edits or longer code reviews where 7B drops ' +
+      'context.',
+  },
+
+  // ─── generalists ──────────────────────────────────────────────────────────
+  {
+    tag: 'llama3.1:8b',
+    params: '8B',
+    runtimeRamGB: 5.5,
+    diskSizeGB: 4.9,
+    role: 'generalist',
+    endpoint: 'generate',
+    notes:
+      'Existing generalist. Used for changelog and status summarization; ' +
+      'kept as a fallback when newer models OOM or stall.',
+  },
+  {
+    tag: 'qwen3:14b',
+    params: '14B',
+    runtimeRamGB: 9.3,
+    diskSizeGB: 9.3,
+    role: 'generalist',
+    endpoint: 'chat',
+    emitsThinkingByDefault: true,
+    notes:
+      'Strongest 14B-class generalist on M1 Pro. Emits chain-of-thought by ' +
+      'default — call via /api/chat with think:false (or prefix prompts with ' +
+      '/no_think) to keep latency low. Reach for it on harder reasoning that ' +
+      'we currently route to Claude Sonnet.',
+  },
+  {
+    tag: 'mistral-nemo:12b',
+    params: '12B',
+    runtimeRamGB: 7.0,
+    diskSizeGB: 7.1,
+    role: 'long-context',
+    endpoint: 'generate',
+    notes:
+      '128k context window. Use for whole-file summarization or long memory ' +
+      'rollups where stuffing the prompt into a 32k window would truncate. ' +
+      'NOTE: pull on demand — not yet pre-pulled by LAI-001.',
+  },
+
+  // ─── reasoning ────────────────────────────────────────────────────────────
+  {
+    tag: 'phi4',
+    params: '14B',
+    runtimeRamGB: 9.1,
+    diskSizeGB: 9.1,
+    role: 'reasoning',
+    endpoint: 'generate',
+    notes:
+      'Microsoft Phi-4. GPT-4o-mini-class on MATH and GPQA benchmarks. ' +
+      'Reach for it on STEM / formal-reasoning tasks; weaker on raw code ' +
+      'generation than the qwen2.5-coder family.',
+  },
+
+  // ─── embeddings ───────────────────────────────────────────────────────────
+  {
+    tag: 'nomic-embed-text',
+    params: '137M',
+    runtimeRamGB: 0.3,
+    diskSizeGB: 0.27,
+    role: 'embeddings',
+    endpoint: 'embeddings',
+    notes:
+      'Default embeddings model. 768-dim output, fast (sub-100ms on M1 Pro). ' +
+      'Used by LAI-003 (@chiefaia/local-rag) and LAI-004 (@chiefaia/llm-cache).',
+  },
+];
+
+/** Index models by tag for O(1) lookup. */
+const _byTag = new Map<string, LocalModel>(
+  MODEL_CATALOG.map((m) => [m.tag, m]),
+);
+
+/** Look up a model by its Ollama tag. Returns undefined if unknown. */
+export function getModel(tag: string): LocalModel | undefined {
+  return _byTag.get(tag);
+}
+
+/** Return all catalog entries with a given role. */
+export function modelsByRole(role: ModelRole): LocalModel[] {
+  return MODEL_CATALOG.filter((m) => m.role === role);
+}
+
+/**
+ * Total runtime RAM if every catalog model were loaded simultaneously.
+ * Useful for a "fits-on-this-machine?" sanity check.
+ */
+export function totalRuntimeRamGB(): number {
+  return MODEL_CATALOG.reduce((sum, m) => sum + m.runtimeRamGB, 0);
+}
+
+/**
+ * Hardware budget M1 Pro 16GB unified RAM, leaving ~5 GB for OS + editor.
+ * Used by tests to detect catalog drift past the hardware ceiling.
+ */
+export const M1_PRO_USABLE_MODEL_RAM_GB = 11;

--- a/packages/local-llm-router/tests/model-catalog.test.ts
+++ b/packages/local-llm-router/tests/model-catalog.test.ts
@@ -1,0 +1,133 @@
+// Unit tests for the model catalog (LAI-001).
+
+import { describe, it, expect } from 'vitest';
+import {
+  MODEL_CATALOG,
+  getModel,
+  modelsByRole,
+  totalRuntimeRamGB,
+  M1_PRO_USABLE_MODEL_RAM_GB,
+} from '../src/model-catalog.js';
+
+describe('model-catalog', () => {
+  describe('MODEL_CATALOG', () => {
+    it('has at least one model per role we route on today', () => {
+      const roles = new Set(MODEL_CATALOG.map((m) => m.role));
+      expect(roles.has('coder')).toBe(true);
+      expect(roles.has('generalist')).toBe(true);
+      expect(roles.has('reasoning')).toBe(true);
+      expect(roles.has('embeddings')).toBe(true);
+    });
+
+    it('every entry has a non-empty tag and notes', () => {
+      for (const m of MODEL_CATALOG) {
+        expect(m.tag.length).toBeGreaterThan(0);
+        expect(m.notes.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('every entry declares positive RAM and disk usage', () => {
+      for (const m of MODEL_CATALOG) {
+        expect(m.runtimeRamGB).toBeGreaterThan(0);
+        expect(m.diskSizeGB).toBeGreaterThan(0);
+      }
+    });
+
+    it('uses unique tags', () => {
+      const tags = MODEL_CATALOG.map((m) => m.tag);
+      expect(new Set(tags).size).toBe(tags.length);
+    });
+
+    it('flags qwen3 as emitting thinking tokens by default', () => {
+      // Belt-and-braces: anyone routing through qwen3 needs to know to send
+      // think:false via the chat endpoint, otherwise responses come back
+      // empty and eval_count is consumed by chain-of-thought tokens.
+      const qwen3 = getModel('qwen3:14b');
+      expect(qwen3?.emitsThinkingByDefault).toBe(true);
+      expect(qwen3?.endpoint).toBe('chat');
+    });
+
+    it('keeps the existing baseline models in the catalog', () => {
+      // Don't drop these without consciously updating routing rules.
+      expect(getModel('qwen2.5-coder:7b')).toBeDefined();
+      expect(getModel('llama3.1:8b')).toBeDefined();
+    });
+
+    it('includes the new LAI-001 14B-class additions', () => {
+      expect(getModel('qwen3:14b')).toBeDefined();
+      expect(getModel('phi4')).toBeDefined();
+      expect(getModel('qwen2.5-coder:14b')).toBeDefined();
+    });
+
+    it('includes an embeddings model for RAG / cache work', () => {
+      const embeddings = modelsByRole('embeddings');
+      expect(embeddings.length).toBeGreaterThan(0);
+      expect(embeddings.some((m) => m.tag === 'nomic-embed-text')).toBe(true);
+    });
+
+    it('every chat-endpoint model that emits thinking declares it', () => {
+      // If we add another chain-of-thought model later, force the catalog
+      // entry to spell out the behaviour rather than rely on caller heuristics.
+      for (const m of MODEL_CATALOG) {
+        if (m.emitsThinkingByDefault) {
+          expect(m.endpoint).toBe('chat');
+        }
+      }
+    });
+  });
+
+  describe('getModel', () => {
+    it('returns the entry for a known tag', () => {
+      const m = getModel('qwen2.5-coder:7b');
+      expect(m?.tag).toBe('qwen2.5-coder:7b');
+      expect(m?.role).toBe('coder');
+    });
+
+    it('returns undefined for an unknown tag', () => {
+      expect(getModel('does-not-exist:100b')).toBeUndefined();
+    });
+  });
+
+  describe('modelsByRole', () => {
+    it('returns only models matching the requested role', () => {
+      const coders = modelsByRole('coder');
+      expect(coders.length).toBeGreaterThan(0);
+      for (const m of coders) {
+        expect(m.role).toBe('coder');
+      }
+    });
+
+    it('returns an empty array when no model fits the role', () => {
+      // No long-context-only models are required by LAI-001; this guards
+      // the call shape in case the catalog regresses in either direction.
+      const result = modelsByRole('long-context');
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('hardware budget', () => {
+    it('records a plausible ceiling for M1 Pro 16GB unified RAM', () => {
+      // Sanity: leaving ~5 GB for OS + editor on a 16 GB machine.
+      expect(M1_PRO_USABLE_MODEL_RAM_GB).toBeGreaterThanOrEqual(8);
+      expect(M1_PRO_USABLE_MODEL_RAM_GB).toBeLessThanOrEqual(13);
+    });
+
+    it('individual catalog entries fit within the M1 Pro budget', () => {
+      // We knowingly catalog several 14B-class models. Each one alone must
+      // fit in the budget; concurrent loading is the router's responsibility,
+      // not the catalog's.
+      for (const m of MODEL_CATALOG) {
+        expect(m.runtimeRamGB).toBeLessThanOrEqual(
+          M1_PRO_USABLE_MODEL_RAM_GB,
+        );
+      }
+    });
+
+    it('flags catalog drift if total RAM exceeds available disk', () => {
+      // M1 Pro currently has 85 GB free disk; this is a soft tripwire — if
+      // we ever catalog so many models that we'd run out of disk on a fresh
+      // machine, force a conscious decision.
+      expect(totalRuntimeRamGB()).toBeLessThan(60);
+    });
+  });
+});

--- a/packages/local-llm-router/tsconfig.bench.json
+++ b/packages/local-llm-router/tsconfig.bench.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src", "scripts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.39
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
       typescript:
         specifier: ^5.4.5
         version: 5.9.3


### PR DESCRIPTION
## What

Pulls four new local models on the M1 Pro 16GB host and adds a typed registry — `MODEL_CATALOG` — that records each one's parameter count, runtime RAM, on-disk size, role, and the right Ollama endpoint to call.

New models pulled:
- `qwen3:14b` — strongest 14B-class generalist; reasoning + coding
- `phi4` — math/STEM specialist (GPT-4o-mini-class on MATH/GPQA)
- `qwen2.5-coder:14b` — bigger coder, optional upgrade over the 7B baseline
- `nomic-embed-text` — embeddings model for LAI-003 (RAG) and LAI-004 (cache)

Total disk added: ~28 GB. M1 Pro hardware budget: each model fits within 11 GB usable RAM (asserted in tests).

## Why

Step 1 of the local-AI 2-5x research push (see `/reports/local-ai-2x-5x-research-2026-04-28.md`). Without bigger / specialized models, we're stuck routing reasoning-heavy work to Claude. With them in the catalog, LAI-005 can promote rules from Claude→local backed by quality benchmarks.

## Important caveat — Qwen3 thinking mode

Qwen3 emits chain-of-thought tokens by default. The catalog flags this (`emitsThinkingByDefault: true`) so callers know to use `/api/chat` with `think: false`. Calling `/api/generate` returns empty responses — the bench script demonstrates the correct call shape.

## Scope

Purely additive — no existing routing rules change, no behavior change for current callers.

```ts
import { MODEL_CATALOG, getModel } from '@chiefaia/local-llm-router';
for (const m of MODEL_CATALOG) console.log(m.tag, m.role);
```

## Quality gates (DoD)

- ✅ 16 new unit tests (39 total in package, all green)
- ✅ `pnpm typecheck` clean
- ✅ `pnpm lint` clean
- ✅ `pnpm build` clean
- ✅ Benchmark fixture script (`pnpm run bench`) — times every catalog model that's pulled, silently skips unpulled
- ✅ README updated with pull list + Qwen3 caveat
- ✅ Integration tests still gated on `SKIP_OLLAMA_INTEGRATION`
- ✅ Hardware budget asserted in tests

## Live bench output (M1 Pro 16GB, cold)

```
tag                     role          endpoint         ms   tok   tok/s  response
qwen2.5-coder:7b        coder         generate       4839     2     0.4  auth
qwen2.5-coder:14b       coder         generate       7500     2     0.3  auth
llama3.1:8b             generalist    generate       4220     2     0.5  auth
qwen3:14b               generalist    chat           5338     2     0.4  auth
phi4                    reasoning     generate       6270     2     0.3  auth
nomic-embed-text        embeddings    embeddings      738   768  1040.7  dim=768
```

All models return correct answer ("auth"). Latencies are cold-load — LAI-002 will tune warm-call performance and add p50/p95 reporting.

## Follow-ups

- LAI-002: speed-tuning (`OLLAMA_NUM_PARALLEL`, KV cache reuse, benchmark harness)
- LAI-003: `@chiefaia/local-rag` (uses `nomic-embed-text` from this PR)
- LAI-004: `@chiefaia/llm-cache`
- LAI-005: routing-rule enrichment (uses MODEL_CATALOG to promote rules from Claude→local)
- LAI-006: token-savings dashboard panel
