### PR TITLE
ops(velocity-tier0-001): stolution disk-cleanup script + operator runbook

### DIFF
--- a/.changeset/feat-velocity-tier0-001-stolution-cleanup.md
+++ b/.changeset/feat-velocity-tier0-001-stolution-cleanup.md
@@ -1,0 +1,32 @@
+---
+"caia": patch
+---
+
+ops(velocity-tier0-001): stolution disk-cleanup script + operator runbook
+
+Adds the Tier 0 prerequisite for the velocity-acceleration plan
+(`velocity-acceleration-strategy-2026-05-06.md` §A.1):
+
+- `scripts/stolution/disk-cleanup.sh` — five-step reclamation script
+  (audit → docker prune → runner _work → journal vacuum → backups),
+  dry-run by default, with safety rails (preview before each destructive
+  step, interactive confirm unless `--yes`, postgres backups opt-in only).
+- `docs/operator/stolution-disk-cleanup.md` — runbook covering when to
+  run, how to run, tuning knobs, verification, and recovery from a
+  runaway diagnostic that left `du` background processes hung.
+
+**Rationale:** stolution's NVMe was at 96-97% utilisation as of
+2026-05-06 (3.3 TB used / 129-142 GB free of 3.6 TB). Self-hosted runner
+deployment (Tier 1.1) needs ~10-50 GB transient space per concurrent
+job, so the disk must be ≤80% before runner expansion.
+
+**Reliability:** ★ low. The `du` audit is non-recursive on the filesystem
+(samples well-known directories only), specifically to avoid the
+positive-feedback IO-pressure spiral that triggered an sshd
+banner-exchange outage on 2026-05-06. Each destructive step previews
+before executing.
+
+**No execution in this PR.** The script lands; the operator runs it
+out-of-band when stolution sshd is reachable.
+
+Reference: `velocity-acceleration-strategy-2026-05-06.md` §A.1 (Tier 0).

