### PR TITLE
feat(mentor-phase4-002): steward-rule proposer + caia-mentor-propose-steward-rule CLI (PR-2)

### DIFF
--- a/packages/mentor-retrieval/package.json
+++ b/packages/mentor-retrieval/package.json
@@ -2,7 +2,7 @@
   "name": "@chiefaia/mentor-retrieval",
   "version": "0.1.0",
   "private": true,
-  "description": "Mentor Phase-3 + Phase-4 lesson retrieval — embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, prepend them to spawned-task prompts as 'Lessons from past similar work — do not repeat:', and cluster the proposal stream to detect systemic-vs-one-off failure patterns. PR-1 ships the index builder + storage; PR-2 adds the retrieval API + caia-mentor-retrieve CLI; PR-3 adds the orchestrator pre-spawn hook (caia-mentor-prepend + prependLessons() library); Phase-4 PR-1 adds caia-mentor-cluster + the cluster() library used by Phase-4 PR-2 (Steward rule proposer).",
+  "description": "Mentor Phase-3 + Phase-4 lesson retrieval — embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, prepend them to spawned-task prompts, cluster the proposal stream to detect systemic-vs-one-off failure patterns, and propose Steward gatekeeper rules for the systemic ones. Phase-3 PR-1/2/3 ship the index + retrieval + prepend hook; Phase-4 PR-1 ships clustering + caia-mentor-cluster; Phase-4 PR-2 ships Steward-rule proposals + caia-mentor-propose-steward-rule.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -11,7 +11,8 @@
     "caia-mentor-index": "./dist/cli.js",
     "caia-mentor-retrieve": "./dist/retrieve-cli.js",
     "caia-mentor-prepend": "./dist/prepend-cli.js",
