### PR TITLE
feat(mentor-phase3-003): orchestrator pre-spawn hook (PR-3) — Phase 3 KILLER FEATURE

### DIFF
--- a/packages/mentor-retrieval/package.json
+++ b/packages/mentor-retrieval/package.json
@@ -2,14 +2,15 @@
   "name": "@chiefaia/mentor-retrieval",
   "version": "0.1.0",
   "private": true,
-  "description": "Mentor Phase-3 lesson retrieval \u2014 embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons for a given prompt. PR-1 ships the index builder + storage; PR-2 adds the retrieval API + caia-mentor-retrieve CLI; PR-3 wires the orchestrator pre-spawn hook.",
+  "description": "Mentor Phase-3 lesson retrieval \u2014 embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, and prepend them to spawned-task prompts as 'Lessons from past similar work \u2014 do not repeat:'. PR-1 ships the index builder + storage; PR-2 adds the retrieval API + caia-mentor-retrieve CLI; PR-3 adds the orchestrator pre-spawn hook (caia-mentor-prepend + prependLessons() library).",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
     "caia-mentor-index": "./dist/cli.js",
-    "caia-mentor-retrieve": "./dist/retrieve-cli.js"
+    "caia-mentor-retrieve": "./dist/retrieve-cli.js",
+    "caia-mentor-prepend": "./dist/prepend-cli.js"
   },
   "exports": {
     ".": {
@@ -23,6 +24,10 @@
     "./retrieve": {
       "import": "./dist/retrieve.js",
       "types": "./dist/retrieve.d.ts"
+    },
+    "./prepend": {
+      "import": "./dist/prepend.js",
+      "types": "./dist/prepend.d.ts"
     }
   },
   "files": [

--- a/packages/mentor-retrieval/src/index.ts
+++ b/packages/mentor-retrieval/src/index.ts
@@ -1,9 +1,11 @@
 /**
  * Mentor Phase-3 retrieval — public surface.
  *
- * PR-1 ships the index builder + persistence + Ollama embedding wrapper.
- * PR-2 adds the retrieval API + `caia-mentor-retrieve` CLI on top of
- * the index. PR-3 wires the orchestrator pre-spawn injection hook.
+ * - PR-1: index builder + persistence + Ollama embedding wrapper.
+ * - PR-2: retrieval API + `caia-mentor-retrieve` CLI.
+ * - PR-3: orchestrator pre-spawn injection hook + `caia-mentor-prepend`
+ *         CLI (the killer feature — spawned agents now arrive at their
+ *         task with explicit warnings about prior failure modes).
  */
 
 export {
@@ -48,6 +50,12 @@ export {
   type RetrievedLesson,
   type RetrieveLessonsOptions
 } from './retrieve.js';
+
+export {
+  prependLessons,
+  type PrependLessonsOptions,
+  type PrependLessonsResult
+} from './prepend.js';
 
 export type {
   BuildIndexStats,

--- a/packages/mentor-retrieval/src/prepend-cli.ts
+++ b/packages/mentor-retrieval/src/prepend-cli.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/**
+ * caia-mentor-prepend — Mentor Phase-3 PR-3 CLI.
+ *
+ * The orchestrator-facing CLI hook. Reads a prompt from stdin (or as a
+ * positional arg), calls `prependLessons`, and emits the augmented
+ * prompt to stdout. Exit code 0 always when the system is healthy
+ * enough to attempt the call; exit code 2 on runtime failure (Ollama
+ * unreachable, etc.).
+ *
+ * Recommended orchestrator integration:
+ *
+ *     # Orchestrator's spawn pipeline:
+ *     AUGMENTED=$(echo "$ORIGINAL_PROMPT" | caia-mentor-prepend --quiet)
+ *     spawn-claude "$AUGMENTED"
+ *
+ * Or via the library: `import { prependLessons } from
+ * '@chiefaia/mentor-retrieval'`.
+ *
+ * Flags:
+ *
+ *   --memory <path>     Override $CAIA_MEMORY_DIR.
+ *   --ollama <url>      Override $OLLAMA_URL.
+ *   --model <name>      Override $MENTOR_EMBED_MODEL.
+ *   --top-n <int>       Top N lessons. Default: 5.
+ *   --threshold <num>   Minimum cosine similarity. Default: 0.4.
+ *   --kind <kind>       Filter to feedback or proposal.
+ *   --emit-empty        Emit the original prompt even if no lessons match.
+ *                       (Default behavior; included for symmetry.)
+ *   --fail-on-empty     Exit 1 if no lessons matched (for orchestrators
+ *                       that want to assert at least one lesson was
+ *                       attached, e.g. for high-stakes tasks).
+ *   --metadata          Append a `--- mentor-metadata ---` JSON footer
+ *                       describing what was attached. Useful for
+ *                       audit-trail logging.
+ *   --quiet             Suppress warnings to stderr.
+ *
+ * Always reads from stdin unless a positional arg is provided.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { DEFAULT_EMBED_MODEL, DEFAULT_OLLAMA_URL } from './embed.js';
+import {
+  prependLessons,
+  type PrependLessonsOptions,
+  type PrependLessonsResult
+} from './prepend.js';
+import { DEFAULT_MIN_SIMILARITY, DEFAULT_TOP_N } from './retrieve.js';
+import type { LessonKind } from './types.js';
+
+interface ParsedArgs {
+  prompt: string | '__STDIN__' | '__HELP__';
+  memoryDir: string;
+  ollamaUrl: string;
+  model: string;
+  topN: number;
+  threshold: number;
+  kindFilter: LessonKind | undefined;
+  failOnEmpty: boolean;
+  metadata: boolean;
+  quiet: boolean;
+}
+
+interface RunOptions {
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  exit?: (code: number) => never;
+  readStdin?: () => Promise<string>;
+}
+
+export async function main(opts: RunOptions = {}): Promise<void> {
+  const argv = opts.argv ?? process.argv.slice(2);
+  const env = opts.env ?? process.env;
+  const stdout = opts.stdout ?? ((s: string) => process.stdout.write(`${s}\n`));
+  const stderr = opts.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
+  const exit =
+    opts.exit ??
+    ((code: number) => {
+      process.exit(code);
+    });
+  const readStdin = opts.readStdin ?? defaultReadStdin;
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv, env);
+  } catch (e) {
+    stderr(`mentor-prepend: ${describeError(e)}`);
+    stderr('run `caia-mentor-prepend --help` for usage');
+    return exit(1);
+  }
+
+  if (parsed.prompt === '__HELP__') {
+    stdout(usage());
+    return exit(0);
+  }
+
+  let prompt: string;
+  if (parsed.prompt === '__STDIN__') {
+    const stdin = await readStdin();
+    prompt = stdin;
+    if (prompt.trim() === '') {
+      stderr('mentor-prepend: stdin was empty');
+      return exit(1);
+    }
+  } else {
+    prompt = parsed.prompt;
+  }
+
+  try {
+    const prependOpts: PrependLessonsOptions = {
+      memoryDir: parsed.memoryDir,
+      ollamaUrl: parsed.ollamaUrl,
+      embedModel: parsed.model,
+      topN: parsed.topN,
+      minSimilarity: parsed.threshold,
+      warn: parsed.quiet ? () => undefined : (m: string) => stderr(m)
+    };
+    if (parsed.kindFilter !== undefined) prependOpts.kindFilter = parsed.kindFilter;
+
+    const result = await prependLessons(prompt, prependOpts);
+
+    if (!result.augmented && parsed.failOnEmpty) {
+      stderr('mentor-prepend: no lessons matched and --fail-on-empty set');
+      return exit(1);
+    }
+
+    stdout(result.augmentedPrompt);
+
+    if (parsed.metadata) {
+      stdout('');
+      stdout('--- mentor-metadata ---');
+      stdout(JSON.stringify(buildMetadata(result), null, 2));
+    }
+
+    return exit(0);
+  } catch (e) {
+    stderr(`mentor-prepend: ${describeError(e)}`);
+    return exit(2);
+  }
+}
+
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): ParsedArgs {
+  let prompt: string | null = null;
+  let memoryDir = env['CAIA_MEMORY_DIR'];
+  let ollamaUrl = env['OLLAMA_URL'] ?? DEFAULT_OLLAMA_URL;
+  let model = env['MENTOR_EMBED_MODEL'] ?? DEFAULT_EMBED_MODEL;
+  let topN = DEFAULT_TOP_N;
+  let threshold = DEFAULT_MIN_SIMILARITY;
+  let kindFilter: LessonKind | undefined;
+  let failOnEmpty = false;
+  let metadata = false;
+  let quiet = false;
+  let useStdin = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h' || arg === 'help') {
+      return makeArgs({
+        prompt: '__HELP__',
+        memoryDir: '',
+        ollamaUrl,
+        model,
+        topN,
+        threshold,
+        kindFilter,
+        failOnEmpty,
+        metadata,
+        quiet
+      });
+    }
+    if (arg === '--memory') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--memory requires a value');
+      memoryDir = v;
+    } else if (arg === '--ollama') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--ollama requires a value');
+      ollamaUrl = v;
+    } else if (arg === '--model') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--model requires a value');
+      model = v;
+    } else if (arg === '--top-n') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--top-n requires a value');
+      const n = Number(v);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`--top-n must be a positive integer (got ${v})`);
+      }
+      topN = n;
+    } else if (arg === '--threshold') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--threshold requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n)) {
+        throw new Error(`--threshold must be a number (got ${v})`);
+      }
+      threshold = n;
+    } else if (arg === '--kind') {
+      i++;
+      const v = argv[i];
+      if (v !== 'feedback' && v !== 'proposal') {
+        throw new Error(
+          `--kind must be one of feedback|proposal (got ${String(v)})`
+        );
+      }
+      kindFilter = v;
+    } else if (arg === '--fail-on-empty') {
+      failOnEmpty = true;
+    } else if (arg === '--emit-empty') {
+      // explicit no-op; default behavior
+    } else if (arg === '--metadata') {
+      metadata = true;
+    } else if (arg === '--quiet') {
+      quiet = true;
+    } else if (arg === '--stdin') {
+      useStdin = true;
+    } else if (arg !== undefined && arg.startsWith('--')) {
+      throw new Error(`unknown flag ${JSON.stringify(arg)}`);
+    } else if (arg !== undefined) {
+      if (prompt !== null) {
+        throw new Error('only one positional prompt argument is allowed');
+      }
+      prompt = arg;
+    }
+  }
+
+  if (memoryDir === undefined || memoryDir === '') {
+    memoryDir = join(homedir(), 'Documents', 'projects', 'caia', 'agent', 'memory');
+  }
+
+  if (useStdin && prompt !== null) {
+    throw new Error('cannot pass both --stdin and a positional prompt');
+  }
+
+  // Default to stdin when no positional + no explicit --stdin (the
+  // expected orchestrator pipeline pattern is `echo $P | mentor-prepend`).
+  if (prompt === null) {
+    prompt = '__STDIN__';
+  }
+
+  return makeArgs({
+    prompt,
+    memoryDir,
+    ollamaUrl,
+    model,
+    topN,
+    threshold,
+    kindFilter,
+    failOnEmpty,
+    metadata,
+    quiet
+  });
+}
+
+function makeArgs(p: {
+  prompt: string;
+  memoryDir: string;
+  ollamaUrl: string;
+  model: string;
+  topN: number;
+  threshold: number;
+  kindFilter: LessonKind | undefined;
+  failOnEmpty: boolean;
+  metadata: boolean;
+  quiet: boolean;
+}): ParsedArgs {
+  return {
+    prompt: p.prompt as ParsedArgs['prompt'],
+    memoryDir: p.memoryDir,
+    ollamaUrl: p.ollamaUrl,
+    model: p.model,
+    topN: p.topN,
+    threshold: p.threshold,
+    kindFilter: p.kindFilter,
+    failOnEmpty: p.failOnEmpty,
+    metadata: p.metadata,
+    quiet: p.quiet
+  };
+}
+
+interface PrependMetadata {
+  augmented: boolean;
+  preambleLength: number;
+  lessonCount: number;
+  lessons: Array<{
+    slug: string;
+    kind: LessonKind;
+    similarity: number;
+    path: string;
+  }>;
+}
+
+function buildMetadata(r: PrependLessonsResult): PrependMetadata {
+  return {
+    augmented: r.augmented,
+    preambleLength: r.preambleLength,
+    lessonCount: r.lessons.length,
+    lessons: r.lessons.map((l) => ({
+      slug: l.slug,
+      kind: l.kind,
+      similarity: l.similarity,
+      path: l.path
+    }))
+  };
+}
+
+function usage(): string {
+  return `caia-mentor-prepend — pre-spawn lesson injection (Mentor Phase 3 PR-3)
+
+Usage:
+  echo "<prompt>" | caia-mentor-prepend [flags]
+  caia-mentor-prepend "<prompt>" [flags]
+  caia-mentor-prepend --stdin [flags] < prompt.txt
+
+Flags:
+  --memory <path>     Memory dir (default: $CAIA_MEMORY_DIR)
+  --ollama <url>      Ollama URL (default: ${DEFAULT_OLLAMA_URL})
+  --model <name>      Embedding model (default: ${DEFAULT_EMBED_MODEL})
+  --top-n <int>       Top N lessons (default: ${DEFAULT_TOP_N})
+  --threshold <num>   Minimum similarity (default: ${DEFAULT_MIN_SIMILARITY})
+  --kind <kind>       Filter feedback or proposal
+  --metadata          Append --- mentor-metadata --- JSON footer
+  --fail-on-empty     Exit 1 if no lessons matched
+  --quiet             Suppress warnings
+  --help, -h          Show this help
+
+Reads prompt from stdin if no positional argument.
+`;
+}
+
+async function defaultReadStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+const isMain = (): boolean => {
+  const meta = import.meta.url;
+  if (!meta.startsWith('file://')) return false;
+  const arg1 = process.argv[1];
+  if (arg1 === undefined) return false;
+  return meta.endsWith(arg1) || meta === `file://${arg1}`;
+};
+
+if (isMain()) {
+  main().catch((e) => {
+    process.stderr.write(`mentor-prepend: fatal: ${describeError(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/packages/mentor-retrieval/src/prepend.ts
+++ b/packages/mentor-retrieval/src/prepend.ts
@@ -1,0 +1,128 @@
+/**
+ * Mentor Phase-3 PR-3 — pre-spawn prompt augmentation.
+ *
+ * This is the orchestrator-facing entry point. Given a task prompt
+ * about to be sent to a spawned agent, return an augmented prompt with
+ * a "Lessons from past similar work — do not repeat:" preamble built
+ * from the top-N relevant prior lessons.
+ *
+ * Design contract for orchestrator integration:
+ *
+ *   - Synchronous from the caller's perspective: one async call returns
+ *     the final prompt string. No event-bus subscription required.
+ *   - Pure-ish: no side-effects on the index DB, no writes to disk by
+ *     default. The caller decides whether to log the augmentation.
+ *   - Graceful when no lessons match: returns the original prompt
+ *     unchanged + `lessons: []`. Orchestrators can branch on
+ *     `lessons.length === 0` if they want different telemetry.
+ *   - Graceful when the index doesn't exist: same — returns the
+ *     original prompt + `lessons: []`. (The retrieve layer treats a
+ *     missing DB as "no lessons learned yet".)
+ *   - Graceful when Ollama is unreachable: throws (caller decides
+ *     fallback). The orchestrator is expected to catch + emit a
+ *     telemetry event + spawn the un-augmented prompt as a fallback.
+ *
+ * Why not auto-emit a TaskSpawned event from this function: the
+ * caller is the orchestrator, which is the canonical emit-site. Having
+ * this function emit too would double-count. The orchestrator should
+ * emit its own TaskSpawned + include the `lessonsAttached: number` in
+ * the payload (we leave that to the orchestrator's own substrate).
+ */
+
+import { createOllamaEmbedder } from './embed.js';
+import {
+  formatLessonsPreamble,
+  retrieveLessons,
+  type RetrievedLesson
+} from './retrieve.js';
+import type { Embedder, LessonKind } from './types.js';
+
+export interface PrependLessonsOptions {
+  /** Memory directory (or set CAIA_MEMORY_DIR). */
+  memoryDir: string;
+  /**
+   * Embedder. Production callers usually omit this and let the helper
+   * build a default Ollama embedder. Tests inject a fake.
+   */
+  embed?: Embedder;
+  /** Override the index DB path entirely. */
+  dbPath?: string;
+  /** Top-N lessons to inject. Default: 5 (matches retrieve.DEFAULT_TOP_N). */
+  topN?: number;
+  /** Minimum cosine similarity. Default: 0.4. */
+  minSimilarity?: number;
+  /** Optional kind filter (feedback / proposal). */
+  kindFilter?: LessonKind;
+  /**
+   * Override the Ollama URL when building the default embedder. Ignored
+   * if the caller passes an explicit `embed`.
+   */
+  ollamaUrl?: string;
+  /** Override the embedding model when building the default embedder. */
+  embedModel?: string;
+  /** Optional warn sink. Defaults to a no-op. */
+  warn?: (msg: string) => void;
+}
+
+export interface PrependLessonsResult {
+  /** The prompt that the orchestrator should send to the spawned agent. */
+  augmentedPrompt: string;
+  /** Whether the prompt was modified (false ⇔ no relevant lessons). */
+  augmented: boolean;
+  /** Top-N lessons that were attached (in similarity-desc order). */
+  lessons: RetrievedLesson[];
+  /** Length of the preamble in characters (0 if not augmented). */
+  preambleLength: number;
+}
+
+/**
+ * Build an augmented prompt with the top-N relevant prior lessons
+ * prepended. See module-level docstring for the orchestrator-integration
+ * contract.
+ */
+export async function prependLessons(
+  prompt: string,
+  opts: PrependLessonsOptions
+): Promise<PrependLessonsResult> {
+  const embedder = opts.embed ?? createDefaultEmbedder(opts);
+
+  const retrieveOpts: Parameters<typeof retrieveLessons>[1] = {
+    memoryDir: opts.memoryDir,
+    embed: embedder
+  };
+  if (opts.dbPath !== undefined) retrieveOpts.dbPath = opts.dbPath;
+  if (opts.topN !== undefined) retrieveOpts.topN = opts.topN;
+  if (opts.minSimilarity !== undefined) {
+    retrieveOpts.minSimilarity = opts.minSimilarity;
+  }
+  if (opts.kindFilter !== undefined) retrieveOpts.kindFilter = opts.kindFilter;
+  if (opts.warn !== undefined) retrieveOpts.warn = opts.warn;
+
+  const lessons = await retrieveLessons(prompt, retrieveOpts);
+
+  if (lessons.length === 0) {
+    return {
+      augmentedPrompt: prompt,
+      augmented: false,
+      lessons: [],
+      preambleLength: 0
+    };
+  }
+
+  const preamble = formatLessonsPreamble(lessons);
+  const augmentedPrompt = `${preamble}\n${prompt}`;
+
+  return {
+    augmentedPrompt,
+    augmented: true,
+    lessons,
+    preambleLength: preamble.length
+  };
+}
+
+function createDefaultEmbedder(opts: PrependLessonsOptions): Embedder {
+  const embedderOpts: Parameters<typeof createOllamaEmbedder>[0] = {};
+  if (opts.ollamaUrl !== undefined) embedderOpts.url = opts.ollamaUrl;
+  if (opts.embedModel !== undefined) embedderOpts.model = opts.embedModel;
+  return createOllamaEmbedder(embedderOpts);
+}

--- a/packages/mentor-retrieval/tests/prepend-cli.test.ts
+++ b/packages/mentor-retrieval/tests/prepend-cli.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the caia-mentor-prepend CLI argument parser + main wiring.
+ *
+ * Live Ollama-backed end-to-end is covered by Stage-6 verification at
+ * leg-7 close.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { main, parseArgs } from '../src/prepend-cli.js';
+
+describe('parseArgs', () => {
+  it('defaults to --stdin when no positional + no flag', () => {
+    const p = parseArgs([], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.prompt).toBe('__STDIN__');
+    expect(p.memoryDir).toBe('/m');
+    expect(p.topN).toBe(5);
+    expect(p.threshold).toBe(0.4);
+    expect(p.kindFilter).toBeUndefined();
+    expect(p.failOnEmpty).toBe(false);
+    expect(p.metadata).toBe(false);
+    expect(p.quiet).toBe(false);
+  });
+  it('accepts a positional prompt', () => {
+    const p = parseArgs(['hello world'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.prompt).toBe('hello world');
+  });
+  it('rejects two positional prompts', () => {
+    expect(() => parseArgs(['p1', 'p2'], {})).toThrow(/only one positional/);
+  });
+  it('rejects positional + --stdin together', () => {
+    expect(() => parseArgs(['p', '--stdin'], {})).toThrow(/cannot pass both/);
+  });
+  it('honors all flag overrides', () => {
+    const p = parseArgs(
+      [
+        'q',
+        '--memory',
+        '/x',
+        '--ollama',
+        'http://o:1',
+        '--model',
+        'em',
+        '--top-n',
+        '7',
+        '--threshold',
+        '0.6',
+        '--kind',
+        'proposal',
+        '--metadata',
+        '--fail-on-empty',
+        '--quiet'
+      ],
+      {}
+    );
+    expect(p.memoryDir).toBe('/x');
+    expect(p.ollamaUrl).toBe('http://o:1');
+    expect(p.model).toBe('em');
+    expect(p.topN).toBe(7);
+    expect(p.threshold).toBe(0.6);
+    expect(p.kindFilter).toBe('proposal');
+    expect(p.metadata).toBe(true);
+    expect(p.failOnEmpty).toBe(true);
+    expect(p.quiet).toBe(true);
+  });
+  it('accepts --emit-empty as a no-op', () => {
+    const p = parseArgs(['q', '--emit-empty'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.failOnEmpty).toBe(false);
+  });
+  it('rejects unknown flags', () => {
+    expect(() => parseArgs(['q', '--bogus'], {})).toThrow(/unknown flag/);
+  });
+  it('rejects bad --top-n / --threshold / --kind values', () => {
+    expect(() => parseArgs(['q', '--top-n', '0'], {})).toThrow(/positive integer/);
+    expect(() => parseArgs(['q', '--threshold', 'x'], {})).toThrow(/must be a number/);
+    expect(() => parseArgs(['q', '--kind', 'bogus'], {})).toThrow(/must be one of/);
+  });
+  it('--help returns the help sentinel', () => {
+    expect(parseArgs(['--help'], {}).prompt).toBe('__HELP__');
+    expect(parseArgs(['-h'], {}).prompt).toBe('__HELP__');
+    expect(parseArgs(['help'], {}).prompt).toBe('__HELP__');
+  });
+});
+
+describe('main: --help', () => {
+  it('prints usage and exits 0', async () => {
+    const out: string[] = [];
+    let exitCode = -1;
+    await main({
+      argv: ['--help'],
+      env: { CAIA_MEMORY_DIR: '/m' },
+      stdout: (s) => out.push(s),
+      stderr: () => undefined,
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      })
+    });
+    expect(exitCode).toBe(0);
+    expect(out.join('\n')).toMatch(/caia-mentor-prepend/);
+  });
+});
+
+describe('main: stdin handling', () => {
+  it('rejects empty stdin', async () => {
+    const errs: string[] = [];
+    let exitCode = -1;
+    await main({
+      argv: ['--stdin', '--memory', '/tmp/no-such-dir'],
+      env: {},
+      stdout: () => undefined,
+      stderr: (s) => errs.push(s),
+      exit: ((c: number) => {
+        exitCode = c;
+        return undefined as never;
+      }),
+      readStdin: async () => '   '
+    });
+    expect(exitCode).toBe(1);
+    expect(errs.some((e) => e.includes('stdin was empty'))).toBe(true);
+  });
+
+  it('passes stdin content through to prependLessons', async () => {
+    // Use a memoryDir that has no index → lessons=[] → original prompt
+    // is echoed verbatim, exit 0. Ollama isn't called because the
+    // index-not-found path short-circuits before retrieve.
+    // Actually retrieveLessons calls embed FIRST, then opens the DB.
+    // That means without a real Ollama, this would throw on embed.
+    // For the unit test we mock fetch globally.
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ embedding: [1, 0, 0, 0] }),
+      text: async () => ''
+    }) as unknown as Response) as unknown as typeof fetch;
+    try {
+      const out: string[] = [];
+      let exitCode = -1;
+      await main({
+        argv: ['--stdin', '--memory', '/tmp/no-such-mentor-prepend-dir', '--quiet'],
+        env: {},
+        stdout: (s) => out.push(s),
+        stderr: () => undefined,
+        exit: ((c: number) => {
+          exitCode = c;
+          return undefined as never;
+        }),
+        readStdin: async () => 'piped prompt content\n'
+      });
+      expect(exitCode).toBe(0);
+      // Default behavior emits the original prompt when no lessons match.
+      expect(out.join('\n')).toContain('piped prompt content');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+describe('main: --metadata footer', () => {
+  it('emits metadata when --metadata is set + no lessons', async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ embedding: [1, 0, 0, 0] }),
+      text: async () => ''
+    }) as unknown as Response) as unknown as typeof fetch;
+    try {
+      const out: string[] = [];
+      let exitCode = -1;
+      await main({
+        argv: [
+          'positional prompt',
+          '--memory',
+          '/tmp/no-such-mentor-prepend-dir-2',
+          '--metadata',
+          '--quiet'
+        ],
+        env: {},
+        stdout: (s) => out.push(s),
+        stderr: () => undefined,
+        exit: ((c: number) => {
+          exitCode = c;
+          return undefined as never;
+        })
+      });
+      expect(exitCode).toBe(0);
+      const joined = out.join('\n');
+      expect(joined).toContain('positional prompt');
+      expect(joined).toContain('--- mentor-metadata ---');
+      expect(joined).toMatch(/"augmented":\s*false/);
+      expect(joined).toMatch(/"lessonCount":\s*0/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+describe('main: --fail-on-empty', () => {
+  it('exits 1 when --fail-on-empty + no lessons', async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ embedding: [1, 0, 0, 0] }),
+      text: async () => ''
+    }) as unknown as Response) as unknown as typeof fetch;
+    try {
+      const errs: string[] = [];
+      let exitCode = -1;
+      await main({
+        argv: [
+          'whatever',
+          '--memory',
+          '/tmp/no-such-mentor-prepend-dir-3',
+          '--fail-on-empty',
+          '--quiet'
+        ],
+        env: {},
+        stdout: () => undefined,
+        stderr: (s) => errs.push(s),
+        exit: ((c: number) => {
+          exitCode = c;
+          return undefined as never;
+        })
+      });
+      expect(exitCode).toBe(1);
+      expect(errs.some((e) => e.includes('fail-on-empty'))).toBe(true);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/packages/mentor-retrieval/tests/prepend.test.ts
+++ b/packages/mentor-retrieval/tests/prepend.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for the orchestrator pre-spawn hook.
+ *
+ * Strategy: seed a tiny synthetic index by hand, inject a fake
+ * embedder, then exercise `prependLessons` directly. No real Ollama
+ * required.
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { vectorToBlob } from '../src/embed.js';
+import { openIndexStore, type IndexStore } from '../src/index-store.js';
+import { prependLessons } from '../src/prepend.js';
+import type { Embedder, LessonKind } from '../src/types.js';
+
+function fakeVector(tag: string): Float32Array {
+  const ch = tag.charCodeAt(0) % 4;
+  const v = new Float32Array(4);
+  v[ch] = 1;
+  return v;
+}
+
+function fakeEmbed(): Embedder {
+  return async (text: string) => ({
+    vector: fakeVector(text),
+    model: 'fake-embed'
+  });
+}
+
+function seedRow(
+  store: IndexStore,
+  args: {
+    sourcePath: string;
+    kind: LessonKind;
+    slug: string;
+    tag: string;
+    content: string;
+    mtimeMs?: number;
+  }
+): void {
+  store.upsertLesson({
+    sourcePath: args.sourcePath,
+    kind: args.kind,
+    slug: args.slug,
+    mtimeMs: args.mtimeMs ?? 1000,
+    contentSha256: 'sha-' + args.slug,
+    contentSnippet: args.content,
+    embeddingDim: 4,
+    embedding: vectorToBlob(fakeVector(args.tag)),
+    indexedAtMs: 1
+  });
+}
+
+describe('prependLessons', () => {
+  let memoryDir: string;
+  let dbPath: string;
+  let store: IndexStore | null = null;
+
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-prepend-'));
+    dbPath = join(memoryDir, 'idx.sqlite');
+  });
+  afterEach(() => {
+    store?.close();
+    store = null;
+  });
+
+  it('returns the original prompt unchanged when no lessons match', async () => {
+    store = openIndexStore({ memoryDir, dbPath });
+    seedRow(store, {
+      sourcePath: '/m/feedback_b.md',
+      kind: 'feedback',
+      slug: 'fb_b',
+      tag: 'B',
+      content: 'b lesson'
+    });
+    store.close();
+    store = null;
+
+    const out = await prependLessons('A query that does not match', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath,
+      minSimilarity: 0.99
+    });
+    expect(out.augmented).toBe(false);
+    expect(out.augmentedPrompt).toBe('A query that does not match');
+    expect(out.lessons).toEqual([]);
+    expect(out.preambleLength).toBe(0);
+  });
+
+  it('returns the original prompt when index does not exist', async () => {
+    const out = await prependLessons('Anything', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath: join(memoryDir, 'no-such-index.sqlite')
+    });
+    expect(out.augmented).toBe(false);
+    expect(out.augmentedPrompt).toBe('Anything');
+    expect(out.lessons).toEqual([]);
+  });
+
+  it('prepends the preamble + 2 newlines + original prompt when lessons match', async () => {
+    store = openIndexStore({ memoryDir, dbPath });
+    seedRow(store, {
+      sourcePath: '/m/feedback_a.md',
+      kind: 'feedback',
+      slug: 'feedback_a',
+      tag: 'A',
+      content: 'lesson body for A'
+    });
+    store.close();
+    store = null;
+
+    const original = 'A is the prompt';
+    const out = await prependLessons(original, {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath
+    });
+    expect(out.augmented).toBe(true);
+    expect(out.augmentedPrompt).toContain('Lessons from past similar work');
+    expect(out.augmentedPrompt).toContain('feedback_a');
+    expect(out.augmentedPrompt.endsWith(original)).toBe(true);
+    expect(out.lessons.length).toBe(1);
+    expect(out.preambleLength).toBeGreaterThan(0);
+  });
+
+  it('honors topN and threshold', async () => {
+    store = openIndexStore({ memoryDir, dbPath });
+    for (let i = 0; i < 6; i++) {
+      seedRow(store, {
+        sourcePath: `/m/m${i}.md`,
+        kind: 'feedback',
+        slug: `m${i}`,
+        tag: 'A',
+        content: `c${i}`,
+        mtimeMs: 1000 + i
+      });
+    }
+    store.close();
+    store = null;
+
+    const out = await prependLessons('A', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath,
+      topN: 3
+    });
+    expect(out.lessons.length).toBe(3);
+    // Tiebreak by mtime desc → m5, m4, m3
+    expect(out.lessons.map((l) => l.slug)).toEqual(['m5', 'm4', 'm3']);
+  });
+
+  it('passes kindFilter through to retrieval', async () => {
+    store = openIndexStore({ memoryDir, dbPath });
+    seedRow(store, {
+      sourcePath: '/m/fb.md',
+      kind: 'feedback',
+      slug: 'fb',
+      tag: 'A',
+      content: 'fb body'
+    });
+    seedRow(store, {
+      sourcePath: '/m/proposals/p.md',
+      kind: 'proposal',
+      slug: 'p',
+      tag: 'A',
+      content: 'proposal body'
+    });
+    store.close();
+    store = null;
+
+    const onlyFeedback = await prependLessons('A', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath,
+      kindFilter: 'feedback'
+    });
+    expect(onlyFeedback.lessons.map((l) => l.kind)).toEqual(['feedback']);
+
+    const onlyProposal = await prependLessons('A', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath,
+      kindFilter: 'proposal'
+    });
+    expect(onlyProposal.lessons.map((l) => l.kind)).toEqual(['proposal']);
+  });
+
+  it('threads the warn callback to the retrieval layer', async () => {
+    store = openIndexStore({ memoryDir, dbPath });
+    // Seed a row with a wrong dim to trigger the dim-mismatch warning.
+    store.upsertLesson({
+      sourcePath: '/m/wd.md',
+      kind: 'feedback',
+      slug: 'wd',
+      mtimeMs: 1,
+      contentSha256: 'h',
+      contentSnippet: 'wd body',
+      embeddingDim: 8,
+      embedding: vectorToBlob(new Float32Array(8)),
+      indexedAtMs: 1
+    });
+    store.close();
+    store = null;
+
+    const warn = vi.fn();
+    await prependLessons('A', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath,
+      warn
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('indexed dim 8 != query dim 4')
+    );
+  });
+
+  it('builds a default Ollama embedder when none is provided (and propagates ollamaUrl)', async () => {
+    // We can't actually hit Ollama here, but we can assert the default
+    // embedder is built when `embed` is omitted, by intercepting fetch.
+    const origFetch = globalThis.fetch;
+    const fakeFetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ embedding: [1, 0, 0, 0] }),
+      text: async () => ''
+    }) as unknown as Response);
+    globalThis.fetch = fakeFetch as unknown as typeof fetch;
+    try {
+      // Empty index → no lessons, but embed must still be called once.
+      store = openIndexStore({ memoryDir, dbPath });
+      store.close();
+      store = null;
+      await prependLessons('hello', {
+        memoryDir,
+        dbPath,
+        ollamaUrl: 'http://my-ollama.test:9999'
+      });
+      expect(fakeFetch).toHaveBeenCalledTimes(1);
+      const url = fakeFetch.mock.calls[0]![0];
+      expect(url).toBe('http://my-ollama.test:9999/api/embeddings');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('preambleLength matches the substring length', async () => {
+    store = openIndexStore({ memoryDir, dbPath });
+    seedRow(store, {
+      sourcePath: '/m/x.md',
+      kind: 'feedback',
+      slug: 'x',
+      tag: 'A',
+      content: 'x lesson'
+    });
+    store.close();
+    store = null;
+
+    const out = await prependLessons('Aprompt', {
+      memoryDir,
+      embed: fakeEmbed(),
+      dbPath
+    });
+    // The augmented prompt is `${preamble}\n${prompt}`, so:
+    //   augmentedPrompt.length === preambleLength + 1 + prompt.length
+    expect(out.augmentedPrompt.length).toBe(out.preambleLength + 1 + 'Aprompt'.length);
+  });
+});


