### PR TITLE
feat(mentor-phase0-001): event-bus skeleton + types + schemas + sqlite client (PR-alpha)

### DIFF
--- a/.changeset/feat-mentor-phase0-001-event-bus-skeleton.md
+++ b/.changeset/feat-mentor-phase0-001-event-bus-skeleton.md
@@ -1,0 +1,76 @@
+---
+"caia": patch
+---
+
+feat(mentor-phase0-001): event-bus skeleton + types + schemas + SQLite client (PR-α)
+
+First PR of the Mentor Phase 0 roadmap (item 2 in the multi-day campaign
+roadmap). Sets up the typed append-only event substrate that subsequent
+PRs (β/γ/δ) will extend.
+
+## What landed
+
+A new monorepo package `@chiefaia/mentor-event-bus` under
+`packages/mentor-event-bus/`:
+
+- `src/types.ts` — 22 EventTypes (per
+  `agent/memory/mentor_agent_directive.md` Phase 0 taxonomy) + per-event
+  payload contracts + `PayloadOf<T>` mapping.
+- `src/schemas.ts` — Zod schemas for each EventType payload + a
+  registry (`EVENT_SCHEMAS`) + `validatePayload` helper that returns a
+  discriminated result rather than throwing.
+- `src/sqlite.ts` — SQLite client (better-sqlite3) with WAL mode,
+  idempotent migration runner, monotonic `ingest_offset` allocator,
+  typed `insertEvent`/`queryEvents`/`countEvents` primitives.
+- `migrations/0001_init.sql` — `events` + `schema_definitions` +
+  `_ingest_counter` tables with composite indexes for the common
+  query shapes.
+- `src/correlation.ts` — `withCorrelation` /
+  `withCorrelationAsync` helpers built on `AsyncLocalStorage` so any
+  nested `emit()` inherits the active `correlation_id` without the
+  caller threading it manually.
+- `src/client.ts` — `Client` class: `emit(type, payload, opts?)` /
+  `getRecent(opts?)` / `count(opts?)` / `close()`. Schema validation
+  failures persist with `validation_failed = 1` rather than throwing
+  (preserves the producer-non-blocking invariant).
+- `src/index.ts` — public API barrel.
+
+## Producer-non-blocking invariant
+
+`emit()` never throws. Every error path (DB write fail, schema violation,
+JSON.stringify fail, post-close emit) is caught and logged via
+`pino`-style `logger.warn`. This is the most important property of the
+substrate per the design doc.
+
+## Tests
+
+42 new tests (5 files):
+
+- `tests/types.test.ts` — 22 event types, no duplicates, every type has a schema.
+- `tests/schemas.test.ts` — happy-path + validation-failure assertions for
+  every important schema.
+- `tests/sqlite.test.ts` — DB open / migrate / insert / query / count /
+  schema_definitions persistence; monotonic offsets; query filters;
+  idempotency on re-open.
+- `tests/correlation.test.ts` — async-context propagation across awaits +
+  setTimeouts; nested-correlation override; reset after fn returns.
+- `tests/client.test.ts` — emit+read; validation-failure persistence;
+  withCorrelation inheritance; explicit-options override; persistence
+  across close+reopen; emit-after-close returns null + logs warn.
+
+## Subscription-only compliance
+
+Dependencies: `better-sqlite3` (already in tree via `llm-cache`),
+`nanoid` (already in tree), `zod` (already in tree). Zero paid services.
+
+## Out of scope (subsequent PRs)
+
+- HTTP server + cross-machine HTTP client (PR-β)
+- Three Phase-0 emit-points + `caia mentor tail` CLI (PR-γ)
+- LaunchAgent plists + install script (PR-δ)
+- Phase 1+ classification engine, pre-spawn injection hook, Steward-rule
+  proposer (Phase 1+, separate item)
+
+References: `~/Documents/projects/reports/mentor-phase0-analysis.md`,
+`agent/memory/mentor_agent_directive.md`,
+`agent/memory/feedback_no_api_key_billing.md`.

