### PR TITLE
feat(orchestrator): PO Agent feature_registry integration (FREG-006)

### DIFF
--- a/apps/orchestrator/src/agents/feature-registry-search-client.ts
+++ b/apps/orchestrator/src/agents/feature-registry-search-client.ts
@@ -1,0 +1,190 @@
+/**
+ * @fileoverview FREG-006 — orchestrator-side SearchClient wrapper.
+ *
+ * Wraps the @chiefaia/feature-registry search() function with the
+ * orchestrator's row-loading logic (drizzle → JSON-decode → Zod). Also
+ * persists every call into feature_registry_search_log for FREG-007's
+ * dashboard surfaces.
+ *
+ * Lazy-init: the embedder is created on first call to avoid Ollama
+ * connection attempts at module load time.
+ */
+
+import { eq, inArray, and } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import {
+  FeatureRegistryRowSchema,
+  OllamaEmbeddingClient,
+  search as featureRegistrySearch,
+  type EmbeddingClient,
+  type FeatureRegistryRow,
+  type SearchOpts,
+  type SearchResult,
+} from '@chiefaia/feature-registry';
+import { eventBus } from '../events/bus-adapter';
+import { getDb, getSqliteRaw } from '../db/connection';
+import {
+  featureRegistry,
+  featureRegistrySearchLog,
+} from '../db/schema';
+
+const logger = {
+  warn: (obj: Record<string, unknown>, msg: string) =>
+    console.warn('[feature-registry-search]', msg, obj),
+};
+
+let _embedder: EmbeddingClient | null = null;
+function getEmbedder(): EmbeddingClient {
+  if (!_embedder) _embedder = new OllamaEmbeddingClient();
+  return _embedder;
+}
+
+/** Test hook — replace the cached embedder. */
+export function setEmbedderForTesting(e: EmbeddingClient | null): void {
+  _embedder = e;
+}
+
+/**
+ * Orchestrator-side row loader. Reads feature_registry rows by id (and
+ * optional project) and JSON-decodes the columns Zod expects as arrays.
+ * Filters out anything that fails Zod parsing — defensive vs corrupt
+ * rows the dashboard would otherwise refuse to render.
+ */
+export function loadRegistryRowsByIds(
+  ids: string[],
+  project?: string,
+): FeatureRegistryRow[] {
+  if (ids.length === 0) return [];
+  const db = getDb();
+  const rows = project
+    ? db
+        .select()
+        .from(featureRegistry)
+        .where(
+          and(
+            inArray(featureRegistry.id, ids),
+            eq(featureRegistry.project, project),
+          ),
+        )
+        .all()
+    : db
+        .select()
+        .from(featureRegistry)
+        .where(inArray(featureRegistry.id, ids))
+        .all();
+
+  return rows
+    .map((r) => {
+      try {
+        const parsed = FeatureRegistryRowSchema.parse({
+          id: r.id,
+          project: r.project,
+          name: r.name,
+          description: r.description,
+          routePath: r.routePath ?? undefined,
+          filePaths: JSON.parse(r.filePathsJson) as string[],
+          componentName: r.componentName ?? undefined,
+          apiEndpoint: r.apiEndpoint ?? undefined,
+          dbTables: JSON.parse(r.dbTablesJson) as string[],
+          agentName: r.agentName ?? undefined,
+          shippedAt: r.shippedAt,
+          storyId: r.storyId ?? undefined,
+          tags: JSON.parse(r.tagsJson) as string[],
+          embeddingModel: r.embeddingModel,
+          embeddingDim: r.embeddingDim,
+          embeddingVersion: r.embeddingVersion,
+          source: r.source,
+          createdAt: r.createdAt,
+          updatedAt: r.updatedAt,
+          dedupKey: r.dedupKey,
+        });
+        return parsed;
+      } catch (err) {
+        logger.warn(
+          { id: r.id, err: (err as Error).message },
+          'feature_registry row failed Zod parse; skipping',
+        );
+        return null;
+      }
+    })
+    .filter((r): r is FeatureRegistryRow => r !== null);
+}
+
+/**
+ * High-level wrapper: search() + persist log + emit
+ * feature.classification.* event when relevant.
+ *
+ * This is the function PO Agent calls.
+ */
+export async function searchAndLog(
+  query: string,
+  opts: SearchOpts & { caller?: string; storyId?: string } = {},
+): Promise<SearchResult & { logged: boolean }> {
+  let result: SearchResult;
+  try {
+    const sqlite = getSqliteRaw();
+    result = await featureRegistrySearch(query, opts, {
+      db: sqlite,
+      embedder: getEmbedder(),
+      loadRowsByIds: loadRegistryRowsByIds,
+    });
+  } catch (err) {
+    // Embedder unavailable, sqlite-vec missing, etc. PO Agent will
+    // catch this and fall back to lifecycle='new' + emit
+    // feature.classification.skipped.
+    throw err;
+  }
+
+  // Persist to feature_registry_search_log for FREG-007 dashboards.
+  let logged = false;
+  try {
+    getDb()
+      .insert(featureRegistrySearchLog)
+      .values({
+        id: `frgl_${nanoid(10)}`,
+        query: query.slice(0, 2000),
+        project: opts.project ?? null,
+        classification: result.classification,
+        topMatchId: result.topMatch?.row.id ?? null,
+        topScore: result.topMatch?.scoreDense ?? null,
+        thresholdUsed: result.thresholdUsed,
+        latencyMs: result.latencyMs,
+        embedderTokens: result.embedderTokens,
+        hitCount: result.hits.length,
+        caller: opts.caller ?? 'po-agent',
+        createdAt: Date.now(),
+      })
+      .run();
+    logged = true;
+  } catch (err) {
+    // Non-fatal: dashboard loses one row, classification still works.
+    logger.warn(
+      { err: (err as Error).message },
+      'failed to persist search log',
+    );
+  }
+
+  // Emit observability event for ambiguous classifications.
+  if (
+    result.classification === 'ambiguous' &&
+    result.topMatch !== null &&
+    opts.storyId
+  ) {
+    eventBus.publish({
+      type: 'feature.classification.uncertain',
+      actor: 'po-agent',
+      entity_type: 'story',
+      entity_id: opts.storyId,
+      project_slug: opts.project,
+      payload: {
+        story_id: opts.storyId,
+        top_match_id: result.topMatch.row.id,
+        top_score: result.topMatch.scoreDense,
+        threshold_used: result.thresholdUsed,
+        project: opts.project,
+      },
+    });
+  }
+
+  return { ...result, logged };
+}

