### PR TITLE
feat(decomposer-recursive): scope detector + atomicity classifier + Zod schemas (PO-DECOMP-001)

### DIFF
--- a/packages/decomposer-recursive/eslint.config.cjs
+++ b/packages/decomposer-recursive/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/decomposer-recursive/package.json
+++ b/packages/decomposer-recursive/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@chiefaia/decomposer-recursive",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Recursive PO decomposition engine — scope detector + atomicity classifier + per-scope decomposers + MECE judge pair.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/local-llm-router": "workspace:*",
+    "@chiefaia/ticket-template": "workspace:*",
+    "nanoid": "^5.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT"
+}

--- a/packages/decomposer-recursive/src/atomicity-classifier.ts
+++ b/packages/decomposer-recursive/src/atomicity-classifier.ts
@@ -1,0 +1,171 @@
+/**
+ * Atomicity classifier.
+ *
+ * After a parent expansion, every candidate child runs through this
+ * classifier to decide:
+ *   - `atomic = true`  → the recursion stops at this child (it's a leaf).
+ *   - `atomic = false` → the child is enqueued for decomposition at the
+ *                        next-lower scope.
+ *
+ * Each scope has its own rubric (proposal §5C). The rubric is sent
+ * verbatim to the LLM along with the child ticket; the LLM returns
+ * `{ atomic, confidence, rationale, failedCriteria[] }`.
+ *
+ * Like the scope detector this is a classification task, so the
+ * `po-decomposer-atomicity-classification` routing rule prefers
+ * Ollama (qwen2.5-coder:7b) with Claude fallback.
+ */
+
+import { AtomicityLlmOutputSchema } from './schemas.js';
+import { callStructured } from './structured-output.js';
+import type {
+  AtomicityVerdict,
+  CancellationSignal,
+  ChildTicket,
+  StoryScope,
+} from './types.js';
+
+export const ATOMICITY_CLASSIFICATION_TASK_TYPE =
+  'po-decomposer-atomicity-classification';
+
+// ─── Per-scope rubrics (proposal §5C) ───────────────────────────────────
+
+/**
+ * Rubric per scope. The LLM is asked to evaluate the candidate child
+ * against EVERY criterion; `atomic = true` requires every criterion
+ * to pass; `failedCriteria[]` lists the criteria that failed when the
+ * verdict is `false`.
+ */
+export const ATOMICITY_RUBRICS: Record<StoryScope, readonly string[]> = {
+  initiative: [
+    'Single strategic bet (one elevator-pitch theme, one OKR/KPI cluster).',
+    'Sized to a single quarter or release-train without further strategic split.',
+    'Has 2-5 expected epics under it (else it is a multi-initiative vision).',
+  ],
+  epic: [
+    'Fits a single Program Increment per SAFe (8-12 weeks).',
+    'Single dominant value theme expressible in <= 25 words.',
+    'Crosses at most 2 modules (else it is an initiative-shaped concern).',
+    'Has 2-10 expected stories under it.',
+  ],
+  module: [
+    'Coherent bounded context (DDD) with single primary tech sub-domain.',
+    'Owns its data — at least one schema/table/state-store is conceptually under this module.',
+    'Has 2-8 stories under it (collapse to story if fewer; split if more).',
+    'Has clear API/contract boundary describable in one paragraph.',
+  ],
+  story: [
+    'INVEST-compliant: Independent (or with explicit deps), Negotiable, Valuable, Estimable, Small, Testable.',
+    'Sized to a single PR / <= 1 sprint of work.',
+    'Touches a single user-visible value increment.',
+    'Has 3-6 concrete acceptance criteria, each testable, each >= 8 words.',
+    'Atomic-self-check: NO description containing "and"/"also"/"while" coordinating two distinct user concerns.',
+  ],
+  task: [
+    'Single concern (no "and"/"also" coordinating distinct concerns in the description).',
+    'Single primary tech sub-domain.',
+    'Sized to <= 1 day of work for a competent engineer.',
+    'Touches <= 3 files or a single tightly-coupled cluster.',
+    'Concrete artifact target: function/class/route/schema name explicitly mentioned or inferable.',
+  ],
+  subtask: [
+    'Single mechanical step (single function, single test, single comment block, single config edit).',
+    'Sized to <= 2 hours of work.',
+    'Names the precise artifact (function name, test name, file region).',
+    'No scope question — implementation is mechanical given the parent task.',
+  ],
+};
+
+// ─── System prompt ──────────────────────────────────────────────────────
+
+function buildAtomicitySystemPrompt(scope: StoryScope): string {
+  const rubric = ATOMICITY_RUBRICS[scope];
+  const rubricBlock = rubric.map((c, i) => `  ${String(i + 1)}. ${c}`).join('\n');
+  return `You are a senior product manager applying the atomicity rubric for a "${scope}" ticket.
+
+A ${scope} is atomic if and only if EVERY rubric item below passes for the candidate ticket.
+
+Rubric for ${scope}:
+${rubricBlock}
+
+Output schema:
+{
+  "atomic": true | false,
+  "confidence": 0.0..1.0,
+  "rationale": "one paragraph (<= 80 words) summarising the verdict",
+  "failedCriteria": [ "verbatim text of each failing rubric item" ]
+}
+
+Hard rules:
+- "atomic": true requires "failedCriteria" to be empty.
+- "atomic": false requires "failedCriteria" to be non-empty.
+- "failedCriteria" entries must be verbatim copies of rubric items above.
+- If you are unsure, prefer "atomic": false with a low confidence — the
+  recursion will refine. Returning a wrong "atomic": true blocks
+  downstream agents from catching a mis-sized ticket.`;
+}
+
+function buildAtomicityUserPrompt(child: ChildTicket): string {
+  const acLine =
+    child.acceptanceCriteria && child.acceptanceCriteria.length > 0
+      ? `Acceptance criteria:\n${child.acceptanceCriteria.map((a) => `  - ${a}`).join('\n')}`
+      : 'Acceptance criteria: (none)';
+
+  return (
+    `Evaluate this candidate ticket against the rubric.\n\n` +
+    `Title: ${child.title}\n` +
+    `Scope: ${child.scope}\n` +
+    `Description: ${child.description}\n` +
+    `In scope: ${child.inScope.join('; ') || '(empty)'}\n` +
+    `Out of scope: ${child.outOfScope.join('; ') || '(empty)'}\n` +
+    `${acLine}\n` +
+    `Lifecycle: ${child.lifecycle}\n` +
+    `Sibling dependencies: ${child.dependencies.length === 0 ? '(none)' : child.dependencies.join(', ')}`
+  );
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────
+
+export interface ClassifyAtomicityOptions {
+  child: ChildTicket;
+  signal?: CancellationSignal;
+}
+
+/**
+ * Classify whether a candidate child is atomic at its declared scope.
+ */
+export async function classifyAtomicity(
+  options: ClassifyAtomicityOptions,
+): Promise<AtomicityVerdict> {
+  const { child, signal } = options;
+
+  const result = await callStructured(AtomicityLlmOutputSchema, {
+    taskType: ATOMICITY_CLASSIFICATION_TASK_TYPE,
+    systemPrompt: buildAtomicitySystemPrompt(child.scope),
+    userPrompt: buildAtomicityUserPrompt(child),
+    maxRetries: 2,
+    ...(signal ? { signal } : {}),
+  });
+
+  // Enforce the contract beyond Zod: if the model returned atomic=true
+  // with non-empty failedCriteria (or vice versa), force-correct by
+  // setting atomic to match the failedCriteria array. Conservative bias
+  // toward "not atomic" so the recursion errs on more decomposition,
+  // never less.
+  let atomic = result.data.atomic;
+  const failedCriteria = result.data.failedCriteria;
+  if (atomic && failedCriteria.length > 0) {
+    atomic = false;
+  } else if (!atomic && failedCriteria.length === 0) {
+    atomic = true;
+  }
+
+  return {
+    atomic,
+    confidence: result.data.confidence,
+    rationale: result.data.rationale,
+    failedCriteria,
+    model: result.model,
+    durationMs: result.durationMs,
+  };
+}

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -1,0 +1,80 @@
+/**
+ * Public API for @chiefaia/decomposer-recursive.
+ *
+ * P0 (this slice): scope detector + atomicity classifier + Zod schemas
+ * + structured-output helper. The orchestrator engine, per-scope
+ * decomposers, and judge pair land in PRs 2 + 3 respectively.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export type {
+  AuditEntry,
+  AtomicityVerdict,
+  CancellationSignal,
+  ChildTicket,
+  ClarifyingQuestion,
+  Decomposition,
+  DependencyEdge,
+  ExistingArtifactRef,
+  ScopeDetection,
+  StoryScope,
+} from './types.js';
+
+export { STORY_SCOPES, STORY_SCOPE_ORDER, isStoryScope } from './types.js';
+
+// ─── Schemas ────────────────────────────────────────────────────────────
+
+export {
+  AuditEntrySchema,
+  AtomicityLlmOutputSchema,
+  ChildTicketArraySchema,
+  ChildTicketSchema,
+  ClarifyingQuestionSchema,
+  DecompositionSchema,
+  DependencyEdgeSchema,
+  ExistingArtifactRefSchema,
+  ScopeDetectionLlmOutputSchema,
+  StoryScopeSchema,
+} from './schemas.js';
+
+export type {
+  ChildTicketSchemaT,
+  ChildTicketArraySchemaT,
+  DecompositionSchemaT,
+  ScopeDetectionLlmOutputT,
+  AtomicityLlmOutputT,
+} from './schemas.js';
+
+// ─── Structured-output helper ───────────────────────────────────────────
+
+export {
+  callStructured,
+  extractJson,
+  StructuredOutputCancelled,
+  StructuredOutputParseError,
+} from './structured-output.js';
+
+export type {
+  StructuredOutputOptions,
+  StructuredOutputResult,
+} from './structured-output.js';
+
+// ─── Scope detector ─────────────────────────────────────────────────────
+
+export {
+  SCOPE_DETECTION_TASK_TYPE,
+  detectScope,
+} from './scope-detector.js';
+
+export type { DetectScopeOptions } from './scope-detector.js';
+
+// ─── Atomicity classifier ──────────────────────────────────────────────
+
+export {
+  ATOMICITY_CLASSIFICATION_TASK_TYPE,
+  ATOMICITY_RUBRICS,
+  classifyAtomicity,
+} from './atomicity-classifier.js';
+
+export type { ClassifyAtomicityOptions } from './atomicity-classifier.js';

--- a/packages/decomposer-recursive/src/schemas.ts
+++ b/packages/decomposer-recursive/src/schemas.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import { STORY_SCOPES } from '@chiefaia/ticket-template';
+
+export const StoryScopeSchema = z.enum(STORY_SCOPES);
+
+export const ExistingArtifactRefSchema = z.object({
+  source: z.enum(['feature', 'arch_artifact']),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  score: z.number().min(0).max(1),
+  hint: z.string().optional(),
+});
+
+export const ChildTicketSchema = z
+  .object({
+    id: z.string().min(1),
+    scope: StoryScopeSchema,
+    title: z.string().min(3).max(200),
+    description: z.string().min(10),
+    acceptanceCriteria: z.array(z.string().min(8)).optional(),
+    inScope: z.array(z.string().min(5)),
+    outOfScope: z.array(z.string()),
+    dependencies: z.array(z.string()),
+    estimatedAtomic: z.boolean(),
+    existingArtifacts: z.array(ExistingArtifactRefSchema),
+    lifecycle: z.enum(['new', 'enhance', 'reuse']),
+  })
+  .refine((c) => !c.dependencies.includes(c.id), {
+    message: 'A child cannot depend on itself',
+    path: ['dependencies'],
+  });
+
+export const ChildTicketArraySchema = z
+  .array(ChildTicketSchema)
+  .refine(
+    (children) => {
+      const ids = new Set<string>();
+      for (const c of children) {
+        if (ids.has(c.id)) return false;
+        ids.add(c.id);
+      }
+      return true;
+    },
+    { message: 'Sibling child IDs must be unique' },
+  );
+
+export const ClarifyingQuestionSchema = z.object({
+  id: z.string().min(1),
+  parentNodeId: z.string().min(1),
+  question: z.string().min(5),
+  proposedAnswers: z.array(z.string()),
+  blocksBranch: z.boolean(),
+  rationale: z.string().min(5),
+});
+
+export const DependencyEdgeSchema = z
+  .object({
+    fromChildId: z.string().min(1),
+    toChildId: z.string().min(1),
+    kind: z.enum(['blocks', 'soft', 'capability']),
+    rationale: z.string().min(3),
+  })
+  .refine((e) => e.fromChildId !== e.toChildId, {
+    message: 'A dependency edge cannot self-loop',
+    path: ['toChildId'],
+  });
+
+export const AuditEntrySchema = z.object({
+  parentNodeId: z.string().min(1),
+  parentScope: StoryScopeSchema,
+  childScope: StoryScopeSchema,
+  attempt: z.number().int().min(1),
+  promptTextHash: z.string().min(1),
+  model: z.string().min(1),
+  tokensIn: z.number().int().min(0),
+  tokensOut: z.number().int().min(0),
+  costUsd: z.number().min(0),
+  durationMs: z.number().min(0),
+  alternativesConsidered: z.number().int().min(0),
+  coverageScore: z.number().min(0).max(1).nullable(),
+  disjointnessScore: z.number().min(0).max(1).nullable(),
+  ambiguityDetected: z.boolean(),
+  questionsEmittedCount: z.number().int().min(0),
+  decisionRationale: z.string(),
+  childrenCount: z.number().int().min(0),
+  outcome: z.enum(['committed', 'reflexive-retry', 'stuck', 'awaiting-clarification']),
+});
+
+export const DecompositionSchema = z.object({
+  childTickets: ChildTicketArraySchema,
+  clarifyingQuestions: z.array(ClarifyingQuestionSchema),
+  dependencies: z.array(DependencyEdgeSchema),
+  confidence: z.number().min(0).max(1).nullable(),
+  judgeScores: z.object({
+    coverage: z.number().min(0).max(1).nullable(),
+    disjointness: z.number().min(0).max(1).nullable(),
+  }),
+  audit: AuditEntrySchema,
+});
+
+export const ScopeDetectionLlmOutputSchema = z.object({
+  targetScope: StoryScopeSchema,
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().min(3),
+});
+
+export const AtomicityLlmOutputSchema = z.object({
+  atomic: z.boolean(),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().min(3),
+  failedCriteria: z.array(z.string()),
+});
+
+export type ChildTicketSchemaT = z.infer<typeof ChildTicketSchema>;
+export type ChildTicketArraySchemaT = z.infer<typeof ChildTicketArraySchema>;
+export type DecompositionSchemaT = z.infer<typeof DecompositionSchema>;
+export type ScopeDetectionLlmOutputT = z.infer<typeof ScopeDetectionLlmOutputSchema>;
+export type AtomicityLlmOutputT = z.infer<typeof AtomicityLlmOutputSchema>;

--- a/packages/decomposer-recursive/src/scope-detector.ts
+++ b/packages/decomposer-recursive/src/scope-detector.ts
@@ -1,0 +1,93 @@
+/**
+ * Adaptive scope detector.
+ *
+ * Given a user prompt (and optional vision-doc summary), classify the
+ * smallest scope at which the prompt can be expressed without further
+ * decomposition. The decomposer engine (PR 2) starts recursion at this
+ * scope rather than always-starting-at-initiative — so "add a logout
+ * button" produces a single story, not a fake five-level tree.
+ *
+ * The classifier itself is a small LLM call routed through the local
+ * Ollama path (with Claude fallback) — it's a classification task,
+ * not a generative one, so qwen2.5-coder:7b handles it well.
+ */
+
+import { ScopeDetectionLlmOutputSchema } from './schemas.js';
+import { callStructured } from './structured-output.js';
+import type { ScopeDetection, CancellationSignal } from './types.js';
+
+export const SCOPE_DETECTION_TASK_TYPE = 'po-decomposer-scope-detection';
+
+export interface DetectScopeOptions {
+  /** The prompt text the user submitted. */
+  promptText: string;
+  /**
+   * Optional pre-extracted theme summary (used for vision documents
+   * post-chunking — P1; in P0 always undefined).
+   */
+  visionDocSummary?: string;
+  /** Optional cancellation signal. */
+  signal?: CancellationSignal;
+}
+
+const SCOPE_DETECTION_SYSTEM_PROMPT = `You are a senior product manager classifying the natural scope of a user request.
+
+The canonical scopes, from largest to smallest:
+- initiative — multi-quarter strategic bet, typically multi-team, multi-feature, multi-platform. Vision documents land here. Examples: "build an analytics SaaS", "launch a new product line".
+- epic — single program-increment-sized chunk (8-12 weeks per SAFe), one elevator-pitch theme, multiple modules. Examples: "build the billing system", "ship the leaderboard feature".
+- module — a coherent bounded context with one primary tech sub-domain and its own data ownership. Crosses 2-8 stories. Examples: "the user-auth module", "the notification dispatcher".
+- story — INVEST-compliant user-value increment. Single PR, ≤ 1 sprint, single user-visible value. Examples: "add a logout button", "users can filter by date".
+- task — single concern, ≤ 1 day, single tech-sub-domain. Often one file group. Examples: "refactor the password validator", "add the GET /users route".
+- subtask — single mechanical step: one function, one test, one config edit. Examples: "rename _x to _internal in foo.ts", "add the test for the empty-input case".
+
+Heuristic anchors:
+- One verb, one object, one concrete deliverable → story.
+- One verb, vague object → task.
+- Multi-paragraph but single feature → epic.
+- "Build [system]" / "we want to launch" → initiative.
+- Vision document, multi-feature, multi-team → initiative.
+- One-line, mechanical, no scope question → subtask.
+
+Output schema:
+{
+  "targetScope": "initiative" | "epic" | "module" | "story" | "task" | "subtask",
+  "confidence": 0.0..1.0,
+  "rationale": "one sentence explaining the verdict"
+}`;
+
+/**
+ * Classify the natural scope of a prompt.
+ *
+ * Returns a `ScopeDetection` with `targetScope`, `confidence`, and a
+ * one-sentence rationale. On parse failure or model error,
+ * propagates `StructuredOutputParseError` / `StructuredOutputCancelled`
+ * — the orchestrator (PR 2) catches and decides whether to file a
+ * `decomposer-stuck` blocker or retry with a fresh model.
+ */
+export async function detectScope(
+  options: DetectScopeOptions,
+): Promise<ScopeDetection> {
+  const userPrompt =
+    `Classify the natural scope of the following user prompt.\n\n` +
+    `=== PROMPT ===\n${options.promptText}\n=== END PROMPT ===\n` +
+    (options.visionDocSummary
+      ? `\n=== VISION-DOC SUMMARY (extracted themes) ===\n` +
+        `${options.visionDocSummary}\n=== END VISION-DOC SUMMARY ===`
+      : '');
+
+  const result = await callStructured(ScopeDetectionLlmOutputSchema, {
+    taskType: SCOPE_DETECTION_TASK_TYPE,
+    systemPrompt: SCOPE_DETECTION_SYSTEM_PROMPT,
+    userPrompt,
+    maxRetries: 2,
+    ...(options.signal ? { signal: options.signal } : {}),
+  });
+
+  return {
+    targetScope: result.data.targetScope,
+    confidence: result.data.confidence,
+    rationale: result.data.rationale,
+    model: result.model,
+    durationMs: result.durationMs,
+  };
+}

--- a/packages/decomposer-recursive/src/structured-output.ts
+++ b/packages/decomposer-recursive/src/structured-output.ts
@@ -1,0 +1,263 @@
+/**
+ * Structured-output helper for LLM calls.
+ *
+ * Every classifier / decomposer in this package routes through
+ * `@chiefaia/local-llm-router` and asks the model to emit JSON
+ * conforming to a Zod schema. This helper:
+ *
+ *   1. Wraps the system+user prompt in a JSON-only envelope.
+ *   2. Calls `route(taskType, prompt)`.
+ *   3. Extracts JSON from the response (the model may wrap the JSON
+ *      in markdown fences or surrounding prose; we tolerate both).
+ *   4. Parses against the Zod schema.
+ *   5. On parse failure, retries up to `maxRetries` times with the
+ *      Zod error appended to the user prompt as feedback. (The
+ *      rationale: this is the same reflexive-retry pattern Reflexion
+ *      formalised — the model gets told what went wrong and tries
+ *      again.)
+ *
+ * The helper does NOT enforce the cancellation signal — the underlying
+ * router doesn't accept one in its current API. The orchestrator (PR 2)
+ * checks `signal.aborted` between top-level recursion steps so a
+ * cancel still bounds wall-clock by ~one outstanding LLM call.
+ *
+ * Cost tracking: PR 1 returns a coarse cost estimate from the routing
+ * rule's claude cost string (per 1000 calls). PR 4 wires this through
+ * to the spend-cap when Track 1 lands.
+ */
+
+import { z } from 'zod';
+import { route } from '@chiefaia/local-llm-router';
+import { perCallCostFromRuleString, getRoute } from '@chiefaia/local-llm-router';
+import type { LLMResponse } from '@chiefaia/local-llm-router';
+
+export interface StructuredOutputOptions {
+  /** Routing-rule task type, e.g. 'po-decomposer-scope-detection'. */
+  taskType: string;
+  /** System-level instructions (role + invariants). */
+  systemPrompt: string;
+  /** User-level prompt (the actual data). */
+  userPrompt: string;
+  /** Max retries on Zod parse failure. Default 2 (so 3 attempts total). */
+  maxRetries?: number;
+  /** Optional cancellation signal — checked before each retry. */
+  signal?: AbortSignal;
+}
+
+export interface StructuredOutputResult<T> {
+  data: T;
+  /** The raw text the model returned on the successful attempt. */
+  rawResponse: string;
+  /** Provider that won (telemetry). */
+  provider: 'local' | 'claude';
+  /** Concrete model that produced the response (telemetry). */
+  model: string;
+  /** Wall-clock ms across all attempts (sum). */
+  durationMs: number;
+  /** USD spend estimate across all attempts. */
+  costUsd: number;
+  /** Number of attempts taken (1-indexed). 1 = no retry. */
+  attempts: number;
+  /** Token usage on the WINNING attempt. */
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+/**
+ * Thrown when even the last retry produced output that doesn't
+ * conform to the schema. The caller sees the final Zod error and the
+ * model's last raw response so it can decide to escalate (model
+ * swap, file a `decomposition-stuck` blocker, or surface to dashboard).
+ */
+export class StructuredOutputParseError extends Error {
+  public readonly attempts: number;
+  public readonly lastRaw: string;
+  public readonly zodError: z.ZodError;
+  public readonly taskType: string;
+
+  constructor(
+    taskType: string,
+    attempts: number,
+    lastRaw: string,
+    zodError: z.ZodError,
+  ) {
+    super(
+      `[decomposer-recursive] structured-output parse failed for task ` +
+        `"${taskType}" after ${String(attempts)} attempt(s): ` +
+        zodError.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+    );
+    this.name = 'StructuredOutputParseError';
+    this.taskType = taskType;
+    this.attempts = attempts;
+    this.lastRaw = lastRaw;
+    this.zodError = zodError;
+  }
+}
+
+/**
+ * Thrown when the user passed an `AbortSignal` and it fired before /
+ * during a retry. The orchestrator catches this to short-circuit
+ * recursion.
+ */
+export class StructuredOutputCancelled extends Error {
+  constructor(taskType: string) {
+    super(`[decomposer-recursive] cancelled before completing "${taskType}"`);
+    this.name = 'StructuredOutputCancelled';
+  }
+}
+
+const JSON_ONLY_INSTRUCTION =
+  '\n\nReturn ONLY a single JSON object that matches the schema described above. ' +
+  'No markdown fences, no surrounding prose, no explanations. ' +
+  'If you cannot answer, return JSON with the best-effort fields populated and ' +
+  'a low confidence value — never return prose.';
+
+/**
+ * Run an LLM call expecting a Zod-shaped JSON response, with bounded
+ * retry on parse failure.
+ */
+export async function callStructured<T extends z.ZodTypeAny>(
+  schema: T,
+  options: StructuredOutputOptions,
+): Promise<StructuredOutputResult<z.infer<T>>> {
+  const maxRetries = options.maxRetries ?? 2;
+  const totalAttempts = maxRetries + 1;
+
+  let totalDurationMs = 0;
+  let totalCostUsd = 0;
+  let lastRaw = '';
+  let lastZodError: z.ZodError | null = null;
+
+  let userPrompt = options.userPrompt;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    if (options.signal?.aborted) {
+      throw new StructuredOutputCancelled(options.taskType);
+    }
+
+    const fullPrompt =
+      `${options.systemPrompt}${JSON_ONLY_INSTRUCTION}\n\n` +
+      `=== USER ===\n${userPrompt}\n=== END USER ===`;
+
+    let resp: LLMResponse;
+    try {
+      resp = await route(options.taskType, fullPrompt);
+    } catch (err) {
+      // Network / model errors propagate. The caller decides whether
+      // to escalate or retry at a higher level (model swap, etc.).
+      throw err;
+    }
+
+    totalDurationMs += resp.durationMs;
+    totalCostUsd += estimateCallCost(options.taskType, resp);
+    lastRaw = resp.response;
+
+    const json = extractJson(resp.response);
+    if (json === null) {
+      lastZodError = new z.ZodError([
+        {
+          code: 'custom',
+          path: [],
+          message:
+            'No JSON object found in model response — wrap the answer in a single { ... } object.',
+        },
+      ]);
+    } else {
+      const parseResult = schema.safeParse(json);
+      if (parseResult.success) {
+        return {
+          data: parseResult.data as z.infer<T>,
+          rawResponse: resp.response,
+          provider: resp.provider,
+          model: resp.model,
+          durationMs: totalDurationMs,
+          costUsd: totalCostUsd,
+          attempts: attempt,
+          ...(resp.usage ? { usage: resp.usage } : {}),
+        };
+      }
+      lastZodError = parseResult.error;
+    }
+
+    // If we have retries left, append the parse error and try again.
+    if (attempt < totalAttempts && lastZodError) {
+      userPrompt =
+        `${options.userPrompt}\n\n=== PRIOR-ATTEMPT FAILURE ===\n` +
+        `Your previous response did not parse against the required schema. ` +
+        `The validator reported:\n` +
+        lastZodError.issues
+          .map((iss) => ` - ${iss.path.join('.') || '(root)'}: ${iss.message}`)
+          .join('\n') +
+        `\nFix every listed issue and return ONLY a single JSON object.`;
+    }
+  }
+
+  throw new StructuredOutputParseError(
+    options.taskType,
+    totalAttempts,
+    lastRaw,
+    lastZodError ?? new z.ZodError([]),
+  );
+}
+
+/**
+ * Best-effort JSON extractor. Tries:
+ *   1. Raw `JSON.parse` of the whole response.
+ *   2. Stripping markdown fences (```json ... ``` or ``` ... ```).
+ *   3. Greedy match for the outermost `{...}` block.
+ *
+ * Returns the parsed object, or `null` if no JSON object is recoverable.
+ */
+export function extractJson(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  // Direct parse.
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    // Fall through.
+  }
+
+  // Markdown-fence parse.
+  const fenceMatch = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
+  if (fenceMatch && fenceMatch[1]) {
+    const inner = fenceMatch[1].trim();
+    try {
+      return JSON.parse(inner) as unknown;
+    } catch {
+      // Fall through.
+    }
+  }
+
+  // Outermost-object parse.
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    const slice = trimmed.slice(firstBrace, lastBrace + 1);
+    try {
+      return JSON.parse(slice) as unknown;
+    } catch {
+      // Fall through.
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Estimate the per-call USD spend by reading the rule's
+ * `estimatedCostClaude` string ("$X per 1000 calls") and dividing by 1000.
+ *
+ * The estimate is intentionally coarse: it's used for the audit-row
+ * `costUsd` field and for the spend-guard pre-check (PR 4 wires that).
+ * Production cost-attribution would require token-level pricing.
+ */
+function estimateCallCost(taskType: string, resp: LLMResponse): number {
+  // Local calls are free.
+  if (resp.provider === 'local') return 0;
+  const rule = getRoute(taskType);
+  return perCallCostFromRuleString(rule.estimatedCostClaude);
+}

--- a/packages/decomposer-recursive/src/structured-output.ts
+++ b/packages/decomposer-recursive/src/structured-output.ts
@@ -142,14 +142,9 @@ export async function callStructured<T extends z.ZodTypeAny>(
       `${options.systemPrompt}${JSON_ONLY_INSTRUCTION}\n\n` +
       `=== USER ===\n${userPrompt}\n=== END USER ===`;
 
-    let resp: LLMResponse;
-    try {
-      resp = await route(options.taskType, fullPrompt);
-    } catch (err) {
-      // Network / model errors propagate. The caller decides whether
-      // to escalate or retry at a higher level (model swap, etc.).
-      throw err;
-    }
+    // Network / model errors propagate. The caller decides whether
+    // to escalate or retry at a higher level (model swap, etc.).
+    const resp: LLMResponse = await route(options.taskType, fullPrompt);
 
     totalDurationMs += resp.durationMs;
     totalCostUsd += estimateCallCost(options.taskType, resp);

--- a/packages/decomposer-recursive/src/types.ts
+++ b/packages/decomposer-recursive/src/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Core types for the recursive decomposer.
+ *
+ * Every type here has a Zod-schema counterpart in `./schemas.ts` —
+ * the schemas are the runtime source of truth for LLM-output
+ * validation; these TypeScript types document the public API and
+ * stay structurally compatible with the schemas.
+ */
+
+import type { StoryScope } from '@chiefaia/ticket-template';
+
+export type { StoryScope } from '@chiefaia/ticket-template';
+export { STORY_SCOPES, STORY_SCOPE_ORDER, isStoryScope } from '@chiefaia/ticket-template';
+
+export interface ExistingArtifactRef {
+  source: 'feature' | 'arch_artifact';
+  id: string;
+  name: string;
+  score: number;
+  hint?: string;
+}
+
+export interface ChildTicket {
+  id: string;
+  scope: StoryScope;
+  title: string;
+  description: string;
+  acceptanceCriteria?: string[];
+  inScope: string[];
+  outOfScope: string[];
+  dependencies: string[];
+  estimatedAtomic: boolean;
+  existingArtifacts: ExistingArtifactRef[];
+  lifecycle: 'new' | 'enhance' | 'reuse';
+}
+
+export interface ClarifyingQuestion {
+  id: string;
+  parentNodeId: string;
+  question: string;
+  proposedAnswers: string[];
+  blocksBranch: boolean;
+  rationale: string;
+}
+
+export interface DependencyEdge {
+  fromChildId: string;
+  toChildId: string;
+  kind: 'blocks' | 'soft' | 'capability';
+  rationale: string;
+}
+
+export interface AuditEntry {
+  parentNodeId: string;
+  parentScope: StoryScope;
+  childScope: StoryScope;
+  attempt: number;
+  promptTextHash: string;
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  costUsd: number;
+  durationMs: number;
+  alternativesConsidered: number;
+  coverageScore: number | null;
+  disjointnessScore: number | null;
+  ambiguityDetected: boolean;
+  questionsEmittedCount: number;
+  decisionRationale: string;
+  childrenCount: number;
+  outcome: 'committed' | 'reflexive-retry' | 'stuck' | 'awaiting-clarification';
+}
+
+export interface Decomposition {
+  childTickets: ChildTicket[];
+  clarifyingQuestions: ClarifyingQuestion[];
+  dependencies: DependencyEdge[];
+  confidence: number | null;
+  judgeScores: {
+    coverage: number | null;
+    disjointness: number | null;
+  };
+  audit: AuditEntry;
+}
+
+export interface ScopeDetection {
+  targetScope: StoryScope;
+  confidence: number;
+  rationale: string;
+  model: string;
+  durationMs: number;
+}
+
+export interface AtomicityVerdict {
+  atomic: boolean;
+  confidence: number;
+  rationale: string;
+  failedCriteria: string[];
+  model: string;
+  durationMs: number;
+}
+
+export type CancellationSignal = AbortSignal;

--- a/packages/decomposer-recursive/tests/_helpers.ts
+++ b/packages/decomposer-recursive/tests/_helpers.ts
@@ -1,0 +1,119 @@
+/**
+ * Test helpers for @chiefaia/decomposer-recursive.
+ *
+ * These wrap the local-llm-router's `__setAdapters` test seam so tests
+ * can drive deterministic LLM responses without booting Ollama or
+ * reaching out to Claude.
+ */
+
+import { vi } from 'vitest';
+import {
+  __setAdapters,
+  type LLMResponse,
+  OllamaAdapter,
+  ClaudeAdapter,
+} from '@chiefaia/local-llm-router';
+
+export interface FakeAdapterConfig {
+  /** Sequence of responses to return on successive `generate` calls. */
+  responses: Array<Partial<LLMResponse> & { response: string }>;
+  /** Whether the local adapter advertises itself as available. Default true. */
+  available?: boolean;
+  /** When set, the adapter throws this error instead of returning. */
+  throws?: Error;
+}
+
+/**
+ * Create an Ollama-style fake. Returns the responses in order; if the
+ * caller exceeds the queue, the LAST response is repeated.
+ */
+export function fakeOllama(config: FakeAdapterConfig): OllamaAdapter {
+  let cursor = 0;
+  return {
+    isAvailable: vi.fn(async () => config.available ?? true),
+    generate: vi.fn(async (model: string): Promise<LLMResponse> => {
+      if (config.throws) throw config.throws;
+      const idx = Math.min(cursor, config.responses.length - 1);
+      cursor++;
+      const next = config.responses[idx];
+      if (!next) throw new Error('fakeOllama: no responses configured');
+      return {
+        response: next.response,
+        model: next.model ?? model,
+        provider: next.provider ?? 'local',
+        durationMs: next.durationMs ?? 12,
+        ...(next.usage ? { usage: next.usage } : {}),
+      };
+    }),
+  } as unknown as OllamaAdapter;
+}
+
+/**
+ * Create a Claude-style fake. Same semantics as fakeOllama.
+ */
+export function fakeClaude(config: FakeAdapterConfig): ClaudeAdapter {
+  let cursor = 0;
+  return {
+    generate: vi.fn(async (model: string): Promise<LLMResponse> => {
+      if (config.throws) throw config.throws;
+      const idx = Math.min(cursor, config.responses.length - 1);
+      cursor++;
+      const next = config.responses[idx];
+      if (!next) throw new Error('fakeClaude: no responses configured');
+      return {
+        response: next.response,
+        model: next.model ?? model,
+        provider: next.provider ?? 'claude',
+        durationMs: next.durationMs ?? 800,
+        ...(next.usage ? { usage: next.usage } : {}),
+      };
+    }),
+  } as unknown as ClaudeAdapter;
+}
+
+/**
+ * Wire fake adapters into the router for the duration of a single test.
+ * The caller MUST clear them in `afterEach` via `clearAdapters()`.
+ */
+export function installFakeAdapters(
+  ollama: OllamaAdapter,
+  claude: ClaudeAdapter,
+): void {
+  __setAdapters(ollama, claude);
+}
+
+export function clearAdapters(): void {
+  __setAdapters(null, null);
+}
+
+/**
+ * Helper that builds a fake response with the supplied JSON payload
+ * already serialised. Keeps the test bodies readable.
+ */
+export function jsonResponse(
+  obj: unknown,
+  overrides: Partial<LLMResponse> = {},
+): Partial<LLMResponse> & { response: string } {
+  const body = JSON.stringify(obj);
+  return {
+    response: body,
+    durationMs: 25,
+    ...overrides,
+  };
+}
+
+/**
+ * Helper for asserting that the parse-failure feedback loop is being
+ * triggered. The first response is intentionally malformed so the
+ * router will retry.
+ */
+export function malformedResponse(
+  text = 'sorry I do not return JSON',
+  overrides: Partial<LLMResponse> = {},
+): Partial<LLMResponse> & { response: string } {
+  return {
+    response: text,
+    durationMs: 25,
+    ...overrides,
+  };
+}

--- a/packages/decomposer-recursive/tests/atomicity-classifier.test.ts
+++ b/packages/decomposer-recursive/tests/atomicity-classifier.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ATOMICITY_RUBRICS, classifyAtomicity } from '../src/atomicity-classifier.js';
+import { STORY_SCOPES } from '../src/types.js';
+import type { ChildTicket } from '../src/types.js';
+import { fakeOllama, fakeClaude, installFakeAdapters, clearAdapters, jsonResponse } from './_helpers.js';
+
+function fixtureChild(scope: ChildTicket['scope']): ChildTicket {
+  return {
+    id: `child-${scope}`,
+    scope,
+    title: `A ${scope} candidate`,
+    description: `Concrete description for the ${scope} candidate`,
+    inScope: ['the in-scope item one', 'in-scope item two'],
+    outOfScope: ['out-of-scope item'],
+    dependencies: [],
+    estimatedAtomic: false,
+    existingArtifacts: [],
+    lifecycle: 'new',
+    acceptanceCriteria: ['When user does X, the system does Y reliably'],
+  };
+}
+
+describe('ATOMICITY_RUBRICS', () => {
+  it('non-empty for every scope', () => {
+    for (const scope of STORY_SCOPES) {
+      const r = ATOMICITY_RUBRICS[scope];
+      expect(r.length).toBeGreaterThan(0);
+      for (const item of r) expect(item.length).toBeGreaterThan(10);
+    }
+  });
+  it('story rubric mentions INVEST', () => {
+    expect(ATOMICITY_RUBRICS.story.join('\n')).toMatch(/INVEST/i);
+  });
+  it('epic rubric mentions SAFe or PI', () => {
+    expect(ATOMICITY_RUBRICS.epic.join('\n')).toMatch(/SAFe|PI/);
+  });
+  it('module rubric mentions DDD or bounded', () => {
+    expect(ATOMICITY_RUBRICS.module.join('\n')).toMatch(/DDD|bounded/i);
+  });
+});
+
+describe('classifyAtomicity', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('atomic=true with empty failedCriteria passes', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('story') });
+    expect(v.atomic).toBe(true);
+  });
+
+  it('atomic=false with failedCriteria passes', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: false, confidence: 0.7, rationale: 'two concerns', failedCriteria: ['some criterion'] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('story') });
+    expect(v.atomic).toBe(false);
+    expect(v.failedCriteria.length).toBe(1);
+  });
+
+  it('force-corrects true+nonEmpty to false', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: true, confidence: 0.4, rationale: 'short rationale', failedCriteria: ['something'] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('module') });
+    expect(v.atomic).toBe(false);
+  });
+
+  it('force-corrects false+empty to true', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: false, confidence: 0.4, rationale: 'short rationale', failedCriteria: [] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('task') });
+    expect(v.atomic).toBe(true);
+  });
+
+  it('exercises every scope', async () => {
+    for (const scope of STORY_SCOPES) {
+      clearAdapters();
+      const ollama = fakeOllama({ responses: [jsonResponse({ atomic: true, confidence: 0.8, rationale: 'a sufficient rationale', failedCriteria: [] })] });
+      installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+      const v = await classifyAtomicity({ child: fixtureChild(scope) });
+      expect(v.atomic).toBe(true);
+    }
+  });
+
+  it('telemetry passes through', async () => {
+    const ollama = fakeOllama({ responses: [{ response: JSON.stringify({ atomic: true, confidence: 0.85, rationale: 'a sufficient rationale', failedCriteria: [] }), model: 'qwen2.5-coder:7b', durationMs: 41 }] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('subtask') });
+    expect(v.model).toBe('qwen2.5-coder:7b');
+    expect(v.durationMs).toBe(41);
+  });
+});

