### PR TITLE
chore/dash-002-event-taxonomy-breaker-events

### DIFF
--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -401,6 +401,9 @@ export type EventType =
   | 'executor.claude.tool_call'
   | 'executor.claude.completed'
   | 'executor.task.failed'
+  // EXEC-001 — circuit breaker observability (PR #222)
+  | 'executor.breaker.tripped'
+  | 'executor.breaker.pause_failed'
   | 'completeness.check.completed'
   | 'pipeline.stage.advanced'
   // ─── Scaffolder agent events (migration 0017) ─────────────────────────────
@@ -511,6 +514,12 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'executor.claude.tool_call': 'debug',
   'executor.claude.completed': 'info',
   'executor.task.failed': 'error',
+  // EXEC-001 — circuit breaker observability (PR #222). `tripped` is the
+  // canonical signal that a task was paused by the breaker; `pause_failed`
+  // is the regression sentinel that fires if the pause endpoint returns
+  // non-2xx (the original pre-fix bug — silent 404 — is now visible).
+  'executor.breaker.tripped': 'warning',
+  'executor.breaker.pause_failed': 'error',
   'completeness.check.completed': 'info',
   'pipeline.stage.advanced': 'info',
   // ─── Scaffolder agent events (migration 0017) ─────────────────────────────

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -176,6 +176,21 @@ events:
     actor: [executor]
     payload: [taskRunId, taskId, rootPromptId, error, retryCount, circuitBreakerTripped]
 
+  # EXEC-001 — circuit breaker observability (PR #222).
+  # tripped fires every time the breaker pauses a task. pause_failed is the
+  # regression sentinel — fires when the pause endpoint returns non-2xx, which
+  # is exactly the failure mode the EXEC-001 fix closed (silent 404 on the
+  # wrong DELETE /unpause call).
+  - type: executor.breaker.tripped
+    severity: warning
+    actor: [executor]
+    payload: [taskId, attemptCount, reason, kind, severity, paused]
+
+  - type: executor.breaker.pause_failed
+    severity: error
+    actor: [executor]
+    payload: [taskId, httpStatus, reason, attemptCount]
+
   # Worker events
   - type: worker.spawned
     severity: info


### PR DESCRIPTION
Opened by `pnpm flow ready`. See caia/docs/git-flow.md.