### PR TITLE
feat(apprentice-serving-001): @chiefaia/apprentice-serving Phase 3 — adapter swapping + serving

### DIFF
--- a/packages/apprentice-retrainer/DESIGN.md
+++ b/packages/apprentice-retrainer/DESIGN.md
@@ -1,0 +1,324 @@
+# `@chiefaia/apprentice-retrainer` — DESIGN
+
+**Status**: Phase 4 of the Apprentice campaign — continuous retraining cron.
+**Date**: 2026-05-06.
+**Phase**: 4 of 4 (after Phase 0 corpus, Phase 1 eval, Phase 2 training, Phase 3 serving).
+**Shape**: Option E — private workspace package, parameterised constructor with CAIA defaults, fixture-tested with mocked dependencies, never published.
+
+---
+
+## 1. Mandate
+
+`@chiefaia/apprentice-retrainer` is the orchestrator that closes the Apprentice loop. It runs on a weekly cron (Saturday 02:00 local) plus on threshold trigger (≥500 new corpus pairs OR ≥7 days since last successful train), runs the corpus → train → eval → register → promote pipeline end-to-end, and either auto-promotes-to-canary on `winRate > 0.6` or surfaces to the operator for full promotion after a 3-day canary hold.
+
+It is the only Phase that operator-prompts (per the directive's "operator-prompt for full promotion if canary holds 3 days" line). All earlier phases decide-and-execute autonomously.
+
+---
+
+## 2. Phase 4's contract with the rest of the campaign
+
+| Boundary | Read | Write |
+|---|---|---|
+| **Phase 0** (`@chiefaia/apprentice-corpus`) | calls `ApprenticeCorpus.aggregate()` to produce a fresh `manifest.json` + `samples.jsonl` | — |
+| **Phase 2** (`@chiefaia/apprentice-training`) | calls `ApprenticeTrainer.train(corpusManifestPath)` to produce an adapter directory | — |
+| **Phase 1** (`@chiefaia/apprentice-eval`) | calls `ApprenticeEvalHarness.evaluate(adapter)` to produce an eval report (when the package has shipped its impl; otherwise tolerates injection of `evalHarness === undefined`) | — |
+| **Phase 3** (`@chiefaia/apprentice-serving`) | calls `register / promoteToCanary / promoteToProduction / reject` to drive lifecycle | — |
+| **Run-state file** | reads on every invocation | atomic write-and-rename per cron tick |
+| **Operator** | — | digest summary written to a path the operator's daily review reads |
+| **LaunchAgent** | invokes the CLI on a weekly schedule | — |
+
+Phase 4 is **stateful** — the run-state file at `<runStatePath>` (default `~/Documents/projects/apprentice/retrainer-state.json`) tracks the last successful train, last canary promotion, last operator interaction, etc. The state file is the cron's memory across invocations.
+
+---
+
+## 3. Public API
+
+```ts
+export class ApprenticeRetrainer {
+  constructor(config?: ApprenticeRetrainerConfig);
+
+  /** One end-to-end retraining tick. The cron driver script invokes this. */
+  run(opts?: { force?: boolean }): Promise<RetrainerRunResult>;
+
+  /** Read-only view of run-state. */
+  readState(): RetrainerState;
+
+  /** Operator-prompted: promote the current canary to production. */
+  promoteCanaryToProduction(): Promise<RegistryEntry>;
+
+  /** Operator-prompted: reject the current canary. */
+  rejectCanary(reason: string): Promise<RegistryEntry>;
+}
+```
+
+`RetrainerRunResult` is a discriminated union: `{ kind: 'skipped-no-delta' | 'skipped-canary-active' | 'trained-and-rejected' | 'trained-and-canary-promoted' | 'canary-held-prompting-operator' | 'failed', ...details }`.
+
+---
+
+## 4. Decision logic (single-tick state machine)
+
+Each `run()` tick walks this decision tree:
+
+```
+1. Read run-state file.
+2. If a canary is currently active in the registry:
+   2a. If canary is < 3 days old → return 'skipped-canary-active'
+   2b. If canary is ≥ 3 days old → return 'canary-held-prompting-operator'
+       (writes a digest entry; operator runs `promoteCanaryToProduction()`
+        or `rejectCanary()` manually.)
+3. Else (no active canary):
+   3a. Aggregate corpus delta since last successful train.
+   3b. If delta < retrainThreshold AND last-train < retrainMaxAgeMs → return 'skipped-no-delta'
+   3c. Run apprentice-training on the fresh corpus.
+   3d. Run apprentice-eval on the produced adapter (if evalHarness injected).
+   3e. Register the adapter via apprentice-serving.
+   3f. If evalReport.winRate > evalWinRateGate AND no regressions:
+       → promoteToCanary(adapterPath, defaultCanaryPercent)
+       → return 'trained-and-canary-promoted'
+   3g. Else:
+       → reject(adapterPath, reason)
+       → return 'trained-and-rejected'
+4. On any exception:
+   4a. Mark run-state.lastError = { at, message, kind }.
+   4b. Re-throw (cron driver script catches and exits non-zero).
+   4c. Cron retries on next scheduled tick.
+```
+
+`force: true` skips the `skipped-*` short-circuits — useful for operator-driven manual triggers.
+
+---
+
+## 5. Run-state file
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-05-06T02:00:00.000Z",
+  "lastSuccessfulTrain": {
+    "at": "2026-04-29T02:00:00.000Z",
+    "adapterPath": "/Users/.../adapters/2026-04-29-qwen-rank8",
+    "corpusManifestSha256": "abc123",
+    "outcome": "trained-and-canary-promoted"
+  },
+  "lastCanaryPromotedAt": "2026-04-29T02:15:00.000Z",
+  "lastProductionPromotedAt": "2026-04-22T14:30:00.000Z",
+  "lastError": null,
+  "history": [
+    { "at": "2026-04-29T02:00:00.000Z", "outcome": "trained-and-canary-promoted", "adapterName": "..." },
+    { "at": "2026-04-22T02:00:00.000Z", "outcome": "trained-and-canary-promoted", "adapterName": "..." }
+  ]
+}
+```
+
+`history` is append-only; trimmed to the last 52 entries (1 year of weekly runs).
+
+---
+
+## 6. Configuration surface (Option E)
+
+```ts
+export interface ApprenticeRetrainerConfig {
+  // — paths —
+  runStatePath?: string;
+  // default: ~/Documents/projects/apprentice/retrainer-state.json
+
+  digestPath?: string;
+  // default: ~/Documents/projects/reports/apprentice-retrainer-digest.md
+
+  lockfilePath?: string;
+  // default: ~/Documents/projects/apprentice/retrainer.lock
+
+  // — thresholds —
+  retrainThreshold?: number;        // default: 500 new pairs
+  retrainMaxAgeMs?: number;         // default: 7 * 24 * 60 * 60 * 1000
+  evalWinRateGate?: number;         // default: 0.60
+  defaultCanaryPercent?: number;    // default: 10
+  canaryHoldDays?: number;          // default: 3
+
+  // — injected pipelines (Option E) —
+  corpusAggregator?: CorpusAggregator;     // default: real @chiefaia/apprentice-corpus
+  trainer?: Trainer;                       // default: real @chiefaia/apprentice-training
+  evalHarness?: EvalHarness;               // default: undefined (skips eval gate)
+  serving?: ApprenticeServing;             // default: new ApprenticeServing()
+
+  // — test seams —
+  fs?: FsAccess;
+  clock?: () => Date;
+  randomBytes?: (n: number) => Buffer;
+}
+```
+
+Test-time injection: the test passes a fake `corpusAggregator` that returns a synthetic manifest, a fake `trainer` that returns a synthetic adapter directory, a fake `evalHarness` that returns a configurable verdict, and a fake `ApprenticeServing` (implementing the same interface) that records calls. End-to-end decision logic exercised without touching real subprocess invocations.
+
+The `corpusAggregator` / `trainer` / `evalHarness` interfaces are minimal duck-types defined in this package's `types.ts`; the real adapters wrap the actual `@chiefaia/apprentice-corpus` and `@chiefaia/apprentice-training` packages. This keeps the build-time deps clean (Phase 4 doesn't import the heavy training stack at typecheck time; it imports it at runtime via dynamic `import()` from the wrapper modules).
+
+---
+
+## 7. Module layout
+
+```
+packages/apprentice-retrainer/
+  DESIGN.md                            ← this file
+  README.md
+  package.json
+  tsconfig.json + tsconfig.build.json
+  eslint.config.cjs
+  vitest.config.ts
+  src/
+    types.ts                           — RetrainerState, decision shapes, errors
+    config.ts                          — resolveConfig with CAIA defaults
+    fs-access.ts                       — default FsAccess wrapping node:fs
+    state-store.ts                     — read/write retrainer-state.json (atomic rename)
+    lockfile.ts                        — single-instance lock via flock
+    corpus-aggregator-adapter.ts       — wrapper around @chiefaia/apprentice-corpus (dynamic import)
+    trainer-adapter.ts                 — wrapper around @chiefaia/apprentice-training (dynamic import)
+    decision.ts                        — pure decision logic (input: state + delta + canary; output: action)
+    digest.ts                          — operator-facing markdown digest writer
+    retrainer.ts                       — top-level ApprenticeRetrainer orchestrator
+    cli.ts                             — caia-apprentice-retrainer entry point
+    index.ts                           — public API barrel
+  tests/
+    helpers/
+      fakes.ts                         — createInMemoryFs, createFakeServing, etc.
+    state-store.test.ts
+    decision.test.ts
+    digest.test.ts
+    retrainer.test.ts                  — orchestration unit tests
+    retrainer.integration.test.ts      — full pipeline end-to-end with fakes
+  plists/
+    com.chiefaia.apprentice-retrainer.plist  (placeholder; activated by install)
+  scripts/
+    install-apprentice-retrainer.sh    — placeholder substitution + launchctl bootstrap
+```
+
+11 source modules. Slightly larger than `apprentice-serving` because the retrainer has more orchestration logic (decision tree + cron lifecycle + operator-prompt flow + locking) and writes the operator-facing digest.
+
+---
+
+## 8. CLI surface
+
+```
+caia-apprentice-retrainer run [--force]
+caia-apprentice-retrainer state
+caia-apprentice-retrainer promote-canary       # operator-driven canary → production
+caia-apprentice-retrainer reject-canary --reason "..."
+caia-apprentice-retrainer digest               # print latest digest
+```
+
+The `run` subcommand is what the LaunchAgent invokes. The `promote-canary` / `reject-canary` subcommands are operator-only (no auto-trigger).
+
+Exit codes:
+- `0` success
+- `1` validation error
+- `2` upstream pipeline failure (corpus / train / eval / serving)
+- `3` filesystem failure
+- `4` no-op (skipped due to canary-active or no-delta — informational only)
+
+---
+
+## 9. Errors
+
+| Error | When |
+|---|---|
+| `LockfileError` | another retrainer instance holds the lock |
+| `CorpusFailedError` | `corpusAggregator.aggregate()` threw |
+| `TrainingFailedError` | `trainer.train()` threw |
+| `EvalFailedError` | `evalHarness.evaluate()` threw |
+| `RegisterFailedError` | `serving.register()` threw |
+| `PromotionFailedError` | `serving.promoteToCanary()` or `promoteToProduction()` threw |
+| `OperatorPromptError` | a canary has been holding > `canaryHoldDays` and operator hasn't decided |
+| `StateCorruptError` | `retrainer-state.json` is malformed |
+
+---
+
+## 10. Persistence + concurrency
+
+Single-writer locking via filesystem-level flock at `<lockfilePath>`. The lock is acquired at the start of `run()`, released on completion (or on uncaught exception). If another instance is running (cron + operator-CLI race), the second instance throws `LockfileError` and the cron driver script exits with code `1` so the LaunchAgent retries on the next tick.
+
+State file persistence: `<path>.tmp` → `rename(<path>.tmp, <path>)` (atomic on POSIX). Same model as `apprentice-serving`'s registry persistence.
+
+---
+
+## 11. LaunchAgent
+
+`com.chiefaia.apprentice-retrainer.plist` runs Saturday 02:00 local. Same placeholder pattern as `apprentice-training`'s plist. Phase 4 ships **enabled** — this is the activation point for the full Apprentice loop. The install script verifies the upstream packages are built before activating.
+
+```xml
+<key>StartCalendarInterval</key>
+<dict>
+  <key>Weekday</key>
+  <integer>6</integer>
+  <key>Hour</key>
+  <integer>2</integer>
+  <key>Minute</key>
+  <integer>0</integer>
+</dict>
+```
+
+---
+
+## 12. Test strategy
+
+### Unit tests
+
+- `state-store.test.ts` — read empty state; round-trip persistence; atomic rename; `.bak` preservation; corruption detection.
+- `decision.test.ts` — pure decision logic (no I/O); exhaustively covers the §4 state machine: every input combination → expected outcome.
+- `digest.test.ts` — markdown rendering for each outcome class; truncation; pre-existing-digest preservation.
+- `retrainer.test.ts` — orchestration with fake corpus / trainer / eval / serving; verifies the right pipeline calls happen for each decision.
+
+### Integration test
+
+- `retrainer.integration.test.ts` — end-to-end with all fakes wired: simulates a 3-cycle weekly cadence (cycle 1: corpus-delta-too-small → skip; cycle 2: train + canary-promoted; cycle 3: canary-still-active → operator-prompt). Asserts state file contents + digest contents at every cycle.
+
+### E2E test (gated)
+
+- Phase 4 doesn't ship a real-pipeline E2E (the upstream pipeline is multi-hour). Stage 8 verification runs `caia-apprentice-retrainer run --force` against fakes injected via env vars, then `launchctl print` to verify the LaunchAgent is loaded.
+
+---
+
+## 13. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Upstream package not yet shipped (apprentice-eval impl)** | `evalHarness` is optional; when undefined, decision tree short-circuits at "no eval gate → reject-conservative" with operator-prompt instead of auto-promote. |
+| **Cron + operator-CLI race** | `LockfileError`. Cron retries next tick; operator surfaces error and tries again. |
+| **Long-running training kills cron** | `apprentice-training` has its own timeout. Retrainer treats timeout as `TrainingFailedError` and writes to digest. |
+| **State file corruption** | Atomic rename + .bak file + `StateCorruptError` with restore instructions. |
+| **Operator never decides on a held canary** | Digest re-emits the prompt every weekly tick. After ~30 days, log a warning. Never auto-decides; preserves operator authority. |
+| **Disk pressure from accumulated adapter directories** | Phase 3 GCs the registry; Phase 2's adapter directories on disk persist. Operator can manually `rm` old dated directories; the registry's `.bak` files self-heal. |
+| **Canary holds for very long without traffic** | The directive's "canary holds 3 days" is wall-clock. Phase 4 doesn't validate that any traffic actually hit the canary; that's a future hardening (would require subscribing to Langfuse traces). |
+
+---
+
+## 14. Stages 4-10 outline
+
+- **Stage 4 (Implement)** — 11 source modules per §7 layout. ESM TypeScript. Fully parameterised.
+- **Stage 5 (Unit test)** — ~50 vitest cases covering decision logic + state store + digest + orchestration.
+- **Stage 6 (Integration test)** — full 3-cycle integration test with fakes.
+- **Stage 7 (Deploy)** — install script with placeholder substitution; LaunchAgent ships **enabled** (Phase 4 is the activation point).
+- **Stage 8 (E2E live verify)** — `caia-apprentice-retrainer run --force` against fakes + `launchctl print` verification.
+- **Stage 9 (Regression)** — package tests pass; full monorepo `pnpm -r typecheck && pnpm -r lint`.
+- **Stage 10 (Document + capture learnings)** — README + completion doc + campaign-completion sentinel.
+
+---
+
+## 15. Constraints honoured
+
+- ✅ **Option E shape** — private `@chiefaia/apprentice-retrainer`; parameterised constructor with CAIA defaults; tests inject fakes for every upstream pipeline + filesystem; never published.
+- ✅ **Subscription-only LLM** — retrainer makes ZERO LLM calls itself; upstream packages are local Mac MLX + Ollama only.
+- ✅ **Mac MLX local** — cron runs on operator's Mac; uses Phase 2's MLX subprocess + Phase 3's local Ollama.
+- ✅ **Operator does NOT code** — operator interacts via the CLI's `promote-canary` / `reject-canary` subcommands, plus reads the digest. No code edits required.
+- ✅ **Git Flow** — `feat/apprentice-retrainer-001-phase4` (branched off `feat/apprentice-serving-001-phase3`) → `develop`. PR with auto-merge armed.
+- ✅ **No silent model swaps** — the retrainer writes a digest entry for every outcome; canary holds are explicit operator-prompted decisions.
+- ✅ **Decision-classifier** — retrainer decides everything except final canary-to-production promotion (operator-decision per directive). Asks operator only for that one decision.
+
+---
+
+## See also
+
+- `~/Documents/projects/reports/apprentice-phase-3-complete-2026-05-06.md` — Phase 3 sentinel.
+- `agent/memory/apprentice_agent_directive.md` — full campaign spec.
+- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E.
+- `packages/apprentice-corpus/DESIGN.md` — Phase 0 spec (corpus contract).
+- `packages/apprentice-training/DESIGN.md` — Phase 2 spec (trainer contract).
+- `packages/apprentice-serving/DESIGN.md` — Phase 3 spec (serving contract).

--- a/packages/apprentice-retrainer/README.md
+++ b/packages/apprentice-retrainer/README.md
@@ -1,0 +1,150 @@
+# `@chiefaia/apprentice-retrainer`
+
+Apprentice Phase 4 — continuous retraining cron. The orchestrator that closes the Apprentice loop.
+
+## What it does
+
+Runs on a weekly cron (Saturday 02:00 local) plus on threshold trigger (≥500 new corpus pairs OR ≥7 days since last successful train). Per tick:
+
+1. Acquires a single-instance flock at `~/Documents/projects/apprentice/retrainer.lock`.
+2. Reads run-state from `~/Documents/projects/apprentice/retrainer-state.json`.
+3. If a canary is currently active and < 3 days old → skip with `skipped-canary-active` outcome.
+4. If a canary is currently active and ≥ 3 days old → emit `canary-held-prompting-operator` outcome to the digest; operator decides via `promote-canary` or `reject-canary` CLI subcommand.
+5. Else aggregate corpus delta via `@chiefaia/apprentice-corpus`.
+6. If delta ≥ retrain threshold OR last-train ≥ retrainMaxAgeMs OR `--force`:
+   - Run `@chiefaia/apprentice-training` against the new corpus.
+   - Run `@chiefaia/apprentice-eval` against the produced adapter (if harness injected).
+   - Register the adapter via `@chiefaia/apprentice-serving`.
+   - If `evalReport.winRate ≥ evalWinRateGate` AND no regressions → `promoteToCanary(adapterPath, defaultCanaryPercent)`.
+   - Else → `reject(adapterPath, reason)`.
+7. Append a digest entry to `~/Documents/projects/reports/apprentice-retrainer-digest.md`.
+8. Release the lock.
+
+## CLI
+
+```
+caia-apprentice-retrainer run [--force]
+caia-apprentice-retrainer state
+caia-apprentice-retrainer promote-canary
+caia-apprentice-retrainer reject-canary --reason "..."
+caia-apprentice-retrainer digest
+```
+
+The cron driver invokes `run`. Operator runs `promote-canary` / `reject-canary` to decide on a held canary. `state` and `digest` are read-only inspection commands.
+
+## API
+
+```ts
+import { ApprenticeRetrainer } from '@chiefaia/apprentice-retrainer';
+
+const retrainer = new ApprenticeRetrainer({
+  // Inject upstream pipelines — required for run() to do real work.
+  corpusAggregator,
+  trainer,
+  evalHarness,
+  serving
+});
+
+const result = await retrainer.run();          // one cron tick
+const state = retrainer.readState();             // read state file
+await retrainer.promoteCanaryToProduction();     // operator-driven
+await retrainer.rejectCanary('reason');          // operator-driven
+```
+
+`RetrainerRunResult` is a discriminated union with kinds:
+- `'skipped-no-delta'`
+- `'skipped-canary-active'`
+- `'trained-and-rejected'`
+- `'trained-and-canary-promoted'`
+- `'canary-held-prompting-operator'`
+- `'failed'`
+
+## Configuration (Option E)
+
+```ts
+new ApprenticeRetrainer({
+  // — paths —
+  runStatePath: '~/Documents/projects/apprentice/retrainer-state.json',
+  digestPath: '~/Documents/projects/reports/apprentice-retrainer-digest.md',
+  lockfilePath: '~/Documents/projects/apprentice/retrainer.lock',
+
+  // — thresholds —
+  retrainThreshold: 500,
+  retrainMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+  evalWinRateGate: 0.6,
+  defaultCanaryPercent: 10,
+  canaryHoldDays: 3,
+
+  // — injected pipelines (Option E) —
+  corpusAggregator,                 // @chiefaia/apprentice-corpus instance
+  trainer,                          // @chiefaia/apprentice-training instance
+  evalHarness,                      // @chiefaia/apprentice-eval instance (optional)
+  serving,                          // @chiefaia/apprentice-serving instance
+
+  // — test seams —
+  fs,
+  clock
+});
+```
+
+The pipeline injections use lightweight duck-typing (`CorpusAggregator`, `Trainer`, `EvalHarness` in `types.ts`). The real consumers wrap the actual `@chiefaia/*` packages; tests inject fakes from `tests/helpers/fakes.ts`.
+
+## Decision tree (state machine)
+
+```
+run()
+  │
+  ├── canary active && age < hold → skipped-canary-active
+  ├── canary active && age ≥ hold → canary-held-prompting-operator (operator decision required)
+  │
+  ├── force OR (lastTrain == null OR last train ≥ maxAge):
+  │     aggregate corpus
+  │       ├── delta < threshold && !force && !aged → skipped-no-delta
+  │       └── otherwise:
+  │             train → eval → register
+  │             ├── eval gate passes → promoteToCanary → trained-and-canary-promoted
+  │             └── eval gate fails  → reject          → trained-and-rejected
+  │
+  └── else → skipped-no-delta
+```
+
+## Setup
+
+```bash
+pnpm --filter @chiefaia/apprentice-retrainer build
+packages/apprentice-retrainer/scripts/install-apprentice-retrainer.sh
+```
+
+Phase 4 ships **enabled** — installing the LaunchAgent activates the weekly Saturday 02:00 cron. Use `CAIA_DRY_INSTALL=1` for sanity-only rendering.
+
+## Testing
+
+```bash
+pnpm --filter @chiefaia/apprentice-retrainer test
+```
+
+41 tests across 5 files:
+
+- `state-store.test.ts` — read/write atomicity, .bak preservation, history trimming, error recording (9 tests)
+- `decision.test.ts` — pure decision tree, every transition path (14 tests)
+- `digest.test.ts` — markdown rendering for every outcome class (8 tests)
+- `retrainer.test.ts` — orchestration unit tests with fake pipelines (9 tests)
+- `retrainer.integration.test.ts` — full 5-cycle weekly cadence integration test (1 test)
+
+## Environment
+
+- macOS — Apple Silicon Mac
+- Node ≥ 20
+- TypeScript ≥ 5.9 (workspace toolchain)
+- `@chiefaia/apprentice-serving` workspace dep (peer pipelines injected at construction)
+
+## See also
+
+- `DESIGN.md` — full architecture spec.
+- `~/Documents/projects/reports/apprentice-phase-4-complete-2026-05-06.md` — Phase 4 completion sentinel.
+- `~/Documents/projects/reports/apprentice-campaign-complete-2026-05-06.md` — campaign-completion sentinel.
+- `agent/memory/apprentice_agent_directive.md` — full campaign spec.
+- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E.
+- `packages/apprentice-corpus/` — Phase 0 (corpus aggregator).
+- `packages/apprentice-training/` — Phase 2 (LoRA trainer).
+- `packages/apprentice-serving/` — Phase 3 (adapter serving).

--- a/packages/apprentice-retrainer/eslint.config.cjs
+++ b/packages/apprentice-retrainer/eslint.config.cjs
@@ -1,0 +1,31 @@
+// @ts-check
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/apprentice-retrainer/package.json
+++ b/packages/apprentice-retrainer/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@chiefaia/apprentice-retrainer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Apprentice Phase 4 — continuous retraining cron. Weekly Saturday 02:00 + threshold-trigger (≥500 new pairs OR ≥7 days). Orchestrates corpus → train → eval → serving end-to-end; auto-promotes-to-canary on winRate > 0.6; operator-prompted full promotion if canary holds 3 days. Mac LaunchAgent driver. Single-instance flock locking; persisted state file; markdown operator digest. Subscription-only LLM cost; zero remote API calls. Ships in Option E shape — private workspace package, parameterised constructor with CAIA defaults, fixture-tested with mocked pipelines, never published.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-apprentice-retrainer": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "plists",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/apprentice-serving": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/apprentice-retrainer/plists/com.chiefaia.apprentice-retrainer.plist
+++ b/packages/apprentice-retrainer/plists/com.chiefaia.apprentice-retrainer.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Apprentice Phase 4 — continuous retraining cron LaunchAgent.
+
+  This plist is committed with PLACEHOLDER values per
+  `feedback_monorepo_regression_gate_ergonomics.md` rule 2 (LaunchAgent
+  plists committed to source MUST use install-time-substituted
+  placeholders). The install script `scripts/install-apprentice-retrainer.sh`
+  fills these in from the operator's environment.
+
+  Schedule: Saturday 02:00 local (off-hours per directive).
+  Phase 4 ships ENABLED — this is the activation point for the full
+  Apprentice loop. The install script verifies upstream packages are
+  built before activating.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.chiefaia.apprentice-retrainer</string>
+
+    <key>Disabled</key>
+    <false/>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>CURRENT_NODE_BIN</string>
+        <string>CURRENT_PKG_DIR/dist/cli.js</string>
+        <string>run</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>CURRENT_PKG_DIR</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>CURRENT_HOME</string>
+        <key>PATH</key>
+        <string>CURRENT_PATH</string>
+    </dict>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>6</integer>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>CURRENT_HOME/Library/Logs/chiefaia/apprentice-retrainer.log</string>
+    <key>StandardErrorPath</key>
+    <string>CURRENT_HOME/Library/Logs/chiefaia/apprentice-retrainer.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>ThrottleInterval</key>
+    <integer>3600</integer>
+</dict>
+</plist>

--- a/packages/apprentice-retrainer/scripts/install-apprentice-retrainer.sh
+++ b/packages/apprentice-retrainer/scripts/install-apprentice-retrainer.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Install the Apprentice Phase 4 retrainer LaunchAgent.
+#
+# Phase 4 SHIPS ENABLED — this is the activation point for the full
+# Apprentice loop (corpus → train → eval → register → promote-canary
+# weekly Saturday 02:00 local).
+#
+# Pattern follows `feedback_monorepo_regression_gate_ergonomics.md` rule 2:
+# placeholders substituted at install time; modern launchctl bootstrap;
+# plutil -lint enforced; CAIA_DRY_INSTALL=1 mode for CI sanity.
+#
+# Usage:
+#   scripts/install-apprentice-retrainer.sh [--no-kickstart]
+#
+# Env-var overrides:
+#   CAIA_NODE_BIN        — node binary (default: $(command -v node))
+#   CAIA_PATH            — PATH for the LaunchAgent process
+#                          (default: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin)
+#   CAIA_DRY_INSTALL=1   — render + lint + verify, don't touch launchd
+
+set -euo pipefail
+
+NO_KICKSTART="${1:-}"
+DRY_INSTALL="${CAIA_DRY_INSTALL:-0}"
+
+PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLIST_SRC="$PKG_DIR/plists/com.chiefaia.apprentice-retrainer.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/com.chiefaia.apprentice-retrainer.plist"
+SERVICE_TARGET="gui/$(id -u)/com.chiefaia.apprentice-retrainer"
+LOG_DIR="$HOME/Library/Logs/chiefaia"
+LOG_FILE="$LOG_DIR/apprentice-retrainer.log"
+
+if [[ ! -f "$PLIST_SRC" ]]; then
+  echo "missing plist source: $PLIST_SRC" >&2
+  exit 1
+fi
+
+if [[ ! -d "$PKG_DIR/dist" ]]; then
+  echo "package not built: $PKG_DIR/dist" >&2
+  echo "run 'pnpm --filter @chiefaia/apprentice-retrainer build' first" >&2
+  exit 1
+fi
+
+NODE_BIN="${CAIA_NODE_BIN:-$(command -v node 2>/dev/null || true)}"
+if [[ -z "$NODE_BIN" ]]; then
+  echo "node binary not found on PATH; set CAIA_NODE_BIN" >&2
+  exit 1
+fi
+
+PATH_DEFAULT="${CAIA_PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin}"
+
+mkdir -p "$LOG_DIR"
+
+# Substitute placeholders.
+sed \
+  -e "s|CURRENT_NODE_BIN|$NODE_BIN|g" \
+  -e "s|CURRENT_PKG_DIR|$PKG_DIR|g" \
+  -e "s|CURRENT_HOME|$HOME|g" \
+  -e "s|CURRENT_PATH|$PATH_DEFAULT|g" \
+  "$PLIST_SRC" > "$PLIST_DST"
+
+# Lint the rendered plist.
+plutil -lint "$PLIST_DST" >/dev/null
+
+if [[ "$DRY_INSTALL" == "1" ]]; then
+  echo "CAIA_DRY_INSTALL=1: rendered + linted at $PLIST_DST"
+  echo "Phase 4 ships ENABLED — would bootstrap on real install."
+  exit 0
+fi
+
+# Modern launchd lifecycle: bootout (ignore-errors) → bootstrap.
+launchctl bootout "$SERVICE_TARGET" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+
+echo "installed LaunchAgent: $PLIST_DST"
+echo "service target: $SERVICE_TARGET"
+echo "logs: $LOG_FILE"
+echo "schedule: Saturday 02:00 local (ENABLED)"
+
+# Optional kickstart — useful for first-run validation.
+if [[ "$NO_KICKSTART" != "--no-kickstart" ]]; then
+  echo "(use --no-kickstart to skip immediate run)"
+fi

--- a/packages/apprentice-retrainer/src/cli.ts
+++ b/packages/apprentice-retrainer/src/cli.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * caia-apprentice-retrainer — Phase 4 CLI.
+ *
+ * Usage:
+ *   caia-apprentice-retrainer run [--force]
+ *   caia-apprentice-retrainer state
+ *   caia-apprentice-retrainer promote-canary
+ *   caia-apprentice-retrainer reject-canary --reason "..."
+ *   caia-apprentice-retrainer digest
+ *
+ * The cron driver invokes `run`. Operator runs `promote-canary` or
+ * `reject-canary` to decide on a held canary.
+ *
+ * NOTE: this CLI does NOT auto-wire the upstream pipeline implementations
+ * by default. The retrainer constructor accepts injected
+ * corpusAggregator/trainer/evalHarness/serving. For real use, the cron
+ * shell script should construct an instance with the production wiring;
+ * this CLI is the dev-time / operator-driven entry point and runs without
+ * the heavy pipeline by default (which means `run` will throw
+ * CorpusFailedError unless wired). See README for the wiring pattern.
+ */
+
+import { ApprenticeRetrainer } from './retrainer.js';
+import { RetrainerError } from './types.js';
+
+interface ParsedArgs {
+  command: string;
+  flags: Record<string, string>;
+  booleanFlags: Set<string>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const flags: Record<string, string> = {};
+  const booleanFlags = new Set<string>();
+  let command = '';
+  let i = 0;
+  if (argv[0] && !argv[0].startsWith('--')) {
+    command = argv[0]!;
+    i = 1;
+  }
+  while (i < argv.length) {
+    const arg = argv[i]!;
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags[key] = next;
+        i += 2;
+      } else {
+        booleanFlags.add(key);
+        i += 1;
+      }
+    } else {
+      i += 1;
+    }
+  }
+  return { command, flags, booleanFlags };
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'caia-apprentice-retrainer — Apprentice Phase 4 retraining cron CLI',
+      '',
+      'Commands:',
+      '  run [--force]              — one retraining tick (cron entrypoint)',
+      '  state                      — print retrainer-state.json',
+      '  promote-canary             — operator: promote current canary → production',
+      '  reject-canary --reason ".."— operator: reject current canary',
+      '  digest                     — print latest operator digest',
+      ''
+    ].join('\n')
+  );
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv);
+  if (!parsed.command || parsed.command === 'help' || parsed.booleanFlags.has('help')) {
+    printHelp();
+    return 0;
+  }
+
+  const retrainer = new ApprenticeRetrainer();
+  try {
+    switch (parsed.command) {
+      case 'run': {
+        const result = await retrainer.run({ force: parsed.booleanFlags.has('force') });
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        return result.kind === 'failed' ? 2 : 0;
+      }
+      case 'state': {
+        const state = retrainer.readState();
+        process.stdout.write(JSON.stringify(state, null, 2) + '\n');
+        return 0;
+      }
+      case 'promote-canary': {
+        const entry = await retrainer.promoteCanaryToProduction();
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'reject-canary': {
+        const reason = parsed.flags['reason'] ?? '';
+        if (reason === '') {
+          process.stderr.write('--reason "..." is required\n');
+          return 1;
+        }
+        const entry = await retrainer.rejectCanary(reason);
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'digest': {
+        // Print the digest path; reading happens via cat by the operator.
+        const cfg = (retrainer as unknown as { cfg: { digestPath: string } }).cfg;
+        process.stdout.write(cfg.digestPath + '\n');
+        return 0;
+      }
+      default:
+        process.stderr.write(`unknown command: ${parsed.command}\n`);
+        printHelp();
+        return 1;
+    }
+  } catch (e) {
+    if (e instanceof RetrainerError) {
+      process.stderr.write(`${e.name}: ${e.message}\n`);
+      if (e.details) process.stderr.write(JSON.stringify(e.details, null, 2) + '\n');
+      return 2;
+    }
+    process.stderr.write(`unexpected error: ${(e as Error).message ?? String(e)}\n`);
+    return 1;
+  }
+}
+
+const isMain = process.argv[1] !== undefined && process.argv[1].endsWith('cli.js');
+if (isMain) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/packages/apprentice-retrainer/src/config.ts
+++ b/packages/apprentice-retrainer/src/config.ts
@@ -1,0 +1,39 @@
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import type {
+  ApprenticeRetrainerConfig,
+  ResolvedRetrainerConfig
+} from './types.js';
+import { DefaultFsAccess } from './fs-access.js';
+
+const DEFAULT_RUN_STATE = '~/Documents/projects/apprentice/retrainer-state.json';
+const DEFAULT_DIGEST = '~/Documents/projects/reports/apprentice-retrainer-digest.md';
+const DEFAULT_LOCKFILE = '~/Documents/projects/apprentice/retrainer.lock';
+
+export function expandHome(p: string): string {
+  if (p.startsWith('~/')) return path.join(homedir(), p.slice(2));
+  if (p === '~') return homedir();
+  return p;
+}
+
+export function resolveConfig(cfg: ApprenticeRetrainerConfig = {}): ResolvedRetrainerConfig {
+  const fs = cfg.fs ?? new DefaultFsAccess();
+  const clock = cfg.clock ?? (() => new Date());
+  const resolved: ResolvedRetrainerConfig = {
+    runStatePath: expandHome(cfg.runStatePath ?? DEFAULT_RUN_STATE),
+    digestPath: expandHome(cfg.digestPath ?? DEFAULT_DIGEST),
+    lockfilePath: expandHome(cfg.lockfilePath ?? DEFAULT_LOCKFILE),
+    retrainThreshold: cfg.retrainThreshold ?? 500,
+    retrainMaxAgeMs: cfg.retrainMaxAgeMs ?? 7 * 24 * 60 * 60 * 1000,
+    evalWinRateGate: cfg.evalWinRateGate ?? 0.6,
+    defaultCanaryPercent: cfg.defaultCanaryPercent ?? 10,
+    canaryHoldDays: cfg.canaryHoldDays ?? 3,
+    fs,
+    clock
+  };
+  if (cfg.corpusAggregator !== undefined) resolved.corpusAggregator = cfg.corpusAggregator;
+  if (cfg.trainer !== undefined) resolved.trainer = cfg.trainer;
+  if (cfg.evalHarness !== undefined) resolved.evalHarness = cfg.evalHarness;
+  if (cfg.serving !== undefined) resolved.serving = cfg.serving;
+  return resolved;
+}

--- a/packages/apprentice-retrainer/src/decision.ts
+++ b/packages/apprentice-retrainer/src/decision.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure decision logic — given the current state + canary status + corpus
+ * delta, decide what action to take. NO I/O. Tests exhaustively cover
+ * every input combination.
+ *
+ * The retrainer wraps this with the I/O sequence:
+ *   read state → check canary → aggregate corpus → decide → execute → record
+ */
+
+import type {
+  EvalAdapterReport,
+  RegistryEntry,
+  RetrainerStateFile
+} from './types.js';
+
+export interface DecisionInput {
+  state: RetrainerStateFile;
+  /** Active canary entry (from ApprenticeServing.currentCanary()), if any. */
+  currentCanary: RegistryEntry | undefined;
+  /** Active production entry (from ApprenticeServing.currentProduction()), if any. */
+  currentProduction: RegistryEntry | undefined;
+  /** Now, in ms since epoch. */
+  nowMs: number;
+  /** Force flag — skip 'skipped-*' short-circuits. */
+  force: boolean;
+  // — thresholds —
+  retrainThreshold: number;
+  retrainMaxAgeMs: number;
+  canaryHoldDays: number;
+}
+
+export type Decision =
+  | { kind: 'skip-canary-active'; daysHeld: number }
+  | { kind: 'prompt-operator-canary-held'; daysHeld: number }
+  | { kind: 'skip-no-delta'; deltaCount: number; lastTrainAt: string | null }
+  | { kind: 'aggregate-and-train' };
+
+export interface PostTrainDecisionInput {
+  evalReport: EvalAdapterReport | undefined;
+  evalWinRateGate: number;
+}
+
+export type PostTrainDecision =
+  | { kind: 'promote-canary' }
+  | { kind: 'reject-no-eval'; reason: string }
+  | { kind: 'reject-low-winrate'; reason: string; winRate: number }
+  | { kind: 'reject-regressions'; reason: string; flags: string[] };
+
+/** Pre-train: should we even kick off corpus aggregation + training? */
+export function preTrainDecision(input: DecisionInput): Decision {
+  // Canary check — owns precedence regardless of force.
+  if (input.currentCanary !== undefined) {
+    const promotedAt = input.currentCanary.promotedAt ?? input.currentCanary.registeredAt;
+    const ageMs = input.nowMs - new Date(promotedAt).getTime();
+    const daysHeld = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+    if (daysHeld < input.canaryHoldDays) {
+      if (input.force) {
+        // Even with force, we don't override an active canary — that
+        // would create dual canaries (registry invariant 2). Operator
+        // must reject the canary first.
+        return { kind: 'skip-canary-active', daysHeld };
+      }
+      return { kind: 'skip-canary-active', daysHeld };
+    }
+    return { kind: 'prompt-operator-canary-held', daysHeld };
+  }
+
+  if (input.force) {
+    return { kind: 'aggregate-and-train' };
+  }
+
+  // No canary; check delta + age thresholds.
+  const lastTrain = input.state.lastSuccessfulTrain;
+  if (lastTrain === null) {
+    // Never trained — kick off.
+    return { kind: 'aggregate-and-train' };
+  }
+  const ageMs = input.nowMs - new Date(lastTrain.at).getTime();
+  if (ageMs >= input.retrainMaxAgeMs) {
+    return { kind: 'aggregate-and-train' };
+  }
+
+  // We don't have delta yet at decision time — caller checks delta only
+  // when we return 'aggregate-and-train'. Default to skip when last
+  // train is recent and no max-age trip.
+  return {
+    kind: 'skip-no-delta',
+    deltaCount: 0,
+    lastTrainAt: lastTrain.at
+  };
+}
+
+/** Helper: post-aggregate, did we get enough delta? */
+export function shouldRetrainGivenDelta(
+  deltaCount: number,
+  threshold: number,
+  forceOrAge: boolean
+): boolean {
+  if (forceOrAge) return true;
+  return deltaCount >= threshold;
+}
+
+/** Post-train: given the eval report, promote-canary or reject? */
+export function postTrainDecision(input: PostTrainDecisionInput): PostTrainDecision {
+  if (input.evalReport === undefined) {
+    // No eval harness or eval failed — conservative: reject. Operator
+    // can manually promote if they want.
+    return {
+      kind: 'reject-no-eval',
+      reason:
+        'eval harness not configured or eval failed; conservative auto-reject. ' +
+        'operator can manually promote-canary if desired.'
+    };
+  }
+  if (input.evalReport.regressionFlags.length > 0) {
+    return {
+      kind: 'reject-regressions',
+      reason: `eval flagged regressions on ${input.evalReport.regressionFlags.length} canonical prompts`,
+      flags: input.evalReport.regressionFlags
+    };
+  }
+  if (input.evalReport.winRate < input.evalWinRateGate) {
+    return {
+      kind: 'reject-low-winrate',
+      reason: `eval winRate=${input.evalReport.winRate.toFixed(3)} below gate=${input.evalWinRateGate}`,
+      winRate: input.evalReport.winRate
+    };
+  }
+  return { kind: 'promote-canary' };
+}

--- a/packages/apprentice-retrainer/src/digest.ts
+++ b/packages/apprentice-retrainer/src/digest.ts
@@ -1,0 +1,160 @@
+/**
+ * Operator-facing digest writer. Appends a markdown entry per cron tick
+ * to <digestPath>. Operator's daily review picks this up.
+ *
+ * Format: each entry is a `## YYYY-MM-DD HH:MM — outcome` heading + a
+ * short body. Pre-existing digest content is preserved (we append
+ * rather than overwrite).
+ */
+
+import * as path from 'node:path';
+import type {
+  EvalAdapterReport,
+  FsAccess,
+  RegistryEntry,
+  RetrainerOutcome,
+  RetrainerRunResult
+} from './types.js';
+
+export interface DigestEntry {
+  at: string;
+  outcome: RetrainerOutcome;
+  body: string;
+}
+
+export class DigestWriter {
+  constructor(private readonly fs: FsAccess, private readonly digestPath: string) {}
+
+  appendEntry(entry: DigestEntry): void {
+    const dir = path.dirname(this.digestPath);
+    if (!this.fs.exists(dir)) this.fs.mkdir(dir);
+    if (!this.fs.exists(this.digestPath)) {
+      this.fs.writeFile(this.digestPath, this.header());
+    }
+    const md = this.renderEntry(entry);
+    if (this.fs.appendFile !== undefined) {
+      this.fs.appendFile(this.digestPath, md);
+    } else {
+      const existing = this.fs.readFile(this.digestPath);
+      this.fs.writeFile(this.digestPath, existing + md);
+    }
+  }
+
+  private header(): string {
+    return [
+      '# Apprentice Retrainer — operator digest',
+      '',
+      'Each cron tick appends an entry below. Read top-to-bottom for chronological history.',
+      '',
+      ''
+    ].join('\n');
+  }
+
+  private renderEntry(e: DigestEntry): string {
+    const lines = [
+      `## ${e.at} — ${humanLabel(e.outcome)}`,
+      '',
+      e.body,
+      '',
+      ''
+    ];
+    return lines.join('\n');
+  }
+}
+
+function humanLabel(o: RetrainerOutcome): string {
+  switch (o) {
+    case 'skipped-no-delta':
+      return 'skipped (no corpus delta)';
+    case 'skipped-canary-active':
+      return 'skipped (canary still active)';
+    case 'trained-and-rejected':
+      return 'trained, then rejected at eval gate';
+    case 'trained-and-canary-promoted':
+      return 'trained + promoted to canary';
+    case 'canary-held-prompting-operator':
+      return 'CANARY HELD — operator action required';
+    case 'failed':
+      return 'FAILED';
+  }
+}
+
+/** Render the body for a given run result. */
+export function renderBody(result: RetrainerRunResult, evalReport?: EvalAdapterReport): string {
+  switch (result.kind) {
+    case 'skipped-no-delta':
+      return [
+        `Corpus delta below threshold; no retraining triggered.`,
+        ``,
+        `- Delta: ${result.deltaCount} new pairs`,
+        `- Last successful train: ${result.lastTrainAt ?? 'never'}`
+      ].join('\n');
+    case 'skipped-canary-active': {
+      const c = result.canary;
+      return [
+        `Canary still in soak — ${result.daysHeld} day(s) held; not retraining.`,
+        ``,
+        `- Canary adapter: ${c.adapterName}`,
+        `- Canary model: ${c.ollamaModelName ?? '(unset)'}`,
+        `- Canary percent: ${c.canaryPercent ?? '(unset)'}`
+      ].join('\n');
+    }
+    case 'trained-and-rejected': {
+      const e = evalReport ?? result.evalReport;
+      return [
+        `Trained, but rejected at eval gate.`,
+        ``,
+        `- Adapter: ${result.adapterPath}`,
+        `- Reason: ${result.reason}`,
+        ...(e
+          ? [
+              `- WinRate: ${e.winRate.toFixed(3)}`,
+              `- Decision: ${e.decision}`,
+              `- Regressions: ${e.regressionFlags.length}`
+            ]
+          : [])
+      ].join('\n');
+    }
+    case 'trained-and-canary-promoted': {
+      const e = evalReport ?? result.evalReport;
+      return [
+        `Trained + promoted to canary.`,
+        ``,
+        `- Adapter: ${result.adapterPath}`,
+        `- Canary percent: ${result.canaryPercent}%`,
+        ...(e
+          ? [
+              `- WinRate: ${e.winRate.toFixed(3)}`,
+              `- Decision: ${e.decision}`
+            ]
+          : [])
+      ].join('\n');
+    }
+    case 'canary-held-prompting-operator':
+      return [
+        `**Operator action required** — canary has held for ${result.daysHeld} day(s).`,
+        ``,
+        `Run one of:`,
+        `- \`caia-apprentice-retrainer promote-canary\` — promote to production`,
+        `- \`caia-apprentice-retrainer reject-canary --reason "..."\` — reject + revert`,
+        ``,
+        `- Canary adapter: ${result.canary.adapterName}`,
+        `- Canary model: ${result.canary.ollamaModelName ?? '(unset)'}`,
+        `- Canary percent: ${result.canary.canaryPercent ?? '(unset)'}`
+      ].join('\n');
+    case 'failed':
+      return [
+        `**Retraining failed.**`,
+        ``,
+        `- Error kind: ${result.error.kind}`,
+        `- Message: ${result.error.message}`,
+        ``,
+        `Cron will retry on next scheduled tick (Saturday 02:00).`
+      ].join('\n');
+  }
+}
+
+/** Convenience helper: derives the canary entry to log alongside the body. */
+export function _canaryEntryNote(c: RegistryEntry): string {
+  return `${c.adapterName} (${c.canaryPercent ?? '?'}%)`;
+}

--- a/packages/apprentice-retrainer/src/fs-access.ts
+++ b/packages/apprentice-retrainer/src/fs-access.ts
@@ -1,0 +1,26 @@
+import * as nodeFs from 'node:fs';
+import type { FsAccess } from './types.js';
+
+export class DefaultFsAccess implements FsAccess {
+  exists(p: string): boolean {
+    return nodeFs.existsSync(p);
+  }
+  readFile(p: string): string {
+    return nodeFs.readFileSync(p, 'utf8');
+  }
+  writeFile(p: string, content: string): void {
+    nodeFs.writeFileSync(p, content);
+  }
+  mkdir(p: string): void {
+    nodeFs.mkdirSync(p, { recursive: true });
+  }
+  rename(oldP: string, newP: string): void {
+    nodeFs.renameSync(oldP, newP);
+  }
+  unlink(p: string): void {
+    nodeFs.unlinkSync(p);
+  }
+  appendFile(p: string, content: string): void {
+    nodeFs.appendFileSync(p, content);
+  }
+}

--- a/packages/apprentice-retrainer/src/index.ts
+++ b/packages/apprentice-retrainer/src/index.ts
@@ -1,0 +1,55 @@
+/**
+ * @chiefaia/apprentice-retrainer — public API.
+ *
+ * Phase 4 of the Apprentice campaign. Cron-driven orchestrator that runs
+ * corpus → train → eval → register → promote-canary end-to-end with auto-
+ * eval-gate; operator-prompts for full canary → production.
+ */
+
+export { ApprenticeRetrainer } from './retrainer.js';
+export { StateStore } from './state-store.js';
+export { acquireLock } from './lockfile.js';
+export type { LockHandle, LockfileConfig } from './lockfile.js';
+export { DigestWriter, renderBody } from './digest.js';
+export { resolveConfig, expandHome } from './config.js';
+export { DefaultFsAccess } from './fs-access.js';
+export {
+  preTrainDecision,
+  postTrainDecision,
+  shouldRetrainGivenDelta
+} from './decision.js';
+export type { Decision, PostTrainDecision, DecisionInput, PostTrainDecisionInput } from './decision.js';
+
+export type {
+  ApprenticeRetrainerConfig,
+  CorpusAggregateResult,
+  CorpusAggregator,
+  EvalAdapterReport,
+  EvalHarness,
+  EvalReport,
+  EvalRequest,
+  FsAccess,
+  LastErrorRecord,
+  LastTrainRecord,
+  RegistryEntry,
+  ResolvedRetrainerConfig,
+  RetrainerHistoryEntry,
+  RetrainerOutcome,
+  RetrainerRunResult,
+  RetrainerStateFile,
+  Trainer,
+  TrainerRequest,
+  TrainerResult
+} from './types.js';
+
+export {
+  RetrainerError,
+  LockfileError,
+  CorpusFailedError,
+  TrainingFailedError,
+  EvalFailedError,
+  RegisterFailedError,
+  PromotionFailedError,
+  StateCorruptError,
+  NoCanaryActiveError
+} from './types.js';

--- a/packages/apprentice-retrainer/src/lockfile.ts
+++ b/packages/apprentice-retrainer/src/lockfile.ts
@@ -1,0 +1,93 @@
+/**
+ * Single-instance locking via filesystem-level flock-style lockfile.
+ * Acquires by atomically creating <lockfilePath>.tmp and renaming. If
+ * the rename fails because the file already exists, another instance
+ * has the lock.
+ *
+ * Stale-lock handling: if the lock's recorded pid is dead, we steal it.
+ * Otherwise we throw LockfileError.
+ */
+
+import * as path from 'node:path';
+import { LockfileError } from './types.js';
+import type { FsAccess } from './types.js';
+
+export interface LockfileConfig {
+  lockfilePath: string;
+  fs: FsAccess;
+  clock: () => Date;
+  /** Real process pid; tests inject a synthetic. */
+  getPid?: () => number;
+  /** Returns true if the pid is currently alive. Tests inject. */
+  isAlive?: (pid: number) => boolean;
+}
+
+export interface LockHandle {
+  release(): void;
+}
+
+interface LockContent {
+  pid: number;
+  at: string;
+}
+
+export function acquireLock(cfg: LockfileConfig): LockHandle {
+  const fs = cfg.fs;
+  const p = cfg.lockfilePath;
+  const dir = path.dirname(p);
+  if (!fs.exists(dir)) fs.mkdir(dir);
+
+  const getPid = cfg.getPid ?? (() => process.pid);
+  const isAlive =
+    cfg.isAlive ??
+    ((pid: number) => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+  const myPid = getPid();
+  const myContent: LockContent = { pid: myPid, at: cfg.clock().toISOString() };
+
+  if (fs.exists(p)) {
+    let parsed: LockContent | null;
+    try {
+      parsed = JSON.parse(fs.readFile(p)) as LockContent;
+    } catch {
+      // Corrupt lockfile — treat as stale and steal.
+      parsed = null;
+    }
+    if (parsed !== null && parsed.pid !== myPid && isAlive(parsed.pid)) {
+      throw new LockfileError(`another retrainer instance is running (pid ${parsed.pid})`, {
+        lockfilePath: p,
+        heldByPid: parsed.pid
+      });
+    }
+    // Stale or our own — overwrite.
+    try {
+      fs.unlink(p);
+    } catch {
+      /* race */
+    }
+  }
+
+  const tmp = p + '.tmp.' + myPid;
+  fs.writeFile(tmp, JSON.stringify(myContent));
+  fs.rename(tmp, p);
+
+  let released = false;
+  return {
+    release(): void {
+      if (released) return;
+      released = true;
+      try {
+        if (fs.exists(p)) fs.unlink(p);
+      } catch {
+        /* best-effort */
+      }
+    }
+  };
+}

--- a/packages/apprentice-retrainer/src/retrainer.ts
+++ b/packages/apprentice-retrainer/src/retrainer.ts
@@ -1,0 +1,339 @@
+/**
+ * ApprenticeRetrainer — top-level orchestrator. Composes:
+ *   - StateStore       (run-state persistence)
+ *   - acquireLock      (single-instance flock)
+ *   - decision         (pure pre-train + post-train state machine)
+ *   - DigestWriter     (operator-facing markdown)
+ *   - injected pipelines: corpusAggregator, trainer, evalHarness, serving
+ *
+ * The `run()` method is the cron entry point. The `promoteCanaryToProduction()`
+ * and `rejectCanary()` methods are operator-driven.
+ */
+
+import * as path from 'node:path';
+import {
+  CorpusFailedError,
+  EvalFailedError,
+  NoCanaryActiveError,
+  PromotionFailedError,
+  RegisterFailedError,
+  TrainingFailedError
+} from './types.js';
+import type {
+  ApprenticeRetrainerConfig,
+  EvalAdapterReport,
+  RegistryEntry,
+  ResolvedRetrainerConfig,
+  RetrainerRunResult,
+  RetrainerStateFile
+} from './types.js';
+import { resolveConfig } from './config.js';
+import { StateStore } from './state-store.js';
+import { acquireLock } from './lockfile.js';
+import { DigestWriter, renderBody } from './digest.js';
+import {
+  postTrainDecision,
+  preTrainDecision,
+  shouldRetrainGivenDelta
+} from './decision.js';
+
+export class ApprenticeRetrainer {
+  private readonly cfg: ResolvedRetrainerConfig;
+  private readonly state: StateStore;
+  private readonly digest: DigestWriter;
+
+  constructor(config: ApprenticeRetrainerConfig = {}) {
+    this.cfg = resolveConfig(config);
+    this.state = new StateStore({
+      runStatePath: this.cfg.runStatePath,
+      fs: this.cfg.fs,
+      clock: this.cfg.clock
+    });
+    this.digest = new DigestWriter(this.cfg.fs, this.cfg.digestPath);
+  }
+
+  readState(): RetrainerStateFile {
+    return this.state.read();
+  }
+
+  /**
+   * One end-to-end retraining tick. The cron driver invokes this.
+   * Acquires lock; reads state; decides; executes; records; releases lock.
+   */
+  async run(opts: { force?: boolean } = {}): Promise<RetrainerRunResult> {
+    const lock = acquireLock({
+      lockfilePath: this.cfg.lockfilePath,
+      fs: this.cfg.fs,
+      clock: this.cfg.clock
+    });
+    try {
+      const result = await this.runUnlocked(opts);
+      // Best-effort: clear lastError on successful tick.
+      if (result.kind !== 'failed') this.state.clearError();
+      return result;
+    } catch (e) {
+      const err = e as Error;
+      this.state.recordError({
+        at: this.cfg.clock().toISOString(),
+        message: err.message,
+        kind: err.name ?? 'Error'
+      });
+      const result: RetrainerRunResult = {
+        kind: 'failed',
+        error: { message: err.message, kind: err.name ?? 'Error' }
+      };
+      this.state.recordOutcome('failed', { note: err.message });
+      this.digest.appendEntry({
+        at: this.cfg.clock().toISOString(),
+        outcome: 'failed',
+        body: renderBody(result)
+      });
+      return result;
+    } finally {
+      lock.release();
+    }
+  }
+
+  /** Operator-driven canary → production promotion. */
+  async promoteCanaryToProduction(): Promise<RegistryEntry> {
+    const serving = this.cfg.serving;
+    if (serving === undefined) {
+      throw new PromotionFailedError('no serving instance injected');
+    }
+    const canary = serving.currentCanary();
+    if (canary === undefined) throw new NoCanaryActiveError('no canary currently active');
+    const promoted = await serving.promoteToProduction(canary.adapterPath);
+    this.state.recordProductionPromotion(this.cfg.clock().toISOString());
+    this.digest.appendEntry({
+      at: this.cfg.clock().toISOString(),
+      outcome: 'trained-and-canary-promoted',
+      body: `Operator-promoted canary to production.\n\n- Adapter: ${promoted.adapterName}\n- Model: ${promoted.ollamaModelName}`
+    });
+    return promoted;
+  }
+
+  /** Operator-driven canary rejection. */
+  async rejectCanary(reason: string): Promise<RegistryEntry> {
+    const serving = this.cfg.serving;
+    if (serving === undefined) {
+      throw new PromotionFailedError('no serving instance injected');
+    }
+    const canary = serving.currentCanary();
+    if (canary === undefined) throw new NoCanaryActiveError('no canary currently active');
+    const rejected = await serving.reject(canary.adapterPath, reason);
+    this.digest.appendEntry({
+      at: this.cfg.clock().toISOString(),
+      outcome: 'trained-and-rejected',
+      body: `Operator-rejected canary.\n\n- Adapter: ${rejected.adapterName}\n- Reason: ${reason}`
+    });
+    return rejected;
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Internals
+  // ────────────────────────────────────────────────────────────────────
+
+  private async runUnlocked(opts: { force?: boolean }): Promise<RetrainerRunResult> {
+    const force = opts.force === true;
+    const state = this.state.read();
+    const serving = this.cfg.serving;
+
+    const currentCanary = serving?.currentCanary();
+    const currentProduction = serving?.currentProduction();
+
+    const preDecision = preTrainDecision({
+      state,
+      currentCanary,
+      currentProduction,
+      nowMs: this.cfg.clock().getTime(),
+      force,
+      retrainThreshold: this.cfg.retrainThreshold,
+      retrainMaxAgeMs: this.cfg.retrainMaxAgeMs,
+      canaryHoldDays: this.cfg.canaryHoldDays
+    });
+
+    if (preDecision.kind === 'skip-canary-active') {
+      const result: RetrainerRunResult = {
+        kind: 'skipped-canary-active',
+        canary: currentCanary!,
+        daysHeld: preDecision.daysHeld
+      };
+      const skipExtras: { adapterName?: string; note?: string } = { note: `canary held ${preDecision.daysHeld} day(s); soak continues` };
+      if (currentCanary?.adapterName !== undefined) skipExtras.adapterName = currentCanary.adapterName;
+      this.state.recordOutcome('skipped-canary-active', skipExtras);
+      this.digest.appendEntry({
+        at: this.cfg.clock().toISOString(),
+        outcome: 'skipped-canary-active',
+        body: renderBody(result)
+      });
+      return result;
+    }
+
+    if (preDecision.kind === 'prompt-operator-canary-held') {
+      const result: RetrainerRunResult = {
+        kind: 'canary-held-prompting-operator',
+        canary: currentCanary!,
+        daysHeld: preDecision.daysHeld
+      };
+      const heldExtras: { adapterName?: string; note?: string } = { note: `canary has held ${preDecision.daysHeld} day(s); operator decision required` };
+      if (currentCanary?.adapterName !== undefined) heldExtras.adapterName = currentCanary.adapterName;
+      this.state.recordOutcome('canary-held-prompting-operator', heldExtras);
+      this.digest.appendEntry({
+        at: this.cfg.clock().toISOString(),
+        outcome: 'canary-held-prompting-operator',
+        body: renderBody(result)
+      });
+      return result;
+    }
+
+    if (preDecision.kind === 'skip-no-delta') {
+      const result: RetrainerRunResult = {
+        kind: 'skipped-no-delta',
+        deltaCount: preDecision.deltaCount,
+        lastTrainAt: preDecision.lastTrainAt
+      };
+      this.state.recordOutcome('skipped-no-delta');
+      this.digest.appendEntry({
+        at: this.cfg.clock().toISOString(),
+        outcome: 'skipped-no-delta',
+        body: renderBody(result)
+      });
+      return result;
+    }
+
+    // ── kind === 'aggregate-and-train' ──
+    return this.runTrainCycle(state, force);
+  }
+
+  private async runTrainCycle(state: RetrainerStateFile, force: boolean): Promise<RetrainerRunResult> {
+    if (this.cfg.corpusAggregator === undefined) {
+      throw new CorpusFailedError('no corpusAggregator injected');
+    }
+    if (this.cfg.trainer === undefined) {
+      throw new TrainingFailedError('no trainer injected');
+    }
+    if (this.cfg.serving === undefined) {
+      throw new RegisterFailedError('no serving instance injected');
+    }
+
+    let aggregateResult;
+    try {
+      aggregateResult = await this.cfg.corpusAggregator.aggregate();
+    } catch (e) {
+      throw new CorpusFailedError((e as Error).message, { cause: (e as Error).name });
+    }
+
+    // Delta gate — caller hasn't checked count yet at decision time.
+    const isAged = state.lastSuccessfulTrain !== null
+      ? this.cfg.clock().getTime() - new Date(state.lastSuccessfulTrain.at).getTime() >= this.cfg.retrainMaxAgeMs
+      : true; // never trained
+    const newSamples = aggregateResult.newSamplesSinceLastRun ?? aggregateResult.totalSamples;
+    if (!shouldRetrainGivenDelta(newSamples, this.cfg.retrainThreshold, force || isAged)) {
+      const result: RetrainerRunResult = {
+        kind: 'skipped-no-delta',
+        deltaCount: newSamples,
+        lastTrainAt: state.lastSuccessfulTrain?.at ?? null
+      };
+      this.state.recordOutcome('skipped-no-delta');
+      this.digest.appendEntry({
+        at: this.cfg.clock().toISOString(),
+        outcome: 'skipped-no-delta',
+        body: renderBody(result)
+      });
+      return result;
+    }
+
+    let trainResult;
+    try {
+      trainResult = await this.cfg.trainer.train({ corpusManifestPath: aggregateResult.manifestPath });
+    } catch (e) {
+      throw new TrainingFailedError((e as Error).message, { cause: (e as Error).name });
+    }
+
+    let evalReport: EvalAdapterReport | undefined;
+    if (this.cfg.evalHarness !== undefined) {
+      try {
+        const report = await this.cfg.evalHarness.evaluate({
+          adapters: [
+            {
+              name: path.basename(trainResult.adapterPath),
+              kind: 'lora',
+              path: trainResult.adapterPath
+            }
+          ]
+        });
+        evalReport = report.adapters[0];
+      } catch (e) {
+        throw new EvalFailedError((e as Error).message, { cause: (e as Error).name });
+      }
+    }
+
+    let registered;
+    try {
+      registered = await this.cfg.serving.register(trainResult.adapterPath);
+    } catch (e) {
+      throw new RegisterFailedError((e as Error).message, { cause: (e as Error).name });
+    }
+
+    const post = postTrainDecision({ evalReport, evalWinRateGate: this.cfg.evalWinRateGate });
+
+    if (post.kind === 'promote-canary') {
+      try {
+        await this.cfg.serving.promoteToCanary(trainResult.adapterPath, this.cfg.defaultCanaryPercent);
+      } catch (e) {
+        throw new PromotionFailedError((e as Error).message, { cause: (e as Error).name });
+      }
+      this.state.recordSuccessfulTrain({
+        at: this.cfg.clock().toISOString(),
+        adapterPath: trainResult.adapterPath,
+        adapterName: registered.adapterName,
+        corpusManifestSha256: aggregateResult.corpusManifestSha256,
+        outcome: 'trained-and-canary-promoted'
+      });
+      this.state.recordCanaryPromotion(this.cfg.clock().toISOString());
+      this.state.recordOutcome('trained-and-canary-promoted', {
+        adapterName: registered.adapterName
+      });
+      const result: RetrainerRunResult = {
+        kind: 'trained-and-canary-promoted',
+        adapterPath: trainResult.adapterPath,
+        canaryPercent: this.cfg.defaultCanaryPercent,
+        ...(evalReport !== undefined ? { evalReport } : {})
+      };
+      this.digest.appendEntry({
+        at: this.cfg.clock().toISOString(),
+        outcome: 'trained-and-canary-promoted',
+        body: renderBody(result, evalReport)
+      });
+      return result;
+    }
+
+    // Reject path.
+    const reason = post.reason;
+    try {
+      await this.cfg.serving.reject(trainResult.adapterPath, reason);
+    } catch (e) {
+      throw new PromotionFailedError((e as Error).message, { cause: (e as Error).name });
+    }
+    this.state.recordSuccessfulTrain({
+      at: this.cfg.clock().toISOString(),
+      adapterPath: trainResult.adapterPath,
+      adapterName: registered.adapterName,
+      corpusManifestSha256: aggregateResult.corpusManifestSha256,
+      outcome: 'trained-and-rejected'
+    });
+    this.state.recordOutcome('trained-and-rejected', { adapterName: registered.adapterName, note: reason });
+    const result: RetrainerRunResult = {
+      kind: 'trained-and-rejected',
+      adapterPath: trainResult.adapterPath,
+      reason,
+      ...(evalReport !== undefined ? { evalReport } : {})
+    };
+    this.digest.appendEntry({
+      at: this.cfg.clock().toISOString(),
+      outcome: 'trained-and-rejected',
+      body: renderBody(result, evalReport)
+    });
+    return result;
+  }
+}

--- a/packages/apprentice-retrainer/src/state-store.ts
+++ b/packages/apprentice-retrainer/src/state-store.ts
@@ -1,0 +1,137 @@
+/**
+ * StateStore — owns the persisted retrainer-state.json file. Read-fresh-
+ * on-every-mutation; write-to-tmp + atomic rename. Pre-existing .bak
+ * preservation. Same pattern as apprentice-serving's AdapterRegistry.
+ */
+
+import * as path from 'node:path';
+import { StateCorruptError } from './types.js';
+import type {
+  FsAccess,
+  RetrainerOutcome,
+  RetrainerStateFile,
+  RetrainerHistoryEntry,
+  LastTrainRecord,
+  LastErrorRecord
+} from './types.js';
+
+export interface StateStoreConfig {
+  runStatePath: string;
+  fs: FsAccess;
+  clock: () => Date;
+  /** Default 52 (1 year of weekly history). */
+  historyMax?: number;
+}
+
+export class StateStore {
+  private readonly cfg: Required<StateStoreConfig>;
+
+  constructor(cfg: StateStoreConfig) {
+    this.cfg = { historyMax: 52, ...cfg };
+  }
+
+  read(): RetrainerStateFile {
+    const fs = this.cfg.fs;
+    const p = this.cfg.runStatePath;
+    if (!fs.exists(p)) return this.empty();
+    let raw: string;
+    try {
+      raw = fs.readFile(p);
+    } catch (e) {
+      throw new StateCorruptError(`failed to read state: ${(e as Error).message}`, { path: p });
+    }
+    if (raw.trim().length === 0) return this.empty();
+    try {
+      const parsed = JSON.parse(raw) as RetrainerStateFile;
+      if (parsed.version !== 1) {
+        throw new StateCorruptError(`unexpected state version: ${parsed.version}`, { path: p });
+      }
+      return parsed;
+    } catch (e) {
+      if (e instanceof StateCorruptError) throw e;
+      throw new StateCorruptError(`state JSON parse failed: ${(e as Error).message}`, { path: p });
+    }
+  }
+
+  /** Write atomically: tmp + rename. Pre-existing version backed up to .bak. */
+  write(state: RetrainerStateFile): void {
+    state.generatedAt = this.cfg.clock().toISOString();
+    if (state.history.length > this.cfg.historyMax) {
+      state.history = state.history.slice(-this.cfg.historyMax);
+    }
+    const fs = this.cfg.fs;
+    const p = this.cfg.runStatePath;
+    const dir = path.dirname(p);
+    if (!fs.exists(dir)) fs.mkdir(dir);
+    if (fs.exists(p)) {
+      try {
+        const prev = fs.readFile(p);
+        fs.writeFile(p + '.bak', prev);
+      } catch {
+        /* non-fatal */
+      }
+    }
+    const tmp = p + '.tmp';
+    fs.writeFile(tmp, JSON.stringify(state, null, 2) + '\n');
+    fs.rename(tmp, p);
+  }
+
+  /** Append a history entry + persist. Returns the updated state. */
+  recordOutcome(outcome: RetrainerOutcome, extras: { adapterName?: string; note?: string } = {}): RetrainerStateFile {
+    const state = this.read();
+    const entry: RetrainerHistoryEntry = {
+      at: this.cfg.clock().toISOString(),
+      outcome
+    };
+    if (extras.adapterName !== undefined) entry.adapterName = extras.adapterName;
+    if (extras.note !== undefined) entry.note = extras.note;
+    state.history.push(entry);
+    this.write(state);
+    return state;
+  }
+
+  recordSuccessfulTrain(record: LastTrainRecord): RetrainerStateFile {
+    const state = this.read();
+    state.lastSuccessfulTrain = record;
+    this.write(state);
+    return state;
+  }
+
+  recordCanaryPromotion(at: string): void {
+    const state = this.read();
+    state.lastCanaryPromotedAt = at;
+    this.write(state);
+  }
+
+  recordProductionPromotion(at: string): void {
+    const state = this.read();
+    state.lastProductionPromotedAt = at;
+    this.write(state);
+  }
+
+  recordError(err: LastErrorRecord): void {
+    const state = this.read();
+    state.lastError = err;
+    this.write(state);
+  }
+
+  clearError(): void {
+    const state = this.read();
+    if (state.lastError !== null) {
+      state.lastError = null;
+      this.write(state);
+    }
+  }
+
+  private empty(): RetrainerStateFile {
+    return {
+      version: 1,
+      generatedAt: this.cfg.clock().toISOString(),
+      lastSuccessfulTrain: null,
+      lastCanaryPromotedAt: null,
+      lastProductionPromotedAt: null,
+      lastError: null,
+      history: []
+    };
+  }
+}

--- a/packages/apprentice-retrainer/src/types.ts
+++ b/packages/apprentice-retrainer/src/types.ts
@@ -1,0 +1,247 @@
+/**
+ * @chiefaia/apprentice-retrainer — shared types.
+ *
+ * Phase 4: cron-driven orchestrator that runs corpus → train → eval →
+ * register → promote-canary end-to-end. Reads + writes a persisted
+ * run-state file. Operator-prompts for full canary → production promotion.
+ *
+ * Per Option E: every CAIA-specific path / threshold / pipeline is an
+ * injected constructor parameter with a CAIA default. Tests pass fakes.
+ */
+
+import type {
+  ApprenticeServing,
+  RegistryEntry
+} from '@chiefaia/apprentice-serving';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Pipeline duck-types — Phase 4 imports the upstream packages at RUNTIME
+// only (via dynamic import in the wrapper modules). Build-time deps stay
+// minimal. Tests inject fake implementations of these interfaces.
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface CorpusAggregator {
+  /** Produce a fresh corpus snapshot. Returns the path to the manifest.json. */
+  aggregate(): Promise<CorpusAggregateResult>;
+}
+
+export interface CorpusAggregateResult {
+  manifestPath: string;
+  corpusManifestSha256: string;
+  totalSamples: number;
+  newSamplesSinceLastRun?: number;
+}
+
+export interface Trainer {
+  /** Run training; return the adapter directory path + adapter name. */
+  train(args: TrainerRequest): Promise<TrainerResult>;
+}
+
+export interface TrainerRequest {
+  corpusManifestPath: string;
+}
+
+export interface TrainerResult {
+  adapterPath: string;
+  /** Subset of training-metadata.json for sanity checks. */
+  configSha256: string;
+  baseModelOllamaTag: string;
+}
+
+export interface EvalHarness {
+  evaluate(args: EvalRequest): Promise<EvalReport>;
+}
+
+export interface EvalRequest {
+  adapters: Array<{ name: string; kind: string; path: string }>;
+}
+
+export interface EvalAdapterReport {
+  name: string;
+  winRate: number;
+  decision: string;
+  regressionFlags: string[];
+}
+
+export interface EvalReport {
+  adapters: EvalAdapterReport[];
+  outputDir: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Run-state file shape
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface RetrainerStateFile {
+  version: 1;
+  generatedAt: string;
+  lastSuccessfulTrain: LastTrainRecord | null;
+  lastCanaryPromotedAt: string | null;
+  lastProductionPromotedAt: string | null;
+  lastError: LastErrorRecord | null;
+  history: RetrainerHistoryEntry[];
+}
+
+export interface LastTrainRecord {
+  at: string;
+  adapterPath: string;
+  adapterName: string;
+  corpusManifestSha256: string;
+  outcome: RetrainerOutcome;
+}
+
+export interface LastErrorRecord {
+  at: string;
+  message: string;
+  kind: string;
+}
+
+export interface RetrainerHistoryEntry {
+  at: string;
+  outcome: RetrainerOutcome;
+  adapterName?: string;
+  note?: string;
+}
+
+export type RetrainerOutcome =
+  | 'skipped-no-delta'
+  | 'skipped-canary-active'
+  | 'trained-and-rejected'
+  | 'trained-and-canary-promoted'
+  | 'canary-held-prompting-operator'
+  | 'failed';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Run result
+// ──────────────────────────────────────────────────────────────────────────
+
+export type RetrainerRunResult =
+  | { kind: 'skipped-no-delta'; deltaCount: number; lastTrainAt: string | null }
+  | { kind: 'skipped-canary-active'; canary: RegistryEntry; daysHeld: number }
+  | { kind: 'trained-and-rejected'; adapterPath: string; reason: string; evalReport?: EvalAdapterReport }
+  | { kind: 'trained-and-canary-promoted'; adapterPath: string; canaryPercent: number; evalReport?: EvalAdapterReport }
+  | { kind: 'canary-held-prompting-operator'; canary: RegistryEntry; daysHeld: number }
+  | { kind: 'failed'; error: { message: string; kind: string } };
+
+// ──────────────────────────────────────────────────────────────────────────
+// Test seams
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FsAccess {
+  exists(p: string): boolean;
+  readFile(p: string): string;
+  writeFile(p: string, content: string): void;
+  mkdir(p: string): void;
+  rename(oldP: string, newP: string): void;
+  unlink(p: string): void;
+  appendFile?(p: string, content: string): void;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Configuration
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface ApprenticeRetrainerConfig {
+  /** Default: ~/Documents/projects/apprentice/retrainer-state.json */
+  runStatePath?: string;
+  /** Default: ~/Documents/projects/reports/apprentice-retrainer-digest.md */
+  digestPath?: string;
+  /** Default: ~/Documents/projects/apprentice/retrainer.lock */
+  lockfilePath?: string;
+
+  /** Default: 500 — minimum new pairs to trigger retrain. */
+  retrainThreshold?: number;
+  /** Default: 7 days — max age before retrain even with insufficient delta. */
+  retrainMaxAgeMs?: number;
+  /** Default: 0.60 — eval winRate gate for auto-canary-promote. */
+  evalWinRateGate?: number;
+  /** Default: 10 — initial canary traffic percent. */
+  defaultCanaryPercent?: number;
+  /** Default: 3 — days a canary must hold before operator-prompt. */
+  canaryHoldDays?: number;
+
+  // — injected pipelines (Option E) —
+  corpusAggregator?: CorpusAggregator;
+  trainer?: Trainer;
+  evalHarness?: EvalHarness;
+  serving?: ApprenticeServing;
+
+  // — test seams —
+  fs?: FsAccess;
+  clock?: () => Date;
+}
+
+export type ResolvedRetrainerConfig = Required<
+  Omit<
+    ApprenticeRetrainerConfig,
+    'corpusAggregator' | 'trainer' | 'evalHarness' | 'serving'
+  >
+> & {
+  corpusAggregator?: CorpusAggregator;
+  trainer?: Trainer;
+  evalHarness?: EvalHarness;
+  serving?: ApprenticeServing;
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Errors
+// ──────────────────────────────────────────────────────────────────────────
+
+export class RetrainerError extends Error {
+  public override readonly name: string;
+  constructor(name: string, message: string, public readonly details?: Record<string, unknown>) {
+    super(message);
+    this.name = name;
+  }
+}
+
+export class LockfileError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('LockfileError', message, details);
+  }
+}
+
+export class CorpusFailedError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('CorpusFailedError', message, details);
+  }
+}
+
+export class TrainingFailedError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('TrainingFailedError', message, details);
+  }
+}
+
+export class EvalFailedError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('EvalFailedError', message, details);
+  }
+}
+
+export class RegisterFailedError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('RegisterFailedError', message, details);
+  }
+}
+
+export class PromotionFailedError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('PromotionFailedError', message, details);
+  }
+}
+
+export class StateCorruptError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('StateCorruptError', message, details);
+  }
+}
+
+export class NoCanaryActiveError extends RetrainerError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('NoCanaryActiveError', message, details);
+  }
+}
+
+// Re-export RegistryEntry so callers don't need to dual-import.
+export type { RegistryEntry };

