### PR TITLE
feat(apprentice-corpus): @chiefaia/apprentice-corpus Phase 0 — corpus aggregator

### DIFF
--- a/packages/apprentice-corpus/DESIGN.md
+++ b/packages/apprentice-corpus/DESIGN.md
@@ -1,0 +1,327 @@
+# `@chiefaia/apprentice-corpus` — Phase 0 Design
+
+**Status**: Phase 0 of the Apprentice Agent (per `agent/memory/apprentice_agent_directive.md`).
+**Shape**: Option E — CAIA-Bonded Skeleton (per `agent_architecture_shape_2026-05-06.md`).
+**Author**: Apprentice Phase 0 leg 2 (2026-05-06).
+**Scope**: corpus aggregator only. Phases 1-4 (eval, training, serving, retrainer) are siblings, NOT this package.
+
+## 1. Mandate
+
+Aggregate CAIA's accumulated artifacts (events, memory, reports, traces, GitHub history) into a unified instruction-output corpus suitable for QLoRA fine-tuning of a 7B base model on Mac M-series. Output is a date-stamped corpus directory containing `samples.jsonl` plus `manifest.json`.
+
+Phase 1 (eval harness) consumes the manifest to score base + adapter; Phase 2 (training) consumes `samples.jsonl` directly via MLX-LM `--data-format messages`.
+
+## 2. Package shape (Option E checklist)
+
+- ✅ `packages/apprentice-corpus/` (NOT `apps/apprentice/corpus-aggregator/` — apps consume packages)
+- ✅ `package.json`: `"private": true`, scope `@chiefaia/apprentice-corpus`, never published
+- ✅ Public API parameterised via `ApprenticeCorpusConfig` constructor — every CAIA path/URL/topic/registry is a parameter with a CAIA default
+- ✅ Tests inject fixture corpora at `tests/__fixtures__/mini-{memory,reports,events}/` — never live CAIA paths
+- ✅ Pre-spawn injection: when this aggregator distills via `claude` binary, the prompt passes through `caia-mentor-prepend | caia-librarian-prepend` (unchanged from existing CAIA convention) — orchestrator wires; package itself doesn't bypass
+- ✅ AGENTS.md (when filed at repo root) is consulted for build/test/lint commands; this package has no special override
+
+## 3. Public API
+
+```typescript
+import { ApprenticeCorpusAggregator } from '@chiefaia/apprentice-corpus';
+
+const aggregator = new ApprenticeCorpusAggregator({
+  // All optional — CAIA defaults filled in by constructor.
+  memoryRoot: '/Users/MAC/Library/Application Support/Claude/local-agent-mode-sessions/<session>/agent/memory',
+  reportsRoot: '~/Documents/projects/reports',
+  eventsDbPath: '~/.caia/mentor/events.sqlite',  // mentor-event-bus default
+  langfuseProjectId: 'caia-prod',                // stub — Langfuse not yet operational
+  langfuseEnabled: false,                         // explicit opt-in once Langfuse ships
+  githubRepo: 'chiefaia/caia',
+  outputRoot: '~/Documents/projects/apprentice/corpora',
+  claudeBinaryPath: 'claude',
+  distillEnabled: true,
+  // Behaviour knobs:
+  maxSamples: 50_000,
+  minSampleLengthChars: 80,
+  maxSampleLengthChars: 16_000,
+  qualityThreshold: 0.4,
+  redactPII: true,
+  // Dependency injection (test seams):
+  fs: defaultFsReader,
+  eventBus: defaultEventBusClient,
+  github: defaultGithubClient,
+  langfuse: defaultLangfuseClient,
+  claudeDistiller: defaultClaudeDistiller,
+  clock: () => new Date(),
+});
+
+const manifest = await aggregator.aggregate();
+// manifest.outputDir is `<outputRoot>/<YYYY-MM-DD>/`
+// manifest.totals.final is the final sample count
+```
+
+CLI:
+
+```bash
+caia-apprentice-corpus aggregate                    # use CAIA defaults
+caia-apprentice-corpus aggregate --dry-run          # plan only, no writes
+caia-apprentice-corpus aggregate --memory-root X    # override single param
+```
+
+## 4. Source readers
+
+Each reader implements:
+
+```typescript
+interface SourceReader {
+  readonly source: SourceTag;       // 'events'|'memory'|'reports'|'langfuse'|'github'
+  read(ctx: ReaderContext): Promise<RawArtifact[]>;
+}
+
+interface RawArtifact {
+  source: SourceTag;
+  sourceId: string;        // file path / event id / trace id / PR number
+  correlationId?: string;  // optional thread-id for grouping
+  kind?: string;           // memory: directive/feedback/...; events: TaskCompleted/...
+  text: string;            // raw textual content
+  sidecar?: Record<string, unknown>;  // optional structured metadata
+  createdAtMs: number;
+}
+```
+
+**5 readers:**
+
+| Reader | Substrate | Default behaviour | Phase 0 status |
+|--------|-----------|-------------------|----------------|
+| `event-bus-reader.ts` | `@chiefaia/mentor-event-bus` `queryEvents` over events.sqlite | All events; chronological; bounded by `maxAgeDays` (default 365) | full |
+| `memory-walker.ts` | node:fs over `memoryRoot` | Walks `*.md`, classifies by filename (directive/feedback/proposal/...), mirrors librarian `pathToKind` rules | full |
+| `reports-walker.ts` | node:fs over `reportsRoot` | Walks `*.md`, treats each as one artifact | full |
+| `langfuse-reader.ts` | fetch /api/public/traces (placeholder) | Returns `[]` if `langfuseEnabled=false` (default); when enabled, paginates traces | **STUB** — full impl deferred to leg 3 once Langfuse operational |
+| `github-reader.ts` | `gh` subprocess (`gh pr list --json`, `gh api`) | Pulls merged PR titles + bodies + Evidence-Gate check results; rate-limited; bounded by `maxAgeDays` | full |
+
+Each reader is independently testable with a fixture-based fake. The aggregator depends on the `SourceReader[]` array, NOT on the concrete fs/event-bus/gh — those are injected via the config.
+
+## 5. Normaliser — RawArtifact → InstructionPair
+
+Heuristics per source kind. The normaliser is a single function with a switch on `source + kind`:
+
+| Source/kind | Instruction | Response | Notes |
+|-------------|-------------|----------|-------|
+| `memory/directive` | "Summarize the standing rule in this directive." | First non-frontmatter paragraph + key bullets | Title becomes part of the instruction. |
+| `memory/feedback` | "What does this feedback say to do/avoid, and why?" | Body + the **Why:** + **How to apply:** lines | Required for catching operator's voice |
+| `memory/architecture` | "Explain the architectural decision in this document." | Body extract | Inputs trimmed to `maxSampleLengthChars`. |
+| `events/PRMerged` | "What was merged in this PR, and what was its purpose?" | Title + body if available | Pulls from event payload. |
+| `events/PostMergeBugReport` | "A regression was reported. What was the issue, and what was learned?" | Body | Used to reinforce DoD discipline. |
+| `events/OperatorCorrection` | "An operator correction was issued. What was wrong, and what's the corrected approach?" | Body | High-quality signal — operator's voice |
+| `events/EvidenceGateFailure` | "An Evidence Gate check failed. What was the failure, and how should it be avoided?" | Body | Mentor's territory but corpus-relevant. |
+| `reports/*` | "Summarize this report." | First section + section headings | Reports are diverse; light touch. |
+| `github/PR` | "What was the goal of this PR and how was it accomplished?" | Title + body + linked issue + checks | Distilled by claude if low-quality. |
+
+Skipped artifacts (no instruction-output extractable): files with frontmatter only, empty events, files smaller than `minSampleLengthChars`.
+
+System message attached to every sample: a stable ≤500-token CAIA primer (constants/`SYSTEM_PROMPT.md`-like) covering the 10-stage DoD, decision-classifier, no-API-key-billing, git-flow rules.
+
+## 6. Dedupe
+
+`Set<contentSha256>` over the normalised `messages[].content` joined by `\n`. First occurrence wins; duplicates dropped. Hash is stored on every sample's `meta.contentSha256` for downstream consumers (Phase 1 eval harness uses it to detect train/eval contamination).
+
+## 7. PII masker
+
+Three regex passes, conservative (false-positives acceptable; false-negatives unacceptable for training data):
+
+1. **Email** — `[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}` → `[redacted-email]`
+2. **API-key-shapes** (gitleaks-style):
+   - `sk-[A-Za-z0-9]{20,}` → `[redacted-secret]` (Anthropic / OpenAI shape)
+   - `ghp_[A-Za-z0-9]{36}` → `[redacted-secret]` (GitHub PAT)
+   - `glpat-[A-Za-z0-9_-]{20}` → `[redacted-secret]` (GitLab PAT)
+   - 32-byte+ hex blocks adjacent to common secret keywords (`secret|password|token|api[_-]?key`) → `[redacted-secret]`
+3. **Local paths with username** — `/Users/[A-Za-z0-9_-]+/` → `~/` (per `path-standards.md`)
+
+The set of redacted span types per sample is recorded in `meta.redactedSpans` for audit.
+
+Operator's name + email (`Prakash`, `prakashmailid@gmail.com`) NOT auto-redacted — these appear deliberately in directives + memory and are intentional training signal. The PII-mask path is for credentials, not identities.
+
+## 8. Quality filter
+
+Each `InstructionPair` gets a quality score 0..1 from a small set of heuristics:
+
+| Heuristic | Weight | Direction |
+|-----------|--------|-----------|
+| Length within `[minSampleLengthChars, maxSampleLengthChars]` | 0.30 | bonus |
+| Response has structure (bullets / headers / paragraphs > 1) | 0.20 | bonus |
+| Source is a directive/feedback (operator's voice) | 0.20 | bonus |
+| Response contains common "thinking-aloud" filler tokens (`um`, `you know`, voice-transcription artifacts) | 0.20 | penalty |
+| Response is mostly code (≥70% of chars inside backticks) | 0.10 | bonus (code is high-signal for coding adapter) |
+
+Samples with `qualityScore < qualityThreshold` (default 0.4) are NOT discarded directly — they are routed to the **claude-distiller** for refinement. If the distiller can't lift them above threshold, they're dropped with a record in the manifest.
+
+## 9. Claude distillation step
+
+For samples below quality threshold (or marked `distill: true` by source-specific heuristics — e.g. all GitHub PR samples without bodies), invoke `claude` binary subprocess to refine.
+
+**Subprocess pattern** — crib from `@chiefaia/local-llm-router`'s `claude-adapter.ts`:
+
+```typescript
+const result = spawnSync(claudeBinaryPath, [
+  '--print',
+  '--output-format', 'json',
+  '--model', 'claude-haiku-4-5-20251001',  // cheap; distillation, not reasoning
+], {
+  input: distillationPrompt,
+  env: { ...process.env, ANTHROPIC_API_KEY: undefined },  // FORBIDDEN — subscription only
+  timeout: 30_000,
+  encoding: 'utf-8',
+});
+```
+
+**Distillation prompt template** (lives in `src/distill-prompt.txt`):
+
+> You are extracting a high-quality instruction-response pair for fine-tuning. Given the raw artifact below, produce a clean Q/A pair that captures the substantive content. Drop voice-transcription noise. Keep operator decisions verbatim. Output strict JSON `{"instruction": "...", "response": "..."}`.
+>
+> Raw artifact source: `<source>:<kind>`
+> Raw artifact:
+> ```
+> <text>
+> ```
+
+If the binary spawn fails (rate-limited, missing, or returns malformed JSON), the sample is dropped with `dropReason: 'distill-failed'` recorded in the manifest. We NEVER fall back to API-key billing.
+
+**Distillation budget** — bounded by `maxDistillCalls` (default 200). When the budget is exhausted, remaining low-quality candidates are dropped without distillation. The cap is conservative to keep the daily aggregator well under subscription limits.
+
+Distillation is OFF by default in tests (`distillEnabled: false` in the fixture default), and the integration test stubs it. The full path is exercised only in E2E.
+
+## 10. Manifest writer
+
+Final layout per run:
+
+```
+<outputRoot>/<YYYY-MM-DD>/
+├── manifest.json
+├── samples.jsonl
+├── sources.json         # one entry per source artifact considered
+├── dropped.jsonl        # artifacts dropped, with reason
+└── config.json          # snapshot of effective config (with secrets stripped)
+```
+
+`manifest.json` schema (versioned):
+
+```json
+{
+  "version": 1,
+  "generatedAt": "<ISO 8601 UTC>",
+  "outputDir": "<absolute path>",
+  "elapsedMs": 12345,
+  "totals": {
+    "rawArtifacts": 2400,
+    "afterDedup": 2150,
+    "afterPII": 2150,
+    "afterQuality": 1820,
+    "distilled": 130,
+    "dropped": 460,
+    "final": 1820
+  },
+  "perSource": {
+    "events": {"artifacts": 1200, "samples": 980},
+    "memory": {"artifacts": 350, "samples": 340},
+    "reports": {"artifacts": 180, "samples": 170},
+    "github": {"artifacts": 670, "samples": 330},
+    "langfuse": {"artifacts": 0, "samples": 0}
+  },
+  "redactedSpansHistogram": {"email": 12, "secret": 0, "path": 240},
+  "qualityHistogram": {"0.0-0.2": 0, "0.2-0.4": 0, "0.4-0.6": 800, "0.6-0.8": 760, "0.8-1.0": 260},
+  "configSha256": "<hex>",
+  "warnings": []
+}
+```
+
+The manifest is the canonical artifact for Phase 1 eval harness + Phase 4 retrainer cron's "is there enough new data to retrain?" check.
+
+## 11. Aggregator orchestration
+
+The top-level `aggregate()` method runs the pipeline:
+
+```
+readers (parallel)
+   → flatten to RawArtifact[]
+   → normalise to InstructionPair[]
+   → dedupe (drop)
+   → PII-mask (mutate; record spans)
+   → quality-score
+   → split into [≥threshold] and [<threshold]
+   → distill the latter (subprocess; bounded; respect budget)
+   → re-score; merge with passing set
+   → cap at maxSamples (highest quality first; ties broken by recency)
+   → write samples.jsonl + manifest.json + sources.json + dropped.jsonl + config.json
+   → return manifest
+```
+
+All steps are pure functions on plain data. The only IO happens at:
+1. The 5 source readers (read).
+2. The claude-distiller (subprocess).
+3. The manifest writer (write).
+
+This keeps the test surface clean — most logic is testable with fixture corpora and zero IO.
+
+## 12. CAIA-bonding
+
+The CAIA defaults baked into the constructor:
+
+```typescript
+const CAIA_DEFAULTS: Required<ApprenticeCorpusConfig> = {
+  memoryRoot: process.env.CAIA_MEMORY_DIR
+    ?? expandHome('~/Library/Application Support/Claude/local-agent-mode-sessions/<resolved-at-runtime>/agent/memory'),
+  reportsRoot: process.env.CAIA_REPORTS_DIR ?? expandHome('~/Documents/projects/reports'),
+  eventsDbPath: process.env.CAIA_EVENTS_DB ?? expandHome('~/.caia/mentor/events.sqlite'),
+  langfuseEnabled: false,
+  langfuseProjectId: 'caia-prod',
+  githubRepo: process.env.CAIA_GITHUB_REPO ?? 'chiefaia/caia',
+  outputRoot: process.env.APPRENTICE_CORPUS_ROOT ?? expandHome('~/Documents/projects/apprentice/corpora'),
+  claudeBinaryPath: process.env.CLAUDE_BINARY_PATH ?? 'claude',
+  distillEnabled: true,
+  maxSamples: 50_000,
+  minSampleLengthChars: 80,
+  maxSampleLengthChars: 16_000,
+  qualityThreshold: 0.4,
+  maxDistillCalls: 200,
+  maxAgeDays: 365,
+  redactPII: true,
+};
+```
+
+Defaults are surveyed for a Library-path resolver that picks the *current* orchestrator session — Phase 0 leg 2 ships a fixed-path env-var fallback for now (operator can set `CAIA_MEMORY_DIR` if the session ID rotates).
+
+## 13. Out-of-scope (do NOT build in this leg)
+
+- **Apprentice Phase 1** (eval harness) — separate package `packages/apprentice-eval/`
+- **Apprentice Phase 2** (training) — separate package `packages/apprentice-training/`
+- **Phase 3-4** — separate packages
+- **Langfuse integration** — stub only; full reader deferred to leg 3 once Langfuse operational
+- **Cowork session transcript ingestion** — directive lists it as source #1 but the export pipeline is separately specced in the directive's "Triggers to start work" section; deferred to leg 3
+- **Mentor's lesson-typed corpus** — Mentor already exposes its own pre-spawn-injection corpus; we do NOT duplicate it. The `events` reader pulls raw events; Mentor's curated lessons stay in Mentor's domain
+
+## 14. Testability checklist (Option E pre-send check)
+
+- ✅ Package private (`package.json` has `"private": true`)
+- ✅ Public API parameterised — every CAIA path/URL/topic is a constructor parameter with a default
+- ✅ Tests use fixture corpora at `tests/__fixtures__/mini-{memory,reports,events}/`
+- ✅ Mentor + Librarian pre-spawn injection respected (the claude-distiller is the only LLM-call site; orchestrator wires the prepends; package doesn't bypass)
+- ✅ No abstraction for a second consumer
+
+## 15. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Operator-name/email-in-corpus may be undesired by future eval | Documented in §7; opt-in extra redaction via `extraRedactPatterns: RegExp[]` config knob |
+| Langfuse stub returns empty → Phase 1 eval has gaps | Documented in §13; full impl deferred but planned for leg 3 |
+| GitHub `gh` rate limits during heavy runs | Bounded by `maxAgeDays` + paginated reads; if rate-limited, emit warning + continue with partial set |
+| Mentor events DB locked during read | better-sqlite3 opens read-only with `WAL` mode; tested |
+| Disk fills with cumulative corpora | Caller's responsibility (cron rotation + `--max-output-dirs` not in this package); documented in README |
+| Claude binary missing at distillation time | Sample dropped with `dropReason: 'distill-failed'`; pipeline continues |
+| Catastrophic forgetting (operator-style overfitting) at training time | NOT this package's concern (Phase 2 territory); but quality filter §8 guards against thinking-aloud filler accumulation |
+
+## 16. Deployment
+
+LaunchAgent `plists/com.chiefaia.apprentice-corpus.plist` runs `caia-apprentice-corpus aggregate` daily at 02:00 local. Output goes to `~/Documents/projects/apprentice/corpora/<YYYY-MM-DD>/`. Failures append to `~/Library/Logs/chiefaia/apprentice-corpus.log`.
+
+Install:
+
+```bash
+cp packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.chiefaia.apprentice-corpus.plist
+```

--- a/packages/apprentice-corpus/README.md
+++ b/packages/apprentice-corpus/README.md
@@ -1,0 +1,140 @@
+# `@chiefaia/apprentice-corpus`
+
+Phase 0 of the [Apprentice Agent](../../docs/EA/) — corpus aggregator.
+
+Walks CAIA's accumulated artifacts (Mentor events, agent/memory directives + feedback, reports, GitHub PR history, Langfuse traces) and normalises them into a unified instruction-output JSONL corpus suitable for QLoRA fine-tuning of a 7B base model on Mac M-series via MLX-LM.
+
+**Shape**: Option E (CAIA-Bonded Skeleton) — private workspace package, fully parameterised constructor with CAIA defaults, fixture-corpora-tested, never published.
+
+## Pipeline
+
+```
+SourceReader[]  →  RawArtifact[]
+              →  InstructionPair[]    (normaliser)
+              →  dedupe
+              →  PII mask
+              →  quality score
+              →  distill (claude binary subprocess) for low-quality
+              →  cap @ maxSamples
+              →  write samples.jsonl + manifest.json
+```
+
+## Programmatic use
+
+```typescript
+import { ApprenticeCorpusAggregator } from '@chiefaia/apprentice-corpus';
+
+// All defaults bond to CAIA
+const aggregator = new ApprenticeCorpusAggregator();
+const manifest = await aggregator.aggregate();
+console.log(`final corpus: ${manifest.totals.final} samples at ${manifest.outputDir}`);
+```
+
+Override any default via the constructor (testability + non-CAIA fixtures):
+
+```typescript
+const aggregator = new ApprenticeCorpusAggregator({
+  memoryRoot: '/path/to/test/memory',
+  reportsRoot: '/path/to/test/reports',
+  outputRoot: '/tmp/test-corpus',
+  distillEnabled: false,
+  qualityThreshold: 0.0,
+  fs: customFsReader,
+  eventBus: customEventBusClient,
+});
+```
+
+## CLI
+
+```bash
+# Run with CAIA defaults (env-var overrides supported)
+caia-apprentice-corpus aggregate
+
+# Plan only (no writes)
+caia-apprentice-corpus aggregate --dry-run
+
+# Override single config
+caia-apprentice-corpus aggregate --memory-root /path --no-distill
+
+# Help
+caia-apprentice-corpus --help
+```
+
+Env vars (in priority order: CLI flag → env → CAIA fallback):
+
+- `CAIA_MEMORY_DIR` — orchestrator session's `agent/memory/` path
+- `CAIA_REPORTS_DIR` — `~/Documents/projects/reports`
+- `CAIA_EVENTS_DB` — Mentor events.sqlite path
+- `CAIA_GITHUB_REPO` — `chiefaia/caia`
+- `APPRENTICE_CORPUS_ROOT` — `~/Documents/projects/apprentice/corpora`
+- `CLAUDE_BINARY_PATH` — `claude`
+
+## Output layout
+
+```
+<outputRoot>/<YYYY-MM-DD>/
+├── manifest.json     — summary + per-source + histograms + config hash
+├── samples.jsonl     — one JSON / line; `messages[]` payload trainable as-is by MLX-LM --data-format messages
+├── sources.json      — index of source artifacts considered
+├── dropped.jsonl     — one record / drop with `reason`
+└── config.json       — sanitized config snapshot
+```
+
+`samples.jsonl` shape:
+
+```json
+{
+  "id": "<sha256>",
+  "messages": [
+    {"role": "system", "content": "<CAIA primer>"},
+    {"role": "user", "content": "<derived instruction>"},
+    {"role": "assistant", "content": "<derived response>"}
+  ],
+  "meta": {
+    "source": "memory|reports|events|langfuse|github",
+    "sourceId": "...",
+    "kind": "directive|feedback|PRMerged|...",
+    "qualityScore": 0.0-1.0,
+    "distilled": false,
+    "redactedSpans": ["email", "secret", "path"],
+    "createdAt": "<ISO 8601>",
+    "contentSha256": "<sha256>"
+  }
+}
+```
+
+## Hard constraints
+
+- 🚨 **No API-key billing.** Distillation uses `claude` subprocess + subscription session only. `ANTHROPIC_API_KEY` is explicitly cleared from the spawned env.
+- 🚨 **PII masking**: credential shapes (sk-, ghp_, glpat-, AWS access keys, generic secret-keyword + value), emails, and `/Users/<name>/`+`/home/<name>/` paths are masked. Operator's name + email NOT auto-redacted (intentional training signal). Add `extraRedactPatterns` to override.
+- 🚨 **Distillation budget**: `maxDistillCalls` (default 200) caps subscription-bucket consumption per run.
+- 🚨 **Langfuse stub**: returns `[]` until Langfuse goes operational; toggle via `langfuseEnabled: true`.
+
+## Deployment
+
+LaunchAgent runs daily at 02:00 local. Install:
+
+```bash
+# Pass the current orchestrator session id (replace with current value)
+scripts/install-launchagent.sh 6c9158cd-cd01-44af-b82f-bf27b437c618/84f7697e-7ae3-4ba4-9f98-166613a82e98
+```
+
+Logs at `~/Library/Logs/chiefaia/apprentice-corpus.log`.
+
+## Testing
+
+```bash
+pnpm test          # 98 tests (13 unit + 5 integration files)
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+Tests inject fixture corpora at `tests/__fixtures__/mini-{memory,reports}/` — never live CAIA paths. The default constructor (CAIA defaults) is exercised in E2E only.
+
+## See also
+
+- [`DESIGN.md`](DESIGN.md) — full architecture rationale
+- `agent/memory/apprentice_agent_directive.md` — Phase 0 spec
+- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E standing rule
+- `~/Documents/projects/reports/agent-architecture-strategic-decision-2026-05-06.md` §5 — bonding mechanism

--- a/packages/apprentice-corpus/eslint.config.cjs
+++ b/packages/apprentice-corpus/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — replaces .eslintrc.json
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/apprentice-corpus/package.json
+++ b/packages/apprentice-corpus/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@chiefaia/apprentice-corpus",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Apprentice Phase 0 — corpus aggregator. Walks CAIA's accumulated artifacts (Mentor events, agent/memory directives + feedback, reports, GitHub PR history, Langfuse traces) and normalises them into a unified instruction-output JSONL corpus suitable for QLoRA fine-tuning of a 7B base on Mac M-series via MLX-LM. Deduplicates by content hash, masks credential-shaped PII (gitleaks-style), scores quality, and routes low-quality candidates through a bounded `claude` binary distillation step (subscription-only — never API-key billing). Output is a date-stamped corpus directory `<outputRoot>/<YYYY-MM-DD>/` containing `samples.jsonl` (OpenAI chat-completions `messages[]` format) plus `manifest.json` for downstream Phase 1 (eval) and Phase 2 (training) consumers. Ships in Option E shape — private workspace package, fully parameterised constructor with CAIA defaults, fixture-corpora-tested, never published.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-apprentice-corpus": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "plists",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/mentor-event-bus": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus.plist
+++ b/packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus.plist
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  com.chiefaia.apprentice-corpus.plist
+
+  LaunchAgent that runs the Apprentice corpus aggregator daily at
+  02:00 local time. Outputs go to ~/Documents/projects/apprentice/corpora/<YYYY-MM-DD>/.
+
+  Install:
+    cp plists/com.chiefaia.apprentice-corpus.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.chiefaia.apprentice-corpus.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.chiefaia.apprentice-corpus.plist
+    rm ~/Library/LaunchAgents/com.chiefaia.apprentice-corpus.plist
+
+  Caller MUST set CAIA_MEMORY_DIR + CAIA_REPORTS_DIR + CAIA_EVENTS_DB
+  via the EnvironmentVariables block below before installing — the
+  defaults assume a specific orchestrator session id that rotates.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.chiefaia.apprentice-corpus</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>/Users/MAC/Documents/projects/caia/packages/apprentice-corpus/dist/cli.js</string>
+    <string>aggregate</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- Update CAIA_MEMORY_DIR to the current orchestrator session's agent/memory path -->
+    <key>CAIA_MEMORY_DIR</key>
+    <string>/Users/MAC/Library/Application Support/Claude/local-agent-mode-sessions/CURRENT_SESSION_ID/agent/memory</string>
+
+    <key>CAIA_REPORTS_DIR</key>
+    <string>/Users/MAC/Documents/projects/reports</string>
+
+    <key>CAIA_EVENTS_DB</key>
+    <string>/Users/MAC/.caia/mentor/events.sqlite</string>
+
+    <key>CAIA_GITHUB_REPO</key>
+    <string>chiefaia/caia</string>
+
+    <key>APPRENTICE_CORPUS_ROOT</key>
+    <string>/Users/MAC/Documents/projects/apprentice/corpora</string>
+
+    <key>CLAUDE_BINARY_PATH</key>
+    <string>/usr/local/bin/claude</string>
+
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+  </dict>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>2</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/MAC/Library/Logs/chiefaia/apprentice-corpus.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/MAC/Library/Logs/chiefaia/apprentice-corpus.err.log</string>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/MAC/Documents/projects/caia</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <key>Nice</key>
+  <integer>5</integer>
+</dict>
+</plist>

--- a/packages/apprentice-corpus/scripts/install-launchagent.sh
+++ b/packages/apprentice-corpus/scripts/install-launchagent.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Install the Apprentice corpus aggregator LaunchAgent.
+#
+# Usage:
+#   scripts/install-launchagent.sh <orchestrator-session-id>
+#
+# The session id is the path component under ~/Library/Application Support/Claude/local-agent-mode-sessions/
+# that contains the current agent/memory directory.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "" ]]; then
+  echo "usage: $0 <orchestrator-session-id>"
+  echo "  e.g. $0 6c9158cd-cd01-44af-b82f-bf27b437c618/84f7697e-7ae3-4ba4-9f98-166613a82e98"
+  exit 2
+fi
+
+SESSION_ID="$1"
+PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLIST_SRC="$PKG_DIR/plists/com.chiefaia.apprentice-corpus.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/com.chiefaia.apprentice-corpus.plist"
+LOG_DIR="$HOME/Library/Logs/chiefaia"
+
+if [[ ! -f "$PLIST_SRC" ]]; then
+  echo "missing plist source: $PLIST_SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$LOG_DIR"
+
+# Patch the session id into a copy of the plist
+sed "s|CURRENT_SESSION_ID|$SESSION_ID|g" "$PLIST_SRC" > "$PLIST_DST"
+
+# Reload the agent
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load "$PLIST_DST"
+
+echo "installed LaunchAgent: $PLIST_DST"
+echo "logs: $LOG_DIR/apprentice-corpus.log"
+echo "next run: tomorrow at 02:00 local"

--- a/packages/apprentice-corpus/src/aggregator.ts
+++ b/packages/apprentice-corpus/src/aggregator.ts
@@ -1,0 +1,357 @@
+/**
+ * Top-level aggregator. Wires together the 5 source readers, the
+ * normaliser, dedupe, PII masker, quality scorer, optional
+ * claude-distillation step, and the manifest writer.
+ *
+ * Construction is fully parameterised — every CAIA-specific path,
+ * URL, topic, and external-tool is a constructor parameter with a
+ * CAIA default. This is the Option E pre-send check made executable.
+ */
+
+import type { ApprenticeCorpusConfig, ResolvedApprenticeCorpusConfig } from './config.js';
+import { resolveConfig, snapshotConfigForHash } from './config.js';
+import { dedupePairs } from './dedupe.js';
+import { defaultEventBusClient, createEventBusReader } from './event-bus-reader.js';
+import { defaultFsReader } from './fs-reader.js';
+import { createGithubReader, defaultGithubClient } from './github-reader.js';
+import { createLangfuseReader, defaultLangfuseClient } from './langfuse-reader.js';
+import { hashConfig, writeCorpus } from './manifest.js';
+import { createMemoryWalker } from './memory-walker.js';
+import { normaliseAll, normaliseOne, sha256OfMessages } from './normaliser.js';
+import { applyPiiMask, DEFAULT_REDACT_PATTERNS } from './pii-mask.js';
+import { scoreAll, scoreOne } from './quality.js';
+import { createReportsWalker } from './reports-walker.js';
+import { createDefaultDistiller, noopDistiller } from './distiller.js';
+import type {
+  ClaudeDistiller,
+  CorpusManifest,
+  DroppedRecord,
+  EventBusClient,
+  GithubClient,
+  InstructionPair,
+  LangfuseClient,
+  RawArtifact,
+  ReaderContext,
+  SourceReader
+} from './types.js';
+
+export class ApprenticeCorpusAggregator {
+  private readonly cfg: ResolvedApprenticeCorpusConfig;
+  private readonly clock: () => Date;
+  private readonly eventBusFactory: () => Promise<EventBusClient>;
+  private readonly githubClient: GithubClient;
+  private readonly langfuseClient: LangfuseClient;
+  private readonly claudeDistiller: ClaudeDistiller;
+  private readonly fs: typeof defaultFsReader;
+
+  constructor(input: ApprenticeCorpusConfig = {}) {
+    this.cfg = resolveConfig(input);
+    this.clock = input.clock ?? (() => new Date());
+    this.fs = input.fs ?? defaultFsReader;
+    this.eventBusFactory = input.eventBus !== undefined
+      ? () => Promise.resolve(input.eventBus as EventBusClient)
+      : () => defaultEventBusClient(this.cfg.eventsDbPath);
+    this.githubClient = input.github ?? defaultGithubClient;
+    this.langfuseClient = input.langfuse ?? defaultLangfuseClient;
+    this.claudeDistiller =
+      input.claudeDistiller
+      ?? (this.cfg.distillEnabled
+        ? createDefaultDistiller({ binaryPath: this.cfg.claudeBinaryPath })
+        : noopDistiller);
+  }
+
+  /** Run the full pipeline. Returns the manifest; outputs are on disk. */
+  async aggregate(opts: { dryRun?: boolean } = {}): Promise<CorpusManifest> {
+    const startedAtMs = Date.now();
+    const generatedAt = this.clock().toISOString();
+    const dropped: DroppedRecord[] = [];
+    const warnings: string[] = [];
+
+    // ── Step 1: read all sources in parallel ──────────────────────────
+    const ctx: ReaderContext = {
+      maxAgeDays: this.cfg.maxAgeDays,
+      nowMs: this.clock().getTime()
+    };
+    const readers = await this.buildReaders();
+    const rawArrays = await Promise.all(readers.map((r) => safeRead(r, ctx, warnings)));
+    const rawArtifacts: RawArtifact[] = rawArrays.flat();
+
+    // ── Step 2: normalise ────────────────────────────────────────────
+    const normaliseRes = normaliseAll(rawArtifacts, {
+      minSampleLengthChars: this.cfg.minSampleLengthChars,
+      maxSampleLengthChars: this.cfg.maxSampleLengthChars,
+      clock: this.clock
+    });
+    let pairs = normaliseRes.kept;
+    for (const d of normaliseRes.droppedSourceIds) {
+      dropped.push({ source: d.source, sourceId: d.id, reason: d.reason });
+    }
+
+    // ── Step 3: dedupe ───────────────────────────────────────────────
+    const dedupRes = dedupePairs(pairs);
+    pairs = dedupRes.kept;
+    for (const d of dedupRes.duplicates) {
+      dropped.push({ source: d.meta.source, sourceId: d.meta.sourceId, reason: 'duplicate' });
+    }
+
+    // ── Step 4: PII mask ─────────────────────────────────────────────
+    if (this.cfg.redactPII) {
+      const patterns = [...DEFAULT_REDACT_PATTERNS, ...this.cfg.extraRedactPatterns];
+      pairs = pairs.map((p) => maskPair(p, patterns));
+    }
+
+    // ── Step 5: quality score ────────────────────────────────────────
+    pairs = scoreAll(pairs, {
+      minSampleLengthChars: this.cfg.minSampleLengthChars,
+      maxSampleLengthChars: this.cfg.maxSampleLengthChars
+    });
+
+    // ── Step 6: split & distill ──────────────────────────────────────
+    let highQuality = pairs.filter((p) => p.meta.qualityScore >= this.cfg.qualityThreshold);
+    const lowQuality = pairs.filter((p) => p.meta.qualityScore < this.cfg.qualityThreshold);
+    let distilled = 0;
+    if (this.cfg.distillEnabled && lowQuality.length > 0) {
+      const budget = this.cfg.maxDistillCalls;
+      for (let i = 0; i < lowQuality.length; i += 1) {
+        const p = lowQuality[i]!;
+        if (i >= budget) {
+          dropped.push({
+            source: p.meta.source,
+            sourceId: p.meta.sourceId,
+            reason: 'low-quality-no-distill-budget',
+            qualityScore: p.meta.qualityScore
+          });
+          continue;
+        }
+        const refined = await this.tryDistill(p);
+        if (refined === null) {
+          dropped.push({
+            source: p.meta.source,
+            sourceId: p.meta.sourceId,
+            reason: 'distill-failed',
+            qualityScore: p.meta.qualityScore
+          });
+          continue;
+        }
+        distilled += 1;
+        const rescored = scoreOne(refined, {
+          minSampleLengthChars: this.cfg.minSampleLengthChars,
+          maxSampleLengthChars: this.cfg.maxSampleLengthChars
+        });
+        if (rescored < this.cfg.qualityThreshold) {
+          dropped.push({
+            source: p.meta.source,
+            sourceId: p.meta.sourceId,
+            reason: 'distill-still-low-quality',
+            qualityScore: rescored
+          });
+          continue;
+        }
+        const updated: InstructionPair = {
+          ...refined,
+          meta: { ...refined.meta, qualityScore: rescored }
+        };
+        highQuality.push(updated);
+      }
+    } else {
+      for (const p of lowQuality) {
+        dropped.push({
+          source: p.meta.source,
+          sourceId: p.meta.sourceId,
+          reason: 'low-quality-no-distill-budget',
+          qualityScore: p.meta.qualityScore
+        });
+      }
+    }
+
+    // ── Step 7: cap at maxSamples ────────────────────────────────────
+    highQuality.sort((a, b) => {
+      if (b.meta.qualityScore !== a.meta.qualityScore) {
+        return b.meta.qualityScore - a.meta.qualityScore;
+      }
+      return b.meta.createdAt.localeCompare(a.meta.createdAt);
+    });
+    if (highQuality.length > this.cfg.maxSamples) {
+      highQuality = highQuality.slice(0, this.cfg.maxSamples);
+    }
+
+    // ── Step 8: write outputs ────────────────────────────────────────
+    const elapsedMs = Date.now() - startedAtMs;
+    const datedDir = generatedAt.slice(0, 10);
+    const outputDir = `${this.cfg.outputRoot}/${datedDir}`;
+    const totals: CorpusManifest['totals'] = {
+      rawArtifacts: rawArtifacts.length,
+      afterDedup: dedupRes.kept.length,
+      afterPII: dedupRes.kept.length, // PII pass doesn't drop, just redacts
+      afterQuality: pairs.length,
+      distilled,
+      dropped: dropped.length,
+      final: highQuality.length
+    };
+    const configSnapshotJson = snapshotConfigForHash(this.cfg);
+    const configHash = hashConfig(configSnapshotJson);
+
+    const inputs = {
+      outputDir,
+      rawArtifacts,
+      finalPairs: highQuality,
+      dropped,
+      totals,
+      warnings,
+      configHash,
+      generatedAt,
+      elapsedMs
+    };
+
+    if (opts.dryRun !== true) {
+      writeCorpus(inputs, configSnapshotJson);
+    }
+
+    return {
+      version: 1,
+      generatedAt,
+      outputDir,
+      elapsedMs,
+      totals,
+      perSource: emptyPerSourceFromArtifacts(rawArtifacts, highQuality),
+      redactedSpansHistogram: histogramFromPairs(highQuality, (p) => p.meta.redactedSpans),
+      qualityHistogram: qualityHistogram(highQuality),
+      configSha256: configHash,
+      warnings
+    };
+  }
+
+  /** Build the SourceReader array, instantiating clients. */
+  private async buildReaders(): Promise<SourceReader[]> {
+    const eventBus = await this.eventBusFactory();
+    return [
+      createMemoryWalker({ memoryRoot: this.cfg.memoryRoot, fs: this.fs }),
+      createReportsWalker({ reportsRoot: this.cfg.reportsRoot, fs: this.fs }),
+      createEventBusReader({ client: eventBus }),
+      createGithubReader({ client: this.githubClient, repo: this.cfg.githubRepo }),
+      createLangfuseReader({
+        client: this.langfuseClient,
+        projectId: this.cfg.langfuseProjectId,
+        enabled: this.cfg.langfuseEnabled
+      })
+    ];
+  }
+
+  private async tryDistill(p: InstructionPair): Promise<InstructionPair | null> {
+    const userTurn = p.messages.find((m) => m.role === 'user')?.content ?? '';
+    const assistantTurn = p.messages.find((m) => m.role === 'assistant')?.content ?? '';
+    try {
+      const out = await this.claudeDistiller.distill({
+        source: p.meta.source,
+        ...(p.meta.kind !== undefined ? { kind: p.meta.kind } : {}),
+        text: `${userTurn}\n\n${assistantTurn}`
+      });
+      const newMessages = [
+        p.messages[0]!, // system stays
+        { role: 'user' as const, content: out.instruction },
+        { role: 'assistant' as const, content: out.response }
+      ];
+      const newId = sha256OfMessages(newMessages);
+      return {
+        id: newId,
+        messages: newMessages,
+        meta: {
+          ...p.meta,
+          distilled: true,
+          contentSha256: newId
+        }
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function safeRead(
+  reader: SourceReader,
+  ctx: ReaderContext,
+  warnings: string[]
+): Promise<RawArtifact[]> {
+  try {
+    return await reader.read(ctx);
+  } catch (e) {
+    warnings.push(`reader[${reader.source}] failed: ${(e as Error).message}`);
+    return [];
+  }
+}
+
+function maskPair(
+  p: InstructionPair,
+  patterns: ReadonlyArray<{ tag: string; pattern: RegExp; replacement: string }>
+): InstructionPair {
+  const seenTags = new Set<string>(p.meta.redactedSpans);
+  const newMessages = p.messages.map((m) => {
+    const r = applyPiiMask(m.content, patterns);
+    for (const t of r.redactedSpans) seenTags.add(t);
+    return { ...m, content: r.masked };
+  });
+  // Re-hash because content changed
+  const newSha = sha256OfMessages(newMessages);
+  return {
+    id: newSha,
+    messages: newMessages,
+    meta: {
+      ...p.meta,
+      contentSha256: newSha,
+      redactedSpans: Array.from(seenTags).sort()
+    }
+  };
+}
+
+// ── helpers for the manifest projection in the return value ────────────
+
+function emptyPerSourceFromArtifacts(
+  rawArtifacts: ReadonlyArray<RawArtifact>,
+  finalPairs: ReadonlyArray<InstructionPair>
+): CorpusManifest['perSource'] {
+  const out: CorpusManifest['perSource'] = {
+    events: { artifacts: 0, samples: 0 },
+    memory: { artifacts: 0, samples: 0 },
+    reports: { artifacts: 0, samples: 0 },
+    langfuse: { artifacts: 0, samples: 0 },
+    github: { artifacts: 0, samples: 0 }
+  };
+  for (const a of rawArtifacts) out[a.source].artifacts += 1;
+  for (const p of finalPairs) out[p.meta.source].samples += 1;
+  return out;
+}
+
+function histogramFromPairs(
+  pairs: ReadonlyArray<InstructionPair>,
+  pick: (p: InstructionPair) => string[]
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const p of pairs) {
+    for (const tag of pick(p)) {
+      out[tag] = (out[tag] ?? 0) + 1;
+    }
+  }
+  return out;
+}
+
+function qualityHistogram(pairs: ReadonlyArray<InstructionPair>): Record<string, number> {
+  const out: Record<string, number> = {
+    '0.0-0.2': 0,
+    '0.2-0.4': 0,
+    '0.4-0.6': 0,
+    '0.6-0.8': 0,
+    '0.8-1.0': 0
+  };
+  for (const p of pairs) {
+    const q = p.meta.qualityScore;
+    if (q < 0.2) out['0.0-0.2']! += 1;
+    else if (q < 0.4) out['0.2-0.4']! += 1;
+    else if (q < 0.6) out['0.4-0.6']! += 1;
+    else if (q < 0.8) out['0.6-0.8']! += 1;
+    else out['0.8-1.0']! += 1;
+  }
+  return out;
+}
+
+// re-export so the index.ts barrel can reach the lazy unused symbol
+export { normaliseOne };

--- a/packages/apprentice-corpus/src/cli.ts
+++ b/packages/apprentice-corpus/src/cli.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * caia-apprentice-corpus CLI.
+ *
+ * Subcommands:
+ *   aggregate              Run the full pipeline against CAIA defaults.
+ *   aggregate --dry-run    Plan only, no writes.
+ *   --memory-root X        Override single config field (also supported via env).
+ *
+ * All flags map directly to `ApprenticeCorpusConfig` keys via kebab-case.
+ */
+
+import { ApprenticeCorpusAggregator } from './aggregator.js';
+import type { ApprenticeCorpusConfig } from './config.js';
+
+interface ParsedArgs {
+  command: string | undefined;
+  dryRun: boolean;
+  config: ApprenticeCorpusConfig;
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = { command: undefined, dryRun: false, config: {} };
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i]!;
+    if (a === '--help' || a === '-h') {
+      out.command = 'help';
+      i += 1;
+      continue;
+    }
+    if (out.command === undefined && !a.startsWith('-')) {
+      out.command = a;
+      i += 1;
+      continue;
+    }
+    if (a === '--dry-run') {
+      out.dryRun = true;
+      i += 1;
+      continue;
+    }
+    if (a === '--memory-root' && i + 1 < argv.length) {
+      out.config.memoryRoot = argv[i + 1] ?? '';
+      i += 2;
+      continue;
+    }
+    if (a === '--reports-root' && i + 1 < argv.length) {
+      out.config.reportsRoot = argv[i + 1] ?? '';
+      i += 2;
+      continue;
+    }
+    if (a === '--events-db' && i + 1 < argv.length) {
+      out.config.eventsDbPath = argv[i + 1] ?? '';
+      i += 2;
+      continue;
+    }
+    if (a === '--output-root' && i + 1 < argv.length) {
+      out.config.outputRoot = argv[i + 1] ?? '';
+      i += 2;
+      continue;
+    }
+    if (a === '--no-distill') {
+      out.config.distillEnabled = false;
+      i += 1;
+      continue;
+    }
+    if (a === '--max-samples' && i + 1 < argv.length) {
+      out.config.maxSamples = Number.parseInt(argv[i + 1]!, 10);
+      i += 2;
+      continue;
+    }
+    if (a === '--max-age-days' && i + 1 < argv.length) {
+      out.config.maxAgeDays = Number.parseInt(argv[i + 1]!, 10);
+      i += 2;
+      continue;
+    }
+    if (a === '--quality-threshold' && i + 1 < argv.length) {
+      out.config.qualityThreshold = Number.parseFloat(argv[i + 1]!);
+      i += 2;
+      continue;
+    }
+    // Unknown — ignore but advance to avoid infinite loop
+    i += 1;
+  }
+  return out;
+}
+
+const HELP = `caia-apprentice-corpus — Apprentice Phase 0 corpus aggregator
+
+Usage:
+  caia-apprentice-corpus aggregate [options]
+
+Options:
+  --memory-root <path>        Override CAIA memory directory
+  --reports-root <path>       Override reports directory
+  --events-db <path>          Override mentor events.sqlite path
+  --output-root <path>        Override corpus output root
+  --no-distill                Disable claude-binary distillation
+  --max-samples <n>           Cap final corpus size (default 50000)
+  --max-age-days <n>          Bound source artifacts by age (default 365)
+  --quality-threshold <f>     Minimum quality score [0..1] (default 0.4)
+  --dry-run                   Plan only; no writes
+  -h, --help                  Show this help
+`;
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.command === 'help' || parsed.command === undefined) {
+    console.log(HELP);
+    return;
+  }
+  if (parsed.command !== 'aggregate') {
+    console.error(`Unknown command: ${parsed.command}`);
+    console.error(HELP);
+    process.exit(2);
+  }
+  const agg = new ApprenticeCorpusAggregator(parsed.config);
+  const manifest = await agg.aggregate({ dryRun: parsed.dryRun });
+  console.log(JSON.stringify(manifest, null, 2));
+}
+
+if (process.argv[1]?.endsWith('cli.js') === true || process.argv[1]?.endsWith('cli.ts') === true) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/apprentice-corpus/src/config.ts
+++ b/packages/apprentice-corpus/src/config.ts
@@ -1,0 +1,163 @@
+/**
+ * Configuration shape + CAIA defaults.
+ *
+ * Option E pre-send check: every CAIA-specific path/URL/topic is here
+ * with a default. Tests inject overrides; production passes CAIA-only.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type {
+  ClaudeDistiller,
+  EventBusClient,
+  FsReader,
+  GithubClient,
+  LangfuseClient
+} from './types.js';
+
+/** Public config — every field is optional; CAIA defaults fill the gaps. */
+export interface ApprenticeCorpusConfig {
+  // ── Source paths / URLs ──────────────────────────────────────────────
+  memoryRoot?: string;
+  reportsRoot?: string;
+  eventsDbPath?: string;
+  langfuseProjectId?: string;
+  langfuseEnabled?: boolean;
+  githubRepo?: string;
+
+  // ── Output ───────────────────────────────────────────────────────────
+  outputRoot?: string;
+
+  // ── External binaries ────────────────────────────────────────────────
+  claudeBinaryPath?: string;
+  distillEnabled?: boolean;
+
+  // ── Behaviour knobs ──────────────────────────────────────────────────
+  maxSamples?: number;
+  minSampleLengthChars?: number;
+  maxSampleLengthChars?: number;
+  qualityThreshold?: number;
+  maxDistillCalls?: number;
+  maxAgeDays?: number;
+  redactPII?: boolean;
+  /** Optional extra patterns the PII masker should redact. */
+  extraRedactPatterns?: ReadonlyArray<{ tag: string; pattern: RegExp; replacement: string }>;
+
+  // ── Test seams (DI) ──────────────────────────────────────────────────
+  fs?: FsReader;
+  eventBus?: EventBusClient;
+  github?: GithubClient;
+  langfuse?: LangfuseClient;
+  claudeDistiller?: ClaudeDistiller;
+  /** Override `now()` for deterministic tests. */
+  clock?: () => Date;
+}
+
+/**
+ * The fully-resolved config — all fields required, defaults filled in.
+ * Internal-only. The aggregator works against this shape.
+ */
+export interface ResolvedApprenticeCorpusConfig {
+  memoryRoot: string;
+  reportsRoot: string;
+  eventsDbPath: string;
+  langfuseProjectId: string;
+  langfuseEnabled: boolean;
+  githubRepo: string;
+  outputRoot: string;
+  claudeBinaryPath: string;
+  distillEnabled: boolean;
+  maxSamples: number;
+  minSampleLengthChars: number;
+  maxSampleLengthChars: number;
+  qualityThreshold: number;
+  maxDistillCalls: number;
+  maxAgeDays: number;
+  redactPII: boolean;
+  extraRedactPatterns: ReadonlyArray<{ tag: string; pattern: RegExp; replacement: string }>;
+}
+
+/** Resolve `~` to `$HOME` in a path. Returns `path` unchanged if it doesn't start with `~/`. */
+export function expandHome(path: string): string {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/')) return join(homedir(), path.slice(2));
+  return path;
+}
+
+/**
+ * Default memory root.
+ *
+ * The orchestrator's session-state directory lives under
+ * `~/Library/Application Support/Claude/local-agent-mode-sessions/<session-id>/agent/memory`.
+ * The session id is dynamic, so production callers should set
+ * `CAIA_MEMORY_DIR` at the env level (a launchd plist or systemd-style
+ * env file). The fallback below points to the canonical 2026-05-06
+ * session for first-run convenience; do not rely on it to outlive
+ * session rotation.
+ */
+const FALLBACK_MEMORY_ROOT =
+  '/Users/MAC/Library/Application Support/Claude/local-agent-mode-sessions/6c9158cd-cd01-44af-b82f-bf27b437c618/84f7697e-7ae3-4ba4-9f98-166613a82e98/agent/memory';
+
+/** Build the resolved config from a partial input. */
+export function resolveConfig(input: ApprenticeCorpusConfig): ResolvedApprenticeCorpusConfig {
+  return {
+    memoryRoot: expandHome(
+      input.memoryRoot ?? process.env['CAIA_MEMORY_DIR'] ?? FALLBACK_MEMORY_ROOT
+    ),
+    reportsRoot: expandHome(
+      input.reportsRoot
+        ?? process.env['CAIA_REPORTS_DIR']
+        ?? '~/Documents/projects/reports'
+    ),
+    eventsDbPath: expandHome(
+      input.eventsDbPath
+        ?? process.env['CAIA_EVENTS_DB']
+        ?? '~/.caia/mentor/events.sqlite'
+    ),
+    langfuseProjectId: input.langfuseProjectId ?? 'caia-prod',
+    langfuseEnabled: input.langfuseEnabled ?? false,
+    githubRepo: input.githubRepo ?? process.env['CAIA_GITHUB_REPO'] ?? 'chiefaia/caia',
+    outputRoot: expandHome(
+      input.outputRoot
+        ?? process.env['APPRENTICE_CORPUS_ROOT']
+        ?? '~/Documents/projects/apprentice/corpora'
+    ),
+    claudeBinaryPath:
+      input.claudeBinaryPath ?? process.env['CLAUDE_BINARY_PATH'] ?? 'claude',
+    distillEnabled: input.distillEnabled ?? true,
+    maxSamples: input.maxSamples ?? 50_000,
+    minSampleLengthChars: input.minSampleLengthChars ?? 80,
+    maxSampleLengthChars: input.maxSampleLengthChars ?? 16_000,
+    qualityThreshold: input.qualityThreshold ?? 0.4,
+    maxDistillCalls: input.maxDistillCalls ?? 200,
+    maxAgeDays: input.maxAgeDays ?? 365,
+    redactPII: input.redactPII ?? true,
+    extraRedactPatterns: input.extraRedactPatterns ?? []
+  };
+}
+
+/**
+ * Hash the resolved config for the manifest. Excludes function-shaped
+ * fields (clock, fs reader, etc.) so the same config yields the same
+ * hash across tests. Uses a stable JSON projection.
+ */
+export function snapshotConfigForHash(cfg: ResolvedApprenticeCorpusConfig): string {
+  return JSON.stringify({
+    memoryRoot: cfg.memoryRoot,
+    reportsRoot: cfg.reportsRoot,
+    eventsDbPath: cfg.eventsDbPath,
+    langfuseProjectId: cfg.langfuseProjectId,
+    langfuseEnabled: cfg.langfuseEnabled,
+    githubRepo: cfg.githubRepo,
+    outputRoot: cfg.outputRoot,
+    distillEnabled: cfg.distillEnabled,
+    maxSamples: cfg.maxSamples,
+    minSampleLengthChars: cfg.minSampleLengthChars,
+    maxSampleLengthChars: cfg.maxSampleLengthChars,
+    qualityThreshold: cfg.qualityThreshold,
+    maxDistillCalls: cfg.maxDistillCalls,
+    maxAgeDays: cfg.maxAgeDays,
+    redactPII: cfg.redactPII
+  });
+}

--- a/packages/apprentice-corpus/src/dedupe.ts
+++ b/packages/apprentice-corpus/src/dedupe.ts
@@ -1,0 +1,30 @@
+/**
+ * Dedupe — drop pairs whose `meta.contentSha256` was seen before.
+ *
+ * Stable: first occurrence wins. The aggregator already orders
+ * artifacts deterministically per source, so dedupe is also stable
+ * across runs.
+ */
+
+import type { InstructionPair } from './types.js';
+
+export interface DedupeResult {
+  kept: InstructionPair[];
+  duplicates: InstructionPair[];
+}
+
+export function dedupePairs(pairs: ReadonlyArray<InstructionPair>): DedupeResult {
+  const seen = new Set<string>();
+  const kept: InstructionPair[] = [];
+  const duplicates: InstructionPair[] = [];
+  for (const p of pairs) {
+    const key = p.meta.contentSha256;
+    if (seen.has(key)) {
+      duplicates.push(p);
+      continue;
+    }
+    seen.add(key);
+    kept.push(p);
+  }
+  return { kept, duplicates };
+}

--- a/packages/apprentice-corpus/src/distiller.ts
+++ b/packages/apprentice-corpus/src/distiller.ts
@@ -1,0 +1,144 @@
+/**
+ * Claude-binary-spawn distiller.
+ *
+ * Cribs from `@chiefaia/local-llm-router`'s `claude-adapter.ts`:
+ *   - subprocess invocation pattern with `--print --output-format json`
+ *   - explicit `ANTHROPIC_API_KEY=undefined` to force subscription path
+ *   - timeout + JSON-parse error handling
+ *
+ * The distiller is invoked for InstructionPairs that score below the
+ * quality threshold. It produces a refined `{instruction, response}`
+ * pair which the aggregator then re-scores. Failures (rate-limit,
+ * missing binary, malformed output) cause the sample to be dropped.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+import type {
+  ClaudeDistiller,
+  DistillInput,
+  DistillOutput
+} from './types.js';
+
+export interface DefaultDistillerOptions {
+  binaryPath: string;
+  timeoutMs?: number;
+  /** Test seam — replace `child_process.spawnSync`. */
+  spawnFn?: typeof spawnSync;
+  /** Optional model override. Default: claude-haiku-4-5 (cheap; distillation is not reasoning). */
+  model?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+
+export const DISTILL_PROMPT_TEMPLATE = `You are extracting a high-quality instruction-response pair for fine-tuning a coding agent.
+
+Given the raw artifact below, produce a clean Q/A pair that captures the substantive content.
+
+Rules:
+- Drop voice-transcription noise (um, uh, you know).
+- Keep operator decisions verbatim.
+- Strip any credentials or personally-identifying patterns you spot.
+- The instruction should be a clear question or task; the response should answer it directly.
+- Output STRICT JSON exactly in the shape: {"instruction": "...", "response": "..."}.
+- No prose before or after the JSON.
+
+Raw artifact source: {source}/{kind}
+Raw artifact:
+"""
+{text}
+"""`;
+
+/**
+ * Build a default distiller backed by the `claude` CLI.
+ *
+ * Honours `feedback_no_api_key_billing.md` — explicitly nukes
+ * `ANTHROPIC_API_KEY` from the spawned env so the binary falls
+ * through to the keychain / OAuth subscription session.
+ */
+export function createDefaultDistiller(opts: DefaultDistillerOptions): ClaudeDistiller {
+  const spawn = opts.spawnFn ?? spawnSync;
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const model = opts.model ?? DEFAULT_MODEL;
+
+  return {
+    async distill(input: DistillInput): Promise<DistillOutput> {
+      const prompt = DISTILL_PROMPT_TEMPLATE
+        .replace('{source}', input.source)
+        .replace('{kind}', input.kind ?? 'unknown')
+        .replace('{text}', input.text);
+
+      const env = { ...process.env };
+      delete env['ANTHROPIC_API_KEY'];
+
+      const result = spawn(
+        opts.binaryPath,
+        ['--print', '--output-format', 'json', '--model', model],
+        {
+          input: prompt,
+          encoding: 'utf-8',
+          timeout,
+          env
+        }
+      );
+
+      if (result.error !== null && result.error !== undefined) {
+        throw new Error(`distiller spawn failed: ${result.error.message}`);
+      }
+      if (result.status !== 0) {
+        throw new Error(
+          `distiller exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
+        );
+      }
+      const stdout = (result.stdout ?? '').toString();
+      return parseDistillerOutput(stdout);
+    }
+  };
+}
+
+/**
+ * Parse the `claude --print --output-format json` envelope, then the
+ * inner JSON the distillation prompt asked for.
+ *
+ * The outer envelope is `{ "result": "..." }` per claude-adapter.ts.
+ * The inner JSON is what the prompt template instructed.
+ */
+export function parseDistillerOutput(stdout: string): DistillOutput {
+  let outer: unknown;
+  try {
+    outer = JSON.parse(stdout);
+  } catch (e) {
+    throw new Error(`distiller stdout not JSON: ${(e as Error).message}`, { cause: e });
+  }
+  if (
+    typeof outer !== 'object'
+    || outer === null
+    || typeof (outer as { result?: unknown }).result !== 'string'
+  ) {
+    throw new Error('distiller envelope missing "result" string');
+  }
+  const inner = (outer as { result: string }).result.trim();
+  // The prompt instructs strict JSON, but be tolerant of leading/trailing whitespace.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(inner);
+  } catch (e) {
+    throw new Error(`distiller inner JSON parse failed: ${(e as Error).message}`, { cause: e });
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('distiller inner JSON is not an object');
+  }
+  const obj = parsed as { instruction?: unknown; response?: unknown };
+  if (typeof obj.instruction !== 'string' || typeof obj.response !== 'string') {
+    throw new Error('distiller inner JSON missing instruction/response');
+  }
+  return { instruction: obj.instruction, response: obj.response };
+}
+
+/** Always-throw stub for tests / disabled distillation. */
+export const noopDistiller: ClaudeDistiller = {
+  async distill(): Promise<never> {
+    throw new Error('distiller-disabled');
+  }
+};

