### PR TITLE
feat(apprentice-corpus): pluggable distiller backend via DISTILL_BACKEND env var

### DIFF
--- a/packages/apprentice-corpus/src/aggregator.ts
+++ b/packages/apprentice-corpus/src/aggregator.ts
@@ -21,7 +21,7 @@ import { normaliseAll, normaliseOne, sha256OfMessages } from './normaliser.js';
 import { applyPiiMask, DEFAULT_REDACT_PATTERNS } from './pii-mask.js';
 import { scoreAll, scoreOne } from './quality.js';
 import { createReportsWalker } from './reports-walker.js';
-import { createDefaultDistiller, noopDistiller } from './distiller.js';
+import { createDistiller, noopDistiller } from './distiller.js';
 import type {
   ClaudeDistiller,
   CorpusManifest,
@@ -57,7 +57,10 @@ export class ApprenticeCorpusAggregator {
     this.claudeDistiller =
       input.claudeDistiller
       ?? (this.cfg.distillEnabled
-        ? createDefaultDistiller({ binaryPath: this.cfg.claudeBinaryPath })
+        ? createDistiller({
+            backend: process.env['DISTILL_BACKEND'],
+            claudeBinaryPath: this.cfg.claudeBinaryPath
+          })
         : noopDistiller);
   }
 

--- a/packages/apprentice-corpus/src/distiller.ts
+++ b/packages/apprentice-corpus/src/distiller.ts
@@ -1,15 +1,23 @@
 /**
- * Claude-binary-spawn distiller.
+ * Distiller — pluggable backend.
  *
- * Cribs from `@chiefaia/local-llm-router`'s `claude-adapter.ts`:
- *   - subprocess invocation pattern with `--print --output-format json`
- *   - explicit `ANTHROPIC_API_KEY=undefined` to force subscription path
- *   - timeout + JSON-parse error handling
+ * Selected by `DISTILL_BACKEND` env var via {@link createDistiller}:
+ *   - `claude-binary` (default, back-compat): subprocess `claude --print`
+ *     under the keychain/OAuth subscription path. Cribs from
+ *     `@chiefaia/local-llm-router`'s `claude-adapter.ts` (subprocess
+ *     pattern + `ANTHROPIC_API_KEY=undefined` to force subscription).
+ *   - `local-llm-router`: HTTP POST to a CAIA-internal Ollama proxy at
+ *     `http://127.0.0.1:7411/v1/chat/completions` with `qwen2.5-coder:7b`.
+ *     Health-checks `/healthz` (2s timeout) before each call; falls back
+ *     to claude-binary if unhealthy. Lifts the ~50-distill/day quota
+ *     into a free-of-subscription-cost regime so the M3 LaunchAgent can
+ *     run with `--max-distill-calls 50` rather than `--no-distill`.
  *
- * The distiller is invoked for InstructionPairs that score below the
- * quality threshold. It produces a refined `{instruction, response}`
- * pair which the aggregator then re-scores. Failures (rate-limit,
- * missing binary, malformed output) cause the sample to be dropped.
+ * The aggregator constructs one of these via {@link createDistiller}
+ * (reads `DISTILL_BACKEND` from the resolved env) and treats the result
+ * as an opaque {@link ClaudeDistiller}. Per-sample failures are caught
+ * by the aggregator and treated as "drop this sample"; the distiller
+ * itself must throw on every error path.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -32,6 +40,10 @@ export interface DefaultDistillerOptions {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
 
+export const LOCAL_LLM_ROUTER_DEFAULT_URL = 'http://127.0.0.1:7411';
+export const LOCAL_LLM_ROUTER_DEFAULT_MODEL = 'qwen2.5-coder:7b';
+const HEALTH_CHECK_TIMEOUT_MS = 2_000;
+
 export const DISTILL_PROMPT_TEMPLATE = `You are extracting a high-quality instruction-response pair for fine-tuning a coding agent.
 
 Given the raw artifact below, produce a clean Q/A pair that captures the substantive content.
@@ -50,6 +62,13 @@ Raw artifact:
 {text}
 """`;
 
+function renderPrompt(input: DistillInput): string {
+  return DISTILL_PROMPT_TEMPLATE
+    .replace('{source}', input.source)
+    .replace('{kind}', input.kind ?? 'unknown')
+    .replace('{text}', input.text);
+}
+
 /**
  * Build a default distiller backed by the `claude` CLI.
  *
@@ -64,10 +83,7 @@ export function createDefaultDistiller(opts: DefaultDistillerOptions): ClaudeDis
 
   return {
     async distill(input: DistillInput): Promise<DistillOutput> {
-      const prompt = DISTILL_PROMPT_TEMPLATE
-        .replace('{source}', input.source)
-        .replace('{kind}', input.kind ?? 'unknown')
-        .replace('{text}', input.text);
+      const prompt = renderPrompt(input);
 
       const env = { ...process.env };
       delete env['ANTHROPIC_API_KEY'];
@@ -97,6 +113,121 @@ export function createDefaultDistiller(opts: DefaultDistillerOptions): ClaudeDis
   };
 }
 
+export interface LocalLlmRouterDistillerOptions {
+  /** Base URL of the router. Default `http://127.0.0.1:7411`. */
+  routerUrl?: string;
+  /** Model id passed to `/v1/chat/completions`. Default `qwen2.5-coder:7b`. */
+  model?: string;
+  /** Overall request timeout for the chat completion call. */
+  timeoutMs?: number;
+  /** Health-check timeout (GET /healthz). Default 2s. */
+  healthCheckTimeoutMs?: number;
+  /**
+   * Fallback distiller used when `/healthz` is not OK. Required: the
+   * migration plan mandates falling back to the claude-binary path
+   * rather than dropping the sample, so the corpus pipeline degrades
+   * gracefully when the router is restarted or stopped.
+   */
+  fallback: ClaudeDistiller;
+  /** Test seam — replace global `fetch`. */
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Local-LLM-router distiller. POSTs to `<routerUrl>/v1/chat/completions`
+ * with the OpenAI chat-completions shape after a fast health check.
+ *
+ * Health-check failure → delegate to `fallback`. Any other error
+ * (request timeout, non-2xx, malformed response, JSON parse failure)
+ * throws, which the aggregator treats as "drop this sample" (same
+ * behaviour as the claude-binary path).
+ */
+export function createLocalLlmRouterDistiller(
+  opts: LocalLlmRouterDistillerOptions
+): ClaudeDistiller {
+  const baseUrl = (opts.routerUrl ?? LOCAL_LLM_ROUTER_DEFAULT_URL).replace(/\/+$/, '');
+  const model = opts.model ?? LOCAL_LLM_ROUTER_DEFAULT_MODEL;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const healthTimeoutMs = opts.healthCheckTimeoutMs ?? HEALTH_CHECK_TIMEOUT_MS;
+  const doFetch: typeof fetch = opts.fetchFn ?? ((globalThis as { fetch: typeof fetch }).fetch);
+
+  return {
+    async distill(input: DistillInput): Promise<DistillOutput> {
+      const healthy = await routerHealthy(doFetch, `${baseUrl}/healthz`, healthTimeoutMs);
+      if (!healthy) {
+        return opts.fallback.distill(input);
+      }
+
+      const prompt = renderPrompt(input);
+      const ctrl = new AbortController();
+      const to = setTimeout(() => ctrl.abort(), timeoutMs);
+      let res: Response;
+      try {
+        res = await doFetch(`${baseUrl}/v1/chat/completions`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            model,
+            messages: [{ role: 'user', content: prompt }],
+            temperature: 0.1
+          }),
+          signal: ctrl.signal
+        });
+      } catch (e) {
+        throw new Error(`local-llm-router request failed: ${(e as Error).message}`, { cause: e });
+      } finally {
+        clearTimeout(to);
+      }
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`local-llm-router responded ${res.status}: ${text.slice(0, 300)}`);
+      }
+      let body: unknown;
+      try {
+        body = await res.json();
+      } catch (e) {
+        throw new Error(`local-llm-router body not JSON: ${(e as Error).message}`, { cause: e });
+      }
+      const content = extractChatCompletionContent(body);
+      return parseInstructionJson(content);
+    }
+  };
+}
+
+async function routerHealthy(
+  doFetch: typeof fetch,
+  url: string,
+  timeoutMs: number
+): Promise<boolean> {
+  const ctrl = new AbortController();
+  const to = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await doFetch(url, { method: 'GET', signal: ctrl.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+function extractChatCompletionContent(body: unknown): string {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('local-llm-router body not an object');
+  }
+  const choices = (body as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    throw new Error('local-llm-router body missing choices[]');
+  }
+  const first = choices[0] as { message?: { content?: unknown } } | undefined;
+  const content = first?.message?.content;
+  if (typeof content !== 'string') {
+    throw new Error('local-llm-router choices[0].message.content not a string');
+  }
+  return content;
+}
+
 /**
  * Parse the `claude --print --output-format json` envelope, then the
  * inner JSON the distillation prompt asked for.
@@ -118,22 +249,98 @@ export function parseDistillerOutput(stdout: string): DistillOutput {
   ) {
     throw new Error('distiller envelope missing "result" string');
   }
-  const inner = (outer as { result: string }).result.trim();
-  // The prompt instructs strict JSON, but be tolerant of leading/trailing whitespace.
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(inner);
-  } catch (e) {
-    throw new Error(`distiller inner JSON parse failed: ${(e as Error).message}`, { cause: e });
+  return parseInstructionJson((outer as { result: string }).result);
+}
+
+/**
+ * Parse a `{instruction, response}` JSON object from a string that may
+ * carry leading prose, code fences, or trailing whitespace. Local
+ * Ollama-served models reliably wrap JSON in ```json fences despite
+ * the prompt's "no prose" instruction, so we strip those defensively
+ * before parsing.
+ */
+export function parseInstructionJson(raw: string): DistillOutput {
+  const trimmed = raw.trim();
+  const candidates = jsonCandidates(trimmed);
+  let lastErr: Error | null = null;
+  for (const c of candidates) {
+    try {
+      const parsed = JSON.parse(c) as unknown;
+      if (
+        typeof parsed === 'object'
+        && parsed !== null
+        && typeof (parsed as { instruction?: unknown }).instruction === 'string'
+        && typeof (parsed as { response?: unknown }).response === 'string'
+      ) {
+        const obj = parsed as { instruction: string; response: string };
+        return { instruction: obj.instruction, response: obj.response };
+      }
+      lastErr = new Error('parsed JSON missing instruction/response strings');
+    } catch (e) {
+      lastErr = e as Error;
+    }
   }
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new Error('distiller inner JSON is not an object');
+  throw new Error(
+    `distiller inner JSON parse failed: ${lastErr?.message ?? 'no candidates'}`,
+    { cause: lastErr ?? undefined }
+  );
+}
+
+function jsonCandidates(s: string): string[] {
+  const out: string[] = [s];
+  const fenced = stripCodeFence(s);
+  if (fenced !== s) out.push(fenced);
+  const first = s.indexOf('{');
+  const last = s.lastIndexOf('}');
+  if (first !== -1 && last > first) {
+    out.push(s.slice(first, last + 1));
   }
-  const obj = parsed as { instruction?: unknown; response?: unknown };
-  if (typeof obj.instruction !== 'string' || typeof obj.response !== 'string') {
-    throw new Error('distiller inner JSON missing instruction/response');
+  return out;
+}
+
+function stripCodeFence(s: string): string {
+  const m = s.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return m?.[1] !== undefined ? m[1].trim() : s;
+}
+
+export interface CreateDistillerOptions {
+  /** Value of `DISTILL_BACKEND`; `undefined` → claude-binary back-compat. */
+  backend?: string | undefined;
+  /** Path to the `claude` binary (used by claude-binary backend + as fallback). */
+  claudeBinaryPath: string;
+  /** Optional router URL override (default `http://127.0.0.1:7411`). */
+  routerUrl?: string;
+  /** Optional router model override (default `qwen2.5-coder:7b`). */
+  routerModel?: string;
+  /** Test seam — replace `spawnSync` for the claude-binary backend. */
+  spawnFn?: typeof spawnSync;
+  /** Test seam — replace `fetch` for the local-llm-router backend. */
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Backend-selecting factory.
+ *
+ * Reads {@link CreateDistillerOptions.backend} (caller passes
+ * `process.env.DISTILL_BACKEND`). Unrecognised values fall back to
+ * `claude-binary` for safety — the corpus pipeline must remain
+ * functional even if the env var is mistyped.
+ */
+export function createDistiller(opts: CreateDistillerOptions): ClaudeDistiller {
+  const claudeBinary = createDefaultDistiller({
+    binaryPath: opts.claudeBinaryPath,
+    ...(opts.spawnFn !== undefined ? { spawnFn: opts.spawnFn } : {})
+  });
+  const backend = (opts.backend ?? 'claude-binary').toLowerCase();
+  if (backend === 'local-llm-router') {
+    return createLocalLlmRouterDistiller({
+      ...(opts.routerUrl !== undefined ? { routerUrl: opts.routerUrl } : {}),
+      ...(opts.routerModel !== undefined ? { model: opts.routerModel } : {}),
+      ...(opts.fetchFn !== undefined ? { fetchFn: opts.fetchFn } : {}),
+      fallback: claudeBinary
+    });
   }
-  return { instruction: obj.instruction, response: obj.response };
+  return claudeBinary;
 }
 
 /** Always-throw stub for tests / disabled distillation. */

--- a/packages/apprentice-corpus/tests/distiller.test.ts
+++ b/packages/apprentice-corpus/tests/distiller.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   DISTILL_PROMPT_TEMPLATE,
+  LOCAL_LLM_ROUTER_DEFAULT_MODEL,
+  LOCAL_LLM_ROUTER_DEFAULT_URL,
   createDefaultDistiller,
-  parseDistillerOutput
+  createDistiller,
+  createLocalLlmRouterDistiller,
+  parseDistillerOutput,
+  parseInstructionJson
 } from '../src/distiller.js';
+import type { ClaudeDistiller, DistillOutput } from '../src/types.js';
 
 describe('parseDistillerOutput', () => {
   it('parses claude envelope + inner JSON', () => {
@@ -32,7 +38,34 @@ describe('parseDistillerOutput', () => {
   });
 });
 
-describe('createDefaultDistiller', () => {
+describe('parseInstructionJson', () => {
+  it('parses plain JSON', () => {
+    const s = JSON.stringify({ instruction: 'q', response: 'a' });
+    expect(parseInstructionJson(s)).toEqual({ instruction: 'q', response: 'a' });
+  });
+
+  it('strips ```json code fences (qwen2.5-coder default output shape)', () => {
+    const fenced = '```json\n{"instruction":"q","response":"a"}\n```';
+    expect(parseInstructionJson(fenced)).toEqual({ instruction: 'q', response: 'a' });
+  });
+
+  it('strips bare ``` fences without language tag', () => {
+    const fenced = '```\n{"instruction":"q","response":"a"}\n```';
+    expect(parseInstructionJson(fenced)).toEqual({ instruction: 'q', response: 'a' });
+  });
+
+  it('extracts JSON object embedded in surrounding prose', () => {
+    const prose =
+      'Sure, here is the pair:\n{"instruction":"q","response":"a"}\nLet me know if you need more.';
+    expect(parseInstructionJson(prose)).toEqual({ instruction: 'q', response: 'a' });
+  });
+
+  it('throws when neither instruction nor response are strings', () => {
+    expect(() => parseInstructionJson(JSON.stringify({ x: 1 }))).toThrow();
+  });
+});
+
+describe('createDefaultDistiller (claude-binary backend)', () => {
   it('strips ANTHROPIC_API_KEY from spawn env', async () => {
     const fakeSpawn = vi.fn().mockReturnValue({
       status: 0,
@@ -89,5 +122,228 @@ describe('DISTILL_PROMPT_TEMPLATE', () => {
     expect(DISTILL_PROMPT_TEMPLATE).toContain('{source}');
     expect(DISTILL_PROMPT_TEMPLATE).toContain('{kind}');
     expect(DISTILL_PROMPT_TEMPLATE).toContain('{text}');
+  });
+});
+
+describe('createLocalLlmRouterDistiller', () => {
+  const goodHealth = (): Response =>
+    new Response(JSON.stringify({ ok: true }), { status: 200 });
+  const goodChat = (instruction: string, response: string): Response =>
+    new Response(
+      JSON.stringify({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '```json\n' + JSON.stringify({ instruction, response }) + '\n```'
+            }
+          }
+        ]
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+
+  function neverCalledFallback(): ClaudeDistiller {
+    return {
+      distill: vi.fn().mockRejectedValue(new Error('fallback should not be called'))
+    };
+  }
+
+  it('POSTs to /v1/chat/completions with qwen2.5-coder:7b and parses fenced JSON', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(async () => goodHealth())
+      .mockImplementationOnce(async () => goodChat('q', 'a'));
+
+    const distiller = createLocalLlmRouterDistiller({
+      fetchFn,
+      fallback: neverCalledFallback()
+    });
+
+    const out = await distiller.distill({ source: 'memory', kind: 'directive', text: 'BODY' });
+    expect(out).toEqual({ instruction: 'q', response: 'a' });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const [healthUrl, healthInit] = fetchFn.mock.calls[0]!;
+    expect(String(healthUrl)).toBe(`${LOCAL_LLM_ROUTER_DEFAULT_URL}/healthz`);
+    expect((healthInit as RequestInit | undefined)?.method ?? 'GET').toBe('GET');
+
+    const [chatUrl, chatInit] = fetchFn.mock.calls[1]!;
+    expect(String(chatUrl)).toBe(`${LOCAL_LLM_ROUTER_DEFAULT_URL}/v1/chat/completions`);
+    const init = chatInit as RequestInit;
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string) as {
+      model: string;
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.model).toBe(LOCAL_LLM_ROUTER_DEFAULT_MODEL);
+    expect(body.messages[0]?.role).toBe('user');
+    expect(body.messages[0]?.content).toContain('BODY');
+    expect(body.messages[0]?.content).toContain('memory/directive');
+  });
+
+  it('falls back to claude-binary when /healthz is unhealthy', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('upstream down', { status: 503 }));
+
+    const fallbackOut: DistillOutput = { instruction: 'fb-q', response: 'fb-a' };
+    const fallback: ClaudeDistiller = {
+      distill: vi.fn().mockResolvedValue(fallbackOut)
+    };
+
+    const distiller = createLocalLlmRouterDistiller({ fetchFn, fallback });
+
+    const result = await distiller.distill({ source: 'memory', text: 'X' });
+    expect(result).toEqual(fallbackOut);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fallback.distill).toHaveBeenCalledOnce();
+  });
+
+  it('falls back when /healthz throws (e.g. connection refused)', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const fallback: ClaudeDistiller = {
+      distill: vi.fn().mockResolvedValue({ instruction: 'fb-q', response: 'fb-a' })
+    };
+    const distiller = createLocalLlmRouterDistiller({ fetchFn, fallback });
+    await expect(distiller.distill({ source: 'memory', text: 'X' })).resolves.toEqual({
+      instruction: 'fb-q',
+      response: 'fb-a'
+    });
+    expect(fallback.distill).toHaveBeenCalledOnce();
+  });
+
+  it('throws (without falling back) when the chat call returns non-2xx', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(goodHealth())
+      .mockResolvedValueOnce(new Response('bad model', { status: 502 }));
+
+    const fallback = neverCalledFallback();
+    const distiller = createLocalLlmRouterDistiller({ fetchFn, fallback });
+    await expect(distiller.distill({ source: 'memory', text: 'X' })).rejects.toThrow(/502/);
+    expect(fallback.distill).not.toHaveBeenCalled();
+  });
+
+  it('throws on malformed chat completion body', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(goodHealth())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      );
+    const distiller = createLocalLlmRouterDistiller({
+      fetchFn,
+      fallback: neverCalledFallback()
+    });
+    await expect(distiller.distill({ source: 'memory', text: 'X' })).rejects.toThrow(
+      /choices\[\]/
+    );
+  });
+});
+
+describe('createDistiller (backend selector)', () => {
+  it('defaults to claude-binary when backend is undefined', async () => {
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
+      stderr: '',
+      error: null
+    });
+    const distiller = createDistiller({
+      backend: undefined,
+      claudeBinaryPath: 'claude',
+      spawnFn: fakeSpawn as never
+    });
+    const out = await distiller.distill({ source: 'memory', text: 'X' });
+    expect(out).toEqual({ instruction: 'q', response: 'a' });
+    expect(fakeSpawn).toHaveBeenCalledOnce();
+  });
+
+  it('uses claude-binary when backend="claude-binary"', async () => {
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
+      stderr: '',
+      error: null
+    });
+    const distiller = createDistiller({
+      backend: 'claude-binary',
+      claudeBinaryPath: 'claude',
+      spawnFn: fakeSpawn as never
+    });
+    await distiller.distill({ source: 'memory', text: 'X' });
+    expect(fakeSpawn).toHaveBeenCalledOnce();
+  });
+
+  it('uses local-llm-router when backend="local-llm-router"', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [
+              { message: { role: 'assistant', content: '{"instruction":"q","response":"a"}' } }
+            ]
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      );
+    const fakeSpawn = vi.fn();
+    const distiller = createDistiller({
+      backend: 'local-llm-router',
+      claudeBinaryPath: 'claude',
+      fetchFn,
+      spawnFn: fakeSpawn as never
+    });
+    const out = await distiller.distill({ source: 'memory', text: 'X' });
+    expect(out).toEqual({ instruction: 'q', response: 'a' });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fakeSpawn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to claude-binary spawn when local-llm-router is unhealthy', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response('down', { status: 503 }));
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({
+        result: JSON.stringify({ instruction: 'fb-q', response: 'fb-a' })
+      }),
+      stderr: '',
+      error: null
+    });
+    const distiller = createDistiller({
+      backend: 'local-llm-router',
+      claudeBinaryPath: 'claude',
+      fetchFn,
+      spawnFn: fakeSpawn as never
+    });
+    const out = await distiller.distill({ source: 'memory', text: 'X' });
+    expect(out).toEqual({ instruction: 'fb-q', response: 'fb-a' });
+    expect(fakeSpawn).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to claude-binary for unknown backend values', async () => {
+    const fakeSpawn = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
+      stderr: '',
+      error: null
+    });
+    const distiller = createDistiller({
+      backend: 'bogus-value',
+      claudeBinaryPath: 'claude',
+      spawnFn: fakeSpawn as never
+    });
+    await distiller.distill({ source: 'memory', text: 'X' });
+    expect(fakeSpawn).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Make corpus distillation backend-configurable via `DISTILL_BACKEND` env var.
- New `local-llm-router` backend POSTs to `http://127.0.0.1:7411/v1/chat/completions` with `qwen2.5-coder:7b`, health-checks `/healthz` (2s timeout) before each call, falls back to claude-binary if unhealthy.
- Default stays `claude-binary` for back-compat.
- M3 LaunchAgent (`com.chiefaia.apprentice-corpus.plist`) gets `DISTILL_BACKEND=local-llm-router` so the 02:00 aggregator runs with `--max-distill-calls 50` without subscription-token cost.

## Why

Phase 1 of `redflag-remediation` chain (Red Flag #4 — Apprentice corpus quality 0.50 avg, zero >0.8). Distillation has been off since 2026-05-11 (`--no-distill` stop-gap), which silently drops 596/791 daily candidates. With distillation back on through the local router, corpus growth lifts ~10/day → ~30-50/day and avg quality moves 0.50 → ~0.58-0.62 over 7-10 days. Detailed analysis in `reports/apprentice_corpus_deep_dive_2026-05-13.md` §F Option 1.

## Test plan

- [x] `pnpm run typecheck` (0 errors)
- [x] `pnpm run lint` (0 warnings)
- [x] `pnpm run test` — 127/127 pass, distiller suite expanded from 9 → 24 tests covering: claude-binary (default), local-llm-router happy path, unhealthy router fallback, malformed responses throw without falling back, factory backend selection.
- [x] `pnpm run build`
- [ ] Smoke test: aggregator invoked with `--max-distill-calls 5` against live router; manifest.json shows `distilled >= 1`; samples.jsonl contains `meta.distilled=true` records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)