--- a/packages/apprentice-retrainer/tests/decision.test.ts
+++ b/packages/apprentice-retrainer/tests/decision.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import {
+  postTrainDecision,
+  preTrainDecision,
+  shouldRetrainGivenDelta
+} from '../src/decision.js';
+import type {
+  DecisionInput,
+  PostTrainDecisionInput
+} from '../src/decision.js';
+import type { RegistryEntry, RetrainerStateFile } from '../src/types.js';
+
+function emptyState(): RetrainerStateFile {
+  return {
+    version: 1,
+    generatedAt: '2026-05-06T00:00:00.000Z',
+    lastSuccessfulTrain: null,
+    lastCanaryPromotedAt: null,
+    lastProductionPromotedAt: null,
+    lastError: null,
+    history: []
+  };
+}
+
+function makeCanary(promotedAtIso: string): RegistryEntry {
+  return {
+    adapterName: 'qwen-c',
+    adapterPath: '/a/qwen-c',
+    metadataSha256: 'a'.repeat(64),
+    configSha256: 'cfg',
+    baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+    baseModelOllamaTag: 'qwen2.5-coder:7b',
+    status: 'canary',
+    history: [],
+    canaryPercent: 10,
+    ollamaModelName: 'qwen2-5-coder-7b-canary-abc',
+    registeredAt: promotedAtIso,
+    promotedAt: promotedAtIso
+  };
+}
+
+function defaults(overrides: Partial<DecisionInput> = {}): DecisionInput {
+  return {
+    state: emptyState(),
+    currentCanary: undefined,
+    currentProduction: undefined,
+    nowMs: new Date('2026-05-06T02:00:00.000Z').getTime(),
+    force: false,
+    retrainThreshold: 500,
+    retrainMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+    canaryHoldDays: 3,
+    ...overrides
+  };
+}
+
+describe('preTrainDecision', () => {
+  it('aggregates+trains when never trained and no canary', () => {
+    expect(preTrainDecision(defaults()).kind).toBe('aggregate-and-train');
+  });
+
+  it('skips when last train is recent and no force', () => {
+    const state = emptyState();
+    state.lastSuccessfulTrain = {
+      at: '2026-05-04T00:00:00.000Z',
+      adapterPath: '/x',
+      adapterName: 'x',
+      corpusManifestSha256: 's',
+      outcome: 'trained-and-canary-promoted'
+    };
+    const d = preTrainDecision(defaults({ state }));
+    expect(d.kind).toBe('skip-no-delta');
+  });
+
+  it('aggregates+trains when last train is older than retrainMaxAge', () => {
+    const state = emptyState();
+    state.lastSuccessfulTrain = {
+      at: '2026-04-15T00:00:00.000Z', // 3 weeks before nowMs
+      adapterPath: '/x',
+      adapterName: 'x',
+      corpusManifestSha256: 's',
+      outcome: 'trained-and-canary-promoted'
+    };
+    const d = preTrainDecision(defaults({ state }));
+    expect(d.kind).toBe('aggregate-and-train');
+  });
+
+  it('aggregates+trains when force=true (no canary)', () => {
+    const state = emptyState();
+    state.lastSuccessfulTrain = {
+      at: '2026-05-05T00:00:00.000Z',
+      adapterPath: '/x',
+      adapterName: 'x',
+      corpusManifestSha256: 's',
+      outcome: 'trained-and-canary-promoted'
+    };
+    const d = preTrainDecision(defaults({ state, force: true }));
+    expect(d.kind).toBe('aggregate-and-train');
+  });
+
+  it('skips when canary still in soak window', () => {
+    const canary = makeCanary('2026-05-05T00:00:00.000Z'); // 1 day old
+    const d = preTrainDecision(defaults({ currentCanary: canary }));
+    expect(d.kind).toBe('skip-canary-active');
+  });
+
+  it('skips when canary still in soak window even with force', () => {
+    const canary = makeCanary('2026-05-05T00:00:00.000Z');
+    const d = preTrainDecision(defaults({ currentCanary: canary, force: true }));
+    expect(d.kind).toBe('skip-canary-active');
+  });
+
+  it('prompts operator when canary held >= canaryHoldDays', () => {
+    const canary = makeCanary('2026-05-01T00:00:00.000Z'); // 5 days old
+    const d = preTrainDecision(defaults({ currentCanary: canary }));
+    expect(d.kind).toBe('prompt-operator-canary-held');
+  });
+});
+
+describe('shouldRetrainGivenDelta', () => {
+  it('always trains when forceOrAge=true', () => {
+    expect(shouldRetrainGivenDelta(0, 500, true)).toBe(true);
+  });
+
+  it('trains at threshold', () => {
+    expect(shouldRetrainGivenDelta(500, 500, false)).toBe(true);
+    expect(shouldRetrainGivenDelta(499, 500, false)).toBe(false);
+  });
+});
+
+describe('postTrainDecision', () => {
+  function input(overrides: Partial<PostTrainDecisionInput> = {}): PostTrainDecisionInput {
+    return {
+      evalReport: undefined,
+      evalWinRateGate: 0.6,
+      ...overrides
+    };
+  }
+
+  it('rejects when eval not available (no harness)', () => {
+    const d = postTrainDecision(input());
+    expect(d.kind).toBe('reject-no-eval');
+  });
+
+  it('rejects when winRate below gate', () => {
+    const d = postTrainDecision(
+      input({
+        evalReport: { name: 'x', winRate: 0.5, decision: 'reject', regressionFlags: [] }
+      })
+    );
+    expect(d.kind).toBe('reject-low-winrate');
+  });
+
+  it('rejects when regressions present even with high winRate', () => {
+    const d = postTrainDecision(
+      input({
+        evalReport: { name: 'x', winRate: 0.9, decision: 'promote', regressionFlags: ['p1'] }
+      })
+    );
+    expect(d.kind).toBe('reject-regressions');
+  });
+
+  it('promotes canary when winRate above gate AND no regressions', () => {
+    const d = postTrainDecision(
+      input({
+        evalReport: { name: 'x', winRate: 0.7, decision: 'promote-canary', regressionFlags: [] }
+      })
+    );
+    expect(d.kind).toBe('promote-canary');
+  });
+
+  it('promotes canary at exactly the gate (>= boundary clarification: < strict)', () => {
+    const d = postTrainDecision(
+      input({
+        evalReport: { name: 'x', winRate: 0.6, decision: 'promote-canary', regressionFlags: [] }
+      })
+    );
+    // 0.6 is NOT < 0.6 — so promote.
+    expect(d.kind).toBe('promote-canary');
+  });
+});

