### PR TITLE
feat(pr-stale): wire PR-stale analyzer to weekly auto-close cron

### DIFF
--- a/.github/workflows/stale-pr-cleanup.yml
+++ b/.github/workflows/stale-pr-cleanup.yml
@@ -1,0 +1,77 @@
+name: stale-pr-cleanup
+
+# Weekly stale-PR auto-close — fires Tuesdays at 14:00 UTC (one day after
+# `dependabot-triage.yml` so the triage issue is fresh when we close eligible
+# PRs). Closes PRs idle >=30d that aren't labelled `keep-open` and aren't
+# authored by `app/dependabot` (those are handled by `dependabot-triage.yml`).
+#
+# Per failure mode #10 in the Steward Gatekeeper (architecture doc §3.10).
+# The `pr-state` analyzer ships in PR #299; this workflow is the action-side
+# hookup — the analyzer detects, this workflow executes the close + comment.
+#
+# The closing comment ("stale; reopen if needed") matches the analyzer's
+# `pr-stale-auto-close` remediation. Repo collaborators can re-open any
+# PR with one click; the comment tells them how.
+#
+# Reference: agent/memory/steward_gatekeeper_directive.md (mode 10),
+# agent/memory/feedback_git_flow_enforced.md.
+
+on:
+  schedule:
+    # Tuesdays 14:00 UTC ≈ 07:00 PT (summer) / 06:00 PT (winter).
+    - cron: '0 14 * * 2'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List eligible PRs without closing them'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: stale-pr-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Close stale PRs (>=30d, not keep-open, not dependabot)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies (steward-analyzers + deps only)
+        run: |
+          pnpm install --filter @chiefaia/steward-analyzers... --frozen-lockfile
+
+      - name: Build steward-analyzers
+        run: pnpm --filter @chiefaia/steward-analyzers build
+
+      - name: Run pr-stale (auto-close eligible)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            echo "→ dry-run: listing eligible PRs only (no close)"
+            node packages/steward-analyzers/bin/steward-gatekeeper.mjs pr-stale
+          else
+            echo "→ live run: auto-closing eligible PRs"
+            node packages/steward-analyzers/bin/steward-gatekeeper.mjs pr-stale --auto-close
+          fi

