### PR TITLE
feat(dspy-004): MIPROv2 daily compile + delta gate + promote/rollback

### DIFF
--- a/infra/cron/dspy-daily-compile.plist
+++ b/infra/cron/dspy-daily-compile.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Daily DSPy compile cron — feeds the §7 feedback loop. Lands a fresh
+  ~/.caia/dspy/compiled/po-scope-detector-vN.pkl every UTC 03:30, gated
+  on a ≥0 delta against the 10 PHASE2E-002 prompts.
+
+  Install:
+      cp infra/cron/dspy-daily-compile.plist ~/Library/LaunchAgents/
+      launchctl bootstrap gui/$UID ~/Library/LaunchAgents/dspy-daily-compile.plist
+
+  Uninstall:
+      launchctl bootout gui/$UID/com.chiefaia.dspy-daily-compile
+
+  Logs land in ~/.caia/logs/dspy-daily-compile.{out,err}.log.
+
+  Reference: caia/docs/dspy-substrate.md §Cron + AI tech modernization
+  proposal §7.
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>com.chiefaia.dspy-daily-compile</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>-lc</string>
+      <string>cd "$HOME/Documents/projects/caia" &amp;&amp; pnpm --filter @chiefaia/dspy-bridge exec tsx scripts/daily-compile.ts</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Hour</key><integer>3</integer>
+      <key>Minute</key><integer>30</integer>
+    </dict>
+
+    <key>StandardOutPath</key><string>/Users/MAC/.caia/logs/dspy-daily-compile.out.log</string>
+    <key>StandardErrorPath</key><string>/Users/MAC/.caia/logs/dspy-daily-compile.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <key>OLLAMA_HOST</key><string>http://127.0.0.1:11434</string>
+    </dict>
+
+    <key>RunAtLoad</key><false/>
+    <key>KeepAlive</key><false/>
+  </dict>
+</plist>

--- a/packages/dspy-bridge/scripts/daily-compile.ts
+++ b/packages/dspy-bridge/scripts/daily-compile.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Cron entry point: run the daily DSPy compile for po-scope-detector.
+ *
+ * Wired by `infra/cron/dspy-daily-compile.plist` (added in this PR).
+ * Run manually with:
+ *
+ *     pnpm --filter @chiefaia/dspy-bridge exec tsx scripts/daily-compile.ts
+ *
+ * Hard contract:
+ *   - exit 0 on promote
+ *   - exit 0 on rollback (it's a successful run, just no promotion)
+ *   - exit non-zero only on infrastructure failure (bridge dead,
+ *     trainset empty, etc.) — those should page the operator.
+ */
+
+import { runDailyCompile, renderVerdictLine } from '../src/compile.js';
+import { PO_SCOPE_DETECTOR_PROGRAM } from '../src/programs/po-scope-detector.js';
+
+async function main(): Promise<number> {
+  const program = process.env['DSPY_PROGRAM'] ?? PO_SCOPE_DETECTOR_PROGRAM;
+  try {
+    const verdict = await runDailyCompile({ program });
+    process.stdout.write(`${renderVerdictLine(verdict)}\n`);
+    if (!verdict.promoted && verdict.delta !== null && verdict.delta < 0) {
+      process.stderr.write(
+        `[dspy] rollback — keeping prev CURRENT (delta=${verdict.delta.toFixed(3)})\n`,
+      );
+    }
+    return 0;
+  } catch (err) {
+    process.stderr.write(
+      `[dspy] daily compile failed: ${(err as Error).message}\n` +
+        `${(err as Error).stack ?? ''}\n`,
+    );
+    return 2;
+  }
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`[dspy] uncaught: ${String(err)}\n`);
+    process.exit(2);
+  },
+);

