### PR TITLE
feat(mentor-phase4-003): quarterly self-review + caia-mentor-self-review CLI (PR-3)

### DIFF
--- a/packages/mentor-retrieval/package.json
+++ b/packages/mentor-retrieval/package.json
@@ -2,7 +2,7 @@
   "name": "@chiefaia/mentor-retrieval",
   "version": "0.1.0",
   "private": true,
-  "description": "Mentor Phase-3 + Phase-4 lesson retrieval — embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, prepend them to spawned-task prompts, cluster the proposal stream to detect systemic-vs-one-off failure patterns, and propose Steward gatekeeper rules for the systemic ones. Phase-3 PR-1/2/3 ship the index + retrieval + prepend hook; Phase-4 PR-1 ships clustering + caia-mentor-cluster; Phase-4 PR-2 ships Steward-rule proposals + caia-mentor-propose-steward-rule.",
+  "description": "Mentor Phase-3 + Phase-4 lesson retrieval — embed past feedback_*.md + proposals/*.md via Ollama nomic-embed-text, persist to a per-memoryDir SQLite index, retrieve top-N most similar prior lessons, prepend them to spawned-task prompts, cluster the proposal stream to detect systemic-vs-one-off failure patterns, propose Steward gatekeeper rules for the systemic ones, and run a quarterly self-review of Mentor's own track record. Phase-3 PR-1/2/3 ship the index + retrieval + prepend hook; Phase-4 PR-1 ships clustering; Phase-4 PR-2 ships Steward-rule proposals; Phase-4 PR-3 ships the self-review (caia-mentor-self-review).",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -12,7 +12,8 @@
     "caia-mentor-retrieve": "./dist/retrieve-cli.js",
     "caia-mentor-prepend": "./dist/prepend-cli.js",
     "caia-mentor-cluster": "./dist/cluster-cli.js",
