### PR TITLE
feat(local-llm-router): HTTP daemon + MCP shim + python client (L4-L9 of Local-LLM-First build plan)

### DIFF
--- a/packages/local-llm-router-mcp/package.json
+++ b/packages/local-llm-router-mcp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@chiefaia/local-llm-router-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP stdio server that exposes the local-llm-router daemon as 5 Cowork tools (local_classify, local_summarize, local_draft, local_format, local_search_memory).",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "caia-local-llm-router-mcp": "./dist/bin/server.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@chiefaia/tsconfig": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module"
+}

--- a/packages/local-llm-router-mcp/src/bin/server.ts
+++ b/packages/local-llm-router-mcp/src/bin/server.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// MCP stdio server for the local-llm-router daemon.
+//
+// Exposes 5 Cowork tools:
+//   local_classify(task_spec)         → IntentResult JSON
+//   local_summarize(text, max_tokens) → summary string
+//   local_draft(brief, max_tokens)    → drafted prose
+//   local_format(text, instruction)   → reformatted text
+//   local_search_memory(query, k)     → top-k memory results (embedding lookup)
+//
+// All RPC the local daemon at ROUTER_BASE_URL (default http://127.0.0.1:7411).
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const ROUTER_BASE_URL = process.env.ROUTER_BASE_URL ?? 'http://127.0.0.1:7411';
+
+interface ToolInput {
+  task_spec?: string;
+  text?: string;
+  brief?: string;
+  query?: string;
+  instruction?: string;
+  max_tokens?: number;
+  k?: number;
+}
+
+const server = new Server(
+  { name: 'caia-local-llm-router-mcp', version: '0.1.0' },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'local_classify',
+        description: 'Classify a task spec into a CAIA intent + recommended tier (local-7b/14b/32b/claude). Routes via the local-llm-router daemon at ' + ROUTER_BASE_URL + '. Use BEFORE invoking heavy reasoning to decide if the task can be served locally.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            task_spec: { type: 'string', description: 'The task description to classify.' },
+          },
+          required: ['task_spec'],
+        },
+      },
+      {
+        name: 'local_summarize',
+        description: 'Summarize text via local 7B model. Use for tool outputs, log dumps, file contents that need to be compressed before reasoning. Returns ≤max_tokens of summary.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'Text to summarize.' },
+            max_tokens: { type: 'integer', description: 'Hard cap on response tokens (default 800).', default: 800 },
+          },
+          required: ['text'],
+        },
+      },
+      {
+        name: 'local_draft',
+        description: 'Draft a prose response (memo, status update, brief reply) via local 7B model.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            brief: { type: 'string', description: 'What to draft (prompt + context).' },
+            max_tokens: { type: 'integer', description: 'Hard cap on response tokens (default 1200).', default: 1200 },
+          },
+          required: ['brief'],
+        },
+      },
+      {
+        name: 'local_format',
+        description: 'Reformat / restructure text via local 7B model (e.g., bullets→prose, JSON→YAML, casing). Deterministic, low temperature.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'Text to reformat.' },
+            instruction: { type: 'string', description: 'How to reformat it.' },
+          },
+          required: ['text', 'instruction'],
+        },
+      },
+      {
+        name: 'local_search_memory',
+        description: 'Embed the query and search the agent-memory index (sqlite-vec + nomic-embed-text). Returns top-k semantically similar memory entries. Use for "is there a memory file about X" lookups before deep-reading the index.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Natural-language query.' },
+            k: { type: 'integer', description: 'Number of results to return (default 5).', default: 5 },
+          },
+          required: ['query'],
+        },
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const name = request.params.name;
+  const args = (request.params.arguments ?? {}) as ToolInput;
+
+  try {
+    if (name === 'local_classify') {
+      const r = await fetch(`${ROUTER_BASE_URL}/v1/intent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ task_spec: args.task_spec }),
+      });
+      const body = await r.json();
+      return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }] };
+    }
+
+    if (name === 'local_summarize' || name === 'local_draft' || name === 'local_format') {
+      const userText = name === 'local_summarize' ? args.text
+        : name === 'local_draft' ? args.brief
+        : `${args.instruction}\n\nTEXT:\n${args.text}`;
+      const sysPrompt = name === 'local_summarize'
+        ? `Summarize the following text. Be concise. Plain prose, no preamble.`
+        : name === 'local_draft'
+        ? `Draft a response per the user's brief. Plain prose, no preamble.`
+        : `Reformat the text per the instruction. Output only the reformatted text, no commentary.`;
+      const maxTokens = args.max_tokens ?? (name === 'local_summarize' ? 800 : name === 'local_draft' ? 1200 : 600);
+      const r = await fetch(`${ROUTER_BASE_URL}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'qwen2.5-coder:7b',
+          messages: [
+            { role: 'system', content: sysPrompt },
+            { role: 'user', content: userText },
+          ],
+          max_tokens: maxTokens,
+          temperature: 0.2,
+          caia_task_type: name === 'local_summarize' ? 'summarize-tool-output'
+                         : name === 'local_draft' ? 'draft-prose'
+                         : 'format-text',
+        }),
+      });
+      const body = await r.json() as { choices?: Array<{ message?: { content?: string } }>; error?: string };
+      const out = body.choices?.[0]?.message?.content ?? `(error: ${body.error ?? 'no-content'})`;
+      return { content: [{ type: 'text', text: out }] };
+    }
+
+    if (name === 'local_search_memory') {
+      // Stub: hits /v1/embeddings to embed the query, then would look up against
+      // a sqlite-vec index. The index doesn't exist yet (L6 deferred), so for
+      // now we return the embedding shape only.
+      const r = await fetch(`${ROUTER_BASE_URL}/v1/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input: args.query, model: 'nomic-embed-text' }),
+      });
+      const body = await r.json() as { data?: Array<{ embedding?: number[] }> };
+      const dims = body.data?.[0]?.embedding?.length ?? 0;
+      return {
+        content: [{
+          type: 'text',
+          text: `local_search_memory: query embedded (${dims} dims). Memory index not yet built (L6 of router build plan deferred). Falling back to: grep on ~/Documents/projects/agent-memory/ recommended.`,
+        }],
+      };
+    }
+
+    return { content: [{ type: 'text', text: `unknown-tool: ${name}` }], isError: true };
+  } catch (e) {
+    return {
+      content: [{ type: 'text', text: `error: ${(e as Error).message}` }],
+      isError: true,
+    };
+  }
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+console.error('caia-local-llm-router-mcp ready (stdio); routing to', ROUTER_BASE_URL);

