### PR TITLE
feat(decomposer-recursive): MECE judge pair — coverage + disjointness (PO-DECOMP-003)

### DIFF
--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -110,3 +110,20 @@ export type {
   FregAkgQueryInput,
   FregAkgQueryResult,
 } from './freg-akg-stub.js';
+
+// ─── Judges (PR 3) ──────────────────────────────────────────────────────
+
+export {
+  COVERAGE_JUDGE_TASK_TYPE,
+  DISJOINTNESS_JUDGE_TASK_TYPE,
+  JUDGE_PASS_THRESHOLD,
+  normaliseJudgeScore,
+  runJudgePair,
+} from './judges.js';
+
+export type {
+  CoverageVerdict,
+  DisjointnessVerdict,
+  JudgeInput,
+  JudgePairResult,
+} from './judges.js';

--- a/packages/decomposer-recursive/src/judges.ts
+++ b/packages/decomposer-recursive/src/judges.ts
@@ -1,0 +1,287 @@
+/**
+ * MECE judge pair (proposal §5F).
+ *
+ * After every parent expansion, two judges run in parallel:
+ *
+ *   1. Parent-coverage judge — does the union of children fully cover
+ *      the parent's inScope? (PMBOK 100% rule.)
+ *   2. Sibling-disjointness judge — do any two children overlap in
+ *      deliverable scope? (MECE-mutually-exclusive.)
+ *
+ * Both judges return a 1-5 score. The pass threshold is 4.0; on
+ * either fail the engine kicks off reflexive retry: the decomposer
+ * is re-invoked with the judge's rejection rationale appended to the
+ * user prompt as Reflexion-style feedback. Up to 2 retries.
+ *
+ * Both judges route through `po-decomposer-coverage-judge` /
+ * `po-decomposer-disjointness-judge` task types (Sonnet) — judging is
+ * high-leverage low-cost relative to regenerating downstream artefacts.
+ */
+
+import { z } from 'zod';
+import { callStructured } from './structured-output.js';
+import type { CancellationSignal, ChildTicket, StoryScope } from './types.js';
+
+export const COVERAGE_JUDGE_TASK_TYPE = 'po-decomposer-coverage-judge';
+export const DISJOINTNESS_JUDGE_TASK_TYPE = 'po-decomposer-disjointness-judge';
+
+/**
+ * Pass threshold for both judges. 4.0 / 5.0 means the model must
+ * agree fairly strongly that the children cover (resp. are disjoint).
+ * Below this, the engine reflexively retries the parent expansion.
+ */
+export const JUDGE_PASS_THRESHOLD = 4.0;
+
+// ─── Schemas ────────────────────────────────────────────────────────────
+
+const CoverageJudgeOutputSchema = z.object({
+  /** 1..5 confidence the children fully cover the parent. */
+  score: z.number().min(1).max(5),
+  /** True iff score >= JUDGE_PASS_THRESHOLD. */
+  covered: z.boolean(),
+  /** Verbatim deliverables the judge thinks are missing. */
+  missingDeliverables: z.array(z.string()),
+  /** Free-form one-paragraph rationale (used as reflexive feedback). */
+  rationale: z.string().min(5),
+});
+
+const DisjointnessJudgeOutputSchema = z.object({
+  score: z.number().min(1).max(5),
+  disjoint: z.boolean(),
+  /** Pairs of overlapping siblings (verbatim ids + a one-line description). */
+  overlaps: z.array(
+    z.object({
+      childA: z.string().min(1),
+      childB: z.string().min(1),
+      overlapDescription: z.string().min(3),
+    }),
+  ),
+  rationale: z.string().min(5),
+});
+
+// ─── Inputs / outputs ───────────────────────────────────────────────────
+
+export interface JudgeInput {
+  /** Parent ticket — judges see this to scope coverage. */
+  parent: {
+    title: string;
+    description: string;
+    scope: StoryScope;
+    inScope: string[];
+    outOfScope: string[];
+  };
+  /** Children produced by the decomposer. */
+  children: ChildTicket[];
+  /** Optional cancellation signal. */
+  signal?: CancellationSignal;
+}
+
+export interface CoverageVerdict {
+  score: number; // 1..5
+  passed: boolean; // score >= threshold
+  missingDeliverables: string[];
+  rationale: string;
+  model: string;
+  durationMs: number;
+  costUsd: number;
+}
+
+export interface DisjointnessVerdict {
+  score: number; // 1..5
+  passed: boolean;
+  overlaps: Array<{ childA: string; childB: string; overlapDescription: string }>;
+  rationale: string;
+  model: string;
+  durationMs: number;
+  costUsd: number;
+}
+
+export interface JudgePairResult {
+  coverage: CoverageVerdict;
+  disjointness: DisjointnessVerdict;
+  /** True iff BOTH judges passed. */
+  bothPassed: boolean;
+  /**
+   * Combined feedback the decomposer can inject as a system message
+   * on the next reflexive retry. Empty string when both judges pass.
+   */
+  reflexiveFeedback: string;
+}
+
+// ─── System prompts ─────────────────────────────────────────────────────
+
+const COVERAGE_JUDGE_SYSTEM_PROMPT = `You are evaluating a Work Breakdown Structure (WBS) for the PMBOK 100% rule.
+
+The 100% rule states: the children must cover 100% of the work implied by the parent's inScope. Anything intentionally omitted must be in the parent's outOfScope.
+
+Score 1..5 (5 = perfect coverage; 4 = minor gaps acceptable; 3 = noticeable gaps; 2 = significant gaps; 1 = major coverage failure). Set "covered": true when score >= 4.0.
+
+List every concrete deliverable from the parent's inScope that is NOT addressed by any child as "missingDeliverables". If "covered" is true and "missingDeliverables" non-empty, you have an internal contradiction — re-evaluate.
+
+Output schema:
+{
+  "score": 1..5,
+  "covered": true | false,
+  "missingDeliverables": [ "verbatim deliverable text" ],
+  "rationale": "one paragraph"
+}`;
+
+const DISJOINTNESS_JUDGE_SYSTEM_PROMPT = `You are evaluating a Work Breakdown Structure (WBS) for the MECE-mutually-exclusive principle.
+
+Children must NOT overlap in deliverable scope. If two children describe the same feature/component/data-store, they overlap — list them in "overlaps".
+
+Score 1..5 (5 = no overlaps; 4 = minor overlap on edge cases; 3 = noticeable overlap; 2 = significant overlap; 1 = severe overlap throughout). Set "disjoint": true when score >= 4.0.
+
+For each overlapping pair, include both child IDs (verbatim from the children list) and a one-line description of the overlap.
+
+Output schema:
+{
+  "score": 1..5,
+  "disjoint": true | false,
+  "overlaps": [
+    { "childA": "id1", "childB": "id2", "overlapDescription": "..." }
+  ],
+  "rationale": "one paragraph"
+}`;
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function buildUserPrompt(input: JudgeInput): string {
+  const childrenBlock = input.children
+    .map(
+      (c, i) =>
+        `### Child ${String(i + 1)} (id=${c.id}, scope=${c.scope})\n` +
+        `Title: ${c.title}\n` +
+        `Description: ${c.description}\n` +
+        `In scope: ${c.inScope.join('; ') || '(empty)'}\n` +
+        `Out of scope: ${c.outOfScope.join('; ') || '(empty)'}`,
+    )
+    .join('\n\n');
+
+  return [
+    `## PARENT`,
+    `Title: ${input.parent.title}`,
+    `Scope: ${input.parent.scope}`,
+    `Description: ${input.parent.description}`,
+    `In scope: ${input.parent.inScope.join('; ') || '(empty)'}`,
+    `Out of scope: ${input.parent.outOfScope.join('; ') || '(empty)'}`,
+    '',
+    `## CHILDREN (${String(input.children.length)})`,
+    childrenBlock,
+  ].join('\n');
+}
+
+function formatCoverageFeedback(v: CoverageVerdict): string {
+  if (v.passed) return '';
+  const missingBullets =
+    v.missingDeliverables.length > 0
+      ? v.missingDeliverables.map((m) => ` - ${m}`).join('\n')
+      : ' - (none listed by judge — see rationale)';
+  return (
+    `### Coverage judge — FAIL (score ${v.score.toFixed(2)} < ${JUDGE_PASS_THRESHOLD.toFixed(1)})\n` +
+    `Missing deliverables:\n${missingBullets}\n` +
+    `Rationale: ${v.rationale}`
+  );
+}
+
+function formatDisjointnessFeedback(v: DisjointnessVerdict): string {
+  if (v.passed) return '';
+  const overlapsBullets =
+    v.overlaps.length > 0
+      ? v.overlaps
+          .map(
+            (o) =>
+              ` - ${o.childA} <-> ${o.childB}: ${o.overlapDescription}`,
+          )
+          .join('\n')
+      : ' - (none listed by judge — see rationale)';
+  return (
+    `### Disjointness judge — FAIL (score ${v.score.toFixed(2)} < ${JUDGE_PASS_THRESHOLD.toFixed(1)})\n` +
+    `Overlapping siblings:\n${overlapsBullets}\n` +
+    `Rationale: ${v.rationale}`
+  );
+}
+
+// ─── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Run both judges in parallel. Returns the verdicts, a `bothPassed`
+ * flag, and a combined `reflexiveFeedback` string the engine can
+ * inject as Reflexion-style feedback on the next decomposer retry.
+ */
+export async function runJudgePair(input: JudgeInput): Promise<JudgePairResult> {
+  const userPrompt = buildUserPrompt(input);
+
+  const [coverageResult, disjointnessResult] = await Promise.all([
+    callStructured(CoverageJudgeOutputSchema, {
+      taskType: COVERAGE_JUDGE_TASK_TYPE,
+      systemPrompt: COVERAGE_JUDGE_SYSTEM_PROMPT,
+      userPrompt,
+      maxRetries: 2,
+      ...(input.signal ? { signal: input.signal } : {}),
+    }),
+    callStructured(DisjointnessJudgeOutputSchema, {
+      taskType: DISJOINTNESS_JUDGE_TASK_TYPE,
+      systemPrompt: DISJOINTNESS_JUDGE_SYSTEM_PROMPT,
+      userPrompt,
+      maxRetries: 2,
+      ...(input.signal ? { signal: input.signal } : {}),
+    }),
+  ]);
+
+  // Force-correct contradictions: if score >= threshold but the
+  // boolean disagrees, override the boolean. Bias toward "fail" when
+  // missingDeliverables / overlaps is non-empty (conservative).
+  let coveragePassed = coverageResult.data.score >= JUDGE_PASS_THRESHOLD;
+  if (coveragePassed && coverageResult.data.missingDeliverables.length > 0) {
+    coveragePassed = false;
+  }
+  let disjointnessPassed = disjointnessResult.data.score >= JUDGE_PASS_THRESHOLD;
+  if (disjointnessPassed && disjointnessResult.data.overlaps.length > 0) {
+    disjointnessPassed = false;
+  }
+
+  const coverage: CoverageVerdict = {
+    score: coverageResult.data.score,
+    passed: coveragePassed,
+    missingDeliverables: coverageResult.data.missingDeliverables,
+    rationale: coverageResult.data.rationale,
+    model: coverageResult.model,
+    durationMs: coverageResult.durationMs,
+    costUsd: coverageResult.costUsd,
+  };
+  const disjointness: DisjointnessVerdict = {
+    score: disjointnessResult.data.score,
+    passed: disjointnessPassed,
+    overlaps: disjointnessResult.data.overlaps,
+    rationale: disjointnessResult.data.rationale,
+    model: disjointnessResult.model,
+    durationMs: disjointnessResult.durationMs,
+    costUsd: disjointnessResult.costUsd,
+  };
+
+  const bothPassed = coverage.passed && disjointness.passed;
+  const reflexiveFeedback = bothPassed
+    ? ''
+    : [
+        '## JUDGE FEEDBACK FROM PRIOR ATTEMPT',
+        formatCoverageFeedback(coverage),
+        formatDisjointnessFeedback(disjointness),
+        '',
+        'Re-decompose the parent addressing every issue above. Cover the missing deliverables; merge or disambiguate the overlapping siblings.',
+      ]
+        .filter((s) => s.length > 0)
+        .join('\n\n');
+
+  return { coverage, disjointness, bothPassed, reflexiveFeedback };
+}
+
+/**
+ * Normalise a 1..5 judge score to a 0..1 confidence range that fits
+ * the AuditEntry / Decomposition schema's `coverageScore` /
+ * `disjointnessScore` field.
+ */
+export function normaliseJudgeScore(scoreOneToFive: number): number {
+  // (s - 1) / 4 maps 1..5 → 0..1.
+  return Math.max(0, Math.min(1, (scoreOneToFive - 1) / 4));
+}

