### PR TITLE
feat(curator-phase2-002): pr-proposal + backlog-directive emitters (PR-2)

### DIFF
--- a/packages/curator/src/actions/backlog-directive-emitter.ts
+++ b/packages/curator/src/actions/backlog-directive-emitter.ts
@@ -1,0 +1,190 @@
+/**
+ * Curator Phase-2 — backlog-directive emitter (output mode 6).
+ *
+ * Per `agent/memory/curator_agent_directive.md`: "Backlog directives —
+ * for substantial changes (new agent, new framework adoption,
+ * architecture shift), Curator files a directive memory the same way
+ * this one was filed."
+ *
+ * The emitter writes one markdown file per directive at:
+ *
+ *   <reportsDir>/curator/backlog-directives/<slug>.md
+ *
+ * Frontmatter mirrors the existing memory-directive style (see
+ * `agent/memory/curator_agent_directive.md`, `mentor_agent_directive.md`,
+ * etc.) so once the operator approves the directive they can `mv` it
+ * straight into `agent/memory/<slug>.md` with no edits to the
+ * frontmatter — only adding the operator-supplied originSessionId
+ * (which Curator can't know).
+ *
+ * Idempotency: existing files preserved unless `force: true`. Mirrors
+ * the alarm + pr-proposal contracts.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { BacklogDirectiveAction, EmitResult } from './types.js';
+
+/** Output dir resolution: `<reportsDir>/curator/backlog-directives`. */
+export function defaultBacklogDirectivesDir(reportsDir: string): string {
+  return join(reportsDir, 'curator', 'backlog-directives');
+}
+
+/**
+ * Render a BacklogDirectiveAction as memory-directive-shaped markdown.
+ *
+ * Layout matches the existing CAIA memory directives so promotion to
+ * `agent/memory/` is one `mv` away:
+ *
+ *   ---
+ *   name: <title>
+ *   description: <summary first line>
+ *   type: curator-backlog-directive
+ *   dimension: <dimension>
+ *   effortEstimate: <small|medium|large|xlarge>
+ *   slug: <slug>
+ *   detectedAt: <iso>
+ *   sourceFindings: [...]
+ *   ---
+ *
+ *   # <title>
+ *
+ *   **Status**: BACKLOG — drafted by Curator (Phase-2 PR-2). Operator
+ *   review required before promotion to `agent/memory/`.
+ *
+ *   ## Mandate
+ *   <summary>
+ *
+ *   ## Evidence
+ *   - ...
+ *
+ *   ## Recommended action
+ *   <recommendation>
+ *
+ *   ## Promotion checklist
+ *   - [ ] Operator reviewed evidence + recommendation
+ *   - [ ] Effort estimate confirmed (current: <effort>)
+ *   - [ ] Mandate-compliance reviewed (no paid services, etc.)
+ *   - [ ] mv to `agent/memory/<slug>.md` after approval
+ */
+export function renderBacklogDirectiveMarkdown(
+  action: BacklogDirectiveAction
+): string {
+  const summaryFirstLine = firstLine(action.summary) || action.title;
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`name: ${yamlSafe(action.title)}`);
+  lines.push(`description: ${yamlSafe(summaryFirstLine)}`);
+  lines.push('type: curator-backlog-directive');
+  lines.push(`dimension: ${yamlSafe(action.dimension)}`);
+  lines.push(`effortEstimate: ${action.effortEstimate}`);
+  lines.push(`slug: ${action.slug}`);
+  lines.push(`detectedAt: ${action.detectedAt}`);
+  lines.push(`sourceFindings: [${action.sourceFindings.map((s) => `"${s}"`).join(', ')}]`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# ${action.title}`);
+  lines.push('');
+  lines.push(
+    '**Status**: BACKLOG — drafted by Curator (Phase-2 PR-2). Operator review required before promotion to `agent/memory/`.'
+  );
+  lines.push('');
+  lines.push('## Mandate');
+  lines.push('');
+  lines.push(action.summary);
+  lines.push('');
+  if (action.evidence.length > 0) {
+    lines.push('## Evidence');
+    lines.push('');
+    for (const e of action.evidence) lines.push(`- ${e}`);
+    lines.push('');
+  }
+  lines.push('## Recommended action');
+  lines.push('');
+  lines.push(action.recommendation);
+  lines.push('');
+  lines.push('## Promotion checklist');
+  lines.push('');
+  lines.push('- [ ] Operator reviewed evidence + recommendation');
+  lines.push(`- [ ] Effort estimate confirmed (current: \`${action.effortEstimate}\`)`);
+  lines.push('- [ ] Mandate-compliance reviewed (subscription-only, no paid services)');
+  lines.push(
+    '- [ ] On approval: `mv` to `agent/memory/<slug>.md` and add `originSessionId` to frontmatter'
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Options for `writeBacklogDirectives`. */
+export interface WriteBacklogDirectivesOptions {
+  /** Output directory. Defaults to `<reportsDir>/curator/backlog-directives`. */
+  outDir?: string;
+  /** Used to compute `outDir` if not passed. */
+  reportsDir?: string;
+  /** Overwrite existing files. */
+  force?: boolean;
+}
+
+/** Persist BacklogDirectiveActions to disk. Returns an EmitResult. */
+export function writeBacklogDirectives(
+  actions: BacklogDirectiveAction[],
+  opts: WriteBacklogDirectivesOptions = {}
+): EmitResult {
+  const dir = resolveDir(opts);
+  ensureDir(dir);
+
+  const written: EmitResult['written'] = [];
+  const skipped: EmitResult['skipped'] = [];
+
+  for (const action of actions) {
+    const path = join(dir, `${action.slug}.md`);
+    const exists = existsSync(path);
+    if (exists && !opts.force) {
+      skipped.push({ path, slug: action.slug, kind: 'backlog-directive' });
+      continue;
+    }
+    const md = renderBacklogDirectiveMarkdown(action);
+    if (exists && opts.force) {
+      const current = readFileSync(path, 'utf-8');
+      if (current === md) {
+        skipped.push({ path, slug: action.slug, kind: 'backlog-directive' });
+        continue;
+      }
+    }
+    writeFileSync(path, md, 'utf-8');
+    written.push({ path, slug: action.slug, kind: 'backlog-directive' });
+  }
+
+  return {
+    outputDir: dir,
+    writtenCount: written.length,
+    skippedCount: skipped.length,
+    written,
+    skipped
+  };
+}
+
+function resolveDir(opts: WriteBacklogDirectivesOptions): string {
+  if (opts.outDir !== undefined) return opts.outDir;
+  if (opts.reportsDir === undefined) {
+    throw new Error(
+      'writeBacklogDirectives: either `outDir` or `reportsDir` must be provided'
+    );
+  }
+  return defaultBacklogDirectivesDir(opts.reportsDir);
+}
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function firstLine(s: string): string {
+  const idx = s.indexOf('\n');
+  return idx === -1 ? s : s.slice(0, idx);
+}
+
+function yamlSafe(s: string): string {
+  if (/^[A-Za-z0-9 _\-./]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, "''")}'`;
+}

--- a/packages/curator/src/actions/index.ts
+++ b/packages/curator/src/actions/index.ts
@@ -7,14 +7,20 @@
  *   - `findingsToActions` — pure classifier that maps Findings to
  *     Actions per the routing rules in `classifier.ts`.
  *   - `slugify`, `actionSlugForFinding`, `classifyKind` — small
- *     helpers used by the classifier; exported so future emitters
- *     (PR-2 + PR-3) can reuse them without re-defining the rules.
+ *     helpers used by the classifier; exported so emitters and the
+ *     industry-briefing scanner (PR-3) can reuse them without
+ *     re-defining the rules.
  *   - `writeAlarms`, `renderAlarmMarkdown`, `defaultAlarmsDir` — the
  *     alarm emitter (output mode 7).
+ *   - `writePrProposals`, `renderPrProposalMarkdown`,
+ *     `defaultPrProposalsDir` — the PR-proposal emitter (output mode 5).
+ *   - `writeBacklogDirectives`, `renderBacklogDirectiveMarkdown`,
+ *     `defaultBacklogDirectivesDir` — the backlog-directive emitter
+ *     (output mode 6).
  *
- * Phase-2 PR-2 will add `writePrProposals` + `writeBacklogDirectives`.
- * Phase-2 PR-3 will add the industry-briefing scanner + a unified
- * `caia-curator act` runner that calls all four emitters in one pass.
+ * Phase-2 PR-3 will add the industry-briefing scanner (output mode 8)
+ * + a unified `caia-curator act` runner that calls all four emitters
+ * in one pass.
  */
 
 export {
@@ -31,6 +37,22 @@ export {
 } from './alarm-emitter.js';
 
 export type { WriteAlarmsOptions } from './alarm-emitter.js';
+
+export {
+  defaultPrProposalsDir,
+  renderPrProposalMarkdown,
+  writePrProposals
+} from './pr-proposal-emitter.js';
+
+export type { WritePrProposalsOptions } from './pr-proposal-emitter.js';
+
+export {
+  defaultBacklogDirectivesDir,
+  renderBacklogDirectiveMarkdown,
+  writeBacklogDirectives
+} from './backlog-directive-emitter.js';
+
+export type { WriteBacklogDirectivesOptions } from './backlog-directive-emitter.js';
 
 export type {
   Action,

--- a/packages/curator/src/actions/pr-proposal-emitter.ts
+++ b/packages/curator/src/actions/pr-proposal-emitter.ts
@@ -1,0 +1,177 @@
+/**
+ * Curator Phase-2 — PR-proposal emitter (output mode 5).
+ *
+ * Per `agent/memory/curator_agent_directive.md`: "PR proposals — for
+ * low-risk mechanical upgrades (dependency bumps with security fixes,
+ * config tunings backed by metrics, dead-code removal), Curator opens
+ * a PR through the standard Evidence Gate."
+ *
+ * The emitter writes one markdown file per PR-proposal at:
+ *
+ *   <reportsDir>/curator/pr-proposals/<slug>.md
+ *
+ * The markdown is Evidence-Gate-shaped: it includes the standard
+ * sections (summary, evidence, affected files, recommended branch
+ * name, operator-review checklist, mandate-compliance footer) so the
+ * operator can copy-paste it into a real PR description with minimal
+ * edits.
+ *
+ * Idempotency: existing files preserved unless `force: true`. Mirrors
+ * the alarm-emitter contract.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { EmitResult, PrProposalAction } from './types.js';
+
+/** Output dir resolution: `<reportsDir>/curator/pr-proposals`. */
+export function defaultPrProposalsDir(reportsDir: string): string {
+  return join(reportsDir, 'curator', 'pr-proposals');
+}
+
+/**
+ * Render a PrProposalAction as Evidence-Gate-shaped markdown. Layout:
+ *
+ *   ---
+ *   type: curator-pr-proposal
+ *   slug: ...
+ *   branchSuffix: ...
+ *   detectedAt: ...
+ *   sourceFindings: [...]
+ *   affectedPaths: [...]
+ *   ---
+ *
+ *   # <title>
+ *
+ *   ## Summary
+ *   <summary>
+ *
+ *   ## Evidence
+ *   - ...
+ *
+ *   ## Suggested branch + affected files
+ *   - branch: chore/curator-<branchSuffix>
+ *   - affected paths: <list or "TBD">
+ *
+ *   ## Recommended action
+ *   <recommendation>
+ *
+ *   ## Operator-review checklist
+ *   - [ ] Confirm change is low-risk + mechanical
+ *   - [ ] Tests still green after applying
+ *   - [ ] No subscription-bucket impact
+ *   - [ ] Evidence Gate green
+ */
+export function renderPrProposalMarkdown(action: PrProposalAction): string {
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push('type: curator-pr-proposal');
+  lines.push(`slug: ${action.slug}`);
+  lines.push(`branchSuffix: ${action.branchSuffix}`);
+  lines.push(`detectedAt: ${action.detectedAt}`);
+  lines.push(`sourceFindings: [${action.sourceFindings.map((s) => `"${s}"`).join(', ')}]`);
+  lines.push(
+    `affectedPaths: [${action.affectedPaths.map((s) => `"${s}"`).join(', ')}]`
+  );
+  lines.push('---');
+  lines.push('');
+  lines.push(`# ${action.title}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(action.summary);
+  lines.push('');
+  if (action.evidence.length > 0) {
+    lines.push('## Evidence');
+    lines.push('');
+    for (const e of action.evidence) lines.push(`- ${e}`);
+    lines.push('');
+  }
+  lines.push('## Suggested branch + affected files');
+  lines.push('');
+  lines.push(`- Branch: \`chore/curator-${action.branchSuffix}\``);
+  if (action.affectedPaths.length > 0) {
+    lines.push('- Affected paths:');
+    for (const p of action.affectedPaths) lines.push(`  - \`${p}\``);
+  } else {
+    lines.push('- Affected paths: _TBD — operator to confirm before opening PR._');
+  }
+  lines.push('');
+  lines.push('## Recommended action');
+  lines.push('');
+  lines.push(action.recommendation);
+  lines.push('');
+  lines.push('## Operator-review checklist');
+  lines.push('');
+  lines.push('- [ ] Change is low-risk + mechanical (dependency bump, config tune, dead-code removal)');
+  lines.push('- [ ] All tests still green after applying');
+  lines.push('- [ ] No new paid services introduced (subscription-bucket compliance)');
+  lines.push('- [ ] Evidence Gate (gitleaks + semgrep + steward-gatekeeper) passes');
+  lines.push('- [ ] No `gh pr update-branch` use (rebase + force-push only)');
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Options for `writePrProposals`. */
+export interface WritePrProposalsOptions {
+  /** Output directory. Defaults to `<reportsDir>/curator/pr-proposals`. */
+  outDir?: string;
+  /** Used to compute `outDir` if not passed. */
+  reportsDir?: string;
+  /** Overwrite existing files. */
+  force?: boolean;
+}
+
+/** Persist PrProposalActions to disk. Returns an EmitResult. */
+export function writePrProposals(
+  actions: PrProposalAction[],
+  opts: WritePrProposalsOptions = {}
+): EmitResult {
+  const dir = resolveDir(opts);
+  ensureDir(dir);
+
+  const written: EmitResult['written'] = [];
+  const skipped: EmitResult['skipped'] = [];
+
+  for (const action of actions) {
+    const path = join(dir, `${action.slug}.md`);
+    const exists = existsSync(path);
+    if (exists && !opts.force) {
+      skipped.push({ path, slug: action.slug, kind: 'pr-proposal' });
+      continue;
+    }
+    const md = renderPrProposalMarkdown(action);
+    if (exists && opts.force) {
+      const current = readFileSync(path, 'utf-8');
+      if (current === md) {
+        skipped.push({ path, slug: action.slug, kind: 'pr-proposal' });
+        continue;
+      }
+    }
+    writeFileSync(path, md, 'utf-8');
+    written.push({ path, slug: action.slug, kind: 'pr-proposal' });
+  }
+
+  return {
+    outputDir: dir,
+    writtenCount: written.length,
+    skippedCount: skipped.length,
+    written,
+    skipped
+  };
+}
+
+function resolveDir(opts: WritePrProposalsOptions): string {
+  if (opts.outDir !== undefined) return opts.outDir;
+  if (opts.reportsDir === undefined) {
+    throw new Error(
+      'writePrProposals: either `outDir` or `reportsDir` must be provided'
+    );
+  }
+  return defaultPrProposalsDir(opts.reportsDir);
+}
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}

--- a/packages/curator/src/cli.ts
+++ b/packages/curator/src/cli.ts
@@ -20,11 +20,20 @@
  *
  *   emit-alarms [--repo <path>] [--memory <dir>] [--reports <dir>]
  *               [--alarms-dir <path>] [--force] [--print]
- *     (Phase-2) Run all phase-1 scanners, classify findings into
+ *     (Phase-2 PR-1) Run all phase-1 scanners, classify findings into
  *     actions, and write the urgent (`alarm`) ones as one .md per
  *     alarm under `<reportsDir>/curator/alarms/`. Idempotent — existing
- *     files are preserved unless `--force`. With `--print` the slugs of
- *     written + skipped alarms are echoed to stdout.
+ *     files are preserved unless `--force`.
+ *
+ *   emit-pr-proposals [--repo <path>] [--memory <dir>] [--reports <dir>]
+ *                     [--out-dir <path>] [--force] [--print]
+ *     (Phase-2 PR-2) Same pipeline, write the `pr-proposal` actions
+ *     under `<reportsDir>/curator/pr-proposals/`.
+ *
+ *   emit-backlog-directives [--repo <path>] [--memory <dir>] [--reports <dir>]
+ *                           [--out-dir <path>] [--force] [--print]
+ *     (Phase-2 PR-2) Same pipeline, write the `backlog-directive`
+ *     actions under `<reportsDir>/curator/backlog-directives/`.
  */
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -33,7 +42,12 @@ import { dirname, join, resolve as pathResolve } from 'node:path';
 import {
   findingsToActions,
   writeAlarms,
-  type AlarmAction
+  writeBacklogDirectives,
+  writePrProposals,
+  type AlarmAction,
+  type BacklogDirectiveAction,
+  type EmitResult,
+  type PrProposalAction
 } from './actions/index.js';
 import { defaultScanContext, type DefaultContextOptions } from './context.js';
 import { renderDigest } from './digest.js';
@@ -136,35 +150,106 @@ async function runOne(args: Argv): Promise<void> {
   console.log(JSON.stringify({ ok: true, scannerId: sc.id, findings }, null, 2));
 }
 
-async function emitAlarms(args: Argv): Promise<void> {
-  const ctx = buildCtx(args);
-  const result = await runScan(phase1Scanners, ctx);
-  const actions = findingsToActions(result.findings);
-  const alarms = actions.filter((a): a is AlarmAction => a.kind === 'alarm');
-
-  const alarmsDirArg = args.flags['alarms-dir'];
-  const force = args.flags['force'] === '1';
-  const emitted = alarmsDirArg
-    ? writeAlarms(alarms, { alarmsDir: pathResolve(alarmsDirArg), force })
-    : writeAlarms(alarms, { reportsDir: ctx.reportsDir, force });
-
-  if (args.flags['print']) {
+/**
+ * Print the JSON summary returned by an emit-* subcommand. Centralised
+ * so all three (alarm / pr-proposal / backlog-directive) use the same
+ * shape.
+ */
+function printEmitSummary(
+  kind: 'alarm' | 'pr-proposal' | 'backlog-directive',
+  emitted: EmitResult,
+  matching: number,
+  totalActions: number,
+  totalFindings: number,
+  print: boolean
+): void {
+  if (print) {
     for (const w of emitted.written) console.log(`written: ${w.slug} -> ${w.path}`);
     for (const s of emitted.skipped) console.log(`skipped: ${s.slug} -> ${s.path}`);
   }
-
   console.log(
     JSON.stringify({
       ok: true,
-      alarmsDir: emitted.outputDir,
+      kind,
+      outputDir: emitted.outputDir,
       writtenCount: emitted.writtenCount,
       skippedCount: emitted.skippedCount,
       written: emitted.written,
       skipped: emitted.skipped,
-      totalAlarms: alarms.length,
-      totalActions: actions.length,
-      totalFindings: result.findings.length
+      matchingActions: matching,
+      totalActions,
+      totalFindings
     })
+  );
+}
+
+async function emitAlarms(args: Argv): Promise<void> {
+  const ctx = buildCtx(args);
+  const result = await runScan(phase1Scanners, ctx);
+  const actions = findingsToActions(result.findings);
+  const matching = actions.filter((a): a is AlarmAction => a.kind === 'alarm');
+
+  const outArg = args.flags['alarms-dir'];
+  const force = args.flags['force'] === '1';
+  const emitted = outArg
+    ? writeAlarms(matching, { alarmsDir: pathResolve(outArg), force })
+    : writeAlarms(matching, { reportsDir: ctx.reportsDir, force });
+
+  printEmitSummary(
+    'alarm',
+    emitted,
+    matching.length,
+    actions.length,
+    result.findings.length,
+    args.flags['print'] === '1'
+  );
+}
+
+async function emitPrProposals(args: Argv): Promise<void> {
+  const ctx = buildCtx(args);
+  const result = await runScan(phase1Scanners, ctx);
+  const actions = findingsToActions(result.findings);
+  const matching = actions.filter(
+    (a): a is PrProposalAction => a.kind === 'pr-proposal'
+  );
+
+  const outArg = args.flags['out-dir'];
+  const force = args.flags['force'] === '1';
+  const emitted = outArg
+    ? writePrProposals(matching, { outDir: pathResolve(outArg), force })
+    : writePrProposals(matching, { reportsDir: ctx.reportsDir, force });
+
+  printEmitSummary(
+    'pr-proposal',
+    emitted,
+    matching.length,
+    actions.length,
+    result.findings.length,
+    args.flags['print'] === '1'
+  );
+}
+
+async function emitBacklogDirectives(args: Argv): Promise<void> {
+  const ctx = buildCtx(args);
+  const result = await runScan(phase1Scanners, ctx);
+  const actions = findingsToActions(result.findings);
+  const matching = actions.filter(
+    (a): a is BacklogDirectiveAction => a.kind === 'backlog-directive'
+  );
+
+  const outArg = args.flags['out-dir'];
+  const force = args.flags['force'] === '1';
+  const emitted = outArg
+    ? writeBacklogDirectives(matching, { outDir: pathResolve(outArg), force })
+    : writeBacklogDirectives(matching, { reportsDir: ctx.reportsDir, force });
+
+  printEmitSummary(
+    'backlog-directive',
+    emitted,
+    matching.length,
+    actions.length,
+    result.findings.length,
+    args.flags['print'] === '1'
   );
 }
 
@@ -178,6 +263,8 @@ function usage(): never {
       '  list-scanners',
       '  run-one <scannerId> [--repo <path>] [--memory <dir>] [--reports <dir>]',
       '  emit-alarms [--repo <path>] [--memory <dir>] [--reports <dir>] [--alarms-dir <path>] [--force] [--print]',
+      '  emit-pr-proposals [--repo <path>] [--memory <dir>] [--reports <dir>] [--out-dir <path>] [--force] [--print]',
+      '  emit-backlog-directives [--repo <path>] [--memory <dir>] [--reports <dir>] [--out-dir <path>] [--force] [--print]',
       '',
       'Env vars:',
       '  CAIA_MEMORY_DIR     overrides default agent/memory path',
@@ -202,6 +289,12 @@ export async function main(argv: string[]): Promise<void> {
       return;
     case 'emit-alarms':
       await emitAlarms(args);
+      return;
+    case 'emit-pr-proposals':
+      await emitPrProposals(args);
+      return;
+    case 'emit-backlog-directives':
+      await emitBacklogDirectives(args);
       return;
     case undefined:
     case '--help':

--- a/packages/curator/src/index.ts
+++ b/packages/curator/src/index.ts
@@ -16,31 +16,14 @@
  *
  * Phase-2 (leg-9, this layer) adds the **action layer** on top — per
  * the directive's output modes 5..8 (PR proposals, backlog directives,
- * alarms, industry briefings). Phase-2 PR-1 ships:
- *   - The `Action` type system + `findingsToActions` classifier.
- *   - The `writeAlarms` emitter (output mode 7) — urgent CVE / ToS /
- *     spend / capacity findings escalate immediately rather than
- *     waiting for the daily digest.
- *
- * Subsequent PRs add the PR-proposal + backlog-directive emitters
- * (PR-2) and the industry-briefing scanner + a unified `caia-curator
- * act` runner (PR-3).
- *
- * Typical use (from a cron / LaunchAgent):
- *
- *   import { runScan, renderDigest, phase1Scanners } from '@chiefaia/curator';
- *   import { defaultScanContext } from '@chiefaia/curator';
- *   import { findingsToActions, writeAlarms } from '@chiefaia/curator';
- *
- *   const ctx = defaultScanContext();
- *   const result = await runScan(phase1Scanners, ctx);
- *   const md = renderDigest(result);
- *   // ... write md to a file ...
- *
- *   // Phase-2 — escalate urgent findings to alarms.
- *   const actions = findingsToActions(result.findings);
- *   const alarms = actions.filter((a) => a.kind === 'alarm');
- *   const emitted = writeAlarms(alarms, { reportsDir: ctx.reportsDir });
+ * alarms, industry briefings). Phase-2 ships incrementally:
+ *   - PR-1: action types + `findingsToActions` classifier + alarm
+ *     emitter (mode 7) + `caia-curator emit-alarms` CLI.
+ *   - PR-2 (THIS): PR-proposal emitter (mode 5) + backlog-directive
+ *     emitter (mode 6) + `caia-curator emit-pr-proposals` and
+ *     `caia-curator emit-backlog-directives` CLIs.
+ *   - PR-3: industry-briefing scanner (mode 8) + unified
+ *     `caia-curator act` runner.
  */
 
 export { runScan, rankFindings } from './orchestrator.js';
@@ -59,10 +42,16 @@ export {
   actionSlugForFinding,
   classifyKind,
   defaultAlarmsDir,
+  defaultBacklogDirectivesDir,
+  defaultPrProposalsDir,
   findingsToActions,
   renderAlarmMarkdown,
+  renderBacklogDirectiveMarkdown,
+  renderPrProposalMarkdown,
   slugify,
-  writeAlarms
+  writeAlarms,
+  writeBacklogDirectives,
+  writePrProposals
 } from './actions/index.js';
 
 export type {
@@ -85,5 +74,7 @@ export type {
   EmittedActionRef,
   IndustryBriefingAction,
   PrProposalAction,
-  WriteAlarmsOptions
+  WriteAlarmsOptions,
+  WriteBacklogDirectivesOptions,
+  WritePrProposalsOptions
 } from './actions/index.js';

--- a/packages/curator/tests/actions/backlog-directive-emitter.test.ts
+++ b/packages/curator/tests/actions/backlog-directive-emitter.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the Curator Phase-2 backlog-directive emitter.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaultBacklogDirectivesDir,
+  renderBacklogDirectiveMarkdown,
+  writeBacklogDirectives
+} from '../../src/actions/backlog-directive-emitter.js';
+import type { BacklogDirectiveAction } from '../../src/actions/types.js';
+
+function fixture(overrides: Partial<BacklogDirectiveAction> = {}): BacklogDirectiveAction {
+  return {
+    kind: 'backlog-directive',
+    slug: 'sample-directive-slug',
+    title: 'Adopt new framework X',
+    summary: 'Mandate paragraph.\n\nMore detail on the second line.',
+    evidence: ['ev-a', 'ev-b'],
+    recommendation: 'Pilot framework X behind a feature flag.',
+    detectedAt: '2026-05-05T22:50:00.000Z',
+    sourceFindings: ['framework-survey'],
+    dimension: 'Intelligence & Autonomy',
+    effortEstimate: 'large',
+    ...overrides
+  };
+}
+
+describe('renderBacklogDirectiveMarkdown', () => {
+  it('renders memory-directive-shaped frontmatter', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture());
+    // Mirrors existing memory directive frontmatter structure (name + description + type).
+    expect(md).toContain('name: Adopt new framework X');
+    expect(md).toContain('description: Mandate paragraph.');
+    expect(md).toContain('type: curator-backlog-directive');
+    expect(md).toContain('dimension: ');
+    expect(md).toContain('effortEstimate: large');
+    expect(md).toContain('slug: sample-directive-slug');
+    expect(md).toContain('detectedAt: 2026-05-05T22:50:00.000Z');
+    expect(md).toContain('sourceFindings: ["framework-survey"]');
+  });
+
+  it('uses first line of summary for description', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture());
+    // Description value should NOT include the second line.
+    expect(md).toContain('description: Mandate paragraph.');
+    expect(md).not.toContain('description: Mandate paragraph.\n\nMore detail');
+  });
+
+  it('falls back to title for description when summary is empty', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture({ summary: '' }));
+    expect(md).toContain('description: Adopt new framework X');
+  });
+
+  it('quote-escapes dimension with special chars', () => {
+    const md = renderBacklogDirectiveMarkdown(
+      fixture({ dimension: 'Spend: weekly trend' })
+    );
+    expect(md).toMatch(/dimension: '[^']*'/);
+  });
+
+  it('renders BACKLOG status header', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture());
+    expect(md).toContain('**Status**: BACKLOG');
+    expect(md).toContain('Curator (Phase-2 PR-2)');
+  });
+
+  it('renders Mandate, Evidence, Recommended action, Promotion checklist sections', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture());
+    expect(md).toContain('## Mandate');
+    expect(md).toContain('Mandate paragraph.');
+    expect(md).toContain('## Evidence');
+    expect(md).toContain('- ev-a');
+    expect(md).toContain('## Recommended action');
+    expect(md).toContain('Pilot framework X');
+    expect(md).toContain('## Promotion checklist');
+  });
+
+  it('promotion checklist mentions effort + mandate-compliance + mv to agent/memory', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture());
+    expect(md).toContain('current: `large`');
+    expect(md).toContain('subscription-only');
+    expect(md).toContain('agent/memory/<slug>.md');
+  });
+
+  it('omits Evidence section when empty', () => {
+    const md = renderBacklogDirectiveMarkdown(fixture({ evidence: [] }));
+    expect(md).not.toContain('## Evidence');
+  });
+});
+
+describe('defaultBacklogDirectivesDir', () => {
+  it('joins reportsDir + curator + backlog-directives', () => {
+    expect(defaultBacklogDirectivesDir('/tmp/reports')).toBe(
+      '/tmp/reports/curator/backlog-directives'
+    );
+  });
+});
+
+describe('writeBacklogDirectives', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'curator-bd-emitter-'));
+  });
+
+  it('writes one .md per action to the explicit outDir', () => {
+    const a = fixture({ slug: 'one' });
+    const b = fixture({ slug: 'two', title: 'Two' });
+    const r = writeBacklogDirectives([a, b], { outDir: tmp });
+    expect(r.outputDir).toBe(tmp);
+    expect(r.writtenCount).toBe(2);
+    expect(r.skippedCount).toBe(0);
+    expect(existsSync(join(tmp, 'one.md'))).toBe(true);
+    expect(existsSync(join(tmp, 'two.md'))).toBe(true);
+  });
+
+  it('uses defaultBacklogDirectivesDir when only reportsDir is passed', () => {
+    const r = writeBacklogDirectives([fixture({ slug: 'rd' })], { reportsDir: tmp });
+    expect(r.outputDir).toBe(join(tmp, 'curator', 'backlog-directives'));
+  });
+
+  it('throws when neither outDir nor reportsDir is provided', () => {
+    expect(() => writeBacklogDirectives([fixture()], {})).toThrow(/outDir.*reportsDir/);
+  });
+
+  it('is idempotent — second run skips existing files', () => {
+    const a = fixture({ slug: 'idem' });
+    const r1 = writeBacklogDirectives([a], { outDir: tmp });
+    expect(r1.writtenCount).toBe(1);
+    const r2 = writeBacklogDirectives([a], { outDir: tmp });
+    expect(r2.writtenCount).toBe(0);
+    expect(r2.skippedCount).toBe(1);
+  });
+
+  it('preserves operator edits without force', () => {
+    const a = fixture({ slug: 'edit' });
+    writeBacklogDirectives([a], { outDir: tmp });
+    const path = join(tmp, 'edit.md');
+    writeFileSync(path, 'EDIT\n');
+    writeBacklogDirectives([a], { outDir: tmp });
+    expect(readFileSync(path, 'utf-8')).toBe('EDIT\n');
+  });
+
+  it('overwrites with force: true', () => {
+    const a = fixture({ slug: 'f' });
+    writeBacklogDirectives([a], { outDir: tmp });
+    writeFileSync(join(tmp, 'f.md'), 'STALE\n');
+    const r = writeBacklogDirectives([a], { outDir: tmp, force: true });
+    expect(r.writtenCount).toBe(1);
+    expect(readFileSync(join(tmp, 'f.md'), 'utf-8')).not.toBe('STALE\n');
+  });
+
+  it('skips force-rewrite when content unchanged', () => {
+    const a = fixture({ slug: 'noop' });
+    writeBacklogDirectives([a], { outDir: tmp });
+    const r = writeBacklogDirectives([a], { outDir: tmp, force: true });
+    expect(r.writtenCount).toBe(0);
+    expect(r.skippedCount).toBe(1);
+  });
+
+  it('returns empty result when called with no actions', () => {
+    const r = writeBacklogDirectives([], { outDir: tmp });
+    expect(r.writtenCount).toBe(0);
+    expect(r.skippedCount).toBe(0);
+    expect(r.written).toEqual([]);
+  });
+
+  it('all written refs use kind: backlog-directive', () => {
+    const r = writeBacklogDirectives(
+      [fixture({ slug: 'a' }), fixture({ slug: 'b' })],
+      { outDir: tmp }
+    );
+    for (const w of r.written) expect(w.kind).toBe('backlog-directive');
+  });
+});

