### PR TITLE
feat(ticket-template,orchestrator): SectionContract + StoryScope + migration 0030 (ACR-001)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0030_story_scope.sql
+++ b/apps/orchestrator/src/db/migrations/0030_story_scope.sql
@@ -1,0 +1,25 @@
+-- Migration 0030: ACR-001 — story_scope column on stories.
+--
+-- The Agent Section Contract Registry (ACR-001 → ACR-011) lets each
+-- ticket-writing agent (PO, BA, EA, Test-Design) declare a contract
+-- listing the sections it will populate, with per-scope rubrics. The
+-- Validator composes contracts at runtime per story scope.
+--
+-- This column captures the scope a story sits at in the SAFe / Jira
+-- hierarchy:
+--   initiative → epic → module → story → task → subtask
+--
+-- The composed validation template per scope is the union of all contracts
+-- whose `appliesTo` includes that scope; legacy stories without an explicit
+-- scope default to 'story' (the canonical sprintable unit) — see ACR-008.
+--
+-- Index supports the dashboard /contracts page (groups stories by scope)
+-- and the Validator's per-scope rubric cache lookup.
+--
+-- See ~/Documents/projects/reports/agent-contract-registry-architecture-2026-04-28.md
+-- for the full design rationale + composition algorithm.
+
+ALTER TABLE `stories` ADD COLUMN `story_scope` text NOT NULL DEFAULT 'story';
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `story_story_scope_idx` ON `stories` (`story_scope`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1778000000000,
       "tag": "0029_story_feature_classification",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1777427184734,
+      "tag": "0030_story_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -443,6 +443,11 @@ export const stories = sqliteTable('stories', {
   featureClassification: text('feature_classification'),               // 'enhance'|'ambiguous'|'new'|null
   featureClassificationScore: real('feature_classification_score'),    // cosine sim of top match
   featureClassificationAt: integer('feature_classification_at'),       // epoch ms
+  // ACR-001 (migration 0030) — story_scope: SAFe / Jira hierarchy slot for the
+  // Agent Section Contract Registry. Validator composes per-scope rubrics from
+  // registered contracts (PO/BA/EA/Test-Design) per `composeTemplate(scope)`.
+  // Legacy rows backfill to 'story' (DEFAULT_STORY_SCOPE) — see ACR-008.
+  storyScope: text('story_scope').notNull().default('story'),          // STORY_SCOPES
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -466,6 +471,9 @@ export const stories = sqliteTable('stories', {
   index('story_validation_attempts_idx').on(t.validationAttempts),
   // FREG-006 index (migration 0029)
   index('story_feature_classification_idx').on(t.featureClassification),
+  // ACR-001 index (migration 0030) — dashboard /contracts page + Validator
+  // per-scope rubric cache lookup.
+  index('story_story_scope_idx').on(t.storyScope),
 ]);
 
 // story_revisions — append-only history of every story-tree edit

--- a/packages/ticket-template/src/index.ts
+++ b/packages/ticket-template/src/index.ts
@@ -86,3 +86,27 @@ export type {
   AgentSectionRule,
   SectionTrigger,
 } from './validation-rubric';
+
+// ACR-001 — Agent Section Contract Registry primitives.
+export {
+  STORY_SCOPES,
+  STORY_SCOPE_ORDER,
+  isStoryScope,
+  DEFAULT_STORY_SCOPE,
+  AGENT_ROLES,
+  AGENT_ORDER,
+  applyScopeOverride,
+  compareScopes,
+  isScopeAtLeastAsCoarseAs,
+} from './section-contract';
+export type {
+  StoryScope,
+  AgentRole,
+  ContractSeverity,
+  SectionRubric,
+  SectionExample,
+  SectionSpec,
+  SectionContract,
+  ComposedSectionEntry,
+  ComposedTemplate,
+} from './section-contract';

--- a/packages/ticket-template/src/section-contract.test.ts
+++ b/packages/ticket-template/src/section-contract.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @chiefaia/ticket-template — section-contract.test.ts (ACR-001)
+ *
+ * Unit coverage for SectionContract / StoryScope primitives. These types
+ * underpin the Agent Section Contract Registry — the goal of these tests
+ * is to prove the data shapes + helper functions behave as the Validator
+ * (and `composeTemplate` in @chiefaia/agent-contract-registry) will rely
+ * on them at runtime.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  STORY_SCOPES,
+  STORY_SCOPE_ORDER,
+  isStoryScope,
+  DEFAULT_STORY_SCOPE,
+  AGENT_ROLES,
+  AGENT_ORDER,
+  applyScopeOverride,
+  compareScopes,
+  isScopeAtLeastAsCoarseAs,
+  type SectionSpec,
+  type SectionContract,
+  type StoryScope,
+} from './section-contract';
+
+describe('StoryScope', () => {
+  it('exports the six canonical scopes in coarse-to-fine order', () => {
+    expect(STORY_SCOPES).toEqual([
+      'initiative',
+      'epic',
+      'module',
+      'story',
+      'task',
+      'subtask',
+    ]);
+  });
+
+  it('STORY_SCOPE_ORDER is a strict ordering with initiative coarsest, subtask finest', () => {
+    const ordered = (STORY_SCOPES as readonly StoryScope[])
+      .map((s) => STORY_SCOPE_ORDER[s])
+      .every((n, i, arr) => i === 0 || arr[i - 1]! < n);
+    expect(ordered).toBe(true);
+    expect(STORY_SCOPE_ORDER.initiative).toBe(0);
+    expect(STORY_SCOPE_ORDER.subtask).toBe(STORY_SCOPES.length - 1);
+  });
+
+  it('isStoryScope returns true for canonical values, false otherwise', () => {
+    for (const s of STORY_SCOPES) expect(isStoryScope(s)).toBe(true);
+    expect(isStoryScope('feature')).toBe(false);
+    expect(isStoryScope('')).toBe(false);
+    expect(isStoryScope(null)).toBe(false);
+    expect(isStoryScope(undefined)).toBe(false);
+    expect(isStoryScope(42)).toBe(false);
+    expect(isStoryScope({ scope: 'story' })).toBe(false);
+  });
+
+  it("DEFAULT_STORY_SCOPE is 'story' — matches ACR-008 backfill default", () => {
+    expect(DEFAULT_STORY_SCOPE).toBe('story');
+    expect(isStoryScope(DEFAULT_STORY_SCOPE)).toBe(true);
+  });
+});
+
+describe('AgentRole', () => {
+  it('exports the four pipeline-canonical roles', () => {
+    expect(AGENT_ROLES).toEqual(['po', 'ba', 'ea', 'test-design']);
+  });
+
+  it('AGENT_ORDER reflects pipeline order PO -> BA -> EA -> Test-Design', () => {
+    expect(AGENT_ORDER.po).toBeLessThan(AGENT_ORDER.ba);
+    expect(AGENT_ORDER.ba).toBeLessThan(AGENT_ORDER.ea);
+    expect(AGENT_ORDER.ea).toBeLessThan(AGENT_ORDER['test-design']);
+  });
+});
+
+describe('compareScopes / isScopeAtLeastAsCoarseAs', () => {
+  it('compareScopes returns negative when first is coarser', () => {
+    expect(compareScopes('initiative', 'story')).toBeLessThan(0);
+    expect(compareScopes('story', 'initiative')).toBeGreaterThan(0);
+    expect(compareScopes('story', 'story')).toBe(0);
+  });
+
+  it('isScopeAtLeastAsCoarseAs identifies coarser-or-equal correctly', () => {
+    expect(isScopeAtLeastAsCoarseAs('initiative', 'story')).toBe(true);
+    expect(isScopeAtLeastAsCoarseAs('story', 'story')).toBe(true);
+    expect(isScopeAtLeastAsCoarseAs('task', 'story')).toBe(false);
+    expect(isScopeAtLeastAsCoarseAs('subtask', 'task')).toBe(false);
+    expect(isScopeAtLeastAsCoarseAs('module', 'task')).toBe(true);
+  });
+});
+
+// ─── applyScopeOverride ────────────────────────────────────────────────────
+
+const baseSpec: SectionSpec = {
+  name: 'scope',
+  description: 'What the work will and will not deliver.',
+  purpose: 'Defines the observable outcome and prevents scope creep.',
+  dataShape: z.object({}).passthrough(),
+  required: true,
+  rubric: {
+    minWords: 30,
+    severityOnFail: 'hard',
+    fixHint: 'Expand to a one-sentence outcome + concrete in/out lists.',
+  },
+  examples: [
+    {
+      good: { summary: 'Add Stripe checkout' },
+      bad: { summary: 'TBD' },
+      badRationale: 'Placeholder summary.',
+    },
+  ],
+};
+
+describe('applyScopeOverride', () => {
+  it('returns base rubric + required when no override exists for the scope', () => {
+    const out = applyScopeOverride(baseSpec, 'story');
+    expect(out.effectiveRubric).toBe(baseSpec.rubric);
+    expect(out.effectiveRequired).toBe(true);
+  });
+
+  it('shallow-merges rubric override fields over the base rubric', () => {
+    const spec: SectionSpec = {
+      ...baseSpec,
+      scopeOverrides: {
+        initiative: { minWords: 80 },
+        subtask: { minWords: 10, fixHint: 'Subtasks need only 10 words.' },
+      },
+    };
+    const init = applyScopeOverride(spec, 'initiative');
+    expect(init.effectiveRubric.minWords).toBe(80);
+    expect(init.effectiveRubric.severityOnFail).toBe('hard');
+    expect(init.effectiveRubric.fixHint).toBe(baseSpec.rubric.fixHint);
+    expect(init.effectiveRequired).toBe(true);
+
+    const sub = applyScopeOverride(spec, 'subtask');
+    expect(sub.effectiveRubric.minWords).toBe(10);
+    expect(sub.effectiveRubric.fixHint).toBe('Subtasks need only 10 words.');
+  });
+
+  it('overrides required when scopeOverrides specifies it', () => {
+    const spec: SectionSpec = {
+      ...baseSpec,
+      required: false,
+      scopeOverrides: {
+        initiative: { required: true, minWords: 60 },
+        story: { required: false },
+      },
+    };
+    expect(applyScopeOverride(spec, 'initiative').effectiveRequired).toBe(true);
+    expect(applyScopeOverride(spec, 'story').effectiveRequired).toBe(false);
+    expect(applyScopeOverride(spec, 'task').effectiveRequired).toBe(false);
+  });
+
+  it('keeps base rubric reference intact (does not mutate)', () => {
+    const spec: SectionSpec = {
+      ...baseSpec,
+      scopeOverrides: { initiative: { minWords: 80 } },
+    };
+    const before = { ...spec.rubric };
+    applyScopeOverride(spec, 'initiative');
+    expect(spec.rubric).toEqual(before);
+  });
+});
+
+// ─── SectionContract structural tests ──────────────────────────────────────
+
+describe('SectionContract structural', () => {
+  it('a minimal contract type-checks with one section', () => {
+    const contract: SectionContract = {
+      ownerAgent: 'po',
+      contractId: 'po-agent.v1',
+      version: '1.0.0',
+      appliesTo: ['initiative', 'story'],
+      sections: [baseSpec],
+    };
+    expect(contract.ownerAgent).toBe('po');
+    expect(contract.sections).toHaveLength(1);
+    expect(contract.appliesTo).toContain('story');
+  });
+
+  it('contract appliesTo can be subset of all scopes', () => {
+    const contract: SectionContract = {
+      ownerAgent: 'test-design',
+      contractId: 'test-design-agent.v1',
+      version: '1.0.0',
+      appliesTo: ['story', 'task'],
+      sections: [],
+    };
+    expect(contract.appliesTo).not.toContain('initiative');
+    expect(contract.appliesTo).toContain('story');
+  });
+
+  it('section dependencies field is optional', () => {
+    const withoutDeps: SectionSpec = baseSpec;
+    const withDeps: SectionSpec = { ...baseSpec, dependencies: ['acceptanceCriteria'] };
+    expect(withoutDeps.dependencies).toBeUndefined();
+    expect(withDeps.dependencies).toEqual(['acceptanceCriteria']);
+  });
+});

