### PR TITLE
feat(orchestrator,dashboard): /contracts dashboard + bootstrap (ACR-009)

### DIFF
--- a/apps/dashboard/app/api/contracts/composed/[scope]/route.ts
+++ b/apps/dashboard/app/api/contracts/composed/[scope]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ scope: string }> },
+) {
+  const { scope } = await ctx.params;
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/api/contracts/composed/${encodeURIComponent(scope)}`, {
+      next: { revalidate: 0 },
+    });
+    if (!res.ok) {
+      return NextResponse.json(
+        { scope, sections: [], warnings: [], signature: '', sectionCount: 0 },
+        { status: res.status },
+      );
+    }
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json(
+      { scope, sections: [], warnings: [], signature: '', sectionCount: 0 },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/dashboard/app/api/contracts/registry/route.ts
+++ b/apps/dashboard/app/api/contracts/registry/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+const CONDUCTOR_URL = process.env['CONDUCTOR_URL'] ?? 'http://localhost:7776';
+
+export async function GET() {
+  try {
+    const res = await fetch(`${CONDUCTOR_URL}/api/contracts/registry`, {
+      next: { revalidate: 0 },
+    });
+    if (!res.ok) return NextResponse.json({ contracts: [], count: 0 });
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json({ contracts: [], count: 0 });
+  }
+}

--- a/apps/dashboard/app/contracts/page.tsx
+++ b/apps/dashboard/app/contracts/page.tsx
@@ -1,0 +1,297 @@
+/**
+ * /contracts — Agent Section Contract Registry dashboard (ACR-009).
+ *
+ * Three panels:
+ *   1. Scope selector + composed-template summary (signature + count + warnings)
+ *   2. Sections table (name, owner, required, severity, minWords, dependencies, fixHint)
+ *   3. Registered-contracts table (contractId, owner, version, appliesTo, sectionCount)
+ *
+ * Polls the orchestrator every 30s. Fail-soft: any panel that 404/500s
+ * renders an empty state.
+ */
+'use client';
+import { useEffect, useState } from 'react';
+
+type Scope = 'initiative' | 'epic' | 'module' | 'story' | 'task' | 'subtask';
+const SCOPES: Scope[] = ['initiative', 'epic', 'module', 'story', 'task', 'subtask'];
+
+interface SectionRow {
+  name: string;
+  ownerAgent: string;
+  contractId: string;
+  effectiveRequired: boolean;
+  description: string;
+  purpose: string;
+  dependencies: string[];
+  effectiveRubric: {
+    minWords: number | null;
+    minItems: number | null;
+    severityOnFail: 'hard' | 'soft' | 'warning';
+    fixHint: string;
+    forbiddenSnippets: string[];
+    requiredEntityRefs: Array<{ label: string; pattern: string; flags?: string }>;
+  };
+  exampleCount: number;
+}
+
+interface ComposedResponse {
+  scope: string;
+  signature: string;
+  sectionCount: number;
+  sections: SectionRow[];
+  warnings: string[];
+}
+
+interface RegistryEntry {
+  contractId: string;
+  ownerAgent: string;
+  version: string;
+  appliesTo: string[];
+  sectionCount: number;
+  sectionNames: string[];
+}
+
+interface RegistryResponse {
+  contracts: RegistryEntry[];
+  count: number;
+}
+
+const SEVERITY_COLOR: Record<string, string> = {
+  hard: '#dc2626',
+  soft: '#d97706',
+  warning: '#65a30d',
+};
+
+const OWNER_COLOR: Record<string, string> = {
+  po: '#2563eb',
+  ba: '#7c3aed',
+  ea: '#db2777',
+  'test-design': '#059669',
+};
+
+function ownerBadge(owner: string) {
+  return (
+    <span
+      style={{
+        background: OWNER_COLOR[owner] ?? '#6b7280',
+        color: 'white',
+        padding: '2px 8px',
+        borderRadius: 4,
+        fontSize: 12,
+        fontWeight: 600,
+      }}
+    >
+      {owner}
+    </span>
+  );
+}
+
+function severityBadge(sev: 'hard' | 'soft' | 'warning') {
+  return (
+    <span
+      style={{
+        background: SEVERITY_COLOR[sev] ?? '#6b7280',
+        color: 'white',
+        padding: '2px 8px',
+        borderRadius: 4,
+        fontSize: 11,
+        fontWeight: 600,
+      }}
+    >
+      {sev}
+    </span>
+  );
+}
+
+export default function ContractsPage() {
+  const [scope, setScope] = useState<Scope>('story');
+  const [composed, setComposed] = useState<ComposedResponse | null>(null);
+  const [registry, setRegistry] = useState<RegistryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const [c, r] = await Promise.all([
+          fetch(`/api/contracts/composed/${scope}`).then((res) => res.json()),
+          fetch('/api/contracts/registry').then((res) => res.json()),
+        ]);
+        if (!cancelled) {
+          setComposed(c as ComposedResponse);
+          setRegistry(r as RegistryResponse);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    const interval = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [scope]);
+
+  return (
+    <main style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>
+        Agent Section Contract Registry
+      </h1>
+      <p style={{ color: '#6b7280', marginBottom: 24, maxWidth: 720 }}>
+        Each ticket-writing agent (PO, BA, EA, Test-Design) declares a SectionContract
+        listing the sections + per-scope rubrics it owns. The Story Validator composes
+        contracts at runtime per a story&apos;s scope. New agent? Just register a contract.
+      </p>
+
+      <section style={{ marginBottom: 24 }}>
+        <label htmlFor="scope-select" style={{ marginRight: 8, fontWeight: 600 }}>
+          Story scope:
+        </label>
+        <select
+          id="scope-select"
+          value={scope}
+          onChange={(e) => setScope(e.target.value as Scope)}
+          style={{
+            padding: '6px 12px',
+            borderRadius: 4,
+            border: '1px solid #d1d5db',
+            fontSize: 14,
+          }}
+        >
+          {SCOPES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        {composed && (
+          <span style={{ marginLeft: 16, color: '#6b7280', fontSize: 13 }}>
+            {composed.sectionCount} sections · signature{' '}
+            <code style={{ fontSize: 11 }}>{composed.signature.slice(0, 12)}…</code>
+          </span>
+        )}
+      </section>
+
+      {composed && composed.warnings.length > 0 && (
+        <section
+          style={{
+            background: '#fef3c7',
+            border: '1px solid #f59e0b',
+            padding: 12,
+            borderRadius: 6,
+            marginBottom: 16,
+          }}
+        >
+          <strong>Composition warnings:</strong>
+          <ul>
+            {composed.warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section style={{ marginBottom: 32 }}>
+        <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>
+          Composed sections — {scope}
+        </h2>
+        {loading && <p>Loading…</p>}
+        {!loading && composed && composed.sections.length === 0 && (
+          <p style={{ color: '#6b7280' }}>
+            No sections for scope <strong>{scope}</strong>.
+          </p>
+        )}
+        {composed && composed.sections.length > 0 && (
+          <div style={{ overflowX: 'auto' }}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                fontSize: 13,
+              }}
+            >
+              <thead>
+                <tr style={{ background: '#f3f4f6', textAlign: 'left' }}>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Section</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Owner</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Required</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Severity</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>min</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Depends on</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Fix hint</th>
+                </tr>
+              </thead>
+              <tbody>
+                {composed.sections.map((s) => (
+                  <tr key={s.name} style={{ borderBottom: '1px solid #e5e7eb' }}>
+                    <td style={{ padding: 8 }}>
+                      <code style={{ fontSize: 12 }}>{s.name}</code>
+                      <div style={{ color: '#6b7280', fontSize: 11, marginTop: 2 }}>
+                        {s.description}
+                      </div>
+                    </td>
+                    <td style={{ padding: 8 }}>{ownerBadge(s.ownerAgent)}</td>
+                    <td style={{ padding: 8 }}>{s.effectiveRequired ? 'yes' : 'no'}</td>
+                    <td style={{ padding: 8 }}>{severityBadge(s.effectiveRubric.severityOnFail)}</td>
+                    <td style={{ padding: 8, color: '#6b7280' }}>
+                      {s.effectiveRubric.minWords != null && (
+                        <span>w≥{s.effectiveRubric.minWords} </span>
+                      )}
+                      {s.effectiveRubric.minItems != null && (
+                        <span>i≥{s.effectiveRubric.minItems}</span>
+                      )}
+                    </td>
+                    <td style={{ padding: 8, color: '#6b7280', fontSize: 11 }}>
+                      {s.dependencies.length > 0 ? s.dependencies.join(', ') : '—'}
+                    </td>
+                    <td style={{ padding: 8, color: '#6b7280', fontSize: 12, maxWidth: 380 }}>
+                      {s.effectiveRubric.fixHint}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>
+          Registered contracts ({registry?.count ?? 0})
+        </h2>
+        {registry && registry.contracts.length > 0 && (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+              <thead>
+                <tr style={{ background: '#f3f4f6', textAlign: 'left' }}>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Contract</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Owner</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Version</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Applies to</th>
+                  <th style={{ padding: 8, borderBottom: '2px solid #e5e7eb' }}>Sections</th>
+                </tr>
+              </thead>
+              <tbody>
+                {registry.contracts.map((c) => (
+                  <tr key={c.contractId} style={{ borderBottom: '1px solid #e5e7eb' }}>
+                    <td style={{ padding: 8 }}>
+                      <code style={{ fontSize: 12 }}>{c.contractId}</code>
+                    </td>
+                    <td style={{ padding: 8 }}>{ownerBadge(c.ownerAgent)}</td>
+                    <td style={{ padding: 8, color: '#6b7280' }}>{c.version}</td>
+                    <td style={{ padding: 8, color: '#6b7280', fontSize: 11 }}>
+                      {c.appliesTo.join(', ')}
+                    </td>
+                    <td style={{ padding: 8, color: '#6b7280' }}>{c.sectionCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/orchestrator/src/agents/contract-bootstrap.ts
+++ b/apps/orchestrator/src/agents/contract-bootstrap.ts
@@ -1,0 +1,52 @@
+/**
+ * Contract bootstrap (ACR-009).
+ *
+ * One-time registration of every Phase-1 agent's SectionContract on the
+ * default singleton @chiefaia/agent-contract-registry. The orchestrator
+ * boot path imports this; the dashboard /contracts route imports it too
+ * so it can render composed templates per scope.
+ *
+ * Idempotent — safe to call from multiple boot paths in tests; uses
+ * `replace()` so a second call is a no-op rather than a throw.
+ */
+
+import {
+  getDefaultRegistry,
+  type ContractRegistry,
+} from '@chiefaia/agent-contract-registry';
+import type { SectionContract } from '@chiefaia/ticket-template';
+import { poAgentContract } from './po-agent.contract';
+import { baAgentContract } from './ba-agent.contract';
+import { eaAgentContract } from './ea-agent.contract';
+import { testDesignAgentContract } from './test-design-agent.contract';
+
+/** All Phase-1 contracts in pipeline order — exported for tests + dashboards. */
+export const PHASE1_CONTRACTS: readonly SectionContract[] = [
+  poAgentContract,
+  baAgentContract,
+  eaAgentContract,
+  testDesignAgentContract,
+];
+
+let bootstrapped = false;
+
+/**
+ * Register every Phase-1 contract on the default singleton registry.
+ * Idempotent — second call is a no-op.
+ *
+ * Returns the registry for chaining / inspection.
+ */
+export function bootstrapAgentContracts(): ContractRegistry {
+  const reg = getDefaultRegistry();
+  if (bootstrapped) return reg;
+  for (const contract of PHASE1_CONTRACTS) {
+    reg.replace(contract);
+  }
+  bootstrapped = true;
+  return reg;
+}
+
+/** Test-only: clear the bootstrap flag so the next call re-registers. */
+export function resetBootstrapFlag(): void {
+  bootstrapped = false;
+}

--- a/apps/orchestrator/src/api/app.ts
+++ b/apps/orchestrator/src/api/app.ts
@@ -26,6 +26,7 @@ import { registerBucketsRoutes } from './routes/buckets';
 import { registerMetricsPhase1Routes } from './routes/metrics-phase1';
 import { registerDagRoutes } from './routes/dag';
 import { registerFeatureRegistryRoutes } from './routes/feature-registry';
+import { registerContractsRoutes } from './routes/contracts';
 import { promRegistry, httpRequestsTotal } from '../metrics/prometheus';
 
 export function createApp(db: Db): Hono {
@@ -75,6 +76,8 @@ export function createApp(db: Db): Hono {
   registerMetricsPhase1Routes(app, db);
   // FREG-007 — feature registry dashboard backend
   registerFeatureRegistryRoutes(app, db);
+  // ACR-009 — Agent Section Contract Registry dashboard backend
+  registerContractsRoutes(app);
   registerDagRoutes(app, db);
 
   return app;

--- a/apps/orchestrator/src/api/routes/contracts.ts
+++ b/apps/orchestrator/src/api/routes/contracts.ts
@@ -1,0 +1,93 @@
+/**
+ * /api/contracts — Agent Section Contract Registry dashboard backend
+ * (ACR-009).
+ *
+ * Two surfaces consumed by the dashboard's /contracts page:
+ *
+ *   GET /api/contracts/registry
+ *     -> array of every registered SectionContract (id, owner, version,
+ *        appliesTo, section count, signature)
+ *
+ *   GET /api/contracts/composed/:scope
+ *     -> the composed template for a given StoryScope, including each
+ *        section's owner, effective rubric, dependencies, examples,
+ *        and the composition signature + warnings
+ *
+ * Both routes call bootstrapAgentContracts() so the registry is always
+ * populated regardless of orchestrator boot order.
+ */
+
+import type { Hono } from 'hono';
+import { composeTemplate } from '@chiefaia/agent-contract-registry';
+import { STORY_SCOPES, isStoryScope } from '@chiefaia/ticket-template';
+import { bootstrapAgentContracts } from '../../agents/contract-bootstrap';
+
+// @no-events — observability route surfaces, no domain mutations
+export function registerContractsRoutes(app: Hono): void {
+  app.get('/api/contracts/registry', (c) => {
+    const reg = bootstrapAgentContracts();
+    const entries = reg.list().map((contract) => ({
+      contractId: contract.contractId,
+      ownerAgent: contract.ownerAgent,
+      version: contract.version,
+      appliesTo: [...contract.appliesTo],
+      sectionCount: contract.sections.length,
+      sectionNames: contract.sections.map((s) => s.name),
+    }));
+    return c.json({ contracts: entries, count: entries.length });
+  });
+
+  app.get('/api/contracts/composed/:scope', (c) => {
+    const rawScope = c.req.param('scope');
+    if (!isStoryScope(rawScope)) {
+      return c.json(
+        {
+          error: `invalid scope '${rawScope}'`,
+          allowedScopes: [...STORY_SCOPES],
+        },
+        400,
+      );
+    }
+    bootstrapAgentContracts();
+    const template = composeTemplate(rawScope);
+    const sections = [...template.sections.entries()].map(([name, entry]) => ({
+      name,
+      ownerAgent: entry.ownerAgent,
+      contractId: entry.contractId,
+      effectiveRequired: entry.effectiveRequired,
+      description: entry.spec.description,
+      purpose: entry.spec.purpose,
+      dependencies: [...(entry.spec.dependencies ?? [])],
+      effectiveRubric: {
+        minWords: entry.effectiveRubric.minWords ?? null,
+        minItems: entry.effectiveRubric.minItems ?? null,
+        severityOnFail: entry.effectiveRubric.severityOnFail,
+        fixHint: entry.effectiveRubric.fixHint,
+        forbiddenSnippets: [...(entry.effectiveRubric.forbiddenSnippets ?? [])],
+        requiredEntityRefs: [...(entry.effectiveRubric.requiredEntityRefs ?? [])],
+      },
+      exampleCount: entry.spec.examples.length,
+    }));
+    return c.json({
+      scope: template.scope,
+      signature: template.signature,
+      sections,
+      warnings: [...template.warnings],
+      sectionCount: sections.length,
+    });
+  });
+
+  app.get('/api/contracts/composed-all', (c) => {
+    bootstrapAgentContracts();
+    const out: Record<string, { signature: string; sectionCount: number; warnings: string[] }> = {};
+    for (const scope of STORY_SCOPES) {
+      const t = composeTemplate(scope);
+      out[scope] = {
+        signature: t.signature,
+        sectionCount: t.sections.size,
+        warnings: [...t.warnings],
+      };
+    }
+    return c.json({ scopes: out });
+  });
+}

--- a/apps/orchestrator/tests/api/contracts-routes.test.ts
+++ b/apps/orchestrator/tests/api/contracts-routes.test.ts
@@ -1,0 +1,137 @@
+/**
+ * /api/contracts — route tests (ACR-009).
+ *
+ * Verifies the orchestrator exposes a working dashboard backend for the
+ * Agent Section Contract Registry. Uses a real Hono app + the bootstrap
+ * function so the assertions run end-to-end.
+ */
+
+import { Hono } from 'hono';
+import { resetDefaultRegistry } from '@chiefaia/agent-contract-registry';
+import { resetBootstrapFlag } from '../../src/agents/contract-bootstrap';
+import { registerContractsRoutes } from '../../src/api/routes/contracts';
+
+function buildApp(): Hono {
+  resetDefaultRegistry();
+  resetBootstrapFlag();
+  const app = new Hono();
+  registerContractsRoutes(app);
+  return app;
+}
+
+async function get(app: Hono, path: string): Promise<{ status: number; body: any }> {
+  const res = await app.request(path);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { status: res.status, body: (await res.json()) as any };
+}
+
+describe('GET /api/contracts/registry', () => {
+  it('returns all 4 Phase-1 contracts with metadata', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/registry');
+    expect(r.status).toBe(200);
+    expect(r.body.count).toBe(4);
+    const owners = r.body.contracts.map((c: { ownerAgent: string }) => c.ownerAgent);
+    expect(owners.sort()).toEqual(['ba', 'ea', 'po', 'test-design']);
+  });
+
+  it('each contract entry has appliesTo + sectionCount + sectionNames', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/registry');
+    for (const c of r.body.contracts) {
+      expect(Array.isArray(c.appliesTo)).toBe(true);
+      expect(typeof c.sectionCount).toBe('number');
+      expect(c.sectionCount).toBeGreaterThan(0);
+      expect(Array.isArray(c.sectionNames)).toBe(true);
+    }
+  });
+});
+
+describe('GET /api/contracts/composed/:scope', () => {
+  it('story scope returns full union (PO+BA+EA+Test-Design)', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/composed/story');
+    expect(r.status).toBe(200);
+    expect(r.body.scope).toBe('story');
+    expect(r.body.warnings).toEqual([]);
+    const owners = new Set(
+      r.body.sections.map((s: { ownerAgent: string }) => s.ownerAgent),
+    );
+    expect(owners).toEqual(new Set(['po', 'ba', 'ea', 'test-design']));
+  });
+
+  it('initiative scope returns PO-only sections', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/composed/initiative');
+    expect(r.status).toBe(200);
+    const owners = new Set(
+      r.body.sections.map((s: { ownerAgent: string }) => s.ownerAgent),
+    );
+    expect(owners).toEqual(new Set(['po']));
+  });
+
+  it('subtask scope returns PO + EA only', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/composed/subtask');
+    expect(r.status).toBe(200);
+    const owners = new Set(
+      r.body.sections.map((s: { ownerAgent: string }) => s.ownerAgent),
+    );
+    expect(owners).toContain('po');
+    expect(owners).toContain('ea');
+    expect(owners).not.toContain('ba');
+    expect(owners).not.toContain('test-design');
+  });
+
+  it('returns rubric metadata + dependencies + exampleCount per section', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/composed/story');
+    const ac = r.body.sections.find((s: { name: string }) => s.name === 'acceptanceCriteria');
+    expect(ac).toBeDefined();
+    expect(ac.effectiveRubric.severityOnFail).toBe('hard');
+    expect(ac.effectiveRubric.fixHint.length).toBeGreaterThan(0);
+    expect(ac.exampleCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects invalid scope with 400 + allowedScopes list', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/composed/feature');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toContain('feature');
+    expect(r.body.allowedScopes).toEqual([
+      'initiative',
+      'epic',
+      'module',
+      'story',
+      'task',
+      'subtask',
+    ]);
+  });
+
+  it('signature is stable across calls', async () => {
+    const app = buildApp();
+    const a = await get(app, '/api/contracts/composed/story');
+    const b = await get(app, '/api/contracts/composed/story');
+    expect(a.body.signature).toBe(b.body.signature);
+  });
+});
+
+describe('GET /api/contracts/composed-all', () => {
+  it('returns per-scope summary for every canonical scope', async () => {
+    const app = buildApp();
+    const r = await get(app, '/api/contracts/composed-all');
+    expect(r.status).toBe(200);
+    expect(Object.keys(r.body.scopes).sort()).toEqual([
+      'epic',
+      'initiative',
+      'module',
+      'story',
+      'subtask',
+      'task',
+    ]);
+    for (const v of Object.values(r.body.scopes) as Array<{ signature: string; sectionCount: number }>) {
+      expect(typeof v.signature).toBe('string');
+      expect(v.sectionCount).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## ACR-009 — Contract Registry dashboard

Stacked on **#129..#137**.

Adds the `/contracts` dashboard page + orchestrator backend for the Agent Section Contract Registry. Also extracts a one-shot `bootstrapAgentContracts()` helper that registers every Phase-1 contract on the default singleton — used by the orchestrator's `/api/contracts` routes and (later) by ACR-007's Validator refactor.

### What ships

**Orchestrator:**
- `src/agents/contract-bootstrap.ts` — `PHASE1_CONTRACTS` array + idempotent `bootstrapAgentContracts()` via `reg.replace()`
- `src/api/routes/contracts.ts` — three GET endpoints
- `src/api/app.ts` — wires the routes

**Dashboard (Next.js):**
- `app/contracts/page.tsx` — three panels: scope selector + summary, sections table, registered contracts table. Polls every 30s. Owner + severity badges colour-coded.
- `app/api/contracts/registry/route.ts` — proxy
- `app/api/contracts/composed/[scope]/route.ts` — proxy

### API surface

| Method | Path | Returns |
|---|---|---|
| GET | `/api/contracts/registry` | array of contracts + metadata |
| GET | `/api/contracts/composed/:scope` | composed template per scope (sections, signature, warnings) |
| GET | `/api/contracts/composed-all` | per-scope summary (signature + sectionCount + warnings) |

### Tests — 9/9 jest pass

- `/api/contracts/registry` returns all 4 contracts
- composed/story returns full union (PO+BA+EA+Test-Design)
- composed/initiative returns PO-only
- composed/subtask returns PO + EA only
- per-section: rubric metadata + dependencies + exampleCount
- invalid scope → 400 + allowedScopes list
- signature stable across calls
- composed-all returns per-scope summary

`@caia-app/core` typecheck clean; `@caia-app/dashboard` `tsc --noEmit` clean.

### Operator value

Operators can land on `/contracts`, pick a scope, and immediately see what every agent will populate, what severity each rubric carries, and the operator-facing fix hint per section. Drift in composed templates surfaces as a signature change.

Refs: ACR-009