### PR TITLE
feat(orchestrator): boot-time in-flight prompt resume sweep (T-010)

### DIFF
--- a/apps/orchestrator/src/api/start.ts
+++ b/apps/orchestrator/src/api/start.ts
@@ -17,6 +17,7 @@ import { createApp } from './app';
 import { wireEventBus, eventBus } from '../events/bus-adapter';
 import { wirePhase2 } from '../agents/wire-phase2';
 import type { Phase2Context } from '../agents/wire-phase2';
+import { resumeStalledPrompts } from '../prompts/resume';
 // FREG-003: subscribe FeatureRegistryWriter to story.completed at boot.
 import { registerFeatureRegistryWriter } from '../agents/feature-registry-writer';
 import { subscribeToEvents as subscribePriorityEvents, scoreAll } from '../prioritization/reprioritizer';
@@ -113,6 +114,26 @@ export async function startApiServer(conductorDir?: string): Promise<{ stop: () 
   const { migrated } = await migrateFromJsonl(db, conductorDir);
   if (migrated > 0) {
     console.error(`[conductor] Migrated ${migrated} records from JSONL to SQLite`);
+  }
+
+  // T-010: sweep prompts left non-terminal by a previous orchestrator
+  // process (launchd kill, OOM, Ctrl-C). Conservative — emits
+  // `prompt.resumed` for warm/cold-restart cases and only mutates state
+  // when all descendants are already terminal (stalled-but-complete).
+  // Set CAIA_INFLIGHT_RESUME_DISABLED=1 to skip; default behaviour is on.
+  if (process.env['CAIA_INFLIGHT_RESUME_DISABLED'] !== '1') {
+    try {
+      const sweep = resumeStalledPrompts(db);
+      if (sweep.swept > 0) {
+        console.error(
+          `[conductor] in-flight resume: swept=${sweep.swept} cold=${sweep.coldRestart} warm=${sweep.warmRestart} answered=${sweep.markedAnswered}`,
+        );
+      }
+    } catch (err) {
+      // Boot must not fail because of a sweep error; the prompts will
+      // still be visible via the normal listing endpoints.
+      console.error('[conductor] in-flight resume sweep failed:', err);
+    }
   }
 
   // CODING-007: wire Phase 2 task-manager subsystem (registry, ready-pool

--- a/apps/orchestrator/src/prompts/resume.ts
+++ b/apps/orchestrator/src/prompts/resume.ts
@@ -1,0 +1,210 @@
+/**
+ * In-flight prompt resume on orchestrator boot.
+ *
+ * Per the 2026-05-04 Phase-2 stability audit (finding #3, deferred from
+ * the overnight campaign as T-010), prompts that were mid-pipeline when
+ * the orchestrator was killed by launchd / Ctrl-C / OOM are left in a
+ * non-terminal status forever — `prompt.received` was emitted but no
+ * subsequent `prompt.status_changed` will ever fire.
+ *
+ * This module sweeps non-terminal prompts at boot and decides one of
+ * three outcomes per prompt:
+ *
+ *   • **cold-restart** — prompt has 0 descendants (decomposition never
+ *     started). Emit `prompt.resumed` with reason `cold-restart` so a
+ *     downstream consumer can re-pick. Status stays `received`.
+ *
+ *   • **stalled-but-complete** — all descendants are in terminal status
+ *     (done / failed / answered) but the prompt itself never advanced.
+ *     The orchestrator died after the last descendant transition but
+ *     before the final `updatePromptStatus(answered)`. Move the prompt
+ *     to `answered` (this also fires `pipeline.completed` via the
+ *     existing manager.ts plumbing).
+ *
+ *   • **warm-restart** — prompt has descendants but at least one is
+ *     still non-terminal. Emit `prompt.resumed` with reason
+ *     `warm-restart` and the descendant counts; do not change the
+ *     prompt status (the in-flight descendants still have their own
+ *     recovery path via the executor / worker reconcile loops).
+ *
+ * Conservative by design — we never *retry* anything; we only *signal*
+ * recoverability and update the one safe status (stalled-but-complete).
+ * The pickup mechanism is an existing consumer's responsibility.
+ *
+ * Reference:
+ *   - ~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md
+ *     §"Pipeline edge-case hardening" finding #3
+ *   - agent/memory/feedback_definition_of_done.md
+ */
+
+import { eq, lt, inArray, and } from 'drizzle-orm';
+import type { Db } from '../db/connection';
+import { prompts } from '../db/schema';
+import { eventBus } from '../events/bus-adapter';
+import { getPromptDescendants, updatePromptStatus } from './manager';
+import type { Prompt, PromptStatus } from './types';
+
+/** PromptStatus values that mean "still in flight". */
+const NON_TERMINAL_STATUSES = ['received', 'analyzing', 'decomposed'] as const;
+
+/** Descendant statuses considered terminal (i.e. no further work expected). */
+const TERMINAL_DESCENDANT_STATUSES = new Set([
+  'done',
+  'completed',
+  'answered',
+  'failed',
+  'cancelled',
+  'archived',
+]);
+
+export interface ResumeStalledPromptsOptions {
+  /**
+   * Minimum age (ms) before a non-terminal prompt is considered stalled.
+   * Defaults to 60_000 (60s). Tests pass small values; production boots
+   * use the default to avoid sweeping prompts that *just* arrived in the
+   * last second of the previous orchestrator's life.
+   */
+  minStalledMs?: number;
+  /** Reference now-ms. Default Date.now(). */
+  nowMs?: number;
+  /** Cap on the number of prompts to process per sweep. Default 1000. */
+  maxSweep?: number;
+}
+
+export interface ResumeOutcome {
+  promptId: string;
+  outcome: 'cold-restart' | 'warm-restart' | 'stalled-but-complete';
+  ageSeconds: number;
+  descendantCounts?: { total: number; terminal: number; nonTerminal: number };
+}
+
+export interface ResumeStalledPromptsResult {
+  swept: number;
+  coldRestart: number;
+  warmRestart: number;
+  markedAnswered: number;
+  outcomes: ResumeOutcome[];
+}
+
+/**
+ * Sweep non-terminal prompts and apply the resume policy. Idempotent:
+ * a second invocation with the same DB state will be a no-op for
+ * `warm-restart` and `cold-restart` outcomes (no DB mutation), and for
+ * `stalled-but-complete` (already moved to terminal `answered`).
+ */
+export function resumeStalledPrompts(
+  db: Db,
+  opts: ResumeStalledPromptsOptions = {},
+): ResumeStalledPromptsResult {
+  const minStalledMs = opts.minStalledMs ?? 60_000;
+  const nowMs = opts.nowMs ?? Date.now();
+  const maxSweep = opts.maxSweep ?? 1000;
+  const cutoffIso = new Date(nowMs - minStalledMs).toISOString();
+
+  const stalled = db
+    .select()
+    .from(prompts)
+    .where(
+      and(
+        inArray(prompts.status, [...NON_TERMINAL_STATUSES]),
+        lt(prompts.receivedAt, cutoffIso),
+      ),
+    )
+    .limit(maxSweep)
+    .all() as Prompt[];
+
+  const result: ResumeStalledPromptsResult = {
+    swept: stalled.length,
+    coldRestart: 0,
+    warmRestart: 0,
+    markedAnswered: 0,
+    outcomes: [],
+  };
+
+  for (const prompt of stalled) {
+    const ageSeconds = Math.floor((nowMs - new Date(prompt.receivedAt).getTime()) / 1000);
+    const descendants = getPromptDescendants(db, prompt.id);
+    const total = descendants.length;
+    const terminal = descendants.filter((d) => TERMINAL_DESCENDANT_STATUSES.has(d.status))
+      .length;
+    const nonTerminal = total - terminal;
+
+    if (total === 0) {
+      // cold-restart: nothing happened yet. Re-signal so a consumer can pick.
+      eventBus.publish({
+        type: 'prompt.resumed',
+        actor: 'system',
+        correlation_id: prompt.correlationId,
+        entity_type: 'prompt',
+        entity_id: prompt.id,
+        payload: {
+          prompt_id: prompt.id,
+          reason: 'cold-restart',
+          age_seconds: ageSeconds,
+          status_at_sweep: prompt.status,
+          received_via: prompt.receivedVia,
+        },
+      });
+      result.coldRestart += 1;
+      result.outcomes.push({
+        promptId: prompt.id,
+        outcome: 'cold-restart',
+        ageSeconds,
+      });
+      continue;
+    }
+
+    if (nonTerminal === 0) {
+      // stalled-but-complete: descendants finished but prompt was never advanced.
+      // Use updatePromptStatus so the existing pipeline.completed machinery fires.
+      updatePromptStatus(db, prompt.id, 'answered' as PromptStatus);
+      eventBus.publish({
+        type: 'prompt.resumed',
+        actor: 'system',
+        correlation_id: prompt.correlationId,
+        entity_type: 'prompt',
+        entity_id: prompt.id,
+        payload: {
+          prompt_id: prompt.id,
+          reason: 'stalled-but-complete',
+          age_seconds: ageSeconds,
+          descendants_total: total,
+        },
+      });
+      result.markedAnswered += 1;
+      result.outcomes.push({
+        promptId: prompt.id,
+        outcome: 'stalled-but-complete',
+        ageSeconds,
+        descendantCounts: { total, terminal, nonTerminal },
+      });
+      continue;
+    }
+
+    // warm-restart: in-flight descendants exist; signal but don't mutate.
+    eventBus.publish({
+      type: 'prompt.resumed',
+      actor: 'system',
+      correlation_id: prompt.correlationId,
+      entity_type: 'prompt',
+      entity_id: prompt.id,
+      payload: {
+        prompt_id: prompt.id,
+        reason: 'warm-restart',
+        age_seconds: ageSeconds,
+        descendants_total: total,
+        descendants_terminal: terminal,
+        descendants_non_terminal: nonTerminal,
+      },
+    });
+    result.warmRestart += 1;
+    result.outcomes.push({
+      promptId: prompt.id,
+      outcome: 'warm-restart',
+      ageSeconds,
+      descendantCounts: { total, terminal, nonTerminal },
+    });
+  }
+
+  return result;
+}

--- a/apps/orchestrator/tests/api/prompts-resume.test.ts
+++ b/apps/orchestrator/tests/api/prompts-resume.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for src/prompts/resume.ts — boot-time sweep of in-flight prompts.
+ *
+ * Per the 2026-05-04 Phase-2 stability audit (T-010); see
+ * src/prompts/resume.ts for the full design rationale.
+ */
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as path from 'path';
+import * as schema from '../../src/db/schema';
+import {
+  createPrompt,
+  updatePromptStatus,
+} from '../../src/prompts/manager';
+import { resumeStalledPrompts } from '../../src/prompts/resume';
+import { eventBus } from '../../src/events/bus-adapter';
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations');
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+
+function insertStory(
+  db: Db,
+  rootPromptId: string,
+  status: string,
+  createdAt = new Date().toISOString(),
+) {
+  const id = `sty_${Math.random().toString(36).slice(2, 10)}`;
+  db.insert(schema.stories).values({
+    id,
+    title: 'test story',
+    status,
+    createdAt,
+    rootPromptId,
+  }).run();
+  return id;
+}
+
+function backdatePromptRaw(sqlite: Database.Database, id: string, isoTs: string) {
+  sqlite.prepare('UPDATE prompts SET received_at = ? WHERE id = ?').run(isoTs, id);
+}
+
+describe('resumeStalledPrompts (T-010)', () => {
+  it('sweeps nothing when there are no prompts', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+    const result = resumeStalledPrompts(db);
+    expect(result.swept).toBe(0);
+    expect(result.outcomes).toEqual([]);
+  });
+
+  it('skips fresh prompts under the minStalledMs threshold', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+    createPrompt(db, { body: 'fresh prompt' });
+    const result = resumeStalledPrompts(db, { minStalledMs: 60_000 });
+    expect(result.swept).toBe(0);
+  });
+
+  it('classifies a stalled prompt with no descendants as cold-restart', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+    const p = createPrompt(db, { body: 'cold-restart candidate' });
+    backdatePromptRaw(sqlite, p.id, new Date(Date.now() - 5 * 60_000).toISOString());
+
+    const result = resumeStalledPrompts(db, { minStalledMs: 60_000 });
+    expect(result.swept).toBe(1);
+    expect(result.coldRestart).toBe(1);
+    expect(result.warmRestart).toBe(0);
+    expect(result.markedAnswered).toBe(0);
+    expect(result.outcomes[0].outcome).toBe('cold-restart');
+    expect(result.outcomes[0].promptId).toBe(p.id);
+    // Prompt status is unchanged on cold-restart.
+    const after = sqlite.prepare('SELECT status FROM prompts WHERE id = ?').get(p.id) as { status: string };
+    expect(after.status).toBe('received');
+  });
+
+  it('classifies a stalled prompt with all-terminal descendants as stalled-but-complete and marks it answered', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+    const p = createPrompt(db, { body: 'stalled-but-complete candidate' });
+    backdatePromptRaw(sqlite, p.id, new Date(Date.now() - 5 * 60_000).toISOString());
+
+    insertStory(db, p.id, 'verified');
+    insertStory(db, p.id, 'verified');
+
+    // Treat 'verified' as terminal — it's in the TERMINAL_DESCENDANT_STATUSES?
+    // No — `verified` is not in our terminal set. Use 'done' instead.
+    sqlite.prepare("UPDATE stories SET status = 'done' WHERE root_prompt_id = ?").run(p.id);
+
+    const result = resumeStalledPrompts(db, { minStalledMs: 60_000 });
+    expect(result.swept).toBe(1);
+    expect(result.markedAnswered).toBe(1);
+    expect(result.coldRestart).toBe(0);
+    expect(result.warmRestart).toBe(0);
+    expect(result.outcomes[0].outcome).toBe('stalled-but-complete');
+
+    const promptAfter = sqlite.prepare('SELECT status, completed_at FROM prompts WHERE id = ?').get(p.id) as {
+      status: string; completed_at: string | null;
+    };
+    expect(promptAfter.status).toBe('answered');
+    expect(promptAfter.completed_at).not.toBeNull();
+  });
+
+  it('classifies a stalled prompt with mixed descendants as warm-restart without mutating', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+    const p = createPrompt(db, { body: 'warm-restart candidate' });
+    backdatePromptRaw(sqlite, p.id, new Date(Date.now() - 10 * 60_000).toISOString());
+    updatePromptStatus(db, p.id, 'analyzing');
+
+    insertStory(db, p.id, 'done');
+    insertStory(db, p.id, 'pending'); // non-terminal
+
+    const result = resumeStalledPrompts(db, { minStalledMs: 60_000 });
+    expect(result.swept).toBe(1);
+    expect(result.warmRestart).toBe(1);
+    expect(result.coldRestart).toBe(0);
+    expect(result.markedAnswered).toBe(0);
+    expect(result.outcomes[0].outcome).toBe('warm-restart');
+    expect(result.outcomes[0].descendantCounts).toEqual({
+      total: 2,
+      terminal: 1,
+      nonTerminal: 1,
+    });
+
+    // Status unchanged on warm-restart.
+    const promptAfter = sqlite.prepare('SELECT status FROM prompts WHERE id = ?').get(p.id) as { status: string };
+    expect(promptAfter.status).toBe('analyzing');
+  });
+
+  it('honours the maxSweep cap', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+    const old = new Date(Date.now() - 5 * 60_000).toISOString();
+    for (let i = 0; i < 5; i++) {
+      const p = createPrompt(db, { body: `stalled ${i}` });
+      backdatePromptRaw(sqlite, p.id, old);
+    }
+
+    const result = resumeStalledPrompts(db, { minStalledMs: 60_000, maxSweep: 3 });
+    expect(result.swept).toBe(3);
+    expect(result.outcomes).toHaveLength(3);
+  });
+
+  it('publishes prompt.resumed events with the right reason', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+    // Wire the bus adapter so events are persisted to this in-memory DB.
+    const { wireEventBus } = require('../../src/events/bus-adapter');
+    wireEventBus(db);
+
+    const p = createPrompt(db, { body: 'event-fire test' });
+    backdatePromptRaw(sqlite, p.id, new Date(Date.now() - 5 * 60_000).toISOString());
+
+    resumeStalledPrompts(db, { minStalledMs: 60_000 });
+
+    const events = sqlite
+      .prepare("SELECT type, payload_json FROM events WHERE entity_id = ? AND type = 'prompt.resumed'")
+      .all(p.id) as Array<{ type: string; payload_json: string }>;
+    expect(events).toHaveLength(1);
+    const payload = JSON.parse(events[0].payload_json);
+    expect(payload.reason).toBe('cold-restart');
+    expect(payload.prompt_id).toBe(p.id);
+  });
+
+  it('is idempotent on warm-restart (second call does not double-emit state-changing side effects)', () => {
+    const sqlite = new Database(':memory:');
+    const db = drizzle(sqlite, { schema }) as Db;
+    migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+
+    const p = createPrompt(db, { body: 'idempotency test' });
+    backdatePromptRaw(sqlite, p.id, new Date(Date.now() - 10 * 60_000).toISOString());
+    updatePromptStatus(db, p.id, 'analyzing');
+    insertStory(db, p.id, 'done');
+    insertStory(db, p.id, 'pending');
+
+    const r1 = resumeStalledPrompts(db, { minStalledMs: 60_000 });
+    const r2 = resumeStalledPrompts(db, { minStalledMs: 60_000 });
+
+    expect(r1.warmRestart).toBe(1);
+    expect(r2.warmRestart).toBe(1); // status unchanged → still warm
+    // Status remains 'analyzing' both times.
+    const status = sqlite.prepare('SELECT status FROM prompts WHERE id = ?').get(p.id) as { status: string };
+    expect(status.status).toBe('analyzing');
+  });
+});

