### PR TITLE
feat(worker-coding): worktree manager (CODING-002)

### DIFF
--- a/apps/worker-coding/src/worktree-manager.ts
+++ b/apps/worker-coding/src/worktree-manager.ts
@@ -1,0 +1,200 @@
+/**
+ * WorktreeManager — CODING-002 (Phase 2C).
+ *
+ * Owns the per-story git worktree lifecycle for a Coding Agent worker.
+ * Each story gets its own worktree under `~/.caia/worktrees/<storyId>/`
+ * cut from the repository's integration branch (per
+ * feedback_pr_lifecycle_and_branching.md):
+ *
+ *   - caia       → main
+ *   - pokerzeno  → master
+ *   - roulette*  → master
+ *   - other      → develop, falling back to main
+ *
+ * The branch cut on top of the worktree is named per the lifecycle:
+ *   feat/<storyId>-<slug>     for lifecycle in {new, enhance, refactor}
+ *   fix/<storyId>-<slug>      for lifecycle = bug
+ *   chore/<storyId>-<slug>    for lifecycle in {chore, docs}
+ *
+ * The worktree is **kept** when handing off to the Fix-It Test Agent
+ * (same Claude SDK session reuses it). It's only released after
+ * `task.tested_and_done` and PR merged.
+ *
+ * @owner coding-agent (Phase 2C worker track)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface Worktree {
+  storyId: string;
+  path: string;
+  branch: string;
+  integrationBranch: string;
+  createdAt: number;
+}
+
+export interface ClaimInput {
+  storyId: string;
+  /** Absolute path to the canonical repo (where `.git` lives). */
+  repoPath: string;
+  /** Hint for branch naming. Defaults to 'enhance'. */
+  lifecycle?: 'new' | 'enhance' | 'refactor' | 'bug' | 'chore' | 'docs';
+  /** Short URL-safe slug for the branch suffix. Auto-generated from storyId if missing. */
+  slug?: string;
+}
+
+export interface WorktreeManagerOptions {
+  /** Override base directory for worktrees. Default ~/.caia/worktrees. */
+  baseDir?: string;
+  /** Override the git executable. Default 'git'. */
+  gitBin?: string;
+  /** Override fs (tests). */
+  fsImpl?: typeof fs;
+  /** Override execSync (tests). */
+  execImpl?: typeof spawnSync;
+  /** Override now. */
+  now?: () => number;
+}
+
+// ─── Per-repo branch table (from feedback_pr_lifecycle_and_branching.md) ───
+
+const REPO_INTEGRATION_BRANCH: Record<string, string> = {
+  caia: 'main',
+  pokerzeno: 'master',
+  roulettecommunity: 'master',
+  'roulette-advisor-ai': 'master',
+};
+
+/** Returns the configured integration branch for a repo, or 'develop' as fallback. */
+export function detectIntegrationBranch(repoName: string): string {
+  return REPO_INTEGRATION_BRANCH[repoName] ?? 'develop';
+}
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class WorktreeManager {
+  private readonly baseDir: string;
+  private readonly gitBin: string;
+  private readonly fs: typeof fs;
+  private readonly exec: typeof spawnSync;
+  private readonly now: () => number;
+
+  constructor(opts: WorktreeManagerOptions = {}) {
+    this.baseDir = opts.baseDir ?? path.join(os.homedir(), '.caia', 'worktrees');
+    this.gitBin = opts.gitBin ?? 'git';
+    this.fs = opts.fsImpl ?? fs;
+    this.exec = opts.execImpl ?? spawnSync;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Cuts a fresh worktree off the integration branch for the given story.
+   * Throws on git failure with the stderr captured. Idempotent: if a
+   * worktree for this storyId already exists, returns the existing record
+   * (so Fix-It Agent reusing the same worktree is safe).
+   */
+  claim(input: ClaimInput): Worktree {
+    const wtPath = this.pathFor(input.storyId);
+    const branch = this.branchName(input);
+    const repoName = path.basename(input.repoPath);
+    const integrationBranch = detectIntegrationBranch(repoName);
+
+    if (this.exists(input.storyId)) {
+      // Reuse — read the current branch.
+      const head = this.git(['rev-parse', '--abbrev-ref', 'HEAD'], wtPath).trim();
+      return {
+        storyId: input.storyId,
+        path: wtPath,
+        branch: head,
+        integrationBranch,
+        createdAt: this.now(),
+      };
+    }
+
+    if (!this.fs.existsSync(this.baseDir)) {
+      this.fs.mkdirSync(this.baseDir, { recursive: true });
+    }
+
+    // 1. Sync the integration branch in the source repo.
+    this.git(['fetch', 'origin', integrationBranch], input.repoPath);
+
+    // 2. Add a worktree on a new branch off origin/<integration>.
+    this.git(
+      ['worktree', 'add', '-b', branch, wtPath, `origin/${integrationBranch}`],
+      input.repoPath,
+    );
+
+    return {
+      storyId: input.storyId,
+      path: wtPath,
+      branch,
+      integrationBranch,
+      createdAt: this.now(),
+    };
+  }
+
+  /**
+   * Releases a worktree — runs `git worktree remove` and deletes the
+   * directory. Pass `keep: true` to skip removal (useful when handing off
+   * to Fix-It Agent which will release later).
+   */
+  release(storyId: string, repoPath: string, opts: { keep?: boolean } = {}): void {
+    if (opts.keep) return;
+    const wtPath = this.pathFor(storyId);
+    if (!this.fs.existsSync(wtPath)) return;
+    // best-effort: `git worktree remove --force` cleans both the
+    // metadata and the directory.
+    this.git(['worktree', 'remove', '--force', wtPath], repoPath);
+  }
+
+  /** Returns true if a worktree directory exists for this story. */
+  exists(storyId: string): boolean {
+    return this.fs.existsSync(this.pathFor(storyId));
+  }
+
+  /** Absolute path of the worktree directory for a story id. */
+  pathFor(storyId: string): string {
+    return path.join(this.baseDir, storyId);
+  }
+
+  /**
+   * Returns the branch name a fresh claim() would use for this story.
+   * Useful for callers that want to predict the branch name (e.g.
+   * for PR body construction).
+   */
+  branchName(input: ClaimInput): string {
+    const slug = (input.slug ?? this.deriveSlug(input.storyId)).slice(0, 40);
+    const lifecycle = input.lifecycle ?? 'enhance';
+    const prefix = (() => {
+      if (lifecycle === 'bug') return 'fix';
+      if (lifecycle === 'chore' || lifecycle === 'docs') return 'chore';
+      return 'feat';
+    })();
+    return `${prefix}/${input.storyId}-${slug}`;
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private deriveSlug(storyId: string): string {
+    return storyId
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+      .slice(0, 40);
+  }
+
+  private git(args: string[], cwd: string): string {
+    const res = this.exec(this.gitBin, args, { cwd, encoding: 'utf8' });
+    if (res.status !== 0) {
+      throw new Error(
+        `git ${args.join(' ')} failed in ${cwd}: ${res.stderr || res.stdout || `exit ${res.status}`}`,
+      );
+    }
+    return String(res.stdout ?? '');
+  }
+}

--- a/apps/worker-coding/tests/worktree-manager.test.ts
+++ b/apps/worker-coding/tests/worktree-manager.test.ts
@@ -1,0 +1,202 @@
+/**
+ * WorktreeManager — CODING-002 unit tests.
+ *
+ * Uses a stubbed exec + a temp-dir fs so tests don't need a real git
+ * worktree. The integration test that exercises real git is in CODING-009.
+ *
+ * 12 cases.
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { detectIntegrationBranch, WorktreeManager } from '../src/worktree-manager';
+
+describe('detectIntegrationBranch', () => {
+  it('returns main for caia', () => {
+    expect(detectIntegrationBranch('caia')).toBe('main');
+  });
+
+  it('returns master for pokerzeno', () => {
+    expect(detectIntegrationBranch('pokerzeno')).toBe('master');
+  });
+
+  it('returns master for roulettecommunity', () => {
+    expect(detectIntegrationBranch('roulettecommunity')).toBe('master');
+  });
+
+  it('falls back to develop for unknown repos', () => {
+    expect(detectIntegrationBranch('mystery-repo')).toBe('develop');
+  });
+});
+
+describe('WorktreeManager.branchName', () => {
+  function makeManager() {
+    return new WorktreeManager({
+      execImpl: jest.fn() as never,
+      fsImpl: { existsSync: () => false, mkdirSync: () => undefined } as never,
+    });
+  }
+
+  it('uses feat/ prefix for lifecycle=new', () => {
+    const m = makeManager();
+    expect(m.branchName({ storyId: 'story-abc', repoPath: '/x', lifecycle: 'new' })).toBe('feat/story-abc-story-abc');
+  });
+
+  it('uses feat/ prefix for lifecycle=enhance (default)', () => {
+    const m = makeManager();
+    expect(m.branchName({ storyId: 'story-xyz', repoPath: '/x' })).toBe('feat/story-xyz-story-xyz');
+  });
+
+  it('uses fix/ prefix for lifecycle=bug', () => {
+    const m = makeManager();
+    expect(m.branchName({ storyId: 'story-bug', repoPath: '/x', lifecycle: 'bug' })).toBe('fix/story-bug-story-bug');
+  });
+
+  it('uses chore/ prefix for lifecycle=chore or docs', () => {
+    const m = makeManager();
+    expect(m.branchName({ storyId: 's_chore', repoPath: '/x', lifecycle: 'chore' })).toBe('chore/s_chore-s-chore');
+    expect(m.branchName({ storyId: 's_docs', repoPath: '/x', lifecycle: 'docs' })).toBe('chore/s_docs-s-docs');
+  });
+
+  it('honours an explicit slug', () => {
+    const m = makeManager();
+    expect(
+      m.branchName({ storyId: 's1', repoPath: '/x', lifecycle: 'new', slug: 'add-leaderboard' }),
+    ).toBe('feat/s1-add-leaderboard');
+  });
+
+  it('truncates very long slugs to 40 chars', () => {
+    const m = makeManager();
+    const long = 'a'.repeat(100);
+    const branch = m.branchName({ storyId: 's', repoPath: '/x', slug: long });
+    // prefix + 's' + '-' + 40 chars
+    expect(branch).toBe('feat/s-' + 'a'.repeat(40));
+  });
+});
+
+describe('WorktreeManager.claim — happy path', () => {
+  it('mkdir + git fetch + git worktree add, returns Worktree record', () => {
+    const calls: Array<{ bin: string; args: string[]; cwd?: string }> = [];
+    const exec = ((bin: string, args: string[], opts: { cwd?: string }) => {
+      calls.push({ bin, args, cwd: opts.cwd });
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const made: string[] = [];
+    const fsImpl = {
+      existsSync: () => false,
+      mkdirSync: (p: string) => { made.push(p); },
+    } as never;
+    const m = new WorktreeManager({
+      baseDir: '/tmp/caia-test-worktrees',
+      execImpl: exec,
+      fsImpl,
+      now: () => 12345,
+    });
+    const wt = m.claim({
+      storyId: 'story-abc',
+      repoPath: '/Users/x/code/caia',
+      lifecycle: 'new',
+      slug: 'add-foo',
+    });
+    expect(made).toContain('/tmp/caia-test-worktrees');
+    expect(calls.length).toBe(2);
+    expect(calls[0]!.args).toEqual(['fetch', 'origin', 'main']);
+    expect(calls[1]!.args).toEqual([
+      'worktree', 'add', '-b', 'feat/story-abc-add-foo',
+      '/tmp/caia-test-worktrees/story-abc',
+      'origin/main',
+    ]);
+    expect(wt.path).toBe('/tmp/caia-test-worktrees/story-abc');
+    expect(wt.branch).toBe('feat/story-abc-add-foo');
+    expect(wt.integrationBranch).toBe('main');
+    expect(wt.createdAt).toBe(12345);
+  });
+});
+
+describe('WorktreeManager.claim — idempotency', () => {
+  it('reuses existing worktree if already present', () => {
+    const calls: Array<{ args: string[]; cwd?: string }> = [];
+    const exec = ((_bin: string, args: string[], opts: { cwd?: string }) => {
+      calls.push({ args, cwd: opts.cwd });
+      // For rev-parse --abbrev-ref HEAD, return a branch name
+      if (args[0] === 'rev-parse') {
+        return { status: 0, stdout: 'feat/existing-branch\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const fsImpl = {
+      existsSync: () => true,           // worktree dir already exists
+      mkdirSync: () => undefined,
+    } as never;
+    const m = new WorktreeManager({
+      baseDir: '/tmp/wt',
+      execImpl: exec,
+      fsImpl,
+      now: () => 9999,
+    });
+    const wt = m.claim({ storyId: 'story-abc', repoPath: '/repo' });
+    // Only the rev-parse should run; no fetch + worktree add.
+    expect(calls.map((c) => c.args[0])).toEqual(['rev-parse']);
+    expect(wt.branch).toBe('feat/existing-branch');
+  });
+});
+
+describe('WorktreeManager.claim — error propagation', () => {
+  it('throws with stderr when git fails', () => {
+    const exec = (() => ({ status: 128, stdout: '', stderr: 'fatal: not a repo' })) as never;
+    const fsImpl = { existsSync: () => false, mkdirSync: () => undefined } as never;
+    const m = new WorktreeManager({ baseDir: '/tmp/wt', execImpl: exec, fsImpl });
+    expect(() => m.claim({ storyId: 's1', repoPath: '/repo' })).toThrow(/not a repo/);
+  });
+});
+
+describe('WorktreeManager.release', () => {
+  it('runs git worktree remove --force', () => {
+    const calls: string[][] = [];
+    const exec = ((_bin: string, args: string[]) => {
+      calls.push(args);
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const fsImpl = { existsSync: () => true, mkdirSync: () => undefined } as never;
+    const m = new WorktreeManager({ baseDir: '/tmp/wt', execImpl: exec, fsImpl });
+    m.release('s1', '/repo');
+    expect(calls).toEqual([['worktree', 'remove', '--force', '/tmp/wt/s1']]);
+  });
+
+  it('skips when keep:true', () => {
+    const calls: string[][] = [];
+    const exec = ((_bin: string, args: string[]) => {
+      calls.push(args);
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const fsImpl = { existsSync: () => true, mkdirSync: () => undefined } as never;
+    const m = new WorktreeManager({ baseDir: '/tmp/wt', execImpl: exec, fsImpl });
+    m.release('s1', '/repo', { keep: true });
+    expect(calls).toEqual([]);
+  });
+
+  it('no-op when worktree does not exist', () => {
+    const calls: string[][] = [];
+    const exec = ((_bin: string, args: string[]) => {
+      calls.push(args);
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const fsImpl = { existsSync: () => false, mkdirSync: () => undefined } as never;
+    const m = new WorktreeManager({ baseDir: '/tmp/wt', execImpl: exec, fsImpl });
+    m.release('s1', '/repo');
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('WorktreeManager — paths', () => {
+  it('pathFor concatenates baseDir and storyId', () => {
+    const m = new WorktreeManager({ baseDir: '/tmp/x' });
+    expect(m.pathFor('story-1')).toBe('/tmp/x/story-1');
+  });
+
+  it('default baseDir is under ~/.caia/worktrees', () => {
+    const m = new WorktreeManager();
+    expect(m.pathFor('s')).toBe(path.join(os.homedir(), '.caia', 'worktrees', 's'));
+  });
+});


### PR DESCRIPTION
## Phase 2C — CODING-002 (WorktreeManager)

Second PR in the Coding Agent track. Builds on CODING-001 (#152).

## What this PR ships

**`WorktreeManager` class** at `apps/worker-coding/src/worktree-manager.ts`. Owns the per-story git worktree lifecycle for one Coding Agent worker.

**API:**
- `claim({ storyId, repoPath, lifecycle?, slug? })` — cuts a fresh worktree off the integration branch, creates a feature branch on top. Idempotent: existing worktrees are reused (Fix-It Agent reuses across the fix loop).
- `release(storyId, repoPath, opts)` — `git worktree remove --force` + dir delete. `keep: true` skips removal (during Fix-It hand-off).
- `branchName(input)` — feat/ for new+enhance+refactor, fix/ for bug, chore/ for chore+docs. Slug auto-derived from storyId, truncated to 40 chars.
- `pathFor(storyId)`, `exists(storyId)` — auxiliary read accessors.

**Default baseDir:** `~/.caia/worktrees/<storyId>/`.

**Integration branch detection** — `detectIntegrationBranch(repoName)` exported helper that maps repo names per the per-repo table in `feedback_pr_lifecycle_and_branching.md`:

| Repo | Integration branch |
|---|---|
| caia | main |
| pokerzeno | master |
| roulettecommunity | master |
| roulette-advisor-ai | master |
| (others) | develop fallback |

## Tests

18 jest cases in `tests/worktree-manager.test.ts`:
- `detectIntegrationBranch` × 4 — exact mappings + fallback
- `branchName` × 7 — every lifecycle prefix + slug honour + truncation
- `claim` × 3 — happy path command sequence + idempotency + error propagation
- `release` × 3 — happens, keep:true, no-op when missing
- paths × 2 — `pathFor` + default base dir

All green via stubbed `exec` + `fs`. Real-git integration test lands in CODING-009.

## Coordination

- `WorktreeManager.claim` will be called by the Coding Agent's main loop on `task.assigned` (CODING-007).
- `release` is called twice: once with `keep: true` after Coding Agent finishes (so Fix-It can use the same worktree), once with `keep: false` after `task.tested_and_done` + PR merge.
- Branch naming honours the PR-lifecycle rule.

## DoD

- [x] Class implementing the spec from architecture report §4.2
- [x] 18 jest cases all green
- [x] Per-repo integration branch table covers all in-tree repos
- [x] Idempotent claim verified (existing worktree reused)
- [x] Error stderr surfaced in thrown messages

## Status

8th of 31 Phase 2 PRs. CODING track: 2 of 9.