--- a/packages/mentor-event-bus/.gitignore
+++ b/packages/mentor-event-bus/.gitignore
@@ -1,0 +1,8 @@
+# build outputs (tsc emits to dist/, but defensive):
+src/*.js
+src/*.d.ts
+src/*.d.ts.map
+src/*.js.map
+dist/
+node_modules/
+*.tsbuildinfo

--- a/packages/mentor-event-bus/eslint.config.cjs
+++ b/packages/mentor-event-bus/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — replaces .eslintrc.json
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/mentor-event-bus/migrations/0001_init.sql
+++ b/packages/mentor-event-bus/migrations/0001_init.sql
@@ -1,0 +1,37 @@
+-- Mentor event-bus initial schema.
+-- See packages/mentor-event-bus/src/sqlite.ts for migration runner + WAL setup.
+
+CREATE TABLE events (
+  id              TEXT PRIMARY KEY,
+  event_type      TEXT NOT NULL,
+  schema_version  INTEGER NOT NULL DEFAULT 1,
+  correlation_id  TEXT,
+  parent_event_id TEXT,
+  emitted_at      TEXT NOT NULL,
+  hostname        TEXT NOT NULL,
+  process_name    TEXT,
+  payload_json    TEXT NOT NULL,
+  validation_failed INTEGER NOT NULL DEFAULT 0,
+  ingest_offset   INTEGER NOT NULL
+);
+
+CREATE INDEX idx_events_type_emitted ON events(event_type, emitted_at);
+CREATE INDEX idx_events_correlation  ON events(correlation_id);
+CREATE INDEX idx_events_emitted      ON events(emitted_at);
+CREATE INDEX idx_events_offset       ON events(ingest_offset);
+
+-- Per-row monotonic ingest offset; populated by AUTOINCREMENT-equivalent below.
+CREATE TABLE _ingest_counter (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  next_offset INTEGER NOT NULL DEFAULT 1
+);
+INSERT INTO _ingest_counter (id, next_offset) VALUES (1, 1);
+
+-- Schema definitions (Zod schemas serialized for cross-language consumers).
+CREATE TABLE schema_definitions (
+  event_type     TEXT NOT NULL,
+  schema_version INTEGER NOT NULL,
+  zod_schema     TEXT NOT NULL,
+  registered_at  TEXT NOT NULL,
+  PRIMARY KEY (event_type, schema_version)
+);

--- a/packages/mentor-event-bus/package.json
+++ b/packages/mentor-event-bus/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@chiefaia/mentor-event-bus",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Typed append-only event substrate for Mentor Phase 0. SQLite-backed events table with Zod-validated schemas and AsyncLocalStorage-based correlation IDs. Producers emit; Mentor / Curator / Steward query.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "migrations"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2",
+    "nanoid": "^3.3.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^20",
+    "eslint": "^9.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/mentor-event-bus/src/client.ts
+++ b/packages/mentor-event-bus/src/client.ts
@@ -1,0 +1,234 @@
+/**
+ * Mentor event-bus client — local SQLite-direct emit + query.
+ *
+ * Public API surface:
+ *   - new Client({ dbPath, ... })
+ *   - emit(type, payload, opts?)        — fire-and-forget; never throws
+ *   - getRecent(opts?)                  — query persisted events
+ *   - close()                           — close the underlying DB
+ *
+ * Phase 0 invariant (per design doc): producer code is NEVER blocked by
+ * Mentor's reliability. emit() catches every error path and falls through
+ * to console.warn — it does not throw. Validation failures persist the
+ * event with `validation_failed = 1` so Mentor can detect schema drift.
+ *
+ * The cross-machine HTTP path lives in PR-β (`http-client.ts`).
+ */
+
+import { hostname as osHostname } from 'node:os';
+import { customAlphabet } from 'nanoid';
+import type { Database as DatabaseInstance } from 'better-sqlite3';
+
+import {
+  countEvents,
+  insertEvent,
+  openDatabase,
+  queryEvents,
+  registerSchemaDefinition,
+  type QueryEventsOptions
+} from './sqlite.js';
+import { describeSchema, EVENT_SCHEMAS, validatePayload } from './schemas.js';
+import {
+  EVENT_TYPES,
+  type EmittedEvent,
+  type EventRow,
+  type EventType,
+  type PayloadOf
+} from './types.js';
+import { currentCorrelationId, currentParentEventId } from './correlation.js';
+
+// ─── ID generator ─────────────────────────────────────────────────────────
+
+// 16 chars over [0-9a-z] gives ~10^25 possible IDs — collision-free at our scale.
+const makeId = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 16);
+
+function newEventId(): string {
+  return `ev_${Date.now().toString(36)}_${makeId()}`;
+}
+
+// ─── Client ───────────────────────────────────────────────────────────────
+
+export interface ClientOptions {
+  /** Absolute path to the SQLite file, or `:memory:` for tests. */
+  dbPath: string;
+  /** Override migrations dir (default: package's migrations/). */
+  migrationsDir?: string;
+  /** Hostname to record on emitted events. Default: os.hostname(). */
+  hostname?: string;
+  /** Process name (e.g., 'orchestrator', 'worker-coding'). */
+  processName?: string;
+  /** Logger for non-throwing warnings. Default: console. */
+  logger?: { warn: (m: string, ctx?: unknown) => void };
+  /** Disable WAL (use only for tests with `:memory:`). */
+  disableWal?: boolean;
+  /** Skip schema_definitions registration (tests). Default false. */
+  skipSchemaRegistration?: boolean;
+}
+
+export interface EmitOptions {
+  /** Override the inherited correlation_id. */
+  correlationId?: string;
+  /** Override the inherited parent_event_id. */
+  parentEventId?: string;
+  /** Override schema_version (for explicit version pinning). */
+  schemaVersion?: number;
+  /** Override emitted_at (default: now). Useful for tests. */
+  emittedAt?: Date;
+}
+
+const consoleLogger = {
+  warn: (m: string, ctx?: unknown): void => {
+    if (ctx !== undefined) console.warn(m, ctx);
+    else console.warn(m);
+  }
+};
+
+/**
+ * The main client. Creates / opens the SQLite file, registers schemas, and
+ * exposes emit() + getRecent().
+ */
+export class Client {
+  private readonly db: DatabaseInstance;
+  private readonly hostname: string;
+  private readonly processName: string | null;
+  private readonly logger: { warn: (m: string, ctx?: unknown) => void };
+  private closed = false;
+
+  constructor(opts: ClientOptions) {
+    this.db = openDatabase(opts.dbPath, opts.migrationsDir, !opts.disableWal);
+    this.hostname = opts.hostname ?? osHostname();
+    this.processName = opts.processName ?? null;
+    this.logger = opts.logger ?? consoleLogger;
+
+    if (!opts.skipSchemaRegistration) {
+      this.registerAllSchemas();
+    }
+  }
+
+  /**
+   * Persist a Zod-schema fingerprint for every known EventType. Idempotent.
+   */
+  private registerAllSchemas(): void {
+    for (const t of EVENT_TYPES) {
+      const schema = EVENT_SCHEMAS[t];
+      const desc = describeSchema(schema);
+      registerSchemaDefinition(this.db, {
+        event_type: t,
+        schema_version: 1,
+        zod_schema: desc
+      });
+    }
+  }
+
+  /**
+   * Emit an event. Type + payload are validated against the Zod schema.
+   * Validation failures are persisted with `validation_failed = 1` rather
+   * than thrown, preserving the producer-non-blocking invariant.
+   *
+   * Returns the assigned event id, or null if the underlying DB write
+   * threw (in which case a warning is logged).
+   */
+  emit<T extends EventType>(type: T, payload: PayloadOf<T>, opts: EmitOptions = {}): string | null {
+    if (this.closed) {
+      this.logger.warn(`[mentor-event-bus] emit on closed client: type=${type}`);
+      return null;
+    }
+
+    let validation_failed: 0 | 1 = 0;
+    const validation = validatePayload(type, payload);
+    if (!validation.ok) {
+      validation_failed = 1;
+      this.logger.warn(`[mentor-event-bus] schema validation failed for ${type}`, validation.error.issues);
+    }
+
+    const id = newEventId();
+    const correlation_id =
+      opts.correlationId ?? currentCorrelationId() ?? null;
+    const parent_event_id =
+      opts.parentEventId ?? currentParentEventId() ?? null;
+    const emitted_at = (opts.emittedAt ?? new Date()).toISOString();
+    const schema_version = opts.schemaVersion ?? 1;
+
+    let payload_json: string;
+    try {
+      payload_json = JSON.stringify(payload);
+    } catch (e) {
+      this.logger.warn(`[mentor-event-bus] payload JSON.stringify failed for ${type}`, e);
+      return null;
+    }
+
+    try {
+      insertEvent(this.db, {
+        id,
+        event_type: type,
+        schema_version,
+        correlation_id,
+        parent_event_id,
+        emitted_at,
+        hostname: this.hostname,
+        process_name: this.processName,
+        payload_json,
+        validation_failed
+      });
+      return id;
+    } catch (e) {
+      this.logger.warn(`[mentor-event-bus] DB insert failed for ${type}`, e);
+      return null;
+    }
+  }
+
+  /**
+   * Query persisted events.
+   */
+  getRecent(opts: QueryEventsOptions = {}): EmittedEvent[] {
+    const rows = queryEvents(this.db, { order: 'desc', limit: 100, ...opts });
+    return rows.map(decodeRow);
+  }
+
+  /**
+   * Count persisted events matching the query.
+   */
+  count(opts: QueryEventsOptions = {}): number {
+    return countEvents(this.db, opts);
+  }
+
+  /**
+   * Close the underlying DB. Safe to call multiple times.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.db.close();
+    } catch (e) {
+      this.logger.warn('[mentor-event-bus] db close failed', e);
+    }
+  }
+
+  /** Test/debug helper — exposes the raw DB. NOT part of the stable API. */
+  unsafeGetDb(): DatabaseInstance {
+    return this.db;
+  }
+}
+
+function decodeRow(row: EventRow): EmittedEvent {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(row.payload_json);
+  } catch {
+    payload = null;
+  }
+  return {
+    id: row.id,
+    type: row.event_type,
+    schemaVersion: row.schema_version,
+    correlationId: row.correlation_id,
+    parentEventId: row.parent_event_id,
+    emittedAt: row.emitted_at,
+    hostname: row.hostname,
+    processName: row.process_name,
+    payload,
+    validationFailed: row.validation_failed === 1,
+    ingestOffset: row.ingest_offset
+  };
+}

