### PR TITLE
feat(decomposer-recursive): PORecursiveDecomposer engine + per-scope prompts (PO-DECOMP-002)

### DIFF
--- a/packages/decomposer-recursive/src/decomposer.ts
+++ b/packages/decomposer-recursive/src/decomposer.ts
@@ -1,0 +1,437 @@
+/**
+ * PORecursiveDecomposer — the engine.
+ *
+ * Stateless across calls (every input is explicit; no shared per-class
+ * state). Cancellable via an AbortSignal that is checked between
+ * recursion steps so a cancel bounds wall-clock by ~one outstanding
+ * LLM call. Cost-tracked: every parent expansion emits an AuditEntry
+ * with model, tokens, cost; the engine sums these and exposes a
+ * cumulative total via `decomposeRoot`'s return value.
+ *
+ * P0 scope (this slice):
+ *   - one parent → children expansion via `decomposeOne`
+ *   - bounded retry on schema parse failure (via callStructured)
+ *   - per-child atomicity classification (via classifyAtomicity)
+ *   - recursion via `decomposeRoot` that walks down to atomicity
+ *
+ * P0 explicitly does NOT:
+ *   - run MECE judges (that's PR 3)
+ *   - generate clarifying questions (that's P1)
+ *   - chunk vision documents (P1)
+ *   - call the real FREG/AKG (P1 — the stub returns empty)
+ */
+
+import { createHash } from 'node:crypto';
+
+import { classifyAtomicity } from './atomicity-classifier.js';
+import {
+  formatAkgHitsForPrompt,
+  formatFregHitsForPrompt,
+  querySubstrateStub,
+} from './freg-akg-stub.js';
+import {
+  CHILD_SCOPE_OF,
+  DECOMPOSER_SYSTEM_PROMPTS,
+  DECOMPOSER_TASK_TYPES,
+} from './per-scope-prompts.js';
+import { ChildTicketArraySchema } from './schemas.js';
+import { callStructured } from './structured-output.js';
+import type {
+  AuditEntry,
+  CancellationSignal,
+  ChildTicket,
+  Decomposition,
+  StoryScope,
+} from './types.js';
+import { STORY_SCOPE_ORDER } from './types.js';
+
+/**
+ * The parent-node shape the engine expects. Either a synthetic root
+ * (built from the user's prompt) or a previously-emitted child being
+ * recursively expanded.
+ */
+export interface ParentNode {
+  id: string;
+  scope: StoryScope;
+  title: string;
+  description: string;
+  inScope: string[];
+  outOfScope: string[];
+  /** Optional acceptance criteria (story+ scope only). */
+  acceptanceCriteria?: string[];
+  /** Optional project slug for FREG queries (P1 will use it). */
+  projectSlug?: string;
+  /** Optional tech sub-domains for AKG queries (P1 will use it). */
+  techSubDomains?: string[];
+}
+
+export interface DecomposeOneOptions {
+  parent: ParentNode;
+  /** The scope of the children to produce (one level below parent). */
+  childScope: StoryScope;
+  /** Optional cancellation signal (checked before LLM call). */
+  signal?: CancellationSignal;
+}
+
+export interface DecomposeRootOptions {
+  parent: ParentNode;
+  /**
+   * Target scope — recursion stops once children at this scope are
+   * produced. Used by the orchestrator (PR 4) when the scope detector
+   * picks a deep starting scope (e.g., 'story') so we don't build
+   * artificial above-story ancestry.
+   */
+  targetScope: StoryScope;
+  /**
+   * Maximum recursion depth (levels). Defaults to 5 (initiative →
+   * subtask). Caller should set this to the worst-case depth.
+   */
+  maxDepth?: number;
+  /**
+   * Maximum total parent expansions across the whole tree. A cost
+   * guard against runaway prompts. Default 200; vision-doc decomps
+   * may need more.
+   */
+  maxExpansions?: number;
+  /** Optional cancellation signal. */
+  signal?: CancellationSignal;
+}
+
+export interface DecomposedTreeNode {
+  ticket: ChildTicket;
+  children: DecomposedTreeNode[];
+  /** Whether this node was deemed atomic by the classifier. */
+  atomic: boolean;
+}
+
+export interface DecomposeRootResult {
+  /** Sub-tree rooted at the original parent. */
+  tree: DecomposedTreeNode;
+  /** Audit entries in expansion order, every level included. */
+  audits: AuditEntry[];
+  /** Cumulative cost across the whole tree (USD). */
+  totalCostUsd: number;
+  /** Cumulative wall-clock across the whole tree (ms). */
+  totalDurationMs: number;
+  /** Total LLM calls made. */
+  totalCalls: number;
+  /** True if the engine hit max-expansions (partial tree). */
+  truncated: boolean;
+}
+
+export class PORecursiveDecomposerCancelled extends Error {
+  constructor() {
+    super('[decomposer-recursive] decomposition cancelled');
+    this.name = 'PORecursiveDecomposerCancelled';
+  }
+}
+
+export class PORecursiveDecomposer {
+  /**
+   * Expand ONE parent into its children at `childScope`. Stateless;
+   * the caller drives the recursion via `decomposeRoot` or directly.
+   *
+   * Returns a `Decomposition` with:
+   *   - childTickets[] — typed children parsed against the schema
+   *   - audit — single AuditEntry for this expansion
+   *   - judgeScores: { coverage: null, disjointness: null } — judges
+   *     are not in P0; PR 3 fills them.
+   */
+  async decomposeOne(opts: DecomposeOneOptions): Promise<Decomposition> {
+    const { parent, childScope, signal } = opts;
+
+    if (signal?.aborted) throw new PORecursiveDecomposerCancelled();
+
+    const taskType = DECOMPOSER_TASK_TYPES[parent.scope];
+    const systemPrompt = DECOMPOSER_SYSTEM_PROMPTS[parent.scope];
+
+    const substrate = await querySubstrateStub({
+      query: `${parent.title}\n\n${parent.description}`,
+      ...(parent.projectSlug ? { projectSlug: parent.projectSlug } : {}),
+      ...(parent.techSubDomains ? { techSubDomains: parent.techSubDomains } : {}),
+    });
+
+    const userPrompt = buildUserPrompt(parent, childScope, substrate);
+    const promptHash = sha256(systemPrompt + '\n\n' + userPrompt);
+
+    if (signal?.aborted) throw new PORecursiveDecomposerCancelled();
+
+    const result = await callStructured(ChildTicketArraySchema, {
+      taskType,
+      systemPrompt,
+      userPrompt,
+      maxRetries: 2,
+      ...(signal ? { signal } : {}),
+    });
+
+    // Parse into ChildTicket[]. Set every child's scope to childScope
+    // (the LLM is asked to label, but we override to be safe).
+    const childTickets: ChildTicket[] = result.data.map((c) => {
+      const cleanedExistingArtifacts = c.existingArtifacts.map((a) => {
+        const out: { source: 'feature' | 'arch_artifact'; id: string; name: string; score: number; hint?: string } = {
+          source: a.source,
+          id: a.id,
+          name: a.name,
+          score: a.score,
+        };
+        if (a.hint !== undefined) out.hint = a.hint;
+        return out;
+      });
+      const base: ChildTicket = {
+        id: c.id,
+        scope: childScope,
+        title: c.title,
+        description: c.description,
+        inScope: c.inScope,
+        outOfScope: c.outOfScope,
+        dependencies: c.dependencies,
+        existingArtifacts: cleanedExistingArtifacts,
+        lifecycle: c.lifecycle,
+        estimatedAtomic: false,
+      };
+      if (c.acceptanceCriteria !== undefined) {
+        base.acceptanceCriteria = c.acceptanceCriteria;
+      }
+      return base;
+    });
+
+    const audit: AuditEntry = {
+      parentNodeId: parent.id,
+      parentScope: parent.scope,
+      childScope,
+      attempt: result.attempts,
+      promptTextHash: promptHash,
+      model: result.model,
+      tokensIn: result.usage?.promptTokens ?? 0,
+      tokensOut: result.usage?.completionTokens ?? 0,
+      costUsd: result.costUsd,
+      durationMs: result.durationMs,
+      alternativesConsidered: 1, // P0 single-sample
+      coverageScore: null,
+      disjointnessScore: null,
+      ambiguityDetected: false,
+      questionsEmittedCount: 0,
+      decisionRationale: `single-sample expansion (P0); ${String(childTickets.length)} children produced`,
+      childrenCount: childTickets.length,
+      outcome: 'committed',
+    };
+
+    return {
+      childTickets,
+      clarifyingQuestions: [],
+      dependencies: [],
+      confidence: null,
+      judgeScores: { coverage: null, disjointness: null },
+      audit,
+    };
+  }
+
+  /**
+   * Recursively decompose a parent down to the atomicity floor (or
+   * to `targetScope`, whichever is hit first).
+   *
+   * Walks depth-first. Runs the atomicity classifier on each child
+   * after generation; atomic children become leaves, non-atomic ones
+   * recurse one scope deeper.
+   */
+  async decomposeRoot(
+    opts: DecomposeRootOptions,
+  ): Promise<DecomposeRootResult> {
+    const { parent, targetScope, signal } = opts;
+    const maxDepth = opts.maxDepth ?? 5;
+    const maxExpansions = opts.maxExpansions ?? 200;
+
+    const audits: AuditEntry[] = [];
+    let totalCostUsd = 0;
+    let totalDurationMs = 0;
+    let totalCalls = 0;
+    let expansions = 0;
+    let truncated = false;
+
+    // The root is presented as itself a "child" in the tree (so the
+    // tree shape is uniform for the caller). Build a synthetic
+    // ChildTicket from the parent.
+    const rootTicket: ChildTicket = {
+      id: parent.id,
+      scope: parent.scope,
+      title: parent.title,
+      description: parent.description,
+      ...(parent.acceptanceCriteria && parent.acceptanceCriteria.length > 0
+        ? { acceptanceCriteria: parent.acceptanceCriteria }
+        : {}),
+      inScope: parent.inScope,
+      outOfScope: parent.outOfScope,
+      dependencies: [],
+      estimatedAtomic: false,
+      existingArtifacts: [],
+      lifecycle: 'new',
+    };
+    const rootNode: DecomposedTreeNode = {
+      ticket: rootTicket,
+      children: [],
+      atomic: false,
+    };
+
+    // BFS-frontier of (parentNode, depthFromRoot) pairs to expand.
+    type FrontierItem = {
+      node: DecomposedTreeNode;
+      parent: ParentNode;
+      depth: number;
+    };
+    const frontier: FrontierItem[] = [
+      { node: rootNode, parent, depth: 0 },
+    ];
+
+    while (frontier.length > 0) {
+      if (signal?.aborted) throw new PORecursiveDecomposerCancelled();
+      const item = frontier.shift();
+      if (!item) break;
+      const { node, parent: p, depth } = item;
+
+      // Atomicity floor check by scope index.
+      const childScope = CHILD_SCOPE_OF[p.scope];
+      if (childScope === null) {
+        // Already at subtask — never decompose further.
+        node.atomic = true;
+        continue;
+      }
+      // Hard depth + scope guard.
+      if (depth >= maxDepth) {
+        node.atomic = true;
+        continue;
+      }
+      // Target-scope guard: don't decompose past the requested target scope.
+      const childScopeIdx = STORY_SCOPE_ORDER[childScope];
+      const targetIdx = STORY_SCOPE_ORDER[targetScope];
+      if (childScopeIdx > targetIdx) {
+        // We've already produced children AT or BELOW the target scope.
+        // The current parent is at-or-above target — but we only get
+        // here if its scope index is < target's. Decompose anyway —
+        // we want to land EXACTLY at target.
+      }
+      if (STORY_SCOPE_ORDER[p.scope] >= targetIdx) {
+        // Parent is already at-or-below target scope; it is the leaf.
+        node.atomic = true;
+        continue;
+      }
+
+      // Cost/expansion budget guard.
+      if (expansions >= maxExpansions) {
+        truncated = true;
+        node.atomic = true;
+        continue;
+      }
+      expansions++;
+
+      // Run the expansion.
+      const decomp = await this.decomposeOne({
+        parent: p,
+        childScope,
+        ...(signal ? { signal } : {}),
+      });
+      audits.push(decomp.audit);
+      totalCostUsd += decomp.audit.costUsd;
+      totalDurationMs += decomp.audit.durationMs;
+      totalCalls += decomp.audit.attempt;
+
+      // For each child, run atomicity classification then enqueue
+      // for further expansion if not atomic and below target scope.
+      for (const child of decomp.childTickets) {
+        const verdict = await classifyAtomicity({
+          child,
+          ...(signal ? { signal } : {}),
+        });
+        // (atomicity classifier call counts toward totalCalls but not audits)
+        totalCalls += 1;
+        // Pass-through telemetry: classifier doesn't currently land in audits[].
+        const childWithVerdict: ChildTicket = {
+          ...child,
+          estimatedAtomic: verdict.atomic,
+        };
+        const childNode: DecomposedTreeNode = {
+          ticket: childWithVerdict,
+          children: [],
+          atomic: verdict.atomic,
+        };
+        node.children.push(childNode);
+
+        const childIdx = STORY_SCOPE_ORDER[childWithVerdict.scope];
+        const targetIdxInner = STORY_SCOPE_ORDER[targetScope];
+        if (!verdict.atomic && childIdx < targetIdxInner) {
+          frontier.push({
+            node: childNode,
+            parent: childTicketToParent(childWithVerdict, p),
+            depth: depth + 1,
+          });
+        }
+      }
+    }
+
+    return {
+      tree: rootNode,
+      audits,
+      totalCostUsd,
+      totalDurationMs,
+      totalCalls,
+      truncated,
+    };
+  }
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+function buildUserPrompt(
+  parent: ParentNode,
+  childScope: StoryScope,
+  substrate: { fregHits: never[] | unknown[]; akgHits: never[] | unknown[] },
+): string {
+  const fregBlock = formatFregHitsForPrompt(
+    substrate.fregHits as Parameters<typeof formatFregHitsForPrompt>[0],
+  );
+  const akgBlock = formatAkgHitsForPrompt(
+    substrate.akgHits as Parameters<typeof formatAkgHitsForPrompt>[0],
+  );
+
+  const acBlock =
+    parent.acceptanceCriteria && parent.acceptanceCriteria.length > 0
+      ? `\nAcceptance criteria:\n${parent.acceptanceCriteria.map((a) => `  - ${a}`).join('\n')}`
+      : '';
+
+  return [
+    `Decompose the parent ticket below into ${childScope} children.`,
+    '',
+    '## PARENT TICKET',
+    `Title: ${parent.title}`,
+    `Scope: ${parent.scope}`,
+    `Description: ${parent.description}`,
+    `In scope: ${parent.inScope.join('; ') || '(empty)'}`,
+    `Out of scope: ${parent.outOfScope.join('; ') || '(empty)'}${acBlock}`,
+    '',
+    fregBlock,
+    akgBlock,
+  ]
+    .filter((s) => s.length > 0)
+    .join('\n');
+}
+
+function childTicketToParent(child: ChildTicket, parentOfChild: ParentNode): ParentNode {
+  return {
+    id: child.id,
+    scope: child.scope,
+    title: child.title,
+    description: child.description,
+    inScope: child.inScope,
+    outOfScope: child.outOfScope,
+    ...(child.acceptanceCriteria && child.acceptanceCriteria.length > 0
+      ? { acceptanceCriteria: child.acceptanceCriteria }
+      : {}),
+    ...(parentOfChild.projectSlug ? { projectSlug: parentOfChild.projectSlug } : {}),
+    ...(parentOfChild.techSubDomains
+      ? { techSubDomains: parentOfChild.techSubDomains }
+      : {}),
+  };
+}
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}

