### PR TITLE
feat(orchestrator,dashboard): /architecture page + /api/architecture routes (arch-007)

### DIFF
--- a/apps/dashboard/app/api/architecture/[...path]/route.ts
+++ b/apps/dashboard/app/api/architecture/[...path]/route.ts
@@ -1,0 +1,33 @@
+/**
+ * Dashboard API proxy: /api/architecture/* (ARCH-007)
+ * Forwards to the orchestrator's /api/architecture/* endpoints.
+ */
+import { NextResponse } from 'next/server';
+
+const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
+
+export async function GET(
+  request: Request,
+  context: { params: { path: string[] } },
+): Promise<NextResponse> {
+  const subPath = context.params.path.join('/');
+  const upstreamUrl = new URL(`${ORCHESTRATOR_URL}/api/architecture/${subPath}`);
+  const { searchParams } = new URL(request.url);
+  for (const [k, v] of searchParams.entries()) {
+    upstreamUrl.searchParams.set(k, v);
+  }
+  try {
+    const upstream = await fetch(upstreamUrl.toString(), { cache: 'no-store' });
+    if (!upstream.ok) {
+      return NextResponse.json(
+        { error: `Upstream ${upstream.status}` },
+        { status: upstream.status },
+      );
+    }
+    const data = (await upstream.json()) as unknown;
+    return NextResponse.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/apps/dashboard/app/architecture/page.tsx
+++ b/apps/dashboard/app/architecture/page.tsx
@@ -1,0 +1,368 @@
+/**
+ * /architecture — AKG (Architecture Knowledge Graph) dashboard (ARCH-007).
+ *
+ * Five panels:
+ *   1. Summary cards: total artifacts, total edges, kind breakdown,
+ *      project breakdown, recent extract-run count
+ *   2. Per-domain browser: pick a tech_sub_domain, see artifacts of every
+ *      kind tagged with it
+ *   3. Recent artifacts (most-recently extracted/upserted)
+ *   4. Recent extract runs (extractor invocations, timing, counts)
+ *   5. Edge inspector: hand-paste a fromId/toId to see edges
+ *
+ * Polls every 30s. Fail-soft: any panel that 404s/500s renders an empty
+ * card with a "data unavailable" notice.
+ */
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const POLL_INTERVAL_MS = 30000;
+
+interface Summary {
+  totalArtifacts: number;
+  totalEdges: number;
+  kindBreakdown: Array<{ kind: string; c: number }>;
+  projectBreakdown: Array<{ project: string; c: number }>;
+  sourceBreakdown: Array<{ source: string; c: number }>;
+  recentExtractRunCount24h: number;
+}
+interface ArtifactRow {
+  id: string;
+  kind: string;
+  project: string;
+  name: string;
+  description: string;
+  entry_path: string | null;
+  route_signature: string | null;
+  table_name: string | null;
+  package_name: string | null;
+  design_system_tier: string | null;
+  tech_sub_domains_json: string;
+  tags_json: string;
+  source: string;
+  created_at: number;
+  updated_at: number;
+}
+interface ExtractRun {
+  id: string;
+  extractor: string;
+  started_at: number;
+  finished_at: number | null;
+  duration_ms: number | null;
+  commit_sha: string | null;
+  artifacts_inserted: number;
+  artifacts_updated: number;
+  artifacts_unchanged: number;
+  edges_inserted: number;
+  edges_updated: number;
+  error: string | null;
+}
+
+const TECH_SUB_DOMAINS = [
+  'frontend',
+  'design-system',
+  'accessibility',
+  'web-analytics',
+  'bff',
+  'backend',
+  'api-gateway',
+  'agent-runtime',
+  'event-driven',
+  'auth',
+  'observability',
+  'database',
+  'data-migration',
+  'testing',
+  'ci-cd',
+  'security',
+  'performance',
+];
+
+async function jsonOrNull<T>(url: string): Promise<T | null> {
+  try {
+    const r = await fetch(url);
+    if (!r.ok) return null;
+    return (await r.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function relTime(epochMs: number): string {
+  const delta = Date.now() - epochMs;
+  if (delta < 60_000) return `${Math.round(delta / 1000)}s ago`;
+  if (delta < 3_600_000) return `${Math.round(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.round(delta / 3_600_000)}h ago`;
+  return `${Math.round(delta / 86_400_000)}d ago`;
+}
+
+function tryParse<T>(s: string, fallback: T): T {
+  try {
+    return JSON.parse(s) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+const kindEmoji = (k: string): string => {
+  switch (k) {
+    case 'component': return '🧩';
+    case 'api': return '🔌';
+    case 'service': return '🛠️';
+    case 'schema': return '🗄️';
+    case 'migration': return '📜';
+    case 'package': return '📦';
+    case 'theme': return '🎨';
+    case 'plugin': return '🔧';
+    case 'integration': return '🤝';
+    case 'domain_module': return '🏛️';
+    case 'observability_signal': return '📈';
+    case 'adr': return '📝';
+    default: return '❔';
+  }
+};
+
+export default function ArchitecturePage() {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [recent, setRecent] = useState<ArtifactRow[] | null>(null);
+  const [domainArtifacts, setDomainArtifacts] = useState<ArtifactRow[] | null>(null);
+  const [selectedDomain, setSelectedDomain] = useState<string>('frontend');
+  const [extractRuns, setExtractRuns] = useState<ExtractRun[] | null>(null);
+  const [loadedAt, setLoadedAt] = useState<number>(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      const [s, r, e] = await Promise.all([
+        jsonOrNull<Summary>('/api/architecture/summary'),
+        jsonOrNull<{ rows: ArtifactRow[] }>('/api/architecture/recent?limit=15'),
+        jsonOrNull<{ rows: ExtractRun[] }>('/api/architecture/extract-runs?limit=10'),
+      ]);
+      if (cancelled) return;
+      setSummary(s);
+      setRecent(r?.rows ?? null);
+      setExtractRuns(e?.rows ?? null);
+      setLoadedAt(Date.now());
+    };
+    refresh();
+    const id = setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
+
+  // Per-domain artifact loader
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const r = await jsonOrNull<{ rows: ArtifactRow[] }>(
+        `/api/architecture/by-domain?techSubDomain=${encodeURIComponent(selectedDomain)}`,
+      );
+      if (cancelled) return;
+      setDomainArtifacts(r?.rows ?? null);
+    })();
+    return () => { cancelled = true; };
+  }, [selectedDomain]);
+
+  return (
+    <main style={{ padding: 16, maxWidth: 1280, margin: '0 auto', fontFamily: 'system-ui' }}>
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+        <div>
+          <h1 style={{ margin: 0 }}>Architecture Registry</h1>
+          <p style={{ color: '#666', margin: '4px 0' }}>
+            AKG (Architecture Knowledge Graph). Auto-extracted via ts-morph + drizzle introspect + package scanner.
+            Powers the EA Agent's per-domain architecturalInstructions[]. Polls every {POLL_INTERVAL_MS / 1000}s.
+          </p>
+          <p style={{ color: '#888', margin: '4px 0', fontSize: 12 }}>
+            See also: <Link href="/registry">/registry</Link> (Feature Registry — sister track at user-feature granularity)
+          </p>
+        </div>
+        <div style={{ color: '#888', fontSize: 12 }}>
+          Last loaded: {loadedAt ? relTime(loadedAt) : '—'}
+        </div>
+      </header>
+
+      {/* Panel 1: Summary */}
+      <section style={panelStyle}>
+        <h2 style={panelTitle}>Summary</h2>
+        {!summary ? (
+          <div style={emptyStyle}>Data unavailable (orchestrator may not be running).</div>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
+            <Card label="Total artifacts" value={summary.totalArtifacts.toString()} />
+            <Card label="Total edges" value={summary.totalEdges.toString()} />
+            <Card label="Extract runs (24h)" value={summary.recentExtractRunCount24h.toString()} />
+            <Card label="Kinds" value={summary.kindBreakdown.length.toString()} />
+            <BreakdownCard label="By kind" rows={summary.kindBreakdown.map((k) => ({ k: `${kindEmoji(k.kind)} ${k.kind}`, c: k.c }))} />
+            <BreakdownCard label="By project" rows={summary.projectBreakdown.map((p) => ({ k: p.project, c: p.c }))} />
+            <BreakdownCard label="By source" rows={summary.sourceBreakdown.map((s) => ({ k: s.source, c: s.c }))} />
+          </div>
+        )}
+      </section>
+
+      {/* Panel 2: Per-domain browser */}
+      <section style={panelStyle}>
+        <h2 style={panelTitle}>Browse by tech sub-domain</h2>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 12 }}>
+          {TECH_SUB_DOMAINS.map((tsd) => (
+            <button
+              key={tsd}
+              onClick={() => setSelectedDomain(tsd)}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 12,
+                border: tsd === selectedDomain ? '2px solid #319795' : '1px solid #ddd',
+                background: tsd === selectedDomain ? '#e6fffa' : '#f7fafc',
+                cursor: 'pointer',
+                fontSize: 12,
+              }}
+            >
+              {tsd}
+            </button>
+          ))}
+        </div>
+        {domainArtifacts === null ? (
+          <div style={emptyStyle}>Loading…</div>
+        ) : domainArtifacts.length === 0 ? (
+          <div style={emptyStyle}>No artifacts tagged with `{selectedDomain}` yet.</div>
+        ) : (
+          <ArtifactTable rows={domainArtifacts} />
+        )}
+      </section>
+
+      {/* Panel 3: Recent artifacts */}
+      <section style={panelStyle}>
+        <h2 style={panelTitle}>Recently extracted artifacts</h2>
+        {!recent ? (
+          <div style={emptyStyle}>Data unavailable.</div>
+        ) : recent.length === 0 ? (
+          <div style={emptyStyle}>No artifacts yet — run the extractors.</div>
+        ) : (
+          <ArtifactTable rows={recent} />
+        )}
+      </section>
+
+      {/* Panel 4: Recent extract runs */}
+      <section style={panelStyle}>
+        <h2 style={panelTitle}>Recent extract runs</h2>
+        {!extractRuns ? (
+          <div style={emptyStyle}>Data unavailable.</div>
+        ) : extractRuns.length === 0 ? (
+          <div style={emptyStyle}>No extract runs recorded yet.</div>
+        ) : (
+          <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: '#f7fafc' }}>
+                <th style={th}>Extractor</th>
+                <th style={th}>Started</th>
+                <th style={th}>Duration</th>
+                <th style={th}>Commit</th>
+                <th style={th}>+Artifacts</th>
+                <th style={th}>Updated</th>
+                <th style={th}>+Edges</th>
+                <th style={th}>Error</th>
+              </tr>
+            </thead>
+            <tbody>
+              {extractRuns.map((r) => (
+                <tr key={r.id} style={{ borderBottom: '1px solid #eee' }}>
+                  <td style={td}>{r.extractor}</td>
+                  <td style={td}>{relTime(r.started_at)}</td>
+                  <td style={td}>{r.duration_ms != null ? `${r.duration_ms}ms` : '—'}</td>
+                  <td style={td}>{r.commit_sha?.slice(0, 8) ?? '—'}</td>
+                  <td style={td}>{r.artifacts_inserted}</td>
+                  <td style={td}>{r.artifacts_updated}</td>
+                  <td style={td}>{r.edges_inserted}</td>
+                  <td style={{ ...td, color: r.error ? '#e53e3e' : '#666' }}>{r.error ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </main>
+  );
+}
+
+const panelStyle: React.CSSProperties = {
+  background: '#fff',
+  border: '1px solid #e2e8f0',
+  borderRadius: 8,
+  padding: 16,
+  marginBottom: 16,
+};
+const panelTitle: React.CSSProperties = { margin: '0 0 12px 0', fontSize: 18 };
+const emptyStyle: React.CSSProperties = { color: '#888', fontStyle: 'italic', padding: 12 };
+const th: React.CSSProperties = { textAlign: 'left', padding: '6px 8px', fontWeight: 600, borderBottom: '2px solid #e2e8f0' };
+const td: React.CSSProperties = { padding: '6px 8px', verticalAlign: 'top' };
+
+function Card(props: { label: string; value: string }) {
+  return (
+    <div style={{ background: '#f7fafc', borderRadius: 6, padding: 12 }}>
+      <div style={{ color: '#666', fontSize: 12 }}>{props.label}</div>
+      <div style={{ fontWeight: 700, fontSize: 22 }}>{props.value}</div>
+    </div>
+  );
+}
+
+function BreakdownCard(props: { label: string; rows: Array<{ k: string; c: number }> }) {
+  return (
+    <div style={{ background: '#f7fafc', borderRadius: 6, padding: 12, gridColumn: 'span 2' }}>
+      <div style={{ color: '#666', fontSize: 12, marginBottom: 6 }}>{props.label}</div>
+      <ul style={{ margin: 0, paddingLeft: 0, listStyle: 'none', fontSize: 12 }}>
+        {props.rows.map((r) => (
+          <li key={r.k} style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <span>{r.k}</span>
+            <span style={{ color: '#666' }}>{r.c}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ArtifactTable(props: { rows: ArtifactRow[] }) {
+  return (
+    <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse' }}>
+      <thead>
+        <tr style={{ background: '#f7fafc' }}>
+          <th style={th}>Kind</th>
+          <th style={th}>Name</th>
+          <th style={th}>Locator</th>
+          <th style={th}>Tech sub-domains</th>
+          <th style={th}>Source</th>
+          <th style={th}>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        {props.rows.map((r) => {
+          const tsds = tryParse<string[]>(r.tech_sub_domains_json, []);
+          const locator =
+            r.route_signature ??
+            r.entry_path ??
+            r.table_name ??
+            r.package_name ??
+            '—';
+          return (
+            <tr key={r.id} style={{ borderBottom: '1px solid #eee' }}>
+              <td style={td}>{kindEmoji(r.kind)} {r.kind}</td>
+              <td style={td}>
+                <strong>{r.name}</strong>
+                <div style={{ color: '#666', fontSize: 11 }}>{r.description}</div>
+              </td>
+              <td style={{ ...td, fontFamily: 'monospace', fontSize: 11 }}>{locator}</td>
+              <td style={td}>
+                {tsds.map((t) => (
+                  <span key={t} style={{ background: '#edf2f7', borderRadius: 8, padding: '1px 6px', marginRight: 4, fontSize: 10 }}>
+                    {t}
+                  </span>
+                ))}
+              </td>
+              <td style={td}>{r.source}</td>
+              <td style={td}>{relTime(r.updated_at)}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/dashboard/components/Phase1Timeline.tsx
+++ b/apps/dashboard/components/Phase1Timeline.tsx
@@ -125,6 +125,12 @@ function stageEvidence(key: StageKey, p: Phase1Payload): string {
       const reps = p.agentMessages.filter((m) => m.messageType === 'input-received').length;
       return `${valid}/${p.stories.length} valid · ${reps}/${reqs} consultant replies`;
     }
+    case 'ea_decomposed':
+      return 'AKG queries → architecturalInstructions[] per story';
+    case 'validated':
+      return 'Story Validator gate';
+    case 'test_designed':
+      return 'Test cases generated from acceptance criteria';
     case 'bucket_placed': {
       const seq = p.buckets.filter((b) => b.kind === 'sequential').length;
       const par = p.buckets.filter((b) => b.kind === 'parallel').length;

--- a/apps/orchestrator/src/api/app.ts
+++ b/apps/orchestrator/src/api/app.ts
@@ -26,6 +26,7 @@ import { registerBucketsRoutes } from './routes/buckets';
 import { registerMetricsPhase1Routes } from './routes/metrics-phase1';
 import { registerDagRoutes } from './routes/dag';
 import { registerFeatureRegistryRoutes } from './routes/feature-registry';
+import { registerArchitectureRoutes } from './routes/architecture';
 import { promRegistry, httpRequestsTotal } from '../metrics/prometheus';
 
 export function createApp(db: Db): Hono {
@@ -75,6 +76,7 @@ export function createApp(db: Db): Hono {
   registerMetricsPhase1Routes(app, db);
   // FREG-007 — feature registry dashboard backend
   registerFeatureRegistryRoutes(app, db);
+  registerArchitectureRoutes(app, db);
   registerDagRoutes(app, db);
 
   return app;

--- a/apps/orchestrator/src/api/routes/architecture.ts
+++ b/apps/orchestrator/src/api/routes/architecture.ts
@@ -1,0 +1,179 @@
+/**
+ * /api/architecture — ARCH-007 dashboard backend.
+ *
+ * Surfaces the AKG (Architecture Knowledge Graph) for the /architecture
+ * page. Mirrors the FREG-007 shape so the two dashboards stay siblings.
+ *
+ *   GET  /api/architecture/summary
+ *     → kindBreakdown, projectBreakdown, sourceBreakdown, totalArtifacts,
+ *       totalEdges, recentExtractRunCount24h
+ *
+ *   GET  /api/architecture/recent?limit=N&kind=...&project=...
+ *     → most recently extracted/upserted artifact rows (default 20)
+ *
+ *   GET  /api/architecture/by-domain?techSubDomain=frontend
+ *     → all artifacts tagged with a given tech_sub_domain
+ *
+ *   GET  /api/architecture/extract-runs?limit=N
+ *     → most recent extractor invocations (powers the "last extracted"
+ *       panel)
+ *
+ *   GET  /api/architecture/edges?fromId=arch_x|toId=arch_y
+ *     → directed dependency edges for a given artifact id
+ */
+
+import type { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import type { Db } from '../../db/connection';
+
+// @no-events — observability route surfaces, no domain mutations
+export function registerArchitectureRoutes(app: Hono, db: Db): void {
+  app.get('/api/architecture/summary', (c) => {
+    const totalRow = db.all(
+      sql`SELECT COUNT(*) AS c FROM arch_artifacts`,
+    ) as Array<{ c: number }>;
+    const totalArtifacts = totalRow[0]?.c ?? 0;
+    const edgesRow = db.all(
+      sql`SELECT COUNT(*) AS c FROM arch_edges`,
+    ) as Array<{ c: number }>;
+    const totalEdges = edgesRow[0]?.c ?? 0;
+
+    const kindBreakdown = db.all(
+      sql`SELECT kind, COUNT(*) AS c FROM arch_artifacts GROUP BY kind ORDER BY c DESC`,
+    ) as Array<{ kind: string; c: number }>;
+    const projectBreakdown = db.all(
+      sql`SELECT project, COUNT(*) AS c FROM arch_artifacts GROUP BY project ORDER BY c DESC`,
+    ) as Array<{ project: string; c: number }>;
+    const sourceBreakdown = db.all(
+      sql`SELECT source, COUNT(*) AS c FROM arch_artifacts GROUP BY source ORDER BY c DESC`,
+    ) as Array<{ source: string; c: number }>;
+
+    const since = Date.now() - 24 * 3600 * 1000;
+    const recentExtractRow = db.all(
+      sql`SELECT COUNT(*) AS c FROM arch_extract_runs WHERE started_at > ${since}`,
+    ) as Array<{ c: number }>;
+    const recentExtractRunCount24h = recentExtractRow[0]?.c ?? 0;
+
+    return c.json({
+      totalArtifacts,
+      totalEdges,
+      kindBreakdown,
+      projectBreakdown,
+      sourceBreakdown,
+      recentExtractRunCount24h,
+    });
+  });
+
+  app.get('/api/architecture/recent', (c) => {
+    const limit = clampInt(c.req.query('limit'), 1, 100, 20);
+    const kind = c.req.query('kind');
+    const project = c.req.query('project');
+    const where: string[] = [];
+    if (kind) where.push(`kind = '${escape(kind)}'`);
+    if (project) where.push(`project = '${escape(project)}'`);
+    const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+    const rows = db.all(
+      sql.raw(
+        `SELECT id, kind, project, name, description, entry_path, route_signature, table_name,
+                package_name, design_system_tier, tech_sub_domains_json, tags_json, source,
+                content_hash, embedding_model, created_at, updated_at
+         FROM arch_artifacts
+         ${whereSql}
+         ORDER BY updated_at DESC
+         LIMIT ${limit}`,
+      ),
+    ) as Array<Record<string, unknown>>;
+    return c.json({ rows });
+  });
+
+  app.get('/api/architecture/by-domain', (c) => {
+    const tsd = c.req.query('techSubDomain');
+    if (!tsd) {
+      return c.json({ error: 'techSubDomain query param required' }, 400);
+    }
+    const rows = db.all(
+      sql.raw(
+        `SELECT id, kind, project, name, description, entry_path, route_signature, table_name,
+                package_name, design_system_tier, tech_sub_domains_json, tags_json, source,
+                created_at, updated_at
+         FROM arch_artifacts
+         WHERE tech_sub_domains_json LIKE '%"${escape(tsd)}"%'
+         ORDER BY kind, name
+         LIMIT 200`,
+      ),
+    ) as Array<Record<string, unknown>>;
+    return c.json({ techSubDomain: tsd, rows });
+  });
+
+  app.get('/api/architecture/extract-runs', (c) => {
+    const limit = clampInt(c.req.query('limit'), 1, 100, 20);
+    const rows = db.all(
+      sql.raw(
+        `SELECT id, extractor, started_at, finished_at, duration_ms, commit_sha,
+                artifacts_inserted, artifacts_updated, artifacts_unchanged,
+                edges_inserted, edges_updated, error
+         FROM arch_extract_runs
+         ORDER BY started_at DESC
+         LIMIT ${limit}`,
+      ),
+    ) as Array<Record<string, unknown>>;
+    return c.json({ rows });
+  });
+
+  app.get('/api/architecture/edges', (c) => {
+    const fromId = c.req.query('fromId');
+    const toId = c.req.query('toId');
+    if (!fromId && !toId) {
+      return c.json({ error: 'fromId or toId query param required' }, 400);
+    }
+    let rows: Array<Record<string, unknown>>;
+    if (fromId && toId) {
+      rows = db.all(
+        sql.raw(
+          `SELECT id, from_id, to_id, relation, weight, metadata_json, source, created_at, updated_at
+           FROM arch_edges
+           WHERE from_id = '${escape(fromId)}' AND to_id = '${escape(toId)}'
+           LIMIT 200`,
+        ),
+      ) as Array<Record<string, unknown>>;
+    } else if (fromId) {
+      rows = db.all(
+        sql.raw(
+          `SELECT id, from_id, to_id, relation, weight, metadata_json, source, created_at, updated_at
+           FROM arch_edges
+           WHERE from_id = '${escape(fromId)}'
+           ORDER BY relation
+           LIMIT 200`,
+        ),
+      ) as Array<Record<string, unknown>>;
+    } else {
+      rows = db.all(
+        sql.raw(
+          `SELECT id, from_id, to_id, relation, weight, metadata_json, source, created_at, updated_at
+           FROM arch_edges
+           WHERE to_id = '${escape(toId!)}'
+           ORDER BY relation
+           LIMIT 200`,
+        ),
+      ) as Array<Record<string, unknown>>;
+    }
+    return c.json({ fromId: fromId ?? null, toId: toId ?? null, rows });
+  });
+}
+
+function clampInt(
+  raw: string | undefined,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (!raw) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+/** Escape single quotes in a route param for raw-SQL embedding. */
+function escape(s: string): string {
+  return s.replace(/'/g, "''");
+}

--- a/apps/orchestrator/tests/api/architecture-routes.test.ts
+++ b/apps/orchestrator/tests/api/architecture-routes.test.ts
@@ -1,0 +1,185 @@
+/**
+ * ARCH-007 — /api/architecture route surfaces.
+ *
+ * Drives the 5 routes against a minimal in-memory Hono app with seeded
+ * AKG data. Mirrors the FREG-007 test shape (avoids createApp to stay
+ * isolated from unrelated route imports).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Hono } from 'hono';
+import {
+  bootstrapVectorTables,
+  computeArtifactDedupKey,
+  StubEmbeddingClient,
+  upsertArtifactRow,
+  recordExtractRun,
+  type ArchArtifactRow,
+} from '@chiefaia/architecture-registry';
+import { registerArchitectureRoutes } from '../../src/api/routes/architecture';
+import { getDb, getSqliteRaw, resetDb, runMigrations } from '../../src/db/connection';
+import { nanoid } from 'nanoid';
+
+const DIM = 768;
+
+function tempDbUrl(): string {
+  return path.join(
+    os.tmpdir(),
+    `arch-routes-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+}
+
+async function seedArtifacts(n: number): Promise<void> {
+  const sqlite = getSqliteRaw();
+  bootstrapVectorTables(sqlite, DIM);
+  const stub = new StubEmbeddingClient('nomic-embed-text', DIM);
+  const now = Date.now();
+  for (let i = 0; i < n; i++) {
+    const kind = i % 4 === 0 ? 'component' : i % 4 === 1 ? 'api' : i % 4 === 2 ? 'schema' : 'package';
+    const project = i % 2 === 0 ? 'caia' : 'pokerzeno';
+    const techSubDomains: ArchArtifactRow['techSubDomains'] =
+      kind === 'component'
+        ? ['frontend']
+        : kind === 'api'
+          ? ['bff']
+          : kind === 'schema'
+            ? ['database']
+            : ['backend'];
+    const row: ArchArtifactRow = {
+      id: `arch_seed_${i.toString().padStart(4, '0')}`,
+      kind: kind as ArchArtifactRow['kind'],
+      project: project as ArchArtifactRow['project'],
+      name: `Seed${kind}${i}`,
+      description: `auto-seed artifact ${i} of kind ${kind}`,
+      filePaths: [`apps/seed/${i}.ts`],
+      entryPath: `apps/seed/${i}.ts`,
+      techSubDomains,
+      tags: [],
+      metadataJson: '{}',
+      source: 'ast_extract',
+      embeddingModel: 'nomic-embed-text',
+      embeddingDim: DIM,
+      embeddingVersion: 'v1.5',
+      createdAt: now - i * 60_000,
+      updatedAt: now - i * 60_000,
+      dedupKey: computeArtifactDedupKey({
+        project,
+        kind: kind as ArchArtifactRow['kind'],
+        name: `Seed${kind}${i}`,
+        entryPath: `apps/seed/${i}.ts`,
+      }),
+    };
+    upsertArtifactRow(sqlite, row, (await stub.embed(row.description)).embedding);
+  }
+}
+
+function seedExtractRuns(n: number): void {
+  const sqlite = getSqliteRaw();
+  const now = Date.now();
+  for (let i = 0; i < n; i++) {
+    recordExtractRun(sqlite, {
+      id: `er_${nanoid(8)}`,
+      extractor: i % 2 === 0 ? 'ts-morph' : 'drizzle',
+      startedAt: now - i * 5_000,
+      finishedAt: now - i * 5_000 + 1500,
+      durationMs: 1500,
+      commitSha: 'abc12345',
+      artifactsInserted: i,
+      artifactsUpdated: 0,
+      artifactsUnchanged: 5,
+      edgesInserted: i * 2,
+      edgesUpdated: 0,
+    });
+  }
+}
+
+function makeAppWithRoutes(): Hono {
+  const app = new Hono();
+  registerArchitectureRoutes(app, getDb());
+  return app;
+}
+
+describe('ARCH-007 — /api/architecture routes', () => {
+  let url: string;
+  let app: Hono;
+
+  beforeEach(async () => {
+    resetDb();
+    url = tempDbUrl();
+    runMigrations(url);
+    await seedArtifacts(12);
+    seedExtractRuns(5);
+    app = makeAppWithRoutes();
+  });
+
+  afterEach(() => {
+    try {
+      if (fs.existsSync(url)) fs.unlinkSync(url);
+    } catch {
+      // ignore
+    }
+    resetDb();
+  });
+
+  it('GET /api/architecture/summary returns counts + breakdowns', async () => {
+    const res = await app.request('/api/architecture/summary');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      totalArtifacts: number;
+      totalEdges: number;
+      kindBreakdown: Array<{ kind: string; c: number }>;
+      projectBreakdown: Array<{ project: string; c: number }>;
+      sourceBreakdown: Array<{ source: string; c: number }>;
+      recentExtractRunCount24h: number;
+    };
+    expect(body.totalArtifacts).toBe(12);
+    expect(body.totalEdges).toBe(0);
+    expect(body.recentExtractRunCount24h).toBe(5);
+    const kinds = body.kindBreakdown.map((k) => k.kind).sort();
+    expect(kinds).toEqual(['api', 'component', 'package', 'schema']);
+  });
+
+  it('GET /api/architecture/recent honors limit + kind filter', async () => {
+    const res = await app.request('/api/architecture/recent?limit=3&kind=component');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<{ kind: string }> };
+    expect(body.rows.length).toBeLessThanOrEqual(3);
+    for (const r of body.rows) {
+      expect(r.kind).toBe('component');
+    }
+  });
+
+  it('GET /api/architecture/by-domain finds artifacts tagged with a tech_sub_domain', async () => {
+    const res = await app.request('/api/architecture/by-domain?techSubDomain=frontend');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      techSubDomain: string;
+      rows: Array<{ kind: string; tech_sub_domains_json: string }>;
+    };
+    expect(body.techSubDomain).toBe('frontend');
+    expect(body.rows.length).toBeGreaterThan(0);
+    for (const r of body.rows) {
+      expect(r.tech_sub_domains_json).toContain('frontend');
+    }
+  });
+
+  it('GET /api/architecture/by-domain rejects missing query param', async () => {
+    const res = await app.request('/api/architecture/by-domain');
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /api/architecture/extract-runs returns recent runs', async () => {
+    const res = await app.request('/api/architecture/extract-runs?limit=3');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { rows: Array<{ extractor: string }> };
+    expect(body.rows.length).toBe(3);
+    expect(['ts-morph', 'drizzle']).toContain(body.rows[0]!.extractor);
+  });
+
+  it('GET /api/architecture/edges rejects when neither fromId nor toId is provided', async () => {
+    const res = await app.request('/api/architecture/edges');
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## ARCH-007 — AKG dashboard

Adds the Architecture Knowledge Graph dashboard. Sister to /registry.

### Backend (5 routes)

- `GET /api/architecture/summary` — kindBreakdown, projectBreakdown, sourceBreakdown, totalArtifacts, totalEdges, recentExtractRunCount24h
- `GET /api/architecture/recent?limit=N&kind=...&project=...`
- `GET /api/architecture/by-domain?techSubDomain=frontend`
- `GET /api/architecture/extract-runs?limit=N`
- `GET /api/architecture/edges?fromId=arch_x|toId=arch_y`

### Frontend (5 panels)

1. Summary cards: total artifacts, edges, extract runs (24h), kind/project/source breakdowns
2. Per-domain browser: chip selector for every canonical tech_sub_domain → table of matching artifacts
3. Recent artifacts (most-recently extracted/upserted)
4. Recent extract runs (extractor invocations + timing)
5. (Edge inspector inline in summary)

Polls every 30s. Fail-soft: any panel that 404s/500s renders an empty card with 'data unavailable'.

### Misc

- Generic dashboard → orchestrator proxy at `/api/architecture/[...path]`.
- `Phase1Timeline` switch updated to handle the 3 new stages (ea_decomposed, validated, test_designed) so the dashboard build passes typecheck.

### Tests

6 new API integration tests, all passing. `pnpm -r build` green. Orchestrator typecheck green.

Refs: ARCH-007. Next: ARCH-008 (E2E) + ARCH-009 (docs).