### PR TITLE
feat(chain-runner): node@22 pin + healthz preflight + doctor cmd

### DIFF
--- a/packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus-heartbeat.plist
+++ b/packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus-heartbeat.plist
@@ -35,6 +35,8 @@
         <string>CURRENT_HOME</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CAIA_NODE_BIN</key>
+        <string>CURRENT_NODE_BIN</string>
     </dict>
 
     <key>StartCalendarInterval</key>

--- a/packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus.plist
+++ b/packages/apprentice-corpus/plists/com.chiefaia.apprentice-corpus.plist
@@ -32,6 +32,9 @@
   <key>EnvironmentVariables</key>
   <dict>
     <!-- Patched at install time by scripts/install-apprentice-corpus.sh -->
+    <key>CAIA_NODE_BIN</key>
+    <string>CURRENT_NODE_BIN</string>
+
     <key>CAIA_MEMORY_DIR</key>
     <string>CURRENT_HOME/Library/Application Support/Claude/local-agent-mode-sessions/CURRENT_SESSION_ID/agent/memory</string>
 

--- a/packages/apprentice-corpus/scripts/install-apprentice-corpus.sh
+++ b/packages/apprentice-corpus/scripts/install-apprentice-corpus.sh
@@ -60,7 +60,6 @@ LOG_DIR="$HOME/Library/Logs/chiefaia"
 DOMAIN="gui/$(id -u)"
 SERVICE_TARGET="$DOMAIN/$LABEL"
 
-NODE_BIN="${CAIA_NODE_BIN:-$(command -v node || echo /usr/local/bin/node)}"
 CLAUDE_BIN="${CAIA_CLAUDE_BIN:-$(command -v claude || echo /usr/local/bin/claude)}"
 DEFAULT_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 RENDERED_PATH="${CAIA_PATH:-$DEFAULT_PATH}"
@@ -75,11 +74,11 @@ if [[ ! -d "$PKG_DIR/dist" ]]; then
   exit 1
 fi
 
-if [[ ! -x "$NODE_BIN" ]]; then
-  echo "node binary not found / not executable at: $NODE_BIN" >&2
-  echo "set CAIA_NODE_BIN to override" >&2
-  exit 1
-fi
+# Refuse to install if node major version doesn't match expected (default 22).
+# See scripts/lib/check-node-version.sh for the rationale (better-sqlite3 ABI lock).
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 mkdir -p "$LOG_DIR"
 mkdir -p "$(dirname "$PLIST_DST")"

--- a/packages/apprentice-corpus/scripts/install-heartbeat.sh
+++ b/packages/apprentice-corpus/scripts/install-heartbeat.sh
@@ -18,18 +18,11 @@ if [[ ! -f "$PLIST_SRC" ]]; then
   exit 1
 fi
 
-# Native module ABI (see install-apprentice-retrainer.sh for context).
-if [[ -n "${CAIA_NODE_BIN:-}" ]]; then
-  NODE_BIN="$CAIA_NODE_BIN"
-elif [[ -x /opt/homebrew/opt/node@22/bin/node ]]; then
-  NODE_BIN="/opt/homebrew/opt/node@22/bin/node"
-else
-  NODE_BIN="$(command -v node 2>/dev/null || true)"
-fi
-if [[ -z "$NODE_BIN" ]]; then
-  echo "node binary not found; set CAIA_NODE_BIN" >&2
-  exit 1
-fi
+# Refuse to install if node major version doesn't match expected (default 22).
+# Native modules (better-sqlite3) require the binary to match the runtime.
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 mkdir -p "$LOG_DIR"
 

--- a/packages/apprentice-retrainer/plists/com.chiefaia.apprentice-retrainer.plist
+++ b/packages/apprentice-retrainer/plists/com.chiefaia.apprentice-retrainer.plist
@@ -38,6 +38,8 @@
         <string>CURRENT_HOME</string>
         <key>PATH</key>
         <string>CURRENT_PATH</string>
+        <key>CAIA_NODE_BIN</key>
+        <string>CURRENT_NODE_BIN</string>
     </dict>
 
     <key>StartCalendarInterval</key>

--- a/packages/apprentice-retrainer/scripts/install-apprentice-retrainer.sh
+++ b/packages/apprentice-retrainer/scripts/install-apprentice-retrainer.sh
@@ -42,19 +42,11 @@ if [[ ! -d "$PKG_DIR/dist" ]]; then
 fi
 
 # Native binaries in the pnpm store are built against Node 22 (NODE_MODULE_VERSION 127).
-# Prefer node@22 by default so the retrainer process doesn't ABI-fail under newer
-# Homebrew node. CAIA_NODE_BIN overrides.
-if [[ -n "${CAIA_NODE_BIN:-}" ]]; then
-  NODE_BIN="$CAIA_NODE_BIN"
-elif [[ -x /opt/homebrew/opt/node@22/bin/node ]]; then
-  NODE_BIN="/opt/homebrew/opt/node@22/bin/node"
-else
-  NODE_BIN="$(command -v node 2>/dev/null || true)"
-fi
-if [[ -z "$NODE_BIN" ]]; then
-  echo "node binary not found on PATH; set CAIA_NODE_BIN" >&2
-  exit 1
-fi
+# The shared guard rejects installation when the resolved node major doesn't match
+# CAIA_EXPECTED_NODE_MAJOR (default 22). See scripts/lib/check-node-version.sh.
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 PATH_DEFAULT="${CAIA_PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin}"
 

