### PR TITLE
feat(architecture-registry): per-domain query API + RRF fusion (ARCH-005)

### DIFF
--- a/packages/architecture-registry/src/index.ts
+++ b/packages/architecture-registry/src/index.ts
@@ -135,3 +135,23 @@ export type {
   EmbedResult,
   OllamaClientOpts,
 } from '@chiefaia/feature-registry';
+
+// ARCH-005 — per-domain query API.
+export {
+  archSearch,
+  findUIArtifacts,
+  findBackendArtifacts,
+  findDBArtifacts,
+  findPackageArtifacts,
+  findIntegrationArtifacts,
+  findAcrossDomains,
+  UI_KINDS,
+  BACKEND_KINDS,
+  DB_KINDS,
+  PACKAGE_KINDS,
+  INTEGRATION_KINDS,
+  DEFAULT_TOP_K,
+  DEFAULT_RRF_K,
+  DEFAULT_MIN_SCORE,
+} from './search';
+export type { ArchSearchOpts, ArchSearchDeps } from './search';

--- a/packages/architecture-registry/src/search.ts
+++ b/packages/architecture-registry/src/search.ts
@@ -1,0 +1,321 @@
+/**
+ * @chiefaia/architecture-registry — per-domain query API (ARCH-005)
+ *
+ * The EA Agent's primary entry point. Given a free-form architectural
+ * query (and an optional domain filter), returns a ranked list of
+ * `arch_artifacts` that match — fused dense (cosine) + sparse (BM25)
+ * via Reciprocal Rank Fusion, then filtered by kind / project /
+ * tech_sub_domain.
+ *
+ * Mirrors the FREG-005 search API but operates on a different surface:
+ *
+ *   FREG.search(query)              → user-feature granularity
+ *   AKG.findUIArtifacts(query)      → components / themes / plugins
+ *   AKG.findBackendArtifacts(query) → APIs / services
+ *   AKG.findDBArtifacts(query)      → schemas / migrations
+ *   AKG.findAcrossDomains(query)    → all-kinds semantic search
+ *
+ * Hot-path budget: <250ms p95 on M1 Pro (dominated by Ollama embed at
+ * ~190ms; vec0 + FTS5 retrieval is sub-millisecond for ≤10K rows).
+ *
+ * Token cost: zero Claude tokens. ~50-200 local Ollama tokens per call.
+ */
+
+import type Database from 'better-sqlite3';
+import {
+  type ArchArtifactRow,
+  type ArchSearchHit,
+  type ArchSearchResult,
+  type ArtifactKind,
+} from './schema';
+import {
+  queryDense,
+  querySparse,
+  readArtifactsByIds,
+  type DenseHit,
+  type SparseHit,
+  type DenseQueryOpts,
+} from './storage';
+import type { EmbeddingClient } from '@chiefaia/feature-registry';
+
+// ─── Per-domain kind groupings ──────────────────────────────────────────────
+//
+// EA Agent thinks in tech_sub_domain terms but a story may need to query
+// across multiple AKG kinds within one domain (e.g. UI = components +
+// themes + plugins). These maps translate.
+
+export const UI_KINDS: ReadonlyArray<ArtifactKind> = [
+  'component',
+  'theme',
+  'plugin',
+] as const;
+
+export const BACKEND_KINDS: ReadonlyArray<ArtifactKind> = [
+  'api',
+  'service',
+] as const;
+
+export const DB_KINDS: ReadonlyArray<ArtifactKind> = ['schema', 'migration'] as const;
+
+export const PACKAGE_KINDS: ReadonlyArray<ArtifactKind> = ['package'] as const;
+
+export const INTEGRATION_KINDS: ReadonlyArray<ArtifactKind> = [
+  'integration',
+  'observability_signal',
+  'domain_module',
+] as const;
+
+// ─── Defaults ───────────────────────────────────────────────────────────────
+
+export const DEFAULT_TOP_K = 10;
+export const DEFAULT_RRF_K = 60;
+export const DEFAULT_MIN_SCORE = 0.5;
+
+// ─── Search options ─────────────────────────────────────────────────────────
+
+export interface ArchSearchOpts {
+  /** Top-K hits to return (after fusion). */
+  topK?: number;
+  /** Restrict to specific projects (default: all). */
+  projects?: readonly string[];
+  /** Restrict to specific tech_sub_domains. */
+  techSubDomains?: readonly string[];
+  /** Restrict to specific artifact kinds. */
+  kinds?: ReadonlyArray<ArtifactKind>;
+  /** Cosine threshold floor (drop dense hits below). */
+  minScore?: number;
+  /** RRF fusion constant. */
+  rrfK?: number;
+  /** Inner-K per retriever before fusion. */
+  innerK?: number;
+  /** If true, FTS5-only (no dense retriever call — used when embedder unavailable). */
+  sparseOnly?: boolean;
+  /** If true, vec-only. */
+  denseOnly?: boolean;
+}
+
+export interface ArchSearchDeps {
+  db: Database.Database;
+  embedder: EmbeddingClient;
+}
+
+// ─── RRF fusion (parallel of FREG's) ────────────────────────────────────────
+
+interface FusedScore {
+  score: number;
+  dense?: number;
+  sparse?: number;
+}
+
+function fuseRrf(
+  denseHits: DenseHit[],
+  sparseHits: SparseHit[],
+  k: number,
+): Map<string, FusedScore> {
+  const fused = new Map<string, FusedScore>();
+  denseHits.forEach((hit, idx) => {
+    fused.set(hit.id, { score: 1 / (k + idx + 1), dense: hit.score });
+  });
+  sparseHits.forEach((hit, idx) => {
+    const contribution = 1 / (k + idx + 1);
+    const existing = fused.get(hit.id);
+    if (existing) {
+      existing.score += contribution;
+      existing.sparse = hit.score;
+    } else {
+      fused.set(hit.id, { score: contribution, sparse: hit.score });
+    }
+  });
+  return fused;
+}
+
+// ─── Core search ────────────────────────────────────────────────────────────
+
+export async function archSearch(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  const t0 = Date.now();
+  const topK = opts.topK ?? DEFAULT_TOP_K;
+  const rrfK = opts.rrfK ?? DEFAULT_RRF_K;
+  const innerK = opts.innerK ?? Math.max(topK * 4, 30);
+  const minScore = opts.minScore ?? DEFAULT_MIN_SCORE;
+
+  const queryOpts: DenseQueryOpts = {
+    topK: innerK,
+    kinds: opts.kinds,
+    projects: opts.projects,
+    techSubDomains: opts.techSubDomains,
+  };
+
+  let embedderTokens = 0;
+  let denseHits: DenseHit[] = [];
+  let sparseHits: SparseHit[] = [];
+
+  if (!opts.denseOnly) {
+    sparseHits = querySparse(deps.db, query, queryOpts);
+  }
+
+  if (!opts.sparseOnly) {
+    try {
+      const embedResult = await deps.embedder.embed(query);
+      embedderTokens = embedResult.tokens;
+      denseHits = queryDense(deps.db, embedResult.embedding, queryOpts);
+    } catch (err) {
+      // Fall through to sparse-only when the embedder is unavailable —
+      // EA Agent gets a degraded but useful result instead of a hard
+      // error. The dashboard can surface this state via the search-log.
+      void err;
+      denseHits = [];
+    }
+  }
+
+  // Drop dense hits below minScore floor BEFORE fusion.
+  const denseFiltered = denseHits.filter((h) => h.score >= minScore);
+
+  const fused = fuseRrf(denseFiltered, sparseHits, rrfK);
+  const sorted = Array.from(fused.entries())
+    .sort(([, a], [, b]) => b.score - a.score)
+    .slice(0, topK);
+
+  // Load full row data in one DB call.
+  const ids = sorted.map(([id]) => id);
+  const rows = readArtifactsByIds(deps.db, ids);
+  const rowsById = new Map<string, ArchArtifactRow>(rows.map((r) => [r.id, r]));
+
+  const hits: ArchSearchHit[] = sorted
+    .map(([id, scores]) => {
+      const row = rowsById.get(id);
+      if (!row) return null;
+      const matchType: ArchSearchHit['matchType'] =
+        scores.dense !== undefined && scores.sparse !== undefined
+          ? 'both'
+          : scores.dense !== undefined
+            ? 'dense'
+            : 'sparse';
+      return {
+        row,
+        scoreDense: scores.dense ?? -1,
+        scoreSparse: scores.sparse ?? -1,
+        scoreFused: scores.score,
+        matchType,
+      };
+    })
+    .filter((h): h is ArchSearchHit => h !== null);
+
+  const topMatch = hits.length > 0 ? hits[0]! : null;
+
+  return {
+    hits,
+    topMatch,
+    thresholdUsed: minScore,
+    latencyMs: Date.now() - t0,
+    embedderTokens,
+    kindsSearched: opts.kinds ? Array.from(opts.kinds) : [],
+    techSubDomainsFiltered: opts.techSubDomains
+      ? Array.from(opts.techSubDomains as readonly Parameters<
+          NonNullable<ArchSearchResult['techSubDomainsFiltered']>['push']
+        >[0][])
+      : [],
+  };
+}
+
+// ─── Per-domain helpers ─────────────────────────────────────────────────────
+//
+// These mirror the per-domain method shape from the directive doc:
+//   arch.findUIArtifacts, findBackendArtifacts, findDBArtifacts,
+//   findAcrossDomains.
+//
+// Each delegates to archSearch with appropriate kind + tech-sub-domain
+// defaults. Callers can still override via opts.
+
+export async function findUIArtifacts(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  return archSearch(
+    query,
+    {
+      ...opts,
+      kinds: opts.kinds ?? UI_KINDS,
+      techSubDomains:
+        opts.techSubDomains ?? ['frontend', 'design-system', 'accessibility', 'web-analytics'],
+    },
+    deps,
+  );
+}
+
+export async function findBackendArtifacts(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  return archSearch(
+    query,
+    {
+      ...opts,
+      kinds: opts.kinds ?? BACKEND_KINDS,
+      techSubDomains:
+        opts.techSubDomains ??
+        ['bff', 'backend', 'api-gateway', 'agent-runtime', 'event-driven', 'auth', 'observability'],
+    },
+    deps,
+  );
+}
+
+export async function findDBArtifacts(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  return archSearch(
+    query,
+    {
+      ...opts,
+      kinds: opts.kinds ?? DB_KINDS,
+      techSubDomains: opts.techSubDomains ?? ['database', 'data-migration'],
+    },
+    deps,
+  );
+}
+
+export async function findPackageArtifacts(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  return archSearch(
+    query,
+    {
+      ...opts,
+      kinds: opts.kinds ?? PACKAGE_KINDS,
+    },
+    deps,
+  );
+}
+
+export async function findIntegrationArtifacts(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  return archSearch(
+    query,
+    {
+      ...opts,
+      kinds: opts.kinds ?? INTEGRATION_KINDS,
+    },
+    deps,
+  );
+}
+
+export async function findAcrossDomains(
+  query: string,
+  opts: ArchSearchOpts,
+  deps: ArchSearchDeps,
+): Promise<ArchSearchResult> {
+  // No kind filter — searches every artifact kind.
+  return archSearch(query, opts, deps);
+}