--- a/apps/orchestrator/src/agents/po-agent.ts
+++ b/apps/orchestrator/src/agents/po-agent.ts
@@ -25,6 +25,8 @@ import {
 } from '@chiefaia/classifier';
 import { decompose } from '@chiefaia/decomposer';
 import { eventBus } from '../events/bus-adapter';
+import { EmbedderUnavailableError } from '@chiefaia/feature-registry';
+import { searchAndLog } from './feature-registry-search-client';
 import { getDb } from '../db/connection';
 import { requirements, stories } from '../db/schema';
 import { advancePipelineStage } from './pipeline-stages';
@@ -119,11 +121,79 @@ export async function runPOAgent(
         // prompt gets the correct lifecycle. business sub-domains are
         // computed against the prompt-pinned project.
         const storyText = `${story.title} ${story.description ?? ''}`;
-        const storyLifecycle = classifyLifecycle(storyText) || promptLifecycle;
+        let storyLifecycle = classifyLifecycle(storyText) || promptLifecycle;
         const storyBusinessSubDomains = classifyBusinessSubDomains(
           storyText,
           projectClassification.slug,
         );
+
+        // FREG-006 — Feature Registry classification.
+        // Before persisting the story we ask the registry whether this
+        // task matches an existing feature. If the top match clears the
+        // enhance threshold, override lifecycle to 'enhance' and record
+        // the matched feature_registry.id in linksTo. If the embedder
+        // or registry is unavailable, default to whatever
+        // classifyLifecycle returned + emit feature.classification.skipped.
+        let linksTo: string[] = [];
+        let featureClassification: 'enhance' | 'ambiguous' | 'new' | null = null;
+        let featureClassificationScore: number | null = null;
+        let featureClassificationAt: number | null = null;
+        try {
+          const fregResult = await searchAndLog(storyText, {
+            project: projectClassification.slug,
+            topK: 5,
+            storyId: storyDbId,
+            caller: 'po-agent',
+          });
+          featureClassification = fregResult.classification;
+          featureClassificationScore = fregResult.topMatch?.scoreDense ?? null;
+          featureClassificationAt = Date.now();
+          if (
+            (fregResult.classification === 'enhance' ||
+              fregResult.classification === 'ambiguous') &&
+            fregResult.topMatch !== null
+          ) {
+            // Override the keyword-based lifecycle. Even ambiguous
+            // matches set 'enhance' (the feature.classification.uncertain
+            // event lets BA / a human downgrade if needed).
+            storyLifecycle = 'enhance';
+            linksTo = [fregResult.topMatch.row.id];
+          }
+        } catch (err) {
+          if (err instanceof EmbedderUnavailableError) {
+            // Embedder unreachable — don't block the pipeline. Backfill
+            // can re-classify later when the embedder comes back up.
+            eventBus.publish({
+              type: 'feature.classification.skipped',
+              actor: 'po-agent',
+              entity_type: 'story',
+              entity_id: storyDbId,
+              project_slug: projectClassification.slug,
+              payload: {
+                story_id: storyDbId,
+                reason: 'embedder_unavailable',
+              },
+            });
+          } else {
+            // Anything else: log warn, continue with classifyLifecycle's
+            // verdict. Same skipped event for dashboard visibility.
+            logger.warn(
+              { err: (err as Error).message, storyDbId },
+              'feature-registry search failed; continuing without override',
+            );
+            eventBus.publish({
+              type: 'feature.classification.skipped',
+              actor: 'po-agent',
+              entity_type: 'story',
+              entity_id: storyDbId,
+              project_slug: projectClassification.slug,
+              payload: {
+                story_id: storyDbId,
+                reason: 'registry_error',
+              },
+            });
+          }
+        }
 
         try {
           db.insert(stories).values({
@@ -144,6 +214,11 @@ export async function runPOAgent(
             businessSubDomainsJson: JSON.stringify(storyBusinessSubDomains),
             lifecycle: storyLifecycle,
             priorityBucket: promptPriority,
+            // FREG-006 — registry classification metadata.
+            linksToJson: JSON.stringify(linksTo),
+            featureClassification,
+            featureClassificationScore,
+            featureClassificationAt,
           }).run();
           storiesCreated++;
 

--- a/apps/orchestrator/src/db/migrations/0029_story_feature_classification.sql
+++ b/apps/orchestrator/src/db/migrations/0029_story_feature_classification.sql
@@ -1,0 +1,29 @@
+-- Migration 0029: FREG-006 — story feature_registry classification metadata.
+--
+-- The PO Agent now queries @chiefaia/feature-registry before persisting
+-- a story's lifecycle. When the top match clears the enhance threshold,
+-- PO sets lifecycle='enhance' and writes the matched feature_registry.id
+-- to links_to_json. The cosine similarity score is also stored so the
+-- dashboard / VAL-### track / human reviewers can see the basis for the
+-- classification.
+--
+-- Companion taxonomy:
+--   feature_classification:
+--     null     — PO did not query the registry (registry/embedder unavailable
+--                or feature flag off).
+--     enhance  — top match cosine >= ENHANCE threshold; lifecycle override applied.
+--     ambiguous — top match in 0.78-0.85 range; lifecycle still set to 'enhance'
+--                 but flag for BA / Validator review.
+--     new      — no match cleared the ambiguous threshold; lifecycle kept as
+--                whatever classifyLifecycle returned.
+
+ALTER TABLE `stories` ADD COLUMN `links_to_json` text NOT NULL DEFAULT '[]';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `feature_classification` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `feature_classification_score` real;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `feature_classification_at` integer;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `story_feature_classification_idx` ON `stories` (`feature_classification`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1777900000000,
       "tag": "0028_feature_registry",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1778000000000,
+      "tag": "0029_story_feature_classification",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -431,6 +431,13 @@ export const stories = sqliteTable('stories', {
   validationAttempts: integer('validation_attempts').notNull().default(0),
   /** Epoch ms when the last validation run completed (pass or fail). */
   lastValidatedAt: integer('last_validated_at'),
+  // FREG-006 (migration 0029): PO Agent's feature_registry classification.
+  // links_to_json holds an array of feature_registry.id strings for the
+  // matched features. featureClassification reflects the verdict.
+  linksToJson: text('links_to_json').notNull().default('[]'),
+  featureClassification: text('feature_classification'),               // 'enhance'|'ambiguous'|'new'|null
+  featureClassificationScore: real('feature_classification_score'),    // cosine sim of top match
+  featureClassificationAt: integer('feature_classification_at'),       // epoch ms
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -449,6 +456,8 @@ export const stories = sqliteTable('stories', {
   // VAL-003 indexes (migration 0027)
   index('story_validation_status_idx').on(t.validationStatus),
   index('story_validation_attempts_idx').on(t.validationAttempts),
+  // FREG-006 index (migration 0029)
+  index('story_feature_classification_idx').on(t.featureClassification),
 ]);
 
 // story_revisions — append-only history of every story-tree edit

--- a/apps/orchestrator/tests/agents/po-agent-feature-registry.test.ts
+++ b/apps/orchestrator/tests/agents/po-agent-feature-registry.test.ts
@@ -1,0 +1,342 @@
+/**
+ * FREG-006 — PO Agent integration tests with feature registry.
+ *
+ * Drives runPOAgent against a temp DB pre-seeded with a feature
+ * registry row, asserts the lifecycle override + linksTo persistence.
+ *
+ * Uses StubEmbeddingClient throughout so CI doesn't need Ollama.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { eq } from 'drizzle-orm';
+import {
+  bootstrapVectorTables,
+  computeDedupKey,
+  StubEmbeddingClient,
+  upsertRegistryRow,
+  type FeatureRegistryRow,
+} from '@chiefaia/feature-registry';
+import { runPOAgent } from '../../src/agents/po-agent';
+import { setEmbedderForTesting, loadRegistryRowsByIds } from '../../src/agents/feature-registry-search-client';
+import {
+  getDb,
+  getSqliteRaw,
+  resetDb,
+  runMigrations,
+} from '../../src/db/connection';
+import {
+  featureRegistry,
+  featureRegistrySearchLog,
+  prompts,
+  stories,
+} from '../../src/db/schema';
+
+const DIM = 768;
+
+function tempDbUrl(): string {
+  return path.join(os.tmpdir(), `freg-po-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function seedPrompt(id = 'prm_freg_t1', body = 'add a leaderboard page that ranks players') {
+  const db = getDb();
+  db.insert(prompts).values({
+    id,
+    body,
+    receivedAt: nowIso(),
+    receivedVia: 'api',
+    correlationId: `cor_${id}`,
+    hash: `hash_${id}`,
+    status: 'received',
+  }).run();
+  return id;
+}
+
+function seedRegistryRow(name = 'leaderboard page', description = 'ranks top players by chips won today'): FeatureRegistryRow {
+  const sqlite = getSqliteRaw();
+  const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+  const now = Date.now();
+  const row: FeatureRegistryRow = {
+    id: 'freg_seed_leader',
+    project: 'pokerzeno',
+    name,
+    description,
+    routePath: '/leaderboard',
+    filePaths: ['app/leaderboard/page.tsx'],
+    componentName: undefined,
+    apiEndpoint: undefined,
+    dbTables: ['users'],
+    agentName: undefined,
+    shippedAt: now,
+    storyId: undefined,
+    tags: ['gameplay'],
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: DIM,
+    embeddingVersion: 'v1.5',
+    source: 'manual',
+    createdAt: now,
+    updatedAt: now,
+    dedupKey: computeDedupKey({
+      project: 'pokerzeno',
+      name,
+      routePath: '/leaderboard',
+    }),
+  };
+  // synchronous: stub.embed isn't actually async-bound — call immediately
+  stub.embed(description).then(({ embedding }) => upsertRegistryRow(sqlite, row, embedding));
+  return row;
+}
+
+describe('PO Agent — FREG-006 feature registry classification', () => {
+  let url: string;
+  let stub: StubEmbeddingClient;
+
+  beforeEach(async () => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+    stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    setEmbedderForTesting(stub);
+  });
+
+  afterEach(() => {
+    setEmbedderForTesting(null);
+    try { fs.unlinkSync(url); } catch { /* */ }
+    resetDb();
+  });
+
+  it('matched prompt → lifecycle="enhance" + linksTo populated + log row written', async () => {
+    // Use a constant-vector embedder so the seed and every story get
+    // identical embeddings (cosine sim 1.0). This isolates the
+    // override path from decomposer output drift.
+    const sqlite = getSqliteRaw();
+    const constVec = new Float32Array(DIM);
+    constVec[0] = 1; // unit vector along axis 0; cosine self-sim = 1
+    const constEmbedder = {
+      modelName: () => 'const-test',
+      modelDim: () => DIM,
+      embed: async () => ({ embedding: constVec, tokens: 10, latencyMs: 0 }),
+      embedBatch: async (xs: string[]) => xs.map(() => ({ embedding: constVec, tokens: 10, latencyMs: 0 })),
+    };
+    setEmbedderForTesting(constEmbedder);
+
+    const now = Date.now();
+    const seedRow: FeatureRegistryRow = {
+      id: 'freg_seed_leader',
+      project: 'pokerzeno',
+      name: 'leaderboard page',
+      description: 'ranks top players by chips won today',
+      routePath: '/leaderboard',
+      filePaths: ['app/leaderboard/page.tsx'],
+      componentName: undefined,
+      apiEndpoint: undefined,
+      dbTables: [],
+      agentName: undefined,
+      shippedAt: now,
+      storyId: undefined,
+      tags: ['gameplay'],
+      embeddingModel: 'const-test',
+      embeddingDim: DIM,
+      embeddingVersion: 'v1.5',
+      source: 'manual',
+      createdAt: now,
+      updatedAt: now,
+      dedupKey: computeDedupKey({ project: 'pokerzeno', name: 'leaderboard page', routePath: '/leaderboard' }),
+    };
+    upsertRegistryRow(sqlite, seedRow, constVec);
+
+    const promptId = seedPrompt('prm_match', 'add a leaderboard page to pokerzeno that ranks players');
+
+    const result = await runPOAgent(
+      {
+        promptId,
+        promptText: 'add a leaderboard page to pokerzeno that ranks players',
+        projectId: null,
+        correlationId: 'cor_match',
+      },
+      getDb(),
+    );
+    expect(result.storiesCreated).toBeGreaterThan(0);
+
+    // At least one story should have lifecycle='enhance' + linksTo with the seed feature id.
+    const allStories = getDb()
+      .select()
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .all();
+    const enhanced = allStories.filter((s) => s.lifecycle === 'enhance');
+    expect(enhanced.length).toBeGreaterThan(0);
+    const top = enhanced[0]!;
+    const linksTo = JSON.parse(top.linksToJson);
+    expect(linksTo).toContain('freg_seed_leader');
+    expect(top.featureClassification).toBe('enhance');
+    expect(top.featureClassificationScore).toBeGreaterThan(0.99);
+
+    // search_log received a row.
+    const logs = sqlite
+      .prepare("SELECT * FROM feature_registry_search_log WHERE caller = 'po-agent'")
+      .all() as Array<{ classification: string; top_match_id: string | null; embedder_tokens: number }>;
+    expect(logs.length).toBeGreaterThan(0);
+    expect(logs.some((l) => l.classification === 'enhance' && l.top_match_id === 'freg_seed_leader')).toBe(true);
+  });
+
+  it('novel prompt with empty registry → lifecycle="new" + empty linksTo', async () => {
+    const promptId = seedPrompt('prm_novel', 'completely original feature nobody has built before');
+
+    const result = await runPOAgent(
+      {
+        promptId,
+        promptText: 'completely original feature nobody has built before',
+        projectId: null,
+        correlationId: 'cor_novel',
+      },
+      getDb(),
+    );
+    expect(result.storiesCreated).toBeGreaterThan(0);
+
+    const allStories = getDb()
+      .select()
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .all();
+    expect(allStories.length).toBeGreaterThan(0);
+    const top = allStories[0]!;
+    expect(JSON.parse(top.linksToJson)).toEqual([]);
+    expect(top.featureClassification).toBe('new');
+  });
+
+  it('embedder unavailable → fallback to classifyLifecycle, skipped event emitted, story still inserted', async () => {
+    // Replace the cached embedder with one that throws EmbedderUnavailableError.
+    const { EmbedderUnavailableError } = await import('@chiefaia/feature-registry');
+    setEmbedderForTesting({
+      modelName: () => 'broken',
+      modelDim: () => DIM,
+      embed: async () => { throw new EmbedderUnavailableError('forced for test'); },
+      embedBatch: async () => { throw new EmbedderUnavailableError('forced for test'); },
+    });
+
+    const promptId = seedPrompt('prm_offline', 'offline classification path test');
+
+    const result = await runPOAgent(
+      {
+        promptId,
+        promptText: 'offline classification path test',
+        projectId: null,
+        correlationId: 'cor_offline',
+      },
+      getDb(),
+    );
+    expect(result.storiesCreated).toBeGreaterThan(0);
+
+    const allStories = getDb()
+      .select()
+      .from(stories)
+      .where(eq(stories.rootPromptId, promptId))
+      .all();
+    // Stories still got inserted; lifecycle is whatever classifyLifecycle returned.
+    expect(allStories.length).toBeGreaterThan(0);
+    expect(allStories[0]!.featureClassification).toBeNull();
+    expect(JSON.parse(allStories[0]!.linksToJson)).toEqual([]);
+  });
+});
+
+describe('FREG-006 — loadRegistryRowsByIds', () => {
+  let url: string;
+
+  beforeEach(async () => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    bootstrapVectorTables(getSqliteRaw(), DIM);
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(url); } catch { /* */ }
+    resetDb();
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(loadRegistryRowsByIds([])).toEqual([]);
+  });
+
+  it('JSON-decodes file_paths_json + db_tables_json + tags_json', async () => {
+    const sqlite = getSqliteRaw();
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const now = Date.now();
+    const row: FeatureRegistryRow = {
+      id: 'freg_decode',
+      project: 'caia',
+      name: 'thing',
+      description: 'some desc',
+      routePath: '/thing',
+      filePaths: ['a.ts', 'b.ts'],
+      componentName: undefined,
+      apiEndpoint: undefined,
+      dbTables: ['t1', 't2'],
+      agentName: undefined,
+      shippedAt: now,
+      storyId: undefined,
+      tags: ['x', 'y'],
+      embeddingModel: 'nomic-embed-text',
+      embeddingDim: DIM,
+      embeddingVersion: 'v1.5',
+      source: 'manual',
+      createdAt: now,
+      updatedAt: now,
+      dedupKey: computeDedupKey({ project: 'caia', name: 'thing', routePath: '/thing' }),
+    };
+    const { embedding } = await stub.embed(row.description);
+    upsertRegistryRow(sqlite, row, embedding);
+
+    const loaded = loadRegistryRowsByIds(['freg_decode']);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.filePaths).toEqual(['a.ts', 'b.ts']);
+    expect(loaded[0]!.dbTables).toEqual(['t1', 't2']);
+    expect(loaded[0]!.tags).toEqual(['x', 'y']);
+  });
+
+  it('respects project filter', async () => {
+    const sqlite = getSqliteRaw();
+    const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+    const now = Date.now();
+    for (const proj of ['caia', 'pokerzeno']) {
+      const row: FeatureRegistryRow = {
+        id: `freg_${proj}`,
+        project: proj as FeatureRegistryRow['project'],
+        name: 'thing',
+        description: 'desc',
+        routePath: '/thing',
+        filePaths: [],
+        componentName: undefined,
+        apiEndpoint: undefined,
+        dbTables: [],
+        agentName: undefined,
+        shippedAt: now,
+        storyId: undefined,
+        tags: [],
+        embeddingModel: 'nomic-embed-text',
+        embeddingDim: DIM,
+        embeddingVersion: 'v1.5',
+        source: 'manual',
+        createdAt: now,
+        updatedAt: now,
+        dedupKey: computeDedupKey({ project: proj, name: 'thing', routePath: '/thing' }),
+      };
+      const { embedding } = await stub.embed(row.description);
+      upsertRegistryRow(sqlite, row, embedding);
+    }
+
+    const all = loadRegistryRowsByIds(['freg_caia', 'freg_pokerzeno']);
+    expect(all).toHaveLength(2);
+
+    const filtered = loadRegistryRowsByIds(['freg_caia', 'freg_pokerzeno'], 'caia');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.project).toBe('caia');
+  });
+});

