### PR TITLE
feat: @chiefaia/code-reviewer Phase 1 — blocking PR code-review agent

### DIFF
--- a/.changeset/feat-code-reviewer-001-design.md
+++ b/.changeset/feat-code-reviewer-001-design.md
@@ -1,0 +1,43 @@
+---
+"@chiefaia/code-reviewer": minor
+---
+
+feat(code-reviewer-001): @chiefaia/code-reviewer Phase 1 — blocking PR code-review agent
+
+New private package `@chiefaia/code-reviewer` shipped per
+`operator_decisions_2026-05-08.md` ## "Branch protection: two AI reviewer
+agents". Sibling to `@chiefaia/critic` (security/regression/cost — also
+blocking) and `@chiefaia/reviewer` (advisory craftsmanship — never blocks).
+
+**Public API**
+
+```ts
+runCodeReview({ prRef, repoPath, diff, context }) -> Promise<CodeReview>
+// CodeReview { verdict: 'approve'|'request-changes', findings, blockingFindings, ... }
+```
+
+**Phase 1 (this PR) — LLM-only**
+
+- Seven dimensions: correctness, bug-risk, style, type-safety, test-coverage,
+  naming, comments (operator-named in `operator_decisions_2026-05-08.md`)
+- Subscription-only LLM via `claude --print --output-format json` —
+  `delete env['ANTHROPIC_API_KEY']` per `feedback_no_api_key_billing.md`
+- Verdict synthesis: `request-changes` iff any finding ≥ blockingSeverityThreshold
+  (default `medium`). Low-severity findings surface but don't block.
+- Disjoint-by-construction with siblings — three layers of denylist
+  enforcement (system prompt + sanitiser + merger). Mirrors the standing
+  pattern from `feedback_reviewer_agent_advisory_only_pattern.md` Rule 2.
+- Hallucination guard, large-diff chunking, conventions loading — same
+  primitives as Critic/Reviewer.
+- 94 tests, 94.5% statement coverage.
+- GitHub Action `.github/workflows/code-reviewer.yml` runs on PR open/sync,
+  posts verdict comment, submits `gh pr review --approve` /
+  `--request-changes`, fails CI on request-changes (blocks merge).
+
+**Phase 2 (planned)**
+
+- Deterministic-tier detectors mirroring Critic's two-tier pattern.
+- Branch protection wiring to require both Code-Reviewer and the
+  Architecture/Security Reviewer (Ollama qwen2.5-coder:32b on stolution).
+  Branch-protection modification is operator-only — surfaced for
+  authorization in this PR's body.

--- a/.github/workflows/code-reviewer.yml
+++ b/.github/workflows/code-reviewer.yml
@@ -81,16 +81,23 @@ jobs:
           # Per `feedback_no_api_key_billing.md`: ANTHROPIC_API_KEY is
           # explicitly NOT set; the agent's spawn env strips any inherited copy.
           CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          # Indirected through env vars to avoid shell-injection (semgrep
+          # yaml.github-actions.security.run-shell-injection): never
+          # interpolate ${{ github.event... }} directly inside `run:`.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         id: review
         run: |
           set +e
           node packages/code-reviewer/dist/cli.js review \
-            --pr ${{ github.event.pull_request.number }} \
+            --pr "$PR_NUMBER" \
             --diff-file /tmp/pr.diff \
             --output json \
-            --base-branch ${{ github.event.pull_request.base.ref }} \
-            --branch ${{ github.event.pull_request.head.ref }} \
-            --title "${{ github.event.pull_request.title }}" \
+            --base-branch "$PR_BASE_REF" \
+            --branch "$PR_HEAD_REF" \
+            --title "$PR_TITLE" \
             > /tmp/review.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           # Extract verdict for the next steps.
@@ -99,14 +106,20 @@ jobs:
 
       - name: Render review comment
         id: render
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          VERDICT: ${{ steps.review.outputs.verdict }}
         run: |
           node packages/code-reviewer/dist/cli.js review \
-            --pr ${{ github.event.pull_request.number }} \
+            --pr "$PR_NUMBER" \
             --diff-file /tmp/pr.diff \
             --output text \
-            --base-branch ${{ github.event.pull_request.base.ref }} \
-            --branch ${{ github.event.pull_request.head.ref }} \
-            --title "${{ github.event.pull_request.title }}" \
+            --base-branch "$PR_BASE_REF" \
+            --branch "$PR_HEAD_REF" \
+            --title "$PR_TITLE" \
             --no-llm \
             > /tmp/review.txt || true
           # Build a body file we can pass to gh.
@@ -114,7 +127,7 @@ jobs:
             echo "<!-- caia-code-reviewer -->"
             echo "## :robot: Code Reviewer (@chiefaia/code-reviewer)"
             echo ""
-            echo "**Verdict:** \`${{ steps.review.outputs.verdict }}\`"
+            echo "**Verdict:** \`$VERDICT\`"
             echo ""
             echo "Sibling: \`@chiefaia/critic\` (security/regression/cost — also blocking) and \`@chiefaia/reviewer\` (advisory craftsmanship — non-blocking)."
             echo ""
@@ -130,19 +143,22 @@ jobs:
       - name: Post review verdict comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/comment.md
 
       - name: Submit PR review (approve / request-changes)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERDICT: ${{ steps.review.outputs.verdict }}
         run: |
-          if [ "${{ steps.review.outputs.verdict }}" = "request-changes" ]; then
-            gh pr review ${{ github.event.pull_request.number }} \
+          if [ "$VERDICT" = "request-changes" ]; then
+            gh pr review "$PR_NUMBER" \
               --request-changes \
               --body "Code-Reviewer requests changes. See the verdict comment above."
           else
-            gh pr review ${{ github.event.pull_request.number }} \
+            gh pr review "$PR_NUMBER" \
               --approve \
               --body "Code-Reviewer approves. See the verdict comment above."
           fi

--- a/.github/workflows/code-reviewer.yml
+++ b/.github/workflows/code-reviewer.yml
@@ -1,0 +1,154 @@
+name: Code Reviewer
+
+# Runs the @chiefaia/code-reviewer agent on PR open + push, posts the review
+# verdict as a PR comment, and submits the PR review (approve / request-changes)
+# via the GitHub API. Together with the Architecture/Security Reviewer
+# (Ollama-based, Phase 5 of PR Review Pipeline Campaign) this fulfills the
+# two-AI-reviewer setup described in operator_decisions_2026-05-08.md.
+#
+# This workflow is the BLOCKING reviewer for correctness/bugs/style/types/
+# tests/naming/comments. The advisory @chiefaia/reviewer agent is sibling
+# but never blocks (its review-comment workflow is non-gating).
+#
+# Subscription-only: never sets ANTHROPIC_API_KEY in the spawn env. The
+# CLAUDE_OAUTH_TOKEN secret authenticates the `claude` binary via the
+# operator's Max subscription accounts.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, develop]
+
+# Skip drafts unless explicitly invoked.
+concurrency:
+  group: code-reviewer-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!docs/**'
+              - '!agent/memory/**'
+              - '!AGENTS.md'
+              - '!CHANGELOG.md'
+              - '!.changeset/**'
+
+  code-review:
+    name: Code Reviewer (blocking)
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.code == 'true' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-pnpm-mono
+
+      - name: Build code-reviewer
+        run: pnpm --filter @chiefaia/code-reviewer build
+
+      - name: Fetch PR diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
+          echo "Diff size: $(wc -c < /tmp/pr.diff) bytes"
+
+      - name: Run code-reviewer
+        env:
+          # Subscription-only auth — the binary picks up CLAUDE_OAUTH_TOKEN
+          # and routes through the operator's Max account, no API-key billing.
+          # Per `feedback_no_api_key_billing.md`: ANTHROPIC_API_KEY is
+          # explicitly NOT set; the agent's spawn env strips any inherited copy.
+          CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+        id: review
+        run: |
+          set +e
+          node packages/code-reviewer/dist/cli.js review \
+            --pr ${{ github.event.pull_request.number }} \
+            --diff-file /tmp/pr.diff \
+            --output json \
+            --base-branch ${{ github.event.pull_request.base.ref }} \
+            --branch ${{ github.event.pull_request.head.ref }} \
+            --title "${{ github.event.pull_request.title }}" \
+            > /tmp/review.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          # Extract verdict for the next steps.
+          VERDICT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('/tmp/review.json','utf-8')).verdict)")
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+
+      - name: Render review comment
+        id: render
+        run: |
+          node packages/code-reviewer/dist/cli.js review \
+            --pr ${{ github.event.pull_request.number }} \
+            --diff-file /tmp/pr.diff \
+            --output text \
+            --base-branch ${{ github.event.pull_request.base.ref }} \
+            --branch ${{ github.event.pull_request.head.ref }} \
+            --title "${{ github.event.pull_request.title }}" \
+            --no-llm \
+            > /tmp/review.txt || true
+          # Build a body file we can pass to gh.
+          {
+            echo "<!-- caia-code-reviewer -->"
+            echo "## :robot: Code Reviewer (@chiefaia/code-reviewer)"
+            echo ""
+            echo "**Verdict:** \`${{ steps.review.outputs.verdict }}\`"
+            echo ""
+            echo "Sibling: \`@chiefaia/critic\` (security/regression/cost — also blocking) and \`@chiefaia/reviewer\` (advisory craftsmanship — non-blocking)."
+            echo ""
+            echo "<details><summary>Full review</summary>"
+            echo ""
+            echo '```'
+            cat /tmp/review.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > /tmp/comment.md
+
+      - name: Post review verdict comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/comment.md
+
+      - name: Submit PR review (approve / request-changes)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.review.outputs.verdict }}" = "request-changes" ]; then
+            gh pr review ${{ github.event.pull_request.number }} \
+              --request-changes \
+              --body "Code-Reviewer requests changes. See the verdict comment above."
+          else
+            gh pr review ${{ github.event.pull_request.number }} \
+              --approve \
+              --body "Code-Reviewer approves. See the verdict comment above."
+          fi
+
+      - name: Fail job on request-changes (blocks merge)
+        if: steps.review.outputs.verdict == 'request-changes'
+        run: |
+          echo "::error::Code Reviewer requested changes — see PR comment for findings."
+          exit 1

--- a/packages/code-reviewer/DESIGN.md
+++ b/packages/code-reviewer/DESIGN.md
@@ -1,0 +1,144 @@
+# `@chiefaia/code-reviewer` — Design
+
+**Status:** Phase 1 design (LLM-only). Phase 2 will add deterministic detectors. **Trigger:** `operator_decisions_2026-05-08.md` ## "Branch protection: two AI reviewer agents". **Architectural shape:** Option E (`agent_architecture_shape_2026-05-06.md`). **LLM billing:** subscription-only via `claude` binary spawn (`feedback_no_api_key_billing.md`).
+
+## §1. Position in the agent fleet
+
+Three PR-review agents now coexist with deliberately disjoint roles:
+
+```
+@chiefaia/critic           — BLOCKING — security/regression/cost (Mentor's 18-cat taxonomy)
+@chiefaia/code-reviewer    — BLOCKING — correctness/bugs/style/types/tests/naming/comments
+@chiefaia/reviewer         — ADVISORY — craftsmanship (readability, idioms, maintainability)
+```
+
+The two BLOCKING reviewers cover separate domains: Critic asks "is this safe to ship?"; Code-Reviewer asks "is this CODE correct?". The ADVISORY Reviewer asks "is this code beautiful?" and never blocks. Together with the Architecture/Security Reviewer (Ollama qwen2.5-coder:32b on stolution, separate package), the two-AI-reviewer setup operator approved is fulfilled by Code-Reviewer + Architecture/Security Reviewer (NOT Code-Reviewer + advisory Reviewer; Reviewer's role is supplementary).
+
+## §2. Public API
+
+```ts
+runCodeReview({
+  prRef: number | string,
+  repoPath: string,
+  diff: string,
+  context: { branch, baseBranch, title, body?, commitSubjects? },
+  config?: CodeReviewerAgentConfig
+}) -> Promise<CodeReview>
+
+interface CodeReview {
+  prNumber: number;
+  reviewedAtIso: string;
+  verdict: 'approve' | 'request-changes';
+  findings: CodeReviewFinding[];
+  blockingFindings: CodeReviewFinding[];
+  totalFindings: number;
+  summary: ReviewSummary;
+}
+```
+
+Operator-named in `reviewer_agent_phase1_stop_condition_2026-05-08.md`. The function is a thin wrapper around `class CodeReviewerAgent` for callers that don't need full DI; tests use the class directly to inject fake `fs` / `llm` / `clock`.
+
+## §3. Seven dimensions
+
+The dimensions are taken verbatim from the operator's domain list in `operator_decisions_2026-05-08.md`: "correctness, bugs, style, test coverage, type safety, naming, comments". Mapped 1:1 to seven `CodeReviewDimensionId`s:
+
+| Dimension | Default severity | Description |
+|---|---|---|
+| `correctness` | `high` | logic errors — off-by-one, wrong operator, missing branch, returns wrong value |
+| `bug-risk` | `high` | latent bugs — null/undefined deref, missing await, race condition, unhandled rejection |
+| `style` | `low` | enforceable style violations — semicolons, quote style, single-line if-without-braces |
+| `type-safety` | `medium` | type errors that compile but are wrong — narrow-then-widen, force-cast, missing null in union |
+| `test-coverage` | `medium` | new public behavior shipped without a test that exercises it |
+| `naming` | `low` | incorrect / misleading names — `isValid` that returns side-effect status |
+| `comments` | `low` | misleading or stale comments — claims `O(n)` on `O(n²)` loop |
+
+Default severity is what the LLM-tier sanitiser uses when the model doesn't volunteer one. The sanitiser also CAPS LLM-suggested severity at the dimension's default — except for `correctness` and `bug-risk` (defaults to `high`), which are allowed to promote to `critical` because real data-loss bugs warrant it.
+
+## §4. Disjoint-by-construction with siblings
+
+Code-Reviewer must not duplicate Critic or advisory Reviewer findings. Three layers of defense:
+
+**Layer 1 — system prompt.** The LLM prompt explicitly enumerates Critic's 18 failure-mode IDs and Reviewer's 16 craftsmanship dimensions, and instructs the model to STAY IN ITS LANE. Verbatim from `src/llm-reasoner.ts`:
+
+> CRITICAL — STAY IN YOUR LANE:
+> (1) Do NOT flag any of these — they belong to the sibling Critic agent: security regressions, credential leaks, cost overruns, ...
+> (2) Do NOT flag stylistic-only refactors that don't have a correctness component — they belong to the advisory Reviewer agent: pure idiom adherence, abstraction quality, ...
+
+**Layer 2 — sanitiser drop.** `parseLlmOutput` -> `sanitiseLlmFinding` checks the `dimension` field against `CRITIC_DENYLIST` and `ADVISORY_REVIEWER_DENYLIST` and drops anything that lands on either set.
+
+**Layer 3 — merger drop + count.** `mergeFindings` re-checks the same denylists and increments `summary.redirectsToCritic` / `summary.redirectsToReviewer`. Surfacing the count lets operators see if the LLM is wandering — and the drop is hard-coded (the merger doesn't trust upstream layers to have already filtered).
+
+Three layers because LLM compliance with prompt instructions is statistical, not deterministic. Same lesson as Reviewer's `feedback_reviewer_agent_advisory_only_pattern.md` Rule 2.
+
+## §5. Verdict synthesis
+
+```
+verdict = blockingFindings.length > 0 ? 'request-changes' : 'approve'
+where blockingFindings = findings.filter(f => SEVERITY_RANK[f.severity] >= SEVERITY_RANK[blockingSeverityThreshold])
+```
+
+Default `blockingSeverityThreshold` is `medium`. So:
+
+* `low`-severity findings (style nits, naming nits, comment freshness) → surfaced but never block.
+* `medium` and above → block (request-changes).
+
+This matches the operator's intent. The advisory Reviewer carries everything as nit/suggestion/consider with NO `blockingFindings` field — that agent's static guarantee. Code-Reviewer's verdict is what the GitHub Action turns into a `gh pr review --approve` / `gh pr review --request-changes`.
+
+## §6. LLM-reasoned tier
+
+* **Binary:** `claude --print --output-format json --model claude-haiku-4-5-20251001` (configurable). Haiku-4.5 chosen as the default because correctness/bug review is well within Haiku's capability and the cost-per-token (vs. Sonnet) is meaningfully lower against the subscription's weekly cap.
+* **Subscription-only:** `delete env['ANTHROPIC_API_KEY']` before spawn. Per `feedback_no_api_key_billing.md`, the agent must NEVER fall through to per-token billing. The CI workflow uses `CLAUDE_OAUTH_TOKEN` to authenticate the binary against the operator's Max account.
+* **Hallucination guard:** drop any LLM finding whose `excerpt` (first 40 chars) isn't actually present in the concatenated diff text. Catches the model inventing line numbers / file paths.
+* **Chunking:** large hunks are split via `chunkHunk(maxBytes)` to a default of 64 KB per chunk (Datadog BewAIre lesson, also used by Critic and Reviewer).
+* **Failure modes:** spawn error / non-zero exit / parse error → `{ ok: false, diagnostic, findings: [] }`. The agent surfaces `summary.llmReasoningSucceeded: false` so operators can see when LLM quality wasn't available; the verdict in that case defaults to `approve` (no blockers found because none could be evaluated). Phase 2's deterministic tier will be a non-LLM safety net.
+
+## §7. Deterministic tier (Phase 2)
+
+Reserved for Phase 2. Will mirror the two-tier pattern from `@chiefaia/critic` (`feedback_critic_agent_two_tier_detector_pattern.md`) and `@chiefaia/reviewer` (`feedback_reviewer_agent_advisory_only_pattern.md`):
+
+* `correctness` — strict-equality misuse (`==` for primitives), unhandled awaited rejection patterns
+* `bug-risk` — `Promise<...>` returned but not awaited, `undefined` used as truthy guard
+* `type-safety` — explicit `as any`, `!.` non-null assertion in untyped context (already partly covered by the advisory `type-any` detector but tilted toward correctness here)
+* `test-coverage` — public export added with no `*.test.ts` change in the same PR
+* `naming` — semantic naming smells (`isXxx` that mutates, plural for singular)
+* `style` — only project-explicit rules (semicolons, quote style)
+* `comments` — comments asserting algorithmic complexity that the diff invalidates
+
+Phase 1 ships LLM-only because the LLM tier alone is sufficient to demonstrate the pipeline end-to-end. Phase 2 adds the safety net so the agent works even when LLM is rate-limited.
+
+## §8. Test strategy
+
+Phase 1 tests cover:
+
+* `diff-parser.test.ts` — happy-path, added/deleted/renamed, multi-file, binary-skip, empty
+* `chunk-hunk` and `walk-hunk` — boundary behavior
+* `config.test.ts` — all env-var paths, all explicit overrides, expandHome
+* `fs-reader.test.ts` — exists/readFile/readDir on tmp tree
+* `conventions-loader.test.ts` — heading allow-list, empty-section skip, fake-fs
+* `llm-reasoner.test.ts` — prompt build, JSON parsing, denylist drops, severity capping, subscription-env-strip, spawn failure paths
+* `merger.test.ts` — verdict synthesis, denylist enforcement, severity floor, sort, cap, dedup, summary
+* `finding-id.test.ts` — determinism, sensitivity to all four inputs
+* `agent.test.ts` — end-to-end with fake LLM, hallucination guard, LLM failure recovery, runCodeReview entrypoint
+* `types.test.ts` — invariants on dimension count, denylist disjointness, severity rank monotonicity
+
+Coverage target: **≥ 80%** on `src/**/*.ts` excluding `cli.ts`.
+
+Stop condition (per `reviewer_agent_phase1_stop_condition_2026-05-08.md`): if coverage drops below 80% on this package, STOP and add tests before merge.
+
+## §9. Branch protection follow-up (operator-only)
+
+Wiring branch protection on `develop` and `main` to require both Code-Reviewer's review AND the Architecture/Security Reviewer's review for merge is a permission change — operator-only per safety rules. Surfaced in this PR's body as a follow-up. Implementation plan once operator authorizes:
+
+1. GitHub App or scoped bot PAT for Code-Reviewer (Vault-stored, scoped to PR-approval only — no push, no admin).
+2. Same for Architecture/Security Reviewer (separate identity to keep approvals distinct).
+3. Branch protection: require 2 approvals from the AI-reviewer designated set; require Code Reviewer status check pass.
+4. Mitigations for bot-PAT compromise: 90-day rotation, weekly Loki audit (per `operator_decisions_2026-05-08.md`).
+
+## §10. References
+
+* `~/Documents/projects/agent-memory/operator_decisions_2026-05-08.md` ## Branch protection: two AI reviewer agents
+* `~/Documents/projects/agent-memory/reviewer_agent_phase1_stop_condition_2026-05-08.md` — Phase 1 stop-condition + Option A merge plan
+* `~/Documents/projects/agent-memory/feedback_reviewer_agent_advisory_only_pattern.md` — sibling advisory pattern (Reviewer)
+* `~/Documents/projects/agent-memory/feedback_critic_agent_two_tier_detector_pattern.md` — sibling two-tier pattern (Critic)
+* `~/Documents/projects/agent-memory/agent_architecture_shape_2026-05-06.md` — Option E
+* `~/Documents/projects/agent-memory/feedback_no_api_key_billing.md` — subscription-only

--- a/packages/code-reviewer/README.md
+++ b/packages/code-reviewer/README.md
@@ -1,0 +1,114 @@
+# `@chiefaia/code-reviewer`
+
+The **blocking** PR code-review agent for the CAIA monorepo. Reviews diffs for **correctness, bugs, style, type safety, test coverage, naming, and comments** and emits a binary `verdict` (`approve` | `request-changes`).
+
+This is the operator-named "Code Reviewer Agent" from `~/Documents/projects/agent-memory/operator_decisions_2026-05-08.md`. It is one of the two AI reviewers required by branch protection on `develop` and `main`. The second is the Architecture/Security Reviewer (Ollama qwen2.5-coder:32b on stolution).
+
+## Sibling agents
+
+This package sits alongside two other PR-review agents in the CAIA fleet. All three are deliberately disjoint by design:
+
+| Package | Block authority | Domain |
+|---|---|---|
+| `@chiefaia/critic` | BLOCKING | security, regressions, cost overruns, the 18-category failure-mode taxonomy |
+| `@chiefaia/code-reviewer` (this package) | BLOCKING | correctness, bugs, style, type safety, test coverage, naming, comments |
+| `@chiefaia/reviewer` | ADVISORY-only | craftsmanship (readability, idioms, maintainability) — never blocks |
+
+Code-Reviewer carries static denylists for both siblings' dimension IDs and drops any LLM-volunteered finding that lands on either. See `DESIGN.md §4` for the disjoint-by-construction argument.
+
+## Public API
+
+```ts
+import { runCodeReview } from '@chiefaia/code-reviewer';
+
+const review = await runCodeReview({
+  prRef: 399,
+  repoPath: '/Users/MAC/Documents/projects/caia',
+  diff: await fetchDiff(399),
+  context: { branch: 'feat/x', baseBranch: 'develop', title: '...' }
+});
+
+review.verdict;            // 'approve' | 'request-changes'
+review.findings;           // CodeReviewFinding[]
+review.blockingFindings;   // findings at or above blockingSeverityThreshold
+review.summary;            // counts, redirectsToCritic, redirectsToReviewer
+```
+
+For full DI (tests / custom drivers), instantiate `CodeReviewerAgent` directly:
+
+```ts
+import { CodeReviewerAgent } from '@chiefaia/code-reviewer';
+
+const agent = new CodeReviewerAgent({
+  fs: myFakeFs,
+  llm: myFakeLlm,
+  enableLlmReasoning: true,
+  severityFloor: 'low',
+  blockingSeverityThreshold: 'medium'
+});
+const review = await agent.reviewPR({ prNumber, diff, context });
+```
+
+## CLI
+
+```
+caia-code-reviewer review --pr <n> [--diff-file <path>] [--output text|json]
+                                   [--severity-floor low|medium|high|critical]
+                                   [--blocking-threshold low|medium|high|critical]
+                                   [--no-llm] [--base-branch <b>] [--branch <b>] [--title <t>]
+```
+
+Exit codes:
+
+* `0` — verdict `approve`
+* `1` — verdict `request-changes`
+* `2` — bad arguments / unrecoverable error
+
+## Subscription-only LLM
+
+The agent spawns the `claude` binary with `claude --print --output-format json --model <tag>`. Per the standing rule in `~/Documents/projects/agent-memory/feedback_no_api_key_billing.md`, the spawn env explicitly **deletes** `ANTHROPIC_API_KEY`. The binary authenticates via the operator's Max subscription account (one of the rotating pool), and per-token billing is impossible by construction.
+
+## Verdict synthesis
+
+`verdict = 'request-changes'` iff `any finding's severity >= blockingSeverityThreshold` (default: `medium`). Otherwise `verdict = 'approve'`.
+
+* **Default blocking threshold is `medium`.** `low`-severity findings (style, naming nits, comment freshness) are surfaced but never block.
+* **Severity floor is separately configurable.** Findings below the floor are dropped from the output entirely; the default is `low` (everything kept).
+
+This is the binary verdict the GitHub Action turns into a PR review (approve / request-changes) via `gh pr review`.
+
+## GitHub Action
+
+`.github/workflows/code-reviewer.yml` runs on PR `opened` / `synchronize` / `reopened` / `ready_for_review`. It fetches the diff via `gh pr diff`, runs the agent, posts the verdict as a PR comment, and submits a PR review. The job fails (red CI) when the verdict is `request-changes` so branch protection blocks merge.
+
+## Configuration
+
+All knobs are constructor parameters (Option E shape). Defaults resolve from env vars first, then compile-time CAIA defaults:
+
+| Parameter | Env var | Default |
+|---|---|---|
+| `conventionsPath` | `CAIA_CONVENTIONS_PATH` | `~/Documents/projects/caia/AGENTS.md` |
+| `claudeBinaryPath` | `CLAUDE_BINARY_PATH` | `claude` |
+| `modelTag` | `CODE_REVIEWER_MODEL_TAG` | `claude-haiku-4-5-20251001` |
+| `maxDiffBytes` | `CODE_REVIEWER_MAX_DIFF_BYTES` | `256000` |
+| `chunkBytes` | `CODE_REVIEWER_CHUNK_BYTES` | `64000` |
+| `severityFloor` | `CODE_REVIEWER_SEVERITY_FLOOR` | `low` |
+| `blockingSeverityThreshold` | `CODE_REVIEWER_BLOCKING_THRESHOLD` | `medium` |
+| `perVectorTimeoutMs` | `CODE_REVIEWER_VECTOR_TIMEOUT_MS` | `60000` |
+| `maxFindingsPerPr` | `CODE_REVIEWER_MAX_FINDINGS` | `50` |
+| `enableLlmReasoning` | `CODE_REVIEWER_LLM_ENABLED` | `true` |
+| `enableDeterministic` | `CODE_REVIEWER_DETERMINISTIC_ENABLED` | `true` (Phase 2) |
+
+## Phase status
+
+* **Phase 1 (this PR)**: skeleton + LLM-only review + verdict synthesis + GitHub Action + tests. Deterministic detectors deferred.
+* **Phase 2 (planned)**: deterministic-tier detectors for the seven dimensions, scaling the same two-tier pattern Critic and Reviewer use.
+* **Phase 3 (planned)**: branch protection wiring on `develop` + `main` (operator-only — see `surface-action.md` in this PR).
+
+## Trail
+
+* Operator decision: `~/Documents/projects/agent-memory/operator_decisions_2026-05-08.md` ## "Branch protection: two AI reviewer agents"
+* Phase 1 stop-condition + Option A merge plan: `~/Documents/projects/agent-memory/reviewer_agent_phase1_stop_condition_2026-05-08.md`
+* Sibling advisory pattern: `~/Documents/projects/agent-memory/feedback_reviewer_agent_advisory_only_pattern.md`
+* Architecture shape: `~/Documents/projects/agent-memory/agent_architecture_shape_2026-05-06.md`
+* LLM billing rule: `~/Documents/projects/agent-memory/feedback_no_api_key_billing.md`

