### PR TITLE
fix(orchestrator-migration): add Drizzle statement-breakpoints to 0052_smart_cicd_observations

### DIFF
--- a/apps/orchestrator/src/db/migrations/0052_smart_cicd_observations.sql
+++ b/apps/orchestrator/src/db/migrations/0052_smart_cicd_observations.sql
@@ -23,7 +23,9 @@ CREATE TABLE IF NOT EXISTS smart_cicd_observations (
   feedback_label TEXT,
   created_at INTEGER NOT NULL
 );
-
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS smart_cicd_obs_date ON smart_cicd_observations(observation_date);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS smart_cicd_obs_action_kind ON smart_cicd_observations(proposed_action_kind);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS smart_cicd_obs_feedback ON smart_cicd_observations(feedback_label);


### PR DESCRIPTION
## Root cause

Migration `0052_smart_cicd_observations.sql` (introduced 2026-05-01 by smart-cicd-001 PR1, #278) was authored as a single SQL chunk containing 4 statements (1 `CREATE TABLE` + 3 `CREATE INDEX`). The matching journal entry (`meta/_journal.json` idx 41) declares `breakpoints: true` — but the file itself contains **no** `--> statement-breakpoint` markers.

Drizzle's better-sqlite3 migrator splits each entry on `--> statement-breakpoint` and runs each chunk through better-sqlite3's `prepare()`, which **only accepts a single statement per call**. With no breakpoints in the file, drizzle hands the whole 4-statement blob to `prepare()` and gets:

```
RangeError: The supplied SQL string contains more than one statement
```

This silently broke **Pipeline-E2E (`tests/e2e/pipeline`)** and **Per-agent regression (`tests/e2e/agents`)** on develop on 2026-05-01 immediately after #278 landed (run 25228996410). Every subsequent PR that runs those suites — including #285 (Steward kickoff) — has been carrying the same red signal.

## Fix

Insert `--> statement-breakpoint` between the four statements, matching the pattern used in every other multi-statement migration (e.g. `0040_spend_caps.sql`).

- No schema change.
- No journal change required (idx 41 already says `breakpoints: true`).
- 4 chunks × 1 statement each, all parseable.

## Verification

Repro'd locally against the orchestrator's installed `drizzle-orm@better-sqlite3` + `better-sqlite3`:

| State | Result |
|---|---|
| Pre-fix | `RangeError: The supplied SQL string contains more than one statement` |
| Post-fix | `OK: migrations ran clean` — table + 3 indices created |

## Impact

Unblocks the develop CI suite (Pipeline regression workflow). Other Evidence-Gate failures (semgrep blocking-findings, axe a11y, lighthouse a11y, visual baselines) are independent and will be addressed in follow-up PRs.

## Linked

- Root cause: #278 (smart-cicd-001 PR1)
- Unblocks: #285 (Steward kickoff)
- Unblocks: stacked PR queue inheriting red CI on develop