### PR TITLE
feat(dash-011): contextual prompts — floating button, Cmd+K, auto-context

### DIFF
--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -2,20 +2,13 @@
 import { Suspense } from 'react';
 import { Sidebar } from '../components/nav/Sidebar';
 import { Breadcrumb } from '../components/Breadcrumb';
+import { AgentActivityRail } from '../components/agents/AgentActivityRail';
+import { FloatingPromptButton } from '../components/prompt/FloatingPromptButton';
 import './globals.css';
 
 /**
- * Root layout — DASH-001 (nav restructure) + DASH-003 (breadcrumb).
- *
- * The 27-item flat sidebar previously inlined here was extracted into
- * `components/nav/Sidebar.tsx` as an accordion-grouped component. The
- * breadcrumb (`components/Breadcrumb.tsx`) renders at the top of the
- * main content area on every page; it self-hides on section landings
- * and the root.
- *
- * URLs do not change in this layout — only the structure does. Route
- * migration to the canonical `/section/resource` schema landed in PR2
- * (`feat/dash-002-url-schema-redirect`).
+ * Root layout — DASH-001 (nav restructure) + DASH-003 (breadcrumb)
+ * + DASH-005 (agent activity rail) + DASH-011 (floating prompt button).
  */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -59,6 +52,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </Suspense>
           {children}
         </main>
+
+        {/* Right rail — agent activity (DASH-005) */}
+        <Suspense fallback={null}>
+          <AgentActivityRail />
+        </Suspense>
+
+        {/* Floating prompt-from-anywhere button + Cmd+K (DASH-011) */}
+        <Suspense fallback={null}>
+          <FloatingPromptButton />
+        </Suspense>
       </body>
     </html>
   );

--- a/apps/dashboard/components/prompt/FloatingPromptButton.tsx
+++ b/apps/dashboard/components/prompt/FloatingPromptButton.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+/**
+ * FloatingPromptButton — bottom-right "submit a prompt" button +
+ * Cmd+K shortcut wiring (DASH-011).
+ *
+ * Mounted in app/layout.tsx so it persists across every page.
+ *
+ * Spec: caia/docs/dashboard-ui-conventions.md §5.
+ */
+
+import { useEffect, useState } from 'react';
+import { PromptModal } from './PromptModal';
+
+const isMacLike = (() => {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPhone|iPad/.test(navigator.platform || '');
+})();
+
+export function FloatingPromptButton() {
+  const [open, setOpen] = useState(false);
+  const [seedText, setSeedText] = useState<string>('');
+
+  // Cmd+K / Ctrl+K to open modal.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const isModK = (isMacLike ? e.metaKey : e.ctrlKey) && (e.key === 'k' || e.key === 'K');
+      if (isModK) {
+        e.preventDefault();
+        setSeedText('');
+        setOpen(true);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  // "Ask CAIA about this →" tooltip on text selection (DASH-011 §3).
+  // Implemented as a floating button anchored to the selection rect.
+  useEffect(() => {
+    let tip: HTMLButtonElement | null = null;
+
+    function clearTip() {
+      if (tip && tip.parentElement) tip.parentElement.removeChild(tip);
+      tip = null;
+    }
+
+    function showTip(rect: DOMRect, selectedText: string) {
+      clearTip();
+      tip = document.createElement('button');
+      tip.type = 'button';
+      tip.textContent = '✨ Ask CAIA about this →';
+      tip.style.cssText = [
+        'position: absolute',
+        `top: ${window.scrollY + rect.bottom + 6}px`,
+        `left: ${window.scrollX + rect.left}px`,
+        'background: #3182ce',
+        'color: #f0f4f8',
+        'border: none',
+        'padding: 4px 8px',
+        'border-radius: 6px',
+        'font-size: 12px',
+        'cursor: pointer',
+        'z-index: 1100',
+        'box-shadow: 0 2px 8px rgba(0,0,0,0.4)',
+      ].join('; ');
+      tip.addEventListener('click', () => {
+        setSeedText(selectedText);
+        setOpen(true);
+        clearTip();
+      });
+      document.body.appendChild(tip);
+    }
+
+    function onUp() {
+      // Avoid fighting the modal — if the user is selecting inside the
+      // modal, suppress the tip.
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) {
+        clearTip();
+        return;
+      }
+      const text = selection.toString().trim();
+      if (!text || text.length < 4) {
+        clearTip();
+        return;
+      }
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+      // Skip if selection is inside the modal itself.
+      const node = range.commonAncestorContainer as HTMLElement;
+      const inDialog = node && (node.closest ? node.closest('[role="dialog"]') : null);
+      if (inDialog) {
+        clearTip();
+        return;
+      }
+      showTip(rect, text);
+    }
+
+    function onDown(e: MouseEvent) {
+      // Clear if click outside selection / tip.
+      if (tip && e.target === tip) return;
+      clearTip();
+    }
+
+    document.addEventListener('mouseup', onUp);
+    document.addEventListener('mousedown', onDown);
+    return () => {
+      document.removeEventListener('mouseup', onUp);
+      document.removeEventListener('mousedown', onDown);
+      clearTip();
+    };
+  }, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setSeedText('');
+          setOpen(true);
+        }}
+        aria-label="Submit a prompt (⌘K)"
+        title={isMacLike ? 'Submit a prompt (⌘K)' : 'Submit a prompt (Ctrl+K)'}
+        style={{
+          position: 'fixed',
+          bottom: 20,
+          right: 300, // sit to the left of the 280px agent rail
+          width: 52,
+          height: 52,
+          borderRadius: '50%',
+          background: '#3182ce',
+          color: '#f0f4f8',
+          border: 'none',
+          fontSize: 22,
+          cursor: 'pointer',
+          boxShadow: '0 6px 20px rgba(49,130,206,0.45)',
+          zIndex: 900,
+        }}
+      >
+        💬
+      </button>
+      <PromptModal open={open} onClose={() => setOpen(false)} initialText={seedText} />
+    </>
+  );
+}
+
+export default FloatingPromptButton;

