### PR TITLE
feat(mentor-phase0-001): caia-mentor CLI + PRMerged emit-point (PR-γ)

### DIFF
--- a/apps/local-preview-orchestrator/package.json
+++ b/apps/local-preview-orchestrator/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@chiefaia/logger": "workspace:*",
+    "@chiefaia/mentor-event-bus": "workspace:*",
     "nanoid": "^3.3.7",
     "pino": "^10.3.1"
   },

--- a/apps/local-preview-orchestrator/src/cli.ts
+++ b/apps/local-preview-orchestrator/src/cli.ts
@@ -10,6 +10,13 @@
  *
  * Wired into `package.json#bin.local-preview` → `dist/src/cli.js`. The PR-D
  * LaunchAgent plists invoke this binary with the appropriate subcommand.
+ *
+ * Mentor integration (PR-γ): if a Mentor event-bus DB path is reachable
+ * (`CAIA_EVENT_BUS_DB_PATH` env var defaults to a Mac path), the CLI
+ * constructs a Mentor `Client` and threads `mentorEmit` through deploy
+ * options so successful deploys emit `PRMerged` events. The Client is
+ * created lazily and silently no-ops if the DB can't be opened —
+ * preserves the producer-non-blocking invariant.
  */
 
 import { homedir } from 'node:os';
@@ -20,6 +27,11 @@ import { startDashboard } from './status-dashboard.js';
 import { deploySite } from './deploy.js';
 import { SITES, getSiteConfig } from './sites-config.js';
 import { buildStatus } from './status-dashboard.js';
