### PR TITLE
feat(local-preview-001): lazy MentorClient open in deploy daemon (PR-H)

### DIFF
--- a/apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
+++ b/apps/local-preview-orchestrator/plists/com.stolution.local-preview.deploy-daemon.plist
@@ -18,6 +18,14 @@
   Per-site branch overrides: __LOCAL_PREVIEW_<SITE>_BRANCH__ placeholders
   are sed-substituted at install time from the operator's env (or the
   bake-in defaults of develop/master/main respectively).
+
+  Mentor event-bus integration (PR-H, leg-4 stage-6 finding):
+  CAIA_EVENT_BUS_DB_PATH points the orchestrator's lazily-opened
+  MentorClient at the production events.sqlite managed by the
+  mentor-event-bus install. If Mentor is not installed yet, the client
+  open silently no-ops; the orchestrator retries opening on each
+  successful deploy so it picks up Mentor whenever it eventually arrives.
+  See apps/local-preview-orchestrator/src/cli.ts `tryOpenMentorClient`.
 -->
 <plist version="1.0">
 <dict>
@@ -50,6 +58,8 @@
         <string>__LOCAL_PREVIEW_POKER_ZENO_BRANCH__</string>
         <key>LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH</key>
         <string>__LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH__</string>
+        <key>CAIA_EVENT_BUS_DB_PATH</key>
+        <string>__CAIA_EVENT_BUS_DB_PATH__</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/apps/local-preview-orchestrator/scripts/install.sh
+++ b/apps/local-preview-orchestrator/scripts/install.sh
@@ -18,6 +18,14 @@
 #   4. launchctl bootstrap each agent (gui/$UID domain)
 #   5. Verifies dashboard responds on http://127.0.0.1:5170/healthz within 30s
 #
+# Mentor event-bus integration (PR-H):
+#   The deploy daemon will lazily attempt to open the events.sqlite at
+#   `CAIA_EVENT_BUS_DB_PATH` on each successful deploy and emit a
+#   `PRMerged` event. Defaults to the same path the mentor-event-bus
+#   install.sh writes to (~/Library/Application Support/caia/events/events.sqlite).
+#   Set CAIA_EVENT_BUS_DISABLED=1 in your env (and re-export into the plist
+#   if needed) to opt out entirely.
+#
 # Per-site branch overrides:
 #   The deploy daemon resolves each site's branch from
 #   `LOCAL_PREVIEW_<SITE>_BRANCH` env vars at runtime. install.sh templates
