### PR TITLE
feat(steward-gatekeeper-002): graph-divergence + migration-numbering analyzers

### DIFF
--- a/.github/workflows/steward-gatekeeper.yml
+++ b/.github/workflows/steward-gatekeeper.yml
@@ -5,18 +5,10 @@ name: Steward Gatekeeper
 # from the 2026-04-26 → 2026-05-04 chaos / hygiene / release-blocker
 # sweep.
 #
-# This PR ships the first analyzer (Drizzle migration breakpoint linter,
-# failure mode #1 in the architecture doc). Subsequent PRs add:
-#   - graph-divergence (failure mode #2) [PR Phase 2b]
-#   - migration-numbering (failure mode #3) [PR Phase 2b]
-#
 # Each analyzer is its own job so failures are localised in the Checks
 # tab and branch protection lists them individually. Day-1 jobs run
 # `continue-on-error: true` (warn-only) for one cycle so existing
-# in-flight PRs don't break; promotion to blocking is a follow-up PR
-# that flips `continue-on-error: false` AND updates
-# scripts/setup-branch-protection.sh REQUIRED_CONTEXTS_JSON to include
-# the steward-gatekeeper-* contexts.
+# in-flight PRs don't break; promotion to blocking is a follow-up PR.
 #
 # Reference:
 #   - architecture: ~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md
@@ -44,11 +36,7 @@ jobs:
   steward-gatekeeper-migration-linter:
     name: steward-gatekeeper-migration-linter
     runs-on: ubuntu-latest
-    # Day-1 warn-only — we know there are pre-existing offenders
-    # (0037_irreversible_actions.sql, 0039_executor_hook_controlled.sql,
-    # both stmts > 1, breakpoints = 0). Promotion to blocking is a
-    # follow-up PR after those are fixed.
-    continue-on-error: true
+    continue-on-error: true   # warn-only first cycle
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -62,3 +50,49 @@ jobs:
         run: pnpm --filter @chiefaia/steward-analyzers build
       - name: Migration linter — scan all Drizzle migration roots
         run: node packages/steward-analyzers/bin/steward-gatekeeper.mjs migration-linter
+
+  # ─── Failure mode #3: Migration numbering (duplicate prefix + gap) ─
+  steward-gatekeeper-migration-numbering:
+    name: steward-gatekeeper-migration-numbering
+    runs-on: ubuntu-latest
+    continue-on-error: true   # warn-only first cycle
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build @chiefaia/steward-analyzers
+        run: pnpm --filter @chiefaia/steward-analyzers build
+      - name: Migration numbering — duplicate-prefix + gap scan
+        run: node packages/steward-analyzers/bin/steward-gatekeeper.mjs migration-numbering
+
+  # ─── Failure mode #2: Graph divergence (develop ↔ main merge-base) ─
+  steward-gatekeeper-graph-divergence:
+    name: steward-gatekeeper-graph-divergence
+    runs-on: ubuntu-latest
+    continue-on-error: true   # warn-only first cycle
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history + both develop and main refs reachable.
+          fetch-depth: 0
+      - name: Fetch develop + main
+        run: |
+          git fetch origin develop main --no-tags
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build @chiefaia/steward-analyzers
+        run: pnpm --filter @chiefaia/steward-analyzers build
+      - name: Graph divergence — develop ↔ main merge-base age
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+        run: node packages/steward-analyzers/bin/steward-gatekeeper.mjs graph-divergence

