### PR TITLE
feat(local-preview-001): per-site branch env override (PR-E)

### DIFF
--- a/apps/local-preview-orchestrator/README.md
+++ b/apps/local-preview-orchestrator/README.md
@@ -2,17 +2,21 @@
 
 Always-on local preview deployments for the three CAIA-affiliated sites:
 
-| Site | Local URL | Source repo |
-|---|---|---|
-| **CAIA dashboard** | http://localhost:5173 | `caia/apps/dashboard` |
-| **poker-zeno** | http://localhost:5174 | `~/Documents/projects/poker-zeno` |
-| **roulette-community** | http://localhost:5175 | `~/Documents/projects/roulette-community` |
-| **status dashboard** | http://localhost:5170 | this app |
+| Site | Local URL | Source repo | Default branch |
+|---|---|---|---|
+| **CAIA dashboard** | http://localhost:5173 | `caia/apps/dashboard` | `develop` |
+| **poker-zeno** | http://localhost:5174 | `~/Documents/projects/poker-zeno` | `master` |
+| **roulette-community** | http://localhost:5175 | `~/Documents/projects/roulette-community` | `main` |
+| **status dashboard** | http://localhost:5170 | this app | — |
 
-When installed, every merge to `develop` of any of the three site repos is
-auto-deployed to the corresponding local URL within 60 seconds, with atomic
-symlink-swap, instant rollback on health-check failure, and ten-build retention
-for manual rollback.
+When installed, every push to each site's tracked branch is auto-deployed to
+the corresponding local URL within 60 seconds, with atomic symlink-swap,
+instant rollback on health-check failure, and ten-build retention for manual
+rollback.
+
+The default branch per site is wired into the SITE_DEFAULTS table in
+`src/sites-config.ts`. Override per-site at install time with the env vars
+listed under [Per-site branch overrides](#per-site-branch-overrides).
 
 Subscription-only by design — no external services, no API keys, no paid
 tunnels. The deploy daemon polls `git fetch` every 30s.
@@ -50,7 +54,7 @@ com.stolution.local-preview.roulette-community  — site supervisor: localhost:5
 ```
 
 The deploy daemon polls each site's repo every 30s. When it sees a new
-`origin/develop` SHA, it:
+`origin/<branch>` SHA, it:
 
 1. `git worktree add` a fresh build copy
 2. runs the configured `buildCmd`
@@ -98,6 +102,33 @@ Env var overrides:
 | `LOCAL_PREVIEW_INSTALL_ROOT` | `~/Library/Application Support/Stolution/local-preview` | Per-site install root |
 | `LOCAL_PREVIEW_BUILD_WORKSPACE` | `/private/tmp/local-preview-build` | Ephemeral build worktrees |
 | `LOCAL_PREVIEW_DASHBOARD_PORT` | `5170` | Status dashboard port |
+
+### Per-site branch overrides
+
+The deploy daemon resolves each site's branch from `LOCAL_PREVIEW_<SITE>_BRANCH`
+env vars at runtime. Defaults match the SITE_DEFAULTS table in `src/sites-config.ts`.
+
+| Var | Default |
+|---|---|
+| `LOCAL_PREVIEW_DASHBOARD_BRANCH` | `develop` |
+| `LOCAL_PREVIEW_POKER_ZENO_BRANCH` | `master` |
+| `LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH` | `main` |
+
+To set them on a clean install, export before running `install.sh`:
+
+```bash
+LOCAL_PREVIEW_DASHBOARD_BRANCH=feature/abc \
+LOCAL_PREVIEW_POKER_ZENO_BRANCH=develop \
+    ./apps/local-preview-orchestrator/scripts/install.sh
+```
+
+`install.sh` writes the values into the deploy-daemon plist's
+`EnvironmentVariables` block. To change after install, re-run `install.sh`
+(it's idempotent — safe to re-run any time).
+
+The override value is validated against a strict allowlist
+(`/^[A-Za-z0-9_./@\-+]+$/`) at both install time and runtime; an attempt to
+inject shell metacharacters fails fast with a clear error.
 
 ## Status dashboard API
 

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
@@ -14,6 +14,10 @@
   Substitute `__USER_HOME__` with $HOME and `__REPO__` with the absolute
   path to your caia checkout when installing. The install.sh script does
   this automatically.
+
+  Per-site branch overrides: __LOCAL_PREVIEW_<SITE>_BRANCH__ placeholders
+  are sed-substituted at install time from the operator's env (or the
+  bake-in defaults of develop/master/main respectively).
 -->
 <plist version="1.0">
 <dict>
@@ -40,6 +44,12 @@
         <string>__USER_HOME__/Library/Application Support/Stolution/local-preview</string>
         <key>LOCAL_PREVIEW_BUILD_WORKSPACE</key>
         <string>/private/tmp/local-preview-build</string>
+        <key>LOCAL_PREVIEW_DASHBOARD_BRANCH</key>
+        <string>__LOCAL_PREVIEW_DASHBOARD_BRANCH__</string>
+        <key>LOCAL_PREVIEW_POKER_ZENO_BRANCH</key>
+        <string>__LOCAL_PREVIEW_POKER_ZENO_BRANCH__</string>
+        <key>LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH</key>
+        <string>__LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH__</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/apps/local-preview-orchestrator/scripts/install.sh
+++ b/apps/local-preview-orchestrator/scripts/install.sh
@@ -18,6 +18,16 @@
 #   4. launchctl bootstrap each agent (gui/$UID domain)
 #   5. Verifies dashboard responds on http://127.0.0.1:5170/healthz within 30s
 #
+# Per-site branch overrides:
+#   The deploy daemon resolves each site's branch from
+#   `LOCAL_PREVIEW_<SITE>_BRANCH` env vars at runtime. install.sh templates
+#   those values into the deploy-daemon plist's EnvironmentVariables block.
+#   Set them in your shell before running install.sh; otherwise they fall
+#   back to the bake-in defaults (develop/master/main):
+#
+#     LOCAL_PREVIEW_DASHBOARD_BRANCH=feature/foo \
+#         ./scripts/install.sh
+#
 # Idempotent: safe to re-run; will bootout any pre-existing copy of each agent first.
 
 set -euo pipefail
@@ -36,6 +46,27 @@ BACKUP_DIR="${HOME}/.caia-backups/launchagents-$(date +%Y%m%d-%H%M%S)"
 SITE_REPO_DASHBOARD="${SITE_REPO_DASHBOARD:-${REPO_ROOT}}"
 SITE_REPO_POKER_ZENO="${SITE_REPO_POKER_ZENO:-${HOME}/Documents/projects/poker-zeno}"
 SITE_REPO_ROULETTE_COMMUNITY="${SITE_REPO_ROULETTE_COMMUNITY:-${HOME}/Documents/projects/roulette-community}"
+
+# Per-site branch overrides (PR-E). Defaults match SITE_DEFAULTS in sites-config.ts.
+LOCAL_PREVIEW_DASHBOARD_BRANCH="${LOCAL_PREVIEW_DASHBOARD_BRANCH:-develop}"
+LOCAL_PREVIEW_POKER_ZENO_BRANCH="${LOCAL_PREVIEW_POKER_ZENO_BRANCH:-master}"
+LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH="${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH:-main}"
+
+# Validate branch refs against the same allowlist used by sites-config.ts and
+# git-ops.shellEscape (alphanumerics, _, ., /, @, -, +). This is defence in
+# depth — the runtime resolver also validates — but failing fast at install
+# time is friendlier than a crash-loop after launchctl bootstrap.
+_validate_branch() {
+    local var_name="$1"
+    local value="$2"
+    if [[ ! "${value}" =~ ^[A-Za-z0-9_./@+\-]+$ ]]; then
+        echo "ERROR: ${var_name}=\"${value}\" contains characters outside the allowlist [A-Za-z0-9_./@+-]." >&2
+        exit 2
+    fi
+}
+_validate_branch LOCAL_PREVIEW_DASHBOARD_BRANCH "${LOCAL_PREVIEW_DASHBOARD_BRANCH}"
+_validate_branch LOCAL_PREVIEW_POKER_ZENO_BRANCH "${LOCAL_PREVIEW_POKER_ZENO_BRANCH}"
+_validate_branch LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH "${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH}"
 
 # ─── Verify pre-conditions ──────────────────────────────────────────────────
 if [[ "$(uname)" != "Darwin" ]]; then
@@ -99,6 +130,10 @@ done
 # ─── Substitute templates + copy ────────────────────────────────────────────
 echo
 echo "Installing plists into ${LA_DIR}/"
+echo "  per-site branches:"
+echo "    dashboard           = ${LOCAL_PREVIEW_DASHBOARD_BRANCH}"
+echo "    poker-zeno          = ${LOCAL_PREVIEW_POKER_ZENO_BRANCH}"
+echo "    roulette-community  = ${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH}"
 for label in "${PLIST_LABELS[@]}"; do
     src="${PLISTS_SRC}/${label}.plist"
     dst="${LA_DIR}/${label}.plist"
@@ -111,6 +146,9 @@ for label in "${PLIST_LABELS[@]}"; do
         -e "s|__REPO__|${REPO_ROOT}|g" \
         -e "s|__SITE_REPO_POKER_ZENO__|${SITE_REPO_POKER_ZENO}|g" \
         -e "s|__SITE_REPO_ROULETTE_COMMUNITY__|${SITE_REPO_ROULETTE_COMMUNITY}|g" \
+        -e "s|__LOCAL_PREVIEW_DASHBOARD_BRANCH__|${LOCAL_PREVIEW_DASHBOARD_BRANCH}|g" \
+        -e "s|__LOCAL_PREVIEW_POKER_ZENO_BRANCH__|${LOCAL_PREVIEW_POKER_ZENO_BRANCH}|g" \
+        -e "s|__LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH__|${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH}|g" \
         -e "s|/usr/local/bin/node|${NODE_BIN}|g" \
         "${src}" > "${dst}"
     echo "  installed ${label}.plist"

--- a/apps/local-preview-orchestrator/src/sites-config.ts
+++ b/apps/local-preview-orchestrator/src/sites-config.ts
@@ -1,6 +1,33 @@
 /**
  * Site configuration registry for local preview deployments.
  * Defines the three sites, their repos, ports, build/start commands, and health checks.
+ *
+ * Per-site branch override:
+ *   The default branch baked into the SITE_DEFAULTS table can be overridden at
+ *   runtime via environment variables of the form:
+ *
+ *     LOCAL_PREVIEW_<SITE_UPPER_SNAKE>_BRANCH
+ *
+ *   For example:
+ *     LOCAL_PREVIEW_DASHBOARD_BRANCH=develop
+ *     LOCAL_PREVIEW_POKER_ZENO_BRANCH=master
+ *     LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH=main
+ *
+ *   This addresses the architectural gap surfaced in Stage-6 verify where
+ *   `branch: 'develop'` was hard-coded for all sites but poker-zeno's default
+ *   branch is `master` and roulette-community's is `main`.
+ *
+ *   The override is read at module-load time from `process.env`. Because the
+ *   poll daemon and site supervisors are bootstrapped via LaunchAgent plists,
+ *   the env var must be exported in the plist's `EnvironmentVariables` block
+ *   (or in the user's launchctl context via `launchctl setenv`) for the
+ *   override to take effect.
+ *
+ * Trust boundary: branch names sourced from env are validated against a
+ * conservative allowlist (`/^[A-Za-z0-9_./@-]+$/`) — the same allowlist used
+ * by `git-ops.shellEscape`. Anything outside the allowlist is rejected at
+ * load time with a clear error so an attacker cannot inject shell
+ * metacharacters via the override env var.
  */
 
 export interface SiteConfig {
@@ -15,11 +42,16 @@ export interface SiteConfig {
   buildArtifacts: string[];
 }
 
-export const SITES: SiteConfig[] = [
+interface SiteDefault extends Omit<SiteConfig, 'branch'> {
+  /** Default branch — overridable via LOCAL_PREVIEW_<SITE_UPPER_SNAKE>_BRANCH. */
+  defaultBranch: string;
+}
+
+const SITE_DEFAULTS: SiteDefault[] = [
   {
     name: 'dashboard',
     repo: '/Users/MAC/Documents/projects/caia/apps/dashboard',
-    branch: 'develop',
+    defaultBranch: 'develop',
     port: 5173,
     buildCmd: 'pnpm install --frozen-lockfile && pnpm --filter @caia-app/dashboard build',
     startCmd: (p) => `pnpm --filter @caia-app/dashboard exec next start -p ${p}`,
@@ -30,7 +62,8 @@ export const SITES: SiteConfig[] = [
   {
     name: 'poker-zeno',
     repo: '/Users/MAC/Documents/projects/poker-zeno',
-    branch: 'develop',
+    // Stage-6 verify (2026-05-05) confirmed poker-zeno's primary branch is master, not develop.
+    defaultBranch: 'master',
     port: 5174,
     buildCmd: 'pnpm install --frozen-lockfile && pnpm build',
     startCmd: (p) => `pnpm preview -- --port ${p}`,
@@ -41,7 +74,8 @@ export const SITES: SiteConfig[] = [
   {
     name: 'roulette-community',
     repo: '/Users/MAC/Documents/projects/roulette-community',
-    branch: 'develop',
+    // Stage-6 verify (2026-05-05) confirmed roulette-community's primary branch is main, not develop.
+    defaultBranch: 'main',
     port: 5175,
     buildCmd: 'pnpm install --frozen-lockfile && pnpm build',
     startCmd: (p) => `pnpm preview -- --port ${p}`,
@@ -50,6 +84,71 @@ export const SITES: SiteConfig[] = [
     buildArtifacts: ['dist', 'package.json']
   }
 ];
+
+/**
+ * Strict allowlist matching `git-ops.shellEscape` — branches must look like
+ * git refs (alphanumerics, `_`, `.`, `/`, `@`, `-`, `+`).
+ */
+const BRANCH_ALLOWLIST = /^[A-Za-z0-9_./@\-+]+$/;
+
+/**
+ * Convert a site name to its env-var infix:
+ *   "dashboard"          -> "DASHBOARD"
+ *   "poker-zeno"         -> "POKER_ZENO"
+ *   "roulette-community" -> "ROULETTE_COMMUNITY"
+ */
+export function envVarNameForSiteBranch(siteName: string): string {
+  return `LOCAL_PREVIEW_${siteName.replace(/-/g, '_').toUpperCase()}_BRANCH`;
+}
+
+/**
+ * Resolve the effective branch for a site:
+ *   1. If `LOCAL_PREVIEW_<SITE>_BRANCH` env var is set and matches the allowlist,
+ *      use it.
+ *   2. If it's set but does NOT match the allowlist, throw — refuse to silently
+ *      fall back, since this is an attempt to inject shell metacharacters.
+ *   3. Otherwise, use the bake-in default.
+ */
+export function resolveBranch(
+  siteName: string,
+  defaultBranch: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const varName = envVarNameForSiteBranch(siteName);
+  const override = env[varName];
+  if (override === undefined || override === '') {
+    return defaultBranch;
+  }
+  if (!BRANCH_ALLOWLIST.test(override)) {
+    throw new Error(
+      `Invalid branch override for ${siteName}: ${varName}="${override}" — must match ${BRANCH_ALLOWLIST}`
+    );
+  }
+  return override;
+}
+
+/**
+ * Materialise the SITES list from the defaults table by resolving each branch
+ * against the current `process.env`. Re-evaluated on every module access via
+ * the `SITES` getter would be cleaner but daemons are long-lived processes
+ * where the env is fixed at bootstrap, so module-load resolution is fine.
+ */
+function buildSites(env: NodeJS.ProcessEnv = process.env): SiteConfig[] {
+  return SITE_DEFAULTS.map(({ defaultBranch, ...rest }) => ({
+    ...rest,
+    branch: resolveBranch(rest.name, defaultBranch, env)
+  }));
+}
+
+export const SITES: SiteConfig[] = buildSites();
+
+/**
+ * Test helper / dynamic-reload: rebuild SITES against an explicit env. Returns
+ * a new array; does NOT mutate the exported `SITES`.
+ */
+export function buildSitesForEnv(env: NodeJS.ProcessEnv): SiteConfig[] {
+  return buildSites(env);
+}
 
 export function getSiteConfig(siteName: string): SiteConfig {
   const config = SITES.find((s) => s.name === siteName);
@@ -61,4 +160,14 @@ export function getSiteConfig(siteName: string): SiteConfig {
 
 export function getAllSiteNames(): string[] {
   return SITES.map((s) => s.name);
+}
+
+/**
+ * Expose the default branch for a site (i.e., what `branch` would be if the
+ * env override is unset). Useful for diagnostic output (status dashboard,
+ * `caia local-preview status`) so users can see the bake-in default vs. the
+ * resolved override.
+ */
+export function getDefaultBranch(siteName: string): string | undefined {
+  return SITE_DEFAULTS.find((s) => s.name === siteName)?.defaultBranch;
 }

--- a/apps/local-preview-orchestrator/tests/sites-config.test.ts
+++ b/apps/local-preview-orchestrator/tests/sites-config.test.ts
@@ -1,30 +1,38 @@
 import { describe, it, expect } from 'vitest';
-import { SITES, getSiteConfig, getAllSiteNames } from '../src/sites-config';
+import {
+  SITES,
+  getSiteConfig,
+  getAllSiteNames,
+  getDefaultBranch,
+  resolveBranch,
+  envVarNameForSiteBranch,
+  buildSitesForEnv
+} from '../src/sites-config';
 
 describe('sites-config', () => {
   it('should have three sites configured', () => {
     expect(SITES.length).toBe(3);
   });
 
-  it('should have dashboard site', () => {
+  it('should have dashboard site (default branch develop)', () => {
     const dashboard = SITES.find((s) => s.name === 'dashboard');
     expect(dashboard).toBeDefined();
     expect(dashboard!.port).toBe(5173);
-    expect(dashboard!.branch).toBe('develop');
+    expect(getDefaultBranch('dashboard')).toBe('develop');
   });
 
-  it('should have poker-zeno site', () => {
+  it('should have poker-zeno site (default branch master, per Stage-6 verify)', () => {
     const pokerZeno = SITES.find((s) => s.name === 'poker-zeno');
     expect(pokerZeno).toBeDefined();
     expect(pokerZeno!.port).toBe(5174);
-    expect(pokerZeno!.branch).toBe('develop');
+    expect(getDefaultBranch('poker-zeno')).toBe('master');
   });
 
-  it('should have roulette-community site', () => {
+  it('should have roulette-community site (default branch main, per Stage-6 verify)', () => {
     const roulette = SITES.find((s) => s.name === 'roulette-community');
     expect(roulette).toBeDefined();
     expect(roulette!.port).toBe(5175);
-    expect(roulette!.branch).toBe('develop');
+    expect(getDefaultBranch('roulette-community')).toBe('main');
   });
 
   it('should have unique ports', () => {
@@ -80,5 +88,133 @@ describe('sites-config', () => {
       expect(Array.isArray(site.buildArtifacts)).toBe(true);
       expect(site.buildArtifacts.length).toBeGreaterThan(0);
     }
+  });
+
+  it('returns undefined defaultBranch for unknown site', () => {
+    expect(getDefaultBranch('not-a-real-site')).toBeUndefined();
+  });
+});
+
+describe('envVarNameForSiteBranch', () => {
+  it('uppercases and hyphen->underscore', () => {
+    expect(envVarNameForSiteBranch('dashboard')).toBe('LOCAL_PREVIEW_DASHBOARD_BRANCH');
+    expect(envVarNameForSiteBranch('poker-zeno')).toBe('LOCAL_PREVIEW_POKER_ZENO_BRANCH');
+    expect(envVarNameForSiteBranch('roulette-community')).toBe(
+      'LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH'
+    );
+  });
+
+  it('handles multi-hyphen names', () => {
+    expect(envVarNameForSiteBranch('a-b-c-d')).toBe('LOCAL_PREVIEW_A_B_C_D_BRANCH');
+  });
+});
+
+describe('resolveBranch', () => {
+  it('returns default when env var is unset', () => {
+    const branch = resolveBranch('dashboard', 'develop', {});
+    expect(branch).toBe('develop');
+  });
+
+  it('returns default when env var is empty string', () => {
+    const branch = resolveBranch('dashboard', 'develop', { LOCAL_PREVIEW_DASHBOARD_BRANCH: '' });
+    expect(branch).toBe('develop');
+  });
+
+  it('returns the override when env var is set and valid', () => {
+    const branch = resolveBranch('dashboard', 'develop', {
+      LOCAL_PREVIEW_DASHBOARD_BRANCH: 'feature/foo'
+    });
+    expect(branch).toBe('feature/foo');
+  });
+
+  it('handles hyphenated site names', () => {
+    const branch = resolveBranch('poker-zeno', 'master', {
+      LOCAL_PREVIEW_POKER_ZENO_BRANCH: 'develop'
+    });
+    expect(branch).toBe('develop');
+  });
+
+  it('handles complex git ref names', () => {
+    const cases = [
+      'develop',
+      'main',
+      'master',
+      'feature/abc',
+      'release/v1.2.3',
+      'fix/st_1dUqW-link-integrity',
+      'user/foo+bar',
+      'a/b/c',
+      'v1.2.3-rc.4',
+      '@scope/branch'
+    ];
+    for (const ref of cases) {
+      expect(
+        resolveBranch('dashboard', 'develop', { LOCAL_PREVIEW_DASHBOARD_BRANCH: ref })
+      ).toBe(ref);
+    }
+  });
+
+  it('throws when override contains shell metacharacters', () => {
+    const cases = [
+      'develop;rm -rf /',
+      'develop && echo hi',
+      'develop | cat',
+      'develop`echo hi`',
+      'develop$(echo hi)',
+      'develop\nfoo',
+      'develop bar', // space
+      'develop"bar"',
+      "develop'bar'",
+      'develop\\foo'
+    ];
+    for (const bad of cases) {
+      expect(() =>
+        resolveBranch('dashboard', 'develop', { LOCAL_PREVIEW_DASHBOARD_BRANCH: bad })
+      ).toThrow(/Invalid branch override/);
+    }
+  });
+
+  it('different sites have independent overrides', () => {
+    const env = {
+      LOCAL_PREVIEW_DASHBOARD_BRANCH: 'develop',
+      LOCAL_PREVIEW_POKER_ZENO_BRANCH: 'master'
+    };
+    expect(resolveBranch('dashboard', 'X', env)).toBe('develop');
+    expect(resolveBranch('poker-zeno', 'X', env)).toBe('master');
+    expect(resolveBranch('roulette-community', 'X', env)).toBe('X');
+  });
+});
+
+describe('buildSitesForEnv', () => {
+  it('returns the bake-in defaults when env is empty', () => {
+    const sites = buildSitesForEnv({});
+    expect(sites.find((s) => s.name === 'dashboard')!.branch).toBe('develop');
+    expect(sites.find((s) => s.name === 'poker-zeno')!.branch).toBe('master');
+    expect(sites.find((s) => s.name === 'roulette-community')!.branch).toBe('main');
+  });
+
+  it('applies overrides to the right sites independently', () => {
+    const sites = buildSitesForEnv({
+      LOCAL_PREVIEW_DASHBOARD_BRANCH: 'feature/foo',
+      LOCAL_PREVIEW_POKER_ZENO_BRANCH: 'feature/bar'
+    });
+    expect(sites.find((s) => s.name === 'dashboard')!.branch).toBe('feature/foo');
+    expect(sites.find((s) => s.name === 'poker-zeno')!.branch).toBe('feature/bar');
+    expect(sites.find((s) => s.name === 'roulette-community')!.branch).toBe('main');
+  });
+
+  it('throws if one site has an invalid override', () => {
+    expect(() =>
+      buildSitesForEnv({
+        LOCAL_PREVIEW_POKER_ZENO_BRANCH: 'master; rm -rf /'
+      })
+    ).toThrow(/Invalid branch override/);
+  });
+
+  it('returns a fresh array (does not mutate the live SITES export)', () => {
+    const len = SITES.length;
+    buildSitesForEnv({ LOCAL_PREVIEW_DASHBOARD_BRANCH: 'feature/foo' });
+    expect(SITES.length).toBe(len);
+    expect(SITES.find((s) => s.name === 'dashboard')!.branch).toBe('develop');
   });
 });


### PR DESCRIPTION
## Summary

Closes the first of three Stage-6 architectural gaps surfaced during the leg-2 live install on the operator's Mac (see leg-2 handoff §"Stage 6 findings").

The previous `branch: 'develop'` hard-code in `sites-config.ts` caused all three site deploys to abort with `fatal: couldn't find remote ref develop`, because:
- `poker-zeno` HEAD is `master` (no `develop`)
- `roulette-community` upstream default is `main` (no `develop`)
- Only the dashboard actually has a `develop` branch

This PR makes `branch` resolvable per-site at runtime via env var, with sane bake-in defaults that match observed reality.

## Changes

| File | Change |
|---|---|
| `src/sites-config.ts` | introduce `SITE_DEFAULTS` table; `resolveBranch()` reads `LOCAL_PREVIEW_<SITE>_BRANCH` env var with strict allowlist validation |
| `tests/sites-config.test.ts` | 14 net-new tests: env-var name derivation, resolveBranch happy/sad/invalid paths, buildSitesForEnv |
| `plists/com.stolution.local-preview.deploy-daemon.plist` | three new `__LOCAL_PREVIEW_<SITE>_BRANCH__` placeholders in EnvironmentVariables |
| `scripts/install.sh` | read+validate+template the three branch env vars; print resolved values |
| `README.md` | document "Per-site branch overrides" with example |

## Defaults (per Stage-6 verify)

| Site | Default branch |
|---|---|
| dashboard | `develop` (unchanged) |
| poker-zeno | `master` (was `develop`) |
| roulette-community | `main` (was `develop`) |

## Override usage

```bash
LOCAL_PREVIEW_DASHBOARD_BRANCH=feature/foo \
LOCAL_PREVIEW_POKER_ZENO_BRANCH=develop \
    ./apps/local-preview-orchestrator/scripts/install.sh
```

## Trust boundary

Branch overrides are validated at both install-time (bash regex) and runtime (TS regex) against `/^[A-Za-z0-9_./@\\-+]+$/` — the same allowlist used by `git-ops.shellEscape`. Shell-metacharacter injection attempts fail fast with a clear error.

## Evidence

- Tests: 105 passed (12 files); 14 net-new in sites-config.test.ts
- Typecheck: clean
- Lint: clean
- Build: clean
- Steward analyzers: 2 pre-existing migration-numbering medium findings on develop, both non-blocking

## Stage progression (per 6-stage DoD)

| Stage | Status |
|---|---|
| 1. Analyze | ✓ leg-1 + leg-2 handoffs + sites-config.ts surface |
| 2. Research | ✓ env-var pattern matches existing `SITE_REPO_*` convention in install.sh |
| 3. Solution | ✓ env override + bake-in defaults + strict allowlist validation |
| 4. Implement | this PR |
| 5. Test+integrate | unit tests + install.sh integration; runtime + install-time validation |
| 6. Test again | gated on PR-F + PR-G landing, then live re-install verify |

## Closes

Item-1 architectural gap (1 of 3) from `reports/multi-day-campaign-leg-2-handoff.md`.