--- a/packages/decomposer-recursive/src/freg-akg-stub.ts
+++ b/packages/decomposer-recursive/src/freg-akg-stub.ts
@@ -1,0 +1,61 @@
+/**
+ * FREG + AKG substrate query stubs (P0).
+ *
+ * In P1 these will be replaced by real calls to:
+ *   - `searchAndLog` from @chiefaia/feature-registry (for FREG hits)
+ *   - `archSearch` from @chiefaia/architecture-registry (for AKG hits)
+ *
+ * For P0 they always return an empty list — the decomposer engine
+ * still wires the substrate-context block into the prompt envelope so
+ * P1 only has to swap the stub for the real call. The lifecycle
+ * default is therefore always `'new'` in P0.
+ */
+
+import type { ExistingArtifactRef } from './types.js';
+
+export interface FregAkgQueryInput {
+  /** Title + description of the parent ticket. */
+  query: string;
+  /** Project slug, used to scope FREG. */
+  projectSlug?: string;
+  /** Tech sub-domains the parent implies (used to scope AKG). */
+  techSubDomains?: string[];
+}
+
+export interface FregAkgQueryResult {
+  fregHits: ExistingArtifactRef[];
+  akgHits: ExistingArtifactRef[];
+}
+
+/**
+ * P0 stub — returns empty FREG + AKG hits for every query.
+ * Wired so PR 5's validation suite doesn't break on real prompts.
+ */
+export async function querySubstrateStub(
+  _input: FregAkgQueryInput,
+): Promise<FregAkgQueryResult> {
+  // P0: stub. P1 wires real registries.
+  // TODO(po-decomp-p1): replace with real FREG + AKG queries.
+  return Promise.resolve({ fregHits: [], akgHits: [] });
+}
+
+/**
+ * Format substrate hits into a markdown block to inject into the
+ * decomposer prompt envelope. Empty strings are returned for empty
+ * hit-lists (the prompt envelope omits empty sections).
+ */
+export function formatFregHitsForPrompt(hits: ExistingArtifactRef[]): string {
+  if (hits.length === 0) return '';
+  const lines = hits.map(
+    (h) => ` - ${h.id} (score ${h.score.toFixed(2)}): ${h.name}${h.hint ? ' — ' + h.hint : ''}`,
+  );
+  return `## EXISTING FEATURES (FREG)\n${lines.join('\n')}\n`;
+}
+
+export function formatAkgHitsForPrompt(hits: ExistingArtifactRef[]): string {
+  if (hits.length === 0) return '';
+  const lines = hits.map(
+    (h) => ` - ${h.id} (${h.hint ?? 'artifact'}): ${h.name}`,
+  );
+  return `## EXISTING ARCHITECTURE (AKG)\n${lines.join('\n')}\n`;
+}

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -78,3 +78,35 @@ export {
 } from './atomicity-classifier.js';
 
 export type { ClassifyAtomicityOptions } from './atomicity-classifier.js';
