### PR TITLE
feat(orchestrator): chain-fragmenter (WCC + level scheduling) (BUCKET-008)

### DIFF
--- a/apps/orchestrator/src/scheduling/chain-fragmenter.ts
+++ b/apps/orchestrator/src/scheduling/chain-fragmenter.ts
@@ -1,0 +1,190 @@
+/**
+ * Chain fragmenter — BUCKET-008.
+ *
+ * Pure function. Given a set of stories and their `blockedBy` dependency
+ * graph, partition the graph into weakly-connected components (WCCs) and
+ * compute level-scheduled batches inside each component.
+ *
+ * Why level scheduling instead of Dilworth chain cover (proposal §9.2):
+ *   - Dilworth gives the true minimum number of chains needed to cover the
+ *     DAG (= longest antichain), but requires max-flow / bipartite matching:
+ *     O(N² × √N).
+ *   - Level scheduling is O(N + E) and matches Dilworth's optimum
+ *     parallelism when worker count >= longest antichain — which is true
+ *     for our hardware budget. Filed `bucket-placer.optim.future-dilworth-
+ *     chain-cover` for the post-MVP optimization.
+ *
+ * Outputs are persisted into `task_buckets.levels_json` (already a column
+ * via migration 0024) so the dashboard can render Kanban level-coloring
+ * without recomputing.
+ */
+
+export interface FragmentInput {
+  storyIds: string[];
+  /** Adjacency: story id -> ids that BLOCK it (its upstream blockers). */
+  blockedBy: Map<string, string[]>;
+}
+
+export interface WCC {
+  /** Story ids in this connected component. */
+  storyIds: string[];
+  /** levels[k] = story ids whose deepest blocker chain is at level k-1. */
+  levels: string[][];
+  /** Length of the longest chain in this component (== levels.length). */
+  longestChain: number;
+}
+
+export interface FragmentResult {
+  wccs: WCC[];
+  /** Cycles detected — these story ids do NOT appear in any WCC's levels. */
+  cycleStoryIds: string[];
+}
+
+// ─── WCC discovery (union-find) ─────────────────────────────────────────────
+
+class UnionFind {
+  parent = new Map<string, string>();
+  rank = new Map<string, number>();
+  add(id: string): void {
+    if (!this.parent.has(id)) {
+      this.parent.set(id, id);
+      this.rank.set(id, 0);
+    }
+  }
+  find(id: string): string {
+    const p = this.parent.get(id);
+    if (p === undefined) {
+      this.add(id);
+      return id;
+    }
+    if (p === id) return id;
+    const root = this.find(p);
+    this.parent.set(id, root);
+    return root;
+  }
+  union(a: string, b: string): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra === rb) return;
+    const rankA = this.rank.get(ra) ?? 0;
+    const rankB = this.rank.get(rb) ?? 0;
+    if (rankA < rankB) this.parent.set(ra, rb);
+    else if (rankA > rankB) this.parent.set(rb, ra);
+    else {
+      this.parent.set(rb, ra);
+      this.rank.set(ra, rankA + 1);
+    }
+  }
+}
+
+function findWccs(input: FragmentInput): Map<string, string[]> {
+  const uf = new UnionFind();
+  for (const id of input.storyIds) uf.add(id);
+  for (const [child, blockers] of input.blockedBy) {
+    if (!input.storyIds.includes(child)) continue;
+    for (const blocker of blockers) {
+      if (input.storyIds.includes(blocker)) uf.union(child, blocker);
+    }
+  }
+  const groups = new Map<string, string[]>();
+  for (const id of input.storyIds) {
+    const root = uf.find(id);
+    const arr = groups.get(root) ?? [];
+    arr.push(id);
+    groups.set(root, arr);
+  }
+  return groups;
+}
+
+// ─── Level scheduling (Kahn's BFS) ──────────────────────────────────────────
+
+interface LevelResult {
+  levels: string[][];
+  cycleMembers: string[];
+}
+
+function levelScheduleWithinGroup(
+  group: string[],
+  blockedBy: Map<string, string[]>,
+): LevelResult {
+  const groupSet = new Set(group);
+  // Filter blockedBy to only include intra-group edges.
+  const inDegree = new Map<string, number>();
+  for (const id of group) {
+    const blockers = (blockedBy.get(id) ?? []).filter((b) => groupSet.has(b));
+    inDegree.set(id, blockers.length);
+  }
+
+  const visited = new Set<string>();
+  const levels: string[][] = [];
+  let frontier = group.filter((id) => (inDegree.get(id) ?? 0) === 0);
+
+  while (frontier.length > 0) {
+    frontier.sort();
+    levels.push([...frontier]);
+    for (const id of frontier) visited.add(id);
+
+    const nextFrontier: string[] = [];
+    for (const id of group) {
+      if (visited.has(id)) continue;
+      const remainingBlockers = (blockedBy.get(id) ?? []).filter(
+        (b) => groupSet.has(b) && !visited.has(b),
+      );
+      if (remainingBlockers.length === 0) nextFrontier.push(id);
+    }
+    frontier = [...new Set(nextFrontier)];
+  }
+
+  const cycleMembers = group.filter((id) => !visited.has(id));
+  return { levels, cycleMembers };
+}
+
+// ─── Main entry point ──────────────────────────────────────────────────────
+
+/**
+ * Fragment a set of stories + blockedBy edges into WCCs with level batches.
+ * Cycles (which the placer should never produce — they're flagged earlier
+ * as `task-scheduler.cycle-detected`) are surfaced as `cycleStoryIds`.
+ */
+export function fragmentChains(input: FragmentInput): FragmentResult {
+  const groups = findWccs(input);
+  const wccs: WCC[] = [];
+  const allCycleMembers: string[] = [];
+
+  // Sort groups by their first id (stable). Within each group, sort by id.
+  const sortedGroups = Array.from(groups.values())
+    .map((g) => [...g].sort())
+    .sort((a, b) => (a[0] ?? '').localeCompare(b[0] ?? ''));
+
+  for (const group of sortedGroups) {
+    const { levels, cycleMembers } = levelScheduleWithinGroup(group, input.blockedBy);
+    if (cycleMembers.length > 0) allCycleMembers.push(...cycleMembers);
+    wccs.push({
+      storyIds: group,
+      levels,
+      longestChain: levels.length,
+    });
+  }
+
+  return { wccs, cycleStoryIds: allCycleMembers };
+}
+
+// ─── Convenience: parse stories rows into FragmentInput ─────────────────────
+
+export function buildFragmentInput(
+  rows: Array<{ id: string; blockedByJson?: string | null }>,
+): FragmentInput {
+  const storyIds = rows.map((r) => r.id);
+  const blockedBy = new Map<string, string[]>();
+  for (const r of rows) {
+    let parsed: string[] = [];
+    try {
+      const json = JSON.parse(r.blockedByJson ?? '[]');
+      if (Array.isArray(json)) parsed = json.filter((v) => typeof v === 'string');
+    } catch {
+      /* malformed JSON treated as no blockers */
+    }
+    blockedBy.set(r.id, parsed);
+  }
+  return { storyIds, blockedBy };
+}

