### PR TITLE
feat(librarian): mem0 backend swap behind interface — default-flip

### DIFF
--- a/.changeset/feat-librarian-mem0-004-default-flip.md
+++ b/.changeset/feat-librarian-mem0-004-default-flip.md
@@ -1,0 +1,40 @@
+---
+"@chiefaia/librarian": minor
+---
+
+feat(librarian-mem0-004): flip default backend from `sqlite-vec` to `mem0`
+
+Phase-2 default-flip for Librarian's pluggable memory backend. The
+implementation has shipped behind a flag since PR #369 (2026-05-06)
+and the A/B harness in PR #370 measured Mem0 winning 7/10 top-1 hits
+vs sqlite-vec's 3/10 on the live 286-file CAIA corpus. Latency is
+~6× higher (avg 190ms / p95 307ms vs 30ms / 44ms) but well under the
+1-2 second pre-spawn budget. Hard constraints all hold: no Anthropic
+API key, no OpenAI API key, no per-token billing. Markdown remains
+source of truth.
+
+**What changes**
+
+- `DEFAULT_BACKEND` in `packages/librarian/src/backends/types.ts`
+  flips from `'sqlite-vec'` → `'mem0'`. Callers that don't pass a
+  `backend` flag now route to the Mem0 dispatcher.
+- `'sqlite-vec'` remains a fully-supported opt-in backend for tests
+  and rollback. Phase-1 code is not removed.
+- Test `mem0-backend.test.ts` adds a parity smoke test exercising
+  build → retrieve → prepend on BOTH backends and asserting the
+  result shapes are structurally compatible (same `RetrievedPrecedent`
+  keys, same preamble header, same `PrependPrecedentResult` shape).
+
+**Operator authorization**
+
+Per `feedback_validation_decisions_2026-05-06.md` decision #4
+("Mem0 swap baked into Librarian Phase 2") and the 2026-05-08
+"scaling forward" directive.
+
+**Re-evaluation triggers** (any one fires → revert default to
+`'sqlite-vec'`):
+
+- Mem0 v3.x ships a schema-breaking change.
+- Operator's day-to-day usage shows >2 missed top-1 retrievals out of
+  any 10-query window.
+- Latency p95 grows past 500ms at corpus scale.

--- a/packages/librarian/src/backends/types.ts
+++ b/packages/librarian/src/backends/types.ts
@@ -5,17 +5,18 @@
  *
  * Two backends are supported:
  *
- *   - `'sqlite-vec'`  (default) — Librarian Phase-1's existing
- *     better-sqlite3 + JS-side cosine implementation. Named
- *     `'sqlite-vec'` in the user-facing flag for consistency with the
- *     campaign brief; the actual implementation does NOT use the
- *     sqlite-vec extension.
+ *   - `'sqlite-vec'` — Librarian Phase-1's existing better-sqlite3 +
+ *     JS-side cosine implementation. Named `'sqlite-vec'` in the
+ *     user-facing flag for consistency with the campaign brief; the
+ *     actual implementation does NOT use the sqlite-vec extension.
+ *     Retained as an opt-in for tests and rollback.
  *
- *   - `'mem0'` — Mem0 OSS Node.js (`mem0ai/oss`). Configured with
- *     `infer: false` (no LLM round-trip) + Ollama embedder + `'memory'`
- *     vector-store provider (which is misleadingly named — it is
- *     actually better-sqlite3 + JS-side cosine, with a different
- *     schema from Librarian Phase-1).
+ *   - `'mem0'`  (default since Phase 2 default-flip, 2026-05-08) —
+ *     Mem0 OSS Node.js (`mem0ai/oss`). Configured with `infer: false`
+ *     (no LLM round-trip) + Ollama embedder + `'memory'` vector-store
+ *     provider (which is misleadingly named — it is actually
+ *     better-sqlite3 + JS-side cosine, with a different schema from
+ *     Librarian Phase-1).
  *
  * Both backends honour the same hard constraints from
  * `feedback_no_api_key_billing.md` — no Anthropic API key, no OpenAI
