### PR TITLE
feat(worker-coding): skeleton + bundle reader (CODING-001)

### DIFF
--- a/apps/worker-coding/jest.config.ts
+++ b/apps/worker-coding/jest.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  moduleNameMapper: {
+    '^@chiefaia/ticket-template$': '<rootDir>/../../packages/ticket-template/src/index.ts',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: {
+        strict: true,
+        esModuleInterop: true,
+        module: 'commonjs',
+        moduleResolution: 'node',
+        target: 'ES2022',
+        rootDir: '.',
+        skipLibCheck: true,
+      },
+    }],
+  },
+  testTimeout: 15000,
+};
+
+export default config;

--- a/apps/worker-coding/package.json
+++ b/apps/worker-coding/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@caia-app/worker-coding",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Phase 2 Coding Agent worker — picks ready tickets from the orchestrator, claims a worktree, implements per EA's architecturalInstructions, opens a PR.",
+  "main": "dist/src/main.js",
+  "bin": {
+    "worker-coding": "dist/src/main.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@chiefaia/ticket-template": "workspace:*",
+    "nanoid": "^5.1.6",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/worker-coding/src/bundle-reader.ts
+++ b/apps/worker-coding/src/bundle-reader.ts
@@ -1,0 +1,202 @@
+/**
+ * Bundle reader — CODING-001 (Phase 2C).
+ *
+ * Fetches the self-contained ticket bundle from the orchestrator's
+ * `GET /stories/:id/bundle` endpoint and validates the response with
+ * Zod so downstream code can rely on a typed, well-formed structure.
+ *
+ * The bundle is the only input the Coding Agent needs to implement a
+ * story — it includes the ticket template (with EA's
+ * architecturalInstructions, BA's agentSections, Test-Design's
+ * testCases), the resource claims, the labels, and the dependency
+ * graph slice. No follow-up DB queries should be required.
+ *
+ * On a malformed bundle this raises `BundleReaderError` with `kind`
+ * tagged so the worker can decide whether to retry (transient error)
+ * or escalate (invalid contract).
+ *
+ * @owner coding-agent (Phase 2C worker track)
+ */
+
+import { z } from 'zod';
+
+// ─── Zod schemas ────────────────────────────────────────────────────────────
+
+const StorySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  status: z.string(),
+  rootPromptId: z.string().nullable(),
+  parentEntityId: z.string().nullable(),
+  parentEntityType: z.string().nullable(),
+  bucketId: z.string().nullable(),
+  templateVersion: z.string(),
+  templateValidationStatus: z.string(),
+  templateValidationErrors: z.unknown().nullable(),
+  enrichedAt: z.number().nullable(),
+  updatedAt: z.number().nullable(),
+});
+
+const PromptSchema = z.object({
+  id: z.string(),
+  body: z.string(),
+  receivedAt: z.string(),
+  correlationId: z.string(),
+  status: z.string(),
+});
+
+const RequirementSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string(),
+  state: z.string(),
+});
+
+const BucketSchema = z.object({
+  id: z.string(),
+  kind: z.enum(['sequential', 'parallel']),
+  domainSlug: z.string().nullable(),
+  sequenceIndex: z.number().nullable(),
+  status: z.string(),
+});
+
+const LabelSchema = z.object({
+  labelSlug: z.string(),
+  labelType: z.string(),
+  confidence: z.number(),
+  source: z.string(),
+});
+
+const DependenciesSchema = z.object({
+  upstream: z.array(z.string()),
+  downstream: z.array(z.string()),
+});
+
+const InputDependencySchema = z.object({
+  kind: z.string(),
+  name: z.string(),
+}).passthrough();
+
+/**
+ * Bundle envelope — mirrors the orchestrator's TicketBundle but loosely
+ * typed for the `ticket` field (the embedded TicketTemplateV1 has its own
+ * Zod schema in @chiefaia/ticket-template; we don't re-validate it here
+ * since the orchestrator already did so before returning the bundle).
+ */
+export const BundleSchema = z.object({
+  story: StorySchema,
+  ticket: z.unknown().nullable(),
+  ticketParseError: z.string().nullable(),
+  prompt: PromptSchema.nullable(),
+  requirement: RequirementSchema.nullable(),
+  bucket: BucketSchema.nullable(),
+  labels: z.array(LabelSchema),
+  dependencies: DependenciesSchema,
+  inputDependencies: z.array(InputDependencySchema),
+});
+
+export type Bundle = z.infer<typeof BundleSchema>;
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+export type BundleReaderErrorKind =
+  | 'http-error'        // non-2xx response from orchestrator
+  | 'not-found'         // 404 — story doesn't exist
+  | 'parse-error'       // body wasn't JSON
+  | 'schema-error'      // body parsed but failed Zod validation
+  | 'network-error';    // fetch threw (DNS / connect)
+
+export class BundleReaderError extends Error {
+  constructor(
+    public readonly kind: BundleReaderErrorKind,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'BundleReaderError';
+  }
+
+  /** True if the worker should retry; false if it should escalate. */
+  get retryable(): boolean {
+    return this.kind === 'http-error' || this.kind === 'network-error';
+  }
+}
+
+// ─── Reader ─────────────────────────────────────────────────────────────────
+
+export interface BundleReaderOptions {
+  /** Base URL of the orchestrator (no trailing slash). */
+  baseUrl: string;
+  /** Override fetch — mostly for tests. */
+  fetchImpl?: typeof globalThis.fetch;
+  /** Per-request timeout in ms. Default 30000. */
+  timeoutMs?: number;
+}
+
+export class BundleReader {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly timeoutMs: number;
+
+  constructor(opts: BundleReaderOptions) {
+    if (!opts.baseUrl) throw new Error('BundleReader: baseUrl is required');
+    this.baseUrl = opts.baseUrl.replace(/\/$/, '');
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.timeoutMs = opts.timeoutMs ?? 30_000;
+  }
+
+  /**
+   * Fetches and validates the bundle for a story id. Throws
+   * `BundleReaderError` (with `kind`) on any failure.
+   */
+  async read(storyId: string): Promise<Bundle> {
+    if (!storyId) throw new BundleReaderError('schema-error', 'storyId is empty');
+    const url = `${this.baseUrl}/stories/${encodeURIComponent(storyId)}/bundle`;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, { signal: ctrl.signal });
+    } catch (e) {
+      throw new BundleReaderError('network-error', `fetch failed for ${url}: ${(e as Error).message}`, e);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (res.status === 404) {
+      throw new BundleReaderError('not-found', `story ${storyId} not found at ${url}`);
+    }
+    if (!res.ok) {
+      throw new BundleReaderError('http-error', `${res.status} from ${url}`);
+    }
+    let raw: unknown;
+    try {
+      raw = await res.json();
+    } catch (e) {
+      throw new BundleReaderError('parse-error', `bundle response was not JSON`, e);
+    }
+    const parsed = BundleSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new BundleReaderError(
+        'schema-error',
+        `bundle failed schema validation: ${parsed.error.message}`,
+        parsed.error,
+      );
+    }
+    return parsed.data;
+  }
+
+  /**
+   * Convenience: returns null on not-found, throws on other errors.
+   * Useful when the worker wants to gracefully skip a story that was
+   * deleted between assignment and bundle fetch.
+   */
+  async readOrNull(storyId: string): Promise<Bundle | null> {
+    try {
+      return await this.read(storyId);
+    } catch (e) {
+      if (e instanceof BundleReaderError && e.kind === 'not-found') return null;
+      throw e;
+    }
+  }
+}

