### PR TITLE
feat(chain-runner): h-1 failure classification + d-1 auto-resolve + autonomy header

### DIFF
--- a/packages/chain-runner/src/classify.ts
+++ b/packages/chain-runner/src/classify.ts
@@ -1,0 +1,315 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { isoNow } from './time.js';
+import { findPhase } from './spec.js';
+import type { StateContext } from './state.js';
+import type { FailureClass, LockFile, PhaseFailure } from './types.js';
+
+// H-1 (chain-runner-battle-harden phase 2, 2026-05-14). Classifies a stale
+// worker into a FailureClass by sniffing its dispatch log + checking artifact
+// presence. Maps to gap-analysis §1.1 F-01..F-15 and the three overnight
+// incidents documented in reports/overnight_incidents_2026-05-14.md:
+//   - incident #1 (phase 3 hang after artifact write) → worker_hung_post_success
+//   - incident #2 (phase 7 rate-limit at spawn) → worker_no_start_rate_limit
+//   - incident #3 (silent stall variant) → worker_hung_mid_work
+
+const LOG_SNIFF_MAX_BYTES = 256 * 1024;
+
+// Patterns keyed by failure class. Order matters: rate-limit first because
+// the limit banner is the most specific (and is the literal string the
+// claude CLI prints on cap exhaustion).
+const LOG_PATTERNS: Array<{
+  class: FailureClass;
+  pattern: RegExp;
+  describe: (m: RegExpExecArray) => string;
+}> = [
+  {
+    class: 'worker_no_start_rate_limit',
+    pattern: /You(?:'|’)ve hit your limit(?:[^\n]*?resets ([^\n]+))?/i,
+    describe: (m) => {
+      const reset = m[1]?.trim();
+      return reset
+        ? `rate limit hit; resets ${reset}`
+        : 'rate limit hit (no reset time captured)';
+    },
+  },
+  {
+    class: 'worker_no_start_auth_failure',
+    pattern:
+      /Invalid authentication credentials|API Error 401|Unauthorized: invalid (?:api )?key|authentication_error/i,
+    describe: () => 'authentication failure (token rejected by API)',
+  },
+  {
+    class: 'worker_no_start_binary_missing',
+    pattern:
+      /command not found|claude: No such file|No such file or directory.*claude|ENOENT.*claude/i,
+    describe: () => 'claude binary missing or not on PATH',
+  },
+  {
+    class: 'worker_no_start_spawn_error',
+    pattern:
+      /EACCES|EPERM|spawn\s+\S+\s+(?:EACCES|EPERM|ENOMEM)|cannot allocate memory/i,
+    describe: () => 'spawn failed (permission denied / resource error)',
+  },
+  {
+    class: 'worker_no_start_bad_args',
+    pattern:
+      /unknown option|unrecognized option|invalid argument|usage:\s+claude/i,
+    describe: () => 'bad CLI args passed to claude',
+  },
+  {
+    class: 'worker_crashed',
+    pattern:
+      /Segmentation fault|core dumped|FATAL:|Uncaught (?:Exception|Error)|panic:|signal\s+(?:SIGSEGV|SIGBUS|SIGABRT)/i,
+    describe: () => 'worker crashed (fatal signal or uncaught exception)',
+  },
+];
+
+interface ResolvedSuccessCriteria {
+  output_file: string | undefined;
+  min_bytes: number;
+  grep_match: string | undefined;
+}
+
+function resolveSuccessCriteria(
+  ctx: StateContext,
+  phaseId: number,
+): ResolvedSuccessCriteria | null {
+  let phase;
+  try {
+    phase = findPhase(ctx.spec, phaseId);
+  } catch {
+    return null;
+  }
+  const sc = (phase.success_criteria ?? {}) as Record<string, unknown>;
+  const output = typeof sc.output_file === 'string' ? sc.output_file : undefined;
+  const min = typeof sc.min_bytes === 'number' ? sc.min_bytes : 0;
+  const grep = typeof sc.grep_match === 'string' ? sc.grep_match : undefined;
+  return { output_file: output, min_bytes: min, grep_match: grep };
+}
+
+function expandHome(p: string): string {
+  if (p.startsWith('~/')) return join(process.env['HOME'] ?? '', p.slice(2));
+  return p;
+}
+
+function readLogTail(path: string): string | null {
+  if (!existsSync(path)) return null;
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return null;
+    const size = stat.size;
+    const buf = readFileSync(path);
+    if (size <= LOG_SNIFF_MAX_BYTES) return buf.toString('utf8');
+    return buf.subarray(size - LOG_SNIFF_MAX_BYTES).toString('utf8');
+  } catch {
+    return null;
+  }
+}
+
+export interface ArtifactCheck {
+  exists: boolean;
+  size_bytes: number;
+  meets_min_bytes: boolean;
+  grep_matched: boolean | null; // null = no grep_match configured
+  path: string | null;
+}
+
+export function checkArtifact(
+  ctx: StateContext,
+  phaseId: number,
+): ArtifactCheck {
+  const sc = resolveSuccessCriteria(ctx, phaseId);
+  if (!sc || !sc.output_file) {
+    return {
+      exists: false,
+      size_bytes: 0,
+      meets_min_bytes: false,
+      grep_matched: null,
+      path: null,
+    };
+  }
+  const path = expandHome(sc.output_file);
+  if (!existsSync(path)) {
+    return {
+      exists: false,
+      size_bytes: 0,
+      meets_min_bytes: false,
+      grep_matched: null,
+      path,
+    };
+  }
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch {
+    size = 0;
+  }
+  const meets = size >= (sc.min_bytes ?? 0);
+  let grepMatched: boolean | null = null;
+  if (sc.grep_match) {
+    try {
+      const body = readFileSync(path, 'utf8');
+      grepMatched = new RegExp(sc.grep_match).test(body);
+    } catch {
+      grepMatched = false;
+    }
+  }
+  return {
+    exists: true,
+    size_bytes: size,
+    meets_min_bytes: meets,
+    grep_matched: grepMatched,
+    path,
+  };
+}
+
+export function sniffLogForClass(logPath?: string | null): {
+  match: { class: FailureClass; reason: string; matched_text: string } | null;
+  log_sampled: boolean;
+} {
+  if (!logPath) return { match: null, log_sampled: false };
+  const body = readLogTail(logPath);
+  if (body === null) return { match: null, log_sampled: false };
+  for (const p of LOG_PATTERNS) {
+    const m = p.pattern.exec(body);
+    if (m) {
+      return {
+        match: {
+          class: p.class,
+          reason: p.describe(m),
+          matched_text: m[0].slice(0, 200),
+        },
+        log_sampled: true,
+      };
+    }
+  }
+  return { match: null, log_sampled: true };
+}
+
+// Primary entry-point: classify a stale lock event into a structured
+// PhaseFailure. Inputs: chain context, the lock at the moment of detection,
+// and optionally an explicit dispatch-log path. When the path is omitted,
+// the classifier still produces a class via artifact-presence and timing
+// signals (worker_hung_post_success if the artifact landed; worker_hung_mid_work
+// if heartbeat aged out without progress; runtime_exceeded if the cap tripped).
+export interface ClassifyStaleLockOptions {
+  /** Optional dispatch log path. If unset, only artifact + lock evidence is used. */
+  dispatchLogPath?: string | null;
+  /** Indicates the staleness path that triggered classification. */
+  trigger?: 'heartbeat' | 'timeout';
+  /** Observed heartbeat age in seconds at detection (purely evidence). */
+  hb_age_sec?: number;
+  /** Observed runtime in seconds at detection (purely evidence). */
+  run_sec?: number;
+  /** Cap in seconds. */
+  cap_sec?: number;
+}
+
+export function classifyStaleLock(
+  ctx: StateContext,
+  lock: LockFile,
+  opts: ClassifyStaleLockOptions = {},
+): PhaseFailure {
+  const evidence: Record<string, unknown> = {
+    phase_id: lock.phase_id,
+    session_id: lock.session_id,
+    trigger: opts.trigger ?? 'heartbeat',
+  };
+  if (typeof opts.hb_age_sec === 'number') {
+    evidence['hb_age_sec'] = Math.floor(opts.hb_age_sec);
+  }
+  if (typeof opts.run_sec === 'number') {
+    evidence['run_sec'] = Math.floor(opts.run_sec);
+  }
+  if (typeof opts.cap_sec === 'number') {
+    evidence['cap_sec'] = opts.cap_sec;
+  }
+  if (opts.dispatchLogPath) {
+    evidence['dispatch_log'] = opts.dispatchLogPath;
+  }
+
+  // (1) Sniff the worker's log first — covers F-01..F-04 (rate limit, auth,
+  // binary missing, spawn error, crash). These dominate the "worker never ran"
+  // bucket.
+  const sniffed = sniffLogForClass(opts.dispatchLogPath ?? null);
+  evidence['log_sampled'] = sniffed.log_sampled;
+  if (sniffed.match) {
+    evidence['matched_text'] = sniffed.match.matched_text;
+    return {
+      class: sniffed.match.class,
+      reason: sniffed.match.reason,
+      detected_at: isoNow(),
+      evidence,
+    };
+  }
+
+  // (2) Runtime cap tripped — explicit timeout. The lock.ts caller passes
+  // trigger='timeout' for this branch.
+  if (opts.trigger === 'timeout') {
+    return {
+      class: 'runtime_exceeded',
+      reason: `runtime cap exceeded run_sec=${Math.floor(
+        opts.run_sec ?? 0,
+      )} cap_sec=${opts.cap_sec ?? 0}`,
+      detected_at: isoNow(),
+      evidence,
+    };
+  }
+
+  // (3) Heartbeat aged out but the artifact landed → the canonical "hung
+  // after success" pattern from incident #1.
+  const art = checkArtifact(ctx, lock.phase_id);
+  evidence['artifact'] = {
+    exists: art.exists,
+    size_bytes: art.size_bytes,
+    meets_min_bytes: art.meets_min_bytes,
+    grep_matched: art.grep_matched,
+    path: art.path,
+  };
+  if (art.exists && art.meets_min_bytes && art.grep_matched !== false) {
+    return {
+      class: 'worker_hung_post_success',
+      reason:
+        'heartbeat stale but artifact validates success_criteria — worker hung after writing deliverable',
+      detected_at: isoNow(),
+      evidence,
+    };
+  }
+
+  // (4) Heartbeat aged out with no artifact and no log signal → mid-work hang.
+  // Distinguished from `unknown` by the heartbeat-trigger; `unknown` is the
+  // fallback when we have neither evidence.
+  if (
+    opts.trigger === 'heartbeat' &&
+    typeof opts.hb_age_sec === 'number' &&
+    opts.hb_age_sec > 0
+  ) {
+    return {
+      class: 'worker_hung_mid_work',
+      reason: `heartbeat aged out (${Math.floor(
+        opts.hb_age_sec,
+      )}s) with no artifact and no log signal`,
+      detected_at: isoNow(),
+      evidence,
+    };
+  }
+
+  return {
+    class: 'unknown',
+    reason: 'no log signal, no artifact, no timing evidence',
+    detected_at: isoNow(),
+    evidence,
+  };
+}
+
+// Helper: construct a PhaseFailure from a free-form reason string for the
+// back-compat shim in state.markFailed.
+export function failureFromReason(reason: string): PhaseFailure {
+  return {
+    class: 'unknown',
+    reason: reason.slice(0, 500),
+    detected_at: isoNow(),
+    evidence: { legacy_string_reason: true },
+  };
+}

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -186,13 +186,54 @@ export function buildProgram(): Command {
   attachCommonOptions(program.command('mark-failed'))
     .argument('<phase-id>')
     .argument('[reason...]')
-    .description('Transition a phase to failed and clear the lock')
-    .action((phaseId: string, reason: string[], opts: BaseOptions) => {
-      const ctx = ctxFromOpts(opts);
-      const r = reason.length > 0 ? reason.join(' ') : 'no_reason';
-      markFailed(ctx, phaseId, r);
-      clearLock(ctx);
-    });
+    .option(
+      '--class <class>',
+      'FailureClass (e.g. worker_no_start_rate_limit, worker_hung_post_success); default `unknown`',
+    )
+    .option(
+      '--evidence <kv>',
+      'one or more key=value evidence pairs (repeatable, comma-separated)',
+      (val: string, acc: string[]) => acc.concat(val),
+      [] as string[],
+    )
+    .description(
+      'Transition a phase to failed and clear the lock. Legacy string reason still accepted (becomes class=unknown).',
+    )
+    .action(
+      (
+        phaseId: string,
+        reason: string[],
+        cmdOpts: { class?: string; evidence?: string[] },
+        cmd: Command,
+      ) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions;
+        const ctx = ctxFromOpts(opts);
+        const r = reason.length > 0 ? reason.join(' ') : 'no_reason';
+        if (cmdOpts.class) {
+          const evidence: Record<string, unknown> = {
+            source: 'cli_mark_failed',
+          };
+          for (const kv of cmdOpts.evidence ?? []) {
+            for (const piece of kv.split(',')) {
+              const eq = piece.indexOf('=');
+              if (eq > 0) {
+                evidence[piece.slice(0, eq).trim()] = piece.slice(eq + 1).trim();
+              }
+            }
+          }
+          markFailed(ctx, phaseId, {
+            class: cmdOpts.class as never,
+            reason: r,
+            detected_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+            evidence,
+          });
+        } else {
+          // Back-compat shim — string reason, classifier coerces to unknown.
+          markFailed(ctx, phaseId, r);
+        }
+        clearLock(ctx);
+      },
+    );
 
   attachCommonOptions(program.command('heartbeat'))
     .argument('<session-id>')
