### PR TITLE
feat(dspy-003): trace pipeline (spend_records source, Langfuse later)

### DIFF
--- a/packages/dspy-bridge/src/evalsets/po-scope-detector-phase2e002.ts
+++ b/packages/dspy-bridge/src/evalsets/po-scope-detector-phase2e002.ts
@@ -1,0 +1,138 @@
+/**
+ * The 10 PHASE2E-002 prompts — vendored from
+ * `packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts`
+ * so the eval set can be emitted without depending on a test file.
+ *
+ * Keep in sync. The validation suite imports `PROMPT_FIXTURES` from the
+ * test file; here we re-encode the same data with `tolerance` already
+ * resolved per row so the JSONL eval rows are flat.
+ *
+ * Source of truth: `SCOPE_DETECTION_TOLERANCE` + `PROMPT_FIXTURES` in
+ * the validation test. PRs that mutate one MUST mutate both — covered
+ * by a sync test in PR4.
+ */
+
+import type { TrainsetRow } from '../trainset.js';
+
+export interface Phase2e002Fixture {
+  tag: string;
+  scenario:
+    | 'new-feature'
+    | 'bug-fix'
+    | 'enhancement'
+    | 'cross-domain'
+    | 'refactor'
+    | 'spike'
+    | 'multi-agent-collab'
+    | 'ea-heavy'
+    | 'test-heavy'
+    | 'chore';
+  body: string;
+  /** The single "primary" expected scope per the proposal heuristics. */
+  expectedScope:
+    | 'initiative' | 'epic' | 'module' | 'story' | 'task' | 'subtask';
+  /** All scopes the proposal accepts as "correct" for this prompt. */
+  tolerance: ReadonlyArray<
+    'initiative' | 'epic' | 'module' | 'story' | 'task' | 'subtask'
+  >;
+}
+
+export const PHASE2E_002_FIXTURES: readonly Phase2e002Fixture[] = [
+  {
+    tag: 'simple-feature',
+    scenario: 'new-feature',
+    body:
+      'add a user profile page with avatar upload and a display-name field; persist to the users table and render an Edit button',
+    expectedScope: 'story',
+    tolerance: ['story', 'epic'],
+  },
+  {
+    tag: 'bug-fix',
+    scenario: 'bug-fix',
+    body:
+      'fix the login button not responsive on mobile — at <375px viewport the click target shrinks below the WCAG 2.1 minimum and the button stops responding to taps',
+    expectedScope: 'task',
+    tolerance: ['task', 'story', 'subtask'],
+  },
+  {
+    tag: 'enhancement',
+    scenario: 'enhancement',
+    body:
+      'add a filter dropdown to the existing dashboard table — the user can filter rows by domain (auth / payments / observability) and the URL reflects the active filter',
+    expectedScope: 'story',
+    tolerance: ['story', 'epic'],
+  },
+  {
+    tag: 'cross-domain',
+    scenario: 'cross-domain',
+    body:
+      'add real-time notifications — needs a WebSocket-based UI component, a BFF route to subscribe, a notifications database table, and observability metrics around connection lifecycle',
+    expectedScope: 'epic',
+    tolerance: ['epic', 'module'],
+  },
+  {
+    tag: 'refactor',
+    scenario: 'refactor',
+    body:
+      'extract the user-auth logic into a reusable @chiefaia/auth-core package — every app currently duplicates the JWT parsing and session validation; consolidate behind a typed API',
+    expectedScope: 'module',
+    tolerance: ['module', 'epic'],
+  },
+  {
+    tag: 'spike',
+    scenario: 'spike',
+    body:
+      'research the best caching library for our use case — compare lru-cache, node-cache, keyv, and redis-based options, document trade-offs in an ADR, and recommend one',
+    expectedScope: 'task',
+    tolerance: ['task', 'story'],
+  },
+  {
+    tag: 'multi-agent-collab',
+    scenario: 'multi-agent-collab',
+    body:
+      'add e-commerce checkout — needs a UI checkout flow, a BFF /checkout route, integration with the Stripe payments API, and analytics events for cart abandonment + completion',
+    expectedScope: 'epic',
+    tolerance: ['epic', 'module', 'initiative'],
+  },
+  {
+    tag: 'ea-heavy',
+    scenario: 'ea-heavy',
+    body:
+      'migrate from Postgres to event-sourced architecture for orders — design the event log, projections, and the migration strategy from the existing CRUD model',
+    expectedScope: 'epic',
+    tolerance: ['epic', 'module', 'initiative'],
+  },
+  {
+    tag: 'test-heavy',
+    scenario: 'test-heavy',
+    body:
+      'add an accessibility audit pipeline + WCAG 2.1 AA conformance tests — every page rendered should pass axe-core checks; add a CI job that fails on regressions',
+    expectedScope: 'epic',
+    tolerance: ['epic', 'module', 'story'],
+  },
+  {
+    tag: 'chore',
+    scenario: 'chore',
+    body:
+      'update all @chiefaia/* package descriptions to be more descriptive — current descriptions read like internal codenames; rewrite for the open-source registry',
+    expectedScope: 'task',
+    tolerance: ['task', 'story', 'subtask'],
+  },
+] as const;
+
+/**
+ * Convert the fixtures to JSONL-ready trainset rows. Used by the cron
+ * to persist the eval set the Python compile reads.
+ *
+ * Shape mirrors the Python side — `target_scope` (snake_case) and
+ * `tolerance` are the label keys the compile metric reads.
+ */
+export function fixturesToEvalsetRows(): TrainsetRow[] {
+  return PHASE2E_002_FIXTURES.map((f) => ({
+    input: { promptText: f.body },
+    label: {
+      target_scope: f.expectedScope,
+      tolerance: [...f.tolerance],
+    },
+  }));
+}

