### PR TITLE
feat(ea-mesh): domain triage classifier (EA-MESH-002)

### DIFF
--- a/apps/orchestrator/src/agents/__tests__/domain-triage.test.ts
+++ b/apps/orchestrator/src/agents/__tests__/domain-triage.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runDomainTriage, MACRO_DOMAINS, type MacroDomain } from '../domain-triage';
+import * as router from '@chiefaia/local-llm-router';
+
+// Mock the router
+vi.mock('@chiefaia/local-llm-router', () => ({
+  route: vi.fn(),
+}));
+
+describe('runDomainTriage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should classify simple UI feature as ui only', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Add user profile page',
+        description: 'Create a React component to display user avatar and display-name',
+        primaryDomain: 'ui-frontend',
+      },
+      { keywordOnly: true }, // Skip LLM for determinism
+    );
+
+    expect(result.inScopeDomains).toContain('ui');
+  });
+
+  it('should classify cross-domain feature as multiple domains', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Add real-time notifications',
+        description: 'WebSocket UI component, BFF subscription route, notifications DB table, observability metrics',
+        primaryDomain: 'api-integration',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toEqual(expect.arrayContaining(['ui', 'backend', 'data', 'platform']));
+  });
+
+  it('should classify data migration as data domain', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Migrate orders to event sourcing',
+        description: 'Design event log, projections, and backfill strategy from CRUD',
+        primaryDomain: 'data-storage',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toContain('data');
+  });
+
+  it('should classify security work as quality-security', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Add WCAG 2.1 AA conformance tests',
+        description: 'axe-core audit pipeline, CI job that fails on regressions',
+        primaryDomain: 'ui-frontend',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toContain('quality-security');
+  });
+
+  it('should classify infrastructure work as platform', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Add observability instrumentation',
+        description: 'Add logging, metrics, and traces to all services',
+        primaryDomain: 'devops',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toContain('platform');
+  });
+
+  it('should classify Stripe integration as integrations', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Add Stripe checkout',
+        description: 'Integrate Stripe payment API, handle webhooks',
+        primaryDomain: 'api-integration',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toContain('integrations');
+  });
+
+  it('should default to backend if no domains match', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Update README',
+        description: 'Make the documentation more descriptive',
+        primaryDomain: 'backend',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toContain('backend');
+  });
+
+  it('should always return sorted domains', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'Add real-time notifications with secure auth',
+        description: 'WebSocket, BFF, DB, observability, security audit',
+        primaryDomain: 'api-integration',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toEqual([...result.inScopeDomains].sort());
+  });
+
+  it('should fallback to keywords on LLM failure', async () => {
+    vi.mocked(router.route).mockRejectedValue(new Error('Ollama unavailable'));
+
+    const result = await runDomainTriage({
+      title: 'Add user profile page with database',
+      description: 'React component + Postgres schema + API route',
+      primaryDomain: 'api-integration',
+    });
+
+    // Should have fallen back to keyword pass
+    expect(result.inScopeDomains).toBeDefined();
+    expect(result.inScopeDomains.length).toBeGreaterThan(0);
+  });
+
+  it('should include all domains for multi-agent collab stories', async () => {
+    const result = await runDomainTriage(
+      {
+        title: 'E-commerce checkout feature',
+        description: `
+          UI: React checkout flow
+          Backend: BFF /checkout route, order service, payment orchestration
+          Data: orders table, payment logs
+          Platform: observability for payment pipeline
+          Quality: security audit, payment compliance
+          Integrations: Stripe API, analytics
+        `,
+        primaryDomain: 'api-integration',
+      },
+      { keywordOnly: true },
+    );
+
+    expect(result.inScopeDomains).toEqual(
+      expect.arrayContaining(['ui', 'backend', 'data', 'platform', 'quality-security', 'integrations']),
+    );
+  });
+
+  it('should have valid macro-domain values', async () => {
+    const result = await runDomainTriage({
+      title: 'Any ticket',
+      description: 'Any description',
+    });
+
+    for (const domain of result.inScopeDomains) {
+      expect(MACRO_DOMAINS).toContain(domain as MacroDomain);
+    }
+  });
+});

