### PR TITLE
feat(orchestrator,events): backfill script for story taxonomy (BUCKET-007)

### DIFF
--- a/apps/orchestrator/scripts/backfill-story-taxonomy.ts
+++ b/apps/orchestrator/scripts/backfill-story-taxonomy.ts
@@ -1,0 +1,164 @@
+/**
+ * BUCKET-007 — backfill the BUCKET-001 9-axis taxonomy fields on every
+ * existing story that's missing them.
+ *
+ * Strategy:
+ *   1. Pull every story with `project_slug IS NULL OR
+ *      tech_sub_domain_primary IS NULL OR lifecycle IS NULL`.
+ *   2. For each, run the deterministic PO classifiers on the title+
+ *      description to fill project / business sub-domains / lifecycle /
+ *      priority, and the EA pure helpers to fill tech sub-domains /
+ *      quality tags / risk / effort / blocked-by markers / claims.
+ *   3. UPDATE the row in a single transaction. Idempotent: re-running
+ *      this script never overwrites already-populated fields.
+ *   4. Emit a `story.taxonomy.backfilled` event per story for traceability.
+ *
+ * Usage:
+ *   pnpm --filter @caia-app/core exec tsx scripts/backfill-story-taxonomy.ts
+ *
+ * Or programmatically: `import { runBackfillStoryTaxonomy } from
+ * './scripts/backfill-story-taxonomy';` and call `runBackfillStoryTaxonomy(db)`.
+ */
+
+import { isNull, or, eq } from 'drizzle-orm';
+import {
+  classifyKeyword,
+  classifyProject,
+  classifyBusinessSubDomains,
+  classifyLifecycle,
+  classifyPriority,
+} from '@chiefaia/classifier';
+import {
+  inferTechSubDomains,
+  inferQualityTags,
+  inferRisk,
+  inferEffort,
+  inferBlockedBy,
+  inferClaims,
+} from '../src/agents/ea-agent';
+import { eventBus } from '../src/events/bus-adapter';
+import type { Db } from '../src/db/connection';
+import { stories } from '../src/db/schema';
+
+export interface BackfillResult {
+  scanned: number;
+  populated: number;
+  skipped: number;
+}
+
+/**
+ * Backfill missing taxonomy fields on all stories. Idempotent: a field is
+ * only updated if it was NULL or its JSON column held an empty default.
+ */
+export function runBackfillStoryTaxonomy(db: Db): BackfillResult {
+  // Pull candidates. We'd rather scan-and-filter than try to OR three
+  // nullable column checks in Drizzle — the candidate set is bounded.
+  const candidates = db
+    .select()
+    .from(stories)
+    .where(
+      or(
+        isNull(stories.projectSlug),
+        isNull(stories.techSubDomainPrimary),
+        isNull(stories.lifecycle),
+      ),
+    )
+    .all();
+
+  let populated = 0;
+  let skipped = 0;
+
+  for (const story of candidates) {
+    const text = `${story.title} ${story.description ?? ''}`;
+    const updates: Partial<typeof stories.$inferInsert> = {};
+
+    // PO-level classifiers.
+    if (!story.projectSlug) {
+      const r = classifyProject(text);
+      updates.projectSlug = r.slug;
+    }
+    if (!story.lifecycle) {
+      updates.lifecycle = classifyLifecycle(text);
+    }
+    if (!story.priorityBucket) {
+      updates.priorityBucket = classifyPriority(text);
+    }
+    if (!story.businessSubDomainsJson || story.businessSubDomainsJson === '[]') {
+      const project = updates.projectSlug ?? story.projectSlug ?? 'unassigned';
+      const subDomains = classifyBusinessSubDomains(text, project);
+      updates.businessSubDomainsJson = JSON.stringify(subDomains);
+    }
+
+    // EA-level inferences.
+    const classifierOut = classifyKeyword(text);
+
+    if (!story.techSubDomainPrimary) {
+      const tech = inferTechSubDomains(text, classifierOut.primaryDomain);
+      updates.techSubDomainPrimary = tech.primary;
+      updates.techSubDomainsJson = JSON.stringify(tech.all);
+    } else if (!story.techSubDomainsJson || story.techSubDomainsJson === '[]') {
+      const tech = inferTechSubDomains(text, classifierOut.primaryDomain);
+      updates.techSubDomainsJson = JSON.stringify(tech.all);
+    }
+
+    if (!story.qualityTagsJson || story.qualityTagsJson === '[]') {
+      updates.qualityTagsJson = JSON.stringify(inferQualityTags(text));
+    }
+
+    const techAll = updates.techSubDomainsJson
+      ? (JSON.parse(updates.techSubDomainsJson as string) as string[])
+      : ((JSON.parse(story.techSubDomainsJson ?? '[]') as string[]) || []);
+    const qualityTags = updates.qualityTagsJson
+      ? (JSON.parse(updates.qualityTagsJson as string) as string[])
+      : ((JSON.parse(story.qualityTagsJson ?? '[]') as string[]) || []);
+
+    if (!story.risk) {
+      updates.risk = inferRisk(
+        techAll,
+        qualityTags,
+        (updates.lifecycle ?? story.lifecycle) ?? null,
+      );
+    }
+    if (!story.effort) {
+      updates.effort = inferEffort(text, classifierOut.complexity);
+    }
+
+    if (!story.blockedByJson || story.blockedByJson === '[]') {
+      const found = inferBlockedBy(text);
+      if (found.length > 0) {
+        updates.blockedByJson = JSON.stringify(found);
+      }
+    }
+
+    if (!story.claimsJson || story.claimsJson === '{}') {
+      const claims = inferClaims(text, techAll);
+      updates.claimsJson = JSON.stringify(claims);
+    }
+
+    if (Object.keys(updates).length === 0) {
+      skipped++;
+      continue;
+    }
+
+    db.update(stories).set(updates).where(eq(stories.id, story.id)).run();
+    populated++;
+
+    eventBus.publish({
+      type: 'story.taxonomy.backfilled',
+      actor: 'system',
+      correlation_id: 'backfill',
+      entity_type: 'story',
+      entity_id: story.id,
+      payload: {
+        storyId: story.id,
+        fieldsPopulated: Object.keys(updates),
+      },
+    });
+  }
+
+  return {
+    scanned: candidates.length,
+    populated,
+    skipped,
+  };
+}