--- a/packages/code-reviewer/eslint.config.cjs
+++ b/packages/code-reviewer/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — replaces .eslintrc.json
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/code-reviewer/package.json
+++ b/packages/code-reviewer/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@chiefaia/code-reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Blocking PR code-review agent — runCodeReview({prRef,repoPath}) → {verdict, findings}. Reviews correctness, bugs, style, type safety, test coverage, naming, comments. Sibling to @chiefaia/critic (security/regression/cost) and @chiefaia/reviewer (advisory craftsmanship). One of the two AI reviewers required by branch protection per operator_decisions_2026-05-08.md. Subscription-only LLM via claude --print. Option E shape — private workspace package, parameterised constructor, fixture-tested.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-code-reviewer": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/mentor-event-bus": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "1.6.1",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/code-reviewer/src/agent.ts
+++ b/packages/code-reviewer/src/agent.ts
@@ -1,0 +1,190 @@
+/**
+ * CodeReviewerAgent — public entrypoint.
+ *
+ * Composes diff parsing → LLM-reasoned tier → merger → verdict synthesis →
+ * CodeReview. Construction takes a fully-parameterised config; defaults
+ * resolve to CAIA paths via `resolveConfig` (Option E shape).
+ *
+ * Distinct from CriticAgent (BLOCKING for security/regression/cost), and
+ * from ReviewerAgent (ADVISORY-only for craftsmanship). This agent BLOCKS
+ * for correctness/bugs/style/types/tests/naming/comments and emits a
+ * binary `verdict`.
+ *
+ * Phase 1 (this PR) ships LLM-only — deterministic detectors are reserved
+ * for Phase 2 once the operator validates the LLM-tier signal quality.
+ */
+
+import type { CodeReviewerAgentConfig, ResolvedCodeReviewerAgentConfig } from './config.js';
+import { resolveConfig } from './config.js';
+import { defaultFsReader } from './fs-reader.js';
+import { parseDiff, chunkHunk } from './diff-parser.js';
+import { loadConventions } from './conventions-loader.js';
+import { createDefaultLlmReviewer, noopLlmReviewer } from './llm-reasoner.js';
+import { mergeFindings } from './merger.js';
+import type {
+  CodeReview,
+  CodeReviewFinding,
+  DiffHunk,
+  FsReader,
+  LlmReviewer,
+  ScanContext
+} from './types.js';
+
+/**
+ * Public API surface — operator-named in
+ * `reviewer_agent_phase1_stop_condition_2026-05-08.md` and
+ * `operator_decisions_2026-05-08.md`.
+ *
+ *   runCodeReview({ prRef, repoPath }) -> { verdict, findings }
+ *
+ * `prRef` is a PR number or branch ref understood by the calling context.
+ * `repoPath` is the absolute path to the repo on disk.
+ *
+ * The function is a thin convenience wrapper around `CodeReviewerAgent`;
+ * tests can either call this entrypoint directly (with a `diff` injection)
+ * or instantiate the class with full DI.
+ */
+export interface RunCodeReviewArgs {
+  /** PR number (preferred) or branch ref. */
+  prRef: number | string;
+  /** Absolute path to the repo on disk — used to resolve AGENTS.md. */
+  repoPath: string;
+  /** Pre-fetched diff. If omitted, the caller is expected to provide one
+   * via the CLI / Action layer (this function does NOT shell out to gh
+   * here so the public surface stays pure-and-injectable). */
+  diff: string;
+  /** Branch metadata for the LLM prompt. */
+  context: {
+    branch: string;
+    baseBranch: string;
+    title: string;
+    body?: string;
+    commitSubjects?: readonly string[];
+  };
+  /** Optional config override — same shape as the agent's constructor. */
+  config?: CodeReviewerAgentConfig;
+}
+
+export async function runCodeReview(args: RunCodeReviewArgs): Promise<CodeReview> {
+  const cfg: CodeReviewerAgentConfig = {
+    ...args.config,
+    conventionsPath: args.config?.conventionsPath ?? `${args.repoPath}/AGENTS.md`
+  };
+  const agent = new CodeReviewerAgent(cfg);
+  const prNumber = typeof args.prRef === 'number' ? args.prRef : 0;
+  return agent.reviewPR({
+    prNumber,
+    diff: args.diff,
+    context: args.context
+  });
+}
+
+export interface ReviewPRArgs {
+  prNumber: number;
+  diff: string;
+  context: {
+    branch: string;
+    baseBranch: string;
+    title: string;
+    body?: string;
+    commitSubjects?: readonly string[];
+  };
+}
+
+export class CodeReviewerAgent {
+  readonly config: ResolvedCodeReviewerAgentConfig;
+  private readonly fs: FsReader;
+  private readonly llm: LlmReviewer;
+  private readonly clock: () => Date;
+
+  constructor(input: CodeReviewerAgentConfig = {}) {
+    this.config = resolveConfig(input);
+    this.fs = input.fs ?? defaultFsReader;
+    this.clock = input.clock ?? ((): Date => new Date());
+    if (input.llm !== undefined) {
+      this.llm = input.llm;
+    } else if (this.config.enableLlmReasoning) {
+      this.llm = createDefaultLlmReviewer({
+        binaryPath: this.config.claudeBinaryPath,
+        modelTag: this.config.modelTag,
+        timeoutMs: this.config.perVectorTimeoutMs
+      });
+    } else {
+      this.llm = noopLlmReviewer;
+    }
+  }
+
+  async reviewPR(args: ReviewPRArgs): Promise<CodeReview> {
+    const t0 = this.clock().getTime();
+    const reviewedAtIso = this.clock().toISOString();
+
+    const parsed = parseDiff(args.diff);
+    const chunkedHunks: DiffHunk[] = parsed.hunks.flatMap(h => chunkHunk(h, this.config.chunkBytes));
+
+    const conventionExcerpts = loadConventions(this.fs, this.config.conventionsPath);
+    const ctx: ScanContext = {
+      conventionExcerpts,
+      pr: {
+        prNumber: args.prNumber,
+        branch: args.context.branch,
+        baseBranch: args.context.baseBranch,
+        title: args.context.title,
+        ...(args.context.body !== undefined ? { body: args.context.body } : {}),
+        commitSubjects: args.context.commitSubjects ?? []
+      },
+      reviewedAtIso
+    };
+
+    // Phase 1 ships LLM-only. Deterministic tier is reserved for Phase 2.
+    const detFindings: CodeReviewFinding[] = [];
+
+    let llmOutput = await (async () => {
+      if (!this.config.enableLlmReasoning || chunkedHunks.length === 0) {
+        return { findings: [], ok: true } as Awaited<ReturnType<LlmReviewer['review']>>;
+      }
+      try {
+        return await this.llm.review({
+          hunks: chunkedHunks,
+          conventionExcerpts: ctx.conventionExcerpts,
+          pr: ctx.pr
+        });
+      } catch (e) {
+        return { findings: [], ok: false, diagnostic: (e as Error).message } as Awaited<ReturnType<LlmReviewer['review']>>;
+      }
+    })();
+
+    // Hallucination guard — drop LLM findings whose excerpt isn't actually
+    // in the diff. Same lesson as Critic / Reviewer: prevents the model
+    // from inventing line numbers.
+    const diffText = chunkedHunks.map(h => h.body).join('\n');
+    llmOutput = {
+      ...llmOutput,
+      findings: llmOutput.findings.filter(f => {
+        if (f.excerpt === '' || f.excerpt === undefined) return true;
+        return diffText.includes(f.excerpt.slice(0, Math.min(40, f.excerpt.length)));
+      })
+    };
+
+    const t1 = this.clock().getTime();
+    const merged = mergeFindings({
+      deterministic: detFindings,
+      llmReasoned: llmOutput,
+      severityFloor: this.config.severityFloor,
+      blockingSeverityThreshold: this.config.blockingSeverityThreshold,
+      maxFindings: this.config.maxFindingsPerPr,
+      llmEnabled: this.config.enableLlmReasoning,
+      chunksReviewed: chunkedHunks.length,
+      durationMs: t1 - t0
+    });
+
+    return {
+      prNumber: args.prNumber,
+      reviewedAtIso,
+      verdict: merged.verdict,
+      findings: merged.findings,
+      blockingFindings: merged.blockingFindings,
+      totalFindings: merged.findings.length,
+      summary: merged.summary
+    };
+  }
+}

