### PR TITLE
feat(feature-registry,orchestrator): @chiefaia/feature-registry skeleton + migration 0028 (FREG-001)

### DIFF
--- a/apps/orchestrator/jest.config.ts
+++ b/apps/orchestrator/jest.config.ts
@@ -25,6 +25,7 @@ const config: Config = {
     '^@chiefaia/decomposer$': '<rootDir>/../../packages/decomposer/src/index.ts',
     '^@chiefaia/dedup-engine$': '<rootDir>/../../packages/dedup-engine/src/index.ts',
     '^@chiefaia/ticket-template$': '<rootDir>/../../packages/ticket-template/src/index.ts',
+    '^@chiefaia/feature-registry$': '<rootDir>/../../packages/feature-registry/src/index.ts',
     // Remap ESM-style `.js` extension imports to `.ts` sources so ts-jest can
     // resolve them without requiring Node ESM module resolution.
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -21,8 +21,8 @@
     "gate:coverage": "ts-node scripts/check-coverage-delta.ts",
     "gate:no-secrets": "gitleaks detect --source . --config .gitleaks.toml --no-banner --redact && trufflehog git file://. --only-verified --fail --no-update",
     "gate:supply-chain": "node -e \"const {execSync}=require('child_process');try{execSync('npm audit --production --audit-level=high',{stdio:'inherit'})}catch(e){process.exit(1)}\"",
-    "gate:a11y": "echo 'gate:a11y: no axe-core runner configured — skipping (add @axe-core/playwright + playwright config to enable)' && exit 0",
-    "gate:brand-lock": "echo 'gate:brand-lock: not a pokerzeno repo — skipping' && exit 0",
+    "gate:a11y": "echo 'gate:a11y: no axe-core runner configured \u2014 skipping (add @axe-core/playwright + playwright config to enable)' && exit 0",
+    "gate:brand-lock": "echo 'gate:brand-lock: not a pokerzeno repo \u2014 skipping' && exit 0",
     "build:run": "bash scripts/build-runner.sh",
     "prepare": "husky"
   },
@@ -45,7 +45,8 @@
     "@chiefaia/decomposer": "workspace:*",
     "@chiefaia/dedup-engine": "workspace:*",
     "@chiefaia/ticket-template": "workspace:*",
-    "@caia-app/pipeline-pulse": "workspace:*"
+    "@caia-app/pipeline-pulse": "workspace:*",
+    "@chiefaia/feature-registry": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",

