### PR TITLE
feat/safety-002-mcp-spawn-wrapper

### DIFF
--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -27,7 +27,8 @@
     "prepare": "husky",
     "test:regression": "jest --testPathPattern \"tests/e2e/(pipeline|agents)\" --runInBand",
     "test:regression:pipeline": "jest --testPathPattern \"tests/e2e/pipeline\" --runInBand",
-    "test:regression:agent": "jest --testPathPattern \"tests/e2e/agents\" --runInBand"
+    "test:regression:agent": "jest --testPathPattern \"tests/e2e/agents\" --runInBand",
+    "test:safety": "vitest run --config vitest.safety.config.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",
@@ -54,7 +55,10 @@
     "@chiefaia/logger": "workspace:*",
     "@chiefaia/architecture-registry": "workspace:*",
     "@chiefaia/ticket-template": "workspace:*",
-    "@chiefaia/capability-broker": "workspace:*"
+    "@chiefaia/capability-broker": "workspace:*",
+    "@chiefaia/mcp-allowlist-proxy": "workspace:*",
+    "@chiefaia/tool-output-sanitizer": "workspace:*",
+    "@chiefaia/spend-guard": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",
@@ -69,6 +73,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/orchestrator/src/install.ts
+++ b/apps/orchestrator/src/install.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { wrapMcpEntry } from './mcp/sandboxed-mcp-config';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -89,10 +90,24 @@ function installMcpConfig(): void {
   if (!mcp.mcpServers) mcp.mcpServers = {};
 
   if (!mcp.mcpServers['conductor']) {
-    mcp.mcpServers['conductor'] = { command: 'conductor', args: ['mcp'] };
+    // SAFETY-002: wrap the conductor MCP entry through sandbox-exec so
+    // when Claude Code spawns it, the process is jailed by the
+    // mcp-sandbox.sb profile (file-system + network restrictions).
+    // On non-Darwin platforms the wrapper falls through to the original
+    // entry but still enforces the spawn-command allowlist + public-bind
+    // guards. See packages/mcp-allowlist-proxy/src/sandbox.ts.
+    const rawConductor = { command: 'conductor', args: ['mcp'] };
+    let entry: { command: string; args: string[] };
+    try {
+      entry = wrapMcpEntry(rawConductor);
+    } catch (err) {
+      console.error('  ✗ Conductor MCP entry rejected by sandbox guards:', (err as Error).message);
+      throw err;
+    }
+    mcp.mcpServers['conductor'] = entry;
     fs.mkdirSync(CLAUDE_DIR, { recursive: true });
     fs.writeFileSync(mcpPath, JSON.stringify(mcp, null, 2));
-    console.log('  Added conductor MCP entry to ~/.claude/mcp.json');
+    console.log('  Added sandboxed conductor MCP entry to ~/.claude/mcp.json');
   } else {
     console.log('  Conductor MCP already configured, skipping');
   }

--- a/apps/orchestrator/src/mcp/sandboxed-mcp-config.test.ts
+++ b/apps/orchestrator/src/mcp/sandboxed-mcp-config.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SAFETY-002 — sandboxed MCP config tests.
+ *
+ * Eight cases covering:
+ *   1. Wraps a basic node MCP entry into sandbox-exec form.
+ *   2. Wraps a python MCP entry (e.g. mac-mcp) into sandbox-exec form.
+ *   3. Idempotent: an already-wrapped entry passes through wrapMcpConfig
+ *      unchanged.
+ *   4. Allowlist enforcement: a `bash` MCP entry is rejected.
+ *   5. Public-bind enforcement: an entry with `--host 0.0.0.0` is rejected.
+ *   6. Non-Darwin host: the wrapper is skipped but allowlist + public-bind
+ *      guards still apply.
+ *   7. Custom profile path is threaded through.
+ *   8. wrapMcpConfig: bulk-wraps multiple entries.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  wrapMcpEntry,
+  wrapMcpConfig,
+  isWrappedEntry,
+} from './sandboxed-mcp-config';
+import {
+  SpawnAllowlistError,
+  PublicBindError,
+} from '@chiefaia/mcp-allowlist-proxy';
+
+describe('SAFETY-002 sandboxed-mcp-config', () => {
+  it('1. wraps a basic node MCP entry into sandbox-exec form (Darwin)', () => {
+    const out = wrapMcpEntry(
+      { command: 'node', args: ['server.js'] },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    );
+    expect(out.command).toBe('/usr/bin/sandbox-exec');
+    expect(out.args).toContain('-f');
+    expect(out.args).toContain('/tmp/test.sb');
+    expect(out.args).toContain('--');
+    expect(out.args).toContain('node');
+    expect(out.args).toContain('server.js');
+  });
+
+  it('2. wraps a python MCP entry (mac-mcp shape)', () => {
+    const out = wrapMcpEntry(
+      { command: 'python3', args: ['-m', 'mac_mcp.server'] },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    );
+    expect(out.command).toBe('/usr/bin/sandbox-exec');
+    const argv = out.args;
+    expect(argv[0]).toBe('-f');
+    expect(argv[1]).toBe('/tmp/test.sb');
+    // The original cmd + args trail after `--`.
+    const dashIdx = argv.indexOf('--');
+    expect(argv[dashIdx + 1]).toBe('python3');
+    expect(argv[dashIdx + 2]).toBe('-m');
+    expect(argv[dashIdx + 3]).toBe('mac_mcp.server');
+  });
+
+  it('3. idempotent — already-wrapped entry passes through wrapMcpConfig', () => {
+    const wrapped = wrapMcpEntry(
+      { command: 'node', args: ['s.js'] },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    );
+    const out = wrapMcpConfig(
+      { mcpServers: { foo: wrapped } },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    );
+    expect(out.mcpServers['foo']).toEqual(wrapped);
+  });
+
+  it('4. allowlist rejects an entry whose command is not on STDIO_ALLOWED_COMMANDS', () => {
+    expect(() => wrapMcpEntry(
+      { command: 'bash', args: ['-c', 'curl https://evil/'] },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    )).toThrow(SpawnAllowlistError);
+  });
+
+  it('5. public-bind guard rejects 0.0.0.0 in args', () => {
+    expect(() => wrapMcpEntry(
+      { command: 'node', args: ['s.js', '--host', '0.0.0.0'] },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    )).toThrow(PublicBindError);
+  });
+
+  it('6. non-Darwin: wrapper skipped, but allowlist + public-bind still apply', () => {
+    // Allowed cmd, no public bind → entry passes through unwrapped.
+    const ok = wrapMcpEntry(
+      { command: 'node', args: ['server.js'] },
+      { platform: 'linux', profile: '/tmp/test.sb' },
+    );
+    expect(ok.command).toBe('node');
+    expect(isWrappedEntry(ok)).toBe(false);
+
+    // Public bind still rejected on linux.
+    expect(() => wrapMcpEntry(
+      { command: 'node', args: ['server.js', '--host', '[::]'] },
+      { platform: 'linux', profile: '/tmp/test.sb' },
+    )).toThrow(PublicBindError);
+  });
+
+  it('7. custom profile path is threaded through', () => {
+    const out = wrapMcpEntry(
+      { command: 'npx', args: ['my-mcp'] },
+      { platform: 'darwin', profile: '/etc/caia/custom.sb' },
+    );
+    expect(out.args).toContain('/etc/caia/custom.sb');
+  });
+
+  it('8. wrapMcpConfig — bulk-wraps multiple entries', () => {
+    const out = wrapMcpConfig(
+      {
+        mcpServers: {
+          a: { command: 'node', args: ['a.js'] },
+          b: { command: 'python3', args: ['b.py'] },
+        },
+      },
+      { platform: 'darwin', profile: '/tmp/test.sb' },
+    );
+    expect(isWrappedEntry(out.mcpServers['a']!)).toBe(true);
+    expect(isWrappedEntry(out.mcpServers['b']!)).toBe(true);
+  });
+});

