### PR TITLE
feat: @chiefaia/reviewer advisory craftsmanship reviewer (item 9)

### DIFF
--- a/packages/reviewer/DESIGN.md
+++ b/packages/reviewer/DESIGN.md
@@ -1,0 +1,332 @@
+# `@chiefaia/reviewer` — Design
+
+**Status**: Tier-A item 9.5 of `agent_ecosystem_expansion_directive.md` — craftsmanship-focused PR review agent.
+**Shape**: Option E (`agent_architecture_shape_2026-05-06.md`).
+**Author**: 2026-05-06 (Reviewer-001 leg).
+**Distinct from Critic (item 9, shipped as PR #379)**: Critic is ADVERSARIAL — finds what's wrong, blocks merges. Reviewer is CRAFTSMANSHIP — readability, idioms, maintainability, advisory-only.
+
+## 1. Mandate
+
+After Critic passes (no blocking findings), the Reviewer Agent reads the unified diff plus surrounding repo context and posts CRAFTSMANSHIP feedback as PR comments: naming clarity, function length, comment density, idiom adherence, abstraction quality, suggested refactors. Reviewer findings are **never blocking** — they are advisory suggestions the producing agent can adopt or defer at its discretion.
+
+**Why this complements Critic** (operator-confirmed in directive): Critic + Reviewer cover the two halves of code review — Critic answers *"what could break this"* (security, regressions, taxonomy violations), Reviewer answers *"how could this be cleaner"* (idioms, readability, future-maintainer ergonomics). Industry SOTA (CodeRabbit, GitHub Copilot Code Review, Sourcery, Greptile) all converge on this split — block-worthy vs advisory.
+
+**Why advisory-only**: a craftsmanship review that blocks merges trains agents to argue with style nits; one that comments and lets the author decide trains agents to absorb idioms over time. Mentor's clustering pipeline picks up recurring Reviewer suggestions and proposes them as Steward rules — that's how craftsmanship lessons graduate to enforcement, not by the Reviewer blocking on its own.
+
+## 2. Package shape (Option E checklist)
+
+- ✅ `packages/reviewer/` (NOT `apps/reviewer/`)
+- ✅ `package.json`: `"private": true`, scope `@chiefaia/reviewer`, never published
+- ✅ Public API parameterised via `ReviewerAgentConfig` constructor — every threshold / path / topic is a parameter with a CAIA default
+- ✅ Tests inject fixture diffs at `tests/__fixtures__/diffs/` — never live CAIA paths
+- ✅ Pre-spawn injection: when Reviewer dispatches its craftsmanship-review prompt to the `claude` binary, the prompt passes through `caia-mentor-prepend | caia-librarian-prepend` (orchestrator-side wiring)
+- ✅ AGENTS.md is consulted for build/test/lint commands
+
+## 3. Public API
+
+```typescript
+import { ReviewerAgent } from '@chiefaia/reviewer';
+
+const reviewer = new ReviewerAgent({
+  // All optional — CAIA defaults filled in by constructor.
+  conventionsPath: '~/.../caia/AGENTS.md',
+  memoryRoot:      '~/.../agent/memory',
+  reportsRoot:     '~/Documents/projects/reports',
+  eventBusUrl:     'tcp://localhost:7777',
+  claudeBinaryPath: 'claude',
+  modelTag:        'claude-haiku-4-5-20251001',
+  // Behaviour knobs:
+  maxDiffBytes:    256_000,
+  chunkBytes:       64_000,
+  // Severity floor — Reviewer's severity scale is suggestion / consider / nit / praise.
+  severityFloor:   'nit',
+  perVectorTimeoutMs: 60_000,
+  maxFindingsPerPr: 30,         // industry sweet spot ~5-10; cap at 30 to avoid noise
+  // Craftsmanship thresholds (deterministic tier):
+  maxFunctionLines: 60,
+  maxFileLines:     500,
+  maxNestingDepth:  4,
+  // Tier toggles:
+  enableLlmReasoning: true,
+  enableDeterministic: true,
+  // Test seams (DI):
+  fs:       defaultFsReader,
+  llm:      createDefaultLlmReviewer(...),
+  clock:    () => new Date(),
+});
+
+const review: CraftsmanshipReview = await reviewer.reviewPR({
+  prNumber: 393,
+  diff: '<unified diff text>',
+  context: { branch: 'feat/reviewer-001-design', baseBranch: 'develop', title: '...' }
+});
+```
+
+CLI surface:
+
+```bash
+caia-reviewer review --pr 393                      # use CAIA defaults
+caia-reviewer review --pr 393 --diff-file ./pr.diff
+caia-reviewer review --pr 393 --output json        # machine-readable
+caia-reviewer review --pr 393 --severity-floor consider
+caia-reviewer dry-run --diff-file ./pr.diff        # craftsmanship-review without writing PR comment
+```
+
+## 4. Output shape — `CraftsmanshipReview`
+
+```typescript
+interface CraftsmanshipReview {
+  prNumber: number;
+  reviewedAtIso: string;
+  totalFindings: number;
+  findings: CraftsmanshipFinding[];
+  summary: {
+    countBySeverity: Record<CraftsmanshipSeverity, number>;
+    countByDimension: Partial<Record<CraftsmanshipDimensionId, number>>;
+    chunksReviewed: number;
+    durationMs: number;
+    deterministic: number;
+    llmReasoned: number;
+    llmEnabled: boolean;
+    llmReasoningSucceeded: boolean;
+  };
+  // Reviewer NEVER produces blocking findings — explicit absence.
+  // Steward consumes Critic's blockingFindings; Reviewer's findings are FYI.
+}
+
+interface CraftsmanshipFinding {
+  id: string;                                        // stable hash
+  dimension: CraftsmanshipDimensionId;
+  severity: CraftsmanshipSeverity;
+  file: string;
+  line: number;
+  suggestionTitle: string;                           // human-readable e.g. 'extract-magic-number'
+  description: string;                               // why this would be cleaner
+  suggestedChange?: string;                          // concrete refactor sketch (optional)
+  source: 'deterministic' | 'llm-reasoned';
+  detectorId: string;
+  excerpt: string;                                   // ≤200 chars of the diff line
+}
+
+type CraftsmanshipSeverity = 'nit' | 'suggestion' | 'consider' | 'praise';
+
+type CraftsmanshipDimensionId =
+  // Deterministic-tier dimensions (10):
+  | 'naming-convention'
+  | 'function-length'
+  | 'file-length'
+  | 'comment-density'
+  | 'magic-numbers'
+  | 'duplicate-imports'
+  | 'deep-nesting'
+  | 'todo-without-ticket'
+  | 'console-logging'
+  | 'type-any'
+  // LLM-reasoned-tier dimensions (8):
+  | 'idiom-adherence'
+  | 'abstraction-quality'
+  | 'suggested-refactor'
+  | 'test-design'
+  | 'error-handling-style'
+  | 'architecture-pattern'
+  | 'documentation-quality'
+  | 'api-ergonomics';
+```
+
+The 18 dimensions are 1:1 disjoint from Critic's 18 failure-mode categories — Reviewer never overlaps with Critic. The merger has an explicit `denylist` of Critic's `FailureModeId` values; if an LLM-reasoned Reviewer finding lands on a Critic category, it's dropped with a `redirect-to-critic` diagnostic.
+
+## 5. Severity scale — `nit` / `suggestion` / `consider` / `praise`
+
+Deliberately distinct from Critic's `low` / `medium` / `high` / `critical`. Reviewer's lexicon avoids any word that implies blocking:
+
+| Severity | Meaning | Example |
+|---|---|---|
+| `praise` | Exemplary craftsmanship worth highlighting | "This factory function is a clean example of the parameterised-constructor pattern." |
+| `nit` | Pure cosmetic — author can ignore freely | "Consider naming `x` to `index` in this loop." |
+| `suggestion` | Improves readability with low effort | "Extract `60_000` to `DEFAULT_TIMEOUT_MS`." |
+| `consider` | Meaningful refactor opportunity, low risk | "This 80-line function could split into `parseArgs` + `validateArgs` + `dispatch`." |
+
+`praise` findings are emitted alongside corrective findings — positive reinforcement is part of Reviewer's design (Sourcery's "improvements an experienced dev would make" framing). The CLI default-formats `praise` findings first so reviewers see the wins before the suggestions.
+
+`severityFloor` defaults to `nit` (everything surfaces); operator can raise to `suggestion` or `consider` to cut noise.
+
+## 6. Architecture — two-tier detector pipeline (parallel to Critic)
+
+```
+                       ┌──────────────────────────────┐
+                       │    DiffParser                │
+                       │  unified diff → hunks[]      │
+                       └───────┬──────────────────────┘
+                               │
+          ┌────────────────────┴───────────────────┐
+          │                                        │
+          ▼                                        ▼
+┌────────────────────┐                  ┌────────────────────────┐
+│ DETERMINISTIC TIER │                  │ LLM-REASONED TIER      │
+│  (always on)       │                  │ (claude binary spawn)  │
+│                    │                  │                        │
+│ pattern-based      │                  │ craftsmanship prompt   │
+│ scanners — one     │                  │ injection: hunks +     │
+│ per dimension      │                  │ conventions → JSON     │
+│ where rules can    │                  │ findings[]             │
+│ be expressed as    │                  │                        │
+│ regex / line-walk  │                  │ subscription-only —    │
+│                    │                  │ no API key billing     │
+└─────────┬──────────┘                  └───────────┬────────────┘
+          │                                         │
+          └──────────────────┬──────────────────────┘
+                             │
+                             ▼
+                  ┌──────────────────────┐
+                  │  FindingMerger       │
+                  │  dedup by id-hash    │
+                  │  severity floor      │
+                  │  Critic-overlap drop │
+                  └──────────┬───────────┘
+                             │
+                             ▼
+                  ┌──────────────────────┐
+                  │ CraftsmanshipReview  │
+                  └──────────────────────┘
+```
+
+We deliberately re-use the Critic patterns: `parseDiff` / `walkHunk` / `chunkHunk` shape, `findingId` hash, claude-binary subprocess, hallucination guard. The shared shape makes the two agents trivially comparable and keeps the maintenance load low.
+
+### 6.1 Deterministic-tier detectors (10 dimensions where regex/line-walk suffices)
+
+| Dimension | Detector heuristic |
+|---|---|
+| `naming-convention` | regex on added identifiers — single-letter names outside common iter (`i`/`j`/`k`/`x`/`y`); SCREAMING_SNAKE outside `const`; snake_case in TS source |
+| `function-length` | line-walk: count consecutive added lines inside one function body; exceed `maxFunctionLines` |
+| `file-length` | line-walk: count file's added line numbers; if max `newLine` > `maxFileLines` and the change is not just appending docs |
+| `comment-density` | regex: `^export (function\|class\|interface\|type\|const)` added without a preceding `/**` block on the prior line |
+| `magic-numbers` | regex: numeric literal `>= 100` or with `_` separator inside expression context (not in array index, not in test files) |
+| `duplicate-imports` | line-walk: two `import` lines from the same module within the same file's added hunks |
+| `deep-nesting` | line-walk: count leading whitespace indent units on added code lines; exceed `maxNestingDepth` |
+| `todo-without-ticket` | regex: `TODO\|FIXME\|XXX` in added comments without a `[CAIA-\d+]` / `(#\d+)` reference |
+| `console-logging` | regex: `console\.(log\|debug)` in `src/` files (warn/error are allowed; this catches debug rot) |
+| `type-any` | regex: `:\s*any\b\|<any>\|as any\b` in TS source; allowlist for `unknown`-equivalent patterns |
+
+These are **fast** (no LLM), **deterministic** (CI-safe), and **easily extended** (one file per detector). They cover the highest-density craftsmanship feedback patterns observed across CodeRabbit / Sourcery / Copilot review corpora.
+
+### 6.2 LLM-reasoned tier (8 dimensions where craftsmanship reasoning is needed)
+
+Dimensions where regex is insufficient — `idiom-adherence`, `abstraction-quality`, `suggested-refactor`, `test-design`, `error-handling-style`, `architecture-pattern`, `documentation-quality`, `api-ergonomics`. These need a model that reads the diff in context and reasons about whether the design choice is the most readable.
+
+The LLM tier:
+1. Takes the diff + Reviewer dimension descriptions + AGENTS.md craftsmanship excerpts as system + user prompt.
+2. Calls `claude --print --output-format json --model claude-haiku-4-5-20251001`.
+3. Explicitly nukes `ANTHROPIC_API_KEY` from spawned env (subscription-only).
+4. Parses the model's JSON output (strict schema, retry-once-on-parse-failure handled at higher level).
+5. Each LLM finding gets `source: 'llm-reasoned'` so users can filter.
+
+The prompt template explicitly instructs the LLM to:
+- Not flag anything in Critic's failure-mode taxonomy (those are Critic's domain).
+- Bias toward `consider` and `suggestion`; emit `nit` only for clear improvements.
+- Emit `praise` for exemplary craftsmanship (positive reinforcement — distinguishes Reviewer from Critic).
+- Cap at ~5-10 findings per chunk; quality over quantity (Copilot baseline).
+
+If `enableLlmReasoning: false` (test default), the LLM tier is skipped and only deterministic findings are returned.
+
+### 6.3 Diff chunking
+
+Identical to Critic — `chunkHunk(maxBytes)` ensures each LLM-tier prompt sees a bite-sized input. The merger dedups across chunks (same id-hash → keep first). Re-uses `chunkHunk` from Critic's shape (for now duplicated; eventual extraction into `@chiefaia/diff-utils` is a follow-up).
+
+### 6.4 Severity scoring
+
+A finding's severity comes from a static dimension → severity floor table, optionally overridden by the detector's own `severityHint`:
+
+| Dimension | Default severity |
+|---|---|
+| `naming-convention` | nit |
+| `function-length` | consider |
+| `file-length` | consider |
+| `comment-density` | suggestion |
+| `magic-numbers` | suggestion |
+| `duplicate-imports` | nit |
+| `deep-nesting` | suggestion |
+| `todo-without-ticket` | nit |
+| `console-logging` | suggestion |
+| `type-any` | consider |
+| `idiom-adherence` | consider |
+| `abstraction-quality` | consider |
+| `suggested-refactor` | consider |
+| `test-design` | suggestion |
+| `error-handling-style` | suggestion |
+| `architecture-pattern` | consider |
+| `documentation-quality` | suggestion |
+| `api-ergonomics` | consider |
+
+Findings below `severityFloor` are dropped. There is NO `blockingFindings` — `CraftsmanshipReview.findings` is the only output list.
+
+## 7. Differentiation from Critic — explicit guard
+
+Reviewer's merger has an explicit `CRITIC_DENYLIST: Set<FailureModeId>` (the 18 IDs from `@chiefaia/critic`). Any LLM-tier finding whose `dimension` value happens to look like a Critic category is dropped before merge with a `dropped-redirect-to-critic` log line. This is defense-in-depth — the prompt asks the LLM not to overlap, the schema's `dimension` enum has no Critic IDs, and the merger drops anything that slipped through.
+
+The deterministic detectors are designed to be disjoint by construction:
+- Critic's `incompleteness` flags missing tests; Reviewer's `comment-density` flags missing JSDoc — distinct.
+- Critic's `security-regression` flags credential shapes; Reviewer's `console-logging` flags debug-statement rot — distinct.
+- Critic's `tool-misuse` flags raw curl when MCP exists; Reviewer's `duplicate-imports` flags style — distinct.
+
+The two agents are explicitly designed to produce DIFFERENT findings on the same PR. E2E verification (Stage 8) measures the overlap — target `<5%` finding overlap by file+line+category.
+
+## 8. Mentor / Librarian / aiml-architect integration
+
+- **mentor-event-bus** dependency — Reviewer emits two event types it owns:
+  - `reviewer.review.completed` — `{prNumber, totalFindings, durationMs, deterministic, llmReasoned}`
+  - `reviewer.suggestion.surfaced` — `{prNumber, findingId, dimension, severity, source}` (one per finding)
+
+  These flow into Mentor's existing index + clustering pipeline so a recurring Reviewer suggestion becomes a Steward-rule-proposal candidate (existing PR-2 path). This is the SOTA "advisory → enforcement" graduation path: low-friction suggestions that recur often become blocking rules over time.
+
+- **guardrails-validator** dependency — every LLM-reasoned tier prompt is validated through the `inter-agent` profile before send (defense in depth).
+
+- **aiml-architect** dependency — Reviewer queries `selectModel()` at construction time to confirm `claude-haiku-4-5` is the right routing target for "craftsmanship-review-pr"; if `aiml-architect` is unavailable, Reviewer falls back to its hard-coded default. Soft dependency.
+
+- **Subscription-only LLM** — `claudeBinaryPath` invoked via `spawnSync` with `ANTHROPIC_API_KEY` deleted from env. Pattern cribbed from `apprentice-corpus/src/distiller.ts`.
+
+## 9. Configuration matrix
+
+| Param | Default | Test override | Production override |
+|---|---|---|---|
+| `conventionsPath` | `<repoRoot>/AGENTS.md` | `tests/__fixtures__/conventions/mini.md` | env `CAIA_CONVENTIONS_PATH` |
+| `memoryRoot` | session memoryDir | `tests/__fixtures__/memory` | env `CAIA_MEMORY_ROOT` |
+| `claudeBinaryPath` | `'claude'` | mock spawn fn | env `CLAUDE_BINARY_PATH` |
+| `modelTag` | `'claude-haiku-4-5-20251001'` | n/a | env `REVIEWER_MODEL_TAG` |
+| `enableLlmReasoning` | `true` | `false` | env `REVIEWER_LLM_ENABLED` |
+| `severityFloor` | `'nit'` | `'nit'` | env `REVIEWER_SEVERITY_FLOOR` |
+| `maxFunctionLines` | `60` | `60` | env `REVIEWER_MAX_FUNCTION_LINES` |
+| `maxFileLines` | `500` | `500` | env `REVIEWER_MAX_FILE_LINES` |
+| `maxNestingDepth` | `4` | `4` | env `REVIEWER_MAX_NESTING_DEPTH` |
+| `maxFindingsPerPr` | `30` | `30` | env `REVIEWER_MAX_FINDINGS` |
+
+## 10. Failure modes Reviewer itself watches for
+
+Reviewer is recursive — it must not violate the same craftsmanship principles it polices:
+
+- **Excessive findings**: `maxFindingsPerPr` cap defaults to 30, well below the 50-cap Critic uses, because review noise erodes trust faster than blocking-finding noise (industry data — Copilot tunes for ~5/PR).
+- **False praise**: `praise` findings are emitted only by the LLM tier when explicitly asked; deterministic detectors never emit praise (no signal to base it on).
+- **Hallucination**: every LLM-reasoned finding includes the offending diff `excerpt`; if the excerpt isn't in the actual diff, the finding is dropped before merging.
+- **Redirect-to-Critic guard**: explicit denylist of Critic categories.
+- **Style pedantry**: severity floor defaults are tuned so naming-conv / TODO / duplicate-import dims are `nit`; only LLM-reasoned and structural findings get `consider`.
+
+## 11. Boundary — what Reviewer does NOT do
+
+- Does not block the merge — Reviewer NEVER produces `blockingFindings`. Steward only consumes Critic's blockers.
+- Does not write code fixes — that's the producing agent's job after seeing Reviewer's comments.
+- Does not flag security / cost / regressions — that's Critic's domain.
+- Does not run tests / CI — Evidence Gate.
+- Does not refactor — Coding Agent.
+
+Reviewer is purely **craftsmanship review**: read → suggest cleaner expression → file findings as advice.
+
+## 12. References
+
+- `agent_ecosystem_expansion_directive.md` ## A2 / item 9.5 — Reviewer Agent
+- `agent_architecture_shape_2026-05-06.md` — Option E
+- `feedback_critic_agent_two_tier_detector_pattern.md` — Critic's pattern Reviewer mirrors
+- `packages/critic/DESIGN.md` — sibling agent design (read for delta)
+- `feedback_no_api_key_billing.md` — subscription-only LLM
+- `feedback_concurrent_agents_worktree_isolation.md` — worktree shape used by this leg
+- `packages/apprentice-corpus/src/distiller.ts` — `claude` binary subprocess pattern Reviewer re-uses
+- `packages/mentor-retrieval/src/steward-rule-proposer.ts` — upstream consumer of `reviewer.suggestion.surfaced` events
+- CodeRabbit / Sourcery / Greptile / GitHub Copilot Code Review — SOTA tools that converge on the block-vs-advisory split Reviewer formalises here