--- a/packages/apprentice-corpus/src/event-bus-reader.ts
+++ b/packages/apprentice-corpus/src/event-bus-reader.ts
@@ -1,0 +1,118 @@
+/**
+ * Event-bus reader — wraps `@chiefaia/mentor-event-bus`'s `queryEvents`.
+ *
+ * Returns a `SourceReader` that pulls events newer than the cutoff and
+ * normalises them into `RawArtifact[]`. The actual `EventBusClient`
+ * implementation is injected via the config; the default constructor
+ * builds one against the events.sqlite path.
+ */
+
+import type {
+  EventBusClient,
+  EventBusRecord,
+  RawArtifact,
+  ReaderContext,
+  SourceReader
+} from './types.js';
+
+export interface EventBusReaderOptions {
+  client: EventBusClient;
+}
+
+export function createEventBusReader(opts: EventBusReaderOptions): SourceReader {
+  return {
+    source: 'events',
+    async read(ctx: ReaderContext): Promise<RawArtifact[]> {
+      const cutoffMs = ctx.nowMs - ctx.maxAgeDays * 24 * 60 * 60 * 1000;
+      let records: EventBusRecord[];
+      try {
+        records = await opts.client.readSince(cutoffMs);
+      } catch {
+        return [];
+      }
+      const out: RawArtifact[] = [];
+      for (const r of records) {
+        const text = projectEventToText(r);
+        if (text === '') continue;
+        out.push({
+          source: 'events',
+          sourceId: r.id,
+          ...(r.correlationId !== undefined ? { correlationId: r.correlationId } : {}),
+          kind: r.type,
+          text,
+          sidecar: { ...r.payload },
+          createdAtMs: r.emittedAtMs
+        });
+      }
+      return out;
+    }
+  };
+}
+
+/**
+ * Project an event payload into a textual artifact. The normaliser will
+ * later decide instruction/response shape based on `kind`; this function
+ * only flattens the payload into a stable, human-readable string.
+ */
+export function projectEventToText(r: EventBusRecord): string {
+  const lines: string[] = [];
+  lines.push(`Event: ${r.type}`);
+  for (const [k, v] of Object.entries(r.payload)) {
+    if (v === undefined || v === null) continue;
+    if (typeof v === 'string') {
+      lines.push(`${k}: ${v}`);
+    } else if (typeof v === 'number' || typeof v === 'boolean') {
+      lines.push(`${k}: ${String(v)}`);
+    } else {
+      lines.push(`${k}: ${JSON.stringify(v)}`);
+    }
+  }
+  // Drop "Event: X" alone — needs at least one detail line to be useful
+  if (lines.length === 1) return '';
+  return lines.join('\n');
+}
+
+/**
+ * Default real-mentor-event-bus-backed client.
+ *
+ * Imports lazily — the package depends on `@chiefaia/mentor-event-bus`
+ * but tests don't need to load it. We keep the import inside the
+ * factory so vitest test suites that inject a fake client never touch
+ * the real better-sqlite3 module.
+ *
+ * The mentor-event-bus stores `payload_json` as a string; we parse it
+ * here. Malformed payloads are surfaced as empty objects (the artifact
+ * still has a useful event_type for the normaliser).
+ */
+export async function defaultEventBusClient(eventsDbPath: string): Promise<EventBusClient> {
+  // Lazy import keeps tests fast and avoids native-module init at import time.
+  const mod = await import('@chiefaia/mentor-event-bus');
+  const db = mod.openDatabase(eventsDbPath);
+  return {
+    async readSince(sinceMs: number): Promise<EventBusRecord[]> {
+      const sinceIso = new Date(sinceMs).toISOString();
+      const rows = mod.queryEvents(db, { sinceIso, limit: 100_000 });
+      return rows.map((row) => {
+        let payload: Record<string, unknown> = {};
+        try {
+          const parsed = JSON.parse(row.payload_json);
+          if (parsed !== null && typeof parsed === 'object') {
+            payload = parsed as Record<string, unknown>;
+          }
+        } catch {
+          // leave as empty object; type alone is still useful
+        }
+        const rec: EventBusRecord = {
+          id: row.id,
+          type: row.event_type,
+          emittedAtMs: Date.parse(row.emitted_at),
+          payload
+        };
+        if (row.correlation_id !== null) {
+          rec.correlationId = row.correlation_id;
+        }
+        return rec;
+      });
+    }
+  };
+}