--- a/packages/dspy-bridge/src/compile.ts
+++ b/packages/dspy-bridge/src/compile.ts
@@ -1,0 +1,203 @@
+/**
+ * Daily compile orchestration — Node side.
+ *
+ * Pulls last-24h traces (PR3), persists trainset + evalset JSONL,
+ * fires `bridge.compile()`, then evaluates the delta gate:
+ *
+ *     delta ≥ 0  →  promote (rewrite CURRENT pointer)
+ *     delta < 0  →  rollback (leave CURRENT untouched, log + alert)
+ *
+ * The actual MIPROv2 work and the per-row scoring runs in Python — this
+ * module is the policy layer (gate, promote, audit log, retention).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { DspyBridge } from './bridge.js';
+import { defaultTraceRoot } from './traces.js';
+import { buildTrainset, writeTrainsetJsonl, type TrainsetRow } from './trainset.js';
+import {
+  fixturesToEvalsetRows,
+  PHASE2E_002_FIXTURES,
+} from './evalsets/po-scope-detector-phase2e002.js';
+import { PO_SCOPE_DETECTOR_PROGRAM } from './programs/po-scope-detector.js';
+
+export interface DailyCompileOptions {
+  /** Program to compile. Default: 'po-scope-detector'. */
+  program?: string;
+  /** Override trace root (test seam). */
+  traceRoot?: string;
+  /** Compiled-program root. Default: ~/.caia/dspy/compiled. */
+  compiledRoot?: string;
+  /**
+   * Override the eval set rows. Default: PHASE2E-002 fixtures.
+   * Supplying a custom set is allowed for back-compat with future
+   * proposals; the runbook documents PHASE2E-002 as the authoritative
+   * gate set.
+   */
+  evalsetRows?: readonly TrainsetRow[];
+  /** Pre-instantiated bridge. Default: new DspyBridge({}). */
+  bridge?: DspyBridge;
+  /** Skip start/stop on the bridge (caller manages the lifecycle). */
+  externallyManagedBridge?: boolean;
+  /**
+   * Promote-or-rollback policy. Default: delta >= 0 promotes.
+   *
+   * Returning `false` keeps the previous CURRENT pointer; returning
+   * `true` rewrites it to the new version.
+   */
+  promotePolicy?: (verdict: CompileVerdict) => boolean;
+  /** Test-seam wall-clock provider. */
+  nowMs?: () => number;
+}
+
+export interface CompileVerdict {
+  program: string;
+  /** Version that was just compiled (e.g. 'v3'). */
+  newVersion: string;
+  /** Path to the new pickle on disk. */
+  newPickle: string;
+  /** Score of the new program on the eval set (0..1+ tie bonus). */
+  newScore: number;
+  /** Score of the previous CURRENT on the same eval set. */
+  prevScore: number | null;
+  /** newScore - prevScore (or null on first compile). */
+  delta: number | null;
+  /**
+   * Whether the policy promoted the new version. true = CURRENT
+   * pointer rewritten; false = no-op.
+   */
+  promoted: boolean;
+  /** Trainset row count fed to MIPROv2. */
+  trainsetSize: number;
+  /** ISO-8601 timestamp the run completed. */
+  finishedAtIso: string;
+}
+
+/**
+ * Run a daily compile end-to-end. Returns the verdict.
+ *
+ * Flow:
+ *   1. start() the bridge (unless externally-managed)
+ *   2. build trainset.jsonl from the last 24h of traces
+ *   3. write evalset.jsonl from PHASE2E-002 fixtures
+ *   4. call bridge.compile() — Python runs MIPROv2 + scores
+ *   5. read the score, compute delta
+ *   6. apply promote/rollback policy
+ *   7. write an audit-log row to ~/.caia/dspy/compiles.log
+ */
+export async function runDailyCompile(
+  options: DailyCompileOptions = {},
+): Promise<CompileVerdict> {
+  const program = options.program ?? PO_SCOPE_DETECTOR_PROGRAM;
+  const compiledRoot =
+    options.compiledRoot ??
+    path.join(os.homedir(), '.caia', 'dspy', 'compiled');
+  const programDir = path.join(compiledRoot, program);
+  fs.mkdirSync(programDir, { recursive: true });
+
+  const traceRoot = options.traceRoot ?? defaultTraceRoot();
+  const now = options.nowMs?.() ?? Date.now();
+  const sinceIso = new Date(now - 24 * 3_600_000).toISOString();
+  const untilIso = new Date(now).toISOString();
+
+  // 2. Trainset.
+  const trainsetRows = buildTrainset({
+    program,
+    sinceIso,
+    untilIso,
+    traceRoot,
+  });
+  const trainsetPath = path.join(programDir, 'trainset.jsonl');
+  writeTrainsetJsonl(trainsetRows, trainsetPath);
+
+  // 3. Evalset.
+  const evalRows = options.evalsetRows ?? fixturesToEvalsetRows();
+  const evalsetPath = path.join(programDir, 'evalset.jsonl');
+  writeTrainsetJsonl(evalRows, evalsetPath);
+
+  // 4. Compile via the bridge.
+  const bridge = options.bridge ?? new DspyBridge();
+  if (!options.externallyManagedBridge) {
+    await bridge.start();
+  }
+  let compileResult;
+  try {
+    compileResult = await bridge.compile({
+      program,
+      optimizer: 'miprov2',
+      trainsetPath,
+      evalsetPath,
+      outDir: programDir,
+    });
+  } finally {
+    if (!options.externallyManagedBridge) {
+      await bridge.stop().catch(() => undefined);
+    }
+  }
+
+  // 5/6. Delta gate.
+  const policy = options.promotePolicy ?? defaultPromotePolicy;
+  const verdict: CompileVerdict = {
+    program,
+    newVersion: compileResult.version,
+    newPickle: compileResult.pickle,
+    newScore: compileResult.newScore,
+    prevScore: compileResult.prevScore,
+    delta: compileResult.delta,
+    promoted: false,
+    trainsetSize: trainsetRows.length,
+    finishedAtIso: new Date(options.nowMs?.() ?? Date.now()).toISOString(),
+  };
+  const shouldPromote = policy(verdict);
+  if (shouldPromote) {
+    fs.writeFileSync(
+      path.join(programDir, 'CURRENT'),
+      `${compileResult.version}\n`,
+      'utf8',
+    );
+    verdict.promoted = true;
+  }
+
+  // 7. Audit-log line.
+  const logPath = path.join(compiledRoot, 'compiles.log');
+  fs.appendFileSync(
+    logPath,
+    `${JSON.stringify(verdict)}\n`,
+    { encoding: 'utf8' },
+  );
+
+  return verdict;
+}
+
+/**
+ * Default policy — promote when delta >= 0 (or no previous version).
+ *
+ * On first compile (prevScore === null), `delta` is null. We promote so
+ * the CURRENT pointer goes from "(none) -> v1" — otherwise the next
+ * runtime predict() falls through to the uncompiled module forever.
+ */
+export function defaultPromotePolicy(verdict: CompileVerdict): boolean {
+  if (verdict.delta === null) return true;
+  return verdict.delta >= 0;
+}
+
+/**
+ * Convenience for the cron CLI — render the verdict as a one-line
+ * sparkline used by the runbook + dashboard.
+ */
+export function renderVerdictLine(verdict: CompileVerdict): string {
+  const prev = verdict.prevScore === null ? '—' : verdict.prevScore.toFixed(3);
+  const next = verdict.newScore.toFixed(3);
+  const delta = verdict.delta === null ? '—' : (verdict.delta >= 0 ? '+' : '') + verdict.delta.toFixed(3);
+  const verb = verdict.promoted ? 'promoted' : 'rolled-back';
+  return (
+    `[dspy:${verdict.program}] ${verb} ${verdict.newVersion} ` +
+    `(prev=${prev} next=${next} Δ=${delta} train=${String(verdict.trainsetSize)})`
+  );
+}
+
+/** Re-export the eval set size as a constant the runbook can quote. */
+export const EVALSET_SIZE = PHASE2E_002_FIXTURES.length;

