### PR TITLE
feat(reliability): A.3 b15.c spawn-v2 + b15.d verifier + b15.e audit-cron bundle

### DIFF
--- a/.changeset/feat-verifier-001-b15d.md
+++ b/.changeset/feat-verifier-001-b15d.md
@@ -1,0 +1,72 @@
+---
+"@chiefaia/verifier": minor
+---
+
+feat(verifier-001): @chiefaia/verifier — fourth review-sibling (B15.D)
+
+New private package `@chiefaia/verifier` ships the VERIFIER spawn — fourth
+sibling alongside `@chiefaia/critic` (security/regression/cost — blocking),
+`@chiefaia/code-reviewer` (correctness/style/types/tests — blocking), and
+`@chiefaia/reviewer` (advisory craftsmanship). Authority:
+`~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md`
+§6.3.
+
+**Public API**
+
+```ts
+runVerifier({ inputs, config }) -> Promise<VerifierRunOutcome>
+// VerifierRunOutcome { ok, verdict, worktreeCleanedUp, cleanupReason, ... }
+```
+
+**Domain**
+
+Acceptance-criteria-satisfaction (the spec-truth check). Independent of every
+other sibling's domain — distinct severity lexicon
+(`pass / fail-impl / fail-spec / uncertain`), distinct verdict structure
+(per-AC + per-test + per-DoD-stage rows + an `overall` binary).
+
+**Worktree isolation**
+
+Every verifier run creates a FRESH `/tmp/verifier_<job_id>` git worktree
+checked out at the implementor's PR head SHA. Cleanup runs via two layers:
+agent-side try/finally (agent.ts) AND wrapper-script bash trap
+(`bin/run-verifier.sh`). Idempotent; runs on success, exception, timeout,
+SIGTERM.
+
+**Routing semantics (per design §6.3.6)**
+
+| Routing class       | Verdict use                                                     |
+| ------------------- | --------------------------------------------------------------- |
+| `autonomous-loop`   | BLOCKING — gates `nodes.status='done'` via SPS B15.D trigger.   |
+| `operator-routed`   | ADVISORY — verdict logged + surfaced; operator decides on merge. |
+
+**DB integration**
+
+`infra/stolution/sps/migrations/2026-05-13_b15d_verifier_verdicts.sql`
+adds the `verifier_verdicts` table and replaces `done_status_guard` with a
+version that requires a row in that table with `overall='pass'` for every
+autonomous-loop subtask done-transition. Companion to B15.B's existing
+trigger (which checks `verifier_verdict_json` column-side); the two arms
+fire defence-in-depth.
+
+**Subscription-only**
+
+Per `feedback_no_api_key_billing.md`, the verifier strips
+`ANTHROPIC_API_KEY` from the spawn env at two layers (agent-side env scrub
++ wrapper-side `unset`). Auth flows through `CLAUDE_OAUTH_TOKEN` only.
+
+**Tests**
+
+- 11 vitest tests (positive/negative verdict capture, exception cleanup
+  audit, schema validation, prompt rendering, routing class flip).
+- 6 SQL trigger tests (`infra/stolution/sps/tests/test_b15d_verifier_verdicts.sh`)
+  proving the trigger blocks fail-verdict + missing-verdict transitions and
+  allows pass-verdict transitions, with AFTER-trigger side-effects intact.
+
+**Out of scope** (deferred to follow-up atomics)
+
+- Phase 2 deterministic detectors.
+- `verifier_queue` reconciler in claude_spawner_agent.py (B15.G).
+- Slot-manager `shadow_slot_id` reservation (design §6.3.3).
+- Operator-applied cluster-DB step on stolution (operator-routed; this PR
+  ships the schema-as-code surface only).

