### PR TITLE
feat(vault-state): hook vault-checks CLI to stolution-side daily cron

### DIFF
--- a/docs/steward.md
+++ b/docs/steward.md
@@ -137,6 +137,46 @@ promotion path.
 2. Ship the analyzer per §4.3.
 3. Update the failure-mode table (§2) and `agent/memory/steward_gatekeeper_directive.md`.
 
+### 4.5 — Deploying the vault-checks CLI on the stolution server
+
+Failure mode #7 (backup pipeline silent failure) needs to be checked on
+both sides — the Mac that pulls the snapshot, AND the stolution server
+that writes it. The Mac side runs via the `vault-checks` LaunchAgent
+(installed by `~/Library/LaunchAgents/com.caia.steward.daily.plist`).
+The stolution side runs via cron, invoking the same CLI bundle.
+
+To deploy / refresh the bundle on stolution:
+
+```bash
+# From caia repo on Mac.
+bash scripts/deploy-steward-stolution.sh
+```
+
+This builds `@chiefaia/steward-analyzers` and rsyncs `dist/` + the
+`bin/steward-gatekeeper.mjs` driver to `stolution:/home/s903/stolution/tools/steward/`.
+The deploy script is idempotent — re-runs just refresh the bundle.
+
+To install the daily cron entry (one-time):
+
+```bash
+bash scripts/install-stolution-cron.sh
+```
+
+Installs `30 17 * * * cd /home/s903/stolution/tools/steward && /usr/bin/node bin/steward-gatekeeper.mjs vault-checks --side stolution >> /home/s903/logs/steward-vault-checks.log 2>&1`
+and snapshots the prior crontab to `/tmp/cron.bak.steward-deploy.<unix-ts>`.
+Idempotent — detects an existing entry and skips if present.
+
+To verify on stolution:
+
+```bash
+ssh stolution "cd /home/s903/stolution/tools/steward && /usr/bin/node bin/steward-gatekeeper.mjs vault-checks --side stolution"
+ssh stolution "tail -20 /home/s903/logs/steward-vault-checks.log"
+```
+
+The `--side stolution` flag changes the default snapshot dir to
+`/home/s903/backups/vault` and labels findings with `side: 'stolution'`
+(vs `'mac'`). Override the dir explicitly with `--snapshot-dir <abs>`.
+
 ## 5. Local pre-flight (before pushing)
 
 Run any analyzer locally to preview before pushing:

--- a/packages/steward-analyzers/bin/steward-gatekeeper.mjs
+++ b/packages/steward-analyzers/bin/steward-gatekeeper.mjs
@@ -18,7 +18,9 @@
  *   --repo-root <path>            repo root (default: ../../../ relative to bin)
  *   --max-age-days <N>            graph-divergence threshold (default 7)
  *   --pr-head-ref <ref>           PR head branch (default $GITHUB_HEAD_REF)
- *   --mac-snapshot-dir <path>     Mac vault snapshot dir for vault-checks
+ *   --mac-snapshot-dir <path>     Mac vault snapshot dir for vault-checks (alias of --snapshot-dir, kept for back-compat)
+ *   --snapshot-dir <path>         Override snapshot dir (works with --side)
+ *   --side <name>                 'mac' (default) or 'stolution'; sets default snapshot dir + finding label
  *   --max-snapshot-age-hours <N>  vault-checks threshold (default 26)
  *
  * Exit codes: 0 (no block findings), 1 (block findings), 2 (usage error).
