### PR TITLE
feat(steward): mac launchd plists for daily + weekly steward runs

### DIFF
--- a/docs/steward.md
+++ b/docs/steward.md
@@ -176,6 +176,50 @@ ssh stolution "tail -20 /home/s903/logs/steward-vault-checks.log"
 The `--side stolution` flag changes the default snapshot dir to
 `/home/s903/backups/vault` and labels findings with `side: 'stolution'`
 (vs `'mac'`). Override the dir explicitly with `--snapshot-dir <abs>`.
+### 4.6 — Mac launchd: daily + weekly Steward runs
+
+Failure modes 4 (stash count), 5 (orphan branches), 6 (worktree count),
+and the Mac side of mode 7 (snapshot age) only have meaningful signal
+*on the Mac itself* — the CI cron sees `origin/`, not the local working
+tree. These are wired up via two launchd LaunchAgents:
+
+| Agent | Cadence | Wraps |
+|---|---|---|
+| `com.steward.daily` | every day 09:00 local | `hygiene-daily` + `vault-checks` |
+| `com.steward.weekly` | Mondays 09:15 local | daily + `pr-stale` (list-only) |
+
+Sources live in `infrastructure/launchd/com.steward.{daily,weekly}.plist`
+and the wrapper at `scripts/steward-run.sh`. The wrapper is mirrored to
+`~/bin/steward-run.sh` at install time because launchd-spawned binaries
+cannot exec targets under `~/Documents/` on modern macOS (TCC privacy
+controls).
+
+Install / re-install:
+
+```bash
+bash scripts/install-steward-launchd.sh
+```
+
+Idempotent — unloads any prior version before re-loading. Operator-level,
+not root.
+
+Verify after install:
+
+```bash
+launchctl list | grep com.steward          # both agents listed, last-exit 0
+launchctl kickstart -k gui/$UID/com.steward.daily   # fire on demand
+tail -50 ~/Library/Logs/steward-daily.launchd.log
+```
+
+When `pr-stale` is added to the CLI (PR #306), the weekly wrapper picks
+it up automatically — no plist edit required. The wrapper records the
+worst exit code across all checks per run; non-zero implies findings,
+zero is clean.
+
+Note the action-side close for stale PRs (mode #10) lives in the GHA
+workflow `.github/workflows/stale-pr-cleanup.yml` (Tuesdays 14:00 UTC),
+not in the Mac weekly launchd run — Mac-side is list-only to avoid
+double-close races.
 
 ## 5. Local pre-flight (before pushing)
 

--- a/infrastructure/launchd/com.steward.daily.plist
+++ b/infrastructure/launchd/com.steward.daily.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.steward.daily
+
+  Mac-side daily Steward Gatekeeper checks. Runs the filesystem-local
+  hygiene + vault-checks aggregates; the GHA-side hygiene-report.yml
+  cron is the network-visible counterpart (it runs against origin,
+  not the local working tree). Mac-launchd is required because
+  failure modes 4 (stash count), 5 (orphan branches), 6 (worktree
+  count) only have meaningful signal *on the Mac*, where the operator
+  actually creates worktrees and stashes.
+
+  Schedule: 09:00 local — picks up state from the previous day's work
+  before the operator starts the next day.
+
+  Install (via the canonical installer script):
+    bash scripts/install-steward-launchd.sh
+
+  Or manually:
+    cp infrastructure/launchd/com.steward.daily.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.steward.daily.plist
+
+  Test (on demand):
+    launchctl kickstart -k gui/$UID/com.steward.daily
+
+  Verify:
+    launchctl list | grep com.steward.daily
+    tail -50 ~/Library/Logs/steward-daily.launchd.log
+
+  Reference: agent/memory/steward_gatekeeper_directive.md (modes 4-7),
+             docs/steward.md §4.6.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.steward.daily</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/MAC/bin/steward-run.sh</string>
+        <string>daily</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Don't run at load (avoid noisy first-fire on launchctl load) -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- One-shot per scheduled trigger; don't keep alive on exit -->
+    <key>KeepAlive</key>
+    <false/>
+
+    <!-- Throttle restart on crash so we don't burn CPU spinning on a bad run -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <!-- Capture launchd-level stdout/err (the wrapper writes its own structured log too) -->
+    <key>StandardOutPath</key>
+    <string>/Users/MAC/Library/Logs/steward-daily.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/MAC/Library/Logs/steward-daily.launchd.log</string>
+
+    <!-- Inherit user's PATH so node, gh, git resolve normally -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/infrastructure/launchd/com.steward.weekly.plist
+++ b/infrastructure/launchd/com.steward.weekly.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.steward.weekly
+
+  Mac-side weekly Steward Gatekeeper checks. Superset of daily —
+  re-runs the daily hygiene + vault aggregates plus pr-stale (mode #10
+  list-only; the action-side close lives in
+  .github/workflows/stale-pr-cleanup.yml on a separate server cron, so
+  this never double-closes).
+
+  Schedule: Mondays 09:15 local — fires 15 minutes after Monday's
+  daily run so the two don't compete for the working tree.
+
+  Install (via the canonical installer script):
+    bash scripts/install-steward-launchd.sh
+
+  Or manually:
+    cp infrastructure/launchd/com.steward.weekly.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.steward.weekly.plist
+
+  Test (on demand):
+    launchctl kickstart -k gui/$UID/com.steward.weekly
+
+  Verify:
+    launchctl list | grep com.steward.weekly
+    tail -50 ~/Library/Logs/steward-weekly.launchd.log
+
+  Reference: agent/memory/steward_gatekeeper_directive.md (modes 4-10),
+             docs/steward.md §4.6.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.steward.weekly</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/MAC/bin/steward-run.sh</string>
+        <string>weekly</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>1</integer> <!-- Monday -->
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/MAC/Library/Logs/steward-weekly.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/MAC/Library/Logs/steward-weekly.launchd.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/install-steward-launchd.sh
+++ b/scripts/install-steward-launchd.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# install-steward-launchd.sh — Install the Mac-side Steward LaunchAgents.
+# Idempotent: unloads any prior version of each plist before re-loading,
+# so re-runs pick up plist edits without operator intervention.
+#
+# Installs:
+#   ~/Library/LaunchAgents/com.steward.daily.plist  (09:00 local daily)
+#   ~/Library/LaunchAgents/com.steward.weekly.plist (Mondays 09:15 local)
+#
+# Verify after install:
+#   launchctl list | grep com.steward
+#   launchctl kickstart -k gui/$UID/com.steward.daily   # fire on demand
+#   tail -50 ~/Library/Logs/steward-daily.launchd.log
+#
+# Reference: agent/memory/steward_gatekeeper_directive.md.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_DIR="${HERE}/infrastructure/launchd"
+DEST_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs"
+# launchd-spawned scripts CANNOT execute targets under ~/Documents on
+# modern macOS (TCC privacy controls block "Full Disk Access" for the
+# launchd worker). Mirror the wrapper into ~/bin/ — the same pattern
+# used by ~/bin/pull-stolution-vault-snapshots.sh shipped with the
+# vault-snapshot-pull LaunchAgent.
+BIN_DIR="${HOME}/bin"
+
+mkdir -p "${DEST_DIR}" "${LOG_DIR}" "${BIN_DIR}"
+
+# Mirror the wrapper to ~/bin/ so launchd can exec it without TCC blocks.
+cp "${HERE}/scripts/steward-run.sh" "${BIN_DIR}/steward-run.sh"
+chmod +x "${BIN_DIR}/steward-run.sh"
+echo "→ mirrored ${BIN_DIR}/steward-run.sh"
+
+for plist in com.steward.daily.plist com.steward.weekly.plist; do
+  src="${SRC_DIR}/${plist}"
+  dest="${DEST_DIR}/${plist}"
+  label="${plist%.plist}"
+
+  if [[ ! -f "${src}" ]]; then
+    echo "✗ source plist missing: ${src}" >&2
+    exit 1
+  fi
+
+  # Unload prior version if loaded (ignore failure — may not be loaded yet).
+  if launchctl list 2>/dev/null | grep -q "${label}"; then
+    echo "→ unloading existing ${label}"
+    launchctl unload "${dest}" 2>/dev/null || true
+  fi
+
+  cp "${src}" "${dest}"
+  echo "→ installed ${dest}"
+
+  launchctl load "${dest}"
+  echo "→ loaded ${label}"
+done
+
+echo
+echo "✓ All Steward launchd agents installed."
+echo
+launchctl list | grep -E "com\.steward\.(daily|weekly)" || true
+echo
+echo "Manual fire (smoke test):"
+echo "  launchctl kickstart -k gui/\$UID/com.steward.daily"

--- a/scripts/steward-run.sh
+++ b/scripts/steward-run.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# steward-run.sh — Wrapper for the Steward CLI invoked by launchd
+# (com.steward.daily / com.steward.weekly). Aggregates the appropriate
+# subcommands per cadence and writes a timestamped log line per run.
+#
+# Why a wrapper instead of putting `steward-gatekeeper.mjs daily` directly
+# in the plist: the set of subcommands we want to run as "daily" / "weekly"
+# evolves over campaigns (new analyzers ship; coverage expands). Keeping
+# the routing in a script means we can add more checks without touching
+# the plist (which is a slower change because it requires `launchctl
+# unload && load` to pick up).
+#
+# Usage (invoked by launchd):
+#   bash scripts/steward-run.sh daily
+#   bash scripts/steward-run.sh weekly
+#
+# Usage (manual / debug):
+#   bash scripts/steward-run.sh daily | tee /tmp/steward-daily.log
+#
+# Reference: agent/memory/steward_gatekeeper_directive.md (modes 4-10),
+#            ~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md.
+
+set -uo pipefail
+# Note: NOT using `set -e` — we want to run all checks even if one is
+# non-zero, then return the worst exit code at the end.
+
+cadence="${1:-}"
+if [[ "${cadence}" != "daily" && "${cadence}" != "weekly" ]]; then
+  echo "usage: $0 <daily|weekly>" >&2
+  exit 2
+fi
+
+# When invoked from the repo: HERE = repo root.
+# When invoked from ~/bin/ (launchd path): fall back to CAIA_REPO_DIR env
+# (default: /Users/MAC/Documents/projects/caia, matching this operator's
+# canonical layout — override via launchd plist EnvironmentVariables to
+# install elsewhere).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -d "${SCRIPT_DIR}/../packages/steward-analyzers" ]]; then
+  HERE="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  HERE="${CAIA_REPO_DIR:-/Users/MAC/Documents/projects/caia}"
+fi
+CLI="${HERE}/packages/steward-analyzers/bin/steward-gatekeeper.mjs"
+NODE="${NODE_BIN:-/opt/homebrew/bin/node}"
+[[ -x "${NODE}" ]] || NODE="$(command -v node || true)"
+[[ -n "${NODE}" ]] || { echo "node not found" >&2; exit 2; }
+[[ -f "${CLI}" ]] || { echo "steward CLI not found at ${CLI}" >&2; exit 2; }
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+worst=0
+record_exit() {
+  local ec=$1
+  if (( ec > worst )); then worst=${ec}; fi
+}
+
+run_check() {
+  local name=$1
+  shift
+  echo "[$(ts)] ── steward ${cadence} :: ${name} ──"
+  "${NODE}" "${CLI}" "$@"
+  local ec=$?
+  if (( ec != 0 )); then
+    record_exit ${ec}
+  fi
+  echo
+}
+
+cd "${HERE}"
+
+case "${cadence}" in
+  daily)
+    # Failure modes 4, 5, 6 (filesystem-local hygiene)
+    run_check "hygiene-daily" hygiene-daily
+    # Failure mode 7 (Mac-side snapshot freshness; stolution-side is on stolution cron)
+    run_check "vault-checks" vault-checks
+    ;;
+  weekly)
+    # Weekly = daily plus mode 10 (PR staleness) listed only — the
+    # action-side close lives in .github/workflows/stale-pr-cleanup.yml
+    # (server cron) so we never double-close from launchd.
+    run_check "hygiene-daily" hygiene-daily
+    run_check "vault-checks" vault-checks
+    # pr-stale subcommand is shipped in PR #306 / develop tip; once that
+    # lands, the line below starts producing findings. Until then it
+    # exits with usage error (handled by `record_exit`, doesn't crash).
+    run_check "pr-stale" pr-stale
+    ;;
+esac
+
+echo "[$(ts)] steward ${cadence} complete; worst exit code: ${worst}"
+exit ${worst}


