### PR TITLE
feat(chain-runner): permanent fix for orchestrator cron stall (RCA 2026-05-13)

### DIFF
--- a/packages/chain-runner/src/bootstrap.ts
+++ b/packages/chain-runner/src/bootstrap.ts
@@ -1,0 +1,155 @@
+// Bootstrap-time safeguards for the chain runner.
+//
+// Two related concerns live here:
+//   1. retryWithBackoff — wraps the MCP create_scheduled_task call (or any
+//      flaky external call) with exponential backoff so a transient MCP
+//      hiccup during bootstrap doesn't leave the chain with a SKILL.md on
+//      disk but no cron registered. Default schedule: 5s, 15s, 45s.
+//   2. verifyBootstrap — polls audit.jsonl for a 'wake' event within
+//      maxWaitMs; the bootstrap is not declared complete until at least one
+//      wake fire has been observed. This catches the disk-vs-registry
+//      asymmetry that produced the 2026-05-13 T2.5 cron stall (see RCA).
+//
+// Both helpers are pure-function-friendly: time / sleep / fs reads are
+// injectable so the unit tests run deterministically without real waits.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { isoNow } from './time.js';
+import type { StateContext } from './state.js';
+
+export interface RetryOptions {
+  /** Per-attempt delays in milliseconds. Default [5_000, 15_000, 45_000]. */
+  backoffMs?: number[];
+  /** Maximum attempts (incl. the first try). Default backoffMs.length + 1 = 4. */
+  maxAttempts?: number;
+  /** Called after a failure, before the sleep. */
+  onRetry?: (attempt: number, err: unknown, delayMs: number) => void;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export const DEFAULT_BACKOFF_MS: readonly number[] = [5_000, 15_000, 45_000];
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T> | T,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const backoff = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const maxAttempts = opts.maxAttempts ?? backoff.length + 1;
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt >= maxAttempts) break;
+      const idx = Math.min(attempt - 1, backoff.length - 1);
+      const delayMs = backoff[idx] ?? 1000;
+      opts.onRetry?.(attempt, err, delayMs);
+      await sleep(delayMs);
+    }
+  }
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error(`retryWithBackoff exhausted: ${String(lastErr)}`);
+}
+
+export interface PreflightOptions {
+  /** Total time to wait for a wake observation, in milliseconds. */
+  maxWaitMs: number;
+  /** How often to poll audit.jsonl. Default 5s. */
+  pollIntervalMs?: number;
+  /** Only count wake events at or after this time. Default: now. */
+  since?: Date;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable clock for tests. */
+  now?: () => Date;
+}
+
+export interface PreflightResult {
+  ok: boolean;
+  observedWakeAt: string | null;
+  waitedMs: number;
+}
+
+/**
+ * Scan audit.jsonl for the first 'wake' event at-or-after `since`.
+ * Returns null if no qualifying entry is found yet.
+ */
+export function findWakeAfter(ctx: StateContext, since: Date): string | null {
+  if (!existsSync(ctx.paths.auditFile)) return null;
+  const raw = readFileSync(ctx.paths.auditFile, 'utf8').trimEnd();
+  if (!raw) return null;
+  const sinceMs = since.getTime();
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    let ev: { ts?: string; event?: string };
+    try {
+      ev = JSON.parse(line) as { ts?: string; event?: string };
+    } catch {
+      continue;
+    }
+    if (!ev.ts || !ev.event) continue;
+    if (ev.event !== 'wake' && ev.event !== 'wake_observed') continue;
+    const ts = Date.parse(ev.ts);
+    if (Number.isNaN(ts)) continue;
+    if (ts >= sinceMs) return ev.ts;
+  }
+  return null;
+}
+
+/**
+ * Block until either (a) a wake event newer than `since` lands in
+ * audit.jsonl, or (b) `maxWaitMs` elapses. Returns ok=true on success,
+ * ok=false on timeout — the caller is expected to fail the bootstrap.
+ */
+export async function verifyBootstrap(
+  ctx: StateContext,
+  opts: PreflightOptions,
+): Promise<PreflightResult> {
+  const pollMs = opts.pollIntervalMs ?? 5_000;
+  const since = opts.since ?? new Date();
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = opts.now ?? (() => new Date());
+  const startMs = now().getTime();
+  // One immediate check before sleeping (in case a wake already landed).
+  let observed = findWakeAfter(ctx, since);
+  if (observed) {
+    return { ok: true, observedWakeAt: observed, waitedMs: 0 };
+  }
+  while (now().getTime() - startMs < opts.maxWaitMs) {
+    await sleep(pollMs);
+    observed = findWakeAfter(ctx, since);
+    if (observed) {
+      return {
+        ok: true,
+        observedWakeAt: observed,
+        waitedMs: now().getTime() - startMs,
+      };
+    }
+  }
+  return { ok: false, observedWakeAt: null, waitedMs: opts.maxWaitMs };
+}
+
+export function preflightSummary(r: PreflightResult): string {
+  if (r.ok) {
+    return `PREFLIGHT_OK wake_at=${r.observedWakeAt} waited_ms=${r.waitedMs}`;
+  }
+  return `PREFLIGHT_TIMEOUT waited_ms=${r.waitedMs} no_wake_event`;
+}
+
+// Re-exported for callers that want a stamped marker in the audit log.
+export const PREFLIGHT_EVENT = 'preflight_verified';
+
+export function preflightAuditDetails(r: PreflightResult): Record<string, unknown> {
+  return {
+    ok: r.ok,
+    observed_wake_at: r.observedWakeAt,
+    waited_ms: r.waitedMs,
+    stamped_at: isoNow(),
+  };
+}

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -25,6 +25,20 @@ import {
 } from './lock.js';
 import { dispatchPhase } from './runner.js';
 import { findPhase } from './spec.js';