--- a/packages/apprentice-corpus/src/fs-reader.ts
+++ b/packages/apprentice-corpus/src/fs-reader.ts
@@ -1,0 +1,26 @@
+/**
+ * Default real-filesystem reader.
+ *
+ * Tests inject a fake by passing `fs` in `ApprenticeCorpusConfig`.
+ * Production passes nothing and gets this implementation.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+
+import type { FsReader } from './types.js';
+
+export const defaultFsReader: FsReader = {
+  exists(p) {
+    return existsSync(p);
+  },
+  readDir(p) {
+    return readdirSync(p);
+  },
+  readFile(p) {
+    return readFileSync(p, 'utf-8');
+  },
+  stat(p) {
+    const s = statSync(p);
+    return { mtimeMs: s.mtimeMs, size: s.size, isFile: s.isFile() };
+  }
+};

--- a/packages/apprentice-corpus/src/github-reader.ts
+++ b/packages/apprentice-corpus/src/github-reader.ts
@@ -1,0 +1,122 @@
+/**
+ * GitHub PR-history reader — uses the `gh` CLI to pull merged PRs.
+ *
+ * The default client shells out to `gh pr list --state merged --json …`.
+ * Tests inject a fake `GithubClient` that returns canned records.
+ *
+ * Bounded by `maxAgeDays` to keep the API call cheap; the merged-at
+ * filter is applied client-side after `gh` returns results.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+import type {
+  GithubClient,
+  GithubPrRecord,
+  RawArtifact,
+  ReaderContext,
+  SourceReader
+} from './types.js';
+
+export interface GithubReaderOptions {
+  client: GithubClient;
+  repo: string;
+}
+
+export function createGithubReader(opts: GithubReaderOptions): SourceReader {
+  return {
+    source: 'github',
+    async read(ctx: ReaderContext): Promise<RawArtifact[]> {
+      const cutoffMs = ctx.nowMs - ctx.maxAgeDays * 24 * 60 * 60 * 1000;
+      let records: GithubPrRecord[];
+      try {
+        records = await opts.client.listMergedPrs(cutoffMs, opts.repo);
+      } catch {
+        return [];
+      }
+      const out: RawArtifact[] = [];
+      for (const r of records) {
+        if (r.mergedAtMs < cutoffMs) continue;
+        const text = formatPrText(r);
+        if (text === '') continue;
+        out.push({
+          source: 'github',
+          sourceId: `pr#${r.number}`,
+          kind: 'PR',
+          text,
+          sidecar: { url: r.url, number: r.number, mergedAtMs: r.mergedAtMs },
+          createdAtMs: r.mergedAtMs
+        });
+      }
+      out.sort((a, b) => a.createdAtMs - b.createdAtMs);
+      return out;
+    }
+  };
+}
+
+export function formatPrText(r: GithubPrRecord): string {
+  const titleLine = r.title.trim();
+  const body = (r.body ?? '').trim();
+  if (titleLine === '' && body === '') return '';
+  if (body === '') return titleLine;
+  return `${titleLine}\n\n${body}`;
+}
+
+/**
+ * Default real-`gh`-backed client.
+ *
+ * Spawns `gh pr list --repo <repo> --state merged --json
+ * number,title,body,url,mergedAt --limit <N> --search "merged:>=<date>"`.
+ * Returns a parsed array of records. Subprocess errors return [] so a
+ * missing `gh` doesn't break the whole pipeline.
+ */
+export const defaultGithubClient: GithubClient = {
+  async listMergedPrs(sinceMs: number, repo: string): Promise<GithubPrRecord[]> {
+    const sinceDate = new Date(sinceMs).toISOString().slice(0, 10);
+    const result = spawnSync(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--repo',
+        repo,
+        '--state',
+        'merged',
+        '--json',
+        'number,title,body,url,mergedAt',
+        '--limit',
+        '500',
+        '--search',
+        `merged:>=${sinceDate}`
+      ],
+      { encoding: 'utf-8', timeout: 60_000 }
+    );
+    if (result.status !== 0 || result.stdout === '') return [];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+    const out: GithubPrRecord[] = [];
+    for (const p of parsed) {
+      if (typeof p !== 'object' || p === null) continue;
+      const obj = p as Record<string, unknown>;
+      const number = typeof obj['number'] === 'number' ? obj['number'] : -1;
+      const title = typeof obj['title'] === 'string' ? obj['title'] : '';
+      const body = typeof obj['body'] === 'string' ? obj['body'] : '';
+      const url = typeof obj['url'] === 'string' ? obj['url'] : '';
+      const mergedAt = typeof obj['mergedAt'] === 'string' ? obj['mergedAt'] : '';
+      if (number < 0 || mergedAt === '') continue;
+      out.push({
+        number,
+        title,
+        body,
+        url,
+        mergedAtMs: Date.parse(mergedAt)
+      });
+    }
+    return out;
+  }
+};

