### PR TITLE
feat(orchestrator): resource-claim checker + cross-bucket ready pool (BUCKET-009)

### DIFF
--- a/apps/orchestrator/src/scheduling/ready-pool.ts
+++ b/apps/orchestrator/src/scheduling/ready-pool.ts
@@ -1,0 +1,214 @@
+/**
+ * Ready pool — BUCKET-009.
+ *
+ * Maintains the cross-bucket pool of stories that are eligible for a
+ * worker to pick up. A story is "ready" iff:
+ *   1. its `blockedBy` chain is satisfied (every blocker is `done`/`verified`)
+ *   2. the fine-grained-claims gate passes (high/critical risk requires
+ *      claims.files non-empty — proposal §9.3)
+ *   3. its claims don't overlap with any currently in-flight story's
+ *      claims on files/schemas/apiRoutes
+ *
+ * The pool is rebuilt incrementally on `story.done` and `story.in-flight`
+ * events; for MVP we expose a pure recompute() that the placer / executor
+ * can call. Persistence is not required — the pool is derivable from
+ * `stories.*` whenever needed.
+ */
+
+import {
+  type Claims,
+  parseClaims,
+  checkClaimsConflict,
+  passesFineGrainedClaimsGate,
+} from './resource-claim-checker';
+
+// ─── Story snapshot (what the pool needs to know) ──────────────────────────
+
+export interface StorySnapshot {
+  id: string;
+  status: string;
+  bucketId: string | null;
+  blockedBy: string[];
+  risk: string | null;
+  priorityBucket: string | null;
+  claims: Claims;
+}
+
+/** Parse a raw story row into the shape the pool uses. */
+export function snapshotStory(row: {
+  id: string;
+  status: string;
+  bucketId?: string | null;
+  blockedByJson?: string | null;
+  risk?: string | null;
+  priorityBucket?: string | null;
+  claimsJson?: string | null;
+}): StorySnapshot {
+  let blockedBy: string[] = [];
+  try {
+    const parsed = JSON.parse(row.blockedByJson ?? '[]');
+    if (Array.isArray(parsed)) blockedBy = parsed.filter((s) => typeof s === 'string');
+  } catch {
+    /* malformed JSON treated as no blockers */
+  }
+  return {
+    id: row.id,
+    status: row.status,
+    bucketId: row.bucketId ?? null,
+    blockedBy,
+    risk: row.risk ?? null,
+    priorityBucket: row.priorityBucket ?? null,
+    claims: parseClaims(row.claimsJson ?? null),
+  };
+}
+
+// ─── Status sets ───────────────────────────────────────────────────────────
+
+const DONE_STATUSES = new Set(['verified', 'done', 'completed']);
+const IN_FLIGHT_STATUSES = new Set(['in_progress', 'running', 'partial']);
+const READY_STATUSES = new Set(['pending', 'ready']);
+
+export function isDone(status: string): boolean {
+  return DONE_STATUSES.has(status);
+}
+export function isInFlight(status: string): boolean {
+  return IN_FLIGHT_STATUSES.has(status);
+}
+export function isPotentiallyReady(status: string): boolean {
+  return READY_STATUSES.has(status);
+}
+
+// ─── Recompute ─────────────────────────────────────────────────────────────
+
+export interface PoolEntry {
+  storyId: string;
+  bucketId: string | null;
+  risk: string | null;
+  priorityBucket: string | null;
+}
+
+export interface DeferredEntry extends PoolEntry {
+  reason: 'blocked-by' | 'claims-gate' | 'claims-conflict';
+  blockerIds: string[];
+  /** Populated when reason === 'claims-conflict' — the first overlapping in-flight story. */
+  conflictingStoryId?: string;
+  conflictingClaim?: { kind: 'file' | 'schema' | 'apiRoute'; value: string };
+}
+
+export interface RecomputeResult {
+  ready: PoolEntry[];
+  deferred: DeferredEntry[];
+  inFlight: PoolEntry[];
+}
+
+/**
+ * Pure recompute. Given the current `stories` snapshot set, partition into
+ * `ready`, `deferred` (with reasons), and `inFlight`.
+ *
+ * Ordering of `ready`: by priorityBucket (P0 first), then story id (stable).
+ * The executor's pickup-time check should re-run `checkClaimsConflict` against
+ * the latest in-flight set — `recompute` is a single point-in-time view.
+ */
+export function recompute(stories: StorySnapshot[]): RecomputeResult {
+  const byId = new Map<string, StorySnapshot>();
+  for (const s of stories) byId.set(s.id, s);
+
+  const inFlight: PoolEntry[] = [];
+  const ready: PoolEntry[] = [];
+  const deferred: DeferredEntry[] = [];
+
+  // First pass: build the in-flight set.
+  for (const s of stories) {
+    if (isInFlight(s.status)) {
+      inFlight.push({
+        storyId: s.id,
+        bucketId: s.bucketId,
+        risk: s.risk,
+        priorityBucket: s.priorityBucket,
+      });
+    }
+  }
+  const inFlightSnapshots = stories.filter((s) => isInFlight(s.status));
+
+  // Second pass: classify the candidates.
+  for (const s of stories) {
+    if (!isPotentiallyReady(s.status)) continue;
+
+    // 1. blockedBy gate.
+    const unfinishedBlockers = s.blockedBy.filter((bid) => {
+      const blocker = byId.get(bid);
+      return !blocker || !isDone(blocker.status);
+    });
+    if (unfinishedBlockers.length > 0) {
+      deferred.push({
+        storyId: s.id,
+        bucketId: s.bucketId,
+        risk: s.risk,
+        priorityBucket: s.priorityBucket,
+        reason: 'blocked-by',
+        blockerIds: unfinishedBlockers,
+      });
+      continue;
+    }
+
+    // 2. fine-grained-claims gate (high/critical risk).
+    if (!passesFineGrainedClaimsGate(s.risk, s.claims)) {
+      deferred.push({
+        storyId: s.id,
+        bucketId: s.bucketId,
+        risk: s.risk,
+        priorityBucket: s.priorityBucket,
+        reason: 'claims-gate',
+        blockerIds: [],
+      });
+      continue;
+    }
+
+    // 3. claims-conflict gate.
+    const conflict = checkClaimsConflict(
+      { id: s.id, claims: s.claims },
+      inFlightSnapshots.map((other) => ({ id: other.id, claims: other.claims })),
+    );
+    if (conflict.conflict) {
+      const firstFile = conflict.overlappingFiles[0];
+      const firstSchema = conflict.overlappingSchemas[0];
+      const firstRoute = conflict.overlappingApiRoutes[0];
+      const conflictingClaim: DeferredEntry['conflictingClaim'] = firstFile
+        ? { kind: 'file', value: firstFile }
+        : firstSchema
+          ? { kind: 'schema', value: firstSchema }
+          : firstRoute
+            ? { kind: 'apiRoute', value: firstRoute }
+            : undefined;
+      deferred.push({
+        storyId: s.id,
+        bucketId: s.bucketId,
+        risk: s.risk,
+        priorityBucket: s.priorityBucket,
+        reason: 'claims-conflict',
+        blockerIds: conflict.blockerStoryId ? [conflict.blockerStoryId] : [],
+        conflictingStoryId: conflict.blockerStoryId,
+        conflictingClaim,
+      });
+      continue;
+    }
+
+    ready.push({
+      storyId: s.id,
+      bucketId: s.bucketId,
+      risk: s.risk,
+      priorityBucket: s.priorityBucket,
+    });
+  }
+
+  // Stable order: P0 < P1 < P2 < P3 < null, then story id ascending.
+  const PRIORITY_ORDER = ['P0', 'P1', 'P2', 'P3'];
+  ready.sort((a, b) => {
+    const ai = a.priorityBucket ? PRIORITY_ORDER.indexOf(a.priorityBucket) : 999;
+    const bi = b.priorityBucket ? PRIORITY_ORDER.indexOf(b.priorityBucket) : 999;
+    if (ai !== bi) return ai - bi;
+    return a.storyId.localeCompare(b.storyId);
+  });
+
+  return { ready, deferred, inFlight };
+}

