### PR TITLE
feat(orchestrator,events): backpressure monitor (TASKMGR-004)

### DIFF
--- a/apps/orchestrator/src/agents/backpressure-monitor.ts
+++ b/apps/orchestrator/src/agents/backpressure-monitor.ts
@@ -1,0 +1,175 @@
+/**
+ * BackpressureMonitor — TASKMGR-004 (Phase 2)
+ *
+ * Watches ready-pool depth per bucket and emits backpressure events when
+ * a bucket's queue grows past the configured ceiling. PO Agent
+ * subscribes to these events and pauses new prompt creation for affected
+ * buckets (deferring to `prompts.status='deferred_backpressure'`) until
+ * the queue drains below the release threshold (ceiling - hysteresis).
+ *
+ * Why hysteresis: prevents flapping when the queue depth oscillates
+ * around the ceiling. Default ceiling=25, hysteresis=5 ⇒ engage at
+ * depth ≥25, release at depth ≤20. PO Agent only sees a fresh event
+ * when the bucket actually transitions states.
+ *
+ * The monitor itself is purely event-driven — it does not poll. Callers
+ * invoke `checkBucket(bucketId)` after every story placement +
+ * completion. Both events change the depth.
+ *
+ * @owner task-manager (Phase 2 worker-pool track)
+ */
+
+import { eq, and, isNull } from 'drizzle-orm';
+import type { Db } from '../db/connection';
+import { stories } from '../db/schema';
+import { eventBus } from '../events/bus-adapter';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface BackpressureOptions {
+  /** Queue depth at which backpressure engages. Default 25. */
+  ceiling?: number;
+  /** Hysteresis: release threshold = ceiling - hysteresis. Default 5. */
+  hysteresis?: number;
+  /** Skip event emission entirely (unit tests that don't wire bus). */
+  silent?: boolean;
+  /** Override for Date.now() in tests. */
+  now?: () => number;
+}
+
+export interface BackpressureSnapshot {
+  bucketId: string;
+  queueDepth: number;
+  engaged: boolean;
+  ceiling: number;
+  hysteresis: number;
+}
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class BackpressureMonitor {
+  private readonly db: Db;
+  private readonly ceiling: number;
+  private readonly hysteresis: number;
+  private readonly silent: boolean;
+  private readonly now: () => number;
+  /** Buckets currently under backpressure (engaged events emitted). */
+  private engaged = new Set<string>();
+
+  constructor(db: Db, opts: BackpressureOptions = {}) {
+    this.db = db;
+    this.ceiling = opts.ceiling ?? 25;
+    this.hysteresis = opts.hysteresis ?? 5;
+    this.silent = opts.silent ?? false;
+    this.now = opts.now ?? Date.now;
+    if (this.ceiling <= 0) {
+      throw new Error(`BackpressureMonitor: ceiling must be > 0 (got ${this.ceiling})`);
+    }
+    if (this.hysteresis < 0 || this.hysteresis >= this.ceiling) {
+      throw new Error(
+        `BackpressureMonitor: hysteresis must be in [0, ceiling) (got ${this.hysteresis} with ceiling ${this.ceiling})`,
+      );
+    }
+  }
+
+  // ─── Snapshots ────────────────────────────────────────────────────────────
+
+  /**
+   * Returns the current queue depth for a bucket. Counts stories that are:
+   *   - bucket_id = the requested bucket
+   *   - status = 'pending'
+   *   - assigned_worker_id IS NULL (not yet picked up by a worker)
+   * This is the same set ReadyPoolConsumer.pump() considers, scoped per bucket.
+   */
+  depth(bucketId: string): number {
+    const rows = this.db
+      .select({ id: stories.id })
+      .from(stories)
+      .where(
+        and(
+          eq(stories.bucketId, bucketId),
+          eq(stories.status, 'pending'),
+          isNull(stories.assignedWorkerId),
+        ),
+      )
+      .all();
+    return rows.length;
+  }
+
+  /** Returns whether the bucket is currently engaged + the depth + thresholds. */
+  snapshot(bucketId: string): BackpressureSnapshot {
+    return {
+      bucketId,
+      queueDepth: this.depth(bucketId),
+      engaged: this.engaged.has(bucketId),
+      ceiling: this.ceiling,
+      hysteresis: this.hysteresis,
+    };
+  }
+
+  /** Returns all currently-engaged bucket ids. Useful for the dashboard. */
+  listEngaged(): string[] {
+    return [...this.engaged];
+  }
+
+  // ─── Mutations ────────────────────────────────────────────────────────────
+
+  /**
+   * Re-evaluates a single bucket's pressure and emits transition events
+   * if the engaged-state changes. Idempotent — calling twice with the
+   * same depth does NOT re-emit. Returns the post-check snapshot.
+   *
+   * Should be called after every event that changes a bucket's queue
+   * depth (story placement, story completion, story reassignment).
+   */
+  checkBucket(bucketId: string): BackpressureSnapshot {
+    const depth = this.depth(bucketId);
+    const releaseAt = this.ceiling - this.hysteresis;
+    const isEngaged = this.engaged.has(bucketId);
+    if (depth >= this.ceiling && !isEngaged) {
+      this.engaged.add(bucketId);
+      this.emit('task-scheduler.backpressure.engaged', {
+        bucketId,
+        queueDepth: depth,
+        ceiling: this.ceiling,
+        ts: this.now(),
+      });
+    } else if (depth <= releaseAt && isEngaged) {
+      this.engaged.delete(bucketId);
+      this.emit('task-scheduler.backpressure.released', {
+        bucketId,
+        queueDepth: depth,
+        ts: this.now(),
+      });
+    }
+    return this.snapshot(bucketId);
+  }
+
+  /**
+   * Re-evaluates every bucket that currently has stories. Useful on
+   * orchestrator startup to rebuild the engaged-set after a restart.
+   */
+  checkAll(): BackpressureSnapshot[] {
+    const distinct = this.db
+      .selectDistinct({ bucketId: stories.bucketId })
+      .from(stories)
+      .where(and(eq(stories.status, 'pending'), isNull(stories.assignedWorkerId)))
+      .all()
+      .map((r) => r.bucketId)
+      .filter((b): b is string => !!b);
+    return distinct.map((b) => this.checkBucket(b));
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private emit(type: string, payload: Record<string, unknown>): void {
+    if (this.silent) return;
+    eventBus.publish({
+      type: type as never,
+      actor: 'task-scheduler',
+      entity_type: 'bucket',
+      entity_id: payload.bucketId as string,
+      payload,
+    });
+  }
+}

--- a/apps/orchestrator/tests/agents/backpressure-monitor.test.ts
+++ b/apps/orchestrator/tests/agents/backpressure-monitor.test.ts
@@ -1,0 +1,211 @@
+/**
+ * BackpressureMonitor — TASKMGR-004 unit tests.
+ *
+ * Verifies the engage/release transitions, hysteresis behaviour,
+ * idempotency, and the listEngaged + checkAll helpers.
+ *
+ * 11 cases.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, taskBuckets, prompts } from '../../src/db/schema';
+import { BackpressureMonitor } from '../../src/agents/backpressure-monitor';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup(opts: { ceiling?: number; hysteresis?: number } = {}) {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  const monitor = new BackpressureMonitor(db, { silent: true, ...opts });
+  db.insert(prompts).values({
+    id: 'p_test',
+    body: 'test',
+    receivedAt: new Date().toISOString(),
+    correlationId: 'corr_test',
+    hash: 'h_test',
+  }).run();
+  for (const bid of ['bkt_a', 'bkt_b', 'bkt_c']) {
+    db.insert(taskBuckets).values({
+      id: bid,
+      kind: 'parallel',
+      promptId: 'p_test',
+      createdAt: Date.now(),
+      status: 'open',
+    }).run();
+  }
+  return { db, monitor };
+}
+
+function fillBucket(
+  db: ReturnType<typeof setup>['db'],
+  bucketId: string,
+  count: number,
+  startIdx = 0,
+) {
+  const now = Date.now();
+  for (let i = 0; i < count; i++) {
+    db.insert(stories)
+      .values({
+        id: `s_${bucketId}_${startIdx + i}`,
+        title: `s${i}`,
+        description: '',
+        expectedBehavior: '',
+        acceptanceCriteriaJson: '[]',
+        verificationPlanJson: '[]',
+        dependsOnJson: '[]',
+        domainSlugsJson: '[]',
+        status: 'pending',
+        createdAt: String(now),
+        agentContributionsJson: '{}',
+        templateVersion: 'v1',
+        templateValidationStatus: 'pending',
+        businessSubDomainsJson: '[]',
+        techSubDomainsJson: '[]',
+        qualityTagsJson: '[]',
+        blockedByJson: '[]',
+        softDependsOnJson: '[]',
+        conflictsWithJson: '[]',
+        claimsJson: '{}',
+        inputDependenciesJson: '[]',
+        testCasesJson: '[]',
+        testDesignStatus: 'pending',
+        validationStatus: 'pending',
+        validationAttempts: 0,
+        linksToJson: '[]',
+        architecturalInstructionsJson: '[]',
+        bucketId,
+      })
+      .run();
+  }
+}
+
+describe('BackpressureMonitor — construction', () => {
+  it('rejects ceiling <= 0', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema });
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+    expect(() => new BackpressureMonitor(db, { ceiling: 0 })).toThrow(/ceiling/);
+  });
+
+  it('rejects hysteresis >= ceiling', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema });
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+    expect(() => new BackpressureMonitor(db, { ceiling: 10, hysteresis: 10 })).toThrow(/hysteresis/);
+  });
+});
+
+describe('BackpressureMonitor — depth + snapshot', () => {
+  it('counts only pending + unassigned stories per bucket', () => {
+    const { db, monitor } = setup();
+    fillBucket(db, 'bkt_a', 5);
+    fillBucket(db, 'bkt_b', 3);
+    expect(monitor.depth('bkt_a')).toBe(5);
+    expect(monitor.depth('bkt_b')).toBe(3);
+    expect(monitor.depth('bkt_unknown')).toBe(0);
+  });
+
+  it('snapshot returns depth + thresholds + engaged state', () => {
+    const { db, monitor } = setup({ ceiling: 5, hysteresis: 2 });
+    fillBucket(db, 'bkt_a', 3);
+    const snap = monitor.snapshot('bkt_a');
+    expect(snap).toEqual({
+      bucketId: 'bkt_a',
+      queueDepth: 3,
+      engaged: false,
+      ceiling: 5,
+      hysteresis: 2,
+    });
+  });
+});
+
+describe('BackpressureMonitor — engage/release transitions', () => {
+  it('engages when depth crosses ceiling', () => {
+    const { db, monitor } = setup({ ceiling: 5, hysteresis: 2 });
+    fillBucket(db, 'bkt_a', 4);
+    let snap = monitor.checkBucket('bkt_a');
+    expect(snap.engaged).toBe(false);
+    fillBucket(db, 'bkt_a', 1, 4);  // depth = 5
+    snap = monitor.checkBucket('bkt_a');
+    expect(snap.engaged).toBe(true);
+  });
+
+  it('does NOT release until depth drops to ceiling-hysteresis (4 with c=5,h=2 → release at 3)', () => {
+    const { db, monitor } = setup({ ceiling: 5, hysteresis: 2 });
+    fillBucket(db, 'bkt_a', 5);
+    monitor.checkBucket('bkt_a');             // engaged
+    // Drop to 4 (above release threshold of 3) — should still be engaged
+    db.delete(stories).where(undefined as never).run = undefined as never;  // noop guard
+    // remove one story by calling delete directly
+    const sqliteDb = (db as unknown as { $client: { exec: (s: string) => void } }).$client;
+    sqliteDb.exec(`DELETE FROM stories WHERE id='s_bkt_a_4'`);
+    expect(monitor.depth('bkt_a')).toBe(4);
+    let snap = monitor.checkBucket('bkt_a');
+    expect(snap.engaged).toBe(true);
+    // Drop to 3 — release threshold met
+    sqliteDb.exec(`DELETE FROM stories WHERE id='s_bkt_a_3'`);
+    expect(monitor.depth('bkt_a')).toBe(3);
+    snap = monitor.checkBucket('bkt_a');
+    expect(snap.engaged).toBe(false);
+  });
+
+  it('engaging is idempotent — second checkBucket at same depth does not re-emit', () => {
+    const { db, monitor } = setup({ ceiling: 5, hysteresis: 2 });
+    fillBucket(db, 'bkt_a', 5);
+    monitor.checkBucket('bkt_a');
+    const before = monitor.listEngaged().length;
+    monitor.checkBucket('bkt_a');
+    monitor.checkBucket('bkt_a');
+    expect(monitor.listEngaged().length).toBe(before);
+  });
+
+  it('listEngaged tracks multiple buckets', () => {
+    const { db, monitor } = setup({ ceiling: 3, hysteresis: 1 });
+    fillBucket(db, 'bkt_a', 3);
+    fillBucket(db, 'bkt_b', 3);
+    fillBucket(db, 'bkt_c', 1);
+    monitor.checkBucket('bkt_a');
+    monitor.checkBucket('bkt_b');
+    monitor.checkBucket('bkt_c');
+    expect(monitor.listEngaged().sort()).toEqual(['bkt_a', 'bkt_b']);
+  });
+});
+
+describe('BackpressureMonitor — checkAll', () => {
+  it('discovers and checks every bucket with pending stories', () => {
+    const { db, monitor } = setup({ ceiling: 3, hysteresis: 1 });
+    fillBucket(db, 'bkt_a', 3);
+    fillBucket(db, 'bkt_b', 3);
+    fillBucket(db, 'bkt_c', 1);
+    const snaps = monitor.checkAll();
+    expect(snaps.find((s) => s.bucketId === 'bkt_a')!.engaged).toBe(true);
+    expect(snaps.find((s) => s.bucketId === 'bkt_b')!.engaged).toBe(true);
+    expect(snaps.find((s) => s.bucketId === 'bkt_c')!.engaged).toBe(false);
+    expect(monitor.listEngaged().sort()).toEqual(['bkt_a', 'bkt_b']);
+  });
+
+  it('returns empty when no buckets have pending stories', () => {
+    const { monitor } = setup();
+    expect(monitor.checkAll()).toEqual([]);
+  });
+});
+
+describe('BackpressureMonitor — assigned stories drop out of depth', () => {
+  it('a story flipped to assigned no longer counts', () => {
+    const { db, monitor } = setup({ ceiling: 5, hysteresis: 2 });
+    fillBucket(db, 'bkt_a', 5);
+    monitor.checkBucket('bkt_a');
+    expect(monitor.listEngaged()).toEqual(['bkt_a']);
+    // simulate one story getting picked up
+    const sqliteDb = (db as unknown as { $client: { exec: (s: string) => void } }).$client;
+    sqliteDb.exec(`UPDATE stories SET assigned_worker_id='wkr_x' WHERE id='s_bkt_a_4'`);
+    expect(monitor.depth('bkt_a')).toBe(4);
+    monitor.checkBucket('bkt_a');
+    expect(monitor.listEngaged()).toEqual(['bkt_a']);  // still above release threshold
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -451,6 +451,9 @@ export type EventType =
   | 'worker.crashed'
   // ─── Phase 2 task assignment (TASKMGR-003) ────────────────────────────────
   | 'task.assigned'
+  // ─── Phase 2 backpressure (TASKMGR-004) ───────────────────────────────────
+  | 'task-scheduler.backpressure.engaged'
+  | 'task-scheduler.backpressure.released'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -565,6 +568,9 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'worker.crashed': 'error',
   // ─── Phase 2 task assignment (TASKMGR-003) ────────────────────────────────
   'task.assigned': 'info',
+  // ─── Phase 2 backpressure (TASKMGR-004) ───────────────────────────────────
+  'task-scheduler.backpressure.engaged': 'warning',
+  'task-scheduler.backpressure.released': 'info',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -546,3 +546,14 @@ events:
     severity: info
     actor: [task-scheduler]
     payload: [storyId, workerId, bucketId, assignedAt, correlationId]
+
+  # Phase 2 backpressure (TASKMGR-004)
+  - type: task-scheduler.backpressure.engaged
+    severity: warning
+    actor: [task-scheduler]
+    payload: [bucketId, queueDepth, ceiling, ts]
+
+  - type: task-scheduler.backpressure.released
+    severity: info
+    actor: [task-scheduler]
+    payload: [bucketId, queueDepth, ts]


### PR DESCRIPTION
## Phase 2 — TASKMGR-004 (backpressure monitor)

Fourth PR in the Phase 2 Task Manager track. Builds on TASKMGR-001..003 (all merged).

## What this PR ships

**2 new event types:**
| Event | Severity | Actor | Payload |
|---|---|---|---|
| `task-scheduler.backpressure.engaged` | warning | task-scheduler | bucketId, queueDepth, ceiling, ts |
| `task-scheduler.backpressure.released` | info | task-scheduler | bucketId, queueDepth, ts |

**`BackpressureMonitor` class** at `apps/orchestrator/src/agents/backpressure-monitor.ts`. Per-bucket queue-depth watcher with hysteresis to prevent flapping.

- **Default thresholds:** ceiling=25, hysteresis=5 → engage at depth ≥25, release at depth ≤20.
- **Validation:** rejects ceiling≤0 or hysteresis≥ceiling at construction.
- **API:** `depth(bucketId)`, `snapshot(bucketId)`, `listEngaged()`, `checkBucket(bucketId)`, `checkAll()`.
- **Counted set:** `stories WHERE bucket_id=X AND status='pending' AND assigned_worker_id IS NULL` (same set ReadyPoolConsumer.pump considers, scoped per bucket).
- **Idempotency:** same depth on successive checks does NOT re-emit.

**Wiring (future):** PO Agent subscribes to engaged/released events and pauses new prompt creation per affected bucket. That wiring lands in TASKMGR-007.

## Tests

11 jest cases in `tests/agents/backpressure-monitor.test.ts` across 5 `describe` blocks. All green.

## Coordination

- TASKMGR-005 (HealthMetricsEmitter) reads `monitor.snapshot()` per bucket every 60s.
- TASKMGR-007 (`wirePhase2()`) hooks the monitor into the bucket-placer + ready-pool-consumer pipeline.