@@ -198,13 +200,26 @@ function newestMtimeEpoch(dir, glob) {
 }
 
 function runVaultChecks(opts) {
-  const macSnapDir = (opts['mac-snapshot-dir'] || `${os.homedir()}/Library/Application Support/Stolution/vault-snapshots`);
-  const macMtime = newestMtimeEpoch(macSnapDir, /^vault-snapshot-.*\.snap$/);
+  // Two invocation modes:
+  //   • Mac (default): scans the LaunchAgent-pulled snapshot dir.
+  //   • Stolution: scans the stolution-side native snapshot dir
+  //     (`/home/s903/backups/vault`). Side identifier comes from --side.
+  //
+  // Override either via --snapshot-dir <abs path>; --mac-snapshot-dir
+  // is preserved as an alias for backward compat with the Mac-only
+  // invocation shipped in PR #298.
+  const side = opts['side'] || 'mac';
+  const defaultDir =
+    side === 'stolution'
+      ? '/home/s903/backups/vault'
+      : `${os.homedir()}/Library/Application Support/Stolution/vault-snapshots`;
+  const snapDir = opts['snapshot-dir'] || opts['mac-snapshot-dir'] || defaultDir;
+  const mtime = newestMtimeEpoch(snapDir, /^vault-snapshot-.*\.snap$/);
 
-  console.log(`vault-checks: scanning Mac snapshot dir ${macSnapDir}`);
+  console.log(`vault-checks: side=${side} scanning snapshot dir ${snapDir}`);
   return checkSnapshotAge({
     snapshots: [
-      { side: 'mac', path: macSnapDir, mtimeEpoch: macMtime },
+      { side, path: snapDir, mtimeEpoch: mtime },
     ],
     maxAgeHours: opts['max-snapshot-age-hours'] ? parseInt(opts['max-snapshot-age-hours'], 10) : 26,
   });

--- a/scripts/deploy-steward-stolution.sh
+++ b/scripts/deploy-steward-stolution.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# deploy-steward-stolution.sh — Build steward-analyzers + rsync the dist
+# bundle to the stolution server, where it runs daily via cron to surface
+# failure mode #7 (backup pipeline silent failure) on the side that
+# actually writes the snapshots.
+#
+# Why this exists: the Mac-side `vault-checks` LaunchAgent (shipped in
+# PR #298) only sees the Mac-pulled snapshot dir. The stolution-native
+# snapshot dir (`/home/s903/backups/vault`) is on the stolution server,
+# so the only way to check it without an SSH round-trip every cron tick
+# is to run the CLI on stolution itself.
+#
+# Operator usage:
+#   bash scripts/deploy-steward-stolution.sh
+#
+# Or non-interactive (CI):
+#   STOLUTION_HOST=stolution bash scripts/deploy-steward-stolution.sh
+#
+# After deploy, verify on stolution:
+#   ssh stolution "node /home/s903/stolution/tools/steward/bin/steward-gatekeeper.mjs vault-checks --side stolution"
+#
+# The cron entry is installed once by `scripts/install-stolution-cron.sh`
+# (separate one-shot) and then re-applies of this script just refresh
+# the bundle without touching cron.
+#
+# Reference: agent/memory/steward_gatekeeper_directive.md (modes 7, 8, 9),
+#            ~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md.
+
+set -euo pipefail
+
+HOST="${STOLUTION_HOST:-stolution}"
+REMOTE_DIR="${REMOTE_DIR:-/home/s903/stolution/tools/steward}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+PKG="${HERE}/packages/steward-analyzers"
+
+echo "→ build @chiefaia/steward-analyzers"
+( cd "${HERE}" && pnpm --filter @chiefaia/steward-analyzers build ) >/dev/null
+
+echo "→ ensure remote dir ${HOST}:${REMOTE_DIR}"
+ssh "${HOST}" "mkdir -p ${REMOTE_DIR}/dist ${REMOTE_DIR}/bin"
+
+echo "→ rsync dist + bin"
+rsync -a --delete "${PKG}/dist/" "${HOST}:${REMOTE_DIR}/dist/"
+rsync -a "${PKG}/bin/steward-gatekeeper.mjs" "${HOST}:${REMOTE_DIR}/bin/steward-gatekeeper.mjs"
+
+# Minimal package.json so node resolves "../dist/index.js" via ESM.
+cat > /tmp/steward-stolution-package.json <<'JSON'
+{
+  "name": "steward-stolution-runtime",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "Stolution-side runtime bundle for @chiefaia/steward-analyzers. Synced by caia/scripts/deploy-steward-stolution.sh. DO NOT edit by hand."
+}
+JSON
+rsync -a /tmp/steward-stolution-package.json "${HOST}:${REMOTE_DIR}/package.json"
+
+echo "→ smoke-test on remote"
+ssh "${HOST}" "cd ${REMOTE_DIR} && node bin/steward-gatekeeper.mjs vault-checks --side stolution || true"
+
+echo "✓ deploy complete. Cron entry must be installed separately (one-time):"
+echo "   ssh ${HOST} 'crontab -l > /tmp/cron.bak && (crontab -l; echo \"30 17 * * * cd ${REMOTE_DIR} && /usr/bin/node bin/steward-gatekeeper.mjs vault-checks --side stolution >> /home/s903/logs/steward-vault-checks.log 2>&1\") | crontab -'"

--- a/scripts/install-stolution-cron.sh
+++ b/scripts/install-stolution-cron.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# install-stolution-cron.sh — One-shot installer for the daily steward
+# vault-checks cron entry on the stolution server. Idempotent: detects
+# an existing entry by line marker and skips if present.
+#
+# Reads + writes the s903 user's crontab (no sudo required). Snapshots
+# the prior crontab to /tmp/cron.bak.steward-deploy.<unix-ts> before
+# any mutation.
+#
+# Pair with `scripts/deploy-steward-stolution.sh` — that script syncs
+# the bundle; this one wires up the cron once. After this runs, future
+# bundle updates only need the deploy script.
+#
+# Usage:
+#   bash scripts/install-stolution-cron.sh
+#
+# Reference: agent/memory/steward_gatekeeper_directive.md (mode 7).
+
+set -euo pipefail
+
+HOST="${STOLUTION_HOST:-stolution}"
+REMOTE_DIR="${REMOTE_DIR:-/home/s903/stolution/tools/steward}"
+LOG="${LOG:-/home/s903/logs/steward-vault-checks.log}"
+# Daily 17:30 UTC ≈ 10:30 PT (summer) / 09:30 PT (winter). Offset 30
+# minutes from hygiene-report.yml (17:00 UTC) to avoid runner contention.
+SCHEDULE="${SCHEDULE:-30 17 * * *}"
+
+CRON_LINE="${SCHEDULE} cd ${REMOTE_DIR} && /usr/bin/node bin/steward-gatekeeper.mjs vault-checks --side stolution >> ${LOG} 2>&1"
+
+ssh "${HOST}" bash -s <<EOF
+set -euo pipefail
+mkdir -p "$(dirname "${LOG}")"
+touch "${LOG}"
+crontab -l > /tmp/cron.bak.steward-deploy.\$(date +%s) 2>&1 || true
+if crontab -l 2>/dev/null | grep -Fq 'bin/steward-gatekeeper.mjs vault-checks --side stolution'; then
+  echo "→ stolution-side steward cron entry already present; skipping."
+  crontab -l | grep -F 'steward-gatekeeper'
+  exit 0
+fi
+( crontab -l 2>/dev/null; echo "${CRON_LINE}" ) | crontab -
+echo "✓ installed cron entry:"
+crontab -l | grep -F 'steward-gatekeeper'
+EOF


### PR DESCRIPTION
## Summary

Failure mode #7 (backup pipeline silent failure) was Mac-only after PR #298. The Mac LaunchAgent only sees the locally-pulled snapshot dir; if stolution-side snapshot writes silently fail, Mac sees the last successful pull and reports clean. This PR makes the CLI stolution-aware and ships deploy + cron-install scripts.

This is item 2 of the four "first hour back" recommendations from `~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md`.

## Changes

- **`packages/steward-analyzers/bin/steward-gatekeeper.mjs`**: \`vault-checks\` now accepts \`--side {mac|stolution}\` (sets default snapshot dir + finding label) and \`--snapshot-dir <abs>\` (override). Backward-compat alias \`--mac-snapshot-dir\` preserved.
- **`scripts/deploy-steward-stolution.sh`**: builds steward-analyzers + rsyncs \`dist/\` + \`bin/\` to \`stolution:/home/s903/stolution/tools/steward/\`. Idempotent — re-runs refresh the bundle.
- **`scripts/install-stolution-cron.sh`**: one-shot installer for the daily cron (17:30 UTC, offset from hygiene-report.yml at 17:00 UTC to avoid runner contention). Snapshots prior crontab before mutating.
- **`docs/steward.md`**: new §4.5 recipe for stolution-side deploy.

## Deployment status (applied autonomously on stolution per Decide → Execute → Inform)

- \`/home/s903/stolution/tools/steward/\` populated with dist + bin
- Cron entry installed: \`30 17 * * * cd /home/s903/stolution/tools/steward && /usr/bin/node bin/steward-gatekeeper.mjs vault-checks --side stolution >> /home/s903/logs/steward-vault-checks.log 2>&1\`
- Manual invocation verified: \`✓ no findings.\` on stolution side (latest snapshot: 20260503-191139.snap, ~18h old, threshold 26h)
- Prior crontab snapshotted to \`/tmp/cron.bak.steward-deploy.<unix-ts>\`

## Verification

- \`pnpm --filter @chiefaia/steward-analyzers test\`: 91 pass (no test changes — the analyzer logic is unchanged; CLI shim added new flag)
- \`bash -n scripts/*.sh\`: syntax valid
- Smoke-tested both modes locally:
  - \`vault-checks\` (default mac side) → no findings on Mac
  - \`vault-checks --side stolution --snapshot-dir /tmp/no-such-dir\` → high-severity \`snapshot-missing\` finding (expected)
  - \`vault-checks --side stolution\` on stolution server → no findings (snapshot fresh)

## Coverage delta

Steward Gatekeeper coverage: **mode #7 promoted from "shipped (Mac-side only)" → "shipped (bidirectional, both sides covered)"**.

## References

- Failure mode #7: \`agent/memory/steward_gatekeeper_directive.md\`
- Related: PR #298 (Mac-side analyzer + LaunchAgent path)
- Architecture: \`~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md\`

🤖 Generated with Claude (Sonnet)