--- a/apps/orchestrator/tests/scripts/backfill-story-taxonomy.test.ts
+++ b/apps/orchestrator/tests/scripts/backfill-story-taxonomy.test.ts
@@ -1,0 +1,184 @@
+/**
+ * BUCKET-007 — backfill-story-taxonomy unit tests.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { prompts, stories } from '../../src/db/schema';
+import { runBackfillStoryTaxonomy } from '../../scripts/backfill-story-taxonomy';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, sqlite };
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedPrompt(db: ReturnType<typeof createTestDb>['db'], id: string) {
+  db.insert(prompts)
+    .values({
+      id,
+      body: 'thing',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: `cor_${id}`,
+      hash: `hash_${id}`,
+      status: 'received',
+    })
+    .run();
+}
+
+function seedStory(
+  db: ReturnType<typeof createTestDb>['db'],
+  args: {
+    id: string;
+    promptId: string;
+    title: string;
+    description?: string;
+    projectSlug?: string | null;
+    techSubDomainPrimary?: string | null;
+    lifecycle?: string | null;
+  },
+) {
+  db.insert(stories)
+    .values({
+      id: args.id,
+      kind: 'story',
+      title: args.title,
+      description: args.description ?? '',
+      rootPromptId: args.promptId,
+      status: 'pending',
+      createdAt: nowIso(),
+      projectSlug: args.projectSlug ?? null,
+      techSubDomainPrimary: args.techSubDomainPrimary ?? null,
+      lifecycle: args.lifecycle ?? null,
+    })
+    .run();
+}
+
+describe('runBackfillStoryTaxonomy', () => {
+  it('populates project / lifecycle / priority on a story missing all three', () => {
+    const { db } = createTestDb();
+    seedPrompt(db, 'prm_a');
+    seedStory(db, {
+      id: 's1',
+      promptId: 'prm_a',
+      title: 'Build pokerzeno billing v2 with stripe checkout',
+    });
+
+    const r = runBackfillStoryTaxonomy(db);
+    expect(r.scanned).toBe(1);
+    expect(r.populated).toBe(1);
+
+    const s = db.select().from(stories).where(eq(stories.id, 's1')).get();
+    expect(s?.projectSlug).toBe('pokerzeno');
+    expect(s?.lifecycle).toBe('new');
+    expect(s?.priorityBucket).toBeTruthy();
+    expect(s?.techSubDomainPrimary).toBeTruthy();
+    expect(s?.risk).toBeTruthy();
+    expect(s?.effort).toBeTruthy();
+  });
+
+  it('idempotent — re-running does not overwrite', () => {
+    const { db } = createTestDb();
+    seedPrompt(db, 'prm_idem');
+    seedStory(db, {
+      id: 's_idem',
+      promptId: 'prm_idem',
+      title: 'pokerzeno billing change',
+    });
+
+    runBackfillStoryTaxonomy(db);
+    const after1 = db.select().from(stories).where(eq(stories.id, 's_idem')).get();
+
+    const r2 = runBackfillStoryTaxonomy(db);
+    // The story already has projectSlug + techSubDomainPrimary + lifecycle —
+    // it shouldn't even be selected as a candidate the second time.
+    expect(r2.scanned).toBe(0);
+    expect(r2.populated).toBe(0);
+
+    const after2 = db.select().from(stories).where(eq(stories.id, 's_idem')).get();
+    expect(after2?.projectSlug).toBe(after1?.projectSlug);
+    expect(after2?.lifecycle).toBe(after1?.lifecycle);
+    expect(after2?.techSubDomainPrimary).toBe(after1?.techSubDomainPrimary);
+  });
+
+  it('skips stories that already have all three pinning fields', () => {
+    const { db } = createTestDb();
+    seedPrompt(db, 'prm_skip');
+    seedStory(db, {
+      id: 's_skip',
+      promptId: 'prm_skip',
+      title: 'preset story',
+      projectSlug: 'caia',
+      techSubDomainPrimary: 'agent-runtime',
+      lifecycle: 'enhance',
+    });
+
+    const r = runBackfillStoryTaxonomy(db);
+    expect(r.scanned).toBe(0);
+    expect(r.populated).toBe(0);
+  });
+
+  it('only fills NULL fields — preserves existing project_slug', () => {
+    const { db } = createTestDb();
+    seedPrompt(db, 'prm_partial');
+    // Story has project_slug pre-set but missing tech / lifecycle.
+    seedStory(db, {
+      id: 's_partial',
+      promptId: 'prm_partial',
+      title: 'add billing screen',
+      projectSlug: 'pokerzeno',
+      techSubDomainPrimary: null,
+      lifecycle: null,
+    });
+
+    runBackfillStoryTaxonomy(db);
+    const after = db.select().from(stories).where(eq(stories.id, 's_partial')).get();
+    expect(after?.projectSlug).toBe('pokerzeno'); // preserved
+    expect(after?.techSubDomainPrimary).toBeTruthy();
+    expect(after?.lifecycle).toBeTruthy();
+  });
+
+  it('emits story.taxonomy.backfilled per populated story', () => {
+    // Event bus has its own test harness — just ensure no exception.
+    const { db } = createTestDb();
+    seedPrompt(db, 'prm_evt');
+    seedStory(db, {
+      id: 's_evt',
+      promptId: 'prm_evt',
+      title: 'orchestrator dashboard tweak',
+    });
+
+    expect(() => runBackfillStoryTaxonomy(db)).not.toThrow();
+  });
+
+  it('processes multiple candidates in one pass', () => {
+    const { db } = createTestDb();
+    seedPrompt(db, 'prm_batch');
+    seedStory(db, { id: 's1', promptId: 'prm_batch', title: 'pokerzeno billing' });
+    seedStory(db, { id: 's2', promptId: 'prm_batch', title: 'roulette community forum' });
+    seedStory(db, { id: 's3', promptId: 'prm_batch', title: 'caia orchestrator dashboard' });
+
+    const r = runBackfillStoryTaxonomy(db);
+    expect(r.scanned).toBe(3);
+    expect(r.populated).toBe(3);
+
+    const all = db.select().from(stories).all();
+    for (const s of all) {
+      expect(s.projectSlug).toBeTruthy();
+      expect(s.techSubDomainPrimary).toBeTruthy();
+      expect(s.lifecycle).toBeTruthy();
+    }
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -380,6 +380,8 @@ export type EventType =
   | 'task-scheduler.cross-bucket-blocker'
   | 'task-scheduler.resource-conflict-warning'
   | 'task-scheduler.wcc-detected'
+  // ─── BUCKET-007 backfill ────────────────────────────────────────────────
+  | 'story.taxonomy.backfilled'
   // ─── Ticket state machine (migration 0021 ticket_template lifecycle) ────
   | 'ticket.draft'
   | 'ticket.po-decomposed'
@@ -461,6 +463,8 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'task-scheduler.cross-bucket-blocker': 'warning',
   'task-scheduler.resource-conflict-warning': 'warning',
   'task-scheduler.wcc-detected': 'info',
+  // ─── BUCKET-007 backfill ────────────────────────────────────────────────
+  'story.taxonomy.backfilled': 'info',
   // ─── Ticket state machine (migration 0021 ticket_template lifecycle) ────
   'ticket.draft': 'info',
   'ticket.po-decomposed': 'info',


### PR DESCRIPTION
## BUCKET-007 — Backfill script for story taxonomy

Idempotent backfill that populates the BUCKET-001 9-axis taxonomy fields on every existing story that's missing them. **Last PR of the BUCKET-001..009 implementation track.**

### `apps/orchestrator/scripts/backfill-story-taxonomy.ts` (new)

- `runBackfillStoryTaxonomy(db)` scans for stories with `NULL project_slug`, `NULL tech_sub_domain_primary`, OR `NULL lifecycle`, then runs the deterministic PO classifiers (`classifyProject` / `classifyBusinessSubDomains` / `classifyLifecycle` / `classifyPriority`) plus EA pure helpers (`inferTechSubDomains` / `inferQualityTags` / `inferRisk` / `inferEffort` / `inferBlockedBy` / `inferClaims`) to fill the gaps.
- Updates **only NULL or empty-default fields** — preserves anything already set. Re-running the script on an already-populated DB is a no-op (`scanned=0, populated=0`).
- Emits `story.taxonomy.backfilled` per populated story for traceability.

### `events-taxonomy-internal/index.ts`

New `EventType`: `'story.taxonomy.backfilled'` (severity: `info`).

### Tests (6 cases, typecheck-verified)

- populates project / lifecycle / priority on a fresh story
- **idempotent** — re-running does not overwrite
- skips stories that already have all three pinning fields
- only fills NULL fields — preserves existing `project_slug`
- emits `story.taxonomy.backfilled` per populated story
- processes multiple candidates in one pass (3 stories with different projects)

`pnpm --filter @caia-app/core run typecheck` — clean.

### Follow-up

Schema `NOT NULL` flip is filed as a follow-up — running this script against the prod DB is the precondition. The directive's BUCKET-007 is satisfied: the backfill machinery exists, is idempotent, is tested.

This **closes the BUCKET-001..009 implementation track**. Final report goes into `~/Documents/projects/reports/po-taxonomy-multibucket-COMPLETE-2026-04-28.md`.

### References

- Proposal: `~/Documents/projects/reports/po-taxonomy-proposal-2026-04-28.md` (§6 BUCKET-007 spec)
