### PR TITLE
feat(mentor-phase2-002): postmerge watcher daemon (PR-2)

### DIFF
--- a/packages/mentor-fastpath/package.json
+++ b/packages/mentor-fastpath/package.json
@@ -2,13 +2,14 @@
   "name": "@chiefaia/mentor-fastpath",
   "version": "0.1.0",
   "private": true,
-  "description": "Mentor Phase-1 reactive fast-path + Phase-2 postmerge data layer. Subscribes to OperatorCorrection events from the Mentor event bus, classifies the failure mode against the 18-category taxonomy, synthesizes a draft markdown lesson, and writes it to <CAIA_MEMORY_DIR>/proposals/ within 1 minute of the operator correction. The Phase-2 postmerge module adds pure-function classifier + synthesizer for PRMerged / EvidenceGateFailure / RegressionDetected event payloads.",
+  "description": "Mentor Phase-1 reactive fast-path + Phase-2 postmerge data layer + Phase-2 postmerge watcher daemon. Subscribes to OperatorCorrection events from the Mentor event bus, classifies the failure mode against the 18-category taxonomy, synthesizes a draft markdown lesson, and writes it to <CAIA_MEMORY_DIR>/proposals/ within 1 minute of the operator correction. The Phase-2 postmerge watcher (caia-postmerge-watcher) polls 'gh pr list --state merged' + 'gh run list --status failure' and emits PRMerged / RegressionDetected / EvidenceGateFailure events into the bus.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "caia-mentor-fastpath": "./dist/cli.js"
+    "caia-mentor-fastpath": "./dist/cli.js",
+    "caia-postmerge-watcher": "./dist/postmerge/watcher/cli.js"
   },
   "exports": {
     ".": {
@@ -22,6 +23,10 @@
     "./postmerge": {
       "import": "./dist/postmerge/index.js",
       "types": "./dist/postmerge/index.d.ts"
+    },
+    "./postmerge/watcher": {
+      "import": "./dist/postmerge/watcher/index.js",
+      "types": "./dist/postmerge/watcher/index.d.ts"
     }
   },
   "files": [

--- a/packages/mentor-fastpath/src/postmerge/watcher/cli.ts
+++ b/packages/mentor-fastpath/src/postmerge/watcher/cli.ts
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * CLI entrypoint for the postmerge watcher.
+ *
+ * Subcommands:
+ *
+ *   watch [--db <path>] [--state <path>] [--base-refs develop,main]
+ *         [--interval-ms 300000] [--initial-lookback-hours 24]
+ *         [--skip-failed-job-lookup]
+ *     Run the long-running poll loop. The --db is the mentor-event-bus
+ *     events.sqlite (we WRITE to it via the bus Client). --state is the
+ *     watcher's own state DB.
+ *
+ *   scan-once [...same flags]
+ *     Run exactly one iteration and exit. Useful for cron / cron-like
+ *     setups + smoke tests + Stage-6 verify.
+ *
+ *   status [--state <path>]
+ *     Print a one-line JSON with seen-counts + cursor.
+ *
+ * Defaults:
+ *   --db    $CAIA_EVENT_BUS_DB_PATH or
+ *           ~/Library/Application Support/caia/events/events.sqlite
+ *   --state ${CAIA_POSTMERGE_STATE_PATH} or <db>.postmerge-watcher-state.sqlite
+ *
+ * Env:
+ *   CAIA_EVENT_BUS_DB_PATH        events.sqlite to write events into
+ *   CAIA_POSTMERGE_STATE_PATH     watcher state DB
+ *   CAIA_POSTMERGE_BASE_REFS      comma-separated branches (default develop,main)
+ *   CAIA_POSTMERGE_INTERVAL_MS    poll interval (default 300000)
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { Client } from '@chiefaia/mentor-event-bus';
+
+import {
+  countSeenPrs,
+  countSeenRuns,
+  getCursor,
+  openStateStore
+} from './state-store.js';
+import {
+  DEFAULT_BASE_REFS,
+  DEFAULT_INITIAL_LOOKBACK_HOURS,
+  DEFAULT_POLL_INTERVAL_MS,
+  runIteration,
+  runProducer
+} from './producer.js';
+
+interface Argv {
+  positional: string[];
+  flags: Record<string, string>;
+}
+
+function parseArgs(argv: string[]): Argv {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (token.startsWith('--')) {
+      const key = token.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = '1';
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { positional, flags };
+}
+
+function defaultBusDbPath(): string {
+  return (
+    process.env['CAIA_EVENT_BUS_DB_PATH'] ??
+    join(
+      homedir(),
+      'Library',
+      'Application Support',
+      'caia',
+      'events',
+      'events.sqlite'
+    )
+  );
+}
+
+function defaultStateDbPath(busDbPath: string): string {
+  return (
+    process.env['CAIA_POSTMERGE_STATE_PATH'] ??
+    `${busDbPath}.postmerge-watcher-state.sqlite`
+  );
+}
+
+function resolveBaseRefs(args: Argv): readonly string[] {
+  const flag = args.flags['base-refs'] ?? process.env['CAIA_POSTMERGE_BASE_REFS'];
+  if (!flag) return DEFAULT_BASE_REFS;
+  return flag
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function buildCommonOpts(args: Argv): {
+  busDb: string;
+  stateDb: string;
+  baseRefs: readonly string[];
+  intervalMs: number;
+  lookbackHours: number;
+  skipFailedJobLookup: boolean;
+} {
+  const busDb = args.flags['db'] ?? defaultBusDbPath();
+  const stateDb = args.flags['state'] ?? defaultStateDbPath(busDb);
+  const baseRefs = resolveBaseRefs(args);
+  const intervalMs = Number(
+    args.flags['interval-ms'] ??
+      process.env['CAIA_POSTMERGE_INTERVAL_MS'] ??
+      DEFAULT_POLL_INTERVAL_MS
+  );
+  const lookbackHours = Number(
+    args.flags['initial-lookback-hours'] ?? DEFAULT_INITIAL_LOOKBACK_HOURS
+  );
+  const skipFailedJobLookup = args.flags['skip-failed-job-lookup'] === '1';
+  return {
+    busDb,
+    stateDb,
+    baseRefs,
+    intervalMs,
+    lookbackHours,
+    skipFailedJobLookup
+  };
+}
+
+async function watchCmd(args: Argv): Promise<void> {
+  const opts = buildCommonOpts(args);
+  const stateDb = openStateStore(opts.stateDb);
+  const busClient = new Client({
+    dbPath: opts.busDb,
+    processName: 'caia-postmerge-watcher'
+  });
+  const ac = new AbortController();
+  const stop = (): void => {
+    ac.abort();
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+
+  await runProducer({
+    stateDb,
+    busClient,
+    baseRefs: opts.baseRefs,
+    pollIntervalMs: opts.intervalMs,
+    initialLookbackHours: opts.lookbackHours,
+    skipFailedJobLookup: opts.skipFailedJobLookup,
+    abortSignal: ac.signal
+  });
+
+  busClient.close();
+  stateDb.close();
+}
+
+async function scanOnceCmd(args: Argv): Promise<void> {
+  const opts = buildCommonOpts(args);
+  const stateDb = openStateStore(opts.stateDb);
+  const busClient = new Client({
+    dbPath: opts.busDb,
+    processName: 'caia-postmerge-watcher'
+  });
+  try {
+    const stats = runIteration({
+      stateDb,
+      busClient,
+      baseRefs: opts.baseRefs,
+      initialLookbackHours: opts.lookbackHours,
+      skipFailedJobLookup: opts.skipFailedJobLookup
+    });
+    console.log(JSON.stringify({ ok: true, stats }));
+  } finally {
+    busClient.close();
+    stateDb.close();
+  }
+}
+
+function statusCmd(args: Argv): void {
+  const opts = buildCommonOpts(args);
+  const stateDb = openStateStore(opts.stateDb);
+  try {
+    const c = getCursor(stateDb);
+    const out = {
+      stateDbPath: opts.stateDb,
+      seenPrCount: countSeenPrs(stateDb),
+      seenRunCount: countSeenRuns(stateDb),
+      lastPrQueryIso: c.lastPrQueryIso,
+      lastRunQueryIso: c.lastRunQueryIso
+    };
+    console.log(JSON.stringify(out));
+  } finally {
+    stateDb.close();
+  }
+}
+
+function usage(): never {
+  console.error(
+    [
+      'Usage: caia-postmerge-watcher <subcommand> [flags]',
+      '',
+      'Subcommands:',
+      '  watch        Long-running poll loop (LaunchAgent-friendly).',
+      '  scan-once    One iteration, then exit.',
+      '  status       Print seen-counts + cursor as one-line JSON.',
+      '',
+      'Flags:',
+      '  --db <path>                          events.sqlite (default: $CAIA_EVENT_BUS_DB_PATH)',
+      '  --state <path>                       watcher state DB',
+      '  --base-refs develop,main             comma-separated branches to watch',
+      '  --interval-ms 300000                 poll interval (watch only)',
+      '  --initial-lookback-hours 24          first-poll look-back window',
+      '  --skip-failed-job-lookup             do not call gh run view (faster, less detail)'
+    ].join('\n')
+  );
+  process.exit(2);
+}
+
+export async function main(argv: string[]): Promise<void> {
+  const [sub, ...rest] = argv;
+  const args = parseArgs(rest);
+  switch (sub) {
+    case 'watch':
+      await watchCmd(args);
+      return;
+    case 'scan-once':
+      await scanOnceCmd(args);
+      return;
+    case 'status':
+      statusCmd(args);
+      return;
+    case undefined:
+    case '--help':
+    case '-h':
+      usage();
+      return;
+    default:
+      console.error(`unknown subcommand: ${sub}`);
+      usage();
+  }
+}
+
+const isMain =
+  process.argv[1] !== undefined &&
+  (import.meta.url === `file://${process.argv[1]}` ||
+    import.meta.url.endsWith(process.argv[1]));
+
+if (isMain) {
+  main(process.argv.slice(2)).catch((e: unknown) => {
+    console.error(`[caia-postmerge-watcher] fatal: ${String(e)}`);
+    process.exit(1);
+  });
+}

--- a/packages/mentor-fastpath/src/postmerge/watcher/gh-client.ts
+++ b/packages/mentor-fastpath/src/postmerge/watcher/gh-client.ts
@@ -1,0 +1,261 @@
+/**
+ * Thin wrapper around the GitHub `gh` CLI for the postmerge watcher.
+ *
+ * Subscription-only constraint: NO Octokit / paid API tokens. The
+ * operator's `gh` CLI is already authenticated against their personal
+ * GitHub account; we shell out to it.
+ *
+ * Each call uses `execFileSync` (NOT `execSync`) to keep arguments out
+ * of shell-escape territory. All commands include `--json <fields>` so
+ * we get parseable output and never depend on `gh` text formatting.
+ *
+ * Errors:
+ *   - Network / auth errors throw — caller decides whether to retry
+ *     vs. surface a warning.
+ *   - JSON parse errors throw with the raw text for debugging.
+ *
+ * Tests inject a mock `runGh` to avoid real network. Production uses
+ * `defaultRunGh` which calls `execFileSync('gh', ...)`.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Function signature for the gh-runner. Tests pass a mock; production
+ * uses `defaultRunGh`. Returns stdout (utf-8, trimmed). Throws on
+ * non-zero exit.
+ */
+export type RunGh = (args: ReadonlyArray<string>) => string;
+
+/** Default real-shell gh runner. Times out after 60s per command. */
+export const defaultRunGh: RunGh = (args) => {
+  const out = execFileSync('gh', [...args], {
+    encoding: 'utf-8',
+    timeout: 60_000,
+    maxBuffer: 32 * 1024 * 1024
+  });
+  return out.trim();
+};
+
+// ─── Type contracts ───────────────────────────────────────────────────────
+
+export interface MergedPr {
+  number: number;
+  title: string;
+  /** Merge SHA. May be empty in degenerate cases — caller should skip. */
+  mergeCommit: string;
+  /** Branch name the PR merged into (e.g. 'develop'). */
+  baseRefName: string;
+  /** PR head ref, e.g. 'feat/mentor-phase2-001-...'. Useful for filtering. */
+  headRefName: string;
+  /** ISO 8601 timestamp of the merge. */
+  mergedAt: string;
+  /** PR author login. */
+  author: string;
+}
+
+export interface FailedRun {
+  /** GitHub workflow-run id. Stable across queries — use for dedupe. */
+  databaseId: number;
+  /** Workflow name (e.g. 'Build · Test · Lint · Typecheck'). */
+  workflowName: string;
+  /** Branch name (head_branch) the run targeted. */
+  headBranch: string;
+  /** Commit SHA the run was triggered against. */
+  headSha: string;
+  /** ISO 8601 of run completion. */
+  updatedAt: string;
+  /** Run status — 'completed' filtered to status=failure / cancelled. */
+  conclusion: string;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+export interface GhClientOptions {
+  /** Mock injection. Default: real `gh` CLI. */
+  runGh?: RunGh;
+  /** Repo owner/name. Default: detected from cwd via `gh repo view`. */
+  repo?: string;
+}
+
+/**
+ * List PRs merged since `sinceIso` against any of the given base refs.
+ *
+ * Uses `gh pr list --state merged --search "merged:>=<sinceIso> base:<branch>"`.
+ *
+ * Returns the parsed PRs in newest-first order (gh's default).
+ */
+export function listMergedPrs(
+  opts: GhClientOptions,
+  sinceIso: string,
+  baseRefs: ReadonlyArray<string> = ['develop', 'main'],
+  limit = 50
+): MergedPr[] {
+  const run = opts.runGh ?? defaultRunGh;
+  const baseQuery = baseRefs.map((b) => `base:${b}`).join(' ');
+  const search = `merged:>=${sinceIso} ${baseQuery}`;
+  const args = [
+    'pr',
+    'list',
+    '--state',
+    'merged',
+    '--search',
+    search,
+    '--limit',
+    String(limit),
+    '--json',
+    'number,title,mergeCommit,baseRefName,headRefName,mergedAt,author'
+  ];
+  if (opts.repo) {
+    args.push('--repo', opts.repo);
+  }
+  const raw = run(args);
+  if (raw.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`gh pr list returned unparseable JSON: ${String(e)}\nraw=${raw.slice(0, 200)}`, { cause: e });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`gh pr list expected array; got ${typeof parsed}`);
+  }
+  return parsed.map(normalizeMergedPr);
+}
+
+/**
+ * List failed workflow runs since `sinceIso` against the given branches.
+ *
+ * Uses `gh run list --branch <b> --status failure` (one call per branch
+ * because gh has no multi-branch filter).
+ */
+export function listFailedRuns(
+  opts: GhClientOptions,
+  sinceIso: string,
+  branches: ReadonlyArray<string> = ['develop', 'main'],
+  limit = 50
+): FailedRun[] {
+  const run = opts.runGh ?? defaultRunGh;
+  const all: FailedRun[] = [];
+  for (const branch of branches) {
+    const args = [
+      'run',
+      'list',
+      '--branch',
+      branch,
+      '--status',
+      'failure',
+      '--limit',
+      String(limit),
+      '--json',
+      'databaseId,name,headBranch,headSha,updatedAt,conclusion'
+    ];
+    if (opts.repo) {
+      args.push('--repo', opts.repo);
+    }
+    const raw = run(args);
+    if (raw.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(
+        `gh run list (branch=${branch}) returned unparseable JSON: ${String(e)}\nraw=${raw.slice(0, 200)}`,
+        { cause: e }
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`gh run list (branch=${branch}) expected array; got ${typeof parsed}`);
+    }
+    for (const r of parsed) {
+      const norm = normalizeRun(r);
+      if (norm.updatedAt >= sinceIso) all.push(norm);
+    }
+  }
+  return all;
+}
+
+/**
+ * Fetch the failed job names within a given workflow run.
+ *
+ * Uses `gh run view <id> --json jobs`. Filters to jobs with
+ * `conclusion === 'failure'`. Returns just the names (the synthesizer
+ * uses these for FailureMode routing).
+ */
+export function getFailedJobNames(
+  opts: GhClientOptions,
+  runId: number
+): string[] {
+  const run = opts.runGh ?? defaultRunGh;
+  const args = ['run', 'view', String(runId), '--json', 'jobs'];
+  if (opts.repo) {
+    args.push('--repo', opts.repo);
+  }
+  const raw = run(args);
+  if (raw.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`gh run view ${runId} returned unparseable JSON: ${String(e)}`, { cause: e });
+  }
+  if (typeof parsed !== 'object' || parsed === null) return [];
+  const jobs = (parsed as { jobs?: Array<{ name?: string; conclusion?: string }> }).jobs;
+  if (!Array.isArray(jobs)) return [];
+  return jobs
+    .filter((j) => j.conclusion === 'failure')
+    .filter((j): j is { name: string; conclusion: string } => typeof j.name === 'string' && j.name.length > 0)
+    .map((j) => j.name);
+}
+
+// ─── Normalizers (defensive parsing for gh JSON variations) ───────────────
+
+interface RawAuthor {
+  login?: string;
+  is_bot?: boolean;
+}
+interface RawMergeCommit {
+  oid?: string;
+}
+interface RawMergedPr {
+  number: number;
+  title: string;
+  mergeCommit?: RawMergeCommit | null;
+  baseRefName?: string;
+  headRefName?: string;
+  mergedAt?: string;
+  author?: RawAuthor;
+}
+interface RawRun {
+  databaseId: number;
+  name?: string;
+  headBranch?: string;
+  headSha?: string;
+  updatedAt?: string;
+  conclusion?: string;
+}
+
+function normalizeMergedPr(raw: unknown): MergedPr {
+  const r = raw as RawMergedPr;
+  return {
+    number: r.number,
+    title: r.title ?? '',
+    mergeCommit: r.mergeCommit?.oid ?? '',
+    baseRefName: r.baseRefName ?? 'develop',
+    headRefName: r.headRefName ?? '',
+    mergedAt: r.mergedAt ?? '',
+    author: r.author?.login ?? 'unknown'
+  };
+}
+
+function normalizeRun(raw: unknown): FailedRun {
+  const r = raw as RawRun;
+  return {
+    databaseId: r.databaseId,
+    workflowName: r.name ?? '',
+    headBranch: r.headBranch ?? '',
+    headSha: r.headSha ?? '',
+    updatedAt: r.updatedAt ?? '',
+    conclusion: r.conclusion ?? ''
+  };
+}

--- a/packages/mentor-fastpath/src/postmerge/watcher/index.ts
+++ b/packages/mentor-fastpath/src/postmerge/watcher/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Postmerge watcher — public surface.
+ *
+ * The watcher polls GitHub via `gh` CLI and emits events into the
+ * mentor-event-bus. Phase-2 PR-2 ships this module; Phase-2 PR-3 will
+ * add the consumer that subscribes to these events and produces
+ * proposals via the Phase-2 PR-1 data layer.
+ */
+
+export {
+  defaultRunGh,
+  listMergedPrs,
+  listFailedRuns,
+  getFailedJobNames,
+  type RunGh,
+  type GhClientOptions,
+  type MergedPr,
+  type FailedRun
+} from './gh-client.js';
+
+export {
+  openStateStore,
+  getCursor,
+  setCursor,
+  isPrSeen,
+  recordPrSeen,
+  isRunSeen,
+  recordRunSeen,
+  countSeenPrs,
+  countSeenRuns,
+  type CursorState
+} from './state-store.js';
+
+export {
+  runProducer,
+  runIteration,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_INITIAL_LOOKBACK_HOURS,
+  DEFAULT_BASE_REFS,
+  type ProducerOptions,
+  type IterationStats
+} from './producer.js';

--- a/packages/mentor-fastpath/src/postmerge/watcher/producer.ts
+++ b/packages/mentor-fastpath/src/postmerge/watcher/producer.ts
@@ -1,0 +1,290 @@
+/**
+ * Postmerge watcher producer — periodic poll loop that emits events
+ * into the mentor-event-bus.
+ *
+ * Each poll iteration:
+ *
+ *   1. Read the cursor (`last_pr_query_iso` / `last_run_query_iso`).
+ *   2. Call `gh pr list --state merged --search "merged:>=<since>"`.
+ *      For each PR not in `seen_prs`: emit a `PRMerged` event,
+ *      record in `seen_prs`.
+ *   3. Call `gh run list --status failure --branch <branch>` for each
+ *      base branch (default: develop, main). For each run not in
+ *      `seen_runs`: classify the run as either:
+ *        - `RegressionDetected` if `head_sha` matches a known merged
+ *          PR's mergeCommit (CI red after a merge).
+ *        - `EvidenceGateFailure` otherwise (failed CI on a feature
+ *          branch — pre-merge gate).
+ *      Emit + record.
+ *   4. Update the cursor to the iso timestamp of this iteration's
+ *      query window.
+ *
+ * Errors during a single iteration are caught + logged; the loop
+ * continues so a transient gh outage doesn't wedge the watcher.
+ *
+ * No proposal generation happens here — proposals are the Phase-2 PR-3
+ * consumer's job. This module only translates "external world signals"
+ * into "events on the bus."
+ */
+
+import { hostname as osHostname } from 'node:os';
+import type { Database as DatabaseInstance } from 'better-sqlite3';
+
+import { Client } from '@chiefaia/mentor-event-bus';
+
+import {
+  getFailedJobNames,
+  listFailedRuns,
+  listMergedPrs,
+  type FailedRun,
+  type GhClientOptions,
+  type MergedPr
+} from './gh-client.js';
+import {
+  getCursor,
+  isPrSeen,
+  isRunSeen,
+  recordPrSeen,
+  recordRunSeen,
+  setCursor
+} from './state-store.js';
+
+/** Default poll interval: 5 min. Postmerge events aren't latency-critical. */
+export const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Default look-back window for the very first poll: 24h. */
+export const DEFAULT_INITIAL_LOOKBACK_HOURS = 24;
+
+/** Default base refs we watch. */
+export const DEFAULT_BASE_REFS: ReadonlyArray<string> = ['develop', 'main'];
+
+export interface ProducerOptions {
+  /** State-store sqlite (already opened). */
+  stateDb: DatabaseInstance;
+  /** Event-bus client. Producer does not own its lifecycle (caller closes). */
+  busClient: Client;
+  /** Mock injection for `gh` CLI calls. */
+  ghClient?: GhClientOptions;
+  /** Branches to watch for merges + failures. Default: develop, main. */
+  baseRefs?: ReadonlyArray<string>;
+  /** First-poll look-back window in hours. Default 24. */
+  initialLookbackHours?: number;
+  /** Poll interval in ms. Default 5min. */
+  pollIntervalMs?: number;
+  /** AbortSignal for graceful shutdown. */
+  abortSignal?: AbortSignal;
+  /** Logger. Default console. */
+  logger?: { info: (m: string) => void; warn: (m: string) => void };
+  /** Override sleep (test injection). */
+  sleepFn?: (ms: number) => Promise<void>;
+  /** Override the now() clock. Default Date.now/Date. */
+  now?: () => Date;
+  /**
+   * If true, do not call `gh run view <id> --json jobs` to fetch failed
+   * job names — emit failedJobs as []. Useful for tests and for low-API
+   * environments. Default false.
+   */
+  skipFailedJobLookup?: boolean;
+}
+
+const consoleLogger = {
+  info: (m: string): void => console.log(m),
+  warn: (m: string): void => console.warn(m)
+};
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Stats returned per iteration — useful for tests + status reporting. */
+export interface IterationStats {
+  prsSeen: number;
+  prsEmitted: number;
+  runsSeen: number;
+  runsEmittedAsRegression: number;
+  runsEmittedAsGateFailure: number;
+  errors: string[];
+}
+
+/** Run a single iteration. Exposed for tests + scan-once CLI. */
+export function runIteration(opts: ProducerOptions): IterationStats {
+  const stats: IterationStats = {
+    prsSeen: 0,
+    prsEmitted: 0,
+    runsSeen: 0,
+    runsEmittedAsRegression: 0,
+    runsEmittedAsGateFailure: 0,
+    errors: []
+  };
+
+  const logger = opts.logger ?? consoleLogger;
+  const baseRefs = opts.baseRefs ?? DEFAULT_BASE_REFS;
+  const lookbackHours =
+    opts.initialLookbackHours ?? DEFAULT_INITIAL_LOOKBACK_HOURS;
+  const now = (opts.now ?? ((): Date => new Date()))();
+  const cursor = getCursor(opts.stateDb);
+  const fallbackPrSince = new Date(
+    now.getTime() - lookbackHours * 3600_000
+  ).toISOString();
+  const sincePrIso = cursor.lastPrQueryIso ?? fallbackPrSince;
+  const sinceRunIso = cursor.lastRunQueryIso ?? fallbackPrSince;
+  // gh search syntax wants minute precision (no T-separator), so format:
+  //   YYYY-MM-DDTHH:MM:SSZ → keep as ISO; gh accepts it.
+  // Use the raw ISO timestamp.
+
+  // ─── 1. Poll merged PRs ──────────────────────────────────────────────
+  let mergedPrs: MergedPr[] = [];
+  try {
+    mergedPrs = listMergedPrs(
+      opts.ghClient ?? {},
+      sincePrIso,
+      baseRefs,
+      50
+    );
+    stats.prsSeen = mergedPrs.length;
+  } catch (e) {
+    const msg = `gh pr list failed: ${String(e)}`;
+    logger.warn(`[postmerge-watcher] ${msg}`);
+    stats.errors.push(msg);
+  }
+
+  for (const pr of mergedPrs) {
+    if (isPrSeen(opts.stateDb, pr.number)) continue;
+    let eventId: string | null = null;
+    try {
+      eventId = opts.busClient.emit('PRMerged', {
+        prNumber: pr.number,
+        sha: pr.mergeCommit,
+        branch: pr.baseRefName,
+        author: pr.author
+      });
+      if (eventId !== null) stats.prsEmitted++;
+    } catch (e) {
+      const msg = `emit PRMerged for #${pr.number} failed: ${String(e)}`;
+      logger.warn(`[postmerge-watcher] ${msg}`);
+      stats.errors.push(msg);
+    }
+    recordPrSeen(opts.stateDb, {
+      prNumber: pr.number,
+      mergeSha: pr.mergeCommit,
+      mergedAt: pr.mergedAt,
+      emittedEventId: eventId,
+      processedAt: now.toISOString()
+    });
+  }
+
+  // ─── 2. Poll failed runs ─────────────────────────────────────────────
+  let failedRuns: FailedRun[] = [];
+  try {
+    failedRuns = listFailedRuns(
+      opts.ghClient ?? {},
+      sinceRunIso,
+      baseRefs,
+      50
+    );
+    stats.runsSeen = failedRuns.length;
+  } catch (e) {
+    const msg = `gh run list failed: ${String(e)}`;
+    logger.warn(`[postmerge-watcher] ${msg}`);
+    stats.errors.push(msg);
+  }
+
+  // Build a sha → mergedPr lookup so we can route by signal type. Both
+  // the freshly-seen PRs above and the existing seen_prs rows are
+  // candidates — query the DB.
+  const mergedShas = new Set<string>();
+  const mergeShaRows = opts.stateDb
+    .prepare("SELECT merge_sha FROM seen_prs WHERE merge_sha IS NOT NULL AND merge_sha != ''")
+    .all() as Array<{ merge_sha: string }>;
+  for (const row of mergeShaRows) mergedShas.add(row.merge_sha);
+
+  for (const run of failedRuns) {
+    if (isRunSeen(opts.stateDb, run.databaseId)) continue;
+    let failedJobs: string[] = [];
+    if (!opts.skipFailedJobLookup) {
+      try {
+        failedJobs = getFailedJobNames(opts.ghClient ?? {}, run.databaseId);
+      } catch (e) {
+        const msg = `gh run view ${run.databaseId} failed: ${String(e)}`;
+        logger.warn(`[postmerge-watcher] ${msg}`);
+        stats.errors.push(msg);
+      }
+    }
+
+    let eventId: string | null = null;
+    try {
+      if (mergedShas.has(run.headSha)) {
+        // Failed CI on a known merge commit → regression.
+        eventId = opts.busClient.emit('RegressionDetected', {
+          testName: run.workflowName || 'unknown-workflow',
+          failedSha: run.headSha
+        });
+        if (eventId !== null) stats.runsEmittedAsRegression++;
+      } else {
+        // Failed CI on a non-merged ref → pre-merge evidence-gate failure.
+        // We don't have a canonical PR# here (run is on a branch, not
+        // necessarily tied to an open PR), so we emit prNumber=0 as a
+        // sentinel meaning "no PR association captured." Consumer
+        // tolerates this.
+        eventId = opts.busClient.emit('EvidenceGateFailure', {
+          prNumber: 0,
+          failedJobs:
+            failedJobs.length > 0
+              ? failedJobs
+              : [run.workflowName || 'unknown-workflow']
+        });
+        if (eventId !== null) stats.runsEmittedAsGateFailure++;
+      }
+    } catch (e) {
+      const msg = `emit run ${run.databaseId} failed: ${String(e)}`;
+      logger.warn(`[postmerge-watcher] ${msg}`);
+      stats.errors.push(msg);
+    }
+    recordRunSeen(opts.stateDb, {
+      runId: run.databaseId,
+      headSha: run.headSha,
+      updatedAt: run.updatedAt,
+      emittedEventId: eventId,
+      processedAt: now.toISOString()
+    });
+  }
+
+  // ─── 3. Advance cursor ───────────────────────────────────────────────
+  setCursor(opts.stateDb, {
+    lastPrQueryIso: now.toISOString(),
+    lastRunQueryIso: now.toISOString()
+  });
+
+  return stats;
+}
+
+/**
+ * Long-running poll loop. Resolves when `abortSignal` fires.
+ *
+ * Each iteration is wrapped in try/catch so a transient gh failure
+ * doesn't kill the daemon. The cursor is only advanced if the iteration
+ * completes without a top-level throw.
+ */
+export async function runProducer(opts: ProducerOptions): Promise<void> {
+  const logger = opts.logger ?? consoleLogger;
+  const sleep = opts.sleepFn ?? defaultSleep;
+  const interval = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const host = osHostname();
+
+  logger.info(
+    `[postmerge-watcher] starting; host=${host} interval=${interval}ms baseRefs=${(opts.baseRefs ?? DEFAULT_BASE_REFS).join(',')}`
+  );
+
+  while (!(opts.abortSignal?.aborted ?? false)) {
+    try {
+      const stats = runIteration(opts);
+      logger.info(
+        `[postmerge-watcher] tick: prs=${stats.prsSeen}/${stats.prsEmitted} runs=${stats.runsSeen}/${stats.runsEmittedAsRegression}+${stats.runsEmittedAsGateFailure} errors=${stats.errors.length}`
+      );
+    } catch (e) {
+      logger.warn(`[postmerge-watcher] iteration threw: ${String(e)}`);
+    }
+    await sleep(interval);
+  }
+
+  logger.info('[postmerge-watcher] producer stopped');
+}

--- a/packages/mentor-fastpath/src/postmerge/watcher/state-store.ts
+++ b/packages/mentor-fastpath/src/postmerge/watcher/state-store.ts
@@ -1,0 +1,180 @@
+/**
+ * State store for the postmerge watcher.
+ *
+ * Tracks which merged PRs and which failed workflow runs we have
+ * already emitted events for, so the watcher is idempotent across
+ * restarts.
+ *
+ * Schema (single sqlite file, separate from the event-bus DB):
+ *
+ *   table seen_prs:
+ *     pr_number INTEGER PRIMARY KEY,
+ *     merge_sha TEXT,
+ *     merged_at TEXT,
+ *     emitted_event_id TEXT,
+ *     processed_at TEXT
+ *
+ *   table seen_runs:
+ *     run_id INTEGER PRIMARY KEY,
+ *     head_sha TEXT,
+ *     updated_at TEXT,
+ *     emitted_event_id TEXT,
+ *     processed_at TEXT
+ *
+ *   table cursor:
+ *     id INTEGER PRIMARY KEY CHECK (id = 1),
+ *     last_pr_query_iso TEXT,
+ *     last_run_query_iso TEXT
+ *
+ * The cursor table holds the rolling "since" timestamp so subsequent
+ * polls don't re-fetch the entire history every time.
+ *
+ * All public functions are synchronous (better-sqlite3 is sync). Safe
+ * to call from a long-running daemon's tick handler.
+ */
+
+import Database from 'better-sqlite3';
+import type { Database as DatabaseInstance } from 'better-sqlite3';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** Open or create the state-store DB. Idempotent. */
+export function openStateStore(path: string): DatabaseInstance {
+  if (path !== ':memory:') {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const db = new Database(path);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS seen_prs (
+      pr_number       INTEGER PRIMARY KEY,
+      merge_sha       TEXT,
+      merged_at       TEXT,
+      emitted_event_id TEXT,
+      processed_at    TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS seen_runs (
+      run_id          INTEGER PRIMARY KEY,
+      head_sha        TEXT,
+      updated_at      TEXT,
+      emitted_event_id TEXT,
+      processed_at    TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS cursor (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      last_pr_query_iso  TEXT,
+      last_run_query_iso TEXT
+    );
+    INSERT OR IGNORE INTO cursor (id, last_pr_query_iso, last_run_query_iso)
+      VALUES (1, NULL, NULL);
+  `);
+  return db;
+}
+
+export interface CursorState {
+  lastPrQueryIso: string | null;
+  lastRunQueryIso: string | null;
+}
+
+export function getCursor(db: DatabaseInstance): CursorState {
+  const row = db
+    .prepare('SELECT last_pr_query_iso, last_run_query_iso FROM cursor WHERE id = 1')
+    .get() as
+    | { last_pr_query_iso: string | null; last_run_query_iso: string | null }
+    | undefined;
+  return {
+    lastPrQueryIso: row?.last_pr_query_iso ?? null,
+    lastRunQueryIso: row?.last_run_query_iso ?? null
+  };
+}
+
+export function setCursor(
+  db: DatabaseInstance,
+  state: Partial<CursorState>
+): void {
+  // Read-modify-write — only update fields the caller passed.
+  const cur = getCursor(db);
+  const next: CursorState = {
+    lastPrQueryIso: state.lastPrQueryIso ?? cur.lastPrQueryIso,
+    lastRunQueryIso: state.lastRunQueryIso ?? cur.lastRunQueryIso
+  };
+  db.prepare(
+    `UPDATE cursor SET last_pr_query_iso = @last_pr_query_iso,
+                       last_run_query_iso = @last_run_query_iso
+       WHERE id = 1`
+  ).run({
+    last_pr_query_iso: next.lastPrQueryIso,
+    last_run_query_iso: next.lastRunQueryIso
+  });
+}
+
+export function isPrSeen(db: DatabaseInstance, prNumber: number): boolean {
+  const r = db
+    .prepare('SELECT 1 FROM seen_prs WHERE pr_number = @pr')
+    .get({ pr: prNumber });
+  return r !== undefined;
+}
+
+export function recordPrSeen(
+  db: DatabaseInstance,
+  rec: {
+    prNumber: number;
+    mergeSha: string;
+    mergedAt: string;
+    emittedEventId: string | null;
+    processedAt: string;
+  }
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO seen_prs
+       (pr_number, merge_sha, merged_at, emitted_event_id, processed_at)
+       VALUES (@pr_number, @merge_sha, @merged_at, @emitted_event_id, @processed_at)`
+  ).run({
+    pr_number: rec.prNumber,
+    merge_sha: rec.mergeSha,
+    merged_at: rec.mergedAt,
+    emitted_event_id: rec.emittedEventId,
+    processed_at: rec.processedAt
+  });
+}
+
+export function isRunSeen(db: DatabaseInstance, runId: number): boolean {
+  const r = db
+    .prepare('SELECT 1 FROM seen_runs WHERE run_id = @id')
+    .get({ id: runId });
+  return r !== undefined;
+}
+
+export function recordRunSeen(
+  db: DatabaseInstance,
+  rec: {
+    runId: number;
+    headSha: string;
+    updatedAt: string;
+    emittedEventId: string | null;
+    processedAt: string;
+  }
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO seen_runs
+       (run_id, head_sha, updated_at, emitted_event_id, processed_at)
+       VALUES (@run_id, @head_sha, @updated_at, @emitted_event_id, @processed_at)`
+  ).run({
+    run_id: rec.runId,
+    head_sha: rec.headSha,
+    updated_at: rec.updatedAt,
+    emitted_event_id: rec.emittedEventId,
+    processed_at: rec.processedAt
+  });
+}
+
+export function countSeenPrs(db: DatabaseInstance): number {
+  const r = db.prepare('SELECT COUNT(*) AS n FROM seen_prs').get() as { n: number };
+  return r.n;
+}
+
+export function countSeenRuns(db: DatabaseInstance): number {
+  const r = db.prepare('SELECT COUNT(*) AS n FROM seen_runs').get() as { n: number };
+  return r.n;
+}

--- a/packages/mentor-fastpath/tests/postmerge/watcher/gh-client.test.ts
+++ b/packages/mentor-fastpath/tests/postmerge/watcher/gh-client.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the gh-client wrapper.
+ *
+ * No real `gh` CLI calls — every test injects a mock RunGh that returns
+ * canned JSON. We verify:
+ *   - The right CLI flags are constructed.
+ *   - JSON parsing works for the expected `gh --json` output shapes.
+ *   - Defensive parsing tolerates missing optional fields.
+ *   - Error paths (non-array JSON, parse failure) throw with helpful
+ *     messages.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getFailedJobNames,
+  listFailedRuns,
+  listMergedPrs,
+  type RunGh
+} from '../../../src/postmerge/watcher/gh-client.js';
+
+function makeMock(): { run: RunGh; calls: string[][]; queue: string[] } {
+  const calls: string[][] = [];
+  const queue: string[] = [];
+  const run: RunGh = (args) => {
+    calls.push([...args]);
+    if (queue.length === 0) return '';
+    return queue.shift()!;
+  };
+  return { run, calls, queue };
+}
+
+describe('listMergedPrs', () => {
+  it('constructs the right gh args', () => {
+    const m = makeMock();
+    m.queue.push('[]');
+    listMergedPrs({ runGh: m.run }, '2026-05-04T00:00:00Z');
+    expect(m.calls.length).toBe(1);
+    const args = m.calls[0]!;
+    expect(args).toContain('pr');
+    expect(args).toContain('list');
+    expect(args).toContain('--state');
+    expect(args).toContain('merged');
+    expect(args.join(' ')).toContain('merged:>=2026-05-04T00:00:00Z');
+    expect(args.join(' ')).toContain('base:develop');
+    expect(args.join(' ')).toContain('base:main');
+    expect(args.join(' ')).toContain('--json');
+  });
+
+  it('parses well-formed gh JSON output', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify([
+        {
+          number: 327,
+          title: 'feat(curator-phase1-001): scan loop',
+          mergeCommit: { oid: 'ea23ab0' },
+          baseRefName: 'develop',
+          headRefName: 'feat/curator-phase1-001-scan-loop',
+          mergedAt: '2026-05-05T05:23:00Z',
+          author: { login: 'campaign-coordinator' }
+        }
+      ])
+    );
+    const prs = listMergedPrs({ runGh: m.run }, '2026-05-04T00:00:00Z');
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toEqual({
+      number: 327,
+      title: 'feat(curator-phase1-001): scan loop',
+      mergeCommit: 'ea23ab0',
+      baseRefName: 'develop',
+      headRefName: 'feat/curator-phase1-001-scan-loop',
+      mergedAt: '2026-05-05T05:23:00Z',
+      author: 'campaign-coordinator'
+    });
+  });
+
+  it('returns [] when gh returns empty string', () => {
+    const m = makeMock();
+    m.queue.push('');
+    const prs = listMergedPrs({ runGh: m.run }, '2026-05-04T00:00:00Z');
+    expect(prs).toEqual([]);
+  });
+
+  it('tolerates missing optional fields (mergeCommit, author)', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify([
+        {
+          number: 100,
+          title: 'partial PR',
+          mergeCommit: null,
+          baseRefName: 'develop',
+          headRefName: '',
+          mergedAt: '2026-05-04T00:00:00Z'
+        }
+      ])
+    );
+    const prs = listMergedPrs({ runGh: m.run }, '2026-05-04T00:00:00Z');
+    expect(prs[0]?.mergeCommit).toBe('');
+    expect(prs[0]?.author).toBe('unknown');
+  });
+
+  it('throws on non-JSON output', () => {
+    const m = makeMock();
+    m.queue.push('not json');
+    expect(() => listMergedPrs({ runGh: m.run }, '2026-05-04T00:00:00Z')).toThrow(
+      /unparseable/
+    );
+  });
+
+  it('throws when JSON is not an array', () => {
+    const m = makeMock();
+    m.queue.push('{}');
+    expect(() => listMergedPrs({ runGh: m.run }, '2026-05-04T00:00:00Z')).toThrow(
+      /expected array/
+    );
+  });
+
+  it('passes --repo flag when provided', () => {
+    const m = makeMock();
+    m.queue.push('[]');
+    listMergedPrs(
+      { runGh: m.run, repo: 'owner/repo' },
+      '2026-05-04T00:00:00Z'
+    );
+    expect(m.calls[0]).toContain('--repo');
+    expect(m.calls[0]).toContain('owner/repo');
+  });
+});
+
+describe('listFailedRuns', () => {
+  it('makes one call per branch', () => {
+    const m = makeMock();
+    m.queue.push('[]', '[]');
+    listFailedRuns({ runGh: m.run }, '2026-05-04T00:00:00Z', ['develop', 'main']);
+    expect(m.calls).toHaveLength(2);
+    expect(m.calls[0]).toContain('develop');
+    expect(m.calls[1]).toContain('main');
+  });
+
+  it('parses run JSON', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify([
+        {
+          databaseId: 12345,
+          name: 'Build · Test · Lint · Typecheck',
+          headBranch: 'develop',
+          headSha: 'ea23ab0',
+          updatedAt: '2026-05-05T05:30:00Z',
+          conclusion: 'failure'
+        }
+      ]),
+      '[]'
+    );
+    const runs = listFailedRuns({ runGh: m.run }, '2026-05-04T00:00:00Z');
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      databaseId: 12345,
+      workflowName: 'Build · Test · Lint · Typecheck',
+      headBranch: 'develop',
+      headSha: 'ea23ab0',
+      conclusion: 'failure'
+    });
+  });
+
+  it('filters out runs older than the since cutoff', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify([
+        {
+          databaseId: 1,
+          name: 'old',
+          headBranch: 'develop',
+          headSha: 'aaa',
+          updatedAt: '2026-05-01T00:00:00Z',
+          conclusion: 'failure'
+        },
+        {
+          databaseId: 2,
+          name: 'new',
+          headBranch: 'develop',
+          headSha: 'bbb',
+          updatedAt: '2026-05-05T05:00:00Z',
+          conclusion: 'failure'
+        }
+      ]),
+      '[]'
+    );
+    const runs = listFailedRuns({ runGh: m.run }, '2026-05-04T00:00:00Z', [
+      'develop'
+    ]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.databaseId).toBe(2);
+  });
+
+  it('handles empty per-branch results without throwing', () => {
+    const m = makeMock();
+    m.queue.push('', '');
+    const runs = listFailedRuns({ runGh: m.run }, '2026-05-04T00:00:00Z');
+    expect(runs).toEqual([]);
+  });
+});
+
+describe('getFailedJobNames', () => {
+  it('returns names of jobs with conclusion=failure', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify({
+        jobs: [
+          { name: 'lint', conclusion: 'failure' },
+          { name: 'typecheck', conclusion: 'success' },
+          { name: 'integration-tests', conclusion: 'failure' }
+        ]
+      })
+    );
+    const names = getFailedJobNames({ runGh: m.run }, 12345);
+    expect(names).toEqual(['lint', 'integration-tests']);
+  });
+
+  it('returns [] when run has no failed jobs', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify({
+        jobs: [{ name: 'all-good', conclusion: 'success' }]
+      })
+    );
+    expect(getFailedJobNames({ runGh: m.run }, 1)).toEqual([]);
+  });
+
+  it('returns [] when gh returns empty string', () => {
+    const m = makeMock();
+    m.queue.push('');
+    expect(getFailedJobNames({ runGh: m.run }, 1)).toEqual([]);
+  });
+
+  it('returns [] when JSON has no jobs key', () => {
+    const m = makeMock();
+    m.queue.push('{}');
+    expect(getFailedJobNames({ runGh: m.run }, 1)).toEqual([]);
+  });
+
+  it('handles missing job names', () => {
+    const m = makeMock();
+    m.queue.push(
+      JSON.stringify({
+        jobs: [
+          { name: 'real', conclusion: 'failure' },
+          { conclusion: 'failure' } // no name
+        ]
+      })
+    );
+    const names = getFailedJobNames({ runGh: m.run }, 1);
+    // Name-less jobs are filtered out (empty name).
+    expect(names).toEqual(['real']);
+  });
+});

--- a/packages/mentor-fastpath/tests/postmerge/watcher/producer.test.ts
+++ b/packages/mentor-fastpath/tests/postmerge/watcher/producer.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Integration test for the postmerge watcher producer.
+ *
+ * Wires:
+ *   - A real :memory: state-store DB.
+ *   - A real :memory: event-bus Client (mentor-event-bus's local mode).
+ *   - A mocked gh-client that returns canned PR + run JSON.
+ *
+ * Verifies that one runIteration() call:
+ *   1. Emits PRMerged events for new merged PRs.
+ *   2. Emits RegressionDetected when a failed run's headSha matches a
+ *      known merged commit.
+ *   3. Emits EvidenceGateFailure when a failed run's headSha is on a
+ *      branch we have no merge record for.
+ *   4. Persists the seen state so a second iteration is a no-op.
+ *   5. Advances the cursor.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { Client } from '@chiefaia/mentor-event-bus';
+
+import {
+  countSeenPrs,
+  countSeenRuns,
+  getCursor,
+  openStateStore
+} from '../../../src/postmerge/watcher/state-store.js';
+import { runIteration } from '../../../src/postmerge/watcher/producer.js';
+import type { GhClientOptions } from '../../../src/postmerge/watcher/gh-client.js';
+
+function buildMockGh(prResp: string, runResps: string[], jobResp = '{}'): {
+  ghClient: GhClientOptions;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  let _prIdx = 0;
+  let runIdx = 0;
+  const runGh = (args: ReadonlyArray<string>): string => {
+    calls.push([...args]);
+    if (args[0] === 'pr' && args[1] === 'list') {
+      _prIdx++;
+      return prResp;
+    }
+    if (args[0] === 'run' && args[1] === 'list') {
+      const out = runResps[runIdx] ?? '[]';
+      runIdx++;
+      return out;
+    }
+    if (args[0] === 'run' && args[1] === 'view') {
+      return jobResp;
+    }
+    return '';
+  };
+  return { ghClient: { runGh }, calls };
+}
+
+function makeBus(): Client {
+  return new Client({
+    dbPath: ':memory:',
+    disableWal: true,
+    skipSchemaRegistration: true
+  });
+}
+
+describe('runIteration — happy path', () => {
+  it('emits PRMerged + classifies runs', () => {
+    const stateDb = openStateStore(':memory:');
+    const busClient = makeBus();
+
+    const prResp = JSON.stringify([
+      {
+        number: 327,
+        title: 'feat(curator-phase1-001): scan loop',
+        mergeCommit: { oid: 'ea23ab0' },
+        baseRefName: 'develop',
+        headRefName: 'feat/curator-phase1-001',
+        mergedAt: '2026-05-05T05:23:00Z',
+        author: { login: 'campaign-coordinator' }
+      }
+    ]);
+
+    // First gh run list (develop branch): one failed run on the merge SHA
+    // → should emit RegressionDetected.
+    const developRuns = JSON.stringify([
+      {
+        databaseId: 12345,
+        name: 'Build · Test · Lint · Typecheck',
+        headBranch: 'develop',
+        headSha: 'ea23ab0',
+        updatedAt: '2026-05-05T05:30:00Z',
+        conclusion: 'failure'
+      }
+    ]);
+    // Second gh run list (main branch): one failed run on a non-merged sha
+    // → should emit EvidenceGateFailure.
+    const mainRuns = JSON.stringify([
+      {
+        databaseId: 22222,
+        name: 'lint',
+        headBranch: 'feat/some-other',
+        headSha: 'unknown-sha',
+        updatedAt: '2026-05-05T05:31:00Z',
+        conclusion: 'failure'
+      }
+    ]);
+    const jobResp = JSON.stringify({
+      jobs: [{ name: 'integration-tests', conclusion: 'failure' }]
+    });
+
+    const { ghClient } = buildMockGh(prResp, [developRuns, mainRuns], jobResp);
+
+    const stats = runIteration({
+      stateDb,
+      busClient,
+      ghClient,
+      now: () => new Date('2026-05-05T05:35:00Z')
+    });
+
+    expect(stats.prsSeen).toBe(1);
+    expect(stats.prsEmitted).toBe(1);
+    expect(stats.runsSeen).toBe(2);
+    expect(stats.runsEmittedAsRegression).toBe(1);
+    expect(stats.runsEmittedAsGateFailure).toBe(1);
+    expect(stats.errors).toEqual([]);
+
+    expect(countSeenPrs(stateDb)).toBe(1);
+    expect(countSeenRuns(stateDb)).toBe(2);
+
+    // Cursor advanced
+    const c = getCursor(stateDb);
+    expect(c.lastPrQueryIso).toBe('2026-05-05T05:35:00.000Z');
+    expect(c.lastRunQueryIso).toBe('2026-05-05T05:35:00.000Z');
+
+    // Verify events landed in the bus
+    const events = busClient.getRecent({ limit: 100 });
+    const types = events.map((e) => e.type).sort();
+    expect(types).toContain('PRMerged');
+    expect(types).toContain('RegressionDetected');
+    expect(types).toContain('EvidenceGateFailure');
+
+    busClient.close();
+    stateDb.close();
+  });
+});
+
+describe('runIteration — idempotency', () => {
+  it('a second iteration with the same gh data emits zero new events', () => {
+    const stateDb = openStateStore(':memory:');
+    const busClient = makeBus();
+
+    const prResp = JSON.stringify([
+      {
+        number: 327,
+        title: 'x',
+        mergeCommit: { oid: 'sha1' },
+        baseRefName: 'develop',
+        headRefName: 'feat/x',
+        mergedAt: '2026-05-05T05:23:00Z',
+        author: { login: 'a' }
+      }
+    ]);
+    const runResp = JSON.stringify([
+      {
+        databaseId: 1,
+        name: 'lint',
+        headBranch: 'develop',
+        headSha: 'sha1',
+        updatedAt: '2026-05-05T05:30:00Z',
+        conclusion: 'failure'
+      }
+    ]);
+
+    // First iteration
+    const m1 = buildMockGh(prResp, [runResp, '[]'], '{}');
+    const stats1 = runIteration({
+      stateDb,
+      busClient,
+      ghClient: m1.ghClient,
+      now: () => new Date('2026-05-05T05:35:00Z')
+    });
+    expect(stats1.prsEmitted).toBe(1);
+    expect(stats1.runsEmittedAsRegression).toBe(1);
+
+    // Second iteration with the SAME gh data
+    const m2 = buildMockGh(prResp, [runResp, '[]'], '{}');
+    const stats2 = runIteration({
+      stateDb,
+      busClient,
+      ghClient: m2.ghClient,
+      now: () => new Date('2026-05-05T05:40:00Z')
+    });
+    expect(stats2.prsSeen).toBe(1); // still saw it from gh
+    expect(stats2.prsEmitted).toBe(0); // but didn't re-emit
+    // Run's updatedAt (T-5min) is now older than the cursor advanced
+    // by iteration 1 (T) — the gh-client filter cuts it before we
+    // reach the seen-runs check. This is correct behaviour: cursor-
+    // advancement is the cheap dedupe, seen_runs is the safety net.
+    expect(stats2.runsEmittedAsRegression).toBe(0);
+    expect(stats2.runsEmittedAsGateFailure).toBe(0);
+
+    busClient.close();
+    stateDb.close();
+  });
+});
+
+describe('runIteration — error handling', () => {
+  it('records a partial error without throwing when gh pr list fails', () => {
+    const stateDb = openStateStore(':memory:');
+    const busClient = makeBus();
+
+    const ghClient: GhClientOptions = {
+      runGh: (args) => {
+        if (args[0] === 'pr') throw new Error('network down');
+        if (args[0] === 'run' && args[1] === 'list') return '[]';
+        return '';
+      }
+    };
+
+    const stats = runIteration({
+      stateDb,
+      busClient,
+      ghClient,
+      now: () => new Date('2026-05-05T05:35:00Z')
+    });
+    expect(stats.errors.length).toBeGreaterThan(0);
+    expect(stats.errors[0]).toMatch(/gh pr list failed/);
+    // Did not crash; runs were still queried.
+    expect(stats.runsSeen).toBe(0);
+
+    busClient.close();
+    stateDb.close();
+  });
+
+  it('continues past a per-PR emit failure', () => {
+    const stateDb = openStateStore(':memory:');
+    const busClient = makeBus();
+
+    // We cannot easily induce an emit failure on the in-memory bus, but
+    // we can verify that the watcher tolerates a gh-pr-view failure
+    // when fetching failed-job names (skips the names but still emits
+    // the event).
+    const prResp = JSON.stringify([
+      {
+        number: 1,
+        title: 'x',
+        mergeCommit: { oid: 'aaa' },
+        baseRefName: 'develop',
+        headRefName: 'feat/y',
+        mergedAt: '2026-05-05T05:23:00Z',
+        author: { login: 'a' }
+      }
+    ]);
+    const runResp = JSON.stringify([
+      {
+        databaseId: 1,
+        name: 'lint',
+        headBranch: 'develop',
+        headSha: 'aaa',
+        updatedAt: '2026-05-05T05:30:00Z',
+        conclusion: 'failure'
+      }
+    ]);
+
+    const ghClient: GhClientOptions = {
+      runGh: (args) => {
+        if (args[0] === 'pr') return prResp;
+        if (args[0] === 'run' && args[1] === 'list') {
+          // First call (develop) returns runResp; subsequent (main) empty.
+          return runResp;
+        }
+        if (args[0] === 'run' && args[1] === 'view') {
+          throw new Error('rate-limited');
+        }
+        return '';
+      }
+    };
+
+    let calls = 0;
+    const wrapped: GhClientOptions = {
+      runGh: (args) => {
+        calls++;
+        if (args[0] === 'pr') return prResp;
+        if (args[0] === 'run' && args[1] === 'list') {
+          // first → develop, second → main
+          return calls <= 3 ? runResp : '[]';
+        }
+        if (args[0] === 'run' && args[1] === 'view') {
+          throw new Error('rate-limited');
+        }
+        return '';
+      }
+    };
+
+    const stats = runIteration({
+      stateDb,
+      busClient,
+      ghClient: wrapped,
+      now: () => new Date('2026-05-05T05:35:00Z')
+    });
+    // Failed-job lookup errored but we still emitted the regression
+    // event with the workflow name as the only "failed job."
+    expect(stats.errors.some((e) => /gh run view/.test(e))).toBe(true);
+    expect(stats.runsEmittedAsRegression).toBeGreaterThanOrEqual(1);
+
+    busClient.close();
+    stateDb.close();
+
+    // Silence unused-binding lint warning
+    void ghClient;
+  });
+});
+
+describe('runIteration — cursor behaviour', () => {
+  it('uses the configured initial-lookback when cursor is empty', () => {
+    const stateDb = openStateStore(':memory:');
+    const busClient = makeBus();
+
+    const captured: string[] = [];
+    const ghClient: GhClientOptions = {
+      runGh: (args) => {
+        captured.push(args.join(' '));
+        if (args[0] === 'pr') return '[]';
+        if (args[0] === 'run' && args[1] === 'list') return '[]';
+        return '';
+      }
+    };
+
+    runIteration({
+      stateDb,
+      busClient,
+      ghClient,
+      initialLookbackHours: 6,
+      now: () => new Date('2026-05-05T05:35:00Z')
+    });
+
+    // pr list call's search includes 'merged:>=' with iso ~6h before now
+    const prCall = captured.find((c) => c.includes('pr list'));
+    expect(prCall).toMatch(/merged:>=2026-05-04T23:35/);
+
+    busClient.close();
+    stateDb.close();
+  });
+});

--- a/packages/mentor-fastpath/tests/postmerge/watcher/state-store.test.ts
+++ b/packages/mentor-fastpath/tests/postmerge/watcher/state-store.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the state-store sqlite helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  countSeenPrs,
+  countSeenRuns,
+  getCursor,
+  isPrSeen,
+  isRunSeen,
+  openStateStore,
+  recordPrSeen,
+  recordRunSeen,
+  setCursor
+} from '../../../src/postmerge/watcher/state-store.js';
+
+describe('state-store — schema', () => {
+  it('opens an empty :memory: DB cleanly', () => {
+    const db = openStateStore(':memory:');
+    expect(countSeenPrs(db)).toBe(0);
+    expect(countSeenRuns(db)).toBe(0);
+    db.close();
+  });
+
+  it('returns null cursor on a fresh DB', () => {
+    const db = openStateStore(':memory:');
+    const c = getCursor(db);
+    expect(c.lastPrQueryIso).toBeNull();
+    expect(c.lastRunQueryIso).toBeNull();
+    db.close();
+  });
+});
+
+describe('state-store — seen_prs', () => {
+  it('records and recognises a seen PR', () => {
+    const db = openStateStore(':memory:');
+    expect(isPrSeen(db, 100)).toBe(false);
+    recordPrSeen(db, {
+      prNumber: 100,
+      mergeSha: 'abc',
+      mergedAt: '2026-05-05T05:00:00Z',
+      emittedEventId: 'ev_1',
+      processedAt: '2026-05-05T05:01:00Z'
+    });
+    expect(isPrSeen(db, 100)).toBe(true);
+    expect(countSeenPrs(db)).toBe(1);
+    db.close();
+  });
+
+  it('idempotent re-record (INSERT OR IGNORE)', () => {
+    const db = openStateStore(':memory:');
+    recordPrSeen(db, {
+      prNumber: 100,
+      mergeSha: 'abc',
+      mergedAt: '2026-05-05T05:00:00Z',
+      emittedEventId: 'ev_1',
+      processedAt: '2026-05-05T05:01:00Z'
+    });
+    recordPrSeen(db, {
+      prNumber: 100,
+      mergeSha: 'different',
+      mergedAt: '2026-05-05T05:00:00Z',
+      emittedEventId: 'ev_2',
+      processedAt: '2026-05-05T05:01:00Z'
+    });
+    expect(countSeenPrs(db)).toBe(1);
+    db.close();
+  });
+
+  it('handles null emittedEventId (failed-emit case)', () => {
+    const db = openStateStore(':memory:');
+    recordPrSeen(db, {
+      prNumber: 200,
+      mergeSha: 'xyz',
+      mergedAt: '2026-05-05T05:00:00Z',
+      emittedEventId: null,
+      processedAt: '2026-05-05T05:01:00Z'
+    });
+    expect(isPrSeen(db, 200)).toBe(true);
+    db.close();
+  });
+});
+
+describe('state-store — seen_runs', () => {
+  it('records and recognises a seen run', () => {
+    const db = openStateStore(':memory:');
+    expect(isRunSeen(db, 12345)).toBe(false);
+    recordRunSeen(db, {
+      runId: 12345,
+      headSha: 'abc',
+      updatedAt: '2026-05-05T05:00:00Z',
+      emittedEventId: 'ev_1',
+      processedAt: '2026-05-05T05:01:00Z'
+    });
+    expect(isRunSeen(db, 12345)).toBe(true);
+    expect(countSeenRuns(db)).toBe(1);
+    db.close();
+  });
+
+  it('idempotent re-record', () => {
+    const db = openStateStore(':memory:');
+    for (let i = 0; i < 3; i++) {
+      recordRunSeen(db, {
+        runId: 999,
+        headSha: 'aaa',
+        updatedAt: '2026-05-05T05:00:00Z',
+        emittedEventId: null,
+        processedAt: '2026-05-05T05:01:00Z'
+      });
+    }
+    expect(countSeenRuns(db)).toBe(1);
+    db.close();
+  });
+});
+
+describe('state-store — cursor', () => {
+  it('round-trips both fields', () => {
+    const db = openStateStore(':memory:');
+    setCursor(db, {
+      lastPrQueryIso: '2026-05-05T05:00:00Z',
+      lastRunQueryIso: '2026-05-05T05:00:30Z'
+    });
+    const c = getCursor(db);
+    expect(c.lastPrQueryIso).toBe('2026-05-05T05:00:00Z');
+    expect(c.lastRunQueryIso).toBe('2026-05-05T05:00:30Z');
+    db.close();
+  });
+
+  it('partial update preserves the un-set field', () => {
+    const db = openStateStore(':memory:');
+    setCursor(db, {
+      lastPrQueryIso: '2026-05-05T05:00:00Z',
+      lastRunQueryIso: '2026-05-05T05:00:30Z'
+    });
+    setCursor(db, { lastPrQueryIso: '2026-05-05T06:00:00Z' });
+    const c = getCursor(db);
+    expect(c.lastPrQueryIso).toBe('2026-05-05T06:00:00Z');
+    expect(c.lastRunQueryIso).toBe('2026-05-05T05:00:30Z');
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary

**Mentor Phase-2 PR-2 of N — postmerge watcher daemon (the producer side).** A long-running daemon that polls `gh pr list --state merged` + `gh run list --status failure` + `gh run view <id>` and emits `PRMerged` / `RegressionDetected` / `EvidenceGateFailure` events into the mentor-event-bus.

Subscription-only constraint honoured: shells out to the operator's authenticated `gh` CLI; no Octokit / paid API tokens. PR-1 (#328) shipped the data layer (classifier + synthesizer); this PR ships the producer that feeds it. The consumer (subscriber that wires producer → data layer → memory-writer) lands in PR-3.

## Components

| Path | Purpose |
|---|---|
| `src/postmerge/watcher/gh-client.ts` | `execFileSync('gh', [...])` wrapper. Exports `listMergedPrs`, `listFailedRuns`, `getFailedJobNames`. Mock-injectable. |
| `src/postmerge/watcher/state-store.ts` | SQLite idempotency: `seen_prs`, `seen_runs`, `cursor` (last-query iso). |
| `src/postmerge/watcher/producer.ts` | `runIteration()` — single poll pass; `runProducer()` — long-running loop. |
| `src/postmerge/watcher/cli.ts` | `caia-postmerge-watcher {watch|scan-once|status}` (added as 2nd bin entry). |

## Routing logic (per iteration)

1. List merged PRs since cursor → emit `PRMerged` for each new
2. List failed runs since cursor → for each new run:
   - If `headSha` matches a known merge commit → emit `RegressionDetected`
   - Otherwise → emit `EvidenceGateFailure` (failed CI on a feature branch)
3. Advance cursor to "now"

The Phase-2 PR-1 classifier (`classifyPostMerge`) takes structured input that maps 1:1 to these events, so PR-3 just needs to wire a subscriber that reads each event type and calls `classifyPostMerge` + `synthesizePostMerge` + `writeProposal`.

## Files

| Path | Lines | Tests |
|---|---|---|
| `src/postmerge/watcher/gh-client.ts` | 250 | 16 |
| `src/postmerge/watcher/state-store.ts` | 165 | 9 |
| `src/postmerge/watcher/producer.ts` | 300 | 5 (integration) |
| `src/postmerge/watcher/cli.ts` | 240 | — (CLI tested in PR-3 / live) |

Test count: **147 → 177** (+30).

## Operator's 6-stage DoD

| Stage | Status |
|---|---|
| 1. Analyze | ✓ Re-read PR-1 data layer + mentor-event-bus client surface |
| 2. Research | ✓ Surveyed `gh pr list / run list / run view` JSON shapes; chose execFileSync+cause for safe error propagation |
| 3. Solution | ✓ sqlite-backed cursor + per-id seen tables; mock-injectable RunGh for tests |
| 4. Implement | ✓ 5 src + 3 test files |
| 5. Test+integrate | ✓ 177 tests, lint clean, typecheck clean, build clean |
| 6. Live verify | ⏳ Deferred to PR-3 alongside consumer wiring (events not visible end-to-end until consumer reads them) |

## Hard constraints

- 🚨 Subscription-only ✓ (no LLM calls; uses operator's `gh` CLI)
- 🚨 No paid services ✓
- ✓ No `gh pr update-branch` (rebased manually)
- ✓ Worktree budget within ≤8

## Refs

- Phase-2 PR-1: #328 (data layer)
- `agent/memory/mentor_agent_directive.md` ## Phased rollout: Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
