### PR TITLE
feat(surface-001): @chiefaia/surface — Phase 0 skeleton (item 11)

### DIFF
--- a/packages/surface/DESIGN.md
+++ b/packages/surface/DESIGN.md
@@ -1,0 +1,102 @@
+# @chiefaia/surface — DESIGN
+
+Surface Agent — operator-curation lens. Filters and digests important findings from PR activity, agent-memory deltas, and agent transcripts so the operator gets a curated "what matters this week" view rather than a firehose.
+
+Phase 0 ships heuristic-only, subscription-free. Phase 2 will add operator-voice rephrasing once the Apprentice operator-style adapter is mature (~2026-05-15 first adapter).
+
+This package is **private** (`"private": true` in package.json) and follows the **Option E** shape per `agent_architecture_shape_2026-05-06.md`. It is never published. Project-bonding to CAIA happens at runtime via constructor defaults; tests inject fixture corpora.
+
+## 1. Why this exists
+
+The CAIA factory produces 30+ PRs/day, 200+ memory deltas/week, and N hourly heartbeat updates per active campaign. Without curation the operator either tunes most of it out (signal loss) or drowns in firehose. Mentor / Curator / Apprentice **capture** signal; Surface **filters** it for operator attention.
+
+See `agent-memory/surface_agent_directive.md` for the full directive (this design's parent doc).
+
+## 2. Sources (Phase 0)
+
+All subscription-free. No API keys.
+
+- **PR connector** (`src/connectors/pr.ts`) — shells out to `gh pr list --json` for merged + open PRs in `ghRepo` (default `prakashgbid/caia`). `gh` uses the operator's existing PAT.
+- **Memory connector** (`src/connectors/memory.ts`) — runs `git log --name-status --since=...` over the agent-memory repo. Falls back to filesystem mtime walk if git fails.
+- **Transcript connector** (`src/connectors/transcript.ts`) — walks `transcriptRoot` (default `~/Library/Application Support/Claude/local-agent-mode-sessions`) up to `maxDepth` (default 4); emits structural metadata only (no body extraction in Phase 0).
+
+Each connector returns a `ConnectorResult` with `findings` and `warnings`. They never throw — failures bubble up as warnings that surface as `connector-degraded` annotation findings in the digest.
+
+## 3. Importance heuristic
+
+```
+score = 0.4 * recency
+      + 0.3 * tag_weight
+      + 0.2 * severity_weight
+      + 0.1 * size_signal
+```
+
+- `recency` — linear decay from 0.0 at older horizon to 1.0 at fresh moment
+- `tag_weight` — keyword presence in title (🚨, BLOCKED, CRITICAL, security, complete, phase, merged, …) plus tag set boost (`feedback`, `directive`, `live`, `complete`, `failure`, `index`)
+- `severity_weight` — by `kind`: `transcript-failure` and `pr-stale` highest (0.85), `memory-added`/`pr-merged` mid (0.6-0.7), `transcript-handoff` low (0.4)
+- `size_signal` — `log10(bytes + 1) / 5` clamped 0..1
+
+All deterministic. Stateless. No LLM in Phase 0.
+
+## 4. Filter
+
+Drops findings below `minImportance` (default 0.35). Sort kept findings by `(importance desc, ts desc, id asc)`. Cap at `maxFindings` (default 100). Overflow goes to `dropped[]` (kept on the result for tests + future feedback loop).
+
+## 5. Digest
+
+Markdown grouped by source (`Pull Requests` → `Agent Memory` → `Agent Transcripts` → `Connector Errors`). Header includes window, generated-at, finding counts, and a per-source summary table with warnings.
+
+Hard size cap: throws `DigestSizeExceededError` if rendered markdown > `maxBytes` (default 50 KB). The error message tells the caller to raise `minImportance` or lower `maxFindings`.
+
+## 6. Public API
+
+```ts
+import { SurfaceAgent } from '@chiefaia/surface';
+
+const agent = new SurfaceAgent({
+  corpusRoot: '~/Documents/projects/agent-memory',
+  ghRepo: 'prakashgbid/caia',
+  transcriptRoot: '~/Library/Application Support/Claude/local-agent-mode-sessions',
+  maxBytes: 50_000,
+  minImportance: 0.35,
+});
+const digest = await agent.generateDigest({ since: '1 day ago' });
+```
+
+CLI:
+
+```
+caia-surface generate --since "1 day ago" --output ~/Documents/projects/reports/digest-2026-05-09.md
+caia-surface generate --since "7 days ago" --gh-repo prakashgbid/caia --min-importance 0.5 --output -
+```
+
+## 7. Determinism guarantee
+
+Given identical sources + clock, two runs produce byte-identical digests. Tests assert this.
+
+The intent: Surface runs daily under cron in Phase 1. Determinism enables idempotent re-runs and stable diff against the previous day's digest, which Phase 1's "delta-since-last-run" feature relies on.
+
+## 8. Option E checklist (mechanical)
+
+| Check | Status |
+|---|---|
+| `package.json` has `"private": true` | ✅ |
+| Public API parameterised — every CAIA path / repo / threshold a constructor arg with default | ✅ (`SurfaceAgentConfig` ↔ `resolveConfig`) |
+| Tests use fixture filesystems / fake runners — no live CAIA paths | ✅ (`FakeFs`, `FakeGh`, `FakeGit`) |
+| Consumes Mentor + Librarian pre-spawn injection (system-prompt at runtime, not hard-coded prompts) | ✅ Phase 0 has no LLM call yet; Phase 2 LLM rephrasing layer will use the standard pre-spawn pipeline |
+| No publishing / no second-customer abstraction | ✅ |
+
+## 9. Roadmap
+
+- **Phase 1** — Telegram + Slack delivery, cron schedule (LaunchAgent), delta-since-last-run state file
+- **Phase 2** — LLM-rephrasing tier using subscription `claude` binary + Apprentice operator-style adapter
+- **Phase 3** — Two-way feedback loop (operator reactions feed Mentor + Apprentice eval)
+- **Phase 4** — Cross-source dedup
+
+## 10. References
+
+- `agent-memory/surface_agent_directive.md` — full directive
+- `agent-memory/agent_ecosystem_expansion_directive.md` — Tier-A summary (this is the expansion of A3)
+- `agent-memory/agent_architecture_shape_2026-05-06.md` — Option E shape
+- `agent-memory/master_backlog_sequencing_2026-05-05.md` — item 11
+- `agent-memory/feedback_no_api_key_billing.md` — subscription-only constraint

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@chiefaia/surface",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Surface Agent — operator-curation lens. Filters and digests important findings from PR activity, agent-memory deltas, and agent transcripts so the operator gets a curated 'what matters this week' view rather than a firehose. Tier-A item 11 of agent_ecosystem_expansion_directive.md. Option E shape — private workspace package, parameterised constructor, fixture-tested, never published.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-surface": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "1.6.1",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/surface/src/agent.ts
+++ b/packages/surface/src/agent.ts
@@ -1,0 +1,199 @@
+/**
+ * SurfaceAgent — public entrypoint.
+ *
+ * Composes connectors → scorer → filter → digest into a single
+ * deterministic pipeline. Construction takes a fully-parameterised config;
+ * defaults resolve to CAIA paths via `resolveConfig`.
+ *
+ * Phase 0: heuristic-only, no LLM. Sub-tier connectors and the scorer are
+ * injectable for tests. The digest size cap is enforced at the digest layer
+ * — if exceeded, the agent surfaces a tightened-floor error to the caller.
+ */
+
+import type { SurfaceAgentConfig, ResolvedSurfaceAgentConfig } from './config.js';
+import { resolveConfig } from './config.js';
+import { defaultFsReader } from './fs-reader.js';
+import { defaultGhRunner, defaultGitRunner } from './gh-runner.js';
+import { createPrConnector } from './connectors/pr.js';
+import { createMemoryConnector } from './connectors/memory.js';
+import { createTranscriptConnector } from './connectors/transcript.js';
+import { applyScores, defaultScorer } from './scorer.js';
+import { applyFilter } from './filter.js';
+import { generateDigest } from './digest.js';
+import type {
+  Connector,
+  ConnectorResult,
+  Digest,
+  Finding,
+  FindingSource,
+  FsReader,
+  GhRunner,
+  GitRunner,
+  ImportanceScorer
+} from './types.js';
+
+export interface GenerateDigestRequest {
+  /** Relative time window like '1 day ago', or absolute ISO8601. */
+  since: string;
+  /** Optional override for upper bound (defaults to now). */
+  until?: string;
+}
+
+/** Convert a relative time string ("N day(s) ago", "N hour(s) ago", "N week(s) ago")
+ *  or an ISO8601 string into a Date. Returns null on parse failure. */
+export function parseSince(s: string, now: Date): Date | null {
+  const trimmed = s.trim();
+  // Absolute ISO8601 first.
+  const iso = Date.parse(trimmed);
+  if (!Number.isNaN(iso)) return new Date(iso);
+
+  const m = /^(\d+)\s+(second|minute|hour|day|week|month)s?\s+ago$/i.exec(trimmed);
+  if (m === null) return null;
+  const qty = Number(m[1]);
+  const unit = (m[2] ?? '').toLowerCase();
+  if (Number.isNaN(qty) || qty < 0) return null;
+  const ms = unitToMs(unit);
+  if (ms === null) return null;
+  return new Date(now.getTime() - qty * ms);
+}
+
+function unitToMs(unit: string): number | null {
+  switch (unit) {
+    case 'second': return 1000;
+    case 'minute': return 60 * 1000;
+    case 'hour': return 60 * 60 * 1000;
+    case 'day': return 24 * 60 * 60 * 1000;
+    case 'week': return 7 * 24 * 60 * 60 * 1000;
+    case 'month': return 30 * 24 * 60 * 60 * 1000;
+    default: return null;
+  }
+}
+
+export class SurfaceAgent {
+  readonly config: ResolvedSurfaceAgentConfig;
+  private readonly fs: FsReader;
+  private readonly gh: GhRunner;
+  private readonly git: GitRunner;
+  private readonly clock: () => Date;
+  private readonly scorer: ImportanceScorer;
+  private readonly connectorOverrides: ReadonlyArray<Connector> | null;
+
+  constructor(input: SurfaceAgentConfig & { connectors?: readonly Connector[]; scorer?: ImportanceScorer } = {}) {
+    this.config = resolveConfig(input);
+    this.fs = input.fs ?? defaultFsReader;
+    this.gh = input.gh ?? defaultGhRunner;
+    this.git = input.git ?? defaultGitRunner;
+    this.clock = input.clock ?? ((): Date => new Date());
+    this.scorer = input.scorer ?? defaultScorer;
+    this.connectorOverrides = input.connectors ?? null;
+  }
+
+  /** Build connectors. Tests can pass `connectors:` to bypass entirely. */
+  private buildConnectors(): readonly Connector[] {
+    if (this.connectorOverrides !== null) return this.connectorOverrides;
+    return [
+      createPrConnector({ ghRepo: this.config.ghRepo, gh: this.gh }),
+      createMemoryConnector({
+        corpusRoot: this.config.corpusRoot,
+        memoryGitRepo: this.config.memoryGitRepo,
+        fs: this.fs,
+        git: this.git
+      }),
+      createTranscriptConnector({
+        transcriptRoot: this.config.transcriptRoot,
+        fs: this.fs
+      })
+    ];
+  }
+
+  async generateDigest(req: GenerateDigestRequest): Promise<Digest> {
+    const now = this.clock();
+    const untilDate = req.until !== undefined
+      ? (parseSince(req.until, now) ?? now)
+      : now;
+    const sinceDate = parseSince(req.since, untilDate);
+    if (sinceDate === null) {
+      throw new Error(`could not parse --since "${req.since}"`);
+    }
+    const sinceIso = sinceDate.toISOString();
+    const untilIso = untilDate.toISOString();
+
+    const connectors = this.buildConnectors();
+    const collectArgs = { sinceIso, untilIso };
+
+    const results: ConnectorResult[] = [];
+    for (const c of connectors) {
+      try {
+        results.push(await c.collect(collectArgs));
+      } catch (e) {
+        // Defensive — every connector should already swallow errors
+        // internally and surface them as `warnings`. If something escapes,
+        // record a connector-error annotation.
+        results.push({
+          source: c.source,
+          findings: [],
+          collectedAtIso: untilIso,
+          warnings: [`uncaught: ${(e as Error).message.slice(0, 200)}`]
+        });
+      }
+    }
+
+    // Build connector-degraded annotation findings for digest visibility.
+    const degraded: Finding[] = [];
+    for (const r of results) {
+      if (r.warnings.length === 0) continue;
+      degraded.push({
+        id: `connector-${r.source}-${untilIso}`,
+        source: 'connector-error',
+        kind: 'connector-degraded',
+        key: r.source,
+        title: `Connector ${r.source} degraded: ${r.warnings.length} warning(s)`,
+        bodyExcerpt: r.warnings.join('; ').slice(0, 1000),
+        tsIso: untilIso,
+        importance: 0.5,
+        tags: ['connector-degraded'],
+        meta: { warningCount: r.warnings.length }
+      });
+    }
+
+    const allRaw: Finding[] = [];
+    for (const r of results) allRaw.push(...r.findings);
+    allRaw.push(...degraded);
+
+    const scored = applyScores(
+      allRaw.map(({ importance: _i, ...rest }) => rest),
+      { sinceIso, untilIso },
+      this.scorer
+    );
+
+    const filtered = applyFilter(scored, {
+      minImportance: this.config.minImportance,
+      maxFindings: this.config.maxFindings
+    });
+
+    const sourceSummary: Record<FindingSource, { collected: number; warnings: readonly string[] }> = {
+      pr: { collected: 0, warnings: [] },
+      memory: { collected: 0, warnings: [] },
+      transcript: { collected: 0, warnings: [] },
+      'connector-error': { collected: 0, warnings: [] }
+    };
+    for (const r of results) {
+      const cur = sourceSummary[r.source];
+      sourceSummary[r.source] = {
+        collected: cur.collected + r.findings.length,
+        warnings: [...cur.warnings, ...r.warnings]
+      };
+    }
+
+    const generatedAtIso = this.clock().toISOString();
+    return generateDigest({
+      findings: filtered.kept,
+      dropped: filtered.dropped,
+      generatedAtIso,
+      sinceIso,
+      untilIso,
+      maxBytes: this.config.maxBytes,
+      sourceSummary
+    });
+  }
+}

--- a/packages/surface/src/cli.ts
+++ b/packages/surface/src/cli.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * caia-surface CLI.
+ *
+ * Subcommands:
+ *   generate --since <expr> --output <path>
+ *            [--gh-repo <owner/name>]
+ *            [--corpus-root <path>]
+ *            [--transcript-root <path>]
+ *            [--max-bytes <n>] [--min-importance <f>] [--max-findings <n>]
+ *
+ * If `--output -` (or omitted), prints to stdout.
+ *
+ * Subscription-only: never sets ANTHROPIC_API_KEY; only shells out to `gh`.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { SurfaceAgent } from './agent.js';
+import type { Digest } from './types.js';
+
+interface ParsedArgs {
+  command: 'generate' | 'help';
+  since: string;
+  output: string | null;
+  ghRepo: string | null;
+  corpusRoot: string | null;
+  transcriptRoot: string | null;
+  maxBytes: number | null;
+  minImportance: number | null;
+  maxFindings: number | null;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const a: ParsedArgs = {
+    command: 'help',
+    since: '1 day ago',
+    output: null,
+    ghRepo: null,
+    corpusRoot: null,
+    transcriptRoot: null,
+    maxBytes: null,
+    minImportance: null,
+    maxFindings: null
+  };
+  if (argv.length === 0) return a;
+  const cmd = argv[0];
+  if (cmd === 'generate') a.command = cmd;
+  for (let i = 1; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    switch (k) {
+      case '--since':
+        a.since = v ?? a.since;
+        i++;
+        break;
+      case '--output':
+        a.output = v ?? null;
+        i++;
+        break;
+      case '--gh-repo':
+        a.ghRepo = v ?? null;
+        i++;
+        break;
+      case '--corpus-root':
+        a.corpusRoot = v ?? null;
+        i++;
+        break;
+      case '--transcript-root':
+        a.transcriptRoot = v ?? null;
+        i++;
+        break;
+      case '--max-bytes':
+        a.maxBytes = v === undefined ? null : Number(v);
+        i++;
+        break;
+      case '--min-importance':
+        a.minImportance = v === undefined ? null : Number(v);
+        i++;
+        break;
+      case '--max-findings':
+        a.maxFindings = v === undefined ? null : Number(v);
+        i++;
+        break;
+      default:
+        // ignore unknown flags
+        break;
+    }
+  }
+  return a;
+}
+
+function helpText(): string {
+  return `caia-surface — operator-curation digest generator
+
+USAGE:
+  caia-surface generate --since "1 day ago" --output ~/Documents/projects/reports/digest-DATE.md
+                        [--gh-repo owner/name]
+                        [--corpus-root <path>]
+                        [--transcript-root <path>]
+                        [--max-bytes <n>] [--min-importance <f>] [--max-findings <n>]
+
+  Pass "--output -" or omit to print to stdout.
+`;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === 'help') {
+    console.log(helpText());
+    process.exit(0);
+  }
+
+  const cfgInput: ConstructorParameters<typeof SurfaceAgent>[0] = {};
+  if (args.ghRepo !== null) cfgInput.ghRepo = args.ghRepo;
+  if (args.corpusRoot !== null) cfgInput.corpusRoot = args.corpusRoot;
+  if (args.transcriptRoot !== null) cfgInput.transcriptRoot = args.transcriptRoot;
+  if (args.maxBytes !== null && !Number.isNaN(args.maxBytes)) cfgInput.maxBytes = args.maxBytes;
+  if (args.minImportance !== null && !Number.isNaN(args.minImportance)) {
+    cfgInput.minImportance = args.minImportance;
+  }
+  if (args.maxFindings !== null && !Number.isNaN(args.maxFindings)) {
+    cfgInput.maxFindings = args.maxFindings;
+  }
+
+  const agent = new SurfaceAgent(cfgInput);
+  let digest: Digest;
+  try {
+    digest = await agent.generateDigest({ since: args.since });
+  } catch (e) {
+    console.error('caia-surface error:', (e as Error).message);
+    process.exit(2);
+  }
+
+  if (args.output === null || args.output === '-' ) {
+    process.stdout.write(digest.markdown);
+    if (!digest.markdown.endsWith('\n')) process.stdout.write('\n');
+  } else {
+    mkdirSync(dirname(args.output), { recursive: true });
+    writeFileSync(args.output, digest.markdown, 'utf-8');
+    console.error(`wrote ${digest.sizeBytes} bytes (${digest.findings.length} findings) → ${args.output}`);
+  }
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error('caia-surface fatal:', (e as Error).message);
+  process.exit(2);
+});