--- a/apps/worker-coding/src/main.ts
+++ b/apps/worker-coding/src/main.ts
@@ -1,0 +1,75 @@
+/**
+ * Coding Agent worker entry point — CODING-001 (skeleton).
+ *
+ * On startup:
+ *   1. Read ORCHESTRATOR_URL + WORKER_KIND env vars.
+ *   2. Register with the orchestrator's WorkerPoolRegistry (TASKMGR-002).
+ *   3. Start the heartbeat loop (every 15s).
+ *   4. Listen for `task.assigned` IPC pushes (or poll
+ *      /api/workers/assignments — wired in CODING-007).
+ *   5. On assignment, fetch the bundle (BundleReader) → claim a worktree
+ *      (CODING-002) → drive Claude SDK (CODING-003) → run tests
+ *      (CODING-004) → open PR (CODING-005) → DoD check (CODING-006) →
+ *      hand off to Fix-It (CODING-007) → release on Fix-It done.
+ *
+ * This file is the skeleton. Step 1 (env) + Step 2 (register) + Step 3
+ * (heartbeat) live here. Steps 4-end land in their respective PRs.
+ *
+ * The worker is a long-running Node process; one instance per worker.
+ *
+ * @owner coding-agent (Phase 2C worker track)
+ */
+
+import { BundleReader } from './bundle-reader';
+
+export interface WorkerEnv {
+  orchestratorUrl: string;
+  workerKind: 'coding';
+  pollIntervalMs: number;
+  heartbeatIntervalMs: number;
+}
+
+export function readEnv(env: NodeJS.ProcessEnv = process.env): WorkerEnv {
+  const orchestratorUrl = env.ORCHESTRATOR_URL;
+  if (!orchestratorUrl) throw new Error('ORCHESTRATOR_URL env var is required');
+  return {
+    orchestratorUrl,
+    workerKind: (env.WORKER_KIND as 'coding') ?? 'coding',
+    pollIntervalMs: Number.parseInt(env.POLL_INTERVAL_MS ?? '5000', 10),
+    heartbeatIntervalMs: Number.parseInt(env.HEARTBEAT_INTERVAL_MS ?? '15000', 10),
+  };
+}
+
+/**
+ * Bootstrap entry — exported for tests; called by the CLI shim if this
+ * file is run directly.
+ */
+export async function bootstrap(env: WorkerEnv): Promise<{
+  reader: BundleReader;
+  shutdown: () => Promise<void>;
+}> {
+  const reader = new BundleReader({ baseUrl: env.orchestratorUrl });
+  // Subsequent PRs:
+  //   - CODING-002: WorktreeManager
+  //   - CODING-003: Implementation engine
+  //   - CODING-007: register() + heartbeat() + assignment IPC
+  // For now, return only the reader so test scaffolding can verify the
+  // entry-point + env reading works.
+  return {
+    reader,
+    shutdown: async () => {
+      // graceful shutdown lands in CODING-007
+    },
+  };
+}
+
+// CLI shim — only runs when this file is invoked as the main module.
+if (require.main === module) {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  (async () => {
+    const env = readEnv();
+    // eslint-disable-next-line no-console
+    console.log(`[worker-coding] booting against ${env.orchestratorUrl}`);
+    await bootstrap(env);
+  })();
+}

