### PR TITLE
feat(steward-002): preflight CLI + daily hygiene (modes 4, 5, 6)

### DIFF
--- a/.github/workflows/hygiene-report.yml
+++ b/.github/workflows/hygiene-report.yml
@@ -9,9 +9,15 @@ name: hygiene-report
 #      backup/*, release/*).
 #   2. Open PRs with no commit activity in the last 48h.
 #   3. Branches >7 days old (any state).
+#   4. Steward hygiene-daily checks (failure modes 4, 5, 6 per
+#      `agent/memory/steward_gatekeeper_directive.md`):
+#      stash count, worktree count, orphan branches without PR.
 #
-# Stashes are out of scope here — they're client-side and covered by the
-# Husky hooks and the caia-flow start/ship lifecycle.
+# Sections 1-3 are the original hygiene scan. Section 4 is the Steward
+# Phase-2c extension (PR #297). Stashes are still out-of-scope at the CI
+# layer for sections 1-3 (they're client-side); the Steward analyzer
+# section *is* CI-visible and reports stash count = 0 on every clean
+# CI runner.
 #
 # Reference: feedback_git_flow_enforced.md, caia/docs/git-flow.md.
 
@@ -153,6 +159,53 @@ jobs:
           echo "Triage with: \`pnpm flow status\` (current branch), \`pnpm flow ship\` (close green PRs), \`pnpm flow archive <reason>\` (preserve to backup/)." >> /tmp/hygiene/report.md
 
           cat /tmp/hygiene/report.md
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies (steward-analyzers + deps only)
+        run: |
+          # Limit install scope to keep the daily run fast — only what
+          # the steward-analyzers package needs to build + run.
+          pnpm install --filter @chiefaia/steward-analyzers... --frozen-lockfile
+
+      - name: Build steward-analyzers
+        run: pnpm --filter @chiefaia/steward-analyzers build
+
+      - name: Append Steward hygiene-daily findings
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          OUT=$(node packages/steward-analyzers/bin/steward-gatekeeper.mjs hygiene-daily 2>&1)
+          STEWARD_EC=$?
+          set -e
+
+          {
+            echo
+            echo "## 4. Steward hygiene-daily checks"
+            echo
+            echo "_Failure modes 4 (stash), 5 (orphan branches), 6 (worktree count) per \`agent/memory/steward_gatekeeper_directive.md\`._"
+            echo
+            echo '```'
+            echo "${OUT}"
+            echo '```'
+            echo
+            if [ "${STEWARD_EC}" -eq 0 ]; then
+              echo "_Steward CLI exit code: 0 (no block findings)._"
+            else
+              echo "_Steward CLI exit code: ${STEWARD_EC} — high/block-severity findings present; review above._"
+            fi
+          } >> /tmp/hygiene/report.md
 
       - name: Open or update tracking issue
         env:

--- a/packages/steward-analyzers/README.md
+++ b/packages/steward-analyzers/README.md
@@ -64,3 +64,47 @@ pnpm --filter @chiefaia/steward-analyzers test
 - `caia/docs/steward.md` (operator runbook, ships with the campaign)
 - `caia/packages/steward-core/` (the predicate-evaluable engine this
   package complements)
+
+## v0.2.0 — Steward Phase-2c additions (failure modes 4, 5, 6)
+
+Extends the analyzer surface to repo-state checks that don't fit the
+pre-merge model — these run via cron (`hygiene-report.yml`) and via the
+`steward preflight` pre-spawn hook (`feedback_operational_discipline.md`).
+
+- `local-state.ts` exports four pure functions:
+  - `checkStashCount(stashEntries[])` — flags any stash count > 0; high
+    severity at > 5 (stashes block worktree cleanup; standing rule is 0).
+  - `checkWorktreeCount(worktrees[])` — warn at > 8 secondary, high at > 12
+    (per `feedback_operational_discipline.md` cap).
+  - `checkOrphanBranches(branches[])` — flags branches > 7 days old with
+    no open PR, ignoring `backup/*`, `release/*`, `dependabot/*`,
+    `archive/*`, `main`, `develop`. High severity above cumulative 50
+    (per architecture doc §3.5).
+  - `preflightChecks({stashEntries, worktrees, dirtyTreeEntries})` —
+    composite for the `steward preflight` pre-spawn hook; sub-second
+    output covering stash + worktree + dirty-tree caps.
+
+- CLI extensions on `bin/steward-gatekeeper.mjs`:
+  - `preflight` — runs preflightChecks on the local repo. Exit 0 = OK to
+    spawn substantial work; exit 1 = blocked. Sub-second.
+  - `hygiene-daily` — runs the full daily set (stash + worktree +
+    orphan branches). Used by `hygiene-report.yml` cron.
+
+- `hygiene-report.yml` extended with a Section 4 that captures
+  `hygiene-daily` output into the daily `Git Hygiene` issue.
+
+Examples:
+
+```sh
+# Local pre-spawn: should run from your CAIA worktree before any substantial spawn
+node packages/steward-analyzers/bin/steward-gatekeeper.mjs preflight
+echo "exit code: $?"   # 0 = clean; 1 = stash/worktree/dirty-tree predicate fired
+
+# What the daily cron will produce
+node packages/steward-analyzers/bin/steward-gatekeeper.mjs hygiene-daily
+```
+
+The `preflight` check is intended to be wired into orchestrator spawn
+paths in a follow-up PR (`@caia-app/orchestrator` task spawn → preflight
+gate). Today it's a manual command; once the orchestrator-side hook
+lands, no substantial-work spawn proceeds with non-zero preflight exit.

