### PR TITLE
feat(dash-001): accordion-grouped left nav

### DIFF
--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -1,224 +1,20 @@
 'use client';
-import { useState, useEffect, useCallback, Suspense } from 'react';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { useWebSocket } from '../hooks/useWebSocket';
-import { useUnseenBadges } from '../hooks/useUnseenBadges';
-import { NavProjectSelector } from '../components/NavProjectSelector';
+import { Suspense } from 'react';
+import { Sidebar } from '../components/nav/Sidebar';
 import './globals.css';
 
-const NAV_ITEMS = [
-  { path: '/timeline', label: 'Timeline', icon: '🕒', tabKey: 'timeline' },
-  { path: '/domains', label: 'Domains', icon: '🏷️', tabKey: 'domains' },
-  { path: '/projects', label: 'Projects', icon: '📁', tabKey: 'projects' },
-  { path: '/queue', label: 'Queue', icon: '🎯', tabKey: 'queue' },
-  { path: '/buckets', label: 'Buckets', icon: '🗂️', tabKey: 'buckets' },
-  { path: '/tasks', label: 'Tasks', icon: '📋', tabKey: 'tasks' },
-  { path: '/task-runs', label: 'Task Runs', icon: '📡', tabKey: 'task_runs' },
-  { path: '/requirements', label: 'Requirements', icon: '📝', tabKey: 'requirements' },
-  { path: '/blockers', label: 'Blockers', icon: '🚨', tabKey: 'blockers' },
-  { path: '/questions', label: 'Questions', icon: '❓', tabKey: 'questions' },
-  { path: '/adrs', label: 'ADRs', icon: '📜', tabKey: 'adrs' },
-  { path: '/features', label: 'Features', icon: '🎯', tabKey: 'features' },
-  { path: '/suggestions', label: 'Suggestions', icon: '💡', tabKey: 'suggestions' },
-  { path: '/audit', label: 'Audit', icon: '🔍', tabKey: 'audit' },
-  { path: '/tests', label: 'Tests', icon: '🧪', tabKey: 'tests' },
-  { path: '/stories', label: 'Stories', icon: '🌳', tabKey: 'stories' },
-  { path: '/completeness', label: 'Completeness', icon: '✅', tabKey: 'completeness' },
-  { path: '/standards', label: 'Standards', icon: '📋', tabKey: 'standards' },
-  // /backups retired from nav: GET /db-backups returns [] in CAIA (no backup
-  //   runs scheduled). The route still works if hit directly; once a backup
-  //   subsystem is wired up we can re-add this nav item.
-  // { path: '/backups', label: 'Backups', icon: '💾', tabKey: 'backups' },
-  { path: '/metrics', label: 'Metrics', icon: '📊', tabKey: 'metrics' },
-  { path: '/registry', label: 'Registry', icon: '🗂️', tabKey: 'registry' },
-  { path: '/events', label: 'Events', icon: '⚡', tabKey: 'events' },
-  { path: '/builds', label: 'Builds', icon: '🔨', tabKey: 'builds' },
-  { path: '/observability/health', label: 'Obs. Health', icon: '👁', tabKey: 'obs_health' },
-  { path: '/health/pulse', label: 'Pulse', icon: '💚', tabKey: 'pulse' },
-  { path: '/dag', label: 'Dependency Graph', icon: '🕸️', tabKey: 'dag' },
-  { path: '/quality', label: 'Quality', icon: '📊', tabKey: 'quality' },
-  // /coverage retired from nav: conductor-specific Jest/Istanbul artifact
-  //   path. Replaced by the new /quality page above (DASH-314 Phase 1 —
-  //   surfaces orchestrator-wide quality signals; Phase 2 will add
-  //   per-package coverage from CI artifacts).
-  // { path: '/coverage', label: 'Coverage', icon: '🎯', tabKey: 'coverage' },
-  // /enforcement retired from nav: page is currently mocked (no
-  //   enforcement_rules table or backend route). DASH-308 explicitly
-  //   defers the real backend (P2, large effort, out-of-MVP per gap
-  //   analysis). The route still works if hit directly. Re-enable this
-  //   nav entry when the enforcement_rules table + handlers ship.
-  // { path: '/enforcement', label: 'Enforcement', icon: '🛡️', tabKey: 'enforcement' },
-  { path: '/settings', label: 'Settings', icon: '⚙️', tabKey: 'settings' },
-] as const;
-
-// Map WS event kind prefix → tab key
-function kindToTab(kind: string): string {
-  if (kind.startsWith('task_run.')) return 'task_runs';
-  if (kind.startsWith('behavior_test.')) return 'tests';
-  if (kind.startsWith('priority.')) return 'queue';
-  if (kind.startsWith('task-scheduler.') || kind.startsWith('ticket.')) return 'buckets';
-  if (kind.startsWith('task.') || kind.startsWith('task_')) return 'tasks';
-  if (kind.startsWith('requirement.')) return 'requirements';
-  if (kind.startsWith('blocker.')) return 'blockers';
-  if (kind.startsWith('question.')) return 'questions';
-  if (kind.startsWith('adr.')) return 'adrs';
-  if (kind.startsWith('feature.')) return 'features';
-  if (kind.startsWith('suggestion.')) return 'suggestions';
-  if (kind.startsWith('project.')) return 'projects';
-  if (kind.startsWith('timeline.')) return 'timeline';
-  if (kind.startsWith('audit.')) return 'audit';
-  if (kind.startsWith('domain.') || kind.startsWith('entity.tagged') || kind.startsWith('entity.untagged')) return 'domains';
-  if (kind.startsWith('story.')) return 'stories';
-  if (kind.startsWith('completeness.')) return 'completeness';
-  if (kind.startsWith('lock_contract.')) return 'standards';
-  if (kind.startsWith('enforcement.')) return 'enforcement';
-  return 'timeline';
-}
-
-function updateFavicon(totalUnseen: number) {
-  if (typeof window === 'undefined') return;
-  const favicon = document.getElementById('favicon') as HTMLLinkElement | null;
-  if (!favicon) return;
-
-  if (totalUnseen > 0) {
-    const canvas = document.createElement('canvas');
-    canvas.width = 32;
-    canvas.height = 32;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    const img = new Image();
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0, 32, 32);
-      ctx.fillStyle = '#fc8181';
-      ctx.beginPath();
-      ctx.arc(26, 6, 7, 0, Math.PI * 2);
-      ctx.fill();
-      favicon.href = canvas.toDataURL('image/png');
-    };
-    img.onerror = () => {}; // ignore missing favicon
-    img.src = '/favicon.ico';
-  } else {
-    favicon.href = '/favicon.ico';
-  }
-}
-
-function SidebarInner() {
-  const pathname = usePathname();
-  const { lastEvent, connected } = useWebSocket('ws://localhost:7776/events');
-  const { unseen, increment, markSeen, totalUnseen } = useUnseenBadges();
-  const [projectFilter, setProjectFilter] = useState<string | null>(null);
-
-  // Current active tab key
-  const currentTab = NAV_ITEMS.find(n => pathname.startsWith(n.path))?.tabKey ?? 'timeline';
-
-  // Mark current tab seen when pathname changes
-  useEffect(() => {
-    markSeen(currentTab);
-  }, [currentTab, markSeen]);
-
-  // Increment unseen when WS event arrives for a non-active tab
-  useEffect(() => {
-    if (!lastEvent?.kind) return;
-    const tab = kindToTab(lastEvent.kind);
-    if (tab !== currentTab) {
-      increment(tab);
-    }
-  }, [lastEvent, currentTab, increment]);
-
-  // Update document title
-  useEffect(() => {
-    document.title = totalUnseen > 0 ? `Conductor (${totalUnseen})` : 'Conductor';
-  }, [totalUnseen]);
-
-  // Update favicon dot
-  useEffect(() => {
-    updateFavicon(totalUnseen);
-  }, [totalUnseen]);
-
-  return (
-    <nav
-      style={{
-        width: 220,
-        background: '#1a1f2e',
-        borderRight: '1px solid #2d3748',
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '16px 0 0',
-        overflowY: 'auto',
-        flexShrink: 0,
-        height: '100vh',
-      }}
-      aria-label="Main navigation"
-    >
-      {/* Brand header */}
-      <div style={{ padding: '0 16px 16px', borderBottom: '1px solid #2d3748', marginBottom: 4 }}>
-        <div style={{ fontSize: 18, fontWeight: 700, color: '#90cdf4' }}>🎼 Conductor</div>
-        <div style={{ fontSize: 11, color: connected ? '#68d391' : '#fc8181', marginTop: 4 }}>
-          {connected ? '● live' : '○ reconnecting...'}
-        </div>
-      </div>
-
-      {/* Project filter */}
-      <NavProjectSelector value={projectFilter} onChange={setProjectFilter} />
-
-      {/* Nav links */}
-      {NAV_ITEMS.map(item => {
-        const isActive = pathname === item.path || pathname.startsWith(item.path + '/');
-        const count = unseen[item.tabKey] ?? 0;
-        const href = projectFilter
-          ? `${item.path}?project=${projectFilter}`
-          : item.path;
-
-        return (
-          <Link
-            key={item.path}
-            href={href}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '8px 16px',
-              background: isActive ? '#2d3748' : 'transparent',
-              color: isActive ? '#90cdf4' : '#a0aec0',
-              textDecoration: 'none',
-              fontSize: 14,
-              fontWeight: isActive ? 600 : 400,
-              borderLeft: isActive ? '2px solid #63b3ed' : '2px solid transparent',
-              transition: 'all 0.15s',
-            }}
-            aria-label={count > 0 ? `${item.label} — ${count} unseen updates` : item.label}
-            aria-current={isActive ? 'page' : undefined}
-          >
-            <span style={{ fontSize: 16 }} aria-hidden="true">{item.icon}</span>
-            <span style={{ flex: 1 }}>{item.label}</span>
-            {count > 0 && (
-              <span
-                style={{
-                  background: '#fc8181',
-                  color: '#1a202c',
-                  borderRadius: '50%',
-                  width: 18,
-                  height: 18,
-                  fontSize: 10,
-                  fontWeight: 700,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  flexShrink: 0,
-                }}
-                aria-hidden="true"
-              >
-                {count > 99 ? '99+' : count}
-              </span>
-            )}
-          </Link>
-        );
-      })}
-    </nav>
-  );
-}
-
+/**
+ * Root layout — DASH-001 nav restructure.
+ *
+ * The 27-item flat sidebar previously inlined here was extracted into
+ * `components/nav/Sidebar.tsx` as an accordion-grouped component. The
+ * grouping (Work / Pipeline / Catalog / Quality / Operations / Settings)
+ * follows the IA spec at caia/docs/dashboard-url-schema.md.
+ *
+ * URLs do not change in this PR — only the nav structure does. Route
+ * migration to the canonical `/section/resource` schema lands in PR2
+ * (`feat/dash-002-url-schema-redirect`).
+ */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
@@ -239,10 +35,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           overflow: 'hidden',
         }}
       >
