### PR TITLE
feat(architecture-registry): @chiefaia/architecture-registry skeleton + migration 0030 (ARCH-001)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0030_architecture_registry.sql
+++ b/apps/orchestrator/src/db/migrations/0030_architecture_registry.sql
@@ -1,0 +1,127 @@
+-- Migration 0030: ARCH-001 — Architecture Knowledge Graph (AKG) tables.
+--
+-- The Architecture Registry catalogs every architectural artifact in CAIA
+-- + sites (services, APIs, components, themes, plugins, packages,
+-- schemas, migrations, integrations, domain modules, observability
+-- signals, ADRs) plus the directed dependency edges between them.
+-- The EA Agent (ARCH-006) queries this graph by `tech_sub_domain` to
+-- produce per-domain technical implementation instructions on every
+-- story.
+--
+-- Two ordinary tables are declared here:
+--
+--   arch_artifacts             — one row per architectural artifact.
+--   arch_edges                 — directed relationship rows.
+--
+-- One observability table:
+--
+--   arch_extract_runs          — each AST/introspect/scan invocation,
+--                                 with timing + counts for the dashboard.
+--
+-- Two virtual tables — `arch_artifacts_vec` (sqlite-vec vec0) and
+-- `arch_artifacts_fts` (FTS5) — are wired by ARCH-004 once the sqlite-vec
+-- extension is loaded into the connection. They are NOT created here for
+-- the same reasons as feature_registry's virtual tables (drizzle-kit
+-- doesn't model virtual tables; the vec0 module isn't loaded at migration
+-- time).
+--
+-- See ~/Documents/projects/reports/architecture-registry-architecture-2026-04-28.md
+-- for the full architecture rationale, schema design, extraction strategy,
+-- and EA Agent integration design.
+
+CREATE TABLE `arch_artifacts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `kind` text NOT NULL,
+  `project` text NOT NULL,
+  `name` text NOT NULL,
+  `description` text NOT NULL,
+  `key_signature` text,
+  `file_paths_json` text NOT NULL DEFAULT '[]',
+  `entry_path` text,
+  `route_signature` text,
+  `table_name` text,
+  `owning_service` text,
+  `package_name` text,
+  `design_system_tier` text,
+  `tech_sub_domains_json` text NOT NULL DEFAULT '[]',
+  `tags_json` text NOT NULL DEFAULT '[]',
+  `metadata_json` text NOT NULL DEFAULT '{}',
+  `source` text NOT NULL,
+  `content_hash` text,
+  `extracted_at_commit` text,
+  `embedding_model` text NOT NULL DEFAULT 'nomic-embed-text',
+  `embedding_dim` integer NOT NULL DEFAULT 768,
+  `embedding_version` text NOT NULL DEFAULT 'v1.5',
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  `dedup_key` text NOT NULL UNIQUE
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `arch_artifacts_kind_idx` ON `arch_artifacts` (`kind`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_project_idx` ON `arch_artifacts` (`project`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_kind_project_idx` ON `arch_artifacts` (`kind`, `project`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_owning_service_idx` ON `arch_artifacts` (`owning_service`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_package_idx` ON `arch_artifacts` (`package_name`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_route_idx` ON `arch_artifacts` (`route_signature`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_table_idx` ON `arch_artifacts` (`table_name`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_source_idx` ON `arch_artifacts` (`source`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_artifacts_updated_idx` ON `arch_artifacts` (`updated_at`);
+--> statement-breakpoint
+
+CREATE TABLE `arch_edges` (
+  `id` text PRIMARY KEY NOT NULL,
+  `from_id` text NOT NULL,
+  `to_id` text NOT NULL,
+  `relation` text NOT NULL,
+  `weight` real NOT NULL DEFAULT 1.0,
+  `metadata_json` text NOT NULL DEFAULT '{}',
+  `source` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  UNIQUE (`from_id`, `to_id`, `relation`)
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `arch_edges_from_idx` ON `arch_edges` (`from_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_edges_to_idx` ON `arch_edges` (`to_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_edges_relation_idx` ON `arch_edges` (`relation`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_edges_from_relation_idx` ON `arch_edges` (`from_id`, `relation`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_edges_to_relation_idx` ON `arch_edges` (`to_id`, `relation`);
+--> statement-breakpoint
+
+-- arch_extract_runs — one row per extractor invocation. Powers the
+-- dashboard /architecture page (ARCH-007) "last extracted" panel and lets
+-- ops see which extractors are slow / produce large deltas.
+CREATE TABLE `arch_extract_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `extractor` text NOT NULL,
+  `started_at` integer NOT NULL,
+  `finished_at` integer,
+  `duration_ms` integer,
+  `commit_sha` text,
+  `artifacts_inserted` integer NOT NULL DEFAULT 0,
+  `artifacts_updated` integer NOT NULL DEFAULT 0,
+  `artifacts_unchanged` integer NOT NULL DEFAULT 0,
+  `edges_inserted` integer NOT NULL DEFAULT 0,
+  `edges_updated` integer NOT NULL DEFAULT 0,
+  `error` text,
+  `metadata_json` text NOT NULL DEFAULT '{}'
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `arch_extract_runs_extractor_idx` ON `arch_extract_runs` (`extractor`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `arch_extract_runs_started_idx` ON `arch_extract_runs` (`started_at`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1778000000000,
       "tag": "0029_story_feature_classification",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1778100000000,
+      "tag": "0030_architecture_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -1019,3 +1019,94 @@ export const featureRegistrySearchLog = sqliteTable('feature_registry_search_log
   index('freg_log_classification_idx').on(t.classification),
   index('freg_log_caller_idx').on(t.caller),
 ]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// arch_artifacts / arch_edges / arch_extract_runs — ARCH-001 (migration 0030)
+//
+// Architecture Knowledge Graph (AKG): structured catalog of every
+// architectural artifact in CAIA + sites — services, APIs, components,
+// themes, plugins, packages, schemas, migrations, integrations, domain
+// modules, observability signals, ADRs — plus the directed dependency
+// edges between them. The EA Agent (ARCH-006) queries this graph by
+// `tech_sub_domain` to produce per-domain technical implementation
+// instructions on every story.
+//
+// See @chiefaia/architecture-registry for the Zod schemas, dedup-key
+// helper, and per-domain query API. Embeddings live in a sibling vec0
+// virtual table (`arch_artifacts_vec`) wired by ARCH-004 — drizzle doesn't
+// model virtual tables so the bootstrap is in TS.
+// ─────────────────────────────────────────────────────────────────────────────
+export const archArtifacts = sqliteTable('arch_artifacts', {
+  id: text('id').primaryKey(),
+  kind: text('kind').notNull(),                       // ARTIFACT_KINDS
+  project: text('project').notNull(),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  keySignature: text('key_signature'),
+  filePathsJson: text('file_paths_json').notNull().default('[]'),
+  entryPath: text('entry_path'),
+  routeSignature: text('route_signature'),            // 'GET /api/leaderboard'
+  tableName: text('table_name'),
+  owningService: text('owning_service'),
+  packageName: text('package_name'),
+  designSystemTier: text('design_system_tier'),       // primitive|pattern|feature|page
+  techSubDomainsJson: text('tech_sub_domains_json').notNull().default('[]'),
+  tagsJson: text('tags_json').notNull().default('[]'),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+  source: text('source').notNull(),                   // ARCH_REGISTRY_SOURCES
+  contentHash: text('content_hash'),
+  extractedAtCommit: text('extracted_at_commit'),
+  embeddingModel: text('embedding_model').notNull().default('nomic-embed-text'),
+  embeddingDim: integer('embedding_dim').notNull().default(768),
+  embeddingVersion: text('embedding_version').notNull().default('v1.5'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  dedupKey: text('dedup_key').notNull().unique(),
+}, (t) => [
+  index('arch_artifacts_kind_idx').on(t.kind),
+  index('arch_artifacts_project_idx').on(t.project),
+  index('arch_artifacts_kind_project_idx').on(t.kind, t.project),
+  index('arch_artifacts_owning_service_idx').on(t.owningService),
+  index('arch_artifacts_package_idx').on(t.packageName),
+  index('arch_artifacts_route_idx').on(t.routeSignature),
+  index('arch_artifacts_table_idx').on(t.tableName),
+  index('arch_artifacts_source_idx').on(t.source),
+  index('arch_artifacts_updated_idx').on(t.updatedAt),
+]);
+
+export const archEdges = sqliteTable('arch_edges', {
+  id: text('id').primaryKey(),
+  fromId: text('from_id').notNull(),
+  toId: text('to_id').notNull(),
+  relation: text('relation').notNull(),               // EDGE_RELATIONS
+  weight: real('weight').notNull().default(1.0),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+  source: text('source').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, (t) => [
+  index('arch_edges_from_idx').on(t.fromId),
+  index('arch_edges_to_idx').on(t.toId),
+  index('arch_edges_relation_idx').on(t.relation),
+  index('arch_edges_from_relation_idx').on(t.fromId, t.relation),
+  index('arch_edges_to_relation_idx').on(t.toId, t.relation),
+]);
+
+export const archExtractRuns = sqliteTable('arch_extract_runs', {
+  id: text('id').primaryKey(),
+  extractor: text('extractor').notNull(),             // 'ts-morph'|'drizzle'|'package'|'adr'
+  startedAt: integer('started_at').notNull(),
+  finishedAt: integer('finished_at'),
+  durationMs: integer('duration_ms'),
+  commitSha: text('commit_sha'),
+  artifactsInserted: integer('artifacts_inserted').notNull().default(0),
+  artifactsUpdated: integer('artifacts_updated').notNull().default(0),
+  artifactsUnchanged: integer('artifacts_unchanged').notNull().default(0),
+  edgesInserted: integer('edges_inserted').notNull().default(0),
+  edgesUpdated: integer('edges_updated').notNull().default(0),
+  error: text('error'),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+}, (t) => [
+  index('arch_extract_runs_extractor_idx').on(t.extractor),
+  index('arch_extract_runs_started_idx').on(t.startedAt),
+]);

--- a/packages/architecture-registry/README.md
+++ b/packages/architecture-registry/README.md
@@ -1,0 +1,107 @@
+# @chiefaia/architecture-registry
+
+The **Architecture Knowledge Graph (AKG)**: a structured, embeddings-augmented
+catalog of every architectural artifact in the CAIA monorepo + sites. Powers
+the EA Agent's per-domain technical implementation instructions on every
+story.
+
+## Why
+
+The Enterprise Architect (EA) Agent runs after the BA Agent on every story
+and produces concrete, per-domain technical instructions (per the
+2026-04-28 directive):
+
+- **UI:** which existing component / theme / plugin to use; if a piece is
+  missing, what to build (with file paths, naming, design-system tier).
+- **Backend / BFF:** existing API to call (route + request/response
+  schema), enhancement to existing API (delta), or brand-new API (full
+  spec).
+- **Database:** schema updates needed (which tables, which migrations).
+- **Analytics / CMS / observability / infra / integration:** per-domain
+  specifics.
+
+To do that without burning Claude tokens or hallucinating API names, EA
+queries this AKG. Each artifact is auto-extracted from the codebase via
+AST parsing + drizzle introspect + package.json scanning, embedded
+locally with `nomic-embed-text` (Ollama), and stored in `sqlite-vec`
+(shared with `@chiefaia/feature-registry`).
+
+## Architecture
+
+- **Auto-extraction:** `ts-morph` for TypeScript components / Hono routes /
+  services; drizzle-kit pull for DB schema; package.json + pnpm-workspace
+  scanners for packages; ADR scanner for decisions.
+- **Storage:** ordinary SQLite tables `arch_artifacts` + `arch_edges` for
+  structured rows + relationships.
+- **Embeddings:** `nomic-embed-text` via Ollama, stored in a sibling vec0
+  virtual table `arch_artifacts_vec`. Hybrid search via FTS5 over name +
+  description + key signature.
+- **Per-domain query API:** `arch.findUIArtifacts`, `findBackendArtifacts`,
+  `findDBArtifacts`, `findAcrossDomains` — ranked, filtered, with full
+  metadata.
+- **Cost:** zero Claude tokens. All extraction + embedding + retrieval is
+  local.
+
+Detailed architecture report:
+`~/Documents/projects/reports/architecture-registry-architecture-2026-04-28.md`.
+
+## Public API (ARCH-001)
+
+```ts
+import {
+  ArchArtifactRowSchema,
+  ArchEdgeRowSchema,
+  ArtifactKind,
+  EdgeRelation,
+  computeArtifactDedupKey,
+  computeEdgeDedupKey,
+  ComponentMetadataSchema,
+  ApiMetadataSchema,
+  SchemaMetadataSchema,
+  ArchitecturalInstructionsSchema,
+} from '@chiefaia/architecture-registry';
+
+// Schema validation
+const row = ArchArtifactRowSchema.parse({ ... });
+
+// Idempotent dedup keys
+const artifactKey = computeArtifactDedupKey({
+  project: 'caia',
+  kind: 'component',
+  name: 'PromptList',
+  entryPath: 'apps/dashboard/components/prompt-list.tsx',
+});
+
+const edgeKey = computeEdgeDedupKey({
+  fromId: 'arch_x',
+  toId: 'arch_y',
+  relation: 'depends_on',
+});
+```
+
+## Coordination
+
+- **FREG-### track** ships the local-AI embedding infrastructure (Ollama
+  client, sqlite-vec bootstrap, embed cache). AKG consumes those via the
+  same `EmbeddingClient` interface — no duplication. Both vector tables
+  live in the orchestrator's SQLite DB.
+- **VAL-### track** can validate that EA's `architecturalInstructions[]`
+  reference real `arch_artifacts.id` rows.
+- **TEST-### track** can scope test cases to the AKG-identified surfaces.
+- **PO Taxonomy (BUCKET-###)** — every AKG row tags one or more
+  `tech_sub_domain` values (canonical enum from `@chiefaia/ticket-template`).
+- **Phase 1 pipeline order** — EA runs **after BA**, before Validator
+  (per 2026-04-28 reorder directive). EA reads BA's enriched ticket,
+  queries the AKG by tech sub-domain, populates `architecturalInstructions[]`
+  on the ticket template; Validator then checks each instruction
+  references real AKG artifacts.
+
+## DoD compliance
+
+- Unit tests over Zod schemas + dedup keys (ARCH-001)
+- AST extractor tests with sample fixtures (ARCH-002)
+- Drizzle introspect tests (ARCH-003)
+- Embedding write/read cycle integration tests (ARCH-004)
+- Search benchmark tests (ARCH-005)
+- E2E test driving full pipeline EA → instructions referencing AKG
+  (ARCH-008)

--- a/packages/architecture-registry/package.json
+++ b/packages/architecture-registry/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@chiefaia/architecture-registry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Architecture Knowledge Graph (AKG): structured catalog of every architectural artifact in the CAIA monorepo + sites — services, APIs, components, themes, plugins, packages, schemas, migrations, integrations, domain modules, observability signals — with dependency edges and shared sqlite-vec embeddings (reuses @chiefaia/feature-registry infra). Powers the EA Agent's per-domain technical instructions per story.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@chiefaia/feature-registry": "workspace:*",
+    "@chiefaia/ticket-template": "workspace:*",
+    "nanoid": "^3.3.7",
+    "zod": "^3.23.8",
+    "better-sqlite3": "^12.6.2",
+    "sqlite-vec": "^0.1.9"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "@types/better-sqlite3": "^7.6.13"
+  }
+}

--- a/packages/architecture-registry/src/dedup-key.ts
+++ b/packages/architecture-registry/src/dedup-key.ts
@@ -1,0 +1,69 @@
+/**
+ * @chiefaia/architecture-registry — dedup key (ARCH-001)
+ *
+ * Idempotency for the AKG: the dedup_key column on `arch_artifacts` has a
+ * UNIQUE constraint, so the AST extractor (ARCH-002), drizzle introspect
+ * (ARCH-003), and any other writer can blindly upsert the same logical
+ * artifact without inserting duplicates.
+ *
+ * Key composition: project + kind + name + most-specific-locator. Locator
+ * preference order (most-specific first):
+ *   - routeSignature   (kind=api)
+ *   - tableName        (kind=schema|migration)
+ *   - packageName      (kind=package)
+ *   - entryPath        (anything with a single canonical entry file)
+ *   - first(filePaths) (fallback)
+ *   - empty            (conceptual artifacts: domain modules without files)
+ *
+ * Output: 64-char hex sha256.
+ */
+
+import { createHash } from 'node:crypto';
+import type { ArtifactKind, EdgeRelation } from './schema';
+
+export interface ArtifactDedupKeyInput {
+  project: string;
+  kind: ArtifactKind;
+  name: string;
+  routeSignature?: string | null;
+  tableName?: string | null;
+  packageName?: string | null;
+  entryPath?: string | null;
+  filePaths?: string[];
+}
+
+function norm(s: string | null | undefined): string {
+  if (!s) return '';
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export function computeArtifactDedupKey(input: ArtifactDedupKeyInput): string {
+  const project = norm(input.project);
+  const kind = norm(input.kind);
+  const name = norm(input.name);
+  const locator =
+    norm(input.routeSignature) ||
+    norm(input.tableName) ||
+    norm(input.packageName) ||
+    norm(input.entryPath) ||
+    norm((input.filePaths ?? []).slice().sort().join('|'));
+
+  const payload = `arch::${project}::${kind}::${name}::${locator}`;
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+export interface EdgeDedupKeyInput {
+  fromId: string;
+  toId: string;
+  relation: EdgeRelation;
+}
+
+/**
+ * Edge dedup key. UNIQUE on (fromId, toId, relation) — so re-extracting
+ * "OrchestratorService depends_on FeatureRegistryPackage" twice doesn't
+ * produce two rows.
+ */
+export function computeEdgeDedupKey(input: EdgeDedupKeyInput): string {
+  const payload = `arch_edge::${input.fromId}::${input.toId}::${input.relation}`;
+  return createHash('sha256').update(payload).digest('hex');
+}

--- a/packages/architecture-registry/src/index.ts
+++ b/packages/architecture-registry/src/index.ts
@@ -1,0 +1,80 @@
+/**
+ * @chiefaia/architecture-registry — public exports
+ *
+ * ARCH-001: schema + dedup key + per-kind metadata payload schemas.
+ * ARCH-002: ts-morph AST extractor for components / APIs / services.
+ * ARCH-003: drizzle introspect + package.json scanner.
+ * ARCH-004: embeddings layer (reuses FREG infra).
+ * ARCH-005: per-domain query API.
+ * ARCH-006: EA Agent integration (architecturalInstructions ticket field).
+ * ARCH-007: dashboard /architecture page.
+ */
+
+export {
+  // Constants + enums
+  ARCHITECTURE_REGISTRY_VERSION,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_VERSION,
+  ARCH_REGISTRY_SOURCES,
+  ARTIFACT_KINDS,
+  EDGE_RELATIONS,
+  ADR_STATUSES,
+  MAX_NAME_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_KEY_SIGNATURE_LENGTH,
+  MAX_TAGS,
+  MAX_FILE_PATHS,
+  // Row schemas
+  ArchArtifactRowSchema,
+  ArchEdgeRowSchema,
+  // Per-kind metadata schemas
+  ComponentMetadataSchema,
+  ApiMetadataSchema,
+  SchemaMetadataSchema,
+  MigrationMetadataSchema,
+  PackageMetadataSchema,
+  ServiceMetadataSchema,
+  ThemeMetadataSchema,
+  PluginMetadataSchema,
+  IntegrationMetadataSchema,
+  DomainModuleMetadataSchema,
+  ObservabilitySignalMetadataSchema,
+  AdrMetadataSchema,
+  // Search schemas
+  ArchSearchHitSchema,
+  ArchSearchResultSchema,
+  ArchQueryOptsSchema,
+  // EA integration schemas
+  ArchitecturalInstructionSchema,
+  ArchitecturalInstructionsSchema,
+} from './schema';
+
+export type {
+  ArchRegistrySource,
+  ArtifactKind,
+  EdgeRelation,
+  AdrStatus,
+  ArchArtifactRow,
+  ArchEdgeRow,
+  ComponentMetadata,
+  ApiMetadata,
+  SchemaMetadata,
+  MigrationMetadata,
+  PackageMetadata,
+  ServiceMetadata,
+  ThemeMetadata,
+  PluginMetadata,
+  IntegrationMetadata,
+  DomainModuleMetadata,
+  ObservabilitySignalMetadata,
+  AdrMetadata,
+  ArchSearchHit,
+  ArchSearchResult,
+  ArchQueryOpts,
+  ArchitecturalInstruction,
+  ArchitecturalInstructions,
+} from './schema';
+
+export { computeArtifactDedupKey, computeEdgeDedupKey } from './dedup-key';
+export type { ArtifactDedupKeyInput, EdgeDedupKeyInput } from './dedup-key';

--- a/packages/architecture-registry/src/schema.ts
+++ b/packages/architecture-registry/src/schema.ts
@@ -1,0 +1,627 @@
+/**
+ * @chiefaia/architecture-registry — schema (ARCH-001)
+ *
+ * Architecture Knowledge Graph (AKG): the canonical, Zod-validated shape of
+ * every architectural artifact in the CAIA monorepo + sites — services,
+ * APIs, components, themes, plugins, packages, schemas, migrations,
+ * integrations, domain modules, observability signals — plus the edge
+ * relationships that connect them (dependency, expose, uses_component,
+ * persists_to).
+ *
+ * Sister track to @chiefaia/feature-registry. Where FREG catalogs *user-
+ * visible features* at story-completion time, the AKG catalogs *building
+ * blocks* extracted from the source code itself. Both share the same
+ * sqlite-vec embedding infrastructure (see ARCH-004) and the same DB file.
+ *
+ * EA Agent integration (ARCH-006): per story, EA queries the AKG by tech
+ * sub-domain and produces concrete `architecturalInstructions` ("use
+ * existing component X" or "create new API Y at path Z").
+ *
+ * Keep this file dependency-free aside from `zod` so it can be imported by
+ * the orchestrator, dashboard, EA Agent, and tooling alike without dragging
+ * in SQLite/Ollama transitive deps.
+ */
+
+import { z } from 'zod';
+import { PROJECT_SLUGS, TECH_SUB_DOMAINS } from '@chiefaia/ticket-template';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const ARCHITECTURE_REGISTRY_VERSION = 'v1' as const;
+
+/**
+ * Default embedding model. Shared with FREG for vector-DB co-tenancy.
+ * Stored on each row so a future model swap can detect-and-backfill stale
+ * rows without rebuilding the whole index from scratch.
+ */
+export const DEFAULT_EMBEDDING_MODEL = 'nomic-embed-text' as const;
+export const DEFAULT_EMBEDDING_DIM = 768 as const;
+export const DEFAULT_EMBEDDING_VERSION = 'v1.5' as const;
+
+/**
+ * Provenance of a row: distinguishes auto-extracted artifacts (which can
+ * be safely re-extracted without losing curation) from human-curated ones
+ * (which a re-extraction should not overwrite).
+ */
+export const ARCH_REGISTRY_SOURCES = [
+  'ast_extract', // ts-morph AST extraction (ARCH-002)
+  'drizzle_introspect', // drizzle schema introspection (ARCH-003)
+  'package_scan', // package.json + pnpm-workspace scanner (ARCH-003)
+  'adr_scan', // ADR markdown frontmatter scanner
+  'manual', // hand-curated row (do not overwrite on re-extract)
+] as const;
+export type ArchRegistrySource = (typeof ARCH_REGISTRY_SOURCES)[number];
+
+/**
+ * The kind of architectural artifact. Drives which extractor populates the
+ * row + which `arch_*` table it lives in. Per-domain queries pivot on this.
+ */
+export const ARTIFACT_KINDS = [
+  'service', // backend service (e.g. orchestrator, executor)
+  'api', // HTTP/WS endpoint (route, method, request/response schema)
+  'component', // UI React component (path, props, exports)
+  'theme', // design-system theme tokens, palettes, typography
+  'plugin', // site/agent plugin (analytics, dev-inspector, etc.)
+  'package', // npm package, internal `@chiefaia/*` or third-party
+  'schema', // DB table (columns, indexes, FKs)
+  'migration', // drizzle migration with up/down + applied state
+  'integration', // third-party integration (Vault, GitHub, Cloudflare)
+  'domain_module', // DDD bounded context (auth, billing, gameplay, etc.)
+  'observability_signal', // log stream, metric, dashboard, alert
+  'adr', // architecture decision record
+] as const;
+export type ArtifactKind = (typeof ARTIFACT_KINDS)[number];
+
+/**
+ * The kind of edge (dependency relationship). All edges live in one
+ * `arch_edges` table; the `relation` column distinguishes them.
+ */
+export const EDGE_RELATIONS = [
+  'depends_on', // import-graph dependency (A imports B)
+  'consumes', // A consumes B's output (e.g. service → API)
+  'exposes', // A exposes B (service → API; module → component)
+  'extends', // A extends/specializes B (theme override, schema migration)
+  'overrides', // A overrides B (plugin override of default)
+  'uses_component', // page/feature uses component
+  'persists_to', // service writes to schema
+  'emits_event', // service emits event type
+  'subscribes_to', // service subscribes to event type
+  'documented_by', // artifact documented by ADR
+] as const;
+export type EdgeRelation = (typeof EDGE_RELATIONS)[number];
+
+/**
+ * Lifecycle state of a stored ADR. Mirrors MADR/log4brains conventions.
+ */
+export const ADR_STATUSES = [
+  'proposed',
+  'accepted',
+  'deprecated',
+  'superseded',
+  'rejected',
+] as const;
+export type AdrStatus = (typeof ADR_STATUSES)[number];
+
+// ─── Bounded ────────────────────────────────────────────────────────────────
+
+export const MAX_NAME_LENGTH = 200;
+export const MAX_DESCRIPTION_LENGTH = 4000;
+export const MAX_KEY_SIGNATURE_LENGTH = 8000;
+export const MAX_TAGS = 20;
+export const MAX_FILE_PATHS = 50;
+
+// Project slug must match the canonical taxonomy from ticket-template.
+const ProjectSlugEnum = z.enum(PROJECT_SLUGS);
+const TechSubDomainEnum = z.enum(TECH_SUB_DOMAINS);
+
+// ─── Per-row schema (entities) ──────────────────────────────────────────────
+
+/**
+ * A single architectural artifact. One row per service / API / component /
+ * theme / plugin / package / schema / migration / integration / domain
+ * module / observability signal / ADR.
+ *
+ * The shape is intentionally union-like: every artifact lives in this one
+ * table, with kind-specific metadata in `metadataJson`. This keeps the
+ * embedding + edge-traversal layers uniform while preserving per-kind
+ * detail.
+ */
+export const ArchArtifactRowSchema = z
+  .object({
+    // ─── Identity ──────────────────────────────────────────────────────────
+    /** `arch_<nanoid12>`. Stable across re-extracts (keyed on dedup_key). */
+    id: z.string().min(1),
+
+    /** What kind of artifact. Drives extractor + per-domain routing. */
+    kind: z.enum(ARTIFACT_KINDS),
+
+    project: ProjectSlugEnum,
+
+    /** Short human-readable name (component name, route path, table name). */
+    name: z.string().min(1).max(MAX_NAME_LENGTH),
+
+    /**
+     * Free-form description. Primary embedding input alongside
+     * keySignature. For auto-extracted rows: JSDoc summary line, README
+     * blurb, or a synthesized one-line summary.
+     */
+    description: z.string().min(1).max(MAX_DESCRIPTION_LENGTH),
+
+    /**
+     * The "shape" of the artifact in code: function signature, route
+     * spec, prop interface, schema columns, etc. Embedded alongside name
+     * + description so semantic search can match on signature shape.
+     */
+    keySignature: z.string().max(MAX_KEY_SIGNATURE_LENGTH).optional(),
+
+    // ─── Locator fields (any may be absent) ────────────────────────────────
+    /**
+     * Repo-relative file paths implementing this artifact. Empty for
+     * conceptual artifacts (e.g. domain modules, ADRs without files).
+     */
+    filePaths: z.array(z.string().min(1)).max(MAX_FILE_PATHS).default([]),
+
+    /** Repo-relative entry point (single canonical path). */
+    entryPath: z.string().optional(),
+
+    /** API route + method (`'GET /api/leaderboard'`) for `kind=api`. */
+    routeSignature: z.string().optional(),
+
+    /** Table name (`'feature_registry'`) for `kind=schema|migration`. */
+    tableName: z.string().optional(),
+
+    /**
+     * Service / package owning this artifact (e.g. 'orchestrator',
+     * '@chiefaia/feature-registry'). Used to traverse from artifact →
+     * owning service. Aligns with arch_services.id when known.
+     */
+    owningService: z.string().optional(),
+
+    /**
+     * For `kind=package`: the npm package name (e.g. '@chiefaia/logger',
+     * 'better-sqlite3'). For internal packages this duplicates `name`;
+     * for external it disambiguates.
+     */
+    packageName: z.string().optional(),
+
+    /** Design-system tier: 'primitive' | 'pattern' | 'feature' | 'page'. */
+    designSystemTier: z
+      .enum(['primitive', 'pattern', 'feature', 'page'])
+      .optional(),
+
+    // ─── Domain tagging ────────────────────────────────────────────────────
+    /**
+     * One or more `tech_sub_domain` slugs (from BUCKET-001 taxonomy).
+     * Drives per-domain queries: `arch.findUIArtifacts` filters by
+     * `frontend|design-system|accessibility`, etc.
+     */
+    techSubDomains: z.array(TechSubDomainEnum).default([]),
+
+    /**
+     * Free-form tags. Union of business sub-domains, quality tags, and
+     * extractor-emitted classifiers. Useful for filtering search results.
+     */
+    tags: z.array(z.string().min(1)).max(MAX_TAGS).default([]),
+
+    // ─── Kind-specific metadata (JSON-serialized payload) ──────────────────
+    /**
+     * Free-form per-kind metadata. Extractors populate kind-appropriate
+     * shapes:
+     *
+     *   kind=component → { props: [{ name, type, required, default? }],
+     *                      exports: string[], jsDocSummary? }
+     *   kind=api       → { method, path, requestSchema?, responseSchema?,
+     *                      authRequired }
+     *   kind=schema    → { columns: [{ name, type, nullable, default? }],
+     *                      indexes: [{ name, columns, unique }],
+     *                      foreignKeys: [...] }
+     *   kind=migration → { upSql?, downSql?, checksum }
+     *   kind=package   → { version, dependencies: string[], internal: bool }
+     *   kind=adr       → { status: AdrStatus, decisionDate, supersedes? }
+     *   ...
+     *
+     * Stored as JSON to avoid an explosion of nullable columns. Per-kind
+     * Zod schemas in `metadata-schemas.ts` validate when extractors
+     * write — call sites that read a row should `.parse` against the
+     * matching schema.
+     */
+    metadataJson: z.string().default('{}'),
+
+    // ─── Provenance ────────────────────────────────────────────────────────
+    source: z.enum(ARCH_REGISTRY_SOURCES),
+
+    /**
+     * SHA-256 of the source content (for AST-extracted rows: the file
+     * contents at extraction time). Lets the incremental extractor skip
+     * rows whose source hasn't changed.
+     */
+    contentHash: z.string().min(8).max(80).optional(),
+
+    /** Git commit SHA at extraction time (8-char short or full 40-char). */
+    extractedAtCommit: z.string().optional(),
+
+    // ─── Embedding metadata ────────────────────────────────────────────────
+    embeddingModel: z.string().default(DEFAULT_EMBEDDING_MODEL),
+    embeddingDim: z.number().int().positive().default(DEFAULT_EMBEDDING_DIM),
+    embeddingVersion: z.string().default(DEFAULT_EMBEDDING_VERSION),
+
+    // ─── Audit ─────────────────────────────────────────────────────────────
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative(),
+
+    /**
+     * sha256 of (project, kind, name, locator). UNIQUE — re-running an
+     * extractor upserts the row idempotently. Locator preference:
+     * routeSignature → entryPath → packageName → tableName → first(filePaths).
+     */
+    dedupKey: z.string().min(40).max(80),
+  })
+  .strict();
+
+export type ArchArtifactRow = z.infer<typeof ArchArtifactRowSchema>;
+
+// ─── Edges ──────────────────────────────────────────────────────────────────
+
+/**
+ * One row per directed relationship between two artifacts. Multi-relation
+ * (A might both `depends_on` and `documented_by` B); UNIQUE on
+ * (fromId, toId, relation).
+ */
+export const ArchEdgeRowSchema = z
+  .object({
+    id: z.string().min(1),
+
+    /** arch_artifacts.id of the source artifact. */
+    fromId: z.string().min(1),
+
+    /** arch_artifacts.id of the target artifact. */
+    toId: z.string().min(1),
+
+    relation: z.enum(EDGE_RELATIONS),
+
+    /** Optional weight for ranked traversals (e.g. import frequency). */
+    weight: z.number().nonnegative().default(1.0),
+
+    /** Free-form per-edge metadata (JSON). */
+    metadataJson: z.string().default('{}'),
+
+    source: z.enum(ARCH_REGISTRY_SOURCES),
+
+    createdAt: z.number().int().nonnegative(),
+    updatedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export type ArchEdgeRow = z.infer<typeof ArchEdgeRowSchema>;
+
+// ─── Per-kind metadata payload schemas ──────────────────────────────────────
+//
+// Optional but encouraged: extractors should validate against these before
+// JSON-serializing into `metadataJson`. Readers can `.parse` the JSON back
+// out to a typed shape when the kind is known.
+
+export const ComponentMetadataSchema = z
+  .object({
+    props: z
+      .array(
+        z.object({
+          name: z.string(),
+          type: z.string(),
+          required: z.boolean().default(false),
+          defaultValue: z.string().optional(),
+          description: z.string().optional(),
+        }),
+      )
+      .default([]),
+    exports: z.array(z.string()).default([]),
+    jsDocSummary: z.string().optional(),
+    isDefaultExport: z.boolean().default(false),
+    /** 'function' | 'class' | 'memo' | 'forwardRef'. */
+    componentForm: z.string().optional(),
+    /** Higher-order things: hooks used, libraries imported. */
+    hooksUsed: z.array(z.string()).default([]),
+    importedLibraries: z.array(z.string()).default([]),
+  })
+  .strict();
+export type ComponentMetadata = z.infer<typeof ComponentMetadataSchema>;
+
+export const ApiMetadataSchema = z
+  .object({
+    method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'WS']),
+    path: z.string(),
+    /** JSON-stringified Zod schema description (best-effort). */
+    requestSchemaSummary: z.string().optional(),
+    responseSchemaSummary: z.string().optional(),
+    authRequired: z.boolean().default(false),
+    middlewareChain: z.array(z.string()).default([]),
+    /** Hono app the route is registered on (e.g. 'orchestrator'). */
+    appName: z.string().optional(),
+  })
+  .strict();
+export type ApiMetadata = z.infer<typeof ApiMetadataSchema>;
+
+export const SchemaMetadataSchema = z
+  .object({
+    tableName: z.string(),
+    columns: z
+      .array(
+        z.object({
+          name: z.string(),
+          type: z.string(),
+          nullable: z.boolean().default(true),
+          defaultValue: z.string().optional(),
+          isPrimaryKey: z.boolean().default(false),
+          isUnique: z.boolean().default(false),
+        }),
+      )
+      .default([]),
+    indexes: z
+      .array(
+        z.object({
+          name: z.string(),
+          columns: z.array(z.string()),
+          unique: z.boolean().default(false),
+        }),
+      )
+      .default([]),
+    foreignKeys: z
+      .array(
+        z.object({
+          column: z.string(),
+          referencesTable: z.string(),
+          referencesColumn: z.string(),
+        }),
+      )
+      .default([]),
+  })
+  .strict();
+export type SchemaMetadata = z.infer<typeof SchemaMetadataSchema>;
+
+export const MigrationMetadataSchema = z
+  .object({
+    /** Migration filename, e.g. '0028_feature_registry.sql'. */
+    fileName: z.string(),
+    /** Sequence number parsed from the filename prefix. */
+    sequenceNumber: z.number().int().nonnegative(),
+    /** SHA-256 of the SQL contents. */
+    checksum: z.string(),
+    /** Tables / indexes touched (best-effort SQL parse). */
+    affectsTables: z.array(z.string()).default([]),
+    /** True if `_journal.json` lists it as applied. */
+    isApplied: z.boolean().default(false),
+  })
+  .strict();
+export type MigrationMetadata = z.infer<typeof MigrationMetadataSchema>;
+
+export const PackageMetadataSchema = z
+  .object({
+    /** semver string from package.json. */
+    version: z.string(),
+    /** True if internal (workspace:* or @chiefaia/*). */
+    internal: z.boolean().default(false),
+    /** Direct dependencies. */
+    dependencies: z.array(z.string()).default([]),
+    /** Direct devDependencies. */
+    devDependencies: z.array(z.string()).default([]),
+    /** Apps + packages that depend on this one (reverse-deps). */
+    consumers: z.array(z.string()).default([]),
+    /** Whether `private:true` in package.json. */
+    isPrivate: z.boolean().default(false),
+    /** package.json `main` / `types` entry. */
+    entryPoint: z.string().optional(),
+  })
+  .strict();
+export type PackageMetadata = z.infer<typeof PackageMetadataSchema>;
+
+export const ServiceMetadataSchema = z
+  .object({
+    /** Hono app name (e.g. 'orchestrator', 'executor'). */
+    appName: z.string().optional(),
+    /** Listening port (if HTTP). */
+    port: z.number().int().positive().optional(),
+    /** Routes exposed by the service (list of arch_artifacts.id). */
+    exposedApis: z.array(z.string()).default([]),
+    /** Schemas the service writes to. */
+    persistsToSchemas: z.array(z.string()).default([]),
+    /** Events the service emits. */
+    emitsEvents: z.array(z.string()).default([]),
+    /** Whether the service has a worker / background loop. */
+    hasBackgroundLoop: z.boolean().default(false),
+  })
+  .strict();
+export type ServiceMetadata = z.infer<typeof ServiceMetadataSchema>;
+
+export const ThemeMetadataSchema = z
+  .object({
+    /** Theme tokens: name → CSS value. */
+    tokens: z.record(z.string()).default({}),
+    /** Color palette names. */
+    palettes: z.array(z.string()).default([]),
+    /** Typography scale step names. */
+    typographySteps: z.array(z.string()).default([]),
+    /** True for light/dark base themes. */
+    isBaseTheme: z.boolean().default(false),
+  })
+  .strict();
+export type ThemeMetadata = z.infer<typeof ThemeMetadataSchema>;
+
+export const PluginMetadataSchema = z
+  .object({
+    /** Plugin kind (e.g. 'analytics', 'dev-inspector', 'cms'). */
+    pluginKind: z.string(),
+    /** Hooks/extension points it implements. */
+    extensionPoints: z.array(z.string()).default([]),
+    /** Sites that use the plugin. */
+    consumers: z.array(z.string()).default([]),
+  })
+  .strict();
+export type PluginMetadata = z.infer<typeof PluginMetadataSchema>;
+
+export const IntegrationMetadataSchema = z
+  .object({
+    /** Vendor (e.g. 'github', 'cloudflare', 'vault'). */
+    vendor: z.string(),
+    /** API surface used. */
+    apiSurface: z.array(z.string()).default([]),
+    /** Auth mechanism (e.g. 'oauth', 'pat', 'api-key', 'approle'). */
+    authMechanism: z.string().optional(),
+    /** Secret paths used (vault locators). */
+    secretPaths: z.array(z.string()).default([]),
+  })
+  .strict();
+export type IntegrationMetadata = z.infer<typeof IntegrationMetadataSchema>;
+
+export const DomainModuleMetadataSchema = z
+  .object({
+    /** DDD bounded-context name (e.g. 'auth', 'billing'). */
+    boundedContext: z.string(),
+    /** Components+services participating. */
+    participants: z.array(z.string()).default([]),
+    /** Upstream / downstream contexts. */
+    upstreamContexts: z.array(z.string()).default([]),
+    downstreamContexts: z.array(z.string()).default([]),
+  })
+  .strict();
+export type DomainModuleMetadata = z.infer<typeof DomainModuleMetadataSchema>;
+
+export const ObservabilitySignalMetadataSchema = z
+  .object({
+    /** 'log_stream' | 'metric' | 'trace' | 'alert' | 'dashboard'. */
+    signalKind: z.string(),
+    /** Event types / metric names emitted. */
+    emitterIds: z.array(z.string()).default([]),
+    /** Severity / threshold info. */
+    severity: z.string().optional(),
+  })
+  .strict();
+export type ObservabilitySignalMetadata = z.infer<typeof ObservabilitySignalMetadataSchema>;
+
+export const AdrMetadataSchema = z
+  .object({
+    status: z.enum(ADR_STATUSES),
+    decisionDate: z.string().optional(), // ISO yyyy-mm-dd
+    supersedes: z.array(z.string()).default([]),
+    supersededBy: z.string().optional(),
+    /** Artifacts the ADR governs. */
+    governs: z.array(z.string()).default([]),
+  })
+  .strict();
+export type AdrMetadata = z.infer<typeof AdrMetadataSchema>;
+
+// ─── Search-result schemas ──────────────────────────────────────────────────
+
+export const ArchSearchHitSchema = z
+  .object({
+    row: ArchArtifactRowSchema,
+    /** cosine similarity in [0, 1]. -1 if dense retrieval missed. */
+    scoreDense: z.number(),
+    /** BM25 normalized to [0, 1]. -1 if sparse retrieval missed. */
+    scoreSparse: z.number(),
+    /** Reciprocal-Rank-Fusion score; higher = better. */
+    scoreFused: z.number(),
+    matchType: z.enum(['dense', 'sparse', 'both']),
+  })
+  .strict();
+export type ArchSearchHit = z.infer<typeof ArchSearchHitSchema>;
+
+export const ArchSearchResultSchema = z
+  .object({
+    hits: z.array(ArchSearchHitSchema),
+    /** null iff hits is empty. */
+    topMatch: ArchSearchHitSchema.nullable(),
+    /** Cosine threshold actually used. */
+    thresholdUsed: z.number(),
+    /** Wall-clock ms for the full search call. */
+    latencyMs: z.number().nonnegative(),
+    /** Local-Ollama tokens. Always 0 in zero-Claude-token paths. */
+    embedderTokens: z.number().int().nonnegative(),
+    /** What kind(s) of artifact were searched. */
+    kindsSearched: z.array(z.enum(ARTIFACT_KINDS)).default([]),
+    /** Tech sub-domains the search was filtered by. */
+    techSubDomainsFiltered: z.array(TechSubDomainEnum).default([]),
+  })
+  .strict();
+export type ArchSearchResult = z.infer<typeof ArchSearchResultSchema>;
+
+// ─── Per-domain query options ────────────────────────────────────────────────
+
+export const ArchQueryOptsSchema = z
+  .object({
+    /** Free-form natural-language query (embedded for dense retrieval). */
+    query: z.string().min(1),
+    /** Restrict to specific artifact kinds. */
+    kinds: z.array(z.enum(ARTIFACT_KINDS)).optional(),
+    /** Restrict to specific tech sub-domains. */
+    techSubDomains: z.array(TechSubDomainEnum).optional(),
+    /** Restrict to specific projects. */
+    projects: z.array(ProjectSlugEnum).optional(),
+    /** Top-K hits to return. */
+    topK: z.number().int().positive().max(50).default(10),
+    /** Cosine threshold floor (drop hits below). */
+    minScore: z.number().min(0).max(1).default(0.5),
+  })
+  .strict();
+export type ArchQueryOpts = z.infer<typeof ArchQueryOptsSchema>;
+
+// ─── EA Agent integration: architecturalInstructions ─────────────────────────
+//
+// These are the structured outputs the EA Agent attaches to a story's ticket
+// template (see ARCH-006 ticket-template Zod schema extension). One per
+// (tech_sub_domain) the story touches.
+
+/**
+ * A single concrete instruction attached to a story by the EA Agent. It
+ * either:
+ *   - References an existing artifact ("use X at path Y"), or
+ *   - Specifies a new artifact to create ("create new component at path Z
+ *     with these props"), or
+ *   - Specifies an enhancement to an existing artifact ("extend API X with
+ *     a new field Y").
+ */
+export const ArchitecturalInstructionSchema = z
+  .object({
+    /** ID — so VAL-### can reference "instruction 3 missing detail". */
+    id: z.string().min(1),
+
+    /** Tech sub-domain this instruction targets. */
+    techSubDomain: TechSubDomainEnum,
+
+    /** What to do: reuse / enhance / create / no-op. */
+    action: z.enum(['reuse', 'enhance', 'create', 'no_op']),
+
+    /** Free-form one-line summary, e.g. "Use existing LeaderboardPage at
+     *  apps/site-pokerzeno/app/leaderboard/page.tsx". */
+    summary: z.string().min(1).max(500),
+
+    /** Concrete details (file paths, naming, props/spec, design-system
+     *  tier compliance, etc.). */
+    details: z.string().min(1).max(MAX_DESCRIPTION_LENGTH),
+
+    /** AKG artifact IDs referenced by this instruction. Empty for `create`
+     *  with no peer to reference. */
+    referencedArtifactIds: z.array(z.string()).default([]),
+
+    /** For `action=create`: where the new artifact should live. */
+    proposedPath: z.string().optional(),
+
+    /** For `action=create`: signature/spec the developer agent should
+     *  implement. Drives test-design + implementation. */
+    proposedSignature: z.string().optional(),
+
+    /** For `action=enhance`: what existing artifact + what delta. */
+    enhancementOfArtifactId: z.string().optional(),
+
+    /** Confidence in the AKG match (1.0 = perfect; <0.85 = ambiguous). */
+    confidence: z.number().min(0).max(1).default(1.0),
+  })
+  .strict();
+export type ArchitecturalInstruction = z.infer<typeof ArchitecturalInstructionSchema>;
+
+/**
+ * The list attached to a story by the EA Agent. ARCH-006 extends the
+ * ticket-template Zod schema to carry this; the dashboard renders it; the
+ * developer agent reads it; the validator (VAL-###) checks each
+ * referenced artifact exists.
+ */
+export const ArchitecturalInstructionsSchema = z.array(ArchitecturalInstructionSchema);
+export type ArchitecturalInstructions = z.infer<typeof ArchitecturalInstructionsSchema>;

--- a/packages/architecture-registry/tests/dedup-key.test.ts
+++ b/packages/architecture-registry/tests/dedup-key.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeArtifactDedupKey,
+  computeEdgeDedupKey,
+} from '../src';
+
+describe('computeArtifactDedupKey', () => {
+  it('returns a 64-char sha256 hex string', () => {
+    const k = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'component',
+      name: 'PromptList',
+      entryPath: 'apps/dashboard/components/prompt-list.tsx',
+    });
+    expect(k).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is stable across whitespace + casing', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'component',
+      name: 'PromptList',
+      entryPath: 'apps/dashboard/components/prompt-list.tsx',
+    });
+    const b = computeArtifactDedupKey({
+      project: ' Caia ',
+      kind: 'component',
+      name: 'promptlist  ',
+      entryPath: '   APPS/dashboard/components/prompt-list.tsx ',
+    });
+    expect(a).toBe(b);
+  });
+
+  it('locator preference: routeSignature beats other locators', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'api',
+      name: 'leaderboard',
+      routeSignature: 'GET /api/leaderboard',
+      entryPath: 'apps/orchestrator/src/api/routes/leaderboard.ts',
+    });
+    const b = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'api',
+      name: 'leaderboard',
+      routeSignature: 'GET /api/leaderboard',
+      entryPath: 'somewhere/else.ts', // ignored — route wins
+    });
+    expect(a).toBe(b);
+  });
+
+  it('locator preference: tableName for schemas + migrations', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'schema',
+      name: 'arch_artifacts',
+      tableName: 'arch_artifacts',
+    });
+    const b = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'schema',
+      name: 'arch_artifacts',
+      tableName: 'arch_artifacts',
+      filePaths: ['apps/orchestrator/src/db/schema.ts'],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('different artifact kind → different key', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'component',
+      name: 'X',
+      entryPath: 'a.tsx',
+    });
+    const b = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'service',
+      name: 'X',
+      entryPath: 'a.tsx',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('different name → different key', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'component',
+      name: 'A',
+      entryPath: 'x.tsx',
+    });
+    const b = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'component',
+      name: 'B',
+      entryPath: 'x.tsx',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('different project → different key', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'component',
+      name: 'X',
+      entryPath: 'a.tsx',
+    });
+    const b = computeArtifactDedupKey({
+      project: 'pokerzeno',
+      kind: 'component',
+      name: 'X',
+      entryPath: 'a.tsx',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to filePaths join when no other locator present', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'domain_module',
+      name: 'auth',
+      filePaths: ['x.ts', 'y.ts'],
+    });
+    // Order independent.
+    const b = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'domain_module',
+      name: 'auth',
+      filePaths: ['y.ts', 'x.ts'],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('handles fully empty locators (conceptual artifacts)', () => {
+    const a = computeArtifactDedupKey({
+      project: 'caia',
+      kind: 'domain_module',
+      name: 'shared-context',
+    });
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('computeEdgeDedupKey', () => {
+  it('returns a 64-char sha256 hex', () => {
+    const k = computeEdgeDedupKey({
+      fromId: 'arch_x',
+      toId: 'arch_y',
+      relation: 'depends_on',
+    });
+    expect(k).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is direction-sensitive', () => {
+    const a = computeEdgeDedupKey({
+      fromId: 'arch_x',
+      toId: 'arch_y',
+      relation: 'depends_on',
+    });
+    const b = computeEdgeDedupKey({
+      fromId: 'arch_y',
+      toId: 'arch_x',
+      relation: 'depends_on',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('is relation-sensitive', () => {
+    const a = computeEdgeDedupKey({
+      fromId: 'arch_x',
+      toId: 'arch_y',
+      relation: 'depends_on',
+    });
+    const b = computeEdgeDedupKey({
+      fromId: 'arch_x',
+      toId: 'arch_y',
+      relation: 'documented_by',
+    });
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/architecture-registry/tests/schema.test.ts
+++ b/packages/architecture-registry/tests/schema.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ArchArtifactRowSchema,
+  ArchEdgeRowSchema,
+  ARTIFACT_KINDS,
+  EDGE_RELATIONS,
+  ARCH_REGISTRY_SOURCES,
+  ADR_STATUSES,
+  DEFAULT_EMBEDDING_DIM,
+  ComponentMetadataSchema,
+  ApiMetadataSchema,
+  SchemaMetadataSchema,
+  MigrationMetadataSchema,
+  PackageMetadataSchema,
+  ServiceMetadataSchema,
+  AdrMetadataSchema,
+  ArchitecturalInstructionSchema,
+  ArchQueryOptsSchema,
+  type ArchArtifactRow,
+  type ArchEdgeRow,
+} from '../src';
+
+const NOW = 1745812800000;
+
+function baseArtifact(over: Partial<ArchArtifactRow> = {}): ArchArtifactRow {
+  return ArchArtifactRowSchema.parse({
+    id: 'arch_a',
+    kind: 'component',
+    project: 'caia',
+    name: 'PromptList',
+    description: 'Renders a paginated list of prompts in the dashboard.',
+    keySignature: 'export function PromptList(props: { promptIds: string[] }): JSX.Element',
+    filePaths: ['apps/dashboard/components/prompt-list.tsx'],
+    entryPath: 'apps/dashboard/components/prompt-list.tsx',
+    techSubDomains: ['frontend', 'design-system'],
+    tags: ['dashboard'],
+    metadataJson: '{}',
+    source: 'ast_extract',
+    embeddingModel: 'nomic-embed-text',
+    embeddingDim: DEFAULT_EMBEDDING_DIM,
+    embeddingVersion: 'v1.5',
+    createdAt: NOW,
+    updatedAt: NOW,
+    dedupKey: 'a'.repeat(64),
+    ...over,
+  });
+}
+
+function baseEdge(over: Partial<ArchEdgeRow> = {}): ArchEdgeRow {
+  return ArchEdgeRowSchema.parse({
+    id: 'edge_a',
+    fromId: 'arch_x',
+    toId: 'arch_y',
+    relation: 'depends_on',
+    weight: 1.0,
+    metadataJson: '{}',
+    source: 'ast_extract',
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...over,
+  });
+}
+
+describe('ArchArtifactRowSchema', () => {
+  it('accepts a minimal valid row', () => {
+    expect(() => baseArtifact()).not.toThrow();
+  });
+
+  it('rejects unknown artifact kind', () => {
+    expect(() =>
+      ArchArtifactRowSchema.parse({
+        ...baseArtifact(),
+        kind: 'not_a_kind',
+      } as unknown),
+    ).toThrow();
+  });
+
+  it('rejects unknown project slug', () => {
+    expect(() =>
+      ArchArtifactRowSchema.parse({
+        ...baseArtifact(),
+        project: 'martian-saas',
+      } as unknown),
+    ).toThrow();
+  });
+
+  it('rejects unknown tech_sub_domain', () => {
+    expect(() => baseArtifact({ techSubDomains: ['quantum'] as unknown as never })).toThrow();
+  });
+
+  it('rejects unknown source', () => {
+    expect(() =>
+      ArchArtifactRowSchema.parse({
+        ...baseArtifact(),
+        source: 'time-traveler',
+      } as unknown),
+    ).toThrow();
+  });
+
+  it('rejects unknown design_system_tier', () => {
+    expect(() => baseArtifact({ designSystemTier: 'galactic' as unknown as never })).toThrow();
+  });
+
+  it('enforces non-empty name + description', () => {
+    expect(() => baseArtifact({ name: '' })).toThrow();
+    expect(() => baseArtifact({ description: '' })).toThrow();
+  });
+
+  it('enforces dedup_key length window', () => {
+    expect(() => baseArtifact({ dedupKey: 'short' })).toThrow();
+    expect(() => baseArtifact({ dedupKey: 'a'.repeat(120) })).toThrow();
+  });
+
+  it('caps file_paths array at 50 entries', () => {
+    const tooMany = Array.from({ length: 51 }, (_, i) => `f${i}.ts`);
+    expect(() => baseArtifact({ filePaths: tooMany })).toThrow();
+  });
+
+  it('exposes the canonical artifact-kind enum', () => {
+    expect(ARTIFACT_KINDS).toContain('component');
+    expect(ARTIFACT_KINDS).toContain('api');
+    expect(ARTIFACT_KINDS).toContain('schema');
+    expect(ARTIFACT_KINDS).toContain('adr');
+    expect(ARTIFACT_KINDS.length).toBeGreaterThanOrEqual(11);
+  });
+
+  it('exposes the source enum + edge relation enum', () => {
+    expect(ARCH_REGISTRY_SOURCES).toContain('ast_extract');
+    expect(EDGE_RELATIONS).toContain('depends_on');
+    expect(EDGE_RELATIONS).toContain('uses_component');
+    expect(EDGE_RELATIONS).toContain('persists_to');
+    expect(ADR_STATUSES).toContain('accepted');
+  });
+
+  it('provides defaults for empty/optional fields', () => {
+    const row = baseArtifact();
+    expect(row.tags).toEqual(['dashboard']);
+    const minimal = ArchArtifactRowSchema.parse({
+      id: 'arch_b',
+      kind: 'component',
+      project: 'caia',
+      name: 'X',
+      description: 'tiny',
+      source: 'ast_extract',
+      createdAt: NOW,
+      updatedAt: NOW,
+      dedupKey: 'b'.repeat(64),
+    });
+    expect(minimal.filePaths).toEqual([]);
+    expect(minimal.tags).toEqual([]);
+    expect(minimal.metadataJson).toBe('{}');
+    expect(minimal.embeddingDim).toBe(768);
+  });
+});
+
+describe('ArchEdgeRowSchema', () => {
+  it('accepts a minimal valid edge', () => {
+    expect(() => baseEdge()).not.toThrow();
+  });
+
+  it('rejects unknown relation', () => {
+    expect(() =>
+      ArchEdgeRowSchema.parse({
+        ...baseEdge(),
+        relation: 'mind-meld',
+      } as unknown),
+    ).toThrow();
+  });
+
+  it('rejects negative weight', () => {
+    expect(() => baseEdge({ weight: -0.1 })).toThrow();
+  });
+});
+
+describe('Per-kind metadata schemas', () => {
+  it('ComponentMetadataSchema accepts props + exports', () => {
+    const meta = ComponentMetadataSchema.parse({
+      props: [
+        { name: 'value', type: 'string', required: true },
+        { name: 'onChange', type: '(v: string) => void', required: false },
+      ],
+      exports: ['Button'],
+      isDefaultExport: true,
+      hooksUsed: ['useState'],
+      importedLibraries: ['react'],
+    });
+    expect(meta.props).toHaveLength(2);
+    expect(meta.exports).toEqual(['Button']);
+  });
+
+  it('ApiMetadataSchema enforces method enum', () => {
+    expect(() =>
+      ApiMetadataSchema.parse({
+        method: 'GET',
+        path: '/api/leaderboard',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      ApiMetadataSchema.parse({
+        method: 'TELEPORT',
+        path: '/api/x',
+      } as unknown),
+    ).toThrow();
+  });
+
+  it('SchemaMetadataSchema collects columns + indexes', () => {
+    const meta = SchemaMetadataSchema.parse({
+      tableName: 'arch_artifacts',
+      columns: [
+        { name: 'id', type: 'TEXT', isPrimaryKey: true, nullable: false },
+        { name: 'kind', type: 'TEXT', nullable: false },
+      ],
+      indexes: [{ name: 'arch_artifacts_kind_idx', columns: ['kind'], unique: false }],
+    });
+    expect(meta.columns).toHaveLength(2);
+    expect(meta.indexes[0]!.columns).toEqual(['kind']);
+  });
+
+  it('MigrationMetadataSchema requires sequence number + checksum', () => {
+    const meta = MigrationMetadataSchema.parse({
+      fileName: '0030_architecture_registry.sql',
+      sequenceNumber: 30,
+      checksum: 'a'.repeat(64),
+      affectsTables: ['arch_artifacts', 'arch_edges'],
+      isApplied: false,
+    });
+    expect(meta.sequenceNumber).toBe(30);
+  });
+
+  it('PackageMetadataSchema captures internal/external split', () => {
+    const meta = PackageMetadataSchema.parse({
+      version: '0.1.0',
+      internal: true,
+      dependencies: ['zod'],
+      consumers: ['orchestrator'],
+      isPrivate: true,
+    });
+    expect(meta.internal).toBe(true);
+    expect(meta.consumers).toEqual(['orchestrator']);
+  });
+
+  it('ServiceMetadataSchema lists exposed APIs', () => {
+    const meta = ServiceMetadataSchema.parse({
+      appName: 'orchestrator',
+      port: 7776,
+      exposedApis: ['arch_api1', 'arch_api2'],
+      hasBackgroundLoop: true,
+    });
+    expect(meta.exposedApis).toEqual(['arch_api1', 'arch_api2']);
+  });
+
+  it('AdrMetadataSchema enforces status enum', () => {
+    expect(() =>
+      AdrMetadataSchema.parse({ status: 'accepted', decisionDate: '2026-04-28' }),
+    ).not.toThrow();
+    expect(() =>
+      AdrMetadataSchema.parse({ status: 'time-locked' } as unknown),
+    ).toThrow();
+  });
+});
+
+describe('ArchitecturalInstructionSchema', () => {
+  it('accepts a reuse instruction', () => {
+    const i = ArchitecturalInstructionSchema.parse({
+      id: 'ai_1',
+      techSubDomain: 'frontend',
+      action: 'reuse',
+      summary: 'Use existing PromptList component',
+      details: 'apps/dashboard/components/prompt-list.tsx — accepts promptIds[].',
+      referencedArtifactIds: ['arch_a'],
+      confidence: 0.92,
+    });
+    expect(i.action).toBe('reuse');
+    expect(i.referencedArtifactIds).toEqual(['arch_a']);
+  });
+
+  it('accepts a create instruction', () => {
+    const i = ArchitecturalInstructionSchema.parse({
+      id: 'ai_2',
+      techSubDomain: 'backend',
+      action: 'create',
+      summary: 'Create new arch search API',
+      details: 'POST /api/architecture/search → returns ranked AKG hits.',
+      proposedPath: 'apps/orchestrator/src/api/routes/architecture.ts',
+      proposedSignature: 'POST /api/architecture/search; body: ArchQueryOpts; response: ArchSearchResult',
+      confidence: 1.0,
+    });
+    expect(i.action).toBe('create');
+    expect(i.proposedPath).toContain('architecture.ts');
+  });
+
+  it('accepts an enhance instruction', () => {
+    const i = ArchitecturalInstructionSchema.parse({
+      id: 'ai_3',
+      techSubDomain: 'database',
+      action: 'enhance',
+      summary: 'Add `arch_referenced_artifact_ids` column to stories',
+      details: 'Migration: ALTER TABLE stories ADD COLUMN arch_referenced_artifact_ids TEXT.',
+      enhancementOfArtifactId: 'arch_stories_table',
+      confidence: 0.87,
+    });
+    expect(i.action).toBe('enhance');
+  });
+
+  it('rejects out-of-range confidence', () => {
+    expect(() =>
+      ArchitecturalInstructionSchema.parse({
+        id: 'ai_x',
+        techSubDomain: 'frontend',
+        action: 'reuse',
+        summary: 'x',
+        details: 'y',
+        confidence: 1.2,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('ArchQueryOptsSchema', () => {
+  it('accepts a minimal query', () => {
+    const opts = ArchQueryOptsSchema.parse({ query: 'leaderboard' });
+    expect(opts.topK).toBe(10);
+    expect(opts.minScore).toBe(0.5);
+  });
+
+  it('caps topK at 50', () => {
+    expect(() => ArchQueryOptsSchema.parse({ query: 'x', topK: 100 })).toThrow();
+  });
+
+  it('rejects empty query', () => {
+    expect(() => ArchQueryOptsSchema.parse({ query: '' })).toThrow();
+  });
+});

--- a/packages/architecture-registry/tsconfig.json
+++ b/packages/architecture-registry/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/architecture-registry/vitest.config.ts
+++ b/packages/architecture-registry/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 30000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,40 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)
 
+  packages/architecture-registry:
+    dependencies:
+      '@chiefaia/feature-registry':
+        specifier: workspace:*
+        version: link:../feature-registry
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../ticket-template
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.9.0
+      nanoid:
+        specifier: ^3.3.7
+        version: 3.3.11
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/backend-core:
     dependencies:
       '@supabase/auth-helpers-nextjs':


### PR DESCRIPTION
## ARCH-001 — Architecture Knowledge Graph foundation

First PR in the Architecture Registry / Knowledge Graph track. Bootstraps the package, Zod schemas, dedup keys, and migration 0030. No runtime extraction logic yet — that comes in ARCH-002 (ts-morph AST extractor) and ARCH-003 (drizzle introspect + package scanner).

### What ships

- New package: `@chiefaia/architecture-registry` (workspace, private)
- Migration 0030 — `arch_artifacts` + `arch_edges` + `arch_extract_runs`
- Drizzle schema additions in `apps/orchestrator/src/db/schema.ts`
- Zod schemas:
  - `ArchArtifactRowSchema` (12 artifact kinds, 10 edge relations)
  - `ArchEdgeRowSchema`
  - 12 per-kind metadata payload schemas
  - `ArchitecturalInstructionSchema` (consumed by ARCH-006 EA Agent integration)
  - `ArchSearchHitSchema` / `ArchSearchResultSchema` (consumed by ARCH-005 query API)
- `computeArtifactDedupKey` + `computeEdgeDedupKey` — idempotent SHA-256 dedup keys

### Why this shape

EA Agent (ARCH-006) needs per-domain technical implementation instructions on every story. To produce concrete instructions referencing real artifacts, it needs a structured, embeddings-augmented index of every architectural building block in the codebase. This package is the schema layer for that index.

Sister track to `@chiefaia/feature-registry`:
- FREG = user-visible features (story-granularity)
- AKG = architectural artifacts (component/service/schema-granularity)
- Both share sqlite-vec + nomic-embed-text infrastructure (wired in ARCH-004)

Every row tags one or more `tech_sub_domain` values from the canonical BUCKET-001 taxonomy so per-domain queries land on coherent slices.

### Pipeline-order coordination

Per Prakash's 2026-04-28 directive, EA now runs **after BA, before Validator**:
```
prompt → PO → BA → EA (with AKG) → Validator → Test-Design → Task Manager
```
The `ea_classified` → `ea_decomposed` rename + the `PIPELINE_STAGE_ORDER` reorder land in ARCH-006 (EA Agent integration), where it's most cohesive.

### DoD compliance

- [x] Unit tests: 41 passing (schema invariants, enum exhaustion, metadata payloads, dedup-key stability + sensitivity)
- [x] Typecheck: `pnpm -r typecheck` green
- [x] Build: `pnpm -r build` green
- [x] No new vulnerabilities introduced
- [x] Documentation: package README + reference to `~/Documents/projects/reports/architecture-registry-architecture-2026-04-28.md`
- [x] Memory updated (architecture_registry_directive.md tracks ARCH-### progression)

### Coordination

- FREG-### track: shared sqlite-vec + Ollama embed pipeline; no duplicate vector store. Wired in ARCH-004.
- VAL-### track: Validator can now check that EA's `architecturalInstructions[]` reference real `arch_artifacts.id` rows.
- TEST-### track: Test-Design Agent can scope tests to AKG-identified surfaces.
- BUCKET-### track: every AKG row tags `tech_sub_domain` from the canonical enum.

Closes ARCH-001.