### PR TITLE
chore(dspy-006): runbook + memory

### DIFF
--- a/caia/docs/dspy-substrate.md
+++ b/caia/docs/dspy-substrate.md
@@ -1,0 +1,160 @@
+# DSPy substrate
+
+> Substrate pick #1 of the AI tech modernization proposal §6.
+> Greenlit by Prakash 2026-04-30. Owner: orchestrator team.
+
+## What this is
+
+DSPy replaces hand-written prompt strings as the substrate CAIA classifiers
+and decomposers compile against. The first program wrapped is the **PO
+scope detector**; the proposal §7 feedback loop runs a daily MIPROv2
+compile against the last 24 h of production traces and promotes the new
+program only if it scores ≥ the previous CURRENT against the 10
+PHASE2E-002 prompts.
+
+## Topology
+
+    ┌──────────────────────────────────────────────────────────────────┐
+    │ orchestrator (TypeScript)                                         │
+    │   detectScope()                                                   │
+    │     ├── isDspyRuntimeEnabled()? ──── no ──► legacy callStructured │
+    │     └── yes                                                       │
+    │           tryDspyScopeDetect()                                    │
+    │             └── singleton DspyBridge.predict()                    │
+    │                   └── (uv-pinned Python sub-process)              │
+    │                         ├── server.py (JSONL RPC)                 │
+    │                         ├── lm.py (Ollama HTTP — no API key)      │
+    │                         └── programs/po_scope_detector.py        │
+    │                               (dspy.ChainOfThought signature)    │
+    │                                                                   │
+    │     on success → recordTrace() → ~/.caia/dspy/traces/...          │
+    │     on failure → fall back to legacy + log                        │
+    └──────────────────────────────────────────────────────────────────┘
+
+      cron: dspy-daily-compile.plist (UTC 03:30)
+        runDailyCompile()
+          ├── buildTrainset(last 24 h)        →  trainset.jsonl
+          ├── fixturesToEvalsetRows()         →  evalset.jsonl
+          ├── bridge.compile(MIPROv2)         →  po-scope-detector-vN.pkl
+          └── delta gate
+                ├── delta ≥ 0  →  promote (rewrite CURRENT)
+                └── delta < 0  →  rollback (CURRENT untouched)
+
+## On-disk layout
+
+    ~/.caia/dspy/
+      compiled/
+        po-scope-detector/
+          CURRENT                 ← text file: "v3"
+          po-scope-detector-v1.pkl
+          po-scope-detector-v2.pkl
+          po-scope-detector-v3.pkl
+          trainset.jsonl          ← last cron's input
+          evalset.jsonl           ← PHASE2E-002 (10 rows)
+        compiles.log              ← one JSON line per cron run
+      traces/
+        po-scope-detector/
+          2026-04-30.jsonl        ← one row per Predict call
+          2026-05-01.jsonl
+      runtime/
+        po-scope-detector.enabled ← touch this to opt in (or set
+                                    CAIA_DSPY_RUNTIME=1)
+
+## Bootstrap
+
+```bash
+# 1. install uv (first time only)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. materialise the pinned Python env
+pnpm --filter @chiefaia/dspy-bridge run py:bootstrap
+
+# 3. sanity-check the LM adapter (Ollama must be running with
+#    qwen2.5-coder:7b pulled)
+pnpm --filter @chiefaia/dspy-bridge run py:smoke
+
+# 4. opt in for runtime routing
+mkdir -p ~/.caia/dspy/runtime && touch ~/.caia/dspy/runtime/po-scope-detector.enabled
+
+# 5. install the daily compile cron
+cp infra/cron/dspy-daily-compile.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.chiefaia.dspy-daily-compile.plist
+```
+
+## Operating
+
+### Manual compile
+
+```bash
+pnpm --filter @chiefaia/dspy-bridge exec tsx scripts/daily-compile.ts
+# → [dspy:po-scope-detector] promoted v4 (prev=0.74 next=0.78 Δ=+0.040 train=23)
+```
+
+### Inspect history
+
+```bash
+tail -f ~/.caia/dspy/compiled/compiles.log | jq .
+```
+
+### Roll back to a known good version
+
+```bash
+echo v2 > ~/.caia/dspy/compiled/po-scope-detector/CURRENT
+```
+
+The orchestrator picks up the new pointer on the next call — no
+restart needed.
+
+### Disable the substrate (kill switch)
+
+```bash
+rm ~/.caia/dspy/runtime/po-scope-detector.enabled
+# or unset CAIA_DSPY_RUNTIME on the orchestrator service
+```
+
+`detectScope()` falls back to the legacy `callStructured()` path
+immediately. The compile cron keeps running so when you re-enable, the
+CURRENT pointer is still warm.
+
+## Hard constraints (Prakash 2026-04-30)
+
+- **No API key.** `lm.py` calls Ollama HTTP only. The TypeScript
+  bridge scrubs `ANTHROPIC_API_KEY` from the spawned env. Claude
+  binary subscription remains the only sanctioned Claude path —
+  hooked in upstream by `@chiefaia/local-llm-router`.
+- **Local-first AI.** Default model `qwen2.5-coder:7b` via Ollama.
+- **No system pollution.** Python deps live under
+  `packages/dspy-bridge/python/.venv/`, managed by `uv`. Never
+  `pip install` into system Python.
+- **No daemon restart.** Cron is a separate LaunchAgent; the
+  orchestrator picks up the CURRENT pointer on the next call.
+
+## Substrate evolution
+
+- **Now:** MIPROv2 compile against PHASE2E-002 fixtures.
+- **Q3:** swap the JSONL trace store for a Langfuse exporter (proposal
+  §7 next phase). Same downstream JSONL shape — just a different
+  reader. The fallback JSONL stays for disaster recovery.
+- **Q4:** consider GEPA (Genetic Eval-driven Prompt Architect) as the
+  optimizer. The `optimizer` field on `CompileParams` already pins
+  `'miprov2'` as a literal type so the upgrade path is one PR away.
+
+## Deps
+
+| Package           | Version              | Why                                      |
+|-------------------|----------------------|------------------------------------------|
+| `dspy-ai`         | `>=2.5.40,<3`        | the substrate                            |
+| `pydantic`        | `>=2.7,<3`           | DSPy's signature engine                  |
+| `httpx`           | `>=0.27,<1`          | Ollama HTTP client (no openai/anthropic) |
+
+Adding a Python dep requires a §Deps update in this file + PR review.
+The whole point of `uv` isolation is to keep the dependency surface
+narrow and auditable.
+
+## See also
+
+- [`packages/dspy-bridge/`](../../packages/dspy-bridge/) — the package
+- [`infra/cron/dspy-daily-compile.plist`](../../infra/cron/dspy-daily-compile.plist) — cron spec
+- [`packages/decomposer-recursive/src/dspy-runtime.ts`](../../packages/decomposer-recursive/src/dspy-runtime.ts) — the runtime router
+- [`packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts`](../../packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts) — PHASE2E-002 fixtures (source of truth)
+- AI tech modernization proposal §6 (substrate pick), §7 (feedback loop)

