### PR TITLE
feat(dspy-005): orchestrator routes scope-detection through compiled DSPy

### DIFF
--- a/packages/decomposer-recursive/package.json
+++ b/packages/decomposer-recursive/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/dspy-bridge": "workspace:*",
     "@chiefaia/local-llm-router": "workspace:*",
     "@chiefaia/ticket-template": "workspace:*",
     "nanoid": "^5.0.0",

--- a/packages/decomposer-recursive/src/dspy-runtime.ts
+++ b/packages/decomposer-recursive/src/dspy-runtime.ts
@@ -1,0 +1,200 @@
+/**
+ * Runtime routing — orchestrator switch for the DSPy substrate.
+ *
+ * The PO scope detector has TWO concrete paths:
+ *
+ *   1. Legacy: hand-written prompt -> @chiefaia/local-llm-router
+ *      (the existing `callStructured()` flow in scope-detector.ts).
+ *
+ *   2. DSPy: compiled program in ~/.caia/dspy/compiled/po-scope-detector/
+ *      reached via @chiefaia/dspy-bridge.
+ *
+ * The router picks the DSPy path when ALL of the following are true:
+ *
+ *   - the runtime flag is enabled
+ *     (env CAIA_DSPY_RUNTIME=1, or the on-disk pointer
+ *      ~/.caia/dspy/runtime/po-scope-detector.enabled exists)
+ *   - the DSPy bridge starts cleanly
+ *   - the bridge call succeeds
+ *
+ * On ANY failure the router falls back to the legacy path and emits a
+ * structured-log line. This is a *strict opt-in* with strict failure
+ * tolerance — the substrate cutover is reversible by removing the
+ * pointer file. No service restart needed.
+ *
+ * Every successful DSPy call writes a trace row via
+ * `@chiefaia/dspy-bridge`'s `recordTrace()` so the next compile cron
+ * has fresh data — closing the §7 feedback loop end-to-end.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  DspyBridge,
+  PoScopeDetectorError,
+  recordTrace,
+  runPoScopeDetector,
+} from '@chiefaia/dspy-bridge';
+
+import type { ScopeDetection } from './types.js';
+
+export interface DspyRuntimeOptions {
+  /**
+   * Force-enable the DSPy path regardless of env / pointer file. Used
+   * by integration tests that bring up an in-process bridge.
+   */
+  forceEnabled?: boolean;
+  /**
+   * Pre-built bridge — bypasses the singleton + lazy-start. Used by
+   * tests; production wiring should leave this undefined.
+   */
+  bridge?: DspyBridge;
+  /** Test-seam wall-clock provider. */
+  nowDateIso?: () => string;
+  /** Disable the trace tap (test-only). */
+  disableTraceTap?: boolean;
+}
+
+let _singleton: DspyBridge | null = null;
+let _starting: Promise<DspyBridge> | null = null;
+let _failed = false;
+
+/**
+ * Returns true if the DSPy path is enabled by env or pointer file.
+ *
+ * Cheap (one stat / env-read) — caller is free to check on every call.
+ */
+export function isDspyRuntimeEnabled(): boolean {
+  if (process.env['CAIA_DSPY_RUNTIME'] === '1') return true;
+  if (process.env['CAIA_DSPY_RUNTIME'] === '0') return false;
+  const pointer = path.join(
+    os.homedir(),
+    '.caia',
+    'dspy',
+    'runtime',
+    'po-scope-detector.enabled',
+  );
+  return fs.existsSync(pointer);
+}
+
+/**
+ * Try the DSPy path. Resolves to null on miss (fall back to legacy);
+ * resolves to a ScopeDetection on hit.
+ *
+ * The "miss" arms:
+ *   - runtime flag is off                            -> null
+ *   - bridge start failed in this process before     -> null
+ *   - bridge start fails this call                   -> null  (sets _failed)
+ *   - bridge.predict throws / returns invalid scope  -> null  (logs + counts)
+ *
+ * Hit:
+ *   - returns the ScopeDetection
+ *   - writes a trace row for the next compile cycle
+ */
+export async function tryDspyScopeDetect(
+  promptText: string,
+  visionDocSummary: string | undefined,
+  options: DspyRuntimeOptions = {},
+): Promise<ScopeDetection | null> {
+  const enabled = options.forceEnabled ?? isDspyRuntimeEnabled();
+  if (!enabled) return null;
+
+  let bridge: DspyBridge;
+  try {
+    bridge = options.bridge ?? (await getOrStartSingleton());
+  } catch (err) {
+    logFallback('bridge-start-failed', err);
+    _failed = true;
+    return null;
+  }
+
+  try {
+    const out = await runPoScopeDetector(bridge, {
+      promptText,
+      ...(visionDocSummary ? { visionDocSummary } : {}),
+    });
+
+    // Trace tap — feed the next compile cycle.
+    if (!options.disableTraceTap) {
+      try {
+        recordTrace(
+          'po-scope-detector',
+          {
+            version: 'runtime',
+            input: {
+              promptText,
+              ...(visionDocSummary ? { visionDocSummary } : {}),
+            },
+            output: {
+              targetScope: out.targetScope,
+              confidence: out.confidence,
+              rationale: out.rationale,
+            },
+            ok: true,
+            model: out.model,
+            durationMs: out.durationMs,
+          },
+          options.nowDateIso ? { nowDateIso: options.nowDateIso } : {},
+        );
+      } catch (tapErr) {
+        // Trace failure must NEVER break a production call.
+        logFallback('trace-tap-failed', tapErr);
+      }
+    }
+
+    return {
+      targetScope: out.targetScope,
+      confidence: out.confidence,
+      rationale: out.rationale,
+      model: out.model,
+      durationMs: out.durationMs,
+    };
+  } catch (err) {
+    if (err instanceof PoScopeDetectorError) {
+      logFallback('invalid-dspy-output', err);
+    } else {
+      logFallback('dspy-predict-failed', err);
+    }
+    return null;
+  }
+}
+
+async function getOrStartSingleton(): Promise<DspyBridge> {
+  if (_failed) {
+    throw new Error('DSPy bridge failed to start earlier in this process');
+  }
+  if (_singleton) return _singleton;
+  if (_starting) return _starting;
+  _starting = (async () => {
+    const bridge = new DspyBridge();
+    await bridge.start();
+    _singleton = bridge;
+    _starting = null;
+    return bridge;
+  })();
+  try {
+    return await _starting;
+  } catch (err) {
+    _starting = null;
+    throw err;
+  }
+}
+
+function logFallback(code: string, err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(
+    `[decomposer-recursive] dspy fallback (${code}): ${msg}\n`,
+  );
+}
+
+/**
+ * Test seam: dispose the singleton bridge between tests so a fresh
+ * one is created. Production code should never call this.
+ */
+export function __resetDspyRuntimeForTests(): void {
+  _singleton = null;
+  _starting = null;
+  _failed = false;
+}

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -139,3 +139,17 @@ export {
 export type {
   UseRecursiveDecomposerOptions,
 } from './feature-flag.js';
+
+// ─── DSPy runtime routing (dspy-005) ────────────────────────────────────
+//
+// `detectScope()` already consults the DSPy substrate transparently. The
+// helpers below are exported for tests, CLI tooling, and dashboards that
+// need to inspect or override the routing decision.
+
+export {
+  isDspyRuntimeEnabled,
+  tryDspyScopeDetect,
+  __resetDspyRuntimeForTests,
+} from './dspy-runtime.js';
+
+export type { DspyRuntimeOptions } from './dspy-runtime.js';

--- a/packages/decomposer-recursive/src/scope-detector.ts
+++ b/packages/decomposer-recursive/src/scope-detector.ts
@@ -3,17 +3,24 @@
  *
  * Given a user prompt (and optional vision-doc summary), classify the
  * smallest scope at which the prompt can be expressed without further
- * decomposition. The decomposer engine (PR 2) starts recursion at this
- * scope rather than always-starting-at-initiative — so "add a logout
- * button" produces a single story, not a fake five-level tree.
+ * decomposition. The decomposer engine starts recursion at this scope
+ * rather than always-starting-at-initiative — so "add a logout button"
+ * produces a single story, not a fake five-level tree.
  *
- * The classifier itself is a small LLM call routed through the local
- * Ollama path (with Claude fallback) — it's a classification task,
- * not a generative one, so qwen2.5-coder:7b handles it well.
+ * Two backends:
+ *   - DSPy runtime (compiled program in ~/.caia/dspy/compiled/...)
+ *     when `CAIA_DSPY_RUNTIME=1` or the pointer file exists.
+ *   - Legacy: hand-written prompt routed through
+ *     @chiefaia/local-llm-router via callStructured().
+ *
+ * The DSPy path is strict opt-in with strict failure tolerance — any
+ * failure falls back to the legacy path with a structured-log line.
+ * See `dspy-runtime.ts` for the policy.
  */
 
 import { ScopeDetectionLlmOutputSchema } from './schemas.js';
 import { callStructured } from './structured-output.js';
+import { tryDspyScopeDetect } from './dspy-runtime.js';
 import type { ScopeDetection, CancellationSignal } from './types.js';
 
 export const SCOPE_DETECTION_TASK_TYPE = 'po-decomposer-scope-detection';
@@ -28,6 +35,12 @@ export interface DetectScopeOptions {
   visionDocSummary?: string;
   /** Optional cancellation signal. */
   signal?: CancellationSignal;
+  /**
+   * Force the legacy path even if the DSPy runtime is enabled. Used by
+   * the regression test suite that snapshots the legacy prompt's
+   * behaviour for compile-time delta validation.
+   */
+  forceLegacy?: boolean;
 }
 
 const SCOPE_DETECTION_SYSTEM_PROMPT = `You are a senior product manager classifying the natural scope of a user request.
@@ -58,15 +71,22 @@ Output schema:
 /**
  * Classify the natural scope of a prompt.
  *
- * Returns a `ScopeDetection` with `targetScope`, `confidence`, and a
- * one-sentence rationale. On parse failure or model error,
- * propagates `StructuredOutputParseError` / `StructuredOutputCancelled`
- * — the orchestrator (PR 2) catches and decides whether to file a
- * `decomposer-stuck` blocker or retry with a fresh model.
+ * Tries the DSPy substrate first when enabled; falls back to the
+ * legacy `callStructured()` path on miss / failure.
  */
 export async function detectScope(
   options: DetectScopeOptions,
 ): Promise<ScopeDetection> {
+  // ── DSPy path (PR5) ─────────────────────────────────────────────────
+  if (!options.forceLegacy) {
+    const dspy = await tryDspyScopeDetect(
+      options.promptText,
+      options.visionDocSummary,
+    );
+    if (dspy !== null) return dspy;
+  }
+
+  // ── Legacy path (unchanged behaviour) ──────────────────────────────
   const userPrompt =
     `Classify the natural scope of the following user prompt.\n\n` +
     `=== PROMPT ===\n${options.promptText}\n=== END PROMPT ===\n` +

--- a/packages/decomposer-recursive/tests/dspy-runtime.test.ts
+++ b/packages/decomposer-recursive/tests/dspy-runtime.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Runtime-routing tests — DSPy path vs legacy fallback.
+ *
+ * The DspyBridge is mocked at the module level so these tests don't
+ * spin up a Python sub-process. Live DSPy traffic is exercised by the
+ * cron itself once the LaunchAgent is loaded.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  __resetDspyRuntimeForTests,
+  isDspyRuntimeEnabled,
+  tryDspyScopeDetect,
+} from '../src/dspy-runtime.js';
+import { detectScope } from '../src/scope-detector.js';
+
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+vi.mock('@chiefaia/dspy-bridge', async () => {
+  // We replace runPoScopeDetector / DspyBridge / recordTrace with stubs
+  // that the test controls via global hooks. The real implementations
+  // are exercised by `@chiefaia/dspy-bridge`'s own test suite.
+  return {
+    DspyBridge: class FakeBridge {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      async start(): Promise<void> {}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      async stop(): Promise<void> {}
+    },
+    PoScopeDetectorError: class extends Error {},
+    runPoScopeDetector: vi.fn(),
+    recordTrace: vi.fn(),
+  };
+});
+
+import { runPoScopeDetector, recordTrace } from '@chiefaia/dspy-bridge';
+
+const runPoScopeDetectorMock = runPoScopeDetector as unknown as ReturnType<typeof vi.fn>;
+const recordTraceMock = recordTrace as unknown as ReturnType<typeof vi.fn>;
+
+describe('isDspyRuntimeEnabled', () => {
+  const origRuntime = process.env['CAIA_DSPY_RUNTIME'];
+  let pointerDir: string;
+
+  beforeEach(() => {
+    delete process.env['CAIA_DSPY_RUNTIME'];
+    pointerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-runtime-flag-'));
+  });
+  afterEach(() => {
+    if (origRuntime !== undefined) process.env['CAIA_DSPY_RUNTIME'] = origRuntime;
+    else delete process.env['CAIA_DSPY_RUNTIME'];
+    fs.rmSync(pointerDir, { recursive: true, force: true });
+  });
+
+  it('respects CAIA_DSPY_RUNTIME=1', () => {
+    process.env['CAIA_DSPY_RUNTIME'] = '1';
+    expect(isDspyRuntimeEnabled()).toBe(true);
+  });
+
+  it('respects CAIA_DSPY_RUNTIME=0 (force-off even if pointer file exists)', () => {
+    process.env['CAIA_DSPY_RUNTIME'] = '0';
+    expect(isDspyRuntimeEnabled()).toBe(false);
+  });
+});
+
+describe('tryDspyScopeDetect', () => {
+  beforeEach(() => {
+    runPoScopeDetectorMock.mockReset();
+    recordTraceMock.mockReset();
+    __resetDspyRuntimeForTests();
+  });
+
+  it('returns null when runtime is disabled', async () => {
+    delete process.env['CAIA_DSPY_RUNTIME'];
+    const out = await tryDspyScopeDetect('add a logout button', undefined);
+    expect(out).toBeNull();
+    expect(runPoScopeDetectorMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the bridge verdict when forceEnabled', async () => {
+    runPoScopeDetectorMock.mockResolvedValueOnce({
+      targetScope: 'story',
+      confidence: 0.9,
+      rationale: 'one verb, one deliverable',
+      model: 'qwen2.5-coder:7b',
+      durationMs: 22,
+    });
+    const out = await tryDspyScopeDetect(
+      'add a logout button',
+      undefined,
+      { forceEnabled: true, bridge: {} as never, disableTraceTap: true },
+    );
+    expect(out).not.toBeNull();
+    expect(out?.targetScope).toBe('story');
+    expect(out?.model).toBe('qwen2.5-coder:7b');
+  });
+
+  it('records a trace row on the happy path', async () => {
+    runPoScopeDetectorMock.mockResolvedValueOnce({
+      targetScope: 'task',
+      confidence: 0.7,
+      rationale: 'one concern',
+      model: 'qwen2.5-coder:7b',
+      durationMs: 11,
+    });
+    await tryDspyScopeDetect(
+      'rename _x to _internal in foo.ts',
+      undefined,
+      { forceEnabled: true, bridge: {} as never },
+    );
+    expect(recordTraceMock).toHaveBeenCalledOnce();
+    const args = recordTraceMock.mock.calls[0];
+    expect(args?.[0]).toBe('po-scope-detector');
+    expect(args?.[1]).toMatchObject({
+      ok: true,
+      version: 'runtime',
+      output: { targetScope: 'task' },
+    });
+  });
+
+  it('returns null and logs on bridge failure', async () => {
+    runPoScopeDetectorMock.mockRejectedValueOnce(new Error('predict timed out'));
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const out = await tryDspyScopeDetect(
+      'whatever',
+      undefined,
+      { forceEnabled: true, bridge: {} as never },
+    );
+    expect(out).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('detectScope — runtime routing integration', () => {
+  beforeEach(() => {
+    clearAdapters();
+    __resetDspyRuntimeForTests();
+    runPoScopeDetectorMock.mockReset();
+    recordTraceMock.mockReset();
+    delete process.env['CAIA_DSPY_RUNTIME'];
+  });
+  afterEach(() => {
+    clearAdapters();
+    delete process.env['CAIA_DSPY_RUNTIME'];
+  });
+
+  it('uses legacy path when DSPy runtime is disabled', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'story',
+          confidence: 0.85,
+          rationale: 'one verb, one deliverable',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({ promptText: 'add a logout button' });
+    expect(out.targetScope).toBe('story');
+    expect(runPoScopeDetectorMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy when DSPy runtime fails', async () => {
+    process.env['CAIA_DSPY_RUNTIME'] = '1';
+    runPoScopeDetectorMock.mockRejectedValueOnce(new Error('bridge dead'));
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'task',
+          confidence: 0.6,
+          rationale: 'fallback',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({ promptText: 'rename _x to _internal in foo.ts' });
+    expect(out.targetScope).toBe('task');
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
PR5 of 6. Stacked on dspy-004.

Wires `detectScope()` to the DSPy substrate. **Strict opt-in with strict failure tolerance** — no production behaviour change unless the operator sets `CAIA_DSPY_RUNTIME=1` or touches the pointer file:

    ~/.caia/dspy/runtime/po-scope-detector.enabled

When the flag is on:
1. `dspy-runtime.ts` lazy-starts a singleton `DspyBridge`.
2. `runPoScopeDetector(bridge, ...)` invokes the compiled program.
3. `recordTrace()` writes the call to `~/.caia/dspy/traces/...` (closes the §7 feedback loop end-to-end).
4. **Any failure** (bridge dead, predict error, invalid scope) logs a structured fallback line and returns null; `detectScope()` falls through to the legacy `callStructured()` path verbatim.

`scope-detector.ts` is a minimal patch — the legacy prompt + flow are unchanged; the DSPy attempt is a 4-line short-circuit at the top of `detectScope()`. `forceLegacy: true` opts a single call out.

`decomposer-recursive/package.json` adds `@chiefaia/dspy-bridge` as a workspace dep.

**Tests**
- isDspyRuntimeEnabled: env=1 → true; env=0 → false (force-off overrides pointer file)
- tryDspyScopeDetect: returns null when disabled, returns verdict on happy path, records trace on hit, returns null + logs on bridge failure
- detectScope integration: legacy path when flag off, fallback to legacy when DSPy errors

**Reversible**: `rm ~/.caia/dspy/runtime/po-scope-detector.enabled` kills the substrate instantly — no service restart.

Greenlit by Prakash 2026-04-30.