--- a/packages/code-reviewer/src/cli.ts
+++ b/packages/code-reviewer/src/cli.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * caia-code-reviewer CLI.
+ *
+ * Subcommands:
+ *   review --pr <n> [--diff-file <path>] [--output text|json]
+ *                    [--severity-floor <s>] [--blocking-threshold <s>]
+ *                    [--no-llm] [--base-branch <b>] [--branch <b>] [--title <t>]
+ *
+ *   dry-run --diff-file <path> [--output text|json] [--no-llm]
+ *
+ * If `--diff-file` is omitted, the CLI shells out to `gh pr diff <n>` to
+ * fetch the diff. SUBSCRIPTION-ONLY: never sets ANTHROPIC_API_KEY.
+ *
+ * Exit codes:
+ *   0 — verdict 'approve'
+ *   1 — verdict 'request-changes'
+ *   2 — bad arguments / unrecoverable error
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { CodeReviewerAgent } from './agent.js';
+import type { CodeReview, CodeReviewSeverity } from './types.js';
+
+interface ParsedArgs {
+  command: 'review' | 'dry-run' | 'help';
+  pr: number;
+  diffFile: string | null;
+  output: 'text' | 'json';
+  severityFloor: CodeReviewSeverity | null;
+  blockingThreshold: CodeReviewSeverity | null;
+  noLlm: boolean;
+  baseBranch: string;
+  branch: string;
+  title: string;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const a: ParsedArgs = {
+    command: 'help',
+    pr: 0,
+    diffFile: null,
+    output: 'text',
+    severityFloor: null,
+    blockingThreshold: null,
+    noLlm: false,
+    baseBranch: 'develop',
+    branch: 'unknown',
+    title: ''
+  };
+  if (argv.length === 0) return a;
+  const cmd = argv[0];
+  if (cmd === 'review' || cmd === 'dry-run') a.command = cmd;
+  for (let i = 1; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    switch (k) {
+      case '--pr':
+        a.pr = Number(v ?? '0');
+        i++;
+        break;
+      case '--diff-file':
+        a.diffFile = v ?? null;
+        i++;
+        break;
+      case '--output':
+        if (v === 'json' || v === 'text') a.output = v;
+        i++;
+        break;
+      case '--severity-floor':
+        if (v === 'low' || v === 'medium' || v === 'high' || v === 'critical') a.severityFloor = v;
+        i++;
+        break;
+      case '--blocking-threshold':
+        if (v === 'low' || v === 'medium' || v === 'high' || v === 'critical') a.blockingThreshold = v;
+        i++;
+        break;
+      case '--no-llm':
+        a.noLlm = true;
+        break;
+      case '--base-branch':
+        a.baseBranch = v ?? 'develop';
+        i++;
+        break;
+      case '--branch':
+        a.branch = v ?? 'unknown';
+        i++;
+        break;
+      case '--title':
+        a.title = v ?? '';
+        i++;
+        break;
+      default:
+        // ignore unknown flags
+        break;
+    }
+  }
+  return a;
+}
+
+function fetchDiffViaGh(prNumber: number): string {
+  const env = { ...process.env };
+  delete env['ANTHROPIC_API_KEY'];
+  const result = spawnSync('gh', ['pr', 'diff', String(prNumber)], {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env
+  });
+  if (result.status !== 0) {
+    throw new Error(`gh pr diff ${prNumber} failed: ${(result.stderr ?? '').toString().slice(0, 300)}`);
+  }
+  return (result.stdout ?? '').toString();
+}
+
+function renderText(review: CodeReview): string {
+  const lines: string[] = [];
+  lines.push(`# Code-Reviewer review for PR #${review.prNumber}`);
+  lines.push(`Reviewed: ${review.reviewedAtIso}`);
+  lines.push(`Verdict: ${review.verdict.toUpperCase()}`);
+  lines.push(`Total findings: ${review.totalFindings}  (blocking: ${review.blockingFindings.length})`);
+  lines.push('');
+  lines.push('## Summary');
+  for (const sev of ['critical', 'high', 'medium', 'low'] as const) {
+    const n = review.summary.countBySeverity[sev];
+    if (n > 0) lines.push(`- ${sev}: ${n}`);
+  }
+  lines.push(`- chunks reviewed: ${review.summary.chunksReviewed}`);
+  lines.push(`- duration: ${review.summary.durationMs}ms`);
+  lines.push(`- LLM-reasoned findings: ${review.summary.llmReasoned} (enabled: ${review.summary.llmEnabled}, ok: ${review.summary.llmReasoningSucceeded})`);
+  lines.push(`- redirects to Critic: ${review.summary.redirectsToCritic}`);
+  lines.push(`- redirects to advisory Reviewer: ${review.summary.redirectsToReviewer}`);
+  lines.push('');
+  if (review.findings.length === 0) {
+    lines.push('No findings above severity floor.');
+    return lines.join('\n');
+  }
+  lines.push('## Findings');
+  for (const f of review.findings) {
+    lines.push('');
+    lines.push(`### [${f.severity}] ${f.issueTitle}  (${f.dimension})`);
+    lines.push(`- file: ${f.file}:${f.line}`);
+    lines.push(`- source: ${f.source} (${f.detectorId})`);
+    lines.push(`- description: ${f.description}`);
+    if (f.reproductionSteps !== undefined && f.reproductionSteps.length > 0) {
+      lines.push('- repro:');
+      for (const s of f.reproductionSteps) lines.push(`  * ${s}`);
+    }
+    if (f.suggestedFix !== undefined) {
+      lines.push(`- fix: ${f.suggestedFix}`);
+    }
+    if (f.excerpt !== '') {
+      lines.push(`- excerpt: \`${f.excerpt.replace(/`/g, "'")}\``);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === 'help') {
+    console.log(`caia-code-reviewer — blocking PR code-review agent
+
+USAGE:
+  caia-code-reviewer review --pr <n> [--diff-file <path>] [--output text|json]
+                                     [--severity-floor low|medium|high|critical]
+                                     [--blocking-threshold low|medium|high|critical]
+                                     [--no-llm] [--base-branch <b>] [--branch <b>] [--title <t>]
+  caia-code-reviewer dry-run --diff-file <path> [--output text|json] [--no-llm]
+
+EXIT CODES:
+  0 — verdict 'approve'
+  1 — verdict 'request-changes'
+  2 — bad arguments / error
+`);
+    process.exit(0);
+  }
+  let diff: string;
+  if (args.diffFile !== null) {
+    diff = readFileSync(args.diffFile, 'utf-8');
+  } else if (args.command === 'review' && args.pr > 0) {
+    diff = fetchDiffViaGh(args.pr);
+  } else {
+    console.error('Either --pr (with gh access) or --diff-file is required.');
+    process.exit(2);
+  }
+  const cfgInput: ConstructorParameters<typeof CodeReviewerAgent>[0] = {};
+  if (args.noLlm) cfgInput.enableLlmReasoning = false;
+  if (args.severityFloor !== null) cfgInput.severityFloor = args.severityFloor;
+  if (args.blockingThreshold !== null) cfgInput.blockingSeverityThreshold = args.blockingThreshold;
+  const agent = new CodeReviewerAgent(cfgInput);
+  const review = await agent.reviewPR({
+    prNumber: args.pr,
+    diff,
+    context: {
+      branch: args.branch,
+      baseBranch: args.baseBranch,
+      title: args.title
+    }
+  });
+  if (args.output === 'json') {
+    console.log(JSON.stringify(review, null, 2));
+  } else {
+    console.log(renderText(review));
+  }
+  process.exit(review.verdict === 'request-changes' ? 1 : 0);
+}
+
+main().catch(e => {
+  console.error('caia-code-reviewer error:', (e as Error).message);
+  process.exit(2);
+});