### PR DESCRIPTION
## Summary

Pipes failure modes 4 (stash), 5 (orphan branches), 6 (worktree count), and the Mac side of 7 (snapshot age) into a launchd schedule. The Mac is the only place these checks have meaningful signal — GHA cron sees \`origin/\`, not the local working tree.

This is item 4 of the four "first hour back" recommendations from \`~/Documents/projects/reports/principal-overnight-shipped-2026-05-04.md\`, completing all four.

## Changes

| File | Role |
|---|---|
| \`infrastructure/launchd/com.steward.daily.plist\` | LaunchAgent: 09:00 local daily |
| \`infrastructure/launchd/com.steward.weekly.plist\` | LaunchAgent: Mondays 09:15 local |
| \`scripts/steward-run.sh\` | Wrapper invoked by both plists; routes \`daily\` / \`weekly\` to the appropriate \`steward-gatekeeper.mjs\` subcommands. Captures worst exit code across checks. |
| \`scripts/install-steward-launchd.sh\` | Idempotent installer; unloads prior version before re-loading. Mirrors wrapper to \`~/bin/\`. |
| \`docs/steward.md\` | New §4.6: install + verify recipe |

## Why a wrapper + ~/bin/ mirror

launchd-spawned binaries cannot exec targets under \`~/Documents/\` on modern macOS (TCC privacy block). Same workaround the existing \`com.stolution.vault-snapshot-pull\` LaunchAgent uses (\`~/bin/pull-stolution-vault-snapshots.sh\`).

The wrapper also makes the daily/weekly *check set* a script-level concern — adding new checks to the daily run requires editing only \`scripts/steward-run.sh\`, not the plist (which would need \`launchctl unload && load\`).

## Already installed + verified on Mac (per decide → execute → inform)

\`\`\`
$ launchctl list | grep com.steward
-       0       com.steward.daily
-       0       com.steward.weekly

$ launchctl kickstart -k gui/$UID/com.steward.daily
$ tail ~/Library/Logs/steward-daily.launchd.log
[2026-05-04T17:54:31Z] ── steward daily :: hygiene-daily ──
hygiene-daily: stash=0 worktrees=0 branches=7
✓ no findings.
[2026-05-04T17:54:32Z] ── steward daily :: vault-checks ──
vault-checks: scanning Mac snapshot dir /Users/MAC/Library/Application Support/Stolution/vault-snapshots
✓ no findings.
[2026-05-04T17:54:32Z] steward daily complete; worst exit code: 0

$ launchctl kickstart -k gui/$UID/com.steward.weekly
$ tail ~/Library/Logs/steward-weekly.launchd.log
... same as daily plus:
[2026-05-04T17:55:05Z] ── steward weekly :: pr-stale ──
unknown command: pr-stale
[2026-05-04T17:55:05Z] steward weekly complete; worst exit code: 2
\`\`\`

The \`pr-stale\` "unknown command" is expected — the subcommand ships in PR #306 (still in CI). Once #306 merges, weekly picks it up automatically; no plist or wrapper edit required.

## Coverage delta

Steward Gatekeeper coverage: **modes 4, 5, 6, 7 (Mac side) now fire automatically on a schedule** instead of requiring manual invocation. This was Phase 2c–2d's "deferred to follow-up" item per \`docs/steward.md\` §10.

## References

- Failure modes 4-7: \`agent/memory/steward_gatekeeper_directive.md\`
- Operational discipline: \`agent/memory/feedback_operational_discipline.md\`
- Existing plist pattern reference: \`com.stolution.vault-snapshot-pull\`

🤖 Generated with Claude (Sonnet)