--- a/apps/orchestrator/src/scheduling/resource-claim-checker.ts
+++ b/apps/orchestrator/src/scheduling/resource-claim-checker.ts
@@ -1,0 +1,120 @@
+/**
+ * Resource-claim conflict checker — BUCKET-009.
+ *
+ * Pure function. Given a candidate story's `claims` and the set of
+ * currently-in-flight stories' claims, return whether the candidate would
+ * overlap on any of {files, schemas, apiRoutes}. The `domains` axis is the
+ * coarse fallback — never used to block, only to route.
+ *
+ * The placer calls this at executor pickup time (NOT at placement time)
+ * so the check is always against the *current* in-flight set, not stale
+ * placement-time state. See proposal §9.3.
+ */
+
+export interface Claims {
+  files: string[];
+  schemas: string[];
+  apiRoutes: string[];
+  domains: string[];
+}
+
+export interface ConflictResult {
+  conflict: boolean;
+  overlappingFiles: string[];
+  overlappingSchemas: string[];
+  overlappingApiRoutes: string[];
+  /** First conflicting in-flight story id, if any (for surfacing). */
+  blockerStoryId?: string;
+}
+
+const EMPTY_CLAIMS: Claims = { files: [], schemas: [], apiRoutes: [], domains: [] };
+
+/** Parse the JSON payload stored in `stories.claims_json` into a Claims object. */
+export function parseClaims(json: string | null | undefined): Claims {
+  if (!json) return { ...EMPTY_CLAIMS };
+  try {
+    const parsed = JSON.parse(json) as Partial<Claims>;
+    return {
+      files: Array.isArray(parsed.files) ? parsed.files.filter((f) => typeof f === 'string') : [],
+      schemas: Array.isArray(parsed.schemas)
+        ? parsed.schemas.filter((s) => typeof s === 'string')
+        : [],
+      apiRoutes: Array.isArray(parsed.apiRoutes)
+        ? parsed.apiRoutes.filter((s) => typeof s === 'string')
+        : [],
+      domains: Array.isArray(parsed.domains)
+        ? parsed.domains.filter((d) => typeof d === 'string')
+        : [],
+    };
+  } catch {
+    return { ...EMPTY_CLAIMS };
+  }
+}
+
+/**
+ * Check whether `candidate.claims` overlaps with any in-flight story's
+ * claims on files, schemas, or apiRoutes. domains alone never causes a
+ * conflict — that's the coarse routing fallback.
+ *
+ * Returns the FIRST conflict found; the placer can decide whether to
+ * defer or surface a warning. (We intentionally don't return all overlaps
+ * — surfacing one root cause keeps the dashboard clean.)
+ */
+export function checkClaimsConflict(
+  candidate: { id: string; claims: Claims },
+  inFlight: Array<{ id: string; claims: Claims }>,
+): ConflictResult {
+  const candFiles = new Set(candidate.claims.files);
+  const candSchemas = new Set(candidate.claims.schemas);
+  const candApiRoutes = new Set(candidate.claims.apiRoutes);
+
+  for (const other of inFlight) {
+    if (other.id === candidate.id) continue;
+    const overlappingFiles = other.claims.files.filter((f) => candFiles.has(f));
+    const overlappingSchemas = other.claims.schemas.filter((s) => candSchemas.has(s));
+    const overlappingApiRoutes = other.claims.apiRoutes.filter((r) => candApiRoutes.has(r));
+    if (
+      overlappingFiles.length > 0 ||
+      overlappingSchemas.length > 0 ||
+      overlappingApiRoutes.length > 0
+    ) {
+      return {
+        conflict: true,
+        overlappingFiles,
+        overlappingSchemas,
+        overlappingApiRoutes,
+        blockerStoryId: other.id,
+      };
+    }
+  }
+
+  return {
+    conflict: false,
+    overlappingFiles: [],
+    overlappingSchemas: [],
+    overlappingApiRoutes: [],
+  };
+}
+
+/**
+ * High-risk granularity escalation. For `risk='high'` or `risk='critical'`,
+ * the scheduler upgrades to require `claims.files` non-empty before the
+ * story can enter the ready pool. This is what keeps two `auth` stories
+ * from concurrently rewriting the same middleware. See proposal §9.3.
+ */
+export function requiresFineGrainedClaims(risk: string | null | undefined): boolean {
+  return risk === 'high' || risk === 'critical';
+}
+
+/**
+ * A candidate story passes the fine-grained-claims gate iff it has at
+ * least one file claim (or non-high risk). Returns true when the gate is
+ * satisfied and the story can proceed.
+ */
+export function passesFineGrainedClaimsGate(
+  risk: string | null | undefined,
+  claims: Claims,
+): boolean {
+  if (!requiresFineGrainedClaims(risk)) return true;
+  return claims.files.length > 0;
+}

