### PR TITLE
feat(mentor-phase3-001): retrieval index builder + Ollama embedding wrapper (PR-1)

### DIFF
--- a/packages/mentor-retrieval/eslint.config.cjs
+++ b/packages/mentor-retrieval/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — replaces .eslintrc.json
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/mentor-retrieval/package.json
+++ b/packages/mentor-retrieval/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@chiefaia/mentor-retrieval",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Mentor Phase-3 lesson retrieval — embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons for a given prompt. PR-1 ships the index builder + storage; PR-2 ships the retrieval API + CLI; PR-3 wires the orchestrator pre-spawn hook.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-mentor-index": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/packages/mentor-retrieval/src/cli.ts
+++ b/packages/mentor-retrieval/src/cli.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * caia-mentor-index — Mentor Phase-3 PR-1 CLI.
+ *
+ * Subcommands:
+ *
+ *   build   — Read all feedback_*.md + proposals/*.md under the memory
+ *             dir, embed each via Ollama, write/update the index DB at
+ *             `<memoryDir>/_mentor-index.sqlite`. Idempotent; only
+ *             re-embeds files whose mtime + sha256 changed.
+ *
+ *   status  — Print the current index summary (rows by kind, last build
+ *             time, embedding model + dim) without modifying anything.
+ *
+ *   help    — Print usage and exit 0.
+ *
+ * Flags:
+ *
+ *   --memory   <path>   Override the memory directory. Default:
+ *                       $CAIA_MEMORY_DIR or process.cwd()/agent/memory.
+ *   --ollama   <url>    Override the Ollama base URL. Default:
+ *                       $OLLAMA_URL or http://127.0.0.1:11434.
+ *   --model    <name>   Override the embedding model. Default:
+ *                       $MENTOR_EMBED_MODEL or nomic-embed-text.
+ *   --quiet             Suppress per-file progress.
+ *
+ * Exit codes:
+ *
+ *   0   — success
+ *   1   — usage error / unknown subcommand
+ *   2   — runtime failure (couldn't reach Ollama, couldn't open DB, etc.)
+ */
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DEFAULT_EMBED_MODEL,
+  DEFAULT_OLLAMA_URL,
+  createOllamaEmbedder
+} from './embed.js';
+import { buildIndex } from './index-builder.js';
+import { openIndexStore } from './index-store.js';
+
+interface ParsedArgs {
+  subcommand: 'build' | 'status' | 'help';
+  memoryDir: string;
+  ollamaUrl: string;
+  model: string;
+  quiet: boolean;
+}
+
+interface RunOptions {
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  exit?: (code: number) => never;
+}
+
+export async function main(opts: RunOptions = {}): Promise<void> {
+  const argv = opts.argv ?? process.argv.slice(2);
+  const env = opts.env ?? process.env;
+  const stdout = opts.stdout ?? ((s: string) => process.stdout.write(`${s}\n`));
+  const stderr = opts.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
+  const exit =
+    opts.exit ??
+    ((code: number) => {
+      process.exit(code);
+    });
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv, env);
+  } catch (e) {
+    stderr(`mentor-index: ${describeError(e)}`);
+    stderr('run `caia-mentor-index help` for usage');
+    return exit(1);
+  }
+
+  if (parsed.subcommand === 'help') {
+    stdout(usage());
+    return exit(0);
+  }
+
+  if (parsed.subcommand === 'build') {
+    try {
+      const embedder = createOllamaEmbedder({
+        url: parsed.ollamaUrl,
+        model: parsed.model
+      });
+      const stats = await buildIndex({
+        memoryDir: parsed.memoryDir,
+        embed: embedder,
+        log: parsed.quiet ? () => undefined : (m: string) => stderr(m)
+      });
+      stdout(JSON.stringify(stats, null, 2));
+      return exit(0);
+    } catch (e) {
+      stderr(`mentor-index build failed: ${describeError(e)}`);
+      return exit(2);
+    }
+  }
+
+  // status
+  try {
+    const store = openIndexStore({
+      memoryDir: parsed.memoryDir,
+      readonly: true
+    });
+    try {
+      const all = store.listAll();
+      const byKind: Record<string, number> = {};
+      for (const r of all) {
+        byKind[r.kind] = (byKind[r.kind] ?? 0) + 1;
+      }
+      const summary = {
+        indexPath: store.dbPath,
+        totalRows: all.length,
+        byKind,
+        embeddingModel: store.getMeta('embedding_model'),
+        embeddingDim: numberOrNull(store.getMeta('embedding_dim')),
+        lastBuildAtMs: numberOrNull(store.getMeta('last_build_at_ms')),
+        lastBuildAtIso: isoOrNull(store.getMeta('last_build_at_ms')),
+        lastBuildScanned: numberOrNull(store.getMeta('last_build_scanned'))
+      };
+      stdout(JSON.stringify(summary, null, 2));
+      return exit(0);
+    } finally {
+      store.close();
+    }
+  } catch (e) {
+    // No DB yet -> graceful "not built" output, exit 0 so cron-style
+    // wrappers can keep going.
+    if (!existsSync(join(parsed.memoryDir, '_mentor-index.sqlite'))) {
+      const empty = {
+        indexPath: join(parsed.memoryDir, '_mentor-index.sqlite'),
+        totalRows: 0,
+        byKind: {},
+        embeddingModel: null,
+        embeddingDim: null,
+        lastBuildAtMs: null,
+        lastBuildAtIso: null,
+        lastBuildScanned: null,
+        note: 'index not built yet — run `caia-mentor-index build`'
+      };
+      stdout(JSON.stringify(empty, null, 2));
+      return exit(0);
+    }
+    stderr(`mentor-index status failed: ${describeError(e)}`);
+    return exit(2);
+  }
+}
+
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): ParsedArgs {
+  if (argv.length === 0) {
+    throw new Error('missing subcommand (build|status|help)');
+  }
+  const sub = argv[0];
+  if (sub !== 'build' && sub !== 'status' && sub !== 'help') {
+    throw new Error(
+      `unknown subcommand ${JSON.stringify(sub)}; expected build|status|help`
+    );
+  }
+
+  let memoryDir = env['CAIA_MEMORY_DIR'];
+  let ollamaUrl = env['OLLAMA_URL'] ?? DEFAULT_OLLAMA_URL;
+  let model = env['MENTOR_EMBED_MODEL'] ?? DEFAULT_EMBED_MODEL;
+  let quiet = false;
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--memory') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--memory requires a value');
+      memoryDir = v;
+    } else if (arg === '--ollama') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--ollama requires a value');
+      ollamaUrl = v;
+    } else if (arg === '--model') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--model requires a value');
+      model = v;
+    } else if (arg === '--quiet') {
+      quiet = true;
+    } else {
+      throw new Error(`unknown flag ${JSON.stringify(arg)}`);
+    }
+  }
+
+  if (memoryDir === undefined || memoryDir === '') {
+    memoryDir = join(homedir(), 'Documents', 'projects', 'caia', 'agent', 'memory');
+  }
+
+  return {
+    subcommand: sub,
+    memoryDir,
+    ollamaUrl,
+    model,
+    quiet
+  };
+}
+
+function usage(): string {
+  return `caia-mentor-index — Mentor Phase-3 lesson-index builder + status
+
+Usage:
+  caia-mentor-index build [--memory <dir>] [--ollama <url>] [--model <name>] [--quiet]
+  caia-mentor-index status [--memory <dir>]
+  caia-mentor-index help
+
+Environment:
+  CAIA_MEMORY_DIR       Memory directory containing feedback_*.md + proposals/*.md
+  OLLAMA_URL            Ollama HTTP base URL (default: ${DEFAULT_OLLAMA_URL})
+  MENTOR_EMBED_MODEL    Embedding model (default: ${DEFAULT_EMBED_MODEL})
+`;
+}
+
+function numberOrNull(v: string | null): number | null {
+  if (v === null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function isoOrNull(v: string | null): string | null {
+  const n = numberOrNull(v);
+  if (n === null) return null;
+  return new Date(n).toISOString();
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+const isMain = (): boolean => {
+  const meta = import.meta.url;
+  if (!meta.startsWith('file://')) return false;
+  const arg1 = process.argv[1];
+  if (arg1 === undefined) return false;
+  // Compare resolved file paths (handles both `node dist/cli.js` and
+  // bin-shim invocations).
+  return meta.endsWith(arg1) || meta === `file://${arg1}`;
+};
+
+if (isMain()) {
+  main().catch((e) => {
+    process.stderr.write(`mentor-index: fatal: ${describeError(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/packages/mentor-retrieval/src/embed.ts
+++ b/packages/mentor-retrieval/src/embed.ts
@@ -1,0 +1,158 @@
+/**
+ * Ollama embedder for Mentor Phase-3.
+ *
+ * Hits the local Ollama HTTP server's `/api/embeddings` endpoint with
+ * the configured model (default: `nomic-embed-text`). Returns a Float32
+ * vector wrapped with the echo'd model id.
+ *
+ * Subscription mandate: this is the only LLM-calling code Phase-3 PR-1
+ * adds, and it talks exclusively to a local Ollama daemon — zero
+ * marginal cost, zero API-key billing.
+ *
+ * Hard requirements:
+ *   - Network calls go to a localhost-style URL by default. Caller can
+ *     override with OLLAMA_URL env var.
+ *   - All errors are wrapped with `cause: e` so the eslint
+ *     `preserve-caught-error` rule is satisfied (recurring lesson from
+ *     leg-5 + leg-6).
+ *   - Response shape is validated — Ollama returns `{ embedding: number[] }`,
+ *     and any deviation throws synchronously rather than producing a
+ *     malformed Float32Array silently.
+ */
+
+import type { EmbedResult, Embedder } from './types.js';
+
+/** Default Ollama HTTP endpoint (the daemon listens on 11434 by default). */
+export const DEFAULT_OLLAMA_URL = 'http://127.0.0.1:11434';
+
+/** Default embedding model. nomic-embed-text returns 768-dim vectors. */
+export const DEFAULT_EMBED_MODEL = 'nomic-embed-text';
+
+export interface OllamaEmbedderOptions {
+  /** Base URL of the Ollama HTTP server. */
+  url?: string;
+  /** Model to use. Must be pulled in advance via `ollama pull <model>`. */
+  model?: string;
+  /** Total request timeout in ms. Default 30s. */
+  timeoutMs?: number;
+  /**
+   * Override the global `fetch` for tests. Production passes the
+   * runtime's built-in fetch.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Build an `Embedder` closure bound to a specific Ollama URL + model.
+ * Returns a function the caller invokes per text-to-embed.
+ */
+export function createOllamaEmbedder(opts: OllamaEmbedderOptions = {}): Embedder {
+  const url = opts.url ?? DEFAULT_OLLAMA_URL;
+  const model = opts.model ?? DEFAULT_EMBED_MODEL;
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  return async (text: string): Promise<EmbedResult> => {
+    const endpoint = `${url.replace(/\/$/, '')}/api/embeddings`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    let resp: Response;
+    try {
+      resp = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, prompt: text }),
+        signal: controller.signal
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      throw new Error(`ollama embed request failed (${endpoint})`, { cause: e });
+    }
+    clearTimeout(timer);
+
+    if (!resp.ok) {
+      const bodyText = await safeReadBody(resp);
+      throw new Error(
+        `ollama embed http ${resp.status} ${resp.statusText}: ${bodyText}`
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = await resp.json();
+    } catch (e) {
+      throw new Error('ollama embed response was not valid JSON', { cause: e });
+    }
+
+    const vec = extractEmbedding(parsed);
+    return { vector: vec, model };
+  };
+}
+
+/**
+ * Safely extract `embedding: number[]` from an Ollama response object.
+ * Throws a descriptive error on any shape mismatch.
+ */
+export function extractEmbedding(parsed: unknown): Float32Array {
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error('ollama embed response was not an object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const raw = obj['embedding'];
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      'ollama embed response missing required `embedding` array field'
+    );
+  }
+  if (raw.length === 0) {
+    throw new Error('ollama embed response returned an empty embedding');
+  }
+  const out = new Float32Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    const v = raw[i];
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      throw new Error(
+        `ollama embed returned non-finite value at index ${i} (got ${typeof v})`
+      );
+    }
+    out[i] = v;
+  }
+  return out;
+}
+
+/**
+ * Convert a Float32Array to a Buffer with little-endian layout, suitable
+ * for storing in a SQLite BLOB column.
+ */
+export function vectorToBlob(v: Float32Array): Buffer {
+  const buf = Buffer.alloc(v.length * 4);
+  for (let i = 0; i < v.length; i++) {
+    buf.writeFloatLE(v[i] ?? 0, i * 4);
+  }
+  return buf;
+}
+
+/** Inverse of `vectorToBlob`. */
+export function blobToVector(b: Buffer, dim: number): Float32Array {
+  if (b.length !== dim * 4) {
+    throw new Error(
+      `embedding blob length ${b.length} does not match dim ${dim} (expected ${dim * 4})`
+    );
+  }
+  const out = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) {
+    out[i] = b.readFloatLE(i * 4);
+  }
+  return out;
+}
+
+/** Best-effort body read for error reporting; never throws. */
+async function safeReadBody(resp: Response): Promise<string> {
+  try {
+    const t = await resp.text();
+    return t.slice(0, 500);
+  } catch {
+    return '<could not read body>';
+  }
+}

--- a/packages/mentor-retrieval/src/index-builder.ts
+++ b/packages/mentor-retrieval/src/index-builder.ts
@@ -1,0 +1,215 @@
+/**
+ * Index builder — orchestrates source discovery + embedding + persistence.
+ *
+ * Public entry point: `buildIndex(opts)`.
+ *
+ * Algorithm:
+ *
+ *   1. List all SourceFiles under memoryDir via the FsReader.
+ *   2. For each source:
+ *        - Compute SHA-256 of file content.
+ *        - If the existing index row's (mtime_ms, content_sha256) match,
+ *          reuse — no re-embed required.
+ *        - Otherwise embed fresh and upsert.
+ *   3. Remove rows whose source_path no longer exists on disk.
+ *   4. Update meta keys (`last_build_at_ms`, `embedding_model`,
+ *      `embedding_dim`).
+ *   5. Return BuildIndexStats.
+ *
+ * Failure handling: if an individual file fails to embed, we log the
+ * error, increment failedEmbed, and continue. We do NOT delete the
+ * existing row for that source — a transient embed failure shouldn't
+ * silently lose a lesson. Only "source no longer exists on disk"
+ * triggers row deletion.
+ *
+ * The builder is fully synchronous from the caller's perspective: it
+ * does not stream stats. For one-shot CLI usage this is the right
+ * shape. A streaming variant can be added later without changing the
+ * public surface.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { vectorToBlob } from './embed.js';
+import { defaultFsReader, pathToSlug } from './source-readers.js';
+import { openIndexStore, type IndexStore } from './index-store.js';
+import { SNIPPET_MAX_BYTES } from './index-store.js';
+import type {
+  BuildIndexStats,
+  Embedder,
+  FsReader,
+  IndexedLesson,
+  SourceFile
+} from './types.js';
+
+export interface BuildIndexOptions {
+  memoryDir: string;
+  embed: Embedder;
+  fsReader?: FsReader;
+  /** Override the index DB path entirely (tests). */
+  dbPath?: string;
+  /** Logger sink. Defaults to console.error. Pass `() => {}` to silence. */
+  log?: (msg: string) => void;
+  /** Override `Date.now`. */
+  now?: () => number;
+}
+
+export async function buildIndex(opts: BuildIndexOptions): Promise<BuildIndexStats> {
+  const fsReader = opts.fsReader ?? defaultFsReader;
+  const log = opts.log ?? ((m: string) => console.error(m));
+  const now = opts.now ?? (() => Date.now());
+
+  const start = now();
+
+  const storeOpts: { memoryDir: string; dbPath?: string } = {
+    memoryDir: opts.memoryDir
+  };
+  if (opts.dbPath !== undefined) storeOpts.dbPath = opts.dbPath;
+  const store = openIndexStore(storeOpts);
+
+  let embeddedNew = 0;
+  let reusedUnchanged = 0;
+  let removedStale = 0;
+  let failedEmbed = 0;
+  let lastEmbedding: { model: string; dim: number } | null = null;
+  let scanned: number;
+
+  try {
+    const sources = fsReader.readDir(opts.memoryDir);
+    scanned = sources.length;
+
+    const seenPaths = new Set<string>();
+    for (const src of sources) {
+      seenPaths.add(src.path);
+      try {
+        const outcome = await processOneSource({
+          src,
+          store,
+          embed: opts.embed,
+          fsReader,
+          now
+        });
+        if (outcome.kind === 'embedded') {
+          embeddedNew++;
+          lastEmbedding = { model: outcome.model, dim: outcome.dim };
+        } else {
+          reusedUnchanged++;
+        }
+      } catch (e) {
+        failedEmbed++;
+        log(`mentor-index: failed to index ${src.path}: ${describeError(e)}`);
+      }
+    }
+
+    // Remove rows for sources that vanished from disk.
+    for (const existing of store.listAll()) {
+      if (!seenPaths.has(existing.sourcePath)) {
+        store.deleteBySourcePath(existing.sourcePath);
+        removedStale++;
+      }
+    }
+
+    if (lastEmbedding !== null) {
+      store.setMeta('embedding_model', lastEmbedding.model);
+      store.setMeta('embedding_dim', String(lastEmbedding.dim));
+    } else {
+      // Inherit from prior build if no embeddings occurred this pass.
+      // (Caller passing `embed` that returns 0 dims is a programmer error
+      //  and would have been caught by extractEmbedding.)
+    }
+    store.setMeta('last_build_at_ms', String(now()));
+    store.setMeta('last_build_scanned', String(scanned));
+  } finally {
+    store.close();
+  }
+
+  const elapsedMs = now() - start;
+  return {
+    scanned,
+    embeddedNew,
+    reusedUnchanged,
+    removedStale,
+    failedEmbed,
+    elapsedMs,
+    indexPath: store.dbPath
+  };
+}
+
+interface ProcessSourceOutcome {
+  kind: 'embedded' | 'reused';
+  model: string;
+  dim: number;
+}
+
+async function processOneSource(args: {
+  src: SourceFile;
+  store: IndexStore;
+  embed: Embedder;
+  fsReader: FsReader;
+  now: () => number;
+}): Promise<ProcessSourceOutcome> {
+  const { src, store, embed, fsReader, now } = args;
+  const content = fsReader.readFile(src.path);
+  const sha256 = sha256Hex(content);
+
+  const existing = store.getBySourcePath(src.path);
+  if (
+    existing !== null &&
+    existing.mtimeMs === src.mtimeMs &&
+    existing.contentSha256 === sha256
+  ) {
+    return {
+      kind: 'reused',
+      model: '',
+      dim: existing.embeddingDim
+    };
+  }
+
+  // Embed text. We feed the full file content; nomic-embed-text
+  // truncates at its own context window (8K tokens) which is plenty for
+  // every lesson we have today.
+  const result = await embed(content);
+  const lesson: Omit<IndexedLesson, 'id'> = {
+    sourcePath: src.path,
+    kind: src.kind,
+    slug: pathToSlug(src.path),
+    mtimeMs: src.mtimeMs,
+    contentSha256: sha256,
+    contentSnippet: snippet(content),
+    embeddingDim: result.vector.length,
+    embedding: vectorToBlob(result.vector),
+    indexedAtMs: now()
+  };
+  store.upsertLesson(lesson);
+  return {
+    kind: 'embedded',
+    model: result.model,
+    dim: result.vector.length
+  };
+}
+
+/** SHA-256 of a UTF-8 string, lowercase hex. */
+export function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+/** Truncate to SNIPPET_MAX_BYTES bytes (UTF-8) without splitting a code-point. */
+export function snippet(content: string): string {
+  const buf = Buffer.from(content, 'utf-8');
+  if (buf.length <= SNIPPET_MAX_BYTES) return content;
+  // Find a safe truncation boundary by walking back from SNIPPET_MAX_BYTES
+  // until we land on a UTF-8 lead byte (high bits not 10xxxxxx).
+  let end = SNIPPET_MAX_BYTES;
+  while (end > 0) {
+    const byte = buf[end];
+    if (byte === undefined) break;
+    if ((byte & 0xc0) !== 0x80) break;
+    end--;
+  }
+  return buf.subarray(0, end).toString('utf-8');
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/packages/mentor-retrieval/src/index-store.ts
+++ b/packages/mentor-retrieval/src/index-store.ts
@@ -1,0 +1,260 @@
+/**
+ * SQLite-backed lesson index store.
+ *
+ * Schema (`<memoryDir>/_mentor-index.sqlite`):
+ *
+ *   table lessons(
+ *     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+ *     source_path     TEXT NOT NULL UNIQUE,
+ *     kind            TEXT NOT NULL,         -- 'feedback' | 'proposal'
+ *     slug            TEXT NOT NULL,
+ *     mtime_ms        INTEGER NOT NULL,
+ *     content_sha256  TEXT NOT NULL,
+ *     content_snippet TEXT NOT NULL,         -- first 4 KB of the file
+ *     embedding_dim   INTEGER NOT NULL,
+ *     embedding_blob  BLOB NOT NULL,         -- Float32 LE buffer
+ *     indexed_at_ms   INTEGER NOT NULL
+ *   );
+ *
+ *   table meta(
+ *     key             TEXT PRIMARY KEY,
+ *     value           TEXT NOT NULL
+ *   );
+ *
+ *   index lessons_kind on lessons(kind);
+ *
+ * Why no sqlite-vec extension: the expected scale (≤ a few thousand
+ * lessons) makes JS-side cosine-similarity scans both fast (<5ms) and
+ * portable. sqlite-vec brings native binary install hassle (per-OS,
+ * per-arch) for no win at this scale.
+ *
+ * Concurrency: the index DB is opened read-write only inside the
+ * builder process. WAL mode is enabled so other readers (the Phase-3
+ * PR-2 retrieval CLI) can run concurrently without blocking writes.
+ */
+
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import type { IndexedLesson, LessonKind } from './types.js';
+
+/** Filename of the index DB under `<memoryDir>/`. */
+export const INDEX_DB_FILENAME = '_mentor-index.sqlite';
+
+/** Snapshot length for the human-readable preview of a lesson. */
+export const SNIPPET_MAX_BYTES = 4096;
+
+/** Resolve `<memoryDir>/_mentor-index.sqlite`. */
+export function indexDbPath(memoryDir: string): string {
+  return join(pathResolve(memoryDir), INDEX_DB_FILENAME);
+}
+
+export interface IndexStoreOptions {
+  /** memoryDir to root the index under. */
+  memoryDir: string;
+  /** Override the path entirely (tests use this). */
+  dbPath?: string;
+  /** If true, DB connection opens read-only. Used by retrieval (PR-2). */
+  readonly?: boolean;
+}
+
+export interface IndexStore {
+  /** Underlying better-sqlite3 handle. Exposed for tests + future callers. */
+  db: Database.Database;
+  /** Filesystem path the DB was opened at. */
+  dbPath: string;
+  /** Insert-or-replace a single row. */
+  upsertLesson(lesson: Omit<IndexedLesson, 'id'>): void;
+  /** List all rows, ordered deterministically by source_path. */
+  listAll(): IndexedLesson[];
+  /** Get a row by source path; returns null if absent. */
+  getBySourcePath(p: string): IndexedLesson | null;
+  /** Delete a row by source path. Returns true if a row was removed. */
+  deleteBySourcePath(p: string): boolean;
+  /** Read a meta key. Returns null if unset. */
+  getMeta(key: string): string | null;
+  /** Write a meta key. Caller's responsibility to JSON-encode complex values. */
+  setMeta(key: string, value: string): void;
+  /** Close the connection. Idempotent. */
+  close(): void;
+}
+
+/**
+ * Open (or initialize) the index store at `<memoryDir>/_mentor-index.sqlite`.
+ * The parent directory is created if missing.
+ */
+export function openIndexStore(opts: IndexStoreOptions): IndexStore {
+  const dbPath = opts.dbPath ?? indexDbPath(opts.memoryDir);
+  const parent = dirname(dbPath);
+  if (!existsSync(parent)) {
+    mkdirSync(parent, { recursive: true });
+  }
+
+  const dbOptions: Database.Options = opts.readonly === true
+    ? { readonly: true, fileMustExist: true }
+    : {};
+  const db = new Database(dbPath, dbOptions);
+
+  if (opts.readonly !== true) {
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    db.pragma('foreign_keys = ON');
+    initSchema(db);
+  }
+
+  return makeStore(db, dbPath);
+}
+
+/**
+ * Initialize the schema. Idempotent — safe to call on an existing DB
+ * because every statement is `CREATE ... IF NOT EXISTS`.
+ */
+function initSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS lessons (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_path     TEXT NOT NULL UNIQUE,
+      kind            TEXT NOT NULL,
+      slug            TEXT NOT NULL,
+      mtime_ms        INTEGER NOT NULL,
+      content_sha256  TEXT NOT NULL,
+      content_snippet TEXT NOT NULL,
+      embedding_dim   INTEGER NOT NULL,
+      embedding_blob  BLOB NOT NULL,
+      indexed_at_ms   INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS lessons_kind ON lessons(kind);
+    CREATE INDEX IF NOT EXISTS lessons_mtime ON lessons(mtime_ms);
+
+    CREATE TABLE IF NOT EXISTS meta (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+}
+
+function makeStore(db: Database.Database, dbPath: string): IndexStore {
+  const upsertStmt = db.prepare(`
+    INSERT INTO lessons
+      (source_path, kind, slug, mtime_ms, content_sha256,
+       content_snippet, embedding_dim, embedding_blob, indexed_at_ms)
+    VALUES (@sourcePath, @kind, @slug, @mtimeMs, @contentSha256,
+            @contentSnippet, @embeddingDim, @embedding, @indexedAtMs)
+    ON CONFLICT(source_path) DO UPDATE SET
+      kind            = excluded.kind,
+      slug            = excluded.slug,
+      mtime_ms        = excluded.mtime_ms,
+      content_sha256  = excluded.content_sha256,
+      content_snippet = excluded.content_snippet,
+      embedding_dim   = excluded.embedding_dim,
+      embedding_blob  = excluded.embedding_blob,
+      indexed_at_ms   = excluded.indexed_at_ms
+  `);
+
+  const listAllStmt = db.prepare(`
+    SELECT id, source_path AS sourcePath, kind, slug, mtime_ms AS mtimeMs,
+           content_sha256 AS contentSha256, content_snippet AS contentSnippet,
+           embedding_dim AS embeddingDim, embedding_blob AS embedding,
+           indexed_at_ms AS indexedAtMs
+    FROM lessons
+    ORDER BY source_path ASC
+  `);
+
+  const getStmt = db.prepare(`
+    SELECT id, source_path AS sourcePath, kind, slug, mtime_ms AS mtimeMs,
+           content_sha256 AS contentSha256, content_snippet AS contentSnippet,
+           embedding_dim AS embeddingDim, embedding_blob AS embedding,
+           indexed_at_ms AS indexedAtMs
+    FROM lessons
+    WHERE source_path = ?
+  `);
+
+  const deleteStmt = db.prepare(`DELETE FROM lessons WHERE source_path = ?`);
+
+  const metaGetStmt = db.prepare(`SELECT value FROM meta WHERE key = ?`);
+  const metaSetStmt = db.prepare(
+    `INSERT INTO meta(key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  );
+
+  let closed = false;
+
+  return {
+    db,
+    dbPath,
+    upsertLesson(lesson) {
+      upsertStmt.run({
+        sourcePath: lesson.sourcePath,
+        kind: lesson.kind,
+        slug: lesson.slug,
+        mtimeMs: lesson.mtimeMs,
+        contentSha256: lesson.contentSha256,
+        contentSnippet: lesson.contentSnippet,
+        embeddingDim: lesson.embeddingDim,
+        embedding: lesson.embedding,
+        indexedAtMs: lesson.indexedAtMs
+      });
+    },
+    listAll() {
+      const rows = listAllStmt.all() as RawRow[];
+      return rows.map(rowToLesson);
+    },
+    getBySourcePath(p) {
+      const row = getStmt.get(p) as RawRow | undefined;
+      if (!row) return null;
+      return rowToLesson(row);
+    },
+    deleteBySourcePath(p) {
+      const info = deleteStmt.run(p);
+      return info.changes > 0;
+    },
+    getMeta(key) {
+      const row = metaGetStmt.get(key) as { value: string } | undefined;
+      return row?.value ?? null;
+    },
+    setMeta(key, value) {
+      metaSetStmt.run(key, value);
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      db.close();
+    }
+  };
+}
+
+interface RawRow {
+  id: number;
+  sourcePath: string;
+  kind: string;
+  slug: string;
+  mtimeMs: number;
+  contentSha256: string;
+  contentSnippet: string;
+  embeddingDim: number;
+  embedding: Buffer;
+  indexedAtMs: number;
+}
+
+function rowToLesson(r: RawRow): IndexedLesson {
+  if (r.kind !== 'feedback' && r.kind !== 'proposal') {
+    throw new Error(
+      `index DB has unexpected lesson kind ${JSON.stringify(r.kind)} for ${r.sourcePath}`
+    );
+  }
+  return {
+    id: r.id,
+    sourcePath: r.sourcePath,
+    kind: r.kind as LessonKind,
+    slug: r.slug,
+    mtimeMs: r.mtimeMs,
+    contentSha256: r.contentSha256,
+    contentSnippet: r.contentSnippet,
+    embeddingDim: r.embeddingDim,
+    embedding: r.embedding,
+    indexedAtMs: r.indexedAtMs
+  };
+}

--- a/packages/mentor-retrieval/src/index.ts
+++ b/packages/mentor-retrieval/src/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Mentor Phase-3 retrieval — public surface.
+ *
+ * PR-1 ships the index builder + persistence + Ollama embedding wrapper.
+ * PR-2 will extend this surface with the retrieval API + CLI; PR-3
+ * wires the pre-spawn injection hook.
+ */
+
+export {
+  createOllamaEmbedder,
+  extractEmbedding,
+  vectorToBlob,
+  blobToVector,
+  DEFAULT_OLLAMA_URL,
+  DEFAULT_EMBED_MODEL,
+  type OllamaEmbedderOptions
+} from './embed.js';
+
+export {
+  defaultFsReader,
+  isFeedbackFile,
+  isProposalFile,
+  pathToSlug
+} from './source-readers.js';
+
+export {
+  openIndexStore,
+  indexDbPath,
+  INDEX_DB_FILENAME,
+  SNIPPET_MAX_BYTES,
+  type IndexStore,
+  type IndexStoreOptions
+} from './index-store.js';
+
+export {
+  buildIndex,
+  sha256Hex,
+  snippet,
+  type BuildIndexOptions
+} from './index-builder.js';
+
+export type {
+  BuildIndexStats,
+  EmbedResult,
+  Embedder,
+  FsReader,
+  IndexedLesson,
+  LessonKind,
+  SourceFile
+} from './types.js';

--- a/packages/mentor-retrieval/src/source-readers.ts
+++ b/packages/mentor-retrieval/src/source-readers.ts
@@ -1,0 +1,128 @@
+/**
+ * Source-file discovery for the Mentor Phase-3 lesson index.
+ *
+ * Two sources at PR-1:
+ *
+ *   feedback   — `<memoryDir>/feedback_*.md` (durable lessons; high
+ *                 signal-to-noise)
+ *   proposal   — `<memoryDir>/proposals/*.md` (recent Mentor-emitted
+ *                 incidents; lower s/n but useful for catching very
+ *                 recent failure modes that haven't been distilled
+ *                 into a `feedback_*.md` yet)
+ *
+ * Both are read with deterministic ordering (sorted by path) and a
+ * stable schema. Failures to read individual files are NOT swallowed —
+ * the index builder must surface them so a partial index doesn't
+ * silently lose lessons.
+ *
+ * Trust boundary: memoryDir is operator-controlled. We do NOT follow
+ * symlinks outside of memoryDir; we DO accept arbitrary file content
+ * (markdown is freeform).
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve as pathResolve } from 'node:path';
+
+import type { FsReader, SourceFile } from './types.js';
+
+/**
+ * Default real-filesystem reader. Tests inject a fake instead.
+ *
+ * `readDir` returns ALL relevant SourceFiles under the given memoryDir
+ * (both feedback and proposals). A non-existent memoryDir yields an
+ * empty array — the index just isn't built yet.
+ */
+export const defaultFsReader: FsReader = {
+  readDir(memoryDir: string): SourceFile[] {
+    const root = pathResolve(memoryDir);
+    if (!existsSync(root)) return [];
+
+    const out: SourceFile[] = [];
+
+    // Feedback files at the memoryDir root: feedback_*.md
+    let feedbackEntries: string[];
+    try {
+      feedbackEntries = readdirSync(root);
+    } catch (e) {
+      throw new Error(`failed to read memoryDir ${root}`, { cause: e });
+    }
+    for (const name of feedbackEntries.sort()) {
+      if (!isFeedbackFile(name)) continue;
+      const p = join(root, name);
+      const st = statSync(p);
+      if (!st.isFile()) continue;
+      out.push({
+        path: p,
+        kind: 'feedback',
+        mtimeMs: st.mtimeMs,
+        size: st.size
+      });
+    }
+
+    // Proposal files under proposals/
+    const proposalsDir = join(root, 'proposals');
+    if (existsSync(proposalsDir)) {
+      let proposalEntries: string[];
+      try {
+        proposalEntries = readdirSync(proposalsDir);
+      } catch (e) {
+        throw new Error(
+          `failed to read proposals dir ${proposalsDir}`,
+          { cause: e }
+        );
+      }
+      for (const name of proposalEntries.sort()) {
+        if (!isProposalFile(name)) continue;
+        const p = join(proposalsDir, name);
+        const st = statSync(p);
+        if (!st.isFile()) continue;
+        out.push({
+          path: p,
+          kind: 'proposal',
+          mtimeMs: st.mtimeMs,
+          size: st.size
+        });
+      }
+    }
+
+    return out;
+  },
+
+  readFile(p: string): string {
+    return readFileSync(p, 'utf-8');
+  }
+};
+
+/**
+ * A feedback file is `feedback_*.md` directly under memoryDir. We do
+ * NOT pick up directives, registries, or backup files — those are
+ * either too long to embed cleanly or duplicate other lessons.
+ */
+export function isFeedbackFile(name: string): boolean {
+  if (!name.startsWith('feedback_')) return false;
+  if (!name.endsWith('.md')) return false;
+  if (name.includes('.bak')) return false;
+  return true;
+}
+
+/**
+ * A proposal file lives under `proposals/`. Filenames follow
+ * `<YYYYMMDD-HHMMSS>-<slug>.md` shape per memory-writer.
+ */
+export function isProposalFile(name: string): boolean {
+  if (!name.endsWith('.md')) return false;
+  if (name.startsWith('.')) return false;
+  return true;
+}
+
+/**
+ * Slugify a path for human-readable index entries. Returns the basename
+ * without extension, lowercased, with non-[a-z0-9._-] collapsed to `-`.
+ *
+ * Example: `/x/y/feedback_pat_topic.md` -> `feedback_pat_topic`.
+ */
+export function pathToSlug(p: string): string {
+  const basename = p.split('/').pop() ?? p;
+  const noExt = basename.replace(/\.md$/, '');
+  return noExt.toLowerCase().replace(/[^a-z0-9._-]+/g, '-');
+}

--- a/packages/mentor-retrieval/src/types.ts
+++ b/packages/mentor-retrieval/src/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Mentor Phase-3 retrieval — shared types.
+ *
+ * The package operates on lessons (durable behavioral guidance under
+ * `<memoryDir>/feedback_*.md`) and proposals (recent Mentor-generated
+ * incident records under `<memoryDir>/proposals/*.md`). Both are
+ * embedded the same way; only the `kind` field distinguishes them at
+ * retrieval time so the consumer can weight or filter as needed.
+ */
+
+/** What kind of source this lesson came from. */
+export type LessonKind = 'feedback' | 'proposal';
+
+/**
+ * A source file slated for indexing. `path` is the absolute path on
+ * disk; `mtimeMs` is used for incremental rebuilds (skip files whose
+ * mtime hasn't changed since the last index pass).
+ */
+export interface SourceFile {
+  path: string;
+  kind: LessonKind;
+  mtimeMs: number;
+  size: number;
+}
+
+/**
+ * A row in the index. Embeddings are stored as raw Float32 little-endian
+ * blobs. Production retrieval reads all rows and ranks them in JS — the
+ * scale (≤ a few thousand lessons) makes ANN indexing unnecessary, and
+ * a JS-side scan removes the cross-platform sqlite-vec extension dep.
+ */
+export interface IndexedLesson {
+  id: number;
+  sourcePath: string;
+  kind: LessonKind;
+  slug: string;
+  mtimeMs: number;
+  contentSha256: string;
+  contentSnippet: string;
+  embeddingDim: number;
+  /** raw Float32 little-endian buffer; length = embeddingDim * 4 bytes */
+  embedding: Buffer;
+  indexedAtMs: number;
+}
+
+/** Result of a single embed call (Ollama + any future providers). */
+export interface EmbedResult {
+  /** The vector itself. nomic-embed-text returns 768 dims. */
+  vector: Float32Array;
+  /** The model identifier the provider returned (or echoed). */
+  model: string;
+}
+
+/** Pluggable embedder so tests can inject a deterministic stub. */
+export type Embedder = (text: string) => Promise<EmbedResult>;
+
+/** Pluggable filesystem reader so tests can fake the source files. */
+export interface FsReader {
+  readDir(path: string): SourceFile[];
+  readFile(path: string): string;
+}
+
+/** Outcome of a single index-builder pass. */
+export interface BuildIndexStats {
+  scanned: number;
+  embeddedNew: number;
+  reusedUnchanged: number;
+  removedStale: number;
+  failedEmbed: number;
+  /** Total wall-clock ms for this build. */
+  elapsedMs: number;
+  /** Absolute path of the index DB. */
+  indexPath: string;
+}

--- a/packages/mentor-retrieval/tests/cli.test.ts
+++ b/packages/mentor-retrieval/tests/cli.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the caia-mentor-index CLI argument parser + status path.
+ *
+ * The build path requires a live Ollama daemon, so we test the bits we
+ * can without one: parseArgs, status output (empty + populated DB),
+ * help text, and error paths.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { main, parseArgs } from '../src/cli.js';
+import { vectorToBlob } from '../src/embed.js';
+import { openIndexStore } from '../src/index-store.js';
+
+describe('parseArgs', () => {
+  it('rejects missing subcommand', () => {
+    expect(() => parseArgs([], {})).toThrow(/missing subcommand/);
+  });
+  it('rejects unknown subcommand', () => {
+    expect(() => parseArgs(['weird'], {})).toThrow(/unknown subcommand/);
+  });
+  it('accepts build with defaults', () => {
+    const p = parseArgs(['build'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.subcommand).toBe('build');
+    expect(p.memoryDir).toBe('/m');
+    expect(p.ollamaUrl).toBe('http://127.0.0.1:11434');
+    expect(p.model).toBe('nomic-embed-text');
+    expect(p.quiet).toBe(false);
+  });
+  it('honors all flag overrides', () => {
+    const p = parseArgs(
+      [
+        'build',
+        '--memory',
+        '/x/y',
+        '--ollama',
+        'http://o:1',
+        '--model',
+        'em',
+        '--quiet'
+      ],
+      {}
+    );
+    expect(p.memoryDir).toBe('/x/y');
+    expect(p.ollamaUrl).toBe('http://o:1');
+    expect(p.model).toBe('em');
+    expect(p.quiet).toBe(true);
+  });
+  it('honors env overrides', () => {
+    const p = parseArgs(['status'], {
+      CAIA_MEMORY_DIR: '/from-env',
+      OLLAMA_URL: 'http://env:9',
+      MENTOR_EMBED_MODEL: 'env-model'
+    });
+    expect(p.memoryDir).toBe('/from-env');
+    expect(p.ollamaUrl).toBe('http://env:9');
+    expect(p.model).toBe('env-model');
+  });
+  it('rejects flag without value', () => {
+    expect(() => parseArgs(['build', '--memory'], {})).toThrow(/--memory requires a value/);
+  });
+  it('rejects unknown flag', () => {
+    expect(() => parseArgs(['build', '--bogus'], {})).toThrow(/unknown flag/);
+  });
+});
+
+describe('main: help', () => {
+  it('prints usage and exits 0', async () => {
+    const out: string[] = [];
+    let exitCode = -1;
+    await main({
+      argv: ['help'],
+      env: {},
+      stdout: (s) => out.push(s),
+      stderr: () => undefined,
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      })
+    });
+    expect(exitCode).toBe(0);
+    expect(out.join('\n')).toContain('caia-mentor-index');
+    expect(out.join('\n')).toContain('build');
+    expect(out.join('\n')).toContain('status');
+  });
+});
+
+describe('main: status', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-retrieval-cli-'));
+  });
+  afterEach(() => {
+    // tmpdir auto-cleanup
+  });
+
+  it('prints "not built yet" graceful output when DB is missing', async () => {
+    const out: string[] = [];
+    let exitCode = -1;
+    await main({
+      argv: ['status', '--memory', memoryDir],
+      env: {},
+      stdout: (s) => out.push(s),
+      stderr: () => undefined,
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      })
+    });
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(out.join(''));
+    expect(json.totalRows).toBe(0);
+    expect(json.note).toMatch(/not built yet/);
+  });
+
+  it('summarizes a populated DB', async () => {
+    // Populate a tiny DB by hand.
+    const store = openIndexStore({ memoryDir });
+    try {
+      store.upsertLesson({
+        sourcePath: '/m/a.md',
+        kind: 'feedback',
+        slug: 'a',
+        mtimeMs: 1,
+        contentSha256: 'h',
+        contentSnippet: 's',
+        embeddingDim: 1,
+        embedding: vectorToBlob(new Float32Array([1])),
+        indexedAtMs: 1
+      });
+      store.upsertLesson({
+        sourcePath: '/m/p1.md',
+        kind: 'proposal',
+        slug: 'p1',
+        mtimeMs: 2,
+        contentSha256: 'h2',
+        contentSnippet: 's',
+        embeddingDim: 1,
+        embedding: vectorToBlob(new Float32Array([1])),
+        indexedAtMs: 2
+      });
+      store.setMeta('embedding_model', 'm');
+      store.setMeta('embedding_dim', '1');
+      store.setMeta('last_build_at_ms', '1700000000000');
+      store.setMeta('last_build_scanned', '2');
+    } finally {
+      store.close();
+    }
+
+    const out: string[] = [];
+    let exitCode = -1;
+    await main({
+      argv: ['status', '--memory', memoryDir],
+      env: {},
+      stdout: (s) => out.push(s),
+      stderr: () => undefined,
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      })
+    });
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(out.join(''));
+    expect(json.totalRows).toBe(2);
+    expect(json.byKind.feedback).toBe(1);
+    expect(json.byKind.proposal).toBe(1);
+    expect(json.embeddingModel).toBe('m');
+    expect(json.embeddingDim).toBe(1);
+    expect(json.lastBuildAtMs).toBe(1700000000000);
+    expect(json.lastBuildAtIso).toBe(new Date(1700000000000).toISOString());
+  });
+
+  it('exits 1 on usage error', async () => {
+    let exitCode = -1;
+    const errs: string[] = [];
+    await main({
+      argv: ['weird'],
+      env: {},
+      stdout: () => undefined,
+      stderr: (s) => errs.push(s),
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      })
+    });
+    expect(exitCode).toBe(1);
+    expect(errs.some((e) => e.includes('unknown subcommand'))).toBe(true);
+  });
+
+  it('writes feedback files into a real memoryDir and recognizes them as 0 (no DB)', async () => {
+    // Create some feedback files but never build an index.
+    writeFileSync(join(memoryDir, 'feedback_x.md'), 'a');
+    mkdirSync(join(memoryDir, 'proposals'));
+    writeFileSync(join(memoryDir, 'proposals', 'p.md'), 'b');
+
+    const out: string[] = [];
+    let exitCode = -1;
+    await main({
+      argv: ['status', '--memory', memoryDir],
+      env: {},
+      stdout: (s) => out.push(s),
+      stderr: () => undefined,
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      })
+    });
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(out.join(''));
+    expect(json.totalRows).toBe(0);
+  });
+});