+
+// ─── Engine (PR 2) ──────────────────────────────────────────────────────
+
+export {
+  PORecursiveDecomposer,
+  PORecursiveDecomposerCancelled,
+} from './decomposer.js';
+
+export type {
+  DecomposeOneOptions,
+  DecomposeRootOptions,
+  DecomposeRootResult,
+  DecomposedTreeNode,
+  ParentNode,
+} from './decomposer.js';
+
+export {
+  CHILD_SCOPE_OF,
+  DECOMPOSER_SYSTEM_PROMPTS,
+  DECOMPOSER_TASK_TYPES,
+} from './per-scope-prompts.js';
+
+export {
+  formatAkgHitsForPrompt,
+  formatFregHitsForPrompt,
+  querySubstrateStub,
+} from './freg-akg-stub.js';
+
+export type {
+  FregAkgQueryInput,
+  FregAkgQueryResult,
+} from './freg-akg-stub.js';

--- a/packages/decomposer-recursive/src/per-scope-prompts.ts
+++ b/packages/decomposer-recursive/src/per-scope-prompts.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-scope decomposition prompts (proposal §6).
+ *
+ * Each prompt is a system-level instruction that grounds the LLM in
+ * the scope's PMBOK/SAFe/DDD/INVEST invariants, asks it to emit a
+ * children array conforming to ChildTicketArraySchema, and includes
+ * the FREG/AKG substrate hints in the user message.
+ *
+ * Prompts are deliberately compact (~600-800 system + ~1.5-3K user
+ * tokens — see proposal §10 cost model). They reference the JSON
+ * envelope from structured-output.ts; they do NOT redeclare the
+ * "return JSON only" instruction.
+ */
+
+import type { StoryScope } from './types.js';
+
+const SHARED_INVARIANTS = `Universal invariants (apply at every scope):
+- 100% rule (PMBOK): the union of children must cover the parent's inScope. List anything you intentionally omit under outOfScope.
+- MECE: no two children may overlap in deliverable scope. If you find yourself describing the same feature in two children, merge them.
+- Honest ambiguity: if the prompt under-specifies persona, KPI, or boundary, emit a child with a low confidence score and call it out in the description; never invent KPIs the user didn't imply.
+- Cite-evidence: every claim about user intent must reference parent-ticket text.
+- Existing substrate: when an EXISTING FEATURES (FREG) or EXISTING ARCHITECTURE (AKG) entry overlaps a child's scope, set lifecycle='enhance' and reference the artifact id; prefer reuse over re-create.
+- IDs: child IDs must be unique strings within the children array; no self-dependencies.
+`;
+
+const INITIATIVE_PROMPT = `You are decomposing a strategic initiative into epics. An initiative is a multi-quarter strategic bet at the portfolio level. An epic is a single program-increment-sized (8-12 weeks per SAFe) chunk of value with one elevator-pitch theme.
+
+Your job: read the initiative ticket and produce 2-5 epics that, taken together, fully deliver the initiative's businessOutcome and respect the initiative's outOfScope.
+
+Strict requirements:
+1. Coverage + Disjointness as in the universal invariants.
+2. Each epic must have its own elevator-pitch summary (<= 25 words) in title+description.
+3. Each epic's inScope[] should have 3-6 items (each >= 5 words); outOfScope[] should have 1-3 items.
+4. Each epic must declare 1-2 dominant tech_sub_domains in the description ("dominant tech: ui+backend").
+5. Cross-epic dependencies: declare a dependency edge in dependencies[] if epic-A blocks epic-B; no self-dependencies.
+6. Each epic's lifecycle: 'enhance' if the FREG/AKG context shows substantial overlap with an existing feature; else 'new'. P0 stubs FREG/AKG to empty so default is 'new'.
+
+${SHARED_INVARIANTS}`;
+
+const EPIC_PROMPT = `You are decomposing an epic into modules. A module is a Domain-Driven-Design bounded context — a coherent capability cluster with a single primary tech_sub_domain and its own data ownership.
+
+Produce 2-6 modules that fully deliver the epic and respect the epic's outOfScope.
+
+Vertical-slicing reminder: if an epic touches UI, backend, and DB, prefer modules sliced by user-visible feature (each touching all three layers thinly) over modules sliced by technical layer.
+
+Strict requirements:
+1. Coverage + Disjointness.
+2. Each module declares its primary tech_sub_domain in the description ("primary tech: backend").
+3. Each module declares its data ownership in inScope[] (which schemas/tables/state-stores it owns).
+4. Cross-module dependencies declared explicitly. Most modules depend on at least one other.
+
+${SHARED_INVARIANTS}`;
+
+const MODULE_PROMPT = `You are decomposing a module into stories. A story is an INVEST-compliant user-value increment.
+
+Produce 2-8 stories that fully deliver the module's user-visible value.
+
+Strict requirements:
+1. Coverage + Disjointness.
+2. Each story has a "As a [persona], I want [outcome] so that [value]" sentence in description.
+3. Each story has acceptanceCriteria with 3-6 concrete items (each >= 8 words, each testable).
+4. Each story has its own inScope[] / outOfScope[].
+5. Vertical slice preferred when user value crosses tech sub-domains.
+
+${SHARED_INVARIANTS}`;
+
+const STORY_PROMPT = `You are decomposing a story into tasks. A task is a single-concern, <= 1-day, single-tech-sub-domain unit of work — typically a single file or tightly-coupled file group.
+
+Produce 1-6 tasks that fully implement the story's acceptance criteria.
+
+Strict requirements:
+1. Each task corresponds to >= 1 AC of the parent story (mention which AC IDs in the description).
+2. Each task has a concrete artifact target: file path, function/class name, schema/migration name, or API route in description.
+3. Each task declares its tech_sub_domain (single primary value) in the description.
+4. Cross-task dependencies declared in dependencies[] (data-model task blocks API task blocks UI task).
+
+${SHARED_INVARIANTS}`;
+
+const TASK_PROMPT = `You are decomposing a task into subtasks. A subtask is a single mechanical step: single function, single test, single comment block, single config edit.
+
+Most tasks do NOT need subtask decomposition. Produce 2-5 subtasks only when the parent task is genuinely multi-step (multi-file refactor, multi-test test addition).
+
+Strict requirements:
+1. Each subtask is <= 2 hours of work for a competent engineer.
+2. Each subtask names the precise artifact (function name, test name, file region) in the description.
+3. Subtasks are typically sequential within a task; declare order via dependencies[].
+
+${SHARED_INVARIANTS}`;
+
+const SUBTASK_PROMPT = `You are at the atomicity floor. Subtasks are leaves and rarely decompose further.
+
+If you absolutely must produce children (e.g., a renamed-as-subtask actually being a multi-step refactor), produce 2-3 micro-steps. Each micro-step is a single file edit or single line change.
+
+${SHARED_INVARIANTS}`;
+
+/**
+ * Map from parent scope to the system prompt for decomposing it into
+ * its child scope. Note: the key is the PARENT scope. The child scope
+ * is one level below per STORY_SCOPE_ORDER.
+ */
+export const DECOMPOSER_SYSTEM_PROMPTS: Record<StoryScope, string> = {
+  initiative: INITIATIVE_PROMPT,
+  epic: EPIC_PROMPT,
+  module: MODULE_PROMPT,
+  story: STORY_PROMPT,
+  task: TASK_PROMPT,
+  subtask: SUBTASK_PROMPT,
+};
+
+/**
+ * Map from parent scope to the routing-rule task type. Used by the
+ * engine to route through @chiefaia/local-llm-router with the right
+ * cost/quality tier.
+ */
+export const DECOMPOSER_TASK_TYPES: Record<StoryScope, string> = {
+  initiative: 'po-decomposer-initiative',
+  epic: 'po-decomposer-epic',
+  module: 'po-decomposer-module',
+  story: 'po-decomposer-story',
+  task: 'po-decomposer-task',
+  subtask: 'po-decomposer-subtask',
+};
+
+/**
+ * Child-scope mapping. `subtask` has no child (it's the atomicity floor);
+ * the engine never asks for sub-subtasks.
+ */
+export const CHILD_SCOPE_OF: Record<StoryScope, StoryScope | null> = {
+  initiative: 'epic',
+  epic: 'module',
+  module: 'story',
+  story: 'task',
+  task: 'subtask',
+  subtask: null,
+};

