### PR TITLE
feat(orchestrator): add test_designed pipeline stage (TEST-002)

### DIFF
--- a/apps/orchestrator/src/agents/pipeline-stages.ts
+++ b/apps/orchestrator/src/agents/pipeline-stages.ts
@@ -3,14 +3,19 @@
  *
  * Phase 1 advances every prompt through this canonical sequence:
  *
- *   ingested → scaffolded → po_decomposed → ba_enriched → bucket_placed
- *   → ready_for_pickup
+ *   ingested → scaffolded → po_decomposed → ba_enriched → test_designed
+ *   → bucket_placed → ready_for_pickup
  *
  * Each transition is recorded in `prompt_pipeline_stages` (one row per
  * advancement, with epoch-ms `enteredAt`) and reflected on
  * `prompts.status` so consumers (the dashboard, the E2E test) can poll a
  * single field. A `pipeline.stage.advanced` event is emitted alongside
  * each transition so subscribers can track progression in real time.
+ *
+ * TEST-002 inserted `test_designed` between `ba_enriched` and
+ * `bucket_placed`: after BA finishes its cross-agent enrichment, the
+ * Testing Agent designs the story-driven test cases (see TEST-004), then
+ * the Task Manager places the ticket into a bucket.
  */
 
 import { nanoid } from 'nanoid';
@@ -25,6 +30,7 @@ export const PIPELINE_STAGE_ORDER = [
   'scaffolded',
   'po_decomposed',
   'ba_enriched',
+  'test_designed', // TEST-002 — Testing Agent generated test_cases.
   'bucket_placed',
   'ready_for_pickup',
 ] as const;

--- a/apps/orchestrator/tests/agents/pipeline-stages.test.ts
+++ b/apps/orchestrator/tests/agents/pipeline-stages.test.ts
@@ -46,16 +46,59 @@ function seedPrompt(db: ReturnType<typeof createTestDb>, id: string) {
 }
 
 describe('PIPELINE_STAGE_ORDER', () => {
-  it('locks the canonical Phase-1 progression', () => {
+  it('locks the canonical Phase-1 progression with TEST-002 test_designed inserted', () => {
     expect([...PIPELINE_STAGE_ORDER]).toEqual([
       'received',
       'ingested',
       'scaffolded',
       'po_decomposed',
       'ba_enriched',
+      'test_designed', // TEST-002
       'bucket_placed',
       'ready_for_pickup',
     ]);
+  });
+
+  it('places test_designed strictly between ba_enriched and bucket_placed', () => {
+    const arr = [...PIPELINE_STAGE_ORDER];
+    expect(arr.indexOf('test_designed')).toBeGreaterThan(arr.indexOf('ba_enriched'));
+    expect(arr.indexOf('test_designed')).toBeLessThan(arr.indexOf('bucket_placed'));
+  });
+});
+
+describe('TEST-002 — test_designed stage', () => {
+  it('advances a prompt from ba_enriched to test_designed and mirrors status', () => {
+    const db = createTestDb();
+    seedPrompt(db, 'prm_test_002');
+
+    advancePipelineStage(
+      { promptId: 'prm_test_002', stage: 'ba_enriched', correlationId: 'cor_t' },
+      db,
+    );
+    advancePipelineStage(
+      {
+        promptId: 'prm_test_002',
+        stage: 'test_designed',
+        correlationId: 'cor_t',
+        metadata: { totalCases: 5 },
+      },
+      db,
+    );
+
+    const rows = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, 'prm_test_002'))
+      .orderBy(asc(promptPipelineStages.enteredAt))
+      .all();
+    const stages = rows.map((r) => r.stage);
+    expect(stages).toContain('ba_enriched');
+    expect(stages).toContain('test_designed');
+    // test_designed must come after ba_enriched.
+    expect(stages.lastIndexOf('test_designed')).toBeGreaterThan(stages.indexOf('ba_enriched'));
+
+    const promptRow = db.select().from(prompts).where(eq(prompts.id, 'prm_test_002')).get();
+    expect(promptRow!.status).toBe('test_designed');
   });
 });
 


### PR DESCRIPTION
## Summary

Inserts the new `test_designed` stage between `ba_enriched` and
`bucket_placed` in the canonical Phase-1 progression. After BA finishes
cross-agent enrichment, the Testing Agent (TEST-004) designs story-driven
test cases; advancing to `test_designed` lets the dashboard render the
test design state alongside the existing BA-enrichment indicator before
the Task Manager places the ticket into a bucket.

## Canonical sequence

```
received -> ingested -> scaffolded -> po_decomposed -> ba_enriched
  -> test_designed -> bucket_placed -> ready_for_pickup
```

`PIPELINE_STAGE_ORDER` is the single source of truth; `prompts.status`
mirrors the latest stage; `prompt_pipeline_stages` logs every transition.

## Out of scope

The Testing Agent and the wiring that emits `advancePipelineStage(test_designed)`
ship in TEST-004 / TEST-005.

## Tests

- `PIPELINE_STAGE_ORDER` assertion updated to include `test_designed`
- New ordering invariant: `test_designed` > `ba_enriched` < `bucket_placed`
- End-to-end stage-row + prompt-status round-trip for the new value
- **7/7 pipeline-stages tests + 24/24 Phase-1 sweep green**
- Orchestrator typecheck: clean