### PR TITLE
feat(classifier,po-agent): project + business + lifecycle + priority classifier (BUCKET-002)

### DIFF
--- a/apps/orchestrator/src/agents/po-agent.ts
+++ b/apps/orchestrator/src/agents/po-agent.ts
@@ -3,15 +3,26 @@
  *
  * Runs after the Scaffolder assembles the team for 'new-project' or 'new-feature' requests.
  * Responsibilities:
- *  1. Classify the prompt domain via @chiefaia/classifier
- *  2. Decompose into Initiative → Epic → Story → Task via @chiefaia/decomposer
- *  3. Persist requirements (one per epic) and stories to the database
- *  4. Emit po-agent.decomposition.complete onto the event bus
+ *  1. Classify the prompt domain via @chiefaia/classifier (legacy primaryDomain
+ *     PLUS the BUCKET-002 9-axis taxonomy: project / lifecycle / priority).
+ *  2. Decompose into Initiative → Epic → Story → Task via @chiefaia/decomposer.
+ *  3. Persist requirements (one per epic) and stories to the database, with
+ *     the per-story BUCKET-002 fields populated (project_slug,
+ *     business_sub_domains_json, lifecycle, priority_bucket).
+ *  4. Emit po-agent.decomposition.complete onto the event bus, including the
+ *     prompt-level taxonomy so downstream agents (EA, BA, Validator,
+ *     Testing) can read it without re-running the classifier.
  */
 
 import { nanoid } from 'nanoid';
 import { eq } from 'drizzle-orm';
-import { classifyKeyword } from '@chiefaia/classifier';
+import {
+  classifyKeyword,
+  classifyProject,
+  classifyBusinessSubDomains,
+  classifyLifecycle,
+  classifyPriority,
+} from '@chiefaia/classifier';
 import { decompose } from '@chiefaia/decomposer';
 import { eventBus } from '../events/bus-adapter';
 import { getDb } from '../db/connection';
@@ -38,6 +49,13 @@ export interface POAgentOutput {
   classification: ReturnType<typeof classifyKeyword>;
   requirementsCreated: number;
   storiesCreated: number;
+  /** BUCKET-002 — prompt-level taxonomy returned for callers + tests. */
+  taxonomy: {
+    project: string;
+    projectConfidence: number;
+    lifecycle: string;
+    priorityBucket: string;
+  };
 }
 
 // ─── Main Agent Runner ───────────────────────────────────────────────────────