--- a/packages/apprentice-corpus/src/index.ts
+++ b/packages/apprentice-corpus/src/index.ts
@@ -1,0 +1,129 @@
+/**
+ * @chiefaia/apprentice-corpus — public surface.
+ *
+ * The aggregator is the primary entry point. Everything else is exposed
+ * for testability + downstream Phase 1/2 packages that may want to
+ * reuse the schema, classifiers, or scoring heuristics directly.
+ *
+ * Option E shape: every export is parameterised; the only way to bond
+ * to CAIA is via the constructor's defaults (which read env vars
+ * + fall back to canonical CAIA paths).
+ */
+
+export { ApprenticeCorpusAggregator } from './aggregator.js';
+
+export {
+  resolveConfig,
+  expandHome,
+  snapshotConfigForHash,
+  type ApprenticeCorpusConfig,
+  type ResolvedApprenticeCorpusConfig
+} from './config.js';
+
+export {
+  defaultFsReader
+} from './fs-reader.js';
+
+export {
+  classifyMemoryFile,
+  parseMarkdown,
+  isEligibleMarkdown,
+  createMemoryWalker,
+  type ParsedMarkdown,
+  type MemoryWalkerOptions
+} from './memory-walker.js';
+
+export {
+  createReportsWalker,
+  type ReportsWalkerOptions
+} from './reports-walker.js';
+
+export {
+  createEventBusReader,
+  defaultEventBusClient,
+  projectEventToText,
+  type EventBusReaderOptions
+} from './event-bus-reader.js';
+
+export {
+  createGithubReader,
+  defaultGithubClient,
+  formatPrText,
+  type GithubReaderOptions
+} from './github-reader.js';
+
+export {
+  createLangfuseReader,
+  defaultLangfuseClient,
+  formatTraceText,
+  type LangfuseReaderOptions
+} from './langfuse-reader.js';
+
+export {
+  CAIA_SYSTEM_PROMPT
+} from './system-prompt.js';
+
+export {
+  instructionFor,
+  buildResponse,
+  normaliseOne,
+  normaliseAll,
+  sha256OfMessages,
+  type NormaliserOptions
+} from './normaliser.js';
+
+export {
+  applyPiiMask,
+  DEFAULT_REDACT_PATTERNS,
+  type RedactPattern,
+  type MaskResult
+} from './pii-mask.js';
+
+export {
+  dedupePairs,
+  type DedupeResult
+} from './dedupe.js';
+
+export {
+  scoreOne,
+  scoreAll,
+  type QualityOptions
+} from './quality.js';
+
+export {
+  createDefaultDistiller,
+  noopDistiller,
+  parseDistillerOutput,
+  DISTILL_PROMPT_TEMPLATE,
+  type DefaultDistillerOptions
+} from './distiller.js';
+
+export {
+  buildManifest,
+  writeCorpus,
+  hashConfig,
+  type WriteCorpusInputs
+} from './manifest.js';
+
+export {
+  ALL_SOURCE_TAGS,
+  type ChatMessage,
+  type ClaudeDistiller,
+  type CorpusManifest,
+  type DistillInput,
+  type DistillOutput,
+  type DropReason,
+  type DroppedRecord,
+  type EventBusClient,
+  type EventBusRecord,
+  type FsReader,
+  type GithubClient,
+  type GithubPrRecord,
+  type InstructionPair,
+  type LangfuseClient,
+  type LangfuseTraceRecord,
+  type RawArtifact,
+  type ReaderContext,
+  type SourceReader,
+  type SourceTag
+} from './types.js';

--- a/packages/apprentice-corpus/src/langfuse-reader.ts
+++ b/packages/apprentice-corpus/src/langfuse-reader.ts
@@ -1,0 +1,70 @@
+/**
+ * Langfuse-traces reader — STUB for Phase 0.
+ *
+ * The directive lists Langfuse traces as corpus source #4. The
+ * Langfuse integration is not yet operational in CAIA today (zero
+ * grep hits in packages/), so this reader ships with `enabled=false`
+ * by default and returns []. When Langfuse goes online, leg 3 of the
+ * Apprentice campaign will implement the real `defaultLangfuseClient`
+ * against the /api/public/traces endpoint.
+ *
+ * The shape is fully wired up so swapping in the real client is a
+ * one-import change with no API churn for downstream consumers.
+ */
+
+import type {
+  LangfuseClient,
+  RawArtifact,
+  ReaderContext,
+  SourceReader
+} from './types.js';
+
+export interface LangfuseReaderOptions {
+  client: LangfuseClient;
+  projectId: string;
+  enabled: boolean;
+}
+
+export function createLangfuseReader(opts: LangfuseReaderOptions): SourceReader {
+  return {
+    source: 'langfuse',
+    async read(ctx: ReaderContext): Promise<RawArtifact[]> {
+      if (!opts.enabled) return [];
+      const cutoffMs = ctx.nowMs - ctx.maxAgeDays * 24 * 60 * 60 * 1000;
+      let records;
+      try {
+        records = await opts.client.listTraces(cutoffMs, opts.projectId);
+      } catch {
+        return [];
+      }
+      const out: RawArtifact[] = [];
+      for (const r of records) {
+        const text = formatTraceText(r.input, r.output);
+        if (text === '') continue;
+        out.push({
+          source: 'langfuse',
+          sourceId: r.id,
+          kind: r.name,
+          text,
+          sidecar: { traceName: r.name },
+          createdAtMs: r.createdAtMs
+        });
+      }
+      return out;
+    }
+  };
+}
+
+export function formatTraceText(input: string, output: string): string {
+  const i = (input ?? '').trim();
+  const o = (output ?? '').trim();
+  if (i === '' && o === '') return '';
+  return `Input:\n${i}\n\nOutput:\n${o}`;
+}
+
+/** Stub — returns []. Real impl deferred to leg 3. */
+export const defaultLangfuseClient: LangfuseClient = {
+  async listTraces(): Promise<[]> {
+    return [];
+  }
+};

--- a/packages/apprentice-corpus/src/manifest.ts
+++ b/packages/apprentice-corpus/src/manifest.ts
@@ -1,0 +1,134 @@
+/**
+ * Manifest + JSONL writer.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type {
+  CorpusManifest,
+  DroppedRecord,
+  InstructionPair,
+  RawArtifact,
+  SourceTag
+} from './types.js';
+import { ALL_SOURCE_TAGS } from './types.js';
+
+export interface WriteCorpusInputs {
+  outputDir: string;
+  rawArtifacts: ReadonlyArray<RawArtifact>;
+  finalPairs: ReadonlyArray<InstructionPair>;
+  dropped: ReadonlyArray<DroppedRecord>;
+  totals: CorpusManifest['totals'];
+  warnings: ReadonlyArray<string>;
+  configHash: string;
+  generatedAt: string;
+  elapsedMs: number;
+}
+
+export function buildManifest(inputs: WriteCorpusInputs): CorpusManifest {
+  const perSource = emptyPerSource();
+  for (const a of inputs.rawArtifacts) {
+    perSource[a.source].artifacts += 1;
+  }
+  for (const p of inputs.finalPairs) {
+    perSource[p.meta.source].samples += 1;
+  }
+
+  const redactedSpansHistogram: Record<string, number> = {};
+  for (const p of inputs.finalPairs) {
+    for (const tag of p.meta.redactedSpans) {
+      redactedSpansHistogram[tag] = (redactedSpansHistogram[tag] ?? 0) + 1;
+    }
+  }
+
+  const qualityHistogram: Record<string, number> = {
+    '0.0-0.2': 0,
+    '0.2-0.4': 0,
+    '0.4-0.6': 0,
+    '0.6-0.8': 0,
+    '0.8-1.0': 0
+  };
+  for (const p of inputs.finalPairs) {
+    const q = p.meta.qualityScore;
+    if (q < 0.2) qualityHistogram['0.0-0.2']! += 1;
+    else if (q < 0.4) qualityHistogram['0.2-0.4']! += 1;
+    else if (q < 0.6) qualityHistogram['0.4-0.6']! += 1;
+    else if (q < 0.8) qualityHistogram['0.6-0.8']! += 1;
+    else qualityHistogram['0.8-1.0']! += 1;
+  }
+
+  return {
+    version: 1,
+    generatedAt: inputs.generatedAt,
+    outputDir: inputs.outputDir,
+    elapsedMs: inputs.elapsedMs,
+    totals: { ...inputs.totals },
+    perSource,
+    redactedSpansHistogram,
+    qualityHistogram,
+    configSha256: inputs.configHash,
+    warnings: [...inputs.warnings]
+  };
+}
+
+function emptyPerSource(): Record<SourceTag, { artifacts: number; samples: number }> {
+  const out = {} as Record<SourceTag, { artifacts: number; samples: number }>;
+  for (const tag of ALL_SOURCE_TAGS) {
+    out[tag] = { artifacts: 0, samples: 0 };
+  }
+  return out;
+}
+
+/**
+ * Write all corpus artifacts to disk:
+ *   <outputDir>/manifest.json
+ *   <outputDir>/samples.jsonl     — one JSON object per line, the trainable set
+ *   <outputDir>/sources.json      — index of source artifacts considered
+ *   <outputDir>/dropped.jsonl     — one record per dropped artifact, with reason
+ *   <outputDir>/config.json       — serialized config snapshot
+ */
+export function writeCorpus(inputs: WriteCorpusInputs, configSnapshot: string): void {
+  mkdirSync(inputs.outputDir, { recursive: true });
+
+  // samples.jsonl — the trainable payload
+  const samplesPath = join(inputs.outputDir, 'samples.jsonl');
+  const samplesLines = inputs.finalPairs.map((p) => JSON.stringify(p));
+  writeFileSync(samplesPath, samplesLines.join('\n') + (samplesLines.length > 0 ? '\n' : ''), 'utf-8');
+
+  // sources.json — index of all considered raw artifacts
+  const sourcesPath = join(inputs.outputDir, 'sources.json');
+  const sourcesProjection = inputs.rawArtifacts.map((a) => ({
+    source: a.source,
+    sourceId: a.sourceId,
+    kind: a.kind ?? null,
+    correlationId: a.correlationId ?? null,
+    createdAtMs: a.createdAtMs,
+    sizeChars: a.text.length
+  }));
+  writeFileSync(sourcesPath, JSON.stringify(sourcesProjection, null, 2), 'utf-8');
+
+  // dropped.jsonl — one record per drop
+  const droppedPath = join(inputs.outputDir, 'dropped.jsonl');
+  const droppedLines = inputs.dropped.map((d) => JSON.stringify(d));
+  writeFileSync(
+    droppedPath,
+    droppedLines.join('\n') + (droppedLines.length > 0 ? '\n' : ''),
+    'utf-8'
+  );
+
+  // config.json — config snapshot (already sanitized by caller)
+  const configPath = join(inputs.outputDir, 'config.json');
+  writeFileSync(configPath, configSnapshot, 'utf-8');
+
+  // manifest.json — top-level summary
+  const manifestPath = join(inputs.outputDir, 'manifest.json');
+  const manifest = buildManifest(inputs);
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
+}
+
+/** Hash a config snapshot for the manifest. */
+export function hashConfig(snapshot: string): string {
+  return createHash('sha256').update(snapshot, 'utf-8').digest('hex');
+}

