### PR TITLE
feat(worker-coding): dod self-check before coding-complete (CODING-006)

### DIFF
--- a/apps/worker-coding/src/dod-self-check.ts
+++ b/apps/worker-coding/src/dod-self-check.ts
@@ -1,0 +1,276 @@
+/**
+ * DoD self-check — CODING-006 (Phase 2C).
+ *
+ * Runs the worker's own Definition-of-Done checklist before emitting
+ * `task.coding_complete`. The orchestrator's Fix-It Test Agent will run
+ * the *test cases* — this checklist verifies the structural surface
+ * (claims respected, lint clean, typecheck clean, PR opened with the
+ * right body, package.json not version-bumped, etc.) so failures are
+ * caught early without spending tokens on a Fix-It loop.
+ *
+ * The checklist is intentionally narrower than the full DoD in
+ * `feedback_definition_of_done.md` — that doc applies to humans + PRs;
+ * this file is the *worker's* per-story automation gate.
+ *
+ * Each check returns a `CheckResult` with a stable id so the failure
+ * event can carry per-check telemetry. `runAll(input)` returns a
+ * `DodReport` summarising pass/fail across the suite.
+ *
+ * @owner coding-agent (Phase 2C worker track)
+ */
+
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import type { Bundle } from './bundle-reader';
+import type { Worktree } from './worktree-manager';
+import type { RunResult } from './local-test-runner';
+import type { OpenPrResult } from './diff-committer';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type CheckId =
+  | 'claims-files'
+  | 'claims-schemas'
+  | 'lint-clean'
+  | 'typecheck-clean'
+  | 'package-version-not-bumped'
+  | 'pr-body-references-story'
+  | 'pr-body-references-test-cases'
+  | 'local-tests-passed';
+
+export interface CheckResult {
+  id: CheckId;
+  passed: boolean;
+  detail: string;
+}
+
+export interface DodReport {
+  passed: boolean;
+  results: CheckResult[];
+  failureCount: number;
+}
+
+export interface DodInput {
+  bundle: Bundle;
+  worktree: Worktree;
+  testRun: RunResult;
+  pr: OpenPrResult;
+  prBody: string;
+  /** Skip lint + typecheck (used in tests where there's no real worktree). */
+  skipShellChecks?: boolean;
+}
+
+export interface DodOptions {
+  fsImpl?: Pick<typeof fs, 'existsSync' | 'readFileSync'>;
+  execImpl?: typeof spawnSync;
+}
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class DodSelfCheck {
+  private readonly fs: Pick<typeof fs, 'existsSync' | 'readFileSync'>;
+  private readonly exec: typeof spawnSync;
+
+  constructor(opts: DodOptions = {}) {
+    this.fs = opts.fsImpl ?? fs;
+    this.exec = opts.execImpl ?? spawnSync;
+  }
+
+  // ─── Public ───────────────────────────────────────────────────────────────
+
+  runAll(input: DodInput): DodReport {
+    const results: CheckResult[] = [];
+    results.push(this.checkLocalTestsPassed(input));
+    results.push(this.checkClaimsFiles(input));
+    results.push(this.checkClaimsSchemas(input));
+    results.push(this.checkPrBodyReferencesStory(input));
+    results.push(this.checkPrBodyReferencesTestCases(input));
+    results.push(this.checkPackageVersionNotBumped(input));
+    if (!input.skipShellChecks) {
+      results.push(this.checkLintClean(input));
+      results.push(this.checkTypecheckClean(input));
+    }
+    const failureCount = results.filter((r) => !r.passed).length;
+    return { passed: failureCount === 0, results, failureCount };
+  }
+
+  // ─── Individual checks ────────────────────────────────────────────────────
+
+  checkLocalTestsPassed(input: DodInput): CheckResult {
+    if (input.testRun.passed) {
+      return { id: 'local-tests-passed', passed: true, detail: `${input.testRun.results.length} phase(s) green` };
+    }
+    const failedPhases = input.testRun.results.filter((r) => !r.passed).map((r) => r.phase);
+    return {
+      id: 'local-tests-passed',
+      passed: false,
+      detail: `phases failed: ${failedPhases.join(', ') || '(none ran)'}`,
+    };
+  }
+
+  checkClaimsFiles(input: DodInput): CheckResult {
+    const ticket = (input.bundle.ticket ?? {}) as Record<string, unknown>;
+    const claims = (ticket.claims ?? {}) as Record<string, unknown>;
+    const allowedFiles = (claims.files ?? []) as unknown[];
+    if (!Array.isArray(allowedFiles) || allowedFiles.length === 0) {
+      return { id: 'claims-files', passed: true, detail: 'no claims declared (read-only mode)' };
+    }
+    const allowed = new Set(allowedFiles.filter((f): f is string => typeof f === 'string'));
+    const touched = this.touchedFiles(input.worktree.path);
+    const out = touched.filter((f) => !allowed.has(f) && !this.isAllowedAuxFile(f));
+    if (out.length === 0) {
+      return { id: 'claims-files', passed: true, detail: `${touched.length} file(s) touched, all within claims` };
+    }
+    return {
+      id: 'claims-files',
+      passed: false,
+      detail: `${out.length} file(s) touched outside claims: ${out.slice(0, 5).join(', ')}${out.length > 5 ? '…' : ''}`,
+    };
+  }
+
+  checkClaimsSchemas(input: DodInput): CheckResult {
+    const ticket = (input.bundle.ticket ?? {}) as Record<string, unknown>;
+    const claims = (ticket.claims ?? {}) as Record<string, unknown>;
+    const allowedSchemas = (claims.schemas ?? []) as unknown[];
+    if (!Array.isArray(allowedSchemas) || allowedSchemas.length === 0) {
+      // No schema claims - can't have touched any (otherwise we'd see migration files in claims-files).
+      // Treat as pass; if claims-files passed and no migration is touched, we're fine.
+      return { id: 'claims-schemas', passed: true, detail: 'no schema claims declared' };
+    }
+    // Heuristic: a touched migration file (.sql under migrations/) implies a schema change.
+    // We assume the schema list is what the dev expected; an unexpected migration file would
+    // already fail claims-files.
+    return { id: 'claims-schemas', passed: true, detail: 'schema claims structurally satisfied' };
+  }
+
+  checkPrBodyReferencesStory(input: DodInput): CheckResult {
+    const id = input.bundle.story.id;
+    if (input.prBody.includes(id)) {
+      return { id: 'pr-body-references-story', passed: true, detail: `body contains story id ${id}` };
+    }
+    return {
+      id: 'pr-body-references-story',
+      passed: false,
+      detail: `pr body missing story id reference (${id})`,
+    };
+  }
+
+  checkPrBodyReferencesTestCases(input: DodInput): CheckResult {
+    const ticket = (input.bundle.ticket ?? {}) as Record<string, unknown>;
+    const tcs = ticket.testCases;
+    if (!Array.isArray(tcs) || tcs.length === 0) {
+      return { id: 'pr-body-references-test-cases', passed: true, detail: 'no test cases on ticket (skipped)' };
+    }
+    const ids = tcs
+      .map((t) => (t && typeof t === 'object' ? String((t as Record<string, unknown>).id ?? '') : ''))
+      .filter(Boolean);
+    if (ids.length === 0) {
+      return { id: 'pr-body-references-test-cases', passed: true, detail: 'no test case ids to check' };
+    }
+    const missing = ids.filter((id) => !input.prBody.includes(id));
+    if (missing.length === 0) {
+      return {
+        id: 'pr-body-references-test-cases',
+        passed: true,
+        detail: `${ids.length} test case id(s) referenced in body`,
+      };
+    }
+    return {
+      id: 'pr-body-references-test-cases',
+      passed: false,
+      detail: `pr body missing ${missing.length}/${ids.length} test case ids: ${missing.slice(0, 3).join(', ')}`,
+    };
+  }
+
+  checkPackageVersionNotBumped(input: DodInput): CheckResult {
+    // The Release Agent owns version bumps. Coding Agent must never bump
+    // package.json versions. Look for `package.json` in touched files, then
+    // diff for `"version":` lines.
+    const touched = this.touchedFiles(input.worktree.path);
+    const pkgs = touched.filter((f) => f.endsWith('package.json'));
+    if (pkgs.length === 0) {
+      return { id: 'package-version-not-bumped', passed: true, detail: 'no package.json touched' };
+    }
+    // For each touched package.json, check the diff for version line changes.
+    for (const p of pkgs) {
+      const diff = this.gitDiff(input.worktree.path, p);
+      if (/^[+-]\s*"version":/m.test(diff)) {
+        return {
+          id: 'package-version-not-bumped',
+          passed: false,
+          detail: `version-line change detected in ${p}`,
+        };
+      }
+    }
+    return { id: 'package-version-not-bumped', passed: true, detail: `${pkgs.length} package.json touched, no version changes` };
+  }
+
+  checkLintClean(input: DodInput): CheckResult {
+    const res = this.exec('bash', ['-c', 'pnpm lint || exit $?'], {
+      cwd: input.worktree.path,
+      encoding: 'utf8',
+      timeout: 300_000,
+    });
+    if ((res.status ?? -1) === 0) {
+      return { id: 'lint-clean', passed: true, detail: 'pnpm lint exit 0' };
+    }
+    return { id: 'lint-clean', passed: false, detail: `pnpm lint exit ${res.status}` };
+  }
+
+  checkTypecheckClean(input: DodInput): CheckResult {
+    const res = this.exec('bash', ['-c', 'pnpm typecheck || exit $?'], {
+      cwd: input.worktree.path,
+      encoding: 'utf8',
+      timeout: 300_000,
+    });
+    if ((res.status ?? -1) === 0) {
+      return { id: 'typecheck-clean', passed: true, detail: 'pnpm typecheck exit 0' };
+    }
+    return { id: 'typecheck-clean', passed: false, detail: `pnpm typecheck exit ${res.status}` };
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private touchedFiles(repoPath: string): string[] {
+    const res = this.exec(
+      'git',
+      ['diff', '--name-only', 'HEAD~1', 'HEAD'],
+      { cwd: repoPath, encoding: 'utf8' },
+    );
+    if ((res.status ?? -1) !== 0) {
+      // Fall back to staged/unstaged if no commit yet
+      const fallback = this.exec(
+        'git',
+        ['status', '--porcelain'],
+        { cwd: repoPath, encoding: 'utf8' },
+      );
+      return String(fallback.stdout ?? '')
+        .split('\n')
+        .map((line) => line.trim().replace(/^\S+\s+/, ''))
+        .filter(Boolean);
+    }
+    return String(res.stdout ?? '')
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  private gitDiff(repoPath: string, filePath: string): string {
+    const res = this.exec(
+      'git',
+      ['diff', 'HEAD~1', 'HEAD', '--', filePath],
+      { cwd: repoPath, encoding: 'utf8' },
+    );
+    return String(res.stdout ?? '');
+  }
+
+  private isAllowedAuxFile(p: string): boolean {
+    // pnpm-lock.yaml and journal updates are auto-managed; allow them
+    // unconditionally so claim authors don't need to enumerate them.
+    if (p === 'pnpm-lock.yaml') return true;
+    if (p.endsWith('/_journal.json')) return true;
+    if (path.basename(p) === '.test-output.log') return true;
+    return false;
+  }
+}

--- a/apps/worker-coding/tests/dod-self-check.test.ts
+++ b/apps/worker-coding/tests/dod-self-check.test.ts
@@ -1,0 +1,321 @@
+/**
+ * DodSelfCheck — CODING-006 unit tests.
+ *
+ * Stubbed exec + fs let us run the checklist deterministically. Covers
+ * each check's pass + fail path + the runAll aggregator.
+ *
+ * 14 cases.
+ */
+
+import { DodSelfCheck } from '../src/dod-self-check';
+import type { Bundle } from '../src/bundle-reader';
+import type { Worktree } from '../src/worktree-manager';
+import type { RunResult } from '../src/local-test-runner';
+import type { OpenPrResult } from '../src/diff-committer';
+
+function makeBundle(overrides: Partial<Bundle> = {}): Bundle {
+  return {
+    story: {
+      id: 's_test',
+      title: '',
+      description: '',
+      status: 'pending',
+      rootPromptId: null,
+      parentEntityId: null,
+      parentEntityType: null,
+      bucketId: null,
+      templateVersion: 'v1',
+      templateValidationStatus: 'pending',
+      templateValidationErrors: null,
+      enrichedAt: null,
+      updatedAt: null,
+    },
+    ticket: {
+      claims: { files: ['apps/dashboard/app/health/route.ts'], schemas: [], apiRoutes: [], domains: [] },
+      testCases: [{ id: 'TC-001', title: 'happy', category: 'happy' }],
+    },
+    ticketParseError: null,
+    prompt: null,
+    requirement: null,
+    bucket: null,
+    labels: [],
+    dependencies: { upstream: [], downstream: [] },
+    inputDependencies: [],
+    ...overrides,
+  };
+}
+
+function makeWorktree(): Worktree {
+  return {
+    storyId: 's_test',
+    path: '/tmp/wt/s_test',
+    branch: 'feat/s_test',
+    integrationBranch: 'main',
+    createdAt: 0,
+  };
+}
+
+function makeRunResult(passed = true): RunResult {
+  return {
+    results: [{ phase: 'unit', command: 'pnpm test', exitCode: passed ? 0 : 1, durationMs: 100, stdoutTail: '', stderrTail: '', passed }],
+    passed,
+    totalDurationMs: 100,
+    logPath: '/tmp/wt/s_test/.test-output.log',
+  };
+}
+
+function makePr(): OpenPrResult {
+  return { prNumber: 42, prUrl: 'https://github.com/x/y/pull/42' };
+}
+
+function makeExec(touched: string[], pkgDiff = '') {
+  return ((bin: string, args: string[]) => {
+    if (bin === 'git' && args[0] === 'diff' && args.includes('--name-only')) {
+      return { status: 0, stdout: touched.join('\n'), stderr: '' };
+    }
+    if (bin === 'git' && args[0] === 'diff') {
+      return { status: 0, stdout: pkgDiff, stderr: '' };
+    }
+    if (bin === 'bash') {
+      return { status: 0, stdout: 'ok', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  }) as never;
+}
+
+describe('DodSelfCheck.checkLocalTestsPassed', () => {
+  it('passes when test run passed', () => {
+    const dod = new DodSelfCheck();
+    const r = dod.checkLocalTestsPassed({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 's_test TC-001',
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when test run failed', () => {
+    const dod = new DodSelfCheck();
+    const r = dod.checkLocalTestsPassed({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(false),
+      pr: makePr(),
+      prBody: 's_test TC-001',
+    });
+    expect(r.passed).toBe(false);
+    expect(r.detail).toContain('unit');
+  });
+});
+
+describe('DodSelfCheck.checkClaimsFiles', () => {
+  it('passes when touched files all in claims', () => {
+    const exec = makeExec(['apps/dashboard/app/health/route.ts']);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const r = dod.checkClaimsFiles({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when a file outside claims is touched', () => {
+    const exec = makeExec(['apps/dashboard/app/health/route.ts', 'apps/orchestrator/src/x.ts']);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const r = dod.checkClaimsFiles({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(false);
+    expect(r.detail).toContain('apps/orchestrator/src/x.ts');
+  });
+
+  it('always allows pnpm-lock.yaml and _journal.json + .test-output.log', () => {
+    const exec = makeExec([
+      'apps/dashboard/app/health/route.ts',
+      'pnpm-lock.yaml',
+      'apps/orchestrator/src/db/migrations/meta/_journal.json',
+      '.test-output.log',
+    ]);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const r = dod.checkClaimsFiles({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('passes (read-only mode) when ticket declares no claims', () => {
+    const exec = makeExec(['apps/anything/whatever.ts']);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const bundle = makeBundle();
+    (bundle.ticket as Record<string, unknown>).claims = {};
+    const r = dod.checkClaimsFiles({
+      bundle,
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(true);
+    expect(r.detail).toContain('read-only');
+  });
+});
+
+describe('DodSelfCheck.checkPrBodyReferencesStory', () => {
+  it('passes when story id present in body', () => {
+    const dod = new DodSelfCheck();
+    const r = dod.checkPrBodyReferencesStory({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 'Story: s_test\nDoes things',
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when story id missing', () => {
+    const dod = new DodSelfCheck();
+    const r = dod.checkPrBodyReferencesStory({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 'No story id here',
+    });
+    expect(r.passed).toBe(false);
+  });
+});
+
+describe('DodSelfCheck.checkPrBodyReferencesTestCases', () => {
+  it('passes when every test case id appears', () => {
+    const dod = new DodSelfCheck();
+    const r = dod.checkPrBodyReferencesTestCases({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 'TC-001 happy path',
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when some test case ids missing', () => {
+    const dod = new DodSelfCheck();
+    const bundle = makeBundle();
+    (bundle.ticket as Record<string, unknown>).testCases = [
+      { id: 'TC-001' }, { id: 'TC-002' }, { id: 'TC-003' },
+    ];
+    const r = dod.checkPrBodyReferencesTestCases({
+      bundle,
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 'mentions TC-001 only',
+    });
+    expect(r.passed).toBe(false);
+    expect(r.detail).toContain('TC-002');
+  });
+
+  it('skipped when no test cases on ticket', () => {
+    const dod = new DodSelfCheck();
+    const bundle = makeBundle();
+    (bundle.ticket as Record<string, unknown>).testCases = [];
+    const r = dod.checkPrBodyReferencesTestCases({
+      bundle,
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 'anything',
+    });
+    expect(r.passed).toBe(true);
+    expect(r.detail).toContain('skipped');
+  });
+});
+
+describe('DodSelfCheck.checkPackageVersionNotBumped', () => {
+  it('passes when no package.json touched', () => {
+    const exec = makeExec(['apps/x/y.ts']);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const r = dod.checkPackageVersionNotBumped({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when version line changed in touched package.json', () => {
+    const exec = makeExec(['apps/x/package.json'], '+  "version": "0.2.0",\n-  "version": "0.1.0",\n');
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const r = dod.checkPackageVersionNotBumped({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(false);
+    expect(r.detail).toContain('version-line change');
+  });
+
+  it('passes when package.json touched but no version change', () => {
+    const exec = makeExec(['apps/x/package.json'], '+  "scripts": { "x": "y" },\n');
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const r = dod.checkPackageVersionNotBumped({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: '',
+    });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe('DodSelfCheck.runAll', () => {
+  it('aggregates check results', () => {
+    const exec = makeExec(['apps/dashboard/app/health/route.ts']);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const report = dod.runAll({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(true),
+      pr: makePr(),
+      prBody: 'Story: s_test\nTC-001 yes',
+      skipShellChecks: true,
+    });
+    expect(report.passed).toBe(true);
+    expect(report.failureCount).toBe(0);
+    expect(report.results.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('reports failureCount > 0 when any check fails', () => {
+    const exec = makeExec(['out/of/scope.ts']);
+    const dod = new DodSelfCheck({ execImpl: exec });
+    const report = dod.runAll({
+      bundle: makeBundle(),
+      worktree: makeWorktree(),
+      testRun: makeRunResult(false),         // tests failed
+      pr: makePr(),
+      prBody: 'no story id',                // body missing
+      skipShellChecks: true,
+    });
+    expect(report.passed).toBe(false);
+    expect(report.failureCount).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Phase 2C — CODING-006 (DoD self-check)

Sixth PR in the Coding Agent track. Builds on CODING-001..005 (all merged).

## What this PR ships

**`DodSelfCheck` class** at `apps/worker-coding/src/dod-self-check.ts`. Runs the worker's own per-story Definition-of-Done checklist before emitting `task.coding_complete`. Catches structural issues early (claims violations, lint errors, version-bumps, missing PR-body references) without spending tokens on the Fix-It loop.

**8 individual checks**, each returning a `CheckResult { id, passed, detail }`:

| id | what it verifies |
|---|---|
| `local-tests-passed` | `input.testRun.passed` from CODING-004's runner |
| `claims-files` | every touched file is within `ticket.claims.files` (with auto-allowed `pnpm-lock.yaml`, `_journal.json`, `.test-output.log`) |
| `claims-schemas` | structural placeholder; full schema-claim enforcement is a follow-up |
| `pr-body-references-story` | PR body contains the story id |
| `pr-body-references-test-cases` | PR body cites every test-case id (skipped if no test cases on ticket) |
| `package-version-not-bumped` | no `"version":` line diff in any touched `package.json` — Release Agent owns bumps |
| `lint-clean` | `pnpm lint` exit 0 (skippable for tests via `skipShellChecks`) |
| `typecheck-clean` | `pnpm typecheck` exit 0 (skippable for tests) |

**`runAll(input)`** aggregates into `DodReport { passed, results, failureCount }` so the engine can:
- emit `task.coding_failed` with structured per-check results, OR
- proceed to `task.coding_complete` → hand off to Fix-It Agent.

`skipShellChecks: true` bypass for unit tests; full lint+typecheck runs in CODING-009 E2E.

## Tests

16 jest cases in `tests/dod-self-check.test.ts`. All green.

## DoD

- [x] Class implementing the spec from architecture report §4.6
- [x] 8 checks with stable ids for telemetry
- [x] Auto-allow list for build-managed aux files
- [x] Version-bump detection guards against accidental release-agent overlap
- [x] `runAll` aggregator + failureCount surfaces multi-failure cases
- [x] 16 jest cases all green

## Coordination

- Implementation Engine (CODING-003) calls `runAll()` after `LocalTestRunner` (CODING-004) returns and `DiffCommitter.openPr()` (CODING-005) returns.
- IPC server (CODING-007) reports the DodReport's `failureCount` + per-check ids in the `task.coding_failed` event payload (when applicable).
- Test cases for CODING-009 E2E will exercise `skipShellChecks: false` against a real worktree.

## Status

12th of 31 Phase 2 PRs. CODING track: 6 of 9.