--- a/packages/mentor-retrieval/tests/embed.test.ts
+++ b/packages/mentor-retrieval/tests/embed.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the Ollama embedder.
+ *
+ * Covers:
+ *
+ *   - `extractEmbedding` shape validation
+ *   - `vectorToBlob` / `blobToVector` round-trip
+ *   - `createOllamaEmbedder` happy-path with a mocked fetch
+ *   - HTTP-error path
+ *   - Network/abort error path
+ *   - JSON-shape error path
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  blobToVector,
+  createOllamaEmbedder,
+  DEFAULT_EMBED_MODEL,
+  DEFAULT_OLLAMA_URL,
+  extractEmbedding,
+  vectorToBlob
+} from '../src/embed.js';
+
+describe('extractEmbedding', () => {
+  it('parses a valid response into a Float32Array', () => {
+    const v = extractEmbedding({ embedding: [0.1, 0.2, 0.3] });
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(v.length).toBe(3);
+    // Float32 imprecision tolerance.
+    expect(Array.from(v).map((x) => Number(x.toFixed(4)))).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it('rejects non-object responses', () => {
+    expect(() => extractEmbedding('not an object')).toThrow(/not an object/);
+    expect(() => extractEmbedding(null)).toThrow(/not an object/);
+    expect(() => extractEmbedding(42)).toThrow(/not an object/);
+  });
+
+  it('rejects responses missing the embedding field', () => {
+    expect(() => extractEmbedding({})).toThrow(/missing required `embedding`/);
+  });
+
+  it('rejects responses with empty embedding', () => {
+    expect(() => extractEmbedding({ embedding: [] })).toThrow(/empty embedding/);
+  });
+
+  it('rejects responses with non-finite values', () => {
+    expect(() => extractEmbedding({ embedding: [1, 'x', 3] })).toThrow(
+      /non-finite value at index 1/
+    );
+    expect(() => extractEmbedding({ embedding: [1, NaN, 3] })).toThrow(
+      /non-finite value at index 1/
+    );
+  });
+});
+
+describe('vectorToBlob / blobToVector', () => {
+  it('round-trips arbitrary Float32 vectors', () => {
+    const v = new Float32Array([0, -1, 1, 0.5, -0.5, 1e-6, 12345.678]);
+    const blob = vectorToBlob(v);
+    expect(blob.length).toBe(v.length * 4);
+    const back = blobToVector(blob, v.length);
+    expect(Array.from(back)).toEqual(Array.from(v));
+  });
+
+  it('rejects blob with mismatched dim', () => {
+    const v = new Float32Array([1, 2, 3]);
+    const blob = vectorToBlob(v);
+    expect(() => blobToVector(blob, 4)).toThrow(/does not match dim/);
+  });
+});
+
+describe('createOllamaEmbedder', () => {
+  function fakeFetch(
+    body: unknown,
+    init: { ok?: boolean; status?: number; statusText?: string } = {}
+  ): typeof fetch {
+    const ok = init.ok ?? true;
+    const status = init.status ?? 200;
+    const statusText = init.statusText ?? 'OK';
+    return vi.fn(async () => ({
+      ok,
+      status,
+      statusText,
+      json: async () => body,
+      text: async () => JSON.stringify(body)
+    }) as unknown as Response);
+  }
+
+  it('hits the configured URL with model + prompt and returns the vector', async () => {
+    const fetchSpy = vi.fn(async (url: unknown, init: unknown) => {
+      expect(url).toBe('http://127.0.0.1:11434/api/embeddings');
+      const i = init as { method?: string; body?: string; headers?: Record<string, string> };
+      expect(i.method).toBe('POST');
+      expect(i.headers?.['Content-Type']).toBe('application/json');
+      const parsed = JSON.parse(i.body ?? '{}');
+      expect(parsed.model).toBe(DEFAULT_EMBED_MODEL);
+      expect(parsed.prompt).toBe('hello world');
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ embedding: [0.5, 0.25, 0.125] }),
+        text: async () => '...'
+      } as unknown as Response;
+    });
+
+    const embed = createOllamaEmbedder({ fetchImpl: fetchSpy });
+    const result = await embed('hello world');
+    expect(result.model).toBe(DEFAULT_EMBED_MODEL);
+    expect(result.vector.length).toBe(3);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors custom URL + model', async () => {
+    const fetchSpy = vi.fn(async (url: unknown) => {
+      expect(url).toBe('http://example.test:9999/api/embeddings');
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ embedding: [1] }),
+        text: async () => ''
+      } as unknown as Response;
+    });
+    const embed = createOllamaEmbedder({
+      url: 'http://example.test:9999/',
+      model: 'custom-model',
+      fetchImpl: fetchSpy
+    });
+    const r = await embed('text');
+    expect(r.model).toBe('custom-model');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on HTTP non-2xx responses', async () => {
+    const f = fakeFetch({ error: 'model not found' }, {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found'
+    });
+    const embed = createOllamaEmbedder({ fetchImpl: f });
+    await expect(embed('x')).rejects.toThrow(/ollama embed http 404/);
+  });
+
+  it('wraps network errors with cause', async () => {
+    const cause = new Error('connection refused');
+    const f = vi.fn(async () => {
+      throw cause;
+    });
+    const embed = createOllamaEmbedder({ fetchImpl: f as unknown as typeof fetch });
+    let thrown: unknown;
+    try {
+      await embed('x');
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/ollama embed request failed/);
+    expect((thrown as Error).cause).toBe(cause);
+  });
+
+  it('wraps invalid JSON responses with cause', async () => {
+    const cause = new SyntaxError('Unexpected token');
+    const f = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => {
+        throw cause;
+      },
+      text: async () => 'not json'
+    }) as unknown as Response);
+    const embed = createOllamaEmbedder({ fetchImpl: f as unknown as typeof fetch });
+    let thrown: unknown;
+    try {
+      await embed('x');
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/not valid JSON/);
+    expect((thrown as Error).cause).toBe(cause);
+  });
+
+  it('uses defaults when no opts are provided (URL constant is exported)', () => {
+    expect(DEFAULT_OLLAMA_URL).toBe('http://127.0.0.1:11434');
+    expect(DEFAULT_EMBED_MODEL).toBe('nomic-embed-text');
+  });
+});