--- a/packages/apprentice-corpus/src/memory-walker.ts
+++ b/packages/apprentice-corpus/src/memory-walker.ts
@@ -1,0 +1,174 @@
+/**
+ * Memory-walker — reads `<memoryRoot>/*.md` (and `proposals/*.md`) and
+ * classifies each file by filename pattern.
+ *
+ * Mirrors the conventions of `@chiefaia/librarian`'s `pathToKind`, but
+ * without depending on the librarian package directly (the librarian's
+ * classifier is internal; we keep this independent so refactors there
+ * don't ripple here).
+ */
+
+import { join } from 'node:path';
+
+import type { FsReader, RawArtifact, ReaderContext, SourceReader } from './types.js';
+
+/** Stripped frontmatter + raw body. */
+export interface ParsedMarkdown {
+  frontmatter: Record<string, string>;
+  body: string;
+}
+
+/** Classify a memory file by basename. */
+export function classifyMemoryFile(basename: string): string {
+  const name = basename.toLowerCase();
+
+  if (name.endsWith('_directive.md') || name.includes('directive')) return 'directive';
+  if (name.startsWith('feedback_')) return 'feedback';
+  if (name.startsWith('proposal_') || name.includes('proposals/')) return 'proposal';
+  if (name.includes('registry')) return 'registry';
+  if (name.includes('architecture')) return 'architecture';
+  if (name.startsWith('master_')) return 'master';
+  if (name.includes('landscape')) return 'landscape';
+  if (name.startsWith('gate_') || name.startsWith('evidence_')) return 'gate';
+  if (name.startsWith('consolidation_')) return 'consolidation';
+  if (name.startsWith('daemon_')) return 'daemon';
+  if (name.startsWith('cci_')) return 'cci';
+  if (name.startsWith('mac_')) return 'mac';
+  if (name.startsWith('mcp_')) return 'mcp';
+  if (name.startsWith('safety_')) return 'safety';
+  if (name.startsWith('phase')) return 'phase';
+  if (name.startsWith('caia_') || name.startsWith('orchestrator_')) return 'team';
+  if (name.startsWith('backlog_')) return 'backlog';
+  return 'other';
+}
+
+/** Strip simple `---\n...\n---\n` YAML frontmatter; tolerant to absence. */
+export function parseMarkdown(raw: string): ParsedMarkdown {
+  const frontmatter: Record<string, string> = {};
+  if (!raw.startsWith('---')) {
+    return { frontmatter, body: raw };
+  }
+  const closeIdx = raw.indexOf('\n---', 3);
+  if (closeIdx === -1) return { frontmatter, body: raw };
+  const fm = raw.slice(3, closeIdx).trim();
+  for (const line of fm.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    if (key) frontmatter[key] = value;
+  }
+  // After `\n---` skip the next newline if any
+  let bodyStart = closeIdx + 4;
+  if (raw[bodyStart] === '\n') bodyStart += 1;
+  return { frontmatter, body: raw.slice(bodyStart) };
+}
+
+/** Predicate: should this filename be ingested? */
+export function isEligibleMarkdown(basename: string): boolean {
+  if (!basename.endsWith('.md')) return false;
+  if (basename.startsWith('.')) return false;
+  if (basename.includes('.bak')) return false;
+  // MEMORY.md is the index — would inflate similarity and add nothing
+  if (basename === 'MEMORY.md') return false;
+  return true;
+}
+
+export interface MemoryWalkerOptions {
+  memoryRoot: string;
+  fs: FsReader;
+}
+
+/** Build the memory-walker source reader. */
+export function createMemoryWalker(opts: MemoryWalkerOptions): SourceReader {
+  return {
+    source: 'memory',
+    async read(ctx: ReaderContext): Promise<RawArtifact[]> {
+      const out: RawArtifact[] = [];
+      walkMemoryRoot(opts.memoryRoot, opts.fs, ctx, out);
+      // Sort for deterministic ordering across runs / platforms
+      out.sort((a, b) => (a.sourceId < b.sourceId ? -1 : a.sourceId > b.sourceId ? 1 : 0));
+      return out;
+    }
+  };
+}
+
+function walkMemoryRoot(
+  root: string,
+  fs: FsReader,
+  ctx: ReaderContext,
+  out: RawArtifact[]
+): void {
+  if (!fs.exists(root)) return;
+  const cutoffMs = ctx.nowMs - ctx.maxAgeDays * 24 * 60 * 60 * 1000;
+  let entries: string[];
+  try {
+    entries = fs.readDir(root);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!isEligibleMarkdown(name)) {
+      // descend into proposals/ even though it's not a markdown
+      if (name === 'proposals') {
+        const sub = join(root, name);
+        if (fs.exists(sub)) walkProposals(sub, fs, ctx, cutoffMs, out);
+      }
+      continue;
+    }
+    const p = join(root, name);
+    appendMemoryFile(p, name, fs, cutoffMs, out);
+  }
+}
+
+function walkProposals(
+  dir: string,
+  fs: FsReader,
+  _ctx: ReaderContext,
+  cutoffMs: number,
+  out: RawArtifact[]
+): void {
+  let entries: string[];
+  try {
+    entries = fs.readDir(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (!isEligibleMarkdown(name)) continue;
+    const p = join(dir, name);
+    appendMemoryFile(p, name, fs, cutoffMs, out);
+  }
+}
+
+function appendMemoryFile(
+  path: string,
+  basename: string,
+  fs: FsReader,
+  cutoffMs: number,
+  out: RawArtifact[]
+): void {
+  let st;
+  try {
+    st = fs.stat(path);
+  } catch {
+    return;
+  }
+  if (!st.isFile) return;
+  if (st.mtimeMs < cutoffMs) return;
+  let raw: string;
+  try {
+    raw = fs.readFile(path);
+  } catch {
+    return;
+  }
+  const parsed = parseMarkdown(raw);
+  out.push({
+    source: 'memory',
+    sourceId: path,
+    kind: classifyMemoryFile(basename),
+    text: parsed.body,
+    sidecar: parsed.frontmatter,
+    createdAtMs: st.mtimeMs
+  });
+}

--- a/packages/apprentice-corpus/src/normaliser.ts
+++ b/packages/apprentice-corpus/src/normaliser.ts
@@ -1,0 +1,200 @@
+/**
+ * Normaliser — RawArtifact[] → InstructionPair[].
+ *
+ * Per the DESIGN.md table, source+kind picks an instruction template
+ * and a response-extraction strategy. Output is one or more
+ * InstructionPair per artifact (most artifacts produce exactly one).
+ *
+ * Stable id is sha256 of `messages` content joined by `\n` — used as
+ * primary key in dedupe and as `meta.contentSha256`.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { CAIA_SYSTEM_PROMPT } from './system-prompt.js';
+import type {
+  ChatMessage,
+  InstructionPair,
+  RawArtifact,
+  SourceTag
+} from './types.js';
+
+/** Build the user-side instruction text for a given artifact. */
+export function instructionFor(a: RawArtifact): string | null {
+  switch (a.source) {
+    case 'memory':
+      return memoryInstruction(a.kind);
+    case 'reports':
+      return 'Summarize this report and explain its purpose.';
+    case 'events':
+      return eventInstruction(a.kind);
+    case 'github':
+      return 'What was the goal of this PR and how was it accomplished?';
+    case 'langfuse':
+      return 'Given this prior trace input, produce an equivalent response.';
+    default:
+      return null;
+  }
+}
+
+function memoryInstruction(kind: string | undefined): string {
+  switch (kind) {
+    case 'directive':
+      return 'Summarize the standing rule or directive in this document.';
+    case 'feedback':
+      return 'What does this feedback say to do or avoid, and why?';
+    case 'architecture':
+      return 'Explain the architectural decision in this document.';
+    case 'registry':
+      return 'Describe what this registry catalogs and how it is used.';
+    case 'master':
+      return 'Summarize the master plan or sequencing in this document.';
+    case 'landscape':
+      return 'Summarize the ecosystem research in this document.';
+    case 'gate':
+      return 'Explain the gate or evidence rule in this document.';
+    case 'safety':
+      return 'Explain the safety or hardening rule in this document.';
+    case 'team':
+      return 'Describe the team or agent architecture in this document.';
+    case 'phase':
+      return 'Summarize the phase plan described here.';
+    case 'backlog':
+      return 'Describe the backlog item captured in this document.';
+    case 'proposal':
+      return 'What does this proposal recommend, and why?';
+    case 'consolidation':
+      return 'Summarize the consolidation actions in this document.';
+    case 'daemon':
+      return 'Describe the daemon configuration in this document.';
+    case 'cci':
+      return 'Describe the CCI worker configuration in this document.';
+    case 'mac':
+      return 'Describe the Mac dev landscape note in this document.';
+    case 'mcp':
+      return 'Describe the MCP server configuration in this document.';
+    default:
+      return 'Summarize this memory document.';
+  }
+}
+
+function eventInstruction(kind: string | undefined): string {
+  switch (kind) {
+    case 'PRMerged':
+      return 'A PR was merged. What was its purpose and outcome?';
+    case 'PRClosedWithoutMerge':
+      return 'A PR was closed without merging. Why was it abandoned?';
+    case 'PostMergeBugReport':
+      return 'A regression was reported post-merge. What was the issue and what should be learned?';
+    case 'OperatorCorrection':
+      return 'An operator correction was issued. What was wrong and what is the corrected approach?';
+    case 'OperatorAcknowledged':
+      return 'The operator acknowledged a finding. What was confirmed?';
+    case 'EvidenceGateFailure':
+      return 'An Evidence Gate check failed. What was the failure and how can it be avoided?';
+    case 'HallucinationFlagged':
+      return 'A hallucination was flagged. What was the hallucination and what is the truth?';
+    case 'ScopeMismatchFlagged':
+      return 'A scope mismatch was flagged. What was out of scope?';
+    case 'DoDViolation':
+      return 'A Definition-of-Done violation was flagged. What stage was skipped?';
+    case 'TaskFailed':
+      return 'A task failed. What was the error and the recovery action?';
+    case 'TaskAborted':
+      return 'A task was aborted. What was the reason?';
+    case 'DecisionClassifierTrip':
+      return 'The decision classifier was tripped. What kind of decision was misrouted?';
+    case 'ToolMisuseFlagged':
+      return 'Tool misuse was flagged. What was the misuse?';
+    case 'CapabilityBrokerOverride':
+      return 'A capability broker override fired. What capability was gated and why?';
+    default:
+      return `An event of type "${kind ?? 'unknown'}" was emitted. What does it record?`;
+  }
+}
+
+/** Strip noise + cap length on the response text. */
+export function buildResponse(a: RawArtifact, maxChars: number): string {
+  let body = (a.text ?? '').trim();
+  if (body.length > maxChars) {
+    // Truncate at last paragraph break before cap, falling back to hard cut
+    const cap = body.slice(0, maxChars);
+    const lastBreak = cap.lastIndexOf('\n\n');
+    body = lastBreak > maxChars * 0.5 ? cap.slice(0, lastBreak) : cap;
+  }
+  return body;
+}
+
+export interface NormaliserOptions {
+  minSampleLengthChars: number;
+  maxSampleLengthChars: number;
+  systemPrompt?: string;
+  /** Now-getter for stable createdAt timestamps in tests. */
+  clock: () => Date;
+}
+
+/**
+ * Normalise a single artifact. Returns null when the artifact is too
+ * short or when no instruction template applies; the caller records
+ * the drop reason.
+ */
+export function normaliseOne(a: RawArtifact, opts: NormaliserOptions): InstructionPair | null {
+  const instruction = instructionFor(a);
+  if (instruction === null) return null;
+  const response = buildResponse(a, opts.maxSampleLengthChars);
+  if (response.length < opts.minSampleLengthChars) return null;
+
+  const sysPrompt = opts.systemPrompt ?? CAIA_SYSTEM_PROMPT;
+  const messages: ChatMessage[] = [
+    { role: 'system', content: sysPrompt },
+    { role: 'user', content: instruction },
+    { role: 'assistant', content: response }
+  ];
+  const sha = sha256OfMessages(messages);
+  const pair: InstructionPair = {
+    id: sha,
+    messages,
+    meta: {
+      source: a.source,
+      sourceId: a.sourceId,
+      ...(a.correlationId !== undefined ? { correlationId: a.correlationId } : {}),
+      ...(a.kind !== undefined ? { kind: a.kind } : {}),
+      qualityScore: 0, // filled in by quality.ts
+      distilled: false,
+      redactedSpans: [],
+      createdAt: opts.clock().toISOString(),
+      contentSha256: sha
+    }
+  };
+  return pair;
+}
+
+/** Normalise an array. Drops failures silently — caller is the
+ *  aggregator which records the drop reason from a separate pass. */
+export function normaliseAll(
+  artifacts: ReadonlyArray<RawArtifact>,
+  opts: NormaliserOptions
+): { kept: InstructionPair[]; droppedSourceIds: Array<{ id: string; source: SourceTag; reason: 'too-short' | 'no-instruction-extractable' }> } {
+  const kept: InstructionPair[] = [];
+  const dropped: Array<{ id: string; source: SourceTag; reason: 'too-short' | 'no-instruction-extractable' }> = [];
+  for (const a of artifacts) {
+    const instruction = instructionFor(a);
+    if (instruction === null) {
+      dropped.push({ id: a.sourceId, source: a.source, reason: 'no-instruction-extractable' });
+      continue;
+    }
+    const response = buildResponse(a, opts.maxSampleLengthChars);
+    if (response.length < opts.minSampleLengthChars) {
+      dropped.push({ id: a.sourceId, source: a.source, reason: 'too-short' });
+      continue;
+    }
+    const pair = normaliseOne(a, opts);
+    if (pair !== null) kept.push(pair);
+  }
+  return { kept, droppedSourceIds: dropped };
+}
+
+export function sha256OfMessages(messages: ChatMessage[]): string {
+  const joined = messages.map((m) => `${m.role}\n${m.content}`).join('\n---\n');
+  return createHash('sha256').update(joined, 'utf-8').digest('hex');
+}

--- a/packages/apprentice-corpus/src/pii-mask.ts
+++ b/packages/apprentice-corpus/src/pii-mask.ts
@@ -1,0 +1,72 @@
+/**
+ * PII / credential masker.
+ *
+ * Three regex passes, conservative — false-positives accepted, false
+ * negatives unacceptable. The set of redacted span types is recorded
+ * per-sample in `meta.redactedSpans` for audit.
+ *
+ * Operator's name + email NOT auto-redacted — they appear deliberately
+ * in directives + memory and are intentional training signal. Add them
+ * via `extraRedactPatterns` if a downstream consumer wants them gone.
+ */
+
+export interface RedactPattern {
+  tag: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+/** Built-in default patterns. Order matters — secret-shapes come first to avoid masking inside emails. */
+export const DEFAULT_REDACT_PATTERNS: ReadonlyArray<RedactPattern> = Object.freeze([
+  // Anthropic / OpenAI API key shape
+  { tag: 'secret', pattern: /sk-[A-Za-z0-9_-]{20,}/g, replacement: '[redacted-secret]' },
+  // GitHub PAT
+  { tag: 'secret', pattern: /\bghp_[A-Za-z0-9]{36}\b/g, replacement: '[redacted-secret]' },
+  // GitHub fine-grained PAT
+  { tag: 'secret', pattern: /\bgithub_pat_[A-Za-z0-9_]{40,}\b/g, replacement: '[redacted-secret]' },
+  // GitLab PAT
+  { tag: 'secret', pattern: /\bglpat-[A-Za-z0-9_-]{20,}\b/g, replacement: '[redacted-secret]' },
+  // AWS access key
+  { tag: 'secret', pattern: /\bAKIA[0-9A-Z]{16}\b/g, replacement: '[redacted-secret]' },
+  // Generic secret-keyword + value (token=…, password=…, api_key=…)
+  {
+    tag: 'secret',
+    pattern: /\b(?:secret|password|passwd|api[_-]?key|token|bearer)\s*[:=]\s*["']?([A-Za-z0-9_\-./+=]{16,})["']?/gi,
+    replacement: '[redacted-secret-kv]'
+  },
+  // Email
+  { tag: 'email', pattern: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, replacement: '[redacted-email]' },
+  // Mac home path with username
+  { tag: 'path', pattern: /\/Users\/[A-Za-z0-9_-]+\//g, replacement: '~/' },
+  // Linux home path with username
+  { tag: 'path', pattern: /\/home\/[A-Za-z0-9_-]+\//g, replacement: '~/' }
+]);
+
+export interface MaskResult {
+  masked: string;
+  redactedSpans: string[];
+}
+
+/**
+ * Apply all patterns to `text` and return the redacted version plus
+ * the unique set of tag names that fired. The returned `redactedSpans`
+ * is sorted alphabetically for stable test snapshots.
+ */
+export function applyPiiMask(
+  text: string,
+  patterns: ReadonlyArray<RedactPattern> = DEFAULT_REDACT_PATTERNS
+): MaskResult {
+  const redacted = new Set<string>();
+  let out = text;
+  for (const p of patterns) {
+    if (p.pattern.test(out)) {
+      // Reset lastIndex from the test() call before replace
+      p.pattern.lastIndex = 0;
+      out = out.replace(p.pattern, p.replacement);
+      redacted.add(p.tag);
+    }
+    // Reset for next call
+    p.pattern.lastIndex = 0;
+  }
+  return { masked: out, redactedSpans: Array.from(redacted).sort() };
+}

--- a/packages/apprentice-corpus/src/quality.ts
+++ b/packages/apprentice-corpus/src/quality.ts
@@ -1,0 +1,112 @@
+/**
+ * Quality scorer.
+ *
+ * Each InstructionPair gets a score in [0, 1]. Components:
+ *
+ *   length-band:   0.30 if response length is comfortably inside the
+ *                  band [minLen, maxLen]; tapers off at the edges.
+ *   structure:     0.20 if the response has bullets / headers / multi-
+ *                  paragraph structure.
+ *   operator-voice:0.20 if source is `directive` or `feedback` from
+ *                  memory (high signal for the project's idiom).
+ *   filler-penalty:up to 0.20 deducted for thinking-aloud / voice-
+ *                  transcription filler ("um", "you know", "...kind of").
+ *   code-bonus:    0.10 if response is mostly code (≥70% inside ```).
+ *
+ * Sum is clamped to [0, 1].
+ */
+
+import type { InstructionPair } from './types.js';
+
+export interface QualityOptions {
+  minSampleLengthChars: number;
+  maxSampleLengthChars: number;
+}
+
+const FILLER_PATTERNS: ReadonlyArray<RegExp> = Object.freeze([
+  /\bum+\b/gi,
+  /\buh+\b/gi,
+  /\byou know\b/gi,
+  /\bkind of\b/gi,
+  /\bsort of\b/gi,
+  /\.\.\.\s*so\b/gi
+]);
+
+export function scoreOne(pair: InstructionPair, opts: QualityOptions): number {
+  const response = pair.messages.find((m) => m.role === 'assistant')?.content ?? '';
+  const len = response.length;
+
+  // Length floor — too-short samples are unusable; no other component
+  // can rescue them. Returning 0 here makes the score-zero contract
+  // explicit and matches the normaliser's drop behaviour.
+  if (len < opts.minSampleLengthChars) return 0;
+
+  // Length band — full credit at midpoint, taper off at edges
+  let lengthScore: number;
+  const lo = opts.minSampleLengthChars;
+  const hi = opts.maxSampleLengthChars;
+  const sweet = lo + (hi - lo) * 0.4; // sweet spot is in the lower-middle of the band
+  if (len < lo) {
+    lengthScore = 0;
+  } else if (len <= sweet) {
+    lengthScore = 0.3 * ((len - lo) / Math.max(1, sweet - lo));
+  } else if (len <= hi) {
+    // taper from 0.3 down to 0.15 as we approach hi
+    lengthScore = 0.3 - 0.15 * ((len - sweet) / Math.max(1, hi - sweet));
+  } else {
+    lengthScore = 0.1; // overflow penalised but not zero
+  }
+
+  // Structure — bullets / headers / multi-paragraph
+  const hasBullets = /^[-*]\s/m.test(response);
+  const hasHeaders = /^#{1,6}\s/m.test(response);
+  const paragraphs = response.split(/\n\n+/).filter((s) => s.trim() !== '').length;
+  const structureScore = hasBullets || hasHeaders || paragraphs > 1 ? 0.2 : 0;
+
+  // Operator voice — memory directives + feedback
+  const operatorVoiceScore =
+    pair.meta.source === 'memory'
+    && (pair.meta.kind === 'directive' || pair.meta.kind === 'feedback')
+      ? 0.2
+      : 0;
+
+  // Filler penalty — count occurrences across all patterns
+  let fillerHits = 0;
+  for (const re of FILLER_PATTERNS) {
+    const matches = response.match(re);
+    if (matches !== null) fillerHits += matches.length;
+  }
+  const fillerPenalty = Math.min(0.2, fillerHits * 0.04);
+
+  // Code bonus — fraction of chars inside fenced code blocks
+  const codeFraction = computeCodeFraction(response);
+  const codeBonus = codeFraction >= 0.7 ? 0.1 : 0;
+
+  const raw = lengthScore + structureScore + operatorVoiceScore + codeBonus - fillerPenalty;
+  return Math.max(0, Math.min(1, raw));
+}
+
+export function scoreAll(
+  pairs: ReadonlyArray<InstructionPair>,
+  opts: QualityOptions
+): InstructionPair[] {
+  return pairs.map((p) => ({
+    ...p,
+    meta: { ...p.meta, qualityScore: scoreOne(p, opts) }
+  }));
+}
+
+function computeCodeFraction(text: string): number {
+  if (text.length === 0) return 0;
+  let codeChars = 0;
+  let inCode = false;
+  const lines = text.split('\n');
+  for (const line of lines) {
+    if (line.trim().startsWith('```')) {
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode) codeChars += line.length + 1; // +1 for newline
+  }
+  return codeChars / text.length;
+}

--- a/packages/apprentice-corpus/src/reports-walker.ts
+++ b/packages/apprentice-corpus/src/reports-walker.ts
@@ -1,0 +1,65 @@
+/**
+ * Reports-walker — reads `<reportsRoot>/*.md` (handoffs, completion
+ * reports, analyses).
+ *
+ * Reports are diverse — some are dense narrative, some are structured
+ * summaries. The walker stays light: read the file, strip frontmatter
+ * if present, emit. The normaliser decides what to do with the body.
+ */
+
+import { join } from 'node:path';
+
+import { isEligibleMarkdown, parseMarkdown } from './memory-walker.js';
+import type { FsReader, RawArtifact, ReaderContext, SourceReader } from './types.js';
+
+export interface ReportsWalkerOptions {
+  reportsRoot: string;
+  fs: FsReader;
+}
+
+export function createReportsWalker(opts: ReportsWalkerOptions): SourceReader {
+  return {
+    source: 'reports',
+    async read(ctx: ReaderContext): Promise<RawArtifact[]> {
+      const out: RawArtifact[] = [];
+      const root = opts.reportsRoot;
+      if (!opts.fs.exists(root)) return out;
+      const cutoffMs = ctx.nowMs - ctx.maxAgeDays * 24 * 60 * 60 * 1000;
+      let entries: string[];
+      try {
+        entries = opts.fs.readDir(root);
+      } catch {
+        return out;
+      }
+      for (const name of entries) {
+        if (!isEligibleMarkdown(name)) continue;
+        const p = join(root, name);
+        let st;
+        try {
+          st = opts.fs.stat(p);
+        } catch {
+          continue;
+        }
+        if (!st.isFile) continue;
+        if (st.mtimeMs < cutoffMs) continue;
+        let raw: string;
+        try {
+          raw = opts.fs.readFile(p);
+        } catch {
+          continue;
+        }
+        const parsed = parseMarkdown(raw);
+        out.push({
+          source: 'reports',
+          sourceId: p,
+          kind: 'report',
+          text: parsed.body,
+          sidecar: parsed.frontmatter,
+          createdAtMs: st.mtimeMs
+        });
+      }
+      out.sort((a, b) => (a.sourceId < b.sourceId ? -1 : a.sourceId > b.sourceId ? 1 : 0));
+      return out;
+    }
+  };
+}

--- a/packages/apprentice-corpus/src/system-prompt.ts
+++ b/packages/apprentice-corpus/src/system-prompt.ts
@@ -1,0 +1,33 @@
+/**
+ * Stable system-prompt prepended to every training sample.
+ *
+ * Kept ≤500 tokens so the trainable signal is dominated by the
+ * user/assistant turn — the system prompt is a primer, not the lesson.
+ *
+ * Source-of-truth for the rules captured here:
+ *   - feedback_no_api_key_billing.md
+ *   - feedback_decision_classifier.md
+ *   - feedback_definition_of_done.md (10-stage DoD)
+ *   - feedback_git_flow_enforced.md
+ *   - feedback_pat_topic.md
+ *   - feedback_no_token_budgets.md
+ *   - feedback_operator_does_not_code.md
+ *
+ * If any of those rules change, regenerate this primer. The hash of
+ * the current primer text is included in the manifest's `configSha256`
+ * so downstream eval can detect drift.
+ */
+
+export const CAIA_SYSTEM_PROMPT = `You are an agent in the CAIA platform — a 25-agent self-improving AI development system. Operate by these standing rules:
+
+1. Subscription-only LLM costs. The pay-per-token Anthropic API is forbidden. Use the \`claude\` binary with the OAuth subscription session, or local Ollama. Never set ANTHROPIC_API_KEY for spawned children.
+2. Decision-classifier: decide → execute → inform. For any technical decision (library choice, refactor approach, test framework), do not ask the operator — decide and proceed. Ask only on genuine product / architecture pivots.
+3. 10-stage Definition of Done: Analyze → Research → Solution → Implement → Unit test → Integration test → Deploy → End-to-end live verify → Regression test → Document + capture learnings. Skipping stages = shipping debt.
+4. Git Flow: feature → develop → main. Open a PR per logical unit. Pass the Evidence Gate (build, test, lint, typecheck, gitflow-conformance). Never \`gh pr update-branch\` (creates merge commits).
+5. The operator does not code. All work happens in spawned agent sessions. The operator reviews via PR + transcript only.
+6. No token budgets per task. Work until natural completion or hard blocker.
+7. Worktree budget: ≤8 alarm threshold; ≤12 hard block. Snapshot before destructive operations.
+8. PAT-topic standing rule: do not re-flag credential placement decisions the operator has already settled.
+9. Mac=CAIA / remote=Stolution architectural split. Never SSH to remote in a CAIA session.
+
+Speak in the operator's idiom: terse, action-first, no preambles, no recap unless asked.`;

--- a/packages/apprentice-corpus/src/types.ts
+++ b/packages/apprentice-corpus/src/types.ts
@@ -1,0 +1,224 @@
+/**
+ * @chiefaia/apprentice-corpus — shared types.
+ *
+ * Pipeline overview:
+ *
+ *   SourceReader[]  →  RawArtifact[]
+ *                  →  InstructionPair[]    (normaliser)
+ *                  →  dedupe
+ *                  →  PII mask
+ *                  →  quality score
+ *                  →  distill (subprocess) for low-quality
+ *                  →  cap @ maxSamples
+ *                  →  write samples.jsonl + manifest.json
+ *
+ * The Option E shape: every CAIA-specific path/URL/topic is a constructor
+ * parameter with a CAIA default; tests inject fixtures. See DESIGN.md for
+ * the full architecture rationale.
+ */
+
+/** Tagged union of source kinds. */
+export type SourceTag =
+  | 'events'
+  | 'memory'
+  | 'reports'
+  | 'langfuse'
+  | 'github';
+
+/** All recognised source tags — useful for `Object.keys` and exhaustive checks. */
+export const ALL_SOURCE_TAGS: readonly SourceTag[] = Object.freeze([
+  'events',
+  'memory',
+  'reports',
+  'langfuse',
+  'github'
+]);
+
+/**
+ * A raw artifact from one source reader. The text payload is verbatim;
+ * downstream stages (normaliser, PII masker) transform it. `kind` is
+ * source-specific and opaque to the aggregator (e.g. memory → 'directive',
+ * events → 'PRMerged'). The aggregator preserves it for routing in the
+ * normaliser.
+ */
+export interface RawArtifact {
+  source: SourceTag;
+  /** File path / event id / trace id / PR number — must round-trip uniquely. */
+  sourceId: string;
+  /** Optional thread / correlation id for grouping related artifacts. */
+  correlationId?: string;
+  /** Source-specific kind tag (e.g. 'directive', 'PRMerged'). */
+  kind?: string;
+  /** Raw textual content (post-frontmatter strip if applicable). */
+  text: string;
+  /** Optional structured metadata preserved verbatim into meta sidecar. */
+  sidecar?: Record<string, unknown>;
+  /** Artifact creation time; reader's best estimate (mtime / event timestamp). */
+  createdAtMs: number;
+}
+
+/**
+ * One chat-completions turn in the OpenAI / MLX-LM format. The corpus is
+ * shipped as one JSON object per line with a `messages` field that is a
+ * 3-tuple (system, user, assistant) by default.
+ */
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * One curated training pair. The `messages[]` field is the trainable
+ * payload; everything else is metadata for audit + downstream filtering.
+ */
+export interface InstructionPair {
+  /** Stable id (sha256 of messages content for determinism in tests). */
+  id: string;
+  messages: ChatMessage[];
+  meta: {
+    source: SourceTag;
+    sourceId: string;
+    correlationId?: string;
+    kind?: string;
+    qualityScore: number;
+    distilled: boolean;
+    redactedSpans: string[];
+    createdAt: string;
+    contentSha256: string;
+  };
+}
+
+/** Reader context passed to every source reader. */
+export interface ReaderContext {
+  maxAgeDays: number;
+  /** Caller's now() — injected for deterministic tests. */
+  nowMs: number;
+}
+
+/** Common interface for all 5 source readers. */
+export interface SourceReader {
+  readonly source: SourceTag;
+  read(ctx: ReaderContext): Promise<RawArtifact[]>;
+}
+
+/** Filesystem reader interface — injected so tests can fake it. */
+export interface FsReader {
+  exists(path: string): boolean;
+  readDir(path: string): string[];
+  readFile(path: string): string;
+  stat(path: string): { mtimeMs: number; size: number; isFile: boolean };
+}
+
+/** Mentor event-bus client interface — injected so tests can fake it. */
+export interface EventBusClient {
+  /**
+   * Read events newer than `sinceMs`. Returns chronologically
+   * ascending. Implementations may bound the number of events
+   * returned; the aggregator does not assume completeness.
+   */
+  readSince(sinceMs: number): Promise<EventBusRecord[]>;
+}
+
+/** Event bus record — minimal projection of `EmittedEvent`. */
+export interface EventBusRecord {
+  id: string;
+  type: string;
+  emittedAtMs: number;
+  correlationId?: string;
+  payload: Record<string, unknown>;
+}
+
+/** GitHub reader client — injected. */
+export interface GithubClient {
+  /**
+   * List merged PRs with title + body + URL. Bounded by `sinceMs`.
+   * Implementations should respect rate limits and emit warnings; if
+   * rate-limited, return what was fetched so far.
+   */
+  listMergedPrs(sinceMs: number, repo: string): Promise<GithubPrRecord[]>;
+}
+
+/** GitHub PR record. */
+export interface GithubPrRecord {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  mergedAtMs: number;
+}
+
+/** Langfuse client — injected. Phase-0 ships a stub that returns []. */
+export interface LangfuseClient {
+  listTraces(sinceMs: number, projectId: string): Promise<LangfuseTraceRecord[]>;
+}
+
+export interface LangfuseTraceRecord {
+  id: string;
+  name: string;
+  input: string;
+  output: string;
+  createdAtMs: number;
+}
+
+/** Claude distiller — invoked for low-quality samples. Injected. */
+export interface ClaudeDistiller {
+  /**
+   * Refine a raw artifact into a clean `{instruction, response}` pair.
+   * Implementations must respect subscription-only billing — never the
+   * pay-per-token API key path. Throws on rate-limit, timeout, missing
+   * binary, or malformed output. The caller treats any throw as
+   * "drop this sample"; do NOT throw across the whole pipeline.
+   */
+  distill(input: DistillInput): Promise<DistillOutput>;
+}
+
+export interface DistillInput {
+  source: SourceTag;
+  kind?: string;
+  text: string;
+}
+
+export interface DistillOutput {
+  instruction: string;
+  response: string;
+}
+
+/** Manifest schema — version 1. */
+export interface CorpusManifest {
+  version: 1;
+  generatedAt: string;
+  outputDir: string;
+  elapsedMs: number;
+  totals: {
+    rawArtifacts: number;
+    afterDedup: number;
+    afterPII: number;
+    afterQuality: number;
+    distilled: number;
+    dropped: number;
+    final: number;
+  };
+  perSource: Record<SourceTag, { artifacts: number; samples: number }>;
+  redactedSpansHistogram: Record<string, number>;
+  qualityHistogram: Record<string, number>;
+  configSha256: string;
+  warnings: string[];
+}
+
+/** Reason a candidate was dropped from the final corpus. */
+export type DropReason =
+  | 'too-short'
+  | 'too-long'
+  | 'duplicate'
+  | 'low-quality-no-distill-budget'
+  | 'distill-failed'
+  | 'distill-still-low-quality'
+  | 'no-instruction-extractable';
+
+export interface DroppedRecord {
+  source: SourceTag;
+  sourceId: string;
+  reason: DropReason;
+  qualityScore?: number;
+  errorMessage?: string;
+}

--- a/packages/apprentice-corpus/tests/__fixtures__/mini-memory/MEMORY.md
+++ b/packages/apprentice-corpus/tests/__fixtures__/mini-memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index — fixture
+- [test_directive](test_directive.md)
+- [feedback_no_caffeine](feedback_no_caffeine.md)

--- a/packages/apprentice-corpus/tests/__fixtures__/mini-memory/feedback_no_caffeine.md
+++ b/packages/apprentice-corpus/tests/__fixtures__/mini-memory/feedback_no_caffeine.md
@@ -1,0 +1,12 @@
+---
+name: No caffeine after 6pm
+description: Test fixture — operator feedback rule
+type: feedback
+---
+# Standing rule (test fixture)
+
+Do not consume caffeine after 6pm.
+
+**Why**: Disrupts sleep, hurts next-day decision quality.
+
+**How to apply**: Decline coffee, tea (caffeinated), and energy drinks after 18:00 local time. Decaf is fine. Herbal tea is fine.

--- a/packages/apprentice-corpus/tests/__fixtures__/mini-memory/test_directive.md
+++ b/packages/apprentice-corpus/tests/__fixtures__/mini-memory/test_directive.md
@@ -1,0 +1,18 @@
+---
+name: Test directive — fixture-only
+description: Fixture for memory walker tests
+type: project
+---
+# Test directive
+
+This is a fixture directive used in unit tests. It exists so the memory-walker can be exercised against a non-CAIA corpus without coupling tests to the live agent/memory directory.
+
+## Purpose
+
+- Verify the walker classifies `*_directive.md` as `directive`
+- Verify frontmatter is stripped from the body
+- Verify the body becomes the artifact text
+
+## Sample content
+
+The walker should emit one RawArtifact for this file with `kind: 'directive'` and the body above.

--- a/packages/apprentice-corpus/tests/__fixtures__/mini-reports/2026-05-06-test-handoff.md
+++ b/packages/apprentice-corpus/tests/__fixtures__/mini-reports/2026-05-06-test-handoff.md
@@ -1,0 +1,15 @@
+# Test handoff — fixture
+
+This is a synthetic handoff document used in unit tests for the reports-walker.
+
+## Summary
+
+The reports-walker should pick up this file because it lives at the root of `<reportsRoot>/` and ends with `.md`. Its kind is `report` and the entire body becomes the artifact text.
+
+## Body
+
+The body contains enough text to clear the minimum-length threshold so the normaliser keeps it as an InstructionPair. Operator's email prakashmailid@gmail.com appears in this fixture so the PII masker can be tested end-to-end against an email-shaped pattern.
+
+The body also contains a path with username: /Users/test-user/some/file.md which the masker should normalise to ~/.
+
+A fake API key shape: sk-abcdefghijklmnopqrstuvwxyz1234567890 should be redacted.

--- a/packages/apprentice-corpus/tests/aggregator.integration.test.ts
+++ b/packages/apprentice-corpus/tests/aggregator.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration test — exercises the full ApprenticeCorpusAggregator
+ * pipeline against fixture corpora across all 5 readers, with no real
+ * network or subprocess calls. Verifies that the manifest written to
+ * disk matches the expected shape and that samples.jsonl is parseable.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { ApprenticeCorpusAggregator } from '../src/aggregator.js';
+import { defaultFsReader } from '../src/fs-reader.js';
+import {
+  createFakeDistiller,
+  createFakeEventBus,
+  createFakeGithub,
+  createFakeLangfuse
+} from './helpers/fakes.js';
+
+const FIXTURE_MEMORY = join(__dirname, '__fixtures__', 'mini-memory');
+const FIXTURE_REPORTS = join(__dirname, '__fixtures__', 'mini-reports');
+
+describe('ApprenticeCorpusAggregator — integration with fixtures', () => {
+  let outputRoot: string;
+  beforeEach(() => {
+    outputRoot = mkdtempSync(join(tmpdir(), 'apprentice-corpus-int-'));
+  });
+  afterEach(() => {
+    rmSync(outputRoot, { recursive: true, force: true });
+  });
+
+  it('runs end-to-end over fixture memory + reports + fake events + fake PRs', async () => {
+    const fixedClock = () => new Date('2026-05-06T12:00:00Z');
+    const eventTime = Date.parse('2026-05-04T00:00:00Z');
+    const prTime = Date.parse('2026-05-05T00:00:00Z');
+
+    const agg = new ApprenticeCorpusAggregator({
+      memoryRoot: FIXTURE_MEMORY,
+      reportsRoot: FIXTURE_REPORTS,
+      outputRoot,
+      distillEnabled: false,
+      maxAgeDays: 365,
+      qualityThreshold: 0.0, // accept everything for the integration test
+      fs: defaultFsReader,
+      eventBus: createFakeEventBus([
+        {
+          id: 'evt-1',
+          type: 'PRMerged',
+          emittedAtMs: eventTime,
+          payload: {
+            prNumber: 999,
+            title: 'feat(test): integration fixture event',
+            body: 'A merged PR event used to verify the event-bus reader feeds the aggregator end-to-end. The body is comfortably long enough to clear the minimum-length threshold and contribute a real instruction-output sample to the corpus.'
+          }
+        },
+        {
+          id: 'evt-2',
+          type: 'OperatorCorrection',
+          emittedAtMs: eventTime + 1000,
+          payload: {
+            correction: 'Do not use API-key billing. Always use the subscription path via the claude binary. The pay-per-token mode is forbidden per feedback_no_api_key_billing.md and would burn through the budget in days.'
+          }
+        }
+      ]),
+      github: createFakeGithub([
+        {
+          number: 1,
+          title: 'feat(test): fixture pr',
+          body: 'Body of a merged PR fixture, sufficiently long to make it through the normaliser and quality scorer end-to-end so the integration test exercises the github reader path.',
+          url: 'https://example.test/pr/1',
+          mergedAtMs: prTime
+        }
+      ]),
+      langfuse: createFakeLangfuse([]),
+      claudeDistiller: createFakeDistiller(() => {
+        throw new Error('distill should not be called when disabled');
+      }),
+      clock: fixedClock
+    });
+
+    const manifest = await agg.aggregate();
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.totals.rawArtifacts).toBe(6); // 2 memory + 1 report + 2 events + 1 github
+    expect(manifest.totals.final).toBeGreaterThan(0);
+    expect(manifest.perSource.memory.artifacts).toBe(2);
+    expect(manifest.perSource.reports.artifacts).toBe(1);
+    expect(manifest.perSource.events.artifacts).toBe(2);
+    expect(manifest.perSource.github.artifacts).toBe(1);
+    expect(manifest.perSource.langfuse.artifacts).toBe(0);
+    expect(manifest.warnings).toEqual([]);
+
+    // Output dir is dated
+    const expectedDir = join(outputRoot, '2026-05-06');
+    expect(existsSync(expectedDir)).toBe(true);
+    expect(existsSync(join(expectedDir, 'manifest.json'))).toBe(true);
+    expect(existsSync(join(expectedDir, 'samples.jsonl'))).toBe(true);
+    expect(existsSync(join(expectedDir, 'sources.json'))).toBe(true);
+    expect(existsSync(join(expectedDir, 'dropped.jsonl'))).toBe(true);
+    expect(existsSync(join(expectedDir, 'config.json'))).toBe(true);
+
+    // samples.jsonl parses one JSON per line
+    const samplesText = readFileSync(join(expectedDir, 'samples.jsonl'), 'utf-8');
+    const lines = samplesText.split('\n').filter((l) => l !== '');
+    expect(lines.length).toBe(manifest.totals.final);
+    for (const line of lines) {
+      const obj = JSON.parse(line);
+      expect(obj.id).toBeDefined();
+      expect(Array.isArray(obj.messages)).toBe(true);
+      expect(obj.messages.length).toBe(3);
+      expect(obj.messages[0].role).toBe('system');
+      expect(obj.messages[1].role).toBe('user');
+      expect(obj.messages[2].role).toBe('assistant');
+      expect(typeof obj.meta.qualityScore).toBe('number');
+      expect(typeof obj.meta.contentSha256).toBe('string');
+    }
+  });
+
+  it('respects --dry-run by writing nothing', async () => {
+    const agg = new ApprenticeCorpusAggregator({
+      memoryRoot: FIXTURE_MEMORY,
+      reportsRoot: FIXTURE_REPORTS,
+      outputRoot,
+      distillEnabled: false,
+      qualityThreshold: 0.0,
+      eventBus: createFakeEventBus([]),
+      github: createFakeGithub([]),
+      langfuse: createFakeLangfuse([]),
+      clock: () => new Date('2026-05-06T12:00:00Z')
+    });
+    const manifest = await agg.aggregate({ dryRun: true });
+    expect(manifest.totals.final).toBeGreaterThan(0);
+    const expectedDir = join(outputRoot, '2026-05-06');
+    expect(existsSync(expectedDir)).toBe(false);
+  });
+
+  it('redacts credentials from fixture report (PII masking enabled by default)', async () => {
+    const agg = new ApprenticeCorpusAggregator({
+      memoryRoot: FIXTURE_MEMORY,
+      reportsRoot: FIXTURE_REPORTS,
+      outputRoot,
+      distillEnabled: false,
+      qualityThreshold: 0.0,
+      eventBus: createFakeEventBus([]),
+      github: createFakeGithub([]),
+      langfuse: createFakeLangfuse([]),
+      clock: () => new Date('2026-05-06T12:00:00Z')
+    });
+    const manifest = await agg.aggregate();
+    const samplesText = readFileSync(
+      join(outputRoot, '2026-05-06', 'samples.jsonl'),
+      'utf-8'
+    );
+    // The fixture handoff contains a sk- key shape — verify it's redacted
+    expect(samplesText).not.toContain('sk-abcdefghijklmnopqrstuvwxyz1234567890');
+    expect(samplesText).toContain('[redacted-secret');
+    // Email shape redaction
+    expect(samplesText).not.toContain('prakashmailid@gmail.com');
+    expect(samplesText).toContain('[redacted-email]');
+    // Path normalisation
+    expect(samplesText).not.toContain('/Users/test-user/');
+    // The redacted-spans histogram should record what fired
+    expect(Object.keys(manifest.redactedSpansHistogram)).toContain('email');
+    expect(Object.keys(manifest.redactedSpansHistogram)).toContain('secret');
+  });
+
+  it('routes low-quality samples through distiller when enabled', async () => {
+    let distillCalls = 0;
+    const fakeDistiller = createFakeDistiller(() => {
+      distillCalls += 1;
+      return {
+        instruction: 'What is the rule?',
+        response:
+          '# Rule header\n\n- bullet one\n- bullet two\n\nA polished response that is structured, comfortably above the floor, and looks like the operator wrote it.\n\nMore text for additional length contribution.'
+      };
+    });
+
+    const agg = new ApprenticeCorpusAggregator({
+      memoryRoot: FIXTURE_MEMORY,
+      reportsRoot: FIXTURE_REPORTS,
+      outputRoot,
+      distillEnabled: true,
+      qualityThreshold: 0.99, // force every sample below threshold
+      eventBus: createFakeEventBus([]),
+      github: createFakeGithub([]),
+      langfuse: createFakeLangfuse([]),
+      claudeDistiller: fakeDistiller,
+      clock: () => new Date('2026-05-06T12:00:00Z')
+    });
+
+    const manifest = await agg.aggregate();
+    // We had memory + reports artifacts; all routed through distiller
+    expect(distillCalls).toBeGreaterThan(0);
+    expect(manifest.totals.distilled).toBeGreaterThan(0);
+  });
+
+  it('records langfuse=disabled state (Phase-0 stub posture)', async () => {
+    const agg = new ApprenticeCorpusAggregator({
+      memoryRoot: FIXTURE_MEMORY,
+      reportsRoot: FIXTURE_REPORTS,
+      outputRoot,
+      distillEnabled: false,
+      qualityThreshold: 0.0,
+      langfuseEnabled: false, // explicit
+      eventBus: createFakeEventBus([]),
+      github: createFakeGithub([]),
+      // even if langfuse client returns records, the reader skips when disabled
+      langfuse: createFakeLangfuse([
+        {
+          id: 'should-not-appear',
+          name: 'agent.run',
+          input: 'x',
+          output: 'y',
+          createdAtMs: Date.now()
+        }
+      ]),
+      clock: () => new Date('2026-05-06T12:00:00Z')
+    });
+    const manifest = await agg.aggregate();
+    expect(manifest.perSource.langfuse.artifacts).toBe(0);
+  });
+});

--- a/packages/apprentice-corpus/tests/cli.test.ts
+++ b/packages/apprentice-corpus/tests/cli.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseArgs } from '../src/cli.js';
+
+describe('parseArgs', () => {
+  it('extracts the command', () => {
+    expect(parseArgs(['aggregate'])).toMatchObject({ command: 'aggregate' });
+  });
+
+  it('detects --dry-run', () => {
+    expect(parseArgs(['aggregate', '--dry-run'])).toMatchObject({ dryRun: true });
+  });
+
+  it('parses --memory-root with value', () => {
+    const r = parseArgs(['aggregate', '--memory-root', '/x']);
+    expect(r.config.memoryRoot).toBe('/x');
+  });
+
+  it('parses --no-distill', () => {
+    expect(parseArgs(['aggregate', '--no-distill']).config.distillEnabled).toBe(false);
+  });
+
+  it('parses numeric flags', () => {
+    const r = parseArgs([
+      'aggregate',
+      '--max-samples',
+      '7',
+      '--max-age-days',
+      '30',
+      '--quality-threshold',
+      '0.6'
+    ]);
+    expect(r.config.maxSamples).toBe(7);
+    expect(r.config.maxAgeDays).toBe(30);
+    expect(r.config.qualityThreshold).toBe(0.6);
+  });
+
+  it('returns help command on --help', () => {
+    expect(parseArgs(['--help']).command).toBe('help');
+    expect(parseArgs(['-h']).command).toBe('help');
+  });
+
+  it('ignores unknown flags without crashing', () => {
+    expect(() => parseArgs(['aggregate', '--something-unknown'])).not.toThrow();
+  });
+});

--- a/packages/apprentice-corpus/tests/config.test.ts
+++ b/packages/apprentice-corpus/tests/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+
+import { expandHome, resolveConfig, snapshotConfigForHash } from '../src/config.js';
+
+describe('expandHome', () => {
+  it('expands tilde slash', () => {
+    expect(expandHome('~/foo')).toMatch(/\/foo$/);
+    expect(expandHome('~/foo')).not.toBe('~/foo');
+  });
+  it('passes through absolute paths', () => {
+    expect(expandHome('/abs/path')).toBe('/abs/path');
+  });
+  it('handles bare ~', () => {
+    expect(expandHome('~')).not.toBe('~');
+  });
+});
+
+describe('resolveConfig', () => {
+  const snapshot: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of [
+      'CAIA_MEMORY_DIR',
+      'CAIA_REPORTS_DIR',
+      'CAIA_EVENTS_DB',
+      'CAIA_GITHUB_REPO',
+      'APPRENTICE_CORPUS_ROOT',
+      'CLAUDE_BINARY_PATH'
+    ]) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(snapshot)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('falls back to CAIA defaults when nothing provided', () => {
+    const cfg = resolveConfig({});
+    expect(cfg.memoryRoot).toContain('agent/memory');
+    expect(cfg.reportsRoot).toContain('Documents/projects/reports');
+    expect(cfg.outputRoot).toContain('Documents/projects/apprentice/corpora');
+    expect(cfg.githubRepo).toBe('chiefaia/caia');
+    expect(cfg.langfuseEnabled).toBe(false);
+    expect(cfg.distillEnabled).toBe(true);
+  });
+
+  it('lets explicit args override defaults', () => {
+    const cfg = resolveConfig({
+      memoryRoot: '/explicit/mem',
+      reportsRoot: '/explicit/rep',
+      maxSamples: 7,
+      qualityThreshold: 0.9,
+      langfuseEnabled: true
+    });
+    expect(cfg.memoryRoot).toBe('/explicit/mem');
+    expect(cfg.reportsRoot).toBe('/explicit/rep');
+    expect(cfg.maxSamples).toBe(7);
+    expect(cfg.qualityThreshold).toBe(0.9);
+    expect(cfg.langfuseEnabled).toBe(true);
+  });
+
+  it('lets env vars override defaults but not explicit args', () => {
+    process.env['CAIA_MEMORY_DIR'] = '/from/env';
+    expect(resolveConfig({}).memoryRoot).toBe('/from/env');
+    expect(resolveConfig({ memoryRoot: '/from/arg' }).memoryRoot).toBe('/from/arg');
+  });
+
+  it('snapshotConfigForHash is deterministic', () => {
+    const a = snapshotConfigForHash(resolveConfig({ memoryRoot: '/x' }));
+    const b = snapshotConfigForHash(resolveConfig({ memoryRoot: '/x' }));
+    expect(a).toBe(b);
+  });
+});

--- a/packages/apprentice-corpus/tests/dedupe.test.ts
+++ b/packages/apprentice-corpus/tests/dedupe.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { dedupePairs } from '../src/dedupe.js';
+import type { InstructionPair } from '../src/types.js';
+
+function makePair(sha: string, idx: number): InstructionPair {
+  return {
+    id: sha,
+    messages: [
+      { role: 'system', content: 's' },
+      { role: 'user', content: 'u' },
+      { role: 'assistant', content: `a-${idx}` }
+    ],
+    meta: {
+      source: 'memory',
+      sourceId: `id-${idx}`,
+      qualityScore: 0,
+      distilled: false,
+      redactedSpans: [],
+      createdAt: '2026-05-06T00:00:00Z',
+      contentSha256: sha
+    }
+  };
+}
+
+describe('dedupePairs', () => {
+  it('first occurrence wins', () => {
+    const a = makePair('h1', 0);
+    const b = makePair('h2', 1);
+    const c = makePair('h1', 2); // dup
+    const r = dedupePairs([a, b, c]);
+    expect(r.kept.map((p) => p.meta.sourceId)).toEqual(['id-0', 'id-1']);
+    expect(r.duplicates.map((p) => p.meta.sourceId)).toEqual(['id-2']);
+  });
+
+  it('returns empty kept for empty input', () => {
+    const r = dedupePairs([]);
+    expect(r.kept).toEqual([]);
+    expect(r.duplicates).toEqual([]);
+  });
+
+  it('preserves order of kept pairs', () => {
+    const xs = [makePair('h1', 0), makePair('h2', 1), makePair('h3', 2)];
+    const r = dedupePairs(xs);
+    expect(r.kept).toEqual(xs);
+  });
+});

--- a/packages/apprentice-corpus/tests/distiller.test.ts
+++ b/packages/apprentice-corpus/tests/distiller.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DISTILL_PROMPT_TEMPLATE,
+  createDefaultDistiller,
+  parseDistillerOutput
+} from '../src/distiller.js';
+
+describe('parseDistillerOutput', () => {
+  it('parses claude envelope + inner JSON', () => {
+    const inner = JSON.stringify({ instruction: 'q', response: 'a' });
+    const outer = JSON.stringify({ result: inner });
+    expect(parseDistillerOutput(outer)).toEqual({ instruction: 'q', response: 'a' });
+  });
+
+  it('throws on malformed envelope', () => {
+    expect(() => parseDistillerOutput('not json')).toThrow();
+  });
+
+  it('throws when result is not a string', () => {
+    expect(() => parseDistillerOutput(JSON.stringify({ result: 123 }))).toThrow();
+  });
+
+  it('throws on malformed inner JSON', () => {
+    expect(() => parseDistillerOutput(JSON.stringify({ result: 'not-json' }))).toThrow();
+  });
+
+  it('throws when inner JSON missing fields', () => {
+    expect(() =>
+      parseDistillerOutput(JSON.stringify({ result: JSON.stringify({ x: 1 }) }))
+    ).toThrow();
+  });
+});
+
+describe('createDefaultDistiller', () => {
+  it('strips ANTHROPIC_API_KEY from spawn env', async () => {
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
+      stderr: '',
+      error: null
+    });
+    const distiller = createDefaultDistiller({
+      binaryPath: 'claude',
+      spawnFn: fakeSpawn as never
+    });
+    process.env['ANTHROPIC_API_KEY'] = 'should-not-leak';
+    await distiller.distill({ source: 'memory', kind: 'directive', text: 'x' });
+    const callOpts = fakeSpawn.mock.calls[0]?.[2] as { env: Record<string, string | undefined> };
+    expect(callOpts.env['ANTHROPIC_API_KEY']).toBeUndefined();
+  });
+
+  it('throws on non-zero exit', async () => {
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'rate limit',
+      error: null
+    });
+    const distiller = createDefaultDistiller({
+      binaryPath: 'claude',
+      spawnFn: fakeSpawn as never
+    });
+    await expect(
+      distiller.distill({ source: 'memory', text: 'x' })
+    ).rejects.toThrow(/exited 1/);
+  });
+
+  it('passes prompt as input', async () => {
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
+      stderr: '',
+      error: null
+    });
+    const distiller = createDefaultDistiller({
+      binaryPath: 'claude',
+      spawnFn: fakeSpawn as never
+    });
+    await distiller.distill({ source: 'memory', kind: 'directive', text: 'BODY' });
+    const callOpts = fakeSpawn.mock.calls[0]?.[2] as { input: string };
+    expect(callOpts.input).toContain('BODY');
+    expect(callOpts.input).toContain('memory/directive');
+  });
+});
+
+describe('DISTILL_PROMPT_TEMPLATE', () => {
+  it('contains placeholder slots', () => {
+    expect(DISTILL_PROMPT_TEMPLATE).toContain('{source}');
+    expect(DISTILL_PROMPT_TEMPLATE).toContain('{kind}');
+    expect(DISTILL_PROMPT_TEMPLATE).toContain('{text}');
+  });
+});

