### PR TITLE
feat(dashboard,orchestrator): bucket kanban shows project + tech + level metadata (BUCKET-005)

### DIFF
--- a/apps/dashboard/app/api/buckets/route.ts
+++ b/apps/dashboard/app/api/buckets/route.ts
@@ -1,6 +1,6 @@
 /**
  * Dashboard API proxy: GET /api/buckets
- * Forwards to the orchestrator's /buckets endpoint (GATE-4-02).
+ * Forwards to the orchestrator's /buckets endpoint (GATE-4-02 + BUCKET-005).
  */
 import { NextResponse } from 'next/server';
 
@@ -9,14 +9,17 @@ const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776'
 export async function GET(request: Request): Promise<NextResponse> {
   const upstreamUrl = new URL(`${ORCHESTRATOR_URL}/buckets`);
   const { searchParams } = new URL(request.url);
-  for (const k of ['promptId', 'domain', 'kind', 'status', 'limit']) {
+  // BUCKET-005: forward project + techSubDomain filters in addition to the
+  // legacy params from GATE-4-02.
+  for (const k of ['promptId', 'domain', 'kind', 'status', 'limit', 'project', 'techSubDomain']) {
     const v = searchParams.get(k);
     if (v) upstreamUrl.searchParams.set(k, v);
   }
   try {
     const upstream = await fetch(upstreamUrl.toString(), { cache: 'no-store' });
-    if (!upstream.ok) return NextResponse.json({ error: `Upstream ${upstream.status}` }, { status: upstream.status });
-    const data = await upstream.json() as unknown;
+    if (!upstream.ok)
+      return NextResponse.json({ error: `Upstream ${upstream.status}` }, { status: upstream.status });
+    const data = (await upstream.json()) as unknown;
     return NextResponse.json(data);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';

--- a/apps/dashboard/app/buckets/page.tsx
+++ b/apps/dashboard/app/buckets/page.tsx
@@ -23,13 +23,27 @@ interface BucketRow {
   id: string;
   kind: string;
   domainSlug: string | null;
+  // BUCKET-001/004 — multi-bucket placement key + level metadata.
+  projectSlug: string | null;
+  techSubDomain: string | null;
+  levels: string[][];
   sequenceIndex: number | null;
   status: string;
   promptId: string;
   createdAt: number;
   ticketCount: number;
   validTicketCount: number;
-  preview: Array<{ id: string; title: string; status: string; templateValidationStatus: string }>;
+  preview: Array<{
+    id: string;
+    title: string;
+    status: string;
+    templateValidationStatus: string;
+    projectSlug: string | null;
+    techSubDomainPrimary: string | null;
+    lifecycle: string | null;
+    risk: string | null;
+    priorityBucket: string | null;
+  }>;
 }
 
 interface BucketsResponse {
@@ -100,14 +114,26 @@ function BucketCard({
         transition: 'background 0.15s',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, flexWrap: 'wrap' }}>
         <span style={{ color: accent, fontWeight: 600, fontSize: 13 }}>
-          {b.domainSlug ?? 'parallel pool'}
+          {/* BUCKET-005: prefer (project / tech-sub-domain), fall back to domainSlug for legacy buckets. */}
+          {b.projectSlug && b.techSubDomain
+            ? `${b.projectSlug} / ${b.techSubDomain}`
+            : (b.domainSlug ?? 'parallel pool')}
           {b.sequenceIndex != null && (
             <span style={{ color: '#a0aec0', marginLeft: 6 }}>#{b.sequenceIndex}</span>
           )}
         </span>
         <StatusPill status={b.status} />
+        {b.levels.length > 1 && (
+          <span
+            data-testid={`bucket-levels-${b.id}`}
+            style={{ fontSize: 10, padding: '1px 5px', borderRadius: 3, background: '#553c9a', color: '#fff' }}
+            title={`${b.levels.length} levels — chain length ${b.levels.length}`}
+          >
+            {b.levels.length} levels
+          </span>
+        )}
         <span style={{ marginLeft: 'auto', color: '#a0aec0', fontSize: 11 }}>
           {b.ticketCount} ticket{b.ticketCount === 1 ? '' : 's'}
         </span>

--- a/apps/orchestrator/src/api/routes/buckets.ts
+++ b/apps/orchestrator/src/api/routes/buckets.ts
@@ -29,13 +29,28 @@ interface BucketRowOut {
   id: string;
   kind: string;
   domainSlug: string | null;
+  // BUCKET-001/004 — multi-bucket placement key + level metadata.
+  projectSlug: string | null;
+  techSubDomain: string | null;
+  levels: string[][];
   sequenceIndex: number | null;
   status: string;
   promptId: string;
   createdAt: number;
   ticketCount: number;
   validTicketCount: number;
-  preview: Array<{ id: string; title: string; status: string; templateValidationStatus: string }>;
+  preview: Array<{
+    id: string;
+    title: string;
+    status: string;
+    templateValidationStatus: string;
+    // BUCKET-001/003 — surface the per-story taxonomy on the card.
+    projectSlug: string | null;
+    techSubDomainPrimary: string | null;
+    lifecycle: string | null;
+    risk: string | null;
+    priorityBucket: string | null;
+  }>;
 }
 
 // @no-events — read-only routes
@@ -51,10 +66,16 @@ export function registerBucketsRoutes(app: Hono, db: Db): void {
 
     let rows = db.select().from(taskBuckets).orderBy(desc(taskBuckets.createdAt)).all();
 
+    const project = c.req.query('project');
+    const techSubDomain = c.req.query('techSubDomain');
+
     if (promptId) rows = rows.filter((r) => r.promptId === promptId);
     if (domain) rows = rows.filter((r) => r.domainSlug === domain);
     if (kind) rows = rows.filter((r) => r.kind === kind);
     if (status) rows = rows.filter((r) => r.status === status);
+    // BUCKET-005 filters
+    if (project) rows = rows.filter((r) => r.projectSlug === project);
+    if (techSubDomain) rows = rows.filter((r) => r.techSubDomain === techSubDomain);
 
     const cap = limit ? Math.min(parseInt(limit, 10) || 200, 500) : 200;
     rows = rows.slice(0, cap);
@@ -69,6 +90,12 @@ export function registerBucketsRoutes(app: Hono, db: Db): void {
         bucketId: stories.bucketId,
         ordinal: stories.ordinal,
         templateValidationStatus: stories.templateValidationStatus,
+        // BUCKET-001/003 fields surfaced on the bucket card.
+        projectSlug: stories.projectSlug,
+        techSubDomainPrimary: stories.techSubDomainPrimary,
+        lifecycle: stories.lifecycle,
+        risk: stories.risk,
+        priorityBucket: stories.priorityBucket,
       })
       .from(stories)
       .all();
@@ -85,10 +112,22 @@ export function registerBucketsRoutes(app: Hono, db: Db): void {
     const out: BucketRowOut[] = rows.map((b) => {
       const linked = (storiesByBucket.get(b.id) ?? []).slice().sort((a, z) => a.ordinal - z.ordinal);
       const valid = linked.filter((s) => s.templateValidationStatus === 'valid').length;
+      let levels: string[][] = [];
+      try {
+        const parsed = JSON.parse(b.levelsJson ?? '[]');
+        if (Array.isArray(parsed)) {
+          levels = parsed.filter((lvl): lvl is string[] => Array.isArray(lvl));
+        }
+      } catch {
+        /* malformed levelsJson treated as no levels */
+      }
       return {
         id: b.id,
         kind: b.kind,
         domainSlug: b.domainSlug,
+        projectSlug: b.projectSlug,
+        techSubDomain: b.techSubDomain,
+        levels,
         sequenceIndex: b.sequenceIndex,
         status: b.status,
         promptId: b.promptId,
@@ -100,6 +139,11 @@ export function registerBucketsRoutes(app: Hono, db: Db): void {
           title: s.title,
           status: s.status,
           templateValidationStatus: s.templateValidationStatus,
+          projectSlug: s.projectSlug,
+          techSubDomainPrimary: s.techSubDomainPrimary,
+          lifecycle: s.lifecycle,
+          risk: s.risk,
+          priorityBucket: s.priorityBucket,
         })),
       };
     });


### PR DESCRIPTION
## BUCKET-005 — Bucket kanban surfaces project + tech sub-domain + level metadata

Extends the existing GATE-4-02 buckets kanban with the BUCKET-001/004 fields the multi-bucket placer now writes.

### `apps/orchestrator/src/api/routes/buckets.ts`

- `BucketRowOut` now exposes `projectSlug`, `techSubDomain`, and `levels[][]` (parsed from `task_buckets.levels_json` — written by the BUCKET-004 placer via the BUCKET-008 chain-fragmenter).
- Per-story preview now includes `projectSlug`, `techSubDomainPrimary`, `lifecycle`, `risk`, `priorityBucket` so the card has the full taxonomy context without a second round trip.
- New filter params: `?project=<slug>` and `?techSubDomain=<slug>` in addition to the legacy `?domain=`. The legacy filter still works for buckets that haven't been re-classified yet.

### `apps/dashboard/app/api/buckets/route.ts`

Forwards the new `project` + `techSubDomain` params upstream.

### `apps/dashboard/app/buckets/page.tsx`

- `BucketRow` type extended to match the upstream shape.
- Card header now shows `<project> / <techSubDomain>` when those fields are populated, falling back to `domainSlug` for legacy buckets.
- New levels-pill rendered next to the `StatusPill` when a bucket has >1 WCC level — quick visual indicator of chain depth (`data-testid="bucket-levels-<id>"` for E2E).

### Tests

- `pnpm --filter @caia-app/core run typecheck` — clean.
- `pnpm --filter @caia-app/dashboard run build` — compiles cleanly, `/buckets` page renders.
- BUCKET-006 E2E will exercise this view end-to-end.

### What this unblocks

- **BUCKET-006** — E2E test asserts the dashboard renders ≥3 buckets after a multi-domain prompt, with the new levels-pill present on sequential buckets that have chains.

### References

- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§9.6 dashboard visualization)