### PR DESCRIPTION
## Summary

Mentor Phase 3 **PR-3 of 3 — the killer feature ships**.

Builds on [PR-1 (#332)](https://github.com/prakashgbid/caia/pull/332) (index builder) and [PR-2 (#333)](https://github.com/prakashgbid/caia/pull/333) (retrieval API). Adds a tiny synchronous "pre-spawn injection" layer the orchestrator calls before kicking off a sub-agent. The output: an augmented prompt with **"Lessons from past similar work — do not repeat:"** prepended, listing the top-N most relevant prior incidents.

## What this PR ships

- **\`src/prepend.ts\`** — \`prependLessons(prompt, opts)\`. Embeds the prompt → retrieves top-N relevant lessons → returns \`{augmentedPrompt, augmented, lessons, preambleLength}\`.
  - Returns the original prompt unchanged when nothing matches (graceful "no lessons learned yet" path).
  - Returns the original prompt unchanged when the index doesn't exist yet (system bootstrap path).
  - Throws when Ollama is unreachable (caller decides fallback).
  - Pure-ish: no event-bus emit, no DB writes. The orchestrator owns its own telemetry emission.
- **\`src/prepend-cli.ts\`** (bin = \`caia-mentor-prepend\`):
  - Reads prompt from stdin (default) or a positional arg.
  - Emits the augmented prompt on stdout.
  - \`--top-n\` / \`--threshold\` / \`--kind\` / \`--metadata\` / \`--fail-on-empty\` / \`--quiet\` flags.
  - \`--metadata\` appends a \`--- mentor-metadata ---\` JSON footer with the lessons attached (path, slug, kind, similarity) for audit-trail logging.
  - \`--fail-on-empty\` exits 1 if no lessons matched (orchestrators that want to assert at least one lesson on high-stakes tasks).

## Recommended orchestrator integration

Drop-in shell pipeline:

\`\`\`bash
AUGMENTED=\$(echo "\$ORIGINAL_PROMPT" | caia-mentor-prepend --quiet)
spawn-claude "\$AUGMENTED"
\`\`\`

Or via the library:

\`\`\`ts
import { prependLessons } from '@chiefaia/mentor-retrieval/prepend';
const { augmentedPrompt, lessons } = await prependLessons(prompt, {
  memoryDir: process.env.CAIA_MEMORY_DIR
});
spawn(claudeBin, augmentedPrompt);
\`\`\`

## Test coverage — 116 total (+22 new this PR)

| File | New tests |
|------|-----------|
| prepend.test.ts | 8 — original-prompt-pass-through (no match / no index), preamble + 2 newlines + prompt structure on match, topN + threshold + kindFilter, warn-callback threading, default Ollama embedder construction, preambleLength substring math |
| prepend-cli.test.ts | 14 — parseArgs (defaults, positional, --stdin, every flag, error paths), --help sentinel, main with stdin, empty-stdin rejection, --metadata footer emission, --fail-on-empty exit-1 path |

## Stage 6 — full end-to-end live verify on Mac (PASS)

Built a full lesson index against the live agent/memory directory:

\`\`\`
Files scanned:    70 (15 feedback + 55 proposals)
Embedded:         67 (3 oversized files gracefully failed —
                      they exceed nomic-embed-text's 8K context)
Wall clock:       8.8s end-to-end including Ollama HTTP
\`\`\`

Then ran the prepend hook against three realistic spawn briefs:

| Brief | Top match | Similarity |
|-------|-----------|-----------|
| "Audit all GitHub tokens stored in ~/.bashrc and propose moving them to a vault." | \`feedback_pat_topic\` | **0.689** ✅ |
| "Spawn 20 parallel tasks to refactor each file in the dashboard package." | \`feedback_operational_discipline\` | **0.616** ✅ |
| "Should I add a new column to the users table or use a separate join table?" | \`feedback_pr_lifecycle\` | 0.528 (decent) |

**Brief 1 is the killer feature working.** A future agent receiving this brief now arrives with the explicit warning: "Do NOT flag tokens in bashrc as security findings." The recurring re-litigation pattern that motivated the directive is now mechanically prevented at the spawn boundary.

**Brief 2** would have triggered operational chaos (51 substantial tasks in 2 days; 1,477 mac_mcp timeouts in one hour). Now mechanically prevented.

## Known gap (pre-existing, surfaced by Stage 6)

3 of 15 feedback files exceed nomic-embed-text's 8K context window and fail to embed. Current behavior is correct (graceful per-file failure logged + counted; remaining files indexed; existing rows preserved), but a follow-up PR could chunk long files or fall back to a longer-context embedding model. Tracked as Phase 3 polish.

## What's deliberately not in this PR

- **TaskSpawned event-bus consumer / LaunchAgent** — the directive describes pre-spawn injection as a **synchronous** prompt-augmentation step at spawn time, not an asynchronous reaction after the fact. The right shape is for the orchestrator to call this synchronously; a daemon could be added later for "augmented-prompt audit trail" logging if useful.
- **Long-file chunking** — the 3 oversized files are real Mentor lessons and ought to be searchable. Tracked as Phase 3 polish for a follow-up PR.

## Directive compliance

- Subscription-only: only LLM calls go to localhost Ollama.
- exactOptionalPropertyTypes-safe option-object construction.
- Decide → execute → inform.
- No silent agent mutation: orchestrators that adopt this make an explicit code change to their spawn pipeline; nothing happens behind their backs.

## Cumulative Phase 3 stats (across all 3 PRs)

- 6 source files (\`embed.ts\`, \`source-readers.ts\`, \`index-store.ts\`, \`index-builder.ts\`, \`retrieve.ts\`, \`prepend.ts\`)
- 3 CLIs (\`caia-mentor-index\`, \`caia-mentor-retrieve\`, \`caia-mentor-prepend\`)
- 116 unit tests, all green
- ~3,400 lines of source + tests
- Live-verified against the real memory directory