### PR TITLE
feat(architecture-registry): ts-morph AST extractors for components/APIs/services (ARCH-002)

### DIFF
--- a/packages/architecture-registry/package.json
+++ b/packages/architecture-registry/package.json
@@ -15,7 +15,8 @@
     "nanoid": "^3.3.7",
     "zod": "^3.23.8",
     "better-sqlite3": "^12.6.2",
-    "sqlite-vec": "^0.1.9"
+    "sqlite-vec": "^0.1.9",
+    "ts-morph": "^21.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/architecture-registry/src/extractors/api-extractor.ts
+++ b/packages/architecture-registry/src/extractors/api-extractor.ts
@@ -1,0 +1,228 @@
+/**
+ * @chiefaia/architecture-registry — Hono route extractor (ARCH-002)
+ *
+ * Walks TypeScript source files registering Hono routes (`app.get('/...')`,
+ * `app.post('/...')`, etc.) and emits one `arch_artifacts` row per route
+ * with `kind='api'`. Supports the canonical Hono pattern used in CAIA's
+ * orchestrator + executor + dashboard:
+ *
+ *   const app = new Hono();
+ *   app.get('/observability/health', (c) => { ... });
+ *   app.post('/events', zValidator('json', EventSchema), async (c) => { ... });
+ *
+ * Also covers `app.route('/sub', subApp)` mounts (recursive) and the
+ * @hono/zod-openapi `createRoute` builder when present.
+ *
+ * Auth detection: if the route's middleware chain mentions one of the
+ * known auth-middleware identifiers (`requireAuth`, `withAuth`,
+ * `bearerAuth`, etc.), `authRequired = true`.
+ */
+
+import { nanoid } from 'nanoid';
+import {
+  Project,
+  ScriptKind,
+  SyntaxKind,
+  type SourceFile,
+  type CallExpression,
+} from 'ts-morph';
+import {
+  ArchArtifactRowSchema,
+  ApiMetadataSchema,
+  type ArchArtifactRow,
+  type ApiMetadata,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_VERSION,
+} from '../schema';
+import { computeArtifactDedupKey } from '../dedup-key';
+import type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
+import { sha256 } from './utils';
+
+const HONO_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'all']);
+
+const AUTH_MIDDLEWARE_NAMES = [
+  'requireAuth',
+  'withAuth',
+  'bearerAuth',
+  'jwtAuth',
+  'sessionAuth',
+  'authGuard',
+];
+
+function isAuthMiddleware(text: string): boolean {
+  return AUTH_MIDDLEWARE_NAMES.some((n) => text.includes(n));
+}
+
+interface RouteCandidate {
+  method: string;
+  path: string;
+  middlewareChain: string[];
+  authRequired: boolean;
+  signatureText: string;
+  appName?: string;
+  jsDocSummary?: string;
+}
+
+function inspectCallExpression(call: CallExpression): RouteCandidate | undefined {
+  const expr = call.getExpression();
+  if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) return undefined;
+  const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+  const methodName = propAccess.getName();
+  if (!HONO_METHODS.has(methodName)) return undefined;
+
+  const args = call.getArguments();
+  if (args.length < 2) return undefined; // need at least path + handler
+
+  const firstArg = args[0]!;
+  if (firstArg.getKind() !== SyntaxKind.StringLiteral) return undefined;
+  const path = firstArg.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue();
+
+  // Middleware chain: every arg between path and final handler.
+  const middlewareChain: string[] = [];
+  for (let i = 1; i < args.length - 1; i++) {
+    const arg = args[i]!;
+    const text = arg.getText();
+    middlewareChain.push(text.length > 80 ? `${text.slice(0, 80)}…` : text);
+  }
+  const authRequired = middlewareChain.some(isAuthMiddleware);
+
+  // App name: text of the receiver expression (e.g. 'app', 'router', 'subApp').
+  const receiver = propAccess.getExpression().getText();
+
+  return {
+    method: methodName.toUpperCase(),
+    path,
+    middlewareChain,
+    authRequired,
+    signatureText: call.getText().split('\n').slice(0, 3).join('\n'),
+    appName: receiver,
+  };
+}
+
+export function extractApisFromProject(
+  project: Project,
+  sourceFiles: SourceFile[],
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const result: ExtractionResult = { artifacts: [], edges: [], warnings: [] };
+  const newId = opts.newId ?? ((p) => `${p}_${nanoid(12)}`);
+
+  for (const sf of sourceFiles) {
+    const filePath = relativize(opts.repoRoot, sf.getFilePath());
+    const fileText = sf.getFullText();
+    const contentHash = sha256(fileText);
+
+    // Quick bail: if the file doesn't import anything Hono-shaped, skip it.
+    const importText = sf.getImportDeclarations().map((i) => i.getModuleSpecifierValue()).join(' ');
+    const looksLikeHono = importText.includes('hono') || importText.includes('@hono');
+    // We still scan files that match *.routes.ts / *.api.ts even without imports,
+    // because Hono can be imported transitively.
+    const looksLikeRouteFile = /\.(routes|api)\.ts$/.test(filePath);
+    if (!looksLikeHono && !looksLikeRouteFile) continue;
+
+    const callExprs = sf.getDescendantsOfKind(SyntaxKind.CallExpression);
+    for (const call of callExprs) {
+      try {
+        const cand = inspectCallExpression(call);
+        if (!cand) continue;
+
+        const apiMeta: ApiMetadata = ApiMetadataSchema.parse({
+          method: cand.method as ApiMetadata['method'],
+          path: cand.path,
+          authRequired: cand.authRequired,
+          middlewareChain: cand.middlewareChain,
+          appName: cand.appName,
+        });
+
+        const routeSig = `${cand.method} ${cand.path}`;
+        const id = newId('arch');
+        const dedupKey = computeArtifactDedupKey({
+          project: opts.defaultProject,
+          kind: 'api',
+          name: routeSig,
+          routeSignature: routeSig,
+        });
+
+        const description = cand.jsDocSummary ?? `${routeSig} (${cand.appName ?? 'app'}, ${cand.middlewareChain.length} middleware)`;
+        const techSubDomains = inferTechSubDomainsForApi(filePath);
+
+        const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+          id,
+          kind: 'api',
+          project: opts.defaultProject,
+          name: routeSig,
+          description,
+          keySignature: cand.signatureText,
+          filePaths: [filePath],
+          entryPath: filePath,
+          routeSignature: routeSig,
+          techSubDomains,
+          tags: cand.authRequired ? ['auth-required'] : [],
+          metadataJson: JSON.stringify(apiMeta),
+          source: 'ast_extract',
+          contentHash,
+          extractedAtCommit: opts.extractedAtCommit,
+          embeddingModel: DEFAULT_EMBEDDING_MODEL,
+          embeddingDim: DEFAULT_EMBEDDING_DIM,
+          embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+          createdAt: opts.now,
+          updatedAt: opts.now,
+          dedupKey,
+        });
+        result.artifacts.push(artifact);
+      } catch (err) {
+        result.warnings.push(
+          `api-extractor: ${filePath}@${call.getStartLineNumber()} → ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+export function extractApisFromInMemorySources(
+  sources: Array<{ path: string; content: string }>,
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { strict: false, allowJs: true, target: 99 },
+  });
+  const sourceFiles: SourceFile[] = sources.map((s) =>
+    project.createSourceFile(s.path, s.content, { scriptKind: ScriptKind.TS }),
+  );
+  return extractApisFromProject(project, sourceFiles, opts);
+}
+
+export function extractApisFromFiles(
+  filePaths: string[],
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { strict: false, allowJs: true, target: 99 },
+  });
+  const sourceFiles: SourceFile[] = filePaths.map((fp) => project.addSourceFileAtPath(fp));
+  return extractApisFromProject(project, sourceFiles, opts);
+}
+
+function relativize(repoRoot: string, abs: string): string {
+  if (abs.startsWith(repoRoot)) {
+    let rel = abs.slice(repoRoot.length);
+    if (rel.startsWith('/')) rel = rel.slice(1);
+    return rel;
+  }
+  return abs;
+}
+
+function inferTechSubDomainsForApi(filePath: string): string[] {
+  const lower = filePath.toLowerCase();
+  const tags = new Set<string>(['bff']);
+  if (lower.includes('observability') || lower.includes('health')) tags.add('observability');
+  if (lower.includes('events')) tags.add('event-driven');
+  if (lower.includes('auth')) tags.add('auth');
+  if (lower.includes('metrics')) tags.add('observability');
+  return Array.from(tags);
+}

--- a/packages/architecture-registry/src/extractors/component-extractor.ts
+++ b/packages/architecture-registry/src/extractors/component-extractor.ts
@@ -1,0 +1,492 @@
+/**
+ * @chiefaia/architecture-registry — ts-morph component extractor (ARCH-002)
+ *
+ * Walks the TypeScript AST of one or more `.tsx` / `.ts` files and emits
+ * `arch_artifacts` rows for every React component plus dependency edges
+ * for the libraries / hooks / sibling components they import.
+ *
+ * Component detection rules:
+ *   - File must export a function/class whose return type is recognized
+ *     as JSX (best-effort: name starts with capital + returns JSX, or
+ *     `React.FC` / `React.FunctionComponent` typed).
+ *   - Default export OR named export both count.
+ *   - Component name = export name (or function/class name if anonymous
+ *     default export).
+ *
+ * Prop interface extraction:
+ *   - Inspects the first parameter type annotation; resolves type aliases
+ *     and interfaces; captures `name`, `type`, `required`, `default`.
+ *
+ * The extractor is a pure transformation: source files in → ExtractionResult
+ * out. No SQLite, no Ollama, no filesystem writes. Keeps it fast + unit
+ * testable.
+ */
+
+import { nanoid } from 'nanoid';
+import {
+  Project,
+  ScriptKind,
+  SyntaxKind,
+  type SourceFile,
+  type Node,
+  type FunctionDeclaration,
+  type VariableDeclaration,
+  type ClassDeclaration,
+  type ParameterDeclaration,
+  type Type,
+} from 'ts-morph';
+import {
+  ArchArtifactRowSchema,
+  ArchEdgeRowSchema,
+  ComponentMetadataSchema,
+  type ArchArtifactRow,
+  type ArchEdgeRow,
+  type ComponentMetadata,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_VERSION,
+} from '../schema';
+import { computeArtifactDedupKey, computeEdgeDedupKey } from '../dedup-key';
+import type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
+import { sha256 } from './utils';
+
+// ─── Heuristics ──────────────────────────────────────────────────────────────
+
+/** Component-name pattern: PascalCase, ≥2 chars. */
+const COMPONENT_NAME_RE = /^[A-Z][A-Za-z0-9]*$/;
+
+const REACT_TYPE_PREFIXES = [
+  'React.FC',
+  'React.FunctionComponent',
+  'React.VoidFunctionComponent',
+  'FC<',
+  'FunctionComponent<',
+  'VoidFunctionComponent<',
+  'JSX.Element',
+  'ReactElement',
+  'ReactNode',
+];
+
+function isLikelyJsxReturn(returnType: string): boolean {
+  return REACT_TYPE_PREFIXES.some((p) => returnType.includes(p));
+}
+
+/** Returns true when a function body actually returns JSX (regex fallback for inferred types). */
+function bodyContainsJsx(body: Node | undefined): boolean {
+  if (!body) return false;
+  return (
+    body.getDescendantsOfKind(SyntaxKind.JsxElement).length > 0 ||
+    body.getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement).length > 0 ||
+    body.getDescendantsOfKind(SyntaxKind.JsxFragment).length > 0
+  );
+}
+
+// ─── Per-prop parsing ────────────────────────────────────────────────────────
+
+interface PropEntry {
+  name: string;
+  type: string;
+  required: boolean;
+  defaultValue?: string;
+  description?: string;
+}
+
+function extractPropsFromParam(param: ParameterDeclaration | undefined): PropEntry[] {
+  if (!param) return [];
+  const typeNode = param.getTypeNode();
+  if (!typeNode) {
+    // Try to use the param's resolved type (Type) instead.
+    return extractPropsFromType(param.getType());
+  }
+  // Inline literal type: `(props: { foo: string; bar?: number })`
+  if (typeNode.getKind() === SyntaxKind.TypeLiteral) {
+    const propsList: PropEntry[] = [];
+    typeNode.forEachChild((c) => {
+      if (c.getKind() === SyntaxKind.PropertySignature) {
+        const sig = c.asKindOrThrow(SyntaxKind.PropertySignature);
+        propsList.push({
+          name: sig.getName(),
+          type: sig.getTypeNode()?.getText() ?? 'unknown',
+          required: !sig.hasQuestionToken(),
+        });
+      }
+    });
+    return propsList;
+  }
+  // Reference type: `(props: ButtonProps)` — resolve via Type and walk.
+  return extractPropsFromType(param.getType());
+}
+
+function extractPropsFromType(type: Type): PropEntry[] {
+  try {
+    return type.getProperties().map((p) => {
+      const decl = p.getDeclarations()[0];
+      const propType = decl ? p.getTypeAtLocation(decl).getText(decl) : 'unknown';
+      const optional = p.isOptional();
+      return {
+        name: p.getName(),
+        type: propType,
+        required: !optional,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ─── Hooks + library scan ────────────────────────────────────────────────────
+
+const REACT_HOOK_RE = /\buse[A-Z][A-Za-z0-9]*/g;
+
+function collectHooksUsed(body: Node | undefined): string[] {
+  if (!body) return [];
+  const text = body.getText();
+  const matches = text.match(REACT_HOOK_RE) ?? [];
+  return Array.from(new Set(matches));
+}
+
+function collectImportedLibraries(sf: SourceFile): string[] {
+  const libs = new Set<string>();
+  for (const imp of sf.getImportDeclarations()) {
+    const ms = imp.getModuleSpecifierValue();
+    if (ms.startsWith('.') || ms.startsWith('/')) continue; // local
+    libs.add(ms);
+  }
+  return Array.from(libs);
+}
+
+// ─── Per-file extraction ─────────────────────────────────────────────────────
+
+interface ComponentCandidate {
+  name: string;
+  isDefaultExport: boolean;
+  componentForm: 'function' | 'class' | 'arrow' | 'memo' | 'forwardRef';
+  paramNode?: ParameterDeclaration;
+  body?: Node;
+  jsDocSummary?: string;
+  signatureText: string;
+}
+
+function getJsDocSummary(node: Node): string | undefined {
+  const docs = (node as unknown as { getJsDocs?: () => Array<{ getDescription(): string }> }).getJsDocs?.() ?? [];
+  for (const d of docs) {
+    const desc = d.getDescription().trim();
+    if (desc.length > 0) return desc.split('\n')[0]!.trim();
+  }
+  return undefined;
+}
+
+function inspectFunctionDeclaration(fn: FunctionDeclaration): ComponentCandidate | undefined {
+  const name = fn.getName();
+  if (!name) return undefined;
+  if (!COMPONENT_NAME_RE.test(name)) return undefined;
+  const ret = fn.getReturnTypeNode()?.getText() ?? fn.getReturnType().getText();
+  if (!isLikelyJsxReturn(ret) && !bodyContainsJsx(fn.getBody())) return undefined;
+  return {
+    name,
+    isDefaultExport: fn.isDefaultExport(),
+    componentForm: 'function',
+    paramNode: fn.getParameters()[0],
+    body: fn.getBody(),
+    jsDocSummary: getJsDocSummary(fn),
+    signatureText: fn.getText().split('\n').slice(0, 4).join('\n'),
+  };
+}
+
+function inspectVariableDeclaration(v: VariableDeclaration): ComponentCandidate | undefined {
+  const name = v.getName();
+  if (!COMPONENT_NAME_RE.test(name)) return undefined;
+  const init = v.getInitializer();
+  if (!init) return undefined;
+  // Cover three cases: arrow function, React.memo(...), React.forwardRef(...)
+  const initText = init.getText();
+  let componentForm: ComponentCandidate['componentForm'] = 'arrow';
+  let inner: Node = init;
+  if (initText.startsWith('React.memo(') || initText.startsWith('memo(')) {
+    componentForm = 'memo';
+    const args = init.asKind(SyntaxKind.CallExpression)?.getArguments() ?? [];
+    if (args[0]) inner = args[0];
+  } else if (initText.startsWith('React.forwardRef(') || initText.startsWith('forwardRef(')) {
+    componentForm = 'forwardRef';
+    const args = init.asKind(SyntaxKind.CallExpression)?.getArguments() ?? [];
+    if (args[0]) inner = args[0];
+  }
+  // Now inner should be an arrow/function expression.
+  const arrow = inner.asKind(SyntaxKind.ArrowFunction) ?? inner.asKind(SyntaxKind.FunctionExpression);
+  if (!arrow) return undefined;
+  const ret = arrow.getReturnTypeNode()?.getText() ?? arrow.getReturnType().getText();
+  if (!isLikelyJsxReturn(ret) && !bodyContainsJsx(arrow.getBody())) return undefined;
+  const stmt = v.getVariableStatement();
+  return {
+    name,
+    isDefaultExport: stmt?.isDefaultExport() ?? false,
+    componentForm,
+    paramNode: arrow.getParameters()[0],
+    body: arrow.getBody(),
+    jsDocSummary: getJsDocSummary(stmt ?? v),
+    signatureText: v.getText().split('\n').slice(0, 4).join('\n'),
+  };
+}
+
+function inspectClassDeclaration(cl: ClassDeclaration): ComponentCandidate | undefined {
+  const name = cl.getName();
+  if (!name) return undefined;
+  if (!COMPONENT_NAME_RE.test(name)) return undefined;
+  const heritage = cl.getExtends();
+  if (!heritage) return undefined;
+  const ext = heritage.getText();
+  if (!ext.includes('Component') && !ext.includes('PureComponent')) return undefined;
+  const renderFn = cl.getMethod('render');
+  if (!renderFn) return undefined;
+  return {
+    name,
+    isDefaultExport: cl.isDefaultExport(),
+    componentForm: 'class',
+    paramNode: cl.getConstructors()[0]?.getParameters()[0], // props arg of constructor
+    body: renderFn.getBody(),
+    jsDocSummary: getJsDocSummary(cl),
+    signatureText: `class ${name} extends ${ext}`,
+  };
+}
+
+// ─── Public extractor ────────────────────────────────────────────────────────
+
+/**
+ * Extract React component artifacts from one or more source files.
+ *
+ * Caller passes a ts-morph `Project` (or we create one). Returns
+ * `arch_artifacts` rows + dependency edges for libraries imported.
+ */
+export function extractComponentsFromProject(
+  project: Project,
+  sourceFiles: SourceFile[],
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const result: ExtractionResult = { artifacts: [], edges: [], warnings: [] };
+  const newId = opts.newId ?? ((p) => `${p}_${nanoid(12)}`);
+
+  for (const sf of sourceFiles) {
+    const filePath = relativize(opts.repoRoot, sf.getFilePath());
+    const fileText = sf.getFullText();
+    const contentHash = sha256(fileText);
+
+    const candidates: ComponentCandidate[] = [];
+    for (const fn of sf.getFunctions()) {
+      const c = inspectFunctionDeclaration(fn);
+      if (c) candidates.push(c);
+    }
+    for (const v of sf.getVariableDeclarations()) {
+      const c = inspectVariableDeclaration(v);
+      if (c) candidates.push(c);
+    }
+    for (const cl of sf.getClasses()) {
+      const c = inspectClassDeclaration(cl);
+      if (c) candidates.push(c);
+    }
+
+    if (candidates.length === 0) continue;
+
+    const importedLibraries = collectImportedLibraries(sf);
+
+    for (const cand of candidates) {
+      try {
+        const props = extractPropsFromParam(cand.paramNode).map((p) => ({
+          name: p.name,
+          type: p.type,
+          required: p.required,
+          ...(p.defaultValue ? { defaultValue: p.defaultValue } : {}),
+          ...(p.description ? { description: p.description } : {}),
+        }));
+        const hooksUsed = collectHooksUsed(cand.body);
+
+        const componentMeta: ComponentMetadata = ComponentMetadataSchema.parse({
+          props,
+          exports: [cand.name],
+          jsDocSummary: cand.jsDocSummary,
+          isDefaultExport: cand.isDefaultExport,
+          componentForm: cand.componentForm,
+          hooksUsed,
+          importedLibraries,
+        });
+
+        const techSubDomains = inferTechSubDomainsForComponent(filePath);
+        const description = cand.jsDocSummary ?? synthesizeDescription(cand.name, props, importedLibraries);
+        const id = newId('arch');
+        const dedupKey = computeArtifactDedupKey({
+          project: opts.defaultProject,
+          kind: 'component',
+          name: cand.name,
+          entryPath: filePath,
+        });
+
+        const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+          id,
+          kind: 'component',
+          project: opts.defaultProject,
+          name: cand.name,
+          description,
+          keySignature: cand.signatureText,
+          filePaths: [filePath],
+          entryPath: filePath,
+          designSystemTier: inferDesignSystemTier(filePath, cand.name),
+          techSubDomains,
+          tags: [],
+          metadataJson: JSON.stringify(componentMeta),
+          source: 'ast_extract',
+          contentHash,
+          extractedAtCommit: opts.extractedAtCommit,
+          embeddingModel: DEFAULT_EMBEDDING_MODEL,
+          embeddingDim: DEFAULT_EMBEDDING_DIM,
+          embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+          createdAt: opts.now,
+          updatedAt: opts.now,
+          dedupKey,
+        });
+
+        result.artifacts.push(artifact);
+
+        // Edges: depends_on each imported library (we'll only emit the
+        // edge if the target package is also extracted by ARCH-003; for
+        // ARCH-002 we emit a placeholder edge keyed on the package name
+        // so callers can resolve it later).
+        for (const lib of importedLibraries) {
+          // Stable virtual id for placeholder package targets — safe to
+          // upsert idempotently. ARCH-003 (package scan) will later emit
+          // canonical artifacts with these same dedup keys; storage layer
+          // resolves by dedup key.
+          const placeholderTargetId = `pkg::${lib}`;
+          const edgeId = newId('edge');
+          const edge: ArchEdgeRow = ArchEdgeRowSchema.parse({
+            id: edgeId,
+            fromId: id,
+            toId: placeholderTargetId,
+            relation: 'depends_on',
+            weight: 1.0,
+            metadataJson: JSON.stringify({ kind: 'import' }),
+            source: 'ast_extract',
+            createdAt: opts.now,
+            updatedAt: opts.now,
+          });
+          // Stash dedupKey + targetPackageName into metadata for caller
+          // resolution.
+          edge.metadataJson = JSON.stringify({
+            kind: 'import',
+            targetPackageName: lib,
+            edgeDedupKey: computeEdgeDedupKey({
+              fromId: id,
+              toId: placeholderTargetId,
+              relation: 'depends_on',
+            }),
+          });
+          result.edges.push(edge);
+        }
+      } catch (err) {
+        result.warnings.push(
+          `component-extractor: ${filePath}#${cand.name} → ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convenience wrapper: build a ts-morph Project for a list of file paths
+ * and extract.
+ */
+export function extractComponentsFromFiles(
+  filePaths: string[],
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    useInMemoryFileSystem: false,
+    compilerOptions: {
+      jsx: 4 /* React */ as unknown as never, // Preserve = 1 ; React = 2 ; ReactJSX = 4
+      strict: false,
+      allowJs: true,
+      target: 99, // ESNext
+    },
+  });
+  const sourceFiles: SourceFile[] = [];
+  for (const fp of filePaths) {
+    sourceFiles.push(project.addSourceFileAtPath(fp));
+  }
+  return extractComponentsFromProject(project, sourceFiles, opts);
+}
+
+/**
+ * In-memory variant for unit tests.
+ */
+export function extractComponentsFromInMemorySources(
+  sources: Array<{ path: string; content: string }>,
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      jsx: 4 /* React */ as unknown as never,
+      strict: false,
+      allowJs: true,
+      target: 99,
+    },
+  });
+  const sourceFiles: SourceFile[] = sources.map((s) => {
+    const isTsx = s.path.endsWith('.tsx');
+    return project.createSourceFile(s.path, s.content, {
+      scriptKind: isTsx ? ScriptKind.TSX : ScriptKind.TS,
+    });
+  });
+  return extractComponentsFromProject(project, sourceFiles, opts);
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function relativize(repoRoot: string, abs: string): string {
+  if (abs.startsWith(repoRoot)) {
+    let rel = abs.slice(repoRoot.length);
+    if (rel.startsWith('/')) rel = rel.slice(1);
+    return rel;
+  }
+  return abs;
+}
+
+function inferTechSubDomainsForComponent(filePath: string): string[] {
+  const lower = filePath.toLowerCase();
+  const tags = new Set<string>(['frontend']);
+  if (lower.includes('design-system') || lower.includes('ui-primitives') || lower.includes('packages/ui')) {
+    tags.add('design-system');
+  }
+  if (lower.includes('a11y') || lower.includes('accessibility')) {
+    tags.add('accessibility');
+  }
+  if (lower.includes('analytics')) {
+    tags.add('web-analytics');
+  }
+  return Array.from(tags);
+}
+
+function inferDesignSystemTier(filePath: string, name: string): 'primitive' | 'pattern' | 'feature' | 'page' | undefined {
+  const lower = filePath.toLowerCase();
+  if (lower.includes('/pages/') || lower.endsWith('/page.tsx') || lower.endsWith('/layout.tsx')) {
+    return 'page';
+  }
+  // Design-system tiers: be permissive about the path between 'ui' / 'design-system' and 'primitive' / 'pattern'.
+  if (/(?:design-system|ui|ui-primitives)\/[^/]*\/?primitive/i.test(filePath) || /\/primitive\//i.test(filePath)) {
+    return 'primitive';
+  }
+  if (/(?:design-system|ui|ui-primitives)\/[^/]*\/?pattern/i.test(filePath) || /\/pattern\//i.test(filePath)) {
+    return 'pattern';
+  }
+  if (lower.includes('feature') || /Page$/.test(name)) {
+    return 'feature';
+  }
+  return undefined;
+}
+
+function synthesizeDescription(name: string, props: PropEntry[], libs: string[]): string {
+  const propSummary = props.length === 0 ? 'no props' : `props: ${props.map((p) => p.name).join(', ')}`;
+  const libSummary = libs.length === 0 ? '' : `; imports: ${libs.slice(0, 5).join(', ')}`;
+  return `React component ${name} (${propSummary}${libSummary})`;
+}

