### PR TITLE
feat(orchestrator,events): ea agent runtime + tech/quality/risk classification (BUCKET-003)

### DIFF
--- a/apps/orchestrator/src/agents/ea-agent.ts
+++ b/apps/orchestrator/src/agents/ea-agent.ts
@@ -1,0 +1,406 @@
+/**
+ * EA Agent (Enterprise Architect) — Tier 2  (BUCKET-003).
+ *
+ * Runs after the PO Agent's decomposition completes; before the BA Agent
+ * starts enrichment. The EA fills in the rest of the BUCKET-001 9-axis
+ * taxonomy that PO didn't set:
+ *   - tech_sub_domains_json + tech_sub_domain_primary
+ *   - quality_tags_json
+ *   - risk
+ *   - effort
+ *   - blocked_by_json (parsed from text refs like "after #STORY-X")
+ *   - claims_json (BUCKET-009 staging — files / schemas / api routes / domains)
+ *
+ * The EA also enforces the proposal's §4.2 mutual exclusions before BA
+ * picks the ticket up — it cannot fix every violation but flags the worst
+ * (XL effort, critical risk + low priority, lifecycle-mismatch). When a
+ * violation is unfixable, the EA marks the story's
+ * `template_validation_status = 'invalid'` and writes a reason into
+ * `template_validation_errors`.
+ *
+ * The EA is rule-based for MVP — keyword matching against
+ * `TECH_SUB_DOMAINS` from `@chiefaia/ticket-template`. The regex / keyword
+ * tables live local to this module so we don't pull `ticket-template` into
+ * `@chiefaia/classifier`.
+ */
+
+import { eq } from 'drizzle-orm';
+import { TECH_SUB_DOMAINS, QUALITY_TAGS } from '@chiefaia/ticket-template';
+import { classifyKeyword } from '@chiefaia/classifier';
+import { eventBus } from '../events/bus-adapter';
+import { getDb } from '../db/connection';
+import { stories } from '../db/schema';
+import { advancePipelineStage } from './pipeline-stages';
+
+// Logger shim — replaced at runtime by the real pino logger if available.
+const logger = {
+  warn: (obj: Record<string, unknown>, msg: string) => {
+    console.warn('[ea-agent]', msg, obj);
+  },
+};
+
+// ─── Inputs / outputs ────────────────────────────────────────────────────────
+
+export interface EAAgentInput {
+  promptId: string;
+  correlationId: string;
+}
+
+export interface EAAgentOutput {
+  promptId: string;
+  storiesClassified: number;
+  techSubDomainsAssigned: number;
+  qualityTagsAssigned: number;
+  blockedByMarkersFound: number;
+  storiesWithCriticalRisk: number;
+  storiesRequiringSplit: number;
+}
+
+// ─── Tech sub-domain inference ──────────────────────────────────────────────
+
+/**
+ * Keyword map from raw text to TECH_SUB_DOMAINS slugs. Most slugs match
+ * themselves; the rest gain synonyms. The PO Agent's `primaryDomain`
+ * (auth / ui-frontend / api-integration / data-storage / devops) is also
+ * folded in via `mapPrimaryDomainToTech`.
+ */
+const TECH_KEYWORDS: Record<string, string[]> = {
+  frontend: ['component', 'react', 'next.js', 'page', ' ui ', 'tsx', 'css', 'tailwind'],
+  bff: ['route handler', 'api route', '/api/', 'hono', 'gateway'],
+  backend: ['service', 'business logic', 'worker'],
+  database: ['schema', 'migration', 'sqlite', 'postgres', 'drizzle', 'index'],
+  'event-driven': ['event bus', 'pub/sub', 'queue', 'async messaging'],
+  observability: ['log', 'metric', 'trace', 'pino', 'opentelemetry'],
+  'web-analytics': ['ga4', 'mixpanel', 'analytics event', 'tracking'],
+  crm: ['crm', 'customer relationship'],
+  cms: ['sanity', 'contentful', 'cms'],
+  search: ['elasticsearch', 'algolia', 'opensearch', 'embeddings'],
+  auth: ['login', 'oauth', 'jwt', 'session', 'auth'],
+  payments: ['stripe', 'checkout', 'invoice', 'subscription', 'payment'],
+  email: ['sendgrid', 'resend', 'transactional email', 'marketing email'],
+  caching: ['redis', 'cdn', 'cache'],
+  infra: ['cloudflare', 'vercel', 'dns', 'hosting', 'infra'],
+  'ci-cd': ['github actions', 'workflow', 'release pipeline'],
+  'ml-ai': ['model', 'inference', 'training', 'prompt engineering'],
+  testing: ['unit test', 'integration test', 'e2e test', 'playwright', 'vitest', 'behavior test'],
+  accessibility: ['wcag', 'a11y', 'accessib', 'aria', 'keyboard nav'],
+  seo: ['meta tag', 'sitemap', 'canonical', 'json-ld', 'og:'],
+  security: ['threat model', 'vault', 'secret', 'csp', 'xss'],
+  'localization-i18n': ['i18n', 'localization', 'translation', 'locale'],
+  'design-system': ['design system', 'token', 'primitive'],
+  documentation: ['readme', 'doc', 'adr', 'runbook'],
+  'api-gateway': ['api gateway', 'edge router'],
+  websockets: ['websocket', 'realtime push', ' ws '],
+  'file-storage': ['r2', 's3', 'blob storage', 'file upload'],
+  'rate-limiting': ['rate limit', 'throttle'],
+  'feature-flags': ['feature flag', 'kill switch'],
+  'monitoring-alerting': ['pagerduty', 'sentry', 'alert'],
+  'secrets-management': ['vault', 'kms', 'env injection'],
+  'dependency-management': ['renovate', 'dependabot', 'lockfile'],
+  'data-pipeline': ['etl', 'batch job', 'warehouse'],
+  'cron-scheduling': ['cron', 'scheduled task', 'recurring job'],
+  'agent-runtime': ['agent', 'orchestrator', 'collab', 'po-agent', 'ba-agent', 'ea-agent'],
+  'prompt-engineering': ['prompt template', 'prompt rule'],
+  'ticket-template': ['ticket template', 'ticket-template'],
+  'data-migration': ['backfill', 'data migration'],
+  compliance: ['gdpr', 'aml', 'kyc', 'audit trail', 'compliance'],
+  performance: ['lighthouse', 'profil', 'bundle size', 'load test'],
+};
+
+function mapPrimaryDomainToTech(primaryDomain: string): string[] {
+  switch (primaryDomain) {
+    case 'auth': return ['auth'];
+    case 'ui-frontend': return ['frontend'];
+    case 'api-integration': return ['bff', 'backend'];
+    case 'data-storage': return ['database'];
+    case 'devops': return ['infra', 'ci-cd'];
+    default: return [];
+  }
+}
+
+/** Score every TECH_SUB_DOMAIN against the text and return the top matches. */
+export function inferTechSubDomains(text: string, primaryDomain: string): {
+  primary: string;
+  all: string[];
+} {
+  const lower = text.toLowerCase();
+  const seedTech = mapPrimaryDomainToTech(primaryDomain);
+  const scores: Record<string, number> = {};
+  for (const seed of seedTech) scores[seed] = (scores[seed] ?? 0) + 2; // seeding bonus
+
+  for (const [tech, kws] of Object.entries(TECH_KEYWORDS)) {
+    const hits = kws.filter((k) => lower.includes(k)).length;
+    if (hits > 0) scores[tech] = (scores[tech] ?? 0) + hits;
+  }
+
+  const sorted = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+  const valid = sorted.filter(([t]) => (TECH_SUB_DOMAINS as readonly string[]).includes(t));
+  if (valid.length === 0) {
+    return { primary: 'backend', all: ['backend'] };
+  }
+  const primary = valid[0]![0];
+  // Cap total tech sub-domains at 5 to avoid noise.
+  const all = valid.slice(0, 5).map(([t]) => t);
+  return { primary, all };
+}
+
+// ─── Quality tags ───────────────────────────────────────────────────────────
+
+const QUALITY_KEYWORDS: Record<string, string[]> = {
+  accessibility: ['wcag', 'a11y', 'accessib', 'aria', 'keyboard nav', 'screen reader'],
+  seo: ['seo', 'meta tag', 'sitemap', 'canonical', 'json-ld', 'og:', 'open graph'],
+  performance: ['performance', 'lighthouse', 'bundle size', 'load test', 'profil'],
+  security: ['security', 'threat', 'vault', 'csp', 'xss', 'csrf'],
+  compliance: ['gdpr', 'aml', 'kyc', 'audit trail', 'compliance'],
+  observability: ['observability', 'logging', 'tracing', 'metric', 'pino'],
+  internationalization: ['i18n', 'localization', 'locale', 'translation'],
+};
+
+export function inferQualityTags(text: string): string[] {
+  const lower = text.toLowerCase();
+  const tags: string[] = [];
+  for (const [tag, kws] of Object.entries(QUALITY_KEYWORDS)) {
+    if (kws.some((k) => lower.includes(k))) tags.push(tag);
+  }
+  return tags.filter((t) => (QUALITY_TAGS as readonly string[]).includes(t));
+}
+
+// ─── Risk + effort ──────────────────────────────────────────────────────────
+
+const HIGH_RISK_TECH = new Set(['auth', 'payments', 'database', 'compliance', 'secrets-management']);
+const CRITICAL_RISK_TECH = new Set(['data-migration']);
+
+export function inferRisk(
+  techAll: string[],
+  qualityTags: string[],
+  lifecycle: string | null,
+): 'low' | 'medium' | 'high' | 'critical' {
+  if (techAll.some((t) => CRITICAL_RISK_TECH.has(t))) return 'critical';
+  if (lifecycle === 'hotfix') return 'high';
+  if (techAll.some((t) => HIGH_RISK_TECH.has(t))) return 'high';
+  if (qualityTags.includes('compliance') || qualityTags.includes('security')) return 'high';
+  if (lifecycle === 'docs' || lifecycle === 'chore') return 'low';
+  return 'medium';
+}
+
+const COMPLEXITY_TO_EFFORT: Record<string, 'XS' | 'S' | 'M' | 'L' | 'XL'> = {
+  trivial: 'XS',
+  small: 'S',
+  medium: 'M',
+  large: 'L',
+  xl: 'XL',
+};
+
+export function inferEffort(
+  text: string,
+  classifierComplexity: string,
+): 'XS' | 'S' | 'M' | 'L' | 'XL' {
+  const fromClassifier = COMPLEXITY_TO_EFFORT[classifierComplexity];
+  if (fromClassifier) return fromClassifier;
+  // Fallback: word count.
+  const words = text.trim().split(/\s+/).length;
+  if (words < 8) return 'XS';
+  if (words < 24) return 'S';
+  if (words < 80) return 'M';
+  if (words < 200) return 'L';
+  return 'XL';
+}
+
+// ─── Blocked-by parser ─────────────────────────────────────────────────────
+
+const BLOCKED_BY_PATTERNS = [
+  /\bafter\s+#?(story[-_][a-z0-9-]+)/gi,
+  /\bdepends\s+on\s+#?(story[-_][a-z0-9-]+)/gi,
+  /\bblocked\s+by\s+#?(story[-_][a-z0-9-]+)/gi,
+];
+
+export function inferBlockedBy(text: string): string[] {
+  const found = new Set<string>();
+  for (const re of BLOCKED_BY_PATTERNS) {
+    const matches = [...text.matchAll(re)];
+    for (const m of matches) {
+      if (m[1]) found.add(m[1].toLowerCase());
+    }
+  }
+  return Array.from(found);
+}
+
+// ─── Claims inference (BUCKET-009 staging) ─────────────────────────────────
+
+export interface InferredClaims {
+  files: string[];
+  schemas: string[];
+  apiRoutes: string[];
+  domains: string[];
+}
+
+export function inferClaims(text: string, techAll: string[]): InferredClaims {
+  // Files mentioned (very conservative — only obvious paths).
+  const fileMatches = [
+    ...text.matchAll(/[\w-]+\/[\w./-]+\.(?:ts|tsx|js|jsx|sql|md|json|yaml|yml|css)/g),
+  ].map((m) => m[0]);
+
+  // API routes mentioned.
+  const routeMatches = [
+    ...text.matchAll(/\b(?:GET|POST|PUT|PATCH|DELETE)\s+(\/[\w/:-]+)/g),
+  ].map((m) => `${m[0]}`);
+
+  // Schema names mentioned (conservative — table.column or just SQL keywords).
+  const schemaMatches = [...text.matchAll(/\b([a-z_][a-z0-9_]+)\.(\w+)/gi)]
+    .map((m) => `${m[1]}.${m[2]}`)
+    .filter((s) => s.includes('_') || s.endsWith('_json') || /(?:stories|requirements|tasks|prompts|task_buckets)\./.test(s));
+
+  return {
+    files: Array.from(new Set(fileMatches)),
+    schemas: Array.from(new Set(schemaMatches)),
+    apiRoutes: Array.from(new Set(routeMatches)),
+    // Coarse fallback: union of techSubDomains.
+    domains: Array.from(new Set(techAll)),
+  };
+}
+
+// ─── Mutual-exclusion enforcement ──────────────────────────────────────────
+
+export interface ValidationViolation {
+  field: string;
+  message: string;
+}
+
+export function validateTaxonomyInvariants(args: {
+  effort: string;
+  risk: string;
+  priorityBucket: string | null;
+  lifecycle: string | null;
+}): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  if (args.effort === 'XL') {
+    violations.push({ field: 'effort', message: 'effort=XL must be split into smaller stories' });
+  }
+  if (args.risk === 'critical' && args.priorityBucket && !['P0', 'P1'].includes(args.priorityBucket)) {
+    violations.push({
+      field: 'priorityBucket',
+      message: 'risk=critical requires priorityBucket in {P0, P1}',
+    });
+  }
+  if (args.lifecycle === 'spike' && !['XS', 'S', 'M'].includes(args.effort)) {
+    violations.push({ field: 'effort', message: 'lifecycle=spike requires effort in {XS, S, M}' });
+  }
+  return violations;
+}
+
+// ─── Main agent runner ─────────────────────────────────────────────────────
+
+export async function runEAAgent(
+  input: EAAgentInput,
+  db: ReturnType<typeof getDb>,
+): Promise<EAAgentOutput> {
+  const { promptId, correlationId } = input;
+
+  const allStories = db
+    .select()
+    .from(stories)
+    .where(eq(stories.rootPromptId, promptId))
+    .all();
+
+  let storiesClassified = 0;
+  let techSubDomainsAssigned = 0;
+  let qualityTagsAssigned = 0;
+  let blockedByMarkersFound = 0;
+  let storiesWithCriticalRisk = 0;
+  let storiesRequiringSplit = 0;
+
+  for (const story of allStories) {
+    try {
+      const storyText = `${story.title} ${story.description ?? ''}`;
+      const classification = classifyKeyword(storyText);
+
+      const tech = inferTechSubDomains(storyText, classification.primaryDomain);
+      const quality = inferQualityTags(storyText);
+      const risk = inferRisk(tech.all, quality, story.lifecycle ?? null);
+      const effort = inferEffort(storyText, classification.complexity);
+      const blockedBy = inferBlockedBy(storyText);
+      const claims = inferClaims(storyText, tech.all);
+
+      const violations = validateTaxonomyInvariants({
+        effort,
+        risk,
+        priorityBucket: story.priorityBucket ?? null,
+        lifecycle: story.lifecycle ?? null,
+      });
+
+      if (effort === 'XL') storiesRequiringSplit++;
+      if (risk === 'critical') storiesWithCriticalRisk++;
+
+      const validationStatus = violations.length > 0 ? 'invalid' : story.templateValidationStatus;
+      const validationErrors =
+        violations.length > 0 ? JSON.stringify(violations) : story.templateValidationErrors;
+
+      db.update(stories)
+        .set({
+          techSubDomainsJson: JSON.stringify(tech.all),
+          techSubDomainPrimary: tech.primary,
+          qualityTagsJson: JSON.stringify(quality),
+          risk,
+          effort,
+          blockedByJson: JSON.stringify(blockedBy),
+          claimsJson: JSON.stringify(claims),
+          templateValidationStatus: validationStatus,
+          templateValidationErrors: validationErrors,
+        })
+        .where(eq(stories.id, story.id))
+        .run();
+
+      storiesClassified++;
+      techSubDomainsAssigned += tech.all.length;
+      qualityTagsAssigned += quality.length;
+      blockedByMarkersFound += blockedBy.length;
+    } catch (err) {
+      logger.warn({ err, storyId: story.id }, 'EA Agent: story classification failed');
+    }
+  }
+
+  // Advance pipeline to ea_classified (between po_decomposed and ba_enriched).
+  advancePipelineStage(
+    {
+      promptId,
+      stage: 'ea_classified',
+      correlationId,
+      metadata: {
+        storiesClassified,
+        techSubDomainsAssigned,
+        qualityTagsAssigned,
+        storiesWithCriticalRisk,
+        storiesRequiringSplit,
+      },
+    },
+    db,
+  );
+
+  eventBus.publish({
+    type: 'ea-agent.classification.complete',
+    actor: 'ea-agent',
+    correlation_id: correlationId,
+    entity_type: 'prompt',
+    entity_id: promptId,
+    payload: {
+      promptId,
+      correlationId,
+      storiesClassified,
+      techSubDomainsAssigned,
+      qualityTagsAssigned,
+      blockedByMarkersFound,
+      storiesWithCriticalRisk,
+      storiesRequiringSplit,
+    },
+  });
+
+  return {
+    promptId,
+    storiesClassified,
+    techSubDomainsAssigned,
+    qualityTagsAssigned,
+    blockedByMarkersFound,
+    storiesWithCriticalRisk,
+    storiesRequiringSplit,
+  };
+}

