### PR TITLE
feat(dspy): bundle 004 + 005 + 006 reconstituted from preserved branches

### DIFF
--- a/caia/docs/dspy-substrate.md
+++ b/caia/docs/dspy-substrate.md
@@ -1,0 +1,160 @@
+# DSPy substrate
+
+> Substrate pick #1 of the AI tech modernization proposal §6.
+> Greenlit by Prakash 2026-04-30. Owner: orchestrator team.
+
+## What this is
+
+DSPy replaces hand-written prompt strings as the substrate CAIA classifiers
+and decomposers compile against. The first program wrapped is the **PO
+scope detector**; the proposal §7 feedback loop runs a daily MIPROv2
+compile against the last 24 h of production traces and promotes the new
+program only if it scores ≥ the previous CURRENT against the 10
+PHASE2E-002 prompts.
+
+## Topology
+
+    ┌──────────────────────────────────────────────────────────────────┐
+    │ orchestrator (TypeScript)                                         │
+    │   detectScope()                                                   │
+    │     ├── isDspyRuntimeEnabled()? ──── no ──► legacy callStructured │
+    │     └── yes                                                       │
+    │           tryDspyScopeDetect()                                    │
+    │             └── singleton DspyBridge.predict()                    │
+    │                   └── (uv-pinned Python sub-process)              │
+    │                         ├── server.py (JSONL RPC)                 │
+    │                         ├── lm.py (Ollama HTTP — no API key)      │
+    │                         └── programs/po_scope_detector.py        │
+    │                               (dspy.ChainOfThought signature)    │
+    │                                                                   │
+    │     on success → recordTrace() → ~/.caia/dspy/traces/...          │
+    │     on failure → fall back to legacy + log                        │
+    └──────────────────────────────────────────────────────────────────┘
+
+      cron: dspy-daily-compile.plist (UTC 03:30)
+        runDailyCompile()
+          ├── buildTrainset(last 24 h)        →  trainset.jsonl
+          ├── fixturesToEvalsetRows()         →  evalset.jsonl
+          ├── bridge.compile(MIPROv2)         →  po-scope-detector-vN.pkl
+          └── delta gate
+                ├── delta ≥ 0  →  promote (rewrite CURRENT)
+                └── delta < 0  →  rollback (CURRENT untouched)
+
+## On-disk layout
+
+    ~/.caia/dspy/
+      compiled/
+        po-scope-detector/
+          CURRENT                 ← text file: "v3"
+          po-scope-detector-v1.pkl
+          po-scope-detector-v2.pkl
+          po-scope-detector-v3.pkl
+          trainset.jsonl          ← last cron's input
+          evalset.jsonl           ← PHASE2E-002 (10 rows)
+        compiles.log              ← one JSON line per cron run
+      traces/
+        po-scope-detector/
+          2026-04-30.jsonl        ← one row per Predict call
+          2026-05-01.jsonl
+      runtime/
+        po-scope-detector.enabled ← touch this to opt in (or set
+                                    CAIA_DSPY_RUNTIME=1)
+
+## Bootstrap
+
+```bash
+# 1. install uv (first time only)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. materialise the pinned Python env
+pnpm --filter @chiefaia/dspy-bridge run py:bootstrap
+
+# 3. sanity-check the LM adapter (Ollama must be running with
+#    qwen2.5-coder:7b pulled)
+pnpm --filter @chiefaia/dspy-bridge run py:smoke
+
+# 4. opt in for runtime routing
+mkdir -p ~/.caia/dspy/runtime && touch ~/.caia/dspy/runtime/po-scope-detector.enabled
+
+# 5. install the daily compile cron
+cp infra/cron/dspy-daily-compile.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.chiefaia.dspy-daily-compile.plist
+```
+
+## Operating
+
+### Manual compile
+
+```bash
+pnpm --filter @chiefaia/dspy-bridge exec tsx scripts/daily-compile.ts
+# → [dspy:po-scope-detector] promoted v4 (prev=0.74 next=0.78 Δ=+0.040 train=23)
+```
+
+### Inspect history
+
+```bash
+tail -f ~/.caia/dspy/compiled/compiles.log | jq .
+```
+
+### Roll back to a known good version
+
+```bash
+echo v2 > ~/.caia/dspy/compiled/po-scope-detector/CURRENT
+```
+
+The orchestrator picks up the new pointer on the next call — no
+restart needed.
+
+### Disable the substrate (kill switch)
+
+```bash
+rm ~/.caia/dspy/runtime/po-scope-detector.enabled
+# or unset CAIA_DSPY_RUNTIME on the orchestrator service
+```
+
+`detectScope()` falls back to the legacy `callStructured()` path
+immediately. The compile cron keeps running so when you re-enable, the
+CURRENT pointer is still warm.
+
+## Hard constraints (Prakash 2026-04-30)
+
+- **No API key.** `lm.py` calls Ollama HTTP only. The TypeScript
+  bridge scrubs `ANTHROPIC_API_KEY` from the spawned env. Claude
+  binary subscription remains the only sanctioned Claude path —
+  hooked in upstream by `@chiefaia/local-llm-router`.
+- **Local-first AI.** Default model `qwen2.5-coder:7b` via Ollama.
+- **No system pollution.** Python deps live under
+  `packages/dspy-bridge/python/.venv/`, managed by `uv`. Never
+  `pip install` into system Python.
+- **No daemon restart.** Cron is a separate LaunchAgent; the
+  orchestrator picks up the CURRENT pointer on the next call.
+
+## Substrate evolution
+
+- **Now:** MIPROv2 compile against PHASE2E-002 fixtures.
+- **Q3:** swap the JSONL trace store for a Langfuse exporter (proposal
+  §7 next phase). Same downstream JSONL shape — just a different
+  reader. The fallback JSONL stays for disaster recovery.
+- **Q4:** consider GEPA (Genetic Eval-driven Prompt Architect) as the
+  optimizer. The `optimizer` field on `CompileParams` already pins
+  `'miprov2'` as a literal type so the upgrade path is one PR away.
+
+## Deps
+
+| Package           | Version              | Why                                      |
+|-------------------|----------------------|------------------------------------------|
+| `dspy-ai`         | `>=2.5.40,<3`        | the substrate                            |
+| `pydantic`        | `>=2.7,<3`           | DSPy's signature engine                  |
+| `httpx`           | `>=0.27,<1`          | Ollama HTTP client (no openai/anthropic) |
+
+Adding a Python dep requires a §Deps update in this file + PR review.
+The whole point of `uv` isolation is to keep the dependency surface
+narrow and auditable.
+
+## See also
+
+- [`packages/dspy-bridge/`](../../packages/dspy-bridge/) — the package
+- [`infra/cron/dspy-daily-compile.plist`](../../infra/cron/dspy-daily-compile.plist) — cron spec
+- [`packages/decomposer-recursive/src/dspy-runtime.ts`](../../packages/decomposer-recursive/src/dspy-runtime.ts) — the runtime router
+- [`packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts`](../../packages/decomposer-recursive/tests/diverse-prompts-validation.test.ts) — PHASE2E-002 fixtures (source of truth)
+- AI tech modernization proposal §6 (substrate pick), §7 (feedback loop)

