### PR TITLE
feat(enterprise-w1-3): Vercel AI SDK chat panel in CAIA dashboard

### DIFF
--- a/apps/dashboard/app/api/chat/route.ts
+++ b/apps/dashboard/app/api/chat/route.ts
@@ -1,0 +1,96 @@
+/**
+ * /api/chat — Vercel AI SDK-compatible chat streaming endpoint.
+ *
+ * Wave 1.3 of the Enterprise Wave 1 campaign per
+ * `agent/memory/enterprise_ai_landscape_directive.md` (W1-2-add). Adds
+ * an agent-native chat surface to the operator dashboard.
+ *
+ * The routing taxonomy + orchestrator forwarding + AI-SDK encoders all
+ * live in `lib/chat/routing.ts` so the route file exposes ONLY the
+ * Next.js handler exports (Next 14's app router rejects non-handler
+ * exports from `route.ts`).
+ *
+ * Subscription-only LLM constraint preserved: this endpoint NEVER calls
+ * Anthropic's API. The synthesised response is fully local. Operators
+ * who want true LLM-backed chat can swap the streamer for `streamText`
+ * with an `ollama:llama3.2:3b` provider locally.
+ */
+
+import { type NextRequest } from 'next/server';
+
+import {
+  buildAssistantText,
+  encodeFinishMessage,
+  encodeTextChunk,
+  maybeForwardToOrchestrator,
+  routeMessage
+} from '../../../lib/chat/routing';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface ChatRequestBody {
+  messages: ChatMessage[];
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  let body: ChatRequestBody;
+  try {
+    body = (await req.json()) as ChatRequestBody;
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const last = [...body.messages].reverse().find((m) => m.role === 'user');
+  if (!last) {
+    return new Response(JSON.stringify({ error: 'no user message in payload' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const decision = routeMessage(last.content);
+  const promptIdInfo = await maybeForwardToOrchestrator(last.content);
+  const lines = buildAssistantText(decision, promptIdInfo);
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for (const line of lines) {
+          controller.enqueue(encoder.encode(encodeTextChunk(line + '\n')));
+          // Tiny delay so the operator sees real streaming UX. Cap total
+          // latency at well under a second so tests stay fast.
+          await new Promise((r) => setTimeout(r, 30));
+        }
+        const promptTokens = last.content.length;
+        const completionTokens = lines.join('\n').length;
+        controller.enqueue(encoder.encode(encodeFinishMessage(promptTokens, completionTokens)));
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    }
+  });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'X-Vercel-AI-Data-Stream': 'v1',
+    'X-Caia-Routed-Agent': decision.agent,
+    'X-Caia-Classification': decision.classification,
+    'X-Caia-Forwarded': promptIdInfo.forwarded ? '1' : '0'
+  };
+  if (promptIdInfo.promptId) {
+    headers['X-Caia-Prompt-Id'] = promptIdInfo.promptId;
+  }
+
+  return new Response(stream, { headers });
+}

--- a/apps/dashboard/app/chat/page.tsx
+++ b/apps/dashboard/app/chat/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * /chat — operator chat page.
+ *
+ * Wave 1.3 of the Enterprise Wave 1 campaign per
+ * `agent/memory/enterprise_ai_landscape_directive.md` (W1-2-add).
+ */
+
+import { ChatPanel } from '../../components/chat/ChatPanel';
+
+export const dynamic = 'force-dynamic';
+
+export default function ChatPage(): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <h1 style={{ margin: 0, fontSize: 22, color: '#f0f4f8' }}>Chat</h1>
+      <p style={{ margin: 0, fontSize: 13, color: '#a0aec0', maxWidth: 720 }}>
+        Operator chat surface. Messages are routed to one of the 10 canonical CAIA subagents
+        (caia-po / ba / ea / validator / test-design / coding / fix-it / steward / mentor / curator)
+        using the deterministic local routing taxonomy. When{' '}
+        <code style={{ background: '#1a1f2e', padding: '2px 6px', borderRadius: 3 }}>
+          CAIA_ORCHESTRATOR_URL
+        </code>{' '}
+        is set, prompts are also forwarded to the live orchestrator and surface in the prompt
+        journey UI.
+      </p>
+      <ChatPanel />
+    </div>
+  );
+}