--- a/packages/steward-analyzers/bin/steward-gatekeeper.mjs
+++ b/packages/steward-analyzers/bin/steward-gatekeeper.mjs
@@ -11,6 +11,7 @@
  *   vault-checks           — Mac-local snapshot-age check (failure mode #7)
  *   preflight              — fast pre-spawn hook (modes #4 #6 + dirty-tree)
  *   hygiene-daily          — repo-state daily snapshot (modes #4 #5 #6)
+ *   pr-stale               — list/auto-close stale PRs (mode #10); --auto-close to act
  *   all                    — run every pre-merge analyzer; OR exit code across all
  *
  * Flags:
@@ -42,6 +43,7 @@ import {
   checkWorktreeCount,
   checkOrphanBranches,
   preflightChecks,
+  checkPrStaleness,
 } from '../dist/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -308,6 +310,72 @@ function runHygieneDaily(repoRoot) {
   ];
 }
 
+// ─── PR-stale (failure mode #10) ───────────────────────────────────────────
+
+/**
+ * Fetch open PRs via `gh pr list` and run the staleness analyzer.
+ * If `--auto-close` is provided, eligible (>=30d, not keep-open, not
+ * dependabot) PRs are closed via `gh pr close` with the standard comment.
+ *
+ * The "stale; reopen if needed" comment matches the analyzer's
+ * `pr-stale-auto-close` ruleId remediation. Reference:
+ * `agent/memory/steward_gatekeeper_directive.md` (mode 10),
+ * `agent/memory/feedback_git_flow_enforced.md`.
+ */
+function runPrStale(repoRoot, opts) {
+  const autoClose = !!opts['auto-close'];
+  let raw;
+  try {
+    raw = execSync(
+      'gh pr list --state open --limit 200 --json number,title,headRefName,updatedAt,labels,isDraft,author',
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+  } catch (err) {
+    console.log(`pr-stale: cannot list PRs via gh — ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+  let prs;
+  try {
+    const parsed = JSON.parse(raw);
+    prs = parsed.map((p) => ({
+      number: p.number,
+      title: p.title,
+      branch: p.headRefName,
+      updatedAt: p.updatedAt,
+      labels: (p.labels || []).map((l) => (typeof l === 'string' ? l : l.name)),
+      isDraft: !!p.isDraft,
+      author: p.author?.login || p.author?.name || '',
+    }));
+  } catch (err) {
+    console.log(`pr-stale: cannot parse gh output — ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+  console.log(`pr-stale: scanning ${prs.length} open PR(s) (auto-close=${autoClose})`);
+  const findings = checkPrStaleness({ prs });
+  if (autoClose) {
+    const eligible = findings.filter((f) => f.ruleId === 'pr-stale-auto-close');
+    if (eligible.length === 0) {
+      console.log('pr-stale: 0 PR(s) eligible for auto-close.');
+    } else {
+      console.log(`pr-stale: closing ${eligible.length} eligible PR(s)...`);
+    }
+    for (const f of eligible) {
+      const num = f.context?.prNumber;
+      if (typeof num !== 'number') continue;
+      try {
+        execSync(
+          `gh pr close ${num} --comment ${JSON.stringify('stale; reopen if needed')}`,
+          { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' },
+        );
+        console.log(`pr-stale: closed #${num} (${f.context?.ageDays}d idle)`);
+      } catch (err) {
+        console.log(`pr-stale: failed to close #${num}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+  return findings;
+}
+
 // ─── Main entry ────────────────────────────────────────────────────────────
 
 async function main() {
@@ -319,7 +387,7 @@ async function main() {
     console.error('usage: steward-gatekeeper <command> [--repo-root <path>] [--max-age-days <N>] [--pr-head-ref <ref>] [--mac-snapshot-dir <path>]');
     console.error('  pre-merge   : migration-linter | migration-numbering | graph-divergence | all');
     console.error('  pre-spawn   : preflight');
-    console.error('  scheduled   : hygiene-daily | vault-checks');
+    console.error('  scheduled   : hygiene-daily | vault-checks | pr-stale');
     process.exit(2);
   }
 
@@ -337,6 +405,8 @@ async function main() {
       findings = runPreflight(repoRoot);
     } else if (command === 'hygiene-daily') {
       findings = runHygieneDaily(repoRoot);
+    } else if (command === 'pr-stale') {
+      findings = runPrStale(repoRoot, args.flags);
     } else if (command === 'all') {
       const a = await runMigrationLinter(repoRoot);
       const b = await runMigrationNumbering(repoRoot);


### PR DESCRIPTION
## Summary

Failure mode #10 (PRs idle ≥30d) was detection-only after PR #299; this PR adds the action hookup, completing the first "first hour back" recommendation from `~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md`.

## Changes

- **`packages/steward-analyzers/bin/steward-gatekeeper.mjs`** — new `pr-stale` subcommand. Lists findings without flags; with `--auto-close`, closes eligible PRs via `gh pr close --comment 'stale; reopen if needed'`. Skips dependabot (handled by failure mode #11 / dependabot-triage.yml) and \`keep-open\`-labelled PRs.
- **`.github/workflows/stale-pr-cleanup.yml`** — new weekly cron Tuesdays 14:00 UTC (one day after dependabot-triage). \`workflow_dispatch\` with \`dry_run\` input for safe manual testing.

## Verification

- \`pnpm --filter @chiefaia/steward-analyzers test\` — 91 tests pass (no test changes; analyzer logic was already covered by 11 cases in PR #299).
- \`node bin/steward-gatekeeper.mjs pr-stale\` — smoke-tested locally, scans open PRs, prints findings.
- \`node bin/steward-gatekeeper.mjs pr-stale --auto-close\` — smoke-tested, 0 eligible PRs at HEAD (expected; repo just shipped 8 PRs overnight).
- Workflow dispatch will be available immediately after merge for operator-driven dry-run validation.

## Coverage delta

Steward Gatekeeper coverage: **mode #10 promoted from "shipped (detection only)" → "shipped (full action)"**. 

## References

- Failure mode #10: \`agent/memory/steward_gatekeeper_directive.md\`
- Re-open policy: \`agent/memory/feedback_git_flow_enforced.md\`
- Related: PR #299 (analyzer), PR #303 (dependabot-triage workflow)

🤖 Generated with Claude (Sonnet)