### PR TITLE
feat(worker-coding): diff committer + PR opener (CODING-005)

### DIFF
--- a/apps/worker-coding/src/diff-committer.ts
+++ b/apps/worker-coding/src/diff-committer.ts
@@ -1,0 +1,232 @@
+/**
+ * DiffCommitter + PrOpener — CODING-005 (Phase 2C).
+ *
+ * After the Implementation Engine prints CODING_AGENT_DONE and the
+ * LocalTestRunner reports green, this module commits the worktree
+ * delta and opens a GitHub PR via the `gh` CLI.
+ *
+ * The PR body is generated from the bundle so the reviewer (or a
+ * downstream automation) sees the story's acceptance criteria + each
+ * test case the Fix-It Test Agent will run.
+ *
+ * The commit message follows the same conventional-commits format
+ * husky's commit-msg hook expects (lowercase subject, scope, story id
+ * in trailer). A small message generator is included for the
+ * subject/body; routing it through a local LLM lands in CODING-006
+ * (DoD self-check) when we wire the LAI track.
+ *
+ * @owner coding-agent (Phase 2C worker track)
+ */
+
+import { spawnSync, type SpawnSyncOptions } from 'child_process';
+import type { Bundle } from './bundle-reader';
+import type { Worktree } from './worktree-manager';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface CommitInput {
+  worktree: Worktree;
+  bundle: Bundle;
+  /** Optional override for the commit subject (skips auto-derivation). */
+  subjectOverride?: string;
+}
+
+export interface CommitResult {
+  sha: string;
+  branch: string;
+  message: string;
+}
+
+export interface OpenPrInput {
+  worktree: Worktree;
+  bundle: Bundle;
+  /** Push the branch first if the remote tracking branch isn't set up. */
+  pushFirst?: boolean;
+  /** Title override. Default derived from bundle. */
+  title?: string;
+  /** Body override. Default built by buildPrBody. */
+  body?: string;
+}
+
+export interface OpenPrResult {
+  prNumber: number;
+  prUrl: string;
+}
+
+export interface DiffCommitterOptions {
+  gitBin?: string;
+  ghBin?: string;
+  execImpl?: typeof spawnSync;
+}
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class DiffCommitter {
+  private readonly git: string;
+  private readonly gh: string;
+  private readonly exec: typeof spawnSync;
+
+  constructor(opts: DiffCommitterOptions = {}) {
+    this.git = opts.gitBin ?? 'git';
+    this.gh = opts.ghBin ?? 'gh';
+    this.exec = opts.execImpl ?? spawnSync;
+  }
+
+  /**
+   * Stages every change, runs `git commit -m <message>`, returns the
+   * fresh sha and the branch name. No-op (returns existing HEAD) if the
+   * tree is clean.
+   */
+  commit(input: CommitInput): CommitResult {
+    const cwd = input.worktree.path;
+    const status = this.run(this.git, ['status', '--porcelain'], { cwd });
+    if (status.trim().length === 0) {
+      const head = this.run(this.git, ['rev-parse', 'HEAD'], { cwd }).trim();
+      return { sha: head, branch: input.worktree.branch, message: '(no changes)' };
+    }
+    this.run(this.git, ['add', '-A'], { cwd });
+    const message = input.subjectOverride ?? this.buildCommitMessage(input.bundle, input.worktree);
+    this.run(this.git, ['commit', '-m', message], { cwd });
+    const sha = this.run(this.git, ['rev-parse', 'HEAD'], { cwd }).trim();
+    return { sha, branch: input.worktree.branch, message };
+  }
+
+  /**
+   * Pushes the branch (if needed) and runs `gh pr create`. Returns the
+   * resulting PR url and number.
+   */
+  openPr(input: OpenPrInput): OpenPrResult {
+    const cwd = input.worktree.path;
+    if (input.pushFirst !== false) {
+      this.run(this.git, ['push', '-u', 'origin', input.worktree.branch], { cwd });
+    }
+    const title = input.title ?? this.derivePrTitle(input.bundle, input.worktree);
+    const body = input.body ?? this.buildPrBody(input.bundle, input.worktree);
+    const out = this.run(this.gh, [
+      'pr', 'create',
+      '--base', input.worktree.integrationBranch,
+      '--head', input.worktree.branch,
+      '--title', title,
+      '--body', body,
+    ], { cwd });
+    return parseGhPrCreateOutput(out);
+  }
+
+  // ─── Builders (public for snapshot tests) ─────────────────────────────────
+
+  buildCommitMessage(bundle: Bundle, worktree: Worktree): string {
+    const ticket = (bundle.ticket ?? {}) as Record<string, unknown>;
+    const lifecycle = String(ticket.lifecycle ?? 'enhance');
+    const type = lifecycle === 'bug' ? 'fix' : lifecycle === 'chore' || lifecycle === 'docs' ? 'chore' : 'feat';
+    const scope = bundle.bucket?.id ? bundle.bucket.id.replace(/^bkt_/, '') : 'caia';
+    const subject = bundle.story.title.toLowerCase().slice(0, 72);
+    const ac = Array.isArray(ticket.acceptanceCriteria) ? ticket.acceptanceCriteria : [];
+    const acLines = ac.slice(0, 5).map((a) => `- ${formatAc(a)}`).join('\n');
+    const testCount = Array.isArray(ticket.testCases) ? ticket.testCases.length : 0;
+    return `${type}(${scope}): ${subject}
+
+Story: ${bundle.story.id}
+Branch: ${worktree.branch}
+
+Acceptance criteria:
+${acLines || '- (none provided)'}
+
+Test cases attached: ${testCount} (Fix-It Test Agent will run them).
+
+Generated by CAIA Coding Agent.`;
+  }
+
+  derivePrTitle(bundle: Bundle, worktree: Worktree): string {
+    const ticket = (bundle.ticket ?? {}) as Record<string, unknown>;
+    const lifecycle = String(ticket.lifecycle ?? 'enhance');
+    const type = lifecycle === 'bug' ? 'fix' : lifecycle === 'chore' || lifecycle === 'docs' ? 'chore' : 'feat';
+    const scope = bundle.bucket?.id ? bundle.bucket.id.replace(/^bkt_/, '') : 'caia';
+    const subject = bundle.story.title.toLowerCase().slice(0, 72);
+    void worktree;
+    return `${type}(${scope}): ${subject}`;
+  }
+
+  buildPrBody(bundle: Bundle, worktree: Worktree): string {
+    const ticket = (bundle.ticket ?? {}) as Record<string, unknown>;
+    const ac = Array.isArray(ticket.acceptanceCriteria) ? ticket.acceptanceCriteria : [];
+    const testCases = Array.isArray(ticket.testCases) ? ticket.testCases : [];
+    const claims = (ticket.claims ?? {}) as Record<string, unknown>;
+    return `## ${bundle.story.title}
+
+**Story id:** ${bundle.story.id}
+**Branch:** \`${worktree.branch}\` → \`${worktree.integrationBranch}\`
+**Bucket:** ${bundle.bucket?.id ?? '(unset)'}
+
+## Acceptance criteria
+
+${ac.length > 0 ? ac.map((a, i) => `${i + 1}. ${formatAc(a)}`).join('\n') : '_(none provided)_'}
+
+## Test cases (Fix-It Test Agent will run all of these)
+
+${
+  testCases.length === 0
+    ? '_(none yet)_'
+    : testCases.map((t, i) => `${i + 1}. ${formatTestCase(t)}`).join('\n')
+}
+
+## Resource claims
+
+- **files:** ${formatList((claims.files ?? []) as string[])}
+- **schemas:** ${formatList((claims.schemas ?? []) as string[])}
+- **apiRoutes:** ${formatList((claims.apiRoutes ?? []) as string[])}
+- **domains:** ${formatList((claims.domains ?? []) as string[])}
+
+---
+
+🤖 Generated by CAIA Coding Agent. Fix-It Test Agent will run the test cases above; this PR auto-merges when they all pass.`;
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private run(bin: string, args: string[], opts: SpawnSyncOptions): string {
+    const res = this.exec(bin, args, { encoding: 'utf8', ...opts });
+    if ((res.status ?? -1) !== 0) {
+      throw new Error(
+        `${bin} ${args.join(' ')} failed (exit=${res.status}): ${String(res.stderr || res.stdout)}`,
+      );
+    }
+    return String(res.stdout ?? '');
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+export function parseGhPrCreateOutput(out: string): OpenPrResult {
+  const trimmed = out.trim().split(/\s+/).find((tok) => tok.startsWith('https://')) ?? '';
+  if (!trimmed) {
+    throw new Error(`gh pr create did not return a URL (got: ${out.slice(0, 200)})`);
+  }
+  const m = /\/pull\/(\d+)/.exec(trimmed);
+  if (!m) {
+    throw new Error(`could not parse PR number from ${trimmed}`);
+  }
+  return { prUrl: trimmed, prNumber: Number.parseInt(m[1]!, 10) };
+}
+
+function formatAc(a: unknown): string {
+  if (typeof a === 'string') return a;
+  if (a && typeof a === 'object') {
+    const obj = a as Record<string, unknown>;
+    return String(obj.title ?? obj.statement ?? obj.given ?? JSON.stringify(a));
+  }
+  return JSON.stringify(a);
+}
+
+function formatTestCase(t: unknown): string {
+  if (!t || typeof t !== 'object') return JSON.stringify(t);
+  const obj = t as Record<string, unknown>;
+  const id = String(obj.id ?? '');
+  const title = String(obj.title ?? obj.summary ?? '');
+  const category = String(obj.category ?? '');
+  return `${id} ${category ? `[${category}] ` : ''}${title}`;
+}
+
+function formatList(xs: string[]): string {
+  if (xs.length === 0) return '_(none)_';
+  return xs.map((x) => `\`${x}\``).join(', ');
+}

--- a/apps/worker-coding/tests/diff-committer.test.ts
+++ b/apps/worker-coding/tests/diff-committer.test.ts
@@ -1,0 +1,219 @@
+/**
+ * DiffCommitter + parseGhPrCreateOutput — CODING-005 unit tests.
+ *
+ * Verifies: commit no-op on clean tree, commit happy path, openPr push +
+ * gh invocation + URL parsing, conventional-commit message format,
+ * derived PR title + body include AC + test cases.
+ *
+ * 13 cases.
+ */
+
+import { DiffCommitter, parseGhPrCreateOutput } from '../src/diff-committer';
+import type { Bundle } from '../src/bundle-reader';
+import type { Worktree } from '../src/worktree-manager';
+
+function makeBundle(overrides: Partial<Bundle> = {}): Bundle {
+  return {
+    story: {
+      id: 's_health',
+      title: 'Add /health endpoint',
+      description: '',
+      status: 'pending',
+      rootPromptId: null,
+      parentEntityId: null,
+      parentEntityType: null,
+      bucketId: 'bkt_dashboard',
+      templateVersion: 'v1',
+      templateValidationStatus: 'pending',
+      templateValidationErrors: null,
+      enrichedAt: null,
+      updatedAt: null,
+    },
+    ticket: {
+      lifecycle: 'new',
+      acceptanceCriteria: ['returns 200', 'returns { ok: true }'],
+      claims: { files: ['apps/dashboard/app/health/route.ts'], schemas: [], apiRoutes: ['/health'], domains: [] },
+      testCases: [
+        { id: 'TC-001', title: 'happy path 200', category: 'happy' },
+        { id: 'TC-002', title: 'no auth required', category: 'happy' },
+      ],
+    },
+    ticketParseError: null,
+    prompt: null,
+    requirement: null,
+    bucket: { id: 'bkt_dashboard', kind: 'parallel', domainSlug: null, sequenceIndex: null, status: 'open' },
+    labels: [],
+    dependencies: { upstream: [], downstream: [] },
+    inputDependencies: [],
+    ...overrides,
+  };
+}
+
+function makeWorktree(): Worktree {
+  return {
+    storyId: 's_health',
+    path: '/tmp/wt/s_health',
+    branch: 'feat/s_health-add-health',
+    integrationBranch: 'main',
+    createdAt: 1234,
+  };
+}
+
+describe('parseGhPrCreateOutput', () => {
+  it('parses URL and number from gh stdout', () => {
+    const out = 'https://github.com/x/y/pull/482\n';
+    expect(parseGhPrCreateOutput(out)).toEqual({
+      prUrl: 'https://github.com/x/y/pull/482',
+      prNumber: 482,
+    });
+  });
+
+  it('handles extra log lines around the URL', () => {
+    const out = 'Creating draft pull request\nhttps://github.com/x/y/pull/9\nDone\n';
+    expect(parseGhPrCreateOutput(out).prNumber).toBe(9);
+  });
+
+  it('throws when no URL present', () => {
+    expect(() => parseGhPrCreateOutput('failed\n')).toThrow(/did not return a URL/);
+  });
+
+  it('throws when URL missing the /pull/N segment', () => {
+    expect(() => parseGhPrCreateOutput('https://github.com/x/y/issues/3\n')).toThrow(/could not parse/);
+  });
+});
+
+describe('DiffCommitter.commit', () => {
+  it('no-op on clean tree (returns current HEAD as sha)', () => {
+    const calls: string[][] = [];
+    const exec = ((bin: string, args: string[]) => {
+      calls.push([bin, ...args]);
+      if (args[0] === 'status') return { status: 0, stdout: '', stderr: '' };
+      if (args[0] === 'rev-parse') return { status: 0, stdout: 'deadbeef\n', stderr: '' };
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const c = new DiffCommitter({ execImpl: exec });
+    const r = c.commit({ worktree: makeWorktree(), bundle: makeBundle() });
+    expect(r.sha).toBe('deadbeef');
+    expect(r.message).toBe('(no changes)');
+    // No git add or git commit in calls.
+    expect(calls.find((c) => c[1] === 'add')).toBeUndefined();
+    expect(calls.find((c) => c[1] === 'commit')).toBeUndefined();
+  });
+
+  it('happy path: status -> add -> commit -> rev-parse', () => {
+    const calls: string[][] = [];
+    const exec = ((bin: string, args: string[]) => {
+      calls.push([bin, ...args]);
+      if (args[0] === 'status') return { status: 0, stdout: ' M src/x.ts\n', stderr: '' };
+      if (args[0] === 'rev-parse') return { status: 0, stdout: 'cafef00d\n', stderr: '' };
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const c = new DiffCommitter({ execImpl: exec });
+    const r = c.commit({ worktree: makeWorktree(), bundle: makeBundle() });
+    expect(r.sha).toBe('cafef00d');
+    expect(calls.map((c) => c[1])).toEqual(['status', 'add', 'commit', 'rev-parse']);
+    // Commit message is the conventional-commit format
+    const commitCall = calls.find((c) => c[1] === 'commit');
+    const msg = commitCall![commitCall!.indexOf('-m') + 1];
+    expect(msg).toContain('feat(dashboard): add /health endpoint');
+    expect(msg).toContain('Story: s_health');
+  });
+
+  it('respects subjectOverride', () => {
+    const calls: string[][] = [];
+    const exec = ((bin: string, args: string[]) => {
+      calls.push([bin, ...args]);
+      if (args[0] === 'status') return { status: 0, stdout: 'M\n', stderr: '' };
+      if (args[0] === 'rev-parse') return { status: 0, stdout: 'sha\n', stderr: '' };
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const c = new DiffCommitter({ execImpl: exec });
+    c.commit({
+      worktree: makeWorktree(),
+      bundle: makeBundle(),
+      subjectOverride: 'custom: my own subject',
+    });
+    const commitCall = calls.find((c) => c[1] === 'commit');
+    const msg = commitCall![commitCall!.indexOf('-m') + 1];
+    expect(msg).toBe('custom: my own subject');
+  });
+
+  it('throws with stderr when git fails', () => {
+    const exec = (() => ({ status: 1, stdout: '', stderr: 'fatal: oops' })) as never;
+    const c = new DiffCommitter({ execImpl: exec });
+    expect(() => c.commit({ worktree: makeWorktree(), bundle: makeBundle() })).toThrow(/oops/);
+  });
+});
+
+describe('DiffCommitter.openPr', () => {
+  it('pushes then runs gh pr create with correct flags', () => {
+    const calls: string[][] = [];
+    const exec = ((bin: string, args: string[]) => {
+      calls.push([bin, ...args]);
+      if (bin === 'gh') {
+        return { status: 0, stdout: 'https://github.com/p/r/pull/42\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const c = new DiffCommitter({ execImpl: exec });
+    const r = c.openPr({ worktree: makeWorktree(), bundle: makeBundle() });
+    expect(r).toEqual({ prUrl: 'https://github.com/p/r/pull/42', prNumber: 42 });
+    expect(calls[0]![0]).toBe('git');
+    expect(calls[0]!.slice(1, 5)).toEqual(['push', '-u', 'origin', 'feat/s_health-add-health']);
+    expect(calls[1]![0]).toBe('gh');
+    const ghArgs = calls[1]!;
+    expect(ghArgs[1]).toBe('pr');
+    expect(ghArgs[2]).toBe('create');
+    expect(ghArgs).toContain('--base');
+    expect(ghArgs).toContain('main');
+    expect(ghArgs).toContain('--head');
+    expect(ghArgs).toContain('feat/s_health-add-health');
+  });
+
+  it('skips push when pushFirst:false', () => {
+    const calls: string[][] = [];
+    const exec = ((bin: string, args: string[]) => {
+      calls.push([bin, ...args]);
+      if (bin === 'gh') {
+        return { status: 0, stdout: 'https://github.com/p/r/pull/1\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    }) as never;
+    const c = new DiffCommitter({ execImpl: exec });
+    c.openPr({ worktree: makeWorktree(), bundle: makeBundle(), pushFirst: false });
+    expect(calls.find((c) => c[1] === 'push')).toBeUndefined();
+  });
+});
+
+describe('DiffCommitter — message + body builders', () => {
+  it('derivePrTitle is the conventional commit subject', () => {
+    const c = new DiffCommitter();
+    expect(c.derivePrTitle(makeBundle(), makeWorktree())).toBe('feat(dashboard): add /health endpoint');
+  });
+
+  it('buildPrBody embeds AC, test cases, claims', () => {
+    const c = new DiffCommitter();
+    const body = c.buildPrBody(makeBundle(), makeWorktree());
+    expect(body).toContain('Add /health endpoint');
+    expect(body).toContain('returns 200');
+    expect(body).toContain('TC-001');
+    expect(body).toContain('TC-002');
+    expect(body).toContain('apps/dashboard/app/health/route.ts');
+    expect(body).toContain('feat/s_health-add-health');
+    expect(body).toContain('main');
+  });
+
+  it('uses fix/ for lifecycle=bug', () => {
+    const c = new DiffCommitter();
+    const b = makeBundle();
+    (b.ticket as Record<string, unknown>).lifecycle = 'bug';
+    expect(c.derivePrTitle(b, makeWorktree())).toBe('fix(dashboard): add /health endpoint');
+  });
+
+  it('uses chore/ for lifecycle=docs', () => {
+    const c = new DiffCommitter();
+    const b = makeBundle();
+    (b.ticket as Record<string, unknown>).lifecycle = 'docs';
+    expect(c.derivePrTitle(b, makeWorktree())).toBe('chore(dashboard): add /health endpoint');
+  });
+});


### PR DESCRIPTION
## Phase 2C — CODING-005 (DiffCommitter + PR opener)

Fifth PR in the Coding Agent track. Builds on CODING-001..004 (all merged).

## What this PR ships

**`DiffCommitter` class** at `apps/worker-coding/src/diff-committer.ts`. After the Implementation Engine prints `CODING_AGENT_DONE` and `LocalTestRunner` reports green, this module commits the worktree delta and opens a GitHub PR via `gh`.

**`commit(input)`** — handles clean-tree no-op (returns current HEAD), else `git add -A` → `git commit -m <msg>` → `git rev-parse HEAD`. Conventional-commits subject derived per ticket lifecycle:

| lifecycle | type prefix |
|---|---|
| new, enhance, refactor | `feat` |
| bug | `fix` |
| chore, docs | `chore` |

Scope = bucket id (sans `bkt_` prefix). Body includes story id, branch, acceptance criteria (first 5), test case count, attribution.

**`openPr(input)`** — `git push -u origin <branch>` then `gh pr create --base <integration> --head <branch> --title <derived> --body <built>`. Returns `{ prUrl, prNumber }` parsed from gh stdout. `pushFirst: false` opt-out for re-runs after a manual push.

**`buildPrBody(bundle, worktree)`** — markdown body that mirrors the ticket: story title, branch info, AC list, test cases (Fix-It will run these), resource claims, attribution.

**`parseGhPrCreateOutput(stdout)`** — exported helper that extracts the `https://.../pull/N` URL and parses the integer pr number. Throws on unexpected output.

## Tests

14 jest cases in `tests/diff-committer.test.ts`. All green.

## DoD

- [x] Class implementing the spec from architecture report §4.5
- [x] Conventional-commits format with husky-compatible subject case
- [x] Per-lifecycle prefix (feat/fix/chore) verified
- [x] `gh pr create` URL/number parser handles edge cases
- [x] `commit` is no-op on clean tree
- [x] `pushFirst: false` opt-out tested
- [x] 14 jest cases all green

## Coordination

- Implementation Engine (CODING-003) calls `commit() → openPr()` after local tests pass.
- DoD self-check (CODING-006) re-uses `buildPrBody` to verify acceptance criteria are referenced.
- IPC server (CODING-007) reports the resulting `prNumber` + `sha` back to Task Manager via `task.coding_complete`.

## Status

11th of 31 Phase 2 PRs. CODING track: 5 of 9.
