### PR TITLE
feat(orchestrator): backfill script for feature registry (FREG-004)

### DIFF
--- a/apps/orchestrator/scripts/backfill-feature-registry.ts
+++ b/apps/orchestrator/scripts/backfill-feature-registry.ts
@@ -1,0 +1,476 @@
+/**
+ * FREG-004 — Feature Registry backfill script.
+ *
+ * Idempotent + re-runnable. Two modes:
+ *
+ *   1. backfillFromStories(db, embedder, opts)
+ *      Walks the `stories` table for `status IN ('verified','partial')` and
+ *      synthesizes a registry row for each via the same synthesizeRowFromStory
+ *      helper FREG-003 uses for live story.completed events. Token cost: zero
+ *      Claude tokens; ~50-300 local Ollama tokens per story.
+ *
+ *   2. backfillFromCodebase(db, embedder, root, opts)
+ *      Walks the CAIA monorepo for inferable features:
+ *        - apps/<app>/.../app/**\/page.tsx                → route_path features
+ *        - apps/orchestrator/src/agents/*.ts              → agent_name features
+ *        - apps/orchestrator/src/db/migrations/*.sql      → db_table features
+ *      Each becomes a thin registry row that can later be enriched by hand
+ *      (or by a re-run after a manual edit).
+ *
+ * Both modes use computeDedupKey for idempotency — re-running upserts the
+ * embedding + tags + updatedAt without inserting duplicate rows. Safe to
+ * cron on a schedule once we want continuous discovery.
+ *
+ * Usage:
+ *   pnpm tsx apps/orchestrator/scripts/backfill-feature-registry.ts \
+ *     [--from=stories|codebase|both] \
+ *     [--root=/path/to/caia] \
+ *     [--db-url=/path/to/db.sqlite] \
+ *     [--dry-run]
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { eq, inArray } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import {
+  bootstrapVectorTables,
+  computeDedupKey,
+  EmbedderUnavailableError,
+  FeatureRegistryRowSchema,
+  OllamaEmbeddingClient,
+  upsertRegistryRow,
+  type EmbeddingClient,
+  type FeatureRegistryRow,
+} from '@chiefaia/feature-registry';
+import { getDb, getSqliteRaw, runMigrations } from '../src/db/connection';
+import { stories } from '../src/db/schema';
+import {
+  synthesizeRowFromStory,
+} from '../src/agents/feature-registry-writer';
+
+const logger = {
+  info: (msg: string, ctx: Record<string, unknown> = {}) =>
+    console.log(`[backfill] ${msg}`, ctx),
+  warn: (msg: string, ctx: Record<string, unknown> = {}) =>
+    console.warn(`[backfill] ${msg}`, ctx),
+  error: (msg: string, ctx: Record<string, unknown> = {}) =>
+    console.error(`[backfill] ${msg}`, ctx),
+};
+
+export interface BackfillOpts {
+  /** If true, log the synthesized rows but skip writes. */
+  dryRun?: boolean;
+  /** Limit the number of rows processed (for smoke runs). */
+  limit?: number;
+  /** Only process this project. */
+  project?: string;
+}
+
+export interface BackfillReport {
+  processed: number;
+  upserted: number;
+  skipped: number;
+  errors: number;
+  embedderTokens: number;
+  durationMs: number;
+}
+
+// ─── Mode 1: stories table ──────────────────────────────────────────────────
+
+export async function backfillFromStories(
+  db: ReturnType<typeof getDb>,
+  embedder: EmbeddingClient,
+  opts: BackfillOpts = {},
+): Promise<BackfillReport> {
+  const t0 = Date.now();
+  const report: BackfillReport = {
+    processed: 0,
+    upserted: 0,
+    skipped: 0,
+    errors: 0,
+    embedderTokens: 0,
+    durationMs: 0,
+  };
+
+  const all = db
+    .select()
+    .from(stories)
+    .where(inArray(stories.status, ['verified', 'partial']))
+    .all();
+  const filtered = opts.project
+    ? all.filter((s) => s.projectSlug === opts.project)
+    : all;
+  const limited = opts.limit ? filtered.slice(0, opts.limit) : filtered;
+
+  logger.info(`backfilling ${limited.length} stories (verified|partial)`);
+
+  const sqlite = getSqliteRaw();
+
+  for (const story of limited) {
+    report.processed++;
+    const row = synthesizeRowFromStory({ story, now: Date.now() });
+    if (!row) {
+      report.skipped++;
+      continue;
+    }
+
+    if (opts.dryRun) {
+      logger.info(`dry-run`, { storyId: story.id, name: row.name });
+      report.upserted++;
+      continue;
+    }
+
+    try {
+      // Use the same source tag the script's name implies, not 'story_completed' — distinguishes
+      // backfill rows from live-event-driven ones in the source histogram.
+      const backfilledRow: FeatureRegistryRow = { ...row, source: 'backfill_stories' };
+      const { embedding, tokens } = await embedder.embed(backfilledRow.description);
+      report.embedderTokens += tokens;
+      upsertRegistryRow(sqlite, backfilledRow, embedding);
+      report.upserted++;
+    } catch (err) {
+      if (err instanceof EmbedderUnavailableError) {
+        logger.warn('embedder unavailable; aborting backfill', { reason: err.message });
+        report.errors++;
+        break;
+      }
+      report.errors++;
+      logger.warn('row failed', { storyId: story.id, err: (err as Error).message });
+    }
+  }
+
+  report.durationMs = Date.now() - t0;
+  logger.info('backfillFromStories complete', report as unknown as Record<string, unknown>);
+  return report;
+}
+
+// ─── Mode 2: codebase walk ──────────────────────────────────────────────────
+
+interface CodebaseFeature {
+  project: string;
+  name: string;
+  description: string;
+  routePath?: string;
+  filePaths: string[];
+  componentName?: string;
+  agentName?: string;
+  apiEndpoint?: string;
+  dbTables: string[];
+  tags: string[];
+}
+
+/** Scan apps/<app>/(app|pages)/** /page.tsx for Next.js route features. */
+function discoverNextRoutes(root: string): CodebaseFeature[] {
+  const out: CodebaseFeature[] = [];
+  const appsDir = path.join(root, 'apps');
+  if (!fs.existsSync(appsDir)) return out;
+
+  for (const appName of fs.readdirSync(appsDir)) {
+    const appRoot = path.join(appsDir, appName);
+    if (!fs.statSync(appRoot).isDirectory()) continue;
+    // Walk app/ and pages/ subtrees
+    for (const sub of ['app', 'pages']) {
+      const subRoot = path.join(appRoot, sub);
+      if (!fs.existsSync(subRoot)) continue;
+      walkDir(subRoot, (filePath) => {
+        if (!filePath.endsWith('page.tsx') && !filePath.endsWith('page.ts')) return;
+        const rel = path.relative(root, filePath);
+        // Derive route_path from the dirname after 'app/' or 'pages/'.
+        const routeParts = path
+          .relative(subRoot, path.dirname(filePath))
+          .split(path.sep)
+          .filter(Boolean);
+        const routePath = '/' + routeParts.join('/');
+        const lastSeg = routeParts[routeParts.length - 1] ?? appName;
+        out.push({
+          project: appName,
+          name: `${lastSeg} page`,
+          description: `Next.js page at ${routePath} in ${appName}`,
+          routePath,
+          filePaths: [rel],
+          componentName: undefined,
+          dbTables: [],
+          tags: ['frontend', 'route'],
+        });
+      });
+    }
+  }
+  return out;
+}
+
+/** Scan apps/orchestrator/src/agents/*.ts for agent definitions. */
+function discoverAgents(root: string): CodebaseFeature[] {
+  const out: CodebaseFeature[] = [];
+  const dir = path.join(root, 'apps', 'orchestrator', 'src', 'agents');
+  if (!fs.existsSync(dir)) return out;
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.ts') || f.endsWith('.test.ts')) continue;
+    const rel = path.relative(root, path.join(dir, f));
+    const agentName = f.replace(/\.ts$/, '');
+    out.push({
+      project: 'caia',
+      name: `${agentName} agent`,
+      description: `Orchestrator agent ${agentName} (${rel})`,
+      filePaths: [rel],
+      agentName,
+      dbTables: [],
+      tags: ['backend', 'agent-runtime'],
+    });
+  }
+  return out;
+}
+
+/** Scan apps/orchestrator/src/db/migrations/*.sql for db-table features. */
+function discoverDbTables(root: string): CodebaseFeature[] {
+  const out: CodebaseFeature[] = [];
+  const dir = path.join(root, 'apps', 'orchestrator', 'src', 'db', 'migrations');
+  if (!fs.existsSync(dir)) return out;
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.sql')) continue;
+    const rel = path.relative(root, path.join(dir, f));
+    const sql = fs.readFileSync(path.join(dir, f), 'utf-8');
+    const tableMatches = Array.from(
+      sql.matchAll(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?/gi),
+    );
+    for (const m of tableMatches) {
+      const tableName = m[1]!;
+      out.push({
+        project: 'caia',
+        name: `${tableName} table`,
+        description: `SQLite table ${tableName} created by migration ${f}`,
+        filePaths: [rel],
+        dbTables: [tableName],
+        tags: ['database', 'schema'],
+      });
+    }
+  }
+  return out;
+}
+
+function walkDir(root: string, cb: (filePath: string) => void): void {
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      // Skip noise
+      if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'dist' || entry.name === '.git') continue;
+      walkDir(full, cb);
+    } else if (entry.isFile()) {
+      cb(full);
+    }
+  }
+}
+
+/**
+ * The PROJECT_SLUGS enum defines a short list. Codebase-discovered project
+ * names may not match (e.g., we might find an app under `apps/dashboard/`
+ * which isn't a registered slug). Map known apps to slugs; default to
+ * 'caia' for orchestrator-internal stuff and 'unassigned' for everything
+ * else. Adjust as the slug list grows.
+ */
+function normalizeProject(raw: string): string {
+  const map: Record<string, string> = {
+    orchestrator: 'caia',
+    dashboard: 'caia',
+    executor: 'caia',
+    'completeness-sentinel': 'caia',
+    'pipeline-pulse': 'caia',
+    'task-run-poller': 'caia',
+    'story-backfiller': 'caia',
+    'db-backup': 'caia',
+    'orchestrator-middleware': 'caia',
+    pokerzeno: 'pokerzeno',
+    roulettecommunity: 'roulettecommunity',
+    edisoncricket: 'edisoncricket',
+    ankitatiwari: 'ankitatiwari',
+    'prakash-tiwari': 'prakash-tiwari',
+    chiefaia: 'chiefaia.com',
+  };
+  return map[raw] ?? 'unassigned';
+}
+
+export async function backfillFromCodebase(
+  db: ReturnType<typeof getDb>,
+  embedder: EmbeddingClient,
+  root: string,
+  opts: BackfillOpts = {},
+): Promise<BackfillReport> {
+  const t0 = Date.now();
+  const report: BackfillReport = {
+    processed: 0,
+    upserted: 0,
+    skipped: 0,
+    errors: 0,
+    embedderTokens: 0,
+    durationMs: 0,
+  };
+
+  if (!fs.existsSync(root)) {
+    logger.warn('root does not exist; nothing to backfill', { root });
+    return report;
+  }
+
+  const features: CodebaseFeature[] = [
+    ...discoverNextRoutes(root),
+    ...discoverAgents(root),
+    ...discoverDbTables(root),
+  ];
+  const filtered = opts.project
+    ? features.filter((f) => normalizeProject(f.project) === opts.project)
+    : features;
+  const limited = opts.limit ? filtered.slice(0, opts.limit) : filtered;
+
+  logger.info(`backfilling ${limited.length} codebase features`, {
+    routes: features.filter((f) => f.tags.includes('route')).length,
+    agents: features.filter((f) => f.agentName).length,
+    db: features.filter((f) => f.tags.includes('database')).length,
+  });
+
+  const sqlite = getSqliteRaw();
+
+  for (const feat of limited) {
+    report.processed++;
+    const project = normalizeProject(feat.project);
+    const now = Date.now();
+    const candidate = {
+      id: `freg_${nanoid(10)}`,
+      project: project as FeatureRegistryRow['project'],
+      name: feat.name.slice(0, 200),
+      description: feat.description.slice(0, 2000),
+      routePath: feat.routePath,
+      filePaths: feat.filePaths,
+      componentName: feat.componentName,
+      apiEndpoint: feat.apiEndpoint,
+      dbTables: feat.dbTables,
+      agentName: feat.agentName,
+      shippedAt: now,
+      storyId: undefined,
+      tags: feat.tags.slice(0, 20),
+      embeddingModel: 'nomic-embed-text',
+      embeddingDim: 768,
+      embeddingVersion: 'v1.5',
+      source: 'backfill_codebase' as const,
+      createdAt: now,
+      updatedAt: now,
+      dedupKey: computeDedupKey({
+        project,
+        name: feat.name,
+        routePath: feat.routePath,
+        componentName: feat.componentName,
+        agentName: feat.agentName,
+        filePaths: feat.filePaths,
+      }),
+    };
+    const parsed = FeatureRegistryRowSchema.safeParse(candidate);
+    if (!parsed.success) {
+      report.skipped++;
+      logger.warn('row failed Zod validation', { feat: feat.name, errors: parsed.error.errors });
+      continue;
+    }
+
+    if (opts.dryRun) {
+      logger.info('dry-run', { project, name: feat.name, dedupKey: parsed.data.dedupKey.slice(0, 12) });
+      report.upserted++;
+      continue;
+    }
+
+    try {
+      const { embedding, tokens } = await embedder.embed(parsed.data.description);
+      report.embedderTokens += tokens;
+      upsertRegistryRow(sqlite, parsed.data, embedding);
+      report.upserted++;
+    } catch (err) {
+      if (err instanceof EmbedderUnavailableError) {
+        logger.warn('embedder unavailable; aborting codebase backfill', { reason: err.message });
+        report.errors++;
+        break;
+      }
+      report.errors++;
+      logger.warn('row failed', { feat: feat.name, err: (err as Error).message });
+    }
+  }
+
+  report.durationMs = Date.now() - t0;
+  logger.info('backfillFromCodebase complete', report as unknown as Record<string, unknown>);
+  return report;
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+
+interface CliArgs {
+  from: 'stories' | 'codebase' | 'both';
+  root?: string;
+  dbUrl?: string;
+  dryRun: boolean;
+  project?: string;
+  limit?: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { from: 'both', dryRun: false };
+  for (const a of argv) {
+    if (a === '--dry-run') args.dryRun = true;
+    else if (a.startsWith('--from=')) args.from = a.slice('--from='.length) as CliArgs['from'];
+    else if (a.startsWith('--root=')) args.root = a.slice('--root='.length);
+    else if (a.startsWith('--db-url=')) args.dbUrl = a.slice('--db-url='.length);
+    else if (a.startsWith('--project=')) args.project = a.slice('--project='.length);
+    else if (a.startsWith('--limit=')) args.limit = Number(a.slice('--limit='.length));
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const root = args.root ?? path.resolve(__dirname, '..', '..', '..');
+  logger.info('starting backfill', { ...args, root });
+
+  if (args.dbUrl) {
+    runMigrations(args.dbUrl);
+  } else {
+    runMigrations();
+  }
+  bootstrapVectorTables(getSqliteRaw());
+
+  const db = getDb();
+  const embedder = new OllamaEmbeddingClient();
+
+  const opts = { dryRun: args.dryRun, project: args.project, limit: args.limit };
+
+  let total: BackfillReport = {
+    processed: 0,
+    upserted: 0,
+    skipped: 0,
+    errors: 0,
+    embedderTokens: 0,
+    durationMs: 0,
+  };
+
+  if (args.from === 'stories' || args.from === 'both') {
+    const r = await backfillFromStories(db, embedder, opts);
+    total = mergeReport(total, r);
+  }
+  if (args.from === 'codebase' || args.from === 'both') {
+    const r = await backfillFromCodebase(db, embedder, root, opts);
+    total = mergeReport(total, r);
+  }
+
+  logger.info('TOTAL', total as unknown as Record<string, unknown>);
+}
+
+function mergeReport(a: BackfillReport, b: BackfillReport): BackfillReport {
+  return {
+    processed: a.processed + b.processed,
+    upserted: a.upserted + b.upserted,
+    skipped: a.skipped + b.skipped,
+    errors: a.errors + b.errors,
+    embedderTokens: a.embedderTokens + b.embedderTokens,
+    durationMs: a.durationMs + b.durationMs,
+  };
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    logger.error('backfill failed', { err: (err as Error).message });
+    process.exit(1);
+  });
+}

