### PR TITLE
feat(librarian-mem0-002): @chiefaia/librarian backend abstraction + Mem0 backend

### DIFF
--- a/packages/librarian/package.json
+++ b/packages/librarian/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@chiefaia/librarian",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
-  "description": "Librarian Agent Phase-1 — pre-spawn precedent retrieval. Embeds the entire memory + reports corpus (directives, registries, architecture docs, master plans, landscape research, gate completion reports, handoffs) via Ollama nomic-embed-text, persists to a per-memoryDir SQLite index, retrieves top-N most similar prior decisions, and prepends them to spawned-task prompts as 'Precedent from prior decisions — for context:'. Mirrors the `@chiefaia/mentor-retrieval` pattern but with broader corpus + 'precedent' framing instead of 'lesson — do not repeat'. Composes left-to-right with Mentor's prepend so the orchestrator pipeline becomes `echo $P | caia-mentor-prepend | caia-librarian-prepend`. Phase 1 ships the index + retrieval + prepend hook; PR titles + transcripts ingestion is deferred.",
+  "description": "Librarian Agent — pre-spawn precedent retrieval. Embeds the entire memory + reports corpus (directives, registries, architecture docs, master plans, landscape research, gate completion reports, handoffs) via Ollama nomic-embed-text, persists to a per-memoryDir SQLite index, retrieves top-N most similar prior decisions, and prepends them to spawned-task prompts as 'Precedent from prior decisions — for context:'. Mirrors the `@chiefaia/mentor-retrieval` pattern but with broader corpus + 'precedent' framing instead of 'lesson — do not repeat'. Composes left-to-right with Mentor's prepend so the orchestrator pipeline becomes `echo $P | caia-mentor-prepend | caia-librarian-prepend`. Phase 1 ships the better-sqlite3 + JS-side cosine backend; Phase 2 ships the Mem0 alternative backend behind an internal abstraction (validation decision #4, 2026-05-06).",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -28,6 +28,10 @@
     "./prepend": {
       "import": "./dist/prepend.js",
       "types": "./dist/prepend.d.ts"
+    },
+    "./backends": {
+      "import": "./dist/backends/index.js",
+      "types": "./dist/backends/index.d.ts"
     }
   },
   "files": [
@@ -43,7 +47,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "better-sqlite3": "^12.6.2"
+    "better-sqlite3": "^12.6.2",
+    "mem0ai": "^3.0.2"
   },
   "devDependencies": {
     "@chiefaia/eslint-config": "workspace:*",

--- a/packages/librarian/src/backends/dispatcher.ts
+++ b/packages/librarian/src/backends/dispatcher.ts
@@ -1,0 +1,215 @@
+/**
+ * Backend-aware dispatchers for `@chiefaia/librarian`.
+ *
+ * These thin wrappers select between the Phase-1 better-sqlite3
+ * implementation (`'sqlite-vec'`) and the Phase-2 Mem0 implementation
+ * (`'mem0'`) based on a `backend` flag. The Phase-1 public functions
+ * (`buildIndex`, `retrievePrecedent`, `prependPrecedent`) remain
+ * unchanged for callers that don't want to opt in.
+ *
+ * Why a separate dispatcher module rather than overloading the
+ * existing public functions: keeping the dispatch surface in its
+ * own module (a) lets the existing 126 Phase-1 tests run untouched,
+ * (b) makes the A/B harness's call-sites self-documenting (a function
+ * named `retrieveWithBackend` clearly communicates which path is being
+ * exercised), and (c) preserves a hard-stop boundary in case Mem0
+ * regression forces us to roll back — we delete this file and the
+ * `backends/` folder, the rest of the package is unaffected.
+ *
+ * Hard-constraint reminder: both backends use Ollama embeddings (no
+ * Anthropic API key, no OpenAI API key, no per-token billing). The
+ * Mem0 path always passes `infer: false`; its LLM endpoint is
+ * configured but never called.
+ */
+
+import { buildIndex, type BuildIndexOptions } from '../index-builder.js';
+import {
+  retrievePrecedent,
+  formatPrecedentPreamble,
+  type RetrievePrecedentOptions,
+  type RetrievedPrecedent
+} from '../retrieve.js';
+import { prependPrecedent, type PrependPrecedentOptions, type PrependPrecedentResult } from '../prepend.js';
+import { createOllamaEmbedder } from '../embed.js';
+import type { BuildIndexStats } from '../types.js';
+
+import {
+  buildMem0Index,
+  retrieveMem0Precedent,
+  type BuildMem0IndexOptions,
+  type RetrieveMem0PrecedentOptions
+} from './mem0-backend.js';
+import { DEFAULT_BACKEND, type LibrarianBackendName } from './types.js';
+
+// The preamble format is shared across backends — using the Phase-1
+// `formatPrecedentPreamble` for both ensures the prepend output is
+// byte-identical regardless of which backend produced the rows.
+// (No second formatter to maintain.)
+
+export interface BuildIndexWithBackendOptions extends BuildIndexOptions {
+  /** Backend to use. Defaults to `DEFAULT_BACKEND` (`'sqlite-vec'`). */
+  backend?: LibrarianBackendName;
+  /**
+   * Mem0-specific overrides forwarded to `buildMem0Index` when
+   * `backend === 'mem0'`. Ignored otherwise.
+   */
+  mem0?: Omit<BuildMem0IndexOptions, 'memoryDir' | 'reportsDir' | 'fsReader' | 'log' | 'now' | 'embedInputMaxBytes'>;
+}
+
+/**
+ * Build/refresh the index using the selected backend.
+ *
+ * For `backend: 'sqlite-vec'` (default): equivalent to calling
+ * `buildIndex(opts)` directly — the same `embed` + `fsReader` + DB
+ * path are honoured.
+ *
+ * For `backend: 'mem0'`: the `embed` field in `opts` is ignored
+ * (Mem0 owns its embedding pipeline). The `fsReader`, `log`, `now`,
+ * and `embedInputMaxBytes` fields are forwarded. Mem0-specific
+ * overrides go in `opts.mem0`.
+ */
+export async function buildIndexWithBackend(
+  opts: BuildIndexWithBackendOptions
+): Promise<BuildIndexStats> {
+  const backend = opts.backend ?? DEFAULT_BACKEND;
+  if (backend === 'mem0') {
+    const mem0Opts: BuildMem0IndexOptions = {
+      memoryDir: opts.memoryDir
+    };
+    if (opts.reportsDir !== undefined) mem0Opts.reportsDir = opts.reportsDir;
+    if (opts.fsReader !== undefined) mem0Opts.fsReader = opts.fsReader;
+    if (opts.log !== undefined) mem0Opts.log = opts.log;
+    if (opts.now !== undefined) mem0Opts.now = opts.now;
+    if (opts.embedInputMaxBytes !== undefined) mem0Opts.embedInputMaxBytes = opts.embedInputMaxBytes;
+    if (opts.mem0 !== undefined) {
+      Object.assign(mem0Opts, opts.mem0);
+    }
+    return buildMem0Index(mem0Opts);
+  }
+  return buildIndex(opts);
+}
+
+export interface RetrieveWithBackendOptions
+  extends Omit<RetrievePrecedentOptions, 'embed'> {
+  /** Backend to use. Defaults to `DEFAULT_BACKEND` (`'sqlite-vec'`). */
+  backend?: LibrarianBackendName;
+  /**
+   * Embedder for the `'sqlite-vec'` backend. Required when backend is
+   * `'sqlite-vec'`; ignored when backend is `'mem0'` (Mem0 owns its
+   * embedding pipeline). Defaults to a default Ollama embedder if
+   * omitted on the sqlite-vec path.
+   */
+  embed?: RetrievePrecedentOptions['embed'];
+  /**
+   * Mem0-specific overrides forwarded to `retrieveMem0Precedent`
+   * when `backend === 'mem0'`. Ignored otherwise.
+   */
+  mem0?: Omit<RetrieveMem0PrecedentOptions, 'memoryDir' | 'topN' | 'minSimilarity' | 'kindFilter' | 'warn'>;
+}
+
+/**
+ * Retrieve top-N precedent rows using the selected backend.
+ *
+ * Returns `RetrievedPrecedent[]` in both cases. The Mem0 path's
+ * similarity scores are NOT linearly comparable to the sqlite-vec
+ * path's — Mem0's `MemoryVectorStore` uses unnormalized cosine
+ * similarity. Callers comparing scores across backends should use
+ * the rank order, not the raw numbers.
+ */
+export async function retrieveWithBackend(
+  prompt: string,
+  opts: RetrieveWithBackendOptions
+): Promise<RetrievedPrecedent[]> {
+  const backend = opts.backend ?? DEFAULT_BACKEND;
+  if (backend === 'mem0') {
+    const mem0Opts: RetrieveMem0PrecedentOptions = {
+      memoryDir: opts.memoryDir
+    };
+    if (opts.topN !== undefined) mem0Opts.topN = opts.topN;
+    if (opts.minSimilarity !== undefined) mem0Opts.minSimilarity = opts.minSimilarity;
+    if (opts.kindFilter !== undefined) mem0Opts.kindFilter = opts.kindFilter;
+    if (opts.warn !== undefined) mem0Opts.warn = opts.warn;
+    if (opts.mem0 !== undefined) Object.assign(mem0Opts, opts.mem0);
+    return retrieveMem0Precedent(prompt, mem0Opts);
+  }
+  // sqlite-vec backend — embedder required.
+  const embed = opts.embed ?? createOllamaEmbedder();
+  const sqliteOpts: RetrievePrecedentOptions = {
+    memoryDir: opts.memoryDir,
+    embed
+  };
+  if (opts.dbPath !== undefined) sqliteOpts.dbPath = opts.dbPath;
+  if (opts.topN !== undefined) sqliteOpts.topN = opts.topN;
+  if (opts.minSimilarity !== undefined) sqliteOpts.minSimilarity = opts.minSimilarity;
+  if (opts.kindFilter !== undefined) sqliteOpts.kindFilter = opts.kindFilter;
+  if (opts.warn !== undefined) sqliteOpts.warn = opts.warn;
+  return retrievePrecedent(prompt, sqliteOpts);
+}
+
+export interface PrependWithBackendOptions
+  extends Omit<PrependPrecedentOptions, 'embed'> {
+  /** Backend to use. Defaults to `DEFAULT_BACKEND` (`'sqlite-vec'`). */
+  backend?: LibrarianBackendName;
+  /**
+   * Embedder for the `'sqlite-vec'` backend (optional — defaults to
+   * Ollama). Ignored on the Mem0 path.
+   */
+  embed?: PrependPrecedentOptions['embed'];
+  /** Mem0-specific overrides forwarded to `retrieveMem0Precedent`. */
+  mem0?: RetrieveWithBackendOptions['mem0'];
+}
+
+/**
+ * Pre-spawn prompt augmentation using the selected backend.
+ *
+ * For `backend: 'sqlite-vec'`: equivalent to `prependPrecedent`.
+ *
+ * For `backend: 'mem0'`: same orchestrator-facing shape — the
+ * preamble byte format is identical to the Phase-1 path. Only the
+ * underlying retrieval implementation changes.
+ */
+export async function prependWithBackend(
+  prompt: string,
+  opts: PrependWithBackendOptions
+): Promise<PrependPrecedentResult> {
+  const backend = opts.backend ?? DEFAULT_BACKEND;
+  if (backend === 'mem0') {
+    const retrieveOpts: RetrieveWithBackendOptions = {
+      memoryDir: opts.memoryDir,
+      backend: 'mem0'
+    };
+    if (opts.topN !== undefined) retrieveOpts.topN = opts.topN;
+    if (opts.minSimilarity !== undefined) retrieveOpts.minSimilarity = opts.minSimilarity;
+    if (opts.kindFilter !== undefined) retrieveOpts.kindFilter = opts.kindFilter;
+    if (opts.warn !== undefined) retrieveOpts.warn = opts.warn;
+    if (opts.mem0 !== undefined) retrieveOpts.mem0 = opts.mem0;
+    const precedent = await retrieveWithBackend(prompt, retrieveOpts);
+    if (precedent.length === 0) {
+      return {
+        augmentedPrompt: prompt,
+        augmented: false,
+        precedent: [],
+        preambleLength: 0
+      };
+    }
+    const preamble = formatPrecedentPreamble(precedent);
+    const augmentedPrompt = `${preamble}\n${prompt}`;
+    return {
+      augmentedPrompt,
+      augmented: true,
+      precedent,
+      preambleLength: preamble.length
+    };
+  }
+  // sqlite-vec — delegate to the existing prepend.
+  const passThrough: PrependPrecedentOptions = { memoryDir: opts.memoryDir };
+  if (opts.embed !== undefined) passThrough.embed = opts.embed;
+  if (opts.dbPath !== undefined) passThrough.dbPath = opts.dbPath;
+  if (opts.topN !== undefined) passThrough.topN = opts.topN;
+  if (opts.minSimilarity !== undefined) passThrough.minSimilarity = opts.minSimilarity;
+  if (opts.kindFilter !== undefined) passThrough.kindFilter = opts.kindFilter;
+  if (opts.ollamaUrl !== undefined) passThrough.ollamaUrl = opts.ollamaUrl;
+  if (opts.embedModel !== undefined) passThrough.embedModel = opts.embedModel;
+  if (opts.warn !== undefined) passThrough.warn = opts.warn;
+  return prependPrecedent(prompt, passThrough);
+}

--- a/packages/librarian/src/backends/index.ts
+++ b/packages/librarian/src/backends/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Re-exports for the `@chiefaia/librarian` backend abstraction.
+ *
+ * Two backends today:
+ *   - `'sqlite-vec'` (Phase-1 default) lives in the existing
+ *     `index-builder.ts` + `retrieve.ts` modules.
+ *   - `'mem0'` is the new Mem0-backed alternative shipped per
+ *     validation decision #4.
+ *
+ * The dispatcher functions (`buildIndexWithBackend`,
+ * `retrieveWithBackend`, `prependWithBackend`) accept an optional
+ * `backend?: LibrarianBackendName` parameter and pick the right
+ * implementation. The Phase-1 public functions (`buildIndex`,
+ * `retrievePrecedent`, `prependPrecedent`) remain untouched.
+ *
+ * For library callers that want to talk to a backend directly, both
+ * the dispatcher and the Mem0 surface are exported from this module.
+ */
+
+export {
+  DEFAULT_BACKEND,
+  isLibrarianBackendName,
+  type LibrarianBackendName
+} from './types.js';
+
+export {
+  Mem0Backend,
+  buildMem0Index,
+  retrieveMem0Precedent,
+  buildMem0Config,
+  defaultMemoryFactory,
+  MEM0_INDEX_DB_FILENAME,
+  MEM0_HISTORY_DB_FILENAME,
+  DEFAULT_MEM0_USER_ID,
+  DEFAULT_OLLAMA_URL as MEM0_DEFAULT_OLLAMA_URL,
+  DEFAULT_EMBED_MODEL as MEM0_DEFAULT_EMBED_MODEL,
+  DEFAULT_EMBED_DIM as MEM0_DEFAULT_EMBED_DIM,
+  DEFAULT_EXTRACTION_MODEL as MEM0_DEFAULT_EXTRACTION_MODEL,
+  DEFAULT_MEM0_MIN_SIMILARITY,
+  DEFAULT_MEM0_TOP_N,
+  type BuildMem0IndexOptions,
+  type RetrieveMem0PrecedentOptions,
+  type Mem0BackendOptions,
+  type Mem0MemoryFactory,
+  type Mem0MemoryLike
+} from './mem0-backend.js';
+
+export {
+  buildIndexWithBackend,
+  retrieveWithBackend,
+  prependWithBackend,
+  type BuildIndexWithBackendOptions,
+  type RetrieveWithBackendOptions,
+  type PrependWithBackendOptions
+} from './dispatcher.js';

--- a/packages/librarian/src/backends/mem0-backend.ts
+++ b/packages/librarian/src/backends/mem0-backend.ts
@@ -1,0 +1,495 @@
+/**
+ * Mem0 backend for `@chiefaia/librarian` — alternative retrieval
+ * implementation per validation decision #4 (2026-05-06).
+ *
+ * Architecture summary (full design in
+ * `packages/librarian/src/backends/mem0-backend.DESIGN.md`):
+ *
+ *   - Mem0 OSS Node.js (`mem0ai@^3`), `import { Memory } from
+ *     'mem0ai/oss'`.
+ *   - Configured with `infer: false` on every `add()` so the LLM
+ *     round-trip is bypassed. The local extraction model (Ollama
+ *     `qwen2.5-coder:7b`) is referenced only to satisfy Mem0's
+ *     constructor schema; it is never actually called.
+ *   - Embedder: Ollama `nomic-embed-text` (768 dims) — same model
+ *     Librarian Phase-1 uses, so the two backends share embedding
+ *     space and similarity numbers can be compared directly.
+ *   - Vector store: Mem0's `'memory'` provider, which is misleadingly
+ *     named — it persists to a better-sqlite3 file on disk. We
+ *     override the `dbPath` to live next to the Librarian Phase-1
+ *     index in `<memoryDir>/_librarian-mem0-index.sqlite`.
+ *   - All rows tagged with `userId` (default `'caia-librarian'`) plus
+ *     a `metadata` payload containing `source_path`, `kind`, `slug`,
+ *     `mtime_ms`, `content_sha256`, `content_snippet`.
+ *
+ * The shape conforms to Option E (private package, parameterised
+ * constructor with CAIA defaults, fixture-injected `memoryFactory`
+ * for tests). See `agent_architecture_shape_2026-05-06.md`.
+ *
+ * Hard-constraint adherence:
+ *   - No Anthropic API key required (Mem0's Anthropic SDK is a peer
+ *     dep, only loaded when `llm.provider: 'anthropic'`).
+ *   - No OpenAI API key required (the OpenAI SDK is a hard dep but
+ *     only loaded when `llm.provider: 'openai'` or
+ *     `embedder.provider: 'openai'`).
+ *   - No per-token billing — Ollama runs locally.
+ *   - Markdown stays source of truth — Mem0 stores a 4 KB snippet plus
+ *     sha256 for change detection; the canonical content lives in
+ *     `agent/memory/*.md`. If the index is corrupted or lost, rebuild
+ *     via `caia-librarian-index build --backend mem0`.
+ */
+
+import { createHash } from 'node:crypto';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+
+import {
+  defaultFsReader,
+  pathToSlug
+} from '../source-readers.js';
+import {
+  snippet,
+  truncateUtf8,
+  DEFAULT_EMBED_INPUT_MAX_BYTES
+} from '../index-builder.js';
+import type {
+  BuildIndexStats,
+  FsReader,
+  PrecedentKind,
+  SourceRoots
+} from '../types.js';
+import type { RetrievedPrecedent } from '../retrieve.js';
+
+/**
+ * Subset of Mem0's `Memory` class that this backend uses. Defined as
+ * an interface so tests can inject a fake without depending on the
+ * real `mem0ai` package at unit-test time.
+ *
+ * The real `Memory` class from `mem0ai/oss` satisfies this interface
+ * structurally — TypeScript's structural typing means we don't need
+ * to import or extend it.
+ */
+export interface Mem0MemoryLike {
+  add(
+    content: string,
+    config: { userId: string; infer?: boolean; metadata?: Record<string, unknown> }
+  ): Promise<{ results: Array<{ id: string; memory: string; metadata?: Record<string, unknown> }> }>;
+  search(
+    query: string,
+    config: { filters: Record<string, unknown>; limit?: number }
+  ): Promise<{ results: Array<{ id: string; memory: string; score: number; metadata?: Record<string, unknown> }> }>;
+  getAll(
+    config: { filters: Record<string, unknown>; limit?: number }
+  ): Promise<{ results: Array<{ id: string; memory: string; metadata?: Record<string, unknown> }> }>;
+  delete(id: string): Promise<unknown>;
+  update?(id: string, content: string, metadata?: Record<string, unknown>): Promise<unknown>;
+}
+
+/**
+ * Factory that produces a `Mem0MemoryLike` instance from a config
+ * blob. Production callers omit this and let
+ * `defaultMemoryFactory` import the real `mem0ai/oss` module on
+ * first use. Tests inject a fake.
+ */
+export type Mem0MemoryFactory = (config: Record<string, unknown>) => Promise<Mem0MemoryLike> | Mem0MemoryLike;
+
+/**
+ * Default factory — lazily imports `mem0ai/oss` so the package is
+ * not loaded when the backend isn't selected. Callers that don't
+ * use `'mem0'` pay zero cost.
+ */
+export async function defaultMemoryFactory(config: Record<string, unknown>): Promise<Mem0MemoryLike> {
+  const mod = await import('mem0ai/oss');
+  // The real Memory class is constructed via `new Memory(config)`.
+  const Memory = (mod as { Memory: new (c: Record<string, unknown>) => Mem0MemoryLike }).Memory;
+  return new Memory(config);
+}
+
+/**
+ * Filename of the Mem0-backed index DB. Named distinctly from
+ * Librarian Phase-1's `_librarian-index.sqlite` so both can coexist
+ * during the A/B period.
+ */
+export const MEM0_INDEX_DB_FILENAME = '_librarian-mem0-index.sqlite';
+
+/** Filename of the Mem0 history DB (audit trail of add/update/delete). */
+export const MEM0_HISTORY_DB_FILENAME = '_librarian-mem0-history.sqlite';
+
+/** Default user-id partition for Librarian's Mem0 rows. */
+export const DEFAULT_MEM0_USER_ID = 'caia-librarian';
+
+/** Default Ollama URL — same as Librarian Phase-1. */
+export const DEFAULT_OLLAMA_URL = 'http://127.0.0.1:11434';
+
+/** Default embedding model — same as Librarian Phase-1. */
+export const DEFAULT_EMBED_MODEL = 'nomic-embed-text';
+
+/** Default extraction model — only referenced by Mem0's constructor. */
+export const DEFAULT_EXTRACTION_MODEL = 'qwen2.5-coder:7b';
+
+/** Default embedding dimensionality for nomic-embed-text. */
+export const DEFAULT_EMBED_DIM = 768;
+
+/**
+ * Default minimum cosine similarity for Mem0 retrieval. Mem0's
+ * `MemoryVectorStore.cosineSimilarity` does not normalize the way
+ * Librarian Phase-1 does, so the operating range is shifted lower
+ * (probe results: correct top-1 hits at 0.296–0.463). This default
+ * is more permissive than Librarian Phase-1's 0.4 and will be tuned
+ * against the canonical eval suite in Step 4.
+ */
+export const DEFAULT_MEM0_MIN_SIMILARITY = 0.25;
+
+/** Default top-N for retrieval. Same as Librarian Phase-1. */
+export const DEFAULT_MEM0_TOP_N = 5;
+
+export interface Mem0BackendOptions {
+  /** memoryDir — root for the index DB filename when `vectorStoreDbPath` is unset. Required. */
+  memoryDir: string;
+  /** Override the absolute path of the Mem0 vector-store DB. */
+  vectorStoreDbPath?: string;
+  /** Override the absolute path of the Mem0 history DB. */
+  historyDbPath?: string;
+  /** Mem0 user-id partition. Default: `'caia-librarian'`. */
+  userId?: string;
+  /** Ollama URL. Default: `'http://127.0.0.1:11434'`. */
+  ollamaUrl?: string;
+  /** Embedding model. Default: `'nomic-embed-text'`. */
+  embedModel?: string;
+  /** Embedding dimensionality. Default: 768. */
+  embedDim?: number;
+  /** Extraction model — only for Mem0's constructor schema; never invoked. */
+  extractionModel?: string;
+  /** Test seam — inject a fake `Memory` factory. */
+  memoryFactory?: Mem0MemoryFactory;
+}
+
+export class Mem0Backend {
+  readonly name = 'mem0' as const;
+  readonly indexPath: string;
+  readonly historyDbPath: string;
+  readonly userId: string;
+  readonly ollamaUrl: string;
+  readonly embedModel: string;
+  readonly embedDim: number;
+  readonly extractionModel: string;
+  private readonly memoryFactory: Mem0MemoryFactory;
+  private memory: Mem0MemoryLike | null = null;
+
+  constructor(opts: Mem0BackendOptions) {
+    if (!opts.memoryDir || opts.memoryDir.trim() === '') {
+      throw new Error('Mem0Backend: memoryDir is required');
+    }
+    const root = pathResolve(opts.memoryDir);
+    this.indexPath = opts.vectorStoreDbPath ?? join(root, MEM0_INDEX_DB_FILENAME);
+    this.historyDbPath = opts.historyDbPath ?? join(root, MEM0_HISTORY_DB_FILENAME);
+    this.userId = opts.userId ?? DEFAULT_MEM0_USER_ID;
+    this.ollamaUrl = opts.ollamaUrl ?? DEFAULT_OLLAMA_URL;
+    this.embedModel = opts.embedModel ?? DEFAULT_EMBED_MODEL;
+    this.embedDim = opts.embedDim ?? DEFAULT_EMBED_DIM;
+    this.extractionModel = opts.extractionModel ?? DEFAULT_EXTRACTION_MODEL;
+    this.memoryFactory = opts.memoryFactory ?? defaultMemoryFactory;
+  }
+
+  /**
+   * Get the (lazily constructed) `Mem0MemoryLike` instance. Public
+   * for tests; production callers go through `build()` /
+   * `retrieve()` which initialise on first use.
+   */
+  async getMemory(): Promise<Mem0MemoryLike> {
+    if (this.memory !== null) return this.memory;
+    // Ensure the parent dir exists for the SQLite files.
+    const parent = dirname(this.indexPath);
+    if (!existsSync(parent)) mkdirSync(parent, { recursive: true });
+    const config = buildMem0Config({
+      vectorStoreDbPath: this.indexPath,
+      historyDbPath: this.historyDbPath,
+      ollamaUrl: this.ollamaUrl,
+      embedModel: this.embedModel,
+      embedDim: this.embedDim,
+      extractionModel: this.extractionModel
+    });
+    this.memory = await Promise.resolve(this.memoryFactory(config));
+    return this.memory;
+  }
+}
+
+/**
+ * Build the config object passed to Mem0's `Memory` constructor.
+ * Exported for testing the config shape independently of the
+ * runtime.
+ */
+export function buildMem0Config(opts: {
+  vectorStoreDbPath: string;
+  historyDbPath: string;
+  ollamaUrl: string;
+  embedModel: string;
+  embedDim: number;
+  extractionModel: string;
+}): Record<string, unknown> {
+  return {
+    version: 'v1.1',
+    llm: {
+      provider: 'ollama',
+      config: {
+        model: opts.extractionModel,
+        url: opts.ollamaUrl
+      }
+    },
+    embedder: {
+      provider: 'ollama',
+      config: {
+        model: opts.embedModel,
+        url: opts.ollamaUrl
+      }
+    },
+    vectorStore: {
+      provider: 'memory',
+      config: {
+        collectionName: 'librarian',
+        dimension: opts.embedDim,
+        dbPath: opts.vectorStoreDbPath
+      }
+    },
+    historyDbPath: opts.historyDbPath
+  };
+}
+
+export interface BuildMem0IndexOptions {
+  /** Memory directory containing the agent's markdowns. Required. */
+  memoryDir: string;
+  /** Reports directory. Optional. */
+  reportsDir?: string;
+  /** Override fs reader (tests). */
+  fsReader?: FsReader;
+  /** Logger sink. Defaults to console.error. */
+  log?: (msg: string) => void;
+  /** Clock injection. */
+  now?: () => number;
+  /** Truncation cap before passing content to Mem0. Default 4096. */
+  embedInputMaxBytes?: number;
+  /** Backend instance to use. Constructed from `memoryDir` if omitted. */
+  backend?: Mem0Backend;
+  /** Forwarded constructor options when `backend` is omitted. */
+  backendOptions?: Omit<Mem0BackendOptions, 'memoryDir'>;
+}
+
+/**
+ * Build/refresh a Mem0-backed Librarian index.
+ *
+ * Algorithm:
+ *   1. Walk roots via `fsReader` to get `SourceFile[]`.
+ *   2. Pull existing rows once via `mem.getAll` so we can do
+ *      sha256-based change detection without N round-trips.
+ *   3. For each source: read content, sha256, decide reuse / update /
+ *      add. Truncation matches Librarian Phase-1.
+ *   4. Remove rows whose `source_path` is no longer in the seen set.
+ *   5. Return `BuildIndexStats` shape so callers can format the same
+ *      report they'd format for the Phase-1 backend.
+ */
+export async function buildMem0Index(opts: BuildMem0IndexOptions): Promise<BuildIndexStats> {
+  const fsReader = opts.fsReader ?? defaultFsReader;
+  const log = opts.log ?? ((m: string) => console.error(m));
+  const now = opts.now ?? (() => Date.now());
+  const inputCap = opts.embedInputMaxBytes ?? DEFAULT_EMBED_INPUT_MAX_BYTES;
+  const backend = opts.backend ?? new Mem0Backend({ memoryDir: opts.memoryDir, ...(opts.backendOptions ?? {}) });
+
+  const start = now();
+  const memory = await backend.getMemory();
+
+  const roots: SourceRoots = { memoryDir: opts.memoryDir };
+  if (opts.reportsDir !== undefined) roots.reportsDir = opts.reportsDir;
+  const sources = fsReader.readDir(roots);
+
+  // Bulk load existing rows once to drive sha-based reuse logic.
+  const existing = await listAllByPath(memory, backend.userId);
+
+  let embeddedNew = 0;
+  let reusedUnchanged = 0;
+  let removedStale = 0;
+  let failedEmbed = 0;
+  const seen = new Set<string>();
+  const byKind: Record<string, number> = {};
+
+  for (const src of sources) {
+    seen.add(src.path);
+    try {
+      const content = fsReader.readFile(src.path);
+      const sha = sha256Hex(content);
+      const prior = existing.get(src.path);
+      if (
+        prior !== undefined &&
+        prior.metadata?.['content_sha256'] === sha &&
+        prior.metadata?.['mtime_ms'] === src.mtimeMs
+      ) {
+        reusedUnchanged++;
+        bumpKind(byKind, src.kind);
+        continue;
+      }
+      const truncated = inputCap > 0 ? truncateUtf8(content, inputCap) : content;
+      const metadata: Record<string, unknown> = {
+        source_path: src.path,
+        kind: src.kind,
+        slug: pathToSlug(src.path),
+        mtime_ms: src.mtimeMs,
+        content_sha256: sha,
+        content_snippet: snippet(content),
+        indexed_at_ms: now()
+      };
+      if (prior !== undefined) {
+        // Replace: delete + add. Mem0's update() exists but is not
+        // available across all v3.x patch versions; the round-trip
+        // delta is small for our scale.
+        try {
+          await memory.delete(prior.id);
+        } catch (e) {
+          log(`librarian-mem0: warn deleting prior row ${prior.id}: ${describeError(e)}`);
+        }
+      }
+      await memory.add(truncated, {
+        userId: backend.userId,
+        infer: false,
+        metadata
+      });
+      embeddedNew++;
+      bumpKind(byKind, src.kind);
+    } catch (e) {
+      failedEmbed++;
+      log(`librarian-mem0: failed to index ${src.path}: ${describeError(e)}`);
+    }
+  }
+
+  // Remove rows whose source no longer exists on disk.
+  for (const [path, row] of existing.entries()) {
+    if (seen.has(path)) continue;
+    try {
+      await memory.delete(row.id);
+      removedStale++;
+    } catch (e) {
+      log(`librarian-mem0: warn deleting stale ${path}: ${describeError(e)}`);
+    }
+  }
+
+  return {
+    scanned: sources.length,
+    embeddedNew,
+    reusedUnchanged,
+    removedStale,
+    failedEmbed,
+    elapsedMs: now() - start,
+    indexPath: backend.indexPath,
+    byKind
+  };
+}
+
+export interface RetrieveMem0PrecedentOptions {
+  /** Same memoryDir used at build time. */
+  memoryDir: string;
+  /** Top-N results. Default 5. */
+  topN?: number;
+  /** Minimum similarity. Default 0.25 for the Mem0 backend. */
+  minSimilarity?: number;
+  /** Optional kind filter. */
+  kindFilter?: PrecedentKind | PrecedentKind[];
+  /** Backend instance to use; constructed from `memoryDir` if omitted. */
+  backend?: Mem0Backend;
+  /** Forwarded constructor options when `backend` is omitted. */
+  backendOptions?: Omit<Mem0BackendOptions, 'memoryDir'>;
+  /** Optional warn sink. */
+  warn?: (msg: string) => void;
+}
+
+/**
+ * Retrieve top-N precedent rows from the Mem0-backed index. Mirrors
+ * the contract of `retrievePrecedent` from Librarian Phase-1.
+ *
+ * Returns an empty array if Mem0 hasn't been built yet (the
+ * MemoryVectorStore creates an empty SQLite table on first
+ * construction; an empty table searches as empty).
+ */
+export async function retrieveMem0Precedent(
+  prompt: string,
+  opts: RetrieveMem0PrecedentOptions
+): Promise<RetrievedPrecedent[]> {
+  const topN = opts.topN ?? DEFAULT_MEM0_TOP_N;
+  const minSim = opts.minSimilarity ?? DEFAULT_MEM0_MIN_SIMILARITY;
+  const warn = opts.warn ?? ((_m: string) => undefined);
+  const backend = opts.backend ?? new Mem0Backend({ memoryDir: opts.memoryDir, ...(opts.backendOptions ?? {}) });
+
+  const memory = await backend.getMemory();
+  const filters: Record<string, unknown> = { user_id: backend.userId };
+  if (opts.kindFilter !== undefined) {
+    const kinds = Array.isArray(opts.kindFilter) ? opts.kindFilter : [opts.kindFilter];
+    if (kinds.length > 0) filters['kind'] = { in: kinds };
+  }
+
+  let resp;
+  try {
+    resp = await memory.search(prompt, { filters, limit: topN });
+  } catch (e) {
+    warn(`librarian-mem0: search failed: ${describeError(e)}`);
+    return [];
+  }
+
+  const out: RetrievedPrecedent[] = [];
+  for (const r of resp.results ?? []) {
+    if (typeof r.score !== 'number' || !Number.isFinite(r.score)) continue;
+    if (r.score < minSim) continue;
+    const md = r.metadata ?? {};
+    const path = typeof md['source_path'] === 'string' ? md['source_path'] : '';
+    const kindRaw = md['kind'];
+    const kind: PrecedentKind = (typeof kindRaw === 'string' ? kindRaw : 'other') as PrecedentKind;
+    const slug = typeof md['slug'] === 'string' ? md['slug'] : '';
+    const snippetText = typeof md['content_snippet'] === 'string'
+      ? md['content_snippet']
+      : r.memory ?? '';
+    const mtimeMs = typeof md['mtime_ms'] === 'number' ? md['mtime_ms'] : 0;
+    if (path === '' || slug === '') {
+      // Skip rows that lack our own metadata (e.g. were inserted by
+      // some other producer against the same DB partition). This
+      // shouldn't happen given userId partitioning but is defensive.
+      continue;
+    }
+    out.push({ path, kind, slug, similarity: r.score, snippet: snippetText, mtimeMs });
+  }
+
+  out.sort((a, b) => {
+    if (b.similarity !== a.similarity) return b.similarity - a.similarity;
+    return b.mtimeMs - a.mtimeMs;
+  });
+
+  return out.slice(0, topN);
+}
+
+interface ExistingRow {
+  id: string;
+  metadata: Record<string, unknown>;
+}
+
+async function listAllByPath(memory: Mem0MemoryLike, userId: string): Promise<Map<string, ExistingRow>> {
+  const out = new Map<string, ExistingRow>();
+  // Mem0's getAll has a default limit of 100; for our corpus (hundreds
+  // of files) we set it high. The factory pattern ensures the
+  // underlying provider can handle this.
+  const resp = await memory.getAll({ filters: { user_id: userId }, limit: 100_000 });
+  for (const r of resp.results ?? []) {
+    const md = r.metadata ?? {};
+    const sp = typeof md['source_path'] === 'string' ? md['source_path'] : null;
+    if (sp === null) continue;
+    out.set(sp, { id: r.id, metadata: md });
+  }
+  return out;
+}
+
+function bumpKind(byKind: Record<string, number>, kind: PrecedentKind): void {
+  byKind[kind] = (byKind[kind] ?? 0) + 1;
+}
+
+function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/packages/librarian/src/backends/types.ts
+++ b/packages/librarian/src/backends/types.ts
@@ -1,0 +1,50 @@
+/**
+ * @chiefaia/librarian backend types — shared surface for the
+ * pluggable retrieval backends introduced by validation decision #4
+ * (operator-approved 2026-05-06).
+ *
+ * Two backends are supported:
+ *
+ *   - `'sqlite-vec'`  (default) — Librarian Phase-1's existing
+ *     better-sqlite3 + JS-side cosine implementation. Named
+ *     `'sqlite-vec'` in the user-facing flag for consistency with the
+ *     campaign brief; the actual implementation does NOT use the
+ *     sqlite-vec extension.
+ *
+ *   - `'mem0'` — Mem0 OSS Node.js (`mem0ai/oss`). Configured with
+ *     `infer: false` (no LLM round-trip) + Ollama embedder + `'memory'`
+ *     vector-store provider (which is misleadingly named — it is
+ *     actually better-sqlite3 + JS-side cosine, with a different
+ *     schema from Librarian Phase-1).
+ *
+ * Both backends honour the same hard constraints from
+ * `feedback_no_api_key_billing.md` — no Anthropic API key, no OpenAI
+ * API key, no per-token billing. Embeddings come from a local Ollama
+ * daemon (`nomic-embed-text` by default).
+ *
+ * Markdown remains source of truth in both backends. The vector store
+ * is purely an index; if it corrupts or is lost, rebuild from
+ * `agent/memory/*.md` + `~/Documents/projects/reports/*.md`.
+ */
+
+/**
+ * The user-facing backend choice flag. `'sqlite-vec'` is the
+ * Librarian Phase-1 default; `'mem0'` is the new Mem0-backed option
+ * shipped per validation decision #4.
+ */
+export type LibrarianBackendName = 'sqlite-vec' | 'mem0';
+
+/**
+ * Default backend when callers don't supply one. Stays `'sqlite-vec'`
+ * for backwards compatibility until A/B parity is confirmed and the
+ * operator explicitly approves a default-flip.
+ */
+export const DEFAULT_BACKEND: LibrarianBackendName = 'sqlite-vec';
+
+/**
+ * Type guard for the runtime CLI parser. Returns true if `v` is a
+ * known backend name; false otherwise.
+ */
+export function isLibrarianBackendName(v: unknown): v is LibrarianBackendName {
+  return v === 'sqlite-vec' || v === 'mem0';
+}

--- a/packages/librarian/src/index.ts
+++ b/packages/librarian/src/index.ts
@@ -1,13 +1,20 @@
 /**
  * @chiefaia/librarian — public surface.
  *
- * Phase 1 (this release):
+ * Phase 1 (better-sqlite3 + JS-side cosine, the default backend):
  *   - Corpus aggregator + classifier (`source-readers.ts`)
  *   - SQLite index (`index-store.ts`)
  *   - Index builder with Ollama embeddings (`index-builder.ts`)
  *   - Retrieval API (`retrieve.ts`)
  *   - Pre-spawn prompt augmentation (`prepend.ts`)
  *   - Three CLIs (caia-librarian-index|retrieve|prepend)
+ *
+ * Phase 2 (validation decision #4, 2026-05-06):
+ *   - Backend abstraction in `./backends/`
+ *   - Mem0 OSS Node.js as an alternative retrieval backend
+ *   - Dispatcher functions (`buildIndexWithBackend`,
+ *     `retrieveWithBackend`, `prependWithBackend`) accept an
+ *     optional `backend?: 'sqlite-vec' | 'mem0'` flag.
  *
  * Composes with `@chiefaia/mentor-retrieval`'s prepend so an
  * orchestrator can pipe BOTH preambles in either order.
@@ -44,6 +51,8 @@ export {
   buildIndex,
   sha256Hex,
   snippet,
+  truncateUtf8,
+  DEFAULT_EMBED_INPUT_MAX_BYTES,
   type BuildIndexOptions
 } from './index-builder.js';
 
@@ -75,3 +84,35 @@ export {
   type SourceFile,
   type SourceRoots
 } from './types.js';
+
+// Phase-2 backend abstraction (validation decision #4, 2026-05-06).
+export {
+  DEFAULT_BACKEND,
+  isLibrarianBackendName,
+  Mem0Backend,
+  buildMem0Index,
+  retrieveMem0Precedent,
+  buildMem0Config,
+  defaultMemoryFactory,
+  buildIndexWithBackend,
+  retrieveWithBackend,
+  prependWithBackend,
+  MEM0_INDEX_DB_FILENAME,
+  MEM0_HISTORY_DB_FILENAME,
+  DEFAULT_MEM0_USER_ID,
+  MEM0_DEFAULT_OLLAMA_URL,
+  MEM0_DEFAULT_EMBED_MODEL,
+  MEM0_DEFAULT_EMBED_DIM,
+  MEM0_DEFAULT_EXTRACTION_MODEL,
+  DEFAULT_MEM0_MIN_SIMILARITY,
+  DEFAULT_MEM0_TOP_N,
+  type LibrarianBackendName,
+  type BuildMem0IndexOptions,
+  type RetrieveMem0PrecedentOptions,
+  type Mem0BackendOptions,
+  type Mem0MemoryFactory,
+  type Mem0MemoryLike,
+  type BuildIndexWithBackendOptions,
+  type RetrieveWithBackendOptions,
+  type PrependWithBackendOptions
+} from './backends/index.js';

--- a/packages/librarian/tests/backends/mem0-backend.fixture.ts
+++ b/packages/librarian/tests/backends/mem0-backend.fixture.ts
@@ -1,0 +1,128 @@
+/**
+ * In-memory fake of `Mem0MemoryLike` for unit tests of the Mem0
+ * backend. Implements the surface used by the production backend
+ * (`add`, `search`, `getAll`, `delete`) without touching the real
+ * `mem0ai` package, Ollama, or any filesystem.
+ *
+ * Embedding strategy: a deterministic 32-dim hashed bag-of-words —
+ * the same toy embedder Librarian's existing end-to-end test uses,
+ * so similarity numbers are predictable and the tests are stable.
+ *
+ * Filter coverage: `eq` on string fields (e.g., `user_id: 'caia'`)
+ * and `in` on `kind` are supported. Anything more elaborate is
+ * out-of-scope for the fake — the production `Mem0Backend` only
+ * uses these two operators.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type { Mem0MemoryLike } from '../../src/backends/mem0-backend.js';
+
+interface Row {
+  id: string;
+  memory: string;
+  vector: Float32Array;
+  metadata: Record<string, unknown>;
+}
+
+export interface FakeMemoryOptions {
+  /** Vector dimensionality for the toy embedder. Default 32. */
+  dimension?: number;
+  /** Override the random id generator for fully deterministic tests. */
+  idGenerator?: () => string;
+}
+
+export function createFakeMemory(opts: FakeMemoryOptions = {}): Mem0MemoryLike & {
+  rows: Map<string, Row>;
+  reset: () => void;
+} {
+  const dim = opts.dimension ?? 32;
+  const idGen = opts.idGenerator ?? randomUUID;
+  const rows = new Map<string, Row>();
+
+  const embed = (text: string): Float32Array => {
+    const v = new Float32Array(dim);
+    const tokens = text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    for (const t of tokens) {
+      let h = 0;
+      for (let i = 0; i < t.length; i++) h = (h * 31 + t.charCodeAt(i)) | 0;
+      const idx = ((h % dim) + dim) % dim;
+      v[idx] = (v[idx] ?? 0) + 1;
+    }
+    let norm = 0;
+    for (let i = 0; i < dim; i++) norm += (v[i] ?? 0) * (v[i] ?? 0);
+    norm = Math.sqrt(norm);
+    if (norm > 0) {
+      for (let i = 0; i < dim; i++) v[i] = (v[i] ?? 0) / norm;
+    }
+    return v;
+  };
+
+  const cosine = (a: Float32Array, b: Float32Array): number => {
+    let dot = 0;
+    for (let i = 0; i < a.length; i++) dot += (a[i] ?? 0) * (b[i] ?? 0);
+    return dot;
+  };
+
+  const matchFilters = (md: Record<string, unknown>, filters: Record<string, unknown>): boolean => {
+    for (const [k, v] of Object.entries(filters)) {
+      if (k === 'user_id') {
+        if (md['user_id'] !== v) return false;
+        continue;
+      }
+      if (typeof v === 'object' && v !== null && 'in' in v) {
+        const arr = (v as { in: unknown[] }).in;
+        if (!Array.isArray(arr) || !arr.includes(md[k])) return false;
+        continue;
+      }
+      if (md[k] !== v) return false;
+    }
+    return true;
+  };
+
+  return {
+    rows,
+    reset() { rows.clear(); },
+
+    async add(content, config) {
+      const userId = config.userId;
+      const md: Record<string, unknown> = { ...(config.metadata ?? {}), user_id: userId };
+      const id = idGen();
+      rows.set(id, { id, memory: content, vector: embed(content), metadata: md });
+      return { results: [{ id, memory: content, metadata: { event: 'ADD' } }] };
+    },
+
+    async search(query, config) {
+      const queryVec = embed(query);
+      const limit = config.limit ?? 5;
+      const scored: Array<{ id: string; memory: string; score: number; metadata: Record<string, unknown> }> = [];
+      for (const row of rows.values()) {
+        if (!matchFilters(row.metadata, config.filters)) continue;
+        scored.push({
+          id: row.id,
+          memory: row.memory,
+          score: cosine(queryVec, row.vector),
+          metadata: { ...row.metadata }
+        });
+      }
+      scored.sort((a, b) => b.score - a.score);
+      return { results: scored.slice(0, limit) };
+    },
+
+    async getAll(config) {
+      const limit = config.limit ?? 100;
+      const out: Array<{ id: string; memory: string; metadata: Record<string, unknown> }> = [];
+      for (const row of rows.values()) {
+        if (!matchFilters(row.metadata, config.filters)) continue;
+        out.push({ id: row.id, memory: row.memory, metadata: { ...row.metadata } });
+        if (out.length >= limit) break;
+      }
+      return { results: out };
+    },
+
+    async delete(id) {
+      rows.delete(id);
+      return { id };
+    }
+  };
+}