@@ -28,18 +29,23 @@
  */
 
 /**
- * The user-facing backend choice flag. `'sqlite-vec'` is the
- * Librarian Phase-1 default; `'mem0'` is the new Mem0-backed option
- * shipped per validation decision #4.
+ * The user-facing backend choice flag. `'mem0'` is the
+ * default since the Phase 2 default-flip on 2026-05-08 (operator
+ * "scaling forward" authorization, per
+ * `feedback_validation_decisions_2026-05-06.md`). `'sqlite-vec'` is
+ * kept available as an opt-in fallback / rollback.
  */
 export type LibrarianBackendName = 'sqlite-vec' | 'mem0';
 
 /**
- * Default backend when callers don't supply one. Stays `'sqlite-vec'`
- * for backwards compatibility until A/B parity is confirmed and the
- * operator explicitly approves a default-flip.
+ * Default backend when callers don't supply one. Flipped from
+ * `'sqlite-vec'` to `'mem0'` on 2026-05-08 after the A/B harness
+ * (PR #370) confirmed Mem0 won 7/10 vs sqlite-vec's 3/10 on the live
+ * 286-file CAIA corpus, with latency well under the 1-2 sec
+ * pre-spawn budget. Re-evaluation triggers documented in
+ * `feedback_validation_decisions_2026-05-06.md` (decision #4).
  */