--- a/packages/surface/src/config.ts
+++ b/packages/surface/src/config.ts
@@ -1,0 +1,130 @@
+/**
+ * @chiefaia/surface — config resolution.
+ *
+ * Constructor injects every CAIA-specific path / repo / threshold; defaults
+ * resolve from env vars, then from compile-time CAIA defaults. Tests inject
+ * fixture paths and bypass env entirely.
+ *
+ * Per Option E (agent_architecture_shape_2026-05-06.md), all CAIA-specific
+ * literals are constructor parameters with defaults. Tests verify the shape
+ * holds under fixture corpora.
+ */
+
+import { homedir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+import type { FsReader, GhRunner, GitRunner } from './types.js';
+
+export interface SurfaceAgentConfig {
+  /** Memory file root. Defaults to ~/Documents/projects/agent-memory. */
+  corpusRoot?: string;
+  /** GitHub repo for PR connector. Defaults to prakashgbid/caia. */
+  ghRepo?: string;
+  /** Local clone of the repo for memory git-log; defaults to corpusRoot's
+   *  parent (`~/Documents/projects`) when corpusRoot lives inside a git repo,
+   *  otherwise corpusRoot itself. */
+  memoryGitRepo?: string;
+  /** Transcript root. Defaults to local-agent-mode-sessions. */
+  transcriptRoot?: string;
+  /** Reports dir for default --output. Defaults to ~/Documents/projects/reports. */
+  reportsRoot?: string;
+  /** Hard digest size cap in bytes. Defaults to 50_000. */
+  maxBytes?: number;
+  /** Importance floor (0..1). Defaults to 0.35. */
+  minImportance?: number;
+  /** Max findings per digest after filtering. Defaults to 100. */
+  maxFindings?: number;
+  /** DI seams — tests inject fakes. */
+  fs?: FsReader;
+  gh?: GhRunner;
+  git?: GitRunner;
+  clock?: () => Date;
+}
+
+export interface ResolvedSurfaceAgentConfig {
+  corpusRoot: string;
+  ghRepo: string;
+  memoryGitRepo: string;
+  transcriptRoot: string;
+  reportsRoot: string;
+  maxBytes: number;
+  minImportance: number;
+  maxFindings: number;
+}
+
+/**
+ * Expand a leading `~/` to the operator's home dir. Anything else is
+ * returned untouched.
+ */
+export function expandHome(p: string): string {
+  if (p.startsWith('~/')) return resolve(homedir(), p.slice(2));
+  if (p === '~') return homedir();
+  return p;
+}
+
+const DEFAULT_CORPUS_ROOT = '~/Documents/projects/agent-memory';
+const DEFAULT_GH_REPO = 'prakashgbid/caia';
+const DEFAULT_MEMORY_GIT_REPO = '~/Documents/projects/agent-memory';
+const DEFAULT_TRANSCRIPT_ROOT = '~/Library/Application Support/Claude/local-agent-mode-sessions';
+const DEFAULT_REPORTS_ROOT = '~/Documents/projects/reports';
+const DEFAULT_MAX_BYTES = 50_000;
+const DEFAULT_MIN_IMPORTANCE = 0.35;
+const DEFAULT_MAX_FINDINGS = 100;
+
+export function resolveConfig(input: SurfaceAgentConfig = {}): ResolvedSurfaceAgentConfig {
+  const corpusRoot = expandHome(
+    input.corpusRoot
+    ?? process.env['CAIA_MEMORY_ROOT']
+    ?? DEFAULT_CORPUS_ROOT
+  );
+  const ghRepo =
+    input.ghRepo
+    ?? process.env['SURFACE_GH_REPO']
+    ?? DEFAULT_GH_REPO;
+  const memoryGitRepo = expandHome(
+    input.memoryGitRepo
+    ?? process.env['SURFACE_MEMORY_GIT_REPO']
+    ?? DEFAULT_MEMORY_GIT_REPO
+  );
+  const transcriptRoot = expandHome(
+    input.transcriptRoot
+    ?? process.env['SURFACE_TRANSCRIPT_ROOT']
+    ?? DEFAULT_TRANSCRIPT_ROOT
+  );
+  const reportsRoot = expandHome(
+    input.reportsRoot
+    ?? process.env['CAIA_REPORTS_ROOT']
+    ?? DEFAULT_REPORTS_ROOT
+  );
+  const maxBytes =
+    input.maxBytes
+    ?? (Number(process.env['SURFACE_MAX_BYTES']) || DEFAULT_MAX_BYTES);
+  const minImportance =
+    input.minImportance
+    ?? (Number(process.env['SURFACE_MIN_IMPORTANCE']) || DEFAULT_MIN_IMPORTANCE);
+  const maxFindings =
+    input.maxFindings
+    ?? (Number(process.env['SURFACE_MAX_FINDINGS']) || DEFAULT_MAX_FINDINGS);
+
+  return {
+    corpusRoot,
+    ghRepo,
+    memoryGitRepo,
+    transcriptRoot,
+    reportsRoot,
+    maxBytes,
+    minImportance,
+    maxFindings
+  };
+}
+
+/** Convenience: build a default repo path from corpusRoot if user didn't override. */
+export function inferMemoryGitRepo(corpusRoot: string): string {
+  // corpusRoot is typically a sub-folder of a git repo OR is itself a git repo.
+  // We default to corpusRoot — git -C <corpusRoot> walks up to find the repo
+  // automatically.
+  return corpusRoot;
+}
+
+void inferMemoryGitRepo; // exported for completeness; not used in resolveConfig directly to keep constructor surface flat
+export { join };

--- a/packages/surface/src/connectors/index.ts
+++ b/packages/surface/src/connectors/index.ts
@@ -1,0 +1,3 @@
+export { createPrConnector, type PrConnectorOptions } from './pr.js';
+export { createMemoryConnector, parseGitLog, type MemoryConnectorOptions } from './memory.js';
+export { createTranscriptConnector, type TranscriptConnectorOptions } from './transcript.js';

--- a/packages/surface/src/connectors/memory.ts
+++ b/packages/surface/src/connectors/memory.ts
@@ -1,0 +1,188 @@
+/**
+ * Memory connector — reads `git log --name-status --since` against the
+ * agent-memory repo, classifies each touched file as added/updated, and
+ * returns Finding[].
+ *
+ * Falls back to filesystem mtime walk when git-log fails (e.g. agent-memory
+ * isn't a git repo on this machine yet).
+ */
+
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+
+import type {
+  CollectArgs,
+  Connector,
+  ConnectorResult,
+  Finding,
+  FindingKind,
+  FsReader,
+  GitRunner
+} from '../types.js';
+
+export interface MemoryConnectorOptions {
+  corpusRoot: string;
+  memoryGitRepo: string;
+  fs: FsReader;
+  git: GitRunner;
+}
+
+export function createMemoryConnector(opts: MemoryConnectorOptions): Connector {
+  return {
+    source: 'memory',
+    async collect(args: CollectArgs): Promise<ConnectorResult> {
+      const collectedAtIso = args.untilIso;
+      const warnings: string[] = [];
+
+      // Try git log first.
+      const gitFindings = await tryGitLog(opts, args, warnings);
+      if (gitFindings !== null) {
+        return { source: 'memory', findings: gitFindings, collectedAtIso, warnings };
+      }
+
+      // Fallback: filesystem walk + mtime.
+      const fsFindings = walkMtime(opts, args, warnings);
+      return { source: 'memory', findings: fsFindings, collectedAtIso, warnings };
+    }
+  };
+}
+
+interface ParsedCommit {
+  iso: string;
+  changes: ReadonlyArray<{ status: string; path: string }>;
+}
+
+async function tryGitLog(
+  opts: MemoryConnectorOptions,
+  args: CollectArgs,
+  warnings: string[]
+): Promise<readonly Finding[] | null> {
+  if (!opts.fs.exists(opts.memoryGitRepo)) {
+    warnings.push(`memory-git: repo not found at ${opts.memoryGitRepo}`);
+    return null;
+  }
+  let stdout: string;
+  try {
+    stdout = await opts.git.log(opts.memoryGitRepo, [
+      `--since=${args.sinceIso}`,
+      `--until=${args.untilIso}`,
+      '--name-status',
+      '--date=iso-strict',
+      '--pretty=format:--%H--%aI--',
+      '--',
+      // Restrict path scope to the corpus root inside the repo. We pass the
+      // absolute corpusRoot — git resolves it relative to repo root via -C.
+      opts.corpusRoot
+    ]);
+  } catch (e) {
+    warnings.push(`memory-git: ${(e as Error).message.slice(0, 200)}`);
+    return null;
+  }
+
+  const commits = parseGitLog(stdout);
+  if (commits.length === 0) return [];
+
+  // Aggregate per-file: latest status wins, latest commit ts is the finding ts.
+  const perFile = new Map<string, { iso: string; status: string }>();
+  for (const c of commits) {
+    for (const ch of c.changes) {
+      const prev = perFile.get(ch.path);
+      if (prev === undefined || Date.parse(c.iso) > Date.parse(prev.iso)) {
+        perFile.set(ch.path, { iso: c.iso, status: ch.status });
+      }
+    }
+  }
+
+  const findings: Finding[] = [];
+  for (const [path, info] of perFile) {
+    const kind: FindingKind = info.status === 'A' ? 'memory-added' : 'memory-updated';
+    findings.push(buildMemoryFinding(path, info.iso, kind));
+  }
+  return findings;
+}
+
+function walkMtime(
+  opts: MemoryConnectorOptions,
+  args: CollectArgs,
+  warnings: string[]
+): readonly Finding[] {
+  if (!opts.fs.exists(opts.corpusRoot)) {
+    warnings.push(`memory-fs: corpusRoot not found at ${opts.corpusRoot}`);
+    return [];
+  }
+  const sinceMs = Date.parse(args.sinceIso);
+  const untilMs = Date.parse(args.untilIso);
+  const findings: Finding[] = [];
+  const entries = opts.fs.readDir(opts.corpusRoot);
+  for (const name of entries) {
+    if (!name.endsWith('.md')) continue;
+    const fullPath = join(opts.corpusRoot, name);
+    const st = opts.fs.stat(fullPath);
+    if (st === null || !st.isFile) continue;
+    const mtimeMs = Date.parse(st.mtimeIso);
+    if (Number.isNaN(mtimeMs) || mtimeMs < sinceMs || mtimeMs > untilMs) continue;
+    findings.push(buildMemoryFinding(name, st.mtimeIso, 'memory-updated'));
+  }
+  return findings;
+}
+
+export function parseGitLog(stdout: string): readonly ParsedCommit[] {
+  if (stdout.trim() === '') return [];
+  const commits: ParsedCommit[] = [];
+  // Split on commit boundary marker "--<hash>--<iso>--".
+  const lines = stdout.split('\n');
+  let current: { hash: string; iso: string; changes: { status: string; path: string }[] } | null = null;
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    if (line === '') continue;
+    if (line.startsWith('--') && line.endsWith('--')) {
+      const stripped = line.slice(2, -2);
+      const dashIdx = stripped.indexOf('--');
+      if (dashIdx === -1) continue;
+      const hash = stripped.slice(0, dashIdx);
+      const iso = stripped.slice(dashIdx + 2);
+      if (current !== null) commits.push({ iso: current.iso, changes: current.changes });
+      current = { hash, iso, changes: [] };
+    } else if (current !== null) {
+      // name-status line: "<status>\t<path>"
+      const tabIdx = line.indexOf('\t');
+      if (tabIdx === -1) continue;
+      const status = line.slice(0, tabIdx).trim();
+      const path = line.slice(tabIdx + 1).trim();
+      if (status === '' || path === '') continue;
+      current.changes.push({ status: status[0] ?? 'M', path });
+    }
+  }
+  if (current !== null) commits.push({ iso: current.iso, changes: current.changes });
+  return commits;
+}
+
+function buildMemoryFinding(path: string, tsIso: string, kind: FindingKind): Finding {
+  const filename = path.split('/').filter(Boolean).pop() ?? path;
+  const tags: string[] = [];
+  if (filename.startsWith('feedback_')) tags.push('feedback');
+  if (filename.startsWith('apprentice_')) tags.push('apprentice');
+  if (filename.startsWith('mentor_')) tags.push('mentor');
+  if (filename.startsWith('curator_')) tags.push('curator');
+  if (filename.startsWith('librarian_')) tags.push('librarian');
+  if (filename.startsWith('stolution_')) tags.push('stolution');
+  if (/_complete[._]/.test(filename) || filename.endsWith('_complete.md')) tags.push('complete');
+  if (filename.includes('_live_')) tags.push('live');
+  if (filename.includes('_directive')) tags.push('directive');
+  if (filename === 'MEMORY.md') tags.push('index');
+  const idHash = createHash('sha256')
+    .update(`memory|${kind}|${path}|${tsIso}`)
+    .digest('hex')
+    .slice(0, 16);
+  return {
+    id: idHash,
+    source: 'memory',
+    kind,
+    key: path,
+    title: `${filename} ${kind === 'memory-added' ? 'added' : 'updated'}`,
+    tsIso,
+    importance: 0,
+    tags,
+    meta: { path, filename }
+  };
+}