--- a/packages/decomposer-recursive/tests/schemas.test.ts
+++ b/packages/decomposer-recursive/tests/schemas.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AuditEntrySchema,
+  ChildTicketArraySchema,
+  ChildTicketSchema,
+  DependencyEdgeSchema,
+  DecompositionSchema,
+  ExistingArtifactRefSchema,
+  ScopeDetectionLlmOutputSchema,
+  AtomicityLlmOutputSchema,
+  StoryScopeSchema,
+} from '../src/schemas.js';
+import { STORY_SCOPES } from '../src/types.js';
+
+const validChild = {
+  id: 'c1',
+  scope: 'story' as const,
+  title: 'A perfectly fine title',
+  description: 'A description that is long enough to pass min-length',
+  inScope: ['inside scope item'],
+  outOfScope: [],
+  dependencies: [],
+  estimatedAtomic: true,
+  existingArtifacts: [],
+  lifecycle: 'new' as const,
+};
+
+describe('StoryScopeSchema', () => {
+  it('accepts every canonical scope', () => {
+    for (const s of STORY_SCOPES) {
+      expect(StoryScopeSchema.safeParse(s).success).toBe(true);
+    }
+  });
+  it('rejects non-canonical scopes', () => {
+    expect(StoryScopeSchema.safeParse('feature').success).toBe(false);
+    expect(StoryScopeSchema.safeParse('').success).toBe(false);
+    expect(StoryScopeSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe('ExistingArtifactRefSchema', () => {
+  it('accepts a feature ref', () => {
+    const r = ExistingArtifactRefSchema.safeParse({
+      source: 'feature',
+      id: 'feat_x',
+      name: 'Feature X',
+      score: 0.91,
+    });
+    expect(r.success).toBe(true);
+  });
+  it('rejects scores outside 0..1', () => {
+    expect(
+      ExistingArtifactRefSchema.safeParse({
+        source: 'feature',
+        id: 'feat_x',
+        name: 'Feature X',
+        score: 1.5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('ChildTicketSchema', () => {
+  it('accepts a valid child', () => {
+    expect(ChildTicketSchema.safeParse(validChild).success).toBe(true);
+  });
+  it('rejects a self-dependency', () => {
+    const bad = { ...validChild, dependencies: [validChild.id] };
+    expect(ChildTicketSchema.safeParse(bad).success).toBe(false);
+  });
+  it('rejects too-short titles', () => {
+    expect(ChildTicketSchema.safeParse({ ...validChild, title: 'hi' }).success).toBe(false);
+  });
+  it('accepts story with acceptanceCriteria', () => {
+    const r = ChildTicketSchema.safeParse({
+      ...validChild,
+      acceptanceCriteria: ['When the user clicks the button, the page navigates'],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('ChildTicketArraySchema', () => {
+  it('rejects siblings with duplicate ids', () => {
+    const dup = ChildTicketArraySchema.safeParse([validChild, validChild]);
+    expect(dup.success).toBe(false);
+  });
+  it('accepts unique siblings', () => {
+    const ok = ChildTicketArraySchema.safeParse([
+      validChild,
+      { ...validChild, id: 'c2' },
+    ]);
+    expect(ok.success).toBe(true);
+  });
+});
+
+describe('DependencyEdgeSchema', () => {
+  it('rejects self-loops', () => {
+    const r = DependencyEdgeSchema.safeParse({
+      fromChildId: 'a',
+      toChildId: 'a',
+      kind: 'blocks',
+      rationale: 'noop',
+    });
+    expect(r.success).toBe(false);
+  });
+  it('accepts a normal edge', () => {
+    const r = DependencyEdgeSchema.safeParse({
+      fromChildId: 'a',
+      toChildId: 'b',
+      kind: 'blocks',
+      rationale: 'because-data-model-first',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('AuditEntrySchema', () => {
+  it('accepts a complete audit row', () => {
+    const r = AuditEntrySchema.safeParse({
+      parentNodeId: 'p1',
+      parentScope: 'epic',
+      childScope: 'module',
+      attempt: 1,
+      promptTextHash: 'abc123',
+      model: 'claude-sonnet-4-6',
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.001,
+      durationMs: 250,
+      alternativesConsidered: 1,
+      coverageScore: null,
+      disjointnessScore: null,
+      ambiguityDetected: false,
+      questionsEmittedCount: 0,
+      decisionRationale: 'first attempt OK',
+      childrenCount: 3,
+      outcome: 'committed',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('DecompositionSchema', () => {
+  it('accepts a minimal decomposition', () => {
+    const r = DecompositionSchema.safeParse({
+      childTickets: [validChild],
+      clarifyingQuestions: [],
+      dependencies: [],
+      confidence: 0.9,
+      judgeScores: { coverage: null, disjointness: null },
+      audit: {
+        parentNodeId: 'p',
+        parentScope: 'module',
+        childScope: 'story',
+        attempt: 1,
+        promptTextHash: 'h',
+        model: 'm',
+        tokensIn: 0,
+        tokensOut: 0,
+        costUsd: 0,
+        durationMs: 0,
+        alternativesConsidered: 0,
+        coverageScore: null,
+        disjointnessScore: null,
+        ambiguityDetected: false,
+        questionsEmittedCount: 0,
+        decisionRationale: '',
+        childrenCount: 1,
+        outcome: 'committed',
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('LLM-output schemas', () => {
+  it('ScopeDetectionLlmOutputSchema accepts a valid output', () => {
+    const r = ScopeDetectionLlmOutputSchema.safeParse({
+      targetScope: 'story',
+      confidence: 0.9,
+      rationale: 'one-verb-one-object',
+    });
+    expect(r.success).toBe(true);
+  });
+  it('AtomicityLlmOutputSchema accepts a valid output', () => {
+    const r = AtomicityLlmOutputSchema.safeParse({
+      atomic: true,
+      confidence: 0.8,
+      rationale: 'INVEST passes',
+      failedCriteria: [],
+    });
+    expect(r.success).toBe(true);
+  });
+  it('AtomicityLlmOutputSchema rejects out-of-range confidence', () => {
+    const r = AtomicityLlmOutputSchema.safeParse({
+      atomic: true,
+      confidence: 1.5,
+      rationale: 'oops',
+      failedCriteria: [],
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/decomposer-recursive/tests/scope-detector.test.ts
+++ b/packages/decomposer-recursive/tests/scope-detector.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { detectScope } from '../src/scope-detector.js';
+import { StructuredOutputParseError } from '../src/structured-output.js';
+
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+describe('detectScope', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('classifies a one-line story-shaped prompt as story', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'story',
+          confidence: 0.92,
+          rationale: 'one verb, one object, one concrete deliverable',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText: 'add a logout button to the user-menu dropdown',
+    });
+
+    expect(out.targetScope).toBe('story');
+    expect(out.confidence).toBeCloseTo(0.92);
+    expect(out.rationale).toMatch(/one verb/);
+    expect(out.model).toContain('qwen');
+  });
+
+  it('classifies a vision-doc-shaped prompt as initiative', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'initiative',
+          confidence: 0.86,
+          rationale: 'multi-feature, multi-team, multi-platform vision',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText:
+        'Build a poker analytics SaaS. Web + mobile + Stripe billing + Discord integration. Multi-team multi-quarter.',
+    });
+
+    expect(out.targetScope).toBe('initiative');
+    expect(out.confidence).toBeCloseTo(0.86);
+  });
+
+  it('passes the optional vision-doc summary into the prompt body', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'epic',
+          confidence: 0.7,
+          rationale: 'single epic scope per pre-extracted theme',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText: 'Re-vamp checkout',
+      visionDocSummary: 'Theme: cart abandonment, single-page checkout',
+    });
+
+    expect(out.targetScope).toBe('epic');
+    // The router was called once.
+    expect(ollama.generate).toHaveBeenCalledOnce();
+  });
+
+  it('retries when the model returns an out-of-range confidence', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ targetScope: 'task', confidence: 1.7, rationale: 'meh' }),
+        jsonResponse({
+          targetScope: 'task',
+          confidence: 0.55,
+          rationale: 'one concern, one tech sub-domain',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({ promptText: 'refactor the auth module' });
+    expect(out.targetScope).toBe('task');
+    expect(out.confidence).toBeCloseTo(0.55);
+  });
+
+  it('throws when the model never produces a valid scope', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ targetScope: 'feature', confidence: 0.5, rationale: 'meh' }),
+        jsonResponse({ targetScope: 'feature', confidence: 0.5, rationale: 'meh' }),
+        jsonResponse({ targetScope: 'feature', confidence: 0.5, rationale: 'meh' }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    await expect(detectScope({ promptText: 'whatever' })).rejects.toBeInstanceOf(
+      StructuredOutputParseError,
+    );
+  });
+
+  it('includes telemetry (model + durationMs)', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        {
+          response: JSON.stringify({
+            targetScope: 'subtask',
+            confidence: 0.99,
+            rationale: 'mechanical edit',
+          }),
+          model: 'qwen2.5-coder:7b',
+          durationMs: 17,
+        },
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText: 'rename _x to _internal in foo.ts',
+    });
+
+    expect(out.model).toBe('qwen2.5-coder:7b');
+    expect(out.durationMs).toBe(17);
+  });
+});

--- a/packages/decomposer-recursive/tests/structured-output.test.ts
+++ b/packages/decomposer-recursive/tests/structured-output.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+
+import {
+  callStructured,
+  extractJson,
+  StructuredOutputCancelled,
+  StructuredOutputParseError,
+} from '../src/structured-output.js';
+
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+  malformedResponse,
+} from './_helpers.js';
+
+const HappySchema = z.object({
+  word: z.string().min(1),
+  count: z.number().int().min(0),
+});
+
+describe('extractJson', () => {
+  it('parses a clean JSON object', () => {
+    expect(extractJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('strips ```json fences', () => {
+    const raw = 'Here you go:\n```json\n{"a":1}\n```\n';
+    expect(extractJson(raw)).toEqual({ a: 1 });
+  });
+
+  it('strips bare ``` fences', () => {
+    expect(extractJson('```\n{"x":42}\n```')).toEqual({ x: 42 });
+  });
+
+  it('greedy-matches outermost { ... }', () => {
+    expect(extractJson('lol talk talk { "y": 2 } more talk')).toEqual({ y: 2 });
+  });
+
+  it('returns null when no JSON is recoverable', () => {
+    expect(extractJson('absolutely no JSON here at all')).toBeNull();
+  });
+
+  it('handles trailing commas by failing softly (returns null)', () => {
+    expect(extractJson('{"a":1,}')).toBeNull();
+  });
+
+  it('handles nested objects', () => {
+    expect(extractJson('{"a": {"b": [1,2,3]}}')).toEqual({
+      a: { b: [1, 2, 3] },
+    });
+  });
+});
+
+describe('callStructured — happy paths', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('returns parsed data on a happy first attempt', async () => {
+    const ollama = fakeOllama({
+      responses: [jsonResponse({ word: 'hello', count: 3 })],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.data).toEqual({ word: 'hello', count: 3 });
+    expect(result.attempts).toBe(1);
+    expect(result.provider).toBe('local');
+    expect(result.costUsd).toBe(0);
+    expect(result.durationMs).toBe(25);
+  });
+
+  it('parses successfully through markdown fences', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        { response: '```json\n{"word":"ok","count":1}\n```', durationMs: 15 },
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.data).toEqual({ word: 'ok', count: 1 });
+    expect(result.attempts).toBe(1);
+  });
+
+  it('attributes Claude cost when the rule routes Claude', async () => {
+    const claude = fakeClaude({
+      responses: [jsonResponse({ word: 'claude', count: 7 })],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-initiative',
+      systemPrompt: 'decompose',
+      userPrompt: 'big initiative',
+    });
+
+    expect(result.data).toEqual({ word: 'claude', count: 7 });
+    expect(result.provider).toBe('claude');
+    expect(result.costUsd).toBeCloseTo(0.002, 5);
+  });
+
+  it('reports the model and usage on the winning attempt', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        {
+          response: JSON.stringify({ word: 'hi', count: 1 }),
+          model: 'qwen2.5-coder:7b',
+          durationMs: 33,
+          usage: { promptTokens: 100, completionTokens: 12, totalTokens: 112 },
+        },
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.model).toBe('qwen2.5-coder:7b');
+    expect(result.usage?.promptTokens).toBe(100);
+    expect(result.usage?.completionTokens).toBe(12);
+  });
+});
+
+describe('callStructured — retry semantics', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('retries with feedback when the first response has wrong types', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ word: 'hi', count: 'not a number' }),
+        jsonResponse({ word: 'hi', count: 5 }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+      maxRetries: 2,
+    });
+
+    expect(result.data).toEqual({ word: 'hi', count: 5 });
+    expect(result.attempts).toBe(2);
+    expect(result.durationMs).toBe(50);
+  });
+
+  it('retries when the first response has no JSON at all', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        malformedResponse('no JSON for you'),
+        jsonResponse({ word: 'recovered', count: 2 }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.data).toEqual({ word: 'recovered', count: 2 });
+    expect(result.attempts).toBe(2);
+  });
+
+  it('throws StructuredOutputParseError after exhausting retries', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ word: 'a', count: 'still wrong' }),
+        jsonResponse({ word: 'a', count: 'still wrong' }),
+        jsonResponse({ word: 'a', count: 'still wrong' }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    await expect(
+      callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(StructuredOutputParseError);
+  });
+
+  it('preserves the original taskType + last raw on parse failure', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ word: 'broken', count: 'nope' }),
+        jsonResponse({ word: 'broken', count: 'nope' }),
+        jsonResponse({ word: 'broken', count: 'nope' }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    try {
+      await callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        maxRetries: 2,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputParseError);
+      const e = err as StructuredOutputParseError;
+      expect(e.taskType).toBe('po-decomposer-scope-detection');
+      expect(e.attempts).toBe(3);
+      expect(e.lastRaw).toContain('"word":"broken"');
+    }
+  });
+
+  it('respects a maxRetries=0 setting (single attempt only)', async () => {
+    const ollama = fakeOllama({
+      responses: [malformedResponse('no json')],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    await expect(
+      callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        maxRetries: 0,
+      }),
+    ).rejects.toBeInstanceOf(StructuredOutputParseError);
+  });
+});
+
+describe('callStructured — cancellation', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('honours an aborted signal before the first attempt', async () => {
+    const ollama = fakeOllama({
+      responses: [jsonResponse({ word: 'ok', count: 1 })],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const ac = new AbortController();
+    ac.abort();
+
+    await expect(
+      callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        signal: ac.signal,
+      }),
+    ).rejects.toBeInstanceOf(StructuredOutputCancelled);
+  });
+});

--- a/packages/decomposer-recursive/tsconfig.json
+++ b/packages/decomposer-recursive/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}

--- a/packages/decomposer-recursive/vitest.config.ts
+++ b/packages/decomposer-recursive/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();

--- a/packages/local-llm-router/src/routing-config.ts
+++ b/packages/local-llm-router/src/routing-config.ts
@@ -194,6 +194,126 @@ export const ROUTING_RULES: RoutingRule[] = [
     estimatedCostClaude: '$1.50',
   },
 
+  // ─── PO recursive decomposer (PO-DECOMP-### track) ───────────────────────
+  // Per the proposal in `reports/po-decomposition-architecture-proposal-2026-04-29.md`,
+  // the recursive decomposer fans out into a small number of task-types:
+  // classification (Ollama-first), per-scope decomposition (Sonnet for high
+  // scopes, Ollama-first for deep scopes), and a judge pair (Sonnet, with
+  // ensemble for initiative/epic).
+  {
+    taskType: 'po-decomposer-scope-detection',
+    description:
+      'Adaptive scope detector — classify a prompt as initiative | epic | ' +
+      'module | story | task | subtask. Cheap classification call.',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 400,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.04',
+  },
+  {
+    taskType: 'po-decomposer-atomicity-classification',
+    description:
+      'Per-scope atomicity classifier — does a candidate child satisfy the ' +
+      'INVEST/SAFe/DDD rubric for its scope? Cheap classification call.',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 600,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.06',
+  },
+  {
+    taskType: 'po-decomposer-initiative',
+    description:
+      'Initiative → epic decomposition. High-stakes (multi-quarter scope).',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'po-decomposer-epic',
+    description:
+      'Epic → module decomposition. High-stakes (single PI scope).',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'po-decomposer-module',
+    description:
+      'Module → story decomposition. Medium-stakes (bounded-context scope).',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 6000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.50',
+  },
+  {
+    taskType: 'po-decomposer-story',
+    description:
+      'Story → task decomposition. Medium-stakes (single-PR scope).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'po-decomposer-task',
+    description:
+      'Task → subtask decomposition. Low-stakes (single-day scope) — Ollama-first.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 3000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.75',
+  },
+  {
+    taskType: 'po-decomposer-subtask',
+    description:
+      'Subtask → mechanical-step decomposition. Rarely needed; Ollama-first.',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'po-decomposer-coverage-judge',
+    description:
+      'Parent-coverage MECE judge. Did the children cover the parent\'s scope? ' +
+      'Sonnet — judging is high-leverage low-cost relative to regenerating downstream.',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.40',
+  },
+  {
+    taskType: 'po-decomposer-disjointness-judge',
+    description:
+      'Sibling-disjointness MECE judge. Do any two children overlap?',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.40',
+  },
+
   // ─── CLAUDE ONLY — still too high-stakes for the local path ──────────────
   {
     taskType: 'hierarchy-decomposition',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,40 @@ importers:
         specifier: ^5.0.0
         version: 5.1.9
 
+  packages/decomposer-recursive:
+    dependencies:
+      '@chiefaia/local-llm-router':
+        specifier: workspace:*
+        version: link:../local-llm-router
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../ticket-template
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.9
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/dedup-engine: {}
 
   packages/dev-inspector:


### PR DESCRIPTION
P0 slice 1 of the recursive PO decomposer (proposal: `reports/po-decomposition-architecture-proposal-2026-04-29.md`).

## What's in
- New package `@chiefaia/decomposer-recursive`
- Scope detector (`detectScope`) — Ollama-first, Claude fallback
- Atomicity classifier (`classifyAtomicity`) — per-scope rubrics from proposal §5C
- Zod schemas + structured-output helper with bounded-retry parse-feedback loop
- 50 vitest cases (all pass locally)
- 10 new routing rules in `@chiefaia/local-llm-router` (local share remains ≥70%)

## Out of scope (P0 deferral per proposal §11)
- Clarifying-question pipeline → P1
- Vision-doc chunked summarization → P1
- FREG/AKG deep integration → P1 (P0 stubs to `new`)
- Dashboard UI → P1

## Testing
- `pnpm --filter @chiefaia/decomposer-recursive test` → 50 pass
- `pnpm --filter @chiefaia/local-llm-router test` → 15 pass (LAI-005 70% invariant holds)
- `pnpm typecheck` clean

## Lifecycle
PR 1 of 5 in the PO-DECOMP-### track. PR 2 (engine + per-scope prompts) follows.
