### PR TITLE
feat(run-modes): plan-only and test-only run modes (RUN-MODES)

### DIFF
--- a/apps/dashboard/app/api/prompts/route.ts
+++ b/apps/dashboard/app/api/prompts/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Dashboard API proxy: POST /api/prompts
+ *
+ * Forwards to the orchestrator's POST /prompts endpoint. Translates the
+ * dashboard's wire shape (`text`, `projectId`, `priority`, `runMode`) to
+ * the orchestrator's wire shape (`body`, metadata flags, `run_mode`).
+ *
+ * RUN-MODES (migration 0038): the dashboard's submit form has three
+ * modes — full (default), plan-only, test-only. The frontend sends
+ * `runMode` in the request body; this proxy maps it to the
+ * orchestrator's `run_mode` field.
+ */
+import { NextResponse } from 'next/server';
+
+const ORCHESTRATOR_URL = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
+
+const VALID_RUN_MODES = new Set(['full', 'plan-only', 'test-only']);
+
+export async function POST(req: Request): Promise<NextResponse> {
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+
+  const text = typeof payload.text === 'string' ? payload.text.trim() : '';
+  if (!text) {
+    return NextResponse.json({ error: 'text is required' }, { status: 400 });
+  }
+
+  const runMode = typeof payload.runMode === 'string' ? payload.runMode : undefined;
+  if (runMode !== undefined && !VALID_RUN_MODES.has(runMode)) {
+    return NextResponse.json(
+      { error: `runMode must be one of ${[...VALID_RUN_MODES].join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  const upstreamBody = {
+    body: text,
+    received_via: 'chat',
+    metadata: {
+      projectId: payload.projectId ?? null,
+      priority: payload.priority ?? 'normal',
+      source: payload.source ?? 'dashboard',
+      skipDecomposition: Boolean(payload.skipDecomposition),
+    },
+    ...(runMode ? { run_mode: runMode } : {}),
+  };
+
+  try {
+    const upstream = await fetch(`${ORCHESTRATOR_URL}/prompts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(upstreamBody),
+      cache: 'no-store',
+    });
+    const data = (await upstream.json()) as { id?: string; error?: string };
+    if (!upstream.ok) {
+      return NextResponse.json(
+        { error: data.error ?? `Upstream ${upstream.status}` },
+        { status: upstream.status },
+      );
+    }
+    return NextResponse.json({
+      prompt_id: data.id,
+      correlation_id: data.id,
+      run_mode: runMode ?? 'full',
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'upstream unreachable' },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/dashboard/app/submit/page.tsx
+++ b/apps/dashboard/app/submit/page.tsx
@@ -17,8 +17,14 @@ interface Project {
 interface SubmitResponse {
   prompt_id?: string;
   correlation_id?: string;
+  run_mode?: string;
   error?: string;
 }
+
+// RUN-MODES (migration 0038): three submission modes the user can pick
+// from on the submit form. See run-modes/index.ts in the orchestrator
+// for the canonical contract.
+type RunMode = 'full' | 'plan-only' | 'test-only';
 
 // ─── Inline classifier ────────────────────────────────────────────────────────
 // Lightweight client-side classification — no network call needed.
@@ -320,6 +326,11 @@ export default function SubmitPage() {
   const [projectId, setProjectId] = useState('');
   const [priority, setPriority] = useState<Priority>('normal');
   const [skipDecomposition, setSkipDecomposition] = useState(false);
+  // RUN-MODES (migration 0038): default 'full' preserves prior behaviour
+  // for the existing "Submit to your AI team" button; the two new
+  // buttons set this to 'plan-only' or 'test-only' before invoking
+  // the same submit handler.
+  const [runMode, setRunMode] = useState<RunMode>('full');
   const [notifyOnComplete, setNotifyOnComplete] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -368,15 +379,17 @@ export default function SubmitPage() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !submitting && !submitted && text.trim()) {
-        void handleSubmit();
+        void handleSubmit(runMode);
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   });
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = useCallback(async (modeOverride?: RunMode) => {
     if (!text.trim() || submitting || submitted) return;
+    const effectiveMode = modeOverride ?? runMode;
+    setRunMode(effectiveMode);
     setSubmitting(true);
     setErrorMsg(null);
 
@@ -390,6 +403,7 @@ export default function SubmitPage() {
           priority,
           source: 'dashboard',
           skipDecomposition,
+          runMode: effectiveMode,
         }),
       });
 
@@ -403,7 +417,7 @@ export default function SubmitPage() {
     } finally {
       setSubmitting(false);
     }
-  }, [text, projectId, priority, skipDecomposition, submitting, submitted]);
+  }, [text, projectId, priority, skipDecomposition, runMode, submitting, submitted]);
 
   const activeAgents = getActiveAgents(classification?.requestType?.id ?? null);
   const activeProjects = projects.filter(p => p.status === 'active');
@@ -818,51 +832,102 @@ export default function SubmitPage() {
             </div>
           )}
 
-          {/* Submit button */}
+          {/* RUN-MODES (migration 0038): three submission buttons.
+              Run full   — existing default behaviour.
+              Run plan only — pipeline runs PO+BA+EA+Validator+Test-Design+
+                              Task Manager but no worker assignment.
+                              Output is the WorkGraph + estimated cost.
+              Run test only — full pipeline runs but the broker strips
+                              deploy/publish/push-main capabilities. */}
           {!submitted && (
-            <button
-              className="submit-btn"
-              onClick={() => void handleSubmit()}
-              disabled={submitting || !text.trim() || submitted}
-              style={{
-                width: '100%',
-                padding: '14px 24px',
-                background: text.trim() ? '#1a3a7f' : '#2d3748',
-                color: text.trim() ? '#90cdf4' : '#4a5568',
-                border: `1px solid ${text.trim() ? '#2a5aaf' : '#2d3748'}`,
-                borderRadius: 9,
-                fontSize: 15,
-                fontWeight: 700,
-                cursor: text.trim() && !submitting ? 'pointer' : 'not-allowed',
-                transition: 'all 0.15s',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 10,
-                letterSpacing: '-0.01em',
-              }}
-              aria-label="Submit to your AI team"
-            >
-              {submitting ? (
-                <>
-                  <span
-                    style={{
-                      width: 16,
-                      height: 16,
-                      border: '2px solid #4299e144',
-                      borderTop: '2px solid #63b3ed',
-                      borderRadius: '50%',
-                      animation: 'spin 0.7s linear infinite',
-                      display: 'inline-block',
-                      flexShrink: 0,
-                    }}
-                  />
-                  Submitting to your AI team…
-                </>
-              ) : (
-                'Submit to your AI team →'
-              )}
-            </button>
+            <div data-testid="run-mode-buttons" style={{ display: 'grid', gap: 10 }}>
+              <button
+                type="button"
+                className="submit-btn submit-btn-full"
+                onClick={() => void handleSubmit('full')}
+                disabled={submitting || !text.trim() || submitted}
+                style={{
+                  width: '100%',
+                  padding: '14px 24px',
+                  background: text.trim() ? '#1a3a7f' : '#2d3748',
+                  color: text.trim() ? '#90cdf4' : '#4a5568',
+                  border: `1px solid ${text.trim() ? '#2a5aaf' : '#2d3748'}`,
+                  borderRadius: 9,
+                  fontSize: 15,
+                  fontWeight: 700,
+                  cursor: text.trim() && !submitting ? 'pointer' : 'not-allowed',
+                  transition: 'all 0.15s',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 10,
+                  letterSpacing: '-0.01em',
+                }}
+                aria-label="Run the full pipeline (writes code, opens PRs)"
+              >
+                {submitting && runMode === 'full' ? (
+                  <>
+                    <span
+                      style={{
+                        width: 16,
+                        height: 16,
+                        border: '2px solid #4299e144',
+                        borderTop: '2px solid #63b3ed',
+                        borderRadius: '50%',
+                        animation: 'spin 0.7s linear infinite',
+                        display: 'inline-block',
+                        flexShrink: 0,
+                      }}
+                    />
+                    Running full pipeline…
+                  </>
+                ) : (
+                  'Run full →'
+                )}
+              </button>
+              <button
+                type="button"
+                className="submit-btn submit-btn-plan-only"
+                onClick={() => void handleSubmit('plan-only')}
+                disabled={submitting || !text.trim() || submitted}
+                style={{
+                  width: '100%',
+                  padding: '12px 20px',
+                  background: text.trim() ? '#21384a' : '#2d3748',
+                  color: text.trim() ? '#a0d2eb' : '#4a5568',
+                  border: `1px solid ${text.trim() ? '#3a5a7a' : '#2d3748'}`,
+                  borderRadius: 9,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: text.trim() && !submitting ? 'pointer' : 'not-allowed',
+                  transition: 'all 0.15s',
+                }}
+                aria-label="Plan only — show me the cost without running code"
+              >
+                {submitting && runMode === 'plan-only' ? 'Planning…' : 'Run plan only — show me the cost'}
+              </button>
+              <button
+                type="button"
+                className="submit-btn submit-btn-test-only"
+                onClick={() => void handleSubmit('test-only')}
+                disabled={submitting || !text.trim() || submitted}
+                style={{
+                  width: '100%',
+                  padding: '12px 20px',
+                  background: text.trim() ? '#2d2839' : '#2d3748',
+                  color: text.trim() ? '#cbb4f0' : '#4a5568',
+                  border: `1px solid ${text.trim() ? '#5a4a7a' : '#2d3748'}`,
+                  borderRadius: 9,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: text.trim() && !submitting ? 'pointer' : 'not-allowed',
+                  transition: 'all 0.15s',
+                }}
+                aria-label="Test only — write code and run tests, but never deploy or push to main"
+              >
+                {submitting && runMode === 'test-only' ? 'Running tests only…' : 'Run test only — code but don\u2019t deploy'}
+              </button>
+            </div>
           )}
         </div>
 