--- a/packages/curator/tests/actions/pr-proposal-emitter.test.ts
+++ b/packages/curator/tests/actions/pr-proposal-emitter.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the Curator Phase-2 PR-proposal emitter.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaultPrProposalsDir,
+  renderPrProposalMarkdown,
+  writePrProposals
+} from '../../src/actions/pr-proposal-emitter.js';
+import type { PrProposalAction } from '../../src/actions/types.js';
+
+function fixture(overrides: Partial<PrProposalAction> = {}): PrProposalAction {
+  return {
+    kind: 'pr-proposal',
+    slug: 'sample-pr-slug',
+    title: 'Bump foo to 1.2.3',
+    summary: 'Summary paragraph.',
+    evidence: ['ev-1', 'ev-2'],
+    recommendation: 'Apply the bump.',
+    detectedAt: '2026-05-05T22:50:00.000Z',
+    sourceFindings: ['dep-bump-scanner'],
+    branchSuffix: 'sample-pr-slug',
+    affectedPaths: ['package.json', 'pnpm-lock.yaml'],
+    ...overrides
+  };
+}
+
+describe('renderPrProposalMarkdown', () => {
+  it('renders frontmatter with all 6 keys + affectedPaths array', () => {
+    const md = renderPrProposalMarkdown(fixture());
+    expect(md).toContain('type: curator-pr-proposal');
+    expect(md).toContain('slug: sample-pr-slug');
+    expect(md).toContain('branchSuffix: sample-pr-slug');
+    expect(md).toContain('detectedAt: 2026-05-05T22:50:00.000Z');
+    expect(md).toContain('sourceFindings: ["dep-bump-scanner"]');
+    expect(md).toContain('affectedPaths: ["package.json", "pnpm-lock.yaml"]');
+  });
+
+  it('renders title as H1 + summary section', () => {
+    const md = renderPrProposalMarkdown(fixture());
+    expect(md).toContain('# Bump foo to 1.2.3');
+    expect(md).toContain('## Summary');
+    expect(md).toContain('Summary paragraph.');
+  });
+
+  it('renders evidence section with bullet list', () => {
+    const md = renderPrProposalMarkdown(fixture());
+    expect(md).toContain('## Evidence');
+    expect(md).toContain('- ev-1');
+    expect(md).toContain('- ev-2');
+  });
+
+  it('omits evidence section when there is no evidence', () => {
+    const md = renderPrProposalMarkdown(fixture({ evidence: [] }));
+    expect(md).not.toContain('## Evidence');
+  });
+
+  it('renders branch + affected paths section', () => {
+    const md = renderPrProposalMarkdown(fixture());
+    expect(md).toContain('Branch: `chore/curator-sample-pr-slug`');
+    expect(md).toContain('- `package.json`');
+    expect(md).toContain('- `pnpm-lock.yaml`');
+  });
+
+  it('falls back to TBD note when affectedPaths is empty', () => {
+    const md = renderPrProposalMarkdown(fixture({ affectedPaths: [] }));
+    expect(md).toContain('Affected paths: _TBD');
+  });
+
+  it('renders the operator-review checklist with 5 items', () => {
+    const md = renderPrProposalMarkdown(fixture());
+    expect(md).toContain('## Operator-review checklist');
+    const checkboxLines = md.split('\n').filter((l) => l.startsWith('- [ ]'));
+    expect(checkboxLines.length).toBe(5);
+  });
+
+  it('mentions Evidence Gate + subscription-bucket compliance in checklist', () => {
+    const md = renderPrProposalMarkdown(fixture());
+    expect(md).toContain('Evidence Gate');
+    expect(md).toContain('subscription-bucket');
+  });
+});
+
+describe('defaultPrProposalsDir', () => {
+  it('joins reportsDir + curator + pr-proposals', () => {
+    expect(defaultPrProposalsDir('/tmp/reports')).toBe('/tmp/reports/curator/pr-proposals');
+  });
+});
+
+describe('writePrProposals', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'curator-pr-proposal-emitter-'));
+  });
+
+  it('writes one .md per action to the explicit outDir', () => {
+    const a = fixture({ slug: 'one' });
+    const b = fixture({ slug: 'two', title: 'Bump bar' });
+    const r = writePrProposals([a, b], { outDir: tmp });
+    expect(r.outputDir).toBe(tmp);
+    expect(r.writtenCount).toBe(2);
+    expect(r.skippedCount).toBe(0);
+    expect(existsSync(join(tmp, 'one.md'))).toBe(true);
+    expect(existsSync(join(tmp, 'two.md'))).toBe(true);
+  });
+
+  it('uses defaultPrProposalsDir when only reportsDir is passed', () => {
+    const r = writePrProposals([fixture({ slug: 'rd' })], { reportsDir: tmp });
+    expect(r.outputDir).toBe(join(tmp, 'curator', 'pr-proposals'));
+  });
+
+  it('throws when neither outDir nor reportsDir is provided', () => {
+    expect(() => writePrProposals([fixture()], {})).toThrow(/outDir.*reportsDir/);
+  });
+
+  it('is idempotent — second run skips existing files', () => {
+    const a = fixture({ slug: 'idem' });
+    const r1 = writePrProposals([a], { outDir: tmp });
+    expect(r1.writtenCount).toBe(1);
+    const r2 = writePrProposals([a], { outDir: tmp });
+    expect(r2.writtenCount).toBe(0);
+    expect(r2.skippedCount).toBe(1);
+  });
+
+  it('preserves operator edits when force is not set', () => {
+    const a = fixture({ slug: 'edit' });
+    writePrProposals([a], { outDir: tmp });
+    const path = join(tmp, 'edit.md');
+    writeFileSync(path, 'OPERATOR\n');
+    writePrProposals([a], { outDir: tmp });
+    expect(readFileSync(path, 'utf-8')).toBe('OPERATOR\n');
+  });
+
+  it('overwrites with force: true', () => {
+    const a = fixture({ slug: 'force' });
+    writePrProposals([a], { outDir: tmp });
+    const path = join(tmp, 'force.md');
+    writeFileSync(path, 'STALE\n');
+    const r = writePrProposals([a], { outDir: tmp, force: true });
+    expect(r.writtenCount).toBe(1);
+    expect(readFileSync(path, 'utf-8')).not.toBe('STALE\n');
+  });
+
+  it('skips force-rewrite when content unchanged', () => {
+    const a = fixture({ slug: 'noop' });
+    writePrProposals([a], { outDir: tmp });
+    const r = writePrProposals([a], { outDir: tmp, force: true });
+    expect(r.writtenCount).toBe(0);
+    expect(r.skippedCount).toBe(1);
+  });
+
+  it('returns empty result when called with no actions', () => {
+    const r = writePrProposals([], { outDir: tmp });
+    expect(r.writtenCount).toBe(0);
+    expect(r.skippedCount).toBe(0);
+    expect(r.written).toEqual([]);
+    expect(r.skipped).toEqual([]);
+  });
+
+  it('all written refs use kind: pr-proposal', () => {
+    const r = writePrProposals(
+      [fixture({ slug: 'k1' }), fixture({ slug: 'k2' })],
+      { outDir: tmp }
+    );
+    for (const w of r.written) expect(w.kind).toBe('pr-proposal');
+  });
+});