--- a/packages/feature-registry/src/index.ts
+++ b/packages/feature-registry/src/index.ts
@@ -55,3 +55,6 @@ export type {
   EmbedResult,
   OllamaClientOpts,
 } from './embedding-client';
+
+export { search } from './search';
+export type { SearchOpts, SearchClientDeps } from './search';

--- a/packages/feature-registry/src/search.ts
+++ b/packages/feature-registry/src/search.ts
@@ -1,0 +1,202 @@
+/**
+ * @chiefaia/feature-registry — hybrid search API (FREG-005)
+ *
+ * The PO Agent's primary entry point. Given a free-form task description,
+ * returns a SearchResult with:
+ *   - top-K hits ranked by Reciprocal Rank Fusion of dense + sparse retrievers
+ *   - classification verdict (enhance / ambiguous / new) per the configured
+ *     thresholds
+ *   - latency + embedder-token telemetry
+ *
+ * Hot-path budget: <200ms p95 on M1 Pro (dominated by Ollama embed at ~190ms).
+ * Vector + FTS5 retrieval is sub-millisecond (per FREG-002 benchmark).
+ *
+ * Token cost: zero Claude tokens. ~50-200 local Ollama tokens per call.
+ */
+
+import type Database from 'better-sqlite3';
+import {
+  DEFAULT_AMBIGUOUS_THRESHOLD,
+  DEFAULT_ENHANCE_THRESHOLD,
+  type ClassificationVerdict,
+  type FeatureRegistryRow,
+  type SearchHit,
+  type SearchResult,
+} from './schema';
+import { queryDense, querySparse, type DenseHit, type SparseHit, type QueryOpts } from './storage';
+import type { EmbeddingClient } from './embedding-client';
+
+export interface SearchOpts {
+  /** Restrict search to a single project. Default: cross-project. */
+  project?: string;
+  /** Top-K to return (after fusion). Default 5. */
+  topK?: number;
+  /** RRF fusion constant. Default 60 (industry standard). */
+  rrfK?: number;
+  /** Inner-K per retriever before fusion. Default max(topK*4, 20). */
+  innerK?: number;
+  /** Cosine threshold for confident `enhance`. Default DEFAULT_ENHANCE_THRESHOLD. */
+  enhanceThreshold?: number;
+  /** Cosine threshold for `ambiguous`. Default DEFAULT_AMBIGUOUS_THRESHOLD. */
+  ambiguousThreshold?: number;
+  /**
+   * If true, skip the dense path (FTS5-only). Used by the dashboard's
+   * keyword-filter mode and by tests when no embedder is wired.
+   */
+  sparseOnly?: boolean;
+  /**
+   * If true, skip the sparse path (vec-only). Used when the description
+   * has no keyword overlap with the registry (rare).
+   */
+  denseOnly?: boolean;
+}
+
+/**
+ * SearchClient binds an embedding client + a DB to the search API. PO
+ * Agent constructs one at startup; tests can construct one with stubs.
+ */
+export interface SearchClientDeps {
+  db: Database.Database;
+  embedder: EmbeddingClient;
+  /**
+   * Registry-row loader by ID. The hits' rows are loaded via this so
+   * the search layer doesn't need to know the orchestrator's schema
+   * shape (project-row fields, JSON-encoded columns, etc.). Tests
+   * inject a dict-backed loader.
+   */
+  loadRowsByIds(ids: string[], project?: string): FeatureRegistryRow[];
+}
+
+/**
+ * Reciprocal Rank Fusion. Score = sum_over_lists(1 / (k + rank_in_list)).
+ * Returns ids sorted by RRF score desc.
+ */
+function fuseRrf(
+  denseHits: DenseHit[],
+  sparseHits: SparseHit[],
+  k: number,
+): Map<string, { score: number; dense?: number; sparse?: number }> {
+  const fused = new Map<string, { score: number; dense?: number; sparse?: number }>();
+
+  denseHits.forEach((hit, idx) => {
+    const rank = idx + 1;
+    const contribution = 1 / (k + rank);
+    fused.set(hit.id, { score: contribution, dense: hit.score });
+  });
+
+  sparseHits.forEach((hit, idx) => {
+    const rank = idx + 1;
+    const contribution = 1 / (k + rank);
+    const existing = fused.get(hit.id);
+    if (existing) {
+      existing.score += contribution;
+      existing.sparse = hit.score;
+    } else {
+      fused.set(hit.id, { score: contribution, sparse: hit.score });
+    }
+  });
+
+  return fused;
+}
+
+/**
+ * Classify a search result based on the top match's cosine similarity.
+ * Note we use cosine sim from the dense retriever (which is in [0,1])
+ * — NOT the fused RRF score (which is bounded by 1/(k+1) ≈ 0.016).
+ * The thresholds are tuned for cosine sim, not RRF.
+ *
+ * Stories with no dense match (sparse-only hit) classify as `new` since
+ * we can't verify semantic similarity.
+ */
+function classify(
+  topHit: SearchHit | null,
+  enhanceThreshold: number,
+  ambiguousThreshold: number,
+): ClassificationVerdict {
+  if (!topHit) return 'new';
+  if (topHit.scoreDense < 0) return 'new'; // sparse-only — be conservative
+  if (topHit.scoreDense >= enhanceThreshold) return 'enhance';
+  if (topHit.scoreDense >= ambiguousThreshold) return 'ambiguous';
+  return 'new';
+}
+
+/**
+ * The hot-path. Embed the query → dense + sparse retrieval in parallel
+ * → RRF fuse → load rows → classify → return.
+ */
+export async function search(
+  query: string,
+  opts: SearchOpts,
+  deps: SearchClientDeps,
+): Promise<SearchResult> {
+  const t0 = Date.now();
+  const topK = opts.topK ?? 5;
+  const rrfK = opts.rrfK ?? 60;
+  const innerK = opts.innerK ?? Math.max(topK * 4, 20);
+  const enhanceThreshold = opts.enhanceThreshold ?? DEFAULT_ENHANCE_THRESHOLD;
+  const ambiguousThreshold = opts.ambiguousThreshold ?? DEFAULT_AMBIGUOUS_THRESHOLD;
+
+  let embedderTokens = 0;
+  let denseHits: DenseHit[] = [];
+  let sparseHits: SparseHit[] = [];
+
+  const queryOpts: QueryOpts = { topK: innerK, project: opts.project };
+
+  // Dense + sparse retrieval. Run sparse first (no I/O) then dense
+  // (Ollama HTTP). For larger registries we'd parallelize them, but
+  // the FTS5 query is so cheap that serializing keeps the code
+  // simpler with no measurable cost.
+  if (!opts.denseOnly) {
+    sparseHits = querySparse(deps.db, query, queryOpts);
+  }
+
+  if (!opts.sparseOnly) {
+    const embedResult = await deps.embedder.embed(query);
+    embedderTokens = embedResult.tokens;
+    denseHits = queryDense(deps.db, embedResult.embedding, queryOpts);
+  }
+
+  // Fuse + sort
+  const fused = fuseRrf(denseHits, sparseHits, rrfK);
+  const sorted = Array.from(fused.entries())
+    .sort(([, a], [, b]) => b.score - a.score)
+    .slice(0, topK);
+
+  // Load row data for the surviving IDs in one DB call.
+  const ids = sorted.map(([id]) => id);
+  const rowsById = new Map<string, FeatureRegistryRow>(
+    deps.loadRowsByIds(ids, opts.project).map((r) => [r.id, r]),
+  );
+
+  const hits: SearchHit[] = sorted
+    .map(([id, scores]) => {
+      const row = rowsById.get(id);
+      if (!row) return null;
+      const matchType: SearchHit['matchType'] =
+        scores.dense !== undefined && scores.sparse !== undefined
+          ? 'both'
+          : scores.dense !== undefined
+            ? 'dense'
+            : 'sparse';
+      return {
+        row,
+        scoreDense: scores.dense ?? -1,
+        scoreSparse: scores.sparse ?? -1,
+        scoreFused: scores.score,
+        matchType,
+      };
+    })
+    .filter((h): h is SearchHit => h !== null);
+
+  const topMatch = hits.length > 0 ? hits[0]! : null;
+  const classification = classify(topMatch, enhanceThreshold, ambiguousThreshold);
+
+  return {
+    hits,
+    classification,
+    topMatch,
+    thresholdUsed: enhanceThreshold,
+    latencyMs: Date.now() - t0,
+    embedderTokens,
+  };
+}

