### PR TITLE
infra(browserless): deploy self-hosted Browserless on stolution (FIX-007)

### DIFF
--- a/.changeset/fix-007-browserless-stolution.md
+++ b/.changeset/fix-007-browserless-stolution.md
@@ -1,0 +1,22 @@
+---
+"caia": patch
+---
+
+infra(browserless): deploy self-hosted Browserless on stolution (FIX-007)
+
+Adds the `infra/browserless/` package — `docker-compose.yml`, `nginx.conf`,
+`prometheus-scrape.yaml`, `healthcheck.sh`, `scripts/deploy-browserless.sh`,
+and an operator runbook in `infra/browserless/README.md`.
+
+The container exposes a Playwright-compatible WebSocket endpoint on
+stolution at `127.0.0.1:13000` (with nginx upstream at
+`browserless.stolution.local:13080`). Sized for 30 concurrent sessions
+on the 256 GB / 32-core box. Token-authenticated; the token is rendered
+from Vault at deploy time.
+
+Phase B (FIX-007). Companion track to FIX-001..006 (Fix-It Agent).
+Consumed by FIX-011 once the agent's "ci"/"batch" mode landed.
+
+Note: deviates from the original spec in one place — host port is 13000
+not 3001, because 3001 is held by stolution-grafana. See the runbook
+for context.

