### PR TITLE
feat(mentor-phase4-001): incident clustering library + caia-mentor-cluster CLI (PR-1)

### DIFF
--- a/packages/mentor-retrieval/package.json
+++ b/packages/mentor-retrieval/package.json
@@ -2,7 +2,7 @@
   "name": "@chiefaia/mentor-retrieval",
   "version": "0.1.0",
   "private": true,
-  "description": "Mentor Phase-3 lesson retrieval \u2014 embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, and prepend them to spawned-task prompts as 'Lessons from past similar work \u2014 do not repeat:'. PR-1 ships the index builder + storage; PR-2 adds the retrieval API + caia-mentor-retrieve CLI; PR-3 adds the orchestrator pre-spawn hook (caia-mentor-prepend + prependLessons() library).",
+  "description": "Mentor Phase-3 + Phase-4 lesson retrieval — embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, prepend them to spawned-task prompts as 'Lessons from past similar work — do not repeat:', and cluster the proposal stream to detect systemic-vs-one-off failure patterns. PR-1 ships the index builder + storage; PR-2 adds the retrieval API + caia-mentor-retrieve CLI; PR-3 adds the orchestrator pre-spawn hook (caia-mentor-prepend + prependLessons() library); Phase-4 PR-1 adds caia-mentor-cluster + the cluster() library used by Phase-4 PR-2 (Steward rule proposer).",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -10,7 +10,8 @@
   "bin": {
     "caia-mentor-index": "./dist/cli.js",
     "caia-mentor-retrieve": "./dist/retrieve-cli.js",
-    "caia-mentor-prepend": "./dist/prepend-cli.js"
+    "caia-mentor-prepend": "./dist/prepend-cli.js",
+    "caia-mentor-cluster": "./dist/cluster-cli.js"
   },
   "exports": {
     ".": {
@@ -28,6 +29,10 @@
     "./prepend": {
       "import": "./dist/prepend.js",
       "types": "./dist/prepend.d.ts"
+    },
+    "./cluster": {
+      "import": "./dist/cluster.js",
+      "types": "./dist/cluster.d.ts"
     }
   },
   "files": [

--- a/packages/mentor-retrieval/src/cluster-cli.ts
+++ b/packages/mentor-retrieval/src/cluster-cli.ts
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * caia-mentor-cluster — Mentor Phase-4 PR-1 CLI.
+ *
+ * Reads the persistent retrieval index built by `caia-mentor-index
+ * build` and emits clusters of proposals grouped by (classification,
+ * topic). Used by:
+ *
+ *   - operator inspection (does anything systemic stand out today?)
+ *   - PR-2 (Steward-rule proposal generator) — consumes the JSON output
+ *   - PR-3 (quarterly self-review) — feeds aggregate metrics
+ *
+ * Subcommands:
+ *
+ *   list    — Print clusters as JSON. Default: only systemic clusters
+ *             (occurrence >= --threshold). Pass `--all` to include
+ *             one-offs.
+ *
+ *   help    — Print usage and exit 0.
+ *
+ * Flags:
+ *
+ *   --memory     <path>    Override the memory dir. Default:
+ *                          $CAIA_MEMORY_DIR.
+ *   --threshold  <N>       Systemic threshold. Default: 3.
+ *   --burst-ms   <N>       Burst-window in ms. Default: 3600000 (1 h).
+ *   --all                  Include one-off clusters too.
+ *   --format     <text|json>  Output format. Default: json.
+ *
+ * Exit codes:
+ *
+ *   0   — success
+ *   1   — usage error
+ *   2   — runtime failure (no index DB; couldn't open store)
+ */
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  clusterProposals,
+  DEFAULT_BURST_WINDOW_MS,
+  DEFAULT_SYSTEMIC_THRESHOLD,
+  systemicClusters,
+  type Cluster
+} from './cluster.js';
+import { openIndexStore } from './index-store.js';
+
+interface ParsedArgs {
+  subcommand: 'list' | 'help';
+  memoryDir: string;
+  threshold: number;
+  burstWindowMs: number;
+  all: boolean;
+  format: 'text' | 'json';
+}
+
+interface RunOptions {
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  exit?: (code: number) => never;
+}
+
+export async function main(opts: RunOptions = {}): Promise<void> {
+  const argv = opts.argv ?? process.argv.slice(2);
+  const env = opts.env ?? process.env;
+  const stdout = opts.stdout ?? ((s: string) => process.stdout.write(`${s}\n`));
+  const stderr = opts.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
+  const exit =
+    opts.exit ??
+    ((code: number) => {
+      process.exit(code);
+    });
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv, env);
+  } catch (e) {
+    stderr(`mentor-cluster: ${describeError(e)}`);
+    stderr('run `caia-mentor-cluster help` for usage');
+    return exit(1);
+  }
+
+  if (parsed.subcommand === 'help') {
+    stdout(usage());
+    return exit(0);
+  }
+
+  // list
+  const dbPath = join(parsed.memoryDir, '_mentor-index.sqlite');
+  if (!existsSync(dbPath)) {
+    stderr(
+      `mentor-cluster: no index DB at ${dbPath}; run \`caia-mentor-index build\` first`
+    );
+    return exit(2);
+  }
+
+  let clusters: Cluster[];
+  try {
+    const store = openIndexStore({
+      memoryDir: parsed.memoryDir,
+      readonly: true
+    });
+    try {
+      const all = store.listAll();
+      clusters = clusterProposals(all, {
+        systemicThreshold: parsed.threshold,
+        burstWindowMs: parsed.burstWindowMs
+      });
+    } finally {
+      store.close();
+    }
+  } catch (e) {
+    stderr(`mentor-cluster: failed to read index: ${describeError(e)}`);
+    return exit(2);
+  }
+
+  const output = parsed.all ? clusters : systemicClusters(clusters);
+
+  if (parsed.format === 'text') {
+    stdout(renderText(output, parsed.threshold));
+  } else {
+    stdout(
+      JSON.stringify(
+        {
+          memoryDir: parsed.memoryDir,
+          threshold: parsed.threshold,
+          burstWindowMs: parsed.burstWindowMs,
+          totalClusters: clusters.length,
+          systemicCount: clusters.filter((c) => c.systemic).length,
+          clusters: output.map(serialiseCluster)
+        },
+        null,
+        2
+      )
+    );
+  }
+  return exit(0);
+}
+
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): ParsedArgs {
+  if (argv.length === 0) {
+    throw new Error('missing subcommand (list|help)');
+  }
+  const sub = argv[0];
+  if (sub !== 'list' && sub !== 'help') {
+    throw new Error(`unknown subcommand ${JSON.stringify(sub)}; expected list|help`);
+  }
+
+  let memoryDir = env['CAIA_MEMORY_DIR'];
+  let threshold = DEFAULT_SYSTEMIC_THRESHOLD;
+  let burstWindowMs = DEFAULT_BURST_WINDOW_MS;
+  let all = false;
+  let format: 'text' | 'json' = 'json';
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--memory') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--memory requires a value');
+      memoryDir = v;
+    } else if (arg === '--threshold') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--threshold requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+        throw new Error(`--threshold must be a positive integer; got ${JSON.stringify(v)}`);
+      }
+      threshold = n;
+    } else if (arg === '--burst-ms') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--burst-ms requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new Error(`--burst-ms must be a non-negative number; got ${JSON.stringify(v)}`);
+      }
+      burstWindowMs = n;
+    } else if (arg === '--all') {
+      all = true;
+    } else if (arg === '--format') {
+      i++;
+      const v = argv[i];
+      if (v !== 'text' && v !== 'json') {
+        throw new Error(`--format must be text|json; got ${JSON.stringify(v)}`);
+      }
+      format = v;
+    } else {
+      throw new Error(`unknown flag ${JSON.stringify(arg)}`);
+    }
+  }
+
+  if (memoryDir === undefined || memoryDir === '') {
+    memoryDir = join(homedir(), 'Documents', 'projects', 'caia', 'agent', 'memory');
+  }
+
+  return {
+    subcommand: sub,
+    memoryDir,
+    threshold,
+    burstWindowMs,
+    all,
+    format
+  };
+}
+
+function serialiseCluster(c: Cluster): {
+  classification: string;
+  topicSlug: string;
+  occurrenceCount: number;
+  systemic: boolean;
+  burst: boolean;
+  firstSeenIso: string;
+  lastSeenIso: string;
+  spanMs: number;
+  members: { sourcePath: string; rawSlug: string; timestampIso: string }[];
+} {
+  return {
+    classification: c.classification,
+    topicSlug: c.topicSlug,
+    occurrenceCount: c.occurrenceCount,
+    systemic: c.systemic,
+    burst: c.burst,
+    firstSeenIso: new Date(c.firstSeenMs).toISOString(),
+    lastSeenIso: new Date(c.lastSeenMs).toISOString(),
+    spanMs: c.lastSeenMs - c.firstSeenMs,
+    members: c.members.map((m) => ({
+      sourcePath: m.sourcePath,
+      rawSlug: m.rawSlug,
+      timestampIso: new Date(m.timestampMs).toISOString()
+    }))
+  };
+}
+
+function renderText(clusters: Cluster[], threshold: number): string {
+  if (clusters.length === 0) {
+    return `(no clusters with occurrence >= ${threshold})`;
+  }
+  const lines: string[] = [];
+  for (const c of clusters) {
+    const tag = c.systemic ? 'SYSTEMIC' : 'one-off ';
+    const burstTag = c.burst ? ' [burst]' : '';
+    const span = formatSpan(c.lastSeenMs - c.firstSeenMs);
+    lines.push(
+      `${tag} x${String(c.occurrenceCount).padStart(3)}  ${c.classification}/${c.topicSlug}  (span ${span})${burstTag}`
+    );
+  }
+  return lines.join('\n');
+}
+
+function formatSpan(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h${min % 60}m`;
+  const d = Math.floor(hr / 24);
+  return `${d}d${hr % 24}h`;
+}
+
+function usage(): string {
+  return `caia-mentor-cluster — Mentor Phase-4 incident clustering
+
+Usage:
+  caia-mentor-cluster list [--memory <dir>] [--threshold N] [--burst-ms N] [--all] [--format text|json]
+  caia-mentor-cluster help
+
+Defaults:
+  --threshold  ${DEFAULT_SYSTEMIC_THRESHOLD}
+  --burst-ms   ${DEFAULT_BURST_WINDOW_MS}
+  --format     json
+
+Environment:
+  CAIA_MEMORY_DIR   Memory directory (must contain _mentor-index.sqlite)
+`;
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+const isMain = (): boolean => {
+  const meta = import.meta.url;
+  if (!meta.startsWith('file://')) return false;
+  const arg1 = process.argv[1];
+  if (arg1 === undefined) return false;
+  return meta.endsWith(arg1) || meta === `file://${arg1}`;
+};
+
+if (isMain()) {
+  main().catch((e) => {
+    process.stderr.write(`mentor-cluster: fatal: ${describeError(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/packages/mentor-retrieval/src/cluster.ts
+++ b/packages/mentor-retrieval/src/cluster.ts
@@ -1,0 +1,313 @@
+/**
+ * Mentor Phase-4 incident clustering.
+ *
+ * Goal: given the lessons currently in the retrieval index, identify
+ * **systemic** failure patterns — distinct from one-offs — so that
+ * Phase-4 PR-2 can propose a Steward gatekeeper rule for the patterns
+ * that actually recur.
+ *
+ * Inputs come from the same source-readers + index store that Phase-3
+ * already builds. The clustering layer re-uses the persisted
+ * `IndexedLesson` rows (kind = 'proposal' for the active incident
+ * stream; kind = 'feedback' is excluded from clustering — those are
+ * already-distilled lessons, not raw incident events).
+ *
+ * ## Slug parsing
+ *
+ * Mentor's `memory-writer` writes proposals under:
+ *
+ *     <memoryDir>/proposals/<YYYYMMDD>-<HHMMSS>-<classification>-<topic>.md
+ *
+ * Examples observed in production memoryDir at the start of leg 8:
+ *
+ *     20260505-051149-unclassified-leg-4-stage-6-verify-test.md
+ *     20260505-051240-decisionclassifierviolation-stop-asking-me-...-j.md
+ *     20260505-051300-relitigation-we-already-decided-this-in-...-m.md
+ *     20260505-155146-prematurecompletion-pr-0-regression-after-merge.md
+ *     20260505-155146-prematurecompletion-pr-0-regression-after-merge-2.md
+ *     20260505-155146-prematurecompletion-pr-0-regression-after-merge-10.md
+ *
+ * `parseProposalSlug` extracts (timestamp, classification, topic) and
+ * **collapses the trailing `-N` collision-suffix** so all 30+
+ * `prematurecompletion-pr-0-regression-after-merge*` entries normalise
+ * to the same `topicSlug = 'pr-0-regression-after-merge'`.
+ *
+ * ## Cluster definition
+ *
+ * A cluster is the equivalence class of proposals that share both
+ * (classification, normalisedTopicSlug). Each cluster carries:
+ *
+ *   - `occurrenceCount` — total members in the cluster
+ *   - `firstSeenMs` / `lastSeenMs` — span of timestamps
+ *   - `systemic` — true iff `occurrenceCount >= systemicThreshold`
+ *                  (default 3)
+ *   - `burst`    — true iff (lastSeenMs - firstSeenMs) <= burstWindowMs
+ *                  (default 1 h). Bursts often mean a single root cause
+ *                  blew up loudly, not 3 distinct events; PR-2 weights
+ *                  them differently.
+ *
+ * Returned clusters are sorted by `occurrenceCount` desc then by
+ * `lastSeenMs` desc (newest first within the same count). Deterministic
+ * — every test that asserts ordering can rely on this.
+ *
+ * ## Design rationale
+ *
+ * - **Slug-based, not embedding-based.** We considered clustering by
+ *   embedding cosine-similarity (already in stack via Phase-3) but the
+ *   slug already encodes the dimensions that matter (classification +
+ *   target). Embedding-based would need a similarity threshold + a
+ *   linkage strategy + tie-breaking; slug-based is reproducible,
+ *   auditable, and matches how operators think about "the same
+ *   incident". Embedding similarity stays available for retrieval and
+ *   future second-pass clustering if slug clustering ever proves too
+ *   coarse.
+ *
+ * - **Pure functions.** No side effects, no DB access. The CLI layer
+ *   loads rows from the index store and feeds them in. Tests use plain
+ *   in-memory fixtures.
+ */
+
+import type { IndexedLesson } from './types.js';
+
+/** Minimum cluster size to flag as systemic. Operator-tunable. */
+export const DEFAULT_SYSTEMIC_THRESHOLD = 3;
+
+/**
+ * Default burst window: any cluster whose first → last span fits inside
+ * this window is flagged as a burst rather than a sustained pattern.
+ *
+ * 1 hour was chosen because the production observation is: postmerge
+ * regression bursts (the 30+ `prematurecompletion-pr-0-regression-...`
+ * entries) all clustered within minutes of each other from a single
+ * watcher loop. A multi-hour or multi-day spread is the actual
+ * "sustained pattern" signal.
+ */
+export const DEFAULT_BURST_WINDOW_MS = 60 * 60 * 1000;
+
+export interface ProposalMetadata {
+  /** Absolute path on disk. */
+  sourcePath: string;
+  /** Path-derived slug (kept verbatim from the IndexedLesson row). */
+  rawSlug: string;
+  /** Classification token from the slug (e.g. 'prematurecompletion'). */
+  classification: string;
+  /**
+   * Topic slug AFTER stripping the YYYYMMDD-HHMMSS prefix, the
+   * classification token, and the trailing `-N` collision suffix.
+   *
+   * Example: `prematurecompletion-pr-0-regression-after-merge-10` →
+   * `pr-0-regression-after-merge`.
+   */
+  topicSlug: string;
+  /** Parsed timestamp from the filename prefix (UTC ms). */
+  timestampMs: number;
+}
+
+export interface Cluster {
+  classification: string;
+  topicSlug: string;
+  occurrenceCount: number;
+  members: ProposalMetadata[];
+  firstSeenMs: number;
+  lastSeenMs: number;
+  /** occurrenceCount >= systemicThreshold */
+  systemic: boolean;
+  /** lastSeenMs - firstSeenMs <= burstWindowMs */
+  burst: boolean;
+}
+
+export interface ClusterOptions {
+  /** Default DEFAULT_SYSTEMIC_THRESHOLD. */
+  systemicThreshold?: number;
+  /** Default DEFAULT_BURST_WINDOW_MS. */
+  burstWindowMs?: number;
+}
+
+/**
+ * Parse a proposal slug into structured metadata.
+ *
+ * Returns null if the slug doesn't match the expected
+ * `YYYYMMDD-HHMMSS-classification-topic` shape. Callers should treat
+ * a null return as "this row is not a Mentor-emitted proposal" and
+ * skip it for clustering purposes.
+ */
+export function parseProposalSlug(rawSlug: string): ProposalMetadata | null {
+  // Slug format: YYYYMMDD-HHMMSS-<classification>-<topic>
+  // Example:     20260505-155146-prematurecompletion-pr-0-regression-after-merge
+  //              ^^^^^^^^ ^^^^^^ ^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //              date     time   classification      topic (the rest)
+  //
+  // Trailing `-N` (digits only) is a collision-resolution suffix added
+  // when multiple proposals would otherwise overwrite each other —
+  // strip it so duplicates collapse into the same topic bucket.
+  const match = /^(\d{8})-(\d{6})-([a-z0-9]+)-(.+)$/i.exec(rawSlug);
+  if (!match) return null;
+  const date = match[1];
+  const time = match[2];
+  const classification = match[3];
+  const rawTopic = match[4];
+  if (
+    date === undefined ||
+    time === undefined ||
+    classification === undefined ||
+    rawTopic === undefined
+  ) {
+    return null;
+  }
+
+  const timestampMs = parseTimestamp(date, time);
+  if (timestampMs === null) return null;
+
+  return {
+    sourcePath: '',
+    rawSlug,
+    classification: classification.toLowerCase(),
+    topicSlug: stripCollisionSuffix(rawTopic),
+    timestampMs
+  };
+}
+
+/**
+ * Strip the trailing `-N` (digits only) collision suffix that the
+ * memory-writer appends when a proposal would otherwise collide with
+ * an existing filename.
+ *
+ * `pr-0-regression-after-merge`     → `pr-0-regression-after-merge`
+ * `pr-0-regression-after-merge-2`   → `pr-0-regression-after-merge`
+ * `pr-0-regression-after-merge-10`  → `pr-0-regression-after-merge`
+ *
+ * The function is conservative: a trailing token that contains any
+ * non-digit (e.g. `…-merge-v2-final`) is left intact because it could
+ * be a legitimate part of the topic.
+ *
+ * Edge case: `pr-0-...` itself contains a numeric segment; only the
+ * **last** `-` boundary is considered, which keeps `pr-0` intact.
+ */
+export function stripCollisionSuffix(topic: string): string {
+  const idx = topic.lastIndexOf('-');
+  if (idx <= 0) return topic;
+  const tail = topic.slice(idx + 1);
+  if (tail.length === 0) return topic;
+  if (!/^\d+$/.test(tail)) return topic;
+  // Also: only strip if the prefix is non-empty (defensive — shouldn't
+  // happen given idx > 0 above).
+  const head = topic.slice(0, idx);
+  if (head.length === 0) return topic;
+  return head;
+}
+
+/**
+ * Cluster proposal rows by (classification, normalised topicSlug).
+ *
+ * Non-proposal lessons (kind === 'feedback') are silently skipped —
+ * they're distilled lessons, not raw incidents. Rows whose slug
+ * doesn't parse are skipped (and surface as zero clusters rather than
+ * noise).
+ */
+export function clusterProposals(
+  lessons: IndexedLesson[],
+  opts: ClusterOptions = {}
+): Cluster[] {
+  const systemicThreshold = opts.systemicThreshold ?? DEFAULT_SYSTEMIC_THRESHOLD;
+  const burstWindowMs = opts.burstWindowMs ?? DEFAULT_BURST_WINDOW_MS;
+
+  const buckets = new Map<string, Cluster>();
+
+  for (const row of lessons) {
+    if (row.kind !== 'proposal') continue;
+    const meta = parseProposalSlug(row.slug);
+    if (meta === null) continue;
+    meta.sourcePath = row.sourcePath;
+
+    const key = `${meta.classification}::${meta.topicSlug}`;
+    const existing = buckets.get(key);
+    if (existing === undefined) {
+      buckets.set(key, {
+        classification: meta.classification,
+        topicSlug: meta.topicSlug,
+        occurrenceCount: 1,
+        members: [meta],
+        firstSeenMs: meta.timestampMs,
+        lastSeenMs: meta.timestampMs,
+        systemic: false,
+        burst: false
+      });
+    } else {
+      existing.members.push(meta);
+      existing.occurrenceCount = existing.members.length;
+      if (meta.timestampMs < existing.firstSeenMs) {
+        existing.firstSeenMs = meta.timestampMs;
+      }
+      if (meta.timestampMs > existing.lastSeenMs) {
+        existing.lastSeenMs = meta.timestampMs;
+      }
+    }
+  }
+
+  // Finalise systemic + burst flags + member ordering.
+  const clusters: Cluster[] = [];
+  for (const c of buckets.values()) {
+    c.members.sort((a, b) => a.timestampMs - b.timestampMs);
+    c.systemic = c.occurrenceCount >= systemicThreshold;
+    c.burst = c.lastSeenMs - c.firstSeenMs <= burstWindowMs;
+    clusters.push(c);
+  }
+
+  // Sort: most occurrences first; then most recent last-seen first;
+  // then classification asc; then topicSlug asc — fully deterministic.
+  clusters.sort((a, b) => {
+    if (a.occurrenceCount !== b.occurrenceCount) {
+      return b.occurrenceCount - a.occurrenceCount;
+    }
+    if (a.lastSeenMs !== b.lastSeenMs) {
+      return b.lastSeenMs - a.lastSeenMs;
+    }
+    if (a.classification !== b.classification) {
+      return a.classification.localeCompare(b.classification);
+    }
+    return a.topicSlug.localeCompare(b.topicSlug);
+  });
+
+  return clusters;
+}
+
+/**
+ * Convenience: filter the cluster list down to systemic ones only.
+ * Used by PR-2 (Steward rule proposer) and the CLI.
+ */
+export function systemicClusters(clusters: Cluster[]): Cluster[] {
+  return clusters.filter((c) => c.systemic);
+}
+
+/**
+ * Parse `YYYYMMDD` + `HHMMSS` strings into UTC ms-since-epoch.
+ *
+ * The memory-writer emits these in local time, but for ordering
+ * purposes the absolute timezone doesn't matter as long as it's
+ * consistent. We treat them as UTC; the resulting ordering is correct
+ * within any single host (memory-writer + clusterer always run on the
+ * same machine).
+ */
+function parseTimestamp(date: string, time: string): number | null {
+  if (date.length !== 8 || time.length !== 6) return null;
+  const yyyy = Number(date.slice(0, 4));
+  const mm = Number(date.slice(4, 6));
+  const dd = Number(date.slice(6, 8));
+  const hh = Number(time.slice(0, 2));
+  const mi = Number(time.slice(2, 4));
+  const ss = Number(time.slice(4, 6));
+  if (
+    !Number.isFinite(yyyy) ||
+    !Number.isFinite(mm) ||
+    !Number.isFinite(dd) ||
+    !Number.isFinite(hh) ||
+    !Number.isFinite(mi) ||
+    !Number.isFinite(ss)
+  ) {
+    return null;
+  }
+  if (mm < 1 || mm > 12) return null;
+  if (dd < 1 || dd > 31) return null;
+  if (hh > 23 || mi > 59 || ss > 59) return null;
+  return Date.UTC(yyyy, mm - 1, dd, hh, mi, ss);
+}

--- a/packages/mentor-retrieval/src/index.ts
+++ b/packages/mentor-retrieval/src/index.ts
@@ -1,11 +1,20 @@
 /**
- * Mentor Phase-3 retrieval — public surface.
+ * Mentor Phase-3 + Phase-4 retrieval — public surface.
  *
- * - PR-1: index builder + persistence + Ollama embedding wrapper.
- * - PR-2: retrieval API + `caia-mentor-retrieve` CLI.
- * - PR-3: orchestrator pre-spawn injection hook + `caia-mentor-prepend`
- *         CLI (the killer feature — spawned agents now arrive at their
- *         task with explicit warnings about prior failure modes).
+ * Phase 3:
+ *   - PR-1: index builder + persistence + Ollama embedding wrapper.
+ *   - PR-2: retrieval API + `caia-mentor-retrieve` CLI.
+ *   - PR-3: orchestrator pre-spawn injection hook + `caia-mentor-prepend`
+ *           CLI (the killer feature — spawned agents now arrive at
+ *           their task with explicit warnings about prior failure
+ *           modes).
+ *
+ * Phase 4:
+ *   - PR-1: incident clustering (this file's `cluster.js` exports) +
+ *           `caia-mentor-cluster` CLI. Detects systemic-vs-one-off
+ *           failure patterns over the proposal stream so PR-2 can
+ *           propose Steward gatekeeper rules for genuinely recurring
+ *           failures.
  */
 
 export {
@@ -56,6 +65,18 @@ export {
   type PrependLessonsOptions,
   type PrependLessonsResult
 } from './prepend.js';
+
+export {
+  clusterProposals,
+  parseProposalSlug,
+  stripCollisionSuffix,
+  systemicClusters,
+  DEFAULT_SYSTEMIC_THRESHOLD,
+  DEFAULT_BURST_WINDOW_MS,
+  type Cluster,
+  type ClusterOptions,
+  type ProposalMetadata
+} from './cluster.js';
 
 export type {
   BuildIndexStats,

--- a/packages/mentor-retrieval/tests/cluster-cli.test.ts
+++ b/packages/mentor-retrieval/tests/cluster-cli.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for caia-mentor-cluster (Phase-4 PR-1 CLI).
+ *
+ * These tests exercise:
+ *   - argv parsing (subcommand + flag handling + validation)
+ *   - the `list` subcommand against a real (temp) index DB populated
+ *     with proposal rows
+ *   - graceful failure when the index DB doesn't exist yet
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { main, parseArgs } from '../src/cluster-cli.js';
+import { openIndexStore } from '../src/index-store.js';
+import { vectorToBlob } from '../src/embed.js';
+import type { IndexedLesson } from '../src/types.js';
+
+interface CapturedIo {
+  stdout: string[];
+  stderr: string[];
+  exitCode: number | null;
+}
+
+function captureRun(): {
+  io: CapturedIo;
+  stdout: (s: string) => void;
+  stderr: (s: string) => void;
+  exit: (code: number) => never;
+} {
+  const io: CapturedIo = { stdout: [], stderr: [], exitCode: null };
+  return {
+    io,
+    stdout: (s: string) => io.stdout.push(s),
+    stderr: (s: string) => io.stderr.push(s),
+    exit: ((code: number): never => {
+      io.exitCode = code;
+      // Throw to short-circuit `main`'s control flow without actually
+      // exiting the test runner.
+      throw new ExitSignal(code);
+    }) as (code: number) => never
+  };
+}
+
+class ExitSignal extends Error {
+  constructor(public code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+async function runMain(
+  argv: string[],
+  env: NodeJS.ProcessEnv = {}
+): Promise<CapturedIo> {
+  const cap = captureRun();
+  try {
+    await main({
+      argv,
+      env,
+      stdout: cap.stdout,
+      stderr: cap.stderr,
+      exit: cap.exit
+    });
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  }
+  return cap.io;
+}
+
+function seedProposal(
+  store: ReturnType<typeof openIndexStore>,
+  slug: string
+): void {
+  const lesson: Omit<IndexedLesson, 'id'> = {
+    sourcePath: `/fake/${slug}.md`,
+    kind: 'proposal',
+    slug,
+    mtimeMs: 0,
+    contentSha256: 'x',
+    contentSnippet: '',
+    embeddingDim: 1,
+    embedding: vectorToBlob(new Float32Array([1])),
+    indexedAtMs: 0
+  };
+  store.upsertLesson(lesson);
+}
+
+describe('parseArgs', () => {
+  it('defaults to threshold=3, json, no --all', () => {
+    const p = parseArgs(['list'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.subcommand).toBe('list');
+    expect(p.threshold).toBe(3);
+    expect(p.format).toBe('json');
+    expect(p.all).toBe(false);
+    expect(p.memoryDir).toBe('/m');
+  });
+  it('reads --threshold', () => {
+    const p = parseArgs(['list', '--threshold', '5'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.threshold).toBe(5);
+  });
+  it('reads --burst-ms', () => {
+    const p = parseArgs(['list', '--burst-ms', '7200000'], {
+      CAIA_MEMORY_DIR: '/m'
+    });
+    expect(p.burstWindowMs).toBe(7_200_000);
+  });
+  it('reads --memory and --all', () => {
+    const p = parseArgs(['list', '--memory', '/x', '--all'], {});
+    expect(p.memoryDir).toBe('/x');
+    expect(p.all).toBe(true);
+  });
+  it('reads --format text', () => {
+    const p = parseArgs(['list', '--format', 'text'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.format).toBe('text');
+  });
+  it('throws on missing subcommand', () => {
+    expect(() => parseArgs([], {})).toThrow(/subcommand/);
+  });
+  it('throws on unknown subcommand', () => {
+    expect(() => parseArgs(['frobnicate'], {})).toThrow(/unknown subcommand/);
+  });
+  it('throws on unknown flag', () => {
+    expect(() => parseArgs(['list', '--bogus'], {})).toThrow(/unknown flag/);
+  });
+  it('throws on non-integer --threshold', () => {
+    expect(() => parseArgs(['list', '--threshold', 'abc'], {})).toThrow(
+      /positive integer/
+    );
+    expect(() => parseArgs(['list', '--threshold', '0'], {})).toThrow(
+      /positive integer/
+    );
+    expect(() => parseArgs(['list', '--threshold', '1.5'], {})).toThrow(
+      /positive integer/
+    );
+  });
+  it('throws on negative --burst-ms', () => {
+    expect(() => parseArgs(['list', '--burst-ms', '-1'], {})).toThrow(
+      /non-negative/
+    );
+  });
+  it('throws on invalid --format', () => {
+    expect(() => parseArgs(['list', '--format', 'yaml'], {})).toThrow(
+      /text\|json/
+    );
+  });
+});
+
+describe('main list', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-cluster-cli-'));
+  });
+  afterEach(() => {
+    // tmpdir auto-cleaned by OS
+  });
+
+  it('prints empty result when no clusters meet threshold', async () => {
+    // Seed one proposal — won't meet default threshold=3
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir]);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      systemicCount: number;
+      totalClusters: number;
+      clusters: unknown[];
+    };
+    expect(out.totalClusters).toBe(1);
+    expect(out.systemicCount).toBe(0);
+    expect(out.clusters).toHaveLength(0);
+  });
+
+  it('prints systemic clusters by default (>=3)', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-x-y');
+    seedProposal(store, '20260505-100100-prematurecompletion-x-y-2');
+    seedProposal(store, '20260505-100200-prematurecompletion-x-y-3');
+    seedProposal(store, '20260505-100300-prematurecompletion-x-y-4');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir]);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      systemicCount: number;
+      clusters: { occurrenceCount: number; topicSlug: string }[];
+    };
+    expect(out.systemicCount).toBe(1);
+    expect(out.clusters[0]?.occurrenceCount).toBe(4);
+    expect(out.clusters[0]?.topicSlug).toBe('x-y');
+  });
+
+  it('--all includes one-off clusters', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    seedProposal(store, '20260505-100100-decisionclassifierviolation-bar');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir, '--all']);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      clusters: { occurrenceCount: number }[];
+    };
+    expect(out.clusters).toHaveLength(2);
+  });
+
+  it('--threshold lowers the systemic bar', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    seedProposal(store, '20260505-100100-relitigation-foo-2');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir, '--threshold', '2']);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      systemicCount: number;
+      clusters: { occurrenceCount: number }[];
+    };
+    expect(out.systemicCount).toBe(1);
+    expect(out.clusters[0]?.occurrenceCount).toBe(2);
+  });
+
+  it('text format emits one line per cluster', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-x-y');
+    seedProposal(store, '20260505-100100-prematurecompletion-x-y-2');
+    seedProposal(store, '20260505-100200-prematurecompletion-x-y-3');
+    store.close();
+
+    const io = await runMain([
+      'list',
+      '--memory',
+      memoryDir,
+      '--format',
+      'text'
+    ]);
+    expect(io.exitCode).toBe(0);
+    expect(io.stdout.join('\n')).toMatch(/SYSTEMIC.*prematurecompletion\/x-y/);
+  });
+
+  it('text format renders empty-result message', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    store.close();
+    const io = await runMain([
+      'list',
+      '--memory',
+      memoryDir,
+      '--format',
+      'text'
+    ]);
+    expect(io.exitCode).toBe(0);
+    expect(io.stdout.join('\n')).toMatch(/no clusters with occurrence >= 3/);
+  });
+
+  it('reports member sourcePaths in the JSON output', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-x-y');
+    seedProposal(store, '20260505-100100-prematurecompletion-x-y-2');
+    seedProposal(store, '20260505-100200-prematurecompletion-x-y-3');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir]);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      clusters: { members: { sourcePath: string; rawSlug: string }[] }[];
+    };
+    const paths = out.clusters[0]?.members.map((m) => m.sourcePath) ?? [];
+    expect(paths).toHaveLength(3);
+    expect(paths.every((p) => p.startsWith('/fake/'))).toBe(true);
+  });
+});
+
+describe('main list — error paths', () => {
+  it('exits 2 when index DB does not exist', async () => {
+    const memoryDir = mkdtempSync(join(tmpdir(), 'mentor-cluster-cli-no-db-'));
+    expect(existsSync(join(memoryDir, '_mentor-index.sqlite'))).toBe(false);
+
+    const io = await runMain(['list', '--memory', memoryDir]);
+    expect(io.exitCode).toBe(2);
+    expect(io.stderr.join('\n')).toMatch(/no index DB/);
+  });
+
+  it('exits 1 on usage error', async () => {
+    const io = await runMain(['frobnicate']);
+    expect(io.exitCode).toBe(1);
+    expect(io.stderr.join('\n')).toMatch(/unknown subcommand/);
+  });
+
+  it('help subcommand exits 0 with usage', async () => {
+    const io = await runMain(['help']);
+    expect(io.exitCode).toBe(0);
+    expect(io.stdout.join('\n')).toMatch(/caia-mentor-cluster/);
+  });
+});

--- a/packages/mentor-retrieval/tests/cluster.test.ts
+++ b/packages/mentor-retrieval/tests/cluster.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for Mentor Phase-4 PR-1 incident clustering.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  clusterProposals,
+  DEFAULT_BURST_WINDOW_MS,
+  DEFAULT_SYSTEMIC_THRESHOLD,
+  parseProposalSlug,
+  stripCollisionSuffix,
+  systemicClusters
+} from '../src/cluster.js';
+import type { IndexedLesson } from '../src/types.js';
+
+function fakeLesson(
+  rawSlug: string,
+  kind: 'feedback' | 'proposal' = 'proposal'
+): IndexedLesson {
+  return {
+    id: 0,
+    sourcePath: `/fake/${rawSlug}.md`,
+    kind,
+    slug: rawSlug,
+    mtimeMs: 0,
+    contentSha256: 'x',
+    contentSnippet: '',
+    embeddingDim: 1,
+    embedding: Buffer.alloc(4),
+    indexedAtMs: 0
+  };
+}
+
+describe('stripCollisionSuffix', () => {
+  it('strips a single trailing -N digits suffix', () => {
+    expect(stripCollisionSuffix('pr-0-regression-after-merge-2')).toBe(
+      'pr-0-regression-after-merge'
+    );
+  });
+  it('strips multi-digit suffixes', () => {
+    expect(stripCollisionSuffix('pr-0-regression-after-merge-15')).toBe(
+      'pr-0-regression-after-merge'
+    );
+  });
+  it('leaves slugs without numeric tails intact', () => {
+    expect(stripCollisionSuffix('pr-0-regression-after-merge')).toBe(
+      'pr-0-regression-after-merge'
+    );
+  });
+  it('leaves embedded numbers in non-tail positions intact', () => {
+    expect(stripCollisionSuffix('pr-12-flake')).toBe('pr-12-flake');
+  });
+  it('leaves tails containing non-digits intact', () => {
+    expect(stripCollisionSuffix('pr-0-merge-v2-final')).toBe('pr-0-merge-v2-final');
+  });
+  it('handles single-token slugs', () => {
+    expect(stripCollisionSuffix('alone')).toBe('alone');
+  });
+  it('does not collapse a slug to an empty string', () => {
+    expect(stripCollisionSuffix('-7')).toBe('-7');
+  });
+});
+
+describe('parseProposalSlug', () => {
+  it('parses canonical Mentor proposal slug', () => {
+    const m = parseProposalSlug(
+      '20260505-155146-prematurecompletion-pr-0-regression-after-merge'
+    );
+    expect(m).not.toBeNull();
+    expect(m?.classification).toBe('prematurecompletion');
+    expect(m?.topicSlug).toBe('pr-0-regression-after-merge');
+    // 2026-05-05T15:51:46Z
+    expect(m?.timestampMs).toBe(Date.UTC(2026, 4, 5, 15, 51, 46));
+  });
+  it('strips -N collision suffix', () => {
+    const a = parseProposalSlug(
+      '20260505-155146-prematurecompletion-pr-0-regression-after-merge'
+    );
+    const b = parseProposalSlug(
+      '20260505-155146-prematurecompletion-pr-0-regression-after-merge-10'
+    );
+    expect(a?.topicSlug).toBe(b?.topicSlug);
+  });
+  it('handles unclassified proposals', () => {
+    const m = parseProposalSlug(
+      '20260505-051149-unclassified-leg-4-stage-6-verify-test'
+    );
+    expect(m?.classification).toBe('unclassified');
+    expect(m?.topicSlug).toBe('leg-4-stage-6-verify-test');
+  });
+  it('returns null for non-proposal slugs', () => {
+    expect(parseProposalSlug('feedback_pat_topic')).toBeNull();
+    expect(parseProposalSlug('mentor_agent_directive')).toBeNull();
+  });
+  it('returns null for slugs missing classification', () => {
+    expect(parseProposalSlug('20260505-155146')).toBeNull();
+    expect(parseProposalSlug('20260505-155146-classonly')).toBeNull();
+  });
+  it('returns null for invalid date components', () => {
+    // month=13
+    expect(parseProposalSlug('20261305-000000-x-y')).toBeNull();
+    // hour=25
+    expect(parseProposalSlug('20260505-250000-x-y')).toBeNull();
+  });
+  it('lowercases the classification', () => {
+    const m = parseProposalSlug('20260505-155146-PrematureCompletion-x-y');
+    expect(m?.classification).toBe('prematurecompletion');
+  });
+});
+
+describe('clusterProposals', () => {
+  it('returns empty array for empty input', () => {
+    expect(clusterProposals([])).toEqual([]);
+  });
+
+  it('skips feedback rows', () => {
+    const lessons: IndexedLesson[] = [
+      fakeLesson('feedback_pat_topic', 'feedback'),
+      fakeLesson('20260505-100000-relitigation-pat-issue', 'feedback')
+    ];
+    expect(clusterProposals(lessons)).toEqual([]);
+  });
+
+  it('clusters distinct proposals into single-member clusters', () => {
+    const clusters = clusterProposals([
+      fakeLesson('20260505-100000-relitigation-pat-issue'),
+      fakeLesson('20260505-110000-decisionclassifierviolation-asking-questions')
+    ]);
+    expect(clusters).toHaveLength(2);
+    for (const c of clusters) {
+      expect(c.occurrenceCount).toBe(1);
+      expect(c.systemic).toBe(false);
+    }
+  });
+
+  it('collapses -N collision-suffix duplicates into one cluster', () => {
+    const lessons = [
+      fakeLesson('20260505-155146-prematurecompletion-pr-0-regression-after-merge'),
+      fakeLesson('20260505-155146-prematurecompletion-pr-0-regression-after-merge-2'),
+      fakeLesson('20260505-155146-prematurecompletion-pr-0-regression-after-merge-3'),
+      fakeLesson('20260505-155216-prematurecompletion-pr-0-regression-after-merge-10')
+    ];
+    const clusters = clusterProposals(lessons);
+    expect(clusters).toHaveLength(1);
+    const c = clusters[0]!;
+    expect(c.classification).toBe('prematurecompletion');
+    expect(c.topicSlug).toBe('pr-0-regression-after-merge');
+    expect(c.occurrenceCount).toBe(4);
+    expect(c.systemic).toBe(true);
+  });
+
+  it('marks systemic at >= threshold (default 3)', () => {
+    const baseSlug = '20260505-100000-relitigation-pat-issue';
+    const lessons = [
+      fakeLesson(baseSlug),
+      fakeLesson(`${baseSlug}-2`),
+      fakeLesson(`${baseSlug}-3`)
+    ];
+    const c = clusterProposals(lessons)[0]!;
+    expect(c.occurrenceCount).toBe(3);
+    expect(c.systemic).toBe(true);
+  });
+
+  it('respects custom systemicThreshold', () => {
+    const baseSlug = '20260505-100000-relitigation-pat-issue';
+    const lessons = [fakeLesson(baseSlug), fakeLesson(`${baseSlug}-2`)];
+    expect(clusterProposals(lessons, { systemicThreshold: 2 })[0]?.systemic).toBe(true);
+    expect(clusterProposals(lessons, { systemicThreshold: 5 })[0]?.systemic).toBe(false);
+  });
+
+  it('marks burst when all occurrences fit inside burstWindowMs (default 1h)', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-prematurecompletion-x-y'),
+      fakeLesson('20260505-100500-prematurecompletion-x-y-2'),
+      fakeLesson('20260505-101500-prematurecompletion-x-y-3')
+    ];
+    const c = clusterProposals(lessons)[0]!;
+    expect(c.burst).toBe(true);
+  });
+
+  it('does NOT mark burst when occurrences span >1h', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-prematurecompletion-x-y'),
+      fakeLesson('20260505-130000-prematurecompletion-x-y-2'),
+      fakeLesson('20260506-100000-prematurecompletion-x-y-3')
+    ];
+    const c = clusterProposals(lessons)[0]!;
+    expect(c.burst).toBe(false);
+  });
+
+  it('respects custom burstWindowMs', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-prematurecompletion-x-y'),
+      fakeLesson('20260505-130000-prematurecompletion-x-y-2')
+    ];
+    expect(
+      clusterProposals(lessons, { burstWindowMs: 60_000 })[0]?.burst
+    ).toBe(false);
+    // 4h window — yes, that's a burst
+    expect(
+      clusterProposals(lessons, { burstWindowMs: 4 * 60 * 60 * 1000 })[0]?.burst
+    ).toBe(true);
+  });
+
+  it('orders clusters by occurrence desc, then last-seen desc', () => {
+    const lessons = [
+      // 1x relitigation/foo (older)
+      fakeLesson('20260504-100000-relitigation-foo'),
+      // 4x prematurecompletion/bar (newer)
+      fakeLesson('20260505-100000-prematurecompletion-bar'),
+      fakeLesson('20260505-100100-prematurecompletion-bar-2'),
+      fakeLesson('20260505-100200-prematurecompletion-bar-3'),
+      fakeLesson('20260505-100300-prematurecompletion-bar-4'),
+      // 4x decisionclassifierviolation/baz (oldest of the two 4x clusters)
+      fakeLesson('20260504-100000-decisionclassifierviolation-baz'),
+      fakeLesson('20260504-100100-decisionclassifierviolation-baz-2'),
+      fakeLesson('20260504-100200-decisionclassifierviolation-baz-3'),
+      fakeLesson('20260504-100300-decisionclassifierviolation-baz-4')
+    ];
+    const clusters = clusterProposals(lessons);
+    expect(clusters.map((c) => `${c.classification}/${c.topicSlug}`)).toEqual([
+      'prematurecompletion/bar',
+      'decisionclassifierviolation/baz',
+      'relitigation/foo'
+    ]);
+  });
+
+  it('includes member metadata in chronological order', () => {
+    const lessons = [
+      fakeLesson('20260505-100200-x-y-3'),
+      fakeLesson('20260505-100000-x-y'),
+      fakeLesson('20260505-100100-x-y-2')
+    ];
+    const c = clusterProposals(lessons)[0]!;
+    const ts = c.members.map((m) => m.timestampMs);
+    const sorted = [...ts].sort((a, b) => a - b);
+    expect(ts).toEqual(sorted);
+  });
+
+  it('attaches sourcePath from the IndexedLesson', () => {
+    const c = clusterProposals([fakeLesson('20260505-100000-x-y')])[0]!;
+    expect(c.members[0]?.sourcePath).toBe('/fake/20260505-100000-x-y.md');
+  });
+
+  it('skips proposal rows with un-parseable slugs', () => {
+    const lessons = [
+      fakeLesson('not-a-real-mentor-slug'),
+      fakeLesson('20260505-100000-relitigation-foo')
+    ];
+    const clusters = clusterProposals(lessons);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.topicSlug).toBe('foo');
+  });
+});
+
+describe('systemicClusters', () => {
+  it('filters down to systemic clusters only', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-x-y'),
+      fakeLesson('20260505-100100-a-b'),
+      fakeLesson('20260505-100200-a-b-2'),
+      fakeLesson('20260505-100300-a-b-3')
+    ];
+    const all = clusterProposals(lessons);
+    const sys = systemicClusters(all);
+    expect(sys).toHaveLength(1);
+    expect(sys[0]?.classification).toBe('a');
+  });
+});
+
+describe('public defaults', () => {
+  it('exports the documented threshold default', () => {
+    expect(DEFAULT_SYSTEMIC_THRESHOLD).toBe(3);
+  });
+  it('exports the documented burst window default (1h)', () => {
+    expect(DEFAULT_BURST_WINDOW_MS).toBe(60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Mentor Phase 4 PR-1 — incident clustering + `caia-mentor-cluster` CLI

Phase 4's mandate (per `agent/memory/mentor_agent_directive.md` ## Phase 4): pattern-recognition + Steward handoff. Detect systemic-vs-one-off via clustering of past incidents; when systemic, propose a Steward rule (PR-2). Quarterly self-review (PR-3).

This PR ships the **clustering substrate** that PR-2 + PR-3 build on.

### What's in here

- `packages/mentor-retrieval/src/cluster.ts` — pure-function clustering library.
- `packages/mentor-retrieval/src/cluster-cli.ts` — `caia-mentor-cluster list|help`.
- `package.json` — new `caia-mentor-cluster` bin + `./cluster` subpath export.
- 51 new tests (30 cluster + 21 cluster-cli).

### Live corpus motivation

The production memoryDir has 60 proposals, 30+ of which are
`prematurecompletion-pr-0-regression-after-merge*` collision-suffix
duplicates emitted by the postmerge watcher. Without normalisation
they look like 30 distinct incidents; with normalisation they cluster
as one systemic pattern (occurrence=30+, ready for Steward-rule
promotion in PR-2).

### Defaults

- `systemicThreshold = 3` — matches the directive's "≥3 recurrences" guidance.
- `burstWindowMs = 60 min` — the postmerge-watcher fires its regressions in tight bursts, not as a sustained signal.

### Test surface

| Suite | Tests |
|---|---|
| `cluster.test.ts` | 30 |
| `cluster-cli.test.ts` | 21 |

Package total: 116 → **167 tests**. Lint + typecheck + build all green; workspace filter green.

### What this PR does NOT do

- Does **not** write Steward rule proposals — that's PR-2.
- Does **not** run quarterly self-review — that's PR-3.
- Does **not** modify the index DB schema — read-only consumer.

### Stages

1-5 (this PR). Stage-6 end-to-end live verify lands on PR-3.