--- a/packages/dspy-bridge/src/index.ts
+++ b/packages/dspy-bridge/src/index.ts
@@ -21,10 +21,6 @@ export type {
 } from './protocol.js';
 
 // ─── Typed program wrappers ─────────────────────────────────────────────
-//
-// One file per registered DSPy program. The orchestrator imports these
-// rather than calling `bridge.predict(...)` directly so the Node side
-// stays type-safe across the JSONL boundary.
 export {
   runPoScopeDetector,
   PoScopeDetectorError,
@@ -36,3 +32,15 @@ export type {
   PoScopeDetectorOutput,
   StoryScope,
 } from './programs/po-scope-detector.js';
+
+// ─── Trace pipeline (PR3) ───────────────────────────────────────────────
+export { recordTrace, readTraces, defaultTraceRoot } from './traces.js';
+export type { TraceRow, TraceWriterOptions } from './traces.js';
+export { buildTrainset, writeTrainsetJsonl } from './trainset.js';
+export type { BuildTrainsetOptions, TrainsetRow } from './trainset.js';
+export type { SpendRecord } from './spend-bridge.js';
+export {
+  PHASE2E_002_FIXTURES,
+  fixturesToEvalsetRows,
+} from './evalsets/po-scope-detector-phase2e002.js';
+export type { Phase2e002Fixture } from './evalsets/po-scope-detector-phase2e002.js';

--- a/packages/dspy-bridge/src/spend-bridge.ts
+++ b/packages/dspy-bridge/src/spend-bridge.ts
@@ -1,0 +1,24 @@
+/**
+ * Local re-export of @chiefaia/spend-guard's SpendRecord shape so this
+ * package doesn't take a hard dependency on it just for a type.
+ *
+ * The trace pipeline (`trainset.ts`) reads spend records as a *gating
+ * signal*, not as the source of input/output. The Langfuse migration
+ * (proposal §7) swaps both surfaces for a single trace stream, so we
+ * keep the type local — when the migration lands, this file's only job
+ * is to import from `@chiefaia/langfuse-export` instead.
+ */
+
+export interface SpendRecord {
+  id: string;
+  taskId: string;
+  projectId: string | null;
+  agentRole: string;
+  model: string;
+  via: 'subscription' | 'api-key' | 'ollama';
+  accountId: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  tsMsEpoch: number;
+}

--- a/packages/dspy-bridge/src/traces.ts
+++ b/packages/dspy-bridge/src/traces.ts
@@ -1,0 +1,137 @@
+/**
+ * Trace writer — append-only JSONL trace store for DSPy training data.
+ *
+ * Why this exists: the substrate proposal §7 calls for a feedback loop
+ * that compiles the active DSPy program against the last 24h of
+ * production calls. `@chiefaia/spend-guard` already records spend, but
+ * its `SpendRecord` only carries cost / model / tokens — not the prompt
+ * or response.
+ *
+ * This module owns the *content* side of the same event: prompt in,
+ * verdict out, success flag. The trace pipeline (`trainset.ts`) reads
+ * these JSONL files and shapes them into a DSPy trainset.
+ *
+ * The format is intentionally trivial — one JSON object per line, one
+ * file per UTC date per program:
+ *
+ *     ~/.caia/dspy/traces/<program>/YYYY-MM-DD.jsonl
+ *
+ * Files are append-only; rotation is by date; old files can be pruned
+ * by the cron once they roll out of the 24h window.
+ *
+ * Langfuse migration (proposal §7 next phase): swap the writer for a
+ * Langfuse client; the JSONL format stays as the disaster-recovery
+ * fallback so we never lose telemetry on Langfuse outages.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export interface TraceRow {
+  /** ISO-8601 timestamp the call completed at. */
+  ts: string;
+  /** DSPy program name, e.g. 'po-scope-detector'. */
+  program: string;
+  /** The compiled-program version that served the call (or 'uncompiled'). */
+  version: string;
+  /** RPC input dict (typed per program; opaque here). */
+  input: Record<string, unknown>;
+  /** RPC output dict. May be partial when ok=false. */
+  output: Record<string, unknown>;
+  /** Whether the call returned a usable verdict. */
+  ok: boolean;
+  /** Concrete model id reported by the LM. */
+  model: string;
+  /** Wall-clock ms of the predict call. */
+  durationMs: number;
+  /**
+   * Optional ground-truth label. Filled in when the orchestrator later
+   * adjudicates the call (e.g. judge-pair pass on the parent decomposition).
+   * Absent for raw production traces — those become *unsupervised* train
+   * rows for MIPROv2 bootstrapping.
+   */
+  label?: Record<string, unknown>;
+}
+
+export interface TraceWriterOptions {
+  /** Override the trace root. Default: ~/.caia/dspy/traces. */
+  root?: string;
+  /** Test seam. */
+  nowDateIso?: () => string;
+}
+
+/**
+ * Append a trace row for a given program. Idempotent on file creation;
+ * thread-safe on a single Node process via append-only writes.
+ */
+export function recordTrace(
+  program: string,
+  row: Omit<TraceRow, 'ts' | 'program'>,
+  options: TraceWriterOptions = {},
+): void {
+  const root = options.root ?? defaultTraceRoot();
+  const dir = path.join(root, program);
+  fs.mkdirSync(dir, { recursive: true });
+  const tsIso = options.nowDateIso?.() ?? new Date().toISOString();
+  const day = tsIso.slice(0, 10); // YYYY-MM-DD
+  const file = path.join(dir, `${day}.jsonl`);
+  const fullRow: TraceRow = { ts: tsIso, program, ...row };
+  fs.appendFileSync(file, `${JSON.stringify(fullRow)}\n`, { encoding: 'utf8' });
+}
+
+/**
+ * Read all trace rows for a program written between [sinceIso, untilIso].
+ * Inclusive on both ends (same date string -> reads that day's file).
+ *
+ * Filters by ok=true unless `includeFailed: true` is passed — failed
+ * rows are useful for offline debugging but bad for trainsets.
+ */
+export function readTraces(
+  program: string,
+  sinceIso: string,
+  untilIso: string,
+  options: { root?: string; includeFailed?: boolean } = {},
+): TraceRow[] {
+  const root = options.root ?? defaultTraceRoot();
+  const dir = path.join(root, program);
+  if (!fs.existsSync(dir)) return [];
+  const sinceDay = sinceIso.slice(0, 10);
+  const untilDay = untilIso.slice(0, 10);
+  const days = enumerateDays(sinceDay, untilDay);
+
+  const rows: TraceRow[] = [];
+  for (const day of days) {
+    const file = path.join(dir, `${day}.jsonl`);
+    if (!fs.existsSync(file)) continue;
+    const text = fs.readFileSync(file, 'utf8');
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as TraceRow;
+        if (obj.ts < sinceIso || obj.ts > untilIso) continue;
+        if (!options.includeFailed && !obj.ok) continue;
+        rows.push(obj);
+      } catch {
+        // Skip malformed lines; log path is left to the cron.
+      }
+    }
+  }
+  return rows;
+}
+
+export function defaultTraceRoot(): string {
+  return path.join(os.homedir(), '.caia', 'dspy', 'traces');
+}
+
+function enumerateDays(startDay: string, endDay: string): string[] {
+  const out: string[] = [];
+  const start = new Date(`${startDay}T00:00:00Z`);
+  const end = new Date(`${endDay}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return out;
+  for (let d = start; d <= end; d = new Date(d.getTime() + 86_400_000)) {
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}

--- a/packages/dspy-bridge/src/trainset.ts
+++ b/packages/dspy-bridge/src/trainset.ts
@@ -1,0 +1,123 @@
+/**
+ * Trainset / evalset builders.
+ *
+ * Reads:
+ *   - last-24h trace JSONL for a program (from `traces.ts`)
+ *   - the spend-guard `SpendRecord` stream (cost-side tap; passed in by
+ *     the cron because spend-guard's record-sink is owned upstream)
+ *
+ * Writes JSONL files in the shape the Python server expects:
+ *
+ *     {"input": {...}, "label": {...}}
+ *
+ * The label is required for the eval set (PHASE2E-002) and optional for
+ * the trainset (raw production traces are unsupervised; MIPROv2
+ * bootstraps demos via its own self-supervision pass).
+ *
+ * "Pull from spend_records (Langfuse later)" per the proposal §7:
+ *   - Today: the cron passes spend records and traces in side-by-side.
+ *     We use the cost surface to GATE candidates (low-confidence calls
+ *     are higher-leverage to demonstrate) and the trace surface to
+ *     supply the actual (input, output) pairs.
+ *   - Tomorrow: a Langfuse exporter replaces both feeds with a single
+ *     trace stream. Same JSONL output shape.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { SpendRecord } from './spend-bridge.js';
+import { readTraces, type TraceRow } from './traces.js';
+
+export interface BuildTrainsetOptions {
+  program: string;
+  /** ISO-8601 inclusive lower bound. Default: 24h ago. */
+  sinceIso?: string;
+  /** ISO-8601 inclusive upper bound. Default: now. */
+  untilIso?: string;
+  /** Where to read traces from. Default: ~/.caia/dspy/traces. */
+  traceRoot?: string;
+  /** Optional spend records — used to score example leverage. */
+  spendRecords?: readonly SpendRecord[];
+  /** Maximum trainset rows. Default: 200. */
+  maxRows?: number;
+}
+
+export interface TrainsetRow {
+  input: Record<string, unknown>;
+  label?: Record<string, unknown>;
+}
+
+/**
+ * Build a JSONL-serialisable trainset from the last-N-hours of traces.
+ *
+ * Selection rules:
+ *   1. include only rows with ok=true (failures don't teach anything
+ *      useful at this layer — they're a tracing concern)
+ *   2. dedupe by `JSON.stringify(input)` so identical prompts don't
+ *      dominate the optimizer
+ *   3. prefer rows that produced an explicit `label` (judge verdict)
+ *   4. cap at `maxRows` (default 200) — MIPROv2 doesn't need more and
+ *      compile time is roughly linear in trainset size
+ */
+export function buildTrainset(opts: BuildTrainsetOptions): TrainsetRow[] {
+  const sinceIso =
+    opts.sinceIso ?? new Date(Date.now() - 24 * 3_600_000).toISOString();
+  const untilIso = opts.untilIso ?? new Date().toISOString();
+  const max = opts.maxRows ?? 200;
+
+  const traces = readTraces(opts.program, sinceIso, untilIso, {
+    ...(opts.traceRoot ? { root: opts.traceRoot } : {}),
+  });
+
+  const seen = new Set<string>();
+  const rows: TrainsetRow[] = [];
+
+  // Sort: labelled rows first (more informative), then by timestamp DESC.
+  const sorted = [...traces].sort((a, b) => {
+    const labelDelta =
+      (b.label ? 1 : 0) - (a.label ? 1 : 0);
+    if (labelDelta !== 0) return labelDelta;
+    return b.ts.localeCompare(a.ts);
+  });
+
+  for (const t of sorted) {
+    const key = JSON.stringify(t.input);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const row: TrainsetRow = { input: t.input };
+    if (t.label) {
+      row.label = t.label;
+    } else {
+      // Use the model's own verdict as a noisy pseudo-label so the
+      // bootstrap pass has something to chew on. MIPROv2 will discard
+      // demos whose metric-score is poor — this is just seed material.
+      row.label = pseudoLabelFromOutput(t);
+    }
+    rows.push(row);
+    if (rows.length >= max) break;
+  }
+  return rows;
+}
+
+/**
+ * Persist a trainset as JSONL. Returns the absolute path.
+ */
+export function writeTrainsetJsonl(
+  rows: readonly TrainsetRow[],
+  outPath: string,
+): string {
+  const dir = path.dirname(outPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const text = rows.map((r) => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : '');
+  fs.writeFileSync(outPath, text, 'utf8');
+  return path.resolve(outPath);
+}
+
+function pseudoLabelFromOutput(t: TraceRow): Record<string, unknown> {
+  // For po-scope-detector, the output already carries (targetScope,
+  // confidence, rationale). For unknown programs we just pass it
+  // through — the program-specific score() function decides what to
+  // do with it.
+  return { ...t.output };
+}

--- a/packages/dspy-bridge/tests/traces.test.ts
+++ b/packages/dspy-bridge/tests/traces.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { recordTrace, readTraces } from '../src/traces.js';
+
+describe('trace writer + reader', () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-bridge-traces-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('appends one row per call into a YYYY-MM-DD-keyed file', () => {
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText: 'add a logout button' },
+        output: { targetScope: 'story', confidence: 0.92 },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 23,
+      },
+      { root, nowDateIso: () => '2026-04-30T15:00:00.000Z' },
+    );
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText: 'fix login button' },
+        output: { targetScope: 'task', confidence: 0.7 },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 19,
+      },
+      { root, nowDateIso: () => '2026-04-30T15:01:00.000Z' },
+    );
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText: 'next-day call' },
+        output: { targetScope: 'epic', confidence: 0.6 },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 34,
+      },
+      { root, nowDateIso: () => '2026-05-01T01:00:00.000Z' },
+    );
+
+    const apr30 = path.join(root, 'po-scope-detector', '2026-04-30.jsonl');
+    const may01 = path.join(root, 'po-scope-detector', '2026-05-01.jsonl');
+    expect(fs.readFileSync(apr30, 'utf8').trim().split('\n')).toHaveLength(2);
+    expect(fs.readFileSync(may01, 'utf8').trim().split('\n')).toHaveLength(1);
+  });
+
+  it('readTraces filters by [since, until] and skips ok=false by default', () => {
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText: 'good-1' },
+        output: { targetScope: 'story', confidence: 0.9 },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 11,
+      },
+      { root, nowDateIso: () => '2026-04-30T08:00:00.000Z' },
+    );
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText: 'failed-1' },
+        output: {},
+        ok: false,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 12,
+      },
+      { root, nowDateIso: () => '2026-04-30T09:00:00.000Z' },
+    );
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText: 'too-late' },
+        output: { targetScope: 'task', confidence: 0.7 },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 15,
+      },
+      { root, nowDateIso: () => '2026-05-01T08:00:00.000Z' },
+    );
+
+    const rows = readTraces(
+      'po-scope-detector',
+      '2026-04-30T00:00:00.000Z',
+      '2026-04-30T23:59:59.999Z',
+      { root },
+    );
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as { input: { promptText: string } }).input.promptText).toBe('good-1');
+
+    const withFailed = readTraces(
+      'po-scope-detector',
+      '2026-04-30T00:00:00.000Z',
+      '2026-04-30T23:59:59.999Z',
+      { root, includeFailed: true },
+    );
+    expect(withFailed).toHaveLength(2);
+  });
+
+  it('returns [] when the program directory does not exist', () => {
+    const rows = readTraces(
+      'never-recorded',
+      '2026-04-30T00:00:00.000Z',
+      '2026-04-30T23:59:59.999Z',
+      { root },
+    );
+    expect(rows).toEqual([]);
+  });
+});

--- a/packages/dspy-bridge/tests/trainset.test.ts
+++ b/packages/dspy-bridge/tests/trainset.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { recordTrace } from '../src/traces.js';
+import { buildTrainset, writeTrainsetJsonl } from '../src/trainset.js';
+import {
+  PHASE2E_002_FIXTURES,
+  fixturesToEvalsetRows,
+} from '../src/evalsets/po-scope-detector-phase2e002.js';
+
+describe('buildTrainset', () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-bridge-trainset-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function tap(promptText: string, scope: string, ts: string, opts: { ok?: boolean; label?: Record<string, unknown> } = {}) {
+    const row: Parameters<typeof recordTrace>[1] = {
+      version: 'uncompiled',
+      input: { promptText },
+      output: { targetScope: scope, confidence: 0.85, rationale: 'stub' },
+      ok: opts.ok ?? true,
+      model: 'qwen2.5-coder:7b',
+      durationMs: 17,
+    };
+    if (opts.label) row.label = opts.label;
+    recordTrace('po-scope-detector', row, { root, nowDateIso: () => ts });
+  }
+
+  it('dedupes by input and prefers labelled rows', () => {
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    tap('add a logout button', 'story', '2026-04-30T09:00:00.000Z'); // dup
+    tap('refactor the auth module', 'task', '2026-04-30T10:00:00.000Z');
+    tap('refactor the auth module', 'task', '2026-04-30T11:00:00.000Z', {
+      label: { target_scope: 'task', tolerance: ['task'] },
+    });
+
+    const rows = buildTrainset({
+      program: 'po-scope-detector',
+      sinceIso: '2026-04-30T00:00:00.000Z',
+      untilIso: '2026-04-30T23:59:59.999Z',
+      traceRoot: root,
+    });
+    expect(rows).toHaveLength(2);
+    // Labelled row should land first.
+    expect(rows[0]?.label).toMatchObject({ target_scope: 'task' });
+  });
+
+  it('uses model output as a pseudo-label when no real label exists', () => {
+    tap('rename _x to _internal in foo.ts', 'subtask', '2026-04-30T08:00:00.000Z');
+
+    const rows = buildTrainset({
+      program: 'po-scope-detector',
+      sinceIso: '2026-04-30T00:00:00.000Z',
+      untilIso: '2026-04-30T23:59:59.999Z',
+      traceRoot: root,
+    });
+    expect(rows[0]?.label).toMatchObject({ targetScope: 'subtask' });
+  });
+
+  it('caps to maxRows', () => {
+    for (let i = 0; i < 50; i++) {
+      tap(`prompt ${String(i)}`, 'task', `2026-04-30T08:${String(i % 60).padStart(2, '0')}:00.000Z`);
+    }
+    const rows = buildTrainset({
+      program: 'po-scope-detector',
+      sinceIso: '2026-04-30T00:00:00.000Z',
+      untilIso: '2026-04-30T23:59:59.999Z',
+      traceRoot: root,
+      maxRows: 10,
+    });
+    expect(rows).toHaveLength(10);
+  });
+
+  it('writeTrainsetJsonl emits one JSON object per line', () => {
+    const out = path.join(root, 'out.jsonl');
+    writeTrainsetJsonl(
+      [
+        { input: { promptText: 'a' }, label: { target_scope: 'task' } },
+        { input: { promptText: 'b' }, label: { target_scope: 'story' } },
+      ],
+      out,
+    );
+    const lines = fs.readFileSync(out, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] as string)).toEqual({
+      input: { promptText: 'a' },
+      label: { target_scope: 'task' },
+    });
+  });
+});
+
+describe('PHASE2E-002 evalset', () => {
+  it('has exactly 10 fixtures and unique tags', () => {
+    expect(PHASE2E_002_FIXTURES).toHaveLength(10);
+    const tags = new Set(PHASE2E_002_FIXTURES.map((f) => f.tag));
+    expect(tags.size).toBe(10);
+  });
+
+  it('every fixture lists expectedScope inside its tolerance set', () => {
+    for (const f of PHASE2E_002_FIXTURES) {
+      expect(f.tolerance).toContain(f.expectedScope);
+    }
+  });
+
+  it('fixturesToEvalsetRows emits matching JSONL-ready rows', () => {
+    const rows = fixturesToEvalsetRows();
+    expect(rows).toHaveLength(10);
+    expect(rows[0]?.input).toHaveProperty('promptText');
+    expect(rows[0]?.label).toHaveProperty('target_scope');
+    expect(rows[0]?.label).toHaveProperty('tolerance');
+  });
+});


### PR DESCRIPTION
PR3 of 6. Stacked on dspy-002.

Implements the §7 feedback-loop's data plane.

**What this adds**
- `traces.ts` — append-only JSONL trace writer keyed by program + UTC date (`~/.caia/dspy/traces/<program>/YYYY-MM-DD.jsonl`). One row per Predict call. `recordTrace()` / `readTraces()` with [since, until] filtering and a default ok-only filter so failures don't leak into trainsets.
- `trainset.ts` — `buildTrainset()` reads the last 24h, dedupes by input, prefers labelled rows (judge verdicts), pseudo-labels the rest with the model's own output as MIPROv2 bootstrap seed material. Caps at 200 rows. `writeTrainsetJsonl()` persists.
- `spend-bridge.ts` — type-only mirror of `@chiefaia/spend-guard`'s `SpendRecord` shape. The trace pipeline uses spend records as a *gating signal*; the actual prompt/output stream lives in the trace JSONLs. Langfuse migration replaces both surfaces with one trace stream — same downstream JSONL shape.
- `evalsets/po-scope-detector-phase2e002.ts` — vendored PHASE2E-002 fixtures (10 prompts × tolerance set).

**Tests**
- traces: write/read round-trip across day boundaries, ok=false filtering, missing-program-dir → []
- trainset: dedupe + label-priority sort, pseudo-labelling, maxRows cap, JSONL serialisation
- evalset: 10 unique tags, expectedScope ∈ tolerance for each row

Greenlit by Prakash 2026-04-30.