@@ -49,8 +67,13 @@ export async function runPOAgent(
   const { promptId, promptText, projectId, correlationId } = input;
   const now = new Date().toISOString();
 
-  // 1. Classify the prompt domain
+  // 1. Classify the prompt domain (legacy primaryDomain) plus the new
+  //    BUCKET-002 9-axis taxonomy fields (project / lifecycle / priority on
+  //    the prompt; per-story businessSubDomains computed below).
   const classification = classifyKeyword(promptText);
+  const projectClassification = classifyProject(promptText);
+  const promptLifecycle = classifyLifecycle(promptText);
+  const promptPriority = classifyPriority(promptText);
 
   // 2. Decompose into hierarchy (Claude if API key present, rule-based otherwise)
   const decomposition = await decompose(promptText);
@@ -90,6 +113,18 @@ export async function runPOAgent(
 
         const storyDbId = `story-${story.id}-${nanoid(4)}`;
 
+        // BUCKET-002 — per-story taxonomy. project + priority are inherited
+        // from the prompt-level classification; lifecycle is re-classified
+        // on the story body so a "fix bug X" story under a "build feature Y"
+        // prompt gets the correct lifecycle. business sub-domains are
+        // computed against the prompt-pinned project.
+        const storyText = `${story.title} ${story.description ?? ''}`;
+        const storyLifecycle = classifyLifecycle(storyText) || promptLifecycle;
+        const storyBusinessSubDomains = classifyBusinessSubDomains(
+          storyText,
+          projectClassification.slug,
+        );
+
         try {
           db.insert(stories).values({
             id: storyDbId,
@@ -103,6 +138,12 @@ export async function runPOAgent(
             parentEntityType: 'requirement',
             parentEntityId: reqId,
             createdAt: now,
+            // BUCKET-002 — 9-axis taxonomy fields populated by PO. EA fills
+            // techSubDomains/qualityTags/risk/effort/blockedBy in BUCKET-003.
+            projectSlug: projectClassification.slug,
+            businessSubDomainsJson: JSON.stringify(storyBusinessSubDomains),
+            lifecycle: storyLifecycle,
+            priorityBucket: promptPriority,
           }).run();
           storiesCreated++;
 
@@ -122,7 +163,9 @@ export async function runPOAgent(
     }
   }
 
-  // 4. Emit po-agent.decomposition.complete
+  // 4. Emit po-agent.decomposition.complete — payload now includes the
+  //    BUCKET-002 prompt-level taxonomy so downstream agents (EA, BA,
+  //    Validator, Testing) can read it without re-running the classifier.
   eventBus.publish({
     type: 'po-agent.decomposition.complete',
     actor: 'po-agent',
@@ -137,6 +180,11 @@ export async function runPOAgent(
       totalNodes: decomposition.totalNodes,
       summary: decomposition.summary,
       primaryDomain: classification.primaryDomain,
+      // BUCKET-002 prompt-level classification.
+      project: projectClassification.slug,
+      projectConfidence: projectClassification.confidence,
+      lifecycle: promptLifecycle,
+      priorityBucket: promptPriority,
     },
   });
 
@@ -178,5 +226,11 @@ export async function runPOAgent(
     classification,
     requirementsCreated,
     storiesCreated,
+    taxonomy: {
+      project: projectClassification.slug,
+      projectConfidence: projectClassification.confidence,
+      lifecycle: promptLifecycle,
+      priorityBucket: promptPriority,
+    },
   };
 }

--- a/packages/classifier/package.json
+++ b/packages/classifier/package.json
@@ -4,5 +4,14 @@
   "private": true,
   "description": "Domain taxonomy engine — classifies text into functional domains and assigns labels.",
   "main": "src/index.ts",
-  "types": "src/index.ts"
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
 }

--- a/packages/classifier/src/index.ts
+++ b/packages/classifier/src/index.ts
@@ -15,3 +15,12 @@ export {
   type LifecycleLabel,
   type ImpactLabel,
 } from './taxonomy';
+
+// BUCKET-002 — taxonomy classifiers consumed by PO Agent.
+export {
+  classifyProject,
+  classifyBusinessSubDomains,
+  classifyLifecycle,
+  classifyPriority,
+  type ProjectClassification,
+} from './taxonomy-classifier';

--- a/packages/classifier/src/taxonomy-classifier.test.ts
+++ b/packages/classifier/src/taxonomy-classifier.test.ts
@@ -1,0 +1,252 @@
+/**
+ * BUCKET-002 — taxonomy classifier tests.
+ */
+
+import {
+  classifyProject,
+  classifyBusinessSubDomains,
+  classifyLifecycle,
+  classifyPriority,
+} from './taxonomy-classifier';
+
+describe('classifyProject', () => {
+  it('returns unassigned with confidence 0 when nothing matches', () => {
+    const r = classifyProject('completely unrelated text');
+    expect(r.slug).toBe('unassigned');
+    expect(r.confidence).toBe(0);
+    expect(r.matches).toEqual([]);
+  });
+
+  it('matches pokerzeno over generic platform terms', () => {
+    const r = classifyProject('Build the pokerzeno gameplay engine using the orchestrator');
+    expect(r.slug).toBe('pokerzeno');
+  });
+
+  it('matches roulettecommunity', () => {
+    const r = classifyProject('Add a forum to roulette community for advisor discussions');
+    expect(r.slug).toBe('roulettecommunity');
+  });
+
+  it('matches edisoncricket', () => {
+    expect(classifyProject('add live coverage to edison cricket').slug).toBe('edisoncricket');
+  });
+
+  it('matches the platform itself when prompt mentions orchestrator/dashboard', () => {
+    expect(classifyProject('extend the orchestrator dashboard pipeline').slug).toBe('caia');
+  });
+
+  it('matches plugin packages by exact slug', () => {
+    expect(classifyProject('release the dev-inspector plugin v2').slug).toBe('dev-inspector');
+    expect(classifyProject('image-provider needs an R2 backend').slug).toBe('image-provider');
+  });
+
+  it('matches personal sites', () => {
+    expect(classifyProject('redesign ankita tiwari portfolio').slug).toBe('ankitatiwari');
+    expect(classifyProject('prakash personal blog migration').slug).toBe('prakash-tiwari');
+  });
+
+  it('matches chiefaia.com when explicitly mentioned', () => {
+    expect(classifyProject('build the chiefaia.com pricing page').slug).toBe('chiefaia.com');
+  });
+
+  it('reports all match candidates for audit', () => {
+    const r = classifyProject('add a poker zeno gameplay screen and roulette community profile');
+    expect(r.matches.length).toBeGreaterThanOrEqual(2);
+    expect(r.matches.map((m) => m.slug)).toContain('pokerzeno');
+    expect(r.matches.map((m) => m.slug)).toContain('roulettecommunity');
+  });
+
+  it('confidence is in [0,1]', () => {
+    const r = classifyProject('pokerzeno pokerzeno pokerzeno');
+    expect(r.confidence).toBeGreaterThan(0);
+    expect(r.confidence).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('classifyBusinessSubDomains', () => {
+  it('returns [] when project is unknown', () => {
+    expect(classifyBusinessSubDomains('any text', 'unknown-project')).toEqual([]);
+  });
+
+  it('returns [] when no keywords match', () => {
+    expect(classifyBusinessSubDomains('lorem ipsum dolor sit amet', 'pokerzeno')).toEqual([]);
+  });
+
+  it('matches pokerzeno billing + profile when both keywords present', () => {
+    const r = classifyBusinessSubDomains('add a billing tab to the user profile', 'pokerzeno');
+    expect(r).toContain('billing');
+    expect(r).toContain('profile');
+  });
+
+  it('caps results at 4 by default', () => {
+    const r = classifyBusinessSubDomains(
+      'gameplay poker hand deal cards leaderboard ranking subscription invoice profile review',
+      'pokerzeno',
+    );
+    expect(r.length).toBeLessThanOrEqual(4);
+  });
+
+  it('respects an explicit cap', () => {
+    const r = classifyBusinessSubDomains(
+      'gameplay leaderboard profile billing notification campaign',
+      'pokerzeno',
+      2,
+    );
+    expect(r.length).toBe(2);
+  });
+
+  it('orders by score (most matches first)', () => {
+    const r = classifyBusinessSubDomains('billing invoice gameplay', 'pokerzeno');
+    expect(r[0]).toBe('billing');
+  });
+
+  it('handles caia sub-domains', () => {
+    const r = classifyBusinessSubDomains(
+      'wire the orchestrator dashboard for the bucket-placer pipeline',
+      'caia',
+    );
+    expect(r).toContain('orchestration');
+    expect(r).toContain('dashboard');
+    expect(r).toContain('pipeline');
+  });
+});
+
+describe('classifyLifecycle', () => {
+  it('defaults to new when nothing matches', () => {
+    expect(classifyLifecycle('lorem ipsum sit amet')).toBe('new');
+  });
+
+  it('detects hotfix', () => {
+    expect(classifyLifecycle('hotfix the production-down billing endpoint')).toBe('hotfix');
+  });
+
+  it('detects bug', () => {
+    expect(classifyLifecycle('the login flow is broken on mobile')).toBe('bug');
+  });
+
+  it('hotfix outranks bug', () => {
+    expect(classifyLifecycle('hotfix the broken billing endpoint')).toBe('hotfix');
+  });
+
+  it('detects refactor', () => {
+    expect(classifyLifecycle('refactor the bucket-placer module')).toBe('refactor');
+  });
+
+  it('detects chore', () => {
+    expect(classifyLifecycle('chore: bump dependency version')).toBe('chore');
+  });
+
+  it('detects docs', () => {
+    expect(classifyLifecycle('document the new pipeline in the readme')).toBe('docs');
+  });
+
+  it('detects spike', () => {
+    expect(classifyLifecycle('spike on Dilworth chain cover')).toBe('spike');
+  });
+
+  it('detects enhance', () => {
+    expect(classifyLifecycle('improve dashboard rendering performance')).toBe('enhance');
+  });
+
+  it('detects new for build/create/add', () => {
+    expect(classifyLifecycle('add a billing panel')).toBe('new');
+    expect(classifyLifecycle('create a new bucket placer')).toBe('new');
+    expect(classifyLifecycle('build the leaderboard service')).toBe('new');
+  });
+});
+
+describe('classifyPriority', () => {
+  it('defaults to P2', () => {
+    expect(classifyPriority('add a feature')).toBe('P2');
+  });
+
+  it('detects P0 from explicit P0', () => {
+    expect(classifyPriority('P0: production is down')).toBe('P0');
+  });
+
+  it('detects P0 from urgency keywords', () => {
+    expect(classifyPriority('urgent: drop everything')).toBe('P0');
+  });
+
+  it('detects P1', () => {
+    expect(classifyPriority('this week we need this')).toBe('P1');
+  });
+
+  it('detects P3', () => {
+    expect(classifyPriority('nice to have eventually')).toBe('P3');
+  });
+
+  it('P0 outranks P1', () => {
+    expect(classifyPriority('urgent and high priority this week')).toBe('P0');
+  });
+});
+
+describe('classifier slug invariants', () => {
+  it('classifyProject only returns slugs from a known set', () => {
+    const known = new Set([
+      'caia',
+      'pokerzeno',
+      'roulettecommunity',
+      'edisoncricket',
+      'ankitatiwari',
+      'prakash-tiwari',
+      'chiefaia.com',
+      'framework',
+      'site-template',
+      'image-provider',
+      'cast-bridge',
+      'dev-inspector',
+      'backend-core',
+      'content-engine',
+      'integrity-check',
+      'seo-program',
+      'analytics',
+      'unassigned',
+    ]);
+    const samples = [
+      'pokerzeno gameplay',
+      'roulette community forum',
+      'edison cricket scores',
+      'ankita tiwari blog',
+      'prakash tiwari portfolio',
+      'chiefaia.com pricing',
+      'framework example',
+      'site-template scaffold',
+      'dev-inspector plugin',
+      'image-provider api',
+      'cast-bridge fix',
+      'backend-core update',
+      'content-engine renderer',
+      'integrity-check tweak',
+      'seo-program audit',
+      'analytics package readme',
+      'orchestrator dashboard caia',
+      'lorem ipsum dolor',
+    ];
+    for (const s of samples) expect(known.has(classifyProject(s).slug)).toBe(true);
+  });
+
+  it('classifyLifecycle only returns slugs from a known set', () => {
+    const known = new Set(['new', 'enhance', 'bug', 'refactor', 'chore', 'docs', 'hotfix', 'spike']);
+    for (const s of [
+      'add',
+      'improve',
+      'bug',
+      'refactor',
+      'chore',
+      'document',
+      'hotfix',
+      'spike research',
+      'lorem',
+    ]) {
+      expect(known.has(classifyLifecycle(s))).toBe(true);
+    }
+  });
+
+  it('classifyPriority only returns P0 / P1 / P2 / P3', () => {
+    const known = new Set(['P0', 'P1', 'P2', 'P3']);
+    for (const s of ['urgent', 'this week', 'nice to have', 'something']) {
+      expect(known.has(classifyPriority(s))).toBe(true);
+    }
+  });
+});

--- a/packages/classifier/src/taxonomy-classifier.ts
+++ b/packages/classifier/src/taxonomy-classifier.ts
@@ -1,0 +1,261 @@
+/**
+ * Taxonomy classifier — BUCKET-002.
+ *
+ * Pure, dependency-free keyword-driven helpers that PO Agent uses to
+ * populate the new 9-axis taxonomy fields (`project_slug`,
+ * `business_sub_domains`, `lifecycle`, `priority_bucket`) on every story
+ * during decomposition.
+ *
+ * These intentionally mirror the canonical enums in
+ * `@chiefaia/ticket-template`. We don't import them here to keep
+ * `@chiefaia/classifier` self-contained — the slug strings MUST stay in
+ * sync; the BUCKET-006 E2E test is the cross-package sync gate.
+ */
+
+// ─── Project classification ──────────────────────────────────────────────────
+
+const PROJECT_KEYWORDS: Array<{ slug: string; keywords: string[] }> = [
+  { slug: 'ankitatiwari', keywords: ['ankita', 'ankita tiwari', 'ankitatiwari'] },
+  { slug: 'prakash-tiwari', keywords: ['prakash tiwari', 'prakash-tiwari', 'prakash personal'] },
+  { slug: 'chiefaia.com', keywords: ['chiefaia.com', 'chiefaia marketing', 'chiefaia site'] },
+  { slug: 'pokerzeno', keywords: ['pokerzeno', 'poker zeno', 'poker-zeno', 'poker site'] },
+  { slug: 'roulettecommunity', keywords: ['roulettecommunity', 'roulette community', 'roulette-community', 'roulette site', 'roulette advisor'] },
+  { slug: 'edisoncricket', keywords: ['edisoncricket', 'edison cricket', 'edison-cricket', 'cricket site'] },
+  { slug: 'image-provider', keywords: ['image-provider', 'image provider'] },
+  { slug: 'cast-bridge', keywords: ['cast-bridge', 'cast bridge'] },
+  { slug: 'dev-inspector', keywords: ['dev-inspector', 'dev inspector'] },
+  { slug: 'backend-core', keywords: ['backend-core'] },
+  { slug: 'content-engine', keywords: ['content-engine', 'content engine'] },
+  { slug: 'integrity-check', keywords: ['integrity-check', 'integrity check'] },
+  { slug: 'seo-program', keywords: ['seo-program', 'seo program'] },
+  { slug: 'analytics', keywords: ['analytics package', 'analytics plugin'] },
+  { slug: 'framework', keywords: ['framework', 'caia framework'] },
+  { slug: 'site-template', keywords: ['site-template', 'site template'] },
+  {
+    slug: 'caia',
+    keywords: [
+      'caia',
+      'orchestrator',
+      'agent platform',
+      'pipeline',
+      'dashboard',
+      'task manager',
+      'po agent',
+      'ba agent',
+      'ea agent',
+      'task scheduler',
+      'bucket placer',
+      'executor',
+      'observability',
+      'event bus',
+      'classifier',
+      'decomposer',
+      'ticket template',
+      'event taxonomy',
+    ],
+  },
+];
+
+export interface ProjectClassification {
+  slug: string;
+  confidence: number;
+  matches: Array<{ slug: string; matchedKeywords: string[] }>;
+}
+
+export function classifyProject(text: string): ProjectClassification {
+  const lower = text.toLowerCase();
+  const matches: ProjectClassification['matches'] = [];
+
+  for (const entry of PROJECT_KEYWORDS) {
+    const matched = entry.keywords.filter((k) => lower.includes(k));
+    if (matched.length > 0) matches.push({ slug: entry.slug, matchedKeywords: matched });
+  }
+
+  if (matches.length === 0) {
+    return { slug: 'unassigned', confidence: 0, matches: [] };
+  }
+
+  matches.sort((a, b) => b.matchedKeywords.length - a.matchedKeywords.length);
+  const winner = matches[0]!;
+  const totalKeywords =
+    PROJECT_KEYWORDS.find((e) => e.slug === winner.slug)?.keywords.length ?? 1;
+
+  return {
+    slug: winner.slug,
+    confidence: Math.min(winner.matchedKeywords.length / totalKeywords, 1),
+    matches,
+  };
+}
+
+// ─── Business sub-domain classification (per-project) ───────────────────────
+
+const BUSINESS_SUB_DOMAIN_KEYWORDS: Record<string, Record<string, string[]>> = {
+  caia: {
+    orchestration: ['orchestrator', 'orchestration'],
+    'agent-platform': ['agent platform', 'agent runtime', 'po agent', 'ba agent', 'ea agent'],
+    dashboard: ['dashboard', '/queue', '/buckets', '/timeline', 'sidebar'],
+    observability: ['observability', 'logging', 'tracing', 'metric'],
+    'public-api': ['public api', '/api/'],
+    pipeline: ['pipeline', 'pipeline stage'],
+    executor: ['executor'],
+    scheduler: ['scheduler', 'task scheduler'],
+    'ticket-template': ['ticket template', 'ticket-template'],
+    'events-taxonomy': ['event taxonomy', 'events-taxonomy'],
+    'secrets-broker': ['secrets broker', 'secrets-broker', 'vault'],
+    'integrity-check': ['integrity check'],
+    'behavior-suite': ['behavior suite', 'behavior test'],
+    cli: [' cli ', 'command line'],
+    documentation: ['readme', 'adr', 'runbook'],
+    'testing-infra': ['testing infra', 'test infrastructure', 'vitest', 'playwright config'],
+  },
+  pokerzeno: {
+    gameplay: ['gameplay', 'poker hand', 'deal cards', ' seat ', 'poker table'],
+    leaderboard: ['leaderboard', 'ranking', 'standing'],
+    tournaments: ['tournament', 'sit and go'],
+    profile: ['profile', 'avatar', 'username'],
+    billing: ['billing', 'invoice', 'subscription'],
+    payments: ['payment', 'stripe', 'checkout', 'paypal'],
+    content: ['article', 'strategy', 'guide'],
+    engagement: ['notification', 'streak', 'badge'],
+    marketing: ['marketing', 'promo', 'campaign'],
+    retention: ['retention', 'churn'],
+    onboarding: ['onboarding', 'sign up', 'signup'],
+    settings: ['setting', 'preference'],
+    social: ['chat', 'friend', 'social'],
+    reviews: ['review', 'rating'],
+    affiliate: ['affiliate', 'referral'],
+    compliance: ['kyc', 'aml', 'compliance'],
+    support: ['support', 'help center', 'ticket support'],
+  },
+  roulettecommunity: {
+    forum: ['forum', 'thread', 'reply'],
+    education: ['course', 'lesson', 'tutorial'],
+    advisor: ['advisor', 'ai advice', 'recommendation engine'],
+    community: ['community', 'profile', 'post'],
+    content: ['article', 'news'],
+    marketing: ['marketing', 'campaign'],
+    onboarding: ['onboarding', 'signup'],
+    settings: ['setting', 'preference'],
+    social: ['social', 'follow'],
+    reviews: ['review', 'rating'],
+    affiliate: ['affiliate', 'referral'],
+    compliance: ['kyc', 'aml', 'compliance'],
+    support: ['support', 'help'],
+  },
+  edisoncricket: {
+    scores: ['score', 'scorecard'],
+    'live-coverage': ['live coverage', 'live update'],
+    news: ['news', 'article'],
+    analysis: ['analysis', 'commentary'],
+    fantasy: ['fantasy', 'team selection'],
+    community: ['community', 'forum'],
+    content: ['content'],
+    marketing: ['marketing'],
+    onboarding: ['onboarding'],
+    settings: ['setting'],
+  },
+  ankitatiwari: {
+    portfolio: ['portfolio', 'project', 'work'],
+    blog: ['blog', 'post', 'article'],
+    about: ['about'],
+    contact: ['contact'],
+    seo: ['seo'],
+    cms: ['cms'],
+  },
+  'prakash-tiwari': {
+    portfolio: ['portfolio'],
+    blog: ['blog'],
+    about: ['about'],
+    contact: ['contact'],
+    seo: ['seo'],
+    cms: ['cms'],
+  },
+  'chiefaia.com': {
+    marketing: ['marketing', 'landing'],
+    'case-studies': ['case study', 'case-studies'],
+    pricing: ['pricing', 'plan'],
+    docs: ['docs', 'documentation'],
+    signup: ['signup', 'sign up'],
+    'dashboard-marketing': ['dashboard preview'],
+    legal: ['legal', 'terms', 'privacy'],
+    seo: ['seo'],
+  },
+  framework: {
+    scaffolding: ['scaffolding', 'scaffold'],
+    templates: ['template'],
+    boilerplate: ['boilerplate'],
+    documentation: ['readme', 'docs'],
+    examples: ['example'],
+  },
+  'site-template': {
+    scaffolding: ['scaffolding'],
+    templates: ['template'],
+    boilerplate: ['boilerplate'],
+    documentation: ['readme', 'docs'],
+    examples: ['example'],
+  },
+  'image-provider': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  'cast-bridge': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  'dev-inspector': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  'backend-core': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  'content-engine': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  'integrity-check': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  'seo-program': { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+  analytics: { api: ['api'], internals: ['internal'], documentation: ['readme'], examples: ['example'], testing: ['test'] },
+};
+
+export function classifyBusinessSubDomains(
+  text: string,
+  projectSlug: string,
+  cap = 4,
+): string[] {
+  const map = BUSINESS_SUB_DOMAIN_KEYWORDS[projectSlug];
+  if (!map) return [];
+  const lower = text.toLowerCase();
+  const hits: Array<{ subDomain: string; score: number }> = [];
+  for (const [subDomain, keywords] of Object.entries(map)) {
+    const score = keywords.filter((k) => lower.includes(k)).length;
+    if (score > 0) hits.push({ subDomain, score });
+  }
+  hits.sort((a, b) => b.score - a.score);
+  return hits.slice(0, cap).map((h) => h.subDomain);
+}
+
+// ─── Lifecycle classification ───────────────────────────────────────────────
+
+const LIFECYCLE_KEYWORDS: Record<string, string[]> = {
+  hotfix: ['hotfix', 'urgent fix', 'production down', 'prod down', 'critical fix'],
+  bug: ['bug', 'broken', 'error', 'issue', 'wrong', 'incorrect', 'crash', 'fail', 'fix '],
+  refactor: ['refactor', 'restructure', 'reorganize', 'simplify', 'rewrite', 'clean up'],
+  chore: ['chore', 'bump', 'dependency', 'dep update', 'tooling', 'maintenance'],
+  docs: ['document', 'docs ', 'readme', 'doc only', 'docs only'],
+  spike: ['spike', 'research', 'investigate', 'explore', 'poc', 'prototype', 'proof of concept'],
+  enhance: ['enhance', 'improve', 'extend', 'upgrade', 'better', 'optimize'],
+  new: ['add', 'create', 'build', 'implement', 'introduce', 'new feature'],
+};
+
+export function classifyLifecycle(text: string): string {
+  const lower = text.toLowerCase();
+  const ORDER = ['hotfix', 'bug', 'refactor', 'chore', 'docs', 'spike', 'enhance', 'new'] as const;
+  for (const lifecycle of ORDER) {
+    const keywords = LIFECYCLE_KEYWORDS[lifecycle]!;
+    if (keywords.some((k) => lower.includes(k))) return lifecycle;
+  }
+  return 'new';
+}
+
+// ─── Priority classification ────────────────────────────────────────────────
+
+const PRIORITY_KEYWORDS: Record<string, string[]> = {
+  P0: ['p0', 'critical', 'production down', 'asap', 'drop everything', 'urgent'],
+  P1: ['p1', 'this week', 'high priority', 'important'],
+  P3: ['p3', 'nice to have', 'eventually', 'low priority', 'someday', 'backlog'],
+};
+
+export function classifyPriority(text: string): string {
+  const lower = text.toLowerCase();
+  if (PRIORITY_KEYWORDS.P0!.some((k) => lower.includes(k))) return 'P0';
+  if (PRIORITY_KEYWORDS.P1!.some((k) => lower.includes(k))) return 'P1';
+  if (PRIORITY_KEYWORDS.P3!.some((k) => lower.includes(k))) return 'P3';
+  return 'P2';
+}

--- a/packages/classifier/tsconfig.json
+++ b/packages/classifier/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*", "vitest.config.ts"]
+}

--- a/packages/classifier/vitest.config.ts
+++ b/packages/classifier/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,7 +421,17 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)
 
-  packages/classifier: {}
+  packages/classifier:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/cli:
     dependencies:


### PR DESCRIPTION
## BUCKET-002 — PO Agent populates the 9-axis taxonomy

PO Agent now writes `project_slug`, `business_sub_domains_json`, `lifecycle`, and `priority_bucket` (the BUCKET-001 columns) onto every story it creates. EA Agent (BUCKET-003) fills the remaining axes (`tech_sub_domains`, `quality_tags`, `risk`, `effort`, `blocked_by`, `claims`). The new pipeline-order Validator + Testing stages sit downstream of PO and read these fields straight off `stories.*` — no direct integration changes required from BUCKET-002.

### `@chiefaia/classifier`

New module `taxonomy-classifier.ts`:

- `classifyProject(text)` → `{ slug, confidence, matches[] }` — covers all 17 canonical project slugs from §3.1 of the proposal, with `unassigned` as the explicit fallback.
- `classifyBusinessSubDomains(text, project)` → `string[]` (capped at 4) — per-project keyword maps for `caia`, `pokerzeno`, `roulettecommunity`, `edisoncricket`, `ankitatiwari`, `prakash-tiwari`, `chiefaia.com`, `framework`, `site-template`, and 8 plugin packages.
- `classifyLifecycle(text)` → `"new" | "enhance" | "bug" | "refactor" | "chore" | "docs" | "hotfix" | "spike"` — priority order `hotfix > bug > refactor > chore > docs > spike > enhance > new`.
- `classifyPriority(text)` → `"P0" | "P1" | "P2" | "P3"` — `P2` default.

Pure, dependency-free; no `@chiefaia/ticket-template` import to keep the package self-contained. Slug-strings are kept in sync via slug-set invariant tests here and via the BUCKET-006 cross-package E2E.

Also adds package scripts (`test`/`typecheck`), `devDependencies` for vitest, and `vitest.config.ts` (`globals: true`) so the existing `classifier.test.ts` continues to run.

### `apps/orchestrator/src/agents/po-agent.ts`

- Imports the new classifiers.
- Runs `classifyProject` + `classifyLifecycle` + `classifyPriority` once on the prompt body at entry.
- Per-story: re-runs `classifyLifecycle` on the story body (so a "fix bug X" story under a "build feature Y" prompt gets the correct lifecycle), and `classifyBusinessSubDomains` scoped to the prompt-pinned project.
- Persists `projectSlug`, `businessSubDomainsJson`, `lifecycle`, `priorityBucket` on every `stories.*` row.
- `po-agent.decomposition.complete` payload now carries `project`, `projectConfidence`, `lifecycle`, `priorityBucket` so EA/BA/Validator/Testing don't have to re-run the classifier.
- `POAgentOutput` exposes the same `taxonomy` block to callers + tests.

### Drive-by fix

`packages/ticket-template/src/index.ts` didn't re-export the migration-0025 `INPUT_DEPENDENCY_KINDS` / `INPUT_DEPENDENCY_DECLARERS` / `InputDependency` types, and `buildDraftTicket` didn't forward `inputDependencies` from input. Fixed both so the package's own `input-dependencies.test.ts` passes again.

### Tests

- `pnpm --filter @chiefaia/classifier test` — **50/50 pass** (14 existing + 36 new). Coverage: every classifier function with realistic prompts + slug-set invariants for project / lifecycle / priority.
- `pnpm --filter @chiefaia/ticket-template test` — **55/55 pass**, plus the previously-broken input-dependencies tests now pass.
- `pnpm --filter @caia-app/core run typecheck` — clean.

### What this unblocks

- **BUCKET-003** — EA Agent reads `stories.project_slug` + `business_sub_domains_json` + `lifecycle` + `priority_bucket` and adds `tech_sub_domains` + `quality_tags` + `risk` + `effort` + initial `blocked_by` + `claims`.
- **BUCKET-004** — bucket-placer keys on `(project_slug, tech_sub_domain_primary)`.
- **BUCKET-005/006** — dashboard + E2E read the populated taxonomy.

### References

- Directive: `agent/memory/po_taxonomy_directive.md`
- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§3.1–§3.4)
