### PR TITLE
feat(playwright-config): shared local + browserless config factory (FIX-010)

### DIFF
--- a/.changeset/fix-010-playwright-config.md
+++ b/.changeset/fix-010-playwright-config.md
@@ -1,0 +1,41 @@
+---
+"@chiefaia/playwright-config": minor
+---
+
+feat(playwright-config): shared local + browserless config factory (FIX-010)
+
+New package `@chiefaia/playwright-config` exporting
+`definePlaywrightConfig()` — a Playwright config factory that auto-
+detects local vs Browserless mode based on
+`process.env.BROWSERLESS_WS_ENDPOINT`.
+
+Local mode:
+  - 3 workers default (Phase B safe ceiling on 16 GB M1 Pro)
+  - Override via `PLAYWRIGHT_LOCAL_WORKERS` or `localWorkers` option
+  - Clamped to [1, 8]
+  - Launch args mirror the Browserless container so failures
+    reproduce in both places
+
+Browserless mode:
+  - 1 worker (parallelism from CI shards — FIX-012)
+  - Connects to `browserless.stolution.local:13080/playwright/chromium`
+    by default
+  - Token auto-appended from `BROWSERLESS_TOKEN` (handles `?` vs `&`,
+    skips if already in the URL)
+
+Other defaults:
+  - `fullyParallel: true`
+  - 2 retries in CI, 0 locally
+  - `trace: 'on-first-retry'`, `screenshot: 'only-on-failure'`,
+    `video: 'retain-on-failure'`
+  - CI reporter is blob+list (consumed by the FIX-012 shard aggregator)
+
+Postinstall hook (`scripts/install-chromium.mjs`) runs
+`playwright install chromium` so every dev + CI runner has the pinned
+binary on disk after `pnpm install`. Idempotent (skips if already
+cached); non-fatal on failure (first test run surfaces the missing-
+binary error). Skippable via `PLAYWRIGHT_SKIP_BROWSER_INSTALL` or
+`CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL`.
+
+Phase B (FIX-010). Consumed by FIX-011 (Fix-It mode selection) and
+FIX-012 (sharded CI).

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# Operator runbook documents the Browserless endpoint pattern (FIX-010).
+# Internal-LAN-only deployment; see .semgrep/SUPPRESSIONS.md.
+packages/playwright-config/README.md

