### PR TITLE
release(2026-04-30-no-api-key-compliance): cherry-picked LAI-001 + decomposer-widening + scaffolder-fix + routing-default → main

### DIFF
--- a/apps/orchestrator/scripts/boot-orchestrator.cjs
+++ b/apps/orchestrator/scripts/boot-orchestrator.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/* eslint-disable */
+/**
+ * Boot stub for the launchd-managed orchestrator daemon.
+ *
+ * Invoked by ~/Library/LaunchAgents/com.caia.orchestrator.plist via
+ *   node tsx/cli.mjs boot-orchestrator.cjs
+ * which means we run inside tsx's loader context — `require()` here can
+ * load TypeScript sources directly. We import startApiServer from
+ * src/api/start.ts and invoke it.
+ *
+ * Recreated 2026-04-30 as part of the LAI-001 / PO-DECOMP daily release.
+ * The original file was missing, leaving the launchd plist broken; the
+ * orchestrator was only kept alive by a long-running tsx process from
+ * before the deletion.
+ */
+'use strict';
+
+const path = require('path');
+const startTs = path.join(__dirname, '..', 'src', 'api', 'start.ts');
+
+// tsx's loader hooks let us `require` a .ts file directly.
+const { startApiServer } = require(startTs);
+
+(async () => {
+  try {
+    const handle = await startApiServer();
+    const shutdown = (sig) => {
+      try { handle.stop(); } catch (_) {}
+      process.exit(sig === 'SIGINT' ? 130 : 0);
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+    // eslint-disable-next-line no-console
+    console.error('[boot-orchestrator] startApiServer() resolved; pid=' + process.pid);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[boot-orchestrator] startApiServer failed:', err);
+    process.exit(1);
+  }
+})();

--- a/apps/orchestrator/src/agents/scaffolder.ts
+++ b/apps/orchestrator/src/agents/scaffolder.ts
@@ -153,26 +153,41 @@ export const ACTIVATION_MAP: Record<RequestType, string[]> = {
     'testing-agent',
     'release-agent',
   ],
+  // PO-DECOMP-WIDEN-VERBS (2026-04-30): bug-fix / refactor / performance /
+  // security previously had NO po-agent in the activation list, so the
+  // decomposer never ran for these request types and they stalled at
+  // test_designed with 0 stories. The rule-based decomposer now emits
+  // verb-specific story templates for these cases (see
+  // packages/decomposer/src/rule-based.ts) - adding po-agent + ba-agent
+  // here lets the pipeline reach ready_for_pickup for these prompts.
   'bug-fix': [
+    'po-agent',
+    'ba-agent',
     'developer-agent',
     'testing-agent',
     'release-agent',
     'security-agent',
   ],
   'refactor': [
+    'po-agent',
     'ea-agent',
+    'ba-agent',
     'developer-agent',
     'testing-agent',
     'release-agent',
   ],
   'performance': [
+    'po-agent',
+    'ba-agent',
     'developer-agent',
     'observability-agent',
     'testing-agent',
     'release-agent',
   ],
   'security': [
+    'po-agent',
     'security-agent',
+    'ba-agent',
     'developer-agent',
     'testing-agent',
     'release-agent',

--- a/apps/orchestrator/src/agents/scaffolder.ts
+++ b/apps/orchestrator/src/agents/scaffolder.ts
@@ -160,9 +160,16 @@ export const ACTIVATION_MAP: Record<RequestType, string[]> = {
   // verb-specific story templates for these cases (see
   // packages/decomposer/src/rule-based.ts) - adding po-agent + ba-agent
   // here lets the pipeline reach ready_for_pickup for these prompts.
+  //
+  // SCAFFOLDER-TASK-SCHEDULER-FIX (2026-04-30): task-scheduler is what
+  // ultimately advances the prompt to `bucket_placed` -> `ready_for_pickup`.
+  // Without it the pipeline stops at `ea_decomposed`. Adding task-scheduler
+  // to all four request types so they reach the same terminal state as
+  // new-feature / new-project.
   'bug-fix': [
     'po-agent',
     'ba-agent',
+    'task-scheduler',
     'developer-agent',
     'testing-agent',
     'release-agent',
@@ -172,6 +179,7 @@ export const ACTIVATION_MAP: Record<RequestType, string[]> = {
     'po-agent',
     'ea-agent',
     'ba-agent',
+    'task-scheduler',
     'developer-agent',
     'testing-agent',
     'release-agent',
@@ -179,6 +187,7 @@ export const ACTIVATION_MAP: Record<RequestType, string[]> = {
   'performance': [
     'po-agent',
     'ba-agent',
+    'task-scheduler',
     'developer-agent',
     'observability-agent',
     'testing-agent',
@@ -188,6 +197,7 @@ export const ACTIVATION_MAP: Record<RequestType, string[]> = {
     'po-agent',
     'security-agent',
     'ba-agent',
+    'task-scheduler',
     'developer-agent',
     'testing-agent',
     'release-agent',

--- a/apps/orchestrator/src/safety/spend-guard-bridge.test.ts
+++ b/apps/orchestrator/src/safety/spend-guard-bridge.test.ts
@@ -216,3 +216,68 @@ describe('SAFETY-004 spend-guard bridge', () => {
     expect(bridge.pauseState().paused).toBe(false);
   });
 });
+
+
+// ─── No-API-key constraint (Prakash 2026-04-30) ──────────────────────────
+//
+// The bridge defaults rejectApiKeyVia to TRUE. Test 13 asserts default
+// behaviour — every record() with via:'api-key' is refused. Test 14
+// asserts the legacy escape hatch still works for tests that pass
+// `rejectApiKeyVia: false` (no production code does).
+
+import { ApiKeyViaForbiddenError } from '@chiefaia/spend-guard';
+
+describe('SAFETY-004 + LAI-001 no-API-key constraint', () => {
+  it('13. production default rejects via=api-key', async () => {
+    const bridge = buildSpendGuardBridge();
+    await expect(
+      bridge.record({
+        taskId: 't13',
+        projectId: null,
+        agentRole: 'po',
+        model: 'claude-sonnet-4-6',
+        via: 'api-key',
+        accountId: 'apikey-default',
+        inputTokens: 1,
+        outputTokens: 1,
+        costUsd: 0.0001,
+      }),
+    ).rejects.toBeInstanceOf(ApiKeyViaForbiddenError);
+  });
+
+  it('14. opt-out rejectApiKeyVia:false still records api-key (legacy / test only)', async () => {
+    const sink = new InMemoryRecordSink();
+    const bridge = buildSpendGuardBridge({ recordSink: sink, rejectApiKeyVia: false });
+    await bridge.record({
+      taskId: 't14',
+      projectId: null,
+      agentRole: 'po',
+      model: 'claude-sonnet-4-6',
+      via: 'api-key',
+      accountId: 'apikey-default',
+      inputTokens: 1,
+      outputTokens: 1,
+      costUsd: 0.0001,
+    });
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.via).toBe('api-key');
+  });
+
+  it('15. via=subscription is accepted under default config (binary-spawn adapter path)', async () => {
+    const sink = new InMemoryRecordSink();
+    const bridge = buildSpendGuardBridge({ recordSink: sink });
+    await bridge.record({
+      taskId: 't15',
+      projectId: null,
+      agentRole: 'coding',
+      model: 'claude-sonnet-4-6',
+      via: 'subscription',
+      accountId: 'acct-1',
+      inputTokens: 5,
+      outputTokens: 5,
+      costUsd: 0.001,
+    });
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records[0]?.via).toBe('subscription');
+  });
+});

--- a/apps/orchestrator/src/safety/spend-guard-bridge.ts
+++ b/apps/orchestrator/src/safety/spend-guard-bridge.ts
@@ -17,6 +17,13 @@
  * Account-pool default = 2 (multi) per Prakash 2026-04-29 update; serial
  * fallback when both accounts are rate-limited.
  *
+ * No-API-key constraint (Prakash 2026-04-30 — see
+ * `feedback_no_api_key_billing.md`): production wiring constructs the
+ * SpendGuard with `rejectApiKeyVia: true` so any record() that uses
+ * `via: 'api-key'` throws `ApiKeyViaForbiddenError`. Catches regressions
+ * where a code path silently routes a Claude call through the legacy
+ * fetch-based adapter instead of the new `claude` binary spawn.
+ *
  * Reference: caia/docs/spend-guard.md, v2 §6.
  */
 
@@ -28,6 +35,7 @@ import {
   AccountPool,
   computeCostUsd,
   estimateRequestCostUsd,
+  ApiKeyViaForbiddenError,
   type CapStore,
   type SpendRecordSink,
   type SpendCap,
@@ -50,6 +58,14 @@ export interface SpendGuardBridgeOptions {
   nowMs?: () => number;
   /** Optional logger; default stderr. */
   log?: (msg: string) => void;
+  /**
+   * No-API-key constraint (Prakash 2026-04-30,
+   * `feedback_no_api_key_billing.md`). Defaults to TRUE — production
+   * orchestrator wiring rejects any record() with `via: 'api-key'`.
+   * Tests that intentionally exercise the legacy fetch path can pass
+   * `false` to opt out (none should in production code).
+   */
+  rejectApiKeyVia?: boolean;
 }
 
 export interface SpendGuardBridge {
@@ -91,10 +107,13 @@ export function buildSpendGuardBridge(opts: SpendGuardBridgeOptions = {}): Spend
     recordSink,
     ...(opts.caps ? { caps: opts.caps } : {}),
     ...(opts.nowMs ? { nowMs: opts.nowMs } : {}),
+    rejectApiKeyVia: opts.rejectApiKeyVia ?? true,
     log: (ev) => {
       if (ev.kind === 'paused') log(`PAUSED: ${ev.reason}`);
       else if (ev.kind === 'resumed') log(`RESUMED by=${ev.by}`);
       else if (ev.kind === 'cap-breached') log(`cap breach: ${ev.scope}=${ev.resourceId}`);
+      else if (ev.kind === 'api-key-rejected')
+        log(`api-key REJECTED for task=${ev.taskId} model=${ev.model} (no-API-key rule)`);
     },
   });
 
@@ -127,6 +146,7 @@ export function buildAccountPoolBridge(opts: {
 export {
   SpendGuard,
   BudgetExceededError as SpendBudgetExceededError,
+  ApiKeyViaForbiddenError,
   InMemoryCapStore,
   InMemoryRecordSink,
   AccountPool,

--- a/caia/docs/local-llm-router.md
+++ b/caia/docs/local-llm-router.md
@@ -1,0 +1,75 @@
+# local-llm-router
+
+Routing layer that decides whether each task goes to local Ollama or to
+Claude. Lives at `packages/local-llm-router`.
+
+## Adapters
+
+### `ClaudeAdapter` — binary spawn (subscription auth)
+
+**Hard rule (Prakash 2026-04-30, see `feedback_no_api_key_billing.md`):
+the pay-per-token Anthropic API path is forbidden. The Claude path uses
+the `claude` CLI binary exclusively, which authenticates via the
+logged-in Max-20x subscription session.**
+
+Shape (LAI-001):
+
+```ts
+new ClaudeAdapter({
+  binaryPath?: string,        // default: process.env.CLAUDE_BINARY_PATH ?? 'claude'
+  homeOverride?: string,      // override HOME for per-account credentials dir
+  accountId?: string | null,  // attribution for telemetry + rate-limit reporting
+  timeoutMs?: number,         // default: 180_000
+  spawnFn?: typeof spawn,     // test seam
+})
+```
+
+The adapter spawns `claude --print --output-format json --model <model>`
+and pipes the prompt over stdin. It clears `ANTHROPIC_API_KEY` and
+`ANTHROPIC_AUTH_TOKEN` from the child env so the binary always uses the
+subscription session, never the API key. The binary's JSON output is
+parsed into the standard `LLMResponse`; `provider` is `'claude'`.
+
+#### Errors
+
+| Error class               | When                                                                                               |
+|---------------------------|----------------------------------------------------------------------------------------------------|
+| `ClaudeRateLimitedError`  | Anthropic returned 429/quota exhaustion. Subclass of `ClaudeBinaryError`. Carries `accountId`.     |
+| `ClaudeBinaryError`       | Any other failure: missing binary, non-zero exit, malformed JSON, timeout, child error event.      |
+
+The adapter NEVER falls back to API-key billing. The router's
+`fallbackOnError` knob (default true) catches these errors and falls
+back to **Ollama only**.
+
+#### Account rotation
+
+Per-account credentials live in different `~/.config/claude` dirs. The
+spend-guard `AccountPool` picks an account, then constructs a
+`ClaudeAdapter` with `homeOverride` pointing at the right per-account
+home (e.g. `/Users/MAC/.caia/accounts/acc-2`). When that account's
+session is rate-limited, the pool rotates to the next account; when both
+are exhausted, the router falls back to Ollama (or pauses the pipeline
+when the spend-guard `BudgetExceededError` is also live).
+
+### `OllamaAdapter` — local
+
+Unchanged. Pinned IPv4 (`127.0.0.1:11434`); chat-mode for thinking
+models, generate-mode for everything else; 10-minute keep_alive default.
+
+## Spend records
+
+Every Claude call records a `SpendRecord` via `@chiefaia/spend-guard`
+with `via: 'subscription'`. The orchestrator's bridge (`apps/orchestrator/src/safety/spend-guard-bridge.ts`)
+constructs the guard with `rejectApiKeyVia: true` (default), so any
+regression that records `via: 'api-key'` throws
+`ApiKeyViaForbiddenError` at the cap-record boundary.
+
+## No-API-key kludge for the daemon plist
+
+The `com.caia.orchestrator` launchd plist still sets a cosmetic
+`ANTHROPIC_API_KEY=<oauth-token>` env var to avoid noisy "missing key"
+warnings emitted by older code paths that haven't been migrated to the
+binary-spawn adapter yet. This is documented in
+`reports/daemon_repoint_2026-04-30.md` and will be removed once every
+caller is on the binary-spawn path. The kludge has no effect on the new
+adapter — it explicitly clears the variable on every spawn.

--- a/packages/decomposer/package.json
+++ b/packages/decomposer/package.json
@@ -5,7 +5,13 @@
   "description": "AI-driven hierarchy decomposer — breaks natural language into Initiative → Epic → Module → Story → Task.",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run"
+  },
   "dependencies": {
     "nanoid": "^5.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/decomposer/src/rule-based-verbs.test.ts
+++ b/packages/decomposer/src/rule-based-verbs.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression suite — rule-based decomposer must emit ≥3 stories for
+ * fix / refactor / audit / extract phrasings.
+ *
+ * Triggered by the live-pipeline validation on 2026-04-30 where 3/10
+ * prompts (bug-fix, refactor, test-heavy) stalled at `test_designed`
+ * with 0 stories because the decomposer's only verb template was
+ * "Implement core / Add UI/UX / Write tests / Document". This file
+ * keeps that gap closed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decomposeRuleBased } from './rule-based';
+import type { DecompositionNode } from './types';
+
+function flattenStories(nodes: DecompositionNode[]): DecompositionNode[] {
+  const out: DecompositionNode[] = [];
+  const walk = (n: DecompositionNode) => {
+    if (n.level === 'story') out.push(n);
+    n.children?.forEach(walk);
+  };
+  nodes.forEach(walk);
+  return out;
+}
+
+function getInitiativeMeta(
+  nodes: DecompositionNode[],
+): Record<string, unknown> | undefined {
+  return nodes[0]?.metadata;
+}
+
+describe('rule-based decomposer — verb-widened templates', () => {
+  // ─── The 3 prompts that stalled in live-pipeline validation 2026-04-30 ─
+
+  describe('regression: 2026-04-30 stalled prompts must produce ≥3 stories', () => {
+    it('bug-fix: "fix the login button not responsive on mobile"', () => {
+      const prompt = '[VAL-2026-04-30-051730-2-bug-fix] fix the login button not responsive on mobile';
+      const result = decomposeRuleBased(prompt);
+      const stories = flattenStories(result.hierarchy);
+      expect(stories.length).toBeGreaterThanOrEqual(3);
+      expect(getInitiativeMeta(result.hierarchy)?.['verbIntent']).toBe('fix');
+      // Stories should follow the fix template (root-cause / repro / fix / verify).
+      const titles = stories.map((s) => s.title.toLowerCase()).join(' | ');
+      expect(titles).toContain('investigate root cause');
+      expect(titles).toContain('reproducing test');
+      expect(titles).toContain('apply the fix');
+    });
+
+    it('refactor: "extract the user-auth logic into a reusable @chiefaia/auth-core package"', () => {
+      const prompt =
+        '[VAL-2026-04-30-051730-5-refactor] extract the user-auth logic into a reusable @chiefaia/auth-core package - every app currently duplicates the JWT parsing and session validation; consolidate behind a typed API';
+      const result = decomposeRuleBased(prompt);
+      const stories = flattenStories(result.hierarchy);
+      expect(stories.length).toBeGreaterThanOrEqual(3);
+      // "extract" wins over "refactor" because it's more specific.
+      expect(getInitiativeMeta(result.hierarchy)?.['verbIntent']).toBe('extract');
+      const titles = stories.map((s) => s.title.toLowerCase()).join(' | ');
+      expect(titles).toContain('extraction surface');
+      expect(titles).toContain('move the unit');
+      expect(titles).toContain('update consumers');
+    });
+
+    it('test-heavy: "add an accessibility audit pipeline + WCAG 2.1 AA conformance tests"', () => {
+      const prompt =
+        '[VAL-2026-04-30-051730-9-test-heavy] add an accessibility audit pipeline + WCAG 2.1 AA conformance tests for every public route';
+      const result = decomposeRuleBased(prompt);
+      const stories = flattenStories(result.hierarchy);
+      expect(stories.length).toBeGreaterThanOrEqual(3);
+      // "audit" wins because of the "audit pipeline" + "wcag" + "accessibility audit" signals.
+      expect(getInitiativeMeta(result.hierarchy)?.['verbIntent']).toBe('audit');
+      const titles = stories.map((s) => s.title.toLowerCase()).join(' | ');
+      expect(titles).toContain('enumerate audit scope');
+      expect(titles).toContain('automated checks');
+      expect(titles).toContain('audit report');
+    });
+  });
+
+  // ─── verb classification ──────────────────────────────────────────────
+
+  describe('verb intent classification', () => {
+    it('classifies "fix the X" as fix', () => {
+      const r = decomposeRuleBased('fix the broken authentication flow');
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('fix');
+    });
+
+    it('classifies "refactor X" as refactor', () => {
+      const r = decomposeRuleBased('refactor the monolithic UserService into smaller services');
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('refactor');
+    });
+
+    it('classifies "extract Y from Z" as extract (more specific than refactor)', () => {
+      const r = decomposeRuleBased('extract the email-sending logic into its own package');
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('extract');
+    });
+
+    it('classifies "audit the X" as audit', () => {
+      const r = decomposeRuleBased('audit the API surface for breaking-change risk');
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('audit');
+    });
+
+    it('classifies plain "add X" as add (default feature template)', () => {
+      const r = decomposeRuleBased('add a logout button to the navbar');
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('add');
+    });
+
+    it('a "review for security issues" classifies as audit, not add', () => {
+      const r = decomposeRuleBased('review the dependency tree for security issues');
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('audit');
+    });
+  });
+
+  // ─── per-verb story shape ────────────────────────────────────────────
+
+  describe('per-verb story templates', () => {
+    it('fix produces investigate / repro / fix / verify steps', () => {
+      const r = decomposeRuleBased('fix the slow dashboard render');
+      const stories = flattenStories(r.hierarchy);
+      expect(stories.length).toBe(4);
+      const titles = stories.map((s) => s.title.toLowerCase());
+      expect(titles[0]).toContain('investigate root cause');
+      expect(titles[1]).toContain('reproducing test');
+      expect(titles[2]).toContain('apply the fix');
+      expect(titles[3]).toContain('verify');
+    });
+
+    it('refactor produces boundaries / characterisation / incremental / verify steps', () => {
+      const r = decomposeRuleBased('refactor the legacy billing module');
+      const stories = flattenStories(r.hierarchy);
+      expect(stories.length).toBe(4);
+      const titles = stories.map((s) => s.title.toLowerCase());
+      expect(titles[0]).toContain('identify boundaries');
+      expect(titles[1]).toContain('characterisation tests');
+      expect(titles[2]).toContain('incremental commits');
+      expect(titles[3]).toContain('behaviour unchanged');
+    });
+
+    it('extract produces map surface / move unit / update consumers / verify isolation steps', () => {
+      const r = decomposeRuleBased('extract the JWT helpers into @chiefaia/auth-core');
+      const stories = flattenStories(r.hierarchy);
+      expect(stories.length).toBe(4);
+      const titles = stories.map((s) => s.title.toLowerCase());
+      expect(titles[0]).toContain('extraction surface');
+      expect(titles[1]).toContain('move the unit');
+      expect(titles[2]).toContain('update consumers');
+      expect(titles[3]).toContain('isolation');
+    });
+
+    it('audit produces scope / automated / manual / report steps', () => {
+      const r = decomposeRuleBased('audit the storage layer for PII handling');
+      const stories = flattenStories(r.hierarchy);
+      expect(stories.length).toBe(4);
+      const titles = stories.map((s) => s.title.toLowerCase());
+      expect(titles[0]).toContain('enumerate audit scope');
+      expect(titles[1]).toContain('automated checks');
+      expect(titles[2]).toContain('manual review');
+      expect(titles[3]).toContain('audit report');
+    });
+
+    it('every fix/refactor/extract/audit story has acceptance criteria (≥2 each)', () => {
+      const verbs = [
+        'fix the login button',
+        'refactor the user-auth module',
+        'extract the cache layer',
+        'audit the public API',
+      ];
+      for (const p of verbs) {
+        const r = decomposeRuleBased(p);
+        const stories = flattenStories(r.hierarchy);
+        expect(stories.length).toBeGreaterThanOrEqual(3);
+        for (const s of stories) {
+          expect(s.acceptanceCriteria?.length ?? 0).toBeGreaterThanOrEqual(2);
+        }
+      }
+    });
+  });
+
+  // ─── back-compat — the original "add" path still works ───────────────
+
+  describe('back-compat: add-verb prompts unchanged in shape', () => {
+    it('multi-section feature prompt still produces an epic per section', () => {
+      const r = decomposeRuleBased(
+        'add a user profile page with avatar upload and a display-name field',
+      );
+      // "and" splits into 3 sections → 3 epics, each with 2-4 stories
+      expect(r.hierarchy[0]?.children?.length).toBeGreaterThanOrEqual(2);
+      const stories = flattenStories(r.hierarchy);
+      expect(stories.length).toBeGreaterThanOrEqual(4);
+      expect(getInitiativeMeta(r.hierarchy)?.['verbIntent']).toBe('add');
+    });
+  });
+});

--- a/packages/decomposer/src/rule-based.ts
+++ b/packages/decomposer/src/rule-based.ts
@@ -1,6 +1,42 @@
 import { nanoid } from 'nanoid';
 import type { DecompositionNode, DecompositionResult, DecomposerConfig } from './types';
 
+/**
+ * Verb-intent classification used by the rule-based decomposer to pick
+ * a story template. The orchestrator's scaffolder also classifies
+ * request type, but it doesn't influence story content — only agent
+ * activation. This file owns the per-verb story templates.
+ *
+ * Live-pipeline validation 2026-04-30 surfaced the gap: prompts whose
+ * primary verb was fix / refactor / audit / extract stalled with zero
+ * stories because the decomposer's only template was the generic
+ * "Implement core / Add UI/UX / Write tests / Document" set. This file
+ * widens the template library to cover those verbs explicitly.
+ */
+export type VerbIntent =
+  | 'fix' // bug-fix: investigate, repro test, fix, verify
+  | 'refactor' // restructure existing code without behaviour change
+  | 'extract' // pull a module/function/component out into its own unit
+  | 'audit' // enumerate scope, automated checks, manual pass, report
+  | 'add'; // default: feature-add (the original template set)
+
+const FIX_VERBS = ['fix', 'broken', 'bug', 'crash', 'regress', 'not working', "doesn't work", "won't load", 'error', 'unresponsive'];
+const REFACTOR_VERBS = ['refactor', 'restructure', 'simplify', 'clean up', 'consolidate', 'decouple', 'modularize'];
+const EXTRACT_VERBS = ['extract', 'pull out', 'split out', 'move into a package', 'move to a package', 'separate package'];
+const AUDIT_VERBS = ['audit', 'review', 'assess', 'inspect', 'compliance', 'wcag', 'a11y', 'accessibility audit', 'security audit', 'inventory'];
+
+function detectVerbIntent(prompt: string): VerbIntent {
+  const lower = prompt.toLowerCase();
+
+  // Order matters: extract is more specific than refactor, audit is more
+  // specific than fix (an "audit for bugs" should not become a fix story).
+  if (EXTRACT_VERBS.some((v) => lower.includes(v))) return 'extract';
+  if (AUDIT_VERBS.some((v) => lower.includes(v))) return 'audit';
+  if (REFACTOR_VERBS.some((v) => lower.includes(v))) return 'refactor';
+  if (FIX_VERBS.some((v) => lower.includes(v))) return 'fix';
+  return 'add';
+}
+
 function estimateEffort(description: string): 'trivial' | 'small' | 'medium' | 'large' | 'xl' {
   const words = description.split(/\s+/).length;
   if (words < 5) return 'trivial';
@@ -13,16 +49,217 @@ function estimateEffort(description: string): 'trivial' | 'small' | 'medium' | '
 // Extract logical sections from a prompt using heuristics
 function extractSections(prompt: string): string[] {
   // Split on common separators: newlines, "and", semicolons, commas in lists
-  const lines = prompt.split(/\n+/).filter(l => l.trim().length > 5);
-  if (lines.length > 1) return lines.map(l => l.trim());
+  const lines = prompt.split(/\n+/).filter((l) => l.trim().length > 5);
+  if (lines.length > 1) return lines.map((l) => l.trim());
 
   // Single line — split on conjunctions
-  const parts = prompt.split(/,\s+(?:and\s+)?|\s+and\s+|\s*;\s*/i).filter(p => p.trim().length > 3);
+  const parts = prompt.split(/,\s+(?:and\s+)?|\s+and\s+|\s*;\s*/i).filter((p) => p.trim().length > 3);
   return parts.length > 1 ? parts : [prompt];
+}
+
+/**
+ * Verb-aware story template. Each verb has its own ordered set of
+ * story titles + acceptance criteria so the orchestrator's PO agent
+ * persists meaningful stories instead of the generic "Implement core"
+ * placeholder set that produced 0 useful work for fix/refactor/audit
+ * prompts in the 2026-04-30 validation.
+ */
+function templatesFor(verb: VerbIntent, sectionLabel: string): Array<{
+  title: string;
+  description: string;
+  acceptance: string[];
+}> {
+  const trimmed = sectionLabel.slice(0, 60);
+  switch (verb) {
+    case 'fix':
+      return [
+        {
+          title: `Investigate root cause: ${trimmed}`,
+          description: `Reproduce the failing behaviour locally and trace it to the originating module / function. Document the failure mode and the smallest input set that triggers it.`,
+          acceptance: [
+            'A reproducible local repro is documented in the PR description.',
+            'The owning module / function is identified by file path and line range.',
+          ],
+        },
+        {
+          title: `Write a reproducing test: ${trimmed}`,
+          description: `Add a failing test that captures the bug. The test must fail on main without the fix and pass after the fix lands.`,
+          acceptance: [
+            'A new test exists that fails on the unfixed branch.',
+            'The test runs in <5s and is hermetic (no network / DB dependency).',
+          ],
+        },
+        {
+          title: `Apply the fix: ${trimmed}`,
+          description: `Implement the smallest change that makes the reproducing test pass. Avoid drive-by refactors — keep the diff scoped to the bug.`,
+          acceptance: [
+            'The reproducing test passes.',
+            'No unrelated tests regress.',
+            'Change is < 50 LOC unless explicitly justified.',
+          ],
+        },
+        {
+          title: `Verify and add a regression guard: ${trimmed}`,
+          description: `Run the full test suite locally + confirm the fix in a manual smoke test path. Promote the reproducing test to the regression suite so the bug never silently returns.`,
+          acceptance: [
+            'Full test suite green.',
+            'The reproducing test is tagged for the regression suite.',
+            'A short post-mortem note is added to the PR (root cause + prevention).',
+          ],
+        },
+      ];
+
+    case 'refactor':
+      return [
+        {
+          title: `Identify boundaries: ${trimmed}`,
+          description: `Map the current module's surface area: public exports, callers, and shared state. Decide on the new boundary and document the planned structure.`,
+          acceptance: [
+            'A short ADR or PR description documents the new boundary.',
+            'All current callers are enumerated with file paths.',
+          ],
+        },
+        {
+          title: `Write characterisation tests: ${trimmed}`,
+          description: `Before changing any code, capture current behaviour with a set of tests that describe what the module does today (not what it should do). These tests are the safety net for the refactor.`,
+          acceptance: [
+            'New tests cover every public exit of the module.',
+            'All characterisation tests pass on the current main.',
+          ],
+        },
+        {
+          title: `Apply the refactor in incremental commits: ${trimmed}`,
+          description: `Make the structural change in small, mechanically reviewable commits. Each commit should leave the test suite green and the public API unchanged.`,
+          acceptance: [
+            'Each commit individually leaves the suite green.',
+            'No public-API change unless explicitly called out in the PR.',
+            'Commits are squash-mergeable but each is independently revertible.',
+          ],
+        },
+        {
+          title: `Verify behaviour unchanged: ${trimmed}`,
+          description: `Run the full test suite + any relevant integration / E2E checks. Compare the public-API surface area before vs after — they should match.`,
+          acceptance: [
+            'Full unit + integration suite green.',
+            'Public-API diff is empty (or each addition is documented).',
+            'No performance regression > 5% on the affected hot path.',
+          ],
+        },
+      ];
+
+    case 'extract':
+      return [
+        {
+          title: `Map the extraction surface: ${trimmed}`,
+          description: `Identify the unit to extract (function / module / package) and enumerate every consumer. Record the new public API the extracted unit will expose.`,
+          acceptance: [
+            'The extraction boundary is documented (file paths in scope + out of scope).',
+            'Every consumer is enumerated with the symbol they depend on.',
+            'The new public API is committed as a typed signature draft.',
+          ],
+        },
+        {
+          title: `Move the unit + its tests: ${trimmed}`,
+          description: `Cut the code over to its new home and move the corresponding tests with it. Keep the import path stable via a re-export shim where consumers haven't been migrated yet.`,
+          acceptance: [
+            'The unit and its tests live at the new location.',
+            'A re-export shim (or codemod) preserves consumer compatibility.',
+            'The original location is either empty or contains only the shim.',
+          ],
+        },
+        {
+          title: `Update consumers: ${trimmed}`,
+          description: `Migrate every consumer to the new import path. Remove the re-export shim once no consumers remain on the old path.`,
+          acceptance: [
+            'All consumers import from the new path.',
+            'The shim is deleted (or has a deprecation comment with removal-by date).',
+            'Bundle / dependency graph reflects the new boundary.',
+          ],
+        },
+        {
+          title: `Verify isolation: ${trimmed}`,
+          description: `Confirm the extracted unit has no hidden dependency on its former home. Run the full suite + a clean build to surface any latent coupling.`,
+          acceptance: [
+            'A clean build of the extracted unit succeeds with no reverse imports.',
+            'Full test suite green.',
+            'Architecture diagram (or import-graph snapshot) is updated.',
+          ],
+        },
+      ];
+
+    case 'audit':
+      return [
+        {
+          title: `Enumerate audit scope: ${trimmed}`,
+          description: `List the files / modules / endpoints / pages in scope for the audit. Decide which automated checks apply and what the manual review pass needs to cover.`,
+          acceptance: [
+            'A scoped inventory exists (file list or URL list).',
+            'The set of automated checks (linters, scanners, axe runs, dep audits) is committed.',
+            'The manual review checklist is committed.',
+          ],
+        },
+        {
+          title: `Run automated checks: ${trimmed}`,
+          description: `Execute the chosen automated checks. Capture findings in a machine-parseable format (SARIF, JSON) so they can feed the report.`,
+          acceptance: [
+            'Every automated check has a result file in the audit folder.',
+            'False-positives are triaged with a one-line note per dismissal.',
+            'Real findings are filed as backlog issues with severity tags.',
+          ],
+        },
+        {
+          title: `Manual review pass: ${trimmed}`,
+          description: `Walk the manual checklist with at least one reviewer. Combine human findings with the automated output into the unified findings list.`,
+          acceptance: [
+            'Every checklist item is marked PASS / FAIL / N/A with a one-line rationale.',
+            'Findings are appended to the unified list with reproduction steps.',
+            'Reviewer signs off on the manual pass in the PR description.',
+          ],
+        },
+        {
+          title: `Produce audit report: ${trimmed}`,
+          description: `Write the audit report: scope, methodology, findings (categorised + prioritised), recommendations, and a remediation plan. Land it in caia/docs/.`,
+          acceptance: [
+            'A dated report exists at caia/docs/.',
+            'Each finding has owner + severity + a linked backlog item.',
+            'A high-level executive summary is at the top of the report.',
+          ],
+        },
+      ];
+
+    case 'add':
+    default:
+      return [
+        {
+          title: `Implement core ${trimmed} functionality`,
+          description: `Write the core implementation for: ${trimmed}.`,
+          acceptance: [
+            `The ${trimmed.slice(0, 30)} feature works as expected.`,
+            'All tests pass.',
+          ],
+        },
+        {
+          title: `Add UI/UX for ${trimmed}`,
+          description: `Wire the user-facing surface for: ${trimmed}.`,
+          acceptance: ['UI matches the design spec.', 'Accessible by keyboard and screen reader.'],
+        },
+        {
+          title: `Write tests for ${trimmed}`,
+          description: `Unit + integration coverage for: ${trimmed}.`,
+          acceptance: ['Coverage meets the package threshold.', 'Edge cases covered.'],
+        },
+        {
+          title: `Document ${trimmed} implementation`,
+          description: `Update the README + relevant docs for: ${trimmed}.`,
+          acceptance: ['Public API documented.', 'Usage example included.'],
+        },
+      ];
+  }
 }
 
 export function decomposeRuleBased(prompt: string, _config: DecomposerConfig = {}): DecompositionResult {
   const sections = extractSections(prompt);
+  const verb = detectVerbIntent(prompt);
 
   // Create one Initiative for the whole prompt
   const initiative: DecompositionNode = {
@@ -32,42 +269,54 @@ export function decomposeRuleBased(prompt: string, _config: DecomposerConfig = {
     description: prompt,
     estimatedEffort: 'large',
     children: [],
+    metadata: { verbIntent: verb },
   };
 
   // Create one Epic per major section
   const epics: DecompositionNode[] = sections.map((section, i) => {
     const epicId = `epic-${nanoid(6)}`;
 
-    // Create 2-4 stories per epic
-    const storyCount = Math.min(Math.max(2, Math.ceil(section.split(/\s+/).length / 10)), 4);
+    const templates = templatesFor(verb, section);
+    // Story count: at minimum 3 per the user's requirement (must emit ≥3
+    // stories for fix/refactor/audit/extract). Originally we capped by
+    // section word count which produced 0-2 stories for short prompts —
+    // hence the 2026-04-30 stall. New formula:
+    //   feature-add: keep historical 2..4 sizing
+    //   fix/refactor/extract/audit: always emit the full template set (4)
+    //     because each step is an irreducible part of the workflow.
+    let storyCount: number;
+    if (verb === 'add') {
+      storyCount = Math.min(Math.max(2, Math.ceil(section.split(/\s+/).length / 10)), 4);
+    } else {
+      storyCount = templates.length;
+    }
     const stories: DecompositionNode[] = [];
-
-    const storyTemplates = [
-      `Implement core ${section.slice(0, 30)} functionality`,
-      `Add UI/UX for ${section.slice(0, 30)}`,
-      `Write tests for ${section.slice(0, 30)}`,
-      `Document ${section.slice(0, 30)} implementation`,
-    ];
 
     for (let s = 0; s < storyCount; s++) {
       const storyId = `story-${nanoid(6)}`;
-      const storyTitle = storyTemplates[s] ?? `Implement ${section.slice(0, 30)} part ${s + 1}`;
+      const tpl = templates[s] ?? templates[templates.length - 1]!;
 
-      // Create 2 tasks per story
+      // Per-verb task pair. For fix/refactor/extract/audit the second
+      // task is "verify" rather than "tests" because the work itself is
+      // already test-centric (write reproducing test, characterisation
+      // test, etc).
       const tasks: DecompositionNode[] = [
         {
           id: `task-${nanoid(6)}`,
           level: 'task',
-          title: `${storyTitle} — implementation`,
-          description: `Write the code for: ${storyTitle}`,
+          title: `${tpl.title} — implementation`,
+          description: tpl.description,
           estimatedEffort: 'small',
           canParallelize: false,
         },
         {
           id: `task-${nanoid(6)}`,
           level: 'task',
-          title: `${storyTitle} — tests`,
-          description: `Write unit and integration tests for: ${storyTitle}`,
+          title: `${tpl.title} — verification`,
+          description:
+            verb === 'add'
+              ? `Write unit and integration tests for: ${tpl.title}`
+              : `Run the verification step described above and capture evidence.`,
           estimatedEffort: 'small',
           canParallelize: false,
         },
@@ -76,26 +325,28 @@ export function decomposeRuleBased(prompt: string, _config: DecomposerConfig = {
       stories.push({
         id: storyId,
         level: 'story',
-        title: storyTitle,
-        description: `As a user, I want to ${section} so that I can achieve my goal.`,
-        acceptanceCriteria: [
-          `The ${section.slice(0, 30)} feature works as expected`,
-          'All tests pass',
-        ],
+        title: tpl.title,
+        description:
+          verb === 'add'
+            ? `As a user, I want to ${section} so that I can achieve my goal.`
+            : tpl.description,
+        acceptanceCriteria: tpl.acceptance,
         estimatedEffort: estimateEffort(section),
         canParallelize: s > 0, // First story is foundational, rest can parallelize
         children: tasks,
+        metadata: { verbIntent: verb, templateIndex: s },
       });
     }
 
     return {
       id: epicId,
       level: 'epic',
-      title: `Epic ${i + 1}: ${section.slice(0, 50)}`,
+      title: `Epic ${String(i + 1)}: ${section.slice(0, 50)}`,
       description: section,
       estimatedEffort: 'large',
       canParallelize: i > 0,
       children: stories,
+      metadata: { verbIntent: verb },
     };
   });
 
@@ -112,6 +363,6 @@ export function decomposeRuleBased(prompt: string, _config: DecomposerConfig = {
     totalNodes,
     estimatedDays: epics.length * 3,
     recommendedParallelTracks: Math.min(epics.length, 3),
-    summary: `Decomposed into ${epics.length} epic(s) with ${totalNodes} total nodes. Estimated ${epics.length * 3} days.`,
+    summary: `Decomposed (verb=${verb}) into ${String(epics.length)} epic(s) with ${String(totalNodes)} total nodes. Estimated ${String(epics.length * 3)} days.`,
   };
 }

--- a/packages/decomposer/vitest.config.ts
+++ b/packages/decomposer/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest config for @chiefaia/decomposer.
+ *
+ * The original `decomposer.test.ts` was written for Jest and was never
+ * actually run (no test script in package.json). This config wires up
+ * vitest so the rule-based regression tests
+ * (`rule-based-verbs.test.ts`, added 2026-04-30) execute on every PR.
+ *
+ * Only the new vitest-style test runs here. The legacy Jest-style file
+ * is excluded until it is migrated.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/rule-based-verbs.test.ts'],
+    exclude: ['dist/**', 'node_modules/**', 'src/decomposer.test.ts'],
+  },
+});

--- a/packages/local-llm-router/src/claude-adapter.ts
+++ b/packages/local-llm-router/src/claude-adapter.ts
@@ -16,8 +16,20 @@ import type { LLMRequest, LLMResponse } from './types.js';
 
 /** Default path to the `claude` binary. Overridable via env. */
 const DEFAULT_CLAUDE_BINARY = process.env['CLAUDE_BINARY_PATH'] ?? 'claude';
-/** Default subprocess timeout (ms). 3 minutes covers a slow Sonnet response. */
-const DEFAULT_TIMEOUT_MS = 180_000;
+/** Default subprocess timeout (ms).
+ *
+ * Lowered 2026-04-30 from 180_000 to 45_000. The original 3-minute window
+ * was sized for the legacy fetch-based adapter where the cost was network
+ * RTT + model time. The binary-spawn path adds ~6-10s session-init
+ * overhead per call, AND the orchestrator can have many in-flight
+ * validation calls; if Claude is unreachable, waiting 3 minutes per call
+ * before falling back to Ollama bottlenecks the whole pipeline.
+ *
+ * 45s covers a normal Sonnet response with margin while keeping fallback
+ * latency bounded. Overridable via opts.timeoutMs for callers that
+ * deliberately want a longer ceiling (e.g., bulk decomposition).
+ */
+const DEFAULT_TIMEOUT_MS = 45_000;
 
 /** Generic binary-spawn failure. Thrown for missing binary, non-zero exit,
  *  malformed JSON, or any other non-rate-limit error. */

--- a/packages/local-llm-router/src/claude-adapter.ts
+++ b/packages/local-llm-router/src/claude-adapter.ts
@@ -1,85 +1,306 @@
-// Claude API adapter — calls Anthropic's REST API directly via fetch.
-// No Anthropic SDK import so this package stays dependency-free.
+// Claude binary-spawn adapter — spawns the `claude` CLI in --print --output-format=json
+// mode and uses the subscription session (Max 20x) for auth.
+//
+// HARD CONSTRAINT (Prakash 2026-04-30, see feedback_no_api_key_billing.md):
+//   The pay-per-token Anthropic API path is FORBIDDEN. We never set
+//   ANTHROPIC_API_KEY for the spawned child — we explicitly clear it so the
+//   binary falls through to the keychain / OAuth subscription session.
+//   If the binary is missing or fails for any reason, we throw — we NEVER
+//   fall back to API-key billing.
+//
+// The router (router.ts) is responsible for the optional fall-through to
+// Ollama on `ClaudeBinaryError`. The adapter itself is pure: spawn → parse → return.
 
-import type {
-  ClaudeRequest,
-  ClaudeResponse,
-  LLMRequest,
-  LLMResponse,
-} from './types.js';
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import type { LLMRequest, LLMResponse } from './types.js';
 
-const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
-const ANTHROPIC_API_VERSION = '2023-06-01';
+/** Default path to the `claude` binary. Overridable via env. */
+const DEFAULT_CLAUDE_BINARY = process.env['CLAUDE_BINARY_PATH'] ?? 'claude';
+/** Default subprocess timeout (ms). 3 minutes covers a slow Sonnet response. */
+const DEFAULT_TIMEOUT_MS = 180_000;
+
+/** Generic binary-spawn failure. Thrown for missing binary, non-zero exit,
+ *  malformed JSON, or any other non-rate-limit error. */
+export class ClaudeBinaryError extends Error {
+  readonly stderr: string;
+  readonly exitCode: number | null;
+  readonly accountId: string | null;
+
+  constructor(opts: {
+    message: string;
+    stderr?: string;
+    exitCode?: number | null;
+    accountId?: string | null;
+  }) {
+    super(opts.message);
+    this.name = 'ClaudeBinaryError';
+    this.stderr = opts.stderr ?? '';
+    this.exitCode = opts.exitCode ?? null;
+    this.accountId = opts.accountId ?? null;
+  }
+}
+
+/** Specialised binary error indicating the subscription account is rate-limited.
+ *  Spend-guard's pump-side handler treats this the same way as a
+ *  `BudgetExceededError` from `@chiefaia/spend-guard`: pause the pipeline
+ *  (or rotate to the next account in the pool, then pause). */
+export class ClaudeRateLimitedError extends ClaudeBinaryError {
+  constructor(opts: {
+    message: string;
+    stderr?: string;
+    exitCode?: number | null;
+    accountId?: string | null;
+  }) {
+    super(opts);
+    this.name = 'ClaudeRateLimitedError';
+  }
+}
+
+/** Configuration for a single ClaudeAdapter instance. */
+export interface ClaudeAdapterOptions {
+  /** Override path to the `claude` binary. */
+  binaryPath?: string;
+  /**
+   * Override HOME env var so the spawned binary uses a different
+   * credentials dir (~/.config/claude/credentials.json). This is the
+   * mechanism for account rotation: account-1 uses ~/.config/claude,
+   * account-2 uses some other ~/.caia/accounts/acc-2 with its own
+   * `~/.config/claude/credentials.json` symlinked underneath.
+   */
+  homeOverride?: string;
+  /** Optional account id used for telemetry + rate-limit attribution. */
+  accountId?: string | null;
+  /** Override subprocess timeout. */
+  timeoutMs?: number;
+  /** Test seam — replace `node:child_process`'s `spawn`. */
+  spawnFn?: typeof spawn;
+}
+
+/** Shape of the JSON object emitted by `claude --print --output-format json`. */
+interface ClaudeBinaryJsonResult {
+  type: string;
+  subtype?: string;
+  is_error?: boolean;
+  api_error_status?: number | string | null;
+  duration_ms?: number;
+  result?: string;
+  total_cost_usd?: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  modelUsage?: Record<string, { inputTokens?: number; outputTokens?: number; costUSD?: number }>;
+}
 
 export class ClaudeAdapter {
-  private readonly apiKey: string;
+  private readonly binaryPath: string;
+  private readonly homeOverride: string | null;
+  private readonly accountId: string | null;
+  private readonly timeoutMs: number;
+  private readonly spawnFn: typeof spawn;
 
-  constructor(apiKey: string = process.env['ANTHROPIC_API_KEY'] ?? '') {
-    if (!apiKey) {
-      throw new Error(
-        'ClaudeAdapter requires ANTHROPIC_API_KEY env var or explicit apiKey argument.',
-      );
-    }
-    this.apiKey = apiKey;
+  constructor(opts: ClaudeAdapterOptions = {}) {
+    this.binaryPath = opts.binaryPath ?? DEFAULT_CLAUDE_BINARY;
+    this.homeOverride = opts.homeOverride ?? null;
+    this.accountId = opts.accountId ?? null;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.spawnFn = opts.spawnFn ?? spawn;
   }
 
   /**
-   * Generate a completion via the Anthropic Messages API.
+   * Generate a completion via the `claude` binary using subscription auth.
+   *
+   * Throws `ClaudeRateLimitedError` when the spawn output indicates
+   * Anthropic returned 429 / quota exhaustion (callers should rotate
+   * accounts and/or pause via spend-guard). Throws `ClaudeBinaryError`
+   * for any other failure (binary missing, non-zero exit, malformed
+   * output, timeout). NEVER falls back to API-key billing.
    */
-  async generate(
-    model: string,
-    request: LLMRequest,
-  ): Promise<LLMResponse> {
+  async generate(model: string, request: LLMRequest): Promise<LLMResponse> {
     const start = Date.now();
 
-    const body: ClaudeRequest = {
-      model,
-      max_tokens: request.maxTokens ?? 4096,
-      messages: [{ role: 'user', content: request.prompt }],
-      ...(request.systemPrompt ? { system: request.systemPrompt } : {}),
-      ...(request.temperature !== undefined
-        ? { temperature: request.temperature }
-        : {}),
+    const args = ['--print', '--output-format', 'json', '--model', model];
+    if (request.systemPrompt) {
+      args.push('--append-system-prompt', request.systemPrompt);
+    }
+
+    // Build env for the child. Clearing ANTHROPIC_API_KEY is the
+    // single most important step — it forces the binary to use the
+    // OAuth/keychain subscription session instead of pay-per-token.
+    const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+    delete env['ANTHROPIC_API_KEY'];
+    delete env['ANTHROPIC_AUTH_TOKEN'];
+    if (this.homeOverride) env['HOME'] = this.homeOverride;
+
+    const spawnOpts: SpawnOptions = {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
     };
 
-    let res: Response;
+    let child: ChildProcess;
     try {
-      res = await fetch(ANTHROPIC_API_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': this.apiKey,
-          'anthropic-version': ANTHROPIC_API_VERSION,
-        },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(120_000),
-      });
+      child = this.spawnFn(this.binaryPath, args, spawnOpts);
     } catch (err) {
-      throw new Error(`Claude API request failed: ${String(err)}`, { cause: err });
+      throw new ClaudeBinaryError({
+        message: `Failed to spawn '${this.binaryPath}': ${String(err)}`,
+        accountId: this.accountId,
+      });
     }
 
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`Claude API error ${res.status}: ${text}`);
+    // Send the prompt on stdin.
+    const stdin = child.stdin;
+    if (!stdin) {
+      throw new ClaudeBinaryError({
+        message: 'spawned child has no stdin stream',
+        accountId: this.accountId,
+      });
+    }
+    stdin.write(request.prompt);
+    stdin.end();
+
+    // Collect output with a wall-clock timeout.
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* ignore */
+      }
+    }, this.timeoutMs);
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout?.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    const exitCode: number | null = await new Promise((resolve, reject) => {
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        reject(
+          new ClaudeBinaryError({
+            message: `child process error: ${String(err)}`,
+            stderr: Buffer.concat(stderrChunks).toString('utf8'),
+            accountId: this.accountId,
+          }),
+        );
+      });
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+
+    const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+    const stderr = Buffer.concat(stderrChunks).toString('utf8');
+
+    if (timedOut) {
+      throw new ClaudeBinaryError({
+        message: `claude binary timed out after ${String(this.timeoutMs)}ms`,
+        stderr,
+        exitCode,
+        accountId: this.accountId,
+      });
     }
 
-    const data = (await res.json()) as ClaudeResponse;
+    // Detect rate-limit BEFORE checking exit code — the binary may exit
+    // non-zero on rate-limit, and we want the more-specific error class.
+    if (looksLikeRateLimit(stdout, stderr, exitCode)) {
+      throw new ClaudeRateLimitedError({
+        message: 'subscription rate-limited (Anthropic 429 / quota exhausted)',
+        stderr,
+        exitCode,
+        accountId: this.accountId,
+      });
+    }
 
-    const text = data.content
-      .filter((block) => block.type === 'text')
-      .map((block) => block.text)
-      .join('');
+    if (exitCode !== 0) {
+      throw new ClaudeBinaryError({
+        message: `claude binary exited with code ${String(exitCode)}`,
+        stderr,
+        exitCode,
+        accountId: this.accountId,
+      });
+    }
+
+    let parsed: ClaudeBinaryJsonResult;
+    try {
+      parsed = JSON.parse(stdout) as ClaudeBinaryJsonResult;
+    } catch (err) {
+      throw new ClaudeBinaryError({
+        message: `failed to parse claude binary stdout as JSON: ${String(err)}`,
+        stderr,
+        exitCode,
+        accountId: this.accountId,
+      });
+    }
+
+    // The binary signals API errors via is_error + api_error_status — even
+    // when exit code is 0. Treat as rate-limit when status looks 429-ish,
+    // otherwise generic binary error.
+    if (parsed.is_error === true) {
+      if (looksLikeRateLimitStatus(parsed.api_error_status)) {
+        throw new ClaudeRateLimitedError({
+          message: `subscription rate-limited (api_error_status=${String(parsed.api_error_status)})`,
+          stderr,
+          exitCode,
+          accountId: this.accountId,
+        });
+      }
+      throw new ClaudeBinaryError({
+        message: `claude binary reported is_error (api_error_status=${String(parsed.api_error_status)})`,
+        stderr,
+        exitCode,
+        accountId: this.accountId,
+      });
+    }
+
+    const text = typeof parsed.result === 'string' ? parsed.result : '';
+    const inputTokens = parsed.usage?.input_tokens ?? 0;
+    const outputTokens = parsed.usage?.output_tokens ?? 0;
 
     return {
       response: text,
-      model: data.model,
+      model,
       provider: 'claude',
       durationMs: Date.now() - start,
       usage: {
-        promptTokens: data.usage.input_tokens,
-        completionTokens: data.usage.output_tokens,
-        totalTokens: data.usage.input_tokens + data.usage.output_tokens,
+        promptTokens: inputTokens,
+        completionTokens: outputTokens,
+        totalTokens: inputTokens + outputTokens,
       },
     };
   }
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+/** Heuristic: stdout/stderr contains rate-limit signal text. */
+function looksLikeRateLimit(
+  stdout: string,
+  stderr: string,
+  exitCode: number | null,
+): boolean {
+  const haystack = (stdout + '\n' + stderr).toLowerCase();
+  if (
+    haystack.includes('rate limit') ||
+    haystack.includes('rate_limit') ||
+    haystack.includes('quota exceeded') ||
+    haystack.includes('429') ||
+    haystack.includes('too many requests')
+  ) {
+    return true;
+  }
+  // Some binary builds use exit code 28 for rate-limit (curl convention).
+  if (exitCode === 28) return true;
+  return false;
+}
+
+function looksLikeRateLimitStatus(status: number | string | null | undefined): boolean {
+  if (status === null || status === undefined) return false;
+  if (typeof status === 'number') return status === 429 || status === 529;
+  const s = String(status);
+  return s.includes('429') || s.includes('529') || s.toLowerCase().includes('rate');
 }

--- a/packages/local-llm-router/src/index.ts
+++ b/packages/local-llm-router/src/index.ts
@@ -2,7 +2,12 @@
 
 export { route, __setAdapters } from './router.js';
 export { OllamaAdapter } from './ollama-adapter.js';
-export { ClaudeAdapter } from './claude-adapter.js';
+export {
+  ClaudeAdapter,
+  ClaudeBinaryError,
+  ClaudeRateLimitedError,
+} from './claude-adapter.js';
+export type { ClaudeAdapterOptions } from './claude-adapter.js';
 export { getRoute, ROUTING_RULES, COST_ANALYSIS } from './routing-config.js';
 export {
   MODEL_CATALOG,

--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -1,7 +1,17 @@
 // Main routing logic for @chiefaia/local-llm-router
 // Decides local vs Claude based on routing-config.ts, then dispatches.
+//
+// HARD CONSTRAINT (Prakash 2026-04-30): the Claude path uses the binary
+// adapter exclusively (subscription auth via the `claude` CLI). There is
+// NO API-key fallback. If the binary fails for any reason — missing,
+// rate-limited, malformed output — we fall back to Ollama (when
+// `fallbackOnError` is enabled) or rethrow.
 
-import { ClaudeAdapter } from './claude-adapter.js';
+import {
+  ClaudeAdapter,
+  ClaudeBinaryError,
+  ClaudeRateLimitedError,
+} from './claude-adapter.js';
 import { OllamaAdapter } from './ollama-adapter.js';
 import { getRoute } from './routing-config.js';
 import type { LLMProvider, LLMRequest, LLMResponse, RouterOptions } from './types.js';
@@ -73,7 +83,7 @@ export async function route(
       if (fallbackEnabled && rule.claudeModel) {
         console.warn(
           `[local-llm-router] Local model "${rule.localModel}" failed ` +
-            `for task "${taskType}"; falling back to Claude (${rule.claudeModel}). ` +
+            `for task "${taskType}"; falling back to Claude binary (${rule.claudeModel}). ` +
             `Error: ${String(localErr)}`,
         );
         return await dispatchClaude(rule.claudeModel, request);
@@ -85,11 +95,35 @@ export async function route(
     try {
       return await dispatchClaude(claudeModel, request);
     } catch (claudeErr) {
+      // Rate-limit is a SPECIAL case — the spend-guard pump handler
+      // owns the response (rotate account + maybe pause). We rethrow
+      // so the orchestrator can react, but we still allow Ollama
+      // fallback as a last resort if the caller opted in.
+      if (claudeErr instanceof ClaudeRateLimitedError) {
+        if (fallbackEnabled) {
+          console.warn(
+            `[local-llm-router] Claude binary rate-limited for task "${taskType}"; ` +
+              `falling back to Ollama (${rule.localModel}). Spend-guard should pause / rotate.`,
+          );
+          return await dispatchLocal(rule.localModel, request);
+        }
+        throw claudeErr;
+      }
+      if (claudeErr instanceof ClaudeBinaryError) {
+        if (fallbackEnabled) {
+          console.warn(
+            `[local-llm-router] Claude binary failed (${claudeErr.message}) for task "${taskType}"; ` +
+              `falling back to Ollama (${rule.localModel}). NO API-key fallback (rule).`,
+          );
+          return await dispatchLocal(rule.localModel, request);
+        }
+        throw claudeErr;
+      }
+      // Unknown error — preserve previous behaviour.
       if (fallbackEnabled) {
         console.warn(
-          `[local-llm-router] Claude model "${claudeModel}" failed ` +
-            `for task "${taskType}"; falling back to local (${rule.localModel}). ` +
-            `Error: ${String(claudeErr)}`,
+          `[local-llm-router] Claude path failed (${String(claudeErr)}) for task "${taskType}"; ` +
+            `falling back to Ollama (${rule.localModel}).`,
         );
         return await dispatchLocal(rule.localModel, request);
       }

--- a/packages/local-llm-router/src/routing-config.ts
+++ b/packages/local-llm-router/src/routing-config.ts
@@ -361,13 +361,25 @@ export const ROUTING_RULES: RoutingRule[] = [
 export function getRoute(taskType: string): RoutingRule {
   const rule = ROUTING_RULES.find((r) => r.taskType === taskType);
   if (!rule) {
-    // Default: use Claude Sonnet for unknown task types
+    // Default: prefer LOCAL Ollama for unknown task types.
+    //
+    // Updated 2026-04-30 (LAI-002 follow-up): the binary-spawn ClaudeAdapter
+    // takes ~6-10s session init + the prompt cost. For short classification
+    // tasks (validation-*, decomposer-recursive helpers, etc.) Ollama is
+    // strictly faster AND free. Defaulting to local also avoids the
+    // launchd-scoped "claude binary timed out" spiral that blocked the
+    // 2026-04-30 multi-pass validation when validation-content-relevance
+    // and similar unregistered task types fell through to a 180s Claude
+    // wait per call.
+    //
+    // Callers that explicitly want Claude can either register the task in
+    // ROUTING_RULES with useLocal:false or pass options.forceClaude=true.
     return {
       taskType,
-      description: 'Unknown task type',
+      description: 'Unknown task type (defaults to local Ollama)',
       localModel: 'qwen2.5-coder:7b',
       claudeModel: 'claude-sonnet-4-6',
-      useLocal: false,
+      useLocal: true,
       maxTokens: 4000,
       estimatedCostLocal: '$0.00',
       estimatedCostClaude: '$1.00',

--- a/packages/local-llm-router/tests/claude-adapter.test.ts
+++ b/packages/local-llm-router/tests/claude-adapter.test.ts
@@ -1,64 +1,312 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ClaudeAdapter } from '../src/claude-adapter.js';
+/**
+ * Vitest cases for the binary-spawn `ClaudeAdapter`.
+ *
+ * The adapter spawns the `claude` CLI rather than calling the Anthropic
+ * API. To keep the suite hermetic we inject a fake `spawnFn` that returns
+ * a minimal `EventEmitter`-based stand-in for `child_process.spawn`'s
+ * `ChildProcess`. The fake lets us script stdout, stderr, exit code,
+ * and timing per test.
+ *
+ * HARD CONSTRAINT: assert that the adapter NEVER passes ANTHROPIC_API_KEY
+ * through to the spawned child — it must always use subscription auth.
+ */
 
-const ORIGINAL_FETCH = globalThis.fetch;
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import {
+  ClaudeAdapter,
+  ClaudeBinaryError,
+  ClaudeRateLimitedError,
+} from '../src/claude-adapter.js';
 
-describe('ClaudeAdapter', () => {
-  afterEach(() => {
-    globalThis.fetch = ORIGINAL_FETCH;
-    vi.restoreAllMocks();
-  });
+// ─── fake child_process.spawn ───────────────────────────────────────────
 
-  it('throws when no API key is provided', () => {
-    const prev = process.env['ANTHROPIC_API_KEY'];
-    delete process.env['ANTHROPIC_API_KEY'];
-    expect(() => new ClaudeAdapter()).toThrow(/ANTHROPIC_API_KEY/);
-    if (prev !== undefined) process.env['ANTHROPIC_API_KEY'] = prev;
-  });
+interface ScriptedCall {
+  /** stdout written before exit */
+  stdout?: string;
+  /** stderr written before exit */
+  stderr?: string;
+  /** exit code (default 0) */
+  code?: number | null;
+  /** delay in ms before the close event fires (default 0) */
+  delayMs?: number;
+  /** if set, emit an `error` event instead of closing */
+  errorEvent?: Error;
+  /** if set, throw synchronously from spawn (e.g. ENOENT) */
+  spawnThrows?: Error;
+  /** never close — for timeout tests */
+  hang?: boolean;
+}
 
-  it('POSTs to the Anthropic Messages API with the right headers', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        id: 'msg_1',
-        type: 'message',
-        role: 'assistant',
-        content: [{ type: 'text', text: 'hi back' }],
-        model: 'claude-sonnet-4-6',
-        usage: { input_tokens: 5, output_tokens: 3 },
-      }),
-    } as Response);
-    globalThis.fetch = fetchMock;
+interface SpawnInvocation {
+  binary: string;
+  args: string[];
+  env: Record<string, string | undefined>;
+  stdinChunks: string[];
+}
 
-    const adapter = new ClaudeAdapter('test-key');
-    const result = await adapter.generate('claude-sonnet-4-6', {
+function makeFakeSpawn(script: ScriptedCall) {
+  const invocations: SpawnInvocation[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fn: any = (binary: string, args: string[], opts: { env: Record<string, string> }) => {
+    if (script.spawnThrows) throw script.spawnThrows;
+
+    const inv: SpawnInvocation = {
+      binary,
+      args: [...args],
+      env: { ...opts.env },
+      stdinChunks: [],
+    };
+    invocations.push(inv);
+
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: Readable;
+      stderr: Readable;
+      stdin: Writable;
+      kill: (sig?: string) => void;
+    };
+    child.stdout = new Readable({ read() {} });
+    child.stderr = new Readable({ read() {} });
+    child.stdin = new Writable({
+      write(chunk, _enc, cb) {
+        inv.stdinChunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk));
+        cb();
+      },
+    });
+    child.kill = () => {
+      // Simulate kill by emitting close with non-zero code (only if not yet closed).
+      setImmediate(() => {
+        child.stdout.push(null);
+        child.stderr.push(null);
+        child.emit('close', 143);
+      });
+    };
+
+    if (script.hang) {
+      // Never push terminal — the test will rely on the adapter's own timeout.
+      return child;
+    }
+
+    const finishMs = script.delayMs ?? 0;
+    setTimeout(() => {
+      if (script.stdout) child.stdout.push(script.stdout);
+      child.stdout.push(null);
+      if (script.stderr) child.stderr.push(script.stderr);
+      child.stderr.push(null);
+      if (script.errorEvent) {
+        child.emit('error', script.errorEvent);
+        return;
+      }
+      child.emit('close', script.code ?? 0);
+    }, finishMs);
+
+    return child;
+  };
+  return { fn, invocations };
+}
+
+const HAPPY_PATH_JSON = JSON.stringify({
+  type: 'result',
+  subtype: 'success',
+  is_error: false,
+  api_error_status: null,
+  result: 'hi back',
+  total_cost_usd: 0.001,
+  usage: { input_tokens: 5, output_tokens: 3 },
+  modelUsage: { 'claude-sonnet-4-6': { inputTokens: 5, outputTokens: 3, costUSD: 0.001 } },
+});
+
+// ─── tests ───────────────────────────────────────────────────────────────
+
+describe('ClaudeAdapter (binary spawn)', () => {
+  it('happy path — parses JSON output and reports subscription provider', async () => {
+    const { fn } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const out = await adapter.generate('claude-sonnet-4-6', {
       taskType: 'hierarchy-decomposition',
       prompt: 'hi',
-      maxTokens: 100,
     });
-
-    expect(result.provider).toBe('claude');
-    expect(result.response).toBe('hi back');
-    expect(result.usage?.totalTokens).toBe(8);
-
-    const [, init] = fetchMock.mock.calls[0]!;
-    const headers = (init as RequestInit).headers as Record<string, string>;
-    expect(headers['x-api-key']).toBe('test-key');
-    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(out.provider).toBe('claude');
+    expect(out.response).toBe('hi back');
+    expect(out.model).toBe('claude-sonnet-4-6');
+    expect(out.usage?.totalTokens).toBe(8);
   });
 
-  it('throws on non-OK Claude API response', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 429,
-      text: async () => 'rate limited',
-    } as Response);
-    const adapter = new ClaudeAdapter('test-key');
+  it('passes --model + --print + --output-format json to the binary', async () => {
+    const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    await adapter.generate('claude-haiku-4-5', { taskType: 't', prompt: 'p' });
+    const args = invocations[0]!.args;
+    expect(args).toContain('--print');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('json');
+    expect(args).toContain('--model');
+    expect(args).toContain('claude-haiku-4-5');
+  });
+
+  it('writes the prompt to the binary stdin', async () => {
+    const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    await adapter.generate('claude-sonnet-4-6', {
+      taskType: 't',
+      prompt: 'the literal prompt body',
+    });
+    expect(invocations[0]!.stdinChunks.join('')).toBe('the literal prompt body');
+  });
+
+  it('NEVER forwards ANTHROPIC_API_KEY to the child env (subscription only)', async () => {
+    const prev = process.env['ANTHROPIC_API_KEY'];
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-LEAKED-KEY-MUST-NOT-PASS';
+    try {
+      const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+      const adapter = new ClaudeAdapter({ spawnFn: fn });
+      await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
+      expect(invocations[0]!.env['ANTHROPIC_API_KEY']).toBeUndefined();
+      expect(invocations[0]!.env['ANTHROPIC_AUTH_TOKEN']).toBeUndefined();
+    } finally {
+      if (prev !== undefined) process.env['ANTHROPIC_API_KEY'] = prev;
+      else delete process.env['ANTHROPIC_API_KEY'];
+    }
+  });
+
+  it('honors homeOverride for account rotation (HOME → per-account creds dir)', async () => {
+    const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+    const adapter = new ClaudeAdapter({
+      spawnFn: fn,
+      homeOverride: '/Users/MAC/.caia/accounts/acc-2',
+      accountId: 'acc-2',
+    });
+    await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
+    expect(invocations[0]!.env['HOME']).toBe('/Users/MAC/.caia/accounts/acc-2');
+  });
+
+  it('detects rate-limit via stderr text and throws ClaudeRateLimitedError', async () => {
+    const { fn } = makeFakeSpawn({
+      stdout: '',
+      stderr: 'Error: 429 Too Many Requests — rate_limit_exceeded',
+      code: 1,
+    });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, accountId: 'acc-1' });
     await expect(
-      adapter.generate('claude-sonnet-4-6', {
-        taskType: 'x',
-        prompt: 'hi',
-      }),
-    ).rejects.toThrow(/Claude API error 429/);
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toBeInstanceOf(ClaudeRateLimitedError);
+  });
+
+  it('detects rate-limit via api_error_status=429 in JSON result', async () => {
+    const json = JSON.stringify({
+      type: 'result',
+      is_error: true,
+      api_error_status: 429,
+      result: '',
+    });
+    const { fn } = makeFakeSpawn({ stdout: json });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, accountId: 'acc-1' });
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toBeInstanceOf(ClaudeRateLimitedError);
+  });
+
+  it('reports accountId on ClaudeRateLimitedError for pool rotation', async () => {
+    const { fn } = makeFakeSpawn({
+      stdout: '',
+      stderr: '429 rate limit hit',
+      code: 1,
+    });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, accountId: 'acc-7' });
+    try {
+      await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClaudeRateLimitedError);
+      expect((err as ClaudeRateLimitedError).accountId).toBe('acc-7');
+    }
+  });
+
+  it('throws ClaudeBinaryError when the binary is missing (spawn ENOENT)', async () => {
+    const enoent = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
+    const { fn } = makeFakeSpawn({ spawnThrows: enoent });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, binaryPath: 'claude' });
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toBeInstanceOf(ClaudeBinaryError);
+  });
+
+  it('throws ClaudeBinaryError when the binary exits non-zero with no rate-limit signal', async () => {
+    const { fn } = makeFakeSpawn({ stdout: '', stderr: 'unknown error', code: 2 });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toBeInstanceOf(ClaudeBinaryError);
+  });
+
+  it('throws ClaudeBinaryError when stdout is malformed JSON', async () => {
+    const { fn } = makeFakeSpawn({ stdout: 'definitely not json{{{', code: 0 });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toThrow(/parse claude binary stdout/);
+  });
+
+  it('throws ClaudeBinaryError on timeout (kills the child)', async () => {
+    const { fn } = makeFakeSpawn({ hang: true });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, timeoutMs: 25 });
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it('throws ClaudeBinaryError when the child emits an error event', async () => {
+    const { fn } = makeFakeSpawn({ errorEvent: new Error('pipe broken') });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toBeInstanceOf(ClaudeBinaryError);
+  });
+
+  it('does NOT fall back to API-key path when binary fails (must be handled by router/spend-guard)', async () => {
+    // The adapter itself should ALWAYS throw. Router-level fallback to
+    // Ollama is acceptable; API-key fallback is forbidden per Prakash
+    // 2026-04-30 rule. This test asserts the adapter never silently
+    // returns a non-binary response.
+    const { fn } = makeFakeSpawn({ stdout: '', stderr: 'binary blew up', code: 99 });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await expect(
+      adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
+    ).rejects.toBeInstanceOf(ClaudeBinaryError);
+    // The spawned binary path must not have triggered any HTTP call.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('passes --append-system-prompt when systemPrompt is provided', async () => {
+    const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    await adapter.generate('claude-sonnet-4-6', {
+      taskType: 't',
+      prompt: 'user',
+      systemPrompt: 'you are a poet',
+    });
+    const args = invocations[0]!.args;
+    expect(args).toContain('--append-system-prompt');
+    expect(args).toContain('you are a poet');
+  });
+
+  it('reports usage tokens from the binary JSON output', async () => {
+    const json = JSON.stringify({
+      type: 'result',
+      is_error: false,
+      result: 'ok',
+      usage: { input_tokens: 100, output_tokens: 250 },
+    });
+    const { fn } = makeFakeSpawn({ stdout: json });
+    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const out = await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
+    expect(out.usage).toEqual({
+      promptTokens: 100,
+      completionTokens: 250,
+      totalTokens: 350,
+    });
   });
 });

--- a/packages/local-llm-router/tests/routing-config.test.ts
+++ b/packages/local-llm-router/tests/routing-config.test.ts
@@ -107,11 +107,17 @@ describe('routing-config', () => {
       expect(rule.useLocal).toBe(true);
     });
 
-    it('falls back to a Claude-default rule for unknown task types', () => {
+    it('falls back to a Local-default rule for unknown task types (LAI-002 follow-up 2026-04-30)', () => {
+      // Default flipped from useLocal:false to useLocal:true on 2026-04-30
+      // because the binary-spawn ClaudeAdapter has ~6-10s session-init
+      // overhead per call. Unregistered classification tasks (validation-*,
+      // etc.) bottlenecked the pipeline at the 180s timeout; defaulting to
+      // local Ollama makes them snappy and free.
       const rule = getRoute('totally-made-up-task');
       expect(rule.taskType).toBe('totally-made-up-task');
-      expect(rule.useLocal).toBe(false);
+      expect(rule.useLocal).toBe(true);
       expect(rule.claudeModel).toBe('claude-sonnet-4-6');
+      expect(rule.localModel).toBe('qwen2.5-coder:7b');
     });
   });
 

--- a/packages/spend-guard/src/index.ts
+++ b/packages/spend-guard/src/index.ts
@@ -32,6 +32,7 @@ export {
 export {
   SpendGuard,
   BudgetExceededError,
+  ApiKeyViaForbiddenError,
   InMemoryRecordSink,
   type PauseState,
   type SpendGuardOptions,

--- a/packages/spend-guard/src/spend-guard.ts
+++ b/packages/spend-guard/src/spend-guard.ts
@@ -4,6 +4,13 @@
  * and pauses the orchestrator when a cap is breached.
  *
  * Reference: caia/docs/spend-guard.md, v2 §6.
+ *
+ * No-API-key constraint (Prakash 2026-04-30,
+ * `feedback_no_api_key_billing.md`): production callers MUST construct
+ * the guard with `rejectApiKeyVia: true` so any record() with
+ * `via: 'api-key'` throws `ApiKeyViaForbiddenError`. This catches
+ * regressions where a code path silently routes a call back through
+ * the legacy fetch adapter.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -33,6 +40,27 @@ export class BudgetExceededError extends Error {
       `BudgetExceeded: ${cap.scope}='${cap.resourceId}' currentUsd=${cap.currentUsd.toFixed(4)} + attempted=${attemptedUsd.toFixed(4)} > limit=${cap.limitUsd.toFixed(2)}`,
     );
     this.name = 'BudgetExceededError';
+  }
+}
+
+/**
+ * Thrown when a record uses `via: 'api-key'` while the guard is
+ * configured with `rejectApiKeyVia: true` (production wiring).
+ *
+ * Per Prakash 2026-04-30 — the pay-per-token Anthropic API path is
+ * forbidden. Production orchestrator wiring sets `rejectApiKeyVia: true`
+ * so any regression that reroutes Claude traffic through a fetch-based
+ * adapter is caught at record time.
+ */
+export class ApiKeyViaForbiddenError extends Error {
+  constructor(opts: { taskId: string; model: string; agentRole: string }) {
+    super(
+      `ApiKeyViaForbidden: refusing to record via='api-key' for ` +
+        `task='${opts.taskId}' model='${opts.model}' agent='${opts.agentRole}'. ` +
+        `The Anthropic pay-per-token path is disabled (Prakash 2026-04-30). ` +
+        `Use via='subscription' (claude binary) or via='ollama'.`,
+    );
+    this.name = 'ApiKeyViaForbiddenError';
   }
 }
 
@@ -71,8 +99,19 @@ export interface SpendGuardOptions {
     ev:
       | { kind: 'cap-breached'; scope: SpendCapScope; resourceId: string }
       | { kind: 'paused'; reason: string }
-      | { kind: 'resumed'; by: string },
+      | { kind: 'resumed'; by: string }
+      | { kind: 'api-key-rejected'; taskId: string; model: string },
   ) => void;
+  /**
+   * When true, `record({via:'api-key'})` throws `ApiKeyViaForbiddenError`
+   * instead of being persisted. Production orchestrator wiring sets
+   * this flag so any regression that calls the pay-per-token path is
+   * caught at the cap-record boundary.
+   *
+   * Defaults to false to preserve historical test/CI behaviour. Flip
+   * to `true` in `apps/orchestrator/src/safety/spend-guard-bridge.ts`.
+   */
+  rejectApiKeyVia?: boolean;
 }
 
 export class SpendGuard {
@@ -81,6 +120,7 @@ export class SpendGuard {
   private readonly caps: Record<SpendCapScope, number>;
   private readonly nowMs: () => number;
   private readonly log: SpendGuardOptions['log'];
+  private readonly rejectApiKeyVia: boolean;
   private pauseState: PauseState = {
     paused: false,
     reason: null,
@@ -93,6 +133,7 @@ export class SpendGuard {
     this.caps = { ...DEFAULT_CAPS_USD, ...(opts.caps ?? {}) };
     this.nowMs = opts.nowMs ?? (() => Date.now());
     if (opts.log) this.log = opts.log;
+    this.rejectApiKeyVia = opts.rejectApiKeyVia ?? false;
   }
 
   get pause(): PauseState {
@@ -184,6 +225,18 @@ export class SpendGuard {
     outputTokens: number;
     costUsd: number;
   }): Promise<SpendRecord> {
+    if (this.rejectApiKeyVia && opts.via === 'api-key') {
+      this.log?.({
+        kind: 'api-key-rejected',
+        taskId: opts.taskId,
+        model: opts.model,
+      });
+      throw new ApiKeyViaForbiddenError({
+        taskId: opts.taskId,
+        model: opts.model,
+        agentRole: opts.agentRole,
+      });
+    }
     const ts = this.nowMs();
     const record: SpendRecord = SpendRecordSchema.parse({
       id: randomUUID(),

--- a/packages/spend-guard/tests/spend-guard.test.ts
+++ b/packages/spend-guard/tests/spend-guard.test.ts
@@ -224,3 +224,120 @@ describe('SpendGuard.dailySpendPctOver', () => {
     expect(await guard.dailySpendPctOver(0.8)).toBe(true);
   });
 });
+
+
+// ─── No-API-key constraint (Prakash 2026-04-30) ─────────────────────────
+//
+// Production wiring sets `rejectApiKeyVia: true` so any record() that
+// uses `via: 'api-key'` throws `ApiKeyViaForbiddenError`. This catches
+// regressions where a code path silently routes a Claude call through
+// the legacy fetch-based adapter instead of the binary-spawn adapter.
+
+import { ApiKeyViaForbiddenError } from '../src/index.js';
+
+describe('SpendGuard rejectApiKeyVia (production guard)', () => {
+  it('throws ApiKeyViaForbiddenError when via=api-key and the option is on', async () => {
+    const cs = new InMemoryCapStore();
+    const rs = new InMemoryRecordSink();
+    const g = new SpendGuard({
+      capStore: cs,
+      recordSink: rs,
+      rejectApiKeyVia: true,
+    });
+    await expect(
+      g.record({
+        taskId: 't',
+        projectId: null,
+        agentRole: 'coding',
+        model: 'claude-sonnet-4-6',
+        via: 'api-key',
+        accountId: 'apikey-default',
+        inputTokens: 100,
+        outputTokens: 100,
+        costUsd: 0.001,
+      }),
+    ).rejects.toBeInstanceOf(ApiKeyViaForbiddenError);
+    // Nothing got persisted on rejection.
+    expect(rs.records).toHaveLength(0);
+  });
+
+  it('emits an api-key-rejected log event for observability', async () => {
+    const events: Array<{ kind: string; [k: string]: unknown }> = [];
+    const g = new SpendGuard({
+      capStore: new InMemoryCapStore(),
+      recordSink: new InMemoryRecordSink(),
+      rejectApiKeyVia: true,
+      log: (ev) => events.push(ev as { kind: string }),
+    });
+    await g
+      .record({
+        taskId: 't-kludge',
+        projectId: null,
+        agentRole: 'po',
+        model: 'claude-haiku-4-5',
+        via: 'api-key',
+        accountId: 'apikey-default',
+        inputTokens: 1,
+        outputTokens: 1,
+        costUsd: 0.0001,
+      })
+      .catch(() => undefined);
+    expect(events.some((e) => e.kind === 'api-key-rejected')).toBe(true);
+  });
+
+  it('still allows via=subscription / via=ollama when rejectApiKeyVia is on', async () => {
+    const rs = new InMemoryRecordSink();
+    const g = new SpendGuard({
+      capStore: new InMemoryCapStore(),
+      recordSink: rs,
+      rejectApiKeyVia: true,
+    });
+    await g.record({
+      taskId: 't',
+      projectId: null,
+      agentRole: 'coding',
+      model: 'claude-sonnet-4-6',
+      via: 'subscription',
+      accountId: 'acct-1',
+      inputTokens: 10,
+      outputTokens: 10,
+      costUsd: 0.0005,
+    });
+    await g.record({
+      taskId: 't',
+      projectId: null,
+      agentRole: 'coding',
+      model: 'qwen2.5-coder:7b',
+      via: 'ollama',
+      accountId: null,
+      inputTokens: 100,
+      outputTokens: 100,
+      costUsd: 0,
+    });
+    expect(rs.records).toHaveLength(2);
+    expect(rs.records[0]?.via).toBe('subscription');
+    expect(rs.records[1]?.via).toBe('ollama');
+  });
+
+  it('preserves backwards-compat: api-key is still allowed when option is off (default)', async () => {
+    const rs = new InMemoryRecordSink();
+    const g = new SpendGuard({
+      capStore: new InMemoryCapStore(),
+      recordSink: rs,
+      // rejectApiKeyVia not set → defaults to false
+    });
+    await g.record({
+      taskId: 't',
+      projectId: null,
+      agentRole: 'po',
+      model: 'claude-sonnet-4-6',
+      via: 'api-key',
+      accountId: 'apikey-default',
+      inputTokens: 1,
+      outputTokens: 1,
+      costUsd: 0.0001,
+    });
+    expect(rs.records).toHaveLength(1);
+    expect(rs.records[0]?.via).toBe('api-key');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,6 +732,10 @@ importers:
       nanoid:
         specifier: ^5.0.0
         version: 5.1.9
+    devDependencies:
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   packages/decomposer-recursive:
     dependencies:


### PR DESCRIPTION
Cherry-picked 4 PRs from develop to main for 2026-04-30 daily release:\n\n- #242 feat(lai-001): replace ClaudeAdapter API path with claude binary spawn\n- #243 feat(po-decomp): widen rule-based decomposer for fix/refactor/audit/extract verbs\n- #245 fix(scaffolder): add task-scheduler to bug-fix/refactor/performance/security activation maps\n- #251 fix(local-llm-router): default unknown task types to local + drop binary timeout to 45s\n\nDirect develop→main had structural drift; this release uses cherry-picks per the documented fallback (caia-flow.sh / git-flow.md).\n\nReference: feedback_no_api_key_billing.md (Prakash 2026-04-30 hard rule).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orchestrator API server bootstrap with signal handling.
  * Introduced verb-intent detection for improved task decomposition (fix, refactor, extract, audit).
  * Implemented local Claude binary adapter for direct CLI integration.
  * Added API key billing rejection safety guard to prevent unintended charges.

* **Bug Fixes**
  * Enabled additional agents for bug-fix, refactor, performance, and security request types.
  * Improved routing fallback behavior to default to local execution.

* **Documentation**
  * Added local LLM router configuration and behavior guide.

* **Tests**
  * Expanded test coverage for decomposer and spend guard modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->