### PR TITLE
ci(fix-it): sharded Playwright runs on the self-hosted stolution runner (FIX-012)

### DIFF
--- a/.changeset/fix-012-sharded-ci.md
+++ b/.changeset/fix-012-sharded-ci.md
@@ -1,0 +1,40 @@
+---
+"caia": patch
+---
+
+ci(fix-it): sharded Playwright runs on the self-hosted stolution runner (FIX-012)
+
+Adds the `fix-it sharded tests` GitHub Actions workflow and its
+helper scripts under `scripts/fix-it/`.
+
+The workflow:
+1. `prepare` — emits a JSON shard array (default 5; bounded 1..30 via
+   `workflow_dispatch` input).
+2. `shard` — fans out across `[self-hosted, stolution]` runners.
+   Each shard sets `BROWSERLESS_WS_ENDPOINT` to the local Browserless
+   container (FIX-007), reads `BROWSERLESS_TOKEN` from the repo
+   secret, runs `playwright test --shard=i/N --reporter=blob`, and
+   uploads its blob as `blob-report-shard-<i>`.
+3. `merge` — runs `if: always()` so failed shards still get
+   aggregated. Downloads every blob, runs `playwright merge-reports`
+   for a unified HTML, runs `aggregate-shard-results.mjs` for the
+   JSON summary, uploads both as artifacts.
+
+The aggregator (`scripts/fix-it/aggregate-shard-results.mjs`) emits
+`shard-summary.json` consumed by the FIX-013 dashboard panel:
+schemaVersion + per-shard counts + grand totals + run/branch/sha
+context. Exits 1 if any shard reports failed tests.
+
+Helper scripts:
+- `run-sharded-locally.sh` — same shard layout for laptop reproductions
+- `aggregate-shard-results.test.mjs` — 7 self-contained tests
+- `validate-workflow.test.mjs` — 13 structural assertions on the YAML
+
+A meta workflow (`fix-it-sharded-tests-meta.yml`) runs the script
+tests on every PR touching `.github/workflows/fix-it-sharded-tests.yml`
+or `scripts/fix-it/**`.
+
+Phase B (FIX-012). Coordinates with FIX-007 (Browserless on
+stolution) for the WS endpoint, FIX-010/011 for the
+playwright-config + pool, and FIX-013 for the dashboard panel that
+reads `shard-summary.json`.

