### PR TITLE
feat(local-llm-router): sps t2.5 phase 2 — RAG middleware (nomic-embed-text)

### DIFF
--- a/packages/local-llm-router/__tests__/rag.test.ts
+++ b/packages/local-llm-router/__tests__/rag.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { extractMentions, mentionsToQuery } from '../src/rag/extract_mentions.js';
+import { injectFiles } from '../src/rag/inject.js';
+import {
+  __resetIndexCache,
+  __setIndex,
+  topK,
+  lookupByPaths,
+  type FileIndex,
+  type IndexEntry,
+} from '../src/rag/index.js';
+import { runRag } from '../src/rag/middleware.js';
+
+// Build a tiny synthetic file index in memory so the tests don't depend on
+// ~/.caia/router/file_index.json existing on the box that runs CI.
+function makeIndex(entries: Partial<IndexEntry>[]): FileIndex {
+  const filled: IndexEntry[] = entries.map((e, i) => ({
+    path: e.path ?? `/tmp/fake/${i}.ts`,
+    rel: e.rel ?? `tmp/fake/${i}.ts`,
+    size: e.size ?? 0,
+    preview: e.preview ?? `// preview-${i}`,
+    vector: e.vector ?? [1, 0, 0, 0],
+  }));
+  return {
+    version: 1,
+    model: 'nomic-embed-text',
+    dim: filled[0]?.vector.length ?? 0,
+    built_at: new Date().toISOString(),
+    entries: filled,
+  };
+}
+
+describe('rag/extract_mentions', () => {
+  it('captures package-relative TypeScript paths', () => {
+    const m = extractMentions('Please refactor packages/local-llm-router/src/classifier-v2.ts and add tests.');
+    expect(m.hasMentions).toBe(true);
+    expect(m.paths).toContain('packages/local-llm-router/src/classifier-v2.ts');
+  });
+
+  it('captures absolute and home-relative paths', () => {
+    const m = extractMentions('See ~/Documents/projects/caia/packages/foo/bar.py and /tmp/scratch/test.md');
+    expect(m.paths).toEqual(expect.arrayContaining([
+      '~/Documents/projects/caia/packages/foo/bar.py',
+      '/tmp/scratch/test.md',
+    ]));
+  });
+
+  it('captures camelCase and snake_case symbols', () => {
+    const m = extractMentions('The function classifyV2 calls keyword_prepass and then nextTier.');
+    expect(m.symbols).toEqual(expect.arrayContaining(['classifyV2', 'keyword_prepass', 'nextTier']));
+  });
+
+  it('returns hasMentions=false on plain prose', () => {
+    const m = extractMentions('Summarize the quarterly report in three sentences.');
+    expect(m.hasMentions).toBe(false);
+  });
+
+  it('mentionsToQuery prefers paths when present', () => {
+    const m = extractMentions('Refactor packages/foo/bar.ts thoroughly.');
+    const q = mentionsToQuery(m, 'Refactor packages/foo/bar.ts thoroughly.');
+    expect(q).toContain('packages/foo/bar.ts');
+  });
+});
+
+describe('rag/index', () => {
+  beforeEach(() => { __resetIndexCache(); });
+  afterEach(() => { __resetIndexCache(); });
+
+  it('lookupByPaths finds an entry by trailing-segment match', () => {
+    const idx = makeIndex([
+      { rel: 'packages/local-llm-router/src/classifier-v2.ts', path: '/abs/packages/local-llm-router/src/classifier-v2.ts' },
+      { rel: 'packages/other/something.ts', path: '/abs/packages/other/something.ts' },
+    ]);
+    const got = lookupByPaths(['packages/local-llm-router/src/classifier-v2.ts'], 3, idx);
+    expect(got.length).toBe(1);
+    expect(got[0]?.rel).toBe('packages/local-llm-router/src/classifier-v2.ts');
+  });
+
+  it('topK orders entries by cosine similarity', () => {
+    const idx = makeIndex([
+      { rel: 'a.ts', vector: [1, 0, 0] },
+      { rel: 'b.ts', vector: [0, 1, 0] },
+      { rel: 'c.ts', vector: [0.5, 0.5, 0] },
+    ]);
+    const hits = topK([1, 0, 0], 2, idx);
+    expect(hits[0]?.entry.rel).toBe('a.ts');
+    expect(hits[1]?.entry.rel).toBe('c.ts');
+  });
+});
+
+describe('rag/inject', () => {
+  it('returns empty injection on empty entries', () => {
+    const r = injectFiles({ entries: [] });
+    expect(r.systemMessage).toBe('');
+    expect(r.filesIncluded).toBe(0);
+  });
+
+  it('formats files with headers and respects per-file char budget', () => {
+    const tinyBudget = 200; // tokens × 4 = 800 chars total budget
+    const entries: IndexEntry[] = [
+      {
+        path: '/nonexistent/aaa.ts', rel: 'aaa.ts', size: 0,
+        preview: 'X'.repeat(400),
+        vector: [],
+      },
+    ];
+    const r = injectFiles({ entries, similarities: [0.9], tokenBudget: tinyBudget });
+    expect(r.filesIncluded).toBe(1);
+    expect(r.systemMessage).toContain('CAIA RAG context');
+    expect(r.systemMessage).toContain('aaa.ts');
+    expect(r.systemMessage).toContain('(sim=0.900)');
+  });
+});
+
+describe('rag/middleware — injection on a known-file prompt', () => {
+  beforeEach(() => { __resetIndexCache(); });
+  afterEach(() => {
+    __resetIndexCache();
+    __setIndex(null);
+  });
+
+  it('injects context when the prompt mentions a path in the index', async () => {
+    // Seed an in-memory index with one entry that corresponds to a file we
+    // know exists in the repo (this very test file).
+    const knownPath = '/Users/macbook32/Documents/projects/caia/packages/local-llm-router/__tests__/rag.test.ts';
+    const idx = makeIndex([
+      {
+        path: knownPath,
+        rel: 'packages/local-llm-router/__tests__/rag.test.ts',
+        size: 1234,
+        preview: 'rag.test.ts preview',
+        vector: [1, 0, 0, 0],
+      },
+    ]);
+    __setIndex(idx);
+
+    const decision = await runRag(
+      'Read packages/local-llm-router/__tests__/rag.test.ts and explain.',
+      { enabled: true, forceIndex: idx },
+    );
+
+    expect(decision.injected).toBe(true);
+    expect(decision.reason).toBe('injected-by-path');
+    expect(decision.filesIncluded).toBe(1);
+    expect(decision.systemPrepend).toContain('CAIA RAG context');
+    expect(decision.systemPrepend).toContain('rag.test.ts');
+    expect(decision.matchedPaths).toContain('packages/local-llm-router/__tests__/rag.test.ts');
+  });
+
+  it('skips injection when RAG is disabled', async () => {
+    const d = await runRag('something packages/foo/bar.ts', { enabled: false });
+    expect(d.injected).toBe(false);
+    expect(d.reason).toBe('disabled');
+  });
+
+  it('skips injection when prompt has no file/symbol mentions', async () => {
+    const idx = makeIndex([{ rel: 'x.ts', vector: [1, 0] }]);
+    const d = await runRag('how are you today', { enabled: true, forceIndex: idx });
+    expect(d.injected).toBe(false);
+    expect(d.reason).toBe('no-mentions');
+  });
+});

