### PR TITLE
feat(orchestrator): phase 2 worker-pool schema (TASKMGR-001)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0032_story_phase2.sql
+++ b/apps/orchestrator/src/db/migrations/0032_story_phase2.sql
@@ -1,0 +1,60 @@
+-- Migration 0032: TASKMGR-001 — Phase 2 worker-pool columns on stories.
+--
+-- Phase 2 introduces three new agents that pick up validated + test-designed
+-- tickets from the ready-pool (per BUCKET-009): Task Manager assigns tickets
+-- to free Coding Agent workers; Coding Agent claims a worktree, implements
+-- the story per EA's architecturalInstructions and Test-Design's testCases,
+-- opens a PR; Fix-It Test Agent runs the test cases and loops with the
+-- Coding Agent in-session to fix failures until all green.
+--
+-- These columns track the runtime state of every story once it leaves
+-- `ready_for_pickup` and enters the worker pool. They are nullable so they
+-- only populate for stories that actually reach Phase 2 (legacy / pre-Phase-2
+-- rows stay clean).
+--
+-- Companion taxonomy:
+--   phase2_status:
+--     null                  — story has not entered Phase 2 (still pre-pickup
+--                             or legacy); kept null for stories that never reach
+--                             worker pool (e.g., escalated upstream).
+--     coding_in_progress    — Coding Agent has claimed; PR not yet open.
+--     coding_complete       — Coding Agent has opened PR; local unit/integration green.
+--     testing_in_progress   — Fix-It Test Agent running the testCases.
+--     testing_fixing        — mid-fix-loop (one or more retries in flight).
+--     tests_passing         — every testCase green; ready for PR merge.
+--     done                  — PR merged; ticket closed.
+--     escalated             — fix-stuck or coding-stuck blocker filed.
+--
+--   pr_state mirrors GitHub PR lifecycle so the dashboard can surface it
+--   without a network round-trip every render.
+
+ALTER TABLE `stories` ADD COLUMN `assigned_worker_id` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `coding_session_id` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `worktree_path` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `feature_branch` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `pr_number` integer;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `pr_url` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `pr_state` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `last_commit_sha` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `coding_attempts` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `fix_attempts` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `phase2_status` text;
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `phase2_blocker_id` text;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `story_assigned_worker_idx` ON `stories` (`assigned_worker_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_phase2_status_idx` ON `stories` (`phase2_status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `story_pr_state_idx` ON `stories` (`pr_state`);

--- a/apps/orchestrator/src/db/migrations/0033_worker_pool.sql
+++ b/apps/orchestrator/src/db/migrations/0033_worker_pool.sql
@@ -1,0 +1,47 @@
+-- Migration 0033: TASKMGR-001 — worker_pool registry table.
+--
+-- The Task Manager Agent maintains an in-process WorkerPoolRegistry that
+-- mirrors this table. Workers (Coding Agents + Fix-It Test Agents) self-
+-- register on startup, heartbeat every 15s, and emit `worker.released`
+-- when they finish a story. Task Manager's stale-detector sweeps every 30s
+-- and marks workers `crashed` when their last heartbeat is older than 60s.
+--
+-- A separate row exists per worker process. The registry is durable so
+-- that an orchestrator restart can rebuild the in-memory pool (workers
+-- self-re-register on reconnect, but the durable record lets the dashboard
+-- show "last known state" between bounces).
+--
+-- Companion taxonomy:
+--   kind:
+--     'coding'    — Coding Agent worker (apps/worker-coding/)
+--     'fix-it'    — Fix-It Test Agent worker (apps/worker-fix-it/)
+--   status:
+--     'idle'      — registered, no current assignment.
+--     'busy'      — currently working `current_story_id`.
+--     'crashed'   — heartbeat is stale (> 60s); story was requeued.
+--     'released'  — worker explicitly shut down (set on `worker.released`
+--                   for terminal-state workers; useful for debugging).
+--
+--   capabilities is a JSON array of bucket ids the worker is willing to
+--   accept; an empty array means "any bucket" (default).
+
+CREATE TABLE IF NOT EXISTS `worker_pool` (
+  `id` text PRIMARY KEY NOT NULL,
+  `kind` text NOT NULL,
+  `capabilities_json` text NOT NULL DEFAULT '[]',
+  `status` text NOT NULL,
+  `current_story_id` text,
+  `last_heartbeat_at` integer NOT NULL,
+  `registered_at` integer NOT NULL,
+  `released_at` integer,
+  `metadata_json` text NOT NULL DEFAULT '{}'
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `worker_pool_status_idx` ON `worker_pool` (`status`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worker_pool_kind_idx` ON `worker_pool` (`kind`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worker_pool_current_story_idx` ON `worker_pool` (`current_story_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worker_pool_heartbeat_idx` ON `worker_pool` (`last_heartbeat_at`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -218,6 +218,20 @@
       "when": 1778200000000,
       "tag": "0031_story_architectural_instructions",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1778300000000,
+      "tag": "0032_story_phase2",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1778300000001,
+      "tag": "0033_worker_pool",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -446,6 +446,25 @@ export const stories = sqliteTable('stories', {
   // ARCH-006 (migration 0031): EA Agent's per-domain architectural instructions
   architecturalInstructionsJson: text('architectural_instructions_json').notNull().default('[]'),
   eaDecomposedAt: integer('ea_decomposed_at'),
+  // TASKMGR-001 (migration 0032): Phase 2 worker-pool runtime state.
+  // Populated once a story leaves `ready_for_pickup` and enters the worker pool.
+  // assignedWorkerId points at worker_pool.id; codingSessionId is the stable
+  // Claude SDK session id so Fix-It Agent can re-invoke the same warm session
+  // for in-place fixes; worktreePath/featureBranch identify the on-disk state
+  // for the worker; prNumber/prUrl/prState mirror the PR lifecycle so the
+  // dashboard can render without a GitHub round-trip.
+  assignedWorkerId: text('assigned_worker_id'),
+  codingSessionId: text('coding_session_id'),
+  worktreePath: text('worktree_path'),
+  featureBranch: text('feature_branch'),
+  prNumber: integer('pr_number'),
+  prUrl: text('pr_url'),
+  prState: text('pr_state'),                                            // 'draft'|'open'|'merged'|'closed'
+  lastCommitSha: text('last_commit_sha'),
+  codingAttempts: integer('coding_attempts').notNull().default(0),
+  fixAttempts: integer('fix_attempts').notNull().default(0),
+  phase2Status: text('phase2_status'),                                  // 'coding_in_progress'|...|'done'|'escalated'
+  phase2BlockerId: text('phase2_blocker_id'),
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -471,6 +490,10 @@ export const stories = sqliteTable('stories', {
   index('story_feature_classification_idx').on(t.featureClassification),
   // ARCH-006 index (migration 0031)
   index('story_ea_decomposed_idx').on(t.eaDecomposedAt),
+  // TASKMGR-001 indexes (migration 0032)
+  index('story_assigned_worker_idx').on(t.assignedWorkerId),
+  index('story_phase2_status_idx').on(t.phase2Status),
+  index('story_pr_state_idx').on(t.prState),
 ]);
 
 // story_revisions — append-only history of every story-tree edit
@@ -1114,4 +1137,45 @@ export const archExtractRuns = sqliteTable('arch_extract_runs', {
 }, (t) => [
   index('arch_extract_runs_extractor_idx').on(t.extractor),
   index('arch_extract_runs_started_idx').on(t.startedAt),
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// worker_pool — TASKMGR-001 (migration 0033)
+//
+// Durable registry of every Phase 2 worker process (Coding Agent + Fix-It
+// Test Agent). The Task Manager Agent maintains an in-process WorkerPoolRegistry
+// that mirrors this table. Workers self-register on startup, heartbeat every
+// 15s, and emit `worker.released` when finishing a story. Task Manager's
+// stale-detector sweeps every 30s and flips workers to `crashed` when their
+// last_heartbeat_at is older than 60s; the assigned story is requeued.
+//
+// Companion taxonomy:
+//   kind:
+//     'coding'    — Coding Agent worker (apps/worker-coding/)
+//     'fix-it'    — Fix-It Test Agent worker (apps/worker-fix-it/)
+//   status:
+//     'idle'      — registered, no current assignment.
+//     'busy'      — currently working `current_story_id`.
+//     'crashed'   — heartbeat is stale (> 60s); story was requeued.
+//     'released'  — worker explicitly shut down (set on `worker.released`
+//                   for terminal-state workers; useful for debugging).
+//
+//   capabilities is a JSON array of bucket ids the worker is willing to
+//   accept; an empty array means "any bucket" (default).
+// ─────────────────────────────────────────────────────────────────────────────
+export const workerPool = sqliteTable('worker_pool', {
+  id: text('id').primaryKey(),
+  kind: text('kind').notNull(),                                        // 'coding'|'fix-it'
+  capabilitiesJson: text('capabilities_json').notNull().default('[]'),
+  status: text('status').notNull(),                                     // 'idle'|'busy'|'crashed'|'released'
+  currentStoryId: text('current_story_id'),
+  lastHeartbeatAt: integer('last_heartbeat_at').notNull(),
+  registeredAt: integer('registered_at').notNull(),
+  releasedAt: integer('released_at'),
+  metadataJson: text('metadata_json').notNull().default('{}'),
+}, (t) => [
+  index('worker_pool_status_idx').on(t.status),
+  index('worker_pool_kind_idx').on(t.kind),
+  index('worker_pool_current_story_idx').on(t.currentStoryId),
+  index('worker_pool_heartbeat_idx').on(t.lastHeartbeatAt),
 ]);

--- a/apps/orchestrator/tests/db/0032-0033-phase2-worker-pool.test.ts
+++ b/apps/orchestrator/tests/db/0032-0033-phase2-worker-pool.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Migrations 0032 + 0033 smoke tests — TASKMGR-001 Phase 2 worker-pool
+ * runtime state.
+ *
+ * 0032 adds nullable Phase 2 columns to `stories` so worker assignment,
+ * worktree state, PR lifecycle, and retry counters are persisted alongside
+ * the rest of the story. 0033 introduces the `worker_pool` table — durable
+ * registry of every Coding Agent + Fix-It Test Agent process the Task
+ * Manager Agent tracks.
+ *
+ * These tests verify:
+ *   - both migrations apply cleanly to an in-memory DB on top of every
+ *     prior migration (0000..0031, which includes ARCH-006's
+ *     architectural_instructions_json column on stories)
+ *   - the new `stories` columns accept the canonical Phase 2 values
+ *   - `worker_pool` accepts every documented kind/status combination,
+ *     enforces NOT NULL on the heartbeat field, and indexes the columns
+ *     the Task Manager scans every 30s for stale-detection
+ *   - the existing `stories` columns from prior migrations remain
+ *     functional (regression guard against accidental drop/rename)
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq, sql } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, workerPool } from '../../src/db/schema';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function createTestDb() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, sqlite };
+}
+
+function baseStory(id: string, overrides: Partial<Record<string, unknown>> = {}) {
+  const now = Date.now();
+  return {
+    id,
+    title: 'a story',
+    description: '',
+    expectedBehavior: '',
+    acceptanceCriteriaJson: '[]',
+    verificationPlanJson: '[]',
+    dependsOnJson: '[]',
+    domainSlugsJson: '[]',
+    status: 'pending',
+    createdAt: String(now),
+    agentContributionsJson: '{}',
+    templateVersion: 'v1',
+    templateValidationStatus: 'pending',
+    businessSubDomainsJson: '[]',
+    techSubDomainsJson: '[]',
+    qualityTagsJson: '[]',
+    blockedByJson: '[]',
+    softDependsOnJson: '[]',
+    conflictsWithJson: '[]',
+    claimsJson: '{}',
+    inputDependenciesJson: '[]',
+    testCasesJson: '[]',
+    testDesignStatus: 'pending',
+    validationStatus: 'pending',
+    validationAttempts: 0,
+    linksToJson: '[]',
+    architecturalInstructionsJson: '[]',
+    ...overrides,
+  } as const;
+}
+
+describe('migration 0032: stories Phase 2 columns', () => {
+  it('adds the worker-pool columns with the right defaults', () => {
+    const { db } = createTestDb();
+    db.insert(stories).values(baseStory('s_default')).run();
+    const row = db.select().from(stories).where(eq(stories.id, 's_default')).get();
+    expect(row).toBeTruthy();
+    // Nullable columns default to null (no value provided).
+    expect(row!.assignedWorkerId).toBeNull();
+    expect(row!.codingSessionId).toBeNull();
+    expect(row!.worktreePath).toBeNull();
+    expect(row!.featureBranch).toBeNull();
+    expect(row!.prNumber).toBeNull();
+    expect(row!.prUrl).toBeNull();
+    expect(row!.prState).toBeNull();
+    expect(row!.lastCommitSha).toBeNull();
+    expect(row!.phase2Status).toBeNull();
+    expect(row!.phase2BlockerId).toBeNull();
+    // NOT NULL counters default to 0.
+    expect(row!.codingAttempts).toBe(0);
+    expect(row!.fixAttempts).toBe(0);
+  });
+
+  it('accepts the full canonical phase2_status taxonomy', () => {
+    const { db } = createTestDb();
+    const statuses = [
+      'coding_in_progress',
+      'coding_complete',
+      'testing_in_progress',
+      'testing_fixing',
+      'tests_passing',
+      'done',
+      'escalated',
+    ];
+    statuses.forEach((s, i) => {
+      db.insert(stories)
+        .values(baseStory(`s_${i}`, { phase2Status: s }))
+        .run();
+    });
+    const rows = db.select().from(stories).all();
+    expect(rows.map((r) => r.phase2Status).filter(Boolean).sort()).toEqual(statuses.slice().sort());
+  });
+
+  it('accepts the full canonical pr_state taxonomy', () => {
+    const { db } = createTestDb();
+    const prStates = ['draft', 'open', 'merged', 'closed'];
+    prStates.forEach((s, i) => {
+      db.insert(stories)
+        .values(baseStory(`s_pr_${i}`, { prState: s, prNumber: 100 + i, prUrl: `https://github.com/x/y/pull/${100 + i}` }))
+        .run();
+    });
+    const rows = db.select().from(stories).all();
+    expect(rows.map((r) => r.prState).filter(Boolean).sort()).toEqual(prStates.slice().sort());
+  });
+
+  it('persists worktree + sha + counters round-trip', () => {
+    const { db } = createTestDb();
+    db.insert(stories)
+      .values(
+        baseStory('s_full', {
+          assignedWorkerId: 'wkr_abc',
+          codingSessionId: 'sess_xyz',
+          worktreePath: '/Users/MAC/.caia/worktrees/s_full',
+          featureBranch: 'feat/s_full-add-leaderboard',
+          prNumber: 482,
+          prUrl: 'https://github.com/prakashgbid/caia/pull/482',
+          prState: 'open',
+          lastCommitSha: 'abcd1234',
+          codingAttempts: 1,
+          fixAttempts: 3,
+          phase2Status: 'testing_fixing',
+        }),
+      )
+      .run();
+    const row = db.select().from(stories).where(eq(stories.id, 's_full')).get();
+    expect(row!.assignedWorkerId).toBe('wkr_abc');
+    expect(row!.codingSessionId).toBe('sess_xyz');
+    expect(row!.worktreePath).toBe('/Users/MAC/.caia/worktrees/s_full');
+    expect(row!.featureBranch).toBe('feat/s_full-add-leaderboard');
+    expect(row!.prNumber).toBe(482);
+    expect(row!.prUrl).toBe('https://github.com/prakashgbid/caia/pull/482');
+    expect(row!.prState).toBe('open');
+    expect(row!.lastCommitSha).toBe('abcd1234');
+    expect(row!.codingAttempts).toBe(1);
+    expect(row!.fixAttempts).toBe(3);
+    expect(row!.phase2Status).toBe('testing_fixing');
+  });
+
+  it('creates the Task-Manager-critical indexes', () => {
+    const { db } = createTestDb();
+    const indexes = db.all(sql`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND tbl_name='stories'
+    `) as Array<{ name: string }>;
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain('story_assigned_worker_idx');
+    expect(names).toContain('story_phase2_status_idx');
+    expect(names).toContain('story_pr_state_idx');
+  });
+
+  it('regression guard — pre-Phase-2 columns still exist (FREG-006 + ARCH-006)', () => {
+    const { db } = createTestDb();
+    db.insert(stories)
+      .values(
+        baseStory('s_regression', {
+          // FREG-006 columns (0029)
+          featureClassification: 'enhance',
+          featureClassificationScore: 0.91,
+          featureClassificationAt: Date.now(),
+          // ARCH-006 columns (0031)
+          architecturalInstructionsJson: JSON.stringify([
+            { domain: 'frontend', kind: 'reuse', artifactId: 'arch_x' },
+          ]),
+          eaDecomposedAt: Date.now(),
+        }),
+      )
+      .run();
+    const row = db.select().from(stories).where(eq(stories.id, 's_regression')).get();
+    expect(row!.featureClassification).toBe('enhance');
+    expect(row!.featureClassificationScore).toBeCloseTo(0.91, 2);
+    expect(typeof row!.featureClassificationAt).toBe('number');
+    expect(JSON.parse(row!.architecturalInstructionsJson)).toEqual([
+      { domain: 'frontend', kind: 'reuse', artifactId: 'arch_x' },
+    ]);
+    expect(typeof row!.eaDecomposedAt).toBe('number');
+  });
+});
+
+describe('migration 0033: worker_pool registry', () => {
+  function workerRow(overrides: Partial<Record<string, unknown>> = {}) {
+    const now = Date.now();
+    return {
+      id: 'wkr_default',
+      kind: 'coding',
+      capabilitiesJson: '[]',
+      status: 'idle',
+      currentStoryId: null,
+      lastHeartbeatAt: now,
+      registeredAt: now,
+      releasedAt: null,
+      metadataJson: '{}',
+      ...overrides,
+    } as const;
+  }
+
+  it('inserts and reads back a worker row with the documented defaults', () => {
+    const { db } = createTestDb();
+    db.insert(workerPool).values(workerRow()).run();
+    const row = db.select().from(workerPool).where(eq(workerPool.id, 'wkr_default')).get();
+    expect(row).toBeTruthy();
+    expect(row!.kind).toBe('coding');
+    expect(row!.status).toBe('idle');
+    expect(row!.capabilitiesJson).toBe('[]');
+    expect(row!.metadataJson).toBe('{}');
+    expect(row!.currentStoryId).toBeNull();
+    expect(row!.releasedAt).toBeNull();
+    expect(typeof row!.registeredAt).toBe('number');
+    expect(typeof row!.lastHeartbeatAt).toBe('number');
+  });
+
+  it('accepts both worker kinds (coding, fix-it)', () => {
+    const { db } = createTestDb();
+    db.insert(workerPool).values(workerRow({ id: 'wkr_a', kind: 'coding' })).run();
+    db.insert(workerPool).values(workerRow({ id: 'wkr_b', kind: 'fix-it' })).run();
+    const rows = db.select().from(workerPool).all();
+    expect(rows.map((r) => r.kind).sort()).toEqual(['coding', 'fix-it']);
+  });
+
+  it('accepts the full canonical status taxonomy', () => {
+    const { db } = createTestDb();
+    const statuses = ['idle', 'busy', 'crashed', 'released'];
+    statuses.forEach((s, i) => {
+      db.insert(workerPool).values(workerRow({ id: `wkr_${i}`, status: s })).run();
+    });
+    const rows = db.select().from(workerPool).all();
+    expect(rows.map((r) => r.status).sort()).toEqual(statuses.slice().sort());
+  });
+
+  it('persists current_story_id when busy and clears it when idle', () => {
+    const { db } = createTestDb();
+    db.insert(workerPool)
+      .values(workerRow({ id: 'wkr_busy', status: 'busy', currentStoryId: 'story-xyz' }))
+      .run();
+    db.insert(workerPool)
+      .values(workerRow({ id: 'wkr_idle', status: 'idle', currentStoryId: null }))
+      .run();
+    const busy = db.select().from(workerPool).where(eq(workerPool.id, 'wkr_busy')).get();
+    const idle = db.select().from(workerPool).where(eq(workerPool.id, 'wkr_idle')).get();
+    expect(busy!.currentStoryId).toBe('story-xyz');
+    expect(idle!.currentStoryId).toBeNull();
+  });
+
+  it('persists capabilities + metadata as JSON strings', () => {
+    const { db } = createTestDb();
+    db.insert(workerPool)
+      .values(
+        workerRow({
+          id: 'wkr_caps',
+          capabilitiesJson: JSON.stringify(['bkt_a', 'bkt_b']),
+          metadataJson: JSON.stringify({ hostname: 'mac', pid: 1234, version: '1.0.0' }),
+        }),
+      )
+      .run();
+    const row = db.select().from(workerPool).where(eq(workerPool.id, 'wkr_caps')).get();
+    expect(JSON.parse(row!.capabilitiesJson)).toEqual(['bkt_a', 'bkt_b']);
+    expect(JSON.parse(row!.metadataJson)).toEqual({ hostname: 'mac', pid: 1234, version: '1.0.0' });
+  });
+
+  it('enforces NOT NULL on the heartbeat (stale-detector relies on it)', () => {
+    const { db } = createTestDb();
+    expect(() =>
+      db
+        .insert(workerPool)
+        .values(workerRow({ id: 'wkr_no_hb', lastHeartbeatAt: null as unknown as number }))
+        .run(),
+    ).toThrow(/NOT NULL/i);
+  });
+
+  it('creates the Task-Manager-critical indexes (status, kind, current_story, heartbeat)', () => {
+    const { db } = createTestDb();
+    const indexes = db.all(sql`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND tbl_name='worker_pool'
+    `) as Array<{ name: string }>;
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain('worker_pool_status_idx');
+    expect(names).toContain('worker_pool_kind_idx');
+    expect(names).toContain('worker_pool_current_story_idx');
+    expect(names).toContain('worker_pool_heartbeat_idx');
+  });
+
+  it('id is a primary key (no duplicate worker rows)', () => {
+    const { db } = createTestDb();
+    db.insert(workerPool).values(workerRow({ id: 'wkr_pk' })).run();
+    expect(() => db.insert(workerPool).values(workerRow({ id: 'wkr_pk' })).run()).toThrow(/UNIQUE|PRIMARY/i);
+  });
+
+  it('records released_at when worker explicitly shuts down', () => {
+    const { db } = createTestDb();
+    const now = Date.now();
+    db.insert(workerPool)
+      .values(workerRow({ id: 'wkr_released', status: 'released', releasedAt: now }))
+      .run();
+    const row = db.select().from(workerPool).where(eq(workerPool.id, 'wkr_released')).get();
+    expect(row!.releasedAt).toBe(now);
+  });
+});