+import {
+  DEFAULT_BACKOFF_MS,
+  preflightAuditDetails,
+  preflightSummary,
+  retryWithBackoff,
+  verifyBootstrap,
+} from './bootstrap.js';
+import {
+  attemptReRegister,
+  detectStall,
+  recordStallDetected,
+} from './watchdog.js';
+import { appendAudit } from './audit.js';
+import { spawnSync } from 'node:child_process';
 
 interface BaseOptions {
   chainId: string;
@@ -294,6 +308,167 @@ export function buildProgram(): Command {
         process.stdout.write(`${line}\n`);
       }
     });
+
+  attachCommonOptions(program.command('verify-bootstrap'))
+    .description(
+      'Block until a wake event lands in audit.jsonl or timeout. Use after registering a scheduled task to prove cron is firing.',
+    )
+    .option(
+      '--wake-interval-sec <n>',
+      'configured wake interval (seconds)',
+      '900',
+    )
+    .option(
+      '--max-wait-sec <n>',
+      'total wait timeout (seconds); default 2 * wake-interval-sec',
+    )
+    .option(
+      '--poll-interval-sec <n>',
+      'how often to poll audit.jsonl (seconds)',
+      '10',
+    )
+    .action(
+      async (
+        cmdOpts: {
+          wakeIntervalSec?: string;
+          maxWaitSec?: string;
+          pollIntervalSec?: string;
+        },
+        cmd: Command,
+      ) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions & typeof cmdOpts;
+        const ctx = ctxFromOpts(opts);
+        const wakeInterval = Number(cmdOpts.wakeIntervalSec ?? '900');
+        const maxWait = Number(cmdOpts.maxWaitSec ?? String(wakeInterval * 2));
+        const pollInterval = Number(cmdOpts.pollIntervalSec ?? '10');
+        const since = new Date();
+        const result = await verifyBootstrap(ctx, {
+          maxWaitMs: maxWait * 1000,
+          pollIntervalMs: pollInterval * 1000,
+          since,
+        });
+        appendAudit(ctx.paths.auditFile, 'preflight_verified', preflightAuditDetails(result));
+        process.stdout.write(`${preflightSummary(result)}\n`);
+        if (!result.ok) process.exit(3);
+      },
+    );
+
+  attachCommonOptions(program.command('check-stall'))
+    .description(
+      'Self-healing watchdog: detect cron stall and (optionally) re-register the scheduled task.',
+    )
+    .option(
+      '--wake-interval-sec <n>',
+      'configured wake interval (seconds)',
+      '900',
+    )
+    .option('--multiplier <n>', 'stall threshold = multiplier * wake-interval', '2')
+    .option('--inbox <path>', 'path to INBOX.md to append alert')
+    .option('--reregister-cmd <cmd>', 'shell command to re-register the scheduled task on stall')
+    .option('--no-alert', 'suppress INBOX append even when --inbox is given')
+    .action(
+      (
+        cmdOpts: {
+          wakeIntervalSec?: string;
+          multiplier?: string;
+          inbox?: string;
+          reregisterCmd?: string;
+          alert?: boolean;
+        },
+        cmd: Command,
+      ) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions & typeof cmdOpts;
+        const ctx = ctxFromOpts(opts);
+        const state = loadState(ctx);
+        const result = detectStall(state, {
+          wakeIntervalSec: Number(cmdOpts.wakeIntervalSec ?? '900'),
+          multiplier: Number(cmdOpts.multiplier ?? '2'),
+        });
+        if (!result.stalled) {
+          process.stdout.write(
+            `HEALTHY age_sec=${Math.floor(result.ageSec)} threshold_sec=${result.thresholdSec}\n`,
+          );
+          return;
+        }
+        const inboxPath =
+          cmdOpts.alert === false ? undefined : cmdOpts.inbox;
+        recordStallDetected(ctx, result, {
+          ...(inboxPath ? { inboxPath } : {}),
+          chainId: opts.chainId,
+        });
+        let reregOutput = '';
+        if (cmdOpts.reregisterCmd) {
+          const reReg = attemptReRegister(
+            { command: '/bin/sh', args: ['-c', cmdOpts.reregisterCmd] },
+            ctx,
+          );
+          reregOutput = ` reregister_attempted=${reReg.attempted} reregister_ok=${reReg.ok}`;
+        }
+        process.stdout.write(
+          `STALL_DETECTED age_sec=${Math.floor(result.ageSec)} threshold_sec=${result.thresholdSec} reason=${result.reason}${reregOutput}\n`,
+        );
+        process.exit(4);
+      },
+    );
+
+  program
+    .command('retry-cmd')
+    .description(
+      'Run a shell command with exponential backoff (default 5s, 15s, 45s). Exit code 0 on success, last failure code otherwise.',
+    )
+    .option(
+      '--backoff-ms <csv>',
+      'comma-separated delays in ms (default 5000,15000,45000)',
+    )
+    .option('--max-attempts <n>', 'override max attempts')
+    .argument('<command...>')
+    .action(
+      async (
+        command: string[],
+        cmdOpts: { backoffMs?: string; maxAttempts?: string },
+      ) => {
+        if (command.length === 0) fail('retry-cmd requires a command');
+        const backoff = cmdOpts.backoffMs
+          ? cmdOpts.backoffMs.split(',').map((s) => Number(s.trim()))
+          : Array.from(DEFAULT_BACKOFF_MS);
+        const maxAttempts = cmdOpts.maxAttempts
+          ? Number(cmdOpts.maxAttempts)
+          : undefined;
+        let lastCode: number | null = null;
+        let lastStderr = '';
+        try {
+          await retryWithBackoff(
+            () => {
+              const out = spawnSync(command[0]!, command.slice(1), {
+                stdio: ['ignore', 'inherit', 'pipe'],
+              });
+              lastCode = out.status;
+              lastStderr = out.stderr ? out.stderr.toString('utf8') : '';
+              if (out.status !== 0) {
+                throw new Error(
+                  `exit=${out.status} cmd=${command.join(' ').slice(0, 200)}`,
+                );
+              }
+              return out.status;
+            },
+            {
+              backoffMs: backoff,
+              ...(maxAttempts !== undefined ? { maxAttempts } : {}),
+              onRetry: (attempt, err, delayMs) => {
+                process.stderr.write(
+                  `retry-cmd attempt ${attempt} failed (${(err as Error).message}); sleeping ${delayMs}ms\n`,
+                );
+              },
+            },
+          );
+          process.stdout.write('RETRY_OK\n');
+        } catch (err) {
+          if (lastStderr) process.stderr.write(lastStderr);
+          process.stderr.write(`RETRY_EXHAUSTED ${(err as Error).message}\n`);
+          process.exit(lastCode ?? 5);
+        }
+      },
+    );
 
   // Provide a save passthrough (used by some tests)
   attachCommonOptions(program.command('save-state-from-stdin'))