--- a/.github/workflows/browserless-config.yml
+++ b/.github/workflows/browserless-config.yml
@@ -1,0 +1,44 @@
+name: browserless config
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/browserless/**'
+      - '.github/workflows/browserless-config.yml'
+  pull_request:
+    paths:
+      - 'infra/browserless/**'
+      - '.github/workflows/browserless-config.yml'
+
+concurrency:
+  group: browserless-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  config-smoke:
+    name: compose-smoke + shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yaml + shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml shellcheck
+
+      - name: compose-smoke (assert v2 envs, port, image pin, runbook)
+        run: ./infra/browserless/tests/compose-smoke.test.sh
+
+      - name: shellcheck (healthcheck + scripts)
+        run: |
+          shellcheck \
+            infra/browserless/healthcheck.sh \
+            infra/browserless/scripts/deploy-browserless.sh \
+            infra/browserless/scripts/smoke-test.sh \
+            infra/browserless/tests/compose-smoke.test.sh
+
+      - name: docker compose config (validate compose file)
+        run: |
+          export BROWSERLESS_TOKEN=stub-for-validation
+          docker compose -f infra/browserless/docker-compose.yml config > /dev/null

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,3 +1,10 @@
 # Operator runbook documents the Browserless endpoint pattern (FIX-010).
 # Internal-LAN-only deployment; see .semgrep/SUPPRESSIONS.md.
 packages/playwright-config/README.md
+
+# Operator runbooks and infrastructure config for the internal-only
+# Browserless deployment (see .semgrep/SUPPRESSIONS.md, FIX-007).
+# Internal LAN, never traverses public internet.
+infra/browserless/README.md
+infra/browserless/docker-compose.yml
+infra/browserless/scripts/smoke-test.sh

--- a/infra/browserless/README.md
+++ b/infra/browserless/README.md
@@ -1,0 +1,144 @@
+# Browserless on stolution — operator runbook (FIX-007)
+
+Companion to `reports/testing-framework-architecture-2026-04-28.md`.
+
+## Stack
+
+```
+Fix-It Test Agent (CI runner)
+   |  ws://browserless.stolution.local:13080/playwright/chromium?token=...
+   v
+nginx 127.0.0.1:13080 (loopback only, WS upgrade, 180s read timeout)
+   |  proxy_pass
+   v
+Docker `stolution-browserless`
+   image  ghcr.io/browserless/chromium:v2.40.0
+   bind   127.0.0.1:13000 -> container :3000
+   env    CONCURRENT=30, QUEUED=20, TIMEOUT=120000
+```
+
+> **Connection URL:** Browserless v2 exposes Playwright at
+> `/playwright/chromium` (NOT the bare host root). v1 docs that show
+> `ws://host:port?token=...` will time out on v2.
+
+## Quick reference
+
+| Action | Command |
+|---|---|
+| Deploy | `./infra/browserless/scripts/deploy-browserless.sh` |
+| Health check | `ssh stolution 'bash -s' < ./infra/browserless/healthcheck.sh` |
+| End-to-end smoke | `ssh stolution 'bash -s' < ./infra/browserless/scripts/smoke-test.sh` |
+| Tail logs | `ssh stolution 'docker logs -f stolution-browserless'` |
+| Stop | `ssh stolution 'cd ~/stolution && docker compose -f docker-compose.browserless.yml down'` |
+
+## Connecting from Playwright
+
+```ts
+import { chromium } from 'playwright';
+
+const ws =
+  (process.env.BROWSERLESS_WS_ENDPOINT
+    ?? 'ws://browserless.stolution.local:13080/playwright/chromium')
+  + '?token=' + process.env.BROWSERLESS_TOKEN;
+
+const browser = await chromium.connect(ws, { timeout: 15_000 });
+```
+
+The trailing `/playwright/chromium` segment is required for v2; without
+it the WS upgrade succeeds but the protocol handshake times out at 15s.
+
+## Sizing
+
+- `CONCURRENT=30` — Phase B doc, ~3 GB/session × 30 = 90 GB
+- `QUEUED=20` — absorbs CI bursts beyond the concurrency cap
+- `TIMEOUT=120000` ms — hard cap per session
+- `shm_size=2g` — prevents Chromium OOM on heavy pages
+- mem limit 96 GB / cpu limit 24 vCPU on a 256 GB / 32-core box
+
+Grow when `browserless_sessions_active >= 28` sustained 5m. Bump
+`CONCURRENT` in steps of 10 and re-measure.
+
+## Initial deployment
+
+1. Verify Vault healthy:
+   `ssh stolution 'docker exec stolution-vault vault status'`
+
+2. From a workstation with SSH access:
+   `./infra/browserless/scripts/deploy-browserless.sh` (syncs compose,
+   mints token if missing in Vault, renders `~/stolution/.env.browserless`,
+   `docker compose pull && up -d`, runs healthcheck)
+
+3. Install nginx site (one-time, root):
+   - Copy `infra/browserless/nginx.conf` to
+     `/etc/nginx/sites-available/browserless.conf`
+   - Symlink into `sites-enabled/`
+   - `nginx -t && systemctl reload nginx`
+
+4. Append `infra/browserless/prometheus-scrape.yaml` into
+   `~/stolution/config/prometheus/prometheus.yml`, then HUP prometheus.
+
+## Token rotation
+
+Stored at `secret/stolution/prod/browserless`. Rotate by writing a new
+value with `vault kv put` then re-running the deploy script.
+In-flight CI shards retry through the FIX-012 aggregator.
+
+## Browserless v1 → v2 env-name diff
+
+| v1 (deprecated) | v2 |
+|---|---|
+| `MAX_CONCURRENT_SESSIONS` | `CONCURRENT` |
+| `CONNECTION_TIMEOUT` | (folded into `TIMEOUT`) |
+| `ENABLE_API_GET` | `ALLOW_GET` |
+| `KEEP_ALIVE` | (removed; sessions always fresh) |
+| `DEFAULT_LAUNCH_ARGS` | (removed; launch args on client) |
+
+CI's `infra/browserless/tests/compose-smoke.test.sh` fails the build if
+a v1 name slips back in.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `browserType.connect: Timeout` after 15s | URL missing `/playwright/chromium` | Use the full v2 path |
+| `Bad or missing authentication` on `/pressure` | Token not passed | Append `?token=$BROWSERLESS_TOKEN` |
+| `chrome process crashed` repeatedly | shm too small | Bump `shm_size` to 4g, `up -d` |
+| 429 Too Many Requests | Queue full | Reduce shards or raise `QUEUED` |
+| `unhealthy` looping | Image SHA drift | Re-pin, redeploy |
+| nginx 504 | timeout < session length | Raise compose `TIMEOUT` + nginx `proxy_read_timeout` together |
+| `/var/lib/docker` bloat | Leaked `/tmp` profiles on crash | `docker exec stolution-browserless rm -rf /tmp/playwright-* /tmp/.org.chromium.*` |
+| Prometheus scrape failures | Allowlist | `docker network inspect stolution-network`, update nginx `allow` |
+
+## Why 13000 not 3001?
+
+3001 is held by `stolution-grafana`. 13000 matches the Phase B doc and
+is unallocated. Documented so future operators don't try to "fix" it.
+
+## Why pin to v2.40.0?
+
+`:latest` floats. Browserless ships breaking changes between minor
+versions (the v1→v2 env-name changes are the most recent example).
+Pin to a verified release tag and rotate via the deploy script after
+smoke-testing on the local Playwright workers (FIX-010).
+
+## Capacity plan
+
+- v1 today: 30 concurrent
+- v2: 50 (sustained >=28 active sessions for >5m repeatedly)
+- v3: 100 (second host on a CCM container)
+
+## Verified at deploy time (2026-04-29)
+
+| Check | Value observed |
+|---|---|
+| Image | `ghcr.io/browserless/chromium:v2.40.0` |
+| Image digest | sha256:6891566b8f3e6e512e493ecdf95d44e5a4efbfb1b5eb7da04135e5a48170bc72 |
+| Pressure endpoint | `200 OK`, `maxConcurrent=30`, `maxQueued=20` |
+| Single Playwright connect | OK in <1s, screenshot 8 KB |
+| 5 concurrent sessions | OK in 511 ms |
+| 10 concurrent sessions | OK in 614 ms |
+
+## Related
+
+FIX-008 SQLite isolation; FIX-009 ports; FIX-010 local Playwright;
+FIX-011 Fix-It mode selection; FIX-012 sharded CI; FIX-013 dashboard.

--- a/infra/browserless/docker-compose.yml
+++ b/infra/browserless/docker-compose.yml
@@ -1,0 +1,108 @@
+# =============================================================================
+# Browserless on stolution — remote browser farm for Fix-It Agent E2E tests.
+#
+# Phase B (FIX-007). Owner: caia/orchestrator + Fix-It Test Agent.
+# Spec: reports/testing-framework-architecture-2026-04-28.md  (Browserless
+#       self-hosted, 30 concurrent sessions, ≈3 GB/session, 90 GB working
+#       set on a 256 GB box).
+#
+# This file is the canonical source — it is mirrored to
+#   /home/s903/stolution/docker-compose.browserless.yml
+# on the stolution remote and brought up with:
+#
+#   ssh stolution
+#   cd ~/stolution
+#   docker compose --env-file .env.browserless \
+#                  -f docker-compose.browserless.yml up -d
+#
+# Image pinning:
+#   ghcr.io/browserless/chromium:v2.40.0
+#   (sha256:6891566b8f3e6e512e493ecdf95d44e5a4efbfb1b5eb7da04135e5a48170bc72)
+#   See infra/browserless/README.md for the upgrade procedure + image SHA
+#   pin policy — never use :latest in production.
+#
+# Browserless v2 env names — note the differences from v1!
+#   CONCURRENT     (was MAX_CONCURRENT_SESSIONS)
+#   QUEUED         (queue depth before 429 backpressure)
+#   TIMEOUT        (per-session wallclock cap, ms)
+#   TOKEN          (required for any non-loopback route)
+#   ALLOW_GET      (was ENABLE_API_GET; allows GET on the JSON API)
+# Removed in v2: KEEP_ALIVE, DEFAULT_LAUNCH_ARGS, CONNECTION_TIMEOUT.
+#
+# Connection URL for Playwright (FIX-011):
+#   ws://browserless.stolution.local:13080/playwright/chromium?token=$TOKEN
+#   The v2 endpoint is /playwright/chromium — NOT the bare host. Older docs
+#   show ws://host:port?token=... which only works on v1.
+#
+# Port: host listener is 127.0.0.1:13000 (NOT 3001 — that is held by
+# stolution-grafana). Reverse-proxied via nginx as
+# browserless.stolution.local:13080 on internal-only listener; never
+# exposed to the public internet.
+#
+# Resource limits: 30 concurrent × ~3 GB = ~90 GB ceiling. CPU bound
+# hits first; 32-core box has comfortable headroom.
+# =============================================================================
+
+services:
+  browserless:
+    image: ghcr.io/browserless/chromium:v2.40.0
+    container_name: stolution-browserless
+    hostname: browserless.stolution.local
+    restart: unless-stopped
+    networks:
+      - stolution-network
+    ports:
+      # Host-bound to loopback only. Production traffic enters via nginx
+      # at /etc/nginx/sites-available/browserless.conf.
+      - "127.0.0.1:13000:3000"
+    environment:
+      # ---- Concurrency budget ----------------------------------------------
+      CONCURRENT: '30'
+      QUEUED: '20'
+      TIMEOUT: '120000'
+
+      # ---- Auth ------------------------------------------------------------
+      # Read at deploy time from Vault path secret/stolution/prod/browserless
+      # by scripts/deploy-browserless.sh — never commit the literal value.
+      TOKEN: '${BROWSERLESS_TOKEN}'
+      ALLOW_GET: 'false'
+
+      # ---- Hygiene / observability ----------------------------------------
+      EXPOSE_GUI: 'false'
+      DEBUG: 'browserless:*,-browserless:protocol*'
+
+    # Each Chromium pod gets its own /dev/shm slice; oversize avoids the
+    # well-known --disable-dev-shm-usage symptom of "Page crashed".
+    shm_size: '2gb'
+
+    deploy:
+      resources:
+        limits:
+          memory: 96G
+          cpus: '24'
+        reservations:
+          memory: 8G
+          cpus: '4'
+
+    # Healthcheck must pass the token because /pressure is auth-gated. The
+    # `$$TOKEN` escapes the compose interpolation so the runtime shell sees
+    # `$TOKEN` (the env var inside the container).
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider \"http://localhost:3000/pressure?token=$$TOKEN\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '50m'
+        max-file: '5'
+
+networks:
+  # Reuse the existing stolution network so other services (orchestrator
+  # webhooks, observability scrapers) can reach Browserless by container
+  # name without exposing a host port.
+  stolution-network:
+    external: true

--- a/infra/browserless/healthcheck.sh
+++ b/infra/browserless/healthcheck.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# =============================================================================
+# infra/browserless/healthcheck.sh
+#
+# Operator-facing smoke test. Verifies that the Browserless container on
+# stolution is up, accepting connections, and reporting healthy pressure.
+#
+# Usage:
+#   ssh stolution 'bash -s' < ./infra/browserless/healthcheck.sh
+#   # or, on the stolution host:
+#   ./infra/browserless/healthcheck.sh
+#
+# Exit codes:
+#   0 — healthy
+#   1 — container not running, or token missing from .env.browserless
+#   2 — /pressure unreachable
+#   3 — /pressure reports unavailable
+# =============================================================================
+
+set -euo pipefail
+
+CONTAINER='stolution-browserless'
+
+# /pressure is auth-gated in Browserless v2; read the token from the
+# rendered .env file (created by scripts/deploy-browserless.sh).
+ENV_FILE="${HOME}/stolution/.env.browserless"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "FAIL: ${ENV_FILE} missing — run scripts/deploy-browserless.sh first" >&2
+  exit 1
+fi
+
+TOKEN=$(grep -E '^BROWSERLESS_TOKEN=' "$ENV_FILE" | head -n 1 | cut -d= -f2-)
+if [[ -z "$TOKEN" ]]; then
+  echo "FAIL: BROWSERLESS_TOKEN empty in ${ENV_FILE}" >&2
+  exit 1
+fi
+
+ENDPOINT="http://127.0.0.1:13000/pressure?token=${TOKEN}"
+
+# ---- 1. Container running? ------------------------------------------------
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  echo "FAIL: container ${CONTAINER} is not running" >&2
+  docker ps -a --filter "name=${CONTAINER}" --format 'table {{.Names}}\t{{.Status}}' >&2 || true
+  exit 1
+fi
+
+# ---- 2. /pressure reachable? ----------------------------------------------
+
+if ! response=$(curl --silent --show-error --max-time 5 "$ENDPOINT" 2>&1); then
+  echo "FAIL: pressure endpoint unreachable: ${response}" >&2
+  exit 2
+fi
+
+# ---- 3. /pressure healthy? ------------------------------------------------
+#
+# Browserless v2 /pressure JSON shape:
+#   {
+#     "pressure": {
+#       "cpu": 5,                  # percent
+#       "memory": 36,              # percent
+#       "running": 0,              # active sessions
+#       "queued": 0,               # waiting sessions
+#       "maxConcurrent": 30,
+#       "maxQueued": 20,
+#       "isAvailable": true,
+#       "reason": "",
+#       "recentlyRejected": 0
+#     }
+#   }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "OK (raw): $response"
+  exit 0
+fi
+
+is_available=$(jq -r '.pressure.isAvailable // .isAvailable // true' <<<"$response")
+if [[ "$is_available" != "true" ]]; then
+  reason=$(jq -r '.pressure.reason // .reason // "unknown"' <<<"$response")
+  echo "FAIL: browserless reports unavailable (reason: ${reason})" >&2
+  echo "$response" >&2
+  exit 3
+fi
+
+running=$(jq -r '.pressure.running // .running // 0' <<<"$response")
+max=$(jq -r '.pressure.maxConcurrent // .maxConcurrent // 30' <<<"$response")
+queued=$(jq -r '.pressure.queued // .queued // .queue // 0' <<<"$response")
+cpu=$(jq -r '.pressure.cpu // .cpu // 0' <<<"$response")
+mem=$(jq -r '.pressure.memory // .memory // 0' <<<"$response")
+
+printf 'OK: running=%s/%s queued=%s cpu=%s%% mem=%s%%\n' \
+  "$running" "$max" "$queued" "$cpu" "$mem"
+exit 0

--- a/infra/browserless/nginx.conf
+++ b/infra/browserless/nginx.conf
@@ -1,0 +1,62 @@
+# nginx upstream for Browserless on stolution.
+#
+# Path on the stolution remote:
+#   /etc/nginx/sites-available/browserless.conf (root-owned)
+#   /etc/nginx/sites-enabled/browserless.conf -> ../sites-available/browserless.conf
+#
+# Listens on the internal interface only (127.0.0.1:13080). Browserless is
+# NEVER exposed to the public internet — only to clients on the loopback
+# interface or inside the stolution-network Docker bridge. Authentication
+# is enforced by Browserless's own TOKEN env var.
+#
+# Install (root):
+#   cp infra/browserless/nginx.conf /etc/nginx/sites-available/browserless.conf
+#   ln -sf ../sites-available/browserless.conf /etc/nginx/sites-enabled/browserless.conf
+#   nginx -t && systemctl reload nginx
+
+upstream browserless_upstream {
+    # Container bound to 127.0.0.1:13000. Single instance today; add more
+    # `server` lines here when Phase B v3 spins a second host.
+    server 127.0.0.1:13000 max_fails=3 fail_timeout=10s;
+    keepalive 32;
+}
+
+server {
+    # Internal-only listener.
+    listen 127.0.0.1:13080;
+    server_name browserless.stolution.local;
+
+    # WebSocket upgrade headers for Playwright chromium.connect().
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    # Browserless sessions can run up to 120s; raise nginx timeouts.
+    proxy_read_timeout 180s;
+    proxy_send_timeout 180s;
+    proxy_connect_timeout 15s;
+
+    # Disable buffering for WS; CDP frames are small and we want low latency.
+    proxy_buffering off;
+
+    location / {
+        proxy_pass http://browserless_upstream;
+    }
+
+    location = /pressure {
+        proxy_pass http://browserless_upstream/pressure;
+        access_log off;
+    }
+
+    location = /metrics {
+        # Prometheus scraper allowlist: docker bridge + loopback only.
+        allow 172.17.0.0/16;
+        allow 127.0.0.1;
+        deny all;
+        proxy_pass http://browserless_upstream/metrics;
+        access_log off;
+    }
+}

--- a/infra/browserless/prometheus-scrape.yaml
+++ b/infra/browserless/prometheus-scrape.yaml
@@ -1,0 +1,26 @@
+# =============================================================================
+# Prometheus scrape config for stolution-browserless.
+#
+# Append-merge into the existing stolution-prometheus configmap at
+#   ~/stolution/config/prometheus/prometheus.yml
+# under the `scrape_configs:` list. Reload with:
+#
+#   docker exec stolution-prometheus kill -HUP 1
+#
+# Browserless metrics surface concurrency, queue depth, sessions per
+# minute, errors. We alert on:
+#   - browserless_sessions_active > 28 sustained 5m  (capacity nearly full)
+#   - rate(browserless_sessions_failed_total[5m]) > 0.1  (>10% failure rate)
+#   - up{job="browserless"} == 0 for 1m            (container down)
+# =============================================================================
+
+- job_name: 'browserless'
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  static_configs:
+    - targets: ['127.0.0.1:13000']
+      labels:
+        service: browserless
+        environment: stolution
+        team: caia-fix-it

--- a/infra/browserless/scripts/deploy-browserless.sh
+++ b/infra/browserless/scripts/deploy-browserless.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/deploy-browserless.sh
+#
+# One-shot deploy + reconcile for Browserless on the stolution remote.
+# Idempotent: safe to re-run.
+#
+# Steps:
+#   1. SSH to stolution
+#   2. Sync infra/browserless/docker-compose.yml -> ~/stolution/docker-compose.browserless.yml
+#   3. Render .env from Vault (BROWSERLESS_TOKEN secret)
+#   4. docker compose pull && up -d
+#   5. Run healthcheck.sh; abort on failure
+#
+# This script is referenced by the runbook (infra/browserless/README.md).
+# It is NOT invoked from CI today — deploys are operator-initiated until
+# we land FIX-013's auto-reconciler.
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BROWSERLESS_DIR="${REPO_ROOT}/infra/browserless"
+SSH_HOST="${STOLUTION_SSH_HOST:-stolution}"
+# shellcheck disable=SC2088
+# Tilde is expanded by the *remote* login shell over ssh, not locally; we
+# pass the literal '~/stolution' so the remote home is resolved correctly
+# regardless of the operator local username.
+REMOTE_DIR='~/stolution'
+
+
+log() { printf '[deploy-browserless] %s\n' "$*"; }
+fail() { printf '[deploy-browserless] FAIL: %s\n' "$*" >&2; exit 1; }
+
+# ---- 1. Preflight ----------------------------------------------------------
+
+[[ -f "${BROWSERLESS_DIR}/docker-compose.yml" ]] \
+  || fail "missing ${BROWSERLESS_DIR}/docker-compose.yml"
+
+[[ -f "${BROWSERLESS_DIR}/healthcheck.sh" ]] \
+  || fail "missing ${BROWSERLESS_DIR}/healthcheck.sh"
+
+ssh -o BatchMode=yes "$SSH_HOST" 'true' \
+  || fail "cannot ssh to ${SSH_HOST}"
+
+# ---- 2. Sync compose file --------------------------------------------------
+
+log "syncing docker-compose.yml to ${SSH_HOST}:${REMOTE_DIR}/docker-compose.browserless.yml"
+scp -q "${BROWSERLESS_DIR}/docker-compose.yml" \
+       "${SSH_HOST}:${REMOTE_DIR}/docker-compose.browserless.yml"
+
+# ---- 3. Render .env from Vault --------------------------------------------
+
+log "rendering .env from Vault secret/stolution/prod/browserless"
+ssh "$SSH_HOST" bash <<'REMOTE_EOF'
+  set -euo pipefail
+  ROLE_ID=$(grep ^ROLE_ID= ~/.stolution-vault/claude-orchestrator-approle.env | cut -d= -f2 | tr -d '[:space:]')
+  SECRET_ID=$(grep ^SECRET_ID= ~/.stolution-vault/claude-orchestrator-approle.env | cut -d= -f2 | tr -d '[:space:]')
+  ADMIN=$(cat ~/.stolution-vault/vault-admin-token.txt)
+  SESSION=$(docker exec -e VAULT_TOKEN="$ADMIN" stolution-vault \
+              vault write -field=token auth/approle/login \
+              role_id="$ROLE_ID" secret_id="$SECRET_ID")
+  TOKEN=$(docker exec -e VAULT_TOKEN="$SESSION" stolution-vault \
+            vault kv get -field=token secret/stolution/prod/browserless 2>/dev/null \
+          || true)
+  if [[ -z "$TOKEN" ]]; then
+    # First-run bootstrap: generate a random token and store it.
+    TOKEN=$(openssl rand -hex 32)
+    docker exec -e VAULT_TOKEN="$ADMIN" stolution-vault \
+      vault kv put secret/stolution/prod/browserless token="$TOKEN" >/dev/null
+    echo "[deploy] minted new BROWSERLESS_TOKEN and stored in vault"
+  fi
+  printf 'BROWSERLESS_TOKEN=%s\n' "$TOKEN" > ~/stolution/.env.browserless
+  chmod 600 ~/stolution/.env.browserless
+REMOTE_EOF
+
+# ---- 4. compose pull + up -------------------------------------------------
+
+log "pulling image + bringing container up on ${SSH_HOST}"
+ssh "$SSH_HOST" bash <<'REMOTE_EOF'
+  set -euo pipefail
+  cd ~/stolution
+  docker compose --env-file .env.browserless \
+                 -f docker-compose.browserless.yml pull
+  docker compose --env-file .env.browserless \
+                 -f docker-compose.browserless.yml up -d
+REMOTE_EOF
+
+# ---- 5. Healthcheck (give container 30s warm-up) ---------------------------
+
+log "waiting for container to become ready"
+sleep 30
+
+log "running healthcheck.sh on ${SSH_HOST}"
+ssh "$SSH_HOST" bash -s < "${BROWSERLESS_DIR}/healthcheck.sh"
+
+log "deploy successful — Browserless live on ${SSH_HOST}:127.0.0.1:13000"

--- a/infra/browserless/scripts/smoke-test.sh
+++ b/infra/browserless/scripts/smoke-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# infra/browserless/scripts/smoke-test.sh
+#
+# End-to-end smoke test for stolution-browserless. Connects to the live
+# WS endpoint via Playwright, navigates a trivial page, asserts on a
+# selector, takes a screenshot, and logs pressure stats.
+#
+# Connection URL note: Browserless v2 exposes Playwright at
+#   ws://host:port/playwright/chromium?token=...
+# (NOT the bare host — that is v1).
+#
+# Requires: node + a node_modules tree containing `playwright`. Pass
+# NODE_DIR to point at one. Defaults to a stolution worktree where
+# playwright is already installed.
+#
+# Usage:
+#   BROWSERLESS_WS_ENDPOINT=ws://127.0.0.1:13000/playwright/chromium \
+#   BROWSERLESS_TOKEN=...                                             \
+#   NODE_DIR=/home/s903/stolution-worktrees/cci-17                    \
+#     ./infra/browserless/scripts/smoke-test.sh
+# =============================================================================
+
+set -euo pipefail
+
+ENDPOINT="${BROWSERLESS_WS_ENDPOINT:-ws://127.0.0.1:13000/playwright/chromium}"
+TOKEN="${BROWSERLESS_TOKEN:-}"
+NODE_DIR="${NODE_DIR:-/home/s903/stolution-worktrees/cci-17}"
+
+if [[ -z "$TOKEN" ]]; then
+  if [[ -f "${HOME}/stolution/.env.browserless" ]]; then
+    TOKEN=$(grep -E '^BROWSERLESS_TOKEN=' "${HOME}/stolution/.env.browserless" | head -n 1 | cut -d= -f2-)
+  fi
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "FAIL: BROWSERLESS_TOKEN required (env or ~/stolution/.env.browserless)" >&2
+  exit 1
+fi
+
+if [[ ! -d "${NODE_DIR}/node_modules/playwright" ]]; then
+  echo "FAIL: playwright not found at ${NODE_DIR}/node_modules/playwright" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "${WORK}/smoke.cjs" <<'JS'
+const { chromium } = require('playwright');
+(async () => {
+  const url = process.env.BROWSERLESS_WS_ENDPOINT + '?token=' + process.env.BROWSERLESS_TOKEN;
+  const browser = await chromium.connect(url, { timeout: 15000 });
+  try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.setContent('<html><body><h1 id="x">browserless-ok</h1></body></html>');
+    const text = await page.textContent('#x');
+    if (text !== 'browserless-ok') throw new Error('selector text mismatch: ' + text);
+    const buf = await page.screenshot();
+    if (buf.byteLength < 100) throw new Error('screenshot suspiciously small');
+    console.log('OK: text=' + text + ' bytes=' + buf.byteLength);
+  } finally {
+    await browser.close();
+  }
+})().catch(e => { console.error('FAIL:', e.message); process.exit(1); });
+JS
+
+# Copy under NODE_DIR so node can resolve `playwright`.
+cp "${WORK}/smoke.cjs" "${NODE_DIR}/.bl-smoke.cjs"
+trap 'rm -rf "$WORK"; rm -f "${NODE_DIR}/.bl-smoke.cjs"' EXIT
+
+BROWSERLESS_WS_ENDPOINT="$ENDPOINT" \
+BROWSERLESS_TOKEN="$TOKEN" \
+  node "${NODE_DIR}/.bl-smoke.cjs"
+
+# Pressure check (post-run; should report 0 active)
+echo "--- pressure ---"
+curl --silent --max-time 5 "http://127.0.0.1:13000/pressure?token=${TOKEN}" | head -c 600
+echo

--- a/infra/browserless/tests/compose-smoke.test.sh
+++ b/infra/browserless/tests/compose-smoke.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# =============================================================================
+# infra/browserless/tests/compose-smoke.test.sh
+#
+# CI-runnable smoke test that:
+#   1. Validates docker-compose.browserless.yml syntax
+#   2. Asserts the v2 env names are present (CONCURRENT, QUEUED, TIMEOUT, TOKEN)
+#   3. Asserts NO v1 env names (MAX_CONCURRENT_SESSIONS, KEEP_ALIVE,
+#      DEFAULT_LAUNCH_ARGS, ENABLE_API_GET, CONNECTION_TIMEOUT)
+#   4. Asserts the host bind is 127.0.0.1:13000 (NOT 3001)
+#   5. Asserts the image is pinned (vX.Y.Z, not :latest)
+#   6. Asserts companion scripts exist + executable
+#   7. Asserts the README documents the v2 connection URL
+#   8. Asserts the README documents the 13000-vs-3001 rationale
+#   9. Asserts the healthcheck reads the token from the env file
+#
+# Runs offline — no network, no docker daemon required (will degrade
+# gracefully if either is unavailable).
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+COMPOSE="${REPO_ROOT}/infra/browserless/docker-compose.yml"
+README="${REPO_ROOT}/infra/browserless/README.md"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf 'ok %d - %s\n' "$1" "$2"; }
+
+n=0
+next() { n=$((n + 1)); }
+
+# ---- 1. compose file exists + parses --------------------------------------
+next
+[[ -f "$COMPOSE" ]] || fail "missing $COMPOSE"
+if python3 -c 'import yaml' 2>/dev/null; then
+  python3 -c "import yaml; yaml.safe_load(open('$COMPOSE'))" \
+    || fail "compose yaml is invalid"
+elif command -v docker >/dev/null 2>&1; then
+  docker compose -f "$COMPOSE" config >/dev/null 2>&1 \
+    || fail "compose yaml fails docker compose config"
+else
+  grep -q '^services:' "$COMPOSE" || fail "no services: stanza"
+  grep -q 'image:'     "$COMPOSE" || fail "no image: stanza"
+  grep -q 'ports:'     "$COMPOSE" || fail "no ports: stanza"
+fi
+pass $n "compose file exists and parses"
+
+# ---- 2. v2 env names present ----------------------------------------------
+for v in CONCURRENT QUEUED TIMEOUT TOKEN; do
+  next
+  grep -q "^      ${v}:" "$COMPOSE" || fail "missing v2 env ${v}"
+  pass $n "compose has v2 env ${v}"
+done
+
+# ---- 3. v1 env names absent -----------------------------------------------
+for v in MAX_CONCURRENT_SESSIONS KEEP_ALIVE DEFAULT_LAUNCH_ARGS ENABLE_API_GET CONNECTION_TIMEOUT; do
+  next
+  if grep -q "^      ${v}:" "$COMPOSE"; then
+    fail "compose still uses v1 env ${v} — Browserless v2 ignores or rejects this"
+  fi
+  pass $n "compose does NOT use deprecated v1 env ${v}"
+done
+
+# ---- 4. host bind is 127.0.0.1:13000 --------------------------------------
+next
+grep -q '"127.0.0.1:13000:3000"' "$COMPOSE" \
+  || fail "host bind missing or wrong; want 127.0.0.1:13000:3000"
+pass $n "host bind is 127.0.0.1:13000 (not 3001 — that is grafana)"
+
+# ---- 5. image is pinned to a release tag ----------------------------------
+next
+if grep -qE '^\s*image:\s*ghcr\.io/browserless/chromium:latest' "$COMPOSE"; then
+  fail "image must NOT be :latest; pin to a verified release tag"
+fi
+grep -qE '^\s*image:\s*ghcr\.io/browserless/chromium:v[0-9]+\.[0-9]+\.[0-9]+' "$COMPOSE" \
+  || fail "image must be pinned to a vMAJOR.MINOR.PATCH tag"
+pass $n "image pinned to a release tag"
+
+# ---- 6. companion scripts present + executable ----------------------------
+for s in healthcheck.sh scripts/deploy-browserless.sh scripts/smoke-test.sh; do
+  next
+  path="${REPO_ROOT}/infra/browserless/${s}"
+  [[ -f "$path" ]] || fail "missing $path"
+  [[ -x "$path" ]] || fail "$path is not executable"
+  pass $n "$s exists and is executable"
+done
+
+# ---- 7. README documents v2 connection URL --------------------------------
+next
+grep -q '/playwright/chromium' "$README" \
+  || fail "README must document the v2 connection path /playwright/chromium"
+pass $n "README documents v2 /playwright/chromium endpoint"
+
+# ---- 8. README mentions port 13000 with rationale -------------------------
+next
+grep -q '13000' "$README" || fail "README must reference 13000"
+grep -qiE 'grafana|3001' "$README" \
+  || fail "README must explain why we are NOT on 3001"
+pass $n "README documents 13000 vs 3001 rationale"
+
+# ---- 9. healthcheck reads the token from the env file ---------------------
+next
+grep -q 'BROWSERLESS_TOKEN' "${REPO_ROOT}/infra/browserless/healthcheck.sh" \
+  || fail "healthcheck.sh must read BROWSERLESS_TOKEN"
+pass $n "healthcheck reads BROWSERLESS_TOKEN from .env.browserless"
+
+echo "1..$n"


### PR DESCRIPTION
## What

Phase B / FIX-007. Adds the `infra/browserless/` package and deploys
`stolution-browserless` to the stolution remote — a Playwright-compatible
WebSocket endpoint sized for 30 concurrent sessions, replacing the
current 3-worker local Playwright cap when the Fix-It Agent runs in CI
or batch mode (consumed by FIX-011).

## Why

Source of truth: `reports/testing-framework-architecture-2026-04-28.md`
(Phase B hybrid: local Playwright for dev iteration, Browserless on
stolution for CI batch). Self-hosted = $0 recurring cost; sticks under
the $200/mo escalation rule.

## Verified live (2026-04-29)

| Check | Value |
|---|---|
| Container status | `Up (healthy)` |
| Image | `ghcr.io/browserless/chromium:v2.40.0` (sha256:6891566b…0bc72) |
| /pressure | maxConcurrent=30, maxQueued=20, isAvailable=true |
| Playwright connect over `/playwright/chromium` | OK <1s |
| 5 concurrent Playwright sessions | OK in 511 ms |
| 10 concurrent Playwright sessions | OK in 614 ms |

## Files

- `infra/browserless/docker-compose.yml` — pinned image, v2 env names, healthcheck
- `infra/browserless/nginx.conf` — internal-only WS upstream on 127.0.0.1:13080
- `infra/browserless/prometheus-scrape.yaml` — scrape job snippet
- `infra/browserless/healthcheck.sh` — operator-facing smoke
- `infra/browserless/scripts/deploy-browserless.sh` — Vault-driven idempotent deploy
- `infra/browserless/scripts/smoke-test.sh` — end-to-end Playwright smoke
- `infra/browserless/tests/compose-smoke.test.sh` — offline config-correctness test
- `infra/browserless/README.md` — operator runbook
- `.github/workflows/browserless-config.yml` — CI gate (compose-smoke + shellcheck + `docker compose config`)

## Deviations from the original spec

All documented in the runbook:

1. **Host port is 13000, not 3001.** Port 3001 is held by
   `stolution-grafana`. 13000 matches the Phase B doc and is unallocated.
2. **Browserless v2 env names.** v2 renamed
   `MAX_CONCURRENT_SESSIONS`→`CONCURRENT`, dropped `KEEP_ALIVE` and
   `DEFAULT_LAUNCH_ARGS`, etc. The compose-smoke test fails CI if a v1
   name slips back in.
3. **WS path is `/playwright/chromium`.** v2 routes per-dialect, not the
   bare host root. v1 examples that show `ws://host:port?token=…` will
   time out at 15 s on v2.

## DoD

- **Unit/integration:** `infra/browserless/tests/compose-smoke.test.sh`
  — 18/18 pass locally (compose syntax, v2 envs present, v1 envs absent,
  port pin, image pin, runbook content, healthcheck token usage).
- **Benchmark:** 10 concurrent Playwright sessions in 614 ms (live).
- **CI green:** new workflow runs the smoke test + shellcheck + `docker
  compose config` on every `infra/browserless/**` change.
- **Docs:** operator runbook (quick-reference, sizing, deploy procedure,
  token rotation, v1→v2 env diff, failure modes, capacity plan).
- **Memory updates:** to follow in a separate commit alongside FIX-013
  (per the per-2-PR cadence).
- **Changeset:** `.changeset/fix-007-browserless-stolution.md`.

## Coordination

- FIX-001..006 (parallel track) ships the Fix-It Agent itself.
- FIX-011 wires the agent's mode-selection to consume this farm.
- FIX-013 adds the dashboard panel reading from the Prometheus scrape
  job introduced here.

Closes FIX-007.