### PR TITLE
ops(velocity-tier1-001): self-hosted runner-pool infra + health workflow + runbooks

### DIFF
--- a/.changeset/feat-velocity-tier1-001-self-hosted-runners.md
+++ b/.changeset/feat-velocity-tier1-001-self-hosted-runners.md
@@ -1,0 +1,53 @@
+---
+"caia": patch
+---
+
+ops(velocity-tier1-001): self-hosted Actions runner-pool infra + health workflow + runbooks
+
+Adds the infrastructure and operator documentation for the Tier 1.1
+self-hosted GitHub Actions runner pool on stolution. **No workflow
+migration in this PR** — existing workflows continue on `ubuntu-latest`.
+The actual migration (changing `runs-on:` from `ubuntu-latest` to
+`[self-hosted, stolution, caia, linux]`) lands in a follow-up PR after
+the pool has soaked for 48 hours.
+
+What lands here:
+
+- `infra/stolution/systemd/actions.runner.caia.service.template` —
+  systemd unit template (rendered per-runner with `__N__` substitution).
+  Ephemeral semantics (`run.sh --once` + systemd respawn), resource caps
+  (CPUQuota=400%, MemoryLimit=16G), hardening (`ProtectSystem=full`,
+  `NoNewPrivileges=true`, `PrivateTmp=true`).
+- `scripts/stolution/install-runner-pool.sh` — install + register N
+  runners against the `prakashgbid` GitHub org with labels
+  `self-hosted, stolution, caia, linux`. Idempotent. Disk pre-flight
+  refuses if usage > 85%. Dry-run by default.
+- `.github/workflows/runner-pool-health.yml` — every 15 min, pings the
+  pool and asserts disk ≤90% + memory + docker reachability. Failure at
+  >90% disk; warning at >85%.
+- `docs/self-hosted-runners.md` — install runbook, capacity plan,
+  migration order, failure modes.
+- `docs/runner-runbook.md` — operator dashboard, common ops (restart,
+  drain, deregister), alarm response.
+
+**Speedup (when pool is migrated):** 5-10× CI throughput. 8 runners ×
+3-5 min average = ~96 jobs/hour vs the ubuntu-latest queue's ~10-15
+jobs/hour today.
+
+**Cost:** $0 incremental (operator hardware) + ~$38/mo GitHub platform
+fee per the March-2026 pricing change.
+
+**Reliability:** ★ low. Each runner is ephemeral (clean working tree per
+job), respawned by systemd. `ubuntu-latest` remains the fallback; if the
+pool fails, individual workflows can be re-pointed back via a one-line
+edit. The `runner-pool-health.yml` workflow flags 3+ consecutive failures
+to Steward Gatekeeper for automatic fallback-PR proposal.
+
+**Prerequisites for execution:**
+
+1. Tier 0 disk cleanup complete (PR `velocity-tier0-001`)
+2. stolution sshd reachable (currently down as of 2026-05-06)
+3. Runner registration token in Vault at
+   `secret/stolution/prod/infrastructure/github_runner_registration_token`
+
+Reference: `velocity-acceleration-strategy-2026-05-06.md` §4.4, §A.2.

--- a/.github/workflows/runner-pool-health.yml
+++ b/.github/workflows/runner-pool-health.yml
@@ -1,0 +1,61 @@
+name: runner-pool-health
+
+# Health check for the self-hosted GitHub Actions runner pool on stolution.
+#
+# Pings each runner every 15 minutes (and on workflow_dispatch) by claiming
+# a job slot from the pool. Three consecutive failures should be treated as
+# an alarm — the orchestrator's Steward Gatekeeper consumes this workflow's
+# status and proposes a fallback PR (re-pointing affected workflows to
+# `ubuntu-latest`) on persistent failure.
+#
+# Reference: velocity-acceleration-strategy-2026-05-06.md §A.2 (Story 1.1-4).
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-pool-health
+  cancel-in-progress: false
+
+jobs:
+  ping-stolution-runners:
+    name: ping-stolution-runners
+    runs-on: [self-hosted, stolution, caia, linux]
+    timeout-minutes: 2
+    steps:
+      - name: Identify runner
+        run: |
+          echo "runner alive on host: $(hostname)"
+          echo "runner pid: $$"
+          echo "runner uid: $(id -u)"
+
+      - name: Disk health
+        run: |
+          df -h /
+          USE_PCT=$(df --output=pcent / | tail -1 | tr -d ' %')
+          echo "disk use: ${USE_PCT}%"
+          if [ "$USE_PCT" -gt 90 ]; then
+            echo "::error::disk at ${USE_PCT}% (threshold 90%) — schedule cleanup"
+            exit 1
+          fi
+          if [ "$USE_PCT" -gt 85 ]; then
+            echo "::warning::disk at ${USE_PCT}% (warning threshold 85%)"
+          fi
+
+      - name: Memory + load
+        run: |
+          free -h
+          uptime
+
+      - name: Docker reachability
+        run: |
+          if command -v docker >/dev/null 2>&1; then
+            docker version --format '{{.Server.Version}}' || echo "docker unreachable"
+          else
+            echo "docker not installed"
+          fi

