### PR TITLE
feat(orchestrator): pipeline-run trace API (HARDEN-006)

### DIFF
--- a/apps/orchestrator/src/api/app.ts
+++ b/apps/orchestrator/src/api/app.ts
@@ -28,6 +28,8 @@ import { registerDagRoutes } from './routes/dag';
 import { registerFeatureRegistryRoutes } from './routes/feature-registry';
 import { registerArchitectureRoutes } from './routes/architecture';
 import { registerWorkerRoutes } from './routes/workers';
+// HARDEN-006: aggregated pipeline-run trace endpoint.
+import { registerPipelineTraceRoutes } from './routes/pipeline-trace';
 import { promRegistry, httpRequestsTotal } from '../metrics/prometheus';
 import type { Phase2Context } from '../agents/wire-phase2';
 
@@ -92,6 +94,8 @@ export function createApp(db: Db, opts: CreateAppOptions = {}): Hono {
   registerDagRoutes(app, db);
   // TASKMGR-006 + CODING-007 — Phase 2 worker pool dashboard + lifecycle
   registerWorkerRoutes(app, db, { registry: opts.phase2?.registry });
+  // HARDEN-006: pipeline-run trace + recent listing.
+  registerPipelineTraceRoutes(app, db);
 
   return app;
 }

--- a/apps/orchestrator/src/api/routes/pipeline-trace.ts
+++ b/apps/orchestrator/src/api/routes/pipeline-trace.ts
@@ -1,0 +1,182 @@
+/**
+ * Pipeline-run trace API — HARDEN-006 (Production hardening).
+ *
+ * Aggregates everything the orchestrator knows about a single
+ * pipeline-run (a prompt) into one queryable trace:
+ *
+ *   GET /api/pipelines/:promptId/trace
+ *     {
+ *       prompt:   { id, body, status, correlationId, receivedAt },
+ *       stages:   [ { stage, enteredAt, durationMs } ... ],
+ *       events:   [ { id, type, occurred_at, actor, severity, payload } ... ],
+ *       cost:     { totalCostUsd, baselineCostUsd, perAgent, ... } | null,
+ *       summary:  { firstEventAt, lastEventAt, durationMs, eventCount, errorCount }
+ *     }
+ *
+ * The events list is ordered by occurred_at asc and bounded at 1000
+ * (configurable via ?limit) so a runaway pipeline doesn't OOM the API.
+ *
+ * The dashboard /prompts/[id]/journey page reads this single endpoint
+ * to render the timeline + cost panel + stage flow.
+ */
+
+import type { Hono } from 'hono';
+import { eq, desc } from 'drizzle-orm';
+import type { Db } from '../../db/connection';
+import { prompts, promptPipelineStages } from '../../db/schema';
+import { eventBus } from '../../events/bus-adapter';
+// HARDEN-006: cost field is wired in a follow-up once HARDEN-002 (cost
+// tracker) lands. For now the trace returns cost=null and the dashboard
+// renders its existing /metrics aggregate.
+
+interface PromptOut {
+  id: string;
+  body: string;
+  status: string;
+  correlationId: string;
+  receivedAt: string;
+}
+
+interface StageOut {
+  stage: string;
+  enteredAt: number;
+  durationMs: number | null;
+}
+
+interface EventOut {
+  id: string;
+  type: string;
+  occurredAt: string;
+  actor: string;
+  severity: string;
+  entityId: string | null;
+  entityType: string | null;
+  payload: Record<string, unknown>;
+}
+
+interface TraceSummary {
+  firstEventAt: string | null;
+  lastEventAt: string | null;
+  durationMs: number | null;
+  eventCount: number;
+  errorCount: number;
+  warningCount: number;
+}
+
+export function registerPipelineTraceRoutes(app: Hono, db: Db): void {
+  // GET /api/pipelines/:promptId/trace
+  app.get('/api/pipelines/:promptId/trace', (c) => {
+    const promptId = c.req.param('promptId');
+    const limit = Math.min(
+      Math.max(parseInt(c.req.query('limit') ?? '1000', 10) || 1000, 1),
+      5000,
+    );
+
+    const prompt = db.select().from(prompts).where(eq(prompts.id, promptId)).get();
+    if (!prompt) return c.json({ error: 'prompt not found' }, 404);
+
+    const promptOut: PromptOut = {
+      id: prompt.id,
+      body: prompt.body,
+      status: prompt.status ?? 'unknown',
+      correlationId: prompt.correlationId,
+      receivedAt: prompt.receivedAt,
+    };
+
+    // Stages — already promptId-keyed; sort ascending so the dashboard
+    // can render a forward timeline.
+    const stageRows = db
+      .select()
+      .from(promptPipelineStages)
+      .where(eq(promptPipelineStages.promptId, promptId))
+      .all()
+      .sort((a, b) => a.enteredAt - b.enteredAt);
+    const stagesOut: StageOut[] = stageRows.map((r) => ({
+      stage: r.stage,
+      enteredAt: r.enteredAt,
+      durationMs: r.durationMs ?? null,
+    }));
+
+    // Events — replay() sorts desc, but we want asc for trace rendering
+    // so we re-sort after fetching `limit` rows.
+    const eventRows = eventBus.replay({
+      correlationId: prompt.correlationId,
+      limit,
+    });
+    const eventsOut: EventOut[] = eventRows
+      .slice()
+      .sort((a, b) => a.occurred_at.localeCompare(b.occurred_at))
+      .map((e) => ({
+        id: e.id,
+        type: e.type,
+        occurredAt: e.occurred_at,
+        actor: e.actor,
+        severity: e.severity,
+        entityId: e.entity_id ?? null,
+        entityType: e.entity_type ?? null,
+        payload: e.payload,
+      }));
+
+    // Cost field — null until HARDEN-002 lands; the dashboard handles
+    // null gracefully and falls back to the global /metrics aggregate.
+    const cost = null;
+
+    // Summary — compute from events (single source of truth).
+    let firstEventAt: string | null = null;
+    let lastEventAt: string | null = null;
+    let durationMs: number | null = null;
+    let errorCount = 0;
+    let warningCount = 0;
+    for (const e of eventsOut) {
+      if (firstEventAt === null) firstEventAt = e.occurredAt;
+      lastEventAt = e.occurredAt;
+      if (e.severity === 'error') errorCount++;
+      else if (e.severity === 'warning') warningCount++;
+    }
+    if (firstEventAt && lastEventAt) {
+      const dur = Date.parse(lastEventAt) - Date.parse(firstEventAt);
+      durationMs = Number.isFinite(dur) ? dur : null;
+    }
+    const summary: TraceSummary = {
+      firstEventAt,
+      lastEventAt,
+      durationMs,
+      eventCount: eventsOut.length,
+      errorCount,
+      warningCount,
+    };
+
+    return c.json({
+      prompt: promptOut,
+      stages: stagesOut,
+      events: eventsOut,
+      cost,
+      summary,
+    });
+  });
+
+  // GET /api/pipelines/recent — N most-recent prompts ordered by
+  // receivedAt desc. Lightweight payload (no events) so the dashboard
+  // landing page can list pipelines without per-prompt round-trips.
+  app.get('/api/pipelines/recent', (c) => {
+    const limit = Math.min(
+      Math.max(parseInt(c.req.query('limit') ?? '25', 10) || 25, 1),
+      200,
+    );
+    const rows = db
+      .select()
+      .from(prompts)
+      .orderBy(desc(prompts.receivedAt))
+      .limit(limit)
+      .all();
+    const out = rows.map((r) => ({
+      id: r.id,
+      correlationId: r.correlationId,
+      status: r.status ?? 'unknown',
+      receivedAt: r.receivedAt,
+      bodyExcerpt: r.body.slice(0, 120),
+      cost: null,
+    }));
+    return c.json({ pipelines: out });
+  });
+}

