### PR TITLE
feat(apprentice-corpus-003): add deterministic holdout split (R6 follow-up)

### DIFF
--- a/packages/apprentice-corpus/DESIGN.md
+++ b/packages/apprentice-corpus/DESIGN.md
@@ -226,9 +226,12 @@ Final layout per run:
   "redactedSpansHistogram": {"email": 12, "secret": 0, "path": 240},
   "qualityHistogram": {"0.0-0.2": 0, "0.2-0.4": 0, "0.4-0.6": 800, "0.6-0.8": 760, "0.8-1.0": 260},
   "configSha256": "<hex>",
-  "warnings": []
+  "warnings": [],
+  "holdout": ["<sha256-id>", "<sha256-id>", "..."]
 }
 ```
+
+The `holdout` array contains the stable ids of curated pairs that were excluded from `samples.jsonl` and reserved as a deterministic test set for Phase 1's `apprentice-eval` harness. Sampling is seeded by `holdoutSeed` (config; default 42) and the fraction by `holdoutFraction` (default 0.05 — 5%); reruns of the same config produce identical holdouts. Pair ordering inside the input is irrelevant — we sort by the pair's own stable id (sha256) before sampling.
 
 The manifest is the canonical artifact for Phase 1 eval harness + Phase 4 retrainer cron's "is there enough new data to retrain?" check.
 

--- a/packages/apprentice-corpus/src/aggregator.ts
+++ b/packages/apprentice-corpus/src/aggregator.ts
@@ -34,6 +34,7 @@ import type {
   ReaderContext,
   SourceReader
 } from './types.js';
+import { splitHoldout } from './holdout.js';
 
 export class ApprenticeCorpusAggregator {
   private readonly cfg: ResolvedApprenticeCorpusConfig;
@@ -175,6 +176,18 @@ export class ApprenticeCorpusAggregator {
       highQuality = highQuality.slice(0, this.cfg.maxSamples);
     }
 
+    // ── Step 7b: deterministic holdout split ─────────────────────────
+    // Stable across reruns of the same config (seeded by `holdoutSeed`).
+    // The holdout ids are recorded in `manifest.json` so Phase 1's
+    // apprentice-eval can recover the same prompts deterministically.
+    const split = splitHoldout({
+      pairs: highQuality,
+      seed: this.cfg.holdoutSeed,
+      fraction: this.cfg.holdoutFraction
+    });
+    const trainablePairs = split.trainable;
+    const holdoutIds = split.holdoutIds;
+
     // ── Step 8: write outputs ────────────────────────────────────────
     const elapsedMs = Date.now() - startedAtMs;
     const datedDir = generatedAt.slice(0, 10);
@@ -186,7 +199,7 @@ export class ApprenticeCorpusAggregator {
       afterQuality: pairs.length,
       distilled,
       dropped: dropped.length,
-      final: highQuality.length
+      final: trainablePairs.length
     };
     const configSnapshotJson = snapshotConfigForHash(this.cfg);
     const configHash = hashConfig(configSnapshotJson);
@@ -194,13 +207,14 @@ export class ApprenticeCorpusAggregator {
     const inputs = {
       outputDir,
       rawArtifacts,
-      finalPairs: highQuality,
+      finalPairs: trainablePairs,
       dropped,
       totals,
       warnings,
       configHash,
       generatedAt,
-      elapsedMs
+      elapsedMs,
+      holdoutIds
     };
 
     if (opts.dryRun !== true) {
@@ -213,11 +227,12 @@ export class ApprenticeCorpusAggregator {
       outputDir,
       elapsedMs,
       totals,
-      perSource: emptyPerSourceFromArtifacts(rawArtifacts, highQuality),
-      redactedSpansHistogram: histogramFromPairs(highQuality, (p) => p.meta.redactedSpans),
-      qualityHistogram: qualityHistogram(highQuality),
+      perSource: emptyPerSourceFromArtifacts(rawArtifacts, trainablePairs),
+      redactedSpansHistogram: histogramFromPairs(trainablePairs, (p) => p.meta.redactedSpans),
+      qualityHistogram: qualityHistogram(trainablePairs),
       configSha256: configHash,
-      warnings
+      warnings,
+      holdout: [...holdoutIds]
     };
   }
 

--- a/packages/apprentice-corpus/src/config.ts
+++ b/packages/apprentice-corpus/src/config.ts
@@ -43,6 +43,10 @@ export interface ApprenticeCorpusConfig {
   redactPII?: boolean;
   /** Optional extra patterns the PII masker should redact. */
   extraRedactPatterns?: ReadonlyArray<{ tag: string; pattern: RegExp; replacement: string }>;
+  /** Holdout seed — deterministic across reruns. Default: 42. */
+  holdoutSeed?: number;
+  /** 0..1 fraction of curated pairs to exclude from training; default 0.05 (5%). */
+  holdoutFraction?: number;
 
   // ── Test seams (DI) ──────────────────────────────────────────────────
   fs?: FsReader;
@@ -76,6 +80,8 @@ export interface ResolvedApprenticeCorpusConfig {
   maxAgeDays: number;
   redactPII: boolean;
   extraRedactPatterns: ReadonlyArray<{ tag: string; pattern: RegExp; replacement: string }>;
+  holdoutSeed: number;
+  holdoutFraction: number;
 }
 
 /** Resolve `~` to `$HOME` in a path. Returns `path` unchanged if it doesn't start with `~/`. */
@@ -133,7 +139,9 @@ export function resolveConfig(input: ApprenticeCorpusConfig): ResolvedApprentice
     maxDistillCalls: input.maxDistillCalls ?? 200,
     maxAgeDays: input.maxAgeDays ?? 365,
     redactPII: input.redactPII ?? true,
-    extraRedactPatterns: input.extraRedactPatterns ?? []
+    extraRedactPatterns: input.extraRedactPatterns ?? [],
+    holdoutSeed: input.holdoutSeed ?? 42,
+    holdoutFraction: input.holdoutFraction ?? 0.05
   };
 }
 
@@ -158,6 +166,8 @@ export function snapshotConfigForHash(cfg: ResolvedApprenticeCorpusConfig): stri
     qualityThreshold: cfg.qualityThreshold,
     maxDistillCalls: cfg.maxDistillCalls,
     maxAgeDays: cfg.maxAgeDays,
+    holdoutSeed: cfg.holdoutSeed,
+    holdoutFraction: cfg.holdoutFraction,
     redactPII: cfg.redactPII
   });
 }

--- a/packages/apprentice-corpus/src/holdout.ts
+++ b/packages/apprentice-corpus/src/holdout.ts
@@ -1,0 +1,74 @@
+/**
+ * Deterministic holdout sampler.
+ *
+ * Splits the curated `InstructionPair[]` into a training set + a holdout
+ * set. The holdout is excluded from `samples.jsonl` and its ids are
+ * written to `manifest.holdout: string[]` so downstream eval (Phase 1's
+ * `apprentice-eval`) can recover the same prompts deterministically.
+ *
+ * Determinism:
+ *   - Seeded by `holdoutSeed` (config) so reruns of the same corpus
+ *     produce identical holdouts.
+ *   - Pair ordering inside the input is irrelevant — we sort by the
+ *     pair's own stable id (sha256) before sampling.
+ */
+
+import type { InstructionPair } from './types.js';
+
+export interface HoldoutSplit {
+  readonly trainable: ReadonlyArray<InstructionPair>;
+  readonly holdoutIds: ReadonlyArray<string>;
+}
+
+/**
+ * mulberry32-style 32-bit PRNG. Deterministic across machines + Node
+ * versions. Returns a function `() => [0, 1)`.
+ */
+export function mulberry32(seed: number): () => number {
+  let t = (seed >>> 0) || 0x9e3779b9;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = t;
+    r = Math.imul(r ^ (r >>> 15), r | 1) >>> 0;
+    r ^= r + (Math.imul(r ^ (r >>> 7), r | 61) >>> 0);
+    return ((r ^ (r >>> 14)) >>> 0) / 0x1_0000_0000;
+  };
+}
+
+export interface SplitHoldoutOpts {
+  readonly pairs: ReadonlyArray<InstructionPair>;
+  /** Deterministic seed; default 42. */
+  readonly seed?: number;
+  /** 0..1 fraction of pairs to hold out; default 0.05 (5%). */
+  readonly fraction?: number;
+}
+
+export function splitHoldout(opts: SplitHoldoutOpts): HoldoutSplit {
+  const fraction = Math.max(0, Math.min(1, opts.fraction ?? 0.05));
+  const seed = opts.seed ?? 42;
+  if (opts.pairs.length === 0 || fraction === 0) {
+    return { trainable: opts.pairs, holdoutIds: [] };
+  }
+
+  const sorted = [...opts.pairs].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  const targetCount = Math.max(1, Math.floor(sorted.length * fraction));
+
+  // Reservoir-style deterministic shuffle: assign each pair a key from
+  // the seeded PRNG, sort by key, take the first `targetCount` as holdout.
+  const rng = mulberry32(seed);
+  const keyed = sorted.map((p) => ({ p, key: rng() }));
+  keyed.sort((a, b) => a.key - b.key);
+
+  const holdoutSet = new Set<string>();
+  for (let i = 0; i < targetCount; i++) {
+    holdoutSet.add(keyed[i]!.p.id);
+  }
+
+  const trainable: InstructionPair[] = [];
+  for (const p of opts.pairs) {
+    if (!holdoutSet.has(p.id)) trainable.push(p);
+  }
+  // Sort the holdout id list for stable manifest output.
+  const holdoutIds = [...holdoutSet].sort();
+  return { trainable, holdoutIds };
+}

--- a/packages/apprentice-corpus/src/manifest.ts
+++ b/packages/apprentice-corpus/src/manifest.ts
@@ -25,6 +25,8 @@ export interface WriteCorpusInputs {
   configHash: string;
   generatedAt: string;
   elapsedMs: number;
+  /** Stable ids of pairs held out from training (excluded from samples.jsonl). */
+  holdoutIds: ReadonlyArray<string>;
 }
 
 export function buildManifest(inputs: WriteCorpusInputs): CorpusManifest {
@@ -69,7 +71,8 @@ export function buildManifest(inputs: WriteCorpusInputs): CorpusManifest {
     redactedSpansHistogram,
     qualityHistogram,
     configSha256: inputs.configHash,
-    warnings: [...inputs.warnings]
+    warnings: [...inputs.warnings],
+    holdout: [...inputs.holdoutIds]
   };
 }
 

--- a/packages/apprentice-corpus/src/types.ts
+++ b/packages/apprentice-corpus/src/types.ts
@@ -203,6 +203,8 @@ export interface CorpusManifest {
   qualityHistogram: Record<string, number>;
   configSha256: string;
   warnings: string[];
+  /** Stable ids of pairs held out from training (excluded from samples.jsonl). */
+  holdout: string[];
 }
 
 /** Reason a candidate was dropped from the final corpus. */

--- a/packages/apprentice-corpus/tests/holdout.test.ts
+++ b/packages/apprentice-corpus/tests/holdout.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { mulberry32, splitHoldout } from '../src/holdout.js';
+import type { InstructionPair } from '../src/types.js';
+
+function pair(id: string): InstructionPair {
+  return {
+    id,
+    messages: [
+      { role: 'user', content: 'q' },
+      { role: 'assistant', content: 'a' }
+    ],
+    meta: {
+      source: 'memory',
+      sourceId: id,
+      qualityScore: 0.5,
+      distilled: false,
+      redactedSpans: [],
+      createdAt: '2026-05-06T00:00:00Z',
+      contentSha256: id
+    }
+  };
+}
+
+describe('mulberry32', () => {
+  it('is deterministic for the same seed', () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    for (let i = 0; i < 5; i++) {
+      expect(a()).toBeCloseTo(b(), 10);
+    }
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const a = mulberry32(1);
+    const b = mulberry32(2);
+    const seqA = [a(), a(), a()];
+    const seqB = [b(), b(), b()];
+    expect(seqA).not.toEqual(seqB);
+  });
+
+  it('returns values in [0, 1)', () => {
+    const r = mulberry32(7);
+    for (let i = 0; i < 100; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe('splitHoldout', () => {
+  it('returns the input unchanged when fraction is 0', () => {
+    const pairs = [pair('a'), pair('b'), pair('c')];
+    const r = splitHoldout({ pairs, fraction: 0 });
+    expect(r.trainable).toEqual(pairs);
+    expect(r.holdoutIds).toEqual([]);
+  });
+
+  it('returns the input unchanged when pairs is empty', () => {
+    const r = splitHoldout({ pairs: [], fraction: 0.5 });
+    expect(r.trainable).toEqual([]);
+    expect(r.holdoutIds).toEqual([]);
+  });
+
+  it('selects approximately `fraction` of pairs', () => {
+    const pairs = Array.from({ length: 100 }, (_, i) => pair(`p${i}`));
+    const r = splitHoldout({ pairs, fraction: 0.1, seed: 7 });
+    expect(r.holdoutIds.length).toBe(10);
+    expect(r.trainable.length).toBe(90);
+  });
+
+  it('produces the same holdout for the same seed', () => {
+    const pairs = Array.from({ length: 50 }, (_, i) => pair(`p${i}`));
+    const a = splitHoldout({ pairs, fraction: 0.2, seed: 42 });
+    const b = splitHoldout({ pairs, fraction: 0.2, seed: 42 });
+    expect(a.holdoutIds).toEqual(b.holdoutIds);
+  });
+
+  it('produces different holdouts for different seeds', () => {
+    const pairs = Array.from({ length: 50 }, (_, i) => pair(`p${i}`));
+    const a = splitHoldout({ pairs, fraction: 0.2, seed: 1 });
+    const b = splitHoldout({ pairs, fraction: 0.2, seed: 999 });
+    expect(a.holdoutIds).not.toEqual(b.holdoutIds);
+  });
+
+  it('is invariant to input ordering (sorts by id internally)', () => {
+    const ids = Array.from({ length: 30 }, (_, i) => `p${String(i).padStart(3, '0')}`);
+    const ordered = ids.map(pair);
+    const reversed = [...ordered].reverse();
+    const a = splitHoldout({ pairs: ordered, fraction: 0.2, seed: 5 });
+    const b = splitHoldout({ pairs: reversed, fraction: 0.2, seed: 5 });
+    expect(a.holdoutIds).toEqual(b.holdoutIds);
+  });
+
+  it('always holds out at least one pair when fraction > 0', () => {
+    const pairs = [pair('a'), pair('b'), pair('c')];
+    const r = splitHoldout({ pairs, fraction: 0.001, seed: 1 });
+    expect(r.holdoutIds.length).toBe(1);
+  });
+
+  it('returns sorted holdout ids for stable manifest output', () => {
+    const pairs = Array.from({ length: 20 }, (_, i) => pair(`pair-${i}`));
+    const r = splitHoldout({ pairs, fraction: 0.3, seed: 13 });
+    const sorted = [...r.holdoutIds].sort();
+    expect(r.holdoutIds).toEqual(sorted);
+  });
+
+  it('clamps fraction to [0, 1]', () => {
+    const pairs = [pair('a'), pair('b'), pair('c'), pair('d')];
+    const r1 = splitHoldout({ pairs, fraction: 1.5, seed: 1 });
+    expect(r1.trainable).toEqual([]);
+    expect(r1.holdoutIds.length).toBe(4);
+    const r2 = splitHoldout({ pairs, fraction: -1, seed: 1 });
+    expect(r2.trainable).toEqual(pairs);
+    expect(r2.holdoutIds).toEqual([]);
+  });
+});

--- a/packages/apprentice-corpus/tests/manifest.test.ts
+++ b/packages/apprentice-corpus/tests/manifest.test.ts
@@ -59,7 +59,8 @@ const baseInputs = (outputDir: string) => ({
   warnings: ['langfuse disabled'],
   configHash: hashConfig('{"memoryRoot":"/x"}'),
   generatedAt: '2026-05-06T00:00:00Z',
-  elapsedMs: 1234
+  elapsedMs: 1234,
+  holdoutIds: []
 });
 
 describe('buildManifest', () => {


### PR DESCRIPTION
## Summary

Closes risk R6 from apprentice-eval Phase 1 leg 1: `apprentice-corpus`'s `manifest.json` now includes `holdout: string[]` so Phase 1's eval harness can recover the same prompts deterministically across reruns.

## What ships

- New `src/holdout.ts` module with a mulberry32 PRNG + `splitHoldout` that samples a deterministic fraction of curated pairs after the existing Step 7 quality cap. Sort-by-id makes input ordering irrelevant; same seed → same holdout.
- Two new config fields:
  - `holdoutSeed?: number` — default 42
  - `holdoutFraction?: number` — default 0.05 (5%)
  Both folded into `snapshotConfigForHash` so the manifest hash captures them.
- `CorpusManifest` gains a `holdout: string[]` field — the stable sha256 ids of pairs excluded from `samples.jsonl`.
- `WriteCorpusInputs` gains a `holdoutIds` field; the aggregator wires Step 7b (split) before Step 8 (write).
- `totals.final` reflects the trainable-only count (post-holdout).
- DESIGN.md updated to document the field + sampling semantics.

## Tests

- 11 new tests in `tests/holdout.test.ts` (mulberry32 determinism + splitHoldout: empty input, fraction=0, fraction=1.5 (clamped), fraction=-1 (clamped), seed determinism, seed variance, ordering invariance, ≥1 pair when fraction>0, sorted output).
- Existing manifest test updated to pass `holdoutIds: []`.

## Regression

- `pnpm --filter @chiefaia/apprentice-corpus typecheck` → green
- `pnpm --filter @chiefaia/apprentice-corpus lint` → green
- `pnpm --filter @chiefaia/apprentice-corpus test` → 112/112 passing (was 100)

## Why a separate PR (vs bundled with #366)

The eval harness (PR #366) already tolerates absence of the field (`corpus-bridge.ts` returns empty array when `holdout` is missing), so the two are independent. This PR can land before, after, or alongside #366. Keeping them separate keeps each PR a single logical unit.

## Refs

- `packages/apprentice-corpus/DESIGN.md` (updated)
- `packages/apprentice-eval/DESIGN.md` §11 R6
- `~/Documents/projects/reports/apprentice-phase-1-leg-1-handoff.md`
