### PR TITLE
chore: install direnv + restic; add .envrc + dev-utilities doc (Batch C)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,15 @@
+# CAIA per-project direnv config
+# Activates automatically when shell enters this directory after `direnv allow`.
+
+# Repo root for scripts
+export CAIA_ROOT="$PWD"
+
+# Node + pnpm pinning (rely on .nvmrc / package.json engine if present)
+PATH_add scripts
+PATH_add node_modules/.bin
+
+# Default subscription account selection (overridable per-shell)
+export CLAUDE_ACCOUNT="${CLAUDE_ACCOUNT:-account-1}"
+
+# Memory-session hint (informational only)
+export CAIA_MEMORY_SESSION_HINT="agent/memory/MEMORY.md"

--- a/docs/dev-utilities.md
+++ b/docs/dev-utilities.md
@@ -1,0 +1,42 @@
+# Mac-native dev utilities
+
+> **Source**: distilled from `caia-enterprise-architecture-comprehensive-2026-05-06.md` §9.3.
+
+This document tracks the Mac-native CLI utilities CAIA installs as part of the quick-wins Batch C cluster. Each is `$0`, all run on Mac directly.
+
+## Installed
+
+### `direnv`
+
+- **Purpose**: per-project shell environment isolation. When a shell `cd`s into a directory containing an `.envrc`, direnv applies it; on exit, undoes it.
+- **Installed via**: `brew install direnv`
+- **Shell hook**: `eval "$(/opt/homebrew/bin/direnv hook zsh)"` appended to `~/.zshrc`.
+- **Per-project config**: [`.envrc`](../.envrc) at repo root.
+- **First-use step (interactive, operator-side)**: `cd <repo>; direnv allow` — required once per `.envrc` (security against arbitrary directory-execution).
+
+### `restic`
+
+- **Purpose**: encrypted, deduplicated, snapshot-based backup tool. Compliments existing Vault snapshot + DB hourly backup pipeline (per `caia/docs/information-classification.md`) by adding an option for memory + reports + worktree backup at the same maturity level.
+- **Installed via**: `brew install restic`
+- **Verified**: `restic version` returns `restic 0.18.1`.
+- **First-use plan**: future runbook (e.g., DR drill, backup expansion) will codify a restic repository at `~/Library/Application Support/Stolution/restic-repo` with weekly snapshots of memory + reports.
+
+## Skipped (already adequate)
+
+### Docker alternative (`colima` / `orbstack`)
+
+- **Skipped**. Docker Desktop is already installed (`brew list --cask` shows `docker-desktop`).
+- The audit recommended colima/orbstack as alternatives only if Docker was missing. Re-evaluate only if Docker Desktop becomes problematic (license change, resource overhead).
+
+## Operator-side TODO
+
+These are operations only the operator can do (Claude can install but cannot run interactive shell hooks):
+
+1. Open a fresh terminal session so `direnv hook zsh` activates.
+2. From the caia repo root, run `direnv allow` once to authorise `.envrc`.
+3. Validate by checking `direnv status` from inside the caia directory.
+
+## See also
+
+- [`information-classification.md`](information-classification.md) — backup pipeline classification + retention
+- `~/Documents/projects/reports/caia-enterprise-architecture-comprehensive-2026-05-06.md` §9.3 + §10.2.1 — full audit


### PR DESCRIPTION
Mac-native CLI utility installs from quick-wins Batch C:

- direnv installed via brew; shell hook added to ~/.zshrc; .envrc at repo root.
- restic installed via brew (0.18.1); first-use plan documented.
- colima / orbstack skipped: Docker Desktop already installed.

Operator-side TODO: open a fresh terminal and run `direnv allow` once from the caia root to authorise the .envrc.

Files added:
- .envrc (per-project direnv config)
- docs/dev-utilities.md (utility tracking + operator TODO)

Source: audit sec 9.3 + sec 10.2.1.