@@ -213,31 +254,50 @@ export function buildProgram(): Command {
     });
 
   attachCommonOptions(program.command('check-lock-staleness'))
+    .option(
+      '--dispatch-log <path>',
+      "path to the worker's dispatch log; classifier sniffs it for rate-limit / auth / spawn signals",
+    )
     .description('Clear stale lock if heartbeat or runtime cap exceeded')
-    .action((opts: BaseOptions) => {
-      const ctx = ctxFromOpts(opts);
-      const r = checkLockStaleness(ctx);
-      switch (r.kind) {
-        case 'no_lock':
-          process.stdout.write('NO_LOCK\n');
-          break;
-        case 'live':
-          process.stdout.write(
-            `LOCK_LIVE phase=${r.phaseId} hb_age=${Math.floor(r.hbAgeSec)}s run=${Math.floor(r.runSec)}s cap=${r.capSec}s\n`,
-          );
-          break;
-        case 'cleared': {
-          const detail =
-            r.reason === 'timeout'
-              ? `run=${Math.floor(r.ageSec)}s cap=${r.capSec ?? '?'}s`
-              : `age=${Math.floor(r.ageSec)}s`;
-          process.stdout.write(
-            `STALE_LOCK_CLEARED phase=${r.phaseId} reason=${r.reason} ${detail}\n`,
-          );
-          break;
+    .action(
+      (cmdOpts: { dispatchLog?: string }, cmd: Command) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions;
+        const ctx = ctxFromOpts(opts);
+        const r = checkLockStaleness(ctx, {
+          dispatchLogPath: cmdOpts.dispatchLog ?? null,
+        });
+        switch (r.kind) {
+          case 'no_lock':
+            process.stdout.write('NO_LOCK\n');
+            break;
+          case 'live':
+            process.stdout.write(
+              `LOCK_LIVE phase=${r.phaseId} hb_age=${Math.floor(r.hbAgeSec)}s run=${Math.floor(r.runSec)}s cap=${r.capSec}s\n`,
+            );
+            break;
+          case 'cleared': {
+            const detail =
+              r.reason === 'timeout'
+                ? `run=${Math.floor(r.ageSec)}s cap=${r.capSec ?? '?'}s`
+                : `age=${Math.floor(r.ageSec)}s`;
+            process.stdout.write(
+              `STALE_LOCK_CLEARED phase=${r.phaseId} reason=${r.reason} class=${r.failure.class} ${detail}\n`,
+            );
+            break;
+          }
+          case 'auto_adjudicated':
+            process.stdout.write(
+              `PHASE_AUTO_ADJUDICATED phase=${r.phaseId} class=${r.failure.class} age=${Math.floor(r.ageSec)}s\n`,
+            );
+            // Auto-adjudication is a success-shaped transition; refresh
+            // SESSION_HANDOFF so the operator sees the new state.
+            fireHandoffRefresh({
+              triggeredBy: `chain-phase-auto-adjudicated-${opts.chainId}-${r.phaseId}`,
+            });
+            break;
         }
-      }
-    });
+      },
+    );
 
   attachCommonOptions(program.command('pause'))
     .description('Suppress further dispatch until resume')

