### PR TITLE
feat(orchestrator): EA Agent SectionContract declaration (ACR-005)

### DIFF
--- a/apps/orchestrator/src/agents/ea-agent.contract.ts
+++ b/apps/orchestrator/src/agents/ea-agent.contract.ts
@@ -1,0 +1,284 @@
+/**
+ * EA Agent — Section Contract (ACR-005)
+ *
+ * The Enterprise-Architect agent's declaration of which sections it
+ * populates. EA owns the technical layer of the ticket — agentSections.
+ * architecture, the per-domain `architecturalInstructions` array (when
+ * ARCH-006 lands), the BUCKET-001 taxonomy block (techSubDomains, risk,
+ * effort), and the resource claims block (BUCKET-009).
+ *
+ * Coordination with ARCH-### track:
+ *   - `architecturalInstructions` is declared as a stub here. The actual
+ *     field shape is added by ARCH-006 to TicketTemplateV1Schema. Until
+ *     then, the contract uses z.array(z.unknown()) — the Validator's
+ *     structural step skips structurally-empty sections, but the rubric
+ *     (minItems, requiredEntityRefs) still applies once ARCH-006 lands.
+ *   - When ARCH-006 lands, this contract bumps to v1.1.0 — the
+ *     ComposedTemplate signature changes, the Validator's cached rubric
+ *     invalidates, and the per-domain references kick in.
+ *
+ * EA does not apply to `initiative` or `epic` — those scopes are PO/BA
+ * strategic territory; EA enters at `module` and below.
+ */
+
+import { z } from 'zod';
+import {
+  EFFORT_VALUES,
+  RISK_VALUES,
+  TECH_SUB_DOMAINS,
+  UNIVERSAL_FORBIDDEN_SNIPPETS,
+  type SectionContract,
+  type SectionSpec,
+} from '@chiefaia/ticket-template';
+
+// ─── Section data shapes ────────────────────────────────────────────────────
+
+const ArchitectureSectionSchema = z
+  .object({
+    contributedBy: z.string().min(1),
+    contributedAt: z.number().int().nonnegative(),
+    adrReferences: z.array(z.string()).default([]),
+    constraints: z.array(z.string()).default([]),
+    notes: z.string().default(''),
+  })
+  .strict();
+
+/**
+ * Stub for `architecturalInstructions` — ARCH-006 lands the real shape on
+ * TicketTemplateV1. Until then, we accept any array shape so the rubric's
+ * minItems + requiredEntityRefs apply without coupling to a future schema.
+ */
+const ArchitecturalInstructionsSchema = z.array(z.unknown()).default([]);
+
+const TechSubDomainsSchema = z
+  .object({
+    primary: z.enum(TECH_SUB_DOMAINS),
+    all: z.array(z.enum(TECH_SUB_DOMAINS)).min(1),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    if (!val.all.includes(val.primary)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'techSubDomains.primary must appear in techSubDomains.all',
+        path: ['primary'],
+      });
+    }
+  });
+
+const ClaimsSchema = z
+  .object({
+    files: z.array(z.string()).default([]),
+    schemas: z.array(z.string()).default([]),
+    apiRoutes: z.array(z.string()).default([]),
+    domains: z.array(z.string()).default([]),
+  })
+  .strict();
+
+const EffortSchema = z.enum(EFFORT_VALUES);
+const RiskSchema = z.enum(RISK_VALUES);
+
+// ─── Section specs ──────────────────────────────────────────────────────────
+
+const architectureSpec: SectionSpec = {
+  name: 'agentSections.architecture',
+  description: 'Architecture decisions guiding the implementation: ADR refs, constraints, rationale.',
+  purpose:
+    'Captures EA\'s design choices so the coding agent doesn\'t reinvent them. References ADRs + concrete file paths / packages.',
+  dataShape: ArchitectureSectionSchema,
+  required: false,
+  dependencies: ['scope'],
+  rubric: {
+    minWords: 40,
+    minItemsPerSubField: { constraints: 1 },
+    requiredEntityRefs: [
+      {
+        label: 'file path, ADR ref, or @chiefaia package',
+        pattern: '(\\w+\\.(ts|tsx|js|jsx|sql|md|yaml))|ADR-\\d+|@chiefaia/[\\w-]+',
+        flags: 'i',
+      },
+    ],
+    severityOnFail: 'soft',
+    forbiddenSnippets: [...UNIVERSAL_FORBIDDEN_SNIPPETS],
+    fixHint:
+      'Architecture section needs >=40 words and at least one concrete reference (file path, ADR-#, or @chiefaia/* package). Notes should explain why this approach over alternatives.',
+  },
+  examples: [
+    {
+      good: {
+        contributedBy: 'ea-agent',
+        contributedAt: 1730000000000,
+        adrReferences: ['ADR-12'],
+        constraints: ['No new third-party deps; reuse @chiefaia/secrets.'],
+        notes:
+          'Use @chiefaia/secrets-broker to fetch the Stripe webhook signing key — pattern matches packages/secrets-broker/README.md.',
+      },
+      bad: {
+        contributedBy: 'ea-agent',
+        contributedAt: 0,
+        adrReferences: [],
+        constraints: [],
+        notes: 'TBD',
+      },
+      badRationale: 'Empty + TBD placeholder.',
+    },
+  ],
+  scopeOverrides: {
+    module: { required: true, severityOnFail: 'soft' },
+    story: { required: true, severityOnFail: 'soft' },
+    task: { required: true, severityOnFail: 'soft' },
+    subtask: { required: false },
+  },
+};
+
+const architecturalInstructionsSpec: SectionSpec = {
+  name: 'architecturalInstructions',
+  description:
+    'Per-domain technical instructions referencing AKG (Architecture Knowledge Graph) entities — populated by EA Agent post-ARCH-006.',
+  purpose:
+    'Coding agent gets concrete instructions: which file, which API, which schema, with names — no architectural thinking required at coding time.',
+  dataShape: ArchitecturalInstructionsSchema,
+  required: false,
+  dependencies: ['scope'],
+  rubric: {
+    minItems: 1,
+    severityOnFail: 'soft',
+    requiredEntityRefs: [
+      {
+        label: 'AKG entity reference',
+        pattern:
+          'arch_(services|apis|components|schemas|migrations|themes|plugins|packages|integrations|domain_modules|observability_signals)/[a-z0-9_-]+',
+        flags: 'i',
+      },
+    ],
+    fixHint:
+      'Each instruction must reference a concrete AKG entity by ID (e.g. arch_apis/billing-checkout). Empty array fails the Validator.',
+  },
+  examples: [
+    {
+      good: [
+        { domain: 'backend', instruction: 'Add POST /billing/checkout to arch_apis/billing — reuse arch_components/StripeButton.' },
+      ],
+      bad: [],
+      badRationale: 'Empty defeats the AKG reference rubric.',
+    },
+  ],
+  scopeOverrides: {
+    module: { required: true, severityOnFail: 'soft' },
+    story: { required: true, severityOnFail: 'soft' },
+    task: { required: true, severityOnFail: 'soft' },
+    subtask: { required: false, minItems: 0 },
+  },
+};
+
+const techSubDomainsSpec: SectionSpec = {
+  name: 'taxonomy.techSubDomains',
+  description: 'Technology sub-domains the work touches; one is `primary` (bucket key).',
+  purpose:
+    'BUCKET-### track keys buckets on (project, techSubDomainPrimary). Multi-value tags also drive scheduler claims for resource non-overlap.',
+  dataShape: TechSubDomainsSchema,
+  required: true,
+  rubric: {
+    severityOnFail: 'hard',
+    fixHint: 'Set primary + all from TECH_SUB_DOMAINS. primary must appear in all.',
+  },
+  examples: [
+    {
+      good: { primary: 'backend', all: ['backend', 'database', 'observability'] },
+      bad: { primary: 'backend', all: ['frontend'] },
+      badRationale: 'primary not in all — fails refinement.',
+    },
+  ],
+  scopeOverrides: {
+    subtask: { required: false, severityOnFail: 'warning' },
+  },
+};
+
+const claimsSpec: SectionSpec = {
+  name: 'claims',
+  description: 'Resource claims for the BUCKET-### scheduler — files/schemas/apiRoutes/domains.',
+  purpose:
+    'Scheduler enforces no two in-flight stories intersect on any of files/schemas/apiRoutes — see BUCKET-009 ready-pool.',
+  dataShape: ClaimsSchema,
+  required: false,
+  rubric: {
+    severityOnFail: 'soft',
+    fixHint:
+      'Populate at least one of files/schemas/apiRoutes for stories that will modify code. Empty for spike/docs only.',
+  },
+  examples: [
+    {
+      good: {
+        files: ['apps/orchestrator/src/agents/billing.ts'],
+        schemas: ['stories'],
+        apiRoutes: ['POST /billing/checkout'],
+        domains: ['billing'],
+      },
+      bad: { files: [], schemas: [], apiRoutes: [], domains: [] },
+      badRationale: 'Empty defeats the scheduler\'s claim system.',
+    },
+  ],
+  scopeOverrides: {
+    story: { required: true, severityOnFail: 'soft' },
+    task: { required: true, severityOnFail: 'soft' },
+    subtask: { required: false },
+  },
+};
+
+const effortSpec: SectionSpec = {
+  name: 'taxonomy.effort',
+  description: 'Effort estimate XS through XL.',
+  purpose:
+    'Bucket scheduler uses effort for level-scheduling weight; XL is a guard rail — EA must split before BA finishes.',
+  dataShape: EffortSchema,
+  required: true,
+  rubric: {
+    severityOnFail: 'soft',
+    forbiddenSnippets: ['XL'],
+    fixHint: 'Pick XS / S / M / L. XL must be split into smaller stories before BA finishes.',
+  },
+  examples: [
+    { good: 'M', bad: 'XL', badRationale: 'XL must be split.' },
+  ],
+  scopeOverrides: {
+    epic: { required: true, severityOnFail: 'warning' },
+    subtask: { required: false, severityOnFail: 'warning' },
+  },
+};
+
+const riskSpec: SectionSpec = {
+  name: 'taxonomy.risk',
+  description: 'Technical risk level — low/medium/high/critical.',
+  purpose:
+    'Drives Validator section-required triggers (e.g. risk=critical requires release + observability sections).',
+  dataShape: RiskSchema,
+  required: true,
+  rubric: {
+    severityOnFail: 'soft',
+    fixHint: 'Pick low / medium / high / critical. critical requires P0/P1 priority + release/observability sections.',
+  },
+  examples: [
+    { good: 'high', bad: '', badRationale: 'Missing risk skips downstream Validator triggers.' },
+  ],
+  scopeOverrides: {
+    epic: { required: true, severityOnFail: 'warning' },
+    subtask: { required: false, severityOnFail: 'warning' },
+  },
+};
+
+// ─── Contract export ────────────────────────────────────────────────────────
+
+export const eaAgentContract: SectionContract = {
+  ownerAgent: 'ea',
+  contractId: 'ea-agent.v1',
+  version: '1.0.0',
+  appliesTo: ['module', 'story', 'task', 'subtask'],
+  sections: [
+    architectureSpec,
+    architecturalInstructionsSpec,
+    techSubDomainsSpec,
+    claimsSpec,
+    effortSpec,
+    riskSpec,
+  ],
+};

