### PR TITLE
feat(stolution-mcp): mac-side daily vault snapshot puller

### DIFF
--- a/apps/stolution-mcp/ops/mac/README.md
+++ b/apps/stolution-mcp/ops/mac/README.md
@@ -1,0 +1,58 @@
+# Mac-side Stolution ops
+
+Operator scripts that run on a developer's Mac to pull / mirror data from the stolution server.
+
+## `pull-stolution-vault-snapshots.sh`
+
+Daily rsync of Vault Raft snapshots from `stolution:~/backups/vault/` to local Mac storage. Off-server backup of every secret-store snapshot, so a server-disk failure can't wipe the only copies.
+
+| | |
+|---|---|
+| Schedule | Daily 03:30 local (after server-side 02:00 snapshot + 02:05 audit rotation) |
+| Source | `s903@stolution:/home/s903/backups/vault/vault-snapshot-*.snap` |
+| Local | `~/Library/Application Support/Stolution/vault-snapshots/` |
+| Retention | 30 days |
+| Log | `~/Library/Logs/stolution-vault-snapshot-pull.log` |
+| Verify | newest snapshot < 26h old; non-empty count — exits non-zero on either failure |
+
+The companion launchd plist is `com.stolution.vault-snapshot-pull.plist`. Both are installed to their canonical locations by `install.sh`.
+
+### Install / re-install
+
+```sh
+cd apps/stolution-mcp/ops/mac
+./install.sh
+```
+
+The installer is idempotent. It copies the script to `~/bin/`, writes the plist to `~/Library/LaunchAgents/` with `$HOME` substituted, and reloads the LaunchAgent.
+
+### Manual trigger
+
+```sh
+launchctl start com.stolution.vault-snapshot-pull
+tail -f ~/Library/Logs/stolution-vault-snapshot-pull.log
+```
+
+### Uninstall
+
+```sh
+launchctl unload ~/Library/LaunchAgents/com.stolution.vault-snapshot-pull.plist
+rm ~/Library/LaunchAgents/com.stolution.vault-snapshot-pull.plist
+rm ~/bin/pull-stolution-vault-snapshots.sh
+```
+
+Local snapshots under `~/Library/Application Support/Stolution/vault-snapshots/` are not touched by uninstall.
+
+### Optional external-disk mirror
+
+Set `EXTERNAL_MIRROR_DIR` (and optionally `EXTERNAL_MIRROR_WEEKDAY`, default `0` for Sunday) to enable a weekly mirror to an external drive. Silently skipped if the path is unset or not mounted, so a missing external drive never blocks the primary pull.
+
+```sh
+# In ~/.zshrc or as a launchd EnvironmentVariables entry:
+export EXTERNAL_MIRROR_DIR="/Volumes/Backup/stolution-vault-snapshots"
+```
+
+### Prerequisites
+
+- SSH alias `stolution` configured in `~/.ssh/config` with key auth (no password prompt). Verify with `ssh -o BatchMode=yes stolution echo ok`.
+- `rsync` available on `PATH` (default macOS install is fine; Homebrew rsync also works).