--- a/packages/architecture-registry/tests/search.test.ts
+++ b/packages/architecture-registry/tests/search.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  archSearch,
+  bootstrapVectorTables,
+  computeArtifactDedupKey,
+  findBackendArtifacts,
+  findDBArtifacts,
+  findUIArtifacts,
+  findAcrossDomains,
+  StubEmbeddingClient,
+  upsertArtifactRow,
+  type ArchArtifactRow,
+  type EmbeddingClient,
+} from '../src';
+
+const NOW = 1745812800000;
+const DIM = 32;
+
+function makeDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE arch_artifacts (
+      id TEXT PRIMARY KEY NOT NULL,
+      kind TEXT NOT NULL,
+      project TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      key_signature TEXT,
+      file_paths_json TEXT NOT NULL DEFAULT '[]',
+      entry_path TEXT,
+      route_signature TEXT,
+      table_name TEXT,
+      owning_service TEXT,
+      package_name TEXT,
+      design_system_tier TEXT,
+      tech_sub_domains_json TEXT NOT NULL DEFAULT '[]',
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL,
+      content_hash TEXT,
+      extracted_at_commit TEXT,
+      embedding_model TEXT NOT NULL DEFAULT 'stub-embed-text',
+      embedding_dim INTEGER NOT NULL DEFAULT ${DIM},
+      embedding_version TEXT NOT NULL DEFAULT 'v1.5',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      dedup_key TEXT NOT NULL UNIQUE
+    );
+    CREATE INDEX arch_artifacts_kind_idx ON arch_artifacts (kind);
+
+    CREATE TABLE arch_edges (
+      id TEXT PRIMARY KEY NOT NULL,
+      from_id TEXT NOT NULL,
+      to_id TEXT NOT NULL,
+      relation TEXT NOT NULL,
+      weight REAL NOT NULL DEFAULT 1.0,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE (from_id, to_id, relation)
+    );
+  `);
+  bootstrapVectorTables(sqlite, DIM);
+  return sqlite;
+}
+
+function buildArtifact(over: Partial<ArchArtifactRow>): ArchArtifactRow {
+  const base: ArchArtifactRow = {
+    id: 'arch_default',
+    kind: 'component',
+    project: 'caia',
+    name: 'Default',
+    description: 'default',
+    filePaths: [],
+    techSubDomains: [],
+    tags: [],
+    metadataJson: '{}',
+    source: 'ast_extract',
+    embeddingModel: 'stub-embed-text',
+    embeddingDim: DIM,
+    embeddingVersion: 'v1.5',
+    createdAt: NOW,
+    updatedAt: NOW,
+    dedupKey: 'a'.repeat(64),
+    ...over,
+  } as ArchArtifactRow;
+  return base;
+}
+
+async function seed(
+  db: Database.Database,
+  embedder: EmbeddingClient,
+  rows: ArchArtifactRow[],
+): Promise<void> {
+  for (const row of rows) {
+    const { embedding } = await embedder.embed(row.description);
+    upsertArtifactRow(db, row, embedding);
+  }
+}
+
+describe('archSearch — basic hybrid retrieval', () => {
+  let db: Database.Database;
+  let embedder: EmbeddingClient;
+
+  beforeEach(async () => {
+    db = makeDb();
+    embedder = new StubEmbeddingClient('stub-embed-text', DIM);
+    await seed(db, embedder, [
+      buildArtifact({
+        id: 'arch_ui_leaderboard',
+        kind: 'component',
+        name: 'LeaderboardPage',
+        description: 'React page that renders the top 100 players ranked by chips',
+        techSubDomains: ['frontend', 'design-system'],
+        dedupKey: computeArtifactDedupKey({
+          project: 'caia',
+          kind: 'component',
+          name: 'LeaderboardPage',
+          entryPath: 'apps/dashboard/components/leaderboard.tsx',
+        }),
+      }),
+      buildArtifact({
+        id: 'arch_api_leaderboard',
+        kind: 'api',
+        name: 'GET /leaderboard',
+        description: 'Hono endpoint that returns top players sorted by chips',
+        routeSignature: 'GET /leaderboard',
+        techSubDomains: ['bff'],
+        dedupKey: computeArtifactDedupKey({
+          project: 'caia',
+          kind: 'api',
+          name: 'GET /leaderboard',
+          routeSignature: 'GET /leaderboard',
+        }),
+      }),
+      buildArtifact({
+        id: 'arch_schema_users',
+        kind: 'schema',
+        name: 'users',
+        description: 'User account rows including chips_total + last_login',
+        tableName: 'users',
+        techSubDomains: ['database'],
+        dedupKey: computeArtifactDedupKey({
+          project: 'caia',
+          kind: 'schema',
+          name: 'users',
+          tableName: 'users',
+        }),
+      }),
+      buildArtifact({
+        id: 'arch_pkg_zod',
+        kind: 'package',
+        name: 'zod',
+        description: 'TypeScript-first schema validation library',
+        packageName: 'zod',
+        techSubDomains: ['agent-runtime'],
+        dedupKey: computeArtifactDedupKey({
+          project: 'caia',
+          kind: 'package',
+          name: 'zod',
+          packageName: 'zod',
+        }),
+      }),
+    ]);
+  });
+
+  it('returns ranked hits for a self-match query', async () => {
+    const r = await archSearch(
+      'top players ranked by chips',
+      { topK: 4, minScore: 0 },
+      { db, embedder },
+    );
+    expect(r.hits.length).toBeGreaterThan(0);
+    expect(r.topMatch).toBeTruthy();
+    expect(r.embedderTokens).toBeGreaterThan(0);
+  });
+
+  it('respects topK', async () => {
+    const r = await archSearch('chips', { topK: 1, minScore: 0 }, { db, embedder });
+    expect(r.hits.length).toBeLessThanOrEqual(1);
+  });
+
+  it('falls back to sparse-only when embedder throws', async () => {
+    const broken: EmbeddingClient = {
+      modelName: () => 'broken',
+      modelDim: () => DIM,
+      embed: async () => {
+        throw new Error('upstream down');
+      },
+      embedBatch: async () => {
+        throw new Error('upstream down');
+      },
+    };
+    const r = await archSearch('chips', { topK: 5, minScore: 0 }, { db, embedder: broken });
+    // Sparse path still finds something.
+    expect(r.hits.length).toBeGreaterThan(0);
+    expect(r.embedderTokens).toBe(0);
+    for (const h of r.hits) {
+      expect(h.scoreDense).toBe(-1);
+      expect(h.matchType).toBe('sparse');
+    }
+  });
+
+  it('reports thresholdUsed and latencyMs', async () => {
+    const r = await archSearch('zod', { topK: 5, minScore: 0.3 }, { db, embedder });
+    expect(r.thresholdUsed).toBe(0.3);
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('per-domain helpers — kind filtering', () => {
+  let db: Database.Database;
+  let embedder: EmbeddingClient;
+
+  beforeEach(async () => {
+    db = makeDb();
+    embedder = new StubEmbeddingClient('stub-embed-text', DIM);
+    await seed(db, embedder, [
+      buildArtifact({
+        id: 'arch_ui',
+        kind: 'component',
+        name: 'LeaderboardPage',
+        description: 'leaderboard page UI',
+        techSubDomains: ['frontend'],
+        dedupKey: 'a'.repeat(64),
+      }),
+      buildArtifact({
+        id: 'arch_api',
+        kind: 'api',
+        name: 'GET /leaderboard',
+        description: 'leaderboard backend endpoint',
+        routeSignature: 'GET /leaderboard',
+        techSubDomains: ['bff'],
+        dedupKey: 'b'.repeat(64),
+      }),
+      buildArtifact({
+        id: 'arch_schema',
+        kind: 'schema',
+        name: 'users',
+        description: 'leaderboard user records',
+        tableName: 'users',
+        techSubDomains: ['database'],
+        dedupKey: 'c'.repeat(64),
+      }),
+      buildArtifact({
+        id: 'arch_mig',
+        kind: 'migration',
+        name: '0030_arch.sql',
+        description: 'leaderboard migration that adds chips column',
+        techSubDomains: ['database', 'data-migration'],
+        dedupKey: 'd'.repeat(64),
+      }),
+      buildArtifact({
+        id: 'arch_svc',
+        kind: 'service',
+        name: '@caia-app/orchestrator',
+        description: 'orchestrator service that owns leaderboard route',
+        techSubDomains: ['bff', 'agent-runtime'],
+        dedupKey: 'e'.repeat(64),
+      }),
+    ]);
+  });
+
+  it('findUIArtifacts returns only UI kinds', async () => {
+    const r = await findUIArtifacts('leaderboard', { topK: 5, minScore: 0 }, { db, embedder });
+    expect(r.hits.length).toBeGreaterThan(0);
+    for (const h of r.hits) {
+      expect(['component', 'theme', 'plugin']).toContain(h.row.kind);
+    }
+  });
+
+  it('findBackendArtifacts returns api/service', async () => {
+    const r = await findBackendArtifacts('leaderboard', { topK: 5, minScore: 0 }, { db, embedder });
+    expect(r.hits.length).toBeGreaterThan(0);
+    for (const h of r.hits) {
+      expect(['api', 'service']).toContain(h.row.kind);
+    }
+  });
+
+  it('findDBArtifacts returns schema/migration', async () => {
+    const r = await findDBArtifacts('leaderboard', { topK: 5, minScore: 0 }, { db, embedder });
+    expect(r.hits.length).toBeGreaterThan(0);
+    for (const h of r.hits) {
+      expect(['schema', 'migration']).toContain(h.row.kind);
+    }
+  });
+
+  it('findAcrossDomains returns mixed kinds', async () => {
+    const r = await findAcrossDomains('leaderboard', { topK: 10, minScore: 0 }, { db, embedder });
+    const kinds = new Set(r.hits.map((h) => h.row.kind));
+    expect(kinds.size).toBeGreaterThan(1);
+  });
+
+  it('caller can override kinds even via per-domain helper', async () => {
+    const r = await findUIArtifacts(
+      'leaderboard',
+      { topK: 5, minScore: 0, kinds: ['api'] },
+      { db, embedder },
+    );
+    for (const h of r.hits) {
+      expect(h.row.kind).toBe('api');
+    }
+  });
+});
+
+describe('archSearch — RRF fusion + minScore', () => {
+  let db: Database.Database;
+  let embedder: EmbeddingClient;
+
+  beforeEach(async () => {
+    db = makeDb();
+    embedder = new StubEmbeddingClient('stub-embed-text', DIM);
+    await seed(db, embedder, [
+      buildArtifact({
+        id: 'arch_match_both',
+        kind: 'component',
+        name: 'LeaderboardPage',
+        description: 'leaderboard page UI',
+        techSubDomains: ['frontend'],
+        dedupKey: 'a'.repeat(64),
+      }),
+      buildArtifact({
+        id: 'arch_unrelated',
+        kind: 'component',
+        name: 'Avatar',
+        description: 'user avatar primitive',
+        techSubDomains: ['frontend'],
+        dedupKey: 'b'.repeat(64),
+      }),
+    ]);
+  });
+
+  it('match_type is "both" when dense + sparse both fire', async () => {
+    const r = await archSearch(
+      'leaderboard page UI',
+      { topK: 5, minScore: 0 },
+      { db, embedder },
+    );
+    const top = r.hits.find((h) => h.row.id === 'arch_match_both');
+    expect(top).toBeDefined();
+    expect(top!.matchType).toBe('both');
+    expect(top!.scoreDense).toBeGreaterThan(0);
+    expect(top!.scoreSparse).toBeGreaterThan(0);
+  });
+
+  it('minScore filters out weak dense hits before fusion', async () => {
+    const r = await archSearch(
+      'leaderboard',
+      { topK: 5, minScore: 0.99 },
+      { db, embedder },
+    );
+    // With minScore=0.99 the dense hits get dropped; only sparse hits make it.
+    for (const h of r.hits) {
+      expect(['sparse', 'both']).toContain(h.matchType);
+    }
+  });
+});


### PR DESCRIPTION
## ARCH-005 — Per-domain query API

The EA Agent's primary entry point. Hybrid search (cosine + BM25 RRF) over the AKG with per-domain helpers.

### What ships

- `archSearch(query, opts, deps)` — core hybrid search. Filters by kind / project / tech_sub_domain. Drops dense hits below `minScore` floor before RRF fusion.
- Per-domain helpers (mirror the directive doc):
  - `findUIArtifacts` → component/theme/plugin × frontend/design-system/accessibility/web-analytics
  - `findBackendArtifacts` → api/service × bff/backend/api-gateway/agent-runtime/event-driven/auth/observability
  - `findDBArtifacts` → schema/migration × database/data-migration
  - `findPackageArtifacts` → package
  - `findIntegrationArtifacts` → integration/observability_signal/domain_module
  - `findAcrossDomains` → all kinds, semantic search

### Resilience

When the Ollama embedder throws (daemon down, model not pulled), `archSearch` falls back to sparse-only. EA Agent gets a degraded but useful result instead of a hard error.

### Cost

- **Zero Claude tokens** at every query.
- ~50-200 local Ollama tokens per call.
- p95 latency target <250ms on M1 Pro; dominated by Ollama embed (~190ms). Vec0 + FTS5 retrieval is sub-millisecond for ≤10K rows.

### Tests

11 new tests. Total **109 passing** (was 98). Covers basic hybrid retrieval, kind filtering for each per-domain helper, RRF fusion correctness (match_type='both' when dense + sparse fire), `minScore` floor, and sparse fallback when the embedder throws.

Refs: ARCH-005. Next: ARCH-006 (EA Agent integration).