--- a/docs/runner-runbook.md
+++ b/docs/runner-runbook.md
@@ -1,0 +1,128 @@
+# Self-hosted runner — operator runbook
+
+**Companion to:** `docs/self-hosted-runners.md` (install + design).
+**Reference:** `velocity-acceleration-strategy-2026-05-06.md` §A.2.
+
+## How to know if the pool is healthy
+
+### From GitHub UI
+
+Navigate to **Settings → Actions → Runners**. Each `caia-stolution-{N}`
+should show status **Idle** or **Active** with a recent contact time. The
+runners list refreshes every minute.
+
+### From the `runner-pool-health.yml` workflow
+
+The workflow runs every 15 minutes and emits:
+
+- ✅ green: runner alive, disk ≤85%, docker reachable
+- ⚠ warning at 85% disk: schedule cleanup
+- ❌ failure at >90% disk: blocks runner-pool-health (and signals an alarm
+  to Steward Gatekeeper)
+
+View runs at:
+`https://github.com/prakashgbid/caia/actions/workflows/runner-pool-health.yml`
+
+### From stolution
+
+```bash
+ssh stolution 'systemctl list-units "actions.runner.caia-*.service" --no-pager'
+```
+
+Expected: each unit `active (running)`. A unit in `failed` state means
+something is wrong; check journal:
+
+```bash
+ssh stolution 'journalctl -u actions.runner.caia-3.service -n 100 --no-pager'
+```
+
+## Common operations
+
+### Restart a single runner
+
+```bash
+ssh stolution 'sudo systemctl restart actions.runner.caia-3.service'
+```
+
+The runner finishes its current job (if any) and respawns clean.
+
+### Restart the whole pool
+
+```bash
+ssh stolution 'sudo systemctl restart "actions.runner.caia-*.service"'
+```
+
+Useful after a config change or token rotation.
+
+### Drain a runner (graceful)
+
+```bash
+ssh stolution 'sudo systemctl stop actions.runner.caia-3.service'
+```
+
+Lets the current job finish; does not respawn. Use before maintenance.
+
+### Tail logs
+
+```bash
+# Single runner
+ssh stolution 'journalctl -u actions.runner.caia-3.service -f'
+
+# All runners
+ssh stolution 'journalctl -u "actions.runner.caia-*.service" -f'
+```
+
+### Disk pressure response
+
+If `runner-pool-health.yml` reports >85% disk:
+
+1. Run `scripts/stolution/disk-cleanup.sh` (dry-run first)
+2. If still >85%, run with `--execute --yes`
+3. If still >85%, run with `--include-backups` (after verifying offsite
+   backups exist)
+4. If still >85%, drain runners and investigate manually
+
+### Runner deregistration
+
+```bash
+ssh stolution 'cd /home/s903/actions-runner-3 && \
+  ./config.sh remove --token <fresh-token>'
+ssh stolution 'sudo systemctl disable --now actions.runner.caia-3.service'
+ssh stolution 'sudo rm /etc/systemd/system/actions.runner.caia-3.service'
+```
+
+## Alarm response
+
+| Alarm | Source | Response |
+| --- | --- | --- |
+| 85% disk | `runner-pool-health.yml` warning | Schedule cleanup; non-urgent |
+| 90% disk | `runner-pool-health.yml` failure | Run `disk-cleanup.sh --execute --yes` immediately |
+| Runner pool unreachable | 3+ consecutive `runner-pool-health.yml` failures | Steward Gatekeeper proposes fallback PR re-pointing to `ubuntu-latest` |
+| Runner stuck | Single `actions.runner.caia-N` in failed state | `systemctl restart actions.runner.caia-N.service`; if recurring, check `journalctl` |
+
+## Disk-watch (Tier 0.5 follow-up)
+
+A `disk-watch.ts` analyzer extension to Steward Gatekeeper is planned to
+run in `daily` mode and emit warnings at >90% / hard-stops at >95%. Once
+live, this runbook is the playbook for those alarms.
+
+## Pool sizing decisions
+
+| Concurrent jobs needed | Recommended pool size |
+| --- | --- |
+| 1-3 | 2 runners (start here) |
+| 4-7 | 4 runners |
+| 8-15 | 8 runners |
+| 16+ | 16 runners (max recommended on 72-core stolution) |
+
+Each runner reserves 16 GB RAM ceiling and 4-CPU equivalent. With 16
+runners that's 256 GB RAM ceiling vs 251 GB physical — the kernel
+overcommits, and runners rarely all peak together.
+
+## See also
+
+- `docs/self-hosted-runners.md` — design + install
+- `scripts/stolution/disk-cleanup.sh` — disk reclamation
+- `infra/stolution/systemd/actions.runner.caia.service.template` — systemd unit
+- `scripts/stolution/install-runner-pool.sh` — install script
+- `.github/workflows/runner-pool-health.yml` — 15-min health check