--- a/packages/curator/tests/cli-emit-actions.test.ts
+++ b/packages/curator/tests/cli-emit-actions.test.ts
@@ -1,0 +1,186 @@
+/**
+ * CLI tests for the Phase-2 PR-2 subcommands:
+ *
+ *   - emit-pr-proposals
+ *   - emit-backlog-directives
+ *
+ * Same pattern as `cli-emit-alarms.test.ts` — verify wiring + JSON
+ * output shape against a tmpdir-rooted ScanContext. Real scanners
+ * run; we don't assert specific counts.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { main } from '../src/cli.js';
+
+let tmp: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+function lastJsonLine(): {
+  ok: boolean;
+  kind: string;
+  outputDir: string;
+  writtenCount: number;
+  skippedCount: number;
+  matchingActions: number;
+  totalActions: number;
+  totalFindings: number;
+  written: unknown[];
+  skipped: unknown[];
+} {
+  const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
+  const lines = out.split('\n').filter((l) => l.startsWith('{'));
+  const last = lines[lines.length - 1]!;
+  return JSON.parse(last);
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'curator-cli-emit-actions-'));
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('cli main() emit-pr-proposals', () => {
+  it('produces ok:true JSON with kind: pr-proposal', async () => {
+    const memDir = join(tmp, 'memory');
+    mkdirSync(memDir);
+    writeFileSync(join(memDir, 'MEMORY.md'), '');
+    const outDir = join(tmp, 'pr-proposals');
+
+    await main([
+      'emit-pr-proposals',
+      '--repo',
+      tmp,
+      '--memory',
+      memDir,
+      '--out-dir',
+      outDir
+    ]);
+
+    const json = lastJsonLine();
+    expect(json.ok).toBe(true);
+    expect(json.kind).toBe('pr-proposal');
+    expect(json.outputDir).toBe(outDir);
+    expect(json.writtenCount + json.skippedCount).toBe(json.matchingActions);
+    expect(json.matchingActions).toBeLessThanOrEqual(json.totalActions);
+    expect(json.totalActions).toBeLessThanOrEqual(json.totalFindings);
+    expect(existsSync(outDir)).toBe(true);
+  });
+
+  it('uses defaultPrProposalsDir under reports when --out-dir omitted', async () => {
+    const memDir = join(tmp, 'memory');
+    mkdirSync(memDir);
+    writeFileSync(join(memDir, 'MEMORY.md'), '');
+    const reports = join(tmp, 'reports');
+
+    await main([
+      'emit-pr-proposals',
+      '--repo',
+      tmp,
+      '--memory',
+      memDir,
+      '--reports',
+      reports
+    ]);
+    const json = lastJsonLine();
+    expect(json.outputDir).toBe(join(reports, 'curator', 'pr-proposals'));
+  });
+
+  it('--force flag is parsed cleanly', async () => {
+    const memDir = join(tmp, 'memory');
+    mkdirSync(memDir);
+    writeFileSync(join(memDir, 'MEMORY.md'), '');
+    const outDir = join(tmp, 'pr-force');
+    await main([
+      'emit-pr-proposals',
+      '--repo',
+      tmp,
+      '--memory',
+      memDir,
+      '--out-dir',
+      outDir,
+      '--force'
+    ]);
+    const json = lastJsonLine();
+    expect(json.ok).toBe(true);
+  });
+});
+
+describe('cli main() emit-backlog-directives', () => {
+  it('produces ok:true JSON with kind: backlog-directive', async () => {
+    const memDir = join(tmp, 'memory');
+    mkdirSync(memDir);
+    writeFileSync(join(memDir, 'MEMORY.md'), '');
+    const outDir = join(tmp, 'directives');
+
+    await main([
+      'emit-backlog-directives',
+      '--repo',
+      tmp,
+      '--memory',
+      memDir,
+      '--out-dir',
+      outDir
+    ]);
+
+    const json = lastJsonLine();
+    expect(json.ok).toBe(true);
+    expect(json.kind).toBe('backlog-directive');
+    expect(json.outputDir).toBe(outDir);
+    expect(json.writtenCount + json.skippedCount).toBe(json.matchingActions);
+  });
+
+  it('uses defaultBacklogDirectivesDir when --out-dir omitted', async () => {
+    const memDir = join(tmp, 'memory');
+    mkdirSync(memDir);
+    writeFileSync(join(memDir, 'MEMORY.md'), '');
+    const reports = join(tmp, 'reports');
+
+    await main([
+      'emit-backlog-directives',
+      '--repo',
+      tmp,
+      '--memory',
+      memDir,
+      '--reports',
+      reports
+    ]);
+    const json = lastJsonLine();
+    expect(json.outputDir).toBe(
+      join(reports, 'curator', 'backlog-directives')
+    );
+  });
+
+  it('usage line lists the two new subcommands', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit ${code}`);
+      }) as never);
+    try {
+      await expect(main(['--help'])).rejects.toThrow(/exit 2/);
+      const errOut = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(errOut).toContain('emit-pr-proposals');
+      expect(errOut).toContain('emit-backlog-directives');
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/packages/curator/tests/cli-emit-alarms.test.ts
+++ b/packages/curator/tests/cli-emit-alarms.test.ts
@@ -59,18 +59,20 @@ describe('cli main() emit-alarms', () => {
     const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
     const json = JSON.parse(out.split('\n').filter((l) => l.startsWith('{')).pop()!) as {
       ok: boolean;
-      alarmsDir: string;
+      kind: string;
+      outputDir: string;
       writtenCount: number;
       skippedCount: number;
-      totalAlarms: number;
+      matchingActions: number;
       totalActions: number;
       totalFindings: number;
     };
     expect(json.ok).toBe(true);
-    expect(json.alarmsDir).toBe(alarmsDir);
+    expect(json.kind).toBe('alarm');
+    expect(json.outputDir).toBe(alarmsDir);
     expect(typeof json.writtenCount).toBe('number');
     expect(typeof json.skippedCount).toBe('number');
-    expect(typeof json.totalAlarms).toBe('number');
+    expect(typeof json.matchingActions).toBe('number');
     expect(typeof json.totalActions).toBe('number');
     expect(typeof json.totalFindings).toBe('number');
   });
@@ -93,9 +95,9 @@ describe('cli main() emit-alarms', () => {
 
     const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
     const json = JSON.parse(out.split('\n').filter((l) => l.startsWith('{')).pop()!) as {
-      alarmsDir: string;
+      outputDir: string;
     };
-    expect(json.alarmsDir).toBe(join(reportsDir, 'curator', 'alarms'));
+    expect(json.outputDir).toBe(join(reportsDir, 'curator', 'alarms'));
   });
 
   it('is idempotent — second run of the same input skips files', async () => {
@@ -171,19 +173,21 @@ describe('cli main() emit-alarms', () => {
     const out = logSpy.mock.calls.map((c) => c[0]).join('\n');
     const json = JSON.parse(out.split('\n').filter((l) => l.startsWith('{')).pop()!) as {
       ok: boolean;
+      kind: string;
       writtenCount: number;
       skippedCount: number;
-      totalAlarms: number;
+      matchingActions: number;
       totalActions: number;
       totalFindings: number;
       written: unknown[];
       skipped: unknown[];
     };
     expect(json.ok).toBe(true);
-    expect(json.writtenCount + json.skippedCount).toBe(json.totalAlarms);
+    expect(json.kind).toBe('alarm');
+    expect(json.writtenCount + json.skippedCount).toBe(json.matchingActions);
     expect(Array.isArray(json.written)).toBe(true);
     expect(Array.isArray(json.skipped)).toBe(true);
-    expect(json.totalAlarms).toBeLessThanOrEqual(json.totalActions);
+    expect(json.matchingActions).toBeLessThanOrEqual(json.totalActions);
     expect(json.totalActions).toBeLessThanOrEqual(json.totalFindings);
     expect(existsSync(alarmsDir)).toBe(true);
   });


### PR DESCRIPTION
Builds on PR-1 (#338, action types + classifier + alarm emitter) by adding the remaining two finding-driven output modes from `agent/memory/curator_agent_directive.md`.

## What landed

- **`writePrProposals`** (output mode 5): renders Evidence-Gate-shaped markdown to `<reportsDir>/curator/pr-proposals/<slug>.md`. Each file carries a 5-item operator-review checklist, a recommended branch (`chore/curator-<slug>`), and the affected paths the upgrade is expected to touch.
- **`writeBacklogDirectives`** (output mode 6): renders memory-directive-shaped markdown to `<reportsDir>/curator/backlog-directives/<slug>.md`. Frontmatter (`name` + `description` + `type` + `dimension` + `effortEstimate`) matches existing CAIA memory directives so promotion is one `mv` away.
- New CLI subcommands: `emit-pr-proposals`, `emit-backlog-directives`. Both share the same `printEmitSummary` helper so JSON output shape is uniform across alarm / pr-proposal / backlog-directive (`{ kind, outputDir, writtenCount, skippedCount, matchingActions, totalActions, totalFindings, written, skipped }`).

Idempotency contract is identical to PR-1's `writeAlarms`: existing files preserved unless `--force`; force-rewrite is content-aware (no-op if unchanged).

## Test impact

| Suite | Pre | Post | Delta |
|---|---:|---:|---:|
| `@chiefaia/curator` | 89 | 131 | +42 |

Breakdown: 16 pr-proposal-emitter + 17 backlog-directive-emitter + 6 cli-emit-actions + 3 cli-emit-alarms shape updates.

All green; lint clean; typecheck clean; build clean.

## Mandate compliance

- Subscription-only — no API keys, no paid services.
- Pure-function library + CLI; no new daemons.
- Phase-1 substrate is unchanged.

## Refs

- `agent/memory/curator_agent_directive.md` ## Output modes 5 + 6
- Sibling: PR #338 (curator-phase2-001 — alarms)