### PR TITLE
fix(local-llm-router): restore systemMsg in /v1/chat/completions (post-merge build break)

### DIFF
--- a/packages/local-llm-router/src/server.ts
+++ b/packages/local-llm-router/src/server.ts
@@ -188,8 +188,7 @@ export function buildApp(opts: ServerOptions = {}): Hono {
     if (messages.length === 0) return c.json({ error: 'messages-required' }, 400);
 
     const userMsg = messages.filter(m => m.role === 'user').map(m => m.content).join('\n\n');
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _systemMsg = messages.find(m => m.role === 'system')?.content;
+    const systemMsg = messages.find(m => m.role === 'system')?.content;
 
     // Default to "summarize" task type if caller didn't specify
     const taskType = body.caia_task_type ?? 'route-default';


### PR DESCRIPTION
## Summary
- The squash-merge of PR #431 (RAG middleware) onto develop landed cleanly at the file level but produced a semantic conflict: an unrelated develop commit had renamed `systemMsg` → `_systemMsg` + eslint-disable as "unused", but the RAG block in `/v1/chat/completions` reads it to concatenate the caller's system message with the injected RAG context.
- `tsc` failed post-merge with three "Cannot find name 'systemMsg'" errors at `server.ts:209`. Restored the original name; the variable is no longer unused.

## Test plan
- [x] `pnpm build` clean
- [x] `npx vitest run` — 132/132 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)