### PR TITLE
feat(agent-contract-registry): @chiefaia/agent-contract-registry + composeTemplate (ACR-002)

### DIFF
--- a/packages/agent-contract-registry/README.md
+++ b/packages/agent-contract-registry/README.md
@@ -1,0 +1,53 @@
+# `@chiefaia/agent-contract-registry`
+
+The Agent Section Contract Registry — declarative store of per-agent contracts (PO/BA/EA/Test-Design) plus the `composeTemplate(scope)` function. The Story Validator consumes the runtime-composed template instead of a hard-coded rubric, so adding a new agent is just registering a contract — no Validator change.
+
+## Why
+
+Each ticket-writing agent declares a `SectionContract` listing the sections it populates with per-scope rubrics. The Validator unions those contracts at runtime per a story's `story_scope` (initiative → epic → module → story → task → subtask) and uses the composed template as its rubric.
+
+End state: every story is **self-sufficient, stateless, context-less** — Test-Design + coding agents get everything from the ticket alone.
+
+## Usage
+
+```typescript
+import { register, composeTemplate } from '@chiefaia/agent-contract-registry';
+import { poAgentContract } from './po-agent.contract';
+import { baAgentContract } from './ba-agent.contract';
+
+register(poAgentContract);
+register(baAgentContract);
+
+const template = composeTemplate('story');
+//   ^^^^^^^^^^ ComposedTemplate { scope, sections, signature, warnings }
+
+for (const [sectionName, entry] of template.sections) {
+  console.log(`${sectionName} owned by ${entry.ownerAgent}`);
+}
+```
+
+## API
+
+- `register(contract)` — add to the singleton registry. Throws on duplicate.
+- `getDefaultRegistry()` — singleton instance for advanced use.
+- `composeTemplate(scope, opts?)` — pure compose function. `opts.strict` throws on conflict; `opts.registry` overrides the singleton (tests).
+- `composeAllScopes(opts?)` — convenience returning `Record<StoryScope, ComposedTemplate>`.
+
+## Composition algorithm
+
+1. Filter registry to contracts whose `appliesTo` includes `scope`.
+2. Sort by agent-pipeline order — `PO < BA < EA < Test-Design`. Tie-break alphabetically by `contractId`.
+3. Iterate sections; first contract claiming a section name wins. Subsequent claims log a warning (or throw in strict mode).
+4. Apply per-section `scopeOverrides[scope]` (shallow rubric merge + optional `required` override).
+5. Verify each section's `dependencies` resolve within the composed template; warn for unresolved.
+6. Compute a stable SHA-256 `signature` over the composed entries.
+
+## Performance
+
+`composeTemplate` is pure data manipulation — zero LLM calls. Benchmarked at 24k–92k ops/sec per scope on the full 4-agent contract set (mean < 0.05 ms). The Validator caches results keyed on `signature`.
+
+## See also
+
+- `@chiefaia/ticket-template` — `SectionContract`, `StoryScope`, `ComposedTemplate` types.
+- `~/Documents/projects/reports/agent-contract-registry-architecture-2026-04-28.md` — full architecture report.
+- `caia/docs/agent-contracts.md` — operator-facing pattern doc (ACR-011).