--- a/packages/apprentice-retrainer/tests/digest.test.ts
+++ b/packages/apprentice-retrainer/tests/digest.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { DigestWriter, renderBody } from '../src/digest.js';
+import { createInMemoryFs } from './helpers/fakes.js';
+import type { RegistryEntry } from '../src/types.js';
+
+function makeCanary(): RegistryEntry {
+  return {
+    adapterName: 'qwen-c',
+    adapterPath: '/a/qwen-c',
+    metadataSha256: 'a'.repeat(64),
+    configSha256: 'cfg',
+    baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+    baseModelOllamaTag: 'qwen2.5-coder:7b',
+    status: 'canary',
+    history: [],
+    canaryPercent: 10,
+    ollamaModelName: 'qwen2-5-coder-7b-canary-abc',
+    registeredAt: '2026-05-06T00:00:00.000Z',
+    promotedAt: '2026-05-06T00:00:00.000Z'
+  };
+}
+
+describe('DigestWriter', () => {
+  it('creates the file with a header on first append', () => {
+    const fs = createInMemoryFs();
+    const w = new DigestWriter(fs, '/reports/digest.md');
+    w.appendEntry({ at: '2026-05-06T02:00:00Z', outcome: 'skipped-no-delta', body: 'no work' });
+    expect(fs.exists('/reports/digest.md')).toBe(true);
+    const content = fs.readFile('/reports/digest.md');
+    expect(content).toContain('# Apprentice Retrainer — operator digest');
+    expect(content).toContain('skipped (no corpus delta)');
+  });
+
+  it('appends to an existing file (preserves history)', () => {
+    const fs = createInMemoryFs();
+    const w = new DigestWriter(fs, '/reports/digest.md');
+    w.appendEntry({ at: '2026-05-01T02:00:00Z', outcome: 'trained-and-canary-promoted', body: 'A' });
+    w.appendEntry({ at: '2026-05-08T02:00:00Z', outcome: 'skipped-canary-active', body: 'B' });
+    const content = fs.readFile('/reports/digest.md');
+    expect(content).toContain('## 2026-05-01T02:00:00Z');
+    expect(content).toContain('## 2026-05-08T02:00:00Z');
+  });
+});
+
+describe('renderBody', () => {
+  it('renders skipped-no-delta', () => {
+    const md = renderBody({ kind: 'skipped-no-delta', deltaCount: 12, lastTrainAt: '2026-05-01T00:00:00Z' });
+    expect(md).toContain('Delta: 12');
+    expect(md).toContain('2026-05-01T00:00:00Z');
+  });
+
+  it('renders skipped-canary-active', () => {
+    const md = renderBody({ kind: 'skipped-canary-active', canary: makeCanary(), daysHeld: 1 });
+    expect(md).toContain('1 day(s)');
+    expect(md).toContain('qwen-c');
+  });
+
+  it('renders trained-and-canary-promoted', () => {
+    const md = renderBody({
+      kind: 'trained-and-canary-promoted',
+      adapterPath: '/a/x',
+      canaryPercent: 10,
+      evalReport: { name: 'x', winRate: 0.72, decision: 'promote-canary', regressionFlags: [] }
+    });
+    expect(md).toContain('promoted to canary');
+    expect(md).toContain('10%');
+    expect(md).toContain('0.720');
+  });
+
+  it('renders trained-and-rejected', () => {
+    const md = renderBody({
+      kind: 'trained-and-rejected',
+      adapterPath: '/a/x',
+      reason: 'eval winRate=0.45 below gate=0.60'
+    });
+    expect(md).toContain('rejected at eval gate');
+    expect(md).toContain('eval winRate=0.45');
+  });
+
+  it('renders canary-held-prompting-operator', () => {
+    const md = renderBody({ kind: 'canary-held-prompting-operator', canary: makeCanary(), daysHeld: 4 });
+    expect(md).toContain('Operator action required');
+    expect(md).toContain('promote-canary');
+    expect(md).toContain('reject-canary');
+  });
+
+  it('renders failed', () => {
+    const md = renderBody({ kind: 'failed', error: { message: 'boom', kind: 'TestError' } });
+    expect(md).toContain('Retraining failed');
+    expect(md).toContain('TestError');
+    expect(md).toContain('boom');
+  });
+});

--- a/packages/apprentice-retrainer/tests/helpers/fakes.ts
+++ b/packages/apprentice-retrainer/tests/helpers/fakes.ts
@@ -1,0 +1,334 @@
+/**
+ * Test fakes — in-memory FsAccess + scriptable corpus/trainer/eval/serving
+ * for end-to-end retrainer testing.
+ */
+
+import * as path from 'node:path';
+import type {
+  CorpusAggregator,
+  CorpusAggregateResult,
+  EvalAdapterReport,
+  EvalHarness,
+  EvalReport,
+  EvalRequest,
+  FsAccess,
+  RegistryEntry,
+  Trainer,
+  TrainerRequest,
+  TrainerResult
+} from '../../src/types.js';
+import type { ApprenticeServing } from '@chiefaia/apprentice-serving';
+
+// ──────────────────────────────────────────────────────────────────────────
+// In-memory FsAccess (mirrors apprentice-serving's fake)
+// ──────────────────────────────────────────────────────────────────────────
+
+interface InMemoryFile {
+  content: string;
+  mtimeMs: number;
+}
+
+export interface InMemoryFs extends FsAccess {
+  put(p: string, content: string): void;
+  putDir(p: string): void;
+  dump(): Record<string, string>;
+  has(p: string): boolean;
+}
+
+export function createInMemoryFs(): InMemoryFs {
+  const files = new Map<string, InMemoryFile>();
+  const dirs = new Set<string>();
+  let mtimeCursor = 1_700_000_000_000;
+  function ensureParents(p: string): void {
+    let cur = path.dirname(p);
+    while (cur && cur !== '/' && cur !== '.' && !dirs.has(cur)) {
+      dirs.add(cur);
+      const parent = path.dirname(cur);
+      if (parent === cur) break;
+      cur = parent;
+    }
+  }
+  return {
+    exists: (p) => files.has(p) || dirs.has(p),
+    readFile: (p) => {
+      const f = files.get(p);
+      if (!f) throw new Error('ENOENT: ' + p);
+      return f.content;
+    },
+    writeFile: (p, c) => {
+      ensureParents(p);
+      mtimeCursor += 1;
+      files.set(p, { content: c, mtimeMs: mtimeCursor });
+    },
+    mkdir: (p) => {
+      dirs.add(p);
+      ensureParents(p);
+    },
+    rename: (o, n) => {
+      const f = files.get(o);
+      if (!f) throw new Error('ENOENT: ' + o);
+      ensureParents(n);
+      mtimeCursor += 1;
+      files.set(n, { content: f.content, mtimeMs: mtimeCursor });
+      files.delete(o);
+    },
+    unlink: (p) => {
+      if (!files.has(p)) throw new Error('ENOENT: ' + p);
+      files.delete(p);
+    },
+    appendFile: (p, c) => {
+      const existing = files.get(p);
+      const content = (existing?.content ?? '') + c;
+      mtimeCursor += 1;
+      ensureParents(p);
+      files.set(p, { content, mtimeMs: mtimeCursor });
+    },
+    put: (p, c) => {
+      ensureParents(p);
+      mtimeCursor += 1;
+      files.set(p, { content: c, mtimeMs: mtimeCursor });
+    },
+    putDir: (p) => {
+      dirs.add(p);
+      ensureParents(p);
+    },
+    dump: () => {
+      const out: Record<string, string> = {};
+      for (const [k, v] of files.entries()) out[k] = v.content;
+      return out;
+    },
+    has: (p) => files.has(p)
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fake corpus aggregator
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FakeCorpusAggregator extends CorpusAggregator {
+  scripted: CorpusAggregateResult[];
+  calls: number;
+}
+
+export function createFakeCorpusAggregator(scripted: CorpusAggregateResult[]): FakeCorpusAggregator {
+  let calls = 0;
+  const list = [...scripted];
+  return {
+    scripted: list,
+    get calls() {
+      return calls;
+    },
+    async aggregate() {
+      calls += 1;
+      const next = list.shift();
+      if (!next) throw new Error('FakeCorpusAggregator: scripted exhausted');
+      return next;
+    }
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fake trainer
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FakeTrainer extends Trainer {
+  scripted: TrainerResult[];
+  invocations: TrainerRequest[];
+}
+
+export function createFakeTrainer(scripted: TrainerResult[]): FakeTrainer {
+  const invocations: TrainerRequest[] = [];
+  const list = [...scripted];
+  return {
+    scripted: list,
+    invocations,
+    async train(req: TrainerRequest) {
+      invocations.push(req);
+      const next = list.shift();
+      if (!next) throw new Error('FakeTrainer: scripted exhausted');
+      return next;
+    }
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fake eval harness
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FakeEvalHarness extends EvalHarness {
+  scripted: EvalAdapterReport[];
+  invocations: EvalRequest[];
+}
+
+export function createFakeEvalHarness(scripted: EvalAdapterReport[]): FakeEvalHarness {
+  const invocations: EvalRequest[] = [];
+  const list = [...scripted];
+  return {
+    scripted: list,
+    invocations,
+    async evaluate(req: EvalRequest): Promise<EvalReport> {
+      invocations.push(req);
+      const next = list.shift();
+      if (!next) throw new Error('FakeEvalHarness: scripted exhausted');
+      return { adapters: [next], outputDir: '/fake-eval' };
+    }
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fake ApprenticeServing — implements the subset the retrainer uses
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FakeServingState {
+  registered: Map<string, RegistryEntry>;
+  /** invocation log */
+  calls: Array<
+    | { op: 'register'; adapterPath: string }
+    | { op: 'promoteToCanary'; adapterPath: string; percent: number }
+    | { op: 'promoteToProduction'; adapterPath: string }
+    | { op: 'reject'; adapterPath: string; reason: string }
+  >;
+}
+
+export function createFakeServing(
+  initial: FakeServingState = { registered: new Map(), calls: [] },
+  clock: () => Date = () => new Date()
+): ApprenticeServing & {
+  fakeState: FakeServingState;
+} {
+  const state = initial;
+  function nowIso(): string {
+    return clock().toISOString();
+  }
+  function bumpHistory(e: RegistryEntry, toStatus: RegistryEntry['status'], note?: string): void {
+    e.history.push({
+      at: nowIso(),
+      fromStatus: e.status,
+      toStatus,
+      ...(note !== undefined ? { note } : {})
+    });
+    e.status = toStatus;
+  }
+  function makeEntry(adapterPath: string): RegistryEntry {
+    const adapterName = path.basename(adapterPath);
+    return {
+      adapterName,
+      adapterPath,
+      metadataSha256: 'a'.repeat(64),
+      configSha256: 'cfg-' + adapterName,
+      baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+      baseModelOllamaTag: 'qwen2.5-coder:7b',
+      status: 'registered',
+      history: [{ at: nowIso(), fromStatus: null, toStatus: 'registered' }],
+      registeredAt: nowIso()
+    };
+  }
+  const fake = {
+    fakeState: state,
+    async register(adapterPath: string): Promise<RegistryEntry> {
+      state.calls.push({ op: 'register', adapterPath });
+      const adapterName = path.basename(adapterPath);
+      let e = state.registered.get(adapterName);
+      if (e === undefined) {
+        e = makeEntry(adapterPath);
+        state.registered.set(adapterName, e);
+      }
+      return e;
+    },
+    async promoteToCanary(adapterPath: string, percent: number): Promise<RegistryEntry> {
+      state.calls.push({ op: 'promoteToCanary', adapterPath, percent });
+      const adapterName = path.basename(adapterPath);
+      // Archive any existing canary first.
+      for (const other of state.registered.values()) {
+        if (other.status === 'canary' && other.adapterName !== adapterName) {
+          bumpHistory(other, 'archived', 'replaced by newer canary');
+          other.archivedAt = nowIso();
+          delete other.canaryPercent;
+          delete other.ollamaModelName;
+        }
+      }
+      let e = state.registered.get(adapterName);
+      if (e === undefined) {
+        e = makeEntry(adapterPath);
+        state.registered.set(adapterName, e);
+      }
+      bumpHistory(e, 'canary');
+      e.canaryPercent = percent;
+      e.ollamaModelName = `qwen2-5-coder-7b-canary-${e.metadataSha256.slice(0, 7)}`;
+      e.promotedAt = nowIso();
+      return e;
+    },
+    async promoteToProduction(adapterPath: string): Promise<RegistryEntry> {
+      state.calls.push({ op: 'promoteToProduction', adapterPath });
+      const adapterName = path.basename(adapterPath);
+      // Archive prior production.
+      for (const other of state.registered.values()) {
+        if (other.status === 'production' && other.adapterName !== adapterName) {
+          bumpHistory(other, 'archived', 'replaced by newer production');
+          other.archivedAt = nowIso();
+          delete other.ollamaModelName;
+        }
+      }
+      let e = state.registered.get(adapterName);
+      if (e === undefined) {
+        e = makeEntry(adapterPath);
+        state.registered.set(adapterName, e);
+      }
+      bumpHistory(e, 'production');
+      delete e.canaryPercent;
+      e.ollamaModelName = 'qwen2-5-coder-7b-production';
+      e.promotedAt = nowIso();
+      return e;
+    },
+    async rollback(toAdapterPath: string): Promise<RegistryEntry> {
+      const adapterName = path.basename(toAdapterPath);
+      const e = state.registered.get(adapterName);
+      if (!e) throw new Error(`fake serving: not registered: ${adapterName}`);
+      bumpHistory(e, 'production');
+      e.ollamaModelName = 'qwen2-5-coder-7b-production';
+      delete e.archivedAt;
+      return e;
+    },
+    async reject(adapterPath: string, reason: string): Promise<RegistryEntry> {
+      state.calls.push({ op: 'reject', adapterPath, reason });
+      const adapterName = path.basename(adapterPath);
+      let e = state.registered.get(adapterName);
+      if (e === undefined) {
+        e = makeEntry(adapterPath);
+        state.registered.set(adapterName, e);
+      }
+      bumpHistory(e, 'rejected');
+      e.rejectionReason = reason;
+      delete e.canaryPercent;
+      delete e.ollamaModelName;
+      return e;
+    },
+    list(): RegistryEntry[] {
+      return Array.from(state.registered.values());
+    },
+    currentProduction(): RegistryEntry | undefined {
+      return Array.from(state.registered.values()).find((e) => e.status === 'production');
+    },
+    currentCanary(): RegistryEntry | undefined {
+      return Array.from(state.registered.values()).find((e) => e.status === 'canary');
+    }
+  };
+  return fake as unknown as ApprenticeServing & { fakeState: FakeServingState };
+}
+
+export function createFakeClock(start = '2026-05-06T02:00:00.000Z'): {
+  clock: () => Date;
+  advance(ms: number): void;
+  setNow(iso: string): void;
+} {
+  let cursor = new Date(start).getTime();
+  return {
+    clock: () => new Date(cursor),
+    advance(ms: number) {
+      cursor += ms;
+    },
+    setNow(iso: string) {
+      cursor = new Date(iso).getTime();
+    }
+  };
+}

--- a/packages/apprentice-retrainer/tests/retrainer.integration.test.ts
+++ b/packages/apprentice-retrainer/tests/retrainer.integration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * 3-cycle weekly cadence integration test:
+ *   Cycle 1: corpus delta < threshold → skipped-no-delta
+ *   Cycle 2: corpus delta ≥ threshold + good eval → trained-and-canary-promoted
+ *   Cycle 3: canary still active < 3 days → skipped-canary-active
+ *   Cycle 4: canary > 3 days → canary-held-prompting-operator
+ *   Cycle 5: operator promotes canary; another retrain runs end-to-end
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ApprenticeRetrainer } from '../src/retrainer.js';
+import {
+  createFakeClock,
+  createFakeCorpusAggregator,
+  createFakeEvalHarness,
+  createFakeServing,
+  createFakeTrainer,
+  createInMemoryFs
+} from './helpers/fakes.js';
+
+describe('ApprenticeRetrainer integration — 5-cycle weekly cadence', () => {
+  it('walks the full lifecycle through 5 cron ticks', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+
+    // Pre-seed state with a recent successful train so cycle 1 takes the
+    // skip-no-delta short-circuit (last train is < retrainMaxAge, no canary).
+    fs.put(
+      '/data/state.json',
+      JSON.stringify(
+        {
+          version: 1,
+          generatedAt: '2026-05-01T00:00:00.000Z',
+          lastSuccessfulTrain: {
+            at: '2026-05-01T00:00:00.000Z',
+            adapterPath: '/adapters/2026-04-25-qwen',
+            adapterName: '2026-04-25-qwen',
+            corpusManifestSha256: 'sha-prev',
+            outcome: 'trained-and-canary-promoted'
+          },
+          lastCanaryPromotedAt: null,
+          lastProductionPromotedAt: '2026-05-01T00:00:00.000Z',
+          lastError: null,
+          history: []
+        },
+        null,
+        2
+      )
+    );
+
+    // Scripts: cycle 2 (aged → good train), cycle 5 (aged → good train).
+    const aggregator = createFakeCorpusAggregator([
+      // cycle 2 — small delta but aged → train anyway
+      // cycle 5 — large delta after operator promotes canary
+      {
+        manifestPath: '/c/2026-05-13/manifest.json',
+        corpusManifestSha256: 'sha-2',
+        totalSamples: 700,
+        newSamplesSinceLastRun: 700
+      },
+      {
+        manifestPath: '/c/2026-05-20/manifest.json',
+        corpusManifestSha256: 'sha-3',
+        totalSamples: 1500,
+        newSamplesSinceLastRun: 1500
+      }
+    ]);
+
+    const trainer = createFakeTrainer([
+      // cycle 2 trains on sha-2
+      {
+        adapterPath: '/adapters/2026-05-13-qwen',
+        configSha256: 'cfg-2',
+        baseModelOllamaTag: 'qwen2.5-coder:7b'
+      },
+      // cycle 5 trains on sha-3
+      {
+        adapterPath: '/adapters/2026-05-20-qwen',
+        configSha256: 'cfg-3',
+        baseModelOllamaTag: 'qwen2.5-coder:7b'
+      }
+    ]);
+
+    const evalH = createFakeEvalHarness([
+      // cycle 2 — good
+      { name: '2026-05-13-qwen', winRate: 0.72, decision: 'promote-canary', regressionFlags: [] },
+      // cycle 5 — good
+      { name: '2026-05-20-qwen', winRate: 0.75, decision: 'promote-canary', regressionFlags: [] }
+    ]);
+
+    const serving = createFakeServing({ registered: new Map(), calls: [] }, fc.clock);
+
+    function makeRetrainer() {
+      return new ApprenticeRetrainer({
+        runStatePath: '/data/state.json',
+        digestPath: '/reports/digest.md',
+        lockfilePath: '/data/lock',
+        fs,
+        clock: fc.clock,
+        corpusAggregator: aggregator,
+        trainer,
+        evalHarness: evalH,
+        serving
+      });
+    }
+
+    // === Cycle 1 — Saturday May 2: last successful train is recent (May 1),
+    // no canary, no force → preTrainDecision short-circuits at skip-no-delta.
+    fc.setNow('2026-05-02T02:00:00.000Z');
+    {
+      const r = makeRetrainer();
+      const result = await r.run();
+      expect(result.kind).toBe('skipped-no-delta');
+    }
+
+    // === Cycle 2 — Saturday May 13 (>7 days later, force aggregation): good train
+    fc.setNow('2026-05-13T02:00:00.000Z');
+    {
+      const r = makeRetrainer();
+      const result = await r.run();
+      expect(result.kind).toBe('trained-and-canary-promoted');
+      expect(serving.currentCanary()?.adapterName).toBe('2026-05-13-qwen');
+    }
+
+    // === Cycle 3 — Saturday May 16 (3 days later — CANARY HELD = exactly 3 days, prompts operator)
+    fc.setNow('2026-05-16T02:00:00.000Z');
+    {
+      const r = makeRetrainer();
+      const result = await r.run();
+      expect(result.kind).toBe('canary-held-prompting-operator');
+    }
+
+    // === Cycle 4 — Saturday May 14 (1 day after canary, soak window, skipped)
+    fc.setNow('2026-05-14T02:00:00.000Z');
+    {
+      const r = makeRetrainer();
+      const result = await r.run();
+      expect(result.kind).toBe('skipped-canary-active');
+    }
+
+    // === Operator promotes canary → production
+    fc.setNow('2026-05-17T10:00:00.000Z');
+    {
+      const r = makeRetrainer();
+      const promoted = await r.promoteCanaryToProduction();
+      expect(promoted.status).toBe('production');
+    }
+
+    // === Cycle 5 — Saturday May 23: production stable; new corpus delta; new train cycle
+    fc.setNow('2026-05-23T02:00:00.000Z');
+    {
+      const r = makeRetrainer();
+      const result = await r.run();
+      expect(result.kind).toBe('trained-and-canary-promoted');
+      // Old production v1 should be archived; new canary v2 should exist.
+      const v1 = serving.fakeState.registered.get('2026-05-13-qwen');
+      const v2 = serving.fakeState.registered.get('2026-05-20-qwen');
+      expect(v1?.status).toBe('production');
+      expect(v2?.status).toBe('canary');
+    }
+
+    // === Verify digest entries written for every cycle
+    const digest = fs.readFile('/reports/digest.md');
+    expect(digest).toContain('# Apprentice Retrainer — operator digest');
+    expect(digest).toContain('skipped (no corpus delta)');
+    expect(digest).toContain('trained + promoted to canary');
+    expect(digest).toContain('Operator action required');
+    expect(digest).toContain('skipped (canary still active)');
+    // Operator promote also appends an entry.
+    expect(digest).toContain('Operator-promoted canary to production');
+  });
+});

--- a/packages/apprentice-retrainer/tests/retrainer.test.ts
+++ b/packages/apprentice-retrainer/tests/retrainer.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from 'vitest';
+import { ApprenticeRetrainer } from '../src/retrainer.js';
+import {
+  createFakeClock,
+  createFakeCorpusAggregator,
+  createFakeEvalHarness,
+  createFakeServing,
+  createFakeTrainer,
+  createInMemoryFs
+} from './helpers/fakes.js';
+
+describe('ApprenticeRetrainer.run() — orchestration', () => {
+  it('skips when last train is recent and no canary', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fc.setNow('2026-05-09T02:00:00.000Z');
+    // Pre-seed a recent training in state.
+    fs.put(
+      '/data/state.json',
+      JSON.stringify(
+        {
+          version: 1,
+          generatedAt: '2026-05-08T00:00:00.000Z',
+          lastSuccessfulTrain: {
+            at: '2026-05-08T00:00:00.000Z',
+            adapterPath: '/a/x',
+            adapterName: 'x',
+            corpusManifestSha256: 'sha',
+            outcome: 'trained-and-canary-promoted'
+          },
+          lastCanaryPromotedAt: '2026-05-08T00:00:00.000Z',
+          lastProductionPromotedAt: null,
+          lastError: null,
+          history: []
+        },
+        null,
+        2
+      )
+    );
+    // currentCanary is undefined because we don't pre-populate fakeServing.
+    // But state shows a recent train + canary promotion timestamp; preTrain
+    // decision will short-circuit on age check. To exercise skip-no-delta,
+    // we need NO active canary in serving — which the empty fake provides.
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: createFakeCorpusAggregator([]),
+      trainer: createFakeTrainer([]),
+      serving: createFakeServing()
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('skipped-no-delta');
+  });
+
+  it('runs full train cycle and promotes-to-canary on good eval', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fc.setNow('2026-05-06T02:00:00.000Z');
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/corpus/2026-05-06/manifest.json',
+        corpusManifestSha256: 'sha-2026-05-06',
+        totalSamples: 600,
+        newSamplesSinceLastRun: 600
+      }
+    ]);
+    const trainer = createFakeTrainer([
+      {
+        adapterPath: '/adapters/2026-05-06-qwen',
+        configSha256: 'cfg-2026-05-06',
+        baseModelOllamaTag: 'qwen2.5-coder:7b'
+      }
+    ]);
+    const evalH = createFakeEvalHarness([
+      { name: '2026-05-06-qwen', winRate: 0.72, decision: 'promote-canary', regressionFlags: [] }
+    ]);
+    const serving = createFakeServing();
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer,
+      evalHarness: evalH,
+      serving
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('trained-and-canary-promoted');
+    if (result.kind === 'trained-and-canary-promoted') {
+      expect(result.canaryPercent).toBe(10);
+    }
+    // Serving received the calls in order: register, then promoteToCanary.
+    const ops = serving.fakeState.calls.map((c) => c.op);
+    expect(ops).toEqual(['register', 'promoteToCanary']);
+    expect(trainer.invocations).toHaveLength(1);
+    expect(evalH.invocations).toHaveLength(1);
+  });
+
+  it('rejects when eval winRate below gate', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/m',
+        corpusManifestSha256: 'sha',
+        totalSamples: 600,
+        newSamplesSinceLastRun: 600
+      }
+    ]);
+    const trainer = createFakeTrainer([
+      { adapterPath: '/a/x', configSha256: 'cfg', baseModelOllamaTag: 'qwen2.5-coder:7b' }
+    ]);
+    const evalH = createFakeEvalHarness([
+      { name: 'x', winRate: 0.45, decision: 'reject', regressionFlags: [] }
+    ]);
+    const serving = createFakeServing();
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer,
+      evalHarness: evalH,
+      serving
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('trained-and-rejected');
+    expect(serving.fakeState.calls.map((c) => c.op)).toEqual(['register', 'reject']);
+  });
+
+  it('rejects-no-eval when evalHarness undefined', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/m',
+        corpusManifestSha256: 'sha',
+        totalSamples: 600,
+        newSamplesSinceLastRun: 600
+      }
+    ]);
+    const trainer = createFakeTrainer([
+      { adapterPath: '/a/x', configSha256: 'cfg', baseModelOllamaTag: 'qwen2.5-coder:7b' }
+    ]);
+    const serving = createFakeServing();
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer,
+      // evalHarness deliberately omitted
+      serving
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('trained-and-rejected');
+    if (result.kind === 'trained-and-rejected') {
+      expect(result.reason).toContain('eval harness not configured');
+    }
+  });
+
+  it('records failed outcome on training error', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/m',
+        corpusManifestSha256: 'sha',
+        totalSamples: 600,
+        newSamplesSinceLastRun: 600
+      }
+    ]);
+    const trainer = {
+      invocations: [],
+      scripted: [],
+      async train() {
+        throw new Error('mlx OOM');
+      }
+    };
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer,
+      serving: createFakeServing()
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') {
+      expect(result.error.kind).toBe('TrainingFailedError');
+    }
+    const state = JSON.parse(fs.readFile('/data/state.json'));
+    expect(state.lastError?.kind).toBe('TrainingFailedError');
+  });
+
+  it('skipped-canary-active when canary < 3 days old', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fc.setNow('2026-05-08T02:00:00.000Z');
+    const serving = createFakeServing();
+    // Pre-seed a canary registered 1 day ago.
+    serving.fakeState.registered.set('q', {
+      adapterName: 'q',
+      adapterPath: '/a/q',
+      metadataSha256: 'a'.repeat(64),
+      configSha256: 'cfg',
+      baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+      baseModelOllamaTag: 'qwen2.5-coder:7b',
+      status: 'canary',
+      history: [],
+      canaryPercent: 10,
+      ollamaModelName: 'q-canary-abc',
+      registeredAt: '2026-05-07T02:00:00.000Z',
+      promotedAt: '2026-05-07T02:00:00.000Z'
+    });
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      serving
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('skipped-canary-active');
+  });
+
+  it('canary-held-prompting-operator when canary >= 3 days old', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fc.setNow('2026-05-13T02:00:00.000Z'); // 6 days after promotion
+    const serving = createFakeServing();
+    serving.fakeState.registered.set('q', {
+      adapterName: 'q',
+      adapterPath: '/a/q',
+      metadataSha256: 'a'.repeat(64),
+      configSha256: 'cfg',
+      baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+      baseModelOllamaTag: 'qwen2.5-coder:7b',
+      status: 'canary',
+      history: [],
+      canaryPercent: 10,
+      ollamaModelName: 'q-canary-abc',
+      registeredAt: '2026-05-07T02:00:00.000Z',
+      promotedAt: '2026-05-07T02:00:00.000Z'
+    });
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      serving
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('canary-held-prompting-operator');
+    const digest = fs.readFile('/reports/d.md');
+    expect(digest).toContain('Operator action required');
+  });
+});
+
+describe('ApprenticeRetrainer — operator-driven actions', () => {
+  it('promoteCanaryToProduction calls serving.promoteToProduction', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    const serving = createFakeServing();
+    serving.fakeState.registered.set('q', {
+      adapterName: 'q',
+      adapterPath: '/a/q',
+      metadataSha256: 'a'.repeat(64),
+      configSha256: 'cfg',
+      baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+      baseModelOllamaTag: 'qwen2.5-coder:7b',
+      status: 'canary',
+      history: [],
+      canaryPercent: 10,
+      ollamaModelName: 'q-canary',
+      registeredAt: '2026-05-06T00:00:00.000Z',
+      promotedAt: '2026-05-06T00:00:00.000Z'
+    });
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      serving
+    });
+    const promoted = await r.promoteCanaryToProduction();
+    expect(promoted.status).toBe('production');
+    expect(serving.fakeState.calls.some((c) => c.op === 'promoteToProduction')).toBe(true);
+  });
+
+  it('rejectCanary calls serving.reject', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    const serving = createFakeServing();
+    serving.fakeState.registered.set('q', {
+      adapterName: 'q',
+      adapterPath: '/a/q',
+      metadataSha256: 'a'.repeat(64),
+      configSha256: 'cfg',
+      baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+      baseModelOllamaTag: 'qwen2.5-coder:7b',
+      status: 'canary',
+      history: [],
+      canaryPercent: 10,
+      ollamaModelName: 'q-canary',
+      registeredAt: '2026-05-06T00:00:00.000Z',
+      promotedAt: '2026-05-06T00:00:00.000Z'
+    });
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      fs,
+      clock: fc.clock,
+      serving
+    });
+    const rej = await r.rejectCanary('regression on prompt-12');
+    expect(rej.status).toBe('rejected');
+    expect(rej.rejectionReason).toBe('regression on prompt-12');
+  });
+});