@@ -67,6 +75,12 @@ _validate_branch() {
 _validate_branch LOCAL_PREVIEW_DASHBOARD_BRANCH "${LOCAL_PREVIEW_DASHBOARD_BRANCH}"
 _validate_branch LOCAL_PREVIEW_POKER_ZENO_BRANCH "${LOCAL_PREVIEW_POKER_ZENO_BRANCH}"
 _validate_branch LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH "${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH}"
+
+# Mentor event-bus DB path (PR-H, leg-4 stage-6 finding). The orchestrator's
+# MentorClient lazily attempts to open this DB on each successful deploy and
+# silently no-ops if unavailable, so this var is safe to set even when
+# Mentor isn't installed yet.
+CAIA_EVENT_BUS_DB_PATH="${CAIA_EVENT_BUS_DB_PATH:-${HOME}/Library/Application Support/caia/events/events.sqlite}"
 
 # ─── Verify pre-conditions ──────────────────────────────────────────────────
 if [[ "$(uname)" != "Darwin" ]]; then
@@ -134,6 +148,7 @@ echo "  per-site branches:"
 echo "    dashboard           = ${LOCAL_PREVIEW_DASHBOARD_BRANCH}"
 echo "    poker-zeno          = ${LOCAL_PREVIEW_POKER_ZENO_BRANCH}"
 echo "    roulette-community  = ${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH}"
+echo "  mentor event-bus DB = ${CAIA_EVENT_BUS_DB_PATH}"
 for label in "${PLIST_LABELS[@]}"; do
     src="${PLISTS_SRC}/${label}.plist"
     dst="${LA_DIR}/${label}.plist"
@@ -150,6 +165,7 @@ for label in "${PLIST_LABELS[@]}"; do
         -e "s|__LOCAL_PREVIEW_POKER_ZENO_BRANCH__|${LOCAL_PREVIEW_POKER_ZENO_BRANCH}|g" \
         -e "s|__LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH__|${LOCAL_PREVIEW_ROULETTE_COMMUNITY_BRANCH}|g" \
         -e "s|/usr/local/bin/node|${NODE_BIN}|g" \
+        -e "s|__CAIA_EVENT_BUS_DB_PATH__|${CAIA_EVENT_BUS_DB_PATH}|g" \
         "${src}" > "${dst}"
     echo "  installed ${label}.plist"
 done

--- a/apps/local-preview-orchestrator/src/cli.ts
+++ b/apps/local-preview-orchestrator/src/cli.ts
@@ -11,12 +11,15 @@
  * Wired into `package.json#bin.local-preview` → `dist/src/cli.js`. The PR-D
  * LaunchAgent plists invoke this binary with the appropriate subcommand.
  *
- * Mentor integration (PR-γ): if a Mentor event-bus DB path is reachable
- * (`CAIA_EVENT_BUS_DB_PATH` env var defaults to a Mac path), the CLI
- * constructs a Mentor `Client` and threads `mentorEmit` through deploy
- * options so successful deploys emit `PRMerged` events. The Client is
- * created lazily and silently no-ops if the DB can't be opened —
- * preserves the producer-non-blocking invariant.
+ * Mentor integration (PR-γ + PR-H):
+ *   The orchestrator constructs a Mentor `Client` lazily via `LazyMentor`
+ *   (see `mentor-emit.ts`). The lazy pattern fixes the leg-4 stage-6
+ *   finding: the deploy daemon was bootstrapped BEFORE the
+ *   mentor-event-bus install ran, so the eager open at startup failed and
+ *   no PRMerged event ever fired even after Mentor was eventually
+ *   installed. With LazyMentor, each successful deploy retries the open
+ *   on demand; once Mentor is installed (whenever that happens), the next
+ *   deploy picks it up automatically with no daemon restart.
  */
 
 import { homedir } from 'node:os';
@@ -27,11 +30,7 @@ import { startDashboard } from './status-dashboard.js';
 import { deploySite } from './deploy.js';
 import { SITES, getSiteConfig } from './sites-config.js';
 import { buildStatus } from './status-dashboard.js';
-import {
-  Client as MentorClient,
-  type EventType,
-  type PayloadOf
-} from '@chiefaia/mentor-event-bus';
+import { LazyMentor } from './mentor-emit.js';
 
 const DEFAULT_INSTALL_ROOT = join(
   homedir(),
@@ -51,6 +50,8 @@ const DEFAULT_MENTOR_DB_PATH = join(
   'events.sqlite'
 );
 
+const lazyMentor = new LazyMentor({ defaultDbPath: DEFAULT_MENTOR_DB_PATH });
+
 function deployOptions(): {
   installRoot: string;
   buildWorkspaceRoot: string;
@@ -63,34 +64,17 @@ function deployOptions(): {
     installRoot: process.env['LOCAL_PREVIEW_INSTALL_ROOT'] ?? DEFAULT_INSTALL_ROOT,
     buildWorkspaceRoot: process.env['LOCAL_PREVIEW_BUILD_WORKSPACE'] ?? DEFAULT_BUILD_WORKSPACE
   };
-  const mentor = tryOpenMentorClient();
-  if (!mentor) return base;
-  // Adapt Mentor's typed emit to deploy.ts's narrowly-typed callback.
-  const mentorEmit = <T extends EventType>(type: T, payload: PayloadOf<T>): void => {
-    mentor.emit(type, payload);
+  // The callback is invoked by deploy.ts only on success; we fetch the
+  // lazy mentor at that time so a delayed Mentor install eventually wires
+  // up without daemon restart. LazyMentor.emit returns a boolean for
+  // observability but we ignore it — fire-and-forget by design.
+  const mentorEmit = (
+    type: 'PRMerged',
+    payload: { prNumber: number; sha: string; branch: string; repo?: string; previousSha?: string }
+  ): void => {
+    lazyMentor.emit(type, payload);
   };
   return { ...base, mentorEmit };
-}
-
-/**
- * Try to open a Mentor client for the configured DB path. Returns undefined
- * (and logs nothing more than a single warning) if the path is unset or
- * the open fails — emit-points must NEVER block deploys on Mentor's
- * reliability.
- */
-function tryOpenMentorClient(): MentorClient | undefined {
-  const dbPath = process.env['CAIA_EVENT_BUS_DB_PATH'] ?? DEFAULT_MENTOR_DB_PATH;
-  // Setting CAIA_EVENT_BUS_DISABLED=1 turns mentor emit off entirely (tests + opt-out).
-  if (process.env['CAIA_EVENT_BUS_DISABLED'] === '1') return undefined;
-  try {
-    return new MentorClient({
-      dbPath,
-      processName: 'local-preview-orchestrator'
-    });
-  } catch (e) {
-    console.warn(`[local-preview] mentor client open failed (continuing without emit): ${String(e)}`);
-    return undefined;
-  }
 }
 
 async function main(): Promise<void> {

--- a/apps/local-preview-orchestrator/src/mentor-emit.ts
+++ b/apps/local-preview-orchestrator/src/mentor-emit.ts
@@ -1,0 +1,145 @@
+/**
+ * Lazy + retry-on-each-call wrapper around the Mentor event-bus client.
+ *
+ * Why this exists (PR-H, leg-4 stage-6 finding):
+ * The local-preview deploy daemon is a long-running LaunchAgent. The first
+ * implementation (PR-γ) eagerly opened the Mentor client at process boot;
+ * if Mentor was installed AFTER local-preview, the boot-time open failed
+ * and no future PRMerged event ever fired — even after Mentor was running
+ * — until the daemon was restarted.
+ *
+ * The fix: open lazily, on each emit attempt, and cache once successful.
+ * If a delayed Mentor install happens 2 hours into the daemon's life, the
+ * very next successful deploy will see Mentor available and start emitting
+ * without any restart. A single warning is logged per `WARN_INTERVAL_MS`
+ * window to avoid log spam during the period before Mentor is installed.
+ *
+ * Trust boundary: the wrapper NEVER throws. The producer-non-blocking
+ * invariant from PR-γ is preserved — Mentor unavailability must not block
+ * deploy success.
+ */
+
+import {
+  Client as MentorClient,
+  type EventType,
+  type PayloadOf
+} from '@chiefaia/mentor-event-bus';
+
+export interface LazyMentorOptions {
+  /** Default DB path used when CAIA_EVENT_BUS_DB_PATH env var is unset. */
+  defaultDbPath: string;
+  /**
+   * Override the client constructor (test injection). Defaults to a real
+   * `new MentorClient(...)`.
+   */
+  clientFactory?: (opts: { dbPath: string; processName: string }) => MentorClient;
+  /**
+   * Override the warn function. Defaults to `console.warn`.
+   */
+  warn?: (msg: string) => void;
+  /**
+   * Override the clock. Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * Logger throttling window. Defaults to 5 minutes.
+   */
+  warnIntervalMs?: number;
+}
+
+/**
+ * Lazy / retry singleton for the Mentor client.
+ *
+ * Methods:
+ *   - `getOrOpen(env)`: returns a cached `MentorClient` if available, else
+ *     attempts to open one. Returns undefined on failure or if disabled
+ *     via `CAIA_EVENT_BUS_DISABLED=1`.
+ *   - `emit(type, payload, env)`: convenience for fire-and-forget emit
+ *     that calls `getOrOpen` and emits. Returns true if emitted, false if
+ *     mentor was unavailable (caller can use this to no-op gracefully).
+ */
+export class LazyMentor {
+  private client: MentorClient | undefined;
+  private lastWarnedAt = 0;
+  private readonly defaultDbPath: string;
+  private readonly clientFactory: (opts: {
+    dbPath: string;
+    processName: string;
+  }) => MentorClient;
+  private readonly warn: (msg: string) => void;
+  private readonly now: () => number;
+  private readonly warnIntervalMs: number;
+
+  constructor(opts: LazyMentorOptions) {
+    this.defaultDbPath = opts.defaultDbPath;
+    this.clientFactory =
+      opts.clientFactory ??
+      ((o): MentorClient => new MentorClient(o));
+    this.warn = opts.warn ?? ((m: string): void => console.warn(m));
+    this.now = opts.now ?? Date.now;
+    this.warnIntervalMs = opts.warnIntervalMs ?? 5 * 60_000;
+  }
+
+  /**
+   * Returns the open client, opening it lazily on first call (or after a
+   * previously-failed open) if necessary.
+   *
+   * Returns undefined if:
+   *   - `CAIA_EVENT_BUS_DISABLED=1` is set in env (opt-out)
+   *   - the open fails for any reason (DB not found, permission denied,
+   *     etc.) — a warning is logged at most once per `warnIntervalMs`.
+   */
+  getOrOpen(env: NodeJS.ProcessEnv = process.env): MentorClient | undefined {
+    if (env['CAIA_EVENT_BUS_DISABLED'] === '1') return undefined;
+    if (this.client !== undefined) return this.client;
+    const dbPath = env['CAIA_EVENT_BUS_DB_PATH'] ?? this.defaultDbPath;
+    try {
+      this.client = this.clientFactory({
+        dbPath,
+        processName: 'local-preview-orchestrator'
+      });
+      return this.client;
+    } catch (e) {
+      const tNow = this.now();
+      // First failed open always warns; subsequent failures throttled to
+      // at most one per warnIntervalMs window. Tracked by
+      // `lastWarnedAt === 0` (never warned) → unconditional warn.
+      if (this.lastWarnedAt === 0 || tNow - this.lastWarnedAt > this.warnIntervalMs) {
+        this.warn(
+          `[local-preview] mentor client open failed (will retry; emit suppressed): ${String(e)}`
+        );
+        this.lastWarnedAt = tNow;
+      }
+      return undefined;
+    }
+  }
+
+  /**
+   * Fire-and-forget emit. Returns true if mentor was available and emit
+   * was attempted (mentor's own `emit` swallows internal errors); false if
+   * mentor was unavailable.
+   */
+  emit<T extends EventType>(
+    type: T,
+    payload: PayloadOf<T>,
+    env: NodeJS.ProcessEnv = process.env
+  ): boolean {
+    const mentor = this.getOrOpen(env);
+    if (!mentor) return false;
+    try {
+      mentor.emit(type, payload);
+      return true;
+    } catch (e) {
+      // Defence in depth: mentor.emit shouldn't throw, but if it does we
+      // still must not bubble it back into the deploy pipeline.
+      this.warn(`[local-preview] mentor emit threw (ignored): ${String(e)}`);
+      return false;
+    }
+  }
+
+  /** Reset cached client. Test-only. */
+  _resetForTest(): void {
+    this.client = undefined;
+    this.lastWarnedAt = 0;
+  }
+}

--- a/apps/local-preview-orchestrator/tests/mentor-emit.test.ts
+++ b/apps/local-preview-orchestrator/tests/mentor-emit.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for LazyMentor (PR-H, leg-4 stage-6 finding).
+ *
+ * Covers:
+ *   - lazy open: client constructed on first getOrOpen()
+ *   - cache: subsequent getOrOpen() returns cached client
+ *   - retry on prior failure: getOrOpen() retries when client is undefined
+ *   - opt-out: CAIA_EVENT_BUS_DISABLED=1 returns undefined unconditionally
+ *   - env-var override: CAIA_EVENT_BUS_DB_PATH wins over default
+ *   - warn throttling: at most one warn per warnIntervalMs window
+ *   - emit fire-and-forget: false on unavailable; true on success
+ *   - emit swallow: throws inside underlying emit do not bubble
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { LazyMentor } from '../src/mentor-emit.js';
+
+type FakeMentor = {
+  emit: ReturnType<typeof vi.fn>;
+  close?: () => void;
+  __dbPath: string;
+};
+
+function makeFakeFactory(opts?: {
+  failOnceCount?: number;
+  emitThrows?: boolean;
+}): {
+  factory: (o: { dbPath: string; processName: string }) => FakeMentor;
+  callCount: () => number;
+  lastDbPath: () => string | undefined;
+  emitCalls: () => Array<[unknown, unknown]>;
+} {
+  let calls = 0;
+  let lastDbPath: string | undefined;
+  const emitCalls: Array<[unknown, unknown]> = [];
+  const factory = (o: { dbPath: string; processName: string }): FakeMentor => {
+    calls++;
+    lastDbPath = o.dbPath;
+    if (opts?.failOnceCount && calls <= opts.failOnceCount) {
+      throw new Error(`fake-open-fail attempt ${calls}`);
+    }
+    return {
+      emit: vi.fn().mockImplementation((_t, _p) => {
+        if (opts?.emitThrows) throw new Error('fake-emit-throw');
+        emitCalls.push([_t, _p]);
+      }),
+      __dbPath: o.dbPath
+    };
+  };
+  return {
+    factory: factory as unknown as (o: { dbPath: string; processName: string }) => FakeMentor,
+    callCount: () => calls,
+    lastDbPath: () => lastDbPath,
+    emitCalls: () => emitCalls
+  };
+}
+
+describe('LazyMentor', () => {
+  it('lazily opens on first getOrOpen', () => {
+    const f = makeFakeFactory();
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/default.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any
+    });
+    expect(f.callCount()).toBe(0); // not yet opened
+    const c = m.getOrOpen({});
+    expect(c).toBeDefined();
+    expect(f.callCount()).toBe(1);
+    expect(f.lastDbPath()).toBe('/tmp/default.sqlite');
+  });
+
+  it('caches the client across calls', () => {
+    const f = makeFakeFactory();
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/default.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any
+    });
+    const a = m.getOrOpen({});
+    const b = m.getOrOpen({});
+    const c = m.getOrOpen({});
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(f.callCount()).toBe(1);
+  });
+
+  it('retries opening when the previous attempt failed', () => {
+    const f = makeFakeFactory({ failOnceCount: 2 });
+    const warns: string[] = [];
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any,
+      warn: (msg) => warns.push(msg),
+      warnIntervalMs: 0 // log every warning, no throttling for this test
+    });
+    expect(m.getOrOpen({})).toBeUndefined(); // attempt 1 → fail
+    expect(m.getOrOpen({})).toBeUndefined(); // attempt 2 → fail
+    expect(m.getOrOpen({})).toBeDefined(); //   attempt 3 → success
+    expect(f.callCount()).toBe(3);
+    // After success, no more open attempts
+    m.getOrOpen({});
+    expect(f.callCount()).toBe(3);
+  });
+
+  it('returns undefined unconditionally when CAIA_EVENT_BUS_DISABLED=1', () => {
+    const f = makeFakeFactory();
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any
+    });
+    expect(m.getOrOpen({ CAIA_EVENT_BUS_DISABLED: '1' })).toBeUndefined();
+    expect(m.getOrOpen({ CAIA_EVENT_BUS_DISABLED: '1' })).toBeUndefined();
+    // No open attempts at all
+    expect(f.callCount()).toBe(0);
+  });
+
+  it('respects CAIA_EVENT_BUS_DB_PATH env override', () => {
+    const f = makeFakeFactory();
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/default.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any
+    });
+    m.getOrOpen({ CAIA_EVENT_BUS_DB_PATH: '/tmp/override.sqlite' });
+    expect(f.lastDbPath()).toBe('/tmp/override.sqlite');
+  });
+
+  it('throttles warning logs to at most one per warnIntervalMs', () => {
+    const f = makeFakeFactory({ failOnceCount: Number.MAX_SAFE_INTEGER });
+    const warns: string[] = [];
+    let now = 1000;
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any,
+      warn: (msg) => warns.push(msg),
+      now: () => now,
+      warnIntervalMs: 10_000
+    });
+    m.getOrOpen({}); // t=1000 → first warn
+    m.getOrOpen({}); // t=1000 → suppressed
+    now = 5000;
+    m.getOrOpen({}); // t=5000 → still inside 10s window → suppressed
+    now = 12_000;
+    m.getOrOpen({}); // t=12000 → 11s elapsed → second warn
+    now = 13_000;
+    m.getOrOpen({}); // t=13000 → 1s elapsed since last → suppressed
+    expect(warns.length).toBe(2);
+    expect(f.callCount()).toBeGreaterThan(2); // open is retried each time
+  });
+
+  it('emit returns false when mentor is unavailable', () => {
+    const f = makeFakeFactory({ failOnceCount: Number.MAX_SAFE_INTEGER });
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any,
+      warn: (): void => undefined
+    });
+    expect(
+      m.emit('PRMerged', {
+        prNumber: 1,
+        sha: 'a'.repeat(40),
+        branch: 'develop'
+      })
+    ).toBe(false);
+  });
+
+  it('emit returns true and forwards to mentor on success', () => {
+    const f = makeFakeFactory();
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any
+    });
+    const ok = m.emit('PRMerged', {
+      prNumber: 99,
+      sha: 'b'.repeat(40),
+      branch: 'develop'
+    });
+    expect(ok).toBe(true);
+    const calls = f.emitCalls();
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.[0]).toBe('PRMerged');
+  });
+
+  it('emit swallows errors from underlying mentor.emit (returns false)', () => {
+    const f = makeFakeFactory({ emitThrows: true });
+    const warns: string[] = [];
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any,
+      warn: (msg) => warns.push(msg)
+    });
+    const ok = m.emit('PRMerged', {
+      prNumber: 1,
+      sha: 'c'.repeat(40),
+      branch: 'develop'
+    });
+    expect(ok).toBe(false);
+    expect(warns.some((w) => w.includes('mentor emit threw'))).toBe(true);
+  });
+
+  it('_resetForTest clears cache so next getOrOpen retries', () => {
+    const f = makeFakeFactory();
+    const m = new LazyMentor({
+      defaultDbPath: '/tmp/x.sqlite',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clientFactory: f.factory as unknown as any
+    });
+    m.getOrOpen({});
+    expect(f.callCount()).toBe(1);
+    m._resetForTest();
+    m.getOrOpen({});
+    expect(f.callCount()).toBe(2);
+  });
+});


