### PR TITLE
feat(chain-runner): h-4 preflight + h-9 per-class retry policy

### DIFF
--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -43,6 +43,12 @@ import {
 import { appendAudit } from './audit.js';
 import { doctorExitCode, formatDoctorReport, runDoctor } from './doctor.js';
 import { fireHandoffRefresh } from './handoff-refresh.js';
+import {
+  DEFAULT_PROMPT as PREFLIGHT_DEFAULT_PROMPT,
+  DEFAULT_TIMEOUT_MS as PREFLIGHT_DEFAULT_TIMEOUT_MS,
+  formatPreflightLine,
+  preflightDispatch,
+} from './preflight.js';
 import { spawnSync } from 'node:child_process';
 
 interface BaseOptions {
@@ -152,6 +158,13 @@ export function buildProgram(): Command {
           break;
         case 'in_progress':
           process.stdout.write(`IN_PROGRESS ${result.id}\n`);
+          break;
+        case 'backoff':
+          // H-9: BACKOFF <seconds> phase=<id> until=<iso>. Wake scripts treat
+          // this as noop (log + exit 0).
+          process.stdout.write(
+            `BACKOFF ${result.seconds} phase=${result.id} until=${result.until}\n`,
+          );
           break;
         case 'phase_id':
           process.stdout.write(`${result.id}\n`);
@@ -300,12 +313,27 @@ export function buildProgram(): Command {
     );
 
   attachCommonOptions(program.command('pause'))
+    .option('--reason <text>', 'reason (persisted to state.paused_reason)')
+    .option(
+      '--until <iso>',
+      'ISO timestamp; wake-script shim auto-resumes once now >= until',
+    )
     .description('Suppress further dispatch until resume')
-    .action((opts: BaseOptions) => {
-      const ctx = ctxFromOpts(opts);
-      pause(ctx);
-      process.stdout.write('PAUSED\n');
-    });
+    .action(
+      (
+        cmdOpts: { reason?: string; until?: string },
+        cmd: Command,
+      ) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions;
+        const ctx = ctxFromOpts(opts);
+        const pauseOpts: { reason?: string; pausedUntil?: string } = {};
+        if (cmdOpts.reason !== undefined) pauseOpts.reason = cmdOpts.reason;
+        if (cmdOpts.until !== undefined) pauseOpts.pausedUntil = cmdOpts.until;
+        pause(ctx, pauseOpts);
+        const suffix = cmdOpts.until ? ` until=${cmdOpts.until}` : '';
+        process.stdout.write(`PAUSED${suffix}\n`);
+      },
+    );
 
   attachCommonOptions(program.command('resume'))
     .description('Re-enable dispatch')
@@ -333,6 +361,69 @@ export function buildProgram(): Command {
       }
       recordWake(ctx);
     });
+
+  // H-4 (chain-runner-battle-harden phase 4, 2026-05-14). preflight-dispatch
+  // probes the claude binary BEFORE we burn a dispatch slot. Exit codes are
+  // contract: 0 healthy, 1 generic, 2 rate_limited, 3 auth_failure, 4 timeout,
+  // 5 unknown, 6 api_key_leak. Wake scripts read the exit code + the stdout
+  // PREFLIGHT line; the result is also appended to audit.jsonl when --chain-id
+  // is supplied.
+  program
+    .command('preflight-dispatch')
+    .description(
+      'Probe claude binary before dispatch. Exit codes: 0 healthy, 2 rate_limited, 3 auth_failure, 4 timeout, 5 unknown, 6 api_key_leak.',
+    )
+    .option('--chain-id <id>', 'chain identifier (audit log destination)')
+    .option('--phases <path>', 'path to phases YAML spec (audit log destination)')
+    .option('--binary <path>', 'path to claude binary', 'claude')
+    .option('--prompt <text>', 'one-shot prompt sent via --print -p', PREFLIGHT_DEFAULT_PROMPT)
+    .option(
+      '--timeout-ms <n>',
+      'overall preflight wallclock timeout (ms)',
+      String(PREFLIGHT_DEFAULT_TIMEOUT_MS),
+    )
+    .option('--log <path>', 'append raw stdout/stderr to this path')
+    .option('--allow-api-key', 'do NOT refuse if ANTHROPIC_API_KEY is set (CI tests)')
+    .action(
+      async (cmdOpts: {
+        chainId?: string;
+        phases?: string;
+        binary?: string;
+        prompt?: string;
+        timeoutMs?: string;
+        log?: string;
+        allowApiKey?: boolean;
+      }) => {
+        const preOpts: Parameters<typeof preflightDispatch>[0] = {
+          refuseIfApiKeySet: !cmdOpts.allowApiKey,
+        };
+        if (cmdOpts.binary) preOpts.binary = cmdOpts.binary;
+        if (cmdOpts.prompt) preOpts.prompt = cmdOpts.prompt;
+        if (cmdOpts.timeoutMs) preOpts.timeoutMs = Number(cmdOpts.timeoutMs);
+        if (cmdOpts.log) preOpts.logPath = cmdOpts.log;
+        const r = await preflightDispatch(preOpts);
+        process.stdout.write(`${formatPreflightLine(r)}\n`);
+        // Audit if a chain context is available (chain-id + phases required).
+        if (cmdOpts.chainId && cmdOpts.phases) {
+          try {
+            const ctx = loadContext(cmdOpts.chainId, cmdOpts.phases);
+            const audit: Record<string, unknown> = {
+              status: r.status,
+              exit_code: r.exit_code,
+              elapsed_ms: r.elapsed_ms,
+              message: r.message.slice(0, 500),
+            };
+            if (r.reset_iso) audit['reset_iso'] = r.reset_iso;
+            if (r.reset_banner) audit['reset_banner'] = r.reset_banner;
+            appendAudit(ctx.paths.auditFile, 'preflight_dispatch', audit);
+          } catch {
+            // ignore — audit is a convenience, not load-bearing.
+          }
+        }
+        // 0/1/2/3/4/5/6
+        process.exit(r.exit_code);
+      },
+    );
 
   attachCommonOptions(program.command('dispatch'))
     .argument('<phase-id>')

--- a/packages/chain-runner/src/index.ts
+++ b/packages/chain-runner/src/index.ts
@@ -10,6 +10,13 @@ export * from './time.js';
 export * from './bootstrap.js';
 export * from './watchdog.js';
 export * from './classify.js';
