### PR TITLE
feat(mentor-phase0-001): LaunchAgent plists + memory-watcher + install.sh (PR-δ)

### DIFF
--- a/packages/mentor-event-bus/package.json
+++ b/packages/mentor-event-bus/package.json
@@ -18,7 +18,9 @@
   },
   "files": [
     "dist",
-    "migrations"
+    "migrations",
+    "plists",
+    "scripts"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/mentor-event-bus/plists/com.caia.mentor.memory-watcher.plist
+++ b/packages/mentor-event-bus/plists/com.caia.mentor.memory-watcher.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.caia.mentor.memory-watcher
+  ==============================
+  Recursive fs.watch on agent/memory/. Emits MemoryWritten on every
+  detected create / modify / delete (debounced at 500ms per path).
+
+  Installed by: packages/mentor-event-bus/scripts/install.sh
+  Logs:         ~/Library/Logs/caia-mentor/memory-watcher.{out,err}.log
+
+  Substitutions handled by install.sh:
+    __USER_HOME__       — $HOME
+    __REPO__            — absolute path to caia checkout
+    __EVENTS_DB_PATH__  — events.sqlite path
+    __MEMORY_DIR__      — directory to watch (default $REPO/agent/memory)
+    __NODE_BIN__        — node binary path
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.caia.mentor.memory-watcher</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_BIN__</string>
+        <string>__REPO__/packages/mentor-event-bus/dist/cli.js</string>
+        <string>watch-memory</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CAIA_EVENT_BUS_DB_PATH</key>
+        <string>__EVENTS_DB_PATH__</string>
+        <key>CAIA_MEMORY_DIR</key>
+        <string>__MEMORY_DIR__</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/caia-mentor/memory-watcher.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/caia-mentor/memory-watcher.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/packages/mentor-event-bus/plists/com.caia.mentor.server.plist
+++ b/packages/mentor-event-bus/plists/com.caia.mentor.server.plist
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.caia.mentor.server
+  ======================
+  HTTP server for cross-machine event ingestion. Binds 127.0.0.1:5180 by
+  default. Cross-machine producers (e.g. stolution) reach the bus via the
+  Tailscale IP after the operator updates `CAIA_EVENT_BUS_BIND` here.
+
+  Installed by: packages/mentor-event-bus/scripts/install.sh
+  Logs:         ~/Library/Logs/caia-mentor/server.{out,err}.log
+
+  Substitutions handled by install.sh:
+    __USER_HOME__       — $HOME
+    __REPO__            — absolute path to caia checkout
+    __SECRET_PATH__     — file holding the HMAC shared secret (≥32 chars)
+    __EVENTS_DB_PATH__  — events.sqlite path
+    __NODE_BIN__        — node binary path
+
+  Auth: server reads CAIA_EVENT_BUS_SECRET_PATH at start; refuses to bind
+  if the file is missing or shorter than 32 chars. Operator MUST run
+  `openssl rand -hex 32 > __SECRET_PATH__` before install.sh.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.caia.mentor.server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_BIN__</string>
+        <string>__REPO__/packages/mentor-event-bus/dist/cli.js</string>
+        <string>serve</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CAIA_EVENT_BUS_DB_PATH</key>
+        <string>__EVENTS_DB_PATH__</string>
+        <key>CAIA_EVENT_BUS_SECRET_PATH</key>
+        <string>__SECRET_PATH__</string>
+        <key>CAIA_EVENT_BUS_BIND</key>
+        <string>127.0.0.1</string>
+        <key>CAIA_EVENT_BUS_PORT</key>
+        <string>5180</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/caia-mentor/server.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/caia-mentor/server.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/packages/mentor-event-bus/scripts/install.sh
+++ b/packages/mentor-event-bus/scripts/install.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Install the Mentor event-bus stack on the operator's Mac.
+#
+# Usage:
+#   ./packages/mentor-event-bus/scripts/install.sh
+#
+# What it installs:
+#   1. Provisions ~/.caia-vault/mentor-event-bus-secret if missing
+#      (32-byte secret via openssl rand -hex 32)
+#   2. Templates + copies plists into ~/Library/LaunchAgents/com.caia.mentor.*.plist
+#      - com.caia.mentor.server          (HTTP ingestion on 127.0.0.1:5180)
+#      - com.caia.mentor.memory-watcher  (fs.watch on agent/memory)
+#   3. Creates log + DB dirs
+#   4. launchctl bootstrap each agent
+#   5. Verifies /v1/healthz responds within 30s
+#
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+# ─── Resolve paths ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PACKAGE_DIR}/../.." && pwd)"
+PLISTS_SRC="${PACKAGE_DIR}/plists"
+LA_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs/caia-mentor"
+DB_DIR="${HOME}/Library/Application Support/caia/events"
+DB_PATH="${CAIA_EVENT_BUS_DB_PATH:-${DB_DIR}/events.sqlite}"
+SECRET_PATH="${CAIA_EVENT_BUS_SECRET_PATH:-${HOME}/.caia-vault/mentor-event-bus-secret}"
+MEMORY_DIR="${CAIA_MEMORY_DIR:-${REPO_ROOT}/agent/memory}"
+
+PLIST_LABELS=(
+    "com.caia.mentor.server"
+    "com.caia.mentor.memory-watcher"
+)
+
+# ─── Verify pre-conditions ──────────────────────────────────────────────────
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "ERROR: install.sh runs on macOS only (uname=$(uname))." >&2
+    exit 2
+fi
+
+if [[ ! -d "${PLISTS_SRC}" ]]; then
+    echo "ERROR: plists source dir not found: ${PLISTS_SRC}" >&2
+    exit 2
+fi
+
+if [[ ! -f "${PACKAGE_DIR}/dist/cli.js" ]]; then
+    echo "ERROR: ${PACKAGE_DIR}/dist/cli.js not built. Run:" >&2
+    echo "  pnpm -F @chiefaia/mentor-event-bus build" >&2
+    exit 2
+fi
+
+if [[ ! -d "${MEMORY_DIR}" ]]; then
+    echo "ERROR: memory dir not found: ${MEMORY_DIR}" >&2
+    echo "  Set CAIA_MEMORY_DIR to point at the agent/memory directory." >&2
+    exit 2
+fi
+
+# Resolve node binary path.
+if [[ -x /opt/homebrew/bin/node ]]; then
+    NODE_BIN="/opt/homebrew/bin/node"
+elif [[ -x /usr/local/bin/node ]]; then
+    NODE_BIN="/usr/local/bin/node"
+else
+    NODE_BIN="$(command -v node || true)"
+    if [[ -z "${NODE_BIN}" ]]; then
+        echo "ERROR: node not found." >&2
+        exit 2
+    fi
+fi
+
+# ─── Secret provisioning ────────────────────────────────────────────────────
+mkdir -p "$(dirname "${SECRET_PATH}")"
+chmod 700 "$(dirname "${SECRET_PATH}")"
+if [[ ! -f "${SECRET_PATH}" ]]; then
+    if ! command -v openssl >/dev/null 2>&1; then
+        echo "ERROR: openssl not found; cannot generate secret." >&2
+        exit 2
+    fi
+    openssl rand -hex 32 > "${SECRET_PATH}"
+    chmod 600 "${SECRET_PATH}"
+    echo "Generated new secret at ${SECRET_PATH} (chmod 600)."
+else
+    SECRET_LEN="$(wc -c < "${SECRET_PATH}" | tr -d ' ')"
+    if (( SECRET_LEN < 32 )); then
+        echo "ERROR: existing secret at ${SECRET_PATH} is too short (${SECRET_LEN} bytes; need ≥32)." >&2
+        echo "  Either delete it (re-run regenerates) or write a fresh one yourself." >&2
+        exit 2
+    fi
+    echo "Reusing existing secret at ${SECRET_PATH}"
+fi
+
+# ─── Setup directories ──────────────────────────────────────────────────────
+mkdir -p "${LA_DIR}" "${LOG_DIR}" "${DB_DIR}" "$(dirname "${DB_PATH}")"
+
+# ─── Backup any existing plists ─────────────────────────────────────────────
+BACKUP_DIR="${HOME}/.caia-backups/mentor-launchagents-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "${BACKUP_DIR}"
+for label in "${PLIST_LABELS[@]}"; do
+    src="${LA_DIR}/${label}.plist"
+    if [[ -f "${src}" ]]; then
+        cp "${src}" "${BACKUP_DIR}/"
+        if launchctl list | grep -q "${label}"; then
+            launchctl bootout "gui/$(id -u)" "${src}" 2>/dev/null || true
+        fi
+    fi
+done
+
+# ─── Template + copy ────────────────────────────────────────────────────────
+echo "Installing mentor LaunchAgents into ${LA_DIR}/"
+echo "  events.sqlite  = ${DB_PATH}"
+echo "  secret file    = ${SECRET_PATH}"
+echo "  memory dir     = ${MEMORY_DIR}"
+echo "  node           = ${NODE_BIN}"
+for label in "${PLIST_LABELS[@]}"; do
+    src="${PLISTS_SRC}/${label}.plist"
+    dst="${LA_DIR}/${label}.plist"
+    if [[ ! -f "${src}" ]]; then
+        echo "  WARN: source plist missing: ${src}" >&2
+        continue
+    fi
+    sed \
+        -e "s|__USER_HOME__|${HOME}|g" \
+        -e "s|__REPO__|${REPO_ROOT}|g" \
+        -e "s|__SECRET_PATH__|${SECRET_PATH}|g" \
+        -e "s|__EVENTS_DB_PATH__|${DB_PATH}|g" \
+        -e "s|__MEMORY_DIR__|${MEMORY_DIR}|g" \
+        -e "s|__NODE_BIN__|${NODE_BIN}|g" \
+        "${src}" > "${dst}"
+    echo "  installed ${label}.plist"
+done
+
+# ─── Bootstrap into launchd ─────────────────────────────────────────────────
+echo
+echo "Bootstrapping into launchd (gui/$(id -u))"
+for label in "${PLIST_LABELS[@]}"; do
+    dst="${LA_DIR}/${label}.plist"
+    if [[ ! -f "${dst}" ]]; then continue; fi
+    if launchctl bootstrap "gui/$(id -u)" "${dst}" 2>&1 | grep -v 'Bootstrap failed: 5: Input/output error'; then
+        echo "  bootstrapped ${label}"
+    fi
+done
+
+# ─── Wait for server liveness ───────────────────────────────────────────────
+echo
+echo "Waiting for mentor-server on http://127.0.0.1:5180/v1/healthz ..."
+attempt=0
+max_attempts=30
+ok=0
+while (( attempt < max_attempts )); do
+    if curl -fsS --max-time 2 http://127.0.0.1:5180/v1/healthz >/dev/null 2>&1; then
+        ok=1
+        break
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+if (( ok == 1 )); then
+    echo
+    echo "✓ Mentor server is up: http://127.0.0.1:5180/"
+    echo "✓ Memory watcher is watching: ${MEMORY_DIR}"
+    echo "✓ Logs: ${LOG_DIR}/"
+    echo "✓ Backup of any prior plists: ${BACKUP_DIR}/"
+    echo
+    echo "Next steps:"
+    echo "  - Live tail events:  caia-mentor tail"
+    echo "  - Quick count:       caia-mentor count"
+    echo "  - Manual correction: caia-mentor record-correction \"...\""
+else
+    echo
+    echo "WARN: mentor-server did not respond on /v1/healthz within ${max_attempts}s." >&2
+    echo "  See ${LOG_DIR}/server.err.log for details." >&2
+    exit 1
+fi

--- a/packages/mentor-event-bus/scripts/uninstall.sh
+++ b/packages/mentor-event-bus/scripts/uninstall.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Uninstall the Mentor event-bus stack.
+#
+# Usage:
+#   ./packages/mentor-event-bus/scripts/uninstall.sh           # bootout + remove plists; PRESERVE events.sqlite + secret
+#   ./packages/mentor-event-bus/scripts/uninstall.sh --purge   # also delete events.sqlite + secret
+#
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+PURGE=0
+if [[ "${1:-}" == "--purge" ]]; then
+    PURGE=1
+fi
+
+LA_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs/caia-mentor"
+DB_DIR="${HOME}/Library/Application Support/caia/events"
+SECRET_PATH="${CAIA_EVENT_BUS_SECRET_PATH:-${HOME}/.caia-vault/mentor-event-bus-secret}"
+
+PLIST_LABELS=(
+    "com.caia.mentor.server"
+    "com.caia.mentor.memory-watcher"
+)
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "ERROR: uninstall.sh runs on macOS only." >&2
+    exit 2
+fi
+
+# Bootout + remove plists.
+for label in "${PLIST_LABELS[@]}"; do
+    dst="${LA_DIR}/${label}.plist"
+    if launchctl list | grep -q "${label}"; then
+        launchctl bootout "gui/$(id -u)" "${dst}" 2>/dev/null || true
+        echo "  booted out ${label}"
+    fi
+    if [[ -f "${dst}" ]]; then
+        rm -f "${dst}"
+        echo "  removed ${dst}"
+    fi
+done
+
+if (( PURGE == 1 )); then
+    if [[ -d "${DB_DIR}" ]]; then
+        rm -rf "${DB_DIR}"
+        echo "  purged ${DB_DIR}"
+    fi
+    if [[ -f "${SECRET_PATH}" ]]; then
+        rm -f "${SECRET_PATH}"
+        echo "  purged ${SECRET_PATH}"
+    fi
+    if [[ -d "${LOG_DIR}" ]]; then
+        rm -rf "${LOG_DIR}"
+        echo "  purged ${LOG_DIR}"
+    fi
+else
+    echo "  preserved ${DB_DIR}/ (use --purge to delete)"
+    echo "  preserved ${SECRET_PATH} (use --purge to delete)"
+    echo "  preserved ${LOG_DIR}/ (use --purge to delete)"
+fi
+
+echo
+echo "✓ Mentor event-bus uninstalled."

--- a/packages/mentor-event-bus/src/cli.ts
+++ b/packages/mentor-event-bus/src/cli.ts
@@ -31,6 +31,7 @@ import { Client } from './client.js';
 import { startServer } from './server.js';
 import { loadSecret } from './auth.js';
 import { openDatabase, queryEvents } from './sqlite.js';
+import { startMemoryWatcher } from './memory-watcher.js';
 import type { EmittedEvent } from './types.js';
 import type { OperatorCorrectionPayload } from './types.js';
 
@@ -169,6 +170,33 @@ async function recordCorrection(args: Argv): Promise<void> {
   console.log(JSON.stringify({ ok: true, id, mode: detectionMode }));
 }
 
+async function watchMemory(args: Argv): Promise<void> {
+  const dbPath = args.flags['db'] ?? defaultDbPath();
+  const memoryDir =
+    args.flags['path'] ??
+    process.env['CAIA_MEMORY_DIR'] ??
+    join(homedir(), 'Documents', 'projects', 'caia', 'agent', 'memory');
+  const debounceMs = Number(args.flags['debounce'] ?? 500);
+
+  const client = new Client({
+    dbPath,
+    processName: 'caia-mentor-memory-watcher'
+  });
+  const watcher = startMemoryWatcher({
+    client,
+    rootDir: memoryDir,
+    debounceMs
+  });
+  const stop = (): void => {
+    watcher.close();
+    client.close();
+    process.exit(0);
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+  await new Promise<void>(() => undefined);
+}
+
 async function serve(args: Argv): Promise<void> {
   const dbPath = args.flags['db'] ?? defaultDbPath();
   const host = args.flags['host'] ?? process.env['CAIA_EVENT_BUS_BIND'] ?? '127.0.0.1';
@@ -250,17 +278,21 @@ async function main(): Promise<void> {
     case 'serve':
       await serve(args);
       return;
+    case 'watch-memory':
+      await watchMemory(args);
+      return;
     case 'count':
       count(args);
       return;
     default:
       console.error(
-        'usage: caia-mentor {tail|record-correction|serve|count}\n' +
+        'usage: caia-mentor {tail|record-correction|serve|count|watch-memory}\n' +
           '  Defaults can be overridden via env:\n' +
           '    CAIA_EVENT_BUS_DB_PATH        — events.sqlite path\n' +
           '    CAIA_EVENT_BUS_BIND           — server host (default 127.0.0.1)\n' +
           '    CAIA_EVENT_BUS_PORT           — server port (default 5180)\n' +
-          '    CAIA_EVENT_BUS_SECRET[_PATH]  — HMAC shared secret (≥32 chars)'
+          '    CAIA_EVENT_BUS_SECRET[_PATH]  — HMAC shared secret (≥32 chars)\n' +
+          '    CAIA_MEMORY_DIR               — agent/memory dir to watch'
       );
       process.exit(2);
   }

--- a/packages/mentor-event-bus/src/index.ts
+++ b/packages/mentor-event-bus/src/index.ts
@@ -100,3 +100,11 @@ export {
   type HttpEmitOptions,
   type HttpEmitResult
 } from './http-client.js';
+
+// PR-δ: MemoryWritten emit-point (chokidar-style fs.watch daemon).
+export {
+  startMemoryWatcher,
+  defaultFilter,
+  type WatchMemoryOptions,
+  type MemoryWatcher
+} from './memory-watcher.js';

--- a/packages/mentor-event-bus/src/memory-watcher.ts
+++ b/packages/mentor-event-bus/src/memory-watcher.ts
@@ -1,0 +1,154 @@
+/**
+ * MemoryWritten emit-point.
+ *
+ * Watches a directory tree for file changes via Node's built-in
+ * `fs.watch` (recursive=true; supported on macOS) and emits a
+ * `MemoryWritten` event on every detected create / modify / delete.
+ *
+ * Phase-0 invariants:
+ *   - never throws on emit failure (the underlying Client already swallows)
+ *   - debounces bursts so a single editor save doesn't emit ten events
+ *   - filters out hidden files and `.*.swp` style backup files
+ *   - tolerates the watch root not existing yet (prints a warning + exits)
+ *
+ * Default watch path: $CAIA_MEMORY_DIR or ~/Documents/projects/caia/agent/memory.
+ *
+ * Used by:
+ *   - the `caia-mentor watch-memory` CLI subcommand
+ *   - the LaunchAgent plist `com.caia.mentor.memory-watcher.plist`
+ */
+
+import { watch, statSync, existsSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, relative } from 'node:path';
+
+import type { Client } from './client.js';
+import type { MemoryWrittenPayload } from './types.js';
+
+export interface WatchMemoryOptions {
+  /** Mentor client used to emit. Caller manages lifecycle. */
+  client: Client;
+  /** Root directory to watch recursively. */
+  rootDir: string;
+  /** Debounce window in ms — events on the same path within the window collapse. Default 500. */
+  debounceMs?: number;
+  /** Filter — return false to skip emitting for a path. */
+  filter?: (path: string) => boolean;
+  /** Logger. Default: console. */
+  logger?: { info: (m: string) => void; warn: (m: string, ctx?: unknown) => void };
+  /** Test injection — overrides fs.watch. */
+  watchFn?: typeof watch;
+}
+
+export interface MemoryWatcher {
+  close(): void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 500;
+
+const consoleLogger = {
+  info: (m: string): void => console.log(m),
+  warn: (m: string, ctx?: unknown): void => {
+    if (ctx !== undefined) console.warn(m, ctx);
+    else console.warn(m);
+  }
+};
+
+/**
+ * Default filter: skip dotfiles + editor swap files + .DS_Store.
+ */
+export function defaultFilter(path: string): boolean {
+  const base = path.split('/').pop() ?? '';
+  if (base.startsWith('.')) return false;
+  if (base.endsWith('.swp') || base.endsWith('~')) return false;
+  if (base === 'DS_Store') return false;
+  return true;
+}
+
+/**
+ * Start a memory-watcher daemon. Returns a handle with `close()`.
+ *
+ * Stops automatically when the watch root is removed (rare); also stops
+ * when the caller invokes `close()`.
+ */
+export function startMemoryWatcher(opts: WatchMemoryOptions): MemoryWatcher {
+  const { client, rootDir } = opts;
+  const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const filter = opts.filter ?? defaultFilter;
+  const logger = opts.logger ?? consoleLogger;
+  const watchFn = opts.watchFn ?? watch;
+
+  if (!existsSync(rootDir)) {
+    throw new Error(`startMemoryWatcher: rootDir does not exist: ${rootDir}`);
+  }
+
+  const pendingEmits = new Map<string, NodeJS.Timeout>();
+
+  const watcher = watchFn(rootDir, { recursive: true }, (eventType, filename) => {
+    if (!filename) return;
+    const fullPath = join(rootDir, String(filename));
+    if (!filter(fullPath)) return;
+
+    // Debounce per-path. The actual emit fires after `debounceMs` of quiet.
+    const existing = pendingEmits.get(fullPath);
+    if (existing) clearTimeout(existing);
+    const handle = setTimeout(() => {
+      pendingEmits.delete(fullPath);
+      emitOne(client, rootDir, fullPath, eventType, logger);
+    }, debounceMs);
+    pendingEmits.set(fullPath, handle);
+  });
+
+  watcher.on('error', (err) => {
+    logger.warn(`[memory-watcher] watcher error: ${err.message}`);
+  });
+
+  logger.info(`[memory-watcher] watching ${rootDir} (debounce=${debounceMs}ms)`);
+
+  return {
+    close: () => {
+      for (const h of pendingEmits.values()) clearTimeout(h);
+      pendingEmits.clear();
+      watcher.close();
+    }
+  };
+}
+
+function emitOne(
+  client: Client,
+  rootDir: string,
+  fullPath: string,
+  eventType: string,
+  logger: { warn: (m: string, ctx?: unknown) => void }
+): void {
+  const operation = classify(fullPath, eventType);
+  let size = 0;
+  let sha: string | undefined;
+  try {
+    if (existsSync(fullPath)) {
+      size = statSync(fullPath).size;
+      // Hash for small files only — caps ~1MB to avoid holding RAM.
+      if (size <= 1024 * 1024) {
+        const buf = readFileSync(fullPath);
+        sha = createHash('sha256').update(buf).digest('hex').slice(0, 16);
+      }
+    }
+  } catch (e) {
+    logger.warn(`[memory-watcher] stat/read failed for ${fullPath}: ${e}`);
+  }
+
+  const payload: MemoryWrittenPayload = {
+    path: relative(rootDir, fullPath) || fullPath,
+    size,
+    operation
+  };
+  if (sha !== undefined) payload.sha = sha;
+
+  client.emit('MemoryWritten', payload);
+}
+
+function classify(fullPath: string, eventType: string): MemoryWrittenPayload['operation'] {
+  if (!existsSync(fullPath)) return 'delete';
+  if (eventType === 'rename') return 'create';
+  return 'modify';
+}

--- a/packages/mentor-event-bus/tests/memory-watcher.test.ts
+++ b/packages/mentor-event-bus/tests/memory-watcher.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the MemoryWritten emit-point.
+ *
+ * We test:
+ *   - filter rules (defaultFilter)
+ *   - basic emit on file write (real fs.watch under tmp dir)
+ *   - debounce collapses bursts
+ *   - rejects non-existent rootDir
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { startMemoryWatcher, defaultFilter } from '../src/memory-watcher';
+import { Client } from '../src/client';
+import { queryEvents } from '../src/sqlite';
+
+const migrationsDir = join(__dirname, '..', 'migrations');
+
+let tmpRoot: string;
+let dbPath: string;
+let client: Client;
+
+beforeEach(() => {
+  tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "mentor-memwatch-")));
+  dbPath = join(tmpdir(), `mentor-memwatch-${Math.random().toString(36).slice(2)}.sqlite`);
+  client = new Client({ dbPath, processName: 'memwatch-test', migrationsDir });
+});
+
+afterEach(() => {
+  try {
+    client.close();
+  } catch {
+    // already closed
+  }
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(dbPath, { force: true });
+});
+
+describe('defaultFilter', () => {
+  it('rejects dotfiles', () => {
+    expect(defaultFilter('/dir/.hidden')).toBe(false);
+    expect(defaultFilter('/dir/.DS_Store')).toBe(false);
+  });
+
+  it('rejects vim swap files', () => {
+    expect(defaultFilter('/dir/foo.swp')).toBe(false);
+  });
+
+  it('rejects backup files (~ suffix)', () => {
+    expect(defaultFilter('/dir/file~')).toBe(false);
+  });
+
+  it('accepts ordinary files', () => {
+    expect(defaultFilter('/dir/foo.md')).toBe(true);
+    expect(defaultFilter('/dir/feedback_x.md')).toBe(true);
+  });
+});
+
+describe('startMemoryWatcher', () => {
+  it('rejects when rootDir does not exist', () => {
+    expect(() =>
+      startMemoryWatcher({
+        client,
+        rootDir: '/no/such/dir/at/all',
+        debounceMs: 1
+      })
+    ).toThrow(/does not exist/);
+  });
+
+  it('emits MemoryWritten when a file is created in the watch root', async () => {
+    const watcher = startMemoryWatcher({
+      client,
+      rootDir: tmpRoot,
+      debounceMs: 50,
+      logger: { info: () => undefined, warn: () => undefined }
+    });
+    try {
+      // Write a file
+      const filePath = join(tmpRoot, 'feedback_test.md');
+      writeFileSync(filePath, 'hello world', 'utf-8');
+
+      // Wait for debounce + write to settle
+      await sleep(800);
+
+      const rows = queryEvents(client.unsafeGetDb(), { eventType: 'MemoryWritten' });
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      const payload = JSON.parse(rows[0]!.payload_json) as {
+        path: string;
+        size: number;
+        operation: string;
+      };
+      expect(payload.path).toContain('feedback_test.md');
+      expect(payload.size).toBe('hello world'.length);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  it('debounces rapid writes to the same path', async () => {
+    const watcher = startMemoryWatcher({
+      client,
+      rootDir: tmpRoot,
+      debounceMs: 100,
+      logger: { info: () => undefined, warn: () => undefined }
+    });
+    try {
+      const filePath = join(tmpRoot, 'rapid.md');
+      // 5 rapid writes within debounce window
+      for (let i = 0; i < 5; i++) {
+        writeFileSync(filePath, `content-${i}`, 'utf-8');
+        await sleep(10);
+      }
+      await sleep(800);
+
+      const rows = queryEvents(client.unsafeGetDb(), { eventType: 'MemoryWritten' });
+      const ours = rows.filter((r) => r.payload_json.includes('rapid.md'));
+      // Should be at most 1-2 emits (debounced from 5)
+      expect(ours.length).toBeLessThanOrEqual(2);
+      expect(ours.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  it('skips dotfiles via defaultFilter', async () => {
+    const watcher = startMemoryWatcher({
+      client,
+      rootDir: tmpRoot,
+      debounceMs: 50,
+      logger: { info: () => undefined, warn: () => undefined }
+    });
+    try {
+      writeFileSync(join(tmpRoot, '.hidden'), 'x', 'utf-8');
+      writeFileSync(join(tmpRoot, 'visible.md'), 'y', 'utf-8');
+      await sleep(800);
+
+      const rows = queryEvents(client.unsafeGetDb(), { eventType: 'MemoryWritten' });
+      const dotfileRows = rows.filter((r) => r.payload_json.includes('.hidden'));
+      const visibleRows = rows.filter((r) => r.payload_json.includes('visible.md'));
+      expect(dotfileRows.length).toBe(0);
+      expect(visibleRows.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  it('honours a custom filter', async () => {
+    let filterCalls = 0;
+    const filter = (p: string): boolean => {
+      filterCalls++;
+      return p.endsWith('.md');
+    };
+    const watcher = startMemoryWatcher({
+      client,
+      rootDir: tmpRoot,
+      debounceMs: 50,
+      filter,
+      logger: { info: () => undefined, warn: () => undefined }
+    });
+    try {
+      writeFileSync(join(tmpRoot, 'notes.md'), 'a', 'utf-8');
+      writeFileSync(join(tmpRoot, 'config.json'), 'b', 'utf-8');
+      await sleep(800);
+
+      expect(filterCalls).toBeGreaterThan(0);
+      const rows = queryEvents(client.unsafeGetDb(), { eventType: 'MemoryWritten' });
+      const md = rows.filter((r) => r.payload_json.includes('notes.md'));
+      const json = rows.filter((r) => r.payload_json.includes('config.json'));
+      expect(md.length).toBeGreaterThanOrEqual(1);
+      expect(json.length).toBe(0);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  it('close() clears pending debounced emits', async () => {
+    const watcher = startMemoryWatcher({
+      client,
+      rootDir: tmpRoot,
+      debounceMs: 5_000, // very long
+      logger: { info: () => undefined, warn: () => undefined }
+    });
+    writeFileSync(join(tmpRoot, 'queued.md'), 'x', 'utf-8');
+    await sleep(50);
+    watcher.close();
+
+    // After close, the pending timer is cleared and no emit should land.
+    await sleep(200);
+    const rows = queryEvents(client.unsafeGetDb(), { eventType: 'MemoryWritten' });
+    const queued = rows.filter((r) => r.payload_json.includes('queued.md'));
+    expect(queued.length).toBe(0);
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Closes Mentor Phase 0 implementation track. After this PR lands + Stage-6 live verify on Mac, item 2 (Mentor Phase 0) is fully done and Phase 1 (reactive fast-path) starts.

## What lands

### Memory-watcher daemon (`src/memory-watcher.ts`)

Recursive `fs.watch` daemon emitting `MemoryWritten` on every detected change in `agent/memory/`:

- Per-path debounce (default 500ms) collapses editor-save bursts
- `defaultFilter` rejects dotfiles, `.swp`, `~` backup files, `DS_Store`
- Captures size + sha256 (first 16 hex) for files <1MB
- Never throws — watch errors surface via `logger.warn` only

### CLI `watch-memory` subcommand

Wires the daemon to a long-lived launchd process. Accepts `--path`, `--debounce` flags; reads `CAIA_MEMORY_DIR` for the watch root.

### LaunchAgent plists

| Plist | Purpose | Port |
|---|---|---|
| `com.caia.mentor.server` | HTTP ingestion (caia-mentor serve) | 127.0.0.1:5180 |
| `com.caia.mentor.memory-watcher` | fs.watch daemon (caia-mentor watch-memory) | n/a |

Both have `KeepAlive: { SuccessfulExit: false, Crashed: true }` + `ThrottleInterval: 10`.

### `scripts/install.sh`

- **Provisions** `~/.caia-vault/mentor-event-bus-secret` via `openssl rand -hex 32` if missing; refuses to install if existing secret <32 bytes
- **Templates** plists with `__USER_HOME__` / `__REPO__` / `__SECRET_PATH__` / `__EVENTS_DB_PATH__` / `__MEMORY_DIR__` / `__NODE_BIN__`
- **Backs up** any prior plists into `~/.caia-backups/mentor-launchagents-<ts>/`
- **Bootstraps** each agent in `gui/$UID`
- **Verifies** `http://127.0.0.1:5180/v1/healthz` reachable within 30s

### `scripts/uninstall.sh`

Bootout + remove plists. Default preserves DB + secret + logs. `--purge` drops everything.

## Tests (10 net-new)

| Suite | Tests | Coverage |
|---|---|---|
| defaultFilter | 4 | dotfile, swap, ~ backup, ordinary file rules |
| startMemoryWatcher | 6 | rejects bad rootDir, emit-on-create with real fs.watch, debounce collapses 5 rapid writes to ≤2 emits, dotfile-filter integration, custom-filter integration, close() cancels pending debounced emits |

104 tests in mentor-event-bus (94 prior + 10 new). `plutil -lint` clean for both new plists.

## Evidence

- Tests: 104 passed in mentor-event-bus
- Lint: clean
- Typecheck: clean
- Build: clean
- Plist lint: `plutil -lint` ✓ for both plists
- Steward analyzers: 2 pre-existing migration-numbering medium findings (non-blocking)

## Stage progression (per 6-stage DoD)

| Stage | Status |
|---|---|
| 1. Analyze | ✓ leg-1 design |
| 2. Research | ✓ fs.watch recursive on macOS, launchd KeepAlive semantics |
| 3. Solution | ✓ design doc + this PR's API |
| 4. Implement | this PR |
| 5. Test+integrate | unit tests + plist-lint + install.sh packaged in `package.json#files` |
| 6. Test again | next: live install on Mac, run for ~10 min, verify all 3 emit-points landing in events.sqlite |

## Dependencies

This branch is based on PR-γ (#321), which is based on PR-β (#320). Will rebase cleanly when both upstream PRs merge.

## Closes

Mentor Phase 0 implementation track. After Stage-6 verify lands, item 2 from the multi-day campaign roadmap is fully done.