### PR TITLE
feat(worker-fix-it): subprocess test runner with vitest+playwright parsers (FIX-003)

### DIFF
--- a/apps/worker-fix-it/CHANGELOG.md
+++ b/apps/worker-fix-it/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### FIX-003 — subprocess test runner (this PR)
+
+- New `src/test-runner.ts`:
+  - `SubprocessTestRunner` (real impl of `TestRunner`; replaces
+    `StubTestRunner`).
+  - `CommandExecutor` port + `SpawnCommandExecutor` default; tests
+    inject a mock so CI never spawns a real test process.
+  - Spec-kind heuristic: scans imports → vitest vs Playwright.
+  - `parseVitestJson` + `parsePlaywrightJson` parsers tolerate
+    JSON-in-stdout chatter and walk nested Playwright suites for the
+    first failing test.
+  - Status mapping: passed / failed (with errorMessage + errorStack +
+    tracePath when available) / skipped / timeout / runner-crash.
+  - Per-spec timeout default 60 s.
+- `src/main.ts` plumbs the real `SubprocessTestRunner` into the
+  orchestrator's `runner` port.
+- 18 new vitest cases in `tests/test-runner.test.ts` covering parser
+  shapes (passed / failed / skipped / unparseable / embedded), spec
+  kind detection, command building, and runner end-to-end flow with
+  a `MockExecutor`.
+- 1 new microbenchmark: per-spec runner+parser overhead < 2 ms.
+
 ### FIX-002 — test code generator (this PR)
 
 - New `src/test-code-generator.ts`:

--- a/apps/worker-fix-it/src/main.ts
+++ b/apps/worker-fix-it/src/main.ts
@@ -22,6 +22,7 @@
 
 import { FixItOrchestrator } from './orchestrator';
 import { TemplateTestCodeGenerator } from './test-code-generator';