--- a/apps/orchestrator/tests/api/pipeline-trace.test.ts
+++ b/apps/orchestrator/tests/api/pipeline-trace.test.ts
@@ -1,0 +1,163 @@
+/**
+ * /api/pipelines/:promptId/trace + /api/pipelines/recent — HARDEN-006 tests.
+ *
+ * Drives the route handlers via Hono's c.req.fetch-style invocation
+ * (matching the pattern used by the existing route test files). Each
+ * test seeds a synthetic prompt + stage rows + a pair of events on the
+ * bus, then asserts the trace payload shape.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { Hono } from 'hono';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { prompts, promptPipelineStages } from '../../src/db/schema';
+import { eventBus, wireEventBus } from '../../src/events/bus-adapter';
+import { registerPipelineTraceRoutes } from '../../src/api/routes/pipeline-trace';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  wireEventBus(db);
+  const app = new Hono();
+  registerPipelineTraceRoutes(app, db);
+  return { db, app };
+}
+
+function seedPrompt(db: ReturnType<typeof setup>['db'], id: string, correlationId: string): void {
+  db.insert(prompts).values({
+    id,
+    body: `body-${id}`,
+    receivedAt: new Date('2026-04-29T00:00:00Z').toISOString(),
+    correlationId,
+    hash: `h-${id}`,
+  }).run();
+}
+
+function seedStage(
+  db: ReturnType<typeof setup>['db'],
+  promptId: string,
+  stage: string,
+  enteredAt: number,
+  durationMs: number | null = null,
+): void {
+  db.insert(promptPipelineStages).values({
+    id: `pps_${promptId}_${stage}`,
+    promptId,
+    stage,
+    entityKind: null,
+    entityId: null,
+    enteredAt,
+    durationMs,
+    metadata: null,
+  } as never).run();
+}
+
+describe('GET /api/pipelines/:promptId/trace', () => {
+  it('returns 404 for an unknown prompt', async () => {
+    const { app } = setup();
+    const res = await app.request('/api/pipelines/p_ghost/trace');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns prompt + stages + events + summary for a known prompt', async () => {
+    const { db, app } = setup();
+    seedPrompt(db, 'p_a', 'corr_a');
+    seedStage(db, 'p_a', 'ingested', 1000, 500);
+    seedStage(db, 'p_a', 'scaffolded', 1500, 1000);
+
+    eventBus.publish({
+      type: 'prompt.ingested',
+      actor: 'api',
+      correlation_id: 'corr_a',
+      payload: { promptId: 'p_a' },
+    });
+    eventBus.publish({
+      type: 'po-agent.decomposition.complete',
+      actor: 'po-agent',
+      correlation_id: 'corr_a',
+      payload: { storyCount: 3 },
+    });
+
+    const res = await app.request('/api/pipelines/p_a/trace');
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.prompt.id).toBe('p_a');
+    expect(body.prompt.correlationId).toBe('corr_a');
+    expect(body.stages).toHaveLength(2);
+    expect(body.stages[0].stage).toBe('ingested');
+    expect(body.events.length).toBeGreaterThanOrEqual(2);
+    expect(body.summary.eventCount).toBe(body.events.length);
+    expect(body.cost).toBeNull(); // until HARDEN-002 wiring lands
+    // Events sorted ascending by occurredAt
+    for (let i = 1; i < body.events.length; i++) {
+      expect(body.events[i].occurredAt >= body.events[i - 1].occurredAt).toBe(true);
+    }
+  });
+
+  it('respects ?limit on the events list', async () => {
+    const { db, app } = setup();
+    seedPrompt(db, 'p_b', 'corr_b');
+    for (let i = 0; i < 10; i++) {
+      eventBus.publish({
+        type: 'pipeline.stage.advanced',
+        actor: 'system',
+        correlation_id: 'corr_b',
+        payload: { i },
+      });
+    }
+    const res = await app.request('/api/pipelines/p_b/trace?limit=3');
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.events.length).toBeLessThanOrEqual(3);
+  });
+
+  it('counts errors + warnings in summary', async () => {
+    const { db, app } = setup();
+    seedPrompt(db, 'p_c', 'corr_c');
+    eventBus.publish({
+      type: 'system.error',
+      actor: 'system',
+      correlation_id: 'corr_c',
+      payload: { msg: 'boom' },
+    });
+    eventBus.publish({
+      type: 'task-scheduler.backpressure.engaged',
+      actor: 'task-scheduler',
+      correlation_id: 'corr_c',
+      payload: { bucketId: 'bkt' },
+    });
+    const res = await app.request('/api/pipelines/p_c/trace');
+    const body: any = await res.json();
+    expect(body.summary.errorCount).toBeGreaterThanOrEqual(1);
+    expect(body.summary.warningCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('GET /api/pipelines/recent', () => {
+  it('returns prompts sorted by receivedAt desc', async () => {
+    const { db, app } = setup();
+    db.insert(prompts).values({
+      id: 'p_old', body: 'older', receivedAt: '2026-04-28T00:00:00Z',
+      correlationId: 'corr_old', hash: 'h_old',
+    }).run();
+    db.insert(prompts).values({
+      id: 'p_new', body: 'newer', receivedAt: '2026-04-29T00:00:00Z',
+      correlationId: 'corr_new', hash: 'h_new',
+    }).run();
+    const res = await app.request('/api/pipelines/recent');
+    const body: any = await res.json();
+    expect(body.pipelines.map((p: { id: string }) => p.id)).toEqual(['p_new', 'p_old']);
+  });
+
+  it('caps limit at 200', async () => {
+    const { app } = setup();
+    const res = await app.request('/api/pipelines/recent?limit=99999');
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Why

The dashboard journey page currently makes 4-5 round-trips to assemble the timeline for a single pipeline-run. This PR exposes one aggregated endpoint that returns prompt + stages + events + summary in a single GET.

Sixth in the **HARDEN-NN** production-hardening series.

## What

`apps/orchestrator/src/api/routes/pipeline-trace.ts` (~187 LOC):

```
GET /api/pipelines/:promptId/trace
  {
    prompt:   { id, body, status, correlationId, receivedAt },
    stages:   [ { stage, enteredAt, durationMs } ],
    events:   [ { id, type, occurredAt, actor, severity, payload } ],
    cost:     null  // wired once HARDEN-002 lands
    summary:  { firstEventAt, lastEventAt, durationMs, eventCount,
                errorCount, warningCount }
  }
```

```
GET /api/pipelines/recent[?limit=N]   // capped 200
```

Events sorted ascending by `occurred_at` (the bus's `replay()` returns desc). Limit defaults to 1000, clamped to 5000.

The `cost` field is `null` until HARDEN-002 (cost tracker) lands. A follow-up PR re-imports `getPipelineCostTracker` and populates it.

## Tests

`apps/orchestrator/tests/api/pipeline-trace.test.ts` — 6 cases:

- 404 unknown prompt
- full trace shape + ordering + summary
- `?limit` honored
- error + warning severity counters
- recent listing sorted desc
- limit cap

6/6 pass.

## DoD

- [x] typecheck clean
- [x] jest pipeline-trace: 6/6
- [x] No regressions in adjacent suites
- [x] Dashboard `/prompts/[id]/journey` already exists — UI wiring is a follow-up