--- a/packages/surface/src/connectors/pr.ts
+++ b/packages/surface/src/connectors/pr.ts
@@ -1,0 +1,195 @@
+/**
+ * PR connector — reads `gh pr list --json ...` for merged + open PRs in a
+ * given repo since a relative time, returns Finding[].
+ *
+ * Fields requested: number, title, state, author, mergedAt, createdAt,
+ * updatedAt, url, labels, isDraft, baseRefName, headRefName.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type {
+  CollectArgs,
+  Connector,
+  ConnectorResult,
+  Finding,
+  FindingKind,
+  GhRunner
+} from '../types.js';
+
+interface GhPr {
+  number: number;
+  title: string;
+  state: 'OPEN' | 'CLOSED' | 'MERGED';
+  author?: { login?: string };
+  mergedAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  url?: string;
+  labels?: ReadonlyArray<{ name: string }>;
+  isDraft?: boolean;
+  baseRefName?: string;
+  headRefName?: string;
+}
+
+const PR_FIELDS = [
+  'number',
+  'title',
+  'state',
+  'author',
+  'mergedAt',
+  'createdAt',
+  'updatedAt',
+  'url',
+  'labels',
+  'isDraft',
+  'baseRefName',
+  'headRefName'
+];
+
+const STALE_THRESHOLD_DAYS = 7;
+
+export interface PrConnectorOptions {
+  ghRepo: string;
+  gh: GhRunner;
+  /** Max PRs returned by `gh pr list --limit`. Defaults to 200. */
+  limit?: number;
+}
+
+export function createPrConnector(opts: PrConnectorOptions): Connector {
+  const limit = opts.limit ?? 200;
+
+  return {
+    source: 'pr',
+    async collect(args: CollectArgs): Promise<ConnectorResult> {
+      const collectedAtIso = args.untilIso;
+      const warnings: string[] = [];
+      const findings: Finding[] = [];
+      const sinceMs = Date.parse(args.sinceIso);
+      const untilMs = Date.parse(args.untilIso);
+
+      // Pull both merged + open in two passes — `gh pr list` filters by state
+      // separately and merging the two streams gives the operator a single
+      // ranked view.
+      let mergedJson = '';
+      let openJson = '';
+      try {
+        mergedJson = await opts.gh.run([
+          'pr', 'list',
+          '--repo', opts.ghRepo,
+          '--state', 'merged',
+          '--limit', String(limit),
+          '--json', PR_FIELDS.join(',')
+        ]);
+      } catch (e) {
+        warnings.push(`pr-merged: ${(e as Error).message.slice(0, 200)}`);
+      }
+      try {
+        openJson = await opts.gh.run([
+          'pr', 'list',
+          '--repo', opts.ghRepo,
+          '--state', 'open',
+          '--limit', String(limit),
+          '--json', PR_FIELDS.join(',')
+        ]);
+      } catch (e) {
+        warnings.push(`pr-open: ${(e as Error).message.slice(0, 200)}`);
+      }
+
+      const merged = parseJsonArray(mergedJson, warnings, 'merged');
+      const open = parseJsonArray(openJson, warnings, 'open');
+
+      for (const pr of merged) {
+        const ts = pr.mergedAt ?? pr.updatedAt ?? pr.createdAt;
+        if (ts === undefined || ts === null) continue;
+        const tsMs = Date.parse(ts);
+        if (Number.isNaN(tsMs) || tsMs < sinceMs || tsMs > untilMs) continue;
+        findings.push(buildFinding(pr, ts, 'pr-merged'));
+      }
+      for (const pr of open) {
+        const created = pr.createdAt ?? pr.updatedAt ?? args.sinceIso;
+        const updated = pr.updatedAt ?? pr.createdAt ?? args.sinceIso;
+        const createdMs = Date.parse(created);
+        const updatedMs = Date.parse(updated);
+        // Bucket the open PR as either "newly opened in window" or "stale".
+        const opensInWindow = !Number.isNaN(createdMs) && createdMs >= sinceMs && createdMs <= untilMs;
+        const ageDays = (untilMs - updatedMs) / (1000 * 60 * 60 * 24);
+        if (opensInWindow) {
+          findings.push(buildFinding(pr, created, 'pr-opened'));
+        } else if (ageDays >= STALE_THRESHOLD_DAYS) {
+          findings.push(buildFinding(pr, updated, 'pr-stale'));
+        }
+      }
+
+      return {
+        source: 'pr',
+        findings,
+        collectedAtIso,
+        warnings
+      };
+    }
+  };
+}
+
+function parseJsonArray(json: string, warnings: string[], label: string): GhPr[] {
+  if (json.trim() === '') return [];
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (!Array.isArray(parsed)) {
+      warnings.push(`${label}: gh json was not an array`);
+      return [];
+    }
+    return parsed as GhPr[];
+  } catch (e) {
+    warnings.push(`${label}: json parse failed: ${(e as Error).message.slice(0, 100)}`);
+    return [];
+  }
+}
+
+function buildFinding(pr: GhPr, tsIso: string, kind: FindingKind): Finding {
+  const labels = (pr.labels ?? []).map(l => l.name);
+  const tags: string[] = [
+    `state:${pr.state.toLowerCase()}`,
+    ...(pr.isDraft === true ? ['draft'] : []),
+    ...labels.map(l => `label:${l}`),
+    ...(pr.baseRefName !== undefined ? [`base:${pr.baseRefName}`] : [])
+  ];
+  const titleClean = pr.title.length > 200 ? pr.title.slice(0, 197) + '...' : pr.title;
+  const idHash = createHash('sha256')
+    .update(`pr|${kind}|${pr.number}|${tsIso}`)
+    .digest('hex')
+    .slice(0, 16);
+  const meta: Record<string, string | number | boolean> = {
+    number: pr.number,
+    state: pr.state,
+    isDraft: pr.isDraft ?? false
+  };
+  if (pr.author?.login !== undefined) meta['author'] = pr.author.login;
+  if (pr.headRefName !== undefined) meta['headRefName'] = pr.headRefName;
+  const finding: Finding = {
+    id: idHash,
+    source: 'pr',
+    kind,
+    key: `pr#${pr.number}`,
+    title: `PR #${pr.number} ${kindVerb(kind)}: ${titleClean}`,
+    tsIso,
+    importance: 0,
+    tags,
+    meta
+  };
+  if (pr.url !== undefined) finding.url = pr.url;
+  return finding;
+}
+
+function kindVerb(kind: FindingKind): string {
+  switch (kind) {
+    case 'pr-merged':
+      return 'merged';
+    case 'pr-opened':
+      return 'opened';
+    case 'pr-stale':
+      return 'stale';
+    default:
+      return kind;
+  }
+}

--- a/packages/surface/src/connectors/transcript.ts
+++ b/packages/surface/src/connectors/transcript.ts
@@ -1,0 +1,115 @@
+/**
+ * Transcript connector — walks the local-agent-mode-sessions tree at
+ * configurable depth, surfaces session folders and message files modified
+ * within the window. Phase 0 only emits structural metadata (no content
+ * extraction); Phase 2 will include LLM summaries.
+ *
+ * Heuristic kind assignment:
+ *  - filenames matching /handoff|completion|done/ → 'transcript-handoff'
+ *  - filenames matching /error|failure|crash|abort/ → 'transcript-failure'
+ *  - everything else → 'transcript-handoff' (default; conservative)
+ */
+
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+
+import type {
+  CollectArgs,
+  Connector,
+  ConnectorResult,
+  Finding,
+  FindingKind,
+  FsReader
+} from '../types.js';
+
+export interface TranscriptConnectorOptions {
+  transcriptRoot: string;
+  fs: FsReader;
+  /** Walk depth limit (defaults to 4 — root/session/sub/file). */
+  maxDepth?: number;
+  /** Max findings emitted; defaults to 200. */
+  maxFindings?: number;
+}
+
+const HANDOFF_RE = /handoff|completion|done|complete/i;
+const FAILURE_RE = /error|failure|crash|abort|failed/i;
+
+export function createTranscriptConnector(opts: TranscriptConnectorOptions): Connector {
+  const maxDepth = opts.maxDepth ?? 4;
+  const maxFindings = opts.maxFindings ?? 200;
+
+  return {
+    source: 'transcript',
+    async collect(args: CollectArgs): Promise<ConnectorResult> {
+      const collectedAtIso = args.untilIso;
+      const warnings: string[] = [];
+      const findings: Finding[] = [];
+
+      if (!opts.fs.exists(opts.transcriptRoot)) {
+        warnings.push(`transcript: root not found at ${opts.transcriptRoot}`);
+        return { source: 'transcript', findings, collectedAtIso, warnings };
+      }
+
+      const sinceMs = Date.parse(args.sinceIso);
+      const untilMs = Date.parse(args.untilIso);
+
+      const stack: { path: string; depth: number }[] = [{ path: opts.transcriptRoot, depth: 0 }];
+      while (stack.length > 0 && findings.length < maxFindings) {
+        const next = stack.pop();
+        if (next === undefined) break;
+        const { path, depth } = next;
+        const st = opts.fs.stat(path);
+        if (st === null) continue;
+
+        if (st.isFile) {
+          const mtimeMs = Date.parse(st.mtimeIso);
+          if (Number.isNaN(mtimeMs) || mtimeMs < sinceMs || mtimeMs > untilMs) continue;
+          // Ignore very small files (heuristic — empty or stub).
+          if (st.sizeBytes < 32) continue;
+          // Ignore files that aren't transcript-shaped — keep .md / .txt / .jsonl.
+          if (!/\.(md|txt|jsonl|json|log)$/i.test(path)) continue;
+          findings.push(buildTranscriptFinding(path, st.mtimeIso, st.sizeBytes));
+          continue;
+        }
+
+        if (st.isDirectory) {
+          if (depth >= maxDepth) continue;
+          for (const entry of opts.fs.readDir(path)) {
+            stack.push({ path: join(path, entry), depth: depth + 1 });
+          }
+        }
+      }
+
+      return { source: 'transcript', findings, collectedAtIso, warnings };
+    }
+  };
+}
+
+function buildTranscriptFinding(path: string, mtimeIso: string, sizeBytes: number): Finding {
+  const filename = path.split('/').filter(Boolean).pop() ?? path;
+  let kind: FindingKind = 'transcript-handoff';
+  if (FAILURE_RE.test(filename)) kind = 'transcript-failure';
+  else if (HANDOFF_RE.test(filename)) kind = 'transcript-handoff';
+  // else default to handoff
+  const tags: string[] = [];
+  if (FAILURE_RE.test(filename)) tags.push('failure');
+  if (HANDOFF_RE.test(filename)) tags.push('handoff');
+  if (sizeBytes > 100_000) tags.push('large');
+  const titleBase = filename.replace(/\.[a-z]+$/i, '');
+  const truncated = titleBase.length > 120 ? titleBase.slice(0, 117) + '...' : titleBase;
+  const idHash = createHash('sha256')
+    .update(`transcript|${kind}|${path}|${mtimeIso}`)
+    .digest('hex')
+    .slice(0, 16);
+  return {
+    id: idHash,
+    source: 'transcript',
+    kind,
+    key: path,
+    title: `transcript ${kind === 'transcript-failure' ? 'failure' : 'handoff'}: ${truncated}`,
+    tsIso: mtimeIso,
+    importance: 0,
+    tags,
+    meta: { path, sizeBytes }
+  };
+}

