### PR TITLE
chore/orchestrator-migrations-copy-to-dist

### DIFF
--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -9,7 +9,8 @@
     "conductor": "dist/src/cli/index.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && pnpm run postbuild:copy-migrations",
+    "postbuild:copy-migrations": "node -e \"const fs=require('fs'),path=require('path');const src=path.join(__dirname,'src/db/migrations'),dst=path.join(__dirname,'dist/src/db/migrations');fs.mkdirSync(dst,{recursive:true});fs.cpSync(src,dst,{recursive:true});console.log('[postbuild] copied src/db/migrations -> dist/src/db/migrations');\"",
     "dev": "tsc -p tsconfig.json --watch",
     "test": "echo 'TODO: orchestrator jest config has stale module paths post-consolidation. Stubbed until cleanup PR.' && exit 0",
     "test:e2e": "playwright test",

--- a/apps/orchestrator/scripts/boot-orchestrator.cjs
+++ b/apps/orchestrator/scripts/boot-orchestrator.cjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Bootstrap for com.caia.orchestrator launchd job (replaces legacy ~/Documents/projects/conductor build).
+// Exported function is the same name as legacy (startApiServer) — only the require path moves.
+const { startApiServer } = require('../dist/src/api/start');
+
+startApiServer()
+  .then(() => {
+    console.error('[boot] caia orchestrator API up on port', process.env.CONDUCTOR_HTTP_PORT || 7776);
+  })
+  .catch((e) => {
+    console.error('[boot] FAIL', e && e.stack ? e.stack : e);
+    process.exit(1);
+  });


### PR DESCRIPTION
Opened by `pnpm flow ready`. See caia/docs/git-flow.md.