### PR TITLE
feat(agent-contract-registry): toValidationRubric adapter (ACR-007 Step A)

### DIFF
--- a/packages/agent-contract-registry/src/index.ts
+++ b/packages/agent-contract-registry/src/index.ts
@@ -26,6 +26,17 @@ export type { ComposeOptions } from './compose-template';
 
 export { computeSignature } from './signature';
 
+// ACR-007 Step A — adapter that converts ComposedTemplate into the shape
+// the existing Story Validator (validation-rubric.ts) consumes. Lets the
+// Validator swap consumption from hard-coded constants to runtime-composed
+// templates without changing its scoring logic. See architecture report §7.
+export { toValidationRubric } from './validator-adapter';
+export type {
+  AdapterTopLevelRule,
+  AdapterAgentSectionRule,
+  AdapterRubric,
+} from './validator-adapter';
+
 // Re-export the contract types for convenience — callers don't need to
 // also import from @chiefaia/ticket-template just to type a registration.
 export type {

--- a/packages/agent-contract-registry/src/validator-adapter.ts
+++ b/packages/agent-contract-registry/src/validator-adapter.ts
@@ -1,0 +1,162 @@
+/**
+ * @chiefaia/agent-contract-registry — validator-adapter.ts (ACR-007 Step A)
+ *
+ * Bridges the contract registry's runtime-composed templates to the shape
+ * the existing Story Validator (validation-rubric.ts) consumes. Lets the
+ * Validator switch from hard-coded `TOP_LEVEL_SECTION_RULES` /
+ * `AGENT_SECTION_RULES` to per-scope composed templates without changing
+ * its 6-step pipeline.
+ *
+ * **Phasing (per architecture report section 7):**
+ *
+ *   Step A (THIS PR): adapter exists; both rubric sources can be queried;
+ *     CI snapshot tests assert parity in shape so the swap is safe.
+ *   Step B (post VAL-### merge): Validator's runtime call site flips to
+ *     consume `toValidationRubric(composeTemplate(scope))`. Adapter
+ *     output replaces hard-coded constants behind a feature flag.
+ *   Step C (post drift-free window): hard-coded rule arrays in
+ *     validation-rubric.ts deleted; only helper functions remain.
+ *
+ * The adapter's job is purely structural: map ComposedSectionEntry into
+ * either a TopLevelSectionRule or an AgentSectionRule depending on the
+ * section name's path.
+ */
+
+import type {
+  ComposedSectionEntry,
+  ComposedTemplate,
+} from '@chiefaia/ticket-template';
+
+/**
+ * Adapter output — mirrors what validation-rubric.ts exports today,
+ * minus the `trigger` field on AgentSectionRule (composition has already
+ * resolved scope to a fixed required/optional decision).
+ */
+export interface AdapterTopLevelRule {
+  path: string;
+  purpose: string;
+  minWords: number;
+  forbidSnippets: boolean;
+  runContentRelevance: boolean;
+  severityOnFail: 'hard' | 'soft' | 'warning';
+  fixHint: string;
+  /** Source contract for failure attribution. */
+  contractId: string;
+  ownerAgent: string;
+  required: boolean;
+}
+
+export interface AdapterAgentSectionRule {
+  /** The `agentSections.<key>` suffix — e.g. 'architecture', 'api'. */
+  section: string;
+  purpose: string;
+  minWords: number;
+  minItemsPerSubField?: Readonly<Record<string, number>>;
+  requiredEntityRefs?: ReadonlyArray<{ label: string; pattern: string; flags?: string }>;
+  forbidSnippets: boolean;
+  extraForbiddenSnippets?: readonly string[];
+  runContentRelevance: boolean;
+  severityOnFail: 'hard' | 'soft' | 'warning';
+  fixHint: string;
+  /** Composition has resolved this — true means present-required, false means optional. */
+  required: boolean;
+  /** Source contract for failure attribution. */
+  contractId: string;
+  ownerAgent: string;
+}
+
+export interface AdapterRubric {
+  topLevelRules: readonly AdapterTopLevelRule[];
+  agentSectionRules: readonly AdapterAgentSectionRule[];
+  /** Sections whose `name` doesn't fit the top-level / agentSections.* pattern. */
+  otherSections: readonly AdapterAgentSectionRule[];
+}
+
+/**
+ * Top-level paths the Validator's existing TOP_LEVEL_SECTION_RULES uses.
+ * Sections whose name matches one of these are converted to
+ * AdapterTopLevelRule; everything else is treated as an agent section.
+ */
+const TOP_LEVEL_PATHS = new Set([
+  'scope',
+  'context',
+  'acceptanceCriteria',
+  'verificationPlan',
+  'dependencies',
+]);
+
+function entryToTopLevel(name: string, entry: ComposedSectionEntry): AdapterTopLevelRule {
+  return {
+    path: name,
+    purpose: entry.spec.purpose,
+    minWords: entry.effectiveRubric.minWords ?? 0,
+    forbidSnippets:
+      (entry.effectiveRubric.forbiddenSnippets?.length ?? 0) > 0,
+    // The current validator runs LLM relevance on every text-y top-level
+    // section. We mirror by enabling it whenever a relevance prompt seed
+    // is present on the section.
+    runContentRelevance: !!entry.effectiveRubric.relevancePromptSeed,
+    severityOnFail: entry.effectiveRubric.severityOnFail,
+    fixHint: entry.effectiveRubric.fixHint,
+    contractId: entry.contractId,
+    ownerAgent: entry.ownerAgent,
+    required: entry.effectiveRequired,
+  };
+}
+
+function entryToAgentSection(name: string, entry: ComposedSectionEntry): AdapterAgentSectionRule {
+  // Strip the 'agentSections.' prefix when present; otherwise use the full
+  // section name (so 'architecturalInstructions' carries its own name).
+  const section = name.startsWith('agentSections.')
+    ? name.slice('agentSections.'.length)
+    : name;
+  return {
+    section,
+    purpose: entry.spec.purpose,
+    minWords: entry.effectiveRubric.minWords ?? 0,
+    ...(entry.effectiveRubric.minItemsPerSubField !== undefined && {
+      minItemsPerSubField: entry.effectiveRubric.minItemsPerSubField,
+    }),
+    ...(entry.effectiveRubric.requiredEntityRefs !== undefined && {
+      requiredEntityRefs: entry.effectiveRubric.requiredEntityRefs,
+    }),
+    forbidSnippets: (entry.effectiveRubric.forbiddenSnippets?.length ?? 0) > 0,
+    ...(entry.effectiveRubric.forbiddenSnippets !== undefined && {
+      extraForbiddenSnippets: entry.effectiveRubric.forbiddenSnippets,
+    }),
+    runContentRelevance: !!entry.effectiveRubric.relevancePromptSeed,
+    severityOnFail: entry.effectiveRubric.severityOnFail,
+    fixHint: entry.effectiveRubric.fixHint,
+    required: entry.effectiveRequired,
+    contractId: entry.contractId,
+    ownerAgent: entry.ownerAgent,
+  };
+}
+
+/**
+ * Split a `ComposedTemplate` into top-level vs agent-section rules in
+ * the shape the existing Validator consumes. This is the bridge that
+ * lets ACR-007 Step B flip the Validator over without changing its
+ * scoring logic.
+ */
+export function toValidationRubric(template: ComposedTemplate): AdapterRubric {
+  const topLevelRules: AdapterTopLevelRule[] = [];
+  const agentSectionRules: AdapterAgentSectionRule[] = [];
+  const otherSections: AdapterAgentSectionRule[] = [];
+
+  for (const [name, entry] of template.sections) {
+    if (TOP_LEVEL_PATHS.has(name)) {
+      topLevelRules.push(entryToTopLevel(name, entry));
+    } else if (name.startsWith('agentSections.')) {
+      agentSectionRules.push(entryToAgentSection(name, entry));
+    } else {
+      // Architectural instructions, taxonomy.*, claims, businessOutcome,
+      // testCases, testDesign, etc. — treated as "other" so the Validator
+      // can run rubric checks without confusing them with the legacy
+      // agentSections.<key> structure.
+      otherSections.push(entryToAgentSection(name, entry));
+    }
+  }
+
+  return { topLevelRules, agentSectionRules, otherSections };
+}

--- a/packages/agent-contract-registry/tests/validator-adapter.test.ts
+++ b/packages/agent-contract-registry/tests/validator-adapter.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { SectionContract, SectionSpec } from '@chiefaia/ticket-template';
+import { ContractRegistry, composeTemplate } from '../src';
+import { toValidationRubric } from '../src/validator-adapter';
+
+function spec(name: string, overrides: Partial<SectionSpec> = {}): SectionSpec {
+  return {
+    name,
+    description: `desc ${name}`,
+    purpose: `purpose ${name}`,
+    dataShape: z.object({}).passthrough(),
+    required: true,
+    rubric: {
+      minWords: 20,
+      severityOnFail: 'hard',
+      fixHint: `fix ${name}`,
+      forbiddenSnippets: ['TBD'],
+    },
+    examples: [{ good: {}, bad: {}, badRationale: 'r' }],
+    ...overrides,
+  };
+}
+
+function contract(
+  contractId: string,
+  ownerAgent: SectionContract['ownerAgent'],
+  sections: readonly SectionSpec[],
+): SectionContract {
+  return {
+    ownerAgent,
+    contractId,
+    version: '1.0.0',
+    appliesTo: ['story'],
+    sections,
+  };
+}
+
+describe('toValidationRubric — partition by section path', () => {
+  it('puts top-level paths into topLevelRules', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', [spec('scope'), spec('acceptanceCriteria')]));
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    expect(out.topLevelRules.map((r) => r.path).sort()).toEqual([
+      'acceptanceCriteria',
+      'scope',
+    ]);
+    expect(out.agentSectionRules).toEqual([]);
+    expect(out.otherSections).toEqual([]);
+  });
+
+  it('puts agentSections.* entries into agentSectionRules with stripped prefix', () => {
+    const reg = new ContractRegistry();
+    reg.register(
+      contract('ba', 'ba', [
+        spec('agentSections.api'),
+        spec('agentSections.database'),
+      ]),
+    );
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    expect(out.agentSectionRules.map((r) => r.section).sort()).toEqual([
+      'api',
+      'database',
+    ]);
+    expect(out.topLevelRules).toEqual([]);
+    expect(out.otherSections).toEqual([]);
+  });
+
+  it('puts everything else into otherSections (with full name)', () => {
+    const reg = new ContractRegistry();
+    reg.register(
+      contract('ea', 'ea', [
+        spec('architecturalInstructions'),
+        spec('taxonomy.lifecycle'),
+        spec('claims'),
+      ]),
+    );
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    expect(out.otherSections.map((r) => r.section).sort()).toEqual([
+      'architecturalInstructions',
+      'claims',
+      'taxonomy.lifecycle',
+    ]);
+  });
+});
+
+describe('toValidationRubric — field mapping', () => {
+  it('preserves severityOnFail, fixHint, ownerAgent, contractId', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', [spec('scope', {
+      rubric: { severityOnFail: 'soft', fixHint: 'soften', minWords: 50 },
+    })]));
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    const top = out.topLevelRules[0]!;
+    expect(top.severityOnFail).toBe('soft');
+    expect(top.fixHint).toBe('soften');
+    expect(top.minWords).toBe(50);
+    expect(top.ownerAgent).toBe('po');
+    expect(top.contractId).toBe('po');
+  });
+
+  it('forbidSnippets is true iff forbiddenSnippets has entries', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', [
+      spec('scope'),
+      spec('verificationPlan', {
+        rubric: { severityOnFail: 'soft', fixHint: 'fix', forbiddenSnippets: [] },
+      }),
+    ]));
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    const scope = out.topLevelRules.find((r) => r.path === 'scope')!;
+    const vp = out.topLevelRules.find((r) => r.path === 'verificationPlan')!;
+    expect(scope.forbidSnippets).toBe(true);
+    expect(vp.forbidSnippets).toBe(false);
+  });
+
+  it('runContentRelevance is true iff relevancePromptSeed is set', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', [
+      spec('scope', {
+        rubric: { severityOnFail: 'hard', fixHint: 'fix', relevancePromptSeed: 'seed' },
+      }),
+      spec('context', {
+        rubric: { severityOnFail: 'hard', fixHint: 'fix' },
+      }),
+    ]));
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    expect(out.topLevelRules.find((r) => r.path === 'scope')!.runContentRelevance).toBe(true);
+    expect(out.topLevelRules.find((r) => r.path === 'context')!.runContentRelevance).toBe(false);
+  });
+
+  it('preserves required flag from composition', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('po', 'po', [
+      spec('scope', { required: true }),
+      spec('agentSections.api', { required: false }),
+    ]));
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    expect(out.topLevelRules.find((r) => r.path === 'scope')!.required).toBe(true);
+    expect(out.agentSectionRules.find((r) => r.section === 'api')!.required).toBe(false);
+  });
+
+  it('preserves minItemsPerSubField + requiredEntityRefs on agent sections', () => {
+    const reg = new ContractRegistry();
+    reg.register(contract('ba', 'ba', [spec('agentSections.api', {
+      rubric: {
+        severityOnFail: 'soft',
+        fixHint: 'fix',
+        minWords: 30,
+        minItemsPerSubField: { routes: 1 },
+        requiredEntityRefs: [{ label: 'route', pattern: '/api/' }],
+      },
+    })]));
+    const out = toValidationRubric(composeTemplate('story', { registry: reg }));
+    const api = out.agentSectionRules[0]!;
+    expect(api.minItemsPerSubField).toEqual({ routes: 1 });
+    expect(api.requiredEntityRefs).toEqual([{ label: 'route', pattern: '/api/' }]);
+  });
+});


