### PR TITLE
feat(orchestrator): Test-Design SectionContract + 4-contract integration test (ACR-006)

### DIFF
--- a/apps/orchestrator/src/agents/test-design-agent.contract.ts
+++ b/apps/orchestrator/src/agents/test-design-agent.contract.ts
@@ -1,0 +1,169 @@
+/**
+ * Test-Design Agent — Section Contract (ACR-006)
+ *
+ * The Test-Design agent's declaration of which sections it populates
+ * after the Validator passes the ticket. Wraps the existing TEST-001
+ * `testCases` field on TicketTemplateV1; adds rubric so the Validator can
+ * gate on test-design completeness once ACR-007 swaps the rubric source.
+ *
+ * `testDesign` metadata (totalCases, categoryCounts, designedBy, designedAt)
+ * is also owned here — TEST-001 already validates internal consistency
+ * via the schema's superRefine.
+ */
+
+import { z } from 'zod';
+import {
+  TEST_CASE_CATEGORIES,
+  TEST_CASE_LAYERS,
+  TEST_CASE_STATUSES,
+  type SectionContract,
+  type SectionSpec,
+} from '@chiefaia/ticket-template';
+
+// ─── Section data shapes (mirror TEST-001) ──────────────────────────────────
+
+const TestCaseSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    category: z.enum(TEST_CASE_CATEGORIES),
+    layer: z.enum(TEST_CASE_LAYERS),
+    given: z.string().min(1),
+    when: z.string().min(1),
+    then: z.string().min(1),
+    linkedAcceptanceCriterionIndex: z.number().int().min(0).optional(),
+    selectorHints: z.array(z.string()).default([]),
+    mocks: z
+      .array(
+        z
+          .object({
+            method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+            url: z.string().min(1),
+            status: z.number().int().min(100).max(599).default(200),
+            body: z.string().default(''),
+          })
+          .strict(),
+      )
+      .default([]),
+    required: z.boolean().default(true),
+    status: z.enum(TEST_CASE_STATUSES).default('pending'),
+    designedBy: z.string().min(1),
+    designedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const TestCasesSchema = z.array(TestCaseSchema);
+
+const TestDesignSchema = z
+  .object({
+    designedBy: z.string().min(1),
+    designedAt: z.number().int().nonnegative(),
+    totalCases: z.number().int().nonnegative(),
+    categoryCounts: z
+      .object({
+        happy: z.number().int().nonnegative().default(0),
+        edge: z.number().int().nonnegative().default(0),
+        error: z.number().int().nonnegative().default(0),
+        accessibility: z.number().int().nonnegative().default(0),
+        security: z.number().int().nonnegative().default(0),
+        performance: z.number().int().nonnegative().default(0),
+        visual: z.number().int().nonnegative().default(0),
+      })
+      .strict(),
+    notes: z.string().default(''),
+  })
+  .strict();
+
+// ─── Section specs ──────────────────────────────────────────────────────────
+
+const testCasesSpec: SectionSpec = {
+  name: 'testCases',
+  description:
+    'Story-driven test cases — each acceptance criterion becomes >=1 executable assertion.',
+  purpose:
+    'Test Runner Agent translates each test case into Playwright/vitest source. Required cases gate the story → done transition.',
+  dataShape: TestCasesSchema,
+  required: true,
+  dependencies: ['acceptanceCriteria'],
+  rubric: {
+    minItems: 3,
+    severityOnFail: 'hard',
+    fixHint:
+      'Each acceptance criterion must be covered by >=1 test case. Categories: happy/edge/error are required; a11y/security/perf/visual when story tags warrant.',
+  },
+  examples: [
+    {
+      good: [
+        {
+          id: 'TC-001',
+          title: 'Happy: subscriber upgrades plan via Stripe Checkout',
+          category: 'happy',
+          layer: 'e2e',
+          given: 'an authenticated subscriber on the billing page',
+          when: 'they click Upgrade and complete Stripe Checkout',
+          then: 'their plan is updated and a confirmation email is queued',
+          designedBy: 'test-design-agent',
+          designedAt: 1730000000000,
+          required: true,
+          status: 'pending',
+          selectorHints: ['[data-test=upgrade-btn]'],
+          mocks: [],
+        },
+      ],
+      bad: [],
+      badRationale: 'Empty array means no AC is gated — story can ship untested.',
+    },
+  ],
+  scopeOverrides: {
+    task: { minItems: 1, severityOnFail: 'soft' },
+  },
+};
+
+const testDesignSpec: SectionSpec = {
+  name: 'testDesign',
+  description: 'Test-design metadata — totalCases, categoryCounts, designedBy, designedAt.',
+  purpose:
+    'Dashboard summary tiles + DoD-gating use this. TEST-001 schema enforces totalCases == testCases.length and categoryCounts == actual.',
+  dataShape: TestDesignSchema,
+  required: true,
+  dependencies: ['testCases'],
+  rubric: {
+    severityOnFail: 'soft',
+    fixHint:
+      'When testCases is non-empty, testDesign must be present. totalCases must equal testCases.length and categoryCounts must match the actual breakdown.',
+  },
+  examples: [
+    {
+      good: {
+        designedBy: 'test-design-agent',
+        designedAt: 1730000000000,
+        totalCases: 3,
+        categoryCounts: {
+          happy: 1,
+          edge: 1,
+          error: 1,
+          accessibility: 0,
+          security: 0,
+          performance: 0,
+          visual: 0,
+        },
+        notes: '',
+      },
+      bad: { designedBy: '', designedAt: 0, totalCases: 0, categoryCounts: {} },
+      badRationale: 'Empty designer + zero counts conflict with non-empty testCases.',
+    },
+  ],
+  scopeOverrides: {
+    task: { required: false },
+  },
+};
+
+// ─── Contract export ────────────────────────────────────────────────────────
+
+export const testDesignAgentContract: SectionContract = {
+  ownerAgent: 'test-design',
+  contractId: 'test-design-agent.v1',
+  version: '1.0.0',
+  appliesTo: ['story', 'task'],
+  sections: [testCasesSpec, testDesignSpec],
+};

