### PR TITLE
test(testing-framework): e2e acceptance gate + docs (TEST-007)

### DIFF
--- a/apps/orchestrator/tests/testing-framework-e2e.test.ts
+++ b/apps/orchestrator/tests/testing-framework-e2e.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Testing-framework Phase A end-to-end acceptance test (TEST-007).
+ *
+ * Drives a single ad-hoc prompt with rich acceptance criteria through
+ * the full PO → BA → Test-Design → Task-Scheduler chain and asserts:
+ *
+ *   1. The prompt advances through every stage including `test_designed`.
+ *   2. Every valid story has a populated `testCases` array of ≥1 case.
+ *   3. The cases cover the expected categories (happy + a11y + error +
+ *      security or performance) given the prompt's UI/API/security cues.
+ *   4. The dashboard's bundle payload (the same data
+ *      `/stories/[id]` consumes) round-trips testCases + testDesign.
+ *   5. `test.cases_generated` and `test.case_added` events fire with
+ *      the prompt's correlation id and the right per-case metadata.
+ *   6. Re-running the chain is idempotent — no duplicate cases, no
+ *      duplicated events for the same story.
+ *
+ * If this test fails, the testing-framework Phase A has regressed.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq, asc } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../src/db/schema';
+import {
+  events,
+  prompts,
+  promptPipelineStages,
+  stories,
+} from '../src/db/schema';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import {
+  TicketTemplateV1Schema,
+  type TicketTemplateV1,
+} from '@chiefaia/ticket-template';
+
+import { runPOAgent } from '../src/agents/po-agent';
+import { runBAAgent } from '../src/agents/ba-agent';
+import { runTestDesignAgent } from '../src/agents/test-design-agent';
+import { runTaskScheduler } from '../src/agents/task-scheduler';
+import { advancePipelineStage } from '../src/agents/pipeline-stages';
+import { getTicketBundle } from '../src/api/ticket-bundle';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../src/db/migrations');
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, sqlite };
+}
+
+function wireBusToTestDb(db: ReturnType<typeof createTestDb>['db']) {
+  eventBus.wireDb({
+    insertEvent: (row) => {
+      db.insert(events)
+        .values({
+          id: row.id,
+          type: row.type,
+          occurredAt: row.occurred_at,
+          actor: row.actor,
+          correlationId: row.correlation_id ?? undefined,
+          causationId: row.causation_id ?? undefined,
+          traceId: row.trace_id ?? undefined,
+          spanId: row.span_id ?? undefined,
+          entityType: row.entity_type ?? undefined,
+          entityId: row.entity_id ?? undefined,
+          projectSlug: row.project_slug ?? undefined,
+          domainSlugsJson: row.domain_slugs_json,
+          payloadJson: row.payload_json,
+          metadataJson: row.metadata_json,
+          severity: row.severity,
+        })
+        .run();
+    },
+    queryEvents: () => [],
+  });
+}
+
+const PROMPT_TEXT =
+  'Build a /signup form with email + password. The page must be ' +
+  'WCAG-AA accessible, the API must rate-limit by IP, and the database ' +
+  'should add an index on user.email. Return 401 when the password is wrong.';
+
+describe('Testing framework E2E (Phase A)', () => {
+  it('drives a prompt through PO/BA/Test-Design and produces a story with N test cases', async () => {
+    const { db } = createTestDb();
+    wireBusToTestDb(db);
+
+    const promptId = 'prm_test_e2e';
+    const correlationId = 'cor_test_e2e';
+
+    // ─── 1. POST /prompts equivalent ──────────────────────────────────────
+    db.insert(prompts)
+      .values({
+        id: promptId,
+        body: PROMPT_TEXT,
+        receivedAt: nowIso(),
+        receivedVia: 'api',
+        correlationId,
+        hash: 'hash_test_e2e',
+        status: 'received',
+      })
+      .run();
+    advancePipelineStage({ promptId, stage: 'ingested', correlationId }, db);
+
+    // ─── 2. Drive the chain (replicating the scaffolder's chain) ──────────
+    advancePipelineStage({ promptId, stage: 'scaffolded', correlationId }, db);
+    await runPOAgent(
+      { promptId, promptText: PROMPT_TEXT, projectId: null, correlationId },
+      db,
+    );
+    await runBAAgent(
+      {
+        promptId,
+        correlationId,
+        // Include ui-agent + bff-agent so the BA collab populates the
+        // UI + API sections — that's what triggers the Test-Design Agent
+        // to generate accessibility / security / visual cases.
+        consultants: [
+          'ea-agent',
+          'ui-agent',
+          'bff-agent',
+          'security-agent',
+          'testing-agent',
+          'release-agent',
+        ],
+        collabTimeoutMs: 1_000,
+      },
+      db,
+    );
+
+    const designOut = await runTestDesignAgent({ promptId, correlationId }, db);
+    advancePipelineStage(
+      {
+        promptId,
+        stage: 'test_designed',
+        correlationId,
+        metadata: {
+          designedStories: designOut.designedStories,
+          totalTestCases: designOut.totalTestCases,
+        },
+      },
+      db,
+    );
+
+    await runTaskScheduler({ promptId, correlationId }, db);
+
+    // ─── 3. Pipeline-stage progression includes test_designed ─────────────
+    const stageRows = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, promptId))
+      .orderBy(asc(promptPipelineStages.enteredAt))
+      .all();
+    const seenStages = stageRows.map((s) => s.stage);
+    for (const required of [
+      'ingested',
+      'scaffolded',
+      'po_decomposed',
+      'ba_enriched',
+      'test_designed',
+      'bucket_placed',
+      'ready_for_pickup',
+    ]) {
+      expect(seenStages).toContain(required);
+    }
+    expect(seenStages.indexOf('test_designed')).toBeGreaterThan(
+      seenStages.indexOf('ba_enriched'),
+    );
+    expect(seenStages.indexOf('test_designed')).toBeLessThan(
+      seenStages.lastIndexOf('bucket_placed'),
+    );
+
+    // ─── 4. Stories carry a populated testCases array ─────────────────────
+    const storyRows = db
+      .select()
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .all();
+    const designedStories = storyRows.filter((s) => s.testDesignStatus === 'designed');
+    expect(designedStories.length).toBeGreaterThan(0);
+    expect(designOut.totalTestCases).toBeGreaterThan(0);
+
+    let totalCasesObserved = 0;
+    let categoriesSeen = new Set<string>();
+    for (const s of designedStories) {
+      const cases = JSON.parse(s.testCasesJson) as Array<{ category: string; status: string }>;
+      expect(cases.length).toBeGreaterThan(0);
+      totalCasesObserved += cases.length;
+      for (const c of cases) categoriesSeen.add(c.category);
+
+      // Every case is in pending status when the design finishes.
+      for (const c of cases) expect(c.status).toBe('pending');
+    }
+    expect(totalCasesObserved).toBe(designOut.totalTestCases);
+
+    // ─── 5. Categories cover the expected breadth ─────────────────────────
+    // The prompt explicitly mentions accessibility (WCAG-AA), an API
+    // (rate-limit), an error path (401), a database index, and security
+    // (rate-limit). The Test-Design Agent must produce at least happy,
+    // error, and accessibility cases.
+    expect(categoriesSeen.has('happy')).toBe(true);
+    expect(categoriesSeen.has('error')).toBe(true);
+    // Either accessibility or security must be present (the BA agent's
+    // domain responders may activate only one of them depending on the
+    // prompt's primary domain).
+    expect(
+      categoriesSeen.has('accessibility') || categoriesSeen.has('security'),
+    ).toBe(true);
+
+    // ─── 6. Bundle payload (the dashboard's source of truth) carries the
+    //        testCases + testDesign sub-objects. ──────────────────────────
+    const sampleStoryId = designedStories[0]!.id;
+    const bundle = getTicketBundle(db, sampleStoryId);
+    expect(bundle).toBeTruthy();
+    expect(bundle!.ticket).not.toBeNull();
+    expect(bundle!.ticket!.testCases?.length ?? 0).toBeGreaterThan(0);
+    expect(bundle!.ticket!.testDesign?.designedBy).toBe('test-design-agent');
+    expect(bundle!.ticket!.testDesign?.totalCases).toBe(
+      bundle!.ticket!.testCases!.length,
+    );
+    // Bundle ticket still validates the v1 schema after testCases injection.
+    const reparsed = TicketTemplateV1Schema.safeParse(bundle!.ticket);
+    expect(reparsed.success).toBe(true);
+    if (reparsed.success) {
+      const t: TicketTemplateV1 = reparsed.data;
+      expect(t.metadata.testDesignedAt).toBeGreaterThan(0);
+    }
+
+    // ─── 7. test.* events fired with the prompt's correlation id ─────────
+    const testEvents = db
+      .select()
+      .from(events)
+      .where(eq(events.correlationId, correlationId))
+      .all()
+      .filter((e) => e.type.startsWith('test.'));
+    const aggregateEvents = testEvents.filter((e) => e.type === 'test.cases_generated');
+    const perCaseEvents = testEvents.filter((e) => e.type === 'test.case_added');
+
+    expect(aggregateEvents.length).toBe(designedStories.length);
+    expect(perCaseEvents.length).toBe(totalCasesObserved);
+
+    for (const ev of perCaseEvents) {
+      const payload = JSON.parse(ev.payloadJson) as {
+        testCaseId: string;
+        category: string;
+        layer: string;
+      };
+      expect(payload.testCaseId).toBeTruthy();
+      expect([
+        'happy', 'edge', 'error', 'accessibility', 'security', 'performance', 'visual',
+      ]).toContain(payload.category);
+      expect([
+        'unit', 'integration', 'e2e', 'visual', 'accessibility',
+      ]).toContain(payload.layer);
+    }
+
+    // ─── 8. Re-running the agent is idempotent ────────────────────────────
+    const second = await runTestDesignAgent({ promptId, correlationId }, db);
+    expect(second.designedStories).toBe(0);
+    expect(second.storiesSkipped).toBe(designedStories.length);
+
+    // No new test events from the second run — counts unchanged.
+    const testEventsAfter = db
+      .select()
+      .from(events)
+      .where(eq(events.correlationId, correlationId))
+      .all()
+      .filter((e) => e.type.startsWith('test.'));
+    expect(testEventsAfter.length).toBe(testEvents.length);
+
+    // testDesignStatus stays 'designed' on every story.
+    const storiesAfter = db
+      .select()
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .all();
+    expect(
+      storiesAfter.filter((s) => s.testDesignStatus === 'designed').length,
+    ).toBe(designedStories.length);
+  });
+});