--- a/packages/decomposer-recursive/tests/_helpers.ts
+++ b/packages/decomposer-recursive/tests/_helpers.ts
@@ -16,7 +16,7 @@ import {
 
 export interface FakeAdapterConfig {
   /** Sequence of responses to return on successive `generate` calls. */
-  responses: Array<Partial<LLMResponse> & { response: string }>;
+  responses: Array<Partial<LLMResponse> & { response: string; match?: string }>;
   /** Whether the local adapter advertises itself as available. Default true. */
   available?: boolean;
   /** When set, the adapter throws this error instead of returning. */
@@ -50,14 +50,34 @@ export function fakeOllama(config: FakeAdapterConfig): OllamaAdapter {
 
 /**
  * Create a Claude-style fake. Same semantics as fakeOllama.
+ *
+ * If the test's `responses` array contains entries with a `match` field,
+ * the fake routes by checking whether the request prompt INCLUDES that
+ * substring — useful for parallel Promise.all calls where ordering is
+ * non-deterministic. Fall-through when no match: returns the responses
+ * in queue order.
  */
 export function fakeClaude(config: FakeAdapterConfig): ClaudeAdapter {
   let cursor = 0;
+  const used = new Set<number>();
   return {
-    generate: vi.fn(async (model: string): Promise<LLMResponse> => {
+    generate: vi.fn(async (model: string, req: { prompt: string }): Promise<LLMResponse> => {
       if (config.throws) throw config.throws;
-      const idx = Math.min(cursor, config.responses.length - 1);
-      cursor++;
+      // Try match-based routing first.
+      const promptText = req?.prompt ?? '';
+      let idx = -1;
+      for (let i = 0; i < config.responses.length; i++) {
+        const r = config.responses[i] as Partial<LLMResponse> & { response: string; match?: string };
+        if (r.match && !used.has(i) && promptText.includes(r.match)) {
+          idx = i;
+          break;
+        }
+      }
+      if (idx === -1) {
+        idx = Math.min(cursor, config.responses.length - 1);
+        cursor++;
+      }
+      used.add(idx);
       const next = config.responses[idx];
       if (!next) throw new Error('fakeClaude: no responses configured');
       return {

--- a/packages/decomposer-recursive/tests/judges.test.ts
+++ b/packages/decomposer-recursive/tests/judges.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  JUDGE_PASS_THRESHOLD,
+  normaliseJudgeScore,
+  runJudgePair,
+} from '../src/judges.js';
+import type { ChildTicket } from '../src/types.js';
+import { fakeOllama, fakeClaude, installFakeAdapters, clearAdapters, jsonResponse } from './_helpers.js';
+
+const sampleParent = {
+  title: 'Build the billing module',
+  description: 'A billing module that handles checkout and invoicing',
+  scope: 'epic' as const,
+  inScope: ['stripe checkout', 'monthly invoice generation', 'webhook handler'],
+  outOfScope: ['tax calculation per region'],
+};
+
+function child(id: string, title: string): ChildTicket {
+  return {
+    id,
+    scope: 'module',
+    title,
+    description: `Description for ${title}`,
+    inScope: ['module-level item'],
+    outOfScope: [],
+    dependencies: [],
+    estimatedAtomic: false,
+    existingArtifacts: [],
+    lifecycle: 'new',
+  };
+}
+
+describe('runJudgePair', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('returns bothPassed=true when both scores >= threshold and no missing/overlap', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'every deliverable mapped' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'no overlap' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Checkout'), child('m2', 'Invoicing')],
+    });
+
+    expect(result.coverage.passed).toBe(true);
+    expect(result.disjointness.passed).toBe(true);
+    expect(result.bothPassed).toBe(true);
+    expect(result.reflexiveFeedback).toBe('');
+  });
+
+  it('reports coverage failure with a feedback block', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 3, covered: false, missingDeliverables: ['monthly invoice generation'], rationale: 'invoice generation has no child' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'no overlap' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Checkout')],
+    });
+
+    expect(result.coverage.passed).toBe(false);
+    expect(result.coverage.missingDeliverables).toContain('monthly invoice generation');
+    expect(result.disjointness.passed).toBe(true);
+    expect(result.bothPassed).toBe(false);
+    expect(result.reflexiveFeedback).toContain('Coverage judge — FAIL');
+    expect(result.reflexiveFeedback).toContain('monthly invoice generation');
+  });
+
+  it('reports disjointness failure with overlap detail', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'all covered' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 2, disjoint: false, overlaps: [{ childA: 'm1', childB: 'm2', overlapDescription: 'both modules own checkout state' }], rationale: 'overlap detected' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Checkout v1'), child('m2', 'Checkout v2')],
+    });
+
+    expect(result.coverage.passed).toBe(true);
+    expect(result.disjointness.passed).toBe(false);
+    expect(result.disjointness.overlaps.length).toBe(1);
+    expect(result.bothPassed).toBe(false);
+    expect(result.reflexiveFeedback).toContain('Disjointness judge — FAIL');
+    expect(result.reflexiveFeedback).toContain('m1 <-> m2');
+  });
+
+  it('force-corrects covered=true with non-empty missingDeliverables', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: ['something missing'], rationale: 'self-contradictory output' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'all good' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Mod')],
+    });
+
+    expect(result.coverage.passed).toBe(false); // force-corrected
+  });
+
+  it('force-corrects disjoint=true with non-empty overlaps', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'all good' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [{ childA: 'a', childB: 'b', overlapDescription: 'overlap' }], rationale: 'self-contradictory' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('a', 'A'), child('b', 'B')],
+    });
+
+    expect(result.disjointness.passed).toBe(false);
+  });
+
+  it('runs the two judges in parallel (Promise.all)', async () => {
+    // We can verify parallel by looking at total cost = sum of both
+    // sub-call costs. Both go through Sonnet @ $0.40/1000 = $0.0004.
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'all good' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'all good' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Mod')],
+    });
+
+    expect(result.coverage.costUsd).toBeCloseTo(0.0004, 5);
+    expect(result.disjointness.costUsd).toBeCloseTo(0.0004, 5);
+  });
+});
+
+describe('normaliseJudgeScore', () => {
+  it('maps 1 to 0', () => {
+    expect(normaliseJudgeScore(1)).toBe(0);
+  });
+  it('maps 5 to 1', () => {
+    expect(normaliseJudgeScore(5)).toBe(1);
+  });
+  it('maps 4 to 0.75', () => {
+    expect(normaliseJudgeScore(4)).toBeCloseTo(0.75);
+  });
+  it('clamps below 1 to 0', () => {
+    expect(normaliseJudgeScore(-2)).toBe(0);
+  });
+  it('clamps above 5 to 1', () => {
+    expect(normaliseJudgeScore(7)).toBe(1);
+  });
+});
+
+describe('JUDGE_PASS_THRESHOLD', () => {
+  it('is 4.0 per proposal §5F', () => {
+    expect(JUDGE_PASS_THRESHOLD).toBe(4.0);
+  });
+});


### PR DESCRIPTION
P0 slice 3 of 5. Stacked on top of #214.

## What's in
- `runJudgePair` runs parent-coverage + sibling-disjointness judges in parallel via `Promise.all`.
- Coverage judge — PMBOK 100% rule. Returns 1-5 score + verbatim `missingDeliverables`.
- Disjointness judge — MECE-mutually-exclusive. Returns 1-5 score + `overlaps` pairs (childA/childB).
- Pass threshold `4.0/5` per proposal §5F.
- Force-correction on contradictory output (covered=true with non-empty missing → flips to false; same for disjoint).
- Reflexive-feedback string the engine can inject as a system message on the next decomposer retry (Reflexion pattern). Engine wiring lands in PR 4.

## Tests
12 new vitest cases. Total package suite **70/70 pass**.

## Note
Stacked on #214. Auto-rebases when #213 → #214 → develop chain merges.