--- a/packages/architecture-registry/src/extractors/index.ts
+++ b/packages/architecture-registry/src/extractors/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @chiefaia/architecture-registry — extractors (ARCH-002 + ARCH-003)
+ *
+ * Re-exports per-kind extractors. Composing them into one full backfill:
+ *
+ *   const repo = '/Users/MAC/Documents/projects/caia';
+ *   const opts: ExtractorOptions = { repoRoot: repo, defaultProject: 'caia', now: Date.now() };
+ *   const services = extractServicesFromAppsRoot(opts);
+ *   const apis = extractApisFromFiles(globRouteFiles(repo), opts);
+ *   const components = extractComponentsFromFiles(globComponentFiles(repo), opts);
+ *   // ... persist to DB via storage layer (ARCH-004 wires up the persistence)
+ */
+
+export {
+  extractComponentsFromFiles,
+  extractComponentsFromInMemorySources,
+  extractComponentsFromProject,
+} from './component-extractor';
+
+export {
+  extractApisFromFiles,
+  extractApisFromInMemorySources,
+  extractApisFromProject,
+} from './api-extractor';
+
+export { extractServicesFromAppsRoot } from './service-extractor';
+
+export type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
+export { sha256 } from './utils';

--- a/packages/architecture-registry/src/extractors/service-extractor.ts
+++ b/packages/architecture-registry/src/extractors/service-extractor.ts
@@ -1,0 +1,229 @@
+/**
+ * @chiefaia/architecture-registry — service extractor (ARCH-002)
+ *
+ * Identifies CAIA Hono apps + worker services from `apps/<service>/` folder
+ * conventions and surfaces them as `kind='service'` artifacts. The
+ * extractor pairs with the API extractor: each service's `exposedApis`
+ * metadata is populated by joining on file path.
+ *
+ * Heuristics:
+ *   - Each top-level folder under `apps/` is one service.
+ *   - The service's name = folder basename.
+ *   - `appName` from package.json or first-arg of `new Hono()` if found.
+ *   - `port` parsed from a default in `serve({ port: NNN })` if present.
+ *   - `hasBackgroundLoop = true` if the service has a `pump.ts`,
+ *     `worker.ts`, `loop.ts`, or pump-style filename.
+ *
+ * No deep dependency analysis — that's left to ARCH-003 (package scanner)
+ * which produces the canonical `package` artifacts the service depends on.
+ */
+
+import { nanoid } from 'nanoid';
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ArchArtifactRowSchema,
+  ServiceMetadataSchema,
+  type ArchArtifactRow,
+  type ServiceMetadata,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_VERSION,
+} from '../schema';
+import { computeArtifactDedupKey } from '../dedup-key';
+import type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
+
+const PUMP_FILENAMES = ['pump.ts', 'worker.ts', 'loop.ts', 'poller.ts'];
+
+interface ServiceCandidate {
+  appName: string;
+  folderRel: string;
+  port?: number;
+  hasBackgroundLoop: boolean;
+  description: string;
+  tags: string[];
+}
+
+function safeReadJson(path: string): Record<string, unknown> | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function findFileRecursively(dir: string, predicate: (name: string) => boolean): boolean {
+  let stack: string[] = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = join(cur, e);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        if (e === 'node_modules' || e === 'dist' || e === '.next') continue;
+        stack.push(full);
+      } else if (predicate(e)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function inspectService(appsRoot: string, name: string): ServiceCandidate | undefined {
+  const folder = join(appsRoot, name);
+  if (!existsSync(folder)) return undefined;
+  const pkgPath = join(folder, 'package.json');
+  const pkg = safeReadJson(pkgPath);
+  if (!pkg) return undefined;
+  const appName = (pkg.name as string) ?? name;
+  const description = (pkg.description as string) ?? `Service '${name}' under apps/${name}/`;
+
+  // Port detection: read the entry file referenced by package.json's `main` /
+  // `start` script, or fall back to common entry locations.
+  const port = detectPort(folder, pkg);
+  const hasBackgroundLoop = findFileRecursively(folder, (n) => PUMP_FILENAMES.includes(n));
+
+  const tags: string[] = [];
+  if (pkg.private) tags.push('private');
+  if (Object.keys((pkg.dependencies as object) ?? {}).includes('hono')) tags.push('hono');
+  if (Object.keys((pkg.dependencies as object) ?? {}).includes('next')) tags.push('next');
+
+  return {
+    appName,
+    folderRel: `apps/${name}`,
+    port,
+    hasBackgroundLoop,
+    description,
+    tags,
+  };
+}
+
+const PORT_RE = /\bport\s*[:=]\s*(\d{3,5})\b/i;
+const SERVE_PORT_RE = /serve\(\s*\{[^}]*port\s*:\s*(\d{3,5})/i;
+
+function detectPort(folder: string, _pkg: Record<string, unknown>): number | undefined {
+  const candidates = [
+    join(folder, 'src/index.ts'),
+    join(folder, 'src/main.ts'),
+    join(folder, 'src/server.ts'),
+    join(folder, 'src/start.ts'),
+  ];
+  for (const c of candidates) {
+    if (!existsSync(c)) continue;
+    try {
+      const text = readFileSync(c, 'utf8');
+      const m = SERVE_PORT_RE.exec(text) ?? PORT_RE.exec(text);
+      if (m && m[1]) {
+        const port = Number(m[1]);
+        if (port > 0 && port < 65536) return port;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Public extractor: walks `<repoRoot>/apps/*` and emits `kind='service'`
+ * artifacts.
+ */
+export function extractServicesFromAppsRoot(opts: ExtractorOptions): ExtractionResult {
+  const result: ExtractionResult = { artifacts: [], edges: [], warnings: [] };
+  const newId = opts.newId ?? ((p) => `${p}_${nanoid(12)}`);
+  const appsRoot = join(opts.repoRoot, 'apps');
+  if (!existsSync(appsRoot)) {
+    result.warnings.push(`service-extractor: ${appsRoot} not found; skipped`);
+    return result;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(appsRoot);
+  } catch (err) {
+    result.warnings.push(`service-extractor: cannot list apps/ → ${(err as Error).message}`);
+    return result;
+  }
+
+  for (const name of entries) {
+    try {
+      const cand = inspectService(appsRoot, name);
+      if (!cand) continue;
+
+      const meta: ServiceMetadata = ServiceMetadataSchema.parse({
+        appName: cand.appName,
+        ...(cand.port ? { port: cand.port } : {}),
+        exposedApis: [], // resolved later when API extractor results are joined
+        persistsToSchemas: [],
+        emitsEvents: [],
+        hasBackgroundLoop: cand.hasBackgroundLoop,
+      });
+
+      const id = newId('arch');
+      const dedupKey = computeArtifactDedupKey({
+        project: opts.defaultProject,
+        kind: 'service',
+        name: cand.appName,
+        entryPath: cand.folderRel,
+      });
+
+      const techSubDomains = inferTechSubDomainsForService(name, cand);
+
+      const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+        id,
+        kind: 'service',
+        project: opts.defaultProject,
+        name: cand.appName,
+        description: cand.description,
+        keySignature: undefined,
+        filePaths: [cand.folderRel],
+        entryPath: cand.folderRel,
+        owningService: cand.appName,
+        techSubDomains,
+        tags: cand.tags,
+        metadataJson: JSON.stringify(meta),
+        source: 'ast_extract',
+        extractedAtCommit: opts.extractedAtCommit,
+        embeddingModel: DEFAULT_EMBEDDING_MODEL,
+        embeddingDim: DEFAULT_EMBEDDING_DIM,
+        embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+        createdAt: opts.now,
+        updatedAt: opts.now,
+        dedupKey,
+      });
+      result.artifacts.push(artifact);
+    } catch (err) {
+      result.warnings.push(`service-extractor: apps/${name} → ${(err as Error).message}`);
+    }
+  }
+
+  return result;
+}
+
+function inferTechSubDomainsForService(folderName: string, cand: ServiceCandidate): string[] {
+  const tags = new Set<string>();
+  if (folderName.includes('dashboard')) tags.add('frontend');
+  if (folderName.includes('orchestrator') || folderName.includes('executor') || folderName.includes('poller')) {
+    tags.add('agent-runtime');
+    tags.add('event-driven');
+  }
+  if (cand.tags.includes('hono')) tags.add('bff');
+  if (cand.tags.includes('next')) tags.add('frontend');
+  if (folderName.includes('backup') || folderName.includes('pulse')) tags.add('observability');
+  if (folderName.includes('pulse') || folderName.includes('sentinel')) tags.add('monitoring-alerting');
+  if (tags.size === 0) tags.add('backend');
+  return Array.from(tags);
+}

--- a/packages/architecture-registry/src/extractors/ts-morph-types.ts
+++ b/packages/architecture-registry/src/extractors/ts-morph-types.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared types for ts-morph AST extractors (ARCH-002).
+ */
+
+import type { ArchArtifactRow, ArchEdgeRow } from '../schema';
+
+/**
+ * What the extractor returns. Caller (storage layer or ARCH-007 dashboard)
+ * upserts these into the DB. We don't write directly here so the
+ * extractor is unit-testable without a SQLite dependency.
+ */
+export interface ExtractionResult {
+  artifacts: ArchArtifactRow[];
+  edges: ArchEdgeRow[];
+  /**
+   * Per-extractor diagnostic counters (warning lines, files skipped, etc.)
+   * surfaced to the dashboard "extract runs" panel (ARCH-007).
+   */
+  warnings: string[];
+}
+
+export interface ExtractorOptions {
+  /** Repo root; all extracted file paths are made relative to this. */
+  repoRoot: string;
+  /**
+   * Default project slug for extracted artifacts. Tests / mono-repo
+   * scanners can pass a per-app override via per-call options.
+   */
+  defaultProject: string;
+  /** epoch-ms timestamp to stamp on createdAt/updatedAt. */
+  now: number;
+  /** Optional commit SHA at extraction time. */
+  extractedAtCommit?: string;
+  /**
+   * Caller-provided ID factory. Defaults to `arch_<nanoid12>`. Tests
+   * pass a deterministic factory so fixtures snapshot cleanly.
+   */
+  newId?: (prefix: string) => string;
+}

--- a/packages/architecture-registry/src/extractors/utils.ts
+++ b/packages/architecture-registry/src/extractors/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared extractor utils.
+ */
+
+import { createHash } from 'node:crypto';
+
+export function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}

--- a/packages/architecture-registry/src/index.ts
+++ b/packages/architecture-registry/src/index.ts
@@ -78,3 +78,16 @@ export type {
 
 export { computeArtifactDedupKey, computeEdgeDedupKey } from './dedup-key';
 export type { ArtifactDedupKeyInput, EdgeDedupKeyInput } from './dedup-key';
+
+// ARCH-002: ts-morph AST extractors.
+export {
+  extractComponentsFromFiles,
+  extractComponentsFromInMemorySources,
+  extractComponentsFromProject,
+  extractApisFromFiles,
+  extractApisFromInMemorySources,
+  extractApisFromProject,
+  extractServicesFromAppsRoot,
+  sha256,
+} from './extractors';
+export type { ExtractionResult, ExtractorOptions } from './extractors';

--- a/packages/architecture-registry/tests/api-extractor.test.ts
+++ b/packages/architecture-registry/tests/api-extractor.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { extractApisFromInMemorySources } from '../src';
+
+const NOW = 1745812800000;
+let counter = 0;
+const idFactory = (prefix: string) => `${prefix}_${counter++}`;
+const reset = () => { counter = 0; };
+
+const baseOpts = () => ({
+  repoRoot: '/repo',
+  defaultProject: 'caia',
+  now: NOW,
+  newId: idFactory,
+});
+
+describe('extractApisFromInMemorySources', () => {
+  it('extracts a simple GET route', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/api/routes/health.ts',
+        content: `
+import { Hono } from 'hono';
+const app = new Hono();
+app.get('/observability/health', (c) => c.json({ status: 'ok' }));
+export default app;
+`,
+      },
+    ];
+    const r = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(1);
+    const a = r.artifacts[0]!;
+    expect(a.kind).toBe('api');
+    expect(a.routeSignature).toBe('GET /observability/health');
+    expect(a.name).toBe('GET /observability/health');
+    expect(a.techSubDomains).toContain('bff');
+    expect(a.techSubDomains).toContain('observability');
+    const meta = JSON.parse(a.metadataJson);
+    expect(meta.method).toBe('GET');
+    expect(meta.path).toBe('/observability/health');
+    expect(meta.authRequired).toBe(false);
+  });
+
+  it('extracts a POST route with middleware + auth', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/api/routes/events.ts',
+        content: `
+import { Hono } from 'hono';
+import { requireAuth } from '../middleware/auth';
+import { zValidator } from '../middleware/zv';
+const app = new Hono();
+app.post('/events', requireAuth, zValidator('json', EventSchema), async (c) => c.json({ ok: true }));
+`,
+      },
+    ];
+    const r = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(1);
+    const meta = JSON.parse(r.artifacts[0]!.metadataJson);
+    expect(meta.method).toBe('POST');
+    expect(meta.authRequired).toBe(true);
+    expect(meta.middlewareChain.length).toBe(2);
+    expect(r.artifacts[0]!.tags).toContain('auth-required');
+  });
+
+  it('extracts multiple methods on the same path', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/api/routes/users.ts',
+        content: `
+import { Hono } from 'hono';
+const app = new Hono();
+app.get('/users/:id', (c) => c.json({ id: c.req.param('id') }));
+app.put('/users/:id', (c) => c.json({}));
+app.delete('/users/:id', (c) => c.json({}));
+`,
+      },
+    ];
+    const r = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(3);
+    expect(r.artifacts.map((a) => a.routeSignature).sort()).toEqual([
+      'DELETE /users/:id',
+      'GET /users/:id',
+      'PUT /users/:id',
+    ]);
+  });
+
+  it('skips files with no Hono import + non-route filename', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/random.ts',
+        content: `
+const obj = { get: () => {} };
+obj.get('/x', () => {});
+`,
+      },
+    ];
+    const r = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts).toHaveLength(0);
+  });
+
+  it('does scan files with .routes.ts pattern even without explicit Hono import', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/api/health.routes.ts',
+        content: `
+const app = makeApp();
+app.get('/observability/health', (c) => c.json({}));
+`,
+      },
+    ];
+    const r = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts).toHaveLength(1);
+    expect(r.artifacts[0]!.routeSignature).toBe('GET /observability/health');
+  });
+
+  it('produces stable dedup key on re-extraction', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/api/routes/x.ts',
+        content: `
+import { Hono } from 'hono';
+const app = new Hono();
+app.get('/x', (c) => c.json({}));
+`,
+      },
+    ];
+    const r1 = extractApisFromInMemorySources(sources, baseOpts());
+    counter = 0;
+    const r2 = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r1.artifacts[0]!.dedupKey).toBe(r2.artifacts[0]!.dedupKey);
+  });
+
+  it('handles routes registered on subapps + sibling identifiers', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/orchestrator/src/api/routes/sub.ts',
+        content: `
+import { Hono } from 'hono';
+const router = new Hono();
+router.patch('/profile/:id', (c) => c.json({}));
+`,
+      },
+    ];
+    const r = extractApisFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts).toHaveLength(1);
+    const meta = JSON.parse(r.artifacts[0]!.metadataJson);
+    expect(meta.appName).toBe('router');
+  });
+});