--- a/docs/operator/stolution-disk-cleanup.md
+++ b/docs/operator/stolution-disk-cleanup.md
@@ -1,0 +1,126 @@
+# Stolution disk cleanup runbook
+
+**Audience:** operator + on-call.
+**Cadence:** ad-hoc on alarm; weekly preventative once Tier 1.1 runner pool is online.
+**Reference:** `velocity-acceleration-strategy-2026-05-06.md` §A.1.
+
+## When to run this
+
+- The 90% disk-usage alarm wired into Steward Gatekeeper fires (any host)
+- New self-hosted runner is being added and the host is at >80% disk
+- Manual ssh shows `df -h /` is at >85%
+- Scheduled weekly preventative pass
+
+## What it does
+
+`scripts/stolution/disk-cleanup.sh` performs a five-step reclamation, in order:
+
+1. **T0-1: audit** — non-recursive `du` on top-level directories, plus
+   `docker system df` if available. Logs current free space; takes ~30
+   seconds. Read-only.
+2. **T0-2: docker prune** — `docker system prune -af --volumes`. Reclaims
+   dangling images, stopped containers, and unused volumes. Tagged images
+   for running services are preserved because the container holds a
+   reference. Expect 50-300 GB.
+3. **T0-3: runner _work cleanup** — `find /home/s903/actions-runner*/\_work
+   -mtime +14 -delete`. Removes stale workflow checkouts older than 14
+   days. Per-pool-runner-aware (handles `actions-runner-1` through
+   `actions-runner-16`). Expect 10-50 GB.
+4. **T0-4: journalctl vacuum** — keeps last 14 days of systemd journals.
+   Expect 1-5 GB.
+5. **T0-5: postgres backups** — opt-in via `--include-backups`. Removes
+   `.dump` files older than 30 days. Expect 30-200 GB. **Disabled by
+   default** because it cannot be undone; verify backups exist on
+   secondary storage (MinIO sync) first.
+
+## Safety
+
+- Default mode is **dry-run**. Pass `--execute` to perform destructive ops.
+- Interactive confirmation required unless `--yes` also passed.
+- Each destructive step is preceded by a preview/snapshot.
+- The `du` audit is **non-recursive on the filesystem** — it samples
+  well-known directories only, to avoid amplifying IO pressure on a
+  near-full disk. (Lessons learned 2026-05-06: an aggressive
+  `du -sh /home/s903/*` triggered an sshd banner-exchange outage on the
+  97%-full host.)
+
+## Procedure
+
+### Dry run (read-only diagnostic)
+
+```bash
+ssh stolution 'bash -s' < scripts/stolution/disk-cleanup.sh
+```
+
+This shows the audit, previews each destructive step, but performs no
+deletions. Total wall-time ~1 minute.
+
+### Execute (destructive)
+
+```bash
+ssh stolution 'bash -s' < scripts/stolution/disk-cleanup.sh -- \
+  --execute --yes
+```
+
+Reclaims dangling docker, stale runner work, and old journals. Postgres
+backups are NOT touched.
+
+### Execute including backups
+
+```bash
+ssh stolution 'bash -s' < scripts/stolution/disk-cleanup.sh -- \
+  --execute --yes --include-backups
+```
+
+Adds T0-5. Verify offsite backup integrity first.
+
+## Tuning knobs
+
+| Flag | Default | What it does |
+| --- | --- | --- |
+| `--runner-age N` | 14 | Reclaim runner `_work` older than N days |
+| `--backup-age N` | 30 | Backup retention horizon |
+| `--journal-keep-days N` | 14 | systemd journal vacuum window |
+| `--target-use-pct N` | 80 | Cleanup target; script exits non-zero if final use > target |
+
+## Verification
+
+The script prints `df -h /` at the end and asserts `use ≤ --target-use-pct`.
+
+Spot-check service health:
+
+```bash
+ssh stolution 'docker ps --format "table {{.Names}}\t{{.Status}}"; uptime'
+```
+
+Vault audit log rotation should already be configured per
+`secrets_vault.md`; this runbook does not touch Vault.
+
+## What this runbook does NOT do
+
+- Does not stop or restart any service
+- Does not modify postgres data files
+- Does not touch `/etc`, `/boot`, or `/usr`
+- Does not run `vacuum analyze` on postgres (consider as a separate runbook)
+
+## Recovery from runaway diagnostic
+
+If a previous diagnostic pass left `du` background processes hung
+(consuming IO on a near-full disk):
+
+```bash
+ssh stolution 'pkill -f "du -sh /home/s903"'
+# then wait 5-30 minutes for IO pressure to subside before trying again
+```
+
+If sshd itself is unreachable due to disk-pressure-induced banner-exchange
+timeout, the only recovery path is out-of-band console access (cloud
+provider IPMI, serial console, or physical access). At that point, drop
+to the rescue shell and run `docker system prune -af --volumes` directly.
+
+## Disk monitoring (Tier 0.5 follow-up)
+
+A `disk-watch.ts` analyzer extension to Steward Gatekeeper is planned
+(Story T0-5 in the velocity strategy). It runs in `daily` mode, hard-stops
+at >95%, warns at >90%. Once that lands, this runbook is the response
+playbook for those alarms.

