### PR TITLE
fix(orchestrator-migration): cleanup 0037 collision — rename to 0054 + add breakpoints

### DIFF
--- a/apps/orchestrator/src/db/migrations/0054_irreversible_actions.sql
+++ b/apps/orchestrator/src/db/migrations/0054_irreversible_actions.sql
@@ -2,6 +2,13 @@
 --
 -- Mirrors packages/capability-broker/migrations/0001_irreversible_actions.sql.
 -- Reference: caia/docs/capability-broker.md, third-party-paper §C.1.
+--
+-- Renumbered from 0037 to 0054 by fix/steward-001-cleanup-0037-collision (2026-05-04)
+-- because the original 0037 prefix collided with 0037_story_capsule.sql, and the
+-- file was never registered in meta/_journal.json. Steward analyzer migration-linter
+-- and migration-numbering both flagged this. Renaming + adding statement-breakpoints
+-- + registering in the journal is the safe fix; CREATE TABLE / CREATE INDEX
+-- IF NOT EXISTS is idempotent so re-running on existing DBs is a no-op.
 
 CREATE TABLE IF NOT EXISTS irreversible_actions (
   id              TEXT PRIMARY KEY,
@@ -15,10 +22,12 @@ CREATE TABLE IF NOT EXISTS irreversible_actions (
   result_json     TEXT NOT NULL,
   undo_token      TEXT
 );
-
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS irreversible_actions_task_idx
   ON irreversible_actions (task_id, ts);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS irreversible_actions_capability_idx
   ON irreversible_actions (capability_name, ts);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS irreversible_actions_ts_idx
   ON irreversible_actions (ts);

--- a/apps/orchestrator/src/db/migrations/meta/_journal.json
+++ b/apps/orchestrator/src/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1779800000000,
       "tag": "0053_steward_events",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1779900000000,
+      "tag": "0054_irreversible_actions",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Resolves the two live findings flagged by the Steward analyzers (PRs #291 + #292) against `apps/orchestrator/src/db/migrations/`:

- **migration-linter**: `0037_irreversible_actions.sql` had 4 statements, 0 `--> statement-breakpoint` markers (block-severity).
- **migration-numbering**: `0037` prefix duplicate — `0037_irreversible_actions.sql` (orphan, never registered in journal) collided with `0037_story_capsule.sql` (registered, idx 36).

This PR is the **prerequisite** for promoting Steward Gatekeeper checks 1–3 from `continue-on-error: true` to required-on-develop+main per `~/Documents/projects/reports/steward-gatekeeper-shipped-2026-05-04.md`.

## Changes

1. **Rename**: `0037_irreversible_actions.sql` → `0054_irreversible_actions.sql` (next-free idx; the 0042–0051 gap is a pre-existing DSPy-reconstitution artifact and is explicitly warn-only per Steward analyzer architecture).
2. **Add `--> statement-breakpoint` markers** between every top-level statement so Drizzle's `better-sqlite3` prepare() doesn't reject multi-statement SQL.
3. **Register in `meta/_journal.json`** at idx 43 with `breakpoints: true`.

## Safety

- `schema.ts` already declares the `irreversibleActions` table — the migration was always expected to run; this PR makes it actually runnable.
- `CREATE TABLE / CREATE INDEX IF NOT EXISTS` is idempotent. Re-running on DBs that somehow pre-have the table is a no-op.
- The orphan was never in the journal so no DB has run it before — this is the first registration.

## Verification (local)

```
pnpm install --frozen-lockfile                                    → green
pnpm --filter @chiefaia/steward-analyzers build                   → green
node bin/steward-gatekeeper.mjs migration-linter <migrations>     → ✓ no findings
node bin/steward-gatekeeper.mjs migration-numbering <migrations>  → 0 block; 2 pre-existing gap warns (non-blocking)
pnpm --filter @caia-app/core typecheck                            → green
```

## DoD

- [x] Code committed + pushed
- [x] Migration linter green
- [x] Migration numbering: 0 blocks
- [x] Schema typecheck green
- [x] Idempotency confirmed via `IF NOT EXISTS`
- [x] Memory will be updated post-merge to note the cleanup
- [x] PR open against `develop` (gitflow)
- [ ] CI green on PR (Evidence Gate + Steward Gatekeeper) — auto-merge will gate
- [ ] Squash-merge to develop, branch + worktree gone

## References

- Steward analyzers: PRs #291 #292
- Phase-1 ship report: `~/Documents/projects/reports/steward-gatekeeper-shipped-2026-05-04.md` §"Live-fire validation" + §"Recommendations for the next campaign" #1
- Memory directive: `agent/memory/steward_gatekeeper_directive.md`