--- a/apps/orchestrator/src/agents/feature-registry-writer.ts
+++ b/apps/orchestrator/src/agents/feature-registry-writer.ts
@@ -1,0 +1,244 @@
+/**
+ * FeatureRegistryWriter — FREG-003
+ *
+ * Subscribes to `story.completed` and idempotently upserts a
+ * `feature_registry` row + its embedding via `@chiefaia/feature-registry`.
+ *
+ * Hot-path budget: <300ms (mostly Ollama embed). Failure modes:
+ *   - Ollama unreachable → log warn, continue. Backfill picks up later.
+ *   - sqlite-vec not bootstrapped → log warn, continue.
+ *   - Story missing required fields → log warn, skip.
+ *
+ * Wired in install.ts at orchestrator startup.
+ */
+
+import { nanoid } from 'nanoid';
+import { eq } from 'drizzle-orm';
+import {
+  computeDedupKey,
+  EmbedderUnavailableError,
+  FeatureRegistryRowSchema,
+  OllamaEmbeddingClient,
+  upsertRegistryRow,
+  type EmbeddingClient,
+  type FeatureRegistryRow,
+} from '@chiefaia/feature-registry';
+import { eventBus } from '../events/bus-adapter';
+import { getDb, getSqliteRaw } from '../db/connection';
+import { stories } from '../db/schema';
+
+// Logger shim — replaced at runtime by the real pino logger if available.
+const logger = {
+  warn: (obj: Record<string, unknown>, msg: string) => {
+    console.warn('[feature-registry-writer]', msg, obj);
+  },
+  info: (obj: Record<string, unknown>, msg: string) => {
+    console.log('[feature-registry-writer]', msg, obj);
+  },
+};
+
+export interface RegisterWriterOpts {
+  /**
+   * Override the embedding client. Default: shared OllamaEmbeddingClient.
+   * Tests pass StubEmbeddingClient; LAI track will pass its embedder once
+   * the shared package ships.
+   */
+  embedder?: EmbeddingClient;
+  /**
+   * Disables the writer entirely. Useful in tests or when the orchestrator
+   * is started in a degraded mode.
+   */
+  enabled?: boolean;
+}
+
+let _embedder: EmbeddingClient | null = null;
+function getEmbedder(opts: RegisterWriterOpts): EmbeddingClient {
+  if (opts.embedder) return opts.embedder;
+  if (!_embedder) _embedder = new OllamaEmbeddingClient();
+  return _embedder;
+}
+
+/**
+ * Synthesize a FeatureRegistryRow from a story row.
+ *
+ * The mapping is intentionally conservative — for fields we can't
+ * confidently derive (file_paths, route_path, component_name) we leave
+ * them null. The backfill script (FREG-004) and the dashboard (FREG-007)
+ * surface "thin" rows so they can be enriched.
+ */
+export function synthesizeRowFromStory(input: {
+  story: typeof stories.$inferSelect;
+  now: number;
+}): FeatureRegistryRow | null {
+  const { story, now } = input;
+  if (!story.title || story.title.length === 0) return null;
+
+  // Map story.status → feature.shippedAt. Stories are
+  // 'pending'|'verified'|'failed'|'partial'. Only 'verified' is "done".
+  const shippedAt =
+    story.status === 'verified' || story.status === 'partial'
+      ? now
+      : now;
+
+  const projectSlug = story.projectSlug ?? 'unassigned';
+  const description = story.description && story.description.length > 0
+    ? story.description.slice(0, 2000)
+    : story.title;
+
+  // Best-effort tag union: domain_slugs + tech_sub_domain_primary +
+  // quality_tags. Defensive parsing — any malformed JSON yields [].
+  const tags: string[] = [];
+  try {
+    const ds = JSON.parse(story.domainSlugsJson ?? '[]');
+    if (Array.isArray(ds)) tags.push(...ds.filter((s) => typeof s === 'string'));
+  } catch { /* no-op */ }
+  if (story.techSubDomainPrimary) tags.push(story.techSubDomainPrimary);
+  try {
+    const qt = JSON.parse(story.qualityTagsJson ?? '[]');
+    if (Array.isArray(qt)) tags.push(...qt.filter((s) => typeof s === 'string'));
+  } catch { /* no-op */ }
+  // De-dup + cap
+  const uniqueTags = Array.from(new Set(tags)).slice(0, 20);
+
+  const candidate = {
+    id: `freg_${nanoid(10)}`,
+    project: projectSlug as FeatureRegistryRow['project'],
+    name: story.title.slice(0, 200),
+    description,
+    routePath: undefined,
+    filePaths: [],
+    componentName: undefined,
+    apiEndpoint: undefined,
+    dbTables: [],
+    agentName: undefined,
+    shippedAt,
+    storyId: story.id,
+    tags: uniqueTags,
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: 768,
+    embeddingVersion: 'v1.5',
+    source: 'story_completed' as const,
+    createdAt: now,
+    updatedAt: now,
+    dedupKey: computeDedupKey({
+      project: projectSlug,
+      name: story.title,
+      // No locator known from the story alone; fall back to the
+      // sorted-file-paths bucket which becomes the empty string for
+      // story-only rows. dedup_key is still unique because it includes
+      // project + title.
+    }),
+  };
+  // Return null if Zod refuses to parse (shouldn't happen given the
+  // defensive defaults above, but keeps the contract honest).
+  const parsed = FeatureRegistryRowSchema.safeParse(candidate);
+  if (!parsed.success) {
+    logger.warn(
+      { storyId: story.id, errors: parsed.error.errors },
+      'synthesized row failed Zod validation; skipping',
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+/**
+ * The actual subscriber callback. Exported so tests can drive it
+ * directly without going through the bus.
+ */
+export async function handleStoryCompleted(
+  payload: { story_id?: string },
+  opts: RegisterWriterOpts = {},
+): Promise<{ status: 'ok' | 'skipped' | 'error'; featureId?: string; reason?: string }> {
+  if (opts.enabled === false) return { status: 'skipped', reason: 'disabled' };
+  const storyId = payload?.story_id;
+  if (!storyId) return { status: 'skipped', reason: 'no story_id in payload' };
+
+  let db;
+  try {
+    db = getDb();
+  } catch (err) {
+    return { status: 'error', reason: `getDb: ${(err as Error).message}` };
+  }
+
+  const story = db
+    .select()
+    .from(stories)
+    .where(eq(stories.id, storyId))
+    .get();
+  if (!story) return { status: 'skipped', reason: `story ${storyId} not found` };
+
+  const row = synthesizeRowFromStory({ story, now: Date.now() });
+  if (!row) return { status: 'skipped', reason: 'synthesis returned null' };
+
+  const embedder = getEmbedder(opts);
+  let embedResult;
+  try {
+    embedResult = await embedder.embed(row.description);
+  } catch (err) {
+    if (err instanceof EmbedderUnavailableError) {
+      logger.warn(
+        { storyId, reason: err.message },
+        'embedder unavailable; deferring to backfill',
+      );
+      return { status: 'skipped', reason: `embedder: ${err.message}` };
+    }
+    return { status: 'error', reason: `embed: ${(err as Error).message}` };
+  }
+
+  const sqlite = getSqliteRaw();
+  try {
+    upsertRegistryRow(sqlite, row, embedResult.embedding);
+  } catch (err) {
+    return { status: 'error', reason: `upsert: ${(err as Error).message}` };
+  }
+
+  eventBus.publish({
+    type: 'feature.registry.upserted',
+    actor: 'feature-registry-writer',
+    entity_type: 'feature',
+    entity_id: row.id,
+    project_slug: row.project,
+    payload: {
+      feature_id: row.id,
+      project: row.project,
+      source: row.source,
+      story_id: row.storyId,
+      dedup_key: row.dedupKey,
+      embedding_model: row.embeddingModel,
+      latency_ms: embedResult.latencyMs,
+    },
+  });
+
+  logger.info(
+    { storyId, featureId: row.id, embedderTokens: embedResult.tokens },
+    'registry row upserted',
+  );
+  return { status: 'ok', featureId: row.id };
+}
+
+/**
+ * Wire the subscriber into the event bus. Returns an unsubscribe fn.
+ *
+ * Idempotent: calling twice is safe but discouraged (returns a fresh
+ * unsubscribe each time). Tests that need to swap the embedder should
+ * unsubscribe before re-registering.
+ */
+export function registerFeatureRegistryWriter(
+  opts: RegisterWriterOpts = {},
+): () => void {
+  if (opts.enabled === false) {
+    return () => { /* no-op */ };
+  }
+  const handler = async (ev: { payload?: { story_id?: string } }) => {
+    try {
+      await handleStoryCompleted(ev.payload ?? {}, opts);
+    } catch (err) {
+      logger.warn(
+        { err: (err as Error).message },
+        'unhandled error in story.completed handler',
+      );
+    }
+  };
+  return eventBus.subscribe('story.completed', handler);
+}

--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -15,6 +15,8 @@ import { migrateFromJsonl } from '../db/migrate-from-jsonl';
 import { attachWsServer } from '../ws/index';
 import { createApp } from './app';
 import { wireEventBus, eventBus } from '../events/bus-adapter';
+// FREG-003: subscribe FeatureRegistryWriter to story.completed at boot.
+import { registerFeatureRegistryWriter } from '../agents/feature-registry-writer';
 import { subscribeToEvents as subscribePriorityEvents, scoreAll } from '../prioritization/reprioritizer';
 import { tasks, executorRuns } from '../db/schema';
 
@@ -115,6 +117,12 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
 
   // Wire continuous reprioritization before server starts handling requests
   subscribePriorityEvents(db);
+
+  // FREG-003: wire the FeatureRegistryWriter so story.completed events
+  // auto-populate the @chiefaia/feature-registry catalog. Skipped quietly
+  // if the embedder (Ollama) is unreachable — the backfill script (FREG-004)
+  // will catch up later.
+  registerFeatureRegistryWriter();
 
   // Initial batch score of all unscored/stale tasks (fire-and-forget)
   scoreAll(db, 'system').catch(() => {});

--- a/apps/orchestrator/tests/agents/feature-registry-writer.test.ts
+++ b/apps/orchestrator/tests/agents/feature-registry-writer.test.ts
@@ -1,0 +1,277 @@
+/**
+ * FREG-003 — FeatureRegistryWriter unit + integration tests.
+ *
+ * Drives:
+ *   - synthesizeRowFromStory: edge cases (empty title, missing project, malformed JSON tags)
+ *   - handleStoryCompleted: end-to-end through DB + sqlite-vec + StubEmbeddingClient
+ *   - registerFeatureRegistryWriter: lifecycle (subscribe + unsubscribe)
+ *
+ * Uses StubEmbeddingClient throughout so CI doesn't need Ollama.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { eq } from 'drizzle-orm';
+import { computeDedupKey, StubEmbeddingClient, bootstrapVectorTables } from '@chiefaia/feature-registry';
+import { eventBus } from '@chiefaia/event-bus-internal';
+import {
+  handleStoryCompleted,
+  registerFeatureRegistryWriter,
+  synthesizeRowFromStory,
+} from '../../src/agents/feature-registry-writer';
+import { getDb, getSqliteRaw, resetDb, runMigrations } from '../../src/db/connection';
+import { stories } from '../../src/db/schema';
+
+const DIM = 768;
+
+function tempDbUrl(): string {
+  return path.join(os.tmpdir(), `freg-writer-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+}
+
+function seedStory(db: ReturnType<typeof getDb>, over: Partial<typeof stories.$inferInsert> = {}) {
+  const id = (over.id as string) ?? 'story_test_a';
+  const now = new Date().toISOString();
+  db.insert(stories).values({
+    id,
+    kind: 'story',
+    title: 'leaderboard page',
+    description: 'ranks top players by chips won today',
+    status: 'verified',
+    projectSlug: 'pokerzeno',
+    domainSlugsJson: JSON.stringify(['gameplay']),
+    techSubDomainPrimary: 'frontend',
+    qualityTagsJson: JSON.stringify(['accessibility']),
+    createdAt: now,
+    ...over,
+  }).run();
+  return id;
+}
+
+describe('synthesizeRowFromStory', () => {
+  it('produces a valid row with merged tags from domain + tech + quality axes', () => {
+    const story = {
+      id: 'story_a',
+      title: 'leaderboard page',
+      description: 'ranks top players',
+      status: 'verified',
+      projectSlug: 'pokerzeno',
+      domainSlugsJson: JSON.stringify(['gameplay', 'engagement']),
+      techSubDomainPrimary: 'frontend',
+      qualityTagsJson: JSON.stringify(['accessibility']),
+    } as typeof stories.$inferSelect;
+    const row = synthesizeRowFromStory({ story, now: 1745812800000 });
+    expect(row).not.toBeNull();
+    expect(row!.project).toBe('pokerzeno');
+    expect(row!.name).toBe('leaderboard page');
+    expect(row!.storyId).toBe('story_a');
+    expect(row!.tags).toEqual(expect.arrayContaining(['gameplay', 'engagement', 'frontend', 'accessibility']));
+    expect(row!.source).toBe('story_completed');
+    expect(row!.dedupKey).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('returns null on empty title', () => {
+    const story = {
+      id: 'story_b',
+      title: '',
+      description: '...',
+      status: 'verified',
+      projectSlug: 'pokerzeno',
+      domainSlugsJson: '[]',
+      qualityTagsJson: '[]',
+    } as typeof stories.$inferSelect;
+    expect(synthesizeRowFromStory({ story, now: 1 })).toBeNull();
+  });
+
+  it('falls back project to "unassigned" when null', () => {
+    const story = {
+      id: 'story_c',
+      title: 'tiny',
+      description: 'thing',
+      status: 'verified',
+      projectSlug: null,
+      domainSlugsJson: '[]',
+      qualityTagsJson: '[]',
+    } as typeof stories.$inferSelect;
+    const row = synthesizeRowFromStory({ story, now: 1 });
+    expect(row).not.toBeNull();
+    expect(row!.project).toBe('unassigned');
+  });
+
+  it('survives malformed JSON in tag fields', () => {
+    const story = {
+      id: 'story_d',
+      title: 'tiny',
+      description: 'thing',
+      status: 'verified',
+      projectSlug: 'pokerzeno',
+      domainSlugsJson: 'NOT JSON',
+      qualityTagsJson: 'ALSO NOT JSON',
+    } as typeof stories.$inferSelect;
+    const row = synthesizeRowFromStory({ story, now: 1 });
+    expect(row).not.toBeNull();
+    expect(row!.tags).toEqual([]); // malformed yields no tags
+  });
+});
+
+describe('handleStoryCompleted', () => {
+  let url: string;
+
+  beforeEach(() => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* best-effort */ }
+    resetDb();
+  });
+
+  it('upserts a registry row + embedding for an existing story', async () => {
+    const db = getDb();
+    const sid = seedStory(db);
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    const result = await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+    expect(result.status).toBe('ok');
+    expect(result.featureId).toMatch(/^freg_/);
+
+    const sqlite = getSqliteRaw();
+    const reg = sqlite.prepare(
+      'SELECT id, name, project, story_id, source FROM feature_registry WHERE story_id = ?',
+    ).get(sid) as { id: string; name: string; project: string; story_id: string; source: string };
+    expect(reg.story_id).toBe(sid);
+    expect(reg.project).toBe('pokerzeno');
+    expect(reg.source).toBe('story_completed');
+    expect(reg.id).toBe(result.featureId);
+
+    const vecRow = sqlite.prepare('SELECT id FROM feature_registry_vec WHERE id = ?').get(reg.id);
+    expect(vecRow).toBeDefined();
+  });
+
+  it('is idempotent — re-handling the same story does not create a duplicate', async () => {
+    const db = getDb();
+    const sid = seedStory(db);
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    const sqlite = getSqliteRaw();
+    const count = sqlite.prepare('SELECT COUNT(*) as c FROM feature_registry').get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+
+  it('skips when no story_id in payload', async () => {
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const result = await handleStoryCompleted({}, { embedder: stub });
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/no story_id/);
+  });
+
+  it('skips when story is missing in DB', async () => {
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const result = await handleStoryCompleted(
+      { story_id: 'story_does_not_exist' },
+      { embedder: stub },
+    );
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/not found/);
+  });
+
+  it('emits feature.registry.upserted event on success', async () => {
+    const db = getDb();
+    const sid = seedStory(db);
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    const events: Array<{ type: string; payload: { feature_id?: string; story_id?: string } }> = [];
+    const unsub = eventBus.subscribe('feature.registry.upserted', (ev: any) => {
+      events.push({ type: ev.type, payload: ev.payload });
+    });
+
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload.story_id).toBe(sid);
+    expect(events[0]!.payload.feature_id).toMatch(/^freg_/);
+    unsub();
+  });
+
+  it('updates an existing row when called twice with new data (upsert path)', async () => {
+    const db = getDb();
+    const sid = seedStory(db, { description: 'first iteration of leaderboard' });
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    // Mutate the story's description, then re-fire.
+    db.update(stories)
+      .set({ description: 'second iteration: now with avatars' })
+      .where(eq(stories.id, sid))
+      .run();
+    await handleStoryCompleted({ story_id: sid }, { embedder: stub });
+
+    const sqlite = getSqliteRaw();
+    const rows = sqlite
+      .prepare('SELECT description FROM feature_registry')
+      .all() as Array<{ description: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.description).toMatch(/avatars/);
+  });
+});
+
+describe('registerFeatureRegistryWriter', () => {
+  let url: string;
+  beforeEach(() => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+  });
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* best-effort */ }
+    resetDb();
+  });
+
+  it('subscribing → publishing story.completed → registry row is written', async () => {
+    const db = getDb();
+    const sid = seedStory(db, { id: 'story_via_event' });
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+
+    const unsub = registerFeatureRegistryWriter({ embedder: stub });
+
+    eventBus.publish({
+      type: 'story.completed',
+      actor: 'api',
+      entity_type: 'story',
+      entity_id: sid,
+      payload: {
+        story_id: sid,
+        project_slug: 'pokerzeno',
+        status: 'verified',
+        completed_at: Date.now(),
+      },
+    });
+
+    // Subscriber fires async; give it a tick.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const sqlite = getSqliteRaw();
+    const row = sqlite
+      .prepare('SELECT id, story_id FROM feature_registry WHERE story_id = ?')
+      .get(sid) as { id: string; story_id: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.story_id).toBe(sid);
+    unsub();
+  });
+
+  it('opts.enabled=false short-circuits subscription', () => {
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const unsub = registerFeatureRegistryWriter({ embedder: stub, enabled: false });
+    expect(typeof unsub).toBe('function');
+    // Should not throw when called.
+    unsub();
+  });
+});