+import {
+  Client as MentorClient,
+  type EventType,
+  type PayloadOf
+} from '@chiefaia/mentor-event-bus';
 
 const DEFAULT_INSTALL_ROOT = join(
   homedir(),
@@ -30,11 +42,55 @@ const DEFAULT_INSTALL_ROOT = join(
 );
 const DEFAULT_BUILD_WORKSPACE = '/private/tmp/local-preview-build';
 
-function deployOptions(): { installRoot: string; buildWorkspaceRoot: string } {
-  return {
+const DEFAULT_MENTOR_DB_PATH = join(
+  homedir(),
+  'Library',
+  'Application Support',
+  'caia',
+  'events',
+  'events.sqlite'
+);
+
+function deployOptions(): {
+  installRoot: string;
+  buildWorkspaceRoot: string;
+  mentorEmit?: (
+    event: 'PRMerged',
+    payload: { prNumber: number; sha: string; branch: string; repo?: string; previousSha?: string }
+  ) => void;
+} {
+  const base = {
     installRoot: process.env['LOCAL_PREVIEW_INSTALL_ROOT'] ?? DEFAULT_INSTALL_ROOT,
     buildWorkspaceRoot: process.env['LOCAL_PREVIEW_BUILD_WORKSPACE'] ?? DEFAULT_BUILD_WORKSPACE
   };
+  const mentor = tryOpenMentorClient();
+  if (!mentor) return base;
+  // Adapt Mentor's typed emit to deploy.ts's narrowly-typed callback.
+  const mentorEmit = <T extends EventType>(type: T, payload: PayloadOf<T>): void => {
+    mentor.emit(type, payload);
+  };
+  return { ...base, mentorEmit };
+}
+
+/**
+ * Try to open a Mentor client for the configured DB path. Returns undefined
+ * (and logs nothing more than a single warning) if the path is unset or
+ * the open fails — emit-points must NEVER block deploys on Mentor's
+ * reliability.
+ */
+function tryOpenMentorClient(): MentorClient | undefined {
+  const dbPath = process.env['CAIA_EVENT_BUS_DB_PATH'] ?? DEFAULT_MENTOR_DB_PATH;
+  // Setting CAIA_EVENT_BUS_DISABLED=1 turns mentor emit off entirely (tests + opt-out).
+  if (process.env['CAIA_EVENT_BUS_DISABLED'] === '1') return undefined;
+  try {
+    return new MentorClient({
+      dbPath,
+      processName: 'local-preview-orchestrator'
+    });
+  } catch (e) {
+    console.warn(`[local-preview] mentor client open failed (continuing without emit): ${String(e)}`);
+    return undefined;
+  }
 }
 
 async function main(): Promise<void> {
@@ -97,7 +153,9 @@ async function main(): Promise<void> {
           '  Defaults can be overridden via env:\n' +
           '    LOCAL_PREVIEW_INSTALL_ROOT      — per-site install root\n' +
           '    LOCAL_PREVIEW_BUILD_WORKSPACE   — ephemeral build worktrees\n' +
-          '    LOCAL_PREVIEW_DASHBOARD_PORT    — status dashboard port (default 5170)'
+          '    LOCAL_PREVIEW_DASHBOARD_PORT    — status dashboard port (default 5170)\n' +
+          '    CAIA_EVENT_BUS_DB_PATH          — mentor events.sqlite path\n' +
+          '    CAIA_EVENT_BUS_DISABLED=1       — disable mentor emit'
       );
       process.exit(2);
   }

--- a/apps/local-preview-orchestrator/src/deploy.ts
+++ b/apps/local-preview-orchestrator/src/deploy.ts
@@ -84,6 +84,17 @@ export interface DeployOptions {
 
   /** Force a deploy even when SHAs match. */
   force?: boolean;
+
+  /**
+   * Optional emit callback for the Mentor event bus. When provided and a
+   * deploy succeeds, the deploy pipeline calls
+   * `mentorEmit('PRMerged', {prNumber: 0, sha, branch, repo})`. Must never
+   * throw — the pipeline expects fire-and-forget semantics.
+   *
+   * Defaults to undefined (no-op). PR-γ wires this in cli.ts via a Mentor
+   * `Client` instance.
+   */
+  mentorEmit?: (event: 'PRMerged', payload: { prNumber: number; sha: string; branch: string; repo?: string; previousSha?: string }) => void;
 }
 
 export type DeployResult =
@@ -180,7 +191,8 @@ export async function deploySite(site: SiteConfig, opts: DeployOptions): Promise
     restartProcess = defaultRestartProcess,
     acquireSiteLock = defaultAcquireSiteLock,
     logger = consoleLogger,
-    force = false
+    force = false,
+    mentorEmit
   } = opts;
 
   const sitePath = resolveSitePath(installRoot, site.name);
@@ -475,6 +487,23 @@ export async function deploySite(site: SiteConfig, opts: DeployOptions): Promise
     logger.info(
       `[${site.name}] deployed ${targetSha} in ${Date.now() - startedAt}ms (health ${healthCheckMs}ms)`
     );
+
+    // Mentor emit (PR-γ): fire-and-forget. The PRMerged event is the
+    // best Phase-0 proxy for "a new SHA on origin/<branch> was deployed"
+    // since the orchestrator doesn't yet have direct webhook access.
+    if (mentorEmit) {
+      try {
+        mentorEmit('PRMerged', {
+          prNumber: 0, // unknown at deploy time; orchestrator may enrich later
+          sha: targetSha,
+          branch: site.branch,
+          repo: site.repo,
+          ...(previousSha !== undefined ? { previousSha } : {})
+        });
+      } catch (e) {
+        logger.error(`[${site.name}] mentorEmit threw (ignored): ${e}`);
+      }
+    }
 
     const successResult: DeployResult = {
       status: 'success',

--- a/apps/local-preview-orchestrator/tests/deploy.test.ts
+++ b/apps/local-preview-orchestrator/tests/deploy.test.ts
@@ -166,6 +166,111 @@ describe('deploySite — happy path', () => {
     if (result.status !== 'noop') return;
     expect(result.sha).toBe(SHA);
   });
+
+  it('calls mentorEmit on successful deploy with PRMerged + sha + branch + repo', async () => {
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const restartProcess = vi.fn(async () => undefined);
+    const healthChecker = vi.fn(async () => ({ ok: true, statusCode: 200, responseTime: 5 }));
+    const mentorEmit = vi.fn();
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        restartProcess,
+        healthChecker,
+        healthCheckMaxAttempts: 1,
+        healthCheckInitialDelayMs: 1,
+        mentorEmit
+      }
+    );
+
+    expect(result.status).toBe('success');
+    expect(mentorEmit).toHaveBeenCalledTimes(1);
+    const [eventType, payload] = mentorEmit.mock.calls[0]!;
+    expect(eventType).toBe('PRMerged');
+    expect(payload.sha).toBe(SHA);
+    expect(payload.branch).toBe('develop');
+    expect(payload.repo).toBe(repoPath);
+    expect(payload.prNumber).toBe(0); // unknown at deploy time
+  });
+
+  it('does NOT call mentorEmit on noop deploys', async () => {
+    // Pre-populate sitePath with current symlink at SHA so noop fires.
+    const sitePath = resolveSitePath(installRoot, baseSite.name);
+    mkdirSync(sitePath, { recursive: true });
+    mkdirSync(join(sitePath, 'builds', SHA), { recursive: true });
+    const { symlinkSync } = await import('node:fs');
+    symlinkSync(`builds/${SHA}`, join(sitePath, 'current'), 'dir');
+
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const mentorEmit = vi.fn();
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        mentorEmit
+      }
+    );
+
+    expect(result.status).toBe('noop');
+    expect(mentorEmit).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call mentorEmit on build failure', async () => {
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => failShell(1)) as unknown as ShellRunner;
+    const mentorEmit = vi.fn();
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        mentorEmit
+      }
+    );
+
+    expect(result.status).toBe('build-failed');
+    expect(mentorEmit).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by mentorEmit (logs and continues)', async () => {
+    const { gitOps } = makeStubGitOps(SHA);
+    const shellRunner: ShellRunner = vi.fn(async () => okShell()) as unknown as ShellRunner;
+    const mentorEmit = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const errorLogger = { info: vi.fn(), error: vi.fn() };
+
+    const result = await deploySite(
+      { ...baseSite, repo: repoPath },
+      {
+        installRoot,
+        buildWorkspaceRoot,
+        gitOps,
+        shellRunner,
+        restartProcess: async () => undefined,
+        healthChecker: async () => ({ ok: true, statusCode: 200, responseTime: 1 }),
+        healthCheckMaxAttempts: 1,
+        healthCheckInitialDelayMs: 1,
+        logger: errorLogger,
+        mentorEmit
+      }
+    );
+    // Deploy still succeeds despite mentorEmit throwing.
+    expect(result.status).toBe('success');
+    expect(errorLogger.error).toHaveBeenCalledWith(expect.stringContaining('mentorEmit threw'));
+  });
 });
 
 describe('deploySite — failure paths', () => {

--- a/packages/mentor-event-bus/package.json
+++ b/packages/mentor-event-bus/package.json
@@ -7,6 +7,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-mentor": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/mentor-event-bus/src/cli.ts
+++ b/packages/mentor-event-bus/src/cli.ts
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * CLI entrypoint for the Mentor event bus.
+ *
+ * Subcommands:
+ *   tail [--type <T>] [--correlation <id>] [--since <offset>] [--interval <ms>]
+ *     Live-tail the events.sqlite. Polls every `interval` ms (default 1000).
+ *
+ *   record-correction "<text>" [--context "<ctx>"] [--mode manual|regex|llm]
+ *     Emit OperatorCorrection. The first positional arg is the correction
+ *     text; --context lets the operator attach the chat-message that
+ *     prompted the correction.
+ *
+ *   serve [--port <P>] [--host <H>]
+ *     Start the HTTP server (cross-machine ingestion). Used by the
+ *     LaunchAgent in PR-δ.
+ *
+ *   count [--type <T>] [--since-iso <ISO>]
+ *     Print a one-line JSON count. Useful for status dashboards / CI checks.
+ *
+ * The events.sqlite path defaults to:
+ *   ${LOCAL_PREVIEW_INSTALL_ROOT or $HOME}/Library/Application Support/caia/events/events.sqlite
+ *
+ * Override via $CAIA_EVENT_BUS_DB_PATH (also used by the LaunchAgent in PR-δ).
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { Client } from './client.js';
+import { startServer } from './server.js';
+import { loadSecret } from './auth.js';
+import { openDatabase, queryEvents } from './sqlite.js';
+import type { EmittedEvent } from './types.js';
+import type { OperatorCorrectionPayload } from './types.js';
+
+const DEFAULT_DB_PATH = join(
+  homedir(),
+  'Library',
+  'Application Support',
+  'caia',
+  'events',
+  'events.sqlite'
+);
+
+function defaultDbPath(): string {
+  return process.env['CAIA_EVENT_BUS_DB_PATH'] ?? DEFAULT_DB_PATH;
+}
+
+interface Argv {
+  positional: string[];
+  flags: Record<string, string>;
+}
+
+function parseArgs(argv: string[]): Argv {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (token.startsWith('--')) {
+      const key = token.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = '1';
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { positional, flags };
+}
+
+async function tail(args: Argv): Promise<void> {
+  const dbPath = args.flags['db'] ?? defaultDbPath();
+  const interval = Number(args.flags['interval'] ?? 1000);
+  const filterType = args.flags['type'];
+  const filterCorrelation = args.flags['correlation'];
+  let lastOffset = Number(args.flags['since'] ?? 0);
+
+  const db = openDatabase(dbPath, undefined, true);
+  console.log(`[tail] watching ${dbPath} (interval=${interval}ms, since=${lastOffset})`);
+  let aborted = false;
+  process.on('SIGINT', () => {
+    aborted = true;
+  });
+  process.on('SIGTERM', () => {
+    aborted = true;
+  });
+
+  while (!aborted) {
+    const opts: Parameters<typeof queryEvents>[1] = {
+      sinceOffset: lastOffset,
+      limit: 1000,
+      order: 'asc'
+    };
+    if (filterType) opts.eventType = filterType;
+    if (filterCorrelation) opts.correlationId = filterCorrelation;
+
+    const rows = queryEvents(db, opts);
+    for (const row of rows) {
+      printRow(row);
+      lastOffset = Math.max(lastOffset, row.ingest_offset);
+    }
+    await sleep(interval);
+  }
+  db.close();
+}
+
+function printRow(row: ReturnType<typeof queryEvents>[number]): void {
+  const summary = {
+    offset: row.ingest_offset,
+    type: row.event_type,
+    at: row.emitted_at,
+    host: row.hostname,
+    proc: row.process_name,
+    correlation: row.correlation_id,
+    parent: row.parent_event_id,
+    schemaVersion: row.schema_version,
+    validation: row.validation_failed === 1 ? 'failed' : 'ok',
+    payload: safeParse(row.payload_json)
+  };
+  console.log(JSON.stringify(summary));
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function recordCorrection(args: Argv): Promise<void> {
+  const text = args.positional[0];
+  if (!text) {
+    console.error('usage: caia-mentor record-correction "<text>" [--context "<ctx>"] [--mode manual|regex|llm]');
+    process.exit(2);
+  }
+
+  const dbPath = args.flags['db'] ?? defaultDbPath();
+  const mode = args.flags['mode'];
+  const detectionMode: 'manual' | 'regex' | 'llm' =
+    mode === 'regex' || mode === 'llm' ? mode : 'manual';
+
+  const client = new Client({
+    dbPath,
+    processName: 'caia-mentor-cli'
+  });
+  const payload: OperatorCorrectionPayload = {
+    correctionText: text,
+    detectionMode
+  };
+  const ctx = args.flags['context'];
+  if (ctx) payload.context = ctx;
+  const id = client.emit('OperatorCorrection', payload);
+  client.close();
+
+  if (id === null) {
+    console.error('emit returned null — see warnings above');
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ ok: true, id, mode: detectionMode }));
+}
+
+async function serve(args: Argv): Promise<void> {
+  const dbPath = args.flags['db'] ?? defaultDbPath();
+  const host = args.flags['host'] ?? process.env['CAIA_EVENT_BUS_BIND'] ?? '127.0.0.1';
+  const port = Number(args.flags['port'] ?? process.env['CAIA_EVENT_BUS_PORT'] ?? 5180);
+  const secret = loadSecret();
+  const db = openDatabase(dbPath, undefined, true);
+
+  const running = await startServer({ db, host, port, secret });
+  const stop = (): void => {
+    running.close().then(() => {
+      db.close();
+      process.exit(0);
+    });
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+  await new Promise<void>(() => undefined);
+}
+
+function count(args: Argv): void {
+  const dbPath = args.flags['db'] ?? defaultDbPath();
+  const eventType = args.flags['type'];
+  const sinceIso = args.flags['since-iso'];
+  const db = openDatabase(dbPath, undefined, true);
+  const opts: Parameters<typeof queryEvents>[1] = { limit: 1 };
+  if (eventType) opts.eventType = eventType;
+  if (sinceIso) opts.sinceIso = sinceIso;
+  // Use a quick aggregate via SELECT COUNT(*) by re-using countEvents from sqlite.
+  // We avoid importing countEvents to keep the CLI module bundle small;
+  // queryEvents+limit:1 + a separate COUNT scan would do, but the counter
+  // is nicer.
+  const rows: EmittedEvent[] = [];
+  for (const row of queryEvents(db, { ...opts, limit: 1 })) {
+    rows.push({
+      id: row.id,
+      type: row.event_type,
+      schemaVersion: row.schema_version,
+      correlationId: row.correlation_id,
+      parentEventId: row.parent_event_id,
+      emittedAt: row.emitted_at,
+      hostname: row.hostname,
+      processName: row.process_name,
+      payload: null,
+      validationFailed: row.validation_failed === 1,
+      ingestOffset: row.ingest_offset
+    });
+  }
+  // Aggregate count via SQL.
+  const where: string[] = [];
+  const params: Record<string, string | number> = {};
+  if (eventType) {
+    where.push('event_type = @eventType');
+    params['eventType'] = eventType;
+  }
+  if (sinceIso) {
+    where.push('emitted_at >= @sinceIso');
+    params['sinceIso'] = sinceIso;
+  }
+  const sql = `SELECT COUNT(*) AS n FROM events ${where.length ? 'WHERE ' + where.join(' AND ') : ''}`;
+  const r = db.prepare(sql).get(params) as { n: number } | undefined;
+  const total = r?.n ?? 0;
+  db.close();
+
+  console.log(JSON.stringify({ count: total, eventType: eventType ?? null, sinceIso: sinceIso ?? null }));
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const cmd = argv[0];
+  const args = parseArgs(argv.slice(1));
+
+  switch (cmd) {
+    case 'tail':
+      await tail(args);
+      return;
+    case 'record-correction':
+      await recordCorrection(args);
+      return;
+    case 'serve':
+      await serve(args);
+      return;
+    case 'count':
+      count(args);
+      return;
+    default:
+      console.error(
+        'usage: caia-mentor {tail|record-correction|serve|count}\n' +
+          '  Defaults can be overridden via env:\n' +
+          '    CAIA_EVENT_BUS_DB_PATH        — events.sqlite path\n' +
+          '    CAIA_EVENT_BUS_BIND           — server host (default 127.0.0.1)\n' +
+          '    CAIA_EVENT_BUS_PORT           — server port (default 5180)\n' +
+          '    CAIA_EVENT_BUS_SECRET[_PATH]  — HMAC shared secret (≥32 chars)'
+      );
+      process.exit(2);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('[caia-mentor] fatal:', err);
+  process.exit(1);
+});

--- a/packages/mentor-event-bus/tests/cli.test.ts
+++ b/packages/mentor-event-bus/tests/cli.test.ts
@@ -1,0 +1,115 @@
+/**
+ * CLI smoke tests — spawn the built CLI as a subprocess against a tmp DB.
+ * These tests cover the cleanly-testable subcommands (record-correction,
+ * count). The `tail` and `serve` subcommands run forever and are exercised
+ * indirectly via the server.test.ts + http-client.test.ts integration.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const CLI_DIST = resolve(__dirname, '..', 'dist', 'cli.js');
+
+const skipIfNotBuilt = !existsSync(CLI_DIST);
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'caia-mentor-cli-'));
+  dbPath = join(tmpDir, 'events.sqlite');
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('caia-mentor CLI', () => {
+  it.skipIf(skipIfNotBuilt)('record-correction creates the DB and emits an event', () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI_DIST, 'record-correction', 'use lowercase commit subjects', '--mode', 'manual'],
+      {
+        env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+        encoding: 'utf-8'
+      }
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/"ok":true/);
+    expect(result.stdout).toMatch(/"id":"ev_/);
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  it.skipIf(skipIfNotBuilt)('count returns 1 after one correction was recorded', () => {
+    const result = spawnSync(process.execPath, [CLI_DIST, 'count'], {
+      env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+      encoding: 'utf-8'
+    });
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { count: number };
+    expect(parsed.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it.skipIf(skipIfNotBuilt)('count --type filters by event type', () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI_DIST, 'count', '--type', 'OperatorCorrection'],
+      {
+        env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+        encoding: 'utf-8'
+      }
+    );
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { count: number; eventType: string | null };
+    expect(parsed.count).toBeGreaterThanOrEqual(1);
+    expect(parsed.eventType).toBe('OperatorCorrection');
+  });
+
+  it.skipIf(skipIfNotBuilt)('count --type for non-existent type returns 0', () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI_DIST, 'count', '--type', 'NonExistentEventType'],
+      {
+        env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+        encoding: 'utf-8'
+      }
+    );
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { count: number };
+    expect(parsed.count).toBe(0);
+  });
+
+  it.skipIf(skipIfNotBuilt)('record-correction without a text arg fails with usage', () => {
+    const result = spawnSync(process.execPath, [CLI_DIST, 'record-correction'], {
+      env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+      encoding: 'utf-8'
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/usage:/);
+  });
+
+  it.skipIf(skipIfNotBuilt)('unknown subcommand prints usage and exits 2', () => {
+    const result = spawnSync(process.execPath, [CLI_DIST, 'frobnicate'], {
+      env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+      encoding: 'utf-8'
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/tail|record-correction|serve|count/);
+  });
+
+  it.skipIf(skipIfNotBuilt)('record-correction --mode regex sets detectionMode=regex', () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI_DIST, 'record-correction', 'use unique migration prefixes', '--mode', 'regex'],
+      {
+        env: { ...process.env, CAIA_EVENT_BUS_DB_PATH: dbPath },
+        encoding: 'utf-8'
+      }
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/"mode":"regex"/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       '@chiefaia/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@chiefaia/mentor-event-bus':
+        specifier: workspace:*
+        version: link:../../packages/mentor-event-bus
       nanoid:
         specifier: ^3.3.7
         version: 3.3.11


### PR DESCRIPTION
## Summary

Mentor Phase 0 implementation track — adds the consumer-side CLI binary, the first production emit-point (PRMerged in the local-preview deploy pipeline), and the orchestrator-side Mentor Client integration.

## What lands

### (1) `caia-mentor` CLI binary

`packages/mentor-event-bus/src/cli.ts` + `bin` in package.json.

| Subcommand | Purpose |
|---|---|
| `tail [--type T] [--correlation X] [--since N] [--interval ms]` | Live event tail; polls every 1s by default |
| `record-correction "<text>" [--context X] [--mode manual\|regex\|llm]` | Emit OperatorCorrection (Phase-0 stub for the eventual chat-side fast-path) |
| `serve [--port P] [--host H]` | Start the HTTP server (used by the LaunchAgent in PR-δ) |
| `count [--type T] [--since-iso ISO]` | One-line JSON count for status dashboards / Steward checks |

### (2) PRMerged emit-point in `deploy.ts`

Adds `mentorEmit?: (event, payload) => void` to `DeployOptions`. On a successful deploy (after the state-update step), the pipeline emits `PRMerged` with `{prNumber: 0, sha, branch, repo, previousSha?}`. Fire-and-forget — thrown exceptions are caught and logged so Mentor reliability never blocks deploys.

### (3) Mentor Client integration in local-preview `cli.ts`

Lazily opens a Mentor Client at `$CAIA_EVENT_BUS_DB_PATH` (default `~/Library/Application Support/caia/events/events.sqlite`). Silently no-ops on DB-open failure (logged once) or `CAIA_EVENT_BUS_DISABLED=1` opt-out. The poll-loop daemon now emits `PRMerged` on every new SHA seen on `origin/<branch>` for any of the 3 sites.

## Tests (11 net-new)

| File | Tests | Coverage |
|---|---|---|
| `apps/local-preview-orchestrator/tests/deploy.test.ts` | 4 | mentorEmit happy path, noop-no-emit, build-failed-no-emit, emit-throw-is-swallowed |
| `packages/mentor-event-bus/tests/cli.test.ts` | 7 | spawnSync smoke tests for record-correction, count, count --type filter, missing-arg usage exit, unknown-subcommand usage exit, --mode regex propagation |

109 tests in local-preview-orchestrator (105 prior + 4 new)
94 tests in mentor-event-bus (87 prior + 7 new)

## Evidence

- Lint: clean (both packages)
- Typecheck: clean (both packages)
- Build: clean (both packages)
- Steward analyzers: 2 pre-existing migration-numbering medium findings (non-blocking)

## Stage progression (per 6-stage DoD)

| Stage | Status |
|---|---|
| 1. Analyze | ✓ leg-1 design doc |
| 2. Research | ✓ leg-1 + leg-2 (HMAC AppRole, AsyncLocalStorage) |
| 3. Solution | ✓ design doc + this PR's API |
| 4. Implement | this PR |
| 5. Test+integrate | unit + integration tests + actual emit-point wiring |
| 6. Test again | gated on PR-δ landing then live verify on Mac |

## Dependencies

This branch is based on PR-β (#320). When PR-β merges, this branch will rebase cleanly onto develop. If PR-β fails to merge for any reason, this PR can't merge either — that's the right semantics since this PR consumes the API surface added by PR-β.

## Closes

Mentor Phase 0 implementation track (modulo PR-δ for production install). After PR-δ + Stage-6 verify, Mentor Phase 0 is fully done and Phase 1 (reactive fast-path) starts.