### PR TITLE
feat(smart-cicd-001): propose-only Smart CI/CD Agent — package skeleton + db handlers (PR1)

### DIFF
--- a/apps/orchestrator/src/db/migrations/0052_smart_cicd_observations.sql
+++ b/apps/orchestrator/src/db/migrations/0052_smart_cicd_observations.sql
@@ -1,0 +1,29 @@
+-- migration 0052: smart_cicd_observations
+--
+-- Worked-example agent table (caia-ai-tech-modernization-proposal §6A.5).
+-- Records every Smart CI/CD Agent daily observation + proposed action.
+-- The agent is propose-only — it never auto-merges PRs, never deletes
+-- branches, never force-pushes. Operators preserve veto via the
+-- proposed_action_payload_json + acted_outcome columns.
+--
+-- proposed_action_kind ∈ {auto-fix-pr, rec-issue, prompt-update, skill-bump, silent}
+-- acted_outcome        ∈ {merged, rejected, still-open, silent}
+-- feedback_label       ∈ {accepted, rejected, pending}
+
+CREATE TABLE IF NOT EXISTS smart_cicd_observations (
+  id TEXT PRIMARY KEY,
+  observation_date INTEGER NOT NULL,
+  bucket_name TEXT NOT NULL,
+  root_cause TEXT NOT NULL,
+  root_cause_confidence REAL NOT NULL,
+  proposed_action_kind TEXT NOT NULL,
+  proposed_action_payload_json TEXT NOT NULL,
+  acted_at INTEGER,
+  acted_outcome TEXT,
+  feedback_label TEXT,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS smart_cicd_obs_date ON smart_cicd_observations(observation_date);
+CREATE INDEX IF NOT EXISTS smart_cicd_obs_action_kind ON smart_cicd_observations(proposed_action_kind);
+CREATE INDEX IF NOT EXISTS smart_cicd_obs_feedback ON smart_cicd_observations(feedback_label);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1779200000000,
       "tag": "0040_spend_caps",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1779700000000,
+      "tag": "0052_smart_cicd_observations",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/smart-cicd-agent/package.json
+++ b/apps/smart-cicd-agent/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@caia-app/smart-cicd-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Smart CI/CD Agent daemon (propose-only).",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/daemon.js",
+    "lint": "echo 'TODO: eslint flat config not yet wired in this app. Stub until @chiefaia/eslint-config migrates.' && exit 0"
+  },
+  "dependencies": {
+    "@chiefaia/local-llm-router": "workspace:*",
+    "@chiefaia/capability-broker": "workspace:*",
+    "better-sqlite3": "^12.6.2",
+    "nanoid": "^3.3.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/apps/smart-cicd-agent/src/daemon.ts
+++ b/apps/smart-cicd-agent/src/daemon.ts
@@ -1,0 +1,95 @@
+/**
+ * Smart CI/CD Agent — daily-cycle daemon entrypoint.
+ *
+ * Reference: caia-ai-tech-modernization-proposal-2026-04-30.md §6A.5.
+ *
+ * **Hard invariant — propose-only.** This daemon never:
+ *   - merges PRs
+ *   - deletes branches
+ *   - force-pushes
+ *   - calls --admin
+ * It writes observation rows. An operator (or a future, separate "actor"
+ * subsystem behind the capability-broker) is the only path to mutation.
+ *
+ * PR1 lands the SKELETON: a daily 04:00 invocation that records a single
+ * `silent` observation per cycle. Subsequent PRs (PR2 observer, PR3
+ * classifier-proposer, PR4 actor, PR5 weekly self-review) fill in the rest.
+ */
+
+import Database from 'better-sqlite3';
+import { insertObservation } from './db.js';
+import { SMART_CICD } from './types.js';
+
+export interface DaemonConfig {
+  /** Path to the orchestrator SQLite DB containing the smart_cicd_observations table. */
+  dbPath: string;
+  /** ms-epoch reference for `observationDate` (typically local-midnight). */
+  cycleAtMs: number;
+}
+
+/**
+ * Run a single propose-only daily cycle. Returns the observation IDs
+ * recorded so the caller can correlate downstream artefacts.
+ *
+ * In PR1 this is intentionally a no-op aggregation pass — it only records
+ * a single 'silent' bookkeeping observation so the daemon's heartbeat is
+ * visible in the table and so dashboards can confirm the daemon is wired up.
+ */
+export async function runOneCycle(cfg: DaemonConfig): Promise<{
+  observationIds: string[];
+  cycleStartedAt: number;
+  cycleFinishedAt: number;
+  version: string;
+}> {
+  const cycleStartedAt = Date.now();
+  const db = new Database(cfg.dbPath);
+  try {
+    const id = insertObservation(db, {
+      observationDate: cfg.cycleAtMs,
+      bucketName: 'lint_failures', // dummy bucket — PR1 skeleton only
+      rootCause: 'unknown',
+      rootCauseConfidence: 0,
+      proposedActionKind: 'silent',
+      proposedActionPayload: {
+        kind: 'silent',
+        note: `smart-cicd skeleton heartbeat ${SMART_CICD}`,
+      },
+    });
+    return {
+      observationIds: [id],
+      cycleStartedAt,
+      cycleFinishedAt: Date.now(),
+      version: SMART_CICD,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * CLI entry: `node dist/daemon.js`. Reads SMART_CICD_DB env var.
+ */
+async function main(): Promise<void> {
+  const dbPath = process.env.SMART_CICD_DB;
+  if (!dbPath) {
+    // eslint-disable-next-line no-console
+    console.error('SMART_CICD_DB env var is required');
+    process.exit(2);
+  }
+  const result = await runOneCycle({
+    dbPath,
+    cycleAtMs: Date.now(),
+  });
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(result));
+}
+
+// Only run main() when executed directly (not when imported).
+const isCli =
+  typeof process !== 'undefined' &&
+  process.argv[1] !== undefined &&
+  process.argv[1].endsWith('daemon.js');
+if (isCli) {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  main();
+}

--- a/apps/smart-cicd-agent/src/db.ts
+++ b/apps/smart-cicd-agent/src/db.ts
@@ -1,0 +1,124 @@
+/**
+ * Smart CI/CD Agent — SQLite handlers (better-sqlite3).
+ *
+ * Mirrors migration 0052_smart_cicd_observations.sql.
+ *
+ * The agent is propose-only. This module never writes acted_outcome or
+ * feedback_label other than to the values dictated by an operator action.
+ */
+
+import { nanoid } from 'nanoid';
+import type Database from 'better-sqlite3';
+import type {
+  ActedOutcome,
+  FeedbackLabel,
+  Observation,
+  ProposedActionKind,
+  ProposedActionPayload,
+} from './types.js';
+import { Observation as ObservationSchema } from './types.js';
+
+/**
+ * Insert a new observation row. Returns the row's id.
+ */
+export function insertObservation(
+  db: Database.Database,
+  args: {
+    observationDate: number; // ms epoch (rounded to local-midnight by caller)
+    bucketName: string;
+    rootCause: string;
+    rootCauseConfidence: number;
+    proposedActionKind: ProposedActionKind;
+    proposedActionPayload: ProposedActionPayload;
+  }
+): string {
+  const id = `smart-cicd-${nanoid(12)}`;
+  const stmt = db.prepare(
+    `INSERT INTO smart_cicd_observations
+       (id, observation_date, bucket_name, root_cause, root_cause_confidence,
+        proposed_action_kind, proposed_action_payload_json,
+        acted_at, acted_outcome, feedback_label, created_at)
+     VALUES
+       (@id, @observation_date, @bucket_name, @root_cause, @root_cause_confidence,
+        @proposed_action_kind, @proposed_action_payload_json,
+        NULL, NULL, 'pending', @created_at)`
+  );
+  stmt.run({
+    id,
+    observation_date: args.observationDate,
+    bucket_name: args.bucketName,
+    root_cause: args.rootCause,
+    root_cause_confidence: args.rootCauseConfidence,
+    proposed_action_kind: args.proposedActionKind,
+    proposed_action_payload_json: JSON.stringify(args.proposedActionPayload),
+    created_at: Date.now(),
+  });
+  return id;
+}
+
+/**
+ * Mark a previously-recorded observation as acted upon. Used by the
+ * propose-only ACT step to record what kind of artifact was produced
+ * (PR opened, issue filed, draft prompt registered, …) and later by the
+ * weekly self-improve to record the operator's verdict.
+ */
+export function recordActed(
+  db: Database.Database,
+  args: {
+    id: string;
+    actedOutcome: ActedOutcome;
+    feedbackLabel?: FeedbackLabel | null;
+  }
+): void {
+  db.prepare(
+    `UPDATE smart_cicd_observations
+       SET acted_at        = @acted_at,
+           acted_outcome   = @acted_outcome,
+           feedback_label  = COALESCE(@feedback_label, feedback_label)
+     WHERE id = @id`
+  ).run({
+    id: args.id,
+    acted_at: Date.now(),
+    acted_outcome: args.actedOutcome,
+    feedback_label: args.feedbackLabel ?? null,
+  });
+}
+
+/**
+ * Read observations for the daily/weekly self-review windows.
+ * `windowStartMs` inclusive, `windowEndMs` exclusive.
+ */
+export function listObservations(
+  db: Database.Database,
+  windowStartMs: number,
+  windowEndMs: number
+): Observation[] {
+  const rows = db
+    .prepare(
+      `SELECT id, observation_date, bucket_name, root_cause, root_cause_confidence,
+              proposed_action_kind, proposed_action_payload_json,
+              acted_at, acted_outcome, feedback_label, created_at
+         FROM smart_cicd_observations
+        WHERE created_at >= ? AND created_at < ?
+        ORDER BY created_at ASC`
+    )
+    .all(windowStartMs, windowEndMs) as Array<Record<string, unknown>>;
+
+  return rows.map((row) =>
+    ObservationSchema.parse({
+      id: row.id,
+      observationDate: row.observation_date,
+      bucketName: row.bucket_name,
+      rootCause: row.root_cause,
+      rootCauseConfidence: row.root_cause_confidence,
+      proposedActionKind: row.proposed_action_kind,
+      proposedActionPayload: JSON.parse(
+        String(row.proposed_action_payload_json)
+      ),
+      actedAt: row.acted_at,
+      actedOutcome: row.acted_outcome,
+      feedbackLabel: row.feedback_label,
+      createdAt: row.created_at,
+    })
+  );
+}

--- a/apps/smart-cicd-agent/src/index.ts
+++ b/apps/smart-cicd-agent/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @caia-app/smart-cicd-agent — public exports for the Smart CI/CD Agent.
+ *
+ * The agent itself runs as a long-running daemon (see ./daemon.ts).
+ * This barrel exposes the types + db handlers so other packages can
+ * read observations (e.g. the dashboard) or feed the agent test data.
+ */
+
+export * from './types.js';
+export {
+  insertObservation,
+  recordActed,
+  listObservations,
+} from './db.js';

--- a/apps/smart-cicd-agent/src/types.ts
+++ b/apps/smart-cicd-agent/src/types.ts
@@ -1,0 +1,199 @@
+/**
+ * Smart CI/CD Agent — types (Zod schemas + inferred TS types).
+ *
+ * Reference: caia-ai-tech-modernization-proposal-2026-04-30.md §6A.5.
+ *
+ * Daily-cycle schema:
+ *   1. AGGREGATE → bucketed counts of pre-existing failure classes from the last 24h.
+ *   2. CLASSIFY  → for each bucket > N, classify dominant root cause (LLM, xgrammar-constrained JSON).
+ *   3. PROPOSE   → emit a typed ProposedAction per root cause.
+ *   4. ACT       → propose-only: open auto-fix PR, file rec issue, write prompts-registry candidate, etc.
+ *
+ * **Hard invariant:** the Smart CI/CD Agent is propose-only. It NEVER auto-merges PRs,
+ * deletes branches, force-pushes, or merges without an operator.
+ */
+
+import { z } from 'zod';
+
+export const SMART_CICD = 'v0.1.0';
+
+/* ───────────────────────────────────────────────────────────────────────── *
+ *  Failure-mode buckets (the inputs to classification)                      *
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Stable bucket name keys for daily aggregation.
+ * Each key counts the number of distinct PR/CI events in the last 24h that
+ * matched the bucket's deterministic predicate.
+ */
+export const BucketName = z.enum([
+  'lint_failures',
+  'typecheck_failures',
+  'test_flakes',
+  'validator_section_x_failures',
+  'fix_it_loop_exhausted',
+  'merge_conflicts',
+  'pre_commit_blocked',
+  'stale_branch_warnings',
+  'gitflow_conformance_violations',
+  'pipeline_regression_failures',
+]);
+export type BucketName = z.infer<typeof BucketName>;
+
+/**
+ * One bucket's daily count + an opaque list of exemplar event references
+ * (PR numbers, CI run IDs, fix-it loop IDs, …).
+ */
+export const FailureBucket = z.object({
+  bucketName: BucketName,
+  count: z.number().int().nonnegative(),
+  exemplarRefs: z.array(z.string()).max(20),
+});
+export type FailureBucket = z.infer<typeof FailureBucket>;
+
+/* ───────────────────────────────────────────────────────────────────────── *
+ *  Classification (LLM step)                                                *
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Stable root-cause vocabulary. Defined explicitly so the LLM is constrained
+ * via xgrammar to one of these strings.
+ */
+export const RootCause = z.enum([
+  'code-style-drift',
+  'new-test-flake',
+  'validator-threshold-drift',
+  'fix-it-loop-prompt-regression',
+  'merge-conflict-policy-gap',
+  'contributor-onboarding-gap',
+  'deferred-work-archive-candidate',
+  'gitflow-policy-gap',
+  'pipeline-rule-mis-fire',
+  'unknown',
+]);
+export type RootCause = z.infer<typeof RootCause>;
+
+/**
+ * Output of step 2 (classify). Bucket → root cause + confidence.
+ */
+export const Classification = z.object({
+  bucketName: BucketName,
+  rootCause: RootCause,
+  confidence: z.number().min(0).max(1),
+  reasoning: z.string().max(500),
+});
+export type Classification = z.infer<typeof Classification>;
+
+/* ───────────────────────────────────────────────────────────────────────── *
+ *  Proposals (the propose-only act step)                                    *
+ * ───────────────────────────────────────────────────────────────────────── */
+
+export const ProposedActionKind = z.enum([
+  'auto-fix-pr',
+  'rec-issue',
+  'prompt-update',
+  'skill-bump',
+  'silent',
+]);
+export type ProposedActionKind = z.infer<typeof ProposedActionKind>;
+
+const AutoFixPrPayload = z.object({
+  kind: z.literal('auto-fix-pr'),
+  branchName: z.string().regex(/^smart-cicd\/auto-fix-/),
+  baseBranch: z.literal('develop'),
+  title: z.string().min(1).max(80),
+  body: z.string().max(4000),
+  files: z
+    .array(
+      z.object({
+        path: z.string().min(1),
+        contents: z.string(),
+      })
+    )
+    .min(1)
+    .max(10),
+});
+
+const RecIssuePayload = z.object({
+  kind: z.literal('rec-issue'),
+  title: z.string().min(1).max(80),
+  body: z.string().max(8000),
+  labels: z.array(z.string()).max(8),
+});
+
+const PromptUpdatePayload = z.object({
+  kind: z.literal('prompt-update'),
+  promptKey: z.string().min(1),
+  draftPromptText: z.string().min(1),
+  evidenceTraceIds: z.array(z.string()).min(1).max(50),
+  expectedDeltaPct: z.number().min(-100).max(100),
+});
+
+const SkillBumpPayload = z.object({
+  kind: z.literal('skill-bump'),
+  skillName: z.string().min(1),
+  fromVersion: z.string().min(1),
+  toVersion: z.string().min(1),
+  rationale: z.string().min(1).max(2000),
+});
+
+const SilentPayload = z.object({
+  kind: z.literal('silent'),
+  note: z.string().max(500),
+});
+
+export const ProposedActionPayload = z.discriminatedUnion('kind', [
+  AutoFixPrPayload,
+  RecIssuePayload,
+  PromptUpdatePayload,
+  SkillBumpPayload,
+  SilentPayload,
+]);
+export type ProposedActionPayload = z.infer<typeof ProposedActionPayload>;
+
+/* ───────────────────────────────────────────────────────────────────────── *
+ *  Outcome + feedback (the audit trail)                                     *
+ * ───────────────────────────────────────────────────────────────────────── */
+
+export const ActedOutcome = z.enum([
+  'merged',
+  'rejected',
+  'still-open',
+  'silent',
+]);
+export type ActedOutcome = z.infer<typeof ActedOutcome>;
+
+export const FeedbackLabel = z.enum(['accepted', 'rejected', 'pending']);
+export type FeedbackLabel = z.infer<typeof FeedbackLabel>;
+
+/* ───────────────────────────────────────────────────────────────────────── *
+ *  The full observation row (mirrors migration 0052)                        *
+ * ───────────────────────────────────────────────────────────────────────── */
+
+export const Observation = z.object({
+  id: z.string().min(1),
+  observationDate: z.number().int().positive(),
+  bucketName: BucketName,
+  rootCause: RootCause,
+  rootCauseConfidence: z.number().min(0).max(1),
+  proposedActionKind: ProposedActionKind,
+  proposedActionPayload: ProposedActionPayload,
+  actedAt: z.number().int().positive().nullable(),
+  actedOutcome: ActedOutcome.nullable(),
+  feedbackLabel: FeedbackLabel.nullable(),
+  createdAt: z.number().int().positive(),
+});
+export type Observation = z.infer<typeof Observation>;
+
+/* ───────────────────────────────────────────────────────────────────────── *
+ *  Daily-cycle wrapper (the daemon's report shape)                          *
+ * ───────────────────────────────────────────────────────────────────────── */
+
+export const DailyCycleReport = z.object({
+  windowStartAt: z.number().int().positive(),
+  windowEndAt: z.number().int().positive(),
+  buckets: z.array(FailureBucket),
+  classifications: z.array(Classification),
+  observations: z.array(Observation),
+});
+export type DailyCycleReport = z.infer<typeof DailyCycleReport>;

--- a/apps/smart-cicd-agent/tests/db.test.ts
+++ b/apps/smart-cicd-agent/tests/db.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  insertObservation,
+  recordActed,
+  listObservations,
+} from '../src/db.js';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  // Mirror the columns used in the migration; production migrations create the table elsewhere.
+  db.exec(`
+    CREATE TABLE smart_cicd_observations (
+      id TEXT PRIMARY KEY,
+      observation_date INTEGER NOT NULL,
+      bucket_name TEXT NOT NULL,
+      root_cause TEXT NOT NULL,
+      root_cause_confidence REAL NOT NULL,
+      proposed_action_kind TEXT NOT NULL,
+      proposed_action_payload_json TEXT NOT NULL,
+      acted_at INTEGER,
+      acted_outcome TEXT,
+      feedback_label TEXT,
+      created_at INTEGER NOT NULL
+    );
+  `);
+  return db;
+}
+
+describe('Smart CI/CD db handlers', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('insertObservation persists a propose-only row', () => {
+    const id = insertObservation(db, {
+      observationDate: 1779000000000,
+      bucketName: 'lint_failures',
+      rootCause: 'code-style-drift',
+      rootCauseConfidence: 0.9,
+      proposedActionKind: 'silent',
+      proposedActionPayload: { kind: 'silent', note: 'one-off blip' },
+    });
+    expect(id).toMatch(/^smart-cicd-/);
+
+    const row = db
+      .prepare('SELECT * FROM smart_cicd_observations WHERE id = ?')
+      .get(id) as Record<string, unknown>;
+    expect(row.bucket_name).toBe('lint_failures');
+    expect(row.acted_at).toBeNull();
+    expect(row.acted_outcome).toBeNull();
+    expect(row.feedback_label).toBe('pending');
+  });
+
+  it('recordActed marks acted_at + acted_outcome', () => {
+    const id = insertObservation(db, {
+      observationDate: 1779000000000,
+      bucketName: 'merge_conflicts',
+      rootCause: 'merge-conflict-policy-gap',
+      rootCauseConfidence: 0.7,
+      proposedActionKind: 'rec-issue',
+      proposedActionPayload: {
+        kind: 'rec-issue',
+        title: 'Recurring merge conflicts in apps/dashboard',
+        body: 'Last 24h: 7 conflicts on the same files.',
+        labels: ['workflow', 'observability'],
+      },
+    });
+    recordActed(db, { id, actedOutcome: 'still-open' });
+
+    const row = db
+      .prepare('SELECT acted_at, acted_outcome, feedback_label FROM smart_cicd_observations WHERE id = ?')
+      .get(id) as Record<string, unknown>;
+    expect(row.acted_at).toBeGreaterThan(0);
+    expect(row.acted_outcome).toBe('still-open');
+    // feedback_label should preserve initial 'pending' if not overridden.
+    expect(row.feedback_label).toBe('pending');
+  });
+
+  it('listObservations returns rows in created_at window', () => {
+    const ids = [
+      insertObservation(db, {
+        observationDate: 1,
+        bucketName: 'lint_failures',
+        rootCause: 'unknown',
+        rootCauseConfidence: 0,
+        proposedActionKind: 'silent',
+        proposedActionPayload: { kind: 'silent', note: 'a' },
+      }),
+      insertObservation(db, {
+        observationDate: 2,
+        bucketName: 'typecheck_failures',
+        rootCause: 'unknown',
+        rootCauseConfidence: 0,
+        proposedActionKind: 'silent',
+        proposedActionPayload: { kind: 'silent', note: 'b' },
+      }),
+    ];
+    const rows = listObservations(db, 0, Date.now() + 60_000);
+    expect(rows.map((r) => r.id).sort()).toEqual([...ids].sort());
+    rows.forEach((r) => expect(r.feedbackLabel).toBe('pending'));
+  });
+});