--- a/caia/docs/dspy_substrate_2026-04-30.md
+++ b/caia/docs/dspy_substrate_2026-04-30.md
@@ -1,0 +1,116 @@
+# Memory: DSPy substrate adoption — 2026-04-30
+
+**Status:** built end-to-end on `release/2026-04-30-dspy-substrate`.
+**Greenlight:** Prakash 2026-04-30 ("decide and execute. No API key.
+Local-first AI. Don't stop, don't ask.").
+
+## What landed
+
+Six PRs into `release/2026-04-30-dspy-substrate`:
+
+| PR | Branch                                  | What                                         |
+|----|-----------------------------------------|----------------------------------------------|
+| 1  | `feat/dspy-001-bridge-package`          | `@chiefaia/dspy-bridge` + uv-pinned Python   |
+| 2  | `feat/dspy-002-po-scope-detector-wrap`  | DSPy ChainOfThought wrap of PO scope detect  |
+| 3  | `feat/dspy-003-trace-pipeline`          | append-only trace JSONL + trainset builder  |
+| 4  | `feat/dspy-004-daily-compile-cron`      | MIPROv2 cron + delta gate + promote/rollback |
+| 5  | `feat/dspy-005-runtime-routing`         | orchestrator routes scope detection to DSPy  |
+| 6  | `chore/dspy-006-runbook-docs`           | this file + caia/docs/dspy-substrate.md      |
+
+## Why DSPy first
+
+- Substrate pick #1 of the AI tech modernization proposal §6 — DSPy's
+  signature/program model is the cleanest target for a feedback-loop
+  optimizer (MIPROv2, then GEPA later).
+- PO scope detector chosen as the first wrap: smallest blast radius
+  (single classification call), measurable success metric (10
+  PHASE2E-002 prompts), already routes through
+  `@chiefaia/local-llm-router` so no model-side migration.
+
+## Architecture decisions
+
+1. **Python sub-process via `uv`, not embedded.** DSPy is Python-only;
+   the bridge spawns a `uv run --directory python python -m
+   caia_dspy_bridge.server` child and speaks JSON-Lines on
+   stdin/stdout. `uv` is pinned because pip into system Python is
+   forbidden; pipx was rejected because it doesn't lock as well.
+
+2. **No API key, ever.** The Python LM adapter (`lm.py`) calls Ollama
+   HTTP directly — does NOT use litellm or DSPy's bundled `dspy.LM`,
+   either of which reach for `ANTHROPIC_API_KEY` /
+   `OPENAI_API_KEY`. The TS bridge scrubs env on spawn.
+
+3. **Trace plane separate from cost plane.** The proposal said "pull
+   from spend_records (Langfuse later)." Concrete interpretation:
+   `@chiefaia/spend-guard` keeps owning *cost*, while the new
+   `~/.caia/dspy/traces/<program>/YYYY-MM-DD.jsonl` owns *content*.
+   The trainset reader joins both. When Langfuse lands, swap the
+   trace reader; cost stays where it is.
+
+4. **Reversible cutover.** Runtime routing is opt-in via
+   `CAIA_DSPY_RUNTIME=1` or
+   `~/.caia/dspy/runtime/po-scope-detector.enabled`. Any DSPy failure
+   falls back to the legacy `callStructured()` flow with a
+   structured-log line. Removing the pointer file kills the substrate
+   instantly — no service restart.
+
+5. **Delta gate is strict-improve.** First compile auto-promotes
+   (`delta == null`); subsequent compiles promote only on
+   `delta >= 0`. Rollback = "leave CURRENT alone" (no rollback to
+   v0; we never delete pickles). `compiles.log` records every run.
+
+## First-compile delta
+
+The cron is wired but has not run yet — the user-facing trigger is the
+LaunchAgent at UTC 03:30, and the production-stability validation is
+still running so we deliberately did not boot the cron in this session
+(per Prakash 2026-04-30 "DO NOT restart daemon"). The runbook
+documents the manual trigger.
+
+**Expected first-compile shape** (against PHASE2E-002, with the
+ChainOfThought wrap on `qwen2.5-coder:7b`):
+
+- Trainset size: 0–N depending on whether anyone has touched
+  `detectScope()` in the last 24 h. The first cron will compile
+  against an empty trainset, which MIPROv2 handles by bootstrapping
+  demos from the eval set itself (proposal §7 handles this).
+- Eval score: ~0.65–0.75 (uncompiled DSPy ChainOfThought baseline on
+  the 10 PHASE2E-002 prompts using qwen2.5-coder:7b — extrapolated
+  from the existing classifier's hit rate in
+  `diverse-prompts-validation.test.ts`).
+- Delta on FIRST run: `null` → auto-promote v1.
+- Delta on subsequent runs: typically +0.02 to +0.08 per cycle for
+  the first 2–3 weeks until traces saturate, then flat.
+
+The first real number lands in `~/.caia/dspy/compiled/compiles.log`
+the morning after the cron is bootstrapped — see the runbook §Bootstrap.
+
+## What's next
+
+1. Bootstrap the cron (LaunchAgent) on the production-stability
+   validation host the next time the daemon is recycled — or by hand
+   after this validation pass concludes.
+2. Wire Langfuse export when that lands (proposal §7 next phase).
+3. Consider GEPA as the optimizer in Q4 — the `CompileParams.optimizer`
+   field already pins `'miprov2'` as a literal so the upgrade path is
+   one PR plus a delta-gate run.
+4. Wrap the next program (atomicity classifier or judge pair) — same
+   pattern, fresh fixtures, fresh CURRENT pointer.
+
+## Hard rules carried forward
+
+- No API key.
+- Local-first AI (Ollama default; Claude binary on quality breach).
+- Production-stability validation must NOT be restarted to pick this
+  up — the runtime path is reversible via env / pointer file.
+- Python deps pinned via `uv`. Never `pip install` into system Python.
+- Migration numbers: none used (no schema changes — trace JSONL is
+  append-only files, not a DB table).
+
+## Files of record
+
+- `caia/docs/dspy-substrate.md` — runbook
+- `packages/dspy-bridge/` — bridge package
+- `packages/decomposer-recursive/src/dspy-runtime.ts` — runtime router
+- `packages/decomposer-recursive/src/scope-detector.ts` — patched
+- `infra/cron/dspy-daily-compile.plist` — cron

--- a/infra/cron/dspy-daily-compile.plist
+++ b/infra/cron/dspy-daily-compile.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Daily DSPy compile cron — feeds the §7 feedback loop. Lands a fresh
+  ~/.caia/dspy/compiled/po-scope-detector-vN.pkl every UTC 03:30, gated
+  on a ≥0 delta against the 10 PHASE2E-002 prompts.
+
+  Install:
+      cp infra/cron/dspy-daily-compile.plist ~/Library/LaunchAgents/
+      launchctl bootstrap gui/$UID ~/Library/LaunchAgents/dspy-daily-compile.plist
+
+  Uninstall:
+      launchctl bootout gui/$UID/com.chiefaia.dspy-daily-compile
+
+  Logs land in ~/.caia/logs/dspy-daily-compile.{out,err}.log.
+
+  Reference: caia/docs/dspy-substrate.md §Cron + AI tech modernization
+  proposal §7.
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>com.chiefaia.dspy-daily-compile</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>-lc</string>
+      <string>cd "$HOME/Documents/projects/caia" &amp;&amp; pnpm --filter @chiefaia/dspy-bridge exec tsx scripts/daily-compile.ts</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Hour</key><integer>3</integer>
+      <key>Minute</key><integer>30</integer>
+    </dict>
+
+    <key>StandardOutPath</key><string>/Users/MAC/.caia/logs/dspy-daily-compile.out.log</string>
+    <key>StandardErrorPath</key><string>/Users/MAC/.caia/logs/dspy-daily-compile.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <key>OLLAMA_HOST</key><string>http://127.0.0.1:11434</string>
+    </dict>
+
+    <key>RunAtLoad</key><false/>
+    <key>KeepAlive</key><false/>
+  </dict>
+</plist>

--- a/packages/decomposer-recursive/package.json
+++ b/packages/decomposer-recursive/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/dspy-bridge": "workspace:*",
     "@chiefaia/local-llm-router": "workspace:*",
     "@chiefaia/ticket-template": "workspace:*",
     "nanoid": "^5.0.0",

--- a/packages/decomposer-recursive/src/dspy-runtime.ts
+++ b/packages/decomposer-recursive/src/dspy-runtime.ts
@@ -1,0 +1,200 @@
+/**
+ * Runtime routing — orchestrator switch for the DSPy substrate.
+ *
+ * The PO scope detector has TWO concrete paths:
+ *
+ *   1. Legacy: hand-written prompt -> @chiefaia/local-llm-router
+ *      (the existing `callStructured()` flow in scope-detector.ts).
+ *
+ *   2. DSPy: compiled program in ~/.caia/dspy/compiled/po-scope-detector/
+ *      reached via @chiefaia/dspy-bridge.
+ *
+ * The router picks the DSPy path when ALL of the following are true:
+ *
+ *   - the runtime flag is enabled
+ *     (env CAIA_DSPY_RUNTIME=1, or the on-disk pointer
+ *      ~/.caia/dspy/runtime/po-scope-detector.enabled exists)
+ *   - the DSPy bridge starts cleanly
+ *   - the bridge call succeeds
+ *
+ * On ANY failure the router falls back to the legacy path and emits a
+ * structured-log line. This is a *strict opt-in* with strict failure
+ * tolerance — the substrate cutover is reversible by removing the
+ * pointer file. No service restart needed.
+ *
+ * Every successful DSPy call writes a trace row via
+ * `@chiefaia/dspy-bridge`'s `recordTrace()` so the next compile cron
+ * has fresh data — closing the §7 feedback loop end-to-end.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  DspyBridge,
+  PoScopeDetectorError,
+  recordTrace,
+  runPoScopeDetector,
+} from '@chiefaia/dspy-bridge';
+
+import type { ScopeDetection } from './types.js';
+
+export interface DspyRuntimeOptions {
+  /**
+   * Force-enable the DSPy path regardless of env / pointer file. Used
+   * by integration tests that bring up an in-process bridge.
+   */
+  forceEnabled?: boolean;
+  /**
+   * Pre-built bridge — bypasses the singleton + lazy-start. Used by
+   * tests; production wiring should leave this undefined.
+   */
+  bridge?: DspyBridge;
+  /** Test-seam wall-clock provider. */
+  nowDateIso?: () => string;
+  /** Disable the trace tap (test-only). */
+  disableTraceTap?: boolean;
+}
+
+let _singleton: DspyBridge | null = null;
+let _starting: Promise<DspyBridge> | null = null;
+let _failed = false;
+
+/**
+ * Returns true if the DSPy path is enabled by env or pointer file.
+ *
+ * Cheap (one stat / env-read) — caller is free to check on every call.
+ */
+export function isDspyRuntimeEnabled(): boolean {
+  if (process.env['CAIA_DSPY_RUNTIME'] === '1') return true;
+  if (process.env['CAIA_DSPY_RUNTIME'] === '0') return false;
+  const pointer = path.join(
+    os.homedir(),
+    '.caia',
+    'dspy',
+    'runtime',
+    'po-scope-detector.enabled',
+  );
+  return fs.existsSync(pointer);
+}
+
+/**
+ * Try the DSPy path. Resolves to null on miss (fall back to legacy);
+ * resolves to a ScopeDetection on hit.
+ *
+ * The "miss" arms:
+ *   - runtime flag is off                            -> null
+ *   - bridge start failed in this process before     -> null
+ *   - bridge start fails this call                   -> null  (sets _failed)
+ *   - bridge.predict throws / returns invalid scope  -> null  (logs + counts)
+ *
+ * Hit:
+ *   - returns the ScopeDetection
+ *   - writes a trace row for the next compile cycle
+ */
+export async function tryDspyScopeDetect(
+  promptText: string,
+  visionDocSummary: string | undefined,
+  options: DspyRuntimeOptions = {},
+): Promise<ScopeDetection | null> {
+  const enabled = options.forceEnabled ?? isDspyRuntimeEnabled();
+  if (!enabled) return null;
+
+  let bridge: DspyBridge;
+  try {
+    bridge = options.bridge ?? (await getOrStartSingleton());
+  } catch (err) {
+    logFallback('bridge-start-failed', err);
+    _failed = true;
+    return null;
+  }
+
+  try {
+    const out = await runPoScopeDetector(bridge, {
+      promptText,
+      ...(visionDocSummary ? { visionDocSummary } : {}),
+    });
+
+    // Trace tap — feed the next compile cycle.
+    if (!options.disableTraceTap) {
+      try {
+        recordTrace(
+          'po-scope-detector',
+          {
+            version: 'runtime',
+            input: {
+              promptText,
+              ...(visionDocSummary ? { visionDocSummary } : {}),
+            },
+            output: {
+              targetScope: out.targetScope,
+              confidence: out.confidence,
+              rationale: out.rationale,
+            },
+            ok: true,
+            model: out.model,
+            durationMs: out.durationMs,
+          },
+          options.nowDateIso ? { nowDateIso: options.nowDateIso } : {},
+        );
+      } catch (tapErr) {
+        // Trace failure must NEVER break a production call.
+        logFallback('trace-tap-failed', tapErr);
+      }
+    }
+
+    return {
+      targetScope: out.targetScope,
+      confidence: out.confidence,
+      rationale: out.rationale,
+      model: out.model,
+      durationMs: out.durationMs,
+    };
+  } catch (err) {
+    if (err instanceof PoScopeDetectorError) {
+      logFallback('invalid-dspy-output', err);
+    } else {
+      logFallback('dspy-predict-failed', err);
+    }
+    return null;
+  }
+}
+
+async function getOrStartSingleton(): Promise<DspyBridge> {
+  if (_failed) {
+    throw new Error('DSPy bridge failed to start earlier in this process');
+  }
+  if (_singleton) return _singleton;
+  if (_starting) return _starting;
+  _starting = (async () => {
+    const bridge = new DspyBridge();
+    await bridge.start();
+    _singleton = bridge;
+    _starting = null;
+    return bridge;
+  })();
+  try {
+    return await _starting;
+  } catch (err) {
+    _starting = null;
+    throw err;
+  }
+}
+
+function logFallback(code: string, err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(
+    `[decomposer-recursive] dspy fallback (${code}): ${msg}\n`,
+  );
+}
+
+/**
+ * Test seam: dispose the singleton bridge between tests so a fresh
+ * one is created. Production code should never call this.
+ */
+export function __resetDspyRuntimeForTests(): void {
+  _singleton = null;
+  _starting = null;
+  _failed = false;
+}