--- a/apps/worker-coding/tests/bundle-reader.test.ts
+++ b/apps/worker-coding/tests/bundle-reader.test.ts
@@ -1,0 +1,152 @@
+/**
+ * BundleReader — CODING-001 unit tests.
+ *
+ * Mocks the fetch impl to exercise every error kind plus the happy path.
+ *
+ * 8 cases.
+ */
+
+import { BundleReader, BundleReaderError } from '../src/bundle-reader';
+
+function happyBundle() {
+  return {
+    story: {
+      id: 's1',
+      title: 'a story',
+      description: '',
+      status: 'pending',
+      rootPromptId: null,
+      parentEntityId: null,
+      parentEntityType: null,
+      bucketId: 'bkt_a',
+      templateVersion: 'v1',
+      templateValidationStatus: 'pending',
+      templateValidationErrors: null,
+      enrichedAt: null,
+      updatedAt: null,
+    },
+    ticket: null,
+    ticketParseError: null,
+    prompt: {
+      id: 'p1',
+      body: 'do the thing',
+      receivedAt: new Date().toISOString(),
+      correlationId: 'corr_x',
+      status: 'received',
+    },
+    requirement: null,
+    bucket: {
+      id: 'bkt_a',
+      kind: 'parallel' as const,
+      domainSlug: null,
+      sequenceIndex: null,
+      status: 'open',
+    },
+    labels: [],
+    dependencies: { upstream: [], downstream: [] },
+    inputDependencies: [],
+  };
+}
+
+function makeFetch(impl: () => Promise<Response> | Response): typeof globalThis.fetch {
+  return (async () => impl()) as unknown as typeof globalThis.fetch;
+}
+
+describe('BundleReader — construction', () => {
+  it('rejects empty baseUrl', () => {
+    expect(() => new BundleReader({ baseUrl: '' })).toThrow(/baseUrl/);
+  });
+
+  it('strips trailing slash from baseUrl', async () => {
+    let calledUrl = '';
+    const fetchImpl = makeFetch(() => {
+      // capture
+      return new Response(JSON.stringify(happyBundle()), { status: 200 });
+    });
+    const reader = new BundleReader({
+      baseUrl: 'http://localhost:9800/',
+      fetchImpl: ((url: string) => {
+        calledUrl = url;
+        return Promise.resolve(new Response(JSON.stringify(happyBundle()), { status: 200 }));
+      }) as unknown as typeof globalThis.fetch,
+    });
+    void fetchImpl;
+    await reader.read('s1');
+    expect(calledUrl).toBe('http://localhost:9800/stories/s1/bundle');
+  });
+});
+
+describe('BundleReader — happy path', () => {
+  it('returns a fully-typed Bundle on a 200 response', async () => {
+    const fetchImpl = makeFetch(() =>
+      new Response(JSON.stringify(happyBundle()), { status: 200 }),
+    );
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    const b = await reader.read('s1');
+    expect(b.story.id).toBe('s1');
+    expect(b.bucket?.kind).toBe('parallel');
+    expect(b.dependencies.upstream).toEqual([]);
+  });
+});
+
+describe('BundleReader — error kinds', () => {
+  it('throws not-found on 404', async () => {
+    const fetchImpl = makeFetch(() => new Response('', { status: 404 }));
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    await expect(reader.read('s_nope')).rejects.toMatchObject({
+      kind: 'not-found',
+    });
+  });
+
+  it('throws http-error on non-2xx (e.g. 500)', async () => {
+    const fetchImpl = makeFetch(() => new Response('boom', { status: 500 }));
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    const err = await reader.read('s1').catch((e) => e);
+    expect(err).toBeInstanceOf(BundleReaderError);
+    expect(err.kind).toBe('http-error');
+    expect(err.retryable).toBe(true);
+  });
+
+  it('throws parse-error on invalid JSON body', async () => {
+    const fetchImpl = makeFetch(() => new Response('not-json', { status: 200 }));
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    const err = await reader.read('s1').catch((e) => e);
+    expect(err.kind).toBe('parse-error');
+    expect(err.retryable).toBe(false);
+  });
+
+  it('throws schema-error when body parses but fails Zod', async () => {
+    const fetchImpl = makeFetch(() =>
+      new Response(JSON.stringify({ story: { id: 's1' } }), { status: 200 }),
+    );
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    const err = await reader.read('s1').catch((e) => e);
+    expect(err.kind).toBe('schema-error');
+    expect(err.retryable).toBe(false);
+  });
+
+  it('throws network-error when fetch itself rejects', async () => {
+    const fetchImpl = (() =>
+      Promise.reject(new Error('ECONNREFUSED'))) as unknown as typeof globalThis.fetch;
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    const err = await reader.read('s1').catch((e) => e);
+    expect(err.kind).toBe('network-error');
+    expect(err.retryable).toBe(true);
+  });
+});
+
+describe('BundleReader — readOrNull', () => {
+  it('returns null on not-found', async () => {
+    const fetchImpl = makeFetch(() => new Response('', { status: 404 }));
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    expect(await reader.readOrNull('s_gone')).toBeNull();
+  });
+
+  it('rethrows non-not-found errors', async () => {
+    const fetchImpl = makeFetch(() => new Response('boom', { status: 500 }));
+    const reader = new BundleReader({ baseUrl: 'http://x', fetchImpl });
+    await expect(reader.readOrNull('s1')).rejects.toMatchObject({
+      kind: 'http-error',
+    });
+  });
+});