--- a/apps/orchestrator/tests/scheduling/ready-pool.test.ts
+++ b/apps/orchestrator/tests/scheduling/ready-pool.test.ts
@@ -1,0 +1,176 @@
+/**
+ * BUCKET-009 — ready-pool unit tests.
+ */
+
+import {
+  recompute,
+  snapshotStory,
+  type StorySnapshot,
+} from '../../src/scheduling/ready-pool';
+
+const empty = { files: [], schemas: [], apiRoutes: [], domains: [] };
+
+function story(
+  id: string,
+  status: string,
+  opts: Partial<Omit<StorySnapshot, 'id' | 'status'>> = {},
+): StorySnapshot {
+  return {
+    id,
+    status,
+    bucketId: opts.bucketId ?? null,
+    blockedBy: opts.blockedBy ?? [],
+    risk: opts.risk ?? 'medium',
+    priorityBucket: opts.priorityBucket ?? 'P2',
+    claims: opts.claims ?? empty,
+  };
+}
+
+describe('snapshotStory', () => {
+  it('parses raw row into the snapshot shape', () => {
+    const snap = snapshotStory({
+      id: 's1',
+      status: 'pending',
+      bucketId: 'bkt_a',
+      blockedByJson: '["s2","s3"]',
+      risk: 'high',
+      priorityBucket: 'P1',
+      claimsJson: JSON.stringify({ ...empty, files: ['x.ts'] }),
+    });
+    expect(snap.id).toBe('s1');
+    expect(snap.status).toBe('pending');
+    expect(snap.bucketId).toBe('bkt_a');
+    expect(snap.blockedBy).toEqual(['s2', 's3']);
+    expect(snap.risk).toBe('high');
+    expect(snap.priorityBucket).toBe('P1');
+    expect(snap.claims.files).toEqual(['x.ts']);
+  });
+
+  it('handles null/missing fields gracefully', () => {
+    const snap = snapshotStory({ id: 's1', status: 'pending' });
+    expect(snap.bucketId).toBeNull();
+    expect(snap.blockedBy).toEqual([]);
+    expect(snap.risk).toBeNull();
+    expect(snap.priorityBucket).toBeNull();
+    expect(snap.claims).toEqual(empty);
+  });
+});
+
+describe('recompute — basic gates', () => {
+  it('empty input -> empty output', () => {
+    const r = recompute([]);
+    expect(r.ready).toEqual([]);
+    expect(r.deferred).toEqual([]);
+    expect(r.inFlight).toEqual([]);
+  });
+
+  it('a pending story with no blockers is ready', () => {
+    const r = recompute([story('s1', 'pending')]);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['s1']);
+    expect(r.deferred).toEqual([]);
+  });
+
+  it('a blocked-by gate defers the candidate', () => {
+    const r = recompute([
+      story('blocker', 'pending'),
+      story('s1', 'pending', { blockedBy: ['blocker'] }),
+    ]);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['blocker']);
+    expect(r.deferred).toHaveLength(1);
+    expect(r.deferred[0]!.reason).toBe('blocked-by');
+    expect(r.deferred[0]!.blockerIds).toEqual(['blocker']);
+  });
+
+  it('blocked-by passes once blocker is verified', () => {
+    const r = recompute([
+      story('blocker', 'verified'),
+      story('s1', 'pending', { blockedBy: ['blocker'] }),
+    ]);
+    expect(r.ready.map((e) => e.storyId)).toContain('s1');
+  });
+
+  it('deferred when blocker is not in the snapshot at all', () => {
+    const r = recompute([story('s1', 'pending', { blockedBy: ['ghost'] })]);
+    expect(r.deferred[0]!.reason).toBe('blocked-by');
+  });
+});
+
+describe('recompute — fine-grained-claims gate', () => {
+  it('high risk + empty file claims -> deferred via claims-gate', () => {
+    const r = recompute([story('s1', 'pending', { risk: 'high' })]);
+    expect(r.deferred[0]!.reason).toBe('claims-gate');
+  });
+
+  it('high risk + file claims -> ready', () => {
+    const r = recompute([
+      story('s1', 'pending', { risk: 'high', claims: { ...empty, files: ['x.ts'] } }),
+    ]);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['s1']);
+  });
+
+  it('critical risk requires file claims too', () => {
+    const r = recompute([story('s1', 'pending', { risk: 'critical' })]);
+    expect(r.deferred[0]!.reason).toBe('claims-gate');
+  });
+
+  it('low risk -> no claims requirement', () => {
+    const r = recompute([story('s1', 'pending', { risk: 'low' })]);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['s1']);
+  });
+});
+
+describe('recompute — claims-conflict gate', () => {
+  it('candidate clashes with in-flight on file -> deferred', () => {
+    const r = recompute([
+      story('a', 'in_progress', { claims: { ...empty, files: ['shared.ts'] } }),
+      story('b', 'pending', { claims: { ...empty, files: ['shared.ts'] } }),
+    ]);
+    expect(r.ready.map((e) => e.storyId)).toEqual([]);
+    expect(r.deferred[0]!.reason).toBe('claims-conflict');
+    expect(r.deferred[0]!.conflictingStoryId).toBe('a');
+    expect(r.deferred[0]!.conflictingClaim).toEqual({ kind: 'file', value: 'shared.ts' });
+  });
+
+  it('different files do NOT conflict', () => {
+    const r = recompute([
+      story('a', 'in_progress', { claims: { ...empty, files: ['a.ts'] } }),
+      story('b', 'pending', { claims: { ...empty, files: ['b.ts'] } }),
+    ]);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['b']);
+  });
+
+  it('two pending stories with overlapping claims both READY (only conflict against in-flight)', () => {
+    const r = recompute([
+      story('a', 'pending', { claims: { ...empty, files: ['shared.ts'] } }),
+      story('b', 'pending', { claims: { ...empty, files: ['shared.ts'] } }),
+    ]);
+    expect(r.ready).toHaveLength(2);
+  });
+});
+
+describe('recompute — ordering', () => {
+  it('orders ready by priorityBucket then story id', () => {
+    const r = recompute([
+      story('z', 'pending', { priorityBucket: 'P0' }),
+      story('a', 'pending', { priorityBucket: 'P0' }),
+      story('m', 'pending', { priorityBucket: 'P3' }),
+      story('b', 'pending', { priorityBucket: 'P1' }),
+    ]);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['a', 'z', 'b', 'm']);
+  });
+});
+
+describe('recompute — partition correctness', () => {
+  it('partitions every story into exactly one of {ready, deferred, inFlight, omitted}', () => {
+    const stories = [
+      story('done', 'verified'),
+      story('inflight', 'in_progress'),
+      story('ready', 'pending'),
+      story('blocked', 'pending', { blockedBy: ['done'] }),
+    ];
+    const r = recompute(stories);
+    expect(r.ready.map((e) => e.storyId)).toEqual(['ready', 'blocked']);
+    expect(r.inFlight.map((e) => e.storyId)).toEqual(['inflight']);
+    // 'done' is neither ready nor deferred — it's just done.
+  });
+});