--- a/packages/architecture-registry/tests/component-extractor.test.ts
+++ b/packages/architecture-registry/tests/component-extractor.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { extractComponentsFromInMemorySources } from '../src';
+
+const NOW = 1745812800000;
+let counter = 0;
+const idFactory = (prefix: string) => `${prefix}_${counter++}`;
+
+function reset() {
+  counter = 0;
+}
+
+const baseOpts = (over: Partial<Parameters<typeof extractComponentsFromInMemorySources>[1]> = {}) => ({
+  repoRoot: '/repo',
+  defaultProject: 'caia',
+  now: NOW,
+  newId: idFactory,
+  ...over,
+});
+
+describe('extractComponentsFromInMemorySources', () => {
+  it('extracts a function component with typed props', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/dashboard/components/prompt-list.tsx',
+        content: `
+import * as React from 'react';
+
+interface PromptListProps {
+  promptIds: string[];
+  onSelect?: (id: string) => void;
+}
+
+/**
+ * Renders a paginated list of prompts.
+ */
+export function PromptList(props: PromptListProps): JSX.Element {
+  const [hover, setHover] = React.useState(false);
+  return <ul>{props.promptIds.map((id) => <li key={id}>{id}</li>)}</ul>;
+}
+`,
+      },
+    ];
+
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(1);
+    const a = r.artifacts[0]!;
+    expect(a.kind).toBe('component');
+    expect(a.name).toBe('PromptList');
+    expect(a.entryPath).toBe('apps/dashboard/components/prompt-list.tsx');
+    expect(a.techSubDomains).toContain('frontend');
+    expect(a.description).toContain('paginated list');
+    const meta = JSON.parse(a.metadataJson);
+    expect(meta.props).toHaveLength(2);
+    expect(meta.props.find((p: { name: string }) => p.name === 'promptIds').required).toBe(true);
+    expect(meta.props.find((p: { name: string }) => p.name === 'onSelect').required).toBe(false);
+    expect(meta.componentForm).toBe('function');
+    expect(meta.hooksUsed).toContain('useState');
+  });
+
+  it('extracts an arrow function component', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/apps/dashboard/components/badge.tsx',
+        content: `
+type BadgeProps = { label: string };
+export const Badge = (props: BadgeProps): JSX.Element => <span>{props.label}</span>;
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(1);
+    const a = r.artifacts[0]!;
+    expect(a.name).toBe('Badge');
+    const meta = JSON.parse(a.metadataJson);
+    expect(meta.componentForm).toBe('arrow');
+    expect(meta.props).toHaveLength(1);
+    expect(meta.props[0].name).toBe('label');
+  });
+
+  it('extracts a React.memo component', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/components/avatar.tsx',
+        content: `
+import React from 'react';
+type AvatarProps = { src: string; alt?: string };
+export const Avatar = React.memo((props: AvatarProps): JSX.Element => <img src={props.src} alt={props.alt} />);
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(1);
+    const meta = JSON.parse(r.artifacts[0]!.metadataJson);
+    expect(meta.componentForm).toBe('memo');
+  });
+
+  it('extracts a class component extending React.Component', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/components/legacy-modal.tsx',
+        content: `
+import React from 'react';
+export class LegacyModal extends React.Component<{ title: string }> {
+  render() {
+    return <div>{this.props.title}</div>;
+  }
+}
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts).toHaveLength(1);
+    const a = r.artifacts[0]!;
+    expect(a.name).toBe('LegacyModal');
+    const meta = JSON.parse(a.metadataJson);
+    expect(meta.componentForm).toBe('class');
+  });
+
+  it('skips non-component declarations (lowercase function, no JSX)', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/lib/util.ts',
+        content: `
+export function add(a: number, b: number): number { return a + b; }
+export const helper = (x: number): number => x + 1;
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts).toHaveLength(0);
+  });
+
+  it('detects design-system tier from path', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/packages/ui/src/primitive/button.tsx',
+        content: `
+type ButtonProps = { children: string };
+export const Button = (props: ButtonProps): JSX.Element => <button>{props.children}</button>;
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts[0]!.designSystemTier).toBe('primitive');
+    expect(r.artifacts[0]!.techSubDomains).toContain('design-system');
+  });
+
+  it('emits depends_on edges for imported libraries', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/components/icon.tsx',
+        content: `
+import { Smile } from 'lucide-react';
+import { cn } from '@chiefaia/utils';
+type IconProps = { size: number };
+export const Icon = (props: IconProps): JSX.Element => <Smile size={props.size} />;
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts).toHaveLength(1);
+    expect(r.edges).toHaveLength(2);
+    const targets = r.edges.map((e) => JSON.parse(e.metadataJson).targetPackageName).sort();
+    expect(targets).toEqual(['@chiefaia/utils', 'lucide-react']);
+    expect(r.edges[0]!.relation).toBe('depends_on');
+  });
+
+  it('produces stable dedup key on re-extraction', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/components/x.tsx',
+        content: `
+type XProps = { a: number };
+export const X = (props: XProps): JSX.Element => <div />;
+`,
+      },
+    ];
+    const r1 = extractComponentsFromInMemorySources(sources, baseOpts());
+    counter = 0; // reset so the new id factory yields equivalent ids
+    const r2 = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r1.artifacts[0]!.dedupKey).toBe(r2.artifacts[0]!.dedupKey);
+    expect(r1.artifacts[0]!.contentHash).toBe(r2.artifacts[0]!.contentHash);
+  });
+
+  it('handles syntax errors with a warning, not a throw', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/broken.tsx',
+        content: `export const Y = (props: { z: number }`, // truncated
+      },
+    ];
+    expect(() => extractComponentsFromInMemorySources(sources, baseOpts())).not.toThrow();
+  });
+
+  it('extracts a default export anonymous component (named via variable)', () => {
+    reset();
+    const sources = [
+      {
+        path: '/repo/app/page.tsx',
+        content: `
+type PageProps = { slug: string };
+const Page = (props: PageProps): JSX.Element => <div>{props.slug}</div>;
+export default Page;
+`,
+      },
+    ];
+    const r = extractComponentsFromInMemorySources(sources, baseOpts());
+    expect(r.artifacts).toHaveLength(1);
+    expect(r.artifacts[0]!.name).toBe('Page');
+    expect(r.artifacts[0]!.designSystemTier).toBe('page');
+  });
+});

