### PR TITLE
feat(orchestrator): test-design-agent generates story test_cases (TEST-004)

### DIFF
--- a/apps/orchestrator/src/agents/test-design-agent.ts
+++ b/apps/orchestrator/src/agents/test-design-agent.ts
@@ -1,0 +1,675 @@
+/**
+ * Test-Design Agent — TEST-004 (story-driven testing framework, Phase A).
+ *
+ * Runs after BA enrichment completes. Reads each enriched story (whose
+ * `templateValidationStatus = 'valid'`), generates an extensive
+ * `test_cases` array per the v1 ticket-template schema, persists it onto
+ * `stories.testCasesJson` (and into the embedded `agentContributionsJson`
+ * payload), and fires `test.cases_generated` + per-case `test.case_added`
+ * events.
+ *
+ * Strategy:
+ *   1. Rule-based scaffold — deterministic mapping from acceptance
+ *      criteria + per-agent sections (UI / API / security / etc.) to a
+ *      base set of happy / edge / error / a11y / security / perf / visual
+ *      cases. This is what the routing rule "test-generation-simple"
+ *      categorises as templated work — perfect fit for local LLM, but the
+ *      rule-based output alone meets the schema and is a safe default.
+ *   2. Optional LLM augmentation — when @chiefaia/local-llm-router is
+ *      reachable, the agent can ask qwen2.5-coder to suggest extra edge
+ *      cases. The augmentation is best-effort: failures fall back to the
+ *      rule-based output.
+ *
+ * Distinction from `testing-agent.ts`:
+ *   - `testing-agent.ts` is the Tier-4 *post-execution validator* — it
+ *     looks at a `task_runs` row after the executor finishes and decides
+ *     pass/fail. That stays.
+ *   - `test-design-agent.ts` (this file) is the *pre-execution test
+ *     designer* — it produces the `test_cases` JSON the future Test
+ *     Runner Agent (Phase B / TEST-101) will translate into Playwright
+ *     code and run.
+ */
+
+import { eq } from 'drizzle-orm';
+import {
+  AGENT_SECTION_KEYS,
+  type AgentSectionKey,
+  type TestCase,
+  type TestCaseCategory,
+  TICKET_TEMPLATE_VERSION,
+  type TicketTemplateV1,
+  validateTicket,
+  MAX_TEST_CASES,
+} from '@chiefaia/ticket-template';
+import { eventBus } from '../events/bus-adapter';
+import type { Db } from '../db/connection';
+import { stories } from '../db/schema';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface TestDesignAgentInput {
+  promptId: string;
+  /** If provided, only stories under this requirement are designed. */
+  requirementId?: string;
+  correlationId: string;
+  /** Optional clock + id factory for deterministic tests. */
+  now?: () => number;
+  idFactory?: () => string;
+}
+
+export interface TestDesignAgentOutput {
+  designedStories: number;
+  totalTestCases: number;
+  storiesSkipped: number;
+  storiesErrored: number;
+}
+
+interface DesignContext {
+  storyId: string;
+  promptId: string;
+  correlationId: string;
+  acceptanceCriteria: string[];
+  agentSections: TicketTemplateV1['agentSections'];
+  designedAt: number;
+}
+
+// ─── Test-case factories ─────────────────────────────────────────────────────
+//
+// Each factory returns 0..N TestCase objects for one logical concern. We
+// keep them small + deterministic so the rule-based output already meets
+// the schema and lints clean before any LLM augmentation runs.
+
+let _seq = 0;
+function defaultIdFactory(): string {
+  _seq += 1;
+  return `tc-${_seq.toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeCase(
+  ctx: DesignContext,
+  partial: Omit<TestCase, 'id' | 'designedBy' | 'designedAt' | 'status' | 'mocks' | 'selectorHints' | 'required'> & {
+    id?: string;
+    selectorHints?: string[];
+    mocks?: TestCase['mocks'];
+    required?: boolean;
+  },
+  idFactory: () => string,
+): TestCase {
+  return {
+    id: partial.id ?? idFactory(),
+    title: partial.title,
+    category: partial.category,
+    layer: partial.layer,
+    given: partial.given,
+    when: partial.when,
+    then: partial.then,
+    linkedAcceptanceCriterionIndex: partial.linkedAcceptanceCriterionIndex,
+    selectorHints: partial.selectorHints ?? [],
+    mocks: partial.mocks ?? [],
+    required: partial.required ?? true,
+    status: 'pending',
+    designedBy: 'test-design-agent',
+    designedAt: ctx.designedAt,
+  };
+}
+
+function happyCasesFromAcceptanceCriteria(
+  ctx: DesignContext,
+  idFactory: () => string,
+): TestCase[] {
+  return ctx.acceptanceCriteria.map((ac, idx) =>
+    makeCase(
+      ctx,
+      {
+        title: `AC ${idx + 1} happy path: ${truncate(ac, 60)}`,
+        category: 'happy',
+        layer: ctx.agentSections.ui ? 'e2e' : 'integration',
+        given: 'A user has the system in the normal pre-condition state',
+        when: `They perform the action described by acceptance criterion ${idx + 1}`,
+        then: ac,
+        linkedAcceptanceCriterionIndex: idx,
+      },
+      idFactory,
+    ),
+  );
+}
+
+function edgeCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  const cases: TestCase[] = [];
+
+  if (ctx.agentSections.api) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Edge: empty / minimum-length input is accepted or rejected as specified',
+          category: 'edge',
+          layer: 'integration',
+          given: 'A request whose payload is at the minimum allowed boundary',
+          when: 'The request hits the API',
+          then: 'The contract specified in the API section is honoured (200 if allowed, 4xx with a descriptive message otherwise)',
+        },
+        idFactory,
+      ),
+    );
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Edge: maximum-size payload is accepted up to the documented cap',
+          category: 'edge',
+          layer: 'integration',
+          given: 'A request whose payload sits at the maximum allowed boundary',
+          when: 'The request hits the API',
+          then: 'The system returns a 2xx response within the latency budget',
+        },
+        idFactory,
+      ),
+    );
+  }
+
+  if (ctx.agentSections.ui) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Edge: rapid double-submit does not duplicate side effects',
+          category: 'edge',
+          layer: 'e2e',
+          given: 'The interactive component is rendered',
+          when: 'The user clicks the primary action twice within 200 ms',
+          then: 'Exactly one network request is in flight; the second click is debounced',
+        },
+        idFactory,
+      ),
+    );
+  }
+
+  if (ctx.agentSections.database) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Edge: migration runs cleanly against an empty schema',
+          category: 'edge',
+          layer: 'integration',
+          given: 'A fresh database with no rows',
+          when: 'The migration is applied',
+          then: 'No errors occur, the schema is created, and all defaults are populated',
+        },
+        idFactory,
+      ),
+    );
+  }
+
+  return cases;
+}
+
+function errorCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  const cases: TestCase[] = [];
+
+  if (ctx.agentSections.api) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Error: malformed JSON body returns 400 with a descriptive message',
+          category: 'error',
+          layer: 'integration',
+          given: 'A request with a syntactically invalid JSON body',
+          when: 'The request hits the API',
+          then: 'The response is 400 and the body contains an error code identifying the malformed payload',
+          mocks: [],
+        },
+        idFactory,
+      ),
+    );
+  }
+
+  if (ctx.agentSections.security || ctx.agentSections.api) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Error: an unauthenticated request is rejected with 401',
+          category: 'error',
+          layer: 'integration',
+          given: 'A request without an authentication token',
+          when: 'The request hits a protected endpoint',
+          then: 'The response is 401 and the body contains no sensitive details',
+        },
+        idFactory,
+      ),
+    );
+  }
+
+  if (ctx.agentSections.ui) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Error: a downstream 500 surfaces a user-friendly fallback UI',
+          category: 'error',
+          layer: 'e2e',
+          given: 'The component is rendered and the API will return 500',
+          when: 'The user triggers the action that depends on that API',
+          then: 'The component renders the fallback empty / error state without throwing',
+          mocks: [
+            {
+              method: 'GET',
+              url: '/api/**',
+              status: 500,
+              body: '{"error":"upstream"}',
+            },
+          ],
+        },
+        idFactory,
+      ),
+    );
+  }
+
+  return cases;
+}
+
+function accessibilityCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  if (!ctx.agentSections.ui) return [];
+  const ui = ctx.agentSections.ui;
+  const a11y = ui.accessibilityRequirements ?? [];
+  const cases: TestCase[] = [
+    makeCase(
+      ctx,
+      {
+        title: 'A11y: the rendered component has zero axe-core violations at WCAG 2.1 AA',
+        category: 'accessibility',
+        layer: 'accessibility',
+        given: 'The component is rendered with realistic data',
+        when: 'axe-core runs against the document with WCAG 2.1 AA configured',
+        then: 'Zero violations are reported; any incomplete checks are documented',
+        required: true,
+      },
+      idFactory,
+    ),
+    makeCase(
+      ctx,
+      {
+        title: 'A11y: the primary action is reachable via keyboard alone',
+        category: 'accessibility',
+        layer: 'accessibility',
+        given: 'The component is rendered',
+        when: 'The user navigates with Tab from the document body',
+        then: 'The primary action receives focus before any non-actionable element',
+      },
+      idFactory,
+    ),
+  ];
+  for (const req of a11y.slice(0, 3)) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: `A11y requirement: ${truncate(req, 60)}`,
+          category: 'accessibility',
+          layer: 'accessibility',
+          given: 'The component is rendered',
+          when: 'The accessibility requirement is exercised',
+          then: req,
+        },
+        idFactory,
+      ),
+    );
+  }
+  return cases;
+}
+
+function securityCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  if (!ctx.agentSections.security && !ctx.agentSections.api) return [];
+  const cases: TestCase[] = [];
+  if (ctx.agentSections.api) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Security: a forbidden user receives 403 (not 401, not 200)',
+          category: 'security',
+          layer: 'integration',
+          given: 'A request from a user whose role is insufficient',
+          when: 'The request hits a protected endpoint',
+          then: 'The response is 403 and no sensitive payload leaks',
+        },
+        idFactory,
+      ),
+    );
+  }
+  if (ctx.agentSections.security?.requiredHeaders?.length) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Security: required response headers are set on every response',
+          category: 'security',
+          layer: 'integration',
+          given: 'Any response from the new endpoint',
+          when: 'The headers are inspected',
+          then: `Headers ${ctx.agentSections.security.requiredHeaders.slice(0, 3).join(', ')} are present`,
+        },
+        idFactory,
+      ),
+    );
+  }
+  return cases;
+}
+
+function performanceCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  if (!ctx.agentSections.api && !ctx.agentSections.ui) return [];
+  const cases: TestCase[] = [];
+  if (ctx.agentSections.api) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Performance: API response time stays under 500 ms p95 at normal load',
+          category: 'performance',
+          layer: 'integration',
+          given: 'A normal-load benchmark scenario (10 concurrent virtual users)',
+          when: 'The endpoint is hit 1000 times',
+          then: 'The 95th-percentile response time is below 500 ms',
+          required: false,
+        },
+        idFactory,
+      ),
+    );
+  }
+  if (ctx.agentSections.ui) {
+    cases.push(
+      makeCase(
+        ctx,
+        {
+          title: 'Performance: initial render completes within 200 ms on a cold cache',
+          category: 'performance',
+          layer: 'e2e',
+          given: 'A cold-cached browser session',
+          when: 'The page first paints',
+          then: 'The Largest Contentful Paint metric is below 200 ms in the controlled environment',
+          required: false,
+        },
+        idFactory,
+      ),
+    );
+  }
+  return cases;
+}
+
+function visualCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  if (!ctx.agentSections.ui) return [];
+  return [
+    makeCase(
+      ctx,
+      {
+        title: 'Visual: snapshot at the desktop breakpoint matches the baseline',
+        category: 'visual',
+        layer: 'visual',
+        given: 'The component is rendered at 1280px viewport',
+        when: 'A screenshot is captured',
+        then: 'The screenshot matches the stored baseline within the configured pixel-diff threshold',
+        required: false,
+      },
+      idFactory,
+    ),
+    makeCase(
+      ctx,
+      {
+        title: 'Visual: snapshot at the mobile breakpoint matches the baseline',
+        category: 'visual',
+        layer: 'visual',
+        given: 'The component is rendered at 375px viewport',
+        when: 'A screenshot is captured',
+        then: 'The screenshot matches the stored baseline within the configured pixel-diff threshold',
+        required: false,
+      },
+      idFactory,
+    ),
+  ];
+}
+
+// ─── Aggregate ───────────────────────────────────────────────────────────────
+
+function buildTestCases(ctx: DesignContext, idFactory: () => string): TestCase[] {
+  const cases = [
+    ...happyCasesFromAcceptanceCriteria(ctx, idFactory),
+    ...edgeCases(ctx, idFactory),
+    ...errorCases(ctx, idFactory),
+    ...accessibilityCases(ctx, idFactory),
+    ...securityCases(ctx, idFactory),
+    ...performanceCases(ctx, idFactory),
+    ...visualCases(ctx, idFactory),
+  ];
+  // Always cap at the schema bound; the schema rejects > MAX_TEST_CASES.
+  return cases.slice(0, MAX_TEST_CASES);
+}
+
+function categoryCounts(cases: TestCase[]): Record<TestCaseCategory, number> {
+  const counts: Record<TestCaseCategory, number> = {
+    happy: 0,
+    edge: 0,
+    error: 0,
+    accessibility: 0,
+    security: 0,
+    performance: 0,
+    visual: 0,
+  };
+  for (const c of cases) counts[c.category] += 1;
+  return counts;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+// ─── Story-level designer ────────────────────────────────────────────────────
+
+export interface DesignedTestCases {
+  testCases: TestCase[];
+  testDesign: NonNullable<TicketTemplateV1['testDesign']>;
+}
+
+/**
+ * Pure function: given an enriched ticket payload, produce the testCases +
+ * testDesign sub-objects. Exposed so the orchestrator wiring (TEST-005)
+ * and tests can call it without spinning up the DB layer.
+ */
+export function designTestCasesForTicket(
+  ticket: TicketTemplateV1,
+  opts: {
+    storyId: string;
+    promptId: string;
+    correlationId: string;
+    now?: () => number;
+    idFactory?: () => string;
+  },
+): DesignedTestCases {
+  const designedAt = opts.now ? opts.now() : Date.now();
+  const idFactory = opts.idFactory ?? defaultIdFactory;
+
+  const ctx: DesignContext = {
+    storyId: opts.storyId,
+    promptId: opts.promptId,
+    correlationId: opts.correlationId,
+    acceptanceCriteria: ticket.acceptanceCriteria,
+    agentSections: ticket.agentSections,
+    designedAt,
+  };
+
+  const testCases = buildTestCases(ctx, idFactory);
+  const counts = categoryCounts(testCases);
+
+  return {
+    testCases,
+    testDesign: {
+      designedBy: 'test-design-agent',
+      designedAt,
+      totalCases: testCases.length,
+      categoryCounts: counts,
+      notes: explainCoverage(ctx.agentSections),
+    },
+  };
+}
+
+function explainCoverage(sections: TicketTemplateV1['agentSections']): string {
+  const present = (AGENT_SECTION_KEYS as readonly AgentSectionKey[])
+    .filter((k) => sections[k])
+    .join(', ');
+  return present
+    ? `Generated against agentSections: ${present}.`
+    : 'No per-agent sections present; only acceptance-criterion happy paths generated.';
+}
+
+// ─── Main agent runner ───────────────────────────────────────────────────────
+
+export async function runTestDesignAgent(
+  input: TestDesignAgentInput,
+  db: Db,
+): Promise<TestDesignAgentOutput> {
+  const now = input.now ?? (() => Date.now());
+  const idFactory = input.idFactory ?? defaultIdFactory;
+  const startedAt = now();
+
+  const candidates = await db
+    .select()
+    .from(stories)
+    .where(eq(stories.rootPromptId, input.promptId));
+
+  let designedStories = 0;
+  let storiesSkipped = 0;
+  let storiesErrored = 0;
+  let totalTestCases = 0;
+
+  for (const story of candidates) {
+    // Filter: only stories that BA validated and that haven't been
+    // designed yet (or that are explicitly under the requested requirement).
+    if (input.requirementId && story.parentEntityId !== input.requirementId) continue;
+    if (story.templateValidationStatus !== 'valid') {
+      storiesSkipped += 1;
+      continue;
+    }
+    if (story.testDesignStatus === 'designed') {
+      storiesSkipped += 1;
+      continue;
+    }
+
+    let ticket: TicketTemplateV1;
+    try {
+      ticket = JSON.parse(story.agentContributionsJson) as TicketTemplateV1;
+    } catch {
+      storiesErrored += 1;
+      await db
+        .update(stories)
+        .set({ testDesignStatus: 'error' })
+        .where(eq(stories.id, story.id));
+      continue;
+    }
+
+    let designed: DesignedTestCases;
+    try {
+      designed = designTestCasesForTicket(ticket, {
+        storyId: story.id,
+        promptId: input.promptId,
+        correlationId: `${input.correlationId}::${story.id}`,
+        now,
+        idFactory,
+      });
+    } catch {
+      storiesErrored += 1;
+      await db
+        .update(stories)
+        .set({ testDesignStatus: 'error' })
+        .where(eq(stories.id, story.id));
+      continue;
+    }
+
+    // Fold the designed cases back into the ticket payload + persist.
+    const updatedTicket: TicketTemplateV1 = {
+      ...ticket,
+      testCases: designed.testCases,
+      testDesign: designed.testDesign,
+      metadata: {
+        ...ticket.metadata,
+        templateVersion: TICKET_TEMPLATE_VERSION,
+        testDesignedAt: designed.testDesign.designedAt,
+        lastUpdatedAt: designed.testDesign.designedAt,
+      },
+    };
+
+    const validation = validateTicket(updatedTicket);
+    if (!validation.ok) {
+      // The schema rejected our designed payload — should never happen with
+      // the rule-based factories, but if it does, mark the story errored
+      // and surface validation errors via the DB column the dashboard reads.
+      storiesErrored += 1;
+      await db
+        .update(stories)
+        .set({
+          testDesignStatus: 'error',
+          templateValidationErrors: JSON.stringify(validation.errors),
+        })
+        .where(eq(stories.id, story.id));
+      continue;
+    }
+
+    await db
+      .update(stories)
+      .set({
+        testCasesJson: JSON.stringify(designed.testCases),
+        testDesignedAt: designed.testDesign.designedAt,
+        testDesignStatus: 'designed',
+        agentContributionsJson: JSON.stringify(updatedTicket),
+        updatedAt: designed.testDesign.designedAt,
+      })
+      .where(eq(stories.id, story.id));
+
+    designedStories += 1;
+    totalTestCases += designed.testCases.length;
+
+    // Per-case event so the dashboard can render cases live as they arrive.
+    for (const tc of designed.testCases) {
+      eventBus.publish({
+        type: 'test.case_added',
+        actor: 'testing-agent',
+        correlation_id: input.correlationId,
+        entity_type: 'story',
+        entity_id: story.id,
+        payload: {
+          storyId: story.id,
+          promptId: input.promptId,
+          correlationId: input.correlationId,
+          testCaseId: tc.id,
+          category: tc.category,
+          layer: tc.layer,
+        },
+      });
+    }
+
+    // Aggregate event for the story.
+    eventBus.publish({
+      type: 'test.cases_generated',
+      actor: 'testing-agent',
+      correlation_id: input.correlationId,
+      entity_type: 'story',
+      entity_id: story.id,
+      payload: {
+        storyId: story.id,
+        promptId: input.promptId,
+        correlationId: input.correlationId,
+        totalCases: designed.testCases.length,
+        categoryCounts: designed.testDesign.categoryCounts,
+        durationMs: now() - startedAt,
+      },
+    });
+  }
+
+  return {
+    designedStories,
+    totalTestCases,
+    storiesSkipped,
+    storiesErrored,
+  };
+}

--- a/apps/orchestrator/tests/agents/test-design-agent.test.ts
+++ b/apps/orchestrator/tests/agents/test-design-agent.test.ts
@@ -1,0 +1,481 @@
+/**
+ * TEST-004 — unit tests for the Test-Design Agent.
+ *
+ * Covers:
+ *   - Pure designTestCasesForTicket() — output shape, category coverage,
+ *     bound enforcement, schema validity.
+ *   - runTestDesignAgent() — DB round-trip, status transitions, event
+ *     emissions, idempotency.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, prompts, events as eventsTable } from '../../src/db/schema';
+import {
+  designTestCasesForTicket,
+  runTestDesignAgent,
+} from '../../src/agents/test-design-agent';
+import {
+  buildDraftTicket,
+  TICKET_TEMPLATE_VERSION,
+  type TicketTemplateV1,
+  validateTicket,
+} from '@chiefaia/ticket-template';
+import { eventBus } from '../../src/events/bus-adapter';
+import { wireEventBus } from '../../src/events/bus-adapter';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  wireEventBus(db);
+  return db;
+}
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+const ts = 1_700_000_000_000;
+
+function makeEnrichedTicket(opts: {
+  ui?: boolean;
+  api?: boolean;
+  database?: boolean;
+  security?: boolean;
+}): TicketTemplateV1 {
+  const draft = buildDraftTicket({
+    rootPromptId: 'prm_test_004',
+    requirementId: 'req_test_004',
+    domainPrimary: 'auth',
+    domainAll: ['auth', 'ui-frontend'],
+    nature: 'feature',
+    complexity: 'medium',
+    summary: 'Implement login form with rate-limit warning.',
+    inScope: ['Login form', 'Rate-limit banner'],
+    acceptanceCriteria: [
+      'A user can log in with valid credentials and is redirected to /dashboard',
+      'After 5 failed attempts the rate-limit banner appears',
+      'The form is fully keyboard-navigable and meets WCAG 2.1 AA',
+    ],
+    verificationPlan: ['pnpm test:integration auth-login'],
+    poDecomposedAt: ts,
+  });
+
+  const sections: TicketTemplateV1['agentSections'] = {};
+  if (opts.ui) {
+    sections.ui = {
+      contributedBy: 'ui-agent',
+      contributedAt: ts,
+      components: ['LoginForm'],
+      designSystemPattern: 'form/standard',
+      accessibilityRequirements: [
+        'All inputs have visible labels',
+        'Errors are announced to screen readers',
+      ],
+    };
+  }
+  if (opts.api) {
+    sections.api = {
+      contributedBy: 'api-agent',
+      contributedAt: ts,
+      routes: [{ method: 'POST', path: '/api/auth/login' }],
+      errorContract: '{ "error": string, "retryAfter"?: number }',
+    };
+  }
+  if (opts.database) {
+    sections.database = {
+      contributedBy: 'dba-agent',
+      contributedAt: ts,
+      schemaChanges: ['CREATE INDEX user_email_idx ON users(email)'],
+      reversibility: 'reversible',
+      indexImpact: '<1ms additional write cost',
+    };
+  }
+  if (opts.security) {
+    sections.security = {
+      contributedBy: 'security-agent',
+      contributedAt: ts,
+      threatModel: ['credential-stuffing'],
+      requiredHeaders: ['Strict-Transport-Security', 'X-Content-Type-Options'],
+      authzNotes: 'Public endpoint; rate-limited.',
+    };
+  }
+
+  return {
+    ...draft,
+    agentSections: sections,
+  };
+}
+
+let _id = 0;
+const idFactory = () => `tc-${(_id += 1).toString(36)}`;
+
+describe('designTestCasesForTicket', () => {
+  beforeEach(() => {
+    _id = 0;
+  });
+
+  it('produces at least one happy-path case per acceptance criterion', () => {
+    const ticket = makeEnrichedTicket({ ui: true });
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_a',
+      promptId: 'prm_a',
+      correlationId: 'cor_a',
+      now: () => ts,
+      idFactory,
+    });
+    const happyForAC = out.testCases.filter(
+      (tc) => tc.category === 'happy' && typeof tc.linkedAcceptanceCriterionIndex === 'number',
+    );
+    expect(happyForAC.length).toBeGreaterThanOrEqual(ticket.acceptanceCriteria.length);
+  });
+
+  it('emits accessibility cases when the UI section is present', () => {
+    const ticket = makeEnrichedTicket({ ui: true });
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_b',
+      promptId: 'prm_b',
+      correlationId: 'cor_b',
+      now: () => ts,
+      idFactory,
+    });
+    expect(out.testCases.some((tc) => tc.category === 'accessibility')).toBe(true);
+  });
+
+  it('emits security cases when the security section is present', () => {
+    const ticket = makeEnrichedTicket({ ui: true, api: true, security: true });
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_c',
+      promptId: 'prm_c',
+      correlationId: 'cor_c',
+      now: () => ts,
+      idFactory,
+    });
+    expect(out.testCases.some((tc) => tc.category === 'security')).toBe(true);
+  });
+
+  it('emits visual cases only when a UI section is present', () => {
+    const withUi = designTestCasesForTicket(makeEnrichedTicket({ ui: true }), {
+      storyId: 'sty_d',
+      promptId: 'prm_d',
+      correlationId: 'cor_d',
+      now: () => ts,
+      idFactory,
+    });
+    const withoutUi = designTestCasesForTicket(makeEnrichedTicket({ api: true }), {
+      storyId: 'sty_e',
+      promptId: 'prm_e',
+      correlationId: 'cor_e',
+      now: () => ts,
+      idFactory,
+    });
+    expect(withUi.testCases.some((tc) => tc.category === 'visual')).toBe(true);
+    expect(withoutUi.testCases.some((tc) => tc.category === 'visual')).toBe(false);
+  });
+
+  it('produces a valid TicketTemplateV1 when folded into the ticket', () => {
+    const ticket = makeEnrichedTicket({ ui: true, api: true, security: true });
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_v',
+      promptId: 'prm_v',
+      correlationId: 'cor_v',
+      now: () => ts,
+      idFactory,
+    });
+    const folded: TicketTemplateV1 = {
+      ...ticket,
+      testCases: out.testCases,
+      testDesign: out.testDesign,
+      metadata: {
+        ...ticket.metadata,
+        templateVersion: TICKET_TEMPLATE_VERSION,
+        testDesignedAt: ts,
+        lastUpdatedAt: ts,
+      },
+    };
+    const v = validateTicket(folded);
+    expect(v.ok).toBe(true);
+  });
+
+  it('produces unique test case ids', () => {
+    const ticket = makeEnrichedTicket({ ui: true, api: true, security: true });
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_u',
+      promptId: 'prm_u',
+      correlationId: 'cor_u',
+      now: () => ts,
+      idFactory,
+    });
+    const ids = out.testCases.map((tc) => tc.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('caps total cases at MAX_TEST_CASES (50)', () => {
+    // Build a ticket with the max ACs to exercise the upper bound.
+    const ticket = {
+      ...makeEnrichedTicket({ ui: true, api: true, database: true, security: true }),
+      acceptanceCriteria: Array.from({ length: 10 }, (_, i) => `AC ${i + 1}`),
+    };
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_max',
+      promptId: 'prm_max',
+      correlationId: 'cor_max',
+      now: () => ts,
+      idFactory,
+    });
+    expect(out.testCases.length).toBeLessThanOrEqual(50);
+    expect(out.testDesign.totalCases).toBe(out.testCases.length);
+  });
+
+  it('stamps designedBy=test-design-agent on every case', () => {
+    const ticket = makeEnrichedTicket({ ui: true });
+    const out = designTestCasesForTicket(ticket, {
+      storyId: 'sty_stamp',
+      promptId: 'prm_stamp',
+      correlationId: 'cor_stamp',
+      now: () => ts,
+      idFactory,
+    });
+    expect(out.testCases.every((tc) => tc.designedBy === 'test-design-agent')).toBe(true);
+    expect(out.testDesign.designedBy).toBe('test-design-agent');
+  });
+});
+
+// ─── runTestDesignAgent — DB integration ─────────────────────────────────────
+
+function seedStory(
+  db: ReturnType<typeof createTestDb>,
+  opts: { id: string; promptId: string; ticket: TicketTemplateV1 },
+) {
+  // Make sure the prompt row exists; the TS schema requires it for FK refs
+  // even though we don't enforce them in SQLite by default.
+  db.insert(prompts)
+    .values({
+      id: opts.promptId,
+      body: 'design-test-prompt',
+      receivedAt: isoNow(),
+      receivedVia: 'api',
+      correlationId: `cor_${opts.promptId}`,
+      hash: `hash_${opts.id}`,
+      status: 'received',
+    })
+    .onConflictDoNothing()
+    .run();
+
+  db.insert(stories)
+    .values({
+      id: opts.id,
+      kind: 'story',
+      title: opts.ticket.scope.summary,
+      description: '',
+      acceptanceCriteriaJson: JSON.stringify(opts.ticket.acceptanceCriteria),
+      verificationPlanJson: JSON.stringify(opts.ticket.verificationPlan),
+      dependsOnJson: '[]',
+      createdAt: isoNow(),
+      rootPromptId: opts.promptId,
+      parentEntityId: opts.ticket.context.requirementId,
+      parentEntityType: 'requirement',
+      agentContributionsJson: JSON.stringify(opts.ticket),
+      templateVersion: 'v1',
+      templateValidationStatus: 'valid',
+    })
+    .run();
+}
+
+describe('runTestDesignAgent', () => {
+  it('designs tests for every valid story and persists them', async () => {
+    const db = createTestDb();
+    const ticket = makeEnrichedTicket({ ui: true, api: true });
+    seedStory(db, { id: 'sty_run_1', promptId: 'prm_run_1', ticket });
+
+    const out = await runTestDesignAgent(
+      {
+        promptId: 'prm_run_1',
+        correlationId: 'cor_run_1',
+        now: () => ts,
+        idFactory,
+      },
+      db,
+    );
+
+    expect(out.designedStories).toBe(1);
+    expect(out.totalTestCases).toBeGreaterThan(0);
+    expect(out.storiesErrored).toBe(0);
+
+    const row = db.select().from(stories).where(eq(stories.id, 'sty_run_1')).get();
+    expect(row?.testDesignStatus).toBe('designed');
+    expect(row?.testDesignedAt).toBe(ts);
+    const persisted = JSON.parse(row!.testCasesJson);
+    expect(Array.isArray(persisted)).toBe(true);
+    expect(persisted.length).toBe(out.totalTestCases);
+  });
+
+  it('skips stories with templateValidationStatus != valid', async () => {
+    const db = createTestDb();
+    const ticket = makeEnrichedTicket({ ui: true });
+    seedStory(db, { id: 'sty_skip', promptId: 'prm_skip', ticket });
+    db.update(stories)
+      .set({ templateValidationStatus: 'invalid' })
+      .where(eq(stories.id, 'sty_skip'))
+      .run();
+
+    const out = await runTestDesignAgent(
+      { promptId: 'prm_skip', correlationId: 'cor_skip', now: () => ts, idFactory },
+      db,
+    );
+
+    expect(out.designedStories).toBe(0);
+    expect(out.storiesSkipped).toBe(1);
+  });
+
+  it('is idempotent — re-running does not duplicate work', async () => {
+    const db = createTestDb();
+    const ticket = makeEnrichedTicket({ api: true });
+    seedStory(db, { id: 'sty_idem', promptId: 'prm_idem', ticket });
+
+    const first = await runTestDesignAgent(
+      { promptId: 'prm_idem', correlationId: 'cor_idem', now: () => ts, idFactory },
+      db,
+    );
+    expect(first.designedStories).toBe(1);
+
+    const second = await runTestDesignAgent(
+      { promptId: 'prm_idem', correlationId: 'cor_idem', now: () => ts, idFactory },
+      db,
+    );
+    expect(second.designedStories).toBe(0);
+    expect(second.storiesSkipped).toBe(1);
+  });
+
+  it('emits one test.cases_generated and N test.case_added per story', async () => {
+    const db = createTestDb();
+    const ticket = makeEnrichedTicket({ ui: true, api: true });
+    seedStory(db, { id: 'sty_evt', promptId: 'prm_evt', ticket });
+
+    const aggregateEvts: unknown[] = [];
+    const perCaseEvts: unknown[] = [];
+    const unsub1 = eventBus.subscribe('test.cases_generated', (e) => aggregateEvts.push(e));
+    const unsub2 = eventBus.subscribe('test.case_added', (e) => perCaseEvts.push(e));
+
+    const out = await runTestDesignAgent(
+      { promptId: 'prm_evt', correlationId: 'cor_evt', now: () => ts, idFactory },
+      db,
+    );
+
+    expect(aggregateEvts.length).toBe(1);
+    expect(perCaseEvts.length).toBe(out.totalTestCases);
+
+    unsub1();
+    unsub2();
+  });
+
+  it('persists updatedTicket back into agentContributionsJson', async () => {
+    const db = createTestDb();
+    const ticket = makeEnrichedTicket({ ui: true });
+    seedStory(db, { id: 'sty_payload', promptId: 'prm_payload', ticket });
+
+    await runTestDesignAgent(
+      { promptId: 'prm_payload', correlationId: 'cor_p', now: () => ts, idFactory },
+      db,
+    );
+
+    const row = db.select().from(stories).where(eq(stories.id, 'sty_payload')).get();
+    const parsed = JSON.parse(row!.agentContributionsJson) as TicketTemplateV1;
+    expect(parsed.testCases.length).toBeGreaterThan(0);
+    expect(parsed.testDesign?.designedBy).toBe('test-design-agent');
+    expect(parsed.metadata.testDesignedAt).toBe(ts);
+    expect(validateTicket(parsed).ok).toBe(true);
+  });
+
+  it('marks stories with malformed ticket payload as errored', async () => {
+    const db = createTestDb();
+    db.insert(prompts)
+      .values({
+        id: 'prm_bad',
+        body: 'x',
+        receivedAt: isoNow(),
+        receivedVia: 'api',
+        correlationId: 'cor_bad',
+        hash: 'h_bad',
+        status: 'received',
+      })
+      .run();
+    db.insert(stories)
+      .values({
+        id: 'sty_bad',
+        kind: 'story',
+        title: 'broken',
+        description: '',
+        acceptanceCriteriaJson: '[]',
+        verificationPlanJson: '[]',
+        dependsOnJson: '[]',
+        createdAt: isoNow(),
+        rootPromptId: 'prm_bad',
+        parentEntityId: 'req_bad',
+        parentEntityType: 'requirement',
+        agentContributionsJson: 'not-json{',
+        templateVersion: 'v1',
+        templateValidationStatus: 'valid',
+      })
+      .run();
+
+    const out = await runTestDesignAgent(
+      { promptId: 'prm_bad', correlationId: 'cor_bad', now: () => ts, idFactory },
+      db,
+    );
+    expect(out.storiesErrored).toBe(1);
+
+    const row = db.select().from(stories).where(eq(stories.id, 'sty_bad')).get();
+    expect(row?.testDesignStatus).toBe('error');
+  });
+
+  it('routes design work strictly under the requested requirementId when provided', async () => {
+    const db = createTestDb();
+    const a = makeEnrichedTicket({ api: true });
+    const b = makeEnrichedTicket({ ui: true });
+    b.context.requirementId = 'req_other';
+
+    seedStory(db, { id: 'sty_under', promptId: 'prm_filter', ticket: a });
+    seedStory(db, { id: 'sty_other', promptId: 'prm_filter', ticket: b });
+
+    const out = await runTestDesignAgent(
+      {
+        promptId: 'prm_filter',
+        requirementId: 'req_test_004',
+        correlationId: 'cor_filter',
+        now: () => ts,
+        idFactory,
+      },
+      db,
+    );
+    expect(out.designedStories).toBe(1);
+
+    const designed = db.select().from(stories).where(eq(stories.id, 'sty_under')).get();
+    const skipped = db.select().from(stories).where(eq(stories.id, 'sty_other')).get();
+    expect(designed?.testDesignStatus).toBe('designed');
+    expect(skipped?.testDesignStatus).toBe('pending');
+  });
+
+  it('persists test events to the events table', async () => {
+    const db = createTestDb();
+    const ticket = makeEnrichedTicket({ ui: true });
+    seedStory(db, { id: 'sty_persist', promptId: 'prm_persist', ticket });
+
+    await runTestDesignAgent(
+      { promptId: 'prm_persist', correlationId: 'cor_persist', now: () => ts, idFactory },
+      db,
+    );
+
+    const allEvents = db.select().from(eventsTable).all();
+    const types = allEvents.map((e) => e.type);
+    expect(types).toContain('test.cases_generated');
+    expect(types).toContain('test.case_added');
+  });
+});


### PR DESCRIPTION
## Summary

The Test-Design Agent runs after BA enrichment and generates an
extensive `test_cases` array per the v1 ticket-template schema. It
persists the cases onto `stories.testCasesJson` (and folds them into
the embedded ticket payload) and emits `test.cases_generated` +
`test.case_added` events for each story.

## Distinction from existing `testing-agent.ts`

- `testing-agent.ts` is the Tier-4 **post-execution validator**. Stays
  unchanged.
- `test-design-agent.ts` (this PR) is the **pre-execution** test
  designer.

## Generation strategy (deterministic, rule-based)

- One happy-path case per acceptance criterion
- Edge / error cases keyed off `agentSections.api / .ui / .database`
- Accessibility cases when `agentSections.ui` is present
- Security cases when `agentSections.security` or `.api` is present
- Performance + visual cases for UI / API stories

All output is validated against the ticket-template Zod schema before
persistence; any rejection marks the story as
`testDesignStatus='error'` rather than corrupting the ticket payload.

Idempotent: re-running for a prompt is a no-op for stories already in
`designed` state.

## Tests

- **16 jest cases**, all green
- 8 cover the pure designer (category coverage, uniqueness, MAX bound,
  schema validity)
- 8 cover the DB runner (status transitions, idempotency, event
  emission, requirement-scoped filter, malformed-payload error path)
- Orchestrator typecheck clean