--- a/apps/orchestrator/src/db/migrations/0028_feature_registry.sql
+++ b/apps/orchestrator/src/db/migrations/0028_feature_registry.sql
@@ -1,0 +1,76 @@
+-- Migration 0028: FREG-001 — feature registry tables.
+--
+-- The Feature Registry catalogs every shipped feature/route/component/
+-- agent so the PO Agent can classify a new task as `enhance` (matches
+-- an existing feature) vs `new`. Two ordinary tables are declared here:
+--
+--   feature_registry             — one row per shipped feature.
+--   feature_registry_search_log  — observability ring buffer.
+--
+-- Two virtual tables — `feature_registry_vec` (sqlite-vec vec0) and
+-- `feature_registry_fts` (FTS5) — are wired by FREG-002 once the
+-- sqlite-vec extension is loaded into the connection. They are NOT
+-- created here because:
+--   1. drizzle-kit doesn't model virtual tables; introspection breaks.
+--   2. The vec0 module isn't loaded at migration time; the CREATE
+--      VIRTUAL TABLE call would fail with "no such module: vec0".
+-- FREG-002 calls a small idempotent bootstrap that runs CREATE VIRTUAL
+-- TABLE IF NOT EXISTS for both, after `sqliteVec.load(db)`.
+--
+-- See ~/Documents/projects/reports/feature-registry-architecture-2026-04-28.md
+-- for the architecture rationale, latency budget, and threshold tuning.
+
+CREATE TABLE `feature_registry` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project` text NOT NULL,
+  `name` text NOT NULL,
+  `description` text NOT NULL,
+  `route_path` text,
+  `file_paths_json` text NOT NULL DEFAULT '[]',
+  `component_name` text,
+  `api_endpoint` text,
+  `db_tables_json` text NOT NULL DEFAULT '[]',
+  `agent_name` text,
+  `shipped_at` integer NOT NULL,
+  `story_id` text,
+  `tags_json` text NOT NULL DEFAULT '[]',
+  `embedding_model` text NOT NULL DEFAULT 'nomic-embed-text',
+  `embedding_dim` integer NOT NULL DEFAULT 768,
+  `embedding_version` text NOT NULL DEFAULT 'v1.5',
+  `source` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  `dedup_key` text NOT NULL UNIQUE
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `freg_project_idx` ON `feature_registry` (`project`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `freg_shipped_idx` ON `feature_registry` (`shipped_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `freg_story_idx` ON `feature_registry` (`story_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `freg_source_idx` ON `feature_registry` (`source`);
+--> statement-breakpoint
+
+CREATE TABLE `feature_registry_search_log` (
+  `id` text PRIMARY KEY NOT NULL,
+  `query` text NOT NULL,
+  `project` text,
+  `classification` text NOT NULL,
+  `top_match_id` text,
+  `top_score` real,
+  `threshold_used` real NOT NULL,
+  `latency_ms` integer NOT NULL,
+  `embedder_tokens` integer NOT NULL DEFAULT 0,
+  `hit_count` integer NOT NULL DEFAULT 0,
+  `caller` text NOT NULL DEFAULT 'po-agent',
+  `created_at` integer NOT NULL
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `freg_log_created_idx` ON `feature_registry_search_log` (`created_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `freg_log_classification_idx` ON `feature_registry_search_log` (`classification`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `freg_log_caller_idx` ON `feature_registry_search_log` (`caller`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1777700000003,
       "tag": "0026_story_test_cases",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1777900000000,
+      "tag": "0028_feature_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -926,3 +926,67 @@ export const taskBuckets = sqliteTable('task_buckets', {
   index('idx_tb_prompt_project_tech').on(t.promptId, t.projectSlug, t.techSubDomain),
   index('idx_tb_project_tech').on(t.projectSlug, t.techSubDomain),
 ]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// feature_registry — FREG-001 (migration 0028)
+//
+// Catalog of every shipped feature/route/component/agent. Powers the PO
+// Agent's new-vs-enhance lifecycle classification by way of a hybrid
+// sqlite-vec + FTS5 search. See @chiefaia/feature-registry for the Zod
+// schema, dedup-key helper, and search/write API.
+//
+// Embeddings live in a sibling vec0 virtual table (`feature_registry_vec`)
+// declared in the SQL migration; drizzle doesn't model virtual tables so
+// FREG-002 wires it via raw SQL on top of better-sqlite3.
+// ─────────────────────────────────────────────────────────────────────────────
+export const featureRegistry = sqliteTable('feature_registry', {
+  id: text('id').primaryKey(),
+  project: text('project').notNull(),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  routePath: text('route_path'),
+  filePathsJson: text('file_paths_json').notNull().default('[]'),
+  componentName: text('component_name'),
+  apiEndpoint: text('api_endpoint'),
+  dbTablesJson: text('db_tables_json').notNull().default('[]'),
+  agentName: text('agent_name'),
+  shippedAt: integer('shipped_at').notNull(),
+  storyId: text('story_id'),
+  tagsJson: text('tags_json').notNull().default('[]'),
+  embeddingModel: text('embedding_model').notNull().default('nomic-embed-text'),
+  embeddingDim: integer('embedding_dim').notNull().default(768),
+  embeddingVersion: text('embedding_version').notNull().default('v1.5'),
+  source: text('source').notNull(),                       // FEATURE_REGISTRY_SOURCES
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  dedupKey: text('dedup_key').notNull().unique(),         // sha256 of (project,name,locator)
+}, (t) => [
+  index('freg_project_idx').on(t.project),
+  index('freg_shipped_idx').on(t.shippedAt),
+  index('freg_story_idx').on(t.storyId),
+  index('freg_source_idx').on(t.source),
+]);
+
+// feature_registry_search_log — FREG-001 (migration 0028)
+//
+// One row per `registry.search` invocation. Powers FREG-007's "top match
+// queries" + latency dashboards. Cleared on a 30-day TTL by a background
+// sweep (added when the dashboard ships).
+export const featureRegistrySearchLog = sqliteTable('feature_registry_search_log', {
+  id: text('id').primaryKey(),
+  query: text('query').notNull(),
+  project: text('project'),                                // optional restriction
+  classification: text('classification').notNull(),         // 'enhance'|'ambiguous'|'new'
+  topMatchId: text('top_match_id'),                         // feature_registry.id when present
+  topScore: real('top_score'),                              // cosine sim in [0,1]
+  thresholdUsed: real('threshold_used').notNull(),
+  latencyMs: integer('latency_ms').notNull(),
+  embedderTokens: integer('embedder_tokens').notNull().default(0),
+  hitCount: integer('hit_count').notNull().default(0),
+  caller: text('caller').notNull().default('po-agent'),     // 'po-agent'|'manual'|'validator'|...
+  createdAt: integer('created_at').notNull(),
+}, (t) => [
+  index('freg_log_created_idx').on(t.createdAt),
+  index('freg_log_classification_idx').on(t.classification),
+  index('freg_log_caller_idx').on(t.caller),
+]);

--- a/apps/orchestrator/tests/db/0028-feature-registry.test.ts
+++ b/apps/orchestrator/tests/db/0028-feature-registry.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Migration 0028 smoke tests — feature_registry + feature_registry_search_log.
+ *
+ * Verifies the migration applies cleanly to a fresh in-memory DB and the
+ * new schema is functional via drizzle (insert/select/UNIQUE on dedup_key/
+ * indexes used by the dashboard surfaces in FREG-007).
+ *
+ * vec0 + FTS5 virtual tables are exercised by FREG-002's separate
+ * integration tests (they require the sqlite-vec extension to be loaded
+ * into the connection, which is not part of this migration).
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq, sql } from 'drizzle-orm';
+import * as path from 'path';
+import { computeDedupKey } from '@chiefaia/feature-registry';
+import * as schema from '../../src/db/schema';
+import { featureRegistry, featureRegistrySearchLog } from '../../src/db/schema';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return db;
+}
+
+function row(overrides: Partial<Record<string, unknown>> = {}) {
+  const now = Date.now();
+  const dedupKey = computeDedupKey({
+    project: 'pokerzeno',
+    name: 'leaderboard page',
+    routePath: '/leaderboard',
+  });
+  return {
+    id: 'freg_test000001',
+    project: 'pokerzeno',
+    name: 'leaderboard page',
+    description: 'ranks top players by chips won today',
+    routePath: '/leaderboard',
+    filePathsJson: JSON.stringify(['app/leaderboard/page.tsx']),
+    componentName: 'LeaderboardPage',
+    apiEndpoint: null,
+    dbTablesJson: JSON.stringify(['users']),
+    agentName: null,
+    shippedAt: now,
+    storyId: 'story-leader-aaaa',
+    tagsJson: JSON.stringify(['gameplay', 'frontend']),
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: 768,
+    embeddingVersion: 'v1.5',
+    source: 'story_completed',
+    createdAt: now,
+    updatedAt: now,
+    dedupKey,
+    ...overrides,
+  } as const;
+}
+
+describe('migration 0028: feature_registry', () => {
+  it('creates the feature_registry table and inserts a row', () => {
+    const db = createTestDb();
+    db.insert(featureRegistry).values(row()).run();
+    const rows = db.select().from(featureRegistry).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.project).toBe('pokerzeno');
+    expect(rows[0]!.name).toBe('leaderboard page');
+    expect(rows[0]!.embeddingModel).toBe('nomic-embed-text');
+    expect(rows[0]!.embeddingDim).toBe(768);
+  });
+
+  it('enforces UNIQUE on dedup_key (idempotent upsert key)', () => {
+    const db = createTestDb();
+    db.insert(featureRegistry).values(row({ id: 'freg_a' })).run();
+    expect(() =>
+      db.insert(featureRegistry).values(row({ id: 'freg_b' })).run(),
+    ).toThrow(/UNIQUE/);
+  });
+
+  it('allows two rows when dedup_key differs', () => {
+    const db = createTestDb();
+    db.insert(featureRegistry).values(row({ id: 'freg_a' })).run();
+    db.insert(featureRegistry)
+      .values(
+        row({
+          id: 'freg_b',
+          name: 'profile page',
+          routePath: '/profile',
+          dedupKey: computeDedupKey({
+            project: 'pokerzeno',
+            name: 'profile page',
+            routePath: '/profile',
+          }),
+        }),
+      )
+      .run();
+    const rows = db.select().from(featureRegistry).all();
+    expect(rows).toHaveLength(2);
+  });
+
+  it('indexes project, story_id, source for dashboard queries', () => {
+    const db = createTestDb();
+    const indexes = db.all(sql`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND tbl_name='feature_registry'
+    `) as Array<{ name: string }>;
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain('freg_project_idx');
+    expect(names).toContain('freg_story_idx');
+    expect(names).toContain('freg_source_idx');
+    expect(names).toContain('freg_shipped_idx');
+  });
+});
+
+describe('migration 0028: feature_registry_search_log', () => {
+  it('creates the search log table and inserts a record', () => {
+    const db = createTestDb();
+    db.insert(featureRegistrySearchLog)
+      .values({
+        id: 'frgl_a',
+        query: 'add a leaderboard',
+        project: 'pokerzeno',
+        classification: 'enhance',
+        topMatchId: 'freg_x',
+        topScore: 0.91,
+        thresholdUsed: 0.85,
+        latencyMs: 187,
+        embedderTokens: 42,
+        hitCount: 3,
+        caller: 'po-agent',
+        createdAt: Date.now(),
+      })
+      .run();
+    const rows = db.select().from(featureRegistrySearchLog).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.classification).toBe('enhance');
+    expect(rows[0]!.embedderTokens).toBe(42);
+  });
+
+  it('logs new-classification rows with no top match', () => {
+    const db = createTestDb();
+    db.insert(featureRegistrySearchLog)
+      .values({
+        id: 'frgl_b',
+        query: 'something nobody has built',
+        project: 'caia',
+        classification: 'new',
+        topMatchId: null,
+        topScore: null,
+        thresholdUsed: 0.85,
+        latencyMs: 195,
+        embedderTokens: 30,
+        hitCount: 0,
+        caller: 'po-agent',
+        createdAt: Date.now(),
+      })
+      .run();
+    const rows = db
+      .select()
+      .from(featureRegistrySearchLog)
+      .where(eq(featureRegistrySearchLog.classification, 'new'))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.topMatchId).toBeNull();
+  });
+});

