### PR TITLE
feat(dash-005): agent-activity rail (right sidebar)

### DIFF
--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -1,19 +1,17 @@
 'use client';
 import { Suspense } from 'react';
 import { Sidebar } from '../components/nav/Sidebar';
+import { Breadcrumb } from '../components/Breadcrumb';
+import { AgentActivityRail } from '../components/agents/AgentActivityRail';
 import './globals.css';
 
 /**
- * Root layout — DASH-001 nav restructure.
+ * Root layout — DASH-001 (nav restructure) + DASH-003 (breadcrumb)
+ * + DASH-005 (agent activity rail).
  *
- * The 27-item flat sidebar previously inlined here was extracted into
- * `components/nav/Sidebar.tsx` as an accordion-grouped component. The
- * grouping (Work / Pipeline / Catalog / Quality / Operations / Settings)
- * follows the IA spec at caia/docs/dashboard-url-schema.md.
- *
- * URLs do not change in this PR — only the nav structure does. Route
- * migration to the canonical `/section/resource` schema lands in PR2
- * (`feat/dash-002-url-schema-redirect`).
+ * Three-column shell: left nav (220px) | main content | right rail (280px,
+ * collapsible to 40px). The breadcrumb renders at the top of main on every
+ * drill-down page; section landings and the root self-hide.
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -52,8 +50,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
         {/* Main content area */}
         <main style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
+          <Suspense fallback={null}>
+            <Breadcrumb />
+          </Suspense>
           {children}
         </main>
+
+        {/* Right rail — agent activity (DASH-005) */}
+        <Suspense fallback={null}>
+          <AgentActivityRail />
+        </Suspense>
       </body>
     </html>
   );