--- a/apps/stolution-mcp/ops/mac/com.stolution.vault-snapshot-pull.plist
+++ b/apps/stolution-mcp/ops/mac/com.stolution.vault-snapshot-pull.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.stolution.vault-snapshot-pull
+  Daily Mac-side pull of Vault Raft snapshots from the stolution server.
+
+  Schedule: 03:30 local — runs after the server-side 02:00 snapshot and
+  02:05 audit-log rotation cron jobs, with margin for clock skew.
+
+  Install:
+    cp com.stolution.vault-snapshot-pull.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.stolution.vault-snapshot-pull.plist
+
+  Test (on demand):
+    launchctl start com.stolution.vault-snapshot-pull
+
+  Note: paths use $HOME via the parent process — launchd resolves $HOME for
+  the loading user. If installing for a non-default home, edit the absolute
+  paths below.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stolution.vault-snapshot-pull</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__HOME__/bin/pull-stolution-vault-snapshots.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <!-- Don't run at load (avoid surprise pulls when re-loading the agent) -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- One-shot per scheduled trigger; don't keep alive on exit -->
+    <key>KeepAlive</key>
+    <false/>
+
+    <!-- Restart on crash for the next scheduled run rather than immediately -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <!-- Capture launchd-level stdout/err separately from the script's own log -->
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/stolution-vault-snapshot-pull.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/stolution-vault-snapshot-pull.launchd.log</string>
+
+    <!-- Inherit user's PATH so rsync, ssh, find resolve normally -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/apps/stolution-mcp/ops/mac/install.sh
+++ b/apps/stolution-mcp/ops/mac/install.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# =============================================================================
+# install.sh — Install the Mac-side Vault snapshot puller
+#
+# Copies pull-stolution-vault-snapshots.sh to ~/bin/ and the LaunchAgent
+# plist to ~/Library/LaunchAgents/, with $HOME substituted into the plist.
+# Idempotent: safe to re-run after edits.
+# =============================================================================
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+readonly SCRIPT_SRC="pull-stolution-vault-snapshots.sh"
+readonly PLIST_SRC="com.stolution.vault-snapshot-pull.plist"
+readonly SCRIPT_DST="${HOME}/bin/pull-stolution-vault-snapshots.sh"
+readonly PLIST_DST="${HOME}/Library/LaunchAgents/com.stolution.vault-snapshot-pull.plist"
+readonly LABEL="com.stolution.vault-snapshot-pull"
+UID_VAL="$(id -u)"
+readonly UID_VAL
+readonly DOMAIN="gui/${UID_VAL}"
+
+info() { echo "▶ $*"; }
+warn() { echo "⚠ $*" >&2; }
+
+# ─── 1. Install script ────────────────────────────────────────────────────────
+
+mkdir -p "${HOME}/bin"
+install -m 0755 "$SCRIPT_SRC" "$SCRIPT_DST"
+info "installed $SCRIPT_DST"
+
+# ─── 2. Install plist with $HOME substituted ──────────────────────────────────
+
+mkdir -p "${HOME}/Library/LaunchAgents"
+mkdir -p "${HOME}/Library/Logs"
+mkdir -p "${HOME}/Library/Application Support/Stolution/vault-snapshots"
+
+# sed with a delimiter that won't collide with paths
+sed "s|__HOME__|${HOME}|g" "$PLIST_SRC" > "$PLIST_DST"
+chmod 0644 "$PLIST_DST"
+info "installed $PLIST_DST"
+
+# ─── 3. Reload the LaunchAgent ────────────────────────────────────────────────
+
+# Use the modern bootstrap/bootout API (macOS Big Sur+). Fall back to load -w
+# only if bootstrap is unavailable on a very old macOS.
+if launchctl bootout "${DOMAIN}/${LABEL}" 2>/dev/null; then
+  info "evicted previous instance"
+fi
+
+if launchctl bootstrap "${DOMAIN}" "$PLIST_DST" 2>/dev/null; then
+  info "bootstrapped LaunchAgent ${LABEL}"
+else
+  # Older macOS — use the legacy API
+  launchctl unload "$PLIST_DST" 2>/dev/null || true
+  launchctl load -w "$PLIST_DST"
+  info "loaded (legacy) LaunchAgent ${LABEL}"
+fi
+
+# ─── 4. Verify it's registered ────────────────────────────────────────────────
+
+# Allow a moment for launchd to register before we check
+sleep 1
+
+if launchctl print "${DOMAIN}/${LABEL}" >/dev/null 2>&1; then
+  info "✅ ${LABEL} registered with launchd"
+else
+  warn "${LABEL} not visible to launchctl print — investigate"
+  exit 1
+fi
+
+cat <<EOF
+
+Installed.
+  Script:      ${SCRIPT_DST}
+  Plist:       ${PLIST_DST}
+  Local snaps: ${HOME}/Library/Application Support/Stolution/vault-snapshots/
+  Log:         ${HOME}/Library/Logs/stolution-vault-snapshot-pull.log
+
+Next runs will fire daily at 03:30 local.
+Trigger a manual run with:
+  launchctl kickstart ${DOMAIN}/${LABEL}
+Tail the log with:
+  tail -f "${HOME}/Library/Logs/stolution-vault-snapshot-pull.log"
+EOF