--- a/apps/orchestrator/src/mcp/sandboxed-mcp-config.ts
+++ b/apps/orchestrator/src/mcp/sandboxed-mcp-config.ts
@@ -1,0 +1,125 @@
+/**
+ * SAFETY-002 — wrap `~/.claude/mcp.json` entries through
+ * `@chiefaia/mcp-allowlist-proxy`'s `buildSandboxedSpawn`.
+ *
+ * Claude Code itself is the process that spawns the MCP server (it reads
+ * `~/.claude/mcp.json` and calls `child_process.spawn(entry.command,
+ * entry.args)`). We can't intercept that spawn from outside Claude
+ * Code's process — but we *can* rewrite the `command` + `args` we
+ * register in `~/.claude/mcp.json` so Claude Code ends up spawning
+ * `sandbox-exec -f <profile> -D MCP_WORKTREE=… -- <original-command>
+ * <original-args>`.
+ *
+ * The same allowlist + public-bind guards that `buildSandboxedSpawn`
+ * applies live-fire are also applied at registration time, so a bad
+ * entry never makes it into the json file.
+ *
+ * Reference:
+ *   - caia/docs/mcp-security.md
+ *   - packages/mcp-allowlist-proxy/src/sandbox.ts (the wrapped helper)
+ *   - packages/mcp-allowlist-proxy/src/spawn-allowlist.ts (the guards)
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildSandboxedSpawn,
+  type SandboxedSpawnArgs,
+} from '@chiefaia/mcp-allowlist-proxy';
+
+/** A bare `~/.claude/mcp.json` entry. */
+export interface McpServerEntry {
+  command: string;
+  args: string[];
+  /** Optional env overrides — passed through verbatim. */
+  env?: Record<string, string>;
+}
+
+/** Per-MCP options that map to `buildSandboxedSpawn`. */
+export interface WrapMcpOptions {
+  /** Sandbox profile path (default `<repo>/scripts/mcp-sandbox.sb`). */
+  profile?: string;
+  /** Per-task worktree placeholder. Defaults to `$MCP_WORKTREE` so
+   *  Claude Code / the executor can substitute at spawn time. */
+  worktree?: string;
+  /** Cache dir placeholder. Default `$MCP_CACHE_DIR`. */
+  cacheDir?: string;
+  /**
+   * Override platform (test seam). Defaults to `process.platform`.
+   * sandbox-exec only exists on macOS — on other platforms we skip the
+   * wrapper but still apply the allowlist + public-bind guards.
+   */
+  platform?: NodeJS.Platform;
+  /** Optional spawn-command allowlist override (test seam). */
+  allowedCommands?: readonly string[];
+}
+
+const DEFAULT_PROFILE = path.resolve(__dirname, '..', '..', '..', '..', 'scripts', 'mcp-sandbox.sb');
+
+/**
+ * Wrap a raw MCP entry through the sandbox + allowlist + public-bind
+ * guards. Throws `SpawnAllowlistError` / `PublicBindError` for entries
+ * that can't be safely registered.
+ */
+export function wrapMcpEntry(
+  raw: McpServerEntry,
+  opts: WrapMcpOptions = {},
+): McpServerEntry {
+  const sandboxArgs: SandboxedSpawnArgs = {
+    cmd: raw.command,
+    args: raw.args,
+    worktree: opts.worktree ?? '$MCP_WORKTREE',
+    cacheDir: opts.cacheDir ?? '$MCP_CACHE_DIR',
+    profile: opts.profile ?? DEFAULT_PROFILE,
+    platform: opts.platform ?? process.platform,
+    spawnOpts: { env: raw.env },
+    enforceAllowlist: true,
+    enforceNoPublicBind: true,
+  };
+  if (opts.allowedCommands) {
+    sandboxArgs.allowedCommands = opts.allowedCommands;
+  }
+  const built = buildSandboxedSpawn(sandboxArgs);
+  const wrapped: McpServerEntry = {
+    command: built.cmd,
+    args: [...built.args],
+  };
+  if (raw.env) wrapped.env = raw.env;
+  return wrapped;
+}
+
+/**
+ * Map of well-known MCP server names → sandbox-required hint. The
+ * orchestrator uses this to decide which entries in ~/.claude/mcp.json
+ * to migrate when running `conductor harden-mcps`.
+ */
+export const KNOWN_FIRST_PARTY_MCPS = new Set([
+  'mac-mcp',
+  'stolution-remote',
+  'conductor',
+]);
+
+/**
+ * Bulk-rewrite an `mcp.json` payload — wrap every entry that hasn't
+ * already been wrapped (idempotent). Entries whose `command` is already
+ * `/usr/bin/sandbox-exec` are passed through unchanged.
+ */
+export function wrapMcpConfig(
+  config: { mcpServers?: Record<string, McpServerEntry> },
+  opts: WrapMcpOptions = {},
+): { mcpServers: Record<string, McpServerEntry> } {
+  const out: Record<string, McpServerEntry> = {};
+  for (const [name, entry] of Object.entries(config.mcpServers ?? {})) {
+    if (entry.command === '/usr/bin/sandbox-exec') {
+      out[name] = entry; // already wrapped
+      continue;
+    }
+    out[name] = wrapMcpEntry(entry, opts);
+  }
+  return { mcpServers: out };
+}
+
+/** Test helper — quickly assert an entry has been wrapped. */
+export function isWrappedEntry(entry: McpServerEntry): boolean {
+  return entry.command === '/usr/bin/sandbox-exec';
+}

