### PR TITLE
feat(observability): pino logger rollout to worker-coding

### DIFF
--- a/apps/worker-coding/package.json
+++ b/apps/worker-coding/package.json
@@ -13,9 +13,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@chiefaia/capability-broker": "workspace:*",
+    "@chiefaia/logger": "workspace:*",
     "@chiefaia/ticket-template": "workspace:*",
-    "zod": "^4.1.12",
-    "@chiefaia/capability-broker": "workspace:*"
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/apps/worker-coding/src/logger.ts
+++ b/apps/worker-coding/src/logger.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared worker-coding logger — wraps `@chiefaia/logger` with the worker's
+ * default bindings (`component: 'worker-coding'`) and an HTTP bus transport
+ * that POSTs warn/error/fatal lines as `system.error` events back to the
+ * orchestrator via the `/events` endpoint.
+ *
+ * Why HTTP rather than the in-process bus: the worker runs out-of-process
+ * from the orchestrator API, identical to the executor pattern in
+ * `apps/executor/logger.ts` (PR #86 seed). Same fire-and-forget semantics
+ * — observability MUST never break the caller.
+ *
+ * Use:
+ *   import { logger } from './logger';
+ *   const log = logger.child({ component: 'main', correlation_id });
+ *   log.info('booting', { orchestratorUrl });
+ */
+import { createLogger, busTransport, type Logger, type LoggerEventBus } from '@chiefaia/logger';
+
+const ORCHESTRATOR_URL = process.env['ORCHESTRATOR_URL'] ?? 'http://localhost:7776';
+
+/**
+ * HTTP-bridge implementation of the LoggerEventBus contract — sends events
+ * to the orchestrator's /events endpoint. Fire-and-forget; never throws.
+ */
+const httpBus: LoggerEventBus = {
+  publish: (partial) => {
+    void fetch(`${ORCHESTRATOR_URL}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...partial,
+        timestamp: Date.now(),
+      }),
+    }).catch(() => {
+      /* swallow — observability must never break the caller */
+    });
+    return undefined;
+  },
+};
+
+export const logger: Logger = createLogger({
+  name: 'worker-coding',
+  level:
+    (process.env['WORKER_LOG_LEVEL'] as 'debug' | 'info' | 'warn' | 'error' | undefined) ?? 'info',
+  onWarnOrError: busTransport({
+    bus: httpBus,
+    actor: 'worker-coding',
+  }),
+});

--- a/apps/worker-coding/src/main.ts
+++ b/apps/worker-coding/src/main.ts
@@ -16,10 +16,15 @@
  * `runtime.ts`; this file is the thin CLI shim that wires env → runtime
  * + the per-story dispatch handler. Each piece is unit-tested separately.
  *
+ * Logging: all observability lines route through `./logger` (pino-backed,
+ * HTTP bus to orchestrator). Do not introduce raw `console.*` here —
+ * matches the executor pattern (PR #86 seed).
+ *
  * @owner coding-agent (Phase 2C worker track)
  */
 
 import { BundleReader } from './bundle-reader';
+import { logger } from './logger';
 import { startRuntime, type RuntimeHandle } from './runtime';
 import type { IpcHandlers, FixRequest, FixResultOut } from './ipc-server';
 
@@ -78,8 +83,7 @@ export async function bootstrap(
       // Full per-story dispatch (worktree → engine → tests → PR → DoD →
       // hand-off to Fix-It) lives in CODING-009's E2E. For now, we log
       // and let CODING-009 wire it once we have a real-git harness.
-      // eslint-disable-next-line no-console
-      console.error(`[worker-coding] received assignment storyId=${assignment.storyId}`);
+      logger.info('received assignment', { storyId: assignment.storyId });
     },
   });
 
@@ -113,8 +117,7 @@ export function makeDefaultIpcHandlers(): IpcHandlers {
     shutdown: async () => {
       // Process exit is the responsibility of the CLI shim below; the
       // runtime stops loops on its own when shutdown() is called.
-      // eslint-disable-next-line no-console
-      console.error('[worker-coding] shutdown requested via IPC');
+      logger.info('shutdown requested via IPC');
     },
   };
 }
@@ -124,12 +127,10 @@ if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   (async () => {
     const env = readEnv();
-    // eslint-disable-next-line no-console
-    console.error(`[worker-coding] booting against ${env.orchestratorUrl}`);
+    logger.info('booting', { orchestratorUrl: env.orchestratorUrl });
     const handle = await bootstrap(env, { withRuntime: true });
     const stop = async (signal: string) => {
-      // eslint-disable-next-line no-console
-      console.error(`[worker-coding] received ${signal}, shutting down`);
+      logger.info('shutting down', { signal });
       await handle.shutdown();
       process.exit(0);
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       '@chiefaia/capability-broker':
         specifier: workspace:*
         version: link:../../packages/capability-broker
+      '@chiefaia/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@chiefaia/ticket-template':
         specifier: workspace:*
         version: link:../../packages/ticket-template


### PR DESCRIPTION
## Why

Phase-1 polish G-G from `principal-overnight-roadmap-2026-05-04.md`. PR #86 seeded the `@chiefaia/logger` pattern for orchestrator + executor + secrets-broker. This rollout extends it to `worker-coding` — the highest-traffic out-of-process worker (called per story by the executor).

## What

- New `apps/worker-coding/src/logger.ts` mirroring the executor pattern (HTTP bus to orchestrator `/events`, fire-and-forget).
- Replace 4 `console.error` lines in `main.ts` (CLI shim + default IPC handlers) with structured `logger.info(...)` calls.
- Add `@chiefaia/logger` to `apps/worker-coding/package.json` (workspace:\* like other apps).
- `runtime.ts`'s injectable `log` parameter preserved as-is — it's a test injection point.

## Why HTTP bus, not in-process

worker-coding runs in its own process spawned by the executor; same shape as the executor itself. Reaches the orchestrator via fetch — identical to `apps/executor/logger.ts`. Observability MUST never break the caller, so the `fetch().catch(()=>{})` swallow pattern is preserved.

## Verification

- `pnpm --filter @caia-app/worker-coding build` → clean
- `pnpm --filter @caia-app/worker-coding test` → 12/12 suites, 123/123 tests pass
- `pnpm --filter @caia-app/worker-coding typecheck` → clean

## inputDependencies regression coverage (the companion item in G-G)

Already covered by `packages/ticket-template/src/input-dependencies.test.ts` (11 dedicated tests). The full ticket-template test suite — `pnpm --filter @chiefaia/ticket-template test` → 167/167 tests pass — exercises the schema integration path (schema-v2.test.ts, validation-rubric.test.ts, capsule.test.ts, template.test.ts). The end-to-end wiring through BA-enrich → EA-decompose populates inputDependencies and is exercised by `tests/e2e/pipeline`.

No additional regression test added in this PR — the existing coverage is comprehensive.

## Follow-ups (not blocking this PR)

Same-shape rollout PRs queued for: `worker-fix-it`, `completeness-sentinel`, `task-run-poller`, `smart-cicd-agent`. Each ~50 LoC, no behaviour change. Will ship as quick `feat/observability-002..005` PRs after this lands.

Refs: principal-overnight-roadmap-2026-05-04 G-G / T-012, PR #86