--- a/apps/orchestrator/tests/scheduling/chain-fragmenter.test.ts
+++ b/apps/orchestrator/tests/scheduling/chain-fragmenter.test.ts
@@ -1,0 +1,136 @@
+/**
+ * BUCKET-008 — chain-fragmenter unit tests.
+ */
+
+import {
+  fragmentChains,
+  buildFragmentInput,
+  type FragmentInput,
+} from '../../src/scheduling/chain-fragmenter';
+
+function input(stories: string[], deps: Record<string, string[]>): FragmentInput {
+  const blockedBy = new Map<string, string[]>();
+  for (const s of stories) blockedBy.set(s, deps[s] ?? []);
+  return { storyIds: stories, blockedBy };
+}
+
+describe('fragmentChains — empty + trivial', () => {
+  it('empty input -> empty output', () => {
+    const r = fragmentChains({ storyIds: [], blockedBy: new Map() });
+    expect(r.wccs).toEqual([]);
+    expect(r.cycleStoryIds).toEqual([]);
+  });
+
+  it('single story with no blockers -> one WCC, one level', () => {
+    const r = fragmentChains(input(['s1'], {}));
+    expect(r.wccs).toHaveLength(1);
+    expect(r.wccs[0]!.levels).toEqual([['s1']]);
+    expect(r.wccs[0]!.longestChain).toBe(1);
+  });
+});
+
+describe('fragmentChains — single chain', () => {
+  it('A -> B -> C -> D: one WCC, four levels', () => {
+    const r = fragmentChains(
+      input(['a', 'b', 'c', 'd'], { b: ['a'], c: ['b'], d: ['c'] }),
+    );
+    expect(r.wccs).toHaveLength(1);
+    expect(r.wccs[0]!.levels).toEqual([['a'], ['b'], ['c'], ['d']]);
+    expect(r.wccs[0]!.longestChain).toBe(4);
+  });
+});
+
+describe('fragmentChains — parallel chains', () => {
+  it('two independent chains -> two WCCs', () => {
+    const r = fragmentChains(input(['a', 'b', 'c', 'd'], { b: ['a'], d: ['c'] }));
+    expect(r.wccs).toHaveLength(2);
+    const all = r.wccs.flatMap((w) => w.storyIds).sort();
+    expect(all).toEqual(['a', 'b', 'c', 'd']);
+    for (const w of r.wccs) expect(w.levels).toHaveLength(2);
+  });
+
+  it('three independent starts each with one downstream', () => {
+    const r = fragmentChains(
+      input(['a', 'b', 'e', 'f', 'g', 'h'], { b: ['a'], f: ['e'], h: ['g'] }),
+    );
+    expect(r.wccs).toHaveLength(3);
+    for (const w of r.wccs) expect(w.longestChain).toBe(2);
+  });
+});
+
+describe('fragmentChains — diamond', () => {
+  it('A -> {B,C} -> D: one WCC, three levels', () => {
+    const r = fragmentChains(
+      input(['a', 'b', 'c', 'd'], { b: ['a'], c: ['a'], d: ['b', 'c'] }),
+    );
+    expect(r.wccs).toHaveLength(1);
+    expect(r.wccs[0]!.levels[0]).toEqual(['a']);
+    expect(r.wccs[0]!.levels[1]?.sort()).toEqual(['b', 'c']);
+    expect(r.wccs[0]!.levels[2]).toEqual(['d']);
+    expect(r.wccs[0]!.longestChain).toBe(3);
+  });
+});
+
+describe('fragmentChains — tree', () => {
+  it('shallow tree: A root, B/C/D leaves', () => {
+    const r = fragmentChains(
+      input(['a', 'b', 'c', 'd'], { b: ['a'], c: ['a'], d: ['a'] }),
+    );
+    expect(r.wccs).toHaveLength(1);
+    expect(r.wccs[0]!.levels[0]).toEqual(['a']);
+    expect(r.wccs[0]!.levels[1]?.sort()).toEqual(['b', 'c', 'd']);
+    expect(r.wccs[0]!.longestChain).toBe(2);
+  });
+});
+
+describe('fragmentChains — cycles', () => {
+  it('A <-> B: cycle members surface, no infinite loop', () => {
+    const r = fragmentChains(input(['a', 'b'], { a: ['b'], b: ['a'] }));
+    expect(r.cycleStoryIds.sort()).toEqual(['a', 'b']);
+    const placed = r.wccs.flatMap((w) => w.levels.flat());
+    expect(placed).not.toContain('a');
+    expect(placed).not.toContain('b');
+  });
+});
+
+describe('fragmentChains — proposal worked example', () => {
+  it('section 9.5 8-story example: 3 starts, longest chain 4', () => {
+    const r = fragmentChains(
+      input(
+        ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8'],
+        { s2: ['s1'], s3: ['s2'], s4: ['s3'], s6: ['s5'], s8: ['s7'] },
+      ),
+    );
+    expect(r.wccs).toHaveLength(3);
+    const longest = Math.max(...r.wccs.map((w) => w.longestChain));
+    expect(longest).toBe(4);
+    const level0 = r.wccs.map((w) => w.levels[0]!).flat().sort();
+    expect(level0).toEqual(['s1', 's5', 's7']);
+  });
+});
+
+describe('fragmentChains — out-of-set blockers', () => {
+  it('blockers outside the input set are ignored', () => {
+    const r = fragmentChains(input(['s1', 's2'], { s1: ['external'] }));
+    expect(r.wccs[0]!.levels[0]?.sort()).toEqual(['s1', 's2']);
+  });
+});
+
+describe('buildFragmentInput', () => {
+  it('parses stories rows into FragmentInput', () => {
+    const inp = buildFragmentInput([
+      { id: 'a', blockedByJson: '[]' },
+      { id: 'b', blockedByJson: '["a"]' },
+      { id: 'c', blockedByJson: null },
+    ]);
+    expect(inp.storyIds).toEqual(['a', 'b', 'c']);
+    expect(inp.blockedBy.get('a')).toEqual([]);
+    expect(inp.blockedBy.get('b')).toEqual(['a']);
+    expect(inp.blockedBy.get('c')).toEqual([]);
+  });
+
+  it('handles malformed JSON gracefully', () => {
+    const inp = buildFragmentInput([{ id: 'a', blockedByJson: 'not json' }]);
+    expect(inp.blockedBy.get('a')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## BUCKET-008 — Chain-fragmenter (WCC + level scheduling)

Pure-function building block the multi-bucket placer (BUCKET-004) wires in to compute **level-scheduled batches per weakly-connected component**, instead of naively linearizing into a long sequential queue. See proposal §9.2 for the rationale.

### `apps/orchestrator/src/scheduling/chain-fragmenter.ts` (new)

`fragmentChains({ storyIds, blockedBy })` returns `FragmentResult`:

- `wccs[]` — weakly-connected components, each with:
  - `storyIds` — the component members.
  - `levels[][]` — Kahn's BFS level batches (level *k* runs after *k−1*).
  - `longestChain` — `== levels.length`, the critical-path depth.
- `cycleStoryIds[]` — story ids that participate in a cycle (excluded from any `levels`; the placer should never produce these but we surface them for `task-scheduler.cycle-detected`).

`O(N + E)`. Per proposal §9.2, level scheduling matches Dilworth's chain-cover optimum **when worker count ≥ longest antichain**, which is always true for our hardware budget. Filed `bucket-placer.optim.future-dilworth-chain-cover` for the post-MVP optimization.

`buildFragmentInput(rows)` — convenience parser for `stories.*` rows, tolerant of missing / malformed `blockedByJson`.

### Internals

- WCC discovery via union-find with rank + path compression.
- Level scheduling within each WCC via Kahn's BFS, sorting both the output and frontier deterministically so re-running on the same input yields the same arrangement (proposal §5.5 idempotence).
- Cycles handled by leaving unvisited members in `cycleStoryIds` — no infinite loop, no silent drop.

### Persistence

Levels are written into `task_buckets.levels_json` (column already in place via migration 0024) so the dashboard can render Kanban level-coloring without recomputing.

### Tests (13 cases, typecheck-verified)

`apps/orchestrator/tests/scheduling/chain-fragmenter.test.ts` — empty/trivial input; single chain (`A→B→C→D` ⇒ 4 levels); parallel chains; three independent starts; diamond (`A→{B,C}→D`); shallow tree; cycle handling; **the proposal §9.5 worked example** (8 stories with longest chain 4 + 3 concurrent starts); out-of-set blockers; `buildFragmentInput` parser including malformed-JSON tolerance.

`pnpm --filter @caia-app/core run typecheck` — clean.

### What this unblocks

- **BUCKET-004** absorbs both this fragmenter and the BUCKET-009 resource-claim checker into the multi-bucket placer that keys on `(prompt, project, techSubDomainPrimary)`.

### References

- Directive: `agent/memory/po_taxonomy_directive.md`
- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§9.1 why naive topo-sort wastes parallelism, §9.2 hybrid algorithm, §9.5 worked example)
