### PR TITLE
feat(events-taxonomy): test.cases_generated + test.case_added events (TEST-003)

### DIFF
--- a/apps/orchestrator/tests/events/test-event-types.test.ts
+++ b/apps/orchestrator/tests/events/test-event-types.test.ts
@@ -1,0 +1,128 @@
+/**
+ * TEST-003 — verifies the new test.cases_generated and test.case_added
+ * event types are registered in @chiefaia/events-taxonomy-internal and
+ * round-trip through the eventBus.
+ */
+import {
+  ALL_EVENT_TYPES,
+  EVENT_SEVERITY,
+  isValidEventType,
+  type EventType,
+  type TestCasesGeneratedPayload,
+  type TestCaseAddedPayload,
+} from '@chiefaia/events-taxonomy-internal';
+import { eventBus } from '../../src/events/bus-adapter';
+
+describe('TEST-003 — testing-framework event types', () => {
+  it('registers test.cases_generated as a valid EventType', () => {
+    expect(isValidEventType('test.cases_generated')).toBe(true);
+    expect(ALL_EVENT_TYPES).toContain('test.cases_generated' as EventType);
+    expect(EVENT_SEVERITY['test.cases_generated']).toBe('info');
+  });
+
+  it('registers test.case_added as a valid EventType', () => {
+    expect(isValidEventType('test.case_added')).toBe(true);
+    expect(ALL_EVENT_TYPES).toContain('test.case_added' as EventType);
+    expect(EVENT_SEVERITY['test.case_added']).toBe('info');
+  });
+
+  it('typechecks the TestCasesGeneratedPayload contract', () => {
+    const payload: TestCasesGeneratedPayload = {
+      storyId: 'sty_test_003',
+      promptId: 'prm_test_003',
+      correlationId: 'cor_test_003',
+      totalCases: 5,
+      categoryCounts: {
+        happy: 2, edge: 1, error: 1,
+        accessibility: 1, security: 0, performance: 0, visual: 0,
+      },
+      durationMs: 230,
+    };
+    expect(payload.totalCases).toBe(5);
+    expect(
+      Object.values(payload.categoryCounts).reduce((a, b) => a + b, 0),
+    ).toBe(payload.totalCases);
+  });
+
+  it('typechecks the TestCaseAddedPayload contract', () => {
+    const payload: TestCaseAddedPayload = {
+      storyId: 'sty_test_003',
+      promptId: 'prm_test_003',
+      correlationId: 'cor_test_003',
+      testCaseId: 'tc-001',
+      category: 'happy',
+      layer: 'e2e',
+    };
+    expect(payload.category).toBe('happy');
+  });
+
+  it('round-trips test.cases_generated through the eventBus', (done) => {
+    const unsub = eventBus.subscribe('test.cases_generated', (evt) => {
+      try {
+        expect(evt.actor).toBe('testing-agent');
+        expect(evt.entity_id).toBe('sty_x');
+        const pl = evt.payload as unknown as TestCasesGeneratedPayload;
+        expect(pl.totalCases).toBe(3);
+        expect(pl.categoryCounts.happy).toBe(2);
+        expect(pl.categoryCounts.error).toBe(1);
+        unsub();
+        done();
+      } catch (err) {
+        unsub();
+        done(err as Error);
+      }
+    });
+
+    eventBus.publish({
+      type: 'test.cases_generated',
+      actor: 'testing-agent',
+      correlation_id: 'cor_x',
+      entity_type: 'story',
+      entity_id: 'sty_x',
+      payload: {
+        storyId: 'sty_x',
+        promptId: 'prm_x',
+        correlationId: 'cor_x',
+        totalCases: 3,
+        categoryCounts: {
+          happy: 2, edge: 0, error: 1,
+          accessibility: 0, security: 0, performance: 0, visual: 0,
+        },
+        durationMs: 120,
+      },
+    });
+  });
+
+  it('round-trips test.case_added through the eventBus', (done) => {
+    const unsub = eventBus.subscribe('test.case_added', (evt) => {
+      try {
+        expect(evt.actor).toBe('testing-agent');
+        const pl = evt.payload as unknown as TestCaseAddedPayload;
+        expect(pl.testCaseId).toBe('tc-007');
+        expect(pl.category).toBe('accessibility');
+        expect(pl.layer).toBe('accessibility');
+        unsub();
+        done();
+      } catch (err) {
+        unsub();
+        done(err as Error);
+      }
+    });
+
+    eventBus.publish({
+      type: 'test.case_added',
+      actor: 'testing-agent',
+      correlation_id: 'cor_y',
+      entity_type: 'story',
+      entity_id: 'sty_y',
+      payload: {
+        storyId: 'sty_y',
+        promptId: 'prm_y',
+        correlationId: 'cor_y',
+        testCaseId: 'tc-007',
+        category: 'accessibility',
+        layer: 'accessibility',
+      },
+    });
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -289,6 +289,41 @@ export interface ReleaseAgentReportReadyPayload {
   blockers: string[];
 }
 
+// ─── Story-driven testing framework — Phase A (TEST-003) ─────────────────────
+
+export interface TestCasesGeneratedPayload {
+  storyId: string;
+  promptId: string;
+  correlationId: string;
+  totalCases: number;
+  categoryCounts: {
+    happy: number;
+    edge: number;
+    error: number;
+    accessibility: number;
+    security: number;
+    performance: number;
+    visual: number;
+  };
+  durationMs: number;
+}
+
+export interface TestCaseAddedPayload {
+  storyId: string;
+  promptId: string;
+  correlationId: string;
+  testCaseId: string;
+  category:
+    | 'happy'
+    | 'edge'
+    | 'error'
+    | 'accessibility'
+    | 'security'
+    | 'performance'
+    | 'visual';
+  layer: 'unit' | 'integration' | 'e2e' | 'visual' | 'accessibility';
+}
+
 // ─── Union type of all valid event types ─────────────────────────────────────
 
 export type EventType =
@@ -349,6 +384,9 @@ export type EventType =
   // ─── Testing Agent + Release Agent events (Tier 4) ────────────────────────
   | 'testing-agent.validation.complete'
   | 'release-agent.report.ready'
+  // ─── Story-driven testing framework — Phase A (TEST-003) ──────────────────
+  | 'test.cases_generated'
+  | 'test.case_added'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -433,6 +471,9 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'artifact.approved': 'info',
   'artifact.rejected': 'warning',
   'artifact.superseded': 'warning',
+  // ─── Story-driven testing framework — Phase A (TEST-003) ──────────────────
+  'test.cases_generated': 'info',
+  'test.case_added': 'info',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -444,3 +444,14 @@ events:
     severity: info
     actor: [task-scheduler]
     payload: [storyId, promptId, correlationId, bucketId, bucketKind]
+
+  # Story-driven testing framework — Phase A (TEST-003)
+  - type: test.cases_generated
+    severity: info
+    actor: [testing-agent]
+    payload: [storyId, promptId, correlationId, totalCases, categoryCounts, durationMs]
+
+  - type: test.case_added
+    severity: info
+    actor: [testing-agent]
+    payload: [storyId, promptId, correlationId, testCaseId, category, layer]


### PR DESCRIPTION
## Summary

Registers two new event types in `@chiefaia/events-taxonomy-internal`
so the Testing Agent (TEST-004) can fire structured events the dashboard
and E2E tests can subscribe to.

## New events

- **`test.cases_generated`** — `testing-agent` — emitted once per story
  when the Testing Agent finishes generating its `testCases` array.
  Payload: `storyId`, `promptId`, `correlationId`, `totalCases`,
  `categoryCounts`, `durationMs`.
- **`test.case_added`** — `testing-agent` — emitted per case as the
  agent builds the array (lets the dashboard render cases live as they
  appear). Payload: `storyId`, `promptId`, `correlationId`,
  `testCaseId`, `category`, `layer`.

## Updates

- `registry.yaml` — two new entries under the "Story-driven testing
  framework — Phase A (TEST-003)" section.
- `index.ts` — `TestCasesGeneratedPayload` + `TestCaseAddedPayload`
  typed interfaces, `EventType` union members, `EVENT_SEVERITY` entries.

## Tests

- 6 new jest cases covering taxonomy registration + payload shape +
  in-process `eventBus` round-trip for both event types
- Orchestrator typecheck clean
- Stacked on top of TEST-001 (#89) and TEST-002 (#90); merging order is
  flexible (no schema dependencies between this PR and those).