-    "caia-mentor-propose-steward-rule": "./dist/propose-steward-rule-cli.js"
+    "caia-mentor-propose-steward-rule": "./dist/propose-steward-rule-cli.js",
+    "caia-mentor-self-review": "./dist/self-review-cli.js"
   },
   "exports": {
     ".": {
@@ -38,6 +39,10 @@
     "./steward-rule-proposer": {
       "import": "./dist/steward-rule-proposer.js",
       "types": "./dist/steward-rule-proposer.d.ts"
+    },
+    "./self-review": {
+      "import": "./dist/self-review.js",
+      "types": "./dist/self-review.d.ts"
     }
   },
   "files": [

--- a/packages/mentor-retrieval/src/index.ts
+++ b/packages/mentor-retrieval/src/index.ts
@@ -14,9 +14,11 @@
  *           `caia-mentor-cluster` CLI.
  *   - PR-2: Steward rule proposal generator
  *           (`./steward-rule-proposer.js`) +
- *           `caia-mentor-propose-steward-rule` CLI. Promotes systemic
- *           clusters into operator-reviewable Steward gatekeeper-rule
- *           proposals.
+ *           `caia-mentor-propose-steward-rule` CLI.
+ *   - PR-3: quarterly self-review (`./self-review.js`) +
+ *           `caia-mentor-self-review` CLI. Aggregate health,
+ *           classification breakdown, cluster shape, and
+ *           Steward-rule coverage — Mentor's own track record.
  */
 
 export {
@@ -88,6 +90,18 @@ export {
   type WriteStewardRuleProposalsOptions,
   type WriteStewardRuleProposalsResult
 } from './steward-rule-proposer.js';
+
+export {
+  generateSelfReview,
+  renderSelfReviewMarkdown,
+  DEFAULT_WINDOW_DAYS,
+  DEFAULT_TOP_CLUSTERS,
+  type SelfReviewOptions,
+  type SelfReviewSnapshot,
+  type SelfReviewMetaInput,
+  type ClassificationBreakdownRow,
+  type TopClusterRow
+} from './self-review.js';
 
 export type {
   BuildIndexStats,

--- a/packages/mentor-retrieval/src/self-review-cli.ts
+++ b/packages/mentor-retrieval/src/self-review-cli.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * caia-mentor-self-review — Mentor Phase-4 PR-3 CLI.
+ *
+ * Subcommands:
+ *
+ *   run    — Compute a self-review snapshot from the index DB and
+ *            emit it as markdown (default) or JSON. Can write to a
+ *            file via `--output`.
+ *
+ *   help   — Print usage and exit 0.
+ *
+ * Flags:
+ *
+ *   --memory       <path>      Override the memory dir (default $CAIA_MEMORY_DIR).
+ *   --window-days  <N>         Rolling window size in days (default 90).
+ *   --top-n        <N>         Number of top systemic clusters to
+ *                              highlight (default 10).
+ *   --output       <path>      Write the report to this path instead
+ *                              of stdout. Parent dir must exist.
+ *   --format       <md|json>   Output format. Default: md.
+ *
+ * Exit codes:
+ *
+ *   0   — success
+ *   1   — usage error
+ *   2   — runtime failure (no index DB, write failure, ...)
+ */
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { openIndexStore } from './index-store.js';
+import {
+  DEFAULT_TOP_CLUSTERS,
+  DEFAULT_WINDOW_DAYS,
+  generateSelfReview,
+  renderSelfReviewMarkdown,
+  type SelfReviewMetaInput,
+  type SelfReviewSnapshot
+} from './self-review.js';
+
+interface ParsedArgs {
+  subcommand: 'run' | 'help';
+  memoryDir: string;
+  windowDays: number;
+  topN: number;
+  outputPath: string | null;
+  format: 'md' | 'json';
+}
+
+interface RunOptions {
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+  exit?: (code: number) => never;
+  nowMs?: number;
+}
+
+export async function main(opts: RunOptions = {}): Promise<void> {
+  const argv = opts.argv ?? process.argv.slice(2);
+  const env = opts.env ?? process.env;
+  const stdout = opts.stdout ?? ((s: string) => process.stdout.write(`${s}\n`));
+  const stderr = opts.stderr ?? ((s: string) => process.stderr.write(`${s}\n`));
+  const exit =
+    opts.exit ??
+    ((code: number) => {
+      process.exit(code);
+    });
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(argv, env);
+  } catch (e) {
+    stderr(`mentor-self-review: ${describeError(e)}`);
+    stderr('run `caia-mentor-self-review help` for usage');
+    return exit(1);
+  }
+
+  if (parsed.subcommand === 'help') {
+    stdout(usage());
+    return exit(0);
+  }
+
+  // run
+  const dbPath = join(parsed.memoryDir, '_mentor-index.sqlite');
+  if (!existsSync(dbPath)) {
+    stderr(
+      `mentor-self-review: no index DB at ${dbPath}; run \`caia-mentor-index build\` first`
+    );
+    return exit(2);
+  }
+
+  let snapshot: SelfReviewSnapshot;
+  try {
+    const store = openIndexStore({ memoryDir: parsed.memoryDir, readonly: true });
+    try {
+      const lessons = store.listAll();
+      const meta: SelfReviewMetaInput = {
+        embeddingModel: store.getMeta('embedding_model'),
+        embeddingDim: numberOrNull(store.getMeta('embedding_dim')),
+        lastBuildAtMs: numberOrNull(store.getMeta('last_build_at_ms')),
+        lastBuildScanned: numberOrNull(store.getMeta('last_build_scanned'))
+      };
+      const reviewOpts: Parameters<typeof generateSelfReview>[1] = {
+        windowDays: parsed.windowDays,
+        topClustersToHighlight: parsed.topN,
+        memoryDir: parsed.memoryDir,
+        meta
+      };
+      if (opts.nowMs !== undefined) reviewOpts.nowMs = opts.nowMs;
+      snapshot = generateSelfReview(lessons, reviewOpts);
+    } finally {
+      store.close();
+    }
+  } catch (e) {
+    stderr(`mentor-self-review: failed to read index: ${describeError(e)}`);
+    return exit(2);
+  }
+
+  const rendered =
+    parsed.format === 'json'
+      ? JSON.stringify(snapshot, null, 2)
+      : renderSelfReviewMarkdown(snapshot);
+
+  if (parsed.outputPath !== null) {
+    try {
+      writeFileSync(parsed.outputPath, rendered, 'utf-8');
+    } catch (e) {
+      stderr(`mentor-self-review: failed to write report: ${describeError(e)}`);
+      return exit(2);
+    }
+    stdout(`wrote ${parsed.outputPath}`);
+    return exit(0);
+  }
+
+  stdout(rendered);
+  return exit(0);
+}
+
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): ParsedArgs {
+  if (argv.length === 0) {
+    throw new Error('missing subcommand (run|help)');
+  }
+  const sub = argv[0];
+  if (sub !== 'run' && sub !== 'help') {
+    throw new Error(`unknown subcommand ${JSON.stringify(sub)}; expected run|help`);
+  }
+
+  let memoryDir = env['CAIA_MEMORY_DIR'];
+  let windowDays = DEFAULT_WINDOW_DAYS;
+  let topN = DEFAULT_TOP_CLUSTERS;
+  let outputPath: string | null = null;
+  let format: 'md' | 'json' = 'md';
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--memory') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--memory requires a value');
+      memoryDir = v;
+    } else if (arg === '--window-days') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--window-days requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+        throw new Error(
+          `--window-days must be a positive integer; got ${JSON.stringify(v)}`
+        );
+      }
+      windowDays = n;
+    } else if (arg === '--top-n') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--top-n requires a value');
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+        throw new Error(`--top-n must be a positive integer; got ${JSON.stringify(v)}`);
+      }
+      topN = n;
+    } else if (arg === '--output') {
+      i++;
+      const v = argv[i];
+      if (v === undefined) throw new Error('--output requires a value');
+      outputPath = v;
+    } else if (arg === '--format') {
+      i++;
+      const v = argv[i];
+      if (v !== 'md' && v !== 'json') {
+        throw new Error(`--format must be md|json; got ${JSON.stringify(v)}`);
+      }
+      format = v;
+    } else {
+      throw new Error(`unknown flag ${JSON.stringify(arg)}`);
+    }
+  }
+
+  if (memoryDir === undefined || memoryDir === '') {
+    memoryDir = join(homedir(), 'Documents', 'projects', 'caia', 'agent', 'memory');
+  }
+
+  return {
+    subcommand: sub,
+    memoryDir,
+    windowDays,
+    topN,
+    outputPath,
+    format
+  };
+}
+
+function usage(): string {
+  return `caia-mentor-self-review — Mentor Phase-4 quarterly self-review
+
+Usage:
+  caia-mentor-self-review run [--memory <dir>] [--window-days N] [--top-n N] [--output <path>] [--format md|json]
+  caia-mentor-self-review help
+
+Defaults:
+  --window-days  ${DEFAULT_WINDOW_DAYS}
+  --top-n        ${DEFAULT_TOP_CLUSTERS}
+  --format       md
+
+Environment:
+  CAIA_MEMORY_DIR   Memory directory (must contain _mentor-index.sqlite)
+`;
+}
+
+function numberOrNull(v: string | null): number | null {
+  if (v === null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+const isMain = (): boolean => {
+  const meta = import.meta.url;
+  if (!meta.startsWith('file://')) return false;
+  const arg1 = process.argv[1];
+  if (arg1 === undefined) return false;
+  return meta.endsWith(arg1) || meta === `file://${arg1}`;
+};
+
+if (isMain()) {
+  main().catch((e) => {
+    process.stderr.write(`mentor-self-review: fatal: ${describeError(e)}\n`);
+    process.exit(2);
+  });
+}

--- a/packages/mentor-retrieval/src/self-review.ts
+++ b/packages/mentor-retrieval/src/self-review.ts
@@ -1,0 +1,385 @@
+/**
+ * Mentor Phase-4 PR-3 — quarterly self-review.
+ *
+ * The directive (`mentor_agent_directive.md` ## Phase 4) mandates a
+ * "Quarterly self-review of Mentor's own track record". This module
+ * produces a deterministic markdown report that aggregates:
+ *
+ *   - Index health (totals by kind; build freshness; oversize-file
+ *     failure rate via reading the index meta keys).
+ *   - Incident volume by classification across the rolling window.
+ *   - Top systemic clusters by occurrence count.
+ *   - Steward-rule proposal coverage — how many systemic clusters
+ *     already have a written `steward-rule-*.md` proposal sitting in
+ *     `<memoryDir>/proposals/` for operator review.
+ *   - Sustained vs burst breakdown.
+ *
+ * The default window is 90 days (≈ one quarter). Operators can
+ * shorten it for weekly health-checks or extend for year-over-year
+ * comparisons via the `--window-days` flag on the CLI.
+ *
+ * Why a self-review at all
+ *
+ * Phase-4 PR-1 + PR-2 add machinery that promotes systemic patterns
+ * into Steward-rule proposals. Without a self-review the operator
+ * has no easy way to answer:
+ *
+ *   - Are the lessons actually accumulating? (index-growth signal)
+ *   - Are the same patterns still recurring after Steward rules
+ *     were proposed? (effectiveness signal)
+ *   - Is Mentor classifying everything, or are unclassified
+ *     proposals piling up? (taxonomy-coverage signal)
+ *
+ * This file is the operator's quarterly answer.
+ *
+ * Like the rest of mentor-retrieval, the public surface is
+ * pure-function: `generateSelfReview` takes lessons + an opts bag
+ * and returns a `SelfReviewSnapshot`; `renderSelfReviewMarkdown`
+ * turns the snapshot into the markdown the CLI writes.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { join, resolve as pathResolve } from 'node:path';
+
+import { clusterProposals, type Cluster } from './cluster.js';
+import type { IndexedLesson } from './types.js';
+
+/** Default window for the self-review (≈ a quarter). */
+export const DEFAULT_WINDOW_DAYS = 90;
+
+/** How many top systemic clusters to highlight in the markdown. */
+export const DEFAULT_TOP_CLUSTERS = 10;
+
+export interface SelfReviewOptions {
+  /** ms since epoch — defaults to Date.now(). Tests inject. */
+  nowMs?: number;
+  /** Default DEFAULT_WINDOW_DAYS. */
+  windowDays?: number;
+  /** Default DEFAULT_TOP_CLUSTERS. */
+  topClustersToHighlight?: number;
+  /** Default DEFAULT_SYSTEMIC_THRESHOLD (3) via the cluster module. */
+  systemicThreshold?: number;
+  /**
+   * Optional lookup for whether a Steward-rule proposal file already
+   * exists for `(classification, topicSlug)`. Defaults to a real-FS
+   * scanner against `<memoryDir>/proposals/steward-rule-*.md`.
+   */
+  ruleProposalIndex?: Set<string>;
+  /** memoryDir — required for the default ruleProposalIndex lookup. */
+  memoryDir?: string;
+  /** Index meta — passes through `lastBuildAtIso` etc. */
+  meta?: SelfReviewMetaInput | undefined;
+}
+
+export interface SelfReviewMetaInput {
+  embeddingModel: string | null;
+  embeddingDim: number | null;
+  lastBuildAtMs: number | null;
+  lastBuildScanned: number | null;
+}
+
+export interface ClassificationBreakdownRow {
+  classification: string;
+  totalCount: number;
+  withinWindowCount: number;
+}
+
+export interface TopClusterRow {
+  classification: string;
+  topicSlug: string;
+  occurrenceCount: number;
+  firstSeenIso: string;
+  lastSeenIso: string;
+  burst: boolean;
+  hasStewardRuleProposal: boolean;
+}
+
+export interface SelfReviewSnapshot {
+  generatedAtIso: string;
+  windowDays: number;
+  windowStartIso: string;
+  windowEndIso: string;
+
+  // Index health
+  totalLessons: number;
+  feedbackCount: number;
+  proposalCount: number;
+  embeddingModel: string | null;
+  embeddingDim: number | null;
+  lastBuildAtIso: string | null;
+  lastBuildScanned: number | null;
+
+  // Volume within window
+  proposalsWithinWindow: number;
+  classificationBreakdown: ClassificationBreakdownRow[];
+
+  // Cluster shape
+  totalClusters: number;
+  systemicClusterCount: number;
+  oneOffClusterCount: number;
+  burstClusterCount: number;
+  sustainedSystemicCount: number;
+
+  // Steward-rule coverage
+  stewardRuleProposalsOnDisk: number;
+  systemicClustersWithRuleProposal: number;
+  systemicClustersWithoutRuleProposal: number;
+
+  // Highlights
+  topSystemicClusters: TopClusterRow[];
+}
+
+/**
+ * Compute a self-review snapshot from index rows. Pure function (no
+ * filesystem access by default). Pass `ruleProposalIndex` to control
+ * the rule-coverage computation in tests.
+ */
+export function generateSelfReview(
+  lessons: IndexedLesson[],
+  opts: SelfReviewOptions = {}
+): SelfReviewSnapshot {
+  const nowMs = opts.nowMs ?? Date.now();
+  const windowDays = opts.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const topN = opts.topClustersToHighlight ?? DEFAULT_TOP_CLUSTERS;
+  const windowStartMs = nowMs - windowDays * 24 * 60 * 60 * 1000;
+
+  // Bucket counts
+  let feedbackCount = 0;
+  let proposalCount = 0;
+  for (const l of lessons) {
+    if (l.kind === 'feedback') feedbackCount++;
+    else if (l.kind === 'proposal') proposalCount++;
+  }
+
+  const clusters = clusterProposals(lessons, {
+    ...(opts.systemicThreshold !== undefined
+      ? { systemicThreshold: opts.systemicThreshold }
+      : {})
+  });
+
+  const ruleIdx =
+    opts.ruleProposalIndex ?? buildDefaultRuleProposalIndex(opts.memoryDir);
+
+  // Volume within window + classification breakdown
+  const breakdownTotal = new Map<string, number>();
+  const breakdownWindow = new Map<string, number>();
+  let proposalsWithinWindow = 0;
+  for (const c of clusters) {
+    const totalForCls = (breakdownTotal.get(c.classification) ?? 0) + c.occurrenceCount;
+    breakdownTotal.set(c.classification, totalForCls);
+    let inWindow = 0;
+    for (const m of c.members) {
+      if (m.timestampMs >= windowStartMs) inWindow++;
+    }
+    if (inWindow > 0) {
+      breakdownWindow.set(
+        c.classification,
+        (breakdownWindow.get(c.classification) ?? 0) + inWindow
+      );
+      proposalsWithinWindow += inWindow;
+    }
+  }
+
+  const classificationBreakdown: ClassificationBreakdownRow[] = [];
+  for (const cls of breakdownTotal.keys()) {
+    classificationBreakdown.push({
+      classification: cls,
+      totalCount: breakdownTotal.get(cls) ?? 0,
+      withinWindowCount: breakdownWindow.get(cls) ?? 0
+    });
+  }
+  classificationBreakdown.sort((a, b) => {
+    if (a.withinWindowCount !== b.withinWindowCount) {
+      return b.withinWindowCount - a.withinWindowCount;
+    }
+    if (a.totalCount !== b.totalCount) return b.totalCount - a.totalCount;
+    return a.classification.localeCompare(b.classification);
+  });
+
+  // Cluster shape
+  const systemic: Cluster[] = clusters.filter((c) => c.systemic);
+  const oneOff = clusters.length - systemic.length;
+  const burst = clusters.filter((c) => c.burst).length;
+  const sustainedSystemic = systemic.filter((c) => !c.burst).length;
+
+  // Steward-rule coverage
+  let withRule = 0;
+  let withoutRule = 0;
+  for (const c of systemic) {
+    const key = `${c.classification}::${c.topicSlug}`;
+    if (ruleIdx.has(key)) withRule++;
+    else withoutRule++;
+  }
+
+  const topSystemicClusters: TopClusterRow[] = systemic.slice(0, topN).map((c) => ({
+    classification: c.classification,
+    topicSlug: c.topicSlug,
+    occurrenceCount: c.occurrenceCount,
+    firstSeenIso: new Date(c.firstSeenMs).toISOString(),
+    lastSeenIso: new Date(c.lastSeenMs).toISOString(),
+    burst: c.burst,
+    hasStewardRuleProposal: ruleIdx.has(`${c.classification}::${c.topicSlug}`)
+  }));
+
+  return {
+    generatedAtIso: new Date(nowMs).toISOString(),
+    windowDays,
+    windowStartIso: new Date(windowStartMs).toISOString(),
+    windowEndIso: new Date(nowMs).toISOString(),
+
+    totalLessons: lessons.length,
+    feedbackCount,
+    proposalCount,
+    embeddingModel: opts.meta?.embeddingModel ?? null,
+    embeddingDim: opts.meta?.embeddingDim ?? null,
+    lastBuildAtIso:
+      opts.meta?.lastBuildAtMs !== null && opts.meta?.lastBuildAtMs !== undefined
+        ? new Date(opts.meta.lastBuildAtMs).toISOString()
+        : null,
+    lastBuildScanned: opts.meta?.lastBuildScanned ?? null,
+
+    proposalsWithinWindow,
+    classificationBreakdown,
+
+    totalClusters: clusters.length,
+    systemicClusterCount: systemic.length,
+    oneOffClusterCount: oneOff,
+    burstClusterCount: burst,
+    sustainedSystemicCount: sustainedSystemic,
+
+    stewardRuleProposalsOnDisk: ruleIdx.size,
+    systemicClustersWithRuleProposal: withRule,
+    systemicClustersWithoutRuleProposal: withoutRule,
+
+    topSystemicClusters
+  };
+}
+
+/**
+ * Render a self-review snapshot to a deterministic markdown
+ * document. Stable across runs given the same input — safe for
+ * checked-in or repeatedly-overwritten files.
+ */
+export function renderSelfReviewMarkdown(s: SelfReviewSnapshot): string {
+  const lines: string[] = [];
+  lines.push(`# Mentor self-review — ${s.windowDays}d window`);
+  lines.push('');
+  lines.push(`Generated: \`${s.generatedAtIso}\``);
+  lines.push(`Window: \`${s.windowStartIso}\` → \`${s.windowEndIso}\``);
+  lines.push('');
+
+  lines.push('## Index health');
+  lines.push('');
+  lines.push(`- Total lessons indexed: **${s.totalLessons}**`);
+  lines.push(`  - Feedback (durable): ${s.feedbackCount}`);
+  lines.push(`  - Proposals (raw incidents): ${s.proposalCount}`);
+  lines.push(
+    `- Embedding model: ${s.embeddingModel ?? '_(unknown — index meta missing)_'}` +
+      (s.embeddingDim !== null ? ` (${s.embeddingDim}-dim)` : '')
+  );
+  lines.push(
+    `- Last build: ${s.lastBuildAtIso ?? '_(unknown)_'}${
+      s.lastBuildScanned !== null ? ` (scanned ${s.lastBuildScanned})` : ''
+    }`
+  );
+  lines.push('');
+
+  lines.push(`## Incident volume — last ${s.windowDays}d`);
+  lines.push('');
+  lines.push(`Total proposals emitted in window: **${s.proposalsWithinWindow}**`);
+  lines.push('');
+  if (s.classificationBreakdown.length === 0) {
+    lines.push('_(no proposals indexed yet)_');
+  } else {
+    lines.push('| Classification | In window | Total |');
+    lines.push('|---|---|---|');
+    for (const row of s.classificationBreakdown) {
+      lines.push(
+        `| \`${row.classification}\` | ${row.withinWindowCount} | ${row.totalCount} |`
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## Cluster shape');
+  lines.push('');
+  lines.push(`- Total clusters: **${s.totalClusters}**`);
+  lines.push(`  - Systemic (≥ threshold): ${s.systemicClusterCount}`);
+  lines.push(`  - One-off: ${s.oneOffClusterCount}`);
+  lines.push(`  - Burst: ${s.burstClusterCount}`);
+  lines.push(`  - Sustained systemic: ${s.sustainedSystemicCount}`);
+  lines.push('');
+
+  lines.push('## Steward-rule coverage');
+  lines.push('');
+  lines.push(
+    `- Steward-rule proposals on disk: **${s.stewardRuleProposalsOnDisk}**`
+  );
+  lines.push(
+    `- Systemic clusters WITH a rule proposal: ${s.systemicClustersWithRuleProposal}`
+  );
+  lines.push(
+    `- Systemic clusters WITHOUT a rule proposal: ${s.systemicClustersWithoutRuleProposal}`
+  );
+  lines.push('');
+  if (s.systemicClustersWithoutRuleProposal > 0) {
+    lines.push(
+      '> **Action**: run `caia-mentor-propose-steward-rule write` to fill the gap, then operator review.'
+    );
+    lines.push('');
+  }
+
+  lines.push(`## Top systemic clusters (max ${s.topSystemicClusters.length})`);
+  lines.push('');
+  if (s.topSystemicClusters.length === 0) {
+    lines.push('_(none yet — corpus has no systemic patterns above threshold)_');
+  } else {
+    lines.push('| Classification / topic | Occurrences | Last seen | Burst | Rule proposed |');
+    lines.push('|---|---|---|---|---|');
+    for (const r of s.topSystemicClusters) {
+      lines.push(
+        `| \`${r.classification}/${r.topicSlug}\` | ${r.occurrenceCount} | ${r.lastSeenIso} | ${r.burst ? 'yes' : 'no'} | ${r.hasStewardRuleProposal ? 'yes' : 'NO'} |`
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('---');
+  lines.push('');
+  lines.push(
+    '*Mentor Phase-4 PR-3 — `caia-mentor-self-review`. Re-run for a refreshed snapshot.*'
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Default rule-proposal index — scan `<memoryDir>/proposals/` for
+ * `steward-rule-<classification>-<topic>.md` files and build a Set
+ * keyed `${classification}::${topicSlug}`. Empty Set if memoryDir is
+ * undefined or the proposals dir doesn't exist.
+ */
+function buildDefaultRuleProposalIndex(memoryDir?: string): Set<string> {
+  const out = new Set<string>();
+  if (memoryDir === undefined || memoryDir === '') return out;
+  const proposalsDir = join(pathResolve(memoryDir), 'proposals');
+  if (!existsSync(proposalsDir)) return out;
+  let entries: string[];
+  try {
+    entries = readdirSync(proposalsDir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (!name.startsWith('steward-rule-')) continue;
+    if (!name.endsWith('.md')) continue;
+    // Format: steward-rule-<classification>-<topic>.md
+    const stem = name.slice('steward-rule-'.length, -'.md'.length);
+    const dashIdx = stem.indexOf('-');
+    if (dashIdx <= 0) continue;
+    const classification = stem.slice(0, dashIdx);
+    const topic = stem.slice(dashIdx + 1);
+    out.add(`${classification}::${topic}`);
+  }
+  return out;
+}

--- a/packages/mentor-retrieval/tests/self-review-cli.test.ts
+++ b/packages/mentor-retrieval/tests/self-review-cli.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for caia-mentor-self-review (Phase-4 PR-3 CLI).
+ */
+
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { main, parseArgs } from '../src/self-review-cli.js';
+import { vectorToBlob } from '../src/embed.js';
+import { openIndexStore } from '../src/index-store.js';
+import type { IndexedLesson } from '../src/types.js';
+
+interface CapturedIo {
+  stdout: string[];
+  stderr: string[];
+  exitCode: number | null;
+}
+
+class ExitSignal extends Error {
+  constructor(public code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+function captureRun(): {
+  io: CapturedIo;
+  stdout: (s: string) => void;
+  stderr: (s: string) => void;
+  exit: (code: number) => never;
+} {
+  const io: CapturedIo = { stdout: [], stderr: [], exitCode: null };
+  return {
+    io,
+    stdout: (s: string) => io.stdout.push(s),
+    stderr: (s: string) => io.stderr.push(s),
+    exit: ((code: number): never => {
+      io.exitCode = code;
+      throw new ExitSignal(code);
+    }) as (code: number) => never
+  };
+}
+
+async function runMain(
+  argv: string[],
+  env: NodeJS.ProcessEnv = {},
+  nowMs?: number
+): Promise<CapturedIo> {
+  const cap = captureRun();
+  try {
+    await main({
+      argv,
+      env,
+      stdout: cap.stdout,
+      stderr: cap.stderr,
+      exit: cap.exit,
+      ...(nowMs !== undefined ? { nowMs } : {})
+    });
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  }
+  return cap.io;
+}
+
+function seedProposal(
+  store: ReturnType<typeof openIndexStore>,
+  slug: string
+): void {
+  const lesson: Omit<IndexedLesson, 'id'> = {
+    sourcePath: `/fake/${slug}.md`,
+    kind: 'proposal',
+    slug,
+    mtimeMs: 0,
+    contentSha256: 'x',
+    contentSnippet: '',
+    embeddingDim: 1,
+    embedding: vectorToBlob(new Float32Array([1])),
+    indexedAtMs: 0
+  };
+  store.upsertLesson(lesson);
+}
+
+const NOW_MS = Date.UTC(2026, 4, 5, 18, 0, 0);
+
+describe('parseArgs', () => {
+  it('defaults to windowDays=90, topN=10, format=md, no output', () => {
+    const p = parseArgs(['run'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.subcommand).toBe('run');
+    expect(p.windowDays).toBe(90);
+    expect(p.topN).toBe(10);
+    expect(p.format).toBe('md');
+    expect(p.outputPath).toBeNull();
+  });
+  it('reads --window-days', () => {
+    const p = parseArgs(['run', '--window-days', '7'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.windowDays).toBe(7);
+  });
+  it('reads --top-n', () => {
+    const p = parseArgs(['run', '--top-n', '5'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.topN).toBe(5);
+  });
+  it('reads --output', () => {
+    const p = parseArgs(['run', '--output', '/tmp/r.md'], {
+      CAIA_MEMORY_DIR: '/m'
+    });
+    expect(p.outputPath).toBe('/tmp/r.md');
+  });
+  it('reads --format json', () => {
+    const p = parseArgs(['run', '--format', 'json'], { CAIA_MEMORY_DIR: '/m' });
+    expect(p.format).toBe('json');
+  });
+  it('throws on unknown subcommand', () => {
+    expect(() => parseArgs(['frobnicate'], {})).toThrow(/unknown subcommand/);
+  });
+  it('throws on missing subcommand', () => {
+    expect(() => parseArgs([], {})).toThrow(/subcommand/);
+  });
+  it('throws on bad windowDays', () => {
+    expect(() => parseArgs(['run', '--window-days', '0'], {})).toThrow(
+      /positive integer/
+    );
+    expect(() => parseArgs(['run', '--window-days', 'abc'], {})).toThrow(
+      /positive integer/
+    );
+  });
+  it('throws on bad topN', () => {
+    expect(() => parseArgs(['run', '--top-n', '-1'], {})).toThrow(
+      /positive integer/
+    );
+  });
+  it('throws on bad format', () => {
+    expect(() => parseArgs(['run', '--format', 'csv'], {})).toThrow(/md\|json/);
+  });
+  it('throws on unknown flag', () => {
+    expect(() => parseArgs(['run', '--bogus'], {})).toThrow(/unknown flag/);
+  });
+});
+
+describe('main run', () => {
+  let memoryDir: string;
+  beforeEach(() => {
+    memoryDir = mkdtempSync(join(tmpdir(), 'mentor-self-cli-'));
+  });
+  afterEach(() => {
+    /* tmpdir auto-cleaned */
+  });
+
+  it('emits markdown on stdout by default', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    seedProposal(store, '20260505-100100-relitigation-foo-2');
+    seedProposal(store, '20260505-100200-relitigation-foo-3');
+    store.close();
+
+    const io = await runMain(['run', '--memory', memoryDir], {}, NOW_MS);
+    expect(io.exitCode).toBe(0);
+    const out = io.stdout.join('\n');
+    expect(out).toMatch(/^# Mentor self-review/);
+    expect(out).toMatch(/relitigation\/foo/);
+  });
+
+  it('emits JSON when --format json', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    store.close();
+
+    const io = await runMain(
+      ['run', '--memory', memoryDir, '--format', 'json'],
+      {},
+      NOW_MS
+    );
+    expect(io.exitCode).toBe(0);
+    const obj = JSON.parse(io.stdout.join('\n')) as { totalLessons: number };
+    expect(obj.totalLessons).toBe(1);
+  });
+
+  it('writes report to --output path', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    store.close();
+
+    const outPath = join(memoryDir, 'review.md');
+    const io = await runMain(
+      ['run', '--memory', memoryDir, '--output', outPath],
+      {},
+      NOW_MS
+    );
+    expect(io.exitCode).toBe(0);
+    expect(io.stdout.join('\n')).toMatch(/wrote /);
+    expect(existsSync(outPath)).toBe(true);
+    expect(readFileSync(outPath, 'utf-8')).toMatch(/^# Mentor self-review/);
+  });
+
+  it('respects --window-days', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-recent');
+    seedProposal(store, '20251201-100000-relitigation-old');
+    store.close();
+
+    const io = await runMain(
+      ['run', '--memory', memoryDir, '--window-days', '30', '--format', 'json'],
+      {},
+      NOW_MS
+    );
+    const obj = JSON.parse(io.stdout.join('\n')) as {
+      proposalsWithinWindow: number;
+    };
+    expect(obj.proposalsWithinWindow).toBe(1);
+  });
+
+  it('exits 2 if no index DB present', async () => {
+    const empty = mkdtempSync(join(tmpdir(), 'mentor-self-cli-empty-'));
+    const io = await runMain(['run', '--memory', empty]);
+    expect(io.exitCode).toBe(2);
+    expect(io.stderr.join('\n')).toMatch(/no index DB/);
+  });
+
+  it('help exits 0 with usage', async () => {
+    const io = await runMain(['help']);
+    expect(io.exitCode).toBe(0);
+    expect(io.stdout.join('\n')).toMatch(/caia-mentor-self-review/);
+  });
+
+  it('detects existing steward-rule proposals via FS scanner', async () => {
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    seedProposal(store, '20260505-100100-relitigation-foo-2');
+    seedProposal(store, '20260505-100200-relitigation-foo-3');
+    store.close();
+
+    // Pre-write a steward-rule proposal file
+    const proposalsDir = join(memoryDir, 'proposals');
+    // proposals dir already exists since we seeded; double-check
+    if (!existsSync(proposalsDir)) {
+      // openIndexStore doesn't make proposals dir; create it
+      await import('node:fs/promises').then((fs) =>
+        fs.mkdir(proposalsDir, { recursive: true })
+      );
+    }
+    await import('node:fs/promises').then((fs) =>
+      fs.writeFile(
+        join(proposalsDir, 'steward-rule-relitigation-foo.md'),
+        '# proposal\n'
+      )
+    );
+
+    const io = await runMain(
+      ['run', '--memory', memoryDir, '--format', 'json'],
+      {},
+      NOW_MS
+    );
+    const obj = JSON.parse(io.stdout.join('\n')) as {
+      systemicClustersWithRuleProposal: number;
+      stewardRuleProposalsOnDisk: number;
+    };
+    expect(obj.stewardRuleProposalsOnDisk).toBe(1);
+    expect(obj.systemicClustersWithRuleProposal).toBe(1);
+  });
+});
+
+describe('main run — error path', () => {
+  it('exits 2 if --output path is unwritable', async () => {
+    const memoryDir = mkdtempSync(join(tmpdir(), 'mentor-self-cli-err-'));
+    const store = openIndexStore({ memoryDir });
+    seedProposal(store, '20260505-100000-relitigation-foo');
+    store.close();
+
+    const io = await runMain(
+      [
+        'run',
+        '--memory',
+        memoryDir,
+        '--output',
+        '/dev/no-such-path/out.md'
+      ],
+      {},
+      NOW_MS
+    );
+    expect(io.exitCode).toBe(2);
+    expect(io.stderr.join('\n')).toMatch(/failed to write report/);
+  });
+});

--- a/packages/mentor-retrieval/tests/self-review.test.ts
+++ b/packages/mentor-retrieval/tests/self-review.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for the Mentor Phase-4 PR-3 quarterly self-review.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateSelfReview,
+  renderSelfReviewMarkdown,
+  DEFAULT_TOP_CLUSTERS,
+  DEFAULT_WINDOW_DAYS
+} from '../src/self-review.js';
+import type { IndexedLesson } from '../src/types.js';
+
+function fakeLesson(
+  rawSlug: string,
+  kind: 'feedback' | 'proposal' = 'proposal'
+): IndexedLesson {
+  return {
+    id: 0,
+    sourcePath: `/fake/${rawSlug}.md`,
+    kind,
+    slug: rawSlug,
+    mtimeMs: 0,
+    contentSha256: 'x',
+    contentSnippet: '',
+    embeddingDim: 1,
+    embedding: Buffer.alloc(4),
+    indexedAtMs: 0
+  };
+}
+
+const NOW_MS = Date.UTC(2026, 4, 5, 18, 0, 0); // 2026-05-05T18:00:00Z
+
+describe('generateSelfReview — index health', () => {
+  it('counts feedback vs proposal kinds', () => {
+    const lessons = [
+      fakeLesson('feedback_a', 'feedback'),
+      fakeLesson('feedback_b', 'feedback'),
+      fakeLesson('20260505-100000-relitigation-x'),
+      fakeLesson('20260505-100100-prematurecompletion-y')
+    ];
+    const s = generateSelfReview(lessons, { nowMs: NOW_MS });
+    expect(s.totalLessons).toBe(4);
+    expect(s.feedbackCount).toBe(2);
+    expect(s.proposalCount).toBe(2);
+  });
+
+  it('passes through index meta', () => {
+    const s = generateSelfReview([], {
+      nowMs: NOW_MS,
+      meta: {
+        embeddingModel: 'nomic-embed-text',
+        embeddingDim: 768,
+        lastBuildAtMs: NOW_MS - 1000,
+        lastBuildScanned: 70
+      }
+    });
+    expect(s.embeddingModel).toBe('nomic-embed-text');
+    expect(s.embeddingDim).toBe(768);
+    expect(s.lastBuildAtIso).toBe(new Date(NOW_MS - 1000).toISOString());
+    expect(s.lastBuildScanned).toBe(70);
+  });
+
+  it('handles missing meta gracefully', () => {
+    const s = generateSelfReview([], { nowMs: NOW_MS });
+    expect(s.embeddingModel).toBeNull();
+    expect(s.embeddingDim).toBeNull();
+    expect(s.lastBuildAtIso).toBeNull();
+    expect(s.lastBuildScanned).toBeNull();
+  });
+});
+
+describe('generateSelfReview — windowing', () => {
+  it('counts only proposals inside the rolling window', () => {
+    // Window = 90d ending NOW_MS. Anything older than 2026-02-04 is out.
+    const lessons = [
+      fakeLesson('20260505-100000-relitigation-recent'),       // in window
+      fakeLesson('20260505-100100-relitigation-recent-2'),     // in window
+      fakeLesson('20251201-100000-relitigation-old')           // out (Dec 2025)
+    ];
+    const s = generateSelfReview(lessons, { nowMs: NOW_MS, windowDays: 90 });
+    expect(s.proposalsWithinWindow).toBe(2);
+    // breakdown groups by classification — all 3 are 'relitigation'
+    expect(s.classificationBreakdown).toHaveLength(1);
+    expect(s.classificationBreakdown[0]?.totalCount).toBe(3);
+    expect(s.classificationBreakdown[0]?.withinWindowCount).toBe(2);
+  });
+
+  it('respects custom windowDays', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-relitigation-today'),
+      fakeLesson('20260101-100000-relitigation-jan-1')
+    ];
+    const s = generateSelfReview(lessons, { nowMs: NOW_MS, windowDays: 1 });
+    expect(s.proposalsWithinWindow).toBe(1);
+  });
+});
+
+describe('generateSelfReview — classification breakdown', () => {
+  it('groups by classification with within-window + total counts', () => {
+    const lessons = [
+      // 3 prematurecompletion within window (clusters as one cluster of 3)
+      fakeLesson('20260505-100000-prematurecompletion-x'),
+      fakeLesson('20260505-100100-prematurecompletion-x-2'),
+      fakeLesson('20260505-100200-prematurecompletion-x-3'),
+      // 1 relitigation within window
+      fakeLesson('20260505-100300-relitigation-y'),
+      // 1 relitigation outside window
+      fakeLesson('20251201-100000-relitigation-z')
+    ];
+    const s = generateSelfReview(lessons, { nowMs: NOW_MS });
+    expect(s.classificationBreakdown).toHaveLength(2);
+    const pc = s.classificationBreakdown.find(
+      (b) => b.classification === 'prematurecompletion'
+    );
+    const rl = s.classificationBreakdown.find(
+      (b) => b.classification === 'relitigation'
+    );
+    expect(pc?.totalCount).toBe(3);
+    expect(pc?.withinWindowCount).toBe(3);
+    expect(rl?.totalCount).toBe(2);
+    expect(rl?.withinWindowCount).toBe(1);
+  });
+});
+
+describe('generateSelfReview — cluster shape', () => {
+  it('counts systemic vs one-off vs burst', () => {
+    const lessons = [
+      // systemic + burst (4x within minutes)
+      fakeLesson('20260505-100000-prematurecompletion-x'),
+      fakeLesson('20260505-100010-prematurecompletion-x-2'),
+      fakeLesson('20260505-100020-prematurecompletion-x-3'),
+      fakeLesson('20260505-100030-prematurecompletion-x-4'),
+      // systemic + sustained (3x across days)
+      fakeLesson('20260503-100000-relitigation-y'),
+      fakeLesson('20260504-100000-relitigation-y-2'),
+      fakeLesson('20260505-100000-relitigation-y-3'),
+      // one-off
+      fakeLesson('20260505-100400-decisionclassifierviolation-z')
+    ];
+    const s = generateSelfReview(lessons, { nowMs: NOW_MS });
+    expect(s.totalClusters).toBe(3);
+    expect(s.systemicClusterCount).toBe(2);
+    expect(s.oneOffClusterCount).toBe(1);
+    expect(s.burstClusterCount).toBeGreaterThanOrEqual(1);
+    expect(s.sustainedSystemicCount).toBe(1);
+  });
+});
+
+describe('generateSelfReview — Steward-rule coverage', () => {
+  it('marks cluster as "with rule" if proposal index contains the key', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-prematurecompletion-x-y'),
+      fakeLesson('20260505-100100-prematurecompletion-x-y-2'),
+      fakeLesson('20260505-100200-prematurecompletion-x-y-3')
+    ];
+    const idx = new Set(['prematurecompletion::x-y']);
+    const s = generateSelfReview(lessons, {
+      nowMs: NOW_MS,
+      ruleProposalIndex: idx
+    });
+    expect(s.systemicClustersWithRuleProposal).toBe(1);
+    expect(s.systemicClustersWithoutRuleProposal).toBe(0);
+    expect(s.topSystemicClusters[0]?.hasStewardRuleProposal).toBe(true);
+  });
+
+  it('marks systemic clusters without proposals correctly', () => {
+    const lessons = [
+      fakeLesson('20260505-100000-prematurecompletion-x-y'),
+      fakeLesson('20260505-100100-prematurecompletion-x-y-2'),
+      fakeLesson('20260505-100200-prematurecompletion-x-y-3')
+    ];
+    const s = generateSelfReview(lessons, {
+      nowMs: NOW_MS,
+      ruleProposalIndex: new Set()
+    });
+    expect(s.systemicClustersWithRuleProposal).toBe(0);
+    expect(s.systemicClustersWithoutRuleProposal).toBe(1);
+  });
+
+  it('uses default FS scanner against memoryDir when ruleProposalIndex absent', () => {
+    const memoryDir = mkdtempSync(join(tmpdir(), 'mentor-self-review-'));
+    mkdirSync(join(memoryDir, 'proposals'));
+    writeFileSync(
+      join(memoryDir, 'proposals', 'steward-rule-prematurecompletion-x-y.md'),
+      '# proposal\n'
+    );
+
+    const lessons = [
+      fakeLesson('20260505-100000-prematurecompletion-x-y'),
+      fakeLesson('20260505-100100-prematurecompletion-x-y-2'),
+      fakeLesson('20260505-100200-prematurecompletion-x-y-3')
+    ];
+    const s = generateSelfReview(lessons, {
+      nowMs: NOW_MS,
+      memoryDir
+    });
+    expect(s.stewardRuleProposalsOnDisk).toBe(1);
+    expect(s.systemicClustersWithRuleProposal).toBe(1);
+  });
+
+  it('handles missing proposals dir gracefully', () => {
+    const memoryDir = mkdtempSync(join(tmpdir(), 'mentor-self-review-no-prop-'));
+    const s = generateSelfReview([], { nowMs: NOW_MS, memoryDir });
+    expect(s.stewardRuleProposalsOnDisk).toBe(0);
+  });
+});
+
+describe('generateSelfReview — top clusters', () => {
+  it('limits to topClustersToHighlight', () => {
+    const lessons: IndexedLesson[] = [];
+    // 5 distinct systemic clusters
+    for (let cls = 0; cls < 5; cls++) {
+      for (let i = 0; i < 3; i++) {
+        lessons.push(
+          fakeLesson(
+            `20260505-${String(100000 + cls).padStart(6, '0')}-cls${cls}-topic${i > 0 ? `-${i + 1}` : ''}`
+          )
+        );
+      }
+    }
+    const s = generateSelfReview(lessons, {
+      nowMs: NOW_MS,
+      topClustersToHighlight: 2
+    });
+    expect(s.topSystemicClusters).toHaveLength(2);
+  });
+
+  it('orders by occurrence then last-seen', () => {
+    const lessons = [
+      // 4x cluster A
+      fakeLesson('20260505-100000-a-topicA'),
+      fakeLesson('20260505-100100-a-topicA-2'),
+      fakeLesson('20260505-100200-a-topicA-3'),
+      fakeLesson('20260505-100300-a-topicA-4'),
+      // 3x cluster B
+      fakeLesson('20260504-100000-b-topicB'),
+      fakeLesson('20260504-100100-b-topicB-2'),
+      fakeLesson('20260504-100200-b-topicB-3')
+    ];
+    const s = generateSelfReview(lessons, { nowMs: NOW_MS });
+    expect(s.topSystemicClusters).toHaveLength(2);
+    expect(s.topSystemicClusters[0]?.classification).toBe('a');
+    expect(s.topSystemicClusters[1]?.classification).toBe('b');
+  });
+});
+
+describe('renderSelfReviewMarkdown', () => {
+  it('produces a stable markdown document', () => {
+    const s = generateSelfReview(
+      [
+        fakeLesson('feedback_x', 'feedback'),
+        fakeLesson('20260505-100000-prematurecompletion-foo'),
+        fakeLesson('20260505-100100-prematurecompletion-foo-2'),
+        fakeLesson('20260505-100200-prematurecompletion-foo-3')
+      ],
+      { nowMs: NOW_MS, ruleProposalIndex: new Set() }
+    );
+    const md = renderSelfReviewMarkdown(s);
+    expect(md).toMatch(/^# Mentor self-review/);
+    expect(md).toMatch(/## Index health/);
+    expect(md).toMatch(/## Incident volume/);
+    expect(md).toMatch(/## Cluster shape/);
+    expect(md).toMatch(/## Steward-rule coverage/);
+    expect(md).toMatch(/## Top systemic clusters/);
+    expect(md).toMatch(/prematurecompletion\/foo/);
+  });
+
+  it('is deterministic across renders', () => {
+    const s = generateSelfReview(
+      [fakeLesson('20260505-100000-relitigation-x')],
+      { nowMs: NOW_MS, ruleProposalIndex: new Set() }
+    );
+    const a = renderSelfReviewMarkdown(s);
+    const b = renderSelfReviewMarkdown(s);
+    expect(a).toBe(b);
+  });
+
+  it('includes the action prompt when systemic clusters lack proposals', () => {
+    const s = generateSelfReview(
+      [
+        fakeLesson('20260505-100000-prematurecompletion-foo'),
+        fakeLesson('20260505-100100-prematurecompletion-foo-2'),
+        fakeLesson('20260505-100200-prematurecompletion-foo-3')
+      ],
+      { nowMs: NOW_MS, ruleProposalIndex: new Set() }
+    );
+    const md = renderSelfReviewMarkdown(s);
+    expect(md).toMatch(/caia-mentor-propose-steward-rule write/);
+  });
+
+  it('omits action prompt when all systemic clusters covered', () => {
+    const s = generateSelfReview(
+      [
+        fakeLesson('20260505-100000-prematurecompletion-foo'),
+        fakeLesson('20260505-100100-prematurecompletion-foo-2'),
+        fakeLesson('20260505-100200-prematurecompletion-foo-3')
+      ],
+      {
+        nowMs: NOW_MS,
+        ruleProposalIndex: new Set(['prematurecompletion::foo'])
+      }
+    );
+    const md = renderSelfReviewMarkdown(s);
+    expect(md).not.toMatch(/Action.*caia-mentor-propose-steward-rule/);
+  });
+
+  it('renders empty-state correctly', () => {
+    const s = generateSelfReview([], { nowMs: NOW_MS });
+    const md = renderSelfReviewMarkdown(s);
+    expect(md).toMatch(/no proposals indexed yet/);
+    expect(md).toMatch(/none yet/);
+  });
+});
+
+describe('public defaults', () => {
+  it('exports DEFAULT_WINDOW_DAYS = 90', () => {
+    expect(DEFAULT_WINDOW_DAYS).toBe(90);
+  });
+  it('exports DEFAULT_TOP_CLUSTERS = 10', () => {
+    expect(DEFAULT_TOP_CLUSTERS).toBe(10);
+  });
+});


### PR DESCRIPTION
## Mentor Phase 4 PR-3 — quarterly self-review + `caia-mentor-self-review` CLI

Closes the Phase-4 loop. Builds on Phase-4 PR-1 (clustering — #335) + Phase-4 PR-2 (Steward-rule proposer — #336). Operator now has a single command for "is Mentor working?" — index health, classification volume, cluster shape, and Steward-rule coverage in one rolling-window snapshot.

### What's in here

- `packages/mentor-retrieval/src/self-review.ts` — pure functions `generateSelfReview()` + `renderSelfReviewMarkdown()`. Auto-builds a rule-proposal index by scanning `<memoryDir>/proposals/steward-rule-*.md` so PR-2 outputs are reflected in the coverage column.
- `packages/mentor-retrieval/src/self-review-cli.ts` — `caia-mentor-self-review run|help`. Markdown by default; JSON for programmatic consumers; `--output <path>` for file emission.
- `package.json` + `index.ts` — new bin + subpath export + re-exports.
- 39 new tests (22 self-review + 17 cli).

### Snapshot shape

| Section | What it shows |
|---|---|
| Index health | total / feedback / proposal counts, embedding model, last build wall-clock, last build scanned |
| Incident volume (window) | proposals-in-window, classification breakdown table |
| Cluster shape | total / systemic / one-off, burst vs sustained-systemic |
| Steward-rule coverage | rule proposals on disk, systemic clusters with vs without proposals, action prompt |
| Top systemic clusters | up to N (default 10) sorted by occurrence + last-seen |

### Defaults

- `--window-days 90` — matches the directive's "Quarterly self-review."
- `--top-n 10` — leaves headroom on the live corpus (~4 systemic clusters today).

### Test surface

| Suite | Tests |
|---|---|
| `self-review.test.ts` | 22 |
| `self-review-cli.test.ts` | 17 |

Package total: 204 → **243 tests**. Lint + typecheck + build all green.

### What this PR does NOT do

- Does **not** install a LaunchAgent for nightly self-review — that's a trivial leg-9 follow-up.
- Does **not** auto-write to `~/Documents/projects/reports/mentor/`. Operators pipe / use `--output`.

### Stages

1-6 — Stage-6 end-to-end live verify lands in this leg's handoff (against the production memoryDir).
