### PR TITLE
feat(orchestrator): BA Agent SectionContract declaration (ACR-004)

### DIFF
--- a/apps/orchestrator/src/agents/ba-agent.contract.ts
+++ b/apps/orchestrator/src/agents/ba-agent.contract.ts
@@ -1,0 +1,329 @@
+/**
+ * BA Agent — Section Contract (ACR-004)
+ *
+ * The Business-Analyst agent's declaration of which sections it will
+ * populate after PO decomposition. BA owns the bulk of the ticket — the
+ * functional contract (acceptance criteria) and the per-domain agent
+ * sections (architecture, database, api, ui, security, testing, release,
+ * observability) plus dependencies, risks, assumptions, clarifying
+ * questions.
+ *
+ * BA does NOT apply to `initiative` or `subtask` — initiatives are too
+ * abstract for AC, and subtasks inherit the parent's BA contract.
+ *
+ * The Validator's content-relevance prompts in validation-rubric.ts are
+ * the source of truth for these sections; the contract here mirrors those
+ * thresholds via the rubric so ACR-007 can swap the Validator over to
+ * consume the composed template without behaviour drift.
+ */
+
+import { z } from 'zod';
+import {
+  AGENT_SECTION_KEYS,
+  MIN_ACCEPTANCE_CRITERIA,
+  MAX_ACCEPTANCE_CRITERIA,
+  UNIVERSAL_FORBIDDEN_SNIPPETS,
+  type AgentSectionKey,
+  type SectionContract,
+  type SectionSpec,
+} from '@chiefaia/ticket-template';
+
+// ─── Section data shapes ────────────────────────────────────────────────────
+
+const AcceptanceCriteriaSchema = z
+  .array(z.string().min(1))
+  .min(MIN_ACCEPTANCE_CRITERIA)
+  .max(MAX_ACCEPTANCE_CRITERIA);
+
+const DependenciesSchema = z
+  .object({
+    upstream: z.array(z.string()).default([]),
+    downstream: z.array(z.string()).default([]),
+    files: z.array(z.string()).default([]),
+  })
+  .strict();
+
+const RisksSchema = z.array(z.string().min(1));
+const AssumptionsSchema = z.array(z.string().min(1));
+const ClarifyingQuestionsSchema = z.array(
+  z
+    .object({
+      question: z.string().min(1),
+      askedTo: z.enum(['po', 'ea', 'test-design', 'human']),
+      answer: z.string().optional(),
+      resolvedAt: z.number().int().nonnegative().optional(),
+    })
+    .strict(),
+);
+
+// Per-agent-section data shapes are simply z.unknown() at this layer — the
+// Validator runs the section-specific Zod schemas from `schema.ts` during
+// the structural-validation step. The contract's job is the rubric.
+const AgentSectionPlaceholder = z.unknown();
+
+// ─── Section specs ──────────────────────────────────────────────────────────
+
+const acceptanceCriteriaSpec: SectionSpec = {
+  name: 'acceptanceCriteria',
+  description: 'Testable behavioural contract — each item describes one observable behaviour.',
+  purpose:
+    'The Test-Design Agent translates each AC into >=1 concrete test case; the coding agent uses ACs as the implementation contract.',
+  dataShape: AcceptanceCriteriaSchema,
+  required: true,
+  rubric: {
+    minWords: 24,
+    minItems: MIN_ACCEPTANCE_CRITERIA,
+    severityOnFail: 'hard',
+    forbiddenSnippets: [
+      ...UNIVERSAL_FORBIDDEN_SNIPPETS,
+      'works correctly',
+      'works as expected',
+      'looks good',
+      'as expected',
+      'should work',
+    ],
+    fixHint:
+      'Provide 3-10 acceptance criteria. Each must describe an observable behaviour in >=8 words. Prefer Given/When/Then phrasing. Avoid implementation details.',
+  },
+  examples: [
+    {
+      good: [
+        'Given an authenticated subscriber, when they click "Upgrade", then a Stripe Checkout Session is created and they redirect to the Stripe-hosted page.',
+        'Given a successful payment, when the webhook fires, then the user\'s plan is updated and a confirmation email is queued.',
+        'Given a cancelled checkout, when the user clicks "back", then they return to the billing page with no plan change.',
+      ],
+      bad: ['Billing works correctly', 'Stripe integration works as expected', 'No errors'],
+      badRationale:
+        'Untestable fluff — "works correctly" cannot be verified. No persona/action/outcome.',
+    },
+  ],
+  scopeOverrides: {
+    epic: { minItems: 2, minWords: 16, severityOnFail: 'soft' },
+    module: { minItems: 2, minWords: 16, severityOnFail: 'soft' },
+    task: { minItems: 1, minWords: 8 },
+    subtask: { required: false, severityOnFail: 'warning' },
+  },
+};
+
+const dependenciesSpec: SectionSpec = {
+  name: 'dependencies',
+  description: 'Story-to-story ordering hints + files this story is expected to touch.',
+  purpose:
+    'BUCKET-### track uses dependencies.files to enforce resource non-overlap; upstream/downstream drive level scheduling within each WCC.',
+  dataShape: DependenciesSchema,
+  required: false,
+  rubric: {
+    severityOnFail: 'warning',
+    fixHint:
+      'List upstream story IDs that must complete first, downstream story IDs this enables, and files the implementation will touch.',
+  },
+  examples: [
+    {
+      good: { upstream: ['story-42'], downstream: [], files: ['apps/orchestrator/src/agents/billing.ts'] },
+      bad: { upstream: [], downstream: [], files: [] },
+      badRationale: 'Empty dependencies block defeats the bucket scheduler\'s claim system.',
+    },
+  ],
+  scopeOverrides: {
+    initiative: { required: false },
+    subtask: { required: false },
+  },
+};
+
+const risksSpec: SectionSpec = {
+  name: 'risks',
+  description: 'Project risks BA identified during enrichment.',
+  purpose:
+    'Surfaces in the Validator\'s gestalt prompt; lets the Test-Design Agent target risk-driven test cases.',
+  dataShape: RisksSchema,
+  required: false,
+  rubric: {
+    minItems: 1,
+    severityOnFail: 'soft',
+    fixHint:
+      'Add >=1 risk in concrete terms (e.g. "Stripe webhook ordering may cause double-charge"). Avoid generic OWASP boilerplate.',
+  },
+  examples: [
+    {
+      good: [
+        'Stripe webhook arriving before the redirect can race the local plan update — must be idempotent.',
+      ],
+      bad: ['Things might break'],
+      badRationale: 'Non-actionable.',
+    },
+  ],
+  scopeOverrides: {
+    initiative: { required: true, minItems: 2 },
+    epic: { required: true },
+    module: { required: true },
+    story: { required: false },
+    task: { required: false },
+    subtask: { required: false },
+  },
+};
+
+const assumptionsSpec: SectionSpec = {
+  name: 'assumptions',
+  description: 'Things BA assumed when filling in the ticket — must be verified by EA / coding agent.',
+  purpose:
+    'When the coding agent finds an assumption broken, the story bounces back to BA via the Validator\'s re-attempt loop.',
+  dataShape: AssumptionsSchema,
+  required: false,
+  rubric: {
+    minItems: 1,
+    severityOnFail: 'warning',
+    fixHint: 'List >=1 assumption — even "no assumptions" should be stated explicitly.',
+  },
+  examples: [
+    {
+      good: ['Existing /api/billing route handles auth — confirm with EA.'],
+      bad: [],
+      badRationale: 'Empty defeats the bounce-back-on-broken-assumption loop.',
+    },
+  ],
+  scopeOverrides: {
+    initiative: { required: true },
+    epic: { required: true },
+    module: { required: true },
+    story: { required: false },
+    task: { required: false },
+    subtask: { required: false },
+  },
+};
+
+const clarifyingQuestionsSpec: SectionSpec = {
+  name: 'clarifyingQuestions',
+  description: 'Open questions BA asked during cross-agent collaboration.',
+  purpose:
+    'Resolved questions become a record of the cross-agent collaboration; unresolved questions block the Validator hand-off.',
+  dataShape: ClarifyingQuestionsSchema,
+  required: false,
+  rubric: {
+    severityOnFail: 'warning',
+    fixHint: 'Resolved questions should have a non-empty `answer`; unresolved questions block hand-off.',
+  },
+  examples: [
+    {
+      good: [
+        {
+          question: 'Should we cancel pending Stripe Sessions older than 24h?',
+          askedTo: 'po',
+          answer: 'Yes — cancel after 24h.',
+          resolvedAt: 1730000000000,
+        },
+      ],
+      bad: [{ question: 'Hmm', askedTo: 'po' }],
+      badRationale: 'Vague + unresolved.',
+    },
+  ],
+  scopeOverrides: {
+    story: { required: false },
+    task: { required: false },
+    subtask: { required: false },
+  },
+};
+
+// ─── Per-domain agentSections specs ────────────────────────────────────────
+//
+// The BA contract owns the rubric for every key in AGENT_SECTION_KEYS
+// EXCEPT `architecture` which the EA contract (ACR-005) owns. We declare
+// agentSections.* sections here; ACR-005 declares architecture and
+// architecturalInstructions.
+
+const AGENT_SECTIONS_OWNED_BY_BA: readonly AgentSectionKey[] = AGENT_SECTION_KEYS.filter(
+  (k) => k !== 'architecture',
+);
+
+const AGENT_SECTION_RUBRICS: Record<
+  AgentSectionKey,
+  { minWords: number; fixHint: string }
+> = {
+  architecture: { minWords: 40, fixHint: 'EA owns this section.' },
+  database: {
+    minWords: 30,
+    fixHint:
+      'Database section needs >=1 schemaChange entry, a migrationPath, and concrete table/migration references.',
+  },
+  api: {
+    minWords: 25,
+    fixHint:
+      'API section needs >=1 route entry (method, path, schemas) and an errorContract describing the error response shape.',
+  },
+  ui: {
+    minWords: 25,
+    fixHint:
+      'UI section needs >=1 PascalCase component name. Stories tagged "accessibility" require concrete a11y requirements.',
+  },
+  security: {
+    minWords: 30,
+    fixHint:
+      'Security section needs >=2 threatModel entries that address actual risks. For auth-touching stories, populate authzNotes (>=10 words).',
+  },
+  testing: {
+    minWords: 20,
+    fixHint:
+      'Testing section requires either >=1 unitTestPath or >=1 integrationTestPath. coverageTarget should be >=0.5.',
+  },
+  release: {
+    minWords: 20,
+    fixHint:
+      'Release section needs a rolloutPlan (>=10 words). For risk=critical: also specify a rollbackPlan and a featureFlag.',
+  },
+  observability: {
+    minWords: 20,
+    fixHint:
+      'Observability section needs >=1 metric entry and either >=1 log or >=1 trace. risk=critical requires >=1 alertRule.',
+  },
+};
+
+function makeAgentSectionSpec(key: AgentSectionKey): SectionSpec {
+  const meta = AGENT_SECTION_RUBRICS[key];
+  return {
+    name: `agentSections.${key}`,
+    description: `Per-domain BA contribution for ${key}.`,
+    purpose: `Surfaces the ${key}-domain implementation specifics so the coding agent can implement without follow-up questions.`,
+    dataShape: AgentSectionPlaceholder,
+    required: false,
+    dependencies: ['scope', 'acceptanceCriteria'],
+    rubric: {
+      minWords: meta.minWords,
+      severityOnFail: 'soft',
+      forbiddenSnippets: [...UNIVERSAL_FORBIDDEN_SNIPPETS],
+      fixHint: meta.fixHint,
+    },
+    examples: [
+      {
+        good: { contributedBy: 'ba-agent', contributedAt: 0, notes: 'Concrete content here.' },
+        bad: { contributedBy: 'ba-agent', contributedAt: 0 },
+        badRationale: 'Empty content fails relevance + minWords.',
+      },
+    ],
+    scopeOverrides: {
+      module: { required: false },
+      story: { required: false },
+      task: { required: false },
+      subtask: { required: false },
+    },
+  };
+}
+
+const agentSectionSpecs: readonly SectionSpec[] = AGENT_SECTIONS_OWNED_BY_BA.map(
+  makeAgentSectionSpec,
+);
+
+// ─── Contract export ────────────────────────────────────────────────────────
+
+export const baAgentContract: SectionContract = {
+  ownerAgent: 'ba',
+  contractId: 'ba-agent.v1',
+  version: '1.0.0',
+  appliesTo: ['epic', 'module', 'story', 'task'],
+  sections: [
+    acceptanceCriteriaSpec,
+    dependenciesSpec,
+    risksSpec,
+    assumptionsSpec,
+    clarifyingQuestionsSpec,
+    ...agentSectionSpecs,
+  ],
+};

