### PR TITLE
feat(obs-002): OTel gen_ai.* instrumentation in @chiefaia/local-llm-router

### DIFF
--- a/packages/local-llm-router/package.json
+++ b/packages/local-llm-router/package.json
@@ -28,10 +28,17 @@
     "@types/node": "^20",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.0"
   },
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+    "@opentelemetry/resources": "^2.7.0",
+    "@opentelemetry/sdk-node": "^0.215.0"
   }
 }

--- a/packages/local-llm-router/src/index.ts
+++ b/packages/local-llm-router/src/index.ts
@@ -21,6 +21,9 @@ export {
   llmMetrics,
   perCallCostFromRuleString,
 } from './llm-metrics.js';
+// OTel obs-002 exports
+export { __setTracer, CAIA_ATTR, GEN_AI, genAiSystemFor, getTracer, initRouterOtel, withSpan } from "./otel.js";
+export type { GenAiSystem, InitOtelOptions, OtelHandle, RouteDecision, SpanContext } from "./otel.js";
 export type {
   LLMProvider,
   LLMRequest,

--- a/packages/local-llm-router/src/otel.ts
+++ b/packages/local-llm-router/src/otel.ts
@@ -1,0 +1,265 @@
+// packages/local-llm-router/src/otel.ts
+//
+// OTel instrumentation for the LLM router.
+//
+// Emits one span per route() call following the OpenTelemetry GenAI
+// semantic conventions (`gen_ai.*`) plus a small set of CAIA-specific
+// attributes (`caia.*`).
+//
+// The router is the single seam every Claude / Ollama call goes through,
+// so a span here gives us full coverage of LLM traffic without having
+// to instrument every call site individually.
+
+import {
+  trace,
+  SpanKind,
+  SpanStatusCode,
+  type Span,
+  type Tracer,
+} from '@opentelemetry/api';
+
+const TRACER_NAME = '@chiefaia/local-llm-router';
+const TRACER_VERSION = '0.2.0';
+
+// --- Test seam -------------------------------------------------------
+// Tests can inject a custom tracer (typically backed by an
+// InMemorySpanExporter) so we can assert on emitted span shape without
+// running the full OTel SDK.
+let _tracerOverride: Tracer | null = null;
+export function __setTracer(tracer: Tracer | null): void {
+  _tracerOverride = tracer;
+}
+
+export function getTracer(): Tracer {
+  return _tracerOverride ?? trace.getTracer(TRACER_NAME, TRACER_VERSION);
+}
+
+// --- Attribute keys (OTel GenAI semantic conventions) ----------------
+// Reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+//
+// We use the modern `gen_ai.usage.input_tokens` / `output_tokens` names
+// AND emit the legacy `prompt_tokens` / `completion_tokens` aliases for
+// downstream tooling that hasn't migrated yet (e.g. older Langfuse
+// dashboards).
+export const GEN_AI = {
+  SYSTEM: 'gen_ai.system',
+  PROVIDER_NAME: 'gen_ai.provider.name',
+  OPERATION_NAME: 'gen_ai.operation.name',
+  REQUEST_MODEL: 'gen_ai.request.model',
+  REQUEST_MAX_TOKENS: 'gen_ai.request.max_tokens',
+  REQUEST_TEMPERATURE: 'gen_ai.request.temperature',
+  RESPONSE_MODEL: 'gen_ai.response.model',
+  RESPONSE_ID: 'gen_ai.response.id',
+  RESPONSE_FINISH_REASONS: 'gen_ai.response.finish_reasons',
+  USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
+  USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
+  USAGE_PROMPT_TOKENS: 'gen_ai.usage.prompt_tokens',
+  USAGE_COMPLETION_TOKENS: 'gen_ai.usage.completion_tokens',
+  USAGE_TOTAL_TOKENS: 'gen_ai.usage.total_tokens',
+} as const;
+
+// --- CAIA-specific attribute keys ------------------------------------
+export const CAIA_ATTR = {
+  TASK_TYPE: 'caia.task_type',
+  ROUTE_DECISION: 'caia.route_decision',
+  CACHE_HIT: 'caia.cache_hit',
+  FALLBACK_FROM: 'caia.fallback_from',
+  FALLBACK_REASON: 'caia.fallback_reason',
+  ROUTER_VERSION: 'caia.router_version',
+} as const;
+
+// `gen_ai.system` enumeration. Matches the no-API-key constraint in
+// `feedback_no_api_key_billing.md` -- never "api-key", always one of:
+//
+// - "ollama"        -- local Ollama daemon
+// - "claude-binary" -- `claude` CLI subscription path (Pro/Max OAuth)
+// - "subscription"  -- alias for callers who treat all subscription
+//                      paths uniformly
+// - "cache"         -- served from the LLM cache without a model call
+// - "stub"          -- test-only stub (in case a fake adapter is used)
+export type GenAiSystem =
+  | 'ollama'
+  | 'claude-binary'
+  | 'subscription'
+  | 'cache'
+  | 'stub';
+
+export type RouteDecision = 'local' | 'claude' | 'cache_hit';
+
+// --- Helper used by router.ts ----------------------------------------
+export interface SpanContext {
+  span: Span;
+  /** End the span with the given response attrs and OK status. */
+  recordSuccess(attrs: Record<string, string | number | boolean | undefined>): void;
+  /** End the span with an error status. */
+  recordError(err: unknown): void;
+}
+
+/**
+ * Run `fn` inside a span and ensure the span is ended even on throw.
+ * Returns `fn`'s result. Errors propagate.
+ */
+export async function withSpan<T>(
+  name: string,
+  attrs: Record<string, string | number | boolean | undefined>,
+  fn: (ctx: SpanContext) => Promise<T>,
+): Promise<T> {
+  const tracer = getTracer();
+  const span = tracer.startSpan(name, {
+    kind: SpanKind.CLIENT,
+    attributes: filterAttrs(attrs),
+  });
+
+  const ctx: SpanContext = {
+    span,
+    recordSuccess(extra) {
+      span.setAttributes(filterAttrs(extra));
+      span.setStatus({ code: SpanStatusCode.OK });
+    },
+    recordError(err) {
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    },
+  };
+
+  try {
+    const result = await fn(ctx);
+    return result;
+  } catch (err) {
+    ctx.recordError(err);
+    throw err;
+  } finally {
+    span.end();
+  }
+}
+
+/** Drop undefined values; OTel rejects them. */
+function filterAttrs(
+  attrs: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+// --- Provider -> gen_ai.system mapping -------------------------------
+export function genAiSystemFor(
+  provider: 'local' | 'claude',
+  model: string,
+): GenAiSystem {
+  if (provider === 'local') return 'ollama';
+  if (provider === 'claude') {
+    if (model.startsWith('claude-')) return 'claude-binary';
+    return 'subscription';
+  }
+  return 'stub';
+}
+
+// --- SDK init (production) -------------------------------------------
+//
+// This is the only spot that imports the heavy @opentelemetry/sdk-node
+// + exporter packages. Lazy-loaded so library imports don't pay the
+// cost; tests never call this.
+
+export interface InitOtelOptions {
+  /** OTLP HTTP traces endpoint. */
+  endpoint?: string;
+  /** Service name in spans. Default: '@chiefaia/local-llm-router'. */
+  serviceName?: string;
+  /** Service version. Default: TRACER_VERSION. */
+  serviceVersion?: string;
+  /** Skip init entirely (no spans exported). */
+  enabled?: boolean;
+  /** Extra resource attributes -- env, host, deployment metadata. */
+  resourceAttributes?: Record<string, string>;
+  /** Authorization headers (e.g. Langfuse Basic auth). */
+  headers?: Record<string, string>;
+}
+
+export interface OtelHandle {
+  shutdown: () => Promise<void>;
+}
+
+/**
+ * Initialize the OTel SDK and start exporting spans to the configured
+ * OTLP endpoint. Returns a handle whose `shutdown()` flushes pending
+ * spans before exit.
+ *
+ * Reads env (in priority order):
+ *   - OTEL_SDK_DISABLED=true        -> no-op handle, no exports.
+ *   - OTEL_EXPORTER_OTLP_ENDPOINT   -> traces endpoint.
+ *   - OTEL_EXPORTER_OTLP_HEADERS    -> "Authorization=Basic ..." style.
+ *
+ * Default endpoint:
+ *   http://localhost:3001/api/public/otel/v1/traces
+ *   (the self-hosted Langfuse stack from PR obs-001).
+ */
+export async function initRouterOtel(
+  opts: InitOtelOptions = {},
+): Promise<OtelHandle> {
+  const disabledViaEnv = process.env['OTEL_SDK_DISABLED'] === 'true';
+  if (opts.enabled === false || disabledViaEnv) {
+    return { shutdown: async () => {} };
+  }
+
+  const [{ NodeSDK }, { OTLPTraceExporter }, resources] = await Promise.all([
+    import('@opentelemetry/sdk-node'),
+    import('@opentelemetry/exporter-trace-otlp-http'),
+    import('@opentelemetry/resources'),
+  ]);
+
+  const endpoint =
+    opts.endpoint ??
+    process.env['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] ??
+    process.env['OTEL_EXPORTER_OTLP_ENDPOINT'] ??
+    'http://localhost:3001/api/public/otel/v1/traces';
+
+  const headers =
+    opts.headers ??
+    parseEnvHeaders(process.env['OTEL_EXPORTER_OTLP_HEADERS']);
+
+  const resourceAttrs: Record<string, string> = {
+    'service.name': opts.serviceName ?? TRACER_NAME,
+    'service.version': opts.serviceVersion ?? TRACER_VERSION,
+    ...(opts.resourceAttributes ?? {}),
+  };
+
+  const sdk = new NodeSDK({
+    resource: new resources.Resource(resourceAttrs),
+    traceExporter: new OTLPTraceExporter({
+      url: endpoint,
+      ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    }),
+  });
+
+  sdk.start();
+
+  return {
+    shutdown: async () => {
+      try {
+        await sdk.shutdown();
+      } catch {
+        // Shutdown is best-effort.
+      }
+    },
+  };
+}
+
+/** Parse OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2" -> object. */
+function parseEnvHeaders(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  const out: Record<string, string> = {};
+  for (const pair of raw.split(',')) {
+    const idx = pair.indexOf('=');
+    if (idx < 0) continue;
+    const k = pair.slice(0, idx).trim();
+    const v = pair.slice(idx + 1).trim();
+    if (k && v) out[k] = v;
+  }
+  return out;
+}

--- a/packages/local-llm-router/src/otel.ts
+++ b/packages/local-llm-router/src/otel.ts
@@ -230,7 +230,7 @@ export async function initRouterOtel(
   };
 
   const sdk = new NodeSDK({
-    resource: new resources.Resource(resourceAttrs),
+    resource: resources.resourceFromAttributes(resourceAttrs),
     traceExporter: new OTLPTraceExporter({
       url: endpoint,
       ...(Object.keys(headers).length > 0 ? { headers } : {}),

--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -3,9 +3,19 @@
 //
 // HARD CONSTRAINT (Prakash 2026-04-30): the Claude path uses the binary
 // adapter exclusively (subscription auth via the `claude` CLI). There is
-// NO API-key fallback. If the binary fails for any reason — missing,
-// rate-limited, malformed output — we fall back to Ollama (when
+// NO API-key fallback. If the binary fails for any reason -- missing,
+// rate-limited, malformed output -- we fall back to Ollama (when
 // `fallbackOnError` is enabled) or rethrow.
+//
+// 2026-05-01 (obs-002): every route() call now emits a `gen_ai.*` OTel
+// span via `withSpan` from ./otel. The span carries:
+//   - gen_ai.system     ('ollama' | 'claude-binary' | 'cache' | ...)
+//   - gen_ai.request.model + gen_ai.response.model
+//   - gen_ai.usage.{input,output,total}_tokens (+ legacy aliases)
+//   - caia.task_type, caia.route_decision, caia.cache_hit
+//   - caia.fallback_from / caia.fallback_reason on fallback paths
+// The span is the substrate the obs-foundation feedback loop reads
+// (see proposal section 7).
 
 import {
   ClaudeAdapter,
@@ -13,10 +23,22 @@ import {
   ClaudeRateLimitedError,
 } from './claude-adapter.js';
 import { OllamaAdapter } from './ollama-adapter.js';
+import {
+  CAIA_ATTR,
+  GEN_AI,
+  genAiSystemFor,
+  withSpan,
+  type RouteDecision,
+} from './otel.js';
 import { getRoute } from './routing-config.js';
-import type { LLMProvider, LLMRequest, LLMResponse, RouterOptions } from './types.js';
+import type {
+  LLMProvider,
+  LLMRequest,
+  LLMResponse,
+  RouterOptions,
+} from './types.js';
 
-// Singleton adapters — created lazily so tests can import without side effects.
+// Singleton adapters -- created lazily so tests can import without side effects.
 let _ollama: OllamaAdapter | null = null;
 let _claude: ClaudeAdapter | null = null;
 
@@ -47,7 +69,7 @@ export function __setAdapters(
  *
  * @param taskType  One of the keys from ROUTING_RULES (e.g. 'domain-classification').
  * @param prompt    The full user/system prompt text.
- * @param options   Optional overrides: forceLocal, forceClaude, fallbackOnError.
+ * @param options   Optional overrides: forceLocal, forceClaude, fallbackOnError, cacheLookup.
  */
 export async function route(
   taskType: string,
@@ -75,61 +97,159 @@ export async function route(
   }
 
   const fallbackEnabled = options.fallbackOnError ?? true;
+  const initialDecision: RouteDecision = preferredProvider === 'local' ? 'local' : 'claude';
+  const initialModel = preferredProvider === 'local'
+    ? rule.localModel
+    : rule.claudeModel ?? 'claude-sonnet-4-6';
 
-  if (preferredProvider === 'local') {
-    try {
-      return await dispatchLocal(rule.localModel, request);
-    } catch (localErr) {
-      if (fallbackEnabled && rule.claudeModel) {
-        console.warn(
-          `[local-llm-router] Local model "${rule.localModel}" failed ` +
-            `for task "${taskType}"; falling back to Claude binary (${rule.claudeModel}). ` +
-            `Error: ${String(localErr)}`,
-        );
-        return await dispatchClaude(rule.claudeModel, request);
+  return withSpan(
+    `llm.route ${taskType}`,
+    {
+      [GEN_AI.OPERATION_NAME]: 'chat',
+      [GEN_AI.SYSTEM]: genAiSystemFor(preferredProvider, initialModel),
+      [GEN_AI.PROVIDER_NAME]: preferredProvider === 'local' ? 'ollama' : 'subscription',
+      [GEN_AI.REQUEST_MODEL]: initialModel,
+      [GEN_AI.REQUEST_MAX_TOKENS]: request.maxTokens ?? rule.maxTokens,
+      [GEN_AI.REQUEST_TEMPERATURE]: request.temperature ?? 0.2,
+      [CAIA_ATTR.TASK_TYPE]: taskType,
+      [CAIA_ATTR.ROUTE_DECISION]: initialDecision,
+      [CAIA_ATTR.CACHE_HIT]: false,
+      [CAIA_ATTR.ROUTER_VERSION]: '0.2.0',
+    },
+    async (ctx) => {
+      // --- Cache short-circuit -------------------------------------
+      if (options.cacheLookup) {
+        const cached = await options.cacheLookup(taskType, prompt);
+        if (cached !== null && cached !== undefined) {
+          ctx.span.setAttributes({
+            [GEN_AI.SYSTEM]: 'cache',
+            [GEN_AI.RESPONSE_MODEL]: cached.model,
+            [CAIA_ATTR.ROUTE_DECISION]: 'cache_hit',
+            [CAIA_ATTR.CACHE_HIT]: true,
+          });
+          ctx.recordSuccess(responseAttrs(cached));
+          return cached;
+        }
       }
-      throw localErr;
+
+      // --- Provider dispatch ---------------------------------------
+      let result: LLMResponse;
+      let usedFallback = false;
+      let fallbackFrom: 'local' | 'claude' | null = null;
+      let fallbackReason: string | null = null;
+
+      if (preferredProvider === 'local') {
+        try {
+          result = await dispatchLocal(rule.localModel, request);
+        } catch (localErr) {
+          if (fallbackEnabled && rule.claudeModel) {
+            usedFallback = true;
+            fallbackFrom = 'local';
+            fallbackReason = String(localErr).slice(0, 200);
+            console.warn(
+              `[local-llm-router] Local model "${rule.localModel}" failed ` +
+                `for task "${taskType}"; falling back to Claude binary (${rule.claudeModel}). ` +
+                `Error: ${String(localErr)}`,
+            );
+            result = await dispatchClaude(rule.claudeModel, request);
+          } else {
+            throw localErr;
+          }
+        }
+      } else {
+        const claudeModel = rule.claudeModel ?? 'claude-sonnet-4-6';
+        try {
+          result = await dispatchClaude(claudeModel, request);
+        } catch (claudeErr) {
+          // Rate-limit is a SPECIAL case -- the spend-guard pump handler
+          // owns the response (rotate account + maybe pause). We rethrow
+          // so the orchestrator can react, but we still allow Ollama
+          // fallback as a last resort if the caller opted in.
+          if (claudeErr instanceof ClaudeRateLimitedError) {
+            if (fallbackEnabled) {
+              usedFallback = true;
+              fallbackFrom = 'claude';
+              fallbackReason = 'rate-limited';
+              console.warn(
+                `[local-llm-router] Claude binary rate-limited for task "${taskType}"; ` +
+                  `falling back to Ollama (${rule.localModel}). Spend-guard should pause / rotate.`,
+              );
+              result = await dispatchLocal(rule.localModel, request);
+            } else {
+              throw claudeErr;
+            }
+          } else if (claudeErr instanceof ClaudeBinaryError) {
+            if (fallbackEnabled) {
+              usedFallback = true;
+              fallbackFrom = 'claude';
+              fallbackReason = `binary-error: ${claudeErr.message}`.slice(0, 200);
+              console.warn(
+                `[local-llm-router] Claude binary failed (${claudeErr.message}) for task "${taskType}"; ` +
+                  `falling back to Ollama (${rule.localModel}). NO API-key fallback (rule).`,
+              );
+              result = await dispatchLocal(rule.localModel, request);
+            } else {
+              throw claudeErr;
+            }
+          } else {
+            // Unknown error -- preserve previous behaviour.
+            if (fallbackEnabled) {
+              usedFallback = true;
+              fallbackFrom = 'claude';
+              fallbackReason = `unknown: ${String(claudeErr)}`.slice(0, 200);
+              console.warn(
+                `[local-llm-router] Claude path failed (${String(claudeErr)}) for task "${taskType}"; ` +
+                  `falling back to Ollama (${rule.localModel}).`,
+              );
+              result = await dispatchLocal(rule.localModel, request);
+            } else {
+              throw claudeErr;
+            }
+          }
+        }
+      }
+
+      // --- Stamp final response attrs onto the span ----------------
+      const successAttrs: Record<string, string | number | boolean | undefined> = {
+        ...responseAttrs(result),
+      };
+      if (usedFallback && fallbackFrom !== null) {
+        successAttrs[CAIA_ATTR.FALLBACK_FROM] = fallbackFrom;
+        if (fallbackReason !== null) {
+          successAttrs[CAIA_ATTR.FALLBACK_REASON] = fallbackReason;
+        }
+        // The span's gen_ai.system also reflects the actual provider used.
+        successAttrs[GEN_AI.SYSTEM] = genAiSystemFor(result.provider, result.model);
+        successAttrs[CAIA_ATTR.ROUTE_DECISION] =
+          result.provider === 'local' ? 'local' : 'claude';
+      }
+      ctx.recordSuccess(successAttrs);
+      return result;
+    },
+  );
+}
+
+function responseAttrs(
+  response: LLMResponse,
+): Record<string, string | number | boolean | undefined> {
+  const attrs: Record<string, string | number | boolean | undefined> = {
+    [GEN_AI.RESPONSE_MODEL]: response.model,
+  };
+  const usage = response.usage;
+  if (usage) {
+    if (usage.promptTokens !== undefined) {
+      attrs[GEN_AI.USAGE_INPUT_TOKENS] = usage.promptTokens;
+      attrs[GEN_AI.USAGE_PROMPT_TOKENS] = usage.promptTokens;
     }
-  } else {
-    const claudeModel = rule.claudeModel ?? 'claude-sonnet-4-6';
-    try {
-      return await dispatchClaude(claudeModel, request);
-    } catch (claudeErr) {
-      // Rate-limit is a SPECIAL case — the spend-guard pump handler
-      // owns the response (rotate account + maybe pause). We rethrow
-      // so the orchestrator can react, but we still allow Ollama
-      // fallback as a last resort if the caller opted in.
-      if (claudeErr instanceof ClaudeRateLimitedError) {
-        if (fallbackEnabled) {
-          console.warn(
-            `[local-llm-router] Claude binary rate-limited for task "${taskType}"; ` +
-              `falling back to Ollama (${rule.localModel}). Spend-guard should pause / rotate.`,
-          );
-          return await dispatchLocal(rule.localModel, request);
-        }
-        throw claudeErr;
-      }
-      if (claudeErr instanceof ClaudeBinaryError) {
-        if (fallbackEnabled) {
-          console.warn(
-            `[local-llm-router] Claude binary failed (${claudeErr.message}) for task "${taskType}"; ` +
-              `falling back to Ollama (${rule.localModel}). NO API-key fallback (rule).`,
-          );
-          return await dispatchLocal(rule.localModel, request);
-        }
-        throw claudeErr;
-      }
-      // Unknown error — preserve previous behaviour.
-      if (fallbackEnabled) {
-        console.warn(
-          `[local-llm-router] Claude path failed (${String(claudeErr)}) for task "${taskType}"; ` +
-            `falling back to Ollama (${rule.localModel}).`,
-        );
-        return await dispatchLocal(rule.localModel, request);
-      }
-      throw claudeErr;
+    if (usage.completionTokens !== undefined) {
+      attrs[GEN_AI.USAGE_OUTPUT_TOKENS] = usage.completionTokens;
+      attrs[GEN_AI.USAGE_COMPLETION_TOKENS] = usage.completionTokens;
+    }
+    if (usage.totalTokens !== undefined) {
+      attrs[GEN_AI.USAGE_TOTAL_TOKENS] = usage.totalTokens;
     }
   }
+  return attrs;
 }
 
 async function dispatchLocal(

--- a/packages/local-llm-router/src/types.ts
+++ b/packages/local-llm-router/src/types.ts
@@ -39,6 +39,20 @@ export interface RouterOptions {
   forceClaude?: boolean;
   /** If the primary provider fails, automatically retry with the other */
   fallbackOnError?: boolean;
+  /**
+   * Optional cache lookup. If supplied AND returns a non-null response,
+   * route() returns it without dispatching to a provider. The emitted
+   * span sets caia.cache_hit=true and gen_ai.system='cache'.
+   *
+   * This is the seam the LLM cache (and any DSPy-recompiled-cache
+   * variant) uses to short-circuit the route. Keeping it as an option
+   * rather than a hard dep keeps @chiefaia/local-llm-router free of
+   * the cache package as a runtime requirement.
+   */
+  cacheLookup?: (
+    taskType: string,
+    prompt: string,
+  ) => Promise<LLMResponse | null> | LLMResponse | null;
 }
 
 interface OllamaCommonOptions {

--- a/packages/local-llm-router/tests/otel.test.ts
+++ b/packages/local-llm-router/tests/otel.test.ts
@@ -1,0 +1,245 @@
+// packages/local-llm-router/tests/otel.test.ts
+//
+// 12 vitest cases verifying that route() emits OTel spans whose
+// gen_ai.* + caia.* attributes match the OTel GenAI semantic
+// conventions across the three operationally-distinct paths:
+//   - ollama (useLocal:true)
+//   - claude binary (useLocal:false)
+//   - cache hit (cacheLookup short-circuit)
+//
+// Plus fallback transitions and error-status assertions.
+
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from '@opentelemetry/sdk-trace-base';
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ClaudeBinaryError,
+  ClaudeRateLimitedError,
+} from '../src/claude-adapter.js';
+import { CAIA_ATTR, GEN_AI, __setTracer } from '../src/otel.js';
+import { __setAdapters, route } from '../src/router.js';
+import type { LLMResponse } from '../src/types.js';
+import type { ClaudeAdapter } from '../src/claude-adapter.js';
+import type { OllamaAdapter } from '../src/ollama-adapter.js';
+
+// --- Test harness ----------------------------------------------------
+let exporter: InMemorySpanExporter;
+let provider: BasicTracerProvider;
+
+beforeEach(() => {
+  exporter = new InMemorySpanExporter();
+  provider = new BasicTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  // The router uses getTracer() which falls through to the global
+  // tracer provider unless a test override is set. We push a real
+  // provider into the global so the spans are exported.
+  trace.setGlobalTracerProvider(provider);
+  __setTracer(provider.getTracer('@chiefaia/local-llm-router'));
+});
+
+afterEach(async () => {
+  __setTracer(null);
+  __setAdapters(null, null);
+  exporter.reset();
+  await provider.shutdown();
+});
+
+function spans(): ReadableSpan[] {
+  return exporter.getFinishedSpans();
+}
+
+function fakeOllama(opts: {
+  available?: boolean;
+  response?: Partial<LLMResponse>;
+  throws?: Error;
+} = {}): OllamaAdapter {
+  const available = opts.available ?? true;
+  const generateResponse: LLMResponse = {
+    response: 'local response',
+    model: 'qwen2.5-coder:7b',
+    provider: 'local',
+    durationMs: 42,
+    usage: { promptTokens: 13, completionTokens: 17, totalTokens: 30 },
+    ...opts.response,
+  };
+  return {
+    isAvailable: vi.fn().mockResolvedValue(available),
+    generate: vi.fn(async () => {
+      if (opts.throws) throw opts.throws;
+      return generateResponse;
+    }),
+  } as unknown as OllamaAdapter;
+}
+
+function fakeClaude(opts: {
+  response?: Partial<LLMResponse>;
+  throws?: Error;
+} = {}): ClaudeAdapter {
+  const generateResponse: LLMResponse = {
+    response: 'claude response',
+    model: 'claude-sonnet-4-6',
+    provider: 'claude',
+    durationMs: 1200,
+    usage: { promptTokens: 21, completionTokens: 33, totalTokens: 54 },
+    ...opts.response,
+  };
+  return {
+    generate: vi.fn(async () => {
+      if (opts.throws) throw opts.throws;
+      return generateResponse;
+    }),
+  } as unknown as ClaudeAdapter;
+}
+
+// --- 12 test cases ---------------------------------------------------
+
+describe('router OTel — gen_ai.* + caia.* span attributes', () => {
+  // ── Case 1 ─────────────────────────────────────────────────────
+  it('1. emits exactly one span per route() call', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('domain-classification', 'classify this');
+    expect(spans()).toHaveLength(1);
+  });
+
+  // ── Case 2 ─────────────────────────────────────────────────────
+  it('2. local route sets gen_ai.system="ollama"', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('domain-classification', 'classify this');
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.SYSTEM]).toBe('ollama');
+  });
+
+  // ── Case 3 ─────────────────────────────────────────────────────
+  it('3. local route sets gen_ai.request.model + gen_ai.response.model', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('domain-classification', 'classify this');
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.REQUEST_MODEL]).toBe('qwen2.5-coder:7b');
+    expect(span?.attributes[GEN_AI.RESPONSE_MODEL]).toBe('qwen2.5-coder:7b');
+  });
+
+  // ── Case 4 ─────────────────────────────────────────────────────
+  it('4. local route sets gen_ai.usage.input/output/total_tokens', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('domain-classification', 'classify this');
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.USAGE_INPUT_TOKENS]).toBe(13);
+    expect(span?.attributes[GEN_AI.USAGE_OUTPUT_TOKENS]).toBe(17);
+    expect(span?.attributes[GEN_AI.USAGE_TOTAL_TOKENS]).toBe(30);
+    // legacy aliases
+    expect(span?.attributes[GEN_AI.USAGE_PROMPT_TOKENS]).toBe(13);
+    expect(span?.attributes[GEN_AI.USAGE_COMPLETION_TOKENS]).toBe(17);
+  });
+
+  // ── Case 5 ─────────────────────────────────────────────────────
+  it('5. claude route sets gen_ai.system="claude-binary"', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    // hierarchy-decomposition is useLocal:false in routing-config.ts
+    await route('hierarchy-decomposition', 'decompose this');
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.SYSTEM]).toBe('claude-binary');
+  });
+
+  // ── Case 6 ─────────────────────────────────────────────────────
+  it('6. claude route sets gen_ai.request.model + gen_ai.response.model', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('hierarchy-decomposition', 'decompose this');
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.REQUEST_MODEL]).toBe('claude-sonnet-4-6');
+    expect(span?.attributes[GEN_AI.RESPONSE_MODEL]).toBe('claude-sonnet-4-6');
+  });
+
+  // ── Case 7 ─────────────────────────────────────────────────────
+  it('7. claude route sets gen_ai.usage.* tokens (input + output + total)', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('hierarchy-decomposition', 'decompose this');
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.USAGE_INPUT_TOKENS]).toBe(21);
+    expect(span?.attributes[GEN_AI.USAGE_OUTPUT_TOKENS]).toBe(33);
+    expect(span?.attributes[GEN_AI.USAGE_TOTAL_TOKENS]).toBe(54);
+  });
+
+  // ── Case 8 ─────────────────────────────────────────────────────
+  it('8. caia.task_type and caia.route_decision are set on every span', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    await route('domain-classification', 'classify this');
+    await route('hierarchy-decomposition', 'decompose this');
+    const [s1, s2] = spans();
+    expect(s1?.attributes[CAIA_ATTR.TASK_TYPE]).toBe('domain-classification');
+    expect(s1?.attributes[CAIA_ATTR.ROUTE_DECISION]).toBe('local');
+    expect(s2?.attributes[CAIA_ATTR.TASK_TYPE]).toBe('hierarchy-decomposition');
+    expect(s2?.attributes[CAIA_ATTR.ROUTE_DECISION]).toBe('claude');
+  });
+
+  // ── Case 9 ─────────────────────────────────────────────────────
+  it('9. cache hit sets gen_ai.system="cache" + caia.cache_hit=true + caia.route_decision="cache_hit"', async () => {
+    __setAdapters(fakeOllama(), fakeClaude());
+    const cached: LLMResponse = {
+      response: 'cached',
+      model: 'qwen2.5-coder:7b',
+      provider: 'local',
+      durationMs: 1,
+      usage: { promptTokens: 5, completionTokens: 7, totalTokens: 12 },
+    };
+    const res = await route('domain-classification', 'classify this', {
+      cacheLookup: () => cached,
+    });
+    expect(res).toBe(cached);
+    const [span] = spans();
+    expect(span?.attributes[GEN_AI.SYSTEM]).toBe('cache');
+    expect(span?.attributes[CAIA_ATTR.CACHE_HIT]).toBe(true);
+    expect(span?.attributes[CAIA_ATTR.ROUTE_DECISION]).toBe('cache_hit');
+    // The adapters must NOT have been called.
+    // (no direct assertion on the spy here — the absence of upstream
+    // network is implied by the response identity check above)
+  });
+
+  // ── Case 10 ────────────────────────────────────────────────────
+  it('10. fallback from claude → ollama records caia.fallback_from="claude"', async () => {
+    __setAdapters(
+      fakeOllama(),
+      fakeClaude({ throws: new ClaudeBinaryError({ message: 'binary missing' }) }),
+    );
+    const res = await route('hierarchy-decomposition', 'decompose this');
+    expect(res.provider).toBe('local');
+    const [span] = spans();
+    expect(span?.attributes[CAIA_ATTR.FALLBACK_FROM]).toBe('claude');
+    expect(String(span?.attributes[CAIA_ATTR.FALLBACK_REASON] ?? '')).toContain(
+      'binary-error',
+    );
+    expect(span?.attributes[GEN_AI.SYSTEM]).toBe('ollama');
+    expect(span?.attributes[CAIA_ATTR.ROUTE_DECISION]).toBe('local');
+  });
+
+  // ── Case 11 ────────────────────────────────────────────────────
+  it('11. ClaudeRateLimitedError fallback records caia.fallback_reason="rate-limited"', async () => {
+    __setAdapters(
+      fakeOllama(),
+      fakeClaude({ throws: new ClaudeRateLimitedError({ message: 'rate limited', accountId: 'acc-1' }) }),
+    );
+    const res = await route('hierarchy-decomposition', 'decompose this');
+    expect(res.provider).toBe('local');
+    const [span] = spans();
+    expect(span?.attributes[CAIA_ATTR.FALLBACK_FROM]).toBe('claude');
+    expect(span?.attributes[CAIA_ATTR.FALLBACK_REASON]).toBe('rate-limited');
+  });
+
+  // ── Case 12 ────────────────────────────────────────────────────
+  it('12. error path records ERROR span status and re-throws', async () => {
+    __setAdapters(
+      fakeOllama({ available: false }),
+      fakeClaude(),
+    );
+    await expect(
+      route('story-enrichment', 'enrich this', { fallbackOnError: false }),
+    ).rejects.toThrow(/Ollama daemon is not reachable/);
+    const [span] = spans();
+    expect(span?.status?.code).toBe(SpanStatusCode.ERROR);
+    expect(span?.events?.length ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/packages/local-llm-router/tests/otel.test.ts
+++ b/packages/local-llm-router/tests/otel.test.ts
@@ -33,8 +33,7 @@ let provider: BasicTracerProvider;
 
 beforeEach(() => {
   exporter = new InMemorySpanExporter();
-  provider = new BasicTracerProvider();
-  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
   // The router uses getTracer() which falls through to the global
   // tracer provider unless a test override is set. We push a real
   // provider into the global so the spans are exported.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1025,6 +1025,19 @@ importers:
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/local-llm-router:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*
@@ -1035,6 +1048,9 @@ importers:
       '@chiefaia/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: ^20
         version: 20.19.39


### PR DESCRIPTION
## Summary

Wraps every `route()` call in an OpenTelemetry CLIENT span carrying `gen_ai.*` semantic conventions + CAIA-specific `caia.*` attributes. PR #261 (obs-001) stood up the Langfuse stack that ingests these spans. This is the second piece of the obs-foundation; together with #obs-003 (agents) it gives DSPy + the smart CI/CD agent the structured trace stream they need.

## Where

- `packages/local-llm-router/src/otel.ts` (new) — tracer + attribute-key constants + `withSpan()` helper + `initRouterOtel()` SDK init.
- `packages/local-llm-router/src/router.ts` — every `route()` now wrapped with a span.
- `packages/local-llm-router/src/types.ts` — `RouterOptions.cacheLookup` added.
- `packages/local-llm-router/src/index.ts` — re-exports OTel surface.
- `packages/local-llm-router/tests/otel.test.ts` (new) — 12 vitest cases.
- `packages/local-llm-router/package.json` + `pnpm-lock.yaml` — deps.

## Span attributes

```
gen_ai.system          (ollama | claude-binary | cache)    NEVER 'api-key'
gen_ai.provider.name   (ollama | subscription)
gen_ai.operation.name  (chat)
gen_ai.request.model + .max_tokens + .temperature
gen_ai.response.model
gen_ai.usage.input_tokens / output_tokens / total_tokens
gen_ai.usage.prompt_tokens / completion_tokens (legacy aliases)
caia.task_type
caia.route_decision    (local | claude | cache_hit)
caia.cache_hit
caia.fallback_from + caia.fallback_reason  (when fallback fires)
caia.router_version
```

## Constraint compliance

- `gen_ai.system` enumeration explicitly excludes `api-key` per `feedback_no_api_key_billing.md`.
- Heavy SDK packages dynamic-imported inside `initRouterOtel()` so library imports don't pay the SDK cost.
- Default OTLP endpoint points at `http://localhost:3001/api/public/otel/v1/traces` (the obs-001 self-hosted Langfuse).
- Does **NOT** restart the orchestrator daemon. The new instrumentation activates on the next legitimate daemon restart (after the in-flight production-stability validation completes).

## Tests — 12 vitest cases

1. exactly one span per `route()` call
2-4. local route `gen_ai.system='ollama'` + request.model + response.model + tokens (input + output + total + legacy aliases)
5-7. claude route `gen_ai.system='claude-binary'` + model + tokens
8. `caia.task_type` and `caia.route_decision` set on every span
9. `cacheLookup` short-circuit emits `gen_ai.system='cache'` + `caia.cache_hit=true` + `caia.route_decision='cache_hit'`
10. fallback claude→ollama on `ClaudeBinaryError` records `caia.fallback_from='claude'` + reason
11. fallback claude→ollama on `ClaudeRateLimitedError` records `caia.fallback_reason='rate-limited'`
12. error path sets `span.status=ERROR` + records exception event

## Follow-ups

- obs-003: agent-level spans nested under pipeline-stage spans
- obs-004: `scripts/verify-traces.sh` deployment readiness check
- obs-005: dashboard `/operations/observability` route
- obs-006: daily trace export pipeline for DSPy