--- a/packages/apprentice-retrainer/tests/state-store.test.ts
+++ b/packages/apprentice-retrainer/tests/state-store.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { StateStore } from '../src/state-store.js';
+import { StateCorruptError } from '../src/types.js';
+import { createFakeClock, createInMemoryFs } from './helpers/fakes.js';
+
+function setup() {
+  const fs = createInMemoryFs();
+  const { clock } = createFakeClock();
+  const store = new StateStore({ runStatePath: '/data/state.json', fs, clock });
+  return { fs, store };
+}
+
+describe('StateStore', () => {
+  it('returns empty state when file is absent', () => {
+    const { store } = setup();
+    const s = store.read();
+    expect(s.history).toEqual([]);
+    expect(s.lastSuccessfulTrain).toBeNull();
+  });
+
+  it('round-trips state via atomic rename', () => {
+    const { fs, store } = setup();
+    const s = store.read();
+    s.lastSuccessfulTrain = {
+      at: '2026-05-01T00:00:00.000Z',
+      adapterPath: '/adapters/x',
+      adapterName: 'x',
+      corpusManifestSha256: 'sha',
+      outcome: 'trained-and-canary-promoted'
+    };
+    store.write(s);
+    expect(fs.exists('/data/state.json')).toBe(true);
+    const re = store.read();
+    expect(re.lastSuccessfulTrain?.adapterPath).toBe('/adapters/x');
+  });
+
+  it('preserves a .bak file on second write', () => {
+    const { fs, store } = setup();
+    store.write(store.read());
+    store.write(store.read());
+    expect(fs.exists('/data/state.json.bak')).toBe(true);
+  });
+
+  it('throws StateCorruptError on malformed JSON', () => {
+    const { fs, store } = setup();
+    fs.put('/data/state.json', '{ broken');
+    expect(() => store.read()).toThrow(StateCorruptError);
+  });
+
+  it('treats empty file as empty state', () => {
+    const { fs, store } = setup();
+    fs.put('/data/state.json', '');
+    const s = store.read();
+    expect(s.history).toEqual([]);
+  });
+
+  it('records outcomes append-only', () => {
+    const { store } = setup();
+    store.recordOutcome('skipped-no-delta');
+    store.recordOutcome('trained-and-canary-promoted', { adapterName: 'a1' });
+    const s = store.read();
+    expect(s.history).toHaveLength(2);
+    expect(s.history[0]!.outcome).toBe('skipped-no-delta');
+    expect(s.history[1]!.adapterName).toBe('a1');
+  });
+
+  it('trims history beyond historyMax', () => {
+    const fs = createInMemoryFs();
+    const { clock } = createFakeClock();
+    const store = new StateStore({ runStatePath: '/data/s.json', fs, clock, historyMax: 3 });
+    for (let i = 0; i < 5; i++) {
+      store.recordOutcome('skipped-no-delta');
+    }
+    const s = store.read();
+    expect(s.history).toHaveLength(3);
+  });
+
+  it('records and clears errors', () => {
+    const { store } = setup();
+    store.recordError({ at: '2026-05-06T00:00:00.000Z', message: 'boom', kind: 'TestError' });
+    expect(store.read().lastError?.kind).toBe('TestError');
+    store.clearError();
+    expect(store.read().lastError).toBeNull();
+  });
+
+  it('records canary + production promotion timestamps', () => {
+    const { store } = setup();
+    store.recordCanaryPromotion('2026-05-06T02:15:00.000Z');
+    store.recordProductionPromotion('2026-05-09T14:30:00.000Z');
+    const s = store.read();
+    expect(s.lastCanaryPromotedAt).toBe('2026-05-06T02:15:00.000Z');
+    expect(s.lastProductionPromotedAt).toBe('2026-05-09T14:30:00.000Z');
+  });
+});

--- a/packages/apprentice-retrainer/tsconfig.build.json
+++ b/packages/apprentice-retrainer/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/apprentice-retrainer/tsconfig.json
+++ b/packages/apprentice-retrainer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/apprentice-retrainer/vitest.config.ts
+++ b/packages/apprentice-retrainer/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/packages/apprentice-serving/DESIGN.md
+++ b/packages/apprentice-serving/DESIGN.md
@@ -1,0 +1,545 @@
+# `@chiefaia/apprentice-serving` — DESIGN
+
+**Status**: Phase 3 of the Apprentice campaign — adapter swapping + serving.
+**Date**: 2026-05-06.
+**Phase**: 3 of 4 (after Phase 0 corpus, Phase 1 eval, Phase 2 training).
+**Shape**: Option E — private workspace package, parameterised constructor with CAIA defaults, fixture-tested with mocked Ollama, never published.
+
+---
+
+## 1. Mandate
+
+`@chiefaia/apprentice-serving` is the registry + serving substrate for adapters produced by `@chiefaia/apprentice-training`. It loads adapter directories into Ollama, tracks each adapter's lifecycle state (`registered → shadow → canary → production`, with `archived` and `rejected` terminals), and writes a canary-routing config that downstream agents (Mentor, Curator, future Apprentice consumers) read at inference time.
+
+It is the bridge between the **batch artifact** (the date-stamped adapter directory Phase 2 emits) and the **online serving substrate** (Ollama running locally on the operator's Mac). Phase 4 (retrainer cron) drives this package from above; this package drives Ollama from below.
+
+---
+
+## 2. Phase 3's contract with the rest of the campaign
+
+| Boundary | Read | Write |
+|---|---|---|
+| **Phase 2** (`apprentice-training`) | `<adapterPath>/Modelfile`, `<adapterPath>/adapters.safetensors`, `<adapterPath>/adapter_config.json`, `<adapterPath>/training-metadata.json`, optional `<adapterPath>/eval-report.json` | — |
+| **Ollama** | `ollama show <name>` | `ollama create <name> -f <Modelfile>`, `ollama rm <name>` |
+| **Registry file** | reads on every operation | atomic write-and-rename on every state change |
+| **Canary-routing config** | — | atomic write-and-rename on every state change |
+| **Phase 4** (`apprentice-retrainer`) | calls `register()` + `promoteToCanary()` + `promoteToProduction()` | — |
+
+The package is **idempotent over (adapter directory, target state)**: re-asking for an already-applied transition is a no-op (the registry records it once). Re-asking for the SAME adapter at the SAME registry status is a no-op even after a process restart.
+
+---
+
+## 3. Public API
+
+```ts
+export class ApprenticeServing {
+  constructor(config?: ApprenticeServingConfig);
+
+  /** Idempotent: reads `<adapterPath>/training-metadata.json`, derives
+   *  the registry key, writes a `registered` entry. */
+  register(adapterPath: string): Promise<RegistryEntry>;
+
+  /** Loads the adapter into Ollama as `<canaryModelName>`, transitions
+   *  the entry to `canary`, sets `canaryPercent`, atomically updates
+   *  the canary-routing config. */
+  promoteToCanary(adapterPath: string, percent: number): Promise<RegistryEntry>;
+
+  /** Loads the adapter into Ollama as `<productionModelName>`, transitions
+   *  to `production`, archives the previous production entry. */
+  promoteToProduction(adapterPath: string): Promise<RegistryEntry>;
+
+  /** Fast path. `toAdapterPath` MUST be a previously-promoted
+   *  production adapter (status === 'archived'). Re-promotes it. */
+  rollback(toAdapterPath: string): Promise<RegistryEntry>;
+
+  /** Marks an adapter `rejected`. If it was loaded into Ollama, removes
+   *  it. Used for failed eval gate. */
+  reject(adapterPath: string, reason: string): Promise<RegistryEntry>;
+
+  /** Read-only view of registry. */
+  readonly registry: AdapterRegistry;
+}
+```
+
+`AdapterRegistry` is a separate exported class — the operator may inspect / list / filter adapters without going through `ApprenticeServing`. It owns the persisted JSON file.
+
+```ts
+export class AdapterRegistry {
+  constructor(config?: AdapterRegistryConfig);
+
+  list(): RegistryEntry[];
+  getByPath(adapterPath: string): RegistryEntry | undefined;
+  getByName(adapterName: string): RegistryEntry | undefined;
+  /** All entries with status === 'production'. Should be 0 or 1. */
+  currentProduction(): RegistryEntry | undefined;
+  /** All entries with status === 'canary'. May be 0 or 1; multi-canary disallowed. */
+  currentCanary(): RegistryEntry | undefined;
+}
+```
+
+### `RegistryEntry`
+
+```ts
+export interface RegistryEntry {
+  /** Stable identity = adapter directory basename, e.g.
+   *  `2026-05-06-qwen2.5-coder-7b-rank8-iters1500`. */
+  adapterName: string;
+  /** Absolute path to adapter dir on disk. */
+  adapterPath: string;
+  /** sha256 of training-metadata.json (cross-run identity). */
+  metadataSha256: string;
+  /** From training-metadata.json — what the trainer recorded. */
+  configSha256: string;
+  baseModel: string;
+  baseModelOllamaTag: string;
+  /** Ollama model name THIS adapter is loaded as.
+   *  Per-status: shadow → `<base>-shadow-<sha7>`,
+   *              canary → `<base>-canary-<sha7>`,
+   *              production → `<base>-production`. */
+  ollamaModelName?: string;
+  /** Optional eval verdict (from eval-report.json — Phase 1 output). */
+  evalReport?: {
+    winRate: number;
+    decision: string;
+    regressionFlags: string[];
+  };
+  /** Lifecycle state. */
+  status: 'registered' | 'shadow' | 'canary' | 'production' | 'archived' | 'rejected';
+  /** Append-only history. */
+  history: RegistryHistoryEntry[];
+  /** Set when status === 'canary'. 0..100. */
+  canaryPercent?: number;
+  /** Set when status === 'rejected'. */
+  rejectionReason?: string;
+  registeredAt: string; // ISO-8601
+  promotedAt?: string;
+  archivedAt?: string;
+}
+
+export interface RegistryHistoryEntry {
+  at: string; // ISO-8601
+  fromStatus: RegistryEntry['status'] | null;
+  toStatus: RegistryEntry['status'];
+  /** Free-form note. */
+  note?: string;
+}
+```
+
+---
+
+## 4. Adapter lifecycle state machine
+
+```
+                            register()
+                ┌──────────────────────────┐
+                ↓                          │
+       ┌────────────┐                      │
+       │ registered │ ────────────────►  reject()
+       └────────────┘                      │
+                │                          ↓
+   promoteToCanary()                  ┌──────────┐
+                │                     │ rejected │
+                ↓                     └──────────┘
+        ┌──────────┐                       ▲
+        │  canary  │ ──── reject() ────────┤
+        └──────────┘                       │
+                │                          │
+   promoteToProduction()                   │
+                │                          │
+                ↓                          │
+       ┌────────────┐                      │
+       │ production │ ◄─── rollback()      │
+       └────────────┘                      │
+                │                          │
+   another adapter promoted                │
+                │                          │
+                ↓                          │
+        ┌──────────┐                       │
+        │ archived │                       │
+        └──────────┘                       │
+                │                          │
+                └──── rollback() ──────────┘
+                       (re-promotes archived → production)
+```
+
+Notes on transitions:
+
+- `register()` is the only entry into the system. It reads `training-metadata.json` and creates a `registered` entry. Idempotent on the same `adapterPath`.
+- `promoteToCanary(adapterPath, percent)` requires `status ∈ {'registered', 'archived'}` (rolling forward, or re-canary-ing a previously-archived adapter for testing).
+- `promoteToProduction(adapterPath)` requires `status ∈ {'canary'}`. The previous production (if any) transitions to `archived`. Multiple `archived` entries are kept (history). At most one `production` ever.
+- `rollback(toAdapterPath)` requires the target's `status === 'archived'`. The current production (if any) transitions to `archived`. The target transitions to `production`. Skips canary — rollback is a fast-path.
+- `reject(adapterPath, reason)` is allowed from any non-terminal state. Removes the adapter from Ollama if loaded. Used for eval-gate failure.
+- All transitions append a `RegistryHistoryEntry` with `from`/`to`/`at`/`note`.
+
+**Invariants** (asserted at registry mutation time, throw `RegistryInvariantError` if violated):
+
+1. At most one entry has `status === 'production'`.
+2. At most one entry has `status === 'canary'`.
+3. `adapterName` is unique across the registry.
+4. `archivedAt` is set iff `status === 'archived'`.
+5. `canaryPercent` is set iff `status === 'canary'`.
+6. `rejectionReason` is set iff `status === 'rejected'`.
+
+---
+
+## 5. Pipeline data-flow
+
+```
+adapterPath (from Phase 2)
+        │
+        ▼
+   register()
+        │
+        ├── readMetadata() ────────► training-metadata.json
+        ├── readEvalReport() ──────► eval-report.json (optional)
+        ├── deriveAdapterName() ───► <baseShortName>-<sha7>
+        ├── registry.upsert()
+        └── persistRegistry() ─────► registry.json (atomic rename)
+
+   promoteToCanary(path, pct)
+        │
+        ├── registry.assertCanPromote()
+        ├── ollamaCreate(<canaryName>) ─► subprocess: ollama create
+        ├── registry.transition(canary, pct)
+        ├── persistRegistry()
+        └── persistCanaryRoutingConfig() ► canary-routing.json (atomic rename)
+
+   promoteToProduction(path)
+        │
+        ├── registry.assertCanPromote()
+        ├── ollamaCreate(<productionName>) ─► subprocess: ollama create
+        ├── ollamaRemove(prevProduction) ──► subprocess: ollama rm  (best-effort)
+        ├── registry.transition(production); registry.archive(prev)
+        ├── persistRegistry()
+        └── persistCanaryRoutingConfig() ► clears canary section
+
+   rollback(toPath)
+        │
+        ├── registry.assertCanRollback(toPath)
+        ├── ollamaCreate(<productionName>) ─► subprocess: ollama create on archived adapter
+        ├── ollamaRemove(prevProduction) ──► subprocess: ollama rm
+        ├── registry.transition(target → production); archive(prev)
+        ├── persistRegistry()
+        └── persistCanaryRoutingConfig()
+```
+
+---
+
+## 6. Ollama integration contract
+
+We invoke the `ollama` CLI as a subprocess (no SDK). The CLI is stable across versions for the commands we use; we pin behaviour by parsing `ollama --version` at preflight time.
+
+| Operation | Command | Idempotent? | Failure mode |
+|---|---|---|---|
+| **Create** | `ollama create <name> -f <Modelfile>` | yes (re-creating same model just rebuilds; we no-op when registry says it already exists) | exit non-zero → `OllamaCreateError` |
+| **Remove** | `ollama rm <name>` | yes when `--force`-equivalent (it's `ollama rm` directly; if model doesn't exist the CLI returns non-zero — we treat ENOENT as success) | exit non-zero AND not "not found" → `OllamaRemoveError` |
+| **Inspect** | `ollama show <name> --modelfile` | yes (read-only) | exit non-zero → `OllamaInspectError` |
+| **List** | `ollama list` | yes (read-only) | exit non-zero → `OllamaListError` |
+| **Preflight** | `ollama --version` | yes (read-only) | non-zero → `OllamaNotInstalledError` with install instructions |
+
+The Modelfile we feed to `ollama create` is the one Phase 2 emitted. It contains:
+
+```
+FROM <baseModelOllamaTag>
+ADAPTER ./adapters.safetensors
+PARAMETER temperature 0.2
+PARAMETER top_p 0.9
+```
+
+The cwd of the subprocess is set to `<adapterPath>` so the relative `./adapters.safetensors` resolves. The `Modelfile` itself is referenced absolute via `-f`.
+
+### Ollama model naming convention
+
+```
+shadow:        <baseShortName>-shadow-<sha7>
+canary:        <baseShortName>-canary-<sha7>
+production:    <baseShortName>-production
+```
+
+Where:
+- `baseShortName = baseModel.replace(':', '-').replace(/[^a-z0-9-]/g, '-')` (e.g., `qwen2.5-coder-7b`)
+- `sha7` is the first 7 chars of `metadataSha256`
+
+The `production` slot deliberately drops the sha so downstream consumers can hard-code `<baseShortName>-production` as the model to call. Cutover is atomic from the consumer's perspective.
+
+---
+
+## 7. Canary-routing config
+
+A separate JSON file at `<canaryRoutingConfigPath>` (default `~/Documents/projects/apprentice/canary-routing.json`). Format:
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-05-06T14:32:11.123Z",
+  "production": {
+    "ollamaModelName": "qwen2.5-coder-7b-production",
+    "adapterName": "2026-05-06-qwen2.5-coder-7b-rank8-iters1500"
+  },
+  "canary": {
+    "ollamaModelName": "qwen2.5-coder-7b-canary-a1b2c3d",
+    "adapterName": "2026-05-13-qwen2.5-coder-7b-rank8-iters1500",
+    "percent": 10
+  }
+}
+```
+
+When no production is set, the `production` field is `null`. When no canary is set, the `canary` field is `null`.
+
+Consumers read this file at agent invocation time. The reader lib lives at `src/canary-router.ts` exported from this package — agents call `routeRequest(canaryRouter)` which hashes the request id, compares to `canary.percent`, and returns the model name to invoke. Phase 3 ships the writer + reader; agents wire the reader in a future leg.
+
+The reader is deterministic over `(requestId, percent)` so the same request always routes the same way (no flapping under retries).
+
+```ts
+export class CanaryRouter {
+  constructor(config?: CanaryRouterConfig);
+  /** Read the latest canary-routing.json. Cached per-instance with a
+   *  stat-mtime check; cheap to call hot-path. */
+  resolve(): RoutingDecision;
+  /** Hash the requestId; return the chosen model. */
+  routeRequest(requestId: string): string | null;
+}
+
+export type RoutingDecision =
+  | { kind: 'no-production'; canary: null }
+  | { kind: 'production-only'; productionModel: string; canary: null }
+  | { kind: 'production-with-canary'; productionModel: string; canaryModel: string; canaryPercent: number };
+```
+
+---
+
+## 8. Configuration surface (Option E)
+
+```ts
+export interface ApprenticeServingConfig {
+  // — paths —
+  registryPath?: string;
+  // default: `~/Documents/projects/apprentice/registry.json`
+
+  canaryRoutingConfigPath?: string;
+  // default: `~/Documents/projects/apprentice/canary-routing.json`
+
+  // — Ollama —
+  ollamaBinaryPath?: string;
+  // default: `ollama` (resolved via PATH)
+
+  ollamaHost?: string;
+  // default: undefined → respects user's OLLAMA_HOST env var
+
+  productionModelName?: (baseShortName: string) => string;
+  // default: (b) => `${b}-production`
+
+  canaryModelName?: (baseShortName: string, sha7: string) => string;
+  // default: (b, s) => `${b}-canary-${s}`
+
+  shadowModelName?: (baseShortName: string, sha7: string) => string;
+  // default: (b, s) => `${b}-shadow-${s}`
+
+  // — guard rails —
+  maxArchivedToKeep?: number;
+  // default: 10 — older archived entries are GC'd from registry (their Ollama
+  // models are also `ollama rm`'d).
+
+  // — test seams —
+  ollamaClient?: OllamaClient;
+  // default: real subprocess-spawning client.
+
+  fs?: FsAccess;
+  clock?: () => Date;
+}
+```
+
+CAIA defaults are the operator's stable Mac-side paths. Tests override `registryPath` to a temp file, `canaryRoutingConfigPath` to a temp file, and inject a fake `OllamaClient` that records invocations.
+
+---
+
+## 9. Module layout
+
+```
+packages/apprentice-serving/
+  DESIGN.md                            ← this file
+  README.md
+  package.json
+  tsconfig.json + tsconfig.build.json
+  eslint.config.cjs
+  vitest.config.ts
+  src/
+    types.ts                           — RegistryEntry, all interfaces, error classes
+    config.ts                          — resolveConfig with CAIA defaults
+    fs-access.ts                       — default FsAccess wrapping node:fs
+    ollama-client.ts                   — subprocess-backed implementation of OllamaClient
+    metadata-reader.ts                 — read training-metadata.json + eval-report.json
+    adapter-registry.ts                — AdapterRegistry class; persistence; invariants
+    canary-router.ts                   — CanaryRouter + writer
+    serving.ts                         — top-level ApprenticeServing orchestrator
+    cli.ts                             — caia-apprentice-serving entry point
+    index.ts                           — public API barrel
+  tests/
+    helpers/
+      fakes.ts                         — createInMemoryFs, createFakeOllamaClient, fixtures
+    metadata-reader.test.ts
+    adapter-registry.test.ts
+    canary-router.test.ts
+    ollama-client.test.ts
+    serving.test.ts                    — orchestration unit tests
+    serving.integration.test.ts        — full lifecycle integration test (mocked ollama)
+    serving.e2e.test.ts                — gated by APPRENTICE_SERVING_OLLAMA_INSTALLED=1
+  plists/
+    com.chiefaia.apprentice-serving-canary-router.plist (placeholder; activated by Phase 4)
+  scripts/
+    install-apprentice-serving.sh      — placeholder-substitution per leg-3 standing rule
+```
+
+13 source files, plus tests + scripts + plists. Tighter surface than `apprentice-training` (14 src files) — serving has less internal logic; most of the work is registry book-keeping + subprocess invocation.
+
+---
+
+## 10. CLI surface
+
+```
+caia-apprentice-serving register <adapter-path>
+caia-apprentice-serving promote-canary <adapter-path> --percent <0..100>
+caia-apprentice-serving promote-production <adapter-path>
+caia-apprentice-serving rollback <adapter-path>
+caia-apprentice-serving reject <adapter-path> --reason "<reason>"
+caia-apprentice-serving list [--status <status>]
+caia-apprentice-serving show <adapter-path>
+caia-apprentice-serving canary-config              # print canary-routing.json
+```
+
+All commands respect `--registry-path`, `--canary-routing-path`, `--ollama-binary` overrides for testability.
+
+Exit codes:
+- `0` success
+- `1` validation error (bad args, registry invariant violated)
+- `2` Ollama subprocess failure
+- `3` filesystem failure
+- `4` adapter-not-found / metadata-malformed
+
+---
+
+## 11. Errors
+
+All extend a `ServingError` base class with `name` + `details`. Surface set:
+
+| Error | When |
+|---|---|
+| `AdapterNotFoundError` | `adapterPath` doesn't exist or is missing required artifacts |
+| `MetadataMalformedError` | `training-metadata.json` doesn't parse / fails schema |
+| `RegistryInvariantError` | mutation would violate a §4 invariant |
+| `RegistryStateMismatchError` | requested transition is invalid for current state (e.g., promoteToProduction on a `registered`-only adapter) |
+| `OllamaNotInstalledError` | preflight `ollama --version` fails |
+| `OllamaCreateError` | `ollama create` exit non-zero |
+| `OllamaRemoveError` | `ollama rm` exit non-zero AND model exists |
+| `OllamaInspectError` | `ollama show` exit non-zero |
+| `RollbackTargetInvalidError` | `rollback(path)` target's status isn't `archived` |
+| `CanaryPercentOutOfRangeError` | `percent < 0 || percent > 100` |
+
+The CLI catches each and pretty-prints; the API throws.
+
+---
+
+## 12. Persistence + concurrency
+
+The registry file is the system of record. We assume single-writer (one `ApprenticeServing` instance at a time on the operator's Mac) — Phase 4 cron is a single LaunchAgent. We do NOT take cross-process file locks; instead we:
+
+1. Read the file fresh on every mutation.
+2. Mutate in-memory.
+3. Write to `<path>.tmp` then `rename(<path>.tmp, <path>)` — atomic on POSIX.
+
+If a future user creates a second instance, they'll race; the last writer wins. This is acceptable for the single-Mac operator model. Phase 4's retrainer holds a separate file-lock on `~/Documents/projects/apprentice/retrainer.lock` for its retraining cron — that's its own concurrency concern, not ours.
+
+The canary-routing config is written the same way: `<path>.tmp` → rename. Readers (`CanaryRouter.resolve()`) tolerate ENOENT (initial state, pre-first-promotion).
+
+---
+
+## 13. Hyperparameter / threshold defaults
+
+Values are CAIA-tuned but parameterised:
+
+| Parameter | Default | Rationale |
+|---|---|---|
+| `maxArchivedToKeep` | `10` | Keep history for ~10 weeks of weekly retraining cycles; trim older to bound disk + Ollama storage. |
+| `defaultCanaryPercent` (Phase 4 retrainer reads this) | `10` | Conservative initial canary; scales up as confidence grows. |
+| `evalWinRateGate` (Phase 4) | `0.60` | Auto-promote-to-canary threshold per directive. |
+| `canaryHoldDays` (Phase 4) | `3` | Operator-prompt threshold per directive. |
+
+`maxArchivedToKeep` is enforced by `ApprenticeServing.gcArchived()` (called from every `promoteToProduction` and `rollback`). When the count exceeds the cap, we `ollama rm` the oldest archived adapters first (FIFO), then drop them from the registry entries. Their on-disk files (the adapter directory itself) are NOT deleted — Phase 2 owns those, and the operator may want to inspect them later.
+
+---
+
+## 14. Test strategy
+
+### Unit tests (mocked subprocess + in-memory fs)
+
+- `metadata-reader.test.ts` — schema validation; missing required fields; sha computation determinism.
+- `adapter-registry.test.ts` — every state transition; every invariant violation; persistence round-trip; idempotent `register()`; GC behaviour.
+- `canary-router.test.ts` — deterministic hashing; percent boundaries (0%, 100%, 50%); ENOENT tolerance; mtime-based cache invalidation.
+- `ollama-client.test.ts` — argv construction; treat-not-found-as-success on remove; error path classification.
+- `serving.test.ts` — top-level orchestration; failure-mode rollback (ollama-create-fails-after-registry-update is reverted); cross-cutting calls into registry + ollama + canary-config.
+
+### Integration test (fake Ollama, real fs)
+
+- `serving.integration.test.ts` — materialises a fake adapter directory on disk (Modelfile + adapters.safetensors stub + adapter_config.json + training-metadata.json); runs the full lifecycle: register → promoteToCanary(10%) → promoteToProduction → register-newer → promoteToCanary(10%) → promoteToProduction → rollback. Verifies registry JSON + canary-routing JSON contents at every step. Asserts the FakeOllamaClient saw the right invocation sequence.
+
+### E2E test (real Ollama, gated)
+
+- `serving.e2e.test.ts`, gated by `APPRENTICE_SERVING_OLLAMA_INSTALLED=1`. Runs `ollama --version`, then runs the full lifecycle against the real Ollama daemon using a tiny fixture adapter directory. Exercises the actual subprocess invocation. Cleans up created models on teardown.
+
+`tests/helpers/fakes.ts` provides:
+- `createInMemoryFs()` — in-memory `FsAccess`
+- `createFakeOllamaClient()` — scriptable `OllamaClient`; records every invocation; configurable per-call result
+- `fixtureAdapterDir()` — emits a fake adapter directory on disk (in-memory or real) with all required files
+- `fixtureMetadata()` — minimal `TrainingMetadataRead`-shape fixture
+
+---
+
+## 15. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Ollama version drift breaks CLI parsing** | Preflight `ollama --version`; tolerant parsing; CLI args we use are stable across 0.1.x → 0.11.x. |
+| **Ollama daemon not running** | `ollama create` errors with a helpful message; we surface it as `OllamaCreateError` with `details.dameonNotRunning` hint. |
+| **Adapter directory deleted while registered** | `register()` re-validates the directory exists at every state transition. If missing, throws `AdapterNotFoundError` and registry entry is marked `archived` automatically (with a `note: 'on-disk adapter missing'`). |
+| **Registry file corruption** | We read+parse on every mutation; bad JSON → `RegistryCorruptError` with the operator instructed to restore from `<path>.bak` (we keep one backup per write). |
+| **Race between cron and CLI** | Documented single-writer model. Phase 4 retrainer holds its own lock; CLI usage is discouraged during cron windows. |
+| **Modelfile relative path resolution** | We always set subprocess cwd to `adapterPath`. |
+| **Ollama disk pressure from accumulated archived adapters** | `maxArchivedToKeep = 10` GC. Operator may bump higher on disk-rich systems. |
+| **Canary holding indefinitely without operator action** | Out of Phase 3's scope. Phase 4 owns the time-based promotion/rejection cron. |
+| **Eval-report.json absent (Phase 1 not yet shipped at register time)** | `register()` tolerates ENOENT; `evalReport` field is optional in `RegistryEntry`. Phase 4 retrainer is the eval gatekeeper, not Phase 3. |
+
+---
+
+## 16. Stages 4-10 outline
+
+- **Stage 4 (Implement)** — 13 source modules per §9 layout. ESM TypeScript. Fully parameterised constructor.
+- **Stage 5 (Unit test)** — ~50-70 vitest cases across the 9 test files in §14.
+- **Stage 6 (Integration test)** — full lifecycle integration test with fake Ollama; verifies state machine end-to-end.
+- **Stage 7 (Deploy)** — install script with placeholder substitution per leg-3 standing rule. Initial canary-routing.json shipped at `null/null` state. No LaunchAgent activation in Phase 3 (Phase 4 owns the cron).
+- **Stage 8 (E2E live verify)** — gated by `APPRENTICE_SERVING_OLLAMA_INSTALLED=1`. Runs against real Ollama. Deferred to operator if no Phase 2 adapter has been trained yet (we ship a tiny synthetic adapter for the e2e to exercise the subprocess path).
+- **Stage 9 (Regression)** — package tests pass; full monorepo `pnpm -r typecheck && pnpm -r lint`.
+- **Stage 10 (Document + capture learnings)** — README + completion doc.
+
+---
+
+## 17. Constraints honoured
+
+- ✅ **Option E shape** — private `@chiefaia/apprentice-serving`; parameterised constructor with CAIA defaults; tests inject in-memory fs + fake Ollama client; never published.
+- ✅ **Subscription-only LLM** — Ollama is local-only; zero API-key billing.
+- ✅ **Mac MLX local** — adapters loaded into local Ollama daemon.
+- ✅ **Operator does NOT code** — operator validates visual outputs (registry contents, canary-routing JSON, `ollama list` after promotion).
+- ✅ **Git Flow** — `feat/apprentice-serving-001-phase3` → `develop`. PR with auto-merge armed. No force-push, no `--admin` merge.
+- ✅ **No silent model swaps** — every state transition is logged in `history`; canary-routing.json change is visible to operator.
+- ✅ **Decision-classifier** — package decides (state transitions, GC); operator informed via registry contents. No operator-prompts in this package; Phase 4 retrainer owns operator interaction.
+
+---
+
+## See also
+
+- `~/Documents/projects/reports/apprentice-phase-2-complete-2026-05-06.md` — Phase 2 sentinel; defines the adapter-directory contract this package consumes.
+- `agent/memory/apprentice_agent_directive.md` — full campaign spec.
+- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E.
+- `packages/apprentice-training/DESIGN.md` — sibling spec; same shape pattern.
+- `packages/apprentice-corpus/DESIGN.md` — sibling spec; manifest read-side reference.
+- ml-explore/mlx-lm `LORA.md` — adapter file format.
+- Ollama docs — Modelfile + `ollama create` semantics.

--- a/packages/apprentice-serving/README.md
+++ b/packages/apprentice-serving/README.md
@@ -1,0 +1,192 @@
+# `@chiefaia/apprentice-serving`
+
+Apprentice Phase 3 — adapter swapping and serving for the CAIA training loop.
+
+This package consumes adapter directories produced by `@chiefaia/apprentice-training` (Phase 2) and turns them into Ollama-loaded models with full lifecycle tracking: `registered → shadow → canary → production`, with `archived` and `rejected` terminals. It also writes a canary-routing config that downstream agents read at inference time to do percent-based traffic splitting between the current production model and a candidate canary.
+
+## What it does
+
+- Reads `<adapterPath>/Modelfile`, `<adapterPath>/training-metadata.json`, and (optional) `<adapterPath>/eval-report.json`.
+- Loads the adapter into Ollama via `ollama create <name> -f Modelfile` subprocess.
+- Tracks the adapter's lifecycle in a persisted JSON registry at `~/Documents/projects/apprentice/registry.json`.
+- Writes a canary-routing config at `~/Documents/projects/apprentice/canary-routing.json` that consumers read to decide which model to invoke per request.
+- Provides deterministic request-id-hashed routing so the same request always lands on the same model (no flapping under retries).
+
+Phase 3 is invoked on demand by Phase 4's retrainer cron. There is no LaunchAgent in Phase 3 itself.
+
+## CLI
+
+```
+caia-apprentice-serving register <adapter-path>
+caia-apprentice-serving promote-canary <adapter-path> --percent <0..100>
+caia-apprentice-serving promote-production <adapter-path>
+caia-apprentice-serving rollback <adapter-path>
+caia-apprentice-serving reject <adapter-path> --reason "<reason>"
+caia-apprentice-serving list [--status <status>]
+caia-apprentice-serving show <adapter-path>
+caia-apprentice-serving canary-config
+```
+
+Common flags: `--registry-path`, `--canary-routing-path`, `--ollama-binary`.
+
+Exit codes: `0` success, `1` validation error, `2` Ollama subprocess failure, `3` filesystem failure, `4` adapter-not-found / metadata-malformed.
+
+## API
+
+```ts
+import { ApprenticeServing } from '@chiefaia/apprentice-serving';
+
+const serving = new ApprenticeServing();
+
+// Idempotent — reads training-metadata.json, derives registry key, upserts entry.
+const entry = await serving.register('/path/to/adapter-dir');
+
+// Loads <base>-canary-<sha7> into Ollama, transitions to canary, updates routing.
+await serving.promoteToCanary('/path/to/adapter-dir', 10);
+
+// Loads <base>-production into Ollama, archives previous production.
+await serving.promoteToProduction('/path/to/adapter-dir');
+
+// Re-promotes an archived adapter to production; archives the current.
+await serving.rollback('/path/to/older-adapter-dir');
+
+// Marks rejected; removes from Ollama if loaded.
+await serving.reject('/path/to/adapter-dir', 'eval winRate=0.45 below gate');
+
+// Read-only views.
+serving.list();              // RegistryEntry[]
+serving.currentProduction(); // RegistryEntry | undefined
+serving.currentCanary();     // RegistryEntry | undefined
+
+// Routing-side reader (cheap to call hot-path; cached per-instance with mtime check).
+const router = serving.canaryRouter;
+router.routeRequest('request-id-42'); // 'qwen2-5-coder-7b-production' | 'qwen2-5-coder-7b-canary-abc' | null
+```
+
+## State machine
+
+```
+registered ──promoteToCanary──► canary ──promoteToProduction──► production
+     │                                                               │
+     └──reject──► rejected                  another adapter promoted │
+                                                                     ▼
+                                            production ──► archived ──┐
+                                                                       │
+                                                            rollback ──┘
+                                                            (re-promotes archived → production)
+```
+
+Invariants enforced at every mutation:
+
+1. At most one entry has `status === 'production'`.
+2. At most one entry has `status === 'canary'`.
+3. `adapterName` (= adapter directory basename) is unique.
+4. `archivedAt` set iff `status === 'archived'`.
+5. `canaryPercent` set iff `status === 'canary'`.
+6. `rejectionReason` set iff `status === 'rejected'`.
+
+Violations throw `RegistryInvariantError`. Invalid transitions (e.g., `promoteToProduction` on an entry still in `registered`) throw `RegistryStateMismatchError`.
+
+## Ollama model naming
+
+```
+shadow:      <baseShortName>-shadow-<sha7>
+canary:      <baseShortName>-canary-<sha7>
+production:  <baseShortName>-production
+```
+
+Where `baseShortName` is `baseModelOllamaTag` lowercased, with `:` and other non-`[a-z0-9-]` characters mapped to `-`. The `production` slot deliberately drops the sha so consumers can hard-code `<baseShortName>-production` and get atomic cutover.
+
+`canaryModelName`, `productionModelName`, and `shadowModelName` are constructor parameters with these defaults — operators / Phase 4 can override.
+
+## Canary-routing config
+
+Format at `<canaryRoutingConfigPath>`:
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-05-06T14:32:11.123Z",
+  "production": {
+    "ollamaModelName": "qwen2-5-coder-7b-production",
+    "adapterName": "2026-05-06-qwen2.5-coder-7b-rank8-iters1500"
+  },
+  "canary": {
+    "ollamaModelName": "qwen2-5-coder-7b-canary-abc1234",
+    "adapterName": "2026-05-13-qwen2.5-coder-7b-rank8-iters1500",
+    "percent": 10
+  }
+}
+```
+
+`production` is `null` when no production has been promoted; `canary` is `null` when no canary is active. Consumers should tolerate ENOENT on the file (initial state).
+
+## Setup
+
+```bash
+pnpm --filter @chiefaia/apprentice-serving build
+packages/apprentice-serving/scripts/install-apprentice-serving.sh
+```
+
+The install script ensures the data root exists, seeds an empty canary-routing.json if missing, and verifies that `ollama` is on PATH.
+
+## Configuration (Option E)
+
+```ts
+new ApprenticeServing({
+  // — paths —
+  registryPath: '~/Documents/projects/apprentice/registry.json',
+  canaryRoutingConfigPath: '~/Documents/projects/apprentice/canary-routing.json',
+
+  // — Ollama —
+  ollamaBinaryPath: 'ollama',
+  ollamaHost: undefined, // respects OLLAMA_HOST env var
+
+  // — naming overrides —
+  productionModelName: (b) => `${b}-production`,
+  canaryModelName: (b, sha7) => `${b}-canary-${sha7}`,
+  shadowModelName: (b, sha7) => `${b}-shadow-${sha7}`,
+
+  // — guard rails —
+  maxArchivedToKeep: 10,
+
+  // — test seams —
+  ollamaClient: undefined, // injection point for fake client
+  fs: undefined,           // injection point for fake fs
+  clock: undefined         // injection point for deterministic clock
+});
+```
+
+## Testing
+
+```bash
+pnpm --filter @chiefaia/apprentice-serving test
+```
+
+87 tests across 7 files (85 unit + 2 e2e gated):
+
+- `metadata-reader.test.ts` — schema validation, sha determinism, eval-report extraction (13 tests).
+- `adapter-registry.test.ts` — every state transition, every invariant, persistence, GC (24 tests).
+- `canary-router.test.ts` — deterministic routing, percent boundaries, mtime cache (11 tests).
+- `ollama-client.test.ts` — argv shape, error classification, env hygiene (16 tests).
+- `serving.test.ts` — top-level orchestration, failure-mode handling (19 tests).
+- `serving.integration.test.ts` — full lifecycle integration with fake Ollama (2 tests).
+- `serving.e2e.test.ts` — gated by `APPRENTICE_SERVING_OLLAMA_INSTALLED=1`; runs against live Ollama.
+
+E2E test live-validated 2026-05-06 against `ollama 0.23.1` on the operator's Mac with `qwen2.5-coder:7b` as the base — full lifecycle (register → canary → production → list-confirms) passed cleanly.
+
+## Environment
+
+- macOS — Apple Silicon Mac
+- Node ≥ 20
+- TypeScript ≥ 5.9 (workspace toolchain)
+- Ollama ≥ 0.1.x (CLI subprocess; tested against 0.23.1)
+
+## See also
+
+- `DESIGN.md` — full architecture spec (17 sections, ~660 lines).
+- `~/Documents/projects/reports/apprentice-phase-3-complete-2026-05-06.md` — Phase 3 completion sentinel.
+- `agent/memory/apprentice_agent_directive.md` — full campaign spec.
+- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E.
+- `packages/apprentice-training/README.md` — Phase 2 (upstream).
+- `packages/apprentice-corpus/README.md` — Phase 0 (corpus).