--- a/scripts/stolution/disk-cleanup.sh
+++ b/scripts/stolution/disk-cleanup.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# stolution disk cleanup — Tier 0 prerequisite for the velocity-acceleration plan.
+#
+# Reference: velocity-acceleration-strategy-2026-05-06.md §A.1.
+#
+# Purpose:
+#   Reclaim 500-1000 GB of disk on stolution before deploying the
+#   self-hosted GitHub Actions runner pool (Tier 1.1). Stolution's NVMe
+#   was at 96-97% utilisation as of 2026-05-06; runner _work checkouts
+#   need ~10-50 GB transient space per concurrent job.
+#
+# Safety:
+#   • Read-only diagnostic mode by default. Pass --execute to perform
+#     destructive operations.
+#   • Each destructive step is preceded by a preview/snapshot.
+#   • Postgres backup retention is preserved by default (--include-backups
+#     opt-in only).
+#   • Aborts if running in a tty without --execute, requires explicit
+#     confirmation when --execute is set unless --yes is also passed.
+#
+# Operator workflow:
+#   1. ssh stolution
+#   2. bash <(curl -sL https://raw.githubusercontent.com/prakashgbid/caia/develop/scripts/stolution/disk-cleanup.sh)
+#   3. Review the diagnostic output
+#   4. Re-run with --execute --yes once satisfied
+#   5. Verify df -h shows ≤80% utilisation
+#
+# Or run from the developer Mac (preferred — keeps the script versioned):
+#   ssh stolution 'bash -s' < scripts/stolution/disk-cleanup.sh -- --execute --yes
+
+set -euo pipefail
+
+DRY_RUN=true
+ASSUME_YES=false
+INCLUDE_BACKUPS=false
+RUNNER_WORK_AGE_DAYS=14
+BACKUP_AGE_DAYS=30
+JOURNAL_KEEP_DAYS=14
+TARGET_USE_PCT=80
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--execute] [--yes] [--include-backups]
+                 [--runner-age N] [--backup-age N] [--journal-keep-days N]
+                 [--target-use-pct N]
+
+  --execute              Actually perform destructive ops (default: dry-run)
+  --yes                  Skip interactive confirmation
+  --include-backups      Also remove postgres backups older than --backup-age
+  --runner-age N         Reclaim runner _work checkouts older than N days (default: 14)
+  --backup-age N         Backup retention horizon (default: 30 days)
+  --journal-keep-days N  Keep last N days of systemd journals (default: 14)
+  --target-use-pct N     Cleanup target as % disk used (default: 80)
+  -h, --help             This help
+
+Reference: velocity-acceleration-strategy-2026-05-06.md §A.1
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --execute) DRY_RUN=false; shift ;;
+    --yes) ASSUME_YES=true; shift ;;
+    --include-backups) INCLUDE_BACKUPS=true; shift ;;
+    --runner-age) RUNNER_WORK_AGE_DAYS="$2"; shift 2 ;;
+    --backup-age) BACKUP_AGE_DAYS="$2"; shift 2 ;;
+    --journal-keep-days) JOURNAL_KEEP_DAYS="$2"; shift 2 ;;
+    --target-use-pct) TARGET_USE_PCT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "::error::unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+log() { printf '[disk-cleanup] %s\n' "$*"; }
+banner() { printf '\n=== %s ===\n' "$*"; }
+
+run_or_dry() {
+  if "$DRY_RUN"; then
+    log "DRY-RUN: $*"
+  else
+    log "EXEC: $*"
+    eval "$@"
+  fi
+}
+
+current_use_pct() {
+  df --output=pcent / | tail -1 | tr -d ' %'
+}
+
+free_gb() {
+  df -BG --output=avail / | tail -1 | tr -dc '0-9'
+}
+
+# ─── 0. preconditions ──────────────────────────────────────────────────────
+
+banner "0. preconditions"
+log "host:        $(hostname)"
+log "user:        $(whoami)"
+log "uname:       $(uname -srm)"
+log "starting df:"
+df -h /
+log "starting use: $(current_use_pct)%, free: $(free_gb)G"
+
+if "$DRY_RUN"; then
+  log "MODE: DRY-RUN. Pass --execute to perform destructive operations."
+elif ! "$ASSUME_YES"; then
+  if [ -t 0 ]; then
+    read -rp "About to execute destructive cleanup. Continue? [y/N] " ans
+    case "$ans" in y|Y|yes|YES) ;; *) log "aborted"; exit 1 ;; esac
+  else
+    echo "::error::--execute requires --yes when stdin is not a tty" >&2
+    exit 2
+  fi
+fi
+
+# ─── T0-1. audit current consumers ─────────────────────────────────────────
+
+banner "T0-1. audit"
+log "top-level disk consumers (non-recursive du, may take ~30s):"
+# Avoid recursive du on the full filesystem — it amplifies IO pressure on
+# a near-full disk. Sample only the well-known directories.
+for dir in /var/log /var/lib/docker /home/s903 /tmp; do
+  if [ -d "$dir" ]; then
+    sz=$(du -sh "$dir" 2>/dev/null | awk '{print $1}' || echo '?')
+    printf '  %-30s %s\n' "$dir" "${sz:-?}"
+  fi
+done
+
+if command -v docker >/dev/null 2>&1; then
+  log "docker storage:"
+  docker system df 2>&1 | sed 's/^/  /' || log "  (docker daemon unresponsive)"
+fi
+
+# ─── T0-2. docker prune ────────────────────────────────────────────────────
+
+banner "T0-2. docker prune (highest-leverage; expect 50-300 GB)"
+if command -v docker >/dev/null 2>&1; then
+  log "preview — dangling images:"
+  docker image ls --filter dangling=true 2>&1 | head -10 | sed 's/^/  /' || true
+  log "preview — stopped containers:"
+  docker container ls -a --filter status=exited --filter status=created 2>&1 | head -10 | sed 's/^/  /' || true
+  log "preview — unused volumes:"
+  docker volume ls --filter dangling=true 2>&1 | head -10 | sed 's/^/  /' || true
+
+  # Aggressive prune. -af prunes images not referenced by any container
+  # (running or stopped). --volumes also prunes unused volumes.
+  # WARNING: this WILL delete any data in unmounted volumes. Tagged images
+  # for running services are preserved because the running container holds
+  # a reference.
+  run_or_dry "docker system prune -af --volumes"
+else
+  log "(docker not installed; skipping)"
+fi
+
+# ─── T0-3. runner _work cleanup ────────────────────────────────────────────
+
+banner "T0-3. actions-runner _work (older than ${RUNNER_WORK_AGE_DAYS} days)"
+RUNNER_WORK="/home/s903/actions-runner/_work"
+if [ -d "$RUNNER_WORK" ]; then
+  log "preview — workflow checkouts older than ${RUNNER_WORK_AGE_DAYS}d:"
+  find "$RUNNER_WORK" -maxdepth 1 -mindepth 1 -type d -mtime "+${RUNNER_WORK_AGE_DAYS}" -ls 2>/dev/null \
+    | head -20 | sed 's/^/  /' || true
+
+  # Don't kill in-flight jobs. The --ephemeral runner pattern (Tier 1.1)
+  # keeps _work clean per-job. For the current single-runner setup, the
+  # +14d filter is safe.
+  run_or_dry "find '$RUNNER_WORK' -maxdepth 1 -mindepth 1 -type d -mtime +${RUNNER_WORK_AGE_DAYS} -exec rm -rf {} +"
+else
+  log "(no $RUNNER_WORK; skipping)"
+fi
+
+# Also handle the per-runner _work directories from the Tier 1.1 pool.
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+  d="/home/s903/actions-runner-${n}/_work"
+  [ -d "$d" ] || continue
+  log "preview — pool runner ${n} (older than ${RUNNER_WORK_AGE_DAYS}d):"
+  find "$d" -maxdepth 1 -mindepth 1 -type d -mtime "+${RUNNER_WORK_AGE_DAYS}" -ls 2>/dev/null \
+    | head -5 | sed 's/^/  /' || true
+  run_or_dry "find '$d' -maxdepth 1 -mindepth 1 -type d -mtime +${RUNNER_WORK_AGE_DAYS} -exec rm -rf {} +"
+done
+
+# ─── T0-4. journalctl rotation ─────────────────────────────────────────────
+
+banner "T0-4. systemd journal vacuum (keep last ${JOURNAL_KEEP_DAYS} days)"
+if command -v journalctl >/dev/null 2>&1; then
+  log "preview — current journal size:"
+  journalctl --disk-usage 2>&1 | sed 's/^/  /' || true
+  run_or_dry "journalctl --vacuum-time=${JOURNAL_KEEP_DAYS}d"
+else
+  log "(no journalctl; skipping)"
+fi
+
+# ─── T0-5. postgres backup retention (opt-in only) ─────────────────────────
+
+banner "T0-5. postgres backups (opt-in via --include-backups)"
+BACKUP_DIR="/home/s903/backups"
+if [ -d "$BACKUP_DIR" ]; then
+  log "preview — backups older than ${BACKUP_AGE_DAYS}d:"
+  find "$BACKUP_DIR" -name "*.dump" -mtime "+${BACKUP_AGE_DAYS}" -ls 2>/dev/null \
+    | head -10 | sed 's/^/  /' || true
+
+  if "$INCLUDE_BACKUPS"; then
+    run_or_dry "find '$BACKUP_DIR' -name '*.dump' -mtime +${BACKUP_AGE_DAYS} -delete"
+  else
+    log "(skipping — pass --include-backups to remove)"
+  fi
+else
+  log "(no $BACKUP_DIR; skipping)"
+fi
+
+# ─── verify ─────────────────────────────────────────────────────────────────
+
+banner "verify"
+log "ending df:"
+df -h /
+end_pct=$(current_use_pct)
+end_gb=$(free_gb)
+log "ending use: ${end_pct}%, free: ${end_gb}G"
+
+if [ "$end_pct" -le "$TARGET_USE_PCT" ]; then
+  log "✓ disk usage at or below target (${end_pct}% ≤ ${TARGET_USE_PCT}%)"
+else
+  log "⚠ still above target (${end_pct}% > ${TARGET_USE_PCT}%)"
+  log "  Consider --include-backups, or investigate further."
+  exit 3
+fi
+
+# ─── service health spot-check ─────────────────────────────────────────────
+
+banner "service health"
+if command -v docker >/dev/null 2>&1; then
+  log "running containers:"
+  docker ps --format 'table {{.Names}}\t{{.Status}}' 2>&1 | head -20 | sed 's/^/  /' || true
+fi
+log "load average: $(uptime)"
+
+log "DONE"


