### PR TITLE
fix(steward-006): pass branch arg to protection_body in apply()

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -104,7 +104,7 @@ EOF
 apply() {
   local branch="$1"
   echo "→ ${OWNER}/${REPO}: applying protection to '${branch}'"
-  protection_body | gh api --method PUT \
+  protection_body "${branch}" | gh api --method PUT \
     -H "Accept: application/vnd.github+json" \
     "repos/${OWNER}/${REPO}/branches/${branch}/protection" \
     --input - > /dev/null


### PR DESCRIPTION
## Summary

Direct follow-up to #300. `protection_body()` was updated to take a branch argument (per-branch `required_linear_history`), but `apply()` was not updated to pass it. With bash `set -u`, the unbound `$1` inside `protection_body` errored; gh API got an empty body and returned HTTP 422.

Caught when I tried to apply the manual server-side step. Fixed locally + verified.

## Verification

```
bash scripts/setup-branch-protection.sh all
→ main 9 contexts, linear_history=true
→ develop 9 contexts, linear_history=false
```

Both branches now correctly require the 3 `steward-gatekeeper-*` contexts.

## Post-merge

No further manual step needed. Server-side branch protection is already correct (I applied it locally to unblock T-007). This PR keeps the script in sync.

## DoD

- [x] Bug fixed
- [x] Locally verified script runs cleanly
- [x] Server-side branch protection successfully applied
- [x] PR open against develop
- [ ] CI green; auto-merge will gate
- [ ] Squash-merge to develop, branch gone