--- a/packages/librarian/tests/backends/mem0-backend.test.ts
+++ b/packages/librarian/tests/backends/mem0-backend.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Unit tests for the Mem0 backend.
+ *
+ * The fake `Memory` (in `mem0-backend.fixture.ts`) means these tests
+ * never touch Ollama, the network, or the real `mem0ai` package.
+ * Production wiring is exercised by the same code path; only the
+ * `memoryFactory` constructor seam is replaced.
+ *
+ * Hard-constraint reminder: per `feedback_no_api_key_billing.md`, no
+ * test (and no production code path) is allowed to require an
+ * Anthropic or OpenAI API key. The fake satisfies the
+ * `Mem0MemoryLike` interface entirely in-process, so the test suite
+ * is offline-clean.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMem0Index,
+  buildMem0Config,
+  Mem0Backend,
+  retrieveMem0Precedent,
+  DEFAULT_MEM0_USER_ID,
+  MEM0_INDEX_DB_FILENAME,
+  type Mem0BackendOptions
+} from '../../src/backends/mem0-backend.js';
+import {
+  buildIndexWithBackend,
+  retrieveWithBackend,
+  prependWithBackend
+} from '../../src/backends/dispatcher.js';
+import { isLibrarianBackendName, DEFAULT_BACKEND } from '../../src/backends/types.js';
+
+import { createFakeMemory } from './mem0-backend.fixture.js';
+
+function buildBackendWithFake(overrides: Partial<Mem0BackendOptions> = {}): {
+  backend: Mem0Backend;
+  fake: ReturnType<typeof createFakeMemory>;
+  memoryDir: string;
+  cleanup: () => void;
+} {
+  const tmp = mkdtempSync(join(tmpdir(), 'librarian-mem0-test-'));
+  const memoryDir = join(tmp, 'memory');
+  mkdirSync(memoryDir, { recursive: true });
+  const fake = createFakeMemory({ dimension: 32 });
+  const backend = new Mem0Backend({
+    memoryDir,
+    userId: 'fixture-corpus',
+    memoryFactory: () => fake,
+    ...overrides
+  });
+  return {
+    backend,
+    fake,
+    memoryDir,
+    cleanup: () => rmSync(tmp, { recursive: true, force: true })
+  };
+}
+
+describe('isLibrarianBackendName', () => {
+  it('accepts known backend names', () => {
+    expect(isLibrarianBackendName('sqlite-vec')).toBe(true);
+    expect(isLibrarianBackendName('mem0')).toBe(true);
+  });
+  it('rejects unknown values', () => {
+    expect(isLibrarianBackendName('qdrant')).toBe(false);
+    expect(isLibrarianBackendName(undefined)).toBe(false);
+    expect(isLibrarianBackendName(42)).toBe(false);
+  });
+  it('exposes a sane default', () => {
+    expect(DEFAULT_BACKEND).toBe('sqlite-vec');
+  });
+});
+
+describe('Mem0Backend constructor', () => {
+  it('throws on missing memoryDir', () => {
+    expect(() => new Mem0Backend({ memoryDir: '' })).toThrow(/memoryDir is required/);
+  });
+  it('applies CAIA defaults when only memoryDir is provided', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'librarian-defaults-'));
+    try {
+      const b = new Mem0Backend({ memoryDir: tmp });
+      expect(b.userId).toBe(DEFAULT_MEM0_USER_ID);
+      expect(b.embedModel).toBe('nomic-embed-text');
+      expect(b.embedDim).toBe(768);
+      expect(b.ollamaUrl).toBe('http://127.0.0.1:11434');
+      expect(b.indexPath.endsWith(MEM0_INDEX_DB_FILENAME)).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+  it('honours all constructor overrides (parameterisation works)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'librarian-overrides-'));
+    try {
+      const b = new Mem0Backend({
+        memoryDir: tmp,
+        vectorStoreDbPath: '/custom/vector.db',
+        historyDbPath: '/custom/history.db',
+        userId: 'fixture-corpus',
+        ollamaUrl: 'http://localhost:9999',
+        embedModel: 'nomic-embed-text',
+        embedDim: 1536,
+        extractionModel: 'llama3.1:8b'
+      });
+      expect(b.indexPath).toBe('/custom/vector.db');
+      expect(b.historyDbPath).toBe('/custom/history.db');
+      expect(b.userId).toBe('fixture-corpus');
+      expect(b.ollamaUrl).toBe('http://localhost:9999');
+      expect(b.embedDim).toBe(1536);
+      expect(b.extractionModel).toBe('llama3.1:8b');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildMem0Config', () => {
+  it('produces a Mem0 config that pins infer to false implicitly via metadata only', () => {
+    const c = buildMem0Config({
+      vectorStoreDbPath: '/tmp/vector.db',
+      historyDbPath: '/tmp/history.db',
+      ollamaUrl: 'http://127.0.0.1:11434',
+      embedModel: 'nomic-embed-text',
+      embedDim: 768,
+      extractionModel: 'qwen2.5-coder:7b'
+    });
+    expect(c).toMatchObject({
+      version: 'v1.1',
+      llm: { provider: 'ollama', config: { model: 'qwen2.5-coder:7b', url: 'http://127.0.0.1:11434' } },
+      embedder: { provider: 'ollama', config: { model: 'nomic-embed-text', url: 'http://127.0.0.1:11434' } },
+      vectorStore: { provider: 'memory', config: { dimension: 768, dbPath: '/tmp/vector.db' } },
+      historyDbPath: '/tmp/history.db'
+    });
+  });
+});
+
+describe('buildMem0Index', () => {
+  it('embeds new files and tracks per-kind counts', async () => {
+    const { backend, fake, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(
+        join(memoryDir, 'mentor_agent_directive.md'),
+        'Mentor agent captures incidents and distills lessons over time.'
+      );
+      writeFileSync(
+        join(memoryDir, 'feedback_no_api_key_billing.md'),
+        'Subscription only — never use Anthropic API key.'
+      );
+      writeFileSync(
+        join(memoryDir, 'master_backlog_sequencing_2026-05-05.md'),
+        'Master backlog sequencing for the current campaign.'
+      );
+
+      const stats = await buildMem0Index({
+        memoryDir,
+        backend,
+        log: () => undefined,
+        now: () => 1_700_000_000_000
+      });
+      expect(stats.scanned).toBe(3);
+      expect(stats.embeddedNew).toBe(3);
+      expect(stats.reusedUnchanged).toBe(0);
+      expect(stats.removedStale).toBe(0);
+      expect(stats.failedEmbed).toBe(0);
+      expect(Object.keys(stats.byKind).sort()).toEqual(['directive', 'feedback', 'master'].sort());
+      expect(fake.rows.size).toBe(3);
+      // Each row should have the metadata schema we promised.
+      for (const row of fake.rows.values()) {
+        expect(row.metadata).toMatchObject({
+          source_path: expect.stringMatching(/\.md$/),
+          kind: expect.any(String),
+          slug: expect.any(String),
+          mtime_ms: expect.any(Number),
+          content_sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+          content_snippet: expect.any(String),
+          user_id: 'fixture-corpus'
+        });
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('reuses unchanged files (sha + mtime match)', async () => {
+    const { backend, fake, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'unchanged content');
+      const first = await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      expect(first.embeddedNew).toBe(1);
+      expect(first.reusedUnchanged).toBe(0);
+      const second = await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      expect(second.embeddedNew).toBe(0);
+      expect(second.reusedUnchanged).toBe(1);
+      expect(fake.rows.size).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('removes rows whose source files vanished from disk', async () => {
+    const { backend, fake, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'A');
+      writeFileSync(join(memoryDir, 'feedback_x.md'), 'B');
+      const first = await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      expect(first.embeddedNew).toBe(2);
+      // Now remove one file and rebuild.
+      rmSync(join(memoryDir, 'feedback_x.md'));
+      const second = await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      expect(second.removedStale).toBe(1);
+      expect(fake.rows.size).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('truncates content over the cap before passing to Mem0', async () => {
+    const { backend, fake, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      const longContent = 'x'.repeat(10_000);
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), longContent);
+      await buildMem0Index({
+        memoryDir,
+        backend,
+        log: () => undefined,
+        embedInputMaxBytes: 1024
+      });
+      // The fake stores `memory` = the truncated input.
+      const row = Array.from(fake.rows.values())[0];
+      expect(row).toBeDefined();
+      expect(row?.memory.length).toBe(1024);
+      // But the snippet stored in metadata is the (capped) full content.
+      const snippetText = row?.metadata['content_snippet'] as string | undefined;
+      expect(snippetText).toBeDefined();
+      expect(snippetText?.length).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('retrieveMem0Precedent', () => {
+  it('returns rows ordered by similarity desc and respects topN', async () => {
+    const { backend, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'mentor lessons incidents distill agent');
+      writeFileSync(join(memoryDir, 'curator_agent_directive.md'), 'curator industry opportunities');
+      writeFileSync(join(memoryDir, 'master_backlog_sequencing_2026-05-05.md'), 'master backlog scheduling items');
+      await buildMem0Index({ memoryDir, backend, log: () => undefined });
+
+      const out = await retrieveMem0Precedent('mentor lessons captured by the agent', {
+        memoryDir,
+        backend,
+        topN: 2,
+        minSimilarity: 0.0
+      });
+      expect(out.length).toBe(2);
+      expect(out[0]?.slug).toBe('mentor_agent_directive');
+      // Similarity should be > 0 since at least one token matches.
+      expect(out[0]?.similarity).toBeGreaterThan(0);
+      // Sorted desc.
+      expect(out[0]?.similarity).toBeGreaterThanOrEqual(out[1]?.similarity ?? 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('honours kindFilter to scope results', async () => {
+    const { backend, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'mentor agent doc');
+      writeFileSync(join(memoryDir, 'feedback_no_api_key_billing.md'), 'mentor agent topic in feedback file');
+      await buildMem0Index({ memoryDir, backend, log: () => undefined });
+
+      const onlyFeedback = await retrieveMem0Precedent('mentor agent', {
+        memoryDir,
+        backend,
+        topN: 5,
+        minSimilarity: 0.0,
+        kindFilter: 'feedback'
+      });
+      expect(onlyFeedback.length).toBe(1);
+      expect(onlyFeedback[0]?.kind).toBe('feedback');
+
+      const both = await retrieveMem0Precedent('mentor agent', {
+        memoryDir,
+        backend,
+        topN: 5,
+        minSimilarity: 0.0,
+        kindFilter: ['feedback', 'directive']
+      });
+      expect(both.length).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns empty array when no results clear the threshold', async () => {
+    const { backend, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'mentor doc');
+      await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      const out = await retrieveMem0Precedent('zzqxxq query that does not match anything', {
+        memoryDir,
+        backend,
+        topN: 5,
+        minSimilarity: 0.99
+      });
+      expect(out).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns empty array when retrieval errors (graceful degradation)', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'librarian-mem0-error-'));
+    try {
+      const memoryDir = join(tmp, 'memory');
+      mkdirSync(memoryDir);
+      const backend = new Mem0Backend({
+        memoryDir,
+        memoryFactory: () => ({
+          // Minimal fake that throws on search.
+          add: async () => ({ results: [] }),
+          search: async () => { throw new Error('synthetic failure'); },
+          getAll: async () => ({ results: [] }),
+          delete: async () => undefined
+        })
+      });
+      let warned = '';
+      const out = await retrieveMem0Precedent('hello', {
+        memoryDir,
+        backend,
+        topN: 5,
+        minSimilarity: 0,
+        warn: (m) => { warned = m; }
+      });
+      expect(out).toEqual([]);
+      expect(warned).toMatch(/synthetic failure/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('dispatcher: backend flag', () => {
+  it('buildIndexWithBackend(backend: "mem0") routes to Mem0', async () => {
+    const { backend, fake, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'doc one');
+      const stats = await buildIndexWithBackend({
+        memoryDir,
+        embed: async () => ({ vector: new Float32Array(768), model: 'unused' }),
+        log: () => undefined,
+        backend: 'mem0',
+        mem0: { backend }
+      });
+      expect(stats.scanned).toBe(1);
+      expect(stats.embeddedNew).toBe(1);
+      expect(fake.rows.size).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('retrieveWithBackend(backend: "mem0") returns Mem0 results', async () => {
+    const { backend, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'mentor agent topic');
+      await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      const out = await retrieveWithBackend('mentor agent', {
+        memoryDir,
+        backend: 'mem0',
+        topN: 5,
+        minSimilarity: 0,
+        mem0: { backend }
+      });
+      expect(out.length).toBe(1);
+      expect(out[0]?.slug).toBe('mentor_agent_directive');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('prependWithBackend(backend: "mem0") augments the prompt with the same preamble format', async () => {
+    const { backend, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'mentor agent topic');
+      await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      const r = await prependWithBackend('mentor agent', {
+        memoryDir,
+        backend: 'mem0',
+        topN: 5,
+        minSimilarity: 0,
+        mem0: { backend }
+      });
+      expect(r.augmented).toBe(true);
+      expect(r.precedent.length).toBe(1);
+      // Same preamble as Phase-1.
+      expect(r.augmentedPrompt.startsWith('Precedent from prior decisions — for context:')).toBe(true);
+      // Original prompt is preserved at the bottom.
+      expect(r.augmentedPrompt.endsWith('mentor agent')).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('prependWithBackend with no matches returns the original prompt unchanged', async () => {
+    const { backend, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'mentor agent');
+      await buildMem0Index({ memoryDir, backend, log: () => undefined });
+      const r = await prependWithBackend('totally unrelated zzqxxq', {
+        memoryDir,
+        backend: 'mem0',
+        topN: 5,
+        minSimilarity: 0.99,  // unreachable threshold
+        mem0: { backend }
+      });
+      expect(r.augmented).toBe(false);
+      expect(r.augmentedPrompt).toBe('totally unrelated zzqxxq');
+      expect(r.precedent).toEqual([]);
+      expect(r.preambleLength).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,24 +36,18 @@ importers:
         specifier: ^3.3.7
         version: 3.3.11
     devDependencies:
-      '@types/jest':
-        specifier: ^29.0.0
-        version: 29.5.14
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.39
-      jest:
-        specifier: ^29.0.0
-        version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
-      ts-jest:
-        specifier: ^29.0.0
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   apps/dashboard:
     dependencies:
@@ -250,7 +244,7 @@ importers:
         version: 12.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260506.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
       hono:
         specifier: ^4.12.14
         version: 4.12.15
@@ -391,12 +385,18 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
+      '@vitest/coverage-v8':
+        specifier: ^1.6.0
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(jsdom@26.1.0))
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   apps/story-backfiller:
     devDependencies:
@@ -502,6 +502,9 @@ importers:
 
   configs/vitest-config:
     dependencies:
+      '@vitest/coverage-v8':
+        specifier: '>=1'
+        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(jsdom@26.1.0))
       vitest:
         specifier: '>=1'
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
@@ -732,6 +735,9 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/capability-broker:
     dependencies:
@@ -987,7 +993,11 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
-  packages/dedup-engine: {}
+  packages/dedup-engine:
+    devDependencies:
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   packages/dev-inspector:
     dependencies:
@@ -1232,6 +1242,9 @@ importers:
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.9.0
+      mem0ai:
+        specifier: ^3.0.2
+        version: 3.0.2(@anthropic-ai/sdk@0.36.3)(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260506.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)))(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@mistralai/mistralai@1.15.1)(@qdrant/js-client-rest@1.13.0(typescript@5.9.3))(@supabase/supabase-js@2.104.1)(@types/jest@29.5.14)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0)(compromise@14.15.0)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8))(ollama@0.5.18)(pg@8.20.0)(redis@4.7.1)(ws@8.20.0)
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*
@@ -1574,7 +1587,7 @@ importers:
         version: 20.19.39
       promptfoo:
         specifier: ^0.103.0
-        version: 0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
+        version: 0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@cloudflare/workers-types@4.20260506.1)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1652,6 +1665,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   packages/skills-registry:
     dependencies:
@@ -1821,7 +1837,7 @@ importers:
         version: 12.9.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260506.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0)
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*
@@ -2065,6 +2081,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@anthropic-ai/sdk@0.36.3':
     resolution: {integrity: sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==}
@@ -2349,6 +2369,17 @@ packages:
     resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
     engines: {node: '>=20.0.0'}
 
+  '@azure/core-http-compat@2.4.0':
+    resolution: {integrity: sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
   '@azure/core-rest-pipeline@1.23.0':
     resolution: {integrity: sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==}
     engines: {node: '>=20.0.0'}
@@ -2384,6 +2415,10 @@ packages:
   '@azure/openai-assistants@1.0.0-beta.6':
     resolution: {integrity: sha512-gINKKcqTpR0neF+36Owe0Q1u1JO3IK6clBzWTfZ+9V/TkQq+LoUgp5F8dKvSv/YChfwEpZA2r1DWCwNE07eYIQ==}
     engines: {node: '>=18.0.0'}
+
+  '@azure/search-documents@12.2.0':
+    resolution: {integrity: sha512-4+Qw+qaGqnkdUCq/vEFzk/bkROogTvdbPb1fmI8poxNfDDN1q2WHxBmhI7CYwesrBj1yXC4i5E0aISBxZqZi0g==}
+    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2626,6 +2661,9 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@cloudflare/workers-types@4.20260506.1':
+    resolution: {integrity: sha512-IKv/C08utEbAqEu2zr0/3CMf1MbYrl7x0Z1UsrnMs4xxfIN81vtGTRduCZb7xJQpaICQPe0Sa6fhHlZmUXrMjw==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -3423,6 +3461,10 @@ packages:
     engines: {node: '>=18.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
 
@@ -3437,6 +3479,15 @@ packages:
 
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
+
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@googleapis/sheets@9.8.0':
     resolution: {integrity: sha512-PyzLalHcx25o7+jDYrEm62IsMnNvtBGVJi9Mr2zeIUbTp4y1tBJnPAkQCTBPvmqc14DQchxXnYqsNPIYzkIKmw==}
@@ -3925,6 +3976,9 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mistralai/mistralai@1.15.1':
+    resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -3934,6 +3988,9 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
 
   '@msgpack/msgpack@3.1.3':
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
@@ -4298,6 +4355,81 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@qdrant/js-client-rest@1.13.0':
+    resolution: {integrity: sha512-bewMtnXlGvhhnfXsp0sLoLXOGvnrCM15z9lNlG0Snp021OedNAnRtKkerjk5vkOcbQWUmJHXYCuxDfcT93aSkA==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@qdrant/openapi-typescript-fetch@1.2.6':
+    resolution: {integrity: sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==}
+    engines: {node: '>=18.0.0', pnpm: '>=8'}
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -4449,6 +4581,9 @@ packages:
   '@sentry/utils@6.19.7':
     resolution: {integrity: sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==}
     engines: {node: '>=6'}
+
+  '@sevinf/maybe@0.5.0':
+    resolution: {integrity: sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg==}
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -5005,6 +5140,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
@@ -5013,6 +5151,12 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -5156,6 +5300,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@1.6.1':
+    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+    peerDependencies:
+      vitest: 1.6.1
+
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
@@ -5236,6 +5385,12 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  afinn-165-financialmarketnews@3.0.0:
+    resolution: {integrity: sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==}
+
+  afinn-165@2.0.2:
+    resolution: {integrity: sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -5324,6 +5479,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apparatus@0.0.10:
+    resolution: {integrity: sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==}
+    engines: {node: '>=0.2.6'}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -5394,6 +5553,9 @@ packages:
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
+
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
@@ -5481,6 +5643,9 @@ packages:
 
   bare-url@2.4.2:
     resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
+
+  base-64@0.1.0:
+    resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5575,6 +5740,10 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -5681,6 +5850,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
@@ -5775,6 +5947,13 @@ packages:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
 
+  cloudflare@4.5.0:
+    resolution: {integrity: sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmd-shim@7.0.0:
     resolution: {integrity: sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -5861,6 +6040,10 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
+
+  compromise@14.15.0:
+    resolution: {integrity: sha512-YEMv5JGWyqRJw5hdZqDVQF3MMlHA6TRiXreR8IYffk6xB7GA5p/8DeDzvg0Jy2tHNGpD+qJGl0+oJwA+5R/sVA==}
+    engines: {node: '>=12.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -5954,6 +6137,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
@@ -6144,6 +6330,9 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
+  digest-fetch@1.3.0:
+    resolution: {integrity: sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -6180,6 +6369,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   drizzle-kit@0.31.10:
@@ -6376,6 +6569,10 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  efrt@2.7.0:
+    resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
+    engines: {node: '>=12.0.0'}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
@@ -6892,9 +7089,21 @@ packages:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
 
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -6981,12 +7190,20 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
 
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
   googleapis-common@7.2.0:
@@ -7000,12 +7217,19 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grad-school@0.0.5:
+    resolution: {integrity: sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==}
+    engines: {node: '>=8.0.0'}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  groq-sdk@0.3.0:
+    resolution: {integrity: sha512-Cdgjh4YoSBE2X4S9sxPGXaAy1dlN4bRtAaDZ3cnq+XsxhhN9WSBeHF64l7LWwuD5ntmw7YC5Vf4Ff1oHCg1LOg==}
 
   gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
@@ -7345,6 +7569,10 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -7619,6 +7847,10 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  kareem@3.3.0:
+    resolution: {integrity: sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==}
+    engines: {node: '>=18.0.0'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -7827,6 +8059,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -7853,6 +8088,9 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -7860,6 +8098,37 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  mem0ai@3.0.2:
+    resolution: {integrity: sha512-smB9q27jrJu2D5WZje65+zMVptdS/WsqALxd2kjiZhEpThd/qkS8T3bumatcTu6Zb+LsT28FRpeWjXGTJjyQXQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@anthropic-ai/sdk': ^0.40.1
+      '@azure/identity': ^4.0.0
+      '@azure/search-documents': ^12.0.0
+      '@cloudflare/workers-types': ^4.20250504.0
+      '@google/genai': ^1.2.0
+      '@langchain/core': ^1.0.0
+      '@mistralai/mistralai': ^1.5.2
+      '@qdrant/js-client-rest': 1.13.0
+      '@supabase/supabase-js': ^2.49.1
+      '@types/jest': 29.5.14
+      '@types/pg': 8.11.0
+      better-sqlite3: ^12.6.2
+      cloudflare: ^4.2.0
+      compromise: ^14.0.0
+      groq-sdk: 0.3.0
+      natural: ^8.0.1
+      ollama: ^0.5.14
+      pg: 8.11.3
+      redis: ^4.6.13
+
+  memjs@1.3.2:
+    resolution: {integrity: sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==}
+    engines: {node: '>=0.10.0'}
+
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
@@ -7982,6 +8251,49 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.2.0:
+    resolution: {integrity: sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongoose@9.6.1:
+    resolution: {integrity: sha512-3T8/b0plM3ZJPW3WjlzVMIGJEYYTjgDPQ05Qzru3xu3/wOPSFKWYxdwUF2dl8h3NG5dVkzIuOkZdLacnlLf/sA==}
+    engines: {node: '>=20.19.0'}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@6.0.0:
+    resolution: {integrity: sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==}
+    engines: {node: '>=20.19.0'}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -8032,6 +8344,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  natural@8.1.1:
+    resolution: {integrity: sha512-Ucb+lsUcGxUqu3rn8cwHjT6gJQosO63nIX/aBQXB3+IDkNbFV7PuviysO+Rzz3aKn7PZhPj3bNF4PS9gDVjYCQ==}
+    engines: {node: '>=0.4.10'}
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -8177,6 +8493,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  ollama@0.5.18:
+    resolution: {integrity: sha512-lTFqTf9bo7Cd3hpF6CviBe/DEhewjoZYd9N/uCe7O20qYTvGqrNOFOBDj3lbZgFWHUgDv5EeyusYxsZSLS8nvg==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -8307,6 +8626,10 @@ packages:
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
   p-timeout-compat@1.0.8:
@@ -8893,6 +9216,13 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
+
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
@@ -8951,6 +9281,10 @@ packages:
     engines: {node: '>=10.7.0'}
     peerDependencies:
       axios: '*'
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -9124,6 +9458,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -9199,6 +9536,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -9257,6 +9597,10 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stopwords-iso@1.1.0:
+    resolution: {integrity: sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==}
+    engines: {node: '>=0.10.0'}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -9380,6 +9724,9 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  suffix-thumb@5.0.2:
+    resolution: {integrity: sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==}
+
   supabase@1.226.4:
     resolution: {integrity: sha512-qEzoagrqZs5T7sAlfZzehX3PJ13cSBrJVs2vrh6xC+B0VI0wgOBw2gCNRcsOMJMpSr0V1l0XueCiFBWPm2U03w==}
     engines: {npm: '>=8'}
@@ -9405,6 +9752,10 @@ packages:
     resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  sylvester@0.0.21:
+    resolution: {integrity: sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==}
+    engines: {node: '>=0.2.6'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -9739,11 +10090,18 @@ packages:
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@5.28.5:
+    resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
+    engines: {node: '>=14.0'}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
@@ -9806,6 +10164,10 @@ packages:
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
   uuid@8.3.2:
@@ -9995,6 +10357,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wordnet-db@3.1.14:
+    resolution: {integrity: sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==}
+    engines: {node: '>=0.6.0'}
+
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
@@ -10088,6 +10454,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -10280,6 +10649,11 @@ snapshots:
       - encoding
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@anthropic-ai/sdk@0.36.3':
     dependencies:
@@ -11123,6 +11497,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@azure/core-rest-pipeline@1.23.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -11189,6 +11573,21 @@ snapshots:
       '@azure/core-rest-pipeline': 1.23.0
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/search-documents@12.2.0':
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -11540,6 +11939,8 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@cloudflare/workers-types@4.20260506.1': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -12096,6 +12497,8 @@ snapshots:
       eventsource-parser: 1.1.2
       robot3: 0.4.1
 
+  '@fastify/busboy@2.1.1': {}
+
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -12121,6 +12524,19 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.2':
     dependencies:
       tslib: 2.8.1
+
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.5
+      ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@googleapis/sheets@9.8.0':
     dependencies:
@@ -12755,6 +13171,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mistralai/mistralai@1.15.1':
+    dependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.15)
@@ -12802,6 +13227,10 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@mongodb-js/saslprep@1.4.11':
+    dependencies:
+      sparse-bitfield: 3.0.3
 
   '@msgpack/msgpack@3.1.3': {}
 
@@ -13187,6 +13616,63 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  '@qdrant/js-client-rest@1.13.0(typescript@5.9.3)':
+    dependencies:
+      '@qdrant/openapi-typescript-fetch': 1.2.6
+      '@sevinf/maybe': 0.5.0
+      typescript: 5.9.3
+      undici: 5.28.5
+
+  '@qdrant/openapi-typescript-fetch@1.2.6': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/client@5.12.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
@@ -13303,6 +13789,8 @@ snapshots:
     dependencies:
       '@sentry/types': 6.19.7
       tslib: 1.14.1
+
+  '@sevinf/maybe@0.5.0': {}
 
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
@@ -14039,11 +14527,19 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.0': {}
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
 
   '@types/wrap-ansi@3.0.0': {}
 
@@ -14266,6 +14762,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.19.17)(jsdom@26.1.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      test-exclude: 6.0.0
+      vitest: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@1.6.1':
     dependencies:
       '@vitest/spy': 1.6.1
@@ -14377,6 +14892,10 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  afinn-165-financialmarketnews@3.0.0: {}
+
+  afinn-165@2.0.2: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -14454,6 +14973,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  apparatus@0.0.10:
+    dependencies:
+      sylvester: 0.0.21
+
   arg@4.1.3: {}
 
   arg@5.0.2: {}
@@ -14506,6 +15029,14 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   axe-core@4.11.3: {}
+
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.3.4)
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axios@1.15.2(debug@4.3.4):
     dependencies:
@@ -14615,6 +15146,8 @@ snapshots:
   bare-url@2.4.2:
     dependencies:
       bare-path: 3.0.0
+
+  base-64@0.1.0: {}
 
   base64-js@1.5.1: {}
 
@@ -14734,6 +15267,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  bson@7.2.0: {}
+
   buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
@@ -14836,6 +15371,8 @@ snapshots:
   chardet@0.7.0: {}
 
   chardet@2.1.1: {}
+
+  charenc@0.0.2: {}
 
   check-error@1.0.3:
     dependencies:
@@ -14967,6 +15504,20 @@ snapshots:
 
   clone@2.1.2: {}
 
+  cloudflare@4.5.0:
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  cluster-key-slot@1.1.2: {}
+
   cmd-shim@7.0.0: {}
 
   co@4.6.0: {}
@@ -15048,6 +15599,12 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  compromise@14.15.0:
+    dependencies:
+      efrt: 2.7.0
+      grad-school: 0.0.5
+      suffix-thumb: 5.0.2
 
   concat-map@0.0.1: {}
 
@@ -15144,6 +15701,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypt@0.0.2: {}
 
   crypto-js@4.2.0: {}
 
@@ -15266,6 +15825,11 @@ snapshots:
 
   diff@4.0.4: {}
 
+  digest-fetch@1.3.0:
+    dependencies:
+      base-64: 0.1.0
+      md5: 2.3.0
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -15302,6 +15866,8 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.4.2: {}
+
   drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -15309,16 +15875,18 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.39.3(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0):
+  drizzle-orm@0.39.3(@cloudflare/workers-types@4.20260506.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260506.1
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
       better-sqlite3: 11.10.0
       pg: 8.20.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260506.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(pg@8.20.0):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260506.1
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
@@ -15338,6 +15906,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
+
+  efrt@2.7.0: {}
 
   electron-to-chromium@1.5.344: {}
 
@@ -15699,8 +16269,7 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
-  events@3.3.0:
-    optional: true
+  events@3.3.0: {}
 
   eventsource-parser@1.1.2: {}
 
@@ -16092,6 +16661,14 @@ snapshots:
       - encoding
       - supports-color
 
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gcp-metadata@6.1.1:
     dependencies:
       gaxios: 6.7.1
@@ -16100,6 +16677,16 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -16207,6 +16794,17 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -16220,6 +16818,8 @@ snapshots:
       - supports-color
 
   google-logging-utils@0.0.2: {}
+
+  google-logging-utils@1.1.3: {}
 
   googleapis-common@7.2.0:
     dependencies:
@@ -16237,6 +16837,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  grad-school@0.0.5: {}
+
   graphemer@1.4.0: {}
 
   gray-matter@4.0.3:
@@ -16245,6 +16847,20 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  groq-sdk@0.3.0:
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      digest-fetch: 1.3.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+      web-streams-polyfill: 3.3.3
+    transitivePeerDependencies:
+      - encoding
 
   gtoken@7.1.0:
     dependencies:
@@ -16584,6 +17200,14 @@ snapshots:
       debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17093,6 +17717,8 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  kareem@3.3.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -17296,6 +17922,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
@@ -17326,9 +17958,49 @@ snapshots:
       tiny-emitter: 2.1.0
       typed-function: 4.2.2
 
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
+
+  mem0ai@3.0.2(@anthropic-ai/sdk@0.36.3)(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260506.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)))(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@mistralai/mistralai@1.15.1)(@qdrant/js-client-rest@1.13.0(typescript@5.9.3))(@supabase/supabase-js@2.104.1)(@types/jest@29.5.14)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0)(compromise@14.15.0)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8))(ollama@0.5.18)(pg@8.20.0)(redis@4.7.1)(ws@8.20.0):
+    dependencies:
+      '@anthropic-ai/sdk': 0.36.3
+      '@azure/identity': 4.13.1
+      '@azure/search-documents': 12.2.0
+      '@cloudflare/workers-types': 4.20260506.1
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
+      '@langchain/core': 1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      '@mistralai/mistralai': 1.15.1
+      '@qdrant/js-client-rest': 1.13.0(typescript@5.9.3)
+      '@supabase/supabase-js': 2.104.1
+      '@types/jest': 29.5.14
+      '@types/pg': 8.20.0
+      axios: 1.13.6
+      better-sqlite3: 12.9.0
+      cloudflare: 4.5.0
+      compromise: 14.15.0
+      groq-sdk: 0.3.0
+      natural: 8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8)
+      ollama: 0.5.18
+      openai: 4.104.0(ws@8.20.0)(zod@3.25.76)
+      pg: 8.20.0
+      redis: 4.7.1
+      uuid: 9.0.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - ws
+
+  memjs@1.3.2: {}
+
+  memory-pager@1.5.0: {}
 
   meow@13.2.0: {}
 
@@ -17423,6 +18095,40 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.2.0(socks@2.8.8):
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.11
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
+    optionalDependencies:
+      socks: 2.8.8
+
+  mongoose@9.6.1(socks@2.8.8):
+    dependencies:
+      kareem: 3.3.0
+      mongodb: 7.2.0(socks@2.8.8)
+      mpath: 0.9.0
+      mquery: 6.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+
+  mpath@0.9.0: {}
+
+  mquery@6.0.0: {}
+
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -17456,6 +18162,34 @@ snapshots:
   napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
+
+  natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8):
+    dependencies:
+      afinn-165: 2.0.2
+      afinn-165-financialmarketnews: 3.0.0
+      apparatus: 0.0.10
+      dotenv: 17.4.2
+      memjs: 1.3.2
+      mongoose: 9.6.1(socks@2.8.8)
+      pg: 8.20.0
+      redis: 5.12.1(@opentelemetry/api@1.9.1)
+      safe-stable-stringify: 2.5.0
+      stopwords-iso: 1.1.0
+      sylvester: 0.0.21
+      underscore: 1.13.8
+      uuid: 13.0.2
+      wordnet-db: 3.1.14
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - pg-native
+      - snappy
+      - socks
 
   negotiator@0.6.3: {}
 
@@ -17609,6 +18343,10 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  ollama@0.5.18:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -17750,6 +18488,11 @@ snapshots:
     dependencies:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   p-timeout-compat@1.0.8: {}
 
@@ -18104,7 +18847,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
-  ? promptfoo@0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
+  ? promptfoo@0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@cloudflare/workers-types@4.20260506.1)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
   : dependencies:
       '@adaline/anthropic': 0.20.0
       '@adaline/azure': 0.9.2
@@ -18147,7 +18890,7 @@ snapshots:
       debounce: 2.2.0
       dedent: 1.7.2
       dotenv: 16.6.1
-      drizzle-orm: 0.39.3(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)
+      drizzle-orm: 0.39.3(@cloudflare/workers-types@4.20260506.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(pg@8.20.0)
       express: 4.22.1
       fast-deep-equal: 3.1.3
       fast-xml-parser: 4.5.6
@@ -18481,6 +19224,26 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
+  redis@5.12.1(@opentelemetry/api@1.9.1):
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
   regenerator-runtime@0.13.11: {}
 
   replicate@0.34.1:
@@ -18529,6 +19292,8 @@ snapshots:
   retry-axios@2.6.0(axios@1.15.2(debug@4.3.4)):
     dependencies:
       axios: 1.15.2(debug@4.3.4)
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -18814,6 +19579,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sift@17.1.3: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -18911,6 +19678,10 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -18960,6 +19731,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stopwords-iso@1.1.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -19077,6 +19850,8 @@ snapshots:
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
+  suffix-thumb@5.0.2: {}
+
   supabase@1.226.4:
     dependencies:
       bin-links: 5.0.0
@@ -19105,6 +19880,8 @@ snapshots:
       dequal: 2.0.3
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
+
+  sylvester@0.0.21: {}
 
   symbol-tree@3.2.4: {}
 
@@ -19512,9 +20289,15 @@ snapshots:
       buffer: 5.7.1
       through: 2.3.8
 
+  underscore@1.13.8: {}
+
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  undici@5.28.5:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@6.25.0: {}
 
@@ -19560,6 +20343,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
+
+  uuid@13.0.2: {}
 
   uuid@8.3.2: {}
 
@@ -19896,6 +20681,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wordnet-db@3.1.14: {}
+
   wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
@@ -19958,6 +20745,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,18 +36,24 @@ importers:
         specifier: ^3.3.7
         version: 3.3.11
     devDependencies:
+      '@types/jest':
+        specifier: ^29.0.0
+        version: 29.5.14
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.39
+      jest:
+        specifier: ^29.0.0
+        version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.0.0
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   apps/dashboard:
     dependencies:
@@ -385,18 +391,12 @@ importers:
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
-      '@vitest/coverage-v8':
-        specifier: ^1.6.0
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(jsdom@26.1.0))
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   apps/story-backfiller:
     devDependencies:
@@ -502,9 +502,6 @@ importers:
 
   configs/vitest-config:
     dependencies:
-      '@vitest/coverage-v8':
-        specifier: '>=1'
-        version: 1.6.1(vitest@1.6.1(@types/node@22.19.17)(jsdom@26.1.0))
       vitest:
         specifier: '>=1'
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
@@ -735,9 +732,6 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/capability-broker:
     dependencies:
@@ -993,11 +987,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
-  packages/dedup-engine:
-    devDependencies:
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
+  packages/dedup-engine: {}
 
   packages/dev-inspector:
     dependencies:
@@ -1244,7 +1234,7 @@ importers:
         version: 12.9.0
       mem0ai:
         specifier: ^3.0.2
-        version: 3.0.2(@anthropic-ai/sdk@0.36.3)(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260506.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)))(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@mistralai/mistralai@1.15.1)(@qdrant/js-client-rest@1.13.0(typescript@5.9.3))(@supabase/supabase-js@2.104.1)(@types/jest@29.5.14)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0)(compromise@14.15.0)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8))(ollama@0.5.18)(pg@8.20.0)(redis@4.7.1)(ws@8.20.0)
+        version: 3.0.2(@anthropic-ai/sdk@0.36.3)(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260506.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)))(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@mistralai/mistralai@1.15.1)(@qdrant/js-client-rest@1.13.0(typescript@5.9.3))(@supabase/supabase-js@2.104.1)(@types/jest@29.5.14)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0)(compromise@14.15.0)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8))(ollama@0.5.18)(pg@8.20.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ws@8.20.0)
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*
@@ -1587,7 +1577,7 @@ importers:
         version: 20.19.39
       promptfoo:
         specifier: ^0.103.0
-        version: 0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@cloudflare/workers-types@4.20260506.1)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
+        version: 0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@cloudflare/workers-types@4.20260506.1)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@10.6.2)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1665,9 +1655,6 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   packages/skills-registry:
     dependencies:
@@ -2081,10 +2068,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@anthropic-ai/sdk@0.36.3':
     resolution: {integrity: sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==}
@@ -4365,20 +4348,11 @@ packages:
     resolution: {integrity: sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==}
     engines: {node: '>=18.0.0', pnpm: '>=8'}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
     engines: {node: '>= 18.19.0'}
     peerDependencies:
       '@redis/client': ^5.12.1
-
-  '@redis/client@1.6.1':
-    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
-    engines: {node: '>=14'}
 
   '@redis/client@5.12.1':
     resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
@@ -4392,37 +4366,17 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redis/json@5.12.1':
     resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
     engines: {node: '>= 18.19.0'}
     peerDependencies:
       '@redis/client': ^5.12.1
 
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redis/search@5.12.1':
     resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
     engines: {node: '>= 18.19.0'}
     peerDependencies:
       '@redis/client': ^5.12.1
-
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
 
   '@redis/time-series@5.12.1':
     resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
@@ -5299,11 +5253,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-
-  '@vitest/coverage-v8@1.6.1':
-    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
-    peerDependencies:
-      vitest: 1.6.1
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -7101,10 +7050,6 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  generic-pool@3.9.0:
-    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
-    engines: {node: '>= 4'}
-
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -7567,10 +7512,6 @@ packages:
 
   istanbul-lib-source-maps@4.0.1:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
@@ -8058,9 +7999,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -9215,9 +9153,6 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
-
-  redis@4.7.1:
-    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   redis@5.12.1:
     resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
@@ -10455,9 +10390,6 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -10649,11 +10581,6 @@ snapshots:
       - encoding
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@anthropic-ai/sdk@0.36.3':
     dependencies:
@@ -13625,19 +13552,9 @@ snapshots:
 
   '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
   '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-
-  '@redis/client@1.6.1':
-    dependencies:
-      cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
 
   '@redis/client@5.12.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -13645,29 +13562,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@redis/graph@1.1.1(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/json@1.0.7(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
   '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/search@1.2.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
   '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
 
   '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -14759,25 +14660,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.21(@types/node@22.19.17)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.19.17)(jsdom@26.1.0))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      picocolors: 1.1.1
-      std-env: 3.10.0
-      strip-literal: 2.1.1
-      test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16686,8 +16568,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  generic-pool@3.9.0: {}
-
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -17200,14 +17080,6 @@ snapshots:
       debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17922,12 +17794,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      source-map-js: 1.2.1
-
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
@@ -17968,7 +17834,7 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  mem0ai@3.0.2(@anthropic-ai/sdk@0.36.3)(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260506.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)))(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@mistralai/mistralai@1.15.1)(@qdrant/js-client-rest@1.13.0(typescript@5.9.3))(@supabase/supabase-js@2.104.1)(@types/jest@29.5.14)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0)(compromise@14.15.0)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8))(ollama@0.5.18)(pg@8.20.0)(redis@4.7.1)(ws@8.20.0):
+  mem0ai@3.0.2(@anthropic-ai/sdk@0.36.3)(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260506.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)))(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@mistralai/mistralai@1.15.1)(@qdrant/js-client-rest@1.13.0(typescript@5.9.3))(@supabase/supabase-js@2.104.1)(@types/jest@29.5.14)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0)(compromise@14.15.0)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.1)(socks@2.8.8))(ollama@0.5.18)(pg@8.20.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ws@8.20.0):
     dependencies:
       '@anthropic-ai/sdk': 0.36.3
       '@azure/identity': 4.13.1
@@ -17990,7 +17856,7 @@ snapshots:
       ollama: 0.5.18
       openai: 4.104.0(ws@8.20.0)(zod@3.25.76)
       pg: 8.20.0
-      redis: 4.7.1
+      redis: 5.12.1(@opentelemetry/api@1.9.1)
       uuid: 9.0.1
       zod: 3.25.76
     transitivePeerDependencies:
@@ -18847,7 +18713,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
-  ? promptfoo@0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@cloudflare/workers-types@4.20260506.1)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
+  ? promptfoo@0.103.19(@adaline/anthropic@0.20.0)(@adaline/azure@0.9.2)(@adaline/gateway@0.25.0)(@adaline/google@0.9.0)(@adaline/groq@0.9.0)(@adaline/open-router@0.8.0)(@adaline/openai@0.22.0)(@adaline/provider@0.17.0)(@adaline/together-ai@0.8.0)(@adaline/types@0.15.0)(@adaline/vertex@0.9.0)(@aws-sdk/client-bedrock-runtime@3.1043.0)(@aws-sdk/credential-provider-sso@3.972.38)(@azure/identity@4.13.1)(@azure/openai-assistants@1.0.0-beta.6)(@cloudflare/workers-types@4.20260506.1)(@fal-ai/serverless-client@0.14.3)(@ibm-cloud/watsonx-ai@1.7.11(typescript@5.9.3))(@ibm-generative-ai/node-sdk@2.0.6(@langchain/core@1.1.44(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)))(@opentelemetry/api@1.9.1)(@playwright/browser-chromium@1.59.1)(@smithy/node-http-handler@4.6.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(google-auth-library@10.6.2)(ibm-cloud-sdk-core@5.4.14)(langfuse@3.38.20)(node-sql-parser@5.4.0)(pdf-parse@1.1.4)(pg@8.20.0)(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1))(playwright@1.59.1)(puppeteer-extra-plugin-stealth@2.11.2(playwright-extra@4.3.6(playwright-core@1.59.1)(playwright@1.59.1)))
   : dependencies:
       '@adaline/anthropic': 0.20.0
       '@adaline/azure': 0.9.2
@@ -18896,7 +18762,7 @@ snapshots:
       fast-xml-parser: 4.5.6
       fastest-levenshtein: 1.0.16
       glob: 10.5.0
-      google-auth-library: 9.15.1
+      google-auth-library: 10.6.2
       http-z: 7.1.3
       ibm-cloud-sdk-core: 5.4.14
       inquirer: 11.1.0
@@ -19223,15 +19089,6 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-
-  redis@4.7.1:
-    dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
-      '@redis/client': 1.6.1
-      '@redis/graph': 1.1.1(@redis/client@1.6.1)
-      '@redis/json': 1.0.7(@redis/client@1.6.1)
-      '@redis/search': 1.2.0(@redis/client@1.6.1)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
   redis@5.12.1(@opentelemetry/api@1.9.1):
     dependencies:
@@ -20745,8 +20602,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 


### PR DESCRIPTION
## Validation decision #4 — Step 3 (Implementation)

Builds on PR #368 (investigation + DESIGN.md). Ships the backend abstraction and the Mem0 OSS adapter for `@chiefaia/librarian`.

## What's in this PR

### New code (additive, no breaking changes)

- `packages/librarian/src/backends/types.ts` — \`LibrarianBackendName\` + \`isLibrarianBackendName\` guard + \`DEFAULT_BACKEND = 'sqlite-vec'\`.
- `packages/librarian/src/backends/mem0-backend.ts` — \`Mem0Backend\` class + \`buildMem0Index\` / \`retrieveMem0Precedent\` functions. Configures Mem0 OSS Node.js (\`mem0ai@^3\`) with \`infer: false\` + Ollama embedder + \`vectorStore.provider: 'memory'\` (which is misleadingly named — it's better-sqlite3 + JS-side cosine internally, same primitives Librarian Phase 1 uses).
- `packages/librarian/src/backends/dispatcher.ts` — \`buildIndexWithBackend\` / \`retrieveWithBackend\` / \`prependWithBackend\` thin wrappers that pick between \`'sqlite-vec'\` and \`'mem0'\` via an optional \`backend?\` flag. Default stays \`'sqlite-vec'\`.
- `packages/librarian/src/backends/index.ts` — re-exports.

### Tests

- `tests/backends/mem0-backend.fixture.ts` — in-memory fake satisfying \`Mem0MemoryLike\` with a deterministic 32-dim toy embedder. Zero network, zero filesystem touch in the vector store.
- `tests/backends/mem0-backend.test.ts` — 19 unit tests covering constructor parameterisation, \`buildMem0Config\` shape, idempotent rebuild via sha+mtime reuse, stale-row removal, content truncation, retrieval ordering + kindFilter + threshold, graceful error handling, and the dispatcher flag for build/retrieve/prepend.

### Public API surface

- `packages/librarian/src/index.ts` re-exports the new backends surface (additive).
- `packages/librarian/package.json` bumps version 0.1.0 → 0.2.0, adds \`mem0ai: ^3.0.2\` as a runtime dependency, and exposes a new \`./backends\` subpath export.
- The Phase-1 functions (\`buildIndex\`, \`retrievePrecedent\`, \`prependPrecedent\`) are completely unchanged and continue to default to the sqlite-vec backend.

## Test results

- **145 tests passing** (126 Phase-1, untouched + 19 new for the Mem0 backend)
- **Lint:** clean
- **Typecheck:** clean
- **Build:** clean

\`\`\`
✓ tests/backends/mem0-backend.test.ts  (19 tests) 27ms
✓ tests/end-to-end.test.ts  (3 tests)
✓ tests/index-builder.test.ts  (17 tests)
✓ tests/index-store.test.ts  (11 tests)
✓ tests/retrieve.test.ts  (17 tests)
... etc.
Test Files  11 passed (11)
     Tests  145 passed (145)
\`\`\`

## Hard-constraint adherence

- ✅ **No Anthropic API key.** Mem0 always called with \`infer: false\`; the LLM endpoint is configured (so the constructor schema validates) but never reached.
- ✅ **No OpenAI API key.** Mem0's hard-dep \`openai\` SDK is loaded but the OpenAI provider class is never instantiated.
- ✅ **No per-token billing.** All embeddings via local Ollama \`nomic-embed-text\`.
- ✅ **Markdown stays source of truth.** Backend stores \`source_path\`, \`content_sha256\`, \`mtime_ms\`, and a 4 KB \`content_snippet\` in metadata; the canonical content lives in \`agent/memory/*.md\`.
- ✅ **Option E shape.** \`Mem0Backend\` constructor takes every CAIA-specific value (\`memoryDir\`, \`userId\`, \`ollamaUrl\`, \`embedModel\`, etc.) as a parameter with a CAIA default. Tests inject a \`memoryFactory\` fixture; production uses the lazy import of \`mem0ai/oss\`. Per Option E rule #4, tests use \`userId: 'fixture-corpus'\` not the live CAIA partition.

## Notes for the reviewer

- The Phase-1 default is **preserved** — callers must opt in by passing \`backend: 'mem0'\` to the dispatcher functions. The A/B harness in the next PR will exercise both paths against the same fixture corpus.
- The flag value \`'sqlite-vec'\` is preserved as the user-facing name for consistency with the campaign brief, even though the actual implementation is better-sqlite3 + JS-side cosine. The class name \`Mem0Backend\` reflects what's actually used; there is no \`SqliteVecBackend\` class — the Phase-1 functions are called directly through the dispatcher.
- Mem0 v3.0.2 is a recent release; if a future patch bumps the schema, rebuild via \`buildMem0Index({ ..., backend: ... })\` after wiping the index DB. Documented in DESIGN.md.

## Steps 4-6 (next PR)

- A/B harness over 10 retrieval queries against the live CAIA corpus
- Verdict report (default-flip / parity / regression)
- Final completion report

Refs: \`agent/memory/feedback_validation_decisions_2026-05-06.md\` decision #4
Refs: \`agent/memory/agent_architecture_shape_2026-05-06.md\` (Option E)
Refs: \`agent/memory/feedback_no_api_key_billing.md\` (subscription-only)
Refs: PR #368 (investigation + DESIGN.md)