+export * from './preflight.js';
+export {
+  DEFAULT_RETRY_POLICY,
+  backoffSecForAttempt,
+  resolveRetryPolicy,
+  validateRetryPolicyEntry,
+} from './retry-policy.js';
 export {
   mergeOrFail,
   viewPR,

--- a/packages/chain-runner/src/preflight.ts
+++ b/packages/chain-runner/src/preflight.ts
@@ -1,0 +1,359 @@
+// H-4 (chain-runner-battle-harden phase 4, 2026-05-14). Pre-dispatch health
+// gate. Probes the claude binary BEFORE the wake script spawns a worker so
+// the most common worker-no-start failure modes (rate-limit, auth, missing
+// binary, ANTHROPIC_API_KEY leak) are caught synchronously with a clean
+// classification + reset-time annotation rather than a 60-min watchdog
+// stall.
+//
+// Companion: src/retry-policy.ts (classes), reports/chain_runner_hardening_plan_2026-05-14.md §H-4.
+//
+// Exit-code contract (consumed by wake scripts):
+//   0  healthy        — claude is up, auth ok, no rate limit
+//   1  generic error  — preflight infra issue (file IO, internal exception)
+//   2  rate_limited   — banner matched; result.resetTimestamp may be present
+//   3  auth_failure   — banner matched; token rejected
+//   4  timeout        — claude did not respond within timeoutMs
+//   5  unknown        — claude responded but neither healthy nor
+//                       a recognized failure banner; full stdout in result.raw
+//   6  api_key_leak   — ANTHROPIC_API_KEY is set in the environment
+
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export type PreflightStatus =
+  | 'healthy'
+  | 'rate_limited'
+  | 'auth_failure'
+  | 'timeout'
+  | 'unknown'
+  | 'api_key_leak'
+  | 'preflight_error';
+
+export interface PreflightDispatchOptions {
+  /** Path to the claude binary. Defaults to `claude` (PATH-resolved). */
+  binary?: string;
+  /** Prompt sent via --print --max-turns 1 -p '<prompt>'. */
+  prompt?: string;
+  /** Overall wallclock timeout (ms). Default 15000. */
+  timeoutMs?: number;
+  /** Override env for the spawned process. Mainly for tests. */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Refuse if ANTHROPIC_API_KEY is set. Default true. Standing rule:
+   * subscription-only billing — a leaked API key means the chain is about to
+   * burn API credit instead of consuming the subscription quota.
+   */
+  refuseIfApiKeySet?: boolean;
+  /**
+   * When set, the raw stdout+stderr is also appended to this path so wake
+   * scripts can grep the reset time directly (used by D-4 paused_until).
+   */
+  logPath?: string;
+}
+
+export interface PreflightDispatchResult {
+  status: PreflightStatus;
+  exit_code: number;
+  /** Human-friendly summary, one line. */
+  message: string;
+  /** Wallclock from spawn to settle (ms). */
+  elapsed_ms: number;
+  /** Raw output (stdout+stderr), capped to ~32 KB. */
+  raw: string;
+  /** When status === 'rate_limited' and a reset banner was parsed. */
+  reset_iso?: string;
+  /** Verbatim reset banner sub-match, for audit. */
+  reset_banner?: string;
+}
+
+export const DEFAULT_PROMPT = 'reply with PREFLIGHT_OK in one word';
+export const DEFAULT_TIMEOUT_MS = 15000;
+export const RAW_CAP_BYTES = 32 * 1024;
+
+// Banner regexes. Mirror src/classify.ts:LOG_PATTERNS but tightened — these
+// fire on live preflight output, not post-mortem log scrapes.
+const RE_RATE_LIMIT = /You(?:'|’)ve hit your limit/i;
+const RE_AUTH_FAIL =
+  /Invalid authentication credentials|API Error 401|Unauthorized: invalid (?:api )?key|authentication_error/i;
+const RE_HEALTHY = /PREFLIGHT_OK/;
+
+// Reset banner. Two forms observed in the wild on the 2026-05-14 incident:
+//   "resets May 16 at 12pm (America/New_York)"
+//   "resets 4pm (America/New_York)"
+//   "resets at 12pm"
+// We make month/day optional, allow `at`, and capture the local-time tz.
+export const RE_RESET = /resets\s+(?:([A-Z][a-z]+)\s+(\d{1,2})\s+)?(?:at\s+)?(\d{1,2}(?::\d{2})?\s*(?:am|pm))\s*(?:\(([A-Za-z_]+\/[A-Za-z_]+)\))?/i;
+
+// Parse a reset banner into UTC ISO. Returns null if the banner is missing.
+// Strategy: take the captured (month-name day time tz?) and shape it into a
+// JS-parseable string. When tz is omitted, default to UTC; when month/day are
+// omitted, default to "today" relative to nowMs and bump to tomorrow if the
+// time has already passed.
+export function parseResetIsoFromBanner(
+  raw: string,
+  nowMs: number = Date.now(),
+): { iso: string | null; matched: string | null } {
+  const m = RE_RESET.exec(raw);
+  if (!m) return { iso: null, matched: null };
+  const monthName = m[1];
+  const dayStr = m[2];
+  const timeStr = (m[3] ?? '').trim();
+  const tzName = m[4] ?? null;
+  if (!timeStr) return { iso: null, matched: m[0] };
+
+  // Parse the time portion (e.g. "12pm", "4:30pm").
+  const tm = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(timeStr);
+  if (!tm) return { iso: null, matched: m[0] };
+  let hour = parseInt(tm[1] ?? '0', 10);
+  const minute = parseInt(tm[2] ?? '0', 10);
+  const meridiem = (tm[3] ?? '').toLowerCase();
+  if (meridiem === 'pm' && hour < 12) hour += 12;
+  if (meridiem === 'am' && hour === 12) hour = 0;
+
+  let dateObj: Date | null = null;
+  if (monthName && dayStr) {
+    // Year defaults to "now" — banners never carry a year. If the parsed
+    // date is more than 30 days in the past, bump it +1y.
+    const now = new Date(nowMs);
+    const yr = now.getUTCFullYear();
+    // Use ISO month names → JS Date via month parsing.
+    const tryStr = `${monthName} ${dayStr} ${yr} ${pad(hour)}:${pad(minute)}:00 ${tzAbbrFor(tzName) ?? 'UTC'}`;
+    const candidate = new Date(tryStr);
+    if (!Number.isNaN(candidate.getTime())) {
+      if (candidate.getTime() < nowMs - 30 * 24 * 60 * 60 * 1000) {
+        candidate.setUTCFullYear(yr + 1);
+      }
+      dateObj = candidate;
+    }
+  } else {
+    // No month/day — assume "today, in tz" and bump to tomorrow if the time
+    // has already passed.
+    const now = new Date(nowMs);
+    const todayStr = `${pad(now.getUTCFullYear())}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}`;
+    const tryStr = `${todayStr}T${pad(hour)}:${pad(minute)}:00${tzOffsetFor(tzName) ?? 'Z'}`;
+    const candidate = new Date(tryStr);
+    if (!Number.isNaN(candidate.getTime())) {
+      if (candidate.getTime() <= nowMs) {
+        candidate.setUTCDate(candidate.getUTCDate() + 1);
+      }
+      dateObj = candidate;
+    }
+  }
+  if (!dateObj) return { iso: null, matched: m[0] };
+  return {
+    iso: dateObj.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    matched: m[0],
+  };
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+// Best-effort TZ name → ISO offset. We don't ship a full tzdata; covers the
+// account-region timezones observed on this account.
+function tzOffsetFor(tz: string | null): string | null {
+  if (!tz) return null;
+  switch (tz) {
+    case 'America/New_York':
+      return '-04:00'; // approx; DST handled by JS Date when we reparse
+    case 'America/Los_Angeles':
+      return '-07:00';
+    case 'America/Chicago':
+      return '-05:00';
+    case 'UTC':
+    case 'Etc/UTC':
+      return 'Z';
+    default:
+      return null;
+  }
+}
+
+function tzAbbrFor(tz: string | null): string | null {
+  if (!tz) return null;
+  switch (tz) {
+    case 'America/New_York':
+      return 'EDT';
+    case 'America/Los_Angeles':
+      return 'PDT';
+    case 'America/Chicago':
+      return 'CDT';
+    case 'UTC':
+    case 'Etc/UTC':
+      return 'UTC';
+    default:
+      return null;
+  }
+}
+
+// Append a one-line raw-output dump to logPath. Best effort — preflight is
+// not blocking on log writes.
+function appendLog(logPath: string, body: string): void {
+  try {
+    if (!existsSync(dirname(logPath))) return;
+    const cap = body.length > RAW_CAP_BYTES ? body.slice(-RAW_CAP_BYTES) : body;
+    // Prepend timestamp + role for context.
+    const ts = new Date().toISOString();
+    const existing = existsSync(logPath) ? readFileSync(logPath, 'utf8') : '';
+    writeFileSync(logPath, `${existing}--- preflight ${ts} ---\n${cap}\n`);
+  } catch {
+    // ignore — preflight reports via return value, log is a convenience.
+  }
+}
+
+export async function preflightDispatch(
+  opts: PreflightDispatchOptions = {},
+): Promise<PreflightDispatchResult> {
+  const env = opts.env ?? process.env;
+  const refuseIfApiKey = opts.refuseIfApiKeySet ?? true;
+  if (refuseIfApiKey && typeof env['ANTHROPIC_API_KEY'] === 'string' && env['ANTHROPIC_API_KEY'].length > 0) {
+    const msg =
+      'ANTHROPIC_API_KEY is set in the environment — subscription-only billing requires it unset';
+    return {
+      status: 'api_key_leak',
+      exit_code: 6,
+      message: msg,
+      elapsed_ms: 0,
+      raw: '',
+    };
+  }
+  const binary = opts.binary ?? 'claude';
+  const prompt = opts.prompt ?? DEFAULT_PROMPT;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const t0 = Date.now();
+
+  return new Promise<PreflightDispatchResult>((resolve) => {
+    let settled = false;
+    let raw = '';
+    const settle = (result: PreflightDispatchResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.removeAllListeners();
+      if (opts.logPath) appendLog(opts.logPath, raw);
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // already exited
+      }
+      resolve(result);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(
+        binary,
+        ['--print', '--max-turns', '1', '-p', prompt],
+        {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env,
+        },
+      );
+    } catch (err) {
+      resolve({
+        status: 'preflight_error',
+        exit_code: 1,
+        message: `failed to spawn ${binary}: ${(err as Error).message}`,
+        elapsed_ms: Date.now() - t0,
+        raw: '',
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      settle({
+        status: 'timeout',
+        exit_code: 4,
+        message: `preflight timed out after ${timeoutMs}ms`,
+        elapsed_ms: Date.now() - t0,
+        raw,
+      });
+    }, timeoutMs);
+
+    const onData = (chunk: Buffer): void => {
+      raw += chunk.toString('utf8');
+      if (raw.length > RAW_CAP_BYTES * 2) {
+        raw = raw.slice(-RAW_CAP_BYTES);
+      }
+    };
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.once('error', (err) => {
+      // ENOENT (binary not on PATH), EACCES, etc. Don't classify here as
+      // binary_missing — that's the wake script's job after seeing exit 1
+      // or exit 5; we expose the raw error in `message`.
+      settle({
+        status: 'preflight_error',
+        exit_code: 1,
+        message: `${binary} spawn error: ${(err as { code?: string; message: string }).code ?? err.message}`,
+        elapsed_ms: Date.now() - t0,
+        raw,
+      });
+    });
+    child.once('exit', (code) => {
+      const elapsed = Date.now() - t0;
+      // Decision tree: rate-limit FIRST (banner is the most specific), then
+      // auth, then healthy, then everything else → unknown.
+      if (RE_RATE_LIMIT.test(raw)) {
+        const parsed = parseResetIsoFromBanner(raw, t0);
+        const result: PreflightDispatchResult = {
+          status: 'rate_limited',
+          exit_code: 2,
+          message: parsed.matched
+            ? `rate limit hit (${parsed.matched.trim()})`
+            : 'rate limit hit (no reset banner parsed)',
+          elapsed_ms: elapsed,
+          raw,
+        };
+        if (parsed.iso) result.reset_iso = parsed.iso;
+        if (parsed.matched) result.reset_banner = parsed.matched;
+        settle(result);
+        return;
+      }
+      if (RE_AUTH_FAIL.test(raw)) {
+        settle({
+          status: 'auth_failure',
+          exit_code: 3,
+          message: 'authentication failure (token rejected by API)',
+          elapsed_ms: elapsed,
+          raw,
+        });
+        return;
+      }
+      if (RE_HEALTHY.test(raw)) {
+        settle({
+          status: 'healthy',
+          exit_code: 0,
+          message: `preflight ok (elapsed_ms=${elapsed})`,
+          elapsed_ms: elapsed,
+          raw,
+        });
+        return;
+      }
+      // Exit non-zero with no recognized banner → still unknown so wake
+      // scripts can alert + fall through to next cycle without burning a
+      // retry.
+      settle({
+        status: 'unknown',
+        exit_code: 5,
+        message: `preflight produced no recognized signal (claude exit=${code ?? 'null'})`,
+        elapsed_ms: elapsed,
+        raw,
+      });
+    });
+  });
+}
+
+// Format a one-line stdout line wake scripts can grep deterministically.
+// Schema: `PREFLIGHT status=<s> exit=<n> elapsed_ms=<n> [reset_iso=<iso>] [reset_banner="<...>"]`.
+export function formatPreflightLine(r: PreflightDispatchResult): string {
+  const parts = [
+    `PREFLIGHT status=${r.status}`,
+    `exit=${r.exit_code}`,
+    `elapsed_ms=${r.elapsed_ms}`,
+  ];
+  if (r.reset_iso) parts.push(`reset_iso=${r.reset_iso}`);
+  if (r.reset_banner) parts.push(`reset_banner="${r.reset_banner.replace(/"/g, '\\"')}"`);
+  return parts.join(' ');
+}

--- a/packages/chain-runner/src/retry-policy.ts
+++ b/packages/chain-runner/src/retry-policy.ts
@@ -1,0 +1,121 @@
+// H-9 (chain-runner-battle-harden phase 4, 2026-05-14). Per-failure-class
+// retry policy resolution. Maps each FailureClass to a (max_attempts,
+// backoff_sec[], action) tuple. The chain YAML can override any class via
+// `defaults.retry_policy.<class>`; unset classes fall back to the defaults
+// below, which encode the operator decisions from
+// `reports/chain_runner_hardening_plan_2026-05-14.md §H-9`.
+import type {
+  ChainSpec,
+  FailureClass,
+  RetryPolicyAction,
+  RetryPolicyEntry,
+} from './types.js';
+
+// Defaults, see hardening plan §H-9 YAML block. Each class has an explicit
+// entry — there is no implicit fallback to a single "default" entry; missing
+// classes are filled in below at lookup time.
+export const DEFAULT_RETRY_POLICY: Record<FailureClass, RetryPolicyEntry> = {
+  worker_no_start_rate_limit: { max_attempts: 0, action: 'pause_until_reset' },
+  worker_no_start_auth_failure: { max_attempts: 0, action: 'pause_until_operator' },
+  worker_no_start_binary_missing: { max_attempts: 0, action: 'pause_until_operator' },
+  worker_no_start_spawn_error: {
+    max_attempts: 3,
+    backoff_sec: [60, 300, 900],
+    action: 'retry',
+  },
+  worker_no_start_bad_args: { max_attempts: 0, action: 'pause_until_operator' },
+  worker_hung_post_success: { max_attempts: 0, action: 'adjudicate' },
+  worker_hung_mid_work: { max_attempts: 1, backoff_sec: [60], action: 'retry' },
+  worker_crashed: { max_attempts: 2, backoff_sec: [120, 600], action: 'retry' },
+  mark_done_failed: { max_attempts: 1, backoff_sec: [60], action: 'retry' },
+  artifact_missing: { max_attempts: 1, backoff_sec: [60], action: 'retry' },
+  artifact_malformed: { max_attempts: 0, action: 'adjudicate' },
+  pr_unmerged_at_done: { max_attempts: 0, action: 'adjudicate' },
+  acceptance_failed: { max_attempts: 0, action: 'adjudicate' },
+  runtime_exceeded: { max_attempts: 0, action: 'alert' },
+  unknown: { max_attempts: 1, backoff_sec: [60], action: 'retry' },
+};
+
+// Look up the effective retry policy for a class. Per-chain overrides in
+// `spec.defaults.retry_policy[class]` shallow-merge over the default entry.
+export function resolveRetryPolicy(
+  spec: ChainSpec,
+  cls: FailureClass,
+): RetryPolicyEntry {
+  const base = DEFAULT_RETRY_POLICY[cls];
+  const override = spec.defaults?.retry_policy?.[cls];
+  if (!override) return base;
+  const out: RetryPolicyEntry = {
+    max_attempts: override.max_attempts ?? base.max_attempts,
+  };
+  const backoff = override.backoff_sec ?? base.backoff_sec;
+  if (backoff !== undefined) out.backoff_sec = backoff;
+  const action = override.action ?? base.action;
+  if (action !== undefined) out.action = action;
+  return out;
+}
+
+// Returns the backoff in seconds for the NEXT attempt given the current
+// attempts count (0-indexed: first retry uses backoff_sec[0]). Returns null
+// if the schedule is exhausted, missing, or attempts already past the end.
+export function backoffSecForAttempt(
+  policy: RetryPolicyEntry,
+  attempts: number,
+): number | null {
+  const sched = policy.backoff_sec ?? [];
+  if (sched.length === 0) return null;
+  if (attempts < 0 || attempts >= sched.length) return null;
+  const v = sched[attempts];
+  return typeof v === 'number' && v >= 0 ? v : null;
+}
+
+// Helpers for typed validation in spec.ts. A retry policy entry is well-
+// formed when max_attempts is a non-negative integer and (if present)
+// backoff_sec is a non-negative-integer array of length >= max_attempts.
+export const VALID_ACTIONS: ReadonlySet<RetryPolicyAction> = new Set([
+  'pause_until_reset',
+  'pause_until_operator',
+  'adjudicate',
+  'alert',
+  'block',
+  'retry',
+]);
+
+export function validateRetryPolicyEntry(
+  cls: string,
+  entry: unknown,
+): RetryPolicyEntry {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error(`retry_policy.${cls}: expected object, got ${typeof entry}`);
+  }
+  const e = entry as Record<string, unknown>;
+  const max = e['max_attempts'];
+  if (typeof max !== 'number' || !Number.isInteger(max) || max < 0) {
+    throw new Error(`retry_policy.${cls}.max_attempts: expected non-negative integer`);
+  }
+  let backoff: number[] | undefined;
+  if (e['backoff_sec'] !== undefined) {
+    if (!Array.isArray(e['backoff_sec'])) {
+      throw new Error(`retry_policy.${cls}.backoff_sec: expected array`);
+    }
+    backoff = e['backoff_sec'].map((v, i) => {
+      if (typeof v !== 'number' || v < 0) {
+        throw new Error(`retry_policy.${cls}.backoff_sec[${i}]: expected non-negative number`);
+      }
+      return v;
+    });
+  }
+  let action: RetryPolicyAction | undefined;
+  if (e['action'] !== undefined) {
+    if (typeof e['action'] !== 'string' || !VALID_ACTIONS.has(e['action'] as RetryPolicyAction)) {
+      throw new Error(
+        `retry_policy.${cls}.action: expected one of ${Array.from(VALID_ACTIONS).join(', ')}`,
+      );
+    }
+    action = e['action'] as RetryPolicyAction;
+  }
+  const out: RetryPolicyEntry = { max_attempts: max };
+  if (backoff !== undefined) out.backoff_sec = backoff;
+  if (action !== undefined) out.action = action;
+  return out;
+}

--- a/packages/chain-runner/src/spec.ts
+++ b/packages/chain-runner/src/spec.ts
@@ -1,6 +1,25 @@
 import { readFileSync } from 'node:fs';
 import yaml from 'js-yaml';
-import type { ChainSpec, PhaseDefinition } from './types.js';
+import { validateRetryPolicyEntry } from './retry-policy.js';
+import type { ChainSpec, FailureClass, PhaseDefinition } from './types.js';
+
+const KNOWN_FAILURE_CLASSES: ReadonlySet<FailureClass> = new Set<FailureClass>([
+  'worker_no_start_rate_limit',
+  'worker_no_start_auth_failure',
+  'worker_no_start_binary_missing',
+  'worker_no_start_spawn_error',
+  'worker_no_start_bad_args',
+  'worker_hung_post_success',
+  'worker_hung_mid_work',
+  'worker_crashed',
+  'mark_done_failed',
+  'artifact_missing',
+  'artifact_malformed',
+  'pr_unmerged_at_done',
+  'acceptance_failed',
+  'runtime_exceeded',
+  'unknown',
+]);
 
 export function loadChainSpec(specPath: string): ChainSpec {
   const raw = readFileSync(specPath, 'utf8');
@@ -12,6 +31,20 @@ export function loadChainSpec(specPath: string): ChainSpec {
   for (const p of spec.phases) {
     if (typeof p.id !== 'number' || typeof p.name !== 'string') {
       throw new Error(`phase missing id/name in ${specPath}: ${JSON.stringify(p)}`);
+    }
+  }
+  // H-9: validate defaults.retry_policy if present. Unknown FailureClass keys
+  // are a typo, not a forward-compat feature — fail loud at load time so the
+  // operator catches it before the chain runs unsupervised.
+  const rp = spec.defaults?.retry_policy;
+  if (rp) {
+    for (const [cls, entry] of Object.entries(rp)) {
+      if (!KNOWN_FAILURE_CLASSES.has(cls as FailureClass)) {
+        throw new Error(
+          `retry_policy.${cls}: unknown FailureClass (expected one of ${Array.from(KNOWN_FAILURE_CLASSES).join(', ')})`,
+        );
+      }
+      spec.defaults!.retry_policy![cls as FailureClass] = validateRetryPolicyEntry(cls, entry);
     }
   }
   return spec;

--- a/packages/chain-runner/src/state.ts
+++ b/packages/chain-runner/src/state.ts
@@ -5,6 +5,7 @@ import { ensureChainDir } from './paths.js';
 import { isoNow } from './time.js';
 import { loadChainSpec } from './spec.js';
 import { failureFromReason } from './classify.js';
+import { resolveRetryPolicy } from './retry-policy.js';
 import type {
   ChainPaths,
   ChainSpec,
@@ -42,6 +43,8 @@ export function buildInitialState(spec: ChainSpec): StateFile {
       session_id: null,
       error: null,
       failure: null,
+      last_failure_class: null,
+      backoff_until: null,
     };
   }
   return {
@@ -49,6 +52,8 @@ export function buildInitialState(spec: ChainSpec): StateFile {
     started_at: isoNow(),
     last_wake: null,
     paused: false,
+    paused_until: null,
+    paused_reason: null,
     budget_consumed_pct: 0,
     budget_cap_pct: DEFAULT_BUDGET_CAP_PCT,
     phase_status: phaseStatus,
@@ -98,6 +103,7 @@ export function ensurePhaseEntry(state: StateFile, phaseId: string): PhaseState 
 export type NextPhaseResult =
   | { kind: 'phase_id'; id: number }
   | { kind: 'in_progress'; id: number }
+  | { kind: 'backoff'; id: number; seconds: number; until: string }
   | {
       kind:
         | 'paused'
@@ -113,6 +119,7 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
   }
   if (state.all_done) return { kind: 'all_done' };
 
+  const nowMs = Date.now();
   let mutated = false;
   for (const p of ctx.spec.phases) {
     const pid = String(p.id);
@@ -127,14 +134,59 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
     if (!depsMet) continue;
 
     if (ps.status === 'pending' || ps.status === 'failed') {
-      if (ps.status === 'failed' && ps.attempts >= ps.max_retries) {
-        ps.status = 'blocked';
-        mutated = true;
-        appendAudit(ctx.paths.auditFile, 'phase_blocked', {
-          phase_id: p.id,
-          reason: 'retries_exhausted',
-        });
-        continue;
+      // H-9: class-aware retry decision. Falls back to max_retries when the
+      // phase has no recorded failure class (legacy state files, fresh
+      // phases, or a `pending`-from-init). When the failure came in via the
+      // legacy string-reason CLI shim (evidence.legacy_string_reason=true,
+      // class=unknown), we honor the *legacy* ps.max_retries bound instead
+      // of the H-9 default policy to keep the pre-H-9 regression suite
+      // green; typed failures (with --class on mark-failed or via the
+      // classifier) get class-aware policy.
+      if (ps.status === 'failed') {
+        const cls = ps.last_failure_class ?? ps.failure?.class ?? null;
+        const isLegacyShim =
+          ps.failure?.evidence?.['legacy_string_reason'] === true;
+        const policy =
+          cls && !isLegacyShim ? resolveRetryPolicy(ctx.spec, cls) : null;
+        const policyMax = policy?.max_attempts ?? ps.max_retries;
+        // pause_until_* / adjudicate / alert / block all imply no more retries.
+        const policyTerminal =
+          policy?.action === 'pause_until_reset' ||
+          policy?.action === 'pause_until_operator' ||
+          policy?.action === 'adjudicate' ||
+          policy?.action === 'alert' ||
+          policy?.action === 'block';
+        const retriesExhausted = ps.attempts >= policyMax;
+        if (policyTerminal || retriesExhausted) {
+          ps.status = 'blocked';
+          mutated = true;
+          appendAudit(ctx.paths.auditFile, 'phase_blocked', {
+            phase_id: p.id,
+            reason: policyTerminal
+              ? `policy_action_${policy?.action ?? 'unknown'}`
+              : 'retries_exhausted',
+            class: cls,
+            policy_action: policy?.action ?? null,
+            attempts: ps.attempts,
+            policy_max_attempts: policyMax,
+          });
+          continue;
+        }
+        // Backoff active: return BACKOFF for this phase so wake script
+        // noops without consuming a retry. Surface only if the backoff
+        // timestamp is in the future.
+        if (ps.backoff_until) {
+          const bt = new Date(ps.backoff_until).getTime();
+          if (Number.isFinite(bt) && bt > nowMs) {
+            if (mutated) saveState(ctx, state);
+            return {
+              kind: 'backoff',
+              id: p.id,
+              seconds: Math.max(0, Math.ceil((bt - nowMs) / 1000)),
+              until: ps.backoff_until,
+            };
+          }
+        }
       }
       if (mutated) saveState(ctx, state);
       return { kind: 'phase_id', id: p.id };
@@ -252,6 +304,9 @@ export function markDone(ctx: StateContext, phaseId: string): void {
   const ps2 = ensurePhaseEntry(state2, phaseId);
   ps2.status = 'done';
   ps2.completed_at = isoNow();
+  // H-9: a successful retry clears the backoff window; the class is left in
+  // place as audit trail (it's purely informational once the phase is done).
+  ps2.backoff_until = null;
   saveState(ctx, state2);
   appendAudit(ctx.paths.auditFile, 'phase_done', {
     phase_id: Number(phaseId),
@@ -323,6 +378,39 @@ export function markFailed(
   ps.status = 'failed';
   ps.error = failure.reason.slice(0, 500);
   ps.failure = failure;
+  // H-9: copy class onto top-level field for cheap policy lookup, and if the
+  // policy has a backoff schedule for the next attempt, stamp backoff_until.
+  // Legacy string-reason calls (evidence.legacy_string_reason=true, class=
+  // unknown) skip policy-based backoff to preserve the pre-H-9 retry contract
+  // for callers that haven't migrated to typed failures.
+  ps.last_failure_class = failure.class;
+  const isLegacyShim =
+    failure.evidence?.['legacy_string_reason'] === true;
+  const policy = isLegacyShim
+    ? null
+    : resolveRetryPolicy(ctx.spec, failure.class);
+  // attempts is the next-attempt index (0 for first retry, 1 for second).
+  // Only retry-action policies populate backoff_until. The block/pause/etc
+  // actions deliberately leave it null so the wake doesn't sleep on them.
+  let backoffSec: number | null = null;
+  if (
+    policy &&
+    (policy.action === 'retry' || policy.action === undefined) &&
+    ps.attempts < policy.max_attempts &&
+    policy.backoff_sec &&
+    policy.backoff_sec.length > 0
+  ) {
+    const idx = Math.min(ps.attempts, policy.backoff_sec.length - 1);
+    const v = policy.backoff_sec[idx];
+    if (typeof v === 'number' && v >= 0) backoffSec = v;
+  }
+  if (backoffSec !== null) {
+    ps.backoff_until = new Date(Date.now() + backoffSec * 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+  } else {
+    ps.backoff_until = null;
+  }
   saveState(ctx, state);
   appendAudit(ctx.paths.auditFile, 'phase_failed', {
     phase_id: Number(phaseId),
@@ -331,19 +419,41 @@ export function markFailed(
     attempt: ps.attempts,
     ran_substantively: ranSubstantively,
     evidence: failure.evidence,
+    policy_action: policy?.action ?? null,
+    policy_max_attempts: policy?.max_attempts ?? null,
+    backoff_sec: backoffSec,
+    backoff_until: ps.backoff_until,
   });
 }
 
-export function pause(ctx: StateContext): void {
+export interface PauseOptions {
+  /** Free-form reason; persisted to state.paused_reason. */
+  reason?: string;
+  /**
+   * H-4b / D-4. When set, the wake-script shim auto-resumes the chain once
+   * wallclock passes this ISO timestamp. Used to encode rate-limit reset
+   * times. Persisted to state.paused_until.
+   */
+  pausedUntil?: string;
+}
+
+export function pause(ctx: StateContext, opts: PauseOptions = {}): void {
   const state = loadState(ctx);
   state.paused = true;
+  if (opts.reason !== undefined) state.paused_reason = opts.reason;
+  if (opts.pausedUntil !== undefined) state.paused_until = opts.pausedUntil;
   saveState(ctx, state);
-  appendAudit(ctx.paths.auditFile, 'paused', {});
+  appendAudit(ctx.paths.auditFile, 'paused', {
+    reason: opts.reason ?? null,
+    paused_until: opts.pausedUntil ?? null,
+  });
 }
 
 export function resume(ctx: StateContext): void {
   const state = loadState(ctx);
   state.paused = false;
+  state.paused_until = null;
+  state.paused_reason = null;
   saveState(ctx, state);
   appendAudit(ctx.paths.auditFile, 'resumed', {});
 }

--- a/packages/chain-runner/src/types.ts
+++ b/packages/chain-runner/src/types.ts
@@ -16,10 +16,33 @@ export interface PhaseDefinition {
   [k: string]: unknown;
 }
 
+// H-9 (chain-runner-battle-harden phase 4, 2026-05-14). Per-failure-class
+// retry policy. `action` tells the wake script what to do when retries are
+// exhausted (or zero); `backoff_sec` is the delay schedule between retries.
+// The class-aware policy lets a rate-limit pause cleanly without burning
+// retries, while a spawn-error still backs off and retries 3x.
+export type RetryPolicyAction =
+  | 'pause_until_reset' // rate-limit — pause chain, wait for reset
+  | 'pause_until_operator' // auth / binary missing — needs interactive fix
+  | 'adjudicate' // hung-post-success — operator review
+  | 'alert' // runtime-exceeded — alert + leave failed
+  | 'block' // generic — promote to blocked
+  | 'retry'; // retry with backoff_sec schedule
+
+export interface RetryPolicyEntry {
+  max_attempts: number;
+  /** Backoff delays in seconds. Length should be >= max_attempts when retrying. */
+  backoff_sec?: number[];
+  /** Action to take when retries are exhausted or when max_attempts === 0. */
+  action?: RetryPolicyAction;
+}
+
 export interface ChainDefaults {
   max_retries?: number;
   max_minutes?: number;
   heartbeat_interval_sec?: number;
+  /** H-9: per-FailureClass retry policy. Missing classes inherit DEFAULT_RETRY_POLICY. */
+  retry_policy?: Partial<Record<FailureClass, RetryPolicyEntry>>;
 }
 
 // Operator-decision flags surfaced as chain_config in the spec YAML. Loader
@@ -78,6 +101,18 @@ export interface PhaseState {
   session_id: string | null;
   error: string | null;
   failure?: PhaseFailure | null;
+  /**
+   * H-9 (chain-runner-battle-harden phase 4, 2026-05-14). FailureClass of the
+   * most recent failure, copied off `failure.class` for cheap policy lookup
+   * without rehydrating PhaseFailure. Null until the phase has ever failed.
+   */
+  last_failure_class?: FailureClass | null;
+  /**
+   * H-9. When set, computeNextPhase returns BACKOFF instead of phase_id until
+   * the wallclock passes this ISO timestamp. Populated by markFailed when the
+   * retry policy for the class has a `backoff_sec` schedule.
+   */
+  backoff_until?: string | null;
 }
 
 export interface StateFile {
@@ -85,6 +120,15 @@ export interface StateFile {
   started_at: string;
   last_wake: string | null;
   paused: boolean;
+  /**
+   * H-4b / D-4 (chain-runner-battle-harden phase 4, 2026-05-14). When the
+   * preflight detects a rate-limit and parses the reset time, this ISO
+   * timestamp is written into state.json so wake-script shims can auto-resume
+   * the chain once now >= paused_until.
+   */
+  paused_until?: string | null;
+  /** Why the chain was paused (set alongside `paused`). */
+  paused_reason?: string | null;
   budget_consumed_pct: number;
   budget_cap_pct: number;
   phase_status: Record<string, PhaseState>;

--- a/packages/chain-runner/tests/preflight.test.ts
+++ b/packages/chain-runner/tests/preflight.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  formatPreflightLine,
+  parseResetIsoFromBanner,
+  preflightDispatch,
+} from '../src/preflight.js';
+
+// Build a shell-script "claude" stub that prints canned text on stdout and
+// optionally on stderr. Tests use these to drive every branch of the
+// preflight decision tree without needing the real binary.
+function makeStub(dir: string, name: string, body: string): string {
+  const path = join(dir, name);
+  writeFileSync(path, `#!/bin/bash\n${body}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'caia-preflight-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(workDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P01 — healthy path: stub prints PREFLIGHT_OK
+// ---------------------------------------------------------------------------
+describe('P01_preflight_healthy', () => {
+  it('returns status=healthy, exit_code=0 when claude prints PREFLIGHT_OK', async () => {
+    const stub = makeStub(workDir, 'claude_ok', 'echo PREFLIGHT_OK');
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('healthy');
+    expect(r.exit_code).toBe(0);
+    expect(r.raw).toMatch(/PREFLIGHT_OK/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P02 — rate_limited with parseable reset banner
+// ---------------------------------------------------------------------------
+describe('P02_preflight_rate_limited_with_reset', () => {
+  it('returns status=rate_limited, exit_code=2, reset_iso parsed', async () => {
+    const stub = makeStub(
+      workDir,
+      'claude_ratelimit',
+      "echo \"You've hit your limit · resets May 16 at 12pm (America/New_York)\"",
+    );
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('rate_limited');
+    expect(r.exit_code).toBe(2);
+    expect(r.reset_banner).toMatch(/resets May 16/);
+    expect(r.reset_iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P03 — rate_limited but no reset banner (still exit 2)
+// ---------------------------------------------------------------------------
+describe('P03_preflight_rate_limited_no_reset', () => {
+  it('returns rate_limited with reset_iso undefined when banner missing', async () => {
+    const stub = makeStub(
+      workDir,
+      'claude_ratelimit_nores',
+      "echo \"You've hit your limit. Try again later.\"",
+    );
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('rate_limited');
+    expect(r.exit_code).toBe(2);
+    expect(r.reset_iso).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P04 — auth_failure (401)
+// ---------------------------------------------------------------------------
+describe('P04_preflight_auth_failure', () => {
+  it('returns auth_failure exit_code=3 on API Error 401', async () => {
+    const stub = makeStub(
+      workDir,
+      'claude_auth',
+      'echo "API Error 401 Unauthorized: invalid api key" >&2 ; exit 1',
+    );
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('auth_failure');
+    expect(r.exit_code).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P05 — timeout
+// ---------------------------------------------------------------------------
+describe('P05_preflight_timeout', () => {
+  it('returns timeout exit_code=4 when claude hangs', async () => {
+    const stub = makeStub(workDir, 'claude_hang', 'sleep 10');
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 500,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('timeout');
+    expect(r.exit_code).toBe(4);
+    expect(r.elapsed_ms).toBeGreaterThanOrEqual(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P06 — unknown (claude responds but no recognized banner)
+// ---------------------------------------------------------------------------
+describe('P06_preflight_unknown', () => {
+  it('returns unknown exit_code=5 when output matches no decision branch', async () => {
+    const stub = makeStub(
+      workDir,
+      'claude_unknown',
+      'echo "some random response with no recognized markers"',
+    );
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('unknown');
+    expect(r.exit_code).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P07 — api_key_leak refuses without spawning
+// ---------------------------------------------------------------------------
+describe('P07_preflight_api_key_leak', () => {
+  it('returns api_key_leak exit_code=6 when ANTHROPIC_API_KEY is set', async () => {
+    const stub = makeStub(
+      workDir,
+      'claude_should_not_run',
+      'echo PREFLIGHT_OK_SHOULD_NOT_BE_CALLED',
+    );
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: 'sk-secret-leak' },
+    });
+    expect(r.status).toBe('api_key_leak');
+    expect(r.exit_code).toBe(6);
+    // raw must be empty — we refused without spawning.
+    expect(r.raw).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P08 — api_key_leak refusal can be overridden via refuseIfApiKeySet:false
+// ---------------------------------------------------------------------------
+describe('P08_preflight_api_key_override', () => {
+  it('proceeds with refuseIfApiKeySet=false even when API key is set', async () => {
+    const stub = makeStub(workDir, 'claude_ok2', 'echo PREFLIGHT_OK');
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      refuseIfApiKeySet: false,
+      env: { ...process.env, ANTHROPIC_API_KEY: 'sk-allowed-in-tests' },
+    });
+    expect(r.status).toBe('healthy');
+    expect(r.exit_code).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P09 — missing binary (ENOENT) → preflight_error / generic
+// ---------------------------------------------------------------------------
+describe('P09_preflight_binary_missing', () => {
+  it('returns preflight_error exit_code=1 when binary is missing (ENOENT)', async () => {
+    const r = await preflightDispatch({
+      binary: '/nonexistent/claude-does-not-exist',
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    // Node may surface this as exit code 1 ('preflight_error') or via the
+    // child's exit listener firing with code !=0 and no banner (status=unknown).
+    expect([1, 5]).toContain(r.exit_code);
+    expect(r.status === 'preflight_error' || r.status === 'unknown').toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P10 — rate-limit precedes auth when both appear in output
+// ---------------------------------------------------------------------------
+describe('P10_preflight_rate_limit_precedes_auth', () => {
+  it('classifies as rate_limited when output also contains an auth banner', async () => {
+    const stub = makeStub(
+      workDir,
+      'claude_mixed',
+      'echo "You\'ve hit your limit · resets May 16 at 12pm" ; echo "Invalid authentication credentials"',
+    );
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('rate_limited');
+    expect(r.exit_code).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P11 — formatPreflightLine emits the wake-script-grep contract
+// ---------------------------------------------------------------------------
+describe('P11_format_preflight_line', () => {
+  it('emits PREFLIGHT status=... exit=... elapsed_ms=... [reset_iso=...] [reset_banner=...]', () => {
+    const line = formatPreflightLine({
+      status: 'rate_limited',
+      exit_code: 2,
+      message: 'rate limit hit (resets May 16 at 12pm)',
+      elapsed_ms: 1234,
+      raw: '',
+      reset_iso: '2026-05-16T16:00:00Z',
+      reset_banner: 'resets May 16 at 12pm (America/New_York)',
+    });
+    expect(line).toContain('PREFLIGHT status=rate_limited');
+    expect(line).toContain('exit=2');
+    expect(line).toContain('elapsed_ms=1234');
+    expect(line).toContain('reset_iso=2026-05-16T16:00:00Z');
+    expect(line).toContain('reset_banner="resets May 16 at 12pm (America/New_York)"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P12 — log path is appended after the run
+// ---------------------------------------------------------------------------
+describe('P12_preflight_log_path', () => {
+  it('appends raw output to --log path on completion', async () => {
+    const stub = makeStub(workDir, 'claude_ok3', 'echo PREFLIGHT_OK');
+    const log = join(workDir, 'preflight.log');
+    writeFileSync(log, '');
+    const r = await preflightDispatch({
+      binary: stub,
+      timeoutMs: 4000,
+      logPath: log,
+      env: { ...process.env, ANTHROPIC_API_KEY: '' },
+    });
+    expect(r.status).toBe('healthy');
+    expect(existsSync(log)).toBe(true);
+    const body = readFileSync(log, 'utf8');
+    expect(body).toMatch(/PREFLIGHT_OK/);
+    expect(body).toMatch(/--- preflight \d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P13 — reset banner parsing: month+day+time+tz
+// ---------------------------------------------------------------------------
+describe('P13_reset_banner_parse_full', () => {
+  it('parses "resets May 16 at 12pm (America/New_York)" to a UTC ISO', () => {
+    const nowMs = Date.parse('2026-05-14T18:00:00Z');
+    const r = parseResetIsoFromBanner(
+      "You've hit your limit · resets May 16 at 12pm (America/New_York)",
+      nowMs,
+    );
+    expect(r.iso).toMatch(/^2026-05-1[67]T(15|16):/);
+    expect(r.matched).toMatch(/resets May 16 at 12pm/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P14 — reset banner parsing: time-only (no month/day) bumps to tomorrow
+// when the time has already passed today.
+// ---------------------------------------------------------------------------
+describe('P14_reset_banner_parse_time_only', () => {
+  it('parses "resets at 4pm (America/New_York)" relative to now', () => {
+    // Now = 2026-05-14 22:00 UTC → 18:00 EDT. "4pm" today (16:00 EDT = 20:00
+    // UTC) has already passed, so bump to tomorrow.
+    const nowMs = Date.parse('2026-05-14T22:00:00Z');
+    const r = parseResetIsoFromBanner(
+      'resets at 4pm (America/New_York)',
+      nowMs,
+    );
+    expect(r.iso).not.toBeNull();
+    if (r.iso) {
+      const t = Date.parse(r.iso);
+      expect(t).toBeGreaterThan(nowMs);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture P15 — reset banner missing → iso null
+// ---------------------------------------------------------------------------
+describe('P15_reset_banner_missing', () => {
+  it('returns iso null and matched null when banner absent', () => {
+    const r = parseResetIsoFromBanner(
+      'some unrelated text without a reset banner',
+      Date.now(),
+    );
+    expect(r.iso).toBeNull();
+    expect(r.matched).toBeNull();
+  });
+});

--- a/packages/chain-runner/tests/retry_policy.test.ts
+++ b/packages/chain-runner/tests/retry_policy.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEFAULT_RETRY_POLICY,
+  backoffSecForAttempt,
+  resolveRetryPolicy,
+  validateRetryPolicyEntry,
+} from '../src/retry-policy.js';
+import {
+  computeNextPhase,
+  initState,
+  loadContext,
+  loadState,
+  markFailed,
+  pause,
+  resume,
+  saveState,
+  type StateContext,
+} from '../src/state.js';
+import { loadChainSpec } from '../src/spec.js';
+import { isoNow } from '../src/time.js';
+import type { FailureClass, PhaseFailure } from '../src/types.js';
+
+function makePolicyFixture(label: string, yaml?: string): {
+  ctx: StateContext;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), `caia-retry-${label}-`));
+  const chainHome = join(root, 'chain');
+  mkdirSync(chainHome, { recursive: true });
+  const specPath = join(root, 'phases.yaml');
+  const defaultYaml = `defaults:
+  max_retries: 2
+  max_minutes: 45
+
+phases:
+  - id: 1
+    name: phase_one
+    prompt_template: |
+      first
+  - id: 2
+    name: phase_two
+    deps: [1]
+    prompt_template: |
+      second
+`;
+  writeFileSync(specPath, yaml ?? defaultYaml);
+  process.env['CAIA_CHAIN_HOME'] = chainHome;
+  const chainId = `cr-retry-${label}-${process.pid}-${Math.random().toString(36).slice(2, 6)}`;
+  const ctx = loadContext(chainId, specPath);
+  initState(ctx);
+  return {
+    ctx,
+    cleanup: () => {
+      delete process.env['CAIA_CHAIN_HOME'];
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+function makeFailure(cls: FailureClass): PhaseFailure {
+  return {
+    class: cls,
+    reason: `synthetic ${cls}`,
+    detected_at: isoNow(),
+    evidence: {},
+  };
+}
+
+let cleanup: () => void;
+beforeEach(() => {
+  cleanup = () => undefined;
+});
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// Fixture R01 — DEFAULT_RETRY_POLICY exposes one entry per FailureClass
+// ---------------------------------------------------------------------------
+describe('R01_default_policy_covers_all_classes', () => {
+  it('has one default entry per known FailureClass', () => {
+    const classes: FailureClass[] = [
+      'worker_no_start_rate_limit',
+      'worker_no_start_auth_failure',
+      'worker_no_start_binary_missing',
+      'worker_no_start_spawn_error',
+      'worker_no_start_bad_args',
+      'worker_hung_post_success',
+      'worker_hung_mid_work',
+      'worker_crashed',
+      'mark_done_failed',
+      'artifact_missing',
+      'artifact_malformed',
+      'pr_unmerged_at_done',
+      'acceptance_failed',
+      'runtime_exceeded',
+      'unknown',
+    ];
+    for (const c of classes) {
+      expect(DEFAULT_RETRY_POLICY[c], `missing default for ${c}`).toBeDefined();
+      expect(typeof DEFAULT_RETRY_POLICY[c].max_attempts).toBe('number');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R02 — rate_limit pauses chain (no retry, action=pause_until_reset)
+// ---------------------------------------------------------------------------
+describe('R02_rate_limit_blocks_no_retry', () => {
+  it('marks phase blocked after a single rate_limit failure (max_attempts=0)', () => {
+    const f = makePolicyFixture('ratelimit');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('worker_no_start_rate_limit'), {
+      ranSubstantively: false,
+    });
+    const s = loadState(f.ctx);
+    expect(s.phase_status['1']?.last_failure_class).toBe('worker_no_start_rate_limit');
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    // Phase 1 is now blocked → no eligible phase since phase 2 deps=[1]
+    expect(r.kind).toBe('none_eligible');
+    expect(loadState(f.ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R03 — auth_failure blocks (pause_until_operator)
+// ---------------------------------------------------------------------------
+describe('R03_auth_failure_blocks_no_retry', () => {
+  it('marks phase blocked after a single auth_failure', () => {
+    const f = makePolicyFixture('auth');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('worker_no_start_auth_failure'), {
+      ranSubstantively: false,
+    });
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('none_eligible');
+    expect(loadState(f.ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R04 — binary_missing blocks (pause_until_operator)
+// ---------------------------------------------------------------------------
+describe('R04_binary_missing_blocks_no_retry', () => {
+  it('marks phase blocked after a single binary_missing failure', () => {
+    const f = makePolicyFixture('binmissing');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('worker_no_start_binary_missing'), {
+      ranSubstantively: false,
+    });
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('none_eligible');
+    expect(loadState(f.ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R05 — spawn_error: retries with backoff 60s,300s,900s; BACKOFF emitted
+// ---------------------------------------------------------------------------
+describe('R05_spawn_error_retries_with_backoff', () => {
+  it('emits BACKOFF for the schedule between retries and stays under max_attempts=3', () => {
+    const f = makePolicyFixture('spawnerr');
+    cleanup = f.cleanup;
+    // First failure: worker_no_start_spawn_error → attempts stays at 0 because
+    // markFailed inferRanSubstantivelyFromClass treats worker_no_start_* as false.
+    markFailed(f.ctx, '1', makeFailure('worker_no_start_spawn_error'));
+    const s1 = loadState(f.ctx);
+    expect(s1.phase_status['1']?.attempts).toBe(0);
+    // backoff_until should be ~60s in the future
+    const bu = s1.phase_status['1']?.backoff_until;
+    expect(bu).toBeTruthy();
+    if (bu) {
+      const delta = (new Date(bu).getTime() - Date.now()) / 1000;
+      expect(delta).toBeGreaterThan(50);
+      expect(delta).toBeLessThan(70);
+    }
+    // While in backoff, computeNextPhase returns kind=backoff
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('backoff');
+    if (r.kind === 'backoff') {
+      expect(r.seconds).toBeGreaterThan(0);
+      expect(r.seconds).toBeLessThanOrEqual(60);
+      expect(r.id).toBe(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R06 — backoff window elapsed → next-phase returns phase_id
+// ---------------------------------------------------------------------------
+describe('R06_backoff_elapses_then_retries', () => {
+  it('returns phase_id once backoff_until has passed', () => {
+    const f = makePolicyFixture('backoff-elapsed');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('worker_no_start_spawn_error'));
+    // Hand-wind backoff_until into the past
+    const s = loadState(f.ctx);
+    s.phase_status['1']!.backoff_until = new Date(Date.now() - 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    saveState(f.ctx, s);
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('phase_id');
+    if (r.kind === 'phase_id') expect(r.id).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R07 — hung_post_success: adjudicate action → blocked immediately
+// ---------------------------------------------------------------------------
+describe('R07_hung_post_success_adjudicate', () => {
+  it('promotes to blocked on first failure (action=adjudicate)', () => {
+    const f = makePolicyFixture('adjudicate');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('worker_hung_post_success'), {
+      ranSubstantively: true,
+    });
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('none_eligible');
+    expect(loadState(f.ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R08 — worker_crashed: 2 retries with 120s,600s backoff
+// ---------------------------------------------------------------------------
+describe('R08_worker_crashed_two_retries', () => {
+  it('allows two retries before blocking', () => {
+    const f = makePolicyFixture('crashed');
+    cleanup = f.cleanup;
+    // attempt 1: crashed → attempts becomes 1, backoff 120s
+    markFailed(f.ctx, '1', makeFailure('worker_crashed'));
+    let s = loadState(f.ctx);
+    expect(s.phase_status['1']?.attempts).toBe(1);
+    // simulate backoff elapsed
+    s.phase_status['1']!.backoff_until = new Date(Date.now() - 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    saveState(f.ctx, s);
+    let r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('phase_id');
+    // attempt 2: crashed again → attempts becomes 2, backoff 600s
+    markFailed(f.ctx, '1', makeFailure('worker_crashed'));
+    s = loadState(f.ctx);
+    expect(s.phase_status['1']?.attempts).toBe(2);
+    s.phase_status['1']!.backoff_until = new Date(Date.now() - 1000)
+      .toISOString()
+      .replace(/\.\d{3}Z$/, 'Z');
+    saveState(f.ctx, s);
+    // attempt 3 (next-phase): attempts >= max_attempts(2) → blocked
+    r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('none_eligible');
+    expect(loadState(f.ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R09 — runtime_exceeded action=alert → blocked
+// ---------------------------------------------------------------------------
+describe('R09_runtime_exceeded_alert', () => {
+  it('blocks on runtime_exceeded (action=alert, max_attempts=0)', () => {
+    const f = makePolicyFixture('runtime');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('runtime_exceeded'));
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('none_eligible');
+    expect(loadState(f.ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R10 — YAML override: chain-level retry_policy beats defaults
+// ---------------------------------------------------------------------------
+describe('R10_yaml_override', () => {
+  it('honors defaults.retry_policy.<class> override', () => {
+    const yaml = `defaults:
+  max_retries: 2
+  retry_policy:
+    worker_no_start_rate_limit:
+      max_attempts: 5
+      backoff_sec: [10, 20, 30, 40, 50]
+      action: retry
+phases:
+  - id: 1
+    name: phase_one
+    prompt_template: |
+      first
+`;
+    const f = makePolicyFixture('yaml-override', yaml);
+    cleanup = f.cleanup;
+    // Resolve should use the override, not the default 0-attempts policy
+    const resolved = resolveRetryPolicy(f.ctx.spec, 'worker_no_start_rate_limit');
+    expect(resolved.max_attempts).toBe(5);
+    expect(resolved.backoff_sec).toEqual([10, 20, 30, 40, 50]);
+    expect(resolved.action).toBe('retry');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R11 — spec validation rejects unknown class
+// ---------------------------------------------------------------------------
+describe('R11_spec_validation_unknown_class', () => {
+  it('throws when retry_policy contains an unknown FailureClass key', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-spec-bad-'));
+    const specPath = join(root, 'phases.yaml');
+    writeFileSync(
+      specPath,
+      `defaults:
+  retry_policy:
+    not_a_real_class:
+      max_attempts: 1
+phases:
+  - id: 1
+    name: x
+    prompt_template: |
+      x
+`,
+    );
+    try {
+      expect(() => loadChainSpec(specPath)).toThrow(/unknown FailureClass/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R12 — spec validation rejects malformed entry (max_attempts type)
+// ---------------------------------------------------------------------------
+describe('R12_spec_validation_bad_entry', () => {
+  it('throws when max_attempts is not a non-negative integer', () => {
+    expect(() =>
+      validateRetryPolicyEntry('worker_crashed', {
+        max_attempts: -1,
+      }),
+    ).toThrow(/max_attempts/);
+    expect(() =>
+      validateRetryPolicyEntry('worker_crashed', {
+        max_attempts: 'three',
+      }),
+    ).toThrow(/max_attempts/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R13 — backoffSecForAttempt indexing
+// ---------------------------------------------------------------------------
+describe('R13_backoff_indexing', () => {
+  it('returns the right backoff for each retry index', () => {
+    const policy = { max_attempts: 3, backoff_sec: [60, 300, 900] };
+    expect(backoffSecForAttempt(policy, 0)).toBe(60);
+    expect(backoffSecForAttempt(policy, 1)).toBe(300);
+    expect(backoffSecForAttempt(policy, 2)).toBe(900);
+    expect(backoffSecForAttempt(policy, 3)).toBeNull();
+    expect(backoffSecForAttempt({ max_attempts: 0 }, 0)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R14 — paused chain + paused_until persisted
+// ---------------------------------------------------------------------------
+describe('R14_pause_with_until', () => {
+  it('persists paused_until + paused_reason; resume clears them', () => {
+    const f = makePolicyFixture('pause-until');
+    cleanup = f.cleanup;
+    pause(f.ctx, {
+      reason: 'rate_limit_until_2026-05-16T16:00:00Z',
+      pausedUntil: '2026-05-16T16:00:00Z',
+    });
+    let s = loadState(f.ctx);
+    expect(s.paused).toBe(true);
+    expect(s.paused_until).toBe('2026-05-16T16:00:00Z');
+    expect(s.paused_reason).toMatch(/rate_limit_until/);
+    // computeNextPhase short-circuits on paused.
+    const r = computeNextPhase(f.ctx, s);
+    expect(r.kind).toBe('paused');
+    // Resume clears.
+    resume(f.ctx);
+    s = loadState(f.ctx);
+    expect(s.paused).toBe(false);
+    expect(s.paused_until).toBeNull();
+    expect(s.paused_reason).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R15 — markFailed records last_failure_class in PhaseState
+// ---------------------------------------------------------------------------
+describe('R15_marks_last_failure_class', () => {
+  it('persists last_failure_class on every typed markFailed', () => {
+    const f = makePolicyFixture('lastclass');
+    cleanup = f.cleanup;
+    markFailed(f.ctx, '1', makeFailure('worker_hung_mid_work'));
+    expect(loadState(f.ctx).phase_status['1']?.last_failure_class).toBe(
+      'worker_hung_mid_work',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture R16 — legacy string-reason markFailed preserves old retry contract
+// ---------------------------------------------------------------------------
+describe('R16_legacy_string_reason_back_compat', () => {
+  it('uses ps.max_retries (not class policy) when failure came in via string-reason shim', () => {
+    const f = makePolicyFixture('legacy');
+    cleanup = f.cleanup;
+    // Legacy callers pass a free-form string → class=unknown +
+    // evidence.legacy_string_reason=true → state.markFailed falls back to
+    // ps.max_retries=2 to keep the pre-H-9 regression suite green.
+    markFailed(f.ctx, '1', 'legacy_failure_reason');
+    const ps = loadState(f.ctx).phase_status['1'];
+    expect(ps?.attempts).toBe(1);
+    // attempts(1) < max_retries(2) → still retryable, no backoff
+    const r = computeNextPhase(f.ctx, loadState(f.ctx));
+    expect(r.kind).toBe('phase_id');
+    expect(ps?.backoff_until).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- **H-4**: new `caia-chain preflight-dispatch` CLI verb probes the claude binary before each wake spawns a worker. 6-exit-code contract (0 healthy, 1 generic, 2 rate_limited, 3 auth_failure, 4 timeout, 5 unknown, 6 api_key_leak). Refuses if `ANTHROPIC_API_KEY` is set (subscription-only).
- **H-4b / D-4**: `pause --reason --until` persists `state.paused_until`. Shared `_wake_helpers.sh` adds `respect_paused_until` (auto-resume past boundary) and `preflight_gate` (parses reset_iso, pauses chain, appends pending-MCP action, emits alerts). All 3 wake scripts source the helper.
- **H-9**: per-`FailureClass` retry policy. YAML `defaults.retry_policy.<class>: { max_attempts, backoff_sec, action }`. `computeNextPhase` is class-aware; new `BACKOFF <secs> phase=<id> until=<iso>` result while backoff window is active. `pause_until_*` / `adjudicate` / `alert` actions promote to blocked on first failure.

Phase 4 of the `chain-runner-battle-harden` chain. Plan: `~/Documents/projects/reports/chain_runner_hardening_plan_2026-05-14.md` §H-4 §H-4b §H-9. Phase report: `~/Documents/projects/reports/chain_harden_p4_preflight_2026-05-14.md`.

## Test plan
- [x] `pnpm --filter @chiefaia/chain-runner test` → **189 passed (10 files, 0 failures)**
  - 31 new cases this phase (15 preflight + 16 retry-policy)
  - 79-case regression suite unchanged (legacy string-reason markFailed back-compat)
- [x] `tsc --noEmit` clean
- [x] `eslint src` clean
- [x] CLI smoke-tested via stub binaries (healthy / rate_limited / auth_failure paths each return the right exit code + `PREFLIGHT …` line)
- [x] Wake-script bash syntax verified (`bash -n` on helpers + all 3 wake scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)