### PR TITLE
feat(vastu-002): phase 2 text-to-doc real impl (T4.8)

### DIFF
--- a/packages/vastu/README.md
+++ b/packages/vastu/README.md
@@ -6,13 +6,22 @@ Private CAIA package. Text → formal page brief → Figma spec → Next.js scaf
 
 ## Status
 
-Phase 1 (T4.8) — skeleton + integration contract. Stages are stub implementations.
+Phase 2 (T4.8) — Stage A real implementation landed. Stages B and C remain stubs.
 
 | Stage | Module | Phase | Status |
 |---|---|---:|---|
-| A — text → formal doc | `src/text-to-doc.ts` | 2 | stub |
+| A — text → formal doc | `src/text-to-doc.ts` | 2 | ✅ real impl (heuristic regex pre-pass + local-LLM-router via Ollama, zero-dollar) |
 | B — formal doc → Figma spec | `src/doc-to-figma.ts` | 3 | stub (Stolution port pending) |
 | C — Figma spec → scaffold | `src/figma-to-scaffold.ts` | 4 | stub |
+
+### Stage A pipeline
+
+1. Heuristic regex pre-pass extracts URLs, emails, phone numbers, address lines, industry keywords (legal/saas/real-estate/restaurant/etc.) and section keywords (hero/features/pricing/faq/...) from the prose.
+2. The hints + raw prose are sent to a local Ollama model via `@chiefaia/local-llm-router` (`forceLocal: true`, `fallbackOnError: false` — zero-dollar gate).
+3. The LLM JSON output is validated against `FormalDocSchema` (Zod). On validation failure the call retries ONCE with a simpler prompt + minimal schema, then patches in heuristic + config defaults.
+4. A second failure throws `TextToDocLLMError` carrying both raw responses for triage.
+
+`origin` is `'hybrid'` when heuristic signals contributed and `'llm'` otherwise.
 
 ## Usage
 

--- a/packages/vastu/package.json
+++ b/packages/vastu/package.json
@@ -30,6 +30,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/local-llm-router": "workspace:*",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/vastu/src/formal-doc-schema.ts
+++ b/packages/vastu/src/formal-doc-schema.ts
@@ -1,0 +1,74 @@
+/**
+ * @chiefaia/vastu — Zod schemas for FormalDoc, used to validate LLM output.
+ *
+ * Kept in a separate file from `types.ts` so the type-first contracts stay
+ * clean (no Zod dependency in the public type surface) while we still get
+ * runtime validation at the Stage A / LLM boundary.
+ *
+ * The schema mirrors the `FormalDoc` interface from `./types.ts`. If the
+ * interface changes, update both. There's a TS-level structural check at
+ * the bottom of this file that fails compilation if the two drift.
+ */
+'use strict';
+
+import { z } from 'zod';
+import type { FormalDoc, FormalDocSection } from './types.js';
+
+export const FormalDocSectionSchema = z.object({
+  id: z.string().min(1),
+  section: z.string().min(1),
+  intent: z.string().min(1),
+  height: z.number().int().positive().optional(),
+  props: z.record(z.string(), z.unknown()).optional()
+});
+
+export const FormalDocOriginSchema = z.enum([
+  'heuristic',
+  'llm',
+  'hybrid',
+  'hand-authored',
+  'stub'
+]);
+
+export const FormalDocSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  audience: z.string().min(1),
+  brandVoice: z.string().optional(),
+  industry: z.string().optional(),
+  primaryCtas: z.array(z.string()).optional(),
+  sections: z.array(FormalDocSectionSchema).min(1),
+  origin: FormalDocOriginSchema,
+  metadata: z.record(z.string(), z.unknown()).optional()
+});
+
+/**
+ * Lighter schema used for the second-pass retry. Only the structurally
+ * required fields are enforced; everything else is patched in by the
+ * caller from heuristic hints + config defaults.
+ */
+export const FormalDocMinimalSchema = z.object({
+  sections: z
+    .array(
+      z.object({
+        section: z.string().min(1),
+        intent: z.string().min(1)
+      })
+    )
+    .min(1)
+});
+
+export type FormalDocMinimal = z.infer<typeof FormalDocMinimalSchema>;
+
+/* ─── Compile-time structural drift guard ─────────────────────────────── */
+/* If `FormalDoc` (in types.ts) drifts away from `FormalDocSchema`, these
+ * two `Equals` lines will fail to compile, alerting the developer to
+ * realign the two surfaces. */
+type _SchemaShape = z.infer<typeof FormalDocSchema>;
+type _SectionShape = z.infer<typeof FormalDocSectionSchema>;
+type _SchemaAssign = FormalDoc extends _SchemaShape ? true : never;
+type _SectionAssign = FormalDocSection extends _SectionShape ? true : never;
+const _schemaAssertion: _SchemaAssign = true;
+const _sectionAssertion: _SectionAssign = true;
+void _schemaAssertion;
+void _sectionAssertion;