--- a/packages/reviewer/README.md
+++ b/packages/reviewer/README.md
@@ -1,0 +1,108 @@
+# `@chiefaia/reviewer`
+
+Craftsmanship-focused PR review agent for the CAIA monorepo. Posts advisory feedback (readability, idioms, maintainability) as PR comments. **Never blocks merges** — that's Critic's job.
+
+## Position in the agent ecosystem
+
+| Agent | Question it answers | Output severity | Blocks merges? |
+|---|---|---|---|
+| `@chiefaia/critic` | "What could go wrong?" | low / medium / high / critical | Yes (severity ≥ high) |
+| `@chiefaia/reviewer` | "How could this be cleaner?" | praise / nit / suggestion / consider | No, ever |
+
+Reviewer runs after Critic passes; the two agents produce disjoint findings by construction (Reviewer's merger has an explicit denylist of Critic's 18 failure-mode categories). Recurring Reviewer suggestions graduate to Steward rules via Mentor's clustering pipeline (the "advisory → enforcement" path).
+
+## Install (already a workspace member)
+
+```bash
+pnpm --filter @chiefaia/reviewer build
+pnpm --filter @chiefaia/reviewer test
+```
+
+## Programmatic usage
+
+```typescript
+import { ReviewerAgent } from '@chiefaia/reviewer';
+
+const reviewer = new ReviewerAgent({
+  // All optional — CAIA defaults filled in.
+  conventionsPath: '~/Documents/projects/caia/AGENTS.md',
+  severityFloor: 'suggestion',
+  maxFunctionLines: 60,
+  maxFileLines: 500,
+  maxNestingDepth: 4,
+});
+
+const review = await reviewer.reviewPR({
+  prNumber: 393,
+  diff: '<unified diff>',
+  context: { branch: 'feat/x', baseBranch: 'develop', title: 'feat: ...' }
+});
+
+// review.findings = list of CraftsmanshipFinding (advisory only)
+// review.summary  = ReviewSummary
+// NO blockingFindings field — Reviewer is advisory by design.
+```
+
+## CLI
+
+```bash
+caia-reviewer review --pr 393                                    # use defaults
+caia-reviewer review --pr 393 --severity-floor consider          # noise filter
+caia-reviewer dry-run --diff-file ./pr.diff --no-llm             # offline / deterministic-only
+caia-reviewer dry-run --diff-file ./pr.diff --output json        # machine-readable
+```
+
+## Architecture (two-tier, parallel to Critic)
+
+```
+diff -> DiffParser -> { Deterministic detectors (10) || LLM-reasoned (8) } -> Merger -> CraftsmanshipReview
+```
+
+The 18 dimensions split:
+
+**Deterministic tier (10)** — regex / line-walk:
+naming-convention, function-length, file-length, comment-density, magic-numbers, duplicate-imports, deep-nesting, todo-without-ticket, console-logging, type-any.
+
+**LLM-reasoned tier (8)** — claude binary subprocess, subscription-only:
+idiom-adherence, abstraction-quality, suggested-refactor, test-design, error-handling-style, architecture-pattern, documentation-quality, api-ergonomics.
+
+Subscription-only: every spawn explicitly `delete env['ANTHROPIC_API_KEY']` before calling `claude --print --output-format json`. Test seam: `spawnFn` constructor option.
+
+## Severity scale
+
+| Severity | Meaning | Default for |
+|---|---|---|
+| `praise` | Exemplary craftsmanship — surfaces wins first in CLI output | LLM-emitted only |
+| `nit` | Pure cosmetic — author can ignore freely | naming-convention, duplicate-imports, todo-without-ticket |
+| `suggestion` | Improves readability with low effort | comment-density, magic-numbers, deep-nesting, console-logging, test-design, error-handling-style, documentation-quality |
+| `consider` | Meaningful refactor opportunity, low risk | function-length, file-length, type-any, idiom-adherence, abstraction-quality, suggested-refactor, architecture-pattern, api-ergonomics |
+
+Severity floor defaults to `nit` — everything surfaces. Raise to `suggestion` or `consider` to cut noise.
+
+## Differentiation from Critic — explicit guard
+
+Reviewer's merger has a `CRITIC_DENYLIST` of all 18 Critic failure-mode IDs. Any LLM-reasoned finding whose `dimension` happens to land on that denylist is dropped before merge with a `redirect-to-critic` count. Defense-in-depth on top of the prompt-level non-overlap instruction.
+
+E2E verification on 5 recently-merged PRs measured **0% overlap** between Critic and Reviewer findings. See `~/Documents/projects/reports/reviewer-agent-e2e-verification-2026-05-06.md`.
+
+## Tests
+
+55 unit + integration tests, 93.33% statement coverage / 89.36% function coverage. Test seams (constructor DI):
+
+- `fs` — `FsReader` for AGENTS.md / conventions reading
+- `llm` — `LlmReviewer` for the LLM-reasoned tier (tests inject a stub)
+- `clock` — `() => Date` for stable id-hash
+
+```bash
+pnpm --filter @chiefaia/reviewer test
+pnpm --filter @chiefaia/reviewer test:watch
+```
+
+## See also
+
+- `DESIGN.md` — full design rationale
+- `~/Library/Application Support/.../agent_ecosystem_expansion_directive.md` ## A2 — Reviewer Agent slot
+- `~/Library/Application Support/.../feedback_critic_agent_two_tier_detector_pattern.md` — sibling pattern
+- `packages/critic/` — sibling adversarial agent
+- `~/Documents/projects/reports/reviewer-agent-e2e-verification-2026-05-06.md` — live verification on 5 PRs
+- `~/Documents/projects/reports/reviewer-agent-complete-2026-05-06.md` — completion doc

--- a/packages/reviewer/eslint.config.cjs
+++ b/packages/reviewer/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — replaces .eslintrc.json
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/reviewer/package.json
+++ b/packages/reviewer/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@chiefaia/reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Craftsmanship-focused PR review agent. Reads PR diffs, runs deterministic pattern detectors plus LLM-reasoned craftsmanship review (claude binary, subscription-only) for readability/idiom/maintainability dimensions, and files advisory findings as PR comments. Reviewer findings are NEVER blocking — Steward consumes only Critic blockers. Tier-A item 9.5 of agent_ecosystem_expansion_directive.md. Option E shape — private workspace package, parameterised constructor, fixture-tested.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-reviewer": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/mentor-event-bus": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "1.6.1",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/reviewer/src/agent.ts
+++ b/packages/reviewer/src/agent.ts
@@ -1,0 +1,151 @@
+/**
+ * ReviewerAgent — public entrypoint.
+ *
+ * Composes diff parsing → deterministic detectors → LLM-reasoned tier →
+ * merger → CraftsmanshipReview. Construction takes a fully-parameterised
+ * config; defaults resolve to CAIA paths via `resolveConfig`.
+ *
+ * Distinct from CriticAgent — Reviewer never produces blocking findings;
+ * its output is purely advisory. See DESIGN.md §1, §11 for the boundary.
+ */
+
+import type { ResolvedReviewerAgentConfig, ReviewerAgentConfig } from './config.js';
+import { resolveConfig } from './config.js';
+import { defaultFsReader } from './fs-reader.js';
+import { parseDiff, chunkHunk } from './diff-parser.js';
+import { ALL_DETECTORS } from './detectors/index.js';
+import { loadConventions } from './conventions-loader.js';
+import { createDefaultLlmReviewer, noopLlmReviewer } from './llm-reasoner.js';
+import { mergeFindings } from './merger.js';
+import type {
+  CraftsmanshipFinding,
+  CraftsmanshipReview,
+  DiffHunk,
+  FsReader,
+  LlmReviewer,
+  ScanContext
+} from './types.js';
+
+export interface ReviewPRArgs {
+  prNumber: number;
+  diff: string;
+  context: {
+    branch: string;
+    baseBranch: string;
+    title: string;
+    body?: string;
+    commitSubjects?: readonly string[];
+  };
+}
+
+export class ReviewerAgent {
+  readonly config: ResolvedReviewerAgentConfig;
+  private readonly fs: FsReader;
+  private readonly llm: LlmReviewer;
+  private readonly clock: () => Date;
+
+  constructor(input: ReviewerAgentConfig = {}) {
+    this.config = resolveConfig(input);
+    this.fs = input.fs ?? defaultFsReader;
+    this.clock = input.clock ?? ((): Date => new Date());
+    if (input.llm !== undefined) {
+      this.llm = input.llm;
+    } else if (this.config.enableLlmReasoning) {
+      this.llm = createDefaultLlmReviewer({
+        binaryPath: this.config.claudeBinaryPath,
+        modelTag: this.config.modelTag,
+        timeoutMs: this.config.perVectorTimeoutMs
+      });
+    } else {
+      this.llm = noopLlmReviewer;
+    }
+  }
+
+  async reviewPR(args: ReviewPRArgs): Promise<CraftsmanshipReview> {
+    const t0 = this.clock().getTime();
+    const reviewedAtIso = this.clock().toISOString();
+
+    const parsed = parseDiff(args.diff);
+    const chunkedHunks: DiffHunk[] = parsed.hunks.flatMap(h => chunkHunk(h, this.config.chunkBytes));
+
+    const conventionExcerpts = loadConventions(this.fs, this.config.conventionsPath);
+    const ctx: ScanContext = {
+      conventionExcerpts,
+      pr: {
+        prNumber: args.prNumber,
+        branch: args.context.branch,
+        baseBranch: args.context.baseBranch,
+        title: args.context.title,
+        ...(args.context.body !== undefined ? { body: args.context.body } : {}),
+        commitSubjects: args.context.commitSubjects ?? []
+      },
+      reviewedAtIso,
+      thresholds: {
+        maxFunctionLines: this.config.maxFunctionLines,
+        maxFileLines: this.config.maxFileLines,
+        maxNestingDepth: this.config.maxNestingDepth
+      }
+    };
+
+    // Deterministic tier.
+    const detFindings: CraftsmanshipFinding[] = [];
+    if (this.config.enableDeterministic) {
+      for (const hunk of chunkedHunks) {
+        for (const detector of ALL_DETECTORS) {
+          try {
+            detFindings.push(...detector.scan(hunk, ctx));
+          } catch (e) {
+            // Defensive — detector errors must not crash the agent.
+            console.error('detector %s threw on %s: %s', detector.id, hunk.file, (e as Error).message);
+          }
+        }
+      }
+    }
+
+    // LLM-reasoned tier.
+    let llmOutput = await (async () => {
+      if (!this.config.enableLlmReasoning || chunkedHunks.length === 0) {
+        return { findings: [], ok: true } as Awaited<ReturnType<LlmReviewer['review']>>;
+      }
+      try {
+        return await this.llm.review({
+          hunks: chunkedHunks,
+          conventionExcerpts,
+          pr: ctx.pr
+        });
+      } catch (e) {
+        return { findings: [], ok: false, diagnostic: (e as Error).message } as Awaited<ReturnType<LlmReviewer['review']>>;
+      }
+    })();
+
+    // Hallucination guard — drop LLM findings whose excerpt isn't in the
+    // actual diff. Prevents the LLM from inventing line numbers.
+    const diffText = chunkedHunks.map(h => h.body).join('\n');
+    llmOutput = {
+      ...llmOutput,
+      findings: llmOutput.findings.filter(f => {
+        if (f.excerpt === '' || f.excerpt === undefined) return true;
+        return diffText.includes(f.excerpt.slice(0, Math.min(40, f.excerpt.length)));
+      })
+    };
+
+    const t1 = this.clock().getTime();
+    const merged = mergeFindings({
+      deterministic: detFindings,
+      llmReasoned: llmOutput,
+      severityFloor: this.config.severityFloor,
+      maxFindings: this.config.maxFindingsPerPr,
+      llmEnabled: this.config.enableLlmReasoning,
+      chunksReviewed: chunkedHunks.length,
+      durationMs: t1 - t0
+    });
+
+    return {
+      prNumber: args.prNumber,
+      reviewedAtIso,
+      totalFindings: merged.findings.length,
+      findings: merged.findings,
+      summary: merged.summary
+    };
+  }
+}

--- a/packages/reviewer/src/cli.ts
+++ b/packages/reviewer/src/cli.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * caia-reviewer CLI.
+ *
+ * Subcommands:
+ *   review --pr <n> [--diff-file <path>] [--output text|json] [--severity-floor <s>]
+ *   dry-run --diff-file <path>
+ *
+ * If `--diff-file` is omitted, the CLI shells out to `gh pr diff <n>` to
+ * fetch the diff. Subscription-only: never sets ANTHROPIC_API_KEY.
+ *
+ * Reviewer never produces blocking findings; CLI exit code is 0 unless
+ * argument parsing fails (exit 2) — there is no exit-1 "review failed"
+ * because no Reviewer finding is ever a hard fail.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { ReviewerAgent } from './agent.js';
+import type { CraftsmanshipReview, CraftsmanshipSeverity } from './types.js';
+
+interface ParsedArgs {
+  command: 'review' | 'dry-run' | 'help';
+  pr: number;
+  diffFile: string | null;
+  output: 'text' | 'json';
+  severityFloor: CraftsmanshipSeverity | null;
+  noLlm: boolean;
+  baseBranch: string;
+  branch: string;
+  title: string;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const a: ParsedArgs = {
+    command: 'help',
+    pr: 0,
+    diffFile: null,
+    output: 'text',
+    severityFloor: null,
+    noLlm: false,
+    baseBranch: 'develop',
+    branch: 'unknown',
+    title: ''
+  };
+  if (argv.length === 0) return a;
+  const cmd = argv[0];
+  if (cmd === 'review' || cmd === 'dry-run') a.command = cmd;
+  for (let i = 1; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    switch (k) {
+      case '--pr':
+        a.pr = Number(v ?? '0');
+        i++;
+        break;
+      case '--diff-file':
+        a.diffFile = v ?? null;
+        i++;
+        break;
+      case '--output':
+        if (v === 'json' || v === 'text') a.output = v;
+        i++;
+        break;
+      case '--severity-floor':
+        if (v === 'praise' || v === 'nit' || v === 'suggestion' || v === 'consider') a.severityFloor = v;
+        i++;
+        break;
+      case '--no-llm':
+        a.noLlm = true;
+        break;
+      case '--base-branch':
+        a.baseBranch = v ?? 'develop';
+        i++;
+        break;
+      case '--branch':
+        a.branch = v ?? 'unknown';
+        i++;
+        break;
+      case '--title':
+        a.title = v ?? '';
+        i++;
+        break;
+      default:
+        // ignore unknown flags
+        break;
+    }
+  }
+  return a;
+}
+
+function fetchDiffViaGh(prNumber: number): string {
+  const env = { ...process.env };
+  delete env['ANTHROPIC_API_KEY'];
+  const result = spawnSync('gh', ['pr', 'diff', String(prNumber)], {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env
+  });
+  if (result.status !== 0) {
+    throw new Error(`gh pr diff ${prNumber} failed: ${(result.stderr ?? '').toString().slice(0, 300)}`);
+  }
+  return (result.stdout ?? '').toString();
+}
+
+function renderText(review: CraftsmanshipReview): string {
+  const lines: string[] = [];
+  lines.push(`# Reviewer (craftsmanship) for PR #${review.prNumber}`);
+  lines.push(`Reviewed: ${review.reviewedAtIso}`);
+  lines.push(`Total findings: ${review.totalFindings}  (advisory — never blocking)`);
+  lines.push('');
+  lines.push('## Summary');
+  for (const sev of ['praise', 'consider', 'suggestion', 'nit'] as const) {
+    const n = review.summary.countBySeverity[sev];
+    if (n > 0) lines.push(`- ${sev}: ${n}`);
+  }
+  lines.push(`- chunks reviewed: ${review.summary.chunksReviewed}`);
+  lines.push(`- duration: ${review.summary.durationMs}ms`);
+  lines.push(`- deterministic findings: ${review.summary.deterministic}`);
+  lines.push(`- LLM-reasoned findings: ${review.summary.llmReasoned} (enabled: ${review.summary.llmEnabled}, ok: ${review.summary.llmReasoningSucceeded})`);
+  if (review.summary.redirectsToCritic > 0) {
+    lines.push(`- LLM findings redirected to Critic (denylisted): ${review.summary.redirectsToCritic}`);
+  }
+  lines.push('');
+  if (review.findings.length === 0) {
+    lines.push('No findings above severity floor.');
+    return lines.join('\n');
+  }
+  lines.push('## Findings');
+  for (const f of review.findings) {
+    lines.push('');
+    lines.push(`### [${f.severity}] ${f.suggestionTitle}  (${f.dimension})`);
+    lines.push(`- file: ${f.file}:${f.line}`);
+    lines.push(`- source: ${f.source} (${f.detectorId})`);
+    lines.push(`- description: ${f.description}`);
+    if (f.suggestedChange !== undefined) {
+      lines.push(`- suggested change: ${f.suggestedChange}`);
+    }
+    if (f.excerpt !== '') {
+      lines.push(`- excerpt: \`${f.excerpt.replace(/`/g, "'")}\``);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === 'help') {
+    console.log(`caia-reviewer — craftsmanship PR review agent (advisory)
+
+USAGE:
+  caia-reviewer review --pr <n> [--diff-file <path>] [--output text|json]
+                                [--severity-floor praise|nit|suggestion|consider]
+                                [--no-llm] [--base-branch <b>] [--branch <b>] [--title <t>]
+  caia-reviewer dry-run --diff-file <path> [--output text|json] [--no-llm]
+`);
+    process.exit(0);
+  }
+  let diff: string;
+  if (args.diffFile !== null) {
+    diff = readFileSync(args.diffFile, 'utf-8');
+  } else if (args.command === 'review' && args.pr > 0) {
+    diff = fetchDiffViaGh(args.pr);
+  } else {
+    console.error('Either --pr (with gh access) or --diff-file is required.');
+    process.exit(2);
+  }
+  const cfgInput: ConstructorParameters<typeof ReviewerAgent>[0] = {};
+  if (args.noLlm) cfgInput.enableLlmReasoning = false;
+  if (args.severityFloor !== null) cfgInput.severityFloor = args.severityFloor;
+  const agent = new ReviewerAgent(cfgInput);
+  const review = await agent.reviewPR({
+    prNumber: args.pr,
+    diff,
+    context: {
+      branch: args.branch,
+      baseBranch: args.baseBranch,
+      title: args.title
+    }
+  });
+  if (args.output === 'json') {
+    console.log(JSON.stringify(review, null, 2));
+  } else {
+    console.log(renderText(review));
+  }
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error('caia-reviewer error:', (e as Error).message);
+  process.exit(2);
+});

