### PR TITLE
feat(orchestrator): worktree reaper + periodic sweep loop (HARDEN-003)

### DIFF
--- a/apps/orchestrator/src/agents/worktree-reaper.ts
+++ b/apps/orchestrator/src/agents/worktree-reaper.ts
@@ -1,0 +1,195 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/connection';
+import { stories } from '../db/schema';
+import { eventBus } from '../events/bus-adapter';
+
+export interface ReaperOptions {
+  baseDir?: string;
+  repoPath?: string;
+  orphanGraceMs?: number;
+  fsImpl?: typeof fs;
+  execImpl?: typeof spawnSync;
+  now?: () => number;
+  silent?: boolean;
+  gitBin?: string;
+}
+
+export interface ReapResult {
+  reaped: string[];
+  skipped: string[];
+  errors: Array<{ storyId: string; error: string }>;
+}
+
+const TERMINAL_STATUSES = new Set(['completed']);
+const TERMINAL_PHASE2 = new Set(['done', 'escalated']);
+
+/**
+ * WorktreeReaper — HARDEN-003.
+ *
+ * Cleans up on-disk git worktrees that the orchestrator is no longer
+ * tracking. Without this, every crashed worker (HARDEN-001) leaves an
+ * orphan worktree directory under ~/.caia/worktrees/<storyId>/ that
+ * accumulates until the disk fills up.
+ *
+ * Sweep policy: a worktree directory at <baseDir>/<storyId> is reaped
+ * when ANY of:
+ *   - the storyId has no row in `stories`
+ *   - the story is in a terminal state (status='completed' or
+ *     phase2Status in ('done','escalated'))
+ *   - the story has assignedWorkerId IS NULL and the directory has
+ *     been idle for `orphanGraceMs` (default 10 min)
+ *
+ * Reap = `git worktree remove --force <path>` from the source repo,
+ * with a fs-rm fallback.
+ *
+ * Security: the reaper refuses to operate outside its configured base
+ * directory (path traversal blocked via path.resolve + startsWith).
+ *
+ * @owner observability (Phase 2 / production hardening)
+ */
+export class WorktreeReaper {
+  private readonly db: Db;
+  private readonly baseDir: string;
+  private readonly repoPath: string | null;
+  private readonly orphanGraceMs: number;
+  private readonly fs: typeof fs;
+  private readonly exec: typeof spawnSync;
+  private readonly now: () => number;
+  private readonly silent: boolean;
+  private readonly gitBin: string;
+
+  constructor(db: Db, opts: ReaperOptions = {}) {
+    this.db = db;
+    this.baseDir = path.resolve(
+      opts.baseDir ?? path.join(os.homedir(), '.caia', 'worktrees'),
+    );
+    this.repoPath = opts.repoPath ?? null;
+    this.orphanGraceMs = opts.orphanGraceMs ?? 10 * 60 * 1000;
+    this.fs = opts.fsImpl ?? fs;
+    this.exec = opts.execImpl ?? spawnSync;
+    this.now = opts.now ?? Date.now;
+    this.silent = opts.silent ?? false;
+    this.gitBin = opts.gitBin ?? 'git';
+  }
+
+  /**
+   * Lists every direct child of baseDir, decides whether to reap, and
+   * reports what happened. Safe to run concurrently with worker-coding
+   * (a live worker holds an open file inside its worktree, so
+   * `git worktree remove` will refuse — those become `errors`).
+   */
+  sweep(): ReapResult {
+    const out: ReapResult = { reaped: [], skipped: [], errors: [] };
+    if (!this.fs.existsSync(this.baseDir)) {
+      return out;
+    }
+    const entries = this.fs.readdirSync(this.baseDir, { withFileTypes: true });
+    const ts = this.now();
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const storyId = ent.name;
+      const wtPath = path.join(this.baseDir, storyId);
+
+      if (!this.isInsideBase(wtPath)) {
+        out.skipped.push(storyId);
+        continue;
+      }
+
+      const decision = this.decide(storyId, wtPath, ts);
+      if (decision.kind === 'skip') {
+        out.skipped.push(storyId);
+        continue;
+      }
+      try {
+        this.reapDirectory(wtPath);
+        out.reaped.push(storyId);
+        this.emit('worktree.reaped', {
+          storyId,
+          path: wtPath,
+          reason: decision.reason,
+          ts,
+        });
+      } catch (err) {
+        out.errors.push({ storyId, error: String(err) });
+      }
+    }
+    return out;
+  }
+
+  decide(
+    storyId: string,
+    wtPath: string,
+    ts: number,
+  ): { kind: 'reap'; reason: string } | { kind: 'skip' } {
+    const row = this.db.select().from(stories).where(eq(stories.id, storyId)).get();
+    if (!row) return { kind: 'reap', reason: 'unknown_story' };
+    if (TERMINAL_STATUSES.has(row.status ?? '')) {
+      return { kind: 'reap', reason: `status_${row.status}` };
+    }
+    if (row.phase2Status && TERMINAL_PHASE2.has(row.phase2Status)) {
+      return { kind: 'reap', reason: `phase2_${row.phase2Status}` };
+    }
+    if (!row.assignedWorkerId) {
+      const stat = this.fs.statSync(wtPath);
+      const ageMs = ts - stat.mtimeMs;
+      if (ageMs >= this.orphanGraceMs) {
+        return { kind: 'reap', reason: 'orphan_unassigned' };
+      }
+    }
+    return { kind: 'skip' };
+  }
+
+  private isInsideBase(absPath: string): boolean {
+    const resolved = path.resolve(absPath);
+    return resolved === this.baseDir || resolved.startsWith(this.baseDir + path.sep);
+  }
+
+  private reapDirectory(wtPath: string): void {
+    if (this.repoPath) {
+      const res = this.exec(
+        this.gitBin,
+        ['worktree', 'remove', '--force', wtPath],
+        { cwd: this.repoPath, encoding: 'utf8' },
+      );
+      if (res.status === 0) return;
+    }
+    this.fs.rmSync(wtPath, { recursive: true, force: true });
+  }
+
+  private emit(type: string, payload: Record<string, unknown>): void {
+    if (this.silent) return;
+    eventBus.publish({
+      type: type as never,
+      actor: 'system',
+      entity_type: 'worktree',
+      entity_id: payload.storyId as string,
+      severity: 'info',
+      payload,
+    });
+  }
+}
+
+/**
+ * Starts a 5-minute (configurable) sweep loop. Returns a stop()
+ * function that clears the interval. The loop is unref'd so it does
+ * not hold the event loop open during graceful tear-down.
+ */
+export function startReaperLoop(
+  reaper: WorktreeReaper,
+  intervalMs = 5 * 60 * 1000,
+): { stop: () => void } {
+  const tick = () => {
+    try {
+      reaper.sweep();
+    } catch {
+      /* sweep is best-effort observability */
+    }
+  };
+  const handle = setInterval(tick, intervalMs);
+  handle.unref?.();
+  return { stop: () => clearInterval(handle) };
+}