--- a/packages/feature-registry/README.md
+++ b/packages/feature-registry/README.md
@@ -1,0 +1,77 @@
+# @chiefaia/feature-registry
+
+Fast, local, token-cheap classification system. PO Agent queries the registry
+before classifying a story's `lifecycle` so it can reliably distinguish
+**new functionality** from **enhancement of an existing feature**.
+
+## Why
+
+The PO Agent decomposes user prompts into stories and tags each with
+`lifecycle ∈ {new | enhance | bug | refactor | …}` (per
+`@chiefaia/ticket-template`). Distinguishing `new` from `enhance` requires
+knowing *what already exists*. Scanning the codebase via grep / LLM on every
+decomposition is too slow and burns tokens.
+
+The Feature Registry is a structured, indexed catalog of every shipped
+feature/route/component/agent. PO queries it in <200ms with **zero Claude
+tokens** (embeddings run locally via Ollama).
+
+## Architecture
+
+- **Embeddings:** `nomic-embed-text:latest` via Ollama (137M params, 768d,
+  Apache 2.0). Already pulled on M1 Pro dev hardware. Cold ~600ms; warm
+  ~190ms p50 / 215ms p95 with HTTP keep-alive.
+- **Vector store:** `sqlite-vec` (vec0 virtual table). Loaded into the
+  existing `better-sqlite3` connection — same DB file, no new daemon.
+  Brute-force cosine on ~10K rows is sub-millisecond.
+- **Hybrid search:** dense (sqlite-vec cosine) + sparse (SQLite FTS5
+  BM25), fused via Reciprocal Rank Fusion (k=60). No reranker for v1.
+- **Threshold:** `>= 0.85` cosine sim → confident `enhance`;
+  `0.78–0.85` → ambiguous (BA reviews); `< 0.78` → `new`. Tunable per
+  project.
+
+Detailed architecture report:
+`~/Documents/projects/reports/feature-registry-architecture-2026-04-28.md`.
+
+## Public API
+
+```ts
+import {
+  FeatureRegistryRowSchema,
+  type FeatureRegistryRow,
+  computeDedupKey,
+} from '@chiefaia/feature-registry';
+
+// Schema validation
+const row = FeatureRegistryRowSchema.parse({ ... });
+
+// Idempotent dedup key
+const key = computeDedupKey({
+  project: 'pokerzeno',
+  name: 'leaderboard page',
+  routePath: '/leaderboard',
+});
+```
+
+Search and write APIs land with FREG-002 / FREG-003 / FREG-005.
+
+## Coordination
+
+- **LAI-### track** ships the local-AI embedder/cache infrastructure;
+  this package consumes those via the `EmbeddingClient` interface so
+  there's no duplication.
+- **VAL-### track** can re-use `registry.search` for content-relevance
+  checks once shipped.
+- **BUCKET-### track** owns the `lifecycle` enum (in ticket-template);
+  this package just makes the classification automatic.
+- **Phase 1 pipeline ordering:** FREG runs at the PO step, before BA. PO
+  defaults to `lifecycle='new'` if registry/embedder is unavailable.
+
+## DoD compliance
+
+- Unit tests over the Zod schema + dedup key (FREG-001)
+- Integration tests over the SQLite + sqlite-vec write/read cycle
+  (FREG-002)
+- Benchmark tests for search latency (FREG-005)
+- E2E test driving the full PO pipeline with feature-registry plumbing
+  (FREG-008)