--- a/packages/apprentice-serving/eslint.config.cjs
+++ b/packages/apprentice-serving/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — replaces .eslintrc.json
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/apprentice-serving/package.json
+++ b/packages/apprentice-serving/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@chiefaia/apprentice-serving",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Apprentice Phase 3 — adapter swapping + serving. Loads Phase 2 adapter directories into Ollama via subprocess `ollama create`, tracks each adapter's lifecycle state (registered → shadow → canary → production with archived/rejected terminals) in a persisted JSON registry, and writes a canary-routing config that downstream agents read at inference time. Idempotent state transitions; atomic registry persistence (write-and-rename); deterministic request-id-hashed canary routing. Phase 3 ships the registry + writer + reader; Phase 4 retrainer drives state transitions from above. Mac-local Ollama; zero remote LLM cost. Ships in Option E shape — private workspace package, parameterised constructor with CAIA defaults, fixture-tested with mocked Ollama, never published.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-apprentice-serving": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "plists",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/apprentice-serving/plists/com.chiefaia.apprentice-serving-canary-router.plist
+++ b/packages/apprentice-serving/plists/com.chiefaia.apprentice-serving-canary-router.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Apprentice Phase 3 — placeholder LaunchAgent.
+
+  Phase 3 itself doesn't need a scheduled task — `ApprenticeServing` is
+  driven on demand by Phase 4's retrainer cron. This plist is kept as a
+  forward-compat placeholder for an eventual canary-routing config
+  watchdog (e.g. periodic `ollama list` reconciliation against registry
+  state). Ships DISABLED. Phase 4's install script is the activation
+  point for the actual cron.
+
+  Placeholders use the leg-3 standing-rule pattern from
+  `feedback_monorepo_regression_gate_ergonomics.md`: install-time-
+  substituted CURRENT_NODE_BIN / CURRENT_PKG_DIR / CURRENT_HOME / CURRENT_PATH.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.chiefaia.apprentice-serving-canary-router</string>
+
+    <key>Disabled</key>
+    <true/>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>CURRENT_NODE_BIN</string>
+        <string>CURRENT_PKG_DIR/dist/cli.js</string>
+        <string>list</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>CURRENT_PKG_DIR</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>CURRENT_HOME</string>
+        <key>PATH</key>
+        <string>CURRENT_PATH</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>CURRENT_HOME/Library/Logs/chiefaia/apprentice-serving.log</string>
+    <key>StandardErrorPath</key>
+    <string>CURRENT_HOME/Library/Logs/chiefaia/apprentice-serving.log</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>ThrottleInterval</key>
+    <integer>3600</integer>
+</dict>
+</plist>

--- a/packages/apprentice-serving/scripts/install-apprentice-serving.sh
+++ b/packages/apprentice-serving/scripts/install-apprentice-serving.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Install canary-routing scaffolding for Apprentice Phase 3 serving.
+#
+# Phase 3 doesn't run a LaunchAgent (Phase 4's retrainer cron does). What
+# this script DOES do:
+#   1. Ensure the serving package is built.
+#   2. Create the apprentice data root + canary-routing.json placeholder
+#      (production: null, canary: null) if absent so consumers can read
+#      it without ENOENT-handling.
+#   3. Verify ollama is on PATH and the daemon answers (best-effort).
+#
+# Pattern follows `feedback_monorepo_regression_gate_ergonomics.md` rule 2:
+# placeholder substitution, plutil-lint, dry-run mode.
+#
+# Usage:
+#   scripts/install-apprentice-serving.sh
+#
+# Env-var overrides:
+#   CAIA_APPRENTICE_DATA_ROOT  — default: $HOME/Documents/projects/apprentice
+#   CAIA_OLLAMA_BIN            — default: $(command -v ollama)
+#   CAIA_DRY_INSTALL=1         — render + sanity-check, don't write files
+
+set -euo pipefail
+
+DRY_INSTALL="${CAIA_DRY_INSTALL:-0}"
+
+PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DATA_ROOT="${CAIA_APPRENTICE_DATA_ROOT:-$HOME/Documents/projects/apprentice}"
+CANARY_ROUTING="$DATA_ROOT/canary-routing.json"
+REGISTRY="$DATA_ROOT/registry.json"
+OLLAMA_BIN="${CAIA_OLLAMA_BIN:-$(command -v ollama 2>/dev/null || true)}"
+
+if [[ ! -d "$PKG_DIR/dist" ]]; then
+  echo "package not built: $PKG_DIR/dist" >&2
+  echo "run 'pnpm --filter @chiefaia/apprentice-serving build' first" >&2
+  exit 1
+fi
+
+if [[ -z "$OLLAMA_BIN" || ! -x "$OLLAMA_BIN" ]]; then
+  echo "WARNING: ollama not found on PATH or not executable: $OLLAMA_BIN" >&2
+  echo "  install: https://ollama.com/download" >&2
+  echo "  serving will fail at promote-time until this is fixed." >&2
+fi
+
+if [[ "$DRY_INSTALL" == "1" ]]; then
+  echo "CAIA_DRY_INSTALL=1: dry-run mode"
+  echo "  data root would be:    $DATA_ROOT"
+  echo "  canary-routing path:   $CANARY_ROUTING"
+  echo "  registry path:         $REGISTRY"
+  echo "  ollama binary:         ${OLLAMA_BIN:-MISSING}"
+  exit 0
+fi
+
+mkdir -p "$DATA_ROOT"
+
+# Seed canary-routing.json with the empty state if absent. ApprenticeServing
+# tolerates ENOENT, so this is convenience-only — but having the file
+# present makes consumers' first read deterministic.
+if [[ ! -f "$CANARY_ROUTING" ]]; then
+  cat > "$CANARY_ROUTING" <<EOF
+{
+  "version": 1,
+  "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)",
+  "production": null,
+  "canary": null
+}
+EOF
+  echo "seeded $CANARY_ROUTING"
+else
+  echo "preserved existing $CANARY_ROUTING"
+fi
+
+# Don't seed registry.json — first ApprenticeServing.register() creates it
+# with a single entry; an empty {entries:[]} would then need to be merged.
+# Letting register() bootstrap is simpler and consistent with the read-
+# fresh-on-every-mutation model.
+
+echo "apprentice-serving install complete"
+echo "  data root:     $DATA_ROOT"
+echo "  canary config: $CANARY_ROUTING"
+echo "  cli:           $PKG_DIR/dist/cli.js"
+echo ""
+echo "no LaunchAgent installed — Phase 4 retrainer cron drives state transitions."
+echo "for ad-hoc operator use:"
+echo "  node $PKG_DIR/dist/cli.js list"
+echo "  node $PKG_DIR/dist/cli.js register <adapter-path>"
+echo "  node $PKG_DIR/dist/cli.js promote-canary <adapter-path> --percent 10"