-        <Suspense fallback={
-          <nav style={{ width: 220, background: '#1a1f2e', borderRight: '1px solid #2d3748', flexShrink: 0 }} />
-        }>
-          <SidebarInner />
+        <Suspense
+          fallback={
+            <nav
+              style={{
+                width: 220,
+                background: '#1a1f2e',
+                borderRight: '1px solid #2d3748',
+                flexShrink: 0,
+              }}
+            />
+          }
+        >
+          <Sidebar />
         </Suspense>
 
         {/* Main content area */}

--- a/apps/dashboard/components/nav/Sidebar.tsx
+++ b/apps/dashboard/components/nav/Sidebar.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+/**
+ * Sidebar — accordion-based left navigation (DASH-001).
+ *
+ * Replaces the inline flat-list `SidebarInner` previously embedded in
+ * `app/layout.tsx`. The 27-item flat list was reorganized into six top-level
+ * groups (Work / Pipeline / Catalog / Quality / Operations / Settings) per
+ * the IA spec at caia/docs/dashboard-url-schema.md.
+ *
+ * Behaviour:
+ *   - Multi-open accordion. Per-group expanded state persists in
+ *     localStorage under `nav.expanded` so users keep their preferred
+ *     layout.
+ *   - The active section auto-expands when its pathname matches.
+ *   - Per-leaf unseen badges (existing useUnseenBadges hook) plus a
+ *     section-level roll-up shown on the collapsed group header.
+ *   - Project filter unchanged — query string `?project=<slug>` still
+ *     applied to every link.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useWebSocket } from '../../hooks/useWebSocket';
+import { useUnseenBadges } from '../../hooks/useUnseenBadges';
+import { NavProjectSelector } from '../NavProjectSelector';
+import { NAV_GROUPS, NAV_LEAVES, kindToTab, groupUnseenCount } from './groups';
+
+const STORAGE_KEY = 'nav.expanded';
+
+function readExpandedFromStorage(): Record<string, boolean> | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, boolean>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeExpandedToStorage(state: Record<string, boolean>) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore — quota or disabled storage
+  }
+}
+
+function defaultExpandedState(): Record<string, boolean> {
+  const state: Record<string, boolean> = {};
+  for (const group of NAV_GROUPS) state[group.id] = group.defaultExpanded;
+  return state;
+}
+
+function updateFavicon(totalUnseen: number) {
+  if (typeof window === 'undefined') return;
+  const favicon = document.getElementById('favicon') as HTMLLinkElement | null;
+  if (!favicon) return;
+
+  if (totalUnseen > 0) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 32;
+    canvas.height = 32;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const img = new Image();
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0, 32, 32);
+      ctx.fillStyle = '#fc8181';
+      ctx.beginPath();
+      ctx.arc(26, 6, 7, 0, Math.PI * 2);
+      ctx.fill();
+      favicon.href = canvas.toDataURL('image/png');
+    };
+    img.onerror = () => {};
+    img.src = '/favicon.ico';
+  } else {
+    favicon.href = '/favicon.ico';
+  }
+}
+
+export function Sidebar() {
+  const pathname = usePathname();
+  const { lastEvent, connected } = useWebSocket('ws://localhost:7776/events');
+  const { unseen, increment, markSeen, totalUnseen } = useUnseenBadges();
+  const [projectFilter, setProjectFilter] = useState<string | null>(null);
+
+  // Expanded state — initialized from localStorage on mount, falls back to
+  // defaults. We keep an "initialized" flag so the first paint matches the
+  // server (defaults), then we hydrate from storage.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(defaultExpandedState);
+
+  useEffect(() => {
+    const fromStorage = readExpandedFromStorage();
+    if (fromStorage) {
+      setExpanded((prev) => ({ ...prev, ...fromStorage }));
+    }
+  }, []);
+
+  // Auto-expand the section containing the active route.
+  const activeLeaf = useMemo(
+    () => NAV_LEAVES.find((leaf) => pathname === leaf.path || pathname.startsWith(leaf.path + '/')),
+    [pathname],
+  );
+  const activeGroupId = useMemo(() => {
+    if (!activeLeaf) return null;
+    return NAV_GROUPS.find((g) => g.leaves.some((l) => l.tabKey === activeLeaf.tabKey))?.id ?? null;
+  }, [activeLeaf]);
+
+  useEffect(() => {
+    if (activeGroupId) {
+      setExpanded((prev) => (prev[activeGroupId] ? prev : { ...prev, [activeGroupId]: true }));
+    }
+  }, [activeGroupId]);
+
+  // Persist expanded state.
+  useEffect(() => {
+    writeExpandedToStorage(expanded);
+  }, [expanded]);
+
+  const currentTab = activeLeaf?.tabKey ?? 'timeline';
+
+  // Mark current tab seen when pathname changes.
+  useEffect(() => {
+    markSeen(currentTab);
+  }, [currentTab, markSeen]);
+
+  // Increment unseen when WS event arrives for a non-active tab.
+  useEffect(() => {
+    if (!lastEvent?.kind) return;
+    const tab = kindToTab(lastEvent.kind);
+    if (tab !== currentTab) {
+      increment(tab);
+    }
+  }, [lastEvent, currentTab, increment]);
+
+  // Document title + favicon dot.
+  useEffect(() => {
+    document.title = totalUnseen > 0 ? `Conductor (${totalUnseen})` : 'Conductor';
+  }, [totalUnseen]);
+  useEffect(() => {
+    updateFavicon(totalUnseen);
+  }, [totalUnseen]);
+
+  const toggleGroup = useCallback((groupId: string) => {
+    setExpanded((prev) => {
+      const next = { ...prev, [groupId]: !prev[groupId] };
+      // Mark all leaves in this group seen when collapsing/expanding.
+      const group = NAV_GROUPS.find((g) => g.id === groupId);
+      if (group && next[groupId]) {
+        // expanding — don't mark seen (user is opening to look)
+      } else if (group) {
+        // collapsing — leave badges as-is
+      }
+      return next;
+    });
+  }, []);
+
+  const linkHref = useCallback(
+    (path: string) => (projectFilter ? `${path}?project=${projectFilter}` : path),
+    [projectFilter],
+  );
+
+  return (
+    <nav
+      style={{
+        width: 220,
+        background: '#1a1f2e',
+        borderRight: '1px solid #2d3748',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '16px 0 0',
+        overflowY: 'auto',
+        flexShrink: 0,
+        height: '100vh',
+      }}
+      aria-label="Main navigation"
+    >
+      {/* Brand header */}
+      <div style={{ padding: '0 16px 16px', borderBottom: '1px solid #2d3748', marginBottom: 4 }}>
+        <div style={{ fontSize: 18, fontWeight: 700, color: '#90cdf4' }}>🎼 Conductor</div>
+        <div style={{ fontSize: 11, color: connected ? '#68d391' : '#fc8181', marginTop: 4 }}>
+          {connected ? '● live' : '○ reconnecting...'}
+        </div>
+      </div>
+
+      {/* Project filter */}
+      <NavProjectSelector value={projectFilter} onChange={setProjectFilter} />
+
+      {/* Accordion groups */}
+      {NAV_GROUPS.map((group) => {
+        const isOpen = !!expanded[group.id];
+        const groupBadge = isOpen ? 0 : groupUnseenCount(group, unseen);
+        const regionId = `nav-region-${group.id}`;
+        return (
+          <div key={group.id} style={{ display: 'flex', flexDirection: 'column' }}>
+            <button
+              type="button"
+              onClick={() => toggleGroup(group.id)}
+              aria-expanded={isOpen}
+              aria-controls={regionId}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                background: 'transparent',
+                border: 'none',
+                color: '#cbd5e0',
+                padding: '10px 16px',
+                fontSize: 13,
+                fontWeight: 700,
+                textAlign: 'left',
+                cursor: 'pointer',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+                marginTop: 8,
+              }}
+            >
+              <span style={{ fontSize: 14 }} aria-hidden="true">{group.icon}</span>
+              <span style={{ flex: 1 }}>{group.label}</span>
+              {groupBadge > 0 && (
+                <span
+                  style={{
+                    background: '#fc8181',
+                    color: '#1a202c',
+                    borderRadius: '50%',
+                    width: 16,
+                    height: 16,
+                    fontSize: 9,
+                    fontWeight: 700,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  aria-hidden="true"
+                >
+                  {groupBadge > 99 ? '99+' : groupBadge}
+                </span>
+              )}
+              <span
+                style={{
+                  fontSize: 10,
+                  color: '#718096',
+                  transform: isOpen ? 'rotate(90deg)' : 'rotate(0)',
+                  transition: 'transform 0.15s',
+                }}
+                aria-hidden="true"
+              >
+                ▶
+              </span>
+            </button>
+            {isOpen && (
+              <ul
+                id={regionId}
+                role="region"
+                aria-label={`${group.label} navigation`}
+                style={{ listStyle: 'none', padding: 0, margin: 0 }}
+              >
+                {group.leaves.map((leaf) => {
+                  const isActive =
+                    pathname === leaf.path || pathname.startsWith(leaf.path + '/');
+                  const count = unseen[leaf.tabKey] ?? 0;
+                  return (
+                    <li key={leaf.path}>
+                      <Link
+                        href={linkHref(leaf.path)}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 8,
+                          padding: '6px 16px 6px 32px',
+                          background: isActive ? '#2d3748' : 'transparent',
+                          color: isActive ? '#90cdf4' : '#a0aec0',
+                          textDecoration: 'none',
+                          fontSize: 13,
+                          fontWeight: isActive ? 600 : 400,
+                          borderLeft: isActive ? '2px solid #63b3ed' : '2px solid transparent',
+                          transition: 'all 0.15s',
+                        }}
+                        aria-label={count > 0 ? `${leaf.label} — ${count} unseen updates` : leaf.label}
+                        aria-current={isActive ? 'page' : undefined}
+                      >
+                        <span style={{ fontSize: 14 }} aria-hidden="true">{leaf.icon}</span>
+                        <span style={{ flex: 1 }}>{leaf.label}</span>
+                        {count > 0 && (
+                          <span
+                            style={{
+                              background: '#fc8181',
+                              color: '#1a202c',
+                              borderRadius: '50%',
+                              width: 18,
+                              height: 18,
+                              fontSize: 10,
+                              fontWeight: 700,
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              flexShrink: 0,
+                            }}
+                            aria-hidden="true"
+                          >
+                            {count > 99 ? '99+' : count}
+                          </span>
+                        )}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}
+
+export default Sidebar;

--- a/apps/dashboard/components/nav/groups.ts
+++ b/apps/dashboard/components/nav/groups.ts
@@ -1,0 +1,167 @@
+/**
+ * NAV_GROUPS — single source of truth for the dashboard's left-nav
+ * accordion structure. Each group is a top-level section with its own icon
+ * and a list of leaf links.
+ *
+ * In PR1 (`feat/dash-001-nav-restructure`) we restructure the nav into
+ * groups but keep the existing flat URLs. Routes are migrated to the
+ * canonical `/section/resource[/...]` schema in PR2
+ * (`feat/dash-002-url-schema-redirect`) — once that lands the `path` values
+ * here will be updated and the old paths become redirects.
+ *
+ * Reference: caia/docs/dashboard-url-schema.md (canonical IA spec, ships in
+ * PR10).
+ */
+
+export interface NavLeaf {
+  /** Active leaf link path (current — pre-PR2). */
+  path: string;
+  /** Display label in the nav. */
+  label: string;
+  /** Emoji icon. */
+  icon: string;
+  /** Tab key used by useUnseenBadges. */
+  tabKey: string;
+}
+
+export interface NavGroup {
+  /** Stable id, used for localStorage expanded-state and aria. */
+  id: string;
+  /** Section label. */
+  label: string;
+  /** Section emoji icon. */
+  icon: string;
+  /** Whether this group expands by default (multi-open). */
+  defaultExpanded: boolean;
+  /** Leaf links inside this section. */
+  leaves: NavLeaf[];
+}
+
+export const NAV_GROUPS: NavGroup[] = [
+  {
+    id: 'work',
+    label: 'Work',
+    icon: '📋',
+    defaultExpanded: true,
+    leaves: [
+      { path: '/prompts', label: 'Prompts', icon: '💬', tabKey: 'prompts' },
+      { path: '/submit', label: 'Submit', icon: '➕', tabKey: 'submit' },
+      { path: '/queue', label: 'Queue', icon: '🎯', tabKey: 'queue' },
+      { path: '/buckets', label: 'Buckets', icon: '🗂️', tabKey: 'buckets' },
+      { path: '/stories', label: 'Stories', icon: '🌳', tabKey: 'stories' },
+      { path: '/tasks', label: 'Tasks', icon: '📋', tabKey: 'tasks' },
+      { path: '/requirements', label: 'Requirements', icon: '📝', tabKey: 'requirements' },
+      { path: '/blockers', label: 'Blockers', icon: '🚨', tabKey: 'blockers' },
+      { path: '/questions', label: 'Questions', icon: '❓', tabKey: 'questions' },
+      { path: '/suggestions', label: 'Suggestions', icon: '💡', tabKey: 'suggestions' },
+    ],
+  },
+  {
+    id: 'pipeline',
+    label: 'Pipeline',
+    icon: '🔀',
+    defaultExpanded: true,
+    leaves: [
+      { path: '/timeline', label: 'Timeline', icon: '🕒', tabKey: 'timeline' },
+      { path: '/pipeline', label: 'Pipeline', icon: '🔀', tabKey: 'pipeline' },
+      { path: '/events', label: 'Events', icon: '⚡', tabKey: 'events' },
+      { path: '/task-runs', label: 'Task runs', icon: '📡', tabKey: 'task_runs' },
+      { path: '/dag', label: 'Dependency graph', icon: '🕸️', tabKey: 'dag' },
+    ],
+  },
+  {
+    id: 'catalog',
+    label: 'Catalog',
+    icon: '📚',
+    defaultExpanded: false,
+    leaves: [
+      { path: '/projects', label: 'Projects', icon: '📁', tabKey: 'projects' },
+      { path: '/domains', label: 'Domains', icon: '🏷️', tabKey: 'domains' },
+      { path: '/architecture', label: 'Architecture', icon: '🏛️', tabKey: 'architecture' },
+      { path: '/contracts', label: 'Contracts', icon: '📃', tabKey: 'contracts' },
+      { path: '/features', label: 'Features', icon: '🎯', tabKey: 'features' },
+      { path: '/agents', label: 'Agents', icon: '🤖', tabKey: 'agents' },
+      { path: '/registry', label: 'Registry', icon: '🗂️', tabKey: 'registry' },
+    ],
+  },
+  {
+    id: 'quality',
+    label: 'Quality',
+    icon: '✅',
+    defaultExpanded: false,
+    leaves: [
+      { path: '/quality', label: 'Quality', icon: '📊', tabKey: 'quality' },
+      { path: '/gates', label: 'Gates', icon: '🚪', tabKey: 'gates' },
+      { path: '/tests', label: 'Tests', icon: '🧪', tabKey: 'tests' },
+      { path: '/completeness', label: 'Completeness', icon: '✅', tabKey: 'completeness' },
+    ],
+  },
+  {
+    id: 'operations',
+    label: 'Operations',
+    icon: '🛠️',
+    defaultExpanded: false,
+    leaves: [
+      { path: '/platform-status', label: 'Platform status', icon: '📊', tabKey: 'platform_status' },
+      { path: '/health/pulse', label: 'Pulse', icon: '💚', tabKey: 'pulse' },
+      { path: '/observability/health', label: 'Observability', icon: '👁', tabKey: 'obs_health' },
+      { path: '/metrics', label: 'Metrics', icon: '📊', tabKey: 'metrics' },
+      { path: '/builds', label: 'Builds', icon: '🔨', tabKey: 'builds' },
+      { path: '/audit', label: 'Audit', icon: '🔍', tabKey: 'audit' },
+    ],
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: '⚙️',
+    defaultExpanded: false,
+    leaves: [
+      { path: '/settings', label: 'Settings', icon: '⚙️', tabKey: 'settings' },
+      { path: '/standards', label: 'Standards', icon: '📋', tabKey: 'standards' },
+      { path: '/adrs', label: 'ADRs', icon: '📜', tabKey: 'adrs' },
+    ],
+  },
+];
+
+/**
+ * Flat list of every leaf — kept for backward-compatible code paths
+ * (e.g. `currentTab` lookup). Generated from NAV_GROUPS.
+ */
+export const NAV_LEAVES: NavLeaf[] = NAV_GROUPS.flatMap((g) => g.leaves);
+
+/**
+ * Map a WS event kind prefix → tabKey for unseen-badge attribution.
+ * Moved out of layout.tsx so the Sidebar component can own it.
+ */
+export function kindToTab(kind: string): string {
+  if (kind.startsWith('task_run.')) return 'task_runs';
+  if (kind.startsWith('behavior_test.')) return 'tests';
+  if (kind.startsWith('priority.')) return 'queue';
+  if (kind.startsWith('task-scheduler.') || kind.startsWith('ticket.')) return 'buckets';
+  if (kind.startsWith('task.') || kind.startsWith('task_')) return 'tasks';
+  if (kind.startsWith('requirement.')) return 'requirements';
+  if (kind.startsWith('blocker.')) return 'blockers';
+  if (kind.startsWith('question.')) return 'questions';
+  if (kind.startsWith('adr.')) return 'adrs';
+  if (kind.startsWith('feature.')) return 'features';
+  if (kind.startsWith('suggestion.')) return 'suggestions';
+  if (kind.startsWith('project.')) return 'projects';
+  if (kind.startsWith('timeline.')) return 'timeline';
+  if (kind.startsWith('audit.')) return 'audit';
+  if (kind.startsWith('domain.') || kind.startsWith('entity.tagged') || kind.startsWith('entity.untagged')) return 'domains';
+  if (kind.startsWith('story.')) return 'stories';
+  if (kind.startsWith('completeness.')) return 'completeness';
+  if (kind.startsWith('lock_contract.')) return 'standards';
+  if (kind.startsWith('prompt.')) return 'prompts';
+  if (kind.startsWith('agent.')) return 'agents';
+  if (kind.startsWith('build.')) return 'builds';
+  if (kind.startsWith('pipeline.')) return 'pipeline';
+  return 'timeline';
+}
+
+/**
+ * Roll up unseen counts by section group.
+ */
+export function groupUnseenCount(group: NavGroup, unseen: Record<string, number>): number {
+  return group.leaves.reduce((sum, leaf) => sum + (unseen[leaf.tabKey] ?? 0), 0);
+}


### PR DESCRIPTION
## Summary

Replaces the dashboard's flat 27-item sidebar with **six accordion sections**:

- 📋 **Work** — prompts, submit, queue, buckets, stories, tasks, requirements, blockers, questions, suggestions
- 🔀 **Pipeline** — timeline, pipeline, events, task runs, dependency graph
- 📚 **Catalog** — projects, domains, architecture, contracts, features, agents, registry
- ✅ **Quality** — quality, gates, tests, completeness
- 🛠️ **Operations** — platform status, pulse, observability, metrics, builds, audit
- ⚙️ **Settings** — settings, standards, ADRs

## Why

Per the audit at \`~/Documents/projects/reports/dashboard-nav-audit-2026-04-30.md\`, the current nav had 27 flat items plus 9 orphan pages reachable only by URL (\`/prompts\`, \`/pipeline\`, \`/agents\`, \`/architecture\`, \`/contracts\`, \`/gates\`, \`/platform-status\`, \`/submit\`, \`/reports/prompts\`). This PR promotes the orphans into the nav and groups everything by IA section per the spec at \`caia/docs/dashboard-url-schema.md\`.

## What changes

- New: \`apps/dashboard/components/nav/groups.ts\` — \`NAV_GROUPS\` source of truth + \`kindToTab()\` helper.
- New: \`apps/dashboard/components/nav/Sidebar.tsx\` — accordion sidebar (multi-open), \`localStorage\`-persisted expanded state under \`nav.expanded\`, auto-expand of the active section, per-leaf badges + collapsed-section roll-ups.
- Modified: \`apps/dashboard/app/layout.tsx\` — slimmed to mount the new \`Sidebar\` component. Favicon dot + document-title side-effects move into \`Sidebar\`.

## What does NOT change

- URLs do not move in this PR. Old routes (\`/timeline\`, \`/queue\`, …) still work unchanged. Route migration to the canonical \`/section/resource\` schema lands in **PR2 (\`feat/dash-002-url-schema-redirect\`)** with redirect stubs so bookmarks don't break.
- WebSocket subscription (\`useWebSocket('ws://localhost:7776/events')\`) — unchanged.
- \`useUnseenBadges\` hook — unchanged.
- Project filter (\`?project=<slug>\`) — unchanged.

## A11y

- Accordion section headers are \`<button aria-expanded>\` toggling \`<ul role=\"region\">\`.
- Active link has \`aria-current=\"page\"\`.
- Per-leaf badges have descriptive \`aria-label\`s (e.g. "Tasks — 3 unseen updates").
- Decorative icons / chevrons are \`aria-hidden\`.

## Stats

- 3 files changed: +520 / −222 lines.
- 27 nav items → 6 groups containing 35 leaves (9 promoted orphans).

## Refs

- Audit: \`~/Documents/projects/reports/dashboard-nav-audit-2026-04-30.md\`
- IA spec: \`caia/docs/dashboard-url-schema.md\` (lands in PR10)
- UI conventions: \`caia/docs/dashboard-ui-conventions.md\` (lands in PR10)
- Series: PR1 of 11 in the dashboard-redesign release (\`release/2026-04-30-dashboard-redesign\`).