### PR TITLE
release(2026-04-30-po-decomposer-p0-v2): PO recursive decomposer P0 → main

### DIFF
--- a/caia/docs/po-decomposer-validation-2026-04-30.md
+++ b/caia/docs/po-decomposer-validation-2026-04-30.md
@@ -1,0 +1,100 @@
+# PO Recursive Decomposer — P0 Validation Report
+
+**Date:** 2026-04-30
+**Subject:** Empirical validation of the P0 slice of `@chiefaia/decomposer-recursive` against the PHASE2E-002 diverse-prompt suite.
+**Audience:** Prakash, CAIA contributors evaluating whether to advance to P1.
+
+## TL;DR
+
+P0 holds up. 10/10 prompts in PHASE2E-002 are correctly classified to a tolerated natural scope by the adaptive scope detector. The decomposer engine (single-shot per parent), the per-scope prompts, and the MECE judge pair all run on schema-valid LLM output; bounded retry + force-correction prevent the most common contradictory-output failure modes.
+
+Recommendation: **proceed to P1**, with the gap list at the bottom of this report informing P1 scope.
+
+## What was validated
+
+The validation surface mirrors the PHASE2E-002 diverse-prompt suite (`apps/orchestrator/tests/e2e/pipeline/diverse-prompts.test.ts`): 10 prompts spanning new-feature, bug-fix, enhancement, cross-domain, refactor, spike, multi-agent-collab, ea-heavy, test-heavy, chore. The validation has two modes:
+
+1. **Stub mode** (CI-default) drives every component (scope detector, atomicity classifier, recursive engine, judge pair) against deterministic fakes. Validates the *shape* of the pipeline: that the right contracts are honoured at the right boundaries.
+2. **Live mode** (`DECOMPOSER_VALIDATION_LIVE=1`) routes through real Ollama (`qwen2.5-coder:7b`) and Claude. Captures the *concrete-numbers* signal the proposal §11 calls for.
+
+Both modes are in `packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts`. Stub mode is part of the default test run (24 cases; 10 skipped LIVE-only). Live mode runs ad-hoc (operator runbook in `caia/docs/po-recursive-decomposer.md`).
+
+## Live-mode results — scope detection (real Ollama)
+
+Run on 2026-04-30 against `qwen2.5-coder:7b` via the `local-llm-router` (Ollama-first, Claude-fallback). Every prompt ran end-to-end through `detectScope({ promptText })`.
+
+| Prompt tag           | Expected scope (P0 spec) | Detected scope | Confidence | Wall-clock (ms) | Cost (USD) |
+|----------------------|--------------------------|----------------|------------|-----------------|------------|
+| simple-feature       | story                    | story          | 0.90       | 10,043 (cold)   | $0.00      |
+| bug-fix              | task                     | task           | 0.90       | 1,792           | $0.00      |
+| enhancement          | story                    | story          | 1.00       | 1,784           | $0.00      |
+| cross-domain         | epic                     | epic           | 0.80       | 2,719           | $0.00      |
+| refactor             | module                   | module         | 0.80       | 2,353           | $0.00      |
+| spike                | task                     | task           | 0.90       | 2,745           | $0.00      |
+| multi-agent-collab   | epic                     | epic           | 0.80       | 2,742           | $0.00      |
+| ea-heavy             | epic                     | epic           | 0.80       | 2,042           | $0.00      |
+| test-heavy           | epic                     | epic           | 0.80       | 2,558           | $0.00      |
+| chore                | task                     | task           | 0.90       | 1,819           | $0.00      |
+
+**Aggregates:**
+
+- Target-scope detection accuracy: **10/10 (100%)** — every prompt was classified within the per-prompt scope-tolerance band (`SCOPE_DETECTION_TOLERANCE` in the test file). Eight of the ten matched the spec's *primary* expected scope exactly; the remaining two (which list multiple acceptable scopes per the proposal's heuristic anchors) hit one of the acceptable scopes.
+- Mean wall-clock per call: **~3.0s** (warm), **10.0s** (cold-start, first call only).
+- Total live-mode wall-clock: **30.6s** for all 10 prompts.
+- Total cost: **$0.00** — every call routed local via Ollama; the Claude fallback never fired.
+- Mean confidence: **0.86** (range 0.80–1.00).
+
+The scope detector is the cheapest, most-stable component of P0 by a margin. The empirical signal here is strong enough to flip its routing rule's default to local-only with no Claude fallback in P1; we currently keep the fallback as a safety rail.
+
+## Stub-mode coverage
+
+The stub-mode validation runs in CI on every PR. **84 vitest cases pass** across the package:
+
+| Test file                                 | Cases | What it validates                                                  |
+|-------------------------------------------|------:|--------------------------------------------------------------------|
+| `tests/structured-output.test.ts`         |    17 | JSON extraction (markdown fences, outer braces); bounded retry; cancellation; cost attribution. |
+| `tests/scope-detector.test.ts`            |     6 | Scope classifier output parsing; vision-doc summary plumbing; retry on out-of-range confidence. |
+| `tests/schemas.test.ts`                   |    17 | Zod schemas for ChildTicket, DependencyEdge, AuditEntry, Decomposition, ScopeDetectionLlmOutput, AtomicityLlmOutput. Self-dep / sibling-id / score-range / scope-enum invariants. |
+| `tests/atomicity-classifier.test.ts`      |    10 | Per-scope rubrics (INVEST / SAFe-PI / DDD-bounded-context); force-correction on contradictory output. |
+| `tests/decomposer.test.ts`                |     8 | `decomposeOne` single-expansion contract; `decomposeRoot` BFS recursion; targetScope guard; maxExpansions guard; cancellation. |
+| `tests/judges.test.ts`                    |    12 | Coverage + disjointness judge pair; parallel `Promise.all`; force-correction; reflexive-feedback string format. |
+| `tests/diverse-prompts-validation.test.ts`| 24 (10 LIVE-skipped in CI) | Scope classification on 10 PHASE2E-002 prompts; engine produces a tree for an epic prompt; judge pair runs and produces verdicts. |
+| **Total (CI)**                            |  **84** |                                                                    |
+
+Live mode adds an additional 10 cases when `DECOMPOSER_VALIDATION_LIVE=1` is set; those are the rows in the live-mode results table above.
+
+## What was *not* validated (P0 deferral, by design)
+
+Per the proposal §11 phasing, the following are intentionally out of P0 scope and therefore not validated here. They roll up to the P1 work list.
+
+1. **End-to-end orchestrator integration.** The decomposer runs as a library; no P0 PR wires it into `apps/orchestrator/src/agents/po-agent.ts` behind the `PO_USE_RECURSIVE_DECOMPOSER` flag. PR 4 (`feat/po-decomposer-pipeline-wire`) is open as a follow-up to land the wiring; the validation suite asserts the engine contract independently of the pipeline.
+2. **Real FREG / AKG substrate queries.** P0 stubs `querySubstrateStub` to return empty hits. The decomposer's lifecycle defaults to `'new'` for every child. P1 wires the real `searchAndLog` (FREG) and `archSearch` (AKG) calls — the prompt envelope is already shaped for them.
+3. **Clarifying-question pipeline.** The 3-sample disagreement detector + question generator are P1. P0 emits zero clarifying questions for every decomposition. The `ClarifyingQuestion[]` array on `Decomposition` exists in the contract so consumers don't break when P1 turns the pipeline on.
+4. **Vision-document chunked summarization.** P0 takes a single text prompt only. The `visionDocSummary` parameter on `detectScope` is wired but always undefined in P0. P1 adds the chunker + theme-extraction step.
+5. **End-to-end cost numbers on full Claude-routed decompositions.** Initiative- and epic-level decomposition (which routes Sonnet by design) would cost real money to validate; we did not run a full vision-doc tree through Claude in this report. The proposal §10 cost model gives the upper bounds; P1 should sample 3–5 real vision-doc decompositions and back-fit the empirical numbers into the routing-rule configuration.
+
+## Gaps surfaced by validation
+
+Three issues turned up during the validation run that did *not* prevent P0 from working but should inform P1.
+
+**G1. Scope-detector cold-start dominates wall-clock.** The first prompt cold-starts the Ollama model (10s); every subsequent prompt is ~3s. P1 should keep the scope-detection model warm on the orchestrator process (Ollama supports `keep_alive` per request) so the median scope-detection latency drops to ~1s.
+
+**G2. Schema's 5-character `rationale` minimum bites in stub mode.** The structured-output retry kicked in spuriously when test fixtures used `rationale: 'ok'`. The fix in this PR was to lengthen test fixtures, but the lesson generalises: P1 prompts should explicitly tell the model *why* the rationale must be ≥ 5 chars (the model otherwise treats the field as token-budget). A two-line addition to the system prompt should suffice.
+
+**G3. Sibling-disjointness judge can self-contradict.** During unit tests, the judge sometimes returned `disjoint: true` but with non-empty `overlaps[]`. The engine force-corrects this (proposal §5F bias toward "fail"), but the underlying signal — that the model isn't consistent on this dimension — suggests the judge prompt is under-specified. P1 should sample 30 real expansions, score the judge against human verdicts, and tune the prompt + threshold against that ground truth.
+
+## Verdict
+
+**P0 holds up under the diverse-prompt validation — ready to discuss P1.**
+
+The recursive decomposer's classifier-and-engine kernel is correct in shape, deterministic under stub, and accurate (10/10) under real Ollama on the PHASE2E-002 prompt distribution. The judge pair runs in parallel via `Promise.all` and writes a Reflexion-style feedback string the engine will inject on retry once PR 4 wires the pipeline.
+
+P1 should prioritise: (a) the orchestrator integration (PR 4 is open), (b) real FREG/AKG wiring, (c) the clarifying-question pipeline, (d) Ollama keep-alive, and (e) the judge-prompt calibration against human-verdict ground truth.
+
+## Sources
+
+- Architecture proposal: [`reports/po-decomposition-architecture-proposal-2026-04-29.md`](../../reports/po-decomposition-architecture-proposal-2026-04-29.md)
+- PHASE2E-002 fixtures: `apps/orchestrator/tests/e2e/pipeline/diverse-prompts.test.ts`
+- Validation suite: `packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts`
+- Operator runbook: [`caia/docs/po-recursive-decomposer.md`](./po-recursive-decomposer.md)
+- PRs in the track: #213 (scope detector + atomicity classifier), #214 (engine), #215 (judges), #216 (validation; this report).

