### PR TITLE
docs(adr): file ADR-006..ADR-015 (quick-wins Batch A)

### DIFF
--- a/docs/adr/ADR-006-option-e-agent-shape.md
+++ b/docs/adr/ADR-006-option-e-agent-shape.md
@@ -1,0 +1,78 @@
+# ADR-006 — Option E agent architecture shape (CAIA-Bonded Skeleton)
+
+## Status
+
+**Accepted** — operator-authorised 2026-05-06. Standing rule.
+
+Supersedes prior ad-hoc per-agent shape decisions. Re-evaluation triggers at end of file.
+
+## Context
+
+CAIA ships agents at increasing cadence. Without a shared shape, every new agent re-litigated "should this be generic or hard-coded for CAIA?" Five candidate shapes were on the table:
+
+- **Option A** — pure-generic, OSS-publishable. Maximises reusability; forfeits CAIA-specific velocity. Rejected: open-source is not a priority.
+- **Option B** — pure-CAIA, hard-coded. Maximises velocity short-term; forfeits testability and refactor velocity over time.
+- **Option C** — hybrid, parameterised, framed for eventual open-source. Closest to industry SOTA but with a premium for an OSS path that is not on the roadmap.
+- **Option D** — per-agent decision. Cop-out — reproduces the original problem.
+- **Option E** — parameterised + private + project-bonded at runtime. Industry SOTA pattern (Cursor, Aider, Augment Code, Sourcegraph Cody, Devin all converge here).
+
+Background research: 67-source meta-analysis at `~/Documents/projects/reports/agent-architecture-strategic-decision-2026-05-06.md`. Validated against the broader CAIA approach in `~/Documents/projects/reports/caia-approach-validation-meta-research-2026-05-05.md`.
+
+## Decision
+
+Every CAIA agent built from this point forward ships as a **private `@chiefaia/*` workspace package** in the caia monorepo, parameterised at the constructor with CAIA-default values, project-bonded at runtime via Mentor + Librarian pre-spawn injection + AGENTS.md + system-prompt block + (eventually) Apprentice adapter.
+
+Mechanical gates on every new agent:
+
+1. **Lives at `packages/<agent-name>/`** — not a separate repo, not under `apps/`.
+2. **`package.json` has `"private": true`** and scope `@chiefaia/<agent-name>`.
+3. **Public API is parameterised** — every CAIA-specific path / topic / registry / integration is a constructor parameter with a CAIA default.
+4. **Tests inject fixture corpora**, not live CAIA paths. If a test requires live paths, parameterisation is broken.
+5. **Pre-spawn injection via Mentor + Librarian** is consumed (not bypassed).
+6. **AGENTS.md at repo root** is consulted for project conventions.
+7. **NEVER published** to public npm — configuration matrix is exactly one (CAIA).
+
+Project-bonding mechanism:
+
+- Mentor pre-spawn lesson injection (shipped, Phase 4)
+- Librarian nearest-neighbour precedent retrieval (shipped, Phase 1)
+- `AGENTS.md` auto-read at task start (shipped via PR #346)
+- `@chiefaia/system-prompt-block` ≤1K-token CAIA primer (shipped via PR #347)
+- Apprentice-trained LoRA adapter (Phase 3-4 future work)
+
+The agent's **code** is generic-shape (parameterised, testable, refactorable). The agent's **reasoning context** is narrowed to CAIA on every spawn.
+
+## Consequences
+
+**Positive:**
+- One canonical shape for every new agent → no per-agent re-litigation, faster spawn velocity.
+- Tests stay isolated from CAIA-specific paths → refactor velocity preserved.
+- Productisation pivot (if it happens) is mechanical — swap defaults at construction time, no rewrite.
+- Compatible with current 4 in-flight agents (Mentor, Curator, Librarian, Apprentice all already in this shape or trivially convertible).
+- Steward semgrep rule (PR #347) enforces gates 1-3 mechanically.
+
+**Negative:**
+- Slightly more design overhead per agent (parameterisation up front) than pure-CAIA-hard-coded would be.
+- Productisation re-evaluation eventually required if multi-tenant signs paying customer (re-evaluation trigger #1).
+
+**Neutral:**
+- No backward-compat migration cost — all current agents already match.
+- Consumed-OSS posture unchanged — Aider, Promptfoo, Mem0, Claude Code subagents all stay external dependencies.
+
+## Re-evaluation triggers
+
+Any one fires → re-open this decision:
+
+1. **Productisation trigger** — operator decides to multi-tenant CAIA AND signs ≥1 paying tenant or LOI within 90-day onboarding runway.
+2. **Second-internal-consumer trigger** — a NEW project (not Stolution, not existing websites) appears AND wants to consume an existing CAIA agent.
+3. **OSS-pivot trigger** — operator strategic pivot signals open-source as a priority.
+4. **Bonding-mechanism failure trigger** — Mentor/Librarian/Apprentice fail to deliver project-bonding gains ≥10% on Promptfoo canonical eval.
+5. **Cost-explosion trigger** — subscription-bucket consumption per agent invocation grows to ≥2× baseline (parameterisation overhead too heavy).
+
+## References
+
+- Standing rule: `agent/memory/agent_architecture_shape_2026-05-06.md`
+- Decision report: `~/Documents/projects/reports/agent-architecture-strategic-decision-2026-05-06.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §11.5
+- Related ADRs: ADR-001 (Living Library), ADR-002 (App Code Purity), ADR-004 (Agent-First)
+- Implementing PRs: #346 (AGENTS.md), #347 (system-prompt-block + semgrep)

--- a/docs/adr/ADR-007-subscription-only-llm.md
+++ b/docs/adr/ADR-007-subscription-only-llm.md
@@ -1,0 +1,64 @@
+# ADR-007 — Subscription-only LLM billing (no API keys)
+
+## Status
+
+**Accepted** — operator-authorised standing rule. HARD constraint.
+
+## Context
+
+Anthropic LLM access is consumed in two billing modes: pay-as-you-go API keys (per-token billing, no cap) vs. subscription (Pro / Max plans, weekly cap, no per-token cost). API-key billing is unbounded; a runaway agent could rack up arbitrary spend. Subscription is bounded — when the cap is hit, claude binary returns budget-exceeded; the orchestrator pauses and waits for cap reset.
+
+CAIA runs ≥10 agents continuously plus interactive Cowork sessions. Without spend bounds, a single misconfigured loop or runaway recursion could exhaust thousands of dollars in hours. With API keys this is undetectable until the bill arrives. With subscription it is automatically halted by the provider.
+
+Cloud GPU rental for training (a different category) is permitted at minimal level (`feedback_minimal_cloud_gpu_allowed.md`). This ADR covers per-token LLM API billing only.
+
+## Decision
+
+LLM access is via subscription only. No API keys. Specifically:
+
+- **Allowed**: `claude` binary subprocess spawn (uses subscription auth from `~/.claude/`)
+- **Allowed**: Ollama HTTP at `localhost:11434` (free, local)
+- **Allowed**: cloud GPU rental for training, $50/run + $200/month cap (per `feedback_minimal_cloud_gpu_allowed.md`)
+- **NOT allowed**: Anthropic API key billing (`ANTHROPIC_API_KEY` env var)
+- **NOT allowed**: OpenAI / Replicate / any per-token paid API for production agents
+- **NOT allowed**: Anthropic SDK with API-key auth in any agent code path
+
+When subscription cap exhausts: pause orchestrator, wait for reset (weekly), resume. NEVER fall back to API-key spend.
+
+Account-pool design: 2 Max subscriptions today; eventually 1 Pro 20x. Tenants in productisation phase BYOK (their own subscriptions).
+
+## Consequences
+
+**Positive:**
+- Spend is bounded by subscription cap (predictable monthly cost).
+- Runaway agents cannot exceed cap (Anthropic enforces).
+- Spend Guard package (`@chiefaia/spend-guard`) tracks usage in real time and pauses proactively before hard cap.
+- Ollama bears 60-70% of bulk inference at $0 marginal cost.
+
+**Negative:**
+- Subscription cap can pause the system for hours-to-days (acceptable trade-off).
+- No "burst capacity" — cannot pay-as-you-go during high-pressure sprint.
+- claude binary subprocess overhead (vs. SDK) is minor but non-zero.
+
+**Neutral:**
+- Productisation will re-introduce API-key paths for tenant BYOK — but tenants pay their own bill.
+
+## Enforcement
+
+- `@chiefaia/spend-guard` 4-tier caps: task $1.50/day, project $30/week, global-day $25, global-week $100.
+- 80%-of-cap threshold biases router toward Ollama (reduces Claude usage proactively).
+- Steward semgrep rule blocks `ANTHROPIC_API_KEY` references in production code paths.
+- Code review: any PR adding API-key auth must explicitly justify and tag `@chiefaia/billing-exception`.
+
+## Re-evaluation triggers
+
+1. **Productisation** — tenant BYOK requires API-key support. Re-evaluate at first paying tenant.
+2. **Subscription cap inadequate** — if the cap halts critical work for >7d cumulatively over a 4-week window, re-evaluate adding a third subscription.
+
+## References
+
+- Standing rule: `agent/memory/feedback_no_api_key_billing.md`
+- Cloud GPU carve-out: `agent/memory/feedback_minimal_cloud_gpu_allowed.md`
+- Implementing package: `@chiefaia/spend-guard`
+- MCP allowlist + sanitizer: `agent/memory/safety_hardening_2026-04-29.md`
+- Companion: ADR-008 (Mac-first inference), ADR-010 (4-layer safety stack)

--- a/docs/adr/ADR-008-mac-first-inference.md
+++ b/docs/adr/ADR-008-mac-first-inference.md
@@ -1,0 +1,67 @@
+# ADR-008 — Mac-first inference (Ollama bulk + claude binary synthesis)
+
+## Status
+
+**Accepted**.
+
+## Context
+
+CAIA has many tasks per day across many agent classes. Most are not synthesis-grade — they are classification, embeddings, simple extraction, lookups. Sending every task to Claude is wasteful in two dimensions: subscription bucket consumption (per ADR-007) and latency (network round-trip vs. local-first).
+
+Operator runs a Mac M1 Pro 16GB. This is comfortably above the threshold for running Qwen2.5-Coder-7B and embedding models at usable latencies. The 14B and 32B models exceed RAM with concurrent worktrees but are reachable via cloud GPU spot for occasional heavy work (per `feedback_minimal_cloud_gpu_allowed.md`).
+
+Industry SOTA on routing (Cursor, Augment Code, Cognition) consistently uses cheap-local-first → escalate-to-frontier pattern. Local LLM-router shipped at `@chiefaia/local-llm-router` already supports the routing decision tree.
+
+## Decision
+
+LLM inference is routed in this order:
+
+1. **Ollama-local first** (free, on-Mac):
+   - `qwen2.5-coder:7b` for code-adjacent classification + structured generation
+   - `nomic-embed-text` for embeddings (FREG, AKG, Mentor, Librarian)
+   - Target: 60-70% of agent calls served locally
+
+2. **claude binary spawn** for synthesis tasks:
+   - `--model haiku` for lightweight synthesis
+   - `--model sonnet` for moderate complexity
+   - `--model opus` for top-tier reasoning
+
+3. **Account-pool routing** within claude binary:
+   - account-1 if <80% weekly cap; else account-2
+   - if both >80%: bias router to Ollama
+   - if both 100%: BudgetExceededError → orchestrator pause (per ADR-007, never API-key fallback)
+
+4. **Cloud GPU** for training only (Apprentice phase) at $50/run cap.
+
+Routing decision tree lives in `agent/memory/caia_architecture.md` §intelligence-architecture and `caia/docs/intelligence-architecture.md`.
+
+## Consequences
+
+**Positive:**
+- 60-70% reduction in Claude subscription consumption (Ollama bears bulk).
+- Lower latency for short tasks (no network).
+- Resilient to Anthropic outages (Ollama keeps embedding + classification flowing).
+- Free baseline — adding compute is free (Mac is sunk cost).
+
+**Negative:**
+- 16GB RAM caps concurrent Ollama models — adapter swap requires careful scheduling.
+- Local model quality lags frontier; requires Apprentice LoRA fine-tuning to close the gap on CAIA-specific tasks.
+- Routing bug → wrong model picked → quality regression. Mitigated by Promptfoo CI gate and Curator routing-optimality dimension.
+
+**Neutral:**
+- Future productisation may push some inference to cloud-GPU per-tenant; routing tree extends, decision pattern unchanged.
+
+## Routing optimality measurement
+
+Tracked via Curator Dimension 2 (Subscription-bucket Economics):
+- Ollama-vs-Claude split per agent class
+- Per-agent token attribution
+- Routing optimality — for each task class, is it on the cheapest tier that meets the quality bar?
+
+## References
+
+- Standing rule: `agent/memory/feedback_no_api_key_billing.md`
+- Implementing packages: `@chiefaia/local-llm-router`, `@chiefaia/spend-guard`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §7.4
+- Apprentice LoRA fine-tuning: `agent/memory/apprentice_agent_directive.md`
+- Companion ADRs: ADR-007 (subscription-only), ADR-009 (custom Hono runtime)

--- a/docs/adr/ADR-009-custom-hono-runtime.md
+++ b/docs/adr/ADR-009-custom-hono-runtime.md
@@ -1,0 +1,73 @@
+# ADR-009 — Custom Hono runtime over LangChain/CrewAI/MS Agent Framework
+
+## Status
+
+**Accepted**. Re-evaluation trigger documented at end of file.
+
+## Context
+
+The agent-framework landscape (2025-2026) presents three families of runtime choices:
+
+1. **Heavy frameworks** — LangChain, LangGraph, CrewAI, AutoGen, Microsoft Agent Framework. Pre-built abstractions for tools, memory, planners, multi-agent. High learning curve, high lock-in, opinionated.
+2. **Code-as-graph** — LangGraph, Cognition Devin's internal patterns. Workflows expressed as state machines.
+3. **Microservice + custom orchestration** — agents as Hono services, communication via HTTP + events. CAIA's existing pattern.
+
+The 67-source meta-research (`~/Documents/projects/reports/agent-architecture-strategic-decision-2026-05-06.md`) found that frontier teams (Anthropic, Cognition, Sourcegraph, Augment Code) all favour custom orchestration over heavy frameworks for these reasons:
+
+- Heavy frameworks abstract away the agent decisions that matter (prompt management, tool selection, memory shape) — exactly what teams need to control.
+- Lock-in costs compound: every CAIA-specific extension fights the framework's grain.
+- Hono microservice pattern is the simplest possible runtime — no abstractions to fight, no version-churn risk.
+- Single-threaded write per worktree (ADR-013) doesn't compose well with heavyweight in-process state machines.
+
+The Enterprise AI Landscape directive (`enterprise_ai_landscape_directive.md`) explicitly steel-mans this stack and finds it "aged well" against industry trends.
+
+## Decision
+
+CAIA's runtime is custom-built on Hono microservices. Specifically:
+
+- **Each agent** is a `@chiefaia/<agent>` package. Some run as Hono apps under `apps/<agent>/`; others spawn as ephemeral processes via `claude` binary subprocess.
+- **Communication** is HTTP REST (sync) or Mentor's `ConductorEventBus` (async events).
+- **Workflow** lives in TypeScript code, not in framework DSLs (no LangGraph state machines, no CrewAI roles).
+- **Tools** are MCP servers — standard protocol, framework-agnostic.
+- **Memory + knowledge** flow through Mentor + Librarian + sqlite-vec + AKG.
+- **Eval** via Promptfoo (Wave 1).
+- **Pre-spawn injection** is shaped explicitly as Mentor + Librarian prepend layers, NOT framework middleware.
+
+Heavy frameworks are explicitly **rejected** for CAIA's first-party runtime:
+
+- ❌ LangChain — too heavy, abstracts the wrong layer
+- ❌ LangGraph — code-as-graph pattern doesn't match single-threaded-write-per-worktree shape
+- ❌ CrewAI — role-based orchestration vs. CAIA's pipeline-stage orchestration
+- ❌ Microsoft Agent Framework — corporate roadmap risk
+- ❌ AutoGen — research-stage stability
+
+Tactical OSS adoption stays open: Aider as Coding-Agent backend (validated 2026-05-06), Promptfoo for eval, Mem0 as Librarian backend, Claude Code subagents for sub-task delegation.
+
+## Consequences
+
+**Positive:**
+- Zero framework lock-in — the whole runtime can be re-platformed without coupling to a single vendor's roadmap.
+- Hono is minimal — each agent is a small file with explicit routes.
+- Composes cleanly with single-threaded-write-per-worktree, Evidence Gate, Steward Gatekeeper.
+- Hires (if eventual) onboard via CAIA's own conventions, not framework-specific lore.
+
+**Negative:**
+- More code to write per agent (no pre-built abstractions). Mitigated by `@chiefaia/runtime-helpers` shared utilities and Option E parameterised shape (ADR-006).
+- No "drop in this framework, get a multi-agent demo" path — every capability is built explicitly.
+- Some heavy-framework patterns (e.g., LangGraph's graphical workflow viewer) are absent. Choreographer Phase 5 will provide a comparable EventCatalog dashboard.
+
+**Neutral:**
+- Tactical OSS adoption decisions are independent — Aider, Promptfoo, Mem0 are tools, not frameworks.
+
+## Re-evaluation triggers
+
+1. **Industry consolidation** — if the broader ecosystem consolidates onto one framework (e.g., Microsoft Agent Framework reaches market dominance), re-evaluate consuming it for new agent classes only.
+2. **Productisation** — multi-tenant onboarding may require off-the-shelf runtime abstractions for tenant-defined agents. Re-evaluate at first paying tenant.
+3. **Custom runtime maintenance burden exceeds bench** — if maintaining the custom runtime exceeds 25% of total agent-build effort over a sustained 8-week window, re-evaluate.
+
+## References
+
+- Decision report: `~/Documents/projects/reports/agent-architecture-strategic-decision-2026-05-06.md`
+- Landscape directive: `agent/memory/enterprise_ai_landscape_directive.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §3.4 + §10.2.6
+- Companion ADRs: ADR-006 (Option E shape), ADR-013 (single-threaded write per worktree)

--- a/docs/adr/ADR-010-four-layer-safety-stack.md
+++ b/docs/adr/ADR-010-four-layer-safety-stack.md
@@ -1,0 +1,95 @@
+# ADR-010 — 4-layer safety stack
+
+## Status
+
+**Accepted** — shipped 2026-04-30 (PRs #201, #205, #206). Operator-authorised standing rule.
+
+## Context
+
+Autonomous agents executing tools on behalf of an LLM present compounding safety surfaces:
+
+1. **Tool-side** — MCP supply chain has known systemic vulnerabilities (April 2026 OX disclosure of command-injection RCE in Anthropic's official MCP SDK; Anthropic declined to patch).
+2. **LLM-side** — every tool return value can carry adversarial prompt-injection payloads.
+3. **Capability-side** — irreversible actions (file delete, deploy, push to main) need explicit authorisation.
+4. **Spend-side** — runaway agents could drain subscription bucket without bound.
+
+Off-the-shelf approaches (Anthropic's `--permission-mode bypassPermissions`, naive sandbox) are inadequate at the level CAIA operates at. Per `safety_hardening_2026-04-29.md` and `mcp_security_threat_landscape_2026-04-29.md`, the operator authorised filing a four-layer defensive stack.
+
+## Decision
+
+CAIA's safety stack is four cooperating packages:
+
+### Layer 1 — Capability Broker (`@chiefaia/capability-broker`)
+
+- HMAC-signed capability tokens, 5-minute TTL
+- 5-second irreversible-action delay (cancel window)
+- Ledger persisted to `irreversible_actions` table (audit trail)
+- Hook-controlled-mode adapter — replaces `--permission-mode bypassPermissions` with explicit per-action authorisation
+- Every irreversible action (write to disk, deploy, push) flows through broker
+
+### Layer 2 — MCP Allowlist Proxy (`@chiefaia/mcp-allowlist-proxy`)
+
+- Per-MCP policy file (`policies/<name>.json`):
+  - Pinned upstream commit SHA
+  - Per-tool argument constraints (regex / enum / maxLength / forbid patterns)
+  - Per-task `maxPerTask` budgets
+- Spawn-command allowlist: `{npx, uvx, python, python3, node, docker, deno}` only
+- Rejects 0.0.0.0 / [::] binds (no externally exposed services from MCP)
+- macOS `sandbox-exec` profile applied to MCP server processes
+- Vendored + commit-pinned MCPs only (supply-chain hardening)
+
+### Layer 3 — Tool Output Sanitizer (`@chiefaia/tool-output-sanitizer`)
+
+- Strips role-impersonation markers, zero-width Unicode, ANSI escapes
+- Flags ignore-previous-instructions variants, jailbreak templates, tool-redefinition payloads
+- OWASP LLM Top-10 corpus (12 seed samples; expanded continuously by Mentor)
+- Wraps every MCP tool return + every fetched-content payload before LLM ingestion
+
+### Layer 4 — Spend Guard (`@chiefaia/spend-guard`)
+
+- 4-tier caps:
+  - Per-task: $1.50/day
+  - Per-project: $30/week
+  - Global day: $25/day
+  - Global week: $100/week
+- Auto-pause on cap breach
+- Account-pool with 2 Max subscriptions, serial fallback
+- 80%-of-cap threshold biases router to Ollama (preventive)
+- ToS-aware warning at startup (multi-Max usage tracked)
+
+Plus complementary safety surfaces (not part of the 4-layer stack but cooperating):
+- HashiCorp Vault for secrets (ADR-014)
+- Evidence Gate at PR merge (ADR-011)
+- Steward Gatekeeper (ADR-012)
+- Subscription-only billing (ADR-007)
+
+## Consequences
+
+**Positive:**
+- 10 CVEs addressed in initial ship (per `safety_hardening_2026-04-29.md`).
+- Composable: each layer is independently testable; one failure does not cascade.
+- Mitigates the April 2026 MCP supply-chain RCE class without waiting on Anthropic patch.
+- Capability ledger gives operator and Steward an auditable history.
+- Spend cap is enforceable in real time, before catastrophic drain.
+
+**Negative:**
+- Latency cost — each tool call passes through allowlist + sanitizer.
+- Maintenance burden — policy files require updating on MCP version bumps.
+- Adversarial-injection corpus has only 12 seed samples; continuous expansion required (Mentor surfaces real-world payloads).
+
+**Neutral:**
+- Stack composes with future productisation security additions (per-tenant capability isolation, SBOM, SLSA Level declaration) — Security Architect Agent owns the next layer.
+
+## Re-evaluation triggers
+
+1. **New attack class** — disclosed CVE that bypasses any one layer requires re-evaluation of that layer's implementation.
+2. **Productisation** — tenant isolation requires per-tenant capability scopes; extends Capability Broker.
+3. **Performance regression** — if sanitizer or allowlist proxy introduces >100ms p95 overhead per tool call, re-tune.
+
+## References
+
+- Standing rule: `agent/memory/safety_hardening_2026-04-29.md`
+- MCP threat landscape: `agent/memory/mcp_security_threat_landscape_2026-04-29.md`
+- Implementing PRs: #201 (capability-broker), #205 (mcp-allowlist-proxy + sanitizer), #206 (spend-guard)
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §4.4
+- Companion ADRs: ADR-007 (subscription-only), ADR-011 (Evidence Gate), ADR-012 (Steward Gatekeeper), ADR-014 (Vault)

--- a/docs/adr/ADR-011-evidence-gate.md
+++ b/docs/adr/ADR-011-evidence-gate.md
@@ -1,0 +1,84 @@
+# ADR-011 — Evidence Gate at PR merge
+
+## Status
+
+**Accepted** — operator-authorised standing rule (2026-04-29). Operational in production GitHub Actions.
+
+## Context
+
+Autonomous Claude PRs land at high cadence. Without a deterministic pre-merge gate, regressions, secrets, and architectural violations leak through. Manual review by the operator is impossible at this throughput (and operator does not code per `feedback_operator_does_not_code.md`).
+
+The Evidence Gate is the deterministic, machine-checkable substitute for human PR review. Every Claude-authored PR must pass the same set of checks before merge into `develop`.
+
+## Decision
+
+Six contexts are **required** (blocking) at PR merge. Three are **warn-only**.
+
+### Required (blocking) contexts
+
+| # | Context | What it checks |
+|---|---|---|
+| 1 | `Build·Test·Lint·Typecheck` | Compiles, lints, typechecks, all unit tests pass |
+| 2 | `gitflow-conformance` | Branch source target conforms to Git Flow rules (per ADR-015): feature/* → develop only; release/* → develop and main; main accepts only release/* and hotfix/* |
+| 3 | `typecheck` | Workspace-wide TypeScript typecheck (`tsc --noEmit`) |
+| 4 | `semgrep` | Custom CAIA rules in `.semgrep/caia-rules.yml` (Option E gates, capability-broker-bypass detection, etc.) |
+| 5 | `gitleaks` | Secret-leak scanner (no plaintext credentials in any committed file) |
+| 6 | `bundle-size` | size-limit: ≤500KB total bundle, ≤200KB first-load (dashboard + sites) |
+
+### Warn-only contexts
+
+| # | Context | What it surfaces |
+|---|---|---|
+| 7 | `lighthouse` | Performance regression vs baseline (warn, do not block) |
+| 8 | `axe` | Accessibility regression vs baseline (warn) |
+| 9 | `visual` | Visual diff vs baseline screenshots (warn) |
+
+Warn-only contexts surface but do not block — the operator and Curator review trends, but a single warning does not stall a PR.
+
+### Adversarial-injection corpus
+
+Adversarial-injection regression suite is mandatory per Definition of Done item 15. Corpus seeded with 12 OWASP LLM Top-10 samples; continuously expanded by Mentor on every classified incident.
+
+### Doc-only PR carve-out
+
+Doc-only PRs (zero code changes; only `*.md`, no `package.json` change, no source files modified) may relax some required contexts: `bundle-size`, `axe`, `lighthouse`, `visual` are skipped automatically. `Build·Test·Lint·Typecheck`, `gitflow-conformance`, `semgrep`, `gitleaks` still block.
+
+## Consequences
+
+**Positive:**
+- PR merges are deterministic — green = mergeable, no human review required.
+- Regressions caught at gate, not in production.
+- Operator's "validate visual outputs only" stance preserved (no PR review).
+- Doc-only carve-out keeps quick-wins documentation cluster moving.
+
+**Negative:**
+- Gate run time is ~3-5 minutes per PR (not free).
+- Flaky checks (e.g., visual snapshot drift) require periodic recalibration.
+- Strict semgrep rules occasionally false-positive; suppression requires documented inline rationale.
+
+**Neutral:**
+- Gate composes with Steward Gatekeeper (ADR-012) at additional surfaces (daily, weekly, pre-spawn).
+
+## Enforcement
+
+- GitHub branch protection: `develop` and `main` require all six required contexts green before merge.
+- Evidence Gate workflow: `.github/workflows/evidence-gate.yml`.
+- Custom semgrep rules: `.semgrep/caia-rules.yml`.
+- Operator runbook: [`evidence-gate.md`](../evidence-gate.md).
+
+## Re-evaluation triggers
+
+1. **Gate flake rate >5%** sustained over 4 weeks → tighten flaky checks or move to warn-only.
+2. **New vulnerability class** (e.g., supply-chain-side) requires a new required context.
+3. **Productisation** — tenant-isolation rules add a new required context.
+4. **Performance regression** — gate p95 >10 minutes triggers parallelisation work.
+
+## References
+
+- Standing rule: `agent/memory/evidence_gate_2026-04-29.md`
+- Operator runbook: `caia/docs/evidence-gate.md`
+- Implementing workflow: `.github/workflows/evidence-gate.yml`
+- Custom semgrep rules: `.semgrep/caia-rules.yml`
+- Definition of Done: `agent/memory/feedback_definition_of_done.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §4.4 + §8.3
+- Companion ADRs: ADR-005 (Test-Fix-Commit), ADR-010 (4-layer safety stack), ADR-012 (Steward Gatekeeper), ADR-015 (Git Flow)

--- a/docs/adr/ADR-012-steward-gatekeeper.md
+++ b/docs/adr/ADR-012-steward-gatekeeper.md
@@ -1,0 +1,87 @@
+# ADR-012 — Steward Gatekeeper (15 enumerated failure modes)
+
+## Status
+
+**Accepted** — operator-authorised 2026-05-04.
+
+## Context
+
+The Evidence Gate (ADR-011) catches per-PR regressions but cannot catch systemic, slow-burn failure modes that emerge across PRs and across time:
+
+- A failed Drizzle migration that breaks future migrations (numbering collision).
+- An orphan worktree squatting on memory while its branch is gone.
+- A backup pipeline silently failing for weeks.
+- Memory drift — `MEMORY.md` index out of sync with on-disk files.
+- Stash bloat, dependabot DIRTY, token expiry, MCP saturation.
+
+These are class-failures that compound. Catching them at PR-merge is too late (they are inter-PR phenomena). Catching them by hand is impossible at CAIA's cadence.
+
+The Steward Gatekeeper is the source of truth on code, release, deployment, builds, and platform health.
+
+## Decision
+
+Steward Gatekeeper enumerates **15 failure modes** and surfaces three operational surfaces:
+
+### 15 enumerated failure modes
+
+1. **Migration breakpoints** — Drizzle migrations that won't apply or skip
+2. **Graph divergence** — AKG entities desynced from source
+3. **Numbering collisions** — duplicate migration numbers, duplicate ADR numbers
+4. **Stash hygiene** — stale stash entries hoarding diff context
+5. **Orphan branches** — branches alive without an open PR
+6. **Worktree hygiene** — worktrees alive without a corresponding branch (or vice versa)
+7. **Backup pipeline health** — Vault snapshots, DB hourly backups, memory weekly backups all current
+8. **Audit log bounded growth** — `audit_log` table not growing unbounded
+9. **Token expiry** — GitHub PAT, Anthropic OAuth, Vault AppRole tokens not within expiry window
+10. **PR staleness** — PRs alive >7 days without merge or close
+11. **Dependabot triage** — dependabot PRs not stuck in DIRTY merge state
+12. **Memory drift** — `MEMORY.md` index entries match on-disk files; no orphaned topics
+13. **Spend prediction** — spend trajectory exceeds 80% cap before week reset
+14. **CI flake** — flake rate sustained >5% triggers investigation
+15. **MCP saturation** — MCP timeout rate per hour vs 200/800 alarm thresholds
+
+### Three operational surfaces
+
+| Surface | Trigger | Behaviour |
+|---|---|---|
+| `steward-gatekeeper` CI check | Pre-merge (per PR) | Static analyzers — fast-fail subset of 15 (numbering collisions, stash hygiene, dependabot triage). Blocking. |
+| `steward run` (daily/weekly) | Cron / LaunchAgent | Full 15-mode sweep. Posts daily digest to operator. Files PRs for auto-resolvable issues (Curator-style propose-only). |
+| `steward preflight` | Pre-spawn hook | Before orchestrator spawns a substantial agent task: check spend prediction, MCP saturation, worktree count vs cap. Reject if unsafe. |
+
+Each failure mode has:
+- A **detector** (static analyzer or CLI script)
+- A **classifier** (severity: BLOCKING, WARN, INFO)
+- A **proposer** (Curator-style propose-only — PR through Evidence Gate, never auto-merge)
+
+Architecture report: `~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md`. Implementing engine: `@chiefaia/steward-core` (PR #285).
+
+## Consequences
+
+**Positive:**
+- Inter-PR slow-burn failure modes caught before they cascade.
+- Operator gets one digest, not 15 alarm streams.
+- Pre-spawn preflight prevents wasteful spawns when system is unsafe.
+- Composes with Mentor (incident-driven), Curator (opportunity-driven), Evidence Gate (per-PR), Lantern (observability) for a complete defensive stack.
+
+**Negative:**
+- Maintenance — adding a new failure mode requires writing a detector + classifier.
+- False-positive risk — overly strict detectors create alert fatigue.
+- Daily digest can become noise if not curated.
+
+**Neutral:**
+- Productisation will add tenant-isolation failure modes — extends the enumeration.
+
+## Re-evaluation triggers
+
+1. **New systemic failure mode** observed → add to enumeration; ≥3 new modes accumulated triggers review of taxonomy.
+2. **False-positive rate >10%** sustained → re-tune detectors.
+3. **Mentor surfaces a class of failure** that should be Steward-side rather than Mentor-side (post-hoc lesson) → migrate.
+
+## References
+
+- Standing rule: `agent/memory/steward_gatekeeper_directive.md`
+- Architecture report: `~/Documents/projects/reports/steward-gatekeeper-architecture-2026-05-04.md`
+- Implementing engine: `@chiefaia/steward-core` (PR #285)
+- Operator runbook: `caia/docs/steward.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §4.5
+- Companion ADRs: ADR-010 (4-layer safety stack), ADR-011 (Evidence Gate)

--- a/docs/adr/ADR-013-single-threaded-write-per-worktree.md
+++ b/docs/adr/ADR-013-single-threaded-write-per-worktree.md
@@ -1,0 +1,64 @@
+# ADR-013 — Single-threaded write per worktree
+
+## Status
+
+**Accepted** — operator-authorised standing rule.
+
+## Context
+
+A 2026-04-29 → 2026-05-01 chaos audit (`feedback_operational_discipline.md`) surfaced that concurrent writes within a single worktree caused systematic merge conflicts, half-committed state, and corrupted file edits. Multiple Claude Code subagents writing to the same worktree at the same time produces unrecoverable state.
+
+The fix is mechanical: any given worktree has at most one writer at any time. Multiple worktrees may exist (and writers may be parallel across worktrees), but each worktree is single-threaded for writes.
+
+## Decision
+
+**One writer per worktree.** Specifically:
+
+1. **Each substantive code task** is given its own worktree under `.claude/worktrees/<name>/`.
+2. **Within a single worktree**, only one Claude / Claude Code agent may have write permissions at a time.
+3. **Reads** (Grep, Read, Glob, status checks) may happen concurrently within a worktree — read-only operations are safe.
+4. **Across worktrees**, multiple writers are fine — that's how parallelism is achieved.
+5. **Worktree count cap**: ≤8 alive (alarm threshold), ≤12 (hard block via Steward preflight).
+6. **Substantial Mac-targeted concurrent task cap**: 2 (per `feedback_operational_discipline.md`).
+
+When orchestrator spawns a coding task, it creates a fresh worktree, hands it to the agent, and never spawns a second writer into that worktree until the first agent has either:
+- Merged its PR, or
+- Closed/abandoned the work explicitly.
+
+Pre-spawn checklist (Steward preflight per ADR-012) checks worktree-cap + concurrent-Mac-task-cap before approving spawn.
+
+## Consequences
+
+**Positive:**
+- Eliminates the worst class of concurrent-write corruption observed in the chaos audit.
+- Composes cleanly with Git Flow (ADR-015) — each worktree is a branch.
+- Composes with Option E (ADR-006) — agent code is parameterised, but each agent invocation is bound to one worktree at runtime.
+- Forces explicit parallelism design — orchestrator must explicitly partition work into separate worktrees, not naively fork threads.
+
+**Negative:**
+- Hard cap on per-task throughput within a single feature.
+- Worktree count itself becomes a resource — must be policed (Steward failure mode #6).
+- Spawning many worktrees has filesystem overhead.
+
+**Neutral:**
+- Compatible with Choreographer's eventual cross-project event-driven coordination — different projects naturally have different worktrees.
+
+## Operational rules
+
+- **Worktree-create cadence**: orchestrator creates worktree per substantive task; ephemeral / read-only tasks share the main worktree.
+- **Worktree-destroy cadence**: after PR merged into develop, worktree is removed by Git Flow auto-cleanup. Steward weekly sweep removes orphaned worktrees.
+- **Concurrent-write detection**: Steward semgrep rule + worktree lock file. Second writer sees lock, refuses spawn.
+- **Recovery**: if a worktree is corrupted (merge conflict, partial edits), abandon → recreate from develop.
+
+## Re-evaluation triggers
+
+1. **Observed worktree-cap exhaustion** repeatedly under normal load → re-evaluate cap or partitioning strategy.
+2. **Tooling matures** to allow safe concurrent writes (e.g., file-system-level transaction support) → re-evaluate.
+3. **Productisation** — multi-tenant may require per-tenant worktree isolation; extends but doesn't break this rule.
+
+## References
+
+- Standing rule: `agent/memory/feedback_operational_discipline.md`
+- Standing rule: `agent/memory/feedback_self_perpetuating_campaigns.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §5.2.2 + §10.2.6
+- Companion ADRs: ADR-006 (Option E shape), ADR-012 (Steward Gatekeeper), ADR-015 (Git Flow)

--- a/docs/adr/ADR-014-hashicorp-vault.md
+++ b/docs/adr/ADR-014-hashicorp-vault.md
@@ -1,0 +1,78 @@
+# ADR-014 — HashiCorp Vault for secrets
+
+## Status
+
+**Accepted** — operational. Vault running in Docker on stolution.
+
+## Context
+
+CAIA accumulates secrets at scale: GitHub PAT, Anthropic OAuth tokens, Vault AppRole credentials, OpenAI / Replicate keys (training-only), Cloudflare API keys, GA4 service accounts, Stolution database credentials, Postgres passwords, Loki/Grafana basic-auth.
+
+Storing secrets in `.env` files, plaintext config, or worse, in committed code, is unacceptable. The 2026-04-29 chaos audit confirmed that an unbounded plaintext-secret pattern would compound rapidly.
+
+Three categories of solution were considered:
+- **Cloud SaaS** (AWS Secrets Manager, Doppler, 1Password Connect) — paid; vendor lock-in; not under operator control.
+- **Native (Mac Keychain only)** — Mac-only; doesn't work for stolution server; no audit log.
+- **HashiCorp Vault self-hosted** — free, audited, KV v2 versioning, AppRole pattern for autonomous reads, audit log shippable to Loki.
+
+`feedback_pat_topic.md` documents the operator's explicit position: post-rotation plaintext copies in operational locations (.bashrc, .env, docker config, plist) are intentional ergonomic copies and are NOT to be re-flagged. The canonical secret store is Vault; operational copies are downstream conveniences.
+
+## Decision
+
+HashiCorp Vault is the canonical secret store. Specifically:
+
+- **Server**: Vault in Docker container on stolution server.
+- **Backend**: KV v2 (versioned).
+- **Mount paths**:
+  - `secret/stolution/prod/*` — production stolution secrets
+  - `secret/stolution/staging/*` — staging stolution secrets
+  - `secret/stolution/prod/infrastructure` — GitHub PAT and infrastructure tokens
+  - `secret/caia/*` — CAIA-specific secrets
+- **Authentication**: AppRole pattern for autonomous agent reads (RoleID + SecretID).
+- **Policies**: 7 policies, 3 AppRoles. Each agent role has minimum-privilege scope.
+- **Audit log**: shipped to Loki.
+- **Unseal keys**: backed up off-server in macOS Keychain.
+- **Snapshots**: daily Vault snapshot to `/home/s903/backups/vault/`; 30d retention; off-server rsync to Mac at `~/Library/Application Support/Stolution/vault-snapshots/` (LaunchAgent `com.stolution.vault-snapshot-pull`); quarterly restore drill via `~/stolution/scripts/backup/test-vault-restore.sh`.
+
+Operational-copy carve-out (per `feedback_pat_topic.md`):
+- Plaintext tokens in `.bashrc` / `.env` / `docker-config` / `plist` are **intentional** post-rotation ergonomic copies.
+- Do NOT propose moving these to Vault.
+- Do NOT call them security findings.
+- The canonical source is always Vault; operational copies are downstream conveniences and are rotated when Vault rotates.
+
+## Consequences
+
+**Positive:**
+- Audit log gives full trail of every secret access (Vault → Loki → Grafana dashboard).
+- KV v2 versioning allows rollback after compromise.
+- AppRole pattern enables autonomous agent reads without human-in-loop.
+- Self-hosted = no vendor cost, no vendor lock-in.
+- Off-server unseal-key backup means catastrophic stolution loss does not lose the vault.
+
+**Negative:**
+- Vault is a single point of failure — if it's down, agents can't read secrets.
+- Operational complexity — initialise, unseal, rotate, audit.
+- Quarterly restore drill must actually be run (Steward failure mode #7).
+
+**Neutral:**
+- Productisation may require per-tenant Vault namespaces — extension, not rewrite.
+
+## Operational rules
+
+- **Read pattern**: agents authenticate via AppRole login → fetch secret → cache in process memory only (never persist to disk outside Vault).
+- **Rotation cadence**: GitHub PAT every 90 days; Anthropic tokens per their TTL; Vault unseal keys never rotated (only re-encrypted via `operator rekey`).
+- **Backup verification**: Steward failure mode #7 surfaces a stale or empty vault snapshot.
+
+## Re-evaluation triggers
+
+1. **Vault availability becomes a hot path constraint** — if agent spawn latency is dominated by Vault round-trip, evaluate per-agent secret caching with TTL.
+2. **Productisation** — multi-tenant secret isolation requires per-tenant Vault namespaces.
+3. **Vault project becomes problematic** (license change, abandonment) → evaluate OpenBao fork.
+
+## References
+
+- Standing rule: `agent/memory/secrets_vault.md`
+- Standing rule: `agent/memory/feedback_pat_topic.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §3.2 + §4.4
+- Backup runbook: `caia/docs/test-isolation-runbook.md` (cross-references Vault drill)
+- Companion ADRs: ADR-007 (subscription-only LLM), ADR-010 (4-layer safety stack)

--- a/docs/adr/ADR-015-git-flow-enforcement.md
+++ b/docs/adr/ADR-015-git-flow-enforcement.md
@@ -1,0 +1,88 @@
+# ADR-015 — Git Flow enforcement (feature → develop → main)
+
+## Status
+
+**Accepted** — operator-authorised standing rule. Inviolate.
+
+## Context
+
+Many small Claude PRs landing daily, plus periodic operator interventions, plus auto-perpetuating multi-leg campaigns, demand a predictable branching discipline. Without one:
+
+- Features bypass develop and merge directly to main → broken main.
+- Branches alive without PRs accumulate → orphan-branch sprawl.
+- Force-pushes lose history → dependent branches break.
+- "What's in the next release?" becomes unanswerable.
+
+Trunk-based development (single `main` branch) was considered but doesn't compose with weekly release-candidate windows. GitHub Flow (feature → main) was considered but doesn't compose with the need for a release-staging branch where Evidence Gate has the last word.
+
+Git Flow (feature → develop → main, with release/* and hotfix/* branches) matches CAIA's release rhythm.
+
+## Decision
+
+CAIA enforces a Git Flow variant. Mechanical rules:
+
+### Branch structure
+
+- `main` — always-deployable. Receives merges from `release/*` and `hotfix/*` only.
+- `develop` — integration branch. Receives merges from `feature/*`, `docs/*`, `chore/*`, `fix/*`.
+- `feature/*` — short-lived (≤7d). One PR per branch. Branched from `develop`, merged into `develop`.
+- `docs/*` — same lifecycle as feature/* but for documentation.
+- `release/<date>` — branched from `develop`; merged into `main` AND back-merged into `develop`. Weekly cadence.
+- `hotfix/<issue>` — branched from `main`; merged into `main` AND back-merged into `develop`.
+
+### Hard rules
+
+- 🚨 **NEVER push to `main` or `develop` directly.**
+- 🚨 **NEVER leave a branch alive without an open PR.**
+- 🚨 **NEVER call work "done" until merged into develop AND main, branch + worktree gone.**
+- 🚨 **NEVER `git push --force` literal** — use `git push origin "+HEAD:<branch>"` refspec syntax. (Reason: literal `--force` flag was found to behave inconsistently with some hooks; refspec is reliable.)
+- 🚨 **NEVER use `gh pr update-branch`** — it can produce phantom merge commits in feature PRs that fail `gitflow-conformance`.
+- 🚨 **Squash-and-merge for feature/docs PRs.** Release PRs use merge-commit (preserves history).
+
+### Branch protection
+
+- `main`: requires all 6 Evidence Gate required contexts green; requires conventional-commit on merge; squash forbidden.
+- `develop`: requires all 6 Evidence Gate required contexts green. Linear-history requirement disabled (2026-05-03) to allow classic back-merges.
+- `gitflow-conformance` semgrep check verifies branch source/target conforms to rules above; rejects unwanted merge commits in feature PRs.
+
+### Definition of Done
+
+Item 14: branch merged into develop AND main, branch + worktree gone (per `feedback_definition_of_done.md`).
+
+## Consequences
+
+**Positive:**
+- Predictable releases — `release/<date>` branches give a staging surface.
+- `develop` is always the latest integrated state — cherry-picking and rollbacks are clean.
+- Branch protection + Evidence Gate + squash-merge keep history readable.
+- Steward Gatekeeper failure modes #5, #6, #10 (orphan branches, worktree hygiene, PR staleness) operationalise the rules.
+
+**Negative:**
+- More overhead per change (feature → develop → release → main is 3 merges, not 1).
+- Hotfixes require explicit `hotfix/*` discipline.
+- New contributors must learn the branch structure (operator does not code, but Claude leg handoffs require this knowledge).
+
+**Neutral:**
+- Compatible with auto-perpetuating multi-leg campaigns — each leg files its own feature/* branch.
+
+## Enforcement
+
+- GitHub branch protection rules on `main` and `develop`.
+- `.github/workflows/evidence-gate.yml` runs all 6 required contexts.
+- `.semgrep/caia-rules.yml` includes `gitflow-conformance` check.
+- Operator runbook: [`git-flow.md`](../git-flow.md).
+- Steward Gatekeeper: pre-spawn check for branch source target validity.
+
+## Re-evaluation triggers
+
+1. **Release cadence change** — if the weekly cadence changes to per-PR continuous deploy, re-evaluate the release/* layer.
+2. **Branch-protection drift** — Steward catches; re-evaluate enforcement layer.
+3. **Hotfix volume sustained** — >2 hotfixes/week sustained 4 weeks → re-evaluate develop's stability bar.
+
+## References
+
+- Standing rule: `agent/memory/feedback_git_flow_enforced.md`
+- Operator runbook: `caia/docs/git-flow.md`
+- Definition of Done: `agent/memory/feedback_definition_of_done.md`
+- Audit reference: `caia-enterprise-architecture-comprehensive-2026-05-06.md` §5.2.1
+- Companion ADRs: ADR-005 (Test-Fix-Commit), ADR-011 (Evidence Gate), ADR-012 (Steward Gatekeeper)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,39 @@
+# Architecture Decision Records (ADRs)
+
+This directory holds CAIA's canonical Architecture Decision Records. ADRs are short, format-formalised statements of *why* a load-bearing decision was made. They sit alongside `agent/memory/*.md` (the operator-curated standing rules) and `caia_architecture.md` (the consolidated architecture reference) and serve as the durable decision-precedent surface.
+
+## Format
+
+Every ADR has five sections:
+
+1. **Status** — `Accepted`, `Superseded by ADR-NNN`, `Deprecated`, or `Proposed`
+2. **Context** — what problem made the decision necessary
+3. **Decision** — what we decided
+4. **Consequences** — what follows (positive + negative + neutral)
+5. **References** — links to memory, reports, code
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| ADR-001 | Living Library | Accepted (memory: `caia_architecture.md`) |
+| ADR-002 | Application Code Purity | Accepted (memory: `caia_architecture.md`) |
+| ADR-003 | Event-First | Accepted (memory: `caia_architecture.md`) |
+| ADR-004 | Agent-First | Accepted (memory: `caia_architecture.md`) |
+| ADR-005 | Test-Fix-Commit Cadence | Accepted (memory: `caia_architecture.md`) |
+| [ADR-006](ADR-006-option-e-agent-shape.md) | Option E agent architecture shape (CAIA-Bonded Skeleton) | Accepted |
+| [ADR-007](ADR-007-subscription-only-llm.md) | Subscription-only LLM billing (no API keys) | Accepted |
+| [ADR-008](ADR-008-mac-first-inference.md) | Mac-first inference (Ollama bulk + claude binary synthesis) | Accepted |
+| [ADR-009](ADR-009-custom-hono-runtime.md) | Custom Hono runtime over LangChain/CrewAI/MS Agent Framework | Accepted |
+| [ADR-010](ADR-010-four-layer-safety-stack.md) | 4-layer safety stack | Accepted |
+| [ADR-011](ADR-011-evidence-gate.md) | Evidence Gate at PR merge | Accepted |
+| [ADR-012](ADR-012-steward-gatekeeper.md) | Steward Gatekeeper (15 enumerated failure modes) | Accepted |
+| [ADR-013](ADR-013-single-threaded-write-per-worktree.md) | Single-threaded write per worktree | Accepted |
+| [ADR-014](ADR-014-hashicorp-vault.md) | HashiCorp Vault for secrets | Accepted |
+| [ADR-015](ADR-015-git-flow-enforcement.md) | Git Flow enforcement (feature → develop → main) | Accepted |
+
+## Maintenance
+
+Today: ADRs are filed by Claude as load-bearing decisions are made. Going forward, **Docs Architect Agent** (master sequencing item 13.5) owns this register and gates new ADR proposals through the Evidence Gate.
+
+ADR-001 through ADR-005 are inherited from earlier consolidation work (`caia_architecture.md`). ADR-006 onwards are filed in this directory in standalone form.


### PR DESCRIPTION
## Summary

Files 10 Architecture Decision Records (ADR-006..ADR-015) to formalise load-bearing decisions previously distributed across `agent/memory/*.md` and `~/Documents/projects/reports/*.md`.

This is **Batch A** of the quick-wins documentation cluster identified in `caia-enterprise-architecture-comprehensive-2026-05-06.md` §10.2.1.

## ADRs filed

| ADR | Title |
|---|---|
| ADR-006 | Option E agent architecture shape (CAIA-Bonded Skeleton) |
| ADR-007 | Subscription-only LLM billing (no API keys) |
| ADR-008 | Mac-first inference (Ollama bulk + claude binary synthesis) |
| ADR-009 | Custom Hono runtime over LangChain/CrewAI/MS Agent Framework |
| ADR-010 | 4-layer safety stack |
| ADR-011 | Evidence Gate at PR merge |
| ADR-012 | Steward Gatekeeper (15 enumerated failure modes) |
| ADR-013 | Single-threaded write per worktree |
| ADR-014 | HashiCorp Vault for secrets |
| ADR-015 | Git Flow enforcement |

Plus `docs/adr/README.md` index.

## Format

Each ADR <=200 lines with five sections: status, context, decision, consequences, re-evaluation triggers, references.

ADR-001..ADR-005 are already accepted in `agent/memory/caia_architecture.md`. The README references them and links 006-015 going forward. Docs Architect Agent (master sequencing item 13.5) will own the register going forward.

## Effort + scope

- 11 files added; 0 changed; 0 removed
- Pure markdown -- no code paths touched
- Doc-only PR -- `bundle-size`, `axe`, `lighthouse`, `visual` checks expected to skip per Evidence Gate carve-out

## Validation

- All 10 ADRs source from existing memory + report content (no new claims)
- Re-evaluation triggers explicit on every ADR
- `wc -l docs/adr/*.md` confirms each <=95 lines (well under 200 cap)

## Closes

Quick-wins cluster Batch A -- Item 3 of section 10.2.1.
