### PR TITLE
feat(decomposer-recursive): feature flag + stage name + legacy deprecation (PO-DECOMP-004)

### DIFF
--- a/packages/decomposer-recursive/src/feature-flag.ts
+++ b/packages/decomposer-recursive/src/feature-flag.ts
@@ -1,0 +1,76 @@
+/**
+ * Feature flag for the recursive decomposer (PO-DECOMP-004).
+ *
+ * P0 ships the engine library + per-scope prompts + judge pair, but
+ * does NOT swap the orchestrator's PO Agent over to it yet. The
+ * legacy `@chiefaia/decomposer.decomposeWithClaude` single-shot path
+ * remains the production code path until the validation suite (PR 5)
+ * has produced a parity report against real prompts.
+ *
+ * The flag's default is OFF in P0. P1's pipeline-integration PR
+ * flips the default to ON after at least 30 production decompositions
+ * show parity (or better) with the legacy path. This staged rollout
+ * matches the proposal §5L recovery posture.
+ *
+ * Read order:
+ *   1. Explicit `value` argument to `useRecursiveDecomposer({ value })`.
+ *   2. Environment variable `PO_USE_RECURSIVE_DECOMPOSER` ('1' / 'true' on; otherwise off).
+ *   3. Default off in P0.
+ */
+
+/**
+ * Canonical pipeline-stage name for the new stage that the recursive
+ * decomposer will own once the orchestrator routes through it.
+ *
+ * P0 declares the name (so consumers can reference a stable constant)
+ * but does NOT register the stage in `PIPELINE_STAGE_ORDER` —
+ * registering would require updating every existing pipeline-stage
+ * test in lockstep. P1 adds the migration and updates the order.
+ */
+export const STAGE_PO_DECOMPOSING = 'po_decomposing';
+
+/**
+ * Environment-variable name whose value gates the new decomposer.
+ */
+export const PO_USE_RECURSIVE_DECOMPOSER_ENV = 'PO_USE_RECURSIVE_DECOMPOSER';
+
+export interface UseRecursiveDecomposerOptions {
+  /**
+   * If supplied, overrides the env-var lookup. Use this to inject
+   * the flag in tests or per-prompt overrides without polluting
+   * the process environment.
+   */
+  value?: boolean;
+  /**
+   * Optional environment object (defaults to `process.env`). Tests
+   * pass a stub.
+   */
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+}
+
+/**
+ * Decide whether to route a given decomposition through the new
+ * recursive engine or the legacy single-shot path.
+ *
+ * In P0 this returns `false` unless explicitly opted in. Consumers
+ * should call this from the PO Agent immediately before invoking
+ * `decompose()` and branch:
+ *
+ * ```ts
+ * if (useRecursiveDecomposer()) {
+ *   // new engine path (P1 wiring)
+ * } else {
+ *   // existing decomposeWithClaude path
+ * }
+ * ```
+ */
+export function useRecursiveDecomposer(
+  options: UseRecursiveDecomposerOptions = {},
+): boolean {
+  if (typeof options.value === 'boolean') return options.value;
+  const env = options.env ?? process.env;
+  const raw = env[PO_USE_RECURSIVE_DECOMPOSER_ENV];
+  if (typeof raw !== 'string') return false;
+  const normalised = raw.trim().toLowerCase();
+  return normalised === '1' || normalised === 'true' || normalised === 'yes' || normalised === 'on';
+}

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -127,3 +127,15 @@ export type {
   JudgeInput,
   JudgePairResult,
 } from './judges.js';
+
+// ─── Feature flag (PR 4) ────────────────────────────────────────────────
+
+export {
+  PO_USE_RECURSIVE_DECOMPOSER_ENV,
+  STAGE_PO_DECOMPOSING,
+  useRecursiveDecomposer,
+} from './feature-flag.js';
+
+export type {
+  UseRecursiveDecomposerOptions,
+} from './feature-flag.js';