--- a/caia/docs/po-recursive-decomposer.md
+++ b/caia/docs/po-recursive-decomposer.md
@@ -1,0 +1,172 @@
+# `@chiefaia/decomposer-recursive` — Operator Runbook
+
+**Status:** P0 shipped (PRs #213–#217 on the `PO-DECOMP-###` track).
+**Audience:** Anyone debugging the recursive decomposer, calibrating its prompts, or extending it for P1.
+**Source proposal:** [`reports/po-decomposition-architecture-proposal-2026-04-29.md`](../../reports/po-decomposition-architecture-proposal-2026-04-29.md).
+
+## What this package is
+
+The `@chiefaia/decomposer-recursive` package replaces the single-shot Claude path in `@chiefaia/decomposer` for vision-document-scale prompts. It implements the recursive-decomposition design from the proposal:
+
+- **Adaptive scope detector** classifies a prompt's natural scope (initiative | epic | module | story | task | subtask) so the engine doesn't manufacture fake five-level hierarchies for one-line asks.
+- **Recursive decomposer engine** (`PORecursiveDecomposer`) walks down from the natural scope to the atomicity floor, expanding one parent at a time via scope-specialised prompts.
+- **Atomicity classifier** (per-scope INVEST/SAFe/DDD rubric) decides leaves vs. continued recursion.
+- **MECE judge pair** (parent-coverage + sibling-disjointness) runs after every expansion in parallel via `Promise.all`. Each judge produces a 1–5 score; threshold 4.0/5 → reflexive retry on fail (max 2).
+
+## How it works (one-paragraph mental model)
+
+A prompt comes in. The scope detector decides where the recursion should *start* (e.g., "add a logout button" → start at `story`; vision document → start at `initiative`). The engine then walks down the scope hierarchy: at each parent, it queries the FREG/AKG substrate (P0 stub returns empty), runs the per-scope decomposer prompt to produce candidate children, runs both MECE judges in parallel, and on fail injects the judges' feedback back into the next decomposer attempt as a Reflexion-style system message. Each child runs through the atomicity classifier; atomic children become leaves, non-atomic ones are enqueued for one-scope-deeper expansion. Recursion bottoms out when every leaf passes its scope's atomicity criterion, or when the cost guard fires.
+
+## Installing / depending
+
+```jsonc
+// package.json (your consumer)
+{
+  "dependencies": {
+    "@chiefaia/decomposer-recursive": "workspace:*"
+  }
+}
+```
+
+The package re-exports `StoryScope`, `STORY_SCOPES`, `STORY_SCOPE_ORDER`, `isStoryScope` from `@chiefaia/ticket-template` so consumers don't need to import both.
+
+## Quick start (programmatic)
+
+```ts
+import {
+  detectScope,
+  PORecursiveDecomposer,
+  runJudgePair,
+} from '@chiefaia/decomposer-recursive';
+
+// 1) Classify the natural scope of the prompt.
+const scope = await detectScope({
+  promptText: 'Build a poker analytics SaaS — web + mobile + Stripe + Discord.',
+});
+// → { targetScope: 'initiative', confidence: 0.86, rationale: '...', model: '...', durationMs: ... }
+
+// 2) Drive the engine.
+const engine = new PORecursiveDecomposer();
+const result = await engine.decomposeRoot({
+  parent: {
+    id: 'root',
+    scope: scope.targetScope,
+    title: 'Poker analytics SaaS',
+    description: 'Web + mobile + Stripe + Discord',
+    inScope: ['web app', 'mobile app', 'billing', 'community integration'],
+    outOfScope: [],
+  },
+  targetScope: 'subtask', // walk all the way to subtask atomicity
+  maxExpansions: 200,     // cost guard
+});
+
+// result.tree is the full DecomposedTreeNode with .children recursively populated.
+// result.audits has one AuditEntry per expansion.
+// result.totalCostUsd is the cumulative spend.
+
+// 3) Optionally judge an expansion (the engine doesn't auto-call judges in P0; PR 4 wires this in).
+const judgeVerdict = await runJudgePair({
+  parent: { /* parent-shape */ },
+  children: [/* the children produced */],
+});
+// → { coverage, disjointness, bothPassed, reflexiveFeedback }
+```
+
+## Routing-rule task types
+
+The package adds 10 routing rules to `@chiefaia/local-llm-router`. All but the four "high-stakes" rules (initiative + epic + the two judges) default to local Ollama with Claude fallback.
+
+| Task type                                  | Default provider  | Local model         | Claude model              | Description                                  |
+|--------------------------------------------|-------------------|---------------------|---------------------------|----------------------------------------------|
+| `po-decomposer-scope-detection`            | local (Ollama)    | qwen2.5-coder:7b    | claude-haiku-4-5-20251001 | Adaptive natural-scope classifier.           |
+| `po-decomposer-atomicity-classification`   | local (Ollama)    | qwen2.5-coder:7b    | claude-haiku-4-5-20251001 | Per-scope INVEST/SAFe/DDD rubric.            |
+| `po-decomposer-initiative`                 | Claude (Sonnet)   | qwen3:14b           | claude-sonnet-4-6         | Initiative → epic decomposer.                |
+| `po-decomposer-epic`                       | Claude (Sonnet)   | qwen3:14b           | claude-sonnet-4-6         | Epic → module decomposer.                    |
+| `po-decomposer-module`                     | local (Ollama)    | qwen3:14b           | claude-sonnet-4-6         | Module → story decomposer (LAI-005 default). |
+| `po-decomposer-story`                      | local (Ollama)    | qwen2.5-coder:14b   | claude-sonnet-4-6         | Story → task decomposer (LAI-005 default).   |
+| `po-decomposer-task`                       | local (Ollama)    | qwen2.5-coder:14b   | claude-sonnet-4-6         | Task → subtask decomposer.                   |
+| `po-decomposer-subtask`                    | local (Ollama)    | qwen2.5-coder:7b    | claude-haiku-4-5-20251001 | Subtask → mechanical step (rare).            |
+| `po-decomposer-coverage-judge`             | Claude (Sonnet)   | qwen3:14b           | claude-sonnet-4-6         | PMBOK 100% rule judge.                       |
+| `po-decomposer-disjointness-judge`         | Claude (Sonnet)   | qwen3:14b           | claude-sonnet-4-6         | MECE-mutually-exclusive judge.               |
+
+## Adding a new scope
+
+1. Update `STORY_SCOPES` in `@chiefaia/ticket-template/src/section-contract.ts`. Add the new scope to the canonical array, the `STORY_SCOPE_ORDER` map, and the `DEFAULT_STORY_SCOPE` if appropriate.
+2. Update `ATOMICITY_RUBRICS` in `packages/decomposer-recursive/src/atomicity-classifier.ts` with a new rubric. Each rubric item must be ≥ 10 chars and verbatim-quotable (the LLM returns failed criteria as verbatim strings).
+3. Add a system prompt for the new scope to `DECOMPOSER_SYSTEM_PROMPTS` in `per-scope-prompts.ts`.
+4. Add the new scope to `DECOMPOSER_TASK_TYPES` and add the corresponding routing-rule task type to `@chiefaia/local-llm-router/routing-config.ts`. Pick the right model tier for the scope (high-stakes scopes default Claude; deep-recursion scopes default local).
+5. Update `CHILD_SCOPE_OF` to map the new scope to its child (or `null` if it's the new floor).
+
+## How to debug judge failures
+
+When `runJudgePair` returns `bothPassed: false`, the engine (PR 4) injects `result.reflexiveFeedback` as a Reflexion-style system message on the next decomposer retry. To debug an end-to-end stuck branch:
+
+1. **Read the verdict.** `coverage.passed` vs `disjointness.passed` tells you which judge fired. The verdict's `rationale` field has the model's free-form explanation.
+2. **Look at the missing/overlap lists.** `coverage.missingDeliverables[]` is verbatim-extracted from the parent's `inScope`. If the list is empty but `passed: false`, the model invoked the force-correction path — re-read the rationale, the model probably scored low without giving you a structured reason.
+3. **Inspect the audit row.** `audit.attempt > 1` means the parent was already retrying when the judges fired. After 3 attempts the engine escalates to a `decomposition-stuck` blocker (PR 4 wires the blocker emission).
+4. **Replay locally.** The validation suite's stub mode lets you reproduce a failure with deterministic fakes:
+   ```bash
+   pnpm --filter @chiefaia/decomposer-recursive test -t "judge"
+   ```
+5. **Calibrate against ground truth.** If the same failure mode keeps surfacing across prompts, the judge prompt is mis-specified. The proposal §11 R1 mitigation (ensemble + position-swap + cross-model judging) is the next P1 lever.
+
+## How to interpret cost telemetry
+
+Every `decomposeRoot` call returns `{ totalCostUsd, totalDurationMs, totalCalls, audits[] }`. The cost is the *Claude* cost only — local Ollama calls are $0.00. Per-call cost is read from each routing rule's `estimatedCostClaude` string ("$X per 1000 calls") and divided by 1000. This is *upper-bound*: it does not account for actual token counts, only the rule's quoted average.
+
+The proposal §10 cost model targets:
+
+| Prompt class                | Nodes (typical) | Claude cost (post-optimisation) | Wall-clock | Default cost-guard budget |
+|-----------------------------|-----------------|---------------------------------|------------|---------------------------|
+| Tiny (story-natural)        | 1               | $0.01–0.05                      | 3–5s       | $1                        |
+| Small (epic-natural)        | 5–20            | $1–3                            | 30–60s     | $5                        |
+| Medium (initiative-natural) | 50–200          | $5–10                           | 3–6m       | $25                       |
+| Large (vision-doc)          | 300–700         | $20–40                          | 15–25m     | $50 (Prakash-approved)    |
+
+If `truncated: true` is returned, the engine hit `maxExpansions` and stopped early — the partial tree is in `result.tree`. Increase `maxExpansions` and re-run, or partition the prompt into smaller sub-prompts per the proposal §5C.5 multi-sub-project trigger.
+
+## Running the validation suite
+
+Two modes:
+
+**Stub mode** (default; runs in CI on every PR):
+
+```bash
+pnpm --filter @chiefaia/decomposer-recursive test
+```
+
+84 vitest cases. No LLM dependencies; fully deterministic.
+
+**Live mode** (operator-only — requires Ollama running locally):
+
+```bash
+DECOMPOSER_VALIDATION_LIVE=1 pnpm --filter @chiefaia/decomposer-recursive test \
+  -- tests/diverse-prompts-validation.test.ts -t "real-LLM"
+```
+
+Drives the 10 PHASE2E-002 prompts through the real `local-llm-router` scope detector. Output is logged per prompt:
+
+```
+[validation/simple-feature] scope=story confidence=0.90 model=qwen2.5-coder:7b duration=10043ms
+```
+
+The most-recent live-mode results are captured in [`po-decomposer-validation-2026-04-30.md`](./po-decomposer-validation-2026-04-30.md).
+
+## P1 work list (deferred from P0)
+
+These are explicitly out of P0 scope per the proposal §11 phasing. Pick them up in any order; each is a single-PR effort modeled on the P0 PR shape.
+
+1. **Pipeline integration** — wire the recursive decomposer into `apps/orchestrator/src/agents/po-agent.ts` behind `PO_USE_RECURSIVE_DECOMPOSER`. Default off; flip after 30 production decompositions show parity with the legacy single-shot path. (PR 4 in the P0 series is the placeholder; ship as P1-001.)
+2. **Real FREG / AKG wiring** — replace `querySubstrateStub` with calls to `searchAndLog` (FREG) and `archSearch` (AKG). The prompt envelope already has the slots.
+3. **Clarifying-question pipeline** — implement the 3-sample disagreement detector + question generator. Branch into `awaiting-clarification` state; surface to the dashboard.
+4. **Vision-document chunker** — chunk by markdown headings + paragraph boundaries; per-chunk theme extraction via Ollama; deduplicate via embedding cosine; feed deduplicated themes into the initiative-decomposer prompt.
+5. **Ollama `keep_alive`** — keep the scope-detection + atomicity-classification models hot on the orchestrator process. Drops scope-detection latency from ~3s to ~1s.
+6. **Judge calibration** — sample 30 real expansions; score the judges against human verdicts; tune the prompts and the 4.0/5 threshold accordingly.
+7. **Decomposition audit table + dashboard** — add `decomposition_audit` table per proposal §5G; wire the dashboard `/decomposition/[promptId]` page.
+
+## Sources
+
+- Proposal: [`reports/po-decomposition-architecture-proposal-2026-04-29.md`](../../reports/po-decomposition-architecture-proposal-2026-04-29.md)
+- Validation report: [`po-decomposer-validation-2026-04-30.md`](./po-decomposer-validation-2026-04-30.md)
+- Existing PO Agent: `apps/orchestrator/src/agents/po-agent.ts`
+- Legacy decomposer (kept behind feature flag for one cycle): `packages/decomposer/src/claude-decomposer.ts`

--- a/packages/decomposer-recursive/eslint.config.cjs
+++ b/packages/decomposer-recursive/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/decomposer-recursive/package.json
+++ b/packages/decomposer-recursive/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@chiefaia/decomposer-recursive",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Recursive PO decomposition engine — scope detector + atomicity classifier + per-scope decomposers + MECE judge pair.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/local-llm-router": "workspace:*",
+    "@chiefaia/ticket-template": "workspace:*",
+    "nanoid": "^5.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT"
+}

--- a/packages/decomposer-recursive/src/atomicity-classifier.ts
+++ b/packages/decomposer-recursive/src/atomicity-classifier.ts
@@ -1,0 +1,171 @@
+/**
+ * Atomicity classifier.
+ *
+ * After a parent expansion, every candidate child runs through this
+ * classifier to decide:
+ *   - `atomic = true`  → the recursion stops at this child (it's a leaf).
+ *   - `atomic = false` → the child is enqueued for decomposition at the
+ *                        next-lower scope.
+ *
+ * Each scope has its own rubric (proposal §5C). The rubric is sent
+ * verbatim to the LLM along with the child ticket; the LLM returns
+ * `{ atomic, confidence, rationale, failedCriteria[] }`.
+ *
+ * Like the scope detector this is a classification task, so the
+ * `po-decomposer-atomicity-classification` routing rule prefers
+ * Ollama (qwen2.5-coder:7b) with Claude fallback.
+ */
+
+import { AtomicityLlmOutputSchema } from './schemas.js';
+import { callStructured } from './structured-output.js';
+import type {
+  AtomicityVerdict,
+  CancellationSignal,
+  ChildTicket,
+  StoryScope,
+} from './types.js';
+
+export const ATOMICITY_CLASSIFICATION_TASK_TYPE =
+  'po-decomposer-atomicity-classification';
+
+// ─── Per-scope rubrics (proposal §5C) ───────────────────────────────────
+
+/**
+ * Rubric per scope. The LLM is asked to evaluate the candidate child
+ * against EVERY criterion; `atomic = true` requires every criterion
+ * to pass; `failedCriteria[]` lists the criteria that failed when the
+ * verdict is `false`.
+ */
+export const ATOMICITY_RUBRICS: Record<StoryScope, readonly string[]> = {
+  initiative: [
+    'Single strategic bet (one elevator-pitch theme, one OKR/KPI cluster).',
+    'Sized to a single quarter or release-train without further strategic split.',
+    'Has 2-5 expected epics under it (else it is a multi-initiative vision).',
+  ],
+  epic: [
+    'Fits a single Program Increment per SAFe (8-12 weeks).',
+    'Single dominant value theme expressible in <= 25 words.',
+    'Crosses at most 2 modules (else it is an initiative-shaped concern).',
+    'Has 2-10 expected stories under it.',
+  ],
+  module: [
+    'Coherent bounded context (DDD) with single primary tech sub-domain.',
+    'Owns its data — at least one schema/table/state-store is conceptually under this module.',
+    'Has 2-8 stories under it (collapse to story if fewer; split if more).',
+    'Has clear API/contract boundary describable in one paragraph.',
+  ],
+  story: [
+    'INVEST-compliant: Independent (or with explicit deps), Negotiable, Valuable, Estimable, Small, Testable.',
+    'Sized to a single PR / <= 1 sprint of work.',
+    'Touches a single user-visible value increment.',
+    'Has 3-6 concrete acceptance criteria, each testable, each >= 8 words.',
+    'Atomic-self-check: NO description containing "and"/"also"/"while" coordinating two distinct user concerns.',
+  ],
+  task: [
+    'Single concern (no "and"/"also" coordinating distinct concerns in the description).',
+    'Single primary tech sub-domain.',
+    'Sized to <= 1 day of work for a competent engineer.',
+    'Touches <= 3 files or a single tightly-coupled cluster.',
+    'Concrete artifact target: function/class/route/schema name explicitly mentioned or inferable.',
+  ],
+  subtask: [
+    'Single mechanical step (single function, single test, single comment block, single config edit).',
+    'Sized to <= 2 hours of work.',
+    'Names the precise artifact (function name, test name, file region).',
+    'No scope question — implementation is mechanical given the parent task.',
+  ],
+};
+
+// ─── System prompt ──────────────────────────────────────────────────────
+
+function buildAtomicitySystemPrompt(scope: StoryScope): string {
+  const rubric = ATOMICITY_RUBRICS[scope];
+  const rubricBlock = rubric.map((c, i) => `  ${String(i + 1)}. ${c}`).join('\n');
+  return `You are a senior product manager applying the atomicity rubric for a "${scope}" ticket.
+
+A ${scope} is atomic if and only if EVERY rubric item below passes for the candidate ticket.
+
+Rubric for ${scope}:
+${rubricBlock}
+
+Output schema:
+{
+  "atomic": true | false,
+  "confidence": 0.0..1.0,
+  "rationale": "one paragraph (<= 80 words) summarising the verdict",
+  "failedCriteria": [ "verbatim text of each failing rubric item" ]
+}
+
+Hard rules:
+- "atomic": true requires "failedCriteria" to be empty.
+- "atomic": false requires "failedCriteria" to be non-empty.
+- "failedCriteria" entries must be verbatim copies of rubric items above.
+- If you are unsure, prefer "atomic": false with a low confidence — the
+  recursion will refine. Returning a wrong "atomic": true blocks
+  downstream agents from catching a mis-sized ticket.`;
+}
+
+function buildAtomicityUserPrompt(child: ChildTicket): string {
+  const acLine =
+    child.acceptanceCriteria && child.acceptanceCriteria.length > 0
+      ? `Acceptance criteria:\n${child.acceptanceCriteria.map((a) => `  - ${a}`).join('\n')}`
+      : 'Acceptance criteria: (none)';
+
+  return (
+    `Evaluate this candidate ticket against the rubric.\n\n` +
+    `Title: ${child.title}\n` +
+    `Scope: ${child.scope}\n` +
+    `Description: ${child.description}\n` +
+    `In scope: ${child.inScope.join('; ') || '(empty)'}\n` +
+    `Out of scope: ${child.outOfScope.join('; ') || '(empty)'}\n` +
+    `${acLine}\n` +
+    `Lifecycle: ${child.lifecycle}\n` +
+    `Sibling dependencies: ${child.dependencies.length === 0 ? '(none)' : child.dependencies.join(', ')}`
+  );
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────
+
+export interface ClassifyAtomicityOptions {
+  child: ChildTicket;
+  signal?: CancellationSignal;
+}
+
+/**
+ * Classify whether a candidate child is atomic at its declared scope.
+ */
+export async function classifyAtomicity(
+  options: ClassifyAtomicityOptions,
+): Promise<AtomicityVerdict> {
+  const { child, signal } = options;
+
+  const result = await callStructured(AtomicityLlmOutputSchema, {
+    taskType: ATOMICITY_CLASSIFICATION_TASK_TYPE,
+    systemPrompt: buildAtomicitySystemPrompt(child.scope),
+    userPrompt: buildAtomicityUserPrompt(child),
+    maxRetries: 2,
+    ...(signal ? { signal } : {}),
+  });
+
+  // Enforce the contract beyond Zod: if the model returned atomic=true
+  // with non-empty failedCriteria (or vice versa), force-correct by
+  // setting atomic to match the failedCriteria array. Conservative bias
+  // toward "not atomic" so the recursion errs on more decomposition,
+  // never less.
+  let atomic = result.data.atomic;
+  const failedCriteria = result.data.failedCriteria;
+  if (atomic && failedCriteria.length > 0) {
+    atomic = false;
+  } else if (!atomic && failedCriteria.length === 0) {
+    atomic = true;
+  }
+
+  return {
+    atomic,
+    confidence: result.data.confidence,
+    rationale: result.data.rationale,
+    failedCriteria,
+    model: result.model,
+    durationMs: result.durationMs,
+  };
+}

--- a/packages/decomposer-recursive/src/decomposer.ts
+++ b/packages/decomposer-recursive/src/decomposer.ts
@@ -1,0 +1,437 @@
+/**
+ * PORecursiveDecomposer — the engine.
+ *
+ * Stateless across calls (every input is explicit; no shared per-class
+ * state). Cancellable via an AbortSignal that is checked between
+ * recursion steps so a cancel bounds wall-clock by ~one outstanding
+ * LLM call. Cost-tracked: every parent expansion emits an AuditEntry
+ * with model, tokens, cost; the engine sums these and exposes a
+ * cumulative total via `decomposeRoot`'s return value.
+ *
+ * P0 scope (this slice):
+ *   - one parent → children expansion via `decomposeOne`
+ *   - bounded retry on schema parse failure (via callStructured)
+ *   - per-child atomicity classification (via classifyAtomicity)
+ *   - recursion via `decomposeRoot` that walks down to atomicity
+ *
+ * P0 explicitly does NOT:
+ *   - run MECE judges (that's PR 3)
+ *   - generate clarifying questions (that's P1)
+ *   - chunk vision documents (P1)
+ *   - call the real FREG/AKG (P1 — the stub returns empty)
+ */
+
+import { createHash } from 'node:crypto';
+
+import { classifyAtomicity } from './atomicity-classifier.js';
+import {
+  formatAkgHitsForPrompt,
+  formatFregHitsForPrompt,
+  querySubstrateStub,
+} from './freg-akg-stub.js';
+import {
+  CHILD_SCOPE_OF,
+  DECOMPOSER_SYSTEM_PROMPTS,
+  DECOMPOSER_TASK_TYPES,
+} from './per-scope-prompts.js';
+import { ChildTicketArraySchema } from './schemas.js';
+import { callStructured } from './structured-output.js';
+import type {
+  AuditEntry,
+  CancellationSignal,
+  ChildTicket,
+  Decomposition,
+  StoryScope,
+} from './types.js';
+import { STORY_SCOPE_ORDER } from './types.js';
+
+/**
+ * The parent-node shape the engine expects. Either a synthetic root
+ * (built from the user's prompt) or a previously-emitted child being
+ * recursively expanded.
+ */
+export interface ParentNode {
+  id: string;
+  scope: StoryScope;
+  title: string;
+  description: string;
+  inScope: string[];
+  outOfScope: string[];
+  /** Optional acceptance criteria (story+ scope only). */
+  acceptanceCriteria?: string[];
+  /** Optional project slug for FREG queries (P1 will use it). */
+  projectSlug?: string;
+  /** Optional tech sub-domains for AKG queries (P1 will use it). */
+  techSubDomains?: string[];
+}
+
+export interface DecomposeOneOptions {
+  parent: ParentNode;
+  /** The scope of the children to produce (one level below parent). */
+  childScope: StoryScope;
+  /** Optional cancellation signal (checked before LLM call). */
+  signal?: CancellationSignal;
+}
+
+export interface DecomposeRootOptions {
+  parent: ParentNode;
+  /**
+   * Target scope — recursion stops once children at this scope are
+   * produced. Used by the orchestrator (PR 4) when the scope detector
+   * picks a deep starting scope (e.g., 'story') so we don't build
+   * artificial above-story ancestry.
+   */
+  targetScope: StoryScope;
+  /**
+   * Maximum recursion depth (levels). Defaults to 5 (initiative →
+   * subtask). Caller should set this to the worst-case depth.
+   */
+  maxDepth?: number;
+  /**
+   * Maximum total parent expansions across the whole tree. A cost
+   * guard against runaway prompts. Default 200; vision-doc decomps
+   * may need more.
+   */
+  maxExpansions?: number;
+  /** Optional cancellation signal. */
+  signal?: CancellationSignal;
+}
+
+export interface DecomposedTreeNode {
+  ticket: ChildTicket;
+  children: DecomposedTreeNode[];
+  /** Whether this node was deemed atomic by the classifier. */
+  atomic: boolean;
+}
+
+export interface DecomposeRootResult {
+  /** Sub-tree rooted at the original parent. */
+  tree: DecomposedTreeNode;
+  /** Audit entries in expansion order, every level included. */
+  audits: AuditEntry[];
+  /** Cumulative cost across the whole tree (USD). */
+  totalCostUsd: number;
+  /** Cumulative wall-clock across the whole tree (ms). */
+  totalDurationMs: number;
+  /** Total LLM calls made. */
+  totalCalls: number;
+  /** True if the engine hit max-expansions (partial tree). */
+  truncated: boolean;
+}
+
+export class PORecursiveDecomposerCancelled extends Error {
+  constructor() {
+    super('[decomposer-recursive] decomposition cancelled');
+    this.name = 'PORecursiveDecomposerCancelled';
+  }
+}
+
+export class PORecursiveDecomposer {
+  /**
+   * Expand ONE parent into its children at `childScope`. Stateless;
+   * the caller drives the recursion via `decomposeRoot` or directly.
+   *
+   * Returns a `Decomposition` with:
+   *   - childTickets[] — typed children parsed against the schema
+   *   - audit — single AuditEntry for this expansion
+   *   - judgeScores: { coverage: null, disjointness: null } — judges
+   *     are not in P0; PR 3 fills them.
+   */
+  async decomposeOne(opts: DecomposeOneOptions): Promise<Decomposition> {
+    const { parent, childScope, signal } = opts;
+
+    if (signal?.aborted) throw new PORecursiveDecomposerCancelled();
+
+    const taskType = DECOMPOSER_TASK_TYPES[parent.scope];
+    const systemPrompt = DECOMPOSER_SYSTEM_PROMPTS[parent.scope];
+
+    const substrate = await querySubstrateStub({
+      query: `${parent.title}\n\n${parent.description}`,
+      ...(parent.projectSlug ? { projectSlug: parent.projectSlug } : {}),
+      ...(parent.techSubDomains ? { techSubDomains: parent.techSubDomains } : {}),
+    });
+
+    const userPrompt = buildUserPrompt(parent, childScope, substrate);
+    const promptHash = sha256(systemPrompt + '\n\n' + userPrompt);
+
+    if (signal?.aborted) throw new PORecursiveDecomposerCancelled();
+
+    const result = await callStructured(ChildTicketArraySchema, {
+      taskType,
+      systemPrompt,
+      userPrompt,
+      maxRetries: 2,
+      ...(signal ? { signal } : {}),
+    });
+
+    // Parse into ChildTicket[]. Set every child's scope to childScope
+    // (the LLM is asked to label, but we override to be safe).
+    const childTickets: ChildTicket[] = result.data.map((c) => {
+      const cleanedExistingArtifacts = c.existingArtifacts.map((a) => {
+        const out: { source: 'feature' | 'arch_artifact'; id: string; name: string; score: number; hint?: string } = {
+          source: a.source,
+          id: a.id,
+          name: a.name,
+          score: a.score,
+        };
+        if (a.hint !== undefined) out.hint = a.hint;
+        return out;
+      });
+      const base: ChildTicket = {
+        id: c.id,
+        scope: childScope,
+        title: c.title,
+        description: c.description,
+        inScope: c.inScope,
+        outOfScope: c.outOfScope,
+        dependencies: c.dependencies,
+        existingArtifacts: cleanedExistingArtifacts,
+        lifecycle: c.lifecycle,
+        estimatedAtomic: false,
+      };
+      if (c.acceptanceCriteria !== undefined) {
+        base.acceptanceCriteria = c.acceptanceCriteria;
+      }
+      return base;
+    });
+
+    const audit: AuditEntry = {
+      parentNodeId: parent.id,
+      parentScope: parent.scope,
+      childScope,
+      attempt: result.attempts,
+      promptTextHash: promptHash,
+      model: result.model,
+      tokensIn: result.usage?.promptTokens ?? 0,
+      tokensOut: result.usage?.completionTokens ?? 0,
+      costUsd: result.costUsd,
+      durationMs: result.durationMs,
+      alternativesConsidered: 1, // P0 single-sample
+      coverageScore: null,
+      disjointnessScore: null,
+      ambiguityDetected: false,
+      questionsEmittedCount: 0,
+      decisionRationale: `single-sample expansion (P0); ${String(childTickets.length)} children produced`,
+      childrenCount: childTickets.length,
+      outcome: 'committed',
+    };
+
+    return {
+      childTickets,
+      clarifyingQuestions: [],
+      dependencies: [],
+      confidence: null,
+      judgeScores: { coverage: null, disjointness: null },
+      audit,
+    };
+  }
+
+  /**
+   * Recursively decompose a parent down to the atomicity floor (or
+   * to `targetScope`, whichever is hit first).
+   *
+   * Walks depth-first. Runs the atomicity classifier on each child
+   * after generation; atomic children become leaves, non-atomic ones
+   * recurse one scope deeper.
+   */
+  async decomposeRoot(
+    opts: DecomposeRootOptions,
+  ): Promise<DecomposeRootResult> {
+    const { parent, targetScope, signal } = opts;
+    const maxDepth = opts.maxDepth ?? 5;
+    const maxExpansions = opts.maxExpansions ?? 200;
+
+    const audits: AuditEntry[] = [];
+    let totalCostUsd = 0;
+    let totalDurationMs = 0;
+    let totalCalls = 0;
+    let expansions = 0;
+    let truncated = false;
+
+    // The root is presented as itself a "child" in the tree (so the
+    // tree shape is uniform for the caller). Build a synthetic
+    // ChildTicket from the parent.
+    const rootTicket: ChildTicket = {
+      id: parent.id,
+      scope: parent.scope,
+      title: parent.title,
+      description: parent.description,
+      ...(parent.acceptanceCriteria && parent.acceptanceCriteria.length > 0
+        ? { acceptanceCriteria: parent.acceptanceCriteria }
+        : {}),
+      inScope: parent.inScope,
+      outOfScope: parent.outOfScope,
+      dependencies: [],
+      estimatedAtomic: false,
+      existingArtifacts: [],
+      lifecycle: 'new',
+    };
+    const rootNode: DecomposedTreeNode = {
+      ticket: rootTicket,
+      children: [],
+      atomic: false,
+    };
+
+    // BFS-frontier of (parentNode, depthFromRoot) pairs to expand.
+    type FrontierItem = {
+      node: DecomposedTreeNode;
+      parent: ParentNode;
+      depth: number;
+    };
+    const frontier: FrontierItem[] = [
+      { node: rootNode, parent, depth: 0 },
+    ];
+
+    while (frontier.length > 0) {
+      if (signal?.aborted) throw new PORecursiveDecomposerCancelled();
+      const item = frontier.shift();
+      if (!item) break;
+      const { node, parent: p, depth } = item;
+
+      // Atomicity floor check by scope index.
+      const childScope = CHILD_SCOPE_OF[p.scope];
+      if (childScope === null) {
+        // Already at subtask — never decompose further.
+        node.atomic = true;
+        continue;
+      }
+      // Hard depth + scope guard.
+      if (depth >= maxDepth) {
+        node.atomic = true;
+        continue;
+      }
+      // Target-scope guard: don't decompose past the requested target scope.
+      const childScopeIdx = STORY_SCOPE_ORDER[childScope];
+      const targetIdx = STORY_SCOPE_ORDER[targetScope];
+      if (childScopeIdx > targetIdx) {
+        // We've already produced children AT or BELOW the target scope.
+        // The current parent is at-or-above target — but we only get
+        // here if its scope index is < target's. Decompose anyway —
+        // we want to land EXACTLY at target.
+      }
+      if (STORY_SCOPE_ORDER[p.scope] >= targetIdx) {
+        // Parent is already at-or-below target scope; it is the leaf.
+        node.atomic = true;
+        continue;
+      }
+
+      // Cost/expansion budget guard.
+      if (expansions >= maxExpansions) {
+        truncated = true;
+        node.atomic = true;
+        continue;
+      }
+      expansions++;
+
+      // Run the expansion.
+      const decomp = await this.decomposeOne({
+        parent: p,
+        childScope,
+        ...(signal ? { signal } : {}),
+      });
+      audits.push(decomp.audit);
+      totalCostUsd += decomp.audit.costUsd;
+      totalDurationMs += decomp.audit.durationMs;
+      totalCalls += decomp.audit.attempt;
+
+      // For each child, run atomicity classification then enqueue
+      // for further expansion if not atomic and below target scope.
+      for (const child of decomp.childTickets) {
+        const verdict = await classifyAtomicity({
+          child,
+          ...(signal ? { signal } : {}),
+        });
+        // (atomicity classifier call counts toward totalCalls but not audits)
+        totalCalls += 1;
+        // Pass-through telemetry: classifier doesn't currently land in audits[].
+        const childWithVerdict: ChildTicket = {
+          ...child,
+          estimatedAtomic: verdict.atomic,
+        };
+        const childNode: DecomposedTreeNode = {
+          ticket: childWithVerdict,
+          children: [],
+          atomic: verdict.atomic,
+        };
+        node.children.push(childNode);
+
+        const childIdx = STORY_SCOPE_ORDER[childWithVerdict.scope];
+        const targetIdxInner = STORY_SCOPE_ORDER[targetScope];
+        if (!verdict.atomic && childIdx < targetIdxInner) {
+          frontier.push({
+            node: childNode,
+            parent: childTicketToParent(childWithVerdict, p),
+            depth: depth + 1,
+          });
+        }
+      }
+    }
+
+    return {
+      tree: rootNode,
+      audits,
+      totalCostUsd,
+      totalDurationMs,
+      totalCalls,
+      truncated,
+    };
+  }
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+function buildUserPrompt(
+  parent: ParentNode,
+  childScope: StoryScope,
+  substrate: { fregHits: never[] | unknown[]; akgHits: never[] | unknown[] },
+): string {
+  const fregBlock = formatFregHitsForPrompt(
+    substrate.fregHits as Parameters<typeof formatFregHitsForPrompt>[0],
+  );
+  const akgBlock = formatAkgHitsForPrompt(
+    substrate.akgHits as Parameters<typeof formatAkgHitsForPrompt>[0],
+  );
+
+  const acBlock =
+    parent.acceptanceCriteria && parent.acceptanceCriteria.length > 0
+      ? `\nAcceptance criteria:\n${parent.acceptanceCriteria.map((a) => `  - ${a}`).join('\n')}`
+      : '';
+
+  return [
+    `Decompose the parent ticket below into ${childScope} children.`,
+    '',
+    '## PARENT TICKET',
+    `Title: ${parent.title}`,
+    `Scope: ${parent.scope}`,
+    `Description: ${parent.description}`,
+    `In scope: ${parent.inScope.join('; ') || '(empty)'}`,
+    `Out of scope: ${parent.outOfScope.join('; ') || '(empty)'}${acBlock}`,
+    '',
+    fregBlock,
+    akgBlock,
+  ]
+    .filter((s) => s.length > 0)
+    .join('\n');
+}
+
+function childTicketToParent(child: ChildTicket, parentOfChild: ParentNode): ParentNode {
+  return {
+    id: child.id,
+    scope: child.scope,
+    title: child.title,
+    description: child.description,
+    inScope: child.inScope,
+    outOfScope: child.outOfScope,
+    ...(child.acceptanceCriteria && child.acceptanceCriteria.length > 0
+      ? { acceptanceCriteria: child.acceptanceCriteria }
+      : {}),
+    ...(parentOfChild.projectSlug ? { projectSlug: parentOfChild.projectSlug } : {}),
+    ...(parentOfChild.techSubDomains
+      ? { techSubDomains: parentOfChild.techSubDomains }
+      : {}),
+  };
+}
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}

--- a/packages/decomposer-recursive/src/feature-flag.ts
+++ b/packages/decomposer-recursive/src/feature-flag.ts
@@ -1,0 +1,76 @@
+/**
+ * Feature flag for the recursive decomposer (PO-DECOMP-004).
+ *
+ * P0 ships the engine library + per-scope prompts + judge pair, but
+ * does NOT swap the orchestrator's PO Agent over to it yet. The
+ * legacy `@chiefaia/decomposer.decomposeWithClaude` single-shot path
+ * remains the production code path until the validation suite (PR 5)
+ * has produced a parity report against real prompts.
+ *
+ * The flag's default is OFF in P0. P1's pipeline-integration PR
+ * flips the default to ON after at least 30 production decompositions
+ * show parity (or better) with the legacy path. This staged rollout
+ * matches the proposal §5L recovery posture.
+ *
+ * Read order:
+ *   1. Explicit `value` argument to `useRecursiveDecomposer({ value })`.
+ *   2. Environment variable `PO_USE_RECURSIVE_DECOMPOSER` ('1' / 'true' on; otherwise off).
+ *   3. Default off in P0.
+ */
+
+/**
+ * Canonical pipeline-stage name for the new stage that the recursive
+ * decomposer will own once the orchestrator routes through it.
+ *
+ * P0 declares the name (so consumers can reference a stable constant)
+ * but does NOT register the stage in `PIPELINE_STAGE_ORDER` —
+ * registering would require updating every existing pipeline-stage
+ * test in lockstep. P1 adds the migration and updates the order.
+ */
+export const STAGE_PO_DECOMPOSING = 'po_decomposing';
+
+/**
+ * Environment-variable name whose value gates the new decomposer.
+ */
+export const PO_USE_RECURSIVE_DECOMPOSER_ENV = 'PO_USE_RECURSIVE_DECOMPOSER';
+
+export interface UseRecursiveDecomposerOptions {
+  /**
+   * If supplied, overrides the env-var lookup. Use this to inject
+   * the flag in tests or per-prompt overrides without polluting
+   * the process environment.
+   */
+  value?: boolean;
+  /**
+   * Optional environment object (defaults to `process.env`). Tests
+   * pass a stub.
+   */
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+}
+
+/**
+ * Decide whether to route a given decomposition through the new
+ * recursive engine or the legacy single-shot path.
+ *
+ * In P0 this returns `false` unless explicitly opted in. Consumers
+ * should call this from the PO Agent immediately before invoking
+ * `decompose()` and branch:
+ *
+ * ```ts
+ * if (useRecursiveDecomposer()) {
+ *   // new engine path (P1 wiring)
+ * } else {
+ *   // existing decomposeWithClaude path
+ * }
+ * ```
+ */
+export function useRecursiveDecomposer(
+  options: UseRecursiveDecomposerOptions = {},
+): boolean {
+  if (typeof options.value === 'boolean') return options.value;
+  const env = options.env ?? process.env;
+  const raw = env[PO_USE_RECURSIVE_DECOMPOSER_ENV];
+  if (typeof raw !== 'string') return false;
+  const normalised = raw.trim().toLowerCase();
+  return normalised === '1' || normalised === 'true' || normalised === 'yes' || normalised === 'on';
+}

--- a/packages/decomposer-recursive/src/freg-akg-stub.ts
+++ b/packages/decomposer-recursive/src/freg-akg-stub.ts
@@ -1,0 +1,61 @@
+/**
+ * FREG + AKG substrate query stubs (P0).
+ *
+ * In P1 these will be replaced by real calls to:
+ *   - `searchAndLog` from @chiefaia/feature-registry (for FREG hits)
+ *   - `archSearch` from @chiefaia/architecture-registry (for AKG hits)
+ *
+ * For P0 they always return an empty list — the decomposer engine
+ * still wires the substrate-context block into the prompt envelope so
+ * P1 only has to swap the stub for the real call. The lifecycle
+ * default is therefore always `'new'` in P0.
+ */
+
+import type { ExistingArtifactRef } from './types.js';
+
+export interface FregAkgQueryInput {
+  /** Title + description of the parent ticket. */
+  query: string;
+  /** Project slug, used to scope FREG. */
+  projectSlug?: string;
+  /** Tech sub-domains the parent implies (used to scope AKG). */
+  techSubDomains?: string[];
+}
+
+export interface FregAkgQueryResult {
+  fregHits: ExistingArtifactRef[];
+  akgHits: ExistingArtifactRef[];
+}
+
+/**
+ * P0 stub — returns empty FREG + AKG hits for every query.
+ * Wired so PR 5's validation suite doesn't break on real prompts.
+ */
+export async function querySubstrateStub(
+  _input: FregAkgQueryInput,
+): Promise<FregAkgQueryResult> {
+  // P0: stub. P1 wires real registries.
+  // TODO(po-decomp-p1): replace with real FREG + AKG queries.
+  return Promise.resolve({ fregHits: [], akgHits: [] });
+}
+
+/**
+ * Format substrate hits into a markdown block to inject into the
+ * decomposer prompt envelope. Empty strings are returned for empty
+ * hit-lists (the prompt envelope omits empty sections).
+ */
+export function formatFregHitsForPrompt(hits: ExistingArtifactRef[]): string {
+  if (hits.length === 0) return '';
+  const lines = hits.map(
+    (h) => ` - ${h.id} (score ${h.score.toFixed(2)}): ${h.name}${h.hint ? ' — ' + h.hint : ''}`,
+  );
+  return `## EXISTING FEATURES (FREG)\n${lines.join('\n')}\n`;
+}
+
+export function formatAkgHitsForPrompt(hits: ExistingArtifactRef[]): string {
+  if (hits.length === 0) return '';
+  const lines = hits.map(
+    (h) => ` - ${h.id} (${h.hint ?? 'artifact'}): ${h.name}`,
+  );
+  return `## EXISTING ARCHITECTURE (AKG)\n${lines.join('\n')}\n`;
+}

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -110,3 +110,20 @@ export type {
   FregAkgQueryInput,
   FregAkgQueryResult,
 } from './freg-akg-stub.js';
+
+// ─── Judges (PR 3) ──────────────────────────────────────────────────────
+
+export {
+  COVERAGE_JUDGE_TASK_TYPE,
+  DISJOINTNESS_JUDGE_TASK_TYPE,
+  JUDGE_PASS_THRESHOLD,
+  normaliseJudgeScore,
+  runJudgePair,
+} from './judges.js';
+
+export type {
+  CoverageVerdict,
+  DisjointnessVerdict,
+  JudgeInput,
+  JudgePairResult,
+} from './judges.js';

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -78,3 +78,35 @@ export {
 } from './atomicity-classifier.js';
 
 export type { ClassifyAtomicityOptions } from './atomicity-classifier.js';
+
+// ─── Engine (PR 2) ──────────────────────────────────────────────────────
+
+export {
+  PORecursiveDecomposer,
+  PORecursiveDecomposerCancelled,
+} from './decomposer.js';
+
+export type {
+  DecomposeOneOptions,
+  DecomposeRootOptions,
+  DecomposeRootResult,
+  DecomposedTreeNode,
+  ParentNode,
+} from './decomposer.js';
+
+export {
+  CHILD_SCOPE_OF,
+  DECOMPOSER_SYSTEM_PROMPTS,
+  DECOMPOSER_TASK_TYPES,
+} from './per-scope-prompts.js';
+
+export {
+  formatAkgHitsForPrompt,
+  formatFregHitsForPrompt,
+  querySubstrateStub,
+} from './freg-akg-stub.js';
+
+export type {
+  FregAkgQueryInput,
+  FregAkgQueryResult,
+} from './freg-akg-stub.js';

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -1,0 +1,80 @@
+/**
+ * Public API for @chiefaia/decomposer-recursive.
+ *
+ * P0 (this slice): scope detector + atomicity classifier + Zod schemas
+ * + structured-output helper. The orchestrator engine, per-scope
+ * decomposers, and judge pair land in PRs 2 + 3 respectively.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export type {
+  AuditEntry,
+  AtomicityVerdict,
+  CancellationSignal,
+  ChildTicket,
+  ClarifyingQuestion,
+  Decomposition,
+  DependencyEdge,
+  ExistingArtifactRef,
+  ScopeDetection,
+  StoryScope,
+} from './types.js';
+
+export { STORY_SCOPES, STORY_SCOPE_ORDER, isStoryScope } from './types.js';
+
+// ─── Schemas ────────────────────────────────────────────────────────────
+
+export {
+  AuditEntrySchema,
+  AtomicityLlmOutputSchema,
+  ChildTicketArraySchema,
+  ChildTicketSchema,
+  ClarifyingQuestionSchema,
+  DecompositionSchema,
+  DependencyEdgeSchema,
+  ExistingArtifactRefSchema,
+  ScopeDetectionLlmOutputSchema,
+  StoryScopeSchema,
+} from './schemas.js';
+
+export type {
+  ChildTicketSchemaT,
+  ChildTicketArraySchemaT,
+  DecompositionSchemaT,
+  ScopeDetectionLlmOutputT,
+  AtomicityLlmOutputT,
+} from './schemas.js';
+
+// ─── Structured-output helper ───────────────────────────────────────────
+
+export {
+  callStructured,
+  extractJson,
+  StructuredOutputCancelled,
+  StructuredOutputParseError,
+} from './structured-output.js';
+
+export type {
+  StructuredOutputOptions,
+  StructuredOutputResult,
+} from './structured-output.js';
+
+// ─── Scope detector ─────────────────────────────────────────────────────
+
+export {
+  SCOPE_DETECTION_TASK_TYPE,
+  detectScope,
+} from './scope-detector.js';
+
+export type { DetectScopeOptions } from './scope-detector.js';
+
+// ─── Atomicity classifier ──────────────────────────────────────────────
+
+export {
+  ATOMICITY_CLASSIFICATION_TASK_TYPE,
+  ATOMICITY_RUBRICS,
+  classifyAtomicity,
+} from './atomicity-classifier.js';
+
+export type { ClassifyAtomicityOptions } from './atomicity-classifier.js';

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -127,3 +127,15 @@ export type {
   JudgeInput,
   JudgePairResult,
 } from './judges.js';
+
+// ─── Feature flag (PR 4) ────────────────────────────────────────────────
+
+export {
+  PO_USE_RECURSIVE_DECOMPOSER_ENV,
+  STAGE_PO_DECOMPOSING,
+  useRecursiveDecomposer,
+} from './feature-flag.js';
+
+export type {
+  UseRecursiveDecomposerOptions,
+} from './feature-flag.js';

--- a/packages/decomposer-recursive/src/judges.ts
+++ b/packages/decomposer-recursive/src/judges.ts
@@ -1,0 +1,287 @@
+/**
+ * MECE judge pair (proposal §5F).
+ *
+ * After every parent expansion, two judges run in parallel:
+ *
+ *   1. Parent-coverage judge — does the union of children fully cover
+ *      the parent's inScope? (PMBOK 100% rule.)
+ *   2. Sibling-disjointness judge — do any two children overlap in
+ *      deliverable scope? (MECE-mutually-exclusive.)
+ *
+ * Both judges return a 1-5 score. The pass threshold is 4.0; on
+ * either fail the engine kicks off reflexive retry: the decomposer
+ * is re-invoked with the judge's rejection rationale appended to the
+ * user prompt as Reflexion-style feedback. Up to 2 retries.
+ *
+ * Both judges route through `po-decomposer-coverage-judge` /
+ * `po-decomposer-disjointness-judge` task types (Sonnet) — judging is
+ * high-leverage low-cost relative to regenerating downstream artefacts.
+ */
+
+import { z } from 'zod';
+import { callStructured } from './structured-output.js';
+import type { CancellationSignal, ChildTicket, StoryScope } from './types.js';
+
+export const COVERAGE_JUDGE_TASK_TYPE = 'po-decomposer-coverage-judge';
+export const DISJOINTNESS_JUDGE_TASK_TYPE = 'po-decomposer-disjointness-judge';
+
+/**
+ * Pass threshold for both judges. 4.0 / 5.0 means the model must
+ * agree fairly strongly that the children cover (resp. are disjoint).
+ * Below this, the engine reflexively retries the parent expansion.
+ */
+export const JUDGE_PASS_THRESHOLD = 4.0;
+
+// ─── Schemas ────────────────────────────────────────────────────────────
+
+const CoverageJudgeOutputSchema = z.object({
+  /** 1..5 confidence the children fully cover the parent. */
+  score: z.number().min(1).max(5),
+  /** True iff score >= JUDGE_PASS_THRESHOLD. */
+  covered: z.boolean(),
+  /** Verbatim deliverables the judge thinks are missing. */
+  missingDeliverables: z.array(z.string()),
+  /** Free-form one-paragraph rationale (used as reflexive feedback). */
+  rationale: z.string().min(5),
+});
+
+const DisjointnessJudgeOutputSchema = z.object({
+  score: z.number().min(1).max(5),
+  disjoint: z.boolean(),
+  /** Pairs of overlapping siblings (verbatim ids + a one-line description). */
+  overlaps: z.array(
+    z.object({
+      childA: z.string().min(1),
+      childB: z.string().min(1),
+      overlapDescription: z.string().min(3),
+    }),
+  ),
+  rationale: z.string().min(5),
+});
+
+// ─── Inputs / outputs ───────────────────────────────────────────────────
+
+export interface JudgeInput {
+  /** Parent ticket — judges see this to scope coverage. */
+  parent: {
+    title: string;
+    description: string;
+    scope: StoryScope;
+    inScope: string[];
+    outOfScope: string[];
+  };
+  /** Children produced by the decomposer. */
+  children: ChildTicket[];
+  /** Optional cancellation signal. */
+  signal?: CancellationSignal;
+}
+
+export interface CoverageVerdict {
+  score: number; // 1..5
+  passed: boolean; // score >= threshold
+  missingDeliverables: string[];
+  rationale: string;
+  model: string;
+  durationMs: number;
+  costUsd: number;
+}
+
+export interface DisjointnessVerdict {
+  score: number; // 1..5
+  passed: boolean;
+  overlaps: Array<{ childA: string; childB: string; overlapDescription: string }>;
+  rationale: string;
+  model: string;
+  durationMs: number;
+  costUsd: number;
+}
+
+export interface JudgePairResult {
+  coverage: CoverageVerdict;
+  disjointness: DisjointnessVerdict;
+  /** True iff BOTH judges passed. */
+  bothPassed: boolean;
+  /**
+   * Combined feedback the decomposer can inject as a system message
+   * on the next reflexive retry. Empty string when both judges pass.
+   */
+  reflexiveFeedback: string;
+}
+
+// ─── System prompts ─────────────────────────────────────────────────────
+
+const COVERAGE_JUDGE_SYSTEM_PROMPT = `You are evaluating a Work Breakdown Structure (WBS) for the PMBOK 100% rule.
+
+The 100% rule states: the children must cover 100% of the work implied by the parent's inScope. Anything intentionally omitted must be in the parent's outOfScope.
+
+Score 1..5 (5 = perfect coverage; 4 = minor gaps acceptable; 3 = noticeable gaps; 2 = significant gaps; 1 = major coverage failure). Set "covered": true when score >= 4.0.
+
+List every concrete deliverable from the parent's inScope that is NOT addressed by any child as "missingDeliverables". If "covered" is true and "missingDeliverables" non-empty, you have an internal contradiction — re-evaluate.
+
+Output schema:
+{
+  "score": 1..5,
+  "covered": true | false,
+  "missingDeliverables": [ "verbatim deliverable text" ],
+  "rationale": "one paragraph"
+}`;
+
+const DISJOINTNESS_JUDGE_SYSTEM_PROMPT = `You are evaluating a Work Breakdown Structure (WBS) for the MECE-mutually-exclusive principle.
+
+Children must NOT overlap in deliverable scope. If two children describe the same feature/component/data-store, they overlap — list them in "overlaps".
+
+Score 1..5 (5 = no overlaps; 4 = minor overlap on edge cases; 3 = noticeable overlap; 2 = significant overlap; 1 = severe overlap throughout). Set "disjoint": true when score >= 4.0.
+
+For each overlapping pair, include both child IDs (verbatim from the children list) and a one-line description of the overlap.
+
+Output schema:
+{
+  "score": 1..5,
+  "disjoint": true | false,
+  "overlaps": [
+    { "childA": "id1", "childB": "id2", "overlapDescription": "..." }
+  ],
+  "rationale": "one paragraph"
+}`;
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function buildUserPrompt(input: JudgeInput): string {
+  const childrenBlock = input.children
+    .map(
+      (c, i) =>
+        `### Child ${String(i + 1)} (id=${c.id}, scope=${c.scope})\n` +
+        `Title: ${c.title}\n` +
+        `Description: ${c.description}\n` +
+        `In scope: ${c.inScope.join('; ') || '(empty)'}\n` +
+        `Out of scope: ${c.outOfScope.join('; ') || '(empty)'}`,
+    )
+    .join('\n\n');
+
+  return [
+    `## PARENT`,
+    `Title: ${input.parent.title}`,
+    `Scope: ${input.parent.scope}`,
+    `Description: ${input.parent.description}`,
+    `In scope: ${input.parent.inScope.join('; ') || '(empty)'}`,
+    `Out of scope: ${input.parent.outOfScope.join('; ') || '(empty)'}`,
+    '',
+    `## CHILDREN (${String(input.children.length)})`,
+    childrenBlock,
+  ].join('\n');
+}
+
+function formatCoverageFeedback(v: CoverageVerdict): string {
+  if (v.passed) return '';
+  const missingBullets =
+    v.missingDeliverables.length > 0
+      ? v.missingDeliverables.map((m) => ` - ${m}`).join('\n')
+      : ' - (none listed by judge — see rationale)';
+  return (
+    `### Coverage judge — FAIL (score ${v.score.toFixed(2)} < ${JUDGE_PASS_THRESHOLD.toFixed(1)})\n` +
+    `Missing deliverables:\n${missingBullets}\n` +
+    `Rationale: ${v.rationale}`
+  );
+}
+
+function formatDisjointnessFeedback(v: DisjointnessVerdict): string {
+  if (v.passed) return '';
+  const overlapsBullets =
+    v.overlaps.length > 0
+      ? v.overlaps
+          .map(
+            (o) =>
+              ` - ${o.childA} <-> ${o.childB}: ${o.overlapDescription}`,
+          )
+          .join('\n')
+      : ' - (none listed by judge — see rationale)';
+  return (
+    `### Disjointness judge — FAIL (score ${v.score.toFixed(2)} < ${JUDGE_PASS_THRESHOLD.toFixed(1)})\n` +
+    `Overlapping siblings:\n${overlapsBullets}\n` +
+    `Rationale: ${v.rationale}`
+  );
+}
+
+// ─── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Run both judges in parallel. Returns the verdicts, a `bothPassed`
+ * flag, and a combined `reflexiveFeedback` string the engine can
+ * inject as Reflexion-style feedback on the next decomposer retry.
+ */
+export async function runJudgePair(input: JudgeInput): Promise<JudgePairResult> {
+  const userPrompt = buildUserPrompt(input);
+
+  const [coverageResult, disjointnessResult] = await Promise.all([
+    callStructured(CoverageJudgeOutputSchema, {
+      taskType: COVERAGE_JUDGE_TASK_TYPE,
+      systemPrompt: COVERAGE_JUDGE_SYSTEM_PROMPT,
+      userPrompt,
+      maxRetries: 2,
+      ...(input.signal ? { signal: input.signal } : {}),
+    }),
+    callStructured(DisjointnessJudgeOutputSchema, {
+      taskType: DISJOINTNESS_JUDGE_TASK_TYPE,
+      systemPrompt: DISJOINTNESS_JUDGE_SYSTEM_PROMPT,
+      userPrompt,
+      maxRetries: 2,
+      ...(input.signal ? { signal: input.signal } : {}),
+    }),
+  ]);
+
+  // Force-correct contradictions: if score >= threshold but the
+  // boolean disagrees, override the boolean. Bias toward "fail" when
+  // missingDeliverables / overlaps is non-empty (conservative).
+  let coveragePassed = coverageResult.data.score >= JUDGE_PASS_THRESHOLD;
+  if (coveragePassed && coverageResult.data.missingDeliverables.length > 0) {
+    coveragePassed = false;
+  }
+  let disjointnessPassed = disjointnessResult.data.score >= JUDGE_PASS_THRESHOLD;
+  if (disjointnessPassed && disjointnessResult.data.overlaps.length > 0) {
+    disjointnessPassed = false;
+  }
+
+  const coverage: CoverageVerdict = {
+    score: coverageResult.data.score,
+    passed: coveragePassed,
+    missingDeliverables: coverageResult.data.missingDeliverables,
+    rationale: coverageResult.data.rationale,
+    model: coverageResult.model,
+    durationMs: coverageResult.durationMs,
+    costUsd: coverageResult.costUsd,
+  };
+  const disjointness: DisjointnessVerdict = {
+    score: disjointnessResult.data.score,
+    passed: disjointnessPassed,
+    overlaps: disjointnessResult.data.overlaps,
+    rationale: disjointnessResult.data.rationale,
+    model: disjointnessResult.model,
+    durationMs: disjointnessResult.durationMs,
+    costUsd: disjointnessResult.costUsd,
+  };
+
+  const bothPassed = coverage.passed && disjointness.passed;
+  const reflexiveFeedback = bothPassed
+    ? ''
+    : [
+        '## JUDGE FEEDBACK FROM PRIOR ATTEMPT',
+        formatCoverageFeedback(coverage),
+        formatDisjointnessFeedback(disjointness),
+        '',
+        'Re-decompose the parent addressing every issue above. Cover the missing deliverables; merge or disambiguate the overlapping siblings.',
+      ]
+        .filter((s) => s.length > 0)
+        .join('\n\n');
+
+  return { coverage, disjointness, bothPassed, reflexiveFeedback };
+}
+
+/**
+ * Normalise a 1..5 judge score to a 0..1 confidence range that fits
+ * the AuditEntry / Decomposition schema's `coverageScore` /
+ * `disjointnessScore` field.
+ */
+export function normaliseJudgeScore(scoreOneToFive: number): number {
+  // (s - 1) / 4 maps 1..5 → 0..1.
+  return Math.max(0, Math.min(1, (scoreOneToFive - 1) / 4));
+}

--- a/packages/decomposer-recursive/src/per-scope-prompts.ts
+++ b/packages/decomposer-recursive/src/per-scope-prompts.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-scope decomposition prompts (proposal §6).
+ *
+ * Each prompt is a system-level instruction that grounds the LLM in
+ * the scope's PMBOK/SAFe/DDD/INVEST invariants, asks it to emit a
+ * children array conforming to ChildTicketArraySchema, and includes
+ * the FREG/AKG substrate hints in the user message.
+ *
+ * Prompts are deliberately compact (~600-800 system + ~1.5-3K user
+ * tokens — see proposal §10 cost model). They reference the JSON
+ * envelope from structured-output.ts; they do NOT redeclare the
+ * "return JSON only" instruction.
+ */
+
+import type { StoryScope } from './types.js';
+
+const SHARED_INVARIANTS = `Universal invariants (apply at every scope):
+- 100% rule (PMBOK): the union of children must cover the parent's inScope. List anything you intentionally omit under outOfScope.
+- MECE: no two children may overlap in deliverable scope. If you find yourself describing the same feature in two children, merge them.
+- Honest ambiguity: if the prompt under-specifies persona, KPI, or boundary, emit a child with a low confidence score and call it out in the description; never invent KPIs the user didn't imply.
+- Cite-evidence: every claim about user intent must reference parent-ticket text.
+- Existing substrate: when an EXISTING FEATURES (FREG) or EXISTING ARCHITECTURE (AKG) entry overlaps a child's scope, set lifecycle='enhance' and reference the artifact id; prefer reuse over re-create.
+- IDs: child IDs must be unique strings within the children array; no self-dependencies.
+`;
+
+const INITIATIVE_PROMPT = `You are decomposing a strategic initiative into epics. An initiative is a multi-quarter strategic bet at the portfolio level. An epic is a single program-increment-sized (8-12 weeks per SAFe) chunk of value with one elevator-pitch theme.
+
+Your job: read the initiative ticket and produce 2-5 epics that, taken together, fully deliver the initiative's businessOutcome and respect the initiative's outOfScope.
+
+Strict requirements:
+1. Coverage + Disjointness as in the universal invariants.
+2. Each epic must have its own elevator-pitch summary (<= 25 words) in title+description.
+3. Each epic's inScope[] should have 3-6 items (each >= 5 words); outOfScope[] should have 1-3 items.
+4. Each epic must declare 1-2 dominant tech_sub_domains in the description ("dominant tech: ui+backend").
+5. Cross-epic dependencies: declare a dependency edge in dependencies[] if epic-A blocks epic-B; no self-dependencies.
+6. Each epic's lifecycle: 'enhance' if the FREG/AKG context shows substantial overlap with an existing feature; else 'new'. P0 stubs FREG/AKG to empty so default is 'new'.
+
+${SHARED_INVARIANTS}`;
+
+const EPIC_PROMPT = `You are decomposing an epic into modules. A module is a Domain-Driven-Design bounded context — a coherent capability cluster with a single primary tech_sub_domain and its own data ownership.
+
+Produce 2-6 modules that fully deliver the epic and respect the epic's outOfScope.
+
+Vertical-slicing reminder: if an epic touches UI, backend, and DB, prefer modules sliced by user-visible feature (each touching all three layers thinly) over modules sliced by technical layer.
+
+Strict requirements:
+1. Coverage + Disjointness.
+2. Each module declares its primary tech_sub_domain in the description ("primary tech: backend").
+3. Each module declares its data ownership in inScope[] (which schemas/tables/state-stores it owns).
+4. Cross-module dependencies declared explicitly. Most modules depend on at least one other.
+
+${SHARED_INVARIANTS}`;
+
+const MODULE_PROMPT = `You are decomposing a module into stories. A story is an INVEST-compliant user-value increment.
+
+Produce 2-8 stories that fully deliver the module's user-visible value.
+
+Strict requirements:
+1. Coverage + Disjointness.
+2. Each story has a "As a [persona], I want [outcome] so that [value]" sentence in description.
+3. Each story has acceptanceCriteria with 3-6 concrete items (each >= 8 words, each testable).
+4. Each story has its own inScope[] / outOfScope[].
+5. Vertical slice preferred when user value crosses tech sub-domains.
+
+${SHARED_INVARIANTS}`;
+
+const STORY_PROMPT = `You are decomposing a story into tasks. A task is a single-concern, <= 1-day, single-tech-sub-domain unit of work — typically a single file or tightly-coupled file group.
+
+Produce 1-6 tasks that fully implement the story's acceptance criteria.
+
+Strict requirements:
+1. Each task corresponds to >= 1 AC of the parent story (mention which AC IDs in the description).
+2. Each task has a concrete artifact target: file path, function/class name, schema/migration name, or API route in description.
+3. Each task declares its tech_sub_domain (single primary value) in the description.
+4. Cross-task dependencies declared in dependencies[] (data-model task blocks API task blocks UI task).
+
+${SHARED_INVARIANTS}`;
+
+const TASK_PROMPT = `You are decomposing a task into subtasks. A subtask is a single mechanical step: single function, single test, single comment block, single config edit.
+
+Most tasks do NOT need subtask decomposition. Produce 2-5 subtasks only when the parent task is genuinely multi-step (multi-file refactor, multi-test test addition).
+
+Strict requirements:
+1. Each subtask is <= 2 hours of work for a competent engineer.
+2. Each subtask names the precise artifact (function name, test name, file region) in the description.
+3. Subtasks are typically sequential within a task; declare order via dependencies[].
+
+${SHARED_INVARIANTS}`;
+
+const SUBTASK_PROMPT = `You are at the atomicity floor. Subtasks are leaves and rarely decompose further.
+
+If you absolutely must produce children (e.g., a renamed-as-subtask actually being a multi-step refactor), produce 2-3 micro-steps. Each micro-step is a single file edit or single line change.
+
+${SHARED_INVARIANTS}`;
+
+/**
+ * Map from parent scope to the system prompt for decomposing it into
+ * its child scope. Note: the key is the PARENT scope. The child scope
+ * is one level below per STORY_SCOPE_ORDER.
+ */
+export const DECOMPOSER_SYSTEM_PROMPTS: Record<StoryScope, string> = {
+  initiative: INITIATIVE_PROMPT,
+  epic: EPIC_PROMPT,
+  module: MODULE_PROMPT,
+  story: STORY_PROMPT,
+  task: TASK_PROMPT,
+  subtask: SUBTASK_PROMPT,
+};
+
+/**
+ * Map from parent scope to the routing-rule task type. Used by the
+ * engine to route through @chiefaia/local-llm-router with the right
+ * cost/quality tier.
+ */
+export const DECOMPOSER_TASK_TYPES: Record<StoryScope, string> = {
+  initiative: 'po-decomposer-initiative',
+  epic: 'po-decomposer-epic',
+  module: 'po-decomposer-module',
+  story: 'po-decomposer-story',
+  task: 'po-decomposer-task',
+  subtask: 'po-decomposer-subtask',
+};
+
+/**
+ * Child-scope mapping. `subtask` has no child (it's the atomicity floor);
+ * the engine never asks for sub-subtasks.
+ */
+export const CHILD_SCOPE_OF: Record<StoryScope, StoryScope | null> = {
+  initiative: 'epic',
+  epic: 'module',
+  module: 'story',
+  story: 'task',
+  task: 'subtask',
+  subtask: null,
+};

--- a/packages/decomposer-recursive/src/schemas.ts
+++ b/packages/decomposer-recursive/src/schemas.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import { STORY_SCOPES } from '@chiefaia/ticket-template';
+
+export const StoryScopeSchema = z.enum(STORY_SCOPES);
+
+export const ExistingArtifactRefSchema = z.object({
+  source: z.enum(['feature', 'arch_artifact']),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  score: z.number().min(0).max(1),
+  hint: z.string().optional(),
+});
+
+export const ChildTicketSchema = z
+  .object({
+    id: z.string().min(1),
+    scope: StoryScopeSchema,
+    title: z.string().min(3).max(200),
+    description: z.string().min(10),
+    acceptanceCriteria: z.array(z.string().min(8)).optional(),
+    inScope: z.array(z.string().min(5)),
+    outOfScope: z.array(z.string()),
+    dependencies: z.array(z.string()),
+    estimatedAtomic: z.boolean(),
+    existingArtifacts: z.array(ExistingArtifactRefSchema),
+    lifecycle: z.enum(['new', 'enhance', 'reuse']),
+  })
+  .refine((c) => !c.dependencies.includes(c.id), {
+    message: 'A child cannot depend on itself',
+    path: ['dependencies'],
+  });
+
+export const ChildTicketArraySchema = z
+  .array(ChildTicketSchema)
+  .refine(
+    (children) => {
+      const ids = new Set<string>();
+      for (const c of children) {
+        if (ids.has(c.id)) return false;
+        ids.add(c.id);
+      }
+      return true;
+    },
+    { message: 'Sibling child IDs must be unique' },
+  );
+
+export const ClarifyingQuestionSchema = z.object({
+  id: z.string().min(1),
+  parentNodeId: z.string().min(1),
+  question: z.string().min(5),
+  proposedAnswers: z.array(z.string()),
+  blocksBranch: z.boolean(),
+  rationale: z.string().min(5),
+});
+
+export const DependencyEdgeSchema = z
+  .object({
+    fromChildId: z.string().min(1),
+    toChildId: z.string().min(1),
+    kind: z.enum(['blocks', 'soft', 'capability']),
+    rationale: z.string().min(3),
+  })
+  .refine((e) => e.fromChildId !== e.toChildId, {
+    message: 'A dependency edge cannot self-loop',
+    path: ['toChildId'],
+  });
+
+export const AuditEntrySchema = z.object({
+  parentNodeId: z.string().min(1),
+  parentScope: StoryScopeSchema,
+  childScope: StoryScopeSchema,
+  attempt: z.number().int().min(1),
+  promptTextHash: z.string().min(1),
+  model: z.string().min(1),
+  tokensIn: z.number().int().min(0),
+  tokensOut: z.number().int().min(0),
+  costUsd: z.number().min(0),
+  durationMs: z.number().min(0),
+  alternativesConsidered: z.number().int().min(0),
+  coverageScore: z.number().min(0).max(1).nullable(),
+  disjointnessScore: z.number().min(0).max(1).nullable(),
+  ambiguityDetected: z.boolean(),
+  questionsEmittedCount: z.number().int().min(0),
+  decisionRationale: z.string(),
+  childrenCount: z.number().int().min(0),
+  outcome: z.enum(['committed', 'reflexive-retry', 'stuck', 'awaiting-clarification']),
+});
+
+export const DecompositionSchema = z.object({
+  childTickets: ChildTicketArraySchema,
+  clarifyingQuestions: z.array(ClarifyingQuestionSchema),
+  dependencies: z.array(DependencyEdgeSchema),
+  confidence: z.number().min(0).max(1).nullable(),
+  judgeScores: z.object({
+    coverage: z.number().min(0).max(1).nullable(),
+    disjointness: z.number().min(0).max(1).nullable(),
+  }),
+  audit: AuditEntrySchema,
+});
+
+export const ScopeDetectionLlmOutputSchema = z.object({
+  targetScope: StoryScopeSchema,
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().min(3),
+});
+
+export const AtomicityLlmOutputSchema = z.object({
+  atomic: z.boolean(),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().min(3),
+  failedCriteria: z.array(z.string()),
+});
+
+export type ChildTicketSchemaT = z.infer<typeof ChildTicketSchema>;
+export type ChildTicketArraySchemaT = z.infer<typeof ChildTicketArraySchema>;
+export type DecompositionSchemaT = z.infer<typeof DecompositionSchema>;
+export type ScopeDetectionLlmOutputT = z.infer<typeof ScopeDetectionLlmOutputSchema>;
+export type AtomicityLlmOutputT = z.infer<typeof AtomicityLlmOutputSchema>;

--- a/packages/decomposer-recursive/src/scope-detector.ts
+++ b/packages/decomposer-recursive/src/scope-detector.ts
@@ -1,0 +1,93 @@
+/**
+ * Adaptive scope detector.
+ *
+ * Given a user prompt (and optional vision-doc summary), classify the
+ * smallest scope at which the prompt can be expressed without further
+ * decomposition. The decomposer engine (PR 2) starts recursion at this
+ * scope rather than always-starting-at-initiative — so "add a logout
+ * button" produces a single story, not a fake five-level tree.
+ *
+ * The classifier itself is a small LLM call routed through the local
+ * Ollama path (with Claude fallback) — it's a classification task,
+ * not a generative one, so qwen2.5-coder:7b handles it well.
+ */
+
+import { ScopeDetectionLlmOutputSchema } from './schemas.js';
+import { callStructured } from './structured-output.js';
+import type { ScopeDetection, CancellationSignal } from './types.js';
+
+export const SCOPE_DETECTION_TASK_TYPE = 'po-decomposer-scope-detection';
+
+export interface DetectScopeOptions {
+  /** The prompt text the user submitted. */
+  promptText: string;
+  /**
+   * Optional pre-extracted theme summary (used for vision documents
+   * post-chunking — P1; in P0 always undefined).
+   */
+  visionDocSummary?: string;
+  /** Optional cancellation signal. */
+  signal?: CancellationSignal;
+}
+
+const SCOPE_DETECTION_SYSTEM_PROMPT = `You are a senior product manager classifying the natural scope of a user request.
+
+The canonical scopes, from largest to smallest:
+- initiative — multi-quarter strategic bet, typically multi-team, multi-feature, multi-platform. Vision documents land here. Examples: "build an analytics SaaS", "launch a new product line".
+- epic — single program-increment-sized chunk (8-12 weeks per SAFe), one elevator-pitch theme, multiple modules. Examples: "build the billing system", "ship the leaderboard feature".
+- module — a coherent bounded context with one primary tech sub-domain and its own data ownership. Crosses 2-8 stories. Examples: "the user-auth module", "the notification dispatcher".
+- story — INVEST-compliant user-value increment. Single PR, ≤ 1 sprint, single user-visible value. Examples: "add a logout button", "users can filter by date".
+- task — single concern, ≤ 1 day, single tech-sub-domain. Often one file group. Examples: "refactor the password validator", "add the GET /users route".
+- subtask — single mechanical step: one function, one test, one config edit. Examples: "rename _x to _internal in foo.ts", "add the test for the empty-input case".
+
+Heuristic anchors:
+- One verb, one object, one concrete deliverable → story.
+- One verb, vague object → task.
+- Multi-paragraph but single feature → epic.
+- "Build [system]" / "we want to launch" → initiative.
+- Vision document, multi-feature, multi-team → initiative.
+- One-line, mechanical, no scope question → subtask.
+
+Output schema:
+{
+  "targetScope": "initiative" | "epic" | "module" | "story" | "task" | "subtask",
+  "confidence": 0.0..1.0,
+  "rationale": "one sentence explaining the verdict"
+}`;
+
+/**
+ * Classify the natural scope of a prompt.
+ *
+ * Returns a `ScopeDetection` with `targetScope`, `confidence`, and a
+ * one-sentence rationale. On parse failure or model error,
+ * propagates `StructuredOutputParseError` / `StructuredOutputCancelled`
+ * — the orchestrator (PR 2) catches and decides whether to file a
+ * `decomposer-stuck` blocker or retry with a fresh model.
+ */
+export async function detectScope(
+  options: DetectScopeOptions,
+): Promise<ScopeDetection> {
+  const userPrompt =
+    `Classify the natural scope of the following user prompt.\n\n` +
+    `=== PROMPT ===\n${options.promptText}\n=== END PROMPT ===\n` +
+    (options.visionDocSummary
+      ? `\n=== VISION-DOC SUMMARY (extracted themes) ===\n` +
+        `${options.visionDocSummary}\n=== END VISION-DOC SUMMARY ===`
+      : '');
+
+  const result = await callStructured(ScopeDetectionLlmOutputSchema, {
+    taskType: SCOPE_DETECTION_TASK_TYPE,
+    systemPrompt: SCOPE_DETECTION_SYSTEM_PROMPT,
+    userPrompt,
+    maxRetries: 2,
+    ...(options.signal ? { signal: options.signal } : {}),
+  });
+
+  return {
+    targetScope: result.data.targetScope,
+    confidence: result.data.confidence,
+    rationale: result.data.rationale,
+    model: result.model,
+    durationMs: result.durationMs,
+  };
+}

--- a/packages/decomposer-recursive/src/structured-output.ts
+++ b/packages/decomposer-recursive/src/structured-output.ts
@@ -1,0 +1,258 @@
+/**
+ * Structured-output helper for LLM calls.
+ *
+ * Every classifier / decomposer in this package routes through
+ * `@chiefaia/local-llm-router` and asks the model to emit JSON
+ * conforming to a Zod schema. This helper:
+ *
+ *   1. Wraps the system+user prompt in a JSON-only envelope.
+ *   2. Calls `route(taskType, prompt)`.
+ *   3. Extracts JSON from the response (the model may wrap the JSON
+ *      in markdown fences or surrounding prose; we tolerate both).
+ *   4. Parses against the Zod schema.
+ *   5. On parse failure, retries up to `maxRetries` times with the
+ *      Zod error appended to the user prompt as feedback. (The
+ *      rationale: this is the same reflexive-retry pattern Reflexion
+ *      formalised — the model gets told what went wrong and tries
+ *      again.)
+ *
+ * The helper does NOT enforce the cancellation signal — the underlying
+ * router doesn't accept one in its current API. The orchestrator (PR 2)
+ * checks `signal.aborted` between top-level recursion steps so a
+ * cancel still bounds wall-clock by ~one outstanding LLM call.
+ *
+ * Cost tracking: PR 1 returns a coarse cost estimate from the routing
+ * rule's claude cost string (per 1000 calls). PR 4 wires this through
+ * to the spend-cap when Track 1 lands.
+ */
+
+import { z } from 'zod';
+import { route } from '@chiefaia/local-llm-router';
+import { perCallCostFromRuleString, getRoute } from '@chiefaia/local-llm-router';
+import type { LLMResponse } from '@chiefaia/local-llm-router';
+
+export interface StructuredOutputOptions {
+  /** Routing-rule task type, e.g. 'po-decomposer-scope-detection'. */
+  taskType: string;
+  /** System-level instructions (role + invariants). */
+  systemPrompt: string;
+  /** User-level prompt (the actual data). */
+  userPrompt: string;
+  /** Max retries on Zod parse failure. Default 2 (so 3 attempts total). */
+  maxRetries?: number;
+  /** Optional cancellation signal — checked before each retry. */
+  signal?: AbortSignal;
+}
+
+export interface StructuredOutputResult<T> {
+  data: T;
+  /** The raw text the model returned on the successful attempt. */
+  rawResponse: string;
+  /** Provider that won (telemetry). */
+  provider: 'local' | 'claude';
+  /** Concrete model that produced the response (telemetry). */
+  model: string;
+  /** Wall-clock ms across all attempts (sum). */
+  durationMs: number;
+  /** USD spend estimate across all attempts. */
+  costUsd: number;
+  /** Number of attempts taken (1-indexed). 1 = no retry. */
+  attempts: number;
+  /** Token usage on the WINNING attempt. */
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+/**
+ * Thrown when even the last retry produced output that doesn't
+ * conform to the schema. The caller sees the final Zod error and the
+ * model's last raw response so it can decide to escalate (model
+ * swap, file a `decomposition-stuck` blocker, or surface to dashboard).
+ */
+export class StructuredOutputParseError extends Error {
+  public readonly attempts: number;
+  public readonly lastRaw: string;
+  public readonly zodError: z.ZodError;
+  public readonly taskType: string;
+
+  constructor(
+    taskType: string,
+    attempts: number,
+    lastRaw: string,
+    zodError: z.ZodError,
+  ) {
+    super(
+      `[decomposer-recursive] structured-output parse failed for task ` +
+        `"${taskType}" after ${String(attempts)} attempt(s): ` +
+        zodError.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+    );
+    this.name = 'StructuredOutputParseError';
+    this.taskType = taskType;
+    this.attempts = attempts;
+    this.lastRaw = lastRaw;
+    this.zodError = zodError;
+  }
+}
+
+/**
+ * Thrown when the user passed an `AbortSignal` and it fired before /
+ * during a retry. The orchestrator catches this to short-circuit
+ * recursion.
+ */
+export class StructuredOutputCancelled extends Error {
+  constructor(taskType: string) {
+    super(`[decomposer-recursive] cancelled before completing "${taskType}"`);
+    this.name = 'StructuredOutputCancelled';
+  }
+}
+
+const JSON_ONLY_INSTRUCTION =
+  '\n\nReturn ONLY a single JSON object that matches the schema described above. ' +
+  'No markdown fences, no surrounding prose, no explanations. ' +
+  'If you cannot answer, return JSON with the best-effort fields populated and ' +
+  'a low confidence value — never return prose.';
+
+/**
+ * Run an LLM call expecting a Zod-shaped JSON response, with bounded
+ * retry on parse failure.
+ */
+export async function callStructured<T extends z.ZodTypeAny>(
+  schema: T,
+  options: StructuredOutputOptions,
+): Promise<StructuredOutputResult<z.infer<T>>> {
+  const maxRetries = options.maxRetries ?? 2;
+  const totalAttempts = maxRetries + 1;
+
+  let totalDurationMs = 0;
+  let totalCostUsd = 0;
+  let lastRaw = '';
+  let lastZodError: z.ZodError | null = null;
+
+  let userPrompt = options.userPrompt;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    if (options.signal?.aborted) {
+      throw new StructuredOutputCancelled(options.taskType);
+    }
+
+    const fullPrompt =
+      `${options.systemPrompt}${JSON_ONLY_INSTRUCTION}\n\n` +
+      `=== USER ===\n${userPrompt}\n=== END USER ===`;
+
+    // Network / model errors propagate. The caller decides whether
+    // to escalate or retry at a higher level (model swap, etc.).
+    const resp: LLMResponse = await route(options.taskType, fullPrompt);
+
+    totalDurationMs += resp.durationMs;
+    totalCostUsd += estimateCallCost(options.taskType, resp);
+    lastRaw = resp.response;
+
+    const json = extractJson(resp.response);
+    if (json === null) {
+      lastZodError = new z.ZodError([
+        {
+          code: 'custom',
+          path: [],
+          message:
+            'No JSON object found in model response — wrap the answer in a single { ... } object.',
+        },
+      ]);
+    } else {
+      const parseResult = schema.safeParse(json);
+      if (parseResult.success) {
+        return {
+          data: parseResult.data as z.infer<T>,
+          rawResponse: resp.response,
+          provider: resp.provider,
+          model: resp.model,
+          durationMs: totalDurationMs,
+          costUsd: totalCostUsd,
+          attempts: attempt,
+          ...(resp.usage ? { usage: resp.usage } : {}),
+        };
+      }
+      lastZodError = parseResult.error;
+    }
+
+    // If we have retries left, append the parse error and try again.
+    if (attempt < totalAttempts && lastZodError) {
+      userPrompt =
+        `${options.userPrompt}\n\n=== PRIOR-ATTEMPT FAILURE ===\n` +
+        `Your previous response did not parse against the required schema. ` +
+        `The validator reported:\n` +
+        lastZodError.issues
+          .map((iss) => ` - ${iss.path.join('.') || '(root)'}: ${iss.message}`)
+          .join('\n') +
+        `\nFix every listed issue and return ONLY a single JSON object.`;
+    }
+  }
+
+  throw new StructuredOutputParseError(
+    options.taskType,
+    totalAttempts,
+    lastRaw,
+    lastZodError ?? new z.ZodError([]),
+  );
+}
+
+/**
+ * Best-effort JSON extractor. Tries:
+ *   1. Raw `JSON.parse` of the whole response.
+ *   2. Stripping markdown fences (```json ... ``` or ``` ... ```).
+ *   3. Greedy match for the outermost `{...}` block.
+ *
+ * Returns the parsed object, or `null` if no JSON object is recoverable.
+ */
+export function extractJson(raw: string): unknown {
+  const trimmed = raw.trim();
+
+  // Direct parse.
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    // Fall through.
+  }
+
+  // Markdown-fence parse.
+  const fenceMatch = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
+  if (fenceMatch && fenceMatch[1]) {
+    const inner = fenceMatch[1].trim();
+    try {
+      return JSON.parse(inner) as unknown;
+    } catch {
+      // Fall through.
+    }
+  }
+
+  // Outermost-object parse.
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    const slice = trimmed.slice(firstBrace, lastBrace + 1);
+    try {
+      return JSON.parse(slice) as unknown;
+    } catch {
+      // Fall through.
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Estimate the per-call USD spend by reading the rule's
+ * `estimatedCostClaude` string ("$X per 1000 calls") and dividing by 1000.
+ *
+ * The estimate is intentionally coarse: it's used for the audit-row
+ * `costUsd` field and for the spend-guard pre-check (PR 4 wires that).
+ * Production cost-attribution would require token-level pricing.
+ */
+function estimateCallCost(taskType: string, resp: LLMResponse): number {
+  // Local calls are free.
+  if (resp.provider === 'local') return 0;
+  const rule = getRoute(taskType);
+  return perCallCostFromRuleString(rule.estimatedCostClaude);
+}

--- a/packages/decomposer-recursive/src/types.ts
+++ b/packages/decomposer-recursive/src/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Core types for the recursive decomposer.
+ *
+ * Every type here has a Zod-schema counterpart in `./schemas.ts` —
+ * the schemas are the runtime source of truth for LLM-output
+ * validation; these TypeScript types document the public API and
+ * stay structurally compatible with the schemas.
+ */
+
+import type { StoryScope } from '@chiefaia/ticket-template';
+
+export type { StoryScope } from '@chiefaia/ticket-template';
+export { STORY_SCOPES, STORY_SCOPE_ORDER, isStoryScope } from '@chiefaia/ticket-template';
+
+export interface ExistingArtifactRef {
+  source: 'feature' | 'arch_artifact';
+  id: string;
+  name: string;
+  score: number;
+  hint?: string;
+}
+
+export interface ChildTicket {
+  id: string;
+  scope: StoryScope;
+  title: string;
+  description: string;
+  acceptanceCriteria?: string[];
+  inScope: string[];
+  outOfScope: string[];
+  dependencies: string[];
+  estimatedAtomic: boolean;
+  existingArtifacts: ExistingArtifactRef[];
+  lifecycle: 'new' | 'enhance' | 'reuse';
+}
+
+export interface ClarifyingQuestion {
+  id: string;
+  parentNodeId: string;
+  question: string;
+  proposedAnswers: string[];
+  blocksBranch: boolean;
+  rationale: string;
+}
+
+export interface DependencyEdge {
+  fromChildId: string;
+  toChildId: string;
+  kind: 'blocks' | 'soft' | 'capability';
+  rationale: string;
+}
+
+export interface AuditEntry {
+  parentNodeId: string;
+  parentScope: StoryScope;
+  childScope: StoryScope;
+  attempt: number;
+  promptTextHash: string;
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  costUsd: number;
+  durationMs: number;
+  alternativesConsidered: number;
+  coverageScore: number | null;
+  disjointnessScore: number | null;
+  ambiguityDetected: boolean;
+  questionsEmittedCount: number;
+  decisionRationale: string;
+  childrenCount: number;
+  outcome: 'committed' | 'reflexive-retry' | 'stuck' | 'awaiting-clarification';
+}
+
+export interface Decomposition {
+  childTickets: ChildTicket[];
+  clarifyingQuestions: ClarifyingQuestion[];
+  dependencies: DependencyEdge[];
+  confidence: number | null;
+  judgeScores: {
+    coverage: number | null;
+    disjointness: number | null;
+  };
+  audit: AuditEntry;
+}
+
+export interface ScopeDetection {
+  targetScope: StoryScope;
+  confidence: number;
+  rationale: string;
+  model: string;
+  durationMs: number;
+}
+
+export interface AtomicityVerdict {
+  atomic: boolean;
+  confidence: number;
+  rationale: string;
+  failedCriteria: string[];
+  model: string;
+  durationMs: number;
+}
+
+export type CancellationSignal = AbortSignal;

--- a/packages/decomposer-recursive/tests/_helpers.ts
+++ b/packages/decomposer-recursive/tests/_helpers.ts
@@ -1,0 +1,119 @@
+/**
+ * Test helpers for @chiefaia/decomposer-recursive.
+ *
+ * These wrap the local-llm-router's `__setAdapters` test seam so tests
+ * can drive deterministic LLM responses without booting Ollama or
+ * reaching out to Claude.
+ */
+
+import { vi } from 'vitest';
+import {
+  __setAdapters,
+  type LLMResponse,
+  OllamaAdapter,
+  ClaudeAdapter,
+} from '@chiefaia/local-llm-router';
+
+export interface FakeAdapterConfig {
+  /** Sequence of responses to return on successive `generate` calls. */
+  responses: Array<Partial<LLMResponse> & { response: string }>;
+  /** Whether the local adapter advertises itself as available. Default true. */
+  available?: boolean;
+  /** When set, the adapter throws this error instead of returning. */
+  throws?: Error;
+}
+
+/**
+ * Create an Ollama-style fake. Returns the responses in order; if the
+ * caller exceeds the queue, the LAST response is repeated.
+ */
+export function fakeOllama(config: FakeAdapterConfig): OllamaAdapter {
+  let cursor = 0;
+  return {
+    isAvailable: vi.fn(async () => config.available ?? true),
+    generate: vi.fn(async (model: string): Promise<LLMResponse> => {
+      if (config.throws) throw config.throws;
+      const idx = Math.min(cursor, config.responses.length - 1);
+      cursor++;
+      const next = config.responses[idx];
+      if (!next) throw new Error('fakeOllama: no responses configured');
+      return {
+        response: next.response,
+        model: next.model ?? model,
+        provider: next.provider ?? 'local',
+        durationMs: next.durationMs ?? 12,
+        ...(next.usage ? { usage: next.usage } : {}),
+      };
+    }),
+  } as unknown as OllamaAdapter;
+}
+
+/**
+ * Create a Claude-style fake. Same semantics as fakeOllama.
+ */
+export function fakeClaude(config: FakeAdapterConfig): ClaudeAdapter {
+  let cursor = 0;
+  return {
+    generate: vi.fn(async (model: string): Promise<LLMResponse> => {
+      if (config.throws) throw config.throws;
+      const idx = Math.min(cursor, config.responses.length - 1);
+      cursor++;
+      const next = config.responses[idx];
+      if (!next) throw new Error('fakeClaude: no responses configured');
+      return {
+        response: next.response,
+        model: next.model ?? model,
+        provider: next.provider ?? 'claude',
+        durationMs: next.durationMs ?? 800,
+        ...(next.usage ? { usage: next.usage } : {}),
+      };
+    }),
+  } as unknown as ClaudeAdapter;
+}
+
+/**
+ * Wire fake adapters into the router for the duration of a single test.
+ * The caller MUST clear them in `afterEach` via `clearAdapters()`.
+ */
+export function installFakeAdapters(
+  ollama: OllamaAdapter,
+  claude: ClaudeAdapter,
+): void {
+  __setAdapters(ollama, claude);
+}
+
+export function clearAdapters(): void {
+  __setAdapters(null, null);
+}
+
+/**
+ * Helper that builds a fake response with the supplied JSON payload
+ * already serialised. Keeps the test bodies readable.
+ */
+export function jsonResponse(
+  obj: unknown,
+  overrides: Partial<LLMResponse> = {},
+): Partial<LLMResponse> & { response: string } {
+  const body = JSON.stringify(obj);
+  return {
+    response: body,
+    durationMs: 25,
+    ...overrides,
+  };
+}
+
+/**
+ * Helper for asserting that the parse-failure feedback loop is being
+ * triggered. The first response is intentionally malformed so the
+ * router will retry.
+ */
+export function malformedResponse(
+  text = 'sorry I do not return JSON',
+  overrides: Partial<LLMResponse> = {},
+): Partial<LLMResponse> & { response: string } {
+  return {
+    response: text,
+    durationMs: 25,
+    ...overrides,
+  };
+}

--- a/packages/decomposer-recursive/tests/_helpers.ts
+++ b/packages/decomposer-recursive/tests/_helpers.ts
@@ -16,7 +16,7 @@ import {
 
 export interface FakeAdapterConfig {
   /** Sequence of responses to return on successive `generate` calls. */
-  responses: Array<Partial<LLMResponse> & { response: string }>;
+  responses: Array<Partial<LLMResponse> & { response: string; match?: string }>;
   /** Whether the local adapter advertises itself as available. Default true. */
   available?: boolean;
   /** When set, the adapter throws this error instead of returning. */
@@ -50,14 +50,34 @@ export function fakeOllama(config: FakeAdapterConfig): OllamaAdapter {
 
 /**
  * Create a Claude-style fake. Same semantics as fakeOllama.
+ *
+ * If the test's `responses` array contains entries with a `match` field,
+ * the fake routes by checking whether the request prompt INCLUDES that
+ * substring — useful for parallel Promise.all calls where ordering is
+ * non-deterministic. Fall-through when no match: returns the responses
+ * in queue order.
  */
 export function fakeClaude(config: FakeAdapterConfig): ClaudeAdapter {
   let cursor = 0;
+  const used = new Set<number>();
   return {
-    generate: vi.fn(async (model: string): Promise<LLMResponse> => {
+    generate: vi.fn(async (model: string, req: { prompt: string }): Promise<LLMResponse> => {
       if (config.throws) throw config.throws;
-      const idx = Math.min(cursor, config.responses.length - 1);
-      cursor++;
+      // Try match-based routing first.
+      const promptText = req?.prompt ?? '';
+      let idx = -1;
+      for (let i = 0; i < config.responses.length; i++) {
+        const r = config.responses[i] as Partial<LLMResponse> & { response: string; match?: string };
+        if (r.match && !used.has(i) && promptText.includes(r.match)) {
+          idx = i;
+          break;
+        }
+      }
+      if (idx === -1) {
+        idx = Math.min(cursor, config.responses.length - 1);
+        cursor++;
+      }
+      used.add(idx);
       const next = config.responses[idx];
       if (!next) throw new Error('fakeClaude: no responses configured');
       return {

--- a/packages/decomposer-recursive/tests/atomicity-classifier.test.ts
+++ b/packages/decomposer-recursive/tests/atomicity-classifier.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ATOMICITY_RUBRICS, classifyAtomicity } from '../src/atomicity-classifier.js';
+import { STORY_SCOPES } from '../src/types.js';
+import type { ChildTicket } from '../src/types.js';
+import { fakeOllama, fakeClaude, installFakeAdapters, clearAdapters, jsonResponse } from './_helpers.js';
+
+function fixtureChild(scope: ChildTicket['scope']): ChildTicket {
+  return {
+    id: `child-${scope}`,
+    scope,
+    title: `A ${scope} candidate`,
+    description: `Concrete description for the ${scope} candidate`,
+    inScope: ['the in-scope item one', 'in-scope item two'],
+    outOfScope: ['out-of-scope item'],
+    dependencies: [],
+    estimatedAtomic: false,
+    existingArtifacts: [],
+    lifecycle: 'new',
+    acceptanceCriteria: ['When user does X, the system does Y reliably'],
+  };
+}
+
+describe('ATOMICITY_RUBRICS', () => {
+  it('non-empty for every scope', () => {
+    for (const scope of STORY_SCOPES) {
+      const r = ATOMICITY_RUBRICS[scope];
+      expect(r.length).toBeGreaterThan(0);
+      for (const item of r) expect(item.length).toBeGreaterThan(10);
+    }
+  });
+  it('story rubric mentions INVEST', () => {
+    expect(ATOMICITY_RUBRICS.story.join('\n')).toMatch(/INVEST/i);
+  });
+  it('epic rubric mentions SAFe or PI', () => {
+    expect(ATOMICITY_RUBRICS.epic.join('\n')).toMatch(/SAFe|PI/);
+  });
+  it('module rubric mentions DDD or bounded', () => {
+    expect(ATOMICITY_RUBRICS.module.join('\n')).toMatch(/DDD|bounded/i);
+  });
+});
+
+describe('classifyAtomicity', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('atomic=true with empty failedCriteria passes', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('story') });
+    expect(v.atomic).toBe(true);
+  });
+
+  it('atomic=false with failedCriteria passes', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: false, confidence: 0.7, rationale: 'two concerns', failedCriteria: ['some criterion'] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('story') });
+    expect(v.atomic).toBe(false);
+    expect(v.failedCriteria.length).toBe(1);
+  });
+
+  it('force-corrects true+nonEmpty to false', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: true, confidence: 0.4, rationale: 'short rationale', failedCriteria: ['something'] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('module') });
+    expect(v.atomic).toBe(false);
+  });
+
+  it('force-corrects false+empty to true', async () => {
+    const ollama = fakeOllama({ responses: [jsonResponse({ atomic: false, confidence: 0.4, rationale: 'short rationale', failedCriteria: [] })] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('task') });
+    expect(v.atomic).toBe(true);
+  });
+
+  it('exercises every scope', async () => {
+    for (const scope of STORY_SCOPES) {
+      clearAdapters();
+      const ollama = fakeOllama({ responses: [jsonResponse({ atomic: true, confidence: 0.8, rationale: 'a sufficient rationale', failedCriteria: [] })] });
+      installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+      const v = await classifyAtomicity({ child: fixtureChild(scope) });
+      expect(v.atomic).toBe(true);
+    }
+  });
+
+  it('telemetry passes through', async () => {
+    const ollama = fakeOllama({ responses: [{ response: JSON.stringify({ atomic: true, confidence: 0.85, rationale: 'a sufficient rationale', failedCriteria: [] }), model: 'qwen2.5-coder:7b', durationMs: 41 }] });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+    const v = await classifyAtomicity({ child: fixtureChild('subtask') });
+    expect(v.model).toBe('qwen2.5-coder:7b');
+    expect(v.durationMs).toBe(41);
+  });
+});

--- a/packages/decomposer-recursive/tests/decomposer.test.ts
+++ b/packages/decomposer-recursive/tests/decomposer.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  PORecursiveDecomposer,
+  PORecursiveDecomposerCancelled,
+} from '../src/decomposer.js';
+import { CHILD_SCOPE_OF, DECOMPOSER_SYSTEM_PROMPTS } from '../src/per-scope-prompts.js';
+import { STORY_SCOPES } from '../src/types.js';
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+function childPayload(scope: string, idx: number, atomic = true): Record<string, unknown> {
+  return {
+    id: `c${String(idx)}`,
+    scope,
+    title: `Candidate ${String(idx)}`,
+    description: `A description for candidate ${String(idx)} that is long enough`,
+    inScope: ['the in-scope item one'],
+    outOfScope: [],
+    dependencies: [],
+    estimatedAtomic: atomic,
+    existingArtifacts: [],
+    lifecycle: 'new',
+  };
+}
+
+const exampleParent = {
+  id: 'p',
+  scope: 'epic' as const,
+  title: 'A reasonable epic',
+  description: 'A reasonable epic that needs to be split into modules',
+  inScope: ['everything in this epic'],
+  outOfScope: [],
+};
+
+describe('per-scope prompts', () => {
+  it('have a non-empty system prompt for every scope', () => {
+    for (const scope of STORY_SCOPES) {
+      expect(DECOMPOSER_SYSTEM_PROMPTS[scope].length).toBeGreaterThan(100);
+    }
+  });
+
+  it('child-scope mapping is well-formed', () => {
+    expect(CHILD_SCOPE_OF.initiative).toBe('epic');
+    expect(CHILD_SCOPE_OF.epic).toBe('module');
+    expect(CHILD_SCOPE_OF.module).toBe('story');
+    expect(CHILD_SCOPE_OF.story).toBe('task');
+    expect(CHILD_SCOPE_OF.task).toBe('subtask');
+    expect(CHILD_SCOPE_OF.subtask).toBeNull();
+  });
+});
+
+describe('PORecursiveDecomposer.decomposeOne', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('expands an epic into modules', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([
+          childPayload('module', 1),
+          childPayload('module', 2),
+        ]),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeOne({
+      parent: exampleParent,
+      childScope: 'module',
+    });
+
+    expect(out.childTickets.length).toBe(2);
+    expect(out.childTickets.every((c) => c.scope === 'module')).toBe(true);
+    expect(out.audit.parentNodeId).toBe('p');
+    expect(out.audit.childScope).toBe('module');
+    expect(out.audit.outcome).toBe('committed');
+    expect(out.judgeScores.coverage).toBeNull();
+    expect(out.judgeScores.disjointness).toBeNull();
+    expect(out.clarifyingQuestions).toEqual([]);
+  });
+
+  it('cancellation aborts before the LLM call', async () => {
+    const ollama = fakeOllama({
+      responses: [jsonResponse([childPayload('story', 1)])],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const ac = new AbortController();
+    ac.abort();
+
+    const engine = new PORecursiveDecomposer();
+    await expect(
+      engine.decomposeOne({
+        parent: { ...exampleParent, scope: 'module' },
+        childScope: 'story',
+        signal: ac.signal,
+      }),
+    ).rejects.toBeInstanceOf(PORecursiveDecomposerCancelled);
+  });
+});
+
+describe('PORecursiveDecomposer.decomposeRoot', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('respects the targetScope guard (story-targeted recursion stops at story)', async () => {
+    // Parent is module, target is story. The engine should run one
+    // expansion (module → stories) and then stop because every child
+    // is at the target scope.
+    const ollama = fakeOllama({
+      responses: [
+        // Expansion: module → stories
+        jsonResponse([
+          childPayload('story', 1, true),
+          childPayload('story', 2, true),
+        ]),
+        // Atomicity classifier responses (one per child)
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] }),
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'module' },
+      targetScope: 'story',
+    });
+
+    expect(out.tree.children.length).toBe(2);
+    expect(out.tree.children.every((c) => c.atomic)).toBe(true);
+    expect(out.audits.length).toBe(1);
+    expect(out.truncated).toBe(false);
+  });
+
+  it('halts at maxExpansions (truncated tree)', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([
+          childPayload('module', 1, false),
+          childPayload('module', 2, false),
+        ]),
+        jsonResponse({ atomic: false, confidence: 0.5, rationale: 'too big still', failedCriteria: ['something'] }),
+        jsonResponse({ atomic: false, confidence: 0.5, rationale: 'too big still', failedCriteria: ['something'] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'epic' },
+      targetScope: 'subtask',
+      maxExpansions: 1,
+    });
+
+    expect(out.truncated).toBe(true);
+    expect(out.audits.length).toBeLessThanOrEqual(1);
+  });
+
+  it('decomposes recursively all the way to atomicity', async () => {
+    // Chain: epic → 1 module → 1 story (atomic)
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([childPayload('module', 1, false)]),
+        jsonResponse({ atomic: false, confidence: 0.5, rationale: 'still too big', failedCriteria: ['something'] }),
+        jsonResponse([childPayload('story', 1, true)]),
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'INVEST passes', failedCriteria: [] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'epic' },
+      targetScope: 'subtask',
+    });
+
+    expect(out.audits.length).toBe(2);
+    expect(out.tree.children.length).toBe(1);
+    expect(out.tree.children[0]?.children.length).toBe(1);
+    expect(out.tree.children[0]?.children[0]?.atomic).toBe(true);
+  });
+
+  it('returns total cost + duration accumulators', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse([childPayload('module', 1, true)]),
+        jsonResponse({ atomic: true, confidence: 0.9, rationale: 'ok looks atomic', failedCriteria: [] }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: { ...exampleParent, scope: 'epic' },
+      targetScope: 'module',
+    });
+
+    expect(out.totalCostUsd).toBeGreaterThanOrEqual(0);
+    expect(out.totalDurationMs).toBeGreaterThan(0);
+    expect(out.totalCalls).toBeGreaterThan(0);
+  });
+});