--- a/apps/orchestrator/tests/scripts/backfill-feature-registry.test.ts
+++ b/apps/orchestrator/tests/scripts/backfill-feature-registry.test.ts
@@ -1,0 +1,201 @@
+/**
+ * FREG-004 — backfill script integration tests.
+ *
+ * Drives the two backfill modes against a temp DB + a tempdir
+ * codebase fixture. Uses StubEmbeddingClient so CI doesn't need Ollama.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  bootstrapVectorTables,
+  StubEmbeddingClient,
+} from '@chiefaia/feature-registry';
+import {
+  backfillFromCodebase,
+  backfillFromStories,
+} from '../../scripts/backfill-feature-registry';
+import { getDb, getSqliteRaw, resetDb, runMigrations } from '../../src/db/connection';
+import { stories } from '../../src/db/schema';
+
+const DIM = 768;
+
+function tempDbUrl(): string {
+  return path.join(os.tmpdir(), `freg-backfill-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+describe('backfillFromStories', () => {
+  let url: string;
+
+  beforeEach(() => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* */ }
+    resetDb();
+  });
+
+  it('synthesizes registry rows for verified stories only', async () => {
+    const db = getDb();
+    db.insert(stories).values([
+      { id: 's_v1', kind: 'story', title: 'verified A', description: 'desc A', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() },
+      { id: 's_v2', kind: 'story', title: 'verified B', description: 'desc B', status: 'partial', projectSlug: 'caia', createdAt: nowIso() },
+      { id: 's_p1', kind: 'story', title: 'pending C', description: 'desc C', status: 'pending', projectSlug: 'pokerzeno', createdAt: nowIso() },
+      { id: 's_f1', kind: 'story', title: 'failed D', description: 'desc D', status: 'failed', projectSlug: 'pokerzeno', createdAt: nowIso() },
+    ]).run();
+
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromStories(db, stub, {});
+
+    expect(r.processed).toBe(2);
+    expect(r.upserted).toBe(2);
+
+    const sqlite = getSqliteRaw();
+    const rows = sqlite.prepare("SELECT id, source FROM feature_registry").all() as Array<{ id: string; source: string }>;
+    expect(rows).toHaveLength(2);
+    expect(rows.every(r => r.source === 'backfill_stories')).toBe(true);
+  });
+
+  it('is idempotent — re-running does not duplicate rows', async () => {
+    const db = getDb();
+    db.insert(stories).values({ id: 's_v1', kind: 'story', title: 'verified A', description: 'desc A', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() }).run();
+
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    await backfillFromStories(db, stub);
+    await backfillFromStories(db, stub);
+
+    const sqlite = getSqliteRaw();
+    const count = sqlite.prepare('SELECT COUNT(*) as c FROM feature_registry').get() as { c: number };
+    expect(count.c).toBe(1);
+  });
+
+  it('respects opts.project filter', async () => {
+    const db = getDb();
+    db.insert(stories).values([
+      { id: 's_pz', kind: 'story', title: 'pz feature', description: 'A', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() },
+      { id: 's_rc', kind: 'story', title: 'rc feature', description: 'B', status: 'verified', projectSlug: 'roulettecommunity', createdAt: nowIso() },
+    ]).run();
+
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromStories(db, stub, { project: 'pokerzeno' });
+    expect(r.processed).toBe(1);
+    expect(r.upserted).toBe(1);
+  });
+
+  it('opts.dryRun does not write rows', async () => {
+    const db = getDb();
+    db.insert(stories).values({ id: 's_v1', kind: 'story', title: 'verified A', description: 'desc A', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() }).run();
+
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromStories(db, stub, { dryRun: true });
+    expect(r.upserted).toBe(1);
+
+    const sqlite = getSqliteRaw();
+    const count = sqlite.prepare('SELECT COUNT(*) as c FROM feature_registry').get() as { c: number };
+    expect(count.c).toBe(0);
+  });
+
+  it('opts.limit caps processed rows', async () => {
+    const db = getDb();
+    db.insert(stories).values([
+      { id: 's_v1', kind: 'story', title: 'verified A', description: 'A', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() },
+      { id: 's_v2', kind: 'story', title: 'verified B', description: 'B', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() },
+      { id: 's_v3', kind: 'story', title: 'verified C', description: 'C', status: 'verified', projectSlug: 'pokerzeno', createdAt: nowIso() },
+    ]).run();
+
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromStories(db, stub, { limit: 2 });
+    expect(r.processed).toBe(2);
+  });
+});
+
+describe('backfillFromCodebase', () => {
+  let url: string;
+  let root: string;
+
+  beforeEach(() => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'freg-codebase-'));
+    fs.mkdirSync(path.join(root, 'apps', 'pokerzeno', 'app', 'leaderboard'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'apps', 'pokerzeno', 'app', 'profile'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'apps', 'orchestrator', 'src', 'agents'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'apps', 'orchestrator', 'src', 'db', 'migrations'), { recursive: true });
+
+    fs.writeFileSync(path.join(root, 'apps', 'pokerzeno', 'app', 'leaderboard', 'page.tsx'), 'export default function LeaderboardPage() {}');
+    fs.writeFileSync(path.join(root, 'apps', 'pokerzeno', 'app', 'profile', 'page.tsx'), 'export default function ProfilePage() {}');
+    fs.writeFileSync(path.join(root, 'apps', 'orchestrator', 'src', 'agents', 'po-agent.ts'), 'export const poAgent = {};');
+    fs.writeFileSync(path.join(root, 'apps', 'orchestrator', 'src', 'db', 'migrations', '0001_users.sql'), 'CREATE TABLE users (id TEXT PRIMARY KEY);');
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* */ }
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* */ }
+    resetDb();
+  });
+
+  it('discovers + upserts route, agent, and table features', async () => {
+    const db = getDb();
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromCodebase(db, stub, root);
+
+    expect(r.processed).toBe(4);
+    expect(r.upserted).toBe(4);
+
+    const sqlite = getSqliteRaw();
+    const rows = sqlite.prepare("SELECT name, source, route_path, agent_name, db_tables_json FROM feature_registry").all() as Array<{
+      name: string; source: string; route_path: string | null; agent_name: string | null; db_tables_json: string;
+    }>;
+    expect(rows.every(r => r.source === 'backfill_codebase')).toBe(true);
+
+    const routes = rows.filter(r => r.route_path !== null);
+    expect(routes).toHaveLength(2);
+    expect(routes.map(r => r.route_path).sort()).toEqual(['/leaderboard', '/profile']);
+
+    const agents = rows.filter(r => r.agent_name !== null);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.agent_name).toBe('po-agent');
+
+    const dbRows = rows.filter(r => JSON.parse(r.db_tables_json).length > 0);
+    expect(dbRows).toHaveLength(1);
+    expect(JSON.parse(dbRows[0]!.db_tables_json)).toEqual(['users']);
+  });
+
+  it('is idempotent across re-runs', async () => {
+    const db = getDb();
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    await backfillFromCodebase(db, stub, root);
+    await backfillFromCodebase(db, stub, root);
+
+    const sqlite = getSqliteRaw();
+    const count = sqlite.prepare('SELECT COUNT(*) as c FROM feature_registry').get() as { c: number };
+    expect(count.c).toBe(4);
+  });
+
+  it('opts.project filter scopes to a single project', async () => {
+    const db = getDb();
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromCodebase(db, stub, root, { project: 'pokerzeno' });
+    expect(r.processed).toBe(2);
+  });
+
+  it('non-existent root logs warn and returns empty report (no throw)', async () => {
+    const db = getDb();
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const r = await backfillFromCodebase(db, stub, '/path/does/not/exist/anywhere');
+    expect(r.processed).toBe(0);
+    expect(r.errors).toBe(0);
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -28,7 +28,8 @@ export type EventActor =
   | 'task-scheduler'
   | 'testing-agent'
   | 'release-agent'
-  | 'story-validator';
+  | 'story-validator'
+  | 'feature-registry-writer';
 
 /** Canonical envelope for every event emitted through the bus */
 export interface ConductorEvent {
@@ -70,6 +71,41 @@ export interface StoryCreatedPayload { story_id: string; title: string; kind: st
 export interface StoryUpdatedPayload { story_id: string; fields_changed: string[] }
 export interface StoryStatusChangedPayload { story_id: string; from_status: string; to_status: string }
 export interface StoryDeletedPayload { story_id: string }
+
+// FREG-003 — story completion + feature_registry events
+export interface StoryCompletedPayload {
+  story_id: string;
+  project_slug?: string;
+  /** Terminal status — 'verified' | 'done' | 'partial'. */
+  status: string;
+  /** epoch ms */
+  completed_at: number;
+}
+
+export interface FeatureRegistryUpsertedPayload {
+  feature_id: string;
+  project: string;
+  /** 'story_completed' | 'backfill_codebase' | 'backfill_stories' | 'manual' */
+  source: string;
+  story_id?: string;
+  dedup_key: string;
+  embedding_model: string;
+  latency_ms: number;
+}
+
+export interface FeatureClassificationUncertainPayload {
+  story_id: string;
+  top_match_id: string;
+  top_score: number;
+  threshold_used: number;
+  project?: string;
+}
+
+export interface FeatureClassificationSkippedPayload {
+  story_id: string;
+  /** 'embedder_unavailable' | 'registry_empty' | 'registry_disabled' */
+  reason: string;
+}
 
 // ─── Task ────────────────────────────────────────────────────────────────────
 
@@ -331,6 +367,11 @@ export type EventType =
   | 'pipeline.started' | 'pipeline.completed' | 'pipeline.failed'
   | 'pipeline.decompose_started' | 'pipeline.decompose_completed'
   | 'story.created' | 'story.updated' | 'story.status_changed' | 'story.deleted'
+  // ─── FREG-003 — story completion + feature_registry events ─────────────
+  | 'story.completed'
+  | 'feature.registry.upserted'
+  | 'feature.classification.uncertain'
+  | 'feature.classification.skipped'
   | 'task.created' | 'task.queued' | 'task.started' | 'task.completed'
   | 'task.failed' | 'task.paused' | 'task.resumed' | 'task.status_changed'
   | 'executor.started' | 'executor.stopped' | 'executor.config_changed'
@@ -414,6 +455,11 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'pipeline.started': 'info', 'pipeline.completed': 'info', 'pipeline.failed': 'error',
   'pipeline.decompose_started': 'info', 'pipeline.decompose_completed': 'info',
   'story.created': 'info', 'story.updated': 'info', 'story.status_changed': 'info', 'story.deleted': 'warning',
+  // ─── FREG-003 — story completion + feature_registry events ─────────────
+  'story.completed': 'info',
+  'feature.registry.upserted': 'info',
+  'feature.classification.uncertain': 'warning',
+  'feature.classification.skipped': 'warning',
   'task.created': 'info', 'task.queued': 'info', 'task.started': 'info', 'task.completed': 'info',
   'task.failed': 'error', 'task.paused': 'warning', 'task.resumed': 'info', 'task.status_changed': 'info',
   'executor.started': 'info', 'executor.stopped': 'info', 'executor.config_changed': 'info',

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -52,6 +52,38 @@ events:
     actor: [user, api]
     payload: [story_id]
 
+  # FREG-003 — story completion → feature_registry write hook.
+  # Fired when a story reaches its terminal verified/done state. The
+  # FeatureRegistryWriter subscriber catches this, synthesizes a registry
+  # row, embeds the description via Ollama, and upserts. Until Phase 2
+  # actually ships stories, the only emitter is the API endpoint that
+  # PATCHes a story's status to verified.
+  - type: story.completed
+    severity: info
+    actor: [executor, api, worker]
+    payload: [story_id, project_slug, status, completed_at]
+
+  # FREG-003 — observability for registry writes (story.completed → upsert).
+  - type: feature.registry.upserted
+    severity: info
+    actor: [feature-registry-writer]
+    payload: [feature_id, project, source, story_id, dedup_key, embedding_model, latency_ms]
+
+  # FREG-006 — observability for the PO Agent's lifecycle classification
+  # when the top match falls in the 0.78-0.85 grey zone (PO sets enhance
+  # but flags for human/BA review).
+  - type: feature.classification.uncertain
+    severity: warning
+    actor: [po-agent]
+    payload: [story_id, top_match_id, top_score, threshold_used, project]
+
+  # FREG-006 — observability for the PO Agent's lifecycle classification
+  # when the registry/embedder is unavailable (PO defaults to lifecycle='new').
+  - type: feature.classification.skipped
+    severity: warning
+    actor: [po-agent]
+    payload: [story_id, reason]
+
   # Task events
   - type: task.created
     severity: info


### PR DESCRIPTION
## Summary

Idempotent + re-runnable script that seeds `feature_registry` from two complementary sources, so PO Agent's `enhance` classification has signal from day one.

## What ships

`apps/orchestrator/scripts/backfill-feature-registry.ts`:

- **`backfillFromStories(db, embedder, opts)`** — walks the `stories` table for `status IN ('verified','partial')` and synthesizes a registry row per story via the same `synthesizeRowFromStory` helper FREG-003 uses for live `story.completed` events. `source = 'backfill_stories'`.
- **`backfillFromCodebase(db, embedder, root, opts)`** — walks the CAIA monorepo for inferable features:
  - `apps/<app>/(app|pages)/**/page.tsx` → route_path features
  - `apps/orchestrator/src/agents/*.ts` → agent_name features
  - `apps/orchestrator/src/db/migrations/*.sql` → db_table features (regex over `CREATE TABLE`)
  - Skips `node_modules`, `.next`, `dist`, `.git`
  - `source = 'backfill_codebase'`

Both modes are idempotent via the UNIQUE `dedup_key` constraint — re-running upserts the embedding + tags + updatedAt without duplicating rows.

CLI:
```
pnpm tsx apps/orchestrator/scripts/backfill-feature-registry.ts \
  [--from=stories|codebase|both] \
  [--root=/path/to/caia] \
  [--db-url=/path/to/db.sqlite] \
  [--project=pokerzeno] \
  [--limit=N] \
  [--dry-run]
```

Both modes return a structured `BackfillReport` so the FREG-007 dashboard can render audit logs.

## Token cost

**Zero Claude tokens.** ~50-300 local Ollama tokens per row. For a typical backfill of 1000 stories + 5000 codebase features, expect ~600K-1.5M local-Ollama tokens; on M1 Pro this runs in ~5-15 minutes wall-clock.

## Tests (DoD)

- 5 `backfillFromStories` cases — verified+partial filter, idempotency, project filter, dryRun, limit
- 4 `backfillFromCodebase` cases — three discovery types working together, idempotency, project scope, missing-root tolerance
- All 9 jest cases green

## Coordination

- Imports `synthesizeRowFromStory` from FREG-003. **PR #117 (FREG-003) currently blocks** this PR; FREG-003 commit is cherry-picked into this branch so it builds standalone. After #117 merges to main, this branch's diff against main will be just FREG-004's two files.
- Embedder is the FREG-002 `OllamaEmbeddingClient`; tests use `StubEmbeddingClient` so CI doesn't need Ollama.
- No new SQL migrations.

## Risk

Low. Pure additive script under `scripts/`. Failure mode is either (a) embedder unreachable → script aborts cleanly, no partial state because each row is its own transaction, or (b) malformed story → row skipped + logged. Re-runnable to recover.