--- a/packages/local-llm-router-mcp/src/index.ts
+++ b/packages/local-llm-router-mcp/src/index.ts
@@ -1,0 +1,4 @@
+// @chiefaia/local-llm-router-mcp — MCP stdio server bridging Cowork
+// to the local-llm-router daemon. Entry point lives in bin/server.ts.
+
+export {};

--- a/packages/local-llm-router-mcp/tsconfig.json
+++ b/packages/local-llm-router-mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "ES2022",
+    "lib": ["ES2022"]
+  },
+  "include": ["src"]
+}

--- a/packages/local-llm-router-py-client/README.md
+++ b/packages/local-llm-router-py-client/README.md
@@ -1,0 +1,52 @@
+# `@chiefaia/local-llm-router-py-client`
+
+Python client for the local-llm-router HTTP daemon. Vendored into
+`claude_spawner_agent.py` deployments to add the **pre-spawn classify-and-maybe-route gate** (L9/L10 of the Local-LLM-First build plan).
+
+## Why a separate package
+
+The spawner is operator-deployed Python sitting outside the npm workspace
+graph. We still want the routing-client code under version control in caia
+so the M3 + stolution copies stay in sync. This package is the source of
+truth; deployments vendor `src/local_llm_router_client.py` next to their
+`claude_spawner_agent.py`.
+
+## Installation (deployment)
+
+```bash
+# On M3 (when M3 spawner enrollment completes):
+cp src/local_llm_router_client.py \
+   ~/Documents/projects/reports/claude-spawner-agent/
+
+# On stolution:
+ssh stolution 'cat' > /home/s903/apps/claude-spawner/local_llm_router_client.py < src/local_llm_router_client.py
+```
+
+Then apply `src/spawner_patch.diff` with `patch -p0` from the spawner's
+working directory. Restart the spawner.
+
+## Environment variables (read by the patch)
+
+| Var | Default | Description |
+|---|---|---|
+| `LOCAL_LLM_ROUTER_URL` | `http://100.68.247.58:7411` | M3 Tailscale-private daemon URL |
+| `LOCAL_LLM_ROUTER_TIMEOUT` | `10.0` | Per-call HTTP timeout (seconds) |
+| `ROUTER_GATE_ENABLED` | `true` | Set to `false` to bypass the gate without redeploying |
+
+## Smoke test
+
+```bash
+python3 src/local_llm_router_client.py "rename foo to bar in helpers.ts"
+```
+
+Expected output: `intent: rename`, `recommended_tier: local-7b`, then a
+local-7b response. If the daemon is unreachable, the helper returns
+`(None, {tier: "claude", reason: "router-unreachable"})` so the caller
+falls through to the existing claude subprocess.
+
+## Operator approval required before merge
+
+The reference patch in `src/spawner_patch.diff` modifies the `/spawn`
+handler — production-critical code. Operator should review the diff,
+test on a non-production spawner first, and apply with `patch -p0`
+manually. Do NOT auto-deploy.

--- a/packages/local-llm-router-py-client/package.json
+++ b/packages/local-llm-router-py-client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@chiefaia/local-llm-router-py-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Python client for the local-llm-router daemon. Vendored into claude-spawner-agent on M1+M3+stolution to add the pre-spawn classify-and-maybe-route gate. Pure stdlib (no pip deps); HTTP via urllib.",
+  "files": ["src/local_llm_router_client.py", "src/spawner_patch.diff", "README.md"]
+}

