### PR TITLE
ci(gitflow): add gitflow-conformance required check (L5/bootstrap)

### DIFF
--- a/.github/workflows/gitflow-conformance.yml
+++ b/.github/workflows/gitflow-conformance.yml
@@ -1,0 +1,109 @@
+name: gitflow-conformance
+
+# Required status check on every PR. Enforces the canonical CAIA git flow:
+#
+#   feature/<id>-<slug>  →  PR to develop  →  squash-merge  →  branch deleted
+#   develop              →  release/<date> PR to main       →  merge → tag
+#   main                 ←  only develop or release/* may merge in
+#   backup/<reason>      ←  preservation only, never merged
+#
+# Reference: caia/docs/git-flow.md and feedback_git_flow_enforced.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: gitflow-conformance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  conformance:
+    name: gitflow-conformance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name + target
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          echo "head=${HEAD_REF}"
+          echo "base=${BASE_REF}"
+
+          fail() {
+            echo "::error::gitflow-conformance: $1"
+            echo "::error::fix: $2"
+            exit 1
+          }
+
+          # Rule 1: backup/* branches are preservation-only, never merged.
+          if [[ "${HEAD_REF}" == backup/* ]]; then
+            fail "backup/* branches must never be merged (head=${HEAD_REF})." \
+                 "close this PR; cherry-pick to a feature/ branch if you need the work."
+          fi
+
+          # Rule 2: target=main only allowed from develop or release/*.
+          if [[ "${BASE_REF}" == "main" ]]; then
+            if [[ "${HEAD_REF}" != "develop" && "${HEAD_REF}" != release/* ]]; then
+              fail "PRs to main must come from 'develop' or 'release/*' (got head=${HEAD_REF})." \
+                   "retarget this PR to develop, then ship to main via a release/<date> PR."
+            fi
+            echo "✓ target=main from ${HEAD_REF} — allowed."
+            exit 0
+          fi
+
+          # Rule 3: target=develop allowed from feature/, fix/, chore/, or main (back-merge after release).
+          if [[ "${BASE_REF}" == "develop" ]]; then
+            case "${HEAD_REF}" in
+              feature/*|fix/*|chore/*|main)
+                echo "✓ target=develop from ${HEAD_REF} — allowed."
+                exit 0
+                ;;
+              *)
+                fail "PRs to develop must come from feature/<id>-<slug>, fix/<id>-<slug>, chore/<id>-<slug>, or main (back-merge). Got head=${HEAD_REF}." \
+                     "rename your branch: git branch -m feature/<id>-<slug>; force-push; then retarget the PR to develop."
+                ;;
+            esac
+          fi
+
+          # Rule 4: every other base ref is unsupported.
+          fail "PRs may only target 'main' or 'develop' (got base=${BASE_REF})." \
+               "retarget this PR to develop (the integration branch) or main (release only)."
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject merge commits in PR history
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          # back-merge from main into develop legitimately contains merges.
+          if [[ "${HEAD_REF}" == "main" && "${BASE_REF}" == "develop" ]]; then
+            echo "main → develop back-merge: skipping merge-commit check."
+            exit 0
+          fi
+          # release/* PRs may legitimately contain merges to main.
+          if [[ "${HEAD_REF}" == release/* ]]; then
+            echo "release/* → main: skipping merge-commit check."
+            exit 0
+          fi
+          MERGES=$(git log --merges "${BASE_SHA}..${HEAD_SHA}" --pretty=format:'%h %s' || true)
+          if [[ -n "${MERGES}" ]]; then
+            echo "::error::gitflow-conformance: branch contains merge commits — use rebase, not merge."
+            echo "::error::merge commits found:"
+            echo "${MERGES}" | sed 's/^/::error::  /'
+            echo "::error::fix: git fetch origin && git rebase origin/${BASE_REF} && git push --force-with-lease"
+            exit 1
+          fi
+          echo "✓ no merge commits in branch history — branch is rebased onto ${BASE_REF}."


### PR DESCRIPTION
**Layer 5** of the git-flow enforcement stack — the required PR-conformance check.

Validates every PR against the canonical CAIA flow:

\`\`\`
feature/<id>-<slug>  →  PR to develop  →  squash-merge  →  branch deleted
develop              →  release/<date> PR to main       →  merge → tag
main                 ←  only develop or release/* may merge in
backup/<reason>      ←  preservation only, never merged
\`\`\`

## What it enforces
- Branch name matches \`feature/\`, \`fix/\`, \`chore/\`, \`release/\`, or \`backup/\`.
- \`target=main\` only allowed from \`develop\` or \`release/*\`.
- \`target=develop\` only allowed from \`feature/\`, \`fix/\`, \`chore/\`, or \`main\` (back-merge).
- \`backup/*\` may never be merged.
- No merge commits in PR history (rebase, don't merge), except for legitimate back-merges and releases.

## Bootstrap note
This is the first of two bootstrap PRs landing via the OLD flow (PR-to-main). The conformance check itself **will report red on this PR** because head=feature/… → base=main is the very rule it forbids — that's expected. The check isn't yet a required gate (PR2 turns it on), so this PR can land. Every subsequent PR follows the new flow: feature → develop → release → main.

## Reference
- Standing rules: \`agent/memory/feedback_git_flow_enforced.md\`
- DoD item 14: \`agent/memory/feedback_definition_of_done.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated validation for repository management to ensure code organization and commit history consistency across branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->