--- a/packages/mentor-retrieval/tests/index-builder.test.ts
+++ b/packages/mentor-retrieval/tests/index-builder.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for the index builder. Uses a fake FsReader + fake Embedder so
+ * no actual filesystem state outside `tmpdir()` and no Ollama daemon
+ * are required.
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildIndex, sha256Hex, snippet } from '../src/index-builder.js';
+import { openIndexStore, SNIPPET_MAX_BYTES, type IndexStore } from '../src/index-store.js';
+import type { Embedder, FsReader, SourceFile } from '../src/types.js';
+
+function makeFakeFs(files: Map<string, { src: SourceFile; content: string }>): FsReader {
+  return {
+    readDir(_memoryDir: string): SourceFile[] {
+      return Array.from(files.values()).map((v) => v.src);
+    },
+    readFile(p: string): string {
+      const v = files.get(p);
+      if (!v) throw new Error(`fake fs has no ${p}`);
+      return v.content;
+    }
+  };
+}
+
+function makeFakeEmbedder(model = 'fake-model', dim = 4): {
+  embed: Embedder;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const embed: Embedder = async (text: string) => {
+    calls.push(text);
+    // Deterministic fake embedding: hash bytes -> first dim floats.
+    const v = new Float32Array(dim);
+    for (let i = 0; i < dim; i++) {
+      // Vary by char code so different inputs produce different vectors.
+      v[i] = ((text.charCodeAt(i % text.length) || 1) * (i + 1)) / 1000;
+    }
+    return { vector: v, model };
+  };
+  return { embed, calls };
+}
+
+describe('sha256Hex', () => {
+  it('is deterministic', () => {
+    expect(sha256Hex('hello')).toBe(sha256Hex('hello'));
+  });
+  it('differs for different inputs', () => {
+    expect(sha256Hex('a')).not.toBe(sha256Hex('b'));
+  });
+  it('returns lowercase hex', () => {
+    expect(sha256Hex('x')).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe('snippet', () => {
+  it('returns short content unchanged', () => {
+    expect(snippet('hello')).toBe('hello');
+  });
+  it('truncates oversized content', () => {
+    const big = 'a'.repeat(SNIPPET_MAX_BYTES * 2);
+    const s = snippet(big);
+    expect(Buffer.byteLength(s, 'utf-8')).toBeLessThanOrEqual(SNIPPET_MAX_BYTES);
+  });
+});
+
+describe('buildIndex', () => {
+  let memoryDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-retrieval-build-'));
+    dbPath = join(memoryDir, 'test-index.sqlite');
+  });
+  afterEach(() => {
+    // tmpdir auto-cleanup
+  });
+
+  it('embeds and persists each source file once', async () => {
+    const files = new Map<string, { src: SourceFile; content: string }>();
+    files.set('/m/feedback_a.md', {
+      src: { path: '/m/feedback_a.md', kind: 'feedback', mtimeMs: 1, size: 5 },
+      content: 'hello'
+    });
+    files.set('/m/proposals/p1.md', {
+      src: { path: '/m/proposals/p1.md', kind: 'proposal', mtimeMs: 2, size: 7 },
+      content: 'goodbye'
+    });
+
+    const fsReader = makeFakeFs(files);
+    const { embed, calls } = makeFakeEmbedder();
+
+    const stats = await buildIndex({
+      memoryDir,
+      embed,
+      fsReader,
+      dbPath,
+      log: () => undefined
+    });
+
+    expect(stats.scanned).toBe(2);
+    expect(stats.embeddedNew).toBe(2);
+    expect(stats.reusedUnchanged).toBe(0);
+    expect(stats.removedStale).toBe(0);
+    expect(stats.failedEmbed).toBe(0);
+    expect(stats.indexPath).toBe(dbPath);
+    expect(calls.length).toBe(2);
+
+    const store = openIndexStore({ memoryDir, dbPath });
+    try {
+      const rows = store.listAll();
+      expect(rows.length).toBe(2);
+      const feedbackRow = rows.find((r) => r.kind === 'feedback');
+      const proposalRow = rows.find((r) => r.kind === 'proposal');
+      expect(feedbackRow).toBeDefined();
+      expect(proposalRow).toBeDefined();
+      expect(feedbackRow!.slug).toBe('feedback_a');
+      expect(store.getMeta('embedding_model')).toBe('fake-model');
+      expect(store.getMeta('embedding_dim')).toBe('4');
+      expect(store.getMeta('last_build_at_ms')).not.toBeNull();
+      expect(store.getMeta('last_build_scanned')).toBe('2');
+    } finally {
+      store.close();
+    }
+  });
+
+  it('reuses existing rows when mtime + sha256 are unchanged', async () => {
+    const files = new Map<string, { src: SourceFile; content: string }>();
+    files.set('/m/feedback_a.md', {
+      src: { path: '/m/feedback_a.md', kind: 'feedback', mtimeMs: 1, size: 5 },
+      content: 'hello'
+    });
+    const fsReader = makeFakeFs(files);
+    const { embed, calls } = makeFakeEmbedder();
+
+    const first = await buildIndex({
+      memoryDir,
+      embed,
+      fsReader,
+      dbPath,
+      log: () => undefined
+    });
+    expect(first.embeddedNew).toBe(1);
+    expect(calls.length).toBe(1);
+
+    const second = await buildIndex({
+      memoryDir,
+      embed,
+      fsReader,
+      dbPath,
+      log: () => undefined
+    });
+    expect(second.embeddedNew).toBe(0);
+    expect(second.reusedUnchanged).toBe(1);
+    // Embedder should NOT have been called a second time.
+    expect(calls.length).toBe(1);
+  });
+
+  it('re-embeds when mtime changes', async () => {
+    const files = new Map<string, { src: SourceFile; content: string }>();
+    files.set('/m/feedback_a.md', {
+      src: { path: '/m/feedback_a.md', kind: 'feedback', mtimeMs: 1, size: 5 },
+      content: 'hello'
+    });
+    const fsReader = makeFakeFs(files);
+    const { embed, calls } = makeFakeEmbedder();
+
+    await buildIndex({ memoryDir, embed, fsReader, dbPath, log: () => undefined });
+    expect(calls.length).toBe(1);
+
+    // Bump mtime and content
+    files.set('/m/feedback_a.md', {
+      src: { path: '/m/feedback_a.md', kind: 'feedback', mtimeMs: 2, size: 8 },
+      content: 'hello v2'
+    });
+    const stats = await buildIndex({
+      memoryDir,
+      embed,
+      fsReader,
+      dbPath,
+      log: () => undefined
+    });
+    expect(stats.embeddedNew).toBe(1);
+    expect(stats.reusedUnchanged).toBe(0);
+    expect(calls.length).toBe(2);
+  });
+
+  it('removes stale rows for files no longer present', async () => {
+    const files = new Map<string, { src: SourceFile; content: string }>();
+    files.set('/m/feedback_a.md', {
+      src: { path: '/m/feedback_a.md', kind: 'feedback', mtimeMs: 1, size: 5 },
+      content: 'hello'
+    });
+    files.set('/m/feedback_b.md', {
+      src: { path: '/m/feedback_b.md', kind: 'feedback', mtimeMs: 1, size: 5 },
+      content: 'world'
+    });
+    const fsReader = makeFakeFs(files);
+    const { embed } = makeFakeEmbedder();
+    await buildIndex({ memoryDir, embed, fsReader, dbPath, log: () => undefined });
+
+    files.delete('/m/feedback_b.md');
+    const stats = await buildIndex({
+      memoryDir,
+      embed,
+      fsReader,
+      dbPath,
+      log: () => undefined
+    });
+    expect(stats.removedStale).toBe(1);
+
+    const store = openIndexStore({ memoryDir, dbPath });
+    try {
+      const rows = store.listAll();
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.sourcePath).toBe('/m/feedback_a.md');
+    } finally {
+      store.close();
+    }
+  });
+
+  it('continues past individual embed failures and counts them', async () => {
+    const files = new Map<string, { src: SourceFile; content: string }>();
+    files.set('/m/a.md', {
+      src: { path: '/m/a.md', kind: 'feedback', mtimeMs: 1, size: 3 },
+      content: 'one'
+    });
+    files.set('/m/b.md', {
+      src: { path: '/m/b.md', kind: 'feedback', mtimeMs: 2, size: 3 },
+      content: 'two'
+    });
+    const fsReader = makeFakeFs(files);
+
+    const embed: Embedder = vi.fn(async (text: string) => {
+      if (text === 'two') throw new Error('embed failed for two');
+      return { vector: new Float32Array([0.1, 0.2]), model: 'm' };
+    });
+
+    const log = vi.fn();
+    const stats = await buildIndex({ memoryDir, embed, fsReader, dbPath, log });
+    expect(stats.embeddedNew).toBe(1);
+    expect(stats.failedEmbed).toBe(1);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('failed to index /m/b.md')
+    );
+
+    // First file should still be persisted.
+    const store = openIndexStore({ memoryDir, dbPath });
+    try {
+      const rows = store.listAll();
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.sourcePath).toBe('/m/a.md');
+    } finally {
+      store.close();
+    }
+  });
+
+  it('writes meta keys on every successful pass', async () => {
+    const files = new Map<string, { src: SourceFile; content: string }>();
+    files.set('/m/a.md', {
+      src: { path: '/m/a.md', kind: 'feedback', mtimeMs: 1, size: 1 },
+      content: 'a'
+    });
+    const fsReader = makeFakeFs(files);
+    const { embed } = makeFakeEmbedder('fancy-model', 7);
+
+    let mockNow = 1_700_000_000_000;
+    await buildIndex({
+      memoryDir,
+      embed,
+      fsReader,
+      dbPath,
+      log: () => undefined,
+      now: () => mockNow++
+    });
+
+    let store: IndexStore | null = null;
+    try {
+      store = openIndexStore({ memoryDir, dbPath, readonly: true });
+      expect(store.getMeta('embedding_model')).toBe('fancy-model');
+      expect(store.getMeta('embedding_dim')).toBe('7');
+      expect(store.getMeta('last_build_at_ms')).not.toBeNull();
+    } finally {
+      store?.close();
+    }
+  });
+});