--- a/apps/orchestrator/src/agents/pipeline-stages.ts
+++ b/apps/orchestrator/src/agents/pipeline-stages.ts
@@ -24,7 +24,14 @@ export const PIPELINE_STAGE_ORDER = [
   'ingested',
   'scaffolded',
   'po_decomposed',
+  // BUCKET-003: EA classifies tech / quality / risk / effort between PO and BA.
+  'ea_classified',
   'ba_enriched',
+  // BUCKET-003 / pipeline refresh: Validator + Testing slot between BA and
+  // Task Manager. Their stages live in the enum but the BUCKET-### work
+  // doesn'''t emit them — the Validator and Testing tracks own those.
+  'validated',
+  'test_designed',
   'bucket_placed',
   'ready_for_pickup',
 ] as const;

--- a/apps/orchestrator/src/agents/scaffolder.ts
+++ b/apps/orchestrator/src/agents/scaffolder.ts
@@ -268,6 +268,17 @@ export async function runScaffolder(
 
     poChain
       .then(() => {
+        // BUCKET-003: EA Agent runs between PO and BA — assigns techSubDomains,
+        // qualityTags, risk, effort, blockedBy, claims to every story.
+        if (agentsToActivate.includes('ea-agent') || agentsToActivate.includes('ba-agent')) {
+          return import('./ea-agent')
+            .then(({ runEAAgent }) =>
+              runEAAgent({ promptId, correlationId }, db),
+            )
+            .catch((err: unknown) => logger.warn({ err }, 'EA Agent failed'));
+        }
+      })
+      .then(() => {
         if (agentsToActivate.includes('ba-agent')) {
           return import('./ba-agent')
             .then(({ runBAAgent }) =>
@@ -283,7 +294,7 @@ export async function runScaffolder(
         }
       })
       .catch((err: unknown) =>
-        logger.warn({ err }, 'BA Agent / Task Scheduler chain failed'),
+        logger.warn({ err }, 'EA / BA Agent / Task Scheduler chain failed'),
       );
   }, 5_000);
 }

