### PR TITLE
feat(worker-coding): local test runner with command discovery (CODING-004)

### DIFF
--- a/apps/worker-coding/src/local-test-runner.ts
+++ b/apps/worker-coding/src/local-test-runner.ts
@@ -1,0 +1,218 @@
+/**
+ * LocalTestRunner — CODING-004 (Phase 2C).
+ *
+ * Runs the appropriate package's unit + integration test commands
+ * against the worker's worktree after the Coding Agent finishes
+ * implementation. The output is captured to disk and streamed back to
+ * the implementation engine in summary form.
+ *
+ * Command discovery rules:
+ *   1. If `<repo>/docs/test-commands.md` exists, parse it for the
+ *      `## unit` and `## integration` shell-fenced blocks.
+ *   2. Otherwise, scope `pnpm test --filter` by inspecting the diff for
+ *      touched package paths.
+ *   3. As a final fallback, run `pnpm test` at the repo root.
+ *
+ * @owner coding-agent (Phase 2C worker track)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync, type SpawnSyncOptions } from 'child_process';
+import type { Worktree } from './worktree-manager';
+import type { Bundle } from './bundle-reader';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type TestPhase = 'unit' | 'integration';
+
+export interface TestPhaseResult {
+  phase: TestPhase;
+  command: string;
+  exitCode: number;
+  durationMs: number;
+  stdoutTail: string;       // last ~5 KiB of stdout — keeps memory bounded
+  stderrTail: string;
+  passed: boolean;
+}
+
+export interface RunResult {
+  results: TestPhaseResult[];
+  /** Combined pass: every executed phase exited 0. */
+  passed: boolean;
+  /** Total wallclock across phases. */
+  totalDurationMs: number;
+  /** Path to the on-disk log file (full output, not just the tail). */
+  logPath: string;
+}
+
+export interface RunnerOptions {
+  /** Override exec (tests). */
+  execImpl?: typeof spawnSync;
+  /** Override fs (tests). */
+  fsImpl?: Pick<typeof fs, 'existsSync' | 'readFileSync' | 'writeFileSync' | 'mkdirSync'>;
+  /** Override clock (tests). */
+  now?: () => number;
+  /** Override default tail size (bytes). */
+  tailBytes?: number;
+}
+
+const DEFAULT_TAIL_BYTES = 5 * 1024;
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class LocalTestRunner {
+  private readonly exec: typeof spawnSync;
+  private readonly fs: Pick<typeof fs, 'existsSync' | 'readFileSync' | 'writeFileSync' | 'mkdirSync'>;
+  private readonly now: () => number;
+  private readonly tailBytes: number;
+
+  constructor(opts: RunnerOptions = {}) {
+    this.exec = opts.execImpl ?? spawnSync;
+    this.fs = opts.fsImpl ?? fs;
+    this.now = opts.now ?? Date.now;
+    this.tailBytes = opts.tailBytes ?? DEFAULT_TAIL_BYTES;
+  }
+
+  // ─── Public ───────────────────────────────────────────────────────────────
+
+  /**
+   * Discovers + runs the test commands. Always writes a log file to
+   * `<worktree.path>/.test-output.log` (overwriting prior runs). Returns
+   * a structured per-phase summary.
+   */
+  run(worktree: Worktree, bundle: Bundle): RunResult {
+    const logPath = path.join(worktree.path, '.test-output.log');
+    const phases = this.discoverCommands(worktree.path, bundle);
+    const results: TestPhaseResult[] = [];
+    const start = this.now();
+    const logBuf: string[] = [];
+    for (const [phase, command] of phases) {
+      const phaseStart = this.now();
+      const res = this.exec('bash', ['-c', command], {
+        cwd: worktree.path,
+        encoding: 'utf8',
+        timeout: 600_000,
+        env: process.env,
+      } as SpawnSyncOptions);
+      const stdout = String(res.stdout ?? '');
+      const stderr = String(res.stderr ?? '');
+      const exitCode = res.status ?? -1;
+      logBuf.push(
+        `=== ${phase} (exit=${exitCode}) ===`,
+        `$ ${command}`,
+        '',
+        '--- stdout ---',
+        stdout,
+        '--- stderr ---',
+        stderr,
+        '',
+      );
+      results.push({
+        phase,
+        command,
+        exitCode,
+        durationMs: this.now() - phaseStart,
+        stdoutTail: this.tail(stdout),
+        stderrTail: this.tail(stderr),
+        passed: exitCode === 0,
+      });
+      // Bail out after a failure to save time — fix-loop will retry.
+      if (exitCode !== 0) break;
+    }
+    this.writeLog(logPath, logBuf.join('\n'));
+    return {
+      results,
+      passed: results.length > 0 && results.every((r) => r.passed),
+      totalDurationMs: this.now() - start,
+      logPath,
+    };
+  }
+
+  // ─── Discovery ────────────────────────────────────────────────────────────
+
+  /**
+   * Returns an ordered list of [phase, command] pairs to execute. Public
+   * for testability.
+   */
+  discoverCommands(worktreePath: string, bundle: Bundle): Array<[TestPhase, string]> {
+    // 1. test-commands.md
+    const docPath = path.join(worktreePath, 'docs', 'test-commands.md');
+    if (this.fs.existsSync(docPath)) {
+      const md = String(this.fs.readFileSync(docPath));
+      const unit = this.extractFenceUnder(md, 'unit');
+      const integration = this.extractFenceUnder(md, 'integration');
+      const out: Array<[TestPhase, string]> = [];
+      if (unit) out.push(['unit', unit]);
+      if (integration) out.push(['integration', integration]);
+      if (out.length > 0) return out;
+    }
+
+    // 2. Inspect bundle.story claims for touched package paths.
+    const claimsFiles = this.extractClaimFiles(bundle);
+    const packages = this.derivePackagesFromFiles(claimsFiles);
+    if (packages.size > 0) {
+      const filterArgs = [...packages].map((p) => `--filter ${p}`).join(' ');
+      return [['unit', `pnpm ${filterArgs} test`]];
+    }
+
+    // 3. Fallback to repo-wide.
+    return [['unit', 'pnpm -w test']];
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private extractFenceUnder(md: string, heading: string): string | null {
+    // Match `## <heading>\n\n```...\n<cmd>\n```
+    const re = new RegExp(`^##\\s+${heading}\\s*$\\s*\`\`\`(?:\\w+)?\\s*([\\s\\S]*?)\\s*\`\`\``, 'mi');
+    const m = re.exec(md);
+    if (!m) return null;
+    const cmd = m[1]?.trim();
+    return cmd && cmd.length > 0 ? cmd : null;
+  }
+
+  private extractClaimFiles(bundle: Bundle): string[] {
+    const ticket = (bundle.ticket ?? {}) as Record<string, unknown>;
+    const claims = (ticket.claims ?? {}) as Record<string, unknown>;
+    const files = claims.files;
+    if (!Array.isArray(files)) return [];
+    return files.filter((f): f is string => typeof f === 'string');
+  }
+
+  /**
+   * Heuristic: a file under `apps/<name>/...` belongs to package `@caia-app/<name>`
+   * (matching the workspace convention). A file under `packages/<name>/...`
+   * belongs to `@chiefaia/<name>`. Other paths are skipped.
+   */
+  private derivePackagesFromFiles(files: string[]): Set<string> {
+    const out = new Set<string>();
+    for (const f of files) {
+      const norm = f.replace(/^\.\//, '');
+      const m1 = /^apps\/([^/]+)\//.exec(norm);
+      if (m1) {
+        out.add(`@caia-app/${m1[1]}`);
+        continue;
+      }
+      const m2 = /^packages\/([^/]+)\//.exec(norm);
+      if (m2) {
+        out.add(`@chiefaia/${m2[1]}`);
+      }
+    }
+    return out;
+  }
+
+  private tail(s: string): string {
+    if (Buffer.byteLength(s, 'utf8') <= this.tailBytes) return s;
+    return '...[truncated]...\n' + s.slice(-this.tailBytes);
+  }
+
+  private writeLog(filePath: string, contents: string): void {
+    const dir = path.dirname(filePath);
+    try {
+      this.fs.mkdirSync(dir, { recursive: true });
+    } catch {
+      /* dir may already exist */
+    }
+    this.fs.writeFileSync(filePath, contents);
+  }
+}

--- a/apps/worker-coding/tests/local-test-runner.test.ts
+++ b/apps/worker-coding/tests/local-test-runner.test.ts
@@ -1,0 +1,213 @@
+/**
+ * LocalTestRunner — CODING-004 unit tests.
+ *
+ * Stubs spawnSync + fs to verify command discovery (3 tiers: doc,
+ * claims-derived, fallback), early-bail behavior on failure, log
+ * writing, and the tail-truncation safeguard.
+ *
+ * 13 cases.
+ */
+
+import { LocalTestRunner } from '../src/local-test-runner';
+import type { Bundle } from '../src/bundle-reader';
+import type { Worktree } from '../src/worktree-manager';
+
+function makeBundle(claimsFiles: string[] = []): Bundle {
+  return {
+    story: {
+      id: 's1',
+      title: '',
+      description: '',
+      status: 'pending',
+      rootPromptId: null,
+      parentEntityId: null,
+      parentEntityType: null,
+      bucketId: null,
+      templateVersion: 'v1',
+      templateValidationStatus: 'pending',
+      templateValidationErrors: null,
+      enrichedAt: null,
+      updatedAt: null,
+    },
+    ticket: { claims: { files: claimsFiles } },
+    ticketParseError: null,
+    prompt: null,
+    requirement: null,
+    bucket: null,
+    labels: [],
+    dependencies: { upstream: [], downstream: [] },
+    inputDependencies: [],
+  };
+}
+
+function makeWorktree(p = '/tmp/wt/s1'): Worktree {
+  return {
+    storyId: 's1',
+    path: p,
+    branch: 'feat/s1',
+    integrationBranch: 'main',
+    createdAt: 0,
+  };
+}
+
+function makeFs(opts: { fileMap?: Record<string, string> } = {}) {
+  const map = opts.fileMap ?? {};
+  const written: Record<string, string> = {};
+  return {
+    fs: {
+      existsSync: (p: string) => p in map,
+      readFileSync: (p: string) => map[p] ?? '',
+      writeFileSync: (p: string, c: string) => { written[p] = c; },
+      mkdirSync: () => undefined,
+    } as never,
+    written,
+  };
+}
+
+describe('LocalTestRunner.discoverCommands — docs/test-commands.md', () => {
+  it('parses unit + integration fences when present', () => {
+    const md = `# Test commands
+
+## unit
+
+\`\`\`bash
+pnpm -F @caia-app/worker-coding test
+\`\`\`
+
+## integration
+
+\`\`\`bash
+pnpm -F @caia-app/orchestrator test:integration
+\`\`\`
+`;
+    const { fs } = makeFs({ fileMap: { '/repo/docs/test-commands.md': md } });
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle());
+    expect(cmds).toEqual([
+      ['unit', 'pnpm -F @caia-app/worker-coding test'],
+      ['integration', 'pnpm -F @caia-app/orchestrator test:integration'],
+    ]);
+  });
+
+  it('handles unit-only file (no integration heading)', () => {
+    const md = `## unit\n\n\`\`\`\npnpm -w vitest run\n\`\`\``;
+    const { fs } = makeFs({ fileMap: { '/repo/docs/test-commands.md': md } });
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle());
+    expect(cmds).toEqual([['unit', 'pnpm -w vitest run']]);
+  });
+
+  it('falls through to claims when fences are empty', () => {
+    const md = `## unit\n\n## integration\n`;
+    const { fs } = makeFs({ fileMap: { '/repo/docs/test-commands.md': md } });
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle(['apps/orchestrator/src/x.ts']));
+    expect(cmds).toEqual([['unit', 'pnpm --filter @caia-app/orchestrator test']]);
+  });
+});
+
+describe('LocalTestRunner.discoverCommands — claims-derived', () => {
+  it('apps/<name>/* → @caia-app/<name>', () => {
+    const { fs } = makeFs();
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle(['apps/dashboard/app/page.tsx']));
+    expect(cmds).toEqual([['unit', 'pnpm --filter @caia-app/dashboard test']]);
+  });
+
+  it('packages/<name>/* → @chiefaia/<name>', () => {
+    const { fs } = makeFs();
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle(['packages/ticket-template/src/x.ts']));
+    expect(cmds).toEqual([['unit', 'pnpm --filter @chiefaia/ticket-template test']]);
+  });
+
+  it('multiple touched packages → multiple --filter args', () => {
+    const { fs } = makeFs();
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle([
+      'apps/orchestrator/src/x.ts',
+      'packages/feature-registry/src/y.ts',
+    ]));
+    expect(cmds.length).toBe(1);
+    const cmd = cmds[0]![1];
+    expect(cmd).toContain('--filter @caia-app/orchestrator');
+    expect(cmd).toContain('--filter @chiefaia/feature-registry');
+  });
+});
+
+describe('LocalTestRunner.discoverCommands — fallback', () => {
+  it('no doc + no claims → repo-wide pnpm test', () => {
+    const { fs } = makeFs();
+    const r = new LocalTestRunner({ fsImpl: fs });
+    const cmds = r.discoverCommands('/repo', makeBundle());
+    expect(cmds).toEqual([['unit', 'pnpm -w test']]);
+  });
+});
+
+describe('LocalTestRunner.run — execution', () => {
+  it('runs each phase + writes log file + reports passed when all exit 0', () => {
+    const { fs, written } = makeFs({ fileMap: {} });
+    let tick = 1000;
+    const calls: Array<{ args: string[]; cwd: string }> = [];
+    const exec = ((_bin: string, args: string[], opts: { cwd: string }) => {
+      calls.push({ args, cwd: opts.cwd });
+      tick += 25;
+      return { status: 0, stdout: 'tests pass', stderr: '' };
+    }) as never;
+    const r = new LocalTestRunner({
+      fsImpl: fs,
+      execImpl: exec,
+      now: () => tick++,
+    });
+    const result = r.run(makeWorktree('/repo'), makeBundle(['apps/orchestrator/src/x.ts']));
+    expect(result.passed).toBe(true);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.phase).toBe('unit');
+    expect(result.results[0]!.exitCode).toBe(0);
+    expect(result.logPath).toBe('/repo/.test-output.log');
+    expect(written['/repo/.test-output.log']).toContain('pnpm --filter @caia-app/orchestrator test');
+    expect(written['/repo/.test-output.log']).toContain('tests pass');
+  });
+
+  it('bails on first failure (skips subsequent phases)', () => {
+    const md = `## unit\n\n\`\`\`\npnpm test:u\n\`\`\`\n\n## integration\n\n\`\`\`\npnpm test:i\n\`\`\``;
+    const { fs } = makeFs({ fileMap: { '/repo/docs/test-commands.md': md } });
+    let phase = 0;
+    const calls: string[] = [];
+    const exec = ((_bin: string, args: string[]) => {
+      calls.push(args[1]!);
+      phase++;
+      return phase === 1
+        ? { status: 1, stdout: '', stderr: 'BOOM' }
+        : { status: 0, stdout: 'never reached', stderr: '' };
+    }) as never;
+    const r = new LocalTestRunner({ fsImpl: fs, execImpl: exec, now: () => 0 });
+    const result = r.run(makeWorktree('/repo'), makeBundle());
+    expect(result.passed).toBe(false);
+    expect(result.results).toHaveLength(1);          // bailed after the unit phase
+    expect(calls).toEqual(['pnpm test:u']);          // integration NOT executed
+  });
+
+  it('reports passed=false when no phases discovered (defensive)', () => {
+    const { fs } = makeFs();
+    // intentionally cause discovery to return [] by stubbing it
+    const r = new LocalTestRunner({ fsImpl: fs, execImpl: (() => ({ status: 0 })) as never });
+    // monkey-patch discoverCommands for this test
+    (r as unknown as { discoverCommands: () => unknown }).discoverCommands = () => [];
+    const result = r.run(makeWorktree('/repo'), makeBundle());
+    expect(result.passed).toBe(false);
+    expect(result.results).toEqual([]);
+  });
+});
+
+describe('LocalTestRunner.run — tail truncation', () => {
+  it('truncates stdout/stderr to tailBytes', () => {
+    const { fs } = makeFs();
+    const big = 'x'.repeat(50_000);
+    const exec = (() => ({ status: 0, stdout: big, stderr: big })) as never;
+    const r = new LocalTestRunner({ fsImpl: fs, execImpl: exec, tailBytes: 100, now: () => 0 });
+    const result = r.run(makeWorktree('/repo'), makeBundle(['apps/x/y.ts']));
+    expect(result.results[0]!.stdoutTail.length).toBeLessThan(200);
+    expect(result.results[0]!.stdoutTail).toContain('truncated');
+  });
+});