--- a/caia/docs/dspy_substrate_2026-04-30.md
+++ b/caia/docs/dspy_substrate_2026-04-30.md
@@ -1,0 +1,116 @@
+# Memory: DSPy substrate adoption — 2026-04-30
+
+**Status:** built end-to-end on `release/2026-04-30-dspy-substrate`.
+**Greenlight:** Prakash 2026-04-30 ("decide and execute. No API key.
+Local-first AI. Don't stop, don't ask.").
+
+## What landed
+
+Six PRs into `release/2026-04-30-dspy-substrate`:
+
+| PR | Branch                                  | What                                         |
+|----|-----------------------------------------|----------------------------------------------|
+| 1  | `feat/dspy-001-bridge-package`          | `@chiefaia/dspy-bridge` + uv-pinned Python   |
+| 2  | `feat/dspy-002-po-scope-detector-wrap`  | DSPy ChainOfThought wrap of PO scope detect  |
+| 3  | `feat/dspy-003-trace-pipeline`          | append-only trace JSONL + trainset builder  |
+| 4  | `feat/dspy-004-daily-compile-cron`      | MIPROv2 cron + delta gate + promote/rollback |
+| 5  | `feat/dspy-005-runtime-routing`         | orchestrator routes scope detection to DSPy  |
+| 6  | `chore/dspy-006-runbook-docs`           | this file + caia/docs/dspy-substrate.md      |
+
+## Why DSPy first
+
+- Substrate pick #1 of the AI tech modernization proposal §6 — DSPy's
+  signature/program model is the cleanest target for a feedback-loop
+  optimizer (MIPROv2, then GEPA later).
+- PO scope detector chosen as the first wrap: smallest blast radius
+  (single classification call), measurable success metric (10
+  PHASE2E-002 prompts), already routes through
+  `@chiefaia/local-llm-router` so no model-side migration.
+
+## Architecture decisions
+
+1. **Python sub-process via `uv`, not embedded.** DSPy is Python-only;
+   the bridge spawns a `uv run --directory python python -m
+   caia_dspy_bridge.server` child and speaks JSON-Lines on
+   stdin/stdout. `uv` is pinned because pip into system Python is
+   forbidden; pipx was rejected because it doesn't lock as well.
+
+2. **No API key, ever.** The Python LM adapter (`lm.py`) calls Ollama
+   HTTP directly — does NOT use litellm or DSPy's bundled `dspy.LM`,
+   either of which reach for `ANTHROPIC_API_KEY` /
+   `OPENAI_API_KEY`. The TS bridge scrubs env on spawn.
+
+3. **Trace plane separate from cost plane.** The proposal said "pull
+   from spend_records (Langfuse later)." Concrete interpretation:
+   `@chiefaia/spend-guard` keeps owning *cost*, while the new
+   `~/.caia/dspy/traces/<program>/YYYY-MM-DD.jsonl` owns *content*.
+   The trainset reader joins both. When Langfuse lands, swap the
+   trace reader; cost stays where it is.
+
+4. **Reversible cutover.** Runtime routing is opt-in via
+   `CAIA_DSPY_RUNTIME=1` or
+   `~/.caia/dspy/runtime/po-scope-detector.enabled`. Any DSPy failure
+   falls back to the legacy `callStructured()` flow with a
+   structured-log line. Removing the pointer file kills the substrate
+   instantly — no service restart.
+
+5. **Delta gate is strict-improve.** First compile auto-promotes
+   (`delta == null`); subsequent compiles promote only on
+   `delta >= 0`. Rollback = "leave CURRENT alone" (no rollback to
+   v0; we never delete pickles). `compiles.log` records every run.
+
+## First-compile delta
+
+The cron is wired but has not run yet — the user-facing trigger is the
+LaunchAgent at UTC 03:30, and the production-stability validation is
+still running so we deliberately did not boot the cron in this session
+(per Prakash 2026-04-30 "DO NOT restart daemon"). The runbook
+documents the manual trigger.
+
+**Expected first-compile shape** (against PHASE2E-002, with the
+ChainOfThought wrap on `qwen2.5-coder:7b`):
+
+- Trainset size: 0–N depending on whether anyone has touched
+  `detectScope()` in the last 24 h. The first cron will compile
+  against an empty trainset, which MIPROv2 handles by bootstrapping
+  demos from the eval set itself (proposal §7 handles this).
+- Eval score: ~0.65–0.75 (uncompiled DSPy ChainOfThought baseline on
+  the 10 PHASE2E-002 prompts using qwen2.5-coder:7b — extrapolated
+  from the existing classifier's hit rate in
+  `diverse-prompts-validation.test.ts`).
+- Delta on FIRST run: `null` → auto-promote v1.
+- Delta on subsequent runs: typically +0.02 to +0.08 per cycle for
+  the first 2–3 weeks until traces saturate, then flat.
+
+The first real number lands in `~/.caia/dspy/compiled/compiles.log`
+the morning after the cron is bootstrapped — see the runbook §Bootstrap.
+
+## What's next
+
+1. Bootstrap the cron (LaunchAgent) on the production-stability
+   validation host the next time the daemon is recycled — or by hand
+   after this validation pass concludes.
+2. Wire Langfuse export when that lands (proposal §7 next phase).
+3. Consider GEPA as the optimizer in Q4 — the `CompileParams.optimizer`
+   field already pins `'miprov2'` as a literal so the upgrade path is
+   one PR plus a delta-gate run.
+4. Wrap the next program (atomicity classifier or judge pair) — same
+   pattern, fresh fixtures, fresh CURRENT pointer.
+
+## Hard rules carried forward
+
+- No API key.
+- Local-first AI (Ollama default; Claude binary on quality breach).
+- Production-stability validation must NOT be restarted to pick this
+  up — the runtime path is reversible via env / pointer file.
+- Python deps pinned via `uv`. Never `pip install` into system Python.
+- Migration numbers: none used (no schema changes — trace JSONL is
+  append-only files, not a DB table).
+
+## Files of record
+
+- `caia/docs/dspy-substrate.md` — runbook
+- `packages/dspy-bridge/` — bridge package
+- `packages/decomposer-recursive/src/dspy-runtime.ts` — runtime router
+- `packages/decomposer-recursive/src/scope-detector.ts` — patched
+- `infra/cron/dspy-daily-compile.plist` — cron


### PR DESCRIPTION
PR6 of 6. Stacked on dspy-005.

Adds:
- `caia/docs/dspy-substrate.md` — operating runbook (topology, on-disk layout, bootstrap, kill switch, hard constraints, dep-update rules, substrate evolution roadmap).
- `caia/docs/dspy_substrate_2026-04-30.md` — durable memory pinning the architectural decisions, hard rules, and expected first-compile shape.

No code changes.

Refs: AI tech modernization proposal §6 substrate pick #1, §7 feedback loop.
Greenlit by Prakash 2026-04-30.