--- a/packages/apprentice-corpus/tests/event-bus-reader.test.ts
+++ b/packages/apprentice-corpus/tests/event-bus-reader.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { createEventBusReader, projectEventToText } from '../src/event-bus-reader.js';
+import { createFakeEventBus } from './helpers/fakes.js';
+
+describe('projectEventToText', () => {
+  it('flattens payload to lines', () => {
+    const text = projectEventToText({
+      id: 'e-1',
+      type: 'TaskCompleted',
+      emittedAtMs: 0,
+      payload: { taskId: 't-1', durationMs: 200, exitCode: 0 }
+    });
+    expect(text).toContain('Event: TaskCompleted');
+    expect(text).toContain('taskId: t-1');
+    expect(text).toContain('durationMs: 200');
+  });
+
+  it('returns empty string when payload has no detail lines', () => {
+    const text = projectEventToText({
+      id: 'e-1',
+      type: 'X',
+      emittedAtMs: 0,
+      payload: {}
+    });
+    expect(text).toBe('');
+  });
+});
+
+describe('createEventBusReader', () => {
+  it('reads events newer than the cutoff', async () => {
+    const now = Date.now();
+    const oldEvent = {
+      id: 'old',
+      type: 'TaskCompleted',
+      emittedAtMs: now - 1000 * 60 * 60 * 24 * 400,
+      payload: { taskId: 'old', durationMs: 1, exitCode: 0 }
+    };
+    const newEvent = {
+      id: 'new',
+      type: 'TaskCompleted',
+      emittedAtMs: now,
+      payload: { taskId: 'new', durationMs: 1, exitCode: 0 }
+    };
+    const reader = createEventBusReader({
+      client: createFakeEventBus([oldEvent, newEvent])
+    });
+    const out = await reader.read({ maxAgeDays: 365, nowMs: now });
+    expect(out.map((a) => a.sourceId)).toEqual(['new']);
+    expect(out[0]?.kind).toBe('TaskCompleted');
+    expect(out[0]?.text).toContain('taskId: new');
+  });
+
+  it('returns [] on read error', async () => {
+    const reader = createEventBusReader({
+      client: {
+        async readSince() {
+          throw new Error('boom');
+        }
+      }
+    });
+    expect(await reader.read({ maxAgeDays: 1, nowMs: Date.now() })).toEqual([]);
+  });
+});