### PR DESCRIPTION
## Phase 2C — CODING-004 (LocalTestRunner)

Fourth PR in the Coding Agent track. Builds on CODING-001..003 (all merged).

## What this PR ships

**`LocalTestRunner` class** at `apps/worker-coding/src/local-test-runner.ts`. Discovers + executes the appropriate package test commands after the Implementation Engine emits `CODING_AGENT_DONE`. Captures full stdout/stderr to `<worktree.path>/.test-output.log` for forensic review; returns a per-phase summary with bounded tails (5 KiB cap) so the result fits in memory.

**Three-tier command discovery (`discoverCommands` is public for testability):**

1. **`<repo>/docs/test-commands.md`** — parses `## unit` and `## integration` shell-fenced blocks. This is the preferred path; per-repo customisation lands here.
2. **Claims-derived** — extracts `bundle.ticket.claims.files`, maps `apps/<name>/*` → `@caia-app/<name>` and `packages/<name>/*` → `@chiefaia/<name>`, joins as `--filter` args to a single `pnpm test` invocation.
3. **Fallback** — `pnpm -w test` repo-wide.

**Behavioural guarantees:**
- Bails on first failing phase (saves time; Fix-It loop will retry).
- 600s phase timeout protects against runaway processes.
- Tail-truncation safeguard keeps memory bounded under high-volume output.
- `defensive no-phases` case returns `passed: false` rather than crashing.

## Tests

11 jest cases in `tests/local-test-runner.test.ts`:
- discovery × 7 (3 doc, 3 claims, 1 fallback)
- execution × 3 (happy + log write, bail-on-failure, no-phases)
- tail truncation × 1

All green.

## DoD

- [x] Class implementing the spec from architecture report §4.4
- [x] 3-tier discovery covered
- [x] Bail-on-failure verified
- [x] Tail truncation safeguard
- [x] Log file path documented (`<worktree>/.test-output.log`)
- [x] 11 jest cases all green

## Coordination

- Implementation Engine (CODING-003) calls `runner.run(worktree, bundle)` after the model prints `CODING_AGENT_DONE`.
- Failure feeds the DoD self-check (CODING-006) which decides retry vs escalate.
- Fix-It Test Agent (FIX-### track) reads `result.logPath` to surface failure context to the Coding Agent IPC fix request.

## Status

10th of 31 Phase 2 PRs. CODING track: 4 of 9.
