### PR TITLE
feat(orchestrator): per-pipeline-run cost tracking + alert (HARDEN-002)

### DIFF
--- a/apps/orchestrator/src/agents/pipeline-cost-tracker.ts
+++ b/apps/orchestrator/src/agents/pipeline-cost-tracker.ts
@@ -1,0 +1,297 @@
+/**
+ * PipelineCostTracker — HARDEN-002 (Production hardening).
+ *
+ * Per-pipeline-run cost accounting joined to the prompt's correlation_id.
+ * The existing in-memory llmMetrics tracker (LAI-006) gives a global
+ * aggregate, but operators need to know which pipeline-run is racking
+ * up dollars and which agent inside that run is responsible. This
+ * module persists every call to the `pipeline_run_costs` table and
+ * fires `pipeline.cost.alert` once per run when the cumulative spend
+ * crosses an env-configurable ceiling.
+ *
+ * Schema: pipeline_run_costs (migration 0035)
+ *   - correlation_id     primary key
+ *   - total_calls / local_calls / claude_calls  rolling counts
+ *   - total_cost_usd / baseline_cost_usd        rolling dollars (4dp)
+ *   - per_agent_breakdown_json                  { [agent]: { calls, costUsd, baselineUsd } }
+ *   - started_at / last_updated_at              epoch ms
+ *   - alert_triggered_at                        first time the threshold tripped
+ *
+ * The tracker is plugged into the POST /llm/route handler — every call
+ * with a correlationId + agent in the body lands here.
+ *
+ * @owner observability (Phase 2 / production hardening)
+ */
+
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/connection';
+import { pipelineRunCosts } from '../db/schema';
+import { eventBus } from '../events/bus-adapter';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface CostCallInput {
+  correlationId: string;
+  /** The agent or pipeline stage that issued the LLM call. */
+  agent: string;
+  /** 'local' (Ollama) or 'claude'. */
+  provider: 'local' | 'claude';
+  /** Cost actually incurred (0 for local). */
+  estimatedCostUsd: number;
+  /** What this call would have cost if routed to Claude (the savings). */
+  baselineCostUsd: number;
+}
+
+export interface CostSnapshot {
+  correlationId: string;
+  totalCalls: number;
+  localCalls: number;
+  claudeCalls: number;
+  totalCostUsd: number;
+  baselineCostUsd: number;
+  savedUsd: number;
+  perAgent: Record<string, { calls: number; costUsd: number; baselineUsd: number }>;
+  startedAt: number;
+  lastUpdatedAt: number;
+  alertTriggeredAt: number | null;
+}
+
+export interface TrackerOptions {
+  /** Threshold in USD. Default $5. Single-run ceiling. */
+  alertThresholdUsd?: number;
+  /** Skip event emission (unit tests). */
+  silent?: boolean;
+  /** Override Date.now (tests). */
+  now?: () => number;
+}
+
+// ─── Class ──────────────────────────────────────────────────────────────────
+
+export class PipelineCostTracker {
+  private readonly db: Db;
+  private readonly threshold: number;
+  private readonly silent: boolean;
+  private readonly now: () => number;
+
+  constructor(db: Db, opts: TrackerOptions = {}) {
+    this.db = db;
+    this.threshold = opts.alertThresholdUsd ?? 5;
+    this.silent = opts.silent ?? false;
+    this.now = opts.now ?? Date.now;
+    if (this.threshold <= 0) {
+      throw new Error(
+        `PipelineCostTracker: alertThresholdUsd must be > 0 (got ${this.threshold})`,
+      );
+    }
+  }
+
+  /**
+   * Records a single LLM call into the per-run row. Idempotent on the
+   * insert (UPSERT-style: ROW MISSING -> create with started_at; row
+   * present -> bump counters). Returns the post-update snapshot so
+   * callers can immediately surface dashboard updates without an extra
+   * read.
+   */
+  recordCall(input: CostCallInput): CostSnapshot {
+    const ts = this.now();
+
+    const snapshot = this.db.transaction((trx) => {
+      const existing = trx
+        .select()
+        .from(pipelineRunCosts)
+        .where(eq(pipelineRunCosts.correlationId, input.correlationId))
+        .get();
+
+      const breakdown = existing
+        ? safeJsonObject(existing.perAgentBreakdownJson)
+        : {};
+
+      const agentEntry = (breakdown[input.agent] as
+        | { calls?: number; costUsd?: number; baselineUsd?: number }
+        | undefined) ?? { calls: 0, costUsd: 0, baselineUsd: 0 };
+      breakdown[input.agent] = {
+        calls: (agentEntry.calls ?? 0) + 1,
+        costUsd: round4((agentEntry.costUsd ?? 0) + input.estimatedCostUsd),
+        baselineUsd: round4((agentEntry.baselineUsd ?? 0) + input.baselineCostUsd),
+      };
+
+      const totalCalls = (existing?.totalCalls ?? 0) + 1;
+      const localCalls = (existing?.localCalls ?? 0) + (input.provider === 'local' ? 1 : 0);
+      const claudeCalls = (existing?.claudeCalls ?? 0) + (input.provider === 'claude' ? 1 : 0);
+      const totalCostUsd = round4((existing?.totalCostUsd ?? 0) + input.estimatedCostUsd);
+      const baselineCostUsd = round4((existing?.baselineCostUsd ?? 0) + input.baselineCostUsd);
+      const startedAt = existing?.startedAt ?? ts;
+      const alertTriggeredAt = existing?.alertTriggeredAt ?? null;
+
+      if (existing) {
+        trx
+          .update(pipelineRunCosts)
+          .set({
+            totalCalls,
+            localCalls,
+            claudeCalls,
+            totalCostUsd,
+            baselineCostUsd,
+            perAgentBreakdownJson: JSON.stringify(breakdown),
+            lastUpdatedAt: ts,
+          })
+          .where(eq(pipelineRunCosts.correlationId, input.correlationId))
+          .run();
+      } else {
+        trx
+          .insert(pipelineRunCosts)
+          .values({
+            correlationId: input.correlationId,
+            totalCalls,
+            localCalls,
+            claudeCalls,
+            totalCostUsd,
+            baselineCostUsd,
+            perAgentBreakdownJson: JSON.stringify(breakdown),
+            startedAt,
+            lastUpdatedAt: ts,
+            alertTriggeredAt: null,
+          })
+          .run();
+      }
+
+      return {
+        totalCalls,
+        localCalls,
+        claudeCalls,
+        totalCostUsd,
+        baselineCostUsd,
+        breakdown,
+        startedAt,
+        alertTriggeredAt,
+      };
+    });
+
+    // Threshold trip — fire once per run.
+    let alertTriggeredAt = snapshot.alertTriggeredAt;
+    if (alertTriggeredAt === null && snapshot.totalCostUsd >= this.threshold) {
+      this.db
+        .update(pipelineRunCosts)
+        .set({ alertTriggeredAt: ts })
+        .where(eq(pipelineRunCosts.correlationId, input.correlationId))
+        .run();
+      alertTriggeredAt = ts;
+      this.emit({
+        correlationId: input.correlationId,
+        totalCostUsd: snapshot.totalCostUsd,
+        thresholdUsd: this.threshold,
+        ts,
+      });
+    }
+
+    return {
+      correlationId: input.correlationId,
+      totalCalls: snapshot.totalCalls,
+      localCalls: snapshot.localCalls,
+      claudeCalls: snapshot.claudeCalls,
+      totalCostUsd: snapshot.totalCostUsd,
+      baselineCostUsd: snapshot.baselineCostUsd,
+      savedUsd: round4(snapshot.baselineCostUsd - snapshot.totalCostUsd),
+      perAgent: snapshot.breakdown as CostSnapshot['perAgent'],
+      startedAt: snapshot.startedAt,
+      lastUpdatedAt: ts,
+      alertTriggeredAt,
+    };
+  }
+
+  /** Returns the snapshot for a run (or null). */
+  get(correlationId: string): CostSnapshot | null {
+    const row = this.db
+      .select()
+      .from(pipelineRunCosts)
+      .where(eq(pipelineRunCosts.correlationId, correlationId))
+      .get();
+    if (!row) return null;
+    const breakdown = safeJsonObject(row.perAgentBreakdownJson);
+    return {
+      correlationId: row.correlationId,
+      totalCalls: row.totalCalls,
+      localCalls: row.localCalls,
+      claudeCalls: row.claudeCalls,
+      totalCostUsd: row.totalCostUsd,
+      baselineCostUsd: row.baselineCostUsd,
+      savedUsd: round4(row.baselineCostUsd - row.totalCostUsd),
+      perAgent: breakdown as CostSnapshot['perAgent'],
+      startedAt: row.startedAt,
+      lastUpdatedAt: row.lastUpdatedAt,
+      alertTriggeredAt: row.alertTriggeredAt ?? null,
+    };
+  }
+
+  /** Returns the N most-recent runs sorted by lastUpdatedAt desc. */
+  recent(limit = 25): CostSnapshot[] {
+    const rows = this.db
+      .select()
+      .from(pipelineRunCosts)
+      .all()
+      .sort((a, b) => b.lastUpdatedAt - a.lastUpdatedAt)
+      .slice(0, limit);
+    return rows.map((row) => ({
+      correlationId: row.correlationId,
+      totalCalls: row.totalCalls,
+      localCalls: row.localCalls,
+      claudeCalls: row.claudeCalls,
+      totalCostUsd: row.totalCostUsd,
+      baselineCostUsd: row.baselineCostUsd,
+      savedUsd: round4(row.baselineCostUsd - row.totalCostUsd),
+      perAgent: safeJsonObject(row.perAgentBreakdownJson) as CostSnapshot['perAgent'],
+      startedAt: row.startedAt,
+      lastUpdatedAt: row.lastUpdatedAt,
+      alertTriggeredAt: row.alertTriggeredAt ?? null,
+    }));
+  }
+
+  private emit(payload: {
+    correlationId: string;
+    totalCostUsd: number;
+    thresholdUsd: number;
+    ts: number;
+  }): void {
+    if (this.silent) return;
+    eventBus.publish({
+      type: 'pipeline.cost.alert' as never,
+      actor: 'system',
+      entity_type: 'pipeline_run',
+      entity_id: payload.correlationId,
+      severity: 'warning',
+      correlation_id: payload.correlationId,
+      payload,
+    });
+  }
+}
+
+function safeJsonObject(s: string | null | undefined): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(s ?? '{}');
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}
+
+// ─── Singleton ──────────────────────────────────────────────────────────────
+
+let _singleton: PipelineCostTracker | null = null;
+
+export function getPipelineCostTracker(db?: Db, opts: TrackerOptions = {}): PipelineCostTracker {
+  if (_singleton) return _singleton;
+  if (!db) throw new Error('PipelineCostTracker singleton not yet initialised — pass db on first call');
+  _singleton = new PipelineCostTracker(db, opts);
+  return _singleton;
+}
+
+/** Test-only seam: reset the singleton between cases. */
+export function __resetPipelineCostTracker(): void {
+  _singleton = null;
+}