--- a/packages/code-reviewer/src/config.ts
+++ b/packages/code-reviewer/src/config.ts
@@ -1,0 +1,144 @@
+/**
+ * @chiefaia/code-reviewer — config resolution.
+ *
+ * Constructor injects every CAIA-specific path/topic/threshold; defaults
+ * resolve from env vars, then from compile-time CAIA defaults. Tests inject
+ * fixture corpora and bypass env entirely. Per Option E architecture
+ * (`agent_architecture_shape_2026-05-06.md`).
+ */
+
+import { homedir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+import type { CodeReviewSeverity, FsReader, LlmReviewer } from './types.js';
+
+export interface CodeReviewerAgentConfig {
+  conventionsPath?: string;
+  reportsRoot?: string;
+  eventBusUrl?: string;
+  claudeBinaryPath?: string;
+  modelTag?: string;
+  maxDiffBytes?: number;
+  chunkBytes?: number;
+  /** Severity floor — findings below this are excluded from `findings`
+   * AND ignored for verdict computation. Default: `low`. */
+  severityFloor?: CodeReviewSeverity;
+  /** Minimum severity that triggers a `request-changes` verdict.
+   * Default: `medium`. (i.e. `low` findings never block.) */
+  blockingSeverityThreshold?: CodeReviewSeverity;
+  perVectorTimeoutMs?: number;
+  maxFindingsPerPr?: number;
+  enableLlmReasoning?: boolean;
+  enableDeterministic?: boolean;
+  /** DI seams — tests inject fakes. */
+  fs?: FsReader;
+  llm?: LlmReviewer;
+  clock?: () => Date;
+}
+
+export interface ResolvedCodeReviewerAgentConfig {
+  conventionsPath: string;
+  reportsRoot: string;
+  eventBusUrl: string;
+  claudeBinaryPath: string;
+  modelTag: string;
+  maxDiffBytes: number;
+  chunkBytes: number;
+  severityFloor: CodeReviewSeverity;
+  blockingSeverityThreshold: CodeReviewSeverity;
+  perVectorTimeoutMs: number;
+  maxFindingsPerPr: number;
+  enableLlmReasoning: boolean;
+  enableDeterministic: boolean;
+}
+
+/** Expand a leading `~/` to the operator's home dir. */
+export function expandHome(p: string): string {
+  if (p.startsWith('~/')) return resolve(homedir(), p.slice(2));
+  if (p === '~') return homedir();
+  return p;
+}
+
+const DEFAULT_REPO_GUESS = join(homedir(), 'Documents/projects/caia');
+const DEFAULT_CONVENTIONS_PATH = join(DEFAULT_REPO_GUESS, 'AGENTS.md');
+
+const DEFAULT_REPORTS_ROOT = '~/Documents/projects/reports';
+const DEFAULT_EVENT_BUS_URL = 'tcp://localhost:7777';
+const DEFAULT_CLAUDE_BINARY = 'claude';
+const DEFAULT_MODEL_TAG = 'claude-haiku-4-5-20251001';
+
+const DEFAULT_MAX_DIFF_BYTES = 256_000;
+const DEFAULT_CHUNK_BYTES = 64_000;
+const DEFAULT_SEVERITY_FLOOR: CodeReviewSeverity = 'low';
+const DEFAULT_BLOCKING_THRESHOLD: CodeReviewSeverity = 'medium';
+const DEFAULT_PER_VECTOR_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_FINDINGS_PER_PR = 50;
+
+export function resolveConfig(input: CodeReviewerAgentConfig = {}): ResolvedCodeReviewerAgentConfig {
+  const conventionsPath = expandHome(
+    input.conventionsPath
+    ?? process.env['CAIA_CONVENTIONS_PATH']
+    ?? DEFAULT_CONVENTIONS_PATH
+  );
+  const reportsRoot = expandHome(
+    input.reportsRoot
+    ?? process.env['CAIA_REPORTS_ROOT']
+    ?? DEFAULT_REPORTS_ROOT
+  );
+  const eventBusUrl =
+    input.eventBusUrl
+    ?? process.env['MENTOR_EVENT_BUS_URL']
+    ?? DEFAULT_EVENT_BUS_URL;
+  const claudeBinaryPath =
+    input.claudeBinaryPath
+    ?? process.env['CLAUDE_BINARY_PATH']
+    ?? DEFAULT_CLAUDE_BINARY;
+  const modelTag =
+    input.modelTag
+    ?? process.env['CODE_REVIEWER_MODEL_TAG']
+    ?? DEFAULT_MODEL_TAG;
+
+  const maxDiffBytes =
+    input.maxDiffBytes
+    ?? (Number(process.env['CODE_REVIEWER_MAX_DIFF_BYTES']) || DEFAULT_MAX_DIFF_BYTES);
+  const chunkBytes =
+    input.chunkBytes
+    ?? (Number(process.env['CODE_REVIEWER_CHUNK_BYTES']) || DEFAULT_CHUNK_BYTES);
+  const severityFloor: CodeReviewSeverity =
+    input.severityFloor
+    ?? (process.env['CODE_REVIEWER_SEVERITY_FLOOR'] as CodeReviewSeverity | undefined)
+    ?? DEFAULT_SEVERITY_FLOOR;
+  const blockingSeverityThreshold: CodeReviewSeverity =
+    input.blockingSeverityThreshold
+    ?? (process.env['CODE_REVIEWER_BLOCKING_THRESHOLD'] as CodeReviewSeverity | undefined)
+    ?? DEFAULT_BLOCKING_THRESHOLD;
+  const perVectorTimeoutMs =
+    input.perVectorTimeoutMs
+    ?? (Number(process.env['CODE_REVIEWER_VECTOR_TIMEOUT_MS']) || DEFAULT_PER_VECTOR_TIMEOUT_MS);
+  const maxFindingsPerPr =
+    input.maxFindingsPerPr
+    ?? (Number(process.env['CODE_REVIEWER_MAX_FINDINGS']) || DEFAULT_MAX_FINDINGS_PER_PR);
+
+  const enableLlmReasoning =
+    input.enableLlmReasoning
+    ?? (process.env['CODE_REVIEWER_LLM_ENABLED'] !== '0');
+  const enableDeterministic =
+    input.enableDeterministic
+    ?? (process.env['CODE_REVIEWER_DETERMINISTIC_ENABLED'] !== '0');
+
+  return {
+    conventionsPath,
+    reportsRoot,
+    eventBusUrl,
+    claudeBinaryPath,
+    modelTag,
+    maxDiffBytes,
+    chunkBytes,
+    severityFloor,
+    blockingSeverityThreshold,
+    perVectorTimeoutMs,
+    maxFindingsPerPr,
+    enableLlmReasoning,
+    enableDeterministic
+  };
+}

--- a/packages/code-reviewer/src/conventions-loader.ts
+++ b/packages/code-reviewer/src/conventions-loader.ts
@@ -1,0 +1,95 @@
+/**
+ * Conventions loader — reads AGENTS.md (or any conventions file) and
+ * extracts the sections most relevant to a correctness/bugs/style review.
+ *
+ * Sections of interest (heading-name match, case-insensitive):
+ *   - "Code style"
+ *   - "Conventions"
+ *   - "Naming"
+ *   - "Testing"
+ *   - "Type safety"
+ *   - "Correctness"
+ *   - "Bug patterns"
+ *
+ * Mirrors `@chiefaia/reviewer`'s loader shape but tilts the heading allow-
+ * list toward correctness/bugs (Reviewer tilted toward craftsmanship).
+ *
+ * If the conventions file is missing → returns an empty array (the LLM
+ * tier still runs, just without project-specific grounding).
+ */
+
+import type { ConventionExcerpt, FsReader } from './types.js';
+
+const CONVENTIONS_HEADINGS = [
+  'code style',
+  'conventions',
+  'naming',
+  'testing',
+  'type safety',
+  'correctness',
+  'bug patterns',
+  'review checklist'
+];
+
+const HEADING_LINE = /^##+\s+(.+?)\s*(?:\(.*\))?$/;
+const BODY_EXCERPT_MAX = 500;
+
+export function loadConventions(fs: FsReader, conventionsPath: string): ConventionExcerpt[] {
+  if (!fs.exists(conventionsPath)) return [];
+  let content: string;
+  try {
+    content = fs.readFile(conventionsPath);
+  } catch {
+    return [];
+  }
+  return parseConventionsMarkdown(conventionsPath, content);
+}
+
+export function parseConventionsMarkdown(source: string, content: string): ConventionExcerpt[] {
+  const lines = content.split('\n');
+  const out: ConventionExcerpt[] = [];
+  let currentHeading: string | null = null;
+  let currentBuffer: string[] = [];
+
+  const flush = (): void => {
+    if (currentHeading === null) return;
+    if (!isInterestingHeading(currentHeading)) {
+      currentHeading = null;
+      currentBuffer = [];
+      return;
+    }
+    const body = currentBuffer.join('\n').trim();
+    if (body.length === 0) {
+      currentHeading = null;
+      currentBuffer = [];
+      return;
+    }
+    out.push({
+      source,
+      heading: currentHeading,
+      bodyExcerpt: body.slice(0, BODY_EXCERPT_MAX)
+    });
+    currentHeading = null;
+    currentBuffer = [];
+  };
+
+  for (const line of lines) {
+    const m = HEADING_LINE.exec(line);
+    if (m !== null) {
+      flush();
+      currentHeading = (m[1] ?? '').trim();
+      currentBuffer = [];
+      continue;
+    }
+    if (currentHeading !== null) {
+      currentBuffer.push(line);
+    }
+  }
+  flush();
+  return out;
+}
+
+function isInterestingHeading(heading: string): boolean {
+  const norm = heading.toLowerCase();
+  return CONVENTIONS_HEADINGS.some(h => norm.includes(h));
+}

--- a/packages/code-reviewer/src/diff-parser.ts
+++ b/packages/code-reviewer/src/diff-parser.ts
@@ -1,0 +1,192 @@
+/**
+ * Unified-diff parser — pure functions, no I/O.
+ *
+ * Mirrors the shape used by `@chiefaia/critic` and `@chiefaia/reviewer` —
+ * intentional, all three agents share the same pre-processing path so the
+ * two-tier detector pattern is uniform across the agent fleet.
+ *
+ * Handles GitHub-style unified diff produced by `git diff` / `gh pr diff`:
+ *   - `diff --git a/<path> b/<path>` separator lines
+ *   - `--- a/<path>` / `+++ b/<path>` file headers
+ *   - `@@ -<oldStart>,<oldLen> +<newStart>,<newLen> @@` hunk headers
+ *   - hunk-body lines prefixed with ` `, `+`, `-`
+ *   - `new file mode <oct>` / `deleted file mode <oct>` / `rename from`
+ *
+ * Binary-file diffs are skipped.
+ */
+
+import type { DiffHunk, ParsedDiff } from './types.js';
+
+const FILE_HEADER = /^diff --git a\/(.+?) b\/(.+?)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export function parseDiff(diff: string): ParsedDiff {
+  const lines = diff.split('\n');
+  const hunks: DiffHunk[] = [];
+  const fileSet = new Set<string>();
+
+  let currentFile: string | null = null;
+  let currentStatus: DiffHunk['status'] = 'modified';
+  let currentBody: string[] = [];
+  let currentHeader = '';
+  let currentOldStart = 0;
+  let currentNewStart = 0;
+  let inHunk = false;
+  let isBinary = false;
+
+  const flush = (): void => {
+    if (inHunk && currentFile !== null && !isBinary) {
+      hunks.push({
+        file: currentFile,
+        oldStart: currentOldStart,
+        newStart: currentNewStart,
+        header: currentHeader,
+        body: currentBody.join('\n'),
+        status: currentStatus
+      });
+    }
+    inHunk = false;
+    currentBody = [];
+  };
+
+  for (const line of lines) {
+    const fileMatch = FILE_HEADER.exec(line);
+    if (fileMatch !== null) {
+      flush();
+      currentFile = fileMatch[2] ?? fileMatch[1] ?? null;
+      if (currentFile !== null) fileSet.add(currentFile);
+      currentStatus = 'modified';
+      isBinary = false;
+      continue;
+    }
+    if (line.startsWith('new file mode ')) {
+      currentStatus = 'added';
+      continue;
+    }
+    if (line.startsWith('deleted file mode ')) {
+      currentStatus = 'deleted';
+      continue;
+    }
+    if (line.startsWith('rename from ') || line.startsWith('rename to ')) {
+      currentStatus = 'renamed';
+      continue;
+    }
+    if (line.startsWith('Binary files ')) {
+      isBinary = true;
+      continue;
+    }
+    if (line.startsWith('--- ') || line.startsWith('+++ ')) {
+      // discard — file path already captured
+      continue;
+    }
+    const hunkMatch = HUNK_HEADER.exec(line);
+    if (hunkMatch !== null) {
+      flush();
+      inHunk = true;
+      currentHeader = line;
+      currentOldStart = Number(hunkMatch[1] ?? '0');
+      currentNewStart = Number(hunkMatch[3] ?? '0');
+      currentBody = [];
+      continue;
+    }
+    if (inHunk && currentFile !== null && !isBinary) {
+      if (line === '' || line.startsWith(' ') || line.startsWith('+') || line.startsWith('-') || line.startsWith('\\')) {
+        currentBody.push(line);
+      }
+    }
+  }
+  flush();
+
+  return {
+    hunks,
+    totalBytes: Buffer.byteLength(diff, 'utf-8'),
+    fileCount: fileSet.size
+  };
+}
+
+/** Split a hunk body by max bytes — Datadog BewAIre lesson: large hunks
+ * degrade LLM evaluation quality. Sub-hunks share `file`; line offsets are
+ * adjusted per chunk. */
+export function chunkHunk(hunk: DiffHunk, maxBytes: number): DiffHunk[] {
+  if (Buffer.byteLength(hunk.body, 'utf-8') <= maxBytes) return [hunk];
+
+  const lines = hunk.body.split('\n');
+  const out: DiffHunk[] = [];
+  let bucket: string[] = [];
+  let bucketBytes = 0;
+  let oldOffset = 0;
+  let newOffset = 0;
+  let nextOldOffset = 0;
+  let nextNewOffset = 0;
+
+  const advance = (line: string): void => {
+    if (line.startsWith('-')) nextOldOffset++;
+    else if (line.startsWith('+')) nextNewOffset++;
+    else if (line.startsWith(' ') || line === '') {
+      nextOldOffset++;
+      nextNewOffset++;
+    }
+  };
+
+  const flushBucket = (): void => {
+    if (bucket.length === 0) return;
+    out.push({
+      file: hunk.file,
+      oldStart: hunk.oldStart + oldOffset,
+      newStart: hunk.newStart + newOffset,
+      header: out.length === 0
+        ? hunk.header
+        : `@@ -${hunk.oldStart + oldOffset} +${hunk.newStart + newOffset} @@ (chunked)`,
+      body: bucket.join('\n'),
+      status: hunk.status
+    });
+    oldOffset = nextOldOffset;
+    newOffset = nextNewOffset;
+    bucket = [];
+    bucketBytes = 0;
+  };
+
+  for (const line of lines) {
+    const lineBytes = Buffer.byteLength(line, 'utf-8') + 1;
+    if (bucketBytes + lineBytes > maxBytes && bucket.length > 0) {
+      flushBucket();
+    }
+    bucket.push(line);
+    bucketBytes += lineBytes;
+    advance(line);
+  }
+  flushBucket();
+  return out;
+}
+
+export interface DiffLine {
+  /** kind: '+' added, '-' removed, ' ' context. */
+  kind: '+' | '-' | ' ';
+  newLine: number;
+  oldLine: number;
+  text: string;
+}
+
+/** Walk a hunk body and emit (kind, newLine, oldLine, text) per body line. */
+export function walkHunk(hunk: DiffHunk): DiffLine[] {
+  const out: DiffLine[] = [];
+  let oldLine = hunk.oldStart;
+  let newLine = hunk.newStart;
+  for (const raw of hunk.body.split('\n')) {
+    if (raw === '' || raw.startsWith('\\')) continue;
+    const prefix = raw[0] ?? ' ';
+    const text = raw.slice(1);
+    if (prefix === '+') {
+      out.push({ kind: '+', newLine, oldLine: -1, text });
+      newLine++;
+    } else if (prefix === '-') {
+      out.push({ kind: '-', newLine: -1, oldLine, text });
+      oldLine++;
+    } else {
+      out.push({ kind: ' ', newLine, oldLine, text });
+      newLine++;
+      oldLine++;
+    }
+  }
+  return out;
+}

--- a/packages/code-reviewer/src/finding-id.ts
+++ b/packages/code-reviewer/src/finding-id.ts
@@ -1,0 +1,27 @@
+/**
+ * Stable id-hash for findings — `dimension|file|line|issueTitle`.
+ *
+ * Uses a simple, deterministic FNV-1a 32-bit hash over the canonical key.
+ * No crypto needed (these are dedup keys, not security tokens).
+ */
+
+export interface FindingIdInputs {
+  dimension: string;
+  file: string;
+  line: number;
+  issueTitle: string;
+}
+
+export function findingId(inputs: FindingIdInputs): string {
+  const key = `${inputs.dimension}|${inputs.file}|${inputs.line}|${inputs.issueTitle}`;
+  return fnv1a32(key);
+}
+
+function fnv1a32(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}

--- a/packages/code-reviewer/src/fs-reader.ts
+++ b/packages/code-reviewer/src/fs-reader.ts
@@ -1,0 +1,26 @@
+/**
+ * Default real-filesystem reader. Tests inject a fake instead.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+
+import type { FsReader } from './types.js';
+
+export const defaultFsReader: FsReader = {
+  exists(p: string): boolean {
+    return existsSync(p);
+  },
+  readFile(p: string): string {
+    return readFileSync(p, 'utf-8');
+  },
+  readDir(p: string): string[] {
+    if (!existsSync(p)) return [];
+    try {
+      const st = statSync(p);
+      if (!st.isDirectory()) return [];
+      return readdirSync(p).sort();
+    } catch {
+      return [];
+    }
+  }
+};

--- a/packages/code-reviewer/src/index.ts
+++ b/packages/code-reviewer/src/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @chiefaia/code-reviewer — public surface.
+ *
+ * Sibling to `@chiefaia/critic` (security/regression/cost — BLOCKING) and
+ * `@chiefaia/reviewer` (craftsmanship — ADVISORY-only). This package is
+ * the BLOCKING reviewer for correctness/bugs/style/types/tests/naming/
+ * comments, returning a binary verdict per `operator_decisions_2026-05-08.md`.
+ *
+ * Primary entrypoint: `runCodeReview({ prRef, repoPath, diff, context })`.
+ */
+
+export { CodeReviewerAgent, runCodeReview } from './agent.js';
+export type { ReviewPRArgs, RunCodeReviewArgs } from './agent.js';
+
+export {
+  resolveConfig,
+  expandHome,
+  type CodeReviewerAgentConfig,
+  type ResolvedCodeReviewerAgentConfig
+} from './config.js';
+
+export { defaultFsReader } from './fs-reader.js';
+export { parseDiff, chunkHunk, walkHunk, type DiffLine } from './diff-parser.js';
+export { loadConventions, parseConventionsMarkdown } from './conventions-loader.js';
+export { mergeFindings, type MergeArgs, type MergeResult } from './merger.js';
+export { findingId } from './finding-id.js';
+export {
+  createDefaultLlmReviewer,
+  noopLlmReviewer,
+  parseLlmOutput,
+  buildPrompt,
+  type DefaultLlmReviewerOptions
+} from './llm-reasoner.js';
+
+export type {
+  CodeReview,
+  CodeReviewFinding,
+  CodeReviewDimensionId,
+  CodeReviewSeverity,
+  ConventionExcerpt,
+  Detector,
+  DiffHunk,
+  ParsedDiff,
+  FsReader,
+  LlmReviewer,
+  LlmReviewInput,
+  LlmReviewOutput,
+  ReviewSummary,
+  ScanContext,
+  Verdict
+} from './types.js';
+
+export {
+  ALL_DIMENSIONS,
+  DEFAULT_SEVERITY,
+  SEVERITY_RANK,
+  CRITIC_DENYLIST,
+  ADVISORY_REVIEWER_DENYLIST
+} from './types.js';

--- a/packages/code-reviewer/src/llm-reasoner.ts
+++ b/packages/code-reviewer/src/llm-reasoner.ts
@@ -1,0 +1,281 @@
+/**
+ * LLM-reasoned tier — see DESIGN.md §6.
+ *
+ * Spawns the `claude` binary in subprocess (subscription-only path —
+ * cribbed from `@chiefaia/critic` and `@chiefaia/reviewer`'s reasoners,
+ * compliant with `feedback_no_api_key_billing.md`). The prompt carries:
+ *   1. A correctness/bugs-focused system prompt.
+ *   2. The 7 code-review dimensions with one-line descriptions.
+ *   3. Explicit non-overlap instructions for both siblings (Critic's
+ *      block-worthy categories AND advisory Reviewer's craftsmanship-only
+ *      dimensions are off-limits).
+ *   4. The diff hunks (capped to a configured byte budget).
+ *   5. AGENTS.md / conventions excerpts so the LLM grounds in CAIA idioms.
+ *   6. A strict JSON output schema.
+ *
+ * Failures (timeout, parse-error, non-zero exit) cause `ok: false` and the
+ * caller drops the LLM-tier findings. Deterministic-tier findings (when
+ * added in Phase 2) are always emitted regardless.
+ *
+ * SUBSCRIPTION-ONLY: deletes ANTHROPIC_API_KEY from the spawn env so the
+ * binary cannot fall back to per-token billing under any circumstance.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+
+import type {
+  CodeReviewDimensionId,
+  CodeReviewFinding,
+  CodeReviewSeverity,
+  LlmReviewInput,
+  LlmReviewOutput,
+  LlmReviewer
+} from './types.js';
+import {
+  ADVISORY_REVIEWER_DENYLIST,
+  ALL_DIMENSIONS,
+  CRITIC_DENYLIST,
+  DEFAULT_SEVERITY,
+  SEVERITY_RANK
+} from './types.js';
+
+export interface DefaultLlmReviewerOptions {
+  binaryPath: string;
+  modelTag: string;
+  timeoutMs: number;
+  /** Test seam — replaces `child_process.spawnSync`. */
+  spawnFn?: (
+    cmd: string,
+    args: readonly string[],
+    opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }
+  ) => SpawnSyncReturns<string>;
+}
+
+const DIMENSION_DESCRIPTIONS: Readonly<Record<CodeReviewDimensionId, string>> = {
+  correctness: 'logic errors — off-by-one, wrong operator, missing branch, returns wrong value, mutates wrong target.',
+  'bug-risk': 'latent bugs — null/undefined deref, missing await, race condition, unhandled rejection, exception thrown out of finally.',
+  style: 'enforceable style violations the project explicitly chose — semicolons, quote style, single-line if-without-braces.',
+  'type-safety': 'type errors that compile but are wrong — narrow-then-widen, force-cast around a real type mismatch, missing null in union.',
+  'test-coverage': 'new public behavior shipped without a test that exercises it; new branch in existing fn left uncovered.',
+  naming: 'incorrect / misleading names — `isValid` that returns side-effect status, plural for singular, type/role mismatch.',
+  comments: 'misleading or stale comments — claims `O(n)` on an `O(n²)` loop, references a removed function, contradicts the code.'
+};
+
+const SYSTEM_PROMPT = `You are a code reviewer for the CAIA monorepo. Your job is to spot CORRECTNESS, BUGS, STYLE, TYPE SAFETY, TEST COVERAGE, NAMING, and COMMENTS issues that should block merge until fixed. You have block authority — be precise, evidence-based, and avoid speculation.
+
+Tone: a senior engineer leaving substantive PR comments. Bias toward "medium" and "high" for real bugs and correctness issues; emit "low" for style/naming/comment nits; emit "critical" only for clear data-loss / data-corruption / hard crash bugs in production code paths.
+
+CRITICAL — STAY IN YOUR LANE:
+
+(1) Do NOT flag any of these — they belong to the sibling Critic agent:
+- security regressions, credential leaks, cost overruns
+- hallucination, scope mismatch, wrong direction, lacking information
+- premature completion, re-litigation, decision-classifier violations
+- git/branch hygiene, tool misuse, CI flakes, recipe rot, false-modesty
+- coordination failures, operator confusion, memory drift, incompleteness
+
+(2) Do NOT flag stylistic-only refactors that don't have a correctness component — they belong to the advisory Reviewer agent:
+- pure idiom adherence / abstraction quality / suggested refactors with no bug component
+- function length / file length / magic numbers / nesting depth as PURELY style — only flag if the structure causes a real bug or readability-blocking confusion
+- comment density (missing JSDoc with no correctness implication)
+- type-any used as a craftsmanship critique (DO flag if \`any\` masks a real type mismatch — that's "type-safety", not craftsmanship)
+- TODO without ticket / console.log left in / duplicate imports as pure style
+
+If a finding could go either way (Reviewer vs Code-Reviewer), only emit it here if it has a CORRECTNESS or BUG component. Otherwise leave it for the advisory Reviewer.
+
+Output STRICT JSON in the shape:
+{"findings":[{"dimension":"<id>","severity":"low|medium|high|critical","file":"...","line":123,"issueTitle":"...","description":"...","reproductionSteps":["..."],"suggestedFix":"...","excerpt":"..."}]}
+No prose before or after. No markdown fences. Keep total findings <= 10 per chunk; quality over quantity.`;
+
+export function buildPrompt(input: LlmReviewInput): string {
+  const dimensionsBlock = ALL_DIMENSIONS
+    .map(d => `  - ${d}: ${DIMENSION_DESCRIPTIONS[d]}`)
+    .join('\n');
+  const conventionsBlock = input.conventionExcerpts.length === 0
+    ? '(none — fall back to general TS / Node best practices)'
+    : input.conventionExcerpts
+        .map(c => `### ${c.heading} (from ${c.source})\n${c.bodyExcerpt}`)
+        .join('\n\n');
+  const hunksBlock = input.hunks
+    .map(h => `### ${h.file} (${h.status})\n${h.header}\n${h.body}`)
+    .join('\n\n');
+  return `${SYSTEM_PROMPT}
+
+## Code-review dimensions
+${dimensionsBlock}
+
+## Project conventions
+${conventionsBlock}
+
+## PR metadata
+- prNumber: ${input.pr.prNumber}
+- branch: ${input.pr.branch}
+- baseBranch: ${input.pr.baseBranch}
+- title: ${input.pr.title}
+
+## Diff hunks
+${hunksBlock}
+
+## Output JSON now:`;
+}
+
+export function createDefaultLlmReviewer(opts: DefaultLlmReviewerOptions): LlmReviewer {
+  const spawn = opts.spawnFn ?? spawnSync;
+  return {
+    async review(input: LlmReviewInput): Promise<LlmReviewOutput> {
+      const prompt = buildPrompt(input);
+      // SUBSCRIPTION-ONLY — strip API-key auth env var so the binary cannot
+      // fall through to per-token billing per `feedback_no_api_key_billing.md`.
+      const env = { ...process.env };
+      delete env['ANTHROPIC_API_KEY'];
+      const result = spawn(
+        opts.binaryPath,
+        ['--print', '--output-format', 'json', '--model', opts.modelTag],
+        { input: prompt, encoding: 'utf-8', timeout: opts.timeoutMs, env }
+      );
+      if (result.error !== null && result.error !== undefined) {
+        return {
+          findings: [],
+          ok: false,
+          diagnostic: `claude spawn error: ${result.error.message}`
+        };
+      }
+      if (result.status !== 0) {
+        return {
+          findings: [],
+          ok: false,
+          diagnostic: `claude exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
+        };
+      }
+      const stdout = (result.stdout ?? '').toString();
+      return parseLlmOutput(stdout);
+    }
+  };
+}
+
+/** Noop reviewer — used when `enableLlmReasoning` is false. */
+export const noopLlmReviewer: LlmReviewer = {
+  async review(): Promise<LlmReviewOutput> {
+    return { findings: [], ok: true };
+  }
+};
+
+/** Parse the `claude --print --output-format json` envelope, then the
+ * inner JSON the prompt asked for. Robust against extra whitespace and
+ * leading/trailing prose. */
+export function parseLlmOutput(stdout: string): LlmReviewOutput {
+  let outer: unknown;
+  try {
+    outer = JSON.parse(stdout);
+  } catch (e) {
+    return { findings: [], ok: false, diagnostic: `outer JSON parse: ${(e as Error).message}` };
+  }
+  if (
+    typeof outer !== 'object'
+    || outer === null
+    || typeof (outer as { result?: unknown }).result !== 'string'
+  ) {
+    return { findings: [], ok: false, diagnostic: 'envelope missing "result" string' };
+  }
+  const inner = (outer as { result: string }).result;
+  const block = extractFirstJsonObject(inner);
+  if (block === null) {
+    return { findings: [], ok: false, diagnostic: 'no JSON object in inner result' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(block);
+  } catch (e) {
+    return { findings: [], ok: false, diagnostic: `inner JSON parse: ${(e as Error).message}` };
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { findings: [], ok: false, diagnostic: 'inner not an object' };
+  }
+  const findingsRaw = (parsed as { findings?: unknown }).findings;
+  if (!Array.isArray(findingsRaw)) {
+    return { findings: [], ok: true };
+  }
+  const findings = findingsRaw
+    .map(f => sanitiseLlmFinding(f))
+    .filter((f): f is Omit<CodeReviewFinding, 'id' | 'source' | 'detectorId'> => f !== null);
+  return { findings, ok: true };
+}
+
+function extractFirstJsonObject(s: string): string | null {
+  const start = s.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function sanitiseLlmFinding(raw: unknown): Omit<CodeReviewFinding, 'id' | 'source' | 'detectorId'> | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const dim = r['dimension'];
+  if (typeof dim !== 'string') return null;
+  // Defense in depth on top of the prompt — drop anything that landed on
+  // either sibling's denylist.
+  if (CRITIC_DENYLIST.has(dim)) return null;
+  if (ADVISORY_REVIEWER_DENYLIST.has(dim)) return null;
+  if (!ALL_DIMENSIONS.includes(dim as CodeReviewDimensionId)) return null;
+  const dimension = dim as CodeReviewDimensionId;
+  const file = typeof r['file'] === 'string' ? r['file'] : '';
+  if (file === '') return null;
+  const line = typeof r['line'] === 'number' && Number.isFinite(r['line']) ? r['line'] : 0;
+  const issueTitle = typeof r['issueTitle'] === 'string' && r['issueTitle'].length > 0
+    ? r['issueTitle']
+    : 'unspecified';
+  const description = typeof r['description'] === 'string' ? r['description'] : '';
+  if (description === '') return null;
+  const sevRaw = r['severity'];
+  const severity: CodeReviewSeverity = (sevRaw === 'low' || sevRaw === 'medium' || sevRaw === 'high' || sevRaw === 'critical')
+    ? sevRaw
+    : DEFAULT_SEVERITY[dimension];
+  // Cap LLM-suggested severity at the dimension's default ceiling — except
+  // we let the model promote when the dimension's default is already high
+  // (correctness/bug-risk) and it volunteers a critical bug.
+  const finalSev: CodeReviewSeverity = capSeverity(severity, DEFAULT_SEVERITY[dimension]);
+  const excerptRaw = typeof r['excerpt'] === 'string' ? r['excerpt'].slice(0, 200) : '';
+  const suggestedFix = typeof r['suggestedFix'] === 'string' ? r['suggestedFix'] : undefined;
+  const reproRaw = r['reproductionSteps'];
+  const reproductionSteps = Array.isArray(reproRaw)
+    ? reproRaw.filter((s): s is string => typeof s === 'string').slice(0, 6)
+    : undefined;
+
+  const out: Omit<CodeReviewFinding, 'id' | 'source' | 'detectorId'> = {
+    dimension,
+    severity: finalSev,
+    file,
+    line,
+    issueTitle,
+    description,
+    excerpt: excerptRaw
+  };
+  if (suggestedFix !== undefined) out.suggestedFix = suggestedFix;
+  if (reproductionSteps !== undefined && reproductionSteps.length > 0) {
+    out.reproductionSteps = reproductionSteps;
+  }
+  return out;
+}
+
+/** Cap the LLM-suggested severity. For correctness/bug-risk we permit
+ * promotion up to `critical` because data-loss bugs are real. For other
+ * dimensions, cap at the default to avoid a chatty model promoting style
+ * to high. */
+function capSeverity(suggested: CodeReviewSeverity, defaultForDimension: CodeReviewSeverity): CodeReviewSeverity {
+  if (defaultForDimension === 'high') {
+    // Allow promotion to critical for correctness/bug-risk — caps still apply.
+    return suggested;
+  }
+  return SEVERITY_RANK[suggested] <= SEVERITY_RANK[defaultForDimension]
+    ? suggested
+    : defaultForDimension;
+}

--- a/packages/code-reviewer/src/merger.ts
+++ b/packages/code-reviewer/src/merger.ts
@@ -1,0 +1,149 @@
+/**
+ * FindingMerger + verdict synthesis.
+ *
+ * Inputs:
+ *   - deterministic findings (already have id, source, detectorId; reserved
+ *     for Phase 2 — phase 1 ships LLM-only)
+ *   - LLM-reasoned findings (omit id, source, detectorId — we add them)
+ *
+ * Output: a single deduped, severity-floored, deterministic-ordered list,
+ * AND a binary `verdict` (`approve` | `request-changes`) computed from the
+ * presence of findings at or above `blockingSeverityThreshold`.
+ *
+ * Verdict synthesis rule:
+ *   verdict = (blockingFindings.length > 0) ? 'request-changes' : 'approve'
+ *   where blockingFindings = findings.filter(f => severity >= blockingSeverityThreshold)
+ *
+ * Drop-on-overlap behavior: any finding whose `dimension` lands on Critic's
+ * or advisory Reviewer's denylist is dropped from the output AND counted in
+ * `redirectsToCritic` / `redirectsToReviewer`. Defense in depth on top of
+ * the prompt-level non-overlap instruction and the LLM-tier sanitiser.
+ */
+
+import type {
+  CodeReviewFinding,
+  CodeReviewSeverity,
+  LlmReviewOutput,
+  ReviewSummary,
+  Verdict
+} from './types.js';
+import {
+  ADVISORY_REVIEWER_DENYLIST,
+  ALL_DIMENSIONS,
+  CRITIC_DENYLIST,
+  SEVERITY_RANK
+} from './types.js';
+import { findingId } from './finding-id.js';
+
+export interface MergeArgs {
+  deterministic: readonly CodeReviewFinding[];
+  llmReasoned: LlmReviewOutput;
+  severityFloor: CodeReviewSeverity;
+  blockingSeverityThreshold: CodeReviewSeverity;
+  maxFindings: number;
+  llmEnabled: boolean;
+  chunksReviewed: number;
+  durationMs: number;
+}
+
+export interface MergeResult {
+  findings: CodeReviewFinding[];
+  blockingFindings: CodeReviewFinding[];
+  verdict: Verdict;
+  summary: ReviewSummary;
+}
+
+export function mergeFindings(args: MergeArgs): MergeResult {
+  const {
+    deterministic,
+    llmReasoned,
+    severityFloor,
+    blockingSeverityThreshold,
+    maxFindings,
+    llmEnabled,
+    chunksReviewed,
+    durationMs
+  } = args;
+
+  // Defense in depth — drop anything whose dimension falls on either
+  // sibling's denylist. Counted into the summary so operators can see if
+  // the LLM keeps wandering into sibling domains.
+  let redirectsToCritic = 0;
+  let redirectsToReviewer = 0;
+  const llmKept = llmReasoned.findings.filter(f => {
+    if (CRITIC_DENYLIST.has(f.dimension)) {
+      redirectsToCritic++;
+      return false;
+    }
+    if (ADVISORY_REVIEWER_DENYLIST.has(f.dimension)) {
+      redirectsToReviewer++;
+      return false;
+    }
+    return true;
+  });
+
+  const llmHydrated: CodeReviewFinding[] = llmKept.map(f => ({
+    ...f,
+    id: findingId({ dimension: f.dimension, file: f.file, line: f.line, issueTitle: f.issueTitle }),
+    source: 'llm-reasoned' as const,
+    detectorId: 'llm-reviewer'
+  }));
+
+  const all = [...deterministic, ...llmHydrated];
+
+  // Dedup by id — first occurrence wins (deterministic precedence over LLM).
+  const seen = new Set<string>();
+  const deduped: CodeReviewFinding[] = [];
+  for (const f of all) {
+    if (seen.has(f.id)) continue;
+    seen.add(f.id);
+    deduped.push(f);
+  }
+
+  // Severity floor — drop anything below.
+  const floorRank = SEVERITY_RANK[severityFloor];
+  const floored = deduped.filter(f => SEVERITY_RANK[f.severity] >= floorRank);
+
+  // Stable sort: severity desc, then dimension index asc, then file, then line.
+  floored.sort((a, b) => {
+    const sd = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sd !== 0) return sd;
+    const ci = ALL_DIMENSIONS.indexOf(a.dimension) - ALL_DIMENSIONS.indexOf(b.dimension);
+    if (ci !== 0) return ci;
+    if (a.file < b.file) return -1;
+    if (a.file > b.file) return 1;
+    return a.line - b.line;
+  });
+
+  const capped = floored.slice(0, maxFindings);
+
+  // Verdict synthesis — request-changes iff any finding is at or above
+  // the blocking threshold.
+  const blockingRank = SEVERITY_RANK[blockingSeverityThreshold];
+  const blockingFindings = capped.filter(f => SEVERITY_RANK[f.severity] >= blockingRank);
+  const verdict: Verdict = blockingFindings.length > 0 ? 'request-changes' : 'approve';
+
+  const countBySeverity: Record<CodeReviewSeverity, number> = { low: 0, medium: 0, high: 0, critical: 0 };
+  const countByDimension: ReviewSummary['countByDimension'] = {};
+  for (const f of capped) {
+    countBySeverity[f.severity]++;
+    countByDimension[f.dimension] = (countByDimension[f.dimension] ?? 0) + 1;
+  }
+  const detCount = capped.filter(f => f.source === 'deterministic').length;
+  const llmCount = capped.filter(f => f.source === 'llm-reasoned').length;
+
+  const summary: ReviewSummary = {
+    countBySeverity,
+    countByDimension,
+    chunksReviewed,
+    durationMs,
+    deterministic: detCount,
+    llmReasoned: llmCount,
+    llmEnabled,
+    llmReasoningSucceeded: !llmEnabled || llmReasoned.ok,
+    redirectsToCritic,
+    redirectsToReviewer
+  };
+
+  return { findings: capped, blockingFindings, verdict, summary };
+}

--- a/packages/code-reviewer/src/types.ts
+++ b/packages/code-reviewer/src/types.ts
@@ -1,0 +1,256 @@
+/**
+ * @chiefaia/code-reviewer — public type surface.
+ *
+ * The Code Reviewer Agent reviews PR diffs for correctness, bugs, style,
+ * type safety, test coverage, naming, and comments — and emits a binary
+ * `verdict` (`approve` | `request-changes`) plus the underlying findings.
+ *
+ * Distinct from the two sibling agents:
+ *   - `@chiefaia/critic`        — security/regression/cost (BLOCKING).
+ *   - `@chiefaia/reviewer`      — craftsmanship (ADVISORY-only, never blocks).
+ *   - `@chiefaia/code-reviewer` — this package: correctness/bugs/style
+ *                                 (BLOCKING; emits verdict).
+ *
+ * Code-Reviewer's domain is deliberately disjoint from both siblings:
+ *   - Critic catches security/cost/coordination failure modes Mentor's
+ *     taxonomy treats as adversarial. Code-Reviewer does not duplicate.
+ *   - Reviewer catches stylistic improvements with no block authority.
+ *     Code-Reviewer's findings either block or don't — there is no
+ *     advisory-style middle tier in this agent.
+ */
+
+/** Code-Reviewer severity scale — mirrors Critic's (because both block). */
+export type CodeReviewSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export const SEVERITY_RANK: Readonly<Record<CodeReviewSeverity, number>> = Object.freeze({
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3
+});
+
+/**
+ * Code-Reviewer's seven dimension IDs. Each dimension maps to one of the
+ * review domains operator named in `operator_decisions_2026-05-08.md`:
+ * "correctness, bugs, style, test coverage, type safety, naming, comments".
+ */
+export type CodeReviewDimensionId =
+  | 'correctness'
+  | 'bug-risk'
+  | 'style'
+  | 'type-safety'
+  | 'test-coverage'
+  | 'naming'
+  | 'comments';
+
+export const ALL_DIMENSIONS: readonly CodeReviewDimensionId[] = Object.freeze([
+  'correctness',
+  'bug-risk',
+  'style',
+  'type-safety',
+  'test-coverage',
+  'naming',
+  'comments'
+]);
+
+/** Default severity per dimension — verdict synthesiser uses these defaults
+ * when the LLM doesn't volunteer one. See DESIGN.md §6. */
+export const DEFAULT_SEVERITY: Readonly<Record<CodeReviewDimensionId, CodeReviewSeverity>> = Object.freeze({
+  correctness: 'high',
+  'bug-risk': 'high',
+  style: 'low',
+  'type-safety': 'medium',
+  'test-coverage': 'medium',
+  naming: 'low',
+  comments: 'low'
+});
+
+/**
+ * Critic's 18 failure-mode categories — Code-Reviewer must not duplicate.
+ * Mirrored from `@chiefaia/critic` so the merger has a static denylist
+ * without taking a runtime dependency on critic.
+ */
+export const CRITIC_DENYLIST: ReadonlySet<string> = new Set<string>([
+  'hallucination',
+  'scope-mismatch',
+  'incompleteness',
+  'wrong-direction',
+  'lacking-information',
+  'coordination-failure',
+  'git-branch-hygiene',
+  'cost-overrun',
+  'security-regression',
+  'operator-confusion',
+  'premature-completion',
+  're-litigation',
+  'decision-classifier-violation',
+  'memory-drift',
+  'false-modesty',
+  'recipe-rot',
+  'tool-misuse',
+  'ci-flake-masquerade'
+]);
+
+/**
+ * Advisory Reviewer's 18 craftsmanship dimensions — Code-Reviewer must not
+ * duplicate. Mirrored from `@chiefaia/reviewer`.
+ *
+ * NOTE: Code-Reviewer DOES cover `naming` and `comments` (the operator's
+ * domain list explicitly names them). Reviewer's `naming-convention` and
+ * `comment-density` are stylistic; Code-Reviewer's are semantic
+ * (incorrect-name, misleading-comment). The merger keeps the dimensions
+ * separate by ID.
+ */
+export const ADVISORY_REVIEWER_DENYLIST: ReadonlySet<string> = new Set<string>([
+  'idiom-adherence',
+  'abstraction-quality',
+  'suggested-refactor',
+  'test-design',
+  'error-handling-style',
+  'architecture-pattern',
+  'documentation-quality',
+  'api-ergonomics',
+  'function-length',
+  'file-length',
+  'magic-numbers',
+  'duplicate-imports',
+  'deep-nesting',
+  'todo-without-ticket',
+  'console-logging',
+  'type-any'
+]);
+
+export interface DiffHunk {
+  /** File path relative to repo root (post-rename if renamed). */
+  file: string;
+  /** Old start line — 1-based. 0 for added files. */
+  oldStart: number;
+  /** New start line — 1-based. 0 for deleted files. */
+  newStart: number;
+  /** Hunk header — e.g. '@@ -10,5 +10,7 @@'. */
+  header: string;
+  /** Hunk body — contiguous diff lines. Includes ` `, `+`, `-` prefixes. */
+  body: string;
+  /** Status — added / modified / deleted / renamed. */
+  status: 'added' | 'modified' | 'deleted' | 'renamed';
+}
+
+export interface ParsedDiff {
+  hunks: DiffHunk[];
+  totalBytes: number;
+  fileCount: number;
+}
+
+export interface ConventionExcerpt {
+  /** Source path or filename, e.g. 'AGENTS.md'. */
+  source: string;
+  /** Section heading. */
+  heading: string;
+  /** Body — first ~500 chars. */
+  bodyExcerpt: string;
+}
+
+export interface ScanContext {
+  /** Conventions excerpts loaded from AGENTS.md / craftsmanship docs. */
+  conventionExcerpts: readonly ConventionExcerpt[];
+  /** PR metadata for the LLM prompt. */
+  pr: {
+    prNumber: number;
+    branch: string;
+    baseBranch: string;
+    title: string;
+    body?: string;
+    commitSubjects: readonly string[];
+  };
+  /** Wall clock for stable id-hash. */
+  reviewedAtIso: string;
+}
+
+export interface CodeReviewFinding {
+  /** Stable hash of `dimension|file|line|issueTitle` — dedup key. */
+  id: string;
+  dimension: CodeReviewDimensionId;
+  severity: CodeReviewSeverity;
+  file: string;
+  /** 1-based line in the new file (post-change). 0 if not line-localised. */
+  line: number;
+  /** Short human-readable name — e.g. 'null-deref-on-result'. */
+  issueTitle: string;
+  /** Why this is a problem — one paragraph max. */
+  description: string;
+  /** Concrete steps to reproduce or to verify the bug — if applicable. */
+  reproductionSteps?: string[];
+  /** Suggested fix sketch. */
+  suggestedFix?: string;
+  source: 'deterministic' | 'llm-reasoned';
+  /** Detector identifier for traceability. */
+  detectorId: string;
+  /** ≤200 chars of the offending diff hunk for context. */
+  excerpt: string;
+}
+
+/** Binary verdict — operator-named in `operator_decisions_2026-05-08.md`:
+ * "Either requests-changes blocks merge."
+ */
+export type Verdict = 'approve' | 'request-changes';
+
+export interface CodeReview {
+  prNumber: number;
+  reviewedAtIso: string;
+  /** The headline output — synthesised from finding severity + presence. */
+  verdict: Verdict;
+  /** All findings above the severity floor. */
+  findings: CodeReviewFinding[];
+  /** Findings that drove the `request-changes` verdict (severity >= floor for blocking). */
+  blockingFindings: CodeReviewFinding[];
+  totalFindings: number;
+  summary: ReviewSummary;
+}
+
+export interface ReviewSummary {
+  countBySeverity: Record<CodeReviewSeverity, number>;
+  countByDimension: Partial<Record<CodeReviewDimensionId, number>>;
+  chunksReviewed: number;
+  durationMs: number;
+  deterministic: number;
+  llmReasoned: number;
+  llmEnabled: boolean;
+  llmReasoningSucceeded: boolean;
+  /** Findings dropped because their dimension fell on Critic's denylist. */
+  redirectsToCritic: number;
+  /** Findings dropped because their dimension fell on advisory Reviewer's
+   * denylist. Surfaces if the LLM tries to wander into stylistic-only
+   * dimensions. */
+  redirectsToReviewer: number;
+}
+
+/** Detector contract — every deterministic detector implements this. */
+export interface Detector {
+  readonly id: string;
+  readonly dimension: CodeReviewDimensionId;
+  scan(hunk: DiffHunk, ctx: ScanContext): CodeReviewFinding[];
+}
+
+/** LLM-reasoned tier seam — replaceable in tests. */
+export interface LlmReviewer {
+  review(input: LlmReviewInput): Promise<LlmReviewOutput>;
+}
+
+export interface LlmReviewInput {
+  hunks: readonly DiffHunk[];
+  conventionExcerpts: readonly ConventionExcerpt[];
+  pr: ScanContext['pr'];
+}
+
+export interface LlmReviewOutput {
+  findings: ReadonlyArray<Omit<CodeReviewFinding, 'id' | 'source' | 'detectorId'>>;
+  ok: boolean;
+  diagnostic?: string;
+}
+
+/** Filesystem read seam — every disk read goes through this. */
+export interface FsReader {
+  exists(p: string): boolean;
+  readFile(p: string): string;
+  readDir(p: string): string[];
+}

--- a/packages/code-reviewer/tests/agent.test.ts
+++ b/packages/code-reviewer/tests/agent.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { CodeReviewerAgent, runCodeReview } from '../src/agent.js';
+import type { FsReader, LlmReviewer, LlmReviewOutput } from '../src/types.js';
+
+const fakeFs = (files: Record<string, string>): FsReader => ({
+  exists: (p: string) => Object.prototype.hasOwnProperty.call(files, p),
+  readFile: (p: string) => files[p],
+  readDir: () => []
+});
+
+const fakeLlm = (output: LlmReviewOutput): LlmReviewer => ({
+  async review(): Promise<LlmReviewOutput> {
+    return output;
+  }
+});
+
+const SAMPLE_DIFF = [
+  'diff --git a/src/foo.ts b/src/foo.ts',
+  'index 1234567..abcdefg 100644',
+  '--- a/src/foo.ts',
+  '+++ b/src/foo.ts',
+  '@@ -1,3 +1,4 @@',
+  ' export const x = 1;',
+  '+export const y = nullableThing.field;',
+  ' export const z = 3;',
+  ' export const w = 4;'
+].join('\n');
+
+describe('CodeReviewerAgent', () => {
+  it('returns approve verdict on a clean LLM response', async () => {
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      llm: fakeLlm({ findings: [], ok: true }),
+      enableDeterministic: false,
+      clock: () => new Date('2026-05-08T00:00:00Z')
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.verdict).toBe('approve');
+    expect(review.findings).toHaveLength(0);
+    expect(review.totalFindings).toBe(0);
+  });
+
+  it('returns request-changes when LLM finds high-severity issue', async () => {
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      llm: fakeLlm({
+        findings: [{
+          dimension: 'bug-risk',
+          severity: 'high',
+          file: 'src/foo.ts',
+          line: 2,
+          issueTitle: 'null-deref',
+          description: 'nullableThing might be null',
+          excerpt: 'nullableThing.field'
+        }],
+        ok: true
+      }),
+      enableDeterministic: false,
+      clock: () => new Date('2026-05-08T00:00:00Z')
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.verdict).toBe('request-changes');
+    expect(review.findings).toHaveLength(1);
+    expect(review.blockingFindings).toHaveLength(1);
+  });
+
+  it('hallucination guard drops findings with excerpt not in diff', async () => {
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      llm: fakeLlm({
+        findings: [{
+          dimension: 'bug-risk',
+          severity: 'high',
+          file: 'src/foo.ts',
+          line: 100,
+          issueTitle: 'invented',
+          description: 'this excerpt is not in the diff',
+          excerpt: 'nonexistent_function_call_xyz_12345'
+        }],
+        ok: true
+      }),
+      enableDeterministic: false,
+      clock: () => new Date('2026-05-08T00:00:00Z')
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.findings).toHaveLength(0);
+    expect(review.verdict).toBe('approve');
+  });
+
+  it('passes findings with empty excerpt through hallucination guard', async () => {
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      llm: fakeLlm({
+        findings: [{
+          dimension: 'naming',
+          severity: 'low',
+          file: 'src/foo.ts',
+          line: 1,
+          issueTitle: 'name',
+          description: 'd',
+          excerpt: ''
+        }],
+        ok: true
+      }),
+      enableDeterministic: false,
+      clock: () => new Date('2026-05-08T00:00:00Z')
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.findings).toHaveLength(1);
+  });
+
+  it('handles LLM failure gracefully', async () => {
+    const failingLlm: LlmReviewer = {
+      async review(): Promise<LlmReviewOutput> {
+        throw new Error('boom');
+      }
+    };
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      llm: failingLlm,
+      enableDeterministic: false,
+      clock: () => new Date('2026-05-08T00:00:00Z')
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.verdict).toBe('approve');
+    expect(review.summary.llmReasoningSucceeded).toBe(false);
+  });
+
+  it('disables LLM when configured', async () => {
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      enableLlmReasoning: false,
+      enableDeterministic: false
+    });
+    const review = await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(review.summary.llmEnabled).toBe(false);
+  });
+
+  it('skips LLM call when diff has no hunks', async () => {
+    let called = false;
+    const trackingLlm: LlmReviewer = {
+      async review(): Promise<LlmReviewOutput> {
+        called = true;
+        return { findings: [], ok: true };
+      }
+    };
+    const agent = new CodeReviewerAgent({
+      fs: fakeFs({}),
+      llm: trackingLlm,
+      enableDeterministic: false
+    });
+    await agent.reviewPR({
+      prNumber: 1,
+      diff: '',
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(called).toBe(false);
+  });
+
+  it('loads conventions from configured path', async () => {
+    const fs = fakeFs({
+      '/repo/AGENTS.md': '## Code style\nUse 2 spaces.'
+    });
+    let llmInputConventions = 0;
+    const trackingLlm: LlmReviewer = {
+      async review(input): Promise<LlmReviewOutput> {
+        llmInputConventions = input.conventionExcerpts.length;
+        return { findings: [], ok: true };
+      }
+    };
+    const agent = new CodeReviewerAgent({
+      fs,
+      llm: trackingLlm,
+      conventionsPath: '/repo/AGENTS.md',
+      enableDeterministic: false
+    });
+    await agent.reviewPR({
+      prNumber: 1,
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' }
+    });
+    expect(llmInputConventions).toBe(1);
+  });
+});
+
+describe('runCodeReview entrypoint', () => {
+  it('forwards args and returns the verdict', async () => {
+    const review = await runCodeReview({
+      prRef: 42,
+      repoPath: '/nonexistent/repo',
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/x', baseBranch: 'develop', title: 't' },
+      config: {
+        fs: fakeFs({}),
+        llm: fakeLlm({ findings: [], ok: true }),
+        enableDeterministic: false
+      }
+    });
+    expect(review.verdict).toBe('approve');
+    expect(review.prNumber).toBe(42);
+  });
+
+  it('handles string prRef by zeroing prNumber', async () => {
+    const review = await runCodeReview({
+      prRef: 'feat/foo',
+      repoPath: '/nonexistent/repo',
+      diff: SAMPLE_DIFF,
+      context: { branch: 'feat/foo', baseBranch: 'develop', title: 't' },
+      config: {
+        fs: fakeFs({}),
+        llm: fakeLlm({ findings: [], ok: true }),
+        enableDeterministic: false
+      }
+    });
+    expect(review.prNumber).toBe(0);
+  });
+
+  it('respects config override of conventionsPath', async () => {
+    const fs = fakeFs({
+      '/explicit/AGENTS.md': '## Code style\nfoo'
+    });
+    let pathSeen = '';
+    const trackingFs: FsReader = {
+      exists: (p: string) => { pathSeen = p; return fs.exists(p); },
+      readFile: fs.readFile,
+      readDir: fs.readDir
+    };
+    await runCodeReview({
+      prRef: 1,
+      repoPath: '/repo',
+      diff: SAMPLE_DIFF,
+      context: { branch: 'b', baseBranch: 'develop', title: 't' },
+      config: {
+        fs: trackingFs,
+        llm: fakeLlm({ findings: [], ok: true }),
+        conventionsPath: '/explicit/AGENTS.md',
+        enableDeterministic: false
+      }
+    });
+    expect(pathSeen).toBe('/explicit/AGENTS.md');
+  });
+});

--- a/packages/code-reviewer/tests/config.test.ts
+++ b/packages/code-reviewer/tests/config.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveConfig, expandHome } from '../src/config.js';
+
+describe('expandHome', () => {
+  it('expands leading ~/', () => {
+    const out = expandHome('~/foo');
+    expect(out.endsWith('/foo')).toBe(true);
+    expect(out.startsWith('/')).toBe(true);
+  });
+
+  it('passes ~ alone', () => {
+    const out = expandHome('~');
+    expect(out.startsWith('/')).toBe(true);
+    expect(out.includes('~')).toBe(false);
+  });
+
+  it('passes other paths through', () => {
+    expect(expandHome('/abs/path')).toBe('/abs/path');
+    expect(expandHome('relative/path')).toBe('relative/path');
+  });
+});
+
+describe('resolveConfig', () => {
+  const ENV_KEYS = [
+    'CAIA_CONVENTIONS_PATH',
+    'CAIA_REPORTS_ROOT',
+    'CLAUDE_BINARY_PATH',
+    'CODE_REVIEWER_MODEL_TAG',
+    'CODE_REVIEWER_MAX_DIFF_BYTES',
+    'CODE_REVIEWER_CHUNK_BYTES',
+    'CODE_REVIEWER_SEVERITY_FLOOR',
+    'CODE_REVIEWER_BLOCKING_THRESHOLD',
+    'CODE_REVIEWER_VECTOR_TIMEOUT_MS',
+    'CODE_REVIEWER_MAX_FINDINGS',
+    'CODE_REVIEWER_LLM_ENABLED',
+    'CODE_REVIEWER_DETERMINISTIC_ENABLED',
+    'MENTOR_EVENT_BUS_URL'
+  ];
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('uses defaults when nothing is provided', () => {
+    const cfg = resolveConfig();
+    expect(cfg.modelTag).toBe('claude-haiku-4-5-20251001');
+    expect(cfg.severityFloor).toBe('low');
+    expect(cfg.blockingSeverityThreshold).toBe('medium');
+    expect(cfg.maxDiffBytes).toBe(256_000);
+    expect(cfg.chunkBytes).toBe(64_000);
+    expect(cfg.maxFindingsPerPr).toBe(50);
+    expect(cfg.enableLlmReasoning).toBe(true);
+    expect(cfg.enableDeterministic).toBe(true);
+    expect(cfg.eventBusUrl).toBe('tcp://localhost:7777');
+  });
+
+  it('honors explicit input over env over defaults', () => {
+    process.env['CODE_REVIEWER_MODEL_TAG'] = 'env-model';
+    const cfg = resolveConfig({ modelTag: 'explicit-model' });
+    expect(cfg.modelTag).toBe('explicit-model');
+
+    const cfg2 = resolveConfig();
+    expect(cfg2.modelTag).toBe('env-model');
+  });
+
+  it('honors env-driven severity floor', () => {
+    process.env['CODE_REVIEWER_SEVERITY_FLOOR'] = 'high';
+    const cfg = resolveConfig();
+    expect(cfg.severityFloor).toBe('high');
+  });
+
+  it('honors env-driven blocking threshold', () => {
+    process.env['CODE_REVIEWER_BLOCKING_THRESHOLD'] = 'high';
+    const cfg = resolveConfig();
+    expect(cfg.blockingSeverityThreshold).toBe('high');
+  });
+
+  it('disables LLM via env', () => {
+    process.env['CODE_REVIEWER_LLM_ENABLED'] = '0';
+    const cfg = resolveConfig();
+    expect(cfg.enableLlmReasoning).toBe(false);
+  });
+
+  it('disables deterministic tier via env', () => {
+    process.env['CODE_REVIEWER_DETERMINISTIC_ENABLED'] = '0';
+    const cfg = resolveConfig();
+    expect(cfg.enableDeterministic).toBe(false);
+  });
+
+  it('parses numeric envs', () => {
+    process.env['CODE_REVIEWER_MAX_DIFF_BYTES'] = '999';
+    process.env['CODE_REVIEWER_CHUNK_BYTES'] = '888';
+    process.env['CODE_REVIEWER_VECTOR_TIMEOUT_MS'] = '1234';
+    process.env['CODE_REVIEWER_MAX_FINDINGS'] = '7';
+    const cfg = resolveConfig();
+    expect(cfg.maxDiffBytes).toBe(999);
+    expect(cfg.chunkBytes).toBe(888);
+    expect(cfg.perVectorTimeoutMs).toBe(1234);
+    expect(cfg.maxFindingsPerPr).toBe(7);
+  });
+
+  it('expands ~ in path inputs', () => {
+    const cfg = resolveConfig({ conventionsPath: '~/somewhere/AGENTS.md' });
+    expect(cfg.conventionsPath.includes('~')).toBe(false);
+    expect(cfg.conventionsPath.endsWith('/somewhere/AGENTS.md')).toBe(true);
+  });
+});

--- a/packages/code-reviewer/tests/conventions-loader.test.ts
+++ b/packages/code-reviewer/tests/conventions-loader.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { loadConventions, parseConventionsMarkdown } from '../src/conventions-loader.js';
+import type { FsReader } from '../src/types.js';
+
+const fakeFs = (files: Record<string, string>): FsReader => ({
+  exists: (p: string) => Object.prototype.hasOwnProperty.call(files, p),
+  readFile: (p: string) => {
+    if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+    return files[p];
+  },
+  readDir: () => []
+});
+
+describe('parseConventionsMarkdown', () => {
+  it('extracts code-style sections', () => {
+    const md = `# Title\n\n## Code style\nUse 2 spaces.\n\n## Random\nIgnored.`;
+    const out = parseConventionsMarkdown('AGENTS.md', md);
+    expect(out).toHaveLength(1);
+    expect(out[0].heading.toLowerCase()).toContain('code style');
+    expect(out[0].bodyExcerpt).toContain('2 spaces');
+    expect(out[0].source).toBe('AGENTS.md');
+  });
+
+  it('extracts naming and testing sections', () => {
+    const md = `## Naming\nCamelCase.\n\n## Testing\nVitest.`;
+    const out = parseConventionsMarkdown('a.md', md);
+    expect(out).toHaveLength(2);
+    expect(out.some(s => s.heading.toLowerCase().includes('naming'))).toBe(true);
+    expect(out.some(s => s.heading.toLowerCase().includes('testing'))).toBe(true);
+  });
+
+  it('extracts type-safety, correctness, bug-patterns', () => {
+    const md = `## Type Safety\nNo \`any\`.\n\n## Correctness\nCheck nulls.\n\n## Bug Patterns\nWatch for off-by-one.`;
+    const out = parseConventionsMarkdown('a.md', md);
+    expect(out.length).toBe(3);
+  });
+
+  it('skips empty sections', () => {
+    const md = `## Code style\n\n## Naming\nfoo`;
+    const out = parseConventionsMarkdown('a.md', md);
+    expect(out).toHaveLength(1);
+    expect(out[0].heading.toLowerCase()).toContain('naming');
+  });
+
+  it('truncates long bodies', () => {
+    const long = 'x'.repeat(2000);
+    const md = `## Code style\n${long}`;
+    const out = parseConventionsMarkdown('a.md', md);
+    expect(out[0].bodyExcerpt.length).toBe(500);
+  });
+});
+
+describe('loadConventions', () => {
+  it('returns empty when file missing', () => {
+    const fs = fakeFs({});
+    expect(loadConventions(fs, '/nope.md')).toEqual([]);
+  });
+
+  it('returns parsed sections from a present file', () => {
+    const fs = fakeFs({ '/AGENTS.md': '## Code style\nFoo bar baz' });
+    const out = loadConventions(fs, '/AGENTS.md');
+    expect(out).toHaveLength(1);
+    expect(out[0].source).toBe('/AGENTS.md');
+  });
+
+  it('returns empty when readFile throws', () => {
+    const fs: FsReader = {
+      exists: () => true,
+      readFile: () => { throw new Error('boom'); },
+      readDir: () => []
+    };
+    expect(loadConventions(fs, '/x.md')).toEqual([]);
+  });
+});

--- a/packages/code-reviewer/tests/diff-parser.test.ts
+++ b/packages/code-reviewer/tests/diff-parser.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { parseDiff, chunkHunk, walkHunk } from '../src/diff-parser.js';
+
+describe('parseDiff', () => {
+  it('parses a single-file modified diff', () => {
+    const diff = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      'index 1234567..abcdefg 100644',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -1,3 +1,4 @@',
+      ' export const x = 1;',
+      '+export const y = 2;',
+      ' export const z = 3;',
+      ' export const w = 4;'
+    ].join('\n');
+    const parsed = parseDiff(diff);
+    expect(parsed.hunks).toHaveLength(1);
+    expect(parsed.hunks[0].file).toBe('src/foo.ts');
+    expect(parsed.hunks[0].status).toBe('modified');
+    expect(parsed.hunks[0].oldStart).toBe(1);
+    expect(parsed.hunks[0].newStart).toBe(1);
+    expect(parsed.fileCount).toBe(1);
+  });
+
+  it('parses an added file', () => {
+    const diff = [
+      'diff --git a/src/new.ts b/src/new.ts',
+      'new file mode 100644',
+      'index 0000000..1234567',
+      '--- /dev/null',
+      '+++ b/src/new.ts',
+      '@@ -0,0 +1,2 @@',
+      '+export const x = 1;',
+      '+export const y = 2;'
+    ].join('\n');
+    const parsed = parseDiff(diff);
+    expect(parsed.hunks).toHaveLength(1);
+    expect(parsed.hunks[0].status).toBe('added');
+  });
+
+  it('parses a deleted file', () => {
+    const diff = [
+      'diff --git a/src/gone.ts b/src/gone.ts',
+      'deleted file mode 100644',
+      '--- a/src/gone.ts',
+      '+++ /dev/null',
+      '@@ -1,2 +0,0 @@',
+      '-export const x = 1;',
+      '-export const y = 2;'
+    ].join('\n');
+    const parsed = parseDiff(diff);
+    expect(parsed.hunks).toHaveLength(1);
+    expect(parsed.hunks[0].status).toBe('deleted');
+  });
+
+  it('parses a renamed file', () => {
+    const diff = [
+      'diff --git a/src/old.ts b/src/new.ts',
+      'similarity index 90%',
+      'rename from src/old.ts',
+      'rename to src/new.ts',
+      '--- a/src/old.ts',
+      '+++ b/src/new.ts',
+      '@@ -1,2 +1,2 @@',
+      ' export const x = 1;',
+      '-export const y = 2;',
+      '+export const y = 22;'
+    ].join('\n');
+    const parsed = parseDiff(diff);
+    expect(parsed.hunks).toHaveLength(1);
+    expect(parsed.hunks[0].status).toBe('renamed');
+    expect(parsed.hunks[0].file).toBe('src/new.ts');
+  });
+
+  it('skips binary files', () => {
+    const diff = [
+      'diff --git a/img.png b/img.png',
+      'Binary files a/img.png and b/img.png differ'
+    ].join('\n');
+    const parsed = parseDiff(diff);
+    expect(parsed.hunks).toHaveLength(0);
+  });
+
+  it('parses multi-file diff', () => {
+    const diff = [
+      'diff --git a/a.ts b/a.ts',
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -1,1 +1,2 @@',
+      ' a',
+      '+b',
+      'diff --git a/b.ts b/b.ts',
+      '--- a/b.ts',
+      '+++ b/b.ts',
+      '@@ -1,1 +1,2 @@',
+      ' x',
+      '+y'
+    ].join('\n');
+    const parsed = parseDiff(diff);
+    expect(parsed.hunks).toHaveLength(2);
+    expect(parsed.fileCount).toBe(2);
+  });
+
+  it('returns empty for empty diff', () => {
+    const parsed = parseDiff('');
+    expect(parsed.hunks).toHaveLength(0);
+    expect(parsed.fileCount).toBe(0);
+  });
+});
+
+describe('chunkHunk', () => {
+  it('returns the hunk as-is when body is small', () => {
+    const hunk = {
+      file: 'a.ts',
+      oldStart: 1,
+      newStart: 1,
+      header: '@@ -1,1 +1,1 @@',
+      body: ' a\n+b',
+      status: 'modified' as const
+    };
+    expect(chunkHunk(hunk, 1000)).toEqual([hunk]);
+  });
+
+  it('splits when body exceeds maxBytes', () => {
+    const body = Array.from({ length: 50 }, (_, i) => ` line${i}`).join('\n');
+    const hunk = {
+      file: 'a.ts',
+      oldStart: 1,
+      newStart: 1,
+      header: '@@ -1,50 +1,50 @@',
+      body,
+      status: 'modified' as const
+    };
+    const chunks = chunkHunk(hunk, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    // First chunk keeps original header
+    expect(chunks[0].header).toBe('@@ -1,50 +1,50 @@');
+    // Subsequent chunks are marked
+    expect(chunks[1].header).toMatch(/\(chunked\)/);
+  });
+});
+
+describe('walkHunk', () => {
+  it('emits one entry per body line with correct line numbers', () => {
+    const hunk = {
+      file: 'a.ts',
+      oldStart: 10,
+      newStart: 10,
+      header: '@@ -10,2 +10,3 @@',
+      body: ' a\n+b\n c',
+      status: 'modified' as const
+    };
+    const lines = walkHunk(hunk);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toEqual({ kind: ' ', newLine: 10, oldLine: 10, text: 'a' });
+    expect(lines[1]).toEqual({ kind: '+', newLine: 11, oldLine: -1, text: 'b' });
+    expect(lines[2]).toEqual({ kind: ' ', newLine: 12, oldLine: 11, text: 'c' });
+  });
+
+  it('handles deletions', () => {
+    const hunk = {
+      file: 'a.ts',
+      oldStart: 10,
+      newStart: 10,
+      header: '@@',
+      body: ' a\n-b',
+      status: 'modified' as const
+    };
+    const lines = walkHunk(hunk);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toEqual({ kind: '-', newLine: -1, oldLine: 11, text: 'b' });
+  });
+});

--- a/packages/code-reviewer/tests/finding-id.test.ts
+++ b/packages/code-reviewer/tests/finding-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { findingId } from '../src/finding-id.js';
+
+describe('findingId', () => {
+  it('produces a stable hex string', () => {
+    const id = findingId({ dimension: 'correctness', file: 'a.ts', line: 10, issueTitle: 'bug' });
+    expect(id).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic', () => {
+    const a = findingId({ dimension: 'correctness', file: 'a.ts', line: 10, issueTitle: 'bug' });
+    const b = findingId({ dimension: 'correctness', file: 'a.ts', line: 10, issueTitle: 'bug' });
+    expect(a).toBe(b);
+  });
+
+  it('changes when any input changes', () => {
+    const base = findingId({ dimension: 'correctness', file: 'a.ts', line: 10, issueTitle: 'bug' });
+    expect(findingId({ dimension: 'correctness', file: 'a.ts', line: 11, issueTitle: 'bug' })).not.toBe(base);
+    expect(findingId({ dimension: 'correctness', file: 'b.ts', line: 10, issueTitle: 'bug' })).not.toBe(base);
+    expect(findingId({ dimension: 'naming', file: 'a.ts', line: 10, issueTitle: 'bug' })).not.toBe(base);
+    expect(findingId({ dimension: 'correctness', file: 'a.ts', line: 10, issueTitle: 'other' })).not.toBe(base);
+  });
+});

--- a/packages/code-reviewer/tests/fs-reader.test.ts
+++ b/packages/code-reviewer/tests/fs-reader.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { defaultFsReader } from '../src/fs-reader.js';
+
+describe('defaultFsReader', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cr-fs-reader-'));
+    filePath = join(dir, 'hello.txt');
+    writeFileSync(filePath, 'hello world');
+    mkdirSync(join(dir, 'sub'));
+    writeFileSync(join(dir, 'sub', 'a.txt'), 'a');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('exists returns true for existing file', () => {
+    expect(defaultFsReader.exists(filePath)).toBe(true);
+  });
+
+  it('exists returns false for missing file', () => {
+    expect(defaultFsReader.exists(join(dir, 'nope.txt'))).toBe(false);
+  });
+
+  it('readFile returns file content', () => {
+    expect(defaultFsReader.readFile(filePath)).toBe('hello world');
+  });
+
+  it('readDir returns entries sorted', () => {
+    const entries = defaultFsReader.readDir(dir);
+    expect(entries.includes('hello.txt')).toBe(true);
+    expect(entries.includes('sub')).toBe(true);
+  });
+
+  it('readDir returns [] for missing dir', () => {
+    expect(defaultFsReader.readDir(join(dir, 'doesnotexist'))).toEqual([]);
+  });
+
+  it('readDir returns [] for a file (not a dir)', () => {
+    expect(defaultFsReader.readDir(filePath)).toEqual([]);
+  });
+});

