### PR TITLE
feat(steward-003): vault-state analyzers (modes 7, 8, 9)

### DIFF
--- a/packages/steward-analyzers/bin/steward-gatekeeper.mjs
+++ b/packages/steward-analyzers/bin/steward-gatekeeper.mjs
@@ -7,7 +7,8 @@
  *   migration-linter       — Drizzle multi-statement breakpoint linter (failure mode #1)
  *   migration-numbering    — duplicate-prefix + gap detection (failure mode #3)
  *   graph-divergence       — develop ↔ main merge-base age check (failure mode #2)
- *   all                    — run every analyzer; OR exit code across all
+ *   vault-checks           — Mac-local snapshot-age check (failure mode #7)
+ *   all                    — run every pre-merge analyzer; OR exit code across all
  *
  * Flags:
  *   --repo-root <path>       repo root (default: ../../../ relative to bin)
@@ -23,12 +24,15 @@
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import {
   lintMigrations,
   discoverMigrationRoots,
   checkMigrationNumbering,
   checkGraphDivergence,
   exitCodeFor,
+  checkSnapshotAge,
 } from '../dist/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -168,6 +172,48 @@ function runGraphDivergence(repoRoot, opts) {
   return findings;
 }
 
+
+function newestMtimeEpoch(dir, glob) {
+  try {
+    const entries = fs.readdirSync(dir).filter((name) => name.match(glob));
+    if (entries.length === 0) return null;
+    let newest = 0;
+    for (const name of entries) {
+      try {
+        const st = fs.statSync(`${dir}/${name}`);
+        const t = Math.floor(st.mtimeMs / 1000);
+        if (t > newest) newest = t;
+      } catch { /* ignore */ }
+    }
+    return newest > 0 ? newest : null;
+  } catch {
+    return null;
+  }
+}
+
+function runVaultChecks(opts) {
+  const macSnapDir = (opts['mac-snapshot-dir'] || `${os.homedir()}/Library/Application Support/Stolution/vault-snapshots`);
+  const macMtime = newestMtimeEpoch(macSnapDir, /^vault-snapshot-.*\.snap$/);
+  const macPath = macMtime !== null ? macSnapDir : macSnapDir;
+
+  console.log(`vault-checks: scanning Mac snapshot dir ${macSnapDir}`);
+  const findings = checkSnapshotAge({
+    snapshots: [
+      { side: 'mac', path: macPath, mtimeEpoch: macMtime },
+    ],
+    maxAgeHours: opts['max-snapshot-age-hours'] ? parseInt(opts['max-snapshot-age-hours'], 10) : 26,
+  });
+
+  // Stolution-side snapshot check + Vault token-expiry inventory require
+  // SSH / Vault CLI auth and are intentionally out-of-scope for the
+  // analyzer CLI today. They will be added when the Mac-side
+  // launchd job is installed (follow-up PR with the operator-environment
+  // setup script). For now, the analyzer functions exist and tests cover
+  // them; only the data-collection adapter needs wiring.
+
+  return findings;
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const command = args.positional[0];
@@ -175,7 +221,8 @@ async function main() {
 
   if (!command || command === '--help' || command === '-h') {
     console.error('usage: steward-gatekeeper <command> [--repo-root <path>] [--max-age-days <N>] [--pr-head-ref <ref>]');
-    console.error('  commands: migration-linter | migration-numbering | graph-divergence | all');
+    console.error('  pre-merge   : migration-linter | migration-numbering | graph-divergence | all');
+    console.error('  scheduled   : vault-checks');
     process.exit(2);
   }
 
@@ -187,6 +234,8 @@ async function main() {
       findings = await runMigrationNumbering(repoRoot);
     } else if (command === 'graph-divergence') {
       findings = runGraphDivergence(repoRoot, args.flags);
+    } else if (command === 'vault-checks') {
+      findings = runVaultChecks(args.flags);
     } else if (command === 'all') {
       const a = await runMigrationLinter(repoRoot);
       const b = await runMigrationNumbering(repoRoot);

--- a/packages/steward-analyzers/src/index.ts
+++ b/packages/steward-analyzers/src/index.ts
@@ -28,3 +28,15 @@ export {
   checkGraphDivergence,
   type GraphDivergenceInput,
 } from './graph-divergence.js';
+
+export {
+  checkSnapshotAge,
+  checkTokenExpiry,
+  checkAuditLogRotation,
+  type CheckSnapshotAgeOptions,
+  type CheckTokenExpiryOptions,
+  type CheckAuditLogRotationOptions,
+  type SnapshotEntry,
+  type SecretRecord,
+  type AuditLogState,
+} from './vault-state.js';

--- a/packages/steward-analyzers/src/vault-state.ts
+++ b/packages/steward-analyzers/src/vault-state.ts
@@ -1,0 +1,197 @@
+/**
+ * Vault-state analyzers — failure modes #7 (backup pipeline silent
+ * failure) and #9 (token expiry approaching). Per the architecture
+ * doc §3.7 and §3.9 + memory directive `steward_gatekeeper_directive.md`
+ * (modes 7, 9).
+ *
+ * Mode #8 (audit-log unbounded growth) is also implementable here; it's
+ * a small extension of the snapshot-age check (just looks at a
+ * different file's mtime). Included as `checkAuditLogRotation` for
+ * symmetry.
+ *
+ * As with `local-state.ts`, the analyzers are pure: they accept
+ * already-collected raw inputs (mtimes for snapshot/audit-log,
+ * structured secret records with `*_expires_at` fields). The CLI shim
+ * is responsible for the side-effects (filesystem stat, vault read).
+ *
+ * Why pure functions: the actual signal sources are heterogeneous —
+ * Mac filesystem mtimes for the local snapshot, stolution-remote
+ * filesystem mtimes for the remote snapshot, vault `*_expires_at`
+ * fields for token rotation. Each platform has different access
+ * primitives. Keeping the analyzer logic decoupled means we can
+ * trivially mock for tests and route around platform quirks in the
+ * CLI shim.
+ */
+
+import type { Finding, Severity } from './types.js';
+
+// ── Failure mode #7 — backup pipeline silent failure ──────────────────────
+
+export interface SnapshotEntry {
+  /** Side identifier (e.g. 'mac', 'stolution'). */
+  side: string;
+  /** Filesystem path of the most-recent snapshot file. */
+  path: string | null;
+  /** Modification time as Unix epoch seconds; null if no snapshot found. */
+  mtimeEpoch: number | null;
+}
+
+export interface CheckSnapshotAgeOptions {
+  /** Snapshot entries from each side that the operator expects to be fresh. */
+  snapshots: ReadonlyArray<SnapshotEntry>;
+  /** Reference "now" for age computation. Default Date.now()/1000. */
+  nowEpoch?: number;
+  /**
+   * Max acceptable snapshot age in hours. Default 26 — matches the existing
+   * `com.stolution.vault-snapshot-pull` check threshold.
+   */
+  maxAgeHours?: number;
+}
+
+export function checkSnapshotAge({
+  snapshots,
+  nowEpoch = Math.floor(Date.now() / 1000),
+  maxAgeHours = 26,
+}: CheckSnapshotAgeOptions): Finding[] {
+  const findings: Finding[] = [];
+  const maxAgeSec = maxAgeHours * 3600;
+
+  for (const entry of snapshots) {
+    if (entry.mtimeEpoch === null) {
+      findings.push({
+        analyzer: 'vault-state',
+        ruleId: 'snapshot-missing',
+        path: entry.path ?? `<${entry.side}>`,
+        severity: 'high',
+        message: `No snapshot found on ${entry.side} side. Vault backup pipeline is broken or never ran.`,
+        remediation: `Inspect the ${entry.side}-side snapshot job (cron / LaunchAgent). On Mac: 'launchctl list com.stolution.vault-snapshot-pull'. On stolution: 'crontab -l | grep vault-snapshot'.`,
+        context: { side: entry.side },
+      });
+      continue;
+    }
+    const ageSec = nowEpoch - entry.mtimeEpoch;
+    if (ageSec > maxAgeSec) {
+      const ageHours = Math.round(ageSec / 3600);
+      findings.push({
+        analyzer: 'vault-state',
+        ruleId: 'snapshot-stale',
+        path: entry.path ?? `<${entry.side}>`,
+        severity: 'high',
+        message: `Most recent ${entry.side}-side snapshot is ${ageHours}h old (threshold ${maxAgeHours}h). Backup pipeline silently failing.`,
+        remediation: `Verify the ${entry.side}-side snapshot job last exit code + log. Re-run manually: on Mac, 'launchctl kickstart -k gui/$UID/com.stolution.vault-snapshot-pull'.`,
+        context: { side: entry.side, ageHours, maxAgeHours },
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ── Failure mode #8 — audit log unbounded growth ──────────────────────────
+
+export interface AuditLogState {
+  /** Path to the audit log file. */
+  path: string;
+  /** File size in bytes. null if not present. */
+  sizeBytes: number | null;
+  /** mtime of the most recent rotation marker file. null if no rotation observed. */
+  rotationMtimeEpoch: number | null;
+}
+
+export interface CheckAuditLogRotationOptions {
+  state: AuditLogState;
+  nowEpoch?: number;
+  maxRotationAgeHours?: number;
+  /** Per architecture doc §3.8: 1 GB = block growth alarm. */
+  maxSizeBytes?: number;
+}
+
+export function checkAuditLogRotation({
+  state,
+  nowEpoch = Math.floor(Date.now() / 1000),
+  maxRotationAgeHours = 26,
+  maxSizeBytes = 1_000_000_000,
+}: CheckAuditLogRotationOptions): Finding[] {
+  const findings: Finding[] = [];
+
+  if (state.sizeBytes !== null && state.sizeBytes > maxSizeBytes) {
+    findings.push({
+      analyzer: 'vault-state',
+      ruleId: 'audit-log-oversized',
+      path: state.path,
+      severity: 'medium',
+      message: `Audit log exceeded ${(maxSizeBytes / 1e9).toFixed(1)} GB (current: ${(state.sizeBytes / 1e9).toFixed(2)} GB). Rotation is broken or insufficient.`,
+      remediation: `Check the rotation cron entry exists; force-run 'rotate-vault-audit.sh' manually.`,
+      context: { sizeBytes: state.sizeBytes, maxSizeBytes },
+    });
+  }
+
+  if (state.rotationMtimeEpoch !== null) {
+    const ageSec = nowEpoch - state.rotationMtimeEpoch;
+    const maxAgeSec = maxRotationAgeHours * 3600;
+    if (ageSec > maxAgeSec) {
+      findings.push({
+        analyzer: 'vault-state',
+        ruleId: 'audit-log-rotation-stale',
+        path: state.path,
+        severity: 'medium',
+        message: `Last audit-log rotation was ${Math.round(ageSec / 3600)}h ago (threshold ${maxRotationAgeHours}h). Rotation cron may be unhealthy.`,
+        remediation: `'crontab -l | grep rotate-vault-audit' to verify; manually invoke if needed.`,
+        context: { ageHours: Math.round(ageSec / 3600), maxRotationAgeHours },
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ── Failure mode #9 — token expiry approaching ────────────────────────────
+
+export interface SecretRecord {
+  /** Vault path or identifier. e.g. 'secret/stolution/prod/infrastructure'. */
+  path: string;
+  /** Logical key being tracked (often the token name). */
+  key: string;
+  /** Expiry as Unix epoch seconds; null = no expiry tracked. */
+  expiresAtEpoch: number | null;
+}
+
+export interface CheckTokenExpiryOptions {
+  /** All secrets that have an `*_expires_at` field. */
+  secrets: ReadonlyArray<SecretRecord>;
+  /** Reference "now". Default Date.now()/1000. */
+  nowEpoch?: number;
+  /** Days-to-expiry below which severity is medium. Default 30. */
+  warnDays?: number;
+  /** Days-to-expiry below which severity is high. Default 7. */
+  highDays?: number;
+}
+
+export function checkTokenExpiry({
+  secrets,
+  nowEpoch = Math.floor(Date.now() / 1000),
+  warnDays = 30,
+  highDays = 7,
+}: CheckTokenExpiryOptions): Finding[] {
+  const findings: Finding[] = [];
+  const day = 86400;
+
+  for (const s of secrets) {
+    if (s.expiresAtEpoch === null) continue; // no expiry tracked → out of scope
+    const daysToExpiry = Math.floor((s.expiresAtEpoch - nowEpoch) / day);
+    if (daysToExpiry > warnDays) continue; // healthy
+
+    const severity: Severity = daysToExpiry <= highDays ? 'high' : 'medium';
+    findings.push({
+      analyzer: 'vault-state',
+      ruleId: 'token-expiry-approaching',
+      path: s.path,
+      severity,
+      message: `${s.key} at ${s.path} expires in ${daysToExpiry}d (threshold: warn ${warnDays}d, high ${highDays}d).`,
+      remediation: `Run rotation: ~/bin/rotate-${s.key.toLowerCase()}.sh OR 'gh auth refresh' for github tokens. Update Vault entry after rotation.`,
+      context: { key: s.key, daysToExpiry, warnDays, highDays },
+    });
+  }
+
+  return findings;
+}

--- a/packages/steward-analyzers/tests/vault-state.test.ts
+++ b/packages/steward-analyzers/tests/vault-state.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkSnapshotAge,
+  checkTokenExpiry,
+  checkAuditLogRotation,
+} from '../src/vault-state.js';
+
+const NOW = 1779840000; // 2026-05-04 06:00:00 UTC
+const HOUR = 3600;
+const DAY = 86400;
+
+describe('checkSnapshotAge (failure mode #7)', () => {
+  it('returns no findings when both sides have fresh snapshots', () => {
+    const findings = checkSnapshotAge({
+      snapshots: [
+        { side: 'mac', path: '/snap/a.snap', mtimeEpoch: NOW - 1 * HOUR },
+        { side: 'stolution', path: '/snap/b.snap', mtimeEpoch: NOW - 5 * HOUR },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags missing snapshots as high severity', () => {
+    const findings = checkSnapshotAge({
+      snapshots: [
+        { side: 'mac', path: null, mtimeEpoch: null },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('high');
+    expect(findings[0].ruleId).toBe('snapshot-missing');
+  });
+
+  it('flags stale (>26h) snapshots as high severity', () => {
+    const findings = checkSnapshotAge({
+      snapshots: [
+        {
+          side: 'stolution',
+          path: '/snap/old.snap',
+          mtimeEpoch: NOW - 27 * HOUR,
+        },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('high');
+    expect(findings[0].ruleId).toBe('snapshot-stale');
+    expect(findings[0].context?.ageHours).toBe(27);
+  });
+
+  it('honours custom maxAgeHours', () => {
+    const findings = checkSnapshotAge({
+      snapshots: [
+        { side: 'mac', path: '/snap/a.snap', mtimeEpoch: NOW - 12 * HOUR },
+      ],
+      nowEpoch: NOW,
+      maxAgeHours: 6,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('flags both sides independently', () => {
+    const findings = checkSnapshotAge({
+      snapshots: [
+        { side: 'mac', path: null, mtimeEpoch: null },
+        {
+          side: 'stolution',
+          path: '/snap/b.snap',
+          mtimeEpoch: NOW - 30 * HOUR,
+        },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(2);
+    expect(findings[0].context?.side).toBe('mac');
+    expect(findings[1].context?.side).toBe('stolution');
+  });
+});
+
+describe('checkTokenExpiry (failure mode #9)', () => {
+  it('returns no findings for healthy tokens (>30d to expiry)', () => {
+    const findings = checkTokenExpiry({
+      secrets: [
+        {
+          path: 'secret/foo',
+          key: 'github_pat',
+          expiresAtEpoch: NOW + 60 * DAY,
+        },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('returns medium severity at 8-30 days', () => {
+    const findings = checkTokenExpiry({
+      secrets: [
+        {
+          path: 'secret/foo',
+          key: 'github_pat',
+          expiresAtEpoch: NOW + 14 * DAY,
+        },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(findings[0].context?.daysToExpiry).toBe(14);
+  });
+
+  it('returns high severity at <=7 days', () => {
+    const findings = checkTokenExpiry({
+      secrets: [
+        {
+          path: 'secret/foo',
+          key: 'cf_token',
+          expiresAtEpoch: NOW + 3 * DAY,
+        },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('high');
+  });
+
+  it('handles past-due (negative days) as high severity', () => {
+    const findings = checkTokenExpiry({
+      secrets: [
+        {
+          path: 'secret/expired',
+          key: 'old_pat',
+          expiresAtEpoch: NOW - 1 * DAY,
+        },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('high');
+    expect(findings[0].context?.daysToExpiry).toBe(-1);
+  });
+
+  it('skips secrets without an expiry', () => {
+    const findings = checkTokenExpiry({
+      secrets: [
+        { path: 'secret/foo', key: 'no_expiry', expiresAtEpoch: null },
+      ],
+      nowEpoch: NOW,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('honours custom warnDays / highDays thresholds', () => {
+    const findings = checkTokenExpiry({
+      secrets: [
+        {
+          path: 'secret/foo',
+          key: 'k',
+          expiresAtEpoch: NOW + 50 * DAY,
+        },
+      ],
+      nowEpoch: NOW,
+      warnDays: 90,
+      highDays: 60,
+    });
+    expect(findings[0].severity).toBe('high');
+  });
+});
+
+describe('checkAuditLogRotation (failure mode #8)', () => {
+  it('returns no findings on a healthy state', () => {
+    const findings = checkAuditLogRotation({
+      state: {
+        path: '/audit.log',
+        sizeBytes: 100_000_000, // 100 MB — fine
+        rotationMtimeEpoch: NOW - 1 * HOUR,
+      },
+      nowEpoch: NOW,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags oversized audit log (>1 GB)', () => {
+    const findings = checkAuditLogRotation({
+      state: {
+        path: '/audit.log',
+        sizeBytes: 1_500_000_000,
+        rotationMtimeEpoch: NOW - 1 * HOUR,
+      },
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].ruleId).toBe('audit-log-oversized');
+  });
+
+  it('flags stale rotation (>26h since last)', () => {
+    const findings = checkAuditLogRotation({
+      state: {
+        path: '/audit.log',
+        sizeBytes: 50_000,
+        rotationMtimeEpoch: NOW - 30 * HOUR,
+      },
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].ruleId).toBe('audit-log-rotation-stale');
+  });
+
+  it('flags both conditions independently', () => {
+    const findings = checkAuditLogRotation({
+      state: {
+        path: '/audit.log',
+        sizeBytes: 2_000_000_000,
+        rotationMtimeEpoch: NOW - 30 * HOUR,
+      },
+      nowEpoch: NOW,
+    });
+    expect(findings).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2d of Steward Gatekeeper. Adds analyzers for three vault/backup-related failure modes per `~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md`:

| # | Mode | Threshold |
|---|---|---|
| 7 | Backup pipeline silent failure | snapshot mtime > 26h = high |
| 8 | Audit log unbounded growth | size > 1 GB OR rotation > 26h = medium |
| 9 | Token expiry approaching | < 30d warn / < 7d high |

All three are observe + report; no automatic recovery.

## What's in this PR

- `packages/steward-analyzers/src/vault-state.ts` — `checkSnapshotAge` / `checkTokenExpiry` / `checkAuditLogRotation`. Pure functions; raw inputs come from CLI shim.
- `packages/steward-analyzers/tests/vault-state.test.ts` — 15 vitest cases covering positive / negative / threshold-edge for all three. Includes past-due token + missing-snapshot + oversized-log fixtures.
- `packages/steward-analyzers/bin/steward-gatekeeper.mjs` — `vault-checks` subcommand. Wires the Mac-local snapshot-age check via fs.statSync on `~/Library/Application Support/Stolution/vault-snapshots/`. Token-expiry + stolution-side checks are deferred (need SSH bridge / Vault CLI auth helper) — this PR delivers the analyzer surface, not the data adapter.

## Verification

```
pnpm --filter @chiefaia/steward-analyzers build/typecheck/lint   → green
pnpm --filter @chiefaia/steward-analyzers test                   → 59/59 pass
node bin/steward-gatekeeper.mjs vault-checks                     → clean (newest snapshot ~10h old)
```

## Coordination with PR #297

This PR is independent of PR #297 (Phase 2c — preflight + hygiene-daily). Both extend `packages/steward-analyzers/src/index.ts` via append; whichever merges second rebases trivially. #297 lands first per ordering convention.

## Out of scope

- Mac launchd plist installation (`com.caia.steward.daily` / `com.caia.steward.weekly`) — operator-environment work; ships with a setup script in a follow-up.
- Stolution-side snapshot mtime check — needs SSH bridge.
- Vault CLI token expiry inventory — needs auth helper + AppRole config.
- Audit-log path discovery — analyzer accepts the path; CLI wiring deferred.

## DoD

- [x] Code committed + pushed
- [x] Unit tests: 15 vitest cases covering happy + edge + adversarial paths
- [x] Build, typecheck, lint green
- [x] CLI manually invoked + observed correct output (`vault-checks` no-op-clean against current Mac state)
- [x] PR open against `develop` (gitflow)
- [ ] CI green on PR (auto-merge will gate)
- [ ] Squash-merge to develop, branch + worktree gone

## References

- `reports/steward-gatekeeper-architecture-2026-05-04.md` §3.7-3.9
- `agent/memory/steward_gatekeeper_directive.md` (modes 7-9)
- `agent/memory/secrets_vault.md`
- Predecessor: PRs #285 #291 #292 #297
