### PR TITLE
feat(local-preview-001): deploy pipeline + poll loop + integration test (PR-B)

### DIFF
--- a/.changeset/feat-local-preview-001-deploy-poll.md
+++ b/.changeset/feat-local-preview-001-deploy-poll.md
@@ -1,0 +1,46 @@
+---
+"caia": patch
+---
+
+feat(local-preview-001): deploy.ts + poll-loop.ts + integration test (PR-B)
+
+Adds the end-to-end deploy pipeline and the polling daemon to
+`apps/local-preview-orchestrator/`, building on the PR-A skeleton (#312).
+
+New modules:
+
+- `src/shell-runner.ts` — injectable bash command executor with timeout +
+  exit-code capture. Trust boundary: commands originate from compile-time
+  SITES registry only.
+- `src/git-ops.ts` — `fetch`, `resolveBranchSha`, `worktreeAdd`,
+  `worktreeRemove` over the shell-runner. Strict-allowlist `shellEscape`
+  for any token that might contain shell metacharacters.
+- `src/deploy.ts` — the full deploy state machine: lock → fetch → compare
+  → disk-check → worktree-add → build → copy artifacts → atomic-swap →
+  restart → health-check → (rollback on failure) → prune → cleanup →
+  state-write. Every failure mode returns a typed `DeployResult` rather
+  than throwing.
+- `src/poll-loop.ts` — 30s polling daemon. Per-site coalescing via an
+  in-flight set; iteration is testable in isolation via `pollIteration`.
+- `src/site-state.ts` — atomic JSON state writer the (PR-C) status
+  dashboard will read.
+
+Tests added (42 new, 71 total in this app):
+
+- Unit tests for `shell-runner` (timeout / cwd / exit codes), `git-ops`
+  (command shape + escape rules + error propagation), `site-state`
+  (read/write/update + corrupt-json fallback), `deploy` (happy path,
+  noop, build-failed, health-check rollback, rollback-failed, locked,
+  missing-artifact), `poll-loop` (iteration, abort-during-sleep,
+  in-progress reporting, error capture, max-iterations).
+- Integration test (`deploy.integration.test.ts`) that initialises a
+  real fixture git repo, runs `deploySite` end-to-end with the real
+  `defaultShellRunner` + `makeGitOps`, and asserts: artifacts copied,
+  symlink swapped, state.json reflects success, second invocation is
+  noop, third invocation (after a new commit) succeeds with `previous`
+  pointing at v1, and a build-failed deploy leaves `current` untouched.
+
+No runtime side effects until PR-D wires the LaunchAgents.
+
+References: `~/Documents/projects/reports/local-preview-deploys-analysis.md`,
+`agent/memory/steward_local_preview_deploys_directive.md`.

--- a/apps/local-preview-orchestrator/src/deploy.ts
+++ b/apps/local-preview-orchestrator/src/deploy.ts
@@ -1,0 +1,566 @@
+/**
+ * End-to-end deploy pipeline for a single site.
+ *
+ * Pipeline (per `~/Documents/projects/reports/local-preview-deploys-analysis.md` §Deploy pipeline):
+ *   1. acquire per-site lock (refuse if another deploy is running)
+ *   2. git fetch origin <branch>; resolve target SHA
+ *   3. compare to current symlink target → noop if equal
+ *   4. disk-full check → abort if over budget
+ *   5. add a detached worktree at <buildWorkspace>/<site>-<sha>
+ *   6. run site.buildCmd inside the worktree
+ *      → on failure: log incident, remove worktree, return build-failed
+ *   7. copy build artifacts (site.buildArtifacts) into installDir/builds/<sha>/
+ *   8. atomic-swap the `current` symlink to the new build dir
+ *   9. restart the supervised process (kill PID — launchd KeepAlive restarts it)
+ *  10. poll the health endpoint
+ *      → on failure: rollback symlink, restart, log incident, return health-check-failed
+ *  11. prune old builds (>10) keeping symlink targets
+ *  12. remove the build worktree
+ *  13. update site state.json
+ *  14. return success
+ *
+ * Trust boundary: all paths and commands derive from the compile-time SITES
+ * registry. No user-controllable input reaches a shell, fs path, or git
+ * command in this module.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { atomicSwap, getCurrentTarget, getPreviousTarget, rollbackToPrevious } from './atomic-swap.js';
+import { pollHealthCheck, type HealthCheckResult } from './health-check.js';
+import { pruneBuilds, isDiskUsageOk } from './disk-prune.js';
+import {
+  createDeployFailedRecord,
+  createHealthCheckFailedRecord,
+  createRollbackRecord,
+  logIncident
+} from './incident-log.js';
+import { defaultShellRunner, type ShellRunner } from './shell-runner.js';
+import { makeGitOps, type GitOps } from './git-ops.js';
+import { updateSiteState, type SiteState } from './site-state.js';
+import type { SiteConfig } from './sites-config.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface DeployOptions {
+  /** Root directory where per-site install dirs live, e.g. ~/Library/Application Support/Stolution/local-preview/ */
+  installRoot: string;
+
+  /** Root directory for ephemeral build worktrees, e.g. /private/tmp/local-preview-build/ */
+  buildWorkspaceRoot: string;
+
+  /** Directory the incident log lives under. Default: <installRoot>/_incidents/ */
+  incidentLogDir?: string;
+
+  /** Soft cap on build storage (bytes). Default: 5 GB. */
+  maxDiskBytes?: number;
+
+  /** Number of recent builds to keep when pruning. Default: 10. */
+  keepBuildCount?: number;
+
+  /** Health-check tuning. */
+  healthCheckMaxAttempts?: number;
+  healthCheckInitialDelayMs?: number;
+
+  // ── Injection points (default to real impls; tests override) ───────────
+
+  shellRunner?: ShellRunner;
+  gitOps?: GitOps;
+  /** Override pollHealthCheck. */
+  healthChecker?: (
+    url: string,
+    mustContain: string,
+    maxAttempts: number,
+    initialDelayMs: number
+  ) => Promise<HealthCheckResult>;
+  /** Restart the running process for this site. Default: kill the PID file (launchd KeepAlive restarts). */
+  restartProcess?: (site: SiteConfig, sitePath: string) => Promise<void>;
+  /** Acquire an in-process lock for a site name. Default: per-site mutex map below. */
+  acquireSiteLock?: (siteName: string) => () => void;
+
+  /** Logger. Default: console. */
+  logger?: { info: (msg: string, ctx?: unknown) => void; error: (msg: string, ctx?: unknown) => void };
+
+  /** Force a deploy even when SHAs match. */
+  force?: boolean;
+}
+
+export type DeployResult =
+  | { status: 'noop'; sha: string }
+  | {
+      status: 'success';
+      sha: string;
+      previousSha?: string;
+      durationMs: number;
+      healthCheckMs?: number;
+    }
+  | { status: 'build-failed'; sha: string; error: string; logTail?: string }
+  | {
+      status: 'health-check-failed';
+      sha: string;
+      rolledBackToSha?: string;
+      error: string;
+    }
+  | { status: 'rollback-failed'; sha: string; error: string }
+  | { status: 'disk-full'; error: string }
+  | { status: 'locked'; error: string }
+  | { status: 'aborted'; error: string };
+
+// ─── Per-site lock (in-process) ────────────────────────────────────────────
+
+const inProcessLocks = new Set<string>();
+
+function defaultAcquireSiteLock(siteName: string): () => void {
+  if (inProcessLocks.has(siteName)) {
+    throw new LockHeldError(`Site lock already held: ${siteName}`);
+  }
+  inProcessLocks.add(siteName);
+  return () => inProcessLocks.delete(siteName);
+}
+
+export class LockHeldError extends Error {
+  override readonly name = 'LockHeldError';
+}
+
+// ─── Path helpers ─────────────────────────────────────────────────────────
+
+export function resolveSitePath(installRoot: string, siteName: string): string {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- installRoot+siteName from compile-time SITES registry
+  return join(installRoot, siteName);
+}
+
+export function resolveBuildDir(sitePath: string, sha: string): string {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- sitePath from compile-time SITES registry; sha from git rev-parse
+  return join(sitePath, 'builds', sha);
+}
+
+export function resolveBuildWorkspace(buildWorkspaceRoot: string, siteName: string, sha: string): string {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- buildWorkspaceRoot+siteName from compile-time SITES registry; sha from git rev-parse
+  return join(buildWorkspaceRoot, `${siteName}-${sha}`);
+}
+
+// ─── Default restartProcess (kill PID file → launchd KeepAlive restarts) ──
+
+async function defaultRestartProcess(_site: SiteConfig, sitePath: string): Promise<void> {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- sitePath from compile-time SITES registry
+  const pidFile = join(sitePath, 'pid');
+  if (!existsSync(pidFile)) {
+    // No process running yet (initial deploy or LaunchAgent not yet installed). Nothing to do.
+    return;
+  }
+  try {
+    const raw = readFileSync(pidFile, 'utf-8').trim();
+    const pid = Number.parseInt(raw, 10);
+    if (Number.isFinite(pid) && pid > 1) {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // Process may have already exited. launchd KeepAlive will start a new one.
+      }
+    }
+  } catch {
+    // Unreadable PID file — best-effort.
+  }
+}
+
+// ─── Main entry ───────────────────────────────────────────────────────────
+
+export async function deploySite(site: SiteConfig, opts: DeployOptions): Promise<DeployResult> {
+  const {
+    installRoot,
+    buildWorkspaceRoot,
+    maxDiskBytes = 5 * 1024 * 1024 * 1024,
+    keepBuildCount = 10,
+    healthCheckMaxAttempts = 30,
+    healthCheckInitialDelayMs = 333,
+    shellRunner = defaultShellRunner,
+    gitOps = makeGitOps(shellRunner),
+    healthChecker = pollHealthCheck,
+    restartProcess = defaultRestartProcess,
+    acquireSiteLock = defaultAcquireSiteLock,
+    logger = consoleLogger,
+    force = false
+  } = opts;
+
+  const sitePath = resolveSitePath(installRoot, site.name);
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- installRoot from compile-time SITES registry; '_incidents' is a literal
+  const incidentLogDir = opts.incidentLogDir ?? join(installRoot, '_incidents');
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- incidentLogDir from compile-time SITES registry; site.name is a literal from the same registry
+  const incidentLogPath = join(incidentLogDir, `${site.name}.jsonl`);
+  const stateFallback = { name: site.name, port: site.port };
+
+  // Lock acquisition (or short-circuit if already deploying for this site).
+  let releaseLock: (() => void) | undefined;
+  try {
+    releaseLock = acquireSiteLock(site.name);
+  } catch (err) {
+    if (err instanceof LockHeldError) {
+      return { status: 'locked', error: err.message };
+    }
+    throw err;
+  }
+
+  const startedAt = Date.now();
+  try {
+    // 1. Make sure sitePath exists.
+    if (!existsSync(sitePath)) {
+      mkdirSync(sitePath, { recursive: true });
+    }
+
+    // 2. Fetch + resolve target SHA.
+    await gitOps.fetch(site.repo, site.branch);
+    const targetSha = await gitOps.resolveBranchSha(site.repo, site.branch);
+
+    // 3. Compare to current.
+    const currentTarget = getCurrentTarget(sitePath);
+    const currentSha = currentTarget ? extractShaFromBuildPath(currentTarget) : undefined;
+
+    if (!force && currentSha === targetSha) {
+      logger.info(`[${site.name}] noop: already at ${targetSha}`);
+      updateSiteState(sitePath, stateFallback, {
+        last_deploy_status: 'noop',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: null,
+        last_deploy_duration_ms: Date.now() - startedAt
+      });
+      return { status: 'noop', sha: targetSha };
+    }
+
+    // 4. Disk-full check.
+    if (!isDiskUsageOk(sitePath, maxDiskBytes)) {
+      const msg = `Build storage exceeds ${maxDiskBytes} bytes; aborting deploy`;
+      logger.error(`[${site.name}] disk-full: ${msg}`);
+      logIncident(incidentLogPath, createDeployFailedRecord(site.name, msg, { sha: targetSha }));
+      updateSiteState(sitePath, stateFallback, {
+        last_deploy_status: 'disk-full',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: msg,
+        last_deploy_duration_ms: Date.now() - startedAt
+      });
+      return { status: 'disk-full', error: msg };
+    }
+
+    // 5. Add build worktree.
+    const workspaceDir = resolveBuildWorkspace(buildWorkspaceRoot, site.name, targetSha);
+    if (existsSync(workspaceDir)) {
+      // Stale worktree from a prior crashed deploy — clean it up first.
+      try {
+        rmSync(workspaceDir, { recursive: true, force: true });
+      } catch (e) {
+        logger.error(`[${site.name}] could not clean stale workspace ${workspaceDir}: ${e}`);
+      }
+    }
+    if (!existsSync(buildWorkspaceRoot)) {
+      mkdirSync(buildWorkspaceRoot, { recursive: true });
+    }
+
+    try {
+      await gitOps.worktreeAdd(site.repo, workspaceDir, targetSha);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[${site.name}] worktree add failed: ${msg}`);
+      logIncident(
+        incidentLogPath,
+        createDeployFailedRecord(site.name, `worktree add failed: ${msg}`, { sha: targetSha })
+      );
+      updateSiteState(sitePath, stateFallback, {
+        last_deploy_status: 'aborted',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: `worktree add failed: ${msg}`,
+        last_deploy_duration_ms: Date.now() - startedAt
+      });
+      return { status: 'aborted', error: msg };
+    }
+
+    // 6. Run build command.
+    logger.info(`[${site.name}] building ${targetSha} in ${workspaceDir}`);
+    const buildResult = await shellRunner(site.buildCmd, {
+      cwd: workspaceDir,
+      timeoutMs: 15 * 60_000 // 15-min build timeout
+    });
+
+    if (buildResult.code !== 0) {
+      const tail = buildResult.stderr.slice(-2000);
+      logger.error(`[${site.name}] build failed (exit ${buildResult.code}): ${tail}`);
+      logIncident(
+        incidentLogPath,
+        createDeployFailedRecord(site.name, `build failed exit ${buildResult.code}`, {
+          sha: targetSha,
+          stderr_tail: tail
+        })
+      );
+      // Best-effort cleanup of worktree
+      await safeRemoveWorktree(gitOps, site.repo, workspaceDir, logger);
+      updateSiteState(sitePath, stateFallback, {
+        last_deploy_status: 'build-failed',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: `build failed exit ${buildResult.code}`,
+        last_deploy_duration_ms: Date.now() - startedAt
+      });
+      return { status: 'build-failed', sha: targetSha, error: `exit ${buildResult.code}`, logTail: tail };
+    }
+
+    // 7. Copy artifacts into install dir.
+    const installDir = resolveBuildDir(sitePath, targetSha);
+    if (!existsSync(installDir)) {
+      mkdirSync(installDir, { recursive: true });
+    }
+    for (const artifact of site.buildArtifacts) {
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- workspaceDir+artifact from compile-time SITES registry
+      const src = join(workspaceDir, artifact);
+      // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- installDir+artifact from compile-time SITES registry
+      const dst = join(installDir, artifact);
+      if (!existsSync(src)) {
+        // Build was supposed to produce this artifact. Treat as build failure.
+        const msg = `expected build artifact missing: ${artifact}`;
+        logger.error(`[${site.name}] ${msg}`);
+        logIncident(
+          incidentLogPath,
+          createDeployFailedRecord(site.name, msg, { sha: targetSha, artifact })
+        );
+        await safeRemoveWorktree(gitOps, site.repo, workspaceDir, logger);
+        updateSiteState(sitePath, stateFallback, {
+          last_deploy_status: 'build-failed',
+          last_deploy_at: new Date().toISOString(),
+          last_deploy_error: msg,
+          last_deploy_duration_ms: Date.now() - startedAt
+        });
+        return { status: 'build-failed', sha: targetSha, error: msg };
+      }
+      cpSync(src, dst, { recursive: true, force: true });
+    }
+
+    // 8. Atomic swap.
+    const swapResult = atomicSwap(sitePath, `builds/${targetSha}`);
+    if (!swapResult.success) {
+      const msg = swapResult.error ?? 'atomic swap failed';
+      logger.error(`[${site.name}] swap failed: ${msg}`);
+      logIncident(
+        incidentLogPath,
+        createDeployFailedRecord(site.name, `swap failed: ${msg}`, { sha: targetSha })
+      );
+      await safeRemoveWorktree(gitOps, site.repo, workspaceDir, logger);
+      updateSiteState(sitePath, stateFallback, {
+        last_deploy_status: 'aborted',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: msg,
+        last_deploy_duration_ms: Date.now() - startedAt
+      });
+      return { status: 'aborted', error: msg };
+    }
+
+    // Decode previous SHA from prior current target (best-effort).
+    const previousTargetPath = swapResult.previousTarget;
+    const previousSha = previousTargetPath ? extractShaFromBuildPath(previousTargetPath) : undefined;
+
+    // 9. Restart the running process.
+    try {
+      await restartProcess(site, sitePath);
+    } catch (e) {
+      logger.error(`[${site.name}] restart failed (non-fatal, will rely on launchd): ${e}`);
+    }
+
+    // 10. Health check.
+    const url = `http://localhost:${site.port}${site.healthPath}`;
+    const healthStart = Date.now();
+    const health = await healthChecker(
+      url,
+      site.healthMustContain,
+      healthCheckMaxAttempts,
+      healthCheckInitialDelayMs
+    );
+    const healthCheckMs = Date.now() - healthStart;
+
+    if (!health.ok) {
+      logger.error(`[${site.name}] health-check failed: ${health.error ?? 'unknown'}`);
+      logIncident(
+        incidentLogPath,
+        createHealthCheckFailedRecord(site.name, health.error ?? 'unknown', {
+          sha: targetSha,
+          url,
+          response_time_ms: health.responseTime
+        })
+      );
+
+      // Attempt rollback to previous build.
+      const rollback = rollbackToPrevious(sitePath);
+      if (!rollback.success) {
+        logger.error(`[${site.name}] rollback failed: ${rollback.error ?? 'unknown'}`);
+        logIncident(
+          incidentLogPath,
+          createRollbackRecord(site.name, `rollback failed: ${rollback.error ?? 'unknown'}`, {
+            sha: targetSha
+          })
+        );
+        await safeRemoveWorktree(gitOps, site.repo, workspaceDir, logger);
+        updateSiteState(sitePath, stateFallback, {
+          last_deploy_status: 'rollback-failed',
+          last_deploy_at: new Date().toISOString(),
+          last_deploy_error: `health failed and rollback failed: ${rollback.error ?? 'unknown'}`,
+          last_deploy_duration_ms: Date.now() - startedAt,
+          last_health_check_at: new Date().toISOString(),
+          last_health_check_status: 'failed'
+        });
+        return { status: 'rollback-failed', sha: targetSha, error: rollback.error ?? 'unknown' };
+      }
+
+      // Restart on the rolled-back build.
+      try {
+        await restartProcess(site, sitePath);
+      } catch (e) {
+        logger.error(`[${site.name}] restart-after-rollback failed: ${e}`);
+      }
+
+      const rolledBackToSha = rollback.currentTarget
+        ? extractShaFromBuildPath(rollback.currentTarget)
+        : undefined;
+
+      logIncident(
+        incidentLogPath,
+        createRollbackRecord(site.name, `rolled back to ${rolledBackToSha ?? 'unknown'}`, {
+          failed_sha: targetSha,
+          recovered_sha: rolledBackToSha
+        })
+      );
+
+      const stateUpdate: Partial<SiteState> = {
+        last_deploy_status: 'health-check-failed',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: health.error ?? 'unknown',
+        last_deploy_duration_ms: Date.now() - startedAt,
+        last_health_check_at: new Date().toISOString(),
+        last_health_check_status: 'failed'
+      };
+      if (rolledBackToSha !== undefined) {
+        stateUpdate.current_sha = rolledBackToSha;
+      }
+      updateSiteState(sitePath, stateFallback, stateUpdate);
+
+      await safeRemoveWorktree(gitOps, site.repo, workspaceDir, logger);
+      return {
+        status: 'health-check-failed',
+        sha: targetSha,
+        error: health.error ?? 'unknown',
+        ...(rolledBackToSha !== undefined ? { rolledBackToSha } : {})
+      };
+    }
+
+    // 11. Prune old builds.
+    const pruneResult = pruneBuilds(sitePath, keepBuildCount);
+    if (!pruneResult.success) {
+      logger.error(`[${site.name}] prune failed (non-fatal): ${pruneResult.error}`);
+    }
+
+    // 12. Remove the build worktree.
+    await safeRemoveWorktree(gitOps, site.repo, workspaceDir, logger);
+
+    // 13. Update site state.
+    const newPreviousSha = previousSha ?? getPreviousTargetSha(sitePath);
+    const stateUpdate: Partial<SiteState> = {
+      current_sha: targetSha,
+      last_deploy_status: 'success',
+      last_deploy_at: new Date().toISOString(),
+      last_deploy_error: null,
+      last_deploy_duration_ms: Date.now() - startedAt,
+      last_health_check_at: new Date().toISOString(),
+      last_health_check_status: 'ok',
+      process_state: 'running'
+    };
+    if (newPreviousSha !== undefined) {
+      stateUpdate.previous_sha = newPreviousSha;
+    }
+    updateSiteState(sitePath, stateFallback, stateUpdate);
+
+    logger.info(
+      `[${site.name}] deployed ${targetSha} in ${Date.now() - startedAt}ms (health ${healthCheckMs}ms)`
+    );
+
+    const successResult: DeployResult = {
+      status: 'success',
+      sha: targetSha,
+      durationMs: Date.now() - startedAt,
+      healthCheckMs
+    };
+    if (previousSha !== undefined) {
+      successResult.previousSha = previousSha;
+    }
+    return successResult;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`[${site.name}] deploy threw: ${msg}`);
+    try {
+      logIncident(
+        incidentLogPath,
+        createDeployFailedRecord(site.name, `deploy threw: ${msg}`, {})
+      );
+    } catch {
+      // Ignore logging-on-logging errors
+    }
+    try {
+      updateSiteState(sitePath, stateFallback, {
+        last_deploy_status: 'aborted',
+        last_deploy_at: new Date().toISOString(),
+        last_deploy_error: msg,
+        last_deploy_duration_ms: Date.now() - startedAt
+      });
+    } catch {
+      // Ignore state-write failure during error path
+    }
+    return { status: 'aborted', error: msg };
+  } finally {
+    if (releaseLock) releaseLock();
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Build dirs are stored as `builds/<sha>` relative to sitePath.
+ * The `current` symlink target therefore looks like `builds/<sha>` — extract the SHA.
+ */
+export function extractShaFromBuildPath(buildPath: string): string | undefined {
+  const m = /(?:^|\/)builds\/([0-9a-f]{7,40})(?:\/?$)/.exec(buildPath);
+  return m?.[1];
+}
+
+function getPreviousTargetSha(sitePath: string): string | undefined {
+  const target = getPreviousTarget(sitePath);
+  return target ? extractShaFromBuildPath(target) : undefined;
+}
+
+async function safeRemoveWorktree(
+  gitOps: GitOps,
+  repoPath: string,
+  workspaceDir: string,
+  logger: { error: (msg: string, ctx?: unknown) => void }
+): Promise<void> {
+  if (!existsSync(workspaceDir)) return;
+  try {
+    await gitOps.worktreeRemove(repoPath, workspaceDir);
+  } catch (e) {
+    // Fall back to plain rmSync.
+    logger.error(`worktree remove failed; falling back to rmSync: ${e}`);
+    try {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    } catch (e2) {
+      logger.error(`rmSync fallback also failed: ${e2}`);
+    }
+  }
+}
+
+const consoleLogger = {
+  info: (msg: string, ctx?: unknown): void => {
+    if (ctx !== undefined) console.log(msg, ctx);
+    else console.log(msg);
+  },
+  error: (msg: string, ctx?: unknown): void => {
+    if (ctx !== undefined) console.error(msg, ctx);
+    else console.error(msg);
+  }
+};
+
+// Re-exports for convenience
+export { defaultShellRunner } from './shell-runner.js';
+export { makeGitOps } from './git-ops.js';
+

--- a/apps/local-preview-orchestrator/src/git-ops.ts
+++ b/apps/local-preview-orchestrator/src/git-ops.ts
@@ -1,0 +1,81 @@
+/**
+ * Git operations needed by the deploy pipeline.
+ *
+ * Encapsulated behind an interface so unit tests can stub git without setting
+ * up a real fixture repo (integration tests still use a real fixture).
+ *
+ * Trust boundary: branch names + repo paths come from the compile-time SITES
+ * registry; SHAs come from `git rev-parse` output. No user input is ever
+ * passed to a git command in this module.
+ */
+
+import type { ShellRunner, ShellRunOptions } from './shell-runner.js';
+import { runOrThrow } from './shell-runner.js';
+
+export interface GitOps {
+  fetch(repoPath: string, branch: string): Promise<void>;
+  resolveBranchSha(repoPath: string, branch: string): Promise<string>;
+  worktreeAdd(repoPath: string, targetPath: string, ref: string): Promise<void>;
+  worktreeRemove(repoPath: string, targetPath: string): Promise<void>;
+}
+
+/**
+ * Default GitOps — backed by a ShellRunner.
+ */
+export function makeGitOps(shell: ShellRunner): GitOps {
+  return {
+    async fetch(repoPath, branch) {
+      // Fast-path: --no-tags, only the tracked branch.
+      // 60s timeout is generous for 3 small Mac-local repos.
+      await runOrThrow(shell, `git fetch origin ${shellEscape(branch)} --no-tags --prune`, {
+        cwd: repoPath,
+        timeoutMs: 60_000
+      });
+    },
+    async resolveBranchSha(repoPath, branch) {
+      const result = await runOrThrow(shell, `git rev-parse origin/${shellEscape(branch)}`, {
+        cwd: repoPath,
+        timeoutMs: 10_000
+      });
+      const sha = result.stdout.trim();
+      if (!/^[0-9a-f]{7,40}$/.test(sha)) {
+        throw new Error(`Invalid SHA returned by git rev-parse: "${sha}"`);
+      }
+      return sha;
+    },
+    async worktreeAdd(repoPath, targetPath, ref) {
+      await runOrThrow(
+        shell,
+        // --detach to avoid creating a new branch; --force in case the path was reused
+        `git worktree add --detach --force ${shellEscape(targetPath)} ${shellEscape(ref)}`,
+        { cwd: repoPath, timeoutMs: 60_000 }
+      );
+    },
+    async worktreeRemove(repoPath, targetPath) {
+      // --force in case the worktree has uncommitted changes from the build
+      await runOrThrow(shell, `git worktree remove --force ${shellEscape(targetPath)}`, {
+        cwd: repoPath,
+        timeoutMs: 30_000
+      });
+    }
+  };
+}
+
+/**
+ * Quote a string for safe inclusion in a bash command.
+ * Strict allowlist: branches/SHAs are alphanumeric + a few separators; paths are
+ * absolute filesystem paths from compile-time config. Anything outside the
+ * allowlist gets single-quoted with embedded-quote escaping.
+ */
+export function shellEscape(s: string): string {
+  if (/^[A-Za-z0-9_./@\-+]+$/.test(s)) {
+    return s;
+  }
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Run a `ShellRunOptions`-shaped command and return the raw result.
+ * Re-exported for convenience.
+ */
+export type { ShellRunOptions };

--- a/apps/local-preview-orchestrator/src/index.ts
+++ b/apps/local-preview-orchestrator/src/index.ts
@@ -4,8 +4,13 @@
  */
 
 export { SITES, getSiteConfig, getAllSiteNames, type SiteConfig } from './sites-config.js';
-export { atomicSwap, rollbackToPrevious, getCurrentTarget, getPreviousTarget } from './atomic-swap.js';
-export { healthCheck, pollHealthCheck } from './health-check.js';
+export {
+  atomicSwap,
+  rollbackToPrevious,
+  getCurrentTarget,
+  getPreviousTarget
+} from './atomic-swap.js';
+export { healthCheck, pollHealthCheck, type HealthCheckResult } from './health-check.js';
 export { pruneBuilds, isDiskUsageOk, getBuildsSize } from './disk-prune.js';
 export {
   logIncident,
@@ -14,3 +19,37 @@ export {
   createRollbackRecord,
   type IncidentRecord
 } from './incident-log.js';
+
+// PR-B additions
+export {
+  defaultShellRunner,
+  runOrThrow,
+  type ShellRunner,
+  type ShellRunOptions,
+  type ShellResult
+} from './shell-runner.js';
+export { makeGitOps, shellEscape, type GitOps } from './git-ops.js';
+export {
+  deploySite,
+  resolveSitePath,
+  resolveBuildDir,
+  resolveBuildWorkspace,
+  extractShaFromBuildPath,
+  LockHeldError,
+  type DeployOptions,
+  type DeployResult
+} from './deploy.js';
+export {
+  runPollLoop,
+  pollIteration,
+  defaultSleep,
+  type PollLoopOptions,
+  type IterationResult
+} from './poll-loop.js';
+export {
+  defaultSiteState,
+  readSiteState,
+  writeSiteState,
+  updateSiteState,
+  type SiteState
+} from './site-state.js';

--- a/apps/local-preview-orchestrator/src/poll-loop.ts
+++ b/apps/local-preview-orchestrator/src/poll-loop.ts
@@ -1,0 +1,169 @@
+/**
+ * Polling daemon for local preview deploys.
+ *
+ * Runs continuously inside a LaunchAgent (`com.stolution.local-preview.deploy-daemon`).
+ * Every `intervalMs` (default 30s):
+ *   1. For each configured site, kick off a `deploySite()` if no deploy is
+ *      already in flight for that site.
+ *   2. The deploy itself does the cheap noop short-circuit (git fetch + SHA
+ *      compare); we don't filter at the loop level.
+ *   3. Sleep for the interval; repeat.
+ *
+ * Coalescing: deploys for the same site are serialised by the in-process
+ * lock acquired inside `deploySite`; if a deploy is already running when the
+ * next iteration ticks, that site is skipped this round and re-evaluated next
+ * round (which always operates on the freshest origin/<branch>, so latest-wins).
+ *
+ * Trust boundary: all paths and configs derive from the compile-time SITES
+ * registry; no user-controllable input enters this module.
+ */
+
+import { deploySite, type DeployOptions, type DeployResult } from './deploy.js';
+import type { SiteConfig } from './sites-config.js';
+
+export interface PollLoopOptions {
+  /** Sites to monitor. */
+  sites: SiteConfig[];
+  /** Deploy options passed through to deploySite() per iteration. */
+  deployOptions: DeployOptions;
+  /** Polling interval in ms. Default 30s. */
+  intervalMs?: number;
+  /** AbortSignal for graceful shutdown. */
+  abortSignal?: AbortSignal;
+  /** Override the deploy function (test injection). */
+  deployFn?: (site: SiteConfig, opts: DeployOptions) => Promise<DeployResult>;
+  /** Callback after each iteration with per-site outcomes. */
+  onIteration?: (results: IterationResult) => void;
+  /** Logger. */
+  logger?: { info: (msg: string) => void; error: (msg: string, ctx?: unknown) => void };
+  /** Sleep override (test injection). */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /** Stop after N iterations (testability). 0 / undefined = run forever. */
+  maxIterations?: number;
+}
+
+export type IterationResult = Record<string, DeployResult | { status: 'in-progress' } | { status: 'error'; error: string }>;
+
+const DEFAULT_INTERVAL_MS = 30_000;
+
+const consoleLogger = {
+  info: (msg: string): void => console.log(msg),
+  error: (msg: string, ctx?: unknown): void => {
+    if (ctx !== undefined) console.error(msg, ctx);
+    else console.error(msg);
+  }
+};
+
+/**
+ * Sleep for `ms` milliseconds, or until `signal` is aborted (whichever first).
+ */
+export function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const handle = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(handle);
+      cleanup();
+      resolve();
+    };
+    const cleanup = (): void => {
+      signal?.removeEventListener('abort', onAbort);
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Run a single iteration: kick off deploys for any sites not already in flight.
+ *
+ * Site-level concurrency is enforced inside deploySite() (it returns
+ * `{status: 'locked'}` if another invocation is in flight). We additionally
+ * track in-flight sites here so the iteration callback reports `in-progress`
+ * cleanly without duplicating the lock-failed status.
+ */
+export async function pollIteration(
+  inFlight: Set<string>,
+  opts: Pick<PollLoopOptions, 'sites' | 'deployOptions' | 'deployFn' | 'logger'>
+): Promise<IterationResult> {
+  const logger = opts.logger ?? consoleLogger;
+  const deployFn = opts.deployFn ?? deploySite;
+  const result: IterationResult = {};
+
+  await Promise.all(
+    opts.sites.map(async (site) => {
+      if (inFlight.has(site.name)) {
+        result[site.name] = { status: 'in-progress' };
+        return;
+      }
+      inFlight.add(site.name);
+      try {
+        const r = await deployFn(site, opts.deployOptions);
+        result[site.name] = r;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[poll-loop] deploy ${site.name} threw: ${msg}`);
+        result[site.name] = { status: 'error', error: msg };
+      } finally {
+        inFlight.delete(site.name);
+      }
+    })
+  );
+
+  return result;
+}
+
+/**
+ * Long-running poll loop. Returns when `abortSignal` fires or `maxIterations` is reached.
+ */
+export async function runPollLoop(opts: PollLoopOptions): Promise<void> {
+  const interval = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const sleep = opts.sleep ?? defaultSleep;
+  const logger = opts.logger ?? consoleLogger;
+  const inFlight = new Set<string>();
+  const maxIterations = opts.maxIterations ?? 0;
+
+  let iter = 0;
+  logger.info(
+    `[poll-loop] starting; sites=${opts.sites.map((s) => s.name).join(',')} intervalMs=${interval}`
+  );
+
+  while (!opts.abortSignal?.aborted) {
+    iter++;
+    const start = Date.now();
+    let result: IterationResult;
+    try {
+      result = await pollIteration(inFlight, {
+        sites: opts.sites,
+        deployOptions: opts.deployOptions,
+        ...(opts.deployFn !== undefined ? { deployFn: opts.deployFn } : {}),
+        logger
+      });
+    } catch (err) {
+      logger.error(`[poll-loop] iteration ${iter} threw`, err);
+      result = {};
+    }
+
+    try {
+      opts.onIteration?.(result);
+    } catch (err) {
+      logger.error(`[poll-loop] onIteration handler threw`, err);
+    }
+
+    const elapsed = Date.now() - start;
+    logger.info(`[poll-loop] iteration ${iter} complete in ${elapsed}ms`);
+
+    if (maxIterations > 0 && iter >= maxIterations) break;
+    if (opts.abortSignal?.aborted) break;
+
+    const remaining = Math.max(0, interval - elapsed);
+    await sleep(remaining, opts.abortSignal);
+  }
+
+  logger.info(`[poll-loop] exiting after ${iter} iteration(s)`);
+}

--- a/apps/local-preview-orchestrator/src/shell-runner.ts
+++ b/apps/local-preview-orchestrator/src/shell-runner.ts
@@ -1,0 +1,100 @@
+/**
+ * Shell-runner abstraction.
+ *
+ * Provides an injectable interface for executing shell commands so that the
+ * deploy pipeline can be unit-tested without spawning real processes.
+ *
+ * Trust boundary: all command strings consumed by this module originate from
+ * the compile-time SITES registry in sites-config.ts (buildCmd / startCmd) or
+ * from hard-coded git operations in deploy.ts (e.g. `git fetch origin`).
+ * No user-controllable input reaches a shell here. The `nosemgrep` annotations
+ * below acknowledge semgrep's child-process pattern while documenting the
+ * trust boundary explicitly.
+ */
+
+import { spawn } from 'node:child_process';
+
+export interface ShellResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+export interface ShellRunOptions {
+  cwd: string;
+  timeoutMs?: number;
+  env?: Record<string, string | undefined>;
+}
+
+export type ShellRunner = (cmd: string, opts: ShellRunOptions) => Promise<ShellResult>;
+
+/**
+ * Default shell runner — executes via /bin/bash -c.
+ * Captures stdout + stderr; enforces an optional timeout via SIGKILL.
+ */
+export const defaultShellRunner: ShellRunner = (cmd, opts) =>
+  new Promise<ShellResult>((resolve, reject) => {
+    const startedAt = Date.now();
+    // nosemgrep: javascript.lang.security.audit.detect-child-process.detect-child-process -- cmd originates from compile-time SITES registry or hard-coded git ops; trust boundary documented in module header
+    const child = spawn('/bin/bash', ['-c', cmd], {
+      cwd: opts.cwd,
+      env: { ...process.env, ...(opts.env ?? {}) } as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+
+    child.stdout.on('data', (d: Buffer) => {
+      stdout += d.toString('utf-8');
+    });
+    child.stderr.on('data', (d: Buffer) => {
+      stderr += d.toString('utf-8');
+    });
+
+    if (opts.timeoutMs && opts.timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, opts.timeoutMs);
+    }
+
+    child.on('error', (err) => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      const durationMs = Date.now() - startedAt;
+      const exitCode = timedOut ? 124 : code ?? 0;
+      resolve({
+        code: exitCode,
+        stdout,
+        stderr: timedOut ? `${stderr}\n[killed: timeout after ${opts.timeoutMs}ms]` : stderr,
+        durationMs
+      });
+    });
+  });
+
+/**
+ * Convenience: run a command and throw if exit code is non-zero.
+ * Useful for git plumbing where we expect success.
+ */
+export async function runOrThrow(
+  runner: ShellRunner,
+  cmd: string,
+  opts: ShellRunOptions
+): Promise<ShellResult> {
+  const result = await runner(cmd, opts);
+  if (result.code !== 0) {
+    throw new Error(
+      `Shell command failed (exit ${result.code}): ${cmd}\n` +
+        `stderr: ${result.stderr.slice(0, 4000)}`
+    );
+  }
+  return result;
+}

--- a/apps/local-preview-orchestrator/src/site-state.ts
+++ b/apps/local-preview-orchestrator/src/site-state.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-site state file.
+ *
+ * Each deploy writes the latest state to `installRoot/<site>/state.json` so
+ * the status dashboard (PR-C) can read a single JSON document and render the
+ * full picture without re-walking the filesystem.
+ *
+ * Path-traversal note: `sitePath` arguments come from the compile-time SITES
+ * registry; no user-controllable input reaches this module.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export interface SiteState {
+  name: string;
+  url: string;
+  current_sha: string | null;
+  previous_sha: string | null;
+  last_deploy_at: string | null;
+  last_deploy_status:
+    | 'success'
+    | 'noop'
+    | 'build-failed'
+    | 'health-check-failed'
+    | 'rollback-failed'
+    | 'disk-full'
+    | 'aborted'
+    | null;
+  last_deploy_error: string | null;
+  last_deploy_duration_ms: number | null;
+  last_health_check_at: string | null;
+  last_health_check_status: 'ok' | 'failed' | null;
+  process_state: 'unknown' | 'running' | 'stopped';
+  updated_at: string;
+}
+
+export function defaultSiteState(name: string, port: number): SiteState {
+  return {
+    name,
+    url: `http://localhost:${port}`,
+    current_sha: null,
+    previous_sha: null,
+    last_deploy_at: null,
+    last_deploy_status: null,
+    last_deploy_error: null,
+    last_deploy_duration_ms: null,
+    last_health_check_at: null,
+    last_health_check_status: null,
+    process_state: 'unknown',
+    updated_at: new Date().toISOString()
+  };
+}
+
+/**
+ * Read the state file for a site.
+ * Returns the default state if the file does not exist or is malformed.
+ */
+export function readSiteState(
+  sitePath: string,
+  fallback: { name: string; port: number }
+): SiteState {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- sitePath from compile-time SITES registry
+  const filePath = join(sitePath, 'state.json');
+  if (!existsSync(filePath)) {
+    return defaultSiteState(fallback.name, fallback.port);
+  }
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as SiteState;
+    return parsed;
+  } catch {
+    return defaultSiteState(fallback.name, fallback.port);
+  }
+}
+
+/**
+ * Atomically write the state file for a site.
+ * Writes to a temp file then renames so a concurrent reader never sees a torn write.
+ */
+export function writeSiteState(sitePath: string, state: SiteState): void {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- sitePath from compile-time SITES registry
+  const filePath = join(sitePath, 'state.json');
+  const tmpPath = `${filePath}.tmp`;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const next: SiteState = { ...state, updated_at: new Date().toISOString() };
+  writeFileSync(tmpPath, JSON.stringify(next, null, 2), 'utf-8');
+  // rename is atomic on POSIX
+  renameSync(tmpPath, filePath);
+}
+
+/**
+ * Apply a partial update on top of the existing state and persist it.
+ */
+export function updateSiteState(
+  sitePath: string,
+  fallback: { name: string; port: number },
+  patch: Partial<SiteState>
+): SiteState {
+  const current = readSiteState(sitePath, fallback);
+  const next: SiteState = { ...current, ...patch };
+  writeSiteState(sitePath, next);
+  return next;
+}

--- a/apps/local-preview-orchestrator/tests/deploy.integration.test.ts
+++ b/apps/local-preview-orchestrator/tests/deploy.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration test for deploySite — uses a real git fixture repo + real
+ * shellRunner + real gitOps. Bypasses LaunchAgent / Next.js by using a
+ * trivial fake "build" command that copies files into `dist/`. The health
+ * check is stubbed (unit-tested elsewhere) since spinning up an HTTP server
+ * is out-of-scope here.
+ *
+ * Skipped on CI environments without git or where /private/tmp is locked
+ * down — but every supported CAIA dev/CI environment has both.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { deploySite, resolveSitePath } from '../src/deploy';
+import { defaultShellRunner, runOrThrow } from '../src/shell-runner';
+
+import type { SiteConfig } from '../src/sites-config';
+
+let installRoot: string;
+let buildWorkspaceRoot: string;
+let repoPath: string;
+
+beforeEach(async () => {
+  installRoot = mkdtempSync(join(tmpdir(), 'lp-int-install-'));
+  buildWorkspaceRoot = mkdtempSync(join(tmpdir(), 'lp-int-buildws-'));
+  repoPath = mkdtempSync(join(tmpdir(), 'lp-int-repo-'));
+
+  // Initialise a fixture git repo with one commit on `develop`.
+  await runOrThrow(defaultShellRunner, 'git init -b develop', { cwd: repoPath, timeoutMs: 10_000 });
+  await runOrThrow(defaultShellRunner, 'git config user.email test@test', { cwd: repoPath, timeoutMs: 5_000 });
+  await runOrThrow(defaultShellRunner, 'git config user.name test', { cwd: repoPath, timeoutMs: 5_000 });
+  await runOrThrow(defaultShellRunner, 'git config commit.gpgsign false', { cwd: repoPath, timeoutMs: 5_000 });
+
+  mkdirSync(join(repoPath, 'src'), { recursive: true });
+  writeFileSync(join(repoPath, 'src', 'index.html'), '<html><title>hello</title></html>', 'utf-8');
+  writeFileSync(join(repoPath, 'package.json'), '{"name":"fixture","version":"0.0.0"}', 'utf-8');
+  await runOrThrow(defaultShellRunner, 'git add -A', { cwd: repoPath, timeoutMs: 10_000 });
+  await runOrThrow(defaultShellRunner, "git commit -m 'initial'", { cwd: repoPath, timeoutMs: 10_000 });
+
+  // Set "origin" to the same repo (self-remote) so `git fetch origin` works
+  // without a separate bare repo. Self-remote fetch is a supported git pattern.
+  await runOrThrow(defaultShellRunner, `git remote add origin ${repoPath}`, { cwd: repoPath, timeoutMs: 5_000 });
+  await runOrThrow(defaultShellRunner, 'git fetch origin', { cwd: repoPath, timeoutMs: 10_000 });
+});
+
+afterEach(() => {
+  rmSync(installRoot, { recursive: true, force: true });
+  rmSync(buildWorkspaceRoot, { recursive: true, force: true });
+  rmSync(repoPath, { recursive: true, force: true });
+});
+
+const fixtureSite = (repo: string): SiteConfig => ({
+  name: 'fixture',
+  repo,
+  branch: 'develop',
+  port: 9999,
+  // Trivial "build": copy src/ to dist/. Real Next.js builds are out of scope here.
+  buildCmd: 'mkdir -p dist && cp -r src/* dist/',
+  startCmd: (p) => `echo start ${p}`,
+  healthPath: '/',
+  healthMustContain: '<title',
+  buildArtifacts: ['dist', 'package.json']
+});
+
+describe('deploySite — integration', () => {
+  it('clones a real repo, builds, and atomic-swaps the symlink', async () => {
+    const site = fixtureSite(repoPath);
+    const result = await deploySite(site, {
+      installRoot,
+      buildWorkspaceRoot,
+      // Real shellRunner + real gitOps
+      // Stub the health checker (spinning up an actual HTTP server is out of scope)
+      healthChecker: async () => ({ ok: true, statusCode: 200, responseTime: 1 }),
+      // Stub restart (no LaunchAgent here)
+      restartProcess: async () => undefined,
+      healthCheckMaxAttempts: 1,
+      healthCheckInitialDelayMs: 1,
+      logger: { info: () => undefined, error: () => undefined }
+    });
+
+    expect(result.status).toBe('success');
+    if (result.status !== 'success') return;
+    expect(result.sha).toMatch(/^[0-9a-f]{40}$/);
+
+    const sitePath = resolveSitePath(installRoot, site.name);
+    const currentLink = join(sitePath, 'current');
+    expect(existsSync(currentLink)).toBe(true);
+
+    // Verify the build artifact was copied
+    const target = readlinkSync(currentLink);
+    const indexFile = join(sitePath, target, 'dist', 'index.html');
+    expect(existsSync(indexFile)).toBe(true);
+    expect(readFileSync(indexFile, 'utf-8')).toContain('<title>hello</title>');
+
+    // package.json was also copied
+    const pkgFile = join(sitePath, target, 'package.json');
+    expect(existsSync(pkgFile)).toBe(true);
+
+    // state.json should reflect success
+    const state = JSON.parse(readFileSync(join(sitePath, 'state.json'), 'utf-8'));
+    expect(state.last_deploy_status).toBe('success');
+    expect(state.current_sha).toBe(result.sha);
+  });
+
+  it('detects new commits across two consecutive deploys', async () => {
+    const site = fixtureSite(repoPath);
+    const opts = {
+      installRoot,
+      buildWorkspaceRoot,
+      healthChecker: async () => ({ ok: true as const, statusCode: 200, responseTime: 1 }),
+      restartProcess: async () => undefined,
+      healthCheckMaxAttempts: 1,
+      healthCheckInitialDelayMs: 1,
+      logger: { info: () => undefined, error: () => undefined }
+    };
+
+    const r1 = await deploySite(site, opts);
+    expect(r1.status).toBe('success');
+
+    // Second invocation with no new commits → noop
+    const r2 = await deploySite(site, opts);
+    expect(r2.status).toBe('noop');
+
+    // Add a new commit and deploy again
+    writeFileSync(join(repoPath, 'src', 'index.html'), '<html><title>v2</title></html>', 'utf-8');
+    await runOrThrow(defaultShellRunner, 'git add -A', { cwd: repoPath, timeoutMs: 10_000 });
+    await runOrThrow(defaultShellRunner, "git commit -m 'v2'", { cwd: repoPath, timeoutMs: 10_000 });
+
+    const r3 = await deploySite(site, opts);
+    expect(r3.status).toBe('success');
+    if (r3.status !== 'success') return;
+    if (r1.status !== 'success') return;
+    expect(r3.sha).not.toBe(r1.sha);
+
+    // current symlink now points at v2
+    const sitePath = resolveSitePath(installRoot, site.name);
+    const currentLink = join(sitePath, 'current');
+    const target = readlinkSync(currentLink);
+    const indexContent = readFileSync(join(sitePath, target, 'dist', 'index.html'), 'utf-8');
+    expect(indexContent).toContain('<title>v2</title>');
+
+    // previous symlink should now exist and point at the v1 build
+    const previousLink = join(sitePath, 'previous');
+    expect(existsSync(previousLink)).toBe(true);
+    const prevTarget = readlinkSync(previousLink);
+    expect(prevTarget).toContain(r1.sha);
+  });
+
+  it('on build failure, leaves current symlink untouched', async () => {
+    // Pre-populate a successful first deploy
+    const site = fixtureSite(repoPath);
+    const baseOpts = {
+      installRoot,
+      buildWorkspaceRoot,
+      healthChecker: async () => ({ ok: true as const, statusCode: 200, responseTime: 1 }),
+      restartProcess: async () => undefined,
+      healthCheckMaxAttempts: 1,
+      healthCheckInitialDelayMs: 1,
+      logger: { info: () => undefined, error: () => undefined }
+    };
+    const r1 = await deploySite(site, baseOpts);
+    expect(r1.status).toBe('success');
+
+    const sitePath = resolveSitePath(installRoot, site.name);
+    const currentBefore = readlinkSync(join(sitePath, 'current'));
+
+    // Add a new commit but configure a build that fails
+    writeFileSync(join(repoPath, 'src', 'index.html'), '<html><title>v2</title></html>', 'utf-8');
+    await runOrThrow(defaultShellRunner, 'git add -A', { cwd: repoPath, timeoutMs: 10_000 });
+    await runOrThrow(defaultShellRunner, "git commit -m 'will-fail'", { cwd: repoPath, timeoutMs: 10_000 });
+
+    const failingSite: SiteConfig = { ...site, buildCmd: 'exit 1' };
+    const r2 = await deploySite(failingSite, baseOpts);
+
+    expect(r2.status).toBe('build-failed');
+    // current symlink unchanged
+    const currentAfter = readlinkSync(join(sitePath, 'current'));
+    expect(currentAfter).toBe(currentBefore);
+  });
+});

--- a/apps/local-preview-orchestrator/tests/deploy.test.ts
+++ b/apps/local-preview-orchestrator/tests/deploy.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for deploy.ts — exercise the state machine via stubbed
+ * shell-runner / git-ops / health-checker / restart-process. No real
+ * subprocesses are spawned here; integration coverage lives in
+ * deploy.integration.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  deploySite,
+  extractShaFromBuildPath,
+  resolveBuildDir,
+  resolveSitePath,
+  LockHeldError
+} from '../src/deploy';
+import type { ShellRunner, ShellResult } from '../src/shell-runner';
+import type { GitOps } from '../src/git-ops';
+import type { SiteConfig } from '../src/sites-config';
+
+const SHA = '1111111111111111111111111111111111111111';
+const SHA2 = '2222222222222222222222222222222222222222';
+
+let installRoot: string;
+let buildWorkspaceRoot: string;
+let repoPath: string;
+
+beforeEach(() => {
+  installRoot = mkdtempSync(join(tmpdir(), 'lp-deploy-install-'));
+  buildWorkspaceRoot = mkdtempSync(join(tmpdir(), 'lp-deploy-buildws-'));
+  repoPath = mkdtempSync(join(tmpdir(), 'lp-deploy-repo-'));
+});
+
+afterEach(() => {
+  rmSync(installRoot, { recursive: true, force: true });
+  rmSync(buildWorkspaceRoot, { recursive: true, force: true });
+  rmSync(repoPath, { recursive: true, force: true });
+});
+
+const baseSite: SiteConfig = {
+  name: 'fake-site',
+  repo: '<set per test>',
+  branch: 'develop',
+  port: 9999,
+  buildCmd: 'echo build-ok',
+  startCmd: (p) => `echo start ${p}`,
+  healthPath: '/',
+  healthMustContain: '<title',
+  buildArtifacts: ['dist']
+};
+
+const okShell = (stdout = ''): ShellResult => ({ code: 0, stdout, stderr: '', durationMs: 1 });
+const failShell = (code = 1, stderr = 'oops'): ShellResult => ({ code, stdout: '', stderr, durationMs: 1 });
+
+/**
+ * Build a stub gitOps that mimics worktree-add by populating a directory
+ * with a 'dist/index.html' artifact at the given workspace path.
+ */
+function makeStubGitOps(targetSha: string): { gitOps: GitOps; calls: string[] } {
+  const calls: string[] = [];
+  const gitOps: GitOps = {
+    fetch: async (repo, branch) => {
+      calls.push(`fetch ${repo} ${branch}`);
+    },
+    resolveBranchSha: async (_repo, _branch) => {
+      calls.push('rev-parse');
+      return targetSha;
+    },
+    worktreeAdd: async (_repo, target, _ref) => {
+      calls.push(`worktree-add ${target}`);
+      mkdirSync(join(target, 'dist'), { recursive: true });
+      writeFileSync(join(target, 'dist', 'index.html'), '<html><title>ok</title></html>', 'utf-8');
+    },
+    worktreeRemove: async (_repo, target) => {
+      calls.push(`worktree-remove ${target}`);
+      rmSync(target, { recursive: true, force: true });
+    }
+  };
+  return { gitOps, calls };
+}
+
+describe('extractShaFromBuildPath', () => {
+  it('extracts SHA from a builds/<sha> string', () => {
+    expect(extractShaFromBuildPath('builds/abc1234567')).toBe('abc1234567');
+  });
+  it('extracts SHA from absolute path', () => {
+    expect(extractShaFromBuildPath('/x/y/builds/abc1234567')).toBe('abc1234567');
+  });
+  it('returns undefined for non-build paths', () => {
+    expect(extractShaFromBuildPath('not-a-build')).toBeUndefined();
+  });
+});
+
+describe('deploySite — happy path', () => {
+  it('runs the pipeline end-to-end with stubbed runners', async () => {
+    const { gitOps, calls } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const restartProcess = vi.fn(async () => undefined);
+    const healthChecker = vi.fn(async () => ({ ok: true, statusCode: 200, responseTime: 5 }));
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        restartProcess,
+        healthChecker,
+        healthCheckMaxAttempts: 1,
+        healthCheckInitialDelayMs: 1
+      }
+    );
+
+    expect(result.status).toBe('success');
+    if (result.status !== 'success') return;
+    expect(result.sha).toBe(SHA);
+    expect(result.healthCheckMs).toBeGreaterThanOrEqual(0);
+    expect(restartProcess).toHaveBeenCalledTimes(1);
+    expect(healthChecker).toHaveBeenCalledTimes(1);
+
+    // Symlink swap should have happened
+    const sitePath = resolveSitePath(installRoot, baseSite.name);
+    const currentLink = join(sitePath, 'current');
+    expect(existsSync(currentLink)).toBe(true);
+    expect(readlinkSync(currentLink)).toBe(`builds/${SHA}`);
+
+    // Build artifact should be in place
+    const installedArtifact = join(resolveBuildDir(sitePath, SHA), 'dist', 'index.html');
+    expect(existsSync(installedArtifact)).toBe(true);
+
+    // git fetch happened
+    expect(calls.some((c) => c.startsWith('fetch '))).toBe(true);
+    // worktree-remove happened on success
+    expect(calls.some((c) => c.startsWith('worktree-remove '))).toBe(true);
+
+    // state.json written
+    const statePath = join(sitePath, 'state.json');
+    expect(existsSync(statePath)).toBe(true);
+  });
+
+  it('returns noop when remote SHA matches current symlink target', async () => {
+    // Pre-populate sitePath with a current symlink pointing at builds/<SHA>
+    const sitePath = resolveSitePath(installRoot, baseSite.name);
+    mkdirSync(sitePath, { recursive: true });
+    mkdirSync(join(sitePath, 'builds', SHA), { recursive: true });
+    const { symlinkSync } = await import('node:fs');
+    symlinkSync(`builds/${SHA}`, join(sitePath, 'current'), 'dir');
+
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner
+      }
+    );
+
+    expect(result.status).toBe('noop');
+    if (result.status !== 'noop') return;
+    expect(result.sha).toBe(SHA);
+  });
+});
+
+describe('deploySite — failure paths', () => {
+  it('returns build-failed when build command exits non-zero', async () => {
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => failShell(1, 'compile error')) as unknown as ShellRunner;
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner
+      }
+    );
+
+    expect(result.status).toBe('build-failed');
+    if (result.status !== 'build-failed') return;
+    expect(result.sha).toBe(SHA);
+    expect(result.error).toContain('exit 1');
+    expect(result.logTail).toContain('compile error');
+
+    // No symlink should have been created
+    const sitePath = resolveSitePath(installRoot, baseSite.name);
+    expect(existsSync(join(sitePath, 'current'))).toBe(false);
+  });
+
+  it('rolls back on health-check failure', async () => {
+    // Pre-populate sitePath with a previous build so rollback has somewhere to go.
+    const sitePath = resolveSitePath(installRoot, baseSite.name);
+    mkdirSync(sitePath, { recursive: true });
+    const previousSha = '0000000000000000000000000000000000000000';
+    mkdirSync(join(sitePath, 'builds', previousSha), { recursive: true });
+    const { symlinkSync } = await import('node:fs');
+    symlinkSync(`builds/${previousSha}`, join(sitePath, 'current'), 'dir');
+
+    const { gitOps } = makeStubGitOps(SHA2);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const restartProcess = vi.fn(async () => undefined);
+    const healthChecker = vi.fn(async () => ({ ok: false, error: '503 unavailable' }));
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        restartProcess,
+        healthChecker,
+        healthCheckMaxAttempts: 1,
+        healthCheckInitialDelayMs: 1
+      }
+    );
+
+    expect(result.status).toBe('health-check-failed');
+    if (result.status !== 'health-check-failed') return;
+    expect(result.sha).toBe(SHA2);
+    expect(result.rolledBackToSha).toBe(previousSha);
+
+    // Restart should have been invoked twice: once after swap, once after rollback
+    expect(restartProcess).toHaveBeenCalledTimes(2);
+
+    // current symlink should now point at the previous build
+    const currentLink = join(sitePath, 'current');
+    expect(readlinkSync(currentLink)).toBe(`builds/${previousSha}`);
+  });
+
+  it('returns rollback-failed when no previous build exists', async () => {
+    // Fresh sitePath; first deploy fails health-check; nothing to roll back to.
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const restartProcess = vi.fn(async () => undefined);
+    const healthChecker = vi.fn(async () => ({ ok: false, error: '503 unavailable' }));
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        restartProcess,
+        healthChecker,
+        healthCheckMaxAttempts: 1,
+        healthCheckInitialDelayMs: 1
+      }
+    );
+
+    expect(result.status).toBe('rollback-failed');
+  });
+
+  it('returns locked when site lock is already held', async () => {
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+
+    // Pretend lock is held
+    const acquireSiteLock = (_name: string): never => {
+      throw new LockHeldError('already locked');
+    };
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        acquireSiteLock: acquireSiteLock as unknown as (n: string) => () => void
+      }
+    );
+
+    expect(result.status).toBe('locked');
+  });
+
+  it('reports build-failed when an expected artifact is missing', async () => {
+    const calls: string[] = [];
+    const gitOps: GitOps = {
+      fetch: async () => {
+        calls.push('fetch');
+      },
+      resolveBranchSha: async () => SHA,
+      worktreeAdd: async (_repo, target) => {
+        calls.push(`worktree-add ${target}`);
+        // Intentionally do NOT create the dist artifact
+        mkdirSync(target, { recursive: true });
+      },
+      worktreeRemove: async (_repo, target) => {
+        rmSync(target, { recursive: true, force: true });
+      }
+    };
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      { installRoot, buildWorkspaceRoot, gitOps, shellRunner }
+    );
+
+    expect(result.status).toBe('build-failed');
+    if (result.status !== 'build-failed') return;
+    expect(result.error).toContain('expected build artifact missing');
+  });
+});