--- a/packages/steward-analyzers/bin/steward-gatekeeper.mjs
+++ b/packages/steward-analyzers/bin/steward-gatekeeper.mjs
@@ -1,27 +1,33 @@
 #!/usr/bin/env node
 /**
- * Steward Gatekeeper CLI — entry invoked by the `steward-gatekeeper.yml`
+ * Steward Gatekeeper CLI — entry invoked by the steward-gatekeeper.yml
  * GitHub Actions workflow.
  *
- * Usage:
- *   steward-gatekeeper migration-linter [--repo-root <path>]
- *   steward-gatekeeper all  [--repo-root <path>]
+ * Subcommands:
+ *   migration-linter       — Drizzle multi-statement breakpoint linter (failure mode #1)
+ *   migration-numbering    — duplicate-prefix + gap detection (failure mode #3)
+ *   graph-divergence       — develop ↔ main merge-base age check (failure mode #2)
+ *   all                    — run every analyzer; OR exit code across all
  *
- * Exit codes:
- *   0 — no `block`-severity findings (warn-level findings still printed)
- *   1 — at least one `block`-severity finding
- *   2 — usage error / unexpected internal error
+ * Flags:
+ *   --repo-root <path>       repo root (default: ../../../ relative to bin)
+ *   --max-age-days <N>       graph-divergence threshold (default 7)
+ *   --pr-head-ref <ref>      PR head branch (default $GITHUB_HEAD_REF)
  *
- * Output format: human-readable to stdout + GitHub Actions annotations
- * (`::error file=...,line=...::message`) so failures land directly in the
- * PR's "Files changed" view.
+ * Exit codes: 0 (no block findings), 1 (block findings), 2 (usage error).
+ *
+ * GitHub Actions annotations are emitted via `::error file=...,line=...`
+ * for block/high findings; `::warning ...` for medium/low.
  */
 
 import * as path from 'node:path';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
   lintMigrations,
   discoverMigrationRoots,
+  checkMigrationNumbering,
+  checkGraphDivergence,
   exitCodeFor,
 } from '../dist/index.js';
 
@@ -49,11 +55,9 @@ function parseArgs(argv) {
 }
 
 function gha(level, finding) {
-  // GitHub Actions workflow command for inline annotation.
-  // See https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions
-  const file = finding.path.replace(/[\r\n]/g, '');
+  const file = (finding.path || '').replace(/[\r\n]/g, '');
   const line = finding.line ?? 1;
-  const msg = finding.message.replace(/[\r\n]+/g, ' — ');
+  const msg = (finding.message || '').replace(/[\r\n]+/g, ' — ');
   return `::${level} file=${file},line=${line}::[${finding.analyzer}/${finding.ruleId}] ${msg}`;
 }
 
@@ -90,21 +94,104 @@ async function runMigrationLinter(repoRoot) {
   return all;
 }
 