--- a/apps/orchestrator/src/api/app.ts
+++ b/apps/orchestrator/src/api/app.ts
@@ -70,7 +70,7 @@ export function createApp(db: Db): Hono {
   registerPromptsRoutes(app, db);
   registerPriorityRoutes(app, db);
   registerPulseRoutes(app, db);
-  registerLlmRoutes(app);
+  registerLlmRoutes(app, db);
   registerStatsRoutes(app);
   registerAgentRoutes(app, db);
   registerBucketsRoutes(app, db);

--- a/apps/orchestrator/src/api/routes/llm.ts
+++ b/apps/orchestrator/src/api/routes/llm.ts
@@ -8,6 +8,8 @@
 //   3. GET /llm/metrics returns the aggregated snapshot.
 
 import type { Hono } from 'hono';
+import type { Db } from '../../db/connection';
+import { getPipelineCostTracker } from '../../agents/pipeline-cost-tracker';
 import {
   route,
   getRoute,
@@ -29,10 +31,14 @@ interface LlmRouteBody {
   prompt?: string;
   forceLocal?: boolean;
   forceClaude?: boolean;
+  /** HARDEN-002: pipeline-run id (the prompt's correlation_id). */
+  correlationId?: string;
+  /** HARDEN-002: which agent issued the call (e.g. 'po-agent'). */
+  agent?: string;
 }
 
 // @no-events — pure routing decision endpoint, downstream handlers emit events
-export function registerLlmRoutes(app: Hono): void {
+export function registerLlmRoutes(app: Hono, db: Db): void {
   app.get('/llm/rules', (c) => {
     return c.json({
       rules: ROUTING_RULES,
@@ -115,7 +121,30 @@ export function registerLlmRoutes(app: Hono): void {
         .labels(provider)
         .inc(Math.max(0, baselinePerCall - actualPerCall));
 
-      return c.json(result);
+      // HARDEN-002: persist per-pipeline-run cost when the caller tags
+      // the request with a correlationId + agent. Falls back to silent
+      // no-op so the legacy in-memory tracker still wins for smoke runs.
+      let costSnapshot: ReturnType<ReturnType<typeof getPipelineCostTracker>['recordCall']> | null = null;
+      if (body.correlationId && body.agent) {
+        try {
+          const tracker = getPipelineCostTracker(db, {
+            alertThresholdUsd: parseFloat(
+              process.env['CAIA_PIPELINE_COST_ALERT_USD'] ?? '5',
+            ),
+          });
+          costSnapshot = tracker.recordCall({
+            correlationId: body.correlationId,
+            agent: body.agent,
+            provider,
+            estimatedCostUsd: actualPerCall,
+            baselineCostUsd: baselinePerCall,
+          });
+        } catch {
+          // Cost tracking is observability — never break the route.
+        }
+      }
+
+      return c.json({ ...result, costSnapshot });
     } catch (err) {
       // Best-effort metrics on failure — we still want the call counted
       // even if it errored, so failure rates are visible on the dashboard.

--- a/apps/orchestrator/src/api/routes/metrics.ts
+++ b/apps/orchestrator/src/api/routes/metrics.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono';
 import type { Db } from '../../db/connection';
 import { tasks, blockers, requirements } from '../../db/schema';
+import { getPipelineCostTracker } from '../../agents/pipeline-cost-tracker';
 
 // @no-events — route registration wrapper, individual handlers emit events
 export function registerMetricsRoutes(app: Hono, db: Db): void {
@@ -46,5 +47,29 @@ export function registerMetricsRoutes(app: Hono, db: Db): void {
       totalTasks: filteredTasks.length,
       completedTasks: completedTasks.length,
     });
+  });
+
+  // HARDEN-002: per-pipeline-run cost surface — feeds the dashboard
+  // /metrics/cost panel. Returns the requested run when ?correlationId
+  // is given, otherwise the most-recent N runs (default 25).
+  app.get('/metrics/cost', (c) => {
+    const { correlationId, limit } = c.req.query() as Record<string, string>;
+    let tracker;
+    try {
+      tracker = getPipelineCostTracker(db, {
+        alertThresholdUsd: parseFloat(
+          process.env['CAIA_PIPELINE_COST_ALERT_USD'] ?? '5',
+        ),
+      });
+    } catch {
+      return c.json({ runs: [], note: 'cost-tracker not initialised' });
+    }
+    if (correlationId) {
+      const snap = tracker.get(correlationId);
+      if (!snap) return c.json({ run: null }, 404);
+      return c.json({ run: snap });
+    }
+    const n = limit ? Math.min(Math.max(parseInt(limit, 10) || 25, 1), 200) : 25;
+    return c.json({ runs: tracker.recent(n) });
   });
 }

--- a/apps/orchestrator/src/db/migrations/0035_pipeline_run_costs.sql
+++ b/apps/orchestrator/src/db/migrations/0035_pipeline_run_costs.sql
@@ -1,0 +1,29 @@
+-- Migration 0035: HARDEN-002 — per-pipeline-run cost tracking.
+--
+-- One row per pipeline-run (keyed by the prompt's correlation_id). Every
+-- LLM call routed through @chiefaia/local-llm-router updates the row in
+-- place: total_calls / local_calls / claude_calls / total_cost_usd /
+-- baseline_cost_usd / per_agent_breakdown_json. The dashboard reads
+-- these rows for the /metrics/cost panel.
+--
+-- alert_triggered_at is set the first time a single run exceeds the
+-- env-configurable threshold (CAIA_PIPELINE_COST_ALERT_USD, default $5).
+-- Once set, no further alerts fire for that run — the operator has been
+-- notified.
+
+CREATE TABLE IF NOT EXISTS `pipeline_run_costs` (
+  `correlation_id`        text PRIMARY KEY NOT NULL,
+  `total_calls`           integer NOT NULL DEFAULT 0,
+  `local_calls`           integer NOT NULL DEFAULT 0,
+  `claude_calls`          integer NOT NULL DEFAULT 0,
+  `total_cost_usd`        real    NOT NULL DEFAULT 0,
+  `baseline_cost_usd`     real    NOT NULL DEFAULT 0,
+  `per_agent_breakdown_json` text NOT NULL DEFAULT '{}',
+  `started_at`            integer NOT NULL,
+  `last_updated_at`       integer NOT NULL,
+  `alert_triggered_at`    integer
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `pipeline_run_costs_updated_idx`
+  ON `pipeline_run_costs` (`last_updated_at`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1778400000000,
       "tag": "0034_bucket_health_history",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1779000000000,
+      "tag": "0035_pipeline_run_costs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -1200,3 +1200,24 @@ export const bucketHealthHistory = sqliteTable('bucket_health_history', {
   index('bhh_bucket_ts_idx').on(t.bucketId, t.ts),
   index('bhh_ts_idx').on(t.ts),
 ]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pipeline_run_costs — HARDEN-002 (migration 0035)
+//
+// One row per pipeline-run keyed by correlation_id. Updated in place by
+// PipelineCostTracker on every llm.* call routed through the orchestrator.
+// ─────────────────────────────────────────────────────────────────────────────
+export const pipelineRunCosts = sqliteTable('pipeline_run_costs', {
+  correlationId: text('correlation_id').primaryKey(),
+  totalCalls: integer('total_calls').notNull().default(0),
+  localCalls: integer('local_calls').notNull().default(0),
+  claudeCalls: integer('claude_calls').notNull().default(0),
+  totalCostUsd: real('total_cost_usd').notNull().default(0),
+  baselineCostUsd: real('baseline_cost_usd').notNull().default(0),
+  perAgentBreakdownJson: text('per_agent_breakdown_json').notNull().default('{}'),
+  startedAt: integer('started_at').notNull(),
+  lastUpdatedAt: integer('last_updated_at').notNull(),
+  alertTriggeredAt: integer('alert_triggered_at'),
+}, (t) => [
+  index('pipeline_run_costs_updated_idx').on(t.lastUpdatedAt),
+]);

--- a/apps/orchestrator/tests/agents/pipeline-cost-tracker.test.ts
+++ b/apps/orchestrator/tests/agents/pipeline-cost-tracker.test.ts
@@ -1,0 +1,141 @@
+/**
+ * PipelineCostTracker — HARDEN-002 unit tests.
+ *
+ * Exercises:
+ *   1. recordCall inserts a fresh row with started_at and per-agent breakdown.
+ *   2. recordCall updates an existing row (counters, breakdown, last_updated_at).
+ *   3. Threshold trip emits pipeline.cost.alert exactly once.
+ *   4. recent() returns runs sorted by lastUpdatedAt desc.
+ *   5. get() returns null for unknown correlationId.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { eventBus } from '../../src/events/bus-adapter';
+import { PipelineCostTracker, __resetPipelineCostTracker } from '../../src/agents/pipeline-cost-tracker';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup(now = () => 1000) {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  return { db, sqlite, now };
+}
+
+beforeEach(() => __resetPipelineCostTracker());
+
+describe('PipelineCostTracker.recordCall', () => {
+  it('inserts a fresh row with started_at and per-agent breakdown', () => {
+    let t = 1000;
+    const { db } = setup();
+    const tracker = new PipelineCostTracker(db, { silent: true, now: () => t });
+    const snap = tracker.recordCall({
+      correlationId: 'corr_a',
+      agent: 'po-agent',
+      provider: 'claude',
+      estimatedCostUsd: 0.5,
+      baselineCostUsd: 0.5,
+    });
+    expect(snap.totalCalls).toBe(1);
+    expect(snap.claudeCalls).toBe(1);
+    expect(snap.totalCostUsd).toBe(0.5);
+    expect(snap.startedAt).toBe(1000);
+    expect(snap.perAgent['po-agent']).toEqual({ calls: 1, costUsd: 0.5, baselineUsd: 0.5 });
+    expect(snap.alertTriggeredAt).toBeNull();
+  });
+
+  it('updates the existing row across calls + agents + providers', () => {
+    let t = 1000;
+    const { db } = setup();
+    const tracker = new PipelineCostTracker(db, { silent: true, now: () => t });
+    tracker.recordCall({
+      correlationId: 'corr_b',
+      agent: 'po-agent',
+      provider: 'claude',
+      estimatedCostUsd: 0.4,
+      baselineCostUsd: 0.4,
+    });
+    t = 2000;
+    const snap = tracker.recordCall({
+      correlationId: 'corr_b',
+      agent: 'ba-agent',
+      provider: 'local',
+      estimatedCostUsd: 0,
+      baselineCostUsd: 0.3,
+    });
+    expect(snap.totalCalls).toBe(2);
+    expect(snap.localCalls).toBe(1);
+    expect(snap.claudeCalls).toBe(1);
+    expect(snap.totalCostUsd).toBe(0.4);
+    expect(snap.baselineCostUsd).toBe(0.7);
+    expect(snap.savedUsd).toBe(0.3);
+    expect(snap.startedAt).toBe(1000);   // preserved on update
+    expect(snap.lastUpdatedAt).toBe(2000);
+    expect(snap.perAgent['po-agent']).toEqual({ calls: 1, costUsd: 0.4, baselineUsd: 0.4 });
+    expect(snap.perAgent['ba-agent']).toEqual({ calls: 1, costUsd: 0, baselineUsd: 0.3 });
+  });
+
+  it('threshold trip emits pipeline.cost.alert exactly once', () => {
+    let t = 1000;
+    const { db } = setup();
+    const tracker = new PipelineCostTracker(db, { alertThresholdUsd: 1, silent: false, now: () => t });
+    const events: Array<{ type: string }> = [];
+    const off = eventBus.subscribe('pipeline.cost.alert', (ev) => events.push(ev));
+    try {
+      tracker.recordCall({
+        correlationId: 'corr_c',
+        agent: 'po-agent',
+        provider: 'claude',
+        estimatedCostUsd: 0.4,
+        baselineCostUsd: 0.4,
+      });
+      expect(events).toHaveLength(0);
+      t = 2000;
+      const snap2 = tracker.recordCall({
+        correlationId: 'corr_c',
+        agent: 'ba-agent',
+        provider: 'claude',
+        estimatedCostUsd: 0.7,
+        baselineCostUsd: 0.7,
+      });
+      expect(snap2.alertTriggeredAt).toBe(2000);
+      expect(events).toHaveLength(1);
+      // Third call still over threshold — must NOT re-emit.
+      t = 3000;
+      const snap3 = tracker.recordCall({
+        correlationId: 'corr_c',
+        agent: 'ea-agent',
+        provider: 'claude',
+        estimatedCostUsd: 0.5,
+        baselineCostUsd: 0.5,
+      });
+      expect(snap3.alertTriggeredAt).toBe(2000);
+      expect(events).toHaveLength(1);
+    } finally {
+      off();
+    }
+  });
+
+  it('recent() returns the N latest runs sorted desc by lastUpdatedAt', () => {
+    let t = 1000;
+    const { db } = setup();
+    const tracker = new PipelineCostTracker(db, { silent: true, now: () => t });
+    tracker.recordCall({ correlationId: 'corr_old', agent: 'a', provider: 'local', estimatedCostUsd: 0, baselineCostUsd: 0.1 });
+    t = 2000;
+    tracker.recordCall({ correlationId: 'corr_mid', agent: 'a', provider: 'local', estimatedCostUsd: 0, baselineCostUsd: 0.1 });
+    t = 3000;
+    tracker.recordCall({ correlationId: 'corr_new', agent: 'a', provider: 'local', estimatedCostUsd: 0, baselineCostUsd: 0.1 });
+    const recent = tracker.recent();
+    expect(recent.map((r) => r.correlationId)).toEqual(['corr_new', 'corr_mid', 'corr_old']);
+  });
+
+  it('get() returns null for unknown correlationId', () => {
+    const { db } = setup();
+    const tracker = new PipelineCostTracker(db, { silent: true });
+    expect(tracker.get('corr_ghost')).toBeNull();
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -456,6 +456,8 @@ export type EventType =
   | 'task-scheduler.backpressure.released'
   // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
   | 'task-scheduler.bucket.health'
+  // ─── HARDEN-002 — pipeline cost alerting ──────────────────────────────────
+  | 'pipeline.cost.alert'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -575,6 +577,8 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'task-scheduler.backpressure.released': 'info',
   // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
   'task-scheduler.bucket.health': 'debug',
+  // ─── HARDEN-002 — pipeline cost alerting ──────────────────────────────────
+  'pipeline.cost.alert': 'warning',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -563,3 +563,9 @@ events:
     severity: debug
     actor: [task-scheduler]
     payload: [bucketId, queueDepth, throughputPerHour, oldestReadyAgeS, workersAssigned, engaged, ts]
+
+  # HARDEN-002 — pipeline cost alerting
+  - type: pipeline.cost.alert
+    severity: warning
+    actor: [system]
+    payload: [correlationId, totalCostUsd, thresholdUsd, ts]


### PR DESCRIPTION
## Why

The existing in-memory `llmMetrics` tracker (LAI-006) is a global aggregate. Operators need to see **which pipeline-run** is racking up dollars and **which agent inside that run** is responsible. This PR persists per-run, per-agent cost data and fires an alert when a single run breaches an env-configurable ceiling.

Second in the **HARDEN-NN** production-hardening series.

## What

**Migration 0035** — `pipeline_run_costs`

```
correlation_id PK, total_calls, local_calls, claude_calls,
total_cost_usd, baseline_cost_usd, per_agent_breakdown_json,
started_at, last_updated_at, alert_triggered_at
```

**`apps/orchestrator/src/agents/pipeline-cost-tracker.ts`** (~297 LOC)

- `recordCall()` — UPSERT-style update; per-agent breakdown persists across calls.
- Threshold trip: emits `pipeline.cost.alert` exactly once when `total_cost_usd >= CAIA_PIPELINE_COST_ALERT_USD` (default $5).
- `get()` / `recent()` — read APIs for the dashboard.
- Singleton `getPipelineCostTracker(db)` so route handlers don't instantiate per-request.

**Route wiring**

- `POST /llm/route` now accepts optional `correlationId` + `agent` in the body. When present, the call is recorded and the response includes a `costSnapshot` field.
- `GET /metrics/cost?correlationId=...` returns the run snapshot.
- `GET /metrics/cost?limit=N` (default 25) returns recent runs.
- `registerLlmRoutes(app, db)` signature change; call site in `app.ts` updated.

**Taxonomy**

- Adds `pipeline.cost.alert` (severity `warning`, actor `system`) to `@chiefaia/events-taxonomy-internal`.

## Tests

- `apps/orchestrator/tests/agents/pipeline-cost-tracker.test.ts` — 5/5 pass: insert / update / threshold-once / recent ordering / get-null.
- Adjacent suites (`llm-routes`, `metrics`) — 18/18 pass.

## DoD

- [x] typecheck clean
- [x] cost-tracker tests 5/5
- [x] llm-routes + metrics 18/18 (no regressions)
- [x] Migration journal entry added (idx 34)
- [x] Single-run alert fires exactly once per run

## Follow-up

- Dashboard panel rendering `/metrics/cost` will land in HARDEN-006 (trace + cost UI).