--- a/apps/orchestrator/tests/scheduling/resource-claim-checker.test.ts
+++ b/apps/orchestrator/tests/scheduling/resource-claim-checker.test.ts
@@ -1,0 +1,167 @@
+/**
+ * BUCKET-009 — resource-claim checker unit tests.
+ */
+
+import {
+  parseClaims,
+  checkClaimsConflict,
+  requiresFineGrainedClaims,
+  passesFineGrainedClaimsGate,
+} from '../../src/scheduling/resource-claim-checker';
+
+describe('parseClaims', () => {
+  it('returns empty claims for null/undefined/empty', () => {
+    expect(parseClaims(null)).toEqual({ files: [], schemas: [], apiRoutes: [], domains: [] });
+    expect(parseClaims(undefined)).toEqual({ files: [], schemas: [], apiRoutes: [], domains: [] });
+    expect(parseClaims('')).toEqual({ files: [], schemas: [], apiRoutes: [], domains: [] });
+  });
+
+  it('returns empty on malformed JSON', () => {
+    expect(parseClaims('not json')).toEqual({
+      files: [],
+      schemas: [],
+      apiRoutes: [],
+      domains: [],
+    });
+  });
+
+  it('parses a well-formed claims JSON', () => {
+    const c = parseClaims(
+      JSON.stringify({
+        files: ['a.ts'],
+        schemas: ['t.col'],
+        apiRoutes: ['POST /x'],
+        domains: ['frontend'],
+      }),
+    );
+    expect(c.files).toEqual(['a.ts']);
+    expect(c.schemas).toEqual(['t.col']);
+    expect(c.apiRoutes).toEqual(['POST /x']);
+    expect(c.domains).toEqual(['frontend']);
+  });
+
+  it('filters out non-string entries', () => {
+    const c = parseClaims(
+      JSON.stringify({
+        files: ['a.ts', 42, null, 'b.ts'],
+        schemas: [],
+        apiRoutes: [],
+        domains: [],
+      }),
+    );
+    expect(c.files).toEqual(['a.ts', 'b.ts']);
+  });
+});
+
+describe('checkClaimsConflict', () => {
+  const empty = { files: [], schemas: [], apiRoutes: [], domains: [] };
+
+  it('no conflict when both candidate and inFlight are empty', () => {
+    const r = checkClaimsConflict({ id: 'a', claims: empty }, []);
+    expect(r.conflict).toBe(false);
+  });
+
+  it('conflict on overlapping file', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, files: ['x.ts'] } },
+      [{ id: 'b', claims: { ...empty, files: ['x.ts'] } }],
+    );
+    expect(r.conflict).toBe(true);
+    expect(r.overlappingFiles).toEqual(['x.ts']);
+    expect(r.blockerStoryId).toBe('b');
+  });
+
+  it('conflict on overlapping schema', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, schemas: ['stories.lifecycle'] } },
+      [{ id: 'b', claims: { ...empty, schemas: ['stories.lifecycle'] } }],
+    );
+    expect(r.conflict).toBe(true);
+    expect(r.overlappingSchemas).toEqual(['stories.lifecycle']);
+  });
+
+  it('conflict on overlapping api route', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, apiRoutes: ['POST /api/billing'] } },
+      [{ id: 'b', claims: { ...empty, apiRoutes: ['POST /api/billing'] } }],
+    );
+    expect(r.conflict).toBe(true);
+    expect(r.overlappingApiRoutes).toEqual(['POST /api/billing']);
+  });
+
+  it('domains overlap alone does NOT cause a conflict', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, domains: ['frontend'] } },
+      [{ id: 'b', claims: { ...empty, domains: ['frontend'] } }],
+    );
+    expect(r.conflict).toBe(false);
+  });
+
+  it('different files in same dir do NOT conflict', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, files: ['a/b/x.ts'] } },
+      [{ id: 'b', claims: { ...empty, files: ['a/b/y.ts'] } }],
+    );
+    expect(r.conflict).toBe(false);
+  });
+
+  it('a story does not conflict with itself', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, files: ['x.ts'] } },
+      [{ id: 'a', claims: { ...empty, files: ['x.ts'] } }],
+    );
+    expect(r.conflict).toBe(false);
+  });
+
+  it('returns first conflict only', () => {
+    const r = checkClaimsConflict(
+      { id: 'a', claims: { ...empty, files: ['x.ts', 'y.ts'] } },
+      [
+        { id: 'b', claims: { ...empty, files: ['x.ts'] } },
+        { id: 'c', claims: { ...empty, files: ['y.ts'] } },
+      ],
+    );
+    expect(r.conflict).toBe(true);
+    expect(r.blockerStoryId).toBe('b');
+  });
+});
+
+describe('requiresFineGrainedClaims', () => {
+  it('returns true for high', () => {
+    expect(requiresFineGrainedClaims('high')).toBe(true);
+  });
+  it('returns true for critical', () => {
+    expect(requiresFineGrainedClaims('critical')).toBe(true);
+  });
+  it('returns false for low/medium/null/undefined', () => {
+    expect(requiresFineGrainedClaims('low')).toBe(false);
+    expect(requiresFineGrainedClaims('medium')).toBe(false);
+    expect(requiresFineGrainedClaims(null)).toBe(false);
+    expect(requiresFineGrainedClaims(undefined)).toBe(false);
+  });
+});
+
+describe('passesFineGrainedClaimsGate', () => {
+  const empty = { files: [], schemas: [], apiRoutes: [], domains: [] };
+
+  it('always passes for low/medium risk', () => {
+    expect(passesFineGrainedClaimsGate('low', empty)).toBe(true);
+    expect(passesFineGrainedClaimsGate('medium', empty)).toBe(true);
+  });
+
+  it('fails for high risk with no file claims', () => {
+    expect(passesFineGrainedClaimsGate('high', empty)).toBe(false);
+  });
+
+  it('passes for high risk with file claims', () => {
+    expect(passesFineGrainedClaimsGate('high', { ...empty, files: ['x.ts'] })).toBe(true);
+  });
+
+  it('fails for critical risk with no file claims', () => {
+    expect(passesFineGrainedClaimsGate('critical', empty)).toBe(false);
+  });
+
+  it('passes for critical risk with file claims', () => {
+    expect(passesFineGrainedClaimsGate('critical', { ...empty, files: ['x.ts'] })).toBe(true);
+  });
+});