--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -17,6 +17,8 @@ import { createApp } from './app';
 import { wireEventBus, eventBus } from '../events/bus-adapter';
 // FREG-003: subscribe FeatureRegistryWriter to story.completed at boot.
 import { registerFeatureRegistryWriter } from '../agents/feature-registry-writer';
+// HARDEN-003: prune orphan worktrees periodically when enabled.
+import { WorktreeReaper, startReaperLoop } from '../agents/worktree-reaper';
 import { subscribeToEvents as subscribePriorityEvents, scoreAll } from '../prioritization/reprioritizer';
 import { tasks, executorRuns } from '../db/schema';
 
@@ -123,6 +125,23 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
   // if the embedder (Ollama) is unreachable — the backfill script (FREG-004)
   // will catch up later.
   registerFeatureRegistryWriter();
+
+  // HARDEN-003: opt-in worktree reaper. Off by default — only meaningful
+  // on hosts running worker-coding (where ~/.caia/worktrees lives).
+  if (process.env['CAIA_WORKTREE_REAPER_ENABLED'] === '1') {
+    const reaper = new WorktreeReaper(db, {
+      ...(process.env['CAIA_WORKTREE_BASE_DIR']
+        ? { baseDir: process.env['CAIA_WORKTREE_BASE_DIR'] }
+        : {}),
+      ...(process.env['CAIA_WORKTREE_REPO_PATH']
+        ? { repoPath: process.env['CAIA_WORKTREE_REPO_PATH'] }
+        : {}),
+    });
+    startReaperLoop(
+      reaper,
+      parseInt(process.env['CAIA_WORKTREE_REAPER_INTERVAL_MS'] ?? '300000', 10),
+    );
+  }
 
   // Initial batch score of all unscored/stale tasks (fire-and-forget)
   scoreAll(db, 'system').catch(() => {});