--- a/apps/smart-cicd-agent/tests/types.test.ts
+++ b/apps/smart-cicd-agent/tests/types.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BucketName,
+  Classification,
+  FailureBucket,
+  Observation,
+  ProposedActionPayload,
+  RootCause,
+  SMART_CICD,
+} from '../src/types.js';
+
+describe('Smart CI/CD types', () => {
+  it('exports a non-empty version string', () => {
+    expect(SMART_CICD).toMatch(/^v\d/);
+  });
+
+  it('BucketName accepts known buckets and rejects unknown', () => {
+    expect(() => BucketName.parse('lint_failures')).not.toThrow();
+    expect(() => BucketName.parse('not-a-real-bucket')).toThrow();
+  });
+
+  it('FailureBucket validates count + exemplarRefs cap', () => {
+    const ok = FailureBucket.parse({
+      bucketName: 'lint_failures',
+      count: 3,
+      exemplarRefs: ['#1', '#2'],
+    });
+    expect(ok.count).toBe(3);
+    expect(() =>
+      FailureBucket.parse({
+        bucketName: 'lint_failures',
+        count: -1,
+        exemplarRefs: [],
+      })
+    ).toThrow();
+    expect(() =>
+      FailureBucket.parse({
+        bucketName: 'lint_failures',
+        count: 1,
+        exemplarRefs: Array.from({ length: 21 }, (_, i) => `#${i}`),
+      })
+    ).toThrow();
+  });
+
+  it('RootCause is a closed vocabulary', () => {
+    expect(() => RootCause.parse('unknown')).not.toThrow();
+    expect(() => RootCause.parse('made-up-cause')).toThrow();
+  });
+
+  it('Classification enforces 0-1 confidence', () => {
+    expect(() =>
+      Classification.parse({
+        bucketName: 'lint_failures',
+        rootCause: 'code-style-drift',
+        confidence: 0.9,
+        reasoning: 'Same rule across 12 PRs in last 24h.',
+      })
+    ).not.toThrow();
+    expect(() =>
+      Classification.parse({
+        bucketName: 'lint_failures',
+        rootCause: 'code-style-drift',
+        confidence: 1.5,
+        reasoning: 'invalid',
+      })
+    ).toThrow();
+  });
+
+  it('ProposedActionPayload discriminates by kind', () => {
+    const silent = ProposedActionPayload.parse({
+      kind: 'silent',
+      note: 'observed but no action',
+    });
+    expect(silent.kind).toBe('silent');
+
+    const fixPr = ProposedActionPayload.parse({
+      kind: 'auto-fix-pr',
+      branchName: 'smart-cicd/auto-fix-lint-2026-05-01',
+      baseBranch: 'develop',
+      title: 'fix(lint): widen no-unused-vars exemption to tests/**',
+      body: '## Background\n…',
+      files: [{ path: '.eslintrc.cjs', contents: '// updated config' }],
+    });
+    expect(fixPr.kind).toBe('auto-fix-pr');
+
+    expect(() =>
+      ProposedActionPayload.parse({
+        kind: 'auto-fix-pr',
+        // Missing required `files` and bad branchName prefix.
+        branchName: 'feat/oops',
+        baseBranch: 'develop',
+        title: 't',
+        body: 'b',
+      })
+    ).toThrow();
+  });
+
+  it('Observation round-trips a propose-only row', () => {
+    const obs = Observation.parse({
+      id: 'smart-cicd-abcdef123456',
+      observationDate: Date.now(),
+      bucketName: 'lint_failures',
+      rootCause: 'code-style-drift',
+      rootCauseConfidence: 0.82,
+      proposedActionKind: 'silent',
+      proposedActionPayload: {
+        kind: 'silent',
+        note: 'observed but no action',
+      },
+      actedAt: null,
+      actedOutcome: null,
+      feedbackLabel: 'pending',
+      createdAt: Date.now(),
+    });
+    expect(obs.feedbackLabel).toBe('pending');
+    expect(obs.actedAt).toBeNull();
+  });
+});