--- a/packages/code-reviewer/tests/llm-reasoner.test.ts
+++ b/packages/code-reviewer/tests/llm-reasoner.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPrompt,
+  createDefaultLlmReviewer,
+  noopLlmReviewer,
+  parseLlmOutput
+} from '../src/llm-reasoner.js';
+import type { DiffHunk, LlmReviewInput } from '../src/types.js';
+
+const sampleHunk: DiffHunk = {
+  file: 'src/foo.ts',
+  oldStart: 1,
+  newStart: 1,
+  header: '@@ -1,2 +1,2 @@',
+  body: '-let x = null;\n+let x: string | null = null;',
+  status: 'modified'
+};
+
+const sampleInput: LlmReviewInput = {
+  hunks: [sampleHunk],
+  conventionExcerpts: [],
+  pr: {
+    prNumber: 42,
+    branch: 'feat/x',
+    baseBranch: 'develop',
+    title: 'Fix nullable',
+    commitSubjects: []
+  }
+};
+
+describe('buildPrompt', () => {
+  it('embeds the system instructions', () => {
+    const p = buildPrompt(sampleInput);
+    expect(p).toContain('CORRECTNESS, BUGS');
+    expect(p).toContain('STAY IN YOUR LANE');
+  });
+
+  it('includes the dimensions block', () => {
+    const p = buildPrompt(sampleInput);
+    expect(p).toContain('correctness:');
+    expect(p).toContain('bug-risk:');
+    expect(p).toContain('test-coverage:');
+  });
+
+  it('includes the diff hunks', () => {
+    const p = buildPrompt(sampleInput);
+    expect(p).toContain('src/foo.ts');
+    expect(p).toContain('let x: string | null');
+  });
+
+  it('falls back to default when no conventions', () => {
+    const p = buildPrompt(sampleInput);
+    expect(p).toContain('(none — fall back to general TS / Node best practices)');
+  });
+
+  it('embeds convention excerpts when present', () => {
+    const p = buildPrompt({
+      ...sampleInput,
+      conventionExcerpts: [{ source: 'A.md', heading: 'Code style', bodyExcerpt: 'use 2 spaces' }]
+    });
+    expect(p).toContain('Code style');
+    expect(p).toContain('use 2 spaces');
+  });
+});
+
+describe('parseLlmOutput', () => {
+  it('parses well-formed output', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          {
+            dimension: 'correctness',
+            severity: 'high',
+            file: 'src/foo.ts',
+            line: 10,
+            issueTitle: 'null-deref',
+            description: 'risk of null deref',
+            excerpt: 'foo.bar()'
+          }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.ok).toBe(true);
+    expect(out.findings).toHaveLength(1);
+    expect(out.findings[0].dimension).toBe('correctness');
+    expect(out.findings[0].severity).toBe('high');
+  });
+
+  it('reports a parse error on bad outer JSON', () => {
+    const out = parseLlmOutput('not json');
+    expect(out.ok).toBe(false);
+    expect(out.diagnostic).toContain('outer JSON parse');
+  });
+
+  it('reports envelope missing result', () => {
+    const out = parseLlmOutput(JSON.stringify({ no_result: true }));
+    expect(out.ok).toBe(false);
+    expect(out.diagnostic).toContain('result');
+  });
+
+  it('reports inner parse error', () => {
+    const stdout = JSON.stringify({ result: '{not valid}' });
+    const out = parseLlmOutput(stdout);
+    expect(out.ok).toBe(false);
+  });
+
+  it('drops findings on Critic denylist', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'security-regression', severity: 'high', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' },
+          { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings).toHaveLength(1);
+    expect(out.findings[0].dimension).toBe('correctness');
+  });
+
+  it('drops findings on advisory Reviewer denylist', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'idiom-adherence', severity: 'medium', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('drops findings with unknown dimension', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'totally-made-up', severity: 'high', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('drops findings without file or description', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'correctness', severity: 'high', file: '', line: 1, issueTitle: 't', description: 'x' },
+          { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 1, issueTitle: 't', description: '' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('uses default severity when invalid', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'correctness', severity: 'banana', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings).toHaveLength(1);
+    expect(out.findings[0].severity).toBe('high'); // default for correctness
+  });
+
+  it('caps style severity at default ceiling', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'style', severity: 'critical', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings[0].severity).toBe('low'); // capped at default for style
+  });
+
+  it('allows correctness to promote to critical', () => {
+    const stdout = JSON.stringify({
+      result: JSON.stringify({
+        findings: [
+          { dimension: 'correctness', severity: 'critical', file: 'a.ts', line: 1, issueTitle: 't', description: 'x' }
+        ]
+      })
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings[0].severity).toBe('critical');
+  });
+
+  it('returns empty findings when array missing', () => {
+    const stdout = JSON.stringify({ result: JSON.stringify({}) });
+    const out = parseLlmOutput(stdout);
+    expect(out.ok).toBe(true);
+    expect(out.findings).toHaveLength(0);
+  });
+
+  it('extracts JSON from prose-wrapped result', () => {
+    const stdout = JSON.stringify({
+      result: 'Here is the analysis: {"findings":[{"dimension":"correctness","severity":"medium","file":"a.ts","line":1,"issueTitle":"t","description":"x"}]} done.'
+    });
+    const out = parseLlmOutput(stdout);
+    expect(out.findings).toHaveLength(1);
+  });
+});
+
+describe('createDefaultLlmReviewer (subscription-only)', () => {
+  it('strips ANTHROPIC_API_KEY from spawn env', async () => {
+    let capturedEnv: NodeJS.ProcessEnv = {};
+    const fakeSpawn = (_cmd: string, _args: readonly string[], opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }) => {
+      capturedEnv = opts.env;
+      return {
+        pid: 1,
+        output: [],
+        stdout: JSON.stringify({ result: JSON.stringify({ findings: [] }) }),
+        stderr: '',
+        status: 0,
+        signal: null
+      } as ReturnType<typeof import('node:child_process').spawnSync>;
+    };
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-fake';
+    try {
+      const llm = createDefaultLlmReviewer({
+        binaryPath: 'claude',
+        modelTag: 'claude-haiku-4-5-20251001',
+        timeoutMs: 1000,
+        spawnFn: fakeSpawn
+      });
+      await llm.review(sampleInput);
+      expect('ANTHROPIC_API_KEY' in capturedEnv).toBe(false);
+    } finally {
+      delete process.env['ANTHROPIC_API_KEY'];
+    }
+  });
+
+  it('returns ok:false on spawn error', async () => {
+    const fakeSpawn = () => ({
+      pid: 0,
+      output: [],
+      stdout: '',
+      stderr: '',
+      status: null,
+      signal: null,
+      error: new Error('ENOENT')
+    } as unknown as ReturnType<typeof import('node:child_process').spawnSync>);
+    const llm = createDefaultLlmReviewer({
+      binaryPath: 'nonexistent',
+      modelTag: 'm',
+      timeoutMs: 100,
+      spawnFn: fakeSpawn
+    });
+    const out = await llm.review(sampleInput);
+    expect(out.ok).toBe(false);
+    expect(out.diagnostic).toContain('ENOENT');
+  });
+
+  it('returns ok:false on non-zero exit', async () => {
+    const fakeSpawn = () => ({
+      pid: 1,
+      output: [],
+      stdout: '',
+      stderr: 'rate-limited',
+      status: 1,
+      signal: null
+    } as ReturnType<typeof import('node:child_process').spawnSync>);
+    const llm = createDefaultLlmReviewer({
+      binaryPath: 'claude',
+      modelTag: 'm',
+      timeoutMs: 100,
+      spawnFn: fakeSpawn
+    });
+    const out = await llm.review(sampleInput);
+    expect(out.ok).toBe(false);
+    expect(out.diagnostic).toContain('exited');
+  });
+
+  it('parses successful spawn output', async () => {
+    const fakeSpawn = () => ({
+      pid: 1,
+      output: [],
+      stdout: JSON.stringify({
+        result: JSON.stringify({
+          findings: [
+            { dimension: 'bug-risk', severity: 'high', file: 'a.ts', line: 1, issueTitle: 'race', description: 'shared state' }
+          ]
+        })
+      }),
+      stderr: '',
+      status: 0,
+      signal: null
+    } as ReturnType<typeof import('node:child_process').spawnSync>);
+    const llm = createDefaultLlmReviewer({
+      binaryPath: 'claude',
+      modelTag: 'm',
+      timeoutMs: 100,
+      spawnFn: fakeSpawn
+    });
+    const out = await llm.review(sampleInput);
+    expect(out.ok).toBe(true);
+    expect(out.findings).toHaveLength(1);
+  });
+});
+
+describe('noopLlmReviewer', () => {
+  it('returns empty findings', async () => {
+    const out = await noopLlmReviewer.review(sampleInput);
+    expect(out.ok).toBe(true);
+    expect(out.findings).toHaveLength(0);
+  });
+});