--- a/packages/feature-registry/package.json
+++ b/packages/feature-registry/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@chiefaia/feature-registry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Fast, local, token-cheap feature registry. PO Agent queries it before classifying lifecycle (new vs enhance). Hybrid sqlite-vec + FTS5 search; nomic-embed-text via Ollama; zero Claude tokens per classification.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@chiefaia/ticket-template": "workspace:*",
+    "nanoid": "^3.3.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/feature-registry/src/dedup-key.ts
+++ b/packages/feature-registry/src/dedup-key.ts
@@ -1,0 +1,60 @@
+/**
+ * @chiefaia/feature-registry — dedup key (FREG-001)
+ *
+ * Idempotency for the registry: the dedup_key column has a UNIQUE
+ * constraint, so the story.completed subscriber and backfill script can
+ * blindly upsert the same logical feature without inserting duplicates.
+ *
+ * Key composition: project + name + (route_path || component_name ||
+ * agent_name || api_endpoint || file_paths_canonical). Whatever locator
+ * uniquely identifies the feature within the project. We hash the
+ * concatenation so two different callers building the same logical
+ * feature get the same key regardless of which locator field they
+ * happened to populate first.
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface DedupKeyInput {
+  project: string;
+  name: string;
+  routePath?: string | null;
+  componentName?: string | null;
+  apiEndpoint?: string | null;
+  agentName?: string | null;
+  filePaths?: string[];
+}
+
+/**
+ * Lowercase + trim + collapse whitespace. Defends against the same
+ * feature being seeded once with `' /Leaderboard '` and once with
+ * `'/leaderboard'`.
+ */
+function norm(s: string | null | undefined): string {
+  if (!s) return '';
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Compute a stable, idempotent dedup key for a registry row.
+ *
+ * Output: 64-char hex sha256 string. Stable across processes / language
+ * runtimes / order of locator-field population.
+ */
+export function computeDedupKey(input: DedupKeyInput): string {
+  const project = norm(input.project);
+  const name = norm(input.name);
+  // Locator preference order: most specific first. We use the FIRST
+  // populated locator to define the key — using all of them would mean a
+  // row partially populated by story.completed and later enriched by
+  // backfill would get a different key than the original.
+  const locator =
+    norm(input.routePath) ||
+    norm(input.apiEndpoint) ||
+    norm(input.componentName) ||
+    norm(input.agentName) ||
+    norm((input.filePaths ?? []).slice().sort().join('|'));
+
+  const payload = `${project}::${name}::${locator}`;
+  return createHash('sha256').update(payload).digest('hex');
+}

--- a/packages/feature-registry/src/index.ts
+++ b/packages/feature-registry/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @chiefaia/feature-registry — public exports
+ *
+ * FREG-001: schema + dedup key.
+ * FREG-002: storage layer (sqlite-vec).
+ * FREG-003: story.completed event subscriber.
+ * FREG-004: backfill script.
+ * FREG-005: hybrid search API.
+ * FREG-006: PO Agent integration.
+ */
+
+export {
+  FeatureRegistryRowSchema,
+  ClassificationVerdictSchema,
+  SearchHitSchema,
+  SearchResultSchema,
+  FEATURE_REGISTRY_SOURCES,
+  FEATURE_REGISTRY_VERSION,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_VERSION,
+  DEFAULT_ENHANCE_THRESHOLD,
+  DEFAULT_AMBIGUOUS_THRESHOLD,
+  MAX_NAME_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_TAGS,
+} from './schema';
+export type {
+  FeatureRegistryRow,
+  FeatureRegistrySource,
+  ClassificationVerdict,
+  SearchHit,
+  SearchResult,
+} from './schema';
+
+export { computeDedupKey } from './dedup-key';
+export type { DedupKeyInput } from './dedup-key';

--- a/packages/feature-registry/src/schema.ts
+++ b/packages/feature-registry/src/schema.ts
@@ -1,0 +1,201 @@
+/**
+ * @chiefaia/feature-registry — schema (FREG-001)
+ *
+ * The canonical, Zod-validated shape of a Feature Registry row. Every row
+ * represents one shipped feature/route/component/agent that the PO Agent
+ * can match a new task against (to classify `lifecycle = 'enhance'`).
+ *
+ * Keep this file dependency-free aside from `zod` so it can be imported
+ * by the orchestrator, dashboard, and tooling alike without dragging in
+ * SQLite/Ollama transitive deps.
+ */
+
+import { z } from 'zod';
+import { PROJECT_SLUGS } from '@chiefaia/ticket-template';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const FEATURE_REGISTRY_VERSION = 'v1' as const;
+
+/**
+ * The default embedding model the registry uses for new rows. Stored on
+ * each row so a future model swap can detect-and-backfill stale rows
+ * without rebuilding the whole index from scratch.
+ */
+export const DEFAULT_EMBEDDING_MODEL = 'nomic-embed-text' as const;
+export const DEFAULT_EMBEDDING_DIM = 768 as const;
+export const DEFAULT_EMBEDDING_VERSION = 'v1.5' as const;
+
+/**
+ * Where a registry row originated. Distinguishes auto-populated rows
+ * (which can be safely re-embedded without losing curation) from
+ * human-curated ones (which a backfill should not overwrite).
+ */
+export const FEATURE_REGISTRY_SOURCES = [
+  'story_completed',
+  'backfill_codebase',
+  'backfill_stories',
+  'manual',
+] as const;
+export type FeatureRegistrySource = (typeof FEATURE_REGISTRY_SOURCES)[number];
+
+// ─── Per-row schema ──────────────────────────────────────────────────────────
+
+/**
+ * Bounded so a misbehaving caller (or a corrupted backfill) cannot blow
+ * up the embedding model context. nomic-embed-text caps at 8K tokens,
+ * but well-formed feature blurbs are usually <300 chars; 2000 is generous.
+ */
+export const MAX_NAME_LENGTH = 200;
+export const MAX_DESCRIPTION_LENGTH = 2000;
+export const MAX_TAGS = 20;
+
+/**
+ * Project slug must match the canonical taxonomy from ticket-template
+ * (so cross-project search and dashboard filters are coherent). New
+ * project? Add it to PROJECT_SLUGS first.
+ */
+const ProjectSlugEnum = z.enum(PROJECT_SLUGS);
+
+export const FeatureRegistryRowSchema = z
+  .object({
+    // ─── Identity ──────────────────────────────────────────────────────────
+    /** `freg_<nanoid10>`. Stable across re-embeds. */
+    id: z.string().min(1),
+
+    project: ProjectSlugEnum,
+
+    /** Human-readable feature name. Used as the BM25-search anchor. */
+    name: z.string().min(1).max(MAX_NAME_LENGTH),
+
+    /** Free-form description. The primary embedding input. */
+    description: z.string().min(1).max(MAX_DESCRIPTION_LENGTH),
+
+    // ─── Locator fields (any may be null) ──────────────────────────────────
+    /** e.g. '/leaderboard' or '/api/v1/users/[id]'. */
+    routePath: z.string().optional(),
+
+    /** Files implementing this feature. Empty if not yet known. */
+    filePaths: z.array(z.string().min(1)).default([]),
+
+    /** Exported component name, e.g. 'LeaderboardPage'. */
+    componentName: z.string().optional(),
+
+    /** Backend route signature, e.g. 'GET /api/leaderboard'. */
+    apiEndpoint: z.string().optional(),
+
+    /** Tables the feature reads/writes. */
+    dbTables: z.array(z.string().min(1)).default([]),
+
+    /** Agent name if the feature IS an agent (e.g. 'po-agent'). */
+    agentName: z.string().optional(),
+
+    // ─── Provenance ────────────────────────────────────────────────────────
+    /** epoch ms — when the feature reached `done`. */
+    shippedAt: z.number().int().nonnegative(),
+
+    /** Story it was synthesized from (if any). Back-link for the dashboard. */
+    storyId: z.string().optional(),
+
+    /**
+     * Free-form tags. Union of business-sub-domains, quality tags, and
+     * tech-sub-domains drawn from the BUCKET-001 axes; arbitrary strings
+     * also welcome.
+     */
+    tags: z.array(z.string().min(1)).max(MAX_TAGS).default([]),
+
+    // ─── Embedding metadata ────────────────────────────────────────────────
+    /** Model used to compute the vector stored in feature_registry_vec. */
+    embeddingModel: z.string().default(DEFAULT_EMBEDDING_MODEL),
+
+    /** Dimensionality. Must match the vec0 table column declaration. */
+    embeddingDim: z.number().int().positive().default(DEFAULT_EMBEDDING_DIM),
+
+    /** Model version — used to invalidate on upgrade. */
+    embeddingVersion: z.string().default(DEFAULT_EMBEDDING_VERSION),
+
+    // ─── Audit ─────────────────────────────────────────────────────────────
+    source: z.enum(FEATURE_REGISTRY_SOURCES),
+
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative(),
+
+    /**
+     * sha256 of (project, name, locator). Indexed UNIQUE so the
+     * story.completed subscriber + backfill script are idempotent
+     * (re-running upserts the embedding/tags/updatedAt without
+     * inserting a duplicate row).
+     */
+    dedupKey: z.string().min(40).max(80),
+  })
+  .strict();
+
+export type FeatureRegistryRow = z.infer<typeof FeatureRegistryRowSchema>;
+
+// ─── Search-result schemas ──────────────────────────────────────────────────
+
+/**
+ * The classification verdict returned by `registry.search`.
+ *
+ * `enhance` means: the top match clears the high-confidence threshold;
+ * PO Agent should set `lifecycle='enhance'` and `links_to=[topMatch.id]`.
+ *
+ * `ambiguous` means: top match is in the grey zone. PO Agent should
+ * still set `lifecycle='enhance'` + `links_to=[topMatch.id]` but emit
+ * a `feature.classification.uncertain` event so BA / a human can review.
+ *
+ * `new` means: nothing came close enough. PO Agent sets `lifecycle='new'`.
+ */
+export const ClassificationVerdictSchema = z.enum(['enhance', 'ambiguous', 'new']);
+export type ClassificationVerdict = z.infer<typeof ClassificationVerdictSchema>;
+
+/** Per-hit record in a SearchResult. */
+export const SearchHitSchema = z
+  .object({
+    row: FeatureRegistryRowSchema,
+    /** cosine similarity in [0, 1]. -1 if dense retrieval missed. */
+    scoreDense: z.number(),
+    /** BM25 normalized to [0, 1]. -1 if sparse retrieval missed. */
+    scoreSparse: z.number(),
+    /** Reciprocal-Rank-Fusion score; higher = better. */
+    scoreFused: z.number(),
+    matchType: z.enum(['dense', 'sparse', 'both']),
+  })
+  .strict();
+export type SearchHit = z.infer<typeof SearchHitSchema>;
+
+/** Aggregate result returned by `registry.search`. */
+export const SearchResultSchema = z
+  .object({
+    hits: z.array(SearchHitSchema),
+    classification: ClassificationVerdictSchema,
+    /** null iff hits is empty. */
+    topMatch: SearchHitSchema.nullable(),
+    /** Cosine threshold actually used (after per-project override). */
+    thresholdUsed: z.number(),
+    /** Wall-clock ms for the full search call (embed + retrieve + fuse). */
+    latencyMs: z.number().nonnegative(),
+    /**
+     * Local-Ollama tokens consumed. Reported separately from Claude
+     * tokens (which are always 0 in the search hot path) so dashboards
+     * can prove the zero-Claude-token guarantee.
+     */
+    embedderTokens: z.number().int().nonnegative(),
+  })
+  .strict();
+export type SearchResult = z.infer<typeof SearchResultSchema>;
+
+// ─── Threshold defaults (used by registry.search) ───────────────────────────
+
+/**
+ * Default cosine thresholds. Tune per project after FREG-004 backfill +
+ * FREG-007 dashboard surfaces calibration data.
+ *
+ * Why 0.78 and not 0.7: nomic-embed-text on short English feature
+ * descriptions clusters tighter than the general MTEB distribution.
+ * Empirically (research notebook 2026-04-28), unrelated feature
+ * descriptions land at 0.55-0.65; loosely related ones around 0.7;
+ * clear matches at 0.85+.
+ */
+export const DEFAULT_ENHANCE_THRESHOLD = 0.85 as const;
+export const DEFAULT_AMBIGUOUS_THRESHOLD = 0.78 as const;

--- a/packages/feature-registry/tests/schema.test.ts
+++ b/packages/feature-registry/tests/schema.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FeatureRegistryRowSchema,
+  computeDedupKey,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_MODEL,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_NAME_LENGTH,
+} from '../src';
+
+const NOW = 1745812800000; // 2026-04-28 in epoch ms
+
+function buildRow(overrides: Partial<Record<string, unknown>> = {}) {
+  const base = {
+    id: 'freg_abc1234567',
+    project: 'pokerzeno' as const,
+    name: 'leaderboard page',
+    description: 'ranks top players by chips won today',
+    routePath: '/leaderboard',
+    filePaths: ['app/leaderboard/page.tsx'],
+    componentName: 'LeaderboardPage',
+    apiEndpoint: undefined,
+    dbTables: ['users', 'sessions'],
+    agentName: undefined,
+    shippedAt: NOW,
+    storyId: 'story-leader-aaaa',
+    tags: ['gameplay', 'frontend'],
+    source: 'story_completed' as const,
+    createdAt: NOW,
+    updatedAt: NOW,
+    dedupKey: computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    }),
+  };
+  return { ...base, ...overrides };
+}
+
+describe('FeatureRegistryRowSchema', () => {
+  it('accepts a fully-populated row with the minimum required locator', () => {
+    const parsed = FeatureRegistryRowSchema.parse(buildRow());
+    expect(parsed.id).toBe('freg_abc1234567');
+    expect(parsed.embeddingModel).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(parsed.embeddingDim).toBe(DEFAULT_EMBEDDING_DIM);
+  });
+
+  it('rejects a row with an unknown project slug', () => {
+    expect(() =>
+      FeatureRegistryRowSchema.parse(buildRow({ project: 'fakeproject' as unknown as string })),
+    ).toThrow();
+  });
+
+  it('rejects an empty name', () => {
+    expect(() => FeatureRegistryRowSchema.parse(buildRow({ name: '' }))).toThrow();
+  });
+
+  it('rejects a name beyond MAX_NAME_LENGTH', () => {
+    expect(() =>
+      FeatureRegistryRowSchema.parse(buildRow({ name: 'a'.repeat(MAX_NAME_LENGTH + 1) })),
+    ).toThrow();
+  });
+
+  it('rejects a description beyond MAX_DESCRIPTION_LENGTH', () => {
+    expect(() =>
+      FeatureRegistryRowSchema.parse(
+        buildRow({ description: 'a'.repeat(MAX_DESCRIPTION_LENGTH + 1) }),
+      ),
+    ).toThrow();
+  });
+
+  it('rejects a row with an unknown source', () => {
+    expect(() =>
+      FeatureRegistryRowSchema.parse(buildRow({ source: 'magic' as unknown as string })),
+    ).toThrow();
+  });
+
+  it('rejects a negative shippedAt', () => {
+    expect(() => FeatureRegistryRowSchema.parse(buildRow({ shippedAt: -1 }))).toThrow();
+  });
+
+  it('rejects extra unknown fields (strict)', () => {
+    expect(() =>
+      FeatureRegistryRowSchema.parse({ ...buildRow(), wat: 'extra' } as unknown as object),
+    ).toThrow();
+  });
+
+  it('accepts an agent-style locator (agentName, no routePath)', () => {
+    const row = buildRow({
+      routePath: undefined,
+      componentName: undefined,
+      filePaths: ['apps/orchestrator/src/agents/po-agent.ts'],
+      agentName: 'po-agent',
+      dedupKey: computeDedupKey({
+        project: 'pokerzeno',
+        name: 'leaderboard page',
+        agentName: 'po-agent',
+      }),
+    });
+    expect(() => FeatureRegistryRowSchema.parse(row)).not.toThrow();
+  });
+
+  it('rejects a too-short dedupKey', () => {
+    expect(() => FeatureRegistryRowSchema.parse(buildRow({ dedupKey: 'short' }))).toThrow();
+  });
+
+  it('caps tags at MAX_TAGS', () => {
+    const tooMany = Array.from({ length: 21 }, (_, i) => `tag-${i}`);
+    expect(() => FeatureRegistryRowSchema.parse(buildRow({ tags: tooMany }))).toThrow();
+  });
+});
+
+describe('computeDedupKey', () => {
+  it('is deterministic across calls', () => {
+    const k1 = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    });
+    const k2 = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    });
+    expect(k1).toBe(k2);
+  });
+
+  it('normalizes whitespace and case', () => {
+    const k1 = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'Leaderboard Page',
+      routePath: ' /Leaderboard ',
+    });
+    const k2 = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    });
+    expect(k1).toBe(k2);
+  });
+
+  it('differs when project differs', () => {
+    const k1 = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    });
+    const k2 = computeDedupKey({
+      project: 'roulettecommunity',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('uses route_path before component_name when both are present', () => {
+    const withRoute = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+      componentName: 'LeaderboardPage',
+    });
+    const withoutComponent = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      routePath: '/leaderboard',
+    });
+    expect(withRoute).toBe(withoutComponent);
+  });
+
+  it('falls back to api_endpoint when no route/component/agent', () => {
+    const k = computeDedupKey({
+      project: 'caia',
+      name: 'metrics endpoint',
+      apiEndpoint: 'GET /metrics',
+    });
+    expect(k).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('falls back to sorted file_paths when nothing else is available', () => {
+    const k1 = computeDedupKey({
+      project: 'caia',
+      name: 'shared utility',
+      filePaths: ['packages/utils/src/b.ts', 'packages/utils/src/a.ts'],
+    });
+    const k2 = computeDedupKey({
+      project: 'caia',
+      name: 'shared utility',
+      filePaths: ['packages/utils/src/a.ts', 'packages/utils/src/b.ts'],
+    });
+    expect(k1).toBe(k2);
+  });
+
+  it('produces a 64-char lowercase hex string', () => {
+    const k = computeDedupKey({
+      project: 'pokerzeno',
+      name: 'leaderboard',
+      routePath: '/leaderboard',
+    });
+    expect(k).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/packages/feature-registry/tsconfig.json
+++ b/packages/feature-registry/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/feature-registry/vitest.config.ts
+++ b/packages/feature-registry/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@chiefaia/events-taxonomy-internal':
         specifier: workspace:*
         version: link:../../packages/events-taxonomy-internal
+      '@chiefaia/feature-registry':
+        specifier: workspace:*
+        version: link:../../packages/feature-registry
       '@chiefaia/local-llm-router':
         specifier: workspace:*
         version: link:../../packages/local-llm-router
@@ -643,6 +646,28 @@ importers:
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   packages/events-taxonomy-internal: {}
+
+  packages/feature-registry:
+    dependencies:
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../ticket-template
+      nanoid:
+        specifier: ^3.3.7
+        version: 3.3.11
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/image-provider:
     dependencies:


### PR DESCRIPTION
## Summary

Phase A — schema-only foundation for the **Feature Registry**. PO Agent will query this catalog at decomposition time to classify a story as `enhance` (matches an existing feature) vs `new` — without spending Claude tokens.

This PR is intentionally minimal: only schema, dedup-key, and DB layout. The rest of the rollout:
- **FREG-002** — sqlite-vec wiring (vec0 + FTS5)
- **FREG-003** — `story.completed` event subscriber
- **FREG-004** — backfill script (codebase + shipped stories)
- **FREG-005** — hybrid search API (Ollama + sqlite-vec + RRF)
- **FREG-006** — PO Agent integration
- **FREG-007** — `/registry` dashboard
- **FREG-008** — E2E test (latency + zero Claude tokens)

Architecture report: `~/Documents/projects/reports/feature-registry-architecture-2026-04-28.md`. Directive: `~/Library/Application Support/Claude/.../feature_registry_directive.md`.

## What ships

- New package `@chiefaia/feature-registry`:
  - `FeatureRegistryRowSchema` (strict Zod) — project drawn from `PROJECT_SLUGS`, bounded fields, embedding metadata, UNIQUE `dedupKey`
  - `SearchHitSchema` + `SearchResultSchema` + `ClassificationVerdictSchema` locked in now so FREG-005/006 land without schema churn
  - `DEFAULT_ENHANCE_THRESHOLD = 0.85` + `DEFAULT_AMBIGUOUS_THRESHOLD = 0.78` (per research notebook on `nomic-embed-text` cluster behavior)
  - `computeDedupKey(input)` — sha256 of (project, name, locator) with locator preference `route_path > api_endpoint > component_name > agent_name > sorted file_paths`. Whitespace-collapsed + lowercased so `' /Leaderboard '` and `'/leaderboard'` map to the same key.
- Drizzle table additions in `apps/orchestrator/src/db/schema.ts`: `featureRegistry`, `featureRegistrySearchLog`.
- SQL migration `0028_feature_registry.sql` (regular tables + 7 indexes). The vec0 + FTS5 virtual tables land in FREG-002 via raw SQL after `sqliteVec.load(db)` — drizzle-kit can't model virtual tables.

## Tests (DoD)

- **Unit:** 18/18 vitest cases over the Zod schema + dedup key
- **Integration:** 6/6 jest cases over the live migration on better-sqlite3 (insert/select roundtrip, UNIQUE-on-dedup_key, two-row insertion, index introspection, search-log row with/without top match)
- **Typecheck:** `tsc --noEmit` clean for the new package
- **Docs:** README on the package, architecture report linked above

## Coordination

- **LAI-### track** ships shared embedder/cache infrastructure. This package will consume it via the `EmbeddingClient` interface (defined in FREG-005); for now FREG-002 will ship its own minimal Ollama HTTP client.
- **VAL-### track** can re-use `registry.search` for content-relevance checks once FREG-005 lands.
- **BUCKET-### track** owns `LIFECYCLE_VALUES`; this package only makes the classification automatic.
- **Phase 1 pipeline:** FREG runs at PO step, before BA. PO defaults to `lifecycle='new'` if registry/embedder unavailable.

## Risk

Low. Pure additive — no existing tables touched, no existing code paths changed. Migration is forward-only (matches the convention of every prior `00NN_*.sql`).