### PR TITLE
fix(decomposer): cap rule-based section count at 20

### DIFF
--- a/packages/decomposer/src/rule-based.ts
+++ b/packages/decomposer/src/rule-based.ts
@@ -46,6 +46,35 @@ function estimateEffort(description: string): 'trivial' | 'small' | 'medium' | '
   return 'xl';
 }
 
+/**
+ * Maximum number of logical sections the rule-based decomposer will
+ * produce per prompt. Each section becomes one Epic with up to 4 Stories
+ * (each with 2 Tasks), so cap=20 produces at most 20 epics × 9 nodes/epic
+ * + 1 initiative = 181 descendants. Generous for any legitimate prompt.
+ *
+ * Failure mode (Phase-2 stability audit, 2026-04-30): an 11859-byte
+ * "very-long" prompt produced 2070+ descendants when no cap was applied,
+ * saturating the SQLite write path and intermittently timing out
+ * /health. PR #296 added an 8000-char body cap at the API gateway;
+ * this cap is the defense-in-depth fallback when very-long bodies
+ * somehow get past the gateway (e.g. via direct DB insert / future
+ * webhook ingest path / migration of legacy long prompts).
+ *
+ * Override via DecomposerConfig.maxSections or DECOMPOSER_MAX_SECTIONS env.
+ */
+export const DEFAULT_MAX_SECTIONS = 20;
+
+function applyMaxSections(sections: string[], cap: number): string[] {
+  if (sections.length <= cap) return sections;
+  // Coalesce overflow into the last retained section so no content is lost.
+  const head = sections.slice(0, cap - 1);
+  const tail = sections.slice(cap - 1).join(' ');
+  console.warn(
+    `[decomposer] prompt produced ${String(sections.length)} sections; capped at ${String(cap)} (overflow merged into final section). Increase via DecomposerConfig.maxSections if intentional.`,
+  );
+  return [...head, tail];
+}
+
 // Extract logical sections from a prompt using heuristics
 function extractSections(prompt: string): string[] {
   // Split on common separators: newlines, "and", semicolons, commas in lists
@@ -258,7 +287,13 @@ function templatesFor(verb: VerbIntent, sectionLabel: string): Array<{
 }
 
 export function decomposeRuleBased(prompt: string, _config: DecomposerConfig = {}): DecompositionResult {
-  const sections = extractSections(prompt);
+  const rawSections = extractSections(prompt);
+  // Resolve cap: per-call config > env override > built-in default.
+  const envCap = process.env['DECOMPOSER_MAX_SECTIONS'];
+  const cap =
+    _config.maxSections ??
+    (envCap !== undefined && /^\d+$/.test(envCap) ? parseInt(envCap, 10) : DEFAULT_MAX_SECTIONS);
+  const sections = applyMaxSections(rawSections, cap);
   const verb = detectVerbIntent(prompt);
 
   // Create one Initiative for the whole prompt

--- a/packages/decomposer/src/section-cap.test.ts
+++ b/packages/decomposer/src/section-cap.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { decomposeRuleBased } from './rule-based';
+import type { DecompositionNode } from './types';
+
+/**
+ * Phase-2 stability audit (2026-04-30) finding: an 11859-byte prompt
+ * caused the rule-based decomposer to produce 2070+ descendants.
+ *
+ * PR #296 added an 8000-char body cap at the API gateway. This test
+ * suite exercises the in-decomposer cap (DEFAULT_MAX_SECTIONS = 20)
+ * which is the defense-in-depth fallback for any path that bypasses
+ * the API gateway.
+ */
+
+function flattenDescendants(nodes: DecompositionNode[]): DecompositionNode[] {
+  const out: DecompositionNode[] = [];
+  for (const n of nodes) {
+    out.push(n);
+    if (n.children) out.push(...flattenDescendants(n.children));
+  }
+  return out;
+}
+
+describe('decomposer section cap (T-009)', () => {
+  it('caps section count at default 20 for runaway prompts', () => {
+    // 100 newline-separated short sentences = 100 sections without cap.
+    const sentences = Array.from(
+      { length: 100 },
+      (_, i) => `Add a feature for use case number ${i.toString().padStart(3, '0')} with associated tests`,
+    );
+    const prompt = sentences.join('\n');
+    const result = decomposeRuleBased(prompt);
+    const initiative = result.hierarchy[0];
+    const epicCount = (initiative.children ?? []).length;
+    expect(epicCount).toBeLessThanOrEqual(20);
+    expect(epicCount).toBe(20);
+  });
+
+  it('descendant count stays bounded for very-long prompts', () => {
+    // 200 sentences = 200 sections without cap = ~1800 descendants.
+    // With cap=20, expect ≤ 1 init + 20 epics * 9 nodes = 181 descendants.
+    const sentences = Array.from(
+      { length: 200 },
+      (_, i) => `Build module ${i} that handles a distinct concern`,
+    );
+    const prompt = sentences.join('\n');
+    const result = decomposeRuleBased(prompt);
+    expect(result.totalNodes).toBeLessThanOrEqual(200);
+  });
+
+  it('coalesces overflow sections into the final epic without losing content', () => {
+    const sentences = Array.from(
+      { length: 25 },
+      (_, i) => `Section content marker ${i}`,
+    );
+    const prompt = sentences.join('\n');
+    const result = decomposeRuleBased(prompt);
+    const initiative = result.hierarchy[0];
+    const finalEpic = (initiative.children ?? [])[19];
+    // Final epic's description should include content from sections 19..24.
+    expect(finalEpic.description).toContain('Section content marker 19');
+    expect(finalEpic.description).toContain('Section content marker 24');
+  });
+
+  it('honours per-call config.maxSections override', () => {
+    const sentences = Array.from(
+      { length: 30 },
+      (_, i) => `Item ${i} with sufficient content for a section`,
+    );
+    const prompt = sentences.join('\n');
+    const result = decomposeRuleBased(prompt, { maxSections: 5 });
+    const initiative = result.hierarchy[0];
+    expect((initiative.children ?? []).length).toBe(5);
+  });
+
+  it('does not cap when section count is below the default', () => {
+    // 4 sections — well below cap=20.
+    const prompt = 'Build login.\nBuild signup.\nBuild dashboard.\nBuild settings.';
+    const result = decomposeRuleBased(prompt);
+    const initiative = result.hierarchy[0];
+    expect((initiative.children ?? []).length).toBe(4);
+  });
+});

--- a/packages/decomposer/src/types.ts
+++ b/packages/decomposer/src/types.ts
@@ -28,4 +28,13 @@ export interface DecomposerConfig {
   aiProvider?: 'claude' | 'rule-based';  // rule-based for testing/cost savings
   claudeApiKey?: string;
   claudeModel?: string;       // default: claude-sonnet-4-6
+  /**
+   * Cap on the number of logical sections the rule-based decomposer
+   * will produce per prompt. Each section becomes one Epic; uncapped
+   * very-long prompts (>4 KB) produced 2000+ descendants in the
+   * 2026-04-30 audit. Defaults to 20. Also overridable via
+   * DECOMPOSER_MAX_SECTIONS env var. Excess sections are coalesced
+   * into the final retained section so no prompt content is lost.
+   */
+  maxSections?: number;
 }

--- a/packages/decomposer/vitest.config.ts
+++ b/packages/decomposer/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/rule-based-verbs.test.ts'],
+    include: ['src/rule-based-verbs.test.ts', 'src/section-cap.test.ts'],
     exclude: ['dist/**', 'node_modules/**', 'src/decomposer.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Per the 2026-05-01 production stability audit (`~/Documents/projects/reports/pipeline-production-stability-validation-2026-04-30.md` Phase-2 finding #2): an 11859-byte prompt caused the rule-based decomposer to produce 2070+ descendants. Each section becomes one Epic with 4 Stories × 2 Tasks = 9 nodes; without a cap, runaway prompts saturate SQLite.

This PR is the **defense-in-depth fallback** for the descendant-explosion failure mode. PR #296 already added an 8000-char body cap at the API gateway; this cap protects any path that bypasses the gateway (direct DB insert, future webhook ingest, legacy long-prompt migration).

## Changes

- New `DEFAULT_MAX_SECTIONS = 20` constant in `packages/decomposer/src/rule-based.ts`. Worst case: 1 init + 20 epics × 9 nodes = 181 descendants.
- New `DecomposerConfig.maxSections` config field (per-call override).
- New `DECOMPOSER_MAX_SECTIONS` env var (process-wide override).
- Overflow sections are coalesced into the final retained section so no prompt content is lost. A `console.warn` surfaces the cap event.

## Tests

5 new test cases in `packages/decomposer/src/section-cap.test.ts`:

- `caps section count at default 20 for runaway prompts` (100 sentences → 20 epics)
- `descendant count stays bounded for very-long prompts` (200 sentences → ≤200 nodes)
- `coalesces overflow sections into the final epic without losing content` (25 → 20, last contains content from 19-24)
- `honours per-call config.maxSections override` (cap=5)
- `does not cap when section count is below the default` (4 sections → 4 epics)

## Verification

```
pnpm --filter @chiefaia/decomposer test → 20/20 pass (15 verb + 5 cap)
```

## DoD

- [x] Code committed + pushed
- [x] Tests covering cap activation + override + below-cap + overflow merging
- [x] PR open against `develop`
- [ ] CI green on PR (auto-merge will gate)
- [ ] Squash-merge to develop, branch + worktree gone

## References

- `reports/pipeline-production-stability-validation-2026-04-30.md` Phase-2 finding #2
- PR #296 (API-side gateway cap)
- `reports/live-pipeline-validation-2026-04-30.md` (verb-widening predecessor #243)