--- a/apps/orchestrator/src/db/seeds/agents.ts
+++ b/apps/orchestrator/src/db/seeds/agents.ts
@@ -49,7 +49,8 @@ const AGENTS: AgentSeedRow[] = [
     description: 'Enriches stories with acceptance criteria, functional specs, implementation detail, and domain labels.',
     modelRecommendation: 'sonnet',
     capabilities: ['story-enrichment', 'acceptance-criteria', 'functional-specs'],
-    triggerEvents: ['po-agent.decomposition.complete'],
+    // BUCKET-003: BA now triggers on EA classification complete (PO -> EA -> BA chain).
+    triggerEvents: ['ea-agent.classification.complete'],
   },
   {
     id: 'ux-agent',
@@ -146,10 +147,10 @@ const AGENTS: AgentSeedRow[] = [
     name: 'ea-agent',
     displayName: 'Enterprise Architect Agent',
     tier: 'strategic',
-    description: 'Translates business vision into technical initiatives, produces ADRs, makes platform decisions.',
+    description: 'Classifies stories along the BUCKET-003 taxonomy axes (techSubDomains, qualityTags, risk, effort, blockedBy, claims) and produces ADRs for new projects + major refactors.',
     modelRecommendation: 'opus',
-    capabilities: ['architecture-design', 'adr-production', 'platform-decision'],
-    triggerEvents: ['prompt.ingested'],
+    capabilities: ['architecture-design', 'adr-production', 'platform-decision', 'taxonomy-classification'],
+    triggerEvents: ['po-agent.decomposition.complete'],
   },
   {
     id: 'platform-agent',

--- a/apps/orchestrator/tests/agents/ea-agent.test.ts
+++ b/apps/orchestrator/tests/agents/ea-agent.test.ts
@@ -1,0 +1,236 @@
+/**
+ * BUCKET-003 — EA Agent unit tests.
+ *
+ * Cover the pure helpers (tech sub-domain inference, quality tags, risk,
+ * effort, blocked-by parser, claims inference, mutual-exclusion validator)
+ * — not the DB integration; that's covered by the BUCKET-006 E2E.
+ */
+
+import {
+  inferTechSubDomains,
+  inferQualityTags,
+  inferRisk,
+  inferEffort,
+  inferBlockedBy,
+  inferClaims,
+  validateTaxonomyInvariants,
+} from '../../src/agents/ea-agent';
+
+describe('inferTechSubDomains', () => {
+  it('uses primary-domain seed when text is sparse', () => {
+    const r = inferTechSubDomains('Add OAuth2 login', 'auth');
+    expect(r.primary).toBe('auth');
+    expect(r.all).toContain('auth');
+  });
+
+  it('detects database work', () => {
+    const r = inferTechSubDomains('Add a drizzle migration for the new schema', 'data-storage');
+    expect(r.all).toContain('database');
+    expect(r.primary).toBe('database');
+  });
+
+  it('detects multiple tech sub-domains and orders by score', () => {
+    const r = inferTechSubDomains(
+      'Build a React component that calls /api/billing and renders an invoice',
+      'ui-frontend',
+    );
+    expect(r.all).toContain('frontend');
+    // The seed bonus lands frontend first.
+    expect(r.primary).toBe('frontend');
+  });
+
+  it('falls back to backend when nothing matches', () => {
+    const r = inferTechSubDomains('lorem ipsum dolor sit amet', 'business-logic');
+    expect(r.primary).toBe('backend');
+    expect(r.all).toEqual(['backend']);
+  });
+
+  it('caps tech sub-domains at 5', () => {
+    const longText =
+      'react component, drizzle migration, cron schedule, observability metric, ' +
+      'wcag compliance, sentry alert, vault secret, ga4 analytics, sendgrid email';
+    const r = inferTechSubDomains(longText, 'ui-frontend');
+    expect(r.all.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('inferQualityTags', () => {
+  it('detects accessibility', () => {
+    expect(inferQualityTags('must meet WCAG 2.2 AA with aria roles')).toContain('accessibility');
+  });
+  it('detects seo', () => {
+    expect(inferQualityTags('add canonical URL and og: meta tags')).toContain('seo');
+  });
+  it('detects performance', () => {
+    expect(inferQualityTags('improve lighthouse score and bundle size')).toContain('performance');
+  });
+  it('detects security', () => {
+    expect(inferQualityTags('add CSP header and threat model')).toContain('security');
+  });
+  it('detects compliance', () => {
+    expect(inferQualityTags('GDPR compliance audit trail')).toContain('compliance');
+  });
+  it('detects observability', () => {
+    expect(inferQualityTags('add tracing and structured logging')).toContain('observability');
+  });
+  it('detects internationalization', () => {
+    expect(inferQualityTags('add i18n translation pipeline')).toContain('internationalization');
+  });
+  it('returns [] when no quality concerns mentioned', () => {
+    expect(inferQualityTags('add a billing tab')).toEqual([]);
+  });
+});
+
+describe('inferRisk', () => {
+  it('returns critical for data-migration tech', () => {
+    expect(inferRisk(['data-migration'], [], 'new')).toBe('critical');
+  });
+  it('returns high when auth is touched', () => {
+    expect(inferRisk(['auth'], [], 'new')).toBe('high');
+  });
+  it('returns high when payments is touched', () => {
+    expect(inferRisk(['payments'], [], 'new')).toBe('high');
+  });
+  it('returns high for hotfix lifecycle regardless', () => {
+    expect(inferRisk(['frontend'], [], 'hotfix')).toBe('high');
+  });
+  it('returns high when compliance quality tag is set', () => {
+    expect(inferRisk(['frontend'], ['compliance'], 'new')).toBe('high');
+  });
+  it('returns low for docs lifecycle', () => {
+    expect(inferRisk(['documentation'], [], 'docs')).toBe('low');
+  });
+  it('returns low for chore lifecycle', () => {
+    expect(inferRisk(['ci-cd'], [], 'chore')).toBe('low');
+  });
+  it('returns medium otherwise', () => {
+    expect(inferRisk(['frontend'], [], 'new')).toBe('medium');
+  });
+});
+
+describe('inferEffort', () => {
+  it('maps classifier complexity to effort', () => {
+    expect(inferEffort('x', 'trivial')).toBe('XS');
+    expect(inferEffort('x', 'small')).toBe('S');
+    expect(inferEffort('x', 'medium')).toBe('M');
+    expect(inferEffort('x', 'large')).toBe('L');
+    expect(inferEffort('x', 'xl')).toBe('XL');
+  });
+
+  it('falls back to word count when classifier returns unknown', () => {
+    expect(inferEffort('one two three', 'unknown')).toBe('XS');
+    expect(inferEffort('a b c d e f g h i j', 'unknown')).toBe('S');
+    expect(inferEffort(Array(50).fill('word').join(' '), 'unknown')).toBe('M');
+    expect(inferEffort(Array(150).fill('word').join(' '), 'unknown')).toBe('L');
+    expect(inferEffort(Array(300).fill('word').join(' '), 'unknown')).toBe('XL');
+  });
+});
+
+describe('inferBlockedBy', () => {
+  it('returns [] when no markers present', () => {
+    expect(inferBlockedBy('build a feature')).toEqual([]);
+  });
+
+  it('detects "after #STORY-X"', () => {
+    expect(inferBlockedBy('do this after #story-foo-001')).toEqual(['story-foo-001']);
+  });
+
+  it('detects "depends on STORY-X"', () => {
+    expect(inferBlockedBy('depends on story-bar-002')).toEqual(['story-bar-002']);
+  });
+
+  it('detects "blocked by STORY-X"', () => {
+    expect(inferBlockedBy('this is blocked by #story-baz-003')).toEqual(['story-baz-003']);
+  });
+
+  it('deduplicates repeated markers', () => {
+    const r = inferBlockedBy('after #story-x-1 and after #story-x-1');
+    expect(r).toEqual(['story-x-1']);
+  });
+
+  it('finds multiple distinct markers', () => {
+    const r = inferBlockedBy(
+      'depends on story-a-1 and after #story-b-2 and blocked by story-c-3',
+    );
+    expect(r).toContain('story-a-1');
+    expect(r).toContain('story-b-2');
+    expect(r).toContain('story-c-3');
+  });
+});
+
+describe('inferClaims', () => {
+  it('finds files mentioned in text', () => {
+    const r = inferClaims(
+      'edit apps/orchestrator/src/agents/po-agent.ts',
+      ['agent-runtime'],
+    );
+    expect(r.files).toContain('apps/orchestrator/src/agents/po-agent.ts');
+  });
+
+  it('finds API routes', () => {
+    const r = inferClaims('add POST /api/billing endpoint', ['bff']);
+    expect(r.apiRoutes.some((r) => r.includes('/api/billing'))).toBe(true);
+  });
+
+  it('finds schema columns', () => {
+    const r = inferClaims('add stories.tech_sub_domain_primary column', ['database']);
+    expect(r.schemas.some((s) => s.includes('stories.'))).toBe(true);
+  });
+
+  it('coarse-fallback domains = techAll', () => {
+    const r = inferClaims('lorem', ['frontend', 'bff']);
+    expect(r.domains).toEqual(['frontend', 'bff']);
+  });
+});
+
+describe('validateTaxonomyInvariants', () => {
+  it('flags effort=XL', () => {
+    const v = validateTaxonomyInvariants({
+      effort: 'XL',
+      risk: 'medium',
+      priorityBucket: 'P2',
+      lifecycle: 'new',
+    });
+    expect(v.some((e) => e.field === 'effort')).toBe(true);
+  });
+
+  it('flags critical risk + low priority', () => {
+    const v = validateTaxonomyInvariants({
+      effort: 'M',
+      risk: 'critical',
+      priorityBucket: 'P3',
+      lifecycle: 'new',
+    });
+    expect(v.some((e) => e.field === 'priorityBucket')).toBe(true);
+  });
+
+  it('accepts critical risk + P0', () => {
+    const v = validateTaxonomyInvariants({
+      effort: 'M',
+      risk: 'critical',
+      priorityBucket: 'P0',
+      lifecycle: 'new',
+    });
+    expect(v.length).toBe(0);
+  });
+
+  it('flags lifecycle=spike + effort=L', () => {
+    const v = validateTaxonomyInvariants({
+      effort: 'L',
+      risk: 'medium',
+      priorityBucket: 'P2',
+      lifecycle: 'spike',
+    });
+    expect(v.some((e) => e.field === 'effort' && /spike/.test(e.message))).toBe(true);
+  });
+
+  it('returns [] for valid combinations', () => {
+    const v = validateTaxonomyInvariants({
+      effort: 'M',
+      risk: 'medium',
+      priorityBucket: 'P2',
+      lifecycle: 'new',
+    });
+    expect(v).toEqual([]);
+  });
+});

--- a/apps/orchestrator/tests/agents/pipeline-stages.test.ts
+++ b/apps/orchestrator/tests/agents/pipeline-stages.test.ts
@@ -52,7 +52,10 @@ describe('PIPELINE_STAGE_ORDER', () => {
       'ingested',
       'scaffolded',
       'po_decomposed',
+      'ea_classified',
       'ba_enriched',
+      'validated',
+      'test_designed',
       'bucket_placed',
       'ready_for_pickup',
     ]);

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -23,6 +23,7 @@ export type EventActor =
   | 'secrets-broker'
   | 'scaffolder'
   | 'po-agent'
+  | 'ea-agent'
   | 'ba-agent'
   | 'task-scheduler'
   | 'testing-agent'
@@ -231,6 +232,19 @@ export interface POAgentDecompositionCompletePayload {
   primaryDomain: string;
 }
 
+// ─── EA Agent (BUCKET-003) ───────────────────────────────────────────────────
+
+export interface EAAgentClassificationCompletePayload {
+  promptId: string;
+  correlationId: string;
+  storiesClassified: number;
+  techSubDomainsAssigned: number;
+  qualityTagsAssigned: number;
+  blockedByMarkersFound: number;
+  storiesWithCriticalRisk: number;
+  storiesRequiringSplit: number;
+}
+
 // ─── BA Agent (migration 0018) ────────────────────────────────────────────────
 
 export interface BAAgentEnrichmentCompletePayload {
@@ -316,6 +330,8 @@ export type EventType =
   | 'scaffolder.team.assembled'
   // ─── PO Agent events (migration 0019) ─────────────────────────────────────
   | 'po-agent.decomposition.complete'
+  // ─── EA Agent events (BUCKET-003) ─────────────────────────────────────────
+  | 'ea-agent.classification.complete'
   // ─── BA Agent + Task Scheduler events (migration 0018) ────────────────────
   | 'ba-agent.enrichment.complete'
   // ─── BA cross-agent collaboration protocol (migration 0022) ──────────────
@@ -387,6 +403,8 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'scaffolder.team.assembled': 'info',
   // ─── PO Agent events (migration 0019) ─────────────────────────────────────
   'po-agent.decomposition.complete': 'info',
+  // ─── EA Agent events (BUCKET-003) ─────────────────────────────────────────
+  'ea-agent.classification.complete': 'info',
   // ─── BA Agent + Task Scheduler events (migration 0018) ────────────────────
   'ba-agent.enrichment.complete': 'info',
   // ─── BA cross-agent collaboration protocol (migration 0022) ──────────────


### PR DESCRIPTION
## BUCKET-003 — EA Agent runtime

Inserts the **Enterprise Architect** agent between PO and BA in the orchestration chain. The EA reads every story PO just decomposed and fills in the rest of the BUCKET-001 9-axis taxonomy that PO didn't set: `techSubDomains{primary,all}`, `qualityTags`, `risk`, `effort`, `blockedBy`, plus BUCKET-009-staging `claims`.

### `apps/orchestrator/src/agents/ea-agent.ts` (new)

Pure-function helpers (each individually unit-tested):

- `inferTechSubDomains(text, primaryDomain)` — keyword + seed scoring against the 40-entry `TECH_SUB_DOMAINS` enum; caps at 5; falls back to `backend`.
- `inferQualityTags(text)` — `accessibility / seo / performance / security / compliance / observability / internationalization`.
- `inferRisk(techAll, qualityTags, lifecycle)` — `critical` for data-migration; `high` for auth/payments/database/secrets-management, hotfix lifecycle, or compliance/security quality tags; `low` for docs/chore; else `medium`.
- `inferEffort(text, complexity)` — `trivial→XS … xl→XL`, with word-count fallback when classifier returns unknown.
- `inferBlockedBy(text)` — regex parse of `after #STORY-X` / `depends on STORY-Y` / `blocked by STORY-Z`, deduped.
- `inferClaims(text, techAll)` — files / schemas / apiRoutes from text patterns; coarse `domains = techAll` fallback.
- `validateTaxonomyInvariants(...)` — flags `effort=XL`, `risk=critical + priorityBucket ∈ {P2,P3}`, `lifecycle=spike + effort ∈ {L,XL}`.

`runEAAgent(input, db)` iterates every story under the prompt, persists the taxonomy fields, marks `template_validation_status='invalid'` on §4.2 violations, advances the pipeline to `ea_classified`, and emits `ea-agent.classification.complete`.

### Pipeline wiring

- `scaffolder.ts`: chain becomes **PO → EA → BA → Task Scheduler**. EA runs whenever `ea-agent` OR `ba-agent` is in the activated set so existing BA-only flows keep working unchanged.
- `pipeline-stages.ts`: `PIPELINE_STAGE_ORDER` gains `ea_classified` between `po_decomposed` and `ba_enriched`, plus `validated` and `test_designed` (the parallel Validator + Testing tracks own *emitting* those — BUCKET-003 just reserves the enum slots per the new pipeline order).
- `events-taxonomy-internal/index.ts`: new `EventActor: 'ea-agent'`, new `EventType: 'ea-agent.classification.complete'` (severity `info`), new `EAAgentClassificationCompletePayload` interface.
- `db/seeds/agents.ts`: `ea-agent` triggers on `po-agent.decomposition.complete`; `ba-agent` triggers on `ea-agent.classification.complete`.

### Tests

- `apps/orchestrator/tests/agents/ea-agent.test.ts` — 27 cases covering all pure helpers (typecheck-verified; the orchestrator's jest config is currently stubbed pre-PR cleanup, so these run alongside the other agent tests when the runner is un-stubbed).
- `pipeline-stages.test.ts` updated to lock the new 10-stage canonical order.
- `pnpm --filter @caia-app/core run typecheck` — clean.
- `pnpm --filter @chiefaia/ticket-template test` — 55/55 pass.

### What this unblocks

- **BUCKET-009** — claims field on schema is shipped via BUCKET-001 + populated by EA in this PR; remaining BUCKET-009 work is the ready-pool + claim-checker that the multi-bucket placer enforces.
- **BUCKET-004** — placer keys on `(project_slug, tech_sub_domain_primary)`. Both fields are now populated.
- **BUCKET-005/006** — dashboard + E2E read the populated taxonomy.

### References

- Directive: `agent/memory/po_taxonomy_directive.md`
- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§3.3 tech sub-domains, §3.5–§3.7 quality/risk/effort, §4 composition rules)