--- a/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
+++ b/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
@@ -37,6 +37,10 @@
     <string>qwen2.5-coder:7b</string>
     <key>ROUTER_RAG_ENABLED</key>
     <string>true</string>
+    <key>ROUTER_RAG_TOP_K</key>
+    <string>3</string>
+    <key>ROUTER_RAG_TOKEN_BUDGET</key>
+    <string>2000</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>

--- a/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
+++ b/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
@@ -35,6 +35,8 @@
     <string>http://127.0.0.1:11434</string>
     <key>ROUTER_CLASSIFIER_MODEL</key>
     <string>qwen2.5-coder:7b</string>
+    <key>ROUTER_RAG_ENABLED</key>
+    <string>true</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>

--- a/packages/local-llm-router/scripts/build_file_index.ts
+++ b/packages/local-llm-router/scripts/build_file_index.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// scripts/build_file_index.ts — one-shot index builder for the RAG layer.
+//
+// Walks ~/Documents/projects/caia/{packages,websites,scripts}/**/*.{ts,tsx,js,py,md},
+// embeds each file's first 4K chars via Ollama nomic-embed-text, and writes
+// the result to ~/.caia/router/file_index.json.
+//
+// Run:
+//   pnpm tsx scripts/build_file_index.ts            # default paths
+//   pnpm tsx scripts/build_file_index.ts --roots ../foo
+//
+// Or, after build:
+//   node dist/scripts/build_file_index.js
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const DEFAULT_ROOTS = [
+  join(homedir(), 'Documents/projects/caia/packages'),
+  join(homedir(), 'Documents/projects/caia/websites'),
+  join(homedir(), 'Documents/projects/caia/scripts'),
+];
+const REPO_ROOT = join(homedir(), 'Documents/projects/caia');
+
+const ALLOWED_EXTS = new Set(['.ts', '.tsx', '.js', '.py', '.md']);
+const SKIP_DIR_NAMES = new Set([
+  'node_modules', 'dist', 'build', '.next', '.turbo', '.cache',
+  '__pycache__', '.venv', 'venv', '.git', 'coverage', '.spawn-worktrees',
+]);
+
+const EMBED_CHAR_CAP = 4_000;
+const PREVIEW_CHARS = 256;
+const OLLAMA_URL = process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+const EMBED_MODEL = process.env['ROUTER_RAG_EMBED_MODEL'] ?? 'nomic-embed-text';
+const OUT_PATH = process.env['ROUTER_RAG_INDEX_PATH']
+  ?? join(homedir(), '.caia', 'router', 'file_index.json');
+
+interface CliArgs {
+  roots: string[];
+  out: string;
+  limit: number;          // 0 = no limit; useful for fast smoke runs
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { roots: DEFAULT_ROOTS, out: OUT_PATH, limit: 0, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--roots' && i + 1 < argv.length) {
+      const next = argv[++i];
+      if (next !== undefined) out.roots = next.split(',').map(r => resolve(r));
+    } else if (a === '--out' && i + 1 < argv.length) {
+      const next = argv[++i];
+      if (next !== undefined) out.out = next;
+    } else if (a === '--limit' && i + 1 < argv.length) {
+      const next = argv[++i];
+      if (next !== undefined) out.limit = Number(next);
+    } else if (a === '--dry-run') {
+      out.dryRun = true;
+    }
+  }
+  return out;
+}
+
+function* walk(root: string): Generator<string> {
+  if (!existsSync(root)) return;
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (dir === undefined) break;
+    let entries: { name: string; isDir: boolean }[] = [];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true }).map(d => ({
+        name: d.name, isDir: d.isDirectory(),
+      }));
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith('.') && e.name !== '.github') continue;
+      if (SKIP_DIR_NAMES.has(e.name)) continue;
+      const full = join(dir, e.name);
+      if (e.isDir) {
+        stack.push(full);
+      } else {
+        const dot = e.name.lastIndexOf('.');
+        if (dot === -1) continue;
+        const ext = e.name.slice(dot);
+        if (!ALLOWED_EXTS.has(ext)) continue;
+        yield full;
+      }
+    }
+  }
+}
+
+async function embedOne(text: string): Promise<number[]> {
+  const res = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: EMBED_MODEL, prompt: text }),
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) {
+    throw new Error(`ollama embeddings returned ${res.status}`);
+  }
+  const body = (await res.json()) as { embedding?: number[] };
+  if (!Array.isArray(body.embedding) || body.embedding.length === 0) {
+    throw new Error('empty embedding returned');
+  }
+  return body.embedding;
+}
+
+interface IndexEntry {
+  path: string;
+  rel: string;
+  size: number;
+  preview: string;
+  vector: number[];
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const started = Date.now();
+
+  // ─── collect ──────────────────────────────────────────────────────────
+  const paths: string[] = [];
+  for (const root of args.roots) {
+    for (const p of walk(root)) paths.push(p);
+  }
+  paths.sort();
+  const total = paths.length;
+  // eslint-disable-next-line no-console
+  console.error(`[index] collected ${total} candidate files from ${args.roots.length} root(s)`);
+
+  if (args.dryRun) {
+    // eslint-disable-next-line no-console
+    console.error('[index] dry-run — exiting after collection');
+    return;
+  }
+
+  // ─── embed ────────────────────────────────────────────────────────────
+  const entries: IndexEntry[] = [];
+  let totalBytes = 0;
+  let failures = 0;
+  const limit = args.limit > 0 ? Math.min(args.limit, total) : total;
+
+  for (let i = 0; i < limit; i++) {
+    const p = paths[i];
+    if (p === undefined) continue;
+    let body: string;
+    let size: number;
+    try {
+      body = readFileSync(p, 'utf8');
+      size = statSync(p).size;
+    } catch {
+      failures += 1;
+      continue;
+    }
+    if (body.trim().length === 0) continue;
+    const truncated = body.slice(0, EMBED_CHAR_CAP);
+    totalBytes += truncated.length;
+
+    let vector: number[];
+    try {
+      vector = await embedOne(truncated);
+    } catch (e) {
+      failures += 1;
+      // eslint-disable-next-line no-console
+      console.error(`[index] ${i + 1}/${limit} FAIL ${relative(REPO_ROOT, p)}: ${(e as Error).message}`);
+      continue;
+    }
+
+    entries.push({
+      path: p,
+      rel: relative(REPO_ROOT, p),
+      size,
+      preview: truncated.slice(0, PREVIEW_CHARS),
+      vector,
+    });
+
+    if ((i + 1) % 50 === 0 || i + 1 === limit) {
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+      // eslint-disable-next-line no-console
+      console.error(`[index] ${i + 1}/${limit} embedded — ${entries.length} ok, ${failures} fail, ${elapsed}s elapsed`);
+    }
+  }
+
+  // ─── write ────────────────────────────────────────────────────────────
+  mkdirSync(dirname(args.out), { recursive: true });
+  const doc = {
+    version: 1 as const,
+    model: EMBED_MODEL,
+    dim: entries[0]?.vector.length ?? 0,
+    built_at: new Date().toISOString(),
+    entries,
+  };
+  writeFileSync(args.out, JSON.stringify(doc));
+  const elapsedSec = ((Date.now() - started) / 1000).toFixed(1);
+  const sizeMB = (statSync(args.out).size / (1024 * 1024)).toFixed(2);
+
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify({
+    out: args.out,
+    files_indexed: entries.length,
+    files_failed: failures,
+    total_embed_bytes: totalBytes,
+    elapsed_seconds: Number(elapsedSec),
+    on_disk_mb: Number(sizeMB),
+    dim: doc.dim,
+    model: doc.model,
+  }, null, 2));
+}
+
+main().catch(e => {
+  // eslint-disable-next-line no-console
+  console.error('[index] fatal:', (e as Error).message);
+  process.exit(1);
+});