--- a/packages/agent-contract-registry/package.json
+++ b/packages/agent-contract-registry/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@chiefaia/agent-contract-registry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agent Section Contract Registry — declarative store of per-agent contracts (PO/BA/EA/Test-Design) + composeTemplate(scope) function. The Story Validator consumes the composed template at runtime instead of a hard-coded rubric.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "bench": "vitest bench --run"
+  },
+  "dependencies": {
+    "@chiefaia/ticket-template": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/agent-contract-registry/src/compose-template.ts
+++ b/packages/agent-contract-registry/src/compose-template.ts
@@ -1,0 +1,137 @@
+/**
+ * @chiefaia/agent-contract-registry — compose-template.ts (ACR-002)
+ *
+ * The composition algorithm. Builds a `ComposedTemplate` per `StoryScope`
+ * by unioning all registered contracts whose `appliesTo` includes the
+ * scope, applying scope overrides, resolving conflicts via agent-pipeline
+ * order (PO < BA < EA < Test-Design), and computing a stable signature.
+ *
+ * The result is what the Story Validator consumes at runtime instead of
+ * the hard-coded `validation-rubric.ts`.
+ *
+ * Token cost: zero. This is pure data manipulation — no LLM calls in this
+ * layer. The downstream Validator runs the composed rubric's
+ * `relevancePromptSeed`s identically to today.
+ */
+
+import {
+  AGENT_ORDER,
+  applyScopeOverride,
+  type ComposedSectionEntry,
+  type ComposedTemplate,
+  type SectionContract,
+  type StoryScope,
+} from '@chiefaia/ticket-template';
+import { getDefaultRegistry, type ContractRegistry } from './registry';
+import { computeSignature } from './signature';
+
+export interface ComposeOptions {
+  /**
+   * If true, throw on any composition warning (duplicate section, missing
+   * dependency). CI uses this to fail builds on registry conflicts;
+   * runtime uses the default (false) so warnings only log.
+   */
+  strict?: boolean;
+  /** Override the default registry — useful for tests. */
+  registry?: ContractRegistry;
+}
+
+/**
+ * Compose a per-scope `ComposedTemplate` from the registry. Pure function
+ * given a fixed registry state — the Validator caches results keyed on
+ * the returned `signature`.
+ *
+ * Algorithm:
+ *   1. Filter registry to contracts whose `appliesTo` includes `scope`.
+ *   2. Sort contracts by agent-pipeline order (PO -> BA -> EA -> Test-Design).
+ *      Tie-break by `contractId` for stable output.
+ *   3. Iterate sections; first contract claiming a section name wins.
+ *      Subsequent claims log a warning (or throw in strict mode).
+ *   4. Apply per-section `scopeOverrides[scope]` to compute effective
+ *      rubric + required.
+ *   5. Verify each section's `dependencies` resolve within the composed
+ *      template; warn for unresolved.
+ *   6. Compute a stable `signature` over the composed entries.
+ */
+export function composeTemplate(
+  scope: StoryScope,
+  opts: ComposeOptions = {},
+): ComposedTemplate {
+  const registry = opts.registry ?? getDefaultRegistry();
+  const allContracts = registry.list();
+  const eligible = allContracts.filter((c) => c.appliesTo.includes(scope));
+
+  // Stable ordering: agent pipeline order, then contractId asc for determinism.
+  const ordered: SectionContract[] = [...eligible].sort((a, b) => {
+    const ao = AGENT_ORDER[a.ownerAgent] - AGENT_ORDER[b.ownerAgent];
+    if (ao !== 0) return ao;
+    return a.contractId.localeCompare(b.contractId);
+  });
+
+  const sections = new Map<string, ComposedSectionEntry>();
+  const warnings: string[] = [];
+
+  for (const contract of ordered) {
+    for (const baseSpec of contract.sections) {
+      const existing = sections.get(baseSpec.name);
+      if (existing) {
+        const msg = `section '${baseSpec.name}' claimed by both ${existing.ownerAgent} (${existing.contractId}) and ${contract.ownerAgent} (${contract.contractId}); kept ${existing.contractId}`;
+        if (opts.strict) {
+          throw new Error(`[agent-contract-registry] ${msg}`);
+        }
+        warnings.push(msg);
+        continue;
+      }
+      const { effectiveRubric, effectiveRequired } = applyScopeOverride(
+        baseSpec,
+        scope,
+      );
+      sections.set(baseSpec.name, {
+        spec: baseSpec,
+        effectiveRubric,
+        effectiveRequired,
+        ownerAgent: contract.ownerAgent,
+        contractId: contract.contractId,
+      });
+    }
+  }
+
+  // Dependency resolution check.
+  for (const [name, entry] of sections) {
+    for (const dep of entry.spec.dependencies ?? []) {
+      if (!sections.has(dep)) {
+        const msg = `section '${name}' depends on '${dep}' which is not in the composed template for scope '${scope}'`;
+        if (opts.strict) {
+          throw new Error(`[agent-contract-registry] ${msg}`);
+        }
+        warnings.push(msg);
+      }
+    }
+  }
+
+  const signature = computeSignature(scope, sections);
+
+  return { scope, sections, signature, warnings };
+}
+
+/**
+ * Convenience: compose templates for every canonical `StoryScope`. Useful
+ * for CI assertions ("compose every scope without conflicts") and for the
+ * dashboard `/contracts` page.
+ */
+export function composeAllScopes(
+  opts: ComposeOptions = {},
+): Record<StoryScope, ComposedTemplate> {
+  const out: Partial<Record<StoryScope, ComposedTemplate>> = {};
+  for (const scope of [
+    'initiative',
+    'epic',
+    'module',
+    'story',
+    'task',
+    'subtask',
+  ] as const) {
+    out[scope] = composeTemplate(scope, opts);
+  }
+  return out as Record<StoryScope, ComposedTemplate>;
+}

--- a/packages/agent-contract-registry/src/index.ts
+++ b/packages/agent-contract-registry/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @chiefaia/agent-contract-registry — public entry point (ACR-002)
+ *
+ * The Agent Section Contract Registry. Each ticket-writing agent
+ * (PO/BA/EA/Test-Design) registers a `SectionContract` declaring the
+ * sections + per-scope rubrics it owns. The Story Validator consumes
+ * `composeTemplate(scope)` instead of hard-coded `validation-rubric.ts`.
+ *
+ * Usage:
+ *
+ *   import { register, composeTemplate } from '@chiefaia/agent-contract-registry';
+ *   import { poAgentContract } from './po-agent.contract';
+ *   register(poAgentContract);
+ *   const template = composeTemplate('story');  // ComposedTemplate
+ */
+
+export {
+  ContractRegistry,
+  getDefaultRegistry,
+  resetDefaultRegistry,
+} from './registry';
+export type { RegistryEntry } from './registry';
+
+export { composeTemplate, composeAllScopes } from './compose-template';
+export type { ComposeOptions } from './compose-template';
+
+export { computeSignature } from './signature';
+
+// Re-export the contract types for convenience — callers don't need to
+// also import from @chiefaia/ticket-template just to type a registration.
+export type {
+  StoryScope,
+  AgentRole,
+  ContractSeverity,
+  SectionRubric,
+  SectionExample,
+  SectionSpec,
+  SectionContract,
+  ComposedSectionEntry,
+  ComposedTemplate,
+} from '@chiefaia/ticket-template';
+
+import { getDefaultRegistry } from './registry';
+import type { SectionContract } from '@chiefaia/ticket-template';
+
+/**
+ * Top-level convenience for the canonical pattern: register a contract on
+ * the default singleton registry. Equivalent to
+ * `getDefaultRegistry().register(contract)`.
+ */
+export function register(contract: SectionContract): void {
+  getDefaultRegistry().register(contract);
+}

--- a/packages/agent-contract-registry/src/registry.ts
+++ b/packages/agent-contract-registry/src/registry.ts
@@ -1,0 +1,107 @@
+/**
+ * @chiefaia/agent-contract-registry — registry.ts (ACR-002)
+ *
+ * The contract registry is a process-local, in-memory store of
+ * `SectionContract` objects keyed by `contractId`. It's deliberately
+ * mutable at startup (so each agent's `*-agent.contract.ts` can register
+ * its contract on import) but immutable in steady-state runtime — the
+ * Validator's per-scope composed template is cached against the registry's
+ * `signature` and invalidated only on registry mutation.
+ *
+ * Why a class — testability. Tests can construct a fresh `ContractRegistry`
+ * to avoid cross-test bleed via the shared global. Production code uses
+ * `getDefaultRegistry()` which returns a singleton.
+ *
+ * Why no I/O — the registry holds in-memory contracts only. Persistence
+ * is unnecessary: contracts are code, versioned in git, and registered on
+ * import. There is no "user-uploaded contract" pattern in Phase 1.
+ */
+
+import type { AgentRole, SectionContract } from '@chiefaia/ticket-template';
+
+export interface RegistryEntry {
+  contract: SectionContract;
+  /** Order of registration — used for deterministic ordering when contracts share an agent role. */
+  registrationIndex: number;
+}
+
+export class ContractRegistry {
+  private entries: Map<string, RegistryEntry> = new Map();
+  private nextIndex = 0;
+
+  /**
+   * Register a contract. Throws if a contract with the same `contractId`
+   * is already registered — this catches accidental double-import bugs.
+   * Use `replace()` if intentional override is needed (e.g. test setup).
+   */
+  register(contract: SectionContract): void {
+    if (this.entries.has(contract.contractId)) {
+      throw new Error(
+        `[agent-contract-registry] contract '${contract.contractId}' is already registered. Use replace() for overrides.`,
+      );
+    }
+    this.entries.set(contract.contractId, {
+      contract,
+      registrationIndex: this.nextIndex++,
+    });
+  }
+
+  /**
+   * Replace a contract — overwrites if present, registers if absent.
+   * Useful for test setup and hot-reload in dev. Production code should
+   * prefer `register()`.
+   */
+  replace(contract: SectionContract): void {
+    const existing = this.entries.get(contract.contractId);
+    const registrationIndex = existing?.registrationIndex ?? this.nextIndex++;
+    this.entries.set(contract.contractId, { contract, registrationIndex });
+  }
+
+  /** Remove a contract. Returns true if removed, false if absent. */
+  unregister(contractId: string): boolean {
+    return this.entries.delete(contractId);
+  }
+
+  /** All registered contracts in registration order. */
+  list(): readonly SectionContract[] {
+    return [...this.entries.values()]
+      .sort((a, b) => a.registrationIndex - b.registrationIndex)
+      .map((e) => e.contract);
+  }
+
+  /** All contracts owned by a given agent role. */
+  listByAgent(ownerAgent: AgentRole): readonly SectionContract[] {
+    return this.list().filter((c) => c.ownerAgent === ownerAgent);
+  }
+
+  /** Lookup a contract by ID. */
+  get(contractId: string): SectionContract | undefined {
+    return this.entries.get(contractId)?.contract;
+  }
+
+  /** Number of registered contracts. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Empty the registry. Test-only — production code should never clear. */
+  clear(): void {
+    this.entries.clear();
+    this.nextIndex = 0;
+  }
+}
+
+// ─── Default singleton ──────────────────────────────────────────────────────
+
+let defaultRegistry: ContractRegistry | null = null;
+
+/** Process-singleton registry. Production code should use this. */
+export function getDefaultRegistry(): ContractRegistry {
+  if (!defaultRegistry) defaultRegistry = new ContractRegistry();
+  return defaultRegistry;
+}
+
+/** Reset the default singleton. Test-only. */
+export function resetDefaultRegistry(): void {
+  defaultRegistry = null;
+}

--- a/packages/agent-contract-registry/src/signature.ts
+++ b/packages/agent-contract-registry/src/signature.ts
@@ -1,0 +1,73 @@
+/**
+ * @chiefaia/agent-contract-registry — signature.ts (ACR-002)
+ *
+ * Stable hash over the composed template — used as the Validator's cache
+ * key and for drift detection in CI snapshot tests. Two compositions with
+ * the same signature produce identical Validator behaviour.
+ *
+ * The signature is content-derived only — it does NOT include scope or
+ * agent ordering metadata, since those are inputs that already determine
+ * the section set. Two scopes producing the same composed sections will
+ * have the same signature (rare but harmless).
+ *
+ * Implementation: SHA-256 over a JSON-stable normalisation of the
+ * sections map. We use Node's built-in `crypto` to avoid adding a hash
+ * dependency.
+ */
+
+import { createHash } from 'node:crypto';
+import type { ComposedSectionEntry, StoryScope } from '@chiefaia/ticket-template';
+
+/**
+ * Normalise a `ComposedSectionEntry` for hashing — strip the ZodTypeAny
+ * (not stably JSON-serialisable across runs), keep everything else.
+ */
+function normaliseEntry(entry: ComposedSectionEntry): unknown {
+  return {
+    name: entry.spec.name,
+    ownerAgent: entry.ownerAgent,
+    contractId: entry.contractId,
+    effectiveRequired: entry.effectiveRequired,
+    description: entry.spec.description,
+    purpose: entry.spec.purpose,
+    dependencies: [...(entry.spec.dependencies ?? [])].sort(),
+    rubric: {
+      minWords: entry.effectiveRubric.minWords ?? null,
+      minItems: entry.effectiveRubric.minItems ?? null,
+      minItemsPerSubField: entry.effectiveRubric.minItemsPerSubField
+        ? Object.fromEntries(
+            Object.entries(entry.effectiveRubric.minItemsPerSubField).sort(),
+          )
+        : null,
+      requiredSubFields: [...(entry.effectiveRubric.requiredSubFields ?? [])].sort(),
+      requiredEntityRefs: (entry.effectiveRubric.requiredEntityRefs ?? []).map((r) => ({
+        label: r.label,
+        pattern: r.pattern,
+        flags: r.flags ?? '',
+      })),
+      forbiddenSnippets: [...(entry.effectiveRubric.forbiddenSnippets ?? [])].sort(),
+      relevancePromptSeed: entry.effectiveRubric.relevancePromptSeed ?? null,
+      severityOnFail: entry.effectiveRubric.severityOnFail,
+      fixHint: entry.effectiveRubric.fixHint,
+    },
+  };
+}
+
+/**
+ * Compute a stable SHA-256 signature over the composed template. The
+ * scope is included in the hash input so identical section sets across
+ * scopes still produce distinct signatures (cleaner cache semantics).
+ */
+export function computeSignature(
+  scope: StoryScope,
+  sections: ReadonlyMap<string, ComposedSectionEntry>,
+): string {
+  // Stable section order: alphabetical by name.
+  const orderedNames = [...sections.keys()].sort();
+  const payload = {
+    scope,
+    sections: orderedNames.map((name) => normaliseEntry(sections.get(name)!)),
+  };
+  const json = JSON.stringify(payload);
+  return createHash('sha256').update(json).digest('hex');
+}

--- a/packages/agent-contract-registry/tests/compose-template.bench.ts
+++ b/packages/agent-contract-registry/tests/compose-template.bench.ts
@@ -1,0 +1,63 @@
+/**
+ * Benchmark — composeTemplate must stay << 1ms cold-cache for the full
+ * 4-agent registry. This guards against regressions in the composition
+ * algorithm or signature hashing as the contract count grows.
+ */
+
+import { bench, describe } from 'vitest';
+import { z } from 'zod';
+import type { SectionContract, SectionSpec, StoryScope } from '@chiefaia/ticket-template';
+import { ContractRegistry, composeTemplate } from '../src';
+
+function spec(name: string): SectionSpec {
+  return {
+    name,
+    description: 'd',
+    purpose: 'p',
+    dataShape: z.object({}).passthrough(),
+    required: true,
+    rubric: { severityOnFail: 'hard', fixHint: 'fix', minWords: 20 },
+    examples: [{ good: {}, bad: {}, badRationale: 'r' }],
+  };
+}
+
+function contract(
+  contractId: string,
+  ownerAgent: SectionContract['ownerAgent'],
+  scopes: readonly StoryScope[],
+  sectionNames: readonly string[],
+): SectionContract {
+  return {
+    ownerAgent,
+    contractId,
+    version: '1.0.0',
+    appliesTo: scopes,
+    sections: sectionNames.map(spec),
+  };
+}
+
+const reg = new ContractRegistry();
+reg.register(contract('po-agent.v1', 'po', ['initiative', 'epic', 'module', 'story', 'task', 'subtask'],
+  ['scope', 'userPersona', 'lifecycle', 'priority', 'linkedFeatures', 'parentEntity', 'domain', 'businessSubDomains']));
+reg.register(contract('ba-agent.v1', 'ba', ['epic', 'module', 'story', 'task'],
+  ['acceptanceCriteria', 'agentSections.architecture', 'agentSections.database', 'agentSections.api',
+   'agentSections.ui', 'agentSections.security', 'agentSections.testing', 'agentSections.release',
+   'agentSections.observability', 'dependencies', 'risks', 'assumptions', 'clarifyingQuestions']));
+reg.register(contract('ea-agent.v1', 'ea', ['module', 'story', 'task', 'subtask'],
+  ['architecturalInstructions', 'taxonomy', 'claims', 'effort', 'risk']));
+reg.register(contract('test-design-agent.v1', 'test-design', ['story', 'task'],
+  ['testCases', 'testDataSamples', 'edgeCases', 'errorPaths', 'surface']));
+
+describe('composeTemplate — full registry', () => {
+  bench('story scope', () => {
+    composeTemplate('story', { registry: reg });
+  });
+
+  bench('initiative scope', () => {
+    composeTemplate('initiative', { registry: reg });
+  });
+
+  bench('subtask scope', () => {
+    composeTemplate('subtask', { registry: reg });
+  });
+});

--- a/packages/agent-contract-registry/tests/compose-template.test.ts
+++ b/packages/agent-contract-registry/tests/compose-template.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { SectionContract, SectionSpec, StoryScope } from '@chiefaia/ticket-template';
+import { ContractRegistry, composeTemplate, composeAllScopes } from '../src';
+
+function spec(name: string, overrides: Partial<SectionSpec> = {}): SectionSpec {
+  return {
+    name,
+    description: `desc ${name}`,
+    purpose: `purpose ${name}`,
+    dataShape: z.object({}).passthrough(),
+    required: true,
+    rubric: { severityOnFail: 'hard', fixHint: `fix ${name}` },
+    examples: [{ good: {}, bad: {}, badRationale: 'r' }],
+    ...overrides,
+  };
+}
+
+function contract(
+  contractId: string,
+  ownerAgent: SectionContract['ownerAgent'],
+  appliesTo: readonly StoryScope[],
+  sections: readonly SectionSpec[],
+): SectionContract {
+  return { ownerAgent, contractId, version: '1.0.0', appliesTo, sections };
+}
+
+describe('composeTemplate — basic union', () => {
+  it('returns empty composed template when registry is empty', () => {
+    const reg = new ContractRegistry();
+    const t = composeTemplate('story', { registry: reg });
+    expect(t.scope).toBe('story');
+    expect(t.sections.size).toBe(0);
+    expect(t.warnings).toEqual([]);
+    expect(t.signature).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('includes only contracts whose appliesTo contains the scope', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', ['initiative', 'story'], [spec('scope')]));
+    reg.register(contract('ba', 'ba', ['story', 'task'], [spec('acceptanceCriteria')]));
+    reg.register(contract('td', 'test-design', ['story'], [spec('testCases')]));
+
+    const init = composeTemplate('initiative', { registry: reg });
+    expect([...init.sections.keys()]).toEqual(['scope']);
+
+    const story = composeTemplate('story', { registry: reg });
+    expect([...story.sections.keys()].sort()).toEqual([
+      'acceptanceCriteria',
+      'scope',
+      'testCases',
+    ]);
+
+    const task = composeTemplate('task', { registry: reg });
+    expect([...task.sections.keys()]).toEqual(['acceptanceCriteria']);
+  });
+
+  it('orders sections by agent-pipeline order then contractId', () => {
+    const reg = new ContractRegistry();
+    // Register out-of-order on purpose.
+    reg.register(contract('td', 'test-design', ['story'], [spec('testCases')]));
+    reg.register(contract('ea', 'ea', ['story'], [spec('architecturalInstructions')]));
+    reg.register(contract('ba', 'ba', ['story'], [spec('acceptanceCriteria')]));
+    reg.register(contract('po', 'po', ['story'], [spec('scope')]));
+
+    const t = composeTemplate('story', { registry: reg });
+    // Insertion order in the Map matches the sort: PO -> BA -> EA -> Test-Design.
+    expect([...t.sections.keys()]).toEqual([
+      'scope',
+      'acceptanceCriteria',
+      'architecturalInstructions',
+      'testCases',
+    ]);
+  });
+});
+
+describe('composeTemplate — scope overrides', () => {
+  it('applies scopeOverrides[scope] to rubric and required', () => {
+    const reg = new ContractRegistry();
+    reg.register(
+      contract('po', 'po', ['initiative', 'story', 'subtask'], [
+        spec('scope', {
+          required: true,
+          rubric: { minWords: 30, severityOnFail: 'hard', fixHint: 'fix' },
+          scopeOverrides: {
+            initiative: { minWords: 80 },
+            subtask: { required: false, minWords: 10 },
+          },
+        }),
+      ]),
+    );
+
+    const init = composeTemplate('initiative', { registry: reg }).sections.get('scope')!;
+    expect(init.effectiveRubric.minWords).toBe(80);
+    expect(init.effectiveRequired).toBe(true);
+
+    const sub = composeTemplate('subtask', { registry: reg }).sections.get('scope')!;
+    expect(sub.effectiveRubric.minWords).toBe(10);
+    expect(sub.effectiveRequired).toBe(false);
+
+    const story = composeTemplate('story', { registry: reg }).sections.get('scope')!;
+    expect(story.effectiveRubric.minWords).toBe(30);
+    expect(story.effectiveRequired).toBe(true);
+  });
+});
+
+describe('composeTemplate — conflict resolution', () => {
+  it('first contract by agent-pipeline order wins; later one warns', () => {
+    const reg = new ContractRegistry();
+    // Both BA and EA claim 'taxonomy' — pipeline order says BA wins.
+    reg.register(contract('ba', 'ba', ['story'], [spec('taxonomy')]));
+    reg.register(contract('ea', 'ea', ['story'], [spec('taxonomy')]));
+
+    const t = composeTemplate('story', { registry: reg });
+    expect(t.sections.get('taxonomy')!.ownerAgent).toBe('ba');
+    expect(t.warnings).toHaveLength(1);
+    expect(t.warnings[0]).toContain("section 'taxonomy' claimed by both ba");
+    expect(t.warnings[0]).toContain('kept ba');
+  });
+
+  it('strict mode throws on conflict', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('ba', 'ba', ['story'], [spec('taxonomy')]));
+    reg.register(contract('ea', 'ea', ['story'], [spec('taxonomy')]));
+    expect(() => composeTemplate('story', { registry: reg, strict: true })).toThrow(
+      /claimed by both/,
+    );
+  });
+
+  it('contractId tie-break is alphabetical for stable output within same agent', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po-z', 'po', ['story'], [spec('alpha')]));
+    reg.register(contract('po-a', 'po', ['story'], [spec('beta')]));
+
+    const t = composeTemplate('story', { registry: reg });
+    // po-a comes before po-z; both have unique sections so both included.
+    const order = [...t.sections.keys()];
+    expect(order).toEqual(['beta', 'alpha']);
+  });
+});
+
+describe('composeTemplate — dependencies', () => {
+  it('warns when a section depends on a missing one', () => {
+    const reg = new ContractRegistry();
+    reg.register(
+      contract('td', 'test-design', ['story'], [
+        spec('testCases', { dependencies: ['acceptanceCriteria'] }),
+      ]),
+    );
+    const t = composeTemplate('story', { registry: reg });
+    expect(t.warnings.some((w) => w.includes("'testCases'"))).toBe(true);
+    expect(t.warnings.some((w) => w.includes("'acceptanceCriteria'"))).toBe(true);
+  });
+
+  it('does not warn when the dependency is present', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('ba', 'ba', ['story'], [spec('acceptanceCriteria')]));
+    reg.register(
+      contract('td', 'test-design', ['story'], [
+        spec('testCases', { dependencies: ['acceptanceCriteria'] }),
+      ]),
+    );
+    const t = composeTemplate('story', { registry: reg });
+    expect(t.warnings).toEqual([]);
+  });
+
+  it('strict mode throws on unresolved dependency', () => {
+    const reg = new ContractRegistry();
+    reg.register(
+      contract('td', 'test-design', ['story'], [
+        spec('testCases', { dependencies: ['acceptanceCriteria'] }),
+      ]),
+    );
+    expect(() => composeTemplate('story', { registry: reg, strict: true })).toThrow(
+      /depends on/,
+    );
+  });
+});
+
+describe('composeTemplate — signature stability', () => {
+  it('identical inputs produce identical signatures', () => {
+    const buildReg = () => {
+      const r = new ContractRegistry();
+      r.register(contract('po', 'po', ['story'], [spec('scope')]));
+      r.register(contract('ba', 'ba', ['story'], [spec('acceptanceCriteria')]));
+      return r;
+    };
+    const a = composeTemplate('story', { registry: buildReg() });
+    const b = composeTemplate('story', { registry: buildReg() });
+    expect(a.signature).toBe(b.signature);
+  });
+
+  it('signature changes when a rubric field changes', () => {
+    const r1 = new ContractRegistry();
+    r1.register(contract('po', 'po', ['story'], [
+      spec('scope', { rubric: { severityOnFail: 'hard', fixHint: 'fix', minWords: 30 } }),
+    ]));
+    const r2 = new ContractRegistry();
+    r2.register(contract('po', 'po', ['story'], [
+      spec('scope', { rubric: { severityOnFail: 'hard', fixHint: 'fix', minWords: 60 } }),
+    ]));
+    const a = composeTemplate('story', { registry: r1 });
+    const b = composeTemplate('story', { registry: r2 });
+    expect(a.signature).not.toBe(b.signature);
+  });
+
+  it('signature is sensitive to scope', () => {
+    const r = new ContractRegistry();
+    r.register(contract('po', 'po', ['story', 'epic'], [spec('scope')]));
+    const a = composeTemplate('story', { registry: r });
+    const b = composeTemplate('epic', { registry: r });
+    expect(a.signature).not.toBe(b.signature);
+  });
+});
+
+describe('composeAllScopes', () => {
+  it('returns a composed template per canonical scope', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', ['initiative', 'epic', 'module', 'story', 'task', 'subtask'], [spec('scope')]));
+    const all = composeAllScopes({ registry: reg });
+    expect(Object.keys(all).sort()).toEqual(
+      ['initiative', 'epic', 'module', 'story', 'task', 'subtask'].sort(),
+    );
+    for (const t of Object.values(all)) {
+      expect(t.sections.has('scope')).toBe(true);
+    }
+  });
+});