--- a/packages/apprentice-corpus/tests/github-reader.test.ts
+++ b/packages/apprentice-corpus/tests/github-reader.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { createGithubReader, formatPrText } from '../src/github-reader.js';
+import { createFakeGithub } from './helpers/fakes.js';
+
+describe('formatPrText', () => {
+  it('joins title + body', () => {
+    expect(formatPrText({
+      number: 1,
+      title: 'feat: x',
+      body: 'body content',
+      url: 'http://x',
+      mergedAtMs: 0
+    })).toBe('feat: x\n\nbody content');
+  });
+  it('handles empty body', () => {
+    expect(formatPrText({
+      number: 1,
+      title: 'feat: x',
+      body: '',
+      url: 'http://x',
+      mergedAtMs: 0
+    })).toBe('feat: x');
+  });
+  it('returns empty when both blank', () => {
+    expect(formatPrText({
+      number: 1,
+      title: '',
+      body: '',
+      url: 'http://x',
+      mergedAtMs: 0
+    })).toBe('');
+  });
+});
+
+describe('createGithubReader', () => {
+  it('emits one artifact per merged PR within window', async () => {
+    const now = Date.now();
+    const reader = createGithubReader({
+      client: createFakeGithub([
+        { number: 1, title: 'old', body: 'b', url: 'u', mergedAtMs: now - 1000 * 60 * 60 * 24 * 400 },
+        { number: 2, title: 'new', body: 'b', url: 'u', mergedAtMs: now }
+      ]),
+      repo: 'test/repo'
+    });
+    const out = await reader.read({ maxAgeDays: 365, nowMs: now });
+    expect(out.map((a) => a.sourceId)).toEqual(['pr#2']);
+    expect(out[0]?.kind).toBe('PR');
+    expect(out[0]?.text).toContain('new');
+  });
+
+  it('returns [] on rate limit / failure', async () => {
+    const reader = createGithubReader({
+      client: {
+        async listMergedPrs() {
+          throw new Error('rate limited');
+        }
+      },
+      repo: 'test/repo'
+    });
+    expect(await reader.read({ maxAgeDays: 1, nowMs: Date.now() })).toEqual([]);
+  });
+});

--- a/packages/apprentice-corpus/tests/helpers/fakes.ts
+++ b/packages/apprentice-corpus/tests/helpers/fakes.ts
@@ -1,0 +1,100 @@
+/**
+ * Test helpers — in-memory fakes for the FsReader / EventBusClient /
+ * GithubClient / LangfuseClient / ClaudeDistiller interfaces.
+ */
+
+import type {
+  ClaudeDistiller,
+  DistillInput,
+  DistillOutput,
+  EventBusClient,
+  EventBusRecord,
+  FsReader,
+  GithubClient,
+  GithubPrRecord,
+  LangfuseClient,
+  LangfuseTraceRecord
+} from '../../src/types.js';
+
+/** In-memory FS — handy for normaliser tests that bypass the disk. */
+export interface FakeFsEntry {
+  path: string;
+  content: string;
+  mtimeMs: number;
+}
+
+export function createFakeFs(entries: FakeFsEntry[]): FsReader {
+  const byPath = new Map(entries.map((e) => [e.path, e] as const));
+  // Build a directory map: parent → children
+  const dirMap = new Map<string, Set<string>>();
+  for (const e of entries) {
+    const segments = e.path.split('/');
+    for (let i = 1; i < segments.length; i += 1) {
+      const parent = segments.slice(0, i).join('/');
+      const child = segments[i]!;
+      if (!dirMap.has(parent)) dirMap.set(parent, new Set());
+      dirMap.get(parent)!.add(child);
+    }
+  }
+  return {
+    exists(p) {
+      return byPath.has(p) || dirMap.has(p);
+    },
+    readDir(p) {
+      const set = dirMap.get(p);
+      if (set === undefined) return [];
+      return Array.from(set).sort();
+    },
+    readFile(p) {
+      const e = byPath.get(p);
+      if (e === undefined) throw new Error(`fake fs miss: ${p}`);
+      return e.content;
+    },
+    stat(p) {
+      const e = byPath.get(p);
+      if (e === undefined) {
+        if (dirMap.has(p)) {
+          return { mtimeMs: 0, size: 0, isFile: false };
+        }
+        throw new Error(`fake fs stat miss: ${p}`);
+      }
+      return { mtimeMs: e.mtimeMs, size: e.content.length, isFile: true };
+    }
+  };
+}
+
+/** Stub event-bus client. */
+export function createFakeEventBus(records: EventBusRecord[]): EventBusClient {
+  return {
+    async readSince(sinceMs) {
+      return records.filter((r) => r.emittedAtMs >= sinceMs);
+    }
+  };
+}
+
+export function createFakeGithub(records: GithubPrRecord[]): GithubClient {
+  return {
+    async listMergedPrs(sinceMs) {
+      return records.filter((r) => r.mergedAtMs >= sinceMs);
+    }
+  };
+}
+
+export function createFakeLangfuse(records: LangfuseTraceRecord[]): LangfuseClient {
+  return {
+    async listTraces(sinceMs) {
+      return records.filter((r) => r.createdAtMs >= sinceMs);
+    }
+  };
+}
+
+/** Configurable fake distiller. */
+export function createFakeDistiller(
+  fn: (input: DistillInput) => Promise<DistillOutput> | DistillOutput
+): ClaudeDistiller {
+  return {
+    async distill(input) {
+      return fn(input);
+    }
+  };
+}

--- a/packages/apprentice-corpus/tests/langfuse-reader.test.ts
+++ b/packages/apprentice-corpus/tests/langfuse-reader.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLangfuseReader, formatTraceText } from '../src/langfuse-reader.js';
+import { createFakeLangfuse } from './helpers/fakes.js';
+
+describe('formatTraceText', () => {
+  it('formats input + output', () => {
+    expect(formatTraceText('hi', 'hello')).toBe('Input:\nhi\n\nOutput:\nhello');
+  });
+  it('returns empty when both empty', () => {
+    expect(formatTraceText('', '')).toBe('');
+  });
+});
+
+describe('createLangfuseReader', () => {
+  it('returns [] when disabled (default Phase-0 stub posture)', async () => {
+    const reader = createLangfuseReader({
+      client: createFakeLangfuse([
+        { id: 't1', name: 'x', input: 'a', output: 'b', createdAtMs: Date.now() }
+      ]),
+      projectId: 'test',
+      enabled: false
+    });
+    expect(await reader.read({ maxAgeDays: 1, nowMs: Date.now() })).toEqual([]);
+  });
+
+  it('reads when enabled', async () => {
+    const now = Date.now();
+    const reader = createLangfuseReader({
+      client: createFakeLangfuse([
+        { id: 't1', name: 'agent.run', input: 'a', output: 'b', createdAtMs: now }
+      ]),
+      projectId: 'test',
+      enabled: true
+    });
+    const out = await reader.read({ maxAgeDays: 1, nowMs: now });
+    expect(out.length).toBe(1);
+    expect(out[0]?.sourceId).toBe('t1');
+    expect(out[0]?.kind).toBe('agent.run');
+  });
+});

