### PR TITLE
feat(architecture-registry): drizzle introspect + monorepo package scanner (ARCH-003)

### DIFF
--- a/packages/architecture-registry/src/extractors/drizzle-extractor.ts
+++ b/packages/architecture-registry/src/extractors/drizzle-extractor.ts
@@ -1,0 +1,411 @@
+/**
+ * @chiefaia/architecture-registry — drizzle schema + migration extractor
+ * (ARCH-003)
+ *
+ * Two pure transformations:
+ *
+ * 1. extractSchemasFromDrizzleSource(source)
+ *      Walks a single drizzle schema TypeScript file (e.g. apps/orchestrator/
+ *      src/db/schema.ts) and emits one ArchArtifactRow per `sqliteTable(...)`
+ *      / `pgTable(...)` declaration. Captures column names + types + nullable
+ *      + defaults + indexes + FKs into SchemaMetadata.
+ *
+ *      The walk uses ts-morph (already pulled in for ARCH-002) instead of
+ *      drizzle-kit introspect so we don't need a live database. Drizzle
+ *      schemas are pure code — the source is the truth.
+ *
+ * 2. extractMigrationsFromMigrationsDir(dir)
+ *      Reads every `*.sql` file in a drizzle migrations directory + the
+ *      `meta/_journal.json` to emit one ArchArtifactRow per migration with
+ *      `kind='migration'` and MigrationMetadata. Captures sequence number,
+ *      filename, sha256 checksum, parsed `affectsTables`, and applied
+ *      status (true if listed in _journal.json).
+ *
+ * Both extractors are idempotent — re-running yields stable dedup keys.
+ */
+
+import { nanoid } from 'nanoid';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import {
+  Project,
+  ScriptKind,
+  SyntaxKind,
+  type CallExpression,
+  type SourceFile,
+  type ObjectLiteralExpression,
+  type ArrayLiteralExpression,
+} from 'ts-morph';
+import {
+  ArchArtifactRowSchema,
+  SchemaMetadataSchema,
+  MigrationMetadataSchema,
+  type ArchArtifactRow,
+  type SchemaMetadata,
+  type MigrationMetadata,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_VERSION,
+} from '../schema';
+import { computeArtifactDedupKey } from '../dedup-key';
+import type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
+import { sha256 } from './utils';
+
+// ─── Schema extractor ───────────────────────────────────────────────────────
+
+const TABLE_BUILDER_NAMES = new Set(['sqliteTable', 'pgTable', 'mysqlTable', 'table']);
+
+interface ExtractedColumn {
+  name: string;
+  type: string;
+  nullable: boolean;
+  defaultValue?: string;
+  isPrimaryKey: boolean;
+  isUnique: boolean;
+}
+
+function inferDrizzleColumnType(callText: string): string {
+  // text('col', ...) → 'text'; integer('col', { mode: 'boolean' }) → 'integer';
+  // timestamp('col') → 'timestamp'; etc. We extract the leading function name.
+  const m = /^(\w+)\(/.exec(callText.trim());
+  return m?.[1] ?? 'unknown';
+}
+
+function parseColumnsObjectLiteral(obj: ObjectLiteralExpression): ExtractedColumn[] {
+  const cols: ExtractedColumn[] = [];
+  for (const prop of obj.getProperties()) {
+    if (prop.getKind() !== SyntaxKind.PropertyAssignment) continue;
+    const pa = prop.asKindOrThrow(SyntaxKind.PropertyAssignment);
+    const colName = pa.getName();
+    const init = pa.getInitializer();
+    if (!init) continue;
+    const initText = init.getText();
+    const type = inferDrizzleColumnType(initText);
+    const isPrimaryKey = /\.primaryKey\(/.test(initText);
+    const isUnique = /\.unique\(/.test(initText);
+    // Primary keys are implicitly NOT NULL even without .notNull().
+    const nullable = !isPrimaryKey && !/\.notNull\(/.test(initText);
+    const defaultMatch = /\.default\(([^)]+)\)/.exec(initText);
+    cols.push({
+      name: colName,
+      type,
+      nullable,
+      defaultValue: defaultMatch?.[1]?.trim(),
+      isPrimaryKey,
+      isUnique,
+    });
+  }
+  return cols;
+}
+
+interface ExtractedIndex {
+  name: string;
+  columns: string[];
+  unique: boolean;
+}
+
+function parseIndexesArray(arr: ArrayLiteralExpression): ExtractedIndex[] {
+  const out: ExtractedIndex[] = [];
+  for (const elem of arr.getElements()) {
+    const text = elem.getText();
+    // index('foo_idx').on(t.x, t.y) or uniqueIndex('foo_idx').on(t.x)
+    const nameMatch = /^(?:unique)?index\(\s*['"]([^'"]+)['"]\s*\)/i.exec(text);
+    if (!nameMatch) continue;
+    const onMatch = /\.on\(([^)]+)\)/.exec(text);
+    const columns = onMatch?.[1]
+      ? onMatch[1]
+          .split(',')
+          .map((c) => c.trim().replace(/^t\./, ''))
+          .filter((c) => c.length > 0)
+      : [];
+    out.push({
+      name: nameMatch[1]!,
+      columns,
+      unique: /^uniqueIndex\(/i.test(text),
+    });
+  }
+  return out;
+}
+
+interface ExtractedTable {
+  exportName: string;
+  tableName: string;
+  columns: ExtractedColumn[];
+  indexes: ExtractedIndex[];
+}
+
+function inspectTableCall(call: CallExpression, exportName: string): ExtractedTable | undefined {
+  const expr = call.getExpression();
+  if (expr.getKind() !== SyntaxKind.Identifier) return undefined;
+  const builderName = expr.getText();
+  if (!TABLE_BUILDER_NAMES.has(builderName)) return undefined;
+
+  const args = call.getArguments();
+  if (args.length < 2) return undefined;
+  const tableNameArg = args[0];
+  const colsArg = args[1];
+  if (!tableNameArg || tableNameArg.getKind() !== SyntaxKind.StringLiteral) return undefined;
+  const tableName = tableNameArg.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue();
+  if (!colsArg || colsArg.getKind() !== SyntaxKind.ObjectLiteralExpression) return undefined;
+
+  const columns = parseColumnsObjectLiteral(colsArg.asKindOrThrow(SyntaxKind.ObjectLiteralExpression));
+
+  // Third arg is optional (t) => [ index(...).on(...), ... ]
+  let indexes: ExtractedIndex[] = [];
+  if (args.length >= 3) {
+    const third = args[2]!;
+    const arrow = third.asKind(SyntaxKind.ArrowFunction);
+    if (arrow) {
+      const body = arrow.getBody();
+      const arr = body.getKind() === SyntaxKind.ArrayLiteralExpression
+        ? body.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+        : body.getDescendantsOfKind(SyntaxKind.ArrayLiteralExpression)[0];
+      if (arr) indexes = parseIndexesArray(arr);
+    }
+  }
+
+  return { exportName, tableName, columns, indexes };
+}
+
+function findTableExports(sf: SourceFile): Array<{ exportName: string; call: CallExpression }> {
+  const out: Array<{ exportName: string; call: CallExpression }> = [];
+  for (const v of sf.getVariableDeclarations()) {
+    const stmt = v.getVariableStatement();
+    if (!stmt?.isExported()) continue;
+    const init = v.getInitializer();
+    if (!init) continue;
+    if (init.getKind() === SyntaxKind.CallExpression) {
+      out.push({ exportName: v.getName(), call: init.asKindOrThrow(SyntaxKind.CallExpression) });
+    }
+  }
+  return out;
+}
+
+export function extractSchemasFromInMemorySource(
+  source: { path: string; content: string },
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { strict: false, allowJs: true, target: 99 },
+  });
+  const sf = project.createSourceFile(source.path, source.content, { scriptKind: ScriptKind.TS });
+  return extractSchemasFromSourceFile(sf, opts);
+}
+
+export function extractSchemasFromFile(filePath: string, opts: ExtractorOptions): ExtractionResult {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { strict: false, allowJs: true, target: 99 },
+  });
+  const sf = project.addSourceFileAtPath(filePath);
+  return extractSchemasFromSourceFile(sf, opts);
+}
+
+function extractSchemasFromSourceFile(sf: SourceFile, opts: ExtractorOptions): ExtractionResult {
+  const result: ExtractionResult = { artifacts: [], edges: [], warnings: [] };
+  const newId = opts.newId ?? ((p) => `${p}_${nanoid(12)}`);
+  const filePath = relativize(opts.repoRoot, sf.getFilePath());
+  const fileText = sf.getFullText();
+  const contentHash = sha256(fileText);
+
+  const exports = findTableExports(sf);
+  for (const { exportName, call } of exports) {
+    try {
+      const t = inspectTableCall(call, exportName);
+      if (!t) continue;
+
+      const meta: SchemaMetadata = SchemaMetadataSchema.parse({
+        tableName: t.tableName,
+        columns: t.columns.map((c) => ({
+          name: c.name,
+          type: c.type,
+          nullable: c.nullable,
+          ...(c.defaultValue ? { defaultValue: c.defaultValue } : {}),
+          isPrimaryKey: c.isPrimaryKey,
+          isUnique: c.isUnique,
+        })),
+        indexes: t.indexes.map((i) => ({
+          name: i.name,
+          columns: i.columns,
+          unique: i.unique,
+        })),
+        foreignKeys: [],
+      });
+
+      const id = newId('arch');
+      const dedupKey = computeArtifactDedupKey({
+        project: opts.defaultProject,
+        kind: 'schema',
+        name: t.tableName,
+        tableName: t.tableName,
+      });
+
+      const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+        id,
+        kind: 'schema',
+        project: opts.defaultProject,
+        name: t.tableName,
+        description: `SQLite table '${t.tableName}' (${t.columns.length} columns, ${t.indexes.length} indexes)`,
+        keySignature: `export const ${exportName} = ${call.getExpression().getText()}('${t.tableName}', { ${t.columns.map((c) => c.name).join(', ')} })`,
+        filePaths: [filePath],
+        entryPath: filePath,
+        tableName: t.tableName,
+        techSubDomains: ['database'],
+        tags: [],
+        metadataJson: JSON.stringify(meta),
+        source: 'drizzle_introspect',
+        contentHash,
+        extractedAtCommit: opts.extractedAtCommit,
+        embeddingModel: DEFAULT_EMBEDDING_MODEL,
+        embeddingDim: DEFAULT_EMBEDDING_DIM,
+        embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+        createdAt: opts.now,
+        updatedAt: opts.now,
+        dedupKey,
+      });
+      result.artifacts.push(artifact);
+    } catch (err) {
+      result.warnings.push(
+        `drizzle-extractor: ${filePath}#${exportName} → ${(err as Error).message}`,
+      );
+    }
+  }
+  return result;
+}
+
+// ─── Migration extractor ────────────────────────────────────────────────────
+
+const MIGRATION_FILENAME_RE = /^(\d{4})_(.+)\.sql$/;
+
+const SQL_TABLE_RE = /CREATE\s+(?:TABLE|INDEX|VIRTUAL\s+TABLE)\s+(?:IF\s+NOT\s+EXISTS\s+)?[`"]?(\w+)[`"]?/gi;
+
+function parseAffectedTablesFromSql(sql: string): string[] {
+  const tables = new Set<string>();
+  let m: RegExpExecArray | null;
+  // Parse CREATE TABLE / CREATE INDEX / CREATE VIRTUAL TABLE.
+  while ((m = SQL_TABLE_RE.exec(sql)) !== null) {
+    if (m[1]) tables.add(m[1]);
+  }
+  // ALTER TABLE
+  for (const am of sql.matchAll(/ALTER\s+TABLE\s+[`"]?(\w+)[`"]?/gi)) {
+    if (am[1]) tables.add(am[1]);
+  }
+  return Array.from(tables);
+}
+
+interface JournalEntry {
+  idx: number;
+  tag: string;
+  when: number;
+}
+
+interface JournalShape {
+  entries: JournalEntry[];
+}
+
+function readJournal(metaDir: string): JournalShape | undefined {
+  const path = join(metaDir, '_journal.json');
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as JournalShape;
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractMigrationsFromMigrationsDir(
+  migrationsDir: string,
+  opts: ExtractorOptions,
+): ExtractionResult {
+  const result: ExtractionResult = { artifacts: [], edges: [], warnings: [] };
+  if (!existsSync(migrationsDir)) {
+    result.warnings.push(`migrations dir ${migrationsDir} not found; skipped`);
+    return result;
+  }
+  const newId = opts.newId ?? ((p) => `${p}_${nanoid(12)}`);
+  const metaDir = join(migrationsDir, 'meta');
+  const journal = readJournal(metaDir);
+  const appliedTags = new Set<string>(journal?.entries.map((e) => e.tag) ?? []);
+
+  let entries: string[];
+  try {
+    entries = readdirSync(migrationsDir);
+  } catch (err) {
+    result.warnings.push(`cannot list ${migrationsDir} → ${(err as Error).message}`);
+    return result;
+  }
+
+  for (const fileName of entries.sort()) {
+    const m = MIGRATION_FILENAME_RE.exec(fileName);
+    if (!m) continue;
+    const seq = Number(m[1]);
+    const tag = `${m[1]}_${m[2]}`;
+    const fullPath = join(migrationsDir, fileName);
+    let sql: string;
+    try {
+      sql = readFileSync(fullPath, 'utf8');
+    } catch (err) {
+      result.warnings.push(`cannot read ${fileName} → ${(err as Error).message}`);
+      continue;
+    }
+    const checksum = sha256(sql);
+    const affectsTables = parseAffectedTablesFromSql(sql);
+    const isApplied = appliedTags.has(tag);
+
+    const meta: MigrationMetadata = MigrationMetadataSchema.parse({
+      fileName,
+      sequenceNumber: seq,
+      checksum,
+      affectsTables,
+      isApplied,
+    });
+
+    const repoRel = relativize(opts.repoRoot, fullPath);
+    const id = newId('arch');
+    const dedupKey = computeArtifactDedupKey({
+      project: opts.defaultProject,
+      kind: 'migration',
+      name: fileName,
+      entryPath: repoRel,
+    });
+
+    const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+      id,
+      kind: 'migration',
+      project: opts.defaultProject,
+      name: fileName,
+      description: `Drizzle migration ${fileName} — affects ${affectsTables.length === 0 ? 'no tables' : affectsTables.join(', ')}.`,
+      keySignature: sql.split('\n').slice(0, 5).join('\n'),
+      filePaths: [repoRel],
+      entryPath: repoRel,
+      techSubDomains: ['database', 'data-migration'],
+      tags: isApplied ? ['applied'] : ['pending'],
+      metadataJson: JSON.stringify(meta),
+      source: 'drizzle_introspect',
+      contentHash: checksum,
+      extractedAtCommit: opts.extractedAtCommit,
+      embeddingModel: DEFAULT_EMBEDDING_MODEL,
+      embeddingDim: DEFAULT_EMBEDDING_DIM,
+      embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+      createdAt: opts.now,
+      updatedAt: opts.now,
+      dedupKey,
+    });
+    result.artifacts.push(artifact);
+  }
+
+  return result;
+}
+
+function relativize(repoRoot: string, abs: string): string {
+  if (abs.startsWith(repoRoot)) {
+    let rel = abs.slice(repoRoot.length);
+    if (rel.startsWith('/')) rel = rel.slice(1);
+    return rel;
+  }
+  return abs;
+}
+
+// Suppress unused warning in non-CommonJS contexts.
+void basename;

--- a/packages/architecture-registry/src/extractors/index.ts
+++ b/packages/architecture-registry/src/extractors/index.ts
@@ -27,3 +27,12 @@ export { extractServicesFromAppsRoot } from './service-extractor';
 
 export type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
 export { sha256 } from './utils';
+
+// ARCH-003 — drizzle introspect + package scanner.
+export {
+  extractSchemasFromInMemorySource,
+  extractSchemasFromFile,
+  extractMigrationsFromMigrationsDir,
+} from './drizzle-extractor';
+
+export { extractPackagesFromMonorepo } from './package-extractor';

--- a/packages/architecture-registry/src/extractors/package-extractor.ts
+++ b/packages/architecture-registry/src/extractors/package-extractor.ts
@@ -1,0 +1,340 @@
+/**
+ * @chiefaia/architecture-registry — package.json + pnpm-workspace scanner
+ * (ARCH-003)
+ *
+ * Walks every package in the monorepo (apps/* + packages/* + templates/site-*)
+ * and emits one `arch_artifacts` row per workspace member with `kind='package'`
+ * + `PackageMetadata`. Reverse-deps (`consumers`) are computed by scanning all
+ * packages' `dependencies` for workspace:* references.
+ *
+ * Outputs:
+ *   - `arch_artifacts` rows for each internal workspace member
+ *   - `arch_artifacts` rows for each unique external dependency (deduped)
+ *   - `arch_edges` (relation = 'depends_on') for every internal-→-anything dep
+ */
+
+import { nanoid } from 'nanoid';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ArchArtifactRowSchema,
+  ArchEdgeRowSchema,
+  PackageMetadataSchema,
+  type ArchArtifactRow,
+  type ArchEdgeRow,
+  type PackageMetadata,
+  DEFAULT_EMBEDDING_DIM,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_VERSION,
+} from '../schema';
+import { computeArtifactDedupKey, computeEdgeDedupKey } from '../dedup-key';
+import type { ExtractionResult, ExtractorOptions } from './ts-morph-types';
+
+interface PackageJsonShape {
+  name?: string;
+  version?: string;
+  description?: string;
+  private?: boolean;
+  main?: string;
+  types?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+const WORKSPACE_DIRS = ['apps', 'packages', 'templates'];
+
+function readPkg(folder: string): PackageJsonShape | undefined {
+  const path = join(folder, 'package.json');
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as PackageJsonShape;
+  } catch {
+    return undefined;
+  }
+}
+
+function isInternalRef(ref: string): boolean {
+  return ref.startsWith('workspace:') || ref.startsWith('link:');
+}
+
+function listWorkspaceFolders(repoRoot: string): string[] {
+  const out: string[] = [];
+  for (const ws of WORKSPACE_DIRS) {
+    const wsRoot = join(repoRoot, ws);
+    if (!existsSync(wsRoot)) continue;
+    let entries: string[];
+    try {
+      entries = readdirSync(wsRoot);
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const folder = join(wsRoot, e);
+      let st;
+      try {
+        st = statSync(folder);
+      } catch {
+        continue;
+      }
+      if (!st.isDirectory()) continue;
+      if (existsSync(join(folder, 'package.json'))) {
+        out.push(folder);
+      }
+    }
+  }
+  return out;
+}
+
+interface InternalEntry {
+  folder: string;
+  rel: string;
+  pkg: PackageJsonShape;
+  artifactId: string;
+}
+
+export function extractPackagesFromMonorepo(opts: ExtractorOptions): ExtractionResult {
+  const result: ExtractionResult = { artifacts: [], edges: [], warnings: [] };
+  const newId = opts.newId ?? ((p) => `${p}_${nanoid(12)}`);
+  const folders = listWorkspaceFolders(opts.repoRoot);
+  if (folders.length === 0) {
+    result.warnings.push(`package-extractor: no workspace folders found under ${opts.repoRoot}`);
+    return result;
+  }
+
+  // Pass 1: build internal entries (each gets an artifactId).
+  const internals: InternalEntry[] = [];
+  const internalsByName = new Map<string, InternalEntry>();
+  for (const folder of folders) {
+    const pkg = readPkg(folder);
+    if (!pkg?.name) continue;
+    const rel = relativize(opts.repoRoot, folder);
+    const id = newId('arch');
+    const entry: InternalEntry = { folder, rel, pkg, artifactId: id };
+    internals.push(entry);
+    internalsByName.set(pkg.name, entry);
+  }
+
+  // Pass 2: compute reverse-deps. For each internal package, list which other
+  // internal packages list it in dependencies/devDependencies as workspace:*.
+  const consumersOf = new Map<string, Set<string>>();
+  for (const consumer of internals) {
+    const allDeps = {
+      ...(consumer.pkg.dependencies ?? {}),
+      ...(consumer.pkg.devDependencies ?? {}),
+    };
+    for (const [depName, depRef] of Object.entries(allDeps)) {
+      if (!isInternalRef(depRef)) continue;
+      const set = consumersOf.get(depName) ?? new Set<string>();
+      set.add(consumer.pkg.name!);
+      consumersOf.set(depName, set);
+    }
+  }
+
+  // Pass 3: emit one artifact per internal package.
+  const externalArtifactIds = new Map<string, string>(); // packageName → artifactId
+
+  for (const entry of internals) {
+    const { pkg, rel, artifactId } = entry;
+    try {
+      const internal = true;
+      const deps = Object.keys(pkg.dependencies ?? {});
+      const devDeps = Object.keys(pkg.devDependencies ?? {});
+      const consumers = Array.from(consumersOf.get(pkg.name!) ?? new Set());
+
+      const meta: PackageMetadata = PackageMetadataSchema.parse({
+        version: pkg.version ?? '0.0.0',
+        internal,
+        dependencies: deps,
+        devDependencies: devDeps,
+        consumers,
+        isPrivate: pkg.private === true,
+        ...(pkg.main ? { entryPoint: pkg.main } : {}),
+      });
+
+      const dedupKey = computeArtifactDedupKey({
+        project: opts.defaultProject,
+        kind: 'package',
+        name: pkg.name!,
+        packageName: pkg.name!,
+      });
+
+      const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+        id: artifactId,
+        kind: 'package',
+        project: opts.defaultProject,
+        name: pkg.name!,
+        description: pkg.description ?? `Internal workspace package ${pkg.name} at ${rel}.`,
+        filePaths: [rel],
+        entryPath: rel,
+        packageName: pkg.name!,
+        techSubDomains: inferTechSubDomainsForPackage(pkg.name!, rel),
+        tags: pkg.private ? ['internal', 'private'] : ['internal'],
+        metadataJson: JSON.stringify(meta),
+        source: 'package_scan',
+        extractedAtCommit: opts.extractedAtCommit,
+        embeddingModel: DEFAULT_EMBEDDING_MODEL,
+        embeddingDim: DEFAULT_EMBEDDING_DIM,
+        embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+        createdAt: opts.now,
+        updatedAt: opts.now,
+        dedupKey,
+      });
+      result.artifacts.push(artifact);
+    } catch (err) {
+      result.warnings.push(`package-extractor: ${rel} → ${(err as Error).message}`);
+    }
+  }
+
+  // Pass 4: emit external-package artifacts (lazy — only for packages that
+  // are referenced as deps by ≥1 internal package).
+  const externalNames = new Set<string>();
+  for (const entry of internals) {
+    for (const [d] of Object.entries(entry.pkg.dependencies ?? {})) {
+      if (!internalsByName.has(d)) externalNames.add(d);
+    }
+    for (const [d] of Object.entries(entry.pkg.devDependencies ?? {})) {
+      if (!internalsByName.has(d)) externalNames.add(d);
+    }
+  }
+  for (const ext of externalNames) {
+    const id = newId('arch');
+    externalArtifactIds.set(ext, id);
+    const meta = PackageMetadataSchema.parse({
+      version: 'unknown',
+      internal: false,
+      dependencies: [],
+      devDependencies: [],
+      consumers: [],
+      isPrivate: false,
+    });
+    const dedupKey = computeArtifactDedupKey({
+      project: opts.defaultProject,
+      kind: 'package',
+      name: ext,
+      packageName: ext,
+    });
+    const artifact: ArchArtifactRow = ArchArtifactRowSchema.parse({
+      id,
+      kind: 'package',
+      project: opts.defaultProject,
+      name: ext,
+      description: `External npm package ${ext} (referenced by ${countConsumers(internals, ext)} internal package(s)).`,
+      packageName: ext,
+      techSubDomains: inferTechSubDomainsForExternalPackage(ext),
+      tags: ['external'],
+      metadataJson: JSON.stringify(meta),
+      source: 'package_scan',
+      extractedAtCommit: opts.extractedAtCommit,
+      embeddingModel: DEFAULT_EMBEDDING_MODEL,
+      embeddingDim: DEFAULT_EMBEDDING_DIM,
+      embeddingVersion: DEFAULT_EMBEDDING_VERSION,
+      createdAt: opts.now,
+      updatedAt: opts.now,
+      dedupKey,
+    });
+    result.artifacts.push(artifact);
+  }
+
+  // Pass 5: emit depends_on edges.
+  for (const consumer of internals) {
+    const allDeps = {
+      ...(consumer.pkg.dependencies ?? {}),
+      ...(consumer.pkg.devDependencies ?? {}),
+    };
+    for (const depName of Object.keys(allDeps)) {
+      const internalTarget = internalsByName.get(depName);
+      const targetId = internalTarget?.artifactId ?? externalArtifactIds.get(depName);
+      if (!targetId) continue;
+      try {
+        const edgeId = newId('edge');
+        const edge: ArchEdgeRow = ArchEdgeRowSchema.parse({
+          id: edgeId,
+          fromId: consumer.artifactId,
+          toId: targetId,
+          relation: 'depends_on',
+          weight: 1.0,
+          metadataJson: JSON.stringify({
+            kind: 'package_dependency',
+            consumerName: consumer.pkg.name,
+            targetName: depName,
+            edgeDedupKey: computeEdgeDedupKey({
+              fromId: consumer.artifactId,
+              toId: targetId,
+              relation: 'depends_on',
+            }),
+          }),
+          source: 'package_scan',
+          createdAt: opts.now,
+          updatedAt: opts.now,
+        });
+        result.edges.push(edge);
+      } catch (err) {
+        result.warnings.push(`package-extractor edge ${consumer.pkg.name}→${depName}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  return result;
+}
+
+function countConsumers(internals: InternalEntry[], pkgName: string): number {
+  let n = 0;
+  for (const e of internals) {
+    if ((e.pkg.dependencies ?? {})[pkgName] !== undefined) n++;
+    if ((e.pkg.devDependencies ?? {})[pkgName] !== undefined) n++;
+  }
+  return n;
+}
+
+function inferTechSubDomainsForPackage(name: string, rel: string): string[] {
+  const lower = (name + ' ' + rel).toLowerCase();
+  const tags = new Set<string>();
+  if (lower.includes('analytics')) tags.add('web-analytics');
+  if (lower.includes('logger')) tags.add('observability');
+  if (lower.includes('metrics')) tags.add('observability');
+  if (lower.includes('tracing')) tags.add('observability');
+  if (lower.includes('events')) tags.add('event-driven');
+  if (lower.includes('secrets')) tags.add('secrets-management');
+  if (lower.includes('feature-registry') || lower.includes('architecture-registry') || lower.includes('local-rag') || lower.includes('local-llm')) {
+    tags.add('ml-ai');
+  }
+  if (lower.includes('cli')) tags.add('agent-runtime');
+  if (lower.includes('config')) tags.add('infra');
+  if (lower.includes('test-kit') || lower.includes('vitest')) tags.add('testing');
+  if (lower.includes('errors')) tags.add('observability');
+  if (lower.includes('seo')) tags.add('seo');
+  if (lower.includes('classifier') || lower.includes('decomposer') || lower.includes('story-decomposer') || lower.includes('ticket-template') || lower.includes('dedup')) {
+    tags.add('agent-runtime');
+  }
+  if (lower.includes('image') || lower.includes('content-engine') || lower.includes('cms')) tags.add('cms');
+  if (lower.includes('cast-bridge')) tags.add('integrations');
+  if (lower.includes('integrity-check')) tags.add('testing');
+  if (lower.includes('llm-cache')) tags.add('caching');
+  if (rel.startsWith('apps/')) tags.add('agent-runtime');
+  if (rel.startsWith('packages/')) tags.add('design-system'); // best-effort default
+  if (tags.size === 0) tags.add('backend');
+  return Array.from(tags);
+}
+
+function inferTechSubDomainsForExternalPackage(name: string): string[] {
+  const lower = name.toLowerCase();
+  const tags = new Set<string>();
+  if (lower === 'react' || lower === 'react-dom' || lower.startsWith('@radix-ui') || lower === 'next' || lower === 'tailwindcss') tags.add('frontend');
+  if (lower === 'hono' || lower.startsWith('@hono')) tags.add('bff');
+  if (lower === 'better-sqlite3' || lower === 'drizzle-orm' || lower === 'drizzle-kit' || lower === 'sqlite-vec') tags.add('database');
+  if (lower === 'pino' || lower === 'opentelemetry' || lower.startsWith('@opentelemetry')) tags.add('observability');
+  if (lower === 'zod' || lower === 'nanoid') tags.add('agent-runtime');
+  if (lower === 'vitest' || lower === 'playwright') tags.add('testing');
+  if (lower === 'ts-morph' || lower === '@swc/core') tags.add('agent-runtime');
+  if (tags.size === 0) tags.add('backend');
+  return Array.from(tags);
+}
+
+function relativize(repoRoot: string, abs: string): string {
+  if (abs.startsWith(repoRoot)) {
+    let rel = abs.slice(repoRoot.length);
+    if (rel.startsWith('/')) rel = rel.slice(1);
+    return rel;
+  }
+  return abs;
+}

--- a/packages/architecture-registry/src/index.ts
+++ b/packages/architecture-registry/src/index.ts
@@ -91,3 +91,11 @@ export {
   sha256,
 } from './extractors';
 export type { ExtractionResult, ExtractorOptions } from './extractors';
+
+// ARCH-003 — drizzle introspect + package scanner.
+export {
+  extractSchemasFromInMemorySource,
+  extractSchemasFromFile,
+  extractMigrationsFromMigrationsDir,
+  extractPackagesFromMonorepo,
+} from './extractors';

--- a/packages/architecture-registry/tests/drizzle-extractor.test.ts
+++ b/packages/architecture-registry/tests/drizzle-extractor.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  extractSchemasFromInMemorySource,
+  extractMigrationsFromMigrationsDir,
+} from '../src';
+
+const NOW = 1745812800000;
+let counter = 0;
+const idFactory = (prefix: string) => `${prefix}_${counter++}`;
+const reset = () => { counter = 0; };
+
+const baseOpts = () => ({
+  repoRoot: '/repo',
+  defaultProject: 'caia' as const,
+  now: NOW,
+  newId: idFactory,
+});
+
+const SAMPLE_SCHEMA = `
+import { sqliteTable, text, integer, real, index, primaryKey } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  age: integer('age'),
+  createdAt: integer('created_at').notNull().default(0),
+}, (t) => [
+  index('users_email_idx').on(t.email),
+]);
+
+export const sessions = sqliteTable('sessions', {
+  id: text('id').primaryKey(),
+  userId: text('user_id').notNull(),
+  token: text('token').notNull(),
+});
+`;
+
+describe('extractSchemasFromInMemorySource', () => {
+  beforeEach(() => reset());
+
+  it('extracts table names + column metadata', () => {
+    const r = extractSchemasFromInMemorySource(
+      { path: '/repo/db/schema.ts', content: SAMPLE_SCHEMA },
+      baseOpts(),
+    );
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts.length).toBe(2);
+    const names = r.artifacts.map((a) => a.name).sort();
+    expect(names).toEqual(['sessions', 'users']);
+  });
+
+  it('captures columns + nullable + primary key + unique + defaults', () => {
+    const r = extractSchemasFromInMemorySource(
+      { path: '/repo/db/schema.ts', content: SAMPLE_SCHEMA },
+      baseOpts(),
+    );
+    const users = r.artifacts.find((a) => a.name === 'users')!;
+    const meta = JSON.parse(users.metadataJson);
+    expect(meta.columns).toHaveLength(4);
+    const id = meta.columns.find((c: { name: string }) => c.name === 'id');
+    expect(id.isPrimaryKey).toBe(true);
+    expect(id.nullable).toBe(false);
+    const email = meta.columns.find((c: { name: string }) => c.name === 'email');
+    expect(email.isUnique).toBe(true);
+    expect(email.nullable).toBe(false);
+    const age = meta.columns.find((c: { name: string }) => c.name === 'age');
+    expect(age.nullable).toBe(true);
+    expect(age.isPrimaryKey).toBe(false);
+    const createdAt = meta.columns.find((c: { name: string }) => c.name === 'createdAt');
+    expect(createdAt.defaultValue).toBe('0');
+    expect(createdAt.type).toBe('integer');
+  });
+
+  it('captures table indexes', () => {
+    const r = extractSchemasFromInMemorySource(
+      { path: '/repo/db/schema.ts', content: SAMPLE_SCHEMA },
+      baseOpts(),
+    );
+    const users = r.artifacts.find((a) => a.name === 'users')!;
+    const meta = JSON.parse(users.metadataJson);
+    expect(meta.indexes).toHaveLength(1);
+    expect(meta.indexes[0].name).toBe('users_email_idx');
+    expect(meta.indexes[0].columns).toEqual(['email']);
+  });
+
+  it('produces stable dedup keys on re-extraction', () => {
+    const r1 = extractSchemasFromInMemorySource(
+      { path: '/repo/db/schema.ts', content: SAMPLE_SCHEMA },
+      baseOpts(),
+    );
+    counter = 0;
+    const r2 = extractSchemasFromInMemorySource(
+      { path: '/repo/db/schema.ts', content: SAMPLE_SCHEMA },
+      baseOpts(),
+    );
+    const k1 = r1.artifacts.map((a) => a.dedupKey).sort();
+    const k2 = r2.artifacts.map((a) => a.dedupKey).sort();
+    expect(k1).toEqual(k2);
+  });
+
+  it('skips non-drizzle exports gracefully', () => {
+    const r = extractSchemasFromInMemorySource(
+      {
+        path: '/repo/db/schema.ts',
+        content: `
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+export const users = sqliteTable('users', { id: text('id').primaryKey() });
+export const helper = () => 42;
+export const config = { foo: 'bar' };
+`,
+      },
+      baseOpts(),
+    );
+    expect(r.artifacts).toHaveLength(1);
+    expect(r.artifacts[0]!.name).toBe('users');
+  });
+
+  it('tags every schema row as database', () => {
+    const r = extractSchemasFromInMemorySource(
+      { path: '/repo/db/schema.ts', content: SAMPLE_SCHEMA },
+      baseOpts(),
+    );
+    for (const a of r.artifacts) {
+      expect(a.techSubDomains).toContain('database');
+      expect(a.kind).toBe('schema');
+    }
+  });
+});
+
+describe('extractMigrationsFromMigrationsDir', () => {
+  let root: string;
+  let migDir: string;
+
+  beforeEach(() => {
+    counter = 0;
+    root = mkdtempSync(join(tmpdir(), 'akg-mig-'));
+    migDir = join(root, 'migrations');
+    mkdirSync(join(migDir, 'meta'), { recursive: true });
+    writeFileSync(
+      join(migDir, '0001_initial.sql'),
+      `CREATE TABLE users (id TEXT PRIMARY KEY);\nCREATE INDEX users_idx ON users (id);`,
+    );
+    writeFileSync(
+      join(migDir, '0002_add_sessions.sql'),
+      `CREATE TABLE sessions (id TEXT, user_id TEXT);\nALTER TABLE users ADD COLUMN email TEXT;`,
+    );
+    writeFileSync(
+      join(migDir, '0003_pending.sql'),
+      `CREATE TABLE pending (id TEXT);`,
+    );
+    writeFileSync(
+      join(migDir, 'meta/_journal.json'),
+      JSON.stringify({
+        entries: [
+          { idx: 0, tag: '0001_initial', when: 0 },
+          { idx: 1, tag: '0002_add_sessions', when: 0 },
+        ],
+      }),
+    );
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('extracts every *.sql migration', () => {
+    const r = extractMigrationsFromMigrationsDir(migDir, {
+      ...baseOpts(),
+      repoRoot: root,
+    });
+    expect(r.warnings).toEqual([]);
+    expect(r.artifacts.length).toBe(3);
+    const names = r.artifacts.map((a) => a.name).sort();
+    expect(names).toEqual(['0001_initial.sql', '0002_add_sessions.sql', '0003_pending.sql']);
+  });
+
+  it('parses sequence number + checksum + affected tables', () => {
+    const r = extractMigrationsFromMigrationsDir(migDir, {
+      ...baseOpts(),
+      repoRoot: root,
+    });
+    const second = r.artifacts.find((a) => a.name === '0002_add_sessions.sql')!;
+    const meta = JSON.parse(second.metadataJson);
+    expect(meta.sequenceNumber).toBe(2);
+    expect(meta.checksum).toMatch(/^[0-9a-f]{64}$/);
+    expect(meta.affectsTables).toContain('sessions');
+    expect(meta.affectsTables).toContain('users');
+  });
+
+  it('marks migrations applied/pending via _journal.json', () => {
+    const r = extractMigrationsFromMigrationsDir(migDir, {
+      ...baseOpts(),
+      repoRoot: root,
+    });
+    const first = r.artifacts.find((a) => a.name === '0001_initial.sql')!;
+    const third = r.artifacts.find((a) => a.name === '0003_pending.sql')!;
+    expect(JSON.parse(first.metadataJson).isApplied).toBe(true);
+    expect(JSON.parse(third.metadataJson).isApplied).toBe(false);
+    expect(first.tags).toContain('applied');
+    expect(third.tags).toContain('pending');
+  });
+
+  it('returns a warning when the migrations dir does not exist', () => {
+    const r = extractMigrationsFromMigrationsDir('/no/such/dir', baseOpts());
+    expect(r.artifacts).toHaveLength(0);
+    expect(r.warnings.length).toBe(1);
+  });
+
+  it('produces stable dedup keys on re-extraction', () => {
+    const r1 = extractMigrationsFromMigrationsDir(migDir, { ...baseOpts(), repoRoot: root });
+    counter = 0;
+    const r2 = extractMigrationsFromMigrationsDir(migDir, { ...baseOpts(), repoRoot: root });
+    expect(r1.artifacts.map((a) => a.dedupKey).sort()).toEqual(
+      r2.artifacts.map((a) => a.dedupKey).sort(),
+    );
+  });
+
+  it('tags every migration as database + data-migration', () => {
+    const r = extractMigrationsFromMigrationsDir(migDir, { ...baseOpts(), repoRoot: root });
+    for (const a of r.artifacts) {
+      expect(a.techSubDomains).toContain('database');
+      expect(a.techSubDomains).toContain('data-migration');
+    }
+  });
+});

--- a/packages/architecture-registry/tests/package-extractor.test.ts
+++ b/packages/architecture-registry/tests/package-extractor.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractPackagesFromMonorepo } from '../src';
+
+const NOW = 1745812800000;
+let counter = 0;
+const idFactory = (prefix: string) => `${prefix}_${counter++}`;
+const reset = () => { counter = 0; };
+
+function makeMonorepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'akg-pkg-'));
+  // packages/feature-registry
+  mkdirSync(join(root, 'packages/feature-registry'), { recursive: true });
+  writeFileSync(
+    join(root, 'packages/feature-registry/package.json'),
+    JSON.stringify({
+      name: '@chiefaia/feature-registry',
+      version: '0.1.0',
+      private: true,
+      description: 'Fast, local feature registry.',
+      dependencies: {
+        zod: '^3.23.8',
+        'better-sqlite3': '^12.6.2',
+        '@chiefaia/ticket-template': 'workspace:*',
+      },
+      devDependencies: {
+        vitest: '^1.6.0',
+      },
+    }),
+  );
+  // packages/ticket-template
+  mkdirSync(join(root, 'packages/ticket-template'), { recursive: true });
+  writeFileSync(
+    join(root, 'packages/ticket-template/package.json'),
+    JSON.stringify({
+      name: '@chiefaia/ticket-template',
+      version: '0.2.0',
+      private: true,
+      description: 'Canonical ticket template.',
+      dependencies: { zod: '^3.23.8' },
+    }),
+  );
+  // apps/orchestrator
+  mkdirSync(join(root, 'apps/orchestrator'), { recursive: true });
+  writeFileSync(
+    join(root, 'apps/orchestrator/package.json'),
+    JSON.stringify({
+      name: '@caia-app/orchestrator',
+      version: '0.1.1',
+      private: true,
+      description: 'Orchestrator brain.',
+      dependencies: {
+        hono: '^4.0.0',
+        '@chiefaia/feature-registry': 'workspace:*',
+        '@chiefaia/ticket-template': 'workspace:*',
+      },
+    }),
+  );
+  // an empty folder under apps/ with no package.json — should be skipped
+  mkdirSync(join(root, 'apps/empty'), { recursive: true });
+  return root;
+}
+
+describe('extractPackagesFromMonorepo', () => {
+  let root: string;
+  beforeEach(() => {
+    reset();
+    root = makeMonorepo();
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('emits one artifact per workspace package + one per external dep', () => {
+    const r = extractPackagesFromMonorepo({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    expect(r.warnings).toEqual([]);
+    const internalNames = r.artifacts
+      .filter((a) => a.tags.includes('internal'))
+      .map((a) => a.name)
+      .sort();
+    expect(internalNames).toEqual([
+      '@caia-app/orchestrator',
+      '@chiefaia/feature-registry',
+      '@chiefaia/ticket-template',
+    ]);
+    const externalNames = r.artifacts
+      .filter((a) => a.tags.includes('external'))
+      .map((a) => a.name)
+      .sort();
+    expect(externalNames).toEqual(['better-sqlite3', 'hono', 'vitest', 'zod']);
+  });
+
+  it('records reverse-deps (consumers) for internal packages', () => {
+    const r = extractPackagesFromMonorepo({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    const ticketTpl = r.artifacts.find((a) => a.name === '@chiefaia/ticket-template')!;
+    const meta = JSON.parse(ticketTpl.metadataJson);
+    expect(meta.consumers.sort()).toEqual([
+      '@caia-app/orchestrator',
+      '@chiefaia/feature-registry',
+    ]);
+  });
+
+  it('emits depends_on edges from each consumer to each dep', () => {
+    const r = extractPackagesFromMonorepo({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    expect(r.edges.length).toBeGreaterThanOrEqual(6);
+    const featureRegistry = r.artifacts.find((a) => a.name === '@chiefaia/feature-registry')!;
+    const featureRegistryEdges = r.edges.filter((e) => e.fromId === featureRegistry.id);
+    // feature-registry depends on: zod, better-sqlite3, @chiefaia/ticket-template, vitest
+    const targetIds = new Set(featureRegistryEdges.map((e) => e.toId));
+    expect(targetIds.size).toBe(4);
+    expect(featureRegistryEdges.every((e) => e.relation === 'depends_on')).toBe(true);
+  });
+
+  it('produces stable dedup keys on re-extraction', () => {
+    const r1 = extractPackagesFromMonorepo({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    counter = 0;
+    const r2 = extractPackagesFromMonorepo({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    expect(r1.artifacts.map((a) => a.dedupKey).sort()).toEqual(
+      r2.artifacts.map((a) => a.dedupKey).sort(),
+    );
+  });
+
+  it('returns a warning when no workspace folders exist', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'akg-empty-'));
+    const r = extractPackagesFromMonorepo({
+      repoRoot: empty,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    expect(r.artifacts).toHaveLength(0);
+    expect(r.warnings.length).toBe(1);
+    rmSync(empty, { recursive: true, force: true });
+  });
+
+  it('infers tech sub-domains for internal + external packages', () => {
+    const r = extractPackagesFromMonorepo({
+      repoRoot: root,
+      defaultProject: 'caia',
+      now: NOW,
+      newId: idFactory,
+    });
+    const featureRegistry = r.artifacts.find((a) => a.name === '@chiefaia/feature-registry')!;
+    expect(featureRegistry.techSubDomains.length).toBeGreaterThan(0);
+    const honoExt = r.artifacts.find((a) => a.name === 'hono')!;
+    expect(honoExt.techSubDomains).toContain('bff');
+    const sqliteExt = r.artifacts.find((a) => a.name === 'better-sqlite3')!;
+    expect(sqliteExt.techSubDomains).toContain('database');
+    const zodExt = r.artifacts.find((a) => a.name === 'zod')!;
+    expect(zodExt.techSubDomains).toContain('agent-runtime');
+  });
+});


### PR DESCRIPTION
## ARCH-003 — drizzle introspect + monorepo package scanner

Two more idempotent extractors that produce the foundational artifact catalog.

### What ships

1. **drizzle-extractor** — schemas + migrations
   - `extractSchemasFromInMemorySource` / `extractSchemasFromFile` — walks a drizzle schema TypeScript file and emits one ArchArtifactRow per `sqliteTable()` / `pgTable()` declaration. Captures columns (name, type, nullable, default, primaryKey, unique) + indexes (name, columns, unique). Primary keys correctly marked NOT NULL even without explicit `.notNull()`.
   - `extractMigrationsFromMigrationsDir` — walks every `NNNN_<tag>.sql` + reads `meta/_journal.json`. Emits one row per migration with sequence number, sha256 checksum, parsed `affectsTables` (CREATE TABLE / CREATE INDEX / ALTER TABLE), applied/pending status.

2. **package-extractor** — pnpm workspace scanner
   - One ArchArtifactRow per internal workspace member.
   - One row per unique external dependency (deduped).
   - Reverse-deps (`consumers`) computed by scanning workspace:\* refs.
   - `depends_on` edges from each consumer to each dep.
   - Tech-sub-domain inference (analytics→web-analytics, logger/metrics/tracing→observability, hono→bff, react/next→frontend, drizzle/sqlite→database, etc.).

### Tests

18 new tests added (6 schema + 6 migration + 6 package). Total **81 passing**.

Refs: ARCH-003. Next: ARCH-004 (storage / embedding layer reusing FREG infra).