### PR TITLE
feat(local-llm-router): Headroom sidecar replaces stages 2/3 in claude-adapter (LAI phase 2)

### DIFF
--- a/packages/local-llm-router/python/headroom_sidecar.py
+++ b/packages/local-llm-router/python/headroom_sidecar.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Headroom compression sidecar.
+
+Invoked by the router's claude-adapter as a one-shot subprocess. Reads a
+single JSON request from stdin and writes a single JSON response to
+stdout. Errors go to stderr; non-zero exit code on failure.
+
+Wire format:
+  Request (stdin):  {"messages": [...], "model": "claude-sonnet-4-..."}
+  Response (stdout): {
+      "compressed_messages": [...],
+      "tokens_saved":        <int>,
+      "compression_ratio":   <float>,
+      "original_tokens":     <int>,
+      "final_tokens":        <int>,
+      "transforms_applied":  [<str>, ...]
+  }
+
+The sidecar protocol is intentionally minimal: one request, one
+response, no streaming, no keepalive. The adapter pays roughly one
+Python interpreter startup per request (~250ms cold, less when imports
+are cached). If that becomes a bottleneck we can switch to a long-lived
+daemon, but it's deliberately not optimized yet — correctness first.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _err(msg: str, code: int = 1) -> None:
+    """Emit a structured error to stderr and exit non-zero."""
+    sys.stderr.write(json.dumps({"error": msg}) + "\n")
+    sys.exit(code)
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        _err("empty stdin")
+
+    try:
+        req: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as e:
+        _err(f"invalid JSON on stdin: {e}")
+
+    messages = req.get("messages")
+    if not isinstance(messages, list) or not messages:
+        _err("request missing non-empty 'messages' array")
+
+    model = req.get("model") or "claude-sonnet-4-5-20250929"
+
+    try:
+        from headroom import compress, CompressConfig
+    except ImportError as e:
+        _err(f"headroom not importable from {sys.executable}: {e}", code=2)
+
+    # CAIA's prompts are orchestration-side, not the human's literal
+    # question — so the user-message protection that Headroom enables by
+    # default is the wrong call here. Enabling compress_user_messages lets
+    # SmartCrusher / CodeCompressor / Kompress touch the prompt body where
+    # most of the bytes live. min_tokens_to_compress=250 is the default;
+    # under that threshold the prompt is too short to bother with.
+    cfg = CompressConfig(
+        compress_user_messages=True,
+        compress_system_messages=True,
+        protect_recent=0,
+    )
+
+    try:
+        result = compress(messages, model=model, config=cfg)
+    except Exception as e:  # noqa: BLE001 — surface any headroom failure
+        _err(f"headroom.compress failed: {type(e).__name__}: {e}", code=3)
+
+    payload = {
+        "compressed_messages": result.messages,
+        "tokens_saved": int(result.tokens_saved),
+        "compression_ratio": float(result.compression_ratio),
+        "original_tokens": int(result.tokens_before),
+        "final_tokens": int(result.tokens_after),
+        "transforms_applied": list(result.transforms_applied),
+    }
+    sys.stdout.write(json.dumps(payload))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/local-llm-router/src/claude-adapter.ts
+++ b/packages/local-llm-router/src/claude-adapter.ts
@@ -10,13 +10,31 @@
 //
 // The router (router.ts) is responsible for the optional fall-through to
 // Ollama on `ClaudeBinaryError`. The adapter itself is pure: spawn → parse → return.
+//
+// ─── Prompt compression pipeline (LAI phase 2 — Headroom integration) ───
+// Each request runs through a two-step compression pipeline before the
+// prompt reaches the `claude` binary:
+//
+//   1. Stage 1 (`stage1Prepass`) — rule-based prepass from
+//      @chiefaia/prompt-optimizer. Strips ANSI/CRLF/BOM, dedupes blocks,
+//      folds long file reads, normalizes JSON, etc. Cheap and deterministic.
+//
+//   2. Headroom sidecar — spawns a Python subprocess that calls
+//      headroom.compress(). Headroom owns the heavy lifting: SmartCrusher
+//      for JSON blobs, CodeCompressor for AST-aware code dedup, Kompress
+//      (ModernBERT) for prose summarization. Stage 1 is kept because
+//      Headroom's router protects user turns (it won't dedupe within them),
+//      so our rule prepass handles the in-turn duplication while Headroom
+//      handles tool-result/system content.
+//
+// The two stages are complementary, not redundant. If the sidecar fails for
+// any reason (subprocess error, malformed JSON, timeout), we degrade to
+// Stage-1-only output and emit a `skipped: true` metric — the prompt still
+// goes through; only the savings are reduced.
 
 import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