--- a/packages/steward-analyzers/bin/steward-gatekeeper.mjs
+++ b/packages/steward-analyzers/bin/steward-gatekeeper.mjs
@@ -1,19 +1,24 @@
 #!/usr/bin/env node
 /**
  * Steward Gatekeeper CLI — entry invoked by the steward-gatekeeper.yml
- * GitHub Actions workflow.
+ * GitHub Actions workflow + the hygiene-report.yml + dependabot-triage.yml
+ * cron jobs.
  *
  * Subcommands:
  *   migration-linter       — Drizzle multi-statement breakpoint linter (failure mode #1)
  *   migration-numbering    — duplicate-prefix + gap detection (failure mode #3)
  *   graph-divergence       — develop ↔ main merge-base age check (failure mode #2)
  *   vault-checks           — Mac-local snapshot-age check (failure mode #7)
+ *   preflight              — fast pre-spawn hook (modes #4 #6 + dirty-tree)
+ *   hygiene-daily          — repo-state daily snapshot (modes #4 #5 #6)
  *   all                    — run every pre-merge analyzer; OR exit code across all
  *
  * Flags:
- *   --repo-root <path>       repo root (default: ../../../ relative to bin)
- *   --max-age-days <N>       graph-divergence threshold (default 7)
- *   --pr-head-ref <ref>      PR head branch (default $GITHUB_HEAD_REF)
+ *   --repo-root <path>            repo root (default: ../../../ relative to bin)
+ *   --max-age-days <N>            graph-divergence threshold (default 7)
+ *   --pr-head-ref <ref>           PR head branch (default $GITHUB_HEAD_REF)
+ *   --mac-snapshot-dir <path>     Mac vault snapshot dir for vault-checks
+ *   --max-snapshot-age-hours <N>  vault-checks threshold (default 26)
  *
  * Exit codes: 0 (no block findings), 1 (block findings), 2 (usage error).
  *
@@ -22,10 +27,10 @@
  */
 
 import * as path from 'node:path';
-import { execSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import {
   lintMigrations,
   discoverMigrationRoots,
@@ -33,6 +38,10 @@ import {
   checkGraphDivergence,
   exitCodeFor,
   checkSnapshotAge,
+  checkStashCount,
+  checkWorktreeCount,
+  checkOrphanBranches,
+  preflightChecks,
 } from '../dist/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -83,6 +92,8 @@ function printFindings(findings) {
   }
 }
 