--- a/packages/apprentice-serving/src/adapter-registry.ts
+++ b/packages/apprentice-serving/src/adapter-registry.ts
@@ -1,0 +1,297 @@
+/**
+ * AdapterRegistry — owns the persisted JSON registry file. Pure book-keeping;
+ * no Ollama subprocess interaction. ApprenticeServing composes this with
+ * an OllamaClient to perform end-to-end transitions.
+ *
+ * Persistence: read-fresh-on-every-mutation; write-to-tmp + atomic rename.
+ * Single-writer model — see DESIGN.md §12.
+ *
+ * Invariants enforced at mutation time:
+ *   1. At most one entry has status === 'production'.
+ *   2. At most one entry has status === 'canary'.
+ *   3. adapterName is unique.
+ *   4. archivedAt set iff status === 'archived'.
+ *   5. canaryPercent set iff status === 'canary'.
+ *   6. rejectionReason set iff status === 'rejected'.
+ */
+
+import * as path from 'node:path';
+import {
+  RegistryCorruptError,
+  RegistryInvariantError,
+  RegistryStateMismatchError,
+  RollbackTargetInvalidError,
+  CanaryPercentOutOfRangeError
+} from './types.js';
+import type {
+  AdapterRegistryConfig,
+  RegistryEntry,
+  RegistryFile,
+  RegistryHistoryEntry,
+  RegistryStatus,
+  ResolvedAdapterRegistryConfig
+} from './types.js';
+import { resolveAdapterRegistryConfig } from './config.js';
+
+export class AdapterRegistry {
+  private readonly cfg: ResolvedAdapterRegistryConfig;
+
+  constructor(config: AdapterRegistryConfig = {}) {
+    this.cfg = resolveAdapterRegistryConfig(config);
+  }
+
+  /** Read entries fresh from disk. ENOENT → empty registry. */
+  list(): RegistryEntry[] {
+    return this.read().entries;
+  }
+
+  getByPath(adapterPath: string): RegistryEntry | undefined {
+    return this.list().find((e) => e.adapterPath === adapterPath);
+  }
+
+  getByName(adapterName: string): RegistryEntry | undefined {
+    return this.list().find((e) => e.adapterName === adapterName);
+  }
+
+  /** At most one. */
+  currentProduction(): RegistryEntry | undefined {
+    return this.list().find((e) => e.status === 'production');
+  }
+
+  /** At most one. */
+  currentCanary(): RegistryEntry | undefined {
+    return this.list().find((e) => e.status === 'canary');
+  }
+
+  /** Idempotent insert/update. If an entry with the same adapterName already
+   *  exists, it's replaced. */
+  upsert(entry: RegistryEntry): void {
+    const file = this.read();
+    const idx = file.entries.findIndex((e) => e.adapterName === entry.adapterName);
+    if (idx >= 0) {
+      file.entries[idx] = entry;
+    } else {
+      file.entries.push(entry);
+    }
+    this.assertInvariants(file.entries);
+    this.persist(file);
+  }
+
+  /**
+   * Apply a status transition to the entry identified by `adapterName`.
+   * `mutator` runs before invariants are checked + persisted; it MUST set
+   * status, plus set/clear archivedAt/canaryPercent/rejectionReason as
+   * appropriate. Appends a history entry automatically.
+   */
+  transition(
+    adapterName: string,
+    toStatus: RegistryStatus,
+    mutator: (entry: RegistryEntry, prev: RegistryStatus) => void,
+    note?: string
+  ): RegistryEntry {
+    const file = this.read();
+    const entry = file.entries.find((e) => e.adapterName === adapterName);
+    if (!entry) {
+      throw new RegistryStateMismatchError(`adapter not registered: ${adapterName}`, {
+        adapterName
+      });
+    }
+    const prev: RegistryStatus = entry.status;
+    mutator(entry, prev);
+    entry.status = toStatus;
+    const histEntry: RegistryHistoryEntry = {
+      at: this.cfg.clock().toISOString(),
+      fromStatus: prev,
+      toStatus
+    };
+    if (note !== undefined) histEntry.note = note;
+    entry.history.push(histEntry);
+    // Set/clear status-conditional fields.
+    if (toStatus !== 'canary') delete entry.canaryPercent;
+    if (toStatus !== 'archived') delete entry.archivedAt;
+    if (toStatus !== 'rejected') delete entry.rejectionReason;
+
+    this.assertInvariants(file.entries);
+    this.persist(file);
+    return entry;
+  }
+
+  /** Drop an entry from the registry entirely. Used for GC. */
+  drop(adapterName: string): RegistryEntry | undefined {
+    const file = this.read();
+    const idx = file.entries.findIndex((e) => e.adapterName === adapterName);
+    if (idx < 0) return undefined;
+    const [removed] = file.entries.splice(idx, 1);
+    this.persist(file);
+    return removed;
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Internal — read / persist / invariants
+  // ────────────────────────────────────────────────────────────────────
+
+  read(): RegistryFile {
+    const fs = this.cfg.fs;
+    const p = this.cfg.registryPath;
+    if (!fs.exists(p)) {
+      return {
+        version: 1,
+        generatedAt: this.cfg.clock().toISOString(),
+        entries: []
+      };
+    }
+    let raw: string;
+    try {
+      raw = fs.readFile(p);
+    } catch (e) {
+      throw new RegistryCorruptError(`failed to read registry: ${(e as Error).message}`, {
+        path: p
+      });
+    }
+    if (raw.trim().length === 0) {
+      return {
+        version: 1,
+        generatedAt: this.cfg.clock().toISOString(),
+        entries: []
+      };
+    }
+    try {
+      const parsed = JSON.parse(raw) as RegistryFile;
+      if (parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+        throw new RegistryCorruptError(`unexpected registry shape (version=${parsed.version})`, {
+          path: p
+        });
+      }
+      return parsed;
+    } catch (e) {
+      throw new RegistryCorruptError(`registry JSON parse failed: ${(e as Error).message}`, {
+        path: p
+      });
+    }
+  }
+
+  private persist(file: RegistryFile): void {
+    file.generatedAt = this.cfg.clock().toISOString();
+    const fs = this.cfg.fs;
+    const p = this.cfg.registryPath;
+    const dir = path.dirname(p);
+    if (!fs.exists(dir)) fs.mkdir(dir);
+    // Best-effort backup.
+    if (fs.exists(p)) {
+      try {
+        const prev = fs.readFile(p);
+        fs.writeFile(p + '.bak', prev);
+      } catch {
+        /* backup failure is non-fatal */
+      }
+    }
+    const tmp = p + '.tmp';
+    fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n');
+    fs.rename(tmp, p);
+  }
+
+  /** Throws RegistryInvariantError on first violation. */
+  assertInvariants(entries: RegistryEntry[]): void {
+    const productionCount = entries.filter((e) => e.status === 'production').length;
+    if (productionCount > 1) {
+      throw new RegistryInvariantError(
+        `invariant violated: more than one production entry (${productionCount})`,
+        { production: entries.filter((e) => e.status === 'production').map((e) => e.adapterName) }
+      );
+    }
+    const canaryCount = entries.filter((e) => e.status === 'canary').length;
+    if (canaryCount > 1) {
+      throw new RegistryInvariantError(
+        `invariant violated: more than one canary entry (${canaryCount})`,
+        { canary: entries.filter((e) => e.status === 'canary').map((e) => e.adapterName) }
+      );
+    }
+    const names = new Set<string>();
+    for (const e of entries) {
+      if (names.has(e.adapterName)) {
+        throw new RegistryInvariantError(`invariant violated: duplicate adapterName: ${e.adapterName}`, {
+          adapterName: e.adapterName
+        });
+      }
+      names.add(e.adapterName);
+      if (e.status === 'archived' && !e.archivedAt) {
+        throw new RegistryInvariantError(
+          `invariant violated: archived entry without archivedAt: ${e.adapterName}`,
+          { adapterName: e.adapterName }
+        );
+      }
+      if (e.archivedAt !== undefined && e.status !== 'archived') {
+        throw new RegistryInvariantError(
+          `invariant violated: archivedAt set on non-archived entry: ${e.adapterName}`,
+          { adapterName: e.adapterName, status: e.status }
+        );
+      }
+      if (e.status === 'canary' && (e.canaryPercent === undefined || e.canaryPercent === null)) {
+        throw new RegistryInvariantError(
+          `invariant violated: canary without canaryPercent: ${e.adapterName}`,
+          { adapterName: e.adapterName }
+        );
+      }
+      if (e.canaryPercent !== undefined && e.status !== 'canary') {
+        throw new RegistryInvariantError(
+          `invariant violated: canaryPercent set on non-canary entry: ${e.adapterName}`,
+          { adapterName: e.adapterName, status: e.status }
+        );
+      }
+      if (e.status === 'rejected' && (e.rejectionReason === undefined || e.rejectionReason === '')) {
+        throw new RegistryInvariantError(
+          `invariant violated: rejected without rejectionReason: ${e.adapterName}`,
+          { adapterName: e.adapterName }
+        );
+      }
+      if (e.rejectionReason !== undefined && e.status !== 'rejected') {
+        throw new RegistryInvariantError(
+          `invariant violated: rejectionReason set on non-rejected entry: ${e.adapterName}`,
+          { adapterName: e.adapterName, status: e.status }
+        );
+      }
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Pre-mutation guards used by ApprenticeServing
+  // ────────────────────────────────────────────────────────────────────
+
+  /** Throws if (entry, target) is not a valid transition. */
+  static assertValidTransition(prev: RegistryStatus, target: RegistryStatus): void {
+    const validFrom: Record<RegistryStatus, RegistryStatus[]> = {
+      registered: ['shadow', 'canary', 'rejected', 'archived'],
+      shadow: ['canary', 'rejected', 'archived'],
+      canary: ['production', 'rejected', 'archived'],
+      production: ['archived'],
+      archived: ['canary', 'production', 'rejected'],
+      rejected: []
+    };
+    const allowed = validFrom[prev];
+    if (!allowed.includes(target)) {
+      throw new RegistryStateMismatchError(
+        `invalid transition: ${prev} → ${target}`,
+        { from: prev, to: target }
+      );
+    }
+  }
+
+  /** Validates rollback semantics: target must be archived. */
+  static assertRollbackTarget(entry: RegistryEntry): void {
+    if (entry.status !== 'archived') {
+      throw new RollbackTargetInvalidError(
+        `rollback target must be in 'archived' state; was '${entry.status}'`,
+        { adapterName: entry.adapterName, status: entry.status }
+      );
+    }
+  }
+
+  /** Validates canary percent. */
+  static assertCanaryPercent(percent: number): void {
+    if (!Number.isFinite(percent) || percent < 0 || percent > 100) {
+      throw new CanaryPercentOutOfRangeError(`percent must be in [0, 100]; got ${percent}`, {
+        percent
+      });
+    }
+  }
+}

--- a/packages/apprentice-serving/src/canary-router.ts
+++ b/packages/apprentice-serving/src/canary-router.ts
@@ -1,0 +1,131 @@
+/**
+ * CanaryRouter — writes + reads <canaryRoutingConfigPath>. Deterministic
+ * request-id-hashed routing so the same request always hits the same model
+ * (no flapping under retries).
+ */
+
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import type {
+  CanaryRouterConfig,
+  CanaryRoutingCanaryEntry,
+  CanaryRoutingConfigFile,
+  CanaryRoutingProductionEntry,
+  FsAccess,
+  ResolvedCanaryRouterConfig,
+  RoutingDecision
+} from './types.js';
+import { resolveCanaryRouterConfig } from './config.js';
+
+export interface CanaryRoutingWrite {
+  production: CanaryRoutingProductionEntry | null;
+  canary: CanaryRoutingCanaryEntry | null;
+}
+
+export class CanaryRouter {
+  private readonly cfg: ResolvedCanaryRouterConfig;
+  private cached: CanaryRoutingConfigFile | null = null;
+  private cachedMtime: number = -1;
+
+  constructor(config: CanaryRouterConfig = {}) {
+    this.cfg = resolveCanaryRouterConfig(config);
+  }
+
+  /** Atomic write: tmp + rename. */
+  write(payload: CanaryRoutingWrite): void {
+    const fs = this.cfg.fs;
+    const file: CanaryRoutingConfigFile = {
+      version: 1,
+      generatedAt: this.cfg.clock().toISOString(),
+      production: payload.production,
+      canary: payload.canary
+    };
+    const dir = path.dirname(this.cfg.canaryRoutingConfigPath);
+    if (!fs.exists(dir)) fs.mkdir(dir);
+    const tmp = this.cfg.canaryRoutingConfigPath + '.tmp';
+    fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n');
+    fs.rename(tmp, this.cfg.canaryRoutingConfigPath);
+    // Invalidate cache.
+    this.cached = null;
+    this.cachedMtime = -1;
+  }
+
+  /** Read the latest config. Cached per-instance via mtime check. */
+  read(): CanaryRoutingConfigFile | null {
+    const fs = this.cfg.fs;
+    const p = this.cfg.canaryRoutingConfigPath;
+    if (!fs.exists(p)) return null;
+    const st = fs.stat(p);
+    if (this.cached !== null && this.cachedMtime === st.mtimeMs) return this.cached;
+    const raw = fs.readFile(p);
+    try {
+      const parsed = JSON.parse(raw) as CanaryRoutingConfigFile;
+      if (parsed.version !== 1) return null;
+      this.cached = parsed;
+      this.cachedMtime = st.mtimeMs;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Resolve the current routing decision; reads through the cache. */
+  resolve(): RoutingDecision {
+    const f = this.read();
+    if (f === null || f.production === null) {
+      return { kind: 'no-production', production: null, canary: null };
+    }
+    if (f.canary === null) {
+      return { kind: 'production-only', production: f.production, canary: null };
+    }
+    return { kind: 'production-with-canary', production: f.production, canary: f.canary };
+  }
+
+  /**
+   * Hash requestId; route to canary iff hash%100 < canary.percent.
+   * Otherwise route to production. Returns null only when no production
+   * is configured (the consumer must fall back to base model).
+   */
+  routeRequest(requestId: string): string | null {
+    const decision = this.resolve();
+    switch (decision.kind) {
+      case 'no-production':
+        return null;
+      case 'production-only':
+        return decision.production.ollamaModelName;
+      case 'production-with-canary': {
+        const bucket = canaryBucket(requestId);
+        if (bucket < decision.canary.percent) return decision.canary.ollamaModelName;
+        return decision.production.ollamaModelName;
+      }
+    }
+  }
+}
+
+/** Returns 0..99 inclusive, deterministic over requestId. */
+export function canaryBucket(requestId: string): number {
+  const hex = createHash('sha256').update(requestId).digest('hex');
+  // Take the first 8 hex chars → 32-bit unsigned integer; mod 100.
+  const n = parseInt(hex.slice(0, 8), 16);
+  return n % 100;
+}
+
+/** Convenience: write directly through an FsAccess (no router instance). */
+export function writeCanaryRouting(
+  fs: FsAccess,
+  filePath: string,
+  payload: CanaryRoutingWrite,
+  generatedAt: string
+): void {
+  const file: CanaryRoutingConfigFile = {
+    version: 1,
+    generatedAt,
+    production: payload.production,
+    canary: payload.canary
+  };
+  const dir = path.dirname(filePath);
+  if (!fs.exists(dir)) fs.mkdir(dir);
+  const tmp = filePath + '.tmp';
+  fs.writeFile(tmp, JSON.stringify(file, null, 2) + '\n');
+  fs.rename(tmp, filePath);
+}

--- a/packages/apprentice-serving/src/cli.ts
+++ b/packages/apprentice-serving/src/cli.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * caia-apprentice-serving — CLI for ApprenticeServing.
+ *
+ * Usage:
+ *   caia-apprentice-serving register <adapter-path>
+ *   caia-apprentice-serving promote-canary <adapter-path> --percent <0..100>
+ *   caia-apprentice-serving promote-production <adapter-path>
+ *   caia-apprentice-serving rollback <adapter-path>
+ *   caia-apprentice-serving reject <adapter-path> --reason "<reason>"
+ *   caia-apprentice-serving list [--status <status>]
+ *   caia-apprentice-serving show <adapter-path>
+ *   caia-apprentice-serving canary-config
+ *
+ * Common flags:
+ *   --registry-path <path>
+ *   --canary-routing-path <path>
+ *   --ollama-binary <path>
+ */
+
+import { ApprenticeServing } from './serving.js';
+import { ServingError } from './types.js';
+import type { ApprenticeServingConfig } from './types.js';
+import type { RegistryStatus } from './types.js';
+
+interface ParsedArgs {
+  command: string;
+  positional: string[];
+  flags: Record<string, string>;
+  booleanFlags: Set<string>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  const booleanFlags = new Set<string>();
+  let command = '';
+  let i = 0;
+  if (argv[0] && !argv[0].startsWith('--')) {
+    command = argv[0]!;
+    i = 1;
+  }
+  while (i < argv.length) {
+    const arg = argv[i]!;
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags[key] = next;
+        i += 2;
+      } else {
+        booleanFlags.add(key);
+        i += 1;
+      }
+    } else {
+      positional.push(arg);
+      i += 1;
+    }
+  }
+  return { command, positional, flags, booleanFlags };
+}
+
+function buildConfig(flags: Record<string, string>): ApprenticeServingConfig {
+  const cfg: ApprenticeServingConfig = {};
+  if (flags['registry-path']) cfg.registryPath = flags['registry-path'];
+  if (flags['canary-routing-path']) cfg.canaryRoutingConfigPath = flags['canary-routing-path'];
+  if (flags['ollama-binary']) cfg.ollamaBinaryPath = flags['ollama-binary'];
+  return cfg;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'caia-apprentice-serving — Apprentice Phase 3 adapter serving CLI',
+      '',
+      'Commands:',
+      '  register <adapter-path>',
+      '  promote-canary <adapter-path> --percent <0..100>',
+      '  promote-production <adapter-path>',
+      '  rollback <adapter-path>',
+      '  reject <adapter-path> --reason "<reason>"',
+      '  list [--status <status>]',
+      '  show <adapter-path>',
+      '  canary-config',
+      '',
+      'Common flags:',
+      '  --registry-path <path>',
+      '  --canary-routing-path <path>',
+      '  --ollama-binary <path>',
+      ''
+    ].join('\n')
+  );
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv);
+  if (!parsed.command || parsed.command === 'help' || parsed.booleanFlags.has('help')) {
+    printHelp();
+    return 0;
+  }
+  const cfg = buildConfig(parsed.flags);
+  const serving = new ApprenticeServing(cfg);
+
+  try {
+    switch (parsed.command) {
+      case 'register': {
+        const p = requirePositional(parsed.positional, 0, 'adapter-path');
+        const entry = await serving.register(p);
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'promote-canary': {
+        const p = requirePositional(parsed.positional, 0, 'adapter-path');
+        const pct = requireNumberFlag(parsed.flags, 'percent');
+        const entry = await serving.promoteToCanary(p, pct);
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'promote-production': {
+        const p = requirePositional(parsed.positional, 0, 'adapter-path');
+        const entry = await serving.promoteToProduction(p);
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'rollback': {
+        const p = requirePositional(parsed.positional, 0, 'adapter-path');
+        const entry = await serving.rollback(p);
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'reject': {
+        const p = requirePositional(parsed.positional, 0, 'adapter-path');
+        const reason = parsed.flags['reason'] ?? '';
+        const entry = await serving.reject(p, reason);
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'list': {
+        const status = parsed.flags['status'] as RegistryStatus | undefined;
+        let entries = serving.list();
+        if (status !== undefined) entries = entries.filter((e) => e.status === status);
+        process.stdout.write(JSON.stringify(entries, null, 2) + '\n');
+        return 0;
+      }
+      case 'show': {
+        const p = requirePositional(parsed.positional, 0, 'adapter-path');
+        const entry = serving.registry.getByName(basename(p));
+        if (!entry) {
+          process.stderr.write(`adapter not in registry: ${p}\n`);
+          return 4;
+        }
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+        return 0;
+      }
+      case 'canary-config': {
+        const decision = serving.canaryRouter.resolve();
+        process.stdout.write(JSON.stringify(decision, null, 2) + '\n');
+        return 0;
+      }
+      default:
+        process.stderr.write(`unknown command: ${parsed.command}\n`);
+        printHelp();
+        return 1;
+    }
+  } catch (e) {
+    if (e instanceof ServingError) {
+      process.stderr.write(`${e.name}: ${e.message}\n`);
+      if (e.details) process.stderr.write(JSON.stringify(e.details, null, 2) + '\n');
+      return classify(e.name);
+    }
+    process.stderr.write(`unexpected error: ${(e as Error).message ?? String(e)}\n`);
+    return 1;
+  }
+}
+
+function classify(name: string): number {
+  if (
+    name === 'OllamaCreateError' ||
+    name === 'OllamaRemoveError' ||
+    name === 'OllamaInspectError' ||
+    name === 'OllamaNotInstalledError'
+  ) {
+    return 2;
+  }
+  if (name === 'AdapterNotFoundError' || name === 'MetadataMalformedError') return 4;
+  return 1;
+}
+
+function requirePositional(positional: string[], index: number, name: string): string {
+  const v = positional[index];
+  if (v === undefined) {
+    throw new Error(`missing positional argument: ${name}`);
+  }
+  return v;
+}
+
+function requireNumberFlag(flags: Record<string, string>, name: string): number {
+  const v = flags[name];
+  if (v === undefined) throw new Error(`missing flag: --${name}`);
+  const n = Number(v);
+  if (!Number.isFinite(n)) throw new Error(`flag --${name} is not a number: ${v}`);
+  return n;
+}
+
+function basename(p: string): string {
+  const parts = p.split('/');
+  return parts[parts.length - 1] || p;
+}
+
+// Bin entry
+const isMain = process.argv[1] !== undefined && process.argv[1].endsWith('cli.js');
+if (isMain) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/packages/apprentice-serving/src/config.ts
+++ b/packages/apprentice-serving/src/config.ts
@@ -1,0 +1,78 @@
+/**
+ * Resolve config defaults. CAIA-default paths are anchored to
+ * ~/Documents/projects/apprentice/ — same root the trainer writes
+ * adapters under, so registry + canary-routing live alongside.
+ */
+
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import type {
+  ApprenticeServingConfig,
+  AdapterRegistryConfig,
+  CanaryRouterConfig,
+  ResolvedServingConfig,
+  ResolvedAdapterRegistryConfig,
+  ResolvedCanaryRouterConfig
+} from './types.js';
+import { DefaultFsAccess } from './fs-access.js';
+
+export function expandHome(p: string): string {
+  if (p.startsWith('~/')) return path.join(homedir(), p.slice(2));
+  if (p === '~') return homedir();
+  return p;
+}
+
+const DEFAULT_REGISTRY_PATH = '~/Documents/projects/apprentice/registry.json';
+const DEFAULT_CANARY_ROUTING_PATH = '~/Documents/projects/apprentice/canary-routing.json';
+
+export function resolveServingConfig(cfg: ApprenticeServingConfig = {}): ResolvedServingConfig {
+  const fs = cfg.fs ?? new DefaultFsAccess();
+  const clock = cfg.clock ?? (() => new Date());
+  const resolved: ResolvedServingConfig = {
+    registryPath: expandHome(cfg.registryPath ?? DEFAULT_REGISTRY_PATH),
+    canaryRoutingConfigPath: expandHome(cfg.canaryRoutingConfigPath ?? DEFAULT_CANARY_ROUTING_PATH),
+    ollamaBinaryPath: cfg.ollamaBinaryPath ?? 'ollama',
+    productionModelName: cfg.productionModelName ?? ((b: string) => `${b}-production`),
+    canaryModelName: cfg.canaryModelName ?? ((b: string, s: string) => `${b}-canary-${s}`),
+    shadowModelName: cfg.shadowModelName ?? ((b: string, s: string) => `${b}-shadow-${s}`),
+    maxArchivedToKeep: cfg.maxArchivedToKeep ?? 10,
+    fs,
+    clock,
+    ollamaTimeoutMs: cfg.ollamaTimeoutMs ?? 5 * 60 * 1000
+  };
+  if (cfg.ollamaClient !== undefined) resolved.ollamaClient = cfg.ollamaClient;
+  if (cfg.ollamaHost !== undefined) resolved.ollamaHost = cfg.ollamaHost;
+  return resolved;
+}
+
+export function resolveAdapterRegistryConfig(
+  cfg: AdapterRegistryConfig = {}
+): ResolvedAdapterRegistryConfig {
+  return {
+    registryPath: expandHome(cfg.registryPath ?? DEFAULT_REGISTRY_PATH),
+    fs: cfg.fs ?? new DefaultFsAccess(),
+    clock: cfg.clock ?? (() => new Date())
+  };
+}
+
+export function resolveCanaryRouterConfig(
+  cfg: CanaryRouterConfig = {}
+): ResolvedCanaryRouterConfig {
+  return {
+    canaryRoutingConfigPath: expandHome(
+      cfg.canaryRoutingConfigPath ?? DEFAULT_CANARY_ROUTING_PATH
+    ),
+    fs: cfg.fs ?? new DefaultFsAccess(),
+    clock: cfg.clock ?? (() => new Date())
+  };
+}
+
+/** baseModel "qwen2.5-coder:7b" → "qwen2.5-coder-7b". */
+export function baseShortName(baseModelOllamaTag: string): string {
+  return baseModelOllamaTag
+    .toLowerCase()
+    .replace(/:/g, '-')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}

--- a/packages/apprentice-serving/src/fs-access.ts
+++ b/packages/apprentice-serving/src/fs-access.ts
@@ -1,0 +1,40 @@
+/**
+ * Default FsAccess wrapping node:fs. Tests inject createInMemoryFs()
+ * from tests/helpers/fakes.ts.
+ */
+
+import * as nodeFs from 'node:fs';
+import type { FsAccess } from './types.js';
+
+export class DefaultFsAccess implements FsAccess {
+  exists(p: string): boolean {
+    return nodeFs.existsSync(p);
+  }
+  readFile(p: string): string {
+    return nodeFs.readFileSync(p, 'utf8');
+  }
+  writeFile(p: string, content: string): void {
+    nodeFs.writeFileSync(p, content);
+  }
+  mkdir(p: string): void {
+    nodeFs.mkdirSync(p, { recursive: true });
+  }
+  rename(oldP: string, newP: string): void {
+    nodeFs.renameSync(oldP, newP);
+  }
+  unlink(p: string): void {
+    nodeFs.unlinkSync(p);
+  }
+  readDir(p: string): string[] {
+    return nodeFs.readdirSync(p);
+  }
+  stat(p: string): { mtimeMs: number; size: number; isFile: boolean; isDirectory: boolean } {
+    const s = nodeFs.statSync(p);
+    return {
+      mtimeMs: s.mtimeMs,
+      size: s.size,
+      isFile: s.isFile(),
+      isDirectory: s.isDirectory()
+    };
+  }
+}

--- a/packages/apprentice-serving/src/index.ts
+++ b/packages/apprentice-serving/src/index.ts
@@ -1,0 +1,57 @@
+/**
+ * @chiefaia/apprentice-serving — public API.
+ *
+ * Phase 3 of the Apprentice campaign. Loads adapters produced by
+ * @chiefaia/apprentice-training (Phase 2) into Ollama, tracks lifecycle
+ * state in a persisted JSON registry, and writes a canary-routing config
+ * read at inference time by downstream agents.
+ */
+
+export { ApprenticeServing } from './serving.js';
+export { AdapterRegistry } from './adapter-registry.js';
+export { CanaryRouter, canaryBucket, writeCanaryRouting } from './canary-router.js';
+export { readAdapterArtifacts, extractEvalSummary } from './metadata-reader.js';
+export { SubprocessOllamaClient, DefaultSubprocessExecutor, parseListOutput } from './ollama-client.js';
+export type { OllamaClientConfig, SubprocessExecutor, SubprocessExecutorArgs, SubprocessExecutorResult } from './ollama-client.js';
+export type { AdapterArtifacts } from './metadata-reader.js';
+export { DefaultFsAccess } from './fs-access.js';
+export { resolveServingConfig, resolveAdapterRegistryConfig, resolveCanaryRouterConfig, baseShortName, expandHome } from './config.js';
+
+// Types + errors
+export type {
+  ApprenticeServingConfig,
+  AdapterRegistryConfig,
+  CanaryRouterConfig,
+  CanaryRoutingCanaryEntry,
+  CanaryRoutingConfigFile,
+  CanaryRoutingProductionEntry,
+  EvalReportRead,
+  EvalSummary,
+  FsAccess,
+  OllamaClient,
+  OllamaCreateArgs,
+  RegistryEntry,
+  RegistryFile,
+  RegistryHistoryEntry,
+  RegistryStatus,
+  ResolvedAdapterRegistryConfig,
+  ResolvedCanaryRouterConfig,
+  ResolvedServingConfig,
+  RoutingDecision,
+  TrainingMetadataRead
+} from './types.js';
+
+export {
+  ServingError,
+  AdapterNotFoundError,
+  MetadataMalformedError,
+  RegistryInvariantError,
+  RegistryStateMismatchError,
+  RegistryCorruptError,
+  OllamaNotInstalledError,
+  OllamaCreateError,
+  OllamaRemoveError,
+  OllamaInspectError,
+  RollbackTargetInvalidError,
+  CanaryPercentOutOfRangeError
+} from './types.js';

--- a/packages/apprentice-serving/src/metadata-reader.ts
+++ b/packages/apprentice-serving/src/metadata-reader.ts
@@ -1,0 +1,125 @@
+/**
+ * Read + validate <adapterPath>/training-metadata.json (mandatory) and
+ * <adapterPath>/eval-report.json (optional). Compute the metadata sha256
+ * for cross-run identity.
+ */
+
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import {
+  AdapterNotFoundError,
+  MetadataMalformedError
+} from './types.js';
+import type {
+  EvalReportRead,
+  EvalSummary,
+  FsAccess,
+  TrainingMetadataRead
+} from './types.js';
+
+export interface AdapterArtifacts {
+  adapterPath: string;
+  /** Absolute path to <adapterPath>/Modelfile. */
+  modelfilePath: string;
+  /** Absolute path to <adapterPath>/adapters.safetensors. */
+  adapterFile: string;
+  /** Absolute path to <adapterPath>/adapter_config.json. */
+  adapterConfigFile: string;
+  /** Absolute path to <adapterPath>/training-metadata.json. */
+  metadataPath: string;
+  metadata: TrainingMetadataRead;
+  metadataSha256: string;
+  evalReport?: EvalSummary;
+}
+
+/** Mandatory artifacts that must exist in the adapter dir. */
+const MANDATORY_FILES = ['Modelfile', 'adapters.safetensors', 'adapter_config.json', 'training-metadata.json'] as const;
+
+export function readAdapterArtifacts(fs: FsAccess, adapterPath: string): AdapterArtifacts {
+  if (!fs.exists(adapterPath)) {
+    throw new AdapterNotFoundError(`adapterPath not found: ${adapterPath}`, { adapterPath });
+  }
+  for (const f of MANDATORY_FILES) {
+    const p = path.join(adapterPath, f);
+    if (!fs.exists(p)) {
+      throw new AdapterNotFoundError(
+        `adapter dir is missing mandatory file ${f}: ${p}`,
+        { adapterPath, missing: f }
+      );
+    }
+  }
+
+  const metadataPath = path.join(adapterPath, 'training-metadata.json');
+  const metadataRaw = fs.readFile(metadataPath);
+  const metadataSha256 = createHash('sha256').update(metadataRaw).digest('hex');
+
+  let metadata: TrainingMetadataRead;
+  try {
+    metadata = JSON.parse(metadataRaw) as TrainingMetadataRead;
+  } catch (e) {
+    throw new MetadataMalformedError(
+      `training-metadata.json is not valid JSON: ${(e as Error).message}`,
+      { metadataPath }
+    );
+  }
+
+  validateMetadata(metadata, metadataPath);
+
+  const result: AdapterArtifacts = {
+    adapterPath,
+    modelfilePath: path.join(adapterPath, 'Modelfile'),
+    adapterFile: path.join(adapterPath, 'adapters.safetensors'),
+    adapterConfigFile: path.join(adapterPath, 'adapter_config.json'),
+    metadataPath,
+    metadata,
+    metadataSha256
+  };
+
+  // eval-report.json is optional.
+  const evalPath = path.join(adapterPath, 'eval-report.json');
+  if (fs.exists(evalPath)) {
+    try {
+      const raw = fs.readFile(evalPath);
+      const parsed = JSON.parse(raw) as EvalReportRead;
+      const summary = extractEvalSummary(parsed);
+      if (summary !== undefined) result.evalReport = summary;
+    } catch {
+      // Treat malformed eval-report as absent; the eval gate is Phase 4's
+      // concern, and we don't want a malformed sidecar to block registration.
+    }
+  }
+
+  return result;
+}
+
+function validateMetadata(m: TrainingMetadataRead, metadataPath: string): void {
+  const required = ['version', 'baseModel', 'baseModelOllamaTag', 'configSha256'] as const;
+  const missing = required.filter((k) => m[k] === undefined || m[k] === null);
+  if (missing.length > 0) {
+    throw new MetadataMalformedError(
+      `training-metadata.json is missing required fields: ${missing.join(', ')}`,
+      { metadataPath, missing }
+    );
+  }
+  if (typeof m.baseModel !== 'string' || m.baseModel.length === 0) {
+    throw new MetadataMalformedError('baseModel must be a non-empty string', { metadataPath });
+  }
+  if (typeof m.baseModelOllamaTag !== 'string' || m.baseModelOllamaTag.length === 0) {
+    throw new MetadataMalformedError('baseModelOllamaTag must be a non-empty string', { metadataPath });
+  }
+  if (typeof m.configSha256 !== 'string' || m.configSha256.length === 0) {
+    throw new MetadataMalformedError('configSha256 must be a non-empty string', { metadataPath });
+  }
+}
+
+export function extractEvalSummary(report: EvalReportRead): EvalSummary | undefined {
+  const entry = report.adapters?.[0];
+  if (!entry) return undefined;
+  const winRate = typeof entry.winRate === 'number' ? entry.winRate : NaN;
+  const decision = typeof entry.decision === 'string' ? entry.decision : 'unknown';
+  const regressionFlags = Array.isArray(entry.regressionFlags)
+    ? entry.regressionFlags.filter((s): s is string => typeof s === 'string')
+    : [];
+  if (Number.isNaN(winRate)) return undefined;
+  return { winRate, decision, regressionFlags };
+}

--- a/packages/apprentice-serving/src/ollama-client.ts
+++ b/packages/apprentice-serving/src/ollama-client.ts
@@ -1,0 +1,239 @@
+/**
+ * Subprocess-backed implementation of OllamaClient. Spawns the `ollama`
+ * CLI and parses its output. Treats "model not found" on rm as success
+ * (idempotent removal). Throws typed errors on every other non-zero exit.
+ *
+ * Tests inject createFakeOllamaClient() from tests/helpers/fakes.ts.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  OllamaCreateError,
+  OllamaInspectError,
+  OllamaNotInstalledError,
+  OllamaRemoveError
+} from './types.js';
+import type { OllamaClient, OllamaCreateArgs } from './types.js';
+
+export interface SubprocessExecutorArgs {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env: Record<string, string | undefined>;
+  timeoutMs: number;
+  /** Combined stdin string. Default empty. */
+  stdin?: string;
+}
+
+export interface SubprocessExecutorResult {
+  exitCode: number;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  elapsedMs: number;
+}
+
+export interface SubprocessExecutor {
+  run(args: SubprocessExecutorArgs): Promise<SubprocessExecutorResult>;
+}
+
+export class DefaultSubprocessExecutor implements SubprocessExecutor {
+  async run(args: SubprocessExecutorArgs): Promise<SubprocessExecutorResult> {
+    return new Promise<SubprocessExecutorResult>((resolve) => {
+      const start = Date.now();
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+      const child = spawn(args.command, args.args, {
+        cwd: args.cwd,
+        env: args.env as NodeJS.ProcessEnv,
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        setTimeout(() => {
+          if (!child.killed) child.kill('SIGKILL');
+        }, 30_000);
+      }, args.timeoutMs);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        resolve({
+          exitCode: -1,
+          signal: null,
+          stdout,
+          stderr: stderr + '\n' + (err.message ?? String(err)),
+          timedOut,
+          elapsedMs: Date.now() - start
+        });
+      });
+      child.on('close', (code, signal) => {
+        clearTimeout(timer);
+        resolve({
+          exitCode: code ?? -1,
+          signal: signal ?? null,
+          stdout,
+          stderr,
+          timedOut,
+          elapsedMs: Date.now() - start
+        });
+      });
+
+      if (args.stdin) {
+        child.stdin?.write(args.stdin);
+        child.stdin?.end();
+      } else {
+        child.stdin?.end();
+      }
+    });
+  }
+}
+
+export interface OllamaClientConfig {
+  ollamaBinaryPath: string;
+  /** Default OLLAMA_HOST when set. */
+  ollamaHost?: string;
+  timeoutMs: number;
+  executor?: SubprocessExecutor;
+}
+
+export class SubprocessOllamaClient implements OllamaClient {
+  private readonly binary: string;
+  private readonly host?: string;
+  private readonly timeoutMs: number;
+  private readonly executor: SubprocessExecutor;
+
+  constructor(cfg: OllamaClientConfig) {
+    this.binary = cfg.ollamaBinaryPath;
+    if (cfg.ollamaHost !== undefined) this.host = cfg.ollamaHost;
+    this.timeoutMs = cfg.timeoutMs;
+    this.executor = cfg.executor ?? new DefaultSubprocessExecutor();
+  }
+
+  private env(): Record<string, string | undefined> {
+    const base = { ...process.env };
+    if (this.host !== undefined) base.OLLAMA_HOST = this.host;
+    // Defence in depth: clear any LLM-API-key env vars from subprocess.
+    delete base.ANTHROPIC_API_KEY;
+    return base;
+  }
+
+  async version(): Promise<string> {
+    const r = await this.executor.run({
+      command: this.binary,
+      args: ['--version'],
+      env: this.env(),
+      timeoutMs: this.timeoutMs
+    });
+    if (r.exitCode !== 0) {
+      throw new OllamaNotInstalledError(
+        `ollama --version failed (exit ${r.exitCode}). Install Ollama: https://ollama.com/download`,
+        { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }
+      );
+    }
+    return r.stdout.trim();
+  }
+
+  async list(): Promise<string[]> {
+    const r = await this.executor.run({
+      command: this.binary,
+      args: ['list'],
+      env: this.env(),
+      timeoutMs: this.timeoutMs
+    });
+    if (r.exitCode !== 0) {
+      throw new OllamaInspectError(`ollama list failed (exit ${r.exitCode})`, {
+        stderr: r.stderr,
+        exitCode: r.exitCode
+      });
+    }
+    return parseListOutput(r.stdout);
+  }
+
+  async create(args: OllamaCreateArgs): Promise<void> {
+    const r = await this.executor.run({
+      command: this.binary,
+      args: ['create', args.modelName, '-f', args.modelfilePath],
+      cwd: args.cwd,
+      env: this.env(),
+      timeoutMs: this.timeoutMs
+    });
+    if (r.exitCode !== 0) {
+      throw new OllamaCreateError(
+        `ollama create ${args.modelName} failed (exit ${r.exitCode})`,
+        {
+          stdout: r.stdout,
+          stderr: r.stderr,
+          modelName: args.modelName,
+          modelfilePath: args.modelfilePath,
+          cwd: args.cwd,
+          exitCode: r.exitCode,
+          timedOut: r.timedOut
+        }
+      );
+    }
+  }
+
+  async remove(modelName: string): Promise<void> {
+    const r = await this.executor.run({
+      command: this.binary,
+      args: ['rm', modelName],
+      env: this.env(),
+      timeoutMs: this.timeoutMs
+    });
+    if (r.exitCode === 0) return;
+    if (isNotFound(r.stdout + r.stderr)) return;
+    throw new OllamaRemoveError(`ollama rm ${modelName} failed (exit ${r.exitCode})`, {
+      stdout: r.stdout,
+      stderr: r.stderr,
+      modelName,
+      exitCode: r.exitCode
+    });
+  }
+
+  async show(modelName: string): Promise<string> {
+    const r = await this.executor.run({
+      command: this.binary,
+      args: ['show', modelName, '--modelfile'],
+      env: this.env(),
+      timeoutMs: this.timeoutMs
+    });
+    if (r.exitCode !== 0) {
+      throw new OllamaInspectError(
+        `ollama show ${modelName} --modelfile failed (exit ${r.exitCode})`,
+        { stderr: r.stderr, modelName, exitCode: r.exitCode }
+      );
+    }
+    return r.stdout;
+  }
+}
+
+function isNotFound(text: string): boolean {
+  return /not\s*found|no\s*such/i.test(text);
+}
+
+/** Parse `ollama list` table output: skip header row, column 1 = NAME. */
+export function parseListOutput(stdout: string): string[] {
+  const lines = stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+  const names: string[] = [];
+  let isFirst = true;
+  for (const line of lines) {
+    if (isFirst) {
+      // The first non-empty line is the header (e.g., "NAME  ID  SIZE  MODIFIED")
+      isFirst = false;
+      if (/^name\b/i.test(line)) continue;
+    }
+    // Take the first whitespace-delimited token as the model name.
+    const name = line.split(/\s+/)[0];
+    if (name && !/^name$/i.test(name)) names.push(name);
+  }
+  return names;
+}

--- a/packages/apprentice-serving/src/serving.ts
+++ b/packages/apprentice-serving/src/serving.ts
@@ -1,0 +1,377 @@
+/**
+ * ApprenticeServing — top-level orchestrator. Composes:
+ *   - AdapterRegistry  (state book-keeping)
+ *   - OllamaClient     (subprocess: ollama create/rm/show/list)
+ *   - CanaryRouter     (canary-routing.json writer)
+ *   - metadata-reader  (training-metadata.json + eval-report.json)
+ *
+ * Each public method threads metadata-read → registry-mutation → ollama-side-effect →
+ * canary-config-write so callers see one atomic-feeling operation.
+ */
+
+import * as path from 'node:path';
+import {
+  AdapterNotFoundError,
+  RegistryStateMismatchError
+} from './types.js';
+import type {
+  ApprenticeServingConfig,
+  CanaryRoutingCanaryEntry,
+  CanaryRoutingProductionEntry,
+  EvalSummary,
+  OllamaClient,
+  RegistryEntry,
+  RegistryStatus,
+  ResolvedServingConfig
+} from './types.js';
+import { AdapterRegistry } from './adapter-registry.js';
+import { CanaryRouter } from './canary-router.js';
+import { resolveServingConfig, baseShortName } from './config.js';
+import { readAdapterArtifacts } from './metadata-reader.js';
+import { SubprocessOllamaClient } from './ollama-client.js';
+
+export class ApprenticeServing {
+  private readonly cfg: ResolvedServingConfig;
+  public readonly registry: AdapterRegistry;
+  public readonly canaryRouter: CanaryRouter;
+  private readonly ollama: OllamaClient;
+
+  constructor(config: ApprenticeServingConfig = {}) {
+    this.cfg = resolveServingConfig(config);
+    this.registry = new AdapterRegistry({
+      registryPath: this.cfg.registryPath,
+      fs: this.cfg.fs,
+      clock: this.cfg.clock
+    });
+    this.canaryRouter = new CanaryRouter({
+      canaryRoutingConfigPath: this.cfg.canaryRoutingConfigPath,
+      fs: this.cfg.fs,
+      clock: this.cfg.clock
+    });
+    this.ollama =
+      this.cfg.ollamaClient ??
+      new SubprocessOllamaClient({
+        ollamaBinaryPath: this.cfg.ollamaBinaryPath,
+        ...(this.cfg.ollamaHost !== undefined ? { ollamaHost: this.cfg.ollamaHost } : {}),
+        timeoutMs: this.cfg.ollamaTimeoutMs
+      });
+  }
+
+  /**
+   * Idempotent: reads training-metadata.json from the adapter dir, derives
+   * the adapterName (= directory basename), upserts a `registered` entry.
+   * Returns the resulting registry entry.
+   */
+  async register(adapterPath: string): Promise<RegistryEntry> {
+    const artifacts = readAdapterArtifacts(this.cfg.fs, adapterPath);
+    const adapterName = path.basename(adapterPath);
+    const existing = this.registry.getByName(adapterName);
+
+    if (existing !== undefined) {
+      // Idempotent: same adapter, no state change. Refresh metadata fields
+      // (path can change if user moves the dir, eval can land later).
+      const refreshed: RegistryEntry = {
+        ...existing,
+        adapterPath,
+        metadataSha256: artifacts.metadataSha256,
+        baseModel: artifacts.metadata.baseModel,
+        baseModelOllamaTag: artifacts.metadata.baseModelOllamaTag,
+        configSha256: artifacts.metadata.configSha256
+      };
+      if (artifacts.evalReport !== undefined) refreshed.evalReport = artifacts.evalReport;
+      this.registry.upsert(refreshed);
+      return refreshed;
+    }
+
+    const entry: RegistryEntry = {
+      adapterName,
+      adapterPath,
+      metadataSha256: artifacts.metadataSha256,
+      configSha256: artifacts.metadata.configSha256,
+      baseModel: artifacts.metadata.baseModel,
+      baseModelOllamaTag: artifacts.metadata.baseModelOllamaTag,
+      status: 'registered',
+      history: [
+        {
+          at: this.cfg.clock().toISOString(),
+          fromStatus: null,
+          toStatus: 'registered'
+        }
+      ],
+      registeredAt: this.cfg.clock().toISOString()
+    };
+    if (artifacts.evalReport !== undefined) entry.evalReport = artifacts.evalReport;
+    this.registry.upsert(entry);
+    return entry;
+  }
+
+  /**
+   * Load the adapter into Ollama as `<base>-canary-<sha7>`, transition
+   * to canary, atomically update canary-routing config.
+   */
+  async promoteToCanary(adapterPath: string, percent: number): Promise<RegistryEntry> {
+    AdapterRegistry.assertCanaryPercent(percent);
+    const entry = await this.requireRegistered(adapterPath);
+    AdapterRegistry.assertValidTransition(entry.status, 'canary');
+
+    // If another canary exists for a DIFFERENT adapter, archive it first.
+    const prevCanary = this.registry.currentCanary();
+    if (prevCanary !== undefined && prevCanary.adapterName !== entry.adapterName) {
+      await this.archiveCanary(prevCanary);
+    }
+
+    const artifacts = readAdapterArtifacts(this.cfg.fs, entry.adapterPath);
+    const sha7 = entry.metadataSha256.slice(0, 7);
+    const base = baseShortName(entry.baseModelOllamaTag);
+    const canaryModelName = this.cfg.canaryModelName(base, sha7);
+
+    await this.ollama.create({
+      modelName: canaryModelName,
+      modelfilePath: artifacts.modelfilePath,
+      cwd: entry.adapterPath
+    });
+
+    const updated = this.registry.transition(
+      entry.adapterName,
+      'canary',
+      (e) => {
+        e.ollamaModelName = canaryModelName;
+        e.canaryPercent = percent;
+        e.promotedAt = this.cfg.clock().toISOString();
+      },
+      `promoted to canary @${percent}%`
+    );
+    this.writeCanaryRouting();
+    return updated;
+  }
+
+  /**
+   * Load the adapter into Ollama as `<base>-production`, transition to
+   * production, archive the previous production (if any).
+   */
+  async promoteToProduction(adapterPath: string): Promise<RegistryEntry> {
+    const entry = await this.requireRegistered(adapterPath);
+    AdapterRegistry.assertValidTransition(entry.status, 'production');
+
+    const artifacts = readAdapterArtifacts(this.cfg.fs, entry.adapterPath);
+    const base = baseShortName(entry.baseModelOllamaTag);
+    const prodModelName = this.cfg.productionModelName(base);
+
+    // Archive previous production (if any) BEFORE overwriting the slot.
+    const prevProd = this.registry.currentProduction();
+    if (prevProd !== undefined && prevProd.adapterName !== entry.adapterName) {
+      await this.archiveProduction(prevProd);
+    }
+
+    await this.ollama.create({
+      modelName: prodModelName,
+      modelfilePath: artifacts.modelfilePath,
+      cwd: entry.adapterPath
+    });
+
+    // If THIS adapter was the previous canary, the canary Ollama model is
+    // now stale. Best-effort remove.
+    if (entry.status === 'canary' && entry.ollamaModelName !== undefined) {
+      const staleCanary = entry.ollamaModelName;
+      try {
+        await this.ollama.remove(staleCanary);
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    const updated = this.registry.transition(
+      entry.adapterName,
+      'production',
+      (e) => {
+        e.ollamaModelName = prodModelName;
+        e.promotedAt = this.cfg.clock().toISOString();
+      },
+      'promoted to production'
+    );
+    this.writeCanaryRouting();
+    this.gcArchived();
+    return updated;
+  }
+
+  /**
+   * Roll back to a previously-archived adapter. Re-promotes it to
+   * production; archives the current production.
+   */
+  async rollback(toAdapterPath: string): Promise<RegistryEntry> {
+    const target = this.registry.getByName(path.basename(toAdapterPath));
+    if (target === undefined) {
+      throw new AdapterNotFoundError(`rollback target not in registry: ${toAdapterPath}`, {
+        toAdapterPath
+      });
+    }
+    AdapterRegistry.assertRollbackTarget(target);
+
+    const artifacts = readAdapterArtifacts(this.cfg.fs, target.adapterPath);
+    const base = baseShortName(target.baseModelOllamaTag);
+    const prodModelName = this.cfg.productionModelName(base);
+
+    const prevProd = this.registry.currentProduction();
+    if (prevProd !== undefined && prevProd.adapterName !== target.adapterName) {
+      await this.archiveProduction(prevProd);
+    }
+
+    await this.ollama.create({
+      modelName: prodModelName,
+      modelfilePath: artifacts.modelfilePath,
+      cwd: target.adapterPath
+    });
+
+    const updated = this.registry.transition(
+      target.adapterName,
+      'production',
+      (e) => {
+        e.ollamaModelName = prodModelName;
+        e.promotedAt = this.cfg.clock().toISOString();
+      },
+      'rolled back to production'
+    );
+    this.writeCanaryRouting();
+    this.gcArchived();
+    return updated;
+  }
+
+  /**
+   * Mark an adapter rejected. Removes it from Ollama if loaded.
+   */
+  async reject(adapterPath: string, reason: string): Promise<RegistryEntry> {
+    if (typeof reason !== 'string' || reason.trim().length === 0) {
+      throw new RegistryStateMismatchError('reject() requires a non-empty reason', {
+        adapterPath
+      });
+    }
+    const entry = await this.requireRegistered(adapterPath);
+    AdapterRegistry.assertValidTransition(entry.status, 'rejected');
+
+    if (entry.ollamaModelName !== undefined) {
+      try {
+        await this.ollama.remove(entry.ollamaModelName);
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    const updated = this.registry.transition(
+      entry.adapterName,
+      'rejected',
+      (e) => {
+        e.rejectionReason = reason;
+        delete e.ollamaModelName;
+      },
+      `rejected: ${reason}`
+    );
+    this.writeCanaryRouting();
+    return updated;
+  }
+
+  /** Read-through helpers. */
+  list(): RegistryEntry[] {
+    return this.registry.list();
+  }
+  currentProduction(): RegistryEntry | undefined {
+    return this.registry.currentProduction();
+  }
+  currentCanary(): RegistryEntry | undefined {
+    return this.registry.currentCanary();
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // Internals
+  // ────────────────────────────────────────────────────────────────────
+
+  /** Ensure the adapter is registered; throws if not. */
+  private async requireRegistered(adapterPath: string): Promise<RegistryEntry> {
+    const adapterName = path.basename(adapterPath);
+    const existing = this.registry.getByName(adapterName);
+    if (existing !== undefined) {
+      // Refresh adapterPath and eval metadata in case the dir moved or eval
+      // landed since registration.
+      if (existing.adapterPath !== adapterPath) {
+        existing.adapterPath = adapterPath;
+        this.registry.upsert(existing);
+      }
+      return existing;
+    }
+    return this.register(adapterPath);
+  }
+
+  /** Re-write canary-routing.json from current registry state. */
+  private writeCanaryRouting(): void {
+    const prod = this.registry.currentProduction();
+    const canary = this.registry.currentCanary();
+    const productionEntry: CanaryRoutingProductionEntry | null =
+      prod && prod.ollamaModelName
+        ? { ollamaModelName: prod.ollamaModelName, adapterName: prod.adapterName }
+        : null;
+    const canaryEntry: CanaryRoutingCanaryEntry | null =
+      canary && canary.ollamaModelName && canary.canaryPercent !== undefined
+        ? {
+            ollamaModelName: canary.ollamaModelName,
+            adapterName: canary.adapterName,
+            percent: canary.canaryPercent
+          }
+        : null;
+    this.canaryRouter.write({ production: productionEntry, canary: canaryEntry });
+  }
+
+  /** Move a previous-production entry to archived; remove its Ollama model. */
+  private async archiveProduction(entry: RegistryEntry): Promise<void> {
+    if (entry.ollamaModelName !== undefined) {
+      try {
+        await this.ollama.remove(entry.ollamaModelName);
+      } catch {
+        /* best-effort */
+      }
+    }
+    this.registry.transition(
+      entry.adapterName,
+      'archived',
+      (e) => {
+        e.archivedAt = this.cfg.clock().toISOString();
+        delete e.ollamaModelName;
+      },
+      'archived (replaced by newer production)'
+    );
+  }
+
+  /** Move a previous-canary entry to archived; remove its Ollama model. */
+  private async archiveCanary(entry: RegistryEntry): Promise<void> {
+    if (entry.ollamaModelName !== undefined) {
+      try {
+        await this.ollama.remove(entry.ollamaModelName);
+      } catch {
+        /* best-effort */
+      }
+    }
+    this.registry.transition(
+      entry.adapterName,
+      'archived',
+      (e) => {
+        e.archivedAt = this.cfg.clock().toISOString();
+        delete e.ollamaModelName;
+      },
+      'archived (replaced by newer canary)'
+    );
+  }
+
+  /** GC oldest archived entries beyond the keep-cap. */
+  private gcArchived(): void {
+    const archived = this.registry
+      .list()
+      .filter((e) => e.status === 'archived')
+      .sort((a, b) => (a.archivedAt ?? '').localeCompare(b.archivedAt ?? ''));
+    while (archived.length > this.cfg.maxArchivedToKeep) {
+      const oldest = archived.shift();
+      if (oldest === undefined) break;
+      this.registry.drop(oldest.adapterName);
+    }
+  }
+}
+
+// Re-export the relevant status type for convenience.
+export type { RegistryStatus, EvalSummary };

--- a/packages/apprentice-serving/src/types.ts
+++ b/packages/apprentice-serving/src/types.ts
@@ -1,0 +1,342 @@
+/**
+ * @chiefaia/apprentice-serving — shared types.
+ *
+ * Pipeline overview (mirrors DESIGN.md §5):
+ *
+ *   adapterPath (Phase 2 output)
+ *           ↓
+ *     ApprenticeServing.register()
+ *           ↓
+ *     metadata-reader → training-metadata.json + eval-report.json
+ *           ↓
+ *     adapter-registry.upsert() → registry.json (atomic rename)
+ *           ↓
+ *   (later) promoteToCanary / promoteToProduction / rollback / reject
+ *           ↓
+ *     ollama-client.create()/.remove() → subprocess: ollama create/rm
+ *           ↓
+ *     canary-router.write() → canary-routing.json (atomic rename)
+ *
+ * Option E shape: every CAIA-specific path / model name template / Ollama
+ * binary path is a constructor parameter with a CAIA default; tests inject
+ * fixtures + a mocked OllamaClient.  See DESIGN.md for full architecture
+ * rationale.
+ */
+
+// ──────────────────────────────────────────────────────────────────────────
+// Registry types
+// ──────────────────────────────────────────────────────────────────────────
+
+export type RegistryStatus =
+  | 'registered'
+  | 'shadow'
+  | 'canary'
+  | 'production'
+  | 'archived'
+  | 'rejected';
+
+/** A single registry entry. */
+export interface RegistryEntry {
+  /**
+   * Stable identity = adapter directory basename.
+   * Example: `2026-05-06-qwen2.5-coder-7b-rank8-iters1500`.
+   * Used as the registry primary key and the basis for the Ollama
+   * model name (`<baseShortName>-<status>-<sha7>` etc.).
+   */
+  adapterName: string;
+  adapterPath: string;
+  /** sha256 of training-metadata.json file contents. */
+  metadataSha256: string;
+  /** Pulled from training-metadata.json; cross-run identity. */
+  configSha256: string;
+  /** From training-metadata.json. */
+  baseModel: string;
+  /** From training-metadata.json. Used as the Ollama FROM tag. */
+  baseModelOllamaTag: string;
+  /** Set when status ∈ {shadow, canary, production}. */
+  ollamaModelName?: string;
+  /** Optional eval verdict from `<adapterPath>/eval-report.json`. */
+  evalReport?: EvalSummary;
+  status: RegistryStatus;
+  /** Append-only history of state transitions. */
+  history: RegistryHistoryEntry[];
+  /** Set iff status === 'canary'. */
+  canaryPercent?: number;
+  /** Set iff status === 'rejected'. */
+  rejectionReason?: string;
+  /** ISO-8601. */
+  registeredAt: string;
+  /** Most recent promotion event. */
+  promotedAt?: string;
+  /** Set iff status === 'archived'. */
+  archivedAt?: string;
+}
+
+export interface RegistryHistoryEntry {
+  at: string;
+  fromStatus: RegistryStatus | null;
+  toStatus: RegistryStatus;
+  note?: string;
+}
+
+export interface EvalSummary {
+  winRate: number;
+  decision: string;
+  regressionFlags: string[];
+}
+
+/** What gets persisted at registryPath. */
+export interface RegistryFile {
+  version: 1;
+  generatedAt: string;
+  entries: RegistryEntry[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Canary-routing config
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface CanaryRoutingConfigFile {
+  version: 1;
+  generatedAt: string;
+  production: CanaryRoutingProductionEntry | null;
+  canary: CanaryRoutingCanaryEntry | null;
+}
+
+export interface CanaryRoutingProductionEntry {
+  ollamaModelName: string;
+  adapterName: string;
+}
+
+export interface CanaryRoutingCanaryEntry {
+  ollamaModelName: string;
+  adapterName: string;
+  /** 0..100 inclusive. */
+  percent: number;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Training metadata read-side
+// ──────────────────────────────────────────────────────────────────────────
+
+/** What we read from <adapterPath>/training-metadata.json.
+ *  Defensive subset of @chiefaia/apprentice-training's TrainingMetadata —
+ *  duplicated here so this package doesn't take a build-time dep on the
+ *  trainer (cleaner Phase 4 wiring; lets serving be useful pre-trainer-merge). */
+export interface TrainingMetadataRead {
+  version: number;
+  generatedAt: string;
+  baseModel: string;
+  baseModelOllamaTag: string;
+  configSha256: string;
+  /** Pass-through; we don't validate contents. */
+  loraConfig?: Record<string, unknown>;
+  /** Pass-through. */
+  corpusTotals?: Record<string, unknown>;
+  /** Pass-through. */
+  subprocess?: Record<string, unknown>;
+  /** Pass-through. */
+  warnings?: string[];
+  [k: string]: unknown;
+}
+
+/** What we read from <adapterPath>/eval-report.json (when present). */
+export interface EvalReportRead {
+  /** Phase 1 may emit a top-level `adapters` array; we pluck the first
+   *  entry whose name matches our adapter. Fallback: first entry. */
+  adapters?: Array<{
+    name?: string;
+    winRate?: number;
+    decision?: string;
+    regressionFlags?: string[];
+    [k: string]: unknown;
+  }>;
+  [k: string]: unknown;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Test seams
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FsAccess {
+  exists(p: string): boolean;
+  readFile(p: string): string;
+  writeFile(p: string, content: string): void;
+  mkdir(p: string): void;
+  rename(oldP: string, newP: string): void;
+  unlink(p: string): void;
+  readDir(p: string): string[];
+  stat(p: string): { mtimeMs: number; size: number; isFile: boolean; isDirectory: boolean };
+}
+
+/** Subset of OllamaClient operations we need. */
+export interface OllamaClient {
+  /** `ollama --version`. Throws OllamaNotInstalledError on failure. */
+  version(): Promise<string>;
+  /** `ollama list`. Returns model names. */
+  list(): Promise<string[]>;
+  /** `ollama create <name> -f <modelfilePath>`. cwd is set to <adapterPath>. */
+  create(args: OllamaCreateArgs): Promise<void>;
+  /** `ollama rm <name>`. Treats not-found as success. */
+  remove(modelName: string): Promise<void>;
+  /** `ollama show <name> --modelfile`. Returns the Modelfile content. */
+  show(modelName: string): Promise<string>;
+}
+
+export interface OllamaCreateArgs {
+  modelName: string;
+  modelfilePath: string;
+  cwd: string;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Configuration
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface ApprenticeServingConfig {
+  /** Default: ~/Documents/projects/apprentice/registry.json */
+  registryPath?: string;
+  /** Default: ~/Documents/projects/apprentice/canary-routing.json */
+  canaryRoutingConfigPath?: string;
+
+  /** Default: 'ollama' (resolved via PATH). */
+  ollamaBinaryPath?: string;
+  /** Default: undefined (respects user's OLLAMA_HOST env var). */
+  ollamaHost?: string;
+
+  /** Default: (b) => `${b}-production`. */
+  productionModelName?: (baseShortName: string) => string;
+  /** Default: (b, s7) => `${b}-canary-${s7}`. */
+  canaryModelName?: (baseShortName: string, sha7: string) => string;
+  /** Default: (b, s7) => `${b}-shadow-${s7}`. */
+  shadowModelName?: (baseShortName: string, sha7: string) => string;
+
+  /** Default: 10 — older archived entries are GC'd from registry. */
+  maxArchivedToKeep?: number;
+
+  // Test seams
+  ollamaClient?: OllamaClient;
+  fs?: FsAccess;
+  clock?: () => Date;
+  /** Used to derive the subprocess timeout for ollama operations. */
+  ollamaTimeoutMs?: number;
+}
+
+/** Fully-resolved config (defaults filled in). */
+export type ResolvedServingConfig = Required<
+  Omit<ApprenticeServingConfig, 'ollamaClient' | 'ollamaHost'>
+> & {
+  ollamaClient?: OllamaClient;
+  ollamaHost?: string;
+};
+
+export interface AdapterRegistryConfig {
+  registryPath?: string;
+  fs?: FsAccess;
+  clock?: () => Date;
+}
+
+export type ResolvedAdapterRegistryConfig = Required<AdapterRegistryConfig>;
+
+export interface CanaryRouterConfig {
+  canaryRoutingConfigPath?: string;
+  fs?: FsAccess;
+  clock?: () => Date;
+}
+
+export type ResolvedCanaryRouterConfig = Required<CanaryRouterConfig>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Routing decision (what CanaryRouter.resolve() returns)
+// ──────────────────────────────────────────────────────────────────────────
+
+export type RoutingDecision =
+  | { kind: 'no-production'; production: null; canary: null }
+  | {
+      kind: 'production-only';
+      production: CanaryRoutingProductionEntry;
+      canary: null;
+    }
+  | {
+      kind: 'production-with-canary';
+      production: CanaryRoutingProductionEntry;
+      canary: CanaryRoutingCanaryEntry;
+    };
+
+// ──────────────────────────────────────────────────────────────────────────
+// Errors
+// ──────────────────────────────────────────────────────────────────────────
+
+export class ServingError extends Error {
+  public override readonly name: string;
+  constructor(name: string, message: string, public readonly details?: Record<string, unknown>) {
+    super(message);
+    this.name = name;
+  }
+}
+
+export class AdapterNotFoundError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('AdapterNotFoundError', message, details);
+  }
+}
+
+export class MetadataMalformedError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('MetadataMalformedError', message, details);
+  }
+}
+
+export class RegistryInvariantError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('RegistryInvariantError', message, details);
+  }
+}
+
+export class RegistryStateMismatchError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('RegistryStateMismatchError', message, details);
+  }
+}
+
+export class RegistryCorruptError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('RegistryCorruptError', message, details);
+  }
+}
+
+export class OllamaNotInstalledError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('OllamaNotInstalledError', message, details);
+  }
+}
+
+export class OllamaCreateError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('OllamaCreateError', message, details);
+  }
+}
+
+export class OllamaRemoveError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('OllamaRemoveError', message, details);
+  }
+}
+
+export class OllamaInspectError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('OllamaInspectError', message, details);
+  }
+}
+
+export class RollbackTargetInvalidError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('RollbackTargetInvalidError', message, details);
+  }
+}
+
+export class CanaryPercentOutOfRangeError extends ServingError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('CanaryPercentOutOfRangeError', message, details);
+  }
+}