--- a/packages/agent-contract-registry/tests/registry.test.ts
+++ b/packages/agent-contract-registry/tests/registry.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
+import type { SectionContract, SectionSpec } from '@chiefaia/ticket-template';
+import {
+  ContractRegistry,
+  getDefaultRegistry,
+  resetDefaultRegistry,
+  register,
+} from '../src';
+
+const baseSpec: SectionSpec = {
+  name: 'scope',
+  description: 'desc',
+  purpose: 'purpose',
+  dataShape: z.object({}).passthrough(),
+  required: true,
+  rubric: { severityOnFail: 'hard', fixHint: 'fix it' },
+  examples: [{ good: {}, bad: {}, badRationale: 'r' }],
+};
+
+function mkContract(
+  contractId: string,
+  ownerAgent: SectionContract['ownerAgent'] = 'po',
+  scopes: SectionContract['appliesTo'] = ['story'],
+  sections: readonly SectionSpec[] = [baseSpec],
+): SectionContract {
+  return { ownerAgent, contractId, version: '1.0.0', appliesTo: scopes, sections };
+}
+
+describe('ContractRegistry', () => {
+  let reg: ContractRegistry;
+
+  beforeEach(() => {
+    reg = new ContractRegistry();
+  });
+
+  it('starts empty', () => {
+    expect(reg.size()).toBe(0);
+    expect(reg.list()).toEqual([]);
+  });
+
+  it('register adds a contract', () => {
+    reg.register(mkContract('c1'));
+    expect(reg.size()).toBe(1);
+    expect(reg.get('c1')).toBeDefined();
+  });
+
+  it('register throws on duplicate contractId', () => {
+    reg.register(mkContract('c1'));
+    expect(() => reg.register(mkContract('c1'))).toThrow(/already registered/);
+  });
+
+  it('replace overwrites without throwing', () => {
+    reg.register(mkContract('c1', 'po'));
+    reg.replace(mkContract('c1', 'ba'));
+    expect(reg.get('c1')?.ownerAgent).toBe('ba');
+  });
+
+  it('replace registers when absent', () => {
+    reg.replace(mkContract('c1'));
+    expect(reg.get('c1')).toBeDefined();
+  });
+
+  it('unregister removes and returns true; missing returns false', () => {
+    reg.register(mkContract('c1'));
+    expect(reg.unregister('c1')).toBe(true);
+    expect(reg.unregister('c1')).toBe(false);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('list returns contracts in registration order', () => {
+    reg.register(mkContract('a'));
+    reg.register(mkContract('b'));
+    reg.register(mkContract('c'));
+    expect(reg.list().map((c) => c.contractId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('listByAgent filters by ownerAgent', () => {
+    reg.register(mkContract('po1', 'po'));
+    reg.register(mkContract('ba1', 'ba'));
+    reg.register(mkContract('ea1', 'ea'));
+    expect(reg.listByAgent('ba').map((c) => c.contractId)).toEqual(['ba1']);
+    expect(reg.listByAgent('po').map((c) => c.contractId)).toEqual(['po1']);
+  });
+
+  it('clear empties the registry and resets registrationIndex', () => {
+    reg.register(mkContract('c1'));
+    reg.clear();
+    expect(reg.size()).toBe(0);
+    reg.register(mkContract('c1'));
+    expect(reg.size()).toBe(1);
+  });
+});
+
+describe('default singleton', () => {
+  beforeEach(() => {
+    resetDefaultRegistry();
+  });
+
+  it('getDefaultRegistry returns the same instance across calls', () => {
+    const a = getDefaultRegistry();
+    const b = getDefaultRegistry();
+    expect(a).toBe(b);
+  });
+
+  it('resetDefaultRegistry forces a fresh instance', () => {
+    const a = getDefaultRegistry();
+    resetDefaultRegistry();
+    const b = getDefaultRegistry();
+    expect(a).not.toBe(b);
+  });
+
+  it('register() top-level shorthand uses the default singleton', () => {
+    register(mkContract('c1'));
+    expect(getDefaultRegistry().get('c1')).toBeDefined();
+  });
+});

--- a/packages/agent-contract-registry/tests/signature.test.ts
+++ b/packages/agent-contract-registry/tests/signature.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { ComposedSectionEntry, StoryScope } from '@chiefaia/ticket-template';
+import { computeSignature } from '../src/signature';
+
+function entry(name: string, mut: Partial<ComposedSectionEntry> = {}): ComposedSectionEntry {
+  return {
+    spec: {
+      name,
+      description: 'd',
+      purpose: 'p',
+      dataShape: z.object({}).passthrough(),
+      required: true,
+      rubric: { severityOnFail: 'hard', fixHint: 'fix' },
+      examples: [{ good: {}, bad: {}, badRationale: 'r' }],
+    },
+    effectiveRubric: { severityOnFail: 'hard', fixHint: 'fix' },
+    effectiveRequired: true,
+    ownerAgent: 'po',
+    contractId: 'po-agent.v1',
+    ...mut,
+  };
+}
+
+function mapOf(...entries: ComposedSectionEntry[]): Map<string, ComposedSectionEntry> {
+  const m = new Map<string, ComposedSectionEntry>();
+  for (const e of entries) m.set(e.spec.name, e);
+  return m;
+}
+
+describe('computeSignature', () => {
+  it('returns a 64-char lowercase hex string', () => {
+    const sig = computeSignature('story', mapOf(entry('scope')));
+    expect(sig).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is stable across runs given same input', () => {
+    const a = computeSignature('story', mapOf(entry('scope'), entry('ac')));
+    const b = computeSignature('story', mapOf(entry('scope'), entry('ac')));
+    expect(a).toBe(b);
+  });
+
+  it('is order-independent for the sections map', () => {
+    const a = computeSignature('story', mapOf(entry('scope'), entry('ac')));
+    const b = computeSignature('story', mapOf(entry('ac'), entry('scope')));
+    expect(a).toBe(b);
+  });
+
+  it('differs when scope differs', () => {
+    const a = computeSignature('story', mapOf(entry('scope')));
+    const b = computeSignature('task' as StoryScope, mapOf(entry('scope')));
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when rubric severity differs', () => {
+    const a = computeSignature('story', mapOf(entry('scope', { effectiveRubric: { severityOnFail: 'hard', fixHint: 'fix' } })));
+    const b = computeSignature('story', mapOf(entry('scope', { effectiveRubric: { severityOnFail: 'soft', fixHint: 'fix' } })));
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when required flag differs', () => {
+    const a = computeSignature('story', mapOf(entry('scope', { effectiveRequired: true })));
+    const b = computeSignature('story', mapOf(entry('scope', { effectiveRequired: false })));
+    expect(a).not.toBe(b);
+  });
+
+  it('is independent of dataShape internals (Zod is not stably hashable)', () => {
+    const a = computeSignature('story', mapOf(entry('scope', { spec: { ...entry('scope').spec, dataShape: z.string() } })));
+    const b = computeSignature('story', mapOf(entry('scope', { spec: { ...entry('scope').spec, dataShape: z.number() } })));
+    expect(a).toBe(b);
+  });
+});

--- a/packages/agent-contract-registry/tsconfig.json
+++ b/packages/agent-contract-registry/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/agent-contract-registry/vitest.config.ts
+++ b/packages/agent-contract-registry/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+    benchmark: {
+      include: ['src/**/*.bench.ts', 'tests/**/*.bench.ts'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,25 @@ importers:
         specifier: '>=1'
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
+  packages/agent-contract-registry:
+    dependencies:
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../ticket-template
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+
   packages/analytics:
     dependencies:
       next:


### PR DESCRIPTION
## ACR-002 — Agent Section Contract Registry: package skeleton + composeTemplate

Stacked on **#129 (ACR-001)**.

New workspace package `@chiefaia/agent-contract-registry` providing the declarative contract store + the runtime composition function the Story Validator will consume instead of the hard-coded `validation-rubric.ts`.

### What's in the box

- `ContractRegistry` class — `register`/`replace`/`unregister`/`list`/`listByAgent`/`get`/`clear`. Singleton via `getDefaultRegistry()` + top-level `register()` shorthand.
- `composeTemplate(scope, opts?)` — pure compose function returning `ComposedTemplate { scope, sections, signature, warnings }`. Supports `opts.strict` for CI conflict-failures and `opts.registry` for tests.
- `composeAllScopes(opts?)` — convenience returning every canonical scope.
- `computeSignature()` — stable SHA-256 over normalised composed entries. Validator uses this as a cache key + CI snapshot tests use it for drift detection.

### Composition algorithm

1. Filter registry to contracts whose `appliesTo` includes the scope.
2. Sort by agent-pipeline order — PO < BA < EA < Test-Design. Tie-break alphabetically by `contractId`.
3. First contract to claim a section name wins; subsequent claims log a warning (strict mode throws).
4. Apply per-section `scopeOverrides[scope]` via `applyScopeOverride()`.
5. Verify section `dependencies` resolve within the composed template; warn on unresolved.
6. Compute stable SHA-256 signature.

### Tests — 33/33 pass

- `registry.test.ts` (12) — register/replace/unregister/list/listByAgent/clear/singleton lifecycle.
- `compose-template.test.ts` (14) — empty registry, scope filter, agent ordering, scope overrides, conflict resolution (lenient + strict), contractId tie-break, dependency resolution, signature stability, `composeAllScopes`.
- `signature.test.ts` (7) — hex format, stability, order-independence, scope sensitivity, severity sensitivity, `required` sensitivity, Zod-shape independence.

### Benchmark — full 4-contract registry

| Scope | Ops/sec | Mean |
|---|---|---|
| story | 24,649 | 0.041 ms |
| initiative | 92,279 | 0.011 ms |
| subtask | 56,760 | 0.018 ms |

Well under the < 1 ms cold-cache target.

### Token cost

**Zero.** Pure data manipulation — no LLM calls in this layer. Validator's existing per-section relevance prompts are unchanged; their seeds simply move into the composed template.

### Coordination

- **VAL-### track:** no overlap — this PR ships the registry but does NOT modify the Validator yet. ACR-007 wires the Validator after VAL-004/005/009 land.
- **ARCH-### track:** independent — ACR-005 (EA contract) will declare a stub for `architecturalInstructions` and bump version when ARCH-006 lands.

### Sequencing

ACR-001 (#129) → **ACR-002 (this)** → ACR-003/004/005/006 (parallelizable) → ACR-008 → ACR-007 → ACR-009 → ACR-010 → ACR-011.

Refs: ACR-002 (Agent Section Contract Registry)