### PR TITLE
feat(orchestrator): backfill-story-scope script + inferScope (ACR-008)

### DIFF
--- a/apps/orchestrator/scripts/backfill-story-scope.ts
+++ b/apps/orchestrator/scripts/backfill-story-scope.ts
@@ -1,0 +1,175 @@
+/**
+ * ACR-008 — Backfill `story_scope` on every existing story.
+ *
+ * Migration 0030 (ACR-001) added `story_scope text NOT NULL DEFAULT 'story'`
+ * — SQLite's ALTER TABLE applies the default to existing rows, so the
+ * structural backfill is "free" at migration time. This script is the
+ * **smart-inference** companion: re-classifies stories whose hierarchy
+ * shape suggests something other than the default `'story'` scope.
+ *
+ * Inference rules (best-effort; fall back to 'story'):
+ *
+ *   - parentEntityType = null + zero parentEpic + scope.summary >= 80 words
+ *     + no agentSections → 'initiative'
+ *
+ *   - parentEntityType = 'requirement' AND has children → 'epic'
+ *
+ *   - kind = 'epic' (legacy column) → 'epic'
+ *
+ *   - parentEntityType = 'story' AND zero acceptance criteria → 'task'
+ *
+ *   - kind = 'sub_task' or 'todo' → 'subtask'
+ *
+ *   - default → 'story'
+ *
+ * Idempotency: only updates rows where the inferred scope is *different*
+ * from the current value. Re-running is a no-op once converged.
+ *
+ * Usage:
+ *   pnpm --filter @caia-app/core exec tsx scripts/backfill-story-scope.ts
+ *
+ * Programmatic:
+ *   import { runBackfillStoryScope } from './scripts/backfill-story-scope';
+ *   const result = runBackfillStoryScope(db);
+ */
+
+import { eq } from 'drizzle-orm';
+import { DEFAULT_STORY_SCOPE, type StoryScope } from '@chiefaia/ticket-template';
+import type { Db } from '../src/db/connection';
+import { stories } from '../src/db/schema';
+
+export interface ScopeBackfillResult {
+  scanned: number;
+  reassigned: number;
+  unchanged: number;
+  perScope: Record<StoryScope, number>;
+}
+
+interface StoryRow {
+  id: string;
+  kind: string;
+  storyScope: string;
+  parentEntityType: string | null;
+  parentId: string | null;
+  acceptanceCriteriaJson: string;
+  description: string;
+  agentContributionsJson: string;
+}
+
+function countWords(s: string | null | undefined): number {
+  if (!s) return 0;
+  const t = s.trim();
+  if (t === '') return 0;
+  return t.split(/\s+/).length;
+}
+
+function isEmptyJson(s: string | null | undefined, kind: 'array' | 'object'): boolean {
+  if (!s) return true;
+  try {
+    const parsed = JSON.parse(s);
+    if (kind === 'array') return Array.isArray(parsed) && parsed.length === 0;
+    return typeof parsed === 'object' && parsed !== null && Object.keys(parsed).length === 0;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Pure inference function — exported for unit testing without a DB.
+ */
+export function inferScope(row: StoryRow, hasChildren: boolean): StoryScope {
+  // Legacy `kind` column wins on explicit shape.
+  if (row.kind === 'epic') return 'epic';
+  if (row.kind === 'sub_task' || row.kind === 'todo') return 'subtask';
+
+  // Initiative heuristic — no parent, big scope, no implementation detail.
+  if (
+    row.parentEntityType === null &&
+    countWords(row.description) >= 80 &&
+    isEmptyJson(row.agentContributionsJson, 'object')
+  ) {
+    return 'initiative';
+  }
+
+  // Epic heuristic — under a requirement, with children of its own.
+  if (row.parentEntityType === 'requirement' && hasChildren) return 'epic';
+
+  // Task heuristic — under a story, no AC of its own.
+  if (row.parentEntityType === 'story' && isEmptyJson(row.acceptanceCriteriaJson, 'array')) {
+    return 'task';
+  }
+
+  return DEFAULT_STORY_SCOPE;
+}
+
+/**
+ * Run the backfill. Returns counts; emits one
+ * `story.scope_backfilled` event per reassignment for traceability.
+ */
+export function runBackfillStoryScope(db: Db): ScopeBackfillResult {
+  const all = db
+    .select({
+      id: stories.id,
+      kind: stories.kind,
+      storyScope: stories.storyScope,
+      parentEntityType: stories.parentEntityType,
+      parentId: stories.parentId,
+      acceptanceCriteriaJson: stories.acceptanceCriteriaJson,
+      description: stories.description,
+      agentContributionsJson: stories.agentContributionsJson,
+    })
+    .from(stories)
+    .all();
+
+  // Build a child-presence index (one O(N) pass).
+  const parentIds = new Set<string>();
+  for (const r of all) {
+    if (r.parentId) parentIds.add(r.parentId);
+  }
+
+  const perScope: Record<StoryScope, number> = {
+    initiative: 0,
+    epic: 0,
+    module: 0,
+    story: 0,
+    task: 0,
+    subtask: 0,
+  };
+  let reassigned = 0;
+  let unchanged = 0;
+
+  for (const row of all) {
+    const inferred = inferScope(row as StoryRow, parentIds.has(row.id));
+    perScope[inferred] += 1;
+    if (inferred === row.storyScope) {
+      unchanged += 1;
+      continue;
+    }
+    db.update(stories)
+      .set({ storyScope: inferred })
+      .where(eq(stories.id, row.id))
+      .run();
+    reassigned += 1;
+    // Note: emitting a 'story.scope_backfilled' event would require
+    // adding it to events-taxonomy-internal + extending EventActor.
+    // Skipped for ACR-008 (one-time backfill); add when needed for
+    // observability dashboards.
+  }
+
+  return {
+    scanned: all.length,
+    reassigned,
+    unchanged,
+    perScope,
+  };
+}
+
+// CLI entry — only when invoked directly.
+if (require.main === module) {
+  // Lazy import to avoid forcing a Db instance at module-load time.
+  import('../src/db/connection').then(({ getDb }) => {
+    const db = getDb();
+    const result = runBackfillStoryScope(db);
+    console.log(JSON.stringify(result, null, 2));
+  });
+}

--- a/apps/orchestrator/tests/scripts/backfill-story-scope.test.ts
+++ b/apps/orchestrator/tests/scripts/backfill-story-scope.test.ts
@@ -1,0 +1,139 @@
+/**
+ * ACR-008 — backfill-story-scope tests.
+ *
+ * The pure `inferScope()` function is exhaustively unit-tested for every
+ * inference branch. We mock the DB row shape because the real DB-driven
+ * end-to-end behaviour is exercised by ACR-010's E2E test.
+ */
+
+import { inferScope } from '../../scripts/backfill-story-scope';
+
+interface PartialRow {
+  id?: string;
+  kind?: string;
+  storyScope?: string;
+  parentEntityType?: string | null;
+  parentId?: string | null;
+  acceptanceCriteriaJson?: string;
+  description?: string;
+  agentContributionsJson?: string;
+}
+
+function row(overrides: PartialRow = {}) {
+  return {
+    id: 'st_x',
+    kind: 'story',
+    storyScope: 'story',
+    parentEntityType: null,
+    parentId: null,
+    acceptanceCriteriaJson: '[]',
+    description: '',
+    agentContributionsJson: '{}',
+    ...overrides,
+  };
+}
+
+describe('inferScope — explicit kind column wins', () => {
+  it("kind='epic' -> epic", () => {
+    expect(inferScope(row({ kind: 'epic' }), false)).toBe('epic');
+  });
+
+  it("kind='sub_task' -> subtask", () => {
+    expect(inferScope(row({ kind: 'sub_task' }), false)).toBe('subtask');
+  });
+
+  it("kind='todo' -> subtask", () => {
+    expect(inferScope(row({ kind: 'todo' }), false)).toBe('subtask');
+  });
+});
+
+describe('inferScope — initiative heuristic', () => {
+  const longDesc = Array(90).fill('word').join(' ');
+
+  it('parent=null + long description + empty agentSections -> initiative', () => {
+    expect(
+      inferScope(
+        row({ parentEntityType: null, description: longDesc, agentContributionsJson: '{}' }),
+        false,
+      ),
+    ).toBe('initiative');
+  });
+
+  it('parent=null + short description -> NOT initiative', () => {
+    expect(inferScope(row({ description: 'too short' }), false)).not.toBe('initiative');
+  });
+
+  it('parent=null + long description + populated agentSections -> NOT initiative', () => {
+    expect(
+      inferScope(
+        row({
+          description: longDesc,
+          agentContributionsJson: '{"architecture":{"notes":"x"}}',
+        }),
+        false,
+      ),
+    ).not.toBe('initiative');
+  });
+});
+
+describe('inferScope — epic heuristic', () => {
+  it("parentEntityType='requirement' + has children -> epic", () => {
+    expect(inferScope(row({ parentEntityType: 'requirement' }), true)).toBe('epic');
+  });
+
+  it("parentEntityType='requirement' + no children -> falls back", () => {
+    // Falls through to story (default).
+    expect(inferScope(row({ parentEntityType: 'requirement' }), false)).toBe('story');
+  });
+});
+
+describe('inferScope — task heuristic', () => {
+  it("parentEntityType='story' + zero AC -> task", () => {
+    expect(
+      inferScope(row({ parentEntityType: 'story', acceptanceCriteriaJson: '[]' }), false),
+    ).toBe('task');
+  });
+
+  it("parentEntityType='story' + non-empty AC -> NOT task (defaults to story)", () => {
+    expect(
+      inferScope(
+        row({
+          parentEntityType: 'story',
+          acceptanceCriteriaJson: '["AC1","AC2","AC3"]',
+        }),
+        false,
+      ),
+    ).toBe('story');
+  });
+});
+
+describe('inferScope — default + edge cases', () => {
+  it('returns story when no rule matches', () => {
+    expect(inferScope(row(), false)).toBe('story');
+  });
+
+  it('handles malformed JSON gracefully (treats as empty)', () => {
+    expect(
+      inferScope(
+        row({ parentEntityType: 'story', acceptanceCriteriaJson: 'not-json' }),
+        false,
+      ),
+    ).toBe('task');
+  });
+
+  it('explicit kind=epic beats parent=story heuristic', () => {
+    expect(
+      inferScope(
+        row({ kind: 'epic', parentEntityType: 'story' }),
+        false,
+      ),
+    ).toBe('epic');
+  });
+
+  it('explicit kind=todo beats long-description initiative heuristic', () => {
+    const longDesc = Array(90).fill('word').join(' ');
+    expect(
+      inferScope(row({ kind: 'todo', description: longDesc }), false),
+    ).toBe('subtask');
+  });
+});


### PR DESCRIPTION
## ACR-008 — Smart-inference backfill for legacy stories

Stacked on **#129..#136**.

Migration 0030 (ACR-001) already gives every legacy row `story_scope='story'` via SQLite `DEFAULT`. This script is the smart-inference companion that re-classifies stories whose hierarchy shape suggests something other than the default.

### Inference rules

| Pattern | Inferred scope |
|---|---|
| `kind='epic'` (legacy column) | epic |
| `kind in ('sub_task','todo')` | subtask |
| `parentEntityType=null` + description ≥ 80 words + empty agentSections | initiative |
| `parentEntityType='requirement'` + has children | epic |
| `parentEntityType='story'` + zero AC | task |
| default | story |

Idempotent: only updates rows where inferred ≠ current. Re-running converges in one pass.

### Tests — 14/14 jest pass

Pure `inferScope(row, hasChildren)` is exhaustively tested:
- explicit kind: epic / sub_task / todo
- initiative heuristic: yes/no/no
- epic heuristic: yes/falls-back
- task heuristic: yes/no
- default + edge cases: malformed JSON, kind beats parent

### Usage

```bash
pnpm --filter @caia-app/core exec tsx scripts/backfill-story-scope.ts
```

Programmatic:
```typescript
import { runBackfillStoryScope } from './scripts/backfill-story-scope';
const { scanned, reassigned, perScope } = runBackfillStoryScope(db);
```

### Note on events

Did not emit `story.scope_backfilled` events because that would require adding the type + actor to `@chiefaia/events-taxonomy-internal`. Backfill is a one-time op; observability dashboards can read the rows directly. Add event later if needed.

Refs: ACR-008