--- a/packages/chain-runner/src/index.ts
+++ b/packages/chain-runner/src/index.ts
@@ -9,6 +9,7 @@ export * from './runner.js';
 export * from './time.js';
 export * from './bootstrap.js';
 export * from './watchdog.js';
+export * from './classify.js';
 export {
   mergeOrFail,
   viewPR,

--- a/packages/chain-runner/src/lock.ts
+++ b/packages/chain-runner/src/lock.ts
@@ -5,10 +5,12 @@ import { isoNow, parseIso } from './time.js';
 import {
   ensurePhaseEntry,
   loadState,
+  markAutoAdjudicated,
   markFailed,
   type StateContext,
 } from './state.js';
-import type { LockFile } from './types.js';
+import { checkArtifact, classifyStaleLock } from './classify.js';
+import type { LockFile, PhaseFailure } from './types.js';
 
 export const HEARTBEAT_GRACE_SEC = 3600; // 60 min
 
@@ -78,9 +80,29 @@ export type StalenessResult =
       reason: 'heartbeat' | 'timeout';
       ageSec: number;
       capSec?: number;
+      failure: PhaseFailure;
+    }
+  | {
+      kind: 'auto_adjudicated';
+      phaseId: number;
+      reason: 'heartbeat';
+      ageSec: number;
+      failure: PhaseFailure;
     };
 