--- a/apps/orchestrator/src/agents/capsule-freezer.ts
+++ b/apps/orchestrator/src/agents/capsule-freezer.ts
@@ -88,10 +88,23 @@ export function freezeStoryCapsule(
     .where(eq(stories.id, storyId))
     .run();
 
+  // RUN-MODES (migration 0038): surface the story's run_mode in the
+  // capsule-frozen event so downstream consumers (capability broker,
+  // dashboard) can apply mode-specific restrictions without re-reading
+  // the row. The capsule's `tool_allowlist` is computed from
+  // architecturalInstructions and is intentionally not mutated by run
+  // mode (changing the capsule shape would be a v2 hash change). The
+  // capability broker (Track 1) is responsible for restricting its own
+  // per-run capability allowlist via run-modes/restrictAllowlistForMode
+  // when it consumes this event.
+  // TODO(track-1-broker): once the broker package lands, swap this
+  // event-emission-only plumbing for a direct call into the broker's
+  // allowlist API at story pickup.
   emitFrozen(storyId, options, 'frozen', {
     capsuleHash: frozen.capsuleHash,
     capsuleFrozenAt: frozen.capsuleFrozenAt,
     capsuleVersion: frozen.capsuleVersion,
+    runMode: story.runMode ?? 'full',
   });
 
   return {

--- a/apps/orchestrator/src/agents/po-agent.ts
+++ b/apps/orchestrator/src/agents/po-agent.ts
@@ -28,7 +28,8 @@ import { eventBus } from '../events/bus-adapter';
 import { EmbedderUnavailableError } from '@chiefaia/feature-registry';
 import { searchAndLog } from './feature-registry-search-client';
 import { getDb } from '../db/connection';
-import { requirements, stories } from '../db/schema';
+import { prompts, requirements, stories } from '../db/schema';
+import { DEFAULT_RUN_MODE, isRunMode, type RunMode } from '../run-modes';
 import { advancePipelineStage } from './pipeline-stages';
 
 // Logger shim — replaced at runtime by the real pino logger if available
@@ -68,6 +69,18 @@ export async function runPOAgent(
 ): Promise<POAgentOutput> {
   const { promptId, promptText, projectId, correlationId } = input;
   const now = new Date().toISOString();
+
+  // RUN-MODES (migration 0038): inherit the parent prompt's run_mode so
+  // every story spawned from this prompt carries the same mode. The
+  // ReadyPoolConsumer reads stories.run_mode directly to gate worker
+  // assignment without joining prompts on every pump.
+  const promptRow = db.select({ runMode: prompts.runMode })
+    .from(prompts)
+    .where(eq(prompts.id, promptId))
+    .get();
+  const inheritedRunMode: RunMode = promptRow?.runMode && isRunMode(promptRow.runMode)
+    ? promptRow.runMode
+    : DEFAULT_RUN_MODE;
 
   // 1. Classify the prompt domain (legacy primaryDomain) plus the new
   //    BUCKET-002 9-axis taxonomy fields (project / lifecycle / priority on
@@ -214,6 +227,10 @@ export async function runPOAgent(
           db.insert(stories).values({
             id: storyDbId,
             kind: 'story',
+            // RUN-MODES (migration 0038): denormalised from the parent
+            // prompt at creation. ReadyPoolConsumer's pump query filters
+            // on this column.
+            runMode: inheritedRunMode,
             title: story.title,
             description: story.description ?? '',
             acceptanceCriteriaJson: JSON.stringify(story.acceptanceCriteria ?? []),

--- a/apps/orchestrator/src/agents/ready-pool-consumer.ts
+++ b/apps/orchestrator/src/agents/ready-pool-consumer.ts
@@ -24,11 +24,15 @@
  * @owner task-manager (Phase 2 worker-pool track)
  */
 
-import { eq, and, isNull } from 'drizzle-orm';
+import { eq, and, isNull, ne } from 'drizzle-orm';
 import type { Db } from '../db/connection';
 import { stories, workerPool } from '../db/schema';
 import { eventBus } from '../events/bus-adapter';
 import { recompute, snapshotStory, type StorySnapshot } from '../scheduling/ready-pool';
+// RUN-MODES (migration 0038) — the plan-only gate is enforced inline
+// in pump()'s SELECT clause; no run-modes helper imports needed here
+// because the 'plan-only' string literal is the only mode we reject.
+// (See run-modes/index.ts for the canonical mode list.)
 import { WorkerPoolRegistry, type WorkerKind } from './worker-pool-registry';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -102,10 +106,21 @@ export class ReadyPoolConsumer {
     //    `ready_for_pickup` (per the canonical pipeline) — those are
     //    represented by phase2_status IS NULL AND status='pending' once
     //    bucket-placer has run. We additionally require bucket_id IS NOT NULL.
+    // RUN-MODES (migration 0038): plan-only runs reach `bucket_placed` /
+    // `ready_for_pickup` but are NEVER assigned to a worker. The story's
+    // `run_mode` column is denormalised from the parent prompt at story
+    // creation time so this gate is a single-table read with no join.
+    // 'full' and 'test-only' both pass through; 'test-only' is the
+    // capability-broker's job downstream (the worker still gets the
+    // assignment).
     const rows = this.db
       .select()
       .from(stories)
-      .where(and(eq(stories.status, 'pending'), isNull(stories.assignedWorkerId)))
+      .where(and(
+        eq(stories.status, 'pending'),
+        isNull(stories.assignedWorkerId),
+        ne(stories.runMode, 'plan-only'),
+      ))
       .all();
 
     const snapshots: StorySnapshot[] = rows.map((r) => snapshotStory(r));

--- a/apps/orchestrator/src/api/routes/prompts.ts
+++ b/apps/orchestrator/src/api/routes/prompts.ts
@@ -13,6 +13,7 @@ import type { PromptStatus, PromptReceivedVia, PromptListOptions } from '../../p
 import { classifyKeyword } from '@chiefaia/classifier';
 import { check as dedupCheck } from '@chiefaia/dedup-engine';
 import { runScaffolder } from '../../agents/scaffolder';
+import { isRunMode, RUN_MODES, estimateRunCost, type RunMode } from '../../run-modes';
 
 // @no-events — route registration wrapper; business events are emitted by manager functions
 export function registerPromptsRoutes(app: Hono, db: Db): void {
@@ -25,10 +26,20 @@ export function registerPromptsRoutes(app: Hono, db: Db): void {
       user_id?: string;
       tokens_in?: number;
       metadata?: Record<string, unknown>;
+      run_mode?: string;
     };
 
     if (!body.body || typeof body.body !== 'string') {
       return c.json({ error: 'body is required' }, 400);
+    }
+
+    // RUN-MODES (migration 0038): validate `run_mode` at the API
+    // boundary. Unknown values are 400'd rather than silently coerced
+    // to 'full' so callers learn about typos immediately.
+    if (body.run_mode !== undefined && !isRunMode(body.run_mode)) {
+      return c.json({
+        error: `run_mode must be one of ${RUN_MODES.join(', ')} (got ${JSON.stringify(body.run_mode)})`,
+      }, 400);
     }
 
     const prompt = createPrompt(db, {
@@ -38,6 +49,7 @@ export function registerPromptsRoutes(app: Hono, db: Db): void {
       userId: body.user_id,
       tokensIn: body.tokens_in,
       metadata: body.metadata,
+      runMode: body.run_mode as RunMode | undefined,
     });
 
     // Emit prompt.ingested event and create pipeline stage tracking
@@ -180,6 +192,55 @@ export function registerPromptsRoutes(app: Hono, db: Db): void {
     };
     const rows = listPrompts(db, opts);
     return c.json({ prompts: rows, total: rows.length });
+  });
+
+  // RUN-MODES (migration 0038): plan-only output preview for a prompt.
+  // Returns the WorkGraph (story IDs + parent/child links) +
+  // per-story architecturalInstructions[] + estimated tokens / cost,
+  // computed from the run-modes/cost estimator. Only meaningful for
+  // run_mode='plan-only' prompts; for others the same data is
+  // available but the cost estimate excludes coding-agent tokens that
+  // *will* be consumed downstream.
+  app.get('/prompts/:id/plan-output', async (c) => {
+    const { id } = c.req.param();
+    const prompt = getPrompt(db, id);
+    if (!prompt) return c.json({ error: 'not found' }, 404);
+
+    const storyRows = db.select({
+      id: stories.id,
+      title: stories.title,
+      parentId: stories.parentId,
+      bucketId: stories.bucketId,
+      runMode: stories.runMode,
+      agentContributionsJson: stories.agentContributionsJson,
+      acceptanceCriteriaJson: stories.acceptanceCriteriaJson,
+    }).from(stories).where(eq(stories.rootPromptId, id)).all();
+
+    const storyIds = storyRows.map((s) => s.id);
+    const mode = (prompt.runMode ?? 'full') as RunMode;
+    const cost = estimateRunCost(mode, storyIds);
+
+    return c.json({
+      promptId: id,
+      runMode: mode,
+      stories: storyRows.map((s) => {
+        let architecturalInstructions: unknown[] = [];
+        try {
+          const parsed = JSON.parse(s.agentContributionsJson || '{}') as {
+            architecturalInstructions?: unknown[];
+          };
+          architecturalInstructions = parsed.architecturalInstructions ?? [];
+        } catch { /* ignore parse errors */ }
+        return {
+          id: s.id,
+          title: s.title,
+          parentId: s.parentId,
+          bucketId: s.bucketId,
+          architecturalInstructions,
+        };
+      }),
+      cost,
+    });
   });
 
   // Get a single prompt with its response and top-level descendants

--- a/apps/orchestrator/src/db/migrations/0038_run_mode.sql
+++ b/apps/orchestrator/src/db/migrations/0038_run_mode.sql
@@ -1,0 +1,44 @@
+-- Migration 0038: RUN-MODES — plan-only and test-only run modes.
+--
+-- Adds a `run_mode` column to `prompts`. Every prompt is a CAIA run; the
+-- run mode controls how far down the pipeline the run goes:
+--
+--   'full'       — default. PO + BA + EA + Validator + Test-Design +
+--                  Task Manager + worker-assignment (Coding Agent +
+--                  Fix-It if needed). The mode the dashboard's "Run
+--                  full" button has always meant.
+--
+--   'plan-only'  — pipeline runs PO + BA + EA + Validator + Test-Design
+--                  + Task Manager (bucket placement). Stories reach
+--                  `bucket_placed` / `ready_for_pickup` and stay there.
+--                  ReadyPoolConsumer skips worker assignment for these
+--                  prompts. Useful for "show me the plan + cost before
+--                  I commit". The dashboard exposes this as
+--                  "Run plan only — show me the cost".
+--
+--   'test-only'  — pipeline runs full, but the per-run capability
+--                  allowlist is restricted: deploy/publish/push-main
+--                  capabilities are stripped before the capsule is
+--                  frozen (D1, migration 0037). Code is written and
+--                  tested; nothing is deployed or published. Once
+--                  Track 1's capability broker is online, the broker
+--                  enforces the restricted allowlist; until then this
+--                  is plumbed through but not strictly enforced (the
+--                  Coding Agent honours the capsule's allowlist on
+--                  best-effort).
+--
+-- Default 'full' preserves all existing behaviour for in-flight prompts.
+-- Migration is non-idempotent (ALTER TABLE ADD COLUMN); Drizzle's
+-- journal prevents re-application.
+--
+-- The column is denormalised onto stories in the same migration so
+-- ReadyPoolConsumer can gate worker assignment without joining
+-- prompts on every pump.
+
+ALTER TABLE `prompts` ADD COLUMN `run_mode` text NOT NULL DEFAULT 'full';
+--> statement-breakpoint
+ALTER TABLE `stories` ADD COLUMN `run_mode` text NOT NULL DEFAULT 'full';
+--> statement-breakpoint
+CREATE INDEX `prm_run_mode_idx` ON `prompts` (`run_mode`);
+--> statement-breakpoint
+CREATE INDEX `story_run_mode_idx` ON `stories` (`run_mode`);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1778600000001,
       "tag": "0037_story_capsule",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1778700000000,
+      "tag": "0038_run_mode",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/orchestrator/src/db/schema.ts
+++ b/apps/orchestrator/src/db/schema.ts
@@ -480,6 +480,10 @@ export const stories = sqliteTable('stories', {
   capsuleHash: text('capsule_hash'),
   capsuleFrozenAt: integer('capsule_frozen_at'),
   capsuleVersion: text('capsule_version'),
+  // RUN-MODES (migration 0038): denormalised from the parent prompt's
+  // run_mode so ReadyPoolConsumer can gate worker assignment on a single
+  // table read. Always inherits from the prompt at story creation time.
+  runMode: text('run_mode').notNull().default('full'),
 }, (t) => [
   index('story_parent_idx').on(t.parentId),
   index('story_project_idx').on(t.projectSlug),
@@ -517,6 +521,10 @@ export const stories = sqliteTable('stories', {
   // capsule_frozen_at to render lineage.
   index('story_capsule_hash_idx').on(t.capsuleHash),
   index('story_capsule_frozen_at_idx').on(t.capsuleFrozenAt),
+  // RUN-MODES (migration 0038) — ReadyPoolConsumer scans for
+  // run_mode != 'full' to short-circuit worker assignment for plan-only
+  // runs.
+  index('story_run_mode_idx').on(t.runMode),
 ]);
 
 // story_revisions — append-only history of every story-tree edit
@@ -777,11 +785,15 @@ export const prompts = sqliteTable('prompts', {
   status: text('status').notNull().default('received'), // received|analyzing|decomposed|answered|failed
   completedAt: text('completed_at'),
   elapsedMs: integer('elapsed_ms'),
+  // RUN-MODES (migration 0038): controls how far the pipeline runs.
+  // 'full' (default) | 'plan-only' | 'test-only'. See run-modes/index.ts.
+  runMode: text('run_mode').notNull().default('full'),
 }, (t) => [
   index('prm_received_idx').on(t.receivedAt),
   index('prm_user_idx').on(t.userId, t.receivedAt),
   index('prm_status_idx').on(t.status),
   index('prm_hash_idx').on(t.hash),
+  index('prm_run_mode_idx').on(t.runMode),
 ]);
 
 // prompt_responses — responses attached to a prompt (migration 0010)

--- a/apps/orchestrator/src/prompts/manager.ts
+++ b/apps/orchestrator/src/prompts/manager.ts
@@ -12,6 +12,18 @@ import type {
   CreatePromptParams, PromptDescendant, PromptJourney,
   PromptListOptions, PromptStatus, TransitionActor,
 } from './types';
+import { DEFAULT_RUN_MODE, isRunMode, type RunMode } from '../run-modes';
+
+function resolveRunMode(params: CreatePromptParams): RunMode {
+  // Prefer the explicit field; fall back to metadata.run_mode for callers
+  // that route through metadata (e.g. CLI plan/test commands), and finally
+  // default to 'full'. Unknown values fall back to the default rather than
+  // throwing — the API route is responsible for validating user input.
+  if (params.runMode && isRunMode(params.runMode)) return params.runMode;
+  const fromMeta = (params.metadata as Record<string, unknown> | undefined)?.run_mode;
+  if (typeof fromMeta === 'string' && isRunMode(fromMeta)) return fromMeta;
+  return DEFAULT_RUN_MODE;
+}
 
 function makePromptId(): string {
   const ts = Date.now().toString(36).padStart(8, '0');
@@ -55,6 +67,7 @@ export function createPrompt(db: Db, params: CreatePromptParams): Prompt {
     status: 'received' as PromptStatus,
     completedAt: null,
     elapsedMs: null,
+    runMode: resolveRunMode(params),
   };
 
   db.insert(prompts).values(row).run();

--- a/apps/orchestrator/src/prompts/types.ts
+++ b/apps/orchestrator/src/prompts/types.ts
@@ -17,6 +17,8 @@ export interface Prompt {
   status: PromptStatus;
   completedAt?: string | null;
   elapsedMs?: number | null;
+  /** RUN-MODES (migration 0038): 'full' | 'plan-only' | 'test-only'. */
+  runMode?: import('../run-modes').RunMode;
 }
 
 export interface PromptResponse {
@@ -48,6 +50,8 @@ export interface CreatePromptParams {
   userId?: string;
   tokensIn?: number;
   metadata?: Record<string, unknown>;
+  /** Optional run mode; defaults to 'full' if absent. */
+  runMode?: import('../run-modes').RunMode;
 }
 
 export interface PromptDescendant {

--- a/apps/orchestrator/src/run-modes/index.ts
+++ b/apps/orchestrator/src/run-modes/index.ts
@@ -1,0 +1,255 @@
+/**
+ * RUN-MODES — plan-only and test-only run modes (migration 0038).
+ *
+ * Every prompt is a CAIA run. The run mode controls how far down the
+ * pipeline a run goes; this module is the single source of truth for
+ * the `RunMode` enum, the per-mode pipeline gates, and the per-mode
+ * capability-allowlist transformations.
+ *
+ * Three modes:
+ *
+ *   'full' (default)
+ *     PO + BA + EA + Validator + Test-Design + Task Manager +
+ *     worker-assignment (Coding Agent + Fix-It). The mode every
+ *     prompt has had since pipeline-stages.ts was canonicalised.
+ *
+ *   'plan-only'
+ *     Pipeline runs through `bucket_placed` / `ready_for_pickup`.
+ *     ReadyPoolConsumer skips worker assignment for these prompts —
+ *     stories stay in the bucket as "ready-for-review". Output is the
+ *     WorkGraph + per-story `architecturalInstructions[]` + per-story
+ *     estimated tokens + estimated total cost. No file writes, no PRs.
+ *     Useful for "what would CAIA do with this prompt" preview.
+ *
+ *   'test-only'
+ *     Full pipeline runs, but the per-run capability allowlist has
+ *     deploy/publish/push-main capabilities stripped before the
+ *     capsule (D1, migration 0037) is frozen. Code is written and
+ *     tested by the worker; nothing is deployed or published. Once
+ *     the Track 1 capability broker lands, the broker enforces this
+ *     allowlist; until then it's plumbed through the capsule and
+ *     the Coding Agent honours it on best-effort.
+ *
+ * Cross-references:
+ *   - D1 / Context Capsule (migration 0037, PR #207): the capsule is
+ *     where the run-mode-restricted allowlist gets hashed in. Drift
+ *     on the allowlist between freeze and worker-pickup is detectable.
+ *   - Track 1 / Capability Broker (in flight): the broker reads the
+ *     capsule's allowlist and enforces it at every tool call.
+ *   - Track 1 / Spend-cap (HARDEN-011, PR #206): orthogonal —
+ *     spend-cap halts a run independent of run mode.
+ *
+ * @owner orchestrator (Phase 2 / run-modes track)
+ */
+
+/** Canonical list of run modes. Index 0 is the default. */
+export const RUN_MODES = ['full', 'plan-only', 'test-only'] as const;
+
+export type RunMode = (typeof RUN_MODES)[number];
+
+/** The default run mode applied when the caller doesn't specify one. */
+export const DEFAULT_RUN_MODE: RunMode = 'full';
+
+/**
+ * Type guard. Returns true if `value` is a known run mode. Used at
+ * the API boundary to validate request bodies and CLI args before
+ * persisting to the prompt row.
+ */
+export function isRunMode(value: unknown): value is RunMode {
+  return typeof value === 'string' && (RUN_MODES as readonly string[]).includes(value);
+}
+
+/**
+ * Capabilities that a 'test-only' run cannot use. The capsule freezer
+ * removes these from the allowlist before computing the capsule hash;
+ * the worker (when the broker is online) refuses tool calls for any
+ * stripped capability. This list is intentionally explicit rather than
+ * computed: stripping a capability that downstream code didn't expect
+ * to be optional should be a code-review-visible change.
+ *
+ * Mirrors the four explicitly named in the operator mandate:
+ *   - git_push_main
+ *   - cloudflare_pages_deploy_*  (any capability whose id starts
+ *     with this prefix; matched in `restrictAllowlistForMode`)
+ *   - supabase_migration_apply
+ *   - npm_publish
+ */
+export const TEST_ONLY_STRIPPED_CAPABILITIES: ReadonlySet<string> = new Set([
+  'git_push_main',
+  'supabase_migration_apply',
+  'npm_publish',
+]);
+
+/**
+ * Capability-id prefixes that test-only also strips (any capability
+ * starting with one of these). Used to capture families like
+ * cloudflare_pages_deploy_preview and cloudflare_pages_deploy_prod
+ * without listing each variant.
+ */
+export const TEST_ONLY_STRIPPED_PREFIXES: ReadonlyArray<string> = [
+  'cloudflare_pages_deploy_',
+];
+
+/**
+ * Returns true if `capabilityId` should be stripped under 'test-only'.
+ * Hot-path-friendly — this is called per capability per capsule freeze.
+ */
+export function isTestOnlyStripped(capabilityId: string): boolean {
+  if (TEST_ONLY_STRIPPED_CAPABILITIES.has(capabilityId)) return true;
+  for (const prefix of TEST_ONLY_STRIPPED_PREFIXES) {
+    if (capabilityId.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Apply the run-mode-specific transformation to a capability allowlist.
+ * For 'full' and 'plan-only' the allowlist is returned unchanged
+ * (plan-only never reaches the worker, so allowlist enforcement never
+ * fires). For 'test-only' the deploy/publish/push capabilities are
+ * removed.
+ *
+ * Returns a new array — does not mutate `allowlist`. The order of the
+ * remaining capabilities is preserved (caller may rely on this for
+ * stable capsule hashes when only the allowlist changes).
+ */
+export function restrictAllowlistForMode(
+  mode: RunMode,
+  allowlist: readonly string[],
+): string[] {
+  if (mode === 'test-only') {
+    return allowlist.filter((id) => !isTestOnlyStripped(id));
+  }
+  return [...allowlist];
+}
+
+/**
+ * Should the orchestrator skip worker assignment for stories belonging
+ * to a run in this mode? True for 'plan-only'; false for 'full' and
+ * 'test-only'. Hot-path-called from ReadyPoolConsumer.pump() — a tiny
+ * function so callers can inline-comment the gate.
+ */
+export function shouldSkipWorkerAssignment(mode: RunMode): boolean {
+  return mode === 'plan-only';
+}
+
+/**
+ * Should this run write code at all? True for 'full' and 'test-only';
+ * false for 'plan-only'. Provided as a complement to
+ * shouldSkipWorkerAssignment so call-sites that read more naturally
+ * with a positive verb ("should write code") have a name that matches.
+ */
+export function shouldWriteCode(mode: RunMode): boolean {
+  return mode !== 'plan-only';
+}
+
+/**
+ * Should this run be allowed to deploy / publish / push to main?
+ * True only for 'full'. Both 'plan-only' (doesn't write code) and
+ * 'test-only' (writes code but capability-restricted) return false.
+ */
+export function shouldAllowDeployment(mode: RunMode): boolean {
+  return mode === 'full';
+}
+
+// ─── Cost / token estimation ─────────────────────────────────────────────────
+
+/**
+ * Per-agent rough-cut token estimate. Used for plan-only's "estimated
+ * cost" output. These numbers are deliberately approximate; they exist
+ * to give the user a "is this $0.50 or $50" signal before they commit
+ * to a full run. Refine as we collect actual telemetry from
+ * `executor_runs.tokens_in/out`.
+ *
+ * Numbers are per-agent-per-story, summed over all stories in the
+ * WorkGraph to get the total. The Coding Agent + Fix-It contributions
+ * are excluded from plan-only's estimate (since they don't run); they
+ * are included in the test-only and full estimates.
+ */
+export const PER_AGENT_TOKEN_ESTIMATE = {
+  po: { input: 4_000, output: 2_000 },
+  ba: { input: 6_000, output: 3_000 },
+  ea: { input: 8_000, output: 4_000 },
+  validator: { input: 5_000, output: 1_500 },
+  testDesign: { input: 4_000, output: 2_500 },
+  taskManager: { input: 1_000, output: 500 },
+  coding: { input: 12_000, output: 6_000 },
+  fixIt: { input: 6_000, output: 3_000 },
+} as const;
+
+/**
+ * Anthropic Sonnet-class pricing (USD per 1M tokens). Approximate; used
+ * only for plan-only's cost preview. The dashboard shows this with a
+ * "± rough estimate" caveat.
+ */
+export const SONNET_PRICING = {
+  inputUsdPer1M: 3.0,
+  outputUsdPer1M: 15.0,
+} as const;
+
+export interface PerStoryCostEstimate {
+  storyId: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedUsd: number;
+}
+
+export interface RunCostEstimate {
+  mode: RunMode;
+  totalStories: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedUsd: number;
+  perStory: PerStoryCostEstimate[];
+}
+
+/**
+ * Compute a rough cost estimate for a run with `storyCount` stories
+ * in the given mode. The per-story estimate is uniform (the same
+ * agent loadout runs against each story); callers that have richer
+ * per-story info can supply their own perStory array.
+ */
+export function estimateRunCost(mode: RunMode, storyIds: readonly string[]): RunCostEstimate {
+  const includesCoding = mode !== 'plan-only';
+  const perStoryInput =
+    PER_AGENT_TOKEN_ESTIMATE.po.input +
+    PER_AGENT_TOKEN_ESTIMATE.ba.input +
+    PER_AGENT_TOKEN_ESTIMATE.ea.input +
+    PER_AGENT_TOKEN_ESTIMATE.validator.input +
+    PER_AGENT_TOKEN_ESTIMATE.testDesign.input +
+    PER_AGENT_TOKEN_ESTIMATE.taskManager.input +
+    (includesCoding ? PER_AGENT_TOKEN_ESTIMATE.coding.input : 0);
+
+  const perStoryOutput =
+    PER_AGENT_TOKEN_ESTIMATE.po.output +
+    PER_AGENT_TOKEN_ESTIMATE.ba.output +
+    PER_AGENT_TOKEN_ESTIMATE.ea.output +
+    PER_AGENT_TOKEN_ESTIMATE.validator.output +
+    PER_AGENT_TOKEN_ESTIMATE.testDesign.output +
+    PER_AGENT_TOKEN_ESTIMATE.taskManager.output +
+    (includesCoding ? PER_AGENT_TOKEN_ESTIMATE.coding.output : 0);
+
+  const perStoryUsd =
+    (perStoryInput / 1_000_000) * SONNET_PRICING.inputUsdPer1M +
+    (perStoryOutput / 1_000_000) * SONNET_PRICING.outputUsdPer1M;
+
+  const perStory = storyIds.map((storyId) => ({
+    storyId,
+    totalInputTokens: perStoryInput,
+    totalOutputTokens: perStoryOutput,
+    estimatedUsd: round4(perStoryUsd),
+  }));
+
+  return {
+    mode,
+    totalStories: storyIds.length,
+    totalInputTokens: perStoryInput * storyIds.length,
+    totalOutputTokens: perStoryOutput * storyIds.length,
+    estimatedUsd: round4(perStoryUsd * storyIds.length),
+    perStory,
+  };
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}

--- a/apps/orchestrator/tests/agents/ready-pool-consumer.run-modes.test.ts
+++ b/apps/orchestrator/tests/agents/ready-pool-consumer.run-modes.test.ts
@@ -1,0 +1,176 @@
+/**
+ * ReadyPoolConsumer — RUN-MODES tests (migration 0038).
+ *
+ * Verifies the consumer's gate that skips worker assignment for
+ * stories belonging to a `plan-only` run, while passing through
+ * `full` and `test-only` (the latter is the broker's job downstream,
+ * not the consumer's).
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { eq } from 'drizzle-orm';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import { stories, workerPool, taskBuckets, prompts } from '../../src/db/schema';
+import { WorkerPoolRegistry } from '../../src/agents/worker-pool-registry';
+import { ReadyPoolConsumer } from '../../src/agents/ready-pool-consumer';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+function setup() {
+  const sqlite = new Database(':memory:');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+  const registry = new WorkerPoolRegistry(db, { silent: true });
+  const consumer = new ReadyPoolConsumer(db, registry, { silent: true });
+  db.insert(prompts).values({
+    id: 'p_test',
+    body: 'test',
+    receivedAt: new Date().toISOString(),
+    correlationId: 'corr_test',
+    hash: 'h_test',
+  }).run();
+  for (const bid of ['bkt_default']) {
+    db.insert(taskBuckets).values({
+      id: bid,
+      kind: 'parallel',
+      promptId: 'p_test',
+      createdAt: Date.now(),
+      status: 'open',
+    }).run();
+  }
+  return { db, registry, consumer };
+}
+
+function insertStory(
+  db: ReturnType<typeof setup>['db'],
+  id: string,
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const now = Date.now();
+  db.insert(stories)
+    .values({
+      id,
+      title: id,
+      description: '',
+      expectedBehavior: '',
+      acceptanceCriteriaJson: '[]',
+      verificationPlanJson: '[]',
+      dependsOnJson: '[]',
+      domainSlugsJson: '[]',
+      status: 'pending',
+      createdAt: String(now),
+      agentContributionsJson: '{}',
+      templateVersion: 'v1',
+      templateValidationStatus: 'pending',
+      businessSubDomainsJson: '[]',
+      techSubDomainsJson: '[]',
+      qualityTagsJson: '[]',
+      blockedByJson: '[]',
+      softDependsOnJson: '[]',
+      conflictsWithJson: '[]',
+      claimsJson: '{}',
+      inputDependenciesJson: '[]',
+      testCasesJson: '[]',
+      testDesignStatus: 'pending',
+      validationStatus: 'pending',
+      validationAttempts: 0,
+      linksToJson: '[]',
+      architecturalInstructionsJson: '[]',
+      bucketId: 'bkt_default',
+      priorityBucket: 'P2',
+      ...overrides,
+    })
+    .run();
+}
+
+describe('ReadyPoolConsumer — RUN-MODES gate', () => {
+  it('full-mode story with idle worker is assigned', async () => {
+    const { db, registry, consumer } = setup();
+    insertStory(db, 's_full', { runMode: 'full' });
+    registry.register({ kind: 'coding', id: 'wkr_1' });
+    const r = await consumer.pump();
+    expect(r.assignmentsMade).toHaveLength(1);
+    expect(r.assignmentsMade[0]!.storyId).toBe('s_full');
+  });
+
+  it('plan-only story is NEVER assigned even with an idle worker', async () => {
+    const { db, registry, consumer } = setup();
+    insertStory(db, 's_plan', { runMode: 'plan-only' });
+    registry.register({ kind: 'coding', id: 'wkr_1' });
+    const r = await consumer.pump();
+    expect(r.assignmentsMade).toEqual([]);
+    expect(r.readyButUnassigned).toEqual([]);
+    expect(r.readyTotal).toBe(0);
+    // Worker stays idle.
+    expect(registry.get('wkr_1')!.status).toBe('idle');
+    // Story stays unassigned (not flipped to coding_in_progress).
+    const story = db.select().from(stories).where(eq(stories.id, 's_plan')).get();
+    expect(story!.assignedWorkerId).toBeNull();
+  });
+
+  it('test-only story IS assigned (broker enforces capability allowlist downstream)', async () => {
+    const { db, registry, consumer } = setup();
+    insertStory(db, 's_test', { runMode: 'test-only' });
+    registry.register({ kind: 'coding', id: 'wkr_1' });
+    const r = await consumer.pump();
+    expect(r.assignmentsMade).toHaveLength(1);
+    expect(r.assignmentsMade[0]!.storyId).toBe('s_test');
+  });
+
+  it('mixed-mode batch: full + test-only get assigned, plan-only is skipped', async () => {
+    const { db, registry, consumer } = setup();
+    insertStory(db, 's_full', { runMode: 'full' });
+    insertStory(db, 's_plan', { runMode: 'plan-only' });
+    insertStory(db, 's_test', { runMode: 'test-only' });
+    registry.register({ kind: 'coding', id: 'wkr_a' });
+    registry.register({ kind: 'coding', id: 'wkr_b' });
+    registry.register({ kind: 'coding', id: 'wkr_c' });
+    const r = await consumer.pump();
+    expect(r.assignmentsMade).toHaveLength(2);
+    const assignedIds = r.assignmentsMade.map((a) => a.storyId).sort();
+    expect(assignedIds).toEqual(['s_full', 's_test']);
+    // Plan-only stays untouched.
+    const plan = db.select().from(stories).where(eq(stories.id, 's_plan')).get();
+    expect(plan!.assignedWorkerId).toBeNull();
+  });
+
+  it('plan-only story does not contribute to readyTotal', async () => {
+    const { db, consumer } = setup();
+    insertStory(db, 's_plan_a', { runMode: 'plan-only' });
+    insertStory(db, 's_plan_b', { runMode: 'plan-only' });
+    const r = await consumer.pump();
+    expect(r.readyTotal).toBe(0);
+  });
+
+  it('default run_mode (full) when not explicitly set behaves like full', async () => {
+    const { db, registry, consumer } = setup();
+    // Don't pass runMode override; the column default is 'full'.
+    insertStory(db, 's_default');
+    registry.register({ kind: 'coding', id: 'wkr_1' });
+    const r = await consumer.pump();
+    expect(r.assignmentsMade).toHaveLength(1);
+  });
+
+  it('plan-only story remains unassigned across multiple pumps', async () => {
+    const { db, registry, consumer } = setup();
+    insertStory(db, 's_plan', { runMode: 'plan-only' });
+    registry.register({ kind: 'coding', id: 'wkr_1' });
+    await consumer.pump();
+    await consumer.pump();
+    await consumer.pump();
+    const story = db.select().from(stories).where(eq(stories.id, 's_plan')).get();
+    expect(story!.assignedWorkerId).toBeNull();
+    expect(registry.get('wkr_1')!.status).toBe('idle');
+  });
+
+  it('onBucketPlaced for a plan-only story does not assign', async () => {
+    const { db, registry, consumer } = setup();
+    insertStory(db, 's_plan', { runMode: 'plan-only' });
+    registry.register({ kind: 'coding', id: 'wkr_1' });
+    const r = await consumer.onBucketPlaced({ storyId: 's_plan', bucketId: 'bkt_default' });
+    expect(r.assignmentsMade).toEqual([]);
+  });
+});

--- a/apps/orchestrator/tests/run-modes/index.test.ts
+++ b/apps/orchestrator/tests/run-modes/index.test.ts
@@ -1,0 +1,217 @@
+/**
+ * RUN-MODES unit tests — guards every public function in run-modes/index.ts.
+ *
+ * Coverage strategy: every exported function gets at least one
+ * positive + one negative test case. Cost estimates have a stability
+ * test (same input → same output) and a relative-ordering test
+ * (test-only > plan-only on tokens because coding is included).
+ */
+
+import {
+  RUN_MODES,
+  DEFAULT_RUN_MODE,
+  isRunMode,
+  isTestOnlyStripped,
+  restrictAllowlistForMode,
+  shouldSkipWorkerAssignment,
+  shouldWriteCode,
+  shouldAllowDeployment,
+  estimateRunCost,
+  TEST_ONLY_STRIPPED_CAPABILITIES,
+  TEST_ONLY_STRIPPED_PREFIXES,
+} from '../../src/run-modes/index';
+
+describe('RUN_MODES enum + DEFAULT_RUN_MODE', () => {
+  it('contains exactly three modes with full first', () => {
+    expect(RUN_MODES).toEqual(['full', 'plan-only', 'test-only']);
+  });
+
+  it('default is full', () => {
+    expect(DEFAULT_RUN_MODE).toBe('full');
+  });
+});
+
+describe('isRunMode type guard', () => {
+  it('accepts every canonical mode', () => {
+    expect(isRunMode('full')).toBe(true);
+    expect(isRunMode('plan-only')).toBe(true);
+    expect(isRunMode('test-only')).toBe(true);
+  });
+
+  it('rejects non-string and unknown-string inputs', () => {
+    expect(isRunMode(undefined)).toBe(false);
+    expect(isRunMode(null)).toBe(false);
+    expect(isRunMode(0)).toBe(false);
+    expect(isRunMode('Full')).toBe(false); // case sensitive
+    expect(isRunMode('PLAN-ONLY')).toBe(false);
+    expect(isRunMode('plan_only')).toBe(false);
+    expect(isRunMode('')).toBe(false);
+    expect(isRunMode('execute')).toBe(false);
+  });
+});
+
+describe('isTestOnlyStripped capability filter', () => {
+  it('strips every explicitly named capability', () => {
+    for (const cap of TEST_ONLY_STRIPPED_CAPABILITIES) {
+      expect(isTestOnlyStripped(cap)).toBe(true);
+    }
+  });
+
+  it('strips capabilities matching a stripped prefix', () => {
+    expect(isTestOnlyStripped('cloudflare_pages_deploy_preview')).toBe(true);
+    expect(isTestOnlyStripped('cloudflare_pages_deploy_prod')).toBe(true);
+  });
+
+  it('keeps capabilities that don\'t match the strip list', () => {
+    expect(isTestOnlyStripped('git_clone')).toBe(false);
+    expect(isTestOnlyStripped('npm_install')).toBe(false);
+    expect(isTestOnlyStripped('git_push_feature_branch')).toBe(false);
+    expect(isTestOnlyStripped('supabase_query')).toBe(false);
+  });
+
+  it('exposes a non-empty prefix list (defence against accidental empty)', () => {
+    expect(TEST_ONLY_STRIPPED_PREFIXES.length).toBeGreaterThan(0);
+  });
+});
+
+describe('restrictAllowlistForMode', () => {
+  const FULL_ALLOWLIST = [
+    'git_clone',
+    'git_push_feature_branch',
+    'git_push_main',
+    'npm_install',
+    'npm_publish',
+    'cloudflare_pages_deploy_preview',
+    'cloudflare_pages_deploy_prod',
+    'supabase_query',
+    'supabase_migration_apply',
+  ];
+
+  it('passes through full unchanged', () => {
+    const out = restrictAllowlistForMode('full', FULL_ALLOWLIST);
+    expect(out).toEqual(FULL_ALLOWLIST);
+    // returns a fresh array, not the same reference (defends against
+    // accidental shared mutable state)
+    expect(out).not.toBe(FULL_ALLOWLIST);
+  });
+
+  it('passes through plan-only unchanged (no worker = no enforcement needed)', () => {
+    const out = restrictAllowlistForMode('plan-only', FULL_ALLOWLIST);
+    expect(out).toEqual(FULL_ALLOWLIST);
+  });
+
+  it('strips deploy / publish / push-main capabilities under test-only', () => {
+    const out = restrictAllowlistForMode('test-only', FULL_ALLOWLIST);
+    expect(out).toContain('git_clone');
+    expect(out).toContain('git_push_feature_branch');
+    expect(out).toContain('npm_install');
+    expect(out).toContain('supabase_query');
+    expect(out).not.toContain('git_push_main');
+    expect(out).not.toContain('npm_publish');
+    expect(out).not.toContain('cloudflare_pages_deploy_preview');
+    expect(out).not.toContain('cloudflare_pages_deploy_prod');
+    expect(out).not.toContain('supabase_migration_apply');
+  });
+
+  it('preserves order of remaining capabilities under test-only', () => {
+    const out = restrictAllowlistForMode('test-only', FULL_ALLOWLIST);
+    expect(out).toEqual(['git_clone', 'git_push_feature_branch', 'npm_install', 'supabase_query']);
+  });
+
+  it('handles empty allowlist gracefully', () => {
+    expect(restrictAllowlistForMode('test-only', [])).toEqual([]);
+    expect(restrictAllowlistForMode('full', [])).toEqual([]);
+    expect(restrictAllowlistForMode('plan-only', [])).toEqual([]);
+  });
+});
+
+describe('shouldSkipWorkerAssignment / shouldWriteCode / shouldAllowDeployment', () => {
+  it('plan-only: skip = true, writeCode = false, deploy = false', () => {
+    expect(shouldSkipWorkerAssignment('plan-only')).toBe(true);
+    expect(shouldWriteCode('plan-only')).toBe(false);
+    expect(shouldAllowDeployment('plan-only')).toBe(false);
+  });
+
+  it('test-only: skip = false, writeCode = true, deploy = false', () => {
+    expect(shouldSkipWorkerAssignment('test-only')).toBe(false);
+    expect(shouldWriteCode('test-only')).toBe(true);
+    expect(shouldAllowDeployment('test-only')).toBe(false);
+  });
+
+  it('full: skip = false, writeCode = true, deploy = true', () => {
+    expect(shouldSkipWorkerAssignment('full')).toBe(false);
+    expect(shouldWriteCode('full')).toBe(true);
+    expect(shouldAllowDeployment('full')).toBe(true);
+  });
+});
+
+describe('estimateRunCost', () => {
+  const STORY_IDS = ['story_001', 'story_002', 'story_003'];
+
+  it('returns a stable shape with all fields', () => {
+    const out = estimateRunCost('full', STORY_IDS);
+    expect(out.mode).toBe('full');
+    expect(out.totalStories).toBe(3);
+    expect(out.totalInputTokens).toBeGreaterThan(0);
+    expect(out.totalOutputTokens).toBeGreaterThan(0);
+    expect(out.estimatedUsd).toBeGreaterThan(0);
+    expect(out.perStory).toHaveLength(3);
+    expect(out.perStory[0]?.storyId).toBe('story_001');
+  });
+
+  it('plan-only excludes coding-agent tokens (so estimate is lower than full)', () => {
+    const fullEst = estimateRunCost('full', STORY_IDS);
+    const planEst = estimateRunCost('plan-only', STORY_IDS);
+    expect(planEst.totalInputTokens).toBeLessThan(fullEst.totalInputTokens);
+    expect(planEst.totalOutputTokens).toBeLessThan(fullEst.totalOutputTokens);
+    expect(planEst.estimatedUsd).toBeLessThan(fullEst.estimatedUsd);
+  });
+
+  it('test-only matches full on token count (coding still runs)', () => {
+    const fullEst = estimateRunCost('full', STORY_IDS);
+    const testEst = estimateRunCost('test-only', STORY_IDS);
+    expect(testEst.totalInputTokens).toBe(fullEst.totalInputTokens);
+    expect(testEst.totalOutputTokens).toBe(fullEst.totalOutputTokens);
+    expect(testEst.estimatedUsd).toBe(fullEst.estimatedUsd);
+  });
+
+  it('totals scale linearly with story count', () => {
+    const oneStory = estimateRunCost('full', ['s1']);
+    const tenStories = estimateRunCost('full', Array.from({ length: 10 }, (_, i) => `s${i}`));
+    expect(tenStories.totalInputTokens).toBe(oneStory.totalInputTokens * 10);
+    expect(tenStories.totalOutputTokens).toBe(oneStory.totalOutputTokens * 10);
+    // USD is rounded to 4 decimals so allow tiny drift
+    expect(Math.abs(tenStories.estimatedUsd - oneStory.estimatedUsd * 10)).toBeLessThan(0.001);
+  });
+
+  it('handles zero stories', () => {
+    const out = estimateRunCost('full', []);
+    expect(out.totalStories).toBe(0);
+    expect(out.totalInputTokens).toBe(0);
+    expect(out.totalOutputTokens).toBe(0);
+    expect(out.estimatedUsd).toBe(0);
+    expect(out.perStory).toEqual([]);
+  });
+
+  it('per-story estimate is uniform for a uniform-mode run', () => {
+    const out = estimateRunCost('full', STORY_IDS);
+    const first = out.perStory[0]!;
+    for (const ps of out.perStory) {
+      expect(ps.totalInputTokens).toBe(first.totalInputTokens);
+      expect(ps.totalOutputTokens).toBe(first.totalOutputTokens);
+      expect(ps.estimatedUsd).toBe(first.estimatedUsd);
+    }
+  });
+
+  it('is deterministic on repeated calls', () => {
+    const a = estimateRunCost('full', STORY_IDS);
+    const b = estimateRunCost('full', STORY_IDS);
+    expect(a).toEqual(b);
+  });
+
+  it('records the mode it was called with', () => {
+    expect(estimateRunCost('full', STORY_IDS).mode).toBe('full');
+    expect(estimateRunCost('plan-only', STORY_IDS).mode).toBe('plan-only');
+    expect(estimateRunCost('test-only', STORY_IDS).mode).toBe('test-only');
+  });
+});

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -1,0 +1,84 @@
+# Run modes — plan-only and test-only
+
+Status: shipped 2026-04-30 (migration `0038_run_mode`).
+
+Every prompt submitted to CAIA is a **run**. A run mode controls how far down the pipeline a run goes. There are three modes:
+
+- **`full`** — the default. The full Phase-1 + Phase-2 pipeline runs: PO + BA + EA + Validator + Test-Design + Task Manager + Coding Agent + Fix-It (if needed). Code is written, tests are run, PRs are opened.
+- **`plan-only`** — the decomposition pipeline runs (PO + BA + EA + Validator + Test-Design + Task Manager) and stories reach `bucket_placed` / `ready_for_pickup`, but no worker is ever assigned. The output is the WorkGraph + per-story `architecturalInstructions[]` + estimated tokens / cost. No file writes, no PRs. Useful for "what would CAIA do with this prompt — and how much would it cost?" preview.
+- **`test-only`** — the full pipeline runs, including the Coding Agent, but the per-run capability allowlist is restricted before the Context Capsule is frozen. Deploy / publish / push-main capabilities are stripped: `git_push_main`, `cloudflare_pages_deploy_*`, `supabase_migration_apply`, `npm_publish`. Code is written and tested in a worktree but never deployed or shipped. Useful for "show me what the implementation would look like, but don't go live yet."
+
+The single source of truth for the mode list and the per-mode behaviour is `apps/orchestrator/src/run-modes/index.ts`.
+
+## How to invoke
+
+### Dashboard
+
+The submit form has three buttons:
+
+- **Run full →** — default behaviour, equivalent to the historical "Submit to your AI team".
+- **Run plan only — show me the cost** — submits with `runMode=plan-only`.
+- **Run test only — code but don't deploy** — submits with `runMode=test-only`.
+
+After submission, fetch `/api/prompts/<id>/plan-output` to render the plan and cost breakdown.
+
+### CLI
+
+The `@chiefaia/cli` package now exposes:
+
+```
+caia plan "Build a feature for X"
+caia test "Refactor the auth flow"
+```
+
+Both accept `--api`, `--project`, and `--priority` flags. The CLI POSTs to the orchestrator's `/prompts` endpoint with the corresponding `run_mode` field.
+
+### HTTP API
+
+```
+POST /prompts
+Content-Type: application/json
+
+{
+  "body": "Build a feature for X",
+  "received_via": "api",
+  "run_mode": "plan-only"
+}
+```
+
+`run_mode` is optional. If absent, the orchestrator defaults to `full`. Unknown values are 400'd at the API boundary so callers learn about typos immediately rather than silently falling back.
+
+## What's enforced where
+
+| Concern | Enforced in | Notes |
+|---|---|---|
+| Run mode is recorded on the prompt | `prompts.run_mode` (migration 0038) | `NOT NULL DEFAULT 'full'` |
+| Run mode is denormalised onto every story | `stories.run_mode` (migration 0038) | Inherited from the prompt at PO Agent story-creation time. |
+| Plan-only runs never reach a worker | `ReadyPoolConsumer.pump()` | The SQL `WHERE` clause filters `run_mode != 'plan-only'`. |
+| Test-only runs have restricted capabilities | Capability Broker (Track 1) | Until the broker lands, the orchestrator emits the run-mode in the `ticket.capsule-frozen` event for downstream consumers. |
+| Run-mode validation | `POST /prompts` | 400 with the canonical mode list on unknown values. |
+
+## Cost estimation
+
+`estimateRunCost(mode, storyIds)` in `run-modes/index.ts` returns a rough-cut estimate of input + output tokens and USD cost (Sonnet-class pricing). The per-agent token figures are deliberate approximations; the dashboard renders them with a "± rough estimate" caveat. Refine as actual telemetry from `executor_runs.tokens_in/out` accumulates.
+
+The estimate excludes Coding Agent + Fix-It tokens for `plan-only` runs (they don't run); they are included for `test-only` and `full`.
+
+## Cross-references
+
+- **Context Capsule (PR #207, migration 0037)** — the per-story Context Capsule is what the Coding Agent verifies on pickup. The capsule's `tool_allowlist` slice is the input to the capability allowlist that test-only runs strip. Drift between the freeze (test-only-restricted) and pickup (full allowlist read) is detectable as a `capsule-drift` blocker.
+- **Capability Broker (Track 1, in flight)** — the broker reads `stories.run_mode` and applies `restrictAllowlistForMode()` before any tool call. Until it lands, test-only enforcement is plumbing-level (event signalling) rather than hard-blocked.
+- **Spend-cap auto-pause (PR #206, HARDEN-011)** — orthogonal to run modes. Spend-cap halts a run independent of mode if the per-run dollar cap is exceeded.
+- **Evidence Gate (PR #200, §C.2)** — runs after the Coding Agent. Plan-only runs never reach the gate; test-only and full do.
+
+## Operational notes
+
+Default behaviour for every existing prompt + every in-flight prompt is unchanged. The migration adds the column with `DEFAULT 'full'`, so prompts created before this change carry `run_mode='full'` and follow the historical path.
+
+The denormalised `stories.run_mode` column is what the consumer reads — the join to `prompts` is intentionally avoided in the hot path.
+
+To audit how many runs of each mode have shipped:
+
+```sql
+SELECT run_mode, COUNT(*) FROM prompts GROUP BY run_mode;
+```

--- a/packages/cli/src/commands/plan.ts
+++ b/packages/cli/src/commands/plan.ts
@@ -1,0 +1,61 @@
+import type { Command } from 'commander';
+
+/**
+ * `caia plan <prompt-text>` — submit a prompt in plan-only run mode.
+ *
+ * Plan-only runs the full decomposition pipeline (PO + BA + EA +
+ * Validator + Test-Design + Task Manager) but the ReadyPoolConsumer
+ * skips worker assignment for plan-only stories. Output is the
+ * WorkGraph + per-story architecturalInstructions + estimated
+ * tokens/cost. No file writes, no PRs.
+ *
+ * The CLI POSTs to /api/prompts with `run_mode: "plan-only"`. The
+ * orchestrator's response includes the prompt id; users then fetch
+ * /api/prompts/<id>/plan-output for the rendered plan once the
+ * pipeline completes.
+ *
+ * RUN-MODES (migration 0038, run-modes/index.ts) is the single source
+ * of truth for the run-mode enum.
+ */
+export function registerPlanCommand(program: Command): void {
+  program
+    .command('plan')
+    .description('Submit a prompt in plan-only mode (no code, no PRs — just the plan + cost)')
+    .argument('<prompt...>', 'Prompt text (rest args are joined with spaces)')
+    .option('--api <url>', 'Orchestrator API base URL', 'http://localhost:8787')
+    .option('--project <id>', 'Project id to attach the prompt to')
+    .option('--priority <p>', 'Priority bucket override (P0|P1|P2|P3)')
+    .action(async (promptParts: string[], opts: { api: string; project?: string; priority?: string }) => {
+      const promptText = promptParts.join(' ').trim();
+      if (!promptText) {
+        console.error('error: prompt text is required');
+        process.exit(2);
+      }
+      const payload = {
+        body: promptText,
+        received_via: 'cli',
+        run_mode: 'plan-only',
+        metadata: {
+          ...(opts.project ? { projectId: opts.project } : {}),
+          ...(opts.priority ? { priority: opts.priority } : {}),
+        },
+      };
+      try {
+        const res = await fetch(`${opts.api}/prompts`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = (await res.json()) as { id?: string; error?: string };
+        if (!res.ok) {
+          console.error(`error: ${data.error ?? `HTTP ${res.status}`}`);
+          process.exit(1);
+        }
+        console.log(`Submitted plan-only prompt ${data.id}`);
+        console.log(`  Poll: ${opts.api}/prompts/${data.id}/plan-output`);
+      } catch (err) {
+        console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,0 +1,61 @@
+import type { Command } from 'commander';
+
+/**
+ * `caia test <prompt-text>` — submit a prompt in test-only run mode.
+ *
+ * Test-only runs the full pipeline AND the Coding Agent (so code is
+ * actually written + unit-tested), but the per-run capability
+ * allowlist has deploy / publish / push-main capabilities stripped
+ * before the capsule is frozen. Nothing is deployed, nothing is
+ * published, nothing is pushed to main.
+ *
+ * Until the Track 1 capability broker is online, this is plumbing-
+ * level: the run-mode propagates through the pipeline + capsule, but
+ * actual enforcement is best-effort by the Coding Agent. Once the
+ * broker lands, the broker reads `stories.run_mode` and applies
+ * `restrictAllowlistForMode` from the run-modes module.
+ *
+ * The CLI POSTs to /api/prompts with `run_mode: "test-only"`.
+ */
+export function registerTestCommand(program: Command): void {
+  program
+    .command('test')
+    .description('Submit a prompt in test-only mode (writes code, runs tests, but never deploys / publishes / pushes main)')
+    .argument('<prompt...>', 'Prompt text (rest args are joined with spaces)')
+    .option('--api <url>', 'Orchestrator API base URL', 'http://localhost:8787')
+    .option('--project <id>', 'Project id to attach the prompt to')
+    .option('--priority <p>', 'Priority bucket override (P0|P1|P2|P3)')
+    .action(async (promptParts: string[], opts: { api: string; project?: string; priority?: string }) => {
+      const promptText = promptParts.join(' ').trim();
+      if (!promptText) {
+        console.error('error: prompt text is required');
+        process.exit(2);
+      }
+      const payload = {
+        body: promptText,
+        received_via: 'cli',
+        run_mode: 'test-only',
+        metadata: {
+          ...(opts.project ? { projectId: opts.project } : {}),
+          ...(opts.priority ? { priority: opts.priority } : {}),
+        },
+      };
+      try {
+        const res = await fetch(`${opts.api}/prompts`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = (await res.json()) as { id?: string; error?: string };
+        if (!res.ok) {
+          console.error(`error: ${data.error ?? `HTTP ${res.status}`}`);
+          process.exit(1);
+        }
+        console.log(`Submitted test-only prompt ${data.id}`);
+        console.log(`  Track: ${opts.api}/prompts/${data.id}`);
+      } catch (err) {
+        console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 import { registerNewCommand } from './commands/new.js';
 import { registerDoctorCommand } from './commands/doctor.js';
+import { registerPlanCommand } from './commands/plan.js';
+import { registerTestCommand } from './commands/test.js';
 
 export const program = new Command();
 
@@ -11,6 +13,8 @@ program
 
 registerNewCommand(program);
 registerDoctorCommand(program);
+registerPlanCommand(program);
+registerTestCommand(program);
 
 // Only parse when run directly as a script, not when imported in tests
 const isMain = process.argv[1] !== undefined &&

--- a/packages/cli/tests/run-modes.test.ts
+++ b/packages/cli/tests/run-modes.test.ts
@@ -1,0 +1,116 @@
+/**
+ * RUN-MODES CLI tests — registers `caia plan` and `caia test`.
+ *
+ * The full integration (POSTing to a live orchestrator) is exercised
+ * by the e2e suite; these tests assert the CLI surface, the run-mode
+ * payload shape, and error handling for missing prompt text.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { program } from '../src/index.js';
+
+describe('caia plan / caia test commands', () => {
+  it('registers a plan command', () => {
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain('plan');
+  });
+
+  it('registers a test command', () => {
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain('test');
+  });
+
+  it('plan command takes a variadic prompt argument', () => {
+    const planCmd = program.commands.find((c) => c.name() === 'plan');
+    expect(planCmd).toBeDefined();
+    const helpText = planCmd!.helpInformation();
+    expect(helpText).toMatch(/prompt/i);
+    expect(helpText).toMatch(/plan-only/);
+  });
+
+  it('test command takes a variadic prompt argument', () => {
+    const testCmd = program.commands.find((c) => c.name() === 'test');
+    expect(testCmd).toBeDefined();
+    const helpText = testCmd!.helpInformation();
+    expect(helpText).toMatch(/test-only/);
+  });
+
+  it('plan command exposes --api option with a default', () => {
+    const planCmd = program.commands.find((c) => c.name() === 'plan');
+    const apiOpt = planCmd!.options.find((o) => o.long === '--api');
+    expect(apiOpt).toBeDefined();
+    expect(apiOpt!.defaultValue).toBe('http://localhost:8787');
+  });
+
+  it('test command exposes --api option with a default', () => {
+    const testCmd = program.commands.find((c) => c.name() === 'test');
+    const apiOpt = testCmd!.options.find((o) => o.long === '--api');
+    expect(apiOpt).toBeDefined();
+    expect(apiOpt!.defaultValue).toBe('http://localhost:8787');
+  });
+
+  it('plan command supports --project and --priority flags', () => {
+    const planCmd = program.commands.find((c) => c.name() === 'plan');
+    const longs = planCmd!.options.map((o) => o.long);
+    expect(longs).toContain('--project');
+    expect(longs).toContain('--priority');
+  });
+
+  it('plan command description mentions cost preview', () => {
+    const planCmd = program.commands.find((c) => c.name() === 'plan');
+    const desc = planCmd!.description();
+    expect(desc.toLowerCase()).toMatch(/cost|plan/);
+  });
+});
+
+describe('plan / test commands — POST payload shape', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('plan POSTs run_mode=plan-only', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ id: 'prm_test' }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const planCmd = program.commands.find((c) => c.name() === 'plan')!;
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await planCmd.parseAsync(['Build', 'a', 'feature'], { from: 'user' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.run_mode).toBe('plan-only');
+    expect(body.body).toBe('Build a feature');
+    expect(body.received_via).toBe('cli');
+    consoleSpy.mockRestore();
+  });
+
+  it('test POSTs run_mode=test-only', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ id: 'prm_test' }),
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const testCmd = program.commands.find((c) => c.name() === 'test')!;
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await testCmd.parseAsync(['Refactor', 'something'], { from: 'user' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.run_mode).toBe('test-only');
+    expect(body.body).toBe('Refactor something');
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## RUN-MODES — plan-only + test-only run modes (migration 0038)

Adds two non-default run modes to CAIA's pipeline:

- **`plan-only`** — runs PO + BA + EA + Validator + Test-Design + Task Manager, but `ReadyPoolConsumer.pump()` skips worker assignment for these stories. Output is the WorkGraph + per-story `architecturalInstructions[]` + estimated tokens / cost. No file writes, no PRs.
- **`test-only`** — full pipeline runs including the Coding Agent. The `run_mode` is propagated through prompt -> stories -> capsule-frozen event so the (in-flight) capability broker can strip `git_push_main` / `cloudflare_pages_deploy_*` / `supabase_migration_apply` / `npm_publish` from the per-run allowlist. Until the broker lands, this is plumbing-level (event signalling) — see `TODO(track-1-broker)` in `capsule-freezer.ts`.

Default `full` preserves all existing behaviour.

### What lands

- Migration `0038_run_mode.sql` — adds `run_mode` to `prompts` and (denormalised) to `stories`. `NOT NULL DEFAULT 'full'`. Indexed.
- `apps/orchestrator/src/run-modes/index.ts` — single source of truth: `RUN_MODES`, `isRunMode`, `restrictAllowlistForMode`, `shouldSkipWorkerAssignment`, `estimateRunCost`. 19 unit tests.
- `apps/orchestrator/src/agents/ready-pool-consumer.ts` — pump query filters `run_mode != 'plan-only'`. 8 new integration tests cover the gate.
- `apps/orchestrator/src/agents/po-agent.ts` — propagates `prompts.run_mode` onto every story it creates.
- `apps/orchestrator/src/agents/capsule-freezer.ts` — emits `run_mode` in the `ticket.capsule-frozen` event for downstream broker integration.
- `apps/orchestrator/src/api/routes/prompts.ts` — accepts + validates `run_mode` on `POST /prompts`. New `GET /prompts/:id/plan-output` endpoint returns the WorkGraph + cost estimate.
- `packages/cli` — new `caia plan` and `caia test` commands. 10 new tests.
- `apps/dashboard/app/submit/page.tsx` — three buttons replacing the single submit: "Run full ->", "Run plan only — show me the cost", "Run test only — code but don't deploy".
- `apps/dashboard/app/api/prompts/route.ts` — new POST proxy that translates dashboard -> orchestrator wire shape and forwards `run_mode`.
- `docs/run-modes.md` — operator-facing documentation with the cross-reference table.

### Test counts

- `@chiefaia/ticket-template`: 153 passing (no change)
- `@chiefaia/cli`: 12 passing (10 new)
- `@caia-app/worker-coding`: 123 passing (no change)
- Orchestrator e2e (Pipeline regression): exercised through CI

### Cross-references

- **D1 / Context Capsule (#207, migration 0037)** — capsule's `tool_allowlist` slice is the input to the per-run allowlist that test-only restricts. Drift between freeze (test-only-restricted) and pickup is detectable as `capsule-drift`.
- **Track 1 / Capability Broker (in flight)** — will consume the `ticket.capsule-frozen` event's `runMode` and apply `restrictAllowlistForMode()` at every tool call. Until then test-only is plumbed but enforcement is best-effort.
- **Spend-cap auto-pause (#206, HARDEN-011)** — orthogonal. Spend-cap halts a run independent of mode.
- **Evidence Gate (#200, §C.2)** — runs after Coding Agent. Plan-only never reaches it; full and test-only do.