### PR DESCRIPTION
## BUCKET-009 — Resource-claim checker + cross-bucket ready pool

Pure-function building blocks the multi-bucket placer (BUCKET-004) wires in to enforce the proposal §9.3 resource-claim invariants. Schema + EA-agent population were already shipped in BUCKET-001 / BUCKET-003; this PR is the runtime-side enforcement.

### `apps/orchestrator/src/scheduling/resource-claim-checker.ts` (new)

- `parseClaims(json)` — tolerant JSON → `Claims` parser, returns empty on malformed input.
- `checkClaimsConflict(candidate, inFlight)` — detects overlap on `files`, `schemas`, and `apiRoutes`. `domains` is the coarse routing fallback — never used to block. Returns the **first** conflict so the dashboard can surface a clear root cause.
- `requiresFineGrainedClaims(risk)` — `true` for `high` / `critical`.
- `passesFineGrainedClaimsGate(risk, claims)` — `high`/`critical` risk requires `claims.files` non-empty (§9.3 granularity escalation). This is what keeps two `auth` stories from concurrently rewriting the same middleware.

### `apps/orchestrator/src/scheduling/ready-pool.ts` (new)

- `snapshotStory(row)` — parse a `stories.*` row into the snapshot shape the pool consumes.
- `recompute(stories)` — pure point-in-time partition into:
  - `ready` — passed all three gates (`blockedBy`, claims-gate, claims-conflict).
  - `deferred` — with reason (`'blocked-by' | 'claims-gate' | 'claims-conflict'`) and the offending blockers / conflicting story / claim.
  - `inFlight` — currently `in_progress` / `running` / `partial`.