--- a/docs/self-hosted-runners.md
+++ b/docs/self-hosted-runners.md
@@ -1,0 +1,138 @@
+# Self-hosted GitHub Actions runner pool
+
+**Audience:** operator + on-call.
+**Reference:** `velocity-acceleration-strategy-2026-05-06.md` §4.4, §A.2.
+
+## What this is
+
+A pool of N (ramping 2 → 4 → 8) ephemeral GitHub Actions runners deployed
+on stolution as systemd services. Each runner:
+
+- Lives in its own directory (`/home/s903/actions-runner-{N}/`)
+- Runs as user `s903` under a dedicated systemd unit
+- Uses `--once` mode (single job per `run.sh` invocation)
+- Is respawned by systemd on exit, so each job runs in a freshly-cleaned
+  working tree
+- Carries the labels `self-hosted, stolution, caia, linux`
+
+## Why
+
+Stolution has 72 cores and 251 GB RAM, vastly more than github-hosted
+ubuntu-latest. Migrating the long-running CI workflows (`Build · Test ·
+Lint · Typecheck`, Evidence Gate's typecheck/bundle-size jobs) to the
+self-hosted pool unlocks 5-10× CI throughput.
+
+Existing state at the time this runbook was written: one runner already
+registered for the `fix-it-sharded-tests` workflow on stolution. This
+runbook expands that into a managed pool.
+
+## Prerequisites
+
+1. **Disk at ≤80%.** Run `scripts/stolution/disk-cleanup.sh --execute --yes`
+   first. The pool needs ~10-50 GB transient space per concurrent job.
+2. **Runner registration token.** Two ways to obtain it:
+   - Via Vault (preferred):
+     `vault read -field=token secret/stolution/prod/infrastructure/github_runner_registration_token`
+   - Via GitHub UI (one-off): Settings → Actions → Runners → New self-hosted
+     runner → copy the token from the displayed `./config.sh` command.
+3. **Network egress** from stolution to `api.github.com:443`,
+   `pipelines.actions.githubusercontent.com:443`, and
+   `objects.githubusercontent.com:443`.
+4. **`sudo` for `systemctl`** install (one-off; the runner itself does not
+   require sudo at runtime).
+
+## Install
+
+From the developer Mac:
+
+```bash
+# Dry-run first to see what will happen
+ssh stolution 'bash -s' < scripts/stolution/install-runner-pool.sh
+
+# Once satisfied, ramp 2 runners
+ssh stolution "GITHUB_RUNNER_TOKEN=… bash -s -- --execute --count 2" \
+  < scripts/stolution/install-runner-pool.sh
+
+# After 24h soak, expand to 4
+ssh stolution "GITHUB_RUNNER_TOKEN=… bash -s -- --execute --count 4" \
+  < scripts/stolution/install-runner-pool.sh
+
+# After 48h soak, expand to 8
+ssh stolution "GITHUB_RUNNER_TOKEN=… bash -s -- --execute --count 8" \
+  < scripts/stolution/install-runner-pool.sh
+```
+
+The install is idempotent. Re-running with a higher `--count` adds more
+runners; existing runners are not touched.
+
+## Verify
+
+After install:
+
+```bash
+ssh stolution 'systemctl list-units "actions.runner.caia-*.service" --no-pager'
+```
+
+Expected: each unit shows `active (running)`. In GitHub UI, navigate to
+Settings → Actions → Runners. Each runner appears as `caia-stolution-{N}`
+with labels `self-hosted, stolution, caia, linux` and status "Idle".
+
+The `runner-pool-health.yml` workflow (added in this PR) pings the pool
+every 15 minutes and asserts disk + memory health.
+
+## Migrate workflows
+
+**Not done in this PR.** Workflow migration is a separate follow-up that
+lands once the pool has soaked for 48 hours and `runner-pool-health.yml`
+shows zero failures.
+
+When ready, change individual workflow's `runs-on:` from `ubuntu-latest`
+to `[self-hosted, stolution, caia, linux]`.
+
+Recommended migration order (largest CI savings first):
+
+1. `ci.yml` — Build · Test · Lint · Typecheck (5-7 min critical path)
+2. `evidence-gate.yml`'s `typecheck`, `bundle-size` jobs
+3. `pipeline-regression.yml`'s `pipeline-e2e`, `agents-regression` jobs
+4. `promptfoo-eval.yml`
+
+Keep on `ubuntu-latest`:
+
+- `gitflow-conformance.yml` — sub-second; no benefit
+- `secrets-scan.yml` — security; isolation preferred
+- `mcp-vendored-verify.yml` — SHA-pinned drift checker; ubuntu-latest is fine
+- `release.yml` or any publish workflow — keep clean GitHub-hosted box
+
+## Runtime characteristics
+
+- **Throughput:** 8 runners × 3-5 min average job = ~96 jobs/hour
+- **vs ubuntu-latest queue:** 10-15 jobs/hour today
+- **Speedup:** 7-10× CI throughput
+- **Cost:** $0 incremental (operator's hardware) + ~$38/mo GitHub platform fee
+  per the March-2026 pricing change
+
+## Failure modes
+
+| Scenario | Behaviour | Mitigation |
+| --- | --- | --- |
+| One runner crashes mid-job | systemd respawns; GitHub re-queues | none needed (designed) |
+| All runners stalled | New jobs queue indefinitely | manual: re-point critical workflows to `ubuntu-latest` |
+| Stolution disk fills | Runner jobs fail at checkout | `runner-pool-health.yml` detects at 85%; alarm at 90% |
+| Stolution down | All self-hosted-tagged jobs queue | re-point to `ubuntu-latest` (manual or via Steward Gatekeeper proposed PR) |
+| Token rotation | Runners de-register | re-run `install-runner-pool.sh` with fresh token |
+
+## Token rotation
+
+Runner registration tokens have a short TTL (1 hour). The `.runner` file
+written during `config.sh` contains a long-lived runner credential, so the
+registration token is only needed at install time.
+
+For ongoing rotation (pool expansion, recovery from de-registration),
+fetch a fresh token from Vault each time. The Steward Gatekeeper has a
+weekly rotation policy (`stolution-rotate`) that refreshes the Vault entry.
+
+## See also
+
+- `docs/runner-runbook.md` — operator dashboard / health checks / common ops
+- `scripts/stolution/disk-cleanup.sh` — Tier 0 prerequisite
+- `velocity-acceleration-strategy-2026-05-06.md` — full strategy

--- a/infra/stolution/systemd/actions.runner.caia.service.template
+++ b/infra/stolution/systemd/actions.runner.caia.service.template
@@ -1,0 +1,69 @@
+# systemd unit template for an ephemeral GitHub Actions runner.
+#
+# One copy of this file is installed per runner instance, with @N expanded
+# at install time (see scripts/stolution/install-runner-pool.sh). The
+# install script renders this template into:
+#
+#   /etc/systemd/system/actions.runner.caia-1.service
+#   /etc/systemd/system/actions.runner.caia-2.service
+#   ...
+#   /etc/systemd/system/actions.runner.caia-N.service
+#
+# Reference: velocity-acceleration-strategy-2026-05-06.md §A.2 (Story 1.1-2).
+#
+# Ephemeral semantics:
+#   - run.sh --once exits cleanly after a single job
+#   - Restart=always + RestartSec=5 has systemd respawn the runner with a
+#     freshly-cleaned working tree
+#   - Each runner has its own _work directory under
+#     /home/s903/actions-runner-N/, avoiding cross-runner collision
+#
+# Labels: self-hosted, stolution, caia, linux
+
+[Unit]
+Description=GitHub Actions Runner caia-__N__
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=s903
+WorkingDirectory=/home/s903/actions-runner-__N__
+
+# Each runner exits after one job (--once). systemd respawns with a clean
+# working tree. RestartSec gives the runner registration token time to
+# refresh between cycles.
+ExecStart=/home/s903/actions-runner-__N__/run.sh --once
+Restart=always
+RestartSec=5
+
+# Resource isolation. With 16 runners on 72 cores + 251 GB RAM, each
+# runner gets generous limits but cannot starve the host.
+CPUQuota=400%
+MemoryLimit=16G
+TasksMax=4096
+
+# Environment. RUNNER_NAME is set so the runner identifies itself in
+# the GitHub Actions UI; RUNNER_LABELS is read by run.sh on first
+# registration but is informational once the runner is registered.
+Environment="RUNNER_NAME=caia-stolution-__N__"
+Environment="RUNNER_LABELS=self-hosted,stolution,caia,linux"
+Environment="RUNNER_ALLOW_RUNASROOT=0"
+
+# Hardening
+ProtectSystem=full
+ProtectHome=false
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictRealtime=true
+
+# Logs
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=actions-runner-caia-__N__
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/stolution/install-runner-pool.sh
+++ b/scripts/stolution/install-runner-pool.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Install the self-hosted GitHub Actions runner pool on stolution.
+#
+# Reference: velocity-acceleration-strategy-2026-05-06.md §4.4, §A.2.
+#
+# Deploys N ephemeral runners as systemd services, each with its own
+# /home/s903/actions-runner-{N}/ directory, registered against the
+# `prakashgbid` org with labels: self-hosted, stolution, caia, linux.
+#
+# Prerequisites:
+#   - Disk at ≤80% (run scripts/stolution/disk-cleanup.sh first)
+#   - GitHub Actions runner registration token, fetched from Vault at
+#     secret/stolution/prod/infrastructure/github_runner_registration_token
+#     (or passed via $GITHUB_RUNNER_TOKEN env var)
+#   - Network egress to api.github.com:443 and pipelines.actions.githubusercontent.com:443
+#   - sudo for systemctl (one-time install only)
+#
+# Operator workflow:
+#   1. Run scripts/stolution/disk-cleanup.sh and verify ≤80%
+#   2. Fetch a runner registration token (operator-side; via vault helper or GitHub UI)
+#   3. ssh stolution
+#   4. export GITHUB_RUNNER_TOKEN=<token>
+#   5. RUNNER_COUNT=2 bash scripts/stolution/install-runner-pool.sh   # ramp 2 → 4 → 8
+#   6. Verify with `systemctl list-units 'actions.runner.caia-*'`
+#   7. Confirm runners visible in GitHub Settings → Actions → Runners
+
+set -euo pipefail
+
+RUNNER_VERSION="${RUNNER_VERSION:-2.334.0}"
+RUNNER_COUNT="${RUNNER_COUNT:-2}"
+RUNNER_USER="${RUNNER_USER:-s903}"
+RUNNER_HOME_BASE="/home/${RUNNER_USER}"
+ORG_NAME="${GITHUB_ORG:-prakashgbid}"
+RUNNER_GROUP="${RUNNER_GROUP:-default}"
+TEMPLATE_PATH="${TEMPLATE_PATH:-infra/stolution/systemd/actions.runner.caia.service.template}"
+DRY_RUN="${DRY_RUN:-true}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--execute] [--count N] [--user USER] [--org ORG]
+
+  --execute     Actually install and enable the runners (default: dry-run)
+  --count N     Number of runners to install (default: 2; ramp 2→4→8 over a week)
+  --user USER   Linux user to own the runners (default: s903)
+  --org ORG     GitHub org to register against (default: prakashgbid)
+
+Environment:
+  GITHUB_RUNNER_TOKEN   Required for --execute. Obtain from Vault at
+                        secret/stolution/prod/infrastructure/github_runner_registration_token
+                        or from GitHub Settings → Actions → Runners → New runner.
+  RUNNER_VERSION        Default: ${RUNNER_VERSION}.
+
+Reference: velocity-acceleration-strategy-2026-05-06.md §4.4, §A.2.
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --execute) DRY_RUN=false; shift ;;
+    --count) RUNNER_COUNT="$2"; shift 2 ;;
+    --user) RUNNER_USER="$2"; RUNNER_HOME_BASE="/home/${RUNNER_USER}"; shift 2 ;;
+    --org) ORG_NAME="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "::error::unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '[install-runner-pool] %s\n' "$*"; }
+banner() { printf '\n=== %s ===\n' "$*"; }
+
+run_or_dry() {
+  if "$DRY_RUN"; then log "DRY-RUN: $*"; else log "EXEC: $*"; eval "$@"; fi
+}
+
+# ─── preconditions ─────────────────────────────────────────────────────────
+
+banner "preconditions"
+log "host:           $(hostname)"
+log "runner-version: ${RUNNER_VERSION}"
+log "runner-count:   ${RUNNER_COUNT}"
+log "runner-user:    ${RUNNER_USER}"
+log "github-org:     ${ORG_NAME}"
+log "template:       ${TEMPLATE_PATH}"
+
+if [ ! -f "$TEMPLATE_PATH" ]; then
+  echo "::error::missing systemd template: $TEMPLATE_PATH" >&2
+  echo "  (run from the repository root)" >&2
+  exit 1
+fi
+
+if ! "$DRY_RUN"; then
+  if [ -z "${GITHUB_RUNNER_TOKEN:-}" ]; then
+    echo "::error::GITHUB_RUNNER_TOKEN not set" >&2
+    echo "  Fetch via:  vault read -field=token secret/stolution/prod/infrastructure/github_runner_registration_token" >&2
+    echo "  Or via GitHub UI: Settings → Actions → Runners → New self-hosted runner" >&2
+    exit 1
+  fi
+fi
+
+# Disk check — refuse to run if disk is dangerously full
+USE_PCT=$(df --output=pcent / | tail -1 | tr -d ' %')
+log "current disk use: ${USE_PCT}%"
+if [ "$USE_PCT" -gt 85 ]; then
+  echo "::error::disk at ${USE_PCT}% — run scripts/stolution/disk-cleanup.sh first" >&2
+  exit 2
+fi
+
+# ─── 1. download runner tarball once ───────────────────────────────────────
+
+banner "1. download runner tarball"
+TARBALL="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+TARBALL_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}"
+
+if [ ! -f "/tmp/${TARBALL}" ]; then
+  run_or_dry "curl -sSL -o /tmp/${TARBALL} ${TARBALL_URL}"
+else
+  log "tarball already present at /tmp/${TARBALL}"
+fi
+
+# ─── 2. install N runner instances ─────────────────────────────────────────
+
+for n in $(seq 1 "${RUNNER_COUNT}"); do
+  banner "2.${n} install runner caia-${n}"
+
+  RUNNER_DIR="${RUNNER_HOME_BASE}/actions-runner-${n}"
+  RUNNER_NAME="caia-stolution-${n}"
+
+  # 2a. unpack into per-runner directory
+  if [ ! -d "$RUNNER_DIR" ]; then
+    run_or_dry "mkdir -p '$RUNNER_DIR'"
+    run_or_dry "tar xzf '/tmp/${TARBALL}' -C '$RUNNER_DIR'"
+  else
+    log "$RUNNER_DIR already exists; skipping unpack"
+  fi
+
+  # 2b. configure (registers with GitHub org)
+  if [ ! -f "${RUNNER_DIR}/.runner" ]; then
+    run_or_dry "cd '$RUNNER_DIR' && ./config.sh \
+      --unattended \
+      --url 'https://github.com/${ORG_NAME}' \
+      --token \"\$GITHUB_RUNNER_TOKEN\" \
+      --name '$RUNNER_NAME' \
+      --runnergroup '${RUNNER_GROUP}' \
+      --labels 'self-hosted,stolution,caia,linux' \
+      --work _work \
+      --replace"
+  else
+    log "${RUNNER_DIR}/.runner already exists; runner already registered"
+  fi
+
+  # 2c. render systemd unit
+  UNIT_PATH="/etc/systemd/system/actions.runner.caia-${n}.service"
+  TMP_UNIT="/tmp/actions.runner.caia-${n}.service"
+  sed "s/__N__/${n}/g" "$TEMPLATE_PATH" > "$TMP_UNIT"
+  run_or_dry "sudo install -m 0644 '$TMP_UNIT' '$UNIT_PATH'"
+
+  # 2d. enable + start
+  run_or_dry "sudo systemctl daemon-reload"
+  run_or_dry "sudo systemctl enable --now actions.runner.caia-${n}.service"
+done
+
+# ─── 3. verify ─────────────────────────────────────────────────────────────
+
+banner "3. verify"
+if "$DRY_RUN"; then
+  log "DRY-RUN: skipping verification"
+  exit 0
+fi
+
+systemctl list-units 'actions.runner.caia-*.service' --no-pager
+log "expected runners visible in GitHub Settings → Actions → Runners"
+log "DONE"