--- a/packages/code-reviewer/tests/merger.test.ts
+++ b/packages/code-reviewer/tests/merger.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import { mergeFindings } from '../src/merger.js';
+import type { CodeReviewFinding, LlmReviewOutput } from '../src/types.js';
+
+const baseLlmOutput = (
+  findings: ReadonlyArray<Omit<CodeReviewFinding, 'id' | 'source' | 'detectorId'>>
+): LlmReviewOutput => ({ findings, ok: true });
+
+describe('mergeFindings — verdict synthesis', () => {
+  it('returns approve when no findings', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 0,
+      durationMs: 100
+    });
+    expect(result.verdict).toBe('approve');
+    expect(result.findings).toHaveLength(0);
+    expect(result.blockingFindings).toHaveLength(0);
+  });
+
+  it('returns approve when only low findings (below blocking threshold)', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'style', severity: 'low', file: 'a.ts', line: 1, issueTitle: 'spacing', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.verdict).toBe('approve');
+    expect(result.findings).toHaveLength(1);
+    expect(result.blockingFindings).toHaveLength(0);
+  });
+
+  it('returns request-changes when at least one finding meets blocking threshold', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 1, issueTitle: 'bug', description: 'd', excerpt: '' },
+        { dimension: 'style', severity: 'low', file: 'a.ts', line: 2, issueTitle: 'sp', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.verdict).toBe('request-changes');
+    expect(result.blockingFindings).toHaveLength(1);
+    expect(result.blockingFindings[0].severity).toBe('high');
+  });
+
+  it('honours custom blocking threshold', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'correctness', severity: 'medium', file: 'a.ts', line: 1, issueTitle: 't', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'high',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.verdict).toBe('approve');
+    expect(result.findings).toHaveLength(1);
+    expect(result.blockingFindings).toHaveLength(0);
+  });
+});
+
+describe('mergeFindings — denylist enforcement', () => {
+  it('drops findings on Critic denylist and counts them', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        // Pretend an LLM emitted a Critic-domain finding even after sanitiser
+        { dimension: 'security-regression' as never, severity: 'high', file: 'a.ts', line: 1, issueTitle: 't', description: 'd', excerpt: '' },
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 2, issueTitle: 't', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].dimension).toBe('correctness');
+    expect(result.summary.redirectsToCritic).toBe(1);
+  });
+
+  it('drops findings on advisory Reviewer denylist and counts them', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'idiom-adherence' as never, severity: 'medium', file: 'a.ts', line: 1, issueTitle: 't', description: 'd', excerpt: '' },
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 2, issueTitle: 't', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.summary.redirectsToReviewer).toBe(1);
+  });
+});
+
+describe('mergeFindings — severity floor + sort + cap', () => {
+  it('drops findings below severity floor', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'style', severity: 'low', file: 'a.ts', line: 1, issueTitle: 't', description: 'd', excerpt: '' },
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 2, issueTitle: 't', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'medium',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('high');
+  });
+
+  it('sorts severity descending', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'style', severity: 'low', file: 'a.ts', line: 1, issueTitle: 't1', description: 'd', excerpt: '' },
+        { dimension: 'correctness', severity: 'critical', file: 'a.ts', line: 2, issueTitle: 't2', description: 'd', excerpt: '' },
+        { dimension: 'naming', severity: 'medium', file: 'a.ts', line: 3, issueTitle: 't3', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.findings[0].severity).toBe('critical');
+    expect(result.findings[result.findings.length - 1].severity).toBe('low');
+  });
+
+  it('caps at maxFindings', () => {
+    const findings = Array.from({ length: 100 }, (_, i) => ({
+      dimension: 'correctness' as const,
+      severity: 'high' as const,
+      file: `a${i}.ts`,
+      line: 1,
+      issueTitle: `t${i}`,
+      description: 'd',
+      excerpt: ''
+    }));
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput(findings),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 5,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.findings).toHaveLength(5);
+  });
+
+  it('dedups by id', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 1, issueTitle: 'same', description: 'd', excerpt: '' },
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 1, issueTitle: 'same', description: 'd2', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.findings).toHaveLength(1);
+  });
+});
+
+describe('mergeFindings — summary', () => {
+  it('counts by severity and dimension', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([
+        { dimension: 'correctness', severity: 'high', file: 'a.ts', line: 1, issueTitle: 't1', description: 'd', excerpt: '' },
+        { dimension: 'correctness', severity: 'medium', file: 'a.ts', line: 2, issueTitle: 't2', description: 'd', excerpt: '' },
+        { dimension: 'naming', severity: 'low', file: 'a.ts', line: 3, issueTitle: 't3', description: 'd', excerpt: '' }
+      ]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 2,
+      durationMs: 500
+    });
+    expect(result.summary.countBySeverity.high).toBe(1);
+    expect(result.summary.countBySeverity.medium).toBe(1);
+    expect(result.summary.countBySeverity.low).toBe(1);
+    expect(result.summary.countByDimension.correctness).toBe(2);
+    expect(result.summary.countByDimension.naming).toBe(1);
+    expect(result.summary.chunksReviewed).toBe(2);
+    expect(result.summary.durationMs).toBe(500);
+  });
+
+  it('marks llmReasoningSucceeded false when LLM enabled but ok:false', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: { findings: [], ok: false, diagnostic: 'timeout' },
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: true,
+      chunksReviewed: 1,
+      durationMs: 100
+    });
+    expect(result.summary.llmReasoningSucceeded).toBe(false);
+  });
+
+  it('marks llmReasoningSucceeded true when LLM disabled', () => {
+    const result = mergeFindings({
+      deterministic: [],
+      llmReasoned: baseLlmOutput([]),
+      severityFloor: 'low',
+      blockingSeverityThreshold: 'medium',
+      maxFindings: 50,
+      llmEnabled: false,
+      chunksReviewed: 0,
+      durationMs: 1
+    });
+    expect(result.summary.llmReasoningSucceeded).toBe(true);
+  });
+});