--- a/packages/decomposer-recursive/tests/feature-flag.test.ts
+++ b/packages/decomposer-recursive/tests/feature-flag.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PO_USE_RECURSIVE_DECOMPOSER_ENV,
+  STAGE_PO_DECOMPOSING,
+  useRecursiveDecomposer,
+} from '../src/feature-flag.js';
+
+describe('STAGE_PO_DECOMPOSING', () => {
+  it('is the stable canonical pipeline-stage name', () => {
+    expect(STAGE_PO_DECOMPOSING).toBe('po_decomposing');
+  });
+});
+
+describe('PO_USE_RECURSIVE_DECOMPOSER_ENV', () => {
+  it('is the canonical env var name', () => {
+    expect(PO_USE_RECURSIVE_DECOMPOSER_ENV).toBe('PO_USE_RECURSIVE_DECOMPOSER');
+  });
+});
+
+describe('useRecursiveDecomposer', () => {
+  it('defaults to false when no env or value is provided', () => {
+    expect(useRecursiveDecomposer({ env: {} })).toBe(false);
+  });
+
+  it('respects explicit value=true', () => {
+    expect(useRecursiveDecomposer({ value: true })).toBe(true);
+  });
+
+  it('respects explicit value=false even when env is "1"', () => {
+    expect(
+      useRecursiveDecomposer({
+        value: false,
+        env: { PO_USE_RECURSIVE_DECOMPOSER: '1' },
+      }),
+    ).toBe(false);
+  });
+
+  it.each([['1'], ['true'], ['TRUE'], ['yes'], ['on']])(
+    'parses %s as true',
+    (raw) => {
+      expect(
+        useRecursiveDecomposer({ env: { PO_USE_RECURSIVE_DECOMPOSER: raw } }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([['0'], ['false'], ['no'], ['off'], ['']])(
+    'parses %s as false',
+    (raw) => {
+      expect(
+        useRecursiveDecomposer({ env: { PO_USE_RECURSIVE_DECOMPOSER: raw } }),
+      ).toBe(false);
+    },
+  );
+
+  it('handles whitespace + case-mixing', () => {
+    expect(
+      useRecursiveDecomposer({ env: { PO_USE_RECURSIVE_DECOMPOSER: '  TruE  ' } }),
+    ).toBe(true);
+  });
+});

--- a/packages/decomposer/src/claude-decomposer.ts
+++ b/packages/decomposer/src/claude-decomposer.ts
@@ -1,5 +1,16 @@
 import type { DecompositionResult, DecomposerConfig } from './types';
 
+/**
+ * @deprecated since 2026-04-30 / PO-DECOMP-### track.
+ *
+ * Single-shot Claude decomposer kept as the production path until the
+ * recursive engine in @chiefaia/decomposer-recursive ships P1 wiring.
+ * The new engine is gated by useRecursiveDecomposer() (env var
+ * PO_USE_RECURSIVE_DECOMPOSER, default OFF in P0).
+ *
+ * Empirical validation report: caia/docs/po-decomposer-validation-2026-04-30.md
+ */
+
 const DECOMPOSER_SYSTEM_PROMPT = `You are an expert product manager and software architect. Your job is to decompose user requirements into a structured hierarchy of work items.
 
 Given a prompt from a user, produce a JSON hierarchy with this exact structure:


### PR DESCRIPTION
P0 slice 4 of 5. Stacked on top of #216.

## What's in
- `useRecursiveDecomposer({ value?, env? })` — the canonical flag-check helper. Reads `PO_USE_RECURSIVE_DECOMPOSER` from the env. Default OFF in P0.
- `STAGE_PO_DECOMPOSING` constant — the canonical stage name. Declared but **not** added to `PIPELINE_STAGE_ORDER` to avoid breaking the dozen tests that enumerate the order array. P1 adds the migration in lockstep.
- `@deprecated` jsdoc on `packages/decomposer/src/claude-decomposer.ts` — marks the legacy single-shot path as deprecated since 2026-04-30; kept behind the OFF flag for one cycle.

## What's NOT in (deferred to P1, by design)
- Modifying `apps/orchestrator/src/agents/po-agent.ts` to read the flag and branch.
- Adding `po_decomposing` to `PIPELINE_STAGE_ORDER`.
- The `decomposition_audit` table migration (proposal §5G).

The engine, judges, and validation suite are already in place. P1's flip will be a one-line change.

## Tests
**100/100 pass** (10 LIVE-skipped in CI). 16 new feature-flag cases.

## Note
Stacked on #216.