--- a/apps/orchestrator/src/agents/domain-triage.ts
+++ b/apps/orchestrator/src/agents/domain-triage.ts
@@ -1,0 +1,219 @@
+/**
+ * Domain Triage Classifier (EA Multi-Domain Decomposition PR 2).
+ *
+ * Takes a ticket's title + description and determines which of 6 macro-domains
+ * are in scope for the EA specialist mesh:
+ * - ui: frontend / design / accessibility / UX
+ * - backend: services / APIs / orchestration / async processing
+ * - data: storage / schemas / migrations / ETL
+ * - platform: infrastructure / deployment / observability / CI-CD
+ * - quality-security: testing / a11y / security / performance
+ * - integrations: external services / webhooks / SDKs
+ *
+ * Runs as Stage 1 of the mesh pipeline, before domain-specialists.ts.
+ * Output: the set of inScopeDomains that will be parallelized in Stage 2.
+ */
+
+import { z } from 'zod';
+import { TECH_SUB_DOMAINS, type TechSubDomain, type TicketBundle } from '@chiefaia/ticket-template';
+import { route } from '@chiefaia/local-llm-router';
+import { inferTechSubDomains } from './ea-agent';
+
+// ─── Macro-domain definitions ──────────────────────────────────────────────────
+
+export type MacroDomain =
+  | 'ui'
+  | 'backend'
+  | 'data'
+  | 'platform'
+  | 'quality-security'
+  | 'integrations';
+
+export const MACRO_DOMAINS = ['ui', 'backend', 'data', 'platform', 'quality-security', 'integrations'] as const;
+
+/**
+ * Map from TECH_SUB_DOMAINS to macro-categories per proposal §5.1.
+ * This is the breadth routing: which specialists should be activated.
+ */
+const TECH_TO_MACRO: Record<TechSubDomain, MacroDomain> = {
+  // UI domain
+  'frontend': 'ui',
+  'design-system': 'ui',
+  'accessibility': 'ui',
+  'web-analytics': 'ui',
+  'seo': 'ui',
+  'localization-i18n': 'ui',
+
+  // Backend domain
+  'bff': 'backend',
+  'backend': 'backend',
+  'api-gateway': 'backend',
+  'agent-runtime': 'backend',
+  'event-driven': 'backend',
+  'auth': 'backend',
+  'caching': 'backend',
+  'rate-limiting': 'backend',
+  'file-storage': 'backend',
+  'feature-flags': 'backend',
+  'websockets': 'backend',
+
+  // Data domain
+  'database': 'data',
+  'data-migration': 'data',
+  'data-pipeline': 'data',
+
+  // Platform domain
+  'observability': 'platform',
+  'monitoring-alerting': 'platform',
+  'infra': 'platform',
+  'ci-cd': 'platform',
+  'cron-scheduling': 'platform',
+  'secrets-management': 'platform',
+  'dependency-management': 'platform',
+
+  // Quality-security domain
+  'testing': 'quality-security',
+  'security': 'quality-security',
+  'performance': 'quality-security',
+
+  // Integrations domain
+  'crm': 'integrations',
+  'cms': 'integrations',
+  'search': 'integrations',
+  'payments': 'integrations',
+  'email': 'integrations',
+  'ml-ai': 'integrations',
+
+  // Cross-cutting (can map to multiple, but we'll pick the primary for simplicity in P0)
+  'documentation': 'backend', // Defaults to backend but could span any
+  'prompt-engineering': 'backend', // Agent-related
+  'ticket-template': 'backend', // Infra
+};
+
+// ─── Output schema (Zod for LLM response parsing) ────────────────────────────
+
+const TriageResultSchema = z.object({
+  inScopeDomains: z.array(z.enum(MACRO_DOMAINS)).describe('Macro-domains in scope for specialist mesh'),
+  reasoning: z.string().optional().describe('Why these domains were chosen'),
+});
+
+export type TriageResult = z.infer<typeof TriageResultSchema>;
+
+// ─── Triage logic ──────────────────────────────────────────────────────────────
+
+/**
+ * Run keyword-based triage as the first pass (fast, deterministic).
+ * Returns the set of macro-domains inferred from tech sub-domains.
+ */
+function keywordTriage(text: string, primaryDomain: string): Set<MacroDomain> {
+  const { all: techDomains } = inferTechSubDomains(text, primaryDomain);
+  const macros = new Set<MacroDomain>();
+  for (const tech of techDomains) {
+    const macro = TECH_TO_MACRO[tech];
+    if (macro) macros.add(macro);
+  }
+  // Always include backend as a baseline — most stories touch some service logic
+  if (macros.size === 0) macros.add('backend');
+  return macros;
+}
+
+/**
+ * Run LLM-based triage to refine the keyword pass (validates hypothesis).
+ * Uses the local router with Ollama-first, Claude fallback.
+ */
+async function llmTriage(
+  text: string,
+  keywordDomains: Set<MacroDomain>,
+): Promise<Set<MacroDomain>> {
+  const domainsList = Array.from(keywordDomains).join(', ');
+  const prompt = `
+You are a domain classification assistant for a code generation system.
+
+Given the following ticket:
+---
+${text}
+---
+
+The keyword classifier identified these macro-domains as likely in scope:
+${domainsList}
+
+For each domain below, answer YES or NO (briefly):
+1. UI (frontend / design / accessibility / UX) — does this ticket involve UI work?
+2. Backend (services / APIs / orchestration / async) — does this ticket involve backend work?
+3. Data (storage / schemas / migrations / ETL) — does this ticket involve data modeling or migration?
+4. Platform (infra / observability / CI-CD) — does this ticket involve platform/operational work?
+5. Quality-Security (testing / a11y / security / performance) — does this ticket primarily focus on QA/security/perf?
+6. Integrations (external services / webhooks) — does this ticket involve external service integrations?
+
+Return a JSON object with field inScopeDomains containing the list of domain IDs that are definitely in scope.
+Only include domains where the answer is YES.
+`;
+
+  try {
+    const response = await route('domain-triage', prompt, { forceLocal: true });
+    const parsed = JSON.parse(response.text);
+    const refined = new Set<MacroDomain>();
+    for (const domain of parsed.inScopeDomains || []) {
+      if (MACRO_DOMAINS.includes(domain)) {
+        refined.add(domain);
+      }
+    }
+    // If LLM excluded everything, fall back to keywords
+    return refined.size > 0 ? refined : keywordDomains;
+  } catch (err) {
+    // If LLM fails, fall back gracefully to keyword pass
+    console.warn('[domain-triage] LLM call failed, using keyword domains:', err);
+    return keywordDomains;
+  }
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────────
+
+export interface DomainTriageOptions {
+  /** Force local Ollama (no Claude fallback). Defaults true for triage. */
+  forceLocal?: boolean;
+  /** Skip LLM pass, use keywords only. Useful for testing. */
+  keywordOnly?: boolean;
+}
+
+/**
+ * Run domain triage to determine which macro-domains are in scope for specialists.
+ *
+ * @param ticketData The ticket to classify (title + description).
+ * @param options Routing overrides.
+ * @returns The set of inScopeDomains for Stage 2 specialists.
+ */
+export async function runDomainTriage(
+  ticketData: { title: string; description: string; primaryDomain?: string },
+  options: DomainTriageOptions = {},
+): Promise<TriageResult> {
+  const text = `${ticketData.title}\n${ticketData.description || ''}`;
+  const primaryDomain = ticketData.primaryDomain || 'backend';
+
+  // Stage 1: Keyword triage (fast)
+  const keywordDomains = keywordTriage(text, primaryDomain);
+
+  // Stage 2: LLM refinement (optional, validation)
+  let refinedDomains: Set<MacroDomain>;
+  if (options.keywordOnly) {
+    refinedDomains = keywordDomains;
+  } else {
+    refinedDomains = await llmTriage(text, keywordDomains);
+  }
+
+  return {
+    inScopeDomains: Array.from(refinedDomains).sort(),
+    reasoning: `Keyword pass: ${Array.from(keywordDomains).join(', ')}. LLM refined to: ${Array.from(refinedDomains).join(', ')}`,
+  };
+}
+
+export async function runDomainTriageFromBundle(
+  ticketData: TicketBundle,
+  options: DomainTriageOptions = {},
+): Promise<TriageResult> {
+  return runDomainTriage({
+    title: ticketData.story.title,
+    description: ticketData.story.description || '',
+    primaryDomain: ticketData.story.primaryDomain,
+  }, options);
+}

--- a/apps/orchestrator/src/agents/domain-triage.ts
+++ b/apps/orchestrator/src/agents/domain-triage.ts
@@ -15,25 +15,24 @@
  */
 
 import { z } from 'zod';
-import { TECH_SUB_DOMAINS, type TechSubDomain, type TicketBundle } from '@chiefaia/ticket-template';
+import type { TechSubDomain } from '@chiefaia/ticket-template';
 import { route } from '@chiefaia/local-llm-router';
+import { classifyKeyword } from '@chiefaia/classifier';
 import { inferTechSubDomains } from './ea-agent';
+import type { TicketBundle } from '../api/ticket-bundle';
 
 // ─── Macro-domain definitions ──────────────────────────────────────────────────
 
-export type MacroDomain =
-  | 'ui'
-  | 'backend'
-  | 'data'
-  | 'platform'
-  | 'quality-security'
-  | 'integrations';
-
 export const MACRO_DOMAINS = ['ui', 'backend', 'data', 'platform', 'quality-security', 'integrations'] as const;
+
+export type MacroDomain = (typeof MACRO_DOMAINS)[number];
 
 /**
  * Map from TECH_SUB_DOMAINS to macro-categories per proposal §5.1.
  * This is the breadth routing: which specialists should be activated.
+ *
+ * MUST cover every member of TECH_SUB_DOMAINS — the Record<TechSubDomain,...>
+ * type guarantees this at compile-time.
  */
 const TECH_TO_MACRO: Record<TechSubDomain, MacroDomain> = {
   // UI domain
@@ -75,6 +74,7 @@ const TECH_TO_MACRO: Record<TechSubDomain, MacroDomain> = {
   'testing': 'quality-security',
   'security': 'quality-security',
   'performance': 'quality-security',
+  'compliance': 'quality-security',
 
   // Integrations domain
   'crm': 'integrations',
@@ -84,10 +84,10 @@ const TECH_TO_MACRO: Record<TechSubDomain, MacroDomain> = {
   'email': 'integrations',
   'ml-ai': 'integrations',
 
-  // Cross-cutting (can map to multiple, but we'll pick the primary for simplicity in P0)
-  'documentation': 'backend', // Defaults to backend but could span any
-  'prompt-engineering': 'backend', // Agent-related
-  'ticket-template': 'backend', // Infra
+  // Cross-cutting (default to backend; specialists handle nuance in Stage 2)
+  'documentation': 'backend',
+  'prompt-engineering': 'backend',
+  'ticket-template': 'backend',
 };
 
 // ─── Output schema (Zod for LLM response parsing) ────────────────────────────
@@ -109,7 +109,8 @@ function keywordTriage(text: string, primaryDomain: string): Set<MacroDomain> {
   const { all: techDomains } = inferTechSubDomains(text, primaryDomain);
   const macros = new Set<MacroDomain>();
   for (const tech of techDomains) {
-    const macro = TECH_TO_MACRO[tech];
+    // inferTechSubDomains returns string[]; widen the Record lookup safely.
+    const macro = (TECH_TO_MACRO as Record<string, MacroDomain | undefined>)[tech];
     if (macro) macros.add(macro);
   }
   // Always include backend as a baseline — most stories touch some service logic
@@ -151,11 +152,12 @@ Only include domains where the answer is YES.
 
   try {
     const response = await route('domain-triage', prompt, { forceLocal: true });
-    const parsed = JSON.parse(response.text);
+    const parsed = JSON.parse(response.response) as { inScopeDomains?: unknown };
     const refined = new Set<MacroDomain>();
-    for (const domain of parsed.inScopeDomains || []) {
-      if (MACRO_DOMAINS.includes(domain)) {
-        refined.add(domain);
+    const list = Array.isArray(parsed.inScopeDomains) ? parsed.inScopeDomains : [];
+    for (const domain of list) {
+      if (typeof domain === 'string' && (MACRO_DOMAINS as readonly string[]).includes(domain)) {
+        refined.add(domain as MacroDomain);
       }
     }
     // If LLM excluded everything, fall back to keywords
@@ -202,18 +204,28 @@ export async function runDomainTriage(
   }
 
   return {
-    inScopeDomains: Array.from(refinedDomains).sort(),
+    inScopeDomains: Array.from(refinedDomains).sort() as MacroDomain[],
     reasoning: `Keyword pass: ${Array.from(keywordDomains).join(', ')}. LLM refined to: ${Array.from(refinedDomains).join(', ')}`,
   };
 }
 
+/**
+ * Bundle-friendly variant: pulls title/description from a TicketBundle and
+ * derives primaryDomain via classifyKeyword (mirroring ba-agent + ea-agent).
+ */
 export async function runDomainTriageFromBundle(
-  ticketData: TicketBundle,
+  bundle: TicketBundle,
   options: DomainTriageOptions = {},
 ): Promise<TriageResult> {
-  return runDomainTriage({
-    title: ticketData.story.title,
-    description: ticketData.story.description || '',
-    primaryDomain: ticketData.story.primaryDomain,
-  }, options);
+  const title = bundle.story.title;
+  const description = bundle.story.description || '';
+  const classification = classifyKeyword(`${title} ${description}`);
+  return runDomainTriage(
+    {
+      title,
+      description,
+      primaryDomain: classification.primaryDomain,
+    },
+    options,
+  );
 }

--- a/apps/orchestrator/tests/agents/domain-triage.test.ts
+++ b/apps/orchestrator/tests/agents/domain-triage.test.ts
@@ -1,44 +1,54 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { runDomainTriage, MACRO_DOMAINS, type MacroDomain } from '../domain-triage';
+/**
+ * Domain Triage classifier tests (EA-MESH-002).
+ *
+ * Covers keyword-pass triage (deterministic) plus LLM-fallback resilience
+ * when the local-llm-router throws. Macro-domains: ui, backend, data,
+ * platform, quality-security, integrations.
+ */
+
+import { runDomainTriage, MACRO_DOMAINS, type MacroDomain } from '../../src/agents/domain-triage';
 import * as router from '@chiefaia/local-llm-router';
 
-// Mock the router
-vi.mock('@chiefaia/local-llm-router', () => ({
-  route: vi.fn(),
+jest.mock('@chiefaia/local-llm-router', () => ({
+  __esModule: true,
+  route: jest.fn(),
 }));
+
+const routeMock = router.route as jest.MockedFunction<typeof router.route>;
 
 describe('runDomainTriage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    routeMock.mockReset();
   });
 
-  it('should classify simple UI feature as ui only', async () => {
+  it('classifies a simple UI feature as ui', async () => {
     const result = await runDomainTriage(
       {
         title: 'Add user profile page',
         description: 'Create a React component to display user avatar and display-name',
         primaryDomain: 'ui-frontend',
       },
-      { keywordOnly: true }, // Skip LLM for determinism
+      { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toContain('ui');
   });
 
-  it('should classify cross-domain feature as multiple domains', async () => {
+  it('classifies cross-domain stories as multiple domains', async () => {
     const result = await runDomainTriage(
       {
         title: 'Add real-time notifications',
-        description: 'WebSocket UI component, BFF subscription route, notifications DB table, observability metrics',
+        description:
+          'WebSocket UI component, BFF subscription route, notifications DB table, observability metrics',
         primaryDomain: 'api-integration',
       },
       { keywordOnly: true },
     );
-
-    expect(result.inScopeDomains).toEqual(expect.arrayContaining(['ui', 'backend', 'data', 'platform']));
+    expect(result.inScopeDomains).toEqual(
+      expect.arrayContaining(['ui', 'backend', 'data', 'platform']),
+    );
   });
 
-  it('should classify data migration as data domain', async () => {
+  it('classifies data migration as data domain', async () => {
     const result = await runDomainTriage(
       {
         title: 'Migrate orders to event sourcing',
@@ -47,11 +57,10 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toContain('data');
   });
 
-  it('should classify security work as quality-security', async () => {
+  it('classifies a11y/security work as quality-security', async () => {
     const result = await runDomainTriage(
       {
         title: 'Add WCAG 2.1 AA conformance tests',
@@ -60,11 +69,10 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toContain('quality-security');
   });
 
-  it('should classify infrastructure work as platform', async () => {
+  it('classifies infrastructure work as platform', async () => {
     const result = await runDomainTriage(
       {
         title: 'Add observability instrumentation',
@@ -73,11 +81,10 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toContain('platform');
   });
 
-  it('should classify Stripe integration as integrations', async () => {
+  it('classifies Stripe integration as integrations', async () => {
     const result = await runDomainTriage(
       {
         title: 'Add Stripe checkout',
@@ -86,11 +93,10 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toContain('integrations');
   });
 
-  it('should default to backend if no domains match', async () => {
+  it('defaults to backend if no domains match the keyword pass', async () => {
     const result = await runDomainTriage(
       {
         title: 'Update README',
@@ -99,11 +105,10 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toContain('backend');
   });
 
-  it('should always return sorted domains', async () => {
+  it('returns sorted domains', async () => {
     const result = await runDomainTriage(
       {
         title: 'Add real-time notifications with secure auth',
@@ -112,12 +117,11 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toEqual([...result.inScopeDomains].sort());
   });
 
-  it('should fallback to keywords on LLM failure', async () => {
-    vi.mocked(router.route).mockRejectedValue(new Error('Ollama unavailable'));
+  it('falls back to keyword pass when the LLM call rejects', async () => {
+    routeMock.mockRejectedValueOnce(new Error('Ollama unavailable'));
 
     const result = await runDomainTriage({
       title: 'Add user profile page with database',
@@ -125,12 +129,11 @@ describe('runDomainTriage', () => {
       primaryDomain: 'api-integration',
     });
 
-    // Should have fallen back to keyword pass
     expect(result.inScopeDomains).toBeDefined();
     expect(result.inScopeDomains.length).toBeGreaterThan(0);
   });
 
-  it('should include all domains for multi-agent collab stories', async () => {
+  it('flags all six domains for an end-to-end e-commerce story', async () => {
     const result = await runDomainTriage(
       {
         title: 'E-commerce checkout feature',
@@ -146,18 +149,17 @@ describe('runDomainTriage', () => {
       },
       { keywordOnly: true },
     );
-
     expect(result.inScopeDomains).toEqual(
       expect.arrayContaining(['ui', 'backend', 'data', 'platform', 'quality-security', 'integrations']),
     );
   });
 
-  it('should have valid macro-domain values', async () => {
+  it('returns only valid macro-domain values', async () => {
+    routeMock.mockRejectedValue(new Error('skip llm'));
     const result = await runDomainTriage({
       title: 'Any ticket',
       description: 'Any description',
     });
-
     for (const domain of result.inScopeDomains) {
       expect(MACRO_DOMAINS).toContain(domain as MacroDomain);
     }

--- a/packages/ticket-template/package.json
+++ b/packages/ticket-template/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@chiefaia/ticket-template",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
-  "description": "Strict, Zod-validated ticket template (v1) — the contract between Phase 1 agents (PO, BA, EA, DBA, BFF, UI, Security, Testing, Release) and the executor.",
+  "description": "Strict, Zod-validated ticket template (v1) \u2014 the contract between Phase 1 agents (PO, BA, EA, DBA, BFF, UI, Security, Testing, Release) and the executor.",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {

--- a/packages/ticket-template/src/__tests__/schema-v2.test.ts
+++ b/packages/ticket-template/src/__tests__/schema-v2.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ArchitecturalInstructionSchema,
+  ArchitecturalInstructionV2Schema,
+  type ArchitecturalInstruction,
+  type ArchitecturalInstructionV2,
+} from '../schema';
+
+describe('ArchitecturalInstructionV2Schema', () => {
+  describe('backward compatibility with V1', () => {
+    it('parses a V1 instruction without new fields', () => {
+      const v1Data = {
+        id: 'inst_001',
+        techSubDomain: 'backend',
+        action: 'enhance',
+        summary: 'Update API endpoint',
+        details: 'Add new query parameter to /api/users endpoint',
+        referencedArtifactIds: ['arch_apis/users'],
+        confidence: 0.9,
+      };
+
+      const v1Result = ArchitecturalInstructionSchema.safeParse(v1Data);
+      expect(v1Result.success).toBe(true);
+
+      const v2Result = ArchitecturalInstructionV2Schema.safeParse(v1Data);
+      expect(v2Result.success).toBe(true);
+      if (v2Result.success) {
+        expect(v2Result.data.existingArtifactReferences).toEqual([]);
+        expect(v2Result.data.newArtifactSpecs).toEqual([]);
+        expect(v2Result.data.integrationPoints).toEqual([]);
+        expect(v2Result.data.risks).toEqual([]);
+        expect(v2Result.data.testHooks).toEqual([]);
+        expect(v2Result.data.crossCuttingConcerns).toEqual([]);
+        expect(v2Result.data.candidateAdr).toBeUndefined();
+      }
+    });
+
+    it('parses a full V2 instruction with all new fields', () => {
+      const v2Data = {
+        id: 'inst_002',
+        techSubDomain: 'backend',
+        action: 'create',
+        summary: 'Billing webhook handler',
+        details: 'Receive and process Stripe webhook events',
+        referencedArtifactIds: [],
+        existingArtifactReferences: [
+          {
+            artifactId: 'arch_integrations/stripe',
+            role: 'use_as_is' as const,
+            note: 'Use existing Stripe API integration',
+          },
+        ],
+        newArtifactSpecs: [
+          {
+            proposedKind: 'api' as const,
+            proposedName: 'POST /webhooks/stripe',
+            proposedPath: 'apps/orchestrator/src/routes/webhooks/stripe.ts',
+            toolingChoice: 'stripe',
+            radarRing: 'adopt' as const,
+          },
+        ],
+        integrationPoints: [
+          {
+            direction: 'inbound' as const,
+            protocol: 'http' as const,
+            targetArtifactId: 'arch_integrations/stripe',
+            contract: 'POST /webhooks/stripe { type, data }',
+          },
+        ],
+        risks: [
+          {
+            severity: 'high' as const,
+            summary: 'Webhook signature validation failure',
+            mitigation: 'Verify X-Stripe-Signature header before processing',
+          },
+        ],
+        testHooks: [
+          {
+            kind: 'integration' as const,
+            target: 'webhook handler receives and processes charge.succeeded event',
+            rationale: 'Critical path for payment confirmation',
+          },
+        ],
+        crossCuttingConcerns: ['retry' as const, 'error_handling' as const, 'audit_log' as const],
+        candidateAdr: {
+          title: 'Stripe webhook integration pattern',
+          context: 'Webhooks are async, out-of-order, and may retry',
+          decision: 'Store webhook in pending queue, process idempotently',
+          consequences: ['Adds latency', 'Guarantees exactly-once delivery'],
+        },
+      };
+
+      const result = ArchitecturalInstructionV2Schema.safeParse(v2Data);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.id).toBe('inst_002');
+        expect(result.data.existingArtifactReferences).toHaveLength(1);
+        expect(result.data.newArtifactSpecs).toHaveLength(1);
+        expect(result.data.integrationPoints).toHaveLength(1);
+        expect(result.data.risks).toHaveLength(1);
+        expect(result.data.testHooks).toHaveLength(1);
+        expect(result.data.crossCuttingConcerns).toHaveLength(3);
+        expect(result.data.candidateAdr?.title).toBe('Stripe webhook integration pattern');
+      }
+    });
+  });
+
+  describe('field validation', () => {
+    it('rejects existingArtifactReferences with invalid role', () => {
+      const bad = {
+        id: 'inst_003',
+        techSubDomain: 'backend',
+        action: 'enhance',
+        summary: 'test',
+        details: 'test',
+        existingArtifactReferences: [
+          {
+            artifactId: 'arch_test',
+            role: 'invalid_role',
+          },
+        ],
+      };
+      const result = ArchitecturalInstructionV2Schema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects integrationPoints with invalid protocol', () => {
+      const bad = {
+        id: 'inst_004',
+        techSubDomain: 'backend',
+        action: 'create',
+        summary: 'test',
+        details: 'test',
+        integrationPoints: [
+          {
+            direction: 'inbound' as const,
+            protocol: 'invalid_proto',
+            contract: 'test',
+          },
+        ],
+      };
+      const result = ArchitecturalInstructionV2Schema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects risks with invalid severity', () => {
+      const bad = {
+        id: 'inst_005',
+        techSubDomain: 'backend',
+        action: 'create',
+        summary: 'test',
+        details: 'test',
+        risks: [
+          {
+            severity: 'catastrophic',
+            summary: 'test risk',
+            mitigation: 'test mitigation',
+          },
+        ],
+      };
+      const result = ArchitecturalInstructionV2Schema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects testHooks with invalid kind', () => {
+      const bad = {
+        id: 'inst_006',
+        techSubDomain: 'backend',
+        action: 'create',
+        summary: 'test',
+        details: 'test',
+        testHooks: [
+          {
+            kind: 'manual',
+            target: 'test',
+            rationale: 'test',
+          },
+        ],
+      };
+      const result = ArchitecturalInstructionV2Schema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects crossCuttingConcerns with invalid enum values', () => {
+      const bad = {
+        id: 'inst_007',
+        techSubDomain: 'backend',
+        action: 'create',
+        summary: 'test',
+        details: 'test',
+        crossCuttingConcerns: ['auth', 'unknown_concern'],
+      };
+      const result = ArchitecturalInstructionV2Schema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('default empty arrays', () => {
+    const minimalV2 = {
+      id: 'inst_008',
+      techSubDomain: 'database',
+      action: 'create',
+      summary: 'New schema',
+      details: 'Add users table',
+    };
+
+    it('defaults existingArtifactReferences to []', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.existingArtifactReferences).toEqual([]);
+      }
+    });
+
+    it('defaults newArtifactSpecs to []', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.newArtifactSpecs).toEqual([]);
+      }
+    });
+
+    it('defaults integrationPoints to []', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.integrationPoints).toEqual([]);
+      }
+    });
+
+    it('defaults risks to []', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.risks).toEqual([]);
+      }
+    });
+
+    it('defaults testHooks to []', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.testHooks).toEqual([]);
+      }
+    });
+
+    it('defaults crossCuttingConcerns to []', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.crossCuttingConcerns).toEqual([]);
+      }
+    });
+
+    it('defaults candidateAdr to undefined', () => {
+      const result = ArchitecturalInstructionV2Schema.safeParse(minimalV2);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.candidateAdr).toBeUndefined();
+      }
+    });
+  });
+});

--- a/packages/ticket-template/src/schema.ts
+++ b/packages/ticket-template/src/schema.ts
@@ -557,6 +557,168 @@ export const ArchitecturalInstructionSchema = z
   .strict();
 export type ArchitecturalInstruction = z.infer<typeof ArchitecturalInstructionSchema>;
 
+
+// ─── ARCH-007: ArchitecturalInstructionV2 (additive over V1) ──────────────────
+//
+// P0 of the EA Multi-Domain Decomposition adds five new optional array fields
+// to ArchitecturalInstructionSchema. Each field is default-empty, preserving
+// V1 compatibility: existing V1 instructions parse as V2 with empty arrays.
+//
+// The Version-2 fields materialize the "breadth problem" solution:
+// - existingArtifactReferences[] captures concrete AKG hits with roles
+// - newArtifactSpecs[] lists artifacts to create with tooling choices
+// - integrationPoints[] specifies cross-domain boundaries (inbound/outbound/bidirectional)
+// - risks[] surfaces domain-specific threats + mitigations per OWASP/ISO 25010
+// - testHooks[] prescribes test cases by kind (unit/integration/e2e/security/a11y/etc)
+// - crossCuttingConcerns[] enumerates auth/idempotency/observability/etc that
+//   span multiple domains
+
+export const ARTIFACT_KINDS = [
+  'component',
+  'service',
+  'function',
+  'api',
+  'schema',
+  'migration',
+  'package',
+  'config',
+  'template',
+  'hook',
+  'middleware',
+  'integration',
+] as const;
+export type ArtifactKind = (typeof ARTIFACT_KINDS)[number];
+
+export const INTEGRATION_DIRECTIONS = ['inbound', 'outbound', 'bidirectional'] as const;
+export type IntegrationDirection = (typeof INTEGRATION_DIRECTIONS)[number];
+
+export const INTEGRATION_PROTOCOLS = ['http', 'ws', 'event', 'sql', 'cli', 'fs', 'rpc'] as const;
+export type IntegrationProtocol = (typeof INTEGRATION_PROTOCOLS)[number];
+
+export const RISK_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+export type RiskSeverity = (typeof RISK_SEVERITIES)[number];
+
+export const TEST_HOOK_KINDS = [
+  'unit',
+  'integration',
+  'e2e',
+  'contract',
+  'load',
+  'a11y',
+  'security',
+  'visual',
+] as const;
+export type TestHookKind = (typeof TEST_HOOK_KINDS)[number];
+
+export const CROSS_CUTTING_CONCERNS = [
+  'auth',
+  'authz',
+  'audit_log',
+  'rate_limit',
+  'idempotency',
+  'retry',
+  'caching',
+  'csrf',
+  'xss',
+  'sqli',
+  'pii',
+  'i18n',
+  'a11y',
+  'observability_log',
+  'observability_metric',
+  'observability_trace',
+  'feature_flag',
+  'error_handling',
+] as const;
+export type CrossCuttingConcern = (typeof CROSS_CUTTING_CONCERNS)[number];
+
+export const ARTIFACT_ROLES = ['use_as_is', 'compose_with', 'replace', 'follow_pattern'] as const;
+export type ArtifactRole = (typeof ARTIFACT_ROLES)[number];
+
+export const RADAR_RINGS = ['adopt', 'trial', 'assess', 'hold'] as const;
+export type RadarRing = (typeof RADAR_RINGS)[number];
+
+const ExistingArtifactReference = z
+  .object({
+    artifactId: z.string().min(1).describe('arch_<id> format'),
+    role: z.enum(ARTIFACT_ROLES),
+    note: z.string().max(500).optional(),
+  })
+  .strict();
+
+export type ExistingArtifactReference = z.infer<typeof ExistingArtifactReference>;
+
+const NewArtifactSpec = z
+  .object({
+    proposedKind: z.enum(ARTIFACT_KINDS),
+    proposedName: z.string().min(1).max(255),
+    proposedPath: z.string().optional(),
+    proposedSignature: z.string().optional(),
+    toolingChoice: z.string().optional().describe('must resolve to tech-radar'),
+    radarRing: z.enum(RADAR_RINGS).optional(),
+  })
+  .strict();
+
+export type NewArtifactSpec = z.infer<typeof NewArtifactSpec>;
+
+const IntegrationPoint = z
+  .object({
+    direction: z.enum(INTEGRATION_DIRECTIONS),
+    protocol: z.enum(INTEGRATION_PROTOCOLS),
+    targetArtifactId: z.string().optional().describe('arch_<id> if known'),
+    contract: z.string().min(1).max(2000).describe('schema, route sig, event type'),
+  })
+  .strict();
+
+export type IntegrationPoint = z.infer<typeof IntegrationPoint>;
+
+const Risk = z
+  .object({
+    severity: z.enum(RISK_SEVERITIES),
+    summary: z.string().min(1).max(500),
+    mitigation: z.string().min(1).max(1000),
+  })
+  .strict();
+
+export type Risk = z.infer<typeof Risk>;
+
+const TestHook = z
+  .object({
+    kind: z.enum(TEST_HOOK_KINDS),
+    target: z.string().min(1).max(500).describe('file or behavior under test'),
+    rationale: z.string().min(1).max(500),
+  })
+  .strict();
+
+export type TestHook = z.infer<typeof TestHook>;
+
+const CandidateADR = z
+  .object({
+    title: z.string().min(1).max(200),
+    context: z.string().min(1).max(2000),
+    decision: z.string().min(1).max(2000),
+    consequences: z.array(z.string().max(500)).default([]),
+  })
+  .strict();
+
+export type CandidateADR = z.infer<typeof CandidateADR>;
+
+export const ArchitecturalInstructionV2Schema = ArchitecturalInstructionSchema.extend({
+  // V1 fields kept verbatim:
+  // id, techSubDomain, action, summary, details, referencedArtifactIds,
+  // proposedPath, proposedSignature, enhancementOfArtifactId, confidence
+
+  // V2 new fields (all optional, default-empty for backward compatibility):
+  existingArtifactReferences: z.array(ExistingArtifactReference).default([]),
+  newArtifactSpecs: z.array(NewArtifactSpec).default([]),
+  integrationPoints: z.array(IntegrationPoint).default([]),
+  risks: z.array(Risk).default([]),
+  testHooks: z.array(TestHook).default([]),
+  crossCuttingConcerns: z.array(z.enum(CROSS_CUTTING_CONCERNS)).default([]),
+  candidateAdr: CandidateADR.optional(),
+});
+
+export type ArchitecturalInstructionV2 = z.infer<typeof ArchitecturalInstructionV2Schema>;
 // ─── Top-level template ──────────────────────────────────────────────────────
 
 const Metadata = z


### PR DESCRIPTION
## EA-MESH-002 — Stage 1: Domain triage classifier

PR 2 of the EA Multi-Domain Decomposition track. Stacked on PR #208 (V2 schema).

### What this lands

- `apps/orchestrator/src/agents/domain-triage.ts` (227 LOC). Classifies a ticket into the **6 macro-domains** (`ui | backend | data | platform | quality-security | integrations`) per proposal §5.1.
- `apps/orchestrator/tests/agents/domain-triage.test.ts` (172 LOC, jest). 11 cases covering keyword pass, LLM fallback, default behavior.

### Two-pass triage (proposal §6.A)

1. **Keyword prior** via existing `inferTechSubDomains()` from ea-agent.ts, mapped through a complete `Record<TechSubDomain, MacroDomain>` table (compile-time exhaustiveness check).
2. **LLM refinement** via `route('domain-triage', ..., { forceLocal: true })` — Ollama-first per LAI-005. Gracefully falls back to the keyword pass when the router throws.

### Salvage notes

- Recovered from local-only commit 8fafa1c, which was authored on a develop-base branch. Cherry-picked onto rebased PR #208 so the file lands stacked on V2 schema (next PRs depend on it).
- Test was originally vitest at `src/agents/__tests__/...`; rewritten to jest and moved under `tests/agents/` to match the orchestrator's jest config (`roots: ['<rootDir>/tests']`).
- Fixed typecheck errors caused by the original commit:
  - Bogus `TicketBundle` import from `@chiefaia/ticket-template` → moved to local `api/ticket-bundle`.
  - Missing `compliance` entry in `TECH_TO_MACRO` → `Record<TechSubDomain,...>` now exhaustive.
  - `response.text` → `response.response` (matches `LLMResponse` shape).
  - `runDomainTriageFromBundle` derives `primaryDomain` via `classifyKeyword` (mirrors ba-agent + ea-agent).

### Verification

- `pnpm --filter @caia-app/core typecheck` — 0 errors.
- Backup pushed: `backup/ea-md-002-domain-triage-recovery-2026-04-30`.

### Stack
- Base: `feature/ea-md-001-v2-schema` (PR #208 — V2 schema)
- Next: PR 3 specialists (`feature/ea-md-003-specialists`) branches from this once merged.