### PR DESCRIPTION
## Summary

Adds infrastructure and operator documentation for the Tier 1.1 self-hosted GitHub Actions runner pool on stolution. **No workflow migration in this PR** — existing workflows continue on `ubuntu-latest`. The actual migration (changing `runs-on:` from `ubuntu-latest` to `[self-hosted, stolution, caia, linux]`) lands in a follow-up PR after the pool has soaked for 48 hours.

## What lands here

- **`infra/stolution/systemd/actions.runner.caia.service.template`** — systemd unit template (rendered per-runner with `__N__` substitution). Ephemeral semantics (`run.sh --once` + systemd respawn), resource caps (`CPUQuota=400%`, `MemoryLimit=16G`), hardening (`ProtectSystem=full`, `NoNewPrivileges=true`, `PrivateTmp=true`).
- **`scripts/stolution/install-runner-pool.sh`** — install + register N runners against the `prakashgbid` org with labels `self-hosted, stolution, caia, linux`. Idempotent. Disk pre-flight refuses if usage > 85%. Dry-run by default.
- **`.github/workflows/runner-pool-health.yml`** — every 15 min, pings the pool, asserts disk ≤90%, memory, docker reachability. Failure at >90% disk; warning at >85%.
- **`docs/self-hosted-runners.md`** — install runbook, capacity plan, migration order, failure modes.
- **`docs/runner-runbook.md`** — operator dashboard, common ops (restart, drain, deregister), alarm response.

