### PR TITLE
refactor(feature-registry): extract generic bootstrapVecTable for ARCH coordination

### DIFF
--- a/packages/feature-registry/src/index.ts
+++ b/packages/feature-registry/src/index.ts
@@ -37,13 +37,14 @@ export { computeDedupKey } from './dedup-key';
 export type { DedupKeyInput } from './dedup-key';
 
 export {
+  bootstrapVecTable,
   bootstrapVectorTables,
   upsertRegistryRow,
   buildFtsText,
   queryDense,
   querySparse,
 } from './storage';
-export type { DenseHit, SparseHit, QueryOpts } from './storage';
+export type { DenseHit, SparseHit, QueryOpts, VecTableOpts } from './storage';
 
 export {
   OllamaEmbeddingClient,

--- a/packages/feature-registry/src/storage.ts
+++ b/packages/feature-registry/src/storage.ts
@@ -38,40 +38,71 @@ import {
  * exist. Returns the dim used so callers can assert the registry's
  * embeddingDim matches.
  */
+/**
+ * Generic helper — create a sqlite-vec `vec0` + FTS5 pair scoped to the
+ * given table prefix. Idempotent; safe to call once per process per
+ * connection. Used by both feature_registry (this package) and ARCH-###
+ * (architecture_registry — coordinates with FREG to share infra).
+ *
+ * Created tables:
+ *   <prefix>_vec   — vec0 virtual table; embedding FLOAT[dim]
+ *   <prefix>_fts   — FTS5 virtual table; text column + porter tokenizer
+ *
+ * Returns the dim used + the live sqlite-vec version (proof the
+ * extension is wired correctly).
+ */
+export interface VecTableOpts {
+  /** Prefix for the two virtual tables. Required; no default to prevent collisions. */
+  tablePrefix: string;
+  /** Embedding dimensionality. Must match the EmbeddingClient's modelDim. */
+  dim: number;
+  /** FTS5 tokenizer. Default 'porter' (English-aware stemming). */
+  ftsTokenize?: string;
+}
+
+export function bootstrapVecTable(
+  db: Database.Database,
+  opts: VecTableOpts,
+): { dim: number; vecVersion: string; tablePrefix: string } {
+  sqliteVec.load(db);
+  const versionRow = db.prepare('SELECT vec_version() AS v').get() as { v: string };
+
+  const vecTable = `${opts.tablePrefix}_vec`;
+  const ftsTable = `${opts.tablePrefix}_fts`;
+  const tokenize = opts.ftsTokenize ?? 'porter';
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS ${vecTable} USING vec0(
+      id TEXT PRIMARY KEY,
+      embedding FLOAT[${opts.dim}]
+    );
+  `);
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS ${ftsTable} USING fts5(
+      id UNINDEXED,
+      text,
+      tokenize = '${tokenize}'
+    );
+  `);
+
+  return { dim: opts.dim, vecVersion: versionRow.v, tablePrefix: opts.tablePrefix };
+}
+
+/**
+ * Feature Registry's vec0 + FTS5 setup. Thin wrapper around
+ * bootstrapVecTable; preserved for backwards compatibility with all
+ * existing FREG callers.
+ */
 export function bootstrapVectorTables(
   db: Database.Database,
   dim: number = DEFAULT_EMBEDDING_DIM,
 ): { dim: number; vecVersion: string } {
-  // Idempotent — sqlite-vec's load() is no-op if already loaded.
-  sqliteVec.load(db);
-
-  // Confirm vec_version() is callable (proves the extension is wired).
-  const versionRow = db.prepare('SELECT vec_version() AS v').get() as { v: string };
-
-  // vec0 virtual table for embeddings.
-  // We use BLOB-style FLOAT[N] storage: a single row per registry id
-  // mirroring feature_registry.id, with a fixed-dim embedding vector.
-  db.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS feature_registry_vec USING vec0(
-      id TEXT PRIMARY KEY,
-      embedding FLOAT[${dim}]
-    );
-  `);
-
-  // FTS5 virtual table for BM25 keyword search. We index a single
-  // `text` column that callers concatenate from name + description +
-  // route_path + component_name + tags so BM25 weights all locator
-  // hints equivalently. `id` is UNINDEXED so it round-trips back to the
-  // main table without participating in the inverted index.
-  db.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS feature_registry_fts USING fts5(
-      id UNINDEXED,
-      text,
-      tokenize = 'porter'
-    );
-  `);
-
-  return { dim, vecVersion: versionRow.v };
+  const { dim: d, vecVersion } = bootstrapVecTable(db, {
+    tablePrefix: 'feature_registry',
+    dim,
+  });
+  return { dim: d, vecVersion };
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/feature-registry/tests/bootstrapVecTable.test.ts
+++ b/packages/feature-registry/tests/bootstrapVecTable.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Test the generic bootstrapVecTable() helper. ARCH-### will use this
+ * to spin its own arch_registry_vec without copy-paste from FREG.
+ */
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { bootstrapVecTable, bootstrapVectorTables } from '../src';
+
+describe('bootstrapVecTable — generic helper for ARCH coordination', () => {
+  it('creates vec0 + fts5 with the configured prefix', () => {
+    const db = new Database(':memory:');
+    const result = bootstrapVecTable(db, { tablePrefix: 'arch_registry', dim: 64 });
+
+    expect(result.tablePrefix).toBe('arch_registry');
+    expect(result.dim).toBe(64);
+    expect(result.vecVersion).toMatch(/^v\d+\.\d+/);
+
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' OR type='virtual'")
+      .all() as Array<{ name: string }>;
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('arch_registry_vec');
+    expect(names).toContain('arch_registry_fts');
+    // Should NOT have created the feature_registry_* variants.
+    expect(names).not.toContain('feature_registry_vec');
+  });
+
+  it('is idempotent — second call is a no-op', () => {
+    const db = new Database(':memory:');
+    bootstrapVecTable(db, { tablePrefix: 'thing', dim: 32 });
+    expect(() =>
+      bootstrapVecTable(db, { tablePrefix: 'thing', dim: 32 }),
+    ).not.toThrow();
+  });
+
+  it('coexists with the legacy bootstrapVectorTables (feature_registry_*)', () => {
+    const db = new Database(':memory:');
+    bootstrapVectorTables(db, 768); // FREG default
+    bootstrapVecTable(db, { tablePrefix: 'arch_registry', dim: 64 });
+
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' OR type='virtual'")
+      .all() as Array<{ name: string }>;
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('feature_registry_vec');
+    expect(names).toContain('feature_registry_fts');
+    expect(names).toContain('arch_registry_vec');
+    expect(names).toContain('arch_registry_fts');
+  });
+
+  it('respects custom ftsTokenize', () => {
+    const db = new Database(':memory:');
+    bootstrapVecTable(db, {
+      tablePrefix: 'unicode_test',
+      dim: 32,
+      ftsTokenize: 'unicode61',
+    });
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' OR type='virtual'")
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name)).toContain('unicode_test_fts');
+  });
+});


