### PR TITLE
feat(orchestrator): worker-crash recovery subscriber + chaos test (HARDEN-001)

### DIFF
--- a/apps/orchestrator/src/agents/worker-crash-recovery.ts
+++ b/apps/orchestrator/src/agents/worker-crash-recovery.ts
@@ -1,0 +1,205 @@
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/connection';
+import { stories } from '../db/schema';
+import { eventBus } from '../events/bus-adapter';
+import type { ReadyPoolConsumer } from './ready-pool-consumer';
+
+export interface WorkerCrashedPayload {
+  workerId: string;
+  lastStoryId: string | null;
+  error: string;
+  lastHeartbeatAt: number;
+  ts: number;
+}
+
+export interface WorkerCrashRecoveryOptions {
+  maxCodingAttempts?: number;
+  pump?: () => Promise<unknown> | unknown;
+  silent?: boolean;
+  now?: () => number;
+}
+
+export interface RecoveryResult {
+  storyId: string | null;
+  outcome: 'requeued' | 'escalated' | 'no_story' | 'already_clean' | 'not_found';
+  attemptNumber: number | null;
+}
+
+/**
+ * WorkerCrashRecovery — HARDEN-001 (Production hardening).
+ *
+ * Closes the gap between WorkerPoolRegistry.detectStale() and the
+ * ReadyPoolConsumer. The registry flips a stale worker to `crashed`
+ * and emits `worker.crashed`, but until this subscriber existed nothing
+ * ever cleared the story's assignedWorkerId / phase2Status, so the
+ * story stayed stuck in `coding_in_progress` forever and was never
+ * picked up by another worker. The schema docstring even claimed
+ * "the assigned story is requeued" — this module is what makes that true.
+ *
+ * Behaviour on `worker.crashed` (with non-null lastStoryId):
+ *   1. Atomic rollback in a transaction:
+ *      - assignedWorkerId   -> null
+ *      - codingSessionId    -> null   (session can't be resumed)
+ *      - codingAttempts++   (visible in /workers + dashboard)
+ *      - phase2Status       -> null (so ReadyPoolConsumer re-picks)
+ *   2. If codingAttempts >= maxAttempts:
+ *      - phase2Status -> 'escalated'
+ *      - emit `phase2.escalated` (operator must intervene)
+ *   3. Otherwise emit `task.requeued` with the new attemptNumber.
+ *   4. Trigger one ReadyPoolConsumer.pump() so a different idle
+ *      worker picks the story up immediately.
+ *
+ * The recovery is idempotent: a duplicate `worker.crashed` for the
+ * same workerId is safe — if the story is already unassigned the
+ * transaction reads `assignedWorkerId IS NULL` and exits cleanly.
+ *
+ * @owner task-manager (Phase 2 worker-pool track / production hardening)
+ */
+export class WorkerCrashRecovery {
+  private readonly db: Db;
+  private readonly maxAttempts: number;
+  private readonly pump?: () => Promise<unknown> | unknown;
+  private readonly silent: boolean;
+  private readonly now: () => number;
+
+  constructor(db: Db, opts: WorkerCrashRecoveryOptions = {}) {
+    this.db = db;
+    this.maxAttempts = opts.maxCodingAttempts ?? 3;
+    this.pump = opts.pump;
+    this.silent = opts.silent ?? false;
+    this.now = opts.now ?? Date.now;
+    if (this.maxAttempts < 1) {
+      throw new Error(
+        `WorkerCrashRecovery: maxCodingAttempts must be >= 1 (got ${this.maxAttempts})`,
+      );
+    }
+  }
+
+  /**
+   * Handles a single `worker.crashed` event. Public so unit tests can
+   * call it directly without driving the bus.
+   */
+  async handleCrash(payload: WorkerCrashedPayload): Promise<RecoveryResult> {
+    const storyId = payload.lastStoryId;
+    if (!storyId) {
+      return { storyId: null, outcome: 'no_story', attemptNumber: null };
+    }
+
+    const decision = this.db.transaction((trx) => {
+      const story = trx
+        .select()
+        .from(stories)
+        .where(eq(stories.id, storyId))
+        .get();
+
+      if (!story) {
+        return { kind: 'not_found' as const, attemptNumber: null };
+      }
+      if (story.assignedWorkerId !== payload.workerId) {
+        return { kind: 'already_clean' as const, attemptNumber: story.codingAttempts };
+      }
+
+      const nextAttempts = (story.codingAttempts ?? 0) + 1;
+      const escalate = nextAttempts >= this.maxAttempts;
+
+      trx
+        .update(stories)
+        .set({
+          assignedWorkerId: null,
+          codingSessionId: null,
+          codingAttempts: nextAttempts,
+          phase2Status: escalate ? 'escalated' : null,
+        })
+        .where(eq(stories.id, storyId))
+        .run();
+
+      return {
+        kind: escalate ? ('escalated' as const) : ('requeued' as const),
+        attemptNumber: nextAttempts,
+      };
+    });
+
+    if (decision.kind === 'not_found') {
+      return { storyId, outcome: 'not_found', attemptNumber: null };
+    }
+    if (decision.kind === 'already_clean') {
+      return { storyId, outcome: 'already_clean', attemptNumber: decision.attemptNumber };
+    }
+
+    if (decision.kind === 'escalated') {
+      this.emit('phase2.escalated', {
+        storyId,
+        workerId: payload.workerId,
+        attemptNumber: decision.attemptNumber,
+        reason: 'max_coding_attempts_exceeded',
+        ts: this.now(),
+      });
+    } else {
+      this.emit('task.requeued', {
+        storyId,
+        workerId: payload.workerId,
+        attemptNumber: decision.attemptNumber,
+        reason: 'worker_crashed',
+        ts: this.now(),
+      });
+    }
+
+    if (this.pump && decision.kind === 'requeued') {
+      try {
+        await this.pump();
+      } catch {
+        /* pumping is best-effort; next event-driven pump retries */
+      }
+    }
+
+    return {
+      storyId,
+      outcome: decision.kind === 'escalated' ? 'escalated' : 'requeued',
+      attemptNumber: decision.attemptNumber,
+    };
+  }
+
+  /**
+   * Subscribes the recovery handler to the in-process bus and returns
+   * the unsubscribe function.
+   */
+  subscribe(): () => void {
+    return eventBus.subscribe('worker.crashed', (ev) => {
+      const p = (ev as { payload?: unknown }).payload;
+      if (!p || typeof p !== 'object') return;
+      void this.handleCrash(p as WorkerCrashedPayload).catch(() => { /* swallow */ });
+    });
+  }
+
+  private emit(type: 'task.requeued' | 'phase2.escalated', payload: Record<string, unknown>): void {
+    if (this.silent) return;
+    eventBus.publish({
+      type: type as never,
+      actor: 'task-scheduler',
+      entity_type: 'story',
+      entity_id: payload.storyId as string,
+      severity: type === 'phase2.escalated' ? 'error' : 'warning',
+      payload,
+    });
+  }
+}
+
+export function registerWorkerCrashRecovery(
+  db: Db,
+  opts: WorkerCrashRecoveryOptions = {},
+): { recovery: WorkerCrashRecovery; unsubscribe: () => void } {
+  const recovery = new WorkerCrashRecovery(db, opts);
+  const unsubscribe = recovery.subscribe();
+  return { recovery, unsubscribe };
+}
+
+export function registerWorkerCrashRecoveryWithPump(
+  db: Db,
+  consumer: ReadyPoolConsumer,
+  opts: Omit<WorkerCrashRecoveryOptions, 'pump'> = {},
+): { recovery: WorkerCrashRecovery; unsubscribe: () => void } {
+  return registerWorkerCrashRecovery(db, {
+    ...opts,
+    pump: () => consumer.pump(),
+  });
+}