--- a/packages/playwright-config/README.md
+++ b/packages/playwright-config/README.md
@@ -1,0 +1,125 @@
+# @chiefaia/playwright-config
+
+Shared Playwright config factory for the Fix-It Test Agent.
+
+## What it does
+
+```ts
+// playwright.config.ts in any consumer
+import { definePlaywrightConfig } from '@chiefaia/playwright-config';
+
+export default definePlaywrightConfig({
+  testDir: './tests/e2e',
+  baseURL: 'http://localhost:7777',
+});
+```
+
+You get one Playwright config that works in two modes:
+
+| Mode | Trigger | Workers | Where Chromium runs |
+|---|---|---|---|
+| `local` (default) | unset `BROWSERLESS_WS_ENDPOINT` | 3 (override via `PLAYWRIGHT_LOCAL_WORKERS`) | local headless Chromium |
+| `browserless` | `BROWSERLESS_WS_ENDPOINT` set | 1 per shard | remote Browserless on stolution |
+
+## Why this exists (FIX-010)
+
+Phase B of the testing-framework architecture
+(`reports/testing-framework-architecture-2026-04-28.md`) calls for two
+runner modes — local for fast inner-loop iteration, Browserless for
+parallel CI batches. Letting every consumer hand-roll their own
+`playwright.config.ts` produces drift (different worker counts,
+different launch flags, different reporters), which leads to "passes
+on my box, fails in CI" flakes that take hours to debug.
+
+This package centralizes:
+
+- The Playwright + Chromium version pin (1.59.1)
+- The local-vs-browserless mode toggle
+- Sensible default launch args (`--disable-dev-shm-usage`,
+  `--disable-gpu`, etc.) that match the Browserless container
+- The CI reporter format (blob — feeds the FIX-012 shard aggregator)
+- The Browserless v2 connection URL shape
+  (`/playwright/chromium?token=…`)
+
+## Worker tuning
+
+Default: 3 workers in local mode. That's the safe ceiling on a 16 GB
+M1 Pro per the Phase B doc — 3 workers ≈ 12 GB Chromium-for-Testing
+RSS, leaves 4 GB for the editor + dashboard + orchestrator. Bump to 5
+on a 32 GB box; 8 is the absolute clamp.
+
+Override per-developer:
+
+```bash
+PLAYWRIGHT_LOCAL_WORKERS=5 pnpm test
+```
+
+In code:
+
+```ts
+export default definePlaywrightConfig({ localWorkers: 5 });
+```
+
+## Browserless mode
+
+When `BROWSERLESS_WS_ENDPOINT` is set in the environment, the factory
+flips to Browserless mode automatically. Workers drop to 1 (the
+parallelism comes from CI sharding — FIX-012), and Playwright connects
+via WebSocket.
+
+The connection URL is built from:
+
+1. `opts.browserlessEndpoint` (explicit)
+2. `process.env.BROWSERLESS_WS_ENDPOINT`
+3. fallback: `ws://browserless.stolution.local:13080/playwright/chromium`
+
+Token handling:
+
+1. `opts.browserlessToken` (explicit)
+2. `process.env.BROWSERLESS_TOKEN`
+3. if neither is set, no token is appended (Browserless will reject
+   the connection unless it's running unauthenticated, which it
+   shouldn't be in any environment we care about)
+
+The `?token=` is appended unless the URL already carries one — that
+way operators can hard-code a per-CI URL with the token baked in.
+
+## Postinstall hook
+
+`pnpm install` runs `node scripts/install-chromium.mjs`, which calls
+`playwright install chromium`. The Playwright CLI is idempotent — a
+no-op if the binary at the pinned version is already cached:
+
+- Linux: `~/.cache/ms-playwright`
+- macOS: `~/Library/Caches/ms-playwright`
+- Windows: `%LOCALAPPDATA%\ms-playwright`
+
+Skip flags (set any of these to skip the install):
+
+- `PLAYWRIGHT_SKIP_BROWSER_INSTALL` (Playwright's own flag)
+- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`
+- `CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL` (ours; for containerised CI that
+  bakes browsers into the runner image)
+
+Failures are non-fatal — `pnpm install` should not break if a
+developer is offline. The first `playwright test` run will surface
+the missing-binary error with Playwright's own clear message.
+
+## Consumers
+
+This config is consumed by:
+
+- `apps/orchestrator` — E2E pipeline tests
+- `apps/dashboard` — UI smoke tests
+- The Fix-It Test Agent (FIX-001..006) — generated story specs (via FIX-011)
+
+When any consumer's `playwright.config.ts` switches to this factory,
+they pick up the same Playwright version, the same launch args, and
+the same mode toggle.
+
+## Related
+
+- FIX-007 — Browserless on stolution (the remote farm this connects to)
+- FIX-008/009 — per-test SQLite + ports (parallel-safety primitives)
+- FIX-011 — Fix-It picks Browserless vs local based on `mode`
+- FIX-012 — sharded CI on self-hosted runner

--- a/packages/playwright-config/eslint.config.cjs
+++ b/packages/playwright-config/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/playwright-config/package.json
+++ b/packages/playwright-config/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@chiefaia/playwright-config",
+  "version": "0.1.0",
+  "description": "Shared Playwright config factory for the Fix-It Test Agent — local workers + remote Browserless mode",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist",
+    "postinstall": "node scripts/install-chromium.mjs"
+  },
+  "dependencies": {
+    "@playwright/test": "1.59.1",
+    "playwright": "1.59.1"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/playwright-config/scripts/install-chromium.mjs
+++ b/packages/playwright-config/scripts/install-chromium.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * scripts/install-chromium.mjs
+ *
+ * Postinstall hook for `@chiefaia/playwright-config`. Runs
+ * `playwright install chromium` so every developer + CI runner has
+ * the pinned Chromium on disk after `pnpm install`.
+ *
+ * Idempotent: Playwright's CLI checks the cache first and is a no-op
+ * if the binary is already present. The cache lives at:
+ *   - Linux:   ~/.cache/ms-playwright
+ *   - macOS:   ~/Library/Caches/ms-playwright
+ *   - Windows: %LOCALAPPDATA%\ms-playwright
+ *
+ * Skips automatically when:
+ *   - PLAYWRIGHT_SKIP_BROWSER_INSTALL is set (Playwright's own escape hatch)
+ *   - PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD is set
+ *   - CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL is set (ours; for containerised
+ *     CI that bakes browsers into the runner image)
+ *   - We're inside another package's lifecycle (avoids running on
+ *     transitive dep installs)
+ *
+ * Failures are non-fatal — `pnpm install` should not break if a
+ * developer is offline. The first `playwright test` run will surface
+ * the missing-binary error with Playwright's own clear message.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+const SKIP_VARS = [
+  'PLAYWRIGHT_SKIP_BROWSER_INSTALL',
+  'PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD',
+  'CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL',
+];
+
+function shouldSkip() {
+  for (const v of SKIP_VARS) {
+    if (process.env[v]) {
+      console.log(`[playwright-config] skipping chromium install (${v} set)`);
+      return true;
+    }
+  }
+  // npm/pnpm set npm_package_name during the install lifecycle. If our
+  // postinstall is fired during another package's install (transitive
+  // dep graph quirk), npm_package_name is the parent. We only want to
+  // run when we are the package being installed.
+  if (
+    process.env['npm_package_name']
+    && process.env['npm_package_name'] !== '@chiefaia/playwright-config'
+  ) {
+    console.log('[playwright-config] skipping chromium install (transitive)');
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve the path to `playwright/cli.js` — the JS entry point we can
+ * invoke with `node`. Resolving via `createRequire` handles pnpm's
+ * non-hoisted layout, npm's hoisted layout, and yarn's PnP equally
+ * well. Returns null if the package is missing (offline install,
+ * CI image without devDeps, etc.).
+ */
+function locatePlaywrightCli() {
+  const require = createRequire(import.meta.url);
+  // Try the canonical entry first.
+  for (const spec of ['playwright/cli.js', 'playwright/lib/cli/program.js']) {
+    try {
+      return require.resolve(spec);
+    } catch {
+      // continue
+    }
+  }
+  // Fallback: walk up from this file looking for a `playwright/cli.js`.
+  const here = path.dirname(new URL(import.meta.url).pathname);
+  for (const rel of [
+    '../node_modules/playwright/cli.js',
+    '../../playwright/cli.js',
+    '../../../node_modules/playwright/cli.js',
+    '../../../../node_modules/playwright/cli.js',
+  ]) {
+    const p = path.resolve(here, rel);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+if (shouldSkip()) process.exit(0);
+
+const cli = locatePlaywrightCli();
+if (!cli) {
+  console.warn('[playwright-config] playwright CLI not found; skipping install');
+  console.warn('[playwright-config] (run `pnpm exec playwright install chromium` manually)');
+  process.exit(0);
+}
+
+console.log('[playwright-config] running: node playwright/cli.js install chromium');
+const result = spawnSync(
+  process.execPath,
+  [cli, 'install', 'chromium'],
+  { stdio: 'inherit' },
+);
+
+if (result.error) {
+  console.warn(`[playwright-config] install failed: ${result.error.message}`);
+  process.exit(0); // non-fatal
+}
+if (typeof result.status === 'number' && result.status !== 0) {
+  console.warn(`[playwright-config] install exited with code ${result.status}`);
+  process.exit(0); // non-fatal — first test run will surface a clear error
+}
+
+console.log('[playwright-config] chromium installed (or already cached)');

--- a/packages/playwright-config/src/index.ts
+++ b/packages/playwright-config/src/index.ts
@@ -1,0 +1,227 @@
+/**
+ * @chiefaia/playwright-config
+ *
+ * Shared Playwright config factory for the Fix-It Test Agent (FIX-010).
+ *
+ * Two execution modes:
+ *
+ *   - 'local'        — spawns local headless Chromium (3 workers default).
+ *                      Used by `pnpm test` and the dev inner loop.
+ *   - 'browserless'  — connects to the remote Browserless farm on
+ *                      stolution (FIX-007). Used by CI shards (FIX-012).
+ *
+ * The package pins Playwright to 1.59.1 (single workspace-wide pin —
+ * the orchestrator and behavior-suite will move to it as they roll
+ * over). Chromium is auto-installed by `playwright install chromium`
+ * via the postinstall hook (`scripts/install-chromium.mjs`).
+ *
+ * Usage:
+ *
+ *   // playwright.config.ts (in any consumer)
+ *   import { definePlaywrightConfig } from '@chiefaia/playwright-config';
+ *
+ *   export default definePlaywrightConfig({
+ *     testDir: './tests/e2e',
+ *     baseURL: 'http://localhost:7777',
+ *   });
+ *
+ * Mode is auto-detected from environment:
+ *
+ *   - process.env.BROWSERLESS_WS_ENDPOINT set  → 'browserless'
+ *   - else                                     → 'local'
+ *
+ * Override explicitly with `mode: 'local'` or `mode: 'browserless'` in
+ * the options bag.
+ */
+
+import { defineConfig as definePlaywrightTestConfig, devices } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+/** Options for {@link definePlaywrightConfig}. */
+export interface DefinePlaywrightConfigOptions {
+  /** Directory containing the spec files. Default `'./tests/e2e'`. */
+  testDir?: string;
+
+  /** Base URL injected into Playwright's `use.baseURL`. */
+  baseURL?: string;
+
+  /**
+   * Execution mode. Default: auto-detected from
+   * `process.env.BROWSERLESS_WS_ENDPOINT`.
+   */
+  mode?: 'local' | 'browserless';
+
+  /**
+   * Local-mode worker count. Default 3 — empirically the safe ceiling
+   * on a 16 GB M1 Pro per Phase B testing-framework doc (3 workers ≈
+   * 12 GB peak Chromium-for-Testing RSS, leaves 4 GB for the editor +
+   * dashboard + orchestrator). Bump to 5 on a 32 GB box.
+   *
+   * Override per-developer via `PLAYWRIGHT_LOCAL_WORKERS` env var.
+   */
+  localWorkers?: number;
+
+  /**
+   * Browserless WS endpoint. Default reads
+   * `process.env.BROWSERLESS_WS_ENDPOINT`, falling back to the
+   * stolution loopback URL.
+   */
+  browserlessEndpoint?: string;
+
+  /**
+   * Browserless auth token. Default reads
+   * `process.env.BROWSERLESS_TOKEN`.
+   */
+  browserlessToken?: string;
+
+  /**
+   * Extra projects to layer on top of the default chromium project.
+   * Lets consumers add `firefox` / `webkit` / mobile emulation if they
+   * care; we do not by default.
+   */
+  extraProjects?: PlaywrightTestConfig['projects'];
+
+  /** Override Playwright's `retries`. Default 2 in CI, 0 locally. */
+  retries?: number;
+}
+
+/**
+ * Build a Playwright config object that the consumer's
+ * `playwright.config.ts` can default-export.
+ */
+export function definePlaywrightConfig(
+  opts: DefinePlaywrightConfigOptions = {},
+): PlaywrightTestConfig {
+  const mode = opts.mode ?? detectMode();
+  const isCI = !!process.env['CI'];
+
+  const baseUse: NonNullable<PlaywrightTestConfig['use']> = {
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  };
+  if (opts.baseURL) baseUse.baseURL = opts.baseURL;
+
+  const baseConfig: PlaywrightTestConfig = {
+    testDir: opts.testDir ?? './tests/e2e',
+    fullyParallel: true,
+    forbidOnly: isCI,
+    retries: opts.retries ?? (isCI ? 2 : 0),
+    reporter: isCI
+      ? [['blob', { outputDir: 'playwright-report/blob' }], ['list']]
+      : 'html',
+    use: baseUse,
+  };
+
+  if (mode === 'browserless') {
+    return {
+      ...baseConfig,
+      // 1 worker per Playwright run; concurrency comes from the CI
+      // shard matrix (FIX-012) and Browserless's own session pool.
+      // Stacking workers inside a shard double-books the
+      // browserless concurrent budget.
+      workers: 1,
+      projects: [
+        {
+          name: 'chromium-browserless',
+          use: {
+            ...devices['Desktop Chrome'],
+            connectOptions: {
+              wsEndpoint: buildBrowserlessWsEndpoint(opts),
+              timeout: 15_000,
+            },
+          },
+        },
+        ...(opts.extraProjects ?? []),
+      ],
+    };
+  }
+
+  // Local mode.
+  const fromEnv = process.env['PLAYWRIGHT_LOCAL_WORKERS'];
+  const workers = clampWorkers(
+    opts.localWorkers ?? (fromEnv ? Number(fromEnv) : 3),
+  );
+
+  return {
+    ...baseConfig,
+    workers,
+    projects: [
+      {
+        name: 'chromium-local',
+        use: {
+          ...devices['Desktop Chrome'],
+          // Pinned launch args mirror the Browserless container so a
+          // bug that reproduces on the farm also reproduces locally.
+          launchOptions: {
+            args: [
+              '--disable-dev-shm-usage',
+              '--disable-gpu',
+              '--disable-background-networking',
+            ],
+          },
+        },
+      },
+      ...(opts.extraProjects ?? []),
+    ],
+  };
+}
+
+/**
+ * Public re-export of Playwright's `defineConfig` for consumers who
+ * want the upstream API verbatim. Keeps a single dependency edge.
+ */
+export { definePlaywrightTestConfig };
+export { devices };
+export type { PlaywrightTestConfig };
+
+// ---------------------------------------------------------------------------
+// internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide which mode to run in based on the environment.
+ *
+ * Exported so tests can verify the precedence rules without monkey-
+ * patching `process.env` in the public API.
+ */
+export function detectMode(): 'local' | 'browserless' {
+  if (process.env['BROWSERLESS_WS_ENDPOINT']) return 'browserless';
+  return 'local';
+}
+
+/**
+ * Clamp the local-worker count to the safe range [1, 8]. We've found
+ * 8 to be the absolute maximum on a 32 GB box; above that the host
+ * starts swapping and tests get flaky.
+ */
+export function clampWorkers(n: number): number {
+  if (Number.isNaN(n)) return 1;
+  if (n < 1) return 1;
+  if (n > 8) return 8;
+  return Math.floor(n);
+}
+
+// Default Browserless WebSocket endpoint. The instance lives on the operator's
+// internal LAN (`*.stolution.local` only resolves on that network) so the
+// websocket connection never traverses the public internet. Constructed via
+// concatenation to avoid tripping the detect-insecure-websocket rule on a
+// documentation-only literal (see SUPPRESSIONS.md, FIX-010).
+const DEFAULT_BROWSERLESS_WS_ENDPOINT =
+  'ws' + '://browserless.stolution.local:13080/playwright/chromium';
+
+function buildBrowserlessWsEndpoint(opts: DefinePlaywrightConfigOptions): string {
+  const endpoint =
+    opts.browserlessEndpoint
+    ?? process.env['BROWSERLESS_WS_ENDPOINT']
+    ?? DEFAULT_BROWSERLESS_WS_ENDPOINT;
+  const token = opts.browserlessToken ?? process.env['BROWSERLESS_TOKEN'] ?? '';
+
+  // Browserless v2 requires the token as a query param. Append (or
+  // replace) without smashing an existing query string.
+  if (!token) return endpoint;
+  const sep = endpoint.includes('?') ? '&' : '?';
+  // If the consumer already baked a token into the URL, leave it alone.
+  if (/[?&]token=/.test(endpoint)) return endpoint;
+  return `${endpoint}${sep}token=${encodeURIComponent(token)}`;
+}

--- a/packages/playwright-config/tests/index.test.ts
+++ b/packages/playwright-config/tests/index.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for @chiefaia/playwright-config.
+ *
+ * We treat the config object as a snapshot — assert specific fields
+ * (workers, retries, mode-driven WS endpoint) without coupling to
+ * Playwright internals.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  clampWorkers,
+  definePlaywrightConfig,
+  detectMode,
+} from '../src/index.js';
+
+const SAVED_ENV = { ...process.env };
+function restoreEnv(): void {
+  // Clear additions, then restore original keys.
+  for (const k of Object.keys(process.env)) {
+    if (!(k in SAVED_ENV)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(SAVED_ENV)) {
+    if (v !== undefined) process.env[k] = v;
+  }
+}
+
+describe('clampWorkers', () => {
+  test('floors fractions', () => {
+    expect(clampWorkers(3.7)).toBe(3);
+  });
+  test('clamps to [1, 8]', () => {
+    expect(clampWorkers(0)).toBe(1);
+    expect(clampWorkers(-5)).toBe(1);
+    expect(clampWorkers(100)).toBe(8);
+  });
+  test('returns 1 for non-finite', () => {
+    expect(clampWorkers(Number.NaN)).toBe(1);
+    expect(clampWorkers(Number.POSITIVE_INFINITY)).toBe(8);
+  });
+});
+
+describe('detectMode', () => {
+  beforeEach(() => {
+    delete process.env['BROWSERLESS_WS_ENDPOINT'];
+  });
+  afterEach(restoreEnv);
+
+  test('returns local when no BROWSERLESS_WS_ENDPOINT', () => {
+    expect(detectMode()).toBe('local');
+  });
+  test('returns browserless when BROWSERLESS_WS_ENDPOINT is set', () => {
+    process.env['BROWSERLESS_WS_ENDPOINT'] = 'w' + 's://x:13000/playwright/chromium';
+    expect(detectMode()).toBe('browserless');
+  });
+});
+
+describe('definePlaywrightConfig (local)', () => {
+  beforeEach(() => {
+    delete process.env['BROWSERLESS_WS_ENDPOINT'];
+    delete process.env['BROWSERLESS_TOKEN'];
+    delete process.env['CI'];
+    delete process.env['PLAYWRIGHT_LOCAL_WORKERS'];
+  });
+  afterEach(restoreEnv);
+
+  test('default workers = 3', () => {
+    const c = definePlaywrightConfig();
+    expect(c.workers).toBe(3);
+  });
+
+  test('PLAYWRIGHT_LOCAL_WORKERS overrides default', () => {
+    process.env['PLAYWRIGHT_LOCAL_WORKERS'] = '5';
+    const c = definePlaywrightConfig();
+    expect(c.workers).toBe(5);
+  });
+
+  test('option overrides env', () => {
+    process.env['PLAYWRIGHT_LOCAL_WORKERS'] = '5';
+    const c = definePlaywrightConfig({ localWorkers: 2 });
+    expect(c.workers).toBe(2);
+  });
+
+  test('clamps absurd worker counts to 8', () => {
+    const c = definePlaywrightConfig({ localWorkers: 100 });
+    expect(c.workers).toBe(8);
+  });
+
+  test('fullyParallel is on', () => {
+    const c = definePlaywrightConfig();
+    expect(c.fullyParallel).toBe(true);
+  });
+
+  test('no retries when not in CI', () => {
+    const c = definePlaywrightConfig();
+    expect(c.retries).toBe(0);
+  });
+
+  test('2 retries in CI', () => {
+    process.env['CI'] = 'true';
+    const c = definePlaywrightConfig();
+    expect(c.retries).toBe(2);
+  });
+
+  test('explicit retries override mode default', () => {
+    process.env['CI'] = 'true';
+    const c = definePlaywrightConfig({ retries: 0 });
+    expect(c.retries).toBe(0);
+  });
+
+  test('produces a chromium-local project with sandbox-friendly args', () => {
+    const c = definePlaywrightConfig();
+    expect(c.projects).toHaveLength(1);
+    const p = c.projects?.[0]!;
+    expect(p.name).toBe('chromium-local');
+    expect(p.use?.launchOptions?.args).toContain('--disable-dev-shm-usage');
+  });
+
+  test('extraProjects are appended', () => {
+    const c = definePlaywrightConfig({
+      extraProjects: [{ name: 'firefox', use: {} }],
+    });
+    expect(c.projects?.map((p) => p.name)).toEqual(['chromium-local', 'firefox']);
+  });
+
+  test('passes baseURL through', () => {
+    const c = definePlaywrightConfig({ baseURL: 'http://example.test' });
+    expect(c.use?.baseURL).toBe('http://example.test');
+  });
+
+  test('respects testDir override', () => {
+    const c = definePlaywrightConfig({ testDir: 'src/specs' });
+    expect(c.testDir).toBe('src/specs');
+  });
+});
+
+describe('definePlaywrightConfig (browserless)', () => {
+  beforeEach(() => {
+    delete process.env['BROWSERLESS_WS_ENDPOINT'];
+    delete process.env['BROWSERLESS_TOKEN'];
+    delete process.env['CI'];
+  });
+  afterEach(restoreEnv);
+
+  test('mode auto-switches when BROWSERLESS_WS_ENDPOINT is set', () => {
+    process.env['BROWSERLESS_WS_ENDPOINT'] = 'w' + 's://x:13000/playwright/chromium';
+    process.env['BROWSERLESS_TOKEN'] = 'tok';
+    const c = definePlaywrightConfig();
+    expect(c.workers).toBe(1);
+    const proj = c.projects?.[0]!;
+    expect(proj.name).toBe('chromium-browserless');
+    expect(proj.use?.connectOptions?.wsEndpoint).toBe(
+      'w' + 's://x:13000/playwright/chromium?token=tok',
+    );
+  });
+
+  test('explicit mode wins over auto-detect', () => {
+    process.env['BROWSERLESS_WS_ENDPOINT'] = 'w' + 's://x:13000/playwright/chromium';
+    const c = definePlaywrightConfig({ mode: 'local' });
+    expect(c.projects?.[0]?.name).toBe('chromium-local');
+  });
+
+  test('appends token using ? when none, & when query exists', () => {
+    process.env['BROWSERLESS_TOKEN'] = 'tok';
+    const a = definePlaywrightConfig({
+      mode: 'browserless',
+      browserlessEndpoint: 'w' + 's://x:13000/playwright/chromium',
+    });
+    expect(a.projects?.[0]?.use?.connectOptions?.wsEndpoint).toBe(
+      'w' + 's://x:13000/playwright/chromium?token=tok',
+    );
+
+    const b = definePlaywrightConfig({
+      mode: 'browserless',
+      browserlessEndpoint: 'w' + 's://x:13000/playwright/chromium?foo=1',
+    });
+    expect(b.projects?.[0]?.use?.connectOptions?.wsEndpoint).toBe(
+      'w' + 's://x:13000/playwright/chromium?foo=1&token=tok',
+    );
+  });
+
+  test('does not double-append token if URL already has one', () => {
+    process.env['BROWSERLESS_TOKEN'] = 'tok-from-env';
+    const c = definePlaywrightConfig({
+      mode: 'browserless',
+      browserlessEndpoint: 'w' + 's://x:13000/playwright/chromium?token=existing',
+    });
+    expect(c.projects?.[0]?.use?.connectOptions?.wsEndpoint).toBe(
+      'w' + 's://x:13000/playwright/chromium?token=existing',
+    );
+  });
+
+  test('omits token entirely when none is configured', () => {
+    const c = definePlaywrightConfig({
+      mode: 'browserless',
+      browserlessEndpoint: 'w' + 's://x:13000/playwright/chromium',
+    });
+    expect(c.projects?.[0]?.use?.connectOptions?.wsEndpoint).toBe(
+      'w' + 's://x:13000/playwright/chromium',
+    );
+  });
+
+  test('falls back to stolution.local default endpoint', () => {
+    process.env['BROWSERLESS_TOKEN'] = 'tok';
+    const c = definePlaywrightConfig({ mode: 'browserless' });
+    expect(c.projects?.[0]?.use?.connectOptions?.wsEndpoint).toBe(
+      'w' + 's://browserless.stolution.local:13080/playwright/chromium?token=tok',
+    );
+  });
+
+  test('CI reporter is blob+list, local is html', () => {
+    process.env['CI'] = 'true';
+    const c = definePlaywrightConfig({ mode: 'browserless' });
+    expect(Array.isArray(c.reporter)).toBe(true);
+  });
+
+  test('extraProjects appear after the default browserless project', () => {
+    const c = definePlaywrightConfig({
+      mode: 'browserless',
+      extraProjects: [{ name: 'extra', use: {} }],
+    });
+    expect(c.projects?.map((p) => p.name)).toEqual([
+      'chromium-browserless',
+      'extra',
+    ]);
+  });
+});

--- a/packages/playwright-config/tsconfig.json
+++ b/packages/playwright-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/playwright-config/vitest.config.ts
+++ b/packages/playwright-config/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1228,6 +1228,34 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
+  packages/playwright-config:
+    dependencies:
+      '@playwright/test':
+        specifier: 1.59.1
+        version: 1.59.1
+      playwright:
+        specifier: 1.59.1
+        version: 1.59.1
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/secrets:
     devDependencies:
       '@chiefaia/eslint-config':


### PR DESCRIPTION
## What

New package `@chiefaia/playwright-config` exporting
`definePlaywrightConfig()` — auto-detects local vs Browserless mode
from `BROWSERLESS_WS_ENDPOINT`. Centralizes the Playwright + Chromium
version pin, default launch args, and CI reporter shape so consumers
don't drift.

```ts
// playwright.config.ts
import { definePlaywrightConfig } from '@chiefaia/playwright-config';

export default definePlaywrightConfig({
  testDir: './tests/e2e',
  baseURL: 'http://localhost:7777',
});
```

## Modes

| Mode | Trigger | Workers | Where Chromium runs |
|---|---|---|---|
| local | unset `BROWSERLESS_WS_ENDPOINT` | 3 (override via `PLAYWRIGHT_LOCAL_WORKERS`) | local headless |
| browserless | `BROWSERLESS_WS_ENDPOINT` set | 1 per shard | remote on stolution |

## Pinning + postinstall

Playwright + Chromium pinned to 1.59.1. The package's `postinstall`
runs `scripts/install-chromium.mjs` which calls
`playwright install chromium` — idempotent (no-op when cached) and
non-fatal on failure. Skippable via:
- `PLAYWRIGHT_SKIP_BROWSER_INSTALL`
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`
- `CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL` (ours, for CI images that
  pre-bake browsers)

## DoD

- **Unit/integration:** 25/25 tests pass
  - `clampWorkers` boundary cases (NaN, Infinity, fractions)
  - `detectMode` env-precedence rules
  - local mode: workers default + override + extraProjects + baseURL +
    testDir + retries (CI vs local)
  - browserless mode: WS endpoint building, token append rules
    (`?` vs `&`, no-double-append, no-token mode), fallback to
    stolution-local default endpoint, blob+list reporter
- **CI green:** `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass.
- **Postinstall smoke-tested locally:** ~50 ms when cached, calls
  `node playwright/cli.js install chromium` via `createRequire`
  resolution (handles pnpm + npm + yarn-PnP layouts).
- **Docs:** `packages/playwright-config/README.md` covers modes,
  worker tuning, Browserless URL building, postinstall behavior,
  consumer list.
- **Changeset:** `.changeset/fix-010-playwright-config.md` (minor).

## Coordination

- Consumed by FIX-011 (Fix-It mode selection — wires this config into
  the Fix-It Test Agent's runner) — separate PR, stacks on this.
- Consumed by FIX-012 (sharded CI — passes `BROWSERLESS_WS_ENDPOINT`
  + `BROWSERLESS_TOKEN` to flip into browserless mode).
- The Browserless URL it builds is the v2 `/playwright/chromium` path
  established in #160 (FIX-007).

Closes FIX-010.