-import {
-  optimize as defaultOptimize,
-  type OptimizerInput,
-  type OptimizerResult,
-} from '@chiefaia/prompt-optimizer';
+import { join, dirname } from 'node:path';
+import { stage1Prepass, estimateTokens } from '@chiefaia/prompt-optimizer';
 import type {
   LLMRequest,
   LLMResponse,
@@ -39,6 +57,33 @@ const DEFAULT_CLAUDE_BINARY = process.env['CLAUDE_BINARY_PATH'] ?? 'claude';
  * deliberately want a longer ceiling (e.g., bulk decomposition).
  */
 const DEFAULT_TIMEOUT_MS = 45_000;
+
+/** Default Python interpreter that has `headroom-ai` installed.
+ *
+ * Phase 1 (install_headroom_on_m3) reports headroom is wheeled against
+ * CPython 3.13; the system `python3` is 3.14 which PyO3 does not yet
+ * support. We pin the absolute path so the sidecar always finds the right
+ * interpreter regardless of $PATH ordering. Override via env or opts. */
+const DEFAULT_HEADROOM_PYTHON =
+  process.env['HEADROOM_PYTHON'] ?? '/opt/homebrew/opt/python@3.13/bin/python3.13';
+
+/** Default headroom sidecar path — resolved from the compiled file's
+ *  location at runtime. After build, `__dirname` is `<pkg>/dist`; the
+ *  sidecar lives at `<pkg>/python/headroom_sidecar.py`. */
+const DEFAULT_HEADROOM_SIDECAR = join(dirname(__filename), '..', 'python', 'headroom_sidecar.py');
+
+/** Default Headroom sidecar timeout (ms).
+ *
+ * Cold start dominates: Headroom's Kompress backend lazy-loads a
+ * ModernBERT model on first call, which on M3 takes ~20-25s. After warm,
+ * compression itself is sub-second. 60s gives the first call comfortable
+ * room without unbounded ceilings; subsequent calls finish well under it.
+ * If the sidecar hangs the adapter falls back to Stage-1-only output. */
+const DEFAULT_HEADROOM_TIMEOUT_MS = 60_000;
+
+/** Default target model passed to `headroom.compress(..., model=)`. Headroom
+ *  uses this for token estimation and per-model heuristics. */
+const DEFAULT_HEADROOM_MODEL = 'claude-sonnet-4-5-20250929';
 
 /** Generic binary-spawn failure. Thrown for missing binary, non-zero exit,
  *  malformed JSON, or any other non-rate-limit error. */
@@ -77,6 +122,28 @@ export class ClaudeRateLimitedError extends ClaudeBinaryError {
   }
 }
 