--- a/apps/orchestrator/tests/agents/ba-agent.contract.test.ts
+++ b/apps/orchestrator/tests/agents/ba-agent.contract.test.ts
@@ -1,0 +1,138 @@
+/**
+ * BA Agent contract — composition + per-scope behaviour tests (ACR-004).
+ */
+
+import { ContractRegistry, composeTemplate } from '@chiefaia/agent-contract-registry';
+import type { StoryScope } from '@chiefaia/ticket-template';
+import { baAgentContract } from '../../src/agents/ba-agent.contract';
+
+describe('baAgentContract — registration', () => {
+  it('registers without throwing', () => {
+    const reg = new ContractRegistry();
+    expect(() => reg.register(baAgentContract)).not.toThrow();
+  });
+
+  it('owner is ba', () => {
+    expect(baAgentContract.ownerAgent).toBe('ba');
+  });
+
+  it('appliesTo epic, module, story, task (not initiative or subtask)', () => {
+    expect(baAgentContract.appliesTo).toEqual(['epic', 'module', 'story', 'task']);
+    expect(baAgentContract.appliesTo).not.toContain('initiative');
+    expect(baAgentContract.appliesTo).not.toContain('subtask');
+  });
+
+  it('declares acceptanceCriteria as a hard section', () => {
+    const ac = baAgentContract.sections.find((s) => s.name === 'acceptanceCriteria')!;
+    expect(ac).toBeDefined();
+    expect(ac.required).toBe(true);
+    expect(ac.rubric.severityOnFail).toBe('hard');
+  });
+
+  it('does not own agentSections.architecture (EA territory)', () => {
+    const arch = baAgentContract.sections.find((s) => s.name === 'agentSections.architecture');
+    expect(arch).toBeUndefined();
+  });
+
+  it('owns the other 7 agentSections.* slots', () => {
+    const owned = baAgentContract.sections
+      .map((s) => s.name)
+      .filter((n) => n.startsWith('agentSections.'));
+    expect(owned.sort()).toEqual([
+      'agentSections.api',
+      'agentSections.database',
+      'agentSections.observability',
+      'agentSections.release',
+      'agentSections.security',
+      'agentSections.testing',
+      'agentSections.ui',
+    ]);
+  });
+});
+
+describe('baAgentContract — composition', () => {
+  let reg: ContractRegistry;
+  beforeEach(() => {
+    reg = new ContractRegistry();
+    reg.register(baAgentContract);
+  });
+
+  function compose(scope: StoryScope) {
+    return composeTemplate(scope, { registry: reg });
+  }
+
+  it('story scope: acceptanceCriteria required + hard', () => {
+    const t = compose('story');
+    const ac = t.sections.get('acceptanceCriteria')!;
+    expect(ac.effectiveRequired).toBe(true);
+    expect(ac.effectiveRubric.severityOnFail).toBe('hard');
+    expect(ac.effectiveRubric.minItems).toBe(3);
+  });
+
+  it('epic scope: acceptanceCriteria relaxed (minItems 2, soft)', () => {
+    const t = compose('epic');
+    const ac = t.sections.get('acceptanceCriteria')!;
+    expect(ac.effectiveRubric.minItems).toBe(2);
+    expect(ac.effectiveRubric.severityOnFail).toBe('soft');
+  });
+
+  it('subtask scope: BA contract excluded entirely (subtask not in appliesTo)', () => {
+    // subtask isn't in appliesTo, so the BA contract contributes zero sections.
+    const t = compose('subtask');
+    expect(t.sections.size).toBe(0);
+  });
+
+  it('initiative scope: BA contract excluded entirely (not in appliesTo)', () => {
+    const t = compose('initiative');
+    expect(t.sections.size).toBe(0);
+  });
+
+  it('story scope: agentSections.* are optional (BA fills as relevant)', () => {
+    const t = compose('story');
+    const ui = t.sections.get('agentSections.ui')!;
+    expect(ui.effectiveRequired).toBe(false);
+    expect(ui.effectiveRubric.severityOnFail).toBe('soft');
+  });
+
+  it('agentSections.* declare scope + acceptanceCriteria as dependencies', () => {
+    for (const s of baAgentContract.sections) {
+      if (s.name.startsWith('agentSections.')) {
+        expect(s.dependencies).toEqual(['scope', 'acceptanceCriteria']);
+      }
+    }
+  });
+
+  it('every section has a fixHint and >=1 example', () => {
+    for (const s of baAgentContract.sections) {
+      expect(s.rubric.fixHint.length).toBeGreaterThan(0);
+      expect(s.examples.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('baAgentContract — strict mode CI', () => {
+  it('composes every applicable scope without conflict', () => {
+    const reg = new ContractRegistry();
+    reg.register(baAgentContract);
+    for (const scope of ['epic', 'module', 'story', 'task'] as const) {
+      // dependencies on scope/acceptanceCriteria are unresolved when only BA
+      // is registered (scope is owned by PO). We expect warnings but no throw
+      // unless strict mode is on AND deps are missing.
+      const t = composeTemplate(scope, { registry: reg });
+      // Warnings allowed — they will be resolved when PO contract joins.
+      expect(t.sections.size).toBeGreaterThan(0);
+    }
+  });
+
+  it('signatures differ across applicable scopes', () => {
+    const reg = new ContractRegistry();
+    reg.register(baAgentContract);
+    const sigs = new Set([
+      composeTemplate('epic', { registry: reg }).signature,
+      composeTemplate('module', { registry: reg }).signature,
+      composeTemplate('story', { registry: reg }).signature,
+      composeTemplate('task', { registry: reg }).signature,
+    ]);
+    expect(sigs.size).toBe(4);
+  });
+});


### PR DESCRIPTION
## ACR-004 — BA Agent contract

Stacked on **#129 (ACR-001) → #132 (ACR-002) → #133 (ACR-003)**.

BA Agent declares its sections + per-scope rubrics. BA owns the bulk of the ticket — `acceptanceCriteria`, all `agentSections.*` except `architecture` (EA territory), plus dependencies/risks/assumptions/clarifyingQuestions.

`appliesTo = ['epic','module','story','task']` — initiative too abstract for AC, subtask inherits parent's BA contract.

### Per-scope highlights

- **acceptanceCriteria**: hard on story/task (minItems=3); soft + minItems=2 on epic/module; warning on subtask.
- **risks/assumptions**: required on initiative/epic/module; relaxed on story+; soft on story.
- **agentSections.\***: 7 owned (api, database, observability, release, security, testing, ui — NOT architecture); soft + optional; depends on [scope, acceptanceCriteria].

### Forbidden snippets on AC

`works correctly`, `works as expected`, `looks good`, `as expected`, `should work` — mirrors `AC_ITEM_RULES.forbiddenSnippets` from `validation-rubric.ts` so ACR-007 swap is behaviour-preserving.

### Tests — 15/15 jest pass

- registers without throwing; owner is ba; appliesTo correct
- acceptanceCriteria is hard required (story); soft + relaxed (epic)
- agentSections.architecture NOT owned (EA territory); 7 others owned
- subtask + initiative: BA contract contributes zero sections
- agentSections.* declare [scope, acceptanceCriteria] dependencies
- every section has fixHint + ≥1 example
- strict mode composes every applicable scope; signatures differ across scopes

### Coordination

ACR-005 (EA) ships agentSections.architecture + architecturalInstructions in parallel. The composition algorithm picks them up automatically once both contracts register.

Refs: ACR-004