### PR TITLE
feat(orchestrator,events): validation_report column + validator events (VAL-003)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0027_validation_report.sql
+++ b/apps/orchestrator/src/db/migrations/0027_validation_report.sql
@@ -1,0 +1,32 @@
+-- Migration 0027: VAL-003 — story validation report + status + attempt counter.
+--
+-- The Story Validator Agent (VAL-004) runs after BA enrichment and writes
+-- a structured ValidationReport into validation_report. validation_status
+-- mirrors the headline outcome so dashboard / scheduler queries stay cheap;
+-- validation_attempts counts BA → Validator round-trips before escalation.
+--
+-- Companion taxonomy:
+--   validation_status:
+--     pending     — Validator has not run yet (default for new stories).
+--     in_progress — Validator currently scoring (set at start, cleared on finish).
+--     passed      — Validator score ≥ thresholds; story may advance.
+--     failed      — Validator score < thresholds; orchestrator re-invokes BA.
+--     escalated   — Max attempts exhausted; manual intervention required.
+--
+-- See ~/Documents/projects/reports/story-validator-architecture-2026-04-28.md
+-- for the validation pipeline + verdict aggregation rules.
+
+ALTER TABLE `stories` ADD COLUMN `validation_report` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `validation_status` text NOT NULL DEFAULT 'pending';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `validation_attempts` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `last_validated_at` integer;
+--> statement-breakpoint
+
+-- Indexes — the bucket placer's ready-pool query filters on validation_status
+-- to ensure only validator-passed stories advance to bucket placement.
+CREATE INDEX IF NOT EXISTS `story_validation_status_idx` ON `stories` (`validation_status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_validation_attempts_idx` ON `stories` (`validation_attempts`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1777700000003,
       "tag": "0026_story_test_cases",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1777800000000,
+      "tag": "0027_validation_report",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -422,6 +422,15 @@ export const stories = sqliteTable('stories', {
   testCasesJson: text('test_cases_json').notNull().default('[]'),
   testDesignedAt: integer('test_designed_at'),
   testDesignStatus: text('test_design_status').notNull().default('pending'), // 'pending'|'designed'|'skipped'|'error'
+  // VAL-003 — Story Validator agent (migration 0027)
+  /** Structured ValidationReport (JSON-serialised) — see @chiefaia/ticket-template. */
+  validationReport: text('validation_report'),
+  /** Headline outcome: 'pending' | 'in_progress' | 'passed' | 'failed' | 'escalated' */
+  validationStatus: text('validation_status').notNull().default('pending'),
+  /** Number of Validator → BA round-trips. Capped at VERDICT_THRESHOLDS.maxAttempts. */
+  validationAttempts: integer('validation_attempts').notNull().default(0),
+  /** Epoch ms when the last validation run completed (pass or fail). */
+  lastValidatedAt: integer('last_validated_at'),
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -437,6 +446,9 @@ export const stories = sqliteTable('stories', {
   index('story_priority_bucket_idx').on(t.priorityBucket),
   // TEST-001 index (migration 0026)
   index('story_test_design_status_idx').on(t.testDesignStatus),
+  // VAL-003 indexes (migration 0027)
+  index('story_validation_status_idx').on(t.validationStatus),
+  index('story_validation_attempts_idx').on(t.validationAttempts),
 ]);
 
 // story_revisions — append-only history of every story-tree edit

--- a/apps/orchestrator/tests/db/0027-validation-report.test.ts
+++ b/apps/orchestrator/tests/db/0027-validation-report.test.ts
@@ -1,0 +1,184 @@
+/**
+ * VAL-003 — round-trip test for the validation_report column + companion
+ * status / attempts / last_validated_at fields added by migration 0027.
+ *
+ * Verifies:
+ *   - the migration runs cleanly on a fresh DB
+ *   - the new columns are reachable via the drizzle schema
+ *   - round-tripping a structured ValidationReport JSON preserves fidelity
+ *   - the indexes covering bucket-placer ready-pool queries exist
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, prompts } from '../../src/db/schema';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function setupDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+  db.insert(prompts)
+    .values({
+      id: 'prm_val_test',
+      body: 'test prompt',
+      receivedAt: nowIso(),
+      receivedVia: 'api',
+      correlationId: 'cor_val_test',
+      hash: 'hash_val_test',
+      status: 'received',
+    })
+    .run();
+
+  db.insert(stories)
+    .values({
+      id: 'stry_val_test',
+      title: 'Test story',
+      kind: 'story',
+      createdAt: nowIso(),
+      rootPromptId: 'prm_val_test',
+    })
+    .run();
+
+  return { db, sqlite };
+}
+
+describe('migration 0027 — validation_report column', () => {
+  it('applies cleanly and exposes default values on existing stories', () => {
+    const { db } = setupDb();
+    const row = db.select().from(stories).where(eq(stories.id, 'stry_val_test')).get();
+
+    expect(row).toBeTruthy();
+    expect(row!.validationReport).toBeNull();
+    expect(row!.validationStatus).toBe('pending');
+    expect(row!.validationAttempts).toBe(0);
+    expect(row!.lastValidatedAt).toBeNull();
+  });
+
+  it('round-trips a structured ValidationReport JSON without loss', () => {
+    const { db } = setupDb();
+    const report = {
+      rubricVersion: 'v1',
+      ranAt: 1777800000123,
+      durationMs: 2340,
+      judgeProvider: 'local',
+      judgeModelTouchpoints: ['qwen2.5-coder:7b'],
+      passed: true,
+      score: 91,
+      nextAction: 'proceed',
+      attemptNumber: 1,
+      steps: {
+        schema: { passed: true, durationMs: 1, details: {} },
+        sectionPresence: { passed: true, durationMs: 1, details: {} },
+        detailSufficiency: { passed: true, durationMs: 4, details: {} },
+        contentRelevance: {
+          passed: true,
+          durationMs: 800,
+          details: {},
+          perSection: { architecture: { passed: true, score: 4, concerns: [] } },
+        },
+        crossSectionConsistency: {
+          passed: true,
+          score: 5,
+          durationMs: 600,
+          details: { consistent: true },
+        },
+        completenessGestalt: {
+          passed: true,
+          durationMs: 900,
+          details: {},
+          testingAgentReady: 5,
+          codingAgentReady: 4,
+          blockers: [],
+          rationale: 'fine',
+        },
+      },
+      failedChecks: [],
+      warnings: [],
+      fixSuggestions: [],
+    };
+
+    db.update(stories)
+      .set({
+        validationReport: JSON.stringify(report),
+        validationStatus: 'passed',
+        validationAttempts: 1,
+        lastValidatedAt: report.ranAt,
+      })
+      .where(eq(stories.id, 'stry_val_test'))
+      .run();
+
+    const row = db.select().from(stories).where(eq(stories.id, 'stry_val_test')).get();
+    expect(row!.validationStatus).toBe('passed');
+    expect(row!.validationAttempts).toBe(1);
+    expect(row!.lastValidatedAt).toBe(report.ranAt);
+
+    const parsed = JSON.parse(row!.validationReport!);
+    expect(parsed.rubricVersion).toBe('v1');
+    expect(parsed.score).toBe(91);
+    expect(parsed.nextAction).toBe('proceed');
+    expect(parsed.steps.contentRelevance.perSection.architecture.score).toBe(4);
+  });
+
+  it('accepts the full lifecycle of validation_status values', () => {
+    const { db } = setupDb();
+    for (const status of ['pending', 'in_progress', 'passed', 'failed', 'escalated']) {
+      db.update(stories)
+        .set({ validationStatus: status })
+        .where(eq(stories.id, 'stry_val_test'))
+        .run();
+      const row = db.select().from(stories).where(eq(stories.id, 'stry_val_test')).get();
+      expect(row!.validationStatus).toBe(status);
+    }
+  });
+
+  it('story_validation_status_idx is queryable (covers bucket-placer ready pool)', () => {
+    const { db, sqlite } = setupDb();
+    for (const [id, status] of [
+      ['stry_a', 'pending'],
+      ['stry_b', 'passed'],
+      ['stry_c', 'failed'],
+      ['stry_d', 'passed'],
+    ] as const) {
+      db.insert(stories)
+        .values({
+          id,
+          title: id,
+          kind: 'story',
+          createdAt: nowIso(),
+          rootPromptId: 'prm_val_test',
+          validationStatus: status,
+        })
+        .run();
+    }
+
+    const passedRows = sqlite
+      .prepare(`SELECT id FROM stories WHERE validation_status = 'passed' ORDER BY id`)
+      .all() as { id: string }[];
+    expect(passedRows.map((r) => r.id)).toEqual(['stry_b', 'stry_d']);
+
+    const idx = sqlite
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND name='story_validation_status_idx'`,
+      )
+      .get();
+    expect(idx).toBeTruthy();
+
+    const idx2 = sqlite
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND name='story_validation_attempts_idx'`,
+      )
+      .get();
+    expect(idx2).toBeTruthy();
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -27,7 +27,8 @@ export type EventActor =
   | 'ba-agent'
   | 'task-scheduler'
   | 'testing-agent'
-  | 'release-agent';
+  | 'release-agent'
+  | 'story-validator';
 
 /** Canonical envelope for every event emitted through the bus */
 export interface ConductorEvent {
@@ -387,6 +388,13 @@ export type EventType =
   // ─── Story-driven testing framework — Phase A (TEST-003) ──────────────────
   | 'test.cases_generated'
   | 'test.case_added'
+  // ─── Story Validator Agent — Phase A (VAL-003) ────────────────────────────
+  | 'story.validation_started'
+  | 'story.validation_passed'
+  | 'story.validation_failed'
+  | 'story.validation_escalated'
+  | 'ticket.validating'
+  | 'ticket.validated'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -474,6 +482,13 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   // ─── Story-driven testing framework — Phase A (TEST-003) ──────────────────
   'test.cases_generated': 'info',
   'test.case_added': 'info',
+  // ─── Story Validator Agent — Phase A (VAL-003) ────────────────────────────
+  'story.validation_started': 'info',
+  'story.validation_passed': 'info',
+  'story.validation_failed': 'warning',
+  'story.validation_escalated': 'error',
+  'ticket.validating': 'info',
+  'ticket.validated': 'info',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -455,3 +455,35 @@ events:
     severity: info
     actor: [testing-agent]
     payload: [storyId, promptId, correlationId, testCaseId, category, layer]
+
+  # Story Validator Agent — Phase A (VAL-003)
+  - type: story.validation_started
+    severity: info
+    actor: [story-validator]
+    payload: [storyId, promptId, correlationId, attemptNumber, rubricVersion]
+
+  - type: story.validation_passed
+    severity: info
+    actor: [story-validator]
+    payload: [storyId, promptId, correlationId, attemptNumber, score, durationMs, judgeProvider]
+
+  - type: story.validation_failed
+    severity: warning
+    actor: [story-validator]
+    payload: [storyId, promptId, correlationId, attemptNumber, score, failedCheckCount, nextAction, durationMs]
+
+  - type: story.validation_escalated
+    severity: error
+    actor: [story-validator]
+    payload: [storyId, promptId, correlationId, attemptNumber, blockerId]
+
+  # Ticket-state machine extensions for the Validator gate.
+  - type: ticket.validating
+    severity: info
+    actor: [story-validator]
+    payload: [storyId, promptId, correlationId, attemptNumber]
+
+  - type: ticket.validated
+    severity: info
+    actor: [story-validator]
+    payload: [storyId, promptId, correlationId, score, judgeProvider]


### PR DESCRIPTION
## VAL-003 — Validator persistence layer

Lands the storage and event-bus surface the Story Validator agent (VAL-004) needs:

### Migration 0027 — `stories` columns
- `validation_report` (text JSON) — structured ValidationReport from the validator agent
- `validation_status` (text, default 'pending') — 'pending' | 'in_progress' | 'passed' | 'failed' | 'escalated'
- `validation_attempts` (integer, default 0) — capped at `VERDICT_THRESHOLDS.maxAttempts`
- `last_validated_at` (integer epoch ms)
- Indexes `story_validation_status_idx` + `story_validation_attempts_idx` (bucket-placer ready-pool covers)

### Drizzle schema additions on `stories`
Match the migration 1:1.

### Event taxonomy additions
Six new event types in `@chiefaia/events-taxonomy-internal`:
- `story.validation_started` (info) — validator about to run
- `story.validation_passed` (info) — pass verdict
- `story.validation_failed` (warning) — soft fail; orchestrator re-invokes BA
- `story.validation_escalated` (error) — max attempts exhausted; blocker filed
- `ticket.validating` (info) — ticket-state machine extension
- `ticket.validated` (info) — ticket-state machine extension

`EventActor` union extended with `'story-validator'`.

### Tests
`tests/db/0027-validation-report.test.ts` (4 cases):
- migration applies cleanly; defaults set correctly on existing stories
- structured ValidationReport JSON round-trips with full fidelity
- validation_status accepts the full lifecycle (5 values)
- both indexes exist and the status index is queryable

### Track context
- VAL-001 (#98) — rubric ✅ merged
- VAL-002 (#102) — pipeline-stage scaffolding ✅ merged
- VAL-003 (this PR) — persistence + events
- VAL-004 — Story Validator agent (uses these columns + emits these events)
- VAL-005 — pipeline wiring + retry loop

### Migration journal
Claims idx 26 / tag 0027_validation_report. Coexists with the in-flight 0025 (input-deps) and the merged 0026/0028.

Architecture: `~/Documents/projects/reports/story-validator-architecture-2026-04-28.md`.