+// ─── Headroom sidecar protocol ─────────────────────────────────────────
+
+export interface HeadroomMessage {
+  role: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+export interface HeadroomSidecarRequest {
+  messages: HeadroomMessage[];
+  model: string;
+}
+
+export interface HeadroomSidecarResponse {
+  compressed_messages: HeadroomMessage[];
+  tokens_saved: number;
+  compression_ratio: number;
+  original_tokens: number;
+  final_tokens: number;
+  transforms_applied?: string[];
+}
+
 /** Configuration for a single ClaudeAdapter instance. */
 export interface ClaudeAdapterOptions {
   /** Override path to the `claude` binary. */
@@ -96,24 +163,39 @@ export interface ClaudeAdapterOptions {
   /** Test seam — replace `node:child_process`'s `spawn`. */
   spawnFn?: typeof spawn;
   /**
-   * Disable the @chiefaia/prompt-optimizer pre-pass. Default: optimizer
-   * runs on every call so the spawned `claude` binary sees a compressed
-   * prompt. Disable for adapters that already received an optimized
-   * prompt upstream (e.g. the spawner) or in tests that assert on the
-   * exact byte content of stdin.
+   * Disable the compression pipeline entirely (Stage 1 + Headroom). The
+   * raw prompt is passed straight through to the binary. Use for adapters
+   * that already received an optimized prompt upstream (e.g. the spawner)
+   * or in tests that assert on the exact byte content of stdin.
    */
   optimizerDisabled?: boolean;
   /**
-   * Test seam — replace the optimizer entry point. Defaults to
-   * `optimize` from @chiefaia/prompt-optimizer.
-   */
-  optimizeFn?: (input: OptimizerInput) => Promise<OptimizerResult>;
-  /**
-   * Optional sink for optimizer metrics. Called after each optimization
+   * Optional sink for compression metrics. Called after each compression
    * pass, before the prompt is sent to the binary. Use to forward to
    * OTel / llm-metrics. Defaults to a no-op.
    */
   onOptimizerMetrics?: (metrics: RouterOptimizerMetrics) => void;
+  /**
+   * Absolute path to the Python interpreter that has `headroom-ai`
+   * installed. Defaults to env var HEADROOM_PYTHON, then to
+   * `/opt/homebrew/opt/python@3.13/bin/python3.13` (the path the LAI
+   * Phase 1 install report points at).
+   */
+  headroomPython?: string;
+  /** Absolute path to the headroom_sidecar.py script. */
+  headroomSidecarPath?: string;
+  /** Override sidecar subprocess timeout (ms). */
+  headroomTimeoutMs?: number;
+  /** Override the Headroom-side target model used for token estimation. */
+  headroomModel?: string;
+  /**
+   * Test seam — replace the sidecar invocation. When provided, the
+   * adapter skips spawning a subprocess and calls this function directly.
+   * Used by the unit tests to inject scripted compression results.
+   */
+  sidecarFn?: (
+    req: HeadroomSidecarRequest,
+  ) => Promise<HeadroomSidecarResponse>;
 }
 
 /** Shape of the JSON object emitted by `claude --print --output-format json`. */
@@ -141,9 +223,15 @@ export class ClaudeAdapter {
   private readonly timeoutMs: number;
   private readonly spawnFn: typeof spawn;
   private readonly optimizerDisabled: boolean;
-  private readonly optimizeFn: (input: OptimizerInput) => Promise<OptimizerResult>;
   private readonly onOptimizerMetrics:
     | ((metrics: RouterOptimizerMetrics) => void)
+    | null;
+  private readonly headroomPython: string;
+  private readonly headroomSidecarPath: string;
+  private readonly headroomTimeoutMs: number;
+  private readonly headroomModel: string;
+  private readonly sidecarFn:
+    | ((req: HeadroomSidecarRequest) => Promise<HeadroomSidecarResponse>)
     | null;
 
   constructor(opts: ClaudeAdapterOptions = {}) {
@@ -153,8 +241,12 @@ export class ClaudeAdapter {
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.spawnFn = opts.spawnFn ?? spawn;
     this.optimizerDisabled = opts.optimizerDisabled ?? false;
-    this.optimizeFn = opts.optimizeFn ?? defaultOptimize;
     this.onOptimizerMetrics = opts.onOptimizerMetrics ?? null;
+    this.headroomPython = opts.headroomPython ?? DEFAULT_HEADROOM_PYTHON;
+    this.headroomSidecarPath = opts.headroomSidecarPath ?? DEFAULT_HEADROOM_SIDECAR;
+    this.headroomTimeoutMs = opts.headroomTimeoutMs ?? DEFAULT_HEADROOM_TIMEOUT_MS;
+    this.headroomModel = opts.headroomModel ?? DEFAULT_HEADROOM_MODEL;
+    this.sidecarFn = opts.sidecarFn ?? null;
   }
 
   /**
@@ -169,12 +261,9 @@ export class ClaudeAdapter {
   async generate(model: string, request: LLMRequest): Promise<LLMResponse> {
     const start = Date.now();
 
-    // ─── Pre-pass: run the prompt through the 3-stage optimizer ──────
-    // The optimizer bails out cheaply for short prompts (<500 tok), so
-    // calling it on every request is safe. If it fails for any reason
-    // (e.g. router daemon unreachable), it returns the prepass-only
-    // result — we still get Stage 1 dedup without the local-LLM-backed
-    // Stage 2 / 3.
+    // Run Stage 1 prepass + Headroom sidecar. Failure-mode for the
+    // compression pipeline is best-effort: any error inside degrades to
+    // a less-compressed prompt and a skipped metric, never throws.
     const { promptForBinary, optimizerMetrics } = await this.optimizePrompt(
       request,
     );
@@ -335,15 +424,13 @@ export class ClaudeAdapter {
   }
 
   /**
-   * Run the request prompt + systemPrompt through @chiefaia/prompt-optimizer
-   * and return both the prompt to feed the binary and the metrics to emit.
+   * Run the request prompt through Stage 1 prepass + Headroom sidecar.
+   * Returns the prompt to feed the binary and the metrics to emit.
    *
-   * Failure mode: the optimizer is best-effort. If it throws (which it
-   * normally shouldn't — Stage 2 swallows router errors internally),
-   * we fall back to the original prompt and emit a metrics object with
-   * compression_ratio=1.0 and skipped=true so the call still observes
-   * an optimizer record (helps the dashboard distinguish "no compression
-   * attempted" from "no adapter touched the metric").
+   * Failure mode: best-effort. If Stage 1 throws or Headroom misbehaves
+   * we fall back to the most-compressed prompt we have so far (raw, or
+   * Stage-1 output) and emit a `skipped: true` metric so the dashboard
+   * still observes the call.
    */
   private async optimizePrompt(request: LLMRequest): Promise<{
     promptForBinary: string;
@@ -353,51 +440,161 @@ export class ClaudeAdapter {
       return { promptForBinary: request.prompt, optimizerMetrics: null };
     }
 
-    // NOTE: `request.systemPrompt` is intentionally NOT passed to the
-    // optimizer. The system prompt is forwarded to the binary separately
-    // via `--append-system-prompt`, so feeding it to the optimizer here
-    // would duplicate it on stdin. The optimizer only sees the user-side
-    // prompt that actually flows through stdin.
-    const input: OptimizerInput = {
-      userQuestion: request.prompt,
-    };
+    const wallStart = Date.now();
+    const rawPrompt = request.prompt;
+    const preTokens = estimateTokens(rawPrompt);
 
-    let result: OptimizerResult;
+    // ─── Stage 1: rule-based prepass ──────────────────────────────────
+    // Cheap, deterministic. We keep it even though Headroom exists
+    // because Headroom's router protects user-role turns from
+    // compression by default, so any in-turn duplication (dedupe of
+    // repeated blocks, ANSI stripping, long file-read folding, base64
+    // truncation) has to happen before Headroom sees the messages.
+    let stage1Text: string;
+    let protectedSpans: number;
     try {
-      result = await this.optimizeFn(input);
+      const r = stage1Prepass(rawPrompt);
+      stage1Text = r.text;
+      protectedSpans = r.protectedSpans;
     } catch {
-      // Optimizer blew up — degrade to the raw prompt and emit a
-      // "skipped" metric so the dashboard sees the call.
-      const fallback: RouterOptimizerMetrics = {
-        pre_token_count: 0,
-        post_token_count: 0,
-        compression_ratio: 1,
-        protected_span_count: 0,
-        wall_ms: 0,
-        skipped: true,
-      };
-      this.emitOptimizerMetrics(fallback);
-      return { promptForBinary: request.prompt, optimizerMetrics: fallback };
+      // Prepass blew up — degrade to raw prompt for Stage 1, still try Headroom.
+      stage1Text = rawPrompt;
+      protectedSpans = 0;
     }
 
-    const pre = result.metrics.promptTokensRaw;
-    const post =
-      result.metrics.stage3.skipped && !result.metrics.stage2.skipped
-        ? result.metrics.stage2.tokensOut
-        : result.metrics.stage3.skipped
-          ? result.metrics.stage1.tokensOut
-          : result.metrics.stage3.tokensOut;
+    // ─── Stage 2: Headroom sidecar ────────────────────────────────────
+    const messages: HeadroomMessage[] = [{ role: 'user', content: stage1Text }];
+
+    let sidecarOut: HeadroomSidecarResponse | null = null;
+    try {
+      sidecarOut = await this.invokeSidecar({
+        messages,
+        model: this.headroomModel,
+      });
+    } catch {
+      // Sidecar failed — fall back to Stage-1-only output.
+      const stage1Tokens = estimateTokens(stage1Text);
+      const fallback: RouterOptimizerMetrics = {
+        pre_token_count: preTokens,
+        post_token_count: stage1Tokens,
+        compression_ratio: preTokens > 0 ? stage1Tokens / preTokens : 1,
+        protected_span_count: protectedSpans,
+        wall_ms: Date.now() - wallStart,
+        skipped: true,
+        headroom_tokens_saved: 0,
+        headroom_ratio: 0,
+      };
+      this.emitOptimizerMetrics(fallback);
+      return { promptForBinary: stage1Text, optimizerMetrics: fallback };
+    }
+
+    // Reconstruct the final prompt from compressed messages. With a
+    // single-turn input we expect a single user message back; if
+    // Headroom adds turns (e.g. a system synopsis) we concatenate
+    // their content with double-newlines.
+    const finalPrompt = sidecarOut.compressed_messages
+      .map((m) => (typeof m.content === 'string' ? m.content : ''))
+      .filter((s) => s.length > 0)
+      .join('\n\n');
+
+    const postTokens = sidecarOut.final_tokens;
     const metrics: RouterOptimizerMetrics = {
-      pre_token_count: pre,
-      post_token_count: post,
-      compression_ratio: pre > 0 ? post / pre : 1,
-      protected_span_count: result.protectedSpanCount,
-      wall_ms: result.metrics.totalWallMs,
-      skipped:
-        result.metrics.stage2.skipped && result.metrics.stage3.skipped,
+      pre_token_count: preTokens,
+      post_token_count: postTokens,
+      compression_ratio: preTokens > 0 ? postTokens / preTokens : 1,
+      protected_span_count: protectedSpans,
+      wall_ms: Date.now() - wallStart,
+      skipped: false,
+      headroom_tokens_saved: sidecarOut.tokens_saved,
+      headroom_ratio: sidecarOut.compression_ratio,
     };
     this.emitOptimizerMetrics(metrics);
-    return { promptForBinary: result.optimizedPrompt, optimizerMetrics: metrics };
+    return { promptForBinary: finalPrompt, optimizerMetrics: metrics };
+  }
+
+  /**
+   * Invoke the Headroom Python sidecar.
+   *
+   * Tests pass `sidecarFn` to bypass the subprocess entirely. In
+   * production we spawn `<headroomPython> <headroomSidecarPath>` and
+   * pipe JSON in/out.
+   */
+  private async invokeSidecar(
+    req: HeadroomSidecarRequest,
+  ): Promise<HeadroomSidecarResponse> {
+    if (this.sidecarFn) return this.sidecarFn(req);
+
+    return new Promise<HeadroomSidecarResponse>((resolve, reject) => {
+      let child: ChildProcess;
+      try {
+        child = this.spawnFn(this.headroomPython, [this.headroomSidecarPath], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...(process.env as Record<string, string>) },
+        });
+      } catch (err) {
+        reject(new Error(`failed to spawn headroom sidecar: ${String(err)}`));
+        return;
+      }
+
+      const stdin = child.stdin;
+      if (!stdin) {
+        reject(new Error('headroom sidecar has no stdin'));
+        return;
+      }
+
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          /* ignore */
+        }
+      }, this.headroomTimeoutMs);
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      child.stdout?.on('data', (c: Buffer) => stdoutChunks.push(c));
+      child.stderr?.on('data', (c: Buffer) => stderrChunks.push(c));
+
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        reject(new Error(`headroom sidecar error: ${String(err)}`));
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (timedOut) {
+          reject(new Error(`headroom sidecar timed out after ${String(this.headroomTimeoutMs)}ms`));
+          return;
+        }
+        const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+        const stderr = Buffer.concat(stderrChunks).toString('utf8');
+        if (code !== 0) {
+          reject(
+            new Error(
+              `headroom sidecar exited ${String(code)}: ${stderr.slice(0, 500)}`,
+            ),
+          );
+          return;
+        }
+        let parsed: HeadroomSidecarResponse;
+        try {
+          parsed = JSON.parse(stdout) as HeadroomSidecarResponse;
+        } catch (e) {
+          reject(new Error(`headroom sidecar bad JSON: ${String(e)}`));
+          return;
+        }
+        if (!Array.isArray(parsed.compressed_messages)) {
+          reject(new Error('headroom sidecar response missing compressed_messages array'));
+          return;
+        }
+        resolve(parsed);
+      });
+
+      stdin.write(JSON.stringify(req));
+      stdin.end();
+    });
   }
 
   private emitOptimizerMetrics(metrics: RouterOptimizerMetrics): void {

--- a/packages/local-llm-router/src/types.ts
+++ b/packages/local-llm-router/src/types.ts
@@ -42,7 +42,7 @@ export interface LLMResponse {
 export interface OptimizerMetrics {
   /** Raw prompt token estimate before optimizer ran. */
   pre_token_count: number;
-  /** Optimized prompt token estimate after the 3-stage pipeline. */
+  /** Optimized prompt token estimate after the full pipeline (Stage 1 + Headroom). */
   post_token_count: number;
   /** post / pre. 1.0 = no compression, 0.5 = halved. */
   compression_ratio: number;
@@ -50,8 +50,13 @@ export interface OptimizerMetrics {
   protected_span_count: number;
   /** Wall-clock ms the optimizer pipeline took. */
   wall_ms: number;
-  /** True if the prompt was below the skip-threshold and stages 2/3 were bypassed. */
+  /** True if the Headroom sidecar bailed out (failure or no-op). */
   skipped: boolean;
+  /** Tokens removed by Headroom alone (post-Stage-1). 0 when Headroom skipped. */
+  headroom_tokens_saved: number;
+  /** Headroom's self-reported compression ratio (tokens_saved / original_tokens),
+   *  in [0, 1]. 0 = no compression, 0.7 = 70% of bytes removed. */
+  headroom_ratio: number;
 }
 
 export interface RouterOptions {

--- a/packages/local-llm-router/tests/claude-adapter.test.ts
+++ b/packages/local-llm-router/tests/claude-adapter.test.ts
@@ -7,6 +7,15 @@
  * `ChildProcess`. The fake lets us script stdout, stderr, exit code,
  * and timing per test.
  *
+ * The compression pipeline (Stage 1 prepass + Headroom sidecar) is
+ * stubbed in two ways:
+ *   - For tests that don't care about compression, we pass
+ *     `optimizerDisabled: true` so the raw prompt goes straight to the
+ *     binary and the only spawn call is the `claude` binary.
+ *   - For tests that DO assert on compression behavior, we pass
+ *     `sidecarFn` to return a scripted Headroom response without
+ *     spawning a Python subprocess.
+ *
  * HARD CONSTRAINT: assert that the adapter NEVER passes ANTHROPIC_API_KEY
  * through to the spawned child — it must always use subscription auth.
  */
@@ -14,14 +23,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
-import type {
-  OptimizerInput,
-  OptimizerResult,
-} from '@chiefaia/prompt-optimizer';
 import {
   ClaudeAdapter,
   ClaudeBinaryError,
   ClaudeRateLimitedError,
+  type HeadroomSidecarRequest,
+  type HeadroomSidecarResponse,
 } from '../src/claude-adapter.js';
 import type { OptimizerMetrics } from '../src/types.js';
 
@@ -122,12 +129,30 @@ const HAPPY_PATH_JSON = JSON.stringify({
   modelUsage: { 'claude-sonnet-4-6': { inputTokens: 5, outputTokens: 3, costUSD: 0.001 } },
 });
 
+/** Identity sidecar — returns the messages unchanged, zero compression.
+ *  Used by tests that need the pipeline enabled but don't care about
+ *  Headroom's transforms. */
+const identitySidecar = async (
+  req: HeadroomSidecarRequest,
+): Promise<HeadroomSidecarResponse> => {
+  const joined = req.messages.map((m) => m.content).join('\n\n');
+  const tokens = Math.ceil(joined.length / 4);
+  return {
+    compressed_messages: req.messages,
+    tokens_saved: 0,
+    compression_ratio: 0,
+    original_tokens: tokens,
+    final_tokens: tokens,
+    transforms_applied: [],
+  };
+};
+
 // ─── tests ───────────────────────────────────────────────────────────────
 
 describe('ClaudeAdapter (binary spawn)', () => {
   it('happy path — parses JSON output and reports subscription provider', async () => {
     const { fn } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     const out = await adapter.generate('claude-sonnet-4-6', {
       taskType: 'hierarchy-decomposition',
       prompt: 'hi',
@@ -140,7 +165,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('passes --model + --print + --output-format json to the binary', async () => {
     const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     await adapter.generate('claude-haiku-4-5', { taskType: 't', prompt: 'p' });
     const args = invocations[0]!.args;
     expect(args).toContain('--print');
@@ -152,7 +177,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('writes the prompt to the binary stdin', async () => {
     const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     await adapter.generate('claude-sonnet-4-6', {
       taskType: 't',
       prompt: 'the literal prompt body',
@@ -165,7 +190,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
     process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-LEAKED-KEY-MUST-NOT-PASS';
     try {
       const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-      const adapter = new ClaudeAdapter({ spawnFn: fn });
+      const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
       await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
       expect(invocations[0]!.env['ANTHROPIC_API_KEY']).toBeUndefined();
       expect(invocations[0]!.env['ANTHROPIC_AUTH_TOKEN']).toBeUndefined();
@@ -179,6 +204,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
     const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
     const adapter = new ClaudeAdapter({
       spawnFn: fn,
+      optimizerDisabled: true,
       homeOverride: '/Users/MAC/.caia/accounts/acc-2',
       accountId: 'acc-2',
     });
@@ -192,7 +218,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
       stderr: 'Error: 429 Too Many Requests — rate_limit_exceeded',
       code: 1,
     });
-    const adapter = new ClaudeAdapter({ spawnFn: fn, accountId: 'acc-1' });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true, accountId: 'acc-1' });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toBeInstanceOf(ClaudeRateLimitedError);
@@ -206,7 +232,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
       result: '',
     });
     const { fn } = makeFakeSpawn({ stdout: json });
-    const adapter = new ClaudeAdapter({ spawnFn: fn, accountId: 'acc-1' });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true, accountId: 'acc-1' });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toBeInstanceOf(ClaudeRateLimitedError);
@@ -218,7 +244,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
       stderr: '429 rate limit hit',
       code: 1,
     });
-    const adapter = new ClaudeAdapter({ spawnFn: fn, accountId: 'acc-7' });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true, accountId: 'acc-7' });
     try {
       await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
       throw new Error('expected throw');
@@ -231,7 +257,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
   it('throws ClaudeBinaryError when the binary is missing (spawn ENOENT)', async () => {
     const enoent = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
     const { fn } = makeFakeSpawn({ spawnThrows: enoent });
-    const adapter = new ClaudeAdapter({ spawnFn: fn, binaryPath: 'claude' });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true, binaryPath: 'claude' });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toBeInstanceOf(ClaudeBinaryError);
@@ -239,7 +265,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('throws ClaudeBinaryError when the binary exits non-zero with no rate-limit signal', async () => {
     const { fn } = makeFakeSpawn({ stdout: '', stderr: 'unknown error', code: 2 });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toBeInstanceOf(ClaudeBinaryError);
@@ -247,7 +273,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('throws ClaudeBinaryError when stdout is malformed JSON', async () => {
     const { fn } = makeFakeSpawn({ stdout: 'definitely not json{{{', code: 0 });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toThrow(/parse claude binary stdout/);
@@ -255,7 +281,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('throws ClaudeBinaryError on timeout (kills the child)', async () => {
     const { fn } = makeFakeSpawn({ hang: true });
-    const adapter = new ClaudeAdapter({ spawnFn: fn, timeoutMs: 25 });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true, timeoutMs: 25 });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toThrow(/timed out/);
@@ -263,7 +289,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('throws ClaudeBinaryError when the child emits an error event', async () => {
     const { fn } = makeFakeSpawn({ errorEvent: new Error('pipe broken') });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
     ).rejects.toBeInstanceOf(ClaudeBinaryError);
@@ -275,7 +301,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
     // 2026-04-30 rule. This test asserts the adapter never silently
     // returns a non-binary response.
     const { fn } = makeFakeSpawn({ stdout: '', stderr: 'binary blew up', code: 99 });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
     await expect(
       adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' }),
@@ -287,7 +313,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
 
   it('passes --append-system-prompt when systemPrompt is provided', async () => {
     const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     await adapter.generate('claude-sonnet-4-6', {
       taskType: 't',
       prompt: 'user',
@@ -306,7 +332,7 @@ describe('ClaudeAdapter (binary spawn)', () => {
       usage: { input_tokens: 100, output_tokens: 250 },
     });
     const { fn } = makeFakeSpawn({ stdout: json });
-    const adapter = new ClaudeAdapter({ spawnFn: fn });
+    const adapter = new ClaudeAdapter({ spawnFn: fn, optimizerDisabled: true });
     const out = await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'p' });
     expect(out.usage).toEqual({
       promptTokens: 100,
@@ -315,133 +341,110 @@ describe('ClaudeAdapter (binary spawn)', () => {
     });
   });
 
-  // ─── LAI phase 6 — prompt-optimizer integration ────────────────────
-  describe('prompt-optimizer integration (LAI phase 6)', () => {
-    /** Build a fake optimizeFn that returns a scripted compressed prompt. */
-    function fakeOptimize(opts: {
-      out: string;
-      preTokens: number;
-      postTokens: number;
-      protectedSpans?: number;
-      skipped?: boolean;
-    }): (input: OptimizerInput) => Promise<OptimizerResult> {
-      return async (_input) => ({
-        optimizedPrompt: opts.out,
-        protectedSpanCount: opts.protectedSpans ?? 0,
-        metrics: {
-          promptTokensRaw: opts.preTokens,
-          stage1: {
-            tokensIn: opts.preTokens,
-            tokensOut: opts.preTokens,
-            wallMs: 0,
-            ratio: 1,
-            skipped: false,
-          },
-          stage2: {
-            tokensIn: opts.preTokens,
-            tokensOut: opts.postTokens,
-            wallMs: 0,
-            ratio: opts.preTokens > 0 ? opts.postTokens / opts.preTokens : 1,
-            skipped: opts.skipped ?? false,
-          },
-          stage3: {
-            tokensIn: opts.postTokens,
-            tokensOut: opts.postTokens,
-            wallMs: 0,
-            ratio: 1,
-            skipped: opts.skipped ?? false,
-          },
-          totalWallMs: 7,
-        },
-      });
+  // ─── LAI phase 2 — Stage 1 + Headroom sidecar integration ──────────
+  describe('compression pipeline (Stage 1 + Headroom sidecar)', () => {
+    /** Build a sidecar mock that returns the supplied compressed text and
+     *  reports a fixed savings. */
+    function fakeSidecar(opts: {
+      compressedContent: string;
+      originalTokens: number;
+      finalTokens: number;
+      transforms?: string[];
+    }): (req: HeadroomSidecarRequest) => Promise<HeadroomSidecarResponse> {
+      return async (req) => {
+        const saved = Math.max(0, opts.originalTokens - opts.finalTokens);
+        const ratio =
+          opts.originalTokens > 0 ? saved / opts.originalTokens : 0;
+        return {
+          compressed_messages: [
+            { ...req.messages[0]!, content: opts.compressedContent },
+          ],
+          tokens_saved: saved,
+          compression_ratio: ratio,
+          original_tokens: opts.originalTokens,
+          final_tokens: opts.finalTokens,
+          transforms_applied: opts.transforms ?? ['router:smart_crusher:0.00'],
+        };
+      };
     }
 
-    it('routes the prompt through the optimizer before spawn (compressed body lands on stdin)', async () => {
+    it('routes the prompt through the sidecar before spawn (compressed body lands on stdin)', async () => {
       const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
       const adapter = new ClaudeAdapter({
         spawnFn: fn,
-        optimizeFn: fakeOptimize({
-          out: 'COMPRESSED',
-          preTokens: 1000,
-          postTokens: 200,
+        sidecarFn: fakeSidecar({
+          compressedContent: 'COMPRESSED',
+          originalTokens: 1000,
+          finalTokens: 200,
         }),
       });
       await adapter.generate('claude-sonnet-4-6', {
         taskType: 't',
         prompt: 'the original verbose prompt body with redundant filler text',
       });
+      // Only one spawn (claude binary). Sidecar was injected, not spawned.
+      expect(invocations).toHaveLength(1);
       expect(invocations[0]!.stdinChunks.join('')).toBe('COMPRESSED');
     });
 
-    it('emits pre_token_count / post_token_count / compression_ratio on the response', async () => {
+    it('emits pre/post token counts and headroom_tokens_saved / headroom_ratio', async () => {
       const { fn } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-      const adapter = new ClaudeAdapter({
-        spawnFn: fn,
-        optimizeFn: fakeOptimize({
-          out: 'COMPRESSED',
-          preTokens: 1000,
-          postTokens: 400,
-          protectedSpans: 2,
-        }),
-      });
-      const out = await adapter.generate('claude-sonnet-4-6', {
-        taskType: 't',
-        prompt: 'whatever',
-      });
-      expect(out.optimizer).toBeDefined();
-      expect(out.optimizer!.pre_token_count).toBe(1000);
-      expect(out.optimizer!.post_token_count).toBe(400);
-      expect(out.optimizer!.compression_ratio).toBeCloseTo(0.4, 5);
-      expect(out.optimizer!.protected_span_count).toBe(2);
-      expect(out.optimizer!.skipped).toBe(false);
-    });
-
-    it('forwards optimizer metrics to onOptimizerMetrics sink (OTel/dashboard hook)', async () => {
       const sink = vi.fn();
-      const { fn } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
       const adapter = new ClaudeAdapter({
         spawnFn: fn,
-        optimizeFn: fakeOptimize({
-          out: 'COMPRESSED',
-          preTokens: 800,
-          postTokens: 320,
+        sidecarFn: fakeSidecar({
+          compressedContent: 'COMPRESSED',
+          originalTokens: 1000,
+          finalTokens: 300,
         }),
         onOptimizerMetrics: sink,
       });
-      await adapter.generate('claude-sonnet-4-6', { taskType: 't', prompt: 'x' });
-      expect(sink).toHaveBeenCalledTimes(1);
-      const m = sink.mock.calls[0]![0] as OptimizerMetrics;
-      expect(m.pre_token_count).toBe(800);
-      expect(m.post_token_count).toBe(320);
-      expect(m.compression_ratio).toBeCloseTo(0.4, 5);
-    });
-
-    it('marks skipped=true when both stage2 and stage3 bailed out (short prompt path)', async () => {
-      const { fn } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-      const adapter = new ClaudeAdapter({
-        spawnFn: fn,
-        optimizeFn: fakeOptimize({
-          out: 'short prompt',
-          preTokens: 50,
-          postTokens: 50,
-          skipped: true,
-        }),
-      });
       const out = await adapter.generate('claude-sonnet-4-6', {
         taskType: 't',
-        prompt: 'short prompt',
+        prompt: 'whatever the prompt is, the stage 1 pass plus headroom owns it',
       });
-      expect(out.optimizer?.skipped).toBe(true);
-      expect(out.optimizer?.compression_ratio).toBe(1);
+      expect(out.optimizer).toBeDefined();
+      expect(out.optimizer!.skipped).toBe(false);
+      expect(out.optimizer!.headroom_tokens_saved).toBe(700);
+      expect(out.optimizer!.headroom_ratio).toBeCloseTo(0.7, 5);
+      expect(out.optimizer!.post_token_count).toBe(300);
+      // The sink received the same metrics.
+      expect(sink).toHaveBeenCalledTimes(1);
+      const m = sink.mock.calls[0]![0] as OptimizerMetrics;
+      expect(m.headroom_tokens_saved).toBe(700);
+      expect(m.headroom_ratio).toBeCloseTo(0.7, 5);
     });
 
-    it('degrades gracefully when optimizer throws — sends raw prompt and emits skipped metric', async () => {
-      const sink = vi.fn();
-      const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+    it('passes the user prompt (post-Stage-1) to the sidecar as a single user message', async () => {
+      const { fn } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+      let captured: HeadroomSidecarRequest | null = null;
       const adapter = new ClaudeAdapter({
         spawnFn: fn,
-        optimizeFn: async () => {
-          throw new Error('optimizer exploded');
+        sidecarFn: async (req) => {
+          captured = req;
+          return identitySidecar(req);
+        },
+      });
+      await adapter.generate('claude-sonnet-4-6', {
+        taskType: 't',
+        prompt: 'a short prompt',
+        systemPrompt: 'you are a poet',
+      });
+      expect(captured).not.toBeNull();
+      expect(captured!.messages).toHaveLength(1);
+      expect(captured!.messages[0]!.role).toBe('user');
+      // System prompt must NOT be folded into the sidecar input — it's
+      // forwarded separately via --append-system-prompt.
+      expect(captured!.messages[0]!.content).not.toContain('you are a poet');
+    });
+
+    it('degrades to Stage-1-only output when the sidecar throws', async () => {
+      const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+      const sink = vi.fn();
+      const adapter = new ClaudeAdapter({
+        spawnFn: fn,
+        sidecarFn: async () => {
+          throw new Error('sidecar exploded');
         },
         onOptimizerMetrics: sink,
       });
@@ -449,69 +452,80 @@ describe('ClaudeAdapter (binary spawn)', () => {
         taskType: 't',
         prompt: 'original verbose body',
       });
-      // The raw prompt must reach the binary even when the optimizer fails.
+      // Stage 1 produces the same body for trivial input — the raw
+      // prompt still reaches the binary.
       expect(invocations[0]!.stdinChunks.join('')).toBe('original verbose body');
       expect(out.optimizer?.skipped).toBe(true);
-      expect(out.optimizer?.compression_ratio).toBe(1);
+      expect(out.optimizer?.headroom_tokens_saved).toBe(0);
+      expect(out.optimizer?.headroom_ratio).toBe(0);
       expect(sink).toHaveBeenCalledTimes(1);
     });
 
-    it('honors optimizerDisabled — sends raw prompt unchanged and emits no optimizer field', async () => {
+    it('honors optimizerDisabled — sends raw prompt and emits no optimizer field', async () => {
       const sink = vi.fn();
-      const optimizeFn = vi.fn(async (_input: OptimizerInput) => {
-        throw new Error('optimizer should not be called when disabled');
+      const sidecarFn = vi.fn(async (_req: HeadroomSidecarRequest) => {
+        throw new Error('sidecar must not be called when optimizer is disabled');
       });
       const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
       const adapter = new ClaudeAdapter({
         spawnFn: fn,
         optimizerDisabled: true,
-        optimizeFn,
+        sidecarFn,
         onOptimizerMetrics: sink,
       });
       const out = await adapter.generate('claude-sonnet-4-6', {
         taskType: 't',
         prompt: 'untouched body',
       });
-      expect(optimizeFn).not.toHaveBeenCalled();
+      expect(sidecarFn).not.toHaveBeenCalled();
       expect(sink).not.toHaveBeenCalled();
       expect(invocations[0]!.stdinChunks.join('')).toBe('untouched body');
       expect(out.optimizer).toBeUndefined();
     });
 
-    it('does NOT feed systemPrompt to the optimizer (would otherwise duplicate it on stdin)', async () => {
-      // Capture the optimizer input so we can assert systemPrompt is omitted.
-      let captured: OptimizerInput | null = null;
-      const optimizeFn: (input: OptimizerInput) => Promise<OptimizerResult> = async (
-        input,
-      ) => {
-        captured = input;
-        return {
-          optimizedPrompt: input.userQuestion,
-          protectedSpanCount: 0,
-          metrics: {
-            promptTokensRaw: 10,
-            stage1: { tokensIn: 10, tokensOut: 10, wallMs: 0, ratio: 1, skipped: false },
-            stage2: { tokensIn: 10, tokensOut: 10, wallMs: 0, ratio: 1, skipped: true },
-            stage3: { tokensIn: 10, tokensOut: 10, wallMs: 0, ratio: 1, skipped: true },
-            totalWallMs: 1,
-          },
-        };
-      };
+    it('forwards systemPrompt via --append-system-prompt, NOT through the sidecar', async () => {
       const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
-      const adapter = new ClaudeAdapter({ spawnFn: fn, optimizeFn });
+      const adapter = new ClaudeAdapter({
+        spawnFn: fn,
+        sidecarFn: identitySidecar,
+      });
       await adapter.generate('claude-sonnet-4-6', {
         taskType: 't',
         prompt: 'the user-side body',
         systemPrompt: 'you are a poet',
       });
-      expect(captured).not.toBeNull();
-      expect(captured!.systemPrompt).toBeUndefined();
-      expect(captured!.userQuestion).toBe('the user-side body');
-      // System prompt still goes through the binary's --append-system-prompt flag,
-      // not stdin — so stdin only carries the optimized user prompt.
+      const args = invocations[0]!.args;
+      expect(args).toContain('--append-system-prompt');
+      expect(args).toContain('you are a poet');
+      // The system prompt must not be duplicated on stdin.
       expect(invocations[0]!.stdinChunks.join('')).toBe('the user-side body');
-      expect(invocations[0]!.args).toContain('--append-system-prompt');
-      expect(invocations[0]!.args).toContain('you are a poet');
+    });
+
+    it('rebuilds the final prompt by concatenating compressed_messages content', async () => {
+      const { fn, invocations } = makeFakeSpawn({ stdout: HAPPY_PATH_JSON });
+      // Sidecar returns multiple compressed messages (e.g. Headroom
+      // injected a synopsis turn). The adapter must concat them.
+      const sidecarFn = async (
+        _req: HeadroomSidecarRequest,
+      ): Promise<HeadroomSidecarResponse> => ({
+        compressed_messages: [
+          { role: 'assistant', content: 'PRIOR_SUMMARY' },
+          { role: 'user', content: 'COMPRESSED_USER_BODY' },
+        ],
+        tokens_saved: 500,
+        compression_ratio: 0.5,
+        original_tokens: 1000,
+        final_tokens: 500,
+        transforms_applied: ['router:summarize'],
+      });
+      const adapter = new ClaudeAdapter({ spawnFn: fn, sidecarFn });
+      await adapter.generate('claude-sonnet-4-6', {
+        taskType: 't',
+        prompt: 'a verbose original body',
+      });
+      expect(invocations[0]!.stdinChunks.join('')).toBe(
+        'PRIOR_SUMMARY\n\nCOMPRESSED_USER_BODY',
+      );
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1373,6 +1373,9 @@ importers:
 
   packages/local-llm-router:
     dependencies:
+      '@chiefaia/prompt-optimizer':
+        specifier: workspace:*
+        version: link:../prompt-optimizer
       '@hono/node-server':
         specifier: ^1.13.0
         version: 1.19.14(hono@4.12.15)
@@ -1432,6 +1435,8 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+
+  packages/local-llm-router-py-client: {}
 
   packages/local-rag:
     dependencies:
@@ -1696,6 +1701,27 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
+  packages/prompt-optimizer:
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/researcher:


### PR DESCRIPTION
## Summary
Phase 2 of the Local-AI-First Tier-1 build chain (F2). Replaces the broken `@chiefaia/prompt-optimizer` Stage 2/3 in the `ClaudeAdapter` compression pipeline with a Python sidecar that invokes `headroom.compress()`. Stage 1's rule prepass stays in the loop because Headroom doesn't dedupe the same way — the two are complementary.

- `python/headroom_sidecar.py` — one-shot subprocess; stdin/stdout JSON. Enables `compress_user_messages=True` because CAIA prompts arrive as a single user-role turn (Headroom's default config would route them to `router:protected:user_message` and produce 0% compression).
- `claude-adapter.ts` — sidecar spawn via configurable `HEADROOM_PYTHON`. 60s default timeout to cover Kompress's ~25s ModernBERT cold-start. `sidecarFn` injection seam keeps tests hermetic. On sidecar failure we degrade to Stage-1-only output with `skipped: true`.
- `types.ts` — `OptimizerMetrics` gains `headroom_tokens_saved` + `headroom_ratio`.
- Tests rewritten — 23 cases passing, full router suite 120/120 green.

## Smoke
End-to-end on `apprentice_canonical_brief_2026-05-11.md`:
- pre: 7228 tokens, post: 501 tokens, **93.07% overall reduction** (target >70%)
- Headroom alone: `headroom_tokens_saved=2433`, `headroom_ratio=0.829`
- Wall: 27s (dominated by Kompress cold-start)

Phase report: `~/Documents/projects/reports/local_ai_first_tier1_phase2_wire_2026-05-12.md`.

## Test plan
- [x] `pnpm test` — 120/120 pass
- [x] `pnpm build` — exits 0
- [x] Sidecar wire-format check (stdin/stdout JSON round-trip)
- [x] End-to-end adapter smoke with real Python sidecar + apprentice canonical brief

## Known limitations (out of scope for Phase 2)
- Cold-start cost repeats per call — long-lived sidecar daemon is future work.
- Kompress (ModernBERT) is destructive on prose; literal preservation relies on Stage 1's `<<protected:…>>` spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)