--- a/packages/mentor-event-bus/src/correlation.ts
+++ b/packages/mentor-event-bus/src/correlation.ts
@@ -1,0 +1,73 @@
+/**
+ * Correlation-ID storage backed by AsyncLocalStorage.
+ *
+ * Producers wrap a logical operation in `withCorrelation('id', () => ...)` and
+ * any nested `emit()` calls automatically inherit the correlation_id without
+ * needing to thread it through call sites.
+ *
+ * Why this matters: Mentor reconstructs multi-event chains
+ * (PromptReceived → PromptDecomposed → TaskSpawned → TaskCompleted) by
+ * grouping on correlation_id. If producers had to thread the ID manually,
+ * we'd miss events on every code-path that forgets.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface CorrelationContext {
+  correlationId: string;
+  parentEventId?: string;
+}
+
+const storage = new AsyncLocalStorage<CorrelationContext>();
+
+/**
+ * Run `fn` with the given correlation_id active in the current async context.
+ * Any `emit()` invoked synchronously or asynchronously inside fn picks it up.
+ */
+export function withCorrelation<T>(
+  correlationId: string,
+  fn: () => T,
+  parentEventId?: string
+): T {
+  const ctx: CorrelationContext = { correlationId };
+  if (parentEventId !== undefined) {
+    ctx.parentEventId = parentEventId;
+  }
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Async-aware variant of withCorrelation.
+ */
+export async function withCorrelationAsync<T>(
+  correlationId: string,
+  fn: () => Promise<T>,
+  parentEventId?: string
+): Promise<T> {
+  const ctx: CorrelationContext = { correlationId };
+  if (parentEventId !== undefined) {
+    ctx.parentEventId = parentEventId;
+  }
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Read the current correlation context, or undefined if outside withCorrelation.
+ */
+export function currentCorrelation(): CorrelationContext | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Read just the correlation_id from the current context.
+ */
+export function currentCorrelationId(): string | undefined {
+  return storage.getStore()?.correlationId;
+}
+
+/**
+ * Read just the parent_event_id from the current context.
+ */
+export function currentParentEventId(): string | undefined {
+  return storage.getStore()?.parentEventId;
+}

--- a/packages/mentor-event-bus/src/index.ts
+++ b/packages/mentor-event-bus/src/index.ts
@@ -1,0 +1,71 @@
+/**
+ * @chiefaia/mentor-event-bus — Mentor Phase 0 typed event substrate.
+ *
+ * Producers: import Client + emit. Consumers (Mentor / Curator / Steward):
+ * import Client + getRecent + queryEvents.
+ *
+ * See packages/mentor-event-bus/README.md for usage examples.
+ */
+
+export {
+  Client,
+  type ClientOptions,
+  type EmitOptions
+} from './client.js';
+
+export {
+  withCorrelation,
+  withCorrelationAsync,
+  currentCorrelation,
+  currentCorrelationId,
+  currentParentEventId
+} from './correlation.js';
+
+export {
+  EVENT_TYPES,
+  DEFAULT_SCHEMA_VERSION,
+  type EventType,
+  type EventRow,
+  type EmittedEvent,
+  type EventPayloadMap,
+  type PayloadOf,
+  type PromptReceivedPayload,
+  type PromptDecomposedPayload,
+  type TaskSpawnedPayload,
+  type TaskCompletedPayload,
+  type TaskFailedPayload,
+  type TaskAbortedPayload,
+  type OperatorCorrectionPayload,
+  type OperatorAcknowledgedPayload,
+  type PRMergedPayload,
+  type PRClosedWithoutMergePayload,
+  type PostMergeBugReportPayload,
+  type RegressionDetectedPayload,
+  type EvidenceGateFailurePayload,
+  type HallucinationFlaggedPayload,
+  type ScopeMismatchFlaggedPayload,
+  type DoDViolationPayload,
+  type MemoryWrittenPayload,
+  type MemoryReadMissedPayload,
+  type DecisionClassifierTripPayload,
+  type ToolMisuseFlaggedPayload,
+  type SubscriptionBucketSpikePayload,
+  type CapabilityBrokerOverridePayload
+} from './types.js';
+
+export {
+  EVENT_SCHEMAS,
+  validatePayload,
+  describeSchema,
+  assertEverySchemaPresent
+} from './schemas.js';
+
+export {
+  openDatabase,
+  insertEvent,
+  queryEvents,
+  countEvents,
+  registerSchemaDefinition,
+  type InsertEventArgs,
+  type QueryEventsOptions
+} from './sqlite.js';

--- a/packages/mentor-event-bus/src/schemas.ts
+++ b/packages/mentor-event-bus/src/schemas.ts
@@ -1,0 +1,227 @@
+/**
+ * Zod schemas for each EventType payload.
+ *
+ * The schemas serve two purposes:
+ *   1. emit-time validation — payload checked before it's persisted.
+ *   2. introspection / cross-language consumers — schemas are persisted
+ *      into the `schema_definitions` SQLite table at SDK init time so
+ *      a future Python Mentor can read the canonical contract.
+ *
+ * Adding a new event type:
+ *   1. Add it to EVENT_TYPES in types.ts
+ *   2. Add the payload interface in types.ts
+ *   3. Add the Zod schema below + register in EVENT_SCHEMAS
+ *   4. Bump the schema_version on existing types only when payload changes
+ */
+
+import { z } from 'zod';
+import { EVENT_TYPES, type EventType } from './types.js';
+
+// ─── Per-event schemas ────────────────────────────────────────────────────
+
+export const PromptReceivedSchema = z.object({
+  promptId: z.string().min(1),
+  body: z.string(),
+  source: z.string().optional()
+});
+
+export const PromptDecomposedSchema = z.object({
+  promptId: z.string().min(1),
+  taskCount: z.number().int().nonnegative(),
+  taskIds: z.array(z.string())
+});
+
+export const TaskSpawnedSchema = z.object({
+  taskId: z.string().min(1),
+  parentTaskId: z.string().optional(),
+  agentName: z.string().min(1),
+  promptId: z.string().optional()
+});
+
+export const TaskCompletedSchema = z.object({
+  taskId: z.string().min(1),
+  durationMs: z.number().nonnegative(),
+  exitCode: z.number().int()
+});
+
+export const TaskFailedSchema = z.object({
+  taskId: z.string().min(1),
+  error: z.string(),
+  exitCode: z.number().int().optional()
+});
+
+export const TaskAbortedSchema = z.object({
+  taskId: z.string().min(1),
+  reason: z.string()
+});
+
+export const OperatorCorrectionSchema = z.object({
+  correctionText: z.string().min(1),
+  context: z.string().optional(),
+  detectionMode: z.enum(['manual', 'regex', 'llm'])
+});
+
+export const OperatorAcknowledgedSchema = z.object({
+  ackText: z.string().min(1),
+  context: z.string().optional()
+});
+
+export const PRMergedSchema = z.object({
+  prNumber: z.number().int().positive(),
+  sha: z.string().regex(/^[0-9a-f]{7,40}$/),
+  branch: z.string().min(1),
+  repo: z.string().optional(),
+  author: z.string().optional()
+});
+
+export const PRClosedWithoutMergeSchema = z.object({
+  prNumber: z.number().int().positive(),
+  reason: z.string().optional()
+});
+
+export const PostMergeBugReportSchema = z.object({
+  prNumber: z.number().int().positive().optional(),
+  description: z.string().min(1),
+  reportedAt: z.string()
+});
+
+export const RegressionDetectedSchema = z.object({
+  testName: z.string().min(1),
+  failedSha: z.string().regex(/^[0-9a-f]{7,40}$/),
+  passingSha: z
+    .string()
+    .regex(/^[0-9a-f]{7,40}$/)
+    .optional()
+});
+
+export const EvidenceGateFailureSchema = z.object({
+  prNumber: z.number().int().positive(),
+  failedJobs: z.array(z.string()).min(1)
+});
+
+export const HallucinationFlaggedSchema = z.object({
+  taskId: z.string().optional(),
+  description: z.string().min(1),
+  source: z.string().min(1)
+});
+
+export const ScopeMismatchFlaggedSchema = z.object({
+  taskId: z.string().optional(),
+  description: z.string().min(1)
+});
+
+export const DoDViolationSchema = z.object({
+  taskId: z.string().optional(),
+  rule: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export const MemoryWrittenSchema = z.object({
+  path: z.string().min(1),
+  sha: z.string().optional(),
+  size: z.number().int().nonnegative(),
+  operation: z.enum(['create', 'modify', 'delete'])
+});
+
+export const MemoryReadMissedSchema = z.object({
+  searchedFor: z.string().min(1),
+  context: z.string().optional()
+});
+
+export const DecisionClassifierTripSchema = z.object({
+  decision: z.string().min(1),
+  outcome: z.enum(['asked', 'auto-decided'])
+});
+
+export const ToolMisuseFlaggedSchema = z.object({
+  tool: z.string().min(1),
+  description: z.string().min(1)
+});
+
+export const SubscriptionBucketSpikeSchema = z.object({
+  bucket: z.string().min(1),
+  spikeMagnitude: z.number()
+});
+
+export const CapabilityBrokerOverrideSchema = z.object({
+  capability: z.string().min(1),
+  reason: z.string().min(1),
+  approver: z.string().min(1)
+});
+
+// ─── Registry ─────────────────────────────────────────────────────────────
+
+export const EVENT_SCHEMAS: { [K in EventType]: z.ZodTypeAny } = {
+  PromptReceived: PromptReceivedSchema,
+  PromptDecomposed: PromptDecomposedSchema,
+  TaskSpawned: TaskSpawnedSchema,
+  TaskCompleted: TaskCompletedSchema,
+  TaskFailed: TaskFailedSchema,
+  TaskAborted: TaskAbortedSchema,
+  OperatorCorrection: OperatorCorrectionSchema,
+  OperatorAcknowledged: OperatorAcknowledgedSchema,
+  PRMerged: PRMergedSchema,
+  PRClosedWithoutMerge: PRClosedWithoutMergeSchema,
+  PostMergeBugReport: PostMergeBugReportSchema,
+  RegressionDetected: RegressionDetectedSchema,
+  EvidenceGateFailure: EvidenceGateFailureSchema,
+  HallucinationFlagged: HallucinationFlaggedSchema,
+  ScopeMismatchFlagged: ScopeMismatchFlaggedSchema,
+  DoDViolation: DoDViolationSchema,
+  MemoryWritten: MemoryWrittenSchema,
+  MemoryReadMissed: MemoryReadMissedSchema,
+  DecisionClassifierTrip: DecisionClassifierTripSchema,
+  ToolMisuseFlagged: ToolMisuseFlaggedSchema,
+  SubscriptionBucketSpike: SubscriptionBucketSpikeSchema,
+  CapabilityBrokerOverride: CapabilityBrokerOverrideSchema
+};
+
+/**
+ * Sanity check: enforce that every EventType has a schema.
+ * Imported in tests to assert no entry is missed.
+ */
+export function assertEverySchemaPresent(): void {
+  for (const t of EVENT_TYPES) {
+    if (!(t in EVENT_SCHEMAS)) {
+      throw new Error(`Missing schema for event type: ${t}`);
+    }
+  }
+}
+
+/**
+ * Validate a payload against the schema for an event type.
+ * Returns parsed value on success, error on failure (DOES NOT throw).
+ */
+export function validatePayload<T extends EventType>(
+  type: T,
+  payload: unknown
+):
+  | { ok: true; value: unknown }
+  | { ok: false; error: z.ZodError } {
+  const schema = EVENT_SCHEMAS[type];
+  const result = schema.safeParse(payload);
+  if (result.success) {
+    return { ok: true, value: result.data };
+  }
+  return { ok: false, error: result.error };
+}
+
+/**
+ * Serialize a Zod schema to a string suitable for storage in the
+ * `schema_definitions` table. We just JSON.stringify the schema's
+ * `_def` shape — good enough for introspection; not a round-trippable
+ * serialization (Zod is not natively serializable).
+ */
+export function describeSchema(schema: z.ZodTypeAny): string {
+  try {
+    return JSON.stringify(schema._def, replacer);
+  } catch {
+    return '{}';
+  }
+}
+
+function replacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'function') return '[function]';
+  if (value instanceof RegExp) return value.source;
+  return value;
+}

--- a/packages/mentor-event-bus/src/sqlite.ts
+++ b/packages/mentor-event-bus/src/sqlite.ts
@@ -1,0 +1,239 @@
+/**
+ * SQLite client for the mentor event bus.
+ *
+ * Responsibilities:
+ *   - open a database file (or in-memory for tests)
+ *   - apply migrations idempotently (currently 0001_init.sql)
+ *   - enable WAL mode (default) for safer concurrent reads
+ *   - expose typed insert + query primitives consumed by client.ts
+ *
+ * Migrations live under `migrations/` (sibling to `src/`). At build time
+ * tsc emits `dist/sqlite.js` and the migration files stay alongside the
+ * package root via `package.json#files`.
+ */
+
+import Database, { type Database as DatabaseInstance } from 'better-sqlite3';
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { EventRow } from './types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Open + migrate a database. Returns a connected handle. Idempotent.
+ *
+ * @param dbPath - Absolute path or `:memory:` for tests.
+ * @param migrationsDir - Override migrations dir (default: package's migrations/).
+ * @param wal - Enable WAL mode (default true). Set false for `:memory:`.
+ */
+export function openDatabase(
+  dbPath: string,
+  migrationsDir?: string,
+  wal = true
+): DatabaseInstance {
+  if (dbPath !== ':memory:') {
+    const dir = dirname(dbPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  const db = new Database(dbPath);
+  if (wal && dbPath !== ':memory:') {
+    db.pragma('journal_mode = WAL');
+  }
+  db.pragma('foreign_keys = ON');
+
+  applyMigrations(db, migrationsDir ?? defaultMigrationsDir());
+  return db;
+}
+
+function defaultMigrationsDir(): string {
+  // dist layout: dist/sqlite.js → ../migrations/
+  // src layout (vitest):   src/sqlite.ts → ../migrations/
+  return resolve(__dirname, '..', 'migrations');
+}
+
+/**
+ * Track applied migrations in a small table so re-opening the database
+ * doesn't re-run them. Migration files are sorted by filename.
+ */
+function applyMigrations(db: DatabaseInstance, migrationsDir: string): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      filename TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    );
+  `);
+
+  if (!existsSync(migrationsDir)) {
+    // No migrations dir (tests using ':memory:' with manual schema). Skip.
+    return;
+  }
+
+  const applied = new Set<string>(
+    db.prepare('SELECT filename FROM _migrations').all().map((r) => (r as { filename: string }).filename)
+  );
+
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+
+  const insertMigration = db.prepare(
+    'INSERT INTO _migrations(filename, applied_at) VALUES(?, ?)'
+  );
+
+  for (const f of files) {
+    if (applied.has(f)) continue;
+    const sql = readFileSync(join(migrationsDir, f), 'utf-8');
+    db.transaction(() => {
+      db.exec(sql);
+      insertMigration.run(f, new Date().toISOString());
+    })();
+  }
+}
+
+// ─── CRUD primitives ──────────────────────────────────────────────────────
+
+export interface InsertEventArgs {
+  id: string;
+  event_type: string;
+  schema_version: number;
+  correlation_id: string | null;
+  parent_event_id: string | null;
+  emitted_at: string;
+  hostname: string;
+  process_name: string | null;
+  payload_json: string;
+  validation_failed: 0 | 1;
+}
+
+/**
+ * Insert a single event. The `ingest_offset` is allocated atomically from
+ * `_ingest_counter`. Returns the inserted row's offset.
+ */
+export function insertEvent(db: DatabaseInstance, args: InsertEventArgs): number {
+  // Allocate a monotonic offset.
+  const allocate = db.prepare('UPDATE _ingest_counter SET next_offset = next_offset + 1 WHERE id = 1');
+  const readOffset = db.prepare('SELECT next_offset - 1 AS prev FROM _ingest_counter WHERE id = 1');
+  const insert = db.prepare(`
+    INSERT INTO events (
+      id, event_type, schema_version, correlation_id, parent_event_id,
+      emitted_at, hostname, process_name, payload_json, validation_failed,
+      ingest_offset
+    ) VALUES (
+      @id, @event_type, @schema_version, @correlation_id, @parent_event_id,
+      @emitted_at, @hostname, @process_name, @payload_json, @validation_failed,
+      @ingest_offset
+    )
+  `);
+
+  const tx = db.transaction((row: InsertEventArgs) => {
+    allocate.run();
+    const { prev } = readOffset.get() as { prev: number };
+    const offset = prev;
+    insert.run({ ...row, ingest_offset: offset });
+    return offset;
+  });
+
+  return tx(args);
+}
+
+export interface QueryEventsOptions {
+  eventType?: string;
+  correlationId?: string;
+  sinceIso?: string;
+  untilIso?: string;
+  /** Lower bound on ingest_offset (exclusive). Used by tail consumers. */
+  sinceOffset?: number;
+  limit?: number;
+  /** Order: 'asc' (default) or 'desc' on emitted_at. */
+  order?: 'asc' | 'desc';
+}
+
+export function queryEvents(
+  db: DatabaseInstance,
+  opts: QueryEventsOptions = {}
+): EventRow[] {
+  const where: string[] = [];
+  const params: Record<string, string | number> = {};
+
+  if (opts.eventType !== undefined) {
+    where.push('event_type = @eventType');
+    params['eventType'] = opts.eventType;
+  }
+  if (opts.correlationId !== undefined) {
+    where.push('correlation_id = @correlationId');
+    params['correlationId'] = opts.correlationId;
+  }
+  if (opts.sinceIso !== undefined) {
+    where.push('emitted_at >= @sinceIso');
+    params['sinceIso'] = opts.sinceIso;
+  }
+  if (opts.untilIso !== undefined) {
+    where.push('emitted_at < @untilIso');
+    params['untilIso'] = opts.untilIso;
+  }
+  if (opts.sinceOffset !== undefined) {
+    where.push('ingest_offset > @sinceOffset');
+    params['sinceOffset'] = opts.sinceOffset;
+  }
+
+  const order = opts.order === 'desc' ? 'DESC' : 'ASC';
+  const limitClause = opts.limit !== undefined ? `LIMIT @limit` : '';
+  if (opts.limit !== undefined) params['limit'] = opts.limit;
+
+  const sql = `
+    SELECT id, event_type, schema_version, correlation_id, parent_event_id,
+           emitted_at, hostname, process_name, payload_json, validation_failed,
+           ingest_offset
+    FROM events
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY ingest_offset ${order}
+    ${limitClause}
+  `;
+
+  return db.prepare(sql).all(params) as EventRow[];
+}
+
+export function countEvents(db: DatabaseInstance, opts: QueryEventsOptions = {}): number {
+  const where: string[] = [];
+  const params: Record<string, string | number> = {};
+  if (opts.eventType !== undefined) {
+    where.push('event_type = @eventType');
+    params['eventType'] = opts.eventType;
+  }
+  if (opts.correlationId !== undefined) {
+    where.push('correlation_id = @correlationId');
+    params['correlationId'] = opts.correlationId;
+  }
+  if (opts.sinceIso !== undefined) {
+    where.push('emitted_at >= @sinceIso');
+    params['sinceIso'] = opts.sinceIso;
+  }
+  const sql = `
+    SELECT COUNT(*) AS n
+    FROM events
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+  `;
+  const row = db.prepare(sql).get(params) as { n: number } | undefined;
+  return row?.n ?? 0;
+}
+
+/**
+ * Register or update a Zod-schema fingerprint for an event type.
+ * Idempotent — re-registering the same (type, version, fingerprint) is a no-op.
+ */
+export function registerSchemaDefinition(
+  db: DatabaseInstance,
+  args: { event_type: string; schema_version: number; zod_schema: string }
+): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO schema_definitions
+       (event_type, schema_version, zod_schema, registered_at)
+       VALUES (?, ?, ?, ?)`
+  ).run(args.event_type, args.schema_version, args.zod_schema, new Date().toISOString());
+}

--- a/packages/mentor-event-bus/src/types.ts
+++ b/packages/mentor-event-bus/src/types.ts
@@ -1,0 +1,227 @@
+/**
+ * Mentor event-bus types.
+ *
+ * The event taxonomy is per `agent/memory/mentor_agent_directive.md`
+ * (Phase 0 — Event-substrate prerequisites). 22 event types initially;
+ * the taxonomy is extensible — add a new EventType + corresponding Zod
+ * schema in schemas.ts and a payload type below.
+ */
+
+/** All Mentor event types. */
+export const EVENT_TYPES = [
+  'PromptReceived',
+  'PromptDecomposed',
+  'TaskSpawned',
+  'TaskCompleted',
+  'TaskFailed',
+  'TaskAborted',
+  'OperatorCorrection',
+  'OperatorAcknowledged',
+  'PRMerged',
+  'PRClosedWithoutMerge',
+  'PostMergeBugReport',
+  'RegressionDetected',
+  'EvidenceGateFailure',
+  'HallucinationFlagged',
+  'ScopeMismatchFlagged',
+  'DoDViolation',
+  'MemoryWritten',
+  'MemoryReadMissed',
+  'DecisionClassifierTrip',
+  'ToolMisuseFlagged',
+  'SubscriptionBucketSpike',
+  'CapabilityBrokerOverride'
+] as const;
+
+export type EventType = (typeof EVENT_TYPES)[number];
+
+/** Default schema version per type. Bump when the payload shape changes. */
+export const DEFAULT_SCHEMA_VERSION = 1;
+
+/** Stored event row (as persisted in the events SQLite table). */
+export interface EventRow {
+  id: string;
+  event_type: EventType;
+  schema_version: number;
+  correlation_id: string | null;
+  parent_event_id: string | null;
+  emitted_at: string; // ISO 8601 UTC
+  hostname: string;
+  process_name: string | null;
+  payload_json: string;
+  validation_failed: 0 | 1;
+  ingest_offset: number;
+}
+
+/** Decoded event with parsed payload. */
+export interface EmittedEvent<TPayload = unknown> {
+  id: string;
+  type: EventType;
+  schemaVersion: number;
+  correlationId: string | null;
+  parentEventId: string | null;
+  emittedAt: string;
+  hostname: string;
+  processName: string | null;
+  payload: TPayload;
+  validationFailed: boolean;
+  ingestOffset: number;
+}
+
+// ─── Per-event-type payload contracts ─────────────────────────────────────
+
+export interface PromptReceivedPayload {
+  promptId: string;
+  body: string;
+  source?: string;
+}
+
+export interface PromptDecomposedPayload {
+  promptId: string;
+  taskCount: number;
+  taskIds: string[];
+}
+
+export interface TaskSpawnedPayload {
+  taskId: string;
+  parentTaskId?: string;
+  agentName: string;
+  promptId?: string;
+}
+
+export interface TaskCompletedPayload {
+  taskId: string;
+  durationMs: number;
+  exitCode: number;
+}
+
+export interface TaskFailedPayload {
+  taskId: string;
+  error: string;
+  exitCode?: number;
+}
+
+export interface TaskAbortedPayload {
+  taskId: string;
+  reason: string;
+}
+
+export interface OperatorCorrectionPayload {
+  correctionText: string;
+  context?: string;
+  detectionMode: 'manual' | 'regex' | 'llm';
+}
+
+export interface OperatorAcknowledgedPayload {
+  ackText: string;
+  context?: string;
+}
+
+export interface PRMergedPayload {
+  prNumber: number;
+  sha: string;
+  branch: string;
+  repo?: string;
+  author?: string;
+}
+
+export interface PRClosedWithoutMergePayload {
+  prNumber: number;
+  reason?: string;
+}
+
+export interface PostMergeBugReportPayload {
+  prNumber?: number;
+  description: string;
+  reportedAt: string;
+}
+
+export interface RegressionDetectedPayload {
+  testName: string;
+  failedSha: string;
+  passingSha?: string;
+}
+
+export interface EvidenceGateFailurePayload {
+  prNumber: number;
+  failedJobs: string[];
+}
+
+export interface HallucinationFlaggedPayload {
+  taskId?: string;
+  description: string;
+  source: string;
+}
+
+export interface ScopeMismatchFlaggedPayload {
+  taskId?: string;
+  description: string;
+}
+
+export interface DoDViolationPayload {
+  taskId?: string;
+  rule: string;
+  description: string;
+}
+
+export interface MemoryWrittenPayload {
+  path: string;
+  sha?: string;
+  size: number;
+  operation: 'create' | 'modify' | 'delete';
+}
+
+export interface MemoryReadMissedPayload {
+  searchedFor: string;
+  context?: string;
+}
+
+export interface DecisionClassifierTripPayload {
+  decision: string;
+  outcome: 'asked' | 'auto-decided';
+}
+
+export interface ToolMisuseFlaggedPayload {
+  tool: string;
+  description: string;
+}
+
+export interface SubscriptionBucketSpikePayload {
+  bucket: string;
+  spikeMagnitude: number;
+}
+
+export interface CapabilityBrokerOverridePayload {
+  capability: string;
+  reason: string;
+  approver: string;
+}
+
+/** Maps EventType → its payload contract. */
+export interface EventPayloadMap {
+  PromptReceived: PromptReceivedPayload;
+  PromptDecomposed: PromptDecomposedPayload;
+  TaskSpawned: TaskSpawnedPayload;
+  TaskCompleted: TaskCompletedPayload;
+  TaskFailed: TaskFailedPayload;
+  TaskAborted: TaskAbortedPayload;
+  OperatorCorrection: OperatorCorrectionPayload;
+  OperatorAcknowledged: OperatorAcknowledgedPayload;
+  PRMerged: PRMergedPayload;
+  PRClosedWithoutMerge: PRClosedWithoutMergePayload;
+  PostMergeBugReport: PostMergeBugReportPayload;
+  RegressionDetected: RegressionDetectedPayload;
+  EvidenceGateFailure: EvidenceGateFailurePayload;
+  HallucinationFlagged: HallucinationFlaggedPayload;
+  ScopeMismatchFlagged: ScopeMismatchFlaggedPayload;
+  DoDViolation: DoDViolationPayload;
+  MemoryWritten: MemoryWrittenPayload;
+  MemoryReadMissed: MemoryReadMissedPayload;
+  DecisionClassifierTrip: DecisionClassifierTripPayload;
+  ToolMisuseFlagged: ToolMisuseFlaggedPayload;
+  SubscriptionBucketSpike: SubscriptionBucketSpikePayload;
+  CapabilityBrokerOverride: CapabilityBrokerOverridePayload;
+}
+
+/** Type-safe payload for a given EventType. */
+export type PayloadOf<T extends EventType> = EventPayloadMap[T];

--- a/packages/mentor-event-bus/tests/client.test.ts
+++ b/packages/mentor-event-bus/tests/client.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Client } from '../src/client';
+import { withCorrelation } from '../src/correlation';
+
+let dbDir: string;
+const migrationsDir = join(__dirname, '..', 'migrations');
+
+beforeEach(() => {
+  dbDir = mkdtempSync(join(tmpdir(), 'mentor-bus-client-'));
+});
+afterEach(() => {
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+function makeClient(opts: Partial<ConstructorParameters<typeof Client>[0]> = {}): Client {
+  return new Client({
+    dbPath: join(dbDir, 'events.sqlite'),
+    migrationsDir,
+    hostname: 'test-host',
+    processName: 'test',
+    disableWal: true,
+    ...opts
+  });
+}
+
+describe('Client.emit', () => {
+  it('emits a valid PRMerged event and returns an id', () => {
+    const c = makeClient();
+    const id = c.emit('PRMerged', { prNumber: 312, sha: 'abc1234', branch: 'develop' });
+    expect(id).toBeTruthy();
+    expect(id?.startsWith('ev_')).toBe(true);
+    const rows = c.getRecent({ eventType: 'PRMerged' });
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.payload).toEqual({ prNumber: 312, sha: 'abc1234', branch: 'develop' });
+    expect(rows[0]!.validationFailed).toBe(false);
+    c.close();
+  });
+
+  it('emits even when payload validation fails (with validation_failed=1)', () => {
+    const c = makeClient();
+    // Invalid SHA → validation fails but emit must not throw
+    const id = c.emit('PRMerged', {
+      prNumber: 312,
+      sha: 'NOT-A-SHA',
+      branch: 'develop'
+    } as never);
+    expect(id).toBeTruthy();
+    const rows = c.getRecent({ eventType: 'PRMerged' });
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.validationFailed).toBe(true);
+    c.close();
+  });
+
+  it('inherits correlation_id from withCorrelation', () => {
+    const c = makeClient();
+    let emitted: string | null = null;
+    withCorrelation('corr-test', () => {
+      emitted = c.emit('PromptReceived', { promptId: 'p1', body: 'hello' });
+    });
+    expect(emitted).not.toBeNull();
+    const rows = c.getRecent({ correlationId: 'corr-test' });
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.correlationId).toBe('corr-test');
+    c.close();
+  });
+
+  it('explicit emit-options override the inherited correlation_id', () => {
+    const c = makeClient();
+    withCorrelation('outer', () => {
+      c.emit('PromptReceived', { promptId: 'p1', body: 'hi' }, { correlationId: 'inner' });
+    });
+    const rows = c.getRecent();
+    expect(rows[0]!.correlationId).toBe('inner');
+    c.close();
+  });
+
+  it('records hostname + processName', () => {
+    const c = makeClient({ hostname: 'host-z', processName: 'orchestrator' });
+    c.emit('TaskSpawned', { taskId: 't1', agentName: 'worker-coding' });
+    const rows = c.getRecent();
+    expect(rows[0]!.hostname).toBe('host-z');
+    expect(rows[0]!.processName).toBe('orchestrator');
+    c.close();
+  });
+
+  it('returns null and logs on emit-after-close', () => {
+    let warned = false;
+    const c = makeClient({ logger: { warn: () => { warned = true; } } });
+    c.close();
+    const id = c.emit('TaskCompleted', { taskId: 't1', durationMs: 1, exitCode: 0 });
+    expect(id).toBeNull();
+    expect(warned).toBe(true);
+  });
+});
+
+describe('Client.getRecent', () => {
+  it('returns an empty array on a fresh DB', () => {
+    const c = makeClient();
+    expect(c.getRecent()).toEqual([]);
+    c.close();
+  });
+
+  it('orders by ingest_offset desc by default', () => {
+    const c = makeClient();
+    c.emit('TaskSpawned', { taskId: 't1', agentName: 'a' });
+    c.emit('TaskSpawned', { taskId: 't2', agentName: 'a' });
+    c.emit('TaskSpawned', { taskId: 't3', agentName: 'a' });
+    const rows = c.getRecent({ limit: 10 });
+    expect(rows.map((r) => (r.payload as { taskId: string }).taskId)).toEqual(['t3', 't2', 't1']);
+    c.close();
+  });
+
+  it('count() returns the row total', () => {
+    const c = makeClient();
+    c.emit('TaskSpawned', { taskId: 't1', agentName: 'a' });
+    c.emit('TaskSpawned', { taskId: 't2', agentName: 'a' });
+    expect(c.count()).toBe(2);
+    expect(c.count({ eventType: 'TaskSpawned' })).toBe(2);
+    expect(c.count({ eventType: 'PRMerged' })).toBe(0);
+    c.close();
+  });
+});
+
+describe('Client schema registration', () => {
+  it('populates schema_definitions on init', () => {
+    const c = makeClient();
+    const db = c.unsafeGetDb();
+    const rows = db.prepare('SELECT COUNT(*) AS n FROM schema_definitions').get() as { n: number };
+    // 22 event types, all registered at init time
+    expect(rows.n).toBe(22);
+    c.close();
+  });
+
+  it('skips schema registration when skipSchemaRegistration=true', () => {
+    const c = makeClient({ skipSchemaRegistration: true });
+    const rows = c.unsafeGetDb().prepare('SELECT COUNT(*) AS n FROM schema_definitions').get() as {
+      n: number;
+    };
+    expect(rows.n).toBe(0);
+    c.close();
+  });
+});
+
+describe('Client persistence', () => {
+  it('events survive a close + reopen', () => {
+    const dbPath = join(dbDir, 'persist.sqlite');
+    const c1 = new Client({ dbPath, migrationsDir, disableWal: true });
+    c1.emit('PRMerged', { prNumber: 999, sha: 'deadbeef', branch: 'develop' });
+    c1.close();
+    expect(existsSync(dbPath)).toBe(true);
+    const c2 = new Client({ dbPath, migrationsDir, disableWal: true });
+    const rows = c2.getRecent();
+    expect(rows.length).toBe(1);
+    expect((rows[0]!.payload as { prNumber: number }).prNumber).toBe(999);
+    c2.close();
+  });
+});

