### PR TITLE
ci(velocity-tier1-002): skip Build · Evidence Gate on doc-only PRs

### DIFF
--- a/.changeset/feat-velocity-tier1-002-paths-ignore.md
+++ b/.changeset/feat-velocity-tier1-002-paths-ignore.md
@@ -1,0 +1,28 @@
+---
+"caia": patch
+---
+
+ci(velocity-tier1-002): paths-ignore + dorny/paths-filter on `ci.yml` and `evidence-gate.yml`
+
+Adds a `detect-changes` job at the top of both workflows using
+`dorny/paths-filter@v3` with negation patterns. Every downstream job
+gates on `needs.detect-changes.outputs.code == 'true'`, which evaluates
+to false when a PR touches only `**/*.md`, `**/*.mdx`, `docs/**`,
+`agent/memory/**`, `AGENTS.md`, `CHANGELOG.md`, or `.changeset/**`.
+
+GitHub treats `if:`-skipped jobs as successful for required-status-check
+purposes, so branch protection is preserved.
+
+**Speedup:** ~5 minutes saved per doc-only PR (8 jobs × ubuntu-latest
+ramp + pnpm install). Across the 25-PR campaign baseline (where ~30-40%
+of PRs are documentation-cluster), this is a 30-40% reduction in
+average CI wall-time.
+
+**Reliability:** ★ low. The check name `detect-changes` is a NEW job,
+not a renamed required check, so existing branch-protection rules are
+unaffected. If `dorny/paths-filter@v3` is ever unavailable, the
+`detect-changes` job fails and downstream jobs are skipped — fail-safe
+to "no merge" rather than "merge without validation".
+
+Reference: `velocity-acceleration-strategy-2026-05-06.md` §1.2 (Tier 1.3),
+§A.4.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ─── 0. detect-changes ────────────────────────────────────────────────
+  # Skip heavy build/test/lint/typecheck for PRs that only touch markdown,
+  # docs, agent memory, or changesets. Required-status-checks pass via
+  # GitHub's "skipped due to `if:` is treated as successful" semantics.
+  # Reference: velocity-acceleration-strategy-2026-05-06.md §1.2 (Tier 1.3),
+  # §A.4. Estimated savings: ~5 min per doc-only PR.
+  detect-changes:
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `code` is true if ANY non-documentation file changed.
+          # `**` matches everything; the `!` patterns subtract doc-only paths.
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!docs/**'
+              - '!agent/memory/**'
+              - '!AGENTS.md'
+              - '!CHANGELOG.md'
+              - '!.changeset/**'
+
   ci:
     name: Build · Test · Lint · Typecheck
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/evidence-gate.yml
+++ b/.github/workflows/evidence-gate.yml
@@ -24,6 +24,12 @@ name: Evidence Gate
 # rule.
 #
 # Required-check propagation: see scripts/setup-branch-protection.sh.
+#
+# Doc-only PR fast-path: a `detect-changes` gate at the top short-circuits
+# all 7 downstream jobs when the PR touches only markdown/docs/memory/
+# changesets. Reference: velocity-acceleration-strategy-2026-05-06.md §1.2
+# (Tier 1.3), §A.4. Estimated savings: ~4-5 min per doc-only PR; further
+# 30-40% reduction in average per-PR Evidence Gate wall-time.
 
 on:
   pull_request:
@@ -45,9 +51,36 @@ env:
 
 jobs:
 
+  # ─── 0. detect-changes ────────────────────────────────────────────────
+  # Skip the 7 heavy gate jobs when the PR is doc-only. GitHub treats
+  # `if:`-skipped jobs as successful for required-status-check purposes,
+  # so branch protection still passes.
+  detect-changes:
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!docs/**'
+              - '!agent/memory/**'
+              - '!AGENTS.md'
+              - '!CHANGELOG.md'
+              - '!.changeset/**'
+
   # ─── 1. typecheck ─────────────────────────────────────────────────────
   typecheck:
     name: typecheck
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,6 +97,8 @@ jobs:
   # ─── 2. semgrep ───────────────────────────────────────────────────────
   semgrep:
     name: semgrep
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep:latest
@@ -82,6 +117,8 @@ jobs:
   # ─── 3. gitleaks ──────────────────────────────────────────────────────
   gitleaks:
     name: gitleaks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -101,6 +138,8 @@ jobs:
   # ─── 4. bundle-size ───────────────────────────────────────────────────
   bundle-size:
     name: bundle-size
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +158,8 @@ jobs:
   # ─── 5. lighthouse (warn-only day-1) ─────────────────────────────────
   lighthouse:
     name: lighthouse
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true   # day-1 warn-only; promote to blocking next cycle
     steps:
@@ -142,6 +183,8 @@ jobs:
   # ─── 6. axe a11y (warn-only day-1) ───────────────────────────────────
   axe:
     name: axe
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true   # day-1 warn-only; promote to blocking next cycle
     steps:
@@ -170,6 +213,8 @@ jobs:
   # ─── 7. visual regression (warn-only day-1) ──────────────────────────
   visual:
     name: visual
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true   # day-1 warn-only; promote to blocking next cycle
     steps:


### PR DESCRIPTION
## Summary

Adds a `detect-changes` job at the top of `ci.yml` and `evidence-gate.yml` using `dorny/paths-filter@v3` with negation patterns. Every downstream job gates on `needs.detect-changes.outputs.code == 'true'`, evaluating to false when a PR touches only:

- `**/*.md`, `**/*.mdx`
- `docs/**`, `agent/memory/**`
- `AGENTS.md`, `CHANGELOG.md`
- `.changeset/**`

GitHub treats `if:`-skipped jobs as successful for required-status-check purposes, so existing branch-protection rules are preserved.

## Speedup

**~5 min per doc-only PR.** Across a 25-PR campaign baseline where ~30-40% of PRs are doc-cluster, this is a **30-40% reduction in average CI wall-time**.

## Reliability

★ low. The new `detect-changes` job is additive, not a renamed required check; branch-protection rules unaffected. If `dorny/paths-filter@v3` is ever unavailable, `detect-changes` fails and downstream jobs are skipped — fail-safe to 'no merge'.

## Reference

`velocity-acceleration-strategy-2026-05-06.md` §1.2 (Tier 1.3), §A.4. Tier 1 of the velocity acceleration plan; PR 3 of 5 in the campaign.

## Evidence

- [x] YAML parses (`yaml.safe_load` against both files)
- [x] Required-check semantics preserved (job names unchanged for `Build · Test · Lint · Typecheck`, `typecheck`, `semgrep`, `gitleaks`, `bundle-size`, `lighthouse`, `axe`, `visual`)
- [x] Changeset filed