--- a/packages/dspy-bridge/tests/compile.test.ts
+++ b/packages/dspy-bridge/tests/compile.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { recordTrace } from '../src/traces.js';
+import {
+  defaultPromotePolicy,
+  renderVerdictLine,
+  runDailyCompile,
+  type CompileVerdict,
+} from '../src/compile.js';
+import type { DspyBridge } from '../src/bridge.js';
+import type { CompileResult } from '../src/protocol.js';
+
+function fakeBridgeYielding(result: CompileResult): {
+  bridge: DspyBridge;
+  startSpy: ReturnType<typeof vi.fn>;
+  stopSpy: ReturnType<typeof vi.fn>;
+  compileSpy: ReturnType<typeof vi.fn>;
+} {
+  const startSpy = vi.fn(async () => undefined);
+  const stopSpy = vi.fn(async () => undefined);
+  const compileSpy = vi.fn(async () => result);
+  const bridge = {
+    start: startSpy,
+    stop: stopSpy,
+    compile: compileSpy,
+  } as unknown as DspyBridge;
+  return { bridge, startSpy, stopSpy, compileSpy };
+}
+
+describe('runDailyCompile', () => {
+  let traceRoot: string;
+  let compiledRoot: string;
+  beforeEach(() => {
+    traceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-trace-'));
+    compiledRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-compiled-'));
+  });
+  afterEach(() => {
+    fs.rmSync(traceRoot, { recursive: true, force: true });
+    fs.rmSync(compiledRoot, { recursive: true, force: true });
+  });
+
+  function tap(promptText: string, scope: string, isoTs: string) {
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText },
+        output: { targetScope: scope, confidence: 0.85, rationale: 'stub' },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 17,
+      },
+      { root: traceRoot, nowDateIso: () => isoTs },
+    );
+  }
+
+  it('promotes on first compile (delta=null)', async () => {
+    const nowIso = '2026-04-30T18:00:00.000Z';
+    const nowMs = Date.parse(nowIso);
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    tap('refactor the auth module', 'task', '2026-04-30T09:00:00.000Z');
+
+    const { bridge, compileSpy } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: path.join(compiledRoot, 'po-scope-detector', 'po-scope-detector-v1.pkl'),
+      version: 'v1',
+      newScore: 0.71,
+      prevScore: null,
+      delta: null,
+    });
+
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => nowMs,
+    });
+
+    expect(verdict.promoted).toBe(true);
+    expect(verdict.newVersion).toBe('v1');
+    expect(verdict.delta).toBeNull();
+    expect(compileSpy).toHaveBeenCalledOnce();
+    expect(fs.readFileSync(
+      path.join(compiledRoot, 'po-scope-detector', 'CURRENT'), 'utf8',
+    ).trim()).toBe('v1');
+  });
+
+  it('promotes when delta >= 0', async () => {
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: path.join(compiledRoot, 'po-scope-detector', 'po-scope-detector-v3.pkl'),
+      version: 'v3',
+      newScore: 0.78,
+      prevScore: 0.74,
+      delta: 0.04,
+    });
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    expect(verdict.promoted).toBe(true);
+    expect(verdict.delta).toBeCloseTo(0.04);
+    expect(fs.readFileSync(
+      path.join(compiledRoot, 'po-scope-detector', 'CURRENT'), 'utf8',
+    ).trim()).toBe('v3');
+  });
+
+  it('rolls back when delta < 0', async () => {
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: path.join(compiledRoot, 'po-scope-detector', 'po-scope-detector-v4.pkl'),
+      version: 'v4',
+      newScore: 0.65,
+      prevScore: 0.74,
+      delta: -0.09,
+    });
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    expect(verdict.promoted).toBe(false);
+    expect(verdict.delta).toBeCloseTo(-0.09);
+    // CURRENT must NOT exist (no prior promote in this test, and we
+    // didn't promote this one either).
+    const cur = path.join(compiledRoot, 'po-scope-detector', 'CURRENT');
+    expect(fs.existsSync(cur)).toBe(false);
+  });
+
+  it('writes a JSONL audit-log row to compiles.log', async () => {
+    tap('any', 'task', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: 'p',
+      version: 'v1',
+      newScore: 0.5,
+      prevScore: null,
+      delta: null,
+    });
+    await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    const log = fs.readFileSync(path.join(compiledRoot, 'compiles.log'), 'utf8');
+    const lines = log.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] as string)).toMatchObject({
+      program: 'po-scope-detector',
+      newVersion: 'v1',
+      promoted: true,
+    });
+  });
+
+  it('respects a custom promotePolicy', async () => {
+    tap('any', 'task', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: 'p',
+      version: 'v2',
+      newScore: 0.99,
+      prevScore: 0.5,
+      delta: 0.49,
+    });
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+      // refuse promotion no matter what
+      promotePolicy: () => false,
+    });
+    expect(verdict.promoted).toBe(false);
+  });
+
+  it('honours externallyManagedBridge — never start/stop the bridge', async () => {
+    tap('any', 'task', '2026-04-30T08:00:00.000Z');
+    const { bridge, startSpy, stopSpy } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: 'p',
+      version: 'v1',
+      newScore: 0.5,
+      prevScore: null,
+      delta: null,
+    });
+    await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      externallyManagedBridge: true,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('defaultPromotePolicy', () => {
+  it('promotes on first compile', () => {
+    expect(
+      defaultPromotePolicy({ delta: null } as CompileVerdict),
+    ).toBe(true);
+  });
+  it('promotes when delta == 0', () => {
+    expect(
+      defaultPromotePolicy({ delta: 0 } as CompileVerdict),
+    ).toBe(true);
+  });
+  it('promotes when delta > 0', () => {
+    expect(
+      defaultPromotePolicy({ delta: 0.0001 } as CompileVerdict),
+    ).toBe(true);
+  });
+  it('rolls back when delta < 0', () => {
+    expect(
+      defaultPromotePolicy({ delta: -0.0001 } as CompileVerdict),
+    ).toBe(false);
+  });
+});
+
+describe('renderVerdictLine', () => {
+  it('prints first-compile line', () => {
+    const line = renderVerdictLine({
+      program: 'po-scope-detector',
+      newVersion: 'v1',
+      newPickle: 'p',
+      newScore: 0.71,
+      prevScore: null,
+      delta: null,
+      promoted: true,
+      trainsetSize: 14,
+      finishedAtIso: '2026-04-30T18:00:00.000Z',
+    });
+    expect(line).toContain('promoted v1');
+    expect(line).toContain('Δ=—');
+    expect(line).toContain('next=0.710');
+    expect(line).toContain('train=14');
+  });
+  it('prints rollback line', () => {
+    const line = renderVerdictLine({
+      program: 'po-scope-detector',
+      newVersion: 'v4',
+      newPickle: 'p',
+      newScore: 0.65,
+      prevScore: 0.74,
+      delta: -0.09,
+      promoted: false,
+      trainsetSize: 23,
+      finishedAtIso: '2026-04-30T18:00:00.000Z',
+    });
+    expect(line).toContain('rolled-back');
+    expect(line).toContain('Δ=-0.090');
+  });
+});