+import { SubprocessTestRunner } from './test-runner';
 
 export interface WorkerEnv {
   orchestratorUrl: string;
@@ -84,13 +85,15 @@ export async function bootstrap(env: WorkerEnv): Promise<{
   orchestrator: FixItOrchestrator;
   shutdown: () => Promise<void>;
 }> {
-  // FIX-002 plumbs the real test code generator. Runner / diagnoser / IPC
-  // remain stubbed pending FIX-003..006.
+  // FIX-002 plumbs the real test code generator. FIX-003 plumbs the
+  // real subprocess-based runner. Diagnoser / IPC remain stubbed
+  // pending FIX-004..006.
   const orchestrator = new FixItOrchestrator({
     generator: new TemplateTestCodeGenerator(),
+    runner: new SubprocessTestRunner(),
   });
   // Subsequent PRs:
-  //   - FIX-003 .. FIX-006: real runner/diagnoser/IPC plumbed in
+  //   - FIX-004 .. FIX-006: real diagnoser/IPC plumbed in
   //   - FIX-007 .. FIX-013: heartbeat, register(), assignment IPC, dashboard
   return {
     orchestrator,

--- a/apps/worker-fix-it/src/test-runner.ts
+++ b/apps/worker-fix-it/src/test-runner.ts
@@ -1,0 +1,427 @@
+/**
+ * `SubprocessTestRunner` — FIX-003 (Phase 2D).
+ *
+ * Replaces the FIX-001 `StubTestRunner` with a real subprocess runner
+ * that exec's vitest or Playwright against a generated spec and parses
+ * the output into a structured `RunResult` the orchestrator can act
+ * on.
+ *
+ * Design — the runner is split into two collaborators:
+ *
+ *   - `CommandExecutor`        — exec's a child process; default impl
+ *                                is `child_process.spawn`. Tests inject
+ *                                a mock so we can exercise the parser
+ *                                without booting a real test process.
+ *   - `SubprocessTestRunner`   — picks the runner (vitest vs playwright)
+ *                                based on the spec file's imports,
+ *                                builds the command, exec's, parses,
+ *                                returns RunResult.
+ *
+ * Status mapping:
+ *
+ *   - exit 0 + reporter says PASS  → 'passed'
+ *   - exit 0 + reporter says SKIP  → 'skipped'
+ *   - exit non-zero + reporter has  → 'failed' (with errorMessage,
+ *     a failure                       errorStack, tracePath if any)
+ *   - executor timeout fired       → 'failed' with errorMessage
+ *                                    'timeout after Nms'
+ *   - executor crashed before      → 'failed' with errorMessage
+ *     reporting                      'runner crashed: <msg>'
+ *
+ * The directive's per-test-case wallclock budget is ~10s; the runner
+ * defaults `timeoutMs = 60_000` to give the test process room while
+ * still bounding lockup risk.
+ *
+ * @owner fix-it-test-agent (Phase 2D worker track)
+ */
+
+import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
+
+import type {
+  GeneratedSpec,
+  RunResult,
+  TestRunner,
+} from './stubs';
+
+// ─── Executor port ──────────────────────────────────────────────────────────
+
+export interface ExecOpts {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  /** Hard timeout. Executor must SIGKILL on expiry. */
+  timeoutMs?: number;
+}
+
+export interface ExecResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  durationMs: number;
+}
+
+export interface CommandExecutor {
+  exec(cmd: string, args: ReadonlyArray<string>, opts?: ExecOpts): Promise<ExecResult>;
+}
+
+// ─── Default executor ───────────────────────────────────────────────────────
+
+export class SpawnCommandExecutor implements CommandExecutor {
+  async exec(
+    cmd: string,
+    args: ReadonlyArray<string>,
+    opts: ExecOpts = {},
+  ): Promise<ExecResult> {
+    return new Promise((resolve) => {
+      const start = Date.now();
+      // SpawnCommandExecutor is invoked by the worker with cmd values from a
+      // pinned allowlist (vitest, playwright). The runner never executes
+      // attacker-supplied commands; `cmd` is set by the worker's runtime
+      // configuration, not by ticket payloads.
+      // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+      const child = spawn(cmd, args as string[], {
+        cwd: opts.cwd,
+        env: opts.env ?? process.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+      let killTimer: NodeJS.Timeout | null = null;
+
+      if (opts.timeoutMs && opts.timeoutMs > 0) {
+        killTimer = setTimeout(() => {
+          timedOut = true;
+          child.kill('SIGKILL');
+        }, opts.timeoutMs);
+      }
+
+      child.stdout?.on('data', (b: Buffer) => {
+        stdout += b.toString('utf8');
+      });
+      child.stderr?.on('data', (b: Buffer) => {
+        stderr += b.toString('utf8');
+      });
+
+      child.on('error', (err: Error) => {
+        if (killTimer) clearTimeout(killTimer);
+        resolve({
+          exitCode: null,
+          stdout,
+          stderr: stderr + `\n[runner crashed: ${err.message}]`,
+          timedOut,
+          durationMs: Date.now() - start,
+        });
+      });
+
+      child.on('close', (code: number | null) => {
+        if (killTimer) clearTimeout(killTimer);
+        resolve({
+          exitCode: code,
+          stdout,
+          stderr,
+          timedOut,
+          durationMs: Date.now() - start,
+        });
+      });
+    });
+  }
+}
+
+// ─── Spec → command discovery ───────────────────────────────────────────────
+
+export type RunnerKind = 'vitest' | 'playwright';
+
+export function detectRunnerKind(specPath: string): RunnerKind {
+  let head = '';
+  try {
+    head = readFileSync(specPath, { encoding: 'utf8' }).slice(0, 2048);
+  } catch {
+    // If the file doesn't exist we still need to return something —
+    // vitest is the safer default since it'll error out cleanly when
+    // the file is missing.
+    return 'vitest';
+  }
+  return head.includes('@playwright/test') ? 'playwright' : 'vitest';
+}
+
+/**
+ * Build the argv the test runner expects to exec a single spec.
+ *
+ * For vitest: `pnpm exec vitest run <spec>`
+ * For playwright: `pnpm exec playwright test <spec> --reporter=json`
+ */
+export function buildRunCommand(
+  spec: GeneratedSpec,
+  kind: RunnerKind = detectRunnerKind(spec.specPath),
+): { cmd: string; args: string[] } {
+  if (kind === 'playwright') {
+    return {
+      cmd: 'pnpm',
+      args: [
+        'exec',
+        'playwright',
+        'test',
+        spec.specPath,
+        '--reporter=json',
+      ],
+    };
+  }
+  return {
+    cmd: 'pnpm',
+    args: ['exec', 'vitest', 'run', spec.specPath, '--reporter=json'],
+  };
+}
+
+// ─── Output parsers ─────────────────────────────────────────────────────────
+
+interface ParsedOutcome {
+  status: 'passed' | 'failed' | 'skipped';
+  errorMessage?: string;
+  errorStack?: string;
+  tracePath?: string;
+}
+
+/**
+ * Parse vitest's --reporter=json output for a single-spec run.
+ *
+ * Vitest's JSON shape (loosely; we tolerate variations):
+ *
+ *   {
+ *     numTotalTests: 1,
+ *     numFailedTests: 0,
+ *     numPassedTests: 1,
+ *     numPendingTests: 0,
+ *     testResults: [{
+ *       testFilePath: '...',
+ *       message?: string,
+ *       assertionResults: [{ status: 'passed'|'failed'|'pending',
+ *                            failureMessages?: string[],
+ *                            title: string }]
+ *     }]
+ *   }
+ */
+export function parseVitestJson(stdout: string): ParsedOutcome {
+  const json = extractFirstJsonObject(stdout);
+  if (!json) {
+    return { status: 'failed', errorMessage: 'unparseable vitest output' };
+  }
+  const numFailed = numberOf(json.numFailedTests);
+  const numPassed = numberOf(json.numPassedTests);
+  const numPending = numberOf(json.numPendingTests);
+  if (numFailed > 0) {
+    const messages = collectVitestFailureMessages(json);
+    return {
+      status: 'failed',
+      errorMessage: messages.message,
+      errorStack: messages.stack,
+    };
+  }
+  if (numPassed > 0) return { status: 'passed' };
+  if (numPending > 0) return { status: 'skipped' };
+  return { status: 'failed', errorMessage: 'no tests reported' };
+}
+
+function collectVitestFailureMessages(json: any): {
+  message?: string;
+  stack?: string;
+} {
+  const results = Array.isArray(json.testResults) ? json.testResults : [];
+  for (const tr of results) {
+    const ar = Array.isArray(tr.assertionResults) ? tr.assertionResults : [];
+    for (const a of ar) {
+      if (a.status === 'failed') {
+        const fm = Array.isArray(a.failureMessages) ? a.failureMessages : [];
+        const all = fm.join('\n');
+        const firstLine = all.split('\n')[0] ?? all;
+        return { message: firstLine || tr.message, stack: all || undefined };
+      }
+    }
+    if (tr.status === 'failed' && typeof tr.message === 'string') {
+      return { message: tr.message };
+    }
+  }
+  return {};
+}
+
+/**
+ * Parse Playwright's --reporter=json output. Playwright emits a tree
+ * we walk for the first failing test; if everything passed we report
+ * `passed`.
+ */
+export function parsePlaywrightJson(stdout: string): ParsedOutcome {
+  const json = extractFirstJsonObject(stdout);
+  if (!json) {
+    return { status: 'failed', errorMessage: 'unparseable playwright output' };
+  }
+  // Playwright: { stats: { expected, unexpected, skipped }, suites: [...] }
+  const stats = json.stats ?? {};
+  const unexpected = numberOf(stats.unexpected);
+  const expected = numberOf(stats.expected);
+  const skipped = numberOf(stats.skipped);
+
+  if (unexpected > 0) {
+    const failure = walkPlaywrightForFailure(json);
+    return {
+      status: 'failed',
+      errorMessage: failure.message,
+      errorStack: failure.stack,
+      tracePath: failure.tracePath,
+    };
+  }
+  if (expected > 0) return { status: 'passed' };
+  if (skipped > 0) return { status: 'skipped' };
+  return { status: 'failed', errorMessage: 'no playwright tests reported' };
+}
+
+function walkPlaywrightForFailure(json: any): {
+  message?: string;
+  stack?: string;
+  tracePath?: string;
+} {
+  const queue: any[] = [];
+  if (Array.isArray(json.suites)) queue.push(...json.suites);
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (Array.isArray(node?.specs)) {
+      for (const spec of node.specs) {
+        for (const test of spec.tests ?? []) {
+          for (const result of test.results ?? []) {
+            if (result.status === 'failed' || result.status === 'timedOut' || result.status === 'unexpected') {
+              const err = result.error ?? {};
+              const tracePath = (result.attachments ?? []).find(
+                (a: any) => a?.name === 'trace',
+              )?.path;
+              return {
+                message: err.message ?? `playwright ${result.status}`,
+                stack: err.stack,
+                tracePath,
+              };
+            }
+          }
+        }
+      }
+    }
+    if (Array.isArray(node?.suites)) queue.push(...node.suites);
+  }
+  return {};
+}
+
+function extractFirstJsonObject(s: string): any | null {
+  const start = s.indexOf('{');
+  if (start < 0) return null;
+  // bracket-depth scan
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(s.slice(start, i + 1));
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function numberOf(n: unknown): number {
+  return typeof n === 'number' && Number.isFinite(n) ? n : 0;
+}
+
+// ─── SubprocessTestRunner ───────────────────────────────────────────────────
+
+export interface SubprocessTestRunnerOptions {
+  executor?: CommandExecutor;
+  /** Per-spec timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Override the cwd passed to the executor (defaults to process.cwd()). */
+  cwd?: string;
+}
+
+export const DEFAULT_SPEC_TIMEOUT_MS = 60_000;
+
+export class SubprocessTestRunner implements TestRunner {
+  private readonly executor: CommandExecutor;
+  private readonly timeoutMs: number;
+  private readonly cwd?: string;
+
+  constructor(opts: SubprocessTestRunnerOptions = {}) {
+    this.executor = opts.executor ?? new SpawnCommandExecutor();
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_SPEC_TIMEOUT_MS;
+    this.cwd = opts.cwd;
+  }
+
+  async runSpec(spec: GeneratedSpec): Promise<RunResult> {
+    const kind = detectRunnerKind(spec.specPath);
+    const { cmd, args } = buildRunCommand(spec, kind);
+    const result = await this.executor.exec(cmd, args, {
+      cwd: this.cwd,
+      timeoutMs: this.timeoutMs,
+    });
+
+    if (result.timedOut) {
+      return {
+        testCaseId: spec.testCaseId,
+        status: 'failed',
+        durationMs: result.durationMs,
+        errorMessage: `timeout after ${this.timeoutMs}ms`,
+      };
+    }
+
+    if (result.exitCode === null) {
+      return {
+        testCaseId: spec.testCaseId,
+        status: 'failed',
+        durationMs: result.durationMs,
+        errorMessage:
+          result.stderr.trim() || 'runner crashed before reporting',
+      };
+    }
+
+    const parsed =
+      kind === 'playwright'
+        ? parsePlaywrightJson(result.stdout)
+        : parseVitestJson(result.stdout);
+
+    return {
+      testCaseId: spec.testCaseId,
+      status: parsed.status,
+      durationMs: result.durationMs,
+      tracePath: parsed.tracePath,
+      errorMessage: parsed.errorMessage,
+      errorStack: parsed.errorStack,
+      artifacts: {
+        stdoutTail: tail(result.stdout, 2000),
+        stderrTail: tail(result.stderr, 2000),
+        exitCode: result.exitCode,
+        runnerKind: kind,
+      },
+    };
+  }
+}
+
+function tail(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(-n);
+}

--- a/apps/worker-fix-it/tests/test-runner.bench.ts
+++ b/apps/worker-fix-it/tests/test-runner.bench.ts
@@ -1,0 +1,65 @@
+/**
+ * Microbenchmark — FIX-003.
+ *
+ * The runner's overhead dominates for fast tests; with a mock executor
+ * (i.e. no real subprocess) the runner itself should be near-free —
+ * sub-millisecond per spec. This bench guards against accidentally
+ * regressing into per-spec heavy work.
+ */
+
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  SubprocessTestRunner,
+  type CommandExecutor,
+  type ExecResult,
+} from '../src/test-runner';
+
+const ITER = 200;
+const PER_SPEC_BUDGET_MS = 2;
+
+class FastExecutor implements CommandExecutor {
+  async exec(): Promise<ExecResult> {
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        numFailedTests: 0,
+        numPassedTests: 1,
+        numPendingTests: 0,
+      }),
+      stderr: '',
+      timedOut: false,
+      durationMs: 1,
+    };
+  }
+}
+
+function writeSpec(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'caia-fix-003-bench-'));
+  const path = join(dir, 'tc.spec.ts');
+  writeFileSync(path, "import { it } from 'vitest';\n", 'utf8');
+  return path;
+}
+
+describe('SubprocessTestRunner overhead', () => {
+  it(`stays under ${PER_SPEC_BUDGET_MS}ms / spec with mock executor`, async () => {
+    const path = writeSpec();
+    const runner = new SubprocessTestRunner({ executor: new FastExecutor() });
+    const start = Date.now();
+    for (let i = 0; i < ITER; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await runner.runSpec({
+        testCaseId: `tc${i}`,
+        specPath: path,
+        contentHash: 'h',
+      });
+    }
+    const totalMs = Date.now() - start;
+    const perMs = totalMs / ITER;
+    // eslint-disable-next-line no-console
+    console.log(`[bench] FIX-003 runner+parser: ${perMs.toFixed(3)}ms/spec over ${ITER} specs`);
+    expect(perMs).toBeLessThan(PER_SPEC_BUDGET_MS);
+  });
+});