--- a/apps/orchestrator/tests/agents/all-contracts-composition.test.ts
+++ b/apps/orchestrator/tests/agents/all-contracts-composition.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration test — every PO/BA/EA/Test-Design contract registered
+ * together composes cleanly across every canonical scope (ACR-006).
+ *
+ * This proves the cross-contract behaviour the architecture report
+ * promised: per-scope union of sections, no conflicts under strict mode,
+ * dependencies resolved when contracts are co-registered, signatures
+ * stable + scope-distinct.
+ */
+
+import { ContractRegistry, composeTemplate, composeAllScopes } from '@chiefaia/agent-contract-registry';
+import { STORY_SCOPES } from '@chiefaia/ticket-template';
+import { poAgentContract } from '../../src/agents/po-agent.contract';
+import { baAgentContract } from '../../src/agents/ba-agent.contract';
+import { eaAgentContract } from '../../src/agents/ea-agent.contract';
+import { testDesignAgentContract } from '../../src/agents/test-design-agent.contract';
+
+function buildFullRegistry(): ContractRegistry {
+  const reg = new ContractRegistry();
+  reg.register(poAgentContract);
+  reg.register(baAgentContract);
+  reg.register(eaAgentContract);
+  reg.register(testDesignAgentContract);
+  return reg;
+}
+
+describe('all 4 contracts — integration', () => {
+  it('every canonical scope composes without throwing', () => {
+    const reg = buildFullRegistry();
+    for (const scope of STORY_SCOPES) {
+      expect(() => composeTemplate(scope, { registry: reg })).not.toThrow();
+    }
+  });
+
+  it('every canonical scope composes WITHOUT warnings (no unresolved deps, no conflicts)', () => {
+    const reg = buildFullRegistry();
+    for (const scope of STORY_SCOPES) {
+      const t = composeTemplate(scope, { registry: reg });
+      expect(t.warnings).toEqual([]);
+    }
+  });
+
+  it('strict mode passes on every canonical scope', () => {
+    const reg = buildFullRegistry();
+    for (const scope of STORY_SCOPES) {
+      expect(() => composeTemplate(scope, { registry: reg, strict: true })).not.toThrow();
+    }
+  });
+
+  it('story scope has the union of all 4 contracts', () => {
+    const reg = buildFullRegistry();
+    const t = composeTemplate('story', { registry: reg });
+    // Sample sections from each agent.
+    expect(t.sections.has('scope')).toBe(true);                              // PO
+    expect(t.sections.has('taxonomy.lifecycle')).toBe(true);                  // PO
+    expect(t.sections.has('acceptanceCriteria')).toBe(true);                  // BA
+    expect(t.sections.has('agentSections.api')).toBe(true);                   // BA
+    expect(t.sections.has('agentSections.architecture')).toBe(true);          // EA
+    expect(t.sections.has('architecturalInstructions')).toBe(true);           // EA
+    expect(t.sections.has('claims')).toBe(true);                              // EA
+    expect(t.sections.has('testCases')).toBe(true);                           // Test-Design
+    expect(t.sections.has('testDesign')).toBe(true);                          // Test-Design
+  });
+
+  it('initiative scope is purely PO (BA/EA/Test-Design excluded)', () => {
+    const reg = buildFullRegistry();
+    const t = composeTemplate('initiative', { registry: reg });
+    const owners = new Set(
+      [...t.sections.values()].map((e) => e.ownerAgent),
+    );
+    expect(owners).toEqual(new Set(['po']));
+  });
+
+  it('subtask scope contributors: PO + EA only (BA + Test-Design excluded)', () => {
+    const reg = buildFullRegistry();
+    const t = composeTemplate('subtask', { registry: reg });
+    const owners = new Set([...t.sections.values()].map((e) => e.ownerAgent));
+    expect(owners).toContain('po');
+    expect(owners).toContain('ea');
+    expect(owners).not.toContain('ba');
+    expect(owners).not.toContain('test-design');
+  });
+
+  it('section ownership: agentSections.architecture -> EA, agentSections.api -> BA', () => {
+    const reg = buildFullRegistry();
+    const t = composeTemplate('story', { registry: reg });
+    expect(t.sections.get('agentSections.architecture')!.ownerAgent).toBe('ea');
+    expect(t.sections.get('agentSections.api')!.ownerAgent).toBe('ba');
+  });
+
+  it('signatures differ across all 6 scopes', () => {
+    const reg = buildFullRegistry();
+    const sigs = new Set(STORY_SCOPES.map((s) => composeTemplate(s, { registry: reg }).signature));
+    expect(sigs.size).toBe(6);
+  });
+
+  it('composeAllScopes returns a per-scope template; story has the largest section count', () => {
+    const reg = buildFullRegistry();
+    const all = composeAllScopes({ registry: reg });
+    expect(Object.keys(all).sort()).toEqual([...STORY_SCOPES].sort());
+    // Story scope is the canonical "everyone contributes" scope.
+    const sizes = Object.fromEntries(
+      Object.entries(all).map(([k, v]) => [k, v.sections.size]),
+    );
+    expect(sizes.story).toBeGreaterThan(sizes.initiative);
+    expect(sizes.story).toBeGreaterThan(sizes.subtask);
+  });
+
+  it('composition is deterministic across runs', () => {
+    const a = composeTemplate('story', { registry: buildFullRegistry() });
+    const b = composeTemplate('story', { registry: buildFullRegistry() });
+    expect(a.signature).toBe(b.signature);
+  });
+});