--- a/packages/local-llm-router-py-client/src/local_llm_router_client.py
+++ b/packages/local-llm-router-py-client/src/local_llm_router_client.py
@@ -1,0 +1,172 @@
+"""
+Python client for the local-llm-router HTTP daemon.
+
+Vendored copy lives next to claude_spawner_agent.py on each spawner host:
+  - M3 spawner:        ~/Documents/projects/reports/claude-spawner-agent/
+  - stolution spawner: /home/s903/apps/claude-spawner/
+
+Pure stdlib (urllib.request) — no pip deps to add to the spawner venv.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_BASE_URL = os.environ.get("LOCAL_LLM_ROUTER_URL", "http://100.68.247.58:7411")
+DEFAULT_TIMEOUT = float(os.environ.get("LOCAL_LLM_ROUTER_TIMEOUT", "10.0"))
+
+
+@dataclass
+class IntentResult:
+    intent: str
+    confidence: float
+    needs_escalation: bool
+    recommended_tier: str  # 'local-7b' | 'local-14b' | 'local-32b' | 'claude' | 'stolution-batch'
+    reasoning: str
+    latency_ms: int
+    classifier_model: str
+
+    @property
+    def use_local(self) -> bool:
+        return self.recommended_tier.startswith("local-")
+
+    @property
+    def passthrough_to_claude(self) -> bool:
+        return self.recommended_tier == "claude"
+
+
+def classify(task_spec: str, base_url: str = DEFAULT_BASE_URL,
+             timeout: float = DEFAULT_TIMEOUT) -> Optional[IntentResult]:
+    """Classify a task spec via the router daemon. Returns None on any failure
+    (caller should default to claude path on None)."""
+    body = json.dumps({"task_spec": task_spec}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/intent",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+        return None
+    return IntentResult(
+        intent=payload.get("intent", "unknown"),
+        confidence=float(payload.get("confidence", 0.0)),
+        needs_escalation=bool(payload.get("needs_escalation", True)),
+        recommended_tier=payload.get("recommended_tier", "claude"),
+        reasoning=payload.get("reasoning", ""),
+        latency_ms=int(payload.get("latency_ms", 0)),
+        classifier_model=payload.get("classifier_model", "unknown"),
+    )
+
+
+def execute_local(task_spec: str, recommended_tier: str,
+                  base_url: str = DEFAULT_BASE_URL,
+                  timeout: float = 60.0) -> Optional[str]:
+    """Execute a task on the local model via /v1/chat/completions. Returns the
+    response string, or None on failure (caller falls back to claude binary)."""
+    # Map tier to model
+    model = {
+        "local-7b": "qwen2.5-coder:7b",
+        "local-14b": "qwen2.5-coder:14b",
+        "local-32b": "qwen2.5-coder:32b",
+    }.get(recommended_tier, "qwen2.5-coder:7b")
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": task_spec}],
+        "caia_task_type": "spawner-routed",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+        return None
+    choices = payload.get("choices", [])
+    if not choices:
+        return None
+    return choices[0].get("message", {}).get("content")
+
+
+def health(base_url: str = DEFAULT_BASE_URL, timeout: float = 3.0) -> bool:
+    """Quick health probe — returns True if daemon is reachable + healthy."""
+    try:
+        with urllib.request.urlopen(f"{base_url}/healthz", timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+            return bool(payload.get("ok") and payload.get("ollama", {}).get("ok"))
+    except Exception:
+        return False
+
+
+def classify_and_maybe_route(task_spec: str,
+                              base_url: str = DEFAULT_BASE_URL,
+                              max_local_latency_s: float = 90.0) -> tuple[Optional[str], dict]:
+    """High-level helper for spawners.
+
+    Returns (local_response, metadata):
+      - If local can handle: (response_text, {model: ..., tier: ..., classifier_latency_ms: ..., exec_latency_ms: ...})
+      - If must escalate to claude: (None, {tier: 'claude', reason: ...})
+
+    Metadata is always populated for spawn-record write-through.
+    """
+    t0 = time.time()
+    intent = classify(task_spec, base_url=base_url)
+    if intent is None:
+        return None, {"tier": "claude", "reason": "router-unreachable"}
+    if intent.passthrough_to_claude or intent.needs_escalation:
+        return None, {
+            "tier": "claude",
+            "reason": f"router-recommends-claude (intent={intent.intent}, conf={intent.confidence:.2f})",
+            "classifier_latency_ms": intent.latency_ms,
+            "classifier_model": intent.classifier_model,
+        }
+    if not intent.use_local:
+        return None, {"tier": intent.recommended_tier, "reason": "non-local-non-claude-tier"}
+    # Try local execution
+    response = execute_local(task_spec, intent.recommended_tier,
+                              base_url=base_url, timeout=max_local_latency_s)
+    if response is None:
+        return None, {
+            "tier": "claude",
+            "reason": "local-execute-failed",
+            "intended_tier": intent.recommended_tier,
+            "classifier_latency_ms": intent.latency_ms,
+        }
+    return response, {
+        "tier": intent.recommended_tier,
+        "model": {
+            "local-7b": "qwen2.5-coder:7b",
+            "local-14b": "qwen2.5-coder:14b",
+            "local-32b": "qwen2.5-coder:32b",
+        }.get(intent.recommended_tier, "qwen2.5-coder:7b"),
+        "classifier_latency_ms": intent.latency_ms,
+        "exec_latency_ms": int((time.time() - t0) * 1000) - intent.latency_ms,
+        "intent": intent.intent,
+        "confidence": intent.confidence,
+        "claude_invoked": False,
+    }
+
+
+if __name__ == "__main__":
+    # CLI smoke test
+    import sys
+    spec = sys.argv[1] if len(sys.argv) > 1 else "Rename foo to bar in helpers.ts"
+    print(f"healthz: {health()}")
+    intent = classify(spec)
+    print(f"intent: {intent}")
+    response, meta = classify_and_maybe_route(spec)
+    print(f"response: {response}")
+    print(f"meta: {meta}")

--- a/packages/local-llm-router-py-client/src/spawner_patch.diff
+++ b/packages/local-llm-router-py-client/src/spawner_patch.diff
@@ -1,0 +1,70 @@
+# Reference patch for claude_spawner_agent.py
+#
+# Adds the pre-spawn classify-and-maybe-route gate per L9/L10 of the
+# Local-LLM-First build plan. Apply on M3 + stolution copies of the spawner.
+#
+# DO NOT auto-apply — operator review required. The patch:
+#   1. Imports the vendored local_llm_router_client module (sibling of spawner)
+#   2. In the /spawn handler, before subprocess.spawn(claude_binary, ...),
+#      calls classify_and_maybe_route(task_spec)
+#   3. If local can handle: write a spawn record with model_used=local, claude_invoked=false; return without spawning claude
+#   4. Else: existing claude path unchanged
+#
+# Apply with: cd <spawner-dir>; patch -p0 < spawner_patch.diff
+
+--- claude_spawner_agent.py
++++ claude_spawner_agent.py
+@@ -1,6 +1,7 @@
+ #!/usr/bin/env python3
+ import asyncio
+ import json
+ import os
+ import subprocess
+ import time
+ import uuid
++from local_llm_router_client import classify_and_maybe_route, health
+@@ -10,6 +11,12 @@
+ CLAUDE_BINARY = os.environ.get("CLAUDE_BINARY", "/opt/homebrew/bin/claude")
++ROUTER_URL = os.environ.get("LOCAL_LLM_ROUTER_URL", "http://100.68.247.58:7411")
++ROUTER_GATE_ENABLED = os.environ.get("ROUTER_GATE_ENABLED", "true").lower() in ("1", "true", "yes")
+
+@@ -120,6 +127,40 @@
+ async def handle_spawn(body: SpawnRequest) -> SpawnResponse:
+     """Spawn a claude subprocess for the given task."""
+     spawn_id = str(uuid.uuid4())
++
++    # ── L9/L10 pre-spawn classify-and-maybe-route gate ─────────────────
++    if ROUTER_GATE_ENABLED and health(ROUTER_URL):
++        local_response, route_meta = classify_and_maybe_route(
++            body.task_spec, base_url=ROUTER_URL,
++        )
++        if local_response is not None:
++            # Local handled it — write a spawn record and return without claude
++            record = {
++                "spawn_id": spawn_id,
++                "task_spec": body.task_spec[:200],
++                "outcome": "local_completed",
++                "model_used": route_meta.get("model"),
++                "tier": route_meta.get("tier"),
++                "claude_invoked": False,
++                "classifier_latency_ms": route_meta.get("classifier_latency_ms"),
++                "exec_latency_ms": route_meta.get("exec_latency_ms"),
++                "intent": route_meta.get("intent"),
++                "confidence": route_meta.get("confidence"),
++                "response_preview": local_response[:200],
++                "ts_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
++            }
++            await write_spawn_record(record)
++            return SpawnResponse(
++                spawn_id=spawn_id,
++                status="local_completed",
++                output=local_response,
++                model=route_meta.get("model"),
++            )
++        # else: route_meta tells us why we're falling through to claude
++        # (router unreachable, recommends-claude, local-execute-failed, ...)
++        # The metadata is logged but spawn proceeds to claude as before.
++
+     # ── Existing claude binary spawn (unchanged) ───────────────────────
+     proc = subprocess.Popen(
+         [CLAUDE_BINARY, "--print", "--output-format", "json"],

--- a/packages/local-llm-router/package.json
+++ b/packages/local-llm-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiefaia/local-llm-router",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "LLM routing layer — dispatches tasks to local Ollama models or Claude API based on complexity and cost rules",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,6 +39,11 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
     "@opentelemetry/resources": "^2.7.0",
-    "@opentelemetry/sdk-node": "^0.215.0"
+    "@opentelemetry/sdk-node": "^0.215.0",
+    "hono": "^4.12.14",
+    "@hono/node-server": "^1.13.0"
+  },
+  "bin": {
+    "caia-llm-router-daemon": "./dist/bin/router-daemon.js"
   }
 }

--- a/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
+++ b/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  com.chiefaia.local-llm-router.plist
+
+  Always-on LaunchAgent for the local-llm-router daemon. Listens on
+  port 7411 over 0.0.0.0 (Tailscale ACL is the auth boundary).
+
+  Install:
+    pnpm --filter @chiefaia/local-llm-router build
+    cp packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.chiefaia.local-llm-router.plist
+
+  Uninstall:
+    launchctl bootout gui/$(id -u)/com.chiefaia.local-llm-router
+    rm ~/Library/LaunchAgents/com.chiefaia.local-llm-router.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.chiefaia.local-llm-router</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/opt/node@22/bin/node</string>
+    <string>/Users/macbook32/Documents/projects/caia/packages/local-llm-router/dist/bin/router-daemon.js</string>
+    <string>--port</string>
+    <string>7411</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OLLAMA_BASE_URL</key>
+    <string>http://127.0.0.1:11434</string>
+    <key>ROUTER_CLASSIFIER_MODEL</key>
+    <string>qwen2.5-coder:7b</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>NetworkState</key>
+    <true/>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/macbook32/Library/Logs/chiefaia/local-llm-router.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/macbook32/Library/Logs/chiefaia/local-llm-router.err.log</string>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/macbook32/Documents/projects/caia/packages/local-llm-router</string>
+
+  <key>ProcessType</key>
+  <string>Interactive</string>
+</dict>
+</plist>

--- a/packages/local-llm-router/src/bin/router-daemon.ts
+++ b/packages/local-llm-router/src/bin/router-daemon.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Entrypoint for the local-llm-router daemon.
+// Usage:
+//   caia-llm-router-daemon [--port <n>] [--ollama-url <url>] [--classifier-model <name>]
+//
+// Defaults:
+//   --port 7411
+//   --ollama-url http://127.0.0.1:11434  (or env OLLAMA_BASE_URL)
+//   --classifier-model qwen2.5-coder:7b  (or env ROUTER_CLASSIFIER_MODEL;
+//                                          will become qwen2.5-coder-7b-caia-apprentice
+//                                          once the LoRA is trained)
+
+import { serve } from '@hono/node-server';
+import { buildApp, DEFAULT_ROUTER_PORT } from '../server.js';
+
+interface Args {
+  port: number;
+  ollamaUrl: string | undefined;
+  classifierModel: string | undefined;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    port: Number(process.env['ROUTER_PORT'] ?? DEFAULT_ROUTER_PORT),
+    ollamaUrl: process.env['OLLAMA_BASE_URL'],
+    classifierModel: process.env['ROUTER_CLASSIFIER_MODEL'],
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--port' && i + 1 < argv.length) { out.port = Number(argv[++i]); }
+    else if (a === '--ollama-url' && i + 1 < argv.length) { out.ollamaUrl = argv[++i]; }
+    else if (a === '--classifier-model' && i + 1 < argv.length) { out.classifierModel = argv[++i]; }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  console.log(`caia-llm-router-daemon — local-llm-router HTTP daemon
+
+Usage:
+  caia-llm-router-daemon [options]
+
+Options:
+  --port <n>                  Listen port (default ${DEFAULT_ROUTER_PORT}, env ROUTER_PORT)
+  --ollama-url <url>          Ollama base URL (env OLLAMA_BASE_URL)
+  --classifier-model <name>   Classifier model tag (env ROUTER_CLASSIFIER_MODEL)
+  -h, --help                  Show this help
+
+Endpoints:
+  GET  /healthz
+  GET  /metrics
+  POST /v1/intent             { task_spec }
+  POST /v1/route              { task_type, prompt }
+  POST /v1/chat/completions   OpenAI-compatible
+  POST /v1/embeddings         OpenAI-compatible
+`);
+  process.exit(0);
+}
+
+const app = buildApp({
+  ...(args.ollamaUrl !== undefined ? { ollamaBaseUrl: args.ollamaUrl } : {}),
+  ...(args.classifierModel !== undefined ? { classifierModel: args.classifierModel } : {}),
+});
+
+const port = Number.isFinite(args.port) ? args.port : DEFAULT_ROUTER_PORT;
+
+serve({ fetch: app.fetch, port, hostname: '0.0.0.0' }, (info) => {
+  console.log(`caia-llm-router-daemon listening on http://${info.address}:${info.port}`);
+  console.log(`  ollama_url=${args.ollamaUrl ?? process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434'}`);
+  console.log(`  classifier_model=${args.classifierModel ?? process.env['ROUTER_CLASSIFIER_MODEL'] ?? 'qwen2.5-coder:7b'}`);
+});
+
+// Graceful exit handlers
+const exit = (sig: string) => {
+  console.log(`received ${sig} — exiting`);
+  process.exit(0);
+};
+process.on('SIGINT', () => exit('SIGINT'));
+process.on('SIGTERM', () => exit('SIGTERM'));

--- a/packages/local-llm-router/src/classifier.ts
+++ b/packages/local-llm-router/src/classifier.ts
@@ -1,0 +1,183 @@
+// Intent classifier — uses qwen2.5-coder:7b (or future Apprentice LoRA) via Ollama
+// to classify incoming prompts into a constrained-JSON intent schema.
+//
+// L5 of the Local-LLM-First build plan. Inline implementation rather than a
+// separate @chiefaia/intent-schemas package — keeps the MVP single-package.
+
+import { OllamaAdapter } from './ollama-adapter.js';
+
+export type Intent =
+  | 'classify'
+  | 'summarize'
+  | 'draft-prose'
+  | 'format'
+  | 'lint-fix'
+  | 'rename'
+  | 'fill-template'
+  | 'memory-search'
+  | 'medium-code'
+  | 'doc-write'
+  | 'spec-check'
+  | 'review-prose'
+  | 'hard-code'
+  | 'reason-over-context'
+  | 'new-design'
+  | 'architect'
+  | 'batch-summarize'
+  | 'corpus-distill'
+  | 'embedding-generate'
+  | 'unknown';
+
+export type RecommendedTier = 'local-7b' | 'local-14b' | 'local-32b' | 'claude' | 'stolution-batch';
+
+export interface IntentResult {
+  intent: Intent;
+  confidence: number;          // 0..1
+  needs_escalation: boolean;
+  recommended_tier: RecommendedTier;
+  reasoning: string;
+}
+
+export const INTENT_VALUES: ReadonlyArray<Intent> = [
+  'classify', 'summarize', 'draft-prose', 'format', 'lint-fix', 'rename',
+  'fill-template', 'memory-search', 'medium-code', 'doc-write', 'spec-check',
+  'review-prose', 'hard-code', 'reason-over-context', 'new-design', 'architect',
+  'batch-summarize', 'corpus-distill', 'embedding-generate', 'unknown',
+];
+
+export const TIER_VALUES: ReadonlyArray<RecommendedTier> = [
+  'local-7b', 'local-14b', 'local-32b', 'claude', 'stolution-batch',
+];
+
+/** Classifier system prompt. Pins the model to constrained JSON output. */
+export const CLASSIFIER_SYSTEM_PROMPT = `You are an intent classifier for the CAIA agent system. You read a task spec and emit STRICT JSON describing what kind of work it requires.
+
+Your output is ONLY a JSON object with these fields, no prose:
+
+{
+  "intent": one of [${INTENT_VALUES.join(', ')}],
+  "confidence": float 0.0..1.0 (your subjective confidence in the intent label),
+  "needs_escalation": boolean (true if the task is beyond a 7B coder model's capability),
+  "recommended_tier": one of [${TIER_VALUES.join(', ')}],
+  "reasoning": short string (≤120 chars) explaining the classification
+}
+
+Tier guidance:
+- local-7b: classify, summarize, format, lint-fix, rename, draft-prose, fill-template, memory-search
+- local-14b: medium-code, doc-write, spec-check, review-prose
+- local-32b: hard-code requiring deep reasoning over multiple files
+- claude: reason-over-context, new-design, architect, or anything where confidence < 0.6 on a non-code task
+- stolution-batch: batch-summarize, corpus-distill, embedding-generate (CPU-OK batch work)
+
+If the task is ambiguous, pick "unknown" with confidence < 0.5 and needs_escalation: true.
+
+Output ONLY the JSON object. No markdown, no prose before or after, no code fences.`;
+
+export interface ClassifyOptions {
+  /** Model tag in Ollama; default qwen2.5-coder:7b */
+  model?: string;
+  /** Override Ollama base URL (defaults to env OLLAMA_BASE_URL or http://127.0.0.1:11434) */
+  ollamaBaseUrl?: string;
+  /** Hard latency cap in ms */
+  timeoutMs?: number;
+}
+
+const DEFAULT_MODEL = 'qwen2.5-coder:7b';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Classify a task spec into a constrained intent shape. */
+export async function classify(
+  taskSpec: string,
+  opts: ClassifyOptions = {},
+): Promise<IntentResult> {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const baseUrl = opts.ollamaBaseUrl ?? process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const userPrompt = `Task spec:\n"""\n${taskSpec}\n"""\n\nClassify this task. Output only the JSON.`;
+
+  // Use Ollama /api/chat with format=json for constrained JSON output
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: CLASSIFIER_SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        stream: false,
+        format: 'json',
+        options: { temperature: 0.1, num_predict: 400 },
+      }),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    clearTimeout(timer);
+    return abstainResult((e as Error).message);
+  }
+  clearTimeout(timer);
+
+  if (!res.ok) {
+    return abstainResult(`ollama returned ${res.status}`);
+  }
+
+  const body = (await res.json()) as { message?: { content?: string } };
+  const raw = body.message?.content ?? '';
+  return parseClassifierOutput(raw);
+}
+
+/** Parse the model's JSON output. On any failure, return a safe abstain result. */
+export function parseClassifierOutput(raw: string): IntentResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.trim());
+  } catch {
+    return abstainResult(`json-parse-failed: ${raw.slice(0, 80)}`);
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return abstainResult('not-an-object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const intent = (typeof obj.intent === 'string' && (INTENT_VALUES as readonly string[]).includes(obj.intent)
+    ? obj.intent : 'unknown') as Intent;
+  const confidence = typeof obj.confidence === 'number' && obj.confidence >= 0 && obj.confidence <= 1
+    ? obj.confidence : 0.0;
+  const needs_escalation = Boolean(obj.needs_escalation);
+  const recommended_tier = (typeof obj.recommended_tier === 'string' && (TIER_VALUES as readonly string[]).includes(obj.recommended_tier)
+    ? obj.recommended_tier : tierForIntent(intent, confidence)) as RecommendedTier;
+  const reasoning = typeof obj.reasoning === 'string' ? obj.reasoning.slice(0, 200) : '';
+  return { intent, confidence, needs_escalation, recommended_tier, reasoning };
+}
+
+/** Decide tier from intent+confidence when the model didn't supply one. */
+export function tierForIntent(intent: Intent, confidence: number): RecommendedTier {
+  if (intent === 'embedding-generate' || intent === 'corpus-distill' || intent === 'batch-summarize') {
+    return 'stolution-batch';
+  }
+  const lightLocal: ReadonlyArray<Intent> = [
+    'classify', 'summarize', 'format', 'lint-fix', 'rename', 'draft-prose',
+    'fill-template', 'memory-search',
+  ];
+  const mediumLocal: ReadonlyArray<Intent> = [
+    'medium-code', 'doc-write', 'spec-check', 'review-prose',
+  ];
+  if (lightLocal.includes(intent) && confidence >= 0.6) return 'local-7b';
+  if (mediumLocal.includes(intent) && confidence >= 0.6) return 'local-14b';
+  if (intent === 'hard-code') return 'local-32b';
+  return 'claude';
+}
+
+function abstainResult(reason: string): IntentResult {
+  return {
+    intent: 'unknown',
+    confidence: 0.0,
+    needs_escalation: true,
+    recommended_tier: 'claude',
+    reasoning: `abstain: ${reason}`,
+  };
+}

--- a/packages/local-llm-router/src/server.ts
+++ b/packages/local-llm-router/src/server.ts
@@ -1,0 +1,200 @@
+// HTTP daemon for @chiefaia/local-llm-router (L4 of the Local-LLM-First build plan).
+//
+// Endpoints:
+//   GET  /healthz                  → { ok, ollama, models }
+//   GET  /metrics                  → Prometheus exposition (LLM call totals, savings)
+//   POST /v1/intent                → classify a task spec into Intent JSON
+//   POST /v1/route                 → return route decision without executing
+//   POST /v1/chat/completions      → OpenAI-compatible chat (single-turn)
+//   POST /v1/embeddings            → OpenAI-compatible embeddings
+//
+// Listens on port 7411 by default (env ROUTER_PORT to override).
+// Binds to 0.0.0.0 so Tailscale-private peers can reach it; the Tailscale
+// ACL is the auth surface (no in-process auth).
+
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { route as routerRoute } from './router.js';
+import { classify, type IntentResult } from './classifier.js';
+import { OllamaAdapter } from './ollama-adapter.js';
+import { llmMetrics } from './llm-metrics.js';
+import { ROUTING_RULES } from './routing-config.js';
+
+const ROUTER_VERSION = '0.3.0';
+const DEFAULT_PORT = 7411;
+
+export interface ServerOptions {
+  ollamaBaseUrl?: string;
+  classifierModel?: string;
+}
+
+export function buildApp(opts: ServerOptions = {}): Hono {
+  const app = new Hono();
+  const ollamaBaseUrl = opts.ollamaBaseUrl ?? process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+  const classifierModel = opts.classifierModel ?? process.env['ROUTER_CLASSIFIER_MODEL'] ?? 'qwen2.5-coder:7b';
+
+  // ─── /healthz ─────────────────────────────────────────────────────────
+  app.get('/healthz', async (c: Context) => {
+    let ollamaOk = false;
+    let models: string[] = [];
+    try {
+      const r = await fetch(`${ollamaBaseUrl}/api/tags`, { signal: AbortSignal.timeout(2_000) });
+      if (r.ok) {
+        const body = (await r.json()) as { models?: Array<{ name: string }> };
+        models = (body.models ?? []).map(m => m.name);
+        ollamaOk = true;
+      }
+    } catch { /* ollamaOk stays false */ }
+    return c.json({
+      ok: true,
+      router_version: ROUTER_VERSION,
+      ollama: { base_url: ollamaBaseUrl, ok: ollamaOk, models_count: models.length },
+      models,
+      classifier_model: classifierModel,
+      uptime_seconds: Math.floor(process.uptime()),
+    });
+  });
+
+  // ─── /metrics (Prometheus exposition) ────────────────────────────────
+  app.get('/metrics', (c: Context) => {
+    const snap = llmMetrics.snapshot();
+    const lines: string[] = [];
+    lines.push('# HELP llm_router_calls_total Total LLM calls dispatched, by provider+model.');
+    lines.push('# TYPE llm_router_calls_total counter');
+    lines.push(`llm_router_calls_total{provider="local"} ${snap.localCalls}`);
+    lines.push(`llm_router_calls_total{provider="claude"} ${snap.claudeCalls}`);
+    lines.push(`llm_router_calls_total{provider="cache"} ${snap.cacheHits}`);
+    lines.push('# HELP llm_router_estimated_cost_usd Estimated cost for routed calls (USD).');
+    lines.push('# TYPE llm_router_estimated_cost_usd counter');
+    lines.push(`llm_router_estimated_cost_usd ${snap.estimatedCostUsd}`);
+    lines.push('# HELP llm_router_baseline_cost_usd Baseline (all-Claude) cost for the same calls (USD).');
+    lines.push('# TYPE llm_router_baseline_cost_usd counter');
+    lines.push(`llm_router_baseline_cost_usd ${snap.baselineCostUsd}`);
+    lines.push(`# HELP llm_router_uptime_seconds Process uptime in seconds.`);
+    lines.push(`# TYPE llm_router_uptime_seconds gauge`);
+    lines.push(`llm_router_uptime_seconds ${Math.floor(process.uptime())}`);
+    return c.text(lines.join('\n') + '\n', 200, { 'Content-Type': 'text/plain; version=0.0.4' });
+  });
+
+  // ─── /v1/intent ──────────────────────────────────────────────────────
+  app.post('/v1/intent', async (c: Context) => {
+    let body: { task_spec?: string; model?: string };
+    try { body = await c.req.json(); } catch { return c.json({ error: 'invalid-json' }, 400); }
+    const taskSpec = (body.task_spec ?? '').trim();
+    if (taskSpec === '') return c.json({ error: 'task_spec-required' }, 400);
+    const startMs = Date.now();
+    const result = await classify(taskSpec, { model: body.model ?? classifierModel, ollamaBaseUrl });
+    const latency_ms = Date.now() - startMs;
+    return c.json({ ...result, latency_ms, classifier_model: body.model ?? classifierModel });
+  });
+
+  // ─── /v1/route ──────────────────────────────────────────────────────
+  // Returns the route decision (provider+model+tier) for a (taskType, prompt)
+  // without executing anything. Useful for diagnostics + testing.
+  app.post('/v1/route', async (c: Context) => {
+    let body: { task_type?: string; prompt?: string };
+    try { body = await c.req.json(); } catch { return c.json({ error: 'invalid-json' }, 400); }
+    const taskType = body.task_type ?? '';
+    const prompt = body.prompt ?? '';
+    if (taskType === '' || prompt === '') return c.json({ error: 'task_type-and-prompt-required' }, 400);
+    const rule = ROUTING_RULES.find(r => r.taskType === taskType);
+    if (rule === undefined) {
+      // No rule → ask the classifier
+      const intent = await classify(prompt, { model: classifierModel, ollamaBaseUrl });
+      return c.json({
+        task_type: taskType, has_routing_rule: false,
+        recommended_tier: intent.recommended_tier,
+        intent: intent.intent, confidence: intent.confidence,
+        reasoning: intent.reasoning,
+      });
+    }
+    return c.json({
+      task_type: taskType, has_routing_rule: true,
+      use_local: rule.useLocal,
+      local_model: rule.localModel,
+      claude_model: rule.claudeModel,
+      max_tokens: rule.maxTokens,
+      estimated_cost_local: rule.estimatedCostLocal,
+      estimated_cost_claude: rule.estimatedCostClaude,
+    });
+  });
+
+  // ─── /v1/chat/completions (OpenAI-compatible single-turn) ────────────
+  app.post('/v1/chat/completions', async (c: Context) => {
+    let body: {
+      model?: string;
+      messages?: Array<{ role: string; content: string }>;
+      max_tokens?: number;
+      temperature?: number;
+      caia_task_type?: string;  // CAIA extension — picks routing rule
+    };
+    try { body = await c.req.json(); } catch { return c.json({ error: 'invalid-json' }, 400); }
+    const messages = body.messages ?? [];
+    if (messages.length === 0) return c.json({ error: 'messages-required' }, 400);
+
+    const userMsg = messages.filter(m => m.role === 'user').map(m => m.content).join('\n\n');
+    const systemMsg = messages.find(m => m.role === 'system')?.content;
+
+    // Default to "summarize" task type if caller didn't specify
+    const taskType = body.caia_task_type ?? 'route-default';
+
+    try {
+      // Note: existing route() takes positional (taskType, prompt, options).
+      // systemPrompt + max_tokens + temperature are not part of the current
+      // router signature; the routing-config's per-task max_tokens applies.
+      // Future enhancement: extend router to accept per-call overrides.
+      const llmRes = await routerRoute(taskType, userMsg);
+      // Shape as OpenAI chat-completions
+      return c.json({
+        id: `caia-router-${Date.now()}`,
+        object: 'chat.completion',
+        created: Math.floor(Date.now() / 1000),
+        model: llmRes.model,
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: llmRes.response },
+          finish_reason: 'stop',
+        }],
+        usage: {
+          prompt_tokens: llmRes.usage?.promptTokens ?? 0,
+          completion_tokens: llmRes.usage?.completionTokens ?? 0,
+          total_tokens: llmRes.usage?.totalTokens ?? 0,
+        },
+        caia: { provider: llmRes.provider, duration_ms: llmRes.durationMs },
+      });
+    } catch (e) {
+      return c.json({ error: 'route-failed', message: (e as Error).message }, 502);
+    }
+  });
+
+  // ─── /v1/embeddings (OpenAI-compatible) ──────────────────────────────
+  app.post('/v1/embeddings', async (c: Context) => {
+    let body: { input?: string | string[]; model?: string };
+    try { body = await c.req.json(); } catch { return c.json({ error: 'invalid-json' }, 400); }
+    const input = body.input;
+    if (input === undefined) return c.json({ error: 'input-required' }, 400);
+    const texts = Array.isArray(input) ? input : [input];
+    const model = body.model ?? 'nomic-embed-text';
+    const data: Array<{ object: string; embedding: number[]; index: number }> = [];
+    for (let i = 0; i < texts.length; i++) {
+      const r = await fetch(`${ollamaBaseUrl}/api/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, prompt: texts[i] }),
+      });
+      if (!r.ok) return c.json({ error: 'embeddings-failed', status: r.status }, 502);
+      const j = (await r.json()) as { embedding?: number[] };
+      data.push({ object: 'embedding', embedding: j.embedding ?? [], index: i });
+    }
+    return c.json({
+      object: 'list',
+      data,
+      model,
+      usage: { prompt_tokens: 0, total_tokens: 0 },
+    });
+  });
+
+  return app;
+}
+
+export const DEFAULT_ROUTER_PORT = DEFAULT_PORT;


### PR DESCRIPTION
Implements legs **L4 (router daemon)**, **L5 (classifier prompt — inline)**, **L7 (MCP server)**, **L8 (standing instruction)**, and **L9 (python client + spawner patch reference)** of the [Local-LLM-First build plan](https://github.com/prakashgbid/caia/blob/develop/agent-memory/local_llm_first_build_plan_2026-05-11.md). Defers L6 (semantic cache), L11 (manifest verify cron), and L12 (auto-degrade + Grafana panel).

## Smoke-tested on M3 (2026-05-11)

- daemon LaunchAgent live: `com.chiefaia.local-llm-router` listening on `0.0.0.0:7411`
- `/healthz` healthy: ollama OK, 4 models detected (qwen2.5-coder:7b/14b/32b + nomic-embed-text)
- `/v1/intent` classifies 'rename' → `{intent: rename, confidence: 1.0, recommended_tier: local-7b}` in 4.2s
- `/v1/intent` classifies 'design a sharded DB schema' → `{intent: new-design, confidence: 0.9, recommended_tier: local-14b}` in 3.3s
- `/v1/route` returns the routing rule for known task types (e.g. domain-classification)
- `/v1/embeddings` returns 768-dim nomic-embed-text vectors
- `/metrics` exposes Prometheus-format counters
- MCP server initialize + tools/list handshake works end-to-end
- python client `classify_and_maybe_route()` does a live local execution against the daemon

## Defers / open items

- **L6 semantic cache** (sqlite-vec + nomic-embed-text 24h TTL) — additive optimization, not blocking.
- **L11 manifest verify cron** — config sync between hosts; per-machine model menu already verified manually for M3.
- **L12 auto-degrade + budget guard + Grafana panel** — operations polish; the router currently fails-closed (returns error to caller) on Ollama 5xx instead of auto-degrading to claude. Acceptable for MVP; harden later.
- **Apprentice LoRA classifier head** — pending corpus ≥ 500 samples (~ 2026-05-15 with distillation restored). Today the classifier is vanilla qwen2.5:7b. Swap is a one-line model-name change in the plist's `ROUTER_CLASSIFIER_MODEL` env var.

## Spawner patch — operator action required before applying

`packages/local-llm-router-py-client/src/spawner_patch.diff` contains the `/spawn` handler patch that adds the pre-spawn classify-and-maybe-route gate. **Do NOT auto-apply.** Operator should:

1. Review the diff for risk (it changes the spawn fast-path).
2. Test on a non-production spawner first (M3 spawner is currently unenrolled per `m3_spawner_enrollment_2026-05-10.md`; safest test ground).
3. `patch -p0 < spawner_patch.diff` from the spawner working directory.
4. Restart the spawner.
5. Verify spawn records show `outcome: local_completed` for low-tier work.

## Architecture

This PR adds an HTTP server wrapper around the existing `@chiefaia/local-llm-router` library. The library was built but never instantiated as a daemon; this PR ships the daemon entrypoint, an MCP shim for Cowork, and a python client for spawner integration. Three new private workspace packages, all Option E shape (parameterised constructors with CAIA defaults, never published).

Refs: `local_llm_first_canonical_2026-05-11.md`, `local_llm_first_build_plan_2026-05-11.md`, `apprentice_canonical_brief_2026-05-11.md`, `apprentice_phase_c_step1_complete_2026-05-11.md`.