--- a/packages/apprentice-corpus/tests/manifest.test.ts
+++ b/packages/apprentice-corpus/tests/manifest.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildManifest, hashConfig, writeCorpus } from '../src/manifest.js';
+import type { InstructionPair, RawArtifact } from '../src/types.js';
+
+const baseInputs = (outputDir: string) => ({
+  outputDir,
+  rawArtifacts: [
+    {
+      source: 'memory' as const,
+      sourceId: '/x.md',
+      kind: 'directive',
+      text: 'a'.repeat(200),
+      createdAtMs: 0
+    },
+    {
+      source: 'events' as const,
+      sourceId: 'e-1',
+      kind: 'TaskCompleted',
+      text: 'b'.repeat(200),
+      createdAtMs: 0
+    }
+  ] satisfies RawArtifact[],
+  finalPairs: [
+    {
+      id: 'h1',
+      messages: [
+        { role: 'system', content: 's' },
+        { role: 'user', content: 'u' },
+        { role: 'assistant', content: 'a'.repeat(200) }
+      ],
+      meta: {
+        source: 'memory',
+        sourceId: '/x.md',
+        kind: 'directive',
+        qualityScore: 0.65,
+        distilled: false,
+        redactedSpans: ['email'],
+        createdAt: '2026-05-06T00:00:00Z',
+        contentSha256: 'h1'
+      }
+    }
+  ] satisfies InstructionPair[],
+  dropped: [
+    { source: 'events' as const, sourceId: 'e-1', reason: 'too-short' as const }
+  ],
+  totals: {
+    rawArtifacts: 2,
+    afterDedup: 2,
+    afterPII: 2,
+    afterQuality: 1,
+    distilled: 0,
+    dropped: 1,
+    final: 1
+  },
+  warnings: ['langfuse disabled'],
+  configHash: hashConfig('{"memoryRoot":"/x"}'),
+  generatedAt: '2026-05-06T00:00:00Z',
+  elapsedMs: 1234
+});
+
+describe('buildManifest', () => {
+  it('counts artifacts + samples per source', () => {
+    const m = buildManifest(baseInputs('/tmp/x'));
+    expect(m.perSource.memory.artifacts).toBe(1);
+    expect(m.perSource.memory.samples).toBe(1);
+    expect(m.perSource.events.artifacts).toBe(1);
+    expect(m.perSource.events.samples).toBe(0);
+  });
+
+  it('builds quality histogram', () => {
+    const m = buildManifest(baseInputs('/tmp/x'));
+    expect(m.qualityHistogram['0.6-0.8']).toBe(1);
+    expect(m.qualityHistogram['0.0-0.2']).toBe(0);
+  });
+
+  it('builds redactedSpans histogram', () => {
+    const m = buildManifest(baseInputs('/tmp/x'));
+    expect(m.redactedSpansHistogram['email']).toBe(1);
+  });
+});
+
+describe('writeCorpus', () => {
+  it('writes all 5 files to outputDir', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'apprentice-corpus-test-'));
+    try {
+      const inputs = baseInputs(tmp);
+      writeCorpus(inputs, '{"memoryRoot":"/x"}');
+      const samples = readFileSync(join(tmp, 'samples.jsonl'), 'utf-8');
+      expect(samples.split('\n').filter((l) => l !== '').length).toBe(1);
+      const sources = JSON.parse(readFileSync(join(tmp, 'sources.json'), 'utf-8'));
+      expect(Array.isArray(sources)).toBe(true);
+      expect(sources.length).toBe(2);
+      const dropped = readFileSync(join(tmp, 'dropped.jsonl'), 'utf-8');
+      expect(dropped).toContain('too-short');
+      const config = readFileSync(join(tmp, 'config.json'), 'utf-8');
+      expect(config).toContain('memoryRoot');
+      const manifest = JSON.parse(readFileSync(join(tmp, 'manifest.json'), 'utf-8'));
+      expect(manifest.version).toBe(1);
+      expect(manifest.totals.final).toBe(1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('writes empty files when there is no corpus', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'apprentice-corpus-test-'));
+    try {
+      const inputs = {
+        ...baseInputs(tmp),
+        rawArtifacts: [],
+        finalPairs: [],
+        dropped: [],
+        totals: {
+          rawArtifacts: 0,
+          afterDedup: 0,
+          afterPII: 0,
+          afterQuality: 0,
+          distilled: 0,
+          dropped: 0,
+          final: 0
+        }
+      };
+      writeCorpus(inputs, '{}');
+      expect(readFileSync(join(tmp, 'samples.jsonl'), 'utf-8')).toBe('');
+      expect(readFileSync(join(tmp, 'dropped.jsonl'), 'utf-8')).toBe('');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/apprentice-corpus/tests/memory-walker.test.ts
+++ b/packages/apprentice-corpus/tests/memory-walker.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import {
+  classifyMemoryFile,
+  createMemoryWalker,
+  isEligibleMarkdown,
+  parseMarkdown
+} from '../src/memory-walker.js';
+import { defaultFsReader } from '../src/fs-reader.js';
+
+const FIXTURE_DIR = join(__dirname, '__fixtures__', 'mini-memory');
+
+describe('classifyMemoryFile', () => {
+  it.each([
+    ['feedback_no_caffeine.md', 'feedback'],
+    ['test_directive.md', 'directive'],
+    ['some_registry_directive.md', 'directive'],
+    ['agent_contract_registry.md', 'registry'],
+    ['caia_architecture.md', 'architecture'],
+    ['master_backlog.md', 'master'],
+    ['enterprise_landscape.md', 'landscape'],
+    ['gate_completion.md', 'gate'],
+    ['evidence_gate.md', 'gate'],
+    ['safety_hardening.md', 'safety'],
+    ['phase2-stuff.md', 'phase'],
+    ['caia_agent_team.md', 'team'],
+    ['orchestrator_handoff.md', 'team'],
+    ['backlog_research.md', 'backlog'],
+    ['random_note.md', 'other']
+  ])('classifies %s as %s', (basename, kind) => {
+    expect(classifyMemoryFile(basename)).toBe(kind);
+  });
+});
+
+describe('isEligibleMarkdown', () => {
+  it('accepts plain markdown filenames', () => {
+    expect(isEligibleMarkdown('feedback_x.md')).toBe(true);
+  });
+  it('rejects non-markdown', () => {
+    expect(isEligibleMarkdown('feedback_x.txt')).toBe(false);
+  });
+  it('rejects hidden files', () => {
+    expect(isEligibleMarkdown('.hidden.md')).toBe(false);
+  });
+  it('rejects backup files', () => {
+    expect(isEligibleMarkdown('MEMORY.md.bak-2026-05-04')).toBe(false);
+  });
+  it('rejects MEMORY.md', () => {
+    expect(isEligibleMarkdown('MEMORY.md')).toBe(false);
+  });
+});
+
+describe('parseMarkdown', () => {
+  it('strips simple frontmatter', () => {
+    const raw = '---\nname: x\ntype: feedback\n---\n# Body\nhello';
+    const r = parseMarkdown(raw);
+    expect(r.frontmatter).toEqual({ name: 'x', type: 'feedback' });
+    expect(r.body.startsWith('# Body')).toBe(true);
+  });
+  it('returns full input when no frontmatter', () => {
+    const raw = '# Just a heading\nbody';
+    const r = parseMarkdown(raw);
+    expect(r.frontmatter).toEqual({});
+    expect(r.body).toBe(raw);
+  });
+  it('tolerates malformed frontmatter (no closing ---)', () => {
+    const raw = '---\nname: x\nbody continues';
+    const r = parseMarkdown(raw);
+    expect(r.body).toBe(raw);
+  });
+});
+
+describe('createMemoryWalker — against real fixture dir', () => {
+  it('reads both fixture files and skips MEMORY.md', async () => {
+    const walker = createMemoryWalker({
+      memoryRoot: FIXTURE_DIR,
+      fs: defaultFsReader
+    });
+    const ctx = { maxAgeDays: 365 * 100, nowMs: Date.now() };
+    const artifacts = await walker.read(ctx);
+    expect(artifacts.length).toBe(2);
+    const kinds = artifacts.map((a) => a.kind).sort();
+    expect(kinds).toEqual(['directive', 'feedback']);
+    // MEMORY.md must NOT appear
+    expect(artifacts.find((a) => a.sourceId.endsWith('MEMORY.md'))).toBeUndefined();
+  });
+
+  it('returns deterministically sorted output', async () => {
+    const walker = createMemoryWalker({
+      memoryRoot: FIXTURE_DIR,
+      fs: defaultFsReader
+    });
+    const ctx = { maxAgeDays: 365 * 100, nowMs: Date.now() };
+    const a = await walker.read(ctx);
+    const b = await walker.read(ctx);
+    expect(a.map((x) => x.sourceId)).toEqual(b.map((x) => x.sourceId));
+  });
+
+  it('returns empty list for non-existent root', async () => {
+    const walker = createMemoryWalker({
+      memoryRoot: '/nonexistent-dir-12345-fixture',
+      fs: defaultFsReader
+    });
+    const ctx = { maxAgeDays: 365, nowMs: Date.now() };
+    const artifacts = await walker.read(ctx);
+    expect(artifacts).toEqual([]);
+  });
+});

--- a/packages/apprentice-corpus/tests/normaliser.test.ts
+++ b/packages/apprentice-corpus/tests/normaliser.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildResponse,
+  instructionFor,
+  normaliseAll,
+  normaliseOne,
+  sha256OfMessages
+} from '../src/normaliser.js';
+import type { RawArtifact } from '../src/types.js';
+
+const fixedClock = () => new Date('2026-05-06T01:23:42Z');
+
+describe('instructionFor', () => {
+  it('routes by source + kind', () => {
+    expect(
+      instructionFor({
+        source: 'memory',
+        sourceId: 'x',
+        kind: 'directive',
+        text: 't',
+        createdAtMs: 0
+      })
+    ).toMatch(/standing rule/i);
+    expect(
+      instructionFor({
+        source: 'events',
+        sourceId: 'x',
+        kind: 'PRMerged',
+        text: 't',
+        createdAtMs: 0
+      })
+    ).toMatch(/PR was merged/i);
+  });
+});
+
+describe('buildResponse', () => {
+  it('truncates at last paragraph break before cap', () => {
+    const text = 'a'.repeat(50) + '\n\n' + 'b'.repeat(50);
+    const r = buildResponse(
+      { source: 'memory', sourceId: 'x', text, createdAtMs: 0 },
+      80
+    );
+    expect(r.length).toBeLessThanOrEqual(80);
+    expect(r).toBe('a'.repeat(50));
+  });
+  it('hard-cuts when no good break found', () => {
+    const text = 'a'.repeat(200);
+    const r = buildResponse(
+      { source: 'memory', sourceId: 'x', text, createdAtMs: 0 },
+      50
+    );
+    expect(r.length).toBe(50);
+  });
+  it('returns full text when under cap', () => {
+    const r = buildResponse(
+      { source: 'memory', sourceId: 'x', text: 'short', createdAtMs: 0 },
+      100
+    );
+    expect(r).toBe('short');
+  });
+});
+
+describe('normaliseOne', () => {
+  it('produces system+user+assistant turn', () => {
+    const a: RawArtifact = {
+      source: 'memory',
+      sourceId: 'feedback_x.md',
+      kind: 'feedback',
+      text: 'a'.repeat(200),
+      createdAtMs: 0
+    };
+    const p = normaliseOne(a, {
+      minSampleLengthChars: 80,
+      maxSampleLengthChars: 1000,
+      clock: fixedClock
+    });
+    expect(p).not.toBeNull();
+    expect(p?.messages.length).toBe(3);
+    expect(p?.messages[0]?.role).toBe('system');
+    expect(p?.messages[1]?.role).toBe('user');
+    expect(p?.messages[2]?.role).toBe('assistant');
+    expect(p?.meta.source).toBe('memory');
+    expect(p?.meta.kind).toBe('feedback');
+    expect(p?.id).toBe(p?.meta.contentSha256);
+  });
+
+  it('drops too-short artifacts', () => {
+    const a: RawArtifact = {
+      source: 'memory',
+      sourceId: 'x.md',
+      kind: 'feedback',
+      text: 'tiny',
+      createdAtMs: 0
+    };
+    const p = normaliseOne(a, {
+      minSampleLengthChars: 80,
+      maxSampleLengthChars: 1000,
+      clock: fixedClock
+    });
+    expect(p).toBeNull();
+  });
+});
+
+describe('normaliseAll', () => {
+  it('partitions kept and dropped', () => {
+    const arts: RawArtifact[] = [
+      { source: 'memory', sourceId: 'a.md', kind: 'feedback', text: 'x'.repeat(200), createdAtMs: 0 },
+      { source: 'memory', sourceId: 'b.md', kind: 'feedback', text: 'short', createdAtMs: 0 }
+    ];
+    const r = normaliseAll(arts, {
+      minSampleLengthChars: 80,
+      maxSampleLengthChars: 1000,
+      clock: fixedClock
+    });
+    expect(r.kept.length).toBe(1);
+    expect(r.droppedSourceIds.length).toBe(1);
+    expect(r.droppedSourceIds[0]?.reason).toBe('too-short');
+  });
+});
+
+describe('sha256OfMessages', () => {
+  it('is deterministic', () => {
+    const m = [
+      { role: 'system' as const, content: 's' },
+      { role: 'user' as const, content: 'u' },
+      { role: 'assistant' as const, content: 'a' }
+    ];
+    expect(sha256OfMessages(m)).toBe(sha256OfMessages(m));
+    // Length 64 hex
+    expect(sha256OfMessages(m)).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/apprentice-corpus/tests/pii-mask.test.ts
+++ b/packages/apprentice-corpus/tests/pii-mask.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyPiiMask } from '../src/pii-mask.js';
+
+describe('applyPiiMask', () => {
+  it('redacts email shapes', () => {
+    const r = applyPiiMask('Contact alice@example.com about this.');
+    expect(r.masked).toBe('Contact [redacted-email] about this.');
+    expect(r.redactedSpans).toContain('email');
+  });
+
+  it('redacts Anthropic / OpenAI sk- key shape', () => {
+    const r = applyPiiMask('key=sk-abcdefghijklmnopqrstuvwxyz1234567890');
+    expect(r.masked).toContain('[redacted-secret');
+    expect(r.redactedSpans).toContain('secret');
+  });
+
+  it('redacts GitHub PAT', () => {
+    const r = applyPiiMask('token: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+    expect(r.masked).toContain('[redacted-secret');
+    expect(r.redactedSpans).toContain('secret');
+  });
+
+  it('redacts Mac /Users/name/ paths', () => {
+    const r = applyPiiMask('/Users/test-user/some/file.md');
+    expect(r.masked).toBe('~/some/file.md');
+    expect(r.redactedSpans).toContain('path');
+  });
+
+  it('redacts Linux /home/name/ paths', () => {
+    const r = applyPiiMask('/home/alice/work');
+    expect(r.masked).toBe('~/work');
+    expect(r.redactedSpans).toContain('path');
+  });
+
+  it('handles multiple types in one pass', () => {
+    const r = applyPiiMask(
+      'See alice@example.com or sk-abcdefghijklmnopqrstuvwxyz1234567890 in /Users/x/y.md'
+    );
+    expect(r.redactedSpans.sort()).toEqual(['email', 'path', 'secret']);
+  });
+
+  it('passes through clean text untouched', () => {
+    const r = applyPiiMask('No secrets here, just words.');
+    expect(r.masked).toBe('No secrets here, just words.');
+    expect(r.redactedSpans).toEqual([]);
+  });
+
+  it('redactedSpans is sorted alphabetically for stability', () => {
+    const r = applyPiiMask('alice@example.com and /Users/x/y');
+    const sorted = [...r.redactedSpans].sort();
+    expect(r.redactedSpans).toEqual(sorted);
+  });
+});

--- a/packages/apprentice-corpus/tests/quality.test.ts
+++ b/packages/apprentice-corpus/tests/quality.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { scoreOne } from '../src/quality.js';
+import type { InstructionPair } from '../src/types.js';
+
+const opts = { minSampleLengthChars: 80, maxSampleLengthChars: 1000 };
+
+function makePair(meta: Partial<InstructionPair['meta']>, response: string): InstructionPair {
+  return {
+    id: 'x',
+    messages: [
+      { role: 'system', content: 's' },
+      { role: 'user', content: 'u' },
+      { role: 'assistant', content: response }
+    ],
+    meta: {
+      source: 'memory',
+      sourceId: 'x',
+      qualityScore: 0,
+      distilled: false,
+      redactedSpans: [],
+      createdAt: '2026-05-06T00:00:00Z',
+      contentSha256: 'x',
+      ...meta
+    }
+  };
+}
+
+describe('scoreOne', () => {
+  it('rewards a structured directive of moderate length', () => {
+    const response =
+      '# Header\n\n- bullet one\n- bullet two\n- bullet three\n\nA paragraph that is reasonably long to clear the floor and contribute to length-band scoring without overshooting the sweet spot.\n\nAnother paragraph here for additional structure signal.';
+    const p = makePair({ source: 'memory', kind: 'directive' }, response);
+    const score = scoreOne(p, opts);
+    // Structured (0.2) + operator voice (0.2) + some length contribution > 0.45
+    expect(score).toBeGreaterThan(0.45);
+  });
+
+  it('penalises filler tokens', () => {
+    const filler = 'um you know like sort of kind of um you know like sort of '.repeat(10);
+    const p = makePair({ source: 'memory', kind: 'directive' }, filler);
+    const clean = makePair(
+      { source: 'memory', kind: 'directive' },
+      'A clear, structured directive with no filler at all in the response.'.repeat(5)
+    );
+    expect(scoreOne(p, opts)).toBeLessThan(scoreOne(clean, opts));
+  });
+
+  it('zero score for too-short response', () => {
+    const p = makePair({ source: 'memory', kind: 'directive' }, 'tiny');
+    expect(scoreOne(p, opts)).toBe(0);
+  });
+
+  it('rewards code-heavy responses', () => {
+    const codeResp = '```ts\n' + 'const x = 1;\n'.repeat(20) + '```';
+    const p = makePair({ source: 'memory', kind: 'directive' }, codeResp);
+    expect(scoreOne(p, opts)).toBeGreaterThan(0.4);
+  });
+
+  it('non-memory sources do not get the operator-voice bonus', () => {
+    const text =
+      '# Header\n\n- bullet a\n- bullet b\n\nA reasonably-long body paragraph that comfortably clears the minimum-length floor for quality scoring.\n\nAnother paragraph for additional structure.';
+    const memDir = makePair({ source: 'memory', kind: 'directive' }, text);
+    const evt = makePair({ source: 'events', kind: 'TaskCompleted' }, text);
+    expect(scoreOne(memDir, opts)).toBeGreaterThan(scoreOne(evt, opts));
+  });
+});

--- a/packages/apprentice-corpus/tests/reports-walker.test.ts
+++ b/packages/apprentice-corpus/tests/reports-walker.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { createReportsWalker } from '../src/reports-walker.js';
+import { defaultFsReader } from '../src/fs-reader.js';
+
+const FIXTURE_DIR = join(__dirname, '__fixtures__', 'mini-reports');
+
+describe('createReportsWalker', () => {
+  it('reads markdown files in fixture reports dir', async () => {
+    const walker = createReportsWalker({
+      reportsRoot: FIXTURE_DIR,
+      fs: defaultFsReader
+    });
+    const ctx = { maxAgeDays: 365 * 100, nowMs: Date.now() };
+    const artifacts = await walker.read(ctx);
+    expect(artifacts.length).toBe(1);
+    expect(artifacts[0]?.kind).toBe('report');
+    expect(artifacts[0]?.source).toBe('reports');
+    expect(artifacts[0]?.text).toContain('Test handoff');
+  });
+
+  it('returns [] for missing root', async () => {
+    const walker = createReportsWalker({
+      reportsRoot: '/this/does/not/exist/fixture',
+      fs: defaultFsReader
+    });
+    const ctx = { maxAgeDays: 365, nowMs: Date.now() };
+    expect(await walker.read(ctx)).toEqual([]);
+  });
+});

--- a/packages/apprentice-corpus/tsconfig.build.json
+++ b/packages/apprentice-corpus/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/apprentice-corpus/tsconfig.json
+++ b/packages/apprentice-corpus/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/apprentice-corpus/vitest.config.ts
+++ b/packages/apprentice-corpus/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,6 +568,22 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@24.1.3)
 
+  packages/apprentice-corpus:
+    dependencies:
+      '@chiefaia/mentor-event-bus':
+        specifier: workspace:*
+        version: link:../mentor-event-bus
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/architecture-registry:
     dependencies:
       '@chiefaia/feature-registry':


### PR DESCRIPTION
## Summary

Phase 0 of the Apprentice Agent campaign — a corpus aggregator that walks CAIA's accumulated artifacts (Mentor events, agent/memory directives + feedback, reports, GitHub PR history, Langfuse traces) and normalises them into a unified instruction-output JSONL corpus suitable for QLoRA fine-tuning of a 7B base on Mac M-series via MLX-LM.

Output is a date-stamped corpus directory `<outputRoot>/<YYYY-MM-DD>/` containing `samples.jsonl` (OpenAI chat-completions `messages[]` format trainable as-is by MLX-LM `--data-format messages`) plus `manifest.json` for downstream Phase 1 (eval) and Phase 2 (training) consumers.

## Shape — Option E (CAIA-Bonded Skeleton)

Per `agent_architecture_shape_2026-05-06.md`:

- ✅ `packages/apprentice-corpus/` (NOT under `apps/`)
- ✅ `package.json`: `"private": true`, `@chiefaia/apprentice-corpus`, never published
- ✅ Public API parameterised — every CAIA path/URL/topic is a constructor parameter with a CAIA default (memoryRoot, reportsRoot, eventsDbPath, langfuseProjectId, githubRepo, outputRoot, claudeBinaryPath, ...)
- ✅ Tests inject fixture corpora at `tests/__fixtures__/mini-{memory,reports}/` — never live CAIA paths
- ✅ Distillation respects subscription-only billing (`ANTHROPIC_API_KEY` explicitly cleared from spawn env per `feedback_no_api_key_billing.md`)
- ✅ AGENTS.md (filed in #346) is the cross-tool conventions surface; this package consumes it via the standard `pnpm` build/test/lint commands

## Pipeline

```
SourceReader[]  →  RawArtifact[]
              →  InstructionPair[]   (normaliser)
              →  dedupe              (sha256 of messages)
              →  PII mask            (gitleaks-style: secrets / emails / paths)
              →  quality score       (length / structure / operator-voice / filler / code)
              →  distill             (claude binary subprocess, bounded budget)
              →  cap @ maxSamples
              →  write samples.jsonl + manifest.json + sources.json + dropped.jsonl + config.json
```

## What's IN this leg

- 5 source readers: `memory-walker`, `reports-walker`, `event-bus-reader`, `github-reader`, `langfuse-reader` (stub — full impl deferred to leg 3 once Langfuse operational)
- Normaliser with 21 source/kind → instruction templates
- Dedupe by content sha256
- PII masker — Anthropic/OpenAI sk-, GitHub PAT, GitHub fine-grained PAT, GitLab PAT, AWS access key, generic secret-keyword + value, email shapes, `/Users/<name>/`+`/home/<name>/` paths
- Quality scorer — length-band + structure + operator-voice + filler-penalty + code-bonus
- Claude-binary distiller — cribs subprocess pattern from `@chiefaia/local-llm-router`'s claude-adapter; budget-bounded; subscription-only
- Manifest writer — version 1 schema with totals, perSource, redactedSpansHistogram, qualityHistogram, configSha256
- CLI: `caia-apprentice-corpus aggregate` with --dry-run + --memory-root / --reports-root / --output-root / --no-distill / --max-samples / --max-age-days / --quality-threshold flags
- LaunchAgent plist + install script for daily 02:00 cron
- README + DESIGN.md

## What's OUT (out of scope; deferred to siblings)

- Apprentice Phase 1 (eval harness) — separate `packages/apprentice-eval/`
- Apprentice Phase 2 (training) — separate `packages/apprentice-training/`
- Phase 3-4 — separate packages
- Langfuse full integration — stub only; deferred to leg 3
- Cowork session transcript ingestion — deferred to leg 3

## Test results

```
Test Files  14 passed (14)
     Tests  98 passed (98)
```

13 unit-test files (memory-walker, reports-walker, event-bus-reader, github-reader, langfuse-reader, normaliser, pii-mask, dedupe, quality, distiller, manifest, config, cli) + 1 integration test exercising the full aggregator pipeline against fixture corpora across all 5 readers.

## Live E2E result

Ran against real CAIA `agent/memory/` (148 files) + `~/Documents/projects/reports/` (103 files):

```
totals: rawArtifacts=251, final=251, dropped=0
perSource:  memory=148/148, reports=103/103, events=0, github=0, langfuse=0
redactedSpansHistogram: { path: 32, secret: 4, email: 2 }
qualityHistogram: { 0.0-0.2: 1, 0.2-0.4: 167, 0.4-0.6: 62, 0.6-0.8: 21, 0.8-1.0: 0 }
elapsedMs: 1054
```

Spot-checked 10 random samples: instruction templates fire correctly, frontmatter stripped, PII masked (operator email → `[redacted-email]`, sk- shapes → `[redacted-secret]`, `/Users/<name>/` → `~/`), quality scores spread reasonably.

## Test plan

- [x] `pnpm typecheck` — clean (66 packages, full monorepo)
- [x] `pnpm lint` — clean (37 packages)
- [x] `pnpm test` (package-local) — 98/98 passing
- [x] `pnpm build` — clean
- [x] Live E2E against real CAIA paths — 251 samples, PII redacted, no warnings

## See also

- `packages/apprentice-corpus/DESIGN.md` — full architecture rationale
- `packages/apprentice-corpus/README.md` — usage + CLI
- `agent/memory/apprentice_agent_directive.md` — Phase 0 spec
- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E standing rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)