--- a/packages/mentor-event-bus/tests/correlation.test.ts
+++ b/packages/mentor-event-bus/tests/correlation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  withCorrelation,
+  withCorrelationAsync,
+  currentCorrelationId,
+  currentParentEventId,
+  currentCorrelation
+} from '../src/correlation';
+
+describe('correlation', () => {
+  it('returns undefined outside withCorrelation', () => {
+    expect(currentCorrelationId()).toBeUndefined();
+    expect(currentParentEventId()).toBeUndefined();
+    expect(currentCorrelation()).toBeUndefined();
+  });
+
+  it('exposes correlation_id inside withCorrelation', () => {
+    let captured: string | undefined;
+    withCorrelation('corr-x', () => {
+      captured = currentCorrelationId();
+    });
+    expect(captured).toBe('corr-x');
+    // and is reset after fn returns
+    expect(currentCorrelationId()).toBeUndefined();
+  });
+
+  it('exposes parent_event_id when set', () => {
+    let captured: string | undefined;
+    withCorrelation('corr-y', () => {
+      captured = currentParentEventId();
+    }, 'parent-1');
+    expect(captured).toBe('parent-1');
+  });
+
+  it('propagates across async boundaries', async () => {
+    const observed: string[] = [];
+    await withCorrelationAsync('corr-async', async () => {
+      observed.push(currentCorrelationId() ?? 'none');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      observed.push(currentCorrelationId() ?? 'none');
+      await Promise.resolve();
+      observed.push(currentCorrelationId() ?? 'none');
+    });
+    expect(observed).toEqual(['corr-async', 'corr-async', 'corr-async']);
+  });
+
+  it('nested withCorrelation overrides the outer one', () => {
+    const observed: string[] = [];
+    withCorrelation('outer', () => {
+      observed.push(currentCorrelationId() ?? 'none');
+      withCorrelation('inner', () => {
+        observed.push(currentCorrelationId() ?? 'none');
+      });
+      observed.push(currentCorrelationId() ?? 'none');
+    });
+    expect(observed).toEqual(['outer', 'inner', 'outer']);
+  });
+});