### PR DESCRIPTION
## Why

Closes the leg-4 stage-6 finding (orchestrator-side gap):

The deploy-daemon LaunchAgent was bootstrapped BEFORE the mentor-event-bus install in leg-4 stage-6 verify. PR-γ's eager `tryOpenMentorClient` opened the Mentor client at process start; that open failed (DB didn't exist yet), and the daemon then carried `mentor = undefined` for the rest of its lifetime. Even after Mentor was installed and running, the daemon never picked it up — no `PRMerged` event would ever fire without restarting the daemon.

## What

1. Extract the Mentor client open into a new `LazyMentor` module (`apps/local-preview-orchestrator/src/mentor-emit.ts`):
   - First call to `getOrOpen` attempts to construct the client.
   - On failure, returns undefined and warns (throttled to one log per 5-minute window so the err log doesn't fill up while Mentor is unavailable).
   - On success, caches the client for subsequent calls.
   - Each call retries the open if no cached client is available, so a delayed Mentor install eventually wires up automatically.

2. Replace the eager `tryOpenMentorClient` in cli.ts with a singleton `LazyMentor` whose `.emit(type, payload)` is hooked into deploy.ts's `mentorEmit` callback. The producer-non-blocking invariant is preserved (LazyMentor.emit never throws).

3. Add `CAIA_EVENT_BUS_DB_PATH` to the deploy-daemon plist's EnvironmentVariables block; templated by install.sh from the same default path the mentor-event-bus install.sh writes to. Operators can override via env or set `CAIA_EVENT_BUS_DISABLED=1` to opt out.

## Tests

10 net-new tests cover:
- lazy open on first `getOrOpen`
- cache across repeated calls
- retry-after-failure
- `CAIA_EVENT_BUS_DISABLED=1` opt-out (no open attempts ever)
- `CAIA_EVENT_BUS_DB_PATH` env override
- warn-throttling (first warn always fires; subsequent throttled to one per 5min window)
- emit() returns false when mentor unavailable
- emit() returns true on success
- emit() swallows errors from underlying mentor.emit
- `_resetForTest` helper

## Verification

- `pnpm --filter @caia-app/local-preview-orchestrator build` → clean
- `pnpm --filter @caia-app/local-preview-orchestrator test` → 149/149 tests pass (139 prior + 10 new)
- `pnpm --filter @caia-app/local-preview-orchestrator lint` → clean
- `plutil -lint plists/com.stolution.local-preview.deploy-daemon.plist` → OK
- `bash -n scripts/install.sh` → syntax OK

## Refs

- Leg-3 handoff: 4 PRs merged in-flight; PR-α/β/γ/δ all landed
- Leg-4 handoff (this leg): Stage 6 live install of Mentor Phase 0 + Local-Preview-Deploys passed architectural validation; this PR closes the residual orchestrator-side gap surfaced during that verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)