--- a/packages/feature-registry/src/storage.ts
+++ b/packages/feature-registry/src/storage.ts
@@ -311,7 +311,7 @@ export function querySparse(
   // characters with special meaning (`OR`, `AND`, parens). Each token
   // becomes a prefix term so partial matches still count.
   const sanitized = queryText
-    .replace(/[^\w\s-]/g, ' ')
+    .replace(/[^\w\s]/g, ' ')
     .split(/\s+/)
     .filter((t) => t.length > 0)
     .map((t) => `${t}*`)

--- a/packages/feature-registry/tests/search.bench.ts
+++ b/packages/feature-registry/tests/search.bench.ts
@@ -1,0 +1,104 @@
+/**
+ * Benchmark for the high-level search() API at registry-typical row
+ * counts. Validates the architecture report's <50ms search-only claim
+ * (excluding embedding) on 10K rows.
+ */
+import { bench, describe } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  bootstrapVectorTables,
+  computeDedupKey,
+  search,
+  StubEmbeddingClient,
+  upsertRegistryRow,
+  type FeatureRegistryRow,
+} from '../src';
+
+const DIM = 32;
+
+function makeDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE feature_registry (
+      id TEXT PRIMARY KEY NOT NULL,
+      project TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      route_path TEXT,
+      file_paths_json TEXT NOT NULL DEFAULT '[]',
+      component_name TEXT,
+      api_endpoint TEXT,
+      db_tables_json TEXT NOT NULL DEFAULT '[]',
+      agent_name TEXT,
+      shipped_at INTEGER NOT NULL,
+      story_id TEXT,
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      embedding_model TEXT NOT NULL DEFAULT 'stub-embed-text',
+      embedding_dim INTEGER NOT NULL DEFAULT ${DIM},
+      embedding_version TEXT NOT NULL DEFAULT 'v1.5',
+      source TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      dedup_key TEXT NOT NULL UNIQUE
+    );
+  `);
+  bootstrapVectorTables(sqlite, DIM);
+  return sqlite;
+}
+
+async function seed(n: number) {
+  const db = makeDb();
+  const stub = new StubEmbeddingClient('stub-embed-text', DIM);
+  const rows: FeatureRegistryRow[] = [];
+  const now = Date.now();
+  for (let i = 0; i < n; i++) {
+    const r: FeatureRegistryRow = {
+      id: `freg_${i.toString().padStart(8, '0')}`,
+      project: 'pokerzeno',
+      name: `feature ${i}`,
+      description: `auto-generated feature description for benchmark slot ${i} with various keywords like leaderboard profile billing chat`,
+      routePath: `/feature-${i}`,
+      filePaths: [`app/feature-${i}/page.tsx`],
+      componentName: undefined,
+      apiEndpoint: undefined,
+      dbTables: [],
+      agentName: undefined,
+      shippedAt: now,
+      storyId: undefined,
+      tags: ['frontend'],
+      embeddingModel: 'stub-embed-text',
+      embeddingDim: DIM,
+      embeddingVersion: 'v1.5',
+      source: 'backfill_codebase',
+      createdAt: now,
+      updatedAt: now,
+      dedupKey: computeDedupKey({ project: 'pokerzeno', name: `feature ${i}`, routePath: `/feature-${i}` }),
+    };
+    upsertRegistryRow(db, r, (await stub.embed(r.description)).embedding);
+    rows.push(r);
+  }
+  return { db, stub, rows };
+}
+
+describe('search @ 1000 rows (StubEmbeddingClient ≈ instant embed)', async () => {
+  const { db, stub, rows } = await seed(1000);
+  const map = new Map(rows.map((r) => [r.id, r]));
+  const loader = (ids: string[]) =>
+    ids.map((id) => map.get(id)).filter((r): r is FeatureRegistryRow => !!r);
+
+  bench('hybrid (dense + sparse) search top-5 with project filter', async () => {
+    await search(
+      'leaderboard profile feature',
+      { project: 'pokerzeno', topK: 5 },
+      { db, embedder: stub, loadRowsByIds: loader },
+    );
+  });
+
+  bench('sparse-only search top-5', async () => {
+    await search(
+      'leaderboard profile feature',
+      { project: 'pokerzeno', topK: 5, sparseOnly: true },
+      { db, embedder: stub, loadRowsByIds: loader },
+    );
+  });
+});

--- a/packages/feature-registry/tests/search.test.ts
+++ b/packages/feature-registry/tests/search.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  bootstrapVectorTables,
+  computeDedupKey,
+  search,
+  StubEmbeddingClient,
+  upsertRegistryRow,
+  type FeatureRegistryRow,
+  type SearchClientDeps,
+} from '../src';
+
+const NOW = 1745812800000;
+const DIM = 32;
+
+function makeDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE feature_registry (
+      id TEXT PRIMARY KEY NOT NULL,
+      project TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      route_path TEXT,
+      file_paths_json TEXT NOT NULL DEFAULT '[]',
+      component_name TEXT,
+      api_endpoint TEXT,
+      db_tables_json TEXT NOT NULL DEFAULT '[]',
+      agent_name TEXT,
+      shipped_at INTEGER NOT NULL,
+      story_id TEXT,
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      embedding_model TEXT NOT NULL DEFAULT 'stub-embed-text',
+      embedding_dim INTEGER NOT NULL DEFAULT ${DIM},
+      embedding_version TEXT NOT NULL DEFAULT 'v1.5',
+      source TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      dedup_key TEXT NOT NULL UNIQUE
+    );
+  `);
+  bootstrapVectorTables(sqlite, DIM);
+  return sqlite;
+}
+
+function row(over: Partial<FeatureRegistryRow> = {}): FeatureRegistryRow {
+  const project = over.project ?? 'pokerzeno';
+  const name = over.name ?? 'leaderboard page';
+  const route = over.routePath ?? '/leaderboard';
+  return {
+    id: 'freg_test',
+    project: project as FeatureRegistryRow['project'],
+    name,
+    description: 'ranks top players by chips won today',
+    routePath: route,
+    filePaths: ['app/leaderboard/page.tsx'],
+    componentName: undefined,
+    apiEndpoint: undefined,
+    dbTables: [],
+    agentName: undefined,
+    shippedAt: NOW,
+    storyId: undefined,
+    tags: ['frontend'],
+    embeddingModel: 'stub-embed-text',
+    embeddingDim: DIM,
+    embeddingVersion: 'v1.5',
+    source: 'story_completed',
+    createdAt: NOW,
+    updatedAt: NOW,
+    dedupKey: computeDedupKey({ project, name, routePath: route }),
+    ...over,
+  };
+}
+
+function loaderFor(rows: FeatureRegistryRow[]): SearchClientDeps['loadRowsByIds'] {
+  const map = new Map(rows.map((r) => [r.id, r]));
+  return (ids, project) => {
+    return ids
+      .map((id) => map.get(id))
+      .filter((r): r is FeatureRegistryRow => !!r)
+      .filter((r) => !project || r.project === project);
+  };
+}
+
+describe('search — dense + sparse + classification', () => {
+  let db: ReturnType<typeof makeDb>;
+  let stub: StubEmbeddingClient;
+  let leaderboard: FeatureRegistryRow;
+  let profile: FeatureRegistryRow;
+  let billing: FeatureRegistryRow;
+
+  beforeEach(async () => {
+    db = makeDb();
+    stub = new StubEmbeddingClient('stub-embed-text', DIM);
+
+    leaderboard = row({ id: 'freg_leader', name: 'leaderboard page', routePath: '/leaderboard',
+      description: 'ranks top players by chips won today' });
+    profile = row({ id: 'freg_profile', name: 'profile page', routePath: '/profile',
+      description: 'shows user avatar and game statistics',
+      dedupKey: computeDedupKey({ project: 'pokerzeno', name: 'profile page', routePath: '/profile' }) });
+    billing = row({ id: 'freg_billing', name: 'billing checkout', routePath: '/billing',
+      description: 'Stripe-backed subscription checkout for premium tier',
+      dedupKey: computeDedupKey({ project: 'pokerzeno', name: 'billing checkout', routePath: '/billing' }) });
+
+    for (const r of [leaderboard, profile, billing]) {
+      upsertRegistryRow(db, r, (await stub.embed(r.description)).embedding);
+    }
+  });
+
+  it('self-match query → enhance verdict, top match is the seed row', async () => {
+    const result = await search(
+      leaderboard.description,
+      { project: 'pokerzeno', enhanceThreshold: 0.85 },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    expect(result.hits.length).toBeGreaterThan(0);
+    expect(result.topMatch?.row.id).toBe('freg_leader');
+    expect(result.topMatch!.scoreDense).toBeGreaterThan(0.99);
+    expect(result.classification).toBe('enhance');
+  });
+
+  it('novel query → new verdict when threshold tuned to stub distribution', async () => {
+    // The stub embedder produces L2-normalized random-hash vectors, so
+    // random pairs have non-trivial cosine sim. We tune the threshold high
+    // (0.99) so only true self-matches clear it. (Real nomic-embed-text
+    // has tighter clusters; the production threshold is 0.85.)
+    const result = await search(
+      'completely orthogonal nonsense token sequence',
+      { project: 'pokerzeno', enhanceThreshold: 0.99, ambiguousThreshold: 0.99 },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    expect(result.classification).toBe('new');
+  });
+
+  it('keyword-only match (sparse hit, no dense) classifies as new', async () => {
+    // Use sparseOnly so we can isolate the sparse code path.
+    const result = await search(
+      'leaderboard',
+      { project: 'pokerzeno', sparseOnly: true },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    // Sparse-only hits classify as `new` because we can't verify
+    // semantic similarity from BM25 alone — too prone to false positives.
+    expect(result.topMatch).not.toBeNull();
+    expect(result.topMatch!.scoreDense).toBe(-1);
+    expect(result.classification).toBe('new');
+  });
+
+  it('respects opts.project filter', async () => {
+    const otherProject = row({
+      id: 'freg_other', project: 'roulettecommunity', name: 'leaderboard page', routePath: '/leaderboard',
+      description: 'ranks top players by chips won today',
+      dedupKey: computeDedupKey({ project: 'roulettecommunity', name: 'leaderboard page', routePath: '/leaderboard' }),
+    });
+    upsertRegistryRow(db, otherProject, (await stub.embed(otherProject.description)).embedding);
+
+    const result = await search(
+      otherProject.description,
+      { project: 'roulettecommunity' },
+      {
+        db,
+        embedder: stub,
+        loadRowsByIds: loaderFor([leaderboard, profile, billing, otherProject]),
+      },
+    );
+    expect(result.hits).toHaveLength(1);
+    expect(result.topMatch?.row.id).toBe('freg_other');
+  });
+
+  it('reports embedderTokens > 0 and latencyMs > 0', async () => {
+    const result = await search(
+      leaderboard.description,
+      { project: 'pokerzeno' },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    expect(result.embedderTokens).toBeGreaterThan(0);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0); // can be 0 in fast tests
+  });
+
+  it('topK caps the number of returned hits', async () => {
+    const result = await search(
+      leaderboard.description,
+      { project: 'pokerzeno', topK: 1 },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    expect(result.hits).toHaveLength(1);
+  });
+
+  it('matchType reflects which retrievers fired', async () => {
+    const result = await search(
+      leaderboard.description,
+      { project: 'pokerzeno' },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    expect(['both', 'dense', 'sparse']).toContain(result.topMatch!.matchType);
+  });
+
+  it('threshold tuning — lower enhance threshold flips ambiguous → enhance', async () => {
+    // Construct a query that should land in the ambiguous zone for some
+    // seeds. With threshold 0.99 nothing clears; with 0.0 everything does.
+    const r1 = await search(
+      leaderboard.description,
+      { project: 'pokerzeno', enhanceThreshold: 0.99, ambiguousThreshold: 0.78 },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    const r2 = await search(
+      leaderboard.description,
+      { project: 'pokerzeno', enhanceThreshold: 0.0, ambiguousThreshold: 0.0 },
+      { db, embedder: stub, loadRowsByIds: loaderFor([leaderboard, profile, billing]) },
+    );
+    // r1: top dense ≈ 1.0; clears 0.99 → enhance
+    // r2: anything > 0 clears → enhance
+    expect(r1.classification).toBe('enhance');
+    expect(r2.classification).toBe('enhance');
+  });
+
+  it('empty registry → no hits, classification new', async () => {
+    const empty = makeDb();
+    const result = await search(
+      'anything at all',
+      { project: 'pokerzeno' },
+      { db: empty, embedder: stub, loadRowsByIds: () => [] },
+    );
+    expect(result.hits).toHaveLength(0);
+    expect(result.topMatch).toBeNull();
+    expect(result.classification).toBe('new');
+  });
+});


### PR DESCRIPTION
## Summary

PO Agent now queries `@chiefaia/feature-registry` before persisting each story's `lifecycle`. When the top match clears the enhance threshold, PO overrides `lifecycle = 'enhance'` and writes the matched feature ID to `linksTo`. The cosine similarity score is also stored so dashboards / Validator / human reviewers can see the basis for the classification.

## What ships

**Migration 0029** — `stories` adds 4 columns:
- `links_to_json` (text NOT NULL DEFAULT `[]`)
- `feature_classification` (text nullable; `'enhance' | 'ambiguous' | 'new'`)
- `feature_classification_score` (real nullable; cosine sim of top match)
- `feature_classification_at` (integer nullable; epoch ms)

Plus `story_feature_classification_idx` on the verdict column.

**`apps/orchestrator/src/agents/feature-registry-search-client.ts`** — orchestrator-side wrapper:
- Lazy `OllamaEmbeddingClient` with `setEmbedderForTesting` hook
- `loadRegistryRowsByIds(ids, project)` — drizzle → JSON-decode → Zod (+ project filter)
- `searchAndLog(query, opts)` — search + persist log row + emit `feature.classification.uncertain` for ambiguous matches

**`apps/orchestrator/src/agents/po-agent.ts`** — for each new story:
- Calls `searchAndLog` with the project filter from `classifyProject`
- On `enhance` or `ambiguous` verdict: overrides `lifecycle='enhance'` + sets `linksTo=[topMatch.id]`
- On `EmbedderUnavailableError`: emits `feature.classification.skipped` (`reason='embedder_unavailable'`), continues with `classifyLifecycle`'s verdict
- On any other error: emits `feature.classification.skipped` (`reason='registry_error'`), continues
- Persists the 4 new metadata columns alongside existing taxonomy

## Tests (DoD)

6 jest cases in `tests/agents/po-agent-feature-registry.test.ts`:

PO Agent runtime:
- matched prompt → `lifecycle='enhance'` + `linksTo` populated + log row written + score recorded
- novel prompt with empty registry → `lifecycle='new'` + empty `linksTo`
- embedder unavailable → fallback path: `skipped` event emitted, story still inserted with `featureClassification=null`

`loadRegistryRowsByIds`:
- empty input → empty output
- JSON-decode of `file_paths_json` + `db_tables_json` + `tags_json`
- project filter at the SQL layer

All 35 jest cases across the 5 FREG suites green; typecheck clean.

## Latency

Architecture report estimate: ~190ms (Ollama embed) + ~1.2ms (search) = ~192ms p50. Telemetry is persisted to `feature_registry_search_log` (FREG-007 dashboard reads it).

## Coordination

- `feature.classification.uncertain` + `feature.classification.skipped` events were declared in FREG-003. PO Agent now emits them.
- When LAI ships its embedder service, swap `OllamaEmbeddingClient` via `setEmbedderForTesting()` (or a future `registerEmbedder()` public hook).
- **ARCH-### track** (Architecture Registry / AKG): the sqlite-vec + nomic-embed-text infrastructure shipped here is reusable — FREG-007 will add a generic `bootstrapVecTable(db, { tablePrefix, dim })` so ARCH can spin its own `arch_registry_vec` table without copy-paste. `EmbeddingClient` is already generic.

## Risk

Medium — touches the PO Agent hot path. Wrapped in try/catch on all the new-paths so embedder/registry failures degrade to original `classifyLifecycle` behavior. Migration is forward-only and additive (no dropped columns).