--- a/packages/mentor-event-bus/tests/schemas.test.ts
+++ b/packages/mentor-event-bus/tests/schemas.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { validatePayload, describeSchema, EVENT_SCHEMAS } from '../src/schemas';
+
+describe('validatePayload', () => {
+  it('accepts a valid PRMerged payload', () => {
+    const result = validatePayload('PRMerged', {
+      prNumber: 312,
+      sha: 'abc1234',
+      branch: 'develop'
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects PRMerged with bad SHA', () => {
+    const result = validatePayload('PRMerged', {
+      prNumber: 312,
+      sha: 'NOT-A-SHA',
+      branch: 'develop'
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects PRMerged missing required field', () => {
+    const result = validatePayload('PRMerged', { prNumber: 312, sha: 'abc1234' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts a valid TaskSpawned payload with optional parent', () => {
+    const result = validatePayload('TaskSpawned', {
+      taskId: 't1',
+      agentName: 'worker-coding'
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts MemoryWritten with operation = create', () => {
+    const result = validatePayload('MemoryWritten', {
+      path: 'memory/foo.md',
+      size: 1234,
+      operation: 'create'
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects MemoryWritten with unknown operation', () => {
+    const result = validatePayload('MemoryWritten', {
+      path: 'memory/foo.md',
+      size: 1234,
+      operation: 'wibble'
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts OperatorCorrection with detectionMode=manual', () => {
+    const result = validatePayload('OperatorCorrection', {
+      correctionText: 'no, do it the other way',
+      detectionMode: 'manual'
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects OperatorCorrection with empty text', () => {
+    const result = validatePayload('OperatorCorrection', {
+      correctionText: '',
+      detectionMode: 'manual'
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('describeSchema', () => {
+  it('returns a string', () => {
+    const desc = describeSchema(EVENT_SCHEMAS.PRMerged);
+    expect(typeof desc).toBe('string');
+    expect(desc.length).toBeGreaterThan(2);
+  });
+});

--- a/packages/mentor-event-bus/tests/sqlite.test.ts
+++ b/packages/mentor-event-bus/tests/sqlite.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  openDatabase,
+  insertEvent,
+  queryEvents,
+  countEvents,
+  registerSchemaDefinition,
+  type InsertEventArgs
+} from '../src/sqlite';
+
+let dbDir: string;
+let migrationsDir: string;
+
+beforeEach(() => {
+  dbDir = mkdtempSync(join(tmpdir(), 'mentor-bus-sqlite-'));
+  // Use the actual package migration as fixture
+  migrationsDir = join(__dirname, '..', 'migrations');
+  // sanity
+  if (!existsSync(migrationsDir)) {
+    // fall back: write a copy from the repo location
+    migrationsDir = join(dbDir, 'migrations');
+    mkdirSync(migrationsDir, { recursive: true });
+    writeFileSync(
+      join(migrationsDir, '0001_init.sql'),
+      readFileSync(join(__dirname, '..', 'migrations', '0001_init.sql'), 'utf-8'),
+      'utf-8'
+    );
+  }
+});
+afterEach(() => {
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+const baseInsert = (overrides: Partial<InsertEventArgs> = {}): InsertEventArgs => ({
+  id: 'ev_test_001',
+  event_type: 'PRMerged',
+  schema_version: 1,
+  correlation_id: null,
+  parent_event_id: null,
+  emitted_at: new Date().toISOString(),
+  hostname: 'test-host',
+  process_name: null,
+  payload_json: '{}',
+  validation_failed: 0,
+  ...overrides
+});
+
+describe('openDatabase', () => {
+  it('creates a fresh DB and applies migrations', () => {
+    const dbPath = join(dbDir, 'test.sqlite');
+    const db = openDatabase(dbPath, migrationsDir, false);
+    expect(existsSync(dbPath)).toBe(true);
+    // schema present
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all();
+    const names = tables.map((t) => (t as { name: string }).name);
+    expect(names).toContain('events');
+    expect(names).toContain('schema_definitions');
+    expect(names).toContain('_migrations');
+    db.close();
+  });
+
+  it('is idempotent — re-open is safe', () => {
+    const dbPath = join(dbDir, 'test2.sqlite');
+    const db1 = openDatabase(dbPath, migrationsDir, false);
+    db1.close();
+    const db2 = openDatabase(dbPath, migrationsDir, false);
+    const applied = db2.prepare('SELECT COUNT(*) AS n FROM _migrations').get() as { n: number };
+    expect(applied.n).toBe(1); // not duplicated
+    db2.close();
+  });
+
+  it('opens an in-memory DB', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all();
+    expect(tables.length).toBeGreaterThan(0);
+    db.close();
+  });
+});
+
+describe('insertEvent + queryEvents', () => {
+  it('inserts and reads back a single event', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    const offset = insertEvent(db, baseInsert({ id: 'ev_a' }));
+    expect(offset).toBe(1);
+    const rows = queryEvents(db);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.id).toBe('ev_a');
+    db.close();
+  });
+
+  it('assigns monotonically increasing ingest_offset', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    insertEvent(db, baseInsert({ id: 'ev_1' }));
+    insertEvent(db, baseInsert({ id: 'ev_2' }));
+    insertEvent(db, baseInsert({ id: 'ev_3' }));
+    const rows = queryEvents(db);
+    expect(rows.map((r) => r.ingest_offset)).toEqual([1, 2, 3]);
+    db.close();
+  });
+
+  it('filters by eventType', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    insertEvent(db, baseInsert({ id: 'ev_pr1', event_type: 'PRMerged' }));
+    insertEvent(db, baseInsert({ id: 'ev_t1', event_type: 'TaskSpawned' }));
+    insertEvent(db, baseInsert({ id: 'ev_pr2', event_type: 'PRMerged' }));
+    const prRows = queryEvents(db, { eventType: 'PRMerged' });
+    expect(prRows.length).toBe(2);
+    expect(prRows.every((r) => r.event_type === 'PRMerged')).toBe(true);
+    db.close();
+  });
+
+  it('filters by correlationId', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    insertEvent(db, baseInsert({ id: 'ev_a', correlation_id: 'corr-1' }));
+    insertEvent(db, baseInsert({ id: 'ev_b', correlation_id: 'corr-2' }));
+    insertEvent(db, baseInsert({ id: 'ev_c', correlation_id: 'corr-1' }));
+    const rows = queryEvents(db, { correlationId: 'corr-1' });
+    expect(rows.map((r) => r.id).sort()).toEqual(['ev_a', 'ev_c']);
+    db.close();
+  });
+
+  it('filters by sinceOffset (tail mode)', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    insertEvent(db, baseInsert({ id: 'ev_a' }));
+    insertEvent(db, baseInsert({ id: 'ev_b' }));
+    insertEvent(db, baseInsert({ id: 'ev_c' }));
+    const rows = queryEvents(db, { sinceOffset: 1 });
+    expect(rows.map((r) => r.id)).toEqual(['ev_b', 'ev_c']);
+    db.close();
+  });
+
+  it('respects limit', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    for (let i = 0; i < 10; i++) {
+      insertEvent(db, baseInsert({ id: `ev_${i}` }));
+    }
+    const rows = queryEvents(db, { limit: 3 });
+    expect(rows.length).toBe(3);
+    db.close();
+  });
+
+  it('orders desc when requested', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    insertEvent(db, baseInsert({ id: 'ev_a' }));
+    insertEvent(db, baseInsert({ id: 'ev_b' }));
+    const rows = queryEvents(db, { order: 'desc' });
+    expect(rows.map((r) => r.id)).toEqual(['ev_b', 'ev_a']);
+    db.close();
+  });
+});
+
+describe('countEvents', () => {
+  it('counts inserted events', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    expect(countEvents(db)).toBe(0);
+    insertEvent(db, baseInsert({ id: 'ev_a' }));
+    insertEvent(db, baseInsert({ id: 'ev_b' }));
+    expect(countEvents(db)).toBe(2);
+    db.close();
+  });
+
+  it('counts with eventType filter', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    insertEvent(db, baseInsert({ id: 'ev_a', event_type: 'PRMerged' }));
+    insertEvent(db, baseInsert({ id: 'ev_b', event_type: 'TaskSpawned' }));
+    expect(countEvents(db, { eventType: 'PRMerged' })).toBe(1);
+    expect(countEvents(db, { eventType: 'TaskSpawned' })).toBe(1);
+    db.close();
+  });
+});
+
+describe('registerSchemaDefinition', () => {
+  it('persists a row + is idempotent on conflict', () => {
+    const db = openDatabase(':memory:', migrationsDir, false);
+    registerSchemaDefinition(db, {
+      event_type: 'PRMerged',
+      schema_version: 1,
+      zod_schema: '{"foo":"bar"}'
+    });
+    registerSchemaDefinition(db, {
+      event_type: 'PRMerged',
+      schema_version: 1,
+      zod_schema: '{"foo":"updated"}'
+    });
+    const rows = db.prepare('SELECT * FROM schema_definitions').all() as Array<{
+      zod_schema: string;
+    }>;
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.zod_schema).toBe('{"foo":"updated"}');
+    db.close();
+  });
+});

--- a/packages/mentor-event-bus/tests/types.test.ts
+++ b/packages/mentor-event-bus/tests/types.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { EVENT_TYPES } from '../src/types';
+import { EVENT_SCHEMAS, assertEverySchemaPresent } from '../src/schemas';
+
+describe('event taxonomy', () => {
+  it('declares 22 event types', () => {
+    expect(EVENT_TYPES.length).toBe(22);
+  });
+
+  it('event type names are unique', () => {
+    const set = new Set(EVENT_TYPES);
+    expect(set.size).toBe(EVENT_TYPES.length);
+  });
+
+  it('every event type has a registered Zod schema', () => {
+    expect(() => assertEverySchemaPresent()).not.toThrow();
+    for (const t of EVENT_TYPES) {
+      expect(EVENT_SCHEMAS[t]).toBeDefined();
+    }
+  });
+});

--- a/packages/mentor-event-bus/tsconfig.build.json
+++ b/packages/mentor-event-bus/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/mentor-event-bus/tsconfig.json
+++ b/packages/mentor-event-bus/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/mentor-event-bus/vitest.config.ts
+++ b/packages/mentor-event-bus/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1240,6 +1240,43 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/mentor-event-bus:
+    dependencies:
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.9.0
+      nanoid:
+        specifier: ^3.3.7
+        version: 3.3.11
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.6.1)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/metrics:
     dependencies:
       prom-client:


### PR DESCRIPTION
## Summary

PR-α — first PR of the **Mentor Phase 0** roadmap (item 2 in the multi-day campaign roadmap). Sets up the typed append-only event substrate that subsequent PRs (β/γ/δ) will extend.

Scope: skeleton + types + schemas + SQLite client + correlation helpers + 42 tests. **No emit-points wired in this PR** — that's PR-γ.

## New package

`@chiefaia/mentor-event-bus` under `packages/mentor-event-bus/`:

| File | Purpose |
|---|---|
| `src/types.ts` | 22 EventTypes (per Phase 0 taxonomy) + per-event payload interfaces + `PayloadOf<T>` mapping |
| `src/schemas.ts` | Zod schemas + `EVENT_SCHEMAS` registry + `validatePayload` (returns discriminated result; never throws) |
| `src/sqlite.ts` | better-sqlite3 client; WAL; idempotent migration runner; monotonic `ingest_offset`; `insertEvent`/`queryEvents`/`countEvents` |
| `migrations/0001_init.sql` | `events` + `schema_definitions` + `_ingest_counter` tables with composite indexes |
| `src/correlation.ts` | `withCorrelation`/`withCorrelationAsync` via `AsyncLocalStorage`; nested `emit()` inherits `correlation_id` |
| `src/client.ts` | `Client` class: `emit`/`getRecent`/`count`/`close`; validation-failed events persist with flag rather than throwing |
| `src/index.ts` | public API barrel |

## Producer-non-blocking invariant

The single most important design property per the analysis doc: **`emit()` never throws.** Every error path (DB write fail, schema violation, `JSON.stringify` fail, post-close emit) is caught and logged via a pino-style `logger.warn`.

## Tests (42 new)

```
Test Files  5 passed (5)
     Tests  42 passed (42)
   Duration  ~700ms
```

- `types.test.ts` — taxonomy completeness (22 types, no dupes, every type has a schema)
- `schemas.test.ts` — happy + sad paths for every important schema
- `sqlite.test.ts` — open / migrate / CRUD / monotonic offsets / query filters / idempotency on re-open
- `correlation.test.ts` — async-context propagation across awaits + setTimeouts; nested override; reset after fn returns
- `client.test.ts` — emit+read; validation-failure persistence; `withCorrelation` inheritance; explicit-options override; persistence across close+reopen; emit-after-close returns `null` + logs warn

## Subscription-only compliance

Dependencies: `better-sqlite3` (already in tree via `llm-cache`), `nanoid` (already in tree), `zod` (already in tree). Zero paid services. ✓

## Roadmap

- [x] **PR-α — event-bus skeleton (this PR)**
- [ ] PR-β — HTTP server + cross-machine HTTP client (next)
- [ ] PR-γ — three Phase-0 emit-points + `caia mentor tail` CLI
- [ ] PR-δ — LaunchAgent plists + memory-watcher daemon + install.sh
- [ ] Stage 6 — verify events flow end-to-end via `caia mentor tail`

References: `~/Documents/projects/reports/mentor-phase0-analysis.md`, `agent/memory/mentor_agent_directive.md`, `agent/memory/feedback_no_api_key_billing.md`.