+// ─── Pre-merge analyzers ───────────────────────────────────────────────────
+
 async function runMigrationLinter(repoRoot) {
   const roots = await discoverMigrationRoots(repoRoot);
   if (roots.length === 0) {
@@ -114,8 +125,6 @@ async function runMigrationNumbering(repoRoot) {
 }
 
 function runGraphDivergence(repoRoot, opts) {
-  // Resolve develop ↔ main merge-base + its commit timestamp via git.
-  // Requires actions/checkout@v4 with fetch-depth: 0 + a `git fetch origin develop main`.
   let sha;
   try {
     sha = execSync('git merge-base origin/develop origin/main', {
@@ -124,8 +133,6 @@ function runGraphDivergence(repoRoot, opts) {
     }).trim();
   } catch (err) {
     console.log(`graph-divergence: cannot compute merge-base — origin/develop or origin/main not present locally. Run \`git fetch origin develop main\` before invocation. (${err.message})`);
-    // Don't fail CI — graph-divergence is observational, not a hard
-    // requirement for fork-style PRs that may not have both refs.
     return [];
   }
   const ts = parseInt(
@@ -138,9 +145,6 @@ function runGraphDivergence(repoRoot, opts) {
   const now = Math.floor(Date.now() / 1000);
   const headRef = opts['pr-head-ref'] || process.env.GITHUB_HEAD_REF || '';
 
-  // Cheap check: is a back-merge PR open? Avoid `gh` invocation in CLI
-  // (no auth in some contexts); look for a local ref instead. The
-  // cron run path will pass this in via opts when needed.
   let backMergePrPresent = false;
   try {
     const out = execSync('git for-each-ref refs/remotes/origin/chore/back-merge-main-into-develop-* --format="%(refname:short)|%(committerdate:unix)"', {
@@ -148,7 +152,6 @@ function runGraphDivergence(repoRoot, opts) {
       encoding: 'utf8',
     }).trim();
     if (out) {
-      // Treat "back-merge ref pushed within last 24h" as evidence one is in flight.
       const lines = out.split('\n');
       const recent = lines.find((l) => {
         const parts = l.split('|');
@@ -158,7 +161,7 @@ function runGraphDivergence(repoRoot, opts) {
       backMergePrPresent = !!recent;
     }
   } catch {
-    // ignore — refs may not exist
+    // ignore
   }
 
   const findings = checkGraphDivergence({
@@ -172,6 +175,7 @@ function runGraphDivergence(repoRoot, opts) {
   return findings;
 }
 
+// ─── Vault-state (failure mode #7) ─────────────────────────────────────────
 
 function newestMtimeEpoch(dir, glob) {
   try {
@@ -194,25 +198,117 @@ function newestMtimeEpoch(dir, glob) {
 function runVaultChecks(opts) {
   const macSnapDir = (opts['mac-snapshot-dir'] || `${os.homedir()}/Library/Application Support/Stolution/vault-snapshots`);
   const macMtime = newestMtimeEpoch(macSnapDir, /^vault-snapshot-.*\.snap$/);
-  const macPath = macMtime !== null ? macSnapDir : macSnapDir;
 
   console.log(`vault-checks: scanning Mac snapshot dir ${macSnapDir}`);
-  const findings = checkSnapshotAge({
+  return checkSnapshotAge({
     snapshots: [
-      { side: 'mac', path: macPath, mtimeEpoch: macMtime },
+      { side: 'mac', path: macSnapDir, mtimeEpoch: macMtime },
     ],
     maxAgeHours: opts['max-snapshot-age-hours'] ? parseInt(opts['max-snapshot-age-hours'], 10) : 26,
   });
-
-  // Stolution-side snapshot check + Vault token-expiry inventory require
-  // SSH / Vault CLI auth and are intentionally out-of-scope for the
-  // analyzer CLI today. They will be added when the Mac-side
-  // launchd job is installed (follow-up PR with the operator-environment
-  // setup script). For now, the analyzer functions exist and tests cover
-  // them; only the data-collection adapter needs wiring.
-
-  return findings;
 }
+
+// ─── Local-state (failure modes #4 #5 #6) ──────────────────────────────────
+
+function collectStashEntries(repoRoot) {
+  try {
+    const out = execSync('git stash list', { cwd: repoRoot, encoding: 'utf8' }).trim();
+    return out ? out.split('\n') : [];
+  } catch {
+    return [];
+  }
+}
+
+function collectWorktrees(repoRoot) {
+  try {
+    const out = execSync('git worktree list --porcelain', {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    const blocks = out.split(/\n\n+/).filter(Boolean);
+    return blocks.map((block) => {
+      const lines = block.split('\n');
+      let pathStr = null;
+      let branch = null;
+      for (const line of lines) {
+        if (line.startsWith('worktree ')) pathStr = line.slice('worktree '.length).trim();
+        else if (line.startsWith('branch refs/heads/')) branch = line.slice('branch refs/heads/'.length).trim();
+        else if (line === 'detached') branch = null;
+      }
+      return { path: pathStr ?? '', branch };
+    });
+  } catch {
+    return [];
+  }
+}
+
+function collectDirtyTreeCount(repoRoot) {
+  try {
+    const out = execSync('git status --porcelain', { cwd: repoRoot, encoding: 'utf8' }).trim();
+    return out ? out.split('\n').length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function collectBranchInfo(repoRoot) {
+  let openPrHeads = new Set();
+  try {
+    const prsJson = execSync('gh pr list --state open --limit 200 --json headRefName', {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    const prs = JSON.parse(prsJson);
+    openPrHeads = new Set(prs.map((p) => p.headRefName));
+  } catch {
+    // gh unavailable / unauthenticated; proceed with empty set.
+  }
+  let branches = [];
+  try {
+    const out = execSync(
+      `git for-each-ref refs/remotes/origin --format='%(refname:short)|%(committerdate:unix)'`,
+      { cwd: repoRoot, encoding: 'utf8' },
+    ).trim();
+    branches = out.split('\n').map((line) => {
+      const [refnameRaw, tsRaw] = line.split('|');
+      const branch = (refnameRaw ?? '').replace(/^origin\//, '');
+      return {
+        branch,
+        committerTimeUnix: parseInt(tsRaw ?? '0', 10),
+        hasOpenPr: openPrHeads.has(branch),
+      };
+    }).filter((b) => b.branch && b.branch !== 'HEAD');
+  } catch {
+    // ignore
+  }
+  return branches;
+}
+
+function runPreflight(repoRoot) {
+  const stashEntries = collectStashEntries(repoRoot);
+  const worktrees = collectWorktrees(repoRoot);
+  const dirtyTreeEntries = collectDirtyTreeCount(repoRoot);
+  console.log(
+    `preflight: stash=${stashEntries.length} worktrees=${Math.max(0, worktrees.length - 1)} dirty=${dirtyTreeEntries}`,
+  );
+  return preflightChecks({ stashEntries, worktrees, dirtyTreeEntries });
+}
+
+function runHygieneDaily(repoRoot) {
+  const stashEntries = collectStashEntries(repoRoot);
+  const worktrees = collectWorktrees(repoRoot);
+  const branches = collectBranchInfo(repoRoot);
+  console.log(
+    `hygiene-daily: stash=${stashEntries.length} worktrees=${Math.max(0, worktrees.length - 1)} branches=${branches.length}`,
+  );
+  return [
+    ...checkStashCount({ stashEntries }),
+    ...checkWorktreeCount({ worktrees }),
+    ...checkOrphanBranches({ branches }),
+  ];
+}
+
+// ─── Main entry ────────────────────────────────────────────────────────────
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -220,9 +316,10 @@ async function main() {
   const repoRoot = path.resolve(args.flags['repo-root'] ?? path.resolve(__dirname, '../../..'));
 
   if (!command || command === '--help' || command === '-h') {
-    console.error('usage: steward-gatekeeper <command> [--repo-root <path>] [--max-age-days <N>] [--pr-head-ref <ref>]');
+    console.error('usage: steward-gatekeeper <command> [--repo-root <path>] [--max-age-days <N>] [--pr-head-ref <ref>] [--mac-snapshot-dir <path>]');
     console.error('  pre-merge   : migration-linter | migration-numbering | graph-divergence | all');
-    console.error('  scheduled   : vault-checks');
+    console.error('  pre-spawn   : preflight');
+    console.error('  scheduled   : hygiene-daily | vault-checks');
     process.exit(2);
   }
 
@@ -236,6 +333,10 @@ async function main() {
       findings = runGraphDivergence(repoRoot, args.flags);
     } else if (command === 'vault-checks') {
       findings = runVaultChecks(args.flags);
+    } else if (command === 'preflight') {
+      findings = runPreflight(repoRoot);
+    } else if (command === 'hygiene-daily') {
+      findings = runHygieneDaily(repoRoot);
     } else if (command === 'all') {
       const a = await runMigrationLinter(repoRoot);
       const b = await runMigrationNumbering(repoRoot);

--- a/packages/steward-analyzers/src/index.ts
+++ b/packages/steward-analyzers/src/index.ts
@@ -40,3 +40,17 @@ export {
   type SecretRecord,
   type AuditLogState,
 } from './vault-state.js';
+
+export {
+  checkStashCount,
+  checkWorktreeCount,
+  checkOrphanBranches,
+  preflightChecks,
+  type CheckStashCountOptions,
+  type CheckWorktreeCountOptions,
+  type CheckOrphanBranchesOptions,
+  type WorktreeEntry,
+  type OrphanBranchInput,
+  type PreflightInput,
+  type PreflightOptions,
+} from './local-state.js';

--- a/packages/steward-analyzers/src/local-state.ts
+++ b/packages/steward-analyzers/src/local-state.ts
@@ -1,0 +1,240 @@
+/**
+ * Local-state analyzers — failure modes #4 (stash accumulation),
+ * #5 (orphan branches without open PR), and #6 (worktree count over cap).
+ *
+ * These check the Mac-local working state of a CAIA checkout, so they
+ * are designed to be invoked by:
+ *
+ *   - The `hygiene-report.yml` GitHub Actions cron (which checks-out
+ *     the repo and can call `git stash`, `git worktree list`,
+ *     `git for-each-ref`, and `gh pr list`). Repo-state checks #5
+ *     work in CI; #4 + #6 only meaningfully apply to a developer's
+ *     working tree but are still safe to run in CI (just trivially 0).
+ *   - The `steward preflight` CLI subcommand (Mac-local pre-spawn hook
+ *     per `feedback_operational_discipline.md`).
+ *
+ * Pure analyzer functions accept already-collected raw data and
+ * return Finding[]. The shell/git/gh side-effects live in the CLI
+ * shim (`bin/steward-gatekeeper.mjs`) so unit tests can drive the
+ * analyzers with synthetic inputs.
+ *
+ * Reference: architecture doc §3.4, §3.5, §3.6 + memory directive
+ * `steward_gatekeeper_directive.md` (failure modes 4-6).
+ */
+
+import type { Finding, Severity } from './types.js';
+
+// ── Failure mode #4 — stash accumulation ─────────────────────────────────
+
+export interface CheckStashCountOptions {
+  /** Result of `git stash list` parsed to one entry per line. */
+  stashEntries: ReadonlyArray<string>;
+  /**
+   * Threshold above which severity escalates from `medium` to `high`.
+   * Default 5 (matches steward_gatekeeper_directive.md mode 4).
+   */
+  highThreshold?: number;
+}
+
+export function checkStashCount({
+  stashEntries,
+  highThreshold = 5,
+}: CheckStashCountOptions): Finding[] {
+  const count = stashEntries.length;
+  if (count === 0) return [];
+  const severity: Severity = count > highThreshold ? 'high' : 'medium';
+  return [
+    {
+      analyzer: 'local-state',
+      ruleId: 'stash-accumulation',
+      path: '<repo>',
+      severity,
+      message: `Stash count = ${count}; standing rule is 0 (per feedback_git_flow_enforced.md). Convert each to backup/* via 'git stash branch backup/stash-<slug> stash@{N}' then push.`,
+      remediation:
+        "for i in `seq 0 $(( $(git stash list | wc -l) - 1 ))`; do git stash branch backup/stash-$(date +%s)-$i \"stash@{0}\"; done && git push origin --all 'backup/*'",
+      context: { count, highThreshold },
+    },
+  ];
+}
+
+// ── Failure mode #6 — worktree count over cap ────────────────────────────
+
+export interface WorktreeEntry {
+  /** Filesystem path of the worktree. */
+  path: string;
+  /** Branch checked out, or null for detached. */
+  branch: string | null;
+}
+
+export interface CheckWorktreeCountOptions {
+  /** All worktree entries returned by `git worktree list --porcelain`. */
+  worktrees: ReadonlyArray<WorktreeEntry>;
+  /** Warn threshold. Default 8 (matches steward_gatekeeper_directive.md). */
+  warnThreshold?: number;
+  /** Block threshold. Default 12. */
+  blockThreshold?: number;
+}
+
+export function checkWorktreeCount({
+  worktrees,
+  warnThreshold = 8,
+  blockThreshold = 12,
+}: CheckWorktreeCountOptions): Finding[] {
+  // Subtract 1 for the main checkout. Caller passes ALL entries; the
+  // first is conventionally the primary working tree.
+  const count = Math.max(0, worktrees.length - 1);
+  if (count <= warnThreshold) return [];
+  const overBlock = count > blockThreshold;
+  const severity: Severity = overBlock ? 'high' : 'medium';
+  return [
+    {
+      analyzer: 'local-state',
+      ruleId: 'worktree-cap-exceeded',
+      path: '<repo>',
+      severity,
+      message: overBlock
+        ? `Worktree count = ${count}; exceeds block threshold ${blockThreshold}. Pause new spawn until pruned (per feedback_operational_discipline.md).`
+        : `Worktree count = ${count}; exceeds warn threshold ${warnThreshold}. Prune merged-and-clean worktrees before next spawn.`,
+      remediation:
+        "git worktree list | awk '{print $1}' | tail -n +2 | xargs -I{} sh -c 'cd {} && [ -z \"$(git status --porcelain)\" ] && echo PRUNE-CANDIDATE: {}'",
+      context: { count, warnThreshold, blockThreshold },
+    },
+  ];
+}
+
+// ── Failure mode #5 — orphan branches without open PR ────────────────────
+
+export interface OrphanBranchInput {
+  /** Branch name without the `refs/remotes/origin/` prefix. */
+  branch: string;
+  /** Unix epoch seconds of the branch's last commit. */
+  committerTimeUnix: number;
+  /** True iff there's an open PR with this branch as headRef. */
+  hasOpenPr: boolean;
+}
+
+export interface CheckOrphanBranchesOptions {
+  /** All non-protected branches with their metadata. */
+  branches: ReadonlyArray<OrphanBranchInput>;
+  /** Reference timestamp for "now" (epoch seconds). Default `Date.now()/1000`. */
+  nowEpoch?: number;
+  /**
+   * Branch name patterns to ignore (regex strings, joined with |).
+   * Default ignores main, develop, backup/*, release/*, dependabot/*,
+   * archive/*, gh-pages.
+   */
+  ignorePattern?: RegExp;
+  /**
+   * Age in days above which an orphan is reported. Default 7
+   * (steward_gatekeeper_directive.md mode 5).
+   */
+  ageDaysThreshold?: number;
+  /**
+   * Cumulative count above which severity escalates to `high`.
+   * Default 50 (per architecture doc §3.5).
+   */
+  cumulativeHighThreshold?: number;
+}
+
+const DEFAULT_IGNORE = /^(main|develop|HEAD|gh-pages)$|^(backup|release|dependabot|archive)\//;
+
+export function checkOrphanBranches({
+  branches,
+  nowEpoch = Math.floor(Date.now() / 1000),
+  ignorePattern = DEFAULT_IGNORE,
+  ageDaysThreshold = 7,
+  cumulativeHighThreshold = 50,
+}: CheckOrphanBranchesOptions): Finding[] {
+  const ageThresholdSec = ageDaysThreshold * 86400;
+  const offenders = branches.filter(
+    (b) =>
+      !ignorePattern.test(b.branch) &&
+      !b.hasOpenPr &&
+      nowEpoch - b.committerTimeUnix > ageThresholdSec,
+  );
+  if (offenders.length === 0) return [];
+
+  const severity: Severity =
+    offenders.length > cumulativeHighThreshold ? 'high' : 'medium';
+
+  // One aggregate finding (cumulative count is the actionable signal),
+  // plus per-branch context for the dashboard.
+  return [
+    {
+      analyzer: 'local-state',
+      ruleId: 'orphan-branches',
+      path: '<repo>',
+      severity,
+      message: `${offenders.length} orphan branch(es) older than ${ageDaysThreshold}d with no open PR. Per feedback_git_flow_enforced.md, every live branch must have an open PR or live in backup/*.`,
+      remediation:
+        'For each: open a PR (gh pr create), or archive via tag + delete: git tag archive/$(date +%Y-%m-%d)/<branch> origin/<branch> && git push origin tag archive/* && git push origin :<branch>',
+      context: {
+        count: offenders.length,
+        ageDaysThreshold,
+        cumulativeHighThreshold,
+        offenders: offenders.map((b) => ({
+          branch: b.branch,
+          ageDays: Math.round((nowEpoch - b.committerTimeUnix) / 86400),
+        })),
+      },
+    },
+  ];
+}
+
+// ── Pre-spawn hook — fast subset for `steward preflight` ─────────────────
+
+export interface PreflightInput {
+  stashEntries: ReadonlyArray<string>;
+  worktrees: ReadonlyArray<WorktreeEntry>;
+  /** Output of `git status --porcelain` line count on the primary checkout. */
+  dirtyTreeEntries: number;
+}
+
+export interface PreflightOptions {
+  stashHighThreshold?: number;
+  worktreeWarnThreshold?: number;
+  worktreeBlockThreshold?: number;
+  dirtyTreeBlockThreshold?: number;
+}
+
+/**
+ * Pre-spawn preflight check. Returns Findings for any predicate that
+ * would block a new substantial-work spawn per
+ * `feedback_operational_discipline.md`. The CLI maps any `block` or
+ * `high` severity Finding to exit code 1.
+ */
+export function preflightChecks(
+  input: PreflightInput,
+  opts: PreflightOptions = {},
+): Finding[] {
+  const findings: Finding[] = [];
+  const stashOpts: CheckStashCountOptions = { stashEntries: input.stashEntries };
+  if (opts.stashHighThreshold !== undefined) {
+    stashOpts.highThreshold = opts.stashHighThreshold;
+  }
+  findings.push(...checkStashCount(stashOpts));
+
+  const wtOpts: CheckWorktreeCountOptions = { worktrees: input.worktrees };
+  if (opts.worktreeWarnThreshold !== undefined) {
+    wtOpts.warnThreshold = opts.worktreeWarnThreshold;
+  }
+  if (opts.worktreeBlockThreshold !== undefined) {
+    wtOpts.blockThreshold = opts.worktreeBlockThreshold;
+  }
+  findings.push(...checkWorktreeCount(wtOpts));
+
+  const dirtyBlock = opts.dirtyTreeBlockThreshold ?? 5;
+  if (input.dirtyTreeEntries > dirtyBlock) {
+    findings.push({
+      analyzer: 'local-state',
+      ruleId: 'dirty-tree-cap-exceeded',
+      path: '<repo>',
+      severity: 'high',
+      message: `Dirty-tree entry count = ${input.dirtyTreeEntries}; exceeds block threshold ${dirtyBlock}. Either commit/stash to backup/* or pin spawn to a fresh worktree (per feedback_operational_discipline.md).`,
+      remediation:
+        "git status --porcelain  # inspect; commit relevant files OR 'git stash branch backup/preflight-stash-$(date +%s)' to preserve",
+      context: { count: input.dirtyTreeEntries, dirtyBlock },
+    });
+  }
+  return findings;
+}

--- a/packages/steward-analyzers/tests/local-state.test.ts
+++ b/packages/steward-analyzers/tests/local-state.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkStashCount,
+  checkWorktreeCount,
+  checkOrphanBranches,
+  preflightChecks,
+} from '../src/local-state.js';
+
+describe('checkStashCount (failure mode #4)', () => {
+  it('returns no findings when stash list is empty', () => {
+    expect(checkStashCount({ stashEntries: [] })).toEqual([]);
+  });
+
+  it('returns medium severity for 1-5 stashes', () => {
+    const findings = checkStashCount({
+      stashEntries: ['stash@{0}: WIP', 'stash@{1}: WIP', 'stash@{2}: WIP'],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(findings[0].context?.count).toBe(3);
+    expect(findings[0].ruleId).toBe('stash-accumulation');
+  });
+
+  it('returns high severity above default 5-stash threshold', () => {
+    const stashEntries = Array.from(
+      { length: 6 },
+      (_, i) => `stash@{${i}}: WIP`,
+    );
+    const findings = checkStashCount({ stashEntries });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('high');
+  });
+
+  it('honours a custom highThreshold', () => {
+    const stashEntries = Array.from({ length: 3 }, () => 'stash@{}');
+    expect(
+      checkStashCount({ stashEntries, highThreshold: 2 })[0].severity,
+    ).toBe('high');
+  });
+
+  it('embeds remediation hint pointing at backup/* preservation', () => {
+    const findings = checkStashCount({ stashEntries: ['stash@{0}'] });
+    expect(findings[0].remediation).toContain('git stash branch backup/');
+  });
+});
+
+describe('checkWorktreeCount (failure mode #6)', () => {
+  it('returns no findings at or below warn threshold', () => {
+    // 8 secondary + 1 primary = 9 entries; count = 8; equals warn = 8 → no finding
+    const worktrees = Array.from({ length: 9 }, (_, i) => ({
+      path: `/tmp/wt${i}`,
+      branch: `feature/${i}`,
+    }));
+    expect(checkWorktreeCount({ worktrees })).toEqual([]);
+  });
+
+  it('returns medium severity between warn and block', () => {
+    // 10 secondary + 1 primary; count = 10
+    const worktrees = Array.from({ length: 11 }, (_, i) => ({
+      path: `/tmp/wt${i}`,
+      branch: `feature/${i}`,
+    }));
+    const findings = checkWorktreeCount({ worktrees });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(findings[0].context?.count).toBe(10);
+  });
+
+  it('returns high severity above block threshold', () => {
+    // 13 secondary + 1 primary; count = 13 > block 12
+    const worktrees = Array.from({ length: 14 }, (_, i) => ({
+      path: `/tmp/wt${i}`,
+      branch: `feature/${i}`,
+    }));
+    const findings = checkWorktreeCount({ worktrees });
+    expect(findings[0].severity).toBe('high');
+    expect(findings[0].message).toContain('block threshold');
+  });
+
+  it('handles zero worktrees gracefully', () => {
+    expect(checkWorktreeCount({ worktrees: [] })).toEqual([]);
+  });
+
+  it('honours custom thresholds', () => {
+    // 4 secondary + 1 primary; count=4 > custom warn=3
+    const worktrees = Array.from({ length: 5 }, (_, i) => ({
+      path: `/tmp/wt${i}`,
+      branch: `feature/${i}`,
+    }));
+    const findings = checkWorktreeCount({
+      worktrees,
+      warnThreshold: 3,
+      blockThreshold: 5,
+    });
+    expect(findings[0].severity).toBe('medium');
+  });
+});
+
+describe('checkOrphanBranches (failure mode #5)', () => {
+  const NOW = 1779840000; // 2026-05-04 epoch sec
+  const HOURS = 3600;
+  const DAYS = 86400;
+
+  it('returns no findings when branches list is empty', () => {
+    expect(checkOrphanBranches({ branches: [], nowEpoch: NOW })).toEqual([]);
+  });
+
+  it('ignores main, develop, backup/*, release/*, dependabot/*, archive/*', () => {
+    const branches = [
+      { branch: 'main', committerTimeUnix: NOW - 30 * DAYS, hasOpenPr: false },
+      {
+        branch: 'develop',
+        committerTimeUnix: NOW - 30 * DAYS,
+        hasOpenPr: false,
+      },
+      {
+        branch: 'backup/2026-04-30/foo',
+        committerTimeUnix: NOW - 90 * DAYS,
+        hasOpenPr: false,
+      },
+      {
+        branch: 'release/2026-05-02-cleanup',
+        committerTimeUnix: NOW - 30 * DAYS,
+        hasOpenPr: false,
+      },
+      {
+        branch: 'dependabot/npm/foo',
+        committerTimeUnix: NOW - 14 * DAYS,
+        hasOpenPr: false,
+      },
+      {
+        branch: 'archive/2026-05-04/x',
+        committerTimeUnix: NOW - 90 * DAYS,
+        hasOpenPr: false,
+      },
+    ];
+    expect(
+      checkOrphanBranches({ branches, nowEpoch: NOW }),
+    ).toEqual([]);
+  });
+
+  it('ignores branches younger than 7 days', () => {
+    const branches = [
+      {
+        branch: 'feat/recent',
+        committerTimeUnix: NOW - 3 * DAYS,
+        hasOpenPr: false,
+      },
+    ];
+    expect(checkOrphanBranches({ branches, nowEpoch: NOW })).toEqual([]);
+  });
+
+  it('ignores branches with open PR even when > 7 days old', () => {
+    const branches = [
+      {
+        branch: 'feat/in-review',
+        committerTimeUnix: NOW - 14 * DAYS,
+        hasOpenPr: true,
+      },
+    ];
+    expect(checkOrphanBranches({ branches, nowEpoch: NOW })).toEqual([]);
+  });
+
+  it('flags an old branch without open PR with medium severity', () => {
+    const branches = [
+      {
+        branch: 'feat/old-no-pr',
+        committerTimeUnix: NOW - 10 * DAYS,
+        hasOpenPr: false,
+      },
+    ];
+    const findings = checkOrphanBranches({ branches, nowEpoch: NOW });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(findings[0].context?.count).toBe(1);
+  });
+
+  it('escalates to high above cumulative threshold', () => {
+    const branches = Array.from({ length: 51 }, (_, i) => ({
+      branch: `feat/orphan-${i}`,
+      committerTimeUnix: NOW - 15 * DAYS,
+      hasOpenPr: false,
+    }));
+    const findings = checkOrphanBranches({ branches, nowEpoch: NOW });
+    expect(findings[0].severity).toBe('high');
+    expect(findings[0].context?.count).toBe(51);
+  });
+
+  it('honours custom ageDaysThreshold', () => {
+    const branches = [
+      {
+        branch: 'feat/maybe-orphan',
+        committerTimeUnix: NOW - 5 * DAYS,
+        hasOpenPr: false,
+      },
+    ];
+    expect(
+      checkOrphanBranches({
+        branches,
+        nowEpoch: NOW,
+        ageDaysThreshold: 3,
+      }),
+    ).toHaveLength(1);
+    expect(
+      checkOrphanBranches({
+        branches,
+        nowEpoch: NOW,
+        ageDaysThreshold: 7,
+      }),
+    ).toEqual([]);
+  });
+
+  it('embeds per-branch ageDays in context for dashboard rendering', () => {
+    const branches = [
+      {
+        branch: 'feat/age-9d',
+        committerTimeUnix: NOW - 9 * DAYS - 1 * HOURS,
+        hasOpenPr: false,
+      },
+      {
+        branch: 'feat/age-15d',
+        committerTimeUnix: NOW - 15 * DAYS,
+        hasOpenPr: false,
+      },
+    ];
+    const findings = checkOrphanBranches({ branches, nowEpoch: NOW });
+    const offenders = findings[0].context?.offenders as Array<{
+      branch: string;
+      ageDays: number;
+    }>;
+    expect(offenders).toHaveLength(2);
+    expect(offenders.map((o) => o.branch).sort()).toEqual([
+      'feat/age-15d',
+      'feat/age-9d',
+    ]);
+    // ageDays is rounded; allow ±1 tolerance for rounding edges
+    expect(offenders.find((o) => o.branch === 'feat/age-15d')!.ageDays).toBe(15);
+  });
+});
+
+describe('preflightChecks (pre-spawn hook composite)', () => {
+  it('returns no findings on a clean tree', () => {
+    expect(
+      preflightChecks({
+        stashEntries: [],
+        worktrees: [{ path: '/repo', branch: 'develop' }],
+        dirtyTreeEntries: 0,
+      }),
+    ).toEqual([]);
+  });
+
+  it('flags every preflight predicate that fires', () => {
+    const findings = preflightChecks({
+      stashEntries: Array.from({ length: 6 }, () => 'stash@{}'),
+      worktrees: Array.from({ length: 14 }, (_, i) => ({
+        path: `/tmp/wt${i}`,
+        branch: `f/${i}`,
+      })),
+      dirtyTreeEntries: 8,
+    });
+    expect(findings).toHaveLength(3);
+    const ruleIds = findings.map((f) => f.ruleId).sort();
+    expect(ruleIds).toEqual([
+      'dirty-tree-cap-exceeded',
+      'stash-accumulation',
+      'worktree-cap-exceeded',
+    ]);
+    expect(findings.every((f) => ['high', 'medium'].includes(f.severity))).toBe(
+      true,
+    );
+  });
+
+  it('honours dirtyTreeBlockThreshold', () => {
+    const findings = preflightChecks(
+      {
+        stashEntries: [],
+        worktrees: [{ path: '/repo', branch: 'develop' }],
+        dirtyTreeEntries: 4,
+      },
+      { dirtyTreeBlockThreshold: 3 },
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].ruleId).toBe('dirty-tree-cap-exceeded');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2c of the Steward Gatekeeper rollout per `~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md` §3.4 / §3.5 / §3.6. Adds analyzers for three local-state failure modes:

| # | Mode | Threshold |
|---|---|---|
| 4 | Stash accumulation | > 0 medium / > 5 high |
| 5 | Orphan branches without PR | > 7d age / > 50 cumulative high |
| 6 | Worktree count over cap | > 8 secondary medium / > 12 high |

These don't fit the pre-merge analyzer model — they're repo-state checks. They run via:

- **`steward preflight` CLI** — sub-second pre-spawn hook composing the cap-check subset (stash + worktree + dirty-tree). Codifies the `feedback_operational_discipline.md` pre-spawn checklist as a single mechanical gate.
- **`steward hygiene-daily` CLI** — full daily set surfaced via the existing `hygiene-report.yml` cron into the daily `Git Hygiene` issue (new Section 4).

## What's in this PR

- `packages/steward-analyzers/src/local-state.ts` — `checkStashCount` / `checkWorktreeCount` / `checkOrphanBranches` / `preflightChecks`. Pure functions; raw inputs come from the CLI shim, so tests can drive synthetically.
- `packages/steward-analyzers/bin/steward-gatekeeper.mjs` — new `preflight` and `hygiene-daily` subcommands. New helpers `collectStashEntries` / `collectWorktrees` / `collectDirtyTreeCount` / `collectBranchInfo` encapsulate the shell side-effects.
- `packages/steward-analyzers/tests/local-state.test.ts` — 21 new vitest cases covering positive / negative / threshold-edge / cumulative-escalation paths. Adversarial fixtures embedded.
- `.github/workflows/hygiene-report.yml` — Section 4 added; installs steward-analyzers, builds, runs hygiene-daily, appends output to the daily issue body.
- `packages/steward-analyzers/README.md` — v0.2.0 section documenting the new surface.

## Verification

```
pnpm --filter @chiefaia/steward-analyzers build       → green
pnpm --filter @chiefaia/steward-analyzers typecheck   → green
pnpm --filter @chiefaia/steward-analyzers lint        → green
pnpm --filter @chiefaia/steward-analyzers test        → 65/65 pass
node bin/steward-gatekeeper.mjs preflight             → no findings
node bin/steward-gatekeeper.mjs hygiene-daily         → no findings
```

## Adversarial test pass

Each new CLI behaviour has a dedicated test case that intentionally introduces the failure mode and asserts the analyzer catches it with the expected severity:

- 6 stashes → high severity `stash-accumulation`
- 13 worktrees → high severity `worktree-cap-exceeded`
- 51 orphan branches → high severity `orphan-branches`

## Out of scope

Orchestrator-side wiring of `preflight` as a programmatic pre-spawn gate (call `steward preflight` before `TaskSpawned` and abort on non-zero exit). Today the CLI is callable manually + via cron; orchestrator hook ships in a follow-up PR.

Modes 7-12 (backup pipeline, audit-log rotation health, token expiry, PR stale auto-close, dependabot triage, memory drift) are queued for Phase 2d / 2e in the same campaign.

## DoD

- [x] Code committed + pushed
- [x] Unit tests covering happy + edge + adversarial paths (65/65 pass)
- [x] Build, typecheck, lint green
- [x] CLI manually invoked + observed correct output
- [x] PR open against `develop` (gitflow)
- [ ] CI green on PR (auto-merge will gate)
- [ ] Squash-merge to develop, branch + worktree gone
- [x] Memory directive already references modes 4/5/6 — no rewrite needed
- [x] Architecture doc already exists (this PR is implementation against it)

## References

- Architecture: `~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md` §3.4-3.6
- Memory directive: `agent/memory/steward_gatekeeper_directive.md`
- Operating discipline: `agent/memory/feedback_operational_discipline.md`
- Predecessor: PRs #285 #291 #292 (steward-core engine + analyzers v0.1.0)