--- a/packages/local-llm-router/src/rag/embed.ts
+++ b/packages/local-llm-router/src/rag/embed.ts
@@ -1,0 +1,74 @@
+// embed.ts — thin wrapper around Ollama's /api/embeddings endpoint.
+//
+// We hard-code `nomic-embed-text` as the default since (a) it's already
+// pulled on the dev box (verified via /healthz) and (b) the file index is
+// embedded with the same model — querying with a different one would yield
+// useless distances. The env override exists for experiment runs.
+
+const DEFAULT_MODEL = process.env['ROUTER_RAG_EMBED_MODEL'] ?? 'nomic-embed-text';
+const DEFAULT_OLLAMA_URL = process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+const DEFAULT_TIMEOUT_MS = Number(process.env['ROUTER_RAG_EMBED_TIMEOUT_MS'] ?? 15_000);
+
+export interface EmbedOptions {
+  model?: string;
+  ollamaBaseUrl?: string;
+  timeoutMs?: number;
+}
+
+export class EmbedError extends Error {
+  constructor(message: string, readonly status?: number) {
+    super(message);
+    this.name = 'EmbedError';
+  }
+}
+
+export async function embedOne(
+  text: string,
+  opts: EmbedOptions = {},
+): Promise<number[]> {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const baseUrl = opts.ollamaBaseUrl ?? DEFAULT_OLLAMA_URL;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const res = await fetch(`${baseUrl}/api/embeddings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, prompt: text }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) {
+    throw new EmbedError(`ollama embeddings returned ${res.status}`, res.status);
+  }
+  const body = (await res.json()) as { embedding?: number[] };
+  const v = body.embedding;
+  if (!Array.isArray(v) || v.length === 0) {
+    throw new EmbedError('ollama embeddings returned empty vector');
+  }
+  return v;
+}
+
+// Convenience for the index-builder (sequential — Ollama serializes anyway
+// on a single GPU, and we want to keep the script simple).
+export async function embedMany(
+  texts: string[],
+  opts: EmbedOptions = {},
+): Promise<number[][]> {
+  const out: number[][] = [];
+  for (const t of texts) out.push(await embedOne(t, opts));
+  return out;
+}
+
+// Cosine similarity in [-1, 1]. Returns 0 if either vector is degenerate.
+export function cosineSim(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length);
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < n; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    na += av * av;
+    nb += bv * bv;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}

--- a/packages/local-llm-router/src/rag/extract_mentions.ts
+++ b/packages/local-llm-router/src/rag/extract_mentions.ts
@@ -1,0 +1,120 @@
+// extract_mentions.ts — pull file paths and code symbols from a user message.
+//
+// We try to be permissive on the path regex (Stolution prompts cite paths in
+// markdown, backticks, prose, or git-style diffs) and strict on the symbol
+// regex (camelCase / PascalCase / snake_case identifiers that look distinctive
+// — too loose a match would flood the embed step with noise like "the").
+//
+// Output is deduplicated and order-preserving so the downstream embed step
+// can use the first mention as the query if needed.
+
+const FILE_EXTENSIONS = [
+  'ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs',
+  'py', 'pyi',
+  'md', 'mdx',
+  'yaml', 'yml', 'json', 'toml',
+  'go', 'rs', 'java', 'kt', 'rb', 'php', 'cs',
+  'sh', 'bash', 'zsh',
+  'sql', 'graphql', 'css', 'scss', 'html',
+];
+
+// Match path-like tokens. Accepts:
+//   packages/foo/src/bar.ts
+//   ~/Documents/projects/caia/packages/foo/bar.py
+//   ./relative/path/to/file.tsx
+//   /absolute/path/to/file.md
+//   src/foo.ts:42
+// Excludes pure URLs (handled by the http/https guard below).
+const PATH_RE = new RegExp(
+  String.raw`(?<![A-Za-z0-9])` +
+  String.raw`((?:~\/|\.\/|\.\.\/|\/)?` +
+  String.raw`(?:[A-Za-z0-9._-]+\/){1,}` +
+  String.raw`[A-Za-z0-9._-]+\.(?:` + FILE_EXTENSIONS.join('|') + `))` +
+  String.raw`(?::\d+)?`,
+  'g'
+);
+
+// Match camelCase / PascalCase / snake_case identifiers >= 4 chars and with at
+// least one transition (so plain words like "function" don't match).
+const SYMBOL_RE = /\b([A-Z][a-z]+[A-Z][A-Za-z0-9]+|[a-z]+[A-Z][A-Za-z0-9]+|[a-z]+_[a-z][a-z0-9_]+)\b/g;
+
+// Backtick-quoted spans get an extra pass: anything inside backticks that
+// looks like a callable (foo(), Foo.bar, etc) is captured as a symbol even if
+// it didn't survive the strict pattern above.
+const BACKTICK_RE = /`([^`]{2,80})`/g;
+const CALLABLE_RE = /\b([A-Za-z_][A-Za-z0-9_]*)(?:\(\)|\.\w+)/;
+
+export interface ExtractedMentions {
+  paths: string[];
+  symbols: string[];
+  // True if there is at least one path or at least one symbol — used by
+  // middleware.ts to decide whether to bother embedding the query.
+  hasMentions: boolean;
+}
+
+function uniq(xs: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) { seen.add(x); out.push(x); }
+  }
+  return out;
+}
+
+export function extractMentions(text: string): ExtractedMentions {
+  const paths: string[] = [];
+  const symbols: string[] = [];
+
+  // First pass: paths from raw text (line-anchored line:col strips happen
+  // in the regex via the optional `:\d+` group; we discard the line suffix).
+  let m: RegExpExecArray | null;
+  PATH_RE.lastIndex = 0;
+  while ((m = PATH_RE.exec(text)) !== null) {
+    const candidate = m[1];
+    if (candidate === undefined) continue;
+    // Skip if it looks like a URL host (the path-re won't capture "://" but
+    // belt-and-braces: drop if previous chars are "://")
+    const idx = m.index;
+    if (idx >= 2 && text.slice(idx - 3, idx) === '://') continue;
+    paths.push(candidate);
+  }
+
+  // Second pass: distinctive symbols from raw text.
+  SYMBOL_RE.lastIndex = 0;
+  while ((m = SYMBOL_RE.exec(text)) !== null) {
+    if (m[1] !== undefined) symbols.push(m[1]);
+  }
+
+  // Third pass: backtick-quoted callables.
+  BACKTICK_RE.lastIndex = 0;
+  while ((m = BACKTICK_RE.exec(text)) !== null) {
+    const inner = m[1];
+    if (inner === undefined) continue;
+    const cm = CALLABLE_RE.exec(inner);
+    if (cm !== null && cm[1] !== undefined && cm[1].length >= 3) symbols.push(cm[1]);
+  }
+
+  const uPaths = uniq(paths);
+  const uSyms = uniq(symbols);
+  return {
+    paths: uPaths,
+    symbols: uSyms,
+    hasMentions: uPaths.length > 0 || uSyms.length > 0,
+  };
+}
+
+// Format the extracted mentions as a single short query string the embedding
+// model can chew on. We prefer paths (they are the strongest signal); if none,
+// fall back to symbols joined with spaces.
+export function mentionsToQuery(m: ExtractedMentions, fullText: string): string {
+  if (m.paths.length > 0) {
+    // Paths plus a small slice of context so the embedding is not a bag of
+    // filenames in isolation.
+    const ctx = fullText.length > 400 ? fullText.slice(0, 400) : fullText;
+    return [...m.paths, ctx].join(' ');
+  }
+  if (m.symbols.length > 0) {
+    return m.symbols.slice(0, 8).join(' ');
+  }
+  return fullText.slice(0, 400);
+}

--- a/packages/local-llm-router/src/rag/index.ts
+++ b/packages/local-llm-router/src/rag/index.ts
@@ -1,0 +1,148 @@
+// index.ts — file-content embedding index for the router RAG middleware.
+//
+// On-disk format: a single JSON document at ~/.caia/router/file_index.json
+// (override with ROUTER_RAG_INDEX_PATH). Schema:
+//
+//   {
+//     "version": 1,
+//     "model": "nomic-embed-text",
+//     "dim": 768,
+//     "built_at": "<ISO-8601>",
+//     "entries": [
+//       { "path": "<abs path>", "rel": "<rel-to-root>", "size": <bytes>,
+//         "preview": "<first 256 chars>", "vector": [<dim floats>] },
+//       ...
+//     ]
+//   }
+//
+// JSON was chosen over SQLite because ~1.3K files × 768-float vectors lands
+// at ~10 MB — well under the 50 MB "stay-in-JSON" budget in the spec. If the
+// index ever blows past that, swap this module for a sqlite-backed one;
+// callers only depend on `loadIndex` / `topK`.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { cosineSim } from './embed.js';
+
+export interface IndexEntry {
+  path: string;       // absolute path on disk
+  rel: string;        // path relative to repo root (for display)
+  size: number;       // file size in bytes at index time
+  preview: string;    // first ~256 chars of the file (used by inject.ts fallback)
+  vector: number[];   // embedding of the file's first 4K chars
+}
+
+export interface FileIndex {
+  version: 1;
+  model: string;
+  dim: number;
+  built_at: string;
+  entries: IndexEntry[];
+}
+
+export interface TopKResult {
+  entry: IndexEntry;
+  similarity: number;  // cosine in [-1, 1]
+}
+
+export function defaultIndexPath(): string {
+  return process.env['ROUTER_RAG_INDEX_PATH']
+    ?? join(homedir(), '.caia', 'router', 'file_index.json');
+}
+
+let _cached: FileIndex | null = null;
+let _cachedPath: string | null = null;
+
+/**
+ * Load the on-disk index, caching it in memory across calls. Returns null
+ * (and logs to stderr) if the index is missing or malformed — the
+ * middleware treats a missing index as "RAG disabled" and falls through.
+ */
+export function loadIndex(path: string = defaultIndexPath()): FileIndex | null {
+  if (_cached !== null && _cachedPath === path) return _cached;
+  if (!existsSync(path)) {
+    // Don't error — the operator may not have built the index yet.
+    return null;
+  }
+  try {
+    const raw = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw) as FileIndex;
+    if (parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+      // eslint-disable-next-line no-console
+      console.error(`[rag] index at ${path} has unexpected shape (version=${parsed.version})`);
+      return null;
+    }
+    _cached = parsed;
+    _cachedPath = path;
+    return parsed;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(`[rag] failed to parse index at ${path}: ${(e as Error).message}`);
+    return null;
+  }
+}
+
+/** Test seam — drop the in-memory cache so a fresh read happens next call. */
+export function __resetIndexCache(): void {
+  _cached = null;
+  _cachedPath = null;
+}
+
+/** Inject an index document directly (test helper, no disk involvement). */
+export function __setIndex(idx: FileIndex | null, path: string = defaultIndexPath()): void {
+  _cached = idx;
+  _cachedPath = path;
+}
+
+/**
+ * Return the top-k entries by cosine similarity to `queryEmbedding`.
+ * Returns [] if the index is unavailable or empty.
+ */
+export function topK(
+  queryEmbedding: number[],
+  k = 3,
+  index: FileIndex | null = loadIndex(),
+): TopKResult[] {
+  if (index === null || index.entries.length === 0) return [];
+  const scored: TopKResult[] = index.entries.map(entry => ({
+    entry,
+    similarity: cosineSim(queryEmbedding, entry.vector),
+  }));
+  scored.sort((a, b) => b.similarity - a.similarity);
+  return scored.slice(0, k);
+}
+
+/**
+ * Path-based shortcut: if the user mentioned a known file path verbatim,
+ * we can skip the embedding step and use a substring match. Returns at most
+ * `k` entries whose `rel` ends with one of the mentioned paths, in mention
+ * order. Used by middleware.ts as a fast path before the embed call.
+ */
+export function lookupByPaths(
+  mentionedPaths: string[],
+  k = 3,
+  index: FileIndex | null = loadIndex(),
+): IndexEntry[] {
+  if (index === null || mentionedPaths.length === 0) return [];
+  const found: IndexEntry[] = [];
+  const seen = new Set<string>();
+  for (const m of mentionedPaths) {
+    // Normalize: drop a leading ./ or ~/, strip a trailing :line-number.
+    const norm = m
+      .replace(/^~\//, '')
+      .replace(/^\.\//, '')
+      .replace(/:\d+$/, '');
+    for (const e of index.entries) {
+      if (seen.has(e.path)) continue;
+      if (e.rel === norm || e.rel.endsWith('/' + norm) || e.path.endsWith('/' + norm) || e.path === norm) {
+        found.push(e);
+        seen.add(e.path);
+        if (found.length >= k) return found;
+        break;
+      }
+    }
+  }
+  return found;
+}

--- a/packages/local-llm-router/src/rag/inject.ts
+++ b/packages/local-llm-router/src/rag/inject.ts
@@ -1,16 +1,16 @@
 // inject.ts — format top-K file contents into a system context block.
 //
 // Token budget: we approximate "tokens" as `chars / 4`, which is roughly
-// the GPT-tokenizer ratio for English+code. The 4K-token cap in the spec
-// translates to ~16 000 characters of context. The budget is split evenly
-// across the K files, with each file allowed to use less than its share if
-// the file is small.
+// the GPT-tokenizer ratio for English+code. The 2K-token cap (per the T2.5
+// Phase 2 spec) translates to ~8 000 characters of context. The budget is
+// split evenly across the K files, with each file allowed to use less than
+// its share if the file is small.
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 
 import type { IndexEntry } from './index.js';
 
-export const DEFAULT_TOKEN_BUDGET = Number(process.env['ROUTER_RAG_TOKEN_BUDGET'] ?? 4_000);
+export const DEFAULT_TOKEN_BUDGET = Number(process.env['ROUTER_RAG_TOKEN_BUDGET'] ?? 2_000);
 export const CHARS_PER_TOKEN = 4;                       // ~ heuristic
 const HEADER = '## CAIA RAG context — auto-injected from local file index';
 

--- a/packages/local-llm-router/src/rag/inject.ts
+++ b/packages/local-llm-router/src/rag/inject.ts
@@ -1,0 +1,95 @@
+// inject.ts — format top-K file contents into a system context block.
+//
+// Token budget: we approximate "tokens" as `chars / 4`, which is roughly
+// the GPT-tokenizer ratio for English+code. The 4K-token cap in the spec
+// translates to ~16 000 characters of context. The budget is split evenly
+// across the K files, with each file allowed to use less than its share if
+// the file is small.
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+
+import type { IndexEntry } from './index.js';
+
+export const DEFAULT_TOKEN_BUDGET = Number(process.env['ROUTER_RAG_TOKEN_BUDGET'] ?? 4_000);
+export const CHARS_PER_TOKEN = 4;                       // ~ heuristic
+const HEADER = '## CAIA RAG context — auto-injected from local file index';
+
+export interface InjectInput {
+  entries: IndexEntry[];
+  similarities?: number[];                  // optional, parallel to entries
+  tokenBudget?: number;
+}
+
+export interface InjectResult {
+  systemMessage: string;                    // ready-to-prepend system content
+  filesIncluded: number;
+  charsIncluded: number;
+  truncated: boolean;
+}
+
+export function injectFiles(input: InjectInput): InjectResult {
+  const tokenBudget = input.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+  const charBudget = tokenBudget * CHARS_PER_TOKEN;
+
+  if (input.entries.length === 0) {
+    return { systemMessage: '', filesIncluded: 0, charsIncluded: 0, truncated: false };
+  }
+
+  const perFileBudget = Math.floor(charBudget / input.entries.length);
+  const sections: string[] = [HEADER];
+  let totalChars = HEADER.length;
+  let truncated = false;
+  let filesIncluded = 0;
+
+  for (let i = 0; i < input.entries.length; i++) {
+    const entry = input.entries[i];
+    if (entry === undefined) continue;
+    const sim = input.similarities?.[i];
+
+    let body = '';
+    try {
+      if (existsSync(entry.path)) {
+        // Cap the read at perFileBudget to keep memory bounded for huge files
+        // (some markdowns/notebooks are megabytes). We still slice the result
+        // below so the final string fits.
+        const raw = readFileSync(entry.path, 'utf8');
+        body = raw.slice(0, perFileBudget * 2); // overshoot then slice cleanly
+      } else {
+        body = entry.preview; // file moved/deleted since index build — use preview
+      }
+    } catch {
+      body = entry.preview;
+    }
+
+    if (body.length > perFileBudget) {
+      body = body.slice(0, perFileBudget) + '\n…[truncated]';
+      truncated = true;
+    }
+
+    const simStr = typeof sim === 'number' ? ` (sim=${sim.toFixed(3)})` : '';
+    const section = `\n\n### ${entry.rel}${simStr}\n\n\`\`\`\n${body}\n\`\`\``;
+
+    // Respect the global character budget too — stop adding files if the
+    // running total would exceed it.
+    if (totalChars + section.length > charBudget && filesIncluded > 0) {
+      truncated = true;
+      break;
+    }
+
+    sections.push(section);
+    totalChars += section.length;
+    filesIncluded += 1;
+  }
+
+  return {
+    systemMessage: sections.join(''),
+    filesIncluded,
+    charsIncluded: totalChars,
+    truncated,
+  };
+}
+
+// Lightweight stat helper used by the index-build script.
+export function fileSizeOrZero(path: string): number {
+  try { return statSync(path).size; } catch { return 0; }
+}

--- a/packages/local-llm-router/src/rag/middleware.ts
+++ b/packages/local-llm-router/src/rag/middleware.ts
@@ -1,0 +1,131 @@
+// middleware.ts — entry point used by the /v1/chat/completions handler.
+//
+// Pipeline:
+//   1. Pull the (joined) user text from the chat-completions body.
+//   2. Run extractMentions(); if nothing looks file/symbol-shaped, skip.
+//   3. Try lookupByPaths() first — verbatim file mentions get an exact-match
+//      shortcut so we save the embedding round-trip.
+//   4. Otherwise embed the mentions-derived query via nomic-embed-text and
+//      call topK(k=3) against the file index.
+//   5. Drop results whose top-1 similarity is below a threshold (default
+//      0.45 — tuned empirically against `packages/foo/bar.ts`-style
+//      prompts on the 768-dim nomic vectors).
+//   6. Format with injectFiles() and prepend as a system message.
+//
+// Disabled when:
+//   - process.env.ROUTER_RAG_ENABLED !== 'true'
+//   - extractMentions reports no mentions
+//   - the index isn't present on disk
+//   - top-1 similarity < threshold
+
+import { extractMentions, mentionsToQuery } from './extract_mentions.js';
+import { embedOne } from './embed.js';
+import { loadIndex, lookupByPaths, topK, type IndexEntry } from './index.js';
+import { injectFiles } from './inject.js';
+
+export const DEFAULT_TOP_K = Number(process.env['ROUTER_RAG_TOP_K'] ?? 3);
+export const DEFAULT_MIN_SIMILARITY = Number(process.env['ROUTER_RAG_MIN_SIMILARITY'] ?? 0.45);
+
+export interface RagDecision {
+  injected: boolean;
+  reason: 'disabled' | 'no-mentions' | 'no-index' | 'below-threshold' | 'embed-failed' | 'injected-by-path' | 'injected-by-embed';
+  systemPrepend: string;          // empty when injected=false
+  filesIncluded: number;
+  topSimilarity?: number;
+  matchedPaths: string[];         // rel paths of the chosen files (for logging)
+}
+
+export interface RagOptions {
+  enabled?: boolean;              // overrides ROUTER_RAG_ENABLED for tests
+  topK?: number;
+  minSimilarity?: number;
+  ollamaBaseUrl?: string;
+  // Pre-supplied index — test helper. When set, loadIndex() is bypassed.
+  forceIndex?: ReturnType<typeof loadIndex>;
+}
+
+export function ragEnabled(opts: RagOptions = {}): boolean {
+  if (opts.enabled !== undefined) return opts.enabled;
+  return process.env['ROUTER_RAG_ENABLED'] === 'true';
+}
+
+/**
+ * Run the RAG pipeline on a single chat-completions user message and return
+ * the resulting injection decision. Never throws — embedding failures are
+ * caught and surface as `reason: "embed-failed"` so the request still
+ * proceeds (RAG is best-effort context, not a hard dependency).
+ */
+export async function runRag(
+  userText: string,
+  opts: RagOptions = {},
+): Promise<RagDecision> {
+  if (!ragEnabled(opts)) {
+    return { injected: false, reason: 'disabled', systemPrepend: '', filesIncluded: 0, matchedPaths: [] };
+  }
+
+  const mentions = extractMentions(userText);
+  if (!mentions.hasMentions) {
+    return { injected: false, reason: 'no-mentions', systemPrepend: '', filesIncluded: 0, matchedPaths: [] };
+  }
+
+  const index = opts.forceIndex !== undefined ? opts.forceIndex : loadIndex();
+  if (index === null) {
+    return { injected: false, reason: 'no-index', systemPrepend: '', filesIncluded: 0, matchedPaths: [] };
+  }
+
+  const k = opts.topK ?? DEFAULT_TOP_K;
+
+  // Fast path — verbatim file mention.
+  if (mentions.paths.length > 0) {
+    const exact = lookupByPaths(mentions.paths, k, index);
+    if (exact.length > 0) {
+      const result = injectFiles({ entries: exact });
+      return {
+        injected: result.filesIncluded > 0,
+        reason: 'injected-by-path',
+        systemPrepend: result.systemMessage,
+        filesIncluded: result.filesIncluded,
+        topSimilarity: 1.0,
+        matchedPaths: exact.map(e => e.rel),
+      };
+    }
+  }
+
+  // Slow path — embed and query.
+  const query = mentionsToQuery(mentions, userText);
+  let queryVec: number[];
+  try {
+    queryVec = await embedOne(query, opts.ollamaBaseUrl !== undefined ? { ollamaBaseUrl: opts.ollamaBaseUrl } : {});
+  } catch {
+    return { injected: false, reason: 'embed-failed', systemPrepend: '', filesIncluded: 0, matchedPaths: [] };
+  }
+
+  const hits = topK(queryVec, k, index);
+  if (hits.length === 0) {
+    return { injected: false, reason: 'no-index', systemPrepend: '', filesIncluded: 0, matchedPaths: [] };
+  }
+  const topSim = hits[0]?.similarity ?? 0;
+  const threshold = opts.minSimilarity ?? DEFAULT_MIN_SIMILARITY;
+  if (topSim < threshold) {
+    return {
+      injected: false,
+      reason: 'below-threshold',
+      systemPrepend: '',
+      filesIncluded: 0,
+      topSimilarity: topSim,
+      matchedPaths: hits.map(h => h.entry.rel),
+    };
+  }
+
+  const entries: IndexEntry[] = hits.map(h => h.entry);
+  const sims = hits.map(h => h.similarity);
+  const result = injectFiles({ entries, similarities: sims });
+  return {
+    injected: result.filesIncluded > 0,
+    reason: 'injected-by-embed',
+    systemPrepend: result.systemMessage,
+    filesIncluded: result.filesIncluded,
+    topSimilarity: topSim,
+    matchedPaths: entries.map(e => e.rel),
+  };
+}

--- a/packages/local-llm-router/src/server.ts
+++ b/packages/local-llm-router/src/server.ts
@@ -23,6 +23,8 @@ import { classifyV2 } from './classifier-v2.js';
 import { OllamaAdapter } from './ollama-adapter.js';
 import { llmMetrics } from './llm-metrics.js';
 import { ROUTING_RULES } from './routing-config.js';
+import { ragEnabled, runRag } from './rag/middleware.js';
+import { defaultIndexPath, loadIndex } from './rag/index.js';
 
 const ROUTER_VERSION = '0.3.0';
 const DEFAULT_PORT = 7411;
@@ -49,12 +51,35 @@ export function buildApp(opts: ServerOptions = {}): Hono {
         ollamaOk = true;
       }
     } catch { /* ollamaOk stays false */ }
+    // RAG status — surfaced so operators can verify post-restart that the
+    // middleware is wired and the index is loadable.
+    const ragOn = ragEnabled();
+    const indexPath = defaultIndexPath();
+    let ragIndexLoaded = false;
+    let ragIndexEntries = 0;
+    let ragIndexModel: string | undefined;
+    if (ragOn) {
+      const idx = loadIndex(indexPath);
+      if (idx !== null) {
+        ragIndexLoaded = true;
+        ragIndexEntries = idx.entries.length;
+        ragIndexModel = idx.model;
+      }
+    }
     return c.json({
       ok: true,
       router_version: ROUTER_VERSION,
       ollama: { base_url: ollamaBaseUrl, ok: ollamaOk, models_count: models.length },
       models,
       classifier_model: classifierModel,
+      rag_enabled: ragOn,
+      rag: {
+        enabled: ragOn,
+        index_path: indexPath,
+        index_loaded: ragIndexLoaded,
+        index_entries: ragIndexEntries,
+        index_model: ragIndexModel ?? null,
+      },
       uptime_seconds: Math.floor(process.uptime()),
     });
   });
