### PR TITLE
fix(prompt-optimizer): allow undefined in optional error/source for exactOptionalPropertyTypes build

### DIFF
--- a/packages/prompt-optimizer/src/stage2.ts
+++ b/packages/prompt-optimizer/src/stage2.ts
@@ -32,7 +32,7 @@ export interface Stage2BlobResult {
   tokensIn: number;
   tokensOut: number;
   compressed: boolean;
-  error?: string;
+  error?: string | undefined;
 }
 
 const DEFAULTS: Required<Omit<Stage2Options, 'fetchImpl'>> = {
@@ -55,7 +55,7 @@ Output ONLY the compressed text. No commentary, no preamble, no markdown fences.
 export async function stage2Summarize(
   blobs: ToolOutputBlob[],
   opts: Stage2Options = {},
-): Promise<{ blobs: Stage2BlobResult[]; wallMs: number; error?: string }> {
+): Promise<{ blobs: Stage2BlobResult[]; wallMs: number; error?: string | undefined }> {
   const o = { ...DEFAULTS, ...opts };
   const fetcher = opts.fetchImpl ?? fetch;
   const startedAt = Date.now();

--- a/packages/prompt-optimizer/src/stage3.ts
+++ b/packages/prompt-optimizer/src/stage3.ts
@@ -51,7 +51,7 @@ export interface Stage3Result {
   tokensOut: number;
   wallMs: number;
   backend: 'router' | 'heuristic' | 'skipped';
-  error?: string;
+  error?: string | undefined;
 }
 
 const DEFAULTS: Required<Omit<Stage3Options, 'fetchImpl' | 'forceHeuristic'>> = {

--- a/packages/prompt-optimizer/src/types.ts
+++ b/packages/prompt-optimizer/src/types.ts
@@ -8,7 +8,7 @@ export interface ToolOutputBlob {
   // Optional source hint — used by Stage 1 to know whether to apply
   // file-fold heuristics ("file") vs JSON-normalize ("json") vs leave the
   // content alone ("opaque").
-  source?: 'file' | 'json' | 'shell' | 'opaque';
+  source?: 'file' | 'json' | 'shell' | 'opaque' | undefined;
 }
 
 export interface OptimizerInput {
@@ -43,7 +43,7 @@ export interface StageMetrics {
   wallMs: number;
   ratio: number; // tokensOut / tokensIn
   skipped: boolean;
-  error?: string;
+  error?: string | undefined;
 }
 
 export interface OptimizerMetrics {


### PR DESCRIPTION
## Summary
- Resolves TS2375 errors blocking `pnpm build` under `exactOptionalPropertyTypes`
- Adds `| undefined` to `error?` and `source?` fields in prompt-optimizer types/stage2/stage3

## Test plan
- [x] `pnpm --filter @chiefaia/prompt-optimizer build` succeeds locally
- [x] `pnpm --filter @chiefaia/local-llm-router build` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)