### PR TITLE
feat(local-preview-001): supervisor wait-for-current + poll-loop backoff (PR-F)

### DIFF
--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.dashboard.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.dashboard.plist
@@ -12,6 +12,14 @@
 
   KeepAlive=true so the process is restarted by launchd whenever the deploy
   daemon SIGTERMs it after a symlink swap.
+
+  Wait-for-current shim (PR-F): on first boot, the `current` symlink does
+  not exist until the deploy daemon has run a successful build. Rather than
+  exiting non-zero (which crash-loops via KeepAlive=Crashed=true on a 10s
+  ThrottleInterval), we busy-poll for the symlink with `until ... do sleep 5`
+  and only `cd` into it once it exists. The wait is bounded only by the
+  agent eventually being booted out, which is the right shape for a
+  long-lived supervisor.
 -->
 <plist version="1.0">
 <dict>
@@ -22,7 +30,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>cd "$LOCAL_PREVIEW_INSTALL_ROOT/dashboard/current" || exit 1; echo $$ &gt; "$LOCAL_PREVIEW_INSTALL_ROOT/dashboard/pid"; exec pnpm --filter @caia-app/dashboard exec next start -p 5173</string>
+        <string>INSTALL_DIR="$LOCAL_PREVIEW_INSTALL_ROOT/dashboard"; CURRENT="$INSTALL_DIR/current"; echo "[supervisor:dashboard] waiting for $CURRENT" &gt;&amp;2; until [ -L "$CURRENT" ]; do sleep 5; done; echo "[supervisor:dashboard] symlink found; starting" &gt;&amp;2; cd "$CURRENT" || exit 1; echo $$ &gt; "$INSTALL_DIR/pid"; exec pnpm --filter @caia-app/dashboard exec next start -p 5173</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.poker-zeno.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.poker-zeno.plist
@@ -4,6 +4,8 @@
   com.stolution.local-preview.poker-zeno
   ======================================
   Site supervisor for the poker-zeno preview. Listens on http://localhost:5174.
+
+  Wait-for-current shim (PR-F): see dashboard.plist for rationale.
 -->
 <plist version="1.0">
 <dict>
@@ -14,7 +16,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>cd "$LOCAL_PREVIEW_INSTALL_ROOT/poker-zeno/current" || exit 1; echo $$ &gt; "$LOCAL_PREVIEW_INSTALL_ROOT/poker-zeno/pid"; exec pnpm preview -- --port 5174</string>
+        <string>INSTALL_DIR="$LOCAL_PREVIEW_INSTALL_ROOT/poker-zeno"; CURRENT="$INSTALL_DIR/current"; echo "[supervisor:poker-zeno] waiting for $CURRENT" &gt;&amp;2; until [ -L "$CURRENT" ]; do sleep 5; done; echo "[supervisor:poker-zeno] symlink found; starting" &gt;&amp;2; cd "$CURRENT" || exit 1; echo $$ &gt; "$INSTALL_DIR/pid"; exec pnpm preview -- --port 5174</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.roulette-community.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.roulette-community.plist
@@ -4,6 +4,8 @@
   com.stolution.local-preview.roulette-community
   ==============================================
   Site supervisor for the roulette-community preview. Listens on http://localhost:5175.
+
+  Wait-for-current shim (PR-F): see dashboard.plist for rationale.
 -->
 <plist version="1.0">
 <dict>
@@ -14,7 +16,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>cd "$LOCAL_PREVIEW_INSTALL_ROOT/roulette-community/current" || exit 1; echo $$ &gt; "$LOCAL_PREVIEW_INSTALL_ROOT/roulette-community/pid"; exec pnpm preview -- --port 5175</string>
+        <string>INSTALL_DIR="$LOCAL_PREVIEW_INSTALL_ROOT/roulette-community"; CURRENT="$INSTALL_DIR/current"; echo "[supervisor:roulette-community] waiting for $CURRENT" &gt;&amp;2; until [ -L "$CURRENT" ]; do sleep 5; done; echo "[supervisor:roulette-community] symlink found; starting" &gt;&amp;2; cd "$CURRENT" || exit 1; echo $$ &gt; "$INSTALL_DIR/pid"; exec pnpm preview -- --port 5175</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/apps/local-preview-orchestrator/src/poll-loop.ts
+++ b/apps/local-preview-orchestrator/src/poll-loop.ts
@@ -3,16 +3,27 @@
  *
  * Runs continuously inside a LaunchAgent (`com.stolution.local-preview.deploy-daemon`).
  * Every `intervalMs` (default 30s):
