### PR TITLE
feat(local-preview-001): launchagent plists + install.sh + steward analyzer (PR-D)

### DIFF
--- a/.changeset/feat-local-preview-001-plists-steward.md
+++ b/.changeset/feat-local-preview-001-plists-steward.md
@@ -1,0 +1,74 @@
+---
+"caia": patch
+---
+
+feat(local-preview-001): LaunchAgent plists + install.sh + Steward analyzer (PR-D)
+
+Closes the implementation phase of the Local-Preview-Deploys roadmap
+(item 1 in the multi-day campaign roadmap). Adds the macOS-side
+plumbing that turns the building blocks from PR-A/B/C (#312/#313/#314)
+into an actual always-on local-preview system on the operator's Mac.
+
+## What landed
+
+**5 LaunchAgent plists** under `apps/local-preview-orchestrator/plists/`:
+
+| Label | Role |
+|---|---|
+| `com.stolution.local-preview.deploy-daemon` | poll-loop daemon (one process for all 3 sites) |
+| `com.stolution.local-preview.status-dashboard` | HTTP server on 127.0.0.1:5170 |
+| `com.stolution.local-preview.dashboard` | site supervisor → localhost:5173 |
+| `com.stolution.local-preview.poker-zeno` | site supervisor → localhost:5174 |
+| `com.stolution.local-preview.roulette-community` | site supervisor → localhost:5175 |
+
+All plists pass `plutil -lint`. They use placeholders (`__USER_HOME__`,
+`__REPO__`, `__SITE_REPO_*__`) substituted at install-time.
+
+**Install / uninstall scripts** under
+`apps/local-preview-orchestrator/scripts/`:
+
+- `install.sh` — backs up existing plists to `~/.caia-backups/`,
+  templates the plist placeholders, mkdir's log+state dirs,
+  `launchctl bootstrap`s each agent, then waits up to 30s for the
+  status dashboard to respond on `/healthz`. Idempotent.
+- `uninstall.sh` — `launchctl bootout` + delete plists.
+  `--purge` also removes build artifacts.
+- `status.sh` — `curl /api/status | python -m json.tool`.
+
+All three pass `bash -n` syntax check.
+
+**Steward analyzer**: new `local-preview-health.ts` in
+`packages/steward-analyzers/`:
+
+- `dashboard-unreachable` (high) — dashboard not responding
+- `site-never-deployed` (medium) — no `current_sha` pinned
+- `last-deploy-failed` (medium / high for `rollback-failed`) — last
+  deploy in a failure state
+- `health-check-stale` (medium) — last health check > 10m old
+- `health-check-never-run` (low) — current_sha set but no health timestamp
+- `health-check-failed` (high) — last health check failed
+
+Wired into `bin/steward-gatekeeper.mjs` as the `local-preview-health`
+subcommand. Runs by curl-ing `http://127.0.0.1:5170/api/status` and
+feeding the parsed sites array into the analyzer.
+
+**README** at `apps/local-preview-orchestrator/README.md` covering
+quick-start, architecture, CLI, dashboard API, Steward integration,
+and uninstall.
+
+## Tests
+
+- 10 new unit tests for `checkLocalPreviewHealth` (101 total in
+  steward-analyzers).
+- All 91 existing local-preview-orchestrator tests still pass (no
+  source changes in this PR).
+
+## Stage 6 (live verification on Mac) is intentionally NOT in this PR
+
+Stage 6 = manual install on the operator's Mac + verifying the 3 sites
+are continuously up and that 60s deploy latency / rollback / Mac-reboot
+resilience all work. That's the next leg's first priority.
+
+References: `~/Documents/projects/reports/local-preview-deploys-analysis.md`,
+`agent/memory/steward_local_preview_deploys_directive.md`,
+`agent/memory/daemon_repoint_2026-04-30.md`.

--- a/apps/local-preview-orchestrator/README.md
+++ b/apps/local-preview-orchestrator/README.md
@@ -1,0 +1,147 @@
+# Local Preview Orchestrator
+
+Always-on local preview deployments for the three CAIA-affiliated sites:
+
+| Site | Local URL | Source repo |
+|---|---|---|
+| **CAIA dashboard** | http://localhost:5173 | `caia/apps/dashboard` |
+| **poker-zeno** | http://localhost:5174 | `~/Documents/projects/poker-zeno` |
+| **roulette-community** | http://localhost:5175 | `~/Documents/projects/roulette-community` |
+| **status dashboard** | http://localhost:5170 | this app |
+
+When installed, every merge to `develop` of any of the three site repos is
+auto-deployed to the corresponding local URL within 60 seconds, with atomic
+symlink-swap, instant rollback on health-check failure, and ten-build retention
+for manual rollback.
+
+Subscription-only by design — no external services, no API keys, no paid
+tunnels. The deploy daemon polls `git fetch` every 30s.
+
+## Quick start
+
+```bash
+# 1. Build the orchestrator
+pnpm -F @caia-app/local-preview-orchestrator build
+
+# 2. Install the LaunchAgents (5 plists go into ~/Library/LaunchAgents/)
+./apps/local-preview-orchestrator/scripts/install.sh
+
+# 3. Visit the status dashboard
+open http://127.0.0.1:5170/
+```
+
+The first deploy fires on its own within 30s. Watch progress via the dashboard
+or via:
+
+```bash
+./apps/local-preview-orchestrator/scripts/status.sh
+```
+
+## Architecture
+
+Five LaunchAgents work together:
+
+```
+com.stolution.local-preview.deploy-daemon       — poll-loop daemon (one process for all 3 sites)
+com.stolution.local-preview.status-dashboard    — HTTP server on 5170
+com.stolution.local-preview.dashboard           — site supervisor: localhost:5173
+com.stolution.local-preview.poker-zeno          — site supervisor: localhost:5174
+com.stolution.local-preview.roulette-community  — site supervisor: localhost:5175
+```
+
+The deploy daemon polls each site's repo every 30s. When it sees a new
+`origin/develop` SHA, it:
+
+1. `git worktree add` a fresh build copy
+2. runs the configured `buildCmd`
+3. copies the resulting artifacts into the per-site install dir at
+   `~/Library/Application Support/Stolution/local-preview/<site>/builds/<sha>/`
+4. atomically swaps the `current` symlink to point at the new build
+5. SIGTERMs the running site supervisor (launchd `KeepAlive` re-spawns it
+   pointed at the new build)
+6. polls the site's health endpoint with backoff
+7. on failure: swaps `current ← previous`, restarts again, logs an incident,
+   leaves a note for the Steward analyzer to surface
+
+State for each site lives at:
+
+```
+~/Library/Application Support/Stolution/local-preview/<site>/
+├── builds/<sha>/                 # per-deploy artifact directory (last 10)
+├── current → builds/<sha>/       # symlink to the live build
+├── previous → builds/<sha>/      # symlink to the last-known-good build
+├── pid                           # PID of the running site supervisor
+└── state.json                    # what /api/status reads
+```
+
+Incident log (one JSON-line per event):
+
+```
+~/Library/Application Support/Stolution/local-preview/_incidents/<site>.jsonl
+```
+
+## CLI
+
+The `local-preview` binary (built to `dist/cli.js`) accepts:
+
+| Subcommand | What it does |
+|---|---|
+| `poll-loop` | Long-running daemon. Same thing the LaunchAgent runs. |
+| `status-dashboard` | HTTP server on `${LOCAL_PREVIEW_DASHBOARD_PORT:-5170}` |
+| `deploy <site>` | One-shot deploy of a single site (handy for debugging) |
+| `status` | Print one-line JSON status to stdout |
+
+Env var overrides:
+
+| Var | Default | What |
+|---|---|---|
+| `LOCAL_PREVIEW_INSTALL_ROOT` | `~/Library/Application Support/Stolution/local-preview` | Per-site install root |
+| `LOCAL_PREVIEW_BUILD_WORKSPACE` | `/private/tmp/local-preview-build` | Ephemeral build worktrees |
+| `LOCAL_PREVIEW_DASHBOARD_PORT` | `5170` | Status dashboard port |
+
+## Status dashboard API
+
+| Method | Path | Result |
+|---|---|---|
+| `GET` | `/` | static dashboard HTML |
+| `GET` | `/healthz` | `200 ok` |
+| `GET` | `/api/status` | JSON state for all sites |
+| `GET` | `/api/logs/<site>` | last 200 lines of incident log |
+| `POST` | `/api/redeploy/<site>` | enqueue a forced deploy |
+| `POST` | `/api/rollback/<site>` | swap `current ← previous`, restart |
+
+Bound to `127.0.0.1` only — host = auth boundary, no auth needed.
+
+## Steward integration
+
+A daily Steward analyzer at `packages/steward-analyzers/src/local-preview-health.ts`
+checks:
+
+1. dashboard is reachable
+2. each configured site has a `current_sha` pinned
+3. the most recent deploy is in a `success`/`noop` state
+4. the most recent health check is < 10 minutes old
+5. the most recent health check status is `ok`
+
+Wired into the existing daily Steward cron via the `local-preview-health`
+subcommand of `bin/steward-gatekeeper.mjs`. Run manually:
+
+```bash
+node packages/steward-analyzers/bin/steward-gatekeeper.mjs local-preview-health
+```
+
+Findings flow into the daily Steward report issue.
+
+## Uninstalling
+
+```bash
+./apps/local-preview-orchestrator/scripts/uninstall.sh           # bootout + remove plists
+./apps/local-preview-orchestrator/scripts/uninstall.sh --purge   # also delete build artifacts
+```
+
+## References
+
+- Spec: `agent/memory/steward_local_preview_deploys_directive.md`
+- Design: `~/Documents/projects/reports/local-preview-deploys-analysis.md`
+- LaunchAgent pattern: `agent/memory/daemon_repoint_2026-04-30.md`
+- Subscription mandate: `agent/memory/feedback_no_api_key_billing.md`

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.dashboard.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.dashboard.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.stolution.local-preview.dashboard
+  =====================================
+  Site supervisor for the CAIA dashboard preview.
+
+  Reads the live build via the `current` symlink at:
+    __USER_HOME__/Library/Application Support/Stolution/local-preview/dashboard/current/
+
+  Listens on http://localhost:5173.
+
+  KeepAlive=true so the process is restarted by launchd whenever the deploy
+  daemon SIGTERMs it after a symlink swap.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stolution.local-preview.dashboard</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>cd "$LOCAL_PREVIEW_INSTALL_ROOT/dashboard/current" || exit 1; echo $$ &gt; "$LOCAL_PREVIEW_INSTALL_ROOT/dashboard/pid"; exec pnpm --filter @caia-app/dashboard exec next start -p 5173</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>LOCAL_PREVIEW_INSTALL_ROOT</key>
+        <string>__USER_HOME__/Library/Application Support/Stolution/local-preview</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/dashboard.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/dashboard.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.stolution.local-preview.deploy-daemon
+  =========================================
+  Long-running poll daemon. Iterates every 30s through all configured sites
+  and invokes deploySite() for any whose origin/<branch> SHA differs from
+  the live `current` symlink.
+
+  Installed by: apps/local-preview-orchestrator/scripts/install.sh
+  Source:       apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
+  Logs:         ~/Library/Logs/local-preview/deploy-daemon.{out,err}.log
+
+  Substitute `__USER_HOME__` with $HOME and `__REPO__` with the absolute
+  path to your caia checkout when installing. The install.sh script does
+  this automatically.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stolution.local-preview.deploy-daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>__REPO__/apps/local-preview-orchestrator/dist/cli.js</string>
+        <string>poll-loop</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>LOCAL_PREVIEW_INSTALL_ROOT</key>
+        <string>__USER_HOME__/Library/Application Support/Stolution/local-preview</string>
+        <key>LOCAL_PREVIEW_BUILD_WORKSPACE</key>
+        <string>/private/tmp/local-preview-build</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/deploy-daemon.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/deploy-daemon.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.poker-zeno.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.poker-zeno.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.stolution.local-preview.poker-zeno
+  ======================================
+  Site supervisor for the poker-zeno preview. Listens on http://localhost:5174.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stolution.local-preview.poker-zeno</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>cd "$LOCAL_PREVIEW_INSTALL_ROOT/poker-zeno/current" || exit 1; echo $$ &gt; "$LOCAL_PREVIEW_INSTALL_ROOT/poker-zeno/pid"; exec pnpm preview -- --port 5174</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__SITE_REPO_POKER_ZENO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>LOCAL_PREVIEW_INSTALL_ROOT</key>
+        <string>__USER_HOME__/Library/Application Support/Stolution/local-preview</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/poker-zeno.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/poker-zeno.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.roulette-community.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.roulette-community.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.stolution.local-preview.roulette-community
+  ==============================================
+  Site supervisor for the roulette-community preview. Listens on http://localhost:5175.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stolution.local-preview.roulette-community</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>cd "$LOCAL_PREVIEW_INSTALL_ROOT/roulette-community/current" || exit 1; echo $$ &gt; "$LOCAL_PREVIEW_INSTALL_ROOT/roulette-community/pid"; exec pnpm preview -- --port 5175</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__SITE_REPO_ROULETTE_COMMUNITY__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>LOCAL_PREVIEW_INSTALL_ROOT</key>
+        <string>__USER_HOME__/Library/Application Support/Stolution/local-preview</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/roulette-community.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/roulette-community.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.status-dashboard.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.status-dashboard.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.stolution.local-preview.status-dashboard
+  ============================================
+  Status dashboard HTTP server bound to 127.0.0.1:5170. Serves the static
+  HTML page + the /api/status JSON + redeploy/rollback POST endpoints.
+
+  Substitute `__USER_HOME__` and `__REPO__` at install-time via install.sh.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stolution.local-preview.status-dashboard</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>__REPO__/apps/local-preview-orchestrator/dist/cli.js</string>
+        <string>status-dashboard</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>LOCAL_PREVIEW_INSTALL_ROOT</key>
+        <string>__USER_HOME__/Library/Application Support/Stolution/local-preview</string>
+        <key>LOCAL_PREVIEW_BUILD_WORKSPACE</key>
+        <string>/private/tmp/local-preview-build</string>
+        <key>LOCAL_PREVIEW_DASHBOARD_PORT</key>
+        <string>5170</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/status-dashboard.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/local-preview/status-dashboard.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/apps/local-preview-orchestrator/scripts/install.sh
+++ b/apps/local-preview-orchestrator/scripts/install.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Install LaunchAgents for the local-preview orchestrator on the operator's Mac.
+#
+# Usage:
+#   ./scripts/install.sh
+#
+# Requires:
+#   - macOS (launchctl)
+#   - Node 20+ at /usr/local/bin/node OR /opt/homebrew/bin/node
+#   - pnpm available on PATH
+#   - This repo's `apps/local-preview-orchestrator` is built (`pnpm -F @caia-app/local-preview-orchestrator build`)
+#
+# What it installs:
+#   1. Backs up any existing local-preview plists into ~/.caia-backups/launchagents-YYYYMMDD-HHMMSS/
+#   2. Copies + templates plists into ~/Library/LaunchAgents/com.stolution.local-preview.*.plist
+#   3. mkdir log + state dirs
+#   4. launchctl bootstrap each agent (gui/$UID domain)
+#   5. Verifies dashboard responds on http://127.0.0.1:5170/healthz within 30s
+#
+# Idempotent: safe to re-run; will bootout any pre-existing copy of each agent first.
+
+set -euo pipefail
+
+# ─── Resolve paths ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${APP_DIR}/../.." && pwd)"
+PLISTS_SRC="${APP_DIR}/plists"
+LA_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs/local-preview"
+INSTALL_ROOT="${HOME}/Library/Application Support/Stolution/local-preview"
+BACKUP_DIR="${HOME}/.caia-backups/launchagents-$(date +%Y%m%d-%H%M%S)"
+
+# Site repo paths (override via env if you need to point elsewhere).
+SITE_REPO_DASHBOARD="${SITE_REPO_DASHBOARD:-${REPO_ROOT}}"
+SITE_REPO_POKER_ZENO="${SITE_REPO_POKER_ZENO:-${HOME}/Documents/projects/poker-zeno}"
+SITE_REPO_ROULETTE_COMMUNITY="${SITE_REPO_ROULETTE_COMMUNITY:-${HOME}/Documents/projects/roulette-community}"
+
+# ─── Verify pre-conditions ──────────────────────────────────────────────────
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "ERROR: install.sh runs on macOS only (uname=$(uname))." >&2
+    exit 2
+fi
+
+if [[ ! -d "${PLISTS_SRC}" ]]; then
+    echo "ERROR: plists source dir not found: ${PLISTS_SRC}" >&2
+    exit 2
+fi
+
+if [[ ! -f "${APP_DIR}/dist/cli.js" ]]; then
+    echo "ERROR: ${APP_DIR}/dist/cli.js not built. Run:" >&2
+    echo "  pnpm -F @caia-app/local-preview-orchestrator build" >&2
+    exit 2
+fi
+
+# Resolve a node binary path that the plist can hard-code.
+if [[ -x /opt/homebrew/bin/node ]]; then
+    NODE_BIN="/opt/homebrew/bin/node"
+elif [[ -x /usr/local/bin/node ]]; then
+    NODE_BIN="/usr/local/bin/node"
+else
+    NODE_BIN="$(command -v node || true)"
+    if [[ -z "${NODE_BIN}" ]]; then
+        echo "ERROR: node not found on PATH or at common install locations." >&2
+        exit 2
+    fi
+fi
+
+# ─── Setup directories ──────────────────────────────────────────────────────
+mkdir -p "${LA_DIR}" "${LOG_DIR}" "${INSTALL_ROOT}" "${BACKUP_DIR}"
+mkdir -p "${INSTALL_ROOT}/dashboard/builds" \
+         "${INSTALL_ROOT}/poker-zeno/builds" \
+         "${INSTALL_ROOT}/roulette-community/builds" \
+         "${INSTALL_ROOT}/_incidents"
+
+PLIST_LABELS=(
+    "com.stolution.local-preview.deploy-daemon"
+    "com.stolution.local-preview.status-dashboard"
+    "com.stolution.local-preview.dashboard"
+    "com.stolution.local-preview.poker-zeno"
+    "com.stolution.local-preview.roulette-community"
+)
+
+# ─── Backup + bootout any existing plists ───────────────────────────────────
+echo "Backing up existing plists to ${BACKUP_DIR}/"
+for label in "${PLIST_LABELS[@]}"; do
+    src="${LA_DIR}/${label}.plist"
+    if [[ -f "${src}" ]]; then
+        cp "${src}" "${BACKUP_DIR}/"
+        echo "  backed up ${label}.plist"
+        # bootout if loaded
+        if launchctl list | grep -q "${label}"; then
+            launchctl bootout "gui/$(id -u)" "${src}" 2>/dev/null || true
+        fi
+    fi
+done
+
+# ─── Substitute templates + copy ────────────────────────────────────────────
+echo
+echo "Installing plists into ${LA_DIR}/"
+for label in "${PLIST_LABELS[@]}"; do
+    src="${PLISTS_SRC}/${label}.plist"
+    dst="${LA_DIR}/${label}.plist"
+    if [[ ! -f "${src}" ]]; then
+        echo "  WARN: source plist missing: ${src}"
+        continue
+    fi
+    sed \
+        -e "s|__USER_HOME__|${HOME}|g" \
+        -e "s|__REPO__|${REPO_ROOT}|g" \
+        -e "s|__SITE_REPO_POKER_ZENO__|${SITE_REPO_POKER_ZENO}|g" \
+        -e "s|__SITE_REPO_ROULETTE_COMMUNITY__|${SITE_REPO_ROULETTE_COMMUNITY}|g" \
+        -e "s|/usr/local/bin/node|${NODE_BIN}|g" \
+        "${src}" > "${dst}"
+    echo "  installed ${label}.plist"
+done
+
+# ─── Bootstrap into launchd ─────────────────────────────────────────────────
+echo
+echo "Bootstrapping into launchd (gui/$(id -u))"
+for label in "${PLIST_LABELS[@]}"; do
+    dst="${LA_DIR}/${label}.plist"
+    if [[ ! -f "${dst}" ]]; then continue; fi
+    if launchctl bootstrap "gui/$(id -u)" "${dst}" 2>&1 | grep -v 'Bootstrap failed: 5: Input/output error'; then
+        echo "  bootstrapped ${label}"
+    fi
+done
+
+# ─── Wait for dashboard liveness ────────────────────────────────────────────
+echo
+echo "Waiting for status-dashboard to come up on http://127.0.0.1:5170/healthz ..."
+attempt=0
+max_attempts=30
+ok=0
+while (( attempt < max_attempts )); do
+    if curl -fsS --max-time 2 http://127.0.0.1:5170/healthz >/dev/null 2>&1; then
+        ok=1
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+if (( ok == 1 )); then
+    echo
+    echo "✓ Status dashboard is up: http://127.0.0.1:5170/"
+    echo "✓ Logs: ${LOG_DIR}/"
+    echo "✓ Backup of any prior plists: ${BACKUP_DIR}/"
+    echo
+    echo "Next steps:"
+    echo "  - Visit http://127.0.0.1:5170/ to see site status."
+    echo "  - First deploy will trigger automatically within 30s."
+    echo "  - Check progress: ./scripts/status.sh"
+else
+    echo
+    echo "WARN: dashboard did not respond on /healthz within ${max_attempts}s." >&2
+    echo "  See ${LOG_DIR}/status-dashboard.err.log for details." >&2
+    exit 1
+fi

--- a/apps/local-preview-orchestrator/scripts/status.sh
+++ b/apps/local-preview-orchestrator/scripts/status.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Quick-glance status check for the local preview deploys.
+# Hits the status dashboard's /api/status and pretty-prints it.
+
+set -euo pipefail
+
+URL="${LOCAL_PREVIEW_DASHBOARD_URL:-http://127.0.0.1:5170}"
+
+if ! curl -fsS --max-time 5 "${URL}/healthz" >/dev/null; then
+    echo "Status dashboard at ${URL} is NOT reachable." >&2
+    echo "Is com.stolution.local-preview.status-dashboard running?" >&2
+    echo "  launchctl list | grep com.stolution.local-preview" >&2
+    exit 1
+fi
+
+echo "Dashboard OK at ${URL}"
+echo
+curl -fsS "${URL}/api/status" | python3 -m json.tool

--- a/apps/local-preview-orchestrator/scripts/uninstall.sh
+++ b/apps/local-preview-orchestrator/scripts/uninstall.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Bootout + remove all local-preview LaunchAgents.
+#
+# Does NOT remove build artifacts under
+# ~/Library/Application Support/Stolution/local-preview/  — that's destructive
+# and should be done by hand if desired.
+#
+# Usage:
+#   ./scripts/uninstall.sh
+#   ./scripts/uninstall.sh --purge      # also rm builds/ and incident logs
+
+set -euo pipefail
+
+PURGE=0
+for arg in "$@"; do
+    case "${arg}" in
+        --purge) PURGE=1 ;;
+        *) echo "Unknown arg: ${arg}" >&2; exit 2 ;;
+    esac
+done
+
+LA_DIR="${HOME}/Library/LaunchAgents"
+INSTALL_ROOT="${HOME}/Library/Application Support/Stolution/local-preview"
+
+PLIST_LABELS=(
+    "com.stolution.local-preview.deploy-daemon"
+    "com.stolution.local-preview.status-dashboard"
+    "com.stolution.local-preview.dashboard"
+    "com.stolution.local-preview.poker-zeno"
+    "com.stolution.local-preview.roulette-community"
+)
+
+echo "Booting out + removing local-preview agents..."
+for label in "${PLIST_LABELS[@]}"; do
+    plist="${LA_DIR}/${label}.plist"
+    if [[ -f "${plist}" ]]; then
+        if launchctl list | grep -q "${label}"; then
+            launchctl bootout "gui/$(id -u)" "${plist}" 2>/dev/null || true
+            echo "  booted out ${label}"
+        fi
+        rm -f "${plist}"
+        echo "  removed ${label}.plist"
+    fi
+done
+
+if (( PURGE == 1 )); then
+    echo
+    echo "Purging install root: ${INSTALL_ROOT}"
+    if [[ -d "${INSTALL_ROOT}" ]]; then
+        rm -r "${INSTALL_ROOT}"
+        echo "  removed ${INSTALL_ROOT}"
+    fi
+fi
+
+echo
+echo "✓ Local-preview agents removed."
+if (( PURGE == 0 )); then
+    echo "  Build artifacts under ${INSTALL_ROOT}/ are untouched."
+    echo "  Re-run with --purge to delete them too."
+fi