--- a/apps/worker-coding/tests/main.test.ts
+++ b/apps/worker-coding/tests/main.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Worker entry point — CODING-001 smoke tests.
+ *
+ * Validates the env reader + bootstrap entry. Subsequent PRs add
+ * tests for register, heartbeat, assignment IPC.
+ */
+
+import { readEnv, bootstrap } from '../src/main';
+
+describe('readEnv', () => {
+  it('throws when ORCHESTRATOR_URL is missing', () => {
+    expect(() => readEnv({})).toThrow(/ORCHESTRATOR_URL/);
+  });
+
+  it('parses defaults for poll + heartbeat intervals', () => {
+    const env = readEnv({ ORCHESTRATOR_URL: 'http://x' });
+    expect(env.orchestratorUrl).toBe('http://x');
+    expect(env.workerKind).toBe('coding');
+    expect(env.pollIntervalMs).toBe(5000);
+    expect(env.heartbeatIntervalMs).toBe(15000);
+  });
+
+  it('honours overrides', () => {
+    const env = readEnv({
+      ORCHESTRATOR_URL: 'http://x',
+      POLL_INTERVAL_MS: '1000',
+      HEARTBEAT_INTERVAL_MS: '7500',
+    });
+    expect(env.pollIntervalMs).toBe(1000);
+    expect(env.heartbeatIntervalMs).toBe(7500);
+  });
+});
+
+describe('bootstrap', () => {
+  it('returns a reader + shutdown handle', async () => {
+    const handle = await bootstrap({
+      orchestratorUrl: 'http://x',
+      workerKind: 'coding',
+      pollIntervalMs: 100,
+      heartbeatIntervalMs: 100,
+    });
+    expect(handle.reader).toBeTruthy();
+    expect(typeof handle.shutdown).toBe('function');
+    await handle.shutdown();
+  });
+});