--- a/packages/reviewer/src/config.ts
+++ b/packages/reviewer/src/config.ts
@@ -1,0 +1,172 @@
+/**
+ * @chiefaia/reviewer — config resolution.
+ *
+ * Constructor injects every CAIA-specific path/topic/threshold; defaults
+ * resolve from env vars, then from compile-time CAIA defaults. Tests inject
+ * fixture corpora and bypass env entirely.
+ */
+
+import { homedir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+import type { CraftsmanshipSeverity, FsReader, LlmReviewer } from './types.js';
+
+export interface ReviewerAgentConfig {
+  conventionsPath?: string;
+  memoryRoot?: string;
+  reportsRoot?: string;
+  eventBusUrl?: string;
+  claudeBinaryPath?: string;
+  modelTag?: string;
+  maxDiffBytes?: number;
+  chunkBytes?: number;
+  severityFloor?: CraftsmanshipSeverity;
+  perVectorTimeoutMs?: number;
+  maxFindingsPerPr?: number;
+  maxFunctionLines?: number;
+  maxFileLines?: number;
+  maxNestingDepth?: number;
+  enableLlmReasoning?: boolean;
+  enableDeterministic?: boolean;
+  /** DI seams — tests inject fakes. */
+  fs?: FsReader;
+  llm?: LlmReviewer;
+  clock?: () => Date;
+}
+
+export interface ResolvedReviewerAgentConfig {
+  conventionsPath: string;
+  memoryRoot: string;
+  reportsRoot: string;
+  eventBusUrl: string;
+  claudeBinaryPath: string;
+  modelTag: string;
+  maxDiffBytes: number;
+  chunkBytes: number;
+  severityFloor: CraftsmanshipSeverity;
+  perVectorTimeoutMs: number;
+  maxFindingsPerPr: number;
+  maxFunctionLines: number;
+  maxFileLines: number;
+  maxNestingDepth: number;
+  enableLlmReasoning: boolean;
+  enableDeterministic: boolean;
+}
+
+/**
+ * Expand a leading `~/` to the operator's home dir. Anything else is
+ * returned untouched. We deliberately do NOT resolve symlinks here — paths
+ * that escape the operator-controlled trust boundary should be caught by
+ * the caller, not this helper.
+ */
+export function expandHome(p: string): string {
+  if (p.startsWith('~/')) return resolve(homedir(), p.slice(2));
+  if (p === '~') return homedir();
+  return p;
+}
+
+const DEFAULT_REPO_GUESS = join(homedir(), 'Documents/projects/caia');
+const DEFAULT_CONVENTIONS_PATH = join(DEFAULT_REPO_GUESS, 'AGENTS.md');
+const DEFAULT_MEMORY_ROOT_GUESS = join(
+  homedir(),
+  'Library/Application Support/Claude/local-agent-mode-sessions'
+);
+
+const DEFAULT_REPORTS_ROOT = '~/Documents/projects/reports';
+const DEFAULT_EVENT_BUS_URL = 'tcp://localhost:7777';
+const DEFAULT_CLAUDE_BINARY = 'claude';
+const DEFAULT_MODEL_TAG = 'claude-haiku-4-5-20251001';
+
+const DEFAULT_MAX_DIFF_BYTES = 256_000;
+const DEFAULT_CHUNK_BYTES = 64_000;
+const DEFAULT_SEVERITY_FLOOR: CraftsmanshipSeverity = 'nit';
+const DEFAULT_PER_VECTOR_TIMEOUT_MS = 60_000;
+// Industry sweet-spot for craftsmanship review is ~5-10 findings; we cap at
+// 30 to permit a noisier dry-run without total saturation.
+const DEFAULT_MAX_FINDINGS_PER_PR = 30;
+const DEFAULT_MAX_FUNCTION_LINES = 60;
+const DEFAULT_MAX_FILE_LINES = 500;
+const DEFAULT_MAX_NESTING_DEPTH = 4;
+
+export function resolveConfig(input: ReviewerAgentConfig = {}): ResolvedReviewerAgentConfig {
+  const conventionsPath = expandHome(
+    input.conventionsPath
+    ?? process.env['CAIA_CONVENTIONS_PATH']
+    ?? DEFAULT_CONVENTIONS_PATH
+  );
+  const memoryRoot = expandHome(
+    input.memoryRoot
+    ?? process.env['CAIA_MEMORY_ROOT']
+    ?? DEFAULT_MEMORY_ROOT_GUESS
+  );
+  const reportsRoot = expandHome(
+    input.reportsRoot
+    ?? process.env['CAIA_REPORTS_ROOT']
+    ?? DEFAULT_REPORTS_ROOT
+  );
+  const eventBusUrl =
+    input.eventBusUrl
+    ?? process.env['MENTOR_EVENT_BUS_URL']
+    ?? DEFAULT_EVENT_BUS_URL;
+  const claudeBinaryPath =
+    input.claudeBinaryPath
+    ?? process.env['CLAUDE_BINARY_PATH']
+    ?? DEFAULT_CLAUDE_BINARY;
+  const modelTag =
+    input.modelTag
+    ?? process.env['REVIEWER_MODEL_TAG']
+    ?? DEFAULT_MODEL_TAG;
+
+  const maxDiffBytes =
+    input.maxDiffBytes
+    ?? (Number(process.env['REVIEWER_MAX_DIFF_BYTES']) || DEFAULT_MAX_DIFF_BYTES);
+  const chunkBytes =
+    input.chunkBytes
+    ?? (Number(process.env['REVIEWER_CHUNK_BYTES']) || DEFAULT_CHUNK_BYTES);
+  const severityFloor: CraftsmanshipSeverity =
+    input.severityFloor
+    ?? (process.env['REVIEWER_SEVERITY_FLOOR'] as CraftsmanshipSeverity | undefined)
+    ?? DEFAULT_SEVERITY_FLOOR;
+  const perVectorTimeoutMs =
+    input.perVectorTimeoutMs
+    ?? (Number(process.env['REVIEWER_VECTOR_TIMEOUT_MS']) || DEFAULT_PER_VECTOR_TIMEOUT_MS);
+  const maxFindingsPerPr =
+    input.maxFindingsPerPr
+    ?? (Number(process.env['REVIEWER_MAX_FINDINGS']) || DEFAULT_MAX_FINDINGS_PER_PR);
+
+  const maxFunctionLines =
+    input.maxFunctionLines
+    ?? (Number(process.env['REVIEWER_MAX_FUNCTION_LINES']) || DEFAULT_MAX_FUNCTION_LINES);
+  const maxFileLines =
+    input.maxFileLines
+    ?? (Number(process.env['REVIEWER_MAX_FILE_LINES']) || DEFAULT_MAX_FILE_LINES);
+  const maxNestingDepth =
+    input.maxNestingDepth
+    ?? (Number(process.env['REVIEWER_MAX_NESTING_DEPTH']) || DEFAULT_MAX_NESTING_DEPTH);
+
+  const enableLlmReasoning =
+    input.enableLlmReasoning
+    ?? (process.env['REVIEWER_LLM_ENABLED'] !== '0');
+  const enableDeterministic =
+    input.enableDeterministic
+    ?? (process.env['REVIEWER_DETERMINISTIC_ENABLED'] !== '0');
+
+  return {
+    conventionsPath,
+    memoryRoot,
+    reportsRoot,
+    eventBusUrl,
+    claudeBinaryPath,
+    modelTag,
+    maxDiffBytes,
+    chunkBytes,
+    severityFloor,
+    perVectorTimeoutMs,
+    maxFindingsPerPr,
+    maxFunctionLines,
+    maxFileLines,
+    maxNestingDepth,
+    enableLlmReasoning,
+    enableDeterministic
+  };
+}

--- a/packages/reviewer/src/conventions-loader.ts
+++ b/packages/reviewer/src/conventions-loader.ts
@@ -1,0 +1,92 @@
+/**
+ * Conventions loader — reads AGENTS.md and extracts craftsmanship-relevant
+ * sections to ground the LLM-reasoned tier in CAIA's own style rules.
+ *
+ * Sections of interest (heading-name match, case-insensitive):
+ *   - "Code style"
+ *   - "Conventions"
+ *   - "Craftsmanship"
+ *   - "Idioms"
+ *   - "Naming"
+ *   - "Testing conventions"
+ *
+ * If the conventions file is missing → returns an empty array (the LLM
+ * tier still runs, just without project-specific grounding — the agent's
+ * pre-spawn Mentor + Librarian injection still provides context).
+ */
+
+import type { ConventionExcerpt, FsReader } from './types.js';
+
+/** Headings whose contents we extract for the LLM prompt. */
+const CONVENTIONS_HEADINGS = [
+  'code style',
+  'conventions',
+  'craftsmanship',
+  'idioms',
+  'naming',
+  'testing',
+  'testing conventions'
+];
+
+const HEADING_LINE = /^##+\s+(.+?)\s*(?:\(.*\))?$/;
+const BODY_EXCERPT_MAX = 500;
+
+export function loadConventions(fs: FsReader, conventionsPath: string): ConventionExcerpt[] {
+  if (!fs.exists(conventionsPath)) return [];
+  let content: string;
+  try {
+    content = fs.readFile(conventionsPath);
+  } catch {
+    return [];
+  }
+  return parseConventionsMarkdown(conventionsPath, content);
+}
+
+export function parseConventionsMarkdown(source: string, content: string): ConventionExcerpt[] {
+  const lines = content.split('\n');
+  const out: ConventionExcerpt[] = [];
+  let currentHeading: string | null = null;
+  let currentBuffer: string[] = [];
+
+  const flush = (): void => {
+    if (currentHeading === null) return;
+    if (!isCraftsmanshipHeading(currentHeading)) {
+      currentHeading = null;
+      currentBuffer = [];
+      return;
+    }
+    const body = currentBuffer.join('\n').trim();
+    if (body.length === 0) {
+      currentHeading = null;
+      currentBuffer = [];
+      return;
+    }
+    out.push({
+      source,
+      heading: currentHeading,
+      bodyExcerpt: body.slice(0, BODY_EXCERPT_MAX)
+    });
+    currentHeading = null;
+    currentBuffer = [];
+  };
+
+  for (const line of lines) {
+    const m = HEADING_LINE.exec(line);
+    if (m !== null) {
+      flush();
+      currentHeading = (m[1] ?? '').trim();
+      currentBuffer = [];
+      continue;
+    }
+    if (currentHeading !== null) {
+      currentBuffer.push(line);
+    }
+  }
+  flush();
+  return out;
+}
+
+function isCraftsmanshipHeading(heading: string): boolean {
+  const norm = heading.toLowerCase();
+  return CONVENTIONS_HEADINGS.some(h => norm.includes(h));
+}

--- a/packages/reviewer/src/detectors/comment-density.ts
+++ b/packages/reviewer/src/detectors/comment-density.ts
@@ -1,0 +1,70 @@
+/**
+ * comment-density detector.
+ *
+ * Flags new public exports added without a JSDoc-style comment block on the
+ * preceding line. CAIA convention: every public surface is self-documenting
+ * via JSDoc, even one-liners (so editor tooltips work for downstream
+ * consumers).
+ *
+ * The detector reads the FULL hunk body (added + context) so it can see
+ * the line before the export. If the prior line ends a JSDoc block (last
+ * two chars are an asterisk and a forward slash) or starts with two
+ * slashes, the export is considered documented.
+ */
+
+import type { Detector, DiffHunk } from '../types.js';
+import { walkHunk } from '../diff-parser.js';
+import { excerpt, isFixturePath, isJsTsSrcPath, isTestPath, makeFinding } from './shared.js';
+
+const PUBLIC_EXPORT = /^\s*export\s+(?:async\s+)?(?:function|class|interface|type|const|enum)\s+([A-Za-z_]\w*)/;
+const JSDOC_END = '*' + '/';
+
+export const commentDensityDetector: Detector = {
+  id: 'det-comment-density',
+  dimension: 'comment-density',
+  scan(hunk: DiffHunk, _ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    if (isTestPath(hunk.file)) return [];
+    const lines = walkHunk(hunk);
+    const findings = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line === undefined) continue;
+      if (line.kind !== '+') continue;
+      const m = PUBLIC_EXPORT.exec(line.text);
+      if (m === null) continue;
+      const symbol = m[1] ?? 'export';
+      // Inspect the immediately preceding NON-empty line (added or context)
+      // — comment? then it's documented.
+      let prev = i - 1;
+      while (prev >= 0) {
+        const p = lines[prev];
+        if (p === undefined) break;
+        if (p.text.trim() === '') {
+          prev--;
+          continue;
+        }
+        break;
+      }
+      if (prev >= 0) {
+        const p = lines[prev];
+        if (p !== undefined) {
+          const prevText = p.text.trimEnd();
+          if (prevText.endsWith(JSDOC_END) || prevText.trimStart().startsWith('//')) continue;
+        }
+      }
+      findings.push(makeFinding({
+        dimension: 'comment-density',
+        file: hunk.file,
+        line: line.newLine,
+        suggestionTitle: `undocumented-export-${symbol}`,
+        description: `Public export \`${symbol}\` added without a JSDoc preamble. Even a one-line JSDoc comment surfaces in editor tooltips for downstream consumers.`,
+        suggestedChange: `Add a JSDoc block above \`${symbol}\` describing what it does and any non-obvious constraints.`,
+        detectorId: 'det-comment-density',
+        excerpt: excerpt(line.text)
+      }));
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/detectors/console-logging.ts
+++ b/packages/reviewer/src/detectors/console-logging.ts
@@ -1,0 +1,44 @@
+/**
+ * console-logging detector.
+ *
+ * Flags `console.log` / `console.debug` added in `src/` files. Considered
+ * debug rot — production code uses the project logger; console.warn /
+ * console.error are allowed (legitimate non-fatal signal channels).
+ *
+ * CLI source files (`src/cli.ts`, `bin/*.ts`) are exempt because the CLI
+ * literally writes to stdout for the user.
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, isJsTsSrcPath, isTestPath, makeFinding } from './shared.js';
+
+const CONSOLE_DEBUG = /\bconsole\s*\.\s*(log|debug)\b/;
+const CLI_PATH = /(?:^|\/)(?:cli|bin)\.[jt]sx?$|(?:^|\/)bin\//;
+
+export const consoleLoggingDetector: Detector = {
+  id: 'det-console-logging',
+  dimension: 'console-logging',
+  scan(hunk, _ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    if (isTestPath(hunk.file)) return [];
+    if (CLI_PATH.test(hunk.file)) return [];
+    const findings = [];
+    for (const line of addedTextOnly(hunk)) {
+      const m = CONSOLE_DEBUG.exec(line.text);
+      if (m === null) continue;
+      const method = m[1] ?? 'log';
+      findings.push(makeFinding({
+        dimension: 'console-logging',
+        file: hunk.file,
+        line: line.newLine,
+        suggestionTitle: `console-${method}`,
+        description: `\`console.${method}\` added in production source. Use the project logger for routed/leveled output; console.${method} silently bloats prod logs and skips structured fields.`,
+        suggestedChange: `Switch to the package's logger (e.g. \`logger.info(...)\`); console.warn / console.error are still allowed for unrecoverable channels.`,
+        detectorId: 'det-console-logging',
+        excerpt: excerpt(line.text)
+      }));
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/detectors/deep-nesting.ts
+++ b/packages/reviewer/src/detectors/deep-nesting.ts
@@ -1,0 +1,60 @@
+/**
+ * deep-nesting detector.
+ *
+ * Counts leading whitespace indent units on added lines. When indent
+ * exceeds `ctx.thresholds.maxNestingDepth` (default 4 — matching AGENTS.md
+ * "no nesting >4 levels") we emit a `suggestion` finding pointing at the
+ * deepest line.
+ *
+ * Indentation unit detection: 2 spaces or a tab. Mixed indentation
+ * is treated as if every leading tab is one level.
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, isJsTsSrcPath, makeFinding } from './shared.js';
+
+const SPACES_PER_LEVEL = 2;
+const LEADING_WS = /^([ \t]*)/;
+
+export const deepNestingDetector: Detector = {
+  id: 'det-deep-nesting',
+  dimension: 'deep-nesting',
+  scan(hunk, ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    const findings = [];
+    let deepest = 0;
+    let deepestLine = 0;
+    let deepestText = '';
+    for (const line of addedTextOnly(hunk)) {
+      if (line.text.trim() === '') continue;
+      const m = LEADING_WS.exec(line.text);
+      const ws = m === null ? '' : (m[1] ?? '');
+      // Treat each tab as one level; spaces in groups of two.
+      let level = 0;
+      for (let i = 0; i < ws.length; i++) {
+        if (ws[i] === '\t') level++;
+      }
+      const spaceCount = ws.replace(/\t/g, '').length;
+      level += Math.floor(spaceCount / SPACES_PER_LEVEL);
+      if (level > deepest) {
+        deepest = level;
+        deepestLine = line.newLine;
+        deepestText = line.text;
+      }
+    }
+    if (deepest > ctx.thresholds.maxNestingDepth) {
+      findings.push(makeFinding({
+        dimension: 'deep-nesting',
+        file: hunk.file,
+        line: deepestLine,
+        suggestionTitle: `nesting-depth-${deepest}`,
+        description: `Indent depth ${deepest} exceeds threshold ${ctx.thresholds.maxNestingDepth}. Deep nesting hides control flow; CAIA convention (AGENTS.md "Code style") is "no nesting >4 levels".`,
+        suggestedChange: 'Lift inner blocks into helpers, use early returns, or invert conditionals to flatten the structure.',
+        detectorId: 'det-deep-nesting',
+        excerpt: excerpt(deepestText)
+      }));
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/detectors/duplicate-imports.ts
+++ b/packages/reviewer/src/detectors/duplicate-imports.ts
@@ -1,0 +1,47 @@
+/**
+ * duplicate-imports detector.
+ *
+ * Flags two `import` lines from the same module path within a single
+ * hunk's added content. Common when an agent edits in two passes and
+ * doesn't consolidate the imports.
+ *
+ * Hunk-local — won't catch a duplicate split across hunks of the same
+ * file (acceptable; this is a `nit`-severity advisory).
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, isJsTsSrcPath, makeFinding } from './shared.js';
+
+const IMPORT_FROM = /^\s*import\s+.*?\s+from\s+['"]([^'"]+)['"]/;
+
+export const duplicateImportsDetector: Detector = {
+  id: 'det-duplicate-imports',
+  dimension: 'duplicate-imports',
+  scan(hunk, _ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    const findings = [];
+    const seen = new Map<string, number>();
+    for (const line of addedTextOnly(hunk)) {
+      const m = IMPORT_FROM.exec(line.text);
+      if (m === null) continue;
+      const mod = m[1] ?? '';
+      const firstLine = seen.get(mod);
+      if (firstLine !== undefined) {
+        findings.push(makeFinding({
+          dimension: 'duplicate-imports',
+          file: hunk.file,
+          line: line.newLine,
+          suggestionTitle: `duplicate-import-${mod}`,
+          description: `Module \`${mod}\` imported twice in this hunk (also at line ${firstLine}). Consolidate into a single import statement.`,
+          suggestedChange: `Merge the two \`import\` statements into one combined import.`,
+          detectorId: 'det-duplicate-imports',
+          excerpt: excerpt(line.text)
+        }));
+        continue;
+      }
+      seen.set(mod, line.newLine);
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/detectors/file-length.ts
+++ b/packages/reviewer/src/detectors/file-length.ts
@@ -1,0 +1,45 @@
+/**
+ * file-length detector.
+ *
+ * Flags files where the highest `newLine` number exceeds
+ * `ctx.thresholds.maxFileLines`. Single finding per file (line 1).
+ *
+ * This is a hunk-local heuristic — we conservatively only fire when the
+ * hunk itself reaches the threshold, since we don't have whole-file
+ * context. False negatives (file is already 480 lines and the hunk only
+ * adds 5 more) are acceptable; false positives erode trust faster.
+ */
+
+import type { Detector, DiffHunk } from '../types.js';
+import { walkHunk } from '../diff-parser.js';
+import { excerpt, isDocsPath, isFixturePath, isJsTsSrcPath, makeFinding } from './shared.js';
+
+export const fileLengthDetector: Detector = {
+  id: 'det-file-length',
+  dimension: 'file-length',
+  scan(hunk: DiffHunk, ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isDocsPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    // Walk all body lines; both `+` and ` ` context lines carry valid new-file
+    // line numbers. Removed lines (`-`) don't appear in the new file so we
+    // skip them.
+    const lines = walkHunk(hunk).filter(l => l.kind === '+' || l.kind === ' ');
+    if (lines.length === 0) return [];
+    let lastLineNum = 0;
+    for (const l of lines) {
+      if (l.newLine > lastLineNum) lastLineNum = l.newLine;
+    }
+    if (lastLineNum <= ctx.thresholds.maxFileLines) return [];
+    return [makeFinding({
+      dimension: 'file-length',
+      file: hunk.file,
+      line: 1,
+      suggestionTitle: `file-length-${lastLineNum}`,
+      description: `File extends past line ${lastLineNum} (threshold: ${ctx.thresholds.maxFileLines}). Long files resist navigation; consider splitting along cohesive seams (one type / one detector / one feature per file).`,
+      suggestedChange: 'Identify a cohesive sub-module and extract it. Common seams: types, helpers, dispatch table, factory functions.',
+      detectorId: 'det-file-length',
+      excerpt: excerpt(`file ends at line ${lastLineNum}`)
+    })];
+  }
+};

--- a/packages/reviewer/src/detectors/function-length.ts
+++ b/packages/reviewer/src/detectors/function-length.ts
@@ -1,0 +1,81 @@
+/**
+ * function-length detector.
+ *
+ * Hunk-local heuristic — counts consecutive added lines inside a function
+ * body started by `function`/`=>` keyword and not yet closed by a balanced
+ * `}` at indent depth 0 from the function start. If the count exceeds
+ * `ctx.thresholds.maxFunctionLines`, emit a `consider` finding.
+ *
+ * The detector deliberately uses indentation tracking rather than a full
+ * AST — cheaper, deterministic, and good enough for advisory output.
+ * False positives (functions inside object literals) are acceptable
+ * because the suggestion is non-blocking.
+ */
+
+import type { Detector } from '../types.js';
+import { walkHunk } from '../diff-parser.js';
+import { excerpt, isFixturePath, isJsTsSrcPath, makeFinding } from './shared.js';
+
+const FUNCTION_START = /\b(function|=>)\b/;
+
+export const functionLengthDetector: Detector = {
+  id: 'det-function-length',
+  dimension: 'function-length',
+  scan(hunk, ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    const lines = walkHunk(hunk).filter(l => l.kind === '+' || l.kind === ' ');
+    const findings = [];
+
+    let inFunction = false;
+    let openBraces = 0;
+    let startLine = 0;
+    let lineCount = 0;
+    let firstLineText = '';
+
+    for (const line of lines) {
+      const text = line.text;
+      if (!inFunction) {
+        // Detect a function start: keyword + opening brace on this line OR
+        // arrow with `{` somewhere in this line.
+        if (FUNCTION_START.test(text) && text.includes('{')) {
+          inFunction = true;
+          openBraces = countChar(text, '{') - countChar(text, '}');
+          startLine = line.kind === '+' ? line.newLine : line.oldLine;
+          lineCount = 1;
+          firstLineText = text;
+        }
+        continue;
+      }
+      // Already inside a function — keep counting until braces balance.
+      lineCount++;
+      openBraces += countChar(text, '{') - countChar(text, '}');
+      if (openBraces <= 0) {
+        if (lineCount > ctx.thresholds.maxFunctionLines) {
+          findings.push(makeFinding({
+            dimension: 'function-length',
+            file: hunk.file,
+            line: startLine,
+            suggestionTitle: `function-length-${lineCount}`,
+            description: `Function spans ${lineCount} lines (threshold: ${ctx.thresholds.maxFunctionLines}). Long functions resist comprehension; consider extracting cohesive sections into helpers.`,
+            suggestedChange: 'Extract sub-blocks into well-named helper functions; aim for the function body to read like a high-level summary.',
+            detectorId: 'det-function-length',
+            excerpt: excerpt(firstLineText)
+          }));
+        }
+        inFunction = false;
+        openBraces = 0;
+        lineCount = 0;
+        startLine = 0;
+        firstLineText = '';
+      }
+    }
+    return findings;
+  }
+};
+
+function countChar(s: string, ch: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s[i] === ch) n++;
+  return n;
+}

--- a/packages/reviewer/src/detectors/index.ts
+++ b/packages/reviewer/src/detectors/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Deterministic detector registry — see DESIGN.md §6.1.
+ *
+ * Each detector is a small, testable, regex/line-walk-based scanner
+ * targeting one of the 10 craftsmanship dimensions where pattern matching
+ * is sufficient. The remaining 8 dimensions are LLM-reasoned (see
+ * `../llm-reasoner.ts`).
+ */
+
+import type { Detector } from '../types.js';
+
+import { namingConventionDetector } from './naming-convention.js';
+import { functionLengthDetector } from './function-length.js';
+import { fileLengthDetector } from './file-length.js';
+import { commentDensityDetector } from './comment-density.js';
+import { magicNumbersDetector } from './magic-numbers.js';
+import { duplicateImportsDetector } from './duplicate-imports.js';
+import { deepNestingDetector } from './deep-nesting.js';
+import { todoWithoutTicketDetector } from './todo-without-ticket.js';
+import { consoleLoggingDetector } from './console-logging.js';
+import { typeAnyDetector } from './type-any.js';
+
+/** All deterministic detectors. Order is stable and deterministic. */
+export const ALL_DETECTORS: readonly Detector[] = Object.freeze([
+  namingConventionDetector,
+  functionLengthDetector,
+  fileLengthDetector,
+  commentDensityDetector,
+  magicNumbersDetector,
+  duplicateImportsDetector,
+  deepNestingDetector,
+  todoWithoutTicketDetector,
+  consoleLoggingDetector,
+  typeAnyDetector
+]);
+
+export {
+  namingConventionDetector,
+  functionLengthDetector,
+  fileLengthDetector,
+  commentDensityDetector,
+  magicNumbersDetector,
+  duplicateImportsDetector,
+  deepNestingDetector,
+  todoWithoutTicketDetector,
+  consoleLoggingDetector,
+  typeAnyDetector
+};
+
+export { excerpt, addedTextOnly, isJsTsSrcPath, isTestPath, isDocsPath, isFixturePath } from './shared.js';

--- a/packages/reviewer/src/detectors/magic-numbers.ts
+++ b/packages/reviewer/src/detectors/magic-numbers.ts
@@ -1,0 +1,55 @@
+/**
+ * magic-numbers detector.
+ *
+ * Flags numeric literals that are reasonable candidates for extraction
+ * into named constants. We deliberately tune for low false positives —
+ * the detector only fires when:
+ *   - the literal is >= 100 OR contains an `_` digit separator
+ *   - the literal is not on a `const ... =` declaration line (already named)
+ *   - the file isn't a test or fixture
+ *
+ * Rationale: small literals (0/1/-1/2) and obvious sentinel values rarely
+ * benefit from extraction; large or composite literals nearly always do.
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, isJsTsSrcPath, isTestPath, makeFinding } from './shared.js';
+
+// Match large bare numbers OR numbers with underscores separators.
+const MAGIC_NUMBER = /(?<![\w.])(\d{3,}|\d{1,3}(?:_\d{3,})+)(?![\w.])/g;
+const ASSIGNMENT_DECLARATION = /\b(?:const|let|var|enum|readonly)\s+[A-Z_][A-Z0-9_]*\s*[:=]/;
+const ARRAY_INDEX_HINT = /\[\s*\d+\s*\]/;
+
+export const magicNumbersDetector: Detector = {
+  id: 'det-magic-numbers',
+  dimension: 'magic-numbers',
+  scan(hunk, _ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isTestPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    const findings = [];
+    for (const line of addedTextOnly(hunk)) {
+      // Skip lines that are already a SCREAMING_SNAKE constant declaration —
+      // the literal IS the named constant.
+      if (ASSIGNMENT_DECLARATION.test(line.text)) continue;
+      MAGIC_NUMBER.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = MAGIC_NUMBER.exec(line.text)) !== null) {
+        const literal = m[1] ?? '';
+        // Skip array-index expressions — `arr[0]` style is fine.
+        if (ARRAY_INDEX_HINT.test(line.text) && literal.length < 4) continue;
+        findings.push(makeFinding({
+          dimension: 'magic-numbers',
+          file: hunk.file,
+          line: line.newLine,
+          suggestionTitle: `magic-number-${literal}`,
+          description: `Numeric literal \`${literal}\` used inline. Extracting to a named constant makes intent obvious and centralises the value for future tuning.`,
+          suggestedChange: `Promote \`${literal}\` to a SCREAMING_SNAKE \`const\` at module-top, e.g. \`const DEFAULT_TIMEOUT_MS = ${literal};\`.`,
+          detectorId: 'det-magic-numbers',
+          excerpt: excerpt(line.text)
+        }));
+      }
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/detectors/naming-convention.ts
+++ b/packages/reviewer/src/detectors/naming-convention.ts
@@ -1,0 +1,70 @@
+/**
+ * naming-convention detector.
+ *
+ * Flags identifier choices that don't match the repo's TS conventions:
+ *   - single-letter variable names outside a tiny allowlist of common iter
+ *     letters (i/j/k/x/y/n/t/e), or arrow-function param idioms
+ *   - snake_case identifiers in TS source (CAIA is camelCase / PascalCase)
+ *
+ * The detector is intentionally conservative — naming is the noisiest
+ * craftsmanship dimension, so we only flag clear-cut cases.
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, isJsTsSrcPath, isTestPath, makeFinding } from './shared.js';
+
+const SHORT_NAME_DECLARATION = /\b(?:const|let|var)\s+([a-z])\s*[=:]/g;
+// snake_case identifier introduced as a name. We only catch declarations
+// (const/let/var/function/class/type/interface) — using existing snake_case
+// from a third-party API is fine.
+const SNAKE_DECLARATION = /\b(?:const|let|var|function|class|type|interface)\s+([a-z]+_[a-z_]+)\b/g;
+const ALLOWED_SHORT_NAMES = new Set(['i', 'j', 'k', 'x', 'y', 'n', 't', 'e', '_']);
+
+export const namingConventionDetector: Detector = {
+  id: 'det-naming-convention',
+  dimension: 'naming-convention',
+  scan(hunk, _ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    if (isTestPath(hunk.file)) return [];
+    const findings = [];
+    for (const line of addedTextOnly(hunk)) {
+      // Reset regex state for each line.
+      SHORT_NAME_DECLARATION.lastIndex = 0;
+      SNAKE_DECLARATION.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = SHORT_NAME_DECLARATION.exec(line.text)) !== null) {
+        const name = m[1] ?? '';
+        if (ALLOWED_SHORT_NAMES.has(name)) continue;
+        findings.push(makeFinding({
+          dimension: 'naming-convention',
+          file: hunk.file,
+          line: line.newLine,
+          suggestionTitle: `single-letter-name-${name}`,
+          description: `Single-letter variable name \`${name}\` outside the allowlisted iter set (i/j/k/x/y/n/t/e). Names should be self-describing — even loop counters benefit when the loop body is non-trivial.`,
+          suggestedChange: `Rename \`${name}\` to a descriptive identifier (e.g. \`index\`, \`item\`, \`cursor\`).`,
+          detectorId: 'det-naming-convention',
+          excerpt: excerpt(line.text)
+        }));
+      }
+      while ((m = SNAKE_DECLARATION.exec(line.text)) !== null) {
+        const name = m[1] ?? '';
+        findings.push(makeFinding({
+          dimension: 'naming-convention',
+          file: hunk.file,
+          line: line.newLine,
+          suggestionTitle: `snake-case-${name}`,
+          description: `Identifier \`${name}\` uses snake_case in TypeScript source. CAIA convention (AGENTS.md "Code style") is camelCase for variables/functions and PascalCase for types/classes.`,
+          suggestedChange: `Rename to camelCase (e.g. \`${snakeToCamel(name)}\`).`,
+          detectorId: 'det-naming-convention',
+          excerpt: excerpt(line.text)
+        }));
+      }
+    }
+    return findings;
+  }
+};
+
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_, ch: string) => ch.toUpperCase());
+}

--- a/packages/reviewer/src/detectors/shared.ts
+++ b/packages/reviewer/src/detectors/shared.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared helpers for deterministic detectors.
+ */
+
+import type {
+  CraftsmanshipDimensionId,
+  CraftsmanshipFinding,
+  CraftsmanshipSeverity,
+  DiffHunk
+} from '../types.js';
+import { DEFAULT_SEVERITY } from '../types.js';
+import { walkHunk, type DiffLine } from '../diff-parser.js';
+
+/** Build a stable id-hash for a finding — used for cross-chunk dedup. */
+export function findingId(parts: { dimension: string; file: string; line: number; suggestionTitle: string }): string {
+  const s = `${parts.dimension}|${parts.file}|${parts.line}|${parts.suggestionTitle}`;
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = (h * 33) ^ s.charCodeAt(i);
+  return `rev-${(h >>> 0).toString(16)}`;
+}
+
+/** Cap excerpt at 200 chars per DESIGN.md §4. */
+export function excerpt(text: string, max = 200): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 3) + '...';
+}
+
+/** Iterate added lines only — most detectors only care about new content. */
+export function addedTextOnly(hunk: DiffHunk): DiffLine[] {
+  return walkHunk(hunk).filter(l => l.kind === '+');
+}
+
+export function makeFinding(args: {
+  dimension: CraftsmanshipDimensionId;
+  file: string;
+  line: number;
+  suggestionTitle: string;
+  description: string;
+  suggestedChange?: string;
+  detectorId: string;
+  excerpt: string;
+  severity?: CraftsmanshipSeverity;
+}): CraftsmanshipFinding {
+  const sev = args.severity ?? DEFAULT_SEVERITY[args.dimension];
+  const f: CraftsmanshipFinding = {
+    id: findingId(args),
+    dimension: args.dimension,
+    severity: sev,
+    file: args.file,
+    line: args.line,
+    suggestionTitle: args.suggestionTitle,
+    description: args.description,
+    source: 'deterministic',
+    detectorId: args.detectorId,
+    excerpt: args.excerpt
+  };
+  if (args.suggestedChange !== undefined) {
+    f.suggestedChange = args.suggestedChange;
+  }
+  return f;
+}
+
+/** Path is a test-fixture / fixture file — many craftsmanship rules don't
+ * apply (intentionally messy code, fixtures of forbidden patterns, etc.). */
+export function isFixturePath(file: string): boolean {
+  return /(?:^|\/)(?:__fixtures__|tests\/fixtures|tests\/__fixtures__|fixtures)\//.test(file)
+    || /\.example\b|\.sample\b/.test(file);
+}
+
+/** Path is a test file. */
+export function isTestPath(file: string): boolean {
+  return /(?:^|\/)(?:tests|__tests__)\//.test(file)
+    || /\.(test|spec)\.[jt]sx?$/.test(file);
+}
+
+/** Path is a markdown / docs file — comment-density / type-any don't apply. */
+export function isDocsPath(file: string): boolean {
+  return /\.(md|mdx|markdown)$/i.test(file);
+}
+
+/** Path is TypeScript / JavaScript source under packages or apps. */
+export function isJsTsSrcPath(file: string): boolean {
+  if (!/^(?:packages|apps)\/[^/]+\/src\//.test(file)) return false;
+  return /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(file);
+}

--- a/packages/reviewer/src/detectors/todo-without-ticket.ts
+++ b/packages/reviewer/src/detectors/todo-without-ticket.ts
@@ -1,0 +1,40 @@
+/**
+ * todo-without-ticket detector.
+ *
+ * Flags `TODO` / `FIXME` / `XXX` markers added without a follow-up tracker
+ * reference. CAIA convention: every TODO carries either a ticket id
+ * (`CAIA-1234`), a github issue (`#1234`), or an explicit timestamp
+ * (`TODO(2026-05-06):`).
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, makeFinding } from './shared.js';
+
+const TODO_MARKER = /\b(TODO|FIXME|XXX)\b/;
+const TICKET_REF = /\b(?:CAIA-\d+|#\d+|\d{4}-\d{2}-\d{2})\b/;
+
+export const todoWithoutTicketDetector: Detector = {
+  id: 'det-todo-without-ticket',
+  dimension: 'todo-without-ticket',
+  scan(hunk, _ctx) {
+    if (isFixturePath(hunk.file)) return [];
+    const findings = [];
+    for (const line of addedTextOnly(hunk)) {
+      const m = TODO_MARKER.exec(line.text);
+      if (m === null) continue;
+      if (TICKET_REF.test(line.text)) continue;
+      const marker = m[1] ?? 'TODO';
+      findings.push(makeFinding({
+        dimension: 'todo-without-ticket',
+        file: hunk.file,
+        line: line.newLine,
+        suggestionTitle: `${marker.toLowerCase()}-without-ticket`,
+        description: `\`${marker}\` marker added without a tracker reference (CAIA-####, #####, or YYYY-MM-DD). Untracked TODOs accumulate as silent debt.`,
+        suggestedChange: `Append a ticket / issue / date — e.g. \`${marker}(CAIA-1234): description\` or \`${marker}(2026-05-06): description\`.`,
+        detectorId: 'det-todo-without-ticket',
+        excerpt: excerpt(line.text)
+      }));
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/detectors/type-any.ts
+++ b/packages/reviewer/src/detectors/type-any.ts
@@ -1,0 +1,44 @@
+/**
+ * type-any detector.
+ *
+ * Flags explicit `: any` annotations, `as any` casts, and `<any>` generics
+ * added to TypeScript source. AGENTS.md "Code style" — "No `any`. Use
+ * `unknown` + narrow, or fix the type."
+ *
+ * Test files are exempt — fixture types occasionally need `any` for
+ * shape-mismatch fakes.
+ */
+
+import type { Detector } from '../types.js';
+import { addedTextOnly, excerpt, isFixturePath, isJsTsSrcPath, isTestPath, makeFinding } from './shared.js';
+
+const ANY_ANNOTATION = /:\s*any\b|\bas\s+any\b|<any>/;
+const TYPESCRIPT_FILE = /\.tsx?$/;
+
+export const typeAnyDetector: Detector = {
+  id: 'det-type-any',
+  dimension: 'type-any',
+  scan(hunk, _ctx) {
+    if (!isJsTsSrcPath(hunk.file)) return [];
+    if (!TYPESCRIPT_FILE.test(hunk.file)) return [];
+    if (isTestPath(hunk.file)) return [];
+    if (isFixturePath(hunk.file)) return [];
+    const findings = [];
+    for (const line of addedTextOnly(hunk)) {
+      if (!ANY_ANNOTATION.test(line.text)) continue;
+      // Skip lines that are eslint-disable comments referencing any.
+      if (/eslint-disable.*no-explicit-any/.test(line.text)) continue;
+      findings.push(makeFinding({
+        dimension: 'type-any',
+        file: hunk.file,
+        line: line.newLine,
+        suggestionTitle: 'explicit-any',
+        description: 'Explicit `any` annotation / cast added. CAIA convention (AGENTS.md "Code style") is `unknown` + narrow, or a precise type. `any` silently disables type-checking and propagates unsoundness.',
+        suggestedChange: 'Replace `any` with `unknown` (and narrow at use-site) or with the precise type.',
+        detectorId: 'det-type-any',
+        excerpt: excerpt(line.text)
+      }));
+    }
+    return findings;
+  }
+};

--- a/packages/reviewer/src/diff-parser.ts
+++ b/packages/reviewer/src/diff-parser.ts
@@ -1,0 +1,201 @@
+/**
+ * Unified-diff parser — pure functions, no I/O.
+ *
+ * Mirrors the shape used by `@chiefaia/critic`'s parser (intentional —
+ * Reviewer and Critic share the same pre-processing path so the two-tier
+ * detector pattern is uniform across both agents).
+ *
+ * Handles GitHub-style unified diff:
+ *   - `diff --git a/<path> b/<path>` separator lines
+ *   - `--- a/<path>` / `+++ b/<path>` file headers
+ *   - `@@ -<oldStart>,<oldLen> +<newStart>,<newLen> @@` hunk headers
+ *   - hunk-body lines prefixed with ` `, `+`, `-`
+ *   - `new file mode <oct>` / `deleted file mode <oct>` / `rename from`
+ *
+ * Binary-file diffs are skipped.
+ */
+
+import type { DiffHunk, ParsedDiff } from './types.js';
+
+const FILE_HEADER = /^diff --git a\/(.+?) b\/(.+?)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export function parseDiff(diff: string): ParsedDiff {
+  const lines = diff.split('\n');
+  const hunks: DiffHunk[] = [];
+  const fileSet = new Set<string>();
+
+  let currentFile: string | null = null;
+  let currentStatus: DiffHunk['status'] = 'modified';
+  let currentBody: string[] = [];
+  let currentHeader = '';
+  let currentOldStart = 0;
+  let currentNewStart = 0;
+  let inHunk = false;
+  let isBinary = false;
+
+  const flush = (): void => {
+    if (inHunk && currentFile !== null && !isBinary) {
+      hunks.push({
+        file: currentFile,
+        oldStart: currentOldStart,
+        newStart: currentNewStart,
+        header: currentHeader,
+        body: currentBody.join('\n'),
+        status: currentStatus
+      });
+    }
+    inHunk = false;
+    currentBody = [];
+  };
+
+  for (const line of lines) {
+    const fileMatch = FILE_HEADER.exec(line);
+    if (fileMatch !== null) {
+      flush();
+      currentFile = fileMatch[2] ?? fileMatch[1] ?? null;
+      if (currentFile !== null) fileSet.add(currentFile);
+      currentStatus = 'modified';
+      isBinary = false;
+      continue;
+    }
+    if (line.startsWith('new file mode ')) {
+      currentStatus = 'added';
+      continue;
+    }
+    if (line.startsWith('deleted file mode ')) {
+      currentStatus = 'deleted';
+      continue;
+    }
+    if (line.startsWith('rename from ') || line.startsWith('rename to ')) {
+      currentStatus = 'renamed';
+      continue;
+    }
+    if (line.startsWith('Binary files ')) {
+      isBinary = true;
+      continue;
+    }
+    if (line.startsWith('--- ') || line.startsWith('+++ ')) {
+      // discard — file path already captured
+      continue;
+    }
+    const hunkMatch = HUNK_HEADER.exec(line);
+    if (hunkMatch !== null) {
+      flush();
+      inHunk = true;
+      currentHeader = line;
+      currentOldStart = Number(hunkMatch[1] ?? '0');
+      currentNewStart = Number(hunkMatch[3] ?? '0');
+      currentBody = [];
+      continue;
+    }
+    if (inHunk && currentFile !== null && !isBinary) {
+      if (line === '' || line.startsWith(' ') || line.startsWith('+') || line.startsWith('-') || line.startsWith('\\')) {
+        currentBody.push(line);
+      }
+    }
+  }
+  flush();
+
+  return {
+    hunks,
+    totalBytes: Buffer.byteLength(diff, 'utf-8'),
+    fileCount: fileSet.size
+  };
+}
+
+/**
+ * Split a hunk into smaller sub-hunks of at most `maxBytes` body bytes.
+ * Used for diff-chunking — large hunks degrade LLM evaluation quality
+ * (Datadog BewAIre lesson). Sub-hunks share `file`; line offsets are
+ * adjusted for each chunk.
+ */
+export function chunkHunk(hunk: DiffHunk, maxBytes: number): DiffHunk[] {
+  if (Buffer.byteLength(hunk.body, 'utf-8') <= maxBytes) return [hunk];
+
+  const lines = hunk.body.split('\n');
+  const out: DiffHunk[] = [];
+  let bucket: string[] = [];
+  let bucketBytes = 0;
+  let oldOffset = 0;
+  let newOffset = 0;
+  let nextOldOffset = 0;
+  let nextNewOffset = 0;
+
+  const advance = (line: string): void => {
+    if (line.startsWith('-')) nextOldOffset++;
+    else if (line.startsWith('+')) nextNewOffset++;
+    else if (line.startsWith(' ') || line === '') {
+      nextOldOffset++;
+      nextNewOffset++;
+    }
+  };
+
+  const flushBucket = (): void => {
+    if (bucket.length === 0) return;
+    out.push({
+      file: hunk.file,
+      oldStart: hunk.oldStart + oldOffset,
+      newStart: hunk.newStart + newOffset,
+      header: out.length === 0
+        ? hunk.header
+        : `@@ -${hunk.oldStart + oldOffset} +${hunk.newStart + newOffset} @@ (chunked)`,
+      body: bucket.join('\n'),
+      status: hunk.status
+    });
+    oldOffset = nextOldOffset;
+    newOffset = nextNewOffset;
+    bucket = [];
+    bucketBytes = 0;
+  };
+
+  for (const line of lines) {
+    const lineBytes = Buffer.byteLength(line, 'utf-8') + 1;
+    if (bucketBytes + lineBytes > maxBytes && bucket.length > 0) {
+      flushBucket();
+    }
+    bucket.push(line);
+    bucketBytes += lineBytes;
+    advance(line);
+  }
+  flushBucket();
+  return out;
+}
+
+export interface DiffLine {
+  /** kind: '+' added, '-' removed, ' ' context. */
+  kind: '+' | '-' | ' ';
+  /** New-file line number, 1-based. -1 for removed lines. */
+  newLine: number;
+  /** Old-file line number, 1-based. -1 for added lines. */
+  oldLine: number;
+  /** Raw text with the prefix stripped. */
+  text: string;
+}
+
+/**
+ * Walk a hunk body and emit (kind, newLine, oldLine, text) per body line.
+ * Useful for detectors that need exact line numbers.
+ */
+export function walkHunk(hunk: DiffHunk): DiffLine[] {
+  const out: DiffLine[] = [];
+  let oldLine = hunk.oldStart;
+  let newLine = hunk.newStart;
+  for (const raw of hunk.body.split('\n')) {
+    if (raw === '' || raw.startsWith('\\')) continue;
+    const prefix = raw[0] ?? ' ';
+    const text = raw.slice(1);
+    if (prefix === '+') {
+      out.push({ kind: '+', newLine, oldLine: -1, text });
+      newLine++;
+    } else if (prefix === '-') {
+      out.push({ kind: '-', newLine: -1, oldLine, text });
+      oldLine++;
+    } else {
+      out.push({ kind: ' ', newLine, oldLine, text });
+      newLine++;
+      oldLine++;
+    }
+  }
+  return out;
+}

--- a/packages/reviewer/src/fs-reader.ts
+++ b/packages/reviewer/src/fs-reader.ts
@@ -1,0 +1,26 @@
+/**
+ * Default real-filesystem reader. Tests inject a fake instead.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+
+import type { FsReader } from './types.js';
+
+export const defaultFsReader: FsReader = {
+  exists(p: string): boolean {
+    return existsSync(p);
+  },
+  readFile(p: string): string {
+    return readFileSync(p, 'utf-8');
+  },
+  readDir(p: string): string[] {
+    if (!existsSync(p)) return [];
+    try {
+      const st = statSync(p);
+      if (!st.isDirectory()) return [];
+      return readdirSync(p).sort();
+    } catch {
+      return [];
+    }
+  }
+};

--- a/packages/reviewer/src/index.ts
+++ b/packages/reviewer/src/index.ts
@@ -1,0 +1,68 @@
+/**
+ * @chiefaia/reviewer — public surface.
+ *
+ * Craftsmanship-focused PR review agent — advisory-only. See DESIGN.md
+ * for the design rationale, dimension mapping, and Critic differentiation.
+ */
+
+export { ReviewerAgent, type ReviewPRArgs } from './agent.js';
+export {
+  resolveConfig,
+  expandHome,
+  type ReviewerAgentConfig,
+  type ResolvedReviewerAgentConfig
+} from './config.js';
+
+export { defaultFsReader } from './fs-reader.js';
+export { parseDiff, chunkHunk, walkHunk, type DiffLine } from './diff-parser.js';
+export { loadConventions, parseConventionsMarkdown } from './conventions-loader.js';
+export { mergeFindings, type MergeArgs, type MergeResult } from './merger.js';
+export {
+  createDefaultLlmReviewer,
+  noopLlmReviewer,
+  parseLlmOutput,
+  buildPrompt,
+  type DefaultLlmReviewerOptions
+} from './llm-reasoner.js';
+
+export {
+  ALL_DETECTORS,
+  namingConventionDetector,
+  functionLengthDetector,
+  fileLengthDetector,
+  commentDensityDetector,
+  magicNumbersDetector,
+  duplicateImportsDetector,
+  deepNestingDetector,
+  todoWithoutTicketDetector,
+  consoleLoggingDetector,
+  typeAnyDetector,
+  isJsTsSrcPath,
+  isTestPath,
+  isDocsPath,
+  isFixturePath
+} from './detectors/index.js';
+
+export type {
+  CraftsmanshipFinding,
+  CraftsmanshipReview,
+  CraftsmanshipDimensionId,
+  CraftsmanshipSeverity,
+  ConventionExcerpt,
+  Detector,
+  DiffHunk,
+  ParsedDiff,
+  FsReader,
+  LlmReviewer,
+  LlmReviewInput,
+  LlmReviewOutput,
+  ReviewSummary,
+  ScanContext
+} from './types.js';
+
+export {
+  ALL_DIMENSIONS,
+  DEFAULT_SEVERITY,
+  SEVERITY_RANK,
+  CRITIC_DENYLIST
+} from './types.js';

--- a/packages/reviewer/src/llm-reasoner.ts
+++ b/packages/reviewer/src/llm-reasoner.ts
@@ -1,0 +1,249 @@
+/**
+ * LLM-reasoned tier — see DESIGN.md §6.2.
+ *
+ * Spawns the `claude` binary in subprocess (subscription-only path —
+ * cribbed from packages/apprentice-corpus/src/distiller.ts and the sibling
+ * Critic agent's `llm-reasoner.ts`). The prompt carries:
+ *   1. A craftsmanship-review system prompt (tone: advisory, not adversarial).
+ *   2. The 18 craftsmanship dimensions with one-line descriptions.
+ *   3. A clear NON-OVERLAP instruction: don't flag Critic categories.
+ *   4. The diff hunks (capped to a configured byte budget).
+ *   5. AGENTS.md / conventions excerpts so the LLM grounds in CAIA idioms.
+ *   6. A strict JSON output schema.
+ *
+ * Failures (timeout, parse-error, non-zero exit) cause `ok: false` and the
+ * caller drops the LLM-tier findings. Deterministic-tier findings are
+ * always emitted regardless.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+
+import type {
+  CraftsmanshipDimensionId,
+  CraftsmanshipFinding,
+  CraftsmanshipSeverity,
+  LlmReviewInput,
+  LlmReviewOutput,
+  LlmReviewer
+} from './types.js';
+import { ALL_DIMENSIONS, CRITIC_DENYLIST, DEFAULT_SEVERITY, SEVERITY_RANK } from './types.js';
+
+export interface DefaultLlmReviewerOptions {
+  binaryPath: string;
+  modelTag: string;
+  timeoutMs: number;
+  /** Test seam — replaces `child_process.spawnSync`. */
+  spawnFn?: (
+    cmd: string,
+    args: readonly string[],
+    opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }
+  ) => SpawnSyncReturns<string>;
+}
+
+const DIMENSION_DESCRIPTIONS: Readonly<Record<CraftsmanshipDimensionId, string>> = {
+  'naming-convention': 'identifier choices that don\'t fit the repo style (single-letter outside iters, snake_case in TS).',
+  'function-length': 'function exceeds reasonable length and could split into helpers.',
+  'file-length': 'file is too long; split along cohesive seams.',
+  'comment-density': 'public symbol added without a JSDoc preamble.',
+  'magic-numbers': 'large numeric literal inline rather than as a named constant.',
+  'duplicate-imports': 'two imports from the same module that should consolidate.',
+  'deep-nesting': 'indent depth exceeds repo convention; flatten with early returns / helpers.',
+  'todo-without-ticket': 'TODO/FIXME/XXX without a tracker reference.',
+  'console-logging': 'console.log/debug in production source.',
+  'type-any': 'explicit `any` annotation/cast in TS source.',
+  'idiom-adherence': 'change doesn\'t match the project idiom (factory functions, Option E parameterised constructors).',
+  'abstraction-quality': 'wrong abstraction layer chosen (function vs class vs module).',
+  'suggested-refactor': 'readable but a clearer expression exists.',
+  'test-design': 'tests assert on implementation details rather than behaviour.',
+  'error-handling-style': 'try/catch placement, recoverable vs unrecoverable, error-message clarity.',
+  'architecture-pattern': 'change introduces a pattern when a better idiom exists in the repo.',
+  'documentation-quality': 'README/comments don\'t accurately describe intent.',
+  'api-ergonomics': 'public API is awkward to use correctly.'
+};
+
+const SYSTEM_PROMPT = `You are a craftsmanship-focused code reviewer for the CAIA monorepo. Your job is to suggest how the change could be cleaner, more readable, more idiomatic — but you do NOT block merges. You are advisory.
+
+Tone: a senior engineer leaving thoughtful PR comments. Bias toward "consider" and "suggestion"; emit "nit" only for clear cosmetic improvements; emit "praise" when you see exemplary craftsmanship worth highlighting.
+
+CRITICAL: do NOT flag any of the following — they belong to the sibling Critic agent and Reviewer must stay disjoint:
+- security regressions, credential leaks, cost overruns
+- hallucination, scope mismatch, wrong direction, lacking information
+- premature completion, re-litigation, decision-classifier violations
+- git/branch hygiene, tool misuse, CI flakes, recipe rot, false-modesty
+- coordination failures, operator confusion, memory drift, incompleteness
+
+Output STRICT JSON in the shape:
+{"findings":[{"dimension":"<id>","severity":"praise|nit|suggestion|consider","file":"...","line":123,"suggestionTitle":"...","description":"...","suggestedChange":"...","excerpt":"..."}]}
+No prose before or after. No markdown fences. Keep total findings <= 10 per chunk; quality over quantity.`;
+
+export function buildPrompt(input: LlmReviewInput): string {
+  const dimensionsBlock = ALL_DIMENSIONS
+    .map(d => `  - ${d}: ${DIMENSION_DESCRIPTIONS[d]}`)
+    .join('\n');
+  const conventionsBlock = input.conventionExcerpts.length === 0
+    ? '(none — fall back to general TS / Node best practices)'
+    : input.conventionExcerpts
+        .map(c => `### ${c.heading} (from ${c.source})\n${c.bodyExcerpt}`)
+        .join('\n\n');
+  const hunksBlock = input.hunks
+    .map(h => `### ${h.file} (${h.status})\n${h.header}\n${h.body}`)
+    .join('\n\n');
+  return `${SYSTEM_PROMPT}
+
+## Craftsmanship dimensions
+${dimensionsBlock}
+
+## Project conventions
+${conventionsBlock}
+
+## PR metadata
+- prNumber: ${input.pr.prNumber}
+- branch: ${input.pr.branch}
+- baseBranch: ${input.pr.baseBranch}
+- title: ${input.pr.title}
+
+## Diff hunks
+${hunksBlock}
+
+## Output JSON now:`;
+}
+
+export function createDefaultLlmReviewer(opts: DefaultLlmReviewerOptions): LlmReviewer {
+  const spawn = opts.spawnFn ?? spawnSync;
+  return {
+    async review(input: LlmReviewInput): Promise<LlmReviewOutput> {
+      const prompt = buildPrompt(input);
+      const env = { ...process.env };
+      delete env['ANTHROPIC_API_KEY'];
+      const result = spawn(
+        opts.binaryPath,
+        ['--print', '--output-format', 'json', '--model', opts.modelTag],
+        { input: prompt, encoding: 'utf-8', timeout: opts.timeoutMs, env }
+      );
+      if (result.error !== null && result.error !== undefined) {
+        return {
+          findings: [],
+          ok: false,
+          diagnostic: `claude spawn error: ${result.error.message}`
+        };
+      }
+      if (result.status !== 0) {
+        return {
+          findings: [],
+          ok: false,
+          diagnostic: `claude exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
+        };
+      }
+      const stdout = (result.stdout ?? '').toString();
+      return parseLlmOutput(stdout);
+    }
+  };
+}
+
+/** Noop reviewer — used when `enableLlmReasoning` is false. */
+export const noopLlmReviewer: LlmReviewer = {
+  async review(): Promise<LlmReviewOutput> {
+    return { findings: [], ok: true };
+  }
+};
+
+/** Parse the `claude --print --output-format json` envelope, then the
+ * inner JSON the prompt asked for. Robust against extra whitespace and
+ * leading/trailing prose. */
+export function parseLlmOutput(stdout: string): LlmReviewOutput {
+  let outer: unknown;
+  try {
+    outer = JSON.parse(stdout);
+  } catch (e) {
+    return { findings: [], ok: false, diagnostic: `outer JSON parse: ${(e as Error).message}` };
+  }
+  if (
+    typeof outer !== 'object'
+    || outer === null
+    || typeof (outer as { result?: unknown }).result !== 'string'
+  ) {
+    return { findings: [], ok: false, diagnostic: 'envelope missing "result" string' };
+  }
+  const inner = (outer as { result: string }).result;
+  const block = extractFirstJsonObject(inner);
+  if (block === null) {
+    return { findings: [], ok: false, diagnostic: 'no JSON object in inner result' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(block);
+  } catch (e) {
+    return { findings: [], ok: false, diagnostic: `inner JSON parse: ${(e as Error).message}` };
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { findings: [], ok: false, diagnostic: 'inner not an object' };
+  }
+  const findingsRaw = (parsed as { findings?: unknown }).findings;
+  if (!Array.isArray(findingsRaw)) {
+    return { findings: [], ok: true };
+  }
+  const findings = findingsRaw
+    .map(f => sanitiseLlmFinding(f))
+    .filter((f): f is Omit<CraftsmanshipFinding, 'id' | 'source' | 'detectorId'> => f !== null);
+  return { findings, ok: true };
+}
+
+function extractFirstJsonObject(s: string): string | null {
+  const start = s.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function sanitiseLlmFinding(raw: unknown): Omit<CraftsmanshipFinding, 'id' | 'source' | 'detectorId'> | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const dim = r['dimension'];
+  if (typeof dim !== 'string') return null;
+  // Reject anything that landed on Critic's denylist — defense in depth on
+  // top of the prompt instruction.
+  if (CRITIC_DENYLIST.has(dim)) return null;
+  if (!ALL_DIMENSIONS.includes(dim as CraftsmanshipDimensionId)) return null;
+  const dimension = dim as CraftsmanshipDimensionId;
+  const file = typeof r['file'] === 'string' ? r['file'] : '';
+  if (file === '') return null;
+  const line = typeof r['line'] === 'number' && Number.isFinite(r['line']) ? r['line'] : 0;
+  const suggestionTitle = typeof r['suggestionTitle'] === 'string' && r['suggestionTitle'].length > 0
+    ? r['suggestionTitle']
+    : 'unspecified';
+  const description = typeof r['description'] === 'string' ? r['description'] : '';
+  if (description === '') return null;
+  const sevRaw = r['severity'];
+  const severity: CraftsmanshipSeverity = (sevRaw === 'praise' || sevRaw === 'nit' || sevRaw === 'suggestion' || sevRaw === 'consider')
+    ? sevRaw
+    : DEFAULT_SEVERITY[dimension];
+  // Cap LLM-suggested severity at the dimension's default — we don't want a
+  // chatty model promoting nits to "consider".
+  const finalSev: CraftsmanshipSeverity = SEVERITY_RANK[severity] <= SEVERITY_RANK[DEFAULT_SEVERITY[dimension]]
+    ? severity
+    : DEFAULT_SEVERITY[dimension];
+  const excerptRaw = typeof r['excerpt'] === 'string' ? r['excerpt'].slice(0, 200) : '';
+  const suggestedChange = typeof r['suggestedChange'] === 'string' ? r['suggestedChange'] : undefined;
+
+  const out: Omit<CraftsmanshipFinding, 'id' | 'source' | 'detectorId'> = {
+    dimension,
+    severity: finalSev,
+    file,
+    line,
+    suggestionTitle,
+    description,
+    excerpt: excerptRaw
+  };
+  if (suggestedChange !== undefined) {
+    out.suggestedChange = suggestedChange;
+  }
+  return out;
+}

--- a/packages/reviewer/src/merger.ts
+++ b/packages/reviewer/src/merger.ts
@@ -1,0 +1,119 @@
+/**
+ * FindingMerger — dedup by id-hash, severity floor, drop Critic overlap.
+ *
+ * Inputs:
+ *   - deterministic findings (already have id, source, detectorId)
+ *   - LLM-reasoned findings (omit id, source, detectorId — we add them)
+ *
+ * Output: a single deduped, severity-floored, deterministic-ordered list.
+ *
+ * Reviewer's merger has an explicit Critic-overlap drop step — any LLM
+ * finding whose `dimension` lands on Critic's denylist is dropped. This is
+ * defense-in-depth on top of the prompt-level non-overlap instruction.
+ */
+
+import type {
+  CraftsmanshipFinding,
+  CraftsmanshipSeverity,
+  LlmReviewOutput,
+  ReviewSummary
+} from './types.js';
+import {
+  ALL_DIMENSIONS,
+  CRITIC_DENYLIST,
+  SEVERITY_RANK
+} from './types.js';
+import { findingId } from './detectors/shared.js';
+
+export interface MergeArgs {
+  deterministic: readonly CraftsmanshipFinding[];
+  llmReasoned: LlmReviewOutput;
+  severityFloor: CraftsmanshipSeverity;
+  maxFindings: number;
+  llmEnabled: boolean;
+  chunksReviewed: number;
+  durationMs: number;
+}
+
+export interface MergeResult {
+  findings: CraftsmanshipFinding[];
+  summary: ReviewSummary;
+}
+
+export function mergeFindings(args: MergeArgs): MergeResult {
+  const { deterministic, llmReasoned, severityFloor, maxFindings, llmEnabled, chunksReviewed, durationMs } = args;
+
+  // Filter LLM findings against Critic's denylist — sanitiseLlmFinding
+  // already drops these but defense-in-depth at the merger guards future
+  // changes that bypass the sanitiser.
+  let redirectsToCritic = 0;
+  const llmKept = llmReasoned.findings.filter(f => {
+    if (CRITIC_DENYLIST.has(f.dimension)) {
+      redirectsToCritic++;
+      return false;
+    }
+    return true;
+  });
+
+  const llmHydrated: CraftsmanshipFinding[] = llmKept.map(f => ({
+    ...f,
+    id: findingId({ dimension: f.dimension, file: f.file, line: f.line, suggestionTitle: f.suggestionTitle }),
+    source: 'llm-reasoned' as const,
+    detectorId: 'llm-reviewer'
+  }));
+
+  const all = [...deterministic, ...llmHydrated];
+
+  // Dedup by id — first occurrence wins (deterministic precedence over llm
+  // for stable output).
+  const seen = new Set<string>();
+  const deduped: CraftsmanshipFinding[] = [];
+  for (const f of all) {
+    if (seen.has(f.id)) continue;
+    seen.add(f.id);
+    deduped.push(f);
+  }
+
+  // Severity floor — drop anything below.
+  const floorRank = SEVERITY_RANK[severityFloor];
+  const floored = deduped.filter(f => SEVERITY_RANK[f.severity] >= floorRank);
+
+  // Stable sort: praise first (positive reinforcement leads), then severity desc, then dimension index asc, then file asc, then line asc.
+  floored.sort((a, b) => {
+    // Praise findings always lead — surfaces wins before suggestions.
+    if (a.severity === 'praise' && b.severity !== 'praise') return -1;
+    if (b.severity === 'praise' && a.severity !== 'praise') return 1;
+    const sd = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sd !== 0) return sd;
+    const ci = ALL_DIMENSIONS.indexOf(a.dimension) - ALL_DIMENSIONS.indexOf(b.dimension);
+    if (ci !== 0) return ci;
+    if (a.file < b.file) return -1;
+    if (a.file > b.file) return 1;
+    return a.line - b.line;
+  });
+
+  const capped = floored.slice(0, maxFindings);
+
+  const countBySeverity: Record<CraftsmanshipSeverity, number> = { praise: 0, nit: 0, suggestion: 0, consider: 0 };
+  const countByDimension: ReviewSummary['countByDimension'] = {};
+  for (const f of capped) {
+    countBySeverity[f.severity]++;
+    countByDimension[f.dimension] = (countByDimension[f.dimension] ?? 0) + 1;
+  }
+  const detCount = capped.filter(f => f.source === 'deterministic').length;
+  const llmCount = capped.filter(f => f.source === 'llm-reasoned').length;
+
+  const summary: ReviewSummary = {
+    countBySeverity,
+    countByDimension,
+    chunksReviewed,
+    durationMs,
+    deterministic: detCount,
+    llmReasoned: llmCount,
+    llmEnabled,
+    llmReasoningSucceeded: !llmEnabled || llmReasoned.ok,
+    redirectsToCritic
+  };
+
+  return { findings: capped, summary };
+}

--- a/packages/reviewer/src/types.ts
+++ b/packages/reviewer/src/types.ts
@@ -1,0 +1,255 @@
+/**
+ * @chiefaia/reviewer — public type surface.
+ *
+ * The Reviewer Agent classifies craftsmanship findings into 18 dimensions
+ * spanning naming/length/comments/idioms/abstraction/test-design/etc.
+ * The dimension list is DISJOINT from Critic's 18 failure-mode categories
+ * (mentor_agent_directive.md) — Reviewer never overlaps with Critic.
+ *
+ * Reviewer findings are advisory; there is NO `blockingFindings` output.
+ */
+
+/** Reviewer's severity scale — deliberately distinct lexicon from Critic.
+ * Critic uses low/medium/high/critical (block-worthy spectrum); Reviewer's
+ * vocabulary explicitly avoids any term that implies blocking.
+ *
+ * - `praise`: exemplary craftsmanship worth highlighting.
+ * - `nit`: pure cosmetic; freely ignorable.
+ * - `suggestion`: improves readability with low effort.
+ * - `consider`: meaningful refactor opportunity, low risk.
+ */
+export type CraftsmanshipSeverity = 'praise' | 'nit' | 'suggestion' | 'consider';
+
+export const SEVERITY_RANK: Readonly<Record<CraftsmanshipSeverity, number>> = Object.freeze({
+  praise: 0,
+  nit: 1,
+  suggestion: 2,
+  consider: 3
+});
+
+/**
+ * Craftsmanship dimension IDs — 18 total, deliberately disjoint from
+ * Critic's `FailureModeId`.
+ *
+ * Deterministic-tier (10): naming-convention through type-any.
+ * LLM-reasoned-tier (8):   idiom-adherence through api-ergonomics.
+ */
+export type CraftsmanshipDimensionId =
+  | 'naming-convention'
+  | 'function-length'
+  | 'file-length'
+  | 'comment-density'
+  | 'magic-numbers'
+  | 'duplicate-imports'
+  | 'deep-nesting'
+  | 'todo-without-ticket'
+  | 'console-logging'
+  | 'type-any'
+  | 'idiom-adherence'
+  | 'abstraction-quality'
+  | 'suggested-refactor'
+  | 'test-design'
+  | 'error-handling-style'
+  | 'architecture-pattern'
+  | 'documentation-quality'
+  | 'api-ergonomics';
+
+export const ALL_DIMENSIONS: readonly CraftsmanshipDimensionId[] = Object.freeze([
+  'naming-convention',
+  'function-length',
+  'file-length',
+  'comment-density',
+  'magic-numbers',
+  'duplicate-imports',
+  'deep-nesting',
+  'todo-without-ticket',
+  'console-logging',
+  'type-any',
+  'idiom-adherence',
+  'abstraction-quality',
+  'suggested-refactor',
+  'test-design',
+  'error-handling-style',
+  'architecture-pattern',
+  'documentation-quality',
+  'api-ergonomics'
+]);
+
+/** Default severity per dimension — see DESIGN.md §6.4 */
+export const DEFAULT_SEVERITY: Readonly<Record<CraftsmanshipDimensionId, CraftsmanshipSeverity>> = Object.freeze({
+  'naming-convention': 'nit',
+  'function-length': 'consider',
+  'file-length': 'consider',
+  'comment-density': 'suggestion',
+  'magic-numbers': 'suggestion',
+  'duplicate-imports': 'nit',
+  'deep-nesting': 'suggestion',
+  'todo-without-ticket': 'nit',
+  'console-logging': 'suggestion',
+  'type-any': 'consider',
+  'idiom-adherence': 'consider',
+  'abstraction-quality': 'consider',
+  'suggested-refactor': 'consider',
+  'test-design': 'suggestion',
+  'error-handling-style': 'suggestion',
+  'architecture-pattern': 'consider',
+  'documentation-quality': 'suggestion',
+  'api-ergonomics': 'consider'
+});
+
+/**
+ * Critic's 18 failure-mode categories — Reviewer must never overlap.
+ * Mirrored verbatim from `@chiefaia/critic` types.ts so the merger has
+ * a static denylist without taking a runtime dependency on critic.
+ */
+export const CRITIC_DENYLIST: ReadonlySet<string> = new Set<string>([
+  'hallucination',
+  'scope-mismatch',
+  'incompleteness',
+  'wrong-direction',
+  'lacking-information',
+  'coordination-failure',
+  'git-branch-hygiene',
+  'cost-overrun',
+  'security-regression',
+  'operator-confusion',
+  'premature-completion',
+  're-litigation',
+  'decision-classifier-violation',
+  'memory-drift',
+  'false-modesty',
+  'recipe-rot',
+  'tool-misuse',
+  'ci-flake-masquerade'
+]);
+
+export interface DiffHunk {
+  /** File path relative to repo root (post-rename if renamed). */
+  file: string;
+  /** Old start line — 1-based. 0 for added files. */
+  oldStart: number;
+  /** New start line — 1-based. 0 for deleted files. */
+  newStart: number;
+  /** Hunk header — e.g. '@@ -10,5 +10,7 @@'. */
+  header: string;
+  /** Hunk body — contiguous diff lines. Includes ` `, `+`, `-` prefixes. */
+  body: string;
+  /** Status — added / modified / deleted / renamed. */
+  status: 'added' | 'modified' | 'deleted' | 'renamed';
+}
+
+export interface ParsedDiff {
+  hunks: DiffHunk[];
+  totalBytes: number;
+  fileCount: number;
+}
+
+export interface ScanContext {
+  /** Conventions excerpts loaded from AGENTS.md / craftsmanship docs. */
+  conventionExcerpts: readonly ConventionExcerpt[];
+  /** PR metadata for hygiene checks. */
+  pr: {
+    prNumber: number;
+    branch: string;
+    baseBranch: string;
+    title: string;
+    body?: string;
+    commitSubjects: readonly string[];
+  };
+  /** Wall clock for stable id-hash. */
+  reviewedAtIso: string;
+  /** Thresholds — pulled from ResolvedReviewerAgentConfig. */
+  thresholds: {
+    maxFunctionLines: number;
+    maxFileLines: number;
+    maxNestingDepth: number;
+  };
+}
+
+export interface ConventionExcerpt {
+  /** Source path or filename, e.g. 'AGENTS.md'. */
+  source: string;
+  /** Section heading, e.g. 'Code style (non-negotiable)'. */
+  heading: string;
+  /** Body — first ~500 chars. */
+  bodyExcerpt: string;
+}
+
+export interface CraftsmanshipFinding {
+  /** Stable hash of `dimension|file|line|suggestionTitle` — dedup key. */
+  id: string;
+  dimension: CraftsmanshipDimensionId;
+  severity: CraftsmanshipSeverity;
+  file: string;
+  /** 1-based line in the new file (post-change). 0 if not line-localised. */
+  line: number;
+  /** Short human-readable name e.g. 'extract-magic-number'. */
+  suggestionTitle: string;
+  /** Why this would be cleaner — one paragraph max. */
+  description: string;
+  /** Optional concrete refactor sketch. */
+  suggestedChange?: string;
+  source: 'deterministic' | 'llm-reasoned';
+  /** Detector identifier for traceability. */
+  detectorId: string;
+  /** ≤200 chars of the offending diff hunk for context. */
+  excerpt: string;
+}
+
+export interface CraftsmanshipReview {
+  prNumber: number;
+  reviewedAtIso: string;
+  totalFindings: number;
+  findings: CraftsmanshipFinding[];
+  summary: ReviewSummary;
+  // Note: NO `blockingFindings` — Reviewer is advisory-only by design.
+}
+
+export interface ReviewSummary {
+  countBySeverity: Record<CraftsmanshipSeverity, number>;
+  countByDimension: Partial<Record<CraftsmanshipDimensionId, number>>;
+  chunksReviewed: number;
+  durationMs: number;
+  deterministic: number;
+  llmReasoned: number;
+  /** True iff the LLM tier ran; false in deterministic-only mode. */
+  llmEnabled: boolean;
+  /** Truthful even if 0 — false signals an LLM call was attempted but failed. */
+  llmReasoningSucceeded: boolean;
+  /** Findings dropped because their dimension fell on Critic's denylist. */
+  redirectsToCritic: number;
+}
+
+/** Detector contract — every deterministic detector implements this. */
+export interface Detector {
+  readonly id: string;
+  readonly dimension: CraftsmanshipDimensionId;
+  scan(hunk: DiffHunk, ctx: ScanContext): CraftsmanshipFinding[];
+}
+
+/** LLM-reasoned tier seam — replaceable in tests. */
+export interface LlmReviewer {
+  review(input: LlmReviewInput): Promise<LlmReviewOutput>;
+}
+
+export interface LlmReviewInput {
+  hunks: readonly DiffHunk[];
+  conventionExcerpts: readonly ConventionExcerpt[];
+  pr: ScanContext['pr'];
+}
+
+export interface LlmReviewOutput {
+  findings: ReadonlyArray<Omit<CraftsmanshipFinding, 'id' | 'source' | 'detectorId'>>;
+  /** Whether the LLM call returned valid JSON. False → caller drops findings. */
+  ok: boolean;
+  /** Optional debug / error string. */
+  diagnostic?: string;
+}
+
+/** Filesystem read seam — every disk read goes through this. */
+export interface FsReader {
+  exists(p: string): boolean;
+  readFile(p: string): string;
+  /** List entries in a dir; `[]` if missing. */
+  readDir(p: string): string[];
+}

--- a/packages/reviewer/tests/__fixtures__/conventions/mini.md
+++ b/packages/reviewer/tests/__fixtures__/conventions/mini.md
@@ -1,0 +1,26 @@
+# AGENTS.md (fixture)
+
+A minimal AGENTS.md fixture used by Reviewer's test suite. Real CAIA AGENTS.md
+lives at the repo root and is read at runtime.
+
+## Code style
+
+- TypeScript strict.
+- No `any`.
+- Functions <60 lines.
+- No nesting >4 levels.
+- camelCase for variables and functions; PascalCase for types and classes.
+
+## Testing conventions
+
+- Vitest for new packages.
+- Tests assert on behaviour, not implementation.
+
+## Naming
+
+- Identifiers should be self-describing.
+- Single-letter names only for common iter (i/j/k/x/y/n/t/e).
+
+## Some other unrelated heading
+
+This section should be ignored by the conventions loader.

--- a/packages/reviewer/tests/__fixtures__/diffs/clean.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/clean.diff
@@ -1,0 +1,15 @@
+diff --git a/packages/example/src/clean.ts b/packages/example/src/clean.ts
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/packages/example/src/clean.ts
+@@ -0,0 +1,9 @@
++/**
++ * Documented helper for the example package.
++ */
++export function describeUser(name: string): string {
++  if (name.length === 0) {
++    return 'unnamed';
++  }
++  return `user:${name}`;
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/comment-density.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/comment-density.diff
@@ -1,0 +1,9 @@
+diff --git a/packages/example/src/exports.ts b/packages/example/src/exports.ts
+new file mode 100644
+index 0000000..4444444
+--- /dev/null
++++ b/packages/example/src/exports.ts
+@@ -0,0 +1,3 @@
++export function undocumented(): number {
++  return 42;
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/console.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/console.diff
@@ -1,0 +1,12 @@
+diff --git a/packages/example/src/runner.ts b/packages/example/src/runner.ts
+new file mode 100644
+index 0000000..9999999
+--- /dev/null
++++ b/packages/example/src/runner.ts
+@@ -0,0 +1,6 @@
++/** Logging rot. */
++export function run(): void {
++  console.log('debug message');
++  console.warn('this is allowed');
++  console.error('also allowed');
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/deep-nesting.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/deep-nesting.diff
@@ -1,0 +1,21 @@
+diff --git a/packages/example/src/nested.ts b/packages/example/src/nested.ts
+new file mode 100644
+index 0000000..7777777
+--- /dev/null
++++ b/packages/example/src/nested.ts
+@@ -0,0 +1,15 @@
++/** Deeply nested. */
++export function nested(x: number): number {
++  if (x > 0) {
++    if (x > 1) {
++      if (x > 2) {
++        if (x > 3) {
++          if (x > 4) {
++            return x * 2;
++          }
++        }
++      }
++    }
++  }
++  return 0;
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/duplicate-imports.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/duplicate-imports.diff
@@ -1,0 +1,11 @@
+diff --git a/packages/example/src/imports.ts b/packages/example/src/imports.ts
+new file mode 100644
+index 0000000..6666666
+--- /dev/null
++++ b/packages/example/src/imports.ts
+@@ -0,0 +1,5 @@
++import { foo } from 'node:fs';
++import { bar } from 'node:fs';
++
++/** Tester. */
++export function go(): void { foo(); bar(); }

--- a/packages/reviewer/tests/__fixtures__/diffs/file-length.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/file-length.diff
@@ -1,0 +1,13 @@
+diff --git a/packages/example/src/big.ts b/packages/example/src/big.ts
+new file mode 100644
+index 0000000..bbbbbbb
+--- /dev/null
++++ b/packages/example/src/big.ts
+@@ -495,5 +495,7 @@
+ const PADDING_END = 1;
+ const PADDING_END_2 = 1;
+ const PADDING_END_3 = 1;
++const ADD_LINE_501 = 1;
++const ADD_LINE_502 = 1;
+ const PADDING_END_4 = 1;
+ const PADDING_END_5 = 1;

--- a/packages/reviewer/tests/__fixtures__/diffs/function-length.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/function-length.diff
@@ -1,0 +1,77 @@
+diff --git a/packages/example/src/long-fn.ts b/packages/example/src/long-fn.ts
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/packages/example/src/long-fn.ts
+@@ -0,0 +1,72 @@
++/**
++ * Function longer than the threshold.
++ */
++export function megaProcess(input: number): number {
++  let total = input;
++  total = total + 1;
++  total = total + 2;
++  total = total + 3;
++  total = total + 4;
++  total = total + 5;
++  total = total + 6;
++  total = total + 7;
++  total = total + 8;
++  total = total + 9;
++  total = total + 10;
++  total = total + 11;
++  total = total + 12;
++  total = total + 13;
++  total = total + 14;
++  total = total + 15;
++  total = total + 16;
++  total = total + 17;
++  total = total + 18;
++  total = total + 19;
++  total = total + 20;
++  total = total + 21;
++  total = total + 22;
++  total = total + 23;
++  total = total + 24;
++  total = total + 25;
++  total = total + 26;
++  total = total + 27;
++  total = total + 28;
++  total = total + 29;
++  total = total + 30;
++  total = total + 31;
++  total = total + 32;
++  total = total + 33;
++  total = total + 34;
++  total = total + 35;
++  total = total + 36;
++  total = total + 37;
++  total = total + 38;
++  total = total + 39;
++  total = total + 40;
++  total = total + 41;
++  total = total + 42;
++  total = total + 43;
++  total = total + 44;
++  total = total + 45;
++  total = total + 46;
++  total = total + 47;
++  total = total + 48;
++  total = total + 49;
++  total = total + 50;
++  total = total + 51;
++  total = total + 52;
++  total = total + 53;
++  total = total + 54;
++  total = total + 55;
++  total = total + 56;
++  total = total + 57;
++  total = total + 58;
++  total = total + 59;
++  total = total + 60;
++  total = total + 61;
++  total = total + 62;
++  total = total + 63;
++  total = total + 64;
++  return total;
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/magic-numbers.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/magic-numbers.diff
@@ -1,0 +1,11 @@
+diff --git a/packages/example/src/magic.ts b/packages/example/src/magic.ts
+new file mode 100644
+index 0000000..5555555
+--- /dev/null
++++ b/packages/example/src/magic.ts
+@@ -0,0 +1,5 @@
++/** With magic literals. */
++export function compute(x: number): number {
++  const result = x * 86400 + 3_600;
++  return result;
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/naming-convention.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/naming-convention.diff
@@ -1,0 +1,14 @@
+diff --git a/packages/example/src/naming.ts b/packages/example/src/naming.ts
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/packages/example/src/naming.ts
+@@ -0,0 +1,8 @@
++/**
++ * Naming convention violations.
++ */
++export function processOrders(orders: number[]): number {
++  const a = orders.length;
++  const order_count = a;
++  return order_count;
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/todo.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/todo.diff
@@ -1,0 +1,11 @@
+diff --git a/packages/example/src/todos.ts b/packages/example/src/todos.ts
+new file mode 100644
+index 0000000..8888888
+--- /dev/null
++++ b/packages/example/src/todos.ts
+@@ -0,0 +1,5 @@
++/** todos. */
++export function go(): void {
++  // TODO: handle the edge case
++  // FIXME(CAIA-1234): wired up
++}

--- a/packages/reviewer/tests/__fixtures__/diffs/type-any.diff
+++ b/packages/reviewer/tests/__fixtures__/diffs/type-any.diff
@@ -1,0 +1,11 @@
+diff --git a/packages/example/src/anys.ts b/packages/example/src/anys.ts
+new file mode 100644
+index 0000000..aaaaaaa
+--- /dev/null
++++ b/packages/example/src/anys.ts
+@@ -0,0 +1,5 @@
++/** Anys. */
++export function take(x: any): any {
++  const y = x as any;
++  return y;
++}

--- a/packages/reviewer/tests/agent.test.ts
+++ b/packages/reviewer/tests/agent.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ReviewerAgent } from '../src/agent.js';
+import type { FsReader, LlmReviewer } from '../src/types.js';
+
+const FIXTURES = join(fileURLToPath(import.meta.url), '..', '__fixtures__');
+
+const fakeFs = (files: Record<string, string>): FsReader => ({
+  exists: (p) => p in files,
+  readFile: (p) => {
+    const v = files[p];
+    if (v === undefined) throw new Error(`missing ${p}`);
+    return v;
+  },
+  readDir: () => []
+});
+
+const noopLlm: LlmReviewer = {
+  async review() { return { findings: [], ok: true }; }
+};
+
+const stubLlm = (output: Awaited<ReturnType<LlmReviewer['review']>>): LlmReviewer => ({
+  async review() { return output; }
+});
+
+function loadFixture(name: string): string {
+  return readFileSync(join(FIXTURES, 'diffs', name), 'utf-8');
+}
+
+describe('ReviewerAgent.reviewPR', () => {
+  it('returns 0 findings on a clean diff', async () => {
+    const agent = new ReviewerAgent({
+      enableLlmReasoning: false,
+      conventionsPath: '/none',
+      fs: fakeFs({}),
+      llm: noopLlm,
+      clock: () => new Date('2026-05-06T00:00:00Z')
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: loadFixture('clean.diff'),
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.totalFindings).toBe(0);
+    expect(review.summary.deterministic).toBe(0);
+    expect(review.summary.llmEnabled).toBe(false);
+  });
+
+  it('combines deterministic findings from a noisy diff', async () => {
+    const agent = new ReviewerAgent({
+      enableLlmReasoning: false,
+      conventionsPath: '/none',
+      fs: fakeFs({}),
+      llm: noopLlm
+    });
+    const review = await agent.reviewPR({
+      prNumber: 2,
+      diff: loadFixture('type-any.diff'),
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.totalFindings).toBeGreaterThan(0);
+    expect(review.findings.every(f => f.source === 'deterministic')).toBe(true);
+  });
+
+  it('NEVER produces blocking findings (no blockingFindings field)', async () => {
+    const agent = new ReviewerAgent({ enableLlmReasoning: false, fs: fakeFs({}), llm: noopLlm });
+    const review = await agent.reviewPR({
+      prNumber: 3,
+      diff: loadFixture('type-any.diff'),
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect((review as unknown as Record<string, unknown>)['blockingFindings']).toBeUndefined();
+  });
+
+  it('drops LLM finding whose excerpt isn\'t in the diff (hallucination guard)', async () => {
+    const agent = new ReviewerAgent({
+      enableLlmReasoning: true,
+      fs: fakeFs({}),
+      llm: stubLlm({
+        ok: true,
+        findings: [
+          {
+            dimension: 'idiom-adherence',
+            severity: 'consider',
+            file: 'imaginary.ts',
+            line: 99,
+            suggestionTitle: 'fake',
+            description: 'd',
+            excerpt: 'this string is definitely not in the diff'
+          }
+        ]
+      })
+    });
+    const review = await agent.reviewPR({
+      prNumber: 4,
+      diff: loadFixture('clean.diff'),
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.findings).toHaveLength(0);
+  });
+
+  it('keeps LLM findings whose excerpt IS in the diff', async () => {
+    const agent = new ReviewerAgent({
+      enableLlmReasoning: true,
+      fs: fakeFs({}),
+      llm: stubLlm({
+        ok: true,
+        findings: [
+          {
+            dimension: 'idiom-adherence',
+            severity: 'consider',
+            file: 'packages/example/src/clean.ts',
+            line: 4,
+            suggestionTitle: 'real-finding',
+            description: 'd',
+            excerpt: 'export function describeUser'
+          }
+        ]
+      })
+    });
+    const review = await agent.reviewPR({
+      prNumber: 5,
+      diff: loadFixture('clean.diff'),
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.findings.length).toBe(1);
+    expect(review.findings[0]?.source).toBe('llm-reasoned');
+  });
+
+  it('marks llmReasoningSucceeded=false when LLM throws', async () => {
+    const agent = new ReviewerAgent({
+      enableLlmReasoning: true,
+      fs: fakeFs({}),
+      llm: { async review() { throw new Error('boom'); } }
+    });
+    const review = await agent.reviewPR({
+      prNumber: 6,
+      diff: loadFixture('clean.diff'),
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.summary.llmReasoningSucceeded).toBe(false);
+  });
+});

--- a/packages/reviewer/tests/config.test.ts
+++ b/packages/reviewer/tests/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { resolveConfig, expandHome } from '../src/config.js';
+
+describe('expandHome', () => {
+  it('expands ~/ to homedir', () => {
+    const out = expandHome('~/foo');
+    expect(out).toMatch(/\/foo$/);
+    expect(out.startsWith('~')).toBe(false);
+  });
+
+  it('passes through absolute paths', () => {
+    expect(expandHome('/abs/path')).toBe('/abs/path');
+  });
+
+  it('expands lone ~', () => {
+    expect(expandHome('~')).not.toBe('~');
+  });
+});
+
+describe('resolveConfig', () => {
+  const ENV_KEYS = [
+    'CAIA_CONVENTIONS_PATH', 'CAIA_MEMORY_ROOT', 'CAIA_REPORTS_ROOT',
+    'MENTOR_EVENT_BUS_URL', 'CLAUDE_BINARY_PATH', 'REVIEWER_MODEL_TAG',
+    'REVIEWER_MAX_DIFF_BYTES', 'REVIEWER_CHUNK_BYTES',
+    'REVIEWER_SEVERITY_FLOOR', 'REVIEWER_VECTOR_TIMEOUT_MS',
+    'REVIEWER_MAX_FINDINGS', 'REVIEWER_MAX_FUNCTION_LINES',
+    'REVIEWER_MAX_FILE_LINES', 'REVIEWER_MAX_NESTING_DEPTH',
+    'REVIEWER_LLM_ENABLED', 'REVIEWER_DETERMINISTIC_ENABLED'
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      const prior = saved[k];
+      if (prior === undefined) delete process.env[k];
+      else process.env[k] = prior;
+    }
+  });
+
+  it('uses CAIA defaults when no input/env', () => {
+    const cfg = resolveConfig();
+    expect(cfg.modelTag).toBe('claude-haiku-4-5-20251001');
+    expect(cfg.severityFloor).toBe('nit');
+    expect(cfg.maxFunctionLines).toBe(60);
+    expect(cfg.maxFileLines).toBe(500);
+    expect(cfg.maxNestingDepth).toBe(4);
+    expect(cfg.maxFindingsPerPr).toBe(30);
+    expect(cfg.enableLlmReasoning).toBe(true);
+    expect(cfg.enableDeterministic).toBe(true);
+  });
+
+  it('honours constructor input over defaults', () => {
+    const cfg = resolveConfig({
+      severityFloor: 'consider',
+      maxFunctionLines: 100,
+      enableLlmReasoning: false
+    });
+    expect(cfg.severityFloor).toBe('consider');
+    expect(cfg.maxFunctionLines).toBe(100);
+    expect(cfg.enableLlmReasoning).toBe(false);
+  });
+
+  it('falls through to env when no input', () => {
+    process.env['REVIEWER_MAX_FUNCTION_LINES'] = '42';
+    process.env['REVIEWER_LLM_ENABLED'] = '0';
+    const cfg = resolveConfig();
+    expect(cfg.maxFunctionLines).toBe(42);
+    expect(cfg.enableLlmReasoning).toBe(false);
+  });
+});

--- a/packages/reviewer/tests/conventions-loader.test.ts
+++ b/packages/reviewer/tests/conventions-loader.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { loadConventions, parseConventionsMarkdown } from '../src/conventions-loader.js';
+import type { FsReader } from '../src/types.js';
+
+const fakeFs = (files: Record<string, string>): FsReader => ({
+  exists: (p) => p in files,
+  readFile: (p) => {
+    const v = files[p];
+    if (v === undefined) throw new Error(`missing ${p}`);
+    return v;
+  },
+  readDir: () => []
+});
+
+describe('loadConventions', () => {
+  it('returns [] when path missing', () => {
+    const fs = fakeFs({});
+    expect(loadConventions(fs, '/nope.md')).toEqual([]);
+  });
+
+  it('extracts craftsmanship-relevant headings', () => {
+    const md = [
+      '## Code style',
+      '- TS strict',
+      '- No any',
+      '',
+      '## Some other thing',
+      '- nope',
+      '',
+      '## Naming',
+      'identifiers self-describing',
+      ''
+    ].join('\n');
+    const out = parseConventionsMarkdown('AGENTS.md', md);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.heading).toBe('Code style');
+    expect(out[1]?.heading).toBe('Naming');
+    expect(out[0]?.bodyExcerpt).toContain('No any');
+    expect(out[1]?.bodyExcerpt).toContain('self-describing');
+  });
+
+  it('caps body excerpt at 500 chars', () => {
+    const md = '## Code style\n' + 'x'.repeat(600);
+    const out = parseConventionsMarkdown('AGENTS.md', md);
+    expect(out[0]?.bodyExcerpt.length).toBeLessThanOrEqual(500);
+  });
+});

--- a/packages/reviewer/tests/detectors.test.ts
+++ b/packages/reviewer/tests/detectors.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseDiff } from '../src/diff-parser.js';
+import {
+  ALL_DETECTORS,
+  namingConventionDetector,
+  functionLengthDetector,
+  fileLengthDetector,
+  commentDensityDetector,
+  magicNumbersDetector,
+  duplicateImportsDetector,
+  deepNestingDetector,
+  todoWithoutTicketDetector,
+  consoleLoggingDetector,
+  typeAnyDetector
+} from '../src/detectors/index.js';
+import type { ScanContext } from '../src/types.js';
+
+const FIXTURES = join(fileURLToPath(import.meta.url), '..', '__fixtures__/diffs');
+
+const ctx: ScanContext = {
+  conventionExcerpts: [],
+  pr: {
+    prNumber: 1, branch: 'feat/x', baseBranch: 'develop',
+    title: 't', commitSubjects: []
+  },
+  reviewedAtIso: '2026-05-06T00:00:00Z',
+  thresholds: { maxFunctionLines: 60, maxFileLines: 500, maxNestingDepth: 4 }
+};
+
+function loadFixture(name: string): string {
+  return readFileSync(join(FIXTURES, name), 'utf-8');
+}
+
+describe('ALL_DETECTORS registry', () => {
+  it('exposes 10 deterministic detectors', () => {
+    expect(ALL_DETECTORS).toHaveLength(10);
+    const dims = new Set(ALL_DETECTORS.map(d => d.dimension));
+    expect(dims.size).toBe(10);
+  });
+
+  it('every detector id is unique', () => {
+    const ids = new Set(ALL_DETECTORS.map(d => d.id));
+    expect(ids.size).toBe(10);
+  });
+});
+
+describe('clean diff produces no findings', () => {
+  it('no detector fires', () => {
+    const diff = parseDiff(loadFixture('clean.diff'));
+    const findings = ALL_DETECTORS.flatMap(d => diff.hunks.flatMap(h => d.scan(h, ctx)));
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe('namingConventionDetector', () => {
+  it('flags single-letter and snake_case', () => {
+    const diff = parseDiff(loadFixture('naming-convention.diff'));
+    const findings = diff.hunks.flatMap(h => namingConventionDetector.scan(h, ctx));
+    expect(findings.length).toBeGreaterThan(0);
+    const titles = findings.map(f => f.suggestionTitle);
+    expect(titles.some(t => t.startsWith('single-letter-name-'))).toBe(true);
+    expect(titles.some(t => t.startsWith('snake-case-'))).toBe(true);
+  });
+
+  it('skips iter letters', () => {
+    const diff = parseDiff(loadFixture('clean.diff'));
+    const findings = diff.hunks.flatMap(h => namingConventionDetector.scan(h, ctx));
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe('functionLengthDetector', () => {
+  it('flags functions exceeding the threshold', () => {
+    const diff = parseDiff(loadFixture('function-length.diff'));
+    const findings = diff.hunks.flatMap(h => functionLengthDetector.scan(h, ctx));
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0]?.dimension).toBe('function-length');
+  });
+
+  it('respects custom threshold', () => {
+    const diff = parseDiff(loadFixture('clean.diff'));
+    const tightCtx: ScanContext = { ...ctx, thresholds: { ...ctx.thresholds, maxFunctionLines: 2 } };
+    const findings = diff.hunks.flatMap(h => functionLengthDetector.scan(h, tightCtx));
+    // Clean diff function is small but with maxFunctionLines=2 we may flag.
+    expect(findings.every(f => f.dimension === 'function-length')).toBe(true);
+  });
+});
+
+describe('fileLengthDetector', () => {
+  it('flags files past the threshold', () => {
+    const diff = parseDiff(loadFixture('file-length.diff'));
+    const findings = diff.hunks.flatMap(h => fileLengthDetector.scan(h, ctx));
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0]?.dimension).toBe('file-length');
+  });
+});
+
+describe('commentDensityDetector', () => {
+  it('flags undocumented public exports', () => {
+    const diff = parseDiff(loadFixture('comment-density.diff'));
+    const findings = diff.hunks.flatMap(h => commentDensityDetector.scan(h, ctx));
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.suggestionTitle).toContain('undocumented');
+  });
+
+  it('does not fire on documented exports', () => {
+    const diff = parseDiff(loadFixture('clean.diff'));
+    const findings = diff.hunks.flatMap(h => commentDensityDetector.scan(h, ctx));
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe('magicNumbersDetector', () => {
+  it('flags large literals and underscore-separated literals', () => {
+    const diff = parseDiff(loadFixture('magic-numbers.diff'));
+    const findings = diff.hunks.flatMap(h => magicNumbersDetector.scan(h, ctx));
+    expect(findings.length).toBeGreaterThan(0);
+    const titles = findings.map(f => f.suggestionTitle);
+    expect(titles.some(t => t.includes('86400'))).toBe(true);
+  });
+});
+
+describe('duplicateImportsDetector', () => {
+  it('flags two imports from same module', () => {
+    const diff = parseDiff(loadFixture('duplicate-imports.diff'));
+    const findings = diff.hunks.flatMap(h => duplicateImportsDetector.scan(h, ctx));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.suggestionTitle).toContain('node:fs');
+  });
+});
+
+describe('deepNestingDetector', () => {
+  it('flags depth exceeding threshold', () => {
+    const diff = parseDiff(loadFixture('deep-nesting.diff'));
+    const findings = diff.hunks.flatMap(h => deepNestingDetector.scan(h, ctx));
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0]?.dimension).toBe('deep-nesting');
+  });
+});
+
+describe('todoWithoutTicketDetector', () => {
+  it('flags TODO without ticket and not the FIXME with one', () => {
+    const diff = parseDiff(loadFixture('todo.diff'));
+    const findings = diff.hunks.flatMap(h => todoWithoutTicketDetector.scan(h, ctx));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.suggestionTitle).toContain('todo-');
+  });
+});
+
+describe('consoleLoggingDetector', () => {
+  it('flags console.log; allows warn/error', () => {
+    const diff = parseDiff(loadFixture('console.diff'));
+    const findings = diff.hunks.flatMap(h => consoleLoggingDetector.scan(h, ctx));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.suggestionTitle).toContain('console-log');
+  });
+});
+
+describe('typeAnyDetector', () => {
+  it('flags any annotations and casts', () => {
+    const diff = parseDiff(loadFixture('type-any.diff'));
+    const findings = diff.hunks.flatMap(h => typeAnyDetector.scan(h, ctx));
+    expect(findings.length).toBeGreaterThanOrEqual(2);
+    expect(findings.every(f => f.dimension === 'type-any')).toBe(true);
+  });
+});

--- a/packages/reviewer/tests/diff-parser.test.ts
+++ b/packages/reviewer/tests/diff-parser.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { parseDiff, chunkHunk, walkHunk } from '../src/diff-parser.js';
+import type { DiffHunk } from '../src/types.js';
+
+describe('parseDiff', () => {
+  it('parses a single-file added diff', () => {
+    const diff = [
+      'diff --git a/src/x.ts b/src/x.ts',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/src/x.ts',
+      '@@ -0,0 +1,2 @@',
+      '+const a = 1;',
+      '+const b = 2;'
+    ].join('\n');
+    const out = parseDiff(diff);
+    expect(out.hunks).toHaveLength(1);
+    expect(out.hunks[0]?.file).toBe('src/x.ts');
+    expect(out.hunks[0]?.status).toBe('added');
+    expect(out.fileCount).toBe(1);
+  });
+
+  it('parses a multi-hunk modified diff', () => {
+    const diff = [
+      'diff --git a/src/y.ts b/src/y.ts',
+      '--- a/src/y.ts',
+      '+++ b/src/y.ts',
+      '@@ -10,1 +10,2 @@',
+      ' kept',
+      '+added',
+      '@@ -50,2 +51,1 @@',
+      '-removed',
+      ' kept'
+    ].join('\n');
+    const out = parseDiff(diff);
+    expect(out.hunks).toHaveLength(2);
+    expect(out.hunks[0]?.newStart).toBe(10);
+    expect(out.hunks[1]?.newStart).toBe(51);
+  });
+
+  it('skips binary diffs', () => {
+    const diff = [
+      'diff --git a/src/img.png b/src/img.png',
+      'Binary files a/src/img.png and b/src/img.png differ'
+    ].join('\n');
+    expect(parseDiff(diff).hunks).toHaveLength(0);
+  });
+});
+
+describe('walkHunk', () => {
+  it('emits new/old line numbers correctly', () => {
+    const hunk: DiffHunk = {
+      file: 'a.ts',
+      oldStart: 1,
+      newStart: 1,
+      header: '@@ -1,2 +1,3 @@',
+      body: ' kept\n+added\n-removed',
+      status: 'modified'
+    };
+    const out = walkHunk(hunk);
+    expect(out).toEqual([
+      { kind: ' ', newLine: 1, oldLine: 1, text: 'kept' },
+      { kind: '+', newLine: 2, oldLine: -1, text: 'added' },
+      { kind: '-', newLine: -1, oldLine: 2, text: 'removed' }
+    ]);
+  });
+});
+
+describe('chunkHunk', () => {
+  it('returns single-element array when within budget', () => {
+    const hunk: DiffHunk = {
+      file: 'a.ts', oldStart: 1, newStart: 1,
+      header: '@@', body: '+a\n+b', status: 'added'
+    };
+    expect(chunkHunk(hunk, 1000)).toHaveLength(1);
+  });
+
+  it('splits when over budget', () => {
+    const body = Array.from({ length: 50 }, (_, i) => `+line ${i}`).join('\n');
+    const hunk: DiffHunk = {
+      file: 'a.ts', oldStart: 1, newStart: 1,
+      header: '@@', body, status: 'added'
+    };
+    const chunks = chunkHunk(hunk, 80);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Total bytes preserved.
+    const total = chunks.map(c => c.body).join('\n');
+    expect(total).toContain('line 0');
+    expect(total).toContain('line 49');
+  });
+});

--- a/packages/reviewer/tests/integration.test.ts
+++ b/packages/reviewer/tests/integration.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration test — wire the Reviewer end-to-end against a synthetic PR
+ * diff containing several craftsmanship issues, with the conventions
+ * loader pointed at the fixture AGENTS.md.
+ *
+ * Verifies:
+ *  - Deterministic detectors fire for the expected dimensions.
+ *  - LLM tier is invoked exactly once (and stubbed, no real binary).
+ *  - LLM finding rides through the merger and is in the output.
+ *  - Reviewer's output has no `blockingFindings` field.
+ *  - All Reviewer findings' dimensions are disjoint from Critic's denylist.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ReviewerAgent } from '../src/agent.js';
+import { CRITIC_DENYLIST } from '../src/types.js';
+import type { FsReader, LlmReviewer } from '../src/types.js';
+
+const FIXTURES = join(fileURLToPath(import.meta.url), '..', '__fixtures__');
+
+function loadDiff(name: string): string {
+  return readFileSync(join(FIXTURES, 'diffs', name), 'utf-8');
+}
+
+const fakeFs: FsReader = {
+  exists: (p) => p === join(FIXTURES, 'conventions/mini.md'),
+  readFile: (p) => readFileSync(p, 'utf-8'),
+  readDir: () => []
+};
+
+let llmCallCount = 0;
+const stubLlm: LlmReviewer = {
+  async review() {
+    llmCallCount++;
+    return {
+      ok: true,
+      findings: [{
+        dimension: 'idiom-adherence',
+        severity: 'consider',
+        file: 'packages/example/src/anys.ts',
+        line: 2,
+        suggestionTitle: 'use-unknown',
+        description: 'consider unknown + narrow',
+        excerpt: 'export function take(x: any)'
+      }]
+    };
+  }
+};
+
+describe('Reviewer integration on synthetic PR', () => {
+  it('produces both deterministic and LLM findings, no blocker, no Critic overlap', async () => {
+    llmCallCount = 0;
+    const agent = new ReviewerAgent({
+      conventionsPath: join(FIXTURES, 'conventions/mini.md'),
+      fs: fakeFs,
+      llm: stubLlm,
+      enableLlmReasoning: true
+    });
+    // Combine multiple dimensions of issues into one PR diff string.
+    const combined = [
+      loadDiff('type-any.diff'),
+      loadDiff('console.diff'),
+      loadDiff('comment-density.diff')
+    ].join('\n');
+
+    const review = await agent.reviewPR({
+      prNumber: 999,
+      diff: combined,
+      context: { branch: 'feat/integration', baseBranch: 'develop', title: 'integration' }
+    });
+
+    expect(llmCallCount).toBe(1);
+    expect(review.summary.deterministic).toBeGreaterThan(0);
+    expect(review.summary.llmReasoned).toBe(1);
+    expect(review.summary.llmEnabled).toBe(true);
+    expect(review.summary.llmReasoningSucceeded).toBe(true);
+    // Hard invariant: no finding's dimension may be on Critic's denylist.
+    for (const f of review.findings) {
+      expect(CRITIC_DENYLIST.has(f.dimension)).toBe(false);
+    }
+    // Hard invariant: Reviewer doesn't emit a blockingFindings field.
+    expect((review as unknown as Record<string, unknown>)['blockingFindings']).toBeUndefined();
+  });
+});

--- a/packages/reviewer/tests/llm-reasoner.test.ts
+++ b/packages/reviewer/tests/llm-reasoner.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { buildPrompt, parseLlmOutput, createDefaultLlmReviewer } from '../src/llm-reasoner.js';
+import type { LlmReviewInput } from '../src/types.js';
+
+describe('buildPrompt', () => {
+  it('includes dimensions, conventions, and hunks', () => {
+    const input: LlmReviewInput = {
+      hunks: [{
+        file: 'a.ts', oldStart: 1, newStart: 1,
+        header: '@@', body: '+x', status: 'added'
+      }],
+      conventionExcerpts: [{ source: 'AGENTS.md', heading: 'Code style', bodyExcerpt: 'no any' }],
+      pr: { prNumber: 7, branch: 'b', baseBranch: 'develop', title: 't', commitSubjects: [] }
+    };
+    const p = buildPrompt(input);
+    expect(p).toContain('naming-convention');
+    expect(p).toContain('Code style');
+    expect(p).toContain('a.ts');
+    expect(p).toContain('prNumber: 7');
+    expect(p).toContain('CRITICAL: do NOT flag');
+  });
+
+  it('falls back to message when no conventions', () => {
+    const input: LlmReviewInput = {
+      hunks: [],
+      conventionExcerpts: [],
+      pr: { prNumber: 1, branch: 'b', baseBranch: 'develop', title: 't', commitSubjects: [] }
+    };
+    const p = buildPrompt(input);
+    expect(p).toContain('(none —');
+  });
+});
+
+describe('parseLlmOutput', () => {
+  const wrap = (inner: string): string => JSON.stringify({ result: inner });
+
+  it('returns ok=false for non-JSON', () => {
+    const out = parseLlmOutput('not json');
+    expect(out.ok).toBe(false);
+  });
+
+  it('returns ok=false when envelope missing result', () => {
+    const out = parseLlmOutput(JSON.stringify({ wrong: 'shape' }));
+    expect(out.ok).toBe(false);
+  });
+
+  it('returns ok=true with empty findings when none', () => {
+    const out = parseLlmOutput(wrap('{"findings":[]}'));
+    expect(out.ok).toBe(true);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('parses a valid finding', () => {
+    const inner = '{"findings":[{"dimension":"naming-convention","severity":"nit","file":"a.ts","line":3,"suggestionTitle":"x","description":"y","excerpt":"z"}]}';
+    const out = parseLlmOutput(wrap(inner));
+    expect(out.ok).toBe(true);
+    expect(out.findings).toHaveLength(1);
+    expect(out.findings[0]?.dimension).toBe('naming-convention');
+  });
+
+  it('drops findings with Critic-denylist dimension', () => {
+    const inner = '{"findings":[{"dimension":"security-regression","severity":"consider","file":"a.ts","line":1,"suggestionTitle":"x","description":"y"}]}';
+    const out = parseLlmOutput(wrap(inner));
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('extracts inner JSON from prose-wrapped result', () => {
+    const inner = 'Here is the JSON: {"findings":[]} thanks';
+    const out = parseLlmOutput(wrap(inner));
+    expect(out.ok).toBe(true);
+  });
+
+  it('caps invented severities at the dimension default', () => {
+    const inner = '{"findings":[{"dimension":"naming-convention","severity":"consider","file":"a.ts","line":1,"suggestionTitle":"x","description":"y"}]}';
+    const out = parseLlmOutput(wrap(inner));
+    // naming-convention default is 'nit'; LLM tried to bump to 'consider' — clamped.
+    expect(out.findings[0]?.severity).toBe('nit');
+  });
+});
+
+describe('createDefaultLlmReviewer (with spawnFn seam)', () => {
+  it('returns ok=false on non-zero exit', async () => {
+    const reviewer = createDefaultLlmReviewer({
+      binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
+      spawnFn: (() => ({ status: 1, stdout: '', stderr: 'oops', error: null, signal: null, output: [] })) as never
+    });
+    const out = await reviewer.review({
+      hunks: [], conventionExcerpts: [],
+      pr: { prNumber: 1, branch: 'b', baseBranch: 'develop', title: 't', commitSubjects: [] }
+    });
+    expect(out.ok).toBe(false);
+    expect(out.diagnostic).toContain('exited 1');
+  });
+
+  it('deletes ANTHROPIC_API_KEY from spawned env', async () => {
+    let capturedEnv: NodeJS.ProcessEnv | null = null;
+    const reviewer = createDefaultLlmReviewer({
+      binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
+      spawnFn: ((_cmd, _args, opts) => {
+        capturedEnv = opts.env;
+        return { status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '', error: null, signal: null, output: [] };
+      }) as never
+    });
+    process.env['ANTHROPIC_API_KEY'] = 'sk-test';
+    try {
+      await reviewer.review({
+        hunks: [], conventionExcerpts: [],
+        pr: { prNumber: 1, branch: 'b', baseBranch: 'develop', title: 't', commitSubjects: [] }
+      });
+    } finally {
+      delete process.env['ANTHROPIC_API_KEY'];
+    }
+    expect(capturedEnv).not.toBeNull();
+    expect((capturedEnv as NodeJS.ProcessEnv | null)?.['ANTHROPIC_API_KEY']).toBeUndefined();
+  });
+});

--- a/packages/reviewer/tests/merger.test.ts
+++ b/packages/reviewer/tests/merger.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { mergeFindings } from '../src/merger.js';
+import type { CraftsmanshipFinding } from '../src/types.js';
+
+const det = (over: Partial<CraftsmanshipFinding> = {}): CraftsmanshipFinding => ({
+  id: 'rev-' + Math.random().toString(16).slice(2),
+  dimension: 'naming-convention',
+  severity: 'nit',
+  file: 'a.ts',
+  line: 1,
+  suggestionTitle: 't',
+  description: 'd',
+  source: 'deterministic',
+  detectorId: 'det-x',
+  excerpt: 'e',
+  ...over
+});
+
+describe('mergeFindings', () => {
+  it('dedups by id', () => {
+    const a = det({ id: 'rev-a' });
+    const b = det({ id: 'rev-a' });
+    const merged = mergeFindings({
+      deterministic: [a, b],
+      llmReasoned: { findings: [], ok: true },
+      severityFloor: 'nit',
+      maxFindings: 30,
+      llmEnabled: false,
+      chunksReviewed: 1,
+      durationMs: 0
+    });
+    expect(merged.findings).toHaveLength(1);
+  });
+
+  it('drops findings below severity floor', () => {
+    const a = det({ id: 'rev-a', severity: 'nit' });
+    const b = det({ id: 'rev-b', severity: 'consider' });
+    const merged = mergeFindings({
+      deterministic: [a, b],
+      llmReasoned: { findings: [], ok: true },
+      severityFloor: 'consider',
+      maxFindings: 30,
+      llmEnabled: false,
+      chunksReviewed: 1,
+      durationMs: 0
+    });
+    expect(merged.findings).toHaveLength(1);
+    expect(merged.findings[0]?.severity).toBe('consider');
+  });
+
+  it('caps to maxFindings', () => {
+    const findings = Array.from({ length: 10 }, (_, i) => det({ id: `rev-${i}` }));
+    const merged = mergeFindings({
+      deterministic: findings,
+      llmReasoned: { findings: [], ok: true },
+      severityFloor: 'nit',
+      maxFindings: 3,
+      llmEnabled: false,
+      chunksReviewed: 1,
+      durationMs: 0
+    });
+    expect(merged.findings).toHaveLength(3);
+  });
+
+  it('drops Critic-denylisted LLM findings and counts redirects', () => {
+    const merged = mergeFindings({
+      deterministic: [],
+      llmReasoned: {
+        findings: [
+          { dimension: 'security-regression' as never, severity: 'consider', file: 'a', line: 1, suggestionTitle: 't', description: 'd', excerpt: '' },
+          { dimension: 'naming-convention', severity: 'nit', file: 'a', line: 2, suggestionTitle: 't2', description: 'd', excerpt: '' }
+        ],
+        ok: true
+      },
+      severityFloor: 'nit',
+      maxFindings: 30,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 0
+    });
+    expect(merged.summary.redirectsToCritic).toBe(1);
+    expect(merged.findings).toHaveLength(1);
+    expect(merged.findings[0]?.dimension).toBe('naming-convention');
+  });
+
+  it('praise findings sort first', () => {
+    const a = det({ id: 'a', severity: 'consider' });
+    const p = det({ id: 'p', severity: 'praise' });
+    const merged = mergeFindings({
+      deterministic: [a, p],
+      llmReasoned: { findings: [], ok: true },
+      severityFloor: 'praise',
+      maxFindings: 30,
+      llmEnabled: false,
+      chunksReviewed: 1,
+      durationMs: 0
+    });
+    expect(merged.findings[0]?.severity).toBe('praise');
+  });
+
+  it('llmReasoningSucceeded reflects llm.ok when enabled', () => {
+    const merged = mergeFindings({
+      deterministic: [],
+      llmReasoned: { findings: [], ok: false },
+      severityFloor: 'nit',
+      maxFindings: 30,
+      llmEnabled: true,
+      chunksReviewed: 0,
+      durationMs: 0
+    });
+    expect(merged.summary.llmReasoningSucceeded).toBe(false);
+  });
+});

--- a/packages/reviewer/tsconfig.build.json
+++ b/packages/reviewer/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/reviewer/tsconfig.json
+++ b/packages/reviewer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/reviewer/vitest.config.ts
+++ b/packages/reviewer/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules', 'src/cli.ts']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1632,6 +1632,25 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/reviewer:
+    dependencies:
+      '@chiefaia/mentor-event-bus':
+        specifier: workspace:*
+        version: link:../mentor-event-bus
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      '@vitest/coverage-v8':
+        specifier: 1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.39)(jsdom@26.1.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/secrets:
     devDependencies:
       '@chiefaia/eslint-config':


### PR DESCRIPTION
# `@chiefaia/reviewer` — advisory craftsmanship reviewer (item 9)

This PR lands the craftsmanship-focused PR review agent on `feat/reviewer-001-design` (rebased onto `origin/develop`). It is the **advisory sibling** to `@chiefaia/critic` (item 9, already merged via #379).

## ADVISORY-only — never blocks merges

Per the standing lesson `feedback_reviewer_agent_advisory_only_pattern.md` (2026-05-06), this agent is **purely advisory**:

- Severity lexicon: `praise / nit / suggestion / consider` — deliberately **never** `low/medium/high/critical`.
- Public API: `class ReviewerAgent { reviewPR(args): Promise<CraftsmanshipReview> }` — returns findings list, **does not return a verdict**, **does not have a `blockingFindings` field by design**. Static guarantee that this agent never blocks merges.
- Sibling structure (per `operator_decisions_2026-05-08.md` and the merge-strategy report `reviewer_agent_phase1_stop_condition_2026-05-08.md`):
  - **Critic** (item 9, `@chiefaia/critic`) — blocks for security / regression / cost.
  - **Reviewer** (this PR, `@chiefaia/reviewer`) — advisory craftsmanship.
  - **Code-Reviewer** (upcoming `@chiefaia/code-reviewer`, sibling to this) — blocks for correctness / bugs / style / types / test coverage / naming. Implements the operator-approved blocking AI-Code-Reviewer.
  - **Architecture/Security Reviewer** (Ollama qwen2.5-coder:32b on stolution) — second blocker for the two-AI-reviewer setup.

## What's in this PR

- 50 files / +3929 lines / 55 tests / 93.33% statement coverage
- Public API parameterised per Option E shape (`agent_architecture_shape_2026-05-06.md`) — every CAIA path is a constructor parameter with a CAIA default
- Two-tier detector pipeline:
  - 10 deterministic pattern detectors (disjoint-by-construction with Critic — E2E measured 0% overlap)
  - 8 LLM-reasoned craftsmanship dimensions via `claude --print --output-format json` subprocess
- Subscription-only LLM path: spawns the `claude` binary with `delete env['ANTHROPIC_API_KEY']` per the standing rule `feedback_no_api_key_billing.md` — **never uses the pay-per-token API key**.
- `FindingMerger` carries a static denylist of Critic's category IDs — defense-in-depth on top of the prompt-level non-overlap instruction.
- Hallucination guard, large-diff chunking, path-exclusion regexes — all reused from Critic primitives.
- 30-finding cap matches industry SOTA for advisory tools (CodeRabbit/Sourcery/Copilot).

See `packages/reviewer/DESIGN.md` for full design and `packages/reviewer/README.md` for usage.

## Rebase note

Originally the branch tip carried two unrelated commits (apprentice-serving, apprentice-retrainer). apprentice-serving has since been squash-merged via #374. The rebase used `git rebase --onto origin/develop 6ffc3bc feat/reviewer-001-design` to land **only the reviewer commit** on top of current `origin/develop`. apprentice-retrainer ships separately on its own branch.

## Merge plan

Path B autonomous: admin-merge if CI passes (only pre-existing develop reds expected).

## Trail

- Standing lesson: `~/Documents/projects/agent-memory/feedback_reviewer_agent_advisory_only_pattern.md`
- Merge-strategy report: `~/Documents/projects/agent-memory/reviewer_agent_phase1_stop_condition_2026-05-08.md`
- Operator decision (two-AI-reviewer setup): `~/Documents/projects/agent-memory/operator_decisions_2026-05-08.md`
- Architecture shape: `~/Documents/projects/agent-memory/agent_architecture_shape_2026-05-06.md`
- LLM billing rule: `~/Documents/projects/agent-memory/feedback_no_api_key_billing.md`