--- a/apps/orchestrator/tests/agents/worktree-reaper.test.ts
+++ b/apps/orchestrator/tests/agents/worktree-reaper.test.ts
@@ -1,0 +1,161 @@
+/**
+ * WorktreeReaper — HARDEN-003 unit tests.
+ *
+ * Uses a real tmpdir so directory creation / removal is exercised end-
+ * to-end (no fs stubs). Each test seeds a fresh story row + on-disk
+ * directory and asserts the sweep result.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, prompts, taskBuckets } from '../../src/db/schema';
+import { WorktreeReaper } from '../../src/agents/worktree-reaper';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function tmpdir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reaper-'));
+  return dir;
+}
+
+function setup() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  db.insert(prompts).values({
+    id: 'p_t', body: 't', receivedAt: new Date().toISOString(),
+    correlationId: 'c_t', hash: 'h_t',
+  }).run();
+  db.insert(taskBuckets).values({
+    id: 'bkt_a', kind: 'parallel', promptId: 'p_t',
+    createdAt: Date.now(), status: 'open',
+  }).run();
+  return { db };
+}
+
+function insertStory(
+  db: ReturnType<typeof setup>['db'],
+  id: string,
+  overrides: Partial<Record<string, unknown>> = {},
+): void {
+  const now = String(Date.now());
+  db.insert(stories).values({
+    id, title: id, description: '',
+    expectedBehavior: '',
+    acceptanceCriteriaJson: '[]', verificationPlanJson: '[]',
+    dependsOnJson: '[]', domainSlugsJson: '[]',
+    status: 'pending', createdAt: now,
+    agentContributionsJson: '{}', templateVersion: 'v1',
+    templateValidationStatus: 'pending',
+    businessSubDomainsJson: '[]', techSubDomainsJson: '[]',
+    qualityTagsJson: '[]', blockedByJson: '[]',
+    softDependsOnJson: '[]', conflictsWithJson: '[]',
+    claimsJson: '{}', inputDependenciesJson: '[]',
+    testCasesJson: '[]', testDesignStatus: 'pending',
+    validationStatus: 'pending', validationAttempts: 0,
+    linksToJson: '[]', architecturalInstructionsJson: '[]',
+    bucketId: 'bkt_a', priorityBucket: 'P2',
+    ...overrides,
+  } as never).run();
+}
+
+function mkdir(base: string, name: string): string {
+  const p = path.join(base, name);
+  fs.mkdirSync(p, { recursive: true });
+  fs.writeFileSync(path.join(p, 'placeholder.txt'), 'x');
+  return p;
+}
+
+afterEach(() => {
+  // Cleanup any leftover tmpdirs to keep CI tidy.
+});
+
+describe('WorktreeReaper.sweep', () => {
+  it('reaps a directory whose story is missing from the DB', () => {
+    const base = tmpdir();
+    mkdir(base, 'st_ghost');
+    const { db } = setup();
+    const reaper = new WorktreeReaper(db, { baseDir: base, silent: true });
+    const r = reaper.sweep();
+    expect(r.reaped).toEqual(['st_ghost']);
+    expect(fs.existsSync(path.join(base, 'st_ghost'))).toBe(false);
+  });
+
+  it('reaps a directory whose story phase2Status is `done`', () => {
+    const base = tmpdir();
+    mkdir(base, 'st_done');
+    const { db } = setup();
+    insertStory(db, 'st_done', { phase2Status: 'done' });
+    const reaper = new WorktreeReaper(db, { baseDir: base, silent: true });
+    const r = reaper.sweep();
+    expect(r.reaped).toEqual(['st_done']);
+  });
+
+  it('reaps a directory whose story phase2Status is `escalated`', () => {
+    const base = tmpdir();
+    mkdir(base, 'st_esc');
+    const { db } = setup();
+    insertStory(db, 'st_esc', { phase2Status: 'escalated' });
+    const reaper = new WorktreeReaper(db, { baseDir: base, silent: true });
+    const r = reaper.sweep();
+    expect(r.reaped).toEqual(['st_esc']);
+  });
+
+  it('skips a directory whose story is still assigned to a worker', () => {
+    const base = tmpdir();
+    mkdir(base, 'st_busy');
+    const { db } = setup();
+    insertStory(db, 'st_busy', { assignedWorkerId: 'wkr_1', phase2Status: 'coding_in_progress' });
+    const reaper = new WorktreeReaper(db, { baseDir: base, silent: true });
+    const r = reaper.sweep();
+    expect(r.skipped).toEqual(['st_busy']);
+    expect(fs.existsSync(path.join(base, 'st_busy'))).toBe(true);
+  });
+
+  it('reaps an unassigned orphan once orphanGraceMs has elapsed', () => {
+    const base = tmpdir();
+    const wtPath = mkdir(base, 'st_orphan');
+    const { db } = setup();
+    insertStory(db, 'st_orphan', { assignedWorkerId: null });
+    // Backdate the directory mtime so the grace window is clearly stale.
+    const old = (Date.now() - 20 * 60 * 1000) / 1000;
+    fs.utimesSync(wtPath, old, old);
+    const reaper = new WorktreeReaper(db, {
+      baseDir: base,
+      orphanGraceMs: 10 * 60 * 1000,
+      silent: true,
+    });
+    const r = reaper.sweep();
+    expect(r.reaped).toEqual(['st_orphan']);
+  });
+
+  it('skips an unassigned story whose directory is still inside grace', () => {
+    const base = tmpdir();
+    mkdir(base, 'st_fresh');
+    const { db } = setup();
+    insertStory(db, 'st_fresh', { assignedWorkerId: null });
+    const reaper = new WorktreeReaper(db, {
+      baseDir: base,
+      orphanGraceMs: 10 * 60 * 1000,
+      silent: true,
+    });
+    const r = reaper.sweep();
+    expect(r.skipped).toEqual(['st_fresh']);
+  });
+
+  it('reports an empty result when baseDir does not exist', () => {
+    const { db } = setup();
+    const reaper = new WorktreeReaper(db, {
+      baseDir: '/private/tmp/this-path-does-not-exist-xyz',
+      silent: true,
+    });
+    const r = reaper.sweep();
+    expect(r.reaped).toEqual([]);
+    expect(r.skipped).toEqual([]);
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -456,6 +456,8 @@ export type EventType =
   | 'task-scheduler.backpressure.released'
   // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
   | 'task-scheduler.bucket.health'
+  // ─── HARDEN-003 — worktree reaper ─────────────────────────────────────────
+  | 'worktree.reaped'
   // ─── Blocker / question / requirement writers (DASH-205/206/207) ──────────
   | 'blocker.created' | 'blocker.resolved'
   | 'question.created' | 'question.answered'
@@ -575,6 +577,8 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'task-scheduler.backpressure.released': 'info',
   // ─── Phase 2 bucket health metrics (TASKMGR-005) ──────────────────────────
   'task-scheduler.bucket.health': 'debug',
+  // ─── HARDEN-003 — worktree reaper ─────────────────────────────────────────
+  'worktree.reaped': 'info',
 };
 
 /** All valid event type strings from the registry */

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -563,3 +563,9 @@ events:
     severity: debug
     actor: [task-scheduler]
     payload: [bucketId, queueDepth, throughputPerHour, oldestReadyAgeS, workersAssigned, engaged, ts]
