### PR TITLE
release(2026-04-29-conformance): expand gitflow-conformance prefix list

### DIFF
--- a/.github/workflows/gitflow-conformance.yml
+++ b/.github/workflows/gitflow-conformance.yml
@@ -2,10 +2,17 @@ name: gitflow-conformance
 
 # Required status check on every PR. Enforces the canonical CAIA git flow:
 #
-#   feature/<id>-<slug>  →  PR to develop  →  squash-merge  →  branch deleted
-#   develop              →  release/<date> PR to main       →  merge → tag
-#   main                 ←  only develop or release/* may merge in
-#   backup/<reason>      ←  preservation only, never merged
+#   <prefix>/<id>-<slug>  →  PR to develop  →  squash-merge  →  branch deleted
+#   develop               →  release/<date> PR to main       →  merge → tag
+#   main                  ←  only develop or release/* may merge in
+#   backup/<reason>       ←  preservation only, never merged
+#
+# Allowed feature-branch prefixes (target=develop):
+#   conventional commit:  feat, feature, fix, chore, docs, refactor,
+#                         perf, test, build, ci
+#   CAIA-specific:        harden, arch, acr, freg, bucket, lai, dash,
+#                         gate, phase2e, coding, taskmgr, val
+# Separator after the prefix may be '/' or '-' (legacy CAIA branches use '-').
 #
 # Reference: caia/docs/git-flow.md and feedback_git_flow_enforced.md.
 
@@ -41,6 +48,11 @@ jobs:
             exit 1
           }
 