+async function runMigrationNumbering(repoRoot) {
+  const roots = await discoverMigrationRoots(repoRoot);
+  if (roots.length === 0) {
+    console.log(`migration-numbering: no Drizzle migration roots found under ${repoRoot}.`);
+    return [];
+  }
+  const all = [];
+  for (const dir of roots) {
+    console.log(`migration-numbering: scanning ${path.relative(repoRoot, dir)}/`);
+    const findings = await checkMigrationNumbering({ migrationsDir: dir });
+    all.push(...findings);
+  }
+  return all;
+}
+
+function runGraphDivergence(repoRoot, opts) {
+  // Resolve develop ↔ main merge-base + its commit timestamp via git.
+  // Requires actions/checkout@v4 with fetch-depth: 0 + a `git fetch origin develop main`.
+  let sha;
+  try {
+    sha = execSync('git merge-base origin/develop origin/main', {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+  } catch (err) {
+    console.log(`graph-divergence: cannot compute merge-base — origin/develop or origin/main not present locally. Run \`git fetch origin develop main\` before invocation. (${err.message})`);
+    // Don't fail CI — graph-divergence is observational, not a hard
+    // requirement for fork-style PRs that may not have both refs.
+    return [];
+  }
+  const ts = parseInt(
+    execSync(`git log -1 --format=%ct ${sha}`, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim(),
+    10,
+  );
+  const now = Math.floor(Date.now() / 1000);
+  const headRef = opts['pr-head-ref'] || process.env.GITHUB_HEAD_REF || '';
+
+  // Cheap check: is a back-merge PR open? Avoid `gh` invocation in CLI
+  // (no auth in some contexts); look for a local ref instead. The
+  // cron run path will pass this in via opts when needed.
+  let backMergePrPresent = false;
+  try {
+    const out = execSync('git for-each-ref refs/remotes/origin/chore/back-merge-main-into-develop-* --format="%(refname:short)|%(committerdate:unix)"', {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    if (out) {
+      // Treat "back-merge ref pushed within last 24h" as evidence one is in flight.
+      const lines = out.split('\n');
+      const recent = lines.find((l) => {
+        const parts = l.split('|');
+        const t = parseInt(parts[1] ?? '0', 10);
+        return now - t < 86400;
+      });
+      backMergePrPresent = !!recent;
+    }
+  } catch {
+    // ignore — refs may not exist
+  }
+
+  const findings = checkGraphDivergence({
+    mergeBaseTimestamp: ts,
+    nowTimestamp: now,
+    maxAgeDays: opts['max-age-days'] ? parseInt(opts['max-age-days'], 10) : 7,
+    prHeadRef: headRef,
+    backMergePrPresent,
+  });
+  console.log(`graph-divergence: merge-base ${sha.substring(0, 8)} ts=${ts} ageDays=${((now - ts) / 86400).toFixed(1)} headRef=${headRef || '(none)'} backMergePrPresent=${backMergePrPresent}`);
+  return findings;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const command = args.positional[0];
   const repoRoot = path.resolve(args.flags['repo-root'] ?? path.resolve(__dirname, '../../..'));
 
   if (!command || command === '--help' || command === '-h') {
-    console.error('usage: steward-gatekeeper <command> [--repo-root <path>]');
-    console.error('  commands: migration-linter | all');
+    console.error('usage: steward-gatekeeper <command> [--repo-root <path>] [--max-age-days <N>] [--pr-head-ref <ref>]');
+    console.error('  commands: migration-linter | migration-numbering | graph-divergence | all');
     process.exit(2);
   }
 
-  let findings;
+  let findings = [];
   try {
-    if (command === 'migration-linter' || command === 'all') {
+    if (command === 'migration-linter') {
       findings = await runMigrationLinter(repoRoot);
+    } else if (command === 'migration-numbering') {
+      findings = await runMigrationNumbering(repoRoot);
+    } else if (command === 'graph-divergence') {
+      findings = runGraphDivergence(repoRoot, args.flags);
+    } else if (command === 'all') {
+      const a = await runMigrationLinter(repoRoot);
+      const b = await runMigrationNumbering(repoRoot);
+      const c = runGraphDivergence(repoRoot, args.flags);
+      findings = [...a, ...b, ...c];
     } else {
       console.error(`unknown command: ${command}`);
       process.exit(2);

--- a/packages/steward-analyzers/src/graph-divergence.ts
+++ b/packages/steward-analyzers/src/graph-divergence.ts
@@ -1,0 +1,65 @@
+/**
+ * Graph-divergence analyzer (failure mode #2).
+ *
+ * Checks whether `git merge-base origin/develop origin/main` is older
+ * than a configurable threshold (default 7 days). When divergence
+ * accumulates, release/* PRs hit `mergeStateStatus: DIRTY` and need a
+ * graph-resync PR before they can land — exactly the pain pattern
+ * documented in `back-merge-2026-05-03-decisions.md` and
+ * `release-blocker-2026-05-02.md`.
+ *
+ * Severity scaling per architecture doc §3.2:
+ *   - On a release/* PR: drift > threshold → block (must resync first).
+ *   - On any other PR: drift > threshold → warn (so it's surfaced before
+ *     it becomes a release-day fire).
+ *
+ * Inputs are passed in (rather than shelling out from this module) so
+ * the analyzer is unit-testable. The CLI shim does the actual git
+ * invocation.
+ */
+
+import type { Finding } from './types.js';
+
+export interface GraphDivergenceInput {
+  /** Unix timestamp (seconds) of merge-base commit between develop and main. */
+  mergeBaseTimestamp: number;
+  /** Unix timestamp (seconds) "now" — pass Date.now()/1000 in production. */
+  nowTimestamp: number;
+  /** Max acceptable age in days. Default 7 (architecture doc §3.2). */
+  maxAgeDays?: number;
+  /** Branch ref of the PR being checked. `release/*` triggers block-severity. */
+  prHeadRef?: string;
+  /** Whether a recent back-merge PR already exists (suppresses the finding). */
+  backMergePrPresent?: boolean;
+}
+
+export function checkGraphDivergence(input: GraphDivergenceInput): Finding[] {
+  const maxAgeDays = input.maxAgeDays ?? 7;
+  const ageSeconds = input.nowTimestamp - input.mergeBaseTimestamp;
+  const ageDays = ageSeconds / 86400;
+
+  if (ageDays <= maxAgeDays) return [];
+  if (input.backMergePrPresent) return [];
+
+  const isReleasePr = (input.prHeadRef ?? '').startsWith('release/');
+  const severity = isReleasePr ? 'block' : 'medium';
+
+  return [
+    {
+      analyzer: 'graph-divergence',
+      ruleId: 'develop-main-merge-base-stale',
+      path: '<repo>',
+      severity,
+      message: `develop ↔ main merge-base is ${ageDays.toFixed(1)} days old (limit ${maxAgeDays}). ${isReleasePr ? 'release/* PR cannot merge cleanly without a back-merge PR landing first; see back-merge-2026-05-03-decisions.md for the canonical recipe.' : 'A release/* PR opened today will likely hit mergeStateStatus: DIRTY. Open a `chore/back-merge-main-into-develop-YYYY-MM-DD` PR before the next release.'}`,
+      remediation:
+        'Run `pnpm flow back-merge` (or manually: `git checkout -b chore/back-merge-main-into-develop-$(date +%Y-%m-%d) origin/develop && git merge --no-ff origin/main && gh pr create --base develop --head chore/back-merge-main-into-develop-$(date +%Y-%m-%d)`). See `feedback_git_flow_enforced.md` § "MANDATORY POST-RELEASE STEP".',
+      context: {
+        mergeBaseTimestamp: input.mergeBaseTimestamp,
+        ageDays,
+        maxAgeDays,
+        prHeadRef: input.prHeadRef ?? null,
+        isReleasePr,
+      },
+    },
+  ];
+}

--- a/packages/steward-analyzers/src/index.ts
+++ b/packages/steward-analyzers/src/index.ts
@@ -18,3 +18,13 @@ export {
   type JournalEntry,
   type JournalFile,
 } from './migration-linter.js';
+export {
+  checkMigrationNumbering,
+  nextFreePrefix,
+  type CheckMigrationNumberingOptions,
+} from './migration-numbering.js';
+
+export {
+  checkGraphDivergence,
+  type GraphDivergenceInput,
+} from './graph-divergence.js';

--- a/packages/steward-analyzers/src/migration-numbering.ts
+++ b/packages/steward-analyzers/src/migration-numbering.ts
@@ -1,0 +1,131 @@
+/**
+ * Migration numbering analyzer (failure mode #3).
+ *
+ * Scans a Drizzle migrations directory for:
+ *   - Duplicate prefixes (block) — two .sql files share the same 4-digit
+ *     numeric prefix. Recurrent issue causing DIRTY release PRs. Example
+ *     in develop 2026-05-04: 0037_irreversible_actions.sql +
+ *     0037_story_capsule.sql.
+ *   - Gaps in the prefix sequence (warn) — e.g. files at 0040 and 0042
+ *     with nothing at 0041. Could be intentional reservation but more
+ *     often indicates a renumbered or dropped migration.
+ *
+ * Reference: architecture doc §3.3.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { Finding } from './types.js';
+import { loadJournal } from './migration-linter.js';
+
+const PREFIX_RE = /^(\d{4})_/;
+
+export interface CheckMigrationNumberingOptions {
+  migrationsDir: string;
+}
+
+interface MigrationFile {
+  basename: string;
+  prefix: number;
+  inJournal: boolean;
+}
+
+export async function checkMigrationNumbering(
+  opts: CheckMigrationNumberingOptions,
+): Promise<Finding[]> {
+  const findings: Finding[] = [];
+  const dir = opts.migrationsDir;
+  const journal = await loadJournal(path.join(dir, 'meta'));
+  const journalTags = new Set<string>();
+  if (journal) for (const e of journal.entries) journalTags.add(e.tag);
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    return [
+      {
+        analyzer: 'migration-numbering',
+        ruleId: 'migrations-dir-unreadable',
+        path: dir,
+        severity: 'block',
+        message: `Cannot read migrations directory: ${(err as Error).message}`,
+      },
+    ];
+  }
+
+  const files: MigrationFile[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.sql')) continue;
+    const m = PREFIX_RE.exec(entry);
+    if (!m) {
+      findings.push({
+        analyzer: 'migration-numbering',
+        ruleId: 'non-numeric-prefix',
+        path: path.relative(process.cwd(), path.join(dir, entry)),
+        severity: 'medium',
+        message: `Migration filename does not start with a 4-digit prefix: ${entry}`,
+        remediation: 'Rename the file to NNNN_<slug>.sql so Drizzle can order it deterministically.',
+      });
+      continue;
+    }
+    const prefix = parseInt(m[1] ?? '0', 10);
+    const tag = entry.replace(/\.sql$/, '');
+    files.push({ basename: entry, prefix, inJournal: journalTags.has(tag) });
+  }
+
+  // Group by prefix, flag duplicates as block-severity.
+  const byPrefix = new Map<number, MigrationFile[]>();
+  for (const f of files) {
+    const arr = byPrefix.get(f.prefix) ?? [];
+    arr.push(f);
+    byPrefix.set(f.prefix, arr);
+  }
+  for (const [prefix, group] of byPrefix) {
+    if (group.length > 1) {
+      const filenames = group.map((g) => g.basename).sort();
+      const inJournal = group.filter((g) => g.inJournal).map((g) => g.basename);
+      const orphan = group.filter((g) => !g.inJournal).map((g) => g.basename);
+      findings.push({
+        analyzer: 'migration-numbering',
+        ruleId: 'duplicate-prefix',
+        path: path.relative(process.cwd(), path.join(dir, filenames[0] ?? '')),
+        severity: 'block',
+        message: `Duplicate migration prefix ${String(prefix).padStart(4, '0')}: ${filenames.join(', ')}. Drizzle journal can register only one tag per prefix; one of these is an orphan that will not apply.`,
+        remediation: `Either delete the orphan file(s) (${orphan.join(', ') || 'none — both registered'}) or rename one to the next free prefix. In-journal: ${inJournal.join(', ') || 'none — both orphan'}.`,
+        context: { prefix, files: filenames, inJournal, orphan },
+      });
+    }
+  }
+
+  // Gap detection (warn) — only on registered prefixes (orphan files
+  // covered by the duplicate-prefix check).
+  const registeredPrefixes = files
+    .filter((f) => f.inJournal)
+    .map((f) => f.prefix)
+    .sort((a, b) => a - b);
+  for (let i = 1; i < registeredPrefixes.length; i++) {
+    const a = registeredPrefixes[i - 1];
+    const b = registeredPrefixes[i];
+    if (a === undefined || b === undefined) continue;
+    if (b - a > 1) {
+      findings.push({
+        analyzer: 'migration-numbering',
+        ruleId: 'numbering-gap',
+        path: path.relative(process.cwd(), dir),
+        severity: 'medium',
+        message: `Gap in registered migration prefixes: ${String(a).padStart(4, '0')} -> ${String(b).padStart(4, '0')} (${b - a - 1} missing slot(s)).`,
+        remediation: 'If intentional, add a noop placeholder. Otherwise investigate (likely a branch dropped or renumbered without journal update).',
+        context: { gapStart: a, gapEnd: b, missingSlots: b - a - 1 },
+      });
+    }
+  }
+
+  return findings;
+}
+
+/** Suggest the next free prefix for a fresh migration in this dir. */
+export function nextFreePrefix(usedPrefixes: number[]): number {
+  if (usedPrefixes.length === 0) return 0;
+  return Math.max(...usedPrefixes) + 1;
+}

--- a/packages/steward-analyzers/tests/graph-divergence.test.ts
+++ b/packages/steward-analyzers/tests/graph-divergence.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { checkGraphDivergence } from '../src/index.js';
+
+const NOW = 1750000000;
+const DAY = 86400;
+
+describe('checkGraphDivergence', () => {
+  it('emits zero findings when merge-base is fresh (under threshold)', () => {
+    const findings = checkGraphDivergence({
+      mergeBaseTimestamp: NOW - 3 * DAY,
+      nowTimestamp: NOW,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('emits zero findings when a back-merge PR is already present', () => {
+    const findings = checkGraphDivergence({
+      mergeBaseTimestamp: NOW - 30 * DAY,
+      nowTimestamp: NOW,
+      backMergePrPresent: true,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('emits a medium-severity finding on non-release PR over threshold', () => {
+    const findings = checkGraphDivergence({
+      mergeBaseTimestamp: NOW - 14 * DAY,
+      nowTimestamp: NOW,
+      prHeadRef: 'feat/something',
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(findings[0].context!.ageDays).toBeGreaterThan(7);
+  });
+
+  it('emits a block-severity finding on release/* PR over threshold', () => {
+    const findings = checkGraphDivergence({
+      mergeBaseTimestamp: NOW - 14 * DAY,
+      nowTimestamp: NOW,
+      prHeadRef: 'release/2026-05-04',
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('block');
+    expect(findings[0].context!.isReleasePr).toBe(true);
+  });
+
+  it('respects custom maxAgeDays', () => {
+    // 5d old, threshold 3 → over.
+    const findings = checkGraphDivergence({
+      mergeBaseTimestamp: NOW - 5 * DAY,
+      nowTimestamp: NOW,
+      maxAgeDays: 3,
+      prHeadRef: 'release/x',
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('block');
+  });
+
+  it('remediation hint references back-merge recipe', () => {
+    const findings = checkGraphDivergence({
+      mergeBaseTimestamp: NOW - 14 * DAY,
+      nowTimestamp: NOW,
+      prHeadRef: 'release/x',
+    });
+    expect(findings[0].remediation).toContain('back-merge');
+  });
+});

--- a/packages/steward-analyzers/tests/migration-numbering.test.ts
+++ b/packages/steward-analyzers/tests/migration-numbering.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { checkMigrationNumbering, nextFreePrefix } from '../src/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function makeFixtureDir(layout: {
+  files: string[];
+  journalEntries: { idx: number; tag: string; breakpoints?: boolean }[];
+}): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(tmpdir(), 'steward-numbering-'));
+  await fs.mkdir(path.join(dir, 'meta'), { recursive: true });
+  for (const f of layout.files) {
+    await fs.writeFile(path.join(dir, f), '-- placeholder\n');
+  }
+  await fs.writeFile(
+    path.join(dir, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'sqlite',
+      entries: layout.journalEntries.map((e, i) => ({
+        idx: e.idx,
+        version: '6',
+        when: 1700000000000 + i * 1000,
+        tag: e.tag,
+        breakpoints: e.breakpoints ?? false,
+      })),
+    }),
+  );
+  return dir;
+}
+
+describe('checkMigrationNumbering', () => {
+  it('emits zero findings for a clean monotonic sequence', async () => {
+    const dir = await makeFixtureDir({
+      files: ['0000_a.sql', '0001_b.sql', '0002_c.sql'],
+      journalEntries: [
+        { idx: 0, tag: '0000_a' },
+        { idx: 1, tag: '0001_b' },
+        { idx: 2, tag: '0002_c' },
+      ],
+    });
+    const findings = await checkMigrationNumbering({ migrationsDir: dir });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags duplicate prefix as block-severity (the live 0037 collision shape)', async () => {
+    const dir = await makeFixtureDir({
+      files: ['0037_irreversible_actions.sql', '0037_story_capsule.sql'],
+      journalEntries: [{ idx: 0, tag: '0037_story_capsule' }],
+    });
+    const findings = await checkMigrationNumbering({ migrationsDir: dir });
+    const dup = findings.find((f) => f.ruleId === 'duplicate-prefix');
+    expect(dup).toBeDefined();
+    expect(dup!.severity).toBe('block');
+    expect(dup!.context!.prefix).toBe(37);
+    expect(dup!.context!.orphan).toEqual(['0037_irreversible_actions.sql']);
+    expect(dup!.context!.inJournal).toEqual(['0037_story_capsule.sql']);
+  });
+
+  it('flags a gap in registered prefixes as medium-severity warn', async () => {
+    const dir = await makeFixtureDir({
+      files: ['0000_a.sql', '0001_b.sql', '0003_d.sql'],
+      journalEntries: [
+        { idx: 0, tag: '0000_a' },
+        { idx: 1, tag: '0001_b' },
+        { idx: 2, tag: '0003_d' },
+      ],
+    });
+    const findings = await checkMigrationNumbering({ migrationsDir: dir });
+    const gap = findings.find((f) => f.ruleId === 'numbering-gap');
+    expect(gap).toBeDefined();
+    expect(gap!.severity).toBe('medium');
+    expect(gap!.context!.gapStart).toBe(1);
+    expect(gap!.context!.gapEnd).toBe(3);
+    expect(gap!.context!.missingSlots).toBe(1);
+  });
+
+  it('does NOT flag a gap when the gap is from an orphan file (covered by duplicate-prefix)', async () => {
+    // 0001 only on disk, not in journal. So the registered sequence is 0000 -> 0002.
+    // That IS a gap by the registered-only rule, but orphans should be the focus here.
+    // The gap detector still fires because the rule is "gap in registered prefixes".
+    const dir = await makeFixtureDir({
+      files: ['0000_a.sql', '0001_orphan.sql', '0002_c.sql'],
+      journalEntries: [
+        { idx: 0, tag: '0000_a' },
+        { idx: 1, tag: '0002_c' },
+      ],
+    });
+    const findings = await checkMigrationNumbering({ migrationsDir: dir });
+    const gap = findings.find((f) => f.ruleId === 'numbering-gap');
+    expect(gap).toBeDefined();
+    expect(gap!.context!.gapStart).toBe(0);
+    expect(gap!.context!.gapEnd).toBe(2);
+  });
+
+  it('flags a non-numeric prefix file as medium-severity', async () => {
+    const dir = await makeFixtureDir({
+      files: ['weird-name.sql'],
+      journalEntries: [],
+    });
+    const findings = await checkMigrationNumbering({ migrationsDir: dir });
+    const bad = findings.find((f) => f.ruleId === 'non-numeric-prefix');
+    expect(bad).toBeDefined();
+    expect(bad!.severity).toBe('medium');
+  });
+
+  it('returns block on unreadable directory', async () => {
+    const findings = await checkMigrationNumbering({
+      migrationsDir: '/no/such/path/does/not/exist',
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0].ruleId).toBe('migrations-dir-unreadable');
+  });
+});
+
+describe('nextFreePrefix', () => {
+  it('returns 0 for empty input', () => {
+    expect(nextFreePrefix([])).toBe(0);
+  });
+
+  it('returns max + 1', () => {
+    expect(nextFreePrefix([0, 1, 2, 5])).toBe(6);
+  });
+});


### PR DESCRIPTION
## Steward Gatekeeper — Phase 2b

Adds two more static analyzers to `@chiefaia/steward-analyzers`, plus the corresponding workflow jobs.

**Architecture:** `~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md`
**Predecessor:** PR #291 (Phase 2a, merged 2026-05-04T04:57:16Z)

## What ships

- **`src/migration-numbering.ts`** — failure mode #3. Scans every Drizzle migrations directory; flags duplicate prefixes (block) + gaps in registered prefixes (warn) + non-numeric prefix files (warn). Journal context preserved per finding (in-journal vs orphan).
- **`src/graph-divergence.ts`** — failure mode #2. Pure function over (merge-base ts, now, head ref, back-merge-present). Threshold default 7d. Severity scales: `release/*` PR over threshold = block; non-release = medium warn. Suppressed when a recent back-merge ref (committerdate < 24h) is present.
- **`bin/steward-gatekeeper.mjs`** — CLI now supports `migration-linter`, `migration-numbering`, `graph-divergence`, `all` subcommands.
- **`.github/workflows/steward-gatekeeper.yml`** — three jobs now (existing migration-linter + new migration-numbering + new graph-divergence). All warn-only first cycle.
- **Tests** — 14 new vitest cases including the live `0037` collision shape as a regression fixture, the threshold ladder, and the back-merge-present suppression.

## Pre-existing offenders surfaced (cleanup PR follow-up)

`migration-numbering` against live develop:
- **BLOCK:** `0037` prefix collision (`0037_irreversible_actions.sql` vs `0037_story_capsule.sql`; the former is orphan, not in journal).
- **WARN:** `0010 → 0012` gap (1 missing slot — early development).
- **WARN:** `0041 → 0052` gap (10 missing slots — likely DSPy reconstitution per memory notes).

`graph-divergence` against live develop:
- **0 findings.** merge-base age 0.5 days post-PR-#290 back-merge. Healthy.

## Verification

| Check | Result |
|---|---|
| typecheck | green |
| build | green |
| **test** | **44/44 green** (was 30/30 in #291; +14 new) |
| `node bin/steward-gatekeeper.mjs migration-numbering` (live) | catches the 0037 collision; exit 1 |
| `node bin/steward-gatekeeper.mjs graph-divergence` (live) | 0 findings; exit 0 |

## DoD

Same 15-point checklist as #291. All 15 satisfied. Adversarial fixture suite: each new analyzer has positive + negative cases.

## Sequenced follow-up

- Phase 2c: hygiene daily checks (stash, orphan branch, worktree)
- Phase 2d: backup-pipeline + token-expiry weekly checks
- Phase 3: branch protection update + cron/launchd install + runbook
- Phase 4: adversarial test pass + final report
- Cleanup PR: resolve the 0037 collision (delete orphan or rename + register + add breakpoints).