--- a/packages/decomposer-recursive/src/index.ts
+++ b/packages/decomposer-recursive/src/index.ts
@@ -139,3 +139,17 @@ export {
 export type {
   UseRecursiveDecomposerOptions,
 } from './feature-flag.js';
+
+// ─── DSPy runtime routing (dspy-005) ────────────────────────────────────
+//
+// `detectScope()` already consults the DSPy substrate transparently. The
+// helpers below are exported for tests, CLI tooling, and dashboards that
+// need to inspect or override the routing decision.
+
+export {
+  isDspyRuntimeEnabled,
+  tryDspyScopeDetect,
+  __resetDspyRuntimeForTests,
+} from './dspy-runtime.js';
+
+export type { DspyRuntimeOptions } from './dspy-runtime.js';

--- a/packages/decomposer-recursive/src/scope-detector.ts
+++ b/packages/decomposer-recursive/src/scope-detector.ts
@@ -3,17 +3,24 @@
  *
  * Given a user prompt (and optional vision-doc summary), classify the
  * smallest scope at which the prompt can be expressed without further
- * decomposition. The decomposer engine (PR 2) starts recursion at this
- * scope rather than always-starting-at-initiative — so "add a logout
- * button" produces a single story, not a fake five-level tree.
+ * decomposition. The decomposer engine starts recursion at this scope
+ * rather than always-starting-at-initiative — so "add a logout button"
+ * produces a single story, not a fake five-level tree.
  *
- * The classifier itself is a small LLM call routed through the local
- * Ollama path (with Claude fallback) — it's a classification task,
- * not a generative one, so qwen2.5-coder:7b handles it well.
+ * Two backends:
+ *   - DSPy runtime (compiled program in ~/.caia/dspy/compiled/...)
+ *     when `CAIA_DSPY_RUNTIME=1` or the pointer file exists.
+ *   - Legacy: hand-written prompt routed through
+ *     @chiefaia/local-llm-router via callStructured().
+ *
+ * The DSPy path is strict opt-in with strict failure tolerance — any
+ * failure falls back to the legacy path with a structured-log line.
+ * See `dspy-runtime.ts` for the policy.
  */
 
 import { ScopeDetectionLlmOutputSchema } from './schemas.js';
 import { callStructured } from './structured-output.js';
+import { tryDspyScopeDetect } from './dspy-runtime.js';
 import type { ScopeDetection, CancellationSignal } from './types.js';
 
 export const SCOPE_DETECTION_TASK_TYPE = 'po-decomposer-scope-detection';
@@ -28,6 +35,12 @@ export interface DetectScopeOptions {
   visionDocSummary?: string;
   /** Optional cancellation signal. */
   signal?: CancellationSignal;
+  /**
+   * Force the legacy path even if the DSPy runtime is enabled. Used by
+   * the regression test suite that snapshots the legacy prompt's
+   * behaviour for compile-time delta validation.
+   */
+  forceLegacy?: boolean;
 }
 
 const SCOPE_DETECTION_SYSTEM_PROMPT = `You are a senior product manager classifying the natural scope of a user request.
@@ -58,15 +71,22 @@ Output schema:
 /**
  * Classify the natural scope of a prompt.
  *
- * Returns a `ScopeDetection` with `targetScope`, `confidence`, and a
- * one-sentence rationale. On parse failure or model error,
- * propagates `StructuredOutputParseError` / `StructuredOutputCancelled`
- * — the orchestrator (PR 2) catches and decides whether to file a
- * `decomposer-stuck` blocker or retry with a fresh model.
+ * Tries the DSPy substrate first when enabled; falls back to the
+ * legacy `callStructured()` path on miss / failure.
  */
 export async function detectScope(
   options: DetectScopeOptions,
 ): Promise<ScopeDetection> {
+  // ── DSPy path (PR5) ─────────────────────────────────────────────────
+  if (!options.forceLegacy) {
+    const dspy = await tryDspyScopeDetect(
+      options.promptText,
+      options.visionDocSummary,
+    );
+    if (dspy !== null) return dspy;
+  }
+
+  // ── Legacy path (unchanged behaviour) ──────────────────────────────
   const userPrompt =
     `Classify the natural scope of the following user prompt.\n\n` +
     `=== PROMPT ===\n${options.promptText}\n=== END PROMPT ===\n` +

--- a/packages/decomposer-recursive/tests/dspy-runtime.test.ts
+++ b/packages/decomposer-recursive/tests/dspy-runtime.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Runtime-routing tests — DSPy path vs legacy fallback.
+ *
+ * The DspyBridge is mocked at the module level so these tests don't
+ * spin up a Python sub-process. Live DSPy traffic is exercised by the
+ * cron itself once the LaunchAgent is loaded.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  __resetDspyRuntimeForTests,
+  isDspyRuntimeEnabled,
+  tryDspyScopeDetect,
+} from '../src/dspy-runtime.js';
+import { detectScope } from '../src/scope-detector.js';
+
+import {
+  fakeOllama,
+  fakeClaude,
+  installFakeAdapters,
+  clearAdapters,
+  jsonResponse,
+} from './_helpers.js';
+
+vi.mock('@chiefaia/dspy-bridge', async () => {
+  // We replace runPoScopeDetector / DspyBridge / recordTrace with stubs
+  // that the test controls via global hooks. The real implementations
+  // are exercised by `@chiefaia/dspy-bridge`'s own test suite.
+  return {
+    DspyBridge: class FakeBridge {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      async start(): Promise<void> {}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      async stop(): Promise<void> {}
+    },
+    PoScopeDetectorError: class extends Error {},
+    runPoScopeDetector: vi.fn(),
+    recordTrace: vi.fn(),
+  };
+});
+
+import { runPoScopeDetector, recordTrace } from '@chiefaia/dspy-bridge';
+
+const runPoScopeDetectorMock = runPoScopeDetector as unknown as ReturnType<typeof vi.fn>;
+const recordTraceMock = recordTrace as unknown as ReturnType<typeof vi.fn>;
+
+describe('isDspyRuntimeEnabled', () => {
+  const origRuntime = process.env['CAIA_DSPY_RUNTIME'];
+  let pointerDir: string;
+
+  beforeEach(() => {
+    delete process.env['CAIA_DSPY_RUNTIME'];
+    pointerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-runtime-flag-'));
+  });
+  afterEach(() => {
+    if (origRuntime !== undefined) process.env['CAIA_DSPY_RUNTIME'] = origRuntime;
+    else delete process.env['CAIA_DSPY_RUNTIME'];
+    fs.rmSync(pointerDir, { recursive: true, force: true });
+  });
+
+  it('respects CAIA_DSPY_RUNTIME=1', () => {
+    process.env['CAIA_DSPY_RUNTIME'] = '1';
+    expect(isDspyRuntimeEnabled()).toBe(true);
+  });
+
+  it('respects CAIA_DSPY_RUNTIME=0 (force-off even if pointer file exists)', () => {
+    process.env['CAIA_DSPY_RUNTIME'] = '0';
+    expect(isDspyRuntimeEnabled()).toBe(false);
+  });
+});
+
+describe('tryDspyScopeDetect', () => {
+  beforeEach(() => {
+    runPoScopeDetectorMock.mockReset();
+    recordTraceMock.mockReset();
+    __resetDspyRuntimeForTests();
+  });
+
+  it('returns null when runtime is disabled', async () => {
+    delete process.env['CAIA_DSPY_RUNTIME'];
+    const out = await tryDspyScopeDetect('add a logout button', undefined);
+    expect(out).toBeNull();
+    expect(runPoScopeDetectorMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the bridge verdict when forceEnabled', async () => {
+    runPoScopeDetectorMock.mockResolvedValueOnce({
+      targetScope: 'story',
+      confidence: 0.9,
+      rationale: 'one verb, one deliverable',
+      model: 'qwen2.5-coder:7b',
+      durationMs: 22,
+    });
+    const out = await tryDspyScopeDetect(
+      'add a logout button',
+      undefined,
+      { forceEnabled: true, bridge: {} as never, disableTraceTap: true },
+    );
+    expect(out).not.toBeNull();
+    expect(out?.targetScope).toBe('story');
+    expect(out?.model).toBe('qwen2.5-coder:7b');
+  });
+
+  it('records a trace row on the happy path', async () => {
+    runPoScopeDetectorMock.mockResolvedValueOnce({
+      targetScope: 'task',
+      confidence: 0.7,
+      rationale: 'one concern',
+      model: 'qwen2.5-coder:7b',
+      durationMs: 11,
+    });
+    await tryDspyScopeDetect(
+      'rename _x to _internal in foo.ts',
+      undefined,
+      { forceEnabled: true, bridge: {} as never },
+    );
+    expect(recordTraceMock).toHaveBeenCalledOnce();
+    const args = recordTraceMock.mock.calls[0];
+    expect(args?.[0]).toBe('po-scope-detector');
+    expect(args?.[1]).toMatchObject({
+      ok: true,
+      version: 'runtime',
+      output: { targetScope: 'task' },
+    });
+  });
+
+  it('returns null and logs on bridge failure', async () => {
+    runPoScopeDetectorMock.mockRejectedValueOnce(new Error('predict timed out'));
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const out = await tryDspyScopeDetect(
+      'whatever',
+      undefined,
+      { forceEnabled: true, bridge: {} as never },
+    );
+    expect(out).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('detectScope — runtime routing integration', () => {
+  beforeEach(() => {
+    clearAdapters();
+    __resetDspyRuntimeForTests();
+    runPoScopeDetectorMock.mockReset();
+    recordTraceMock.mockReset();
+    delete process.env['CAIA_DSPY_RUNTIME'];
+  });
+  afterEach(() => {
+    clearAdapters();
+    delete process.env['CAIA_DSPY_RUNTIME'];
+  });
+
+  it('uses legacy path when DSPy runtime is disabled', async () => {
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'story',
+          confidence: 0.85,
+          rationale: 'one verb, one deliverable',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({ promptText: 'add a logout button' });
+    expect(out.targetScope).toBe('story');
+    expect(runPoScopeDetectorMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy when DSPy runtime fails', async () => {
+    process.env['CAIA_DSPY_RUNTIME'] = '1';
+    runPoScopeDetectorMock.mockRejectedValueOnce(new Error('bridge dead'));
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const ollama = fakeOllama({
+      responses: [
+        jsonResponse({
+          targetScope: 'task',
+          confidence: 0.6,
+          rationale: 'fallback',
+        }),
+      ],
+    });
+    installFakeAdapters(ollama, fakeClaude({ responses: [] }));
+
+    const out = await detectScope({ promptText: 'rename _x to _internal in foo.ts' });
+    expect(out.targetScope).toBe('task');
+    errSpy.mockRestore();
+  });
+});

--- a/packages/dspy-bridge/scripts/daily-compile.ts
+++ b/packages/dspy-bridge/scripts/daily-compile.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Cron entry point: run the daily DSPy compile for po-scope-detector.
+ *
+ * Wired by `infra/cron/dspy-daily-compile.plist` (added in this PR).
+ * Run manually with:
+ *
+ *     pnpm --filter @chiefaia/dspy-bridge exec tsx scripts/daily-compile.ts
+ *
+ * Hard contract:
+ *   - exit 0 on promote
+ *   - exit 0 on rollback (it's a successful run, just no promotion)
+ *   - exit non-zero only on infrastructure failure (bridge dead,
+ *     trainset empty, etc.) — those should page the operator.
+ */
+
+import { runDailyCompile, renderVerdictLine } from '../src/compile.js';
+import { PO_SCOPE_DETECTOR_PROGRAM } from '../src/programs/po-scope-detector.js';
+
+async function main(): Promise<number> {
+  const program = process.env['DSPY_PROGRAM'] ?? PO_SCOPE_DETECTOR_PROGRAM;
+  try {
+    const verdict = await runDailyCompile({ program });
+    process.stdout.write(`${renderVerdictLine(verdict)}\n`);
+    if (!verdict.promoted && verdict.delta !== null && verdict.delta < 0) {
+      process.stderr.write(
+        `[dspy] rollback — keeping prev CURRENT (delta=${verdict.delta.toFixed(3)})\n`,
+      );
+    }
+    return 0;
+  } catch (err) {
+    process.stderr.write(
+      `[dspy] daily compile failed: ${(err as Error).message}\n` +
+        `${(err as Error).stack ?? ''}\n`,
+    );
+    return 2;
+  }
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`[dspy] uncaught: ${String(err)}\n`);
+    process.exit(2);
+  },
+);

--- a/packages/dspy-bridge/src/compile.ts
+++ b/packages/dspy-bridge/src/compile.ts
@@ -1,0 +1,203 @@
+/**
+ * Daily compile orchestration — Node side.
+ *
+ * Pulls last-24h traces (PR3), persists trainset + evalset JSONL,
+ * fires `bridge.compile()`, then evaluates the delta gate:
+ *
+ *     delta ≥ 0  →  promote (rewrite CURRENT pointer)
+ *     delta < 0  →  rollback (leave CURRENT untouched, log + alert)
+ *
+ * The actual MIPROv2 work and the per-row scoring runs in Python — this
+ * module is the policy layer (gate, promote, audit log, retention).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { DspyBridge } from './bridge.js';
+import { defaultTraceRoot } from './traces.js';
+import { buildTrainset, writeTrainsetJsonl, type TrainsetRow } from './trainset.js';
+import {
+  fixturesToEvalsetRows,
+  PHASE2E_002_FIXTURES,
+} from './evalsets/po-scope-detector-phase2e002.js';
+import { PO_SCOPE_DETECTOR_PROGRAM } from './programs/po-scope-detector.js';
+
+export interface DailyCompileOptions {
+  /** Program to compile. Default: 'po-scope-detector'. */
+  program?: string;
+  /** Override trace root (test seam). */
+  traceRoot?: string;
+  /** Compiled-program root. Default: ~/.caia/dspy/compiled. */
+  compiledRoot?: string;
+  /**
+   * Override the eval set rows. Default: PHASE2E-002 fixtures.
+   * Supplying a custom set is allowed for back-compat with future
+   * proposals; the runbook documents PHASE2E-002 as the authoritative
+   * gate set.
+   */
+  evalsetRows?: readonly TrainsetRow[];
+  /** Pre-instantiated bridge. Default: new DspyBridge({}). */
+  bridge?: DspyBridge;
+  /** Skip start/stop on the bridge (caller manages the lifecycle). */
+  externallyManagedBridge?: boolean;
+  /**
+   * Promote-or-rollback policy. Default: delta >= 0 promotes.
+   *
+   * Returning `false` keeps the previous CURRENT pointer; returning
+   * `true` rewrites it to the new version.
+   */
+  promotePolicy?: (verdict: CompileVerdict) => boolean;
+  /** Test-seam wall-clock provider. */
+  nowMs?: () => number;
+}
+
+export interface CompileVerdict {
+  program: string;
+  /** Version that was just compiled (e.g. 'v3'). */
+  newVersion: string;
+  /** Path to the new pickle on disk. */
+  newPickle: string;
+  /** Score of the new program on the eval set (0..1+ tie bonus). */
+  newScore: number;
+  /** Score of the previous CURRENT on the same eval set. */
+  prevScore: number | null;
+  /** newScore - prevScore (or null on first compile). */
+  delta: number | null;
+  /**
+   * Whether the policy promoted the new version. true = CURRENT
+   * pointer rewritten; false = no-op.
+   */
+  promoted: boolean;
+  /** Trainset row count fed to MIPROv2. */
+  trainsetSize: number;
+  /** ISO-8601 timestamp the run completed. */
+  finishedAtIso: string;
+}
+
+/**
+ * Run a daily compile end-to-end. Returns the verdict.
+ *
+ * Flow:
+ *   1. start() the bridge (unless externally-managed)
+ *   2. build trainset.jsonl from the last 24h of traces
+ *   3. write evalset.jsonl from PHASE2E-002 fixtures
+ *   4. call bridge.compile() — Python runs MIPROv2 + scores
+ *   5. read the score, compute delta
+ *   6. apply promote/rollback policy
+ *   7. write an audit-log row to ~/.caia/dspy/compiles.log
+ */
+export async function runDailyCompile(
+  options: DailyCompileOptions = {},
+): Promise<CompileVerdict> {
+  const program = options.program ?? PO_SCOPE_DETECTOR_PROGRAM;
+  const compiledRoot =
+    options.compiledRoot ??
+    path.join(os.homedir(), '.caia', 'dspy', 'compiled');
+  const programDir = path.join(compiledRoot, program);
+  fs.mkdirSync(programDir, { recursive: true });
+
+  const traceRoot = options.traceRoot ?? defaultTraceRoot();
+  const now = options.nowMs?.() ?? Date.now();
+  const sinceIso = new Date(now - 24 * 3_600_000).toISOString();
+  const untilIso = new Date(now).toISOString();
+
+  // 2. Trainset.
+  const trainsetRows = buildTrainset({
+    program,
+    sinceIso,
+    untilIso,
+    traceRoot,
+  });
+  const trainsetPath = path.join(programDir, 'trainset.jsonl');
+  writeTrainsetJsonl(trainsetRows, trainsetPath);
+
+  // 3. Evalset.
+  const evalRows = options.evalsetRows ?? fixturesToEvalsetRows();
+  const evalsetPath = path.join(programDir, 'evalset.jsonl');
+  writeTrainsetJsonl(evalRows, evalsetPath);
+
+  // 4. Compile via the bridge.
+  const bridge = options.bridge ?? new DspyBridge();
+  if (!options.externallyManagedBridge) {
+    await bridge.start();
+  }
+  let compileResult;
+  try {
+    compileResult = await bridge.compile({
+      program,
+      optimizer: 'miprov2',
+      trainsetPath,
+      evalsetPath,
+      outDir: programDir,
+    });
+  } finally {
+    if (!options.externallyManagedBridge) {
+      await bridge.stop().catch(() => undefined);
+    }
+  }
+
+  // 5/6. Delta gate.
+  const policy = options.promotePolicy ?? defaultPromotePolicy;
+  const verdict: CompileVerdict = {
+    program,
+    newVersion: compileResult.version,
+    newPickle: compileResult.pickle,
+    newScore: compileResult.newScore,
+    prevScore: compileResult.prevScore,
+    delta: compileResult.delta,
+    promoted: false,
+    trainsetSize: trainsetRows.length,
+    finishedAtIso: new Date(options.nowMs?.() ?? Date.now()).toISOString(),
+  };
+  const shouldPromote = policy(verdict);
+  if (shouldPromote) {
+    fs.writeFileSync(
+      path.join(programDir, 'CURRENT'),
+      `${compileResult.version}\n`,
+      'utf8',
+    );
+    verdict.promoted = true;
+  }
+
+  // 7. Audit-log line.
+  const logPath = path.join(compiledRoot, 'compiles.log');
+  fs.appendFileSync(
+    logPath,
+    `${JSON.stringify(verdict)}\n`,
+    { encoding: 'utf8' },
+  );
+
+  return verdict;
+}
+
+/**
+ * Default policy — promote when delta >= 0 (or no previous version).
+ *
+ * On first compile (prevScore === null), `delta` is null. We promote so
+ * the CURRENT pointer goes from "(none) -> v1" — otherwise the next
+ * runtime predict() falls through to the uncompiled module forever.
+ */
+export function defaultPromotePolicy(verdict: CompileVerdict): boolean {
+  if (verdict.delta === null) return true;
+  return verdict.delta >= 0;
+}
+
+/**
+ * Convenience for the cron CLI — render the verdict as a one-line
+ * sparkline used by the runbook + dashboard.
+ */
+export function renderVerdictLine(verdict: CompileVerdict): string {
+  const prev = verdict.prevScore === null ? '—' : verdict.prevScore.toFixed(3);
+  const next = verdict.newScore.toFixed(3);
+  const delta = verdict.delta === null ? '—' : (verdict.delta >= 0 ? '+' : '') + verdict.delta.toFixed(3);
+  const verb = verdict.promoted ? 'promoted' : 'rolled-back';
+  return (
+    `[dspy:${verdict.program}] ${verb} ${verdict.newVersion} ` +
+    `(prev=${prev} next=${next} Δ=${delta} train=${String(verdict.trainsetSize)})`
+  );
+}
+
+/** Re-export the eval set size as a constant the runbook can quote. */
+export const EVALSET_SIZE = PHASE2E_002_FIXTURES.length;

--- a/packages/dspy-bridge/tests/compile.test.ts
+++ b/packages/dspy-bridge/tests/compile.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { recordTrace } from '../src/traces.js';
+import {
+  defaultPromotePolicy,
+  renderVerdictLine,
+  runDailyCompile,
+  type CompileVerdict,
+} from '../src/compile.js';
+import type { DspyBridge } from '../src/bridge.js';
+import type { CompileResult } from '../src/protocol.js';
+
+function fakeBridgeYielding(result: CompileResult): {
+  bridge: DspyBridge;
+  startSpy: ReturnType<typeof vi.fn>;
+  stopSpy: ReturnType<typeof vi.fn>;
+  compileSpy: ReturnType<typeof vi.fn>;
+} {
+  const startSpy = vi.fn(async () => undefined);
+  const stopSpy = vi.fn(async () => undefined);
+  const compileSpy = vi.fn(async () => result);
+  const bridge = {
+    start: startSpy,
+    stop: stopSpy,
+    compile: compileSpy,
+  } as unknown as DspyBridge;
+  return { bridge, startSpy, stopSpy, compileSpy };
+}
+
+describe('runDailyCompile', () => {
+  let traceRoot: string;
+  let compiledRoot: string;
+  beforeEach(() => {
+    traceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-trace-'));
+    compiledRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dspy-compiled-'));
+  });
+  afterEach(() => {
+    fs.rmSync(traceRoot, { recursive: true, force: true });
+    fs.rmSync(compiledRoot, { recursive: true, force: true });
+  });
+
+  function tap(promptText: string, scope: string, isoTs: string) {
+    recordTrace(
+      'po-scope-detector',
+      {
+        version: 'uncompiled',
+        input: { promptText },
+        output: { targetScope: scope, confidence: 0.85, rationale: 'stub' },
+        ok: true,
+        model: 'qwen2.5-coder:7b',
+        durationMs: 17,
+      },
+      { root: traceRoot, nowDateIso: () => isoTs },
+    );
+  }
+
+  it('promotes on first compile (delta=null)', async () => {
+    const nowIso = '2026-04-30T18:00:00.000Z';
+    const nowMs = Date.parse(nowIso);
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    tap('refactor the auth module', 'task', '2026-04-30T09:00:00.000Z');
+
+    const { bridge, compileSpy } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: path.join(compiledRoot, 'po-scope-detector', 'po-scope-detector-v1.pkl'),
+      version: 'v1',
+      newScore: 0.71,
+      prevScore: null,
+      delta: null,
+    });
+
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => nowMs,
+    });
+
+    expect(verdict.promoted).toBe(true);
+    expect(verdict.newVersion).toBe('v1');
+    expect(verdict.delta).toBeNull();
+    expect(compileSpy).toHaveBeenCalledOnce();
+    expect(fs.readFileSync(
+      path.join(compiledRoot, 'po-scope-detector', 'CURRENT'), 'utf8',
+    ).trim()).toBe('v1');
+  });
+
+  it('promotes when delta >= 0', async () => {
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: path.join(compiledRoot, 'po-scope-detector', 'po-scope-detector-v3.pkl'),
+      version: 'v3',
+      newScore: 0.78,
+      prevScore: 0.74,
+      delta: 0.04,
+    });
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    expect(verdict.promoted).toBe(true);
+    expect(verdict.delta).toBeCloseTo(0.04);
+    expect(fs.readFileSync(
+      path.join(compiledRoot, 'po-scope-detector', 'CURRENT'), 'utf8',
+    ).trim()).toBe('v3');
+  });
+
+  it('rolls back when delta < 0', async () => {
+    tap('add a logout button', 'story', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: path.join(compiledRoot, 'po-scope-detector', 'po-scope-detector-v4.pkl'),
+      version: 'v4',
+      newScore: 0.65,
+      prevScore: 0.74,
+      delta: -0.09,
+    });
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    expect(verdict.promoted).toBe(false);
+    expect(verdict.delta).toBeCloseTo(-0.09);
+    // CURRENT must NOT exist (no prior promote in this test, and we
+    // didn't promote this one either).
+    const cur = path.join(compiledRoot, 'po-scope-detector', 'CURRENT');
+    expect(fs.existsSync(cur)).toBe(false);
+  });
+
+  it('writes a JSONL audit-log row to compiles.log', async () => {
+    tap('any', 'task', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: 'p',
+      version: 'v1',
+      newScore: 0.5,
+      prevScore: null,
+      delta: null,
+    });
+    await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    const log = fs.readFileSync(path.join(compiledRoot, 'compiles.log'), 'utf8');
+    const lines = log.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] as string)).toMatchObject({
+      program: 'po-scope-detector',
+      newVersion: 'v1',
+      promoted: true,
+    });
+  });
+
+  it('respects a custom promotePolicy', async () => {
+    tap('any', 'task', '2026-04-30T08:00:00.000Z');
+    const { bridge } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: 'p',
+      version: 'v2',
+      newScore: 0.99,
+      prevScore: 0.5,
+      delta: 0.49,
+    });
+    const verdict = await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+      // refuse promotion no matter what
+      promotePolicy: () => false,
+    });
+    expect(verdict.promoted).toBe(false);
+  });
+
+  it('honours externallyManagedBridge — never start/stop the bridge', async () => {
+    tap('any', 'task', '2026-04-30T08:00:00.000Z');
+    const { bridge, startSpy, stopSpy } = fakeBridgeYielding({
+      program: 'po-scope-detector',
+      pickle: 'p',
+      version: 'v1',
+      newScore: 0.5,
+      prevScore: null,
+      delta: null,
+    });
+    await runDailyCompile({
+      bridge,
+      traceRoot,
+      compiledRoot,
+      externallyManagedBridge: true,
+      nowMs: () => Date.parse('2026-04-30T18:00:00.000Z'),
+    });
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('defaultPromotePolicy', () => {
+  it('promotes on first compile', () => {
+    expect(
+      defaultPromotePolicy({ delta: null } as CompileVerdict),
+    ).toBe(true);
+  });
+  it('promotes when delta == 0', () => {
+    expect(
+      defaultPromotePolicy({ delta: 0 } as CompileVerdict),
+    ).toBe(true);
+  });
+  it('promotes when delta > 0', () => {
+    expect(
+      defaultPromotePolicy({ delta: 0.0001 } as CompileVerdict),
+    ).toBe(true);
+  });
+  it('rolls back when delta < 0', () => {
+    expect(
+      defaultPromotePolicy({ delta: -0.0001 } as CompileVerdict),
+    ).toBe(false);
+  });
+});
+
+describe('renderVerdictLine', () => {
+  it('prints first-compile line', () => {
+    const line = renderVerdictLine({
+      program: 'po-scope-detector',
+      newVersion: 'v1',
+      newPickle: 'p',
+      newScore: 0.71,
+      prevScore: null,
+      delta: null,
+      promoted: true,
+      trainsetSize: 14,
+      finishedAtIso: '2026-04-30T18:00:00.000Z',
+    });
+    expect(line).toContain('promoted v1');
+    expect(line).toContain('Δ=—');
+    expect(line).toContain('next=0.710');
+    expect(line).toContain('train=14');
+  });
+  it('prints rollback line', () => {
+    const line = renderVerdictLine({
+      program: 'po-scope-detector',
+      newVersion: 'v4',
+      newPickle: 'p',
+      newScore: 0.65,
+      prevScore: 0.74,
+      delta: -0.09,
+      promoted: false,
+      trainsetSize: 23,
+      finishedAtIso: '2026-04-30T18:00:00.000Z',
+    });
+    expect(line).toContain('rolled-back');
+    expect(line).toContain('Δ=-0.090');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
 
   packages/decomposer-recursive:
     dependencies:
+      '@chiefaia/dspy-bridge':
+        specifier: workspace:*
+        version: link:../dspy-bridge
       '@chiefaia/local-llm-router':
         specifier: workspace:*
         version: link:../local-llm-router


### PR DESCRIPTION
## Why bundled

This PR reconstitutes the dspy-004, dspy-005, and dspy-006 work that was lost when the original stacked-PR chain (#274 → #275 → #276 → #277) collapsed.

When PR #273 squash-merged dspy-002 (with dspy-003 already merged into its branch) directly to `develop`, the parent of `feat/dspy-004-daily-compile-cron` became orphaned. PR #275 (dspy-004) and PR #277 (dspy-006) were closed without merging; PR #276 (dspy-005) merged into the dspy-004 branch which then never reached develop. The content survived on the source branches (the audit trail), but was never landed.

**The fix this time: ONE bundled PR with all three commits cherry-picked onto a fresh feature branch off latest develop.** A single non-stacked PR cannot be cascade-collapsed.

## Original PR fates

| PR    | Title                                                               | State                            |
|-------|---------------------------------------------------------------------|----------------------------------|
| #272  | feat(dspy-001): @chiefaia/dspy-bridge package                       | MERGED to develop (dd0279c)      |
| #273  | feat(dspy-002): wrap PO scope detector as a DSPy module             | MERGED to develop (22fdb1d, contains dspy-003 too) |
| #274  | feat(dspy-003): trace pipeline                                      | MERGED into feat/dspy-002 branch (rolled into #273 squash) |
| #275  | feat(dspy-004): MIPROv2 daily compile + delta gate                  | **CLOSED** (parent base deleted) |
| #276  | feat(dspy-005): orchestrator routes scope-detection through compiled DSPy | MERGED into feat/dspy-004 branch (which then never reached develop) |
| #277  | chore(dspy-006): runbook + memory                                   | **CLOSED** (parent base deleted) |

## Cherry-pick provenance

Source SHAs (each commit footer carries `(cherry picked from commit ...)` for full traceability):

| New SHA   | Source SHA  | Source branch                            | Subject                                             |
|-----------|-------------|------------------------------------------|-----------------------------------------------------|
| ac22709   | 38b8b96     | feat/dspy-004-daily-compile-cron         | feat(dspy-004): MIPROv2 daily compile + delta gate  |
| 0ab68ad   | cb0d620     | wip/prune-snapshot-feat-dspy-005-runtime-routing-2026-05-02 (and chore/dspy-006-runbook-docs) | feat(dspy-005): orchestrator routes scope-detection through compiled DSPy |
| 044f28a   | e2a2eba     | chore/dspy-006-runbook-docs              | chore(dspy-006): runbook + memory                   |

**Original source branches are NOT deleted** — they remain on origin as the historical audit trail.

## Conflicts

**Zero.** All three cherry-picks applied cleanly. The original commits were authored against `feat/dspy-003-trace-pipeline`, whose content is now in develop via the PR #273 squash. The deltas touch a disjoint set of files relative to recent develop work (graphrag-001, smart-cicd-001, obs-* series).

## Local test results

| Suite                                                    | Result   | Notes                                                                |
|----------------------------------------------------------|----------|----------------------------------------------------------------------|
| `pnpm install`                                           | OK       | One workspace dep added (decomposer-recursive → @chiefaia/dspy-bridge) |
| `pnpm build`                                             | PASS     | 40/40 tasks                                                          |
| `pnpm typecheck`                                         | PASS     | 51/51 tasks                                                          |
| `pnpm --filter @chiefaia/dspy-bridge test`               | PASS     | 38/38 (incl. 12 new `compile.test.ts` cases from dspy-004)           |
| `pnpm --filter @chiefaia/decomposer-recursive test`      | PASS     | 108/108 (incl. 8 new `dspy-runtime.test.ts` cases from dspy-005)     |
| `pnpm test:regression`                                   | FAIL (pre-existing) | 9 failed suites / 28 failed tests in `apps/orchestrator/tests/e2e/`. **Verified to reproduce identically on `origin/develop` with no DSPy changes** — this is a drizzle-orm `migrate()` SQLite multi-statement issue in the e2e harness (`apps/orchestrator/tests/e2e/_helpers/db.ts`), not introduced by this PR. Should be tracked as its own ticket. |

## What this enables

DSPy substrate fully landed on develop:

- **dspy-001/002/003**: bridge + module + trace pipeline (already on develop)
- **dspy-004**: MIPROv2 daily compile + delta gate + promote/rollback
- **dspy-005**: orchestrator routes scope-detection through compiled DSPy
- **dspy-006**: runbook + memory

This unblocks:
- Optimizer storage (next gate)
- LoRA training feedback loop (the §7 closed loop is now end-to-end: production → traces → trainset → compile → promote → production)

## Hard constraints honoured

- No API key reads (DSPy bridge inherits a scrubbed env)
- No daemon restart (cron is a separate LaunchAgent)
- Local-first (compile runs through bridge → Ollama LM)
- Python pinned via `uv` (no system pollution)
- Reversible runtime kill switch: `rm ~/.caia/dspy/runtime/po-scope-detector.enabled`

## References

- `feedback_no_api_key_billing.md`
- `~/Documents/projects/reports/full-state-audit-2026-05-01.md`
- `~/Documents/projects/reports/dspy-reconstitution-decisions-2026-05-03.md`
- AI tech modernization proposal §6 substrate pick #1, §7 feedback loop

Refs #275 #276 #277.