--- a/apps/dashboard/components/chat/ChatPanel.tsx
+++ b/apps/dashboard/components/chat/ChatPanel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+/**
+ * ChatPanel — operator chat surface backed by `@ai-sdk/react`'s `useChat`
+ * hook + the `/api/chat` streaming endpoint.
+ *
+ * Wave 1.3 of the Enterprise Wave 1 campaign per
+ * `agent/memory/enterprise_ai_landscape_directive.md` (W1-2-add).
+ */
+
+import { useChat } from '@ai-sdk/react';
+import { type FormEvent, useEffect, useRef } from 'react';
+
+const SUBAGENT_HINT = [
+  'Try one of these to see routing:',
+  '  • "Decompose into stories: build a new dashboard"  →  caia-po (decomposition)',
+  '  • "Enrich this story with acceptance criteria"      →  caia-ba (enrichment)',
+  '  • "Run the DoD checklist on PR 342"                 →  caia-validator (dod-check)',
+  '  • "Open the PR with auto-merge"                     →  caia-coding (pr-flow)',
+  '  • "CI failed — diagnose"                            →  caia-fix-it (failure-diagnosis)',
+  '  • "Scan findings + emit alarms"                     →  caia-curator (action-routing)'
+].join('\n');
+
+export function ChatPanel(): JSX.Element {
+  const { messages, input, handleInputChange, handleSubmit, isLoading, error, status } = useChat({
+    api: '/api/chat',
+    initialMessages: [
+      {
+        id: 'system-welcome',
+        role: 'assistant',
+        content:
+          'Hi — I route operator prompts to the canonical CAIA subagents (caia-po, caia-ba, caia-ea, caia-validator, caia-test-design, caia-coding, caia-fix-it, caia-steward, caia-mentor, caia-curator).\n\n' +
+          SUBAGENT_HINT +
+          '\n\nWhen `CAIA_ORCHESTRATOR_URL` is set, prompts are also forwarded to the live orchestrator.'
+      }
+    ]
+  });
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages]);
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    handleSubmit(e);
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'calc(100vh - 96px)',
+        maxHeight: 'calc(100vh - 96px)',
+        background: '#1a1f2e',
+        border: '1px solid #2d3748',
+        borderRadius: 6
+      }}
+      aria-label="CAIA chat panel"
+    >
+      <div
+        ref={scrollRef}
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: 16,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12
+        }}
+        aria-live="polite"
+        data-testid="chat-message-list"
+      >
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            style={{
+              alignSelf: m.role === 'user' ? 'flex-end' : 'flex-start',
+              maxWidth: '85%',
+              background: m.role === 'user' ? '#2d3748' : '#1f2937',
+              border: '1px solid #2d3748',
+              borderRadius: 6,
+              padding: '8px 12px',
+              fontSize: 13,
+              lineHeight: 1.5,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              color: m.role === 'user' ? '#f0f4f8' : '#cbd5e0'
+            }}
+            data-testid={`chat-message-${m.role}`}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                color: m.role === 'user' ? '#90cdf4' : '#68d391',
+                marginBottom: 4,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em'
+              }}
+            >
+              {m.role}
+            </div>
+            {m.content}
+          </div>
+        ))}
+        {isLoading && (
+          <div style={{ fontSize: 12, color: '#a0aec0', padding: '4px 8px' }} data-testid="chat-streaming">
+            Streaming response…
+          </div>
+        )}
+        {error && (
+          <div
+            style={{
+              background: '#742a2a',
+              color: '#fed7d7',
+              border: '1px solid #c53030',
+              borderRadius: 6,
+              padding: '8px 12px',
+              fontSize: 12
+            }}
+            role="alert"
+            data-testid="chat-error"
+          >
+            Chat error: {error.message}
+          </div>
+        )}
+      </div>
+
+      <form
+        onSubmit={onSubmit}
+        style={{
+          display: 'flex',
+          gap: 8,
+          padding: 12,
+          borderTop: '1px solid #2d3748',
+          background: '#1f2937'
+        }}
+        aria-label="Chat input form"
+      >
+        <input
+          type="text"
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask the CAIA platform anything…"
+          aria-label="Chat input"
+          data-testid="chat-input"
+          disabled={isLoading}
+          style={{
+            flex: 1,
+            background: '#0f1117',
+            border: '1px solid #2d3748',
+            borderRadius: 4,
+            padding: '8px 12px',
+            color: '#f0f4f8',
+            fontSize: 13,
+            outline: 'none'
+          }}
+        />
+        <button
+          type="submit"
+          disabled={isLoading || input.trim().length === 0}
+          data-testid="chat-send"
+          style={{
+            background: isLoading || input.trim().length === 0 ? '#2d3748' : '#3182ce',
+            color: '#f0f4f8',
+            border: 'none',
+            borderRadius: 4,
+            padding: '8px 16px',
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: isLoading || input.trim().length === 0 ? 'not-allowed' : 'pointer'
+          }}
+        >
+          {status === 'submitted' || status === 'streaming' ? 'Sending…' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default ChatPanel;

--- a/apps/dashboard/components/chat/README.md
+++ b/apps/dashboard/components/chat/README.md
@@ -1,0 +1,44 @@
+# `components/chat/` — Vercel AI SDK chat panel
+
+Wave 1.3 of the **Enterprise Wave 1** campaign per `agent/memory/enterprise_ai_landscape_directive.md` (W1-2-add — AG-UI / CopilotKit / Vercel AI SDK in CAIA dashboard).
+
+## What ships
+
+- `ChatPanel.tsx` — operator chat UI backed by `@ai-sdk/react`'s `useChat` hook against `/api/chat`. Renders a streaming chat surface inside the dashboard's existing dark-themed shell.
+- `app/chat/page.tsx` — Next.js route that renders the panel.
+- `app/api/chat/route.ts` — POST handler that streams Vercel-AI-SDK Data Stream Protocol chunks back to the client.
+- `lib/chat/routing.ts` — routing taxonomy + orchestrator-forward + AI-SDK encoders. Mirrors the deterministic provider in `@chiefaia/prompt-evals`.
+
+## Routing
+
+Each user message is classified into one of the 10 canonical CAIA subagent roles using deterministic keyword routing. Try:
+
+| Prompt | Routed to | Classification |
+|--------|-----------|----------------|
+| "Decompose into stories: build a new dashboard" | caia-po | decomposition |
+| "Enrich this story with acceptance criteria" | caia-ba | enrichment |
+| "Make a build-vs-buy architecture call here" | caia-ea | architecture |
+| "Run the DoD checklist on PR 342" | caia-validator | dod-check |
+| "Premature completion: typecheck was skipped" | caia-validator | red-flag |
+| "Write the unit test plan" | caia-test-design | plan-design |
+| "Implement the new authentication endpoint" | caia-coding | implementation |
+| "Open the PR with auto-merge" | caia-coding | pr-flow |
+| "CI failed — diagnose" | caia-fix-it | failure-diagnosis |
+| "Run the steward gatekeeper analysis" | caia-steward | gatekeeper-verdict |
+| "Capture this incident as a lesson" | caia-mentor | lesson-capture |
+| "Scan findings + emit alarms" | caia-curator | action-routing |
+
+## Orchestrator forwarding (optional)
+
+When `CAIA_ORCHESTRATOR_URL` is set in the dashboard process environment, every chat message is also POSTed to `/prompts` on the orchestrator (fire-and-forget — failures don't block the chat stream). The returned prompt ID is surfaced in the assistant's reply so operators can jump to the prompt-journey UI.
+
+## Subscription-only constraint
+
+The `/api/chat` endpoint NEVER calls Anthropic's API or any paid LLM service. The synthesised response is fully local + deterministic. Operators who want true LLM-backed chat can swap the streamer for `streamText` with an `ollama:llama3.2:3b` provider locally — the AI SDK protocol is provider-agnostic.
+
+## Tests
+
+- `tests/chat-routing.test.ts` — 16 unit tests covering every routing rule + the unrouted fallback.
+- `tests/chat-route.test.ts` — 7 integration tests for the POST handler (happy path, 400s, header propagation, orchestrator fail-soft).
+
+Run `pnpm --filter @caia-app/dashboard test`.

--- a/apps/dashboard/components/nav/groups.ts
+++ b/apps/dashboard/components/nav/groups.ts
@@ -44,6 +44,7 @@ export const NAV_GROUPS: NavGroup[] = [
     icon: '📋',
     defaultExpanded: true,
     leaves: [
+      { path: '/chat', label: 'Chat', icon: '💭', tabKey: 'chat' },
       { path: '/prompts', label: 'Prompts', icon: '💬', tabKey: 'prompts' },
       { path: '/submit', label: 'Submit', icon: '➕', tabKey: 'submit' },
       { path: '/queue', label: 'Queue', icon: '🎯', tabKey: 'queue' },

--- a/apps/dashboard/lib/chat/routing.ts
+++ b/apps/dashboard/lib/chat/routing.ts
@@ -1,0 +1,154 @@
+/**
+ * Routing taxonomy for the operator-chat panel.
+ *
+ * Mirrors the deterministic local-provider in `@chiefaia/prompt-evals`'s
+ * `evals/_lib/local-provider.mjs`. Inlined here so the dashboard route
+ * has zero runtime dep on the workspace package.
+ *
+ * Wave 1.3 of the Enterprise Wave 1 campaign per
+ * `agent/memory/enterprise_ai_landscape_directive.md` (W1-2-add).
+ */
+
+export interface RouteDecision {
+  agent: string;
+  classification: string;
+  matchedRule: string | null;
+}
+
+const ROUTING_KEYWORDS: Record<string, ReadonlyArray<{ rx: RegExp; classification: string }>> = {
+  'caia-po': [
+    { rx: /decompose|story|epic|initiative/i, classification: 'decomposition' },
+    { rx: /classify|domain|taxonomy/i, classification: 'classification' }
+  ],
+  'caia-ba': [
+    { rx: /acceptance criteria|enrich|ticket template/i, classification: 'enrichment' },
+    { rx: /consultant|architect|database/i, classification: 'consultation' }
+  ],
+  'caia-ea': [
+    { rx: /architecture|design|build-vs-buy/i, classification: 'architecture' }
+  ],
+  'caia-validator': [
+    { rx: /done|dod|definition of done/i, classification: 'dod-check' },
+    { rx: /premature|skipped|--no-verify|gh pr close/i, classification: 'red-flag' }
+  ],
+  'caia-test-design': [
+    { rx: /test plan|unit test|integration|e2e|adversarial/i, classification: 'plan-design' }
+  ],
+  'caia-coding': [
+    { rx: /implement|write code|patch|feature branch/i, classification: 'implementation' },
+    { rx: /\bpr\b|merge|push|gh pr create/i, classification: 'pr-flow' }
+  ],
+  'caia-fix-it': [
+    { rx: /failing|red|broken|ci failed/i, classification: 'failure-diagnosis' },
+    { rx: /flake|timing|retry/i, classification: 'flake-handling' }
+  ],
+  'caia-steward': [
+    { rx: /gatekeeper|failure mode|block|warn|pass/i, classification: 'gatekeeper-verdict' }
+  ],
+  'caia-mentor': [
+    { rx: /lesson|incident|root cause|classification/i, classification: 'lesson-capture' }
+  ],
+  'caia-curator': [
+    {
+      rx: /scan|finding|alarm|pr proposal|backlog directive|industry briefing/i,
+      classification: 'action-routing'
+    }
+  ]
+};
+
+// Order matters: more specific agents come first so general rules (e.g.,
+// PO's `story` regex) don't snipe a more-specific match (e.g., BA's `enrich`).
+const AGENT_ORDER = [
+  'caia-validator',
+  'caia-fix-it',
+  'caia-steward',
+  'caia-mentor',
+  'caia-curator',
+  'caia-test-design',
+  'caia-ea',
+  'caia-ba',
+  'caia-coding',
+  'caia-po'
+];
+
+export function routeMessage(content: string): RouteDecision {
+  for (const agent of AGENT_ORDER) {
+    const rules = ROUTING_KEYWORDS[agent];
+    if (!rules) continue;
+    for (const rule of rules) {
+      if (rule.rx.test(content)) {
+        return { agent, classification: rule.classification, matchedRule: rule.rx.source };
+      }
+    }
+  }
+  return { agent: 'caia-po', classification: 'unrouted', matchedRule: null };
+}
+
+export interface OrchestratorForwardResult {
+  promptId: string | null;
+  forwarded: boolean;
+}
+
+/**
+ * Forward the prompt to the orchestrator if configured. Fire-and-forget;
+ * never throws.
+ */
+export async function maybeForwardToOrchestrator(content: string): Promise<OrchestratorForwardResult> {
+  const url = process.env['CAIA_ORCHESTRATOR_URL'];
+  if (!url) return { promptId: null, forwarded: false };
+  try {
+    const res = await fetch(`${url}/prompts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: content, receivedVia: 'chat' })
+    });
+    if (!res.ok) return { promptId: null, forwarded: false };
+    const data = (await res.json()) as { id?: string };
+    return { promptId: data.id ?? null, forwarded: true };
+  } catch {
+    return { promptId: null, forwarded: false };
+  }
+}
+
+export function buildAssistantText(
+  decision: RouteDecision,
+  promptIdInfo: OrchestratorForwardResult
+): string[] {
+  const lines: string[] = [];
+  lines.push(`Routed to **${decision.agent}** (classification: \`${decision.classification}\`).`);
+  if (decision.matchedRule) {
+    lines.push(`Matched routing rule: \`${decision.matchedRule}\`.`);
+  } else {
+    lines.push('No routing rule matched — defaulted to caia-po.');
+  }
+  lines.push('');
+  if (promptIdInfo.forwarded && promptIdInfo.promptId) {
+    lines.push(`Forwarded to orchestrator as prompt \`${promptIdInfo.promptId}\`.`);
+    lines.push(`See it land at \`/prompts/${promptIdInfo.promptId}\`.`);
+  } else if (promptIdInfo.forwarded) {
+    lines.push('Forwarded to orchestrator but no prompt ID returned.');
+  } else {
+    lines.push('Orchestrator not configured (set `CAIA_ORCHESTRATOR_URL` to forward prompts live).');
+  }
+  return lines;
+}
+
+/**
+ * Encode a string as a Vercel AI SDK Data Stream Protocol "text" chunk.
+ * @see https://sdk.vercel.ai/docs/ai-sdk-ui/stream-protocol#data-stream-protocol
+ */
+export function encodeTextChunk(text: string): string {
+  return `0:${JSON.stringify(text)}\n`;
+}
+
+/**
+ * Encode the AI SDK's "finish_message" frame so the client's useChat
+ * hook closes the message cleanly.
+ */
+export function encodeFinishMessage(promptTokens: number, completionTokens: number): string {
+  const payload = {
+    finishReason: 'stop',
+    usage: { promptTokens, completionTokens }
+  };
+  return `d:${JSON.stringify(payload)}\n`;
+}

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -2,30 +2,39 @@
   "name": "@caia-app/dashboard",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 7777",
     "build": "next build",
-    "start": "next start -p 7777",
-    "typecheck": "tsc --noEmit",
+    "dev": "next dev -p 7777",
     "lighthouse": "lhci autorun --config=./lighthouserc.cjs",
+    "size-limit": "size-limit",
+    "start": "next start -p 7777",
+    "test": "vitest run",
     "test:a11y": "playwright test tests/a11y.spec.ts",
     "test:visual": "playwright test tests/visual.spec.ts",
-    "visual:update": "playwright test tests/visual.spec.ts --update-snapshots",
-    "size-limit": "size-limit"
+    "typecheck": "tsc --noEmit",
+    "visual:update": "playwright test tests/visual.spec.ts --update-snapshots"
   },
   "dependencies": {
+    "@ai-sdk/react": "^1.2.12",
+    "ai": "^4.3.16",
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "swr": "^2.2.0"
+    "swr": "^2.2.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.0",
     "@lhci/cli": "^0.14.0",
     "@playwright/test": "^1.48.0",
     "@size-limit/preset-app": "^11.1.0",
+    "@testing-library/react": "^16.0.1",
     "@types/node": "^20",
     "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
     "size-limit": "^11.1.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.1"
   }
 }

--- a/apps/dashboard/tests/chat-route.test.ts
+++ b/apps/dashboard/tests/chat-route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../app/api/chat/route';
+
+beforeEach(() => {
+  delete process.env['CAIA_ORCHESTRATOR_URL'];
+});
+
+function makeReq(body: unknown): Request {
+  return new Request('http://localhost:7777/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+async function readStreamToText(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return '';
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value);
+  }
+  return out;
+}
+
+describe('POST /api/chat', () => {
+  it('returns 400 when the request body is invalid JSON', async () => {
+    const req = new Request('http://localhost:7777/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json'
+    });
+    const res = await POST(req as never);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when the messages array has no user role', async () => {
+    const res = await POST(
+      makeReq({ messages: [{ role: 'assistant', content: 'hi' }] }) as never
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 + streams a routing decision for a PO-routed message', async () => {
+    const res = await POST(
+      makeReq({
+        messages: [{ role: 'user', content: 'Decompose this story into tasks.' }]
+      }) as never
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-caia-routed-agent')).toBe('caia-po');
+    expect(res.headers.get('x-caia-classification')).toBe('decomposition');
+    expect(res.headers.get('x-caia-forwarded')).toBe('0');
+    expect(res.headers.get('x-vercel-ai-data-stream')).toBe('v1');
+
+    const text = await readStreamToText(res.body);
+    expect(text).toContain('caia-po');
+    expect(text).toContain('decomposition');
+    // AI SDK Data Stream Protocol — text chunks start with `0:`.
+    expect(text).toMatch(/^0:/);
+    // Final finish chunk uses prefix `d:`.
+    expect(text).toContain('d:');
+  });
+
+  it('routes a coding prompt to caia-coding', async () => {
+    const res = await POST(
+      makeReq({
+        messages: [{ role: 'user', content: 'Implement the new feature branch.' }]
+      }) as never
+    );
+    expect(res.headers.get('x-caia-routed-agent')).toBe('caia-coding');
+    expect(res.headers.get('x-caia-classification')).toBe('implementation');
+  });
+
+  it('forwards the prompt to the orchestrator when CAIA_ORCHESTRATOR_URL is set', async () => {
+    process.env['CAIA_ORCHESTRATOR_URL'] = 'http://orchestrator.test';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response(JSON.stringify({ id: 'prm_abc123' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    });
+
+    const res = await POST(
+      makeReq({
+        messages: [{ role: 'user', content: 'Decompose this.' }]
+      }) as never
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://orchestrator.test/prompts',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(res.headers.get('x-caia-forwarded')).toBe('1');
+    expect(res.headers.get('x-caia-prompt-id')).toBe('prm_abc123');
+    fetchSpy.mockRestore();
+  });
+
+  it('does NOT crash when the orchestrator returns 500', async () => {
+    process.env['CAIA_ORCHESTRATOR_URL'] = 'http://orchestrator.test';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response('boom', { status: 500 });
+    });
+
+    const res = await POST(
+      makeReq({ messages: [{ role: 'user', content: 'Decompose this.' }] }) as never
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-caia-forwarded')).toBe('0');
+    fetchSpy.mockRestore();
+  });
+
+  it('does NOT crash when fetch itself rejects', async () => {
+    process.env['CAIA_ORCHESTRATOR_URL'] = 'http://orchestrator.test';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('network down');
+    });
+
+    const res = await POST(
+      makeReq({ messages: [{ role: 'user', content: 'Decompose this.' }] }) as never
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-caia-forwarded')).toBe('0');
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/dashboard/tests/chat-routing.test.ts
+++ b/apps/dashboard/tests/chat-routing.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { routeMessage } from '../lib/chat/routing';
+
+describe('routeMessage — CAIA subagent routing', () => {
+  it('routes a "decompose this story" message to caia-po', () => {
+    const r = routeMessage('Decompose this story into Initiative -> Epic -> Story -> Task.');
+    expect(r.agent).toBe('caia-po');
+    expect(r.classification).toBe('decomposition');
+    expect(r.matchedRule).not.toBeNull();
+  });
+
+  it('routes a "classify domain" message to caia-po (classification rule)', () => {
+    const r = routeMessage('Classify this prompt domain into our taxonomy.');
+    expect(r.agent).toBe('caia-po');
+    expect(r.classification).toBe('classification');
+  });
+
+  it('routes a "enrich with acceptance criteria" message to caia-ba', () => {
+    const r = routeMessage('Enrich this story with acceptance criteria + ticket template payload.');
+    expect(r.agent).toBe('caia-ba');
+    expect(r.classification).toBe('enrichment');
+  });
+
+  it('routes an "architecture decision" message to caia-ea', () => {
+    // Uses unique architecture vocabulary so PO's classification rule doesn't fire first.
+    const r = routeMessage('Make a build-vs-buy architecture call here.');
+    expect(r.agent).toBe('caia-ea');
+    expect(r.classification).toBe('architecture');
+  });
+
+  it('routes a DoD-check message to caia-validator', () => {
+    const r = routeMessage('Run the definition of done checklist.');
+    expect(r.agent).toBe('caia-validator');
+    expect(r.classification).toBe('dod-check');
+  });
+
+  it('routes a premature-completion red-flag message to caia-validator', () => {
+    const r = routeMessage('Premature completion: typecheck was skipped before merge.');
+    expect(r.agent).toBe('caia-validator');
+    expect(r.classification).toBe('red-flag');
+  });
+
+  it('routes a test-plan message to caia-test-design', () => {
+    const r = routeMessage('Write the unit test plan for the new endpoint.');
+    expect(r.agent).toBe('caia-test-design');
+    expect(r.classification).toBe('plan-design');
+  });
+
+  it('routes an "implement this" message to caia-coding', () => {
+    const r = routeMessage('Implement the new authentication endpoint.');
+    expect(r.agent).toBe('caia-coding');
+    expect(r.classification).toBe('implementation');
+  });
+
+  it('routes a "PR-flow" message to caia-coding (pr rule)', () => {
+    const r = routeMessage('Open the PR and merge with auto-merge.');
+    expect(r.agent).toBe('caia-coding');
+    expect(r.classification).toBe('pr-flow');
+  });
+
+  it('routes a "CI failed" message to caia-fix-it', () => {
+    const r = routeMessage('CI failed on PR 342 with a typecheck error.');
+    expect(r.agent).toBe('caia-fix-it');
+    expect(r.classification).toBe('failure-diagnosis');
+  });
+
+  it('routes a flake message to caia-fix-it', () => {
+    const r = routeMessage('This test is flaky due to timing — recommend a retry.');
+    expect(r.agent).toBe('caia-fix-it');
+    expect(r.classification).toBe('flake-handling');
+  });
+
+  it('routes a gatekeeper-verdict message to caia-steward', () => {
+    const r = routeMessage('Run the steward gatekeeper analysis on PR 342.');
+    expect(r.agent).toBe('caia-steward');
+    expect(r.classification).toBe('gatekeeper-verdict');
+  });
+
+  it('routes a lesson-capture message to caia-mentor', () => {
+    const r = routeMessage('Capture this incident as a lesson; root cause was X.');
+    expect(r.agent).toBe('caia-mentor');
+    expect(r.classification).toBe('lesson-capture');
+  });
+
+  it('routes a curator action-routing message to caia-curator', () => {
+    const r = routeMessage('Scan findings and emit alarms via caia-curator act.');
+    expect(r.agent).toBe('caia-curator');
+    expect(r.classification).toBe('action-routing');
+  });
+
+  it('defaults to caia-po with unrouted classification when no rule matches', () => {
+    const r = routeMessage('Hi, how are you?');
+    expect(r.agent).toBe('caia-po');
+    expect(r.classification).toBe('unrouted');
+    expect(r.matchedRule).toBeNull();
+  });
+
+  it('exposes the matched rule source for diagnostics', () => {
+    const r = routeMessage('Decompose this.');
+    expect(typeof r.matchedRule).toBe('string');
+  });
+});

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+/**
+ * Dashboard unit-test config — runs `tests/*.test.ts(x)` only. Playwright
+ * specs (`tests/*.spec.ts`) are excluded because they need a running
+ * Next.js dev server + a browser, which Playwright manages itself.
+ */
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+    exclude: ['node_modules', 'tests/**/*.spec.ts']
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,15 @@ importers:
 
   apps/dashboard:
     dependencies:
+      '@ai-sdk/react':
+        specifier: ^1.2.12
+        version: 1.2.12(react@18.3.1)(zod@3.25.76)
+      ai:
+        specifier: ^4.3.16
+        version: 4.3.19(react@18.3.1)(zod@3.25.76)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -69,6 +75,9 @@ importers:
       swr:
         specifier: ^2.2.0
         version: 2.4.1(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.10.0
@@ -82,18 +91,33 @@ importers:
       '@size-limit/preset-app':
         specifier: ^11.1.0
         version: 11.2.0(size-limit@11.2.0)
+      '@testing-library/react':
+        specifier: ^16.0.1
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^20
         version: 20.19.39
       '@types/react':
         specifier: ^18
         version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.39))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       size-limit:
         specifier: ^11.1.0
         version: 11.2.0
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@25.0.1)
 
   apps/db-backup: {}
 
@@ -214,7 +238,7 @@ importers:
         version: 1.19.14(hono@4.12.15)
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -356,7 +380,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
-        version: 1.29.0(zod@4.3.6)
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       pg:
         specifier: ^8.13.0
         version: 8.20.0
@@ -1415,7 +1439,7 @@ importers:
         version: 20.19.39
       promptfoo:
         specifier: ^0.103.0
-        version: 0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.35)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
+        version: 0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1836,6 +1860,32 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@ai-zen/node-fetch-event-source@2.1.4':
     resolution: {integrity: sha512-OHFwPJecr+qwlyX5CGmTvKAKPZAdZaxvx/XDqS1lx4I2ZAk9riU0XnEaRGOOAEFrdcLZ98O5yWqubwjaQc0umg==}
@@ -3844,6 +3894,10 @@ packages:
     resolution: {integrity: sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -4690,6 +4744,9 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -5019,6 +5076,16 @@ packages:
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -5427,6 +5494,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -5889,6 +5960,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -7297,6 +7371,15 @@ packages:
       canvas:
         optional: true
 
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -7338,6 +7421,11 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -8777,6 +8865,9 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -9210,6 +9301,10 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -9977,6 +10072,34 @@ snapshots:
       zod: 3.25.76
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      react: 18.3.1
+      swr: 2.4.1(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@ai-zen/node-fetch-event-source@2.1.4':
     dependencies:
@@ -12460,7 +12583,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.15)
       ajv: 8.20.0
@@ -12479,10 +12602,12 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.15)
       ajv: 8.20.0
@@ -12501,6 +12626,8 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12578,6 +12705,8 @@ snapshots:
   '@opentelemetry/api-logs@0.215.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -13645,6 +13774,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -14086,6 +14217,18 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ai@4.3.19(react@18.3.1)(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
+    optionalDependencies:
+      react: 18.3.1
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -14513,6 +14656,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
 
@@ -14942,6 +15087,8 @@ snapshots:
   devtools-protocol@0.0.1495869: {}
 
   didyoumean@1.2.2: {}
+
+  diff-match-patch@1.0.5: {}
 
   diff-sequences@29.6.3: {}
 
@@ -16655,6 +16802,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
@@ -16703,6 +16878,12 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -17114,7 +17295,7 @@ snapshots:
 
   netmask@2.1.1: {}
 
-  next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -17124,7 +17305,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -17751,7 +17932,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
-  ? promptfoo@0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.35)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
+  ? promptfoo@0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
   : dependencies:
       '@adaline/anthropic': 0.20.0
       '@adaline/azure': 0.9.2
@@ -17767,7 +17948,7 @@ snapshots:
       '@anthropic-ai/sdk': 0.36.3
       '@apidevtools/json-schema-ref-parser': 11.9.3
       '@aws-sdk/client-bedrock-runtime': 3.1043.0
-      '@aws-sdk/credential-provider-sso': 3.972.35
+      '@aws-sdk/credential-provider-sso': 3.972.38
       '@azure/identity': 4.13.1
       '@azure/openai-assistants': 1.0.0-beta.6
       '@fal-ai/serverless-client': 0.14.3
@@ -18277,6 +18458,8 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
+  secure-json-parse@2.7.0: {}
+
   secure-json-parse@4.1.0: {}
 
   seedrandom@3.0.5: {}
@@ -18691,10 +18874,12 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  styled-jsx@5.1.1(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
@@ -18887,6 +19072,8 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  throttleit@2.1.0: {}
 
   through@2.3.8: {}
 
@@ -19313,6 +19500,41 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@1.6.1(@types/node@20.19.39)(jsdom@25.0.1):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.19.39)
+      vite-node: 1.6.1(@types/node@20.19.39)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## What

Wave 1.3 of the Enterprise Wave 1 campaign per `agent/memory/enterprise_ai_landscape_directive.md` (W1-2-add).

Adds an agent-native chat surface to the operator dashboard so it is no longer engineer-facing-only. Operators type a question, it is routed to the appropriate CAIA subagent role + (optionally) forwarded to the live orchestrator, and the response is streamed back via the Vercel AI SDK Data Stream Protocol.

## Ships

### Frontend

- `apps/dashboard/app/chat/page.tsx` — new `/chat` route.
- `apps/dashboard/components/chat/ChatPanel.tsx` — client component using `@ai-sdk/react`'s `useChat` hook + the dashboard's dark-theme styles.
- `apps/dashboard/components/nav/groups.ts` — Sidebar wired with new 'Chat' leaf at the top of the Work group.

### Backend

- `apps/dashboard/app/api/chat/route.ts` — POST handler that streams Vercel AI SDK Data Stream Protocol chunks (`0:\"<text>\"\\n` ... `d:{...}\\n`).
- `apps/dashboard/lib/chat/routing.ts` — routing taxonomy + AI-SDK encoders + orchestrator forwarder. Mirrors the deterministic provider in `@chiefaia/prompt-evals`.

### Routing

- 10-agent routing taxonomy (caia-po / ba / ea / validator / test-design / coding / fix-it / steward / mentor / curator) — same regex set as W1-2 eval suites for consistency.
- More-specific agents listed first in the resolution order so general rules don't snipe specific ones.

### Tests

- 23 new unit tests via vitest — 16 routing + 7 integration. All green.
- Dashboard now has a unit-test surface alongside its existing Playwright a11y / visual specs.

### Deps added (dashboard)

| Dep | Version | Purpose |
|-----|---------|---------|
| `@ai-sdk/react` | ^1.2.12 | useChat hook |
| `ai` | ^4.3.16 | Streaming utilities (currently using protocol directly) |
| `zod` | ^3.23.8 | Future request validation |
| `vitest` | ^1.6.1 | Unit-test runner |
| `@vitejs/plugin-react` | ^4.3.4 | JSX support |
| `jsdom` | ^25.0.1 | Test environment |
| `@testing-library/react` | ^16.0.1 | Component testing |

## Stage 8 live verify on Mac

```
pnpm --filter @caia-app/dashboard dev
curl -X POST http://localhost:7777/api/chat -d '{"messages":[{"role":"user","content":"Decompose this story: build a chat panel."}]}'
  → HTTP 200
  → x-caia-routed-agent: caia-po
  → x-caia-classification: decomposition
  → x-vercel-ai-data-stream: v1
  → 0:"Routed to **caia-po** (classification: \`decomposition\`).\\n"
  → 0:"Matched routing rule: \`decompose|story|epic|initiative\`.\\n"
  → 0:"\\n"
  → 0:"Orchestrator not configured (set \`CAIA_ORCHESTRATOR_URL\` to forward prompts live).\\n"
  → d:{"finishReason":"stop","usage":{"promptTokens":41,"completionTokens":197}}
GET http://localhost:7777/chat
  → HTML renders ChatPanel + new Chat leaf in sidebar (active state).
```

## Constraints honoured

- **Subscription-only constraint preserved**: `/api/chat` NEVER calls Anthropic. The synthesised response is fully local + deterministic. Operators who want true LLM-backed chat can swap the streamer for `streamText()` with `ollama:llama3.2:3b` locally — the AI SDK protocol is provider-agnostic.
- **Mac M-series 16GB primary surface** — no GPU, no large model downloads.
- **No new daemons** — uses the existing Next.js dashboard runtime.
- **Library-first** — no `@chiefaia`-shaped code is duplicated; the routing taxonomy is dashboard-local because pulling in a workspace dep would force a Node-runtime dep on the shipped Next.js bundle.

## Pre-existing build issue (not introduced by this PR)

Local Mac `pnpm --filter @caia-app/dashboard build` may fail on `Static page generation for /api/completeness-summary-proxy is still timing out after 3 attempts` — this is the same intermittent issue documented in leg-9 handoff (was present before this PR; reproducible on quiet Mac too). The chat page uses `dynamic = 'force-dynamic'` so it doesn't participate in static prerender. CI's Linux runners typically don't hit this. If CI does fail, it's pre-existing.

## DoD

- [x] Stage 1 — analyse (existing dashboard layout + sidebar + API route patterns)
- [x] Stage 2 — research (Vercel AI SDK Data Stream Protocol, useChat hook, Next.js route export rules)
- [x] Stage 3 — solution (handler-only route + lib helpers + sidebar wire-in + vitest setup)
- [x] Stage 4 — implement (1003 LoC across 11 files)
- [x] Stage 5 — unit test (23 tests, all green)
- [x] Stage 6 — integration test (POST /api/chat returns 200 + streamed response with correct headers)
- [x] Stage 7 — deploy (this PR)
- [x] Stage 8 — live verify (dev server + curl + HTML response captured)
- [ ] Stage 9 — regression test (CI matrix run)
- [ ] Stage 10 — document (this PR + components/chat/README.md + handoff)