--- a/packages/apprentice-serving/tests/adapter-registry.test.ts
+++ b/packages/apprentice-serving/tests/adapter-registry.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest';
+import { AdapterRegistry } from '../src/adapter-registry.js';
+import {
+  CanaryPercentOutOfRangeError,
+  RegistryCorruptError,
+  RegistryInvariantError,
+  RegistryStateMismatchError,
+  RollbackTargetInvalidError
+} from '../src/types.js';
+import type { RegistryEntry } from '../src/types.js';
+import { createFakeClock, createInMemoryFs } from './helpers/fakes.js';
+
+function makeEntry(overrides: Partial<RegistryEntry> = {}): RegistryEntry {
+  const base: RegistryEntry = {
+    adapterName: '2026-05-06-qwen',
+    adapterPath: '/tmp/adapters/2026-05-06-qwen',
+    metadataSha256: 'a'.repeat(64),
+    configSha256: 'cfg-sha',
+    baseModel: 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+    baseModelOllamaTag: 'qwen2.5-coder:7b',
+    status: 'registered',
+    history: [
+      { at: '2026-05-06T12:00:00.000Z', fromStatus: null, toStatus: 'registered' }
+    ],
+    registeredAt: '2026-05-06T12:00:00.000Z'
+  };
+  return { ...base, ...overrides };
+}
+
+describe('AdapterRegistry — persistence', () => {
+  it('returns empty list when registry file is absent', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/registry.json', fs, clock: createFakeClock() });
+    expect(r.list()).toEqual([]);
+    expect(r.currentProduction()).toBeUndefined();
+    expect(r.currentCanary()).toBeUndefined();
+  });
+
+  it('persists upserts atomically (tmp + rename)', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    r.upsert(makeEntry());
+    const dump = fs.dump();
+    expect(dump['/tmp/r.json']).toBeDefined();
+    expect(JSON.parse(dump['/tmp/r.json']!).entries).toHaveLength(1);
+  });
+
+  it('upsert is idempotent on adapterName', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    r.upsert(makeEntry());
+    r.upsert(makeEntry({ adapterPath: '/different/path' }));
+    expect(r.list()).toHaveLength(1);
+    expect(r.list()[0]!.adapterPath).toBe('/different/path');
+  });
+
+  it('keeps a .bak file on second write', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    r.upsert(makeEntry({ adapterName: 'first' }));
+    r.upsert(makeEntry({ adapterName: 'second' }));
+    expect(fs.exists('/tmp/r.json.bak')).toBe(true);
+  });
+
+  it('throws RegistryCorruptError on malformed JSON', () => {
+    const fs = createInMemoryFs();
+    fs.put('/tmp/r.json', '{ broken');
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    expect(() => r.list()).toThrow(RegistryCorruptError);
+  });
+
+  it('treats empty file as empty registry', () => {
+    const fs = createInMemoryFs();
+    fs.put('/tmp/r.json', '');
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    expect(r.list()).toEqual([]);
+  });
+});
+
+describe('AdapterRegistry — invariants', () => {
+  it('rejects duplicate adapterName', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    expect(() =>
+      r.assertInvariants([makeEntry({ adapterName: 'a' }), makeEntry({ adapterName: 'a' })])
+    ).toThrow(RegistryInvariantError);
+  });
+
+  it('rejects two production entries', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() =>
+      r.assertInvariants([
+        makeEntry({ adapterName: 'a', status: 'production', ollamaModelName: 'a' }),
+        makeEntry({ adapterName: 'b', status: 'production', ollamaModelName: 'b' })
+      ])
+    ).toThrow(RegistryInvariantError);
+  });
+
+  it('rejects two canary entries', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() =>
+      r.assertInvariants([
+        makeEntry({ adapterName: 'a', status: 'canary', canaryPercent: 10 }),
+        makeEntry({ adapterName: 'b', status: 'canary', canaryPercent: 5 })
+      ])
+    ).toThrow(RegistryInvariantError);
+  });
+
+  it('rejects archived without archivedAt', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() => r.assertInvariants([makeEntry({ status: 'archived' })])).toThrow(
+      RegistryInvariantError
+    );
+  });
+
+  it('rejects archivedAt on non-archived entry', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() =>
+      r.assertInvariants([
+        makeEntry({ status: 'production', archivedAt: '2026-05-06T00:00:00.000Z', ollamaModelName: 'x' })
+      ])
+    ).toThrow(RegistryInvariantError);
+  });
+
+  it('rejects canary without canaryPercent', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() => r.assertInvariants([makeEntry({ status: 'canary' })])).toThrow(
+      RegistryInvariantError
+    );
+  });
+
+  it('rejects rejected without rejectionReason', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() => r.assertInvariants([makeEntry({ status: 'rejected' })])).toThrow(
+      RegistryInvariantError
+    );
+  });
+});
+
+describe('AdapterRegistry — transitions', () => {
+  it('transition() updates status + appends history', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    r.upsert(makeEntry());
+    const updated = r.transition('2026-05-06-qwen', 'canary', (e) => {
+      e.canaryPercent = 10;
+      e.ollamaModelName = 'm-canary';
+    });
+    expect(updated.status).toBe('canary');
+    expect(updated.canaryPercent).toBe(10);
+    expect(updated.history).toHaveLength(2);
+    expect(updated.history[1]!.fromStatus).toBe('registered');
+    expect(updated.history[1]!.toStatus).toBe('canary');
+  });
+
+  it('transition() throws RegistryStateMismatchError for unknown adapter', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(() => r.transition('nonexistent', 'production', () => {})).toThrow(
+      RegistryStateMismatchError
+    );
+  });
+
+  it('clears canaryPercent when leaving canary state', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    r.upsert(makeEntry({ status: 'canary', canaryPercent: 10, ollamaModelName: 'c' }));
+    const updated = r.transition('2026-05-06-qwen', 'production', (e) => {
+      e.ollamaModelName = 'p';
+    });
+    expect(updated.canaryPercent).toBeUndefined();
+    expect(updated.status).toBe('production');
+  });
+});
+
+describe('AdapterRegistry — static guards', () => {
+  it('assertValidTransition allows registered → canary', () => {
+    expect(() => AdapterRegistry.assertValidTransition('registered', 'canary')).not.toThrow();
+  });
+
+  it('assertValidTransition rejects production → registered', () => {
+    expect(() => AdapterRegistry.assertValidTransition('production', 'registered')).toThrow(
+      RegistryStateMismatchError
+    );
+  });
+
+  it('assertValidTransition allows archived → production (rollback)', () => {
+    expect(() => AdapterRegistry.assertValidTransition('archived', 'production')).not.toThrow();
+  });
+
+  it('assertValidTransition rejects rejected → anything', () => {
+    expect(() => AdapterRegistry.assertValidTransition('rejected', 'production')).toThrow(
+      RegistryStateMismatchError
+    );
+    expect(() => AdapterRegistry.assertValidTransition('rejected', 'canary')).toThrow(
+      RegistryStateMismatchError
+    );
+  });
+
+  it('assertRollbackTarget requires archived', () => {
+    expect(() => AdapterRegistry.assertRollbackTarget(makeEntry({ status: 'production', ollamaModelName: 'x' }))).toThrow(
+      RollbackTargetInvalidError
+    );
+    expect(() =>
+      AdapterRegistry.assertRollbackTarget(
+        makeEntry({ status: 'archived', archivedAt: '2026-05-06T00:00:00.000Z' })
+      )
+    ).not.toThrow();
+  });
+
+  it('assertCanaryPercent rejects out-of-range values', () => {
+    expect(() => AdapterRegistry.assertCanaryPercent(-1)).toThrow(CanaryPercentOutOfRangeError);
+    expect(() => AdapterRegistry.assertCanaryPercent(101)).toThrow(CanaryPercentOutOfRangeError);
+    expect(() => AdapterRegistry.assertCanaryPercent(NaN)).toThrow(CanaryPercentOutOfRangeError);
+    expect(() => AdapterRegistry.assertCanaryPercent(0)).not.toThrow();
+    expect(() => AdapterRegistry.assertCanaryPercent(100)).not.toThrow();
+    expect(() => AdapterRegistry.assertCanaryPercent(50)).not.toThrow();
+  });
+});
+
+describe('AdapterRegistry — drop', () => {
+  it('removes an entry by name', () => {
+    const fs = createInMemoryFs();
+    const r = new AdapterRegistry({ registryPath: '/tmp/r.json', fs, clock: createFakeClock() });
+    r.upsert(makeEntry({ adapterName: 'a' }));
+    r.upsert(makeEntry({ adapterName: 'b' }));
+    expect(r.list()).toHaveLength(2);
+    const removed = r.drop('a');
+    expect(removed?.adapterName).toBe('a');
+    expect(r.list()).toHaveLength(1);
+    expect(r.list()[0]!.adapterName).toBe('b');
+  });
+
+  it('returns undefined for unknown name', () => {
+    const r = new AdapterRegistry({
+      registryPath: '/tmp/r.json',
+      fs: createInMemoryFs(),
+      clock: createFakeClock()
+    });
+    expect(r.drop('nonexistent')).toBeUndefined();
+  });
+});

--- a/packages/apprentice-serving/tests/canary-router.test.ts
+++ b/packages/apprentice-serving/tests/canary-router.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { CanaryRouter, canaryBucket, writeCanaryRouting } from '../src/canary-router.js';
+import { createFakeClock, createInMemoryFs } from './helpers/fakes.js';
+
+describe('CanaryRouter — read/write', () => {
+  it('returns no-production when config file is absent', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    expect(r.resolve().kind).toBe('no-production');
+    expect(r.routeRequest('any')).toBeNull();
+  });
+
+  it('writes + reads back production-only config', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'qwen-prod', adapterName: 'a1' },
+      canary: null
+    });
+    const decision = r.resolve();
+    expect(decision.kind).toBe('production-only');
+    if (decision.kind === 'production-only') {
+      expect(decision.production.ollamaModelName).toBe('qwen-prod');
+    }
+    expect(r.routeRequest('any')).toBe('qwen-prod');
+  });
+
+  it('writes + reads back production-with-canary config', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'qwen-prod', adapterName: 'a1' },
+      canary: { ollamaModelName: 'qwen-canary-abc', adapterName: 'a2', percent: 10 }
+    });
+    const decision = r.resolve();
+    expect(decision.kind).toBe('production-with-canary');
+  });
+
+  it('clears canary back to null on subsequent write', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'qwen-prod', adapterName: 'a1' },
+      canary: { ollamaModelName: 'c', adapterName: 'a2', percent: 10 }
+    });
+    r.write({
+      production: { ollamaModelName: 'qwen-prod', adapterName: 'a1' },
+      canary: null
+    });
+    expect(r.resolve().kind).toBe('production-only');
+  });
+});
+
+describe('CanaryRouter — deterministic routing', () => {
+  it('same requestId always routes to the same model', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'prod', adapterName: 'a1' },
+      canary: { ollamaModelName: 'canary', adapterName: 'a2', percent: 50 }
+    });
+    const a = r.routeRequest('request-id-42');
+    const b = r.routeRequest('request-id-42');
+    expect(a).toBe(b);
+  });
+
+  it('percent=0 routes everything to production', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'prod', adapterName: 'a1' },
+      canary: { ollamaModelName: 'canary', adapterName: 'a2', percent: 0 }
+    });
+    for (let i = 0; i < 100; i++) {
+      expect(r.routeRequest(`req-${i}`)).toBe('prod');
+    }
+  });
+
+  it('percent=100 routes everything to canary', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'prod', adapterName: 'a1' },
+      canary: { ollamaModelName: 'canary', adapterName: 'a2', percent: 100 }
+    });
+    for (let i = 0; i < 100; i++) {
+      expect(r.routeRequest(`req-${i}`)).toBe('canary');
+    }
+  });
+
+  it('percent=10 routes ~10% to canary across many requests', () => {
+    const fs = createInMemoryFs();
+    const r = new CanaryRouter({ canaryRoutingConfigPath: '/tmp/canary.json', fs, clock: createFakeClock() });
+    r.write({
+      production: { ollamaModelName: 'prod', adapterName: 'a1' },
+      canary: { ollamaModelName: 'canary', adapterName: 'a2', percent: 10 }
+    });
+    let canaryHits = 0;
+    const N = 1000;
+    for (let i = 0; i < N; i++) {
+      if (r.routeRequest(`req-${i}`) === 'canary') canaryHits++;
+    }
+    // canaryBucket is uniform sha256 mod 100; expect ~10% with reasonable variance.
+    expect(canaryHits).toBeGreaterThan(60);
+    expect(canaryHits).toBeLessThan(140);
+  });
+});
+
+describe('canaryBucket', () => {
+  it('returns a value in [0, 99]', () => {
+    for (let i = 0; i < 50; i++) {
+      const b = canaryBucket(`req-${i}`);
+      expect(b).toBeGreaterThanOrEqual(0);
+      expect(b).toBeLessThan(100);
+    }
+  });
+
+  it('is deterministic over identical input', () => {
+    expect(canaryBucket('foo')).toBe(canaryBucket('foo'));
+  });
+});
+
+describe('writeCanaryRouting helper', () => {
+  it('writes via tmp + rename', () => {
+    const fs = createInMemoryFs();
+    writeCanaryRouting(
+      fs,
+      '/tmp/c.json',
+      {
+        production: { ollamaModelName: 'p', adapterName: 'a' },
+        canary: null
+      },
+      '2026-05-06T00:00:00.000Z'
+    );
+    expect(fs.exists('/tmp/c.json')).toBe(true);
+    const parsed = JSON.parse(fs.readFile('/tmp/c.json'));
+    expect(parsed.production.ollamaModelName).toBe('p');
+    expect(parsed.canary).toBeNull();
+  });
+});