-    "caia-mentor-cluster": "./dist/cluster-cli.js"
+    "caia-mentor-cluster": "./dist/cluster-cli.js",
+    "caia-mentor-propose-steward-rule": "./dist/propose-steward-rule-cli.js"
   },
   "exports": {
     ".": {
@@ -33,6 +34,10 @@
     "./cluster": {
       "import": "./dist/cluster.js",
       "types": "./dist/cluster.d.ts"
+    },
+    "./steward-rule-proposer": {
+      "import": "./dist/steward-rule-proposer.js",
+      "types": "./dist/steward-rule-proposer.d.ts"
     }
   },
   "files": [

--- a/packages/mentor-retrieval/src/index.ts
+++ b/packages/mentor-retrieval/src/index.ts
@@ -10,11 +10,13 @@
  *           modes).
  *
  * Phase 4:
- *   - PR-1: incident clustering (this file's `cluster.js` exports) +
- *           `caia-mentor-cluster` CLI. Detects systemic-vs-one-off
- *           failure patterns over the proposal stream so PR-2 can
- *           propose Steward gatekeeper rules for genuinely recurring
- *           failures.
+ *   - PR-1: incident clustering (`./cluster.js`) +
+ *           `caia-mentor-cluster` CLI.
+ *   - PR-2: Steward rule proposal generator
+ *           (`./steward-rule-proposer.js`) +
+ *           `caia-mentor-propose-steward-rule` CLI. Promotes systemic
+ *           clusters into operator-reviewable Steward gatekeeper-rule
+ *           proposals.
  */
 
 export {
@@ -77,6 +79,15 @@ export {
   type ClusterOptions,
   type ProposalMetadata
 } from './cluster.js';
+
+export {
+  proposeStewardRule,
+  renderStewardRuleProposalMarkdown,
+  writeStewardRuleProposals,
+  type StewardRuleProposal,
+  type WriteStewardRuleProposalsOptions,
+  type WriteStewardRuleProposalsResult
+} from './steward-rule-proposer.js';
 
 export type {
   BuildIndexStats,

--- a/packages/mentor-retrieval/src/propose-steward-rule-cli.ts
+++ b/packages/mentor-retrieval/src/propose-steward-rule-cli.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * caia-mentor-propose-steward-rule — Mentor Phase-4 PR-2 CLI.
+ *
+ * Reads the persisted lesson index, runs the Phase-4 PR-1 clusterer,
+ * and emits a Steward-rule proposal (one per systemic cluster).
+ *
+ * Subcommands:
+ *
+ *   list   — Print the proposals as JSON or markdown without writing
+ *            anything. Default output: JSON.
+ *
+ *   write  — Write each proposal to
+ *            `<memoryDir>/proposals/<proposalSlug>.md`. Existing files
+ *            are preserved unless `--force` is passed (so an operator
+ *            mid-review doesn't get their notes clobbered).
+ *
+ *   help   — Print usage and exit 0.
+ *
+ * Flags:
+ *
+ *   --memory      <path>      Override the memory dir (default $CAIA_MEMORY_DIR).
+ *   --threshold   <N>         Systemic threshold (default 3).
+ *   --burst-ms    <N>         Burst window ms (default 3600000).
+ *   --include-bursts          Include burst clusters too. Default: skip
+ *                             bursts because they usually mean a single
+ *                             watcher loop emitted N duplicates rather
+ *                             than N independent failures.
+ *   --force                   `write` overwrites existing proposals.
+ *   --format      <text|json> `list` output format. Default: json.
+ *
+ * Exit codes:
+ *
+ *   0   — success (zero or more proposals)
+ *   1   — usage error
+ *   2   — runtime failure (no index DB, couldn't write, etc.)
+ */
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  clusterProposals,
+  DEFAULT_BURST_WINDOW_MS,
+  DEFAULT_SYSTEMIC_THRESHOLD,
+  systemicClusters,
+  type Cluster
+} from './cluster.js';
+import { openIndexStore } from './index-store.js';
+import {
+  proposeStewardRule,
+  renderStewardRuleProposalMarkdown,
+  writeStewardRuleProposals,
+  type StewardRuleProposal,
+  type WriteStewardRuleProposalsResult
+} from './steward-rule-proposer.js';
+
+interface ParsedArgs {
+  subcommand: 'list' | 'write' | 'help';
+  memoryDir: string;
+  threshold: number;
+  burstWindowMs: number;
+  includeBursts: boolean;
+  force: boolean;
+  format: 'text' | 'json';
+}
+
+interface RunOptions {
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  exit?: (code: number) => never;
+}
+
+export async function main(opts: RunOptions = {}): Promise<void> {
+  const argv = opts.argv ?? process.argv.slice(2);
+  const env = opts.env ?? process.env;
+  const stdout = opts.stdout ?? ((s: string) => process.stdout.write(`${s}\n`));
+  const stderr = opts.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
+  const exit =
+    opts.exit ??
+    ((code: number) => {
+      process.exit(code);
+    });
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv, env);
+  } catch (e) {
+    stderr(`mentor-propose-steward-rule: ${describeError(e)}`);
+    stderr('run `caia-mentor-propose-steward-rule help` for usage');
+    return exit(1);
+  }
+
+  if (parsed.subcommand === 'help') {
+    stdout(usage());
+    return exit(0);
+  }
+
+  // Common: load + cluster.
+  const dbPath = join(parsed.memoryDir, '_mentor-index.sqlite');
+  if (!existsSync(dbPath)) {
+    stderr(
+      `mentor-propose-steward-rule: no index DB at ${dbPath}; run \`caia-mentor-index build\` first`
+    );
+    return exit(2);
+  }
+
+  let candidateClusters: Cluster[];
+  try {
+    const store = openIndexStore({ memoryDir: parsed.memoryDir, readonly: true });
+    try {
+      const all = store.listAll();
+      const clusters = clusterProposals(all, {
+        systemicThreshold: parsed.threshold,
+        burstWindowMs: parsed.burstWindowMs
+      });
+      const sys = systemicClusters(clusters);
+      candidateClusters = parsed.includeBursts ? sys : sys.filter((c) => !c.burst);
+    } finally {
+      store.close();
+    }
+  } catch (e) {
+    stderr(`mentor-propose-steward-rule: failed to read index: ${describeError(e)}`);
+    return exit(2);
+  }
+
+  const proposals = candidateClusters.map((c) => proposeStewardRule(c));
+
+  if (parsed.subcommand === 'list') {
+    if (parsed.format === 'text') {
+      stdout(renderListText(proposals));
+    } else {
+      stdout(JSON.stringify({ count: proposals.length, proposals }, null, 2));
+    }
+    return exit(0);
+  }
+
+  // write
+  let writeResult: WriteStewardRuleProposalsResult;
+  try {
+    writeResult = writeStewardRuleProposals(candidateClusters, {
+      memoryDir: parsed.memoryDir,
+      force: parsed.force
+    });
+  } catch (e) {
+    stderr(`mentor-propose-steward-rule write failed: ${describeError(e)}`);
+    return exit(2);
+  }
+
+  stdout(
+    JSON.stringify(
+      {
+        proposalsDir: writeResult.proposalsDir,
+        writtenCount: writeResult.written.length,
+        skippedCount: writeResult.skipped.length,
+        written: writeResult.written,
+        skipped: writeResult.skipped
+      },
+      null,
+      2
+    )
+  );
+  return exit(0);
+}
+
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): ParsedArgs {
+  if (argv.length === 0) {
+    throw new Error('missing subcommand (list|write|help)');
+  }
+  const sub = argv[0];
+  if (sub !== 'list' && sub !== 'write' && sub !== 'help') {
+    throw new Error(
+      `unknown subcommand ${JSON.stringify(sub)}; expected list|write|help`
+    );
+  }
+
+  let memoryDir = env['CAIA_MEMORY_DIR'];
+  let threshold = DEFAULT_SYSTEMIC_THRESHOLD;
+  let burstWindowMs = DEFAULT_BURST_WINDOW_MS;
+  let includeBursts = false;
+  let force = false;
+  let format: 'text' | 'json' = 'json';
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--memory') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--memory requires a value');
+      memoryDir = v;
+    } else if (arg === '--threshold') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--threshold requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+        throw new Error(
+          `--threshold must be a positive integer; got ${JSON.stringify(v)}`
+        );
+      }
+      threshold = n;
+    } else if (arg === '--burst-ms') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--burst-ms requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new Error(
+          `--burst-ms must be a non-negative number; got ${JSON.stringify(v)}`
+        );
+      }
+      burstWindowMs = n;
+    } else if (arg === '--include-bursts') {
+      includeBursts = true;
+    } else if (arg === '--force') {
+      force = true;
+    } else if (arg === '--format') {
+      i++;
+      const v = argv[i];
+      if (v !== 'text' && v !== 'json') {
+        throw new Error(`--format must be text|json; got ${JSON.stringify(v)}`);
+      }
+      format = v;
+    } else {
+      throw new Error(`unknown flag ${JSON.stringify(arg)}`);
+    }
+  }
+
+  if (memoryDir === undefined || memoryDir === '') {
+    memoryDir = join(homedir(), 'Documents', 'projects', 'caia', 'agent', 'memory');
+  }
+
+  return {
+    subcommand: sub,
+    memoryDir,
+    threshold,
+    burstWindowMs,
+    includeBursts,
+    force,
+    format
+  };
+}
+
+function renderListText(proposals: StewardRuleProposal[]): string {
+  if (proposals.length === 0) {
+    return '(no systemic-cluster proposals)';
+  }
+  return proposals
+    .map((p) => renderStewardRuleProposalMarkdown(p))
+    .join('\n\n---\n\n');
+}
+
+function usage(): string {
+  return `caia-mentor-propose-steward-rule — Mentor Phase-4 Steward-rule proposer
+
+Usage:
+  caia-mentor-propose-steward-rule list  [--memory <dir>] [--threshold N] [--burst-ms N] [--include-bursts] [--format text|json]
+  caia-mentor-propose-steward-rule write [--memory <dir>] [--threshold N] [--burst-ms N] [--include-bursts] [--force]
+  caia-mentor-propose-steward-rule help
+
+Defaults:
+  --threshold       ${DEFAULT_SYSTEMIC_THRESHOLD}
+  --burst-ms        ${DEFAULT_BURST_WINDOW_MS}
+  --include-bursts  off (burst clusters are usually a single watcher-loop replay)
+  --force           off (existing proposals are preserved)
+  --format          json
+
+Environment:
+  CAIA_MEMORY_DIR   Memory directory (must contain _mentor-index.sqlite)
+`;
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+const isMain = (): boolean => {
+  const meta = import.meta.url;
+  if (!meta.startsWith('file://')) return false;
+  const arg1 = process.argv[1];
+  if (arg1 === undefined) return false;
+  return meta.endsWith(arg1) || meta === `file://${arg1}`;
+};
+
+if (isMain()) {
+  main().catch((e) => {
+    process.stderr.write(`mentor-propose-steward-rule: fatal: ${describeError(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/packages/mentor-retrieval/src/steward-rule-proposer.ts
+++ b/packages/mentor-retrieval/src/steward-rule-proposer.ts
@@ -1,0 +1,366 @@
+/**
+ * Mentor Phase-4 PR-2 — Steward rule proposal generator.
+ *
+ * Given a systemic cluster (from `cluster.ts`), emit a markdown
+ * proposal that Mentor hands to operator review and, on approval,
+ * Steward picks up as a permanent gatekeeper rule.
+ *
+ * The directive (`mentor_agent_directive.md` ## Phase 4) is explicit:
+ *
+ *   "When systemic, propose a Steward rule (PR to Steward checks).
+ *    Quarterly self-review."
+ *
+ * and (## Distinct from Steward and Curator):
+ *
+ *   "A new failure mode is detected by Mentor (incident), proposed as
+ *    a permanent rule by Mentor, then enforced by Steward."
+ *
+ * So this layer does NOT modify Steward code. It produces a
+ * markdown proposal that:
+ *
+ *   1. Lands under `<memoryDir>/proposals/steward-rule-<slug>.md` so
+ *      it joins the existing review queue.
+ *   2. Carries enough metadata for an operator to one-shot decide
+ *      "yes, promote to a Steward rule" or "no, this is a one-off".
+ *   3. Is stable across runs — the same cluster produces the same
+ *      proposal text, so re-running the proposer is idempotent and
+ *      safe in cron.
+ *
+ * This file deliberately does NOT touch Steward's analyzer code or
+ * open a code PR. That step (the actual rule wiring under
+ * `packages/steward-analyzers/`) is operator-driven; Mentor stops at
+ * the proposal boundary.
+ *
+ * The proposed check shape is a recommendation only — Steward's
+ * existing analyzer family (gitflow-conformance, gitleaks, semgrep,
+ * the steward-gatekeeper-* trio) decides which one of them is the
+ * right home for the new rule once it's approved.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve as pathResolve } from 'node:path';
+
+import type { Cluster, ProposalMetadata } from './cluster.js';
+
+/**
+ * One Steward-rule proposal — the structured shape emitted from a
+ * cluster. The CLI renders this to markdown (and optionally JSON)
+ * before writing.
+ */
+export interface StewardRuleProposal {
+  /** Stable identifier — used as filename slug. */
+  proposalSlug: string;
+  /** Classification token from the cluster (e.g. 'prematurecompletion'). */
+  classification: string;
+  /** Topic slug from the cluster (collision-suffix already stripped). */
+  topicSlug: string;
+  /** Total members in the cluster at proposal time. */
+  occurrenceCount: number;
+  /** Cluster span in ms. */
+  spanMs: number;
+  /** First / last ISO timestamps of cluster members. */
+  firstSeenIso: string;
+  lastSeenIso: string;
+  /** Was the cluster a burst (per Cluster.burst)? */
+  burst: boolean;
+  /** Human-readable proposed check title. */
+  proposedCheckTitle: string;
+  /** Categorical check phase. */
+  proposedCheckType: 'pre-merge' | 'post-merge' | 'cron' | 'unclassified';
+  /** Free-form markdown body — trigger heuristic. */
+  triggerHeuristic: string;
+  /** Free-form markdown body — remediation guidance. */
+  remediationGuidance: string;
+  /** Slimmed cluster members for the evidence section. */
+  evidence: {
+    sourcePath: string;
+    rawSlug: string;
+    timestampIso: string;
+  }[];
+}
+
+/**
+ * Build a proposal from a single cluster. Pure function.
+ *
+ * The `classification` token routes to a default check phase + a
+ * default trigger heuristic. Routing is conservative — when we don't
+ * have a recipe, we fall back to `unclassified` and ask the operator
+ * to fill in the check shape.
+ */
+export function proposeStewardRule(cluster: Cluster): StewardRuleProposal {
+  const recipe = checkRecipeFor(cluster.classification);
+
+  return {
+    proposalSlug: `steward-rule-${cluster.classification}-${cluster.topicSlug}`,
+    classification: cluster.classification,
+    topicSlug: cluster.topicSlug,
+    occurrenceCount: cluster.occurrenceCount,
+    spanMs: cluster.lastSeenMs - cluster.firstSeenMs,
+    firstSeenIso: new Date(cluster.firstSeenMs).toISOString(),
+    lastSeenIso: new Date(cluster.lastSeenMs).toISOString(),
+    burst: cluster.burst,
+    proposedCheckTitle: recipe.title(cluster),
+    proposedCheckType: recipe.checkType,
+    triggerHeuristic: recipe.triggerHeuristic(cluster),
+    remediationGuidance: recipe.remediationGuidance(cluster),
+    evidence: cluster.members.map((m) => slimEvidence(m))
+  };
+}
+
+/**
+ * Render a proposal as markdown, ready to write under
+ * `<memoryDir>/proposals/`. Output is deterministic — no timestamps,
+ * no random IDs, so re-running with the same input produces the same
+ * file (idempotent for the writer below).
+ */
+export function renderStewardRuleProposalMarkdown(p: StewardRuleProposal): string {
+  const evidenceLines = p.evidence
+    .map((e) => `- \`${e.rawSlug}\` (\`${e.timestampIso}\`) — \`${e.sourcePath}\``)
+    .join('\n');
+
+  return `---
+name: Steward rule proposal — ${p.proposedCheckTitle}
+description: "Mentor Phase-4 systemic-pattern Steward rule proposal — ${p.classification} / ${p.topicSlug} (${p.occurrenceCount} occurrences)"
+type: steward-rule-proposal
+classifiedAs: ${p.classification}
+topicSlug: ${p.topicSlug}
+occurrenceCount: ${p.occurrenceCount}
+firstSeen: ${p.firstSeenIso}
+lastSeen: ${p.lastSeenIso}
+burst: ${String(p.burst)}
+proposedCheckType: ${p.proposedCheckType}
+---
+
+# Steward rule proposal — ${p.proposedCheckTitle}
+
+## Why
+
+Mentor's clustering layer (Phase-4 PR-1) detected a **systemic** pattern
+of ${p.occurrenceCount} occurrences of \`${p.classification}/${p.topicSlug}\`
+spanning \`${p.firstSeenIso}\` → \`${p.lastSeenIso}\`. ${p.burst ? '**Burst** signal — the entire cluster fired inside a tight window, suggesting a single root-cause loop rather than recurrent independent failures. Verify the underlying source has been addressed before approving this rule.' : 'Sustained signal — occurrences spread across a meaningful time span, which is the directive\'s threshold for promoting a class of failure to a permanent gatekeeper.'}
+
+This proposal exists because the directive
+(\`agent/memory/mentor_agent_directive.md\` ## Phase 4) mandates: when
+N≥3 incidents share a classification + topic, propose a Steward rule
+that mechanically catches the next instance before it merges or after
+it lands.
+
+## Proposed check
+
+**Type**: \`${p.proposedCheckType}\`
+
+**Trigger heuristic** (when Steward should fire):
+
+${p.triggerHeuristic}
+
+## Remediation guidance
+
+${p.remediationGuidance}
+
+## Evidence
+
+${evidenceLines}
+
+## How to apply
+
+1. Operator review: skim 2-3 evidence entries. Confirm the cluster is genuinely systemic and not a single watcher-loop bug emitting duplicate proposals.
+2. If approved, route to \`packages/steward-analyzers/\`. Existing analyzer families (gitflow-conformance, gitleaks, semgrep, steward-gatekeeper-{branch,signing,artifacts}) are the most likely homes; pick the one whose data shape matches the trigger heuristic.
+3. Wire the rule, write the test, ship via the Steward-analyzers PR pipeline. Mentor's job ends here.
+4. Once Steward enforces this rule, the corresponding cluster should stop growing — that's the success metric Phase-4 PR-3 (quarterly self-review) tracks.
+
+---
+
+*This is a Mentor Phase-4 auto-generated systemic-pattern Steward rule proposal. Operator review required before promoting to a Steward analyzer.*
+`;
+}
+
+/** Result of a write run — what got written, what was skipped. */
+export interface WriteStewardRuleProposalsResult {
+  written: { path: string; proposalSlug: string }[];
+  skipped: { path: string; proposalSlug: string; reason: 'already-exists' }[];
+  proposalsDir: string;
+}
+
+export interface WriteStewardRuleProposalsOptions {
+  memoryDir: string;
+  /** If true, overwrite existing proposal files. Default: false. */
+  force?: boolean;
+  /**
+   * If true, only emit per-cluster proposals; the writer is purely
+   * idempotent. Default: false (writer creates the proposals dir if
+   * missing).
+   */
+  dryRun?: boolean;
+}
+
+/**
+ * Write one rule proposal per cluster under
+ * `<memoryDir>/proposals/<proposalSlug>.md`.
+ *
+ * When `force === false` (default), an existing proposal file is
+ * preserved (operator may have already started reviewing it).
+ *
+ * When `dryRun === true`, no files are written — useful for the
+ * `caia-mentor-propose-steward-rule list` subcommand.
+ */
+export function writeStewardRuleProposals(
+  clusters: Cluster[],
+  opts: WriteStewardRuleProposalsOptions
+): WriteStewardRuleProposalsResult {
+  const proposalsDir = join(pathResolve(opts.memoryDir), 'proposals');
+  const force = opts.force ?? false;
+  const dryRun = opts.dryRun ?? false;
+
+  if (!dryRun && !existsSync(proposalsDir)) {
+    mkdirSync(proposalsDir, { recursive: true });
+  }
+
+  const written: { path: string; proposalSlug: string }[] = [];
+  const skipped: {
+    path: string;
+    proposalSlug: string;
+    reason: 'already-exists';
+  }[] = [];
+
+  for (const cluster of clusters) {
+    const proposal = proposeStewardRule(cluster);
+    const filePath = join(proposalsDir, `${proposal.proposalSlug}.md`);
+
+    if (!force && existsSync(filePath)) {
+      skipped.push({
+        path: filePath,
+        proposalSlug: proposal.proposalSlug,
+        reason: 'already-exists'
+      });
+      continue;
+    }
+
+    if (!dryRun) {
+      writeFileSync(filePath, renderStewardRuleProposalMarkdown(proposal), 'utf-8');
+    }
+    written.push({ path: filePath, proposalSlug: proposal.proposalSlug });
+  }
+
+  return { written, skipped, proposalsDir };
+}
+
+interface CheckRecipe {
+  title: (c: Cluster) => string;
+  checkType: StewardRuleProposal['proposedCheckType'];
+  triggerHeuristic: (c: Cluster) => string;
+  remediationGuidance: (c: Cluster) => string;
+}
+
+/**
+ * Routing table from classification token to a default check recipe.
+ *
+ * The recipes are intentionally conservative — they describe what
+ * Steward could detect mechanically (e.g. CI status post-merge), not
+ * the deeper semantic interpretation. Operator picks up the semantic
+ * step when promoting the proposal.
+ */
+function checkRecipeFor(classification: string): CheckRecipe {
+  switch (classification) {
+    case 'prematurecompletion':
+      return {
+        title: (c) => `block premature-completion for ${c.topicSlug}`,
+        checkType: 'post-merge',
+        triggerHeuristic: () =>
+          [
+            '- After a PR merges, watch the canonical CI run on the merge commit.',
+            '- If the same job class fails on the merge commit, classify as PrematureCompletion and surface as a high-priority Steward alert.',
+            '- Bonus: refuse to mark the next PR\'s Stage-6 (Test+integrate) green until the failing job class has been fixed locally.'
+          ].join('\n'),
+        remediationGuidance: () =>
+          [
+            'Run the failing job class locally before declaring a PR ready. If it\'s an integration / e2e job that\'s expensive locally, at least run the unit test that exercises the same code path. PR-claimed-done while CI is red on the merge commit is a Stage-6 failure of the 6-stage DoD — re-do Stage 6 (test+integrate) before merging anything that touches the same code path.'
+          ].join('\n')
+      };
+    case 'relitigation':
+      return {
+        title: (c) => `block re-litigation of ${c.topicSlug}`,
+        checkType: 'pre-merge',
+        triggerHeuristic: () =>
+          [
+            '- Pre-send / pre-merge: scan PR descriptions, commit messages, and Mentor-emitted proposals for "security finding", "should be rotated", "credential leak", or related re-litigation phrasing on topics already settled in `feedback_pat_topic.md` (or whatever feedback file is the canonical authority).',
+            '- If the topic has a settled feedback entry within memoryDir, surface that entry as a hard block on the agent\'s output until acknowledged.'
+          ].join('\n'),
+        remediationGuidance: () =>
+          [
+            'Consult the relevant `feedback_*.md` BEFORE proposing a security finding or topic re-evaluation. Re-litigation is the explicit failure mode the Mentor pre-spawn injection (Phase 3) was built to prevent — if a re-litigation incident still leaks through, treat it as a defect in the prepend hook coverage, not a fresh classification problem.'
+          ].join('\n')
+      };
+    case 'decisionclassifierviolation':
+      return {
+        title: (c) => `block decision-classifier violations for ${c.topicSlug}`,
+        checkType: 'pre-merge',
+        triggerHeuristic: () =>
+          [
+            '- Pre-send mechanical scan of agent output for "want me to / should I / your call" phrasing on technical matters.',
+            '- Refuse the message; require the agent to decide → execute → inform per `feedback_decision_classifier.md`.'
+          ].join('\n'),
+        remediationGuidance: () =>
+          [
+            'On technical matters Mentor + every agent must decide and act, not present options. Operator-decision boundaries (architecture / product pivots) are the only exception, and those are explicitly enumerated in `feedback_autonomous_operation.md`.'
+          ].join('\n')
+      };
+    case 'coordinationfailure':
+    case 'gitbranchhygienefailure':
+      return {
+        title: (c) => `block ${classification} for ${c.topicSlug}`,
+        checkType: 'cron',
+        triggerHeuristic: () =>
+          [
+            '- Daily cron sweep: detect orphan branches, never-merged stashes, worktree-count-over-cap, force-push activity outside expected branches.',
+            '- If any condition trips, file a daily Steward alert until cleared.'
+          ].join('\n'),
+        remediationGuidance: () =>
+          [
+            'Cap concurrent worktrees ≤ 8; cap concurrent substantial Mac-targeted tasks ≤ 2 unless the operator explicitly authorises more. Memory: leg-3 chaos audit (51 tasks, 1,477 mac_mcp timeouts/hour, 41 worktrees at peak) is the canonical cautionary tale.'
+          ].join('\n')
+      };
+    case 'unclassified':
+      return {
+        title: (c) => `manual review needed for ${c.topicSlug} cluster`,
+        checkType: 'unclassified',
+        triggerHeuristic: () =>
+          [
+            '- Unclassified cluster — Mentor\'s automatic taxonomy did not assign a primary failure mode.',
+            '- Operator must skim 2-3 evidence entries and decide:',
+            '  1. Add a new classification to the taxonomy (`mentor_agent_directive.md` ## Failure-mode taxonomy) and re-run the proposer, OR',
+            '  2. Mark the cluster as noise and let it age out, OR',
+            '  3. Hand-write the trigger heuristic + check type in this proposal.'
+          ].join('\n'),
+        remediationGuidance: () =>
+          [
+            'Unclassified clusters are usually a sign that the failure-mode taxonomy is missing a category. Adding a category is preferable to letting clusters fester at "unclassified", because the next pre-spawn injection won\'t surface useful warnings without a category routing.'
+          ].join('\n')
+      };
+    default:
+      return {
+        title: (c) => `${classification} cluster — ${c.topicSlug}`,
+        checkType: 'unclassified',
+        triggerHeuristic: () =>
+          [
+            `- Mentor's classification recipe table does not yet have an entry for \`${classification}\`.`,
+            '- Operator should pick up the semantic interpretation manually and add a recipe in a follow-up PR.'
+          ].join('\n'),
+        remediationGuidance: () =>
+          [
+            `Add a \`case '${classification}':\` entry under \`checkRecipeFor()\` in \`packages/mentor-retrieval/src/steward-rule-proposer.ts\` so future runs of this proposer have a meaningful default to suggest.`
+          ].join('\n')
+      };
+  }
+}
+
+function slimEvidence(m: ProposalMetadata): {
+  sourcePath: string;
+  rawSlug: string;
+  timestampIso: string;
+} {
+  return {
+    sourcePath: m.sourcePath,
+    rawSlug: m.rawSlug,
+    timestampIso: new Date(m.timestampMs).toISOString()
+  };
+}

--- a/packages/mentor-retrieval/tests/propose-steward-rule-cli.test.ts
+++ b/packages/mentor-retrieval/tests/propose-steward-rule-cli.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for caia-mentor-propose-steward-rule (Phase-4 PR-2 CLI).
+ */
+
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { main, parseArgs } from '../src/propose-steward-rule-cli.js';
+import { vectorToBlob } from '../src/embed.js';
+import { openIndexStore } from '../src/index-store.js';
+import type { IndexedLesson } from '../src/types.js';
+
+interface CapturedIo {
+  stdout: string[];
+  stderr: string[];
+  exitCode: number | null;
+}
+
+class ExitSignal extends Error {
+  constructor(public code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+function captureRun(): {
+  io: CapturedIo;
+  stdout: (s: string) => void;
+  stderr: (s: string) => void;
+  exit: (code: number) => never;
+} {
+  const io: CapturedIo = { stdout: [], stderr: [], exitCode: null };
+  return {
+    io,
+    stdout: (s: string) => io.stdout.push(s),
+    stderr: (s: string) => io.stderr.push(s),
+    exit: ((code: number): never => {
+      io.exitCode = code;
+      throw new ExitSignal(code);
+    }) as (code: number) => never
+  };
+}
+
+async function runMain(
+  argv: string[],
+  env: NodeJS.ProcessEnv = {}
+): Promise<CapturedIo> {
+  const cap = captureRun();
+  try {
+    await main({
+      argv,
+      env,
+      stdout: cap.stdout,
+      stderr: cap.stderr,
+      exit: cap.exit
+    });
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  }
+  return cap.io;
+}
+
+function seedProposal(
+  store: ReturnType<typeof openIndexStore>,
+  slug: string
+): void {
+  const lesson: Omit<IndexedLesson, 'id'> = {
+    sourcePath: `/fake/${slug}.md`,
+    kind: 'proposal',
+    slug,
+    mtimeMs: 0,
+    contentSha256: 'x',
+    contentSnippet: '',
+    embeddingDim: 1,
+    embedding: vectorToBlob(new Float32Array([1])),
+    indexedAtMs: 0
+  };
+  store.upsertLesson(lesson);
+}
+
+describe('parseArgs', () => {
+  it('defaults to threshold=3 / json / no force / no include-bursts', () => {
+    const p = parseArgs(['list'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.subcommand).toBe('list');
+    expect(p.threshold).toBe(3);
+    expect(p.format).toBe('json');
+    expect(p.force).toBe(false);
+    expect(p.includeBursts).toBe(false);
+  });
+  it('reads write subcommand', () => {
+    const p = parseArgs(['write'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.subcommand).toBe('write');
+  });
+  it('reads --force', () => {
+    const p = parseArgs(['write', '--force'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.force).toBe(true);
+  });
+  it('reads --include-bursts', () => {
+    const p = parseArgs(['list', '--include-bursts'], {
+      CAIA_MEMORY_DIR: '/m'
+    });
+    expect(p.includeBursts).toBe(true);
+  });
+  it('throws on unknown subcommand', () => {
+    expect(() => parseArgs(['frobnicate'], {})).toThrow(/unknown subcommand/);
+  });
+  it('throws on bad threshold', () => {
+    expect(() => parseArgs(['list', '--threshold', 'abc'], {})).toThrow(
+      /positive integer/
+    );
+  });
+  it('throws on missing subcommand', () => {
+    expect(() => parseArgs([], {})).toThrow(/subcommand/);
+  });
+  it('throws on bad format', () => {
+    expect(() => parseArgs(['list', '--format', 'csv'], {})).toThrow(
+      /text\|json/
+    );
+  });
+});
+
+describe('main list', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-rule-cli-'));
+  });
+  afterEach(() => {
+    /* tmpdir auto-cleaned */
+  });
+
+  it('returns empty proposals when no systemic clusters exist', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    seedProposal(store, '20260505-100100-decisionclassifierviolation-bar');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir]);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      count: number;
+      proposals: unknown[];
+    };
+    expect(out.count).toBe(0);
+  });
+
+  it('skips burst clusters by default', async () => {
+    // A burst cluster: 4 events all within 60s.
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-burst-x');
+    seedProposal(store, '20260505-100010-prematurecompletion-burst-x-2');
+    seedProposal(store, '20260505-100020-prematurecompletion-burst-x-3');
+    seedProposal(store, '20260505-100030-prematurecompletion-burst-x-4');
+    store.close();
+
+    const io = await runMain(['list', '--memory', memoryDir]);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as { count: number };
+    expect(out.count).toBe(0);
+  });
+
+  it('--include-bursts exposes burst clusters', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-burst-x');
+    seedProposal(store, '20260505-100010-prematurecompletion-burst-x-2');
+    seedProposal(store, '20260505-100020-prematurecompletion-burst-x-3');
+    store.close();
+
+    const io = await runMain([
+      'list',
+      '--memory',
+      memoryDir,
+      '--include-bursts'
+    ]);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as { count: number };
+    expect(out.count).toBe(1);
+  });
+
+  it('emits markdown when --format text', async () => {
+    const store = openIndexStore({ memoryDir });
+    // Sustained (non-burst) cluster — events span >1h.
+    seedProposal(store, '20260505-100000-prematurecompletion-sustained-x');
+    seedProposal(store, '20260505-130000-prematurecompletion-sustained-x-2');
+    seedProposal(store, '20260506-100000-prematurecompletion-sustained-x-3');
+    store.close();
+
+    const io = await runMain([
+      'list',
+      '--memory',
+      memoryDir,
+      '--format',
+      'text'
+    ]);
+    expect(io.exitCode).toBe(0);
+    const out = io.stdout.join('\n');
+    expect(out).toMatch(/type: steward-rule-proposal/);
+    expect(out).toMatch(/sustained-x/);
+  });
+
+  it('exits 2 if no index DB present', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'mentor-rule-cli-empty-'));
+    const io = await runMain(['list', '--memory', empty]);
+    expect(io.exitCode).toBe(2);
+    expect(io.stderr.join('\n')).toMatch(/no index DB/);
+  });
+
+  it('help exits 0', async () => {
+    const io = await runMain(['help']);
+    expect(io.exitCode).toBe(0);
+    expect(io.stdout.join('\n')).toMatch(/caia-mentor-propose-steward-rule/);
+  });
+});
+
+describe('main write', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-rule-cli-write-'));
+  });
+  afterEach(() => {
+    /* tmpdir auto-cleaned */
+  });
+
+  it('writes proposal files for sustained systemic clusters', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-sustained-x');
+    seedProposal(store, '20260505-130000-prematurecompletion-sustained-x-2');
+    seedProposal(store, '20260506-100000-prematurecompletion-sustained-x-3');
+    store.close();
+
+    const io = await runMain(['write', '--memory', memoryDir]);
+    expect(io.exitCode).toBe(0);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      writtenCount: number;
+      skippedCount: number;
+      proposalsDir: string;
+    };
+    expect(out.writtenCount).toBe(1);
+    expect(out.skippedCount).toBe(0);
+    expect(
+      existsSync(
+        join(out.proposalsDir, 'steward-rule-prematurecompletion-sustained-x.md')
+      )
+    ).toBe(true);
+  });
+
+  it('preserves existing files when --force is not passed', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-sustained-x');
+    seedProposal(store, '20260505-130000-prematurecompletion-sustained-x-2');
+    seedProposal(store, '20260506-100000-prematurecompletion-sustained-x-3');
+    store.close();
+
+    const io1 = await runMain(['write', '--memory', memoryDir]);
+    expect(io1.exitCode).toBe(0);
+    const io2 = await runMain(['write', '--memory', memoryDir]);
+    const out2 = JSON.parse(io2.stdout.join('\n')) as {
+      writtenCount: number;
+      skippedCount: number;
+    };
+    expect(out2.writtenCount).toBe(0);
+    expect(out2.skippedCount).toBe(1);
+  });
+
+  it('overwrites with --force', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-prematurecompletion-sustained-x');
+    seedProposal(store, '20260505-130000-prematurecompletion-sustained-x-2');
+    seedProposal(store, '20260506-100000-prematurecompletion-sustained-x-3');
+    store.close();
+
+    await runMain(['write', '--memory', memoryDir]);
+    const io = await runMain(['write', '--memory', memoryDir, '--force']);
+    const out = JSON.parse(io.stdout.join('\n')) as {
+      writtenCount: number;
+      skippedCount: number;
+    };
+    expect(out.writtenCount).toBe(1);
+    expect(out.skippedCount).toBe(0);
+  });
+
+  it('exits 2 when no index DB', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'mentor-rule-cli-write-empty-'));
+    const io = await runMain(['write', '--memory', empty]);
+    expect(io.exitCode).toBe(2);
+  });
+});