### PR DESCRIPTION
## Summary

Per Prakash's pipeline-order correction (2026-04-28): the ARCH-### track (Architecture Registry / AKG) reuses the same sqlite-vec + nomic-embed-text infrastructure FREG ships. Extracting a generic helper so ARCH can spin its own `arch_registry_vec` + `arch_registry_fts` virtual tables without copy-paste from FREG.

## What ships

- **New public export:** `bootstrapVecTable(db, { tablePrefix, dim, ftsTokenize? })` — idempotent CREATE-IF-NOT-EXISTS for `<prefix>_vec` (sqlite-vec vec0) + `<prefix>_fts` (FTS5)
- `bootstrapVectorTables(db, dim)` is now a thin wrapper around `bootstrapVecTable({ tablePrefix: 'feature_registry', dim })` — preserves the existing public API + all current FREG callers continue to work unchanged
- New public type export: `VecTableOpts`

## How ARCH uses it

```ts
import { bootstrapVecTable, OllamaEmbeddingClient } from '@chiefaia/feature-registry';

bootstrapVecTable(sqlite, { tablePrefix: 'arch_registry', dim: 768 });
const embedder = new OllamaEmbeddingClient(); // shared
// then upsert into arch_registry_vec + arch_registry_fts directly
```

## Tests

- 4 new vitest cases — prefix-scoped creation + idempotency + coexistence with the legacy call + custom `ftsTokenize`
- All **42 tests** green (38 prior + 4 new)
- Typecheck clean

## Coordination

- `EmbeddingClient` interface is already generic — ARCH consumes `OllamaEmbeddingClient` (or LAI's eventual shared service) via the same API
- FREG's higher-level helpers (`queryDense` / `querySparse` / `search`) are still `feature_registry_*` hardcoded — easy follow-up to parameterize when ARCH needs them; for now ARCH can write its own thin queries against `arch_registry_vec` / `arch_registry_fts`

## Risk

Zero. Pure refactor — no behavior change. `bootstrapVectorTables(db, dim)` is preserved verbatim and now delegates internally.