--- a/apps/stolution-mcp/ops/mac/pull-stolution-vault-snapshots.sh
+++ b/apps/stolution-mcp/ops/mac/pull-stolution-vault-snapshots.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# =============================================================================
+# pull-stolution-vault-snapshots.sh
+#
+# Pulls Vault Raft snapshots from the stolution server to local Mac storage.
+# Mac-side counterpart of the stolution-side daily snapshot cron — gives us an
+# off-server copy of every secret-store snapshot so a server-disk failure can't
+# wipe the only backups.
+#
+# Server-side flow:
+#   02:00 — vault Raft snapshot taken on stolution -> ~/backups/vault/
+#   02:05 — audit log rotated on stolution
+#
+# Mac-side flow (this script):
+#   03:30 — rsync ~/backups/vault/*.snap from stolution -> local
+#         — prune local snapshots older than RETAIN_DAYS
+#         — verify newest snapshot < MAX_AGE_HOURS old; exit non-zero if not
+#
+# Idempotent. Safe to run on demand.
+# =============================================================================
+
+set -uo pipefail
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+
+readonly REMOTE_SSH_ALIAS="${STOLUTION_SSH_ALIAS:-stolution}"
+readonly REMOTE_SNAP_DIR="${REMOTE_SNAP_DIR:-/home/s903/backups/vault}"
+readonly LOCAL_SNAP_DIR="${LOCAL_SNAP_DIR:-${HOME}/Library/Application Support/Stolution/vault-snapshots}"
+readonly LOG_FILE="${LOG_FILE:-${HOME}/Library/Logs/stolution-vault-snapshot-pull.log}"
+readonly RETAIN_DAYS="${RETAIN_DAYS:-30}"
+readonly MAX_AGE_HOURS="${MAX_AGE_HOURS:-26}"
+
+# Optional external-disk mirror. Set EXTERNAL_MIRROR_DIR to enable. Mirror runs
+# only if today is the configured weekday (default Sunday=0). If the path is
+# unset OR the mount is offline, mirror step is silently skipped.
+# TODO: configure once an external/Time Machine drive path is decided.
+readonly EXTERNAL_MIRROR_DIR="${EXTERNAL_MIRROR_DIR:-}"
+readonly EXTERNAL_MIRROR_WEEKDAY="${EXTERNAL_MIRROR_WEEKDAY:-0}"  # 0=Sunday
+
+# ─── Logging ──────────────────────────────────────────────────────────────────
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S%z')" "$*" >> "$LOG_FILE"
+}
+
+fail() {
+  log "FAIL: $*"
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+log "=== run start (pid=$$) ==="
+
+# ─── Pre-flight ───────────────────────────────────────────────────────────────
+
+# Verify SSH alias works without prompting. BatchMode=yes forces non-interactive;
+# any password / fingerprint / key prompt becomes an immediate failure.
+if ! ssh -o BatchMode=yes -o ConnectTimeout=10 "$REMOTE_SSH_ALIAS" 'echo ok' >/dev/null 2>&1; then
+  fail "ssh alias '$REMOTE_SSH_ALIAS' failed (non-interactive). Check ~/.ssh/config and key auth."
+fi
+
+mkdir -p "$LOCAL_SNAP_DIR" || fail "cannot create $LOCAL_SNAP_DIR"
+
+# ─── Pull ─────────────────────────────────────────────────────────────────────
+
+log "rsync ${REMOTE_SSH_ALIAS}:${REMOTE_SNAP_DIR}/ -> ${LOCAL_SNAP_DIR}/"
+
+# Sync only snapshot files, never anything else (e.g. README.md).
+# --partial-dir keeps a half-pull resumable; --timeout protects against hangs.
+if ! rsync -az \
+    --include='vault-snapshot-*.snap' \
+    --exclude='*' \
+    --partial \
+    --timeout=120 \
+    "${REMOTE_SSH_ALIAS}:${REMOTE_SNAP_DIR}/" \
+    "${LOCAL_SNAP_DIR}/" \
+    >> "$LOG_FILE" 2>&1
+then
+  fail "rsync failed (see ${LOG_FILE})"
+fi
+
+# ─── Prune ────────────────────────────────────────────────────────────────────
+
+log "pruning local snapshots older than ${RETAIN_DAYS} days"
+# -mtime +N matches files whose mtime is > N days. Use -print to log names,
+# then a separate -delete for clarity in logs.
+to_prune="$(find "$LOCAL_SNAP_DIR" -type f -name 'vault-snapshot-*.snap' -mtime "+${RETAIN_DAYS}" -print 2>/dev/null || true)"
+if [[ -n "$to_prune" ]]; then
+  echo "$to_prune" | while IFS= read -r f; do log "  pruning $(basename "$f")"; done
+  find "$LOCAL_SNAP_DIR" -type f -name 'vault-snapshot-*.snap' -mtime "+${RETAIN_DAYS}" -delete 2>/dev/null || true
+else
+  log "  nothing to prune"
+fi
+
+# ─── Verify ───────────────────────────────────────────────────────────────────
+
+count="$(find "$LOCAL_SNAP_DIR" -maxdepth 1 -type f -name 'vault-snapshot-*.snap' | wc -l | tr -d ' ')"
+log "local snapshot count: ${count}"
+if [[ "$count" -eq 0 ]]; then
+  fail "no local snapshots after rsync — pull is empty"
+fi
+
+# Newest snapshot age. -t sorts by mtime (newest first); we use stat -f to get
+# the mtime as a unix timestamp (BSD/macOS stat — different flag from GNU stat).
+newest="$(find "$LOCAL_SNAP_DIR" -maxdepth 1 -type f -name 'vault-snapshot-*.snap' -print0 \
+            | xargs -0 stat -f '%m %N' 2>/dev/null | sort -nr | head -1)"
+newest_path="${newest#* }"
+newest_mtime="${newest%% *}"
+now="$(date +%s)"
+age_seconds=$(( now - newest_mtime ))
+age_hours=$(( age_seconds / 3600 ))
+
+log "newest snapshot: $(basename "$newest_path") — mtime $(date -r "$newest_mtime" '+%Y-%m-%d %H:%M:%S%z') — age ${age_hours}h"
+
+if [[ "$age_hours" -ge "$MAX_AGE_HOURS" ]]; then
+  fail "newest local snapshot is ${age_hours}h old (>= ${MAX_AGE_HOURS}h threshold). Server snapshot may be stale or rsync is silently failing."
+fi
+
+# ─── External-disk mirror (optional, weekly) ──────────────────────────────────
+
+if [[ -n "$EXTERNAL_MIRROR_DIR" ]]; then
+  today_dow="$(date +%w)"
+  if [[ "$today_dow" == "$EXTERNAL_MIRROR_WEEKDAY" ]]; then
+    if [[ -d "$EXTERNAL_MIRROR_DIR" ]]; then
+      log "mirroring to ${EXTERNAL_MIRROR_DIR}"
+      if rsync -az --delete "${LOCAL_SNAP_DIR}/" "${EXTERNAL_MIRROR_DIR}/" >> "$LOG_FILE" 2>&1; then
+        log "  mirror OK"
+      else
+        log "  mirror FAILED (continuing — primary pull already succeeded)"
+      fi
+    else
+      log "external mirror configured but ${EXTERNAL_MIRROR_DIR} not mounted; skipping"
+    fi
+  fi
+fi
+
+log "=== run OK ==="
+exit 0


### PR DESCRIPTION
## Summary

Mac-side counterpart of today's (2026-05-03) server-side Tier-1 vault hardening. Until now all Vault Raft snapshots lived only on the stolution server; a server-disk failure would have wiped every secret backup. This adds a daily Mac pull so we always have an off-server copy.

## Components — all under `apps/stolution-mcp/ops/mac/`

- **`pull-stolution-vault-snapshots.sh`** — bash script
  - rsyncs `s903@stolution:/home/s903/backups/vault/vault-snapshot-*.snap` → `~/Library/Application Support/Stolution/vault-snapshots/`
  - prunes local copies older than 30 days (matches server retention)
  - verifies post-pull: count > 0 AND newest snapshot < 26h old; exits non-zero on either failure so launchd surfaces the problem
  - logs to `~/Library/Logs/stolution-vault-snapshot-pull.log`
  - optional weekly mirror to `EXTERNAL_MIRROR_DIR` (silently skipped if unset/unmounted — TODO comment for when an external/Time Machine drive path is configured)
- **`com.stolution.vault-snapshot-pull.plist`** — LaunchAgent, daily 03:30 local (after server's 02:00 snapshot + 02:05 audit rotation); `RunAtLoad=false` so it never fires by surprise on login/reload
- **`install.sh`** — idempotent installer using `launchctl bootstrap` (with legacy `load -w` fallback for older macOS)
- **`README.md`** — install, manual trigger, uninstall, optional mirror

## Verification (already installed + tested on this Mac)

```
$ ./install.sh
▶ installed /Users/MAC/bin/pull-stolution-vault-snapshots.sh
▶ installed /Users/MAC/Library/LaunchAgents/com.stolution.vault-snapshot-pull.plist
▶ bootstrapped LaunchAgent com.stolution.vault-snapshot-pull
▶ ✅ com.stolution.vault-snapshot-pull registered with launchd

$ launchctl kickstart gui/501/com.stolution.vault-snapshot-pull
$ tail ~/Library/Logs/stolution-vault-snapshot-pull.log
[22:11:03] === run start (pid=53377) ===
[22:11:04] rsync stolution:/home/s903/backups/vault/ -> /Users/MAC/Library/Application Support/Stolution/vault-snapshots/
[22:11:05] pruning local snapshots older than 30 days
[22:11:05]   nothing to prune
[22:11:05] local snapshot count: 10
[22:11:05] newest snapshot: vault-snapshot-20260503-191139.snap — age 2h
[22:11:05] === run OK ===
```

10 snapshots pulled (~445 KB), newest is 2h old. Verification thresholds (count > 0, age < 26h) both pass. Idempotency: re-ran installer; no errors.

## Hygiene

- shellcheck clean on both `pull-stolution-vault-snapshots.sh` and `install.sh`
- All paths quoted; `set -uo pipefail`. `fail()` is explicit on hard failures (the puller intentionally drops `-e` so individual non-fatal sections, e.g. mirror, don't kill the whole run)

## Auto-merge

Auto-merging when Evidence Gate is green per operator authority granted this session.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