--- a/packages/steward-analyzers/bin/steward-gatekeeper.mjs
+++ b/packages/steward-analyzers/bin/steward-gatekeeper.mjs
@@ -46,6 +46,7 @@ import {
   checkOrphanBranches,
   preflightChecks,
   checkPrStaleness,
+  checkLocalPreviewHealth,
 } from '../dist/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -391,6 +392,35 @@ function runPrStale(repoRoot, opts) {
   return findings;
 }
 
+
+// ─── Local-preview-health (Phase 2c — Mac-side daily) ─────────────────────
+
+async function runLocalPreviewHealth(opts) {
+  const url = opts['dashboard-url'] ?? 'http://127.0.0.1:5170';
+  const stalenessMin = Number.parseInt(opts['health-staleness-minutes'] ?? '10', 10);
+
+  let dashboardReachable = false;
+  let sites = [];
+  try {
+    const res = await fetch(url + '/api/status', {
+      // Local-only — minimal timeout via AbortController
+    });
+    if (res.ok) {
+      const body = await res.json();
+      dashboardReachable = true;
+      sites = Array.isArray(body?.sites) ? body.sites : [];
+    }
+  } catch {
+    // dashboardReachable stays false
+  }
+
+  return checkLocalPreviewHealth({
+    sites,
+    dashboardReachable,
+    healthStalenessMinutes: stalenessMin,
+  });
+}
+
 // ─── Main entry ────────────────────────────────────────────────────────────
 
 async function main() {
@@ -402,7 +432,7 @@ async function main() {
     console.error('usage: steward-gatekeeper <command> [--repo-root <path>] [--max-age-days <N>] [--pr-head-ref <ref>] [--mac-snapshot-dir <path>]');
     console.error('  pre-merge   : migration-linter | migration-numbering | graph-divergence | all');
     console.error('  pre-spawn   : preflight');
-    console.error('  scheduled   : hygiene-daily | vault-checks | pr-stale');
+    console.error('  scheduled   : hygiene-daily | vault-checks | pr-stale | local-preview-health');
     process.exit(2);
   }
 
@@ -422,6 +452,8 @@ async function main() {
       findings = runHygieneDaily(repoRoot);
     } else if (command === 'pr-stale') {
       findings = runPrStale(repoRoot, args.flags);
+    } else if (command === 'local-preview-health') {
+      findings = await runLocalPreviewHealth(args.flags);
     } else if (command === 'all') {
       const a = await runMigrationLinter(repoRoot);
       const b = await runMigrationNumbering(repoRoot);

--- a/packages/steward-analyzers/src/index.ts
+++ b/packages/steward-analyzers/src/index.ts
@@ -64,3 +64,9 @@ export {
   type PrRecord,
   type DependabotPrRecord,
 } from './pr-state.js';
+
+export {
+  checkLocalPreviewHealth,
+  type CheckLocalPreviewHealthOptions,
+  type SiteStateInput,
+} from './local-preview-health.js';

--- a/packages/steward-analyzers/src/local-preview-health.ts
+++ b/packages/steward-analyzers/src/local-preview-health.ts
@@ -1,0 +1,181 @@
+/**
+ * Local-preview-health analyzer — Phase 2c.
+ *
+ * Asserts that the always-on local preview deploys (per
+ * `agent/memory/steward_local_preview_deploys_directive.md` and
+ * `apps/local-preview-orchestrator/`) are healthy:
+ *
+ *   1. each configured site has an install dir + valid state.json
+ *   2. the most recent deploy did not fail
+ *   3. the most recent health check is recent (< staleness threshold)
+ *   4. all sites have a current_sha pinned (initial deploy completed)
+ *
+ * Pure analyzer function — accepts already-collected per-site state and
+ * returns Finding[]. The shell-side data collection (curl
+ * http://127.0.0.1:5170/api/status) lives in the CLI shim
+ * (bin/steward-gatekeeper.mjs).
+ *
+ * Reference: architecture doc §3.x, memory directive
+ * `steward_local_preview_deploys_directive.md`.
+ */
+
+import type { Finding, Severity } from './types.js';
+
+/** Per-site state shape returned by the local-preview status dashboard. */
+export interface SiteStateInput {
+  name: string;
+  url: string;
+  current_sha: string | null;
+  previous_sha: string | null;
+  last_deploy_at: string | null;
+  last_deploy_status:
+    | 'success'
+    | 'noop'
+    | 'build-failed'
+    | 'health-check-failed'
+    | 'rollback-failed'
+    | 'disk-full'
+    | 'aborted'
+    | null;
+  last_deploy_error: string | null;
+  last_health_check_at: string | null;
+  last_health_check_status: 'ok' | 'failed' | null;
+  process_state: 'unknown' | 'running' | 'stopped';
+}
+
+export interface CheckLocalPreviewHealthOptions {
+  /** Per-site state (one entry per configured site). */
+  sites: ReadonlyArray<SiteStateInput>;
+  /**
+   * Whether the dashboard responded at all. If false we emit a high-severity
+   * finding for the dashboard itself and skip per-site analysis.
+   */
+  dashboardReachable: boolean;
+  /** Reference "now" timestamp (ISO) for staleness math. Default: Date.now(). */
+  nowMs?: number;
+  /** Staleness threshold in minutes for last_health_check_at. Default 10. */
+  healthStalenessMinutes?: number;
+}
+
+const ANALYZER_ID = 'local-preview-health';
+
+/**
+ * Run the analyzer over already-collected per-site state.
+ */
+export function checkLocalPreviewHealth({
+  sites,
+  dashboardReachable,
+  nowMs = Date.now(),
+  healthStalenessMinutes = 10
+}: CheckLocalPreviewHealthOptions): Finding[] {
+  if (!dashboardReachable) {
+    return [
+      {
+        analyzer: ANALYZER_ID,
+        ruleId: 'dashboard-unreachable',
+        path: '<repo>',
+        severity: 'high',
+        message:
+          'Local-preview status dashboard at http://127.0.0.1:5170 is not responding. ' +
+          'The deploy daemon and 3 site processes likely are not running.',
+        remediation:
+          "launchctl list | grep com.stolution.local-preview && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.stolution.local-preview.status-dashboard.plist"
+      }
+    ];
+  }
+
+  const findings: Finding[] = [];
+  const stalenessMs = healthStalenessMinutes * 60 * 1000;
+
+  for (const site of sites) {
+    // Rule 1: site must have a current_sha pinned (initial deploy done).
+    if (!site.current_sha) {
+      findings.push({
+        analyzer: ANALYZER_ID,
+        ruleId: 'site-never-deployed',
+        path: '<repo>',
+        severity: 'medium',
+        message: `Site '${site.name}' has no current_sha — initial deploy has not completed.`,
+        remediation: `local-preview deploy ${site.name}`,
+        context: { site: site.name }
+      });
+    }
+
+    // Rule 2: last deploy must not be in a failure state.
+    if (site.last_deploy_status && isFailedStatus(site.last_deploy_status)) {
+      const severity: Severity = site.last_deploy_status === 'rollback-failed' ? 'high' : 'medium';
+      findings.push({
+        analyzer: ANALYZER_ID,
+        ruleId: 'last-deploy-failed',
+        path: '<repo>',
+        severity,
+        message: `Site '${site.name}' last deploy = ${site.last_deploy_status}: ${
+          site.last_deploy_error ?? 'unknown'
+        }`,
+        remediation:
+          `Investigate via: curl -s http://127.0.0.1:5170/api/logs/${site.name} | jq .\n` +
+          `Then force a redeploy: local-preview deploy ${site.name}`,
+        context: {
+          site: site.name,
+          status: site.last_deploy_status,
+          error: site.last_deploy_error
+        }
+      });
+    }
+
+    // Rule 3: health check must not be stale.
+    if (site.last_health_check_at) {
+      const healthMs = Date.parse(site.last_health_check_at);
+      if (Number.isFinite(healthMs) && nowMs - healthMs > stalenessMs) {
+        findings.push({
+          analyzer: ANALYZER_ID,
+          ruleId: 'health-check-stale',
+          path: '<repo>',
+          severity: 'medium',
+          message: `Site '${site.name}' last health check at ${site.last_health_check_at} is older than ${healthStalenessMinutes}m.`,
+          remediation: `local-preview deploy ${site.name}    # forces a fresh check`,
+          context: {
+            site: site.name,
+            ageMs: nowMs - healthMs,
+            thresholdMs: stalenessMs
+          }
+        });
+      }
+    } else if (site.current_sha) {
+      // Has been deployed but never health-checked? Suspicious.
+      findings.push({
+        analyzer: ANALYZER_ID,
+        ruleId: 'health-check-never-run',
+        path: '<repo>',
+        severity: 'low',
+        message: `Site '${site.name}' has current_sha but no last_health_check_at — was the deploy supervisor running?`,
+        context: { site: site.name }
+      });
+    }
+
+    // Rule 4: last health-check status must be ok if present.
+    if (site.last_health_check_status === 'failed') {
+      findings.push({
+        analyzer: ANALYZER_ID,
+        ruleId: 'health-check-failed',
+        path: '<repo>',
+        severity: 'high',
+        message: `Site '${site.name}' last health check FAILED.`,
+        remediation: `curl -s http://127.0.0.1:5170/api/logs/${site.name} | tail -20`,
+        context: { site: site.name }
+      });
+    }
+  }
+
+  return findings;
+}
+
+function isFailedStatus(status: NonNullable<SiteStateInput['last_deploy_status']>): boolean {
+  return (
+    status === 'build-failed' ||
+    status === 'health-check-failed' ||
+    status === 'rollback-failed' ||
+    status === 'disk-full' ||
+    status === 'aborted'
+  );
+}

--- a/packages/steward-analyzers/tests/local-preview-health.test.ts
+++ b/packages/steward-analyzers/tests/local-preview-health.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the local-preview-health analyzer.
+ *
+ * Pure-function tests — drive the analyzer with synthetic per-site state
+ * inputs and assert the right Findings come out. The shell-side data
+ * collection (curl /api/status) is exercised in the bin/steward-gatekeeper.mjs
+ * shim's smoke tests when the actual dashboard is reachable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkLocalPreviewHealth, type SiteStateInput } from '../src/local-preview-health.js';
+
+const okSite = (overrides: Partial<SiteStateInput> = {}): SiteStateInput => ({
+  name: 'dashboard',
+  url: 'http://localhost:5173',
+  current_sha: 'abc1234',
+  previous_sha: 'def5678',
+  last_deploy_at: new Date().toISOString(),
+  last_deploy_status: 'success',
+  last_deploy_error: null,
+  last_health_check_at: new Date().toISOString(),
+  last_health_check_status: 'ok',
+  process_state: 'running',
+  ...overrides
+});
+
+describe('checkLocalPreviewHealth', () => {
+  it('returns no findings when all sites are healthy', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite(), okSite({ name: 'poker-zeno', url: 'http://localhost:5174' })],
+      dashboardReachable: true
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('emits a high-severity finding when dashboard is unreachable', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [],
+      dashboardReachable: false
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.ruleId).toBe('dashboard-unreachable');
+    expect(findings[0]!.severity).toBe('high');
+  });
+
+  it('flags sites with no current_sha', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ current_sha: null, last_deploy_status: null, last_health_check_at: null, last_health_check_status: null })],
+      dashboardReachable: true
+    });
+    const f = findings.find((x) => x.ruleId === 'site-never-deployed');
+    expect(f).toBeDefined();
+    expect(f!.severity).toBe('medium');
+  });
+
+  it('flags last-deploy-failed (build-failed)', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ last_deploy_status: 'build-failed', last_deploy_error: 'compile error' })],
+      dashboardReachable: true
+    });
+    const f = findings.find((x) => x.ruleId === 'last-deploy-failed');
+    expect(f).toBeDefined();
+    expect(f!.severity).toBe('medium');
+    expect(f!.message).toContain('compile error');
+  });
+
+  it('escalates rollback-failed to high', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ last_deploy_status: 'rollback-failed', last_deploy_error: 'no previous build' })],
+      dashboardReachable: true
+    });
+    const f = findings.find((x) => x.ruleId === 'last-deploy-failed');
+    expect(f).toBeDefined();
+    expect(f!.severity).toBe('high');
+  });
+
+  it('flags stale health check', () => {
+    const stale = new Date(Date.now() - 30 * 60_000).toISOString();
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ last_health_check_at: stale })],
+      dashboardReachable: true,
+      healthStalenessMinutes: 10
+    });
+    const f = findings.find((x) => x.ruleId === 'health-check-stale');
+    expect(f).toBeDefined();
+    expect(f!.severity).toBe('medium');
+  });
+
+  it('flags last health-check-failed at high severity', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ last_health_check_status: 'failed' })],
+      dashboardReachable: true
+    });
+    const f = findings.find((x) => x.ruleId === 'health-check-failed');
+    expect(f).toBeDefined();
+    expect(f!.severity).toBe('high');
+  });
+
+  it('flags health-check-never-run when current_sha set but no health timestamp', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ last_health_check_at: null, last_health_check_status: null })],
+      dashboardReachable: true
+    });
+    const f = findings.find((x) => x.ruleId === 'health-check-never-run');
+    expect(f).toBeDefined();
+    expect(f!.severity).toBe('low');
+  });
+
+  it('does not flag noop status as a failure', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [okSite({ last_deploy_status: 'noop' })],
+      dashboardReachable: true
+    });
+    const f = findings.find((x) => x.ruleId === 'last-deploy-failed');
+    expect(f).toBeUndefined();
+  });
+
+  it('handles multiple sites with mixed states', () => {
+    const findings = checkLocalPreviewHealth({
+      sites: [
+        okSite(),
+        okSite({ name: 'poker-zeno', last_deploy_status: 'build-failed' }),
+        okSite({ name: 'roulette-community', current_sha: null, last_deploy_status: null, last_health_check_at: null })
+      ],
+      dashboardReachable: true
+    });
+    // poker-zeno → 1 finding (last-deploy-failed)
+    // roulette-community → 1 finding (site-never-deployed)
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+    expect(findings.some((f) => f.message.includes('poker-zeno'))).toBe(true);
+    expect(findings.some((f) => f.message.includes('roulette-community'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

PR-D — final implementation PR for **Local-Preview-Deploys**. Closes the implementation phase. Stage 6 (live verify on Mac) is the next leg's first priority.

## What landed

### 5 LaunchAgent plists

`apps/local-preview-orchestrator/plists/`

| Label | Role | Port |
|---|---|---|
| `com.stolution.local-preview.deploy-daemon` | poll-loop daemon (one process for all 3 sites) | — |
| `com.stolution.local-preview.status-dashboard` | HTTP status dashboard | 5170 |
| `com.stolution.local-preview.dashboard` | site supervisor (CAIA dashboard) | 5173 |
| `com.stolution.local-preview.poker-zeno` | site supervisor (poker-zeno) | 5174 |
| `com.stolution.local-preview.roulette-community` | site supervisor (roulette-community) | 5175 |

All 5 pass `plutil -lint`. Use placeholders (`__USER_HOME__`, `__REPO__`, `__SITE_REPO_*__`) substituted at install-time.

### 3 install scripts

`apps/local-preview-orchestrator/scripts/`

- `install.sh` — backs up existing plists to `~/.caia-backups/`, templates the placeholders, mkdir's log+state dirs, `launchctl bootstrap`s each agent, then waits up to 30s for `/healthz`. Idempotent.
- `uninstall.sh` — `launchctl bootout` + delete plists. `--purge` also removes build artifacts.
- `status.sh` — `curl /api/status | python -m json.tool`.

All three pass `bash -n` syntax check.

### Steward analyzer

`packages/steward-analyzers/src/local-preview-health.ts` — 6 rule IDs:

| Rule | Severity | Trigger |
|---|---|---|
| `dashboard-unreachable` | high | dashboard not responding |
| `site-never-deployed` | medium | no `current_sha` pinned |
| `last-deploy-failed` | medium | last deploy in failure state |
| `last-deploy-failed` (rollback-failed variant) | high | rollback also failed |
| `health-check-stale` | medium | last health check > 10m old |
| `health-check-failed` | high | last health check failed |
| `health-check-never-run` | low | current_sha set but no health timestamp |

Wired into `bin/steward-gatekeeper.mjs` as the `local-preview-health` subcommand. Hits `http://127.0.0.1:5170/api/status` and feeds the parsed sites array into the analyzer.

### README

`apps/local-preview-orchestrator/README.md` — quick-start, architecture, CLI, dashboard API, Steward integration, uninstall.

## Tests

- 10 new unit tests for `checkLocalPreviewHealth` (101 total in `@chiefaia/steward-analyzers`).
- 91 in `@caia-app/local-preview-orchestrator` unchanged and still green.
- CLI smoke test passes against an unreachable dashboard (correctly emits the `dashboard-unreachable` finding).

## Stage 6 (live verification on Mac) is intentionally NOT in this PR

That's the operator-side install + verification:
- run `./apps/local-preview-orchestrator/scripts/install.sh`
- watch all 3 sites come up
- merge a throwaway commit on each site repo's develop
- verify deploy fires within 60s + site updates
- verify Mac-restart resilience
- verify disk usage stays under 5GB

Stage 6 is the next leg's first priority.

## Roadmap

- [x] PR-A — skeleton + 29 unit tests (#312)
- [x] PR-B — deploy + poll-loop + integration test (#313)
- [x] PR-C — status dashboard + CLI (#314)
- [x] **PR-D — plists + install.sh + Steward analyzer (this PR)**
- [ ] Stage 6 — 3-site live verify on Mac (next leg)

References: `~/Documents/projects/reports/local-preview-deploys-analysis.md`, `agent/memory/steward_local_preview_deploys_directive.md`, `agent/memory/daemon_repoint_2026-04-30.md`.
