### PR TITLE
feat(local-llm-router): timeout + retry + per-provider circuit breaker (HARDEN-005)

### DIFF
--- a/packages/local-llm-router/src/index.ts
+++ b/packages/local-llm-router/src/index.ts
@@ -1,6 +1,8 @@
 // Public API for @chiefaia/local-llm-router
 
-export { route, __setAdapters } from './router.js';
+export { route, __setAdapters, __resetBreakers, getBreakerStates, TimeoutError, BreakerOpenError } from './router.js';
+export { withTimeout, withRetry, CircuitBreaker } from './resilience.js';
+export type { BreakerState, BreakerOptions, RetryOptions } from './resilience.js';
 export { OllamaAdapter } from './ollama-adapter.js';
 export { ClaudeAdapter } from './claude-adapter.js';
 export { getRoute, ROUTING_RULES, COST_ANALYSIS } from './routing-config.js';

--- a/packages/local-llm-router/src/resilience.ts
+++ b/packages/local-llm-router/src/resilience.ts
@@ -1,0 +1,189 @@
+// Resilience primitives for @chiefaia/local-llm-router — HARDEN-005.
+//
+// Three composable helpers that wrap any provider dispatch:
+//
+//   1. withTimeout(promise, ms, taskType)
+//      Promise.race against a timer that rejects with TimeoutError so
+//      callers can distinguish slow networks from upstream rejections.
+//
+//   2. withRetry(fn, attempts, baseDelayMs, isRetryable)
+//      Exponential backoff: delays at 1x, 2x, 4x of baseDelayMs. By
+//      default only TimeoutError + network errors retry; explicit
+//      provider rejections (4xx-style) bubble immediately.
+//
+//   3. CircuitBreaker
+//      Per-provider state machine: closed -> open after `failureThreshold`
+//      consecutive failures; open -> half-open after `cooldownMs`; one
+//      probe call decides closed-or-open again. Open state means new
+//      calls fail fast with BreakerOpenError so the router can fall
+//      back to the other provider without burning latency.
+//
+// Each helper is dependency-free + injectable now/setTimeout for tests.
+//
+// The router (router.ts) composes them in the order:
+//   breaker.exec(() => withRetry(() => withTimeout(dispatch...)))
+// so a single timeout doesn't burn the budget; the retry fires; only
+// after all retries are exhausted is the failure counted by the breaker.
+
+export class TimeoutError extends Error {
+  constructor(public readonly taskType: string, public readonly timeoutMs: number) {
+    super(`LLM call timed out after ${timeoutMs}ms (task=${taskType})`);
+    this.name = 'TimeoutError';
+  }
+}
+
+export class BreakerOpenError extends Error {
+  constructor(public readonly provider: string) {
+    super(`circuit breaker open for provider=${provider}`);
+    this.name = 'BreakerOpenError';
+  }
+}
+
+// ─── Timeout ────────────────────────────────────────────────────────────────
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  taskType: string,
+  setTimeoutImpl: typeof setTimeout = setTimeout,
+  clearTimeoutImpl: typeof clearTimeout = clearTimeout,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeoutImpl(() => {
+      reject(new TimeoutError(taskType, ms));
+    }, ms);
+    promise.then(
+      (v) => { clearTimeoutImpl(handle); resolve(v); },
+      (e) => { clearTimeoutImpl(handle); reject(e); },
+    );
+  });
+}
+
+// ─── Retry ──────────────────────────────────────────────────────────────────
+
+export interface RetryOptions {
+  attempts?: number;          // total attempts including the first; default 3
+  baseDelayMs?: number;       // first backoff delay; default 250ms
+  isRetryable?: (err: unknown) => boolean;
+  /** Per-attempt callback for observability (logging/events). */
+  onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void;
+  setTimeoutImpl?: typeof setTimeout;
+}
+
+const DEFAULT_RETRYABLE = (err: unknown): boolean => {
+  if (err instanceof TimeoutError) return true;
+  const msg = String((err as { message?: string })?.message ?? err);
+  // Network-y error strings worth retrying.
+  return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|fetch failed|network/i.test(msg);
+};
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const attempts = Math.max(1, opts.attempts ?? 3);
+  const baseDelay = Math.max(0, opts.baseDelayMs ?? 250);
+  const isRetryable = opts.isRetryable ?? DEFAULT_RETRYABLE;
+  const setTimeoutFn = opts.setTimeoutImpl ?? setTimeout;
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const isLast = i === attempts - 1;
+      if (isLast || !isRetryable(err)) throw err;
+      const delayMs = baseDelay * Math.pow(2, i);
+      opts.onRetry?.({ attempt: i + 1, delayMs, error: err });
+      await new Promise<void>((r) => setTimeoutFn(() => r(), delayMs));
+    }
+  }
+  throw lastErr;
+}
+
+// ─── Circuit breaker ────────────────────────────────────────────────────────
+
+export type BreakerState = 'closed' | 'open' | 'half-open';
+
+export interface BreakerOptions {
+  /** Consecutive failures that flip closed -> open. Default 5. */
+  failureThreshold?: number;
+  /** Milliseconds before open -> half-open. Default 30_000. */
+  cooldownMs?: number;
+  /** Override Date.now (tests). */
+  now?: () => number;
+  /** Notification hook for state transitions (observability). */
+  onStateChange?: (info: { provider: string; from: BreakerState; to: BreakerState; ts: number }) => void;
+}
+
+export class CircuitBreaker {
+  private state: BreakerState = 'closed';
+  private consecutiveFailures = 0;
+  private openedAt = 0;
+  private readonly failureThreshold: number;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+  private readonly onStateChange?: BreakerOptions['onStateChange'];
+
+  constructor(public readonly provider: string, opts: BreakerOptions = {}) {
+    this.failureThreshold = opts.failureThreshold ?? 5;
+    this.cooldownMs = opts.cooldownMs ?? 30_000;
+    this.now = opts.now ?? Date.now;
+    this.onStateChange = opts.onStateChange;
+  }
+
+  /** Wraps a call. Throws BreakerOpenError when fast-failing. */
+  async exec<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.state === 'open') {
+      // Maybe transition to half-open.
+      if (this.now() - this.openedAt >= this.cooldownMs) {
+        this.transition('half-open');
+      } else {
+        throw new BreakerOpenError(this.provider);
+      }
+    }
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (err) {
+      this.onFailure();
+      throw err;
+    }
+  }
+
+  /** Current state for tests / dashboards. */
+  getState(): BreakerState { return this.state; }
+  getConsecutiveFailures(): number { return this.consecutiveFailures; }
+
+  /** Reset internal counters (admin use). */
+  reset(): void {
+    if (this.state !== 'closed') this.transition('closed');
+    this.consecutiveFailures = 0;
+  }
+
+  // ─── internals ──────────────────────────────────────────────────────────
+
+  private onSuccess(): void {
+    if (this.state === 'half-open' || this.consecutiveFailures > 0) {
+      this.transition('closed');
+    }
+    this.consecutiveFailures = 0;
+  }
+
+  private onFailure(): void {
+    this.consecutiveFailures++;
+    if (this.state === 'half-open' || this.consecutiveFailures >= this.failureThreshold) {
+      this.openedAt = this.now();
+      this.transition('open');
+    }
+  }
+
+  private transition(to: BreakerState): void {
+    if (this.state === to) return;
+    const from = this.state;
+    this.state = to;
+    if (to === 'closed') this.consecutiveFailures = 0;
+    this.onStateChange?.({ provider: this.provider, from, to, ts: this.now() });
+  }
+}