--- a/apps/orchestrator/vitest.safety.config.ts
+++ b/apps/orchestrator/vitest.safety.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest config scoped to SAFETY-* unit tests. The orchestrator's main
+ * jest config is currently stubbed (stale module paths post-
+ * consolidation, separate cleanup PR). This config runs only the
+ * SAFETY-002 / SAFETY-003 / SAFETY-004 tests so they actually execute
+ * in CI without unblocking the larger jest cleanup.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/mcp/sandboxed-mcp-config.test.ts', 'src/safety/**/*.test.ts'],
+    exclude: ['dist/**', 'node_modules/**'],
+    testTimeout: 10_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,18 @@ importers:
       '@chiefaia/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@chiefaia/mcp-allowlist-proxy':
+        specifier: workspace:*
+        version: link:../../packages/mcp-allowlist-proxy
+      '@chiefaia/spend-guard':
+        specifier: workspace:*
+        version: link:../../packages/spend-guard
       '@chiefaia/ticket-template':
         specifier: workspace:*
         version: link:../../packages/ticket-template
+      '@chiefaia/tool-output-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/tool-output-sanitizer
       '@hono/node-server':
         specifier: ^1.19.14
         version: 1.19.14(hono@4.12.15)
@@ -233,6 +242,9 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   apps/orchestrator-middleware:
     dependencies:


### PR DESCRIPTION
Opened by `pnpm flow ready`. See caia/docs/git-flow.md.