### PR TITLE
fix(steward-008): pass branch arg to protection_body (re-fix)

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -104,7 +104,7 @@ EOF
 apply() {
   local branch="$1"
   echo "→ ${OWNER}/${REPO}: applying protection to '${branch}'"
-  protection_body | gh api --method PUT \
+  protection_body "${branch}" | gh api --method PUT \
     -H "Accept: application/vnd.github+json" \
     "repos/${OWNER}/${REPO}/branches/${branch}/protection" \
     --input - > /dev/null


### PR DESCRIPTION
## Why a v2

PR #302 carried this exact 1-line fix and was on green CI. As part of the campaign's repo-cleanliness pass I deleted some orphan branches without realising one of them was #302's source — closing the PR without merging. This is the same fix on a fresh branch.

## Effect

Server-side branch protection is already correct (I applied the fixed local copy of the script when running `bash scripts/setup-branch-protection.sh all` earlier). This PR keeps the in-tree script in sync so future re-applies don't re-hit the unbound-variable error.

## Verification

```
bash -n scripts/setup-branch-protection.sh   → syntax OK
```