- Ordered: `P0 < P1 < P2 < P3 < null`, then story id ascending (stable).

The pool is intentionally **pure**: BUCKET-004 will call `recompute()` on every `story.done` / `story.in-flight` transition. Persistence isn't needed — the pool is derivable from `stories.*` whenever we want.

### Tests (37 total, all typecheck-verified)

- **resource-claim-checker.test.ts** — 19 cases covering parse, conflict per-axis (file / schema / apiRoute), no-self-conflict, multi-conflict ordering, granularity-escalation thresholds for every risk level.
- **ready-pool.test.ts** — 18 cases covering snapshot parsing, every gate independently, conflict-only-against-in-flight (not against pending peers), partition correctness across `ready`/`deferred`/`inFlight`/`done`, and stable priority+id ordering.

`pnpm --filter @caia-app/core run typecheck` — clean.

### What this unblocks

- **BUCKET-004** — multi-bucket placer absorbs this. Replaces `(prompt, domain)` keying with `(prompt, project, techSubDomainPrimary)`, wires in the chain-fragmenter (BUCKET-008) and this claim-checker, and enforces the level-scheduling algorithm from proposal §9.2 on every `story.done` event.

### References

- Directive: `agent/memory/po_taxonomy_directive.md`
- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§9.2 hybrid algorithm, §9.3 resource-claim model, §9.4 events)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent scheduling logic that determines which work items are ready to execute based on blocker resolution and resource availability.
  * Implemented conflict detection to prevent concurrent execution when work items access overlapping resources (files, schemas, API routes).
  * Added risk-based gating requiring explicit resource claims for high and critical priority items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->