--- a/packages/decomposer-recursive/tests/decomposer.test.ts
+++ b/packages/decomposer-recursive/tests/decomposer.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  PORecursiveDecomposer,
+  PORecursiveDecomposerCancelled,
+} from '../src/decomposer.js';
+import { CHILD_SCOPE_OF, DECOMPOSER_SYSTEM_PROMPTS } from '../src/per-scope-prompts.js';
+import { STORY_SCOPES } from '../src/types.js';
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+function childPayload(scope: string, idx: number, atomic = true): Record<string, unknown> {
+  return {
+    id: `c${String(idx)}`,
+    scope,
+    title: `Candidate ${String(idx)}`,
+    description: `A description for candidate ${String(idx)} that is long enough`,
+    inScope: ['the in-scope item one'],
+    outOfScope: [],
+    dependencies: [],
+    estimatedAtomic: atomic,
+    existingArtifacts: [],
+    lifecycle: 'new',
+  };
+}
+
+const exampleParent = {
+  id: 'p',
+  scope: 'epic' as const,
+  title: 'A reasonable epic',
+  description: 'A reasonable epic that needs to be split into modules',
+  inScope: ['everything in this epic'],
+  outOfScope: [],
+};
+
+describe('per-scope prompts', () => {
+  it('have a non-empty system prompt for every scope', () => {
+    for (const scope of STORY_SCOPES) {
+      expect(DECOMPOSER_SYSTEM_PROMPTS[scope].length).toBeGreaterThan(100);
+    }
+  });
+
+  it('child-scope mapping is well-formed', () => {
+    expect(CHILD_SCOPE_OF.initiative).toBe('epic');
+    expect(CHILD_SCOPE_OF.epic).toBe('module');
+    expect(CHILD_SCOPE_OF.module).toBe('story');
+    expect(CHILD_SCOPE_OF.story).toBe('task');
+    expect(CHILD_SCOPE_OF.task).toBe('subtask');
+    expect(CHILD_SCOPE_OF.subtask).toBeNull();
+  });
+});
+
+describe('PORecursiveDecomposer.decomposeOne', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('expands an epic into modules', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([
+          childPayload('module', 1),
+          childPayload('module', 2),
+        ]),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeOne({
+      parent: exampleParent,
+      childScope: 'module',
+    });
+
+    expect(out.childTickets.length).toBe(2);
+    expect(out.childTickets.every((c) => c.scope === 'module')).toBe(true);
+    expect(out.audit.parentNodeId).toBe('p');
+    expect(out.audit.childScope).toBe('module');
+    expect(out.audit.outcome).toBe('committed');
+    expect(out.judgeScores.coverage).toBeNull();
+    expect(out.judgeScores.disjointness).toBeNull();
+    expect(out.clarifyingQuestions).toEqual([]);
+  });
+
+  it('cancellation aborts before the LLM call', async () => {
+    const ollama = fakeOllama({
+      responses: [jsonResponse([childPayload('story', 1)])],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const ac = new AbortController();
+    ac.abort();
+
+    const engine = new PORecursiveDecomposer();
+    await expect(
+      engine.decomposeOne({
+        parent: { ...exampleParent, scope: 'module' },
+        childScope: 'story',
+        signal: ac.signal,
+      }),
+    ).rejects.toBeInstanceOf(PORecursiveDecomposerCancelled);
+  });
+});
+
+describe('PORecursiveDecomposer.decomposeRoot', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('respects the targetScope guard (story-targeted recursion stops at story)', async () => {
+    // Parent is module, target is story. The engine should run one
+    // expansion (module → stories) and then stop because every child
+    // is at the target scope.
+    const ollama = fakeOllama({
+      responses: [
+        // Expansion: module → stories
+        jsonResponse([
+          childPayload('story', 1, true),
+          childPayload('story', 2, true),
+        ]),
+        // Atomicity classifier responses (one per child)
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] }),
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'module' },
+      targetScope: 'story',
+    });
+
+    expect(out.tree.children.length).toBe(2);
+    expect(out.tree.children.every((c) => c.atomic)).toBe(true);
+    expect(out.audits.length).toBe(1);
+    expect(out.truncated).toBe(false);
+  });
+
+  it('halts at maxExpansions (truncated tree)', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([
+          childPayload('module', 1, false),
+          childPayload('module', 2, false),
+        ]),
+        jsonResponse({ atomic: false, confidence: 0.5, rationale: 'too big still', failedCriteria: ['something'] }),
+        jsonResponse({ atomic: false, confidence: 0.5, rationale: 'too big still', failedCriteria: ['something'] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'epic' },
+      targetScope: 'subtask',
+      maxExpansions: 1,
+    });
+
+    expect(out.truncated).toBe(true);
+    expect(out.audits.length).toBeLessThanOrEqual(1);
+  });
+
+  it('decomposes recursively all the way to atomicity', async () => {
+    // Chain: epic → 1 module → 1 story (atomic)
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([childPayload('module', 1, false)]),
+        jsonResponse({ atomic: false, confidence: 0.5, rationale: 'still too big', failedCriteria: ['something'] }),
+        jsonResponse([childPayload('story', 1, true)]),
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'epic' },
+      targetScope: 'subtask',
+    });
+
+    expect(out.audits.length).toBe(2);
+    expect(out.tree.children.length).toBe(1);
+    expect(out.tree.children[0]?.children.length).toBe(1);
+    expect(out.tree.children[0]?.children[0]?.atomic).toBe(true);
+  });
+
+  it('returns total cost + duration accumulators', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([childPayload('module', 1, true)]),
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'ok looks atomic', failedCriteria: [] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'epic' },
+      targetScope: 'module',
+    });
+
+    expect(out.totalCostUsd).toBeGreaterThanOrEqual(0);
+    expect(out.totalDurationMs).toBeGreaterThan(0);
+    expect(out.totalCalls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
P0 slice 2 of the recursive PO decomposer. Stacked on top of #213.

## What's in
- `PORecursiveDecomposer` class with `decomposeOne` (single expansion) and `decomposeRoot` (recursive driver).
- Six per-scope decomposition system prompts (initiative→epic, epic→module, module→story, story→task, task→subtask, subtask-floor).
- FREG/AKG substrate stub (P0 returns empty; P1 wires real registries).
- Stateless across calls; cancellation via AbortSignal between recursion steps; bounded retry on schema parse failure (max 2).
- Cost-tracked: every expansion writes an AuditEntry; `decomposeRoot` returns cumulative cost/duration/calls + a `truncated` flag if maxExpansions was hit.

## Out of scope (P0 deferral)
- MECE judge pair → PR 3
- Pipeline-stage wiring + feature flag → PR 4
- Empirical validation → PR 5
- Real FREG/AKG → P1
- Clarifying-question pipeline → P1
- Vision-doc chunked summarization → P1

## Testing
- `pnpm --filter @chiefaia/decomposer-recursive test` → 58/58 pass.
- `pnpm typecheck` clean.

## Note
This PR is stacked on top of #213. Once #213 merges to develop, GitHub will auto-rebase this PR's base to develop.