--- a/packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts
+++ b/packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Empirical validation suite (PO-DECOMP-005).
+ *
+ * Drives the 10 PHASE2E-002 diverse prompts through the new
+ * recursive decomposer and asserts:
+ *
+ *   - the scope detector classifies each prompt to a sensible scope
+ *     (story / epic / module / initiative depending on prompt shape);
+ *   - the decomposer engine produces a non-empty children list for
+ *     non-atomic prompts and stops at the leaf for atomic ones;
+ *   - the judge pair runs and produces verdicts;
+ *   - cumulative cost + duration are tracked.
+ *
+ * The suite has TWO MODES:
+ *
+ *   1. STUB mode (default in CI): uses fakeOllama / fakeClaude with
+ *      hand-curated responses tailored to each prompt. Deterministic,
+ *      fast, free. Validates the SHAPE of the pipeline.
+ *
+ *   2. LIVE mode (operator-only): set DECOMPOSER_VALIDATION_LIVE=1.
+ *      Routes through real Ollama + Claude. Captures real-LLM target-
+ *      scope accuracy, child-count distributions, judge-pass rates,
+ *      total cost, total time. Writes a markdown report.
+ *
+ *      LIVE mode is skipped in CI because it requires Ollama running
+ *      and Claude API keys + costs real money. Operator runs it
+ *      ad-hoc on their workstation per the runbook in
+ *      caia/docs/po-recursive-decomposer.md.
+ *
+ * The 10 prompt fixtures are mirrored verbatim from
+ * apps/orchestrator/tests/e2e/pipeline/diverse-prompts.test.ts so the
+ * validation surface matches the existing PHASE2E-002 contract.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { detectScope } from '../src/scope-detector.js';
+import { classifyAtomicity } from '../src/atomicity-classifier.js';
+import { PORecursiveDecomposer } from '../src/decomposer.js';
+import { runJudgePair } from '../src/judges.js';
+import type { StoryScope } from '../src/types.js';
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+// ─── 10 PHASE2E-002 prompts (verbatim) ──────────────────────────────────
+
+interface PromptCase {
+  tag: string;
+  body: string;
+  /** Expected natural scope per the proposal's heuristics. */
+  expectedScope: StoryScope;
+  scenario:
+    | 'new-feature'
+    | 'bug-fix'
+    | 'enhancement'
+    | 'cross-domain'
+    | 'refactor'
+    | 'spike'
+    | 'multi-agent-collab'
+    | 'ea-heavy'
+    | 'test-heavy'
+    | 'chore';
+}
+
+export const PROMPT_FIXTURES: readonly PromptCase[] = [
+  {
+    tag: 'simple-feature',
+    scenario: 'new-feature',
+    body:
+      'add a user profile page with avatar upload and a display-name field; persist to the users table and render an Edit button',
+    expectedScope: 'story',
+  },
+  {
+    tag: 'bug-fix',
+    scenario: 'bug-fix',
+    body:
+      'fix the login button not responsive on mobile — at <375px viewport the click target shrinks below the WCAG 2.1 minimum and the button stops responding to taps',
+    expectedScope: 'task',
+  },
+  {
+    tag: 'enhancement',
+    scenario: 'enhancement',
+    body:
+      'add a filter dropdown to the existing dashboard table — the user can filter rows by domain (auth / payments / observability) and the URL reflects the active filter',
+    expectedScope: 'story',
+  },
+  {
+    tag: 'cross-domain',
+    scenario: 'cross-domain',
+    body:
+      'add real-time notifications — needs a WebSocket-based UI component, a BFF route to subscribe, a notifications database table, and observability metrics around connection lifecycle',
+    expectedScope: 'epic',
+  },
+  {
+    tag: 'refactor',
+    scenario: 'refactor',
+    body:
+      'extract the user-auth logic into a reusable @chiefaia/auth-core package — every app currently duplicates the JWT parsing and session validation; consolidate behind a typed API',
+    expectedScope: 'module',
+  },
+  {
+    tag: 'spike',
+    scenario: 'spike',
+    body:
+      'research the best caching library for our use case — compare lru-cache, node-cache, keyv, and redis-based options, document trade-offs in an ADR, and recommend one',
+    expectedScope: 'task',
+  },
+  {
+    tag: 'multi-agent-collab',
+    scenario: 'multi-agent-collab',
+    body:
+      'add e-commerce checkout — needs a UI checkout flow, a BFF /checkout route, integration with the Stripe payments API, and analytics events for cart abandonment + completion',
+    expectedScope: 'epic',
+  },
+  {
+    tag: 'ea-heavy',
+    scenario: 'ea-heavy',
+    body:
+      'migrate from Postgres to event-sourced architecture for orders — design the event log, projections, and the migration strategy from the existing CRUD model',
+    expectedScope: 'epic',
+  },
+  {
+    tag: 'test-heavy',
+    scenario: 'test-heavy',
+    body:
+      'add an accessibility audit pipeline + WCAG 2.1 AA conformance tests — every page rendered should pass axe-core checks; add a CI job that fails on regressions',
+    expectedScope: 'epic',
+  },
+  {
+    tag: 'chore',
+    scenario: 'chore',
+    body:
+      'update all @chiefaia/* package descriptions to be more descriptive — current descriptions read like internal codenames; rewrite for the open-source registry',
+    expectedScope: 'task',
+  },
+] as const;
+
+export const SCOPE_DETECTION_TOLERANCE: Record<string, StoryScope[]> = {
+  // Per the proposal's scope detector heuristics, some prompts are
+  // genuinely ambiguous between adjacent scopes (story↔task, epic↔module).
+  // The validation accepts any of the listed scopes as "correct".
+  'simple-feature': ['story', 'epic'],
+  'bug-fix': ['task', 'story', 'subtask'],
+  enhancement: ['story', 'epic'],
+  'cross-domain': ['epic', 'module'],
+  refactor: ['module', 'epic'],
+  spike: ['task', 'story'],
+  'multi-agent-collab': ['epic', 'module', 'initiative'],
+  'ea-heavy': ['epic', 'module', 'initiative'],
+  'test-heavy': ['epic', 'module', 'story'],
+  chore: ['task', 'story', 'subtask'],
+};
+
+// ─── STUB-mode validation (default — runs in CI) ────────────────────────
+
+describe('STUB validation: decomposer over PHASE2E-002 prompts', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('all 10 prompts have an expected scope mapping', () => {
+    expect(PROMPT_FIXTURES.length).toBe(10);
+    const tags = PROMPT_FIXTURES.map((p) => p.tag);
+    expect(new Set(tags).size).toBe(10);
+    for (const p of PROMPT_FIXTURES) {
+      expect(SCOPE_DETECTION_TOLERANCE[p.tag]).toBeDefined();
+      expect(SCOPE_DETECTION_TOLERANCE[p.tag]).toContain(p.expectedScope);
+    }
+  });
+
+  it.each(PROMPT_FIXTURES.map((p) => [p.tag, p]))(
+    'scope detector classifies %s into a tolerated scope (stub)',
+    async (_tag, prompt) => {
+      const p = prompt as PromptCase;
+      const ollama = fakeOllama({
+        responses: [
+          jsonResponse({
+            targetScope: p.expectedScope,
+            confidence: 0.85,
+            rationale: `stub classifier for ${p.tag}`,
+          }),
+        ],
+      });
+      installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+      const out = await detectScope({ promptText: p.body });
+      expect(SCOPE_DETECTION_TOLERANCE[p.tag]).toContain(out.targetScope);
+      expect(out.confidence).toBeGreaterThanOrEqual(0.5);
+    },
+  );
+
+  it('atomic-leaf prompts (story/task/subtask scope) reach atomic verdict in stub mode', async () => {
+    // Pick a story-scope prompt; classifier says atomic; engine should
+    // not recurse further.
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          atomic: true,
+          confidence: 0.9,
+          rationale: 'INVEST-compliant; single PR scope; testable AC',
+          failedCriteria: [],
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const verdict = await classifyAtomicity({
+      child: {
+        id: 'story-1',
+        scope: 'story',
+        title: 'add a logout button',
+        description: 'add logout button to the user-menu dropdown',
+        inScope: ['add the button', 'wire to existing /logout route'],
+        outOfScope: [],
+        dependencies: [],
+        estimatedAtomic: false,
+        existingArtifacts: [],
+        lifecycle: 'new',
+      },
+    });
+    expect(verdict.atomic).toBe(true);
+  });
+
+  it('engine produces a tree for an epic-shaped prompt (stub)', async () => {
+    // Stub: epic → 2 modules; both modules are atomic.
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          atomic: true,
+          confidence: 0.9,
+          rationale: 'bounded context; clear data ownership',
+          failedCriteria: [],
+        }),
+        jsonResponse({
+          atomic: true,
+          confidence: 0.9,
+          rationale: 'bounded context; clear data ownership',
+          failedCriteria: [],
+        }),
+      ],
+    });
+    const claude = fakeClaude({
+      responses: [
+        jsonResponse([
+          {
+            id: 'm1',
+            scope: 'module',
+            title: 'Notifications dispatcher',
+            description: 'WebSocket subscriber + dispatch loop with idempotency',
+            inScope: ['the dispatch loop and queue'],
+            outOfScope: [],
+            dependencies: [],
+            estimatedAtomic: false,
+            existingArtifacts: [],
+            lifecycle: 'new',
+          },
+          {
+            id: 'm2',
+            scope: 'module',
+            title: 'Notifications storage',
+            description: 'database table + persistence layer for notifications',
+            inScope: ['the notifications database table'],
+            outOfScope: [],
+            dependencies: [],
+            estimatedAtomic: false,
+            existingArtifacts: [],
+            lifecycle: 'new',
+          },
+        ]),
+      ],
+    });
+    installFakeAdapters(ollama, claude);
+
+    const engine = new PORecursiveDecomposer();
+    const out = await engine.decomposeRoot({
+      parent: {
+        id: 'root',
+        scope: 'epic',
+        title: 'Real-time notifications',
+        description: 'WebSocket-based notifications + storage + observability',
+        inScope: ['websocket UI', 'BFF route', 'notifications table', 'metrics'],
+        outOfScope: [],
+      },
+      targetScope: 'module',
+    });
+
+    expect(out.tree.children.length).toBe(2);
+    expect(out.tree.children.every((c) => c.atomic)).toBe(true);
+    expect(out.audits.length).toBe(1);
+    expect(out.totalCalls).toBeGreaterThan(0);
+  });
+
+  it('judge pair runs over a stub expansion and produces verdicts', async () => {
+    const claude = fakeClaude({
+      responses: [
+        {
+          ...jsonResponse({
+            score: 5,
+            covered: true,
+            missingDeliverables: [],
+            rationale: 'every prompt sentence maps to at least one child',
+          }),
+          match: 'PMBOK 100% rule',
+        },
+        {
+          ...jsonResponse({
+            score: 5,
+            disjoint: true,
+            overlaps: [],
+            rationale: 'no overlap between siblings',
+          }),
+          match: 'MECE-mutually-exclusive',
+        },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: {
+        title: 'Real-time notifications',
+        description: 'WebSocket + storage + metrics',
+        scope: 'epic',
+        inScope: ['websocket UI', 'BFF route', 'notifications table'],
+        outOfScope: [],
+      },
+      children: [
+        {
+          id: 'm1',
+          scope: 'module',
+          title: 'Notifications dispatcher',
+          description: 'WebSocket dispatcher with idempotency',
+          inScope: ['dispatcher'],
+          outOfScope: [],
+          dependencies: [],
+          estimatedAtomic: false,
+          existingArtifacts: [],
+          lifecycle: 'new',
+        },
+      ],
+    });
+    expect(result.coverage.passed).toBe(true);
+    expect(result.disjointness.passed).toBe(true);
+    expect(result.bothPassed).toBe(true);
+  });
+});
+
+// ─── LIVE-mode validation (operator runs ad-hoc) ────────────────────────
+
+const LIVE_MODE = process.env['DECOMPOSER_VALIDATION_LIVE'] === '1';
+
+describe.skipIf(!LIVE_MODE)('LIVE validation (real Ollama + Claude)', () => {
+  // This block is skipped in CI; the operator triggers it via:
+  //   DECOMPOSER_VALIDATION_LIVE=1 pnpm --filter @chiefaia/decomposer-recursive test
+  //
+  // Each prompt is run through the real router. The aggregate report
+  // is written to caia/docs/po-decomposer-validation-2026-04-30.md
+  // after the suite finishes (operator copies the table from stdout).
+
+  it.each(PROMPT_FIXTURES.map((p) => [p.tag, p]))(
+    'real-LLM scope detection of %s',
+    async (_tag, prompt) => {
+      const p = prompt as PromptCase;
+      const out = await detectScope({ promptText: p.body });
+      // eslint-disable-next-line no-console
+      console.log(
+        `[validation/${p.tag}] scope=${out.targetScope} confidence=${out.confidence.toFixed(2)} model=${out.model} duration=${String(out.durationMs)}ms`,
+      );
+      expect(SCOPE_DETECTION_TOLERANCE[p.tag]).toContain(out.targetScope);
+    },
+    60_000,
+  );
+});

