### PR TITLE
feat(orchestrator,events): bucket health metrics emitter (TASKMGR-005)

### DIFF
--- a/apps/orchestrator/src/agents/health-metrics-emitter.ts
+++ b/apps/orchestrator/src/agents/health-metrics-emitter.ts
@@ -1,0 +1,250 @@
+/**
+ * HealthMetricsEmitter — TASKMGR-005 (Phase 2)
+ *
+ * Periodically (default every 60 s) computes per-bucket health metrics
+ * and writes them to `bucket_health_history` (migration 0034) so the
+ * `/workers` dashboard can render sparklines + per-bucket cards. Also
+ * emits `task-scheduler.bucket.health` for in-process subscribers (e.g.
+ * the WS gateway) that want a real-time push.
+ *
+ * Metrics per bucket:
+ *   queueDepth           — count of stories where bucket_id=X AND
+ *                          status='pending' AND assigned_worker_id IS NULL.
+ *   throughputPerHour    — count of `task.tested_and_done` events whose
+ *                          payload.storyId belongs to bucket X over the
+ *                          last hour, projected to /hr.
+ *   oldestReadyAgeS      — age in seconds of the oldest unassigned ready
+ *                          story in this bucket (NULL if no ready stories).
+ *   workersAssigned      — count of workers whose currentStoryId points at
+ *                          a story in this bucket.
+ *   engaged              — boolean, mirrors BackpressureMonitor state.
+ *
+ * The emitter is start/stop-controlled (start the interval, stop on
+ * shutdown). Tests use the `emitOnce()` entry point to skip the timer.
+ *
+ * @owner task-manager (Phase 2 worker-pool track)
+ */
+
+import { eq, and, isNull, gte, sql, asc } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+import type { Db } from '../db/connection';
+import { stories, workerPool, bucketHealthHistory, events } from '../db/schema';
+import { eventBus } from '../events/bus-adapter';
+import type { BackpressureMonitor } from './backpressure-monitor';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface HealthMetric {
+  bucketId: string;
+  queueDepth: number;
+  throughputPerHour: number;
+  oldestReadyAgeS: number | null;
+  workersAssigned: number;
+  engaged: boolean;
+  ts: number;
+}
+
+export interface EmitterOptions {
+  /** Tick interval in ms. Default 60_000. */
+  intervalMs?: number;
+  /** Skip event emission entirely (unit tests that don't wire bus). */
+  silent?: boolean;
+  /** Override for Date.now() in tests. */
+  now?: () => number;
+  /** Optional BackpressureMonitor; if provided, `engaged` reflects it. */
+  backpressureMonitor?: Pick<BackpressureMonitor, 'listEngaged'>;
+}
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class HealthMetricsEmitter {
+  private readonly db: Db;
+  private readonly intervalMs: number;
+  private readonly silent: boolean;
+  private readonly now: () => number;
+  private readonly backpressure?: Pick<BackpressureMonitor, 'listEngaged'>;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(db: Db, opts: EmitterOptions = {}) {
+    this.db = db;
+    this.intervalMs = opts.intervalMs ?? 60_000;
+    this.silent = opts.silent ?? false;
+    this.now = opts.now ?? Date.now;
+    this.backpressure = opts.backpressureMonitor;
+  }
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+  /** Starts the periodic emission timer. Idempotent — calling twice is a no-op. */
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.emitOnce();
+    }, this.intervalMs);
+    // Don't keep the event loop alive just for this timer.
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  /** Stops the periodic emission timer. Idempotent. */
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  // ─── Core ─────────────────────────────────────────────────────────────────
+
+  /** Computes all bucket metrics, writes one history row per bucket, emits one event per bucket. */
+  emitOnce(): HealthMetric[] {
+    const buckets = this.discoverBuckets();
+    const metrics: HealthMetric[] = [];
+    const engagedSet = new Set(this.backpressure?.listEngaged() ?? []);
+    const ts = this.now();
+    for (const bucketId of buckets) {
+      const m = this.computeMetric(bucketId, ts, engagedSet);
+      metrics.push(m);
+      this.persist(m);
+      this.emit(m);
+    }
+    return metrics;
+  }
+
+  // ─── Aggregations ─────────────────────────────────────────────────────────
+
+  private discoverBuckets(): string[] {
+    // Buckets that have ANY in-pipeline story (pending or already assigned).
+    // Filters out NULL bucket_id rows (legacy / pre-BUCKET-001 stories).
+    const rows = this.db
+      .selectDistinct({ bucketId: stories.bucketId })
+      .from(stories)
+      .all();
+    return rows
+      .map((r) => r.bucketId)
+      .filter((b): b is string => !!b);
+  }
+
+  private computeMetric(bucketId: string, ts: number, engagedSet: Set<string>): HealthMetric {
+    const queueDepth = this.queueDepthFor(bucketId);
+    const throughputPerHour = this.throughputPerHourFor(bucketId, ts);
+    const oldestReadyAgeS = this.oldestReadyAgeSecFor(bucketId, ts);
+    const workersAssigned = this.workersAssignedFor(bucketId);
+    return {
+      bucketId,
+      queueDepth,
+      throughputPerHour,
+      oldestReadyAgeS,
+      workersAssigned,
+      engaged: engagedSet.has(bucketId),
+      ts,
+    };
+  }
+
+  private queueDepthFor(bucketId: string): number {
+    return this.db
+      .select({ id: stories.id })
+      .from(stories)
+      .where(
+        and(
+          eq(stories.bucketId, bucketId),
+          eq(stories.status, 'pending'),
+          isNull(stories.assignedWorkerId),
+        ),
+      )
+      .all().length;
+  }
+
+  /**
+   * Counts task.tested_and_done events for stories in this bucket over
+   * the last hour. We join to the stories table on entity_id (the event
+   * payload sets entity_id=storyId per the Phase 2A spec).
+   */
+  private throughputPerHourFor(bucketId: string, ts: number): number {
+    const oneHourAgoIso = new Date(ts - 60 * 60 * 1000).toISOString();
+    const rows = this.db
+      .select({ storyId: stories.id })
+      .from(events)
+      .innerJoin(stories, eq(events.entityId, stories.id))
+      .where(
+        and(
+          eq(events.type, 'task.tested_and_done'),
+          eq(stories.bucketId, bucketId),
+          gte(events.occurredAt, oneHourAgoIso),
+        ),
+      )
+      .all();
+    return rows.length;  // already a per-hour count (window is 1h)
+  }
+
+  private oldestReadyAgeSecFor(bucketId: string, ts: number): number | null {
+    const oldest = this.db
+      .select({ createdAt: stories.createdAt })
+      .from(stories)
+      .where(
+        and(
+          eq(stories.bucketId, bucketId),
+          eq(stories.status, 'pending'),
+          isNull(stories.assignedWorkerId),
+        ),
+      )
+      .orderBy(asc(stories.createdAt))
+      .limit(1)
+      .get();
+    if (!oldest) return null;
+    const createdMs = Number.parseInt(oldest.createdAt, 10);
+    if (!Number.isFinite(createdMs)) {
+      // createdAt is sometimes ISO; try parsing.
+      const parsed = Date.parse(oldest.createdAt);
+      if (Number.isNaN(parsed)) return null;
+      return Math.max(0, Math.floor((ts - parsed) / 1000));
+    }
+    return Math.max(0, Math.floor((ts - createdMs) / 1000));
+  }
+
+  private workersAssignedFor(bucketId: string): number {
+    // Count workers whose currentStoryId points at a story in this bucket.
+    const rows = this.db
+      .select({ id: workerPool.id })
+      .from(workerPool)
+      .innerJoin(stories, eq(workerPool.currentStoryId, stories.id))
+      .where(and(eq(workerPool.status, 'busy'), eq(stories.bucketId, bucketId)))
+      .all();
+    return rows.length;
+  }
+
+  // ─── Side effects ─────────────────────────────────────────────────────────
+
+  private persist(m: HealthMetric): void {
+    this.db
+      .insert(bucketHealthHistory)
+      .values({
+        id: `bhh_${nanoid(12)}`,
+        bucketId: m.bucketId,
+        ts: m.ts,
+        queueDepth: m.queueDepth,
+        throughputPerHour: m.throughputPerHour,
+        oldestReadyAgeS: m.oldestReadyAgeS,
+        workersAssigned: m.workersAssigned,
+        engaged: m.engaged ? 1 : 0,
+      })
+      .run();
+  }
+
+  private emit(m: HealthMetric): void {
+    if (this.silent) return;
+    eventBus.publish({
+      type: 'task-scheduler.bucket.health' as never,
+      actor: 'task-scheduler',
+      entity_type: 'bucket',
+      entity_id: m.bucketId,
+      payload: {
+        bucketId: m.bucketId,
+        queueDepth: m.queueDepth,
+        throughputPerHour: m.throughputPerHour,
+        oldestReadyAgeS: m.oldestReadyAgeS,
+        workersAssigned: m.workersAssigned,
+        engaged: m.engaged,
+        ts: m.ts,
+      },
+    });
+  }
+}