--- a/packages/architecture-registry/tests/service-extractor.test.ts
+++ b/packages/architecture-registry/tests/service-extractor.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractServicesFromAppsRoot } from '../src';
+
+const NOW = 1745812800000;
+let counter = 0;
+const idFactory = (prefix: string) => `${prefix}_${counter++}`;
+
+function makeRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'akg-test-'));
+  // apps/orchestrator
+  mkdirSync(join(root, 'apps/orchestrator/src'), { recursive: true });
+  writeFileSync(
+    join(root, 'apps/orchestrator/package.json'),
+    JSON.stringify({
+      name: '@caia-app/orchestrator',
+      private: true,
+      description: 'Orchestrator brain (MCP server + Hono API + WebSocket).',
+      dependencies: { hono: '^4.0.0' },
+    }),
+  );
+  writeFileSync(
+    join(root, 'apps/orchestrator/src/index.ts'),
+    `
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+const app = new Hono();
+serve({ fetch: app.fetch, port: 7776 });
+`,
+  );
+  mkdirSync(join(root, 'apps/orchestrator/src/pump'), { recursive: true });
+  writeFileSync(
+    join(root, 'apps/orchestrator/src/pump/pump.ts'),
+    'export class PumpEngine {}',
+  );
+
+  // apps/dashboard (Next.js)
+  mkdirSync(join(root, 'apps/dashboard/app'), { recursive: true });
+  writeFileSync(
+    join(root, 'apps/dashboard/package.json'),
+    JSON.stringify({
+      name: '@caia-app/dashboard',
+      private: true,
+      description: 'CAIA orchestrator dashboard.',
+      dependencies: { next: '^15.0.0', react: '^18.0.0' },
+    }),
+  );
+
+  // apps/db-backup — has no port, no pump
+  mkdirSync(join(root, 'apps/db-backup'), { recursive: true });
+  writeFileSync(
+    join(root, 'apps/db-backup/package.json'),
+    JSON.stringify({ name: 'db-backup', description: 'SQLite backup job.' }),
+  );
+
+  return root;
+}
+
+describe('extractServicesFromAppsRoot', () => {
+  let root: string;
+
+  beforeEach(() => {
+    counter = 0;
+    root = makeRepo();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('extracts each apps/* folder as a service', () => {
+    const r = extractServicesFromAppsRoot({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts.length).toBe(3);
+    const names = r.artifacts.map((a) => a.name).sort();
+    expect(names).toEqual(['@caia-app/dashboard', '@caia-app/orchestrator', 'db-backup']);
+  });
+
+  it('detects port + background loop on orchestrator', () => {
+    const r = extractServicesFromAppsRoot({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    const orch = r.artifacts.find((a) => a.name === '@caia-app/orchestrator')!;
+    expect(orch).toBeDefined();
+    const meta = JSON.parse(orch.metadataJson);
+    expect(meta.port).toBe(7776);
+    expect(meta.hasBackgroundLoop).toBe(true);
+    expect(orch.techSubDomains).toContain('bff');
+    expect(orch.techSubDomains).toContain('agent-runtime');
+    expect(orch.tags).toContain('hono');
+  });
+
+  it('tags Next.js apps as frontend', () => {
+    const r = extractServicesFromAppsRoot({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    const dash = r.artifacts.find((a) => a.name === '@caia-app/dashboard')!;
+    expect(dash.techSubDomains).toContain('frontend');
+    expect(dash.tags).toContain('next');
+  });
+
+  it('produces stable dedup key on re-extraction', () => {
+    const opts = {
+      repoRoot: root,
+      defaultProject: 'caia' as const,
+      now: NOW,
+      newId: idFactory,
+    };
+    const r1 = extractServicesFromAppsRoot(opts);
+    counter = 0;
+    const r2 = extractServicesFromAppsRoot(opts);
+    const keys1 = r1.artifacts.map((a) => a.dedupKey).sort();
+    const keys2 = r2.artifacts.map((a) => a.dedupKey).sort();
+    expect(keys1).toEqual(keys2);
+  });
+
+  it('returns a warning when apps/ does not exist', () => {
+    const r = extractServicesFromAppsRoot({
+      repoRoot: '/nonexistent-repo-path',
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    expect(r.artifacts).toEqual([]);
+    expect(r.warnings.length).toBe(1);
+    expect(r.warnings[0]).toContain('not found');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       sqlite-vec:
         specifier: ^0.1.9
         version: 0.1.9
+      ts-morph:
+        specifier: ^21.0.1
+        version: 21.0.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -3502,6 +3505,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@ts-morph/common@0.22.0':
+    resolution: {integrity: sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -4207,6 +4213,9 @@ packages:
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  code-block-writer@12.0.0:
+    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
 
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
@@ -5901,6 +5910,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -6814,6 +6826,9 @@ packages:
         optional: true
       jest-util:
         optional: true
+
+  ts-morph@21.0.1:
+    resolution: {integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -9829,6 +9844,13 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@ts-morph/common@0.22.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 9.0.9
+      mkdirp: 3.0.1
+      path-browserify: 1.0.1
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -10654,6 +10676,8 @@ snapshots:
   cmd-shim@7.0.0: {}
 
   co@4.6.0: {}
+
+  code-block-writer@12.0.0: {}
 
   collect-v8-coverage@1.0.3: {}
 
@@ -12517,6 +12541,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.5.0: {}
@@ -13588,6 +13614,11 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.0)
       esbuild: 0.27.7
       jest-util: 29.7.0
+
+  ts-morph@21.0.1:
+    dependencies:
+      '@ts-morph/common': 0.22.0
+      code-block-writer: 12.0.0
 
   ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## ARCH-002 — ts-morph AST extractors

Three idempotent, re-runnable extractors that walk the TypeScript AST and emit `ArchArtifactRow` + `ArchEdgeRow` records for the AKG.

### What ships

1. **component-extractor** — React components (function / arrow / memo / forwardRef / class). Extracts props (name, type, required, default), JSDoc summary, hooks used, imported libraries, design-system tier (path-inferred), tech-sub-domains. Emits `depends_on` edges for imports.

2. **api-extractor** — Hono routes. Walks every `app.<method>('path', ...)` call; captures method, path, middleware chain, auth detection (requireAuth / withAuth / bearerAuth / jwtAuth / sessionAuth / authGuard). Subapp + router-style identifiers supported.

3. **service-extractor** — `apps/<service>/` folder convention. One artifact per top-level app with package.json; port detection from `serve({port:...})`; `hasBackgroundLoop` from pump/worker/loop/poller filenames; tech-sub-domain heuristics for orchestrator/executor/dashboard/backup.

All extractors are pure transformations (sources in → ExtractionResult out). No DB writes — that lands in ARCH-004.

### Tests

22 new tests added (10 component + 7 api + 5 service). Total 63 passing. Covers extraction happy paths, edge cases (anonymous default exports, syntax errors handled with warnings, multi-method routes, sub-app identifiers), and idempotency (re-extraction yields stable dedup keys).

### Tech-sub-domain coverage (per BUCKET-001 taxonomy)

- Components → `frontend`, `design-system`, `accessibility`, `web-analytics`
- APIs → `bff`, `observability`, `event-driven`, `auth`
- Services → `agent-runtime`, `event-driven`, `bff`, `frontend`, `monitoring-alerting`, `observability`, `backend`

Each row tags one or more values from the canonical `TECH_SUB_DOMAINS` enum so per-domain queries (ARCH-005) land on coherent slices.

### DoD compliance

- [x] Unit tests: 63 passing
- [x] Typecheck green
- [x] No new vulnerabilities
- [x] Documentation: per-extractor JSDoc + extractor index
- [x] Adds `ts-morph@^21.0.1` (Apache 2.0) as a dependency

Refs: ARCH-002. Next: ARCH-003 (drizzle introspect + package.json scanner).