### PR TITLE
fix(orchestrator-api): reject whitespace-only + over-cap prompt bodies

### DIFF
--- a/apps/orchestrator/src/api/routes/prompts.ts
+++ b/apps/orchestrator/src/api/routes/prompts.ts
@@ -16,6 +16,25 @@ import { runScaffolder } from '../../agents/scaffolder';
 import { isRunMode, RUN_MODES, estimateRunCost, type RunMode } from '../../run-modes';
 
 // @no-events — route registration wrapper; business events are emitted by manager functions
+//
+// API-VALIDATION-001 (2026-05-04): per the 2026-05-01 production stability
+// audit (`~/Documents/projects/reports/pipeline-production-stability-validation-2026-04-30.md`
+// §"Fix PRs opened during this campaign" #1 + #2), the POST /prompts
+// route accepted two known-bad input shapes:
+//
+//   1. Whitespace-only body (e.g. "   ") → returned 201 instead of 400.
+//      Caused the daemon to chase a phantom decomposition path.
+//   2. Very-long body (>~8 KB, observed at 11859 bytes) → rule-based
+//      decomposer treated each filler sentence as a separate feature
+//      and spawned 2000+ descendants, saturating SQLite write path
+//      and intermittently timing out /health.
+//
+// Both are now rejected at the API boundary. The body-length cap is
+// generous (PROMPT_BODY_MAX_CHARS = 8000) — covers the audit's
+// observed legitimate "vision-doc" 4-paragraph case (~1-2 KB) with
+// 4-5x headroom while blocking the runaway shape.
+export const PROMPT_BODY_MAX_CHARS = 8000;
+
 export function registerPromptsRoutes(app: Hono, db: Db): void {
   // Create a new prompt (idempotent by hash in 10s window)
   app.post('/prompts', async (c) => {
@@ -31,6 +50,25 @@ export function registerPromptsRoutes(app: Hono, db: Db): void {
 
     if (!body.body || typeof body.body !== 'string') {
       return c.json({ error: 'body is required' }, 400);
+    }
+
+    // API-VALIDATION-001: reject whitespace-only bodies. Per the
+    // 2026-05-01 stability audit, "   " was accepted as 201 and
+    // chased a phantom decomposition. Trim before hash-idempotency
+    // would mask other bugs; better to 400 at the boundary.
+    if (body.body.trim().length === 0) {
+      return c.json({
+        error: 'body must contain non-whitespace characters',
+      }, 400);
+    }
+
+    // API-VALIDATION-001: reject very-long bodies. Per the same audit,
+    // 11859-byte bodies caused descendant explosion (2000+). Cap at
+    // PROMPT_BODY_MAX_CHARS to keep decomposer output bounded.
+    if (body.body.length > PROMPT_BODY_MAX_CHARS) {
+      return c.json({
+        error: `body must be at most ${PROMPT_BODY_MAX_CHARS} characters (got ${body.body.length})`,
+      }, 400);
     }
 
     // RUN-MODES (migration 0038): validate `run_mode` at the API

--- a/apps/orchestrator/tests/api/prompts.test.ts
+++ b/apps/orchestrator/tests/api/prompts.test.ts
@@ -312,6 +312,43 @@ describe('POST /prompts', () => {
     const p = getPrompt(db, id);
     expect(p!.receivedVia).toBe('cli');
   });
+
+  // API-VALIDATION-001 (2026-05-04) — reject known-bad input shapes that
+  // the 2026-05-01 stability audit surfaced:
+  //   - whitespace-only body (was accepted as 201; chased phantom decomp)
+  //   - over-cap body (was triggering descendant runaway)
+
+  it('returns 400 for whitespace-only body', async () => {
+    const db = createTestDb();
+    const app = createApp(db);
+    const { status, body } = await req(app, 'POST', '/prompts', { body: '   \t\n  ' });
+    expect(status).toBe(400);
+    expect((body as { error: string }).error).toMatch(/non-whitespace/i);
+  });
+
+  it('returns 400 for empty-string body', async () => {
+    const db = createTestDb();
+    const app = createApp(db);
+    const { status } = await req(app, 'POST', '/prompts', { body: '' });
+    expect(status).toBe(400);
+  });
+
+  it('returns 400 for body over PROMPT_BODY_MAX_CHARS (8000)', async () => {
+    const db = createTestDb();
+    const app = createApp(db);
+    const overCap = 'a'.repeat(8001);
+    const { status, body } = await req(app, 'POST', '/prompts', { body: overCap });
+    expect(status).toBe(400);
+    expect((body as { error: string }).error).toMatch(/at most 8000/);
+  });
+
+  it('accepts body at exactly PROMPT_BODY_MAX_CHARS (8000)', async () => {
+    const db = createTestDb();
+    const app = createApp(db);
+    const atCap = 'b'.repeat(8000);
+    const { status } = await req(app, 'POST', '/prompts', { body: atCap });
+    expect(status).toBe(201);
+  });
 });
 
 describe('GET /prompts', () => {


### PR DESCRIPTION
## Summary

Per the 2026-05-01 production stability audit (`~/Documents/projects/reports/pipeline-production-stability-validation-2026-04-30.md` §"Fix PRs opened during this campaign" #1 + #2), POST /prompts accepted two known-bad input shapes that caused real damage in production:

1. **Whitespace-only body** (e.g. `"   "`) returned 201 instead of 400. The daemon chased a phantom decomposition path.
2. **Very-long body** (>~8 KB; observed at 11859 bytes) → rule-based decomposer spawned 2000+ descendants and saturated SQLite.

## Changes

- New constant `PROMPT_BODY_MAX_CHARS = 8000`.
- `body.trim().length === 0` → 400 `body must contain non-whitespace characters`.
- `body.length > 8000` → 400 `body must be at most 8000 characters (got N)`.
- The existing `body is required` check (missing/non-string) is unchanged.

## Tests

Added 4 new test cases under `describe('POST /prompts')`:

- `returns 400 for whitespace-only body` (`"   \t\n  "`)
- `returns 400 for empty-string body`
- `returns 400 for body over PROMPT_BODY_MAX_CHARS` (8001 chars)
- `accepts body at exactly PROMPT_BODY_MAX_CHARS` (8000 chars; sanity check on the boundary)

All 8 `POST /prompts` tests now pass.

## Verification

```
pnpm --filter @caia-app/core typecheck → green
jest --testPathPattern='tests/api/prompts.test.ts' --testNamePattern='POST /prompts' → 8/8 passed
```

## Scope

This addresses the **API-layer half** of the runaway-decomposition finding. The decomposer-side descendant-count cap (audit fix #2 per-decomposer) is a separate follow-up that should land on `@chiefaia/decomposer`. Left as a separate Decomposer track since it touches rule logic, not the API gateway.

## DoD

- [x] Code committed + pushed
- [x] Unit tests added covering happy + edge + error paths
- [x] Typecheck green
- [x] Jest 8/8 pass on POST /prompts
- [x] PR open against develop (gitflow)
- [ ] CI green on PR (Evidence Gate, Steward Gatekeeper, gitflow-conformance, semgrep, gitleaks) — auto-merge will gate
- [ ] Squash-merge to develop, branch gone

## References

- Production stability audit: `~/Documents/projects/reports/pipeline-production-stability-validation-2026-04-30.md`
- Phase 2 edge cases finding: `whitespace-only` (201 → should 400) + `very-long` (descendant runaway)
- Memory: feedback_definition_of_done.md (15-point DoD)
