### PR TITLE
docs: file caia/docs/runbooks/INDEX.md + 10 stubs (quick-wins B9)

### DIFF
--- a/docs/runbooks/INDEX.md
+++ b/docs/runbooks/INDEX.md
@@ -1,0 +1,104 @@
+# Runbook Library
+
+> **Source**: distilled from `caia-enterprise-architecture-comprehensive-2026-05-06.md` §4.3.3.
+> **Maintenance**: today this index is operator-curated; Lantern (master sequencing item 16.5) auto-detects new failure modes and proposes runbooks.
+
+This is the runbook library scaffolding. Each runbook is a step-by-step recovery procedure for a specific failure or operational task. The intent is that, when a SLO breach or alert fires at 3am, the operator (or Claude on operator's behalf) opens this index, finds the matching runbook, and follows the procedure.
+
+The 10 most likely runbook topics are scaffolded below as placeholders. Each will be authored as the corresponding system matures or its first incident lands.
+
+## Status legend
+
+- ✅ **Authored** — runbook is in this directory and current
+- 📝 **Stub** — placeholder; first author trigger pending
+- 📋 **Planned** — to be authored by a specific agent / phase
+
+## Existing runbooks (already in `caia/docs/`)
+
+| Topic | Path | Status |
+|---|---|---|
+| Evidence Gate | [`../evidence-gate.md`](../evidence-gate.md) | ✅ Authored |
+| Steward Gatekeeper | [`../steward.md`](../steward.md) | ✅ Authored |
+| Capability Broker | [`../capability-broker.md`](../capability-broker.md) | ✅ Authored |
+| MCP Security | [`../mcp-security.md`](../mcp-security.md) | ✅ Authored |
+| Spend Guard | [`../spend-guard.md`](../spend-guard.md) | ✅ Authored |
+| Git Flow | [`../git-flow.md`](../git-flow.md) | ✅ Authored |
+| Test Isolation | [`../test-isolation-runbook.md`](../test-isolation-runbook.md) | ✅ Authored |
+| Prompt Injection Defense | [`../prompt-injection-defense.md`](../prompt-injection-defense.md) | ✅ Authored |
+| Regression Testing | [`../regression-testing.md`](../regression-testing.md) | ✅ Authored |
+| Safety Hardening | [`../safety_hardening_2026-04-29.md`](../safety_hardening_2026-04-29.md) | ✅ Authored |
+
+## Top 10 runbook stubs (this leg of work)
+
+| # | Runbook | First-author trigger | Slot |
+|---|---|---|---|
+| 1 | [Subscription cap exhausted](subscription-cap-exhausted.md) | First spend-guard 100%-cap pause event | First incident or Lantern Phase 1 |
+| 2 | [Vault unsealed sequence](vault-unsealed-sequence.md) | First Vault container restart drill | DevOps Architect (item 11.9) |
+| 3 | [PR auto-merge stuck](pr-auto-merge-stuck.md) | First Evidence-Gate + auto-merge stall | First incident |
+| 4 | [Worktree corruption recovery](worktree-corruption-recovery.md) | First single-threaded-write violation observed | DevOps Architect |
+| 5 | [Database migration failure](database-migration-failure.md) | First Steward failure-mode #1 fire | Database Architect (item 11.7) |
+| 6 | [MCP saturation / timeout cascade](mcp-saturation.md) | First failure-mode #15 fire | Lantern Phase 1 |
+| 7 | [Disaster recovery (DR drill)](disaster-recovery.md) | Pre-productisation milestone | Cross-cutting; pre-productisation |
+| 8 | [Mac LaunchAgent supervision failure](launchagent-supervision-failure.md) | First daemon crash-loop | DevOps Architect |
+| 9 | [GitHub PAT expiry](github-pat-expiry.md) | First Steward failure-mode #9 fire | DevOps Architect |
+| 10 | [Apprentice adapter rollback](apprentice-adapter-rollback.md) | First adapter regression detection | Apprentice Phase 3 |
+
+## Per-runbook template
+
+Every runbook in this library follows the same shape:
+
+```
+# Runbook: <Name>
+
+## Symptom
+What the operator / Claude observes that triggers this runbook.
+
+## Severity
+SEV-1 (page operator), SEV-2 (operator review next session), SEV-3 (informational)
+
+## Detection
+How this is detected (alert source, dashboard panel, log pattern).
+
+## Immediate response
+Steps to stabilise the system. Time-bounded.
+
+## Diagnosis
+Steps to identify root cause.
+
+## Resolution
+Steps to fix.
+
+## Post-mortem
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+Related runbooks, ADRs, memory files.
+```
+
+## Stub files
+
+The 10 stub runbooks below are placeholders — they exist so cross-references resolve when a runbook is referenced before it is fully authored. Each will be expanded the first time its trigger fires.
+
+- [`subscription-cap-exhausted.md`](subscription-cap-exhausted.md)
+- [`vault-unsealed-sequence.md`](vault-unsealed-sequence.md)
+- [`pr-auto-merge-stuck.md`](pr-auto-merge-stuck.md)
+- [`worktree-corruption-recovery.md`](worktree-corruption-recovery.md)
+- [`database-migration-failure.md`](database-migration-failure.md)
+- [`mcp-saturation.md`](mcp-saturation.md)
+- [`disaster-recovery.md`](disaster-recovery.md)
+- [`launchagent-supervision-failure.md`](launchagent-supervision-failure.md)
+- [`github-pat-expiry.md`](github-pat-expiry.md)
+- [`apprentice-adapter-rollback.md`](apprentice-adapter-rollback.md)
+
+## Re-evaluation triggers
+
+1. **First Lantern Phase 1 alert** — review which runbooks were consulted; promote the most-used to "Authored" status.
+2. **New systemic failure mode** observed → file a runbook stub.
+3. **Pre-productisation milestone** — run a full DR drill; promote disaster-recovery.md to Authored.
+
+## See also
+
+- [`../slos.md`](../slos.md) — SLOs that gate runbook triggers
+- [`../adr/ADR-012-steward-gatekeeper.md`](../adr/ADR-012-steward-gatekeeper.md) — 15 enumerated failure modes
+- `agent/memory/steward_gatekeeper_directive.md` — failure-mode taxonomy
+- `~/Documents/projects/reports/caia-enterprise-architecture-comprehensive-2026-05-06.md` §4.3.3 + §4.5.2 — full audit

--- a/docs/runbooks/apprentice-adapter-rollback.md
+++ b/docs/runbooks/apprentice-adapter-rollback.md
@@ -1,0 +1,38 @@
+# Runbook: Apprentice adapter rollback
+
+> **Status**: STUB. First-author trigger: First adapter regression detection.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/database-migration-failure.md
+++ b/docs/runbooks/database-migration-failure.md
@@ -1,0 +1,38 @@
+# Runbook: Database migration failure
+
+> **Status**: STUB. First-author trigger: First Steward failure-mode #1 fire.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -1,0 +1,38 @@
+# Runbook: Disaster recovery (DR drill)
+
+> **Status**: STUB. First-author trigger: Pre-productisation milestone.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/github-pat-expiry.md
+++ b/docs/runbooks/github-pat-expiry.md
@@ -1,0 +1,38 @@
+# Runbook: GitHub PAT expiry
+
+> **Status**: STUB. First-author trigger: First Steward failure-mode #9 fire.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/launchagent-supervision-failure.md
+++ b/docs/runbooks/launchagent-supervision-failure.md
@@ -1,0 +1,38 @@
+# Runbook: Mac LaunchAgent supervision failure
+
+> **Status**: STUB. First-author trigger: First daemon crash-loop.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/mcp-saturation.md
+++ b/docs/runbooks/mcp-saturation.md
@@ -1,0 +1,38 @@
+# Runbook: MCP saturation / timeout cascade
+
+> **Status**: STUB. First-author trigger: First Steward failure-mode #15 fire.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/pr-auto-merge-stuck.md
+++ b/docs/runbooks/pr-auto-merge-stuck.md
@@ -1,0 +1,38 @@
+# Runbook: PR auto-merge stuck
+
+> **Status**: STUB. First-author trigger: First Evidence-Gate + auto-merge stall.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/subscription-cap-exhausted.md
+++ b/docs/runbooks/subscription-cap-exhausted.md
@@ -1,0 +1,38 @@
+# Runbook: Subscription cap exhausted
+
+> **Status**: STUB. First-author trigger: First spend-guard 100% cap pause event.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/vault-unsealed-sequence.md
+++ b/docs/runbooks/vault-unsealed-sequence.md
@@ -1,0 +1,38 @@
+# Runbook: Vault unsealed sequence
+
+> **Status**: STUB. First-author trigger: First Vault container restart drill.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue

--- a/docs/runbooks/worktree-corruption-recovery.md
+++ b/docs/runbooks/worktree-corruption-recovery.md
@@ -1,0 +1,38 @@
+# Runbook: Worktree corruption recovery
+
+> **Status**: STUB. First-author trigger: First single-threaded-write violation observed.
+>
+> This is a placeholder so cross-references resolve. The full runbook will be authored the first time the trigger fires (or when the responsible architect agent is slotted, whichever comes first).
+
+## Symptom
+
+(To be authored)
+
+## Severity
+
+(To be authored)
+
+## Detection
+
+(To be authored)
+
+## Immediate response
+
+(To be authored)
+
+## Diagnosis
+
+(To be authored)
+
+## Resolution
+
+(To be authored)
+
+## Post-mortem
+
+Mentor incident classification + lesson-synthesis trigger.
+
+## See also
+
+- [`INDEX.md`](INDEX.md) — runbook library
+- [`../slos.md`](../slos.md) — SLO catalogue


### PR DESCRIPTION
Files caia/docs/runbooks/INDEX.md + 10 stub runbooks. Library scaffolding for SEV-1/2 failure modes. Stubs expand the first time their trigger fires.

Existing authored runbooks (already in caia/docs/) catalogued in the index: evidence-gate, steward, capability-broker, mcp-security, spend-guard, git-flow, test-isolation, prompt-injection-defense, regression-testing, safety_hardening.

Batch B-9 of quick-wins cluster.

Source: audit sec 4.3.3.

Doc-only PR.