--- a/packages/vastu/src/heuristics.ts
+++ b/packages/vastu/src/heuristics.ts
@@ -1,0 +1,236 @@
+/**
+ * @chiefaia/vastu — Stage A heuristic regex pre-pass.
+ *
+ * Extracts structured signals from raw input prose so the LLM enrichment
+ * step (text-to-doc.ts) doesn't have to re-discover them. All extraction is
+ * deterministic, zero-cost, and offline.
+ *
+ * The hints are passed:
+ *   - to the LLM as context (so it has stable, parsed values to work with)
+ *   - back to the caller via FormalDoc.metadata (so downstream stages
+ *     don't have to re-parse)
+ *
+ * Patterns are intentionally permissive — false positives are fine here
+ * because the LLM gets a chance to re-evaluate. False negatives are the
+ * thing to avoid.
+ */
+'use strict';
+
+export interface ExtractedHints {
+  /** http(s):// URLs and bare-domain references found in the prose. */
+  urls: string[];
+  /** Email addresses. */
+  emails: string[];
+  /** Phone numbers (NANP-shaped + international `+...` shapes). */
+  phones: string[];
+  /** Address-shaped lines (very loose — used as LLM hints, not parsed strictly). */
+  addresses: string[];
+  /**
+   * Inferred industry slugs derived from a small keyword vocabulary
+   * (e.g. ['legal', 'real-estate']).
+   */
+  industries: string[];
+  /**
+   * Section-name keywords extracted from the prose
+   * (e.g. ['hero', 'features', 'pricing']).
+   */
+  sectionKeywords: string[];
+}
+
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"']+/gi;
+const BARE_DOMAIN_PATTERN =
+  /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:com|net|org|io|co|ai|app|dev|gg|tv|news|biz|info|me|us|uk|ca|au|de|fr|jp)\b/gi;
+const EMAIL_PATTERN = /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b/gi;
+const PHONE_PATTERN =
+  /(?:\+?\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}/g;
+const ADDRESS_HINT_PATTERN =
+  /\d+\s+[A-Z][A-Za-z'.-]*(?:\s+[A-Z][A-Za-z'.-]*)*\s+(?:St(?:reet)?|Ave(?:nue)?|Rd|Road|Blvd|Boulevard|Lane|Ln|Drive|Dr|Way|Plaza|Square|Sq|Court|Ct)\b/g;
+
+/**
+ * Industry → keyword vocabulary. Order matters: earlier matches win
+ * in case of overlap (e.g. "law firm" wins over the bare "law" → 'legal').
+ */
+const INDUSTRY_KEYWORDS: Array<{ slug: string; patterns: RegExp[] }> = [
+  {
+    slug: 'legal',
+    patterns: [/\b(law\s*firm|attorney|lawyer|legal|counsel|litigation|paralegal)\b/i]
+  },
+  {
+    slug: 'real-estate',
+    patterns: [/\b(real\s*estate|realty|realtor|property|listings?|homes?\s*for\s*sale)\b/i]
+  },
+  {
+    slug: 'restaurant',
+    patterns: [/\b(restaurant|menu|bistro|cafe|café|eatery|kitchen|catering|chef)\b/i]
+  },
+  {
+    slug: 'e-commerce',
+    patterns: [/\b(e[-\s]?commerce|online\s*store|shop(?:ify)?|cart|checkout|sku|catalog)\b/i]
+  },
+  {
+    slug: 'healthcare',
+    patterns: [/\b(clinic|doctor|physician|hospital|medical|patient|telehealth|dentist)\b/i]
+  },
+  {
+    slug: 'education',
+    patterns: [/\b(school|university|college|tutor(?:ing)?|course|curriculum|edtech|classroom)\b/i]
+  },
+  {
+    slug: 'fintech',
+    patterns: [/\b(fintech|banking|trading|investment|crypto|wallet|portfolio|loan)\b/i]
+  },
+  {
+    slug: 'saas',
+    patterns: [/\b(saas|software\s*as\s*a\s*service|api|dashboard|webhook|subscription\s*plan)\b/i]
+  },
+  {
+    slug: 'gaming',
+    patterns: [/\b(game|gaming|gamers?|leaderboard|esports?|tournament|playable)\b/i]
+  },
+  {
+    slug: 'agency',
+    patterns: [/\b(agency|studio|consultanc(?:y|ies)|creative\s*shop)\b/i]
+  },
+  {
+    slug: 'portfolio',
+    patterns: [/\b(portfolio|case\s*stud(?:y|ies)|works?|showcase|projects?\s*gallery)\b/i]
+  },
+  {
+    slug: 'blog',
+    patterns: [/\b(blog|articles?|posts?|newsletter|column|writer)\b/i]
+  }
+];
+
+/**
+ * Section-keyword vocabulary. Match the prose against these to suggest
+ * sections to the LLM ("you mentioned a hero — output a hero section").
+ *
+ * The mapping value is the canonical kebab-case section keyword. The LLM
+ * decides the final `section` component name.
+ */
+const SECTION_KEYWORDS: Array<{ keyword: string; patterns: RegExp[] }> = [
+  { keyword: 'hero', patterns: [/\bhero\b/i, /\bbanner\b/i, /\bsplash\b/i] },
+  {
+    keyword: 'features',
+    patterns: [/\bfeatures?\b/i, /\bfeature\s*grid\b/i, /\bcards?\b/i, /\bbenefits?\b/i]
+  },
+  {
+    keyword: 'pricing',
+    patterns: [/\bpricing\b/i, /\bplans?\b/i, /\btiers?\b/i, /\bpackages?\b/i]
+  },
+  {
+    keyword: 'testimonials',
+    patterns: [/\btestimonials?\b/i, /\bquotes?\b/i, /\bcustomer\s*stor(?:y|ies)\b/i]
+  },
+  {
+    keyword: 'faq',
+    patterns: [/\bfaq\b/i, /\bfrequently\s*asked\b/i, /\bquestions?\b/i]
+  },
+  {
+    keyword: 'contact',
+    patterns: [/\bcontact\b/i, /\breach\s*us\b/i, /\bget\s*in\s*touch\b/i]
+  },
+  {
+    keyword: 'newsletter',
+    patterns: [/\bnewsletter\b/i, /\bsubscribe\b/i, /\bsign[-\s]*up\s*for\s*updates\b/i]
+  },
+  {
+    keyword: 'gallery',
+    patterns: [/\bgallery\b/i, /\bphotos?\b/i, /\bimages?\s*grid\b/i]
+  },
+  {
+    keyword: 'team',
+    patterns: [/\bteam\b/i, /\bmeet\s*the\s*team\b/i, /\bfounders?\b/i, /\bstaff\b/i]
+  },
+  { keyword: 'about', patterns: [/\babout\s*us\b/i, /\bour\s*stor(?:y|ies)\b/i, /\bmission\b/i] },
+  {
+    keyword: 'services',
+    patterns: [/\bservices?\b/i, /\bofferings?\b/i, /\bwhat\s*we\s*do\b/i]
+  },
+  {
+    keyword: 'cta',
+    patterns: [/\bcta\b/i, /\bcall\s*to\s*action\b/i, /\bsign\s*up\b/i, /\bget\s*started\b/i]
+  },
+  {
+    keyword: 'stats',
+    patterns: [/\bstats?\b/i, /\bnumbers?\b/i, /\bmetrics?\b/i, /\bby\s*the\s*numbers\b/i]
+  }
+];
+
+/**
+ * Run the full heuristic pre-pass over the input prose.
+ *
+ * All arrays are de-duplicated. Order is preserved as best-effort
+ * first-seen.
+ */
+export function extractHeuristics(inputText: string): ExtractedHints {
+  const text = inputText ?? '';
+  const urls = unique(matchAll(text, URL_PATTERN));
+  // Bare domains — but exclude ones already inside an http(s) URL match.
+  const bareDomains = unique(matchAll(text, BARE_DOMAIN_PATTERN)).filter(
+    (d) => !urls.some((u) => u.includes(d))
+  );
+  const allUrls = unique([...urls, ...bareDomains]);
+
+  const emails = unique(matchAll(text, EMAIL_PATTERN).map((e) => e.toLowerCase()));
+
+  const rawPhones = matchAll(text, PHONE_PATTERN)
+    .map((s) => s.trim())
+    // discard "phone-like" sequences that are clearly years, IDs etc.
+    .filter((s) => {
+      const digits = s.replace(/\D/g, '');
+      return digits.length >= 7 && digits.length <= 15;
+    });
+  const phones = unique(rawPhones);
+
+  const addresses = unique(matchAll(text, ADDRESS_HINT_PATTERN));
+
+  const industries: string[] = [];
+  for (const { slug, patterns } of INDUSTRY_KEYWORDS) {
+    if (patterns.some((p) => p.test(text))) {
+      industries.push(slug);
+    }
+  }
+
+  const sectionKeywords: string[] = [];
+  for (const { keyword, patterns } of SECTION_KEYWORDS) {
+    if (patterns.some((p) => p.test(text))) {
+      sectionKeywords.push(keyword);
+    }
+  }
+
+  return {
+    urls: allUrls,
+    emails,
+    phones,
+    addresses,
+    industries,
+    sectionKeywords
+  };
+}
+
+function matchAll(text: string, pattern: RegExp): string[] {
+  // Defensive: rebuild a fresh global regex so /g state from the source
+  // cannot leak between calls in a hot path.
+  const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.push(m[0]);
+    // safety against zero-width match infinite loops
+    if (m.index === re.lastIndex) re.lastIndex++;
+  }
+  return out;
+}
+
+function unique<T>(xs: T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/packages/vastu/src/heuristics.ts
+++ b/packages/vastu/src/heuristics.ts
@@ -210,15 +210,12 @@ export function extractHeuristics(inputText: string): ExtractedHints {
 }
 
 function matchAll(text: string, pattern: RegExp): string[] {
-  // Defensive: rebuild a fresh global regex so /g state from the source
-  // cannot leak between calls in a hot path.
-  const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
+  // All patterns above are built with the `g` flag. Use String.prototype.matchAll
+  // to avoid any /g lastIndex leakage between calls without dynamically
+  // rebuilding the RegExp (which trips semgrep's detect-non-literal-regexp rule).
   const out: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) {
+  for (const m of text.matchAll(pattern)) {
     out.push(m[0]);
-    // safety against zero-width match infinite loops
-    if (m.index === re.lastIndex) re.lastIndex++;
   }
   return out;
 }

--- a/packages/vastu/src/index.ts
+++ b/packages/vastu/src/index.ts
@@ -11,8 +11,18 @@
 export { runVastuPipeline } from './pipeline.js';
 export type { RunVastuPipelineOptions } from './pipeline.js';
 
-export { textToDoc } from './text-to-doc.js';
-export type { TextToDocOptions } from './text-to-doc.js';
+export { textToDoc, TextToDocLLMError } from './text-to-doc.js';
+export type { TextToDocOptions, RouteFn } from './text-to-doc.js';
+
+export { extractHeuristics } from './heuristics.js';
+export type { ExtractedHints } from './heuristics.js';
+
+export {
+  FormalDocSchema,
+  FormalDocSectionSchema,
+  FormalDocOriginSchema,
+  FormalDocMinimalSchema
+} from './formal-doc-schema.js';
 
 export { docToFigma, computeChecksum } from './doc-to-figma.js';
 export type { DocToFigmaOptions } from './doc-to-figma.js';

--- a/packages/vastu/src/pipeline.ts
+++ b/packages/vastu/src/pipeline.ts
@@ -2,12 +2,16 @@
  * @chiefaia/vastu — pipeline orchestrator.
  *
  * Public entry: `runVastuPipeline({ inputText, config, ... })`.
- * Composes Stages A → B → C left-to-right. Phase 1 stages are stubs but the
- * orchestrator + contract is real; downstream consumers can wire against this
- * API today and pick up the real behaviour as later phases land.
+ * Composes Stages A → B → C left-to-right.
+ *
+ * Phase 2 (T4.8): Stage A is now real (LLM-routed text→FormalDoc with
+ * heuristic regex pre-pass). Stages B and C remain Phase-1 stubs until
+ * Phases 3 and 4 land. The orchestrator + contract are stable; downstream
+ * consumers can wire against this API today and pick up the real
+ * behaviour as later phases land.
  */
 
-import { textToDoc } from './text-to-doc.js';
+import { textToDoc, type RouteFn } from './text-to-doc.js';
 import { docToFigma } from './doc-to-figma.js';
 import { figmaToScaffold } from './figma-to-scaffold.js';
 import type { VastuInput, VastuResult } from './types.js';
@@ -15,12 +19,24 @@ import type { VastuConfig } from './config.js';
 
 export interface RunVastuPipelineOptions extends VastuInput {
   config: VastuConfig;
+  /**
+   * Test seam — injected directly into Stage A. Defaults to the production
+   * router from @chiefaia/local-llm-router.
+   */
+  routeFn?: RouteFn;
 }
 
 export async function runVastuPipeline(opts: RunVastuPipelineOptions): Promise<VastuResult> {
-  const { inputText, formalDoc: providedDoc, pageId, config } = opts;
+  const { inputText, formalDoc: providedDoc, pageId, config, routeFn } = opts;
 
-  const formalDoc = providedDoc ?? (await textToDoc({ inputText, config, ...(pageId ? { pageId } : {}) }));
+  const formalDoc =
+    providedDoc ??
+    (await textToDoc({
+      inputText,
+      config,
+      ...(pageId ? { pageId } : {}),
+      ...(routeFn ? { routeFn } : {})
+    }));
   const figmaSpec = await docToFigma({ formalDoc, config });
   const scaffold = await figmaToScaffold({ figmaSpec, config });
 

--- a/packages/vastu/src/text-to-doc-prompt.ts
+++ b/packages/vastu/src/text-to-doc-prompt.ts
@@ -1,0 +1,129 @@
+/**
+ * @chiefaia/vastu — Stage A prompt templates.
+ *
+ * Two prompts:
+ *   - buildFullPrompt: first attempt. Asks the LLM for the full FormalDoc
+ *     shape with all the optional metadata (industry, primaryCtas, brandVoice).
+ *   - buildSimplifiedPrompt: retry attempt. Only asks for the structural
+ *     minimum (`sections: [{section, intent}]`). The orchestrator fills in
+ *     the rest from heuristic hints + config defaults.
+ *
+ * Both are deterministic strings — no LLM-side templating, no random
+ * sampling. The prompts intentionally over-explain the JSON contract
+ * because Ollama-served local models occasionally lapse into prose.
+ */
+'use strict';
+
+import type { ExtractedHints } from './heuristics.js';
+import type { VastuConfig } from './config.js';
+
+export interface PromptInputs {
+  inputText: string;
+  config: VastuConfig;
+  hints: ExtractedHints;
+  pageId: string;
+}
+
+const FULL_SCHEMA_DESC = `JSON schema (TypeScript):
+{
+  "id": string,
+  "name": string,
+  "audience": string,
+  "brandVoice"?: string,
+  "industry"?: string,
+  "primaryCtas"?: string[],
+  "sections": Array<{
+    "id": string,        // kebab-case, unique within the page
+    "section": string,   // canonical PascalCase component name (e.g. "HeroSection")
+    "intent": string,    // 1-3 sentences describing what the section does
+    "height"?: number,   // desktop pixel height; OMIT to use the default
+    "props"?: object     // free-form props (copy strings, links, etc.)
+  }>,
+  "origin": "llm",       // always "llm" — this is the Stage-A LLM output
+  "metadata"?: object
+}`;
+
+export function buildFullPrompt({ inputText, config, hints, pageId }: PromptInputs): string {
+  const hintsBlock = renderHintsBlock(hints);
+  const knownSections =
+    Object.keys(config.componentLibrary).length > 0
+      ? `Known component-library section names (prefer these when applicable):\n  ${Object.keys(
+          config.componentLibrary
+        )
+          .sort()
+          .join(', ')}`
+      : 'No pre-registered component library — pick descriptive PascalCase section names yourself (HeroSection, FeatureGrid, PricingTable, etc.).';
+
+  return [
+    'You are a website-architecture analyst. Convert the user prose into a strict JSON FormalDoc.',
+    '',
+    'Rules:',
+    `  • Output ONLY valid JSON. No prose, no markdown fences, no commentary.`,
+    `  • Use the page id "${pageId}" verbatim as the "id" field.`,
+    `  • "audience" defaults to "${config.brandVoice.audience}" if the prose doesn't specify one.`,
+    `  • "brandVoice" defaults to "${config.brandVoice.tone}" unless the prose contradicts it.`,
+    `  • Every section needs a kebab-case "id", a PascalCase "section" component name, and a 1-3 sentence "intent".`,
+    `  • Set "origin" to "llm".`,
+    `  • If you can identify them, populate "industry" with a short slug (e.g. "legal", "saas") and "primaryCtas" with the 1-3 user actions the page is steering toward.`,
+    '',
+    knownSections,
+    '',
+    FULL_SCHEMA_DESC,
+    '',
+    hintsBlock,
+    '',
+    'User prose (verbatim):',
+    '"""',
+    inputText.trim(),
+    '"""',
+    '',
+    'Respond with the JSON only.'
+  ].join('\n');
+}
+
+export function buildSimplifiedPrompt({ inputText, hints }: PromptInputs): string {
+  const hintsLine =
+    hints.sectionKeywords.length > 0
+      ? `Section keywords detected: ${hints.sectionKeywords.join(', ')}.`
+      : '';
+  return [
+    'Output ONLY valid JSON. No prose. No markdown fences.',
+    '',
+    'Schema:',
+    '  {"sections": [{"section": "PascalCaseComponentName", "intent": "1-3 sentences"}]}',
+    '',
+    'Each section MUST have a non-empty "section" and a non-empty "intent".',
+    'Produce at least one section. Prefer 3-6 sections for typical landing pages.',
+    hintsLine,
+    '',
+    'User prose:',
+    '"""',
+    inputText.trim(),
+    '"""',
+    '',
+    'JSON only.'
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+}
+
+function renderHintsBlock(hints: ExtractedHints): string {
+  const parts: string[] = ['Heuristic hints already extracted from the prose (use these verbatim — do not re-invent):'];
+  if (hints.urls.length > 0) parts.push(`  • urls: ${truncateList(hints.urls)}`);
+  if (hints.emails.length > 0) parts.push(`  • emails: ${truncateList(hints.emails)}`);
+  if (hints.phones.length > 0) parts.push(`  • phones: ${truncateList(hints.phones)}`);
+  if (hints.addresses.length > 0) parts.push(`  • addresses: ${truncateList(hints.addresses)}`);
+  if (hints.industries.length > 0) parts.push(`  • inferred industry: ${hints.industries.join(', ')}`);
+  if (hints.sectionKeywords.length > 0)
+    parts.push(`  • section-name hints: ${hints.sectionKeywords.join(', ')}`);
+  if (parts.length === 1) {
+    parts.push('  (none — work from the prose alone)');
+  }
+  return parts.join('\n');
+}
+
+function truncateList(xs: string[]): string {
+  const max = 6;
+  if (xs.length <= max) return xs.join(', ');
+  return `${xs.slice(0, max).join(', ')}, … (${xs.length - max} more)`;
+}

--- a/packages/vastu/src/text-to-doc.ts
+++ b/packages/vastu/src/text-to-doc.ts
@@ -1,61 +1,334 @@
 /**
- * Stage A — text → FormalDoc.
+ * Stage A — text → FormalDoc real implementation (Phase 2, T4.8).
  *
- * Phase 1 STUB. Phase 2 will wire this to:
- *   - heuristic section-name detection (regex over the prose)
- *   - LLM-routed structured-output extraction via @chiefaia/local-llm-router
- *   - merge of the two into a typed FormalDoc
+ * Pipeline:
+ *   1. Heuristic regex pre-pass extracts URLs / emails / phones / addresses /
+ *      industry hints / section-name keywords from the prose. Cheap +
+ *      deterministic. Result is attached to FormalDoc.metadata.heuristics.
+ *   2. LLM enrichment via @chiefaia/local-llm-router (Ollama-backed,
+ *      zero-dollar) produces a structured FormalDoc. The heuristic hints
+ *      are injected into the prompt so the LLM doesn't have to re-discover
+ *      them.
+ *   3. The LLM JSON output is parsed through `FormalDocSchema`. On parse
+ *      failure we retry ONCE with a simpler prompt + minimal schema, then
+ *      patch the heuristic + config defaults onto the result. A second
+ *      parse failure throws `TextToDocLLMError` carrying both raw responses
+ *      for triage.
  *
- * For Phase 1 the stub produces a deterministic single-section "stub" doc so
- * downstream stages compile and the pipeline contract is exercisable.
+ * Production wires the real `route()` from @chiefaia/local-llm-router.
+ * Tests inject `routeFn` to bypass Ollama entirely.
  */
+'use strict';
 
-import type { FormalDoc } from './types.js';
+import { route as defaultRoute } from '@chiefaia/local-llm-router';
+import type { LLMResponse, RouterOptions } from '@chiefaia/local-llm-router';
+
 import type { VastuConfig } from './config.js';
+import { extractHeuristics, type ExtractedHints } from './heuristics.js';
+import {
+  FormalDocMinimalSchema,
+  FormalDocSchema,
+  type FormalDocMinimal
+} from './formal-doc-schema.js';
+import { buildFullPrompt, buildSimplifiedPrompt } from './text-to-doc-prompt.js';
+import type { FormalDoc, FormalDocSection } from './types.js';
+
+/** Function shape compatible with `@chiefaia/local-llm-router#route`. */
+export type RouteFn = (
+  taskType: string,
+  prompt: string,
+  options?: RouterOptions
+) => Promise<LLMResponse>;
 
 export interface TextToDocOptions {
   inputText: string;
   config: VastuConfig;
   pageId?: string;
+  /** Test seam — defaults to the production router. */
+  routeFn?: RouteFn;
+  /** Override task-type used for routing. Default: 'vastu-text-to-doc'. */
+  taskType?: string;
 }
 
 /**
- * Produce a stub FormalDoc from the input text.
- *
- * The stub:
- *  - derives `id` from `pageId` or a short slug
- *  - puts the entire prose as a single section's intent
- *  - flags `origin: 'stub'` so callers know it isn't a real LLM extraction
- *
- * The function is intentionally synchronous in Phase 1; Phase 2's LLM call
- * will make it async. We keep the return type `Promise<FormalDoc>` already so
- * callers don't need to refactor when the implementation lands.
+ * Error surfaced when the LLM's structured output fails Zod validation
+ * twice in a row. Carries the raw responses so the caller (or a future
+ * Mentor probe) can triage the prompt.
  */
+export class TextToDocLLMError extends Error {
+  public readonly fullResponseRaw: string;
+  public readonly retryResponseRaw: string;
+  public readonly fullParseError: string;
+  public readonly retryParseError: string;
+  constructor(opts: {
+    message: string;
+    fullResponseRaw: string;
+    retryResponseRaw: string;
+    fullParseError: string;
+    retryParseError: string;
+  }) {
+    super(opts.message);
+    this.name = 'TextToDocLLMError';
+    this.fullResponseRaw = opts.fullResponseRaw;
+    this.retryResponseRaw = opts.retryResponseRaw;
+    this.fullParseError = opts.fullParseError;
+    this.retryParseError = opts.retryParseError;
+  }
+}
+
+const DEFAULT_TASK_TYPE = 'vastu-text-to-doc';
+
 export async function textToDoc(opts: TextToDocOptions): Promise<FormalDoc> {
-  const { inputText, config, pageId } = opts;
-  const trimmed = inputText.trim();
+  const { inputText, config, pageId: pageIdOverride } = opts;
+  const trimmed = inputText?.trim() ?? '';
   if (!trimmed) {
     throw new Error('textToDoc: inputText is empty');
   }
 
-  const id = pageId ?? (slugify(trimmed.slice(0, 40)) || 'page');
+  const pageId = pageIdOverride ?? deriveSlug(trimmed) ?? 'page';
+  const hints = extractHeuristics(trimmed);
 
-  return {
-    id,
-    name: humanise(id),
-    audience: config.brandVoice.audience,
-    brandVoice: config.brandVoice.tone,
-    sections: [
-      {
-        id: 'stub-section',
-        section: 'PlaceholderSection',
-        intent: trimmed,
-        height: config.defaultSectionHeight,
-        props: {}
-      }
-    ],
-    origin: 'stub'
+  // Tests inject a stub; production uses the real router.
+  const routeFn: RouteFn = opts.routeFn ?? defaultRoute;
+  const taskType = opts.taskType ?? DEFAULT_TASK_TYPE;
+
+  // ── Attempt 1 — full prompt ────────────────────────────────────────
+  const fullPrompt = buildFullPrompt({ inputText: trimmed, config, hints, pageId });
+  const fullResponse = await invokeRoute(routeFn, taskType, fullPrompt);
+  const fullParse = tryParseFormalDoc(fullResponse.response);
+
+  if (fullParse.ok) {
+    return finaliseDoc(fullParse.value, {
+      pageId,
+      hints,
+      config,
+      llmModel: fullResponse.model,
+      provider: fullResponse.provider,
+      attempt: 1
+    });
+  }
+
+  // ── Attempt 2 — simplified prompt + minimal schema ─────────────────
+  const simplifiedPrompt = buildSimplifiedPrompt({
+    inputText: trimmed,
+    config,
+    hints,
+    pageId
+  });
+  const retryResponse = await invokeRoute(routeFn, taskType, simplifiedPrompt);
+  const retryParse = tryParseMinimalDoc(retryResponse.response);
+
+  if (retryParse.ok) {
+    const reconstructed = reconstructFromMinimal(retryParse.value, {
+      pageId,
+      trimmedInput: trimmed,
+      hints,
+      config
+    });
+    return finaliseDoc(reconstructed, {
+      pageId,
+      hints,
+      config,
+      llmModel: retryResponse.model,
+      provider: retryResponse.provider,
+      attempt: 2
+    });
+  }
+
+  throw new TextToDocLLMError({
+    message:
+      'textToDoc: LLM output failed FormalDoc schema validation twice. ' +
+      'See fullParseError + retryParseError for details.',
+    fullResponseRaw: fullResponse.response,
+    retryResponseRaw: retryResponse.response,
+    fullParseError: fullParse.error,
+    retryParseError: retryParse.error
+  });
+}
+
+/* ─── Internals ─────────────────────────────────────────────────────── */
+
+interface FinaliseInputs {
+  pageId: string;
+  hints: ExtractedHints;
+  config: VastuConfig;
+  llmModel: string;
+  provider: string;
+  attempt: 1 | 2;
+}
+
+function finaliseDoc(doc: FormalDoc, info: FinaliseInputs): FormalDoc {
+  const sections = doc.sections.map((s, i) => ensureSectionShape(s, i, info.config));
+  const hasHeuristicSignal =
+    info.hints.urls.length > 0 ||
+    info.hints.emails.length > 0 ||
+    info.hints.phones.length > 0 ||
+    info.hints.addresses.length > 0 ||
+    info.hints.industries.length > 0 ||
+    info.hints.sectionKeywords.length > 0;
+  const origin: FormalDoc['origin'] = hasHeuristicSignal ? 'hybrid' : 'llm';
+
+  const metadata: Record<string, unknown> = {
+    ...(doc.metadata ?? {}),
+    heuristics: info.hints,
+    llm: {
+      model: info.llmModel,
+      provider: info.provider,
+      attempt: info.attempt
+    }
   };
+
+  const merged: FormalDoc = {
+    ...doc,
+    id: info.pageId,
+    name: doc.name && doc.name.trim() !== '' ? doc.name : humanise(info.pageId),
+    audience: doc.audience && doc.audience.trim() !== '' ? doc.audience : info.config.brandVoice.audience,
+    brandVoice: doc.brandVoice ?? info.config.brandVoice.tone,
+    sections,
+    origin,
+    metadata
+  };
+  if (info.hints.industries[0] && !merged.industry) {
+    merged.industry = info.hints.industries[0];
+  }
+  return merged;
+}
+
+function ensureSectionShape(
+  section: FormalDocSection,
+  index: number,
+  config: VastuConfig
+): FormalDocSection {
+  const id =
+    section.id && section.id.trim() !== ''
+      ? section.id.trim()
+      : `${slugify(section.section || `section-${index + 1}`)}-${index + 1}`;
+  return {
+    ...section,
+    id,
+    height: section.height ?? config.defaultSectionHeight
+  };
+}
+
+function reconstructFromMinimal(
+  minimal: FormalDocMinimal,
+  ctx: { pageId: string; trimmedInput: string; hints: ExtractedHints; config: VastuConfig }
+): FormalDoc {
+  const sections: FormalDocSection[] = minimal.sections.map((s, i) => ({
+    id: `${slugify(s.section)}-${i + 1}`,
+    section: s.section,
+    intent: s.intent,
+    height: ctx.config.defaultSectionHeight
+  }));
+  return {
+    id: ctx.pageId,
+    name: humanise(ctx.pageId),
+    audience: ctx.config.brandVoice.audience,
+    brandVoice: ctx.config.brandVoice.tone,
+    sections,
+    origin: 'llm'
+  };
+}
+
+interface ParseOk<T> {
+  ok: true;
+  value: T;
+}
+interface ParseErr {
+  ok: false;
+  error: string;
+}
+
+function tryParseFormalDoc(raw: string): ParseOk<FormalDoc> | ParseErr {
+  const json = extractJsonObject(raw);
+  if (json === null) {
+    return { ok: false, error: 'no-json-object-in-response' };
+  }
+  const result = FormalDocSchema.safeParse(json);
+  if (!result.success) {
+    return { ok: false, error: result.error.message.slice(0, 600) };
+  }
+  return { ok: true, value: result.data as FormalDoc };
+}
+
+function tryParseMinimalDoc(raw: string): ParseOk<FormalDocMinimal> | ParseErr {
+  const json = extractJsonObject(raw);
+  if (json === null) {
+    return { ok: false, error: 'no-json-object-in-response' };
+  }
+  const result = FormalDocMinimalSchema.safeParse(json);
+  if (!result.success) {
+    return { ok: false, error: result.error.message.slice(0, 600) };
+  }
+  return { ok: true, value: result.data };
+}
+
+/**
+ * Pull the first JSON object out of a raw LLM response. Tolerates:
+ *   - bare JSON
+ *   - JSON wrapped in ```json fences
+ *   - JSON preceded/followed by chatter
+ *
+ * Returns null if no balanced object is found.
+ */
+function extractJsonObject(raw: string): unknown {
+  if (!raw) return null;
+  // Strip code-fence wrappers (```json ... ``` or ``` ... ```).
+  let text = raw.trim();
+  const fence = /```(?:json)?\s*([\s\S]*?)\s*```/i.exec(text);
+  if (fence?.[1]) {
+    text = fence[1].trim();
+  }
+  // Find the first balanced top-level { ... } block.
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        const candidate = text.slice(start, i + 1);
+        try {
+          return JSON.parse(candidate) as unknown;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+async function invokeRoute(
+  routeFn: RouteFn,
+  taskType: string,
+  prompt: string
+): Promise<LLMResponse> {
+  // Zero-dollar gate: force local. The router falls back to the Claude
+  // binary by default for many task types; we want pure Ollama here.
+  return routeFn(taskType, prompt, { forceLocal: true, fallbackOnError: false });
+}
+
+function deriveSlug(text: string): string | null {
+  const slug = slugify(text.split(/[.\n!?]/, 1)[0]?.slice(0, 60) ?? '');
+  return slug || null;
 }
 
 function slugify(s: string): string {

--- a/packages/vastu/src/types.ts
+++ b/packages/vastu/src/types.ts
@@ -40,10 +40,16 @@ export interface FormalDoc {
   audience: string;
   /** Brand voice override — defaults to config.brandVoice if omitted. */
   brandVoice?: string;
+  /** Optional inferred industry slug (e.g. 'legal', 'real-estate', 'saas'). */
+  industry?: string;
+  /** Primary calls-to-action surfaced from the prose. */
+  primaryCtas?: string[];
   /** Ordered section list. */
   sections: FormalDocSection[];
   /** Provenance: how this doc was built (heuristic, llm, hybrid, hand-authored). */
   origin: 'heuristic' | 'llm' | 'hybrid' | 'hand-authored' | 'stub';
+  /** Free-form metadata (heuristic hints, LLM provenance, etc.). */
+  metadata?: Record<string, unknown>;
 }
 
 /* ───────────────── Stage B — FigmaSpec ───────────────── */

--- a/packages/vastu/tests/fixtures/mock-route.ts
+++ b/packages/vastu/tests/fixtures/mock-route.ts
@@ -1,0 +1,80 @@
+/**
+ * Test fixtures — mock LLM router for Stage A unit tests.
+ *
+ * Mimics the `route(taskType, prompt, options)` shape from
+ * @chiefaia/local-llm-router. Tests configure a queue of canned responses;
+ * the mock pops them in order.
+ */
+
+import type { LLMResponse, RouterOptions } from '@chiefaia/local-llm-router';
+
+export interface MockRouterCall {
+  taskType: string;
+  prompt: string;
+  options?: RouterOptions;
+}
+
+export interface MockRouter {
+  route: (taskType: string, prompt: string, options?: RouterOptions) => Promise<LLMResponse>;
+  calls: MockRouterCall[];
+}
+
+/**
+ * Build a mock router. Each call pops the next response from the queue.
+ *
+ * Each queued entry can be:
+ *   - a string  → wrapped into a default LLMResponse
+ *   - an LLMResponse object → returned verbatim
+ *   - an Error → thrown
+ */
+export function makeMockRouter(
+  responses: Array<string | LLMResponse | Error>
+): MockRouter {
+  const queue = [...responses];
+  const calls: MockRouterCall[] = [];
+
+  const route = async (
+    taskType: string,
+    prompt: string,
+    options?: RouterOptions
+  ): Promise<LLMResponse> => {
+    calls.push({ taskType, prompt, ...(options ? { options } : {}) });
+    if (queue.length === 0) {
+      throw new Error('makeMockRouter: queue empty — more calls than canned responses');
+    }
+    const next = queue.shift();
+    if (next instanceof Error) throw next;
+    if (typeof next === 'string') {
+      return {
+        response: next,
+        model: 'mock-qwen',
+        provider: 'local',
+        durationMs: 1
+      };
+    }
+    return next as LLMResponse;
+  };
+
+  return { route, calls };
+}
+
+/**
+ * Helper for the common case: a single happy-path response with a
+ * complete FormalDoc payload.
+ */
+export function happyDocResponse(extras: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    id: 'placeholder-id',
+    name: 'Placeholder Page',
+    audience: 'placeholder audience',
+    brandVoice: 'placeholder voice',
+    industry: 'saas',
+    primaryCtas: ['Sign up'],
+    sections: [
+      { id: 'hero-1', section: 'HeroSection', intent: 'Hero copy', height: 480 },
+      { id: 'features-2', section: 'FeatureGrid', intent: 'Three feature cards' }
+    ],
+    origin: 'llm',
+    ...extras
+  });
+}

--- a/packages/vastu/tests/pipeline.test.ts
+++ b/packages/vastu/tests/pipeline.test.ts
@@ -4,15 +4,19 @@ import { textToDoc } from '../src/text-to-doc.js';
 import { docToFigma, computeChecksum } from '../src/doc-to-figma.js';
 import { figmaToScaffold } from '../src/figma-to-scaffold.js';
 import { mockVastuConfig } from './fixtures/mock-config.js';
+import { happyDocResponse, makeMockRouter } from './fixtures/mock-route.js';
 
-describe('runVastuPipeline (Phase 1 stub contract)', () => {
+describe('runVastuPipeline (contract)', () => {
   it('returns formalDoc + figmaSpec + scaffold from raw inputText', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
     const result = await runVastuPipeline({
       inputText: 'A hero, three feature cards, and a newsletter signup.',
-      config: mockVastuConfig
+      config: mockVastuConfig,
+      routeFn: router.route
     });
 
-    expect(result.formalDoc.origin).toBe('stub');
+    // Phase 2 — origin is hybrid (heuristic signals + LLM) or llm.
+    expect(['llm', 'hybrid']).toContain(result.formalDoc.origin);
     expect(result.formalDoc.sections.length).toBeGreaterThan(0);
     expect(result.figmaSpec.frames.length).toBe(result.formalDoc.sections.length);
     expect(result.figmaSpec.writeStatus).toBe('dry-run');
@@ -20,10 +24,12 @@ describe('runVastuPipeline (Phase 1 stub contract)', () => {
   });
 
   it('honours pageId override', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
     const result = await runVastuPipeline({
       inputText: 'Content',
       config: mockVastuConfig,
-      pageId: 'custom-page-id'
+      pageId: 'custom-page-id',
+      routeFn: router.route
     });
     expect(result.formalDoc.id).toBe('custom-page-id');
     expect(result.figmaSpec.meta.pageId).toBe('custom-page-id');
@@ -68,18 +74,22 @@ describe('runVastuPipeline (Phase 1 stub contract)', () => {
   });
 });
 
-describe('textToDoc (Phase 1 stub)', () => {
+describe('textToDoc (smoke)', () => {
   it('throws on empty input', async () => {
     await expect(
-      textToDoc({ inputText: '   ', config: mockVastuConfig })
+      textToDoc({ inputText: '   ', config: mockVastuConfig, routeFn: makeMockRouter([]).route })
     ).rejects.toThrow();
   });
 
-  it('returns a single-section stub doc with origin=stub', async () => {
-    const doc = await textToDoc({ inputText: 'Hello world', config: mockVastuConfig });
-    expect(doc.origin).toBe('stub');
-    expect(doc.sections.length).toBe(1);
-    expect(doc.sections[0]?.intent).toBe('Hello world');
+  it('produces an llm/hybrid-origin doc with at least one section', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
+    const doc = await textToDoc({
+      inputText: 'Hello world',
+      config: mockVastuConfig,
+      routeFn: router.route
+    });
+    expect(['llm', 'hybrid']).toContain(doc.origin);
+    expect(doc.sections.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/vastu/tests/text-to-doc.test.ts
+++ b/packages/vastu/tests/text-to-doc.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Stage A — text-to-doc real-implementation tests (Phase 2, T4.8).
+ *
+ * Uses a mock router that mimics @chiefaia/local-llm-router#route, so tests
+ * are deterministic and never call out to Ollama.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { textToDoc, TextToDocLLMError } from '../src/text-to-doc.js';
+import { extractHeuristics } from '../src/heuristics.js';
+import { mockVastuConfig } from './fixtures/mock-config.js';
+import { happyDocResponse, makeMockRouter } from './fixtures/mock-route.js';
+
+describe('textToDoc — input guards', () => {
+  it('throws on empty input', async () => {
+    await expect(
+      textToDoc({ inputText: '   ', config: mockVastuConfig, routeFn: makeMockRouter([]).route })
+    ).rejects.toThrow(/empty/i);
+  });
+});
+
+describe('textToDoc — happy path (LLM produces valid FormalDoc on first try)', () => {
+  it('returns a hybrid-origin doc when heuristic signals are present', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
+
+    const doc = await textToDoc({
+      inputText: 'Visit https://lawfirm.example.com for a free consultation. Email us at hi@lawfirm.example.com or call (415) 555-0100.',
+      config: mockVastuConfig,
+      pageId: 'home',
+      routeFn: router.route
+    });
+
+    expect(doc.id).toBe('home');
+    expect(doc.origin).toBe('hybrid');
+    expect(doc.sections.length).toBeGreaterThan(0);
+    expect(doc.metadata?.heuristics).toBeDefined();
+    expect(doc.metadata?.llm).toMatchObject({ provider: 'local', attempt: 1 });
+    expect(router.calls.length).toBe(1);
+    // forceLocal must be set so the zero-dollar gate holds
+    expect(router.calls[0]?.options?.forceLocal).toBe(true);
+  });
+
+  it('returns origin=llm when no heuristic signal at all', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
+    const doc = await textToDoc({
+      inputText: 'Build me a thing.',
+      config: mockVastuConfig,
+      pageId: 'thing',
+      routeFn: router.route
+    });
+    // "thing" trips no industry/section keyword; URL/email/phone all absent.
+    expect(doc.origin).toBe('llm');
+  });
+
+  it('forces id to pageId override even when LLM picks a different id', async () => {
+    const llmJson = JSON.stringify({
+      id: 'whatever-the-llm-picked',
+      name: 'A Page',
+      audience: 'general',
+      sections: [{ id: 'a', section: 'HeroSection', intent: 'Hero' }],
+      origin: 'llm'
+    });
+    const router = makeMockRouter([llmJson]);
+    const doc = await textToDoc({
+      inputText: 'Tiny page',
+      config: mockVastuConfig,
+      pageId: 'override-id',
+      routeFn: router.route
+    });
+    expect(doc.id).toBe('override-id');
+    expect(doc.audience).toBe('general');
+  });
+
+  it('falls back to config defaults when retry path produces a minimal doc', async () => {
+    // First attempt: garbage. Second attempt: minimal schema (sections-only).
+    // Retry path should reconstruct, filling audience/brandVoice from config.
+    const minimalRetry = JSON.stringify({
+      sections: [{ section: 'HeroSection', intent: 'Hero' }]
+    });
+    const router = makeMockRouter(['nope', minimalRetry]);
+    const doc = await textToDoc({
+      inputText: 'Tiny page',
+      config: mockVastuConfig,
+      pageId: 'p',
+      routeFn: router.route
+    });
+    expect(doc.audience).toBe(mockVastuConfig.brandVoice.audience);
+    expect(doc.brandVoice).toBe(mockVastuConfig.brandVoice.tone);
+  });
+
+  it('strips ```json fences from LLM response', async () => {
+    const wrapped = '```json\n' + happyDocResponse() + '\n```';
+    const router = makeMockRouter([wrapped]);
+    const doc = await textToDoc({
+      inputText: 'Build a hero',
+      config: mockVastuConfig,
+      pageId: 'page',
+      routeFn: router.route
+    });
+    expect(doc.sections.length).toBeGreaterThan(0);
+  });
+});
+
+describe('textToDoc — retry on malformed LLM response', () => {
+  it('falls through to simplified prompt on garbage first response and succeeds', async () => {
+    const minimalResponse = JSON.stringify({
+      sections: [
+        { section: 'HeroSection', intent: 'Hero band' },
+        { section: 'FAQSection', intent: 'Frequently asked questions' }
+      ]
+    });
+    const router = makeMockRouter(['this is not json at all', minimalResponse]);
+
+    const doc = await textToDoc({
+      inputText: 'Show me a hero and an FAQ',
+      config: mockVastuConfig,
+      pageId: 'page',
+      routeFn: router.route
+    });
+
+    expect(router.calls.length).toBe(2);
+    expect(doc.sections.length).toBe(2);
+    expect(doc.sections[0]?.section).toBe('HeroSection');
+    expect(doc.metadata?.llm).toMatchObject({ attempt: 2 });
+    // Second prompt should be the simplified one — much shorter
+    expect(router.calls[1]?.prompt.length).toBeLessThan(router.calls[0]!.prompt.length);
+  });
+
+  it('retries when first response fails Zod schema (missing required fields)', async () => {
+    const malformed = JSON.stringify({ id: 'x', sections: [] }); // empty sections array
+    const minimal = JSON.stringify({
+      sections: [{ section: 'HeroSection', intent: 'Hero' }]
+    });
+    const router = makeMockRouter([malformed, minimal]);
+
+    const doc = await textToDoc({
+      inputText: 'Hero only',
+      config: mockVastuConfig,
+      routeFn: router.route
+    });
+    expect(doc.sections.length).toBe(1);
+    expect(doc.metadata?.llm).toMatchObject({ attempt: 2 });
+  });
+
+  it('throws TextToDocLLMError when both attempts fail to parse', async () => {
+    const router = makeMockRouter(['nope', 'still nope']);
+
+    await expect(
+      textToDoc({
+        inputText: 'Anything',
+        config: mockVastuConfig,
+        routeFn: router.route
+      })
+    ).rejects.toBeInstanceOf(TextToDocLLMError);
+
+    expect(router.calls.length).toBe(2);
+  });
+
+  it('TextToDocLLMError carries both raw responses for triage', async () => {
+    const router = makeMockRouter(['first garbage', 'second garbage']);
+    try {
+      await textToDoc({
+        inputText: 'x',
+        config: mockVastuConfig,
+        routeFn: router.route
+      });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(TextToDocLLMError);
+      const err = e as TextToDocLLMError;
+      expect(err.fullResponseRaw).toBe('first garbage');
+      expect(err.retryResponseRaw).toBe('second garbage');
+      expect(err.fullParseError.length).toBeGreaterThan(0);
+      expect(err.retryParseError.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('textToDoc — heuristic pre-pass', () => {
+  it('extractHeuristics finds URLs, emails, phones, addresses', () => {
+    const hints = extractHeuristics(
+      [
+        'Our practice is at 123 Main Street, San Francisco.',
+        'Call (415) 555-0100 or email contact@firm.example.com.',
+        'Visit https://firm.example.com for more.'
+      ].join(' ')
+    );
+    expect(hints.urls).toContain('https://firm.example.com');
+    expect(hints.emails).toContain('contact@firm.example.com');
+    expect(hints.phones.length).toBeGreaterThan(0);
+    expect(hints.addresses.length).toBeGreaterThan(0);
+  });
+
+  it('extractHeuristics infers industry from keywords', () => {
+    expect(extractHeuristics('We are a law firm.').industries).toContain('legal');
+    expect(extractHeuristics('Run my online store').industries).toContain('e-commerce');
+    expect(extractHeuristics('A tutoring platform for students').industries).toContain(
+      'education'
+    );
+    expect(extractHeuristics('Just a plain page').industries).toEqual([]);
+  });
+
+  it('extractHeuristics surfaces section keywords from the prose', () => {
+    const hints = extractHeuristics(
+      'A hero, three feature cards, a pricing table, and an FAQ section.'
+    );
+    expect(hints.sectionKeywords).toContain('hero');
+    expect(hints.sectionKeywords).toContain('features');
+    expect(hints.sectionKeywords).toContain('pricing');
+    expect(hints.sectionKeywords).toContain('faq');
+  });
+
+  it('extracted heuristics are attached to FormalDoc.metadata', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
+    const doc = await textToDoc({
+      inputText: 'Visit https://example.com — call (415) 555-1212',
+      config: mockVastuConfig,
+      pageId: 'p',
+      routeFn: router.route
+    });
+    const heuristics = doc.metadata?.heuristics as { urls: string[]; phones: string[] };
+    expect(heuristics.urls).toContain('https://example.com');
+    expect(heuristics.phones.length).toBeGreaterThan(0);
+  });
+
+  it('first inferred industry is promoted to FormalDoc.industry when LLM omits one', async () => {
+    const noIndustry = JSON.stringify({
+      id: 'p',
+      name: 'P',
+      audience: 'a',
+      sections: [{ id: 's', section: 'HeroSection', intent: 'h' }],
+      origin: 'llm'
+    });
+    const router = makeMockRouter([noIndustry]);
+    const doc = await textToDoc({
+      inputText: 'A law firm landing page',
+      config: mockVastuConfig,
+      pageId: 'p',
+      routeFn: router.route
+    });
+    expect(doc.industry).toBe('legal');
+  });
+});
+
+describe('textToDoc — prompt content sanity', () => {
+  it('embeds page id, audience default, and detected hints into the full prompt', async () => {
+    const router = makeMockRouter([happyDocResponse()]);
+    await textToDoc({
+      inputText: 'Restaurant landing page. Visit https://eatery.example.com',
+      config: mockVastuConfig,
+      pageId: 'home',
+      routeFn: router.route
+    });
+    const prompt = router.calls[0]!.prompt;
+    expect(prompt).toContain('home'); // page id
+    expect(prompt).toContain(mockVastuConfig.brandVoice.audience);
+    expect(prompt).toContain('https://eatery.example.com');
+    expect(prompt).toContain('restaurant'); // industry hint
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1990,6 +1990,9 @@ importers:
 
   packages/vastu:
     dependencies:
+      '@chiefaia/local-llm-router':
+        specifier: workspace:*
+        version: link:../local-llm-router
       zod:
         specifier: ^3.23.8
         version: 3.25.76


### PR DESCRIPTION
## Phase 2 — Stage A real implementation (T4.8 — vastu-002)

Phase 1 (PR #394, `d5ff28b`) shipped the `@chiefaia/vastu` skeleton + integration contract with a single-section `origin:'stub'` `textToDoc()`. Phase 2 replaces that stub with a real text→`FormalDoc` transformation.

### Architecture

```
inputText ──► [heuristic regex pre-pass]   ◄── deterministic, zero-cost
              ├─ urls, emails, phones
              ├─ addresses
              ├─ industry slugs   (legal, saas, real-estate, …)
              └─ section keywords (hero, features, pricing, faq, …)
                                ▼
              [@chiefaia/local-llm-router]
              forceLocal:true, fallbackOnError:false
              (Ollama only — zero-dollar gate)
                                ▼
              [Zod validate FormalDocSchema]
                ├─ ok → finalise (patch defaults, attach hints) ──► FormalDoc
                ├─ fail → simplified prompt retry (minimal schema)
                │         ├─ ok → reconstruct + finalise ──► FormalDoc
                │         └─ fail → throw TextToDocLLMError
```

`origin` is `'hybrid'` when any heuristic signal contributed and `'llm'` otherwise.

### Files

| File | Purpose |
|---|---|
| `src/heuristics.ts` (new) | Regex pre-pass + `ExtractedHints` type |
| `src/formal-doc-schema.ts` (new) | Zod schemas + structural drift guard against `types.ts` |
| `src/text-to-doc-prompt.ts` (new) | Full + simplified prompt builders |
| `src/text-to-doc.ts` (rewrite) | Real implementation: heuristic → LLM → validate → retry → finalise |
| `src/pipeline.ts` (touched) | Forwards optional `routeFn` to Stage A for testability |
| `src/types.ts` (touched) | Adds optional `industry`, `primaryCtas`, `metadata` to `FormalDoc` |
| `src/index.ts` (touched) | Exports the new public surface |
| `tests/text-to-doc.test.ts` (new) | 16 tests |
| `tests/fixtures/mock-route.ts` (new) | Mock LLM router (mimics `route()` shape) |
| `tests/pipeline.test.ts` (touched) | Updated to use the mock router |
| `package.json` | Adds `@chiefaia/local-llm-router` workspace dep |
| `README.md` | Phase 2 status + pipeline description |

### LLM prompt design

- **Full prompt** (attempt 1): system + rules + known component-library names from `config.componentLibrary` + heuristic hints block + raw prose + JSON schema description. Asks for the full `FormalDoc` shape (`id`, `name`, `audience`, `brandVoice`, `industry`, `primaryCtas`, `sections`, `origin`).
- **Simplified prompt** (attempt 2): minimal schema — `{sections: [{section, intent}]}`. Caller patches `id`/`name`/`audience`/`brandVoice` from `pageId` + config defaults.
- Temperature is the router default (0.2). `forceLocal:true` + `fallbackOnError:false` — strict zero-dollar gate.
- `extractJsonObject()` strips ```` ```json ```` fences and handles bare `{...}` braces with string-aware depth counting, so models that occasionally wrap or precede JSON with chatter still parse.

### Tests (33/33 ✅)

```
✓ tests/config.test.ts           (7 tests)
✓ tests/pipeline.test.ts         (10 tests)
✓ tests/text-to-doc.test.ts      (16 tests)
   - happy path (hybrid + llm origin)
   - pageId override behaviour
   - retry-path config-default fill-in
   - ```json fence stripping
   - retry on garbage first response (simplified path)
   - retry on Zod-failed first response
   - both attempts fail → TextToDocLLMError
   - error carries both raw responses
   - heuristic URL / email / phone / address extraction
   - industry inference (legal, e-commerce, education)
   - section keyword extraction
   - heuristics surfaced via FormalDoc.metadata
   - first inferred industry promoted to FormalDoc.industry
   - prompt embeds page id / audience / hints
```

### Compliance

- ✅ Zero-dollar — Ollama only via `forceLocal:true` + `fallbackOnError:false`
- ✅ No new external runtime deps (`@chiefaia/local-llm-router` is a workspace package)
- ✅ Public API preserved (`runVastuPipeline`, `textToDoc`, `defaultCaiaVastuConfig`)
- ✅ Zod schema present at LLM boundary
- ✅ Compile-time drift guard between `types.ts` and `formal-doc-schema.ts`

### Path B

Admin-merge if CI passes. Pre-existing develop reds tolerated.

### Next

Auto-spawn Phase 3 (doc-to-figma) on merge per `feedback_self_perpetuating_campaigns.md` + bulletproof rule.