--- a/apps/dashboard/components/agents/AgentActivityRail.tsx
+++ b/apps/dashboard/components/agents/AgentActivityRail.tsx
@@ -1,0 +1,302 @@
+'use client';
+
+/**
+ * AgentActivityRail — persistent right-sidebar showing currently-active
+ * agents. Click-to-navigate to the agent's detail page or the in-flight
+ * task. (DASH-005, "agents roaming around" widget.)
+ *
+ * Spec: caia/docs/dashboard-ui-conventions.md §4.
+ *
+ * Subscribes to the existing WS event bus via useAgentActivity. No new
+ * backend code; the orchestrator endpoint /agents seeds the roster, and
+ * per-agent live state is derived client-side.
+ *
+ * Collapsible to a 40px rail (toggle persists in localStorage).
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import Link from 'next/link';
+import { useAgentActivity, type AgentLiveState } from '../../hooks/useAgentActivity';
+
+const STORAGE_KEY = 'agent-rail.collapsed';
+
+function readCollapsed(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeCollapsed(collapsed: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, collapsed ? '1' : '0');
+  } catch {
+    // ignore
+  }
+}
+
+function fmtElapsed(startedAt: number | null): string {
+  if (!startedAt) return '';
+  const ms = Date.now() - startedAt;
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+  return `${Math.floor(ms / 3_600_000)}h`;
+}
+
+function statusColor(status: AgentLiveState['status']): string {
+  if (status === 'error') return '#fc8181';
+  if (status === 'busy') return '#68d391';
+  return '#a0aec0';
+}
+
+function AgentCard({ agent, now }: { agent: AgentLiveState; now: number }) {
+  const elapsed = agent.stageStartedAt ? fmtElapsed(agent.stageStartedAt) : '';
+  const headerHref = `/catalog/agents/${encodeURIComponent(agent.agentId)}`;
+  const taskHref = agent.currentTaskId ? `/work/tasks/${encodeURIComponent(agent.currentTaskId)}` : null;
+  const stageHref =
+    agent.currentPromptId && agent.currentStage
+      ? `/work/prompts/${encodeURIComponent(agent.currentPromptId)}/pipeline/${encodeURIComponent(agent.currentStage)}`
+      : null;
+  const lastLog = agent.recentLogs[0];
+
+  return (
+    <div
+      style={{
+        background: '#1a1f2e',
+        border: agent.status === 'error' ? '1px solid #fc8181' : '1px solid #2d3748',
+        borderRadius: 8,
+        padding: 10,
+        marginBottom: 8,
+        fontSize: 12,
+      }}
+    >
+      <Link
+        href={headerHref}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          textDecoration: 'none',
+          color: '#f0f4f8',
+          marginBottom: 6,
+        }}
+      >
+        <span aria-hidden="true">🤖</span>
+        <span style={{ flex: 1, fontWeight: 600 }}>{agent.displayName ?? agent.name}</span>
+        <span
+          style={{
+            color: statusColor(agent.status),
+            fontSize: 11,
+            fontWeight: 600,
+          }}
+        >
+          {agent.status}
+          {elapsed ? ` ${elapsed}` : ''}
+        </span>
+      </Link>
+      {taskHref && (
+        <div style={{ marginTop: 4 }}>
+          <Link href={taskHref} style={{ color: '#90cdf4', textDecoration: 'none' }}>
+            ▸ task {agent.currentTaskId}
+          </Link>
+        </div>
+      )}
+      {stageHref && (
+        <div style={{ marginTop: 2 }}>
+          <Link href={stageHref} style={{ color: '#a0aec0', textDecoration: 'none' }}>
+            stage: {agent.currentStage}
+          </Link>
+        </div>
+      )}
+      <div style={{ marginTop: 6, color: '#718096', fontSize: 11 }}>
+        Today: {agent.todayCompleted} • Errors 7d: {agent.errors7d}
+      </div>
+      {lastLog && (
+        <div
+          style={{
+            marginTop: 6,
+            padding: '4px 6px',
+            background: '#0f1117',
+            borderRadius: 4,
+            color: '#cbd5e0',
+            fontSize: 11,
+            fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          title={agent.recentLogs.join('\n')}
+        >
+          &gt; {lastLog}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ThoughtsTicker({ agents }: { agents: AgentLiveState[] }) {
+  const tickerLines = useMemo(() => {
+    const all: { agent: string; line: string }[] = [];
+    for (const a of agents) {
+      for (const line of a.recentLogs) {
+        all.push({ agent: a.displayName ?? a.name, line });
+      }
+    }
+    return all.slice(0, 4);
+  }, [agents]);
+
+  if (tickerLines.length === 0) return null;
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        padding: 10,
+        background: '#0f1117',
+        border: '1px solid #2d3748',
+        borderRadius: 8,
+      }}
+    >
+      <div style={{ fontSize: 10, color: '#718096', marginBottom: 4, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        Live thoughts
+      </div>
+      {tickerLines.map((t, i) => (
+        <div
+          key={i}
+          style={{
+            fontSize: 11,
+            color: '#cbd5e0',
+            fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            marginBottom: 2,
+          }}
+        >
+          <span style={{ color: '#90cdf4' }}>{t.agent}:</span> {t.line}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function AgentActivityRail() {
+  const { agents, connected } = useAgentActivity();
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const [now, setNow] = useState<number>(Date.now());
+
+  // Hydrate collapsed from storage.
+  useEffect(() => {
+    setCollapsed(readCollapsed());
+  }, []);
+  useEffect(() => {
+    writeCollapsed(collapsed);
+  }, [collapsed]);
+
+  // Tick now once a second to refresh time-in-stage display.
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  if (collapsed) {
+    return (
+      <aside
+        aria-label="Agent activity (collapsed)"
+        style={{
+          width: 40,
+          background: '#1a1f2e',
+          borderLeft: '1px solid #2d3748',
+          flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: '12px 0',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setCollapsed(false)}
+          aria-label="Expand agent activity"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: '#90cdf4',
+            fontSize: 18,
+            cursor: 'pointer',
+            padding: 4,
+          }}
+        >
+          🤖
+        </button>
+        <div style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', marginTop: 12, fontSize: 11, color: '#a0aec0' }}>
+          {agents.filter((a) => a.status === 'busy').length} busy
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      aria-label="Agent activity"
+      style={{
+        width: 280,
+        background: '#1a1f2e',
+        borderLeft: '1px solid #2d3748',
+        flexShrink: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        overflowY: 'auto',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '12px 12px 8px',
+          borderBottom: '1px solid #2d3748',
+        }}
+      >
+        <span style={{ fontSize: 14, fontWeight: 700, color: '#cbd5e0', flex: 1 }}>
+          🤖 Agent activity
+        </span>
+        <span style={{ fontSize: 10, color: connected ? '#68d391' : '#fc8181' }}>
+          {connected ? '● live' : '○ off'}
+        </span>
+        <button
+          type="button"
+          onClick={() => setCollapsed(true)}
+          aria-label="Collapse agent activity"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: '#a0aec0',
+            cursor: 'pointer',
+            fontSize: 14,
+            padding: 2,
+          }}
+        >
+          ›
+        </button>
+      </div>
+
+      <div style={{ padding: 10 }}>
+        {agents.length === 0 && (
+          <div style={{ fontSize: 12, color: '#718096', padding: 8 }}>
+            No agents active right now.
+          </div>
+        )}
+        {agents.map((a) => (
+          <AgentCard key={a.agentId} agent={a} now={now} />
+        ))}
+        <ThoughtsTicker agents={agents} />
+      </div>
+    </aside>
+  );
+}
+
+export default AgentActivityRail;

--- a/apps/dashboard/hooks/useAgentActivity.ts
+++ b/apps/dashboard/hooks/useAgentActivity.ts
@@ -1,0 +1,177 @@
+'use client';
+
+/**
+ * useAgentActivity — derives a per-agent live-activity map from the
+ * existing WS event feed (no new backend code).
+ *
+ * Spec: caia/docs/dashboard-ui-conventions.md §4.
+ *
+ * Behaviour:
+ *   - On mount, fetches `/api/agents` (or `/agents` if available) for the
+ *     agent roster. Failures are non-fatal — the hook falls back to deriving
+ *     agents from observed events.
+ *   - Subscribes to the WS feed via useWebSocket('ws://localhost:7776/events')
+ *     and updates per-agent state in response to `task_run.*`, `task.*`,
+ *     `agent.*`, and `pipeline.*` event kinds.
+ *   - Computes derived fields client-side: time-in-stage, busy/idle,
+ *     today-completed, errors-7d.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useWebSocket } from './useWebSocket';
+
+const API = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:7776';
+
+export interface AgentLiveState {
+  agentId: string;
+  name: string;
+  displayName?: string;
+  tier?: string;
+  status: 'idle' | 'busy' | 'error';
+  currentTaskId: string | null;
+  currentPromptId: string | null;
+  currentStage: string | null;
+  stageStartedAt: number | null;
+  todayCompleted: number;
+  errors7d: number;
+  recentLogs: string[];
+}
+
+const MAX_LOG_LINES = 5;
+
+function emptyState(agentId: string, name?: string): AgentLiveState {
+  return {
+    agentId,
+    name: name ?? agentId,
+    status: 'idle',
+    currentTaskId: null,
+    currentPromptId: null,
+    currentStage: null,
+    stageStartedAt: null,
+    todayCompleted: 0,
+    errors7d: 0,
+    recentLogs: [],
+  };
+}
+
+interface RosterAgent {
+  id: string;
+  name?: string;
+  displayName?: string;
+  tier?: string;
+}
+
+export function useAgentActivity() {
+  const { lastEvent, connected } = useWebSocket('ws://localhost:7776/events');
+  const [agents, setAgents] = useState<Record<string, AgentLiveState>>({});
+  const [rosterLoaded, setRosterLoaded] = useState(false);
+  const lastEventRef = useRef<typeof lastEvent>(null);
+
+  // Bootstrap roster.
+  useEffect(() => {
+    let alive = true;
+    fetch(`${API}/agents`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error('roster fetch failed'))))
+      .then((data: unknown) => {
+        if (!alive) return;
+        const list = Array.isArray(data)
+          ? (data as RosterAgent[])
+          : (data && typeof data === 'object' && 'agents' in data
+              ? ((data as { agents: RosterAgent[] }).agents)
+              : []);
+        const next: Record<string, AgentLiveState> = {};
+        for (const a of list) {
+          const id = a.id || a.name || '';
+          if (!id) continue;
+          next[id] = {
+            ...emptyState(id, a.displayName ?? a.name ?? id),
+            displayName: a.displayName,
+            tier: a.tier,
+          };
+        }
+        setAgents((prev) => ({ ...next, ...prev }));
+        setRosterLoaded(true);
+      })
+      .catch(() => {
+        if (alive) setRosterLoaded(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Apply WS events.
+  useEffect(() => {
+    if (!lastEvent || lastEvent === lastEventRef.current) return;
+    lastEventRef.current = lastEvent;
+
+    const kind = lastEvent.kind ?? '';
+    const payload = (lastEvent as unknown as { payload?: Record<string, unknown> }).payload ?? {};
+    const agentId =
+      (payload['agent_id'] as string | undefined) ??
+      (payload['agentId'] as string | undefined) ??
+      (payload['agent'] as string | undefined) ??
+      null;
+    if (!agentId) return;
+
+    setAgents((prev) => {
+      const cur = prev[agentId] ?? emptyState(agentId);
+      const next: AgentLiveState = { ...cur };
+
+      // Stage / task transitions.
+      if (kind.startsWith('task_run.started') || kind.startsWith('agent.busy')) {
+        next.status = 'busy';
+        next.stageStartedAt = Date.now();
+        next.currentStage = (payload['stage'] as string | undefined) ?? next.currentStage;
+        next.currentTaskId = (payload['task_id'] as string | undefined) ?? next.currentTaskId;
+        next.currentPromptId = (payload['prompt_id'] as string | undefined) ?? next.currentPromptId;
+      } else if (
+        kind.startsWith('task_run.completed') ||
+        kind.startsWith('agent.idle') ||
+        kind === 'task.completed'
+      ) {
+        next.status = 'idle';
+        next.currentStage = null;
+        next.currentTaskId = null;
+        next.stageStartedAt = null;
+        next.todayCompleted = (cur.todayCompleted ?? 0) + 1;
+      } else if (kind.startsWith('task_run.failed') || kind.startsWith('agent.error')) {
+        next.status = 'error';
+        next.errors7d = (cur.errors7d ?? 0) + 1;
+      } else if (kind.startsWith('pipeline.stage_changed')) {
+        next.currentStage = (payload['stage'] as string | undefined) ?? next.currentStage;
+        next.stageStartedAt = Date.now();
+      }
+
+      // Capture log lines.
+      const message =
+        (payload['message'] as string | undefined) ??
+        (payload['text'] as string | undefined) ??
+        null;
+      if (message) {
+        next.recentLogs = [message, ...cur.recentLogs].slice(0, MAX_LOG_LINES);
+      }
+
+      return { ...prev, [agentId]: next };
+    });
+  }, [lastEvent]);
+
+  // Derived sorted list — busy first, then idle, errors pinned to top.
+  const sortedAgents = useMemo(() => {
+    const arr = Object.values(agents);
+    return arr.sort((a, b) => {
+      if (a.status === 'error' && b.status !== 'error') return -1;
+      if (b.status === 'error' && a.status !== 'error') return 1;
+      if (a.status === 'busy' && b.status !== 'busy') return -1;
+      if (b.status === 'busy' && a.status !== 'busy') return 1;
+      if (a.status === 'busy' && b.status === 'busy') {
+        const at = a.stageStartedAt ?? 0;
+        const bt = b.stageStartedAt ?? 0;
+        return at - bt;
+      }
+      return (a.displayName ?? a.name).localeCompare(b.displayName ?? b.name);
+    });
+  }, [agents]);
+
+  return { agents: sortedAgents, connected, rosterLoaded };
+}


### PR DESCRIPTION
Adds the persistent right-sidebar 'agents roaming around' widget. Subscribes to existing WS feed (no new backend). Per-agent cards show name + status pill + current task/stage links + counters + last log line. Collapsible to 40px rail. Refs caia/docs/dashboard-ui-conventions.md §4. PR5 of 11.