### PR DESCRIPTION
## ACR-007 Step A — Validator-refactor adapter

Stacked on **#129..#142**.

Step A of the ACR-007 Validator-refactor plan (per architecture report §7). Ships the adapter function that converts a `ComposedTemplate` into the shape the existing Story Validator (`validation-rubric.ts`) consumes. Steps B + C land post-VAL-### merge to avoid double-shipping rubric logic.

### What this PR adds

`packages/agent-contract-registry/src/validator-adapter.ts`:
- `toValidationRubric(template)` → `{ topLevelRules, agentSectionRules, otherSections }`
- `AdapterTopLevelRule` mirrors `validation-rubric.ts`'s `TopLevelSectionRule` for top-level paths (scope, context, acceptanceCriteria, verificationPlan, dependencies)
- `AdapterAgentSectionRule` mirrors `AgentSectionRule` for `agentSections.<key>` sections (prefix stripped)
- `otherSections` is the catch-all bucket — architecturalInstructions, taxonomy.*, claims, businessOutcome, testCases, testDesign

### Field mapping

| Adapter field | Source |
|---|---|
| `severityOnFail` | `spec.rubric.severityOnFail` |
| `fixHint` | `spec.rubric.fixHint` |
| `forbidSnippets` | derived: `forbiddenSnippets.length > 0` |
| `runContentRelevance` | derived: `!!relevancePromptSeed` |
| `required` | composition's `effectiveRequired` (scope-resolved, no more `trigger`) |
| `ownerAgent`, `contractId` | carried through for failure attribution |

### Tests — 8/8 vitest pass (41 total in package)

- partition by section path (top-level vs agentSections.* vs other)
- prefix stripped on conversion
- preserves severity/fixHint/owner/contractId/minWords
- derived forbidSnippets / runContentRelevance
- preserves required flag from composition
- preserves minItemsPerSubField + requiredEntityRefs

### Steps B + C — what's left

- **Step B** — Validator runtime call site flips to consume `toValidationRubric(composeTemplate(scope))` behind a feature flag. Lands AFTER VAL-004 (#115) / VAL-005 (#118) / VAL-009 (#123) merge to `main`.
- **Step C** — hard-coded `TOP_LEVEL_SECTION_RULES` / `AGENT_SECTION_RULES` arrays deleted; only helper functions remain.

This PR is purely additive — no existing code path changes.

Refs: ACR-007 Step A