-export const DEFAULT_BACKEND: LibrarianBackendName = 'sqlite-vec';
+export const DEFAULT_BACKEND: LibrarianBackendName = 'mem0';
 
 /**
  * Type guard for the runtime CLI parser. Returns true if `v` is a

--- a/packages/librarian/tests/backends/mem0-backend.test.ts
+++ b/packages/librarian/tests/backends/mem0-backend.test.ts
@@ -72,7 +72,11 @@ describe('isLibrarianBackendName', () => {
     expect(isLibrarianBackendName(42)).toBe(false);
   });
   it('exposes a sane default', () => {
-    expect(DEFAULT_BACKEND).toBe('sqlite-vec');
+    // 2026-05-08: default flipped from 'sqlite-vec' to 'mem0' after
+    // A/B parity (Mem0 won 7/10 vs sqlite-vec 3/10) and operator
+    // "scaling forward" authorization. See
+    // feedback_validation_decisions_2026-05-06.md decision #4.
+    expect(DEFAULT_BACKEND).toBe('mem0');
   });
 });
 
@@ -425,6 +429,165 @@ describe('dispatcher: backend flag', () => {
       expect(r.augmentedPrompt).toBe('totally unrelated zzqxxq');
       expect(r.precedent).toEqual([]);
       expect(r.preambleLength).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+/**
+ * Phase-2 default-flip parity smoke test (2026-05-08).
+ *
+ * Per the Phase-2 brief: "write a small integration test that proves
+ * both backends pass the same suite of operations." The two backends
+ * have separate test surfaces elsewhere — this suite runs the same
+ * sequence of build → retrieve → prepend operations against BOTH
+ * backends back-to-back and asserts the result shapes are
+ * structurally compatible (same `RetrievedPrecedent` keys, same
+ * preamble format, same prompt-augmentation semantics).
+ *
+ * Similarity scores are NOT compared across backends — Mem0's
+ * `MemoryVectorStore` uses unnormalized cosine similarity while the
+ * Phase-1 path uses normalized cosine. Callers comparing across
+ * backends should use rank order, not raw scores.
+ *
+ * Both backends are exercised offline:
+ *   - sqlite-vec via a deterministic `embed` stub.
+ *   - Mem0 via the same `createFakeMemory` fixture used elsewhere.
+ *
+ * No Ollama, no network, no API keys.
+ */
+describe('parity smoke: same operations across both backends', () => {
+  // Deterministic embed stub for the sqlite-vec backend. Returns a
+  // stable 768-dim zero vector — sqlite-vec's Phase-1 retrieve will
+  // match all rows at similarity 0, which is fine for this smoke test
+  // because we only assert structural shape (not score order).
+  const stubEmbed = async (): Promise<{ vector: Float32Array; model: string }> => ({
+    vector: new Float32Array(768),
+    model: 'parity-stub'
+  });
+
+  it('build → retrieve → prepend produces structurally compatible outputs on both backends', async () => {
+    // Set up a fresh corpus directory used by BOTH backends.
+    const tmp = mkdtempSync(join(tmpdir(), 'librarian-parity-'));
+    const memoryDir = join(tmp, 'memory');
+    mkdirSync(memoryDir, { recursive: true });
+    writeFileSync(
+      join(memoryDir, 'mentor_agent_directive.md'),
+      'mentor agent topic — pre-spawn injection rules'
+    );
+
+    const fake = createFakeMemory({ dimension: 32 });
+    const mem0 = new Mem0Backend({
+      memoryDir,
+      userId: 'parity-fixture',
+      memoryFactory: () => fake
+    });
+
+    try {
+      // ---- BUILD ----
+      const sqliteStats = await buildIndexWithBackend({
+        memoryDir,
+        embed: stubEmbed,
+        log: () => undefined,
+        backend: 'sqlite-vec'
+      });
+      const mem0Stats = await buildIndexWithBackend({
+        memoryDir,
+        embed: stubEmbed,  // unused on the mem0 path
+        log: () => undefined,
+        backend: 'mem0',
+        mem0: { backend: mem0 }
+      });
+
+      // Both backends scan the same number of files and report the
+      // same per-kind counts shape (BuildIndexStats).
+      expect(sqliteStats.scanned).toBe(1);
+      expect(mem0Stats.scanned).toBe(1);
+      expect(sqliteStats.embeddedNew).toBe(1);
+      expect(mem0Stats.embeddedNew).toBe(1);
+      // Same key shape on the result objects.
+      expect(Object.keys(sqliteStats).sort()).toEqual(
+        Object.keys(mem0Stats).sort()
+      );
+
+      // ---- RETRIEVE ----
+      const sqliteHits = await retrieveWithBackend('mentor agent', {
+        memoryDir,
+        backend: 'sqlite-vec',
+        embed: stubEmbed,
+        topN: 5,
+        minSimilarity: 0
+      });
+      const mem0Hits = await retrieveWithBackend('mentor agent', {
+        memoryDir,
+        backend: 'mem0',
+        topN: 5,
+        minSimilarity: 0,
+        mem0: { backend: mem0 }
+      });
+
+      // Both backends found the doc.
+      expect(sqliteHits.length).toBeGreaterThan(0);
+      expect(mem0Hits.length).toBeGreaterThan(0);
+      // Same RetrievedPrecedent key shape on every row.
+      const sqliteKeys = Object.keys(sqliteHits[0] ?? {}).sort();
+      const mem0Keys = Object.keys(mem0Hits[0] ?? {}).sort();
+      expect(sqliteKeys).toEqual(mem0Keys);
+      // Both surface the corpus slug we wrote.
+      expect(sqliteHits.some((r) => r.slug === 'mentor_agent_directive')).toBe(true);
+      expect(mem0Hits.some((r) => r.slug === 'mentor_agent_directive')).toBe(true);
+
+      // ---- PREPEND ----
+      const sqlitePrepended = await prependWithBackend('mentor agent', {
+        memoryDir,
+        backend: 'sqlite-vec',
+        embed: stubEmbed,
+        topN: 5,
+        minSimilarity: 0
+      });
+      const mem0Prepended = await prependWithBackend('mentor agent', {
+        memoryDir,
+        backend: 'mem0',
+        topN: 5,
+        minSimilarity: 0,
+        mem0: { backend: mem0 }
+      });
+
+      // Both augmented the prompt.
+      expect(sqlitePrepended.augmented).toBe(true);
+      expect(mem0Prepended.augmented).toBe(true);
+      // Both used the byte-identical preamble header.
+      const HEADER = 'Precedent from prior decisions — for context:';
+      expect(sqlitePrepended.augmentedPrompt.startsWith(HEADER)).toBe(true);
+      expect(mem0Prepended.augmentedPrompt.startsWith(HEADER)).toBe(true);
+      // Both preserve the original prompt at the tail.
+      expect(sqlitePrepended.augmentedPrompt.endsWith('mentor agent')).toBe(true);
+      expect(mem0Prepended.augmentedPrompt.endsWith('mentor agent')).toBe(true);
+      // PrependPrecedentResult key shape matches on both backends.
+      expect(Object.keys(sqlitePrepended).sort()).toEqual(
+        Object.keys(mem0Prepended).sort()
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('default backend (no explicit flag) routes to mem0 after Phase-2 default-flip', async () => {
+    const { backend, fake, memoryDir, cleanup } = buildBackendWithFake();
+    try {
+      writeFileSync(join(memoryDir, 'mentor_agent_directive.md'), 'topic');
+      // Omit `backend:` flag entirely — should route to DEFAULT_BACKEND.
+      const stats = await buildIndexWithBackend({
+        memoryDir,
+        embed: async () => ({ vector: new Float32Array(768), model: 'unused' }),
+        log: () => undefined,
+        mem0: { backend }
+      });
+      expect(stats.scanned).toBe(1);
+      // Confirm it landed in the mem0 fake (proves the default routed
+      // through the mem0 dispatcher, not the sqlite-vec dispatcher).
+      expect(fake.rows.size).toBe(1);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Phase 2 default-flip — `sqlite-vec` → `mem0`

Completes the Librarian Phase-2 Mem0 swap by flipping the default
backend. Implementation shipped behind a flag in PR #369; A/B harness
in PR #370 produced the verdict that justifies this flip.

### Why

A/B against the live 286-file CAIA corpus on 10 canonical queries
(see \`~/Documents/projects/reports/mem0-vs-sqlite-vec-ab-2026-05-06.md\`):

| metric | sqlite-vec (Phase-1) | mem0 (Phase-2) |
|---|---|---|
| top-1 relevant hits | 3 / 10 | **7 / 10** |
| avg latency | 30 ms | 190 ms |
| p95 latency | 44 ms | 307 ms |
| pre-spawn budget | 1–2 s | 1–2 s |

Mem0 wins on relevance by a clear margin; latency is ~6× higher but
well inside the pre-spawn budget. Verdict report:
\`mem0-swap-verdict-2026-05-06.md\`.

### What changes

- \`DEFAULT_BACKEND\` in \`packages/librarian/src/backends/types.ts\`
  flips \`'sqlite-vec'\` → \`'mem0'\`. Callers that omit \`backend:\` now
  route to the Mem0 dispatcher.
- \`'sqlite-vec'\` remains a fully-supported opt-in (Phase-1 code is
  preserved for tests and rollback).
- \`tests/backends/mem0-backend.test.ts\` gains a parity smoke test
  exercising build → retrieve → prepend on **both** backends and
  asserting structural-shape compatibility on \`RetrievedPrecedent\`,
  \`PrependPrecedentResult\`, and \`BuildIndexStats\`.
- Test count: 145 → **147** (all green).

### Hard constraints (all hold)

- No Anthropic API key.
- No OpenAI API key.
- No per-token billing — embeddings via local Ollama \`nomic-embed-text\`.
- Markdown remains source of truth (Mem0 stores 4 KB snippet + sha256;
  rebuild from \`agent/memory/*.md\` if the index is lost).
- mem0ai npm package is **Apache-2.0** licensed (verified in this PR).

### Re-evaluation triggers

Revert default to \`'sqlite-vec'\` if any fires:

- Mem0 v3.x ships a schema-breaking change.
- Operator's day-to-day usage shows > 2 missed top-1 retrievals in
  any 10-query window.
- Latency p95 grows past 500 ms at corpus scale.

### Operator authorization

\`feedback_validation_decisions_2026-05-06.md\` decision #4
("Mem0 swap baked into Librarian Phase 2") and the 2026-05-08
"scaling forward" directive.

### Refs

- #345 — Librarian Phase 1
- #368 — Mem0 DESIGN.md
- #369 — backend abstraction + Mem0 backend
- #370 — A/B harness + verdict
- This PR — default-flip

### Path B

Per \`path_b_admin_merge_campaign_2026-05-08.md\`: admin-merge if CI
passes.