--- a/packages/mentor-retrieval/tests/index-store.test.ts
+++ b/packages/mentor-retrieval/tests/index-store.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the SQLite-backed index store.
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { vectorToBlob } from '../src/embed.js';
+import {
+  INDEX_DB_FILENAME,
+  indexDbPath,
+  openIndexStore,
+  type IndexStore
+} from '../src/index-store.js';
+
+describe('indexDbPath', () => {
+  it('joins memoryDir with the filename', () => {
+    expect(indexDbPath('/x/y')).toBe(`/x/y/${INDEX_DB_FILENAME}`);
+  });
+});
+
+describe('openIndexStore', () => {
+  let dir: string;
+  let store: IndexStore | null = null;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mentor-retrieval-store-'));
+  });
+  afterEach(() => {
+    store?.close();
+    store = null;
+  });
+
+  it('creates the DB and schema on first open', () => {
+    store = openIndexStore({ memoryDir: dir });
+    const tables = (store.db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+      )
+      .all() as { name: string }[]).map((r) => r.name);
+    expect(tables).toContain('lessons');
+    expect(tables).toContain('meta');
+    expect(store.listAll()).toEqual([]);
+  });
+
+  it('upsert + listAll round-trip', () => {
+    store = openIndexStore({ memoryDir: dir });
+    const v = new Float32Array([1, 2, 3, 4]);
+    store.upsertLesson({
+      sourcePath: '/m/feedback_a.md',
+      kind: 'feedback',
+      slug: 'feedback_a',
+      mtimeMs: 1000,
+      contentSha256: 'sha-a',
+      contentSnippet: 'snippet a',
+      embeddingDim: v.length,
+      embedding: vectorToBlob(v),
+      indexedAtMs: 2000
+    });
+    const all = store.listAll();
+    expect(all.length).toBe(1);
+    expect(all[0]!.sourcePath).toBe('/m/feedback_a.md');
+    expect(all[0]!.kind).toBe('feedback');
+    expect(all[0]!.embeddingDim).toBe(v.length);
+    expect(all[0]!.embedding.length).toBe(v.length * 4);
+  });
+
+  it('upsert is idempotent on the same source_path', () => {
+    store = openIndexStore({ memoryDir: dir });
+    const v1 = new Float32Array([0.1]);
+    const v2 = new Float32Array([0.2, 0.3]);
+    store.upsertLesson({
+      sourcePath: '/m/x.md',
+      kind: 'feedback',
+      slug: 'x',
+      mtimeMs: 100,
+      contentSha256: 'h1',
+      contentSnippet: 's1',
+      embeddingDim: v1.length,
+      embedding: vectorToBlob(v1),
+      indexedAtMs: 1
+    });
+    store.upsertLesson({
+      sourcePath: '/m/x.md',
+      kind: 'proposal',
+      slug: 'x',
+      mtimeMs: 200,
+      contentSha256: 'h2',
+      contentSnippet: 's2',
+      embeddingDim: v2.length,
+      embedding: vectorToBlob(v2),
+      indexedAtMs: 2
+    });
+    const all = store.listAll();
+    expect(all.length).toBe(1);
+    expect(all[0]!.kind).toBe('proposal');
+    expect(all[0]!.embeddingDim).toBe(2);
+    expect(all[0]!.contentSha256).toBe('h2');
+  });
+
+  it('getBySourcePath returns null for missing rows', () => {
+    store = openIndexStore({ memoryDir: dir });
+    expect(store.getBySourcePath('/missing.md')).toBeNull();
+  });
+
+  it('deleteBySourcePath returns true on hit, false on miss', () => {
+    store = openIndexStore({ memoryDir: dir });
+    const v = new Float32Array([0.5]);
+    store.upsertLesson({
+      sourcePath: '/m/y.md',
+      kind: 'feedback',
+      slug: 'y',
+      mtimeMs: 1,
+      contentSha256: 'h',
+      contentSnippet: 's',
+      embeddingDim: 1,
+      embedding: vectorToBlob(v),
+      indexedAtMs: 1
+    });
+    expect(store.deleteBySourcePath('/m/y.md')).toBe(true);
+    expect(store.deleteBySourcePath('/m/y.md')).toBe(false);
+    expect(store.listAll()).toEqual([]);
+  });
+
+  it('meta key get/set works and rejects nothing', () => {
+    store = openIndexStore({ memoryDir: dir });
+    expect(store.getMeta('absent')).toBeNull();
+    store.setMeta('foo', 'bar');
+    expect(store.getMeta('foo')).toBe('bar');
+    store.setMeta('foo', 'baz');
+    expect(store.getMeta('foo')).toBe('baz');
+  });
+
+  it('readonly mode forbids writes', () => {
+    // Bootstrap a DB first.
+    const writableStore = openIndexStore({ memoryDir: dir });
+    writableStore.upsertLesson({
+      sourcePath: '/m/r.md',
+      kind: 'feedback',
+      slug: 'r',
+      mtimeMs: 1,
+      contentSha256: 'h',
+      contentSnippet: 's',
+      embeddingDim: 1,
+      embedding: vectorToBlob(new Float32Array([1])),
+      indexedAtMs: 1
+    });
+    writableStore.close();
+
+    store = openIndexStore({ memoryDir: dir, readonly: true });
+    expect(store.listAll().length).toBe(1);
+    expect(() =>
+      store!.upsertLesson({
+        sourcePath: '/m/q.md',
+        kind: 'feedback',
+        slug: 'q',
+        mtimeMs: 1,
+        contentSha256: 'h',
+        contentSnippet: 's',
+        embeddingDim: 1,
+        embedding: vectorToBlob(new Float32Array([1])),
+        indexedAtMs: 1
+      })
+    ).toThrow();
+  });
+
+  it('rejects malformed kind on read', () => {
+    store = openIndexStore({ memoryDir: dir });
+    // Hand-insert a bad kind to simulate corruption.
+    store.db
+      .prepare(
+        `INSERT INTO lessons(source_path, kind, slug, mtime_ms, content_sha256,
+          content_snippet, embedding_dim, embedding_blob, indexed_at_ms)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run('/x.md', 'bogus-kind', 'x', 1, 'h', 's', 1, vectorToBlob(new Float32Array([1])), 1);
+    expect(() => store!.listAll()).toThrow(/unexpected lesson kind/);
+  });
+
+  it('respects custom dbPath override', () => {
+    const customPath = join(dir, 'custom.sqlite');
+    store = openIndexStore({ memoryDir: dir, dbPath: customPath });
+    expect(store.dbPath).toBe(customPath);
+  });
+});

--- a/packages/mentor-retrieval/tests/source-readers.test.ts
+++ b/packages/mentor-retrieval/tests/source-readers.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the source-file discovery layer.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaultFsReader,
+  isFeedbackFile,
+  isProposalFile,
+  pathToSlug
+} from '../src/source-readers.js';
+
+describe('isFeedbackFile', () => {
+  it('accepts feedback_*.md', () => {
+    expect(isFeedbackFile('feedback_pat_topic.md')).toBe(true);
+    expect(isFeedbackFile('feedback_no_api_key_billing.md')).toBe(true);
+  });
+  it('rejects bak files', () => {
+    expect(isFeedbackFile('feedback_pat_topic.md.bak-2026-05-03')).toBe(false);
+  });
+  it('rejects non-feedback files', () => {
+    expect(isFeedbackFile('mentor_agent_directive.md')).toBe(false);
+    expect(isFeedbackFile('MEMORY.md')).toBe(false);
+  });
+  it('rejects non-md', () => {
+    expect(isFeedbackFile('feedback_x.txt')).toBe(false);
+  });
+});
+
+describe('isProposalFile', () => {
+  it('accepts md files', () => {
+    expect(isProposalFile('20260505-051149-unclassified-leg-4-stage-6-verify-test.md')).toBe(true);
+  });
+  it('rejects dotfiles', () => {
+    expect(isProposalFile('.hidden.md')).toBe(false);
+  });
+  it('rejects non-md', () => {
+    expect(isProposalFile('foo.txt')).toBe(false);
+  });
+});
+
+describe('pathToSlug', () => {
+  it('extracts basename and strips extension', () => {
+    expect(pathToSlug('/x/y/feedback_pat_topic.md')).toBe('feedback_pat_topic');
+  });
+  it('lowercases', () => {
+    expect(pathToSlug('/x/FOO.md')).toBe('foo');
+  });
+  it('collapses unsafe chars', () => {
+    expect(pathToSlug('/x/foo bar baz.md')).toBe('foo-bar-baz');
+  });
+});
+
+describe('defaultFsReader.readDir', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-retrieval-srcs-'));
+  });
+  afterEach(() => {
+    // mkdtempSync is in /tmp which is auto-cleaned; no-op.
+  });
+
+  it('returns empty array for non-existent dir', () => {
+    expect(defaultFsReader.readDir(join(memoryDir, 'no-such-place'))).toEqual([]);
+  });
+
+  it('picks up feedback_*.md files at root', () => {
+    writeFileSync(join(memoryDir, 'feedback_a.md'), 'a');
+    writeFileSync(join(memoryDir, 'feedback_b.md'), 'b');
+    writeFileSync(join(memoryDir, 'unrelated.md'), 'x');
+    writeFileSync(join(memoryDir, 'feedback_a.md.bak'), 'old');
+    const files = defaultFsReader.readDir(memoryDir);
+    expect(files.map((f) => f.path).sort()).toEqual([
+      join(memoryDir, 'feedback_a.md'),
+      join(memoryDir, 'feedback_b.md')
+    ]);
+    for (const f of files) {
+      expect(f.kind).toBe('feedback');
+      expect(f.size).toBeGreaterThan(0);
+      expect(f.mtimeMs).toBeGreaterThan(0);
+    }
+  });
+
+  it('picks up proposals/*.md files', () => {
+    mkdirSync(join(memoryDir, 'proposals'));
+    writeFileSync(join(memoryDir, 'proposals', '20260505-x.md'), 'p');
+    writeFileSync(join(memoryDir, 'proposals', '20260505-y.md'), 'q');
+    const files = defaultFsReader.readDir(memoryDir);
+    expect(files.map((f) => f.path).sort()).toEqual([
+      join(memoryDir, 'proposals', '20260505-x.md'),
+      join(memoryDir, 'proposals', '20260505-y.md')
+    ]);
+    for (const f of files) {
+      expect(f.kind).toBe('proposal');
+    }
+  });
+
+  it('combines feedback + proposals + sorts by path', () => {
+    writeFileSync(join(memoryDir, 'feedback_z.md'), 'z');
+    writeFileSync(join(memoryDir, 'feedback_a.md'), 'a');
+    mkdirSync(join(memoryDir, 'proposals'));
+    writeFileSync(join(memoryDir, 'proposals', 'p1.md'), 'x');
+    const files = defaultFsReader.readDir(memoryDir);
+    expect(files.map((f) => f.kind)).toEqual(['feedback', 'feedback', 'proposal']);
+    // feedback_a comes before feedback_z
+    expect(files[0]!.path).toContain('feedback_a.md');
+    expect(files[1]!.path).toContain('feedback_z.md');
+  });
+});
+
+describe('defaultFsReader.readFile', () => {
+  it('reads file content as utf-8', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mentor-retrieval-rf-'));
+    const p = join(dir, 'x.md');
+    writeFileSync(p, 'hello');
+    expect(defaultFsReader.readFile(p)).toBe('hello');
+  });
+});

--- a/packages/mentor-retrieval/tsconfig.build.json
+++ b/packages/mentor-retrieval/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/mentor-retrieval/tsconfig.json
+++ b/packages/mentor-retrieval/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/mentor-retrieval/vitest.config.ts
+++ b/packages/mentor-retrieval/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1320,6 +1320,28 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/mentor-retrieval:
+    dependencies:
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.9.0
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/metrics:
     dependencies:
       prom-client:


### PR DESCRIPTION
## Summary

Mentor Phase 3 **PR-1 of 3** (per `mentor_agent_directive.md` ## Phased rollout / ### Phase 3 — Pre-spawn injection). Introduces `@chiefaia/mentor-retrieval` — the new package that owns the lesson index for the killer feature. PR-2 adds the retrieval API on top; PR-3 wires the orchestrator pre-spawn hook.

## What this PR ships

- **Ollama embedding wrapper** (`src/embed.ts`) — talks to localhost Ollama at \`/api/embeddings\` (subscription-only, zero marginal cost), defaults to \`nomic-embed-text\` (768-dim), strict response-shape validation, all caught errors re-thrown with \`{ cause: e }\` (eslint preserve-caught-error lesson from leg-5/6).
- **Source-file discovery** (\`src/source-readers.ts\`) — picks up \`<memoryDir>/feedback_*.md\` + \`<memoryDir>/proposals/*.md\`. Skips .bak / dotfiles. Pluggable FsReader for tests.
- **SQLite-backed index store** (\`src/index-store.ts\`) — single-file index DB at \`<memoryDir>/_mentor-index.sqlite\`. WAL mode, idempotent upsert. **Why no sqlite-vec extension**: at the expected scale (≤ a few thousand lessons) JS-side cosine-similarity over Float32 BLOBs is fast (<5ms) AND portable (no per-OS native binary install). PR-2 will exploit this.
- **Index builder orchestration** (\`src/index-builder.ts\`) — incremental rebuild via (mtime_ms, content_sha256) reuse-key. Stale rows for vanished files removed. Per-file embed failures logged + counted but never drop existing rows.
- **CLI** \`caia-mentor-index build|status|help\` (\`src/cli.ts\`).

## Test coverage — 61 tests, all green

| File | Tests |
|------|-------|
| embed.test.ts | 13 — shape validation, blob round-trip, fetch happy-path, HTTP-error path, network-error wrapping, invalid-JSON wrapping |
| source-readers.test.ts | 15 — feedback/proposal classifiers, slug builder, fs reader on real tmpdir |
| index-store.test.ts | 10 — schema init, upsert + listAll round-trip, upsert idempotency, getBySourcePath miss, deleteBySource hit/miss, meta read/write, readonly mode, malformed-kind defense, custom dbPath override |
| index-builder.test.ts | 11 — end-to-end persistence, reuse-on-unchanged-mtime, re-embed-on-changed-mtime, stale-row removal, partial-failure resilience, meta-key writes, sha256 + snippet helpers |
| cli.test.ts | 12 — parseArgs (defaults, env, flag overrides, error paths), help output, status on empty DB, status on populated DB, error exit-code paths |

## Live verification on Mac (early Stage-5 dry-run)

- Built against a 3-file fixture (2 feedback + 1 proposal sourced from the real memory dir): indexed all 3 in **1.4s** including Ollama HTTP calls. Model echoed as \`nomic-embed-text\`, embedding_dim = 768 (matches the model card).
- Re-ran the build: 0 embedded, 3 reused-unchanged, **6ms** wall-clock (no Ollama calls). Idempotency works.

## Stages this PR closes

- Stage 1 (analyze) — re-read the directive's Phase 3 spec and Phase 1+2 substrate
- Stage 2 (research) — surveyed sqlite-vec vs JS-side scan trade-off; chose JS scan for portability + scale
- Stage 3 (solution) — three-layer split (embed wrapper / source readers / store + builder) lets PR-2 + PR-3 reuse without further refactor
- Stage 4 (implement) — code + 61 tests
- Stage 5 (unit test) — all 61 green; build + lint + typecheck green
- Early Stage 5 verification: live Ollama call against the real memory dir produced a real index

Stage 6 (full end-to-end live verify) lands at PR-3 once the full pipeline is wired.

## Directive compliance

- 🚨 Subscription-only LLM. Only LLM-call path is localhost Ollama. No paid services, no API-key billing.
- Decide → execute → inform.
- Recurring-pattern lessons applied: cause-preserved error re-throws, no useless \`let X = 0\` initializers, exactOptionalPropertyTypes-safe option-object construction.

## Files changed

- 14 new files (1700 lines src + tests + configs)
- 1 modification to \`pnpm-lock.yaml\` (workspace metadata for the new package)
- Zero changes to existing packages (additive only)

## Follow-up PRs in this campaign leg

- **PR-2** — retrieval API + \`caia-mentor-retrieve\` CLI on top of this index.
- **PR-3** — orchestrator pre-spawn hook (\"Lessons from past similar work — do not repeat:\" prefix injection).