--- a/apps/orchestrator/tests/agents/test-design-agent.contract.test.ts
+++ b/apps/orchestrator/tests/agents/test-design-agent.contract.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Test-Design Agent contract — composition + per-scope behaviour tests
+ * (ACR-006).
+ */
+
+import { ContractRegistry, composeTemplate } from '@chiefaia/agent-contract-registry';
+import type { StoryScope } from '@chiefaia/ticket-template';
+import { testDesignAgentContract } from '../../src/agents/test-design-agent.contract';
+
+describe('testDesignAgentContract — registration', () => {
+  it('registers without throwing', () => {
+    const reg = new ContractRegistry();
+    expect(() => reg.register(testDesignAgentContract)).not.toThrow();
+  });
+
+  it('owner is test-design', () => {
+    expect(testDesignAgentContract.ownerAgent).toBe('test-design');
+  });
+
+  it('appliesTo only story + task', () => {
+    expect(testDesignAgentContract.appliesTo).toEqual(['story', 'task']);
+  });
+
+  it('owns testCases + testDesign', () => {
+    const names = testDesignAgentContract.sections.map((s) => s.name);
+    expect(names.sort()).toEqual(['testCases', 'testDesign']);
+  });
+
+  it('testCases depends on acceptanceCriteria', () => {
+    const tc = testDesignAgentContract.sections.find((s) => s.name === 'testCases')!;
+    expect(tc.dependencies).toEqual(['acceptanceCriteria']);
+  });
+
+  it('testDesign depends on testCases', () => {
+    const td = testDesignAgentContract.sections.find((s) => s.name === 'testDesign')!;
+    expect(td.dependencies).toEqual(['testCases']);
+  });
+
+  it('every section has fixHint + >=1 example', () => {
+    for (const s of testDesignAgentContract.sections) {
+      expect(s.rubric.fixHint.length).toBeGreaterThan(0);
+      expect(s.examples.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('testDesignAgentContract — composition', () => {
+  let reg: ContractRegistry;
+  beforeEach(() => {
+    reg = new ContractRegistry();
+    reg.register(testDesignAgentContract);
+  });
+
+  function compose(scope: StoryScope) {
+    return composeTemplate(scope, { registry: reg });
+  }
+
+  it('story scope: testCases hard + minItems=3', () => {
+    const t = compose('story');
+    const tc = t.sections.get('testCases')!;
+    expect(tc.effectiveRequired).toBe(true);
+    expect(tc.effectiveRubric.severityOnFail).toBe('hard');
+    expect(tc.effectiveRubric.minItems).toBe(3);
+  });
+
+  it('task scope: testCases relaxed (minItems=1, soft)', () => {
+    const t = compose('task');
+    const tc = t.sections.get('testCases')!;
+    expect(tc.effectiveRubric.minItems).toBe(1);
+    expect(tc.effectiveRubric.severityOnFail).toBe('soft');
+  });
+
+  it('story scope: testDesign required + soft', () => {
+    const t = compose('story');
+    const td = t.sections.get('testDesign')!;
+    expect(td.effectiveRequired).toBe(true);
+    expect(td.effectiveRubric.severityOnFail).toBe('soft');
+  });
+
+  it('task scope: testDesign optional', () => {
+    const t = compose('task');
+    const td = t.sections.get('testDesign')!;
+    expect(td.effectiveRequired).toBe(false);
+  });
+
+  it('non-story-non-task scopes get nothing from this contract', () => {
+    for (const scope of ['initiative', 'epic', 'module', 'subtask'] as const) {
+      const t = compose(scope);
+      expect(t.sections.size).toBe(0);
+    }
+  });
+
+  it('warnings: testCases dep on acceptanceCriteria + testDesign dep on testCases', () => {
+    // With only test-design contract registered, testCases.dependencies
+    // (=> acceptanceCriteria) is unresolved — expect a warning. testDesign
+    // depends on testCases which IS in the same composed template, so no
+    // warning for that one.
+    const t = compose('story');
+    const acWarn = t.warnings.find((w) => w.includes("'acceptanceCriteria'"));
+    expect(acWarn).toBeDefined();
+    const tdWarn = t.warnings.find((w) => w.includes("'testDesign'") && w.includes("'testCases'"));
+    expect(tdWarn).toBeUndefined();
+  });
+});
+
+describe('testDesignAgentContract — strict mode', () => {
+  it('strict mode throws on unresolved acceptanceCriteria dep', () => {
+    const reg = new ContractRegistry();
+    reg.register(testDesignAgentContract);
+    expect(() => composeTemplate('story', { registry: reg, strict: true })).toThrow(
+      /'acceptanceCriteria'/,
+    );
+  });
+});


### PR DESCRIPTION
## ACR-006 — Test-Design Agent contract + integration test

Stacked on **#129 → #132 → #133 → #134 → #135**.

Wraps the existing TEST-001 `testCases` field with a SectionContract; adds an integration test proving all 4 contracts (PO/BA/EA/Test-Design) compose cleanly across every canonical scope without warnings or conflicts.

### Sections owned

- **testCases** — hard, minItems=3 on story; soft, minItems=1 on task. `dependencies=['acceptanceCriteria']`.
- **testDesign** — soft, required on story (depends on testCases). Wraps existing TEST-001 metadata field.

`appliesTo = ['story','task']` only.

### Tests — 24/24 jest pass

**Per-contract** (`test-design-agent.contract.test.ts` — 14):
- registers; owner; appliesTo; section list
- testCases depends on acceptanceCriteria; testDesign depends on testCases
- story: testCases hard + minItems=3; task: relaxed
- story: testDesign required + soft; task: optional
- non-story-non-task scopes: empty contribution
- isolated-contract warnings + strict-mode throws on unresolved AC dep

**Integration** (`all-contracts-composition.test.ts` — 10):
- every canonical scope composes without throwing
- every canonical scope composes WITHOUT warnings
- strict mode passes on every scope (CI gate)
- story scope union has scope/lifecycle/AC/architecture/architecturalInstructions/claims/testCases/testDesign
- initiative scope: only PO contributes
- subtask scope: PO + EA only
- ownership: agentSections.architecture → EA, agentSections.api → BA
- signatures differ across all 6 scopes
- composeAllScopes returns per-scope templates; story has largest count
- composition is deterministic across runs

### What ACR-001..006 buys you

The full registry composes cleanly. The composition signature is deterministic. Per-scope behaviour is correct: initiatives stay PO-only, stories pull in everyone, subtasks skip BA + Test-Design. Adding a new agent now means adding one `*.contract.ts` file — no Validator change.

### Next

- ACR-008 — backfill migration (parallel; doesn't touch Validator).
- ACR-007 — Validator refactor to consume `composeTemplate(scope)` (gated on VAL-004/005/009 merging).
- ACR-009 — dashboard `/contracts` page.
- ACR-010 — E2E test (multi-scope).
- ACR-011 — documentation.

Refs: ACR-006