--- a/packages/apprentice-training/scripts/install-apprentice-training.sh
+++ b/packages/apprentice-training/scripts/install-apprentice-training.sh
@@ -44,11 +44,10 @@ if [[ ! -d "$PKG_DIR/dist" ]]; then
   exit 1
 fi
 
-NODE_BIN="${CAIA_NODE_BIN:-$(command -v node 2>/dev/null || true)}"
-if [[ -z "$NODE_BIN" ]]; then
-  echo "node binary not found on PATH; set CAIA_NODE_BIN" >&2
-  exit 1
-fi
+# Refuse to install if node major version doesn't match expected (default 22).
+# shellcheck source=/dev/null
+source "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 PYTHON_BIN="${CAIA_PYTHON_BIN:-$HOME/Documents/projects/apprentice/venv/bin/python}"
 if [[ ! -x "$PYTHON_BIN" ]]; then

--- a/packages/chain-runner/src/bootstrap.ts
+++ b/packages/chain-runner/src/bootstrap.ts
@@ -17,6 +17,109 @@ import { existsSync, readFileSync } from 'node:fs';
 import { isoNow } from './time.js';
 import type { StateContext } from './state.js';
 
+/**
+ * Default healthz endpoints checked during verify-bootstrap.
+ *
+ * Background: 2026-05-13 mentor-event-bus went dark for ~3 days because the
+ * native better-sqlite3 binary (compiled for Node 22) was loaded by node@26
+ * after a brew upgrade, and the server crashed silently on startup. The
+ * chain runner had no signal to detect this. These endpoints are the
+ * pre-flight signal — if either is unhealthy, bootstrap fails (exit 3)
+ * instead of silently dispatching a chain into a broken environment.
+ */
+export const DEFAULT_HEALTHZ_ENDPOINTS: readonly HealthzEndpoint[] = [
+  { name: 'mentor', url: 'http://127.0.0.1:5180/v1/healthz' },
+  { name: 'router', url: 'http://127.0.0.1:7411/healthz' },
+];
+
+export interface HealthzEndpoint {
+  name: string;
+  url: string;
+}
+
+export interface HealthzCheckResult {
+  name: string;
+  url: string;
+  ok: boolean;
+  status: number | null;
+  error: string | null;
+  elapsedMs: number;
+}
+
+/** Inject a fetch impl in tests; defaults to global fetch. */
+export type FetchLike = (
+  url: string,
+  init?: { signal?: AbortSignal },
+) => Promise<{ status: number; ok: boolean }>;
+
+export async function checkHealthz(
+  endpoint: HealthzEndpoint,
+  opts: { timeoutMs?: number; fetchImpl?: FetchLike } = {},
+): Promise<HealthzCheckResult> {
+  const timeoutMs = opts.timeoutMs ?? 2_000;
+  const fetchImpl = (opts.fetchImpl ?? (globalThis.fetch as FetchLike)) as
+    | FetchLike
+    | undefined;
+  const start = Date.now();
+  if (!fetchImpl) {
+    return {
+      name: endpoint.name,
+      url: endpoint.url,
+      ok: false,
+      status: null,
+      error: 'no_fetch_impl',
+      elapsedMs: 0,
+    };
+  }
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(endpoint.url, { signal: ac.signal });
+    return {
+      name: endpoint.name,
+      url: endpoint.url,
+      ok: res.ok,
+      status: res.status,
+      error: res.ok ? null : `http_${res.status}`,
+      elapsedMs: Date.now() - start,
+    };
+  } catch (err) {
+    const msg =
+      err instanceof Error
+        ? err.name === 'AbortError'
+          ? `timeout_${timeoutMs}ms`
+          : err.message
+        : String(err);
+    return {
+      name: endpoint.name,
+      url: endpoint.url,
+      ok: false,
+      status: null,
+      error: msg,
+      elapsedMs: Date.now() - start,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkHealthzAll(
+  endpoints: readonly HealthzEndpoint[] = DEFAULT_HEALTHZ_ENDPOINTS,
+  opts: { timeoutMs?: number; fetchImpl?: FetchLike } = {},
+): Promise<HealthzCheckResult[]> {
+  return Promise.all(endpoints.map((e) => checkHealthz(e, opts)));
+}
+
+export function summarizeHealthz(results: HealthzCheckResult[]): string {
+  return results
+    .map((r) =>
+      r.ok
+        ? `${r.name}=OK(${r.status} ${r.elapsedMs}ms)`
+        : `${r.name}=FAIL(${r.error ?? 'unknown'})`,
+    )
+    .join(' ');
+}
+
 export interface RetryOptions {
   /** Per-attempt delays in milliseconds. Default [5_000, 15_000, 45_000]. */
   backoffMs?: number[];

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -27,9 +27,12 @@ import { dispatchPhase } from './runner.js';
 import { findPhase } from './spec.js';
 import {
   DEFAULT_BACKOFF_MS,
+  DEFAULT_HEALTHZ_ENDPOINTS,
+  checkHealthzAll,
   preflightAuditDetails,
   preflightSummary,
   retryWithBackoff,
+  summarizeHealthz,
   verifyBootstrap,
 } from './bootstrap.js';
 import {
@@ -38,6 +41,7 @@ import {
   recordStallDetected,
 } from './watchdog.js';
 import { appendAudit } from './audit.js';
+import { doctorExitCode, formatDoctorReport, runDoctor } from './doctor.js';
 import { spawnSync } from 'node:child_process';
 
 interface BaseOptions {
@@ -311,7 +315,7 @@ export function buildProgram(): Command {
 
   attachCommonOptions(program.command('verify-bootstrap'))
     .description(
-      'Block until a wake event lands in audit.jsonl or timeout. Use after registering a scheduled task to prove cron is firing.',
+      'Block until a wake event lands in audit.jsonl or timeout. Use after registering a scheduled task to prove cron is firing. Also pre-flights healthz of mentor + router; exits 3 if either is unhealthy.',
     )
     .option(
       '--wake-interval-sec <n>',
@@ -327,17 +331,58 @@ export function buildProgram(): Command {
       'how often to poll audit.jsonl (seconds)',
       '10',
     )
+    .option('--skip-healthz', 'skip mentor/router healthz pre-flight (CI / tests)')
+    .option(
+      '--healthz-timeout-ms <n>',
+      'per-endpoint healthz timeout (ms)',
+      '2000',
+    )
     .action(
       async (
         cmdOpts: {
           wakeIntervalSec?: string;
           maxWaitSec?: string;
           pollIntervalSec?: string;
+          skipHealthz?: boolean;
+          healthzTimeoutMs?: string;
         },
         cmd: Command,
       ) => {
         const opts = cmd.optsWithGlobals() as BaseOptions & typeof cmdOpts;
         const ctx = ctxFromOpts(opts);
+
+        // Healthz pre-flight: refuse to declare bootstrap healthy if either
+        // the mentor event-bus or the local-llm-router is dark. See
+        // src/bootstrap.ts:DEFAULT_HEALTHZ_ENDPOINTS for rationale.
+        if (!cmdOpts.skipHealthz) {
+          const timeoutMs = Number(cmdOpts.healthzTimeoutMs ?? '2000');
+          const results = await checkHealthzAll(DEFAULT_HEALTHZ_ENDPOINTS, {
+            timeoutMs,
+          });
+          const summary = summarizeHealthz(results);
+          process.stdout.write(`HEALTHZ ${summary}\n`);
+          appendAudit(ctx.paths.auditFile, 'preflight_healthz', {
+            ok: results.every((r) => r.ok),
+            results: results.map((r) => ({
+              name: r.name,
+              url: r.url,
+              ok: r.ok,
+              status: r.status,
+              error: r.error,
+              elapsed_ms: r.elapsedMs,
+            })),
+            stamped_at: new Date().toISOString(),
+          });
+          const failures = results.filter((r) => !r.ok);
+          if (failures.length > 0) {
+            const names = failures.map((r) => r.name).join(',');
+            process.stderr.write(
+              `HEALTHZ_FAIL endpoints=${names} — refusing to declare bootstrap healthy. See \`caia-chain doctor\` for diagnostics.\n`,
+            );
+            process.exit(3);
+          }
+        }
+
         const wakeInterval = Number(cmdOpts.wakeIntervalSec ?? '900');
         const maxWait = Number(cmdOpts.maxWaitSec ?? String(wakeInterval * 2));
         const pollInterval = Number(cmdOpts.pollIntervalSec ?? '10');
@@ -410,6 +455,29 @@ export function buildProgram(): Command {
         process.exit(4);
       },
     );
+
+  program
+    .command('doctor')
+    .description(
+      'On-demand health snapshot: node version, mentor/router healthz, launchd plist state for known labels, last_wake for each chain.',
+    )
+    .option(
+      '--healthz-timeout-ms <n>',
+      'per-endpoint healthz timeout (ms)',
+      '2000',
+    )
+    .option('--json', 'emit machine-readable JSON instead of the text table')
+    .action(async (cmdOpts: { healthzTimeoutMs?: string; json?: boolean }) => {
+      const report = await runDoctor({
+        healthzTimeoutMs: Number(cmdOpts.healthzTimeoutMs ?? '2000'),
+      });
+      if (cmdOpts.json) {
+        process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      } else {
+        process.stdout.write(`${formatDoctorReport(report)}\n`);
+      }
+      process.exit(doctorExitCode(report));
+    });
 
   program
     .command('retry-cmd')

--- a/packages/chain-runner/src/doctor.ts
+++ b/packages/chain-runner/src/doctor.ts
@@ -1,0 +1,246 @@
+// `caia-chain doctor` — operator-friendly health snapshot.
+//
+// Prints, in order:
+//   1. node version (which interpreter caia-chain itself is running under)
+//   2. healthz of mentor (5180) + local-llm-router (7411)
+//   3. launchctl print state of each known plist (label + state + last_exit_status)
+//   4. last_wake of each chain under ~/.caia/chain/*/state.json
+//
+// Designed for autonomous chains and human operators alike. Output is
+// plain text on stdout with one table per section. Doctor exits 0 if
+// every check passes, 1 if any check is degraded.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import {
+  DEFAULT_HEALTHZ_ENDPOINTS,
+  checkHealthzAll,
+  type HealthzCheckResult,
+} from './bootstrap.js';
+
+/**
+ * Known LaunchAgent labels managed by the CAIA stack. Doctor calls
+ * `launchctl print gui/<uid>/<label>` on each; missing labels are
+ * reported as "not_loaded" but do not fail the doctor (the operator
+ * may have intentionally unloaded one).
+ */
+export const KNOWN_PLIST_LABELS: readonly string[] = [
+  'com.caia.chain-watchdog',
+  'com.caia.handoff-refresh-hourly',
+  'com.caia.hygiene-audit-daily',
+  'com.caia.mentor.memory-watcher',
+  'com.caia.mentor.server',
+  'com.caia.pr-drainer-hourly',
+  'com.caia.redflag-wake',
+  'com.caia.stability-completion-wake',
+  'com.caia.tier25-wake',
+  'com.chiefaia.apprentice-corpus',
+  'com.chiefaia.apprentice-corpus-heartbeat',
+  'com.chiefaia.apprentice-retrainer',
+  'com.chiefaia.local-llm-router',
+  'com.chiefaia.sps-audit-recent-done-hourly',
+];
+
+export interface PlistState {
+  label: string;
+  loaded: boolean;
+  state: string | null;
+  lastExitStatus: number | null;
+  raw: string;
+}
+
+export interface ChainWakeState {
+  chainId: string;
+  lastWake: string | null;
+  currentPhase: number | null;
+  paused: boolean | null;
+  allDone: boolean | null;
+}
+
+export interface DoctorReport {
+  nodeVersion: string;
+  nodeBin: string;
+  healthz: HealthzCheckResult[];
+  plists: PlistState[];
+  chains: ChainWakeState[];
+}
+
+function runLaunchctlPrint(label: string, uid: number): string {
+  const out = spawnSync('/bin/launchctl', ['print', `gui/${uid}/${label}`], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+  if (out.status !== 0) return '';
+  return out.stdout ?? '';
+}
+
+export function parseLaunchctlPrint(raw: string): {
+  state: string | null;
+  lastExitStatus: number | null;
+} {
+  if (!raw) return { state: null, lastExitStatus: null };
+  // launchctl print emits lines like `state = waiting` and
+  // `last exit code = 0` (or `last exit status = -1`).
+  let state: string | null = null;
+  let lastExitStatus: number | null = null;
+  for (const line of raw.split('\n')) {
+    const s = line.trim();
+    if (state === null && s.startsWith('state ')) {
+      const m = /state\s*=\s*(.+)$/.exec(s);
+      if (m && m[1]) state = m[1].trim();
+    }
+    if (lastExitStatus === null) {
+      const m =
+        /last exit (?:status|code)\s*=\s*(-?\d+)/.exec(s) ??
+        /last exit reason\s*=\s*(-?\d+)/.exec(s);
+      if (m && m[1]) lastExitStatus = Number(m[1]);
+    }
+  }
+  return { state, lastExitStatus };
+}
+
+export function inspectPlist(label: string, uid: number = process.getuid?.() ?? 501): PlistState {
+  const raw = runLaunchctlPrint(label, uid);
+  const loaded = raw.length > 0;
+  const parsed = parseLaunchctlPrint(raw);
+  return {
+    label,
+    loaded,
+    state: parsed.state,
+    lastExitStatus: parsed.lastExitStatus,
+    raw,
+  };
+}
+
+export function readChainWakes(chainRoot: string = join(homedir(), '.caia', 'chain')): ChainWakeState[] {
+  if (!existsSync(chainRoot)) return [];
+  const out: ChainWakeState[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(chainRoot);
+  } catch {
+    return [];
+  }
+  for (const name of entries) {
+    const dir = join(chainRoot, name);
+    let isDir: boolean;
+    try {
+      isDir = statSync(dir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    const stateFile = join(dir, 'state.json');
+    if (!existsSync(stateFile)) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(readFileSync(stateFile, 'utf8')) as Record<string, unknown>;
+    } catch {
+      out.push({
+        chainId: name,
+        lastWake: null,
+        currentPhase: null,
+        paused: null,
+        allDone: null,
+      });
+      continue;
+    }
+    out.push({
+      chainId: name,
+      lastWake: (parsed['last_wake'] as string | null | undefined) ?? null,
+      currentPhase:
+        typeof parsed['current_phase'] === 'number'
+          ? (parsed['current_phase'] as number)
+          : null,
+      paused: typeof parsed['paused'] === 'boolean' ? (parsed['paused'] as boolean) : null,
+      allDone:
+        typeof parsed['all_done'] === 'boolean' ? (parsed['all_done'] as boolean) : null,
+    });
+  }
+  out.sort((a, b) => a.chainId.localeCompare(b.chainId));
+  return out;
+}
+
+export async function runDoctor(opts: {
+  uid?: number;
+  chainRoot?: string;
+  healthzTimeoutMs?: number;
+  plistLabels?: readonly string[];
+} = {}): Promise<DoctorReport> {
+  const uid = opts.uid ?? process.getuid?.() ?? 501;
+  const labels = opts.plistLabels ?? KNOWN_PLIST_LABELS;
+  const healthz = await checkHealthzAll(DEFAULT_HEALTHZ_ENDPOINTS, {
+    timeoutMs: opts.healthzTimeoutMs ?? 2_000,
+  });
+  const plists = labels.map((l) => inspectPlist(l, uid));
+  const chains = readChainWakes(opts.chainRoot);
+  return {
+    nodeVersion: process.version,
+    nodeBin: process.execPath,
+    healthz,
+    plists,
+    chains,
+  };
+}
+
+function pad(s: string, w: number): string {
+  if (s.length >= w) return s;
+  return s + ' '.repeat(w - s.length);
+}
+
+export function formatDoctorReport(r: DoctorReport): string {
+  const lines: string[] = [];
+  lines.push('# node');
+  lines.push(`  version: ${r.nodeVersion}`);
+  lines.push(`  bin:     ${r.nodeBin}`);
+  lines.push('');
+  lines.push('# healthz');
+  for (const h of r.healthz) {
+    const status = h.ok ? 'OK' : 'FAIL';
+    const detail = h.ok
+      ? `http=${h.status} elapsed_ms=${h.elapsedMs}`
+      : `error=${h.error ?? 'unknown'}`;
+    lines.push(`  ${pad(h.name, 8)} ${pad(status, 4)} ${pad(h.url, 38)} ${detail}`);
+  }
+  lines.push('');
+  lines.push('# launchd plists');
+  lines.push(
+    `  ${pad('label', 50)} ${pad('loaded', 8)} ${pad('state', 16)} ${pad('last_exit', 10)}`,
+  );
+  for (const p of r.plists) {
+    lines.push(
+      `  ${pad(p.label, 50)} ${pad(p.loaded ? 'yes' : 'no', 8)} ${pad(
+        p.state ?? '-',
+        16,
+      )} ${pad(p.lastExitStatus === null ? '-' : String(p.lastExitStatus), 10)}`,
+    );
+  }
+  lines.push('');
+  lines.push('# chains');
+  if (r.chains.length === 0) {
+    lines.push('  (none)');
+  } else {
+    lines.push(
+      `  ${pad('chain_id', 40)} ${pad('current_phase', 14)} ${pad('paused', 7)} ${pad('all_done', 9)} last_wake`,
+    );
+    for (const c of r.chains) {
+      lines.push(
+        `  ${pad(c.chainId, 40)} ${pad(
+          c.currentPhase === null ? '-' : String(c.currentPhase),
+          14,
+        )} ${pad(c.paused === null ? '-' : String(c.paused), 7)} ${pad(
+          c.allDone === null ? '-' : String(c.allDone),
+          9,
+        )} ${c.lastWake ?? 'never'}`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+export function doctorExitCode(r: DoctorReport): number {
+  if (r.healthz.some((h) => !h.ok)) return 1;
+  return 0;
+}

--- a/packages/chain-runner/tests/doctor.test.ts
+++ b/packages/chain-runner/tests/doctor.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  formatDoctorReport,
+  parseLaunchctlPrint,
+  readChainWakes,
+  type DoctorReport,
+} from '../src/doctor.js';
+
+describe('parseLaunchctlPrint', () => {
+  it('extracts state + last exit status from a typical launchctl print dump', () => {
+    const raw = [
+      'com.caia.mentor.server = {',
+      '\ttype = LaunchAgent',
+      '\tstate = running',
+      '\tprogram = /opt/homebrew/opt/node@22/bin/node',
+      '\tlast exit code = 0',
+      '\tpid = 12345',
+      '}',
+    ].join('\n');
+    const parsed = parseLaunchctlPrint(raw);
+    expect(parsed.state).toBe('running');
+    expect(parsed.lastExitStatus).toBe(0);
+  });
+
+  it('handles "last exit status = -1" (signalled exit)', () => {
+    const raw = ['\tstate = waiting', '\tlast exit status = -1'].join('\n');
+    expect(parseLaunchctlPrint(raw).lastExitStatus).toBe(-1);
+  });
+
+  it('returns nulls for empty output (unloaded service)', () => {
+    expect(parseLaunchctlPrint('')).toEqual({
+      state: null,
+      lastExitStatus: null,
+    });
+  });
+});
+
+describe('readChainWakes', () => {
+  it('returns one entry per chain, sorted by chain id', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-'));
+    const chainRoot = join(root, 'chain');
+    mkdirSync(join(chainRoot, 'zeta'), { recursive: true });
+    mkdirSync(join(chainRoot, 'alpha'), { recursive: true });
+    writeFileSync(
+      join(chainRoot, 'alpha', 'state.json'),
+      JSON.stringify({
+        last_wake: '2026-05-14T01:00:00Z',
+        current_phase: 3,
+        paused: false,
+        all_done: false,
+      }),
+    );
+    writeFileSync(
+      join(chainRoot, 'zeta', 'state.json'),
+      JSON.stringify({
+        last_wake: null,
+        current_phase: null,
+        paused: false,
+        all_done: true,
+      }),
+    );
+    const wakes = readChainWakes(chainRoot);
+    expect(wakes.map((w) => w.chainId)).toEqual(['alpha', 'zeta']);
+    expect(wakes[0]?.lastWake).toBe('2026-05-14T01:00:00Z');
+    expect(wakes[0]?.currentPhase).toBe(3);
+    expect(wakes[1]?.allDone).toBe(true);
+  });
+
+  it('returns [] when chain root does not exist', () => {
+    expect(readChainWakes(join(tmpdir(), 'definitely-not-real-xyz'))).toEqual([]);
+  });
+
+  it('skips directories with no state.json', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-empty-'));
+    const chainRoot = join(root, 'chain');
+    mkdirSync(join(chainRoot, 'empty-chain'), { recursive: true });
+    expect(readChainWakes(chainRoot)).toEqual([]);
+  });
+});
+
+describe('formatDoctorReport', () => {
+  it('renders all four sections in order', () => {
+    const r: DoctorReport = {
+      nodeVersion: 'v22.22.2',
+      nodeBin: '/opt/homebrew/opt/node@22/bin/node',
+      healthz: [
+        {
+          name: 'mentor',
+          url: 'http://127.0.0.1:5180/v1/healthz',
+          ok: true,
+          status: 200,
+          error: null,
+          elapsedMs: 12,
+        },
+        {
+          name: 'router',
+          url: 'http://127.0.0.1:7411/healthz',
+          ok: false,
+          status: null,
+          error: 'ECONNREFUSED',
+          elapsedMs: 5,
+        },
+      ],
+      plists: [
+        {
+          label: 'com.caia.mentor.server',
+          loaded: true,
+          state: 'running',
+          lastExitStatus: 0,
+          raw: '',
+        },
+      ],
+      chains: [
+        {
+          chainId: 'redflag-remediation',
+          lastWake: '2026-05-14T00:00:00Z',
+          currentPhase: 3,
+          paused: false,
+          allDone: false,
+        },
+      ],
+    };
+    const out = formatDoctorReport(r);
+    expect(out).toMatch(/# node/);
+    expect(out).toMatch(/v22\.22\.2/);
+    expect(out).toMatch(/# healthz/);
+    expect(out).toMatch(/mentor.*OK/);
+    expect(out).toMatch(/router.*FAIL/);
+    expect(out).toMatch(/ECONNREFUSED/);
+    expect(out).toMatch(/# launchd plists/);
+    expect(out).toMatch(/com\.caia\.mentor\.server/);
+    expect(out).toMatch(/# chains/);
+    expect(out).toMatch(/redflag-remediation/);
+  });
+});

--- a/packages/chain-runner/tests/healthz.test.ts
+++ b/packages/chain-runner/tests/healthz.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkHealthz,
+  checkHealthzAll,
+  summarizeHealthz,
+  type FetchLike,
+} from '../src/bootstrap.js';
+
+const okFetch: FetchLike = async (url) => ({ ok: true, status: 200 });
+const fail500: FetchLike = async () => ({ ok: false, status: 500 });
+
+describe('checkHealthz', () => {
+  it('reports ok=true on 2xx', async () => {
+    const r = await checkHealthz(
+      { name: 'mentor', url: 'http://127.0.0.1:5180/v1/healthz' },
+      { fetchImpl: okFetch },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.error).toBeNull();
+  });
+
+  it('reports ok=false with http_<status> error on non-2xx', async () => {
+    const r = await checkHealthz(
+      { name: 'router', url: 'http://127.0.0.1:7411/healthz' },
+      { fetchImpl: fail500 },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(500);
+    expect(r.error).toBe('http_500');
+  });
+
+  it('reports timeout when fetch never resolves', async () => {
+    const hangingFetch: FetchLike = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    const r = await checkHealthz(
+      { name: 'mentor', url: 'http://127.0.0.1:5180/v1/healthz' },
+      { timeoutMs: 25, fetchImpl: hangingFetch },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('timeout_25ms');
+  });
+
+  it('reports refused error message verbatim', async () => {
+    const refusedFetch: FetchLike = async () => {
+      throw new Error('ECONNREFUSED 127.0.0.1:7411');
+    };
+    const r = await checkHealthz(
+      { name: 'router', url: 'http://127.0.0.1:7411/healthz' },
+      { fetchImpl: refusedFetch },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('ECONNREFUSED');
+  });
+});
+
+describe('checkHealthzAll + summarizeHealthz', () => {
+  it('returns one result per endpoint in declaration order', async () => {
+    const results = await checkHealthzAll(
+      [
+        { name: 'a', url: 'http://x/a' },
+        { name: 'b', url: 'http://x/b' },
+      ],
+      { fetchImpl: okFetch },
+    );
+    expect(results.map((r) => r.name)).toEqual(['a', 'b']);
+    expect(results.every((r) => r.ok)).toBe(true);
+  });
+
+  it('summary renders OK + FAIL legibly', async () => {
+    const ab: FetchLike = async (url) =>
+      url.endsWith('/a')
+        ? { ok: true, status: 200 }
+        : { ok: false, status: 503 };
+    const results = await checkHealthzAll(
+      [
+        { name: 'mentor', url: 'http://x/a' },
+        { name: 'router', url: 'http://x/b' },
+      ],
+      { fetchImpl: ab },
+    );
+    const s = summarizeHealthz(results);
+    expect(s).toMatch(/mentor=OK\(200/);
+    expect(s).toMatch(/router=FAIL\(http_503\)/);
+  });
+});

--- a/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
+++ b/packages/local-llm-router/plists/com.chiefaia.local-llm-router.plist
@@ -31,6 +31,8 @@
 
   <key>EnvironmentVariables</key>
   <dict>
+    <key>CAIA_NODE_BIN</key>
+    <string>/opt/homebrew/opt/node@22/bin/node</string>
     <key>OLLAMA_BASE_URL</key>
     <string>http://127.0.0.1:11434</string>
     <key>ROUTER_CLASSIFIER_MODEL</key>

--- a/packages/mentor-event-bus/plists/com.caia.mentor.memory-watcher.plist
+++ b/packages/mentor-event-bus/plists/com.caia.mentor.memory-watcher.plist
@@ -37,6 +37,8 @@
         <string>__USER_HOME__</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CAIA_NODE_BIN</key>
+        <string>__NODE_BIN__</string>
         <key>CAIA_EVENT_BUS_DB_PATH</key>
         <string>__EVENTS_DB_PATH__</string>
         <key>CAIA_MEMORY_DIR</key>

--- a/packages/mentor-event-bus/plists/com.caia.mentor.server.plist
+++ b/packages/mentor-event-bus/plists/com.caia.mentor.server.plist
@@ -42,6 +42,8 @@
         <string>__USER_HOME__</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CAIA_NODE_BIN</key>
+        <string>__NODE_BIN__</string>
         <key>CAIA_EVENT_BUS_DB_PATH</key>
         <string>__EVENTS_DB_PATH__</string>
         <key>CAIA_EVENT_BUS_SECRET_PATH</key>

--- a/packages/mentor-event-bus/scripts/install.sh
+++ b/packages/mentor-event-bus/scripts/install.sh
@@ -59,25 +59,14 @@ if [[ ! -d "${MEMORY_DIR}" ]]; then
     exit 2
 fi
 
-# Resolve node binary path.
+# Refuse to install if node major version doesn't match expected (default 22).
 # The native better-sqlite3 binary in this repo's pnpm store is built against
-# Node 22 (NODE_MODULE_VERSION 127). Prefer node@22 when available so the
-# LaunchAgent doesn't ABI-fail under newer Homebrew node. CAIA_NODE_BIN overrides.
-if [[ -n "${CAIA_NODE_BIN:-}" && -x "${CAIA_NODE_BIN}" ]]; then
-    NODE_BIN="${CAIA_NODE_BIN}"
-elif [[ -x /opt/homebrew/opt/node@22/bin/node ]]; then
-    NODE_BIN="/opt/homebrew/opt/node@22/bin/node"
-elif [[ -x /opt/homebrew/bin/node ]]; then
-    NODE_BIN="/opt/homebrew/bin/node"
-elif [[ -x /usr/local/bin/node ]]; then
-    NODE_BIN="/usr/local/bin/node"
-else
-    NODE_BIN="$(command -v node || true)"
-    if [[ -z "${NODE_BIN}" ]]; then
-        echo "ERROR: node not found." >&2
-        exit 2
-    fi
-fi
+# Node 22 (NODE_MODULE_VERSION 127); loading it under a different major
+# silently crashes the mentor-server at require() time (3-day outage on
+# 2026-05-13). See scripts/lib/check-node-version.sh.
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 # ─── Secret provisioning ────────────────────────────────────────────────────
 mkdir -p "$(dirname "${SECRET_PATH}")"

--- a/packages/mentor-fastpath/scripts/install-postmerge.sh
+++ b/packages/mentor-fastpath/scripts/install-postmerge.sh
@@ -65,11 +65,10 @@ if [[ ! -f "${WATCHER_DIST}" ]] || [[ ! -f "${CONSUMER_DIST}" ]]; then
     exit 2
 fi
 
-NODE_BIN="$(command -v node || true)"
-if [[ -z "${NODE_BIN}" ]]; then
-    echo "ERROR: 'node' not found on PATH." >&2
-    exit 2
-fi
+# Refuse to install if node major doesn't match expected (default 22).
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 # ─── Prepare host filesystem ────────────────────────────────────────────────
 mkdir -p "${LA_DIR}" "${LOG_DIR}" "${MEMORY_DIR}/proposals"

--- a/packages/mentor-fastpath/scripts/install.sh
+++ b/packages/mentor-fastpath/scripts/install.sh
@@ -71,18 +71,10 @@ if [[ ! -f "${DB_PATH}" ]]; then
     echo "  mentor-event-bus is installed and produces events." >&2
 fi
 
-# Resolve node binary path (mirror mentor-event-bus install.sh logic).
-if [[ -x /opt/homebrew/bin/node ]]; then
-    NODE_BIN="/opt/homebrew/bin/node"
-elif [[ -x /usr/local/bin/node ]]; then
-    NODE_BIN="/usr/local/bin/node"
-else
-    NODE_BIN="$(command -v node || true)"
-    if [[ -z "${NODE_BIN}" ]]; then
-        echo "ERROR: node not found." >&2
-        exit 2
-    fi
-fi
+# Refuse to install if node major doesn't match expected (default 22).
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/check-node-version.sh"
+NODE_BIN="$(check_node_version)"
 
 # ─── Setup directories ──────────────────────────────────────────────────────
 mkdir -p "${LA_DIR}" "${LOG_DIR}" "${MEMORY_DIR}/proposals"

--- a/scripts/lib/check-node-version.sh
+++ b/scripts/lib/check-node-version.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# scripts/lib/check-node-version.sh
+#
+# Shared LaunchAgent install guard: refuse to install if the resolved
+# node binary doesn't match the expected major version. Prevents the
+# 2026-05-13 mentor-event-bus failure mode (better-sqlite3 native
+# binary compiled for node@22, but launchd invoked node@26 → silent
+# crash; event bus dark for 3 days).
+#
+# Usage:
+#   # shellcheck source=/dev/null
+#   source "$(dirname "${BASH_SOURCE[0]}")/../../scripts/lib/check-node-version.sh"
+#   NODE_BIN="$(check_node_version)"   # exits 4 on mismatch
+#
+# Or call directly with an explicit binary:
+#   check_node_version /opt/homebrew/opt/node@22/bin/node
+#
+# Resolution order (when no arg given):
+#   1. $CAIA_NODE_BIN (explicit operator override)
+#   2. /opt/homebrew/opt/node@22/bin/node (the pinned default)
+#   3. $(command -v node) (fall-back; will likely be rejected)
+#
+# Expected major version: 22 (CAIA_EXPECTED_NODE_MAJOR overrides).
+#
+# Exit codes:
+#   0  node binary resolved and matches expected major
+#   4  refused: missing binary or major version mismatch
+
+CAIA_EXPECTED_NODE_MAJOR="${CAIA_EXPECTED_NODE_MAJOR:-22}"
+
+check_node_version() {
+    local node_bin="${1:-}"
+
+    if [[ -z "$node_bin" ]]; then
+        if [[ -n "${CAIA_NODE_BIN:-}" ]]; then
+            node_bin="$CAIA_NODE_BIN"
+        elif [[ -x /opt/homebrew/opt/node@22/bin/node ]]; then
+            node_bin="/opt/homebrew/opt/node@22/bin/node"
+        else
+            node_bin="$(command -v node || true)"
+        fi
+    fi
+
+    if [[ -z "$node_bin" || ! -x "$node_bin" ]]; then
+        echo "ERROR: node binary not found / not executable: '${node_bin}'" >&2
+        echo "  Install node@22 (brew install node@22) or set CAIA_NODE_BIN." >&2
+        exit 4
+    fi
+
+    local raw
+    if ! raw="$("$node_bin" --version 2>/dev/null)"; then
+        echo "ERROR: failed to run '$node_bin --version'" >&2
+        exit 4
+    fi
+
+    # raw is e.g. "v22.22.2"
+    local major="${raw#v}"
+    major="${major%%.*}"
+
+    if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: could not parse major version from '$raw' (binary=$node_bin)" >&2
+        exit 4
+    fi
+
+    if (( major != CAIA_EXPECTED_NODE_MAJOR )); then
+        echo "ERROR: node major version mismatch — refusing to install LaunchAgent." >&2
+        echo "  binary:   $node_bin" >&2
+        echo "  version:  $raw (major=$major)" >&2
+        echo "  expected: major=$CAIA_EXPECTED_NODE_MAJOR" >&2
+        echo "" >&2
+        echo "  Why: native modules in this repo's pnpm store (e.g. better-sqlite3)" >&2
+        echo "  are compiled for Node ${CAIA_EXPECTED_NODE_MAJOR}. Loading them under" >&2
+        echo "  a different major silently crashes the daemon at require() time." >&2
+        echo "  See ~/Documents/projects/reports/apprentice_gap_fix_2026-05-13.md." >&2
+        echo "" >&2
+        echo "  Fix one of:" >&2
+        echo "    - export CAIA_NODE_BIN=/opt/homebrew/opt/node@${CAIA_EXPECTED_NODE_MAJOR}/bin/node" >&2
+        echo "    - brew install node@${CAIA_EXPECTED_NODE_MAJOR}" >&2
+        exit 4
+    fi
+
+    echo "$node_bin"
+}


### PR DESCRIPTION
## Summary
Prevents the 2026-05-13 mentor event-bus failure mode (better-sqlite3 ABI mismatch silently dark for 3 days) with three CI guards:

- **`CAIA_NODE_BIN` pinned on every LaunchAgent plist** (source templates + live `~/Library/LaunchAgents/` patched). 14/14 plists carry `/opt/homebrew/opt/node@22/bin/node`.
- **`caia-chain verify-bootstrap` healthz pre-flight.** Hits `5180/v1/healthz` (mentor) + `7411/healthz` (router) with 2s timeout. Failures stamp `preflight_healthz {ok:false,…}` in audit.jsonl and exit **3** with a clear `HEALTHZ_FAIL …` message.
- **Shared `scripts/lib/check-node-version.sh`** sourced by every install script: refuses with exit **4** if the resolved node major ≠ `CAIA_EXPECTED_NODE_MAJOR` (default 22). Wired into 7 install scripts.
- **New `caia-chain doctor`** subcommand emits node version, mentor/router healthz, launchd state of 14 known plists, and `last_wake`/`current_phase` of every chain. `--json` mode for hygiene-audit ingestion.

Closes Red Flag #3 from `~/Documents/projects/reports/redflag_remediation_plan_2026-05-13.md`.

## Test plan
- [x] `pnpm --filter @chiefaia/chain-runner test` — 118 passing (13 new: 6 healthz + 7 doctor)
- [x] `pnpm --filter @chiefaia/chain-runner lint` — clean
- [x] `pnpm --filter @chiefaia/chain-runner typecheck` — clean
- [x] `plutil -lint` on all 14 patched live plists — clean
- [x] Smoke `caia-chain doctor` — emits 4 sections, exits 0 with healthy daemons
- [x] Smoke `caia-chain verify-bootstrap --healthz-timeout-ms 1` — exits 3 with `HEALTHZ_FAIL endpoints=mentor,router`
- [x] Manual test wrong-node refusal: `CAIA_NODE_BIN=/opt/homebrew/bin/node CAIA_DRY_INSTALL=1 bash packages/apprentice-retrainer/scripts/install-apprentice-retrainer.sh` → exit 4 with remediation

Full report: `~/Documents/projects/reports/mentor_ci_guard_2026-05-14.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)