### PR TITLE
feat(mentor-phase1-003): fastpath CLI + LaunchAgent + install scripts (PR-3)

### DIFF
--- a/packages/mentor-fastpath/package.json
+++ b/packages/mentor-fastpath/package.json
@@ -2,19 +2,28 @@
   "name": "@chiefaia/mentor-fastpath",
   "version": "0.1.0",
   "private": true,
-  "description": "Mentor Phase-1 reactive fast-path. Subscribes to OperatorCorrection events from the Mentor event bus, classifies the failure mode against the 18-category taxonomy, and (in subsequent PRs) synthesizes durable lesson memory updates within 1 minute of the operator correction.",
+  "description": "Mentor Phase-1 reactive fast-path. Subscribes to OperatorCorrection events from the Mentor event bus, classifies the failure mode against the 18-category taxonomy, synthesizes a draft markdown lesson, and writes it to <CAIA_MEMORY_DIR>/proposals/ within 1 minute of the operator correction.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-mentor-fastpath": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "plists",
+    "scripts"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/mentor-fastpath/plists/com.caia.mentor.fastpath.plist
+++ b/packages/mentor-fastpath/plists/com.caia.mentor.fastpath.plist
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.caia.mentor.fastpath
+  ========================
+  Mentor Phase-1 reactive fast-path daemon. Polls the mentor-event-bus
+  events.sqlite for new OperatorCorrection events; classifies each
+  against the 18-category taxonomy; synthesizes a draft markdown lesson
+  and writes it under <CAIA_MEMORY_DIR>/proposals/.
+
+  Loop interval is 10s by default — well inside the directive's
+  ≤1-minute correction-to-proposal SLO.
+
+  This LaunchAgent depends on com.caia.mentor.server's events.sqlite
+  being present (read-only access in WAL mode). The fastpath consumer
+  does NOT block if the DB is missing — it logs a warning and retries
+  on the next poll, so install ordering is forgiving.
+
+  Installed by: packages/mentor-fastpath/scripts/install.sh
+  Logs:         ~/Library/Logs/caia-mentor/fastpath.{out,err}.log
+
+  Substitutions handled by install.sh:
+    __USER_HOME__       — $HOME
+    __REPO__            — absolute path to caia checkout
+    __EVENTS_DB_PATH__  — events.sqlite path (must match server's path)
+    __MEMORY_DIR__      — agent/memory dir (proposals dir is created on first run)
+    __NODE_BIN__        — node binary path
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.caia.mentor.fastpath</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_BIN__</string>
+        <string>__REPO__/packages/mentor-fastpath/dist/cli.js</string>
+        <string>watch</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CAIA_EVENT_BUS_DB_PATH</key>
+        <string>__EVENTS_DB_PATH__</string>
+        <key>CAIA_MEMORY_DIR</key>
+        <string>__MEMORY_DIR__</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Library/Logs/caia-mentor/fastpath.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Library/Logs/caia-mentor/fastpath.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/packages/mentor-fastpath/scripts/install.sh
+++ b/packages/mentor-fastpath/scripts/install.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Install the Mentor Phase-1 fast-path LaunchAgent on the operator's Mac.
+#
+# Usage:
+#   ./packages/mentor-fastpath/scripts/install.sh
+#
+# What it installs:
+#   1. Templates + copies plists/com.caia.mentor.fastpath.plist into
+#      ~/Library/LaunchAgents/
+#   2. Creates ~/Library/Logs/caia-mentor/ if missing
+#   3. Creates <CAIA_MEMORY_DIR>/proposals/ if missing
+#   4. launchctl bootstrap the agent
+#   5. Verifies the daemon is alive within 30s
+#
+# Pre-conditions (will fail with a clear message if not met):
+#   - macOS (uname == Darwin)
+#   - dist/cli.js built (`pnpm -F @chiefaia/mentor-fastpath build`)
+#   - CAIA_MEMORY_DIR env var set, pointing at the agent/memory dir
+#   - mentor-event-bus already installed (events.sqlite must exist;
+#     the fast-path opens it read-only)
+#
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+# ─── Resolve paths ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PACKAGE_DIR}/../.." && pwd)"
+PLISTS_SRC="${PACKAGE_DIR}/plists"
+LA_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs/caia-mentor"
+DB_DIR="${HOME}/Library/Application Support/caia/events"
+DB_PATH="${CAIA_EVENT_BUS_DB_PATH:-${DB_DIR}/events.sqlite}"
+MEMORY_DIR="${CAIA_MEMORY_DIR:-}"
+
+PLIST_LABEL="com.caia.mentor.fastpath"
+
+# ─── Verify pre-conditions ──────────────────────────────────────────────────
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "ERROR: install.sh runs on macOS only (uname=$(uname))." >&2
+    exit 2
+fi
+
+if [[ -z "${MEMORY_DIR}" ]]; then
+    echo "ERROR: CAIA_MEMORY_DIR is required." >&2
+    echo "  export CAIA_MEMORY_DIR=/path/to/agent/memory" >&2
+    exit 2
+fi
+
+if [[ ! -d "${MEMORY_DIR}" ]]; then
+    echo "ERROR: memory dir not found: ${MEMORY_DIR}" >&2
+    exit 2
+fi
+
+if [[ ! -d "${PLISTS_SRC}" ]]; then
+    echo "ERROR: plists source dir not found: ${PLISTS_SRC}" >&2
+    exit 2
+fi
+
+if [[ ! -f "${PACKAGE_DIR}/dist/cli.js" ]]; then
+    echo "ERROR: ${PACKAGE_DIR}/dist/cli.js not built. Run:" >&2
+    echo "  pnpm -F @chiefaia/mentor-fastpath build" >&2
+    exit 2
+fi
+
+if [[ ! -f "${DB_PATH}" ]]; then
+    echo "WARN: events.sqlite not found at ${DB_PATH}." >&2
+    echo "  The fast-path will idle (no events to read) until the" >&2
+    echo "  mentor-event-bus is installed and produces events." >&2
+fi
+
+# Resolve node binary path (mirror mentor-event-bus install.sh logic).
+if [[ -x /opt/homebrew/bin/node ]]; then
+    NODE_BIN="/opt/homebrew/bin/node"
+elif [[ -x /usr/local/bin/node ]]; then
+    NODE_BIN="/usr/local/bin/node"
+else
+    NODE_BIN="$(command -v node || true)"
+    if [[ -z "${NODE_BIN}" ]]; then
+        echo "ERROR: node not found." >&2
+        exit 2
+    fi
+fi
+
+# ─── Setup directories ──────────────────────────────────────────────────────
+mkdir -p "${LA_DIR}" "${LOG_DIR}" "${MEMORY_DIR}/proposals"
+
+# ─── Backup any existing plist ──────────────────────────────────────────────
+BACKUP_DIR="${HOME}/.caia-backups/mentor-fastpath-launchagents-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "${BACKUP_DIR}"
+src="${LA_DIR}/${PLIST_LABEL}.plist"
+if [[ -f "${src}" ]]; then
+    cp "${src}" "${BACKUP_DIR}/"
+    if launchctl list | grep -q "${PLIST_LABEL}"; then
+        launchctl bootout "gui/$(id -u)" "${src}" 2>/dev/null || true
+    fi
+fi
+
+# ─── Template + copy ────────────────────────────────────────────────────────
+echo "Installing ${PLIST_LABEL} into ${LA_DIR}/"
+echo "  events.sqlite  = ${DB_PATH}"
+echo "  memory dir     = ${MEMORY_DIR}"
+echo "  proposals dir  = ${MEMORY_DIR}/proposals"
+echo "  node           = ${NODE_BIN}"
+echo "  log dir        = ${LOG_DIR}"
+
+src="${PLISTS_SRC}/${PLIST_LABEL}.plist"
+dst="${LA_DIR}/${PLIST_LABEL}.plist"
+sed \
+    -e "s|__USER_HOME__|${HOME}|g" \
+    -e "s|__REPO__|${REPO_ROOT}|g" \
+    -e "s|__EVENTS_DB_PATH__|${DB_PATH}|g" \
+    -e "s|__MEMORY_DIR__|${MEMORY_DIR}|g" \
+    -e "s|__NODE_BIN__|${NODE_BIN}|g" \
+    "${src}" > "${dst}"
+echo "  installed ${PLIST_LABEL}.plist"
+
+# ─── Validate plist syntax (catches sed substitution errors) ─────────────────
+if command -v plutil >/dev/null 2>&1; then
+    if ! plutil -lint "${dst}" >/dev/null 2>&1; then
+        echo "ERROR: plutil -lint rejected ${dst}" >&2
+        plutil -lint "${dst}" || true
+        exit 2
+    fi
+fi
+
+# ─── Bootstrap into launchd ─────────────────────────────────────────────────
+echo
+echo "Bootstrapping into launchd (gui/$(id -u))"
+if launchctl bootstrap "gui/$(id -u)" "${dst}" 2>&1 | grep -v 'Bootstrap failed: 5: Input/output error'; then
+    echo "  bootstrapped ${PLIST_LABEL}"
+fi
+
+# ─── Wait for fastpath liveness ─────────────────────────────────────────────
+echo
+echo "Waiting for ${PLIST_LABEL} to start ..."
+attempt=0
+max_attempts=30
+ok=0
+while (( attempt < max_attempts )); do
+    if launchctl list | grep -q "${PLIST_LABEL}"; then
+        # Confirm a real PID, not a "-" placeholder
+        pid="$(launchctl list | awk -v label="${PLIST_LABEL}" '$3 == label { print $1 }')"
+        if [[ "${pid}" != "-" && -n "${pid}" ]]; then
+            ok=1
+            break
+        fi
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+if (( ok == 1 )); then
+    echo
+    echo "✓ ${PLIST_LABEL} is running (pid=${pid})"
+    echo "✓ Watching:    ${DB_PATH}"
+    echo "✓ Writing to:  ${MEMORY_DIR}/proposals/"
+    echo "✓ Logs:        ${LOG_DIR}/fastpath.{out,err}.log"
+    echo "✓ Backup:      ${BACKUP_DIR}/"
+    echo
+    echo "Next steps:"
+    echo "  - Status:           caia-mentor-fastpath status"
+    echo "  - Manual one-shot:  caia-mentor-fastpath process-once"
+    echo "  - Plant a test:     caia-mentor record-correction \"stop asking\""
+    echo "    (then check ${MEMORY_DIR}/proposals/ for a new file)"
+else
+    echo
+    echo "WARN: ${PLIST_LABEL} did not register a PID within ${max_attempts}s." >&2
+    echo "  See ${LOG_DIR}/fastpath.err.log for details." >&2
+    exit 1
+fi

--- a/packages/mentor-fastpath/scripts/uninstall.sh
+++ b/packages/mentor-fastpath/scripts/uninstall.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Uninstall the Mentor Phase-1 fast-path LaunchAgent.
+#
+# Usage:
+#   ./packages/mentor-fastpath/scripts/uninstall.sh
+#       — bootout + remove the plist; PRESERVE proposals/ + offset DB
+#   ./packages/mentor-fastpath/scripts/uninstall.sh --purge
+#       — also delete the offset DB (events.sqlite.fastpath-offset.sqlite)
+#       — does NOT delete proposals/ (those are operator artifacts)
+#
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+PURGE=0
+if [[ "${1:-}" == "--purge" ]]; then
+    PURGE=1
+fi
+
+LA_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs/caia-mentor"
+DB_DIR="${HOME}/Library/Application Support/caia/events"
+DB_PATH="${CAIA_EVENT_BUS_DB_PATH:-${DB_DIR}/events.sqlite}"
+OFFSET_DB="${DB_PATH}.fastpath-offset.sqlite"
+
+PLIST_LABEL="com.caia.mentor.fastpath"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "ERROR: uninstall.sh runs on macOS only." >&2
+    exit 2
+fi
+
+# Bootout + remove the plist.
+dst="${LA_DIR}/${PLIST_LABEL}.plist"
+if launchctl list | grep -q "${PLIST_LABEL}"; then
+    launchctl bootout "gui/$(id -u)" "${dst}" 2>/dev/null || true
+    echo "  booted out ${PLIST_LABEL}"
+fi
+if [[ -f "${dst}" ]]; then
+    rm -f "${dst}"
+    echo "  removed ${dst}"
+fi
+
+if (( PURGE == 1 )); then
+    if [[ -f "${OFFSET_DB}" ]]; then
+        rm -f "${OFFSET_DB}" "${OFFSET_DB}-wal" "${OFFSET_DB}-shm"
+        echo "  purged ${OFFSET_DB} (+ WAL/SHM)"
+    fi
+else
+    echo "  preserved ${OFFSET_DB} (use --purge to delete)"
+fi
+
+# Always preserve proposals — those are operator artifacts, not infra state.
+echo "  preserved <CAIA_MEMORY_DIR>/proposals/ (intentional — operator review queue)"
+
+echo
+echo "✓ Mentor fast-path uninstalled."

--- a/packages/mentor-fastpath/src/cli.ts
+++ b/packages/mentor-fastpath/src/cli.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * CLI entrypoint for the Mentor Phase-1 reactive fast-path.
+ *
+ * Subcommands:
+ *
+ *   watch [--db <path>] [--memory <dir>] [--interval <ms>] [--batch <n>]
+ *     Long-running daemon. Polls the events.sqlite for new
+ *     OperatorCorrection events; classifies + synthesizes + writes
+ *     proposals under <memoryDir>/proposals/. Used by the LaunchAgent
+ *     in PR-3.
+ *
+ *   process-once [--db <path>] [--memory <dir>] [--batch <n>]
+ *     One-shot: process whatever new events exist right now and exit.
+ *     Useful for cron-style cleanup or on-demand manual catch-up.
+ *
+ *   status [--db <path>]
+ *     One-line summary: last processed offset + total processed count.
+ *
+ * Defaults:
+ *   --db      $CAIA_EVENT_BUS_DB_PATH or
+ *             $HOME/Library/Application Support/caia/events/events.sqlite
+ *   --memory  $CAIA_MEMORY_DIR (no default — fail loudly if not set or
+ *             passed; we will not silently write to the wrong dir).
+ *   --interval 10000 (ms) — meets the ≤1 minute correction-to-action SLO.
+ *   --batch   100
+ *
+ * Both env vars + flags are honored; flags win when both supplied.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_POLL_INTERVAL_MS,
+  processOnce,
+  runConsumer
+} from './consumer.js';
+import { makeProposalCallback } from './proposal-callback.js';
+import {
+  countProcessed,
+  getLastProcessedOffset,
+  openOffsetDb
+} from './offset-store.js';
+
+const DEFAULT_DB_PATH = join(
+  homedir(),
+  'Library',
+  'Application Support',
+  'caia',
+  'events',
+  'events.sqlite'
+);
+
+interface Argv {
+  positional: string[];
+  flags: Record<string, string>;
+}
+
+function parseArgs(argv: string[]): Argv {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (token.startsWith('--')) {
+      const key = token.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = '1';
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { positional, flags };
+}
+
+function defaultDbPath(): string {
+  return process.env['CAIA_EVENT_BUS_DB_PATH'] ?? DEFAULT_DB_PATH;
+}
+
+function resolveMemoryDir(args: Argv): string {
+  const flagDir = args.flags['memory'];
+  const envDir = process.env['CAIA_MEMORY_DIR'];
+  const memoryDir = flagDir ?? envDir;
+  if (!memoryDir) {
+    throw new Error(
+      'CAIA_MEMORY_DIR is required (set the env var or pass --memory <dir>)'
+    );
+  }
+  return memoryDir;
+}
+
+async function watch(args: Argv): Promise<void> {
+  const eventsDbPath = args.flags['db'] ?? defaultDbPath();
+  const memoryDir = resolveMemoryDir(args);
+  const pollIntervalMs = Number(
+    args.flags['interval'] ?? String(DEFAULT_POLL_INTERVAL_MS)
+  );
+  const batchSize = Number(args.flags['batch'] ?? String(DEFAULT_BATCH_SIZE));
+
+  const onClassified = makeProposalCallback({ memoryDir });
+
+  const controller = new AbortController();
+  const sigHandler = (): void => {
+    console.log('[mentor-fastpath] received signal; shutting down');
+    controller.abort();
+  };
+  process.on('SIGINT', sigHandler);
+  process.on('SIGTERM', sigHandler);
+
+  console.log(
+    `[mentor-fastpath] watch starting; eventsDb=${eventsDbPath} memoryDir=${memoryDir}`
+  );
+  await runConsumer({
+    eventsDbPath,
+    pollIntervalMs,
+    batchSize,
+    onClassified,
+    abortSignal: controller.signal
+  });
+}
+
+async function once(args: Argv): Promise<void> {
+  const eventsDbPath = args.flags['db'] ?? defaultDbPath();
+  const memoryDir = resolveMemoryDir(args);
+  const batchSize = Number(args.flags['batch'] ?? String(DEFAULT_BATCH_SIZE));
+
+  const onClassified = makeProposalCallback({ memoryDir });
+  const n = await processOnce({
+    eventsDbPath,
+    batchSize,
+    onClassified
+  });
+  console.log(JSON.stringify({ ok: true, processed: n }));
+}
+
+function status(args: Argv): void {
+  const eventsDbPath = args.flags['db'] ?? defaultDbPath();
+  const offsetDbPath =
+    args.flags['offset-db'] ?? `${eventsDbPath}.fastpath-offset.sqlite`;
+  const db = openOffsetDb(offsetDbPath);
+  const lastOffset = getLastProcessedOffset(db);
+  const total = countProcessed(db);
+  db.close();
+  console.log(
+    JSON.stringify({
+      ok: true,
+      offsetDb: offsetDbPath,
+      lastOffset,
+      processedCount: total
+    })
+  );
+}
+
+function usage(): never {
+  console.error(
+    [
+      'Usage: caia-mentor-fastpath <subcommand> [flags]',
+      '',
+      'Subcommands:',
+      '  watch [--db <path>] [--memory <dir>] [--interval <ms>] [--batch <n>]',
+      '  process-once [--db <path>] [--memory <dir>] [--batch <n>]',
+      '  status [--db <path>] [--offset-db <path>]',
+      '',
+      'Env vars:',
+      '  CAIA_EVENT_BUS_DB_PATH    events.sqlite path',
+      '  CAIA_MEMORY_DIR           memory dir (proposals land in <dir>/proposals/)'
+    ].join('\n')
+  );
+  process.exit(2);
+}
+
+/**
+ * CLI dispatcher. Exported so tests can drive subcommands directly
+ * without needing a child-process spawn.
+ */
+export async function main(argv: string[]): Promise<void> {
+  const [sub, ...rest] = argv;
+  const args = parseArgs(rest);
+  switch (sub) {
+    case 'watch':
+      await watch(args);
+      return;
+    case 'process-once':
+      await once(args);
+      return;
+    case 'status':
+      status(args);
+      return;
+    case undefined:
+    case '--help':
+    case '-h':
+      usage();
+      return;
+    default:
+      console.error(`unknown subcommand: ${sub}`);
+      usage();
+  }
+}
+
+const isMain =
+  process.argv[1] !== undefined &&
+  (import.meta.url === `file://${process.argv[1]}` ||
+    import.meta.url.endsWith(process.argv[1]));
+
+if (isMain) {
+  main(process.argv.slice(2)).catch((e: unknown) => {
+    console.error(`[mentor-fastpath] fatal: ${String(e)}`);
+    process.exit(1);
+  });
+}

--- a/packages/mentor-fastpath/tests/cli.test.ts
+++ b/packages/mentor-fastpath/tests/cli.test.ts
@@ -1,0 +1,153 @@
+/**
+ * CLI tests — exercise the `main(argv)` dispatcher in-process.
+ *
+ * Avoids spawning child processes (slow + flaky in monorepo CI).
+ * Captures stdout via console.log spy. Uses tmp DBs + memoryDir so
+ * tests are isolated.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { main } from '../src/cli.js';
+
+let tmp: string;
+let eventsDbPath: string;
+let memoryDir: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mentor-cli-test-'));
+  eventsDbPath = join(tmp, 'events.sqlite');
+  memoryDir = join(tmp, 'memory');
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  // Clear env for deterministic tests
+  delete process.env['CAIA_EVENT_BUS_DB_PATH'];
+  delete process.env['CAIA_MEMORY_DIR'];
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function seedEventsDb(): void {
+  const db = new Database(eventsDbPath);
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE events (
+      id              TEXT PRIMARY KEY,
+      event_type      TEXT NOT NULL,
+      schema_version  INTEGER NOT NULL DEFAULT 1,
+      correlation_id  TEXT,
+      parent_event_id TEXT,
+      emitted_at      TEXT NOT NULL,
+      hostname        TEXT NOT NULL,
+      process_name    TEXT,
+      payload_json    TEXT NOT NULL,
+      validation_failed INTEGER NOT NULL DEFAULT 0,
+      ingest_offset   INTEGER NOT NULL UNIQUE
+    );
+    CREATE INDEX idx_events_type_off ON events(event_type, ingest_offset);
+    INSERT INTO events VALUES (
+      'ev_cli_test', 'OperatorCorrection', 1, NULL, NULL,
+      '2026-05-05T01:00:00Z', 'test-host', 'test-proc',
+      '{"correctionText":"stop asking","detectionMode":"manual"}',
+      0, 1
+    );
+  `);
+  db.close();
+}
+
+describe('cli main()', () => {
+  it('process-once writes a proposal and prints {ok:true,processed:N}', async () => {
+    seedEventsDb();
+    await main(['process-once', '--db', eventsDbPath, '--memory', memoryDir]);
+    const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('"processed":1');
+    expect(out).toContain('"ok":true');
+    const proposalsDir = join(memoryDir, 'proposals');
+    const files = readdirSync(proposalsDir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toContain('decisionclassifierviolation');
+  });
+
+  it('process-once requires --memory or CAIA_MEMORY_DIR', async () => {
+    seedEventsDb();
+    await expect(
+      main(['process-once', '--db', eventsDbPath])
+    ).rejects.toThrow(/CAIA_MEMORY_DIR is required/);
+  });
+
+  it('process-once accepts CAIA_MEMORY_DIR env var as fallback', async () => {
+    seedEventsDb();
+    process.env['CAIA_MEMORY_DIR'] = memoryDir;
+    await main(['process-once', '--db', eventsDbPath]);
+    const proposalsDir = join(memoryDir, 'proposals');
+    const files = readdirSync(proposalsDir);
+    expect(files.length).toBe(1);
+  });
+
+  it('status prints offset + processed count', () => {
+    seedEventsDb();
+    main(['status', '--db', eventsDbPath]).catch(() => undefined);
+    // status is sync; immediately check
+    const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('"ok":true');
+    expect(out).toContain('"lastOffset":0');
+    expect(out).toContain('"processedCount":0');
+  });
+
+  it('--help prints usage and exits with code 2', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    try {
+      await expect(main(['--help'])).rejects.toThrow(/exit 2/);
+      expect(errSpy.mock.calls.some((c) => String(c[0]).includes('Usage'))).toBe(
+        true
+      );
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('unknown subcommand prints error + usage and exits with code 2', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    try {
+      await expect(main(['bogus'])).rejects.toThrow(/exit 2/);
+      expect(
+        errSpy.mock.calls.some((c) => String(c[0]).includes('unknown subcommand'))
+      ).toBe(true);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('flags can take values without spaces ahead of next flag', async () => {
+    seedEventsDb();
+    await main([
+      'process-once',
+      '--db',
+      eventsDbPath,
+      '--memory',
+      memoryDir,
+      '--batch',
+      '50'
+    ]);
+    const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(out).toContain('"processed":1');
+  });
+});


### PR DESCRIPTION
## Summary

PR-3 of Mentor Phase 1 reactive fast-path. Adds the long-running daemon infrastructure so the consumer + classifier + synthesizer + memory-writer chain (PR-1 + PR-2) runs continuously on the operator's Mac.

After this PR merges and the operator runs the install script, the full reactive loop is live: an \`OperatorCorrection\` event in the bus → a proposal markdown in \`<CAIA_MEMORY_DIR>/proposals/\` within ~10s.

## Stages traversed

- **1. Analyze** — Re-read the leg-4 PR-3 plan + the existing mentor-event-bus plists/install.sh as the reference style.
- **2. Research** — Looked at \`com.caia.mentor.server.plist\` + \`com.caia.mentor.memory-watcher.plist\` for the conventions (KeepAlive=Crashed-only, ThrottleInterval=10s, Background ProcessType, sed-templated env vars).
- **3. Solution** — Single CLI module exposing 3 subcommands (watch / process-once / status); single LaunchAgent plist; install + uninstall scripts mirroring the event-bus pattern; \`bin\` field in package.json.
- **4. Implement** — 5 files (cli, plist, install.sh, uninstall.sh, cli.test.ts) + package.json update.
- **5. Test + integrate** — pnpm typecheck ✓, lint ✓, test ✓ (100 cases — 93 carried + 7 net new). \`bash -n\` + \`plutil -lint\` both ok on the new scripts/plist.
- **6. Test again** — Stage 6 happens on Mac in the next leg-5 step (live install, plant a correction, verify proposal lands).

## What's added

| File | Purpose | LoC |
|---|---|---|
| \`src/cli.ts\` | argparse + dispatch (watch / process-once / status) | ~200 |
| \`plists/com.caia.mentor.fastpath.plist\` | LaunchAgent template | (xml) |
| \`scripts/install.sh\` | Idempotent install with plutil-lint validation | ~160 |
| \`scripts/uninstall.sh\` | Bootout + remove; \`--purge\` drops offset DB | ~50 |
| \`tests/cli.test.ts\` | 7 cases (subcommand dispatch, env-var fallback, error paths) | ~150 |
| \`package.json\` | \`bin\` + \`./cli\` export + \`files\` includes plists/scripts | (modified) |

## Stage 6 verification plan (next leg-5 step, post-merge)

\`\`\`bash
pnpm -F @chiefaia/mentor-fastpath build
CAIA_MEMORY_DIR=\"\$HOME/Library/Application Support/Claude/local-agent-mode-sessions/.../agent/memory\" \\
  bash packages/mentor-fastpath/scripts/install.sh

# Inject a fake operator correction via the existing event-bus CLI:
caia-mentor record-correction \"stop asking me what to do next\"

# Within 10-15s, expect a new file under \$CAIA_MEMORY_DIR/proposals/
# classified as DecisionClassifierViolation.
ls -la \"\$CAIA_MEMORY_DIR/proposals/\"
\`\`\`

## Subscription-only compliance

✓ No new paid deps. LaunchAgent runs locally. No network calls beyond what the consumer already does (read-only SQLite).

## What this completes

After PR-3 ships and is installed, the Phase-1 minimum from the directive (\"Reactive Mentor (2-3 days): operator-correction fast path only. When operator types corrective language, Mentor detects via simple regex + LLM verification, classifies, and proposes a memory update for review\") is fully achievable end-to-end via the manual \`caia-mentor record-correction\` CLI. The remaining gap toward full Phase 1 is automatic detection of operator corrections in chat (PR-4 — pattern detection) and optional LLM verification (PR-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)