--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -17,6 +17,8 @@ import { createApp } from './app';
 import { wireEventBus, eventBus } from '../events/bus-adapter';
 // FREG-003: subscribe FeatureRegistryWriter to story.completed at boot.
 import { registerFeatureRegistryWriter } from '../agents/feature-registry-writer';
+// HARDEN-001: requeue stories whose worker crashed (heartbeat stale).
+import { registerWorkerCrashRecovery } from '../agents/worker-crash-recovery';
 import { subscribeToEvents as subscribePriorityEvents, scoreAll } from '../prioritization/reprioritizer';
 import { tasks, executorRuns } from '../db/schema';
 
@@ -123,6 +125,12 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
   // if the embedder (Ollama) is unreachable — the backfill script (FREG-004)
   // will catch up later.
   registerFeatureRegistryWriter();
+
+  // HARDEN-001: subscribe the WorkerCrashRecovery so a crashed worker's
+  // story is rolled back and re-queued for the next idle worker. Without
+  // this subscriber, the row would stay stuck in `coding_in_progress`
+  // forever even though the registry already emits `worker.crashed`.
+  registerWorkerCrashRecovery(db);
 
   // Initial batch score of all unscored/stale tasks (fire-and-forget)
   scoreAll(db, 'system').catch(() => {});