## Speedup (when pool is migrated)

**5-10× CI throughput.** 8 runners × 3-5 min average = ~96 jobs/hour vs ubuntu-latest queue's ~10-15 today.

## Cost

$0 incremental (operator hardware) + ~$38/mo GitHub platform fee per March-2026 pricing change.

## Reliability

★ low. Each runner is ephemeral (clean working tree per job), respawned by systemd. `ubuntu-latest` remains the fallback; if the pool fails, individual workflows can be re-pointed back via a one-line edit. `runner-pool-health.yml` flags 3+ consecutive failures to Steward Gatekeeper for automatic fallback-PR proposal.

## Prerequisites for execution

1. Tier 0 disk cleanup complete (PR `velocity-tier0-001`, #381)
2. stolution sshd reachable (currently intermittent as of 2026-05-06; see status report at `~/Documents/projects/reports/stolution-disk-cleanup-2026-05-06.md`)
3. Runner registration token in Vault at `secret/stolution/prod/infrastructure/github_runner_registration_token`

## Reference

`velocity-acceleration-strategy-2026-05-06.md` §4.4, §A.2. Tier 1.1 of the velocity acceleration plan; PR 2 of 5 in the campaign.

## Evidence

- [x] Shell syntax check passes (`bash -n install-runner-pool.sh`)
- [x] YAML parses (`yaml.safe_load` against runner-pool-health.yml)
- [x] systemd unit template uses `__N__` placeholder for sed substitution (no shell expansion in template)
- [x] Changeset filed
- [x] Migration to `runs-on: [self-hosted, ...]` deferred to follow-up PR