--- a/apps/worker-fix-it/tests/test-runner.test.ts
+++ b/apps/worker-fix-it/tests/test-runner.test.ts
@@ -1,0 +1,384 @@
+/**
+ * `SubprocessTestRunner` — FIX-003 contract tests.
+ *
+ * The runner has two units we test independently:
+ *
+ *   1. The pure parsers (vitest + playwright JSON shapes).
+ *   2. The runner itself, exercised against a mock CommandExecutor so
+ *      we never spawn a real test process from CI.
+ *
+ * Bonus tests cover the spec-kind heuristic (vitest vs playwright)
+ * and the buildRunCommand mapping.
+ */
+
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  DEFAULT_SPEC_TIMEOUT_MS,
+  SubprocessTestRunner,
+  buildRunCommand,
+  detectRunnerKind,
+  parsePlaywrightJson,
+  parseVitestJson,
+  type CommandExecutor,
+  type ExecOpts,
+  type ExecResult,
+} from '../src/test-runner';
+import type { GeneratedSpec } from '../src/stubs';
+
+class MockExecutor implements CommandExecutor {
+  public calls: Array<{ cmd: string; args: ReadonlyArray<string>; opts?: ExecOpts }> = [];
+  constructor(private readonly canned: ExecResult) {}
+  async exec(
+    cmd: string,
+    args: ReadonlyArray<string>,
+    opts?: ExecOpts,
+  ): Promise<ExecResult> {
+    this.calls.push({ cmd, args, opts });
+    return this.canned;
+  }
+}
+
+function specForFile(path: string): GeneratedSpec {
+  return { testCaseId: 'tc1', specPath: path, contentHash: 'h' };
+}
+
+function writeSpecFile(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'caia-fix-003-'));
+  const path = join(dir, 'tc.spec.ts');
+  writeFileSync(path, content, 'utf8');
+  return path;
+}
+
+// ─── parseVitestJson ────────────────────────────────────────────────────────
+
+describe('parseVitestJson', () => {
+  it('returns passed when numPassedTests > 0 and no failures', () => {
+    const out = parseVitestJson(
+      JSON.stringify({
+        numTotalTests: 1,
+        numFailedTests: 0,
+        numPassedTests: 1,
+        numPendingTests: 0,
+        testResults: [],
+      }),
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  it('returns failed and lifts the first failure message + stack', () => {
+    const out = parseVitestJson(
+      JSON.stringify({
+        numFailedTests: 1,
+        numPassedTests: 0,
+        numPendingTests: 0,
+        testResults: [
+          {
+            assertionResults: [
+              {
+                status: 'failed',
+                title: 'tc',
+                failureMessages: [
+                  'Expected: /dashboard\nGot: /login\n  at line 42',
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toBe('Expected: /dashboard');
+    expect(out.errorStack).toContain('at line 42');
+  });
+
+  it('returns skipped when only pending tests exist', () => {
+    const out = parseVitestJson(
+      JSON.stringify({
+        numFailedTests: 0,
+        numPassedTests: 0,
+        numPendingTests: 1,
+        testResults: [],
+      }),
+    );
+    expect(out.status).toBe('skipped');
+  });
+
+  it('returns failed with message when stdout is not parseable', () => {
+    const out = parseVitestJson('garbage');
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toContain('unparseable');
+  });
+
+  it('handles JSON embedded in stdout chatter', () => {
+    const wrapped = `> vitest run ts.spec.ts\n${JSON.stringify({
+      numFailedTests: 0,
+      numPassedTests: 1,
+      numPendingTests: 0,
+    })}\n[stderr line]`;
+    const out = parseVitestJson(wrapped);
+    expect(out.status).toBe('passed');
+  });
+});
+
+// ─── parsePlaywrightJson ────────────────────────────────────────────────────
+
+describe('parsePlaywrightJson', () => {
+  it('returns passed on stats.expected > 0 and no unexpected', () => {
+    const out = parsePlaywrightJson(
+      JSON.stringify({
+        stats: { expected: 1, unexpected: 0, skipped: 0 },
+        suites: [],
+      }),
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  it('returns failed with message + stack + tracePath on stats.unexpected', () => {
+    const out = parsePlaywrightJson(
+      JSON.stringify({
+        stats: { expected: 0, unexpected: 1, skipped: 0 },
+        suites: [
+          {
+            specs: [
+              {
+                tests: [
+                  {
+                    results: [
+                      {
+                        status: 'failed',
+                        error: {
+                          message: 'expected /dashboard, got /login',
+                          stack: 'TestError\n  at thing.ts:1',
+                        },
+                        attachments: [
+                          { name: 'trace', path: '/tmp/trace.zip' },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toContain('/dashboard');
+    expect(out.errorStack).toContain('TestError');
+    expect(out.tracePath).toBe('/tmp/trace.zip');
+  });
+
+  it('returns skipped when only skipped > 0', () => {
+    const out = parsePlaywrightJson(
+      JSON.stringify({
+        stats: { expected: 0, unexpected: 0, skipped: 1 },
+        suites: [],
+      }),
+    );
+    expect(out.status).toBe('skipped');
+  });
+
+  it('walks nested suites to find the failure', () => {
+    const out = parsePlaywrightJson(
+      JSON.stringify({
+        stats: { expected: 0, unexpected: 1, skipped: 0 },
+        suites: [
+          {
+            suites: [
+              {
+                specs: [
+                  {
+                    tests: [
+                      { results: [{ status: 'timedOut', error: { message: 'timeout' } }] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toBe('timeout');
+  });
+});
+
+// ─── detectRunnerKind ───────────────────────────────────────────────────────
+
+describe('detectRunnerKind', () => {
+  it('returns playwright when the spec imports @playwright/test', () => {
+    const path = writeSpecFile("import { test, expect } from '@playwright/test';");
+    expect(detectRunnerKind(path)).toBe('playwright');
+  });
+
+  it('returns vitest by default', () => {
+    const path = writeSpecFile("import { it, expect } from 'vitest';");
+    expect(detectRunnerKind(path)).toBe('vitest');
+  });
+
+  it('returns vitest when the file is missing', () => {
+    expect(detectRunnerKind('/tmp/this-file-does-not-exist.spec.ts')).toBe('vitest');
+  });
+});
+
+// ─── buildRunCommand ────────────────────────────────────────────────────────
+
+describe('buildRunCommand', () => {
+  it('builds vitest run for vitest specs', () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const out = buildRunCommand(specForFile(path));
+    expect(out.cmd).toBe('pnpm');
+    expect(out.args).toEqual(['exec', 'vitest', 'run', path, '--reporter=json']);
+  });
+
+  it('builds playwright test for playwright specs', () => {
+    const path = writeSpecFile("import { test } from '@playwright/test';");
+    const out = buildRunCommand(specForFile(path));
+    expect(out.cmd).toBe('pnpm');
+    expect(out.args).toEqual(['exec', 'playwright', 'test', path, '--reporter=json']);
+  });
+});
+
+// ─── SubprocessTestRunner end-to-end with mock executor ─────────────────────
+
+describe('SubprocessTestRunner', () => {
+  function runResult(canned: Partial<ExecResult>): ExecResult {
+    return {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      durationMs: 12,
+      ...canned,
+    };
+  }
+
+  it('returns passed for a green vitest spec', async () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const exec = new MockExecutor(
+      runResult({
+        stdout: JSON.stringify({
+          numFailedTests: 0,
+          numPassedTests: 1,
+          numPendingTests: 0,
+        }),
+      }),
+    );
+    const runner = new SubprocessTestRunner({ executor: exec });
+    const out = await runner.runSpec(specForFile(path));
+    expect(out.status).toBe('passed');
+    expect(out.durationMs).toBe(12);
+    expect(out.artifacts).toMatchObject({ runnerKind: 'vitest', exitCode: 0 });
+    expect(exec.calls[0]?.cmd).toBe('pnpm');
+    expect(exec.calls[0]?.opts?.timeoutMs).toBe(DEFAULT_SPEC_TIMEOUT_MS);
+  });
+
+  it('returns failed for a red vitest spec and lifts the message', async () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const exec = new MockExecutor(
+      runResult({
+        exitCode: 1,
+        stdout: JSON.stringify({
+          numFailedTests: 1,
+          numPassedTests: 0,
+          numPendingTests: 0,
+          testResults: [
+            {
+              assertionResults: [
+                {
+                  status: 'failed',
+                  failureMessages: ['boom\n  at x.ts:1'],
+                },
+              ],
+            },
+          ],
+        }),
+      }),
+    );
+    const runner = new SubprocessTestRunner({ executor: exec });
+    const out = await runner.runSpec(specForFile(path));
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toBe('boom');
+    expect(out.errorStack).toContain('at x.ts');
+  });
+
+  it('returns failed with timeout message when executor reports timedOut', async () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const exec = new MockExecutor(
+      runResult({ exitCode: null, timedOut: true, durationMs: 60_000 }),
+    );
+    const runner = new SubprocessTestRunner({ executor: exec, timeoutMs: 60_000 });
+    const out = await runner.runSpec(specForFile(path));
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toContain('timeout');
+    expect(out.errorMessage).toContain('60000ms');
+  });
+
+  it('returns failed when the runner crashed (exitCode null, not timed out)', async () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const exec = new MockExecutor(
+      runResult({ exitCode: null, stderr: 'enoent: pnpm not found' }),
+    );
+    const runner = new SubprocessTestRunner({ executor: exec });
+    const out = await runner.runSpec(specForFile(path));
+    expect(out.status).toBe('failed');
+    expect(out.errorMessage).toContain('pnpm not found');
+  });
+
+  it('routes a Playwright spec to the playwright reporter', async () => {
+    const path = writeSpecFile("import { test } from '@playwright/test';");
+    const exec = new MockExecutor(
+      runResult({
+        stdout: JSON.stringify({
+          stats: { expected: 1, unexpected: 0, skipped: 0 },
+          suites: [],
+        }),
+      }),
+    );
+    const runner = new SubprocessTestRunner({ executor: exec });
+    const out = await runner.runSpec(specForFile(path));
+    expect(out.status).toBe('passed');
+    expect(out.artifacts).toMatchObject({ runnerKind: 'playwright' });
+    expect(exec.calls[0]?.args).toContain('playwright');
+  });
+
+  it('returns skipped when a vitest run reports only pending tests', async () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const exec = new MockExecutor(
+      runResult({
+        stdout: JSON.stringify({
+          numFailedTests: 0,
+          numPassedTests: 0,
+          numPendingTests: 1,
+        }),
+      }),
+    );
+    const runner = new SubprocessTestRunner({ executor: exec });
+    const out = await runner.runSpec(specForFile(path));
+    expect(out.status).toBe('skipped');
+  });
+
+  it('passes cwd through to the executor when configured', async () => {
+    const path = writeSpecFile("import { it } from 'vitest';");
+    const exec = new MockExecutor(
+      runResult({
+        stdout: JSON.stringify({
+          numFailedTests: 0,
+          numPassedTests: 1,
+          numPendingTests: 0,
+        }),
+      }),
+    );
+    const runner = new SubprocessTestRunner({
+      executor: exec,
+      cwd: '/some/where',
+    });
+    await runner.runSpec(specForFile(path));
+    expect(exec.calls[0]?.opts?.cwd).toBe('/some/where');
+  });
+});

--- a/docs/fix-it-test-agent.md
+++ b/docs/fix-it-test-agent.md
@@ -87,7 +87,7 @@ change needed.
 - [x] Operator runbook (this file).
 - [x] FIX-002: Real test code generator (`TemplateTestCodeGenerator`)
       with layer dispatch and idempotency, plumbed into `bootstrap()`.
-- [ ] FIX-003: Real test runner (replaces `StubTestRunner`).
+- [x] FIX-003: Real test runner (`SubprocessTestRunner` over an injectable `CommandExecutor`).
 - [ ] FIX-004: Real failure diagnoser (replaces `StubFailureDiagnoser`).
 - [ ] FIX-005: Real Coding Agent IPC client (replaces
       `StubCodingIpcInvoker`; coordinates with CODING-007).


### PR DESCRIPTION
## FIX-003 — Subprocess test runner

Replaces the FIX-001 `StubTestRunner` with a real subprocess runner that exec's vitest or Playwright against a generated spec and parses the output into a structured `RunResult`.

### Design

Split into two collaborators:

| Collaborator | Role |
|--------------|------|
| `CommandExecutor` | exec's a child process; default `SpawnCommandExecutor` uses `child_process.spawn`. Tests inject a mock so CI never spawns a real test process. |
| `SubprocessTestRunner` | picks the runner (vitest vs Playwright) based on the spec's imports, builds the command, exec's, parses, returns `RunResult`. |

### Status mapping

- exit 0 + reporter passes → `passed`
- exit 0 + reporter pending → `skipped`
- exit non-zero + reporter has a failure → `failed` with `errorMessage`, `errorStack`, `tracePath` (from Playwright attachments)
- executor timed out → `failed` with `errorMessage = 'timeout after Nms'`
- executor crashed before reporting → `failed` with stderr lifted

Per-spec timeout defaults to 60s.

### Tests (18 new + 1 bench)

| Suite | Cases |
|-------|-------|
| `parseVitestJson` | passed / failed (lifts message+stack) / skipped / unparseable / JSON embedded in chatter |
| `parsePlaywrightJson` | passed / failed (lifts message+stack+tracePath) / skipped / nested suite walk |
| `detectRunnerKind` | playwright import / vitest default / missing file |
| `buildRunCommand` | vitest argv / playwright argv |
| `SubprocessTestRunner` | green vitest / red vitest / timeout / crash / playwright route / vitest skipped / cwd propagation |
| Microbench | runner+parser overhead < 2 ms / spec |

### Wiring

`src/main.ts`'s `bootstrap()` now defaults the orchestrator's `runner` port to `SubprocessTestRunner`. Diagnoser / IPC stay stubbed pending FIX-004..006.

### Per-DoD

- [x] Unit tests (parser + runner)
- [x] Integration test (orchestrator with new runner via stubs)
- [x] Microbenchmark with budget assertion
- [x] CI green (local typecheck + test + bench)
- [x] Docs (`docs/fix-it-test-agent.md` + CHANGELOG)
- [x] Memory updates (architecture spec at `~/Documents/projects/reports/phase2-completion-architecture-2026-04-28.md` §5.3)

Refs: phase2-completion-architecture-2026-04-28.md §5.3

🤖 Generated with CAIA Phase 2D worker track