--- a/apps/dashboard/components/prompt/PromptModal.tsx
+++ b/apps/dashboard/components/prompt/PromptModal.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+/**
+ * PromptModal — the modal used by the floating prompt button + inline
+ * `+` triggers + Cmd+K (DASH-011).
+ *
+ * Sends POST /api/prompts with `metadata.context` derived from the
+ * current URL via usePromptContext. The CAIA pipeline (PO → BA → EA …)
+ * processes the prompt; metadata.context becomes a hint to PO's
+ * scope-detector.
+ *
+ * Spec: caia/docs/dashboard-ui-conventions.md §5.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { usePromptContext, type PromptContext } from '../../hooks/usePromptContext';
+
+const HISTORY_KEY = 'prompt-history';
+const HISTORY_MAX = 5;
+
+const RUN_MODES = ['plan-only', 'test-only', 'full'] as const;
+type RunMode = typeof RUN_MODES[number];
+
+const SCOPES = ['initiative', 'epic', 'module', 'story', 'task', 'subtask', 'auto'] as const;
+type Scope = typeof SCOPES[number];
+
+interface PromptModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Optional pre-fill (e.g. selected text or row context). */
+  initialText?: string;
+  /** Optional context overrides (e.g. when triggered from a row). */
+  contextOverride?: Partial<PromptContext>;
+}
+
+interface HistoryEntry {
+  text: string;
+  ts: number;
+}
+
+function readHistory(): HistoryEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return parsed.slice(0, HISTORY_MAX) as HistoryEntry[];
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function appendHistory(text: string) {
+  if (typeof window === 'undefined') return;
+  try {
+    const cur = readHistory();
+    const next: HistoryEntry[] = [{ text, ts: Date.now() }, ...cur.filter((e) => e.text !== text)].slice(0, HISTORY_MAX);
+    window.localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+  } catch {
+    // ignore
+  }
+}
+
+export function PromptModal({ open, onClose, initialText = '', contextOverride }: PromptModalProps) {
+  const ctx = usePromptContext();
+  const mergedContext: PromptContext = { ...ctx, ...(contextOverride ?? {}) };
+  const [text, setText] = useState(initialText);
+  const [runMode, setRunMode] = useState<RunMode>('full');
+  const [scope, setScope] = useState<Scope>('auto');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [ok, setOk] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset on open.
+  useEffect(() => {
+    if (open) {
+      setText(initialText);
+      setErr(null);
+      setOk(null);
+      setHistory(readHistory());
+      // Focus next tick.
+      setTimeout(() => textareaRef.current?.focus(), 0);
+    }
+  }, [open, initialText]);
+
+  // Esc to close.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  async function submit() {
+    if (!text.trim()) return;
+    setSubmitting(true);
+    setErr(null);
+    setOk(null);
+    try {
+      const body = {
+        text: text.trim(),
+        run_mode: runMode,
+        ...(scope !== 'auto' ? { scope } : {}),
+        metadata: { context: mergedContext },
+      };
+      const r = await fetch('/api/prompts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) {
+        const msg = await r.text().catch(() => `HTTP ${r.status}`);
+        throw new Error(msg || `HTTP ${r.status}`);
+      }
+      const data = (await r.json()) as { prompt_id?: string };
+      appendHistory(text.trim());
+      setOk(data.prompt_id ? `Submitted as ${data.prompt_id}` : 'Submitted');
+      setText('');
+      setTimeout(() => onClose(), 800);
+    } catch (e) {
+      setErr(String((e as Error)?.message ?? e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Submit a prompt"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        zIndex: 1000,
+        padding: '10vh 16px 16px',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        style={{
+          width: 'min(680px, 100%)',
+          background: '#1a1f2e',
+          border: '1px solid #2d3748',
+          borderRadius: 12,
+          padding: 16,
+          color: '#f0f4f8',
+          boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <span style={{ fontSize: 14, fontWeight: 700, flex: 1 }}>💬 Submit a prompt</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{ background: 'transparent', border: 'none', color: '#a0aec0', fontSize: 18, cursor: 'pointer' }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div style={{ fontSize: 11, color: '#718096', marginBottom: 8 }}>
+          From: <span style={{ color: '#90cdf4' }}>{mergedContext.submittedFrom}</span>
+          {Object.keys(mergedContext.scope_hint).length > 0 && (
+            <>
+              {' • Hint:'}{' '}
+              {Object.entries(mergedContext.scope_hint).map(([k, v]) => (
+                <span key={k} style={{ marginRight: 8, color: '#cbd5e0' }}>
+                  <code>{k}={v}</code>
+                </span>
+              ))}
+            </>
+          )}
+        </div>
+
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={6}
+          placeholder="Ask CAIA to do something. Context (URL, parents, filters) is auto-attached."
+          style={{
+            width: '100%',
+            background: '#0f1117',
+            border: '1px solid #2d3748',
+            borderRadius: 8,
+            padding: 10,
+            color: '#f0f4f8',
+            fontSize: 14,
+            fontFamily: 'inherit',
+            resize: 'vertical',
+            boxSizing: 'border-box',
+          }}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              e.preventDefault();
+              void submit();
+            }
+          }}
+        />
+
+        <div style={{ display: 'flex', gap: 12, marginTop: 12, flexWrap: 'wrap' }}>
+          <label style={{ fontSize: 12, color: '#a0aec0', display: 'flex', alignItems: 'center', gap: 6 }}>
+            Run mode
+            <select
+              value={runMode}
+              onChange={(e) => setRunMode(e.target.value as RunMode)}
+              style={{
+                background: '#0f1117',
+                color: '#f0f4f8',
+                border: '1px solid #2d3748',
+                borderRadius: 6,
+                padding: '4px 6px',
+                fontSize: 12,
+              }}
+            >
+              {RUN_MODES.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </label>
+          <label style={{ fontSize: 12, color: '#a0aec0', display: 'flex', alignItems: 'center', gap: 6 }}>
+            Scope
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value as Scope)}
+              style={{
+                background: '#0f1117',
+                color: '#f0f4f8',
+                border: '1px solid #2d3748',
+                borderRadius: 6,
+                padding: '4px 6px',
+                fontSize: 12,
+              }}
+            >
+              {SCOPES.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </label>
+
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            style={{
+              background: 'transparent',
+              border: '1px solid #2d3748',
+              color: '#a0aec0',
+              padding: '6px 12px',
+              borderRadius: 6,
+              fontSize: 13,
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void submit()}
+            disabled={submitting || !text.trim()}
+            style={{
+              background: submitting || !text.trim() ? '#2d3748' : '#3182ce',
+              border: 'none',
+              color: '#f0f4f8',
+              padding: '6px 14px',
+              borderRadius: 6,
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: submitting || !text.trim() ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {submitting ? 'Submitting…' : 'Submit (⌘↵)'}
+          </button>
+        </div>
+
+        {err && <div style={{ marginTop: 10, color: '#fc8181', fontSize: 12 }}>Error: {err}</div>}
+        {ok && <div style={{ marginTop: 10, color: '#68d391', fontSize: 12 }}>{ok}</div>}
+
+        {history.length > 0 && (
+          <div style={{ marginTop: 16, paddingTop: 12, borderTop: '1px solid #2d3748' }}>
+            <div style={{ fontSize: 10, color: '#718096', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 6 }}>
+              Recent prompts
+            </div>
+            {history.map((h, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setText(h.text)}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'left',
+                  background: 'transparent',
+                  border: '1px solid #2d3748',
+                  borderRadius: 6,
+                  padding: '6px 8px',
+                  marginBottom: 4,
+                  color: '#cbd5e0',
+                  fontSize: 12,
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+                title={h.text}
+              >
+                {h.text}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PromptModal;

--- a/apps/dashboard/hooks/usePromptContext.ts
+++ b/apps/dashboard/hooks/usePromptContext.ts
@@ -1,0 +1,146 @@
+'use client';
+
+/**
+ * usePromptContext — derives the prompt-from-anywhere context payload
+ * from the current URL + filter state. Used by the floating prompt
+ * button (DASH-011) and any inline `+` button to send a prompt to
+ * /api/prompts with metadata.context attached.
+ *
+ * Spec: caia/docs/dashboard-ui-conventions.md §5.
+ */
+
+import { useMemo } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+const SECTION_LABELS: Record<string, string> = {
+  work: 'Work',
+  pipeline: 'Pipeline',
+  catalog: 'Catalog',
+  quality: 'Quality',
+  operations: 'Operations',
+  settings: 'Settings',
+};
+
+const KNOWN_SEGMENTS: Record<string, string> = {
+  prompts: 'Prompts',
+  stories: 'Stories',
+  tasks: 'Tasks',
+  blockers: 'Blockers',
+  requirements: 'Requirements',
+  questions: 'Questions',
+  suggestions: 'Suggestions',
+  queue: 'Queue',
+  buckets: 'Buckets',
+  submit: 'Submit',
+  journey: 'Journey',
+  pipeline: 'Pipeline',
+  agents: 'Agents',
+  architecture: 'Architecture',
+  contracts: 'Contracts',
+  features: 'Features',
+  domains: 'Domains',
+  projects: 'Projects',
+  registry: 'Registry',
+  gates: 'Gates',
+  tests: 'Tests',
+  completeness: 'Completeness',
+  health: 'Health',
+  observability: 'Observability',
+  metrics: 'Metrics',
+  builds: 'Builds',
+  audit: 'Audit',
+  standards: 'Standards',
+  adrs: 'ADRs',
+  reports: 'Reports',
+  timeline: 'Timeline',
+  events: 'Events',
+  'task-runs': 'Task runs',
+  dag: 'DAG',
+};
+
+export interface PromptScopeHint {
+  projectSlug?: string;
+  promptId?: string;
+  storyId?: string;
+  taskId?: string;
+  agentId?: string;
+  blockerId?: string;
+  requirementId?: string;
+  questionId?: string;
+}
+
+export interface PromptContext {
+  currentRoute: string;
+  breadcrumb: string[];
+  scope_hint: PromptScopeHint;
+  submittedFrom: string;
+  filterState: Record<string, string>;
+}
+
+function deriveBreadcrumb(segments: string[]): string[] {
+  return segments.map((seg) => {
+    if (SECTION_LABELS[seg]) return SECTION_LABELS[seg];
+    if (KNOWN_SEGMENTS[seg]) return KNOWN_SEGMENTS[seg];
+    // Dynamic segment — render as "<KindFromPrev> <id>" if previous segment
+    // was a known kind; else just the raw value.
+    return seg;
+  });
+}
+
+function deriveScopeHint(segments: string[], filterState: Record<string, string>): PromptScopeHint {
+  const hint: PromptScopeHint = {};
+  if (filterState['project']) hint.projectSlug = filterState['project'];
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const next = segments[i + 1];
+    if (!next || KNOWN_SEGMENTS[next]) continue;
+    // The next segment is a dynamic id under this collection.
+    if (seg === 'prompts') hint.promptId = next;
+    else if (seg === 'stories') hint.storyId = next;
+    else if (seg === 'tasks') hint.taskId = next;
+    else if (seg === 'agents') hint.agentId = next;
+    else if (seg === 'blockers') hint.blockerId = next;
+    else if (seg === 'requirements') hint.requirementId = next;
+    else if (seg === 'questions') hint.questionId = next;
+    else if (seg === 'projects' && !hint.projectSlug) hint.projectSlug = next;
+  }
+  return hint;
+}
+
+function deriveSubmittedFrom(segments: string[]): string {
+  if (segments.length === 0) return 'home';
+  // Prefer the most specific known label.
+  const known = segments
+    .filter((s) => SECTION_LABELS[s] || KNOWN_SEGMENTS[s])
+    .map((s) => SECTION_LABELS[s] ?? KNOWN_SEGMENTS[s]);
+  if (known.length === 0) return segments.join('/');
+  return known.join(' > ');
+}
+
+export function usePromptContext(extraFilterState?: Record<string, string>): PromptContext {
+  const pathname = usePathname() || '/';
+  const searchParams = useSearchParams();
+
+  return useMemo(() => {
+    const segments = pathname.split('/').filter(Boolean);
+
+    // Materialise query-string filters.
+    const filterState: Record<string, string> = {};
+    if (searchParams) {
+      searchParams.forEach((v, k) => {
+        filterState[k] = v;
+      });
+    }
+    if (extraFilterState) {
+      Object.assign(filterState, extraFilterState);
+    }
+
+    return {
+      currentRoute: pathname,
+      breadcrumb: deriveBreadcrumb(segments),
+      scope_hint: deriveScopeHint(segments, filterState),
+      submittedFrom: deriveSubmittedFrom(segments),
+      filterState,
+    };
+  }, [pathname, searchParams, extraFilterState]);
+}


### PR DESCRIPTION
Adds prompt-from-anywhere with auto-context capture.

- Floating bottom-right button (left of agent rail), opens prompt modal.
- Cmd+K / Ctrl+K global shortcut.
- Text-selection 'Ask CAIA about this →' tooltip pre-fills modal.
- Modal captures full context: currentRoute, breadcrumb, scope_hint (promptId/storyId/taskId/agentId/projectSlug from URL), submittedFrom, filterState (query string).
- Sends POST /api/prompts with metadata.context attached.
- Run-mode + scope selectors. Prompt history (last 5, localStorage).

Files: usePromptContext hook, PromptModal, FloatingPromptButton.

Backend: still UI-only. metadata.context is sent on existing POST /prompts; backend ignores extra fields today. Backlog item: make metadata.context first-class for PO scope-detector.

Refs caia/docs/dashboard-ui-conventions.md §5. PR11 of 11.