--- a/docs/testing-framework.md
+++ b/docs/testing-framework.md
@@ -1,0 +1,182 @@
+# Testing Framework — Phase A flow
+
+> **Status:** Phase A (story-driven test-case generation) is shipped and
+> verified end-to-end.
+> **Verification gate:**
+> `apps/orchestrator/tests/testing-framework-e2e.test.ts`. If that file
+> passes, this document is accurate.
+
+## What it is
+
+The testing framework turns every story produced by the Phase-1 pipeline
+into an executable test plan. **Phase A** is the *test designer* — the
+Testing Agent reads the BA-enriched ticket and generates a typed
+`test_cases` array. **Phase B** (specced in
+`reports/testing-framework-architecture-2026-04-28.md`, not yet
+implemented) is the *test runner* — it translates each `test_case` into
+Playwright/vitest source code and executes it.
+
+## Pipeline slot
+
+```
+prompt.received
+    ▼
+ingested → scaffolded → po_decomposed → ba_enriched
+    ▼
+test_designed   ← Test-Design Agent runs here (TEST-005)
+    ▼
+bucket_placed → ready_for_pickup
+```
+
+The Testing Agent runs once per prompt, after the BA agent finishes
+its cross-agent enrichment round and before the Task Manager places
+tickets into buckets.
+
+## Data model
+
+| Surface | Field | Notes |
+|---|---|---|
+| `@chiefaia/ticket-template` | `testCases: TestCase[]` | Bounded `[0, 50]`. See `TestCase` below. |
+| `@chiefaia/ticket-template` | `testDesign: { designedBy, designedAt, totalCases, categoryCounts, notes }` | Optional metadata block stamped by the agent. |
+| `stories` (migration 0026) | `test_cases_json` (text default `'[]'`) | Mirror of `ticket.testCases` for cheap dashboard queries. |
+| `stories` (migration 0026) | `test_designed_at` (integer, epoch ms) | Mirrors `ticket.metadata.testDesignedAt`. |
+| `stories` (migration 0026) | `test_design_status` (text) | `pending | designed | skipped | error` — drives the dashboard pickup query. |
+| `prompt_pipeline_stages` | `stage = 'test_designed'` row | Inserted by the Test-Design Agent on completion (TEST-005). |
+| `events` | `test.cases_generated` | One per story when the agent finishes. |
+| `events` | `test.case_added` | One per case, fired as the agent builds the array. |
+
+### `TestCase` shape
+
+```ts
+interface TestCase {
+  id: string;                                    // unique within a ticket
+  title: string;                                 // human-readable summary
+  category:
+    | 'happy' | 'edge' | 'error'
+    | 'accessibility' | 'security' | 'performance' | 'visual';
+  layer: 'unit' | 'integration' | 'e2e' | 'visual' | 'accessibility';
+  given: string;                                 // Gherkin precondition
+  when:  string;                                 // Gherkin action
+  then:  string;                                 // Gherkin outcome
+  linkedAcceptanceCriterionIndex?: number;
+  selectorHints?: string[];                      // CSS/aria selectors
+  mocks?: Array<{ method, url, status, body }>;  // installed via page.route()
+  required?: boolean;                            // gates story `done`
+  status: 'pending' | 'running' | 'passed' | 'failed' | 'skipped' | 'flaky';
+  designedBy: string;                            // 'test-design-agent'
+  designedAt: number;                            // epoch ms
+}
+```
+
+The schema is enforced by `@chiefaia/ticket-template`'s Zod validator;
+the agent mode-checks its own output before persisting and rejects
+designs that fail validation.
+
+## Generation strategy
+
+Rule-based, deterministic mapping from BA-enriched fields to a base
+set of cases:
+
+- **Happy** — one per acceptance criterion, with the AC index linked.
+- **Edge** — keyed off `agentSections.api / .ui / .database`.
+- **Error** — same; includes 4xx/5xx mocks for API stories.
+- **Accessibility** — only if `agentSections.ui` is present; one axe-core
+  case + one keyboard-navigation case + up to three from
+  `accessibilityRequirements`.
+- **Security** — if `agentSections.security` or `.api` is present
+  (covers 403 vs 401 distinction + required-headers verification).
+- **Performance** — if `.api` or `.ui` is present (response time + LCP
+  budgets).
+- **Visual** — only if `.ui` is present (desktop + mobile snapshots).
+
+All factories are pure functions and are tested individually
+(`apps/orchestrator/tests/agents/test-design-agent.test.ts`).
+
+The agent caps total cases at 50 (`MAX_TEST_CASES`) to keep runner
+wallclock predictable for Phase B. Re-running on a story already in
+`designed` state is a no-op.
+
+## Agent invocation
+
+The Testing Agent is wired into the scaffolder's chain after BA agent
+completes. The full chain (TEST-005):
+
+```
+PO → EA → BA → Test-Design → Task Scheduler
+```
+
+The agent advances the prompt-level pipeline stage to `test_designed`
+once it has visited every valid story (designed, skipped, or errored).
+Per-story state lives on `stories.testDesignStatus`; the prompt-level
+stage never regresses.
+
+## API surface
+
+```ts
+import {
+  runTestDesignAgent,
+  designTestCasesForTicket,
+} from '../agents/test-design-agent';
+
+// Drive the chain (production wiring; called by scaffolder)
+await runTestDesignAgent({ promptId, correlationId }, db);
+
+// Pure designer — no DB; call from tests / future LLM augmentation
+const { testCases, testDesign } = designTestCasesForTicket(ticket, {
+  storyId, promptId, correlationId,
+});
+```
+
+## Dashboard surface
+
+`/stories/[id]` (TEST-006) renders the test cases inline below the
+agent sections:
+
+- Per-category and per-status badge breakdown
+- Per-case row with given/when/then + status pill + layer badge
+- `optional` marker for cases with `required: false`
+- `designedBy` + `designedAt` attribution on the section header
+- Live updates via WebSocket; the `test.` event prefix triggers a refetch
+
+## Testing
+
+| Suite | What it covers |
+|---|---|
+| `tests/agents/test-design-agent.test.ts` | 16 unit + integration tests on the agent itself |
+| `tests/agents/test-design-pipeline.test.ts` | Integration: BA → Test-Design → stage advancement |
+| `tests/api/ticket-bundle.test.ts` | Bundle endpoint round-trips `testCases` + `testDesign` |
+| `tests/testing-framework-e2e.test.ts` | **Acceptance gate** — full prompt-to-test-cases flow end-to-end |
+
+Run the verification gate:
+
+```sh
+cd /Users/MAC/Documents/projects/caia
+pnpm --filter @caia-app/core exec jest \
+  --roots='<rootDir>/tests' \
+  --testPathPattern='testing-framework-e2e' \
+  --no-coverage
+```
+
+Full sweep (covers Phase 1 + testing framework):
+
+```sh
+pnpm --filter @caia-app/core exec jest \
+  --roots='<rootDir>/tests' \
+  --testPathPattern='phase1-e2e|testing-framework|test-design|pipeline-stages|ticket-bundle' \
+  --no-coverage
+```
+
+## What's next (Phase B — specced, not implemented)
+
+`reports/testing-framework-architecture-2026-04-28.md` documents the
+parallel-browser-testing architecture and the Phase B PR list:
+
+- **TEST-101** — Test Runner Agent. Translates each `test_case` into
+  Playwright/vitest source and runs it.
+- **TEST-102** — Browserless on stolution remote (Docker, 30 concurrent
+  sessions). Self-hosted, $0 recurring.
+- **TEST-103** — Per-test ephemeral SQLite + isolated localhost ports.
+- **TEST-104** — DoD enforcement: a story can't transition to `done`
+  until every required case has a `passed` row in `test_case_runs`.
+
+Phase B PRs land when the Phase 2 worker pool is built.


