### PR TITLE
feat(chain-runner): event-triggered SESSION_HANDOFF.md refresh (red-flag #8)

### DIFF
--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -42,6 +42,7 @@ import {
 } from './watchdog.js';
 import { appendAudit } from './audit.js';
 import { doctorExitCode, formatDoctorReport, runDoctor } from './doctor.js';
+import { fireHandoffRefresh } from './handoff-refresh.js';
 import { spawnSync } from 'node:child_process';
 
 interface BaseOptions {
@@ -175,6 +176,11 @@ export function buildProgram(): Command {
       const ctx = ctxFromOpts(opts);
       markDone(ctx, phaseId);
       clearLock(ctx);
+      // Event-triggered SESSION_HANDOFF.md refresh closes the staleness gap
+      // between hourly cron ticks (red-flag-remediation phase 5, 2026-05-14).
+      fireHandoffRefresh({
+        triggeredBy: `chain-phase-done-${opts.chainId}-${phaseId}`,
+      });
     });
 
   attachCommonOptions(program.command('mark-failed'))

--- a/packages/chain-runner/src/handoff-refresh.ts
+++ b/packages/chain-runner/src/handoff-refresh.ts
@@ -1,0 +1,60 @@
+// Fire-and-forget hook to refresh SESSION_HANDOFF.md when a chain-runner event
+// occurs that materially changes repo or chain state (PR merge, phase done).
+//
+// Rationale: SESSION_HANDOFF.md is the KT brief for new agents. A pure
+// time-based cron (hourly) leaves a staleness window during which multiple
+// merges/phase completions can land between refreshes. Firing event-triggered
+// refreshes closes that gap.
+//
+// Constraints:
+// - MUST NOT block the caller. The refresh script does network IO (gh api);
+//   we detach it.
+// - MUST NOT throw — if the helper is missing or fails, that's a soft failure;
+//   the cron will still refresh on its next tick.
+// - The triggered-by reason is forwarded to the script so the resulting banner
+//   says exactly what fired the refresh (e.g. `pr-merged-prakashgbid/caia#434`,
+//   `chain-phase-done-redflag-remediation-5`).
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const DEFAULT_REFRESH_SCRIPT = join(
+  homedir(),
+  '.caia',
+  'handoff',
+  'refresh_handoff.sh',
+);
+
+export interface FireHandoffRefreshOpts {
+  triggeredBy: string;
+  scriptPath?: string;
+  enabled?: boolean; // default true; set false to no-op in tests
+}
+
+export function fireHandoffRefresh(opts: FireHandoffRefreshOpts): void {
+  if (opts.enabled === false) return;
+  if (process.env.CAIA_DISABLE_HANDOFF_REFRESH === '1') return;
+
+  const script = opts.scriptPath ?? DEFAULT_REFRESH_SCRIPT;
+  if (!existsSync(script)) {
+    // Soft failure: cron remains the safety net.
+    return;
+  }
+
+  const reason = (opts.triggeredBy || 'unspecified')
+    .replace(/[\r\n]/g, ' ')
+    .slice(0, 120);
+
+  try {
+    const child = spawn('/bin/bash', [script, '--triggered-by', reason], {
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    child.unref();
+  } catch {
+    // Never throw from the hook.
+  }
+}

--- a/packages/chain-runner/src/pr-merge/index.ts
+++ b/packages/chain-runner/src/pr-merge/index.ts
@@ -19,6 +19,7 @@ import { spawnSync } from 'node:child_process';
 import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { fireHandoffRefresh } from '../handoff-refresh.js';
 
 export interface MergeOrFailOpts {
   repo: string; // OWNER/REPO
@@ -366,6 +367,9 @@ export async function mergeOrFail(
         mergedAt: st.mergedAt,
       });
       postMergeSweep(st.headRefName, opts.workdir);
+      fireHandoffRefresh({
+        triggeredBy: `pr-merged-${opts.repo}#${opts.pr}`,
+      });
       return {
         kind: 'merged',
         pr: opts.pr,
@@ -480,6 +484,9 @@ export async function mergeOrFail(
             mergedAt: verify.mergedAt,
             bypassed: false,
           });
+          fireHandoffRefresh({
+            triggeredBy: `pr-merged-${opts.repo}#${opts.pr}`,
+          });
           return {
             kind: 'merged',
             pr: opts.pr,
@@ -547,6 +554,9 @@ export async function mergeOrFail(
             pr: opts.pr,
             mergedAt: verify.mergedAt,
             bypassed: true,
+          });
+          fireHandoffRefresh({
+            triggeredBy: `pr-merged-${opts.repo}#${opts.pr}`,
           });
           return {
             kind: 'merged',

--- a/packages/chain-runner/tests/handoff-refresh.test.ts
+++ b/packages/chain-runner/tests/handoff-refresh.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fireHandoffRefresh } from '../src/handoff-refresh.js';
+
+function waitForFile(path: string, timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      if (existsSync(path)) return resolve();
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`timeout waiting for ${path}`));
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+}
+
+describe('fireHandoffRefresh', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'handoff-refresh-'));
+  });
+
+  it('no-ops silently when the refresh script does not exist', () => {
+    const missing = join(tmp, 'does-not-exist.sh');
+    expect(() =>
+      fireHandoffRefresh({ triggeredBy: 'test', scriptPath: missing }),
+    ).not.toThrow();
+  });
+
+  it('no-ops when enabled=false', () => {
+    const script = join(tmp, 'should-not-run.sh');
+    writeFileSync(script, '#!/bin/bash\ntouch ' + join(tmp, 'ran') + '\n', {
+      mode: 0o755,
+    });
+    fireHandoffRefresh({
+      triggeredBy: 'test',
+      scriptPath: script,
+      enabled: false,
+    });
+    // give the (non-spawned) process a tick
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(existsSync(join(tmp, 'ran'))).toBe(false);
+        resolve();
+      }, 100);
+    });
+  });
+
+  it('spawns the script detached with --triggered-by forwarded', async () => {
+    const script = join(tmp, 'recorder.sh');
+    const outFile = join(tmp, 'reason.txt');
+    // Script writes its second arg ($2) — the reason — to a file we can assert on.
+    writeFileSync(
+      script,
+      `#!/bin/bash\n` +
+        `if [ "$1" = "--triggered-by" ]; then echo "$2" > "${outFile}"; fi\n`,
+      { mode: 0o755 },
+    );
+    fireHandoffRefresh({
+      triggeredBy: 'pr-merged-foo/bar#123',
+      scriptPath: script,
+    });
+    await waitForFile(outFile);
+    expect(readFileSync(outFile, 'utf8').trim()).toBe(
+      'pr-merged-foo/bar#123',
+    );
+  });
+
+  it('truncates a too-long reason to 120 chars and strips newlines', async () => {
+    const script = join(tmp, 'recorder.sh');
+    const outFile = join(tmp, 'reason.txt');
+    writeFileSync(
+      script,
+      `#!/bin/bash\n` +
+        `if [ "$1" = "--triggered-by" ]; then echo "$2" > "${outFile}"; fi\n`,
+      { mode: 0o755 },
+    );
+    const long = 'a'.repeat(200);
+    fireHandoffRefresh({
+      triggeredBy: long + '\nINJECT',
+      scriptPath: script,
+    });
+    await waitForFile(outFile);
+    const got = readFileSync(outFile, 'utf8').trim();
+    // Newlines replaced with spaces, then sliced to 120.
+    expect(got.length).toBe(120);
+    expect(got.includes('\n')).toBe(false);
+  });
+
+  it('honors CAIA_DISABLE_HANDOFF_REFRESH=1', () => {
+    const script = join(tmp, 'should-not-run.sh');
+    const marker = join(tmp, 'ran');
+    writeFileSync(script, `#!/bin/bash\ntouch "${marker}"\n`, { mode: 0o755 });
+    const prev = process.env.CAIA_DISABLE_HANDOFF_REFRESH;
+    process.env.CAIA_DISABLE_HANDOFF_REFRESH = '1';
+    try {
+      fireHandoffRefresh({ triggeredBy: 'test', scriptPath: script });
+    } finally {
+      if (prev === undefined) delete process.env.CAIA_DISABLE_HANDOFF_REFRESH;
+      else process.env.CAIA_DISABLE_HANDOFF_REFRESH = prev;
+    }
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(existsSync(marker)).toBe(false);
+        resolve();
+      }, 100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the staleness window in `SESSION_HANDOFF.md` (red flag #8 of the
2026-05-13 remediation plan). The previous hourly cron leaves a gap
during which multiple PR merges and chain-phase completions can land
between ticks; operators switching accounts have read stale handoff
briefs as a result.

- Add `packages/chain-runner/src/handoff-refresh.ts` — small fire-and-forget helper that detaches `~/.caia/handoff/refresh_handoff.sh` with a `--triggered-by` reason. Never throws. `CAIA_DISABLE_HANDOFF_REFRESH=1` opt-out for tests / CI.
- `pr-merge/index.ts`: call `fireHandoffRefresh` on every `merged` outcome (plain merge, admin-bypass merge, already-merged sweep).
- `cli.ts`: call `fireHandoffRefresh` from `caia-chain mark-done` so any chain phase completion stamps the handoff banner.
- 5 new vitest cases (missing-script, disabled, arg forwarding, reason truncation, env-var opt-out). All 123 tests pass.

A companion shell change (`~/.caia/handoff/refresh_handoff.sh`, outside this repo) adds the `--triggered-by` arg, writes a freshness banner with ISO timestamp + reason + caia/stolution develop SHAs + a 30-min staleness directive.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 123/123 green (handoff-refresh.test.ts: 5/5)
- [x] Smoke: `caia-chain mark-done` against a throwaway chain fires the script with `--triggered-by chain-phase-done-<chain>-<phase>`
- [x] Smoke: direct call to `fireHandoffRefresh` updates SESSION_HANDOFF.md banner with reason + SHAs within 1s
- [ ] End-to-end PR merge of this PR itself: SESSION_HANDOFF.md timestamp updates within 30s and banner shows `pr-merged-prakashgbid/caia#<n>`

## Red flag

#8 — SESSION_HANDOFF.md stale. Per `~/Documents/projects/reports/redflag_remediation_plan_2026-05-13.md` §Red Flag #8: recommended path A+B (post-merge + post-phase-done hooks + freshness banner).

## Chain

`redflag-remediation` phase 5 (`handoff_refresh_hardening`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)