--- a/packages/code-reviewer/tests/types.test.ts
+++ b/packages/code-reviewer/tests/types.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_DIMENSIONS,
+  DEFAULT_SEVERITY,
+  SEVERITY_RANK,
+  CRITIC_DENYLIST,
+  ADVISORY_REVIEWER_DENYLIST
+} from '../src/types.js';
+
+describe('types — invariants', () => {
+  it('SEVERITY_RANK is monotonic', () => {
+    expect(SEVERITY_RANK.low).toBeLessThan(SEVERITY_RANK.medium);
+    expect(SEVERITY_RANK.medium).toBeLessThan(SEVERITY_RANK.high);
+    expect(SEVERITY_RANK.high).toBeLessThan(SEVERITY_RANK.critical);
+  });
+
+  it('DEFAULT_SEVERITY covers all dimensions', () => {
+    for (const d of ALL_DIMENSIONS) {
+      expect(DEFAULT_SEVERITY[d]).toBeDefined();
+    }
+  });
+
+  it('ALL_DIMENSIONS has 7 entries', () => {
+    // Per operator's domain list: correctness, bugs, style, type safety,
+    // test coverage, naming, comments
+    expect(ALL_DIMENSIONS).toHaveLength(7);
+  });
+
+  it('Critic denylist is non-empty and disjoint from our dimensions', () => {
+    expect(CRITIC_DENYLIST.size).toBeGreaterThan(0);
+    for (const d of ALL_DIMENSIONS) {
+      expect(CRITIC_DENYLIST.has(d)).toBe(false);
+    }
+  });
+
+  it('advisory Reviewer denylist is non-empty and disjoint from our dimensions', () => {
+    expect(ADVISORY_REVIEWER_DENYLIST.size).toBeGreaterThan(0);
+    for (const d of ALL_DIMENSIONS) {
+      expect(ADVISORY_REVIEWER_DENYLIST.has(d)).toBe(false);
+    }
+  });
+
+  it('Critic and advisory Reviewer denylists are themselves disjoint', () => {
+    for (const d of CRITIC_DENYLIST) {
+      expect(ADVISORY_REVIEWER_DENYLIST.has(d)).toBe(false);
+    }
+  });
+
+  it('correctness/bug-risk default to high', () => {
+    expect(DEFAULT_SEVERITY.correctness).toBe('high');
+    expect(DEFAULT_SEVERITY['bug-risk']).toBe('high');
+  });
+
+  it('style/naming/comments default to low', () => {
+    expect(DEFAULT_SEVERITY.style).toBe('low');
+    expect(DEFAULT_SEVERITY.naming).toBe('low');
+    expect(DEFAULT_SEVERITY.comments).toBe('low');
+  });
+});