+          # Canonical allowed-prefix regex (head branch must start with one
+          # of these, followed by '/' or '-'). Keep this in sync with
+          # scripts/caia-flow.sh and caia/docs/git-flow.md.
+          ALLOWED_PREFIX_RE='^(feat|feature|fix|chore|docs|refactor|perf|test|build|ci|harden|arch|acr|freg|bucket|lai|dash|gate|phase2e|coding|taskmgr|val)(/|-)'
+
           # Rule 1: backup/* branches are preservation-only, never merged.
           if [[ "${HEAD_REF}" == backup/* ]]; then
             fail "backup/* branches must never be merged (head=${HEAD_REF})." \
@@ -57,18 +69,19 @@ jobs:
             exit 0
           fi
 
-          # Rule 3: target=develop allowed from feature/, fix/, chore/, or main (back-merge after release).
+          # Rule 3: target=develop allowed from an approved prefix branch
+          # or from main (back-merge after release).
           if [[ "${BASE_REF}" == "develop" ]]; then
-            case "${HEAD_REF}" in
-              feature/*|fix/*|chore/*|main)
-                echo "✓ target=develop from ${HEAD_REF} — allowed."
-                exit 0
-                ;;
-              *)
-                fail "PRs to develop must come from feature/<id>-<slug>, fix/<id>-<slug>, chore/<id>-<slug>, or main (back-merge). Got head=${HEAD_REF}." \
-                     "rename your branch: git branch -m feature/<id>-<slug>; force-push; then retarget the PR to develop."
-                ;;
-            esac
+            if [[ "${HEAD_REF}" == "main" ]]; then
+              echo "✓ target=develop from main (back-merge) — allowed."
+              exit 0
+            fi
+            if [[ "${HEAD_REF}" =~ ${ALLOWED_PREFIX_RE} ]]; then
+              echo "✓ target=develop from ${HEAD_REF} — allowed."
+              exit 0
+            fi
+            fail "PRs to develop must come from an approved prefix branch (feat|feature|fix|chore|docs|refactor|perf|test|build|ci|harden|arch|acr|freg|bucket|lai|dash|gate|phase2e|coding|taskmgr|val) using '/' or '-' as separator, or from main (back-merge). Got head=${HEAD_REF}." \
+                 "rename your branch: git branch -m feat/<id>-<slug>; force-push; then retarget the PR to develop."
           fi
 
           # Rule 4: every other base ref is unsupported.

--- a/docs/git-flow.md
+++ b/docs/git-flow.md
@@ -6,9 +6,9 @@
 
 ```
                            ┌────────────────────────┐
-                           │ feature/<id>-<slug>    │ ◄── cut from origin/develop
-                           │ fix/<id>-<slug>        │     (never from main)
-                           │ chore/<id>-<slug>      │
+                           │ <prefix>/<id>-<slug>   │ ◄── cut from origin/develop
+                           │   (feat, fix, chore,   │     (never from main)
+                           │    arch, harden, …)    │
                            └─────────────┬──────────┘
                                          │ commit, push
                                          │
@@ -39,6 +39,27 @@
            backup/<reason>      preservation only — NEVER merged
 ```
 
+## Approved branch prefixes
+
+Every feature/fix/chore branch must start with one of these prefixes. The
+separator after the prefix may be `/` or `-` (legacy CAIA branches use `-`,
+new branches should prefer `/`).
+
+| Family                  | Prefixes                                                                |
+| ----------------------- | ----------------------------------------------------------------------- |
+| Conventional Commits    | `feat`, `feature`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci` |
+| CAIA work-stream        | `harden`, `arch`, `acr`, `freg`, `bucket`, `lai`, `dash`, `gate`, `phase2e`, `coding`, `taskmgr`, `val` |
+| Release / preservation  | `release/<date>` (PRs to main), `backup/<reason>` (preservation, never merged) |
+
+The canonical regex (server-side and client-side):
+
+```
+^(feat|feature|fix|chore|docs|refactor|perf|test|build|ci|harden|arch|acr|freg|bucket|lai|dash|gate|phase2e|coding|taskmgr|val)(/|-)
+```
+
+`feat/` is preferred (Conventional Commits); `feature/` is accepted for
+backward compatibility with the runbook examples.
+
 ## Lifecycle — the only allowed path
 
 ```
@@ -47,7 +68,7 @@ start  →  work  →  ready  →  ship  →  (release at end of day)
 
 | Step      | Command                          | What happens                                                                                                  |
 | --------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `start`   | `pnpm flow start <id>-<slug>`    | `git fetch origin develop && git checkout -b feature/<id>-<slug> origin/develop`                              |
+| `start`   | `pnpm flow start <id>-<slug>`    | `git fetch origin develop && git checkout -b <prefix>/<id>-<slug> origin/develop` (default prefix `feature/`) |
 | `work`    | edit, commit                     | Husky pre-commit blocks any commit on `main` or `develop`.                                                    |
 | `push`    | `git push`                       | Husky pre-push blocks any push to `main` or `develop`.                                                        |
 | `ready`   | `pnpm flow ready`                | Pushes the branch and opens (or marks ready) a PR vs `develop`.                                               |
@@ -59,15 +80,17 @@ start  →  work  →  ready  →  ship  →  (release at end of day)
 
 ## Branches
 
-| Prefix       | Cut from   | PRs into                                                       | Lifespan          | Notes                                                                |
-| ------------ | ---------- | -------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------- |
-| `feature/`   | `develop`  | `develop`                                                      | ≤ 24h ideal, 7d max | Where new work lives.                                                |
-| `fix/`       | `develop`  | `develop`                                                      | ≤ 24h            | Bug fixes; same lifecycle as feature.                                |
-| `chore/`     | `develop`  | `develop`                                                      | ≤ 24h            | Cleanup, refactors, doc-only.                                        |
-| `release/`   | `develop`  | `main`                                                         | hours            | Optional staged release PRs; tagged on merge.                        |
-| `backup/`    | anywhere   | (never)                                                        | forever           | Preservation only. Excluded from auto-PR + hygiene scanning.         |
-| `main`       | (release)  | (release)                                                      | forever           | Stable release branch. Server-side protected.                        |
-| `develop`    | (start)    | (release)                                                      | forever           | Integration branch. Server-side protected.                           |
+| Prefix                    | Cut from   | PRs into   | Lifespan          | Notes                                                                |
+| ------------------------- | ---------- | ---------- | ----------------- | -------------------------------------------------------------------- |
+| `feat/`, `feature/`       | `develop`  | `develop`  | ≤ 24h ideal, 7d max | New work. `feat/` is preferred (Conventional Commits).             |
+| `fix/`                    | `develop`  | `develop`  | ≤ 24h            | Bug fixes; same lifecycle as feature.                                |
+| `chore/`                  | `develop`  | `develop`  | ≤ 24h            | Cleanup, refactors, doc-only.                                        |
+| `docs/`, `refactor/`, `perf/`, `test/`, `build/`, `ci/` | `develop` | `develop` | ≤ 24h | Conventional Commits scopes — same lifecycle as feature. |
+| `harden/`, `arch/`, `acr/`, `freg/`, `bucket/`, `lai/`, `dash/`, `gate/`, `phase2e/`, `coding/`, `taskmgr/`, `val/` | `develop` | `develop` | ≤ 24h–7d | CAIA work-stream prefixes; legacy branches may use `-` separator. |
+| `release/`                | `develop`  | `main`     | hours            | Optional staged release PRs; tagged on merge.                        |
+| `backup/`                 | anywhere   | (never)    | forever           | Preservation only. Excluded from auto-PR + hygiene scanning.         |
+| `main`                    | (release)  | (release)  | forever           | Stable release branch. Server-side protected.                        |
+| `develop`                 | (start)    | (release)  | forever           | Integration branch. Server-side protected.                           |
 
 ## Mechanical enforcement layers
 
@@ -81,9 +104,9 @@ start  →  work  →  ready  →  ship  →  (release at end of day)
    Configured by [`scripts/setup-branch-protection.sh`](../scripts/setup-branch-protection.sh) — idempotent.
 
 2. **`gitflow-conformance` required check** ([`.github/workflows/gitflow-conformance.yml`](../.github/workflows/gitflow-conformance.yml)):
-   - Branch name matches `^(feature|fix|chore|release|backup)/`.
+   - Branch name matches the canonical prefix regex (see above).
    - target=main → head ∈ {develop, release/*}.
-   - target=develop → head ∈ {feature/*, fix/*, chore/*, main} (main allowed for back-merge after release).
+   - target=develop → head matches an approved prefix, OR head=main (back-merge after release).
    - `backup/*` may never be merged.
    - No merge commits in PR history (rebase, don't merge).
 
@@ -107,6 +130,9 @@ start  →  work  →  ready  →  ship  →  (release at end of day)
 
 ```
 pnpm flow start fix-013-test-isolation       # cuts feature/fix-013-test-isolation
+                                              # (default prefix is feature/ if you don't supply one)
+pnpm flow start chore/clean-stale-tasks      # explicit prefix → cuts chore/clean-stale-tasks
+pnpm flow start arch/l5-router               # explicit prefix → cuts arch/l5-router
 # ...edit, commit, push as needed...
 pnpm flow ready                              # opens PR
 pnpm flow ship                               # auto-merge (squash) when green
@@ -177,15 +203,17 @@ You're on `develop`. Switch to a feature branch:
 pnpm flow start <id>-<slug>
 ```
 
-### "gitflow-conformance: Branch name '<x>' does not match required pattern."
+### "gitflow-conformance: PRs to develop must come from an approved prefix branch …"
 
-Rename the branch:
+Your branch name doesn't match the canonical prefix regex. Rename the branch:
 
 ```
-git branch -m feature/<id>-<slug>
-git push origin --delete <old> && git push -u origin feature/<id>-<slug>
-gh pr edit <num> --head feature/<id>-<slug>
+git branch -m feat/<id>-<slug>
+git push origin --delete <old> && git push -u origin feat/<id>-<slug>
+gh pr edit <num> --head feat/<id>-<slug>
 ```
+
+The full prefix list is in the **Approved branch prefixes** section above.
 
 ### "gitflow-conformance: branch contains merge commits — use rebase, not merge."
 

--- a/scripts/caia-flow.sh
+++ b/scripts/caia-flow.sh
@@ -24,6 +24,10 @@ die() { echo "✗ $*" >&2; exit 1; }
 info() { echo "→ $*"; }
 ok() { echo "✓ $*"; }
 
+# Canonical allowed-prefix regex — keep in sync with
+# .github/workflows/gitflow-conformance.yml and caia/docs/git-flow.md.
+ALLOWED_PREFIX_RE='^(feat|feature|fix|chore|docs|refactor|perf|test|build|ci|harden|arch|acr|freg|bucket|lai|dash|gate|phase2e|coding|taskmgr|val)(/|-)'
+
 repo_root() {
   git rev-parse --show-toplevel 2>/dev/null \
     || die "not inside a git repository."
@@ -44,13 +48,14 @@ require_clean_tree() {
 require_branch_prefix() {
   local b
   b="$(current_branch)"
-  case "${b}" in
-    feature/*|fix/*|chore/*) return 0 ;;
-    *)
-      die "current branch '${b}' is not a feature/ fix/ or chore/ branch.
-   Run 'pnpm flow start <id>-<slug>' first."
-      ;;
-  esac
+  if [[ "${b}" =~ ${ALLOWED_PREFIX_RE} ]]; then
+    return 0
+  fi
+  die "current branch '${b}' does not start with an approved prefix.
+   Approved prefixes (with '/' or '-' separator): feat, feature, fix, chore,
+   docs, refactor, perf, test, build, ci, harden, arch, acr, freg, bucket,
+   lai, dash, gate, phase2e, coding, taskmgr, val.
+   Run 'pnpm flow start <id>-<slug>' to cut a new feature branch."
 }
 
 usage_top() {
@@ -74,10 +79,15 @@ Subcommands:
 
 Flow (the only allowed path):
 
-  feature/<id>-<slug>  →  PR to develop  →  squash-merge  →  branch deleted
-  develop              →  release/<date> PR to main       →  merge
-  main                 ←  only develop or release/* may merge in
-  backup/<reason>      ←  preservation only, never merged
+  <prefix>/<id>-<slug>  →  PR to develop  →  squash-merge  →  branch deleted
+  develop               →  release/<date> PR to main       →  merge
+  main                  ←  only develop or release/* may merge in
+  backup/<reason>       ←  preservation only, never merged
+
+Approved <prefix> values (separator '/' or '-'):
+  feat, feature, fix, chore, docs, refactor, perf, test, build, ci,
+  harden, arch, acr, freg, bucket, lai, dash, gate, phase2e, coding,
+  taskmgr, val.
 
 Reference: caia/docs/git-flow.md, feedback_git_flow_enforced.md.
 EOF
@@ -89,10 +99,11 @@ cmd_start() {
   local slug="${1:-}"
   [[ -n "${slug}" ]] || die "missing <id>-<slug>. Example: pnpm flow start fix-013-test-isolation"
 
-  case "${slug}" in
-    feature/*|fix/*|chore/*) ;;
-    *) slug="feature/${slug}" ;;
-  esac
+  # If user supplied an already-prefixed branch, leave it alone; otherwise
+  # default to feature/<slug>.
+  if [[ ! "${slug}" =~ ${ALLOWED_PREFIX_RE} ]]; then
+    slug="feature/${slug}"
+  fi
 
   info "fetching origin/develop"
   git fetch origin develop --quiet
@@ -327,16 +338,21 @@ cmd_help() {
       cat <<EOF
 pnpm flow start <id>-<slug>
 
-Cuts a new feature branch from origin/develop. Branch name is normalised
-to feature/<id>-<slug> if you don't supply a prefix yourself.
+Cuts a new feature branch from origin/develop. If <id>-<slug> already
+starts with an approved prefix (feat/, feature/, fix/, chore/, docs/,
+refactor/, perf/, test/, build/, ci/, harden/, arch/, acr/, freg/,
+bucket/, lai/, dash/, gate/, phase2e/, coding/, taskmgr/, val/, with
+'/' or '-' separator), it is used as-is. Otherwise the branch is
+normalised to feature/<id>-<slug>.
 
 Example:
   pnpm flow start fix-013-test-isolation
   pnpm flow start chore/clean-stale-tasks
+  pnpm flow start arch/l5-router
 
 Side effects:
   - git fetch origin develop
-  - git checkout -b feature/<id>-<slug> origin/develop
+  - git checkout -b <branch> origin/develop
 EOF
       ;;
     ready)


### PR DESCRIPTION
Release PR — cherry-picked the gitflow-conformance prefix extension
(#197) from develop directly onto a release branch cut from main.

The standard develop→main release path produced spurious add/add merge
conflicts because main and develop have diverged commit-graph-wise even
though their trees match (each side received independent squash-merges
of the same prior PRs #188–#192). Cherry-picking the single conformance
commit onto a fresh release branch cut from main sidesteps this
squash-merge ghost.

## What's in this release

- chore(gitflow): expand conformance prefixes for CAIA work-streams (#197)

The conformance regex now accepts the prefixes CAIA actually uses
(Conventional Commits + work-stream prefixes), with both '/' and '-' as
separator. Once this lands on main, the active feature PRs that have
been retargeted from main to develop will pass conformance.

Reference: caia/docs/git-flow.md.