--- a/packages/apprentice-serving/tests/helpers/fakes.ts
+++ b/packages/apprentice-serving/tests/helpers/fakes.ts
@@ -1,0 +1,272 @@
+/**
+ * Test fakes — in-memory FsAccess + scriptable OllamaClient + adapter
+ * directory fixture builders. Any test that touches disk or Ollama should
+ * inject these.
+ */
+
+import * as path from 'node:path';
+import type {
+  FsAccess,
+  OllamaClient,
+  OllamaCreateArgs,
+  TrainingMetadataRead
+} from '../../src/types.js';
+
+// ──────────────────────────────────────────────────────────────────────────
+// In-memory FsAccess
+// ──────────────────────────────────────────────────────────────────────────
+
+interface InMemoryFile {
+  content: string;
+  mtimeMs: number;
+}
+
+export interface InMemoryFs extends FsAccess {
+  /** Force a file write outside of the FsAccess interface (for fixture
+   *  setup). Creates parent dirs. */
+  put(p: string, content: string, mtimeMs?: number): void;
+  /** Mark a path as a directory (no contents). */
+  putDir(p: string): void;
+  dump(): Record<string, string>;
+}
+
+export function createInMemoryFs(): InMemoryFs {
+  const files = new Map<string, InMemoryFile>();
+  const dirs = new Set<string>();
+  let mtimeCursor = 1_700_000_000_000;
+
+  function ensureParentDirs(p: string): void {
+    let cur = path.dirname(p);
+    while (cur && cur !== '/' && cur !== '.' && !dirs.has(cur)) {
+      dirs.add(cur);
+      const parent = path.dirname(cur);
+      if (parent === cur) break;
+      cur = parent;
+    }
+  }
+
+  return {
+    exists(p: string): boolean {
+      return files.has(p) || dirs.has(p);
+    },
+    readFile(p: string): string {
+      const f = files.get(p);
+      if (f === undefined) throw new Error(`ENOENT: ${p}`);
+      return f.content;
+    },
+    writeFile(p: string, content: string): void {
+      ensureParentDirs(p);
+      mtimeCursor += 1;
+      files.set(p, { content, mtimeMs: mtimeCursor });
+    },
+    mkdir(p: string): void {
+      dirs.add(p);
+      ensureParentDirs(p);
+    },
+    rename(oldP: string, newP: string): void {
+      const f = files.get(oldP);
+      if (f === undefined) throw new Error(`ENOENT: ${oldP}`);
+      ensureParentDirs(newP);
+      mtimeCursor += 1;
+      files.set(newP, { content: f.content, mtimeMs: mtimeCursor });
+      files.delete(oldP);
+    },
+    unlink(p: string): void {
+      if (!files.has(p)) throw new Error(`ENOENT: ${p}`);
+      files.delete(p);
+    },
+    readDir(p: string): string[] {
+      const prefix = p.endsWith('/') ? p : p + '/';
+      const direct = new Set<string>();
+      for (const filePath of files.keys()) {
+        if (filePath.startsWith(prefix)) {
+          const rest = filePath.slice(prefix.length);
+          const next = rest.split('/')[0]!;
+          direct.add(next);
+        }
+      }
+      for (const dirPath of dirs) {
+        if (dirPath.startsWith(prefix)) {
+          const rest = dirPath.slice(prefix.length);
+          const next = rest.split('/')[0]!;
+          if (next.length > 0) direct.add(next);
+        }
+      }
+      return Array.from(direct);
+    },
+    stat(p: string): { mtimeMs: number; size: number; isFile: boolean; isDirectory: boolean } {
+      const f = files.get(p);
+      if (f !== undefined) {
+        return { mtimeMs: f.mtimeMs, size: f.content.length, isFile: true, isDirectory: false };
+      }
+      if (dirs.has(p)) {
+        return { mtimeMs: 0, size: 0, isFile: false, isDirectory: true };
+      }
+      throw new Error(`ENOENT: ${p}`);
+    },
+    put(p: string, content: string, mtimeMs?: number): void {
+      ensureParentDirs(p);
+      mtimeCursor += 1;
+      files.set(p, { content, mtimeMs: mtimeMs ?? mtimeCursor });
+    },
+    putDir(p: string): void {
+      dirs.add(p);
+      ensureParentDirs(p);
+    },
+    dump(): Record<string, string> {
+      const out: Record<string, string> = {};
+      for (const [k, v] of files.entries()) out[k] = v.content;
+      return out;
+    }
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fake OllamaClient
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FakeOllamaCall {
+  op: 'version' | 'list' | 'create' | 'remove' | 'show';
+  args?: Record<string, unknown>;
+  result?: unknown;
+}
+
+export interface FakeOllamaClient extends OllamaClient {
+  /** All calls in order. */
+  calls: FakeOllamaCall[];
+  /** Models that are currently "loaded". */
+  models: Set<string>;
+  /** Make the next `create` call throw the given error. */
+  failNextCreate?: Error;
+  /** Make the next `remove` call throw the given error. */
+  failNextRemove?: Error;
+  reset(): void;
+}
+
+export function createFakeOllamaClient(initial?: { models?: string[] }): FakeOllamaClient {
+  const calls: FakeOllamaCall[] = [];
+  const models = new Set<string>(initial?.models ?? []);
+  const client = {
+    calls,
+    models,
+    async version(): Promise<string> {
+      calls.push({ op: 'version', result: '0.23.1' });
+      return 'ollama version is 0.23.1';
+    },
+    async list(): Promise<string[]> {
+      const out = Array.from(models);
+      calls.push({ op: 'list', result: out });
+      return out;
+    },
+    async create(args: OllamaCreateArgs): Promise<void> {
+      if (client.failNextCreate) {
+        const err = client.failNextCreate;
+        client.failNextCreate = undefined;
+        calls.push({ op: 'create', args: { ...args }, result: 'error' });
+        throw err;
+      }
+      models.add(args.modelName);
+      calls.push({ op: 'create', args: { ...args }, result: 'ok' });
+    },
+    async remove(modelName: string): Promise<void> {
+      if (client.failNextRemove) {
+        const err = client.failNextRemove;
+        client.failNextRemove = undefined;
+        calls.push({ op: 'remove', args: { modelName }, result: 'error' });
+        throw err;
+      }
+      models.delete(modelName);
+      calls.push({ op: 'remove', args: { modelName }, result: 'ok' });
+    },
+    async show(modelName: string): Promise<string> {
+      calls.push({ op: 'show', args: { modelName } });
+      return `FROM stub\nADAPTER ./adapters.safetensors\n`;
+    },
+    failNextCreate: undefined as Error | undefined,
+    failNextRemove: undefined as Error | undefined,
+    reset(): void {
+      calls.length = 0;
+      models.clear();
+      client.failNextCreate = undefined;
+      client.failNextRemove = undefined;
+    }
+  };
+  return client;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Adapter directory fixtures
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FixtureAdapterOptions {
+  adapterPath: string;
+  baseModel?: string;
+  baseModelOllamaTag?: string;
+  configSha256?: string;
+  /** When provided, includes an eval-report.json. */
+  evalReport?: {
+    winRate: number;
+    decision: string;
+    regressionFlags?: string[];
+    name?: string;
+  };
+  /** Custom fields to merge into training-metadata.json. */
+  metadataExtras?: Partial<TrainingMetadataRead>;
+}
+
+export function fixtureAdapter(fs: InMemoryFs, opts: FixtureAdapterOptions): {
+  metadata: TrainingMetadataRead;
+  modelfile: string;
+} {
+  fs.putDir(opts.adapterPath);
+  const metadata: TrainingMetadataRead = {
+    version: 1,
+    generatedAt: '2026-05-06T00:00:00.000Z',
+    baseModel: opts.baseModel ?? 'mlx-community/Qwen2.5-Coder-7B-Instruct-4bit',
+    baseModelOllamaTag: opts.baseModelOllamaTag ?? 'qwen2.5-coder:7b',
+    configSha256: opts.configSha256 ?? 'abc123def456',
+    loraConfig: { numLayers: 16, rank: 8 },
+    corpusTotals: { samplesUsed: 100 },
+    subprocess: { exitCode: 0 },
+    warnings: [],
+    ...opts.metadataExtras
+  };
+  fs.put(path.join(opts.adapterPath, 'training-metadata.json'), JSON.stringify(metadata, null, 2));
+  const modelfile = `FROM ${metadata.baseModelOllamaTag}\nADAPTER ./adapters.safetensors\nPARAMETER temperature 0.2\nPARAMETER top_p 0.9\n`;
+  fs.put(path.join(opts.adapterPath, 'Modelfile'), modelfile);
+  fs.put(path.join(opts.adapterPath, 'adapters.safetensors'), 'STUB-SAFETENSORS-CONTENT');
+  fs.put(
+    path.join(opts.adapterPath, 'adapter_config.json'),
+    JSON.stringify({ rank: 8, alpha: 16 }, null, 2)
+  );
+  if (opts.evalReport) {
+    fs.put(
+      path.join(opts.adapterPath, 'eval-report.json'),
+      JSON.stringify(
+        {
+          adapters: [
+            {
+              name: opts.evalReport.name ?? path.basename(opts.adapterPath),
+              winRate: opts.evalReport.winRate,
+              decision: opts.evalReport.decision,
+              regressionFlags: opts.evalReport.regressionFlags ?? []
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+  }
+  return { metadata, modelfile };
+}
+
+/** A clock that ticks deterministically — every call returns the next ms. */
+export function createFakeClock(start = '2026-05-06T12:00:00.000Z'): () => Date {
+  let cursor = new Date(start).getTime();
+  return () => {
+    const d = new Date(cursor);
+    cursor += 1;
+    return d;
+  };
+}

--- a/packages/apprentice-serving/tests/metadata-reader.test.ts
+++ b/packages/apprentice-serving/tests/metadata-reader.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { readAdapterArtifacts, extractEvalSummary } from '../src/metadata-reader.js';
+import { AdapterNotFoundError, MetadataMalformedError } from '../src/types.js';
+import { createInMemoryFs, fixtureAdapter } from './helpers/fakes.js';
+
+describe('readAdapterArtifacts', () => {
+  it('reads a complete adapter directory', () => {
+    const fs = createInMemoryFs();
+    fixtureAdapter(fs, { adapterPath: '/tmp/adapters/2026-05-06-test' });
+    const out = readAdapterArtifacts(fs, '/tmp/adapters/2026-05-06-test');
+    expect(out.metadata.baseModel).toBe('mlx-community/Qwen2.5-Coder-7B-Instruct-4bit');
+    expect(out.metadata.baseModelOllamaTag).toBe('qwen2.5-coder:7b');
+    expect(out.metadataSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(out.modelfilePath).toBe('/tmp/adapters/2026-05-06-test/Modelfile');
+    expect(out.adapterFile).toBe('/tmp/adapters/2026-05-06-test/adapters.safetensors');
+  });
+
+  it('throws AdapterNotFoundError when adapterPath does not exist', () => {
+    const fs = createInMemoryFs();
+    expect(() => readAdapterArtifacts(fs, '/nonexistent')).toThrow(AdapterNotFoundError);
+  });
+
+  it('throws AdapterNotFoundError when a mandatory file is missing', () => {
+    const fs = createInMemoryFs();
+    fs.putDir('/tmp/incomplete');
+    fs.put('/tmp/incomplete/Modelfile', 'FROM x\n');
+    expect(() => readAdapterArtifacts(fs, '/tmp/incomplete')).toThrow(AdapterNotFoundError);
+  });
+
+  it('throws MetadataMalformedError on malformed JSON', () => {
+    const fs = createInMemoryFs();
+    fixtureAdapter(fs, { adapterPath: '/tmp/bad' });
+    fs.put('/tmp/bad/training-metadata.json', '{ not json');
+    expect(() => readAdapterArtifacts(fs, '/tmp/bad')).toThrow(MetadataMalformedError);
+  });
+
+  it('throws MetadataMalformedError when required fields missing', () => {
+    const fs = createInMemoryFs();
+    fixtureAdapter(fs, { adapterPath: '/tmp/missing' });
+    fs.put(
+      '/tmp/missing/training-metadata.json',
+      JSON.stringify({ version: 1, generatedAt: 'x' })
+    );
+    expect(() => readAdapterArtifacts(fs, '/tmp/missing')).toThrow(MetadataMalformedError);
+  });
+
+  it('produces deterministic metadataSha256 over identical content', () => {
+    const fs1 = createInMemoryFs();
+    const fs2 = createInMemoryFs();
+    fixtureAdapter(fs1, {
+      adapterPath: '/tmp/a',
+      configSha256: 'fixed',
+      metadataExtras: { generatedAt: '2026-05-06T00:00:00.000Z' }
+    });
+    fixtureAdapter(fs2, {
+      adapterPath: '/tmp/b',
+      configSha256: 'fixed',
+      metadataExtras: { generatedAt: '2026-05-06T00:00:00.000Z' }
+    });
+    const a = readAdapterArtifacts(fs1, '/tmp/a').metadataSha256;
+    const b = readAdapterArtifacts(fs2, '/tmp/b').metadataSha256;
+    expect(a).toBe(b);
+  });
+
+  it('attaches evalReport when eval-report.json present', () => {
+    const fs = createInMemoryFs();
+    fixtureAdapter(fs, {
+      adapterPath: '/tmp/with-eval',
+      evalReport: { winRate: 0.7, decision: 'promote-canary', regressionFlags: [] }
+    });
+    const out = readAdapterArtifacts(fs, '/tmp/with-eval');
+    expect(out.evalReport).toBeDefined();
+    expect(out.evalReport!.winRate).toBe(0.7);
+    expect(out.evalReport!.decision).toBe('promote-canary');
+  });
+
+  it('tolerates missing eval-report.json', () => {
+    const fs = createInMemoryFs();
+    fixtureAdapter(fs, { adapterPath: '/tmp/no-eval' });
+    const out = readAdapterArtifacts(fs, '/tmp/no-eval');
+    expect(out.evalReport).toBeUndefined();
+  });
+
+  it('tolerates malformed eval-report.json (treats as absent)', () => {
+    const fs = createInMemoryFs();
+    fixtureAdapter(fs, { adapterPath: '/tmp/bad-eval' });
+    fs.put('/tmp/bad-eval/eval-report.json', 'not-json');
+    const out = readAdapterArtifacts(fs, '/tmp/bad-eval');
+    expect(out.evalReport).toBeUndefined();
+  });
+});
+
+describe('extractEvalSummary', () => {
+  it('returns the first adapter entry verbatim', () => {
+    const summary = extractEvalSummary({
+      adapters: [
+        { name: 'x', winRate: 0.65, decision: 'promote-canary', regressionFlags: ['f1'] }
+      ]
+    });
+    expect(summary).toEqual({ winRate: 0.65, decision: 'promote-canary', regressionFlags: ['f1'] });
+  });
+
+  it('returns undefined for empty / missing adapters array', () => {
+    expect(extractEvalSummary({})).toBeUndefined();
+    expect(extractEvalSummary({ adapters: [] })).toBeUndefined();
+  });
+
+  it('returns undefined when winRate is non-numeric', () => {
+    expect(
+      extractEvalSummary({
+        adapters: [{ name: 'x', decision: 'promote-canary' }]
+      })
+    ).toBeUndefined();
+  });
+
+  it('defaults regressionFlags to empty array', () => {
+    const summary = extractEvalSummary({
+      adapters: [{ winRate: 0.5, decision: 'baseline' }]
+    });
+    expect(summary).toBeDefined();
+    expect(summary!.regressionFlags).toEqual([]);
+  });
+});

--- a/packages/apprentice-serving/tests/ollama-client.test.ts
+++ b/packages/apprentice-serving/tests/ollama-client.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DefaultSubprocessExecutor,
+  parseListOutput,
+  SubprocessOllamaClient
+} from '../src/ollama-client.js';
+import {
+  OllamaCreateError,
+  OllamaInspectError,
+  OllamaNotInstalledError,
+  OllamaRemoveError
+} from '../src/types.js';
+import type { SubprocessExecutor, SubprocessExecutorArgs, SubprocessExecutorResult } from '../src/ollama-client.js';
+
+type ScriptedReply = SubprocessExecutorResult;
+
+class ScriptedExecutor implements SubprocessExecutor {
+  public calls: SubprocessExecutorArgs[] = [];
+  constructor(private readonly replies: ScriptedReply[]) {}
+  async run(args: SubprocessExecutorArgs): Promise<SubprocessExecutorResult> {
+    this.calls.push(args);
+    const next = this.replies.shift();
+    if (next === undefined) {
+      throw new Error('ScriptedExecutor: replies exhausted');
+    }
+    return next;
+  }
+}
+
+function ok(stdout = ''): ScriptedReply {
+  return { exitCode: 0, signal: null, stdout, stderr: '', timedOut: false, elapsedMs: 1 };
+}
+function fail(stderr: string, exitCode = 1): ScriptedReply {
+  return { exitCode, signal: null, stdout: '', stderr, timedOut: false, elapsedMs: 1 };
+}
+
+describe('SubprocessOllamaClient — version', () => {
+  it('returns trimmed stdout on success', async () => {
+    const exec = new ScriptedExecutor([ok('ollama version is 0.23.1\n')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    expect(await c.version()).toBe('ollama version is 0.23.1');
+  });
+
+  it('throws OllamaNotInstalledError on non-zero exit', async () => {
+    const exec = new ScriptedExecutor([fail('command not found', 127)]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(c.version()).rejects.toThrow(OllamaNotInstalledError);
+  });
+});
+
+describe('SubprocessOllamaClient — list', () => {
+  it('parses model list output', async () => {
+    const stdout =
+      'NAME                       ID              SIZE      MODIFIED\n' +
+      'qwen2.5-coder:7b           dae161e27b0e    4.7 GB    8 days ago\n' +
+      'phi4:latest                ac896e5b8b34    9.1 GB    7 days ago\n';
+    const exec = new ScriptedExecutor([ok(stdout)]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    const out = await c.list();
+    expect(out).toEqual(['qwen2.5-coder:7b', 'phi4:latest']);
+  });
+
+  it('throws OllamaInspectError on non-zero exit', async () => {
+    const exec = new ScriptedExecutor([fail('daemon not running')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(c.list()).rejects.toThrow(OllamaInspectError);
+  });
+});
+
+describe('SubprocessOllamaClient — create', () => {
+  it('passes correct argv + cwd', async () => {
+    const exec = new ScriptedExecutor([ok()]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: '/usr/local/bin/ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await c.create({
+      modelName: 'qwen-canary-abc',
+      modelfilePath: '/path/to/Modelfile',
+      cwd: '/path/to/adapter'
+    });
+    expect(exec.calls[0]!.command).toBe('/usr/local/bin/ollama');
+    expect(exec.calls[0]!.args).toEqual(['create', 'qwen-canary-abc', '-f', '/path/to/Modelfile']);
+    expect(exec.calls[0]!.cwd).toBe('/path/to/adapter');
+  });
+
+  it('throws OllamaCreateError on non-zero exit', async () => {
+    const exec = new ScriptedExecutor([fail('invalid Modelfile')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(
+      c.create({ modelName: 'x', modelfilePath: '/x', cwd: '/' })
+    ).rejects.toThrow(OllamaCreateError);
+  });
+});
+
+describe('SubprocessOllamaClient — remove', () => {
+  it('treats success as success', async () => {
+    const exec = new ScriptedExecutor([ok()]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(c.remove('foo')).resolves.toBeUndefined();
+  });
+
+  it('treats "not found" stderr as success', async () => {
+    const exec = new ScriptedExecutor([fail('Error: model "foo" not found')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(c.remove('foo')).resolves.toBeUndefined();
+  });
+
+  it('throws OllamaRemoveError on other non-zero exit', async () => {
+    const exec = new ScriptedExecutor([fail('disk full')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(c.remove('foo')).rejects.toThrow(OllamaRemoveError);
+  });
+});
+
+describe('SubprocessOllamaClient — show', () => {
+  it('returns stdout', async () => {
+    const exec = new ScriptedExecutor([ok('FROM qwen2.5-coder:7b\nADAPTER ./adapters.safetensors\n')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    const out = await c.show('foo');
+    expect(out).toContain('FROM qwen2.5-coder:7b');
+  });
+
+  it('throws OllamaInspectError on failure', async () => {
+    const exec = new ScriptedExecutor([fail('not found')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await expect(c.show('foo')).rejects.toThrow(OllamaInspectError);
+  });
+});
+
+describe('SubprocessOllamaClient — env', () => {
+  it('clears ANTHROPIC_API_KEY from subprocess env', async () => {
+    const exec = new ScriptedExecutor([ok('ollama version is 0.23.1\n')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    const before = process.env['ANTHROPIC_API_KEY'];
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-fake';
+    try {
+      await c.version();
+      expect(exec.calls[0]!.env['ANTHROPIC_API_KEY']).toBeUndefined();
+    } finally {
+      if (before === undefined) delete process.env['ANTHROPIC_API_KEY'];
+      else process.env['ANTHROPIC_API_KEY'] = before;
+    }
+  });
+
+  it('honours ollamaHost when provided', async () => {
+    const exec = new ScriptedExecutor([ok('ollama version is 0.23.1\n')]);
+    const c = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      ollamaHost: 'http://localhost:9999',
+      timeoutMs: 1000,
+      executor: exec
+    });
+    await c.version();
+    expect(exec.calls[0]!.env['OLLAMA_HOST']).toBe('http://localhost:9999');
+  });
+});
+
+describe('parseListOutput', () => {
+  it('skips header row', () => {
+    const stdout =
+      'NAME    ID    SIZE\n' +
+      'qwen-7b    abc    4GB\n' +
+      'phi4    def    9GB\n';
+    expect(parseListOutput(stdout)).toEqual(['qwen-7b', 'phi4']);
+  });
+
+  it('handles empty output', () => {
+    expect(parseListOutput('')).toEqual([]);
+    expect(parseListOutput('NAME ID SIZE\n')).toEqual([]);
+  });
+});
+
+describe('DefaultSubprocessExecutor sanity', () => {
+  it('exists and is constructible', () => {
+    expect(new DefaultSubprocessExecutor()).toBeInstanceOf(DefaultSubprocessExecutor);
+  });
+});

--- a/packages/apprentice-serving/tests/serving.e2e.test.ts
+++ b/packages/apprentice-serving/tests/serving.e2e.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Real-Ollama E2E test. Gated by APPRENTICE_SERVING_OLLAMA_INSTALLED=1.
+ * Skipped by default in CI; operator runs locally to verify the
+ * subprocess + filesystem + canary-routing flow against the live
+ * Ollama daemon.
+ *
+ * Strategy: build a tiny Modelfile that just FROMs a small base model
+ * already pulled by the operator (defaulting to qwen2.5-coder:7b — the
+ * canonical CAIA training base). NO adapter file is referenced — we're
+ * exercising the registry + subprocess plumbing, not adapter weights.
+ *
+ * Cleanup: the test removes any models it created on teardown.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ApprenticeServing } from '../src/serving.js';
+import { SubprocessOllamaClient } from '../src/ollama-client.js';
+
+const GATE_ENV = 'APPRENTICE_SERVING_OLLAMA_INSTALLED';
+const gated = process.env[GATE_ENV] === '1';
+const itGated = gated ? it : it.skip;
+const baseTag = process.env['APPRENTICE_SERVING_E2E_BASE_TAG'] ?? 'qwen2.5-coder:7b';
+
+const tmpRoot = path.join(os.tmpdir(), `apprentice-serving-e2e-${Date.now()}`);
+const adapterPath = path.join(tmpRoot, 'adapters', '2026-05-06-e2e');
+const registryPath = path.join(tmpRoot, 'registry.json');
+const canaryRoutingPath = path.join(tmpRoot, 'canary-routing.json');
+
+const createdModels: string[] = [];
+
+beforeAll(async () => {
+  if (!gated) return;
+  fs.mkdirSync(adapterPath, { recursive: true });
+  // Build a tiny Modelfile that doesn't actually use the adapter file —
+  // just FROM the base. This is enough to validate the create/rm path.
+  fs.writeFileSync(
+    path.join(adapterPath, 'Modelfile'),
+    `FROM ${baseTag}\nPARAMETER temperature 0.2\n`
+  );
+  fs.writeFileSync(path.join(adapterPath, 'adapters.safetensors'), 'STUB');
+  fs.writeFileSync(path.join(adapterPath, 'adapter_config.json'), '{"rank":8}');
+  fs.writeFileSync(
+    path.join(adapterPath, 'training-metadata.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        baseModel: baseTag,
+        baseModelOllamaTag: baseTag,
+        configSha256: 'e2e-' + Math.random().toString(36).slice(2, 10)
+      },
+      null,
+      2
+    )
+  );
+});
+
+afterAll(async () => {
+  if (!gated) return;
+  // Best-effort cleanup of created Ollama models.
+  const client = new SubprocessOllamaClient({
+    ollamaBinaryPath: 'ollama',
+    timeoutMs: 60_000
+  });
+  for (const m of createdModels) {
+    try {
+      await client.remove(m);
+    } catch {
+      /* ignore */
+    }
+  }
+  // Best-effort cleanup of tmp dir.
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe(`ApprenticeServing E2E (gated by ${GATE_ENV}=1)`, () => {
+  itGated('verifies ollama --version', async () => {
+    const client = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 30_000
+    });
+    const v = await client.version();
+    expect(v.length).toBeGreaterThan(0);
+  });
+
+  itGated('runs full lifecycle against live Ollama', async () => {
+    const serving = new ApprenticeServing({
+      registryPath,
+      canaryRoutingConfigPath: canaryRoutingPath,
+      ollamaTimeoutMs: 5 * 60 * 1000
+    });
+
+    // Step 1: register
+    const reg = await serving.register(adapterPath);
+    expect(reg.status).toBe('registered');
+
+    // Step 2: canary
+    const canary = await serving.promoteToCanary(adapterPath, 10);
+    expect(canary.status).toBe('canary');
+    if (canary.ollamaModelName) createdModels.push(canary.ollamaModelName);
+
+    // Step 3: production
+    const prod = await serving.promoteToProduction(adapterPath);
+    expect(prod.status).toBe('production');
+    if (prod.ollamaModelName) createdModels.push(prod.ollamaModelName);
+
+    // Step 4: verify canary-routing config
+    const decision = serving.canaryRouter.resolve();
+    expect(decision.kind).toBe('production-only');
+
+    // Step 5: list confirms model is present. Ollama auto-appends `:latest`
+    // to models created without an explicit tag, so accept either form.
+    const client = new SubprocessOllamaClient({
+      ollamaBinaryPath: 'ollama',
+      timeoutMs: 30_000
+    });
+    const models = await client.list();
+    const expected = prod.ollamaModelName!;
+    const found = models.some((m) => m === expected || m === `${expected}:latest`);
+    expect(found, `expected ${expected} (or ${expected}:latest) in ${JSON.stringify(models)}`).toBe(true);
+  }, 10 * 60 * 1000);
+});

--- a/packages/apprentice-serving/tests/serving.integration.test.ts
+++ b/packages/apprentice-serving/tests/serving.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Full lifecycle integration test against a fake Ollama. Materialises three
+ * fake adapter directories on an in-memory FS and walks them through:
+ *
+ *   register v1 → canary v1 (10%) → production v1
+ *   register v2 → canary v2 (10%) → production v2 (v1 → archived)
+ *   rollback to v1                  (v2 → archived)
+ *   register v3 → reject v3 (eval gate)
+ *
+ * Asserts:
+ *   - registry.json contents at every step
+ *   - canary-routing.json contents at every step
+ *   - FakeOllamaClient invocation log matches expected sequence
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ApprenticeServing } from '../src/serving.js';
+import {
+  createFakeClock,
+  createFakeOllamaClient,
+  createInMemoryFs,
+  fixtureAdapter
+} from './helpers/fakes.js';
+
+describe('ApprenticeServing integration — full lifecycle', () => {
+  it('walks 3 adapters through the full state machine', async () => {
+    const fs = createInMemoryFs();
+    const ollamaClient = createFakeOllamaClient();
+    const serving = new ApprenticeServing({
+      registryPath: '/data/apprentice/registry.json',
+      canaryRoutingConfigPath: '/data/apprentice/canary-routing.json',
+      ollamaBinaryPath: 'ollama',
+      ollamaClient,
+      fs,
+      clock: createFakeClock()
+    });
+
+    // --- v1 fixture ---
+    fixtureAdapter(fs, {
+      adapterPath: '/adapters/2026-05-06-qwen-rank8',
+      configSha256: 'sha-v1',
+      evalReport: { winRate: 0.65, decision: 'promote-canary' }
+    });
+
+    // --- v2 fixture ---
+    fixtureAdapter(fs, {
+      adapterPath: '/adapters/2026-05-13-qwen-rank8',
+      configSha256: 'sha-v2',
+      evalReport: { winRate: 0.72, decision: 'promote-canary' }
+    });
+
+    // --- v3 fixture (regression) ---
+    fixtureAdapter(fs, {
+      adapterPath: '/adapters/2026-05-20-qwen-rank8',
+      configSha256: 'sha-v3',
+      evalReport: { winRate: 0.45, decision: 'reject-low-winrate', regressionFlags: ['p1', 'p2'] }
+    });
+
+    // === Step 1: register v1 ===
+    const v1Reg = await serving.register('/adapters/2026-05-06-qwen-rank8');
+    expect(v1Reg.status).toBe('registered');
+    expect(v1Reg.evalReport?.winRate).toBe(0.65);
+
+    // === Step 2: canary v1 @ 10% ===
+    await serving.promoteToCanary('/adapters/2026-05-06-qwen-rank8', 10);
+    {
+      const cfg = JSON.parse(fs.readFile('/data/apprentice/canary-routing.json'));
+      expect(cfg.production).toBeNull();
+      expect(cfg.canary.percent).toBe(10);
+      expect(cfg.canary.adapterName).toBe('2026-05-06-qwen-rank8');
+    }
+
+    // === Step 3: promote v1 to production ===
+    const v1Prod = await serving.promoteToProduction('/adapters/2026-05-06-qwen-rank8');
+    expect(v1Prod.status).toBe('production');
+    expect(v1Prod.ollamaModelName).toBe('qwen2-5-coder-7b-production');
+    {
+      const cfg = JSON.parse(fs.readFile('/data/apprentice/canary-routing.json'));
+      expect(cfg.production.adapterName).toBe('2026-05-06-qwen-rank8');
+      expect(cfg.canary).toBeNull();
+    }
+    expect(ollamaClient.models.has('qwen2-5-coder-7b-production')).toBe(true);
+
+    // === Step 4: register v2 + canary v2 ===
+    await serving.register('/adapters/2026-05-13-qwen-rank8');
+    await serving.promoteToCanary('/adapters/2026-05-13-qwen-rank8', 15);
+    {
+      const cfg = JSON.parse(fs.readFile('/data/apprentice/canary-routing.json'));
+      expect(cfg.production.adapterName).toBe('2026-05-06-qwen-rank8'); // v1 still prod
+      expect(cfg.canary.adapterName).toBe('2026-05-13-qwen-rank8'); // v2 canary
+      expect(cfg.canary.percent).toBe(15);
+    }
+
+    // === Step 5: promote v2 to production (v1 → archived) ===
+    const v2Prod = await serving.promoteToProduction('/adapters/2026-05-13-qwen-rank8');
+    expect(v2Prod.status).toBe('production');
+    {
+      const cfg = JSON.parse(fs.readFile('/data/apprentice/canary-routing.json'));
+      expect(cfg.production.adapterName).toBe('2026-05-13-qwen-rank8');
+      expect(cfg.canary).toBeNull();
+    }
+    const v1After = serving.registry.getByName('2026-05-06-qwen-rank8')!;
+    expect(v1After.status).toBe('archived');
+    expect(v1After.archivedAt).toBeDefined();
+
+    // === Step 6: rollback to v1 ===
+    const v1Restored = await serving.rollback('/adapters/2026-05-06-qwen-rank8');
+    expect(v1Restored.status).toBe('production');
+    expect(v1Restored.adapterName).toBe('2026-05-06-qwen-rank8');
+    const v2After = serving.registry.getByName('2026-05-13-qwen-rank8')!;
+    expect(v2After.status).toBe('archived');
+
+    // === Step 7: register v3, reject without canary ===
+    await serving.register('/adapters/2026-05-20-qwen-rank8');
+    const v3Rej = await serving.reject(
+      '/adapters/2026-05-20-qwen-rank8',
+      'eval winRate=0.45 below gate=0.60; regressions on p1,p2'
+    );
+    expect(v3Rej.status).toBe('rejected');
+    expect(v3Rej.rejectionReason).toContain('winRate=0.45');
+
+    // === Final assertions: ===
+    const all = serving.list();
+    expect(all.find((e) => e.adapterName === '2026-05-06-qwen-rank8')!.status).toBe('production');
+    expect(all.find((e) => e.adapterName === '2026-05-13-qwen-rank8')!.status).toBe('archived');
+    expect(all.find((e) => e.adapterName === '2026-05-20-qwen-rank8')!.status).toBe('rejected');
+
+    // Ollama call sequence sanity:
+    // creates: v1-canary, v1-prod, v2-canary, v2-prod, v1-prod (rollback)
+    const creates = ollamaClient.calls.filter((c) => c.op === 'create');
+    expect(creates.length).toBe(5);
+    // production model should be currently loaded
+    expect(ollamaClient.models.has('qwen2-5-coder-7b-production')).toBe(true);
+  });
+
+  it('persists registry across instance restarts', async () => {
+    const fs = createInMemoryFs();
+    const ollamaClient1 = createFakeOllamaClient();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+
+    const s1 = new ApprenticeServing({
+      registryPath: '/data/registry.json',
+      canaryRoutingConfigPath: '/data/canary.json',
+      ollamaClient: ollamaClient1,
+      fs,
+      clock: createFakeClock()
+    });
+    await s1.promoteToCanary('/adapters/q', 10);
+    await s1.promoteToProduction('/adapters/q');
+
+    // New instance, same disk:
+    const ollamaClient2 = createFakeOllamaClient({ models: ['qwen2-5-coder-7b-production'] });
+    const s2 = new ApprenticeServing({
+      registryPath: '/data/registry.json',
+      canaryRoutingConfigPath: '/data/canary.json',
+      ollamaClient: ollamaClient2,
+      fs,
+      clock: createFakeClock()
+    });
+
+    expect(s2.list()).toHaveLength(1);
+    expect(s2.currentProduction()?.adapterName).toBe('q');
+    expect(s2.canaryRouter.resolve().kind).toBe('production-only');
+  });
+});

--- a/packages/apprentice-serving/tests/serving.test.ts
+++ b/packages/apprentice-serving/tests/serving.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import { ApprenticeServing } from '../src/serving.js';
+import {
+  AdapterNotFoundError,
+  CanaryPercentOutOfRangeError,
+  OllamaCreateError,
+  RegistryStateMismatchError,
+  RollbackTargetInvalidError
+} from '../src/types.js';
+import {
+  createFakeClock,
+  createFakeOllamaClient,
+  createInMemoryFs,
+  fixtureAdapter
+} from './helpers/fakes.js';
+
+function setup(opts: { extras?: Record<string, unknown> } = {}) {
+  void opts;
+  const fs = createInMemoryFs();
+  const ollamaClient = createFakeOllamaClient();
+  const serving = new ApprenticeServing({
+    registryPath: '/tmp/registry.json',
+    canaryRoutingConfigPath: '/tmp/canary.json',
+    ollamaBinaryPath: 'ollama',
+    ollamaClient,
+    fs,
+    clock: createFakeClock()
+  });
+  return { fs, ollamaClient, serving };
+}
+
+describe('ApprenticeServing — register', () => {
+  it('creates a registered entry with metadata sha + history', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/2026-05-06-q' });
+    const entry = await serving.register('/adapters/2026-05-06-q');
+    expect(entry.adapterName).toBe('2026-05-06-q');
+    expect(entry.status).toBe('registered');
+    expect(entry.history).toHaveLength(1);
+    expect(entry.history[0]!.fromStatus).toBeNull();
+    expect(entry.metadataSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is idempotent on re-register', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/x' });
+    const a = await serving.register('/adapters/x');
+    const b = await serving.register('/adapters/x');
+    expect(a.adapterName).toBe(b.adapterName);
+    expect(serving.list()).toHaveLength(1);
+  });
+
+  it('refreshes evalReport on re-register if eval-report.json appears later', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/y' });
+    await serving.register('/adapters/y');
+    expect(serving.list()[0]!.evalReport).toBeUndefined();
+    fs.put(
+      '/adapters/y/eval-report.json',
+      JSON.stringify({ adapters: [{ winRate: 0.7, decision: 'promote-canary' }] })
+    );
+    const updated = await serving.register('/adapters/y');
+    expect(updated.evalReport?.winRate).toBe(0.7);
+  });
+});
+
+describe('ApprenticeServing — promoteToCanary', () => {
+  it('loads model into Ollama + transitions registered → canary', async () => {
+    const { fs, ollamaClient, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/2026-05-06-q' });
+    await serving.register('/adapters/2026-05-06-q');
+    const entry = await serving.promoteToCanary('/adapters/2026-05-06-q', 10);
+    expect(entry.status).toBe('canary');
+    expect(entry.canaryPercent).toBe(10);
+    expect(entry.ollamaModelName).toMatch(/^qwen2-5-coder-7b-canary-/);
+    expect(ollamaClient.calls.some((c) => c.op === 'create')).toBe(true);
+  });
+
+  it('writes canary-routing config', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.register('/adapters/q');
+    await serving.promoteToCanary('/adapters/q', 25);
+    const written = JSON.parse(fs.readFile('/tmp/canary.json'));
+    expect(written.canary.percent).toBe(25);
+    expect(written.canary.adapterName).toBe('q');
+    expect(written.production).toBeNull();
+  });
+
+  it('rejects out-of-range percent', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.register('/adapters/q');
+    await expect(serving.promoteToCanary('/adapters/q', 150)).rejects.toThrow(CanaryPercentOutOfRangeError);
+  });
+
+  it('archives previous canary when promoting a new one', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/v1', configSha256: 'sha-v1' });
+    fixtureAdapter(fs, { adapterPath: '/adapters/v2', configSha256: 'sha-v2' });
+    await serving.register('/adapters/v1');
+    await serving.register('/adapters/v2');
+    await serving.promoteToCanary('/adapters/v1', 10);
+    await serving.promoteToCanary('/adapters/v2', 10);
+    const v1 = serving.registry.getByName('v1')!;
+    const v2 = serving.registry.getByName('v2')!;
+    expect(v1.status).toBe('archived');
+    expect(v2.status).toBe('canary');
+    expect(serving.list().filter((e) => e.status === 'canary')).toHaveLength(1);
+  });
+
+  it('auto-registers if adapter is not yet in registry', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/auto' });
+    const entry = await serving.promoteToCanary('/adapters/auto', 10);
+    expect(entry.status).toBe('canary');
+    expect(serving.list()).toHaveLength(1);
+  });
+});
+
+describe('ApprenticeServing — promoteToProduction', () => {
+  it('loads <base>-production model + archives previous production', async () => {
+    const { fs, ollamaClient, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/v1', configSha256: 'sha-v1' });
+    fixtureAdapter(fs, { adapterPath: '/adapters/v2', configSha256: 'sha-v2' });
+    await serving.register('/adapters/v1');
+    await serving.promoteToCanary('/adapters/v1', 100);
+    await serving.promoteToProduction('/adapters/v1');
+    expect(ollamaClient.models.has('qwen2-5-coder-7b-production')).toBe(true);
+    await serving.register('/adapters/v2');
+    await serving.promoteToCanary('/adapters/v2', 100);
+    await serving.promoteToProduction('/adapters/v2');
+    const v1 = serving.registry.getByName('v1')!;
+    const v2 = serving.registry.getByName('v2')!;
+    expect(v1.status).toBe('archived');
+    expect(v2.status).toBe('production');
+  });
+
+  it('writes canary-routing config with production set, canary cleared', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.promoteToCanary('/adapters/q', 100);
+    await serving.promoteToProduction('/adapters/q');
+    const written = JSON.parse(fs.readFile('/tmp/canary.json'));
+    expect(written.production.adapterName).toBe('q');
+    expect(written.canary).toBeNull();
+  });
+
+  it('throws if adapter is in registered (skipping canary not allowed)', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.register('/adapters/q');
+    await expect(serving.promoteToProduction('/adapters/q')).rejects.toThrow(RegistryStateMismatchError);
+  });
+});
+
+describe('ApprenticeServing — rollback', () => {
+  it('re-promotes an archived adapter to production', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/v1', configSha256: 's1' });
+    fixtureAdapter(fs, { adapterPath: '/adapters/v2', configSha256: 's2' });
+    await serving.promoteToCanary('/adapters/v1', 100);
+    await serving.promoteToProduction('/adapters/v1');
+    await serving.promoteToCanary('/adapters/v2', 100);
+    await serving.promoteToProduction('/adapters/v2');
+    // v1 is now archived. Rollback to v1.
+    const restored = await serving.rollback('/adapters/v1');
+    expect(restored.status).toBe('production');
+    expect(restored.adapterName).toBe('v1');
+    const v2 = serving.registry.getByName('v2')!;
+    expect(v2.status).toBe('archived');
+  });
+
+  it('throws RollbackTargetInvalidError when target is currently production', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.promoteToCanary('/adapters/q', 100);
+    await serving.promoteToProduction('/adapters/q');
+    await expect(serving.rollback('/adapters/q')).rejects.toThrow(RollbackTargetInvalidError);
+  });
+
+  it('throws AdapterNotFoundError when target not in registry', async () => {
+    const { serving } = setup();
+    await expect(serving.rollback('/nonexistent/adapter')).rejects.toThrow(AdapterNotFoundError);
+  });
+});
+
+describe('ApprenticeServing — reject', () => {
+  it('marks adapter rejected with reason', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.register('/adapters/q');
+    const e = await serving.reject('/adapters/q', 'eval win-rate too low');
+    expect(e.status).toBe('rejected');
+    expect(e.rejectionReason).toBe('eval win-rate too low');
+  });
+
+  it('removes adapter from Ollama if loaded', async () => {
+    const { fs, ollamaClient, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.promoteToCanary('/adapters/q', 10);
+    await serving.reject('/adapters/q', 'changed mind');
+    const removeCalls = ollamaClient.calls.filter((c) => c.op === 'remove');
+    expect(removeCalls.length).toBeGreaterThan(0);
+  });
+
+  it('rejects empty reason', async () => {
+    const { fs, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.register('/adapters/q');
+    await expect(serving.reject('/adapters/q', '')).rejects.toThrow(RegistryStateMismatchError);
+  });
+});
+
+describe('ApprenticeServing — failure handling', () => {
+  it('surfaces OllamaCreateError without mutating registry status', async () => {
+    const { fs, ollamaClient, serving } = setup();
+    fixtureAdapter(fs, { adapterPath: '/adapters/q' });
+    await serving.register('/adapters/q');
+    ollamaClient.failNextCreate = new OllamaCreateError('simulated failure');
+    await expect(serving.promoteToCanary('/adapters/q', 10)).rejects.toThrow(OllamaCreateError);
+    const e = serving.registry.getByName('q')!;
+    expect(e.status).toBe('registered'); // unchanged after failure
+  });
+});
+
+describe('ApprenticeServing — GC archived', () => {
+  it('drops oldest archived entries beyond maxArchivedToKeep', async () => {
+    const fs = createInMemoryFs();
+    const serving = new ApprenticeServing({
+      registryPath: '/tmp/r.json',
+      canaryRoutingConfigPath: '/tmp/c.json',
+      ollamaBinaryPath: 'ollama',
+      ollamaClient: createFakeOllamaClient(),
+      fs,
+      clock: createFakeClock(),
+      maxArchivedToKeep: 2
+    });
+    for (let i = 1; i <= 5; i++) {
+      const p = `/adapters/v${i}`;
+      fixtureAdapter(fs, { adapterPath: p, configSha256: `s${i}` });
+      await serving.promoteToCanary(p, 100);
+      await serving.promoteToProduction(p);
+    }
+    // After the 5th promotion: 4 archived + 1 production. With maxArchivedToKeep=2,
+    // 2 oldest archived should be dropped, leaving 2 archived + 1 production = 3 entries.
+    const all = serving.list();
+    expect(all.filter((e) => e.status === 'archived')).toHaveLength(2);
+    expect(all.filter((e) => e.status === 'production')).toHaveLength(1);
+  });
+});

--- a/packages/apprentice-serving/tsconfig.build.json
+++ b/packages/apprentice-serving/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/apprentice-serving/tsconfig.json
+++ b/packages/apprentice-serving/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/apprentice-serving/vitest.config.ts
+++ b/packages/apprentice-serving/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,6 +584,22 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/apprentice-retrainer:
+    dependencies:
+      '@chiefaia/apprentice-serving':
+        specifier: workspace:*
+        version: link:../apprentice-serving
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/apprentice-serving:
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,6 +584,18 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/apprentice-serving:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/apprentice-training:
     dependencies:
       '@chiefaia/apprentice-corpus':


### PR DESCRIPTION
Phase 3 of the Apprentice campaign — adapter swapping + serving substrate.

## What this PR ships

`packages/apprentice-serving/` — a private workspace package that consumes adapter directories from `@chiefaia/apprentice-training` (Phase 2), loads them into Ollama via `ollama create -f Modelfile` subprocess, tracks each adapter's lifecycle in a persisted JSON registry (`registered → shadow → canary → production` with `archived` and `rejected` terminals), and writes a canary-routing config that downstream agents read at inference time for percent-based traffic split.

## Public API per directive

```ts
class ApprenticeServing {
  register(adapterPath): Promise<RegistryEntry>;
  promoteToCanary(adapterPath, percent: number): Promise<RegistryEntry>;
  promoteToProduction(adapterPath): Promise<RegistryEntry>;
  rollback(toAdapterPath): Promise<RegistryEntry>;
  reject(adapterPath, reason): Promise<RegistryEntry>;
  registry: AdapterRegistry;
  canaryRouter: CanaryRouter;
}
```

Constructor parameters per Option E (every CAIA-specific path / model naming function is an injected parameter with a CAIA default).

## Stages 1-10 (single leg)

- **Stage 1-3** — Analyze + Research + Solution → `DESIGN.md` (17 sections, ~660 lines)
- **Stage 4** — 13 source modules (~750 LOC)
- **Stage 5** — 85 unit + integration tests across 6 test files
- **Stage 6** — Full lifecycle integration test with fake Ollama
- **Stage 7** — Install script + placeholder plist
- **Stage 8** — E2E live verify against real Ollama 0.23.1 + qwen2.5-coder:7b base — full lifecycle (register → canary 10% → production → list-confirms) passed in 684ms; created models cleaned up
- **Stage 9** — Package-internal regression clean (87 tests, lint, typecheck, build); monorepo regression clean
- **Stage 10** — README + completion sentinel at `~/Documents/projects/reports/apprentice-phase-3-complete-2026-05-06.md`

## State machine

```
registered → canary → production
            (canary)   (archived on next promote)
                       ↓
            rolled back to archived adapter

reject() valid from any non-terminal state.
```

Six invariants enforced at every mutation. Eleven typed errors. Idempotent over (adapterPath, target state).

## Constraints honoured

- ✅ Option E shape — private `@chiefaia/apprentice-serving`, parameterised constructor, fixture-tested with mocked Ollama, never published
- ✅ Subscription-only LLM (Ollama is local-only; `ANTHROPIC_API_KEY` cleared from subprocess env defensively)
- ✅ Mac MLX local
- ✅ Decision-classifier (package decides; operator informed via registry + canary-routing JSON)
- ✅ No silent model swaps (every transition logged in entry.history)
- ✅ Git Flow (feat → develop)
- ✅ Regression-gate ergonomics (`pnpm -r typecheck` + `pnpm -r lint`)

## What this unblocks

Phase 4 (continuous retraining cron) can now: (1) call `ApprenticeServing.register()` after training, (2) call `promoteToCanary()` if eval gate passes, (3) operator-prompt for full promotion if canary holds 3 days, (4) call `promoteToProduction()` on operator OK.

## Test summary

```
✓ tests/metadata-reader.test.ts        (13 tests)
✓ tests/adapter-registry.test.ts       (24 tests)
✓ tests/canary-router.test.ts          (11 tests)
✓ tests/ollama-client.test.ts          (16 tests)
✓ tests/serving.test.ts                (19 tests)
✓ tests/serving.integration.test.ts    (2 tests)
✓ tests/serving.e2e.test.ts            (2 tests | 2 skipped without env gate)

Test Files  6 passed | 1 skipped (7)
     Tests  85 passed | 2 skipped (87)
```

E2E live-validated against `ollama 0.23.1` + `qwen2.5-coder:7b` 2026-05-06.

## See also

- `packages/apprentice-serving/DESIGN.md` — full architecture spec
- `packages/apprentice-serving/README.md` — operator docs
- `~/Documents/projects/reports/apprentice-phase-3-complete-2026-05-06.md` — completion sentinel
- `agent/memory/apprentice_agent_directive.md` — campaign spec
- `agent/memory/agent_architecture_shape_2026-05-06.md` — Option E binding