--- a/apps/orchestrator/src/db/migrations/0034_bucket_health_history.sql
+++ b/apps/orchestrator/src/db/migrations/0034_bucket_health_history.sql
@@ -1,0 +1,34 @@
+-- Migration 0034: TASKMGR-005 — bucket_health_history ring buffer.
+--
+-- The HealthMetricsEmitter writes one row per bucket per emission cycle
+-- (default 60s). The /workers dashboard renders the last 60 entries per
+-- bucket as a sparkline so operators can see trends.
+--
+-- Rows are append-only; a periodic prune (or just a SELECT ... LIMIT 60
+-- ORDER BY ts DESC at read time) keeps the surface manageable.
+--
+-- Companion shape (per the architecture report §3.5):
+--   queue_depth         — count of stories where bucket_id=X AND status='pending'
+--                         AND assigned_worker_id IS NULL.
+--   throughput_per_hour — count of `task.tested_and_done` events for stories in
+--                         this bucket over the last hour, projected to /hr rate.
+--   oldest_ready_age_s  — age in seconds of the oldest unassigned ready story
+--                         in this bucket (NULL if no ready stories).
+--   workers_assigned    — count of workers whose currentStoryId points at a
+--                         story in this bucket.
+
+CREATE TABLE IF NOT EXISTS `bucket_health_history` (
+  `id` text PRIMARY KEY NOT NULL,
+  `bucket_id` text NOT NULL,
+  `ts` integer NOT NULL,
+  `queue_depth` integer NOT NULL,
+  `throughput_per_hour` real NOT NULL,
+  `oldest_ready_age_s` integer,
+  `workers_assigned` integer NOT NULL,
+  `engaged` integer NOT NULL DEFAULT 0
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `bhh_bucket_ts_idx` ON `bucket_health_history` (`bucket_id`, `ts`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `bhh_ts_idx` ON `bucket_health_history` (`ts`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1778300000001,
       "tag": "0033_worker_pool",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1778400000000,
+      "tag": "0034_bucket_health_history",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -1179,3 +1179,24 @@ export const workerPool = sqliteTable('worker_pool', {
   index('worker_pool_current_story_idx').on(t.currentStoryId),
   index('worker_pool_heartbeat_idx').on(t.lastHeartbeatAt),
 ]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// bucket_health_history — TASKMGR-005 (migration 0034)
+//
+// Append-only ring-style history table written every 60s by
+// HealthMetricsEmitter. The /workers dashboard renders the last 60
+// entries per bucket as a sparkline so operators can see trends.
+// ─────────────────────────────────────────────────────────────────────────────
+export const bucketHealthHistory = sqliteTable('bucket_health_history', {
+  id: text('id').primaryKey(),
+  bucketId: text('bucket_id').notNull(),
+  ts: integer('ts').notNull(),
+  queueDepth: integer('queue_depth').notNull(),
+  throughputPerHour: real('throughput_per_hour').notNull(),
+  oldestReadyAgeS: integer('oldest_ready_age_s'),
+  workersAssigned: integer('workers_assigned').notNull(),
+  engaged: integer('engaged').notNull().default(0),                     // 0|1
+}, (t) => [
+  index('bhh_bucket_ts_idx').on(t.bucketId, t.ts),
+  index('bhh_ts_idx').on(t.ts),
+]);

--- a/apps/orchestrator/tests/agents/health-metrics-emitter.test.ts
+++ b/apps/orchestrator/tests/agents/health-metrics-emitter.test.ts
@@ -1,0 +1,289 @@
+/**
+ * HealthMetricsEmitter — TASKMGR-005 unit tests.
+ *
+ * Verifies the per-bucket aggregation (queue depth, throughput,
+ * oldest-ready age, workers assigned), the persistence to
+ * bucket_health_history, and the engaged flag mirroring from
+ * a BackpressureMonitor stub.
+ *
+ * 9 cases.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq, asc } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, workerPool, taskBuckets, prompts, events, bucketHealthHistory } from '../../src/db/schema';
+import { HealthMetricsEmitter } from '../../src/agents/health-metrics-emitter';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup(opts: { now?: () => number; backpressureEngaged?: string[] } = {}) {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  db.insert(prompts).values({
+    id: 'p_test',
+    body: 'test',
+    receivedAt: new Date().toISOString(),
+    correlationId: 'corr_test',
+    hash: 'h_test',
+  }).run();
+  for (const bid of ['bkt_a', 'bkt_b']) {
+    db.insert(taskBuckets).values({
+      id: bid,
+      kind: 'parallel',
+      promptId: 'p_test',
+      createdAt: Date.now(),
+      status: 'open',
+    }).run();
+  }
+  const backpressureMonitor = opts.backpressureEngaged
+    ? { listEngaged: () => opts.backpressureEngaged! }
+    : undefined;
+  const emitter = new HealthMetricsEmitter(db, {
+    silent: true,
+    now: opts.now,
+    backpressureMonitor,
+  });
+  return { db, emitter };
+}
+
+function insertStory(
+  db: ReturnType<typeof setup>['db'],
+  id: string,
+  bucketId: string,
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const now = Date.now();
+  db.insert(stories)
+    .values({
+      id,
+      title: id,
+      description: '',
+      expectedBehavior: '',
+      acceptanceCriteriaJson: '[]',
+      verificationPlanJson: '[]',
+      dependsOnJson: '[]',
+      domainSlugsJson: '[]',
+      status: 'pending',
+      createdAt: String(now),
+      agentContributionsJson: '{}',
+      templateVersion: 'v1',
+      templateValidationStatus: 'pending',
+      businessSubDomainsJson: '[]',
+      techSubDomainsJson: '[]',
+      qualityTagsJson: '[]',
+      blockedByJson: '[]',
+      softDependsOnJson: '[]',
+      conflictsWithJson: '[]',
+      claimsJson: '{}',
+      inputDependenciesJson: '[]',
+      testCasesJson: '[]',
+      testDesignStatus: 'pending',
+      validationStatus: 'pending',
+      validationAttempts: 0,
+      linksToJson: '[]',
+      architecturalInstructionsJson: '[]',
+      bucketId,
+      ...overrides,
+    })
+    .run();
+}
+
+describe('HealthMetricsEmitter — discoverBuckets', () => {
+  it('returns no metrics when no buckets have stories', () => {
+    const { emitter } = setup();
+    expect(emitter.emitOnce()).toEqual([]);
+  });
+
+  it('returns one metric per distinct bucket_id with at least one story', () => {
+    const { db, emitter } = setup();
+    insertStory(db, 's_a', 'bkt_a');
+    insertStory(db, 's_b1', 'bkt_b');
+    insertStory(db, 's_b2', 'bkt_b');
+    const metrics = emitter.emitOnce();
+    expect(metrics.map((m) => m.bucketId).sort()).toEqual(['bkt_a', 'bkt_b']);
+  });
+});
+
+describe('HealthMetricsEmitter — queueDepth', () => {
+  it('counts only pending + unassigned stories', () => {
+    const { db, emitter } = setup();
+    insertStory(db, 's1', 'bkt_a');
+    insertStory(db, 's2', 'bkt_a');
+    insertStory(db, 's3', 'bkt_a', { assignedWorkerId: 'wkr_x' });  // excluded
+    insertStory(db, 's4', 'bkt_a', { status: 'verified' });          // excluded
+    const m = emitter.emitOnce().find((x) => x.bucketId === 'bkt_a')!;
+    expect(m.queueDepth).toBe(2);
+  });
+});
+
+describe('HealthMetricsEmitter — workersAssigned', () => {
+  it('counts busy workers whose currentStoryId is in the bucket', () => {
+    const { db, emitter } = setup();
+    insertStory(db, 's1', 'bkt_a');
+    insertStory(db, 's2', 'bkt_a');
+    insertStory(db, 's3', 'bkt_b');
+    db.insert(workerPool).values([
+      {
+        id: 'wkr_1',
+        kind: 'coding',
+        status: 'busy',
+        currentStoryId: 's1',
+        capabilitiesJson: '[]',
+        lastHeartbeatAt: Date.now(),
+        registeredAt: Date.now(),
+        metadataJson: '{}',
+      },
+      {
+        id: 'wkr_2',
+        kind: 'coding',
+        status: 'busy',
+        currentStoryId: 's2',
+        capabilitiesJson: '[]',
+        lastHeartbeatAt: Date.now(),
+        registeredAt: Date.now(),
+        metadataJson: '{}',
+      },
+      {
+        id: 'wkr_3',
+        kind: 'coding',
+        status: 'busy',
+        currentStoryId: 's3',
+        capabilitiesJson: '[]',
+        lastHeartbeatAt: Date.now(),
+        registeredAt: Date.now(),
+        metadataJson: '{}',
+      },
+      {
+        id: 'wkr_4',
+        kind: 'coding',
+        status: 'idle',
+        currentStoryId: null,
+        capabilitiesJson: '[]',
+        lastHeartbeatAt: Date.now(),
+        registeredAt: Date.now(),
+        metadataJson: '{}',
+      },
+    ]).run();
+    const metrics = emitter.emitOnce();
+    expect(metrics.find((m) => m.bucketId === 'bkt_a')!.workersAssigned).toBe(2);
+    expect(metrics.find((m) => m.bucketId === 'bkt_b')!.workersAssigned).toBe(1);
+  });
+});
+
+describe('HealthMetricsEmitter — oldestReadyAgeS', () => {
+  it('returns null when no ready stories', () => {
+    const { db, emitter } = setup();
+    insertStory(db, 's_assigned', 'bkt_a', { assignedWorkerId: 'wkr_x' });
+    const m = emitter.emitOnce().find((x) => x.bucketId === 'bkt_a')!;
+    expect(m.oldestReadyAgeS).toBeNull();
+  });
+
+  it('computes age in seconds from createdAt to ts', () => {
+    const fakeNow = 1_000_000_000_000;
+    const { db, emitter } = setup({ now: () => fakeNow });
+    // Two stories, oldest at fakeNow - 5000ms
+    insertStory(db, 's_old', 'bkt_a', { createdAt: String(fakeNow - 5_000) });
+    insertStory(db, 's_new', 'bkt_a', { createdAt: String(fakeNow - 1_000) });
+    const m = emitter.emitOnce().find((x) => x.bucketId === 'bkt_a')!;
+    expect(m.oldestReadyAgeS).toBe(5);
+  });
+});
+
+describe('HealthMetricsEmitter — throughputPerHour', () => {
+  it('counts task.tested_and_done events for stories in the bucket within 1 hour', () => {
+    const fakeNow = 1_000_000_000_000;
+    const { db, emitter } = setup({ now: () => fakeNow });
+    insertStory(db, 's1', 'bkt_a');
+    insertStory(db, 's2', 'bkt_a');
+    insertStory(db, 's3', 'bkt_b');
+    // Insert events: 2 done in bkt_a within the hour, 1 outside, 1 in bkt_b
+    db.insert(events).values([
+      {
+        id: 'ev_1',
+        type: 'task.tested_and_done',
+        occurredAt: new Date(fakeNow - 30 * 60 * 1000).toISOString(),
+        actor: 'task-scheduler',
+        entityId: 's1',
+        domainSlugsJson: '[]',
+        payloadJson: '{}',
+        metadataJson: '{}',
+        severity: 'info',
+      },
+      {
+        id: 'ev_2',
+        type: 'task.tested_and_done',
+        occurredAt: new Date(fakeNow - 50 * 60 * 1000).toISOString(),
+        actor: 'task-scheduler',
+        entityId: 's2',
+        domainSlugsJson: '[]',
+        payloadJson: '{}',
+        metadataJson: '{}',
+        severity: 'info',
+      },
+      {
+        id: 'ev_3',
+        type: 'task.tested_and_done',
+        occurredAt: new Date(fakeNow - 90 * 60 * 1000).toISOString(),    // outside 1h window
+        actor: 'task-scheduler',
+        entityId: 's1',
+        domainSlugsJson: '[]',
+        payloadJson: '{}',
+        metadataJson: '{}',
+        severity: 'info',
+      },
+      {
+        id: 'ev_4',
+        type: 'task.tested_and_done',
+        occurredAt: new Date(fakeNow - 10 * 60 * 1000).toISOString(),
+        actor: 'task-scheduler',
+        entityId: 's3',                                                  // bkt_b
+        domainSlugsJson: '[]',
+        payloadJson: '{}',
+        metadataJson: '{}',
+        severity: 'info',
+      },
+    ]).run();
+    const metrics = emitter.emitOnce();
+    expect(metrics.find((m) => m.bucketId === 'bkt_a')!.throughputPerHour).toBe(2);
+    expect(metrics.find((m) => m.bucketId === 'bkt_b')!.throughputPerHour).toBe(1);
+  });
+});
+
+describe('HealthMetricsEmitter — engaged flag', () => {
+  it('mirrors backpressure monitor when provided', () => {
+    const { db, emitter } = setup({ backpressureEngaged: ['bkt_a'] });
+    insertStory(db, 's_a', 'bkt_a');
+    insertStory(db, 's_b', 'bkt_b');
+    const metrics = emitter.emitOnce();
+    expect(metrics.find((m) => m.bucketId === 'bkt_a')!.engaged).toBe(true);
+    expect(metrics.find((m) => m.bucketId === 'bkt_b')!.engaged).toBe(false);
+  });
+
+  it('defaults to false when no backpressure monitor wired', () => {
+    const { db, emitter } = setup();
+    insertStory(db, 's_a', 'bkt_a');
+    const m = emitter.emitOnce()[0]!;
+    expect(m.engaged).toBe(false);
+  });
+});
+
+describe('HealthMetricsEmitter — persistence', () => {
+  it('writes one bucket_health_history row per bucket per emitOnce', () => {
+    const { db, emitter } = setup();
+    insertStory(db, 's_a', 'bkt_a');
+    insertStory(db, 's_b', 'bkt_b');
+    emitter.emitOnce();
+    emitter.emitOnce();
+    const rows = db.select().from(bucketHealthHistory).orderBy(asc(bucketHealthHistory.ts)).all();
+    expect(rows.length).toBe(4);  // 2 buckets × 2 cycles
+    expect(rows.every((r) => ['bkt_a', 'bkt_b'].includes(r.bucketId))).toBe(true);
+    const lastA = rows.filter((r) => r.bucketId === 'bkt_a').slice(-1)[0]!;
+    expect(lastA.queueDepth).toBe(1);
+    expect(lastA.workersAssigned).toBe(0);
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -454,6 +454,8 @@ export type EventType =
   // ─── Phase 2 backpressure (TASKMGR-004) ───────────────────────────────────
   | 'task-scheduler.backpressure.engaged'
   | 'task-scheduler.backpressure.released'
+  // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
+  | 'task-scheduler.bucket.health'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -571,6 +573,8 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   // ─── Phase 2 backpressure (TASKMGR-004) ───────────────────────────────────
   'task-scheduler.backpressure.engaged': 'warning',
   'task-scheduler.backpressure.released': 'info',
+  // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
+  'task-scheduler.bucket.health': 'debug',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -557,3 +557,9 @@ events:
     severity: info
     actor: [task-scheduler]
     payload: [bucketId, queueDepth, ts]
+
+  # Phase 2 bucket health metrics (TASKMGR-005)
+  - type: task-scheduler.bucket.health
+    severity: debug
+    actor: [task-scheduler]
+    payload: [bucketId, queueDepth, throughputPerHour, oldestReadyAgeS, workersAssigned, engaged, ts]


### PR DESCRIPTION
## Phase 2 — TASKMGR-005 (health metrics emitter)

Fifth PR in the Phase 2 Task Manager track. Builds on TASKMGR-001..004 (all merged).

## What this PR ships

**Migration 0034** — `bucket_health_history` ring buffer table. One row per bucket per emission cycle; `/workers` dashboard reads the last 60 entries per bucket as a sparkline.

**1 new event:** `task-scheduler.bucket.health` (severity=debug — high-cardinality so kept off info channel).

**`HealthMetricsEmitter` class** at `apps/orchestrator/src/agents/health-metrics-emitter.ts`. Computes per-bucket metrics and persists every cycle.

**Aggregations:**
- `queueDepth` — pending + unassigned stories per bucket
- `throughputPerHour` — `task.tested_and_done` events for stories in bucket over last hour (joined to stories)
- `oldestReadyAgeS` — age of oldest unassigned ready story; null if none
- `workersAssigned` — busy workers whose `currentStoryId` is in bucket
- `engaged` — mirrors `BackpressureMonitor.listEngaged()` when wired

**Lifecycle:** `start()` / `stop()` for the periodic timer (default 60s, `unref`ed). `emitOnce()` for tests + manual triggers.

## Tests

10 jest cases in `tests/agents/health-metrics-emitter.test.ts` across 7 `describe` blocks. All green.

## Coordination

- Reads from existing tables (`stories`, `worker_pool`, `events`, `task_buckets`); writes only to new `bucket_health_history`.
- Optionally consumes `BackpressureMonitor` (TASKMGR-004) via the `backpressureMonitor` constructor option for the `engaged` flag.
- Persisted rows are read by the `/workers` dashboard (TASKMGR-006).