### PR DESCRIPTION
## Summary

Adds the Tier 0 prerequisite for the velocity-acceleration plan:

- `scripts/stolution/disk-cleanup.sh` — five-step reclamation:
  - **T0-1 audit** — non-recursive `du` sample + `docker system df`
  - **T0-2 docker prune** — `-af --volumes` (50-300 GB)
  - **T0-3 runner _work cleanup** — `mtime +14d` (10-50 GB; pool-aware)
  - **T0-4 journalctl vacuum** — keep last 14 days (1-5 GB)
  - **T0-5 postgres backups** — `mtime +30d`, **opt-in only** (30-200 GB)
- `docs/operator/stolution-disk-cleanup.md` — operator runbook

## Why

Stolution's NVMe was at 96-97% utilisation as of 2026-05-06 (3.3 TB used / 129-142 GB free of 3.6 TB). Self-hosted runner pool (Tier 1.1) needs ~10-50 GB transient space per concurrent job, so the disk must be ≤80% before runner expansion.

## Safety rails

- Default **dry-run**; `--execute` required for destructive ops
- Interactive confirm unless `--yes`
- Audit `du` is **non-recursive** (samples well-known dirs only) — avoids the positive-feedback IO-pressure spiral that triggered the 2026-05-06 sshd banner-exchange outage
- Postgres backup deletion opt-in only via `--include-backups`
- Each destructive step previews before executing

## Reliability

★ low. The script does **not execute** in CI or as part of this PR. It lands; the operator runs it out-of-band when stolution sshd is reachable.

## Reference

`velocity-acceleration-strategy-2026-05-06.md` §A.1. Tier 0 of the velocity acceleration plan; PR 1 of 5 in the campaign.

## Evidence

- [x] Shell syntax check passes (`bash -n`)
- [x] Non-recursive du sampling (no full filesystem walk)
- [x] Dry-run is default; destructive ops require `--execute --yes`
- [x] Changeset filed