+
+  # HARDEN-003 — worktree reaper
+  - type: worktree.reaped
+    severity: info
+    actor: [system]
+    payload: [storyId, path, reason, ts]


### PR DESCRIPTION
## Why

Every crashed worker (HARDEN-001) leaves an orphan worktree directory under `~/.caia/worktrees/<storyId>/`. Without periodic cleanup the disk fills up and `git worktree list` becomes unreadable. This PR adds a reaper that prunes worktrees whose story is missing, terminal, or has been unassigned past a grace window.

Third in the **HARDEN-NN** production-hardening series.

## What

`apps/orchestrator/src/agents/worktree-reaper.ts` (~195 LOC):

- `WorktreeReaper.sweep()` — walks `<baseDir>`, reaps every directory whose story is missing / terminal / unassigned-past-grace.
- Reap = `git worktree remove --force <path>` with `fs.rmSync` fallback.
- Path-traversal defence: refuses to operate outside `baseDir` via `path.resolve + startsWith` on every entry.
- Emits `worktree.reaped` events with `reason` for the audit log.
- `startReaperLoop(reaper, intervalMs)` — unref'd `setInterval` that swallows sweep errors.

## Wiring (start.ts)

Opt-in via `CAIA_WORKTREE_REAPER_ENABLED=1`. Overrides:

- `CAIA_WORKTREE_BASE_DIR` (default `~/.caia/worktrees`)
- `CAIA_WORKTREE_REPO_PATH` (required for `git worktree remove`)
- `CAIA_WORKTREE_REAPER_INTERVAL_MS` (default 5 min)

Off by default — only hosts running `worker-coding` need it.

## Taxonomy

Adds `worktree.reaped` (severity `info`, actor `system`).

## Tests

`apps/orchestrator/tests/agents/worktree-reaper.test.ts` — real tmpdir end-to-end, 7 cases:

- `unknown_story` reaped
- `phase2_done` reaped
- `phase2_escalated` reaped
- busy worker skipped
- orphan with stale mtime reaped
- fresh orphan skipped (still in grace)
- missing baseDir = empty result

7/7 pass.

## DoD

- [x] typecheck clean
- [x] jest worktree-reaper 7/7
- [x] No regressions in adjacent suites
- [x] Path-traversal defence (security check)
- [x] Opt-in env flag (default off)

## Follow-up

- Worker-side cleanup signal (`worker.released` -> the worker's own process removes its worktree before exiting). Currently relies on the periodic sweep to catch up.