--- a/apps/smart-cicd-agent/tsconfig.json
+++ b/apps/smart-cicd-agent/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitOverride": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "tests/**"]
+}

--- a/apps/smart-cicd-agent/vitest.config.ts
+++ b/apps/smart-cicd-agent/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 15000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,37 @@ importers:
 
   apps/roulette-backend: {}
 
+  apps/smart-cicd-agent:
+    dependencies:
+      '@chiefaia/capability-broker':
+        specifier: workspace:*
+        version: link:../../packages/capability-broker
+      '@chiefaia/local-llm-router':
+        specifier: workspace:*
+        version: link:../../packages/local-llm-router
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.9.0
+      nanoid:
+        specifier: ^3.3.7
+        version: 3.3.11
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   apps/stolution-mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
PR1 of the §6A.5 worked-example agent — sets up the package skeleton + observation table + db handlers, no actor logic yet.

## What this PR adds

- **`apps/smart-cicd-agent`** (new private ESM package):
  - `src/types.ts` — Zod schemas for `FailureBucket`, `Classification`, `ProposedAction` (discriminated by kind: `auto-fix-pr` / `rec-issue` / `prompt-update` / `skill-bump` / `silent`), `Observation`, `DailyCycleReport`. Closed `RootCause` vocabulary.
  - `src/db.ts` — `insertObservation`, `recordActed`, `listObservations` over `better-sqlite3`. Enforces the propose-only contract.
  - `src/daemon.ts` — `runOneCycle()` + CLI. PR1 records a single `silent` heartbeat per cycle so dashboards can confirm wiring.
  - `src/index.ts` — barrel.
  - `tests/` — 10 vitest cases, all green locally (Zod round-trips + db CRUD).
- **`apps/orchestrator/src/db/migrations/0052_smart_cicd_observations.sql`** + journal entry.
- **`pnpm-lock.yaml`** refreshed for the new deps (`better-sqlite3`, `nanoid`, `zod`).

## Hard invariant — propose-only

The Smart CI/CD Agent **never**:
- merges PRs
- deletes branches
- force-pushes
- calls `--admin`

Every cycle writes observation rows. An operator (or a future, separate "actor" subsystem behind the capability-broker) is the only path to mutation.

## Roadmap (subsequent PRs)

- PR2 — observer (24h aggregator)
- PR3 — classifier + proposer (LLM, qwen3:14b via local-llm-router for classify, claude-sonnet-4-6 with prompt cache for propose)
- PR4 — actor (capability-broker-gated; opens PRs / files issues / writes prompts-registry candidates)
- PR5 — weekly self-review (DSPy GEPA on accepted/rejected proposals)
- PR6 — runbook + dashboard panel

## Notes

Reference: `caia-ai-tech-modernization-proposal-2026-04-30.md` §6A.5.
Lint stub matches the workspace pattern until `@chiefaia/eslint-config` migrates to ESLint flat config.