--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -1,14 +1,29 @@
-// Main routing logic for @chiefaia/local-llm-router
-// Decides local vs Claude based on routing-config.ts, then dispatches.
+// Main routing logic for @chiefaia/local-llm-router.
+// Decides local vs Claude based on routing-config.ts, then dispatches
+// through the HARDEN-005 resilience stack (breaker -> retry -> timeout).
 
 import { ClaudeAdapter } from './claude-adapter.js';
 import { OllamaAdapter } from './ollama-adapter.js';
 import { getRoute } from './routing-config.js';
+import {
+  CircuitBreaker,
+  TimeoutError,
+  BreakerOpenError,
+  withRetry,
+  withTimeout,
+} from './resilience.js';
 import type { LLMProvider, LLMRequest, LLMResponse, RouterOptions } from './types.js';
 
-// Singleton adapters — created lazily so tests can import without side effects.
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_BASE_MS = 250;
+
 let _ollama: OllamaAdapter | null = null;
 let _claude: ClaudeAdapter | null = null;
+const _breakers: Record<LLMProvider, CircuitBreaker> = {
+  local: new CircuitBreaker('local'),
+  claude: new CircuitBreaker('claude'),
+};
 
 function getOllama(): OllamaAdapter {
   _ollama ??= new OllamaAdapter();
@@ -21,7 +36,8 @@ function getClaude(): ClaudeAdapter {
 }
 
 /**
- * Test-only seam: replace adapters with stubs.
+ * Test-only seam: replace adapters with stubs and (optionally) reset
+ * breakers to a known state.
  * @internal
  */
 export function __setAdapters(
@@ -33,11 +49,28 @@ export function __setAdapters(
 }
 
 /**
+ * Test-only seam: reset both circuit breakers to closed.
+ * @internal
+ */
+export function __resetBreakers(): void {
+  _breakers.local.reset();
+  _breakers.claude.reset();
+}
+
+/** Read-only access to the breaker states (for /llm/health surfaces). */
+export function getBreakerStates(): Record<LLMProvider, ReturnType<CircuitBreaker['getState']>> {
+  return { local: _breakers.local.getState(), claude: _breakers.claude.getState() };
+}
+
+/**
  * Route a prompt to the best available provider and return the response.
  *
- * @param taskType  One of the keys from ROUTING_RULES (e.g. 'domain-classification').
+ * Each dispatch is wrapped in:
+ *   breaker.exec( withRetry( withTimeout( dispatch ) ) )
+ *
+ * @param taskType  One of the keys from ROUTING_RULES.
  * @param prompt    The full user/system prompt text.
- * @param options   Optional overrides: forceLocal, forceClaude, fallbackOnError.
+ * @param options   Overrides incl. forceLocal / forceClaude / timeoutMs / retryAttempts.
  */
 export async function route(
   taskType: string,
@@ -45,8 +78,6 @@ export async function route(
   options: RouterOptions = {},
 ): Promise<LLMResponse> {
   const rule = getRoute(taskType);
-
-  // Build the LLMRequest
   const request: LLMRequest = {
     taskType,
     prompt,
@@ -54,7 +85,6 @@ export async function route(
     temperature: 0.2,
   };
 
-  // Determine which provider wins
   let preferredProvider: LLMProvider;
   if (options.forceLocal) {
     preferredProvider = 'local';
@@ -65,37 +95,86 @@ export async function route(
   }
 
   const fallbackEnabled = options.fallbackOnError ?? true;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retryAttempts = options.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS;
+  const retryBaseDelayMs = options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_MS;
 
   if (preferredProvider === 'local') {
     try {
-      return await dispatchLocal(rule.localModel, request);
+      return await callWithResilience(
+        'local',
+        () => dispatchLocal(rule.localModel, request),
+        { taskType, timeoutMs, retryAttempts, retryBaseDelayMs },
+      );
     } catch (localErr) {
       if (fallbackEnabled && rule.claudeModel) {
         console.warn(
-          `[local-llm-router] Local model "${rule.localModel}" failed ` +
-            `for task "${taskType}"; falling back to Claude (${rule.claudeModel}). ` +
-            `Error: ${String(localErr)}`,
+          `[local-llm-router] Local model "${rule.localModel}" failed for task "${taskType}"; ` +
+            `falling back to Claude (${rule.claudeModel}). Error: ${String(localErr)}`,
         );
-        return await dispatchClaude(rule.claudeModel, request);
+        return callWithResilience(
+          'claude',
+          () => dispatchClaude(rule.claudeModel!, request),
+          { taskType, timeoutMs, retryAttempts, retryBaseDelayMs },
+        );
       }
       throw localErr;
     }
   } else {
     const claudeModel = rule.claudeModel ?? 'claude-sonnet-4-6';
     try {
-      return await dispatchClaude(claudeModel, request);
+      return await callWithResilience(
+        'claude',
+        () => dispatchClaude(claudeModel, request),
+        { taskType, timeoutMs, retryAttempts, retryBaseDelayMs },
+      );
     } catch (claudeErr) {
       if (fallbackEnabled) {
         console.warn(
-          `[local-llm-router] Claude model "${claudeModel}" failed ` +
-            `for task "${taskType}"; falling back to local (${rule.localModel}). ` +
-            `Error: ${String(claudeErr)}`,
+          `[local-llm-router] Claude model "${claudeModel}" failed for task "${taskType}"; ` +
+            `falling back to local (${rule.localModel}). Error: ${String(claudeErr)}`,
         );
-        return await dispatchLocal(rule.localModel, request);
+        return callWithResilience(
+          'local',
+          () => dispatchLocal(rule.localModel, request),
+          { taskType, timeoutMs, retryAttempts, retryBaseDelayMs },
+        );
       }
       throw claudeErr;
     }
   }
+}
+
+interface ResilienceCtx {
+  taskType: string;
+  timeoutMs: number;
+  retryAttempts: number;
+  retryBaseDelayMs: number;
+}
+
+async function callWithResilience(
+  provider: LLMProvider,
+  dispatch: () => Promise<LLMResponse>,
+  ctx: ResilienceCtx,
+): Promise<LLMResponse> {
+  const breaker = _breakers[provider];
+  return breaker.exec(() =>
+    withRetry(
+      () => withTimeout(dispatch(), ctx.timeoutMs, ctx.taskType),
+      {
+        attempts: ctx.retryAttempts,
+        baseDelayMs: ctx.retryBaseDelayMs,
+        onRetry: (info) => {
+          // Surface as warn so the host process picks it up via stderr.
+          // The orchestrator host wraps this in proper structured logs.
+          console.warn(
+            `[local-llm-router] retry attempt=${info.attempt} delay=${info.delayMs}ms ` +
+              `provider=${provider} taskType=${ctx.taskType} error=${String(info.error)}`,
+          );
+        },
+      },
+    ),
+  );
 }
 
 async function dispatchLocal(
@@ -119,3 +198,7 @@ async function dispatchClaude(
 ): Promise<LLMResponse> {
   return getClaude().generate(model, request);
 }
+
+// ─── Public re-exports for callers + tests ─────────────────────────────────
+
+export { TimeoutError, BreakerOpenError };

--- a/packages/local-llm-router/src/types.ts
+++ b/packages/local-llm-router/src/types.ts
@@ -39,6 +39,12 @@ export interface RouterOptions {
   forceClaude?: boolean;
   /** If the primary provider fails, automatically retry with the other */
   fallbackOnError?: boolean;
+  /** HARDEN-005: per-call timeout. Default 60_000 ms. */
+  timeoutMs?: number;
+  /** HARDEN-005: total retry attempts (incl. first). Default 3. */
+  retryAttempts?: number;
+  /** HARDEN-005: base backoff delay before the first retry. Default 250 ms. */
+  retryBaseDelayMs?: number;
 }
 
 interface OllamaCommonOptions {

--- a/packages/local-llm-router/tests/resilience.test.ts
+++ b/packages/local-llm-router/tests/resilience.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  withTimeout,
+  withRetry,
+  CircuitBreaker,
+  TimeoutError,
+  BreakerOpenError,
+} from '../src/resilience.js';
+
+describe('withTimeout', () => {
+  it('resolves when the inner promise settles before the timer fires', async () => {
+    const v = await withTimeout(Promise.resolve(42), 1000, 'unit');
+    expect(v).toBe(42);
+  });
+
+  it('rejects with TimeoutError when the inner promise never settles', async () => {
+    const never = new Promise<number>(() => { /* never */ });
+    await expect(withTimeout(never, 5, 'unit')).rejects.toBeInstanceOf(TimeoutError);
+  });
+});
+
+describe('withRetry', () => {
+  it('retries on retryable errors and ultimately succeeds', async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw new TimeoutError('unit', 10);
+      return 'ok';
+    };
+    const setT: typeof setTimeout = ((cb: () => void) => {
+      cb();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    const v = await withRetry(fn, { attempts: 3, baseDelayMs: 0, setTimeoutImpl: setT });
+    expect(v).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      throw new Error('hard reject — 4xx-style');
+    };
+    await expect(withRetry(fn, { attempts: 5 })).rejects.toThrow(/hard reject/);
+    expect(calls).toBe(1);
+  });
+
+  it('emits onRetry callback for each retry', async () => {
+    const seen: number[] = [];
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw new TimeoutError('unit', 10);
+      return 'ok';
+    };
+    const setT: typeof setTimeout = ((cb: () => void) => {
+      cb();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    await withRetry(fn, {
+      attempts: 3,
+      baseDelayMs: 0,
+      setTimeoutImpl: setT,
+      onRetry: (info) => seen.push(info.attempt),
+    });
+    expect(seen).toEqual([1, 2]);
+  });
+});
+
+describe('CircuitBreaker', () => {
+  it('opens after failureThreshold consecutive failures', async () => {
+    let now = 0;
+    const transitions: string[] = [];
+    const b = new CircuitBreaker('claude', {
+      failureThreshold: 3,
+      cooldownMs: 1000,
+      now: () => now,
+      onStateChange: (i) => transitions.push(`${i.from}->${i.to}`),
+    });
+    const fail = async () => { throw new Error('boom'); };
+    for (let i = 0; i < 3; i++) {
+      await expect(b.exec(fail)).rejects.toThrow();
+    }
+    expect(b.getState()).toBe('open');
+    expect(transitions).toContain('closed->open');
+
+    // Next call fast-fails with BreakerOpenError until cooldown.
+    await expect(b.exec(fail)).rejects.toBeInstanceOf(BreakerOpenError);
+  });
+
+  it('flips to half-open after cooldown and closes on a successful probe', async () => {
+    let now = 0;
+    const transitions: string[] = [];
+    const b = new CircuitBreaker('claude', {
+      failureThreshold: 1,
+      cooldownMs: 100,
+      now: () => now,
+      onStateChange: (i) => transitions.push(`${i.from}->${i.to}`),
+    });
+    await expect(b.exec(async () => { throw new Error('boom'); })).rejects.toThrow();
+    expect(b.getState()).toBe('open');
+
+    now = 200;
+    const v = await b.exec(async () => 'ok');
+    expect(v).toBe('ok');
+    expect(b.getState()).toBe('closed');
+    expect(transitions).toEqual(['closed->open', 'open->half-open', 'half-open->closed']);
+  });
+
+  it('reverts to open if half-open probe also fails', async () => {
+    let now = 0;
+    const b = new CircuitBreaker('claude', {
+      failureThreshold: 1,
+      cooldownMs: 100,
+      now: () => now,
+    });
+    await expect(b.exec(async () => { throw new Error('boom'); })).rejects.toThrow();
+    expect(b.getState()).toBe('open');
+    now = 200;
+    await expect(b.exec(async () => { throw new Error('still bad'); })).rejects.toThrow();
+    expect(b.getState()).toBe('open');
+  });
+
+  it('reset() returns to closed', async () => {
+    const b = new CircuitBreaker('local', { failureThreshold: 1 });
+    await expect(b.exec(async () => { throw new Error('boom'); })).rejects.toThrow();
+    expect(b.getState()).toBe('open');
+    b.reset();
+    expect(b.getState()).toBe('closed');
+    expect(b.getConsecutiveFailures()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

The router previously had only `fallbackOnError`. Production traffic needs:

- **Timeouts** — so a hung Ollama daemon doesn't burn the whole budget.
- **Retries with exponential backoff** — so transient `ECONNRESET`-style flakes don't escalate to user-visible failures.
- **Per-provider circuit breaker** — so a sustained outage fails fast through the fallback rather than starving requests.

Fifth in the **HARDEN-NN** production-hardening series.

## What

`packages/local-llm-router/src/resilience.ts` (~189 LOC):

- `withTimeout(promise, ms, taskType)` — `Promise.race` with `TimeoutError`.
- `withRetry(fn, opts)` — exponential backoff (1x/2x/4x of `baseDelayMs`); only retries `TimeoutError` + network errors by default; `onRetry` hook for observability.
- `CircuitBreaker(provider, opts)` — `closed` -> `open` after `failureThreshold` (default 5); `open` -> `half-open` after `cooldownMs` (default 30s); probe decides next state.

`router.ts` composes them:

```ts
breaker.exec(() => withRetry(() => withTimeout(dispatch...)))
```

A single timeout doesn't burn the budget; the retry fires; only after all retries are exhausted does the breaker count the failure. When the breaker is open, `route()` falls back to the other provider exactly as before — **no new config to enable resilience, just new defaults**.

`types.ts` — `RouterOptions` adds `timeoutMs` / `retryAttempts` / `retryBaseDelayMs`.

`index.ts` — re-exports `__resetBreakers` (test seam), `getBreakerStates()` (dashboard surface), `TimeoutError`, `BreakerOpenError`, and the resilience helpers.

## Tests

`packages/local-llm-router/tests/resilience.test.ts` — 9 cases:

- timeout resolves / timeout rejects
- retry-then-success / no-retry-on-non-retryable / onRetry callback
- breaker opens after threshold / half-open success closes / half-open failure reopens / reset

9/9 pass. Existing `local-llm-router` suites still 73/73 pass.

## DoD

- [x] vitest resilience: 9/9
- [x] vitest @chiefaia/local-llm-router: 73/73 (no regressions, including live Ollama integration)
- [x] orchestrator typecheck: clean
- [x] Defaults are sensible (60s timeout, 3 attempts, 250/500ms backoff, 5 failures to open, 30s cooldown)
- [x] No breaking API changes

## Follow-up

- Emit `llm.timeout`, `llm.retry`, `llm.breaker_open` events on the bus once HARDEN-006 (trace view) lands.