--- a/packages/ticket-template/src/section-contract.ts
+++ b/packages/ticket-template/src/section-contract.ts
@@ -1,0 +1,356 @@
+/**
+ * @chiefaia/ticket-template — SectionContract + StoryScope (ACR-001)
+ *
+ * The Agent Section Contract Registry's primitive types. Each agent that
+ * writes into a Phase-1 ticket — PO, BA, EA, Test-Design — declares a
+ * `SectionContract` listing the sections it will populate, with descriptions
+ * and per-scope rubrics. The Story Validator consolidates contracts at
+ * runtime via `composeTemplate(scope)` (ACR-002) into a scope-aware
+ * `ComposedTemplate` and uses that as its rubric.
+ *
+ * Goal: every story is self-sufficient, stateless, context-less.
+ * Test-Design + coding agents get everything from the ticket alone.
+ *
+ * Design notes:
+ *
+ *  - `StoryScope` mirrors the SAFe / Jira hierarchy (initiative → epic →
+ *    module → story → task → subtask). The DB column on `stories.story_scope`
+ *    indexes which scope a row sits at; legacy rows backfill to 'story'.
+ *  - `SectionContract.appliesTo` is the per-scope opt-in. The composed
+ *    template for a given scope is the union of contracts whose
+ *    `appliesTo` includes that scope.
+ *  - `SectionSpec.scopeOverrides` lets a single section relax/tighten its
+ *    rubric per scope (e.g. initiative scope demands more strategic depth
+ *    than a subtask).
+ *  - All types here are framework-agnostic; the registry + composition
+ *    algorithm live in `@chiefaia/agent-contract-registry` (ACR-002).
+ */
+
+import type { ZodTypeAny } from 'zod';
+
+// ─── StoryScope ─────────────────────────────────────────────────────────────
+
+/**
+ * The six canonical scopes a Phase-1 ticket can occupy. Aligned to SAFe /
+ * Jira hierarchy with one CAIA-specific nuance: `module` represents a DDD
+ * bounded context / capability cluster (we deliberately skip SAFe's
+ * `Capability` level because `module` covers it for our needs).
+ *
+ * Semantics:
+ *  - `initiative` — strategic bet, multi-quarter, portfolio level.
+ *  - `epic`       — ART-level grouping, multi-PI.
+ *  - `module`     — bounded context / capability cluster.
+ *  - `story`      — sprintable user-value unit (THE canonical ticket).
+ *  - `task`       — self-contained unit of work, one-coder/one-bucket.
+ *  - `subtask`    — smallest atomic step (rare).
+ */
+export const STORY_SCOPES = [
+  'initiative',
+  'epic',
+  'module',
+  'story',
+  'task',
+  'subtask',
+] as const;
+
+export type StoryScope = (typeof STORY_SCOPES)[number];
+
+/**
+ * Stable ordinal — useful for sorting + scope-comparison checks
+ * ("section X applies to scopes >= module"). Lower number = higher level.
+ */
+export const STORY_SCOPE_ORDER: Record<StoryScope, number> = {
+  initiative: 0,
+  epic: 1,
+  module: 2,
+  story: 3,
+  task: 4,
+  subtask: 5,
+};
+
+/** Type guard — useful at the DB-load boundary where we accept arbitrary text. */
+export function isStoryScope(value: unknown): value is StoryScope {
+  return typeof value === 'string' && (STORY_SCOPES as readonly string[]).includes(value);
+}
+
+/** Default scope assigned to legacy stories that pre-date the `story_scope` column. */
+export const DEFAULT_STORY_SCOPE: StoryScope = 'story';
+
+// ─── AgentRole ──────────────────────────────────────────────────────────────
+
+/**
+ * The four agent roles that own ticket sections in Phase 1. The pipeline
+ * order — PO → BA → EA → Test-Design — drives both the ticket-writing
+ * sequence and the conflict-resolution tie-breaker in `composeTemplate`.
+ */
+export const AGENT_ROLES = ['po', 'ba', 'ea', 'test-design'] as const;
+export type AgentRole = (typeof AGENT_ROLES)[number];
+
+/**
+ * Pipeline order of agent contributions. `composeTemplate` uses this as the
+ * tie-breaker when two contracts claim the same section — the earlier
+ * agent wins (PO < BA < EA < Test-Design).
+ */
+export const AGENT_ORDER: Record<AgentRole, number> = {
+  po: 0,
+  ba: 1,
+  ea: 2,
+  'test-design': 3,
+};
+
+// ─── Severity (mirrors validation-rubric.ts) ────────────────────────────────
+
+/**
+ * Severity of a per-section finding. Matches `RubricSeverity` from
+ * `validation-rubric.ts` — kept as a parallel type here so the contract
+ * package doesn't take a circular dependency on the rubric module.
+ *
+ *  - `hard`    → blocks pipeline; story cannot advance.
+ *  - `soft`    → blocks first attempt only; warning on attempt 2+.
+ *  - `warning` → never blocks; surfaced on the dashboard.
+ */
+export type ContractSeverity = 'hard' | 'soft' | 'warning';
+
+// ─── SectionRubric ──────────────────────────────────────────────────────────
+
+/**
+ * Per-section validation expectations. The Validator's six-step pipeline
+ * runs these as deterministic checks (steps 2-3) plus an LLM relevance
+ * judge (step 4) seeded by `relevancePromptSeed`.
+ *
+ * All numeric thresholds default to "no minimum" if absent.
+ */
+export interface SectionRubric {
+  /** Sum of words across all string fields in the section. */
+  minWords?: number;
+  /** Minimum array length when the section's data shape is itself an array. */
+  minItems?: number;
+  /**
+   * Map of sub-field path (relative to the section) → min item count.
+   * Example: `{ 'routes': 1, 'errorContract': 0 }` for the api section.
+   */
+  minItemsPerSubField?: Readonly<Record<string, number>>;
+  /** Sub-field paths that must exist and be non-empty (string or array). */
+  requiredSubFields?: readonly string[];
+  /**
+   * Regex patterns (source form, JS-compatible). The section's concatenated
+   * text must contain at least one match per entry.
+   */
+  requiredEntityRefs?: ReadonlyArray<{
+    /** Identifier surfaced in failure reports. */
+    label: string;
+    /** Regex source. */
+    pattern: string;
+    /** Optional JS regex flags (e.g. `i`). */
+    flags?: string;
+  }>;
+  /**
+   * Phrases that, if present (word-boundary, case-insensitive), trigger a
+   * `forbidden_snippet` finding. Layered on top of the universal forbidden
+   * list from `validation-rubric.ts`.
+   */
+  forbiddenSnippets?: readonly string[];
+  /**
+   * Prompt seed for the LLM relevance judge. The Validator builds the full
+   * relevance prompt via `buildContentRelevancePrompt(...)` from
+   * `validation-rubric.ts`, using this as the section-purpose body.
+   */
+  relevancePromptSeed?: string;
+  /** Severity if the deterministic rules fail. */
+  severityOnFail: ContractSeverity;
+  /** Operator-facing fix hint surfaced to the owning agent on failure. */
+  fixHint: string;
+}
+
+// ─── SectionExample ─────────────────────────────────────────────────────────
+
+/**
+ * Two examples per section — a "good" and a "bad" — teach the LLM judge
+ * what "complete" looks like. Used as few-shot fragments in relevance
+ * prompts and surfaced on the dashboard `/contracts` page.
+ */
+export interface SectionExample {
+  /** A canonical "complete" populated section. */
+  good: unknown;
+  /** A canonical "incomplete" / "off-topic" populated section. */
+  bad: unknown;
+  /**
+   * Short rationale for why `bad` is bad — fed into the LLM judge's
+   * few-shot prompt and shown to operators on the dashboard.
+   */
+  badRationale: string;
+}
+
+// ─── SectionSpec ────────────────────────────────────────────────────────────
+
+/**
+ * One section in an agent's contract. The validator iterates the union of
+ * specs from the composed template per story.
+ */
+export interface SectionSpec {
+  /**
+   * Dotted path identifying the section within the ticket payload, e.g.
+   * `'scope'`, `'agentSections.architecture'`, `'taxonomy.effort'`,
+   * `'architecturalInstructions'` (when ARCH-006 lands).
+   *
+   * Used as the `section` key in `validation-rubric.ts` findings and as the
+   * key in `EA_OWNED_PREFIXES` ownership classification.
+   */
+  name: string;
+  /** Operator-facing description: what this section IS. */
+  description: string;
+  /** Operator-facing rationale: why downstream agents need this section. */
+  purpose: string;
+  /**
+   * Structural validation. The Validator parses the section payload through
+   * this Zod schema before any rubric checks run.
+   */
+  dataShape: ZodTypeAny;
+  /**
+   * Hard-required vs optional within the contract's `appliesTo` scopes.
+   * Override per-scope via `scopeOverrides`.
+   */
+  required: boolean;
+  /** Per-section validation rubric (deterministic + LLM). */
+  rubric: SectionRubric;
+  /**
+   * Other section names (in the same composed template) that must be present
+   * and valid before this section is evaluated. Composition warns if a
+   * declared dependency is missing in the composed template for a scope.
+   */
+  dependencies?: readonly string[];
+  /**
+   * Two examples — the LLM judge uses these as few-shot fragments and the
+   * dashboard renders them as "what good/bad looks like".
+   */
+  examples: readonly SectionExample[];
+  /**
+   * Optional per-scope overrides — relax `required` or shrink/grow rubric
+   * thresholds at specific scopes (e.g. initiative scope demands more
+   * strategic depth from `scope.summary`; subtask demands less).
+   *
+   * Override semantics:
+   *  - `required` (if set) replaces the base `required`.
+   *  - Rubric fields (if set) shallow-merge over the base rubric — i.e.
+   *    each set field replaces the base value.
+   */
+  scopeOverrides?: Partial<
+    Record<StoryScope, Partial<SectionRubric> & { required?: boolean }>
+  >;
+}
+
+// ─── SectionContract ────────────────────────────────────────────────────────
+
+/**
+ * The top-level contract object an agent registers with the Agent Section
+ * Contract Registry. One agent may register multiple contracts (e.g. one
+ * per scope-cluster) but the canonical pattern is a single contract per
+ * agent role.
+ */
+export interface SectionContract {
+  /** Owning agent — drives ownership classification + pipeline ordering. */
+  ownerAgent: AgentRole;
+  /**
+   * Stable identifier — used for de-dup, conflict messages, and dashboard
+   * navigation. Format suggestion: `<agent>-agent.v<major>` (e.g.
+   * `'po-agent.v1'`).
+   */
+  contractId: string;
+  /**
+   * Human-readable semver-ish version. Bumped on any rubric/spec change.
+   * Surfaced in the `signature` of the ComposedTemplate so drift is
+   * detectable.
+   */
+  version: string;
+  /** Story scopes this contract is required for. */
+  appliesTo: readonly StoryScope[];
+  /** Sections this contract owns. */
+  sections: readonly SectionSpec[];
+}
+
+// ─── ComposedTemplate (consumed by Validator) ───────────────────────────────
+
+/**
+ * One section as it appears in the runtime-composed template, after applying
+ * scope overrides and resolving any conflicts via the agent-pipeline order.
+ */
+export interface ComposedSectionEntry {
+  spec: SectionSpec;
+  /** Base `rubric` shallow-merged with the matching `scopeOverrides[scope]`. */
+  effectiveRubric: SectionRubric;
+  /** Base `required` overridden by `scopeOverrides[scope].required` if set. */
+  effectiveRequired: boolean;
+  /** Owning agent — copied from the contract for fast lookup. */
+  ownerAgent: AgentRole;
+  /** Source contract ID — for failure-attribution and dashboard rendering. */
+  contractId: string;
+}
+
+/**
+ * The validator's runtime input. Built by `composeTemplate(scope)` from the
+ * registry; cached per scope per process; invalidated on registry mutation.
+ */
+export interface ComposedTemplate {
+  scope: StoryScope;
+  /**
+   * Section name → composed entry. `Map` preserves insertion order, which
+   * matches agent-pipeline order (PO sections first, then BA, then EA, then
+   * Test-Design).
+   */
+  sections: ReadonlyMap<string, ComposedSectionEntry>;
+  /**
+   * Stable signature — a hash of the normalized composed spec. Two
+   * compositions with the same signature produce identical validator
+   * behaviour. Used for cache keying + drift detection.
+   */
+  signature: string;
+  /**
+   * Composition warnings (non-fatal):
+   *  - Two contracts claim the same section name (later one ignored).
+   *  - A section's `dependencies` references an absent section.
+   */
+  warnings: readonly string[];
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the effective rubric + required for a section at a given scope.
+ * Pure; used internally by `composeTemplate` and exposed for tests.
+ */
+export function applyScopeOverride(
+  spec: SectionSpec,
+  scope: StoryScope,
+): { effectiveRubric: SectionRubric; effectiveRequired: boolean } {
+  const override = spec.scopeOverrides?.[scope];
+  if (!override) {
+    return { effectiveRubric: spec.rubric, effectiveRequired: spec.required };
+  }
+  const { required: overrideRequired, ...rubricOverride } = override;
+  const effectiveRubric: SectionRubric = {
+    ...spec.rubric,
+    ...rubricOverride,
+  };
+  const effectiveRequired =
+    overrideRequired !== undefined ? overrideRequired : spec.required;
+  return { effectiveRubric, effectiveRequired };
+}
+
+/**
+ * Compare two scopes by ordinal — useful for "section X applies to scopes
+ * coarser than module".
+ */
+export function compareScopes(a: StoryScope, b: StoryScope): number {
+  return STORY_SCOPE_ORDER[a] - STORY_SCOPE_ORDER[b];
+}
+
+/**
+ * True iff `scope` is at least as coarse (higher in the hierarchy) as
+ * `referenceScope`. `initiative` is the coarsest, `subtask` the finest.
+ */
+export function isScopeAtLeastAsCoarseAs(
+  scope: StoryScope,
+  referenceScope: StoryScope,
+): boolean {
+  return STORY_SCOPE_ORDER[scope] <= STORY_SCOPE_ORDER[referenceScope];
+}


### PR DESCRIPTION
## ACR-001 — Agent Section Contract Registry primitives

First PR in the **Agent Section Contract Registry** track. Adds the primitive types (`SectionContract`, `SectionSpec`, `SectionRubric`, `ComposedTemplate`) plus the `StoryScope` hierarchy (initiative → epic → module → story → task → subtask) and a `story_scope` column on the `stories` table.

Each ticket-writing agent (PO, BA, EA, Test-Design) will declare a `SectionContract` listing the sections it populates with per-scope rubrics. The Validator composes contracts at runtime via `composeTemplate(scope)` (ACR-002) and uses the result as its rubric. Adding a new agent is just registering a contract — no Validator change.

End state: every story self-sufficient, stateless, context-less. Test-Design + coding agents get everything from the ticket alone.

### Changes

- `packages/ticket-template/src/section-contract.ts` — new file. `StoryScope`, `AgentRole`, `SectionRubric`, `SectionExample`, `SectionSpec`, `SectionContract`, `ComposedSectionEntry`, `ComposedTemplate`, helpers (`applyScopeOverride`, `compareScopes`, `isScopeAtLeastAsCoarseAs`, `isStoryScope`).
- `packages/ticket-template/src/section-contract.test.ts` — 15 unit tests.
- `packages/ticket-template/src/index.ts` — re-exports.
- `apps/orchestrator/src/db/migrations/0030_story_scope.sql` — `story_scope` column + `story_story_scope_idx` index. NOT NULL DEFAULT 'story'.
- `apps/orchestrator/src/db/migrations/meta/_journal.json` — appended 0030 entry.
- `apps/orchestrator/src/db/schema.ts` — `storyScope` column + index.

### Test results

- 130/130 ticket-template tests pass (15 new in `section-contract.test.ts`).
- `@caia-app/core typecheck` clean.

### Coordination

- **VAL-### track:** no overlap — this PR is types + migration only. ACR-007 will refactor the Validator to consume composed templates AFTER VAL-004/005/009 land.
- **ARCH-### track:** independent — ACR-005 (EA contract) will declare a stub for `architecturalInstructions` and bump version when ARCH-006 lands.
- **TEST-### track:** ACR-006 will wrap the existing `testCases` field.
- **BUCKET-### track:** taxonomy enums consumed read-only.

### Architecture report

`~/Documents/projects/reports/agent-contract-registry-architecture-2026-04-28.md`

### Sequencing

- ACR-001 (this PR) → ACR-002 → ACR-003/004/005/006 (parallelizable) → ACR-008 (backfill) → ACR-007 (Validator refactor, gated on VAL merges) → ACR-009 (dashboard) → ACR-010 (E2E) → ACR-011 (docs).

Refs: ACR-001 (Agent Section Contract Registry)