--- a/.github/workflows/verifier.yml
+++ b/.github/workflows/verifier.yml
@@ -1,0 +1,155 @@
+name: Verifier (B15.D)
+
+# Runs the @chiefaia/verifier agent on PRs whose body declares an SPS task
+# binding. The verifier is the fourth review-sibling — its domain is
+# acceptance-criteria-satisfaction (the spec-truth check), distinct from
+# Critic (security/regression/cost), Code-Reviewer (correctness/style/types),
+# and Reviewer (craftsmanship). See packages/verifier/DESIGN.md.
+#
+# BLOCKING for PRs flagged routing-class=autonomous-loop in the PR body
+# (e.g. "<!-- routing-class: autonomous-loop -->"); ADVISORY otherwise.
+#
+# Subscription-only: never sets ANTHROPIC_API_KEY in the spawn env. The
+# CLAUDE_OAUTH_TOKEN secret authenticates the `claude` binary via the
+# operator's Max subscription accounts.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, develop]
+
+concurrency:
+  group: verifier-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-spec-binding:
+    name: detect-spec-binding
+    runs-on: ubuntu-latest
+    outputs:
+      bound: ${{ steps.scan.outputs.bound }}
+      routing_class: ${{ steps.scan.outputs.routing_class }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan PR body for SPS task binding
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # The PR body is expected to carry an `<!-- sps-task-id: ... -->`
+        # marker added by the slot-manager when the autonomous-loop opens
+        # the PR. PRs without that marker get verifier=ADVISORY and the
+        # verifier inputs are skipped — the workflow exits 0.
+        run: |
+          BODY=$(gh pr view "$PR_NUMBER" --json body --jq .body 2>/dev/null || echo "")
+          ROUTING="advisory"
+          if echo "$BODY" | grep -q "routing-class: autonomous-loop"; then
+            ROUTING="autonomous-loop"
+          elif echo "$BODY" | grep -q "routing-class: operator-routed"; then
+            ROUTING="operator-routed"
+          fi
+          BOUND="false"
+          if echo "$BODY" | grep -q "sps-task-id:"; then
+            BOUND="true"
+          fi
+          echo "bound=$BOUND"        >> "$GITHUB_OUTPUT"
+          echo "routing_class=$ROUTING" >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Verifier (${{ needs.detect-spec-binding.outputs.routing_class }})
+    needs: detect-spec-binding
+    if: |
+      needs.detect-spec-binding.outputs.bound == 'true' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-pnpm-mono
+
+      - name: Build verifier
+        run: pnpm --filter @chiefaia/verifier build
+
+      - name: Fetch SPS task spec
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # The slot-manager attaches the SPS task spec as an artifact on the
+          # PR via a `<!-- sps-task-spec-url: ... -->` marker. We materialize
+          # it into a verifier-inputs JSON file (see
+          # packages/verifier/src/types.ts VerifierSpawnInputs).
+          BODY=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+          SPEC_URL=$(echo "$BODY" | sed -n 's/.*sps-task-spec-url: \([^ ]*\).*/\1/p' | head -1)
+          if [ -z "$SPEC_URL" ]; then
+            echo "::warning::No sps-task-spec-url on PR — verifier exiting advisory-skip."
+            echo "skip=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          curl -sSL "$SPEC_URL" -o /tmp/verifier-inputs.json
+          echo "skip=false" >> "$GITHUB_ENV"
+
+      - name: Run verifier
+        if: env.skip != 'true'
+        env:
+          CLAUDE_OAUTH_TOKEN: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          ROUTING_CLASS: ${{ needs.detect-spec-binding.outputs.routing_class }}
+        id: verify
+        run: |
+          set +e
+          # The wrapper handles worktree create/cleanup via trap.
+          packages/verifier/bin/run-verifier.sh \
+            --inputs /tmp/verifier-inputs.json \
+            --out    /tmp/verifier-verdict.json \
+            --repo   "$PWD" \
+            --budget-seconds 900
+          RC=$?
+          OVERALL=$(node -e "
+            try {
+              const v = JSON.parse(require('fs').readFileSync('/tmp/verifier-verdict.json','utf8'));
+              console.log((v.verdict && v.verdict.overall) || 'unknown');
+            } catch (e) { console.log('parse-failed'); }
+          ")
+          echo "rc=$RC"           >> "$GITHUB_OUTPUT"
+          echo "overall=$OVERALL" >> "$GITHUB_OUTPUT"
+
+      - name: Post verifier verdict comment
+        if: env.skip != 'true' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          OVERALL: ${{ steps.verify.outputs.overall }}
+          ROUTING: ${{ needs.detect-spec-binding.outputs.routing_class }}
+        run: |
+          {
+            echo "<!-- caia-verifier -->"
+            echo "## :detective: Verifier (@chiefaia/verifier)"
+            echo ""
+            echo "**Routing:** \`$ROUTING\`"
+            echo "**Overall verdict:** \`$OVERALL\`"
+            echo ""
+            echo "Sibling agents: \`@chiefaia/critic\` (security/regression/cost), \`@chiefaia/code-reviewer\` (correctness/style/types), \`@chiefaia/reviewer\` (advisory craftsmanship). The verifier covers acceptance-criteria-satisfaction."
+            echo ""
+            echo '<details><summary>Full verdict JSON</summary>'
+            echo ""
+            echo '```json'
+            cat /tmp/verifier-verdict.json 2>/dev/null || echo '{"error":"no verdict file"}'
+            echo '```'
+            echo "</details>"
+          } > /tmp/verifier-comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/verifier-comment.md
+
+      - name: Fail on verifier=fail (autonomous-loop only — blocks merge)
+        if: |
+          env.skip != 'true' &&
+          needs.detect-spec-binding.outputs.routing_class == 'autonomous-loop' &&
+          steps.verify.outputs.overall != 'pass'
+        run: |
+          echo "::error::Verifier returned overall=${{ steps.verify.outputs.overall }} for an autonomous-loop PR — blocking merge."
+          exit 1

--- a/infra/stolution/sps/README.md
+++ b/infra/stolution/sps/README.md
@@ -36,3 +36,22 @@ them; B15.C is otherwise behaviour-neutral until B15.E lands.
 
 See `tests/test_b15b_done_triggers.sh` for the 3 negative + 1 positive
 acceptance tests.
+
+## 2026-05-13 — B15.D verifier verdicts
+
+`migrations/2026-05-13_b15d_verifier_verdicts.sql` adds the `verifier_verdicts`
+table (full provenance for every VERIFIER spawn run — see
+`packages/verifier/`) and replaces `done_status_guard` with a version that
+ALSO checks for a row in that table with `overall='pass'` for every
+autonomous-loop (scope-2/3) subtask done-transition. Operator-routed
+(scope-1) subtasks remain advisory — the verdict is recorded but does not
+block, matching the design's
+"blocking-for-autonomous-loop / advisory-for-operator-routed" rule.
+
+See `tests/test_b15d_verifier_verdicts.sh` for the negative + positive
+acceptance tests (6/6 pass).
+
+Apply order: `2026-05-13_b15b_done_triggers.sql` first, then
+`2026-05-13_b15d_verifier_verdicts.sql`. The B15.D migration drops and
+recreates `done_status_guard`; B15.B's `done_status_history_guard` and
+`cascade_on_done` are untouched.

--- a/infra/stolution/sps/README.md
+++ b/infra/stolution/sps/README.md
@@ -12,6 +12,7 @@ version control alongside CAIA.
 ```
 schema/00_baseline_schema.sql         — canonical schema (mirror of the SPS service)
 migrations/<datestamp>_<name>.sql     — sequenced, idempotent migrations
+scripts/<name>.py                     — operational scripts (e.g. cron jobs)
 tests/test_*.sh                       — acceptance tests, run against an
                                         ephemeral DB seeded from baseline+migrations
 ```
@@ -55,3 +56,24 @@ Apply order: `2026-05-13_b15b_done_triggers.sql` first, then
 `2026-05-13_b15d_verifier_verdicts.sql`. The B15.D migration drops and
 recreates `done_status_guard`; B15.B's `done_status_history_guard` and
 `cascade_on_done` are untouched.
+
+## 2026-05-13 — B15.E reliability_rolling + hourly audit cron
+
+`migrations/2026-05-13_b15e_reliability_rolling.sql` adds the
+`reliability_rolling` table (one row per 1h audit bucket) and the
+`redecompose_queue` table (auto-redo target for nodes scoring ≤ 2).
+
+`scripts/audit_recent_done.py` is the deterministic local scorer that fires
+hourly. It reads `done` nodes from the closed hour, applies the 0–5 rubric from
+`completion_audit_methodology_2026-05-10.md` to each, UPSERTs a row into
+`reliability_rolling`, dispatches score≤2 nodes into `redecompose_queue`
+(B14.J path), and appends a `[B15.E reliability-alert]` line to `INBOX.md`
+when the bucket reliability drops below 95% (or flips from clear to breached).
+
+Cron registration: `~/Library/LaunchAgents/com.chiefaia.sps-audit-recent-done-hourly.plist`
+(launchd, `StartCalendarInterval Minute=0` ≡ cron `0 * * * *`).
+Logs at `~/Library/Logs/chiefaia/sps-audit-recent-done.{out,err}.log`.
+
+See `tests/test_b15e_audit_recent_done.sh` for the 6 acceptance tests
+(schema / empty-bucket / bucket-math / auto-redo / INBOX-alert / UPSERT
+idempotence — 6/6 pass).

--- a/infra/stolution/sps/launchd/com.chiefaia.sps-audit-recent-done-hourly.plist
+++ b/infra/stolution/sps/launchd/com.chiefaia.sps-audit-recent-done-hourly.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.chiefaia.sps-audit-recent-done-hourly
+  ============================================================================
+  Hourly trigger for the B15.E audit_recent_done feedback loop.
+
+  Cron equivalent: 0 * * * *  (minute=0 of every hour).
+  Audits the closed hour (e.g. fires at 04:00:00, audits [03:00, 04:00)).
+
+  Source script:    infra/stolution/sps/scripts/audit_recent_done.py
+  Writes to:        ~/.sps/sps.db (reliability_rolling + redecompose_queue)
+  May append to:    ~/Documents/projects/agent-memory/INBOX.md (on breach)
+  Logs:             ~/Library/Logs/chiefaia/sps-audit-recent-done.{out,err}.log
+
+  Aligned with the existing chiefaia LaunchAgent convention used by
+  com.chiefaia.apprentice-corpus and com.chiefaia.local-llm-router (the cron
+  pattern the operator's standing scheduling rule follows on this Mac).
+  ============================================================================
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.chiefaia.sps-audit-recent-done-hourly</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>python3</string>
+    <string>/Users/macbook32/Documents/projects/caia/infra/stolution/sps/scripts/audit_recent_done.py</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>/Users/macbook32</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/macbook32/Documents/projects/caia/infra/stolution/sps</string>
+
+  <key>StandardOutPath</key>
+  <string>/Users/macbook32/Library/Logs/chiefaia/sps-audit-recent-done.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/macbook32/Library/Logs/chiefaia/sps-audit-recent-done.err.log</string>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>Nice</key>
+  <integer>5</integer>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/infra/stolution/sps/migrations/2026-05-13_b15d_verifier_verdicts.sql
+++ b/infra/stolution/sps/migrations/2026-05-13_b15d_verifier_verdicts.sql
@@ -1,0 +1,162 @@
+-- =============================================================================
+-- SPS Migration: 2026-05-13_b15d_verifier_verdicts
+-- =============================================================================
+-- Wires the B15.D VERIFIER (4th review-sibling) verdict into the SPS gating
+-- contract.  Companion to:
+--   * B15.B (2026-05-13_b15b_done_triggers.sql) — the done_status_guard
+--     trigger this migration UPDATES to additionally check a row in the new
+--     `verifier_verdicts` table (instead of solely relying on the
+--     `verifier_verdict_json` column on `nodes` from B15.C).
+--   * @chiefaia/verifier — the spawn package that produces verdicts conforming
+--     to packages/verifier/templates/verifier_verdict_schema.json.
+--
+-- Adds:
+--   1. `verifier_verdicts` table (full provenance per design §6.3.5):
+--      one row per verifier run, keyed by (node_id, verifier_spawn_id).
+--   2. `done_status_guard_v2` trigger replacing the B15.B `done_status_guard`:
+--      requires (per-row) a verifier_verdicts row with overall='pass' AND
+--      blocking=1 for autonomous-loop subtasks.  Operator-routed subtasks
+--      (scope_tag='1' single-stage path) are advisory — the trigger logs
+--      the verdict via the existing `done_status_history_guard` AFTER trigger
+--      but does NOT block on it.  The autonomous-loop path (scope_tag in
+--      ('2','3')) requires both the verdict row AND overall='pass'.
+--
+-- Why a separate table when nodes.verifier_verdict_json already exists?
+--   Per the task brief: "the trigger should check for a row in a
+--   `verifier_verdicts` table (or analogous) before allowing status='done'."
+--   The column form is a convenience cache; the table form is the truth-
+--   bearing record (multiple verdicts per node are allowed across retries —
+--   verification_attempt 1, 2, ... — and the `verifier_verdicts` table
+--   carries each).  The trigger gates on the LATEST row by (node_id,
+--   attempted_at).
+--
+-- Authoritative refs:
+--   ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md
+--     §6.3.4  verifier prompt template (B15.F)
+--     §6.3.5  verifier state machine integration + verifications table schema
+--     §6.3.6  blocking-for-autonomous-loop / advisory-for-operator-routed
+--   packages/verifier/templates/verifier_verdict_schema.json — the JSON shape
+--     the trigger json_extract()s ($.overall, $.verdict, $.blocking).
+--
+-- Idempotency: every statement uses IF NOT EXISTS or DROP+CREATE in a
+-- transaction so re-running on a DB that already has it is a no-op.
+-- =============================================================================
+
+PRAGMA foreign_keys = ON;
+
+BEGIN;
+
+-- Migration tracker (created by B15.B; this row guards re-apply).
+INSERT INTO schema_migrations (name) VALUES ('2026-05-13_b15d_verifier_verdicts');
+
+-- -----------------------------------------------------------------------------
+-- Part 1 — verifier_verdicts table (full provenance)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS verifier_verdicts (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id                 TEXT    NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    implementing_spawn_id   TEXT,
+    verifier_spawn_id       TEXT    NOT NULL,
+    pr_url                  TEXT,
+    pr_head_sha             TEXT,
+    -- 'pass' | 'fail' (binary used by the trigger).
+    overall                 TEXT    NOT NULL CHECK (overall IN ('pass','fail')),
+    -- 'pass' | 'fail-impl' | 'fail-spec' | 'uncertain' (fine-grained).
+    verdict                 TEXT    NOT NULL CHECK (verdict IN ('pass','fail-impl','fail-spec','uncertain')),
+    -- 1 (autonomous-loop) | 0 (operator-routed); the trigger respects this.
+    blocking                INTEGER NOT NULL DEFAULT 1 CHECK (blocking IN (0,1)),
+    routing_class           TEXT    NOT NULL CHECK (routing_class IN ('autonomous-loop','operator-routed')),
+    recommendation          TEXT,
+    -- Full verdict object as emitted by @chiefaia/verifier (schema_version='v1').
+    verdict_json            TEXT    NOT NULL,
+    reasons_json            TEXT,
+    summary                 TEXT,
+    attempted_at            TEXT    NOT NULL DEFAULT (datetime('now')),
+    duration_ms             INTEGER,
+    worktree_cleaned_up     INTEGER NOT NULL DEFAULT 1 CHECK (worktree_cleaned_up IN (0,1)),
+    UNIQUE (node_id, verifier_spawn_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_verifier_verdicts_node          ON verifier_verdicts(node_id);
+CREATE INDEX IF NOT EXISTS idx_verifier_verdicts_node_attempt  ON verifier_verdicts(node_id, attempted_at);
+CREATE INDEX IF NOT EXISTS idx_verifier_verdicts_overall       ON verifier_verdicts(overall);
+CREATE INDEX IF NOT EXISTS idx_verifier_verdicts_routing       ON verifier_verdicts(routing_class);
+
+-- -----------------------------------------------------------------------------
+-- Part 2 — replace done_status_guard with a version that ALSO checks the
+-- verifier_verdicts table.  We DROP+CREATE so this migration is idempotent
+-- regardless of the order of B15.B and B15.D landing on a given DB.
+-- -----------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS done_status_guard;
+
+CREATE TRIGGER done_status_guard
+BEFORE UPDATE OF status ON nodes
+FOR EACH ROW
+WHEN NEW.status = 'done' AND OLD.status != 'done'
+BEGIN
+  SELECT
+    CASE
+      -- ============================================================
+      -- Scope-1 (operator-routed, single-stage row-N) subtasks
+      -- ============================================================
+      WHEN NEW.scope_tag = '1' AND NEW.granularity = 'subtask' AND NEW.pr_url IS NULL
+        THEN RAISE(ABORT, 'done_status_guard: scope-1 subtask requires pr_url')
+      WHEN NEW.scope_tag = '1' AND NEW.granularity = 'subtask' AND NEW.verifier_verdict_json IS NULL
+        THEN RAISE(ABORT, 'done_status_guard: scope-1 subtask requires verifier_verdict_json')
+      -- Scope-1 is operator-routed — verifier verdict is ADVISORY.  The
+      -- column being non-null is enough; we do NOT require overall='pass'
+      -- here.  The audit dashboard surfaces the verdict for operator action.
+
+      -- ============================================================
+      -- Scope-2 / scope-3 (autonomous-loop) subtasks
+      -- ============================================================
+      WHEN NEW.scope_tag IN ('2','3') AND NEW.granularity = 'subtask' AND NEW.pr_url IS NULL
+        THEN RAISE(ABORT, 'done_status_guard: scope-2/3 subtask requires pr_url')
+      WHEN NEW.scope_tag IN ('2','3') AND NEW.granularity = 'subtask' AND NEW.pr_merge_sha IS NULL
+        THEN RAISE(ABORT, 'done_status_guard: scope-2/3 subtask requires pr_merge_sha')
+      WHEN NEW.scope_tag IN ('2','3') AND NEW.granularity = 'subtask' AND NEW.verifier_verdict_json IS NULL
+        THEN RAISE(ABORT, 'done_status_guard: scope-2/3 subtask requires verifier_verdict_json')
+      WHEN NEW.scope_tag IN ('2','3') AND NEW.granularity = 'subtask' AND NEW.regression_check_sha IS NULL
+        THEN RAISE(ABORT, 'done_status_guard: scope-2/3 subtask requires regression_check_sha')
+
+      -- The B15.B json_extract() check on the verdict column — kept as a
+      -- defensive layer (quick reject without needing to scan
+      -- verifier_verdicts).  Accepts both legacy {verdict:'pass',...} and
+      -- new {overall:'pass', verdict:'pass', ...} shapes.
+      WHEN NEW.scope_tag IN ('2','3') AND NEW.granularity = 'subtask'
+           AND COALESCE(json_extract(NEW.verifier_verdict_json, '$.overall'),
+                        json_extract(NEW.verifier_verdict_json, '$.verdict'))
+               != 'pass'
+        THEN RAISE(ABORT, 'done_status_guard: verifier verdict must be pass')
+
+      -- B15.D — the trigger ALSO checks verifier_verdicts table.  At least
+      -- one row must exist for this node, with overall='pass'.  Multiple
+      -- rows are allowed (re-attempts); we accept iff the LATEST one passes.
+      -- Empty table or no row for the node => reject.
+      WHEN NEW.scope_tag IN ('2','3') AND NEW.granularity = 'subtask'
+           AND NOT EXISTS (
+             SELECT 1
+             FROM verifier_verdicts vv
+             WHERE vv.node_id = NEW.id
+               AND vv.attempted_at = (
+                 SELECT MAX(attempted_at) FROM verifier_verdicts
+                 WHERE node_id = NEW.id
+               )
+               AND vv.overall = 'pass'
+           )
+        THEN RAISE(ABORT, 'done_status_guard: verifier_verdicts row with overall=pass required for autonomous-loop done')
+
+      -- Default-reject (carried forward from B15.B): subtasks without a
+      -- valid scope_tag cannot be promoted.
+      WHEN NEW.granularity = 'subtask' AND (NEW.scope_tag IS NULL OR NEW.scope_tag NOT IN ('1','2','3'))
+        THEN RAISE(ABORT, 'done_status_guard: subtask requires scope_tag in (1,2,3)')
+
+      ELSE NULL
+    END;
+END;
+
+COMMIT;
+
+-- =============================================================================
+-- End of migration 2026-05-13_b15d_verifier_verdicts
+-- =============================================================================

--- a/infra/stolution/sps/migrations/2026-05-13_b15e_reliability_rolling.sql
+++ b/infra/stolution/sps/migrations/2026-05-13_b15e_reliability_rolling.sql
@@ -1,0 +1,141 @@
+-- =============================================================================
+-- SPS Migration: 2026-05-13_b15e_reliability_rolling
+-- =============================================================================
+-- Adds the rolling reliability ledger that the hourly `audit_recent_done`
+-- cron writes to.  Companion to:
+--   * B15.B (2026-05-13_b15b_done_triggers.sql)       — static guard
+--   * B15.D (2026-05-13_b15d_verifier_verdicts.sql)   — VERIFIER sibling
+--   * scripts/audit_recent_done.py                    — the audit job
+--   * Library/LaunchAgents/com.chiefaia.sps-audit-recent-done-hourly.plist
+--                                                      — the hourly trigger
+--
+-- Closes the FEEDBACK loop of the Reliability-99% design (B15.E):
+--   triggers + verifier provide STATIC defence (block bad writes); the audit
+--   cron + this table + INBOX alerts provide DYNAMIC defence (re-score what
+--   slipped through and re-decompose the worst items via B14.J).
+--
+-- Schema design notes:
+--   * One row per audit bucket (1h window).  bucket_start is the PRIMARY KEY
+--     so the audit script can UPSERT (INSERT ... ON CONFLICT(bucket_start) DO
+--     UPDATE) and idempotently re-run the audit for any bucket without
+--     duplicating rows.
+--   * `reliability_pct` is computed at write-time, not as a generated column,
+--     so the audit script controls the divisor (synthetic test::* nodes are
+--     excluded per completion-audit methodology §2 sub-rule + §4 Class D).
+--   * `breached_threshold` is a snapshot-at-write of `reliability_pct < 95`,
+--     stored explicitly so downstream alerting can detect threshold *flips*
+--     (transition between consecutive buckets) without re-deriving the rule.
+--   * `nodes_redecomposed_json` carries the list of node_ids the audit pushed
+--     into B14.J's re-decompose path during the same run, for traceability.
+--
+-- Authoritative refs:
+--   ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md
+--     §6.6   reliability_rolling table + audit_recent_done cron (B15.E)
+--     §6.7   INBOX.md alert format on breach
+--     §6.8   auto-redo path (B14.J integration)
+--   ~/Documents/projects/agent-memory/completion_audit_methodology_2026-05-10.md
+--     §2     0–5 scoring rubric (the audit script implements this)
+--     §4     per-class verification methods
+--     §8     aggregate definitions (reliability rate = score≥3 / real items)
+--   ~/Documents/projects/agent-memory/scope_pipeline_unification_2026-05-10.md
+--     §[12]  re-decomposition on code/uncompletable (B14.J)
+--
+-- Idempotency: every statement uses IF NOT EXISTS.  Re-running the migration
+-- on a DB that already has it is a no-op (the schema_migrations row is the
+-- only side-effect that can collide, and it conflicts harmlessly).
+-- =============================================================================
+
+PRAGMA foreign_keys = ON;
+
+BEGIN;
+
+INSERT INTO schema_migrations (name) VALUES ('2026-05-13_b15e_reliability_rolling');
+
+-- -----------------------------------------------------------------------------
+-- reliability_rolling — one row per hourly audit bucket
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS reliability_rolling (
+    -- Bucket window — half-open interval [bucket_start, bucket_end).
+    -- bucket_start is normalised to the start of the hour in UTC ISO-8601
+    -- (e.g. '2026-05-13T03:00:00Z'); bucket_end = bucket_start + 1h.
+    bucket_start              TEXT    PRIMARY KEY,
+    bucket_end                TEXT    NOT NULL,
+
+    -- Headline counts (excluding synthetic test::* nodes per Class-D rule).
+    nodes_audited             INTEGER NOT NULL DEFAULT 0,
+    nodes_passing             INTEGER NOT NULL DEFAULT 0,   -- score >= 3
+    nodes_score_le_2          INTEGER NOT NULL DEFAULT 0,   -- score <= 2 (auto-redo target)
+    nodes_score_3_to_4        INTEGER NOT NULL DEFAULT 0,
+    nodes_score_5             INTEGER NOT NULL DEFAULT 0,
+
+    -- Computed reliability percentage (0.0 - 100.0).  Stored, not generated,
+    -- so the audit script controls the divisor (excluded synthetic nodes).
+    -- NULL when nodes_audited = 0 (degenerate bucket — no audit signal).
+    reliability_pct           REAL,
+
+    -- Snapshot-at-write of `reliability_pct < 95.0`.  Stored explicitly so the
+    -- INBOX alert wiring can detect FLIPS between consecutive buckets without
+    -- re-deriving the rule (the threshold itself is a constant in the audit
+    -- script — moving it requires a code change AND a backfill).
+    breached_threshold        INTEGER NOT NULL DEFAULT 0
+                                CHECK (breached_threshold IN (0,1)),
+
+    -- Audit-run provenance.  Multiple audit_run_ids per bucket are possible
+    -- only when the audit is replayed; the LATEST run wins (UPSERT behaviour).
+    audit_run_id              TEXT    NOT NULL,
+    audit_started_at          TEXT    NOT NULL,
+    audit_finished_at         TEXT    NOT NULL,
+    audit_duration_ms         INTEGER,
+
+    -- Auto-redo trace (B14.J integration).  JSON array of {node_id, score,
+    -- reason} for every node the audit dispatched into the re-decompose
+    -- queue during this run.  Empty array '[]' when none were dispatched.
+    nodes_redecomposed_json   TEXT    NOT NULL DEFAULT '[]',
+
+    -- Free-form notes (e.g. "audit aborted at node X — partial bucket").
+    notes                     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_reliability_rolling_breach
+    ON reliability_rolling(breached_threshold, bucket_start);
+CREATE INDEX IF NOT EXISTS idx_reliability_rolling_audit_run
+    ON reliability_rolling(audit_run_id);
+
+-- -----------------------------------------------------------------------------
+-- redecompose_queue — light-weight target table for the B14.J path
+-- -----------------------------------------------------------------------------
+-- Per the design, B14.J's reconciler polls SPS for rows with
+-- `next_action='re-decompose'`.  In the live SPS service that lives in the
+-- DLQ table, but this stand-alone Mac-side DB doesn't yet have the DLQ — we
+-- create a thin queue table so the audit script can record its dispatch
+-- decisions deterministically and the B14.J reconciler can drain them with
+-- the same SELECT shape.  When the live DLQ lands here this table can be
+-- replaced by a VIEW backed by `dead_letter`.
+CREATE TABLE IF NOT EXISTS redecompose_queue (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id         TEXT    NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+    next_action     TEXT    NOT NULL DEFAULT 're-decompose'
+                       CHECK (next_action IN ('re-decompose','operator-decision','escalate')),
+    -- The score the audit assigned that triggered this dispatch (≤ 2).
+    audit_score     INTEGER NOT NULL CHECK (audit_score BETWEEN 0 AND 5),
+    audit_reason    TEXT,
+    audit_run_id    TEXT    NOT NULL,
+    audit_bucket    TEXT    NOT NULL,
+    queued_at       TEXT    NOT NULL DEFAULT (datetime('now')),
+    -- Bounded by depth, not time — see scope_pipeline_unification §[12].
+    depth_at_queue  INTEGER NOT NULL DEFAULT 0,
+    decided         INTEGER NOT NULL DEFAULT 0 CHECK (decided IN (0,1)),
+    decided_at      TEXT,
+    UNIQUE (node_id, audit_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_redecompose_queue_open
+    ON redecompose_queue(decided, next_action, queued_at);
+CREATE INDEX IF NOT EXISTS idx_redecompose_queue_node
+    ON redecompose_queue(node_id);
+
+COMMIT;
+
+-- =============================================================================
+-- End of migration 2026-05-13_b15e_reliability_rolling
+-- =============================================================================

--- a/infra/stolution/sps/scripts/audit_recent_done.py
+++ b/infra/stolution/sps/scripts/audit_recent_done.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# =============================================================================
+# audit_recent_done — hourly self-audit feedback loop (B15.E)
+# =============================================================================
+# Re-scores `done` nodes from the last 1h against the 10-stage Definition-of-
+# Done methodology and writes the result to `reliability_rolling`.  Items
+# scoring <=2 are dispatched into the B14.J `re-decompose` queue.
+#
+# This script is a deterministic local scorer over DB rows — it does NOT
+# spawn `claude` or call any LLM.  All of the heuristics live in
+# `score_node()` below and follow `completion_audit_methodology_2026-05-10.md`.
+#
+# Cron contract (com.chiefaia.sps-audit-recent-done-hourly):
+#   * Runs at minute 0 of every hour.
+#   * Audits the bucket [previous-hour-start, previous-hour-end) — i.e. the
+#     hour that JUST closed, not the in-progress hour.
+#   * Idempotent: re-running for an existing bucket UPSERTs the row.
+#   * Writes one row to reliability_rolling, plus N rows to redecompose_queue
+#     (one per score≤2 node), all in a single transaction.
+#   * On bucket reliability < 95% (or threshold flip vs prior bucket), appends
+#     a structured alert line to ~/Documents/projects/agent-memory/INBOX.md.
+#
+# Exit codes:
+#   0 — audit completed (bucket may be empty; that's not an error).
+#   1 — DB unavailable / schema missing.
+#   2 — audit ran but the alert append failed (caller may want to retry).
+#
+# Usage:
+#   audit_recent_done.py                    # audit prev hour, write to live DB
+#   audit_recent_done.py --bucket 2026-05-13T02:00:00Z   # audit specific bucket
+#   audit_recent_done.py --db /tmp/x.db --inbox /tmp/y.md   # ephemeral test mode
+#   audit_recent_done.py --dry-run          # print summary, do not write
+#
+# Authoritative refs:
+#   ~/Documents/projects/agent-memory/completion_audit_methodology_2026-05-10.md
+#   ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md §6.6-6.8
+#   ~/Documents/projects/agent-memory/scope_pipeline_unification_2026-05-10.md §[12]
+# =============================================================================
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# ---- Constants --------------------------------------------------------------
+
+RELIABILITY_THRESHOLD_PCT = 95.0          # design §6.6: alert below this
+MAX_REDECOMPOSE_DEPTH      = 3            # design §[12]: bounded recursion
+SYNTHETIC_NODE_PREFIXES    = ('test::',)  # methodology §4 Class D — exclude
+
+DEFAULT_DB    = Path.home() / '.sps' / 'sps.db'
+DEFAULT_INBOX = Path.home() / 'Documents' / 'projects' / 'agent-memory' / 'INBOX.md'
+
+# ---- Bucket helpers ---------------------------------------------------------
+
+def previous_hour_bucket(now: datetime | None = None) -> tuple[str, str]:
+    """Return (bucket_start, bucket_end) ISO-8601 UTC strings for the hour
+    that just closed (i.e. one hour before `now` rounded down to the hour)."""
+    now = now or datetime.now(tz=timezone.utc)
+    end = now.replace(minute=0, second=0, microsecond=0)
+    start = end - timedelta(hours=1)
+    iso = lambda dt: dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+    return iso(start), iso(end)
+
+
+def parse_bucket(bucket_start: str) -> tuple[str, str]:
+    """Given an ISO-8601 bucket_start, return (bucket_start, bucket_end)
+    where bucket_end = bucket_start + 1h."""
+    dt = datetime.strptime(bucket_start, '%Y-%m-%dT%H:%M:%SZ').replace(
+        tzinfo=timezone.utc)
+    end = dt + timedelta(hours=1)
+    return bucket_start, end.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+# ---- Scoring ----------------------------------------------------------------
+
+def is_synthetic(node_id: str) -> bool:
+    return any(node_id.startswith(p) for p in SYNTHETIC_NODE_PREFIXES)
+
+
+def score_node(row: dict[str, Any]) -> tuple[int, str]:
+    """Apply the 0-5 rubric to one row.  Returns (score, reason).
+
+    Methodology §2 mapping (deterministic over DB columns — the rubric's
+    `code shipped`, `tests`, `regression`, `documentation` heuristics are
+    proxied by the evidence columns added in B15.C):
+
+      * pr_url IS NULL                            → score 0 (false-claim)
+      * pr_url present but no pr_merge_sha        → score 1 (verify-noop)
+      * verifier_verdict_json overall != 'pass'   → score 1 (failed verdict)
+      * dod_stages_evidenced character count vs required:
+          0/10 → 0 ; 1-3/10 → 1 ; 4-5/10 → 2 ; 6-7/10 → 3 ; 8-9/10 → 4 ; 10/10 → 5
+      * regression_check_result != 'pass'         → cap at 4
+      * No regression_check_sha                   → cap at 3
+    """
+    pr_url           = row.get('pr_url')
+    pr_merge_sha     = row.get('pr_merge_sha')
+    vv_json          = row.get('verifier_verdict_json')
+    dod_required     = row.get('dod_stages_required') or ''
+    dod_evidenced    = row.get('dod_stages_evidenced') or ''
+    regr_result      = row.get('regression_check_result')
+    regr_sha         = row.get('regression_check_sha')
+
+    if not pr_url:
+        return 0, 'no pr_url — false-claim per methodology §2 score-0 rule'
+    if not pr_merge_sha:
+        return 1, 'pr_url present but no pr_merge_sha — verify-noop'
+    if vv_json:
+        try:
+            vv = json.loads(vv_json)
+            overall = (vv.get('overall') or '').lower()
+            if overall and overall != 'pass':
+                return 1, f'verifier verdict overall={overall!r}'
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    stages_met = sum(1 for c in dod_evidenced if c == 'X')
+    if not dod_evidenced:
+        # No DoD self-cert at all but PR merged — base-line proves "Implement".
+        # Treat as score-3 "real change, weak proof" (methodology §2).
+        base_score = 3
+        reason = 'pr merged but no dod self-cert — base-line proof only'
+    elif stages_met == 10:
+        base_score = 5
+        reason = 'dod 10/10 stages evidenced'
+    elif stages_met >= 8:
+        base_score = 4
+        reason = f'dod {stages_met}/10 stages evidenced'
+    elif stages_met >= 6:
+        base_score = 3
+        reason = f'dod {stages_met}/10 stages evidenced'
+    elif stages_met >= 4:
+        base_score = 2
+        reason = f'dod {stages_met}/10 stages evidenced — trivial-PR cap'
+    elif stages_met >= 1:
+        base_score = 1
+        reason = f'dod {stages_met}/10 stages evidenced — verify-noop band'
+    else:
+        base_score = 0
+        reason = 'dod 0/10 stages evidenced — false-claim'
+
+    score = base_score
+    if regr_result and regr_result != 'pass':
+        score = min(score, 4)
+        reason += f'; regression={regr_result} (capped 4)'
+    elif not regr_sha:
+        score = min(score, 3)
+        reason += '; no regression_check_sha (capped 3)'
+
+    return score, reason
+
+
+# ---- DB I/O -----------------------------------------------------------------
+
+NODE_COLUMNS = [
+    'id', 'item_code', 'status', 'updated_at', 'scope_tag',
+    'pr_url', 'pr_merge_sha',
+    'verifier_verdict_json', 'verifier_feedback_json',
+    'regression_check_sha', 'regression_check_result',
+    'dod_stages_required', 'dod_stages_evidenced', 'dod_self_cert_json',
+    'redecompose_attempt',
+]
+
+
+def _iso_to_sqlite(iso: str) -> str:
+    """Convert 'YYYY-MM-DDTHH:MM:SSZ' to SQLite's 'YYYY-MM-DD HH:MM:SS'.
+    nodes.updated_at uses the SQLite native (space-separated, no Z) format,
+    so bucket boundary comparisons must match that or string ordering breaks
+    (' ' < 'T' in ASCII)."""
+    return iso.replace('T', ' ').rstrip('Z')
+
+
+def fetch_done_in_bucket(conn: sqlite3.Connection,
+                         bucket_start: str,
+                         bucket_end: str) -> list[dict[str, Any]]:
+    cols = ', '.join(NODE_COLUMNS)
+    rows = conn.execute(
+        f'SELECT {cols} FROM nodes '
+        f"WHERE status = 'done' "
+        f'  AND updated_at >= ? '
+        f'  AND updated_at <  ? '
+        f'ORDER BY updated_at ASC',
+        (_iso_to_sqlite(bucket_start), _iso_to_sqlite(bucket_end)),
+    ).fetchall()
+    return [dict(zip(NODE_COLUMNS, r)) for r in rows]
+
+
+def upsert_bucket_row(conn: sqlite3.Connection, payload: dict[str, Any]) -> None:
+    conn.execute(
+        '''INSERT INTO reliability_rolling
+              (bucket_start, bucket_end,
+               nodes_audited, nodes_passing, nodes_score_le_2,
+               nodes_score_3_to_4, nodes_score_5,
+               reliability_pct, breached_threshold,
+               audit_run_id, audit_started_at, audit_finished_at,
+               audit_duration_ms, nodes_redecomposed_json, notes)
+           VALUES (:bucket_start, :bucket_end,
+                   :nodes_audited, :nodes_passing, :nodes_score_le_2,
+                   :nodes_score_3_to_4, :nodes_score_5,
+                   :reliability_pct, :breached_threshold,
+                   :audit_run_id, :audit_started_at, :audit_finished_at,
+                   :audit_duration_ms, :nodes_redecomposed_json, :notes)
+           ON CONFLICT(bucket_start) DO UPDATE SET
+               bucket_end              = excluded.bucket_end,
+               nodes_audited           = excluded.nodes_audited,
+               nodes_passing           = excluded.nodes_passing,
+               nodes_score_le_2        = excluded.nodes_score_le_2,
+               nodes_score_3_to_4      = excluded.nodes_score_3_to_4,
+               nodes_score_5           = excluded.nodes_score_5,
+               reliability_pct         = excluded.reliability_pct,
+               breached_threshold      = excluded.breached_threshold,
+               audit_run_id            = excluded.audit_run_id,
+               audit_started_at        = excluded.audit_started_at,
+               audit_finished_at       = excluded.audit_finished_at,
+               audit_duration_ms       = excluded.audit_duration_ms,
+               nodes_redecomposed_json = excluded.nodes_redecomposed_json,
+               notes                   = excluded.notes
+        ''', payload)
+
+
+def insert_redecompose(conn: sqlite3.Connection,
+                       node_id: str,
+                       audit_score: int,
+                       audit_reason: str,
+                       audit_run_id: str,
+                       audit_bucket: str,
+                       depth: int) -> bool:
+    if depth >= MAX_REDECOMPOSE_DEPTH:
+        # Bounded by depth; escalate instead.
+        next_action = 'operator-decision'
+    else:
+        next_action = 're-decompose'
+    try:
+        conn.execute(
+            '''INSERT INTO redecompose_queue
+                  (node_id, next_action, audit_score, audit_reason,
+                   audit_run_id, audit_bucket, depth_at_queue)
+               VALUES (?,?,?,?,?,?,?)''',
+            (node_id, next_action, audit_score, audit_reason,
+             audit_run_id, audit_bucket, depth),
+        )
+        return True
+    except sqlite3.IntegrityError:
+        # UNIQUE(node_id, audit_run_id) — already dispatched this run.
+        return False
+
+
+def previous_bucket_breached(conn: sqlite3.Connection,
+                             bucket_start: str) -> bool | None:
+    """Return the breached_threshold of the bucket immediately preceding
+    bucket_start, or None if there is no prior bucket."""
+    row = conn.execute(
+        'SELECT breached_threshold FROM reliability_rolling '
+        'WHERE bucket_start < ? ORDER BY bucket_start DESC LIMIT 1',
+        (bucket_start,),
+    ).fetchone()
+    return bool(row[0]) if row else None
+
+
+# ---- INBOX append -----------------------------------------------------------
+
+def append_inbox_alert(inbox_path: Path,
+                       bucket_start: str,
+                       bucket_end: str,
+                       reliability_pct: float | None,
+                       nodes_audited: int,
+                       nodes_score_le_2: int,
+                       flip: str,
+                       db_path: Path) -> None:
+    """Append an INBOX alert per design §6.7.
+
+    Format (single line, prefix-tagged so jq/grep can detect it):
+        [B15.E reliability-alert] <ts> bucket=<start>/<end> rel=<pct>% audited=<N> score_le_2=<M> flip=<flip> db=<path>
+    """
+    ts = datetime.now(tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    rel = f'{reliability_pct:.2f}' if reliability_pct is not None else 'N/A'
+    line = (
+        f'\n[B15.E reliability-alert] ts={ts} '
+        f'bucket={bucket_start}/{bucket_end} '
+        f'rel={rel}% audited={nodes_audited} '
+        f'score_le_2={nodes_score_le_2} flip={flip} '
+        f'db={db_path} '
+        f'(see reliability_rolling row for bucket_start={bucket_start})\n'
+    )
+    inbox_path.parent.mkdir(parents=True, exist_ok=True)
+    with inbox_path.open('a', encoding='utf-8') as fh:
+        fh.write(line)
+
+
+# ---- Main -------------------------------------------------------------------
+
+def run_audit(db_path: Path,
+              inbox_path: Path,
+              bucket_start: str | None = None,
+              dry_run: bool = False) -> dict[str, Any]:
+    if not db_path.exists():
+        raise FileNotFoundError(f'SPS DB not found at {db_path}')
+
+    bucket_start, bucket_end = (
+        parse_bucket(bucket_start) if bucket_start else previous_hour_bucket()
+    )
+
+    started_at_iso = datetime.now(tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    started_at_mono = time.monotonic()
+    audit_run_id = f'audit-{uuid.uuid4().hex[:12]}'
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute('PRAGMA foreign_keys = ON')
+    try:
+        rows = fetch_done_in_bucket(conn, bucket_start, bucket_end)
+        real_rows = [r for r in rows if not is_synthetic(r['id'])]
+
+        nodes_audited      = len(real_rows)
+        nodes_score_5      = 0
+        nodes_score_3_to_4 = 0
+        nodes_score_le_2   = 0
+        redecomposed: list[dict[str, Any]] = []
+        per_node_scores: list[dict[str, Any]] = []
+
+        for r in real_rows:
+            score, reason = score_node(r)
+            per_node_scores.append({
+                'node_id': r['id'], 'item_code': r['item_code'],
+                'score': score, 'reason': reason,
+            })
+            if score == 5:
+                nodes_score_5 += 1
+            elif score >= 3:
+                nodes_score_3_to_4 += 1
+            else:
+                nodes_score_le_2 += 1
+                if not dry_run:
+                    inserted = insert_redecompose(
+                        conn, r['id'], score, reason,
+                        audit_run_id, bucket_start,
+                        int(r.get('redecompose_attempt') or 0),
+                    )
+                    if inserted:
+                        redecomposed.append({
+                            'node_id': r['id'], 'score': score,
+                            'reason': reason,
+                        })
+
+        nodes_passing  = nodes_score_3_to_4 + nodes_score_5
+        reliability_pct = (
+            (nodes_passing / nodes_audited * 100.0) if nodes_audited else None
+        )
+        breached = bool(
+            reliability_pct is not None and reliability_pct < RELIABILITY_THRESHOLD_PCT
+        )
+
+        finished_at_iso = datetime.now(tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+        duration_ms = int((time.monotonic() - started_at_mono) * 1000)
+
+        payload = {
+            'bucket_start': bucket_start, 'bucket_end': bucket_end,
+            'nodes_audited': nodes_audited,
+            'nodes_passing': nodes_passing,
+            'nodes_score_le_2': nodes_score_le_2,
+            'nodes_score_3_to_4': nodes_score_3_to_4,
+            'nodes_score_5': nodes_score_5,
+            'reliability_pct': reliability_pct,
+            'breached_threshold': 1 if breached else 0,
+            'audit_run_id': audit_run_id,
+            'audit_started_at': started_at_iso,
+            'audit_finished_at': finished_at_iso,
+            'audit_duration_ms': duration_ms,
+            'nodes_redecomposed_json': json.dumps(redecomposed),
+            'notes': None,
+        }
+
+        prior_breached = previous_bucket_breached(conn, bucket_start)
+        flip = 'first' if prior_breached is None else (
+            'flip-to-breach' if (breached and not prior_breached) else
+            'flip-to-clear'  if (not breached and prior_breached) else
+            ('still-breached' if breached else 'still-clear')
+        )
+
+        if not dry_run:
+            upsert_bucket_row(conn, payload)
+            conn.commit()
+
+            if breached or flip == 'flip-to-breach':
+                try:
+                    append_inbox_alert(
+                        inbox_path, bucket_start, bucket_end,
+                        reliability_pct, nodes_audited,
+                        nodes_score_le_2, flip, db_path,
+                    )
+                except OSError as exc:
+                    return {'ok': False, 'inbox_error': str(exc), **payload,
+                            'flip': flip, 'per_node_scores': per_node_scores}
+
+        return {
+            'ok': True, 'flip': flip,
+            'per_node_scores': per_node_scores,
+            'redecomposed': redecomposed,
+            **payload,
+        }
+    finally:
+        conn.close()
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description='Hourly self-audit of recent done nodes (B15.E)')
+    p.add_argument('--db',     default=str(DEFAULT_DB),    help='SPS DB path')
+    p.add_argument('--inbox',  default=str(DEFAULT_INBOX), help='INBOX.md path')
+    p.add_argument('--bucket', default=None,
+                   help='ISO-8601 bucket_start (default: previous closed hour)')
+    p.add_argument('--dry-run', action='store_true',
+                   help='Print summary but do not write to DB or INBOX')
+    p.add_argument('--json', action='store_true',
+                   help='Emit summary as JSON instead of human text')
+    args = p.parse_args(argv)
+
+    try:
+        result = run_audit(Path(args.db), Path(args.inbox),
+                           bucket_start=args.bucket, dry_run=args.dry_run)
+    except FileNotFoundError as exc:
+        print(f'ERR: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        rel = result['reliability_pct']
+        rel_s = f'{rel:.2f}%' if rel is not None else 'N/A (empty bucket)'
+        print(
+            f"audit_run_id={result['audit_run_id']} "
+            f"bucket={result['bucket_start']}/{result['bucket_end']}\n"
+            f"  audited={result['nodes_audited']} "
+            f"passing={result['nodes_passing']} "
+            f"score_le_2={result['nodes_score_le_2']} "
+            f"score_3_to_4={result['nodes_score_3_to_4']} "
+            f"score_5={result['nodes_score_5']}\n"
+            f"  reliability={rel_s} breached={bool(result['breached_threshold'])} "
+            f"flip={result['flip']}\n"
+            f"  redecomposed={len(result.get('redecomposed', []))} nodes "
+            f"duration_ms={result['audit_duration_ms']}"
+        )
+
+    if not result.get('ok', True):
+        return 2
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/infra/stolution/sps/tests/test_b15d_verifier_verdicts.sh
+++ b/infra/stolution/sps/tests/test_b15d_verifier_verdicts.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# =============================================================================
+# B15.D verifier-verdicts trigger acceptance tests
+# =============================================================================
+# Two tests prove the wiring of the VERIFIER verdict into the autonomous-loop
+# done-path:
+#
+#   POSITIVE — verifier verdict overall='pass' written to verifier_verdicts
+#              row for an autonomous-loop (scope-2) subtask with all four
+#              evidence columns populated; the UPDATE nodes SET status='done'
+#              succeeds and the AFTER-triggers (history marker + cascade row)
+#              fire.
+#
+#   NEGATIVE — verifier verdict overall='fail' (or no row in verifier_verdicts
+#              at all) for a scope-2 subtask blocks the done transition with
+#              the new "verifier_verdicts row with overall=pass required ..."
+#              error.  Row remains status='in_review' (== 'running' in the
+#              SPS schema's status enum — there is no `in_review` state, so
+#              we use 'running' which is the in-flight state in the canonical
+#              schema; the task's "in_review" label is a working name for
+#              the same in-flight state — see DEVIATION 3 in the report).
+#
+# Runs against an ephemeral SQLite DB seeded from the canonical schema +
+# B15.B migration + B15.D migration.
+#
+# Usage:   ./test_b15d_verifier_verdicts.sh
+# Exit:    0 = all pass; 1+ = number of failures
+# =============================================================================
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SPS_ROOT="$(cd "$HERE/.." && pwd)"
+SCHEMA="$SPS_ROOT/schema/00_baseline_schema.sql"
+MIG_B15B="$SPS_ROOT/migrations/2026-05-13_b15b_done_triggers.sql"
+MIG_B15D="$SPS_ROOT/migrations/2026-05-13_b15d_verifier_verdicts.sql"
+TMP_DB="$(mktemp -t sps_b15d_test.XXXXXX.db)"
+trap 'rm -f "$TMP_DB" "$TMP_DB-shm" "$TMP_DB-wal"' EXIT
+
+for f in "$SCHEMA" "$MIG_B15B" "$MIG_B15D"; do
+  [[ -f "$f" ]] || { echo "FAIL: missing $f" >&2; exit 1; }
+done
+
+# Apply schema + migrations in order (B15.B first; B15.D drops+recreates
+# done_status_guard so the order is enforced by the test, not the migrations).
+sqlite3 "$TMP_DB" < "$SCHEMA"
+sqlite3 "$TMP_DB" < "$MIG_B15B"
+sqlite3 "$TMP_DB" < "$MIG_B15D"
+
+PASS=0
+FAIL=0
+
+# Seed two scope-2 subtask nodes — one for the negative, one for the positive.
+sqlite3 "$TMP_DB" <<'SQL'
+INSERT INTO nodes (id, title, item_code, granularity, status, scope_tag,
+                   pr_url, pr_merge_sha, regression_check_sha,
+                   verifier_verdict_json)
+VALUES
+  ('test::b15d-fail',
+   'b15d negative — verifier overall=fail blocks done',
+   'TEST.B15D.1', 'subtask', 'running', '2',
+   'https://github.com/x/y/pull/100',
+   'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+   'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+   '{"schema_version":"v1","overall":"fail","verdict":"fail-impl","reasons":["AC#1 not-met"]}'),
+  ('test::b15d-pass',
+   'b15d positive — verifier overall=pass allows done',
+   'TEST.B15D.2', 'subtask', 'running', '2',
+   'https://github.com/x/y/pull/101',
+   'cccccccccccccccccccccccccccccccccccccccc',
+   'dddddddddddddddddddddddddddddddddddddddd',
+   '{"schema_version":"v1","overall":"pass","verdict":"pass","reasons":[]}');
+SQL
+
+run_negative() {
+  # $1 = test name, $2 = SQL that must fail with trigger error, $3 = expected error fragment
+  local name="$1" sql="$2" expected="$3"
+  local out rc
+  out="$(sqlite3 "$TMP_DB" "$sql" 2>&1)"
+  rc=$?
+  if [[ $rc -ne 0 ]] && [[ "$out" == *"$expected"* ]]; then
+    echo "PASS [negative] $name"
+    echo "        rc=$rc  error=$(echo "$out" | head -1)"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [negative] $name"
+    echo "        rc=$rc  expected fragment=$expected"
+    echo "        got=$out"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+run_positive() {
+  # $1 = test name, $2 = SQL that must succeed, $3 = follow-up SELECT, $4 = expected output
+  local name="$1" sql="$2" check_sql="$3" expected="$4"
+  local update_out rc
+  update_out="$(sqlite3 "$TMP_DB" "$sql" 2>&1)"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL [positive] $name (UPDATE failed)"
+    echo "        rc=$rc"
+    echo "        out=$update_out"
+    FAIL=$((FAIL+1))
+    return
+  fi
+  local got
+  got="$(sqlite3 "$TMP_DB" "$check_sql" 2>&1)"
+  if [[ "$got" == "$expected" ]]; then
+    echo "PASS [positive] $name"
+    echo "        check=$got"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL [positive] $name (check mismatch)"
+    echo "        expected=$expected"
+    echo "        got=$got"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# =============================================================================
+# NEGATIVE — verifier overall=fail blocks autonomous-loop done
+# =============================================================================
+# Insert a verifier_verdicts row with overall='fail' for the negative node.
+# This proves the new B15.D trigger arm rejects the done-transition even
+# though all four evidence columns are populated and verifier_verdict_json
+# carries a fail verdict.
+sqlite3 "$TMP_DB" <<'SQL'
+INSERT INTO verifier_verdicts
+  (node_id, implementing_spawn_id, verifier_spawn_id, pr_url, pr_head_sha,
+   overall, verdict, blocking, routing_class, recommendation,
+   verdict_json, reasons_json, summary, duration_ms, worktree_cleaned_up)
+VALUES
+  ('test::b15d-fail', 'spawn::imp-1', 'spawn::ver-1',
+   'https://github.com/x/y/pull/100',
+   'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+   'fail', 'fail-impl', 1, 'autonomous-loop', 're-implement',
+   '{"schema_version":"v1","overall":"fail","verdict":"fail-impl","reasons":["AC#1 not-met"]}',
+   '["AC#1 not-met"]', 'AC#1 not-met after diff inspection', 78000, 1);
+SQL
+
+# The B15.B json_extract guard fires first (verifier_verdict_json says fail),
+# so we expect that error message — both the B15.B and the B15.D arms reject
+# the same write.  Either error message is acceptable proof; we look for the
+# common stem "verifier verdict must be pass" OR the B15.D stem "verifier_verdicts
+# row with overall=pass required".
+out_neg="$(sqlite3 "$TMP_DB" "UPDATE nodes SET status='done' WHERE id='test::b15d-fail';" 2>&1)"
+rc_neg=$?
+if [[ $rc_neg -ne 0 ]] && \
+   ( [[ "$out_neg" == *"verifier verdict must be pass"* ]] || \
+     [[ "$out_neg" == *"verifier_verdicts row with overall=pass required"* ]] ); then
+  echo "PASS [negative] verifier overall=fail blocks autonomous-loop done"
+  echo "        rc=$rc_neg  error=$(echo "$out_neg" | head -1)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [negative] expected trigger rejection with verifier-fail message"
+  echo "        rc=$rc_neg"
+  echo "        got=$out_neg"
+  FAIL=$((FAIL+1))
+fi
+
+# Sanity: the row must remain in 'running' (the SPS in-flight state — see
+# DEVIATION 3 in the phase report; "in_review" is a working name for this).
+got_status="$(sqlite3 "$TMP_DB" "SELECT status FROM nodes WHERE id='test::b15d-fail';")"
+if [[ "$got_status" == "running" ]]; then
+  echo "        sanity: row remains status=running after rejected UPDATE — OK (interpreted as 'in_review' per the task brief)"
+else
+  echo "        sanity: row status=$got_status after rejected UPDATE — UNEXPECTED"
+  FAIL=$((FAIL+1))
+fi
+
+# =============================================================================
+# Sub-negative — even with verifier_verdict_json updated to pass, an EMPTY
+# verifier_verdicts table for the node ALSO blocks (proves the B15.D arm
+# fires independently of the B15.B json_extract arm).
+# =============================================================================
+sqlite3 "$TMP_DB" <<'SQL'
+-- Update only the JSON column to pass; leave verifier_verdicts UNCHANGED
+-- (still contains the fail row from above).  Then DELETE the verifier_verdicts
+-- row to simulate the "no verdict ever recorded" condition and re-attempt.
+UPDATE nodes
+SET verifier_verdict_json='{"schema_version":"v1","overall":"pass","verdict":"pass","reasons":[]}'
+WHERE id='test::b15d-fail';
+DELETE FROM verifier_verdicts WHERE node_id='test::b15d-fail';
+SQL
+
+run_negative "no verifier_verdicts row at all blocks autonomous-loop done" \
+  "UPDATE nodes SET status='done' WHERE id='test::b15d-fail';" \
+  "verifier_verdicts row with overall=pass required"
+
+# =============================================================================
+# POSITIVE — verifier overall=pass row in verifier_verdicts allows done
+# =============================================================================
+# Insert a passing verifier_verdicts row for the positive node and execute
+# the done-transition.
+sqlite3 "$TMP_DB" <<'SQL'
+INSERT INTO verifier_verdicts
+  (node_id, implementing_spawn_id, verifier_spawn_id, pr_url, pr_head_sha,
+   overall, verdict, blocking, routing_class, recommendation,
+   verdict_json, reasons_json, summary, duration_ms, worktree_cleaned_up)
+VALUES
+  ('test::b15d-pass', 'spawn::imp-2', 'spawn::ver-2',
+   'https://github.com/x/y/pull/101',
+   'cccccccccccccccccccccccccccccccccccccccc',
+   'pass', 'pass', 1, 'autonomous-loop', 'merge',
+   '{"schema_version":"v1","overall":"pass","verdict":"pass","reasons":[]}',
+   '[]', 'all ACs met, all tests passing', 92000, 1);
+
+-- regression_check_result is also required by the autonomous-loop done-path
+-- although the B15.B trigger does not check it (the FastAPI service does);
+-- we set it for completeness so this positive test mirrors the operator-side
+-- happy path exactly.
+UPDATE nodes
+SET regression_check_result='pass'
+WHERE id='test::b15d-pass';
+SQL
+
+run_positive "verifier overall=pass row allows autonomous-loop done" \
+  "UPDATE nodes SET status='done' WHERE id='test::b15d-pass';" \
+  "SELECT status FROM nodes WHERE id='test::b15d-pass';" \
+  "done"
+
+# AFTER-trigger: history row written
+hist_count="$(sqlite3 "$TMP_DB" "SELECT count(*) FROM history WHERE event='auto-history-done-marker' AND node_id='test::b15d-pass';")"
+if [[ "$hist_count" == "1" ]]; then
+  echo "PASS [positive] done_status_history_guard wrote auto-history-done-marker row"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [positive] expected 1 history marker row, got $hist_count"
+  FAIL=$((FAIL+1))
+fi
+
+# AFTER-trigger: cascade row queued
+cascade_count="$(sqlite3 "$TMP_DB" "SELECT count(*) FROM cascade_pending_queue WHERE node_id='test::b15d-pass' AND drained_at IS NULL;")"
+if [[ "$cascade_count" == "1" ]]; then
+  echo "PASS [positive] cascade_on_done queued cascade_pending_queue row"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [positive] expected 1 cascade row, got $cascade_count"
+  FAIL=$((FAIL+1))
+fi
+
+# Provenance: the verifier_verdicts row carries the worktree-cleanup attestation.
+clean_attest="$(sqlite3 "$TMP_DB" "SELECT worktree_cleaned_up FROM verifier_verdicts WHERE node_id='test::b15d-pass';")"
+if [[ "$clean_attest" == "1" ]]; then
+  echo "PASS [positive] verifier_verdicts row carries worktree_cleaned_up=1 attestation"
+  PASS=$((PASS+1))
+else
+  echo "FAIL [positive] expected worktree_cleaned_up=1, got $clean_attest"
+  FAIL=$((FAIL+1))
+fi
+
+echo "----"
+echo "B15.D verifier-verdicts trigger tests: $PASS passed, $FAIL failed"
+exit "$FAIL"

--- a/infra/stolution/sps/tests/test_b15e_audit_recent_done.sh
+++ b/infra/stolution/sps/tests/test_b15e_audit_recent_done.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# =============================================================================
+# B15.E audit_recent_done acceptance tests
+# =============================================================================
+# Six tests covering the full feedback loop:
+#
+#   1. SCHEMA          — migration creates reliability_rolling +
+#                        redecompose_queue.
+#   2. EMPTY_BUCKET    — audit on a bucket with zero done nodes writes a
+#                        row with reliability_pct NULL, breached=0.
+#   3. PASSING_BUCKET  — audit on a bucket with all-score-5 nodes writes
+#                        reliability=100, breached=0, no INBOX append.
+#   4. AUTO_REDO       — synthetic score-1 node (pr_url present, no
+#                        pr_merge_sha → score 1) triggers a redecompose_queue
+#                        insertion within the SAME audit run.
+#   5. INBOX_ALERT     — synthetic mixed bucket below 95% writes an INBOX
+#                        line with the structured prefix [B15.E ...].
+#   6. UPSERT_IDEMPOTENT — re-running the audit for the same bucket UPSERTs
+#                        and does NOT duplicate the row.
+#
+# Runs against an ephemeral SQLite DB seeded from the canonical schema +
+# B15.B + B15.D + B15.E migrations.  Synthetic test::* nodes are excluded
+# from the audit per methodology §4 Class D, so we use real-looking IDs.
+#
+# Usage:   ./test_b15e_audit_recent_done.sh
+# Exit:    0 = all pass; 1+ = number of failures
+# =============================================================================
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SPS_ROOT="$(cd "$HERE/.." && pwd)"
+SCHEMA="$SPS_ROOT/schema/00_baseline_schema.sql"
+MIG_B15B="$SPS_ROOT/migrations/2026-05-13_b15b_done_triggers.sql"
+MIG_B15D="$SPS_ROOT/migrations/2026-05-13_b15d_verifier_verdicts.sql"
+MIG_B15E="$SPS_ROOT/migrations/2026-05-13_b15e_reliability_rolling.sql"
+SCRIPT="$SPS_ROOT/scripts/audit_recent_done.py"
+
+TMP_DIR="$(mktemp -d -t sps_b15e_test.XXXXXX)"
+TMP_DB="$TMP_DIR/sps.db"
+TMP_INBOX="$TMP_DIR/INBOX.md"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+for f in "$SCHEMA" "$MIG_B15B" "$MIG_B15D" "$MIG_B15E" "$SCRIPT"; do
+  [[ -f "$f" ]] || { echo "FAIL: missing $f" >&2; exit 1; }
+done
+
+sqlite3 "$TMP_DB" < "$SCHEMA"        || { echo "FAIL: baseline schema apply" >&2; exit 1; }
+sqlite3 "$TMP_DB" < "$MIG_B15B"      || { echo "FAIL: B15.B migration apply" >&2; exit 1; }
+sqlite3 "$TMP_DB" < "$MIG_B15D"      || { echo "FAIL: B15.D migration apply" >&2; exit 1; }
+sqlite3 "$TMP_DB" < "$MIG_B15E"      || { echo "FAIL: B15.E migration apply" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); echo "PASS  $1"; }
+fail() { FAIL=$((FAIL+1)); echo "FAIL  $1: $2"; }
+
+# -----------------------------------------------------------------------------
+# Test 1 — SCHEMA
+# -----------------------------------------------------------------------------
+TABLES="$(sqlite3 "$TMP_DB" \
+  "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('reliability_rolling','redecompose_queue') ORDER BY name;")"
+if [[ "$TABLES" == "redecompose_queue
+reliability_rolling" ]]; then
+  ok "SCHEMA  — both tables exist"
+else
+  fail "SCHEMA" "missing tables; got: $TABLES"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 2 — EMPTY_BUCKET
+# -----------------------------------------------------------------------------
+OUT="$(python3 "$SCRIPT" --db "$TMP_DB" --inbox "$TMP_INBOX" \
+        --bucket 2026-05-13T00:00:00Z --json 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]] && \
+   [[ "$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM reliability_rolling WHERE bucket_start='2026-05-13T00:00:00Z'")" == "1" ]] && \
+   [[ "$(sqlite3 "$TMP_DB" "SELECT nodes_audited FROM reliability_rolling WHERE bucket_start='2026-05-13T00:00:00Z'")" == "0" ]] && \
+   [[ "$(sqlite3 "$TMP_DB" "SELECT IFNULL(reliability_pct, 'NULL') FROM reliability_rolling WHERE bucket_start='2026-05-13T00:00:00Z'")" == "NULL" ]]; then
+  ok "EMPTY_BUCKET  — row written with NULL reliability and zero counts"
+else
+  fail "EMPTY_BUCKET" "rc=$RC out=$OUT"
+fi
+
+# -----------------------------------------------------------------------------
+# Setup — seed the bucket [01:00-02:00) with realistic nodes
+# -----------------------------------------------------------------------------
+# Node A: score-5    — pr_url + pr_merge_sha + verifier pass + dod 10/10 + regression pass
+# Node B: score-1    — pr_url BUT no pr_merge_sha (verify-noop) — auto-redo target
+# Node C: score-0    — no pr_url at all (false-claim) — auto-redo target
+# Node D: score-3    — pr_url + pr_merge_sha + dod 6/10 + regression pass
+# Node E: synthetic  — should be EXCLUDED from the audit denominator
+#
+# We INSERT directly bypassing the done_status_guard trigger by setting
+# status='done' at INSERT (the trigger only fires on UPDATE OF status).
+
+DOD_FULL='XXXXXXXXXX'
+DOD_SIX='XXXXXX....'
+
+sqlite3 "$TMP_DB" <<SQL
+INSERT INTO nodes (id, title, item_code, granularity, status, scope_tag,
+                   pr_url, pr_merge_sha, verifier_verdict_json,
+                   dod_stages_required, dod_stages_evidenced,
+                   regression_check_sha, regression_check_result,
+                   updated_at)
+VALUES
+  ('audit-test-A', 'A — score 5', 'TEST.A', 'subtask', 'done', '2',
+   'https://github.com/x/y/pull/501',
+   'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+   '{"schema_version":"v1","overall":"pass","verdict":"pass"}',
+   '$DOD_FULL', '$DOD_FULL',
+   'aaaaaaaa1111111111111111111111111111aaaa', 'pass',
+   '2026-05-13 01:15:00'),
+  ('audit-test-B', 'B — score 1 verify-noop', 'TEST.B', 'subtask', 'done', '2',
+   'https://github.com/x/y/pull/502',
+   NULL,
+   '{"schema_version":"v1","overall":"pass","verdict":"pass"}',
+   '$DOD_FULL', '$DOD_FULL',
+   'bbbbbbbb2222222222222222222222222222bbbb', 'pass',
+   '2026-05-13 01:25:00'),
+  ('audit-test-C', 'C — score 0 false-claim', 'TEST.C', 'subtask', 'done', '2',
+   NULL, NULL, NULL,
+   '$DOD_FULL', '..........',
+   NULL, NULL,
+   '2026-05-13 01:35:00'),
+  ('audit-test-D', 'D — score 3', 'TEST.D', 'subtask', 'done', '2',
+   'https://github.com/x/y/pull/504',
+   'dddddddddddddddddddddddddddddddddddddddd',
+   '{"schema_version":"v1","overall":"pass","verdict":"pass"}',
+   '$DOD_FULL', '$DOD_SIX',
+   'dddddddd4444444444444444444444444444dddd', 'pass',
+   '2026-05-13 01:45:00'),
+  ('test::synthetic-node-1', 'E — synthetic excluded', 'TEST.E', 'subtask', 'done', '2',
+   NULL, NULL, NULL, '..........', '..........', NULL, NULL,
+   '2026-05-13 01:50:00');
+SQL
+
+# -----------------------------------------------------------------------------
+# Test 3 — PASSING vs FAIL bucket math
+# -----------------------------------------------------------------------------
+# For bucket [01:00, 02:00):  audited=4 (B,C,D,A), passing=2 (A=5, D=3),
+#                             score_le_2=2 (B=1, C=0); reliability=50%; breach.
+OUT="$(python3 "$SCRIPT" --db "$TMP_DB" --inbox "$TMP_INBOX" \
+        --bucket 2026-05-13T01:00:00Z --json 2>&1)"
+RC=$?
+AUDITED=$(sqlite3 "$TMP_DB" "SELECT nodes_audited FROM reliability_rolling WHERE bucket_start='2026-05-13T01:00:00Z'")
+PASSING=$(sqlite3 "$TMP_DB" "SELECT nodes_passing FROM reliability_rolling WHERE bucket_start='2026-05-13T01:00:00Z'")
+LE2=$(sqlite3 "$TMP_DB" "SELECT nodes_score_le_2 FROM reliability_rolling WHERE bucket_start='2026-05-13T01:00:00Z'")
+SCORE5=$(sqlite3 "$TMP_DB" "SELECT nodes_score_5 FROM reliability_rolling WHERE bucket_start='2026-05-13T01:00:00Z'")
+RELS=$(sqlite3 "$TMP_DB" "SELECT printf('%.2f', reliability_pct) FROM reliability_rolling WHERE bucket_start='2026-05-13T01:00:00Z'")
+BREACH=$(sqlite3 "$TMP_DB" "SELECT breached_threshold FROM reliability_rolling WHERE bucket_start='2026-05-13T01:00:00Z'")
+if [[ $RC -eq 0 ]] && [[ "$AUDITED" == "4" ]] && [[ "$PASSING" == "2" ]] && \
+   [[ "$LE2" == "2" ]] && [[ "$SCORE5" == "1" ]] && \
+   [[ "$RELS" == "50.00" ]] && [[ "$BREACH" == "1" ]]; then
+  ok "BUCKET_MATH    — audited=4 passing=2 le2=2 reliability=50% breached"
+else
+  fail "BUCKET_MATH" "rc=$RC audited=$AUDITED passing=$PASSING le2=$LE2 score5=$SCORE5 rel=$RELS breach=$BREACH"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 4 — AUTO_REDO
+# -----------------------------------------------------------------------------
+QUEUED=$(sqlite3 "$TMP_DB" "SELECT GROUP_CONCAT(node_id, ',') FROM redecompose_queue WHERE next_action='re-decompose' ORDER BY node_id")
+if [[ "$QUEUED" == *"audit-test-B"* ]] && [[ "$QUEUED" == *"audit-test-C"* ]]; then
+  ok "AUTO_REDO      — score-1 (B) and score-0 (C) nodes queued: $QUEUED"
+else
+  fail "AUTO_REDO" "expected B+C queued, got: $QUEUED"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 5 — INBOX_ALERT
+# -----------------------------------------------------------------------------
+if [[ -f "$TMP_INBOX" ]] && grep -q '\[B15.E reliability-alert\]' "$TMP_INBOX" && \
+   grep -q 'bucket=2026-05-13T01:00:00Z/2026-05-13T02:00:00Z' "$TMP_INBOX" && \
+   grep -q 'rel=50.00%' "$TMP_INBOX"; then
+  ok "INBOX_ALERT    — structured alert appended (rel=50% < 95% threshold)"
+else
+  fail "INBOX_ALERT" "no alert line; inbox=$([ -f "$TMP_INBOX" ] && cat "$TMP_INBOX" || echo "missing")"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 6 — UPSERT_IDEMPOTENT
+# -----------------------------------------------------------------------------
+COUNT_BEFORE=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM reliability_rolling")
+QUEUE_BEFORE=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM redecompose_queue")
+python3 "$SCRIPT" --db "$TMP_DB" --inbox "$TMP_INBOX" \
+        --bucket 2026-05-13T01:00:00Z --json >/dev/null 2>&1
+COUNT_AFTER=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM reliability_rolling")
+QUEUE_AFTER=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM redecompose_queue")
+if [[ "$COUNT_BEFORE" == "$COUNT_AFTER" ]] && [[ "$QUEUE_AFTER" -gt "$QUEUE_BEFORE" ]]; then
+  # New audit_run_id => new redecompose_queue rows are EXPECTED (one per re-run)
+  ok "UPSERT_IDEMPOTENT — reliability_rolling stable at $COUNT_AFTER row(s); queue grew by audit_run_id"
+elif [[ "$COUNT_BEFORE" == "$COUNT_AFTER" ]] && [[ "$QUEUE_AFTER" == "$QUEUE_BEFORE" ]]; then
+  ok "UPSERT_IDEMPOTENT — both tables idempotent (queue UNIQUE prevented dup)"
+else
+  fail "UPSERT_IDEMPOTENT" "rolling: $COUNT_BEFORE -> $COUNT_AFTER ; queue: $QUEUE_BEFORE -> $QUEUE_AFTER"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+TOTAL=$((PASS+FAIL))
+echo
+echo "========================================================="
+echo "B15.E audit_recent_done tests: $PASS / $TOTAL passed ($FAIL failed)"
+echo "========================================================="
+exit $FAIL

--- a/packages/local-llm-router-py-client/README.md
+++ b/packages/local-llm-router-py-client/README.md
@@ -50,3 +50,39 @@ The reference patch in `src/spawner_patch.diff` modifies the `/spawn`
 handler — production-critical code. Operator should review the diff,
 test on a non-production spawner first, and apply with `patch -p0`
 manually. Do NOT auto-deploy.
+
+## B15.C — v2 spawn prompt + strict JSON output schema
+
+The `templates/spawn_prompt_v2.md` + `src/spawn_prompt_loader.py` ship the
+v2 spawn template that replaces `build_prompt_real_edit` in
+`claude_spawner_agent.py`. Design authority:
+`~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md`
+§6.2.2.
+
+Wire-up (reference): `src/spawner_patch_v3.diff`.
+Output schema: `templates/spawn_output_schema.v2.json`.
+
+The v2 template injects four contract sections — `acceptance_criteria`,
+`file_scope`, `tests_required`, `dod_required_stages` — from the task's
+`prompt_material` (populated by the orchestrator's BA/EA agents via UDP),
+and demands the implementor emit a strict-JSON final line that the spawner
+validates before deciding outcome. The B15.D VERIFIER spawn reads the
+same JSON to grade the diff independently.
+
+### Env knob for rollback
+
+| Var | Default | Description |
+|---|---|---|
+| `SPAWN_PROMPT_VERSION` | `v2` | Set to `v1` for emergency rollback to legacy prompt (no AC, no schema, rc-only outcome). |
+
+### Run the tests
+
+```bash
+cd packages/local-llm-router-py-client
+python3 -m unittest tests.test_spawn_prompt_v2 -v
+```
+
+Eighteen tests cover template rendering, env-driven version dispatch,
+the strict schema validator (positive + 6 negatives), and an end-to-end
+fixture task ("add SPDX header to file X") that renders the v2 prompt
+and validates a simulated spawn output against the schema.

--- a/packages/local-llm-router-py-client/package.json
+++ b/packages/local-llm-router-py-client/package.json
@@ -1,7 +1,21 @@
 {
   "name": "@chiefaia/local-llm-router-py-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
-  "description": "Python client for the local-llm-router daemon. Vendored into claude-spawner-agent on M1+M3+stolution to add the pre-spawn classify-and-maybe-route gate. Pure stdlib (no pip deps); HTTP via urllib.",
-  "files": ["src/local_llm_router_client.py", "src/spawner_patch.diff", "README.md"]
+  "description": "Python client + B15.C v2 spawn prompt template (with strict-JSON output schema + DoD self-cert). Vendored into claude-spawner-agent on M1+M3+stolution. Pure stdlib (no pip deps); HTTP via urllib; schema validation via stdlib re/json.",
+  "files": [
+    "src/local_llm_router_client.py",
+    "src/spawn_prompt_loader.py",
+    "src/spawner_patch.diff",
+    "src/spawner_patch_v2.diff",
+    "src/spawner_patch_v3.diff",
+    "templates/spawn_prompt_v2.md",
+    "templates/spawn_prompt_v1.md.archived",
+    "templates/spawn_output_schema.v2.json",
+    "tests/test_spawn_prompt_v2.py",
+    "README.md"
+  ],
+  "scripts": {
+    "test:py": "python3 -m unittest tests.test_spawn_prompt_v2 -v"
+  }
 }

--- a/packages/local-llm-router-py-client/src/spawn_prompt_loader.py
+++ b/packages/local-llm-router-py-client/src/spawn_prompt_loader.py
@@ -1,0 +1,394 @@
+"""Spawn prompt v2 loader + output schema validator.
+
+B15.C (A.3 reliability chain phase 2). Design authority:
+  ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md
+  (§6.2.2 — v2 prompt template + strict JSON output schema).
+
+This module is intentionally pure-stdlib: it is vendored into
+claude_spawner_agent.py at deploy time alongside local_llm_router_client.py.
+No pip deps; no jsonschema; the validator is a hand-rolled walk against
+the schema constants below. Matches the package's stated convention
+('Pure stdlib (no pip deps); HTTP via urllib.' — README/package.json).
+
+PUBLIC API:
+  - build_prompt_v2(task_spec, *, spawn_id, permission_mode, cwd, branch,
+                    risk_tier, spawned_by_trailer) -> str
+  - build_prompt_v1(task_spec, ...) -> str   # rollback path; mirrors v1
+  - build_prompt(version, task_spec, ...)    # dispatcher honoring
+                                             # SPAWN_PROMPT_VERSION env var
+  - validate_spawn_output(parsed) -> tuple[bool, list[str]]
+  - load_template(version: str) -> str
+
+ENV:
+  SPAWN_PROMPT_VERSION   "v2" (default) | "v1" (rollback)
+  SPAWN_PROMPT_TEMPLATE_DIR  path to override the templates dir (test only)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+DEFAULT_VERSION = "v2"
+SUPPORTED_VERSIONS = ("v1", "v2")
+
+_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+
+
+def _templates_dir() -> Path:
+    override = os.environ.get("SPAWN_PROMPT_TEMPLATE_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path(__file__).resolve().parent.parent / "templates"
+
+
+def load_template(version: str) -> str:
+    """Return the template body for `version`, with the YAML frontmatter stripped."""
+    if version not in SUPPORTED_VERSIONS:
+        raise ValueError(
+            f"unsupported spawn prompt version {version!r}; "
+            f"want one of {SUPPORTED_VERSIONS}"
+        )
+    name = "spawn_prompt_v2.md" if version == "v2" else "spawn_prompt_v1.md.archived"
+    body = (_templates_dir() / name).read_text(encoding="utf-8")
+    return _FRONTMATTER_RE.sub("", body, count=1)
+
+
+def load_output_schema() -> dict[str, Any]:
+    p = _templates_dir() / "spawn_output_schema.v2.json"
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def resolve_version() -> str:
+    v = os.environ.get("SPAWN_PROMPT_VERSION", DEFAULT_VERSION).strip().lower()
+    return v if v in SUPPORTED_VERSIONS else DEFAULT_VERSION
+
+
+def _block(items: list[str], *, empty: str = "(none)") -> str:
+    if not items:
+        return f"  {empty}"
+    return "\n".join(f"  - {x}" for x in items)
+
+
+def _format_ac_block(acs: list[Any]) -> str:
+    if not acs:
+        return "  (none — verifier will fail-spec)"
+    lines: list[str] = []
+    for i, ac in enumerate(acs, start=1):
+        if isinstance(ac, dict):
+            text = ac.get("text") or ac.get("ac") or json.dumps(ac, sort_keys=True)
+        else:
+            text = str(ac)
+        lines.append(f"  {i}. {text}")
+    return "\n".join(lines)
+
+
+def _format_files_block(files: list[Any]) -> str:
+    if not files:
+        return "  (none — implementor may produce zero-diff and self-cert ok=false)"
+    return "\n".join(f"  - {f}" for f in files)
+
+
+def _format_tests_block(tests: list[Any]) -> str:
+    if not tests:
+        return "  (none required by spec)"
+    lines: list[str] = []
+    for t in tests:
+        if isinstance(t, dict):
+            name = t.get("name") or t.get("path") or json.dumps(t, sort_keys=True)
+            kind = t.get("kind") or t.get("type") or "test"
+            lines.append(f"  - [{kind}] {name}")
+        else:
+            lines.append(f"  - {t}")
+    return "\n".join(lines)
+
+
+def _format_dod_block(stages: list[Any]) -> str:
+    if not stages:
+        return "  (none — falls back to [Implement, Unit-test])"
+    return "\n".join(f"  - {s}" for s in stages)
+
+
+def _format_must_read(refs: list[Any]) -> str:
+    if not refs:
+        return "  (none — DO NOT load any file unless the AC explicitly says so)"
+    return "\n".join(f"  - {r}" for r in refs)
+
+
+def _schema_block() -> str:
+    schema = load_output_schema()
+    pretty = json.dumps(schema, indent=2, sort_keys=False)
+    return pretty
+
+
+def build_prompt_v2(
+    task_spec: dict[str, Any],
+    *,
+    spawn_id: str,
+    permission_mode: str,
+    cwd: str,
+    branch: str,
+    risk_tier: str | None,
+    spawned_by_trailer: str,
+) -> str:
+    """Fill the v2 template from a UDP-enriched task_spec.
+
+    task_spec is the node payload the slot-manager hands to the spawner;
+    its `prompt_material` substructure is what B14.A-K / UDP populate.
+    Reads (with safe fallbacks; never raises on missing fields):
+      task_spec.id | title | item_code | scope_tag | target_bucket
+      task_spec.prompt_material.{acceptance_criteria, file_scope,
+                                 package_scope_negative, tests_required,
+                                 tech_context, architectural_constraints,
+                                 dod_required_stages, must_read_first,
+                                 work_directive, parent_context}
+    """
+    tmpl = load_template("v2")
+    pm = task_spec.get("prompt_material", {}) or {}
+
+    title = task_spec.get("title", "<no title>")
+    work_directive = (
+        pm.get("work_directive")
+        or task_spec.get("work_directive")
+        or pm.get("description")
+        or task_spec.get("description")
+        or title
+    )
+    parent = pm.get("parent_context") or {}
+    if not isinstance(parent, dict):
+        parent = {}
+
+    acs = pm.get("acceptance_criteria") or task_spec.get("acceptance_criteria") or []
+    file_scope = pm.get("file_scope") or task_spec.get("file_scope") or []
+    pkg_neg = pm.get("package_scope_negative") or []
+    tests = pm.get("tests_required") or task_spec.get("tests_required") or []
+    tech = pm.get("tech_context") or task_spec.get("tech_context") or []
+    constraints = pm.get("architectural_constraints") or []
+    stages = pm.get("dod_required_stages") or task_spec.get("dod_required_stages") or []
+    must_read = pm.get("must_read_first") or []
+
+    tests_filter_expr = pm.get("tests_filter_expr") or task_spec.get(
+        "tests_filter_expr"
+    ) or "<scope/path glob>"
+
+    subs = {
+        "{spawn_id}": spawn_id,
+        "{permission_mode}": permission_mode,
+        "{risk_tier}": risk_tier or "low",
+        "{cwd}": cwd,
+        "{branch}": branch,
+        "{node_id}": str(task_spec.get("id", "<unknown>")),
+        "{item_code}": str(pm.get("item_code") or task_spec.get("item_code") or "?"),
+        "{scope_tag}": str(pm.get("scope_tag") or task_spec.get("scope_tag") or "?"),
+        "{target_bucket}": str(
+            task_spec.get("target_bucket")
+            or task_spec.get("resolved_bucket")
+            or "<no bucket>"
+        ),
+        "{title}": title,
+        "{parent_context_title}": str(parent.get("title") or "(root)"),
+        "{parent_context_scope}": str(parent.get("scope") or "?"),
+        "{work_directive}": work_directive,
+        "{acceptance_criteria_block}": _format_ac_block(acs),
+        "{file_scope_block}": _format_files_block(file_scope),
+        "{package_scope_negative_list}": ", ".join(str(x) for x in pkg_neg) or "(none)",
+        "{tests_required_block}": _format_tests_block(tests),
+        "{tests_filter_expr}": tests_filter_expr,
+        "{tech_context_block}": _block(
+            [str(x) for x in tech], empty="(no EA tech_context resolved)"
+        ),
+        "{architectural_constraints_block}": _block(
+            [str(x) for x in constraints], empty="(none declared)"
+        ),
+        "{dod_required_stages_block}": _format_dod_block(stages),
+        "{must_read_first_block}": _format_must_read(must_read),
+        "{SPAWNED_BY_TRAILER}": spawned_by_trailer,
+        "{json_schema_block}": _schema_block(),
+    }
+
+    out = tmpl
+    for k, v in subs.items():
+        out = out.replace(k, v)
+    return out
+
+
+def build_prompt_v1(
+    task_spec: dict[str, Any],
+    *,
+    spawn_id: str,
+    permission_mode: str,
+    cwd: str,
+    branch: str,
+    risk_tier: str | None,
+    spawned_by_trailer: str,
+) -> str:
+    """Rollback path. Reproduces the v1 prompt byte-for-byte (modulo whitespace)
+    from claude_spawner_agent.py:build_prompt_real_edit. Kept here so the
+    loader-based wiring works in both versions and rollback is a single env flip.
+    """
+    pm = task_spec.get("prompt_material", {}) or {}
+    nid = task_spec.get("id", "<unknown>")
+    title = task_spec.get("title", "<no title>")
+    bucket = (
+        task_spec.get("target_bucket")
+        or task_spec.get("resolved_bucket")
+        or "<no bucket>"
+    )
+    refs = pm.get("must_read_first") or []
+    work = (
+        pm.get("work_directive")
+        or task_spec.get("work_directive")
+        or pm.get("description")
+        or task_spec.get("description")
+        or title
+    )
+    scope = pm.get("scope_tag") or task_spec.get("scope_tag") or "?"
+    item = pm.get("item_code") or task_spec.get("item_code") or "?"
+    files = pm.get("file_scope") or task_spec.get("file_scope")
+
+    refs_block = "\n".join(f"- {r}" for r in refs) if refs else "(none provided)"
+    files_block = (
+        f"\nFile scope (only edit these unless absolutely necessary):\n  {files}\n"
+        if files
+        else ""
+    )
+    return (
+        "You are spawned by the slot-manager autonomous loop in REAL-EDIT mode.\n"
+        f"  permission_mode : {permission_mode}\n"
+        f"  risk_tier       : {risk_tier or 'low'}\n"
+        f"  spawn_id        : {spawn_id}\n"
+        f"  working dir     : {cwd}\n"
+        f"  branch          : {branch} (already checked out for you)\n"
+        "\n"
+        "TASK:\n"
+        f"  id        : {nid}\n"
+        f"  item_code : {item}\n"
+        f"  scope_tag : {scope}\n"
+        f"  bucket    : {bucket}\n"
+        f"  title     : {title}\n"
+        f"  directive : {work}\n"
+        f"{files_block}"
+        "\n"
+        "Must-read-first refs:\n"
+        f"{refs_block}\n"
+        "\n"
+        "RULES:\n"
+        f"1. Stay inside {cwd}. Do not edit files outside this tree.\n"
+        f"2. Commit in small, focused chunks. Every commit message MUST include the footer\n"
+        f"   `{spawned_by_trailer}` (it can be the only line if needed). The spawner appends\n"
+        f"   it for you if you forget, but your messages are clearer if you include it.\n"
+        "3. Do NOT push, do NOT open PRs, do NOT touch git remotes. The spawner handles\n"
+        "   push + PR + auto-merge after you exit.\n"
+        "4. If the directive is impossible or already done, leave the branch unchanged\n"
+        "   and exit with a brief explanation. Empty branches will not produce a PR.\n"
+        "5. When done, output ONE final compact line of JSON to summarise:\n"
+        '   {"ok": true, "task_id": "<id>", "files_touched": <int>, "commits_made": <int>, "summary": "<one-line>"}\n'
+        "\n"
+        "Begin."
+    )
+
+
+def build_prompt(version: str | None, task_spec: dict[str, Any], **kwargs: Any) -> str:
+    """Dispatch entry point. `version=None` honors SPAWN_PROMPT_VERSION env."""
+    v = (version or resolve_version()).strip().lower()
+    if v == "v1":
+        return build_prompt_v1(task_spec, **kwargs)
+    return build_prompt_v2(task_spec, **kwargs)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Schema validator — stdlib-only walk against load_output_schema().
+# Covers: required keys, additionalProperties=false, type matching, enum,
+# pattern, minLength/maxLength, minimum/maximum, items, anyOf.
+# This is intentionally narrow to the v2 schema's shape; not a general
+# JSON-Schema implementation.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _type_ok(value: Any, t: str) -> bool:
+    return (
+        (t == "object" and isinstance(value, dict))
+        or (t == "array" and isinstance(value, list))
+        or (t == "string" and isinstance(value, str))
+        or (t == "integer" and isinstance(value, int) and not isinstance(value, bool))
+        or (
+            t == "number"
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        )
+        or (t == "boolean" and isinstance(value, bool))
+        or (t == "null" and value is None)
+    )
+
+
+def _validate_node(value: Any, schema: dict[str, Any], path: str, errs: list[str]) -> None:
+    if "anyOf" in schema:
+        for sub in schema["anyOf"]:
+            sub_errs: list[str] = []
+            _validate_node(value, sub, path, sub_errs)
+            if not sub_errs:
+                return
+        errs.append(f"{path}: did not match any of anyOf")
+        return
+
+    if "enum" in schema:
+        if value not in schema["enum"]:
+            errs.append(f"{path}: value {value!r} not in enum {schema['enum']}")
+        return
+
+    if "type" in schema:
+        t = schema["type"]
+        if not _type_ok(value, t):
+            errs.append(f"{path}: expected type={t}, got {type(value).__name__}")
+            return
+
+        if t == "string":
+            if "minLength" in schema and len(value) < schema["minLength"]:
+                errs.append(f"{path}: minLength {schema['minLength']} violated")
+            if "maxLength" in schema and len(value) > schema["maxLength"]:
+                errs.append(f"{path}: maxLength {schema['maxLength']} violated")
+            if "pattern" in schema and not re.search(schema["pattern"], value):
+                errs.append(f"{path}: pattern {schema['pattern']} violated")
+
+        elif t == "integer" or t == "number":
+            if "minimum" in schema and value < schema["minimum"]:
+                errs.append(f"{path}: minimum {schema['minimum']} violated")
+            if "maximum" in schema and value > schema["maximum"]:
+                errs.append(f"{path}: maximum {schema['maximum']} violated")
+
+        elif t == "array":
+            item_schema = schema.get("items")
+            if item_schema is not None:
+                for i, v in enumerate(value):
+                    _validate_node(v, item_schema, f"{path}[{i}]", errs)
+
+        elif t == "object":
+            required = schema.get("required") or []
+            for r in required:
+                if r not in value:
+                    errs.append(f"{path}.{r}: missing required field")
+            props = schema.get("properties") or {}
+            extra_allowed = schema.get("additionalProperties", True)
+            for k, v in value.items():
+                if k in props:
+                    _validate_node(v, props[k], f"{path}.{k}", errs)
+                else:
+                    if extra_allowed is False:
+                        errs.append(f"{path}.{k}: additionalProperties not allowed")
+                    elif isinstance(extra_allowed, dict):
+                        _validate_node(v, extra_allowed, f"{path}.{k}", errs)
+
+
+def validate_spawn_output(parsed: Any) -> tuple[bool, list[str]]:
+    """Validate a parsed spawn-output dict against the v2 schema.
+
+    Returns (is_valid, error_list). The spawner uses this to decide between
+    outcome='implementor-claimed' (schema-conformant + ok=true) and
+    outcome='spawner_error' (schema violation).
+    """
+    schema = load_output_schema()
+    errs: list[str] = []
+    _validate_node(parsed, schema, "$", errs)
+    return (len(errs) == 0, errs)

--- a/packages/local-llm-router-py-client/src/spawner_patch_v3.diff
+++ b/packages/local-llm-router-py-client/src/spawner_patch_v3.diff
@@ -1,0 +1,141 @@
+# Reference patch v3 for claude_spawner_agent.py — B15.C
+#
+# Supersedes spawner_patch_v2.diff (v2 added the LAI phase 7 optimizer);
+# v3 adds the B15.C v2 spawn prompt + strict-JSON output schema gate.
+#
+# v3 changes from v2:
+#   - Import `build_prompt` and `validate_spawn_output` from
+#     `spawn_prompt_loader` (vendored alongside local_llm_router_client.py).
+#   - Replace the call site at claude_spawner_agent.py:1692 from
+#       `build_prompt_real_edit(task_spec, ...)` to
+#       `build_prompt(None, task_spec, ..., spawned_by_trailer=SPAWNED_BY_TRAILER)`
+#     so the version dispatch reads SPAWN_PROMPT_VERSION at request time.
+#   - Replace the outcome derivation block (claude_spawner_agent.py:1572-1586)
+#     to gate `outcome="ok"` on (a) parseable final-JSON, (b) schema
+#     conformance, (c) `ok=true`, (d) `ready_for_verifier=true`, (e) non-empty
+#     `commits_made`. Maps to the new outcome value `implementor-claimed`
+#     (consumed by slot_manager's sm_outcome→sps_outcome mapping in B15.E).
+#   - Keep the v1 build_prompt_real_edit function in the module for the
+#     SPAWN_PROMPT_VERSION=v1 rollback (build_prompt() delegates to v1 or v2;
+#     when v1 is selected the legacy outcome derivation also kicks in via
+#     the `parsed is None` short-circuit at the top of the new gate block).
+#
+# DO NOT auto-apply — operator review required. This is a reference patch.
+# The real spawner is ~1800 lines; the hunks below show the intent and exact
+# lines to change against the v2-patched source tree.
+#
+# Smoke test post-deploy:
+#   1. Verify SPAWN_PROMPT_VERSION env (default "v2") is loaded by the
+#      spawner systemd/launchd unit. The com.caia.claude-spawner-agent.plist
+#      template should pick up env from the operator's shell.
+#   2. Send a synthetic /spawn carrying a task_spec.prompt_material with
+#      acceptance_criteria, file_scope, tests_required, dod_required_stages
+#      populated (see tests/test_spawn_prompt_v2.py for a fixture).
+#   3. Confirm the rendered prompt (logged at DEBUG) contains an
+#      "ACCEPTANCE CRITERIA" header and the JSON schema block.
+#   4. Stub the claude subprocess with a script that prints a v2-schema
+#      conformant final-JSON line and verify the spawn record carries
+#      outcome='implementor-claimed' (NOT 'ok').
+#   5. Flip SPAWN_PROMPT_VERSION=v1, restart, repeat smoke; confirm legacy
+#      prompt is rendered and outcome derivation falls back to rc-only.
+
+--- claude_spawner_agent.py
++++ claude_spawner_agent.py
+@@ -1,9 +1,11 @@
+ #!/usr/bin/env python3
+ import asyncio
+ import json
+ import os
+ import subprocess
+ import time
+ import uuid
+ from local_llm_router_client import classify_and_maybe_route, health, optimize_prompt
++# B15.C — vendored v2 prompt + strict-JSON output schema validator
++from spawn_prompt_loader import build_prompt, validate_spawn_output, resolve_version
+@@ -10,8 +12,12 @@ CLAUDE_BINARY = os.environ.get("CLAUDE_BINARY", "/opt/homebrew/bin/claude")
+ ROUTER_URL = os.environ.get("LOCAL_LLM_ROUTER_URL", "http://100.68.247.58:7411")
+ ROUTER_GATE_ENABLED = os.environ.get("ROUTER_GATE_ENABLED", "true").lower() in ("1", "true", "yes")
+ OPTIMIZER_ENABLED = os.environ.get("OPTIMIZER_ENABLED", "true").lower() in ("1", "true", "yes")
+ OPTIMIZER_TIMEOUT_S = float(os.environ.get("OPTIMIZER_TIMEOUT_S", "30.0"))
++
++# B15.C — prompt version dispatch. Default v2 (B15 contract); operator can
++# flip to v1 for emergency rollback without redeploying. resolve_version()
++# reads the env at request time, so a hot-flip + service restart is enough.
+@@ -1689,8 +1695,11 @@ async def _do_spawn(...):
+     # ── Build the prompt ─────────────────────────────────────────────
+-    prompt = build_prompt_real_edit(
+-        task_spec,
++    prompt_version = resolve_version()  # "v1" | "v2"
++    prompt = build_prompt(
++        prompt_version,
++        task_spec,
++        spawned_by_trailer=SPAWNED_BY_TRAILER,
+         permission_mode=permission_mode,
+         cwd=cwd,
+         branch=branch,
+         spawn_id=spawn_id,
+         risk_tier=risk_tier,
+     )
++    record["prompt_version"] = prompt_version  # journal which version ran
+@@ -1572,8 +1581,46 @@ async def _finalize_record(record, ...):
+-    # Legacy outcome derivation (v1): rc-only signal.
+-    rc = record.get("rc")
+-    timed_out = record.get("timed_out")
+-    if timed_out:
+-        outcome = "timeout"
+-    elif rc is not None and rc < 0:
+-        outcome = "crashed"
+-    elif rc != 0:
+-        outcome = "spawner_error"
+-    else:
+-        outcome = "ok"
+-    record["outcome"] = outcome
++    # B15.C — gated outcome derivation.
++    # Falls back to legacy rc-only when the request used SPAWN_PROMPT_VERSION=v1
++    # (the v1 prompt does not emit a v2-schema final JSON, so schema gating
++    # would always reject it).
++    rc = record.get("rc")
++    timed_out = record.get("timed_out")
++    parsed = record.get("parsed_final_json")  # produced by the existing
++                                              # stdout-tail parser; v2 prompt
++                                              # promises one JSON line at end.
++    prompt_version = record.get("prompt_version", "v2")
++
++    if timed_out:
++        outcome = "timeout"
++        outcome_detail = None
++    elif rc is not None and rc < 0:
++        outcome = "crashed"
++        outcome_detail = f"signal rc={rc}"
++    elif rc != 0:
++        outcome = "spawner_error"
++        outcome_detail = f"rc={rc}"
++    elif prompt_version == "v1":
++        # Rollback path — v1 prompt has no schema contract; preserve old behaviour.
++        outcome = "ok"
++        outcome_detail = "v1-prompt-rollback"
++    elif not parsed or not isinstance(parsed, dict):
++        outcome = "spawner_error"
++        outcome_detail = "missing-final-json"
++    else:
++        is_valid, errs = validate_spawn_output(parsed)
++        if not is_valid:
++            outcome = "spawner_error"
++            outcome_detail = "json-schema-violation: " + "; ".join(errs[:3])
++        elif parsed.get("ok") is not True:
++            outcome = "task-self-failed"
++            outcome_detail = json.dumps({
++                "reason_class": parsed.get("reason_class"),
++                "reason_evidence": parsed.get("reason_evidence"),
++            })
++        elif parsed.get("ready_for_verifier") is not True:
++            outcome = "task-self-failed"
++            outcome_detail = "ready_for_verifier=false"
++        elif not parsed.get("commits_made"):
++            outcome = "task-self-failed"
++            outcome_detail = "commits_made empty"
++        else:
++            outcome = "implementor-claimed"
++            outcome_detail = f"commits={len(parsed['commits_made'])}"
++    record["outcome"] = outcome
++    record["outcome_detail"] = outcome_detail

--- a/packages/local-llm-router-py-client/templates/spawn_output_schema.v2.json
+++ b/packages/local-llm-router-py-client/templates/spawn_output_schema.v2.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://caia.chiefaia.dev/schemas/spawn_output.v2.json",
+  "title": "Spawn Output v2 (B15.C)",
+  "description": "Strict JSON output schema for the v2 spawn prompt. The spawn's last stdout line MUST be a JSON object conforming to this schema. The B15.C spawner gates outcome on schema conformance + ok-flag; the B15.D VERIFIER spawn consumes this same blob to compare against the live diff.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "task_id",
+    "spawn_id",
+    "files_touched",
+    "commits_made",
+    "acceptance_criteria_self_cert",
+    "tests_required_self_cert",
+    "dod_self_cert",
+    "ready_for_verifier",
+    "reason_class",
+    "reason_evidence",
+    "summary"
+  ],
+  "properties": {
+    "ok": { "type": "boolean" },
+    "task_id": { "type": "string", "minLength": 1 },
+    "spawn_id": { "type": "string", "minLength": 1 },
+    "files_touched": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "additions", "deletions"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "additions": { "type": "integer", "minimum": 0 },
+          "deletions": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "extra_files_touched": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "rationale"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "rationale": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "commits_made": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sha", "message_subject"],
+        "properties": {
+          "sha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+          "message_subject": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "commit_hashes": {
+      "type": "array",
+      "description": "Convenience: list of commit SHAs for the B15.D VERIFIER. Derivable from commits_made[].sha; included for schema-direct consumers.",
+      "items": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" }
+    },
+    "acceptance_criteria_self_cert": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ac", "self_status", "evidence"],
+        "properties": {
+          "ac": { "type": "string", "minLength": 1 },
+          "self_status": { "enum": ["met", "not-met", "uncertain"] },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "acceptance_criteria_met": {
+      "type": "array",
+      "description": "Booleans aligned positionally with acceptance_criteria_self_cert[]. Convenience for the B15.D VERIFIER (faster to scan than parsing self_status). True iff self_status == 'met'.",
+      "items": { "type": "boolean" }
+    },
+    "file_scope_honored": {
+      "type": "boolean",
+      "description": "True iff every entry in files_touched[] was inside the FILE SCOPE allowlist. False whenever extra_files_touched[] is non-empty."
+    },
+    "tests_added": {
+      "type": "array",
+      "description": "Paths of test files added or extended in this spawn. Distinct from tests_required_self_cert[], which is the spec's required tests; tests_added captures NEW tests the implementor wrote.",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "tests_passing": {
+      "type": "boolean",
+      "description": "True iff every test in tests_required_self_cert[] has self_status == 'passing'."
+    },
+    "tests_required_self_cert": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["test", "self_status", "evidence"],
+        "properties": {
+          "test": { "type": "string", "minLength": 1 },
+          "self_status": { "enum": ["passing", "failing", "not-run"] },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "dod_self_cert": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["stage", "self_status", "evidence"],
+        "properties": {
+          "stage": {
+            "enum": [
+              "Analyze",
+              "Research",
+              "Solution/Design",
+              "Implement",
+              "Unit-test",
+              "Integration-test",
+              "Deploy",
+              "End-to-end live verify",
+              "Regression test",
+              "Document + capture learnings"
+            ]
+          },
+          "self_status": { "enum": ["done", "skipped", "not-applicable"] },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "definition_of_done": {
+      "type": "object",
+      "description": "Aggregated DoD report for the B15.D VERIFIER. Keys mirror dod_self_cert[].stage; values are the self_status. Convenience for verifier code that wants a stage->status map without re-iterating.",
+      "additionalProperties": { "enum": ["done", "skipped", "not-applicable"] }
+    },
+    "ready_for_verifier": { "type": "boolean" },
+    "reason_class": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "enum": [
+            "code/uncompletable",
+            "data/missing-input",
+            "policy/rejected",
+            "infra/transient",
+            "infra/persistent"
+          ]
+        }
+      ]
+    },
+    "reason_evidence": { "type": "string" },
+    "summary": { "type": "string", "maxLength": 200 }
+  }
+}

--- a/packages/local-llm-router-py-client/templates/spawn_prompt_v1.md.archived
+++ b/packages/local-llm-router-py-client/templates/spawn_prompt_v1.md.archived
@@ -1,0 +1,66 @@
+---
+status: ARCHIVED
+superseded_by: spawn_prompt_v2.md
+retired_on: 2026-05-13
+retired_by: B15.C (A.3 reliability chain phase 2)
+keep_for: emergency rollback via SPAWN_PROMPT_VERSION=v1
+source_of_truth: ~/Documents/projects/reports/claude-spawner-agent/claude_spawner_agent.py
+                 (function: build_prompt_real_edit, lines ~693-753)
+documented_failure_modes:
+  - title-as-directive (the 30-char title was the entire spec)
+  - must_read_first hard-coded to the same file every spawn
+  - free-form prose output; no structured DoD; no schema check
+  - exit-code-only success signal silently approves no-op spawns
+---
+
+# spawn_prompt v1 — archived
+
+Verbatim reproduction of the v1 prompt built by `build_prompt_real_edit`.
+Kept for emergency rollback (`SPAWN_PROMPT_VERSION=v1`). Do NOT edit; this is
+a frozen snapshot.
+
+```
+You are spawned by the slot-manager autonomous loop in REAL-EDIT mode.
+  permission_mode : {permission_mode}
+  risk_tier       : {risk_tier or 'low'}
+  spawn_id        : {spawn_id}
+  working dir     : {cwd}
+  branch          : {branch} (already checked out for you)
+
+TASK:
+  id        : {nid}
+  item_code : {item}
+  scope_tag : {scope}
+  bucket    : {bucket}
+  title     : {title}
+  directive : {work}
+[optional File scope block when prompt_material.file_scope is populated]
+
+Must-read-first refs:
+{refs_block}
+
+RULES:
+1. Stay inside {cwd}. Do not edit files outside this tree.
+2. Commit in small, focused chunks. Every commit message MUST include the footer
+   `{SPAWNED_BY_TRAILER}` (it can be the only line if needed). The spawner appends
+   it for you if you forget, but your messages are clearer if you include it.
+3. Do NOT push, do NOT open PRs, do NOT touch git remotes. The spawner handles
+   push + PR + auto-merge after you exit.
+4. If the directive is impossible or already done, leave the branch unchanged
+   and exit with a brief explanation. Empty branches will not produce a PR.
+5. When done, output ONE final compact line of JSON to summarise:
+   {"ok": true, "task_id": "<id>", "files_touched": <int>, "commits_made": <int>, "summary": "<one-line>"}
+
+Begin.
+```
+
+## Why this template was retired
+
+The completion audit (2026-05-10) found reliability of 18.6% and a false-claim
+rate of 23.3%. Root cause from the B15 design (§6.2.1): the v1 template gave
+the model **no acceptance criteria, no file scope, no tests, no DoD checklist**.
+The single-line JSON summary was structurally too thin to drive an outcome
+decision — and the spawner ignored it anyway (`rc==0 → outcome=ok`).
+
+v2 (`spawn_prompt_v2.md`) injects all four contract fields and enforces a
+strict JSON output schema validated by the spawner before declaring success.

--- a/packages/local-llm-router-py-client/templates/spawn_prompt_v2.md
+++ b/packages/local-llm-router-py-client/templates/spawn_prompt_v2.md
@@ -1,0 +1,93 @@
+---
+version: v2
+authored: 2026-05-13
+authored_by: B15.C (A.3 reliability chain phase 2)
+design_authority: ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md
+                  (§6.2.2 — v2 prompt template + strict JSON output schema)
+supersedes: spawn_prompt_v1.md.archived
+rollback: set SPAWN_PROMPT_VERSION=v1 in the spawner's process env, restart
+binding_rules:
+  - acceptance_criteria is explicit; the spawn may NOT interpret beyond it.
+  - file_scope is binding; out-of-scope edits go in extra_files_touched with rationale.
+  - tests_required must be run; results captured in tests_required_self_cert.
+  - dod_required_stages must each receive an evidence field; missing → fail.
+  - must_read_first only appears when the AC explicitly requires reading a doc.
+  - The final line of stdout MUST be one JSON object conforming to the schema below.
+substitution_placeholders:
+  - {spawn_id}, {permission_mode}, {risk_tier}, {cwd}, {branch}
+  - {node_id}, {item_code}, {scope_tag}, {target_bucket}, {title}
+  - {parent_context_title}, {parent_context_scope}, {work_directive}
+  - {acceptance_criteria_block}, {file_scope_block}, {package_scope_negative_list}
+  - {tests_required_block}, {tests_filter_expr}
+  - {tech_context_block}, {architectural_constraints_block}
+  - {dod_required_stages_block}, {must_read_first_block}
+  - {SPAWNED_BY_TRAILER}, {json_schema_block}
+---
+
+You are spawned by the slot-manager autonomous loop in REAL-EDIT mode (v2).
+
+CONTEXT
+  spawn_id        : {spawn_id}
+  permission_mode : {permission_mode}
+  risk_tier       : {risk_tier}
+  worktree        : {cwd}
+  branch          : {branch} (already checked out)
+
+WHAT YOU MUST PRODUCE
+  A PR-ready commit (or commits) on the branch above that:
+    1. Touches ONLY the files listed in FILE SCOPE below (unless absolutely necessary, see RULES).
+    2. Makes EVERY acceptance criterion in ACCEPTANCE CRITERIA pass.
+    3. Makes every test in TESTS REQUIRED pass when run against the post-edit branch.
+    4. Self-certifies DoD STAGES with explicit evidence (see DOD SELF-CERT block).
+
+TASK
+  id          : {node_id}
+  item_code   : {item_code}
+  scope_tag   : {scope_tag}
+  bucket      : {target_bucket}
+  title       : {title}
+  parent      : {parent_context_title} (scope={parent_context_scope})
+  directive   : {work_directive}
+
+ACCEPTANCE CRITERIA (Given/When/Then — every line must hold after your edit)
+{acceptance_criteria_block}
+
+FILE SCOPE (the files you are expected to touch)
+{file_scope_block}
+  Out of scope (forbidden): {package_scope_negative_list}
+
+TESTS REQUIRED (these tests must pass against your branch HEAD)
+{tests_required_block}
+  Run them with: pnpm test:filter {tests_filter_expr}   OR equivalent
+
+TECH CONTEXT (from EA, AKG-grounded)
+{tech_context_block}
+
+ARCHITECTURAL CONSTRAINTS
+{architectural_constraints_block}
+
+DOD STAGES REQUIRED FOR THIS TASK
+{dod_required_stages_block}
+  For each stage you complete, fill the corresponding evidence field in DOD SELF-CERT.
+
+MUST READ FIRST
+{must_read_first_block}
+
+RULES
+  1. Stay inside {cwd}. Do not edit files outside this tree.
+  2. Touch only FILE SCOPE files unless a file outside scope is strictly required.
+     If you must touch a file outside scope, append it to dod_self_cert.extra_files_touched with rationale.
+  3. Commit in small, focused chunks. Every commit message MUST include the trailer
+     `{SPAWNED_BY_TRAILER}`.
+  4. Do NOT push, do NOT open PRs, do NOT touch git remotes. The spawner handles
+     push + PR + auto-merge after you exit.
+  5. If the directive is impossible or already done, leave the branch unchanged
+     and exit with structured-output `ok=false`, `reason_class` set, and a
+     concrete `reason_evidence` quote.
+  6. When done, output ONE final compact line of JSON conforming to the schema below.
+     The spawner WILL parse it. Malformed or missing JSON => outcome=spawner_error.
+
+REQUIRED FINAL OUTPUT (single line, parsed as JSON)
+{json_schema_block}
+
+Begin.

--- a/packages/local-llm-router-py-client/tests/test_spawn_prompt_v2.py
+++ b/packages/local-llm-router-py-client/tests/test_spawn_prompt_v2.py
@@ -1,0 +1,369 @@
+"""B15.C fixture test — verify that:
+  1. The v2 template renders all four contract sections (AC, file_scope,
+     tests, DoD) from a UDP-shaped task_spec.
+  2. A "tiny fixture task" (add a comment to file X) flowing through the
+     loader produces a prompt containing the expected directive + file scope.
+  3. A simulated spawn final-JSON output validates against the strict v2
+     schema (positive case + multiple negative cases).
+  4. SPAWN_PROMPT_VERSION env override actually selects the v1 prompt for
+     rollback (no AC block, no schema block).
+
+Pure stdlib (unittest). No pytest, no jsonschema. Run with:
+    python3 -m unittest tests/test_spawn_prompt_v2.py -v
+or
+    python3 tests/test_spawn_prompt_v2.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import unittest
+
+# Allow `python3 tests/test_spawn_prompt_v2.py` from package root.
+_PKG_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG_ROOT / "src"))
+
+from spawn_prompt_loader import (  # noqa: E402
+    build_prompt,
+    build_prompt_v1,
+    build_prompt_v2,
+    load_output_schema,
+    load_template,
+    resolve_version,
+    validate_spawn_output,
+)
+
+
+TINY_FIXTURE_TASK = {
+    "id": "B15.C.fixture.001",
+    "title": "Add a license-header comment to packages/foo/src/index.ts",
+    "item_code": "FIX-1",
+    "scope_tag": "[scope:1]",
+    "target_bucket": "stolution-claude",
+    "prompt_material": {
+        "work_directive": "Insert `// SPDX-License-Identifier: MIT` as the first line of the file.",
+        "parent_context": {"title": "License hygiene sweep", "scope": "2"},
+        "acceptance_criteria": [
+            "Given the repo at HEAD When the file is opened Then line 1 is the SPDX header.",
+            "Given the build is run When tsc compiles the file Then it emits zero errors.",
+        ],
+        "file_scope": ["packages/foo/src/index.ts"],
+        "package_scope_negative": ["packages/foo/src/internal/**"],
+        "tests_required": [
+            {"name": "license-header.spec.ts", "kind": "unit"},
+        ],
+        "tech_context": ["TypeScript 5.5, ESM, vitest"],
+        "architectural_constraints": ["No new dependencies"],
+        "dod_required_stages": ["Implement", "Unit-test"],
+        "must_read_first": [],
+        "tests_filter_expr": "packages/foo",
+    },
+}
+
+
+def _valid_output_for(task_id: str, spawn_id: str) -> dict:
+    """A minimal v2-schema-conformant spawn-output blob."""
+    return {
+        "ok": True,
+        "task_id": task_id,
+        "spawn_id": spawn_id,
+        "files_touched": [
+            {"path": "packages/foo/src/index.ts", "additions": 1, "deletions": 0}
+        ],
+        "extra_files_touched": [],
+        "commits_made": [
+            {"sha": "abc1234", "message_subject": "feat(foo): add SPDX header"}
+        ],
+        "commit_hashes": ["abc1234"],
+        "acceptance_criteria_self_cert": [
+            {
+                "ac": "Given the repo at HEAD When the file is opened Then line 1 is the SPDX header.",
+                "self_status": "met",
+                "evidence": "packages/foo/src/index.ts:1",
+            },
+            {
+                "ac": "Given the build is run When tsc compiles the file Then it emits zero errors.",
+                "self_status": "met",
+                "evidence": "tsc output: 0 errors",
+            },
+        ],
+        "acceptance_criteria_met": [True, True],
+        "file_scope_honored": True,
+        "tests_added": [],
+        "tests_passing": True,
+        "tests_required_self_cert": [
+            {
+                "test": "license-header.spec.ts",
+                "self_status": "passing",
+                "evidence": "vitest: 1 passed",
+            }
+        ],
+        "dod_self_cert": [
+            {"stage": "Implement", "self_status": "done", "evidence": "abc1234"},
+            {
+                "stage": "Unit-test",
+                "self_status": "done",
+                "evidence": "vitest: 1 passed",
+            },
+        ],
+        "definition_of_done": {"Implement": "done", "Unit-test": "done"},
+        "ready_for_verifier": True,
+        "reason_class": None,
+        "reason_evidence": "",
+        "summary": "Added SPDX header; 1 test passing.",
+    }
+
+
+class TestTemplateLoading(unittest.TestCase):
+    def test_v2_template_loads_with_frontmatter_stripped(self) -> None:
+        body = load_template("v2")
+        self.assertFalse(body.startswith("---"), "frontmatter should be stripped")
+        self.assertIn("ACCEPTANCE CRITERIA", body)
+        self.assertIn("FILE SCOPE", body)
+        self.assertIn("TESTS REQUIRED", body)
+        self.assertIn("DOD STAGES REQUIRED", body)
+        self.assertIn("REQUIRED FINAL OUTPUT", body)
+        # No leftover placeholders that v2-only template should keep
+        self.assertIn("{acceptance_criteria_block}", body)
+        self.assertIn("{json_schema_block}", body)
+
+    def test_v1_archived_template_loads(self) -> None:
+        body = load_template("v1")
+        # v1 had the title-as-directive shape; sanity-check the headers
+        self.assertIn("REAL-EDIT mode", body)
+        self.assertIn("Must-read-first refs", body)
+
+    def test_unsupported_version_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            load_template("v99")
+
+
+class TestPromptRendering(unittest.TestCase):
+    def test_v2_renders_all_four_contract_sections(self) -> None:
+        out = build_prompt_v2(
+            TINY_FIXTURE_TASK,
+            spawn_id="spawn-test-001",
+            permission_mode="bypassPermissions",
+            cwd="/tmp/wt",
+            branch="auto/b15c-fixture-spawn-test",
+            risk_tier="low",
+            spawned_by_trailer="Spawned-By: claude-spawner-agent",
+        )
+        # AC section populated from prompt_material.acceptance_criteria[]
+        self.assertIn("ACCEPTANCE CRITERIA", out)
+        self.assertIn("1. Given the repo at HEAD", out)
+        self.assertIn("2. Given the build is run", out)
+        # File scope binding
+        self.assertIn("FILE SCOPE", out)
+        self.assertIn("packages/foo/src/index.ts", out)
+        # Negative scope
+        self.assertIn("packages/foo/src/internal/**", out)
+        # Tests required
+        self.assertIn("TESTS REQUIRED", out)
+        self.assertIn("license-header.spec.ts", out)
+        # DoD stages
+        self.assertIn("DOD STAGES REQUIRED", out)
+        self.assertIn("Implement", out)
+        self.assertIn("Unit-test", out)
+        # JSON schema is inlined verbatim
+        self.assertIn("REQUIRED FINAL OUTPUT", out)
+        self.assertIn("\"acceptance_criteria_self_cert\"", out)
+        self.assertIn("\"dod_self_cert\"", out)
+        # No must_read_first leak (the fixture has none — verify the
+        # "DO NOT load any file" guard rendered, not a stale ref list)
+        self.assertIn("DO NOT load any file unless the AC explicitly says so", out)
+        # No unsubstituted placeholders left
+        for ph in (
+            "{spawn_id}",
+            "{node_id}",
+            "{acceptance_criteria_block}",
+            "{file_scope_block}",
+            "{tests_required_block}",
+            "{dod_required_stages_block}",
+            "{json_schema_block}",
+        ):
+            self.assertNotIn(ph, out, f"placeholder {ph} not substituted")
+
+    def test_v1_rendering_path_is_legacy(self) -> None:
+        out = build_prompt_v1(
+            TINY_FIXTURE_TASK,
+            spawn_id="spawn-test-001",
+            permission_mode="bypassPermissions",
+            cwd="/tmp/wt",
+            branch="auto/b15c-fixture",
+            risk_tier="low",
+            spawned_by_trailer="Spawned-By: claude-spawner-agent",
+        )
+        # v1 lacks the structured headers
+        self.assertNotIn("ACCEPTANCE CRITERIA", out)
+        self.assertNotIn("DOD STAGES REQUIRED", out)
+        # v1 has the one-line JSON ack instead of the full schema
+        self.assertIn("ONE final compact line of JSON", out)
+        self.assertNotIn("acceptance_criteria_self_cert", out)
+
+    def test_dispatcher_honours_env_override(self) -> None:
+        old = os.environ.get("SPAWN_PROMPT_VERSION")
+        try:
+            os.environ["SPAWN_PROMPT_VERSION"] = "v1"
+            self.assertEqual(resolve_version(), "v1")
+            out = build_prompt(
+                None,  # honors env
+                TINY_FIXTURE_TASK,
+                spawn_id="s",
+                permission_mode="bypassPermissions",
+                cwd="/tmp/wt",
+                branch="auto/b15c-fixture",
+                risk_tier="low",
+                spawned_by_trailer="t",
+            )
+            self.assertNotIn("ACCEPTANCE CRITERIA", out, "v1 path should not emit AC header")
+
+            os.environ["SPAWN_PROMPT_VERSION"] = "v2"
+            self.assertEqual(resolve_version(), "v2")
+            out = build_prompt(
+                None,
+                TINY_FIXTURE_TASK,
+                spawn_id="s",
+                permission_mode="bypassPermissions",
+                cwd="/tmp/wt",
+                branch="auto/b15c-fixture",
+                risk_tier="low",
+                spawned_by_trailer="t",
+            )
+            self.assertIn("ACCEPTANCE CRITERIA", out, "v2 path must emit AC header")
+        finally:
+            if old is None:
+                os.environ.pop("SPAWN_PROMPT_VERSION", None)
+            else:
+                os.environ["SPAWN_PROMPT_VERSION"] = old
+
+    def test_garbage_version_falls_back_to_v2(self) -> None:
+        old = os.environ.get("SPAWN_PROMPT_VERSION")
+        try:
+            os.environ["SPAWN_PROMPT_VERSION"] = "vBogus"
+            self.assertEqual(resolve_version(), "v2")
+        finally:
+            if old is None:
+                os.environ.pop("SPAWN_PROMPT_VERSION", None)
+            else:
+                os.environ["SPAWN_PROMPT_VERSION"] = old
+
+
+class TestOutputSchemaValidation(unittest.TestCase):
+    def test_minimal_valid_output_passes(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        ok, errs = validate_spawn_output(out)
+        self.assertTrue(ok, msg=f"unexpected errors: {errs}")
+        self.assertEqual(errs, [])
+
+    def test_missing_required_field_rejected(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        del out["dod_self_cert"]
+        ok, errs = validate_spawn_output(out)
+        self.assertFalse(ok)
+        self.assertTrue(any("dod_self_cert" in e and "missing" in e for e in errs), errs)
+
+    def test_unknown_top_level_field_rejected(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["i_just_made_this_up"] = "lol"
+        ok, errs = validate_spawn_output(out)
+        self.assertFalse(ok)
+        self.assertTrue(
+            any("additionalProperties not allowed" in e for e in errs), errs
+        )
+
+    def test_bad_enum_value_rejected(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["acceptance_criteria_self_cert"][0]["self_status"] = "ish"
+        ok, errs = validate_spawn_output(out)
+        self.assertFalse(ok)
+        self.assertTrue(any("enum" in e for e in errs), errs)
+
+    def test_bad_commit_sha_pattern_rejected(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["commits_made"][0]["sha"] = "NOT-A-SHA"
+        ok, errs = validate_spawn_output(out)
+        self.assertFalse(ok)
+        self.assertTrue(any("pattern" in e for e in errs), errs)
+
+    def test_bool_for_integer_rejected(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["files_touched"][0]["additions"] = True  # bool, not int
+        ok, errs = validate_spawn_output(out)
+        self.assertFalse(ok)
+        self.assertTrue(any("expected type=integer" in e for e in errs), errs)
+
+    def test_dod_stage_enum_rejected(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["dod_self_cert"][0]["stage"] = "Vibes"
+        ok, errs = validate_spawn_output(out)
+        self.assertFalse(ok)
+        self.assertTrue(any("enum" in e for e in errs), errs)
+
+    def test_reason_class_null_accepted(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["reason_class"] = None
+        ok, errs = validate_spawn_output(out)
+        self.assertTrue(ok, errs)
+
+    def test_reason_class_typed_accepted(self) -> None:
+        out = _valid_output_for("B15.C.fixture.001", "spawn-test-001")
+        out["ok"] = False
+        out["reason_class"] = "code/uncompletable"
+        out["reason_evidence"] = "directive ambiguous: no AC for stage X"
+        ok, errs = validate_spawn_output(out)
+        self.assertTrue(ok, errs)
+
+
+class TestFixtureTaskFullCycle(unittest.TestCase):
+    """End-to-end: tiny fixture task → render prompt → simulate spawn
+    output → assert schema conformance. This is the deliverable test
+    called out in the B15.C task: "spawn a tiny fixture task (e.g. 'add
+    a comment to file X') and assert the spawn output validates against
+    the strict JSON schema." We simulate the spawn (don't shell out to
+    `claude --print`) so the test is hermetic and fast.
+    """
+
+    def test_full_cycle(self) -> None:
+        rendered = build_prompt_v2(
+            TINY_FIXTURE_TASK,
+            spawn_id="spawn-fixture-b15c",
+            permission_mode="bypassPermissions",
+            cwd="/tmp/wt",
+            branch="auto/b15c-fixture",
+            risk_tier="low",
+            spawned_by_trailer="Spawned-By: claude-spawner-agent",
+        )
+        # Render check (prompt is well-formed)
+        self.assertGreater(len(rendered), 1000)
+        self.assertIn("\"acceptance_criteria_self_cert\"", rendered)
+
+        # Simulated spawn output — a well-behaved implementor would emit
+        # exactly this as its final stdout line.
+        simulated = _valid_output_for("B15.C.fixture.001", "spawn-fixture-b15c")
+        as_line = json.dumps(simulated, separators=(",", ":"))
+        # Spawner-side: tail-parse the JSON line, validate, decide outcome.
+        parsed = json.loads(as_line)
+        ok, errs = validate_spawn_output(parsed)
+        self.assertTrue(ok, msg=f"validator errors on fixture: {errs}")
+
+        # And the gate logic the spawner will apply:
+        self.assertTrue(parsed["ok"])
+        self.assertTrue(parsed["ready_for_verifier"])
+        self.assertTrue(parsed["commits_made"], "implementor must report commits")
+        # → outcome would be 'implementor-claimed' per spawner_patch_v3.diff
+
+
+class TestSchemaLoadable(unittest.TestCase):
+    def test_schema_is_valid_json(self) -> None:
+        s = load_output_schema()
+        self.assertEqual(s.get("$schema"), "https://json-schema.org/draft/2020-12/schema")
+        self.assertIn("acceptance_criteria_self_cert", s["properties"])
+        self.assertIn("dod_self_cert", s["properties"])
+        self.assertIn("commit_hashes", s["properties"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/packages/verifier/DESIGN.md
+++ b/packages/verifier/DESIGN.md
@@ -1,0 +1,85 @@
+# @chiefaia/verifier — Design
+
+## Why a fourth sibling
+
+Today (Critic + Code-Reviewer + Reviewer) covers **code-quality** dimensions
+— security, correctness, style, craftsmanship. None of them ask "did the
+implementor actually satisfy the acceptance criteria the spec listed?" The
+forensic audit that motivated B15
+(`completion_audit_report_2026-05-10.md`) found 41 nodes whose `status='done'`
+flag was untrue: the implementor self-claimed completion but the AC
+behaviour wasn't in the diff. That's the gap the VERIFIER closes.
+
+## Disjoint-by-construction with the other three
+
+Per `feedback_critic_agent_two_tier_detector_pattern.md`, sibling agents
+must have **distinct severity lexicon, distinct domain, denylist of
+sibling categories**. The verifier:
+
+| Dimension         | Critic / Code-Reviewer / Reviewer | Verifier                                        |
+| ----------------- | --------------------------------- | ----------------------------------------------- |
+| Severity lexicon  | `critical / high / medium / low`  | `pass / fail-impl / fail-spec / uncertain`      |
+| Verdict structure | findings list                     | verdict object + per-AC + per-test + per-stage  |
+| Source of truth   | the diff                          | the diff **vs** the spec's acceptance criteria  |
+| Domain            | code quality                      | spec satisfaction                               |
+
+The verifier's category set (`acceptance_criteria_verdicts`,
+`tests_required_verdicts`, `dod_stages_verdicts`) is disjoint from every
+sibling's category enum. No cross-finding leakage by construction.
+
+## Worktree isolation rationale
+
+Per the design doc §6.3.3, the verifier MUST run in a **different worktree
+than the implementing spawn** so its judgment is unbiased by:
+- the implementor's working files (uncommitted state),
+- any process-state the implementor left behind (env vars, tmp files),
+- `git diff` against an artificially-quiet base.
+
+A fresh `/tmp/verifier_<job_id>` checkout off the merged commit gives the
+verifier exactly the post-merge state — what every downstream consumer
+will see.
+
+## Cleanup contract
+
+Two cleanup layers stack:
+
+1. **Agent-side** (`worktree.ts`): every `verify()` call uses try/finally;
+   on exception, timeout, or successful completion the worktree handle's
+   `cleanup()` runs before the function returns. Idempotent.
+2. **Wrapper-side** (`bin/run-verifier.sh`): bash `trap cleanup EXIT INT
+   TERM HUP` removes the worktree even if the node process is SIGKILLed
+   mid-spawn (the trap doesn't fire on SIGKILL, but it does fire on every
+   SIGTERM/timeout path the spawner uses).
+
+If both layers somehow fail (e.g. the host crashes before either fires),
+the **spawner-side reaper** (claude_spawner_agent.py's
+`reap_worktrees_at_startup`, see `WORKTREE_LOCK_FILE` constants) sweeps
+stale `/tmp/verifier_*` dirs at next process startup. Three layers of
+defence.
+
+## Budget contract
+
+- 15-minute hard wall-clock (matches every other spawn type).
+- One `claude --print` invocation only — the verifier does NOT recurse
+  (no nested verifier on the verifier; that would be unbounded recursion
+  with no termination signal).
+- Subscription-only; `ANTHROPIC_API_KEY` is stripped from the spawn env.
+
+## Phase 1 scope
+
+This phase ships:
+- The TypeScript agent + CLI + bash wrapper.
+- The verdict JSON schema + validator.
+- The prompt template + builder.
+- The DB migration that gates `nodes.status='done'` on the verdict.
+- A common review-sibling dispatcher script.
+- The `.github/workflows/verifier.yml` workflow alongside the other 3.
+
+Out of scope (deferred):
+- Deterministic detectors (Phase 2 — once LLM-tier signal quality is
+  validated, mirroring the Critic / Code-Reviewer Phase 1 → Phase 2 path).
+- Full `verifier_queue` reconciler in claude_spawner_agent.py (B15.G);
+  this phase wires the verdict consumer (the trigger) but the queue is
+  a separate atomic.
+- The slot-manager `shadow_slot_id` reservation (design §6.3.3) — that's
+  a slot-manager change, not a verifier-package change.

--- a/packages/verifier/README.md
+++ b/packages/verifier/README.md
@@ -1,0 +1,85 @@
+# @chiefaia/verifier
+
+VERIFIER is the **fourth review-sibling**, alongside Critic
+(`@chiefaia/critic` — security/regression/cost), Code-Reviewer
+(`@chiefaia/code-reviewer` — correctness/style/types/tests), and Reviewer
+(`@chiefaia/reviewer` — craftsmanship). Its domain is
+**acceptance-criteria-satisfaction** — the spec-truth check that none of
+the other three siblings cover.
+
+## What it does
+
+For every implementing-spawn PR, the verifier:
+
+1. **Creates a fresh git worktree** at `/tmp/verifier_<job_id>` checked out
+   at the implementor's PR head SHA. This gives the verifier zero shared
+   state with the implementing spawn (different worktree, different prompt).
+2. **Reads the implementor's strict-JSON DoD self-cert** (per
+   `@chiefaia/local-llm-router-py-client`'s `spawn_output_schema.v2.json`
+   from B15.C). Treats every claim as **untrusted**.
+3. **For each acceptance criterion** in the spec: re-reads the changed
+   files, decides `met / not-met / uncertain`, captures evidence (file:line
+   or test name) — never lifts the implementor's claim verbatim.
+4. **For each test in `tests_required`**: runs it against the head SHA in
+   the fresh worktree, captures the runner output excerpt.
+5. **For each DoD stage** in `dod_required_stages`: decides whether the
+   diff materially contributes (using the diff itself, not the
+   self-cert).
+6. **Emits a strict-JSON verdict** conforming to
+   `templates/verifier_verdict_schema.json`.
+7. **Cleans up the worktree** via try/finally — runs on success, exception,
+   timeout, and SIGTERM paths.
+
+## Routing semantics
+
+Per `~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md`
+§6.3.6:
+
+| Routing class       | Verdict use                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------------- |
+| `autonomous-loop`   | **BLOCKING** — gates `nodes.status='done'` via SPS B15.B `done_status_guard` trigger. `pass` is required. |
+| `operator-routed`   | **ADVISORY** — verdict is logged + surfaced in the spawn report; operator decides on merge.               |
+
+The `blocking` field on the verdict mirrors this — set by the prompt builder
+based on the `routingClass` input.
+
+## CLI
+
+```sh
+caia-verifier verify           --input inputs.json [--out verdict.json]
+caia-verifier render-prompt    --input inputs.json
+caia-verifier validate-verdict --verdict verdict.json
+```
+
+`bin/run-verifier.sh` is the operator/spawner-side wrapper that adds a bash
+`trap` for worktree cleanup on EXIT/INT/TERM/HUP. Always prefer the wrapper
+over calling the CLI directly when running outside the node agent's own
+process.
+
+## Subscription-only
+
+The verifier's `claude --print` invocation runs with `ANTHROPIC_API_KEY`
+**explicitly stripped** from the env (matching the convention every other
+review-sibling follows — see `feedback_no_api_key_billing.md`). Auth flows
+through `CLAUDE_OAUTH_TOKEN` only.
+
+## Design refs
+
+- `~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md`
+  §6.3 — verifier spawn architecture, prompt template, verdict schema.
+- `~/Documents/projects/agent-memory/feedback_reviewer_agent_advisory_only_pattern.md`
+  — sibling advisory pattern (we adopt the autonomous-loop / operator-routed
+  split).
+- `~/Documents/projects/agent-memory/feedback_critic_agent_two_tier_detector_pattern.md`
+  — sibling architecture conventions (Phase 1 ships LLM-only).
+- `~/Documents/projects/caia/packages/local-llm-router-py-client/templates/spawn_output_schema.v2.json`
+  — the implementor's strict-JSON output the verifier consumes.
+
+## See also
+
+- `infra/stolution/sps/migrations/2026-05-13_b15d_verifier_verdicts.sql` —
+  DB layer that gates `nodes.status='done'` on this verdict.
+- `.github/workflows/verifier.yml` — PR-time verifier workflow alongside
+  the other sibling workflows.
+- `scripts/review-siblings/dispatch.sh` — common review-sibling dispatcher
+  that runs Critic + Code-Reviewer + Reviewer + Verifier in parallel.

--- a/packages/verifier/bin/run-verifier.sh
+++ b/packages/verifier/bin/run-verifier.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run-verifier.sh — operator/spawner-side verifier launcher with hardened
+# worktree lifecycle.
+#
+# Wraps `node dist/cli.js verify --input <inputs.json>` with a bash trap that
+# cleans up the worktree even on SIGTERM/SIGINT/script-crash. The trap is
+# defence-in-depth on top of the agent's own try/finally cleanup — together
+# they guarantee no leaked /tmp/verifier_* dirs even if the node process is
+# killed mid-spawn.
+#
+# Subscription-only: `unset ANTHROPIC_API_KEY` happens here so the inherited
+# env from the calling shell never leaks into `claude --print`.
+#
+# Exit codes:
+#   0   verdict.overall == 'pass'
+#   1   verdict.overall == 'fail' (autonomous-loop will surface as failed)
+#   2   schema/parse/transport error (treated as fail-impl by spawner)
+#  124  timeout (matches `timeout(1)` convention)
+#
+# Usage:
+#   run-verifier.sh \
+#     --inputs /path/to/inputs.json \
+#     --out    /path/to/verdict.json \
+#     [--repo  /abs/path/to/repo] \
+#     [--budget-seconds 900]
+# =============================================================================
+set -uo pipefail
+
+INPUTS=""
+OUT=""
+REPO_PATH="${PWD}"
+BUDGET_SECONDS=900
+JOB_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inputs)         INPUTS="$2"; shift 2 ;;
+    --out)            OUT="$2"; shift 2 ;;
+    --repo)           REPO_PATH="$2"; shift 2 ;;
+    --budget-seconds) BUDGET_SECONDS="$2"; shift 2 ;;
+    --job-id)         JOB_ID="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "$0"; exit 0 ;;
+    *)
+      echo "run-verifier: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$INPUTS" ]] || [[ ! -f "$INPUTS" ]]; then
+  echo "run-verifier: --inputs <path> is required and must exist" >&2
+  exit 2
+fi
+if [[ -z "$OUT" ]]; then
+  OUT="$(mktemp -t verifier_verdict_XXXXXX.json)"
+fi
+
+# subscription-only — strip API key from spawn env (defence-in-depth on top
+# of the node agent's env scrub).
+unset ANTHROPIC_API_KEY
+
+# Default JOB_ID derives from the inputs file's task_id field for stable
+# worktree paths across retries (idempotent cleanup if a prior run left a
+# leftover worktree dir).
+if [[ -z "$JOB_ID" ]]; then
+  JOB_ID="$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).taskId || 'unknown')" "$INPUTS" 2>/dev/null || echo unknown)"
+  JOB_ID="${JOB_ID}-$$"
+fi
+WORKTREE="/tmp/verifier_${JOB_ID}"
+
+# Defence-in-depth cleanup. Runs on EXIT (every script termination path),
+# including when the node child is killed by the timeout below or when a
+# SIGTERM is delivered to this wrapper. The agent itself ALSO cleans up,
+# so this is belt-and-braces — both must be safe to no-op when the worktree
+# is already gone.
+cleanup() {
+  local rc=$?
+  # `git worktree remove --force` is idempotent on a missing path (errors
+  # but doesn't leave residue); the rm -rf below tolerates the same.
+  ( cd "$REPO_PATH" 2>/dev/null && git worktree remove --force "$WORKTREE" >/dev/null 2>&1 ) || true
+  rm -rf "$WORKTREE" 2>/dev/null || true
+  ( cd "$REPO_PATH" 2>/dev/null && git worktree prune >/dev/null 2>&1 ) || true
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM HUP
+
+# Inject the worktree path into the inputs blob so the agent uses our
+# trap-protected path rather than minting its own. Pure-stdlib jq replacement
+# via node so we don't take a jq dep.
+PATCHED_INPUTS="$(mktemp -t verifier_inputs_XXXXXX.json)"
+node -e "
+const fs=require('node:fs');
+const inputs=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));
+inputs.verifierWorktree=process.argv[2];
+fs.writeFileSync(process.argv[3], JSON.stringify(inputs));
+" "$INPUTS" "$WORKTREE" "$PATCHED_INPUTS"
+
+# Pre-create the worktree from the patched inputs' prHeadSha. This ensures
+# the trap-protected path exists before the node process runs.
+HEAD_SHA="$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).prHeadSha)" "$PATCHED_INPUTS")"
+( cd "$REPO_PATH" && git worktree add --detach "$WORKTREE" "$HEAD_SHA" ) >/tmp/verifier_${JOB_ID}.wt-add.log 2>&1 || {
+  echo "run-verifier: failed to create worktree at $WORKTREE for $HEAD_SHA" >&2
+  cat "/tmp/verifier_${JOB_ID}.wt-add.log" >&2 || true
+  exit 2
+}
+
+# Run the agent with a hard budget — the GNU/BSD timeout cmd sends SIGTERM
+# at deadline; our trap fires regardless.
+DIST="$(cd "$(dirname "$0")/.." && pwd)/dist/cli.js"
+if ! command -v timeout >/dev/null 2>&1; then
+  # macOS without coreutils — fall back to no external timeout (the agent's
+  # internal deadline still applies).
+  node "$DIST" verify --input "$PATCHED_INPUTS" --out "$OUT"
+  RC=$?
+else
+  timeout "${BUDGET_SECONDS}s" node "$DIST" verify --input "$PATCHED_INPUTS" --out "$OUT"
+  RC=$?
+fi
+
+# trap cleanup() will fire on exit. RC propagates to the spawner.
+exit "$RC"

--- a/packages/verifier/eslint.config.cjs
+++ b/packages/verifier/eslint.config.cjs
@@ -1,0 +1,32 @@
+// @ts-check
+// ESLint v9 flat config — mirrors the other review-sibling packages.
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@chiefaia/verifier",
+  "version": "0.1.0",
+  "private": true,
+  "description": "VERIFIER review-sibling — fourth sibling alongside Critic, Code-Reviewer, Reviewer. Spawns a fresh-prompt, fresh-worktree claude binary that re-derives acceptance-criteria/test/file-scope verdicts from the actual diff and emits a strict-JSON verdict. BLOCKING for autonomous-loop spawns (gates `nodes.status='done'` via SPS done_status_guard trigger), ADVISORY for operator-routed spawns. Subscription-only — never sets ANTHROPIC_API_KEY.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "caia-verifier": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "templates",
+    "bin"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "1.6.1",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/verifier/src/agent.ts
+++ b/packages/verifier/src/agent.ts
@@ -1,0 +1,280 @@
+/**
+ * VerifierAgent — public entrypoint.
+ *
+ * Orchestrates a single verifier run end-to-end:
+ *
+ *   1. Create a fresh git worktree at /tmp/verifier_<job_id> at PR head SHA.
+ *   2. Build the verifier prompt (independent of implementing spawn — fresh
+ *      prompt, no shared context beyond the strict-JSON DoD blob).
+ *   3. Spawn `claude --print --permission-mode bypassPermissions`, with
+ *      ANTHROPIC_API_KEY scrubbed from env (subscription-only path).
+ *   4. Parse + schema-validate the last-line JSON blob.
+ *   5. Cleanup the worktree (try/finally — runs on success, exception,
+ *      and timeout paths). Idempotent.
+ *
+ * The agent itself NEVER recurses (no nested verifier on the verifier).
+ * The MAX_VERIFIER_BUDGET_MS cap (15 min) enforces the "budget it like any
+ * other spawn" constraint from the operating contract.
+ *
+ * Returns a VerifierRunOutcome describing the final verdict, the cleanup
+ * outcome, and the failure reason (if any).
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildVerifierPrompt } from './prompt-builder.js';
+import type {
+  RoutingClass,
+  VerifierRunOutcome,
+  VerifierSpawnInputs,
+  VerifierVerdict
+} from './types.js';
+import { parseAndValidateVerdict } from './verdict-validator.js';
+import { createWorktree, type WorktreeHandle } from './worktree.js';
+
+/** 15-minute hard cap per the operating contract. */
+const MAX_VERIFIER_BUDGET_MS = 15 * 60 * 1000;
+
+export interface VerifierAgentConfig {
+  /** Repo root the verifier runs against. Defaults to cwd. */
+  repoPath?: string;
+  /** Override the default `claude` binary lookup. */
+  claudeBinary?: string;
+  /** Maximum wall-clock for the spawn. Default 15min. */
+  maxBudgetMs?: number;
+  /** Test seam — replaces the runChild() implementation. */
+  runChild?: RunChildFn;
+  /** Test seam — replaces the worktree factory. */
+  worktreeFactory?: typeof createWorktree;
+}
+
+export interface RunChildResult {
+  rc: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+export type RunChildFn = (args: {
+  binary: string;
+  argv: string[];
+  cwd: string;
+  prompt: string;
+  env: Record<string, string>;
+  timeoutMs: number;
+}) => Promise<RunChildResult>;
+
+/**
+ * Default child runner — uses node:child_process.spawn with stdin pipe.
+ * Times out via SIGTERM at deadline.
+ */
+const defaultRunChild: RunChildFn = ({ binary, argv, cwd, prompt, env, timeoutMs }) => {
+  return new Promise((resolve) => {
+    const child = spawn(binary, argv, {
+      cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    let timedOut = false;
+    const t = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // ignore
+      }
+    }, timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (d) => {
+      stdoutBuf += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderrBuf += d;
+    });
+    child.on('close', (code) => {
+      clearTimeout(t);
+      resolve({
+        rc: code ?? -1,
+        stdout: stdoutBuf,
+        stderr: stderrBuf,
+        timedOut
+      });
+    });
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+};
+
+function lastJsonLine(stdout: string): string | null {
+  const lines = stdout.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const raw = lines[i];
+    if (raw === undefined) continue;
+    const t = raw.trim();
+    if (t.startsWith('{') && t.endsWith('}')) return t;
+  }
+  return null;
+}
+
+function buildEnvWithoutApiKey(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k === 'ANTHROPIC_API_KEY') continue; // subscription-only
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+export class VerifierAgent {
+  readonly config: Required<Omit<VerifierAgentConfig, 'runChild' | 'worktreeFactory'>> & {
+    runChild: RunChildFn;
+    worktreeFactory: typeof createWorktree;
+  };
+
+  constructor(input: VerifierAgentConfig = {}) {
+    this.config = {
+      repoPath: input.repoPath ?? process.cwd(),
+      claudeBinary: input.claudeBinary ?? 'claude',
+      maxBudgetMs: input.maxBudgetMs ?? MAX_VERIFIER_BUDGET_MS,
+      runChild: input.runChild ?? defaultRunChild,
+      worktreeFactory: input.worktreeFactory ?? createWorktree
+    };
+  }
+
+  async verify(input: VerifierSpawnInputs): Promise<VerifierRunOutcome> {
+    const startedAt = Date.now();
+
+    // The slot-manager may have already created the worktree, in which
+    // case input.verifierWorktree is honoured as-is and the agent does
+    // NOT create one. This lets the spawner own the lifecycle when it
+    // runs the verifier as a vendored phase, while letting the CLI use
+    // the agent standalone.
+    let wt: WorktreeHandle | null = null;
+    let worktreePath = input.verifierWorktree;
+    let cleanupReason: 'success' | 'exception' | 'timeout' | 'sigterm' = 'success';
+    let worktreeCleanedUp = false;
+
+    try {
+      if (!worktreePath || worktreePath === '') {
+        const jobId = `${input.taskId}-${input.verifierSpawnId}`;
+        wt = this.config.worktreeFactory({
+          repoPath: this.config.repoPath,
+          jobId,
+          commitSha: input.prHeadSha
+        });
+        worktreePath = wt.path;
+      }
+      const promptInput: VerifierSpawnInputs = { ...input, verifierWorktree: worktreePath };
+      const prompt = buildVerifierPrompt(promptInput);
+
+      const env = buildEnvWithoutApiKey();
+      const claudeArgs = [
+        '--print',
+        '--permission-mode',
+        'bypassPermissions',
+        '--output-format',
+        'text'
+      ];
+      const childResult = await this.config.runChild({
+        binary: this.config.claudeBinary,
+        argv: claudeArgs,
+        cwd: worktreePath,
+        prompt,
+        env,
+        timeoutMs: this.config.maxBudgetMs
+      });
+
+      if (childResult.timedOut) cleanupReason = 'timeout';
+      const stdoutTail = childResult.stdout.slice(-2000);
+      const stderrTail = childResult.stderr.slice(-2000);
+      const lastLine = lastJsonLine(childResult.stdout);
+
+      let verdict: VerifierVerdict | null = null;
+      let failureReason: string | null = null;
+
+      if (childResult.timedOut) {
+        failureReason = `verifier timed out after ${this.config.maxBudgetMs}ms`;
+      } else if (childResult.rc !== 0) {
+        failureReason = `verifier rc=${childResult.rc}; stderr-tail=${stderrTail.slice(-500)}`;
+      } else if (lastLine === null) {
+        failureReason = 'verifier produced no parseable JSON last-line';
+      } else {
+        const r = parseAndValidateVerdict(lastLine);
+        if (r.ok && r.verdict) {
+          verdict = r.verdict;
+        } else {
+          failureReason = `verifier verdict failed schema: ${r.errors.join('; ')}`;
+        }
+      }
+
+      // Cleanup runs whether verdict was good or bad — finally branch.
+      if (wt) {
+        await wt.cleanup(cleanupReason);
+        worktreeCleanedUp = wt.cleanedUp();
+      } else {
+        worktreeCleanedUp = true; // caller manages
+      }
+
+      const ok = verdict !== null && verdict.overall === 'pass';
+      return {
+        ok,
+        verdict,
+        rawLastLine: lastLine,
+        stdoutTail,
+        stderrTail,
+        worktreePath,
+        worktreeCleanedUp,
+        cleanupReason,
+        durationMs: Date.now() - startedAt,
+        failureReason
+      };
+    } catch (e) {
+      cleanupReason = 'exception';
+      if (wt) {
+        await wt.cleanup(cleanupReason);
+        worktreeCleanedUp = wt.cleanedUp();
+      }
+      return {
+        ok: false,
+        verdict: null,
+        rawLastLine: null,
+        stdoutTail: '',
+        stderrTail: '',
+        worktreePath,
+        worktreeCleanedUp,
+        cleanupReason,
+        durationMs: Date.now() - startedAt,
+        failureReason: `verifier exception: ${(e as Error).message}`
+      };
+    }
+  }
+}
+
+export interface RunVerifierArgs {
+  inputs: VerifierSpawnInputs;
+  config?: VerifierAgentConfig;
+}
+
+export async function runVerifier(args: RunVerifierArgs): Promise<VerifierRunOutcome> {
+  const agent = new VerifierAgent(args.config);
+  return agent.verify(args.inputs);
+}
+
+/** Map a routing class to the autonomous-loop blocking semantics. */
+export function isBlockingForRouting(rc: RoutingClass): boolean {
+  return rc === 'autonomous-loop';
+}
+
+/** Helper used by tests + the CLI to fabricate a stable jobId. */
+export function deriveJobId(taskId: string, verifierSpawnId: string): string {
+  return mkdtempSync(join(tmpdir(), `${taskId}-${verifierSpawnId}-`))
+    .split('/')
+    .pop() as string;
+}

--- a/packages/verifier/src/cli.ts
+++ b/packages/verifier/src/cli.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * caia-verifier CLI.
+ *
+ * Subcommands:
+ *   verify --input <path>            Run a verifier against a JSON inputs blob.
+ *                                    Inputs file conforms to VerifierSpawnInputs.
+ *   render-prompt --input <path>     Print the prompt the spawn would receive.
+ *   validate-verdict --verdict <p>   Validate a verdict JSON against the schema.
+ *
+ * Subscription-only: never sets ANTHROPIC_API_KEY in the spawn env (the
+ * agent strips any inherited copy before exec'ing claude).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { VerifierAgent } from './agent.js';
+import { buildVerifierPrompt } from './prompt-builder.js';
+import type { VerifierSpawnInputs } from './types.js';
+import { parseAndValidateVerdict } from './verdict-validator.js';
+
+interface ParsedArgs {
+  command: 'verify' | 'render-prompt' | 'validate-verdict' | 'help';
+  inputPath: string | null;
+  verdictPath: string | null;
+  outPath: string | null;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const a: ParsedArgs = {
+    command: 'help',
+    inputPath: null,
+    verdictPath: null,
+    outPath: null
+  };
+  if (argv.length === 0) return a;
+  const cmd = argv[0];
+  if (cmd === 'verify' || cmd === 'render-prompt' || cmd === 'validate-verdict') {
+    a.command = cmd;
+  }
+  for (let i = 1; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    switch (k) {
+      case '--input':
+        a.inputPath = v ?? null;
+        i++;
+        break;
+      case '--verdict':
+        a.verdictPath = v ?? null;
+        i++;
+        break;
+      case '--out':
+        a.outPath = v ?? null;
+        i++;
+        break;
+    }
+  }
+  return a;
+}
+
+function helpText(): string {
+  return [
+    'caia-verifier — VERIFIER spawn (4th review-sibling).',
+    '',
+    'Commands:',
+    '  verify --input <inputs.json> [--out <verdict.json>]',
+    '      Spawns claude --print, captures + validates the verdict.',
+    '  render-prompt --input <inputs.json>',
+    '      Prints the verbatim spawn prompt to stdout.',
+    '  validate-verdict --verdict <verdict.json>',
+    '      Validates a verdict file against the schema; exits non-zero on failure.'
+  ].join('\n');
+}
+
+function loadInputs(path: string): VerifierSpawnInputs {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === 'help' || (args.command !== 'validate-verdict' && !args.inputPath)) {
+    console.log(helpText());
+    process.exit(args.command === 'help' ? 0 : 2);
+  }
+
+  if (args.command === 'render-prompt') {
+    const inputs = loadInputs(args.inputPath as string);
+    process.stdout.write(buildVerifierPrompt(inputs));
+    return;
+  }
+
+  if (args.command === 'validate-verdict') {
+    if (!args.verdictPath) {
+      console.log(helpText());
+      process.exit(2);
+    }
+    const raw = readFileSync(args.verdictPath, 'utf8').trim();
+    const r = parseAndValidateVerdict(raw);
+    if (r.ok) {
+      console.log(`OK — verdict valid (overall=${r.verdict?.overall} verdict=${r.verdict?.verdict})`);
+      process.exit(0);
+    }
+    console.error('FAIL — verdict invalid:');
+    for (const e of r.errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  // verify
+  const inputs = loadInputs(args.inputPath as string);
+  const agent = new VerifierAgent({});
+  const outcome = await agent.verify(inputs);
+  const blob = {
+    ok: outcome.ok,
+    verdict: outcome.verdict,
+    rawLastLine: outcome.rawLastLine,
+    stdoutTail: outcome.stdoutTail,
+    stderrTail: outcome.stderrTail,
+    worktreePath: outcome.worktreePath,
+    worktreeCleanedUp: outcome.worktreeCleanedUp,
+    cleanupReason: outcome.cleanupReason,
+    durationMs: outcome.durationMs,
+    failureReason: outcome.failureReason
+  };
+  const json = JSON.stringify(blob, null, 2);
+  if (args.outPath) {
+    writeFileSync(args.outPath, json);
+  } else {
+    process.stdout.write(json + '\n');
+  }
+  process.exit(outcome.ok ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(`verifier CLI failed: ${(e as Error).message}`);
+  process.exit(2);
+});

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -1,0 +1,29 @@
+/** Public API of @chiefaia/verifier. */
+export { VerifierAgent, runVerifier, isBlockingForRouting } from './agent.js';
+export {
+  buildVerifierPrompt,
+  loadVerdictSchema,
+  loadVerifierTemplate
+} from './prompt-builder.js';
+export {
+  parseAndValidateVerdict,
+  validateVerifierVerdict
+} from './verdict-validator.js';
+export { createWorktree } from './worktree.js';
+export type {
+  AcVerdict,
+  AcVerdictRow,
+  ArchitecturalConstraintViolation,
+  DodStageVerdict,
+  DodStageVerdictRow,
+  FineVerdict,
+  OutOfScopeFile,
+  OverallVerdict,
+  Recommendation,
+  RoutingClass,
+  TestVerdict,
+  TestVerdictRow,
+  VerifierRunOutcome,
+  VerifierSpawnInputs,
+  VerifierVerdict
+} from './types.js';

--- a/packages/verifier/src/prompt-builder.ts
+++ b/packages/verifier/src/prompt-builder.ts
@@ -1,0 +1,99 @@
+/**
+ * Verifier prompt builder.
+ *
+ * Loads templates/verifier_prompt.md and substitutes the {placeholder}
+ * tokens with the spec material the slot-manager hands the verifier
+ * spawn. Pure, stdlib-only; no IO beyond reading the template files.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { VerifierSpawnInputs } from './types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const TEMPLATE_PATH = join(HERE, '..', 'templates', 'verifier_prompt.md');
+const SCHEMA_PATH = join(HERE, '..', 'templates', 'verifier_verdict_schema.json');
+
+const FRONTMATTER_RE = /^---\n[\s\S]*?\n---\n/;
+
+export function loadVerifierTemplate(): string {
+  const raw = readFileSync(TEMPLATE_PATH, 'utf8');
+  return raw.replace(FRONTMATTER_RE, '');
+}
+
+export function loadVerdictSchema(): Record<string, unknown> {
+  const raw = readFileSync(SCHEMA_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function formatAcBlock(items: VerifierSpawnInputs['spec']['acceptanceCriteria']): string {
+  if (!items || items.length === 0) return '  (none — verdict will be fail-spec)';
+  const lines: string[] = [];
+  items.forEach((ac, i) => {
+    const text = typeof ac === 'string' ? ac : (ac.text ?? ac.ac ?? JSON.stringify(ac));
+    lines.push(`  ${i + 1}. ${text}`);
+  });
+  return lines.join('\n');
+}
+
+function formatFileBlock(files: string[]): string {
+  if (!files || files.length === 0) return '  (none — implementor may have legitimately changed nothing)';
+  return files.map((f) => `  - ${f}`).join('\n');
+}
+
+function formatTestsBlock(tests: VerifierSpawnInputs['spec']['testsRequired']): string {
+  if (!tests || tests.length === 0) return '  (none required by spec)';
+  return tests
+    .map((t) => {
+      if (typeof t === 'string') return `  - ${t}`;
+      const name = t.name ?? t.path ?? JSON.stringify(t);
+      const kind = t.kind ?? 'test';
+      return `  - [${kind}] ${name}`;
+    })
+    .join('\n');
+}
+
+function formatBullets(items: string[], emptyText: string): string {
+  if (!items || items.length === 0) return `  ${emptyText}`;
+  return items.map((x) => `  - ${x}`).join('\n');
+}
+
+/** Build the verbatim prompt the spawner hands to `claude --print`. */
+export function buildVerifierPrompt(input: VerifierSpawnInputs): string {
+  const tmpl = loadVerifierTemplate();
+  const schema = loadVerdictSchema();
+
+  const subs: Record<string, string> = {
+    '{verifier_spawn_id}': input.verifierSpawnId,
+    '{implementing_spawn_id}': input.implementingSpawnId,
+    '{node_id}': input.taskId,
+    '{pr_url}': input.prUrl,
+    '{pr_branch}': input.prBranch,
+    '{pr_base_sha}': input.prBaseSha,
+    '{pr_head_sha}': input.prHeadSha,
+    '{verifier_worktree}': input.verifierWorktree,
+    '{routing_class}': input.routingClass,
+    '{blocking}': input.routingClass === 'autonomous-loop' ? 'true' : 'false',
+    '{title}': input.spec.title,
+    '{work_directive}': input.spec.workDirective,
+    '{parent_context}': input.spec.parentContext || '(root)',
+    '{tech_context}': formatBullets(input.spec.techContext, '(no EA tech_context resolved)'),
+    '{architectural_constraints}': formatBullets(input.spec.architecturalConstraints, '(none declared)'),
+    '{dod_required_stages}': formatBullets(input.spec.dodRequiredStages, '(none — falls back to [Implement, Unit-test])'),
+    '{acceptance_criteria_block}': formatAcBlock(input.spec.acceptanceCriteria),
+    '{file_scope_block}': formatFileBlock(input.spec.fileScope),
+    '{tests_required_block}': formatTestsBlock(input.spec.testsRequired),
+    '{tests_filter_expr}': input.spec.testsFilterExpr || '<scope/path glob>',
+    '{implementor_claim_json_pretty}': JSON.stringify(input.implementorClaim, null, 2),
+    '{verdict_schema_block}': JSON.stringify(schema, null, 2)
+  };
+
+  let out = tmpl;
+  for (const [k, v] of Object.entries(subs)) {
+    out = out.split(k).join(v);
+  }
+  return out;
+}

--- a/packages/verifier/src/types.ts
+++ b/packages/verifier/src/types.ts
@@ -1,0 +1,142 @@
+/**
+ * Public types for @chiefaia/verifier.
+ *
+ * The VERIFIER spawn is the fourth review-sibling alongside Critic /
+ * Code-Reviewer / Reviewer. Its domain is acceptance-criteria-satisfaction
+ * (the spec-truth check), distinct from Critic's security/regression/cost,
+ * Code-Reviewer's correctness/style, and Reviewer's craftsmanship.
+ *
+ * Authority: ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md §6.3.
+ */
+
+/** Coarse-grained binary verdict for the SPS done_status_guard trigger. */
+export type OverallVerdict = 'pass' | 'fail';
+
+/** Fine-grained verdict driving slot-manager routing. */
+export type FineVerdict = 'pass' | 'fail-impl' | 'fail-spec' | 'uncertain';
+
+/** Per-AC verdict (positionally aligned with implementor self-cert). */
+export type AcVerdict = 'met' | 'not-met' | 'uncertain';
+
+/** Per-test verdict from the actual test runner output. */
+export type TestVerdict = 'passing' | 'failing' | 'not-run';
+
+/** Per-DoD-stage verdict from the diff. */
+export type DodStageVerdict = 'evidenced' | 'missing-evidence' | 'not-applicable';
+
+export type Recommendation = 'merge' | 're-implement' | 're-decompose' | 'operator-decide';
+
+export type RoutingClass = 'autonomous-loop' | 'operator-routed';
+
+/** Per-AC row in the verdict object. */
+export interface AcVerdictRow {
+  ac: string;
+  verdict: AcVerdict;
+  evidence: string;
+  implementor_self_cert_matches?: boolean;
+}
+
+export interface TestVerdictRow {
+  test: string;
+  verdict: TestVerdict;
+  runner_output_excerpt: string;
+  implementor_self_cert_matches?: boolean;
+}
+
+export interface DodStageVerdictRow {
+  stage: string;
+  verdict: DodStageVerdict;
+  evidence: string;
+}
+
+export interface OutOfScopeFile {
+  path: string;
+  implementor_rationale: string | null;
+}
+
+export interface ArchitecturalConstraintViolation {
+  constraint: string;
+  evidence: string;
+}
+
+/** The full strict-JSON verdict object the verifier emits. */
+export interface VerifierVerdict {
+  schema_version: 'v1';
+  verifier_spawn_id: string;
+  implementing_spawn_id: string;
+  task_id: string;
+  pr_url?: string | null;
+  pr_head_sha?: string | null;
+  overall: OverallVerdict;
+  verdict: FineVerdict;
+  acceptance_criteria_verdicts: AcVerdictRow[];
+  tests_required_verdicts: TestVerdictRow[];
+  tests_run_verdict: boolean;
+  file_scope_verdict: boolean;
+  dod_stages_verdicts: DodStageVerdictRow[];
+  out_of_scope_files_touched: OutOfScopeFile[];
+  architectural_constraint_violations: ArchitecturalConstraintViolation[];
+  recommendation: Recommendation;
+  reasons: string[];
+  blocking: boolean;
+  summary: string;
+  verifier_worktree_cleaned_up?: boolean;
+}
+
+/** Inputs the verifier's prompt builder needs. */
+export interface VerifierSpawnInputs {
+  /** Spawn id assigned by the slot-manager for this verifier. */
+  verifierSpawnId: string;
+  /** Implementing spawn id (the one whose work we're verifying). */
+  implementingSpawnId: string;
+  /** SPS node id (the task being verified). */
+  taskId: string;
+  /** PR URL the implementor opened. */
+  prUrl: string;
+  /** Branch name of the implementor's PR (origin/<branch>). */
+  prBranch: string;
+  /** Base SHA of the PR (the merge-base). */
+  prBaseSha: string;
+  /** Head SHA of the PR — the verifier worktree is checked out at this SHA. */
+  prHeadSha: string;
+  /** Absolute path to the FRESH worktree the spawner created for this verifier. */
+  verifierWorktree: string;
+  /** Routing class — controls the `blocking` field. */
+  routingClass: RoutingClass;
+  /** SPS spec material (UDP-derived). */
+  spec: {
+    title: string;
+    workDirective: string;
+    parentContext: string;
+    techContext: string[];
+    architecturalConstraints: string[];
+    dodRequiredStages: string[];
+    acceptanceCriteria: Array<string | { ac?: string; text?: string }>;
+    fileScope: string[];
+    testsRequired: Array<string | { name?: string; path?: string; kind?: string }>;
+    testsFilterExpr: string;
+  };
+  /** The implementor's strict-JSON DoD self-cert blob (per spawn_output_schema.v2.json). */
+  implementorClaim: Record<string, unknown>;
+}
+
+/** Outcome a runner returns after a complete verifier run (worktree-managed). */
+export interface VerifierRunOutcome {
+  ok: boolean;
+  verdict: VerifierVerdict | null;
+  /** Raw last-line stdout from the spawn (for debugging when verdict=null). */
+  rawLastLine: string | null;
+  /** Stdout/stderr captured (truncated). */
+  stdoutTail: string;
+  stderrTail: string;
+  /** Path of the verifier worktree the runner created/cleaned. */
+  worktreePath: string;
+  /** Cleanup outcome — TRUE iff the worktree was removed (success or failure). */
+  worktreeCleanedUp: boolean;
+  /** Why cleanup ran (success | exception | timeout) — for the cleanup audit. */
+  cleanupReason: 'success' | 'exception' | 'timeout' | 'sigterm';
+  /** Wall-clock elapsed in milliseconds. */
+  durationMs: number;
+  /** Failure reason class for the SPS, if !ok. */
+  failureReason: string | null;
+}

--- a/packages/verifier/src/verdict-validator.ts
+++ b/packages/verifier/src/verdict-validator.ts
@@ -1,0 +1,143 @@
+/**
+ * Verifier verdict validator.
+ *
+ * Hand-rolled JSON-Schema walker (no external dep) that validates the
+ * verifier's strict-JSON output against templates/verifier_verdict_schema.json.
+ * Mirrors the stdlib pattern in @chiefaia/local-llm-router-py-client's
+ * spawn_prompt_loader.py — covers type / enum / const / pattern / required /
+ * additionalProperties / items / minLength / maxLength / minimum / anyOf.
+ */
+
+import { loadVerdictSchema } from './prompt-builder.js';
+import type { VerifierVerdict } from './types.js';
+
+type SchemaNode = Record<string, unknown>;
+
+function walk(value: unknown, schema: SchemaNode, path: string, errors: string[]): void {
+  // anyOf
+  if (Array.isArray(schema.anyOf)) {
+    const branchErrors: string[][] = [];
+    for (const sub of schema.anyOf) {
+      const local: string[] = [];
+      walk(value, sub as SchemaNode, path, local);
+      if (local.length === 0) return;
+      branchErrors.push(local);
+    }
+    errors.push(`${path}: did not match any anyOf branch (${branchErrors.length} attempted)`);
+    return;
+  }
+
+  // const
+  if ('const' in schema) {
+    if (value !== schema.const) {
+      errors.push(`${path}: expected const ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`);
+    }
+    return;
+  }
+
+  // type
+  const t = schema.type as string | string[] | undefined;
+  if (t !== undefined) {
+    const types = Array.isArray(t) ? t : [t];
+    let typeOk = false;
+    for (const ty of types) {
+      if (ty === 'string' && typeof value === 'string') typeOk = true;
+      else if (ty === 'integer' && typeof value === 'number' && Number.isInteger(value)) typeOk = true;
+      else if (ty === 'number' && typeof value === 'number') typeOk = true;
+      else if (ty === 'boolean' && typeof value === 'boolean') typeOk = true;
+      else if (ty === 'object' && value !== null && typeof value === 'object' && !Array.isArray(value)) typeOk = true;
+      else if (ty === 'array' && Array.isArray(value)) typeOk = true;
+      else if (ty === 'null' && value === null) typeOk = true;
+    }
+    if (!typeOk) {
+      errors.push(`${path}: expected type ${JSON.stringify(t)}, got ${typeof value}`);
+      return;
+    }
+  }
+
+  // enum
+  if (Array.isArray(schema.enum)) {
+    if (!schema.enum.includes(value as never)) {
+      errors.push(`${path}: value ${JSON.stringify(value)} not in enum ${JSON.stringify(schema.enum)}`);
+      return;
+    }
+  }
+
+  // string-specific
+  if (typeof value === 'string') {
+    if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+      errors.push(`${path}: string length ${value.length} < minLength ${schema.minLength}`);
+    }
+    if (typeof schema.maxLength === 'number' && value.length > schema.maxLength) {
+      errors.push(`${path}: string length ${value.length} > maxLength ${schema.maxLength}`);
+    }
+    if (typeof schema.pattern === 'string') {
+      const re = new RegExp(schema.pattern);
+      if (!re.test(value)) {
+        errors.push(`${path}: string does not match pattern ${schema.pattern}`);
+      }
+    }
+  }
+
+  // number-specific
+  if (typeof value === 'number') {
+    if (typeof schema.minimum === 'number' && value < schema.minimum) {
+      errors.push(`${path}: number ${value} < minimum ${schema.minimum}`);
+    }
+  }
+
+  // object-specific
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (Array.isArray(schema.required)) {
+      for (const req of schema.required as string[]) {
+        if (!(req in obj)) {
+          errors.push(`${path}: missing required field "${req}"`);
+        }
+      }
+    }
+    const props = (schema.properties as Record<string, SchemaNode> | undefined) ?? {};
+    if (schema.additionalProperties === false) {
+      for (const k of Object.keys(obj)) {
+        if (!(k in props)) {
+          errors.push(`${path}: unexpected field "${k}" (additionalProperties: false)`);
+        }
+      }
+    }
+    for (const [k, subSchema] of Object.entries(props)) {
+      if (k in obj) {
+        walk(obj[k], subSchema, `${path}.${k}`, errors);
+      }
+    }
+  }
+
+  // array-specific
+  if (Array.isArray(value) && schema.items) {
+    for (let i = 0; i < value.length; i++) {
+      walk(value[i], schema.items as SchemaNode, `${path}[${i}]`, errors);
+    }
+  }
+}
+
+export function validateVerifierVerdict(blob: unknown): { ok: boolean; errors: string[] } {
+  const schema = loadVerdictSchema();
+  const errors: string[] = [];
+  walk(blob, schema, '$', errors);
+  return { ok: errors.length === 0, errors };
+}
+
+/** Parse the spawn's last stdout line and validate it against the schema. */
+export function parseAndValidateVerdict(rawLine: string): {
+  ok: boolean;
+  verdict: VerifierVerdict | null;
+  errors: string[];
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawLine);
+  } catch (e) {
+    return { ok: false, verdict: null, errors: [`JSON.parse failed: ${(e as Error).message}`] };
+  }
+  const { ok, errors } = validateVerifierVerdict(parsed);
+  return { ok, verdict: ok ? (parsed as VerifierVerdict) : null, errors };
+}

--- a/packages/verifier/src/worktree.ts
+++ b/packages/verifier/src/worktree.ts
@@ -1,0 +1,113 @@
+/**
+ * Verifier worktree lifecycle.
+ *
+ * Creates a FRESH git worktree at /tmp/verifier_<job_id> checked out at
+ * the implementor's PR head SHA, then cleans up via a try/finally pattern
+ * so cleanup runs on BOTH the success and the failure path. Idempotent:
+ * `git worktree remove --force` is safe on a never-created path; the
+ * filesystem `rm -rf` fallback also tolerates missing dirs.
+ *
+ * Defence-in-depth — the spawn prompt also asks the verifier to set
+ * verdict.verifier_worktree_cleaned_up=true on its own, so we get both an
+ * orchestrator-side cleanup AND a verifier-side self-attestation.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface WorktreeOptions {
+  /** Repo root (cwd to run git from). */
+  repoPath: string;
+  /** Stable id used in the worktree path. Falls back to a tmp suffix when omitted. */
+  jobId?: string;
+  /** SHA to check out into the worktree. REQUIRED. */
+  commitSha: string;
+  /** Optional override for the spawn function (test seam). */
+  spawn?: (cmd: string, args: string[], cwd: string) => SpawnSyncReturns<Buffer>;
+}
+
+export interface WorktreeHandle {
+  path: string;
+  jobId: string;
+  cleanup: (reason: 'success' | 'exception' | 'timeout' | 'sigterm') => Promise<void>;
+  cleanupReason: () => 'success' | 'exception' | 'timeout' | 'sigterm' | null;
+  cleanedUp: () => boolean;
+}
+
+function defaultSpawn(cmd: string, args: string[], cwd: string): SpawnSyncReturns<Buffer> {
+  return spawnSync(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * Create a fresh worktree. Throws on failure (no partial state). The handle
+ * carries an idempotent `cleanup()` callable the orchestrator must invoke in
+ * a try/finally — call patterns:
+ *   const wt = createWorktree({...});
+ *   try { ...do work... ; await wt.cleanup('success'); }
+ *   catch (e) { await wt.cleanup('exception'); throw e; }
+ */
+export function createWorktree(opts: WorktreeOptions): WorktreeHandle {
+  const spawn = opts.spawn ?? defaultSpawn;
+  const jobId =
+    opts.jobId ??
+    mkdtempSync(join(tmpdir(), 'verifier_')).split('verifier_').slice(1).join('verifier_');
+  const wtPath = join(tmpdir(), `verifier_${jobId}`);
+
+  // Ensure stale worktree dir isn't present from a prior run with the same jobId.
+  // git worktree add refuses to overwrite — we explicitly clean first.
+  if (existsSync(wtPath)) {
+    const r = spawn('git', ['worktree', 'remove', '--force', wtPath], opts.repoPath);
+    if (r.status !== 0) {
+      // Not fatal — fs rm below handles it.
+      try {
+        rmSync(wtPath, { recursive: true, force: true });
+      } catch {
+        // ignore — git worktree add will error and we'll surface that
+      }
+    }
+  }
+
+  const r = spawn('git', ['worktree', 'add', '--detach', wtPath, opts.commitSha], opts.repoPath);
+  if (r.status !== 0) {
+    const err = (r.stderr ?? Buffer.from('')).toString();
+    throw new Error(`git worktree add failed (rc=${r.status}): ${err}`);
+  }
+
+  let cleaned = false;
+  let reason: 'success' | 'exception' | 'timeout' | 'sigterm' | null = null;
+
+  const cleanup = async (whyVal: 'success' | 'exception' | 'timeout' | 'sigterm') => {
+    if (cleaned) return; // idempotent
+    cleaned = true;
+    reason = whyVal;
+    // Try git worktree remove first (cleanest — also updates .git/worktrees/).
+    try {
+      spawn('git', ['worktree', 'remove', '--force', wtPath], opts.repoPath);
+    } catch {
+      // fall through to fs rm
+    }
+    // Defence-in-depth filesystem rm.
+    try {
+      await rm(wtPath, { recursive: true, force: true });
+    } catch {
+      // tolerate — the git remove above almost always succeeds
+    }
+    // Prune .git/worktrees in case a stale entry remains.
+    try {
+      spawn('git', ['worktree', 'prune'], opts.repoPath);
+    } catch {
+      // ignore
+    }
+  };
+
+  return {
+    path: wtPath,
+    jobId,
+    cleanup,
+    cleanupReason: () => reason,
+    cleanedUp: () => cleaned
+  };
+}

--- a/packages/verifier/templates/verifier_prompt.md
+++ b/packages/verifier/templates/verifier_prompt.md
@@ -1,0 +1,103 @@
+---
+name: verifier_prompt
+version: v1
+purpose: |
+  VERIFIER spawn prompt — fourth review-sibling alongside Critic /
+  Code-Reviewer / Reviewer. Fresh prompt + fresh worktree, independent of
+  the implementing spawn. Reads the implementor's strict-JSON DoD output
+  (per spawn_output_schema.v2.json from B15.C) and verifies each
+  acceptance-criterion + test + file-scope claim against the actual
+  diff/run, emitting a `pass`/`fail-impl`/`fail-spec`/`uncertain` verdict.
+authority: ~/Documents/projects/agent-memory/reliability_99pct_design_2026-05-11.md §6.3.4
+---
+You are the VERIFIER spawn. Your job: independently decide whether the
+implementing spawn satisfied the spec, by inspecting (a) the implementing
+spawn's PR diff in a FRESH worktree, (b) the spec's tests_required, and
+(c) the spec's acceptance_criteria. You have NO shared state with the
+implementor — you do not trust their self-certification.
+
+YOU MAY NOT WRITE TO THE IMPLEMENTING BRANCH. The worktree you are in
+({verifier_worktree}) is a read-only checkout of the implementor's merged
+commit. Any `git push`, `git commit`, or `git reset --hard` is forbidden;
+your verdict JSON line is the ONLY output the spawner will consume.
+
+CONTEXT
+  verifier_spawn_id      : {verifier_spawn_id}
+  implementing_spawn_id  : {implementing_spawn_id}
+  task_id                : {node_id}
+  pr_url                 : {pr_url}
+  pr_branch              : {pr_branch}
+  pr_base_sha            : {pr_base_sha}
+  pr_head_sha            : {pr_head_sha}
+  verifier_worktree      : {verifier_worktree}
+  routing_class          : {routing_class}     # autonomous-loop | operator-routed
+  blocking               : {blocking}          # true (autonomous) | false (operator-routed)
+
+SPEC (verbatim, from UDP — source of truth, NOT the implementor's claim)
+  Title                    : {title}
+  Directive                : {work_directive}
+  Parent context           : {parent_context}
+  EA tech context          : {tech_context}
+  Architectural constraints: {architectural_constraints}
+  DoD required stages      : {dod_required_stages}
+
+ACCEPTANCE CRITERIA (each must be evaluated to met / not-met / uncertain)
+{acceptance_criteria_block}
+
+FILE SCOPE (the implementor was expected to touch only these)
+{file_scope_block}
+
+TESTS REQUIRED (each must be evaluated to passing / failing / not-run)
+{tests_required_block}
+
+IMPLEMENTOR SELF-CERTIFICATION (per spawn_output_schema.v2.json — DO NOT trust verbatim)
+{implementor_claim_json_pretty}
+
+YOUR PROCESS
+  1. cd into {verifier_worktree} (the spawner already created it via
+     `git worktree add {verifier_worktree} {pr_head_sha}`). Verify with
+     `git rev-parse HEAD` that you are on {pr_head_sha}.
+  2. Inspect the diff via `git log {pr_base_sha}..{pr_head_sha}` and
+     `git diff {pr_base_sha}..{pr_head_sha}`. Compare the changed-file
+     list to FILE SCOPE; flag any path outside scope without
+     extra_files_touched[].rationale in the implementor's claim.
+  3. For EACH acceptance criterion: re-read the relevant files in the
+     diff; decide met / not-met / uncertain; capture an evidence quote
+     (file:line, test name, or diff hunk excerpt) — NOT the implementor's
+     self-cert. Set implementor_self_cert_matches=true iff your verdict
+     matches the implementor's self_status for the same AC.
+  4. For EACH test in TESTS REQUIRED: run it against {pr_head_sha} via
+     `pnpm test:filter {tests_filter_expr}` (or the equivalent command for
+     the test runner). Capture the runner's output excerpt (<= 500 chars).
+     Set implementor_self_cert_matches=true iff your verdict matches the
+     implementor's self_status for the same test.
+  5. For EACH DoD stage in {dod_required_stages}: decide whether the diff
+     materially contributes to that stage. Use evidence from the diff (or
+     test runner output), NOT the implementor's self-cert.
+  6. If the diff touches files outside FILE SCOPE without rationale in
+     implementor_claim_json.extra_files_touched[], add to
+     out_of_scope_files_touched[] with implementor_rationale=null.
+  7. Compute the overall verdict per VERDICT RULES.
+  8. Emit ONE final compact line of JSON conforming to the schema below.
+     The spawner WILL parse it. Malformed/missing JSON => verdict treated
+     as `fail-impl` with reason="malformed-verifier-output".
+
+VERDICT RULES (deterministic; no "we'll be lenient" judgment)
+  - pass: every AC.verdict=met AND every test.verdict=passing AND no
+    architectural constraint violated AND every DoD stage materially-
+    evidenced AND no out-of-scope file without rationale.
+  - fail-impl: at least one AC=not-met OR at least one test=failing OR an
+    architectural constraint is violated OR a forbidden out-of-scope file
+    was touched. Recommendation: re-implement (slot-manager re-dispatches
+    the implementor with verifier_feedback_json injected).
+  - fail-spec: the spec itself appears un-satisfiable or contradictory
+    (e.g. AC requires behaviour that a constraint forbids).
+    Recommendation: re-decompose (route to PO via B14.J).
+  - uncertain: cannot determine met/not-met without infrastructure not
+    available in this worktree (e.g. needs a live DB). On the SECOND
+    attempt the state machine treats uncertain as fail-impl.
+
+OUTPUT (single line, parsed as JSON conforming to schema below)
+{verdict_schema_block}
+
+Begin.

--- a/packages/verifier/templates/verifier_verdict_schema.json
+++ b/packages/verifier/templates/verifier_verdict_schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://caia.chiefaia.dev/schemas/verifier_verdict.v1.json",
+  "title": "Verifier Verdict v1 (B15.D)",
+  "description": "Strict JSON output schema for the VERIFIER spawn (4th review-sibling). The verifier's last stdout line MUST be a JSON object conforming to this schema. The B15.B done_status_guard SQLite trigger checks json_extract(verifier_verdict_json, '$.overall') == 'pass' for every scope-2/3 subtask done-transition; the autonomous-loop done-path also short-circuits to status='failed' when overall='fail-impl' or 'fail-spec'.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "verifier_spawn_id",
+    "implementing_spawn_id",
+    "task_id",
+    "overall",
+    "verdict",
+    "acceptance_criteria_verdicts",
+    "tests_required_verdicts",
+    "tests_run_verdict",
+    "file_scope_verdict",
+    "dod_stages_verdicts",
+    "out_of_scope_files_touched",
+    "architectural_constraint_violations",
+    "recommendation",
+    "reasons",
+    "summary",
+    "blocking",
+    "schema_version"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "v1",
+      "description": "Schema version. Bump on breaking change; spawner / SPS gate on this."
+    },
+    "verifier_spawn_id": { "type": "string", "minLength": 1 },
+    "implementing_spawn_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "pr_url": { "type": ["string", "null"] },
+    "pr_head_sha": { "type": ["string", "null"], "pattern": "^[0-9a-f]{7,40}$|^$" },
+    "overall": {
+      "enum": ["pass", "fail"],
+      "description": "Coarse-grained binary verdict for the SPS done_status_guard trigger. `pass` iff verdict=='pass'; `fail` for fail-impl / fail-spec / uncertain (uncertain second-attempt is also `fail`). The trigger reads json_extract(..., '$.overall')."
+    },
+    "verdict": {
+      "enum": ["pass", "fail-impl", "fail-spec", "uncertain"],
+      "description": "Fine-grained verdict driving slot-manager routing. `fail-impl` => re-dispatch implementor with feedback. `fail-spec` => re-decompose parent. `uncertain` => second-attempt or treat-as-fail-impl."
+    },
+    "acceptance_criteria_verdicts": {
+      "type": "array",
+      "description": "One row per AC in spec; positionally aligned with the implementor's acceptance_criteria_self_cert[] for diff comparison.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ac", "verdict", "evidence"],
+        "properties": {
+          "ac": { "type": "string", "minLength": 1 },
+          "verdict": { "enum": ["met", "not-met", "uncertain"] },
+          "evidence": { "type": "string" },
+          "implementor_self_cert_matches": { "type": "boolean" }
+        }
+      }
+    },
+    "tests_required_verdicts": {
+      "type": "array",
+      "description": "One row per test in spec; verifier RAN each test in the fresh worktree.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["test", "verdict", "runner_output_excerpt"],
+        "properties": {
+          "test": { "type": "string", "minLength": 1 },
+          "verdict": { "enum": ["passing", "failing", "not-run"] },
+          "runner_output_excerpt": { "type": "string", "maxLength": 500 },
+          "implementor_self_cert_matches": { "type": "boolean" }
+        }
+      }
+    },
+    "tests_run_verdict": {
+      "type": "boolean",
+      "description": "Convenience: TRUE iff every entry in tests_required_verdicts[].verdict == 'passing'. The B15.B done_status_guard does NOT read this directly (it gates on $.overall) but the autonomous-loop guard reads it for the 4-way AND."
+    },
+    "file_scope_verdict": {
+      "type": "boolean",
+      "description": "TRUE iff out_of_scope_files_touched[] is empty (i.e. every changed file was inside FILE SCOPE)."
+    },
+    "dod_stages_verdicts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["stage", "verdict", "evidence"],
+        "properties": {
+          "stage": { "type": "string", "minLength": 1 },
+          "verdict": { "enum": ["evidenced", "missing-evidence", "not-applicable"] },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "out_of_scope_files_touched": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path"],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "implementor_rationale": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "architectural_constraint_violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["constraint", "evidence"],
+        "properties": {
+          "constraint": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "recommendation": {
+      "enum": ["merge", "re-implement", "re-decompose", "operator-decide"]
+    },
+    "reasons": {
+      "type": "array",
+      "description": "Free-form list of reason strings the SPS surfaces as the failure error message. Empty when overall=='pass'.",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "blocking": {
+      "type": "boolean",
+      "description": "Mirror of the prompt's `blocking` flag — TRUE for autonomous-loop, FALSE for operator-routed. Lets the SPS know whether to enforce the verdict."
+    },
+    "summary": { "type": "string", "maxLength": 300 },
+    "verifier_worktree_cleaned_up": {
+      "type": "boolean",
+      "description": "Self-attestation that the verifier worktree was removed before exit. The spawner ALSO cleans up via trap as defence-in-depth."
+    }
+  }
+}

--- a/packages/verifier/tests/agent.test.ts
+++ b/packages/verifier/tests/agent.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Vitest tests for @chiefaia/verifier — covers the two scenarios required
+ * by the B15.D phase brief:
+ *   1) POSITIVE — verifier verdict overall='pass' produces ok=true and
+ *      the orchestrator-side worktree cleanup runs on the success path.
+ *   2) NEGATIVE — verifier verdict overall='fail' produces ok=false and
+ *      cleanup STILL runs (proves the try/finally semantics).
+ *
+ * Plus four supporting tests covering schema validation, prompt rendering,
+ * and the wrapper-script cleanup audit trail.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { isBlockingForRouting, runVerifier } from '../src/agent.js';
+import { buildVerifierPrompt, loadVerdictSchema } from '../src/prompt-builder.js';
+import type {
+  VerifierSpawnInputs,
+  VerifierVerdict
+} from '../src/types.js';
+import { parseAndValidateVerdict, validateVerifierVerdict } from '../src/verdict-validator.js';
+
+const FIXTURE_INPUTS: VerifierSpawnInputs = {
+  verifierSpawnId: 'spawn::ver-fixture',
+  implementingSpawnId: 'spawn::imp-fixture',
+  taskId: 'node::test-1',
+  prUrl: 'https://github.com/x/y/pull/42',
+  prBranch: 'feat/fixture',
+  prBaseSha: '0000000000000000000000000000000000000000',
+  prHeadSha: '1111111111111111111111111111111111111111',
+  verifierWorktree: '/tmp/verifier_node--test-1-spawn--ver-fixture',
+  routingClass: 'autonomous-loop',
+  spec: {
+    title: 'fixture: insert MIT SPDX header',
+    workDirective: 'Insert `// SPDX-License-Identifier: MIT` as the first line of packages/foo/src/index.ts.',
+    parentContext: 'foo package licensing rollout',
+    techContext: ['TypeScript ES module package', 'pnpm monorepo'],
+    architecturalConstraints: ['No new runtime deps'],
+    dodRequiredStages: ['Implement', 'Unit-test'],
+    acceptanceCriteria: [
+      'Given the file packages/foo/src/index.ts, When opened, Then the first line MUST be `// SPDX-License-Identifier: MIT`',
+      'Given pnpm test:filter @chiefaia/foo, When run against HEAD, Then it MUST pass'
+    ],
+    fileScope: ['packages/foo/src/index.ts'],
+    testsRequired: [{ kind: 'unit', name: 'packages/foo/tests/index.test.ts' }],
+    testsFilterExpr: '@chiefaia/foo'
+  },
+  implementorClaim: {
+    ok: true,
+    task_id: 'node::test-1',
+    spawn_id: 'spawn::imp-fixture',
+    files_touched: [{ path: 'packages/foo/src/index.ts', additions: 1, deletions: 0 }],
+    commits_made: [{ sha: '1111111', message_subject: 'feat(foo): SPDX header' }],
+    acceptance_criteria_self_cert: [
+      { ac: 'AC1', self_status: 'met', evidence: 'first line of index.ts' },
+      { ac: 'AC2', self_status: 'met', evidence: 'unit test green' }
+    ],
+    tests_required_self_cert: [
+      { test: 'packages/foo/tests/index.test.ts', self_status: 'passing', evidence: '1/1 pass in 12ms' }
+    ],
+    dod_self_cert: [
+      { stage: 'Implement', self_status: 'done', evidence: 'commit 1111111' },
+      { stage: 'Unit-test', self_status: 'done', evidence: 'all green' }
+    ],
+    ready_for_verifier: true,
+    reason_class: null,
+    reason_evidence: '',
+    summary: 'SPDX header added'
+  }
+};
+
+function passingVerdict(input: Pick<VerifierVerdict, 'verifier_spawn_id' | 'implementing_spawn_id' | 'task_id'>): VerifierVerdict {
+  return {
+    schema_version: 'v1',
+    verifier_spawn_id: input.verifier_spawn_id,
+    implementing_spawn_id: input.implementing_spawn_id,
+    task_id: input.task_id,
+    pr_url: 'https://github.com/x/y/pull/42',
+    pr_head_sha: '1111111111111111111111111111111111111111',
+    overall: 'pass',
+    verdict: 'pass',
+    acceptance_criteria_verdicts: [
+      { ac: 'AC1', verdict: 'met', evidence: 'first line of index.ts after diff', implementor_self_cert_matches: true },
+      { ac: 'AC2', verdict: 'met', evidence: 'unit runner output 1/1 pass', implementor_self_cert_matches: true }
+    ],
+    tests_required_verdicts: [
+      { test: 'packages/foo/tests/index.test.ts', verdict: 'passing', runner_output_excerpt: 'PASS  1/1 in 12ms', implementor_self_cert_matches: true }
+    ],
+    tests_run_verdict: true,
+    file_scope_verdict: true,
+    dod_stages_verdicts: [
+      { stage: 'Implement', verdict: 'evidenced', evidence: 'header insert hunk' },
+      { stage: 'Unit-test', verdict: 'evidenced', evidence: 'test green' }
+    ],
+    out_of_scope_files_touched: [],
+    architectural_constraint_violations: [],
+    recommendation: 'merge',
+    reasons: [],
+    blocking: true,
+    summary: 'all ACs met, all tests passing, file scope honoured',
+    verifier_worktree_cleaned_up: true
+  };
+}
+
+function failingVerdict(input: Pick<VerifierVerdict, 'verifier_spawn_id' | 'implementing_spawn_id' | 'task_id'>): VerifierVerdict {
+  return {
+    schema_version: 'v1',
+    verifier_spawn_id: input.verifier_spawn_id,
+    implementing_spawn_id: input.implementing_spawn_id,
+    task_id: input.task_id,
+    pr_url: 'https://github.com/x/y/pull/42',
+    pr_head_sha: '1111111111111111111111111111111111111111',
+    overall: 'fail',
+    verdict: 'fail-impl',
+    acceptance_criteria_verdicts: [
+      { ac: 'AC1', verdict: 'not-met', evidence: 'first line of index.ts is unchanged', implementor_self_cert_matches: false }
+    ],
+    tests_required_verdicts: [
+      { test: 'packages/foo/tests/index.test.ts', verdict: 'failing', runner_output_excerpt: 'FAIL — assertion line 12', implementor_self_cert_matches: false }
+    ],
+    tests_run_verdict: false,
+    file_scope_verdict: true,
+    dod_stages_verdicts: [
+      { stage: 'Implement', verdict: 'missing-evidence', evidence: 'no SPDX hunk in diff' }
+    ],
+    out_of_scope_files_touched: [],
+    architectural_constraint_violations: [],
+    recommendation: 're-implement',
+    reasons: ['AC1 not-met: first line of index.ts is unchanged', 'unit test failing'],
+    blocking: true,
+    summary: 'AC1 not-met; tests failing — re-implement',
+    verifier_worktree_cleaned_up: true
+  };
+}
+
+describe('VerifierAgent — POSITIVE: pass verdict transitions to ok=true', () => {
+  it('captures the verdict, marks ok, and runs cleanup with reason=success', async () => {
+    const cleanupCalls: Array<'success' | 'exception' | 'timeout' | 'sigterm'> = [];
+    const fakeWorktreeFactory = vi.fn().mockImplementation(() => ({
+      path: '/tmp/verifier_TEST-positive',
+      jobId: 'TEST-positive',
+      cleanup: async (reason: 'success' | 'exception' | 'timeout' | 'sigterm') => {
+        cleanupCalls.push(reason);
+      },
+      cleanupReason: () => cleanupCalls[0] ?? null,
+      cleanedUp: () => cleanupCalls.length > 0
+    }));
+    const verdictBlob = passingVerdict({
+      verifier_spawn_id: FIXTURE_INPUTS.verifierSpawnId,
+      implementing_spawn_id: FIXTURE_INPUTS.implementingSpawnId,
+      task_id: FIXTURE_INPUTS.taskId
+    });
+    const fakeRunChild = vi.fn().mockResolvedValue({
+      rc: 0,
+      stdout: 'some intermediate noise\n' + JSON.stringify(verdictBlob) + '\n',
+      stderr: '',
+      timedOut: false
+    });
+
+    const inputsNoWorktree = { ...FIXTURE_INPUTS, verifierWorktree: '' };
+    const out = await runVerifier({
+      inputs: inputsNoWorktree,
+      config: {
+        repoPath: '/tmp/fake-repo',
+        runChild: fakeRunChild,
+        worktreeFactory: fakeWorktreeFactory
+      }
+    });
+    expect(out.ok).toBe(true);
+    expect(out.verdict).not.toBeNull();
+    expect(out.verdict?.overall).toBe('pass');
+    expect(out.verdict?.verdict).toBe('pass');
+    expect(out.failureReason).toBeNull();
+    expect(out.cleanupReason).toBe('success');
+    expect(out.worktreeCleanedUp).toBe(true);
+    expect(cleanupCalls).toEqual(['success']);
+  });
+});
+
+describe('VerifierAgent — NEGATIVE: fail verdict surfaces ok=false but cleanup STILL runs', () => {
+  it('captures the fail verdict and runs cleanup on the failure path', async () => {
+    const cleanupCalls: Array<'success' | 'exception' | 'timeout' | 'sigterm'> = [];
+    const fakeWorktreeFactory = vi.fn().mockImplementation(() => ({
+      path: '/tmp/verifier_TEST-negative',
+      jobId: 'TEST-negative',
+      cleanup: async (reason: 'success' | 'exception' | 'timeout' | 'sigterm') => {
+        cleanupCalls.push(reason);
+      },
+      cleanupReason: () => cleanupCalls[0] ?? null,
+      cleanedUp: () => cleanupCalls.length > 0
+    }));
+    const verdictBlob = failingVerdict({
+      verifier_spawn_id: FIXTURE_INPUTS.verifierSpawnId,
+      implementing_spawn_id: FIXTURE_INPUTS.implementingSpawnId,
+      task_id: FIXTURE_INPUTS.taskId
+    });
+    const fakeRunChild = vi.fn().mockResolvedValue({
+      rc: 0,
+      stdout: JSON.stringify(verdictBlob) + '\n',
+      stderr: '',
+      timedOut: false
+    });
+
+    const inputsNoWorktree = { ...FIXTURE_INPUTS, verifierWorktree: '' };
+    const out = await runVerifier({
+      inputs: inputsNoWorktree,
+      config: {
+        repoPath: '/tmp/fake-repo',
+        runChild: fakeRunChild,
+        worktreeFactory: fakeWorktreeFactory
+      }
+    });
+    expect(out.ok).toBe(false); // overall='fail' => ok=false
+    expect(out.verdict).not.toBeNull();
+    expect(out.verdict?.overall).toBe('fail');
+    expect(out.verdict?.verdict).toBe('fail-impl');
+    expect(out.verdict?.reasons.length).toBeGreaterThan(0);
+    // CRITICAL: cleanup STILL runs on the failure path (try/finally).
+    expect(out.cleanupReason).toBe('success'); // success === non-exception child
+    expect(out.worktreeCleanedUp).toBe(true);
+    expect(cleanupCalls).toEqual(['success']);
+  });
+});
+
+describe('VerifierAgent — exception path also cleans up', () => {
+  it('runs cleanup with reason=exception when the spawn throws', async () => {
+    const cleanupCalls: Array<'success' | 'exception' | 'timeout' | 'sigterm'> = [];
+    const fakeWorktreeFactory = vi.fn().mockImplementation(() => ({
+      path: '/tmp/verifier_TEST-exception',
+      jobId: 'TEST-exception',
+      cleanup: async (reason: 'success' | 'exception' | 'timeout' | 'sigterm') => {
+        cleanupCalls.push(reason);
+      },
+      cleanupReason: () => cleanupCalls[0] ?? null,
+      cleanedUp: () => cleanupCalls.length > 0
+    }));
+    const fakeRunChild = vi.fn().mockRejectedValue(new Error('simulated child crash'));
+
+    const inputsNoWorktree = { ...FIXTURE_INPUTS, verifierWorktree: '' };
+    const out = await runVerifier({
+      inputs: inputsNoWorktree,
+      config: {
+        repoPath: '/tmp/fake-repo',
+        runChild: fakeRunChild,
+        worktreeFactory: fakeWorktreeFactory
+      }
+    });
+    expect(out.ok).toBe(false);
+    expect(out.cleanupReason).toBe('exception');
+    expect(out.worktreeCleanedUp).toBe(true);
+    expect(cleanupCalls).toEqual(['exception']);
+    expect(out.failureReason).toContain('simulated child crash');
+  });
+});
+
+describe('verdict schema validation', () => {
+  it('accepts a well-formed pass verdict', () => {
+    const v = passingVerdict({ verifier_spawn_id: 'a', implementing_spawn_id: 'b', task_id: 'c' });
+    const r = validateVerifierVerdict(v);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+  it('rejects a verdict missing schema_version', () => {
+    const v = passingVerdict({ verifier_spawn_id: 'a', implementing_spawn_id: 'b', task_id: 'c' });
+    const broken = { ...v };
+    delete (broken as Partial<VerifierVerdict>).schema_version;
+    const r = validateVerifierVerdict(broken);
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toContain('schema_version');
+  });
+  it('rejects a verdict with bad overall enum value', () => {
+    const v = passingVerdict({ verifier_spawn_id: 'a', implementing_spawn_id: 'b', task_id: 'c' });
+    const broken = { ...v, overall: 'nope' as 'pass' };
+    const r = validateVerifierVerdict(broken);
+    expect(r.ok).toBe(false);
+    expect(r.errors.join('\n')).toContain('overall');
+  });
+  it('rejects malformed JSON last-line', () => {
+    const r = parseAndValidateVerdict('this is not JSON');
+    expect(r.ok).toBe(false);
+    expect(r.verdict).toBeNull();
+    expect(r.errors[0]).toContain('JSON.parse');
+  });
+});
+
+describe('prompt rendering', () => {
+  it('renders the spawn prompt with all fixture placeholders substituted', () => {
+    const prompt = buildVerifierPrompt(FIXTURE_INPUTS);
+    expect(prompt).toContain('You are the VERIFIER spawn.');
+    expect(prompt).toContain(FIXTURE_INPUTS.verifierSpawnId);
+    expect(prompt).toContain(FIXTURE_INPUTS.implementingSpawnId);
+    expect(prompt).toContain(FIXTURE_INPUTS.taskId);
+    expect(prompt).toContain(FIXTURE_INPUTS.prUrl);
+    expect(prompt).toContain(FIXTURE_INPUTS.prBaseSha);
+    expect(prompt).toContain(FIXTURE_INPUTS.prHeadSha);
+    expect(prompt).toContain(FIXTURE_INPUTS.verifierWorktree);
+    expect(prompt).toContain('routing_class          : autonomous-loop');
+    expect(prompt).toContain('blocking               : true');
+    // Both ACs from the fixture appear with positional numbering.
+    expect(prompt).toContain('1. Given the file packages/foo/src/index.ts');
+    expect(prompt).toContain('2. Given pnpm test:filter');
+    // The implementor's self-cert appears verbatim in the prompt.
+    expect(prompt).toContain('"task_id": "node::test-1"');
+    // The schema appears verbatim too.
+    expect(prompt).toContain('verifier_verdict.v1.json');
+  });
+
+  it('flips blocking flag to false for operator-routed', () => {
+    const inputs = { ...FIXTURE_INPUTS, routingClass: 'operator-routed' as const };
+    const prompt = buildVerifierPrompt(inputs);
+    expect(prompt).toContain('routing_class          : operator-routed');
+    expect(prompt).toContain('blocking               : false');
+  });
+});
+
+describe('isBlockingForRouting', () => {
+  it('returns true for autonomous-loop, false for operator-routed', () => {
+    expect(isBlockingForRouting('autonomous-loop')).toBe(true);
+    expect(isBlockingForRouting('operator-routed')).toBe(false);
+  });
+});
+
+describe('schema is well-formed', () => {
+  it('loadVerdictSchema returns a valid JSON Schema object', () => {
+    const s = loadVerdictSchema();
+    expect(s.$schema).toContain('json-schema.org');
+    expect(s.title).toContain('Verifier Verdict');
+    expect((s.required as string[]).includes('overall')).toBe(true);
+    expect((s.required as string[]).includes('blocking')).toBe(true);
+  });
+});

--- a/packages/verifier/tsconfig.build.json
+++ b/packages/verifier/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/verifier/tsconfig.json
+++ b/packages/verifier/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/verifier/vitest.config.ts
+++ b/packages/verifier/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules', 'src/cli.ts']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2182,6 +2182,21 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/verifier:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      '@vitest/coverage-v8':
+        specifier: 1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.39)(jsdom@26.1.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   templates/site-pokerzeno:
     dependencies:
       next:

--- a/scripts/review-siblings/dispatch.sh
+++ b/scripts/review-siblings/dispatch.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/review-siblings/dispatch.sh
+# =============================================================================
+# Common review-sibling dispatcher. Spawns the four review-siblings in
+# PARALLEL (they're independent — see DESIGN below) and aggregates verdicts:
+#
+#   * @chiefaia/critic         — security/regression/cost     (BLOCKING)
+#   * @chiefaia/code-reviewer  — correctness/style/types/tests (BLOCKING)
+#   * @chiefaia/reviewer       — craftsmanship                 (ADVISORY)
+#   * @chiefaia/verifier       — acceptance-criteria-satisfaction
+#                                (BLOCKING for autonomous-loop,
+#                                 ADVISORY for operator-routed)
+#
+# The dispatcher is the canonical entry point for both:
+#   (a) the autonomous-loop spawner (vendored from caia and called via
+#       claude_spawner_agent.py's review-sibling-dispatch hook); and
+#   (b) the per-PR GitHub Actions workflows (each sibling already has its
+#       own workflow; this script is the local-dev / autonomous-loop entry
+#       so the four siblings can run as a single cohesive batch).
+#
+# DESIGN — independence:
+#   Each sibling reads the diff and emits a verdict; none modifies state
+#   the others depend on. They ARE allowed to share the diff file (read-
+#   only) but each operates in its own pid + cwd. The verifier additionally
+#   creates its own /tmp/verifier_* worktree. This makes parallel dispatch
+#   safe and ~Nx faster than serial.
+#
+# Exit codes:
+#   0   all blocking siblings PASS (advisory siblings can FAIL or PASS;
+#       --routing-class autonomous-loop also requires verifier=pass).
+#   1   at least one blocking sibling FAIL.
+#   2   transport / setup error (couldn't find diff file, bad arg, ...).
+#
+# Usage:
+#   scripts/review-siblings/dispatch.sh \
+#     --pr <number> \
+#     --diff-file /tmp/pr.diff \
+#     --base-branch develop \
+#     --branch <head-branch> \
+#     --title "PR title" \
+#     --routing-class {autonomous-loop|operator-routed} \
+#     [--verifier-inputs /path/to/inputs.json]   # required when routing-class!=skip
+#     [--out-dir /tmp/sibling-verdicts]          # default: $PWD/.review-siblings
+# =============================================================================
+set -uo pipefail
+
+PR=""
+DIFF_FILE=""
+BASE_BRANCH="develop"
+BRANCH="unknown"
+TITLE=""
+ROUTING_CLASS="autonomous-loop"
+VERIFIER_INPUTS=""
+OUT_DIR="${PWD}/.review-siblings"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)              PR="$2"; shift 2 ;;
+    --diff-file)       DIFF_FILE="$2"; shift 2 ;;
+    --base-branch)     BASE_BRANCH="$2"; shift 2 ;;
+    --branch)          BRANCH="$2"; shift 2 ;;
+    --title)           TITLE="$2"; shift 2 ;;
+    --routing-class)   ROUTING_CLASS="$2"; shift 2 ;;
+    --verifier-inputs) VERIFIER_INPUTS="$2"; shift 2 ;;
+    --out-dir)         OUT_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    *)
+      echo "dispatch: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PR" ]] || [[ -z "$DIFF_FILE" ]] || [[ ! -f "$DIFF_FILE" ]]; then
+  echo "dispatch: --pr <n> and --diff-file <existing path> are required" >&2
+  exit 2
+fi
+if [[ "$ROUTING_CLASS" != "autonomous-loop" && "$ROUTING_CLASS" != "operator-routed" ]]; then
+  echo "dispatch: --routing-class must be one of {autonomous-loop, operator-routed}" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+# subscription-only — strip API key once at top so all siblings inherit clean env
+unset ANTHROPIC_API_KEY
+
+# -------------------------------------------------------------------------
+# Spawn each sibling in parallel. Each writes its verdict JSON to OUT_DIR.
+# We capture the pid + exit-code via wait so we can map FAIL->blocking.
+# -------------------------------------------------------------------------
+
+PIDS=()
+NAMES=()
+
+run_sibling() {
+  local name="$1" cmd="$2"
+  ( eval "$cmd" >"$OUT_DIR/${name}.stdout" 2>"$OUT_DIR/${name}.stderr"; echo "$?" >"$OUT_DIR/${name}.rc" ) &
+  PIDS+=("$!")
+  NAMES+=("$name")
+}
+
+# The blocking siblings — share the same diff file.
+run_sibling critic \
+  "node $REPO_ROOT/packages/critic/dist/cli.js review --pr '$PR' --diff-file '$DIFF_FILE' --output json --base-branch '$BASE_BRANCH' --branch '$BRANCH' --title '$TITLE'"
+
+run_sibling code-reviewer \
+  "node $REPO_ROOT/packages/code-reviewer/dist/cli.js review --pr '$PR' --diff-file '$DIFF_FILE' --output json --base-branch '$BASE_BRANCH' --branch '$BRANCH' --title '$TITLE'"
+
+# Advisory sibling — never blocks, but its verdict is logged.
+run_sibling reviewer \
+  "node $REPO_ROOT/packages/reviewer/dist/cli.js review --pr '$PR' --diff-file '$DIFF_FILE' --output json --base-branch '$BASE_BRANCH' --branch '$BRANCH' --title '$TITLE' || true"
+
+# Verifier — only meaningful when verifier inputs JSON is provided. Skipped
+# when --verifier-inputs is omitted (e.g. PRs that aren't tied to an SPS
+# task; those routes get verdicts from the other three siblings only).
+if [[ -n "$VERIFIER_INPUTS" ]] && [[ -f "$VERIFIER_INPUTS" ]]; then
+  run_sibling verifier \
+    "$REPO_ROOT/packages/verifier/bin/run-verifier.sh --inputs '$VERIFIER_INPUTS' --out '$OUT_DIR/verifier.verdict.json' --repo '$REPO_ROOT'"
+else
+  echo "dispatch: --verifier-inputs not provided; skipping verifier (routing=$ROUTING_CLASS)"
+fi
+
+# Wait for every spawned child.
+for pid in "${PIDS[@]}"; do
+  wait "$pid" || true   # rc captured to file, not via $?
+done
+
+# -------------------------------------------------------------------------
+# Aggregate verdicts. Blocking semantics:
+#   - critic / code-reviewer FAIL  => blocking fail
+#   - verifier overall=fail AND routing=autonomous-loop => blocking fail
+#   - verifier overall=fail AND routing=operator-routed => advisory only
+#   - reviewer is always advisory
+# -------------------------------------------------------------------------
+
+BLOCKING_FAILED=0
+SUMMARY=""
+
+for name in "${NAMES[@]}"; do
+  rc_file="$OUT_DIR/${name}.rc"
+  rc=$(cat "$rc_file" 2>/dev/null || echo "??")
+  case "$name" in
+    critic|code-reviewer)
+      if [[ "$rc" != "0" ]]; then
+        BLOCKING_FAILED=1
+        SUMMARY+="  - $name: BLOCKING-FAIL (rc=$rc)\n"
+      else
+        SUMMARY+="  - $name: PASS\n"
+      fi
+      ;;
+    reviewer)
+      if [[ "$rc" != "0" ]]; then
+        SUMMARY+="  - $name: ADVISORY-FAIL (rc=$rc; non-blocking)\n"
+      else
+        SUMMARY+="  - $name: ADVISORY-PASS\n"
+      fi
+      ;;
+    verifier)
+      if [[ "$rc" == "0" ]]; then
+        SUMMARY+="  - $name: PASS\n"
+      else
+        if [[ "$ROUTING_CLASS" == "autonomous-loop" ]]; then
+          BLOCKING_FAILED=1
+          SUMMARY+="  - $name: BLOCKING-FAIL (rc=$rc; routing=autonomous-loop)\n"
+        else
+          SUMMARY+="  - $name: ADVISORY-FAIL (rc=$rc; routing=operator-routed)\n"
+        fi
+      fi
+      ;;
+  esac
+done
+
+echo "review-siblings dispatch summary (PR=$PR, routing=$ROUTING_CLASS):"
+printf "%b" "$SUMMARY"
+echo "verdict files in: $OUT_DIR"
+
+exit "$BLOCKING_FAILED"


