### PR TITLE
build(husky): client-side guards on main/develop commits + pushes (L6)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+# Git-flow guard: never commit directly to main or develop.
+#
+# Reference: feedback_git_flow_enforced.md, caia/docs/git-flow.md.
+
+[ -n "$CI" ] && exit 0
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+
+case "${branch}" in
+  main|develop)
+    cat <<MSG >&2
+
+╭───────────────────────────────────────────────────────────────────╮
+│  ✗ git-flow: direct commit to '${branch}' is forbidden.
+│
+│  Use a feature branch instead:
+│
+│      pnpm flow start <id>-<slug>
+│
+│  Or manually:
+│
+│      git checkout -b feature/<id>-<slug> origin/develop
+│
+│  Reference: caia/docs/git-flow.md
+╰───────────────────────────────────────────────────────────────────╯
+MSG
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+
+# Git-flow guard: never push directly to main or develop, regardless of
+# what local branch we're on. The remote branch protection enforces this
+# server-side too; this hook surfaces the failure earlier with a clear
+# message.
+#
+# Reference: feedback_git_flow_enforced.md, caia/docs/git-flow.md.
+
+[ -n "$CI" ] && exit 0
+
+remote="$1"
+url="$2"
+
+# Stdin: <local_ref> <local_sha> <remote_ref> <remote_sha>
+zero='0000000000000000000000000000000000000000'
+violation=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "${remote_ref}" in
+    refs/heads/main|refs/heads/develop)
+      cat <<MSG >&2
+
+╭───────────────────────────────────────────────────────────────────╮
+│  ✗ git-flow: direct push to '${remote_ref##refs/heads/}' is forbidden.
+│
+│  All work merges through a PR:
+│
+│    feature/<id>-<slug>  →  PR to develop  →  squash-merge
+│    develop              →  release/<date> PR to main → merge
+│
+│  Use:
+│
+│      pnpm flow ready    # mark current PR ready for review
+│      pnpm flow ship     # squash-merge when CI green + delete branch
+│      pnpm flow release  # open release/<date> PR develop → main
+│
+│  Reference: caia/docs/git-flow.md
+╰───────────────────────────────────────────────────────────────────╯
+MSG
+      violation=1
+      ;;
+  esac
+done
+
+[ "${violation}" -eq 1 ] && exit 1
+exit 0


### PR DESCRIPTION
**Layer 6** — defence-in-depth client-side guards. Server-side branch protection already enforces the rule; the hook surfaces the failure earlier with a clear fix command.

## What changes
- \`.husky/pre-commit\` — blocks \`git commit\` on \`main\` or \`develop\`.
- \`.husky/pre-push\` — blocks \`git push\` to \`refs/heads/main\` or \`refs/heads/develop\` on any remote.

Both hooks are no-ops when \`CI=1\` so CI checkouts stay clean.

## Wiring
Husky 9 is already enabled via \`pnpm prepare\` in \`package.json\`. No package.json change required.

## Reference
- \`feedback_git_flow_enforced.md\`
- \`caia/docs/git-flow.md\` (lands in L8)