### PR DESCRIPTION
## Phase 2 — TASKMGR-001 (foundational migrations)

First PR in the **Phase 2 — every remaining agent + fix-it test loop + E2E pipeline** track per the directive at `~/Library/Application Support/Claude/local-agent-mode-sessions/.../agent/memory/phase2_completion_directive.md`.

The Phase 2A spec doc lives at `~/Documents/projects/reports/phase2-completion-architecture-2026-04-28.md` — read that first for the full picture (31-PR plan, inter-agent protocol, Fix-It loop design).

## What this PR ships

**Migration 0032** — adds 12 nullable Phase 2 columns to `stories` (assigned_worker_id, coding_session_id, worktree_path, feature_branch, pr_number, pr_url, pr_state, last_commit_sha, coding_attempts, fix_attempts, phase2_status, phase2_blocker_id). Plus 3 indexes on `assigned_worker_id`, `phase2_status`, `pr_state`.

**Migration 0033** — new `worker_pool` table — durable registry of every Phase 2 worker process. Task Manager Agent maintains an in-process `WorkerPoolRegistry` mirroring this; workers self-register on startup, heartbeat every 15s, emit `worker.released` on completion. Stale-detector flips workers to `crashed` when `last_heartbeat_at` > 60s. Plus 4 indexes on `status`, `kind`, `current_story_id`, `last_heartbeat_at`.