--- a/packages/mentor-retrieval/tests/steward-rule-proposer.test.ts
+++ b/packages/mentor-retrieval/tests/steward-rule-proposer.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for the Mentor Phase-4 PR-2 Steward rule proposer.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  proposeStewardRule,
+  renderStewardRuleProposalMarkdown,
+  writeStewardRuleProposals
+} from '../src/steward-rule-proposer.js';
+import type { Cluster, ProposalMetadata } from '../src/cluster.js';
+
+function fakeMember(rawSlug: string, ts: number): ProposalMetadata {
+  return {
+    sourcePath: `/fake/${rawSlug}.md`,
+    rawSlug,
+    classification: 'unused',
+    topicSlug: 'unused',
+    timestampMs: ts
+  };
+}
+
+function fakeCluster(opts: {
+  classification: string;
+  topicSlug: string;
+  occurrences: number;
+  burst?: boolean;
+  baseTs?: number;
+  spreadMs?: number;
+}): Cluster {
+  const baseTs = opts.baseTs ?? Date.UTC(2026, 4, 5, 10, 0, 0);
+  const spreadMs = opts.spreadMs ?? (opts.burst === false ? 7 * 24 * 3600 * 1000 : 60_000);
+
+  const members: ProposalMetadata[] = [];
+  for (let i = 0; i < opts.occurrences; i++) {
+    const ts = baseTs + Math.floor((i * spreadMs) / Math.max(opts.occurrences - 1, 1));
+    const slug = `20260505-${String(100000 + i).padStart(6, '0')}-${opts.classification}-${opts.topicSlug}${i > 0 ? `-${i + 1}` : ''}`;
+    members.push(fakeMember(slug, ts));
+  }
+  members.sort((a, b) => a.timestampMs - b.timestampMs);
+  const firstSeenMs = members[0]!.timestampMs;
+  const lastSeenMs = members[members.length - 1]!.timestampMs;
+  return {
+    classification: opts.classification,
+    topicSlug: opts.topicSlug,
+    occurrenceCount: opts.occurrences,
+    members,
+    firstSeenMs,
+    lastSeenMs,
+    systemic: opts.occurrences >= 3,
+    burst: opts.burst ?? lastSeenMs - firstSeenMs <= 60 * 60 * 1000
+  };
+}
+
+describe('proposeStewardRule', () => {
+  it('returns a proposal with stable slug', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'pr-0-regression-after-merge',
+      occurrences: 5
+    });
+    const p = proposeStewardRule(c);
+    expect(p.proposalSlug).toBe(
+      'steward-rule-prematurecompletion-pr-0-regression-after-merge'
+    );
+    expect(p.classification).toBe('prematurecompletion');
+    expect(p.topicSlug).toBe('pr-0-regression-after-merge');
+    expect(p.occurrenceCount).toBe(5);
+  });
+
+  it('routes prematurecompletion to post-merge with relevant heuristic', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    const p = proposeStewardRule(c);
+    expect(p.proposedCheckType).toBe('post-merge');
+    expect(p.triggerHeuristic).toMatch(/CI run on the merge commit/);
+    expect(p.remediationGuidance).toMatch(/Stage-6/);
+  });
+
+  it('routes relitigation to pre-merge with feedback consultation', () => {
+    const c = fakeCluster({
+      classification: 'relitigation',
+      topicSlug: 'pat-topic',
+      occurrences: 3
+    });
+    const p = proposeStewardRule(c);
+    expect(p.proposedCheckType).toBe('pre-merge');
+    expect(p.triggerHeuristic).toMatch(/feedback_pat_topic/);
+  });
+
+  it('routes decisionclassifierviolation to pre-merge with phrase scan', () => {
+    const c = fakeCluster({
+      classification: 'decisionclassifierviolation',
+      topicSlug: 'asking-questions',
+      occurrences: 3
+    });
+    const p = proposeStewardRule(c);
+    expect(p.proposedCheckType).toBe('pre-merge');
+    expect(p.triggerHeuristic).toMatch(/want me to|should I|your call/);
+  });
+
+  it('routes coordinationfailure / gitbranchhygienefailure to cron', () => {
+    const a = proposeStewardRule(
+      fakeCluster({
+        classification: 'coordinationfailure',
+        topicSlug: 'parallel-overrun',
+        occurrences: 3
+      })
+    );
+    const b = proposeStewardRule(
+      fakeCluster({
+        classification: 'gitbranchhygienefailure',
+        topicSlug: 'orphan-branch',
+        occurrences: 3
+      })
+    );
+    expect(a.proposedCheckType).toBe('cron');
+    expect(b.proposedCheckType).toBe('cron');
+  });
+
+  it('routes unclassified explicitly with operator-prompt', () => {
+    const p = proposeStewardRule(
+      fakeCluster({
+        classification: 'unclassified',
+        topicSlug: 'foo',
+        occurrences: 3
+      })
+    );
+    expect(p.proposedCheckType).toBe('unclassified');
+    expect(p.triggerHeuristic).toMatch(/Operator must skim/);
+  });
+
+  it('falls back to unclassified for unknown classifications', () => {
+    const p = proposeStewardRule(
+      fakeCluster({
+        classification: 'xyznevergonnaknow',
+        topicSlug: 'foo',
+        occurrences: 3
+      })
+    );
+    expect(p.proposedCheckType).toBe('unclassified');
+    expect(p.triggerHeuristic).toMatch(/does not yet have an entry/);
+  });
+
+  it('preserves the cluster span + member list', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 4,
+      burst: true
+    });
+    const p = proposeStewardRule(c);
+    expect(p.spanMs).toBe(c.lastSeenMs - c.firstSeenMs);
+    expect(p.evidence).toHaveLength(4);
+    expect(p.evidence[0]?.timestampIso).toBe(new Date(c.firstSeenMs).toISOString());
+  });
+
+  it('records burst flag from the cluster', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3,
+      burst: true
+    });
+    expect(proposeStewardRule(c).burst).toBe(true);
+  });
+});
+
+describe('renderStewardRuleProposalMarkdown', () => {
+  it('produces YAML frontmatter + headings + evidence list', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    const md = renderStewardRuleProposalMarkdown(proposeStewardRule(c));
+    expect(md).toMatch(/^---\n/);
+    expect(md).toMatch(/type: steward-rule-proposal/);
+    expect(md).toMatch(/classifiedAs: prematurecompletion/);
+    expect(md).toMatch(/topicSlug: foo/);
+    expect(md).toMatch(/occurrenceCount: 3/);
+    expect(md).toMatch(/^# Steward rule proposal — /m);
+    expect(md).toMatch(/## Why/);
+    expect(md).toMatch(/## Proposed check/);
+    expect(md).toMatch(/## Evidence/);
+    expect(md).toMatch(/## How to apply/);
+  });
+
+  it('is deterministic across calls', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    const a = renderStewardRuleProposalMarkdown(proposeStewardRule(c));
+    const b = renderStewardRuleProposalMarkdown(proposeStewardRule(c));
+    expect(a).toBe(b);
+  });
+
+  it('mentions burst caveat when cluster.burst is true', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3,
+      burst: true
+    });
+    const md = renderStewardRuleProposalMarkdown(proposeStewardRule(c));
+    expect(md).toMatch(/burst.*Verify the underlying source/i);
+  });
+
+  it('mentions sustained-signal language when cluster.burst is false', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3,
+      burst: false
+    });
+    const md = renderStewardRuleProposalMarkdown(proposeStewardRule(c));
+    expect(md).toMatch(/Sustained signal/);
+  });
+});
+
+describe('writeStewardRuleProposals', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-rule-writer-'));
+  });
+  afterEach(() => {
+    // tmpdir auto-cleaned
+  });
+
+  it('writes one file per cluster under proposals/', () => {
+    const a = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    const b = fakeCluster({
+      classification: 'relitigation',
+      topicSlug: 'pat-topic',
+      occurrences: 3
+    });
+    const result = writeStewardRuleProposals([a, b], { memoryDir });
+    expect(result.written).toHaveLength(2);
+    expect(result.skipped).toHaveLength(0);
+    for (const w of result.written) {
+      expect(existsSync(w.path)).toBe(true);
+      const md = readFileSync(w.path, 'utf-8');
+      expect(md).toMatch(/type: steward-rule-proposal/);
+    }
+  });
+
+  it('creates the proposals dir if missing', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    expect(existsSync(join(memoryDir, 'proposals'))).toBe(false);
+    const result = writeStewardRuleProposals([c], { memoryDir });
+    expect(existsSync(join(memoryDir, 'proposals'))).toBe(true);
+    expect(result.proposalsDir).toBe(join(memoryDir, 'proposals'));
+  });
+
+  it('preserves existing files when force=false (default)', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    // Pre-write an "operator-edited" file.
+    const proposalsDir = join(memoryDir, 'proposals');
+    const path = join(proposalsDir, 'steward-rule-prematurecompletion-foo.md');
+    const result1 = writeStewardRuleProposals([c], { memoryDir });
+    expect(result1.written).toHaveLength(1);
+    writeFileSync(path, '# operator-edited content\n', 'utf-8');
+
+    const result2 = writeStewardRuleProposals([c], { memoryDir });
+    expect(result2.written).toHaveLength(0);
+    expect(result2.skipped).toHaveLength(1);
+    expect(result2.skipped[0]?.reason).toBe('already-exists');
+    // Operator content preserved.
+    expect(readFileSync(path, 'utf-8')).toMatch(/operator-edited/);
+  });
+
+  it('overwrites existing files when force=true', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    const result1 = writeStewardRuleProposals([c], { memoryDir });
+    const path = result1.written[0]!.path;
+    writeFileSync(path, '# operator-edited content\n', 'utf-8');
+
+    const result2 = writeStewardRuleProposals([c], { memoryDir, force: true });
+    expect(result2.written).toHaveLength(1);
+    expect(result2.skipped).toHaveLength(0);
+    expect(readFileSync(path, 'utf-8')).toMatch(/type: steward-rule-proposal/);
+  });
+
+  it('dryRun does not write but returns intended paths', () => {
+    const c = fakeCluster({
+      classification: 'prematurecompletion',
+      topicSlug: 'foo',
+      occurrences: 3
+    });
+    const result = writeStewardRuleProposals([c], { memoryDir, dryRun: true });
+    expect(result.written).toHaveLength(1);
+    expect(existsSync(result.written[0]!.path)).toBe(false);
+  });
+
+  it('handles empty cluster list as no-op', () => {
+    const result = writeStewardRuleProposals([], { memoryDir });
+    expect(result.written).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Mentor Phase 4 PR-2 — steward-rule proposer + `caia-mentor-propose-steward-rule` CLI

Builds on Phase-4 PR-1 (#335). Promotes systemic clusters into Steward gatekeeper-rule **proposals** that land under `<memoryDir>/proposals/steward-rule-<slug>.md` for operator review. No Steward source code is touched in this PR — that step (wiring the rule under `packages/steward-analyzers/`) stays operator-driven, as the directive mandates.

### What's in here

- `packages/mentor-retrieval/src/steward-rule-proposer.ts` — `proposeStewardRule()` + `renderStewardRuleProposalMarkdown()` + `writeStewardRuleProposals()`.
- `packages/mentor-retrieval/src/propose-steward-rule-cli.ts` — `caia-mentor-propose-steward-rule list|write|help`.
- `package.json` + `index.ts` — new bin + subpath export + re-exports.
- 37 new tests (19 proposer + 18 cli).

### Routing recipes shipped

| Classification | Default check phase | Trigger heuristic gist |
|---|---|---|
| `prematurecompletion` | post-merge | watch CI on the merge commit; alarm if same job class fails |
| `relitigation` | pre-merge | scan for "security finding / should be rotated" against settled feedback |
| `decisionclassifierviolation` | pre-merge | scan for "want me to / should I / your call" |
| `coordinationfailure` / `gitbranchhygienefailure` | cron | daily orphan branch / worktree cap / stash sweep |
| `unclassified` | unclassified | operator-prompted manual review |
| (unknown) | unclassified | suggests adding a recipe |

### Burst handling

By default the CLI skips burst clusters (span ≤ 1h) — the production observation is that postmerge regression bursts fire from a single watcher loop emitting 30+ duplicates within minutes. Use `--include-bursts` to override.

### Mid-leg fix

Initial PR-2 implementation had `try { … exit(0) } catch { exit(2) }` around the write subcommand. When tests inject an exit callback that throws (to short-circuit `main`), the throw was caught and re-routed through the error path. Restructured: the IO call sits inside a try; the success-path stdout + exit(0) sit outside. This is the established pattern from Phase-3 PR-3 and is captured as a Mentor seed lesson in this leg's handoff.

### Test surface

| Suite | Tests |
|---|---|
| `steward-rule-proposer.test.ts` | 19 |
| `propose-steward-rule-cli.test.ts` | 18 |

Package total: 167 → **204 tests**. Lint + typecheck + build all green; workspace filter green.

### What this PR does NOT do

- Does **not** modify Steward analyzer code.
- Does **not** auto-promote proposals — operator review required.
- Does **not** track outcome of accepted proposals — that's PR-3 (quarterly self-review).

### Stages

1-5 (this PR). Stage-6 end-to-end live verify lands on PR-3.