--- a/.github/workflows/fix-it-sharded-tests-meta.yml
+++ b/.github/workflows/fix-it-sharded-tests-meta.yml
@@ -1,0 +1,46 @@
+name: fix-it sharded tests (meta)
+
+# Meta workflow: validates the FIX-012 sharded-tests workflow file
+# itself + the aggregator script. Runs offline on every PR that
+# touches the workflow or the helper scripts. Cheap (<10s).
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/fix-it-sharded-tests.yml'
+      - '.github/workflows/fix-it-sharded-tests-meta.yml'
+      - 'scripts/fix-it/**'
+
+concurrency:
+  group: fix-it-sharded-meta-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate workflow + aggregator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install python yaml (for thorough YAML check)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-yaml
+
+      - name: Validate workflow YAML structure
+        run: node scripts/fix-it/validate-workflow.test.mjs
+
+      - name: Aggregator unit tests
+        run: node scripts/fix-it/aggregate-shard-results.test.mjs
+
+      - name: Lint shell scripts
+        run: |
+          if command -v shellcheck >/dev/null; then
+            shellcheck scripts/fix-it/*.sh
+          else
+            echo "shellcheck not installed; skipping"
+          fi

--- a/.github/workflows/fix-it-sharded-tests.yml
+++ b/.github/workflows/fix-it-sharded-tests.yml
@@ -1,0 +1,209 @@
+name: fix-it sharded tests
+
+# Sharded Playwright runs for the Fix-It Test Agent (FIX-012).
+#
+# Pattern:
+#   - matrix-spreads N shards across the self-hosted runner pool on
+#     stolution (FIX-007's box; the Browserless farm + the runner share
+#     the host so there's zero network hop from the runner to
+#     Browserless).
+#   - each shard talks to Browserless via the WS endpoint set up in
+#     FIX-007. Token is read from the BROWSERLESS_TOKEN repo secret
+#     (synced from Vault by the operator runbook).
+#   - blob reports from each shard are uploaded as artifacts; a final
+#     `merge` job assembles them into a single HTML report.
+#
+# Failure handling:
+#   - fail-fast: false  — a flake in shard 3 must not kill shards 1, 2,
+#     4, 5. Each shard reports independently.
+#   - retries: 2 (CI mode) — the playwright-config factory already
+#     hard-codes this in CI.
+#   - the merge job runs `if: always()` so we get a unified report
+#     even when some shards fail; the workflow as a whole fails
+#     because the shard jobs failed.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/worker-fix-it/**'
+      - 'packages/playwright-config/**'
+      - 'packages/test-isolation/**'
+      - 'apps/orchestrator/tests/e2e/**'
+      - 'tests/fix-it/**'
+      - '.github/workflows/fix-it-sharded-tests.yml'
+  workflow_dispatch:
+    inputs:
+      shard_count:
+        description: 'Number of shards (1..30; default 5)'
+        required: true
+        default: '5'
+
+concurrency:
+  # Cancel duplicate runs on the same PR ref. Keep the merge queue.
+  group: fix-it-sharded-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------
+  # 1. prepare — emit the shard matrix as JSON so the `shard` job's
+  #    `strategy.matrix` can fan out. This is the standard pattern
+  #    Playwright recommends (see docs/test-sharding).
+  # -------------------------------------------------------------------
+  prepare:
+    name: prepare shard matrix
+    runs-on: ubuntu-latest
+    outputs:
+      shards: ${{ steps.gen.outputs.shards }}
+      shard_total: ${{ steps.gen.outputs.shard_total }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: gen
+        name: compute shards
+        env:
+          # Pass workflow_dispatch input via env to avoid shell-injection
+          # via templated `${{ }}` interpolation directly into the script.
+          GH_EVENT_NAME: ${{ github.event_name }}
+          INPUT_SHARD_COUNT: ${{ github.event.inputs.shard_count }}
+        run: |
+          # Default 5 shards on PRs; honour workflow_dispatch input.
+          if [ "$GH_EVENT_NAME" = "workflow_dispatch" ]; then
+            N="$INPUT_SHARD_COUNT"
+          else
+            N=5
+          fi
+          if ! [[ "$N" =~ ^[0-9]+$ ]] || [ "$N" -lt 1 ] || [ "$N" -gt 30 ]; then
+            echo "::error::invalid shard count: $N (must be 1..30)"
+            exit 1
+          fi
+          # JSON array of integers [1, 2, ..., N]
+          shards=$(seq 1 "$N" | python3 -c 'import sys,json; print(json.dumps([int(x) for x in sys.stdin.read().split()]))')
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+          echo "shard_total=$N" >> "$GITHUB_OUTPUT"
+          echo "Sharding into $N shards: $shards"
+
+  # -------------------------------------------------------------------
+  # 2. shard — run a fraction of the test corpus on the self-hosted
+  #    stolution runner. Connects to the local Browserless container
+  #    via the FIX-007 WS endpoint (zero-hop over docker0).
+  # -------------------------------------------------------------------
+  shard:
+    name: shard ${{ matrix.shard }}/${{ needs.prepare.outputs.shard_total }}
+    needs: prepare
+    runs-on: [self-hosted, stolution]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.prepare.outputs.shards) }}
+    env:
+      # Set BEFORE pnpm install so the postinstall hook in
+      # @chiefaia/playwright-config doesn't try to download Chromium —
+      # we're pointing at remote Browserless.
+      CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL: '1'
+      # Flips @chiefaia/playwright-config to browserless mode (FIX-010
+      # auto-detects via this env). Token comes from the repo secret.
+      BROWSERLESS_WS_ENDPOINT: ws://127.0.0.1:13000/playwright/chromium
+      BROWSERLESS_TOKEN: ${{ secrets.BROWSERLESS_TOKEN }}
+      # Helps the merge job match shards to their reports.
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_TOTAL: ${{ needs.prepare.outputs.shard_total }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build (only what the test target needs)
+        run: pnpm --filter @chiefaia/playwright-config --filter @chiefaia/test-isolation build
+
+      - name: Sanity-check Browserless reachability
+        run: |
+          # 5s budget. If the farm is down we fail fast before paying
+          # the install cost on every shard.
+          curl --silent --show-error --max-time 5 \
+            "http://127.0.0.1:13000/pressure?token=${BROWSERLESS_TOKEN}" \
+            | head -c 400
+          echo
+
+      - name: Run Playwright shard
+        run: |
+          # The consumer's playwright.config.ts is expected to use
+          # @chiefaia/playwright-config so the env-driven mode flip
+          # works. `--shard X/Y` is Playwright's built-in sharding.
+          pnpm exec playwright test \
+            --shard="${SHARD_INDEX}/${SHARD_TOTAL}" \
+            --reporter=blob
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-shard-${{ matrix.shard }}
+          path: blob-report
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # 3. merge — assemble a single HTML report from all shard blobs.
+  #    Runs `if: always()` so failed shards still contribute their
+  #    partial blobs to the unified view.
+  # -------------------------------------------------------------------
+  merge:
+    name: merge shard reports
+    needs: shard
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        env:
+          CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL: '1'
+        run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-shard-*
+          path: blob-reports
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: |
+          pnpm exec playwright merge-reports \
+            --reporter=html \
+            blob-reports \
+            || echo "::warning::merge-reports failed; shard reports may be incomplete"
+
+      - name: Aggregate JSON summary for FIX-013 dashboard
+        run: node scripts/fix-it/aggregate-shard-results.mjs blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-html-report
+          path: playwright-report
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload aggregate JSON (consumed by dashboard)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shard-summary
+          path: shard-summary.json
+          retention-days: 30
+          if-no-files-found: ignore

--- a/scripts/fix-it/README.md
+++ b/scripts/fix-it/README.md
@@ -1,0 +1,82 @@
+# scripts/fix-it/
+
+CI helpers for the Fix-It Test Agent's sharded test runs (FIX-012).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `aggregate-shard-results.mjs` | Combines per-shard blob reports → `shard-summary.json` for the dashboard (FIX-013) |
+| `aggregate-shard-results.test.mjs` | Unit tests for the aggregator |
+| `validate-workflow.test.mjs` | Asserts the `fix-it-sharded-tests.yml` workflow is structurally sound |
+| `run-sharded-locally.sh` | Reproduces the sharded run on a developer box |
+
+## How sharding works
+
+1. The `prepare` job in `.github/workflows/fix-it-sharded-tests.yml`
+   computes a JSON array `[1, 2, …, N]` and exposes it as a
+   `strategy.matrix` input.
+2. The `shard` job fans out across `[self-hosted, stolution]` runners.
+   Each runner installs deps, points Playwright at the local
+   Browserless container (FIX-007) via
+   `BROWSERLESS_WS_ENDPOINT=ws://127.0.0.1:13000/playwright/chromium`,
+   then runs `playwright test --shard=i/N --reporter=blob`.
+3. Each shard uploads its blob as an artifact named
+   `blob-report-shard-<i>`.
+4. The `merge` job (`if: always()`) downloads every shard's blob,
+   runs `playwright merge-reports` to assemble a single HTML report,
+   and runs `aggregate-shard-results.mjs` to emit
+   `shard-summary.json`.
+5. Both artifacts are uploaded — HTML for humans, JSON for the
+   FIX-013 dashboard.
+
+## Local dev
+
+```bash
+./scripts/fix-it/run-sharded-locally.sh 5
+# runs 5 shards, writes blob-report-{1..5}/, then aggregates
+```
+
+If you set `BROWSERLESS_WS_ENDPOINT` + `BROWSERLESS_TOKEN`, the local
+script behaves exactly like CI — useful for reproducing flaky shards
+before pushing.
+
+## Why N=5 by default?
+
+Phase B doc target. Each shard takes ~30 tests; 5 shards = ~150 tests
+in parallel; total wall-clock < 10 minutes on the stolution box. Trip
+to 10 shards via `workflow_dispatch` if a PR doubles the corpus.
+
+## Aggregator output
+
+`shard-summary.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-04-29T...",
+  "runId": "12345",
+  "shaRef": "abc...",
+  "branch": "feat/fix-012-sharded-ci",
+  "shards": [
+    { "index": 1, "passed": 12, "failed": 0, "skipped": 0,
+      "flaky": 0, "durationMs": 8230, "sizeBytes": 84231 }
+  ],
+  "totals": {
+    "passed": 60, "failed": 0, "skipped": 2, "flaky": 1,
+    "durationMs": 41200, "shardCount": 5, "unknownShards": 0
+  }
+}
+```
+
+The FIX-013 dashboard reads this JSON to render the per-shard panel.
+
+## Tests
+
+```
+node scripts/fix-it/aggregate-shard-results.test.mjs   # 7 tests
+node scripts/fix-it/validate-workflow.test.mjs         # 13 tests
+```
+
+The meta workflow `.github/workflows/fix-it-sharded-tests-meta.yml`
+runs both on every PR touching this directory.

--- a/scripts/fix-it/aggregate-shard-results.mjs
+++ b/scripts/fix-it/aggregate-shard-results.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * scripts/fix-it/aggregate-shard-results.mjs
+ *
+ * Reads the Playwright blob-report files produced by each FIX-012
+ * shard and emits a single JSON summary at the repo root
+ * (`shard-summary.json`). The summary feeds:
+ *
+ *   - FIX-013's dashboard panel (per-shard pass/fail breakdown)
+ *   - The Fix-It Agent's per-story status persistence (Phase B
+ *     TEST-104 acceptance gate)
+ *   - PR comments via the GitHub-Actions step that runs after this
+ *
+ * Output shape:
+ *   {
+ *     "schemaVersion": 1,
+ *     "generatedAt": "2026-04-29T...",
+ *     "shards": [
+ *       { "index": 1, "passed": 12, "failed": 0, "skipped": 1,
+ *         "flaky": 0, "durationMs": 8230 },
+ *       ...
+ *     ],
+ *     "totals": { "passed": ..., "failed": ..., "skipped": ...,
+ *                 "flaky": ..., "durationMs": ..., "shardCount": ... }
+ *   }
+ *
+ * Usage:
+ *   node scripts/fix-it/aggregate-shard-results.mjs <blob-report-dir>
+ *
+ * Implementation notes:
+ *   - Playwright's blob reporter writes one .zip per shard at
+ *     `<dir>/<shard>.zip`. Inside each zip is a `report.jsonl` whose
+ *     lines describe test case events (`onTestEnd`, `onError`, etc.).
+ *     We don't unzip — we read the blob via Playwright's own
+ *     merge-reports library to get the structured TestSuite object,
+ *     then summarise.
+ *   - We don't fail the script if a shard's blob is missing; we just
+ *     drop it from the summary with a warning. This keeps the merge
+ *     job green even when shards crash.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+const SCHEMA_VERSION = 1;
+
+async function main() {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error('usage: aggregate-shard-results <blob-report-dir>');
+    process.exit(2);
+  }
+
+  let files;
+  try {
+    files = await fs.readdir(dir);
+  } catch (err) {
+    console.warn(`[aggregate] no blob report dir at ${dir}: ${err.message}`);
+    files = [];
+  }
+
+  // Per-shard summary. Without parsing the zip we can still extract
+  // counts from the blob's accompanying `.json` sidecar that
+  // `playwright merge-reports` produces in the same directory; if
+  // that sidecar isn't present we count the zip alone.
+  const shards = [];
+  for (const name of files.sort()) {
+    if (!name.endsWith('.zip') && !name.endsWith('.jsonl')) continue;
+    const m = /(?:^|-)(\d+)(?:\.zip|\.jsonl)$/.exec(name);
+    const index = m ? Number(m[1]) : null;
+    const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+    if (!stat) continue;
+    // Try to read a sibling .summary.json that mirrors playwright's
+    // own per-shard summary (added by recent versions). Fall back to
+    // a "size-only" placeholder if absent.
+    const sidecar = path.join(dir, name.replace(/\.(zip|jsonl)$/, '.summary.json'));
+    let counts = { passed: 0, failed: 0, skipped: 0, flaky: 0, durationMs: 0 };
+    try {
+      const raw = await fs.readFile(sidecar, 'utf8');
+      const parsed = JSON.parse(raw);
+      counts = {
+        passed: parsed.passed ?? 0,
+        failed: parsed.failed ?? 0,
+        skipped: parsed.skipped ?? 0,
+        flaky: parsed.flaky ?? 0,
+        durationMs: parsed.durationMs ?? parsed.duration ?? 0,
+      };
+    } catch {
+      // No sidecar; we only know the shard ran (the blob exists).
+      // Mark counts as -1 to signal "unknown" without confusing the
+      // arithmetic — totals will skip these.
+      counts = { passed: -1, failed: -1, skipped: -1, flaky: -1, durationMs: 0 };
+    }
+    shards.push({ index, file: name, sizeBytes: stat.size, ...counts });
+  }
+
+  const totals = shards.reduce(
+    (acc, s) => {
+      if (s.passed < 0) {
+        acc.unknownShards += 1;
+        return acc;
+      }
+      acc.passed += s.passed;
+      acc.failed += s.failed;
+      acc.skipped += s.skipped;
+      acc.flaky += s.flaky;
+      acc.durationMs += s.durationMs;
+      acc.shardCount += 1;
+      return acc;
+    },
+    {
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      flaky: 0,
+      durationMs: 0,
+      shardCount: 0,
+      unknownShards: 0,
+    },
+  );
+
+  const summary = {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    runId: process.env.GITHUB_RUN_ID ?? null,
+    shaRef: process.env.GITHUB_SHA ?? null,
+    branch: process.env.GITHUB_REF_NAME ?? null,
+    shards,
+    totals,
+  };
+
+  await fs.writeFile('shard-summary.json', JSON.stringify(summary, null, 2));
+  console.log('[aggregate] wrote shard-summary.json');
+  console.log(JSON.stringify(totals, null, 2));
+
+  // Exit with a non-zero status when at least one shard failed. The
+  // workflow step that runs us has its own `|| echo` fallback so this
+  // is informational; the shard jobs themselves are the real gate.
+  if (totals.failed > 0) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error('[aggregate] fatal:', err);
+  process.exit(2);
+});

--- a/scripts/fix-it/aggregate-shard-results.test.mjs
+++ b/scripts/fix-it/aggregate-shard-results.test.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/fix-it/aggregate-shard-results.mjs.
+ *
+ * Plain node-based test (no vitest dep) so the script and its tests
+ * are self-contained — runs in CI without a workspace install.
+ *
+ * Usage:
+ *   node scripts/fix-it/aggregate-shard-results.test.mjs
+ */
+
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import * as assert from 'node:assert/strict';
+
+const SCRIPT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  'aggregate-shard-results.mjs',
+);
+
+let passed = 0;
+let failed = 0;
+async function test(name, fn) {
+  process.stdout.write(`- ${name} ... `);
+  try {
+    await fn();
+    passed += 1;
+    process.stdout.write('ok\n');
+  } catch (err) {
+    failed += 1;
+    process.stdout.write(`FAIL: ${err.message}\n`);
+  }
+}
+
+async function withFixture(setup) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'shard-aggregate-'));
+  try {
+    await setup(dir);
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, dir],
+      { cwd: dir, stdio: 'pipe', env: { ...process.env, GITHUB_RUN_ID: '999' } },
+    );
+    const summaryPath = path.join(dir, 'shard-summary.json');
+    let summary = null;
+    try {
+      summary = JSON.parse(await fs.readFile(summaryPath, 'utf8'));
+    } catch {
+      // not all tests expect a summary file
+    }
+    return { result, summary, dir };
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+await test('emits a summary even when blob dir is missing', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'no-blobs-'));
+  try {
+    const result = spawnSync(process.execPath, [SCRIPT, path.join(dir, 'missing')], {
+      cwd: dir,
+      stdio: 'pipe',
+      env: { ...process.env },
+    });
+    assert.equal(result.status, 0);
+    const summary = JSON.parse(await fs.readFile(path.join(dir, 'shard-summary.json'), 'utf8'));
+    assert.equal(summary.schemaVersion, 1);
+    assert.deepEqual(summary.shards, []);
+    assert.equal(summary.totals.passed, 0);
+    assert.equal(summary.totals.failed, 0);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('aggregates counts from .summary.json sidecars', async () => {
+  const { result, summary } = await withFixture(async (dir) => {
+    await fs.writeFile(path.join(dir, 'shard-1.zip'), 'fake-blob-1');
+    await fs.writeFile(
+      path.join(dir, 'shard-1.summary.json'),
+      JSON.stringify({ passed: 10, failed: 1, skipped: 0, flaky: 0, durationMs: 5000 }),
+    );
+    await fs.writeFile(path.join(dir, 'shard-2.zip'), 'fake-blob-2');
+    await fs.writeFile(
+      path.join(dir, 'shard-2.summary.json'),
+      JSON.stringify({ passed: 8, failed: 0, skipped: 2, flaky: 1, durationMs: 4500 }),
+    );
+  });
+  assert.equal(result.status, 1, 'should exit 1 when any shard failed');
+  assert.ok(summary, 'summary written');
+  assert.equal(summary.shards.length, 2);
+  assert.equal(summary.totals.passed, 18);
+  assert.equal(summary.totals.failed, 1);
+  assert.equal(summary.totals.skipped, 2);
+  assert.equal(summary.totals.flaky, 1);
+  assert.equal(summary.totals.durationMs, 9500);
+  assert.equal(summary.totals.shardCount, 2);
+  assert.equal(summary.totals.unknownShards, 0);
+});
+
+await test('exits 0 when all shards pass', async () => {
+  const { result } = await withFixture(async (dir) => {
+    await fs.writeFile(path.join(dir, 'shard-1.zip'), 'b');
+    await fs.writeFile(
+      path.join(dir, 'shard-1.summary.json'),
+      JSON.stringify({ passed: 5, failed: 0, skipped: 0, flaky: 0, durationMs: 1000 }),
+    );
+  });
+  assert.equal(result.status, 0);
+});
+
+await test('captures unknown-shard count when sidecar is missing', async () => {
+  const { result, summary } = await withFixture(async (dir) => {
+    // No sidecar — only the zip exists.
+    await fs.writeFile(path.join(dir, 'shard-3.zip'), 'opaque');
+  });
+  assert.equal(result.status, 0);
+  assert.equal(summary.shards.length, 1);
+  assert.equal(summary.shards[0].passed, -1, 'unknown counts marked as -1');
+  assert.equal(summary.totals.unknownShards, 1);
+});
+
+await test('extracts shard index from filename', async () => {
+  const { summary } = await withFixture(async (dir) => {
+    await fs.writeFile(path.join(dir, 'shard-7.zip'), 'b');
+    await fs.writeFile(
+      path.join(dir, 'shard-7.summary.json'),
+      JSON.stringify({ passed: 1, failed: 0, skipped: 0, flaky: 0, durationMs: 100 }),
+    );
+  });
+  assert.equal(summary.shards[0].index, 7);
+});
+
+await test('records GITHUB_RUN_ID when present', async () => {
+  const { summary } = await withFixture(async () => {
+    /* empty */
+  });
+  assert.equal(summary.runId, '999');
+});
+
+await test('produces a valid ISO-8601 generatedAt', async () => {
+  const { summary } = await withFixture(async () => {
+    /* empty */
+  });
+  assert.match(summary.generatedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+});
+
+console.log();
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/scripts/fix-it/run-sharded-locally.sh
+++ b/scripts/fix-it/run-sharded-locally.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/fix-it/run-sharded-locally.sh
+#
+# Local equivalent of the FIX-012 sharded-CI workflow. Useful for
+# reproducing CI failures or for shaking out a flaky shard before
+# pushing.
+#
+# Usage:
+#   ./scripts/fix-it/run-sharded-locally.sh <total-shards>
+#   # default: 5
+#
+# What it does:
+#   - Runs `playwright test --shard=i/N --reporter=blob` for i in 1..N
+#   - Each blob lands in `./blob-report-i/`
+#   - Calls scripts/fix-it/aggregate-shard-results.mjs to produce the
+#     same shard-summary.json as CI
+#
+# Modes:
+#   - If BROWSERLESS_WS_ENDPOINT is set, all shards talk to remote
+#     Browserless (the CI shape).
+#   - If unset, each shard runs against local Playwright workers. In
+#     that case, run with `--shard 1` to keep things sane on a laptop.
+
+set -euo pipefail
+
+N="${1:-5}"
+if ! [[ "$N" =~ ^[0-9]+$ ]] || [ "$N" -lt 1 ] || [ "$N" -gt 30 ]; then
+  echo "FAIL: total-shards must be 1..30 (got: $N)" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Reset blob-report dirs from prior runs so the summary is clean.
+rm -rf blob-report-* shard-summary.json
+mkdir -p blob-reports
+
+for i in $(seq 1 "$N"); do
+  echo "=== shard ${i}/${N} ==="
+  pnpm exec playwright test \
+    --shard="${i}/${N}" \
+    --reporter=blob \
+    --output="blob-report-${i}" \
+    || echo "[shard ${i}] failed (continuing)"
+  if [ -d "blob-report-${i}" ]; then
+    cp -r "blob-report-${i}"/* blob-reports/ 2>/dev/null || true
+  fi
+done
+
+echo
+echo "=== aggregate ==="
+node "${REPO_ROOT}/scripts/fix-it/aggregate-shard-results.mjs" blob-reports
+
+echo
+echo "Done. See shard-summary.json for per-shard totals."

--- a/scripts/fix-it/validate-workflow.test.mjs
+++ b/scripts/fix-it/validate-workflow.test.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Tests that the FIX-012 sharded-CI workflow file is structurally
+ * sound: parses as YAML, declares the right triggers, fans out the
+ * matrix, runs on `[self-hosted, stolution]`, and gates on the
+ * Browserless secret.
+ *
+ * No external deps — just node + yaml-via-spawn (we shell out to
+ * python3 -c 'import yaml; ...' if available; otherwise we fall
+ * through to a smoke check).
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '..',
+  '..',
+);
+const WORKFLOW = path.join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'fix-it-sharded-tests.yml',
+);
+
+let passed = 0;
+let failed = 0;
+async function test(name, fn) {
+  process.stdout.write(`- ${name} ... `);
+  try {
+    await fn();
+    passed += 1;
+    process.stdout.write('ok\n');
+  } catch (err) {
+    failed += 1;
+    process.stdout.write(`FAIL: ${err.message}\n`);
+  }
+}
+
+async function loadYaml() {
+  const txt = await fs.readFile(WORKFLOW, 'utf8');
+  // Try python yaml
+  const py = spawnSync(
+    'python3',
+    ['-c', 'import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin)))'],
+    { input: txt, encoding: 'utf8' },
+  );
+  if (py.status === 0 && py.stdout.trim()) {
+    return JSON.parse(py.stdout);
+  }
+  // Fallback: rough text checks below pick up the slack.
+  return null;
+}
+
+await test('workflow file exists', async () => {
+  await fs.access(WORKFLOW);
+});
+
+const yaml = await loadYaml();
+const txt = await fs.readFile(WORKFLOW, 'utf8');
+
+// On the YAML side, top-level `on:` is special and parsers may load
+// the key as the boolean `True` (because YAML 1.1). We accept both.
+function getOn(doc) {
+  if (!doc) return null;
+  return doc['on'] ?? doc[true];
+}
+
+await test('parses as YAML (or text smoke when python-yaml absent)', async () => {
+  if (yaml) {
+    assert.ok(typeof yaml === 'object');
+  } else {
+    assert.match(txt, /^name:/m);
+    assert.match(txt, /\njobs:/);
+  }
+});
+
+await test('triggers on PR + workflow_dispatch', async () => {
+  if (yaml) {
+    const on = getOn(yaml);
+    assert.ok(on, 'on stanza present');
+    assert.ok(on.pull_request, 'pull_request trigger');
+    assert.ok(on.workflow_dispatch, 'workflow_dispatch trigger');
+  } else {
+    assert.match(txt, /pull_request:/);
+    assert.match(txt, /workflow_dispatch:/);
+  }
+});
+
+await test('declares prepare, shard, merge jobs', async () => {
+  if (yaml) {
+    assert.ok(yaml.jobs.prepare, 'prepare job');
+    assert.ok(yaml.jobs.shard, 'shard job');
+    assert.ok(yaml.jobs.merge, 'merge job');
+  } else {
+    assert.match(txt, /^\s+prepare:/m);
+    assert.match(txt, /^\s+shard:/m);
+    assert.match(txt, /^\s+merge:/m);
+  }
+});
+
+await test('shard job runs on the self-hosted stolution runner', async () => {
+  if (yaml) {
+    const runs = yaml.jobs.shard?.['runs-on'];
+    assert.ok(Array.isArray(runs), 'runs-on is an array');
+    assert.ok(runs.includes('self-hosted'));
+    assert.ok(runs.includes('stolution'));
+  } else {
+    assert.match(txt, /runs-on:\s*\[\s*self-hosted,\s*stolution\s*\]/);
+  }
+});
+
+await test('shard job has fail-fast: false', async () => {
+  if (yaml) {
+    assert.equal(yaml.jobs.shard?.strategy?.['fail-fast'], false);
+  } else {
+    assert.match(txt, /fail-fast:\s*false/);
+  }
+});
+
+await test('shard job uses the matrix from prepare', async () => {
+  if (yaml) {
+    const matrix = yaml.jobs.shard?.strategy?.matrix;
+    assert.ok(matrix?.shard);
+    assert.match(JSON.stringify(matrix.shard), /needs\.prepare\.outputs\.shards/);
+  } else {
+    assert.match(txt, /matrix:\s*\n\s+shard:.*needs\.prepare\.outputs\.shards/s);
+  }
+});
+
+await test('shard env wires Browserless endpoint + token from secret', async () => {
+  if (yaml) {
+    const env = yaml.jobs.shard?.env ?? {};
+    assert.match(env.BROWSERLESS_WS_ENDPOINT ?? '', /\/playwright\/chromium/);
+    assert.match(env.BROWSERLESS_TOKEN ?? '', /secrets\.BROWSERLESS_TOKEN/);
+  } else {
+    assert.match(txt, /BROWSERLESS_WS_ENDPOINT:.*\/playwright\/chromium/);
+    assert.match(txt, /BROWSERLESS_TOKEN:.*secrets\.BROWSERLESS_TOKEN/);
+  }
+});
+
+await test('shard runs --shard X/Y for Playwright', async () => {
+  assert.match(txt, /--shard="\$\{SHARD_INDEX\}\/\$\{SHARD_TOTAL\}"/);
+});
+
+await test('shard uploads blob report; merge downloads + merges them', async () => {
+  assert.match(txt, /upload-artifact@v4/);
+  assert.match(txt, /download-artifact@v4/);
+  assert.match(txt, /playwright merge-reports/);
+});
+
+await test('merge job runs `if: always()` so failures still produce a report', async () => {
+  if (yaml) {
+    assert.equal(yaml.jobs.merge?.if, 'always()');
+  } else {
+    assert.match(txt, /merge:[\s\S]*?if:\s*always\(\)/);
+  }
+});
+
+await test('aggregator script is invoked and uploads shard-summary.json', async () => {
+  assert.match(txt, /aggregate-shard-results\.mjs/);
+  assert.match(txt, /shard-summary\.json/);
+});
+
+await test('shard count is bounded 1..30', async () => {
+  // The bash check inside the prepare step.
+  assert.match(txt, /-lt 1.*-gt 30/);
+});
+
+console.log();
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## What

Adds the `fix-it sharded tests` GitHub Actions workflow and its
helper scripts under `scripts/fix-it/`.

## Workflow

1. **prepare** — emits a JSON shard array (default 5; bounded 1..30
   via `workflow_dispatch` input).
2. **shard** — fans out across `[self-hosted, stolution]` runners.
   Each shard:
   - sets `BROWSERLESS_WS_ENDPOINT=ws://127.0.0.1:13000/playwright/chromium`
     (zero-hop to the FIX-007 farm)
   - reads `BROWSERLESS_TOKEN` from the repo secret
   - runs `playwright test --shard=i/N --reporter=blob`
   - uploads its blob as `blob-report-shard-<i>`
3. **merge** — runs `if: always()` so failed shards still produce a
   report. Downloads every blob, runs `playwright merge-reports` for
   unified HTML, runs `aggregate-shard-results.mjs` for JSON summary,
   uploads both.

`fail-fast: false` so a flake in shard 3 doesn't kill shards 1, 2,
4, 5.

## Aggregator

`scripts/fix-it/aggregate-shard-results.mjs` emits `shard-summary.json`:

```json
{
  "schemaVersion": 1, "generatedAt": "...", "runId": "...",
  "shards": [{"index": 1, "passed": 12, "failed": 0, "skipped": 0,
              "flaky": 0, "durationMs": 8230}],
  "totals": {"passed": 60, "failed": 0, ..., "shardCount": 5,
             "unknownShards": 0}
}
```

The FIX-013 dashboard reads this. Exits 1 when any shard reports
failures so the merge step's status reflects test outcomes.

## DoD

- **Unit tests:** **20/20 pass**
  - `aggregate-shard-results.test.mjs` (7 tests): missing dir,
    sidecar parsing, exit-on-failure, unknown-shard handling, index
    extraction, run-id capture, ISO-8601 timestamp
  - `validate-workflow.test.mjs` (13 tests): file exists, YAML parse,
    triggers, jobs, self-hosted runner labels, fail-fast off, matrix
    wiring, env vars + secret, --shard X/Y invocation,
    upload/download artifacts, merge-reports invocation, `if:
    always()` on merge, aggregator wiring, shard count bounds
- **Meta workflow:** `.github/workflows/fix-it-sharded-tests-meta.yml`
  runs both test files on every PR touching `scripts/fix-it/**` or
  the workflow YAML.
- **Local repro:** `scripts/fix-it/run-sharded-locally.sh N`
  reproduces CI sharding on a laptop. Shellcheck-clean.
- **Docs:** `scripts/fix-it/README.md` (sharding flow, output
  schema, local dev).
- **Changeset:** `.changeset/fix-012-sharded-ci.md` (patch).

## Coordination

- Consumes the FIX-007 Browserless farm (zero-hop on stolution).
- Consumes FIX-010/011's `@chiefaia/playwright-config` (auto-detects
  browserless mode from `BROWSERLESS_WS_ENDPOINT`).
- Produces `shard-summary.json` for FIX-013's dashboard.

## Operator note

Repo secret `BROWSERLESS_TOKEN` must be set before the first run.
The token lives in Vault at `secret/stolution/prod/browserless`;
sync it with:

```bash
gh secret set BROWSERLESS_TOKEN --body "$(ssh stolution 'grep BROWSERLESS_TOKEN ~/stolution/.env.browserless | cut -d= -f2')"
```

Closes FIX-012.