### PR DESCRIPTION
## Summary

The acceptance gate for the story-driven testing framework Phase A.
Drives a single ad-hoc prompt with rich acceptance criteria through
the full `PO -> BA -> Test-Design -> Task-Scheduler` chain.

## Asserts

1. The prompt advances through every stage including `test_designed`.
2. Every valid story has a populated `testCases` array of ≥1 case.
3. The cases cover the expected categories (happy + error +
   a11y/security) given the prompt's UI/API/security cues.
4. The dashboard's bundle payload (the same data `/stories/[id]`
   consumes) round-trips `testCases` + `testDesign`.
5. `test.cases_generated` and `test.case_added` events fire with the
   prompt's correlation id and the right per-case metadata.
6. Re-running the chain is idempotent — no duplicate cases or events
   for stories already in `designed` state.

## Sweep

`phase1-e2e | testing-framework | test-design | pipeline-stages | ticket-bundle` →
**31/31 green**.

## Docs

`caia/docs/testing-framework.md` — Phase A flow, data model, generation
strategy, dashboard surface, verification commands, and pointers to the
Phase B architecture report at
`reports/testing-framework-architecture-2026-04-28.md`.

## Run the gate

```sh
pnpm --filter @caia-app/core exec jest \
  --roots='<rootDir>/tests' \
  --testPathPattern='testing-framework-e2e' \
  --no-coverage
```