@@ -166,12 +191,31 @@ export function buildApp(opts: ServerOptions = {}): Hono {
     // Default to "summarize" task type if caller didn't specify
     const taskType = body.caia_task_type ?? 'route-default';
 
+    // ── RAG middleware (Tier 2.5 — feat/sps-t2.5-rag-layer) ──────────
+    // Runs BEFORE classification so injected context can also flow into the
+    // classifier's view of the request. Best-effort: any failure short-circuits
+    // back to the un-augmented path without surfacing the error to the caller.
+    let ragDecision: Awaited<ReturnType<typeof runRag>> | null = null;
+    let augmentedPrompt = userMsg;
+    try {
+      ragDecision = await runRag(userMsg, { ollamaBaseUrl });
+      if (ragDecision.injected && ragDecision.systemPrepend.length > 0) {
+        // Prepend the RAG context. We do NOT replace any existing system msg
+        // the caller passed — we concatenate, RAG first then the caller's.
+        const rag = ragDecision.systemPrepend;
+        const callerSys = (systemMsg !== undefined && systemMsg.length > 0) ? `\n\n---\n\n${systemMsg}` : '';
+        augmentedPrompt = `${rag}${callerSys}\n\n---\n\n${userMsg}`;
+      }
+    } catch {
+      ragDecision = null;
+    }
+
     try {
       // Note: existing route() takes positional (taskType, prompt, options).
       // systemPrompt + max_tokens + temperature are not part of the current
       // router signature; the routing-config's per-task max_tokens applies.
       // Future enhancement: extend router to accept per-call overrides.
-      const llmRes = await routerRoute(taskType, userMsg);
+      const llmRes = await routerRoute(taskType, augmentedPrompt);
       // Shape as OpenAI chat-completions
       return c.json({
         id: `caia-router-${Date.now()}`,
@@ -188,7 +232,17 @@ export function buildApp(opts: ServerOptions = {}): Hono {
           completion_tokens: llmRes.usage?.completionTokens ?? 0,
           total_tokens: llmRes.usage?.totalTokens ?? 0,
         },
-        caia: { provider: llmRes.provider, duration_ms: llmRes.durationMs },
+        caia: {
+          provider: llmRes.provider,
+          duration_ms: llmRes.durationMs,
+          rag: ragDecision === null ? { injected: false, reason: 'middleware-error' } : {
+            injected: ragDecision.injected,
+            reason: ragDecision.reason,
+            files_included: ragDecision.filesIncluded,
+            matched_paths: ragDecision.matchedPaths,
+            ...(ragDecision.topSimilarity !== undefined ? { top_similarity: ragDecision.topSimilarity } : {}),
+          },
+        },
       });
     } catch (e) {
       return c.json({ error: 'route-failed', message: (e as Error).message }, 502);


### PR DESCRIPTION
## Summary
- Adds RAG middleware to `/v1/chat/completions` that extracts file/symbol mentions, queries a local `nomic-embed-text` file-content index, and injects top-3 nearest files as system context before classification.
- File index builder: `scripts/build_file_index.ts` walks `caia/{packages,websites,scripts}` and writes `~/.caia/router/file_index.json` (1267 files, ~19 MB, ~102 s build).
- `/healthz` now surfaces `rag_enabled`, `index_path`, `index_loaded`, `index_entries`.
- `/v1/chat/completions` response now includes `caia.rag.{injected, reason, files_included, matched_paths, top_similarity}`.
- LaunchAgent plist sets `ROUTER_RAG_ENABLED=true`, `ROUTER_RAG_TOP_K=3`, `ROUTER_RAG_TOKEN_BUDGET=2000` by default.

Token-budget default tightened from 4K → 2K per the T2.5 Phase 2 / stability-completion phase 6 spec (smaller context = better keyword-prepass cache hit + less noise for the 7B model).

Resolves Tier 2.5 Phase 2 of the local-real-traffic chain.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run __tests__/rag.test.ts` — 12/12 pass
- [x] `/healthz` post-restart shows `rag_enabled: true`, `index_loaded: true`, `index_entries: 1267`
- [x] Smoke A — path mention → `injected-by-path`, 1 file, sim=1.0; local 7B summarized the actual file faithfully
- [x] Smoke B — symbol-only → `injected-by-embed`, 3 files, sim=0.619
- [x] Smoke C — plain prose → `no-mentions` skip
- [x] Canonical eval (`run_canonical_suite_v2.py`) — overall acc=70.6%, disp=58.7%, fc=7.9% (identical to post-Phase-1 baseline, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)