### PR TITLE
feat(chain-runner): h-10 alerting backbone + h-5 NONE_ELIGIBLE escalation

### DIFF
--- a/packages/chain-runner/src/alerting.ts
+++ b/packages/chain-runner/src/alerting.ts
@@ -1,0 +1,381 @@
+// H-10 (chain-runner-battle-harden phase 5, 2026-05-14). Unified alerting
+// backbone for the chain runner. Replaces the four ad-hoc INBOX/handoff/
+// notification writers (src/watchdog.ts:appendInboxAlert, watchdog.js inbox
+// append, _wake_helpers.sh:wake_emit_alert, and the various scripts that
+// shelled `osascript` directly) with a single typed entry point.
+//
+// Channels (D-3):
+//   handoff       — append a JSONL record to ~/.caia/handoff/active_alerts.jsonl;
+//                   refresh_handoff.sh renders it into SESSION_HANDOFF.md's
+//                   Active alerts section on its next tick (option B from the
+//                   hardening plan — alerts are pulled, not inserted in-place).
+//   inbox         — append a markdown block to ~/.caia/chain-watchdog/INBOX.md
+//   notification  — macOS `osascript -e 'display notification ...'`
+//   audit         — appendAudit on the per-chain audit.jsonl (event: alert_emitted)
+//
+// Anti-spam: each alert has a fingerprint = sha256(chain | type | day). The
+// dedupe map at ~/.caia/chain-watchdog/.alert-dedupe.json tracks the
+// last-emit timestamp per fingerprint. Within the 6h window the alert is
+// suppressed on EVERY channel (so the loudest channel — osascript — cannot
+// pager-storm even if the underlying condition oscillates).
+//
+// Force-flag bypasses dedupe; reserve for true incidents where a fresh page
+// is genuinely warranted.
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { appendAudit } from './audit.js';
+
+export type AlertChannel = 'handoff' | 'inbox' | 'notification' | 'audit';
+
+export type AlertType =
+  | 'chain_stalled'
+  | 'chain_rate_limited'
+  | 'chain_auth_failed'
+  | 'chain_preflight_failed'
+  | 'chain_doctor_degraded'
+  | 'operator_action_required'
+  | 'cron_stall_detected'
+  | string;
+
+export type AlertSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface AlertEvent {
+  type: AlertType;
+  severity: AlertSeverity;
+  title: string;
+  detail: string;
+  /** Chain identifier — load-bearing for the dedupe fingerprint. */
+  chain: string;
+  evidence?: Record<string, unknown>;
+  /**
+   * When set, overrides the dedupe day component. Tests use this to drive
+   * the fingerprint deterministically.
+   */
+  fingerprintDay?: string;
+  /** Skip dedupe — fire even if a matching fingerprint is within the window. */
+  force?: boolean;
+  /** Per-event override of the default channel set for this type. */
+  channels?: AlertChannel[];
+}
+
+export interface EmitAlertOptions {
+  /** Per-chain audit.jsonl path (audit channel). */
+  auditFile?: string;
+  /** Default: ~/.caia/chain-watchdog/INBOX.md */
+  inboxPath?: string;
+  /** Default: ~/.caia/handoff/active_alerts.jsonl */
+  alertsJsonlPath?: string;
+  /** Default: ~/.caia/chain-watchdog/.alert-dedupe.json */
+  dedupePath?: string;
+  /** Dedupe window in seconds (default 6h). */
+  dedupeWindowSec?: number;
+  /** Channels resolved by the caller. When omitted, defaults-by-type apply. */
+  configChannels?: string[];
+  /** Injectable clock for tests. */
+  now?: () => Date;
+  /**
+   * Toggle osascript invocation. Default true on darwin; tests may pass false.
+   * (We always honor the channel selection — only the actual side-effect is
+   * skipped.)
+   */
+  notificationsEnabled?: boolean;
+  /** Custom spawn fn for the notification channel. Tests inject this. */
+  spawn?: (cmd: string, args: string[]) => { status: number | null };
+}
+
+export interface EmitAlertResult {
+  fingerprint: string;
+  fired: AlertChannel[];
+  suppressed: AlertChannel[];
+  deduped: boolean;
+  reason?: string;
+}
+
+// D-3 default channel set. The four "operator-must-see" event types get all
+// four channels; the diagnostic ones (doctor_degraded, preflight_failed) stay
+// quiet on notification to avoid pager fatigue. Per-event override via
+// AlertEvent.channels and per-chain override via chain_config.alert_channels
+// both take precedence over this default.
+export const DEFAULT_CHANNELS_BY_TYPE: Readonly<Record<string, AlertChannel[]>> =
+  Object.freeze({
+    chain_stalled: ['handoff', 'inbox', 'notification', 'audit'],
+    chain_rate_limited: ['handoff', 'inbox', 'notification', 'audit'],
+    chain_auth_failed: ['handoff', 'inbox', 'notification', 'audit'],
+    operator_action_required: ['handoff', 'inbox', 'notification', 'audit'],
+    chain_preflight_failed: ['inbox', 'audit'],
+    chain_doctor_degraded: ['inbox', 'audit'],
+    cron_stall_detected: ['handoff', 'inbox', 'audit'],
+  });
+
+// Resolved lazily so tests can set CAIA_ALERT_* env vars after module load to
+// redirect side effects into a tmpdir. (Static `const = process.env.X` would
+// bake the value in at first import, which is awkward inside vitest.)
+function defaultInboxPath(): string {
+  return (
+    process.env['CAIA_ALERT_INBOX_PATH'] ??
+    join(homedir(), '.caia', 'chain-watchdog', 'INBOX.md')
+  );
+}
+function defaultAlertsJsonlPath(): string {
+  return (
+    process.env['CAIA_ALERT_HANDOFF_JSONL_PATH'] ??
+    join(homedir(), '.caia', 'handoff', 'active_alerts.jsonl')
+  );
+}
+function defaultDedupePath(): string {
+  return (
+    process.env['CAIA_ALERT_DEDUPE_PATH'] ??
+    join(homedir(), '.caia', 'chain-watchdog', '.alert-dedupe.json')
+  );
+}
+function notificationsEnabledByEnv(): boolean {
+  return process.env['CAIA_DISABLE_NOTIFICATIONS'] !== '1';
+}
+const DEFAULT_DEDUPE_WINDOW_SEC = 6 * 3600;
+const KNOWN_CHANNELS: ReadonlySet<AlertChannel> = new Set<AlertChannel>([
+  'handoff',
+  'inbox',
+  'notification',
+  'audit',
+]);
+
+export function fingerprintForAlert(event: AlertEvent, now?: () => Date): string {
+  const day =
+    event.fingerprintDay ??
+    (now ?? (() => new Date()))().toISOString().slice(0, 10);
+  const raw = `${event.chain}|${event.type}|${day}`;
+  return createHash('sha256').update(raw).digest('hex').slice(0, 16);
+}
+
+interface DedupeFile {
+  fingerprints: Record<string, string>;
+}
+
+function loadDedupe(p: string): DedupeFile {
+  if (!existsSync(p)) return { fingerprints: {} };
+  try {
+    const raw = JSON.parse(readFileSync(p, 'utf8')) as unknown;
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      'fingerprints' in raw &&
+      typeof (raw as DedupeFile).fingerprints === 'object'
+    ) {
+      return raw as DedupeFile;
+    }
+  } catch {
+    // fall-through to empty
+  }
+  return { fingerprints: {} };
+}
+
+function saveDedupe(p: string, state: DedupeFile): void {
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(state, null, 2), { mode: 0o600 });
+}
+
+export function resolveChannels(
+  event: AlertEvent,
+  configChannels?: string[] | undefined,
+): AlertChannel[] {
+  if (event.channels && event.channels.length > 0) {
+    return event.channels.filter((c): c is AlertChannel => KNOWN_CHANNELS.has(c));
+  }
+  if (configChannels && configChannels.length > 0) {
+    const filtered = configChannels.filter((c): c is AlertChannel =>
+      KNOWN_CHANNELS.has(c as AlertChannel),
+    );
+    if (filtered.length > 0) return filtered;
+  }
+  return DEFAULT_CHANNELS_BY_TYPE[event.type] ?? ['inbox', 'audit'];
+}
+
+export function emitAlert(
+  channels: AlertChannel[] | undefined,
+  event: AlertEvent,
+  opts: EmitAlertOptions = {},
+): EmitAlertResult {
+  if (!event.chain || typeof event.chain !== 'string') {
+    throw new Error('emitAlert: event.chain is required (load-bearing for fingerprint)');
+  }
+  const now = (opts.now ?? (() => new Date()))();
+  const dedupeWindow = opts.dedupeWindowSec ?? DEFAULT_DEDUPE_WINDOW_SEC;
+  const dedupePath = opts.dedupePath ?? defaultDedupePath();
+  const inboxPath = opts.inboxPath ?? defaultInboxPath();
+  const alertsPath = opts.alertsJsonlPath ?? defaultAlertsJsonlPath();
+  const notificationsEnabled =
+    opts.notificationsEnabled ?? notificationsEnabledByEnv();
+
+  const resolved =
+    channels && channels.length > 0
+      ? channels.filter((c) => KNOWN_CHANNELS.has(c))
+      : resolveChannels(event, opts.configChannels);
+
+  const fp = fingerprintForAlert(event, opts.now);
+  const dedupe = loadDedupe(dedupePath);
+  const lastIso = dedupe.fingerprints[fp];
+  const lastMs = lastIso ? Date.parse(lastIso) : NaN;
+  const ageSec = Number.isFinite(lastMs)
+    ? (now.getTime() - lastMs) / 1000
+    : Infinity;
+  const isDuplicate = !event.force && ageSec < dedupeWindow;
+
+  if (isDuplicate) {
+    if (opts.auditFile) {
+      appendAudit(opts.auditFile, 'alert_suppressed_duplicate', {
+        type: event.type,
+        chain: event.chain,
+        fingerprint: fp,
+        age_sec_since_last: Math.floor(ageSec),
+        dedupe_window_sec: dedupeWindow,
+        intended_channels: resolved,
+      });
+    }
+    return {
+      fingerprint: fp,
+      fired: [],
+      suppressed: resolved,
+      deduped: true,
+      reason: 'duplicate_within_window',
+    };
+  }
+
+  const fired: AlertChannel[] = [];
+  const suppressed: AlertChannel[] = [];
+  for (const ch of resolved) {
+    try {
+      switch (ch) {
+        case 'audit':
+          if (opts.auditFile) {
+            appendAudit(opts.auditFile, 'alert_emitted', {
+              type: event.type,
+              severity: event.severity,
+              title: event.title,
+              detail: event.detail.slice(0, 500),
+              chain: event.chain,
+              fingerprint: fp,
+              evidence: event.evidence ?? {},
+              forced: event.force === true,
+            });
+            fired.push('audit');
+          } else {
+            suppressed.push('audit');
+          }
+          break;
+        case 'inbox':
+          writeInboxBlock(inboxPath, event, now, fp);
+          fired.push('inbox');
+          break;
+        case 'handoff':
+          writeHandoffJsonl(alertsPath, event, now, fp);
+          fired.push('handoff');
+          break;
+        case 'notification':
+          if (!notificationsEnabled) {
+            suppressed.push('notification');
+          } else {
+            sendOsascriptNotification(event, opts.spawn);
+            fired.push('notification');
+          }
+          break;
+      }
+    } catch {
+      suppressed.push(ch);
+    }
+  }
+
+  if (fired.length > 0) {
+    // Record the EMIT time using the same clock that gated the decision, so
+    // tests injecting a fake clock get deterministic behavior across calls.
+    dedupe.fingerprints[fp] = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+    saveDedupe(dedupePath, dedupe);
+  }
+
+  return { fingerprint: fp, fired, suppressed, deduped: false };
+}
+
+function writeInboxBlock(
+  path: string,
+  event: AlertEvent,
+  now: Date,
+  fp: string,
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const header = existsSync(path) ? '' : '# Chain-Watchdog INBOX\n\n';
+  const ts = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const evLines = Object.entries(event.evidence ?? {})
+    .map(([k, v]) => `- ${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
+    .join('\n');
+  const block =
+    `${header}## [${ts}] ${event.type} — ${event.chain}\n` +
+    `- severity: ${event.severity}\n` +
+    `- title: ${event.title}\n` +
+    `- detail: ${event.detail}\n` +
+    `- fingerprint: ${fp}\n` +
+    (evLines ? `${evLines}\n` : '') +
+    '\n';
+  appendFileSync(path, block);
+}
+
+function writeHandoffJsonl(
+  jsonlPath: string,
+  event: AlertEvent,
+  now: Date,
+  fp: string,
+): void {
+  mkdirSync(dirname(jsonlPath), { recursive: true });
+  const entry = {
+    ts: now.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    type: event.type,
+    severity: event.severity,
+    chain: event.chain,
+    title: event.title,
+    detail: event.detail.slice(0, 500),
+    fingerprint: fp,
+    evidence: event.evidence ?? {},
+  };
+  appendFileSync(jsonlPath, JSON.stringify(entry) + '\n');
+}
+
+function sendOsascriptNotification(
+  event: AlertEvent,
+  spawn?: (cmd: string, args: string[]) => { status: number | null },
+): void {
+  // Sanitize: osascript -e takes a single shell-escaped string; we use the
+  // single-arg form, so the only injection vector is the script contents.
+  // Replace double-quotes with apostrophes and cap length.
+  const title = `caia ${event.type}`.replace(/"/g, "'").slice(0, 120);
+  const body = `${event.chain}: ${event.detail}`
+    .replace(/"/g, "'")
+    .replace(/[\r\n]+/g, ' ')
+    .slice(0, 250);
+  const script = `display notification "${body}" with title "${title}"`;
+  const runner =
+    spawn ??
+    ((cmd: string, args: string[]) => {
+      const out = spawnSync(cmd, args, { stdio: 'ignore', timeout: 5_000 });
+      return { status: out.status };
+    });
+  runner('osascript', ['-e', script]);
+}
+
+// Convenience helper for callers that already have a chain context and want
+// the typed defaults. Exists so wake-script-equivalent code in this package
+// (watchdog.ts, the future stall-root-cause CLI) can stay terse.
+export function emitChainAlert(
+  event: AlertEvent,
+  auditFile: string,
+  opts: Omit<EmitAlertOptions, 'auditFile'> = {},
+): EmitAlertResult {
+  return emitAlert(undefined, event, { ...opts, auditFile });
+}

--- a/packages/chain-runner/src/cascade.ts
+++ b/packages/chain-runner/src/cascade.ts
@@ -1,0 +1,172 @@
+// H-5 / H-17 (chain-runner-battle-harden phase 5, 2026-05-14). Stall root-cause
+// analysis. Walks the dependency graph from the first non-`done` phase and
+// reports the upstream blocker (status, failure class, attempts), then
+// suggests an adjudication CLI invocation the operator can run to unblock the
+// chain. Used by `caia-chain stall-root-cause` and surfaced in the
+// chain_stalled alert detail string so the inbox/handoff blocks are
+// actionable instead of just descriptive.
+
+import type {
+  ChainSpec,
+  PhaseDefinition,
+  PhaseState,
+  StateFile,
+} from './types.js';
+
+export interface RootCauseDiagnosis {
+  /** First phase that is not yet `done`, walking ids in spec order. */
+  nextPending: PhaseDefinition | null;
+  /**
+   * The upstream phase blocking progress, if any. This is the deepest non-done
+   * ancestor of `nextPending` whose status is `blocked` or `failed`. When
+   * `nextPending` itself is dispatchable (deps met) and not yet started, this
+   * is null and the diagnosis explains that the chain is simply idle / not
+   * yet woken.
+   */
+  blocker: PhaseDefinition | null;
+  blockerState: PhaseState | null;
+  /** Free-form human summary suitable for INBOX/HANDOFF rendering. */
+  diagnosis: string;
+  /** Suggested CLI command. May be a multi-line string. */
+  suggested: string;
+}
+
+export function diagnoseStall(spec: ChainSpec, state: StateFile): RootCauseDiagnosis {
+  if (state.all_done) {
+    return {
+      nextPending: null,
+      blocker: null,
+      blockerState: null,
+      diagnosis: 'Chain is all_done; no stall to diagnose.',
+      suggested: '(no action — chain finished)',
+    };
+  }
+  if (state.paused) {
+    const until = state.paused_until ?? null;
+    const reason = state.paused_reason ?? '(no reason recorded)';
+    return {
+      nextPending: null,
+      blocker: null,
+      blockerState: null,
+      diagnosis: `Chain is paused: ${reason}${until ? ` (paused_until=${until})` : ''}`,
+      suggested:
+        until !== null
+          ? `wait for ${until}, or run \`caia-chain resume --chain-id <id> --phases <yaml>\``
+          : `run \`caia-chain resume --chain-id <id> --phases <yaml>\``,
+    };
+  }
+  const nextPending = firstNonDone(spec, state);
+  if (!nextPending) {
+    return {
+      nextPending: null,
+      blocker: null,
+      blockerState: null,
+      diagnosis:
+        'No non-done phase found, but state.all_done=false — invariant broken; inspect state.json.',
+      suggested:
+        'Run `caia-chain status` and verify phase_status; an adjudication may be required.',
+    };
+  }
+
+  // Walk the dependency graph upward to find the deepest blocker.
+  const blockerPid = findDeepestBlocker(spec, state, nextPending.id);
+  if (blockerPid === null) {
+    const deps = nextPending.deps ?? [];
+    return {
+      nextPending,
+      blocker: null,
+      blockerState: null,
+      diagnosis:
+        `Phase ${nextPending.id} (${nextPending.name}) is pending; deps=[${deps.join(',')}] all done. ` +
+        `Chain may be idle (wake not yet fired) or in backoff.`,
+      suggested:
+        `Verify a wake has fired (\`caia-chain audit-tail\`); inspect backoff_until on the phase.`,
+    };
+  }
+  const blocker = spec.phases.find((p) => p.id === blockerPid) ?? null;
+  const blockerState = state.phase_status[String(blockerPid)] ?? null;
+  const cls =
+    blockerState?.last_failure_class ?? blockerState?.failure?.class ?? 'unknown';
+  const attempts = blockerState?.attempts ?? 0;
+  const reason = blockerState?.failure?.reason ?? blockerState?.error ?? '(no recorded reason)';
+
+  const diagnosis =
+    `Phase ${nextPending.id} (${nextPending.name}) cannot run because ` +
+    `phase ${blockerPid} (${blocker?.name ?? '?'}) is ${blockerState?.status ?? '?'} ` +
+    `[class=${cls} attempts=${attempts}]: ${reason}`;
+
+  const suggested = suggestRecovery(blockerPid, blockerState, cls);
+
+  return {
+    nextPending,
+    blocker,
+    blockerState,
+    diagnosis,
+    suggested,
+  };
+}
+
+function firstNonDone(spec: ChainSpec, state: StateFile): PhaseDefinition | null {
+  for (const p of spec.phases) {
+    const ps = state.phase_status[String(p.id)];
+    if (!ps) continue;
+    if (ps.status !== 'done') return p;
+  }
+  return null;
+}
+
+// Recursive walk: for the target phase, if any of its deps is non-done, recurse
+// into that dep. The deepest reachable non-done is the blocker. Cycles in the
+// dep graph would be a spec error (loadChainSpec doesn't currently check that),
+// so we guard with a visited set.
+function findDeepestBlocker(
+  spec: ChainSpec,
+  state: StateFile,
+  targetId: number,
+  visited: Set<number> = new Set(),
+): number | null {
+  if (visited.has(targetId)) return null;
+  visited.add(targetId);
+  const target = spec.phases.find((p) => p.id === targetId);
+  if (!target) return null;
+  for (const depId of target.deps ?? []) {
+    const depState = state.phase_status[String(depId)];
+    if (!depState) continue;
+    if (depState.status === 'done') continue;
+    // Found a non-done dep. Recurse to see if it has its own blocker.
+    const deeper = findDeepestBlocker(spec, state, depId, visited);
+    return deeper ?? depId;
+  }
+  // No non-done deps. If the target itself is blocked or failed, IT is the blocker.
+  const targetState = state.phase_status[String(targetId)];
+  if (targetState && (targetState.status === 'blocked' || targetState.status === 'failed')) {
+    return targetId;
+  }
+  return null;
+}
+
+function suggestRecovery(
+  blockerId: number,
+  blockerState: PhaseState | null,
+  cls: string,
+): string {
+  const re_arm = `caia-chain re-arm ${blockerId} --reset-attempts --reason '<your reason>'`;
+  switch (cls) {
+    case 'worker_no_start_rate_limit': {
+      const reset = blockerState?.failure?.evidence?.['reset_iso'];
+      return reset
+        ? `Wait for rate-limit reset at ${String(reset)}, then run:\n  ${re_arm}`
+        : `Wait for rate-limit reset (check preflight banner), then run:\n  ${re_arm}`;
+    }
+    case 'worker_no_start_auth_failure':
+      return `OPERATOR_ACTION_REQUIRED: re-authenticate the claude CLI (\`claude logout && claude\`), then run:\n  ${re_arm}`;
+    case 'worker_no_start_binary_missing':
+      return `OPERATOR_ACTION_REQUIRED: install / fix path to the claude binary, then run:\n  ${re_arm}`;
+    case 'worker_hung_post_success':
+      return `If artifact/PR look correct, adjudicate to done:\n  caia-chain adjudicate ${blockerId} --to done --reason 'hung-post-success; verified manually'`;
+    case 'runtime_exceeded':
+      return `Inspect the dispatch log; if expected, raise max_minutes for this phase in the YAML, then:\n  ${re_arm}`;
+    default:
+      return `Inspect the failure evidence, fix the underlying cause, then:\n  ${re_arm}`;
+  }
+}

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -41,6 +41,14 @@ import {
   recordStallDetected,
 } from './watchdog.js';
 import { appendAudit } from './audit.js';
+import {
+  emitAlert,
+  type AlertChannel,
+  type AlertSeverity,
+  type AlertEvent,
+} from './alerting.js';
+import { diagnoseStall } from './cascade.js';
+import { chainPaths } from './paths.js';
 import { doctorExitCode, formatDoctorReport, runDoctor } from './doctor.js';
 import { fireHandoffRefresh } from './handoff-refresh.js';
 import {
@@ -585,7 +593,7 @@ export function buildProgram(): Command {
 
   attachCommonOptions(program.command('check-stall'))
     .description(
-      'Self-healing watchdog: detect cron stall and (optionally) re-register the scheduled task.',
+      'Self-healing watchdog: detect cron stall and (optionally) re-register the scheduled task. H-5: also escalates NONE_ELIGIBLE stalls via --alert-on-streak.',
     )
     .option(
       '--wake-interval-sec <n>',
@@ -596,6 +604,10 @@ export function buildProgram(): Command {
     .option('--inbox <path>', 'path to INBOX.md to append alert')
     .option('--reregister-cmd <cmd>', 'shell command to re-register the scheduled task on stall')
     .option('--no-alert', 'suppress INBOX append even when --inbox is given')
+    .option(
+      '--alert-on-streak <n>',
+      'H-5: if state.none_eligible_streak >= n, emit a chain_stalled alert (channels honor chain_config.alert_channels; default [handoff,inbox,notification,audit]) and return STREAK_ALERT_FIRED. Use 2 for the 30-min escalation default.',
+    )
     .action(
       (
         cmdOpts: {
@@ -604,12 +616,61 @@ export function buildProgram(): Command {
           inbox?: string;
           reregisterCmd?: string;
           alert?: boolean;
+          alertOnStreak?: string;
         },
         cmd: Command,
       ) => {
         const opts = cmd.optsWithGlobals() as BaseOptions & typeof cmdOpts;
         const ctx = ctxFromOpts(opts);
         const state = loadState(ctx);
+
+        // H-5: NONE_ELIGIBLE streak escalation. Decoupled from the cron-stall
+        // path — both can fire in the same tick, but they describe different
+        // failure modes. The streak is owned by computeNextPhase; check-stall
+        // just READS it and decides whether to escalate.
+        const streakThreshold = cmdOpts.alertOnStreak
+          ? Number(cmdOpts.alertOnStreak)
+          : null;
+        let streakFired = false;
+        if (streakThreshold !== null && Number.isFinite(streakThreshold)) {
+          const streak = state.none_eligible_streak ?? 0;
+          if (streak >= streakThreshold) {
+            const diag = diagnoseStall(ctx.spec, state);
+            const configChannels = ctx.spec.chain_config?.alert_channels;
+            const alertEvent: AlertEvent = {
+              type: 'chain_stalled',
+              severity: 'high',
+              title: `chain_stalled — ${opts.chainId} (streak=${streak})`,
+              detail: diag.diagnosis,
+              chain: opts.chainId,
+              evidence: {
+                streak,
+                threshold: streakThreshold,
+                next_pending_id: diag.nextPending?.id ?? null,
+                next_pending_name: diag.nextPending?.name ?? null,
+                blocker_id: diag.blocker?.id ?? null,
+                blocker_status: diag.blockerState?.status ?? null,
+                blocker_class:
+                  diag.blockerState?.last_failure_class ??
+                  diag.blockerState?.failure?.class ??
+                  null,
+                blocker_attempts: diag.blockerState?.attempts ?? null,
+                suggested: diag.suggested,
+              },
+            };
+            const emitOpts: Parameters<typeof emitAlert>[2] = {
+              auditFile: ctx.paths.auditFile,
+            };
+            if (cmdOpts.inbox) emitOpts.inboxPath = cmdOpts.inbox;
+            if (configChannels) emitOpts.configChannels = configChannels;
+            const r = emitAlert(undefined, alertEvent, emitOpts);
+            streakFired = r.fired.length > 0;
+            process.stdout.write(
+              `STREAK_ALERT streak=${streak} threshold=${streakThreshold} fired=${r.fired.join(',') || 'none'} deduped=${r.deduped}\n`,
+            );
+          }
+        }
+
         const result = detectStall(state, {
           wakeIntervalSec: Number(cmdOpts.wakeIntervalSec ?? '900'),
           multiplier: Number(cmdOpts.multiplier ?? '2'),
@@ -618,6 +679,10 @@ export function buildProgram(): Command {
           process.stdout.write(
             `HEALTHY age_sec=${Math.floor(result.ageSec)} threshold_sec=${result.thresholdSec}\n`,
           );
+          // Streak alert is its own exit signal; cron-healthy and streak-fired
+          // can coexist (a chain that's waking every 15 min but stalling on
+          // NONE_ELIGIBLE).
+          if (streakFired) process.exit(5);
           return;
         }
         const inboxPath =
@@ -638,6 +703,174 @@ export function buildProgram(): Command {
           `STALL_DETECTED age_sec=${Math.floor(result.ageSec)} threshold_sec=${result.thresholdSec} reason=${result.reason}${reregOutput}\n`,
         );
         process.exit(4);
+      },
+    );
+
+  // H-10 (phase 5, 2026-05-14). emit-alert — generic CLI entry point to the
+  // alerting backbone. Used by:
+  //   - autonomy directive — workers running into operator-only carve-outs
+  //     (`caia-chain emit-alert --type operator_action_required ...`)
+  //   - shell wake scripts that want the unified dedupe/handoff/inbox/notify
+  //     fan-out instead of the legacy wake_emit_alert bash helper
+  //   - external watchdogs (chain-watchdog/watchdog.js) escalating cron stalls
+  //
+  // chain-id is REQUIRED (load-bearing for the fingerprint dedupe). --phases
+  // is OPTIONAL — when given, the alert is also appended to the chain's
+  // audit.jsonl via the audit channel; when omitted, the audit channel is
+  // suppressed and the chain dir is derived from `chainPaths(chainId)` so the
+  // dedupe key still works.
+  program
+    .command('emit-alert')
+    .description(
+      'Emit an alert through the unified backbone (handoff + inbox + notification + audit). Required for the autonomy directive `OPERATOR_ACTION_REQUIRED` flow.',
+    )
+    .requiredOption('--chain-id <id>', 'chain identifier (load-bearing for dedupe fingerprint)')
+    .requiredOption(
+      '--type <type>',
+      'alert type (chain_stalled | chain_rate_limited | chain_auth_failed | operator_action_required | chain_preflight_failed | chain_doctor_degraded | cron_stall_detected | <custom>)',
+    )
+    .requiredOption('--severity <level>', 'low | medium | high | critical')
+    .requiredOption('--detail <text>', 'short human-readable detail string')
+    .option('--phases <path>', 'phases YAML — when given, the audit channel logs onto chain audit.jsonl')
+    .option('--title <text>', 'optional alert title (defaults to "<type> — <chain-id>")')
+    .option(
+      '--channels <csv>',
+      'override channels: csv of handoff|inbox|notification|audit',
+    )
+    .option('--force', 'bypass the 6h dedupe (use sparingly)')
+    .option(
+      '--evidence <kv>',
+      'key=value evidence pairs (repeatable)',
+      (val: string, acc: string[]) => acc.concat(val),
+      [] as string[],
+    )
+    .action(
+      (cmdOpts: {
+        chainId: string;
+        type: string;
+        severity: string;
+        detail: string;
+        phases?: string;
+        title?: string;
+        channels?: string;
+        force?: boolean;
+        evidence?: string[];
+      }) => {
+        const severity = cmdOpts.severity as AlertSeverity;
+        const evidence: Record<string, unknown> = {};
+        for (const kv of cmdOpts.evidence ?? []) {
+          for (const piece of kv.split(',')) {
+            const eq = piece.indexOf('=');
+            if (eq > 0) {
+              evidence[piece.slice(0, eq).trim()] = piece.slice(eq + 1).trim();
+            }
+          }
+        }
+        const event: AlertEvent = {
+          type: cmdOpts.type,
+          severity,
+          title: cmdOpts.title ?? `${cmdOpts.type} — ${cmdOpts.chainId}`,
+          detail: cmdOpts.detail,
+          chain: cmdOpts.chainId,
+          evidence,
+          ...(cmdOpts.force ? { force: true } : {}),
+        };
+        const channels = cmdOpts.channels
+          ? (cmdOpts.channels
+              .split(',')
+              .map((c) => c.trim())
+              .filter(Boolean) as AlertChannel[])
+          : undefined;
+
+        // Audit file: derive from phases YAML if available (canonical context),
+        // else from chainPaths so we still get an audit trail per chain.
+        let auditFile: string | undefined;
+        let configChannels: string[] | undefined;
+        if (cmdOpts.phases) {
+          try {
+            const ctx = loadContext(cmdOpts.chainId, cmdOpts.phases);
+            auditFile = ctx.paths.auditFile;
+            configChannels = ctx.spec.chain_config?.alert_channels;
+          } catch {
+            // Fall through; audit-channel will be suppressed if no path.
+          }
+        }
+        if (!auditFile) {
+          try {
+            auditFile = chainPaths(cmdOpts.chainId).auditFile;
+          } catch {
+            // chain-id failed validation; emitAlert will throw later if needed.
+          }
+        }
+
+        const emitOpts: Parameters<typeof emitAlert>[2] = {};
+        if (auditFile) emitOpts.auditFile = auditFile;
+        if (configChannels) emitOpts.configChannels = configChannels;
+        const r = emitAlert(channels, event, emitOpts);
+        process.stdout.write(
+          `ALERT_EMIT type=${event.type} chain=${event.chain} fired=${r.fired.join(',') || 'none'} suppressed=${r.suppressed.join(',') || 'none'} deduped=${r.deduped} fp=${r.fingerprint}\n`,
+        );
+        if (r.deduped) process.exit(8); // distinct exit so callers can detect dedupe
+      },
+    );
+
+  // H-5 / H-17. stall-root-cause — read-only inspection that walks the
+  // dependency graph from the first non-`done` phase and reports the
+  // upstream blocker + a suggested adjudication command. Used by operators
+  // running `caia-chain stall-root-cause --chain-id ...` after seeing a
+  // chain_stalled alert.
+  attachCommonOptions(program.command('stall-root-cause'))
+    .description(
+      'Walk the dependency graph from the first non-done phase and print the upstream blocker plus a suggested adjudication command.',
+    )
+    .option('--json', 'emit JSON instead of text')
+    .action(
+      (cmdOpts: { json?: boolean }, cmd: Command) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions & typeof cmdOpts;
+        const ctx = ctxFromOpts(opts);
+        const state = loadState(ctx);
+        const diag = diagnoseStall(ctx.spec, state);
+        if (cmdOpts.json) {
+          process.stdout.write(
+            JSON.stringify(
+              {
+                chain_id: opts.chainId,
+                next_pending: diag.nextPending
+                  ? { id: diag.nextPending.id, name: diag.nextPending.name }
+                  : null,
+                blocker: diag.blocker
+                  ? { id: diag.blocker.id, name: diag.blocker.name }
+                  : null,
+                blocker_state: diag.blockerState
+                  ? {
+                      status: diag.blockerState.status,
+                      attempts: diag.blockerState.attempts,
+                      class:
+                        diag.blockerState.last_failure_class ??
+                        diag.blockerState.failure?.class ??
+                        null,
+                      reason:
+                        diag.blockerState.failure?.reason ??
+                        diag.blockerState.error ??
+                        null,
+                    }
+                  : null,
+                diagnosis: diag.diagnosis,
+                suggested: diag.suggested,
+                none_eligible_streak: state.none_eligible_streak ?? 0,
+              },
+              null,
+              2,
+            ) + '\n',
+          );
+        } else {
+          process.stdout.write(`STALL_ROOT_CAUSE chain=${opts.chainId}\n`);
+          process.stdout.write(`  diagnosis: ${diag.diagnosis}\n`);
+          process.stdout.write(`  suggested: ${diag.suggested}\n`);
+          process.stdout.write(
+            `  none_eligible_streak: ${state.none_eligible_streak ?? 0}\n`,
+          );
+        }
       },
     );
 

--- a/packages/chain-runner/src/index.ts
+++ b/packages/chain-runner/src/index.ts
@@ -11,6 +11,8 @@ export * from './bootstrap.js';
 export * from './watchdog.js';
 export * from './classify.js';
 export * from './preflight.js';
+export * from './alerting.js';
+export * from './cascade.js';
 export {
   DEFAULT_RETRY_POLICY,
   backoffSecForAttempt,

--- a/packages/chain-runner/src/state.ts
+++ b/packages/chain-runner/src/state.ts
@@ -59,6 +59,11 @@ export function buildInitialState(spec: ChainSpec): StateFile {
     phase_status: phaseStatus,
     current_phase: null,
     all_done: false,
+    // H-5 (phase 5, 2026-05-14). Live count of consecutive NONE_ELIGIBLE
+    // wakes. Incremented inside computeNextPhase whenever it returns
+    // none_eligible, reset to 0 on any other result kind. Used by
+    // check-stall --alert-on-streak to escalate silent stalls.
+    none_eligible_streak: 0,
   };
 }
 
@@ -112,12 +117,39 @@ export type NextPhaseResult =
         | 'none_eligible';
     };
 
-export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhaseResult {
-  if (state.paused) return { kind: 'paused' };
-  if (state.budget_consumed_pct >= state.budget_cap_pct) {
-    return { kind: 'budget_exhausted' };
+// H-5 (phase 5, 2026-05-14). After computeNextPhase decides the outcome, this
+// helper updates state.none_eligible_streak — increment on `none_eligible`,
+// reset to 0 on every other result kind (including `paused`, `all_done`, and
+// `backoff`, all of which are well-defined non-stalled states). Saves only
+// when the value actually changes, so happy-path wakes don't churn state.json.
+function _applyNoneEligibleStreak(
+  ctx: StateContext,
+  state: StateFile,
+  result: NextPhaseResult,
+): NextPhaseResult {
+  const current = state.none_eligible_streak ?? 0;
+  const next = result.kind === 'none_eligible' ? current + 1 : 0;
+  if (next !== current) {
+    state.none_eligible_streak = next;
+    saveState(ctx, state);
+  } else if (state.none_eligible_streak === undefined) {
+    // Promote the optional field once so older state files migrate forward.
+    state.none_eligible_streak = next;
+    saveState(ctx, state);
   }
-  if (state.all_done) return { kind: 'all_done' };
+  return result;
+}
+
+export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhaseResult {
+  if (state.paused) {
+    return _applyNoneEligibleStreak(ctx, state, { kind: 'paused' });
+  }
+  if (state.budget_consumed_pct >= state.budget_cap_pct) {
+    return _applyNoneEligibleStreak(ctx, state, { kind: 'budget_exhausted' });
+  }
+  if (state.all_done) {
+    return _applyNoneEligibleStreak(ctx, state, { kind: 'all_done' });
+  }
 
   const nowMs = Date.now();
   let mutated = false;
@@ -179,21 +211,21 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
           const bt = new Date(ps.backoff_until).getTime();
           if (Number.isFinite(bt) && bt > nowMs) {
             if (mutated) saveState(ctx, state);
-            return {
+            return _applyNoneEligibleStreak(ctx, state, {
               kind: 'backoff',
               id: p.id,
               seconds: Math.max(0, Math.ceil((bt - nowMs) / 1000)),
               until: ps.backoff_until,
-            };
+            });
           }
         }
       }
       if (mutated) saveState(ctx, state);
-      return { kind: 'phase_id', id: p.id };
+      return _applyNoneEligibleStreak(ctx, state, { kind: 'phase_id', id: p.id });
     }
     if (ps.status === 'in_progress') {
       if (mutated) saveState(ctx, state);
-      return { kind: 'in_progress', id: p.id };
+      return _applyNoneEligibleStreak(ctx, state, { kind: 'in_progress', id: p.id });
     }
   }
 
@@ -205,10 +237,16 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
     state.all_done = true;
     saveState(ctx, state);
     appendAudit(ctx.paths.auditFile, 'all_done', {});
-    return { kind: 'all_done' };
+    return _applyNoneEligibleStreak(ctx, state, { kind: 'all_done' });
   }
   if (mutated) saveState(ctx, state);
-  return { kind: 'none_eligible' };
+  // H-5: emit a structured audit entry on every none_eligible result so
+  // operators have first-class telemetry of stalls (not just inferred from
+  // wake-script logs). The stall-root-cause CLI consumes this.
+  appendAudit(ctx.paths.auditFile, 'none_eligible', {
+    streak_before: state.none_eligible_streak ?? 0,
+  });
+  return _applyNoneEligibleStreak(ctx, state, { kind: 'none_eligible' });
 }
 
 // H-2 (chain-runner-battle-harden phase 3, 2026-05-14). markInProgress emits

--- a/packages/chain-runner/src/types.ts
+++ b/packages/chain-runner/src/types.ts
@@ -134,6 +134,15 @@ export interface StateFile {
   phase_status: Record<string, PhaseState>;
   current_phase: number | null;
   all_done: boolean;
+  /**
+   * H-5 (chain-runner-battle-harden phase 5, 2026-05-14). Count of consecutive
+   * wakes that produced `none_eligible` from computeNextPhase. Used by
+   * `caia-chain check-stall --alert-on-streak <n>` to escalate silent chain
+   * stalls (the 8-hour 2026-05-14 incident pattern). Resets to 0 on any
+   * non-`none_eligible` result. Optional in the schema so older state.json
+   * files load without a migration; first save promotes it to 0.
+   */
+  none_eligible_streak?: number;
 }
 
 export interface LockFile {

--- a/packages/chain-runner/src/watchdog.ts
+++ b/packages/chain-runner/src/watchdog.ts
@@ -11,11 +11,9 @@
 // This is the second of four safeguards against the RCA failure mode
 // where SKILL.md is on disk but no cron is firing.
 
-import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { dirname } from 'node:path';
 import { appendAudit } from './audit.js';
-import { isoNow } from './time.js';
+import { emitAlert } from './alerting.js';
 import type { StateContext } from './state.js';
 import type { StateFile } from './types.js';
 
@@ -90,33 +88,32 @@ export function recordStallDetected(
     threshold_sec: result.thresholdSec,
     reason: result.reason,
   });
-  if (opts.inboxPath) {
-    appendInboxAlert(opts.inboxPath, ctx, result, opts.chainId);
-  }
-}
-
-function appendInboxAlert(
-  inboxPath: string,
-  ctx: StateContext,
-  result: StallCheckResult,
-  chainId?: string,
-): void {
-  mkdirSync(dirname(inboxPath), { recursive: true });
-  const header = existsSync(inboxPath) ? '' : '# INBOX\n\n';
-  const chain = chainId ?? ctx.paths.baseDir;
-  const ageStr =
-    Number.isFinite(result.ageSec) && result.ageSec >= 0
-      ? `${Math.floor(result.ageSec)}s`
-      : 'n/a';
-  const block =
-    `${header}## [${isoNow()}] cron_stall_detected — ${chain}\n` +
-    `- chain dir: ${ctx.paths.baseDir}\n` +
-    `- last_wake: ${result.lastWake ?? 'never'}\n` +
-    `- age: ${ageStr}\n` +
-    `- threshold: ${result.thresholdSec}s\n` +
-    `- reason: ${result.reason}\n` +
-    `- action: re-register scheduled task and verify with caia-chain verify-bootstrap\n\n`;
-  appendFileSync(inboxPath, block);
+  // H-10 (phase 5, 2026-05-14). Route the inbox-style alert through the
+  // unified alerting backbone. The default channel set for
+  // cron_stall_detected is [handoff, inbox, audit] (D-3 keeps notification
+  // off for cron-stall to avoid pager fatigue on the 30-minute watchdog
+  // tick); per-event channel override is supported via opts.channels but the
+  // legacy call sites all rely on the default.
+  const chainId = opts.chainId ?? ctx.paths.baseDir;
+  emitAlert(undefined, {
+    type: 'cron_stall_detected',
+    severity: 'medium',
+    title: `cron_stall_detected — ${chainId}`,
+    detail: `last_wake=${result.lastWake ?? 'never'} age=${Math.floor(result.ageSec)}s threshold=${result.thresholdSec}s reason=${result.reason}`,
+    chain: chainId,
+    evidence: {
+      chain_dir: ctx.paths.baseDir,
+      last_wake: result.lastWake,
+      age_sec: Math.floor(result.ageSec),
+      threshold_sec: result.thresholdSec,
+      reason: result.reason,
+      action:
+        'investigate scheduled-task registry; re-register via mcp__scheduled-tasks__create_scheduled_task and verify with `caia-chain verify-bootstrap`',
+    },
+  }, {
+    auditFile: ctx.paths.auditFile,
+    ...(opts.inboxPath ? { inboxPath: opts.inboxPath } : {}),
+  });
 }
 
 export interface ReRegisterAttempt {

--- a/packages/chain-runner/tests/alerting.test.ts
+++ b/packages/chain-runner/tests/alerting.test.ts
@@ -1,0 +1,341 @@
+// H-10 (chain-runner-battle-harden phase 5, 2026-05-14) — alerting backbone
+// tests. Specifically validates fingerprint dedupe across all four channels,
+// since "broken dedupe = pager storm" was called out as the #1 risk in the
+// hardening plan. osascript invocations are stubbed via opts.spawn to avoid
+// firing real notifications during test runs.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  DEFAULT_CHANNELS_BY_TYPE,
+  emitAlert,
+  fingerprintForAlert,
+  resolveChannels,
+  type AlertEvent,
+  type AlertChannel,
+} from '../src/alerting.js';
+
+function makeAlertEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'caia-alert-'));
+  return {
+    root,
+    inboxPath: join(root, 'INBOX.md'),
+    alertsJsonlPath: join(root, 'active_alerts.jsonl'),
+    dedupePath: join(root, 'dedupe.json'),
+    auditFile: join(root, 'audit.jsonl'),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function baseEvent(over: Partial<AlertEvent> = {}): AlertEvent {
+  return {
+    type: 'chain_stalled',
+    severity: 'high',
+    title: 't',
+    detail: 'd',
+    chain: 'test-chain',
+    ...over,
+  };
+}
+
+describe('fingerprintForAlert', () => {
+  it('produces a deterministic short hash for (chain, type, day)', () => {
+    const now = () => new Date('2026-05-14T12:00:00Z');
+    const a = fingerprintForAlert(baseEvent(), now);
+    const b = fingerprintForAlert(baseEvent(), now);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('differs by chain', () => {
+    const now = () => new Date('2026-05-14T12:00:00Z');
+    const a = fingerprintForAlert(baseEvent({ chain: 'A' }), now);
+    const b = fingerprintForAlert(baseEvent({ chain: 'B' }), now);
+    expect(a).not.toBe(b);
+  });
+
+  it('differs by type', () => {
+    const now = () => new Date('2026-05-14T12:00:00Z');
+    const a = fingerprintForAlert(baseEvent({ type: 'chain_stalled' }), now);
+    const b = fingerprintForAlert(baseEvent({ type: 'chain_rate_limited' }), now);
+    expect(a).not.toBe(b);
+  });
+
+  it('differs by day', () => {
+    const a = fingerprintForAlert(baseEvent({ fingerprintDay: '2026-05-14' }));
+    const b = fingerprintForAlert(baseEvent({ fingerprintDay: '2026-05-15' }));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('resolveChannels', () => {
+  it('honors per-event channels first', () => {
+    const ev = baseEvent({ channels: ['audit'] });
+    expect(resolveChannels(ev, ['handoff', 'inbox', 'notification'])).toEqual(['audit']);
+  });
+
+  it('falls back to configChannels (chain_config.alert_channels)', () => {
+    const ev = baseEvent();
+    expect(resolveChannels(ev, ['audit', 'inbox'])).toEqual(['audit', 'inbox']);
+  });
+
+  it('falls back to defaults-by-type when neither is given', () => {
+    const ev = baseEvent({ type: 'chain_stalled' });
+    expect(resolveChannels(ev)).toEqual(DEFAULT_CHANNELS_BY_TYPE['chain_stalled']);
+  });
+
+  it('filters unknown channel names from configChannels', () => {
+    const ev = baseEvent({ type: 'chain_stalled' });
+    const out = resolveChannels(ev, ['handoff', 'sms', 'pagerduty']);
+    expect(out).toEqual(['handoff']);
+  });
+
+  it('default for unknown event types is [inbox,audit]', () => {
+    const ev = baseEvent({ type: 'made_up_type' });
+    expect(resolveChannels(ev)).toEqual(['inbox', 'audit']);
+  });
+});
+
+describe('emitAlert — channel fan-out', () => {
+  let env: ReturnType<typeof makeAlertEnv>;
+  beforeEach(() => {
+    env = makeAlertEnv();
+  });
+  afterEach(() => env.cleanup());
+
+  it('writes to handoff JSONL, inbox markdown, audit jsonl, and notification (stubbed)', () => {
+    const notifs: string[][] = [];
+    const r = emitAlert(['handoff', 'inbox', 'notification', 'audit'], baseEvent(), {
+      auditFile: env.auditFile,
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      spawn: (cmd, args) => {
+        notifs.push([cmd, ...args]);
+        return { status: 0 };
+      },
+    });
+    expect(r.fired.sort()).toEqual(['audit', 'handoff', 'inbox', 'notification']);
+    expect(r.deduped).toBe(false);
+
+    // Handoff JSONL — exactly one line, parses as JSON
+    const handoffBody = readFileSync(env.alertsJsonlPath, 'utf8').trim();
+    const lines = handoffBody.split('\n');
+    expect(lines).toHaveLength(1);
+    const rec = JSON.parse(lines[0]!);
+    expect(rec.type).toBe('chain_stalled');
+    expect(rec.chain).toBe('test-chain');
+    expect(rec.fingerprint).toMatch(/^[0-9a-f]{16}$/);
+
+    // Inbox markdown
+    const inbox = readFileSync(env.inboxPath, 'utf8');
+    expect(inbox).toContain('## ');
+    expect(inbox).toContain('chain_stalled — test-chain');
+    expect(inbox).toContain('fingerprint:');
+
+    // Audit
+    const audit = readFileSync(env.auditFile, 'utf8');
+    expect(audit).toContain('"event":"alert_emitted"');
+    expect(audit).toContain('"type":"chain_stalled"');
+    expect(audit).toContain('"fingerprint":');
+
+    // Notification — osascript called once with -e
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0]![0]).toBe('osascript');
+    expect(notifs[0]![1]).toBe('-e');
+  });
+
+  it('audit channel is suppressed when auditFile is omitted', () => {
+    const r = emitAlert(['audit', 'inbox'], baseEvent(), {
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+    });
+    expect(r.fired).toContain('inbox');
+    expect(r.fired).not.toContain('audit');
+    expect(r.suppressed).toContain('audit');
+    expect(existsSync(env.auditFile)).toBe(false);
+  });
+
+  it('notification channel is suppressed when notificationsEnabled=false', () => {
+    let called = 0;
+    const r = emitAlert(['notification'], baseEvent(), {
+      auditFile: env.auditFile,
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      notificationsEnabled: false,
+      spawn: () => {
+        called += 1;
+        return { status: 0 };
+      },
+    });
+    expect(r.fired).not.toContain('notification');
+    expect(r.suppressed).toContain('notification');
+    expect(called).toBe(0);
+  });
+
+  it('throws when event.chain is missing', () => {
+    expect(() =>
+      emitAlert(['inbox'], { ...baseEvent(), chain: '' } as AlertEvent, {
+        inboxPath: env.inboxPath,
+        alertsJsonlPath: env.alertsJsonlPath,
+        dedupePath: env.dedupePath,
+      }),
+    ).toThrow(/event\.chain/);
+  });
+});
+
+describe('emitAlert — fingerprint dedupe', () => {
+  let env: ReturnType<typeof makeAlertEnv>;
+  beforeEach(() => {
+    env = makeAlertEnv();
+  });
+  afterEach(() => env.cleanup());
+
+  it('suppresses identical (chain, type, day) within the 6h window — INCLUDING notification', () => {
+    let notifs = 0;
+    const spawn = (_cmd: string, _args: string[]) => {
+      notifs += 1;
+      return { status: 0 };
+    };
+    const channels: AlertChannel[] = ['handoff', 'inbox', 'notification', 'audit'];
+    const ev = baseEvent();
+    const opts = {
+      auditFile: env.auditFile,
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      spawn,
+    };
+
+    const r1 = emitAlert(channels, ev, opts);
+    const r2 = emitAlert(channels, ev, opts);
+    const r3 = emitAlert(channels, ev, opts);
+
+    expect(r1.fired.length).toBe(4);
+    expect(r2.deduped).toBe(true);
+    expect(r2.fired).toEqual([]);
+    expect(r3.deduped).toBe(true);
+    expect(r3.fired).toEqual([]);
+
+    // CRITICAL: osascript invoked exactly ONCE across three emits.
+    expect(notifs).toBe(1);
+
+    // Handoff JSONL has exactly one record
+    const lines = readFileSync(env.alertsJsonlPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    // Inbox has exactly one block (heading appears once)
+    const inbox = readFileSync(env.inboxPath, 'utf8');
+    expect(inbox.match(/cron_stall_detected|chain_stalled/g)?.length ?? 0).toBe(1);
+
+    // Audit: 1 emitted + 2 suppressed
+    const audit = readFileSync(env.auditFile, 'utf8').trim().split('\n');
+    const emitted = audit.filter((l) => l.includes('"event":"alert_emitted"'));
+    const suppressed = audit.filter((l) => l.includes('"event":"alert_suppressed_duplicate"'));
+    expect(emitted).toHaveLength(1);
+    expect(suppressed).toHaveLength(2);
+  });
+
+  it('re-fires after the dedupe window elapses', () => {
+    const ev = baseEvent();
+    const opts = {
+      auditFile: env.auditFile,
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      notificationsEnabled: false,
+      dedupeWindowSec: 3600,
+    };
+    const r1 = emitAlert(['inbox', 'audit'], ev, {
+      ...opts,
+      now: () => new Date('2026-05-14T10:00:00Z'),
+    });
+    expect(r1.fired.length).toBe(2);
+    const r2 = emitAlert(['inbox', 'audit'], ev, {
+      ...opts,
+      now: () => new Date('2026-05-14T11:30:00Z'), // > 1h later
+    });
+    expect(r2.deduped).toBe(false);
+    expect(r2.fired.length).toBe(2);
+  });
+
+  it('force=true bypasses dedupe even within window', () => {
+    let notifs = 0;
+    const ev = baseEvent();
+    const opts = {
+      auditFile: env.auditFile,
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      spawn: () => {
+        notifs += 1;
+        return { status: 0 };
+      },
+    };
+    emitAlert(['notification'], ev, opts);
+    const r2 = emitAlert(['notification'], { ...ev, force: true }, opts);
+    expect(r2.deduped).toBe(false);
+    expect(r2.fired).toContain('notification');
+    expect(notifs).toBe(2);
+  });
+
+  it('different types share the dedupe window-by-type, not collide', () => {
+    const opts = {
+      auditFile: env.auditFile,
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      notificationsEnabled: false,
+    };
+    const a = emitAlert(['inbox'], baseEvent({ type: 'chain_stalled' }), opts);
+    const b = emitAlert(['inbox'], baseEvent({ type: 'chain_rate_limited' }), opts);
+    expect(a.fired).toContain('inbox');
+    expect(b.fired).toContain('inbox');
+    expect(a.fingerprint).not.toBe(b.fingerprint);
+  });
+
+  it('does not record dedupe when ALL channels were suppressed (recovers next time)', () => {
+    // emit with only the 'audit' channel but no auditFile → audit suppressed,
+    // no other channels fire → dedupe should NOT be locked in.
+    const opts = {
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      notificationsEnabled: false,
+    };
+    const r1 = emitAlert(['audit'], baseEvent(), opts);
+    expect(r1.fired).toEqual([]);
+    expect(r1.suppressed).toEqual(['audit']);
+    expect(existsSync(env.dedupePath)).toBe(false);
+
+    // Next call with the inbox channel must NOT be deduped — the prior call
+    // didn't earn a dedupe entry because nothing fired.
+    const r2 = emitAlert(['inbox'], baseEvent(), opts);
+    expect(r2.deduped).toBe(false);
+    expect(r2.fired).toContain('inbox');
+  });
+
+  it('survives a corrupt dedupe file (treats as empty)', () => {
+    writeFileSync(env.dedupePath, '{not valid json');
+    const r = emitAlert(['inbox'], baseEvent(), {
+      inboxPath: env.inboxPath,
+      alertsJsonlPath: env.alertsJsonlPath,
+      dedupePath: env.dedupePath,
+      notificationsEnabled: false,
+    });
+    expect(r.fired).toContain('inbox');
+    // After successful emit, dedupe file is replaced with a valid one.
+    const parsed = JSON.parse(readFileSync(env.dedupePath, 'utf8'));
+    expect(parsed.fingerprints).toBeDefined();
+  });
+});

--- a/packages/chain-runner/tests/fixtures.ts
+++ b/packages/chain-runner/tests/fixtures.ts
@@ -89,12 +89,25 @@ export function makeFixture(label = 'cr-test'): FixtureBundle {
   const specPath = join(root, 'phases.yaml');
   writeFileSync(specPath, FIXTURE_SPEC);
   process.env['CAIA_CHAIN_HOME'] = chainHome;
+  // H-10: redirect the alerting backbone defaults into the tmpdir so tests
+  // don't write to the user's real INBOX.md / active_alerts.jsonl / dedupe
+  // state. CAIA_DISABLE_NOTIFICATIONS=1 also skips osascript so test runs
+  // don't fire OS notifications. Each fixture gets its own dedupe file so
+  // tests are independent.
+  process.env['CAIA_ALERT_INBOX_PATH'] = join(root, 'INBOX.md');
+  process.env['CAIA_ALERT_HANDOFF_JSONL_PATH'] = join(root, 'active_alerts.jsonl');
+  process.env['CAIA_ALERT_DEDUPE_PATH'] = join(root, '.alert-dedupe.json');
+  process.env['CAIA_DISABLE_NOTIFICATIONS'] = '1';
   return {
     chainHome,
     chainId: `cr-${label}-${process.pid}`,
     specPath,
     cleanup: () => {
       delete process.env['CAIA_CHAIN_HOME'];
+      delete process.env['CAIA_ALERT_INBOX_PATH'];
+      delete process.env['CAIA_ALERT_HANDOFF_JSONL_PATH'];
+      delete process.env['CAIA_ALERT_DEDUPE_PATH'];
+      delete process.env['CAIA_DISABLE_NOTIFICATIONS'];
       try {
         rmSync(root, { recursive: true, force: true });
       } catch {

--- a/packages/chain-runner/tests/none_eligible_streak.test.ts
+++ b/packages/chain-runner/tests/none_eligible_streak.test.ts
@@ -1,0 +1,256 @@
+// H-5 (chain-runner-battle-harden phase 5, 2026-05-14). End-to-end test of
+// the NONE_ELIGIBLE escalation flow:
+//
+//   1. State carries a `none_eligible_streak` field that increments inside
+//      computeNextPhase on every `none_eligible` result and resets to 0 on
+//      every other result kind.
+//   2. cascade.diagnoseStall walks the dep graph and names the upstream
+//      blocker plus a suggested re-arm command.
+//   3. Integration: chain with phase 2 deps=[1], force phase 1 blocked, run
+//      3 simulated "wake" iterations of [check-stall --alert-on-streak 2].
+//      After the wakes, the unified backbone must have fired exactly ONE
+//      alert (dedupe), so SESSION_HANDOFF JSONL has one record and INBOX.md
+//      has one block.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { makeFixture, type FixtureBundle } from './fixtures.js';
+import {
+  computeNextPhase,
+  initState,
+  loadContext,
+  loadState,
+  markDone,
+  saveState,
+  type StateContext,
+} from '../src/state.js';
+import { diagnoseStall } from '../src/cascade.js';
+import { emitAlert } from '../src/alerting.js';
+import type { AlertEvent } from '../src/alerting.js';
+
+let fx: FixtureBundle;
+let ctx: StateContext;
+
+beforeEach(() => {
+  fx = makeFixture(`streak-${Math.random().toString(36).slice(2, 8)}`);
+  ctx = loadContext(fx.chainId, fx.specPath);
+  initState(ctx);
+});
+
+afterEach(() => fx.cleanup());
+
+describe('none_eligible_streak — state machine', () => {
+  it('starts at 0', () => {
+    const state = loadState(ctx);
+    expect(state.none_eligible_streak).toBe(0);
+  });
+
+  it('does not increment when a dispatchable phase is found', () => {
+    // Phase 1 has no deps and is pending → next-phase returns phase_id.
+    computeNextPhase(ctx, loadState(ctx));
+    expect(loadState(ctx).none_eligible_streak).toBe(0);
+  });
+
+  it('increments by 1 each time computeNextPhase returns none_eligible', () => {
+    // Force a stall: block phase 1 so phase 2..13 can't run.
+    const state = loadState(ctx);
+    state.phase_status['1']!.status = 'blocked';
+    saveState(ctx, state);
+
+    const r1 = computeNextPhase(ctx, loadState(ctx));
+    expect(r1.kind).toBe('none_eligible');
+    expect(loadState(ctx).none_eligible_streak).toBe(1);
+
+    const r2 = computeNextPhase(ctx, loadState(ctx));
+    expect(r2.kind).toBe('none_eligible');
+    expect(loadState(ctx).none_eligible_streak).toBe(2);
+
+    const r3 = computeNextPhase(ctx, loadState(ctx));
+    expect(r3.kind).toBe('none_eligible');
+    expect(loadState(ctx).none_eligible_streak).toBe(3);
+  });
+
+  it('resets to 0 on the first non-none_eligible result', () => {
+    // Stall first.
+    const s1 = loadState(ctx);
+    s1.phase_status['1']!.status = 'blocked';
+    saveState(ctx, s1);
+    computeNextPhase(ctx, loadState(ctx));
+    computeNextPhase(ctx, loadState(ctx));
+    expect(loadState(ctx).none_eligible_streak).toBe(2);
+
+    // Unblock phase 1 — now next-phase finds a dispatchable phase.
+    const s2 = loadState(ctx);
+    s2.phase_status['1']!.status = 'pending';
+    saveState(ctx, s2);
+    const r = computeNextPhase(ctx, loadState(ctx));
+    expect(r.kind).toBe('phase_id');
+    expect(loadState(ctx).none_eligible_streak).toBe(0);
+  });
+
+  it('resets on paused / all_done / backoff / in_progress results too', () => {
+    // Stall first.
+    const s1 = loadState(ctx);
+    s1.phase_status['1']!.status = 'blocked';
+    saveState(ctx, s1);
+    computeNextPhase(ctx, loadState(ctx));
+    expect(loadState(ctx).none_eligible_streak).toBe(1);
+
+    // Pause the chain — next computeNextPhase returns 'paused' and resets.
+    const s2 = loadState(ctx);
+    s2.paused = true;
+    saveState(ctx, s2);
+    const r = computeNextPhase(ctx, loadState(ctx));
+    expect(r.kind).toBe('paused');
+    expect(loadState(ctx).none_eligible_streak).toBe(0);
+  });
+
+  it('emits an audit none_eligible event on each stall tick', () => {
+    const s = loadState(ctx);
+    s.phase_status['1']!.status = 'blocked';
+    saveState(ctx, s);
+    computeNextPhase(ctx, loadState(ctx));
+    const audit = readFileSync(ctx.paths.auditFile, 'utf8');
+    expect(audit).toContain('"event":"none_eligible"');
+  });
+});
+
+describe('diagnoseStall — root cause walker', () => {
+  it('names the blocker when an upstream phase is blocked', () => {
+    const s = loadState(ctx);
+    // Mark phase 1 blocked with a typed failure.
+    s.phase_status['1']!.status = 'blocked';
+    s.phase_status['1']!.last_failure_class = 'worker_no_start_rate_limit';
+    s.phase_status['1']!.failure = {
+      class: 'worker_no_start_rate_limit',
+      reason: 'rate limit until 2026-05-16T16:00Z',
+      detected_at: '2026-05-14T12:00:00Z',
+      evidence: { reset_iso: '2026-05-16T16:00Z' },
+    };
+    saveState(ctx, s);
+
+    const diag = diagnoseStall(ctx.spec, loadState(ctx));
+    expect(diag.nextPending?.id).toBe(1);
+    expect(diag.blocker?.id).toBe(1);
+    expect(diag.diagnosis).toContain('phase 1');
+    expect(diag.diagnosis).toContain('blocked');
+    expect(diag.diagnosis).toContain('worker_no_start_rate_limit');
+    expect(diag.suggested).toContain('re-arm 1');
+  });
+
+  it('walks the dep graph to the deepest blocker', () => {
+    const s = loadState(ctx);
+    // Phase 1 done; phase 2 blocked; phase 3 pending with deps=[2].
+    markDone(ctx, '1');
+    const s2 = loadState(ctx);
+    s2.phase_status['2']!.status = 'blocked';
+    s2.phase_status['2']!.last_failure_class = 'worker_no_start_auth_failure';
+    saveState(ctx, s2);
+
+    const diag = diagnoseStall(ctx.spec, loadState(ctx));
+    expect(diag.nextPending?.id).toBe(2);
+    expect(diag.blocker?.id).toBe(2);
+    expect(diag.suggested).toContain('OPERATOR_ACTION_REQUIRED');
+  });
+
+  it('reports idle (not stalled) when next pending has deps met but is just pending', () => {
+    // Fresh state — phase 1 pending, no deps; chain is dispatchable, not stalled.
+    const diag = diagnoseStall(ctx.spec, loadState(ctx));
+    expect(diag.nextPending?.id).toBe(1);
+    expect(diag.blocker).toBeNull();
+    expect(diag.diagnosis).toContain('pending');
+  });
+
+  it('respects paused state', () => {
+    const s = loadState(ctx);
+    s.paused = true;
+    s.paused_reason = 'rate_limit_until_2026-05-16T16:00Z';
+    s.paused_until = '2026-05-16T16:00:00Z';
+    saveState(ctx, s);
+    const diag = diagnoseStall(ctx.spec, loadState(ctx));
+    expect(diag.diagnosis).toContain('paused');
+    expect(diag.diagnosis).toContain('2026-05-16T16:00:00Z');
+  });
+});
+
+describe('integration — 3 wakes with phase 1 blocked produce exactly one alert', () => {
+  // Mirrors the task spec: "simulate a chain with phase 2 deps=[1], force
+  // phase 1 blocked, run 3 wakes, assert SESSION_HANDOFF gets exactly one
+  // block and INBOX gets one block." The fixture has phases 1..13 with
+  // chained deps; blocking phase 1 cascades to all downstream phases.
+
+  it('one INBOX block + one handoff JSONL record across 3 stall wakes', () => {
+    // Force the stall.
+    const s = loadState(ctx);
+    s.phase_status['1']!.status = 'blocked';
+    s.phase_status['1']!.last_failure_class = 'worker_no_start_rate_limit';
+    saveState(ctx, s);
+
+    const inboxPath = process.env['CAIA_ALERT_INBOX_PATH']!;
+    const handoffPath = process.env['CAIA_ALERT_HANDOFF_JSONL_PATH']!;
+
+    // Simulate three wake ticks. Each tick:
+    //   1. computeNextPhase → none_eligible → streak ++
+    //   2. if streak >= 2, emit chain_stalled alert (dedupe-protected)
+    let notifs = 0;
+    for (let i = 0; i < 3; i++) {
+      const result = computeNextPhase(ctx, loadState(ctx));
+      expect(result.kind).toBe('none_eligible');
+      const state = loadState(ctx);
+      const streak = state.none_eligible_streak ?? 0;
+      if (streak >= 2) {
+        const diag = diagnoseStall(ctx.spec, state);
+        const event: AlertEvent = {
+          type: 'chain_stalled',
+          severity: 'high',
+          title: `chain_stalled — ${fx.chainId}`,
+          detail: diag.diagnosis,
+          chain: fx.chainId,
+          evidence: { streak },
+        };
+        emitAlert(undefined, event, {
+          auditFile: ctx.paths.auditFile,
+          // Override the fixture-default CAIA_DISABLE_NOTIFICATIONS=1 so the
+          // notification channel actually attempts the spawn; we stub spawn
+          // itself to count calls without firing a real osascript.
+          notificationsEnabled: true,
+          spawn: () => {
+            notifs += 1;
+            return { status: 0 };
+          },
+        });
+      }
+    }
+
+    // Streak hit 3, but only ticks 2 and 3 attempted emit, and only ONE
+    // landed because of fingerprint dedupe within the 6h window.
+    expect(loadState(ctx).none_eligible_streak).toBe(3);
+
+    // INBOX.md — exactly one chain_stalled block (count headings, not the
+    // title field which also includes the type→chain string).
+    expect(existsSync(inboxPath)).toBe(true);
+    const inbox = readFileSync(inboxPath, 'utf8');
+    const inboxBlocks = inbox.match(/^## \[.*\] chain_stalled — /gm) ?? [];
+    expect(inboxBlocks).toHaveLength(1);
+
+    // active_alerts.jsonl — exactly one chain_stalled record
+    expect(existsSync(handoffPath)).toBe(true);
+    const handoffLines = readFileSync(handoffPath, 'utf8').trim().split('\n');
+    expect(handoffLines).toHaveLength(1);
+    const rec = JSON.parse(handoffLines[0]!);
+    expect(rec.type).toBe('chain_stalled');
+    expect(rec.chain).toBe(fx.chainId);
+
+    // osascript — exactly one notification across 3 wakes
+    expect(notifs).toBe(1);
+
+    // Audit log — one emit + one suppression (the third tick fingerprint-deduped)
+    const audit = readFileSync(ctx.paths.auditFile, 'utf8').trim().split('\n');
+    const emitLines = audit.filter((l) => l.includes('"event":"alert_emitted"'));
+    const suppressLines = audit.filter((l) =>
+      l.includes('"event":"alert_suppressed_duplicate"'),
+    );
+    expect(emitLines).toHaveLength(1);
+    expect(suppressLines).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5 of chain-runner-battle-harden (2026-05-14). Closes **H-10** (unified 4-channel alerting with per-fingerprint dedupe) and **H-5** (silent-stall escalation after 2 consecutive NONE_ELIGIBLE wakes).

**H-10 — alerting backbone**
- New `src/alerting.ts`: `emitAlert(channels, event, opts)` routes to `handoff` (active_alerts.jsonl), `inbox` (INBOX.md), `notification` (osascript), `audit` (chain audit.jsonl). Per-event override > chain_config override > defaults-by-type.
- Fingerprint dedupe: `sha256(chain | type | day).slice(0,16)`; 6h window. Critically, dedupe gates **all four channels** — the loud `osascript` channel cannot pager-storm even on oscillating stall conditions.
- Migrated `src/watchdog.ts:appendInboxAlert` and `~/.caia/chain-watchdog/watchdog.js` to call `emitAlert`. All alerting policy now lives in one module.
- New `caia-chain emit-alert` CLI verb — used by the autonomy directive's `OPERATOR_ACTION_REQUIRED` flow and by shell wake scripts.

**H-5 — NONE_ELIGIBLE escalation**
- `StateFile.none_eligible_streak` (optional, back-compat). Incremented inside `computeNextPhase` on every `none_eligible` result, reset to 0 on every other kind.
- New `src/cascade.ts:diagnoseStall` — walks dep graph from first non-done phase to deepest blocker, produces diagnosis + suggested `re-arm` command. Surfaced via `caia-chain stall-root-cause`.
- `caia-chain check-stall --alert-on-streak <n>` — reads `none_eligible_streak`; emits `chain_stalled` (severity high) when threshold met.
- All 3 wake scripts (`chain_harden_wake.sh`, `redflag_remediation_wake.sh`, `stability_completion_wake.sh`) call `check-stall --alert-on-streak 2` on `NONE_ELIGIBLE`.

**SESSION_HANDOFF integration (option B — pulled, never injected)**
- New `~/.caia/handoff/append_alert.sh` shell helper.
- `refresh_handoff.sh` rebuilds an Active alerts section from `active_alerts.jsonl` (24h, deduped by fingerprint) inside `<!-- HANDOFF_ACTIVE_ALERTS:BEGIN ... END -->` on every tick. Producers don't touch the markdown.

**Before / after.** The 2026-05-14 incident: phase 7 of redflag-remediation went NONE_ELIGIBLE at 07:00Z; operator noticed 8h later at 15:26Z. After this PR: 2nd NONE_ELIGIBLE wake (~30 min in) triggers `chain_stalled` on all four channels with diagnosis + suggested adjudication command. 30-min escalation latency vs 8-hour silent stall.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm test` — 219 / 219 pass (30 new tests: 19 alerting + 11 streak/cascade/integration; 75-case regression suite remains green)
- [x] CLI smoke: `caia-chain emit-alert --chain-id smoke-test --type operator_action_required --severity high --detail 'smoke'` → fires on 3 channels (notification suppressed via CAIA_DISABLE_NOTIFICATIONS=1)
- [x] Dedupe smoke: second emit-alert call returns `deduped=true fired=none`; handoff JSONL retains a single record
- [x] `append_alert.sh` shell helper writes a valid JSONL line with deterministic fingerprint matching the TS implementation

## Report

`~/Documents/projects/reports/chain_harden_p5_alerting_2026-05-14.md` — channel table, dedupe behavior, before/after timeline, full file list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)