-export function checkLockStaleness(ctx: StateContext): StalenessResult {
+export interface CheckLockStalenessOptions {
+  /** Optional dispatch log path to sniff for rate-limit / auth / spawn signals. */
+  dispatchLogPath?: string | null;
+}
+
+function isAutoResolveEnabled(ctx: StateContext): boolean {
+  return ctx.spec.chain_config?.auto_resolve_hung_post_success === true;
+}
+
+export function checkLockStaleness(
+  ctx: StateContext,
+  opts: CheckLockStalenessOptions = {},
+): StalenessResult {
   const lock = loadLock(ctx);
   if (!lock) return { kind: 'no_lock' };
 
@@ -94,36 +116,78 @@ export function checkLockStaleness(ctx: StateContext): StalenessResult {
   const capSec = (ps.max_minutes ?? 45) * 60;
 
   if (ageSec > HEARTBEAT_GRACE_SEC) {
-    markFailed(
-      ctx,
-      String(lock.phase_id),
-      `stale_lock heartbeat_age_sec=${Math.floor(ageSec)}`,
-    );
+    const failure = classifyStaleLock(ctx, lock, {
+      trigger: 'heartbeat',
+      hb_age_sec: ageSec,
+      run_sec: runSec,
+      cap_sec: capSec,
+      dispatchLogPath: opts.dispatchLogPath ?? null,
+    });
+    // D-1 auto-adjudicate: if the classifier observed worker_hung_post_success
+    // AND the chain opted in via chain_config.auto_resolve_hung_post_success,
+    // and the artifact already validates success_criteria, mark the phase
+    // done and emit phase_auto_adjudicated instead of phase_failed.
+    if (
+      failure.class === 'worker_hung_post_success' &&
+      isAutoResolveEnabled(ctx)
+    ) {
+      const art = checkArtifact(ctx, lock.phase_id);
+      const grepOk = art.grep_matched !== false;
+      if (art.exists && art.meets_min_bytes && grepOk) {
+        markAutoAdjudicated(ctx, String(lock.phase_id), failure, {
+          artifact_path: art.path,
+          artifact_size_bytes: art.size_bytes,
+          grep_matched: art.grep_matched,
+          hb_age_sec: Math.floor(ageSec),
+        });
+        clearLock(ctx);
+        appendAudit(ctx.paths.auditFile, 'lock_cleared', {
+          phase_id: lock.phase_id,
+          reason: 'heartbeat',
+          age_sec: Math.floor(ageSec),
+          disposition: 'auto_adjudicated',
+        });
+        return {
+          kind: 'auto_adjudicated',
+          phaseId: lock.phase_id,
+          reason: 'heartbeat',
+          ageSec,
+          failure,
+        };
+      }
+    }
+    markFailed(ctx, String(lock.phase_id), failure);
     clearLock(ctx);
     appendAudit(ctx.paths.auditFile, 'lock_cleared', {
       phase_id: lock.phase_id,
       reason: 'heartbeat',
       age_sec: Math.floor(ageSec),
+      class: failure.class,
     });
     return {
       kind: 'cleared',
       phaseId: lock.phase_id,
       reason: 'heartbeat',
       ageSec,
+      failure,
     };
   }
   if (runSec > capSec) {
-    markFailed(
-      ctx,
-      String(lock.phase_id),
-      `runtime_exceeded run_sec=${Math.floor(runSec)} cap_sec=${capSec}`,
-    );
+    const failure = classifyStaleLock(ctx, lock, {
+      trigger: 'timeout',
+      hb_age_sec: ageSec,
+      run_sec: runSec,
+      cap_sec: capSec,
+      dispatchLogPath: opts.dispatchLogPath ?? null,
+    });
+    markFailed(ctx, String(lock.phase_id), failure);
     clearLock(ctx);
     appendAudit(ctx.paths.auditFile, 'lock_cleared', {
       phase_id: lock.phase_id,
       reason: 'timeout',
       run_sec: Math.floor(runSec),
       cap_sec: capSec,
+      class: failure.class,
     });
     return {
       kind: 'cleared',
@@ -131,6 +195,7 @@ export function checkLockStaleness(ctx: StateContext): StalenessResult {
       reason: 'timeout',
       ageSec: runSec,
       capSec,
+      failure,
     };
   }
   return {

--- a/packages/chain-runner/src/runner.ts
+++ b/packages/chain-runner/src/runner.ts
@@ -26,6 +26,23 @@ function genSessionId(phaseId: number): string {
   return `phase${phaseId}-${ts}-${process.pid}`;
 }
 
+// H-1 extension (chain-runner-battle-harden phase 2, 2026-05-14):
+// inject the standing autonomy directive into every spawned prompt so
+// future chains don't need to duplicate it in every YAML phase. Operator
+// hard rule 2026-05-14: spawned workers decide-and-act, never ask-and-wait.
+//
+// The directive is concise on purpose — long preambles waste worker
+// context. The operator-only carve-out list is the lowest-cardinality
+// part because the worker needs it to know which decisions to defer.
+const AUTONOMY_DIRECTIVE = `## Autonomy directive (standing rule, 2026-05-14)
+You are a spawned worker — operate fully autonomously. Decide-and-act, do NOT ask-and-wait.
+- Do thorough analysis first, make the best informed call, execute, then inform via the phase report.
+- Banned phrases: "Would you like / Should I / Want me to / Your call / Path A or B?" — kill the draft, decide, ship.
+- The ONLY operator-only actions you may defer are: interactive auth/login (gh / claude logout-login), account or billing changes, physical hardware. Flag those into the phase report with \`OPERATOR_ACTION_REQUIRED: <description>\` AND call \`caia-chain emit-alert --type operator_action_required --severity high\` (alerting backbone lands in phase 5; until then, append to ~/.caia/chain-watchdog/INBOX.md).
+- Apply standing rules unprompted: subscription-only billing, bypassPermissions for nested spawns, worktree isolation, true-zero before new PR, gate-mark-done.sh before mark-done.
+- For everything else: pick a path, execute, document the decision in the phase report.
+`;
+
 export function buildPromptFile(
   ctx: StateContext,
   phaseId: number,
@@ -42,6 +59,7 @@ Operate fully autonomously:
 - DO NOT return for clarification. Make best informed decisions and document them.
 - Stay within budget: max ${maxMinutes} minutes wall-clock.
 
+${AUTONOMY_DIRECTIVE}
 Your task starts below:
 ---
 `;

--- a/packages/chain-runner/src/state.ts
+++ b/packages/chain-runner/src/state.ts
@@ -4,7 +4,14 @@ import { appendAudit } from './audit.js';
 import { ensureChainDir } from './paths.js';
 import { isoNow } from './time.js';
 import { loadChainSpec } from './spec.js';
-import type { ChainPaths, ChainSpec, PhaseState, StateFile } from './types.js';
+import { failureFromReason } from './classify.js';
+import type {
+  ChainPaths,
+  ChainSpec,
+  PhaseFailure,
+  PhaseState,
+  StateFile,
+} from './types.js';
 
 export const SCHEMA_VERSION = 1;
 export const DEFAULT_BUDGET_CAP_PCT = 25;
@@ -33,6 +40,7 @@ export function buildInitialState(spec: ChainSpec): StateFile {
       completed_at: null,
       session_id: null,
       error: null,
+      failure: null,
     };
   }
   return {
@@ -182,20 +190,56 @@ export function markDone(ctx: StateContext, phaseId: string): void {
   });
 }
 
-export function markFailed(
+// Mark a phase done via the D-1 auto-adjudication path. Used when the
+// classifier emits worker_hung_post_success AND chain_config has
+// auto_resolve_hung_post_success=true AND the artifact validates the
+// declared success_criteria. The audit event is distinct from a normal
+// phase_done so operators can audit auto-recoveries vs first-class success.
+export function markAutoAdjudicated(
   ctx: StateContext,
   phaseId: string,
-  reason: string,
+  failure: PhaseFailure,
+  verification: Record<string, unknown>,
 ): void {
   const state = loadState(ctx);
   const ps = ensurePhaseEntry(state, phaseId);
+  ps.status = 'done';
+  ps.completed_at = isoNow();
+  ps.failure = failure;
+  saveState(ctx, state);
+  appendAudit(ctx.paths.auditFile, 'phase_auto_adjudicated', {
+    phase_id: Number(phaseId),
+    class: failure.class,
+    reason: failure.reason,
+    verification,
+  });
+}
+
+// Back-compat shim: legacy callers pass a string reason; new callers pass a
+// structured PhaseFailure. The shim wraps the string under class=unknown so
+// existing wake scripts + the `caia-chain mark-failed <id> <reason>` CLI
+// keep working through one release. The structured form is preferred.
+export function markFailed(
+  ctx: StateContext,
+  phaseId: string,
+  failureOrReason: PhaseFailure | string,
+): void {
+  const failure: PhaseFailure =
+    typeof failureOrReason === 'string'
+      ? failureFromReason(failureOrReason)
+      : failureOrReason;
+  const state = loadState(ctx);
+  const ps = ensurePhaseEntry(state, phaseId);
   ps.status = 'failed';
-  ps.error = reason.slice(0, 500);
+  ps.error = failure.reason.slice(0, 500);
+  ps.failure = failure;
   saveState(ctx, state);
   appendAudit(ctx.paths.auditFile, 'phase_failed', {
     phase_id: Number(phaseId),
-    reason: reason.slice(0, 500),
+    class: failure.class,
+    reason: failure.reason.slice(0, 500),
     attempt: ps.attempts,
+    evidence: failure.evidence,
   });
 }
 

--- a/packages/chain-runner/src/types.ts
+++ b/packages/chain-runner/src/types.ts
@@ -22,9 +22,50 @@ export interface ChainDefaults {
   heartbeat_interval_sec?: number;
 }
 
+// Operator-decision flags surfaced as chain_config in the spec YAML. Loader
+// passes them through verbatim; only the keys consumed by runtime today are
+// declared here, but [k: string]: unknown keeps future opt-in flags painless.
+export interface ChainConfig {
+  auto_resolve_hung_post_success?: boolean;
+  max_concurrent?: number;
+  alert_channels?: string[];
+  none_eligible_alert_threshold?: number;
+  account_quota_reset_aware?: boolean;
+  acceptance_enforce_default?: 'warn' | 'strict';
+  [k: string]: unknown;
+}
+
 export interface ChainSpec {
   defaults?: ChainDefaults;
+  chain_config?: ChainConfig;
   phases: PhaseDefinition[];
+}
+
+// H-1 (phase 2 of chain-runner-battle-harden, 2026-05-14): typed failure
+// classification. Replaces the single `stale_lock` string reason with a
+// closed enum captured at detection time. Maps to gap-analysis §1.1 F-01..F-15.
+export type FailureClass =
+  | 'worker_no_start_rate_limit'
+  | 'worker_no_start_auth_failure'
+  | 'worker_no_start_binary_missing'
+  | 'worker_no_start_spawn_error'
+  | 'worker_no_start_bad_args'
+  | 'worker_hung_post_success'
+  | 'worker_hung_mid_work'
+  | 'worker_crashed'
+  | 'mark_done_failed'
+  | 'artifact_missing'
+  | 'artifact_malformed'
+  | 'pr_unmerged_at_done'
+  | 'acceptance_failed'
+  | 'runtime_exceeded'
+  | 'unknown';
+
+export interface PhaseFailure {
+  class: FailureClass;
+  reason: string;
+  detected_at: string;
+  evidence: Record<string, unknown>;
 }
 
 export interface PhaseState {
@@ -36,6 +77,7 @@ export interface PhaseState {
   completed_at: string | null;
   session_id: string | null;
   error: string | null;
+  failure?: PhaseFailure | null;
 }
 
 export interface StateFile {

--- a/packages/chain-runner/tests/classify.test.ts
+++ b/packages/chain-runner/tests/classify.test.ts
@@ -1,0 +1,428 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  checkArtifact,
+  classifyStaleLock,
+  failureFromReason,
+  sniffLogForClass,
+} from '../src/classify.js';
+import { loadContext, type StateContext } from '../src/state.js';
+import { makeFixture, type FixtureBundle } from './fixtures.js';
+import type { FailureClass, LockFile } from '../src/types.js';
+
+// Inline fixture-with-success-criteria builder. The classifier's
+// worker_hung_post_success branch reads spec.phases[].success_criteria, so a
+// dedicated fixture with declared criteria is needed for incident-#1-shaped
+// tests.
+function makeFixtureWithCriteria(label: string, opts: {
+  output_file: string;
+  min_bytes: number;
+  grep_match?: string;
+  auto_resolve?: boolean;
+}): { fx: FixtureBundle; ctx: StateContext } {
+  const root = mkdtempSync(join(tmpdir(), `caia-cr-classify-${label}-`));
+  const chainHome = join(root, 'chain');
+  mkdirSync(chainHome, { recursive: true });
+  const specPath = join(root, 'phases.yaml');
+  const yaml = `defaults:
+  max_retries: 2
+  max_minutes: 45
+  heartbeat_interval_sec: 120
+
+chain_config:
+  auto_resolve_hung_post_success: ${opts.auto_resolve ? 'true' : 'false'}
+
+phases:
+  - id: 1
+    name: classify_phase_one
+    deps: []
+    max_minutes: 45
+    success_criteria:
+      output_file: "${opts.output_file}"
+      min_bytes: ${opts.min_bytes}${
+    opts.grep_match
+      ? `\n      grep_match: "${opts.grep_match}"`
+      : ''
+  }
+    prompt_template: |
+      classification test phase
+  - id: 2
+    name: classify_phase_two
+    deps: [1]
+    prompt_template: |
+      downstream
+`;
+  writeFileSync(specPath, yaml);
+  process.env['CAIA_CHAIN_HOME'] = chainHome;
+  const chainId = `cr-classify-${label}-${process.pid}`;
+  const fx: FixtureBundle = {
+    chainHome,
+    chainId,
+    specPath,
+    cleanup: () => {
+      delete process.env['CAIA_CHAIN_HOME'];
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    },
+  };
+  const ctx = loadContext(chainId, specPath);
+  return { fx, ctx };
+}
+
+function fakeLock(phaseId = 1): LockFile {
+  return {
+    phase_id: phaseId,
+    session_id: `sess-cls-${phaseId}-${Math.random().toString(36).slice(2, 8)}`,
+    started_at: '2026-05-14T00:00:00Z',
+    heartbeat: '2026-05-14T00:00:00Z',
+  };
+}
+
+function writeLog(dir: string, name: string, body: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, body);
+  return p;
+}
+
+let fx: FixtureBundle;
+let ctx: StateContext;
+let logDir: string;
+
+beforeEach(() => {
+  fx = makeFixture(`cls-${Math.random().toString(36).slice(2, 8)}`);
+  ctx = loadContext(fx.chainId, fx.specPath);
+  logDir = mkdtempSync(join(tmpdir(), 'caia-cls-logs-'));
+});
+
+afterEach(() => {
+  fx.cleanup();
+  try {
+    rmSync(logDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 01 — F-01: rate-limit banner with reset time
+// ---------------------------------------------------------------------------
+describe('F01_rate_limit_with_reset_time', () => {
+  it('classifies as worker_no_start_rate_limit and parses reset time', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_ratelimit.log',
+      "Loading...\nYou've hit your limit · resets May 16 at 12pm (America/New_York)\n",
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_rate_limit');
+    expect(r.reason).toMatch(/resets May 16/i);
+    expect(r.evidence['matched_text']).toBeTypeOf('string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 02 — F-01b: rate-limit banner without reset time (curly apostrophe)
+// ---------------------------------------------------------------------------
+describe('F01b_rate_limit_unicode_apostrophe', () => {
+  it('matches the curly-apostrophe variant', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_ratelimit_unicode.log',
+      'You’ve hit your limit. Try again later.\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 4000,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_rate_limit');
+    expect(r.reason).toMatch(/no reset time captured|resets/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 03 — F-02: auth failure (401)
+// ---------------------------------------------------------------------------
+describe('F02_auth_failure_401', () => {
+  it('classifies as worker_no_start_auth_failure', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_auth.log',
+      'API Error 401 Unauthorized: invalid api key\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_auth_failure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 04 — F-02b: auth failure ("Invalid authentication credentials")
+// ---------------------------------------------------------------------------
+describe('F02b_invalid_authentication_credentials', () => {
+  it('classifies as worker_no_start_auth_failure via the literal string', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_auth2.log',
+      'authentication_error: Invalid authentication credentials\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_auth_failure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 05 — F-03: binary missing (command not found)
+// ---------------------------------------------------------------------------
+describe('F03_binary_missing_command_not_found', () => {
+  it('classifies as worker_no_start_binary_missing', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_no_binary.log',
+      '/bin/sh: claude: command not found\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_binary_missing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 06 — F-04: spawn error (EACCES)
+// ---------------------------------------------------------------------------
+describe('F04_spawn_error_EACCES', () => {
+  it('classifies as worker_no_start_spawn_error', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_eacces.log',
+      'spawn claude EACCES: permission denied\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_spawn_error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 07 — F-05: bad CLI args
+// ---------------------------------------------------------------------------
+describe('F05_bad_cli_args', () => {
+  it('classifies as worker_no_start_bad_args', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_bad_args.log',
+      'claude: unknown option `--nonsense`\nusage: claude [...]\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_bad_args');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 08 — F-06: worker hung post-success (artifact validates)
+// ---------------------------------------------------------------------------
+describe('F06_worker_hung_post_success', () => {
+  it('classifies as worker_hung_post_success when artifact exists + meets criteria', () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), 'caia-cls-art-'));
+    const artifactPath = join(artifactDir, 'phase1_artifact.md');
+    writeFileSync(
+      artifactPath,
+      '# phase 1 artifact\n' +
+        'status: COMPLETE\n' +
+        'a'.repeat(2000) +
+        '\nCAIA_NODE_BIN: /opt/homebrew/opt/node@22/bin/node\n',
+    );
+    const built = makeFixtureWithCriteria('hung-post-success', {
+      output_file: artifactPath,
+      min_bytes: 1500,
+      grep_match: 'CAIA_NODE_BIN|healthz',
+    });
+    try {
+      // No log signals — log is empty, but artifact landed.
+      const r = classifyStaleLock(built.ctx, fakeLock(), {
+        trigger: 'heartbeat',
+        hb_age_sec: 4497,
+      });
+      expect(r.class).toBe<FailureClass>('worker_hung_post_success');
+      const art = r.evidence['artifact'] as Record<string, unknown>;
+      expect(art.exists).toBe(true);
+      expect(art.meets_min_bytes).toBe(true);
+      expect(art.grep_matched).toBe(true);
+    } finally {
+      built.fx.cleanup();
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 09 — F-06b: hung post-success rejected when grep_match fails
+// ---------------------------------------------------------------------------
+describe('F06b_artifact_grep_mismatch_falls_through_to_mid_work', () => {
+  it('does NOT classify as hung_post_success when grep does not match', () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), 'caia-cls-art-'));
+    const artifactPath = join(artifactDir, 'phase1_artifact.md');
+    writeFileSync(artifactPath, 'wrong content ' + 'b'.repeat(3000));
+    const built = makeFixtureWithCriteria('grep-mismatch', {
+      output_file: artifactPath,
+      min_bytes: 1500,
+      grep_match: 'CAIA_NODE_BIN|healthz',
+    });
+    try {
+      const r = classifyStaleLock(built.ctx, fakeLock(), {
+        trigger: 'heartbeat',
+        hb_age_sec: 4497,
+      });
+      // Falls through to mid-work (heartbeat aged out, no log signal,
+      // artifact exists but didn't validate).
+      expect(r.class).toBe<FailureClass>('worker_hung_mid_work');
+    } finally {
+      built.fx.cleanup();
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 10 — F-07: worker hung mid-work (no artifact, no log signal)
+// ---------------------------------------------------------------------------
+describe('F07_worker_hung_mid_work', () => {
+  it('classifies as worker_hung_mid_work when heartbeat aged out with no evidence', () => {
+    const log = writeLog(logDir, 'phase1_silent.log', 'some unrelated chatter\n');
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 7200,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_hung_mid_work');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 11 — F-08: worker crashed (SIGSEGV / fatal)
+// ---------------------------------------------------------------------------
+describe('F08_worker_crashed_sigsegv', () => {
+  it('classifies as worker_crashed', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_crash.log',
+      'Segmentation fault (core dumped)\nFATAL: bus error\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_crashed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 12 — F-14: runtime cap exceeded
+// ---------------------------------------------------------------------------
+describe('F14_runtime_exceeded', () => {
+  it('classifies as runtime_exceeded when trigger=timeout', () => {
+    const log = writeLog(logDir, 'phase1_slow.log', 'still working...\n');
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'timeout',
+      run_sec: 5000,
+      cap_sec: 2700,
+      hb_age_sec: 30,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('runtime_exceeded');
+    expect(r.evidence['cap_sec']).toBe(2700);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 13 — F-15: unknown (no log path, no timing evidence)
+// ---------------------------------------------------------------------------
+describe('F15_unknown_no_evidence', () => {
+  it('classifies as unknown when no log + no hb_age + no trigger evidence', () => {
+    const r = classifyStaleLock(ctx, fakeLock(), {});
+    expect(r.class).toBe<FailureClass>('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 14 — Log precedence: rate-limit wins over auth in mixed log
+// ---------------------------------------------------------------------------
+describe('LP01_rate_limit_precedes_auth_in_mixed_log', () => {
+  it('returns worker_no_start_rate_limit even when log also contains auth string', () => {
+    const log = writeLog(
+      logDir,
+      'phase1_mixed.log',
+      "You've hit your limit · resets May 16 at 12pm\n" +
+        'Invalid authentication credentials\n',
+    );
+    const r = classifyStaleLock(ctx, fakeLock(), {
+      trigger: 'heartbeat',
+      hb_age_sec: 3700,
+      dispatchLogPath: log,
+    });
+    expect(r.class).toBe<FailureClass>('worker_no_start_rate_limit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 15 — Back-compat shim: failureFromReason → unknown
+// ---------------------------------------------------------------------------
+describe('LP02_failure_from_reason_back_compat_shim', () => {
+  it('wraps a string reason as class=unknown with legacy_string_reason evidence', () => {
+    const f = failureFromReason('stale_lock heartbeat_age_sec=4497');
+    expect(f.class).toBe<FailureClass>('unknown');
+    expect(f.reason).toContain('stale_lock');
+    expect(f.evidence['legacy_string_reason']).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bonus / sanity coverage (not counted toward the 15) — sniff + artifact helpers
+// ---------------------------------------------------------------------------
+describe('classifier helpers', () => {
+  it('sniffLogForClass returns null when path is missing', () => {
+    const r = sniffLogForClass(null);
+    expect(r.match).toBeNull();
+    expect(r.log_sampled).toBe(false);
+  });
+
+  it('checkArtifact returns exists=false when output_file absent in success_criteria', () => {
+    const built = makeFixtureWithCriteria('noop', {
+      output_file: '/tmp/does-not-exist-caia-classify-test.txt',
+      min_bytes: 10,
+    });
+    try {
+      const a = checkArtifact(built.ctx, 1);
+      expect(a.exists).toBe(false);
+    } finally {
+      built.fx.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of `chain-runner-battle-harden` chain. Replaces the single `stale_lock` string reason with a typed `FailureClass` enum captured at detection time, persisted in `PhaseState` + audit. Adds the **D-1 auto-resolve `worker_hung_post_success`** opt-in path and folds the **standing autonomy directive** into `buildPromptFile` so future chains don't duplicate it in every YAML phase.

- New `FailureClass` union (15 variants) + `PhaseFailure` interface in `src/types.ts`
- New `src/classify.ts` — `classifyStaleLock(ctx, lock, opts)` sniffs the worker's dispatch log for rate-limit / auth / binary-missing / spawn-error / bad-args / crash patterns; falls through to artifact-presence and heartbeat-age signals
- `src/lock.ts:checkLockStaleness` now emits structured failures; D-1 branch: when `class=worker_hung_post_success` + `chain_config.auto_resolve_hung_post_success=true` + artifact validates `success_criteria`, calls `markAutoAdjudicated` and emits `phase_auto_adjudicated` instead of `phase_failed`
- `src/state.ts:markFailed` widened to accept `PhaseFailure|string`; the string form is wrapped via `failureFromReason` as `class=unknown` so legacy callers keep working
- `src/runner.ts:buildPromptFile` prepends the standing autonomy directive (H-1 extension)
- CLI: `mark-failed --class <c> --evidence k=v` (new) + legacy form; `check-lock-staleness --dispatch-log <path>` plumbs the sniff path; auto-adjudication prints `PHASE_AUTO_ADJUDICATED` and triggers a SESSION_HANDOFF refresh

### Coverage of the three 2026-05-14 overnight incidents

- **Incident #1** (phase 3 hung after writing deliverable) → `worker_hung_post_success`; with the opt-in flag set, the chain would auto-mark the phase done on the next wake instead of leaving it `blocked`.
- **Incident #2** (phase 7 rate-limit at spawn) → `worker_no_start_rate_limit`; the reset banner is parsed into `reason` so an operator (and phase 4's preflight in a future PR) can act on it.
- **Incident #3** (silent stall variant) → `worker_hung_mid_work`.

## Test plan

- [x] 17 new tests in `tests/classify.test.ts` (15 failure-mode fixtures + 2 helper-coverage cases) — all pass
- [x] Existing 75-case regression in `tests/regression.test.ts` remains green
- [x] Full suite: **140 tests passed, 0 failures**
- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean
- [x] CLI smoke test: \`caia-chain mark-failed --help\` shows new \`--class\` / \`--evidence\` flags; legacy \`mark-failed <id> <reason>\` path still works (back-compat shim wraps to \`class=unknown\`)

Refs: `reports/chain_runner_hardening_plan_2026-05-14.md` §H-1 and §"Operator decisions — RESOLVED 2026-05-14" (D-1); `reports/overnight_incidents_2026-05-14.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)