**Schema (drizzle):** new `workerPool` table export + the 12 new fields on the existing `stories` table.

**Tests:** 15 jest cases across 2 `describe` blocks in `tests/db/0032-0033-phase2-worker-pool.test.ts`. Roundtrips defaults, every taxonomy enum value, NOT NULL on heartbeat, the 7 critical indexes, and a regression guard for FREG-006 + ARCH-006 columns. All 15 pass.

## Why first?

Every subsequent TASKMGR / CODING / FIX PR depends on these tables — no Task Manager assignment without a worker pool, no Coding Agent without somewhere to record the worktree path, no Fix-It loop without somewhere to count attempts. Ships them first so the rest of Phase 2 has a stable foundation.

## DoD

- [x] Migrations 0032 + 0033 committed
- [x] Drizzle schema updated to match
- [x] 15 jest cases all green (`./node_modules/.bin/jest tests/db/0032-0033-phase2-worker-pool.test.ts`)
- [x] No regressions on prior-migration columns (regression guard test covers 0029 + 0031)
- [x] Architecture report covering this PR + the 30 to follow at `~/Documents/projects/reports/phase2-completion-architecture-2026-04-28.md`
- [x] PR opened against `main` with this body

## Coordination

- Migration numbering picks up from 0031 (ARCH-006). No further conflicts expected.
- ACR-001..006 (open) extend `stories` with `story_scope` — additive; rebase straightforward.
- This PR does NOT touch any agent code; that lands in TASKMGR-002 onwards.