--- a/packages/decomposer-recursive/tests/feature-flag.test.ts
+++ b/packages/decomposer-recursive/tests/feature-flag.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PO_USE_RECURSIVE_DECOMPOSER_ENV,
+  STAGE_PO_DECOMPOSING,
+  useRecursiveDecomposer,
+} from '../src/feature-flag.js';
+
+describe('STAGE_PO_DECOMPOSING', () => {
+  it('is the stable canonical pipeline-stage name', () => {
+    expect(STAGE_PO_DECOMPOSING).toBe('po_decomposing');
+  });
+});
+
+describe('PO_USE_RECURSIVE_DECOMPOSER_ENV', () => {
+  it('is the canonical env var name', () => {
+    expect(PO_USE_RECURSIVE_DECOMPOSER_ENV).toBe('PO_USE_RECURSIVE_DECOMPOSER');
+  });
+});
+
+describe('useRecursiveDecomposer', () => {
+  it('defaults to false when no env or value is provided', () => {
+    expect(useRecursiveDecomposer({ env: {} })).toBe(false);
+  });
+
+  it('respects explicit value=true', () => {
+    expect(useRecursiveDecomposer({ value: true })).toBe(true);
+  });
+
+  it('respects explicit value=false even when env is "1"', () => {
+    expect(
+      useRecursiveDecomposer({
+        value: false,
+        env: { PO_USE_RECURSIVE_DECOMPOSER: '1' },
+      }),
+    ).toBe(false);
+  });
+
+  it.each([['1'], ['true'], ['TRUE'], ['yes'], ['on']])(
+    'parses %s as true',
+    (raw) => {
+      expect(
+        useRecursiveDecomposer({ env: { PO_USE_RECURSIVE_DECOMPOSER: raw } }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([['0'], ['false'], ['no'], ['off'], ['']])(
+    'parses %s as false',
+    (raw) => {
+      expect(
+        useRecursiveDecomposer({ env: { PO_USE_RECURSIVE_DECOMPOSER: raw } }),
+      ).toBe(false);
+    },
+  );
+
+  it('handles whitespace + case-mixing', () => {
+    expect(
+      useRecursiveDecomposer({ env: { PO_USE_RECURSIVE_DECOMPOSER: '  TruE  ' } }),
+    ).toBe(true);
+  });
+});

--- a/packages/decomposer-recursive/tests/judges.test.ts
+++ b/packages/decomposer-recursive/tests/judges.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  JUDGE_PASS_THRESHOLD,
+  normaliseJudgeScore,
+  runJudgePair,
+} from '../src/judges.js';
+import type { ChildTicket } from '../src/types.js';
+import { fakeOllama, fakeClaude, installFakeAdapters, clearAdapters, jsonResponse } from './_helpers.js';
+
+const sampleParent = {
+  title: 'Build the billing module',
+  description: 'A billing module that handles checkout and invoicing',
+  scope: 'epic' as const,
+  inScope: ['stripe checkout', 'monthly invoice generation', 'webhook handler'],
+  outOfScope: ['tax calculation per region'],
+};
+
+function child(id: string, title: string): ChildTicket {
+  return {
+    id,
+    scope: 'module',
+    title,
+    description: `Description for ${title}`,
+    inScope: ['module-level item'],
+    outOfScope: [],
+    dependencies: [],
+    estimatedAtomic: false,
+    existingArtifacts: [],
+    lifecycle: 'new',
+  };
+}
+
+describe('runJudgePair', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('returns bothPassed=true when both scores >= threshold and no missing/overlap', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'every deliverable mapped' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'no overlap' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Checkout'), child('m2', 'Invoicing')],
+    });
+
+    expect(result.coverage.passed).toBe(true);
+    expect(result.disjointness.passed).toBe(true);
+    expect(result.bothPassed).toBe(true);
+    expect(result.reflexiveFeedback).toBe('');
+  });
+
+  it('reports coverage failure with a feedback block', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 3, covered: false, missingDeliverables: ['monthly invoice generation'], rationale: 'invoice generation has no child' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'no overlap' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Checkout')],
+    });
+
+    expect(result.coverage.passed).toBe(false);
+    expect(result.coverage.missingDeliverables).toContain('monthly invoice generation');
+    expect(result.disjointness.passed).toBe(true);
+    expect(result.bothPassed).toBe(false);
+    expect(result.reflexiveFeedback).toContain('Coverage judge — FAIL');
+    expect(result.reflexiveFeedback).toContain('monthly invoice generation');
+  });
+
+  it('reports disjointness failure with overlap detail', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'all covered' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 2, disjoint: false, overlaps: [{ childA: 'm1', childB: 'm2', overlapDescription: 'both modules own checkout state' }], rationale: 'overlap detected' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Checkout v1'), child('m2', 'Checkout v2')],
+    });
+
+    expect(result.coverage.passed).toBe(true);
+    expect(result.disjointness.passed).toBe(false);
+    expect(result.disjointness.overlaps.length).toBe(1);
+    expect(result.bothPassed).toBe(false);
+    expect(result.reflexiveFeedback).toContain('Disjointness judge — FAIL');
+    expect(result.reflexiveFeedback).toContain('m1 <-> m2');
+  });
+
+  it('force-corrects covered=true with non-empty missingDeliverables', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: ['something missing'], rationale: 'self-contradictory output' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'all good' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Mod')],
+    });
+
+    expect(result.coverage.passed).toBe(false); // force-corrected
+  });
+
+  it('force-corrects disjoint=true with non-empty overlaps', async () => {
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'all good' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [{ childA: 'a', childB: 'b', overlapDescription: 'overlap' }], rationale: 'self-contradictory' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('a', 'A'), child('b', 'B')],
+    });
+
+    expect(result.disjointness.passed).toBe(false);
+  });
+
+  it('runs the two judges in parallel (Promise.all)', async () => {
+    // We can verify parallel by looking at total cost = sum of both
+    // sub-call costs. Both go through Sonnet @ $0.40/1000 = $0.0004.
+    const claude = fakeClaude({
+      responses: [
+        { ...jsonResponse({ score: 5, covered: true, missingDeliverables: [], rationale: 'all good' }), match: 'PMBOK 100% rule' },
+        { ...jsonResponse({ score: 5, disjoint: true, overlaps: [], rationale: 'all good' }), match: 'MECE-mutually-exclusive' },
+      ],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await runJudgePair({
+      parent: sampleParent,
+      children: [child('m1', 'Mod')],
+    });
+
+    expect(result.coverage.costUsd).toBeCloseTo(0.0004, 5);
+    expect(result.disjointness.costUsd).toBeCloseTo(0.0004, 5);
+  });
+});
+
+describe('normaliseJudgeScore', () => {
+  it('maps 1 to 0', () => {
+    expect(normaliseJudgeScore(1)).toBe(0);
+  });
+  it('maps 5 to 1', () => {
+    expect(normaliseJudgeScore(5)).toBe(1);
+  });
+  it('maps 4 to 0.75', () => {
+    expect(normaliseJudgeScore(4)).toBeCloseTo(0.75);
+  });
+  it('clamps below 1 to 0', () => {
+    expect(normaliseJudgeScore(-2)).toBe(0);
+  });
+  it('clamps above 5 to 1', () => {
+    expect(normaliseJudgeScore(7)).toBe(1);
+  });
+});
+
+describe('JUDGE_PASS_THRESHOLD', () => {
+  it('is 4.0 per proposal §5F', () => {
+    expect(JUDGE_PASS_THRESHOLD).toBe(4.0);
+  });
+});