- *   1. For each configured site, kick off a `deploySite()` if no deploy is
- *      already in flight for that site.
+ *   1. For each configured site, check the per-site cooldown:
+ *      - if cooldownUntil > now, skip with `{status: 'cooling-down', cooldownRemainingMs: N}`
+ *      - else kick off a `deploySite()` if no deploy is already in flight
  *   2. The deploy itself does the cheap noop short-circuit (git fetch + SHA
  *      compare); we don't filter at the loop level.
- *   3. Sleep for the interval; repeat.
+ *   3. Update the failure tracker based on the deploy outcome:
+ *      - failure → increment `consecutive[site]`, set
+ *        `cooldownUntil[site] = now + min(2^N * baseMs, capMs)`
+ *      - success / noop → reset both
+ *      - locked / in-progress / cooling-down → no change
+ *   4. Sleep for the interval; repeat.
  *
  * Coalescing: deploys for the same site are serialised by the in-process
  * lock acquired inside `deploySite`; if a deploy is already running when the
  * next iteration ticks, that site is skipped this round and re-evaluated next
  * round (which always operates on the freshest origin/<branch>, so latest-wins).
+ *
+ * Backoff (PR-F): the cooldown table above prevents the tight 30s retry
+ * burn observed during Stage-6 verify when a site's build kept failing. The
+ * deploy daemon still ticks every 30s; sites in cooldown report
+ * `cooling-down` status until their backoff window elapses.
  *
  * Trust boundary: all paths and configs derive from the compile-time SITES
  * registry; no user-controllable input enters this module.
@@ -40,11 +51,35 @@ export interface PollLoopOptions {
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   /** Stop after N iterations (testability). 0 / undefined = run forever. */
   maxIterations?: number;
+  /** Backoff configuration. Defaults to base 30s, cap 30min. */
+  backoff?: BackoffOptions;
+  /** Failure tracker (test injection). */
+  failureTracker?: FailureTracker;
+  /** Clock injection for tests. */
+  now?: () => number;
 }
 
-export type IterationResult = Record<string, DeployResult | { status: 'in-progress' } | { status: 'error'; error: string }>;
+export interface BackoffOptions {
+  /** Base interval used in `min(2^N * baseMs, capMs)`. Default 30_000. */
+  baseMs?: number;
+  /** Max cooldown. Default 30 * 60_000 = 30 min. */
+  capMs?: number;
+}
+
+export interface FailureTracker {
+  consecutive: Map<string, number>;
+  cooldownUntil: Map<string, number>;
+}
+
+export type CoolingDown = { status: 'cooling-down'; cooldownRemainingMs: number };
+export type IterationResult = Record<
+  string,
+  DeployResult | { status: 'in-progress' } | { status: 'error'; error: string } | CoolingDown
+>;
 
 const DEFAULT_INTERVAL_MS = 30_000;
+const DEFAULT_BACKOFF_BASE_MS = 30_000;
+const DEFAULT_BACKOFF_CAP_MS = 30 * 60_000;
 
 const consoleLogger = {
   info: (msg: string): void => console.log(msg),
@@ -53,6 +88,25 @@ const consoleLogger = {
     else console.error(msg);
   }
 };
