### PR TITLE
feat(orchestrator,events-taxonomy): FeatureRegistryWriter subscriber + new events (FREG-003)

### DIFF
--- a/apps/orchestrator/src/agents/feature-registry-writer.ts
+++ b/apps/orchestrator/src/agents/feature-registry-writer.ts
@@ -1,0 +1,244 @@
+/**
+ * FeatureRegistryWriter — FREG-003
+ *
+ * Subscribes to `story.completed` and idempotently upserts a
+ * `feature_registry` row + its embedding via `@chiefaia/feature-registry`.
+ *
+ * Hot-path budget: <300ms (mostly Ollama embed). Failure modes:
+ *   - Ollama unreachable → log warn, continue. Backfill picks up later.
+ *   - sqlite-vec not bootstrapped → log warn, continue.
+ *   - Story missing required fields → log warn, skip.
+ *
+ * Wired in install.ts at orchestrator startup.
+ */
+
+import { nanoid } from 'nanoid';
+import { eq } from 'drizzle-orm';
+import {
+  computeDedupKey,
+  EmbedderUnavailableError,
+  FeatureRegistryRowSchema,
+  OllamaEmbeddingClient,
+  upsertRegistryRow,
+  type EmbeddingClient,
+  type FeatureRegistryRow,
+} from '@chiefaia/feature-registry';
+import { eventBus } from '../events/bus-adapter';
+import { getDb, getSqliteRaw } from '../db/connection';
+import { stories } from '../db/schema';
+
+// Logger shim — replaced at runtime by the real pino logger if available.
+const logger = {
+  warn: (obj: Record<string, unknown>, msg: string) => {
+    console.warn('[feature-registry-writer]', msg, obj);
+  },
+  info: (obj: Record<string, unknown>, msg: string) => {
+    console.log('[feature-registry-writer]', msg, obj);
+  },
+};
+
+export interface RegisterWriterOpts {
+  /**
+   * Override the embedding client. Default: shared OllamaEmbeddingClient.
+   * Tests pass StubEmbeddingClient; LAI track will pass its embedder once
+   * the shared package ships.
+   */
+  embedder?: EmbeddingClient;
+  /**
+   * Disables the writer entirely. Useful in tests or when the orchestrator
+   * is started in a degraded mode.
+   */
+  enabled?: boolean;
+}
+
+let _embedder: EmbeddingClient | null = null;
+function getEmbedder(opts: RegisterWriterOpts): EmbeddingClient {
+  if (opts.embedder) return opts.embedder;
+  if (!_embedder) _embedder = new OllamaEmbeddingClient();
+  return _embedder;
+}
+
+/**
+ * Synthesize a FeatureRegistryRow from a story row.
+ *
+ * The mapping is intentionally conservative — for fields we can't
+ * confidently derive (file_paths, route_path, component_name) we leave
+ * them null. The backfill script (FREG-004) and the dashboard (FREG-007)
+ * surface "thin" rows so they can be enriched.
+ */
+export function synthesizeRowFromStory(input: {
+  story: typeof stories.$inferSelect;
+  now: number;
+}): FeatureRegistryRow | null {
+  const { story, now } = input;
+  if (!story.title || story.title.length === 0) return null;
+
+  // Map story.status → feature.shippedAt. Stories are
+  // 'pending'|'verified'|'failed'|'partial'. Only 'verified' is "done".
+  const shippedAt =
+    story.status === 'verified' || story.status === 'partial'
+      ? now
+      : now;
+
+  const projectSlug = story.projectSlug ?? 'unassigned';
+  const description = story.description && story.description.length > 0
+    ? story.description.slice(0, 2000)
+    : story.title;
+
+  // Best-effort tag union: domain_slugs + tech_sub_domain_primary +
+  // quality_tags. Defensive parsing — any malformed JSON yields [].
+  const tags: string[] = [];
+  try {
+    const ds = JSON.parse(story.domainSlugsJson ?? '[]');
+    if (Array.isArray(ds)) tags.push(...ds.filter((s) => typeof s === 'string'));
+  } catch { /* no-op */ }
+  if (story.techSubDomainPrimary) tags.push(story.techSubDomainPrimary);
+  try {
+    const qt = JSON.parse(story.qualityTagsJson ?? '[]');
+    if (Array.isArray(qt)) tags.push(...qt.filter((s) => typeof s === 'string'));
+  } catch { /* no-op */ }
+  // De-dup + cap
+  const uniqueTags = Array.from(new Set(tags)).slice(0, 20);
+
+  const candidate = {
+    id: `freg_${nanoid(10)}`,
+    project: projectSlug as FeatureRegistryRow['project'],
+    name: story.title.slice(0, 200),
+    description,
+    routePath: undefined,
+    filePaths: [],
+    componentName: undefined,
+    apiEndpoint: undefined,
+    dbTables: [],
+    agentName: undefined,
+    shippedAt,
+    storyId: story.id,
+    tags: uniqueTags,
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: 768,
+    embeddingVersion: 'v1.5',
+    source: 'story_completed' as const,
+    createdAt: now,
+    updatedAt: now,
+    dedupKey: computeDedupKey({
+      project: projectSlug,
+      name: story.title,
+      // No locator known from the story alone; fall back to the
+      // sorted-file-paths bucket which becomes the empty string for
+      // story-only rows. dedup_key is still unique because it includes
+      // project + title.
+    }),
+  };
+  // Return null if Zod refuses to parse (shouldn't happen given the
+  // defensive defaults above, but keeps the contract honest).
+  const parsed = FeatureRegistryRowSchema.safeParse(candidate);
+  if (!parsed.success) {
+    logger.warn(
+      { storyId: story.id, errors: parsed.error.errors },
+      'synthesized row failed Zod validation; skipping',
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+/**
+ * The actual subscriber callback. Exported so tests can drive it
+ * directly without going through the bus.
+ */
+export async function handleStoryCompleted(
+  payload: { story_id?: string },
+  opts: RegisterWriterOpts = {},
+): Promise<{ status: 'ok' | 'skipped' | 'error'; featureId?: string; reason?: string }> {
+  if (opts.enabled === false) return { status: 'skipped', reason: 'disabled' };
+  const storyId = payload?.story_id;
+  if (!storyId) return { status: 'skipped', reason: 'no story_id in payload' };
+
+  let db;
+  try {
+    db = getDb();
+  } catch (err) {
+    return { status: 'error', reason: `getDb: ${(err as Error).message}` };
+  }
+
+  const story = db
+    .select()
+    .from(stories)
+    .where(eq(stories.id, storyId))
+    .get();
+  if (!story) return { status: 'skipped', reason: `story ${storyId} not found` };
+
+  const row = synthesizeRowFromStory({ story, now: Date.now() });
+  if (!row) return { status: 'skipped', reason: 'synthesis returned null' };
+
+  const embedder = getEmbedder(opts);
+  let embedResult;
+  try {
+    embedResult = await embedder.embed(row.description);
+  } catch (err) {
+    if (err instanceof EmbedderUnavailableError) {
+      logger.warn(
+        { storyId, reason: err.message },
+        'embedder unavailable; deferring to backfill',
+      );
+      return { status: 'skipped', reason: `embedder: ${err.message}` };
+    }
+    return { status: 'error', reason: `embed: ${(err as Error).message}` };
+  }
+
+  const sqlite = getSqliteRaw();
+  try {
+    upsertRegistryRow(sqlite, row, embedResult.embedding);
+  } catch (err) {
+    return { status: 'error', reason: `upsert: ${(err as Error).message}` };
+  }
+
+  eventBus.publish({
+    type: 'feature.registry.upserted',
+    actor: 'feature-registry-writer',
+    entity_type: 'feature',
+    entity_id: row.id,
+    project_slug: row.project,
+    payload: {
+      feature_id: row.id,
+      project: row.project,
+      source: row.source,
+      story_id: row.storyId,
+      dedup_key: row.dedupKey,
+      embedding_model: row.embeddingModel,
+      latency_ms: embedResult.latencyMs,
+    },
+  });
+
+  logger.info(
+    { storyId, featureId: row.id, embedderTokens: embedResult.tokens },
+    'registry row upserted',
+  );
+  return { status: 'ok', featureId: row.id };
+}
+
+/**
+ * Wire the subscriber into the event bus. Returns an unsubscribe fn.
+ *
+ * Idempotent: calling twice is safe but discouraged (returns a fresh
+ * unsubscribe each time). Tests that need to swap the embedder should
+ * unsubscribe before re-registering.
+ */
+export function registerFeatureRegistryWriter(
+  opts: RegisterWriterOpts = {},
+): () => void {
+  if (opts.enabled === false) {
+    return () => { /* no-op */ };
+  }
+  const handler = async (ev: { payload?: { story_id?: string } }) => {
+    try {
+      await handleStoryCompleted(ev.payload ?? {}, opts);
+    } catch (err) {
+      logger.warn(
+        { err: (err as Error).message },
+        'unhandled error in story.completed handler',
+      );
+    }
+  };
+  return eventBus.subscribe('story.completed', handler);
+}

--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -15,6 +15,8 @@ import { migrateFromJsonl } from '../db/migrate-from-jsonl';
 import { attachWsServer } from '../ws/index';
 import { createApp } from './app';
 import { wireEventBus, eventBus } from '../events/bus-adapter';
+// FREG-003: subscribe FeatureRegistryWriter to story.completed at boot.
+import { registerFeatureRegistryWriter } from '../agents/feature-registry-writer';
 import { subscribeToEvents as subscribePriorityEvents, scoreAll } from '../prioritization/reprioritizer';
 import { tasks, executorRuns } from '../db/schema';
 
@@ -115,6 +117,12 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
 
   // Wire continuous reprioritization before server starts handling requests
   subscribePriorityEvents(db);
+
+  // FREG-003: wire the FeatureRegistryWriter so story.completed events
+  // auto-populate the @chiefaia/feature-registry catalog. Skipped quietly
+  // if the embedder (Ollama) is unreachable — the backfill script (FREG-004)
+  // will catch up later.
+  registerFeatureRegistryWriter();
 
   // Initial batch score of all unscored/stale tasks (fire-and-forget)
   scoreAll(db, 'system').catch(() => {});

--- a/apps/orchestrator/tests/agents/feature-registry-writer.test.ts
+++ b/apps/orchestrator/tests/agents/feature-registry-writer.test.ts
@@ -1,0 +1,277 @@
+/**
+ * FREG-003 — FeatureRegistryWriter unit + integration tests.
+ *
+ * Drives:
+ *   - synthesizeRowFromStory: edge cases (empty title, missing project, malformed JSON tags)
+ *   - handleStoryCompleted: end-to-end through DB + sqlite-vec + StubEmbeddingClient
+ *   - registerFeatureRegistryWriter: lifecycle (subscribe + unsubscribe)
+ *
+ * Uses StubEmbeddingClient throughout so CI doesn't need Ollama.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { eq } from 'drizzle-orm';
+import { computeDedupKey, StubEmbeddingClient, bootstrapVectorTables } from '@chiefaia/feature-registry';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import {
+  handleStoryCompleted,
+  registerFeatureRegistryWriter,
+  synthesizeRowFromStory,
+} from '../../src/agents/feature-registry-writer';
+import { getDb, getSqliteRaw, resetDb, runMigrations } from '../../src/db/connection';
+import { stories } from '../../src/db/schema';
+
+const DIM = 768;
+
+function tempDbUrl(): string {
+  return path.join(os.tmpdir(), `freg-writer-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+}
+
+function seedStory(db: ReturnType<typeof getDb>, over: Partial<typeof stories.$inferInsert> = {}) {
+  const id = (over.id as string) ?? 'story_test_a';
+  const now = new Date().toISOString();
+  db.insert(stories).values({
+    id,
+    kind: 'story',
+    title: 'leaderboard page',
+    description: 'ranks top players by chips won today',
+    status: 'verified',
+    projectSlug: 'pokerzeno',
+    domainSlugsJson: JSON.stringify(['gameplay']),
+    techSubDomainPrimary: 'frontend',
+    qualityTagsJson: JSON.stringify(['accessibility']),
+    createdAt: now,
+    ...over,
+  }).run();
+  return id;
+}
+
+describe('synthesizeRowFromStory', () => {
+  it('produces a valid row with merged tags from domain + tech + quality axes', () => {
+    const story = {
+      id: 'story_a',
+      title: 'leaderboard page',
+      description: 'ranks top players',
+      status: 'verified',
+      projectSlug: 'pokerzeno',
+      domainSlugsJson: JSON.stringify(['gameplay', 'engagement']),
+      techSubDomainPrimary: 'frontend',
+      qualityTagsJson: JSON.stringify(['accessibility']),
+    } as typeof stories.$inferSelect;
+    const row = synthesizeRowFromStory({ story, now: 1745812800000 });
+    expect(row).not.toBeNull();
+    expect(row!.project).toBe('pokerzeno');
+    expect(row!.name).toBe('leaderboard page');
+    expect(row!.storyId).toBe('story_a');
+    expect(row!.tags).toEqual(expect.arrayContaining(['gameplay', 'engagement', 'frontend', 'accessibility']));
+    expect(row!.source).toBe('story_completed');
+    expect(row!.dedupKey).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('returns null on empty title', () => {
+    const story = {
+      id: 'story_b',
+      title: '',
+      description: '...',
+      status: 'verified',
+      projectSlug: 'pokerzeno',
+      domainSlugsJson: '[]',
+      qualityTagsJson: '[]',
+    } as typeof stories.$inferSelect;
+    expect(synthesizeRowFromStory({ story, now: 1 })).toBeNull();
+  });
+
+  it('falls back project to "unassigned" when null', () => {
+    const story = {
+      id: 'story_c',
+      title: 'tiny',
+      description: 'thing',
+      status: 'verified',
+      projectSlug: null,
+      domainSlugsJson: '[]',
+      qualityTagsJson: '[]',
+    } as typeof stories.$inferSelect;
+    const row = synthesizeRowFromStory({ story, now: 1 });
+    expect(row).not.toBeNull();
+    expect(row!.project).toBe('unassigned');
+  });
+
+  it('survives malformed JSON in tag fields', () => {
+    const story = {
+      id: 'story_d',
+      title: 'tiny',
+      description: 'thing',
+      status: 'verified',
+      projectSlug: 'pokerzeno',
+      domainSlugsJson: 'NOT JSON',
+      qualityTagsJson: 'ALSO NOT JSON',
+    } as typeof stories.$inferSelect;
+    const row = synthesizeRowFromStory({ story, now: 1 });
+    expect(row).not.toBeNull();
+    expect(row!.tags).toEqual([]); // malformed yields no tags
+  });
+});
+
+describe('handleStoryCompleted', () => {
+  let url: string;
+
+  beforeEach(() => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* best-effort */ }
+    resetDb();
+  });
+
+  it('upserts a registry row + embedding for an existing story', async () => {
+    const db = getDb();
+    const sid = seedStory(db);
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    const result = await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+    expect(result.status).toBe('ok');
+    expect(result.featureId).toMatch(/^freg_/);
+
+    const sqlite = getSqliteRaw();
+    const reg = sqlite.prepare(
+      'SELECT id, name, project, story_id, source FROM feature_registry WHERE story_id = ?',
+    ).get(sid) as { id: string; name: string; project: string; story_id: string; source: string };
+    expect(reg.story_id).toBe(sid);
+    expect(reg.project).toBe('pokerzeno');
+    expect(reg.source).toBe('story_completed');
+    expect(reg.id).toBe(result.featureId);
+
+    const vecRow = sqlite.prepare('SELECT id FROM feature_registry_vec WHERE id = ?').get(reg.id);
+    expect(vecRow).toBeDefined();
+  });
+
+  it('is idempotent — re-handling the same story does not create a duplicate', async () => {
+    const db = getDb();
+    const sid = seedStory(db);
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    const sqlite = getSqliteRaw();
+    const count = sqlite.prepare('SELECT COUNT(*) as c FROM feature_registry').get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+
+  it('skips when no story_id in payload', async () => {
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const result = await handleStoryCompleted({}, { embedder: stub });
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/no story_id/);
+  });
+
+  it('skips when story is missing in DB', async () => {
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const result = await handleStoryCompleted(
+      { story_id: 'story_does_not_exist' },
+      { embedder: stub },
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/not found/);
+  });
+
+  it('emits feature.registry.upserted event on success', async () => {
+    const db = getDb();
+    const sid = seedStory(db);
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    const events: Array<{ type: string; payload: { feature_id?: string; story_id?: string } }> = [];
+    const unsub = eventBus.subscribe('feature.registry.upserted', (ev: any) => {
+      events.push({ type: ev.type, payload: ev.payload });
+    });
+
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload.story_id).toBe(sid);
+    expect(events[0]!.payload.feature_id).toMatch(/^freg_/);
+    unsub();
+  });
+
+  it('updates an existing row when called twice with new data (upsert path)', async () => {
+    const db = getDb();
+    const sid = seedStory(db, { description: 'first iteration of leaderboard' });
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    // Mutate the story's description, then re-fire.
+    db.update(stories)
+      .set({ description: 'second iteration: now with avatars' })
+      .where(eq(stories.id, sid))
+      .run();
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    const sqlite = getSqliteRaw();
+    const rows = sqlite
+      .prepare('SELECT description FROM feature_registry')
+      .all() as Array<{ description: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.description).toMatch(/avatars/);
+  });
+});
+
+describe('registerFeatureRegistryWriter', () => {
+  let url: string;
+  beforeEach(() => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* best-effort */ }
+    resetDb();
+  });
+
+  it('subscribing → publishing story.completed → registry row is written', async () => {
+    const db = getDb();
+    const sid = seedStory(db, { id: 'story_via_event' });
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    const unsub = registerFeatureRegistryWriter({ embedder: stub });
+
+    eventBus.publish({
+      type: 'story.completed',
+      actor: 'api',
+      entity_type: 'story',
+      entity_id: sid,
+      payload: {
+        story_id: sid,
+        project_slug: 'pokerzeno',
+        status: 'verified',
+        completed_at: Date.now(),
+      },
+    });
+
+    // Subscriber fires async; give it a tick.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const sqlite = getSqliteRaw();
+    const row = sqlite
+      .prepare('SELECT id, story_id FROM feature_registry WHERE story_id = ?')
+      .get(sid) as { id: string; story_id: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.story_id).toBe(sid);
+    unsub();
+  });
+
+  it('opts.enabled=false short-circuits subscription', () => {
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const unsub = registerFeatureRegistryWriter({ embedder: stub, enabled: false });
+    expect(typeof unsub).toBe('function');
+    // Should not throw when called.
+    unsub();
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -28,7 +28,8 @@ export type EventActor =
   | 'task-scheduler'
   | 'testing-agent'
   | 'release-agent'
-  | 'story-validator';
+  | 'story-validator'
+  | 'feature-registry-writer';
 
 /** Canonical envelope for every event emitted through the bus */
 export interface ConductorEvent {
@@ -70,6 +71,41 @@ export interface StoryCreatedPayload { story_id: string; title: string; kind: st
 export interface StoryUpdatedPayload { story_id: string; fields_changed: string[] }
 export interface StoryStatusChangedPayload { story_id: string; from_status: string; to_status: string }
 export interface StoryDeletedPayload { story_id: string }
+
+// FREG-003 — story completion + feature_registry events
+export interface StoryCompletedPayload {
+  story_id: string;
+  project_slug?: string;
+  /** Terminal status — 'verified' | 'done' | 'partial'. */
+  status: string;
+  /** epoch ms */
+  completed_at: number;
+}
+
+export interface FeatureRegistryUpsertedPayload {
+  feature_id: string;
+  project: string;
+  /** 'story_completed' | 'backfill_codebase' | 'backfill_stories' | 'manual' */
+  source: string;
+  story_id?: string;
+  dedup_key: string;
+  embedding_model: string;
+  latency_ms: number;
+}
+
+export interface FeatureClassificationUncertainPayload {
+  story_id: string;
+  top_match_id: string;
+  top_score: number;
+  threshold_used: number;
+  project?: string;
+}
+
+export interface FeatureClassificationSkippedPayload {
+  story_id: string;
+  /** 'embedder_unavailable' | 'registry_empty' | 'registry_disabled' */
+  reason: string;
+}
 
 // ─── Task ────────────────────────────────────────────────────────────────────
 
@@ -331,6 +367,11 @@ export type EventType =
   | 'pipeline.started' | 'pipeline.completed' | 'pipeline.failed'
   | 'pipeline.decompose_started' | 'pipeline.decompose_completed'
   | 'story.created' | 'story.updated' | 'story.status_changed' | 'story.deleted'
+  // ─── FREG-003 — story completion + feature_registry events ─────────────
+  | 'story.completed'
+  | 'feature.registry.upserted'
+  | 'feature.classification.uncertain'
+  | 'feature.classification.skipped'
   | 'task.created' | 'task.queued' | 'task.started' | 'task.completed'
   | 'task.failed' | 'task.paused' | 'task.resumed' | 'task.status_changed'
   | 'executor.started' | 'executor.stopped' | 'executor.config_changed'
@@ -414,6 +455,11 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'pipeline.started': 'info', 'pipeline.completed': 'info', 'pipeline.failed': 'error',
   'pipeline.decompose_started': 'info', 'pipeline.decompose_completed': 'info',
   'story.created': 'info', 'story.updated': 'info', 'story.status_changed': 'info', 'story.deleted': 'warning',
+  // ─── FREG-003 — story completion + feature_registry events ─────────────
+  'story.completed': 'info',
+  'feature.registry.upserted': 'info',
+  'feature.classification.uncertain': 'warning',
+  'feature.classification.skipped': 'warning',
   'task.created': 'info', 'task.queued': 'info', 'task.started': 'info', 'task.completed': 'info',
   'task.failed': 'error', 'task.paused': 'warning', 'task.resumed': 'info', 'task.status_changed': 'info',
   'executor.started': 'info', 'executor.stopped': 'info', 'executor.config_changed': 'info',

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -52,6 +52,38 @@ events:
     actor: [user, api]
     payload: [story_id]
 
+  # FREG-003 — story completion → feature_registry write hook.
+  # Fired when a story reaches its terminal verified/done state. The
+  # FeatureRegistryWriter subscriber catches this, synthesizes a registry
+  # row, embeds the description via Ollama, and upserts. Until Phase 2
+  # actually ships stories, the only emitter is the API endpoint that
+  # PATCHes a story's status to verified.
+  - type: story.completed
+    severity: info
+    actor: [executor, api, worker]
+    payload: [story_id, project_slug, status, completed_at]
+
+  # FREG-003 — observability for registry writes (story.completed → upsert).
+  - type: feature.registry.upserted
+    severity: info
+    actor: [feature-registry-writer]
+    payload: [feature_id, project, source, story_id, dedup_key, embedding_model, latency_ms]
+
+  # FREG-006 — observability for the PO Agent's lifecycle classification
+  # when the top match falls in the 0.78-0.85 grey zone (PO sets enhance
+  # but flags for human/BA review).
+  - type: feature.classification.uncertain
+    severity: warning
+    actor: [po-agent]
+    payload: [story_id, top_match_id, top_score, threshold_used, project]
+
+  # FREG-006 — observability for the PO Agent's lifecycle classification
+  # when the registry/embedder is unavailable (PO defaults to lifecycle='new').
+  - type: feature.classification.skipped
+    severity: warning
+    actor: [po-agent]
+    payload: [story_id, reason]
+
   # Task events
   - type: task.created
     severity: info


### PR DESCRIPTION
## Summary

Phase A continues — FREG-001 + FREG-002 shipped the schema + storage; this PR wires the auto-write hook so completed stories land in the registry.

## What ships

**`@chiefaia/events-taxonomy-internal`** picks up four new events + a new actor:
- `story.completed` — fired when a story reaches verified/done
- `feature.registry.upserted` — observability for FREG writes
- `feature.classification.uncertain` — PO grey-zone match (warning)
- `feature.classification.skipped` — registry/embedder unavailable (warning)
- New `EventActor` literal `'feature-registry-writer'`

All four registered in `registry.yaml` + `EventType` union + `EVENT_SEVERITY` map + typed payload interfaces.

**`apps/orchestrator/src/agents/feature-registry-writer.ts`** — new agent:
- `synthesizeRowFromStory(story, now)` — pure mapping from a `stories` row to a `FeatureRegistryRow`. Tags merged from `domain_slugs` + `tech_sub_domain_primary` + `quality_tags`. Defensive against malformed JSON; project falls back to `'unassigned'`.
- `handleStoryCompleted(payload, opts)` — exported entry point so tests can drive without going through the bus. Catches `EmbedderUnavailableError` → returns `skipped` (backfill catches up later). Emits `feature.registry.upserted` on success.
- `registerFeatureRegistryWriter(opts)` — bus subscription returning an unsubscribe fn. Honors `opts.enabled=false` for degraded boot.

**`apps/orchestrator/src/api/start.ts`** wires `registerFeatureRegistryWriter()` next to `subscribePriorityEvents(db)` so the subscriber is live as soon as the API server is.

## Tests (DoD)

- 9 jest cases in `tests/agents/feature-registry-writer.test.ts`:
  - `synthesizeRowFromStory`: tag merge across 3 axes, empty-title null, project fallback to `'unassigned'`, malformed-JSON resilience
  - `handleStoryCompleted`: end-to-end upsert + vec0 + fts5 round-trip, idempotency on re-fire, missing `story_id` skip, missing-story skip, `feature.registry.upserted` event emission, upsert-update path on re-fire with mutated description
  - `registerFeatureRegistryWriter`: live event-bus subscription writes the row; `opts.enabled=false` short-circuits

All 20 jest cases across the FREG-001/002/003 suite green.

## Coordination

- **Phase 2** will emit `story.completed` when a worker ships a story; until then, the only emitter will be the API endpoint that PATCHes a story to `verified` status (existing endpoint emits `story.status_changed`; we'll wire `story.completed` alongside in FREG-006). FREG-004 backfill covers the historical gap.
- **LAI track:** swap `OllamaEmbeddingClient` via `registerFeatureRegistryWriter({ embedder: laiEmbedder })` when LAI ships its embedder service.
- `feature.classification.*` events are declared here; FREG-006 will emit them from `po-agent.ts`.

## Risk

Low. Pure additive — new agent file, no existing hot paths altered. Subscriber is wrapped in try/catch and gracefully degrades on embedder/DB errors so worst case is a missing registry row, not a crashed orchestrator.