### PR TITLE
chore(dash-007): consolidate redundant routes

### DIFF
--- a/apps/dashboard/app/projects/[slug]/blockers/page.tsx
+++ b/apps/dashboard/app/projects/[slug]/blockers/page.tsx
@@ -1,5 +1,9 @@
+/**
+ * Project filter shortcut — DASH-007 retarget.
+ * Redirects to /work/blockers?project=<slug> in the new IA.
+ */
 import { redirect } from 'next/navigation';
 
 export default function ProjectBlockers({ params }: { params: { slug: string } }) {
-  redirect(`/blockers?project=${params.slug}`);
+  redirect(`/work/blockers?project=${params.slug}`);
 }

--- a/apps/dashboard/app/projects/[slug]/questions/page.tsx
+++ b/apps/dashboard/app/projects/[slug]/questions/page.tsx
@@ -1,5 +1,9 @@
+/**
+ * Project filter shortcut — DASH-007 retarget.
+ * Redirects to /work/questions?project=<slug> in the new IA.
+ */
 import { redirect } from 'next/navigation';
 
 export default function ProjectQuestions({ params }: { params: { slug: string } }) {
-  redirect(`/questions?project=${params.slug}`);
+  redirect(`/work/questions?project=${params.slug}`);
 }

--- a/apps/dashboard/app/projects/[slug]/requirements/page.tsx
+++ b/apps/dashboard/app/projects/[slug]/requirements/page.tsx
@@ -1,5 +1,9 @@
+/**
+ * Project filter shortcut — DASH-007 retarget.
+ * Redirects to /work/requirements?project=<slug> in the new IA.
+ */
 import { redirect } from 'next/navigation';
 
 export default function ProjectRequirements({ params }: { params: { slug: string } }) {
-  redirect(`/requirements?project=${params.slug}`);
+  redirect(`/work/requirements?project=${params.slug}`);
 }

--- a/apps/dashboard/app/projects/[slug]/tasks/page.tsx
+++ b/apps/dashboard/app/projects/[slug]/tasks/page.tsx
@@ -1,5 +1,9 @@
+/**
+ * Project filter shortcut — DASH-007 retarget.
+ * Redirects to /work/tasks?project=<slug> in the new IA.
+ */
 import { redirect } from 'next/navigation';
 
 export default function ProjectTasks({ params }: { params: { slug: string } }) {
-  redirect(`/tasks?project=${params.slug}`);
+  redirect(`/work/tasks?project=${params.slug}`);
 }

--- a/apps/dashboard/app/projects/[slug]/timeline/page.tsx
+++ b/apps/dashboard/app/projects/[slug]/timeline/page.tsx
@@ -1,5 +1,9 @@
+/**
+ * Project filter shortcut — DASH-007 retarget.
+ * Redirects to /pipeline/timeline?project=<slug> in the new IA.
+ */
 import { redirect } from 'next/navigation';
 
 export default function ProjectTimeline({ params }: { params: { slug: string } }) {
-  redirect(`/timeline?project=${params.slug}`);
+  redirect(`/pipeline/timeline?project=${params.slug}`);
 }

--- a/apps/dashboard/app/work/prompts/reports/page.tsx
+++ b/apps/dashboard/app/work/prompts/reports/page.tsx
@@ -1,0 +1,7 @@
+/**
+ * /work/prompts/reports — DASH-007 consolidation stub.
+ * Re-exports the legacy /reports/prompts implementation. The bare
+ * /reports parent had no top-level page; this consolidates the
+ * single useful child into the Work section.
+ */
+export { default } from '../../../reports/prompts/page';


### PR DESCRIPTION
Retargets /projects/[slug]/* filter-shortcut redirects to new IA paths (e.g. /pipeline/timeline?project=… instead of /timeline?project=…). Adds /work/prompts/reports stub for the previously orphan /reports/prompts page. Refs caia/docs/dashboard-url-schema.md §3. PR7 of 11.