### PR DESCRIPTION
PR4 of 6. Stacked on dspy-003.

Closes the §7 feedback loop for po-scope-detector.

**`src/compile.ts` — `runDailyCompile()`**
1. Resolve last-24h trace window.
2. `buildTrainset()` (PR3) -> writes `~/.caia/dspy/compiled/<program>/trainset.jsonl`.
3. Write `evalset.jsonl` from PHASE2E-002 fixtures.
4. `bridge.compile({ optimizer: 'miprov2', trainset, evalset, outDir })` -> Python MIPROv2 + per-row scoring.
5. **Delta gate**:
    - `delta == null`  → promote (first compile bootstraps CURRENT)
    - `delta >= 0`     → promote (rewrite CURRENT pointer)
    - `delta < 0`      → rollback (CURRENT untouched)
6. Append a JSONL audit row to `~/.caia/dspy/compiled/compiles.log`.

**`scripts/daily-compile.ts` — cron entry-point**
- exits 0 on promote AND on rollback (both successful runs)
- exits 2 only on infra failure
- `DSPY_PROGRAM` env override for future programs

**`infra/cron/dspy-daily-compile.plist`**
- LaunchAgent that runs at UTC 03:30 daily
- logs to `~/.caia/logs/dspy-daily-compile.{out,err}.log`
- separate from the main daemon — **no daemon restart needed** (per Prakash 2026-04-30)

**Tests** — first-compile, happy delta, rollback, audit log, custom policy seam, externallyManagedBridge, defaultPromotePolicy boundaries, renderVerdictLine.

Greenlit by Prakash 2026-04-30.