--- a/packages/chain-runner/src/index.ts
+++ b/packages/chain-runner/src/index.ts
@@ -7,3 +7,5 @@ export * from './state.js';
 export * from './lock.js';
 export * from './runner.js';
 export * from './time.js';
+export * from './bootstrap.js';
+export * from './watchdog.js';

--- a/packages/chain-runner/src/watchdog.ts
+++ b/packages/chain-runner/src/watchdog.ts
@@ -1,0 +1,174 @@
+// Self-healing watchdog for the chain runner.
+//
+// Every wake, the orchestrator calls `caia-chain check-stall --wake-interval-sec N`.
+// If `last_wake` has not advanced within `multiplier * wakeIntervalSec` (default
+// 2× the configured wake interval), the runner:
+//   1. logs a `cron_stall_detected` audit event,
+//   2. appends an alert to INBOX.md (if provided),
+//   3. optionally invokes a re-register hook (the bootstrap script /
+//      SKILL.md re-issues create_scheduled_task).
+//
+// This is the second of four safeguards against the RCA failure mode
+// where SKILL.md is on disk but no cron is firing.
+
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { appendAudit } from './audit.js';
+import { isoNow } from './time.js';
+import type { StateContext } from './state.js';
+import type { StateFile } from './types.js';
+
+export interface StallCheckOptions {
+  /** Configured wake-interval in seconds (e.g. 900 for a 15-minute cron). */
+  wakeIntervalSec: number;
+  /** Multiplier on top of wakeIntervalSec before declaring a stall. Default 2. */
+  multiplier?: number;
+  /** Injectable clock for tests. */
+  now?: () => Date;
+}
+
+export interface StallCheckResult {
+  stalled: boolean;
+  lastWake: string | null;
+  /** Seconds since last_wake (or since started_at if last_wake is null). */
+  ageSec: number;
+  /** Threshold the age was compared against. */
+  thresholdSec: number;
+  /** Reason classification for the audit event. */
+  reason: 'never_waked' | 'wake_overdue' | 'healthy';
+}
+
+export function detectStall(state: StateFile, opts: StallCheckOptions): StallCheckResult {
+  if (!Number.isFinite(opts.wakeIntervalSec) || opts.wakeIntervalSec <= 0) {
+    throw new Error(`detectStall: wakeIntervalSec must be > 0, got ${opts.wakeIntervalSec}`);
+  }
+  const multiplier = opts.multiplier ?? 2;
+  const thresholdSec = opts.wakeIntervalSec * multiplier;
+  const now = (opts.now ?? (() => new Date()))();
+  if (!state.last_wake) {
+    const startedMs = Date.parse(state.started_at);
+    const ageSec = Number.isFinite(startedMs)
+      ? (now.getTime() - startedMs) / 1000
+      : 0;
+    const stalled = ageSec > thresholdSec;
+    return {
+      stalled,
+      lastWake: null,
+      ageSec,
+      thresholdSec,
+      reason: stalled ? 'never_waked' : 'healthy',
+    };
+  }
+  const lastMs = Date.parse(state.last_wake);
+  const ageSec = (now.getTime() - lastMs) / 1000;
+  const stalled = ageSec > thresholdSec;
+  return {
+    stalled,
+    lastWake: state.last_wake,
+    ageSec,
+    thresholdSec,
+    reason: stalled ? 'wake_overdue' : 'healthy',
+  };
+}
+
+export interface RecordStallOptions {
+  /** Path to INBOX.md to append a human-readable alert. Optional. */
+  inboxPath?: string;
+  /** Chain id, used in the INBOX message for operator clarity. */
+  chainId?: string;
+}
+
+export function recordStallDetected(
+  ctx: StateContext,
+  result: StallCheckResult,
+  opts: RecordStallOptions = {},
+): void {
+  appendAudit(ctx.paths.auditFile, 'cron_stall_detected', {
+    last_wake: result.lastWake,
+    age_sec: Math.floor(result.ageSec),
+    threshold_sec: result.thresholdSec,
+    reason: result.reason,
+  });
+  if (opts.inboxPath) {
+    appendInboxAlert(opts.inboxPath, ctx, result, opts.chainId);
+  }
+}
+
+function appendInboxAlert(
+  inboxPath: string,
+  ctx: StateContext,
+  result: StallCheckResult,
+  chainId?: string,
+): void {
+  mkdirSync(dirname(inboxPath), { recursive: true });
+  const header = existsSync(inboxPath) ? '' : '# INBOX\n\n';
+  const chain = chainId ?? ctx.paths.baseDir;
+  const ageStr =
+    Number.isFinite(result.ageSec) && result.ageSec >= 0
+      ? `${Math.floor(result.ageSec)}s`
+      : 'n/a';
+  const block =
+    `${header}## [${isoNow()}] cron_stall_detected — ${chain}\n` +
+    `- chain dir: ${ctx.paths.baseDir}\n` +
+    `- last_wake: ${result.lastWake ?? 'never'}\n` +
+    `- age: ${ageStr}\n` +
+    `- threshold: ${result.thresholdSec}s\n` +
+    `- reason: ${result.reason}\n` +
+    `- action: re-register scheduled task and verify with caia-chain verify-bootstrap\n\n`;
+  appendFileSync(inboxPath, block);
+}
+
+export interface ReRegisterAttempt {
+  command: string;
+  args: string[];
+  /** Spawn fn — injectable for tests. */
+  spawn?: (cmd: string, args: string[]) => { status: number | null; stderr?: string };
+}
+
+export interface ReRegisterResult {
+  attempted: boolean;
+  ok: boolean;
+  exitCode: number | null;
+  stderr?: string;
+}
+
+/**
+ * Best-effort: run an external re-register command. The chain-runner has
+ * no MCP client of its own; the bootstrap script (or a per-chain helper)
+ * is expected to wrap the actual mcp__scheduled-tasks__create_scheduled_task
+ * call. If `command` is empty / undefined, this is a no-op.
+ */
+export function attemptReRegister(
+  attempt: ReRegisterAttempt | undefined,
+  ctx: StateContext,
+): ReRegisterResult {
+  if (!attempt || !attempt.command) {
+    appendAudit(ctx.paths.auditFile, 'cron_reregister_skipped', {
+      reason: 'no_command_configured',
+    });
+    return { attempted: false, ok: false, exitCode: null };
+  }
+  const runner =
+    attempt.spawn ??
+    ((cmd: string, args: string[]) => {
+      const out = spawnSync(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      return {
+        status: out.status,
+        stderr: out.stderr ? out.stderr.toString('utf8') : undefined,
+      };
+    });
+  const out = runner(attempt.command, attempt.args);
+  const ok = out.status === 0;
+  appendAudit(ctx.paths.auditFile, 'cron_reregister_attempted', {
+    command: attempt.command,
+    exit_code: out.status,
+    ok,
+  });
+  return {
+    attempted: true,
+    ok,
+    exitCode: out.status,
+    ...(out.stderr !== undefined ? { stderr: out.stderr } : {}),
+  };
+}

--- a/packages/chain-runner/tests/watchdog.test.ts
+++ b/packages/chain-runner/tests/watchdog.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import {
+  attemptReRegister,
+  detectStall,
+  recordStallDetected,
+  type StallCheckResult,
+} from '../src/watchdog.js';
+import {
+  findWakeAfter,
+  retryWithBackoff,
+  verifyBootstrap,
+} from '../src/bootstrap.js';
+import { makeFixture, type FixtureBundle } from './fixtures.js';
+import {
+  initState,
+  loadContext,
+  loadState,
+  recordWake,
+  saveState,
+  type StateContext,
+} from '../src/state.js';
+import type { StateFile } from '../src/types.js';
+
+// ---------- detectStall ----------
+
+function freshState(overrides: Partial<StateFile> = {}): StateFile {
+  return {
+    schema_version: 1,
+    started_at: new Date(Date.now() - 60_000).toISOString(),
+    last_wake: null,
+    paused: false,
+    budget_consumed_pct: 0,
+    budget_cap_pct: 25,
+    phase_status: {},
+    current_phase: null,
+    all_done: false,
+    ...overrides,
+  };
+}
+
+describe('detectStall', () => {
+  it('reports healthy when last_wake is recent', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    const state = freshState({
+      last_wake: new Date(now.getTime() - 60_000).toISOString(),
+    });
+    const r = detectStall(state, { wakeIntervalSec: 900, now: () => now });
+    expect(r.stalled).toBe(false);
+    expect(r.reason).toBe('healthy');
+    expect(r.ageSec).toBeLessThan(r.thresholdSec);
+  });
+
+  it('reports wake_overdue when last_wake is older than 2x interval', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    const state = freshState({
+      last_wake: new Date(now.getTime() - 3 * 900 * 1000).toISOString(),
+    });
+    const r = detectStall(state, { wakeIntervalSec: 900, now: () => now });
+    expect(r.stalled).toBe(true);
+    expect(r.reason).toBe('wake_overdue');
+    expect(r.ageSec).toBeGreaterThan(r.thresholdSec);
+  });
+
+  it('reports never_waked when last_wake is null and started_at is old', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    const state = freshState({
+      started_at: new Date(now.getTime() - 4 * 900 * 1000).toISOString(),
+      last_wake: null,
+    });
+    const r = detectStall(state, { wakeIntervalSec: 900, now: () => now });
+    expect(r.stalled).toBe(true);
+    expect(r.reason).toBe('never_waked');
+    expect(r.lastWake).toBeNull();
+  });
+
+  it('stays healthy when last_wake null but started_at is recent', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    const state = freshState({
+      started_at: new Date(now.getTime() - 60_000).toISOString(),
+      last_wake: null,
+    });
+    const r = detectStall(state, { wakeIntervalSec: 900, now: () => now });
+    expect(r.stalled).toBe(false);
+    expect(r.reason).toBe('healthy');
+  });
+
+  it('honours custom multiplier', () => {
+    const now = new Date('2026-05-13T12:00:00Z');
+    const state = freshState({
+      last_wake: new Date(now.getTime() - 1500 * 1000).toISOString(),
+    });
+    // 1500s age, 900s interval → 1.67x; multiplier=3 means threshold=2700s, healthy
+    const r1 = detectStall(state, {
+      wakeIntervalSec: 900,
+      multiplier: 3,
+      now: () => now,
+    });
+    expect(r1.stalled).toBe(false);
+    // multiplier=1 means threshold=900s, stalled
+    const r2 = detectStall(state, {
+      wakeIntervalSec: 900,
+      multiplier: 1,
+      now: () => now,
+    });
+    expect(r2.stalled).toBe(true);
+  });
+
+  it('rejects invalid wakeIntervalSec', () => {
+    expect(() => detectStall(freshState(), { wakeIntervalSec: 0 })).toThrow();
+    expect(() => detectStall(freshState(), { wakeIntervalSec: -1 })).toThrow();
+  });
+});
+
+// ---------- recordStallDetected ----------
+
+describe('recordStallDetected', () => {
+  let fx: FixtureBundle;
+  let ctx: StateContext;
+  beforeEach(() => {
+    fx = makeFixture(`stall-${Math.random().toString(36).slice(2, 8)}`);
+    ctx = loadContext(fx.chainId, fx.specPath);
+    initState(ctx);
+  });
+  afterEach(() => fx.cleanup());
+
+  it('writes audit event with stall metadata', () => {
+    const result: StallCheckResult = {
+      stalled: true,
+      lastWake: '2026-05-13T10:00:00Z',
+      ageSec: 7200,
+      thresholdSec: 1800,
+      reason: 'wake_overdue',
+    };
+    recordStallDetected(ctx, result);
+    const audit = readFileSync(ctx.paths.auditFile, 'utf8');
+    expect(audit).toContain('"event":"cron_stall_detected"');
+    expect(audit).toContain('"age_sec":7200');
+    expect(audit).toContain('"threshold_sec":1800');
+    expect(audit).toContain('"reason":"wake_overdue"');
+  });
+
+  it('appends INBOX.md alert when inboxPath given', () => {
+    const inboxDir = mkdtempSync(join(tmpdir(), 'inbox-test-'));
+    const inboxPath = join(inboxDir, 'INBOX.md');
+    try {
+      const result: StallCheckResult = {
+        stalled: true,
+        lastWake: null,
+        ageSec: 9999,
+        thresholdSec: 1800,
+        reason: 'never_waked',
+      };
+      recordStallDetected(ctx, result, { inboxPath, chainId: 'sample-chain' });
+      expect(existsSync(inboxPath)).toBe(true);
+      const body = readFileSync(inboxPath, 'utf8');
+      expect(body).toContain('cron_stall_detected');
+      expect(body).toContain('sample-chain');
+      expect(body).toContain('never');
+      expect(body).toContain('1800s');
+    } finally {
+      rmSync(inboxDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------- attemptReRegister ----------
+
+describe('attemptReRegister', () => {
+  let fx: FixtureBundle;
+  let ctx: StateContext;
+  beforeEach(() => {
+    fx = makeFixture(`rereg-${Math.random().toString(36).slice(2, 8)}`);
+    ctx = loadContext(fx.chainId, fx.specPath);
+    initState(ctx);
+  });
+  afterEach(() => fx.cleanup());
+
+  it('is a no-op without a command', () => {
+    const r = attemptReRegister(undefined, ctx);
+    expect(r.attempted).toBe(false);
+    const audit = readFileSync(ctx.paths.auditFile, 'utf8');
+    expect(audit).toContain('cron_reregister_skipped');
+  });
+
+  it('runs spawn fn and reports success', () => {
+    const r = attemptReRegister(
+      { command: '/bin/true', args: [], spawn: () => ({ status: 0 }) },
+      ctx,
+    );
+    expect(r.attempted).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.exitCode).toBe(0);
+    const audit = readFileSync(ctx.paths.auditFile, 'utf8');
+    expect(audit).toContain('"event":"cron_reregister_attempted"');
+    expect(audit).toContain('"ok":true');
+  });
+
+  it('reports failure when spawn returns non-zero', () => {
+    const r = attemptReRegister(
+      {
+        command: '/bin/false',
+        args: [],
+        spawn: () => ({ status: 7, stderr: 'boom' }),
+      },
+      ctx,
+    );
+    expect(r.attempted).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(7);
+    expect(r.stderr).toBe('boom');
+  });
+});
+
+// ---------- retryWithBackoff ----------
+
+describe('retryWithBackoff', () => {
+  it('returns on first success without sleeping', async () => {
+    const sleeps: number[] = [];
+    const result = await retryWithBackoff(() => 'ok', {
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(result).toBe('ok');
+    expect(sleeps).toEqual([]);
+  });
+
+  it('retries with default backoff and eventually succeeds', async () => {
+    let attempt = 0;
+    const sleeps: number[] = [];
+    const result = await retryWithBackoff(
+      () => {
+        attempt += 1;
+        if (attempt < 3) throw new Error(`fail ${attempt}`);
+        return 'win';
+      },
+      {
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+    expect(result).toBe('win');
+    expect(attempt).toBe(3);
+    expect(sleeps).toEqual([5_000, 15_000]);
+  });
+
+  it('exhausts retries and throws the last error', async () => {
+    let attempt = 0;
+    const sleeps: number[] = [];
+    await expect(
+      retryWithBackoff(
+        () => {
+          attempt += 1;
+          throw new Error(`fail ${attempt}`);
+        },
+        {
+          sleep: async (ms) => {
+            sleeps.push(ms);
+          },
+        },
+      ),
+    ).rejects.toThrow(/fail 4/);
+    expect(attempt).toBe(4);
+    expect(sleeps).toEqual([5_000, 15_000, 45_000]);
+  });
+
+  it('honours custom backoff schedule', async () => {
+    let attempt = 0;
+    const sleeps: number[] = [];
+    await expect(
+      retryWithBackoff(
+        () => {
+          attempt += 1;
+          throw new Error('nope');
+        },
+        {
+          backoffMs: [10, 20],
+          sleep: async (ms) => {
+            sleeps.push(ms);
+          },
+        },
+      ),
+    ).rejects.toThrow();
+    expect(attempt).toBe(3);
+    expect(sleeps).toEqual([10, 20]);
+  });
+
+  it('respects maxAttempts override', async () => {
+    let attempt = 0;
+    await expect(
+      retryWithBackoff(
+        () => {
+          attempt += 1;
+          throw new Error('nope');
+        },
+        {
+          backoffMs: [1, 1, 1, 1, 1],
+          maxAttempts: 2,
+          sleep: async () => {},
+        },
+      ),
+    ).rejects.toThrow();
+    expect(attempt).toBe(2);
+  });
+
+  it('invokes onRetry hook on each retry', async () => {
+    const log: string[] = [];
+    let attempt = 0;
+    await expect(
+      retryWithBackoff(
+        () => {
+          attempt += 1;
+          throw new Error(`fail ${attempt}`);
+        },
+        {
+          backoffMs: [10, 20],
+          sleep: async () => {},
+          onRetry: (a, err, delay) => {
+            log.push(`a=${a} err=${(err as Error).message} delay=${delay}`);
+          },
+        },
+      ),
+    ).rejects.toThrow();
+    expect(log).toEqual([
+      'a=1 err=fail 1 delay=10',
+      'a=2 err=fail 2 delay=20',
+    ]);
+  });
+});
+
+// ---------- verifyBootstrap ----------
+
+describe('verifyBootstrap', () => {
+  let fx: FixtureBundle;
+  let ctx: StateContext;
+  beforeEach(() => {
+    fx = makeFixture(`vboot-${Math.random().toString(36).slice(2, 8)}`);
+    ctx = loadContext(fx.chainId, fx.specPath);
+    initState(ctx);
+  });
+  afterEach(() => fx.cleanup());
+
+  it('returns ok=true when a wake lands during the poll loop', async () => {
+    let elapsed = 0;
+    const since = new Date('2026-05-13T12:00:00Z');
+    // Schedule a wake event to be appended after the first poll sleep.
+    const result = await verifyBootstrap(ctx, {
+      maxWaitMs: 30_000,
+      pollIntervalMs: 5_000,
+      since,
+      now: () => new Date(since.getTime() + elapsed),
+      sleep: async (ms) => {
+        elapsed += ms;
+        if (elapsed >= 5_000) {
+          // Inject a wake event into audit.jsonl
+          const wakeTs = new Date(since.getTime() + 6_000).toISOString();
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const fs = require('node:fs') as typeof import('node:fs');
+          fs.appendFileSync(
+            ctx.paths.auditFile,
+            `${JSON.stringify({ ts: wakeTs, event: 'wake' })}\n`,
+          );
+        }
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.observedWakeAt).not.toBeNull();
+  });
+
+  it('returns ok=false on timeout', async () => {
+    let elapsed = 0;
+    const since = new Date('2026-05-13T12:00:00Z');
+    const result = await verifyBootstrap(ctx, {
+      maxWaitMs: 30_000,
+      pollIntervalMs: 10_000,
+      since,
+      now: () => new Date(since.getTime() + elapsed),
+      sleep: async (ms) => {
+        elapsed += ms;
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.observedWakeAt).toBeNull();
+    expect(result.waitedMs).toBe(30_000);
+  });
+
+  it('ignores wake events older than `since`', async () => {
+    // Stamp an old wake event before starting verification.
+    recordWake(ctx);
+    const state = loadState(ctx);
+    const oldWakeTs = state.last_wake!;
+    const since = new Date(Date.parse(oldWakeTs) + 1000);
+    let elapsed = 0;
+    const result = await verifyBootstrap(ctx, {
+      maxWaitMs: 20_000,
+      pollIntervalMs: 10_000,
+      since,
+      now: () => new Date(since.getTime() + elapsed),
+      sleep: async (ms) => {
+        elapsed += ms;
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('findWakeAfter returns the first matching event', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('node:fs') as typeof import('node:fs');
+    fs.appendFileSync(
+      ctx.paths.auditFile,
+      `${JSON.stringify({ ts: '2026-05-13T11:00:00Z', event: 'wake' })}\n` +
+        `${JSON.stringify({ ts: '2026-05-13T12:00:00Z', event: 'wake' })}\n`,
+    );
+    const got = findWakeAfter(ctx, new Date('2026-05-13T11:30:00Z'));
+    expect(got).toBe('2026-05-13T12:00:00Z');
+    const none = findWakeAfter(ctx, new Date('2026-05-13T12:30:00Z'));
+    expect(none).toBeNull();
+  });
+});
+
+// ---------- integration smoke: state→detectStall round trip ----------
+
+describe('watchdog integration with real state', () => {
+  let fx: FixtureBundle;
+  let ctx: StateContext;
+  beforeEach(() => {
+    fx = makeFixture(`int-${Math.random().toString(36).slice(2, 8)}`);
+    ctx = loadContext(fx.chainId, fx.specPath);
+    initState(ctx);
+  });
+  afterEach(() => fx.cleanup());
+
+  it('detects stall after backdating last_wake', () => {
+    const state = loadState(ctx);
+    state.last_wake = new Date(Date.now() - 3600 * 1000).toISOString();
+    saveState(ctx, state);
+    const r = detectStall(loadState(ctx), { wakeIntervalSec: 900 });
+    expect(r.stalled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Permanent systemic guard against the failure mode discovered in the 2026-05-13 RCA: a chain bootstrap can produce a `SKILL.md` on disk without registering the scheduled task, leaving the chain orphaned with no cron firing. Four layered safeguards.

## Safeguards

1. **Pre-flight cron verification** (`caia-chain verify-bootstrap`)
   Polls `audit.jsonl` for a `wake` event within `2 × wake_interval` (default 30 min). Bootstrap is not declared complete until at least one wake observation lands. Exits 3 on timeout so the bootstrap shell script fails loudly.

2. **Self-healing watchdog** (`caia-chain check-stall`)
   Every wake, compute `now - last_wake` and compare against `multiplier * wake_interval_sec` (default 2×). On stall: append `cron_stall_detected` to `audit.jsonl`, append alert to `INBOX.md`, optionally invoke `--reregister-cmd`. Exits 4 on stall.

3. **Belt-and-suspenders launchd watchdog**
   Standalone Node script at `~/.caia/chain-watchdog/watchdog.js` scans `~/.caia/chain/*/state.json` every 30 min via `~/Library/LaunchAgents/com.caia.chain-watchdog.plist`. Pokes any chain whose `last_wake` is more than 1h old. Installed and running locally — kickstart already detected the existing T2.5 stall.

4. **Retry-with-backoff** (`caia-chain retry-cmd` + exported `retryWithBackoff`)
   Wrap any flaky external call (e.g. `mcp__scheduled-tasks__create_scheduled_task`) with exponential backoff. Default schedule 5s → 15s → 45s; configurable via `--backoff-ms` + `--max-attempts`.

## Files

- New: `packages/chain-runner/src/bootstrap.ts` (retry + preflight)
- New: `packages/chain-runner/src/watchdog.ts` (stall detect + INBOX + re-register)
- New: `packages/chain-runner/tests/watchdog.test.ts` (22 tests)
- Modified: `packages/chain-runner/src/cli.ts` (new commands), `index.ts` (exports)

Out of repo (installed to local Mac, scoped by RCA): `~/.caia/chain-watchdog/watchdog.js` + `~/Library/LaunchAgents/com.caia.chain-watchdog.plist`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 101 tests pass (22 new for watchdog + retry + verifyBootstrap, 79 pre-existing regression)
- [x] `pnpm build` clean
- [x] Manual: `check-stall` reports `HEALTHY` on fresh init, `STALL_DETECTED reason=never_waked` after backdating `started_at`
- [x] Manual: `retry-cmd /usr/bin/false --backoff-ms 50,100,200` exits non-zero with 3 retry log lines and exit code 1
- [x] Manual: `verify-bootstrap` blocks then returns `PREFLIGHT_OK` when a wake-observed lands during the poll window
- [x] Manual: `launchctl kickstart com.caia.chain-watchdog` produces `scan_complete scanned=3 stalled=1` and appends the T2.5 stall to INBOX.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)