### PR TITLE
feat(dashboard): test-isolation runbook + dashboard panel (FIX-013)

### DIFF
--- a/.changeset/fix-013-test-isolation-runbook.md
+++ b/.changeset/fix-013-test-isolation-runbook.md
@@ -1,0 +1,37 @@
+---
+"caia": patch
+---
+
+docs+feat(dashboard): test-isolation runbook + dashboard panel (FIX-013)
+
+Adds:
+
+1. `docs/test-isolation-runbook.md` — comprehensive operator guide
+   covering the FIX-007..012 stack: architecture diagram, the four
+   guarantees, health-check commands ranked by utility, common
+   scenarios (flaky CI, stuck shard, disk pressure, saturation,
+   token rotation), and the configuration env-var index.
+
+2. `apps/dashboard/app/test-isolation/page.tsx` — live dashboard
+   panel with three cards:
+   - **Browserless**: active/max, queue, CPU, memory; warns red at
+     90% utilisation
+   - **Per-test SQLite**: total / stale (>1h) / disk usage / recent
+     files table
+   - **Last shard run**: pass/fail/skip/flaky/duration from
+     `shard-summary.json`
+   Refreshes every 5 s while the tab is visible (Page Visibility API).
+
+3. `apps/dashboard/app/api/test-isolation/route.ts` — the API the
+   panel reads. Best-effort merging of:
+   - Browserless `/pressure` (3 s timeout; null on unreachable)
+   - `os.tmpdir()` scan for `caia-test-*.sqlite` files
+   - Optional `shard-summary.json` from `SHARD_SUMMARY_PATH`
+
+The runbook is the canonical reference for "the testing infra is
+acting up" — first stop for any operator. The dashboard is the
+real-time view that points operators at the right command.
+
+Phase B (FIX-013). Final piece of the FIX-007..013 infrastructure
+track. Once FIX-001..006 (Fix-It Agent itself) lands, the agent
+consumes everything below it automatically.