--- a/apps/orchestrator/tests/agents/ea-agent.contract.test.ts
+++ b/apps/orchestrator/tests/agents/ea-agent.contract.test.ts
@@ -1,0 +1,127 @@
+/**
+ * EA Agent contract — composition + per-scope behaviour tests (ACR-005).
+ */
+
+import { ContractRegistry, composeTemplate } from '@chiefaia/agent-contract-registry';
+import type { StoryScope } from '@chiefaia/ticket-template';
+import { eaAgentContract } from '../../src/agents/ea-agent.contract';
+
+describe('eaAgentContract — registration', () => {
+  it('registers without throwing', () => {
+    const reg = new ContractRegistry();
+    expect(() => reg.register(eaAgentContract)).not.toThrow();
+  });
+
+  it('owner is ea', () => {
+    expect(eaAgentContract.ownerAgent).toBe('ea');
+  });
+
+  it('appliesTo module, story, task, subtask (not initiative or epic)', () => {
+    expect(eaAgentContract.appliesTo).toEqual(['module', 'story', 'task', 'subtask']);
+    expect(eaAgentContract.appliesTo).not.toContain('initiative');
+    expect(eaAgentContract.appliesTo).not.toContain('epic');
+  });
+
+  it('owns agentSections.architecture (BA does not)', () => {
+    expect(
+      eaAgentContract.sections.find((s) => s.name === 'agentSections.architecture'),
+    ).toBeDefined();
+  });
+
+  it('declares architecturalInstructions stub (for ARCH-006 wiring)', () => {
+    const ai = eaAgentContract.sections.find((s) => s.name === 'architecturalInstructions');
+    expect(ai).toBeDefined();
+    // Stub: minItems rubric is set, but until ARCH-006 lands the schema, EA
+    // populates an empty array. The contract's required rubric kicks in once
+    // ARCH-006 ships.
+    expect(ai!.rubric.minItems).toBe(1);
+    expect(ai!.rubric.requiredEntityRefs?.[0]?.pattern).toContain('arch_');
+  });
+
+  it('owns taxonomy.techSubDomains, claims, effort, risk', () => {
+    const names = eaAgentContract.sections.map((s) => s.name);
+    expect(names).toContain('taxonomy.techSubDomains');
+    expect(names).toContain('claims');
+    expect(names).toContain('taxonomy.effort');
+    expect(names).toContain('taxonomy.risk');
+  });
+
+  it('every section has fixHint + >=1 example', () => {
+    for (const s of eaAgentContract.sections) {
+      expect(s.rubric.fixHint.length).toBeGreaterThan(0);
+      expect(s.examples.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('eaAgentContract — composition', () => {
+  let reg: ContractRegistry;
+  beforeEach(() => {
+    reg = new ContractRegistry();
+    reg.register(eaAgentContract);
+  });
+
+  function compose(scope: StoryScope) {
+    return composeTemplate(scope, { registry: reg });
+  }
+
+  it('story scope: architecture + architecturalInstructions required + soft', () => {
+    const t = compose('story');
+    const arch = t.sections.get('agentSections.architecture')!;
+    const ai = t.sections.get('architecturalInstructions')!;
+    expect(arch.effectiveRequired).toBe(true);
+    expect(arch.effectiveRubric.severityOnFail).toBe('soft');
+    expect(ai.effectiveRequired).toBe(true);
+    expect(ai.effectiveRubric.severityOnFail).toBe('soft');
+  });
+
+  it('story scope: techSubDomains hard required', () => {
+    const t = compose('story');
+    const tx = t.sections.get('taxonomy.techSubDomains')!;
+    expect(tx.effectiveRequired).toBe(true);
+    expect(tx.effectiveRubric.severityOnFail).toBe('hard');
+  });
+
+  it('subtask scope: architecturalInstructions optional + minItems=0', () => {
+    const t = compose('subtask');
+    const ai = t.sections.get('architecturalInstructions')!;
+    expect(ai.effectiveRequired).toBe(false);
+    expect(ai.effectiveRubric.minItems).toBe(0);
+  });
+
+  it('module scope: architecture + architecturalInstructions required', () => {
+    const t = compose('module');
+    expect(t.sections.get('agentSections.architecture')!.effectiveRequired).toBe(true);
+    expect(t.sections.get('architecturalInstructions')!.effectiveRequired).toBe(true);
+  });
+
+  it('initiative scope: EA contract excluded entirely', () => {
+    const t = compose('initiative');
+    expect(t.sections.size).toBe(0);
+  });
+
+  it('epic scope: EA contract excluded entirely', () => {
+    const t = compose('epic');
+    expect(t.sections.size).toBe(0);
+  });
+
+  it('every section depends only on `scope`', () => {
+    for (const s of eaAgentContract.sections) {
+      if (s.dependencies) {
+        expect(s.dependencies).toEqual(['scope']);
+      }
+    }
+  });
+});
+
+describe('eaAgentContract — strict mode', () => {
+  it('composes every applicable scope without conflict (warnings allowed for missing PO scope)', () => {
+    const reg = new ContractRegistry();
+    reg.register(eaAgentContract);
+    for (const scope of ['module', 'story', 'task', 'subtask'] as const) {
+      const t = composeTemplate(scope, { registry: reg });
+      expect(t.sections.size).toBeGreaterThan(0);
+      // Warnings allowed — `scope` dependency unresolved without PO.
+    }
+  });
+});


### PR DESCRIPTION
## ACR-005 — EA Agent contract

Stacked on **#129 → #132 → #133 → #134**.

EA Agent declares its sections + per-scope rubrics. EA owns the technical layer of the ticket — `agentSections.architecture`, the `architecturalInstructions` array (stub pending ARCH-006), the BUCKET-001 taxonomy block (`techSubDomains`, `risk`, `effort`), and the BUCKET-009 `claims` block.

`appliesTo = ['module','story','task','subtask']` — initiative + epic are PO/BA strategic territory; EA enters at module.

### Sections owned

- **agentSections.architecture** — required + soft on module/story/task; optional on subtask. minWords=40, requiredEntityRefs match file paths, ADR refs, or @chiefaia/* packages.
- **architecturalInstructions** — STUB pending ARCH-006. `dataShape` is `z.array(z.unknown()).default([])`; rubric.minItems=1 + requiredEntityRefs match `arch_<entity>/<id>` AKG pattern.
- **taxonomy.techSubDomains** — HARD on module/story/task; warning on subtask. `primary` must appear in `all`.
- **claims** (files/schemas/apiRoutes/domains) — required on story/task; optional on module/subtask.
- **taxonomy.effort** — soft, forbiddenSnippets=['XL'] (split before BA done).
- **taxonomy.risk** — soft.

### Coordination with ARCH-### track

When **ARCH-006** lands the `architecturalInstructions` field on `TicketTemplateV1Schema`, this contract bumps to v1.1.0 — composed-template signature changes, Validator cache invalidates, AKG rubric kicks in. The `validator-loop.ts` already routes failures on `architecturalInstructions` to EA via `EA_OWNED_PREFIXES` (VAL-009).

### Tests — 15/15 jest pass

- registers; owner; appliesTo correct
- owns `agentSections.architecture` (BA does NOT)
- `architecturalInstructions` stub: minItems=1, AKG entity ref pattern
- owns techSubDomains, claims, effort, risk
- every section has fixHint + ≥1 example
- story scope: architecture + architecturalInstructions required + soft
- story scope: techSubDomains HARD required
- subtask scope: architecturalInstructions optional, minItems=0
- module scope: architecture + architecturalInstructions required
- initiative + epic: EA contract excluded
- every section depends only on `scope`
- strict-mode composes every applicable scope

Refs: ACR-005