+
+/**
+ * Statuses that count as a failure for backoff purposes.
+ *
+ * `locked` is **not** a failure — it means another instance is in flight,
+ * which is an internal-coordination outcome unrelated to upstream health.
+ *
+ * `in-progress` is also not a failure — it means we skipped this site this
+ * iteration because we already kicked off a deploy in a prior tick that
+ * hasn't returned yet.
+ */
+const FAILURE_STATUSES: ReadonlySet<string> = new Set([
+  'build-failed',
+  'health-check-failed',
+  'rollback-failed',
+  'disk-full',
+  'aborted',
+  'error'
+]);
 
 /**
  * Sleep for `ms` milliseconds, or until `signal` is aborted (whichever first).
@@ -80,7 +134,69 @@ export function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 /**
- * Run a single iteration: kick off deploys for any sites not already in flight.
+ * Compute the cooldown duration after the Nth consecutive failure.
+ *
+ * For N=1: `2^1 * baseMs` capped (i.e., 60s under defaults).
+ * For N=2: `2^2 * baseMs` capped (120s).
+ * ...
+ * For large N: `capMs`.
+ *
+ * For N=0 (no failures yet): 0.
+ */
+export function computeBackoffMs(
+  consecutiveFailures: number,
+  opts: { baseMs?: number; capMs?: number } = {}
+): number {
+  if (consecutiveFailures <= 0) return 0;
+  const baseMs = opts.baseMs ?? DEFAULT_BACKOFF_BASE_MS;
+  const capMs = opts.capMs ?? DEFAULT_BACKOFF_CAP_MS;
+  // 2^N * baseMs, but guard against overflow at N>50 by capping the exponent.
+  const safeN = Math.min(consecutiveFailures, 30);
+  const raw = Math.pow(2, safeN) * baseMs;
+  return Math.min(raw, capMs);
+}
+
+/**
+ * Create a fresh failure tracker. Each call returns a new pair of empty maps.
+ */
+export function createFailureTracker(): FailureTracker {
+  return {
+    consecutive: new Map(),
+    cooldownUntil: new Map()
+  };
+}
+
+/**
+ * Update the failure tracker for one site based on its iteration outcome.
+ * Pure-ish (mutates the tracker) — exported for testability.
+ */
+export function updateFailureTracker(
+  tracker: FailureTracker,
+  siteName: string,
+  outcome: { status: string },
+  now: number,
+  backoff: BackoffOptions = {}
+): void {
+  const status = outcome.status;
+  if (status === 'success' || status === 'noop') {
+    tracker.consecutive.delete(siteName);
+    tracker.cooldownUntil.delete(siteName);
+    return;
+  }
+  if (FAILURE_STATUSES.has(status)) {
+    const prev = tracker.consecutive.get(siteName) ?? 0;
+    const next = prev + 1;
+    tracker.consecutive.set(siteName, next);
+    const cooldownMs = computeBackoffMs(next, backoff);
+    tracker.cooldownUntil.set(siteName, now + cooldownMs);
+    return;
+  }
+  // 'locked', 'in-progress', 'cooling-down', or anything else: no-op
+}
+
+/**
+ * Run a single iteration: kick off deploys for any sites not already in flight
+ * and not currently in their backoff cooldown.
  *
  * Site-level concurrency is enforced inside deploySite() (it returns
  * `{status: 'locked'}` if another invocation is in flight). We additionally
@@ -89,10 +205,15 @@ export function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
  */
 export async function pollIteration(
   inFlight: Set<string>,
-  opts: Pick<PollLoopOptions, 'sites' | 'deployOptions' | 'deployFn' | 'logger'>
+  opts: Pick<
+    PollLoopOptions,
+    'sites' | 'deployOptions' | 'deployFn' | 'logger' | 'failureTracker' | 'backoff' | 'now'
+  >
 ): Promise<IterationResult> {
   const logger = opts.logger ?? consoleLogger;
   const deployFn = opts.deployFn ?? deploySite;
+  const tracker = opts.failureTracker;
+  const now = opts.now ?? Date.now;
   const result: IterationResult = {};
 
   await Promise.all(
@@ -101,14 +222,32 @@ export async function pollIteration(
         result[site.name] = { status: 'in-progress' };
         return;
       }
+
+      // Backoff gate: skip if we're still in the cooldown window from prior failures.
+      if (tracker) {
+        const cooldownUntil = tracker.cooldownUntil.get(site.name) ?? 0;
+        const remaining = cooldownUntil - now();
+        if (remaining > 0) {
+          result[site.name] = { status: 'cooling-down', cooldownRemainingMs: remaining };
+          return;
+        }
+      }
+
       inFlight.add(site.name);
       try {
         const r = await deployFn(site, opts.deployOptions);
         result[site.name] = r;
+        if (tracker) {
+          updateFailureTracker(tracker, site.name, r, now(), opts.backoff);
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.error(`[poll-loop] deploy ${site.name} threw: ${msg}`);
-        result[site.name] = { status: 'error', error: msg };
+        const errorOutcome = { status: 'error' as const, error: msg };
+        result[site.name] = errorOutcome;
+        if (tracker) {
+          updateFailureTracker(tracker, site.name, errorOutcome, now(), opts.backoff);
+        }
       } finally {
         inFlight.delete(site.name);
       }
@@ -127,6 +266,7 @@ export async function runPollLoop(opts: PollLoopOptions): Promise<void> {
   const logger = opts.logger ?? consoleLogger;
   const inFlight = new Set<string>();
   const maxIterations = opts.maxIterations ?? 0;
+  const failureTracker = opts.failureTracker ?? createFailureTracker();
 
   let iter = 0;
   logger.info(
@@ -142,6 +282,9 @@ export async function runPollLoop(opts: PollLoopOptions): Promise<void> {
         sites: opts.sites,
         deployOptions: opts.deployOptions,
         ...(opts.deployFn !== undefined ? { deployFn: opts.deployFn } : {}),
+        ...(opts.backoff !== undefined ? { backoff: opts.backoff } : {}),
+        ...(opts.now !== undefined ? { now: opts.now } : {}),
+        failureTracker,
         logger
       });
     } catch (err) {

--- a/apps/local-preview-orchestrator/tests/poll-loop.test.ts
+++ b/apps/local-preview-orchestrator/tests/poll-loop.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runPollLoop, pollIteration, defaultSleep } from '../src/poll-loop';
+import {
+  runPollLoop,
+  pollIteration,
+  defaultSleep,
+  computeBackoffMs,
+  createFailureTracker,
+  updateFailureTracker
+} from '../src/poll-loop';
 import type { SiteConfig } from '../src/sites-config';
 import type { DeployOptions, DeployResult } from '../src/deploy';
 
@@ -92,6 +99,47 @@ describe('pollIteration', () => {
     });
     expect(result.a).toEqual({ status: 'error', error: 'boom' });
   });
+
+  it('skips sites in cooldown without invoking deployFn', async () => {
+    const sites = [fakeSite('a', 1), fakeSite('b', 2)];
+    const tracker = createFailureTracker();
+    const now = vi.fn().mockReturnValue(1_000_000);
+    tracker.cooldownUntil.set('a', 1_000_500); // 500ms remaining
+    const deployFn = vi.fn(async (): Promise<DeployResult> => ({
+      status: 'success',
+      sha: 'x',
+      durationMs: 1,
+      healthCheckMs: 0
+    }));
+    const result = await pollIteration(new Set(), {
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn,
+      failureTracker: tracker,
+      now
+    });
+    expect(deployFn).toHaveBeenCalledTimes(1);
+    expect(deployFn.mock.calls[0]![0]!.name).toBe('b');
+    expect(result.a).toEqual({ status: 'cooling-down', cooldownRemainingMs: 500 });
+    expect(result.b).toEqual({ status: 'success', sha: 'x', durationMs: 1, healthCheckMs: 0 });
+  });
+
+  it('runs the site if cooldown has just elapsed', async () => {
+    const sites = [fakeSite('a', 1)];
+    const tracker = createFailureTracker();
+    const now = vi.fn().mockReturnValue(1_000_000);
+    tracker.cooldownUntil.set('a', 1_000_000); // exactly elapsed
+    const deployFn = vi.fn(async (): Promise<DeployResult> => ({ status: 'noop', sha: 'x' }));
+    const result = await pollIteration(new Set(), {
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn,
+      failureTracker: tracker,
+      now
+    });
+    expect(deployFn).toHaveBeenCalledTimes(1);
+    expect(result.a).toEqual({ status: 'noop', sha: 'x' });
+  });
 });
 
 describe('runPollLoop', () => {
@@ -136,7 +184,6 @@ describe('runPollLoop', () => {
       abortSignal: ctrl.signal,
       intervalMs: 1
     });
-    // Should have stopped after the abort fired during sleep
     expect(deployFn.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
@@ -162,5 +209,221 @@ describe('runPollLoop', () => {
         logger: { info: () => undefined, error: () => undefined }
       })
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('computeBackoffMs', () => {
+  it('returns 0 for 0 consecutive failures', () => {
+    expect(computeBackoffMs(0)).toBe(0);
+  });
+
+  it('returns 0 for negative consecutive failures', () => {
+    expect(computeBackoffMs(-1)).toBe(0);
+  });
+
+  it('doubles each step under defaults (base=30s)', () => {
+    expect(computeBackoffMs(1)).toBe(60_000);
+    expect(computeBackoffMs(2)).toBe(120_000);
+    expect(computeBackoffMs(3)).toBe(240_000);
+    expect(computeBackoffMs(4)).toBe(480_000);
+    expect(computeBackoffMs(5)).toBe(960_000);
+  });
+
+  it('caps at 30 minutes after enough failures', () => {
+    expect(computeBackoffMs(6)).toBe(30 * 60_000); // 2^6 * 30s = 1920s, capped at 1800s
+    expect(computeBackoffMs(10)).toBe(30 * 60_000);
+    expect(computeBackoffMs(100)).toBe(30 * 60_000);
+  });
+
+  it('honours custom baseMs', () => {
+    expect(computeBackoffMs(1, { baseMs: 1000 })).toBe(2000);
+    expect(computeBackoffMs(2, { baseMs: 1000 })).toBe(4000);
+  });
+
+  it('honours custom capMs', () => {
+    expect(computeBackoffMs(10, { capMs: 5000 })).toBe(5000);
+  });
+
+  it('does not overflow on huge consecutive counts', () => {
+    expect(Number.isFinite(computeBackoffMs(1000))).toBe(true);
+    expect(computeBackoffMs(1000)).toBe(30 * 60_000);
+  });
+});
+
+describe('updateFailureTracker', () => {
+  it('clears state on success', () => {
+    const tracker = createFailureTracker();
+    tracker.consecutive.set('a', 3);
+    tracker.cooldownUntil.set('a', 12345);
+    updateFailureTracker(tracker, 'a', { status: 'success' }, Date.now());
+    expect(tracker.consecutive.has('a')).toBe(false);
+    expect(tracker.cooldownUntil.has('a')).toBe(false);
+  });
+
+  it('clears state on noop', () => {
+    const tracker = createFailureTracker();
+    tracker.consecutive.set('a', 2);
+    tracker.cooldownUntil.set('a', 9999);
+    updateFailureTracker(tracker, 'a', { status: 'noop' }, Date.now());
+    expect(tracker.consecutive.has('a')).toBe(false);
+    expect(tracker.cooldownUntil.has('a')).toBe(false);
+  });
+
+  it('increments consecutive on build-failed', () => {
+    const tracker = createFailureTracker();
+    updateFailureTracker(tracker, 'a', { status: 'build-failed' }, 1000);
+    expect(tracker.consecutive.get('a')).toBe(1);
+    expect(tracker.cooldownUntil.get('a')).toBe(1000 + 60_000);
+
+    updateFailureTracker(tracker, 'a', { status: 'build-failed' }, 60_500);
+    expect(tracker.consecutive.get('a')).toBe(2);
+    expect(tracker.cooldownUntil.get('a')).toBe(60_500 + 120_000);
+  });
+
+  it('increments on health-check-failed', () => {
+    const tracker = createFailureTracker();
+    updateFailureTracker(tracker, 'a', { status: 'health-check-failed' }, 1000);
+    expect(tracker.consecutive.get('a')).toBe(1);
+  });
+
+  it('increments on rollback-failed, disk-full, aborted, error', () => {
+    const tracker = createFailureTracker();
+    for (const status of ['rollback-failed', 'disk-full', 'aborted', 'error']) {
+      updateFailureTracker(tracker, 'a', { status }, 0);
+    }
+    expect(tracker.consecutive.get('a')).toBe(4);
+  });
+
+  it('does NOT count locked as a failure', () => {
+    const tracker = createFailureTracker();
+    tracker.consecutive.set('a', 2);
+    updateFailureTracker(tracker, 'a', { status: 'locked' }, 1000);
+    expect(tracker.consecutive.get('a')).toBe(2); // unchanged
+  });
+
+  it('does NOT count in-progress as a failure', () => {
+    const tracker = createFailureTracker();
+    tracker.consecutive.set('a', 1);
+    updateFailureTracker(tracker, 'a', { status: 'in-progress' }, 1000);
+    expect(tracker.consecutive.get('a')).toBe(1);
+  });
+
+  it('does NOT count cooling-down as a failure', () => {
+    const tracker = createFailureTracker();
+    updateFailureTracker(tracker, 'a', { status: 'cooling-down' }, 1000);
+    expect(tracker.consecutive.has('a')).toBe(false);
+  });
+
+  it('honours custom backoff options', () => {
+    const tracker = createFailureTracker();
+    updateFailureTracker(
+      tracker,
+      'a',
+      { status: 'build-failed' },
+      1000,
+      { baseMs: 1000, capMs: 10_000 }
+    );
+    expect(tracker.cooldownUntil.get('a')).toBe(1000 + 2000);
+  });
+
+  it('tracks each site independently', () => {
+    const tracker = createFailureTracker();
+    updateFailureTracker(tracker, 'a', { status: 'build-failed' }, 1000);
+    updateFailureTracker(tracker, 'b', { status: 'success' }, 1000);
+    expect(tracker.consecutive.get('a')).toBe(1);
+    expect(tracker.consecutive.has('b')).toBe(false);
+  });
+});
+
+describe('runPollLoop with backoff (integration)', () => {
+  it('skips a site that is in cooldown but still ticks others', async () => {
+    const sites = [fakeSite('a', 1), fakeSite('b', 2)];
+
+    let nowVal = 1_000_000;
+    const now = (): number => nowVal;
+    const tracker = createFailureTracker();
+
+    // Two iterations: a always fails, b always succeeds.
+    let iter = 0;
+    const deployFn = vi.fn(async (s: SiteConfig): Promise<DeployResult> => {
+      iter += 1;
+      if (s.name === 'a') {
+        return { status: 'build-failed', sha: 'x', error: 'fail' };
+      }
+      return { status: 'success', sha: `sha-b-${iter}`, durationMs: 1, healthCheckMs: 0 };
+    });
+
+    const seen: Array<Record<string, string>> = [];
+    const onIteration = (r: Record<string, { status: string }>): void => {
+      const summary: Record<string, string> = {};
+      for (const [k, v] of Object.entries(r)) summary[k] = v.status;
+      seen.push(summary);
+      // Clock ticks 10s between iterations.
+      nowVal += 10_000;
+    };
+
+    const sleep = vi.fn(async () => undefined);
+    await runPollLoop({
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn,
+      onIteration,
+      sleep,
+      intervalMs: 1,
+      maxIterations: 4,
+      failureTracker: tracker,
+      now
+    });
+
+    // iter1: both run. a fails (cooldown=60s), b succeeds.
+    // iter2 (now=1010s): a's cooldown is until 1060s — still in cooldown. b runs again.
+    // iter3 (now=1020s): a still in cooldown. b runs.
+    // iter4 (now=1030s): a still in cooldown (until 1060s). b runs.
+    expect(seen[0]).toEqual({ a: 'build-failed', b: 'success' });
+    expect(seen[1]?.a).toBe('cooling-down');
+    expect(seen[1]?.b).toBe('success');
+    expect(seen[2]?.a).toBe('cooling-down');
+    expect(seen[3]?.a).toBe('cooling-down');
+
+    // Across 4 iterations, a was attempted only once; b was attempted 4 times.
+    expect(deployFn).toHaveBeenCalledTimes(5); // 1 (a, iter1) + 4 (b, iter1-4)
+  });
+
+  it('resets cooldown after a successful deploy', async () => {
+    const sites = [fakeSite('a', 1)];
+
+    let nowVal = 1_000_000;
+    const tracker = createFailureTracker();
+
+    let iter = 0;
+    const deployFn = vi.fn(async (): Promise<DeployResult> => {
+      iter += 1;
+      // 1st call fails; 2nd call succeeds.
+      if (iter === 1) return { status: 'build-failed', sha: 'x', error: 'fail' };
+      return { status: 'success', sha: 'y', durationMs: 1, healthCheckMs: 0 };
+    });
+
+    const sleep = vi.fn(async () => undefined);
+
+    // Iter 1 — fail. Iter 2 — skipped (cooldown). Iter 3 — clock advanced past cooldown, retry.
+    const advanceClock = (advanceMs: number): void => {
+      nowVal += advanceMs;
+    };
+
+    await runPollLoop({
+      sites,
+      deployOptions: dummyDeployOpts,
+      deployFn,
+      onIteration: () => advanceClock(30_000), // each iteration advances 30s; iter1=run, iter2=cooldown(60s remaining), iter3=clock=cooldownUntil-->run
+      sleep,
+      intervalMs: 1,
+      maxIterations: 3,
+      failureTracker: tracker,
+      now: () => nowVal
+    });
+
+    expect(deployFn).toHaveBeenCalledTimes(2);
+    expect(tracker.consecutive.has('a')).toBe(false); // reset on success
+    expect(tracker.cooldownUntil.has('a')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes the second + third Stage-6 architectural gaps surfaced during leg-2 live install.

### Gap 2 — supervisor crash-loop on missing `current` symlink

**Was:** `cd $LOCAL_PREVIEW_INSTALL_ROOT/<site>/current || exit 1` exits non-zero before the first successful deploy ever runs. With `KeepAlive: { Crashed: true }` and `ThrottleInterval: 10`, the supervisor respawns every ~10s.

**Now:** `until [ -L $CURRENT ]; do sleep 5; done` patiently waits until the deploy daemon creates the symlink. Single stderr line at start + on detection for log visibility.

### Gap 3 — tight retry on repeated build failures

**Was:** 30s poll loop kicks off a fresh build immediately on the next tick after a failure. The leg-2 dashboard build took ~13 min and failed; the next iteration tried again 30s later. CPU + disk-I/O burn.

**Now:** Per-site exponential cooldown `min(2^N * 30s, 30min)` after N consecutive failures. Reset to 0 on success/noop.

| N consecutive failures | Cooldown |
|---|---|
| 1 | 60s |
| 2 | 120s |
| 3 | 240s |
| 4 | 480s |
| 5 | 960s |
| 6+ | 1800s (cap) |

## Failure-classification rule

Statuses counted as failures for backoff:
`build-failed`, `health-check-failed`, `rollback-failed`, `disk-full`, `aborted`, `error`.

Statuses NOT counted (they're coordination outcomes, not upstream-health signals):
`success`, `noop` (reset counter), `locked`, `in-progress`, `cooling-down` (no-op).

## Changes

| File | Change |
|---|---|
| `src/poll-loop.ts` | new `computeBackoffMs` / `createFailureTracker` / `updateFailureTracker`; `failureTracker` + `now` injection threaded through `pollIteration` + `runPollLoop`; new `cooling-down` outcome |
| `tests/poll-loop.test.ts` | 21 net-new tests: backoff math, tracker mutation rules, pollIteration cooldown skip, multi-iteration integration |
| `plists/com.stolution.local-preview.{dashboard,poker-zeno,roulette-community}.plist` | prepend `until [ -L $CURRENT ]; do sleep 5; done` shim |

## Evidence

- Tests: 126 passed (105 prior + 21 new)
- `plutil -lint` clean for all 5 plists
- Typecheck: clean
- Lint: clean
- Build: clean
- Steward analyzers: 2 pre-existing migration-numbering medium findings on develop, non-blocking

## Stage progression (per 6-stage DoD)

| Stage | Status |
|---|---|
| 1. Analyze | ✓ leg-2 handoff §"Stage 6 findings" + poll-loop.ts surface |
| 2. Research | ✓ launchd KeepAlive semantics; cooldown math vs. operator-suggested `2^N * 30s, 30min cap` |
| 3. Solution | ✓ wait-for-current shim + per-site failure tracker + cooldown gate |
| 4. Implement | this PR |
| 5. Test+integrate | unit tests + plist lint + integration scenario in poll-loop.test.ts |
| 6. Test again | gated on PR-G landing, then live re-install verify |

## Closes

Item-1 architectural gaps (2 and 3 of 3) from `reports/multi-day-campaign-leg-2-handoff.md`. After PR-G merges and Stage-6 re-verify passes on Mac, item 1 (Local-Preview-Deploys) is fully done.