### PR TITLE
chore(steward-005): promote steward-gatekeeper checks to required

### DIFF
--- a/.github/workflows/steward-gatekeeper.yml
+++ b/.github/workflows/steward-gatekeeper.yml
@@ -6,9 +6,10 @@ name: Steward Gatekeeper
 # sweep.
 #
 # Each analyzer is its own job so failures are localised in the Checks
-# tab and branch protection lists them individually. Day-1 jobs run
-# `continue-on-error: true` (warn-only) for one cycle so existing
-# in-flight PRs don't break; promotion to blocking is a follow-up PR.
+# tab and branch protection lists them individually. As of 2026-05-04
+# (PR #TBD), all three analyzers are promoted to required-on-develop+main
+# after one full clean cycle on develop (PR #295 cleanup of the live
+# 0037 collision proved them green).
 #
 # Reference:
 #   - architecture: ~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md
@@ -36,7 +37,7 @@ jobs:
   steward-gatekeeper-migration-linter:
     name: steward-gatekeeper-migration-linter
     runs-on: ubuntu-latest
-    continue-on-error: true   # warn-only first cycle
+    # promoted to required-on-develop+main 2026-05-04 (PR #TBD)
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -55,7 +56,7 @@ jobs:
   steward-gatekeeper-migration-numbering:
     name: steward-gatekeeper-migration-numbering
     runs-on: ubuntu-latest
-    continue-on-error: true   # warn-only first cycle
+    # promoted to required-on-develop+main 2026-05-04 (PR #TBD)
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -74,7 +75,7 @@ jobs:
   steward-gatekeeper-graph-divergence:
     name: steward-gatekeeper-graph-divergence
     runs-on: ubuntu-latest
-    continue-on-error: true   # warn-only first cycle
+    # promoted to required-on-develop+main 2026-05-04 (PR #TBD)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -13,8 +13,13 @@
 #       * "semgrep"                          (.github/workflows/evidence-gate.yml)
 #       * "gitleaks"                         (.github/workflows/evidence-gate.yml)
 #       * "bundle-size"                      (.github/workflows/evidence-gate.yml)
+#       * "steward-gatekeeper-migration-linter"     (.github/workflows/steward-gatekeeper.yml)
+#       * "steward-gatekeeper-migration-numbering"  (.github/workflows/steward-gatekeeper.yml)
+#       * "steward-gatekeeper-graph-divergence"     (.github/workflows/steward-gatekeeper.yml)
 #   - Require strict status checks (branch up-to-date with target before merge).
-#   - Require linear history (squash or rebase merge only).
+#   - Require linear history on main (squash or rebase merge only).
+#     Develop has linear-history DISABLED to allow back-merges from main
+#     (per agent/memory/feedback_git_flow_enforced.md 2026-05-03 update).
 #   - No force-push, no deletion.
 #   - Apply rules to admins (enforce_admins=true).
 #   - Require conversation resolution before merge.
@@ -55,10 +60,22 @@ REQUIRED_CONTEXTS_JSON='[
   "typecheck",
   "semgrep",
   "gitleaks",
-  "bundle-size"
+  "bundle-size",
+  "steward-gatekeeper-migration-linter",
+  "steward-gatekeeper-migration-numbering",
+  "steward-gatekeeper-graph-divergence"
 ]'
 
 protection_body() {
+  local branch="$1"
+  # Per agent/memory/feedback_git_flow_enforced.md (2026-05-03):
+  # required_linear_history must be DISABLED on develop so back-merges
+  # from main can land as merge commits (preserving "main is ancestor").
+  # main keeps it ENABLED — main is squash-merge from develop only.
+  local linear_history='true'
+  if [[ "${branch}" == 'develop' ]]; then
+    linear_history='false'
+  fi
   cat <<EOF
 {
   "required_status_checks": {
@@ -73,7 +90,7 @@ protection_body() {
     "required_approving_review_count": 0
   },
   "restrictions": null,
-  "required_linear_history": true,
+  "required_linear_history": ${linear_history},
   "allow_force_pushes": false,
   "allow_deletions": false,
   "block_creations": false,


### PR DESCRIPTION
## Summary

After PR #295 (the 0037 collision cleanup) landed and one full clean cycle of the `steward-gatekeeper-*` analyzers ran green on develop, the three Phase-2a/b checks are eligible for promotion to required-on-develop+main per the Phase 1 ship report (`reports/steward-gatekeeper-shipped-2026-05-04.md` recommendation #3).

## Changes

1. `.github/workflows/steward-gatekeeper.yml` — remove `continue-on-error: true` from all 3 jobs.
2. `scripts/setup-branch-protection.sh` — add the 3 steward-gatekeeper contexts to `REQUIRED_CONTEXTS_JSON`; `protection_body()` now per-branch (develop = `required_linear_history: false` per the 2026-05-03 back-merge fix, main = `true`).

## Why per-branch linear-history

The script currently emits `"required_linear_history": true` for all branches. Per `agent/memory/feedback_git_flow_enforced.md`, develop has linear-history DISABLED (operator-authorised 2026-05-03) so back-merges from main can land as merge commits — without this, every release-PR hits `mergeStateStatus: DIRTY`. Re-running the existing script would silently undo this fix. This PR codifies the per-branch rule so future re-applies are safe.

## Manual step after merge

```
bash scripts/setup-branch-protection.sh all
```

This applies the new contexts to GitHub. The script is idempotent.

## Risk assessment

- **Existing PRs (#296, #293, #297, #299)**: their current `statusCheckRollup` shows all 3 steward-gatekeeper checks SUCCESS. Once they re-run (post-merge of this PR), they remain passing.
- **Future PRs**: any PR that introduces a multi-statement migration without breakpoints / duplicate 4-digit prefix / release PR with stale develop-main merge-base will be REJECTED. This is the desired behavior.

## Verification

```
bash -n scripts/setup-branch-protection.sh                   → syntax OK
grep continue-on-error .github/workflows/steward-gatekeeper.yml  → 0 occurrences (was 3)
REQUIRED_CONTEXTS_JSON                                        → 9 contexts (was 6)
```

## DoD

- [x] Code committed + pushed
- [x] Script syntax-checked locally
- [x] Risk-assessed against in-flight PRs
- [x] PR open against `develop` (gitflow)
- [ ] CI green on PR (auto-merge will gate)
- [ ] Squash-merge to develop, branch + worktree gone
- [ ] Manual `bash scripts/setup-branch-protection.sh all` post-merge

## References

- `reports/steward-gatekeeper-architecture-2026-05-04.md` §7 (rollout safety)
- `reports/steward-gatekeeper-shipped-2026-05-04.md` recommendation #3
- `agent/memory/feedback_git_flow_enforced.md` (linear-history rule)
- `agent/memory/steward_gatekeeper_directive.md` (modes 1, 2, 3)
- Predecessor: PRs #285 #291 #292 #295