--- a/packages/decomposer-recursive/tests/schemas.test.ts
+++ b/packages/decomposer-recursive/tests/schemas.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AuditEntrySchema,
+  ChildTicketArraySchema,
+  ChildTicketSchema,
+  DependencyEdgeSchema,
+  DecompositionSchema,
+  ExistingArtifactRefSchema,
+  ScopeDetectionLlmOutputSchema,
+  AtomicityLlmOutputSchema,
+  StoryScopeSchema,
+} from '../src/schemas.js';
+import { STORY_SCOPES } from '../src/types.js';
+
+const validChild = {
+  id: 'c1',
+  scope: 'story' as const,
+  title: 'A perfectly fine title',
+  description: 'A description that is long enough to pass min-length',
+  inScope: ['inside scope item'],
+  outOfScope: [],
+  dependencies: [],
+  estimatedAtomic: true,
+  existingArtifacts: [],
+  lifecycle: 'new' as const,
+};
+
+describe('StoryScopeSchema', () => {
+  it('accepts every canonical scope', () => {
+    for (const s of STORY_SCOPES) {
+      expect(StoryScopeSchema.safeParse(s).success).toBe(true);
+    }
+  });
+  it('rejects non-canonical scopes', () => {
+    expect(StoryScopeSchema.safeParse('feature').success).toBe(false);
+    expect(StoryScopeSchema.safeParse('').success).toBe(false);
+    expect(StoryScopeSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe('ExistingArtifactRefSchema', () => {
+  it('accepts a feature ref', () => {
+    const r = ExistingArtifactRefSchema.safeParse({
+      source: 'feature',
+      id: 'feat_x',
+      name: 'Feature X',
+      score: 0.91,
+    });
+    expect(r.success).toBe(true);
+  });
+  it('rejects scores outside 0..1', () => {
+    expect(
+      ExistingArtifactRefSchema.safeParse({
+        source: 'feature',
+        id: 'feat_x',
+        name: 'Feature X',
+        score: 1.5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('ChildTicketSchema', () => {
+  it('accepts a valid child', () => {
+    expect(ChildTicketSchema.safeParse(validChild).success).toBe(true);
+  });
+  it('rejects a self-dependency', () => {
+    const bad = { ...validChild, dependencies: [validChild.id] };
+    expect(ChildTicketSchema.safeParse(bad).success).toBe(false);
+  });
+  it('rejects too-short titles', () => {
+    expect(ChildTicketSchema.safeParse({ ...validChild, title: 'hi' }).success).toBe(false);
+  });
+  it('accepts story with acceptanceCriteria', () => {
+    const r = ChildTicketSchema.safeParse({
+      ...validChild,
+      acceptanceCriteria: ['When the user clicks the button, the page navigates'],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('ChildTicketArraySchema', () => {
+  it('rejects siblings with duplicate ids', () => {
+    const dup = ChildTicketArraySchema.safeParse([validChild, validChild]);
+    expect(dup.success).toBe(false);
+  });
+  it('accepts unique siblings', () => {
+    const ok = ChildTicketArraySchema.safeParse([
+      validChild,
+      { ...validChild, id: 'c2' },
+    ]);
+    expect(ok.success).toBe(true);
+  });
+});
+
+describe('DependencyEdgeSchema', () => {
+  it('rejects self-loops', () => {
+    const r = DependencyEdgeSchema.safeParse({
+      fromChildId: 'a',
+      toChildId: 'a',
+      kind: 'blocks',
+      rationale: 'noop',
+    });
+    expect(r.success).toBe(false);
+  });
+  it('accepts a normal edge', () => {
+    const r = DependencyEdgeSchema.safeParse({
+      fromChildId: 'a',
+      toChildId: 'b',
+      kind: 'blocks',
+      rationale: 'because-data-model-first',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('AuditEntrySchema', () => {
+  it('accepts a complete audit row', () => {
+    const r = AuditEntrySchema.safeParse({
+      parentNodeId: 'p1',
+      parentScope: 'epic',
+      childScope: 'module',
+      attempt: 1,
+      promptTextHash: 'abc123',
+      model: 'claude-sonnet-4-6',
+      tokensIn: 100,
+      tokensOut: 50,
+      costUsd: 0.001,
+      durationMs: 250,
+      alternativesConsidered: 1,
+      coverageScore: null,
+      disjointnessScore: null,
+      ambiguityDetected: false,
+      questionsEmittedCount: 0,
+      decisionRationale: 'first attempt OK',
+      childrenCount: 3,
+      outcome: 'committed',
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('DecompositionSchema', () => {
+  it('accepts a minimal decomposition', () => {
+    const r = DecompositionSchema.safeParse({
+      childTickets: [validChild],
+      clarifyingQuestions: [],
+      dependencies: [],
+      confidence: 0.9,
+      judgeScores: { coverage: null, disjointness: null },
+      audit: {
+        parentNodeId: 'p',
+        parentScope: 'module',
+        childScope: 'story',
+        attempt: 1,
+        promptTextHash: 'h',
+        model: 'm',
+        tokensIn: 0,
+        tokensOut: 0,
+        costUsd: 0,
+        durationMs: 0,
+        alternativesConsidered: 0,
+        coverageScore: null,
+        disjointnessScore: null,
+        ambiguityDetected: false,
+        questionsEmittedCount: 0,
+        decisionRationale: '',
+        childrenCount: 1,
+        outcome: 'committed',
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('LLM-output schemas', () => {
+  it('ScopeDetectionLlmOutputSchema accepts a valid output', () => {
+    const r = ScopeDetectionLlmOutputSchema.safeParse({
+      targetScope: 'story',
+      confidence: 0.9,
+      rationale: 'one-verb-one-object',
+    });
+    expect(r.success).toBe(true);
+  });
+  it('AtomicityLlmOutputSchema accepts a valid output', () => {
+    const r = AtomicityLlmOutputSchema.safeParse({
+      atomic: true,
+      confidence: 0.8,
+      rationale: 'INVEST passes',
+      failedCriteria: [],
+    });
+    expect(r.success).toBe(true);
+  });
+  it('AtomicityLlmOutputSchema rejects out-of-range confidence', () => {
+    const r = AtomicityLlmOutputSchema.safeParse({
+      atomic: true,
+      confidence: 1.5,
+      rationale: 'oops',
+      failedCriteria: [],
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/decomposer-recursive/tests/scope-detector.test.ts
+++ b/packages/decomposer-recursive/tests/scope-detector.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { detectScope } from '../src/scope-detector.js';
+import { StructuredOutputParseError } from '../src/structured-output.js';
+
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+describe('detectScope', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('classifies a one-line story-shaped prompt as story', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'story',
+          confidence: 0.92,
+          rationale: 'one verb, one object, one concrete deliverable',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText: 'add a logout button to the user-menu dropdown',
+    });
+
+    expect(out.targetScope).toBe('story');
+    expect(out.confidence).toBeCloseTo(0.92);
+    expect(out.rationale).toMatch(/one verb/);
+    expect(out.model).toContain('qwen');
+  });
+
+  it('classifies a vision-doc-shaped prompt as initiative', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'initiative',
+          confidence: 0.86,
+          rationale: 'multi-feature, multi-team, multi-platform vision',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText:
+        'Build a poker analytics SaaS. Web + mobile + Stripe billing + Discord integration. Multi-team multi-quarter.',
+    });
+
+    expect(out.targetScope).toBe('initiative');
+    expect(out.confidence).toBeCloseTo(0.86);
+  });
+
+  it('passes the optional vision-doc summary into the prompt body', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'epic',
+          confidence: 0.7,
+          rationale: 'single epic scope per pre-extracted theme',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText: 'Re-vamp checkout',
+      visionDocSummary: 'Theme: cart abandonment, single-page checkout',
+    });
+
+    expect(out.targetScope).toBe('epic');
+    // The router was called once.
+    expect(ollama.generate).toHaveBeenCalledOnce();
+  });
+
+  it('retries when the model returns an out-of-range confidence', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ targetScope: 'task', confidence: 1.7, rationale: 'meh' }),
+        jsonResponse({
+          targetScope: 'task',
+          confidence: 0.55,
+          rationale: 'one concern, one tech sub-domain',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({ promptText: 'refactor the auth module' });
+    expect(out.targetScope).toBe('task');
+    expect(out.confidence).toBeCloseTo(0.55);
+  });
+
+  it('throws when the model never produces a valid scope', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ targetScope: 'feature', confidence: 0.5, rationale: 'meh' }),
+        jsonResponse({ targetScope: 'feature', confidence: 0.5, rationale: 'meh' }),
+        jsonResponse({ targetScope: 'feature', confidence: 0.5, rationale: 'meh' }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    await expect(detectScope({ promptText: 'whatever' })).rejects.toBeInstanceOf(
+      StructuredOutputParseError,
+    );
+  });
+
+  it('includes telemetry (model + durationMs)', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        {
+          response: JSON.stringify({
+            targetScope: 'subtask',
+            confidence: 0.99,
+            rationale: 'mechanical edit',
+          }),
+          model: 'qwen2.5-coder:7b',
+          durationMs: 17,
+        },
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({
+      promptText: 'rename _x to _internal in foo.ts',
+    });
+
+    expect(out.model).toBe('qwen2.5-coder:7b');
+    expect(out.durationMs).toBe(17);
+  });
+});

--- a/packages/decomposer-recursive/tests/structured-output.test.ts
+++ b/packages/decomposer-recursive/tests/structured-output.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+
+import {
+  callStructured,
+  extractJson,
+  StructuredOutputCancelled,
+  StructuredOutputParseError,
+} from '../src/structured-output.js';
+
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+  malformedResponse,
+} from './_helpers.js';
+
+const HappySchema = z.object({
+  word: z.string().min(1),
+  count: z.number().int().min(0),
+});
+
+describe('extractJson', () => {
+  it('parses a clean JSON object', () => {
+    expect(extractJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('strips ```json fences', () => {
+    const raw = 'Here you go:\n```json\n{"a":1}\n```\n';
+    expect(extractJson(raw)).toEqual({ a: 1 });
+  });
+
+  it('strips bare ``` fences', () => {
+    expect(extractJson('```\n{"x":42}\n```')).toEqual({ x: 42 });
+  });
+
+  it('greedy-matches outermost { ... }', () => {
+    expect(extractJson('lol talk talk { "y": 2 } more talk')).toEqual({ y: 2 });
+  });
+
+  it('returns null when no JSON is recoverable', () => {
+    expect(extractJson('absolutely no JSON here at all')).toBeNull();
+  });
+
+  it('handles trailing commas by failing softly (returns null)', () => {
+    expect(extractJson('{"a":1,}')).toBeNull();
+  });
+
+  it('handles nested objects', () => {
+    expect(extractJson('{"a": {"b": [1,2,3]}}')).toEqual({
+      a: { b: [1, 2, 3] },
+    });
+  });
+});
+
+describe('callStructured — happy paths', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('returns parsed data on a happy first attempt', async () => {
+    const ollama = fakeOllama({
+      responses: [jsonResponse({ word: 'hello', count: 3 })],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.data).toEqual({ word: 'hello', count: 3 });
+    expect(result.attempts).toBe(1);
+    expect(result.provider).toBe('local');
+    expect(result.costUsd).toBe(0);
+    expect(result.durationMs).toBe(25);
+  });
+
+  it('parses successfully through markdown fences', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        { response: '```json\n{"word":"ok","count":1}\n```', durationMs: 15 },
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.data).toEqual({ word: 'ok', count: 1 });
+    expect(result.attempts).toBe(1);
+  });
+
+  it('attributes Claude cost when the rule routes Claude', async () => {
+    const claude = fakeClaude({
+      responses: [jsonResponse({ word: 'claude', count: 7 })],
+    });
+    installFakeAdapters(fakeOllama({ responses: [] }), claude);
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-initiative',
+      systemPrompt: 'decompose',
+      userPrompt: 'big initiative',
+    });
+
+    expect(result.data).toEqual({ word: 'claude', count: 7 });
+    expect(result.provider).toBe('claude');
+    expect(result.costUsd).toBeCloseTo(0.002, 5);
+  });
+
+  it('reports the model and usage on the winning attempt', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        {
+          response: JSON.stringify({ word: 'hi', count: 1 }),
+          model: 'qwen2.5-coder:7b',
+          durationMs: 33,
+          usage: { promptTokens: 100, completionTokens: 12, totalTokens: 112 },
+        },
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.model).toBe('qwen2.5-coder:7b');
+    expect(result.usage?.promptTokens).toBe(100);
+    expect(result.usage?.completionTokens).toBe(12);
+  });
+});
+
+describe('callStructured — retry semantics', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('retries with feedback when the first response has wrong types', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ word: 'hi', count: 'not a number' }),
+        jsonResponse({ word: 'hi', count: 5 }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+      maxRetries: 2,
+    });
+
+    expect(result.data).toEqual({ word: 'hi', count: 5 });
+    expect(result.attempts).toBe(2);
+    expect(result.durationMs).toBe(50);
+  });
+
+  it('retries when the first response has no JSON at all', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        malformedResponse('no JSON for you'),
+        jsonResponse({ word: 'recovered', count: 2 }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const result = await callStructured(HappySchema, {
+      taskType: 'po-decomposer-scope-detection',
+      systemPrompt: 'classify',
+      userPrompt: 'do it',
+    });
+
+    expect(result.data).toEqual({ word: 'recovered', count: 2 });
+    expect(result.attempts).toBe(2);
+  });
+
+  it('throws StructuredOutputParseError after exhausting retries', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ word: 'a', count: 'still wrong' }),
+        jsonResponse({ word: 'a', count: 'still wrong' }),
+        jsonResponse({ word: 'a', count: 'still wrong' }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    await expect(
+      callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(StructuredOutputParseError);
+  });
+
+  it('preserves the original taskType + last raw on parse failure', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({ word: 'broken', count: 'nope' }),
+        jsonResponse({ word: 'broken', count: 'nope' }),
+        jsonResponse({ word: 'broken', count: 'nope' }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    try {
+      await callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        maxRetries: 2,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(StructuredOutputParseError);
+      const e = err as StructuredOutputParseError;
+      expect(e.taskType).toBe('po-decomposer-scope-detection');
+      expect(e.attempts).toBe(3);
+      expect(e.lastRaw).toContain('"word":"broken"');
+    }
+  });
+
+  it('respects a maxRetries=0 setting (single attempt only)', async () => {
+    const ollama = fakeOllama({
+      responses: [malformedResponse('no json')],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    await expect(
+      callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        maxRetries: 0,
+      }),
+    ).rejects.toBeInstanceOf(StructuredOutputParseError);
+  });
+});
+
+describe('callStructured — cancellation', () => {
+  beforeEach(() => clearAdapters());
+  afterEach(() => clearAdapters());
+
+  it('honours an aborted signal before the first attempt', async () => {
+    const ollama = fakeOllama({
+      responses: [jsonResponse({ word: 'ok', count: 1 })],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const ac = new AbortController();
+    ac.abort();
+
+    await expect(
+      callStructured(HappySchema, {
+        taskType: 'po-decomposer-scope-detection',
+        systemPrompt: 'classify',
+        userPrompt: 'do it',
+        signal: ac.signal,
+      }),
+    ).rejects.toBeInstanceOf(StructuredOutputCancelled);
+  });
+});

--- a/packages/decomposer-recursive/tsconfig.json
+++ b/packages/decomposer-recursive/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}

--- a/packages/decomposer-recursive/vitest.config.ts
+++ b/packages/decomposer-recursive/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();

--- a/packages/decomposer/src/claude-decomposer.ts
+++ b/packages/decomposer/src/claude-decomposer.ts
@@ -1,5 +1,16 @@
 import type { DecompositionResult, DecomposerConfig } from './types';
 
+/**
+ * @deprecated since 2026-04-30 / PO-DECOMP-### track.
+ *
+ * Single-shot Claude decomposer kept as the production path until the
+ * recursive engine in @chiefaia/decomposer-recursive ships P1 wiring.
+ * The new engine is gated by useRecursiveDecomposer() (env var
+ * PO_USE_RECURSIVE_DECOMPOSER, default OFF in P0).
+ *
+ * Empirical validation report: caia/docs/po-decomposer-validation-2026-04-30.md
+ */
+
 const DECOMPOSER_SYSTEM_PROMPT = `You are an expert product manager and software architect. Your job is to decompose user requirements into a structured hierarchy of work items.
 
 Given a prompt from a user, produce a JSON hierarchy with this exact structure:

--- a/packages/local-llm-router/src/routing-config.ts
+++ b/packages/local-llm-router/src/routing-config.ts
@@ -194,6 +194,126 @@ export const ROUTING_RULES: RoutingRule[] = [
     estimatedCostClaude: '$1.50',
   },
 
+  // ─── PO recursive decomposer (PO-DECOMP-### track) ───────────────────────
+  // Per the proposal in `reports/po-decomposition-architecture-proposal-2026-04-29.md`,
+  // the recursive decomposer fans out into a small number of task-types:
+  // classification (Ollama-first), per-scope decomposition (Sonnet for high
+  // scopes, Ollama-first for deep scopes), and a judge pair (Sonnet, with
+  // ensemble for initiative/epic).
+  {
+    taskType: 'po-decomposer-scope-detection',
+    description:
+      'Adaptive scope detector — classify a prompt as initiative | epic | ' +
+      'module | story | task | subtask. Cheap classification call.',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 400,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.04',
+  },
+  {
+    taskType: 'po-decomposer-atomicity-classification',
+    description:
+      'Per-scope atomicity classifier — does a candidate child satisfy the ' +
+      'INVEST/SAFe/DDD rubric for its scope? Cheap classification call.',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 600,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.06',
+  },
+  {
+    taskType: 'po-decomposer-initiative',
+    description:
+      'Initiative → epic decomposition. High-stakes (multi-quarter scope).',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'po-decomposer-epic',
+    description:
+      'Epic → module decomposition. High-stakes (single PI scope).',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'po-decomposer-module',
+    description:
+      'Module → story decomposition. Medium-stakes (bounded-context scope).',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 6000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.50',
+  },
+  {
+    taskType: 'po-decomposer-story',
+    description:
+      'Story → task decomposition. Medium-stakes (single-PR scope).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'po-decomposer-task',
+    description:
+      'Task → subtask decomposition. Low-stakes (single-day scope) — Ollama-first.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 3000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.75',
+  },
+  {
+    taskType: 'po-decomposer-subtask',
+    description:
+      'Subtask → mechanical-step decomposition. Rarely needed; Ollama-first.',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'po-decomposer-coverage-judge',
+    description:
+      'Parent-coverage MECE judge. Did the children cover the parent\'s scope? ' +
+      'Sonnet — judging is high-leverage low-cost relative to regenerating downstream.',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.40',
+  },
+  {
+    taskType: 'po-decomposer-disjointness-judge',
+    description:
+      'Sibling-disjointness MECE judge. Do any two children overlap?',
+    localModel: 'qwen3:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.40',
+  },
+
   // ─── CLAUDE ONLY — still too high-stakes for the local path ──────────────
   {
     taskType: 'hierarchy-decomposition',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,40 @@ importers:
         specifier: ^5.0.0
         version: 5.1.9
 
+  packages/decomposer-recursive:
+    dependencies:
+      '@chiefaia/local-llm-router':
+        specifier: workspace:*
+        version: link:../local-llm-router
+      '@chiefaia/ticket-template':
+        specifier: workspace:*
+        version: link:../ticket-template
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.9
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/dedup-engine: {}
 
   packages/dev-inspector:


### PR DESCRIPTION
## release(2026-04-30-po-decomposer-p0-v2): PO recursive decomposer P0 → main

Replaces #218. The original release branch contained 13 prior commits whose content was already squash-merged to main as #211 (safety-hardening) and #212 (run-modes), causing potential conflicts when merging to main. This v2 branch is cut fresh from `origin/main` and contains only the 5 PO-DECOMP cherry-picks.

### Squash-merge commits cherry-picked from develop

- `9ab5a71` — feat(decomposer-recursive): scope detector + atomicity classifier + Zod schemas (PO-DECOMP-001) (#213)
  — develop SHA: `85f5c0180adc423e3a828034855e213d4bdfd064`
- `629f0fe` — feat(decomposer-recursive): PORecursiveDecomposer engine + per-scope prompts (PO-DECOMP-002) (#214)
  — develop SHA: `4cd80f15157e2e6fa71c42e881796b84e1cb34ce`
- `b9db9b7` — feat(decomposer-recursive): MECE judge pair — coverage + disjointness (PO-DECOMP-003) (#215)
  — develop SHA: `93ce49c04844d01ad855dc34d4cff28ec337b6e6`
- `3d31e92` — feat(decomposer-recursive): feature flag + stage name + legacy deprecation (PO-DECOMP-004) (#217)
  — develop SHA: `56825facdbca107612b75afc1135b0919e7e568d`
- `2561d72` — feat(decomposer-recursive): empirical validation + operator runbook (PO-DECOMP-005) (#216)
  — develop SHA: `6fc0d700df212d0871fab9c962ddce58ba3f7c11`

### Verification

- Local `pnpm install --frozen-lockfile` clean
- Local `pnpm -w run typecheck` 43/43 pass
- Validation suite (84/84, 10 LIVE-skipped) verified on develop merges
- Feature flag `PO_USE_RECURSIVE_DECOMPOSER` defaults OFF in P0 (safe to ship)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recursive decomposition capability to break down large work items (initiatives, epics, modules) into smaller, atomic tasks
  * Introduced scope detection to classify work item size and complexity automatically
  * Added validation judges to ensure decompositions are complete and non-overlapping
  * Feature flag (`PO_USE_RECURSIVE_DECOMPOSER`) to control rollout

* **Documentation**
  * Added validation report confirming the recursive decomposer meets quality thresholds
  * Added operator runbook with usage examples and debugging guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->