### PR TITLE
feat(orchestrator,docs): workers api + task manager runbook (TASKMGR-006)

### DIFF
--- a/apps/orchestrator/src/api/app.ts
+++ b/apps/orchestrator/src/api/app.ts
@@ -27,6 +27,7 @@ import { registerMetricsPhase1Routes } from './routes/metrics-phase1';
 import { registerDagRoutes } from './routes/dag';
 import { registerFeatureRegistryRoutes } from './routes/feature-registry';
 import { registerArchitectureRoutes } from './routes/architecture';
+import { registerWorkerRoutes } from './routes/workers';
 import { promRegistry, httpRequestsTotal } from '../metrics/prometheus';
 
 export function createApp(db: Db): Hono {
@@ -78,6 +79,8 @@ export function createApp(db: Db): Hono {
   registerFeatureRegistryRoutes(app, db);
   registerArchitectureRoutes(app, db);
   registerDagRoutes(app, db);
+  // TASKMGR-006 — Phase 2 worker pool dashboard backend
+  registerWorkerRoutes(app, db);
 
   return app;
 }

--- a/apps/orchestrator/src/api/routes/workers.ts
+++ b/apps/orchestrator/src/api/routes/workers.ts
@@ -1,0 +1,169 @@
+/**
+ * Workers routes — TASKMGR-006.
+ *
+ * Surfaces the Phase 2 worker pool + per-bucket health metrics to the
+ * dashboard. Read-only — workers self-register via the WorkerPoolRegistry
+ * (TASKMGR-002); these endpoints are pure projections.
+ *
+ * Endpoints:
+ *   GET /api/workers/summary           — aggregate counts + per-bucket cards
+ *   GET /api/workers/list              — every worker row with current status
+ *   GET /api/workers/health/:bucketId  — last 60 entries of bucket_health_history
+ *
+ * The frontend dashboard (apps/dashboard/app/workers/page.tsx — to be
+ * shipped in a follow-up UI PR) polls /summary every 5s for the overview
+ * and /health/:bucketId every 30s for the per-bucket sparkline.
+ */
+
+import type { Hono } from 'hono';
+import { eq, desc, and } from 'drizzle-orm';
+import type { Db } from '../../db/connection';
+import { workerPool, bucketHealthHistory, stories } from '../../db/schema';
+
+interface WorkerOut {
+  id: string;
+  kind: string;
+  capabilities: string[];
+  status: string;
+  currentStoryId: string | null;
+  lastHeartbeatAt: number;
+  registeredAt: number;
+  releasedAt: number | null;
+  uptimeMs: number | null;        // when status='busy', heartbeat - registered
+  metadata: Record<string, unknown>;
+}
+
+interface BucketCardOut {
+  bucketId: string;
+  queueDepth: number;
+  throughputPerHour: number;
+  oldestReadyAgeS: number | null;
+  workersAssigned: number;
+  engaged: boolean;
+  ts: number;
+}
+
+interface SummaryOut {
+  counts: { idle: number; busy: number; crashed: number; released: number };
+  perBucket: BucketCardOut[];
+  generatedAt: number;
+}
+
+interface HealthOut {
+  bucketId: string;
+  series: Array<{
+    ts: number;
+    queueDepth: number;
+    throughputPerHour: number;
+    oldestReadyAgeS: number | null;
+    workersAssigned: number;
+    engaged: boolean;
+  }>;
+}
+
+function safeJsonArray(s: string | null | undefined): string[] {
+  try {
+    const parsed = JSON.parse(s ?? '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeJsonObject(s: string | null | undefined): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(s ?? '{}');
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function toWorkerOut(r: typeof workerPool.$inferSelect): WorkerOut {
+  return {
+    id: r.id,
+    kind: r.kind,
+    capabilities: safeJsonArray(r.capabilitiesJson),
+    status: r.status,
+    currentStoryId: r.currentStoryId ?? null,
+    lastHeartbeatAt: r.lastHeartbeatAt,
+    registeredAt: r.registeredAt,
+    releasedAt: r.releasedAt ?? null,
+    uptimeMs: r.status === 'busy' ? r.lastHeartbeatAt - r.registeredAt : null,
+    metadata: safeJsonObject(r.metadataJson),
+  };
+}
+
+export function registerWorkerRoutes(app: Hono, db: Db): void {
+  // GET /api/workers/summary
+  app.get('/api/workers/summary', (c) => {
+    const allWorkers = db.select().from(workerPool).all();
+    const counts = { idle: 0, busy: 0, crashed: 0, released: 0 };
+    for (const w of allWorkers) {
+      const s = w.status as keyof typeof counts;
+      if (s in counts) counts[s] = (counts[s] ?? 0) + 1;
+    }
+    // For perBucket we read the most recent bucket_health_history row per bucket.
+    // SQLite doesn't have window functions everywhere; do it in-process.
+    const allHealth = db
+      .select()
+      .from(bucketHealthHistory)
+      .orderBy(desc(bucketHealthHistory.ts))
+      .limit(500)
+      .all();
+    const seen = new Set<string>();
+    const perBucket: BucketCardOut[] = [];
+    for (const r of allHealth) {
+      if (seen.has(r.bucketId)) continue;
+      seen.add(r.bucketId);
+      perBucket.push({
+        bucketId: r.bucketId,
+        queueDepth: r.queueDepth,
+        throughputPerHour: r.throughputPerHour,
+        oldestReadyAgeS: r.oldestReadyAgeS,
+        workersAssigned: r.workersAssigned,
+        engaged: r.engaged === 1,
+        ts: r.ts,
+      });
+    }
+    perBucket.sort((a, b) => b.queueDepth - a.queueDepth);
+    const out: SummaryOut = { counts, perBucket, generatedAt: Date.now() };
+    return c.json(out);
+  });
+
+  // GET /api/workers/list
+  app.get('/api/workers/list', (c) => {
+    const rows = db
+      .select()
+      .from(workerPool)
+      .orderBy(desc(workerPool.registeredAt))
+      .all();
+    return c.json({ workers: rows.map(toWorkerOut), total: rows.length });
+  });
+
+  // GET /api/workers/health/:bucketId
+  app.get('/api/workers/health/:bucketId', (c) => {
+    const bucketId = c.req.param('bucketId');
+    const rows = db
+      .select()
+      .from(bucketHealthHistory)
+      .where(eq(bucketHealthHistory.bucketId, bucketId))
+      .orderBy(desc(bucketHealthHistory.ts))
+      .limit(60)
+      .all();
+    const out: HealthOut = {
+      bucketId,
+      series: rows
+        .reverse()
+        .map((r) => ({
+          ts: r.ts,
+          queueDepth: r.queueDepth,
+          throughputPerHour: r.throughputPerHour,
+          oldestReadyAgeS: r.oldestReadyAgeS,
+          workersAssigned: r.workersAssigned,
+          engaged: r.engaged === 1,
+        })),
+    };
+    return c.json(out);
+  });
+}

--- a/apps/orchestrator/tests/api/workers-routes.test.ts
+++ b/apps/orchestrator/tests/api/workers-routes.test.ts
@@ -1,0 +1,174 @@
+/**
+ * /api/workers/* contract tests — TASKMGR-006.
+ *
+ * Hits each of the three endpoints against a freshly-migrated in-memory
+ * SQLite seeded with workers + bucket health rows. Verifies the JSON
+ * shape, sort order, the engaged-flag projection, and the per-bucket
+ * 60-row history limit.
+ *
+ * 6 cases.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import { Hono } from 'hono';
+import * as schema from '../../src/db/schema';
+import { workerPool, bucketHealthHistory } from '../../src/db/schema';
+import { registerWorkerRoutes } from '../../src/api/routes/workers';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  // Build a minimal Hono app with only the worker routes — avoids
+  // pulling in apps/orchestrator/src/api/app.ts which has unrelated
+  // module-resolution issues for routes outside this PR's scope.
+  const app = new Hono();
+  registerWorkerRoutes(app, db);
+  return { db, app };
+}
+
+async function get(app: ReturnType<typeof setup>['app'], path: string) {
+  const res = await app.request(path);
+  expect(res.status).toBe(200);
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+describe('GET /api/workers/summary', () => {
+  it('returns zero counts + empty perBucket for a fresh DB', async () => {
+    const { app } = setup();
+    const body = await get(app, '/api/workers/summary');
+    expect(body.counts).toEqual({ idle: 0, busy: 0, crashed: 0, released: 0 });
+    expect(body.perBucket).toEqual([]);
+    expect(typeof body.generatedAt).toBe('number');
+  });
+
+  it('aggregates counts across all worker statuses', async () => {
+    const { db, app } = setup();
+    const now = Date.now();
+    const seed = (id: string, status: string, kind = 'coding') => ({
+      id,
+      kind,
+      status,
+      capabilitiesJson: '[]',
+      lastHeartbeatAt: now,
+      registeredAt: now,
+      metadataJson: '{}',
+    });
+    db.insert(workerPool).values([
+      seed('w1', 'idle'),
+      seed('w2', 'idle'),
+      seed('w3', 'busy'),
+      seed('w4', 'crashed'),
+      seed('w5', 'released'),
+      seed('w6', 'idle', 'fix-it'),
+    ]).run();
+    const body = await get(app, '/api/workers/summary');
+    expect(body.counts).toEqual({ idle: 3, busy: 1, crashed: 1, released: 1 });
+  });
+
+  it('perBucket reflects the most recent bucket_health_history row per bucket', async () => {
+    const { db, app } = setup();
+    const now = Date.now();
+    const row = (id: string, bucketId: string, ts: number, depth: number, engaged = 0) => ({
+      id,
+      bucketId,
+      ts,
+      queueDepth: depth,
+      throughputPerHour: 1,
+      oldestReadyAgeS: null,
+      workersAssigned: 0,
+      engaged,
+    });
+    db.insert(bucketHealthHistory).values([
+      row('h1', 'bkt_a', now - 2000, 5),
+      row('h2', 'bkt_a', now - 1000, 7),       // newest a
+      row('h3', 'bkt_b', now - 500, 12, 1),    // newest b, engaged
+    ]).run();
+    const body = await get(app, '/api/workers/summary');
+    const perBucket = body.perBucket as Array<Record<string, unknown>>;
+    expect(perBucket).toHaveLength(2);
+    // sorted by queueDepth desc — bkt_b (12) before bkt_a (7)
+    expect(perBucket[0]!.bucketId).toBe('bkt_b');
+    expect(perBucket[0]!.queueDepth).toBe(12);
+    expect(perBucket[0]!.engaged).toBe(true);
+    expect(perBucket[1]!.bucketId).toBe('bkt_a');
+    expect(perBucket[1]!.queueDepth).toBe(7);
+  });
+});
+
+describe('GET /api/workers/list', () => {
+  it('returns all workers sorted by registeredAt desc', async () => {
+    const { db, app } = setup();
+    const now = Date.now();
+    db.insert(workerPool).values([
+      {
+        id: 'w_old',
+        kind: 'coding',
+        status: 'idle',
+        capabilitiesJson: '[]',
+        lastHeartbeatAt: now,
+        registeredAt: now - 10_000,
+        metadataJson: '{}',
+      },
+      {
+        id: 'w_new',
+        kind: 'coding',
+        status: 'busy',
+        currentStoryId: 'story-x',
+        capabilitiesJson: JSON.stringify(['bkt_a']),
+        lastHeartbeatAt: now,
+        registeredAt: now - 1_000,
+        metadataJson: JSON.stringify({ pid: 1234 }),
+      },
+    ]).run();
+    const body = await get(app, '/api/workers/list');
+    expect(body.total).toBe(2);
+    const workers = body.workers as Array<Record<string, unknown>>;
+    expect(workers[0]!.id).toBe('w_new');         // most recently registered first
+    expect(workers[0]!.capabilities).toEqual(['bkt_a']);
+    expect(workers[0]!.metadata).toEqual({ pid: 1234 });
+    expect(typeof workers[0]!.uptimeMs).toBe('number');
+    expect(workers[1]!.id).toBe('w_old');
+    expect(workers[1]!.uptimeMs).toBeNull();      // idle workers have no uptime
+  });
+});
+
+describe('GET /api/workers/health/:bucketId', () => {
+  it('returns the last 60 rows for the bucket in chronological order', async () => {
+    const { db, app } = setup();
+    // Insert 80 rows for bkt_a; only the last 60 should appear.
+    const rows = Array.from({ length: 80 }, (_, i) => ({
+      id: `h${i}`,
+      bucketId: 'bkt_a',
+      ts: 1000 + i,
+      queueDepth: i,
+      throughputPerHour: 0,
+      oldestReadyAgeS: null,
+      workersAssigned: 0,
+      engaged: 0,
+    }));
+    db.insert(bucketHealthHistory).values(rows).run();
+    const body = await get(app, '/api/workers/health/bkt_a');
+    expect(body.bucketId).toBe('bkt_a');
+    const series = body.series as Array<Record<string, unknown>>;
+    expect(series).toHaveLength(60);
+    // oldest in returned set should be ts=1020 (i=20), newest ts=1079 (i=79)
+    expect(series[0]!.ts).toBe(1020);
+    expect(series[series.length - 1]!.ts).toBe(1079);
+    // strictly ascending
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i]!.ts).toBeGreaterThan(series[i - 1]!.ts as number);
+    }
+  });
+
+  it('returns empty series for an unknown bucket', async () => {
+    const { app } = setup();
+    const body = await get(app, '/api/workers/health/nonexistent');
+    expect(body).toEqual({ bucketId: 'nonexistent', series: [] });
+  });
+});

--- a/docs/task-manager.md
+++ b/docs/task-manager.md
@@ -1,0 +1,182 @@
+# Task Manager Agent — operator runbook
+
+**Last updated:** 2026-04-28
+**Track:** Phase 2 worker pool (TASKMGR-001 through TASKMGR-007)
+**Architecture report:** `~/Documents/projects/reports/phase2-completion-architecture-2026-04-28.md`
+**Audience:** anyone bringing up the orchestrator or debugging Phase 2 routing.
+
+## What it is
+
+The Task Manager Agent owns the runtime that picks validated +
+test-designed tickets off the bucket-placer's ready-pool and dispatches
+them to free Coding Agent workers. It also tracks worker liveness,
+applies backpressure to the PO Agent when buckets fill, and emits the
+per-bucket health metrics the dashboard renders.
+
+Three composable pieces:
+
+1. **`WorkerPoolRegistry`** (TASKMGR-002) — durable registry of every
+   Coding/Fix-It worker process; in-process mirror of the `worker_pool`
+   table from migration 0033. Stale-detector reaps workers whose
+   heartbeat is older than 60 s.
+2. **`ReadyPoolConsumer`** (TASKMGR-003) — bridges the BUCKET-009
+   ready-pool recompute to the worker pool. On every
+   `ticket.bucket_placed` / `task.completed`, snapshots stories,
+   recomputes the ready set, and atomically assigns each ready story to a
+   compatible idle worker. Atomicity comes from a SQLite transaction
+   that re-checks worker.status + story.assignedWorkerId inside the tx.
+3. **`BackpressureMonitor`** (TASKMGR-004) — per-bucket queue-depth
+   watcher with hysteresis. Engages at depth ≥ ceiling, releases at
+   depth ≤ ceiling - hysteresis. Defaults: ceiling = 25, hysteresis = 5.
+4. **`HealthMetricsEmitter`** (TASKMGR-005) — periodic (default 60 s)
+   per-bucket aggregator. Persists rows to `bucket_health_history`
+   (migration 0034) and emits `task-scheduler.bucket.health` for live
+   subscribers.
+
+The `/api/workers/*` routes (TASKMGR-006) project the in-memory state
+plus the persisted history for the dashboard.
+
+## State model
+
+Two tables own the Phase 2 runtime state:
+
+- `worker_pool` (migration 0033) — one row per worker process. Fields:
+  `id, kind ('coding'|'fix-it'), capabilities (JSON []), status
+  ('idle'|'busy'|'crashed'|'released'), current_story_id,
+  last_heartbeat_at, registered_at, released_at, metadata (JSON)`.
+- `stories` (12 new columns from migration 0032): `assigned_worker_id,
+  coding_session_id, worktree_path, feature_branch, pr_number, pr_url,
+  pr_state, last_commit_sha, coding_attempts, fix_attempts,
+  phase2_status, phase2_blocker_id`.
+
+`phase2_status` taxonomy:
+
+| value | meaning |
+|---|---|
+| `coding_in_progress` | Coding Agent has claimed; PR not yet open. |
+| `coding_complete` | PR open; local unit/integration green. |
+| `testing_in_progress` | Fix-It Test Agent running the testCases. |
+| `testing_fixing` | mid-fix-loop (one or more retries in flight). |
+| `tests_passing` | every testCase green; ready for PR merge. |
+| `done` | PR merged; ticket closed. |
+| `escalated` | fix-stuck or coding-stuck blocker filed. |
+
+## Event taxonomy (additions from this track)
+
+| Event | Severity | Payload (key fields) |
+|---|---|---|
+| `worker.registered` | info | workerId, kind, capabilities, registeredAt |
+| `worker.heartbeat` | debug | workerId, status, currentStoryId, ts |
+| `worker.released` | info | workerId, lastStoryId, releasedAt, reason |
+| `worker.crashed` | error | workerId, lastStoryId, error, lastHeartbeatAt, ts |
+| `task.assigned` | info | storyId, workerId, bucketId, assignedAt, correlationId |
+| `task-scheduler.backpressure.engaged` | warning | bucketId, queueDepth, ceiling, ts |
+| `task-scheduler.backpressure.released` | info | bucketId, queueDepth, ts |
+| `task-scheduler.bucket.health` | debug | bucketId + the 5 metrics + ts |
+
+`worker.crashed` is emitted by Task Manager (actor=task-scheduler), not
+by the worker; the worker can't notify its own death.
+
+## Lifecycle
+
+### Worker startup (Coding Agent / Fix-It Agent)
+
+```
+worker process boots →
+  registry.register({ kind, capabilities }) → emits worker.registered
+  setInterval(15s, () => registry.heartbeat(workerId))
+```
+
+### Story assignment
+
+```
+bucket-placer writes story.bucket_id + emits ticket.bucket_placed →
+  ReadyPoolConsumer.onBucketPlaced() →
+    pump():
+      snapshots stories where status='pending' AND assigned_worker_id IS NULL
+      recompute() returns { ready, deferred, inFlight }
+      for each ready story:
+        listIdle({ kind: 'coding', bucket: story.bucketId })
+        atomicAssign — tx flips worker + story
+        emit task.assigned
+```
+
+### Backpressure engage / release
+
+```
+BackpressureMonitor.checkBucket(bucketId) →
+  depth = SELECT count(*) FROM stories WHERE bucket_id=? AND status='pending' AND assigned_worker_id IS NULL
+  if depth >= ceiling AND not engaged: engaged.add; emit engaged event
+  if depth <= ceiling-hysteresis AND engaged: engaged.delete; emit released event
+```
+
+PO Agent subscribes to engaged/released; when a bucket it would write
+into is engaged, it defers new prompts to
+`prompts.status='deferred_backpressure'` and resumes on release.
+
+### Stale detection
+
+```
+setInterval(30s, () => registry.detectStale()):
+  for each row where last_heartbeat_at < now - 60_000 AND status in ('idle','busy'):
+    flip to 'crashed'; emit worker.crashed
+    Task Manager requeues currentStoryId by clearing assigned_worker_id +
+    nulling phase2_status (so ReadyPoolConsumer picks it up next pump).
+```
+
+Workers in `released` or already `crashed` are skipped — never resurrected.
+
+## Bringing up the orchestrator
+
+Phase 2 wiring is in `wirePhase2()` (TASKMGR-007 in the same PR set).
+The orchestrator startup sequence:
+
+1. Apply migrations (0000..0034).
+2. Wire event bus (`wireEventBus(db)`).
+3. Construct `WorkerPoolRegistry`, `ReadyPoolConsumer`, `BackpressureMonitor`,
+   `HealthMetricsEmitter`.
+4. Subscribe consumer + monitor to the bus glob `ticket.bucket_placed`,
+   `task.completed`, `task.tested_and_done`.
+5. Start the periodic timers — registry stale-detector (30 s),
+   health-metrics emitter (60 s).
+
+## Operating
+
+- **List workers + counts:** `curl localhost:9800/api/workers/list`.
+- **Per-bucket dashboard summary:** `curl localhost:9800/api/workers/summary`.
+- **Per-bucket sparkline:** `curl localhost:9800/api/workers/health/<bucket_id>`.
+- **Manually evict a stuck worker:** today this is a SQL update
+  (`UPDATE worker_pool SET status='crashed' WHERE id='wkr_xyz'`); a
+  `POST /api/workers/:id/evict` endpoint is on the dashboard polish
+  follow-up.
+- **Drain a bucket on engaged backpressure:** wait for either workers
+  to free up OR for PO to stop adding to the bucket; the system
+  self-resolves once depth drops past ceiling - hysteresis.
+
+## Failure modes
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Worker crashes mid-story | Stale-detector flips to crashed at 60 s | Story requeued (assigned_worker_id cleared); next pump reassigns |
+| Two pumps race the same idle worker | Atomic-assign tx aborts second one | Story tagged readyButUnassigned; next pump cycle picks up |
+| Bucket fills past ceiling | `task-scheduler.backpressure.engaged` event | PO defers new prompts until release |
+| `bucket_health_history` grows unbounded | Tablespace alarm | Periodic prune `DELETE WHERE ts < now() - 24h` (cron, future) |
+| Ollama down → emit fails on `worker.heartbeat` | Bus emit returns void | Heartbeat itself doesn't depend on Ollama; debug-severity event drops silently |
+
+## Tests
+
+- `tests/db/0032-0033-phase2-worker-pool.test.ts` — migration roundtrip (15 cases).
+- `tests/agents/worker-pool-registry.test.ts` — registry contract (21 cases).
+- `tests/agents/ready-pool-consumer.test.ts` — atomic assign + race (14 cases).
+- `tests/agents/backpressure-monitor.test.ts` — engage/release + hysteresis (11 cases).
+- `tests/agents/health-metrics-emitter.test.ts` — aggregation + persistence (10 cases).
+- `tests/api/workers-routes.test.ts` — contract (6 cases).
+
+Total: 77 jest cases.
+
+## What's NOT here
+
+- The Next.js `/workers` dashboard page is a separate UI PR (followup).
+- Auto-eviction of crashed workers' assigned stories — the assigned-worker
+  clear is in the next PR (TASKMGR-007 wiring).
+- Per-worker observability metrics (Prometheus exporters) are a follow-up.


### PR DESCRIPTION
## Phase 2 — TASKMGR-006 (workers API + runbook)

Combines the original TASKMGR-006 (API endpoints) and TASKMGR-007 (operator runbook) into a single PR — both are docs/glue that don't introduce new agents.

## What this PR ships

**3 new endpoints** at `apps/orchestrator/src/api/routes/workers.ts`, wired into `createApp` via `registerWorkerRoutes`:

- `GET /api/workers/summary` — { counts: { idle, busy, crashed, released }, perBucket: BucketCard[], generatedAt }. Sorted by queueDepth desc.
- `GET /api/workers/list` — { workers: WorkerOut[], total }. Sorted by registeredAt desc. Parses capabilities + metadata from JSON. Computes `uptimeMs` for busy workers.
- `GET /api/workers/health/:bucketId` — { bucketId, series: HealthPoint[] }. Last 60 `bucket_health_history` entries in chronological order.

**`docs/task-manager.md` operator runbook** — covers:
- The five Phase 2 components (registry, consumer, monitor, emitter, routes)
- State model (worker_pool + 12 new story columns + phase2_status taxonomy)
- 8 new event types (4 worker lifecycle + assigned + 2 backpressure + bucket health)
- Lifecycle flows (worker startup, story assignment, backpressure engage/release, stale detection)
- Bring-up sequence
- Operating commands (`curl`)
- 5-row failure-mode recovery table

## Tests

6 jest contract cases in `tests/api/workers-routes.test.ts` — counts aggregation, perBucket projection from latest history row, sort orders, 60-row limit, empty-bucket handling. All green.

Tests use a minimal Hono app (just `registerWorkerRoutes`) instead of the full `createApp()` to sidestep an unrelated module-resolution issue in `routes/llm.ts`.

## DoD

- [x] 3 endpoints + JSON shape verified
- [x] runbook covers state, events, lifecycle, ops, failures
- [x] 6 jest cases green
- [x] App wiring complete (`registerWorkerRoutes` in `app.ts`)

## What's NOT here

- Next.js `/workers` dashboard page (UI follow-up).
- Auto-eviction of crashed workers' assigned stories (lands in TASKMGR-007 `wirePhase2()` follow-up alongside CODING-001's startup script).
- Prometheus exporter for per-worker metrics (separate observability PR).

## Status

This is the 6th of 31 Phase 2 PRs. After this merges, TASKMGR track is complete (the Phase 2 wiring helper `wirePhase2()` will ship alongside CODING-001 since it has no test surface without a worker process to wire). Moving to **Phase 2C — Coding Agent (worker)** next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added worker pool dashboard backend with three new API endpoints: worker status summary, complete worker list, and bucket health history for performance monitoring.

* **Documentation**
  * Added comprehensive task manager operator runbook documenting Phase 2 routing operational procedures and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->