--- a/packages/surface/src/digest.ts
+++ b/packages/surface/src/digest.ts
@@ -1,0 +1,125 @@
+/**
+ * Digest generator — renders curated Finding[] to markdown, grouped by source.
+ *
+ * Hard size cap: throws DigestSizeExceededError if rendered markdown would
+ * exceed maxBytes. Caller (agent) should tighten minImportance and retry.
+ */
+
+import type { Digest, Finding, FindingSource } from './types.js';
+
+export class DigestSizeExceededError extends Error {
+  readonly sizeBytes: number;
+  readonly maxBytes: number;
+  readonly findingCount: number;
+  constructor(sizeBytes: number, maxBytes: number, findingCount: number) {
+    super(
+      `Digest size ${sizeBytes}B exceeds cap ${maxBytes}B with ${findingCount} findings — ` +
+      'importance filter not strict enough. Raise minImportance or lower maxFindings.'
+    );
+    this.name = 'DigestSizeExceededError';
+    this.sizeBytes = sizeBytes;
+    this.maxBytes = maxBytes;
+    this.findingCount = findingCount;
+  }
+}
+
+export interface GenerateDigestArgs {
+  findings: readonly Finding[];
+  dropped: readonly Finding[];
+  generatedAtIso: string;
+  sinceIso: string;
+  untilIso: string;
+  maxBytes: number;
+  sourceSummary: Record<FindingSource, { collected: number; warnings: readonly string[] }>;
+}
+
+const SECTION_ORDER: readonly FindingSource[] = ['pr', 'memory', 'transcript', 'connector-error'];
+
+const SECTION_LABEL: Readonly<Record<FindingSource, string>> = {
+  pr: 'Pull Requests',
+  memory: 'Agent Memory',
+  transcript: 'Agent Transcripts',
+  'connector-error': 'Connector Errors'
+};
+
+export function generateDigest(args: GenerateDigestArgs): Digest {
+  const lines: string[] = [];
+  lines.push(`# Surface Digest — ${args.untilIso}`);
+  lines.push('');
+  lines.push(`Window: \`${args.sinceIso}\` → \`${args.untilIso}\``);
+  lines.push(`Generated: \`${args.generatedAtIso}\``);
+  lines.push(`Findings: **${args.findings.length}** kept, ${args.dropped.length} dropped (below importance floor or over cap)`);
+  lines.push('');
+
+  // Summary table.
+  lines.push('## Source summary');
+  lines.push('');
+  lines.push('| Source | Collected | Warnings |');
+  lines.push('|---|---:|---|');
+  for (const src of SECTION_ORDER) {
+    const s = args.sourceSummary[src];
+    if (s === undefined) continue;
+    const w = s.warnings.length === 0
+      ? '—'
+      : '`' + s.warnings.map(x => x.slice(0, 60)).join('` `') + '`';
+    lines.push(`| ${SECTION_LABEL[src]} | ${s.collected} | ${w} |`);
+  }
+  lines.push('');
+
+  // Group findings by source.
+  const groups = new Map<FindingSource, Finding[]>();
+  for (const f of args.findings) {
+    const list = groups.get(f.source);
+    if (list === undefined) groups.set(f.source, [f]);
+    else list.push(f);
+  }
+
+  for (const src of SECTION_ORDER) {
+    const list = groups.get(src);
+    if (list === undefined || list.length === 0) continue;
+    lines.push(`## ${SECTION_LABEL[src]}`);
+    lines.push('');
+    for (const f of list) {
+      lines.push(renderFinding(f));
+    }
+    lines.push('');
+  }
+
+  if (args.findings.length === 0) {
+    lines.push('_No findings above importance floor._');
+    lines.push('');
+  }
+
+  const markdown = lines.join('\n');
+  const sizeBytes = Buffer.byteLength(markdown, 'utf-8');
+
+  if (sizeBytes > args.maxBytes) {
+    throw new DigestSizeExceededError(sizeBytes, args.maxBytes, args.findings.length);
+  }
+
+  return {
+    markdown,
+    findings: args.findings,
+    dropped: args.dropped,
+    sizeBytes,
+    generatedAtIso: args.generatedAtIso,
+    sinceIso: args.sinceIso,
+    untilIso: args.untilIso,
+    sourceSummary: args.sourceSummary
+  };
+}
+
+function renderFinding(f: Finding): string {
+  const importance = (f.importance * 100).toFixed(0).padStart(3, ' ');
+  const ts = f.tsIso;
+  const linkPart = f.url !== undefined ? ` [↗](${f.url})` : '';
+  const tagPart = f.tags.length === 0
+    ? ''
+    : ' ' + f.tags.slice(0, 6).map(t => '`' + t + '`').join(' ');
+  return `- **[${importance}%]** \`${ts}\` — ${escapeMd(f.title)}${linkPart}${tagPart}`;
+}
+
+function escapeMd(s: string): string {
+  // Light: prevent accidental list/section breakage. Don't HTML-escape.
+  return s.replace(/\|/g, '\\|').replace(/\n+/g, ' ');
+}

--- a/packages/surface/src/filter.ts
+++ b/packages/surface/src/filter.ts
@@ -1,0 +1,50 @@
+/**
+ * Filter rules — drop low-importance findings, then enforce a hard cap.
+ *
+ * Determinism: stable sort by (importance desc, tsIso desc, id asc).
+ */
+
+import type { Finding } from './types.js';
+
+export interface FilterOptions {
+  minImportance: number;
+  /** Hard cap on findings count. */
+  maxFindings: number;
+}
+
+export interface FilterResult {
+  kept: readonly Finding[];
+  dropped: readonly Finding[];
+}
+
+export function applyFilter(findings: readonly Finding[], opts: FilterOptions): FilterResult {
+  const kept: Finding[] = [];
+  const dropped: Finding[] = [];
+
+  for (const f of findings) {
+    if (f.importance < opts.minImportance) {
+      dropped.push(f);
+      continue;
+    }
+    kept.push(f);
+  }
+
+  // Stable ordering. Comparators all return -1/0/1.
+  kept.sort(compareFinding);
+
+  if (kept.length > opts.maxFindings) {
+    const trimmed = kept.slice(0, opts.maxFindings);
+    const overflow = kept.slice(opts.maxFindings);
+    dropped.push(...overflow);
+    return { kept: trimmed, dropped };
+  }
+
+  return { kept, dropped };
+}
+
+function compareFinding(a: Finding, b: Finding): number {
+  if (a.importance !== b.importance) return a.importance < b.importance ? 1 : -1;
+  if (a.tsIso !== b.tsIso) return a.tsIso < b.tsIso ? 1 : -1;
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+  return 0;
+}

--- a/packages/surface/src/fs-reader.ts
+++ b/packages/surface/src/fs-reader.ts
@@ -1,0 +1,40 @@
+/**
+ * Default real-filesystem reader. Tests inject a fake instead.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+
+import type { FsReader } from './types.js';
+
+export const defaultFsReader: FsReader = {
+  exists(p: string): boolean {
+    return existsSync(p);
+  },
+  readFile(p: string): string {
+    return readFileSync(p, 'utf-8');
+  },
+  readDir(p: string): string[] {
+    if (!existsSync(p)) return [];
+    try {
+      const st = statSync(p);
+      if (!st.isDirectory()) return [];
+      return readdirSync(p).sort();
+    } catch {
+      return [];
+    }
+  },
+  stat(p: string) {
+    if (!existsSync(p)) return null;
+    try {
+      const st = statSync(p);
+      return {
+        isDirectory: st.isDirectory(),
+        isFile: st.isFile(),
+        sizeBytes: st.size,
+        mtimeIso: st.mtime.toISOString()
+      };
+    } catch {
+      return null;
+    }
+  }
+};

--- a/packages/surface/src/gh-runner.ts
+++ b/packages/surface/src/gh-runner.ts
@@ -1,0 +1,61 @@
+/**
+ * Default `gh` CLI runner. Tests inject a fake.
+ *
+ * Subscription-only: we never set ANTHROPIC_API_KEY here. The shell-out is
+ * `gh`, which uses the operator's existing PAT — no per-token billing.
+ */
+
+import { spawn } from 'node:child_process';
+
+import type { GhRunner, GitRunner } from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export const defaultGhRunner: GhRunner = {
+  run(args: readonly string[]): Promise<string> {
+    return runShell('gh', args, undefined);
+  }
+};
+
+export const defaultGitRunner: GitRunner = {
+  log(repo: string, args: readonly string[]): Promise<string> {
+    return runShell('git', ['-C', repo, 'log', ...args], undefined);
+  }
+};
+
+function runShell(cmd: string, args: readonly string[], cwd: string | undefined): Promise<string> {
+  return new Promise((resolveP, rejectP) => {
+    const env = { ...process.env };
+    delete env['ANTHROPIC_API_KEY'];
+
+    const child = spawn(cmd, [...args], {
+      env,
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    const chunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    child.stdout.on('data', d => chunks.push(d as Buffer));
+    child.stderr.on('data', d => errChunks.push(d as Buffer));
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      rejectP(new Error(`${cmd} ${args.join(' ')} timed out after ${DEFAULT_TIMEOUT_MS}ms`));
+    }, DEFAULT_TIMEOUT_MS);
+
+    child.on('error', e => {
+      clearTimeout(timer);
+      rejectP(e);
+    });
+    child.on('close', code => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        const err = Buffer.concat(errChunks).toString('utf-8').slice(0, 500);
+        rejectP(new Error(`${cmd} exited ${code}: ${err}`));
+        return;
+      }
+      resolveP(Buffer.concat(chunks).toString('utf-8'));
+    });
+  });
+}

--- a/packages/surface/src/index.ts
+++ b/packages/surface/src/index.ts
@@ -1,0 +1,64 @@
+/**
+ * @chiefaia/surface — public surface.
+ *
+ * Surface Agent — operator-curation lens. Reads PR activity, agent-memory
+ * deltas, and agent transcripts; scores findings by importance; emits a
+ * markdown digest under a hard size cap.
+ *
+ * See DESIGN.md and ../../agent-memory/surface_agent_directive.md.
+ */
+
+export { SurfaceAgent, parseSince, type GenerateDigestRequest } from './agent.js';
+
+export {
+  resolveConfig,
+  expandHome,
+  type SurfaceAgentConfig,
+  type ResolvedSurfaceAgentConfig
+} from './config.js';
+
+export { defaultFsReader } from './fs-reader.js';
+export { defaultGhRunner, defaultGitRunner } from './gh-runner.js';
+
+export {
+  createPrConnector,
+  createMemoryConnector,
+  createTranscriptConnector,
+  parseGitLog,
+  type PrConnectorOptions,
+  type MemoryConnectorOptions,
+  type TranscriptConnectorOptions
+} from './connectors/index.js';
+
+export {
+  defaultScorer,
+  applyScores
+} from './scorer.js';
+
+export {
+  applyFilter,
+  type FilterOptions,
+  type FilterResult
+} from './filter.js';
+
+export {
+  generateDigest,
+  DigestSizeExceededError,
+  type GenerateDigestArgs
+} from './digest.js';
+
+export type {
+  CollectArgs,
+  Connector,
+  ConnectorResult,
+  Digest,
+  Finding,
+  FindingKind,
+  FindingSource,
+  FsReader,
+  GhRunner,
+  GitRunner,
+  ImportanceScorer,
+  ScoringContext,
+  FilterRule
+} from './types.js';

