### PR TITLE
feat(worker-fix-it): retest loop controller with persistence + blocker writer (FIX-006)

### DIFF
--- a/apps/worker-fix-it/CHANGELOG.md
+++ b/apps/worker-fix-it/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+### FIX-006 — retest loop controller (this PR)
+
+- New `src/retest-loop-controller.ts`:
+  - `RetestLoopController` extracted from the orchestrator's per-case
+    loop. Owns three responsibilities the orchestrator delegates:
+    1. The retest loop itself (generate → run → diagnose → IPC →
+       loop, capped at `DEFAULT_MAX_ATTEMPTS = 6`).
+    2. Persistence: every (testCase, attempt) pair is recorded via
+       the injected `RunHistoryRecorder` so the dashboard timeline
+       and the `task.test_case.result` event stream both have a
+       faithful audit trail.
+    3. Blocker writing: terminal failures file a structured
+       `fix-stuck` / `coding-stuck` / `same-sha-twice` blocker via
+       the injected `BlockerWriter`.
+  - **Same-sha guard** — if the Coding Agent applies the same sha
+    twice in a row for the same test case, bail immediately rather
+    than burning the remaining attempts. That is the strongest signal
+    that the agent isn't actually changing the code, so continuing
+    the loop would only waste tokens.
+- `FixItOrchestrator` refactored to delegate per-case work to
+  `RetestLoopController`. Its run-level state machine (fan out cases,
+  roll up outcomes, emit terminal `tested_and_done` /
+  `fix_loop_escalated`) is unchanged.
+- 8 new vitest cases in `tests/retest-loop-controller.test.ts`:
+  pass-on-attempt-1 / one-retry-then-pass / attempts-exhausted /
+  IPC-ok-false / same-sha-twice / maxAttempts override / DEFAULT
+  pinned / history timing fields.
+- 1 new microbenchmark: controller dispatch < 2 ms / attempt.
+- Updates the existing orchestrator test that previously assumed a
+  same-sha-tolerant loop to use distinct shas per attempt (so the
+  exhausted path is exercised, not the same-sha guard).
+
 ### FIX-005 — Coding Agent IPC client (this PR)
 
 - New `src/coding-ipc-client.ts`: `MemoryCodingIpcInvoker` (default

--- a/apps/worker-fix-it/src/orchestrator.ts
+++ b/apps/worker-fix-it/src/orchestrator.ts
@@ -1,12 +1,11 @@
 /**
  * `FixItOrchestrator` — the inner state-machine of the Fix-It Test
- * Agent — FIX-001 (Phase 2D).
+ * Agent.
  *
  * Inputs:
  *   - `task.coding_complete` payload (with worktree path + Coding Agent
  *     session reference)
- *   - the ticket bundle (fetched via the orchestrator's
- *     `GET /stories/:id/bundle`; injected here for testability)
+ *   - the ticket's `testCases` array
  *
  * Outputs:
  *   - `task.tested_and_done` payload — every test case green
@@ -17,9 +16,11 @@
  * with a stub default. FIX-002 .. FIX-006 swap each stub out for the
  * real implementation while keeping this orchestrator unchanged.
  *
- * The retest loop (`MAX_ATTEMPTS_PER_CASE = 6`) lives here in skeleton
- * form for FIX-001; FIX-006 layers on per-attempt persistence + the
- * `fix-stuck` escalation contract.
+ * As of FIX-006, the per-case loop is delegated to
+ * `RetestLoopController` so the loop logic, persistence, and blocker
+ * writing can be tested in isolation. The orchestrator's job here is
+ * solely to fan the testCases out to the controller and roll up the
+ * per-case outcomes into a run-level result.
  *
  * @owner fix-it-test-agent (Phase 2D worker track)
  */
@@ -45,6 +46,14 @@ import {
   StubTestRunner,
 } from './stubs';
 
+import {
+  type BlockerWriter,
+  type RunHistoryRecorder,
+  NoopBlockerWriter,
+  NoopRunHistoryRecorder,
+  RetestLoopController,
+} from './retest-loop-controller';
+
 /** Ports the orchestrator depends on; each replaceable per PR. */
 export interface FixItOrchestratorPorts {
   generator: TestCodeGenerator;
@@ -52,6 +61,10 @@ export interface FixItOrchestratorPorts {
   diagnoser: FailureDiagnoser;
   ipc: CodingIpcInvoker;
   emitter: ResultEmitter;
+  /** FIX-006: persistence of per-attempt run history. */
+  history: RunHistoryRecorder;
+  /** FIX-006: blocker writer for fix-stuck / coding-stuck escalations. */
+  blockers: BlockerWriter;
   /** Wall clock — injectable for deterministic tests. */
   now?: () => number;
 }
@@ -65,6 +78,7 @@ export const MAX_ATTEMPTS_PER_CASE = 6;
 
 export class FixItOrchestrator {
   private readonly ports: Required<FixItOrchestratorPorts>;
+  private readonly controller: RetestLoopController;
 
   constructor(ports: Partial<FixItOrchestratorPorts> = {}) {
     this.ports = {
@@ -73,20 +87,29 @@ export class FixItOrchestrator {
       diagnoser: ports.diagnoser ?? new StubFailureDiagnoser(),
       ipc: ports.ipc ?? new StubCodingIpcInvoker(),
       emitter: ports.emitter ?? new NoopResultEmitter(),
+      history: ports.history ?? new NoopRunHistoryRecorder(),
+      blockers: ports.blockers ?? new NoopBlockerWriter(),
       now: ports.now ?? Date.now,
     };
+    this.controller = new RetestLoopController({
+      generator: this.ports.generator,
+      runner: this.ports.runner,
+      diagnoser: this.ports.diagnoser,
+      ipc: this.ports.ipc,
+      emitter: this.ports.emitter,
+      history: this.ports.history,
+      blockers: this.ports.blockers,
+      now: this.ports.now,
+    });
   }
 
   /**
    * Drive a single coding-complete handoff through the test/fix cycle.
    *
-   * Per-test-case retest loop (FIX-006 will deepen):
-   *   1. generate spec → run → record result
-   *   2. if passed → next case
-   *   3. if failed → diagnose → IPC apply_fix → loop (capped at N)
-   *   4. if cap reached → mark exhausted; do NOT abort the run — every
-   *      remaining case must be attempted so the escalation payload
-   *      lists *every* exhausted case in one shot.
+   * Per-test-case loop is delegated to `RetestLoopController`. The
+   * orchestrator does NOT abort on the first exhausted case — every
+   * remaining case must be attempted so the escalation payload lists
+   * every exhausted case in one shot.
    */
   async run(
     payload: CodingCompletePayload,
@@ -99,7 +122,10 @@ export class FixItOrchestrator {
     let totalAttempts = 0;
 
     for (const testCase of testCases) {
-      const outcome = await this.runCase(testCase, payload, maxAttempts);
+      // eslint-disable-next-line no-await-in-loop
+      const outcome = await this.controller.runCase(testCase, payload, {
+        maxAttempts,
+      });
       outcomes.push(outcome);
       totalAttempts += outcome.attempts;
       if (outcome.lastSha) lastSha = outcome.lastSha;
@@ -109,7 +135,7 @@ export class FixItOrchestrator {
       (o) => o.finalStatus === 'exhausted' || o.finalStatus === 'fix-failed',
     );
 
-    const allPassedAt = this.ports.now();
+    const ts = this.ports.now();
 
     if (exhausted.length === 0) {
       // Tell the still-warm Coding Agent it can release the worktree.
@@ -119,7 +145,7 @@ export class FixItOrchestrator {
         payload: {
           storyId: payload.storyId,
           workerId: payload.workerId,
-          allPassedAt,
+          allPassedAt: ts,
           totalAttempts: Math.max(totalAttempts, 1),
           finalSha: lastSha,
           correlationId: payload.correlationId,
@@ -138,100 +164,9 @@ export class FixItOrchestrator {
           attempt: o.attempts,
           errorMessage: o.lastErrorMessage ?? 'no error captured',
         })),
-        escalatedAt: allPassedAt,
+        escalatedAt: ts,
         correlationId: payload.correlationId,
       },
-    };
-  }
-
-  /**
-   * Run one test case through the per-case retest loop.
-   *
-   * FIX-001: skeleton — implements the loop with stub collaborators
-   * so the happy path emits tested_and_done.
-   */
-  private async runCase(
-    testCase: TestCase,
-    payload: CodingCompletePayload,
-    maxAttempts: number,
-  ): Promise<TestCaseOutcome> {
-    let lastErrorMessage: string | undefined;
-    let lastSha: string | undefined;
-
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      const spec = await this.ports.generator.generate(testCase, {
-        storyId: payload.storyId,
-        worktreePath: payload.worktreePath,
-      });
-      const runResult = await this.ports.runner.runSpec(spec);
-
-      await this.ports.emitter.emitTestCaseResult({
-        storyId: payload.storyId,
-        testCaseId: testCase.id,
-        status: runResult.status,
-        attempt,
-        durationMs: runResult.durationMs,
-        traceUrl: runResult.tracePath ?? null,
-        error: runResult.errorMessage ?? null,
-        correlationId: payload.correlationId,
-      });
-
-      if (runResult.status === 'passed') {
-        return {
-          testCaseId: testCase.id,
-          finalStatus: 'passed',
-          attempts: attempt,
-          lastSha,
-        };
-      }
-
-      lastErrorMessage = runResult.errorMessage ?? `${runResult.status}`;
-
-      if (attempt === maxAttempts) break;
-
-      const report = await this.ports.diagnoser.diagnose(
-        runResult,
-        testCase,
-        attempt,
-      );
-
-      const ipcResult = await this.ports.ipc.applyFix({
-        storyId: payload.storyId,
-        testCaseId: testCase.id,
-        attempt,
-        whatFailed: report.errorMessage,
-        hypothesisFromDiagnoser: report.inferredCause,
-        artifactsRef:
-          report.artifacts.screenshotUrl ?? report.artifacts.tracePath
-            ? {
-                screenshotUrl: report.artifacts.screenshotUrl ?? undefined,
-                tracePath: report.artifacts.tracePath ?? undefined,
-              }
-            : undefined,
-        testCaseSpecPath: spec.specPath,
-        hintFiles: [],
-        preserveScopeOf: 'fix-only',
-      });
-
-      if (!ipcResult.ok) {
-        return {
-          testCaseId: testCase.id,
-          finalStatus: 'fix-failed',
-          attempts: attempt,
-          lastSha,
-          lastErrorMessage: ipcResult.error ?? 'coding-agent-ipc-failed',
-        };
-      }
-
-      if (ipcResult.sha) lastSha = ipcResult.sha;
-    }
-
-    return {
-      testCaseId: testCase.id,
-      finalStatus: 'exhausted',
-      attempts: maxAttempts,
-      lastSha,
-      lastErrorMessage,
     };
   }
 }

--- a/apps/worker-fix-it/src/retest-loop-controller.ts
+++ b/apps/worker-fix-it/src/retest-loop-controller.ts
@@ -1,0 +1,341 @@
+/**
+ * `RetestLoopController` — FIX-006 (Phase 2D).
+ *
+ * Owns the per-test-case retest loop. Lifted out of the orchestrator
+ * so its three responsibilities can be tested in isolation:
+ *
+ *   1. **Loop**: generate spec → run → if pass, exit. Else diagnose →
+ *      apply fix via IPC → loop. Cap at `maxAttempts` (default 6).
+ *   2. **Persistence**: every (testCase, attempt) pair is recorded
+ *      via the injected `RunHistoryRecorder` so the dashboard timeline
+ *      and the orchestrator's `task.test_case.result` event stream
+ *      both have a faithful audit trail.
+ *   3. **Blocker writing**: on exhaustion (or coding-agent-failed-to-
+ *      fix), the controller hands the full failure history to the
+ *      injected `BlockerWriter` which files a `fix-stuck` /
+ *      `coding-stuck` blocker. The orchestrator still emits the
+ *      `task.fix_loop_escalated` event; the blocker writer covers the
+ *      table side.
+ *
+ * Plus a defensive **same-sha guard**: per the architecture risk
+ * register, if the Coding Agent applies the same sha twice in a row
+ * for the same test case the loop bails immediately with a
+ * `same-sha-twice` reason — that is a strong signal the agent isn't
+ * actually changing the code, and continuing to ask it would just
+ * waste tokens.
+ *
+ * @owner fix-it-test-agent (Phase 2D worker track)
+ */
+
+import type { TestCase } from '@chiefaia/ticket-template';
+
+import type {
+  CodingIpcInvoker,
+  FailureDiagnoser,
+  GeneratedSpec,
+  ResultEmitter,
+  RunResult,
+  TestCodeGenerator,
+} from './stubs';
+import type {
+  CodingCompletePayload,
+  TestCaseOutcome,
+  TestFailureReport,
+  FixRequest,
+} from './types';
+
+// ─── New ports (in addition to the orchestrator's existing ones) ────────────
+
+/**
+ * Persists every (testCase, attempt) result to a durable store —
+ * normally the orchestrator's `test_case_runs` table. Tests inject a
+ * recorder that captures rows in memory.
+ */
+export interface RunHistoryRecorder {
+  record(row: RunHistoryRow): Promise<void>;
+}
+
+export interface RunHistoryRow {
+  storyId: string;
+  testCaseId: string;
+  attempt: number;
+  status: 'passed' | 'failed' | 'skipped' | 'flaky';
+  durationMs: number;
+  errorMessage: string | null;
+  errorStack: string | null;
+  tracePath: string | null;
+  failureDiagnosis: TestFailureReport | null;
+  startedAt: number;
+  endedAt: number;
+}
+
+/** No-op recorder default — tests inject a recording one. */
+export class NoopRunHistoryRecorder implements RunHistoryRecorder {
+  async record(_row: RunHistoryRow): Promise<void> {
+    // no-op
+  }
+}
+
+/**
+ * Files a blocker on terminal failure — fix-stuck (case exhausted)
+ * or coding-stuck (Coding Agent IPC returned ok:false).
+ */
+export interface BlockerWriter {
+  fileBlocker(blocker: BlockerInput): Promise<void>;
+}
+
+export interface BlockerInput {
+  storyId: string;
+  testCaseId: string;
+  kind: 'fix-stuck' | 'coding-stuck' | 'same-sha-twice';
+  attempts: number;
+  history: ReadonlyArray<TestFailureReport>;
+  /** Last error message captured (for the dashboard's blocker card). */
+  lastErrorMessage: string;
+}
+
+export class NoopBlockerWriter implements BlockerWriter {
+  async fileBlocker(_input: BlockerInput): Promise<void> {
+    // no-op
+  }
+}
+
+// ─── Controller ─────────────────────────────────────────────────────────────
+
+export interface RetestLoopControllerPorts {
+  generator: TestCodeGenerator;
+  runner: TestRunnerPort;
+  diagnoser: FailureDiagnoser;
+  ipc: CodingIpcInvoker;
+  emitter?: ResultEmitter;
+  history?: RunHistoryRecorder;
+  blockers?: BlockerWriter;
+  now?: () => number;
+}
+
+/** Subset of `TestRunner` the controller needs. */
+export interface TestRunnerPort {
+  runSpec(spec: GeneratedSpec): Promise<RunResult>;
+}
+
+export interface RetestLoopOptions {
+  /** Per-case attempt cap. Defaults to 6 per the directive. */
+  maxAttempts?: number;
+}
+
+export const DEFAULT_MAX_ATTEMPTS = 6;
+
+/**
+ * The richer per-case outcome the controller returns; the orchestrator
+ * lifts the four fields it cares about into its public TestCaseOutcome.
+ */
+export interface ControllerOutcome extends TestCaseOutcome {
+  history: ReadonlyArray<TestFailureReport>;
+}
+
+export class RetestLoopController {
+  private readonly ports: Required<
+    Omit<RetestLoopControllerPorts, 'emitter' | 'history' | 'blockers' | 'now'>
+  > & {
+    emitter: ResultEmitter | undefined;
+    history: RunHistoryRecorder;
+    blockers: BlockerWriter;
+    now: () => number;
+  };
+
+  constructor(ports: RetestLoopControllerPorts) {
+    this.ports = {
+      generator: ports.generator,
+      runner: ports.runner,
+      diagnoser: ports.diagnoser,
+      ipc: ports.ipc,
+      emitter: ports.emitter,
+      history: ports.history ?? new NoopRunHistoryRecorder(),
+      blockers: ports.blockers ?? new NoopBlockerWriter(),
+      now: ports.now ?? Date.now,
+    };
+  }
+
+  /**
+   * Drive a single test case through the retest loop.
+   *
+   * The controller writes one `RunHistoryRow` per attempt (so the
+   * dashboard's per-case timeline is faithful), files a blocker on
+   * terminal failure, and returns a `ControllerOutcome` the
+   * orchestrator can roll up into the run-level result.
+   */
+  async runCase(
+    testCase: TestCase,
+    payload: CodingCompletePayload,
+    opts: RetestLoopOptions = {},
+  ): Promise<ControllerOutcome> {
+    const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    const history: TestFailureReport[] = [];
+    let lastErrorMessage: string | undefined;
+    let lastSha: string | undefined;
+    let priorFixSha: string | undefined;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const startedAt = this.ports.now();
+      const spec = await this.ports.generator.generate(testCase, {
+        storyId: payload.storyId,
+        worktreePath: payload.worktreePath,
+      });
+      const runResult = await this.ports.runner.runSpec(spec);
+      const endedAt = this.ports.now();
+
+      // Emit the per-attempt event (orchestrator → bus).
+      await this.ports.emitter?.emitTestCaseResult({
+        storyId: payload.storyId,
+        testCaseId: testCase.id,
+        status: runResult.status,
+        attempt,
+        durationMs: runResult.durationMs,
+        traceUrl: runResult.tracePath ?? null,
+        error: runResult.errorMessage ?? null,
+        correlationId: payload.correlationId,
+      });
+
+      if (runResult.status === 'passed') {
+        await this.ports.history.record(
+          this.toHistoryRow(payload.storyId, testCase, attempt, runResult, null, startedAt, endedAt),
+        );
+        return {
+          testCaseId: testCase.id,
+          finalStatus: 'passed',
+          attempts: attempt,
+          lastSha,
+          history,
+        };
+      }
+
+      lastErrorMessage = runResult.errorMessage ?? `${runResult.status}`;
+
+      const report = await this.ports.diagnoser.diagnose(
+        runResult,
+        testCase,
+        attempt,
+      );
+      history.push(report);
+
+      await this.ports.history.record(
+        this.toHistoryRow(payload.storyId, testCase, attempt, runResult, report, startedAt, endedAt),
+      );
+
+      if (attempt === maxAttempts) break;
+
+      const fixRequest: FixRequest = {
+        storyId: payload.storyId,
+        testCaseId: testCase.id,
+        attempt,
+        whatFailed: report.errorMessage,
+        hypothesisFromDiagnoser: report.inferredCause,
+        artifactsRef:
+          report.artifacts.screenshotUrl ?? report.artifacts.tracePath
+            ? {
+                screenshotUrl: report.artifacts.screenshotUrl ?? undefined,
+                tracePath: report.artifacts.tracePath ?? undefined,
+              }
+            : undefined,
+        testCaseSpecPath: spec.specPath,
+        hintFiles: [],
+        preserveScopeOf: 'fix-only',
+      };
+
+      const ipcResult = await this.ports.ipc.applyFix(fixRequest);
+
+      if (!ipcResult.ok) {
+        await this.ports.blockers.fileBlocker({
+          storyId: payload.storyId,
+          testCaseId: testCase.id,
+          kind: 'coding-stuck',
+          attempts: attempt,
+          history,
+          lastErrorMessage:
+            ipcResult.error ?? lastErrorMessage ?? 'coding-agent-ipc-failed',
+        });
+        return {
+          testCaseId: testCase.id,
+          finalStatus: 'fix-failed',
+          attempts: attempt,
+          lastSha,
+          lastErrorMessage:
+            ipcResult.error ?? 'coding-agent-ipc-failed',
+          history,
+        };
+      }
+
+      // Same-sha guard: if Coding Agent didn't produce a new sha for
+      // two consecutive fix requests, escalate immediately. Continuing
+      // to ask is just burning tokens.
+      if (ipcResult.sha && priorFixSha === ipcResult.sha) {
+        await this.ports.blockers.fileBlocker({
+          storyId: payload.storyId,
+          testCaseId: testCase.id,
+          kind: 'same-sha-twice',
+          attempts: attempt,
+          history,
+          lastErrorMessage: `coding agent produced same sha twice (${ipcResult.sha})`,
+        });
+        return {
+          testCaseId: testCase.id,
+          finalStatus: 'fix-failed',
+          attempts: attempt,
+          lastSha: ipcResult.sha,
+          lastErrorMessage: `coding agent produced same sha twice (${ipcResult.sha})`,
+          history,
+        };
+      }
+
+      if (ipcResult.sha) {
+        priorFixSha = ipcResult.sha;
+        lastSha = ipcResult.sha;
+      }
+    }
+
+    // attempts exhausted
+    await this.ports.blockers.fileBlocker({
+      storyId: payload.storyId,
+      testCaseId: testCase.id,
+      kind: 'fix-stuck',
+      attempts: maxAttempts,
+      history,
+      lastErrorMessage: lastErrorMessage ?? 'attempts-exhausted',
+    });
+
+    return {
+      testCaseId: testCase.id,
+      finalStatus: 'exhausted',
+      attempts: maxAttempts,
+      lastSha,
+      lastErrorMessage,
+      history,
+    };
+  }
+
+  // ─── helpers ──────────────────────────────────────────────────────────────
+
+  private toHistoryRow(
+    storyId: string,
+    testCase: TestCase,
+    attempt: number,
+    runResult: RunResult,
+    diagnosis: TestFailureReport | null,
+    startedAt: number,
+    endedAt: number,
+  ): RunHistoryRow {
+    return {
+      storyId,
+      testCaseId: testCase.id,
+      attempt,
+      status: runResult.status,
+      durationMs: runResult.durationMs,
+      errorMessage: runResult.errorMessage ?? null,
+      errorStack: runResult.errorStack ?? null,
+      tracePath: runResult.tracePath ?? null,
+      failureDiagnosis: diagnosis,
+      startedAt,
+      endedAt,
+    };
+  }
+}

--- a/apps/worker-fix-it/tests/orchestrator.test.ts
+++ b/apps/worker-fix-it/tests/orchestrator.test.ts
@@ -1,5 +1,5 @@
 /**
- * `FixItOrchestrator` — FIX-001 contract tests.
+ * `FixItOrchestrator` — orchestrator-level contract tests.
  *
  * Drives the orchestrator with hand-rolled stub ports so we can assert
  * the four interesting branches without booting a real worker:
@@ -11,8 +11,10 @@
  *      `fix-failed`
  *   4. attempts exhausted — escalation with finalStatus `exhausted`
  *
- * Subsequent FIX-### PRs add tests for real generator/runner/diagnoser
- * behaviour; this file pins the orchestrator's state-machine contract.
+ * The per-case loop (and its same-sha guard, blocker writing, and
+ * persistence) is now owned by RetestLoopController; see
+ * `tests/retest-loop-controller.test.ts` for that file's tests. This
+ * file pins the orchestrator's run-level state machine.
  */
 
 import {
@@ -80,7 +82,7 @@ class RecordingEmitter implements ResultEmitter {
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
-describe('FixItOrchestrator (FIX-001 stubs)', () => {
+describe('FixItOrchestrator', () => {
   it('emits tested_and_done when every case passes on attempt 1', async () => {
     const emitter = new RecordingEmitter();
     const orchestrator = new FixItOrchestrator({
@@ -235,19 +237,21 @@ describe('FixItOrchestrator (FIX-001 stubs)', () => {
         errorMessage: 'still broken',
       }),
     };
+    let attemptCount = 0;
     const ipc: CodingIpcInvoker = {
-      applyFix: async (): Promise<FixOutcome> => ({
-        ok: true,
-        sha: 'attempt-fix',
-        summary: 'tried',
-      }),
+      // Each retry produces a unique sha so the FIX-006 same-sha guard
+      // doesn't fire — we want to exercise the attempts-exhausted path.
+      applyFix: async (): Promise<FixOutcome> => {
+        attemptCount += 1;
+        return { ok: true, sha: `attempt${attemptCount}fix`, summary: 'tried' };
+      },
       shutdown: async () => undefined,
     };
-    let shutdownCalls = 0;
+    let exitCalls = 0;
     const ipcCounted: CodingIpcInvoker = {
       applyFix: ipc.applyFix.bind(ipc),
       shutdown: async () => {
-        shutdownCalls += 1;
+        exitCalls += 1;
       },
     };
 
@@ -269,9 +273,9 @@ describe('FixItOrchestrator (FIX-001 stubs)', () => {
     expect(result.payload.lastFailures[0]?.attempt).toBe(3);
     expect(result.payload.lastFailures[0]?.errorMessage).toBe('still broken');
 
-    // Escalation path should NOT call ipc.shutdown — the worker stays
+    // Escalation path should NOT close the IPC — the worker stays
     // alive so the blocker can be inspected.
-    expect(shutdownCalls).toBe(0);
+    expect(exitCalls).toBe(0);
   });
 
   it('exposes MAX_ATTEMPTS_PER_CASE = 6 as the directive contract', () => {

--- a/apps/worker-fix-it/tests/retest-loop-controller.bench.ts
+++ b/apps/worker-fix-it/tests/retest-loop-controller.bench.ts
@@ -1,0 +1,96 @@
+/**
+ * Microbenchmark — FIX-006.
+ *
+ * Controller dispatch overhead per (testCase × attempt). With stub
+ * collaborators the path is pure orchestration so any regression
+ * here points at logic creep — the budget is < 2 ms / attempt.
+ */
+
+import {
+  RetestLoopController,
+  type BlockerWriter,
+  type RunHistoryRecorder,
+  type RunHistoryRow,
+  type BlockerInput,
+  type TestRunnerPort,
+} from '../src/retest-loop-controller';
+import {
+  StubCodingIpcInvoker,
+  StubFailureDiagnoser,
+  StubTestCodeGenerator,
+} from '../src/stubs';
+import type { CodingCompletePayload } from '../src/types';
+import type { TestCase } from '@chiefaia/ticket-template';
+
+const ITER = 200;
+const PER_ATTEMPT_BUDGET_MS = 2;
+
+const payload: CodingCompletePayload = {
+  storyId: 's',
+  workerId: 'w',
+  prUrl: 'https://github.com/x/y/pull/1',
+  prNumber: 1,
+  sha: 'abcdefg',
+  localTestsPassed: true,
+  worktreePath: '/tmp/wt',
+  codingSessionId: 'sess',
+  completedAt: 1,
+  correlationId: 'c',
+};
+
+const tc: TestCase = {
+  id: 'tc1',
+  title: 't',
+  category: 'happy',
+  layer: 'unit',
+  given: 'g',
+  when: 'w',
+  then: 't',
+  selectorHints: [],
+  mocks: [],
+  required: true,
+  status: 'pending',
+  designedBy: 'testing-agent',
+  designedAt: 0,
+};
+
+const passingRunner: TestRunnerPort = {
+  runSpec: async () => ({ testCaseId: 'tc1', status: 'passed', durationMs: 0 }),
+};
+
+class CountingHistory implements RunHistoryRecorder {
+  rows = 0;
+  async record(_r: RunHistoryRow): Promise<void> {
+    this.rows += 1;
+  }
+}
+
+class CountingBlocker implements BlockerWriter {
+  count = 0;
+  async fileBlocker(_b: BlockerInput): Promise<void> {
+    this.count += 1;
+  }
+}
+
+describe('RetestLoopController dispatch overhead', () => {
+  it(`stays under ${PER_ATTEMPT_BUDGET_MS}ms / attempt on the happy path`, async () => {
+    const controller = new RetestLoopController({
+      generator: new StubTestCodeGenerator(),
+      runner: passingRunner,
+      diagnoser: new StubFailureDiagnoser(),
+      ipc: new StubCodingIpcInvoker(),
+      history: new CountingHistory(),
+      blockers: new CountingBlocker(),
+    });
+    const start = Date.now();
+    for (let i = 0; i < ITER; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await controller.runCase(tc, payload);
+    }
+    const totalMs = Date.now() - start;
+    const perMs = totalMs / ITER;
+    // eslint-disable-next-line no-console
+    console.log(`[bench] FIX-006 controller: ${perMs.toFixed(3)}ms/attempt over ${ITER} iters`);
+    expect(perMs).toBeLessThan(PER_ATTEMPT_BUDGET_MS);
+  });
+});

--- a/apps/worker-fix-it/tests/retest-loop-controller.test.ts
+++ b/apps/worker-fix-it/tests/retest-loop-controller.test.ts
@@ -1,0 +1,307 @@
+/**
+ * `RetestLoopController` — FIX-006 contract tests.
+ *
+ * Pins three behaviours independent of the orchestrator:
+ *
+ *   1. **History persistence** — every (testCase, attempt) pair gets
+ *      one row recorded, regardless of outcome.
+ *   2. **Blocker writing** — fix-stuck (exhausted) / coding-stuck
+ *      (IPC ok:false) / same-sha-twice all get the right blocker
+ *      kind and history payload.
+ *   3. **Same-sha guard** — Coding Agent producing the same sha twice
+ *      bails immediately rather than burning the remaining attempts.
+ */
+
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  RetestLoopController,
+  type BlockerInput,
+  type BlockerWriter,
+  type RunHistoryRecorder,
+  type RunHistoryRow,
+  type TestRunnerPort,
+} from '../src/retest-loop-controller';
+import {
+  type CodingIpcInvoker,
+  type FailureDiagnoser,
+  type FixOutcome,
+  type GenerateContext,
+  type GeneratedSpec,
+  type ResultEmitter,
+  type RunResult,
+  type TestCodeGenerator,
+} from '../src/stubs';
+import type {
+  CodingCompletePayload,
+  FixRequest,
+  TestCaseResultPayload,
+  TestFailureReport,
+} from '../src/types';
+import type { TestCase } from '@chiefaia/ticket-template';
+
+// ─── Recorders ──────────────────────────────────────────────────────────────
+
+class RecordingHistory implements RunHistoryRecorder {
+  public rows: RunHistoryRow[] = [];
+  async record(row: RunHistoryRow): Promise<void> {
+    this.rows.push(row);
+  }
+}
+
+class RecordingBlocker implements BlockerWriter {
+  public blockers: BlockerInput[] = [];
+  async fileBlocker(b: BlockerInput): Promise<void> {
+    this.blockers.push(b);
+  }
+}
+
+class RecordingEmitter implements ResultEmitter {
+  public events: TestCaseResultPayload[] = [];
+  async emitTestCaseResult(p: TestCaseResultPayload): Promise<void> {
+    this.events.push(p);
+  }
+}
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const payload: CodingCompletePayload = {
+  storyId: 'story_test',
+  workerId: 'worker_test',
+  prUrl: 'https://github.com/x/y/pull/1',
+  prNumber: 1,
+  sha: 'origsha',
+  localTestsPassed: true,
+  worktreePath: '/tmp/wt',
+  codingSessionId: 'sess',
+  completedAt: 1,
+  correlationId: 'corr',
+};
+
+function makeCase(id = 'tc1'): TestCase {
+  return {
+    id,
+    title: 't',
+    category: 'happy',
+    layer: 'unit',
+    given: 'g',
+    when: 'w',
+    then: 't',
+    selectorHints: [],
+    mocks: [],
+    required: true,
+    status: 'pending',
+    designedBy: 'testing-agent',
+    designedAt: 0,
+  };
+}
+
+const fakeGenerator: TestCodeGenerator = {
+  generate: async (tc: TestCase, ctx: GenerateContext): Promise<GeneratedSpec> => ({
+    testCaseId: tc.id,
+    specPath: `${ctx.worktreePath}/spec.ts`,
+    contentHash: 'h',
+  }),
+};
+
+const fakeDiagnoser: FailureDiagnoser = {
+  diagnose: async (
+    runResult: RunResult,
+    tc: TestCase,
+    attempt: number,
+  ): Promise<TestFailureReport> => ({
+    testCaseId: tc.id,
+    attempt,
+    category: tc.category,
+    errorMessage: runResult.errorMessage ?? 'unknown',
+    errorStack: null,
+    failingAssertion: null,
+    artifacts: {},
+    inferredCause: 'cause',
+  }),
+};
+
+function buildIpc(applyFix: (req: FixRequest) => Promise<FixOutcome> | FixOutcome): CodingIpcInvoker {
+  return {
+    applyFix: async (req) => applyFix(req),
+    shutdown: async () => undefined,
+  };
+}
+
+function buildRunner(plan: ReadonlyArray<RunResult>): TestRunnerPort {
+  let i = 0;
+  return {
+    runSpec: async () => plan[Math.min(i++, plan.length - 1)] ?? plan[plan.length - 1]!,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('RetestLoopController', () => {
+  it('passes on attempt 1 → records 1 history row, files no blocker', async () => {
+    const history = new RecordingHistory();
+    const blockers = new RecordingBlocker();
+    const emitter = new RecordingEmitter();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: buildRunner([{ testCaseId: 'tc1', status: 'passed', durationMs: 5 }]),
+      diagnoser: fakeDiagnoser,
+      ipc: buildIpc(() => ({ ok: true, sha: 'never-called' })),
+      emitter,
+      history,
+      blockers,
+      now: () => 100,
+    });
+
+    const out = await controller.runCase(makeCase(), payload);
+
+    expect(out.finalStatus).toBe('passed');
+    expect(out.attempts).toBe(1);
+    expect(history.rows).toHaveLength(1);
+    expect(history.rows[0]?.status).toBe('passed');
+    expect(blockers.blockers).toHaveLength(0);
+    expect(emitter.events.map((e) => e.status)).toEqual(['passed']);
+  });
+
+  it('one retry then pass → 2 history rows, no blocker, lastSha lifted', async () => {
+    const history = new RecordingHistory();
+    const blockers = new RecordingBlocker();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: buildRunner([
+        { testCaseId: 'tc1', status: 'failed', durationMs: 5, errorMessage: 'boom' },
+        { testCaseId: 'tc1', status: 'passed', durationMs: 6 },
+      ]),
+      diagnoser: fakeDiagnoser,
+      ipc: buildIpc(() => ({ ok: true, sha: 'fix1234567' })),
+      history,
+      blockers,
+    });
+
+    const out = await controller.runCase(makeCase(), payload);
+
+    expect(out.finalStatus).toBe('passed');
+    expect(out.attempts).toBe(2);
+    expect(out.lastSha).toBe('fix1234567');
+    expect(history.rows.map((r) => r.status)).toEqual(['failed', 'passed']);
+    expect(history.rows[0]?.failureDiagnosis).not.toBeNull();
+    expect(history.rows[1]?.failureDiagnosis).toBeNull();
+    expect(blockers.blockers).toHaveLength(0);
+  });
+
+  it('attempts exhausted → fix-stuck blocker + finalStatus exhausted', async () => {
+    const history = new RecordingHistory();
+    const blockers = new RecordingBlocker();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: buildRunner([
+        { testCaseId: 'tc1', status: 'failed', durationMs: 1, errorMessage: 'still broken' },
+      ]),
+      diagnoser: fakeDiagnoser,
+      ipc: buildIpc((req) => ({ ok: true, sha: `f${req.attempt}1234567` })),
+      history,
+      blockers,
+    });
+
+    const out = await controller.runCase(makeCase(), payload, { maxAttempts: 3 });
+
+    expect(out.finalStatus).toBe('exhausted');
+    expect(out.attempts).toBe(3);
+    expect(history.rows).toHaveLength(3);
+    expect(blockers.blockers).toHaveLength(1);
+    expect(blockers.blockers[0]?.kind).toBe('fix-stuck');
+    expect(blockers.blockers[0]?.attempts).toBe(3);
+    expect(blockers.blockers[0]?.history).toHaveLength(3);
+    expect(blockers.blockers[0]?.lastErrorMessage).toBe('still broken');
+  });
+
+  it('IPC returns ok:false → coding-stuck blocker + finalStatus fix-failed', async () => {
+    const history = new RecordingHistory();
+    const blockers = new RecordingBlocker();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: buildRunner([
+        { testCaseId: 'tc1', status: 'failed', durationMs: 1, errorMessage: 'broken' },
+      ]),
+      diagnoser: fakeDiagnoser,
+      ipc: buildIpc(() => ({ ok: false, error: 'sdk-rate-limit' })),
+      history,
+      blockers,
+    });
+
+    const out = await controller.runCase(makeCase(), payload);
+
+    expect(out.finalStatus).toBe('fix-failed');
+    expect(out.lastErrorMessage).toBe('sdk-rate-limit');
+    expect(blockers.blockers).toHaveLength(1);
+    expect(blockers.blockers[0]?.kind).toBe('coding-stuck');
+    expect(blockers.blockers[0]?.lastErrorMessage).toBe('sdk-rate-limit');
+  });
+
+  it('same-sha twice → same-sha-twice blocker + finalStatus fix-failed', async () => {
+    const history = new RecordingHistory();
+    const blockers = new RecordingBlocker();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: buildRunner([
+        { testCaseId: 'tc1', status: 'failed', durationMs: 1, errorMessage: 'broken' },
+      ]),
+      diagnoser: fakeDiagnoser,
+      // Always returns the same sha, simulating a Coding Agent that
+      // committed without making a meaningful change.
+      ipc: buildIpc(() => ({ ok: true, sha: 'samesha1234567' })),
+      history,
+      blockers,
+    });
+
+    const out = await controller.runCase(makeCase(), payload, { maxAttempts: 6 });
+
+    expect(out.finalStatus).toBe('fix-failed');
+    expect(out.lastErrorMessage).toContain('same sha twice');
+    // Should NOT exhaust all 6 — bail at attempt 2 (the second time we
+    // see the same sha).
+    expect(out.attempts).toBe(2);
+    expect(blockers.blockers).toHaveLength(1);
+    expect(blockers.blockers[0]?.kind).toBe('same-sha-twice');
+  });
+
+  it('respects maxAttempts override', async () => {
+    const blockers = new RecordingBlocker();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: buildRunner([
+        { testCaseId: 'tc1', status: 'failed', durationMs: 1, errorMessage: 'x' },
+      ]),
+      diagnoser: fakeDiagnoser,
+      ipc: buildIpc((req) => ({ ok: true, sha: `s${req.attempt}xxxxx` })),
+      blockers,
+    });
+    const out = await controller.runCase(makeCase(), payload, { maxAttempts: 2 });
+    expect(out.attempts).toBe(2);
+    expect(out.finalStatus).toBe('exhausted');
+  });
+
+  it('exposes DEFAULT_MAX_ATTEMPTS = 6 (matches directive contract)', () => {
+    expect(DEFAULT_MAX_ATTEMPTS).toBe(6);
+  });
+
+  it('records run history with correct timing fields', async () => {
+    let nowVal = 1000;
+    const history = new RecordingHistory();
+    const controller = new RetestLoopController({
+      generator: fakeGenerator,
+      runner: {
+        runSpec: async () => {
+          nowVal += 50;
+          return { testCaseId: 'tc1', status: 'passed', durationMs: 50 };
+        },
+      },
+      diagnoser: fakeDiagnoser,
+      ipc: buildIpc(() => ({ ok: true })),
+      history,
+      now: () => nowVal,
+    });
+    await controller.runCase(makeCase(), payload);
+    expect(history.rows[0]?.startedAt).toBe(1000);
+    expect(history.rows[0]?.endedAt).toBe(1050);
+  });
+});

--- a/docs/fix-it-test-agent.md
+++ b/docs/fix-it-test-agent.md
@@ -90,7 +90,7 @@ change needed.
 - [x] FIX-003: Real test runner (`SubprocessTestRunner` over an injectable `CommandExecutor`).
 - [x] FIX-004: Real failure diagnoser (`StructuredFailureDiagnoser` with heuristic cause inference).
 - [x] FIX-005: Real Coding Agent IPC client (`UnixSocketCodingIpcClient` + `MemoryCodingIpcInvoker` fallback; coordinates with CODING-007).
-- [ ] FIX-006: Re-test loop persistence + fix-stuck blocker writer.
+- [x] FIX-006: Re-test loop persistence + fix-stuck blocker writer (`RetestLoopController` + same-sha guard).
 - [ ] Real-browser test with seeded failure — FIX-007 .. FIX-013.
 
 ## See also


### PR DESCRIPTION
## FIX-006 — Retest loop controller

Lifts the per-test-case retest loop out of the orchestrator into `RetestLoopController` so its three responsibilities can be tested in isolation:

1. **Loop** — generate spec → run → if pass, exit. Else diagnose → apply fix via IPC → loop. Cap at `DEFAULT_MAX_ATTEMPTS = 6` (the directive contract).
2. **Persistence** — every `(testCase, attempt)` pair is recorded via the injected `RunHistoryRecorder` so the dashboard timeline and the `task.test_case.result` event stream both have a faithful audit trail.
3. **Blocker writing** — terminal failures file a structured `fix-stuck` / `coding-stuck` / `same-sha-twice` blocker via the injected `BlockerWriter`.

### Same-sha guard

Per the architecture spec's risk register: if the Coding Agent produces the same sha twice in a row for the same test case, the loop bails immediately. That is the strongest signal that the agent isn't actually changing the code, so continuing to ask is just burning tokens.

| Termination | Blocker kind | When |
|--|--|--|
| `exhausted` | `fix-stuck` | All N attempts ran, every attempt failed |
| `fix-failed` (IPC) | `coding-stuck` | IPC returned `ok: false` |
| `fix-failed` (sha) | `same-sha-twice` | Two consecutive fix-requests produced identical shas |

### Orchestrator refactor

`FixItOrchestrator` now delegates per-case work to `RetestLoopController`. Its run-level state machine (fan out cases, roll up outcomes, emit terminal `tested_and_done` / `fix_loop_escalated`) is unchanged.

### Tests (8 new + 1 bench)

| Test | Asserts |
|--|--|
| pass-on-attempt-1 | 1 history row, 0 blockers |
| one-retry-then-pass | 2 history rows, 0 blockers, lastSha lifted |
| attempts-exhausted | N history rows, fix-stuck blocker, full history payload |
| IPC ok:false | coding-stuck blocker, finalStatus fix-failed |
| same-sha-twice | bails at attempt 2 (not 6), same-sha-twice blocker |
| maxAttempts override | controller honours injected cap |
| DEFAULT_MAX_ATTEMPTS pinned | 6 |
| history timing fields | startedAt/endedAt populated correctly |
| Microbench | controller dispatch < 2 ms / attempt |

The existing orchestrator-level test that previously assumed a same-sha-tolerant loop has been updated to use distinct shas per attempt so the exhausted path is exercised, not the same-sha guard.

### Per-DoD

- [x] Unit tests
- [x] Integration tests (orchestrator end-to-end with new controller)
- [x] Microbenchmark with budget assertion
- [x] CI green (local typecheck + test + bench)
- [x] Docs (`docs/fix-it-test-agent.md` + CHANGELOG)
- [x] Memory updates (architecture spec at `~/Documents/projects/reports/phase2-completion-architecture-2026-04-28.md` §5.7 + risk register)

Refs: phase2-completion-architecture-2026-04-28.md §5.7 + risk register

🤖 Generated with CAIA Phase 2D worker track