--- a/apps/local-preview-orchestrator/tests/git-ops.test.ts
+++ b/apps/local-preview-orchestrator/tests/git-ops.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeGitOps, shellEscape } from '../src/git-ops';
+import type { ShellRunner, ShellResult } from '../src/shell-runner';
+
+const okResult = (stdout: string): ShellResult => ({ code: 0, stdout, stderr: '', durationMs: 0 });
+const failResult = (code: number, stderr = 'boom'): ShellResult => ({ code, stdout: '', stderr, durationMs: 0 });
+
+describe('shellEscape', () => {
+  it('passes through clean tokens', () => {
+    expect(shellEscape('develop')).toBe('develop');
+    expect(shellEscape('abc123def4567')).toBe('abc123def4567');
+    expect(shellEscape('/Users/MAC/project')).toBe('/Users/MAC/project');
+  });
+
+  it('quotes tokens with shell metacharacters', () => {
+    expect(shellEscape('a b')).toBe("'a b'");
+    expect(shellEscape("she's here")).toBe("'she'\\''s here'");
+    expect(shellEscape('a;b')).toBe("'a;b'");
+  });
+});
+
+describe('makeGitOps', () => {
+  it('fetch issues git fetch origin <branch>', async () => {
+    const fakeShell: ShellRunner = vi.fn(async () => okResult(''));
+    const gitOps = makeGitOps(fakeShell);
+    await gitOps.fetch('/repo', 'develop');
+    expect(fakeShell).toHaveBeenCalledOnce();
+    const [cmd, opts] = (fakeShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(cmd).toContain('git fetch origin develop');
+    expect(opts.cwd).toBe('/repo');
+  });
+
+  it('resolveBranchSha returns the trimmed SHA', async () => {
+    const sha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const fakeShell: ShellRunner = vi.fn(async () => okResult(`${sha}\n`));
+    const gitOps = makeGitOps(fakeShell);
+    const result = await gitOps.resolveBranchSha('/repo', 'develop');
+    expect(result).toBe(sha);
+  });
+
+  it('resolveBranchSha rejects malformed output', async () => {
+    const fakeShell: ShellRunner = vi.fn(async () => okResult('not-a-sha-at-all\n'));
+    const gitOps = makeGitOps(fakeShell);
+    await expect(gitOps.resolveBranchSha('/repo', 'develop')).rejects.toThrow(/Invalid SHA/);
+  });
+
+  it('worktreeAdd issues correct command', async () => {
+    const fakeShell: ShellRunner = vi.fn(async () => okResult(''));
+    const gitOps = makeGitOps(fakeShell);
+    await gitOps.worktreeAdd('/repo', '/tmp/wt-x', 'abc1234');
+    const [cmd] = (fakeShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(cmd).toContain('git worktree add --detach --force');
+    expect(cmd).toContain('/tmp/wt-x');
+    expect(cmd).toContain('abc1234');
+  });
+
+  it('worktreeRemove issues correct command', async () => {
+    const fakeShell: ShellRunner = vi.fn(async () => okResult(''));
+    const gitOps = makeGitOps(fakeShell);
+    await gitOps.worktreeRemove('/repo', '/tmp/wt-x');
+    const [cmd] = (fakeShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(cmd).toContain('git worktree remove --force');
+  });
+
+  it('throws when shell command fails', async () => {
+    const fakeShell: ShellRunner = vi.fn(async () => failResult(128, 'fatal: not a git repository'));
+    const gitOps = makeGitOps(fakeShell);
+    await expect(gitOps.fetch('/not-a-repo', 'develop')).rejects.toThrow(/exit 128/);
+  });
+});

--- a/apps/local-preview-orchestrator/tests/poll-loop.test.ts
+++ b/apps/local-preview-orchestrator/tests/poll-loop.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runPollLoop, pollIteration, defaultSleep } from '../src/poll-loop';
+import type { SiteConfig } from '../src/sites-config';
+import type { DeployOptions, DeployResult } from '../src/deploy';
+
+const fakeSite = (name: string, port: number): SiteConfig => ({
+  name,
+  repo: `/tmp/${name}`,
+  branch: 'develop',
+  port,
+  buildCmd: 'echo build',
+  startCmd: (p) => `echo start ${p}`,
+  healthPath: '/',
+  healthMustContain: '<title',
+  buildArtifacts: ['dist']
+});
+
+const dummyDeployOpts: DeployOptions = {
+  installRoot: '/tmp/install',
+  buildWorkspaceRoot: '/tmp/buildws'
+};
+
+describe('defaultSleep', () => {
+  it('sleeps for at least roughly the requested ms', async () => {
+    const start = Date.now();
+    await defaultSleep(40);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(30);
+  });
+
+  it('returns early when signal is already aborted', async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const start = Date.now();
+    await defaultSleep(5_000, ctrl.signal);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('returns early on signal abort during sleep', async () => {
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 30);
+    const start = Date.now();
+    await defaultSleep(5_000, ctrl.signal);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+});
+
+describe('pollIteration', () => {
+  it('invokes deployFn for each site', async () => {
+    const sites = [fakeSite('a', 1), fakeSite('b', 2)];
+    const deployFn = vi.fn(async (s: SiteConfig): Promise<DeployResult> => ({
+      status: 'success',
+      sha: `sha-${s.name}`,
+      durationMs: 5,
+      healthCheckMs: 1
+    }));
+    const result = await pollIteration(new Set(), {
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn
+    });
+    expect(deployFn).toHaveBeenCalledTimes(2);
+    expect(result.a).toEqual({ status: 'success', sha: 'sha-a', durationMs: 5, healthCheckMs: 1 });
+    expect(result.b).toEqual({ status: 'success', sha: 'sha-b', durationMs: 5, healthCheckMs: 1 });
+  });
+
+  it('reports in-progress when site lock is held by previous iteration', async () => {
+    const sites = [fakeSite('a', 1)];
+    const deployFn = vi.fn(async (): Promise<DeployResult> => ({
+      status: 'noop',
+      sha: 'x'
+    }));
+    const inFlight = new Set<string>(['a']);
+    const result = await pollIteration(inFlight, {
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn
+    });
+    expect(deployFn).not.toHaveBeenCalled();
+    expect(result.a).toEqual({ status: 'in-progress' });
+  });
+
+  it('captures errors thrown by deployFn', async () => {
+    const sites = [fakeSite('a', 1)];
+    const deployFn = vi.fn(async (): Promise<DeployResult> => {
+      throw new Error('boom');
+    });
+    const result = await pollIteration(new Set(), {
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn
+    });
+    expect(result.a).toEqual({ status: 'error', error: 'boom' });
+  });
+});
+
+describe('runPollLoop', () => {
+  it('runs N iterations when maxIterations is set', async () => {
+    const sites = [fakeSite('a', 1)];
+    const deployFn = vi.fn(async (): Promise<DeployResult> => ({
+      status: 'noop',
+      sha: 'x'
+    }));
+    const onIteration = vi.fn();
+    const sleep = vi.fn(async () => undefined);
+    await runPollLoop({
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn,
+      onIteration,
+      sleep,
+      intervalMs: 1,
+      maxIterations: 3
+    });
+    expect(onIteration).toHaveBeenCalledTimes(3);
+    expect(deployFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops on abort', async () => {
+    const sites = [fakeSite('a', 1)];
+    const deployFn = vi.fn(async (): Promise<DeployResult> => ({
+      status: 'noop',
+      sha: 'x'
+    }));
+    const ctrl = new AbortController();
+    let count = 0;
+    const sleep = vi.fn(async () => {
+      count++;
+      if (count >= 2) ctrl.abort();
+    });
+    await runPollLoop({
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn,
+      sleep,
+      abortSignal: ctrl.signal,
+      intervalMs: 1
+    });
+    // Should have stopped after the abort fired during sleep
+    expect(deployFn.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it('does not throw when an iteration handler errors', async () => {
+    const sites = [fakeSite('a', 1)];
+    const deployFn = vi.fn(async (): Promise<DeployResult> => ({
+      status: 'noop',
+      sha: 'x'
+    }));
+    const onIteration = vi.fn(() => {
+      throw new Error('handler boom');
+    });
+    const sleep = vi.fn(async () => undefined);
+    await expect(
+      runPollLoop({
+        sites,
+        deployOptions: dummyDeployOpts,
+        deployFn,
+        onIteration,
+        sleep,
+        intervalMs: 1,
+        maxIterations: 1,
+        logger: { info: () => undefined, error: () => undefined }
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/local-preview-orchestrator/tests/shell-runner.test.ts
+++ b/apps/local-preview-orchestrator/tests/shell-runner.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { defaultShellRunner, runOrThrow } from '../src/shell-runner';
+
+describe('shell-runner', () => {
+  it('runs a simple bash command and returns code 0', async () => {
+    const result = await defaultShellRunner('echo hello', { cwd: '/tmp', timeoutMs: 5_000 });
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toBe('hello');
+    expect(result.stderr).toBe('');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('captures non-zero exit code without throwing', async () => {
+    const result = await defaultShellRunner('exit 42', { cwd: '/tmp', timeoutMs: 5_000 });
+    expect(result.code).toBe(42);
+  });
+
+  it('captures stderr', async () => {
+    const result = await defaultShellRunner('echo oops 1>&2', { cwd: '/tmp', timeoutMs: 5_000 });
+    expect(result.code).toBe(0);
+    expect(result.stderr.trim()).toBe('oops');
+  });
+
+  it('respects cwd', async () => {
+    // /tmp is a symlink to /private/tmp on macOS — pwd reports the resolved path.
+    // Use a freshly-created mkdtempSync directory so we get a stable absolute path
+    // without symlink ambiguity.
+    const { mkdtempSync, rmSync, realpathSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'shell-cwd-test-')));
+    try {
+      const result = await defaultShellRunner('pwd', { cwd: dir, timeoutMs: 5_000 });
+      expect(result.stdout.trim()).toBe(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces timeout (SIGKILL on overrun)', async () => {
+    const result = await defaultShellRunner('sleep 5', { cwd: '/tmp', timeoutMs: 100 });
+    expect(result.code).toBe(124);
+    expect(result.stderr).toContain('killed: timeout');
+  });
+
+  it('runOrThrow returns on success', async () => {
+    const result = await runOrThrow(defaultShellRunner, 'echo ok', { cwd: '/tmp', timeoutMs: 5_000 });
+    expect(result.stdout.trim()).toBe('ok');
+  });
+
+  it('runOrThrow throws on non-zero exit', async () => {
+    await expect(
+      runOrThrow(defaultShellRunner, 'false', { cwd: '/tmp', timeoutMs: 5_000 })
+    ).rejects.toThrow(/exit 1/);
+  });
+});

--- a/apps/local-preview-orchestrator/tests/site-state.test.ts
+++ b/apps/local-preview-orchestrator/tests/site-state.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  defaultSiteState,
+  readSiteState,
+  writeSiteState,
+  updateSiteState
+} from '../src/site-state';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'site-state-test-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('site-state', () => {
+  it('default state has expected shape', () => {
+    const s = defaultSiteState('dashboard', 5173);
+    expect(s.name).toBe('dashboard');
+    expect(s.url).toBe('http://localhost:5173');
+    expect(s.current_sha).toBeNull();
+    expect(s.last_deploy_status).toBeNull();
+    expect(s.process_state).toBe('unknown');
+    expect(s.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('readSiteState returns default when no file exists', () => {
+    const s = readSiteState(dir, { name: 'dashboard', port: 5173 });
+    expect(s.name).toBe('dashboard');
+    expect(s.current_sha).toBeNull();
+  });
+
+  it('writeSiteState persists JSON', () => {
+    const initial = defaultSiteState('dashboard', 5173);
+    writeSiteState(dir, { ...initial, current_sha: 'abc1234' });
+    const filePath = join(dir, 'state.json');
+    expect(existsSync(filePath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+    expect(parsed.current_sha).toBe('abc1234');
+  });
+
+  it('updateSiteState merges patch on top of existing state', () => {
+    const fallback = { name: 'dashboard', port: 5173 };
+    writeSiteState(dir, { ...defaultSiteState('dashboard', 5173), current_sha: 'old-sha' });
+    const updated = updateSiteState(dir, fallback, {
+      current_sha: 'new-sha',
+      last_deploy_status: 'success',
+      last_deploy_duration_ms: 1234
+    });
+    expect(updated.current_sha).toBe('new-sha');
+    expect(updated.last_deploy_status).toBe('success');
+    expect(updated.last_deploy_duration_ms).toBe(1234);
+
+    const reread = readSiteState(dir, fallback);
+    expect(reread.current_sha).toBe('new-sha');
+    expect(reread.last_deploy_status).toBe('success');
+  });
+
+  it('readSiteState returns default on malformed JSON', () => {
+    const fallback = { name: 'dashboard', port: 5173 };
+    const filePath = join(dir, 'state.json');
+    writeFileSync(filePath, '{ not valid json', 'utf-8');
+    const s = readSiteState(dir, fallback);
+    expect(s.name).toBe('dashboard');
+    expect(s.current_sha).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

PR-B of the Local-Preview-Deploys roadmap. Builds on the PR-A skeleton (#312) merged earlier today.

Adds:
- the **end-to-end deploy state machine** (\`src/deploy.ts\`)
- the **30s polling daemon** (\`src/poll-loop.ts\`)
- supporting infrastructure: \`src/shell-runner.ts\`, \`src/git-ops.ts\`, \`src/site-state.ts\`
- **42 new tests** (71 total in this app), including an integration test against a real fixture git repo

No runtime side effects until PR-D wires the LaunchAgents.

## Modules

| File | Purpose |
|---|---|
| \`src/shell-runner.ts\` | Injectable \`bash -c\` executor with timeout + exit-code + stdout/stderr capture |
| \`src/git-ops.ts\` | \`fetch\` / \`resolveBranchSha\` / \`worktreeAdd\` / \`worktreeRemove\` over the shell-runner; strict-allowlist \`shellEscape\` |
| \`src/deploy.ts\` | Full pipeline: lock → fetch → compare → disk-check → worktree → build → copy → swap → restart → health → (rollback) → prune → state-write |
| \`src/poll-loop.ts\` | \`runPollLoop\` long-running daemon + \`pollIteration\` (single-tick helper for tests) |
| \`src/site-state.ts\` | Atomic JSON state writer the PR-C dashboard will read |

## State machine

The deploy returns a typed discriminated union \`DeployResult\` covering every outcome:
\`success | noop | build-failed | health-check-failed | rollback-failed | disk-full | locked | aborted\`. No throw paths leak out of \`deploySite\`.

## Test coverage

- Unit tests for each new module (mocked subprocesses + git ops where appropriate)
- **Integration test** (\`deploy.integration.test.ts\`) that:
  - inits a real fixture git repo (self-remote) with one commit
  - runs \`deploySite\` end-to-end with the real \`defaultShellRunner\` + \`makeGitOps\`
  - asserts artifacts copied, symlink swapped, \`state.json\` reflects success
  - second invocation = \`noop\`; third (after a new commit) = \`success\` with \`previous\` pointing at v1
  - build-failed deploy leaves \`current\` symlink untouched

\`\`\`
Test Files  11 passed (11)
     Tests  71 passed (71)
\`\`\`

## Trust boundary

All paths and commands derive from the **compile-time SITES registry**. No user-controllable input reaches a shell, fs path, or git command. Every \`path.join(siteDerivedPath, …)\` and the one \`spawn('/bin/bash', ['-c', cmd], …)\` carry explicit \`// nosemgrep:\` annotations with trust-boundary justification.

## Roadmap

- [x] PR-A — skeleton + 29 unit tests (#312)
- [x] **PR-B — deploy + poll-loop + integration test (this PR)**
- [ ] PR-C — status dashboard + e2e test
- [ ] PR-D — LaunchAgent plists + install.sh + Steward analyzer
- [ ] Stage 6 — 3-site live verify on Mac

References: \`~/Documents/projects/reports/local-preview-deploys-analysis.md\`, \`agent/memory/steward_local_preview_deploys_directive.md\`.