### PR DESCRIPTION
## Summary

This PR bundles three A.3 reliability commits (rebased onto current develop):

1. **b15.c** — feat(spawner): v2 spawn template + strict-JSON output schema. Replaces v1 title-as-directive prompt with explicit `acceptance_criteria`, `file_scope`, `tests_required`, `dod_required_stages`. Adds `spawn_prompt_loader.py` and validates output against `spawn_output_schema.v2.json`. `SPAWN_PROMPT_VERSION=v2` by default; flip to `v1` for emergency rollback.

2. **b15.d** — feat(verifier): @chiefaia/verifier — fourth review-sibling alongside Critic / Code-Reviewer / Reviewer. Domain: **acceptance-criteria-satisfaction**. Runs in a fresh `/tmp/verifier_<job_id>` worktree at the implementor PR head SHA. Two-layer worktree cleanup (try/finally + bash trap). DB: new `verifier_verdicts` table; `done_status_guard` requires `overall=pass` for every autonomous-loop done event.

3. **b15.e** — feat(sps): hourly audit cron + `reliability_rolling` table + INBOX alerts + auto-redo. Adds `infra/stolution/sps/scripts/audit_recent_done.py`, `2026-05-13_b15e_reliability_rolling.sql`, hourly plist, test fixture.

## Why bundled

Operator true-zero cleanup mandate 2026-05-13 — drained 9 stolution PRs + caia #423 (which incorrectly targeted main). The b15.e branch had no PR yet but contained real audit-cron work; folded into #424 to land under the "no new PR" rule. b15.m db-triggers commit was skipped on rebase (already merged on develop).

## Verification

- Clean rebase on `origin/develop` (no manual conflict resolution needed)
- 37 files changed, +4947 / -3
- Three commits preserved with original messages

Operator true-zero cleanup 2026-05-13.