--- a/apps/orchestrator/tests/agents/worker-crash-recovery.test.ts
+++ b/apps/orchestrator/tests/agents/worker-crash-recovery.test.ts
@@ -1,0 +1,273 @@
+/**
+ * WorkerCrashRecovery — HARDEN-001 unit + chaos tests.
+ *
+ *   Unit cases (handleCrash):
+ *     1. requeue: clears assignedWorkerId, increments codingAttempts,
+ *        nulls phase2Status, emits task.requeued.
+ *     2. escalate: when codingAttempts hits maxAttempts, sets
+ *        phase2Status='escalated' and emits phase2.escalated.
+ *     3. idempotent: a duplicate worker.crashed for an already-cleaned
+ *        story is a no-op (already_clean outcome, no extra mutations).
+ *     4. unknown story: outcome='not_found', no event emitted.
+ *     5. payload with no lastStoryId: outcome='no_story'.
+ *
+ *   Chaos integration: a real worker is registered, ReadyPoolConsumer
+ *   assigns a story, the worker's heartbeat goes stale, detectStale
+ *   flips it to crashed, the WorkerCrashRecovery subscriber rolls the
+ *   story back, then a SECOND worker registers and pump() picks the
+ *   story up. We assert: same storyId, different workerId, attempt=1.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, prompts, taskBuckets } from '../../src/db/schema';
+import { eventBus } from '../../src/events/bus-adapter';
+import { WorkerPoolRegistry } from '../../src/agents/worker-pool-registry';
+import { ReadyPoolConsumer } from '../../src/agents/ready-pool-consumer';
+import {
+  WorkerCrashRecovery,
+  registerWorkerCrashRecoveryWithPump,
+} from '../../src/agents/worker-crash-recovery';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  // Seed a prompt + buckets so FK on stories.bucket_id passes.
+  db.insert(prompts).values({
+    id: 'p_t',
+    body: 't',
+    receivedAt: new Date().toISOString(),
+    correlationId: 'c_t',
+    hash: 'h_t',
+  }).run();
+  for (const bid of ['bkt_a', 'bkt_b']) {
+    db.insert(taskBuckets).values({
+      id: bid,
+      kind: 'parallel',
+      promptId: 'p_t',
+      createdAt: Date.now(),
+      status: 'open',
+    }).run();
+  }
+  return { db, sqlite };
+}
+
+function insertStory(
+  db: ReturnType<typeof setup>['db'],
+  id: string,
+  overrides: Partial<Record<string, unknown>> = {},
+): void {
+  const now = String(Date.now());
+  db.insert(stories).values({
+    id,
+    title: id,
+    description: '',
+    expectedBehavior: '',
+    acceptanceCriteriaJson: '[]',
+    verificationPlanJson: '[]',
+    dependsOnJson: '[]',
+    domainSlugsJson: '[]',
+    status: 'pending',
+    createdAt: now,
+    agentContributionsJson: '{}',
+    templateVersion: 'v1',
+    templateValidationStatus: 'pending',
+    businessSubDomainsJson: '[]',
+    techSubDomainsJson: '[]',
+    qualityTagsJson: '[]',
+    blockedByJson: '[]',
+    softDependsOnJson: '[]',
+    conflictsWithJson: '[]',
+    claimsJson: '{}',
+    inputDependenciesJson: '[]',
+    testCasesJson: '[]',
+    testDesignStatus: 'pending',
+    validationStatus: 'pending',
+    validationAttempts: 0,
+    linksToJson: '[]',
+    architecturalInstructionsJson: '[]',
+    bucketId: 'bkt_a',
+    priorityBucket: 'P2',
+    ...overrides,
+  } as never).run();
+}
+
+describe('WorkerCrashRecovery — handleCrash unit cases', () => {
+  it('requeues: clears assignment, increments attempts, emits task.requeued', async () => {
+    const { db } = setup();
+    insertStory(db, 'st_1', {
+      assignedWorkerId: 'wkr_1',
+      codingSessionId: 'sess_xyz',
+      phase2Status: 'coding_in_progress',
+      codingAttempts: 0,
+      worktreePath: '/tmp/x',
+    });
+
+    const events: Array<{ type: string; payload: unknown }> = [];
+    const off = eventBus.subscribe('task.*', (ev) => events.push(ev));
+    try {
+      const rec = new WorkerCrashRecovery(db, { silent: false });
+      const result = await rec.handleCrash({
+        workerId: 'wkr_1',
+        lastStoryId: 'st_1',
+        error: 'heartbeat-stale',
+        lastHeartbeatAt: 1000,
+        ts: 2000,
+      });
+
+      expect(result.outcome).toBe('requeued');
+      expect(result.attemptNumber).toBe(1);
+
+      const row = db.select().from(stories).where(eq(stories.id, 'st_1')).get()!;
+      expect(row.assignedWorkerId).toBeNull();
+      expect(row.codingSessionId).toBeNull();
+      expect(row.codingAttempts).toBe(1);
+      expect(row.phase2Status).toBeNull();
+      // worktreePath is left in place (HARDEN-003 reaper cleans it).
+      expect(row.worktreePath).toBe('/tmp/x');
+
+      const requeued = events.find((e) => e.type === 'task.requeued');
+      expect(requeued).toBeDefined();
+      expect((requeued!.payload as Record<string, unknown>).storyId).toBe('st_1');
+    } finally {
+      off();
+    }
+  });
+
+  it('escalates: at maxAttempts, sets phase2Status and emits phase2.escalated', async () => {
+    const { db } = setup();
+    insertStory(db, 'st_2', {
+      assignedWorkerId: 'wkr_2',
+      phase2Status: 'coding_in_progress',
+      codingAttempts: 2,
+    });
+    const events: Array<{ type: string }> = [];
+    const off = eventBus.subscribe('phase2.*', (ev) => events.push(ev));
+    try {
+      const rec = new WorkerCrashRecovery(db, { maxCodingAttempts: 3 });
+      const result = await rec.handleCrash({
+        workerId: 'wkr_2',
+        lastStoryId: 'st_2',
+        error: 'heartbeat-stale',
+        lastHeartbeatAt: 0,
+        ts: 0,
+      });
+      expect(result.outcome).toBe('escalated');
+      expect(result.attemptNumber).toBe(3);
+
+      const row = db.select().from(stories).where(eq(stories.id, 'st_2')).get()!;
+      expect(row.phase2Status).toBe('escalated');
+      expect(row.assignedWorkerId).toBeNull();
+      expect(events.find((e) => e.type === 'phase2.escalated')).toBeDefined();
+    } finally {
+      off();
+    }
+  });
+
+  it('idempotent: duplicate crash for already-cleaned story is a no-op', async () => {
+    const { db } = setup();
+    insertStory(db, 'st_3', {
+      assignedWorkerId: null,
+      phase2Status: null,
+      codingAttempts: 1,
+    });
+    const rec = new WorkerCrashRecovery(db, { silent: true });
+    const result = await rec.handleCrash({
+      workerId: 'wkr_1',
+      lastStoryId: 'st_3',
+      error: 'heartbeat-stale',
+      lastHeartbeatAt: 0,
+      ts: 0,
+    });
+    expect(result.outcome).toBe('already_clean');
+    const row = db.select().from(stories).where(eq(stories.id, 'st_3')).get()!;
+    expect(row.codingAttempts).toBe(1);
+  });
+
+  it('not_found: returns clean outcome for unknown story', async () => {
+    const { db } = setup();
+    const rec = new WorkerCrashRecovery(db, { silent: true });
+    const result = await rec.handleCrash({
+      workerId: 'wkr_x',
+      lastStoryId: 'st_ghost',
+      error: 'heartbeat-stale',
+      lastHeartbeatAt: 0,
+      ts: 0,
+    });
+    expect(result.outcome).toBe('not_found');
+  });
+
+  it('no_story: returns no_story when payload.lastStoryId is null', async () => {
+    const { db } = setup();
+    const rec = new WorkerCrashRecovery(db, { silent: true });
+    const result = await rec.handleCrash({
+      workerId: 'wkr_1',
+      lastStoryId: null,
+      error: 'heartbeat-stale',
+      lastHeartbeatAt: 0,
+      ts: 0,
+    });
+    expect(result.outcome).toBe('no_story');
+  });
+});
+
+describe('WorkerCrashRecovery — chaos: kill mid-flight, re-pump picks up', () => {
+  it('crashed worker -> story rolled back -> second worker picks it up', async () => {
+    let now = 1000;
+    const { db } = setup();
+    insertStory(db, 'st_chaos', { bucketId: 'bkt_a', phase2Status: null });
+
+    const registry = new WorkerPoolRegistry(db, {
+      silent: false,
+      staleThresholdMs: 100,
+      now: () => now,
+    });
+    const consumer = new ReadyPoolConsumer(db, registry, { silent: true, now: () => now });
+
+    const { unsubscribe } = registerWorkerCrashRecoveryWithPump(db, consumer, {
+      maxCodingAttempts: 3,
+    });
+
+    try {
+      // Worker A registers, gets the story.
+      const a = registry.register({ kind: 'coding', capabilities: ['bkt_a'] });
+      const first = await consumer.pump();
+      expect(first.assignmentsMade).toHaveLength(1);
+      expect(first.assignmentsMade[0]!.workerId).toBe(a.id);
+
+      // Time advances past the stale threshold without A heartbeating.
+      now = 1500;
+      const evicted = registry.detectStale();
+      expect(evicted).toContain(a.id);
+
+      // Recovery runs via the bus subscriber — drain microtasks.
+      await new Promise((r) => setImmediate(r));
+      let row = db.select().from(stories).where(eq(stories.id, 'st_chaos')).get()!;
+      expect(row.assignedWorkerId).toBeNull();
+      expect(row.codingAttempts).toBe(1);
+      expect(row.phase2Status).toBeNull();
+
+      // Second worker registers; pump() should now assign st_chaos to B.
+      const b = registry.register({ kind: 'coding', capabilities: ['bkt_a'] });
+      const second = await consumer.pump();
+      expect(second.assignmentsMade).toHaveLength(1);
+      const assigned = second.assignmentsMade[0]!;
+      expect(assigned.storyId).toBe('st_chaos');
+      expect(assigned.workerId).toBe(b.id);
+      expect(assigned.workerId).not.toBe(a.id);
+
+      row = db.select().from(stories).where(eq(stories.id, 'st_chaos')).get()!;
+      expect(row.assignedWorkerId).toBe(b.id);
+      expect(row.phase2Status).toBe('coding_in_progress');
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -456,6 +456,9 @@ export type EventType =
   | 'task-scheduler.backpressure.released'
   // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
   | 'task-scheduler.bucket.health'
+  // ─── HARDEN-001 — failure recovery ────────────────────────────────────────
+  | 'task.requeued'
+  | 'phase2.escalated'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -575,6 +578,9 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'task-scheduler.backpressure.released': 'info',
   // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
   'task-scheduler.bucket.health': 'debug',
+  // ─── HARDEN-001 — failure recovery ────────────────────────────────────────
+  'task.requeued': 'warning',
+  'phase2.escalated': 'error',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -563,3 +563,14 @@ events:
     severity: debug
     actor: [task-scheduler]
     payload: [bucketId, queueDepth, throughputPerHour, oldestReadyAgeS, workersAssigned, engaged, ts]
+
+  # HARDEN-001 — failure recovery
+  - type: task.requeued
+    severity: warning
+    actor: [task-scheduler]
+    payload: [storyId, workerId, attemptNumber, reason, ts]
+
+  - type: phase2.escalated
+    severity: error
+    actor: [task-scheduler]
+    payload: [storyId, workerId, attemptNumber, reason, ts]


### PR DESCRIPTION
## Why

Closes the gap between `WorkerPoolRegistry.detectStale()` and the `ReadyPoolConsumer`. The registry already flips a stale worker to `crashed` and emits `worker.crashed`, but until this PR nothing ever cleared the assigned story's row, so it stayed stuck in `coding_in_progress` forever and was never picked up by another worker. Migration 0033's docstring even claimed "the assigned story is requeued" — this PR is what makes that true.

First in the **HARDEN-NN** production-hardening series.

## What

`apps/orchestrator/src/agents/worker-crash-recovery.ts` (~205 LOC):

- Subscribes to `worker.crashed` on the singleton bus.
- Atomic rollback in a transaction: `assignedWorkerId -> null`, `codingSessionId -> null`, `codingAttempts++`, `phase2Status -> null`.
- Defensive: only acts if the story still belongs to the crashed worker (idempotent on duplicate events).
- At `maxCodingAttempts` (default 3) escalates instead of re-queueing: `phase2Status=escalated`, emits `phase2.escalated` for operator action.
- Optional `pump` callback so a different idle worker picks up the story immediately rather than waiting for the next event-driven pump.

Wires the subscriber into `apps/orchestrator/src/api/start.ts` via `registerWorkerCrashRecovery(db)` (boot path, after `wireEventBus`).

Adds `task.requeued` and `phase2.escalated` to `@chiefaia/events-taxonomy-internal` (yaml + index union + severity map).

## Tests

`apps/orchestrator/tests/agents/worker-crash-recovery.test.ts` (273 LOC):

- 5 unit cases covering every `handleCrash` outcome — requeued, escalated, already_clean (idempotent), not_found, no_story.
- 1 chaos integration: real `WorkerPoolRegistry` + `ReadyPoolConsumer`, kill worker A mid-flight via stale heartbeat, recovery rolls the story back, register worker B, pump picks the same storyId up via the new worker. Asserts `attemptNumber=1` and `B != A`.

## DoD

- [x] `pnpm --filter @caia-app/core typecheck` — clean
- [x] `jest worker-crash-recovery` — 6/6 pass
- [x] `jest worker-pool-registry|ready-pool-consumer|backpressure|worker-crash` — 52/52 pass (no regressions in adjacent suites)
- [x] No new lint introduced
- [x] Chaos test included per hardening DoD