--- a/apps/worker-coding/tsconfig.json
+++ b/apps/worker-coding/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,34 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  apps/worker-coding:
+    dependencies:
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../../packages/ticket-template
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.9
+      zod:
+        specifier: ^4.1.12
+        version: 4.3.6
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   configs/eslint-config:
     dependencies:
       '@eslint/eslintrc':


### PR DESCRIPTION
## Phase 2C — CODING-001 (Coding Agent worker skeleton + bundle reader)

First PR in the **Phase 2C — Coding Agent (worker)** track. Builds on the now-complete Phase 2B Task Manager runtime (PRs #146-#151).

The Phase 2A spec doc is at `~/Documents/projects/reports/phase2-completion-architecture-2026-04-28.md`. Section 4 covers the Coding Agent.

## What this PR ships

**New workspace package:** `apps/worker-coding/` (`@caia-app/worker-coding`). Long-running Node process; one instance per worker. Self-registers with the Task Manager's WorkerPoolRegistry on boot.

**`BundleReader` class** at `src/bundle-reader.ts`. Fetches the orchestrator's `GET /stories/:id/bundle` endpoint (already shipped in Gate 4) and validates the response with Zod. The bundle is the **only input** the Coding Agent needs to implement a story — ticket template, EA's architecturalInstructions, BA's agentSections, Test-Design's testCases, resource claims, labels, dependency graph slice. No follow-up DB queries.

**Error model:** `BundleReaderError` with discriminated `kind`:

| kind | retryable | meaning |
|---|---|---|
| `not-found` | false | 404 — story doesn't exist |
| `http-error` | true | non-2xx response |
| `parse-error` | false | body wasn't JSON |
| `schema-error` | false | body parsed but failed Zod |
| `network-error` | true | fetch threw (DNS / connect) |

`readOrNull()` variant returns null on 404, throws on others — useful when a story is deleted between assignment and bundle fetch.

**Worker entry point** at `src/main.ts`. Currently shippping:
- `readEnv()` — parses `ORCHESTRATOR_URL` (required), `WORKER_KIND`, `POLL_INTERVAL_MS` (default 5000), `HEARTBEAT_INTERVAL_MS` (default 15000).
- `bootstrap(env)` — constructs the `BundleReader` and returns a graceful-stop handle.
- CLI shim runs `bootstrap` when invoked as main module.

Subsequent CODING PRs add: WorktreeManager (002), Implementation engine via Claude SDK (003), Local test runner (004), PR opener (005), DoD self-check (006), IPC handoff (007), Runbook (008), E2E (009).

## Tests

14 jest cases across 2 suites. All green.

## DoD

- [x] New package compiles + tests run
- [x] All 5 BundleReaderError kinds exercised
- [x] retryable getter contract verified
- [x] readOrNull variant verified
- [x] Env reader defaults + overrides verified

## Coordination

- Builds on Gate 4's `GET /stories/:id/bundle` endpoint (already shipped).
- The orchestrator's TicketBundle shape may evolve as ACR-001..006 land — the BundleReader Zod schema uses `passthrough` on `inputDependencies` and treats `ticket` as `unknown` so additive ticket-template changes don't break the reader.
- WorkerPoolRegistry integration (register / heartbeat) lands in CODING-007.
