### PR TITLE
ci: skip self-approval in Code Reviewer workflow

### DIFF
--- a/.github/workflows/code-reviewer.yml
+++ b/.github/workflows/code-reviewer.yml
@@ -147,7 +147,49 @@ jobs:
         run: |
           gh pr comment "$PR_NUMBER" --body-file /tmp/comment.md
 
+      - name: Detect self-authored PR
+        # GitHub rejects PR reviews when the authenticated token user equals
+        # the PR author with "Can not approve your own pull request". The
+        # autonomous-loop pipeline opens PRs under the same identity that
+        # owns GH_TOKEN, so any review submission for those PRs would 422
+        # and turn the required `Code Reviewer (blocking)` check red even
+        # when the LLM verdict was `approve`. We detect that case here and
+        # gate the submission step on the result. The verdict has already
+        # been posted as a regular PR comment above, so reviewers (human or
+        # bot) still see the LLM output. Job exit code below preserves the
+        # required-check semantics: approve/comment -> 0 (green),
+        # request-changes -> 1 (red).
+        id: self_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set +e
+          TOKEN_LOGIN=$(gh api user --jq .login 2>/dev/null)
+          rc=$?
+          set -e
+          if [ $rc -ne 0 ] || [ -z "$TOKEN_LOGIN" ]; then
+            # If we can't resolve the token identity (e.g. a fine-grained
+            # token without /user scope), fall through and let the review
+            # submission step run. GitHub will still reject self-approvals
+            # with a clear error, which is no worse than the prior state.
+            TOKEN_LOGIN="unknown"
+          fi
+          echo "token_login=$TOKEN_LOGIN" >> "$GITHUB_OUTPUT"
+          if [ "$TOKEN_LOGIN" = "$PR_AUTHOR" ]; then
+            echo "self_authored=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Code Reviewer: PR author ($PR_AUTHOR) matches GH_TOKEN identity ($TOKEN_LOGIN) — skipping review submission to avoid GitHub self-approval rejection. Verdict posted as a regular comment instead."
+            {
+              echo "### Code Reviewer self-approval skip"
+              echo ""
+              echo "PR author \`$PR_AUTHOR\` equals GH_TOKEN identity \`$TOKEN_LOGIN\`. GitHub disallows self-reviews, so the review submission was skipped. The LLM verdict was posted as a regular PR comment, and this job's exit code reflects the verdict (approve/comment -> green, request-changes -> red)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "self_authored=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Submit PR review (approve / request-changes)
+        if: steps.self_check.outputs.self_authored != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Why

The `Code Reviewer (blocking)` workflow currently calls `gh pr review --approve` (or `--request-changes`) using `GH_TOKEN`. When the PR was opened by the same identity that owns `GH_TOKEN` — which is the case for every PR opened by the autonomous-loop pipeline (`prakashgbid`) — GitHub rejects the review with:

> Can not approve your own pull request

That 422 fails the step, the job exits non-zero, and the required `Code Reviewer (blocking)` check goes red even when the LLM verdict was `approve`. PR #407 is currently blocked exactly this way (LLM said approve, submission failed).

This will hit every autonomous PR until fixed, so it is a hard prerequisite for backlog drain.

## What changed

A new `Detect self-authored PR` step resolves the `GH_TOKEN` identity via `gh api user --jq .login` and compares it against `github.event.pull_request.user.login`.

- **When they match (self-authored):** the existing `Submit PR review` step is skipped via `if:`. The verdict was already posted as a regular PR comment in the prior step, and a `::notice::` annotation plus a `$GITHUB_STEP_SUMMARY` block records the skip so the audit trail is preserved.
- **When they don't match:** the original review-submission path runs unchanged. PRs from any other user (or a future dedicated bot account) still get a real GitHub review.

Job exit semantics are preserved: the `Fail job on request-changes` step still fires for `request-changes` verdicts, so the required-check name (`Code Reviewer (blocking)`) and its red/green semantics continue to track the LLM verdict (approve/comment → green, request-changes → red). Branch protection continues to match by name — no settings change required.

If `gh api user` cannot resolve the token identity (e.g. a fine-grained token without `/user` scope), the step falls through and the existing review-submission path runs — no worse than the prior state.

## Followup (out of scope tonight)

The cleaner long-term fix is to rotate the autonomous-loop's PR-opening identity to a dedicated bot account distinct from `GH_TOKEN`'s identity. With separate identities, the reviewer would submit a real GitHub review (counting toward branch-protection "approving review" requirements) instead of falling back to a comment. Identity rotation is a non-trivial change to the orchestrator and is being tracked separately.

## Verification plan

1. Wait for CI on this PR. Because this PR is itself opened by `prakashgbid`, it will exercise the new self-approval-skip path on its own `Code Reviewer (blocking)` run. Expected outcome: comment posted with verdict, review submission skipped, job exits 0 (or 1 if the LLM requests changes), check reflects the verdict.
2. After merge, retrigger the Code Reviewer workflow on PR #407 (or push an empty commit) and confirm it ends green with a posted comment instead of a failed review submission.

Spawned-By: caia-orchestrator-ci-fix
