### PR TITLE
feat(chain-runner): h-2 attempts-on-completion + h-3 early-exit capture

### DIFF
--- a/packages/chain-runner/src/classify.ts
+++ b/packages/chain-runner/src/classify.ts
@@ -313,3 +313,52 @@ export function failureFromReason(reason: string): PhaseFailure {
     evidence: { legacy_string_reason: true },
   };
 }
+
+// H-3 (chain-runner-battle-harden phase 3, 2026-05-14). Classify a non-zero
+// child exit observed within the post-spawn 5s window. Sniffs the dispatch
+// log first so rate-limit / auth / binary-missing banners win over the
+// default. Falls back to worker_no_start_spawn_error keyed on the exit code.
+export interface ClassifyEarlyExitOptions {
+  exitCode: number | null;
+  signal?: string | null;
+  dispatchLogPath?: string | null;
+  elapsedMs?: number;
+}
+
+export function classifyEarlyExit(
+  lock: LockFile,
+  opts: ClassifyEarlyExitOptions,
+): PhaseFailure {
+  const evidence: Record<string, unknown> = {
+    phase_id: lock.phase_id,
+    session_id: lock.session_id,
+    trigger: 'early_exit',
+    exit_code: opts.exitCode,
+    signal: opts.signal ?? null,
+  };
+  if (typeof opts.elapsedMs === 'number') {
+    evidence['elapsed_ms'] = opts.elapsedMs;
+  }
+  if (opts.dispatchLogPath) {
+    evidence['dispatch_log'] = opts.dispatchLogPath;
+  }
+  const sniffed = sniffLogForClass(opts.dispatchLogPath ?? null);
+  evidence['log_sampled'] = sniffed.log_sampled;
+  if (sniffed.match) {
+    evidence['matched_text'] = sniffed.match.matched_text;
+    return {
+      class: sniffed.match.class,
+      reason: sniffed.match.reason,
+      detected_at: isoNow(),
+      evidence,
+    };
+  }
+  return {
+    class: 'worker_no_start_spawn_error',
+    reason: `worker exited early code=${opts.exitCode ?? 'null'}${
+      opts.signal ? ` signal=${opts.signal}` : ''
+    }`,
+    detected_at: isoNow(),
+    evidence,
+  };
+}

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -337,26 +337,54 @@ export function buildProgram(): Command {
   attachCommonOptions(program.command('dispatch'))
     .argument('<phase-id>')
     .option('--spawn <command>', 'background command to spawn (receives PHASE_ID SESSION_ID PROMPT_FILE)')
+    .option(
+      '--early-exit-window-ms <n>',
+      'window (ms) to watch for an immediate child exit; default 5000',
+    )
     .description('Build the prompt file, mark in_progress, acquire lock, optionally spawn a runner')
     .action(
-      (
+      async (
         phaseId: string,
-        cmdOpts: { spawn?: string },
+        cmdOpts: { spawn?: string; earlyExitWindowMs?: string },
         cmd: Command,
       ) => {
-        const opts = cmd.optsWithGlobals() as BaseOptions & { spawn?: string };
+        const opts = cmd.optsWithGlobals() as BaseOptions & {
+          spawn?: string;
+          earlyExitWindowMs?: string;
+        };
         const ctx = ctxFromOpts(opts);
         // Validate the phase exists in the spec
         findPhase(ctx.spec, Number(phaseId));
         const dispatchOpts = cmdOpts.spawn
-          ? { command: cmdOpts.spawn, args: [] as string[] }
+          ? {
+              command: cmdOpts.spawn,
+              args: [] as string[],
+              ...(cmdOpts.earlyExitWindowMs
+                ? { earlyExitWindowMs: Number(cmdOpts.earlyExitWindowMs) }
+                : {}),
+            }
           : undefined;
-        const result = dispatchPhase(ctx, Number(phaseId), dispatchOpts);
+        const result = await dispatchPhase(ctx, Number(phaseId), dispatchOpts);
         process.stdout.write(
           `dispatched phase=${result.phaseId} session=${result.sessionId} prompt=${result.promptFile}` +
             (result.pid ? ` pid=${result.pid}` : '') +
+            (result.logFile ? ` log=${result.logFile}` : '') +
             '\n',
         );
+        // Surface H-3 early-exit signal on stderr+exit code so wake scripts
+        // can react without parsing stdout.
+        if (typeof result.early_exit_code === 'number') {
+          const cls = result.early_failure?.class ?? 'graceful';
+          process.stderr.write(
+            `EARLY_EXIT phase=${result.phaseId} exit_code=${result.early_exit_code} class=${cls}\n`,
+          );
+          if (result.early_failure) {
+            // Distinct exit code so the wake script can fall through to
+            // its own backoff / classification log without treating this as
+            // a generic dispatch error.
+            process.exit(7);
+          }
+        }
       },
     );
 

--- a/packages/chain-runner/src/lock.ts
+++ b/packages/chain-runner/src/lock.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs';
 import { atomicWriteJson } from './atomic.js';
 import { appendAudit } from './audit.js';
 import { isoNow, parseIso } from './time.js';
@@ -13,6 +13,33 @@ import { checkArtifact, classifyStaleLock } from './classify.js';
 import type { LockFile, PhaseFailure } from './types.js';
 
 export const HEARTBEAT_GRACE_SEC = 3600; // 60 min
+
+// H-2 (chain-runner-battle-harden phase 3, 2026-05-14). A worker is counted
+// as having run "substantively" if any of these are true at staleness-detect
+// time:
+//   - it fired at least one heartbeat() (hadAnyHeartbeat)
+//   - its dispatch log accumulated more than SUBSTANTIVE_LOG_BYTES
+//   - the declared artifact landed (worker reached deliverable write)
+// Anything less (rate-limit at spawn, /bin/false, immediate crash before
+// stdout flush) leaves attempts untouched so a benign re-dispatch isn't
+// burned as a retry.
+export const SUBSTANTIVE_LOG_BYTES = 1024;
+
+export function hadAnyHeartbeat(lock: LockFile): boolean {
+  if (!lock.heartbeat || !lock.started_at) return false;
+  return lock.heartbeat !== lock.started_at;
+}
+
+function logFileSize(path: string | null | undefined): number {
+  if (!path) return 0;
+  try {
+    if (!existsSync(path)) return 0;
+    const st = statSync(path);
+    return st.isFile() ? st.size : 0;
+  } catch {
+    return 0;
+  }
+}
 
 export function loadLock(ctx: StateContext): LockFile | null {
   if (!existsSync(ctx.paths.lockFile)) return null;
@@ -115,6 +142,14 @@ export function checkLockStaleness(
   const runSec = (now.getTime() - started.getTime()) / 1000;
   const capSec = (ps.max_minutes ?? 45) * 60;
 
+  // H-2 evidence used by both staleness branches to decide whether to
+  // increment ps.attempts when we mark the phase failed.
+  const hbFired = hadAnyHeartbeat(lock);
+  const logBytes = logFileSize(opts.dispatchLogPath ?? null);
+  const art = checkArtifact(ctx, lock.phase_id);
+  const ranSubstantively =
+    hbFired || logBytes > SUBSTANTIVE_LOG_BYTES || art.exists;
+
   if (ageSec > HEARTBEAT_GRACE_SEC) {
     const failure = classifyStaleLock(ctx, lock, {
       trigger: 'heartbeat',
@@ -131,7 +166,6 @@ export function checkLockStaleness(
       failure.class === 'worker_hung_post_success' &&
       isAutoResolveEnabled(ctx)
     ) {
-      const art = checkArtifact(ctx, lock.phase_id);
       const grepOk = art.grep_matched !== false;
       if (art.exists && art.meets_min_bytes && grepOk) {
         markAutoAdjudicated(ctx, String(lock.phase_id), failure, {
@@ -156,13 +190,19 @@ export function checkLockStaleness(
         };
       }
     }
-    markFailed(ctx, String(lock.phase_id), failure);
+    markFailed(ctx, String(lock.phase_id), failure, { ranSubstantively });
     clearLock(ctx);
     appendAudit(ctx.paths.auditFile, 'lock_cleared', {
       phase_id: lock.phase_id,
       reason: 'heartbeat',
       age_sec: Math.floor(ageSec),
       class: failure.class,
+      ran_substantively: ranSubstantively,
+      evidence: {
+        hb_fired: hbFired,
+        log_bytes: logBytes,
+        artifact_exists: art.exists,
+      },
     });
     return {
       kind: 'cleared',
@@ -180,7 +220,9 @@ export function checkLockStaleness(
       cap_sec: capSec,
       dispatchLogPath: opts.dispatchLogPath ?? null,
     });
-    markFailed(ctx, String(lock.phase_id), failure);
+    // Runtime cap exceeded implies the worker ran past its budget — treat as
+    // substantive regardless of the heuristic-evidence inputs.
+    markFailed(ctx, String(lock.phase_id), failure, { ranSubstantively: true });
     clearLock(ctx);
     appendAudit(ctx.paths.auditFile, 'lock_cleared', {
       phase_id: lock.phase_id,

--- a/packages/chain-runner/src/runner.ts
+++ b/packages/chain-runner/src/runner.ts
@@ -1,14 +1,22 @@
-import { spawn } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { closeSync, mkdtempSync, openSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { acquireLock } from './lock.js';
+import { acquireLock, clearLock } from './lock.js';
+import { appendAudit } from './audit.js';
+import { classifyEarlyExit } from './classify.js';
 import { findPhase } from './spec.js';
-import { markInProgress, type StateContext } from './state.js';
+import { markFailed, markInProgress, type StateContext } from './state.js';
+import type { LockFile, PhaseFailure } from './types.js';
 
 export interface DispatchOptions {
   command: string;
   args?: string[];
+  /**
+   * Override the post-spawn early-exit detection window (ms). Default 5000.
+   * Tests pass a shorter value to keep the suite snappy.
+   */
+  earlyExitWindowMs?: number;
 }
 
 export interface DispatchResult {
@@ -16,6 +24,50 @@ export interface DispatchResult {
   sessionId: string;
   promptFile: string;
   pid: number | null;
+  /** Per-dispatch log file path (stdout+stderr of the spawned worker). */
+  logFile?: string;
+  /** Set when the child exited within the post-spawn early-exit window. */
+  early_exit_code?: number | null;
+  /** Optional kill signal (e.g. 'SIGKILL') if process was terminated. */
+  early_exit_signal?: string | null;
+  /** Set when an early exit triggered classification + markFailed. */
+  early_failure?: PhaseFailure;
+}
+
+const DEFAULT_EARLY_EXIT_WINDOW_MS = 5000;
+
+interface EarlyExit {
+  code: number | null;
+  signal: string | null;
+}
+
+function waitForEarlyExit(
+  child: ChildProcess,
+  windowMs: number,
+): Promise<EarlyExit | null> {
+  return new Promise<EarlyExit | null>((resolve) => {
+    let settled = false;
+    const settle = (v: EarlyExit | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off('exit', onExit);
+      child.off('error', onError);
+      resolve(v);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      settle({ code, signal: signal ?? null });
+    };
+    const onError = (): void => {
+      // Spawn failed (ENOENT, EACCES, EPERM …). Without this handler, the
+      // 'error' event becomes an unhandled exception. Synthesize a non-zero
+      // exit so the caller classifies it as a worker_no_start_* failure.
+      settle({ code: 127, signal: null });
+    };
+    const timer = setTimeout(() => settle(null), windowMs);
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
 }
 
 function genSessionId(phaseId: number): string {
@@ -76,32 +128,151 @@ Your task starts below:
  *
  * If `dispatch.command` is empty, returns the prompt file + session id
  * without spawning — useful for callers that want to manage the spawn.
+ *
+ * H-3 (2026-05-14): when a command is spawned, dispatchPhase opens a
+ * per-dispatch log file (stdio routed there) and races the child's `exit`
+ * against a 5s window. An early non-zero exit is classified via
+ * classifyEarlyExit (sniffs the log for rate-limit / auth banners), the
+ * phase is marked failed (attempts NOT charged because the worker didn't
+ * run), and the lock is cleared so the next wake can re-dispatch.
  */
-export function dispatchPhase(
+export async function dispatchPhase(
   ctx: StateContext,
   phaseId: number,
   dispatch?: DispatchOptions,
-): DispatchResult {
+): Promise<DispatchResult> {
   const sessionId = genSessionId(phaseId);
   const promptFile = buildPromptFile(ctx, phaseId, ctx.spec.phases.length);
 
   markInProgress(ctx, String(phaseId), sessionId);
   acquireLock(ctx, phaseId, sessionId);
 
-  let pid: number | null = null;
-  if (dispatch?.command) {
-    const args = [
-      ...(dispatch.args ?? []),
-      String(phaseId),
-      sessionId,
-      promptFile,
-    ];
+  if (!dispatch?.command) {
+    return { phaseId, sessionId, promptFile, pid: null };
+  }
+
+  const logFile = join(
+    ctx.paths.baseDir,
+    `dispatch-${phaseId}-${sessionId}.log`,
+  );
+  const args = [
+    ...(dispatch.args ?? []),
+    String(phaseId),
+    sessionId,
+    promptFile,
+  ];
+
+  let logFd: number;
+  try {
+    logFd = openSync(logFile, 'a');
+  } catch (err) {
+    // Disk full / permission denied opening the log → fall back to a
+    // no-stdio spawn so we still launch the worker. Audit the degraded state.
+    appendAudit(ctx.paths.auditFile, 'dispatch_log_open_failed', {
+      phase_id: phaseId,
+      session_id: sessionId,
+      log_file: logFile,
+      error: (err as Error).message,
+    });
     const child = spawn(dispatch.command, args, {
       detached: true,
       stdio: 'ignore',
     });
     child.unref();
-    pid = child.pid ?? null;
+    return {
+      phaseId,
+      sessionId,
+      promptFile,
+      pid: child.pid ?? null,
+      logFile,
+    };
   }
-  return { phaseId, sessionId, promptFile, pid };
+
+  const child = spawn(dispatch.command, args, {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+  });
+  child.unref();
+  const pid = child.pid ?? null;
+
+  appendAudit(ctx.paths.auditFile, 'dispatch_spawned', {
+    phase_id: phaseId,
+    session_id: sessionId,
+    pid,
+    command: dispatch.command,
+    log_file: logFile,
+  });
+
+  const windowMs = dispatch.earlyExitWindowMs ?? DEFAULT_EARLY_EXIT_WINDOW_MS;
+  const t0 = Date.now();
+  const exit = await waitForEarlyExit(child, windowMs);
+  // Best-effort close of our copy of the log fd. The child still holds it via
+  // inheritance; node won't actually release the file until the child exits.
+  try {
+    closeSync(logFd);
+  } catch {
+    // ignore
+  }
+
+  if (!exit) {
+    // Window elapsed with the child still running — happy path.
+    return { phaseId, sessionId, promptFile, pid, logFile };
+  }
+
+  // Child exited within the window.
+  if (exit.code === 0 && exit.signal === null) {
+    // Graceful early completion — worker called mark-done itself, or
+    // dispatch target was a stub like /bin/true. Don't classify as failure.
+    appendAudit(ctx.paths.auditFile, 'dispatch_early_exit_clean', {
+      phase_id: phaseId,
+      session_id: sessionId,
+      pid,
+      elapsed_ms: Date.now() - t0,
+    });
+    return {
+      phaseId,
+      sessionId,
+      promptFile,
+      pid,
+      logFile,
+      early_exit_code: 0,
+      early_exit_signal: null,
+    };
+  }
+
+  // Non-zero exit (or signal) — classify, markFailed, clear lock so retry can run.
+  const lockSnapshot: LockFile = {
+    phase_id: phaseId,
+    session_id: sessionId,
+    started_at: new Date(t0).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    heartbeat: new Date(t0).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+  };
+  const failure = classifyEarlyExit(lockSnapshot, {
+    exitCode: exit.code,
+    signal: exit.signal,
+    dispatchLogPath: logFile,
+    elapsedMs: Date.now() - t0,
+  });
+  // Worker never ran substantively (it exited within 5s, no heartbeat).
+  markFailed(ctx, String(phaseId), failure, { ranSubstantively: false });
+  clearLock(ctx);
+  appendAudit(ctx.paths.auditFile, 'dispatch_early_exit_failed', {
+    phase_id: phaseId,
+    session_id: sessionId,
+    pid,
+    exit_code: exit.code,
+    signal: exit.signal,
+    class: failure.class,
+    elapsed_ms: Date.now() - t0,
+  });
+  return {
+    phaseId,
+    sessionId,
+    promptFile,
+    pid,
+    logFile,
+    early_exit_code: exit.code,
+    early_exit_signal: exit.signal,
+    early_failure: failure,
+  };
 }

--- a/packages/chain-runner/src/state.ts
+++ b/packages/chain-runner/src/state.ts
@@ -8,6 +8,7 @@ import { failureFromReason } from './classify.js';
 import type {
   ChainPaths,
   ChainSpec,
+  FailureClass,
   PhaseFailure,
   PhaseState,
   StateFile,
@@ -158,6 +159,12 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
   return { kind: 'none_eligible' };
 }
 
+// H-2 (chain-runner-battle-harden phase 3, 2026-05-14). markInProgress emits
+// only the lifecycle audit events; it no longer mutates ps.attempts. The
+// counter advances in recordAttemptCompleted, which is called by markDone /
+// markFailed / the lock-staleness path with a `ranSubstantively` flag — a
+// worker that never started (rate-limit, auth-fail, /bin/false) leaves
+// attempts untouched, so a benign re-dispatch isn't burned as a retry.
 export function markInProgress(
   ctx: StateContext,
   phaseId: string,
@@ -168,10 +175,19 @@ export function markInProgress(
   ps.status = 'in_progress';
   ps.session_id = sessionId;
   ps.started_at = isoNow();
-  ps.attempts += 1;
   ps.error = null;
   state.current_phase = Number(phaseId);
   saveState(ctx, state);
+  // New event: attempt_started — fires once per dispatch regardless of whether
+  // the worker actually runs. Use the audit timeline to count dispatches.
+  appendAudit(ctx.paths.auditFile, 'attempt_started', {
+    phase_id: Number(phaseId),
+    session_id: sessionId,
+    attempts_so_far: ps.attempts,
+  });
+  // Keep phase_in_progress for back-compat with watchdogs / regression tests
+  // that grep for it. The `attempt` field reports the current counter; it
+  // does NOT pre-increment.
   appendAudit(ctx.paths.auditFile, 'phase_in_progress', {
     phase_id: Number(phaseId),
     session_id: sessionId,
@@ -179,12 +195,64 @@ export function markInProgress(
   });
 }
 
+// H-2. Called by markDone, markFailed, and the lock-staleness recovery path.
+// Increments ps.attempts iff the worker showed any sign of running — heartbeat
+// fired, log produced output, artifact landed, or the worker itself called
+// mark-done/mark-failed. A zero-evidence early exit (binary missing, rate
+// limit at spawn) returns without incrementing so the retry policy gets a
+// clean slate.
+export function recordAttemptCompleted(
+  ctx: StateContext,
+  phaseId: string,
+  sessionId: string | null,
+  ranSubstantively: boolean,
+): void {
+  const state = loadState(ctx);
+  const ps = ensurePhaseEntry(state, phaseId);
+  const before = ps.attempts;
+  if (ranSubstantively) {
+    ps.attempts = before + 1;
+    saveState(ctx, state);
+  }
+  appendAudit(ctx.paths.auditFile, 'attempt_completed', {
+    phase_id: Number(phaseId),
+    session_id: sessionId,
+    ran_substantively: ranSubstantively,
+    attempts_before: before,
+    attempts_after: ps.attempts,
+  });
+}
+
+// H-2 heuristic. Returns true when the failure evidence shows the worker did
+// real work. Used by markFailed's default path when the caller hasn't already
+// computed ranSubstantively from the lock.
+//
+// Rule of thumb:
+//   - worker_no_start_*           → false (worker never got going)
+//   - runtime_exceeded            → true  (worker ran past the cap)
+//   - worker_hung_*               → true
+//   - worker_crashed              → true
+//   - mark_done_failed, artifact_*→ true  (the worker had to run to fail here)
+//   - acceptance_failed, pr_unmerged_at_done → true
+//   - unknown                     → true  (conservative — counts toward retry)
+function inferRanSubstantivelyFromClass(cls: FailureClass): boolean {
+  if (cls.startsWith('worker_no_start_')) return false;
+  return true;
+}
+
 export function markDone(ctx: StateContext, phaseId: string): void {
   const state = loadState(ctx);
   const ps = ensurePhaseEntry(state, phaseId);
-  ps.status = 'done';
-  ps.completed_at = isoNow();
-  saveState(ctx, state);
+  const sessionId = ps.session_id;
+  // Increment attempts before flipping status so the audit shows the final
+  // count when the phase finishes.
+  recordAttemptCompleted(ctx, phaseId, sessionId, true);
+  // Re-load: recordAttemptCompleted just persisted.
+  const state2 = loadState(ctx);
+  const ps2 = ensurePhaseEntry(state2, phaseId);
+  ps2.status = 'done';
+  ps2.completed_at = isoNow();
+  saveState(ctx, state2);
   appendAudit(ctx.paths.auditFile, 'phase_done', {
     phase_id: Number(phaseId),
   });
@@ -201,6 +269,10 @@ export function markAutoAdjudicated(
   failure: PhaseFailure,
   verification: Record<string, unknown>,
 ): void {
+  const sessionId =
+    loadState(ctx).phase_status[phaseId]?.session_id ?? null;
+  // worker_hung_post_success means the artifact landed — the worker ran.
+  recordAttemptCompleted(ctx, phaseId, sessionId, true);
   const state = loadState(ctx);
   const ps = ensurePhaseEntry(state, phaseId);
   ps.status = 'done';
@@ -215,6 +287,17 @@ export function markAutoAdjudicated(
   });
 }
 
+export interface MarkFailedOptions {
+  /**
+   * Whether the worker showed signs of actually running. When omitted, the
+   * value is inferred from `failure.class` (worker_no_start_* → false,
+   * otherwise → true). The lock-staleness path passes an explicit boolean
+   * computed from heartbeat / log-size / artifact evidence so a zero-work
+   * dispatch isn't charged as a retry.
+   */
+  ranSubstantively?: boolean;
+}
+
 // Back-compat shim: legacy callers pass a string reason; new callers pass a
 // structured PhaseFailure. The shim wraps the string under class=unknown so
 // existing wake scripts + the `caia-chain mark-failed <id> <reason>` CLI
@@ -223,11 +306,18 @@ export function markFailed(
   ctx: StateContext,
   phaseId: string,
   failureOrReason: PhaseFailure | string,
+  opts: MarkFailedOptions = {},
 ): void {
   const failure: PhaseFailure =
     typeof failureOrReason === 'string'
       ? failureFromReason(failureOrReason)
       : failureOrReason;
+  const ranSubstantively =
+    opts.ranSubstantively ?? inferRanSubstantivelyFromClass(failure.class);
+  // Stash sessionId before mutating state, for the attempt_completed event.
+  const sessionId =
+    loadState(ctx).phase_status[phaseId]?.session_id ?? null;
+  recordAttemptCompleted(ctx, phaseId, sessionId, ranSubstantively);
   const state = loadState(ctx);
   const ps = ensurePhaseEntry(state, phaseId);
   ps.status = 'failed';
@@ -239,6 +329,7 @@ export function markFailed(
     class: failure.class,
     reason: failure.reason.slice(0, 500),
     attempt: ps.attempts,
+    ran_substantively: ranSubstantively,
     evidence: failure.evidence,
   });
 }

--- a/packages/chain-runner/tests/lifecycle.test.ts
+++ b/packages/chain-runner/tests/lifecycle.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { makeFixture, type FixtureBundle } from './fixtures.js';
+import {
+  loadContext,
+  loadState,
+  markDone,
+  markFailed,
+  markInProgress,
+  recordAttemptCompleted,
+  type StateContext,
+} from '../src/state.js';
+import {
+  acquireLock,
+  checkLockStaleness,
+  clearLock,
+  hadAnyHeartbeat,
+  heartbeat,
+  loadLock,
+  saveLock,
+} from '../src/lock.js';
+import { dispatchPhase } from '../src/runner.js';
+import type { LockFile } from '../src/types.js';
+
+// Lifecycle test suite — H-2 (attempts semantics) + H-3 (early-exit capture).
+//
+// Scenarios covered:
+//   L01_markInProgress_does_not_increment_attempts
+//   L02_markDone_after_heartbeat_increments_attempts
+//   L03_markFailed_no_heartbeat_no_log_no_artifact_does_not_increment
+//   L04_markFailed_after_heartbeat_increments
+//   L05_checkLockStaleness_zero_evidence_no_increment
+//   L06_checkLockStaleness_with_heartbeat_increments
+//   L07_dispatch_early_exit_binfalse_marks_failed_no_attempts
+//   L08_dispatch_sleep_stub_returns_quickly_in_progress
+//   L09_recordAttemptCompleted_helper_direct
+//   L10_hadAnyHeartbeat_helper
+
+let fx: FixtureBundle;
+let ctx: StateContext;
+
+beforeEach(() => {
+  fx = makeFixture(`life-${Math.random().toString(36).slice(2, 8)}`);
+  ctx = loadContext(fx.chainId, fx.specPath);
+});
+
+afterEach(() => {
+  fx.cleanup();
+});
+
+describe('L01_markInProgress_does_not_increment_attempts', () => {
+  it('attempts stays at 0 after first markInProgress', () => {
+    markInProgress(ctx, '1', 'sess-l01');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(0);
+    expect(state.phase_status['1']?.status).toBe('in_progress');
+  });
+
+  it('emits attempt_started audit event', () => {
+    markInProgress(ctx, '1', 'sess-l01b');
+    const lines = readFileSync(ctx.paths.auditFile, 'utf8').trim().split('\n');
+    const events = lines.map((ln) => JSON.parse(ln).event as string);
+    expect(events).toContain('attempt_started');
+    expect(events).toContain('phase_in_progress');
+  });
+});
+
+describe('L02_markDone_after_heartbeat_increments_attempts_to_1', () => {
+  it('attempts=1 after a heartbeat-fired run', () => {
+    markInProgress(ctx, '1', 'sess-l02');
+    acquireLock(ctx, 1, 'sess-l02');
+    const hb = heartbeat(ctx, 'sess-l02');
+    expect(hb.kind).toBe('ok');
+    markDone(ctx, '1');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(1);
+    expect(state.phase_status['1']?.status).toBe('done');
+  });
+});
+
+describe('L03_markFailed_no_heartbeat_no_log_no_artifact_does_not_increment', () => {
+  it('ranSubstantively=false leaves attempts at 0', () => {
+    markInProgress(ctx, '1', 'sess-l03');
+    acquireLock(ctx, 1, 'sess-l03');
+    // Mark failed with an explicit ranSubstantively=false (rate-limit shape).
+    markFailed(
+      ctx,
+      '1',
+      {
+        class: 'worker_no_start_rate_limit',
+        reason: 'rate limit hit at dispatch',
+        detected_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        evidence: {},
+      },
+      { ranSubstantively: false },
+    );
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(0);
+    expect(state.phase_status['1']?.status).toBe('failed');
+  });
+
+  it('default inference: worker_no_start_* class → ranSubstantively=false', () => {
+    markInProgress(ctx, '2', 'sess-l03b');
+    markFailed(ctx, '2', {
+      class: 'worker_no_start_binary_missing',
+      reason: 'claude binary missing',
+      detected_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      evidence: {},
+    });
+    const state = loadState(ctx);
+    expect(state.phase_status['2']?.attempts).toBe(0);
+  });
+});
+
+describe('L04_markFailed_after_heartbeat_increments', () => {
+  it('explicit ranSubstantively=true bumps attempts', () => {
+    markInProgress(ctx, '1', 'sess-l04');
+    acquireLock(ctx, 1, 'sess-l04');
+    heartbeat(ctx, 'sess-l04');
+    markFailed(
+      ctx,
+      '1',
+      {
+        class: 'worker_crashed',
+        reason: 'SIGSEGV',
+        detected_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        evidence: {},
+      },
+      { ranSubstantively: true },
+    );
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(1);
+  });
+
+  it('default inference: non-worker_no_start class → ranSubstantively=true', () => {
+    markInProgress(ctx, '1', 'sess-l04b');
+    markFailed(ctx, '1', {
+      class: 'worker_hung_mid_work',
+      reason: 'silent stall',
+      detected_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      evidence: {},
+    });
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(1);
+  });
+});
+
+describe('L05_checkLockStaleness_zero_evidence_no_increment', () => {
+  it('staleness clears lock without charging an attempt when no heartbeat fired, no log, no artifact', () => {
+    markInProgress(ctx, '1', 'sess-l05');
+    acquireLock(ctx, 1, 'sess-l05');
+    // Backdate the heartbeat to be older than HEARTBEAT_GRACE_SEC. Use the
+    // SAME timestamp for started_at so hadAnyHeartbeat returns false.
+    const lock = loadLock(ctx) as LockFile;
+    const past = new Date(Date.now() - 4 * 3600 * 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    saveLock(ctx, { ...lock, started_at: past, heartbeat: past });
+
+    const r = checkLockStaleness(ctx);
+    expect(r.kind).toBe('cleared');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(0);
+  });
+});
+
+describe('L06_checkLockStaleness_with_heartbeat_increments', () => {
+  it('staleness with heartbeat evidence bumps attempts to 1', () => {
+    markInProgress(ctx, '1', 'sess-l06');
+    acquireLock(ctx, 1, 'sess-l06');
+    // Need a started_at != heartbeat to prove heartbeat() fired. Set both
+    // backdated so the staleness path triggers, but with different values.
+    const startedPast = new Date(Date.now() - 5 * 3600 * 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    const hbPast = new Date(Date.now() - 4 * 3600 * 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    const lock = loadLock(ctx) as LockFile;
+    saveLock(ctx, { ...lock, started_at: startedPast, heartbeat: hbPast });
+
+    const r = checkLockStaleness(ctx);
+    expect(r.kind).toBe('cleared');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(1);
+  });
+});
+
+describe('L07_dispatch_early_exit_binfalse_marks_failed_no_attempts', () => {
+  // `/bin/false` doesn't exist on macOS — falsey binary lives at /usr/bin/false.
+  // Use whichever is present so this test works on both Linux and macOS CI.
+  const FALSE_BIN = existsSync('/bin/false') ? '/bin/false' : '/usr/bin/false';
+
+  it('early-exit binary triggers markFailed with class=worker_no_start_spawn_error, attempts NOT incremented', async () => {
+    const result = await dispatchPhase(ctx, 1, {
+      command: FALSE_BIN,
+      earlyExitWindowMs: 1500,
+    });
+    expect(typeof result.early_exit_code).toBe('number');
+    expect(result.early_exit_code).not.toBe(0);
+    expect(result.early_failure?.class).toBe('worker_no_start_spawn_error');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.status).toBe('failed');
+    expect(state.phase_status['1']?.attempts).toBe(0);
+    expect(existsSync(ctx.paths.lockFile)).toBe(false);
+  });
+
+  it('ENOENT (missing binary) is captured as worker_no_start_spawn_error via error event', async () => {
+    const result = await dispatchPhase(ctx, 1, {
+      command: '/definitely/not/a/real/binary/caia-chain-test',
+      earlyExitWindowMs: 1500,
+    });
+    expect(typeof result.early_exit_code).toBe('number');
+    expect(result.early_exit_code).not.toBe(0);
+    expect(result.early_failure?.class).toBe('worker_no_start_spawn_error');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(0);
+  });
+});
+
+describe('L08_dispatch_sleep_stub_returns_quickly_in_progress', () => {
+  it('long-running spawn returns within the early-exit window with phase still in_progress', async () => {
+    // Use a shell wrapper because dispatchPhase appends phase/session/prompt
+    // args to dispatch.args, and `/bin/sleep` errors on non-numeric args.
+    // `sh -c <cmd>` ignores positional args after $0, so this just sleeps.
+    const t0 = Date.now();
+    const result = await dispatchPhase(ctx, 1, {
+      command: '/bin/sh',
+      args: ['-c', 'sleep 5'],
+      earlyExitWindowMs: 300,
+    });
+    const elapsed = Date.now() - t0;
+    expect(result.early_exit_code).toBeUndefined();
+    expect(elapsed).toBeLessThan(2000);
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.status).toBe('in_progress');
+    expect(state.phase_status['1']?.attempts).toBe(0);
+    expect(existsSync(ctx.paths.lockFile)).toBe(true);
+    // Reap the lingering sh child so the test runner can exit promptly.
+    if (result.pid) {
+      try {
+        process.kill(result.pid, 'SIGKILL');
+      } catch {
+        // ignore — already gone
+      }
+    }
+    clearLock(ctx);
+  });
+});
+
+describe('L09_recordAttemptCompleted_helper_direct', () => {
+  it('records audit event and does not increment when ranSubstantively=false', () => {
+    markInProgress(ctx, '1', 'sess-l09');
+    recordAttemptCompleted(ctx, '1', 'sess-l09', false);
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(0);
+    const lines = readFileSync(ctx.paths.auditFile, 'utf8').trim().split('\n');
+    const completed = lines
+      .map((ln) => JSON.parse(ln))
+      .filter((ev) => ev.event === 'attempt_completed');
+    expect(completed.length).toBeGreaterThanOrEqual(1);
+    const last = completed[completed.length - 1];
+    expect(last.ran_substantively).toBe(false);
+    expect(last.attempts_after).toBe(0);
+  });
+
+  it('increments when ranSubstantively=true', () => {
+    markInProgress(ctx, '1', 'sess-l09b');
+    recordAttemptCompleted(ctx, '1', 'sess-l09b', true);
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.attempts).toBe(1);
+  });
+});
+
+describe('L10_hadAnyHeartbeat_helper', () => {
+  it('returns false when heartbeat == started_at (no heartbeat() call made)', () => {
+    acquireLock(ctx, 1, 'sess-l10');
+    const lock = loadLock(ctx) as LockFile;
+    expect(hadAnyHeartbeat(lock)).toBe(false);
+  });
+
+  it('returns true when heartbeat differs from started_at', async () => {
+    acquireLock(ctx, 1, 'sess-l10b');
+    // Need at least 1s gap (isoNow drops millis).
+    await new Promise((r) => setTimeout(r, 1100));
+    const r = heartbeat(ctx, 'sess-l10b');
+    expect(r.kind).toBe('ok');
+    const lock = loadLock(ctx) as LockFile;
+    expect(hadAnyHeartbeat(lock)).toBe(true);
+  });
+});
+
+describe('lifecycle invariants', () => {
+  it('audit event sequence on a normal mark-done: attempt_started → phase_in_progress → attempt_completed → phase_done', () => {
+    markInProgress(ctx, '1', 'sess-inv');
+    markDone(ctx, '1');
+    const lines = readFileSync(ctx.paths.auditFile, 'utf8').trim().split('\n');
+    const seq = lines.map((ln) => JSON.parse(ln).event as string);
+    const idx = (e: string): number => seq.indexOf(e);
+    expect(idx('attempt_started')).toBeGreaterThanOrEqual(0);
+    expect(idx('phase_in_progress')).toBeGreaterThan(idx('attempt_started'));
+    expect(idx('attempt_completed')).toBeGreaterThan(idx('phase_in_progress'));
+    expect(idx('phase_done')).toBeGreaterThan(idx('attempt_completed'));
+  });
+
+  it('legacy string-reason markFailed still works (back-compat shim)', () => {
+    markInProgress(ctx, '1', 'sess-legacy');
+    markFailed(ctx, '1', 'something went wrong');
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.status).toBe('failed');
+    expect(state.phase_status['1']?.failure?.class).toBe('unknown');
+    // Default inference for unknown → ranSubstantively=true (conservative).
+    expect(state.phase_status['1']?.attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the `chain-runner-battle-harden` chain. Implements H-2 (move
`attempts++` from dispatch to completion) and H-3 (capture child exit code
in a 5s post-spawn window).

- **H-2** — `markInProgress` no longer increments `ps.attempts`. New
  `recordAttemptCompleted(ctx, phaseId, sessionId, ranSubstantively)` is
  called by `markDone`, `markFailed`, and the lock-staleness path with an
  explicit `ranSubstantively` flag. A worker that never ran (rate-limit at
  spawn, `/bin/false`, ENOENT) leaves attempts untouched, so a benign
  re-dispatch doesn't burn a retry.
- **H-3** — `dispatchPhase` is now async. Opens a per-dispatch log file
  (stdio routed to it), races the child's `exit` event against a 5s window,
  and on early non-zero exit classifies via the new `classifyEarlyExit`
  (sniffs the log first, falls back to `worker_no_start_spawn_error`),
  marks failed with `ranSubstantively: false`, and clears the lock so the
  next wake can re-dispatch.
- ENOENT-style spawn errors are caught via an `error` listener so they no
  longer escape as unhandled exceptions.
- CLI `dispatch` exits 7 with `EARLY_EXIT phase=X exit_code=Y class=...`
  on stderr when an early failure is detected.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 158/158 green (regression 79 + classify 17 + watchdog 22
      + doctor 7 + healthz 6 + handoff-refresh 5 + pr-merge 4 + lifecycle 18)
- [x] New `tests/lifecycle.test.ts` covers:
  - L01–L02: `markInProgress` doesn't increment; `markDone` after heartbeat → attempts=1
  - L03–L04: `markFailed` `ranSubstantively` inference by class
  - L05–L06: `checkLockStaleness` zero-evidence vs. heartbeat-fired
  - L07: `/bin/false` (or `/usr/bin/false`) + missing-binary ENOENT → `worker_no_start_spawn_error`, attempts=0
  - L08: `sh -c 'sleep 5'` returns within the early-exit window with phase still `in_progress`
  - L09–L10: `recordAttemptCompleted` + `hadAnyHeartbeat` helpers
  - Audit-event sequence + legacy string-reason back-compat

## Standing rules respected

- Subscription-only billing (no `ANTHROPIC_API_KEY`)
- Worktree isolation (`feat/chain-harden-p3-lifecycle-2026-05-14` from `develop`)
- Backwards-compatible YAML schema unchanged
- 75-case regression suite still green (now 79 with no behavioral changes
  to existing assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)