--- a/packages/code-reviewer/tsconfig.build.json
+++ b/packages/code-reviewer/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/code-reviewer/tsconfig.json
+++ b/packages/code-reviewer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/code-reviewer/vitest.config.ts
+++ b/packages/code-reviewer/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules', 'src/cli.ts']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,6 +875,25 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/code-reviewer:
+    dependencies:
+      '@chiefaia/mentor-event-bus':
+        specifier: workspace:*
+        version: link:../mentor-event-bus
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      '@vitest/coverage-v8':
+        specifier: 1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.39)(jsdom@26.1.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/config:
     dependencies:
       '@chiefaia/errors':


### PR DESCRIPTION
# `@chiefaia/code-reviewer` Phase 1 — blocking PR code-review agent

This PR ships the **blocking** PR code-review agent operator named in `~/Documents/projects/agent-memory/operator_decisions_2026-05-08.md` ## "Branch protection: two AI reviewer agents". It is one of the two AI reviewers required by branch protection on `develop` / `main`.

## Position in the agent fleet — three sibling reviewers

| Package | Block authority | Domain |
|---|---|---|
| `@chiefaia/critic` (item 9, already merged via #379) | BLOCKING | security, regression, cost — the 18-category failure-mode taxonomy |
| **`@chiefaia/code-reviewer`** (this PR) | BLOCKING | correctness, bugs, style, type safety, test coverage, naming, comments |
| `@chiefaia/reviewer` (PR #399, advisory companion) | ADVISORY-only | craftsmanship — never blocks |

The fourth reviewer in the two-AI-reviewer setup is the **Architecture/Security Reviewer** (Ollama qwen2.5-coder:32b on stolution), shipping under the PR Review Pipeline Campaign Phase 5.

All three CAIA review agents are deliberately disjoint by construction. Code-Reviewer carries static denylists for both siblings' dimension IDs and drops any LLM-volunteered finding that lands on either set — three layers of defense (system prompt, sanitiser, merger). See `DESIGN.md §4`.

## Public API

```ts
runCodeReview({ prRef, repoPath, diff, context }) -> Promise<CodeReview>

interface CodeReview {
  prNumber: number;
  reviewedAtIso: string;
  verdict: 'approve' | 'request-changes';
  findings: CodeReviewFinding[];
  blockingFindings: CodeReviewFinding[];
  totalFindings: number;
  summary: ReviewSummary;
}
```

Operator-named in `reviewer_agent_phase1_stop_condition_2026-05-08.md`. The function is a thin convenience wrapper around `class CodeReviewerAgent`; tests instantiate the class directly with full DI of `fs` / `llm` / `clock`.

## Verdict synthesis

```
verdict = 'request-changes' iff any finding's severity >= blockingSeverityThreshold
```

Default `blockingSeverityThreshold` is `medium`. So `low`-severity findings (style nits, naming nits, comment freshness) surface but never block. The GitHub Action turns the verdict into a `gh pr review --approve` / `gh pr review --request-changes`, and fails CI on the latter so branch protection blocks merge.

## Subscription-only LLM

Spawns `claude --print --output-format json --model claude-haiku-4-5-20251001` with `delete env['ANTHROPIC_API_KEY']` per the standing rule in `~/Documents/projects/agent-memory/feedback_no_api_key_billing.md`. **Per-token billing is impossible by construction.** The CI workflow uses `CLAUDE_OAUTH_TOKEN` to authenticate the binary against the operator's Max account.

## What's in this PR

- 30 files / +3555 lines / **94 tests / 94.5% statement coverage** (above the >80% stop-condition threshold)
- Public API parameterised per Option E shape (`agent_architecture_shape_2026-05-06.md`)
- Seven `CodeReviewDimensionId`s mapped 1:1 to operator's domain list
- Hallucination guard, large-diff chunking, AGENTS.md conventions loading
- GitHub Action `.github/workflows/code-reviewer.yml` runs on PR open/sync, posts verdict comment, submits PR review, fails CI on request-changes
- CLI `caia-code-reviewer` for local dry-runs

## Phase status

* **Phase 1 (this PR)** — skeleton + LLM-only review + verdict synthesis + GitHub Action + tests
* **Phase 2 (planned)** — deterministic-tier detectors mirroring Critic's two-tier pattern
* **Phase 3 (operator-only)** — branch protection wiring (see follow-up below)

## Operator-action required: branch protection wiring

Wiring branch protection on `develop` and `main` to require both Code-Reviewer's review AND the Architecture/Security Reviewer's review for merge is a permission change — operator-only per safety rules. Implementation plan, ready when you authorize:

1. GitHub App or scoped bot PAT for Code-Reviewer (Vault-stored, scoped to PR-approval only — no push, no admin)
2. Same for Architecture/Security Reviewer (separate identity to keep the two approvals distinct)
3. Branch protection on `develop` and `main`: require 2 approvals from the AI-reviewer designated set; require `Code Reviewer (blocking)` status check pass
4. Mitigations for bot-PAT compromise: 90-day rotation, weekly Loki audit (per `operator_decisions_2026-05-08.md`)

## Merge plan

Path B autonomous: admin-merge if CI passes (only pre-existing develop reds expected).

## Trail

- Operator decision: `~/Documents/projects/agent-memory/operator_decisions_2026-05-08.md`
- Phase 1 stop-condition + Option A merge plan: `~/Documents/projects/agent-memory/reviewer_agent_phase1_stop_condition_2026-05-08.md`
- Sibling advisory pattern: `~/Documents/projects/agent-memory/feedback_reviewer_agent_advisory_only_pattern.md`
- Architecture shape: `~/Documents/projects/agent-memory/agent_architecture_shape_2026-05-06.md`
- LLM billing rule: `~/Documents/projects/agent-memory/feedback_no_api_key_billing.md`
- Advisory companion PR: #399 (`feat: @chiefaia/reviewer advisory craftsmanship reviewer`)