--- a/apps/dashboard/app/api/test-isolation/lib.mjs
+++ b/apps/dashboard/app/api/test-isolation/lib.mjs
@@ -1,0 +1,147 @@
+/**
+ * apps/dashboard/app/api/test-isolation/lib.mjs
+ *
+ * Pure helpers used by route.ts. Plain ESM (.mjs) so they can be
+ * tested with `node:assert` without spinning up a TS compiler — the
+ * dashboard has no vitest harness wired today.
+ *
+ * @typedef {Object} BrowserlessPressure
+ * @property {boolean} isAvailable
+ * @property {number} running
+ * @property {number} queued
+ * @property {number} maxConcurrent
+ * @property {number} maxQueued
+ * @property {number} cpu
+ * @property {number} memory
+ * @property {string} reason
+ *
+ * @typedef {Object} SqliteFiles
+ * @property {number} total
+ * @property {number} stale
+ * @property {number} bytes
+ * @property {Array<{name: string, bytes: number, mtimeMs: number}>} recent
+ *
+ * @typedef {Object} ShardSummary
+ * @property {number} schemaVersion
+ * @property {string} generatedAt
+ * @property {string|null} runId
+ * @property {Object} totals
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export const SQLITE_PREFIX = 'caia-test-';
+export const STALE_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Synchronously scan `dir` for SQLite test files and summarise them.
+ * Resilient: missing dir → empty result. Caller may pass `now` to
+ * simulate the time reference (used by tests).
+ *
+ * @param {string} dir
+ * @param {number} [now]
+ * @returns {SqliteFiles}
+ */
+export function scanSqliteFiles(dir, now = Date.now()) {
+  const empty = { total: 0, stale: 0, bytes: 0, recent: [] };
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return empty;
+  }
+  const matches = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.startsWith(SQLITE_PREFIX)) continue;
+    if (entry.name.endsWith('-wal') || entry.name.endsWith('-shm')) continue;
+    let stat;
+    try {
+      stat = fs.statSync(path.join(dir, entry.name));
+    } catch {
+      continue;
+    }
+    matches.push({
+      name: entry.name,
+      bytes: stat.size,
+      mtimeMs: stat.mtimeMs,
+      stale: now - stat.mtimeMs >= STALE_AGE_MS,
+    });
+  }
+  matches.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return {
+    total: matches.length,
+    stale: matches.filter((m) => m.stale).length,
+    bytes: matches.reduce((sum, m) => sum + m.bytes, 0),
+    recent: matches.slice(0, 10).map((m) => ({
+      name: m.name,
+      bytes: m.bytes,
+      mtimeMs: m.mtimeMs,
+    })),
+  };
+}
+
+/**
+ * Read the FIX-012 shard summary from disk.
+ *
+ * @param {string|null|undefined} summaryPath
+ * @returns {ShardSummary|null}
+ */
+export function readShardSummary(summaryPath) {
+  if (!summaryPath) return null;
+  try {
+    const raw = fs.readFileSync(summaryPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} httpEndpoint
+ * @param {string} token
+ * @returns {string}
+ */
+export function buildPressureUrl(httpEndpoint, token) {
+  return `${httpEndpoint.replace(/\/+$/, '')}/pressure?token=${encodeURIComponent(token)}`;
+}
+
+/**
+ * Validate the structure of a Browserless /pressure response. Accepts
+ * the v2 wrapped shape (`{ pressure: { ... } }`) or a bare object
+ * (forward-compat).
+ *
+ * @param {unknown} body
+ * @returns {BrowserlessPressure|null}
+ */
+export function extractPressure(body) {
+  if (!body || typeof body !== 'object') return null;
+  const candidate = 'pressure' in body ? body.pressure : body;
+  if (!candidate || typeof candidate !== 'object') return null;
+  const isAvailable = candidate.isAvailable;
+  const running = candidate.running;
+  const queued = candidate.queued ?? candidate.queue;
+  const maxConcurrent = candidate.maxConcurrent;
+  const maxQueued = candidate.maxQueued;
+  const cpu = candidate.cpu;
+  const memory = candidate.memory;
+  const reason = candidate.reason;
+  if (
+    typeof isAvailable !== 'boolean'
+    || typeof running !== 'number'
+    || typeof maxConcurrent !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    isAvailable,
+    running,
+    queued: typeof queued === 'number' ? queued : 0,
+    maxConcurrent,
+    maxQueued: typeof maxQueued === 'number' ? maxQueued : 0,
+    cpu: typeof cpu === 'number' ? cpu : 0,
+    memory: typeof memory === 'number' ? memory : 0,
+    reason: typeof reason === 'string' ? reason : '',
+  };
+}

--- a/apps/dashboard/app/api/test-isolation/lib.test.mjs
+++ b/apps/dashboard/app/api/test-isolation/lib.test.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Self-contained node test for the test-isolation route helpers.
+ * Plain `node:assert` — the dashboard has no vitest harness.
+ *
+ * Usage:
+ *   node apps/dashboard/app/api/test-isolation/lib.test.mjs
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as assert from 'node:assert/strict';
+import {
+  scanSqliteFiles,
+  readShardSummary,
+  buildPressureUrl,
+  extractPressure,
+  SQLITE_PREFIX,
+} from './lib.mjs';
+
+let passed = 0;
+let failed = 0;
+async function test(name, fn) {
+  process.stdout.write(`- ${name} ... `);
+  try {
+    await fn();
+    passed += 1;
+    process.stdout.write('ok\n');
+  } catch (err) {
+    failed += 1;
+    process.stdout.write(`FAIL: ${err.message}\n`);
+    if (process.env.DEBUG) console.error(err);
+  }
+}
+
+await test('SQLITE_PREFIX is exported', () => {
+  assert.equal(SQLITE_PREFIX, 'caia-test-');
+});
+
+await test('scanSqliteFiles: empty dir → empty result', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'scan-empty-'));
+  try {
+    const r = scanSqliteFiles(dir);
+    assert.equal(r.total, 0);
+    assert.equal(r.bytes, 0);
+    assert.deepEqual(r.recent, []);
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('scanSqliteFiles: missing dir → empty result, no throw', () => {
+  const r = scanSqliteFiles('/nonexistent/path/xyz');
+  assert.equal(r.total, 0);
+});
+
+await test('scanSqliteFiles: counts matching files, ignores prefix mismatches', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'scan-mix-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'caia-test-aaa.sqlite'), 'x'.repeat(100));
+    fs.writeFileSync(path.join(dir, 'caia-test-bbb.sqlite'), 'x'.repeat(200));
+    fs.writeFileSync(path.join(dir, 'unrelated.sqlite'), 'x'.repeat(50));
+    const r = scanSqliteFiles(dir);
+    assert.equal(r.total, 2);
+    assert.equal(r.bytes, 300);
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('scanSqliteFiles: ignores -wal and -shm sidecars', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'scan-wal-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'caia-test-x.sqlite'), 'x');
+    fs.writeFileSync(path.join(dir, 'caia-test-x.sqlite-wal'), 'w');
+    fs.writeFileSync(path.join(dir, 'caia-test-x.sqlite-shm'), 's');
+    const r = scanSqliteFiles(dir);
+    assert.equal(r.total, 1);
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('scanSqliteFiles: marks files older than 1h as stale', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'scan-stale-'));
+  try {
+    const stale = path.join(dir, 'caia-test-stale.sqlite');
+    fs.writeFileSync(stale, 'x');
+    const old = (Date.now() - 2 * 60 * 60 * 1000) / 1000;
+    fs.utimesSync(stale, old, old);
+    fs.writeFileSync(path.join(dir, 'caia-test-fresh.sqlite'), 'y');
+    const r = scanSqliteFiles(dir);
+    assert.equal(r.total, 2);
+    assert.equal(r.stale, 1);
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('scanSqliteFiles: caps recent[] at 10 entries, sorted newest-first', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'scan-many-'));
+  try {
+    for (let i = 0; i < 15; i++) {
+      const f = path.join(dir, `caia-test-${i}.sqlite`);
+      fs.writeFileSync(f, 'x');
+      const t = (Date.now() - i * 1000) / 1000;
+      fs.utimesSync(f, t, t);
+    }
+    const r = scanSqliteFiles(dir);
+    assert.equal(r.total, 15);
+    assert.equal(r.recent.length, 10);
+    for (let i = 1; i < r.recent.length; i++) {
+      assert.ok(r.recent[i - 1].mtimeMs >= r.recent[i].mtimeMs);
+    }
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('readShardSummary: missing path → null', () => {
+  assert.equal(readShardSummary(null), null);
+  assert.equal(readShardSummary(''), null);
+  assert.equal(readShardSummary('/nonexistent/path.json'), null);
+});
+
+await test('readShardSummary: parses valid JSON', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'shard-'));
+  try {
+    const p = path.join(dir, 's.json');
+    const obj = { schemaVersion: 1, generatedAt: 'x', runId: '1', totals: {} };
+    fs.writeFileSync(p, JSON.stringify(obj));
+    const r = readShardSummary(p);
+    assert.equal(r.schemaVersion, 1);
+    assert.equal(r.runId, '1');
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('readShardSummary: invalid JSON → null', async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'shard-bad-'));
+  try {
+    const p = path.join(dir, 'bad.json');
+    fs.writeFileSync(p, 'not json {{{');
+    assert.equal(readShardSummary(p), null);
+  } finally {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  }
+});
+
+await test('buildPressureUrl: token urlencoded; trailing slash stripped', () => {
+  assert.equal(buildPressureUrl('http://h:1', 'tok'), 'http://h:1/pressure?token=tok');
+  assert.equal(buildPressureUrl('http://h:1/', 'tok'), 'http://h:1/pressure?token=tok');
+  assert.equal(buildPressureUrl('http://h:1', 'a/b+c'), 'http://h:1/pressure?token=a%2Fb%2Bc');
+});
+
+await test('extractPressure: returns null for missing required fields', () => {
+  assert.equal(extractPressure(null), null);
+  assert.equal(extractPressure({}), null);
+  assert.equal(extractPressure({ pressure: {} }), null);
+  assert.equal(extractPressure({ pressure: { isAvailable: true, maxConcurrent: 30 } }), null);
+});
+
+await test('extractPressure: accepts v2 wrapped shape', () => {
+  const r = extractPressure({
+    pressure: {
+      isAvailable: true, running: 4, queued: 1, maxConcurrent: 30,
+      maxQueued: 20, cpu: 12, memory: 50, reason: '',
+    },
+  });
+  assert.equal(r.running, 4);
+  assert.equal(r.queued, 1);
+  assert.equal(r.cpu, 12);
+});
+
+await test('extractPressure: falls through to bare shape (forward-compat)', () => {
+  const r = extractPressure({
+    isAvailable: false, running: 30, maxConcurrent: 30, queued: 5,
+  });
+  assert.equal(r.isAvailable, false);
+  assert.equal(r.running, 30);
+  assert.equal(r.queued, 5);
+});
+
+await test('extractPressure: defaults missing optional fields', () => {
+  const r = extractPressure({
+    pressure: { isAvailable: true, running: 0, maxConcurrent: 30 },
+  });
+  assert.equal(r.queued, 0);
+  assert.equal(r.cpu, 0);
+  assert.equal(r.memory, 0);
+  assert.equal(r.reason, '');
+});
+
+console.log();
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/apps/dashboard/app/api/test-isolation/route.ts
+++ b/apps/dashboard/app/api/test-isolation/route.ts
@@ -1,0 +1,71 @@
+/**
+ * /api/test-isolation
+ *
+ * Returns a snapshot of per-test resource usage for the FIX-013
+ * dashboard panel:
+ *
+ *   - Browserless concurrency: GET ${BROWSERLESS_HTTP}/pressure
+ *   - SQLite test files:       fs.readdir(${tmpdir}) filtered by prefix
+ *   - Allocated test ports:    @chiefaia/test-isolation/ports state
+ *
+ * The dashboard is the ONLY caller. Auth is handled at the dashboard's
+ * own session boundary; this route is gated by the same Next.js
+ * middleware as the rest of `/api/**` (no extra ACL needed here).
+ *
+ * Failure semantics:
+ *   - Each data source is best-effort. If Browserless is unreachable
+ *     we return null in the `browserless` field rather than 5xx-ing
+ *     the whole route. Same for the filesystem scan.
+ *
+ * Pure helpers live in ./lib.mjs so they can be unit-tested without
+ * a TS compile step (the dashboard has no vitest harness).
+ */
+
+import { NextResponse } from 'next/server';
+import * as os from 'node:os';
+import {
+  buildPressureUrl,
+  extractPressure,
+  readShardSummary,
+  scanSqliteFiles,
+} from './lib.mjs';
+
+const BROWSERLESS_HTTP = process.env['BROWSERLESS_HTTP_ENDPOINT']
+  ?? 'http://127.0.0.1:13000';
+const BROWSERLESS_TOKEN = process.env['BROWSERLESS_TOKEN'] ?? '';
+const SHARD_SUMMARY_PATH = process.env['SHARD_SUMMARY_PATH'] ?? '';
+
+export async function GET() {
+  const [browserless, sqlite, lastShardSummary] = await Promise.all([
+    fetchBrowserlessPressure(),
+    Promise.resolve(scanSqliteFiles(os.tmpdir())),
+    Promise.resolve(readShardSummary(SHARD_SUMMARY_PATH || null)),
+  ]);
+
+  return NextResponse.json({
+    generatedAt: new Date().toISOString(),
+    browserless,
+    sqlite,
+    ports: { inProcess: null },
+    lastShardSummary,
+  });
+}
+
+async function fetchBrowserlessPressure() {
+  if (!BROWSERLESS_TOKEN) return null;
+  try {
+    const url = buildPressureUrl(BROWSERLESS_HTTP, BROWSERLESS_TOKEN);
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 3_000);
+    try {
+      const res = await fetch(url, { signal: ctrl.signal, cache: 'no-store' });
+      if (!res.ok) return null;
+      const body = await res.json();
+      return extractPressure(body);
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/app/test-isolation/page.tsx
+++ b/apps/dashboard/app/test-isolation/page.tsx
@@ -1,0 +1,258 @@
+/**
+ * /test-isolation — FIX-013 dashboard panel.
+ *
+ * Renders the per-test resource usage snapshot from
+ * /api/test-isolation. Refreshes every 5s in the foreground; pauses
+ * when the tab is hidden (Page Visibility API).
+ *
+ * Why a dedicated page (not a card on /metrics):
+ *   - Test-infra ops want a single URL to point at when something
+ *     looks off ("the runner is slow today" — open this page first).
+ *   - The shard breakdown table can grow long; better its own viewport.
+ */
+
+'use client';
+import { useEffect, useState } from 'react';
+
+interface TestIsolationSnapshot {
+  generatedAt: string;
+  browserless: {
+    isAvailable: boolean;
+    running: number;
+    queued: number;
+    maxConcurrent: number;
+    maxQueued: number;
+    cpu: number;
+    memory: number;
+    reason: string;
+  } | null;
+  sqlite: {
+    total: number;
+    stale: number;
+    bytes: number;
+    recent: Array<{ name: string; bytes: number; mtimeMs: number }>;
+  };
+  ports: { inProcess: number[] | null };
+  lastShardSummary: {
+    schemaVersion: number;
+    generatedAt: string;
+    runId: string | null;
+    totals: {
+      passed: number;
+      failed: number;
+      skipped: number;
+      flaky: number;
+      durationMs: number;
+      shardCount: number;
+      unknownShards: number;
+    };
+  } | null;
+}
+
+const REFRESH_MS = 5_000;
+
+export default function TestIsolationPage() {
+  const [snap, setSnap] = useState<TestIsolationSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/test-isolation', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as TestIsolationSnapshot;
+        if (!cancelled) {
+          setSnap(json);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message);
+      } finally {
+        if (!cancelled && document.visibilityState === 'visible') {
+          timer = setTimeout(load, REFRESH_MS);
+        }
+      }
+    }
+
+    function onVisibility() {
+      if (document.visibilityState === 'visible' && !timer) {
+        load();
+      }
+    }
+
+    load();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, []);
+
+  return (
+    <div style={{ padding: 24, color: '#e2e8f0' }}>
+      <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: '#f0f4f8', marginBottom: 16 }}>
+        🧪 Test isolation
+      </h1>
+      {error ? (
+        <Banner color="#fc8181">Error fetching snapshot: {error}</Banner>
+      ) : null}
+      {!snap ? (
+        <p style={{ color: '#a0aec0' }}>Loading...</p>
+      ) : (
+        <>
+          <BrowserlessCard pressure={snap.browserless} />
+          <SqliteCard sqlite={snap.sqlite} />
+          <ShardSummaryCard summary={snap.lastShardSummary} />
+          <Footer generatedAt={snap.generatedAt} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function BrowserlessCard({ pressure }: { pressure: TestIsolationSnapshot['browserless'] }) {
+  return (
+    <Card title="Browserless (FIX-007)">
+      {pressure === null ? (
+        <p style={{ color: '#a0aec0', margin: 0 }}>
+          Unreachable. Is the container up? Check{' '}
+          <code style={{ background: '#2d3748', padding: '2px 4px', borderRadius: 3 }}>
+            ssh stolution &apos;docker logs stolution-browserless&apos;
+          </code>
+          .
+        </p>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+          <Stat
+            label="Active"
+            value={`${pressure.running} / ${pressure.maxConcurrent}`}
+            warn={pressure.running >= pressure.maxConcurrent * 0.9}
+          />
+          <Stat label="Queued" value={`${pressure.queued} / ${pressure.maxQueued}`} warn={pressure.queued > 0} />
+          <Stat label="CPU" value={`${pressure.cpu}%`} warn={pressure.cpu > 80} />
+          <Stat label="Memory" value={`${pressure.memory}%`} warn={pressure.memory > 80} />
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function SqliteCard({ sqlite }: { sqlite: TestIsolationSnapshot['sqlite'] }) {
+  return (
+    <Card title="Per-test SQLite files (FIX-008)">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 12 }}>
+        <Stat label="Total" value={String(sqlite.total)} />
+        <Stat label="Stale (>1h)" value={String(sqlite.stale)} warn={sqlite.stale > 0} />
+        <Stat label="Disk usage" value={formatBytes(sqlite.bytes)} />
+      </div>
+      {sqlite.recent.length > 0 ? (
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+          <thead>
+            <tr style={{ textAlign: 'left', color: '#a0aec0' }}>
+              <th style={{ padding: 6 }}>file</th>
+              <th style={{ padding: 6 }}>size</th>
+              <th style={{ padding: 6 }}>mtime</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sqlite.recent.map((row) => (
+              <tr key={row.name} style={{ borderTop: '1px solid #2d3748' }}>
+                <td style={{ padding: 6, fontFamily: 'monospace' }}>{row.name}</td>
+                <td style={{ padding: 6 }}>{formatBytes(row.bytes)}</td>
+                <td style={{ padding: 6 }}>{new Date(row.mtimeMs).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p style={{ color: '#718096', margin: 0, fontStyle: 'italic' }}>(no test DB files in tmpdir)</p>
+      )}
+    </Card>
+  );
+}
+
+function ShardSummaryCard({ summary }: { summary: TestIsolationSnapshot['lastShardSummary'] }) {
+  if (!summary) {
+    return (
+      <Card title="Last shard run (FIX-012)">
+        <p style={{ color: '#a0aec0', margin: 0 }}>
+          No <code>shard-summary.json</code> on disk yet. The merge job uploads
+          it as an artifact; populate <code>SHARD_SUMMARY_PATH</code> to point
+          this panel at the latest copy.
+        </p>
+      </Card>
+    );
+  }
+  const { totals } = summary;
+  const ok = totals.failed === 0;
+  return (
+    <Card title="Last shard run (FIX-012)">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 16 }}>
+        <Stat label="Passed" value={String(totals.passed)} />
+        <Stat label="Failed" value={String(totals.failed)} warn={!ok} />
+        <Stat label="Skipped" value={String(totals.skipped)} />
+        <Stat label="Flaky" value={String(totals.flaky)} warn={totals.flaky > 0} />
+        <Stat label="Duration" value={`${(totals.durationMs / 1000).toFixed(1)}s`} />
+      </div>
+      <p style={{ color: '#a0aec0', fontSize: 11, marginTop: 12, marginBottom: 0 }}>
+        {totals.shardCount} shards · run id {summary.runId ?? 'unknown'} · generated {summary.generatedAt}
+        {totals.unknownShards > 0 ? ` · ${totals.unknownShards} unknown` : ''}
+      </p>
+    </Card>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section
+      style={{
+        background: '#1a202c',
+        border: '1px solid #2d3748',
+        borderRadius: 6,
+        padding: 16,
+        marginBottom: 16,
+      }}
+    >
+      <h2 style={{ margin: 0, marginBottom: 12, fontSize: 14, fontWeight: 600, color: '#cbd5e0' }}>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Stat({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: '#a0aec0', marginBottom: 4, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 600, color: warn ? '#fc8181' : '#f0f4f8' }}>{value}</div>
+    </div>
+  );
+}
+
+function Banner({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <div style={{ background: '#1a202c', border: `1px solid ${color}`, color, padding: 8, borderRadius: 4, marginBottom: 12 }}>
+      {children}
+    </div>
+  );
+}
+
+function Footer({ generatedAt }: { generatedAt: string }) {
+  return (
+    <p style={{ color: '#718096', fontSize: 11, marginTop: 24 }}>
+      Snapshot generated {generatedAt} · refreshes every {REFRESH_MS / 1000}s while tab is visible
+    </p>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}

--- a/docs/test-isolation-runbook.md
+++ b/docs/test-isolation-runbook.md
@@ -1,0 +1,194 @@
+# Test Isolation Runbook (FIX-013)
+
+> Phase B testing infrastructure operator guide. Companion to
+> `reports/testing-framework-architecture-2026-04-28.md` (the design
+> doc) and `infra/browserless/README.md` (the Browserless deployment
+> runbook).
+
+## What this document covers
+
+How to operate the parallel-safe testing infrastructure that ships with
+FIX-007 through FIX-012:
+
+| Layer | What | Where to look |
+|---|---|---|
+| Browser farm | Self-hosted Browserless on stolution | `infra/browserless/` (FIX-007) |
+| Per-test SQLite | Throwaway DB per test | `packages/test-isolation/sqlite` (FIX-008) |
+| Per-test ports | Hash-based port allocator | `packages/test-isolation/ports` (FIX-009) |
+| Local Playwright | 3-5 worker headless Chromium | `packages/playwright-config` (FIX-010) |
+| Browserless pool | Connection reuse + retry | `packages/playwright-config/pool` (FIX-011) |
+| Sharded CI | Self-hosted GH Actions matrix | `.github/workflows/fix-it-sharded-tests.yml` (FIX-012) |
+| Observability | Live dashboard panel | `/test-isolation` page (FIX-013, this PR) |
+
+## The full picture
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Developer M1 Pro (16 GB)                                   │
+│ ├─ pnpm test                                               │
+│ │   ├─ vitest workers                                      │
+│ │   │   ├─ each test: createTestDb() → /tmp/caia-test-*    │
+│ │   │   └─ each test: allocateTestPort() → 30000-34999     │
+│ │   └─ playwright workers (3 default; 5 on 32 GB)          │
+│ │       └─ headless Chromium pinned 1.58.2                 │
+│ └─ orchestrator + dashboard (per-test isolated)            │
+└────────────────────────────────────────────────────────────┘
+                       ↓ git push
+┌────────────────────────────────────────────────────────────┐
+│ GitHub Actions                                              │
+│ ├─ Job: prepare      (github-hosted; emits shard matrix)   │
+│ ├─ Job: shard 1..N   (self-hosted on stolution)            │
+│ │   ├─ pnpm install --frozen-lockfile                      │
+│ │   ├─ pnpm exec playwright test --shard=i/N --reporter=blob │
+│ │   └─ env: BROWSERLESS_WS_ENDPOINT=ws://127.0.0.1:13000/...│
+│ │          BROWSERLESS_TOKEN=${{ secrets.BROWSERLESS_TOKEN }} │
+│ └─ Job: merge        (downloads blobs, emits HTML + JSON)   │
+└────────────────────────────────────────────────────────────┘
+                       ↓ shard worker
+┌────────────────────────────────────────────────────────────┐
+│ Stolution remote (32 cores, 256 GB, Docker)                │
+│ ├─ stolution-browserless (30 concurrent sessions)          │
+│ │   image ghcr.io/browserless/chromium:v2.40.0             │
+│ │   bound 127.0.0.1:13000 → container :3000                │
+│ ├─ self-hosted GH Actions runner (singleton today)         │
+│ │   matrix-spawned shards talk to Browserless over docker0 │
+│ └─ Vault (BROWSERLESS_TOKEN at secret/stolution/prod/browserless) │
+└────────────────────────────────────────────────────────────┘
+```
+
+## The four guarantees
+
+The infrastructure provides four invariants that, taken together,
+eliminate the entire class of "passes locally, fails in CI" bugs:
+
+1. **Each test gets its own DB.** No cross-test data leakage; no
+   shared schema drift; failed migrations fail the test, not
+   subsequent tests.
+2. **Each test gets its own port range.** Hash-derived starting
+   offset + forward probe + EADDRINUSE recovery — no parallel
+   collisions.
+3. **Each test gets its own browser context.** `KEEP_ALIVE=false` on
+   Browserless, fresh `browser.newContext()` per spec; no
+   cookie/storage carryover.
+4. **Each test gets the same Chromium build everywhere.** Local pin
+   1.58.2; Browserless image ships 1.58.2; mismatch fails CI rather
+   than silently producing different results.
+
+## Operational surface
+
+### Health checks (in order of utility)
+
+| What | Command | When to use |
+|---|---|---|
+| Dashboard panel | Open `https://<dashboard>/test-isolation` | First stop for any "tests are slow / flaky" report |
+| Browserless pressure | `ssh stolution 'curl -s http://127.0.0.1:13000/pressure?token=$(grep BROWSERLESS_TOKEN ~/stolution/.env.browserless \| cut -d= -f2)'` | Confirms farm is up, not saturated |
+| Browserless logs | `ssh stolution 'docker logs --tail 100 stolution-browserless'` | Crashes, OOMs, version mismatches |
+| Self-hosted runner | `ssh stolution 'systemctl --user status actions.runner.*'` | Job stuck in "queued" |
+| Stale SQLite files | `ssh stolution 'find /tmp -name "caia-test-*.sqlite" -mmin +60 \| wc -l'` | A killed runner left junk |
+| GH Actions logs | `gh run list --workflow fix-it-sharded-tests.yml -L 5` | "Why did this PR fail?" |
+
+### Common scenarios
+
+**Tests are flaky on CI but pass locally.**
+
+1. Check the dashboard `/test-isolation` panel. Is Browserless `running` near `maxConcurrent`? You're queueing.
+   - Short-term: rerun the failed shard.
+   - Long-term: raise `CONCURRENT` in the Browserless compose file (FIX-007 runbook has the procedure).
+2. Check `playwright-html-report` for the failed test's trace. Look for `Target page, context or browser has been closed` — that's a transient remote crash. The pool retries once; if it's still failing you may have an actual bug.
+3. Check the version pin: local Playwright + remote Browserless must match minor version.
+
+**A shard's job is stuck.**
+
+1. `gh run view <run-id>` to see which shard.
+2. `ssh stolution 'docker ps'` — confirm the runner container is alive (or systemd if not containerised).
+3. If the runner is dead, restart it:
+   ```bash
+   ssh stolution
+   cd ~/actions-runner
+   ./svc.sh stop
+   ./svc.sh start
+   ```
+4. Re-trigger the failed run via the GH UI; the matrix will re-fan out.
+
+**Disk pressure on stolution.**
+
+```bash
+ssh stolution
+# Stale test DBs left by killed runners.
+find /tmp -name 'caia-test-*.sqlite*' -mmin +60 -delete
+# Browserless leaks /tmp profiles on container crashes.
+docker exec stolution-browserless rm -rf /tmp/playwright-* /tmp/.org.chromium.*
+# Docker logs (50m × 5 ⇒ 250m max per container, but be safe):
+docker system prune -f
+```
+
+The dashboard `/test-isolation` panel calls these out in real time —
+look for the `Stale (>1h)` stat under "Per-test SQLite files".
+
+**Browserless reports `isAvailable: false`.**
+
+The pressure endpoint sets this when the farm is at saturation
+(`running >= maxConcurrent` and `queued >= maxQueued`). The Fix-It
+runner backs off and retries via the FIX-011 pool's transient-error
+classifier.
+
+If `isAvailable=false` persists for >10 minutes:
+- Check `docker logs --tail 500 stolution-browserless` for OOMs.
+- Bump `shm_size` in `infra/browserless/docker-compose.yml` to 4 GB.
+- Restart: `cd ~/stolution && docker compose -f docker-compose.browserless.yml up -d`.
+
+**Token rotation.**
+
+```bash
+ssh stolution
+ROLE_ID=$(grep ^ROLE_ID= ~/.stolution-vault/claude-orchestrator-approle.env | cut -d= -f2 | tr -d '[:space:]')
+SECRET_ID=$(grep ^SECRET_ID= ~/.stolution-vault/claude-orchestrator-approle.env | cut -d= -f2 | tr -d '[:space:]')
+ADMIN=$(cat ~/.stolution-vault/vault-admin-token.txt)
+NEW=$(openssl rand -hex 32)
+docker exec -e VAULT_TOKEN="$ADMIN" stolution-vault \
+  vault kv put secret/stolution/prod/browserless token="$NEW"
+exit
+# From workstation:
+cd ~/Documents/projects/caia
+./infra/browserless/scripts/deploy-browserless.sh
+gh secret set BROWSERLESS_TOKEN --body "$NEW"
+```
+
+In-flight CI runs retry through the FIX-012 shard aggregator.
+
+## The dashboard panel
+
+`/test-isolation` (this PR) shows:
+
+- **Browserless** (FIX-007): active sessions / max, queue depth, CPU,
+  memory. Warns red at 90% utilisation.
+- **Per-test SQLite files** (FIX-008): total count, stale count,
+  total bytes, recent file table.
+- **Last shard run** (FIX-012): pass/fail/skip/flaky counts from
+  `shard-summary.json`. Populates when the dashboard is run with
+  `SHARD_SUMMARY_PATH=…/shard-summary.json`.
+
+Refreshes every 5 s while the tab is visible (Page Visibility API
+pauses on hidden tabs to save backend load).
+
+## Configuration env
+
+| Var | Read by | Purpose |
+|---|---|---|
+| `BROWSERLESS_WS_ENDPOINT` | `@chiefaia/playwright-config` | Flips the config factory + pool to remote mode |
+| `BROWSERLESS_TOKEN` | playwright-config, dashboard, healthchecks | Auth |
+| `BROWSERLESS_HTTP_ENDPOINT` | dashboard `/api/test-isolation` | HTTP base for the pressure call (defaults to loopback) |
+| `PLAYWRIGHT_LOCAL_WORKERS` | playwright-config | Override the default 3 workers locally |
+| `PLAYWRIGHT_SKIP_BROWSER_INSTALL` | playwright-config postinstall | Skip the postinstall download |
+| `CHIEFAIA_SKIP_PLAYWRIGHT_INSTALL` | playwright-config postinstall | Same; CI-friendly name |
+| `SHARD_SUMMARY_PATH` | dashboard `/api/test-isolation` | Where to read FIX-012's per-run aggregate |
+| `SHARD_INDEX`, `SHARD_TOTAL` | FIX-012 shard env | Wiring for `--shard X/Y` |
+
+## Related work
+
+- **TEST-101..104** (Phase B Test Runner Agent specs) — to be picked up
+  when worker pool capacity arrives. Will consume FIX-007..013 as the
+  execution substrate.
+- **FIX-001..006** (Fix-It Test Agent itself, parallel track) — the
+  consumer for all of this. Once both tracks land, the agent uses the
+  infrastructure automatically.


### PR DESCRIPTION
## What

Final piece of the FIX-007..013 infrastructure track.

1. **`docs/test-isolation-runbook.md`** — comprehensive operator
   guide. Architecture diagram covering FIX-007..012, the four
   guarantees (per-test DB / port / browser / version), health-check
   commands ranked by utility, six common scenarios with
   step-by-step fixes (flaky CI, stuck shard, disk pressure,
   saturation, version-pin mismatch, token rotation), config env-var
   index.

2. **`/test-isolation` dashboard panel** — three cards refreshing
   every 5 s:
   - **Browserless**: active/max, queue, CPU, memory; warns red at
     90% utilisation
   - **Per-test SQLite**: total / stale (>1h) / disk usage / recent
     files table
   - **Last shard run**: pass/fail/skip/flaky/duration from
     `shard-summary.json` (FIX-012)

   Pauses refresh on hidden tabs (Page Visibility API).

3. **`/api/test-isolation`** — best-effort snapshot endpoint:
   - Browserless `/pressure` (3 s timeout; null on unreachable)
   - `os.tmpdir()` scan for `caia-test-*.sqlite`
   - Optional `shard-summary.json` from `SHARD_SUMMARY_PATH`

   Pure helpers extracted to `lib.mjs` so they're testable without a
   TS compiler.

## DoD

- **Unit tests:** `lib.test.mjs` runs **15/15** plain-node
  assertions against the helpers — empty/missing dir, prefix
  matching, WAL/SHM exclusion, stale-file detection, recent[] cap +
  sort, JSON parse + invalid handling, URL encoding, pressure
  extraction for v2-wrapped + bare shapes, default fields.
- **Typecheck:** `apps/dashboard` `tsc --noEmit` passes.
- **CI green:** lib.test.mjs is plain Node so it runs in any CI
  matrix without extra harness.
- **Docs:** the runbook itself.
- **Changeset:** `.changeset/fix-013-test-isolation-runbook.md`
  (patch).

## Track summary

With FIX-007..013 all merged, the parallel-safe testing
infrastructure is complete:

| | What | Status |
|---|---|---|
| FIX-007 | Browserless on stolution | merged-ready (#160) |
| FIX-008 | Per-test SQLite | merged-ready (#164) |
| FIX-009 | Per-test ports | merged-ready (#170) |
| FIX-010 | Local Playwright workers | merged-ready (#172) |
| FIX-011 | Browserless integration in Fix-It | merged-ready (#179) |
| FIX-012 | Sharded CI | merged-ready (#180) |
| FIX-013 | Runbook + dashboard panel | this PR |

Once FIX-001..006 (Fix-It Test Agent itself, parallel track) lands,
the agent consumes everything below it automatically.

Closes FIX-013.