--- a/packages/surface/src/scorer.ts
+++ b/packages/surface/src/scorer.ts
@@ -1,0 +1,117 @@
+/**
+ * Importance scorer — Phase 0 heuristic.
+ *
+ *   score = 0.4 * recency
+ *         + 0.3 * tag_weight
+ *         + 0.2 * severity_weight
+ *         + 0.1 * size_signal
+ *
+ * Deterministic. Stateless. No LLM. Bounded to [0, 1].
+ */
+
+import type {
+  Finding,
+  ImportanceScorer,
+  ScoringContext
+} from './types.js';
+
+const HIGH_TAGS = new Set([
+  'feedback',
+  'directive',
+  'live',
+  'complete',
+  'failure',
+  'index'
+]);
+
+const KEYWORD_BUMPS: ReadonlyArray<{ re: RegExp; bump: number }> = [
+  { re: /\bBLOCK(?:ED|ER)\b/i, bump: 0.6 },
+  { re: /\bCRITICAL\b/i, bump: 0.5 },
+  { re: /\bFAIL(?:ED|URE)\b/i, bump: 0.4 },
+  { re: /🚨/u, bump: 0.5 },
+  { re: /\bsecurity\b/i, bump: 0.4 },
+  { re: /\bcomplete(?:d|s)?\b/i, bump: 0.3 },
+  { re: /\bphase\s?\d+\b/i, bump: 0.2 },
+  { re: /\bmerged\b/i, bump: 0.15 }
+];
+
+const SEVERITY_KIND_WEIGHT: Readonly<Record<string, number>> = {
+  'pr-merged': 0.7,
+  'pr-opened': 0.5,
+  'pr-stale': 0.85,
+  'memory-added': 0.6,
+  'memory-updated': 0.5,
+  'transcript-handoff': 0.4,
+  'transcript-failure': 0.85,
+  'connector-degraded': 0.3
+};
+
+/** Default scorer instance. Stateless. */
+export const defaultScorer: ImportanceScorer = {
+  score(finding, ctx) {
+    return clamp01(
+      0.4 * recencyComponent(finding.tsIso, ctx) +
+      0.3 * tagComponent(finding.tags, finding.title) +
+      0.2 * severityComponent(finding.kind) +
+      0.1 * sizeComponent(finding)
+    );
+  }
+};
+
+export function applyScores(
+  findings: ReadonlyArray<Omit<Finding, 'importance'>>,
+  ctx: ScoringContext,
+  scorer: ImportanceScorer = defaultScorer
+): readonly Finding[] {
+  return findings.map(f => ({
+    ...f,
+    importance: scorer.score(f, ctx)
+  }));
+}
+
+function recencyComponent(tsIso: string, ctx: ScoringContext): number {
+  const tMs = Date.parse(tsIso);
+  const sinceMs = Date.parse(ctx.sinceIso);
+  const untilMs = Date.parse(ctx.untilIso);
+  if (Number.isNaN(tMs) || Number.isNaN(sinceMs) || Number.isNaN(untilMs)) return 0.5;
+  const span = untilMs - sinceMs;
+  if (span <= 0) return 1.0;
+  const offset = tMs - sinceMs;
+  const ratio = clamp01(offset / span);
+  // Linear: 0.0 at older horizon edge, 1.0 at the freshest moment.
+  return ratio;
+}
+
+function tagComponent(tags: readonly string[], title: string): number {
+  let weight = 0;
+  for (const t of tags) {
+    if (HIGH_TAGS.has(t)) weight += 0.35;
+    else weight += 0.05;
+  }
+  for (const { re, bump } of KEYWORD_BUMPS) {
+    if (re.test(title)) weight += bump;
+  }
+  return clamp01(weight);
+}
+
+function severityComponent(kind: string): number {
+  return SEVERITY_KIND_WEIGHT[kind] ?? 0.3;
+}
+
+function sizeComponent(finding: Pick<Finding, 'meta' | 'bodyExcerpt'>): number {
+  const m = finding.meta;
+  let bytes = finding.bodyExcerpt?.length ?? 0;
+  if (m !== undefined) {
+    const sb = m['sizeBytes'];
+    if (typeof sb === 'number') bytes = Math.max(bytes, sb);
+  }
+  if (bytes <= 0) return 0;
+  return clamp01(Math.log10(bytes + 1) / 5);
+}
+
+function clamp01(x: number): number {
+  if (Number.isNaN(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}

--- a/packages/surface/src/types.ts
+++ b/packages/surface/src/types.ts
@@ -1,0 +1,140 @@
+/**
+ * @chiefaia/surface — public type surface.
+ *
+ * Surface Agent ingests three subscription-free sources (gh PR list, memory
+ * file diffs, agent transcript metadata), scores each item by importance, and
+ * emits a markdown digest under a hard size cap.
+ *
+ * Phase 0 ships heuristic-only scoring (no LLM). Phase 2 adds operator-voice
+ * rephrasing once the Apprentice operator-style adapter is mature.
+ */
+
+/** Where a finding came from. Stable across phases. */
+export type FindingSource = 'pr' | 'memory' | 'transcript' | 'connector-error';
+
+/** Coarse human label — drives section grouping in the digest. */
+export type FindingKind =
+  | 'pr-merged'
+  | 'pr-opened'
+  | 'pr-stale'
+  | 'memory-added'
+  | 'memory-updated'
+  | 'transcript-handoff'
+  | 'transcript-failure'
+  | 'connector-degraded';
+
+/**
+ * One curated item. The agent collects Finding[] from every connector,
+ * scores them, filters, then renders to markdown grouped by source.
+ */
+export interface Finding {
+  /** Stable hash of `source|kind|key|tsIso` — dedup key. */
+  id: string;
+  source: FindingSource;
+  kind: FindingKind;
+  /** Connector-supplied unique identifier within source. PR number as string,
+   *  memory filename, transcript path, etc. */
+  key: string;
+  /** Single-line human-readable headline. ≤200 chars. */
+  title: string;
+  /** Optional 1-3 paragraph snippet. Phase 0 only includes structural metadata,
+   *  no body content extraction. ≤2000 chars. */
+  bodyExcerpt?: string;
+  /** ISO8601 wall-clock timestamp the underlying event happened. */
+  tsIso: string;
+  /** Importance score 0..1. Computed by ImportanceScorer; higher = more important. */
+  importance: number;
+  /** Tags drawn from filename / labels / branch. Used by scorer + digest. */
+  tags: readonly string[];
+  /** Optional operator-clickable URL (PR HTML URL, agent-memory file path). */
+  url?: string;
+  /** Connector-supplied extra metadata. Opaque to scorer; used for digest formatting. */
+  meta?: Record<string, string | number | boolean>;
+}
+
+/** A connector returns either findings, or an error annotation Finding. Never throws. */
+export interface ConnectorResult {
+  source: FindingSource;
+  findings: readonly Finding[];
+  /** ISO8601 of when the connector ran. */
+  collectedAtIso: string;
+  /** Optional warning emitted alongside findings (e.g. gh rate-limit hit). */
+  warnings: readonly string[];
+}
+
+/** Connector contract — every source implements this. */
+export interface Connector {
+  readonly source: FindingSource;
+  collect(args: CollectArgs): Promise<ConnectorResult>;
+}
+
+export interface CollectArgs {
+  /** Lower bound — only emit findings with tsIso >= sinceIso. */
+  sinceIso: string;
+  /** Upper bound — only emit findings with tsIso <= untilIso. Defaults to now. */
+  untilIso: string;
+}
+
+/** Importance scorer contract. Stateless, deterministic. */
+export interface ImportanceScorer {
+  score(finding: Omit<Finding, 'id' | 'importance'>, ctx: ScoringContext): number;
+}
+
+export interface ScoringContext {
+  /** Earliest ts considered "fresh" — same as collect's sinceIso. */
+  sinceIso: string;
+  /** Now-ish — same as collect's untilIso. */
+  untilIso: string;
+}
+
+/** Filter rule contract. Drops findings that don't pass. */
+export interface FilterRule {
+  /** Keep iff predicate returns true. */
+  keep(f: Finding): boolean;
+  /** Optional ordered cap — sort by importance desc, take first N. */
+  cap?: number;
+}
+
+/** A digest's final output. */
+export interface Digest {
+  /** Rendered markdown, ≤ maxBytes. */
+  markdown: string;
+  /** Findings included after filtering, ordered as rendered. */
+  findings: readonly Finding[];
+  /** Findings dropped by filter (importance < floor or cap). Useful for tests. */
+  dropped: readonly Finding[];
+  /** Byte length of `markdown`. */
+  sizeBytes: number;
+  generatedAtIso: string;
+  sinceIso: string;
+  untilIso: string;
+  /** Per-source counts and warnings for the digest header. */
+  sourceSummary: Record<FindingSource, { collected: number; warnings: readonly string[] }>;
+}
+
+/** Filesystem read seam — every disk read goes through this (testable). */
+export interface FsReader {
+  exists(p: string): boolean;
+  readFile(p: string): string;
+  /** List entries in a dir; `[]` if missing. */
+  readDir(p: string): string[];
+  /** Stat-like info — only fields we use. `null` if missing. */
+  stat(p: string): { isDirectory: boolean; isFile: boolean; sizeBytes: number; mtimeIso: string } | null;
+}
+
+/** Shell-out seam for `gh`. Tests inject a fake. */
+export interface GhRunner {
+  /**
+   * Run `gh <args>` and return stdout. Throws on non-zero exit (caller
+   * catches and converts to ConnectorResult.warnings).
+   */
+  run(args: readonly string[]): Promise<string>;
+}
+
+/** Git-log seam for memory deltas. Tests inject a fake. */
+export interface GitRunner {
+  /**
+   * Run `git -C <repo> log <args>` and return stdout. Throws on non-zero exit.
+   */
+  log(repo: string, args: readonly string[]): Promise<string>;
+}

--- a/packages/surface/tests/__fixtures__/fs.ts
+++ b/packages/surface/tests/__fixtures__/fs.ts
@@ -1,0 +1,73 @@
+/**
+ * In-memory FsReader for tests. Build a virtual filesystem with `addFile` /
+ * `addDir`, then pass to connectors via DI.
+ */
+
+import type { FsReader } from '../../src/types.js';
+
+interface FileEntry {
+  kind: 'file';
+  body: string;
+  mtimeIso: string;
+}
+interface DirEntry {
+  kind: 'dir';
+}
+type Entry = FileEntry | DirEntry;
+
+export class FakeFs implements FsReader {
+  private readonly entries = new Map<string, Entry>();
+
+  addFile(path: string, body: string, mtimeIso: string): this {
+    this.entries.set(path, { kind: 'file', body, mtimeIso });
+    // Auto-create parent dirs.
+    let cur = path;
+    while (cur.includes('/')) {
+      cur = cur.slice(0, cur.lastIndexOf('/'));
+      if (cur === '') break;
+      if (!this.entries.has(cur)) this.entries.set(cur, { kind: 'dir' });
+    }
+    return this;
+  }
+
+  addDir(path: string): this {
+    this.entries.set(path, { kind: 'dir' });
+    return this;
+  }
+
+  exists(p: string): boolean {
+    return this.entries.has(p);
+  }
+  readFile(p: string): string {
+    const e = this.entries.get(p);
+    if (e === undefined || e.kind !== 'file') throw new Error(`fake-fs: not a file: ${p}`);
+    return e.body;
+  }
+  readDir(p: string): string[] {
+    const e = this.entries.get(p);
+    if (e === undefined || e.kind !== 'dir') return [];
+    const prefix = p === '/' ? '/' : p + '/';
+    const children = new Set<string>();
+    for (const path of this.entries.keys()) {
+      if (!path.startsWith(prefix)) continue;
+      const rest = path.slice(prefix.length);
+      if (rest === '') continue;
+      const top = rest.includes('/') ? rest.slice(0, rest.indexOf('/')) : rest;
+      children.add(top);
+    }
+    return [...children].sort();
+  }
+  stat(p: string) {
+    const e = this.entries.get(p);
+    if (e === undefined) return null;
+    if (e.kind === 'dir') {
+      return { isDirectory: true, isFile: false, sizeBytes: 0, mtimeIso: '1970-01-01T00:00:00.000Z' };
+    }
+    return {
+      isDirectory: false,
+      isFile: true,
+      sizeBytes: Buffer.byteLength(e.body, 'utf-8'),
+      mtimeIso: e.mtimeIso
+    };
+  }
+}

--- a/packages/surface/tests/__fixtures__/runners.ts
+++ b/packages/surface/tests/__fixtures__/runners.ts
@@ -1,0 +1,43 @@
+/**
+ * Fake GhRunner / GitRunner for tests.
+ */
+
+import type { GhRunner, GitRunner } from '../../src/types.js';
+
+export class FakeGh implements GhRunner {
+  private readonly responses: Array<{ match: (args: readonly string[]) => boolean; result: string | Error }> = [];
+
+  on(match: (args: readonly string[]) => boolean, result: string | Error): this {
+    this.responses.push({ match, result });
+    return this;
+  }
+
+  async run(args: readonly string[]): Promise<string> {
+    for (const r of this.responses) {
+      if (r.match(args)) {
+        if (r.result instanceof Error) throw r.result;
+        return r.result;
+      }
+    }
+    throw new Error(`fake-gh: no matching response for: ${args.join(' ')}`);
+  }
+}
+
+export class FakeGit implements GitRunner {
+  private readonly responses: Array<{ repo: string; match: (args: readonly string[]) => boolean; result: string | Error }> = [];
+
+  on(repo: string, match: (args: readonly string[]) => boolean, result: string | Error): this {
+    this.responses.push({ repo, match, result });
+    return this;
+  }
+
+  async log(repo: string, args: readonly string[]): Promise<string> {
+    for (const r of this.responses) {
+      if (r.repo === repo && r.match(args)) {
+        if (r.result instanceof Error) throw r.result;
+        return r.result;
+      }
+    }
+    throw new Error(`fake-git: no matching response for ${repo}: ${args.join(' ')}`);
+  }
+}

--- a/packages/surface/tests/agent.test.ts
+++ b/packages/surface/tests/agent.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+
+import { SurfaceAgent, parseSince } from '../src/agent.js';
+import type { Connector, ConnectorResult, Finding, FindingSource } from '../src/types.js';
+import { FakeFs } from './__fixtures__/fs.js';
+import { FakeGh, FakeGit } from './__fixtures__/runners.js';
+
+const FIXED_NOW = new Date('2026-05-09T12:00:00.000Z');
+
+function constantClock(d = FIXED_NOW): () => Date {
+  return () => d;
+}
+
+function findingFx(over: Partial<Finding> & { source: FindingSource }): Finding {
+  return {
+    id: 'fx',
+    kind: 'memory-updated',
+    key: 'k',
+    title: 't',
+    tsIso: '2026-05-09T01:00:00.000Z',
+    importance: 0,
+    tags: [],
+    ...over
+  };
+}
+
+function fakeConnector(source: FindingSource, findings: Finding[], warnings: string[] = []): Connector {
+  return {
+    source,
+    async collect(args): Promise<ConnectorResult> {
+      return {
+        source,
+        findings,
+        collectedAtIso: args.untilIso,
+        warnings
+      };
+    }
+  };
+}
+
+describe('parseSince', () => {
+  it('parses "1 day ago"', () => {
+    const d = parseSince('1 day ago', FIXED_NOW);
+    expect(d).not.toBeNull();
+    expect(d?.toISOString()).toBe('2026-05-08T12:00:00.000Z');
+  });
+  it('parses "3 hours ago"', () => {
+    const d = parseSince('3 hours ago', FIXED_NOW);
+    expect(d?.toISOString()).toBe('2026-05-09T09:00:00.000Z');
+  });
+  it('parses ISO8601', () => {
+    const d = parseSince('2026-05-01T00:00:00.000Z', FIXED_NOW);
+    expect(d?.toISOString()).toBe('2026-05-01T00:00:00.000Z');
+  });
+  it('rejects gibberish', () => {
+    expect(parseSince('something invalid', FIXED_NOW)).toBeNull();
+  });
+});
+
+describe('SurfaceAgent', () => {
+  it('runs end-to-end with injected connectors and produces a digest', async () => {
+    const findings = [
+      findingFx({ source: 'pr', kind: 'pr-merged', title: 'PR #400 merged: feature x', tsIso: '2026-05-09T03:00:00.000Z' }),
+      findingFx({ source: 'memory', kind: 'memory-added', title: 'feedback_x.md added', tags: ['feedback'], tsIso: '2026-05-09T04:00:00.000Z' })
+    ];
+    const agent = new SurfaceAgent({
+      maxBytes: 50_000,
+      minImportance: 0.0,
+      clock: constantClock(),
+      connectors: [
+        fakeConnector('pr', [findings[0]!]),
+        fakeConnector('memory', [findings[1]!])
+      ]
+    });
+    const d = await agent.generateDigest({ since: '1 day ago' });
+    expect(d.findings.length).toBeGreaterThanOrEqual(2);
+    expect(d.markdown).toContain('Surface Digest');
+    expect(d.markdown).toContain('PR #400');
+    expect(d.markdown).toContain('feedback_x.md');
+  });
+
+  it('throws when exceeding maxBytes (importance not strict enough)', async () => {
+    const many: Finding[] = [];
+    for (let i = 0; i < 500; i++) {
+      many.push(findingFx({
+        id: `i${i}`,
+        source: 'memory',
+        title: 'x'.repeat(500),
+        importance: 0.9
+      }));
+    }
+    const agent = new SurfaceAgent({
+      maxBytes: 5000,
+      minImportance: 0.0,
+      maxFindings: 1000,
+      clock: constantClock(),
+      connectors: [fakeConnector('memory', many)]
+    });
+    await expect(agent.generateDigest({ since: '1 day ago' })).rejects.toThrow(/Digest size/);
+  });
+
+  it('drops findings below minImportance', async () => {
+    const agent = new SurfaceAgent({
+      maxBytes: 50_000,
+      minImportance: 0.99,
+      clock: constantClock(),
+      connectors: [fakeConnector('memory', [
+        findingFx({ id: 'a', source: 'memory', title: 'low importance' })
+      ])]
+    });
+    const d = await agent.generateDigest({ since: '1 day ago' });
+    expect(d.findings.length).toBe(0);
+    expect(d.dropped.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits a connector-degraded annotation on warnings', async () => {
+    const agent = new SurfaceAgent({
+      maxBytes: 50_000,
+      minImportance: 0.0,
+      clock: constantClock(),
+      connectors: [fakeConnector('pr', [], ['rate-limit hit'])]
+    });
+    const d = await agent.generateDigest({ since: '1 day ago' });
+    expect(d.markdown).toContain('Connector pr degraded');
+  });
+
+  it('determinism: same fakes, two runs → byte-identical markdown', async () => {
+    const findings = [findingFx({ id: 'a', source: 'memory', title: 'x' })];
+    const a1 = new SurfaceAgent({
+      maxBytes: 50_000, minImportance: 0.0, clock: constantClock(),
+      connectors: [fakeConnector('memory', findings)]
+    });
+    const a2 = new SurfaceAgent({
+      maxBytes: 50_000, minImportance: 0.0, clock: constantClock(),
+      connectors: [fakeConnector('memory', findings)]
+    });
+    const d1 = await a1.generateDigest({ since: '1 day ago' });
+    const d2 = await a2.generateDigest({ since: '1 day ago' });
+    expect(d1.markdown).toBe(d2.markdown);
+  });
+
+  it('survives a connector that throws', async () => {
+    const agent = new SurfaceAgent({
+      maxBytes: 50_000,
+      minImportance: 0.0,
+      clock: constantClock(),
+      connectors: [
+        {
+          source: 'pr',
+          async collect(): Promise<ConnectorResult> {
+            throw new Error('boom');
+          }
+        }
+      ]
+    });
+    const d = await agent.generateDigest({ since: '1 day ago' });
+    expect(d.markdown).toContain('Connector pr degraded');
+  });
+
+  it('--since gibberish rejected with clear error', async () => {
+    const agent = new SurfaceAgent({ clock: constantClock(), connectors: [] });
+    await expect(agent.generateDigest({ since: 'not-a-time' })).rejects.toThrow(/could not parse/);
+  });
+
+  it('uses defaults for max bytes/findings/importance', () => {
+    const agent = new SurfaceAgent({});
+    expect(agent.config.maxBytes).toBe(50_000);
+    expect(agent.config.maxFindings).toBe(100);
+    expect(agent.config.minImportance).toBeCloseTo(0.35, 5);
+  });
+
+  it('integration: built-in connectors used when no override (with fake fs/gh/git)', async () => {
+    const fs = new FakeFs()
+      .addDir('/m')
+      .addFile('/m/feedback_x.md', 'b'.repeat(200), '2026-05-09T03:00:00.000Z');
+    const gh = new FakeGh()
+      .on(args => args.includes('merged'), '[]')
+      .on(args => args.includes('open'), '[]');
+    // Force fs-walk fallback by simulating "agent-memory not a git repo"
+    const git = new FakeGit().on('/m', _ => true, new Error('not a git repo'));
+    const agent = new SurfaceAgent({
+      corpusRoot: '/m',
+      memoryGitRepo: '/m',
+      transcriptRoot: '/no',
+      ghRepo: 'r/r',
+      maxBytes: 50_000,
+      minImportance: 0.0,
+      fs, gh, git,
+      clock: constantClock()
+    });
+    const d = await agent.generateDigest({ since: '1 day ago' });
+    // Memory file fs-walk fallback should pick up feedback_x.md.
+    const seenFx = d.markdown.includes('feedback_x.md');
+    expect(seenFx).toBe(true);
+  });
+});

--- a/packages/surface/tests/config.test.ts
+++ b/packages/surface/tests/config.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { resolveConfig, expandHome } from '../src/config.js';
+
+describe('config', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = [
+    'CAIA_MEMORY_ROOT',
+    'SURFACE_GH_REPO',
+    'SURFACE_MEMORY_GIT_REPO',
+    'SURFACE_TRANSCRIPT_ROOT',
+    'CAIA_REPORTS_ROOT',
+    'SURFACE_MAX_BYTES',
+    'SURFACE_MIN_IMPORTANCE',
+    'SURFACE_MAX_FINDINGS'
+  ] as const;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  it('expands ~/ to home', () => {
+    const home = process.env['HOME'] ?? '';
+    expect(expandHome('~/foo')).toBe(`${home}/foo`);
+  });
+
+  it('returns absolute paths untouched', () => {
+    expect(expandHome('/abs/x')).toBe('/abs/x');
+  });
+
+  it('uses CAIA defaults when no input or env', () => {
+    const c = resolveConfig({});
+    expect(c.ghRepo).toBe('prakashgbid/caia');
+    expect(c.maxBytes).toBe(50_000);
+    expect(c.minImportance).toBeCloseTo(0.35, 5);
+    expect(c.maxFindings).toBe(100);
+    expect(c.corpusRoot).toContain('agent-memory');
+  });
+
+  it('honours constructor input over env', () => {
+    process.env['SURFACE_GH_REPO'] = 'env/repo';
+    const c = resolveConfig({ ghRepo: 'arg/repo' });
+    expect(c.ghRepo).toBe('arg/repo');
+  });
+
+  it('honours env over default', () => {
+    process.env['SURFACE_GH_REPO'] = 'env/repo';
+    const c = resolveConfig({});
+    expect(c.ghRepo).toBe('env/repo');
+  });
+
+  it('parses numeric env vars', () => {
+    process.env['SURFACE_MAX_BYTES'] = '12345';
+    process.env['SURFACE_MIN_IMPORTANCE'] = '0.7';
+    process.env['SURFACE_MAX_FINDINGS'] = '42';
+    const c = resolveConfig({});
+    expect(c.maxBytes).toBe(12345);
+    expect(c.minImportance).toBeCloseTo(0.7, 5);
+    expect(c.maxFindings).toBe(42);
+  });
+
+  it('falls back to defaults on unparseable numeric env', () => {
+    process.env['SURFACE_MAX_BYTES'] = 'not-a-number';
+    const c = resolveConfig({});
+    expect(c.maxBytes).toBe(50_000);
+  });
+
+  it('expands ~/ in path inputs', () => {
+    const c = resolveConfig({ corpusRoot: '~/foo/bar' });
+    expect(c.corpusRoot.startsWith('/')).toBe(true);
+    expect(c.corpusRoot.endsWith('/foo/bar')).toBe(true);
+  });
+
+  it('preserves all CAIA-default literals as constructor parameters (Option E shape)', () => {
+    // Re-assert: every CAIA-specific path is overridable via input.
+    const c = resolveConfig({
+      corpusRoot: '/x/agent-memory',
+      ghRepo: 'x/y',
+      memoryGitRepo: '/x/agent-memory',
+      transcriptRoot: '/x/transcripts',
+      reportsRoot: '/x/reports',
+      maxBytes: 1,
+      minImportance: 0.99,
+      maxFindings: 1
+    });
+    expect(c).toEqual({
+      corpusRoot: '/x/agent-memory',
+      ghRepo: 'x/y',
+      memoryGitRepo: '/x/agent-memory',
+      transcriptRoot: '/x/transcripts',
+      reportsRoot: '/x/reports',
+      maxBytes: 1,
+      minImportance: 0.99,
+      maxFindings: 1
+    });
+  });
+
+  it('treats `~` (no trailing slash) as home', () => {
+    const home = process.env['HOME'] ?? '';
+    expect(expandHome('~')).toBe(home);
+  });
+});

--- a/packages/surface/tests/connectors/memory.test.ts
+++ b/packages/surface/tests/connectors/memory.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+
+import { createMemoryConnector, parseGitLog } from '../../src/connectors/memory.js';
+import { FakeFs } from '../__fixtures__/fs.js';
+import { FakeGit } from '../__fixtures__/runners.js';
+
+const NOW = '2026-05-09T12:00:00.000Z';
+const SINCE = '2026-05-08T12:00:00.000Z';
+
+describe('memory connector', () => {
+  it('parses git log --name-status output', () => {
+    const stdout = [
+      '--abc--2026-05-09T01:00:00+00:00--',
+      'A\tagent-memory/feedback_new.md',
+      'M\tagent-memory/MEMORY.md',
+      '--def--2026-05-09T02:00:00+00:00--',
+      'M\tagent-memory/feedback_new.md'
+    ].join('\n');
+    const commits = parseGitLog(stdout);
+    expect(commits.length).toBe(2);
+    expect(commits[0]?.changes.length).toBe(2);
+    expect(commits[1]?.changes.length).toBe(1);
+  });
+
+  it('emits findings via git log when repo exists', async () => {
+    const fs = new FakeFs().addDir('/repo').addDir('/repo/agent-memory');
+    const git = new FakeGit().on('/repo/agent-memory', _ => true, [
+      '--abc--2026-05-09T03:00:00+00:00--',
+      'A\tagent-memory/feedback_new_2026-05-09.md',
+      'M\tagent-memory/MEMORY.md'
+    ].join('\n'));
+
+    const c = createMemoryConnector({
+      corpusRoot: '/repo/agent-memory',
+      memoryGitRepo: '/repo/agent-memory',
+      fs,
+      git
+    });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(2);
+    const added = r.findings.find(f => f.kind === 'memory-added');
+    expect(added?.tags).toContain('feedback');
+    const updated = r.findings.find(f => f.key === 'agent-memory/MEMORY.md');
+    expect(updated?.kind).toBe('memory-updated');
+    expect(updated?.tags).toContain('index');
+  });
+
+  it('falls back to filesystem walk when git fails', async () => {
+    const fs = new FakeFs()
+      .addDir('/cm')
+      .addFile('/cm/feedback_x.md', 'body', '2026-05-09T05:00:00.000Z')
+      .addFile('/cm/old.md', 'body', '2026-04-01T00:00:00.000Z');
+    const git = new FakeGit().on('/cm', _ => true, new Error('not a git repo'));
+    const c = createMemoryConnector({
+      corpusRoot: '/cm',
+      memoryGitRepo: '/cm',
+      fs,
+      git
+    });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.warnings.some(w => w.includes('memory-git'))).toBe(true);
+    const f = r.findings.find(x => x.key === 'feedback_x.md');
+    expect(f).toBeDefined();
+    expect(f?.tags).toContain('feedback');
+    expect(r.findings.find(x => x.key === 'old.md')).toBeUndefined();
+  });
+
+  it('returns warning + empty when corpusRoot missing entirely', async () => {
+    const fs = new FakeFs(); // empty
+    const git = new FakeGit().on('/missing', _ => true, new Error('no repo'));
+    const c = createMemoryConnector({
+      corpusRoot: '/missing',
+      memoryGitRepo: '/missing',
+      fs,
+      git
+    });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+    expect(r.warnings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('latest-status-wins when same file appears in multiple commits', async () => {
+    const fs = new FakeFs().addDir('/repo');
+    const git = new FakeGit().on('/repo', _ => true, [
+      '--c1--2026-05-09T01:00:00+00:00--',
+      'A\tfile.md',
+      '--c2--2026-05-09T02:00:00+00:00--',
+      'M\tfile.md'
+    ].join('\n'));
+    const c = createMemoryConnector({ corpusRoot: '/repo', memoryGitRepo: '/repo', fs, git });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(1);
+    expect(r.findings[0]?.kind).toBe('memory-updated');
+  });
+
+  it('tags directives, completes, lives, etc.', async () => {
+    const fs = new FakeFs().addDir('/r');
+    const git = new FakeGit().on('/r', _ => true, [
+      '--c--2026-05-09T01:00:00+00:00--',
+      'A\tagent-memory/curator_agent_directive.md',
+      'A\tagent-memory/apprentice_phase1_complete_2026-05-09.md',
+      'A\tagent-memory/slot_manager_phase0_live_2026-05-08.md',
+      'A\tagent-memory/stolution_data_architecture.md'
+    ].join('\n'));
+    const c = createMemoryConnector({ corpusRoot: '/r', memoryGitRepo: '/r', fs, git });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    const directiveTag = r.findings.find(f => f.key.endsWith('curator_agent_directive.md'));
+    const completeTag = r.findings.find(f => f.key.endsWith('apprentice_phase1_complete_2026-05-09.md'));
+    const liveTag = r.findings.find(f => f.key.endsWith('slot_manager_phase0_live_2026-05-08.md'));
+    const stolutionTag = r.findings.find(f => f.key.endsWith('stolution_data_architecture.md'));
+    expect(directiveTag?.tags).toContain('directive');
+    expect(completeTag?.tags).toContain('complete');
+    expect(liveTag?.tags).toContain('live');
+    expect(stolutionTag?.tags).toContain('stolution');
+  });
+
+  it('returns empty findings when git log returns nothing', async () => {
+    const fs = new FakeFs().addDir('/r');
+    const git = new FakeGit().on('/r', _ => true, '');
+    const c = createMemoryConnector({ corpusRoot: '/r', memoryGitRepo: '/r', fs, git });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+    expect(r.warnings.length).toBe(0);
+  });
+
+  it('finding ids are deterministic', async () => {
+    const fs = new FakeFs().addDir('/r');
+    const stdout = [
+      '--c--2026-05-09T01:00:00+00:00--',
+      'A\tx.md'
+    ].join('\n');
+    const c1 = createMemoryConnector({
+      corpusRoot: '/r', memoryGitRepo: '/r', fs,
+      git: new FakeGit().on('/r', _ => true, stdout)
+    });
+    const c2 = createMemoryConnector({
+      corpusRoot: '/r', memoryGitRepo: '/r', fs,
+      git: new FakeGit().on('/r', _ => true, stdout)
+    });
+    const r1 = await c1.collect({ sinceIso: SINCE, untilIso: NOW });
+    const r2 = await c2.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r1.findings.map(f => f.id)).toEqual(r2.findings.map(f => f.id));
+  });
+
+  it('respects time window via mtime fallback', async () => {
+    const fs = new FakeFs()
+      .addDir('/r')
+      .addFile('/r/in.md', 'b', '2026-05-09T01:00:00.000Z')
+      .addFile('/r/out.md', 'b', '2026-05-07T01:00:00.000Z');
+    const git = new FakeGit().on('/r', _ => true, new Error('fail'));
+    const c = createMemoryConnector({ corpusRoot: '/r', memoryGitRepo: '/r', fs, git });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.find(f => f.key === 'in.md')).toBeDefined();
+    expect(r.findings.find(f => f.key === 'out.md')).toBeUndefined();
+  });
+
+  it('parseGitLog tolerates malformed lines', () => {
+    const stdout = [
+      'no-marker-here',
+      '--bad',
+      '--abc--2026-05-09T01:00:00+00:00--',
+      'malformed',
+      'A\tgood.md'
+    ].join('\n');
+    const commits = parseGitLog(stdout);
+    expect(commits.length).toBe(1);
+    expect(commits[0]?.changes.length).toBe(1);
+  });
+});

--- a/packages/surface/tests/connectors/pr.test.ts
+++ b/packages/surface/tests/connectors/pr.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+
+import { createPrConnector } from '../../src/connectors/pr.js';
+import { FakeGh } from '../__fixtures__/runners.js';
+
+const NOW = '2026-05-09T12:00:00.000Z';
+const SINCE = '2026-05-08T12:00:00.000Z';
+
+function makeMergedJson() {
+  return JSON.stringify([
+    {
+      number: 400,
+      title: 'feat: code-reviewer Phase 1',
+      state: 'MERGED',
+      author: { login: 'prakashgbid' },
+      mergedAt: '2026-05-09T01:00:00.000Z',
+      createdAt: '2026-05-08T20:00:00.000Z',
+      updatedAt: '2026-05-09T01:00:00.000Z',
+      url: 'https://github.com/prakashgbid/caia/pull/400',
+      labels: [{ name: 'agent' }, { name: 'auto-merge' }],
+      isDraft: false,
+      baseRefName: 'develop',
+      headRefName: 'feat/code-reviewer-001'
+    },
+    {
+      number: 100,
+      title: 'old',
+      state: 'MERGED',
+      mergedAt: '2026-04-01T00:00:00.000Z',
+      createdAt: '2026-03-31T00:00:00.000Z',
+      updatedAt: '2026-04-01T00:00:00.000Z',
+      url: 'u',
+      labels: [],
+      isDraft: false
+    }
+  ]);
+}
+
+function makeOpenJson() {
+  return JSON.stringify([
+    {
+      number: 410,
+      title: 'wip: surface skeleton',
+      state: 'OPEN',
+      createdAt: '2026-05-09T10:00:00.000Z',
+      updatedAt: '2026-05-09T10:30:00.000Z',
+      url: 'https://github.com/prakashgbid/caia/pull/410',
+      labels: [{ name: 'agent' }],
+      isDraft: false,
+      baseRefName: 'develop',
+      headRefName: 'feat/surface-001-skeleton'
+    },
+    {
+      number: 50,
+      title: 'old open one',
+      state: 'OPEN',
+      createdAt: '2026-04-01T00:00:00.000Z',
+      updatedAt: '2026-04-15T00:00:00.000Z',
+      url: 'u',
+      labels: [],
+      isDraft: false
+    }
+  ]);
+}
+
+describe('pr connector', () => {
+  it('emits findings for merged PRs in window', async () => {
+    const gh = new FakeGh()
+      .on(args => args.includes('--state') && args.includes('merged'), makeMergedJson())
+      .on(args => args.includes('--state') && args.includes('open'), makeOpenJson());
+
+    const c = createPrConnector({ ghRepo: 'prakashgbid/caia', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+
+    const merged = r.findings.find(f => f.kind === 'pr-merged');
+    expect(merged).toBeDefined();
+    expect(merged?.title).toContain('PR #400 merged');
+    expect(merged?.url).toBe('https://github.com/prakashgbid/caia/pull/400');
+    expect(merged?.tags).toContain('label:agent');
+    expect(merged?.tags).toContain('base:develop');
+  });
+
+  it('drops merged PRs older than --since', async () => {
+    const gh = new FakeGh()
+      .on(args => args.includes('--state') && args.includes('merged'), makeMergedJson())
+      .on(args => args.includes('--state') && args.includes('open'), makeOpenJson());
+    const c = createPrConnector({ ghRepo: 'prakashgbid/caia', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.find(f => f.key === 'pr#100')).toBeUndefined();
+  });
+
+  it('classifies open PR opened in window as pr-opened', async () => {
+    const gh = new FakeGh()
+      .on(args => args.includes('--state') && args.includes('merged'), makeMergedJson())
+      .on(args => args.includes('--state') && args.includes('open'), makeOpenJson());
+    const c = createPrConnector({ ghRepo: 'prakashgbid/caia', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    const f = r.findings.find(x => x.key === 'pr#410');
+    expect(f?.kind).toBe('pr-opened');
+  });
+
+  it('classifies old open PR as pr-stale', async () => {
+    const gh = new FakeGh()
+      .on(args => args.includes('--state') && args.includes('merged'), makeMergedJson())
+      .on(args => args.includes('--state') && args.includes('open'), makeOpenJson());
+    const c = createPrConnector({ ghRepo: 'prakashgbid/caia', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    const f = r.findings.find(x => x.key === 'pr#50');
+    expect(f?.kind).toBe('pr-stale');
+  });
+
+  it('emits warning when gh fails for merged but still tries open', async () => {
+    const gh = new FakeGh()
+      .on(args => args.includes('--state') && args.includes('merged'), new Error('rate-limit'))
+      .on(args => args.includes('--state') && args.includes('open'), makeOpenJson());
+    const c = createPrConnector({ ghRepo: 'prakashgbid/caia', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(r.warnings.some(w => w.includes('rate-limit'))).toBe(true);
+    expect(r.findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles malformed gh json gracefully', async () => {
+    const gh = new FakeGh()
+      .on(args => args.includes('--state') && args.includes('merged'), 'not-json')
+      .on(args => args.includes('--state') && args.includes('open'), '');
+    const c = createPrConnector({ ghRepo: 'prakashgbid/caia', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+    expect(r.warnings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('finding ids are stable across runs (deterministic)', async () => {
+    const gh1 = new FakeGh()
+      .on(args => args.includes('merged'), makeMergedJson())
+      .on(args => args.includes('open'), makeOpenJson());
+    const gh2 = new FakeGh()
+      .on(args => args.includes('merged'), makeMergedJson())
+      .on(args => args.includes('open'), makeOpenJson());
+    const c1 = createPrConnector({ ghRepo: 'prakashgbid/caia', gh: gh1 });
+    const c2 = createPrConnector({ ghRepo: 'prakashgbid/caia', gh: gh2 });
+    const r1 = await c1.collect({ sinceIso: SINCE, untilIso: NOW });
+    const r2 = await c2.collect({ sinceIso: SINCE, untilIso: NOW });
+    const ids1 = r1.findings.map(f => f.id).sort();
+    const ids2 = r2.findings.map(f => f.id).sort();
+    expect(ids1).toEqual(ids2);
+  });
+
+  it('truncates long titles to ≤200 chars', async () => {
+    const longTitle = 'x'.repeat(300);
+    const json = JSON.stringify([{
+      number: 1,
+      title: longTitle,
+      state: 'MERGED',
+      mergedAt: '2026-05-09T01:00:00.000Z',
+      url: 'u',
+      labels: [],
+      isDraft: false
+    }]);
+    const gh = new FakeGh()
+      .on(args => args.includes('merged'), json)
+      .on(args => args.includes('open'), '[]');
+    const c = createPrConnector({ ghRepo: 'r/r', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings[0]?.title.length ?? 0).toBeLessThanOrEqual(220);
+  });
+
+  it('returns empty findings + warning when both gh calls fail', async () => {
+    const gh = new FakeGh()
+      .on(_ => true, new Error('gh not installed'));
+    const c = createPrConnector({ ghRepo: 'r/r', gh });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+    expect(r.warnings.length).toBe(2);
+  });
+
+  it('passes the configured limit to gh', async () => {
+    let captured: string[] = [];
+    const gh = new FakeGh().on(args => {
+      captured = [...args];
+      return true;
+    }, '[]');
+    const c = createPrConnector({ ghRepo: 'r/r', gh, limit: 25 });
+    await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(captured).toContain('--limit');
+    const idx = captured.indexOf('--limit');
+    expect(captured[idx + 1]).toBe('25');
+  });
+});

--- a/packages/surface/tests/connectors/transcript.test.ts
+++ b/packages/surface/tests/connectors/transcript.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+
+import { createTranscriptConnector } from '../../src/connectors/transcript.js';
+import { FakeFs } from '../__fixtures__/fs.js';
+
+const NOW = '2026-05-09T12:00:00.000Z';
+const SINCE = '2026-05-08T12:00:00.000Z';
+
+function bigBody(): string { return 'x'.repeat(2000); }
+
+describe('transcript connector', () => {
+  it('finds transcript-shaped files in window', async () => {
+    const fs = new FakeFs()
+      .addDir('/sessions')
+      .addDir('/sessions/run-1')
+      .addFile('/sessions/run-1/handoff.md', bigBody(), '2026-05-09T03:00:00.000Z')
+      .addFile('/sessions/run-1/error.log', bigBody(), '2026-05-09T04:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/sessions', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.find(f => f.key.endsWith('handoff.md'))?.kind).toBe('transcript-handoff');
+    expect(r.findings.find(f => f.key.endsWith('error.log'))?.kind).toBe('transcript-failure');
+  });
+
+  it('returns warning + empty when root missing', async () => {
+    const fs = new FakeFs();
+    const c = createTranscriptConnector({ transcriptRoot: '/no/such', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+    expect(r.warnings.length).toBe(1);
+  });
+
+  it('skips files outside time window', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addFile('/s/handoff.md', bigBody(), '2026-04-01T00:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+  });
+
+  it('skips tiny files (heuristic <32 bytes)', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addFile('/s/handoff.md', 'tiny', '2026-05-09T03:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+  });
+
+  it('skips non-transcript extensions', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addFile('/s/blob.bin', bigBody(), '2026-05-09T03:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+  });
+
+  it('respects depth cap', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addDir('/s/a').addDir('/s/a/b').addDir('/s/a/b/c').addDir('/s/a/b/c/d')
+      .addFile('/s/a/b/c/d/handoff.md', bigBody(), '2026-05-09T03:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs, maxDepth: 2 });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBe(0);
+  });
+
+  it('respects maxFindings cap', async () => {
+    const fs = new FakeFs().addDir('/s');
+    for (let i = 0; i < 10; i++) {
+      fs.addFile(`/s/handoff-${i}.md`, bigBody(), '2026-05-09T03:00:00.000Z');
+    }
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs, maxFindings: 3 });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings.length).toBeLessThanOrEqual(3);
+  });
+
+  it('default kind for non-keyword filename is handoff', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addFile('/s/random.md', bigBody(), '2026-05-09T03:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings[0]?.kind).toBe('transcript-handoff');
+  });
+
+  it('tags large files', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addFile('/s/big.md', 'a'.repeat(150_000), '2026-05-09T03:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.findings[0]?.tags).toContain('large');
+  });
+
+  it('finding ids are deterministic across runs', async () => {
+    const fs1 = new FakeFs().addDir('/s').addFile('/s/handoff.md', bigBody(), '2026-05-09T03:00:00.000Z');
+    const fs2 = new FakeFs().addDir('/s').addFile('/s/handoff.md', bigBody(), '2026-05-09T03:00:00.000Z');
+    const c1 = createTranscriptConnector({ transcriptRoot: '/s', fs: fs1 });
+    const c2 = createTranscriptConnector({ transcriptRoot: '/s', fs: fs2 });
+    const r1 = await c1.collect({ sinceIso: SINCE, untilIso: NOW });
+    const r2 = await c2.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r1.findings.map(f => f.id)).toEqual(r2.findings.map(f => f.id));
+  });
+
+  it('emits no warnings on happy path', async () => {
+    const fs = new FakeFs()
+      .addDir('/s')
+      .addFile('/s/handoff.md', bigBody(), '2026-05-09T03:00:00.000Z');
+    const c = createTranscriptConnector({ transcriptRoot: '/s', fs });
+    const r = await c.collect({ sinceIso: SINCE, untilIso: NOW });
+    expect(r.warnings.length).toBe(0);
+  });
+});

--- a/packages/surface/tests/digest.test.ts
+++ b/packages/surface/tests/digest.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+
+import { generateDigest, DigestSizeExceededError } from '../src/digest.js';
+import type { Finding, FindingSource } from '../src/types.js';
+
+function findingFx(over: Partial<Finding> = {}): Finding {
+  return {
+    id: 'f1',
+    source: 'memory',
+    kind: 'memory-updated',
+    key: 'feedback_x.md',
+    title: 'feedback_x.md updated',
+    tsIso: '2026-05-09T01:00:00.000Z',
+    importance: 0.7,
+    tags: ['feedback'],
+    ...over
+  };
+}
+
+const sourceSummary: Record<FindingSource, { collected: number; warnings: readonly string[] }> = {
+  pr: { collected: 0, warnings: [] },
+  memory: { collected: 1, warnings: [] },
+  transcript: { collected: 0, warnings: [] },
+  'connector-error': { collected: 0, warnings: [] }
+};
+
+describe('digest', () => {
+  it('renders a non-empty markdown digest', () => {
+    const d = generateDigest({
+      findings: [findingFx()],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    });
+    expect(d.markdown).toContain('# Surface Digest');
+    expect(d.markdown).toContain('feedback_x.md updated');
+    expect(d.findings.length).toBe(1);
+    expect(d.sizeBytes).toBe(Buffer.byteLength(d.markdown, 'utf-8'));
+  });
+
+  it('groups findings by source in section order', () => {
+    const d = generateDigest({
+      findings: [
+        findingFx({ id: '1', source: 'pr', kind: 'pr-merged', title: 'PR #1 merged' }),
+        findingFx({ id: '2', source: 'memory', title: 'mem' }),
+        findingFx({ id: '3', source: 'transcript', kind: 'transcript-handoff', title: 'tx' })
+      ],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary: {
+        pr: { collected: 1, warnings: [] },
+        memory: { collected: 1, warnings: [] },
+        transcript: { collected: 1, warnings: [] },
+        'connector-error': { collected: 0, warnings: [] }
+      }
+    });
+    const prIdx = d.markdown.indexOf('## Pull Requests');
+    const memIdx = d.markdown.indexOf('## Agent Memory');
+    const txIdx = d.markdown.indexOf('## Agent Transcripts');
+    expect(prIdx).toBeGreaterThan(0);
+    expect(memIdx).toBeGreaterThan(prIdx);
+    expect(txIdx).toBeGreaterThan(memIdx);
+  });
+
+  it('throws DigestSizeExceededError when over cap', () => {
+    const findings: Finding[] = [];
+    for (let i = 0; i < 1000; i++) {
+      findings.push(findingFx({
+        id: `i${i}`,
+        title: 'x'.repeat(1000)
+      }));
+    }
+    expect(() => generateDigest({
+      findings,
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 5000,
+      sourceSummary
+    })).toThrow(DigestSizeExceededError);
+  });
+
+  it('shows source warnings in summary', () => {
+    const ss: typeof sourceSummary = {
+      ...sourceSummary,
+      pr: { collected: 0, warnings: ['rate-limit hit'] }
+    };
+    const d = generateDigest({
+      findings: [],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary: ss
+    });
+    expect(d.markdown).toContain('rate-limit hit');
+  });
+
+  it('renders findings in given order (caller pre-sorts)', () => {
+    const d = generateDigest({
+      findings: [
+        findingFx({ id: 'b', title: 'second' }),
+        findingFx({ id: 'a', title: 'first' })
+      ],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    });
+    const idxFirst = d.markdown.indexOf('first');
+    const idxSecond = d.markdown.indexOf('second');
+    expect(idxSecond).toBeGreaterThan(0);
+    expect(idxFirst).toBeGreaterThan(idxSecond);
+  });
+
+  it('shows "no findings" message when empty', () => {
+    const d = generateDigest({
+      findings: [],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    });
+    expect(d.markdown).toContain('No findings');
+  });
+
+  it('renders finding URL as a markdown link', () => {
+    const d = generateDigest({
+      findings: [findingFx({ url: 'https://x.test/pr/1' })],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    });
+    expect(d.markdown).toContain('https://x.test/pr/1');
+  });
+
+  it('determinism: same input → identical markdown', () => {
+    const args = {
+      findings: [findingFx()],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    } as const;
+    const d1 = generateDigest({ ...args });
+    const d2 = generateDigest({ ...args });
+    expect(d1.markdown).toBe(d2.markdown);
+  });
+
+  it('escapes pipe characters in titles', () => {
+    const d = generateDigest({
+      findings: [findingFx({ title: 'has | pipe' })],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    });
+    expect(d.markdown).toContain('has \\| pipe');
+  });
+
+  it('size is reported truthfully', () => {
+    const d = generateDigest({
+      findings: [findingFx()],
+      dropped: [],
+      generatedAtIso: '2026-05-09T12:00:00.000Z',
+      sinceIso: '2026-05-08T00:00:00.000Z',
+      untilIso: '2026-05-09T00:00:00.000Z',
+      maxBytes: 50_000,
+      sourceSummary
+    });
+    expect(d.sizeBytes).toBe(Buffer.byteLength(d.markdown, 'utf-8'));
+    expect(d.sizeBytes).toBeLessThan(50_000);
+  });
+});

--- a/packages/surface/tests/filter.test.ts
+++ b/packages/surface/tests/filter.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+
+import { applyFilter } from '../src/filter.js';
+import type { Finding } from '../src/types.js';
+
+function fixture(over: Partial<Finding> = {}): Finding {
+  return {
+    id: over.id ?? 'a',
+    source: 'memory',
+    kind: 'memory-updated',
+    key: 'k',
+    title: 't',
+    tsIso: over.tsIso ?? '2026-05-09T01:00:00.000Z',
+    importance: over.importance ?? 0.5,
+    tags: [],
+    ...over
+  };
+}
+
+describe('filter', () => {
+  it('drops findings below floor', () => {
+    const r = applyFilter([
+      fixture({ id: 'low', importance: 0.1 }),
+      fixture({ id: 'high', importance: 0.9 })
+    ], { minImportance: 0.5, maxFindings: 100 });
+    expect(r.kept.length).toBe(1);
+    expect(r.kept[0]?.id).toBe('high');
+    expect(r.dropped.length).toBe(1);
+    expect(r.dropped[0]?.id).toBe('low');
+  });
+
+  it('caps result count and returns overflow as dropped', () => {
+    const arr: Finding[] = [];
+    for (let i = 0; i < 10; i++) {
+      arr.push(fixture({ id: `i${i}`, importance: 0.5 + i * 0.01 }));
+    }
+    const r = applyFilter(arr, { minImportance: 0.0, maxFindings: 3 });
+    expect(r.kept.length).toBe(3);
+    expect(r.dropped.length).toBe(7);
+  });
+
+  it('orders kept by importance desc then ts desc then id asc', () => {
+    const arr: Finding[] = [
+      fixture({ id: 'b', importance: 0.5, tsIso: '2026-05-09T01:00:00.000Z' }),
+      fixture({ id: 'a', importance: 0.5, tsIso: '2026-05-09T01:00:00.000Z' }),
+      fixture({ id: 'c', importance: 0.9, tsIso: '2026-05-09T01:00:00.000Z' }),
+      fixture({ id: 'd', importance: 0.5, tsIso: '2026-05-09T02:00:00.000Z' })
+    ];
+    const r = applyFilter(arr, { minImportance: 0.0, maxFindings: 100 });
+    expect(r.kept.map(f => f.id)).toEqual(['c', 'd', 'a', 'b']);
+  });
+
+  it('handles empty input', () => {
+    const r = applyFilter([], { minImportance: 0.5, maxFindings: 10 });
+    expect(r.kept.length).toBe(0);
+    expect(r.dropped.length).toBe(0);
+  });
+
+  it('keeps everything when floor=0 and cap > size', () => {
+    const arr = [fixture({ id: 'a' }), fixture({ id: 'b' })];
+    const r = applyFilter(arr, { minImportance: 0, maxFindings: 100 });
+    expect(r.kept.length).toBe(2);
+    expect(r.dropped.length).toBe(0);
+  });
+
+  it('keeps overflow ordered correctly across floor + cap interaction', () => {
+    const arr: Finding[] = [
+      fixture({ id: 'low', importance: 0.1 }),
+      fixture({ id: 'a', importance: 0.7 }),
+      fixture({ id: 'b', importance: 0.8 }),
+      fixture({ id: 'c', importance: 0.9 })
+    ];
+    const r = applyFilter(arr, { minImportance: 0.5, maxFindings: 2 });
+    expect(r.kept.map(f => f.id)).toEqual(['c', 'b']);
+    expect(r.dropped.map(f => f.id).sort()).toEqual(['a', 'low']);
+  });
+
+  it('does not mutate input array', () => {
+    const arr: Finding[] = [
+      fixture({ id: 'b', importance: 0.5 }),
+      fixture({ id: 'a', importance: 0.9 })
+    ];
+    const before = arr.map(f => f.id);
+    applyFilter(arr, { minImportance: 0, maxFindings: 100 });
+    expect(arr.map(f => f.id)).toEqual(before);
+  });
+
+  it('floor at exactly equal value keeps the item', () => {
+    const r = applyFilter([fixture({ id: 'x', importance: 0.5 })], {
+      minImportance: 0.5,
+      maxFindings: 10
+    });
+    expect(r.kept.length).toBe(1);
+  });
+
+  it('determinism: stable across two runs', () => {
+    const arr: Finding[] = [
+      fixture({ id: 'a', importance: 0.5 }),
+      fixture({ id: 'b', importance: 0.5 }),
+      fixture({ id: 'c', importance: 0.5 })
+    ];
+    const r1 = applyFilter(arr, { minImportance: 0, maxFindings: 100 });
+    const r2 = applyFilter(arr, { minImportance: 0, maxFindings: 100 });
+    expect(r1.kept.map(f => f.id)).toEqual(r2.kept.map(f => f.id));
+  });
+
+  it('cap=0 returns empty kept and full dropped', () => {
+    const arr = [fixture({ id: 'a' })];
+    const r = applyFilter(arr, { minImportance: 0, maxFindings: 0 });
+    expect(r.kept.length).toBe(0);
+    expect(r.dropped.length).toBe(1);
+  });
+});

--- a/packages/surface/tests/scorer.test.ts
+++ b/packages/surface/tests/scorer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+
+import { defaultScorer, applyScores } from '../src/scorer.js';
+import type { Finding, ScoringContext } from '../src/types.js';
+
+const ctx: ScoringContext = {
+  sinceIso: '2026-05-08T00:00:00.000Z',
+  untilIso: '2026-05-09T00:00:00.000Z'
+};
+
+function f(over: Partial<Finding> = {}): Omit<Finding, 'id' | 'importance'> {
+  return {
+    source: 'memory',
+    kind: 'memory-updated',
+    key: 'k',
+    title: 't',
+    tsIso: '2026-05-08T12:00:00.000Z',
+    tags: [],
+    ...over
+  };
+}
+
+describe('importance scorer', () => {
+  it('returns score in [0,1]', () => {
+    const s = defaultScorer.score(f(), ctx);
+    expect(s).toBeGreaterThanOrEqual(0);
+    expect(s).toBeLessThanOrEqual(1);
+  });
+
+  it('newer events score higher than older', () => {
+    const newer = defaultScorer.score(f({ tsIso: '2026-05-08T23:00:00.000Z' }), ctx);
+    const older = defaultScorer.score(f({ tsIso: '2026-05-08T01:00:00.000Z' }), ctx);
+    expect(newer).toBeGreaterThan(older);
+  });
+
+  it('🚨 keyword bumps title weight', () => {
+    const noEmoji = defaultScorer.score(f({ title: 'phase 0 live' }), ctx);
+    const withEmoji = defaultScorer.score(f({ title: '🚨 phase 0 live' }), ctx);
+    expect(withEmoji).toBeGreaterThan(noEmoji);
+  });
+
+  it('BLOCKED in title increases score', () => {
+    const a = defaultScorer.score(f({ title: 'something' }), ctx);
+    const b = defaultScorer.score(f({ title: 'BLOCKED something' }), ctx);
+    expect(b).toBeGreaterThan(a);
+  });
+
+  it('feedback tag boosts above plain memory-updated', () => {
+    const plain = defaultScorer.score(f({ tags: [] }), ctx);
+    const fb = defaultScorer.score(f({ tags: ['feedback'] }), ctx);
+    expect(fb).toBeGreaterThan(plain);
+  });
+
+  it('pr-stale severity is higher than pr-opened', () => {
+    const opened = defaultScorer.score(f({ source: 'pr', kind: 'pr-opened' }), ctx);
+    const stale = defaultScorer.score(f({ source: 'pr', kind: 'pr-stale' }), ctx);
+    expect(stale).toBeGreaterThan(opened);
+  });
+
+  it('transcript-failure scored higher than transcript-handoff', () => {
+    const ok = defaultScorer.score(f({ source: 'transcript', kind: 'transcript-handoff' }), ctx);
+    const fail = defaultScorer.score(f({ source: 'transcript', kind: 'transcript-failure' }), ctx);
+    expect(fail).toBeGreaterThan(ok);
+  });
+
+  it('NaN-ts tolerated', () => {
+    const s = defaultScorer.score(f({ tsIso: 'garbage' }), ctx);
+    expect(s).toBeGreaterThanOrEqual(0);
+    expect(s).toBeLessThanOrEqual(1);
+  });
+
+  it('unknown kind falls back to default severity', () => {
+    const s = defaultScorer.score(f({ kind: 'connector-degraded' as never }), ctx);
+    expect(s).toBeGreaterThanOrEqual(0);
+  });
+
+  it('size signal reflects sizeBytes meta', () => {
+    const small = defaultScorer.score(f({ meta: { sizeBytes: 10 } }), ctx);
+    const large = defaultScorer.score(f({ meta: { sizeBytes: 100_000 } }), ctx);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('applyScores attaches importance to every finding', () => {
+    const arr = [f(), f({ tsIso: '2026-05-08T01:00:00.000Z' })].map((x, i) => ({
+      ...x,
+      id: `id-${i}`
+    }));
+    const scored = applyScores(arr, ctx);
+    expect(scored.length).toBe(2);
+    expect(scored[0]?.importance).toBeDefined();
+    expect(scored[1]?.importance).toBeDefined();
+  });
+
+  it('determinism: identical input produces identical scores', () => {
+    const x = f({ title: 'phase 0 live', tags: ['feedback', 'live'] });
+    const a = defaultScorer.score(x, ctx);
+    const b = defaultScorer.score(x, ctx);
+    expect(a).toBe(b);
+  });
+});

--- a/packages/surface/tsconfig.build.json
+++ b/packages/surface/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/surface/tsconfig.json
+++ b/packages/surface/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/surface/vitest.config.ts
+++ b/packages/surface/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules', 'src/cli.ts']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1905,6 +1905,21 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  packages/surface:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      '@vitest/coverage-v8':
+        specifier: 1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.39)(jsdom@26.1.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/system-prompt-block:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
# Surface Agent — Phase 0 skeleton (item 11)

Implements **item 11** of `master_backlog_sequencing_2026-05-05.md` (Tier-A operator-replacement agent A3 of `agent_ecosystem_expansion_directive.md`). Confirmed PENDING in `backlog_reconciliation_2026-05-09.md` §3.

## What it does

`@chiefaia/surface` is an operator-curation lens. It reads PR activity, agent-memory deltas, and agent transcripts; scores each finding by importance; and emits a single markdown digest under a hard size cap. The operator gets a curated "what matters" view rather than a firehose.

```
caia-surface generate --since "1 day ago" --output ~/Documents/projects/reports/digest-2026-05-09.md
```

## Scope (Phase 0)

- **Three subscription-free connectors** — `gh pr list` for PRs, `git log --name-status` (with fs-mtime fallback) for memory deltas, filesystem walk by metadata for transcripts. No API keys.
- **Heuristic importance scorer** — `0.4·recency + 0.3·tag_weight + 0.2·severity_weight + 0.1·size_signal`. Stateless, deterministic.
- **Filter** — drops below `minImportance` (default 0.35), caps at `maxFindings` (default 100). Stable order.
- **Markdown digest** — grouped by source, hard 50 KB cap (throws `DigestSizeExceededError` when exceeded).
- **CLI** — `caia-surface generate --since --output [...]`, with `--gh-repo --corpus-root --transcript-root --max-bytes --min-importance --max-findings`.

## Out of scope (later phases)

- Phase 1: Telegram + Slack delivery, cron schedule (LaunchAgent), delta-since-last-run state.
- Phase 2: LLM-rephrasing tier (subscription `claude` binary + Apprentice operator-style adapter).
- Phase 3: feedback loop (operator reactions feed Mentor + Apprentice eval).
- Phase 4: cross-source dedup.

## Option E checklist (per `agent_architecture_shape_2026-05-06.md`)

| Check | Status |
|---|---|
| `package.json` has `"private": true` | ✅ |
| Public API parameterised — every CAIA path / repo / threshold is a constructor arg with default | ✅ (`SurfaceAgentConfig` ↔ `resolveConfig`) |
| Tests use fixture filesystems / fake runners; no live CAIA paths | ✅ (`FakeFs`, `FakeGh`, `FakeGit`) |
| Pre-spawn injection compatible — Phase 0 has no LLM call; Phase 2 LLM tier will use Mentor + Librarian via standard pipeline | ✅ |
| Not published, no second-customer abstraction | ✅ |

## Stop conditions verified

- **Package conflict** — none. `@chiefaia/surface` was not present.
- **API-key sources** — only `gh` CLI (operator's existing PAT) and local fs reads. No Slack/Telegram in this PR.
- **Digest > 50 KB** — fail-closed via `DigestSizeExceededError` with message "importance filter not strict enough." Tested.

## Determinism

Given identical sources + clock, two runs produce byte-identical digests. Test asserts this.

## Evidence

- 86 tests across 8 files — all green
- `pnpm typecheck` — green (`tsc --noEmit`)
- `pnpm build` — green (`tsc -p tsconfig.build.json`)
- CLI smoke — `node dist/cli.js` prints help

## Files

- New: `packages/surface/{package.json,tsconfig.json,tsconfig.build.json,vitest.config.ts,DESIGN.md,src/...,tests/...}` (29 files)
- Modified: `pnpm-lock.yaml` (only adds `packages/surface` importer block; no other workspace changes)

## Memory

- Filed: `agent-memory/surface_agent_directive.md` (directive — full Phase-roadmap)
- Filed (separate commit on memory repo): `agent-memory/surface_phase0_live_2026-05-09.md` (completion memo) + `agent-memory/surface_phase1_brief.md` (auto-perpetuation hook for Phase 1)

## Standing rules followed

- Subscription-only LLM (no LLM calls in Phase 0; future phases use subscription `claude` binary)
- Git Flow + Evidence Gate + worktree isolation (built in `.claude/worktrees/surface-001/`)
- Decide → execute → inform — no options presented to operator
- Determinism / fail-closed / size cap

Closes part of `master_backlog_sequencing_2026-05-05.md` item 11. Phase 1 will auto-spawn per `feedback_self_perpetuating_campaigns.md`.