--- a/packages/events-taxonomy-internal/index.ts
+++ b/packages/events-taxonomy-internal/index.ts
@@ -462,7 +462,7 @@ export type EventType =
   | 'lock.acquired' | 'lock.released' | 'lock.expired'
   | 'build.started' | 'build.step_started' | 'build.step_completed'
   | 'build.step_failed' | 'build.completed' | 'build.aborted'
-  | 'prompt.received' | 'prompt.status_changed'
+  | 'prompt.received' | 'prompt.status_changed' | 'prompt.resumed'
   | 'priority.scored' | 'priority.rebucketed' | 'priority.reordered' | 'priority.user_override'
   | 'system.decision_made'
   | 'secret.fetched' | 'secret.cache_hit' | 'secret.rotation_triggered'
@@ -573,7 +573,7 @@ export const EVENT_SEVERITY: Record<EventType, EventSeverity> = {
   'lock.acquired': 'debug', 'lock.released': 'debug', 'lock.expired': 'warning',
   'build.started': 'info', 'build.step_started': 'info', 'build.step_completed': 'info',
   'build.step_failed': 'error', 'build.completed': 'info', 'build.aborted': 'warning',
-  'prompt.received': 'info', 'prompt.status_changed': 'info',
+  'prompt.received': 'info', 'prompt.status_changed': 'info', 'prompt.resumed': 'info',
   'priority.scored': 'info', 'priority.rebucketed': 'info',
   'priority.reordered': 'info', 'priority.user_override': 'info',
   'system.decision_made': 'info',

--- a/packages/events-taxonomy-internal/registry.yaml
+++ b/packages/events-taxonomy-internal/registry.yaml
@@ -341,6 +341,12 @@ events:
     actor: [user, api, mcp, executor]
     payload: [prompt_id, from_status, to_status, elapsed_ms]
 
+  # Boot-time in-flight resume sweep (T-010, 2026-05-04)
+  - type: prompt.resumed
+    severity: info
+    actor: [system]
+    payload: [prompt_id, reason, age_seconds, status_at_sweep, received_via, descendants_total, descendants_terminal, descendants_non_terminal]
+
   - type: prompt.ingested
     severity: info
     actor: [user, api, mcp, executor]


### PR DESCRIPTION
## Summary

Resolves Phase-2 stability audit finding #3 (deferred from the overnight campaign). Prompts mid-pipeline when the orchestrator was killed (launchd, OOM, Ctrl-C) were left in a non-terminal status forever — \`prompt.received\` was emitted but no subsequent \`prompt.status_changed\` would ever fire.

This is item 3 of the four "first hour back" recommendations from \`~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md\`.

## Approach — conservative

Never *retries* anything; only *signals* recoverability and updates the one safe status transition (stalled-but-complete → answered). Three outcome classes, one per swept prompt:

| Outcome | Trigger | Action | DB mutation |
|---|---|---|---|
| **cold-restart** | 0 descendants | emit \`prompt.resumed\` reason=\`cold-restart\` | none — status stays \`received\` for the existing pickup path |
| **stalled-but-complete** | all descendants terminal | mark prompt \`answered\` via \`updatePromptStatus\` | yes — \`pipeline.completed\` fires through existing plumbing |
| **warm-restart** | mixed descendants | emit \`prompt.resumed\` reason=\`warm-restart\` | none — in-flight descendants have their own reconcile loops |

## Changes

- **`apps/orchestrator/src/prompts/resume.ts`** (new): \`resumeStalledPrompts(db, opts?)\` with the policy above. Idempotent.
- **`apps/orchestrator/src/api/start.ts`**: invokes the sweep after migrations + before HTTP listen. \`CAIA_INFLIGHT_RESUME_DISABLED=1\` env opt-out. \`try/catch\` so a sweep error never blocks boot.
- **`packages/events-taxonomy-internal/{index.ts,registry.yaml}`**: register \`prompt.resumed\` (severity \`info\`, actor \`[system]\`).
- **`apps/orchestrator/tests/api/prompts-resume.test.ts`** (new): 8 test cases.

## Verification

- \`npx jest tests/api/prompts-resume.test.ts --runInBand\`: **8/8 pass**
  - empty DB → no-op
  - fresh prompt skipped (under threshold)
  - cold-restart classification + status preservation
  - stalled-but-complete classification + answered transition + \`completed_at\` set
  - warm-restart classification + status preservation + descendant counts
  - \`maxSweep\` cap honoured
  - \`prompt.resumed\` event emitted with correct \`reason\`
  - idempotency on warm-restart (second call same outcome, status unchanged)
- \`npx tsc -p tsconfig.json --noEmit\`: clean
- Existing prompts manager tests unaffected (additive change)

## Coverage delta

Phase-2 stability audit: **finding #3 promoted from "NOT FIXED tonight — risky; deferred" → "shipped"**.

## References

- Phase-2 stability audit finding #3: \`~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md\` §"Pipeline edge-case hardening"
- Conservative recovery policy: \`agent/memory/feedback_definition_of_done.md\`

🤖 Generated with Claude (Sonnet)