### PR TITLE
feat(chain-runner): h-6 reap-orphans + h-7 doctor v2

### DIFF
--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -50,6 +50,7 @@ import {
 import { diagnoseStall } from './cascade.js';
 import { chainPaths } from './paths.js';
 import { doctorExitCode, formatDoctorReport, runDoctor } from './doctor.js';
+import { formatReapReport, reapOrphans } from './reap.js';
 import { fireHandoffRefresh } from './handoff-refresh.js';
 import {
   DEFAULT_PROMPT as PREFLIGHT_DEFAULT_PROMPT,
@@ -874,6 +875,47 @@ export function buildProgram(): Command {
       },
     );
 
+  // H-6 (chain-runner-battle-harden phase 6, 2026-05-14). reap-orphans walks
+  // the process tree, finds claude --print workers whose owning phase has
+  // since transitioned out of `in_progress`, and (unless --dry-run) terminates
+  // them. Wake scripts call this at the top of each wake — cheap (ps + state
+  // read).
+  program
+    .command('reap-orphans')
+    .description(
+      'Find claude/bash workers whose owning phase is no longer in_progress and (unless --dry-run) reap them. Returns JSON when --json is set.',
+    )
+    .option('--dry-run', 'list orphans but do not signal them')
+    .option('--chain-id <id>', 'restrict reap to a single chain')
+    .option('--json', 'emit machine-readable JSON')
+    .option(
+      '--term-grace-ms <n>',
+      'grace period between SIGTERM and SIGKILL (ms); default 10000',
+    )
+    .action(
+      async (cmdOpts: {
+        dryRun?: boolean;
+        chainId?: string;
+        json?: boolean;
+        termGraceMs?: string;
+      }) => {
+        const reapOpts: Parameters<typeof reapOrphans>[0] = {
+          dryRun: cmdOpts.dryRun ?? false,
+        };
+        if (cmdOpts.chainId) reapOpts.chainId = cmdOpts.chainId;
+        if (cmdOpts.termGraceMs) reapOpts.termGraceMs = Number(cmdOpts.termGraceMs);
+        const report = await reapOrphans(reapOpts);
+        if (cmdOpts.json) {
+          process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        } else {
+          process.stdout.write(`${formatReapReport(report)}\n`);
+        }
+        // Exit 0 even when orphans were found; the report is the signal. Wake
+        // scripts treat a non-zero exit as "reap infra broke" rather than
+        // "orphans existed".
+      },
+    );
+
   program
     .command('doctor')
     .description(
@@ -885,17 +927,28 @@ export function buildProgram(): Command {
       '2000',
     )
     .option('--json', 'emit machine-readable JSON instead of the text table')
-    .action(async (cmdOpts: { healthzTimeoutMs?: string; json?: boolean }) => {
-      const report = await runDoctor({
-        healthzTimeoutMs: Number(cmdOpts.healthzTimeoutMs ?? '2000'),
-      });
-      if (cmdOpts.json) {
-        process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-      } else {
-        process.stdout.write(`${formatDoctorReport(report)}\n`);
-      }
-      process.exit(doctorExitCode(report));
-    });
+    .option('--legacy-only', 'emit only V1 sections (node/healthz/plists/chains)')
+    .option('--skip-auth', 'skip auth preflight (faster — does not spawn claude)')
+    .action(
+      async (cmdOpts: {
+        healthzTimeoutMs?: string;
+        json?: boolean;
+        legacyOnly?: boolean;
+        skipAuth?: boolean;
+      }) => {
+        const report = await runDoctor({
+          healthzTimeoutMs: Number(cmdOpts.healthzTimeoutMs ?? '2000'),
+          legacyOnly: cmdOpts.legacyOnly ?? false,
+          skipAuth: cmdOpts.skipAuth ?? false,
+        });
+        if (cmdOpts.json) {
+          process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        } else {
+          process.stdout.write(`${formatDoctorReport(report)}\n`);
+        }
+        process.exit(doctorExitCode(report));
+      },
+    );
 
   program
     .command('retry-cmd')

--- a/packages/chain-runner/src/doctor.ts
+++ b/packages/chain-runner/src/doctor.ts
@@ -1,17 +1,28 @@
 // `caia-chain doctor` — operator-friendly health snapshot.
 //
-// Prints, in order:
+// V1 sections (original):
 //   1. node version (which interpreter caia-chain itself is running under)
 //   2. healthz of mentor (5180) + local-llm-router (7411)
 //   3. launchctl print state of each known plist (label + state + last_exit_status)
 //   4. last_wake of each chain under ~/.caia/chain/*/state.json
 //
-// Designed for autonomous chains and human operators alike. Output is
-// plain text on stdout with one table per section. Doctor exits 0 if
-// every check passes, 1 if any check is degraded.
+// V2 sections (H-7, chain-runner-battle-harden phase 6, 2026-05-14):
+//   5. chains: phase counts by status + lock age + NONE_ELIGIBLE streak +
+//      last successful phase_done timestamp (read from audit.jsonl).
+//   6. orphans: reapOrphans(dryRun=true) summary.
+//   7. disk: free space on / and $TMPDIR; if either < 5 GB doctor exits 1.
+//   8. auth: preflightDispatch result (subscription quota + auth liveness).
+//   9. quota: most-imminent rate-limit reset banner scraped from recent
+//      dispatch logs across all chains.
+//
+// Exit codes:
+//   0 healthy
+//   1 degraded (healthz fail, low disk, preflight non-zero, etc.)
+//   2 stalled-chain (any chain has phase counts that look stuck — none_eligible
+//     streak >= 2 or lock_age_sec > 3h)
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import {
@@ -19,6 +30,13 @@ import {
   checkHealthzAll,
   type HealthzCheckResult,
 } from './bootstrap.js';
+import { reapOrphans, type ReapReport } from './reap.js';
+import {
+  parseResetIsoFromBanner,
+  preflightDispatch,
+  type PreflightDispatchResult,
+} from './preflight.js';
+import type { PhaseState, StateFile } from './types.js';
 
 /**
  * Known LaunchAgent labels managed by the CAIA stack. Doctor calls
@@ -43,6 +61,18 @@ export const KNOWN_PLIST_LABELS: readonly string[] = [
   'com.chiefaia.sps-audit-recent-done-hourly',
 ];
 
+/** Disk-free threshold (KB). doctor degrades to exit 1 below this. */
+export const DISK_FREE_DEGRADE_KB = 5 * 1024 * 1024; // 5 GB
+
+/** A chain's lock is considered too-old past this many seconds (3 x grace). */
+export const LOCK_AGE_STALLED_SEC = 3 * 3600;
+
+/** none_eligible_streak >= this counts as stalled. */
+export const NONE_ELIGIBLE_STALLED_STREAK = 2;
+
+/** Quota-section log scan: window for "recent" dispatch logs (ms). */
+export const QUOTA_SCAN_WINDOW_MS = 24 * 3600 * 1000;
+
 export interface PlistState {
   label: string;
   loaded: boolean;
@@ -59,12 +89,53 @@ export interface ChainWakeState {
   allDone: boolean | null;
 }
 
+export interface ChainHealth {
+  chainId: string;
+  /** Phase counts by status. */
+  counts: Record<string, number>;
+  /** Age of the active lock file in seconds (null if no lock). */
+  lockAgeSec: number | null;
+  /** Active lock phase id, if any. */
+  lockedPhase: number | null;
+  /** None-eligible streak from state.json (0 if missing). */
+  noneEligibleStreak: number;
+  /** Timestamp of the most recent `phase_done` audit event. */
+  lastPhaseDone: string | null;
+  /** True if this chain is stalled (none_eligible_streak high, or lock too old). */
+  stalled: boolean;
+  paused: boolean;
+  pausedUntil: string | null;
+}
+
+export interface DiskCheck {
+  mount: string;
+  /** Free KB (df -k Avail column). */
+  availKb: number;
+  total: number;
+  ok: boolean;
+}
+
+export interface QuotaWarning {
+  chainId: string;
+  logPath: string;
+  resetIso: string | null;
+  banner: string;
+  detectedAt: string;
+}
+
 export interface DoctorReport {
   nodeVersion: string;
   nodeBin: string;
   healthz: HealthzCheckResult[];
   plists: PlistState[];
   chains: ChainWakeState[];
+  // V2 additions — optional in JSON so older tooling consuming the report
+  // doesn't break. Always present when produced by runDoctor in v2 mode.
+  chainHealth?: ChainHealth[];
+  orphans?: ReapReport;
+  disk?: DiskCheck[];
+  auth?: PreflightDispatchResult | { status: 'skipped'; message: string };
+  quota?: QuotaWarning[];
 }
 
 function runLaunchctlPrint(label: string, uid: number): string {
@@ -81,8 +152,6 @@ export function parseLaunchctlPrint(raw: string): {
   lastExitStatus: number | null;
 } {
   if (!raw) return { state: null, lastExitStatus: null };
-  // launchctl print emits lines like `state = waiting` and
-  // `last exit code = 0` (or `last exit status = -1`).
   let state: string | null = null;
   let lastExitStatus: number | null = null;
   for (const line of raw.split('\n')) {
@@ -163,12 +232,249 @@ export function readChainWakes(chainRoot: string = join(homedir(), '.caia', 'cha
   return out;
 }
 
-export async function runDoctor(opts: {
+/** Walk a state.json into the per-status counts + stall heuristics. */
+export function summariseChainHealth(
+  chainId: string,
+  state: StateFile | null,
+  lockMtimeMs: number | null,
+  lockedPhase: number | null,
+  lastPhaseDone: string | null,
+  nowMs: number = Date.now(),
+): ChainHealth {
+  const counts: Record<string, number> = {};
+  if (state?.phase_status) {
+    for (const p of Object.values(state.phase_status) as PhaseState[]) {
+      counts[p.status] = (counts[p.status] ?? 0) + 1;
+    }
+  }
+  const lockAgeSec =
+    lockMtimeMs === null ? null : Math.max(0, Math.floor((nowMs - lockMtimeMs) / 1000));
+  const noneEligibleStreak = state?.none_eligible_streak ?? 0;
+  const stalled =
+    noneEligibleStreak >= NONE_ELIGIBLE_STALLED_STREAK ||
+    (lockAgeSec !== null && lockAgeSec > LOCK_AGE_STALLED_SEC);
+  return {
+    chainId,
+    counts,
+    lockAgeSec,
+    lockedPhase,
+    noneEligibleStreak,
+    lastPhaseDone,
+    stalled,
+    paused: state?.paused ?? false,
+    pausedUntil: state?.paused_until ?? null,
+  };
+}
+
+/** Find the most recent `phase_done` event in audit.jsonl. Returns its ts or null. */
+export function lastPhaseDoneTs(auditFile: string): string | null {
+  if (!existsSync(auditFile)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(auditFile, 'utf8');
+  } catch {
+    return null;
+  }
+  // Walk lines from end → start so we find the most-recent event quickly.
+  const lines = raw.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line) continue;
+    // Cheap pre-filter to avoid JSON.parse cost.
+    if (!line.includes('"phase_done"')) continue;
+    try {
+      const ev = JSON.parse(line) as { event?: string; ts?: string };
+      if (ev.event === 'phase_done' && typeof ev.ts === 'string') return ev.ts;
+    } catch {
+      // continue
+    }
+  }
+  return null;
+}
+
+export function readChainHealth(
+  chainRoot: string = join(homedir(), '.caia', 'chain'),
+  nowMs: number = Date.now(),
+): ChainHealth[] {
+  if (!existsSync(chainRoot)) return [];
+  const out: ChainHealth[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(chainRoot);
+  } catch {
+    return [];
+  }
+  for (const name of entries) {
+    const dir = join(chainRoot, name);
+    let isDir: boolean;
+    try {
+      isDir = statSync(dir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    const stateFile = join(dir, 'state.json');
+    if (!existsSync(stateFile)) continue;
+    let state: StateFile | null;
+    try {
+      state = JSON.parse(readFileSync(stateFile, 'utf8')) as StateFile;
+    } catch {
+      state = null;
+    }
+    const lockFile = join(dir, 'lock.json');
+    let lockMtimeMs: number | null = null;
+    let lockedPhase: number | null = null;
+    if (existsSync(lockFile)) {
+      try {
+        const st = statSync(lockFile);
+        lockMtimeMs = st.mtimeMs;
+        const lock = JSON.parse(readFileSync(lockFile, 'utf8')) as { phase_id?: number };
+        if (typeof lock.phase_id === 'number') lockedPhase = lock.phase_id;
+      } catch {
+        // ignore
+      }
+    }
+    const auditFile = join(dir, 'audit.jsonl');
+    const lastDone = lastPhaseDoneTs(auditFile);
+    out.push(summariseChainHealth(name, state, lockMtimeMs, lockedPhase, lastDone, nowMs));
+  }
+  out.sort((a, b) => a.chainId.localeCompare(b.chainId));
+  return out;
+}
+
+/** Check free space on the given mount via `df -k`. */
+export function checkDiskFree(mount: string): DiskCheck {
+  const out = spawnSync('/bin/df', ['-k', mount], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (out.status !== 0 || !out.stdout) {
+    return { mount, availKb: 0, total: 0, ok: false };
+  }
+  return parseDfOutput(mount, out.stdout);
+}
+
+export function parseDfOutput(mount: string, raw: string): DiskCheck {
+  // df -k: Filesystem 1024-blocks Used Available Capacity ... Mounted on
+  const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return { mount, availKb: 0, total: 0, ok: false };
+  const dataLine = lines[lines.length - 1] ?? '';
+  const parts = dataLine.split(/\s+/);
+  const nums = parts.filter((p) => /^\d+$/.test(p)).map((p) => Number(p));
+  if (nums.length < 3) return { mount, availKb: 0, total: 0, ok: false };
+  const total = nums[0] ?? 0;
+  // Avail is third numeric column on macOS (1024-blocks, Used, Avail).
+  const availKb = nums[2] ?? 0;
+  return { mount, availKb, total, ok: availKb >= DISK_FREE_DEGRADE_KB };
+}
+
+/**
+ * Scrape per-chain dispatch logs for rate-limit banners. Returns one warning
+ * per chain whose most-recent banner has a future reset ISO. Sorted by
+ * `resetIso` ascending so the most-imminent reset is the first element.
+ */
+export function scanQuotaWarnings(
+  chainRoot: string = join(homedir(), '.caia', 'chain'),
+  nowMs: number = Date.now(),
+  watchdogLogs: string = join(homedir(), '.caia', 'chain-watchdog', 'logs'),
+): QuotaWarning[] {
+  const out: QuotaWarning[] = [];
+  const seenChains = new Set<string>();
+  const collect = (chainId: string, logPath: string): void => {
+    try {
+      const st = statSync(logPath);
+      if (nowMs - st.mtimeMs > QUOTA_SCAN_WINDOW_MS) return;
+      const raw = readFileSync(logPath, 'utf8');
+      if (!/hit your limit|limit/i.test(raw)) return;
+      const parsed = parseResetIsoFromBanner(raw, nowMs);
+      if (!parsed.matched) return;
+      if (seenChains.has(chainId)) return;
+      seenChains.add(chainId);
+      out.push({
+        chainId,
+        logPath,
+        resetIso: parsed.iso,
+        banner: parsed.matched,
+        detectedAt: new Date(nowMs).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      });
+    } catch {
+      // ignore unreadable logs
+    }
+  };
+  if (existsSync(chainRoot)) {
+    let entries: string[];
+    try {
+      entries = readdirSync(chainRoot);
+    } catch {
+      entries = [];
+    }
+    for (const name of entries) {
+      const dir = join(chainRoot, name);
+      try {
+        if (!statSync(dir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      let files: string[];
+      try {
+        files = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        if (!f.startsWith('dispatch-') || !f.endsWith('.log')) continue;
+        collect(name, join(dir, f));
+      }
+    }
+  }
+  if (existsSync(watchdogLogs)) {
+    let files: string[];
+    try {
+      files = readdirSync(watchdogLogs);
+    } catch {
+      files = [];
+    }
+    for (const f of files) {
+      if (!f.startsWith('preflight_') || !f.endsWith('.log')) continue;
+      const m = /^preflight_(.+?)_\d{4}-\d{2}-\d{2}\.log$/.exec(f);
+      const chainId = m && m[1] ? m[1] : f;
+      collect(chainId, join(watchdogLogs, f));
+    }
+  }
+  out.sort((a, b) => {
+    const ai = a.resetIso ?? '';
+    const bi = b.resetIso ?? '';
+    return ai.localeCompare(bi);
+  });
+  return out;
+}
+
+export interface RunDoctorOptions {
   uid?: number;
   chainRoot?: string;
   healthzTimeoutMs?: number;
   plistLabels?: readonly string[];
-} = {}): Promise<DoctorReport> {
+  /** Skip the V2 sections (faster path used by old callers). Default false. */
+  legacyOnly?: boolean;
+  /** Skip the auth preflight (it spawns claude — slow). Default false. */
+  skipAuth?: boolean;
+  /** Override mounts checked in disk section. */
+  diskMounts?: string[];
+  /** Inject a clock for tests. */
+  nowMs?: number;
+  /** Inject a reapOrphans fn for tests. */
+  reapFn?: typeof reapOrphans;
+  /** Inject a preflight fn for tests. */
+  preflightFn?: typeof preflightDispatch;
+  /** Inject a disk-check fn for tests. */
+  diskFn?: typeof checkDiskFree;
+  /** Inject a quota scanner for tests. */
+  quotaFn?: typeof scanQuotaWarnings;
+  /** Watchdog log dir (for quota scan). */
+  watchdogLogs?: string;
+}
+
+export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorReport> {
   const uid = opts.uid ?? process.getuid?.() ?? 501;
   const labels = opts.plistLabels ?? KNOWN_PLIST_LABELS;
   const healthz = await checkHealthzAll(DEFAULT_HEALTHZ_ENDPOINTS, {
@@ -176,13 +482,58 @@ export async function runDoctor(opts: {
   });
   const plists = labels.map((l) => inspectPlist(l, uid));
   const chains = readChainWakes(opts.chainRoot);
-  return {
+  const report: DoctorReport = {
     nodeVersion: process.version,
     nodeBin: process.execPath,
     healthz,
     plists,
     chains,
   };
+  if (opts.legacyOnly) return report;
+
+  const nowMs = opts.nowMs ?? Date.now();
+
+  // 5. chain section
+  report.chainHealth = readChainHealth(opts.chainRoot, nowMs);
+
+  // 6. orphans section (always dry-run from doctor)
+  const reapFn = opts.reapFn ?? reapOrphans;
+  try {
+    report.orphans = await reapFn({ dryRun: true });
+  } catch (err) {
+    report.orphans = {
+      scannedAt: new Date(nowMs).toISOString(),
+      candidates: 0,
+      suspects: 0,
+      orphans: [],
+      actions: [],
+      dryRun: true,
+    };
+    (report.orphans as ReapReport & { _error?: string })._error = (err as Error).message;
+  }
+
+  // 7. disk section
+  const diskFn = opts.diskFn ?? checkDiskFree;
+  const mounts = opts.diskMounts ?? ['/', process.env['TMPDIR'] ?? tmpdir()];
+  report.disk = mounts.map((m) => diskFn(m));
+
+  // 8. auth section (skippable — preflight spawns claude which is slow)
+  if (!opts.skipAuth) {
+    const preflightFn = opts.preflightFn ?? preflightDispatch;
+    try {
+      report.auth = await preflightFn({ timeoutMs: 15_000 });
+    } catch (err) {
+      report.auth = { status: 'skipped', message: `preflight error: ${(err as Error).message}` };
+    }
+  } else {
+    report.auth = { status: 'skipped', message: 'skipped via --skip-auth' };
+  }
+
+  // 9. quota section
+  const quotaFn = opts.quotaFn ?? scanQuotaWarnings;
+  report.quota = quotaFn(opts.chainRoot, nowMs, opts.watchdogLogs);
+
+  return report;
 }
 
 function pad(s: string, w: number): string {
@@ -237,10 +588,93 @@ export function formatDoctorReport(r: DoctorReport): string {
       );
     }
   }
+  // V2 sections — only emit when present so legacy callers see the original
+  // four-section output verbatim.
+  if (r.chainHealth) {
+    lines.push('');
+    lines.push('# chain health');
+    if (r.chainHealth.length === 0) {
+      lines.push('  (none)');
+    } else {
+      lines.push(
+        `  ${pad('chain_id', 36)} ${pad('counts', 38)} ${pad('lock_age_sec', 12)} ${pad('streak', 6)} ${pad('stalled', 7)} last_phase_done`,
+      );
+      for (const c of r.chainHealth) {
+        const countStr = Object.entries(c.counts)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(',');
+        lines.push(
+          `  ${pad(c.chainId, 36)} ${pad(countStr || '-', 38)} ${pad(
+            c.lockAgeSec === null ? '-' : String(c.lockAgeSec),
+            12,
+          )} ${pad(String(c.noneEligibleStreak), 6)} ${pad(
+            c.stalled ? 'yes' : 'no',
+            7,
+          )} ${c.lastPhaseDone ?? '-'}`,
+        );
+      }
+    }
+  }
+  if (r.orphans) {
+    lines.push('');
+    lines.push('# orphans (dry-run)');
+    const orphanCount = r.orphans.orphans.filter((o) => o.isOrphan).length;
+    lines.push(
+      `  candidates=${r.orphans.candidates} suspects=${r.orphans.suspects} orphans=${orphanCount}`,
+    );
+    for (const o of r.orphans.orphans.filter((o) => o.isOrphan)) {
+      lines.push(
+        `  pid=${o.pid} chain=${o.chainId} phase=${o.phaseId} status=${o.phaseStatus} age_sec=${o.ageSec}`,
+      );
+    }
+  }
+  if (r.disk) {
+    lines.push('');
+    lines.push('# disk');
+    lines.push(`  ${pad('mount', 28)} ${pad('avail_kb', 14)} ${pad('total_kb', 14)} ok`);
+    for (const d of r.disk) {
+      lines.push(
+        `  ${pad(d.mount, 28)} ${pad(String(d.availKb), 14)} ${pad(String(d.total), 14)} ${d.ok ? 'yes' : 'no'}`,
+      );
+    }
+  }
+  if (r.auth) {
+    lines.push('');
+    lines.push('# auth');
+    if ('exit_code' in r.auth) {
+      lines.push(
+        `  status=${r.auth.status} exit=${r.auth.exit_code} elapsed_ms=${r.auth.elapsed_ms} message="${r.auth.message.slice(0, 200)}"`,
+      );
+    } else {
+      lines.push(`  status=${r.auth.status} message="${r.auth.message.slice(0, 200)}"`);
+    }
+  }
+  if (r.quota) {
+    lines.push('');
+    lines.push('# quota');
+    if (r.quota.length === 0) {
+      lines.push('  (no rate-limit banners in recent dispatch logs)');
+    } else {
+      for (const q of r.quota) {
+        lines.push(
+          `  chain=${q.chainId} reset_iso=${q.resetIso ?? '-'} banner="${q.banner}" log=${q.logPath}`,
+        );
+      }
+    }
+  }
   return lines.join('\n');
 }
 
+/**
+ * Exit-code policy:
+ *   0 healthy: every section ok
+ *   1 degraded: healthz, disk, auth, or orphan scan reported a problem
+ *   2 stalled-chain: any chain has stalled=true in chainHealth
+ */
 export function doctorExitCode(r: DoctorReport): number {
+  if (r.chainHealth && r.chainHealth.some((c) => c.stalled)) return 2;
   if (r.healthz.some((h) => !h.ok)) return 1;
+  if (r.disk && r.disk.some((d) => !d.ok)) return 1;
+  if (r.auth && 'exit_code' in r.auth && r.auth.exit_code !== 0) return 1;
   return 0;
 }

--- a/packages/chain-runner/src/reap.ts
+++ b/packages/chain-runner/src/reap.ts
@@ -1,0 +1,498 @@
+// H-6 (chain-runner-battle-harden phase 6, 2026-05-14). Reap orphan worker
+// processes — claude/bash children whose owning phase has since been marked
+// done/blocked/failed but who failed to exit on their own. Companion to
+// reports/chain_runner_hardening_plan_2026-05-14.md §H-6.
+//
+// Algorithm:
+//   1. Snapshot `ps -axo pid,ppid,etime,command` (or accept an injected
+//      snapshot for tests).
+//   2. Filter for claude workers — `claude --permission-mode bypassPermissions
+//      --print`.
+//   3. For each candidate, walk the parent chain until we find a process whose
+//      basename matches a known per-chain runner shell (table below). That
+//      gives us the chain id + the phase id (the runner script is invoked as
+//      `_chain_run_phase.sh PHASE_ID SESSION_ID PROMPT_FILE`).
+//   4. Read that chain's state.json. If `phase_status[PHASE_ID].status !==
+//      "in_progress"`, the claude process is an orphan.
+//   5. SIGTERM, sleep grace, SIGKILL if still alive. Emit
+//      `orphan_reaped(phase_id, pid, age_sec, command)` to the chain's audit
+//      log (and a top-level reap.jsonl for cross-chain operator review).
+//
+// Safety: a live worker for an `in_progress` phase is NEVER reaped (the test
+// suite has a fixture asserting this). Accidentally killing a live worker is
+// the failure mode this module guards against.
+
+import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import { chainPaths, chainRoot } from './paths.js';
+import { appendAudit } from './audit.js';
+import { isoNow } from './time.js';
+import type { StateFile } from './types.js';
+
+export interface PsEntry {
+  pid: number;
+  ppid: number;
+  /** Elapsed time as reported by ps (`MM:SS` or `HH:MM:SS` or `D-HH:MM:SS`). */
+  etime: string;
+  /** Full command including argv[0]; verbatim from `ps -axo command`. */
+  command: string;
+}
+
+export interface OrphanSuspect {
+  pid: number;
+  ppid: number;
+  command: string;
+  ageSec: number;
+  chainId: string;
+  phaseId: number;
+  runnerScript: string;
+}
+
+export interface OrphanFinding extends OrphanSuspect {
+  /** Phase status read from state.json at scan time. */
+  phaseStatus: string;
+  /** True if `phaseStatus !== 'in_progress'` (the orphan condition). */
+  isOrphan: boolean;
+}
+
+export interface ReapAction {
+  pid: number;
+  chainId: string;
+  phaseId: number;
+  /** What we did: `term` only, `kill` after grace, `already_gone`, `skipped_dry_run`, `error`. */
+  outcome: 'term' | 'kill' | 'already_gone' | 'skipped_dry_run' | 'error';
+  ageSec: number;
+  command: string;
+  /** Error message if outcome === 'error'. */
+  error?: string;
+}
+
+export interface ReapReport {
+  scannedAt: string;
+  candidates: number;
+  suspects: number;
+  orphans: OrphanFinding[];
+  /** Subset of `orphans` for which we attempted a reap (or noted dry-run). */
+  actions: ReapAction[];
+  dryRun: boolean;
+}
+
+/**
+ * Per-chain runner shell basename → chain-id mapping. The mapping is
+ * configurable via the `CAIA_REAP_RUNNER_MAP` env var (JSON
+ * `{"basename": "chain-id"}`) so new chains can opt in without a code change.
+ *
+ * If a runner shell is observed whose basename is NOT in this table, it is
+ * skipped (logged as an unknown-runner suspect rather than an orphan) — we'd
+ * rather under-reap than kill a live worker for a chain we don't recognise.
+ */
+export const DEFAULT_RUNNER_MAP: Readonly<Record<string, string>> = Object.freeze({
+  '_chain_harden_run_phase.sh': 'chain-runner-battle-harden',
+  '_redflag_remediation_run_phase.sh': 'redflag-remediation',
+  '_stability_completion_run_phase.sh': 'stability-completion',
+  '_tier25_run_phase.sh': 'tier-2.5-local-real-traffic',
+  '_a3_reliability_run_phase.sh': 'a3-reliability',
+  '_local_ai_first_run_phase.sh': 'local-ai-first',
+});
+
+const CLAUDE_PATTERN = /claude\s+(?:.*\s)?--permission-mode\s+bypassPermissions\b.*--print\b/;
+
+export function loadRunnerMap(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...DEFAULT_RUNNER_MAP };
+  const raw = env['CAIA_REAP_RUNNER_MAP'];
+  if (!raw) return merged;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'string' && v) merged[k] = v;
+      }
+    }
+  } catch {
+    // ignore malformed override — keep defaults
+  }
+  return merged;
+}
+
+/** Run `ps -axo pid,ppid,etime,command` and parse the output. */
+export function snapshotPs(): PsEntry[] {
+  const out = spawnSync('/bin/ps', ['-axo', 'pid,ppid,etime,command'], {
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  if (out.status !== 0 || !out.stdout) return [];
+  return parsePs(out.stdout);
+}
+
+/**
+ * Parse `ps -axo pid,ppid,etime,command` output. First line is a header that
+ * is discarded. Empty lines are skipped. Lines that don't parse cleanly (e.g.
+ * kernel processes with odd formatting) are skipped.
+ */
+export function parsePs(raw: string): PsEntry[] {
+  const lines = raw.split('\n');
+  const out: PsEntry[] = [];
+  let started = false;
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    if (!started) {
+      // Skip the header row (contains "PID" and "COMMAND" labels).
+      if (/^\s*PID\b/.test(line)) {
+        started = true;
+        continue;
+      }
+      // Some pseudo-terminals may emit ps without a header — fall through.
+      started = true;
+    }
+    // ps fixed-width-ish: PID PPID ELAPSED COMMAND...
+    // Use a permissive split on whitespace for the first 3 cols, then take the rest as command.
+    const m = /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/.exec(line);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    const etime = m[3] ?? '';
+    const command = (m[4] ?? '').trim();
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    out.push({ pid, ppid, etime, command });
+  }
+  return out;
+}
+
+/** Convert ps `etime` to seconds. Forms: `SS`, `MM:SS`, `HH:MM:SS`, `D-HH:MM:SS`. */
+export function etimeToSeconds(etime: string): number {
+  if (!etime) return 0;
+  // D-HH:MM:SS
+  const dMatch = /^(\d+)-(\d+):(\d+):(\d+)$/.exec(etime);
+  if (dMatch) {
+    const d = Number(dMatch[1]);
+    const h = Number(dMatch[2]);
+    const m = Number(dMatch[3]);
+    const s = Number(dMatch[4]);
+    return d * 86400 + h * 3600 + m * 60 + s;
+  }
+  const parts = etime.split(':').map((p) => Number(p));
+  if (parts.some((p) => !Number.isFinite(p))) return 0;
+  if (parts.length === 3) {
+    return (parts[0] ?? 0) * 3600 + (parts[1] ?? 0) * 60 + (parts[2] ?? 0);
+  }
+  if (parts.length === 2) {
+    return (parts[0] ?? 0) * 60 + (parts[1] ?? 0);
+  }
+  if (parts.length === 1) return parts[0] ?? 0;
+  return 0;
+}
+
+/**
+ * Walk the parent chain from `pid` until we find a process whose command
+ * basename matches a known runner-shell entry. Returns the runner entry
+ * (which carries chain id + the phase id from its argv) or null.
+ *
+ * We bound the walk at 32 hops to defend against pathological cycles (which
+ * shouldn't exist on a sane system but ps + corrupted state could lie).
+ */
+export function findRunnerAncestor(
+  pid: number,
+  byPid: Map<number, PsEntry>,
+  runnerMap: Record<string, string>,
+): { entry: PsEntry; chainId: string; phaseId: number; runnerScript: string } | null {
+  let current = byPid.get(pid);
+  let hops = 0;
+  while (current && hops < 32) {
+    const match = matchRunner(current.command, runnerMap);
+    if (match) {
+      return {
+        entry: current,
+        chainId: match.chainId,
+        phaseId: match.phaseId,
+        runnerScript: match.runnerScript,
+      };
+    }
+    if (current.ppid <= 1 || current.ppid === current.pid) return null;
+    current = byPid.get(current.ppid);
+    hops += 1;
+  }
+  return null;
+}
+
+/**
+ * Match a command line against the runner-map. Looks for any token in the
+ * command whose basename appears in the map. Returns the chain id + parsed
+ * phase id from the runner script's first positional arg, or null.
+ */
+function matchRunner(
+  command: string,
+  runnerMap: Record<string, string>,
+): { chainId: string; phaseId: number; runnerScript: string } | null {
+  // Tokenise on whitespace. `bash _foo_run_phase.sh 7 sess123 prompt.txt`
+  // or `/usr/bin/env bash /abs/_foo_run_phase.sh 7 ...` — find the first
+  // token whose basename is in the runner map and treat the *next* token as
+  // the phase id.
+  const tokens = command.split(/\s+/).filter((t) => t.length > 0);
+  for (let i = 0; i < tokens.length; i += 1) {
+    const tok = tokens[i] ?? '';
+    const bn = basename(tok);
+    const chainId = runnerMap[bn];
+    if (!chainId) continue;
+    const phaseTok = tokens[i + 1] ?? '';
+    const phaseId = Number(phaseTok);
+    if (!Number.isInteger(phaseId) || phaseId < 0) return null;
+    return { chainId, phaseId, runnerScript: bn };
+  }
+  return null;
+}
+
+export interface ReapOptions {
+  dryRun?: boolean;
+  /** Restrict the scan to a single chain id. */
+  chainId?: string;
+  /** Inject a ps snapshot for tests. When set, `snapshotPs()` is NOT called. */
+  psSnapshot?: PsEntry[];
+  /** Inject the runner map (overrides DEFAULT_RUNNER_MAP + env). */
+  runnerMap?: Record<string, string>;
+  /** Inject a state reader for tests; defaults to reading from disk. */
+  readState?: (chainId: string) => StateFile | null;
+  /** Inject a killer for tests. Returns true if the process was alive after
+   *  the signal (i.e., still present and needs a stronger signal). */
+  kill?: (pid: number, signal: NodeJS.Signals) => 'sent' | 'esrch' | 'eperm' | 'err';
+  /** Inject a probe — returns true if the pid is still alive. */
+  isAlive?: (pid: number) => boolean;
+  /** Grace period between SIGTERM and SIGKILL, ms. Default 10_000. */
+  termGraceMs?: number;
+  /** Sleep impl, for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Audit file appender override, for tests. */
+  appendAuditFn?: typeof appendAudit;
+  /** Top-level reap log path. Set to null to disable. */
+  reapLogPath?: string | null;
+}
+
+const DEFAULT_TERM_GRACE_MS = 10_000;
+
+export function defaultReadState(chainId: string): StateFile | null {
+  try {
+    const paths = chainPaths(chainId);
+    if (!existsSync(paths.stateFile)) return null;
+    return JSON.parse(readFileSync(paths.stateFile, 'utf8')) as StateFile;
+  } catch {
+    return null;
+  }
+}
+
+function defaultKill(
+  pid: number,
+  signal: NodeJS.Signals,
+): 'sent' | 'esrch' | 'eperm' | 'err' {
+  try {
+    process.kill(pid, signal);
+    return 'sent';
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === 'ESRCH') return 'esrch';
+    if (code === 'EPERM') return 'eperm';
+    return 'err';
+  }
+}
+
+function defaultIsAlive(pid: number): boolean {
+  try {
+    // signal 0 = existence check
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === 'EPERM') return true; // exists, just not ours
+    return false;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Find orphan workers and (unless dryRun) reap them. Always returns the full
+ * scan report so doctor can surface counts.
+ */
+export async function reapOrphans(opts: ReapOptions = {}): Promise<ReapReport> {
+  const dryRun = opts.dryRun ?? false;
+  const psSnapshot = opts.psSnapshot ?? snapshotPs();
+  const runnerMap = opts.runnerMap ?? loadRunnerMap();
+  const readState = opts.readState ?? defaultReadState;
+  const kill = opts.kill ?? defaultKill;
+  const isAlive = opts.isAlive ?? defaultIsAlive;
+  const sleep = opts.sleep ?? defaultSleep;
+  const auditFn = opts.appendAuditFn ?? appendAudit;
+  const termGraceMs = opts.termGraceMs ?? DEFAULT_TERM_GRACE_MS;
+  const reapLogPath =
+    opts.reapLogPath === undefined
+      ? join(chainRoot(), '..', 'chain-watchdog', 'reap.jsonl')
+      : opts.reapLogPath;
+
+  const byPid = new Map<number, PsEntry>();
+  for (const e of psSnapshot) byPid.set(e.pid, e);
+
+  // Step 2 — filter claude workers.
+  const candidates = psSnapshot.filter((e) => CLAUDE_PATTERN.test(e.command));
+
+  // Step 3 — find runner ancestor + chain/phase.
+  const suspects: OrphanSuspect[] = [];
+  for (const c of candidates) {
+    const anc = findRunnerAncestor(c.pid, byPid, runnerMap);
+    if (!anc) continue;
+    if (opts.chainId && anc.chainId !== opts.chainId) continue;
+    suspects.push({
+      pid: c.pid,
+      ppid: c.ppid,
+      command: c.command,
+      ageSec: etimeToSeconds(c.etime),
+      chainId: anc.chainId,
+      phaseId: anc.phaseId,
+      runnerScript: anc.runnerScript,
+    });
+  }
+
+  // Step 4 — read state and classify.
+  const orphans: OrphanFinding[] = [];
+  // Cache state per chain so we don't re-read state.json N times.
+  const stateCache = new Map<string, StateFile | null>();
+  for (const s of suspects) {
+    let state = stateCache.get(s.chainId);
+    if (state === undefined) {
+      state = readState(s.chainId);
+      stateCache.set(s.chainId, state);
+    }
+    let phaseStatus = 'unknown';
+    if (state && state.phase_status) {
+      const ps = state.phase_status[String(s.phaseId)];
+      if (ps && typeof ps.status === 'string') phaseStatus = ps.status;
+    }
+    const isOrphan = phaseStatus !== 'in_progress';
+    orphans.push({ ...s, phaseStatus, isOrphan });
+  }
+
+  // Step 5 — reap.
+  const actions: ReapAction[] = [];
+  for (const o of orphans) {
+    if (!o.isOrphan) continue;
+    if (dryRun) {
+      actions.push({
+        pid: o.pid,
+        chainId: o.chainId,
+        phaseId: o.phaseId,
+        outcome: 'skipped_dry_run',
+        ageSec: o.ageSec,
+        command: o.command,
+      });
+      continue;
+    }
+    const action = await reapOne(o, kill, isAlive, sleep, termGraceMs);
+    actions.push(action);
+    // Emit per-chain audit + top-level reap log
+    try {
+      const paths = chainPaths(o.chainId);
+      auditFn(paths.auditFile, 'orphan_reaped', {
+        phase_id: o.phaseId,
+        pid: o.pid,
+        age_sec: o.ageSec,
+        command: o.command.slice(0, 500),
+        outcome: action.outcome,
+      });
+    } catch {
+      // best effort — never let an audit-write failure mask a successful kill
+    }
+    if (reapLogPath) {
+      try {
+        mkdirSync(join(reapLogPath, '..'), { recursive: true });
+        appendFileSync(
+          reapLogPath,
+          JSON.stringify({
+            ts: isoNow(),
+            chain: o.chainId,
+            phase_id: o.phaseId,
+            pid: o.pid,
+            age_sec: o.ageSec,
+            outcome: action.outcome,
+            command: o.command.slice(0, 500),
+          }) + '\n',
+          { mode: 0o600 },
+        );
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  return {
+    scannedAt: isoNow(),
+    candidates: candidates.length,
+    suspects: suspects.length,
+    orphans,
+    actions,
+    dryRun,
+  };
+}
+
+async function reapOne(
+  orphan: OrphanFinding,
+  kill: NonNullable<ReapOptions['kill']>,
+  isAlive: NonNullable<ReapOptions['isAlive']>,
+  sleep: NonNullable<ReapOptions['sleep']>,
+  termGraceMs: number,
+): Promise<ReapAction> {
+  const base = {
+    pid: orphan.pid,
+    chainId: orphan.chainId,
+    phaseId: orphan.phaseId,
+    ageSec: orphan.ageSec,
+    command: orphan.command,
+  };
+  const termOutcome = kill(orphan.pid, 'SIGTERM');
+  if (termOutcome === 'esrch') {
+    return { ...base, outcome: 'already_gone' };
+  }
+  if (termOutcome === 'err' || termOutcome === 'eperm') {
+    return { ...base, outcome: 'error', error: `SIGTERM ${termOutcome}` };
+  }
+  await sleep(termGraceMs);
+  if (!isAlive(orphan.pid)) {
+    return { ...base, outcome: 'term' };
+  }
+  const killOutcome = kill(orphan.pid, 'SIGKILL');
+  if (killOutcome === 'esrch') {
+    return { ...base, outcome: 'term' };
+  }
+  if (killOutcome === 'err' || killOutcome === 'eperm') {
+    return { ...base, outcome: 'error', error: `SIGKILL ${killOutcome}` };
+  }
+  return { ...base, outcome: 'kill' };
+}
+
+/**
+ * Convenience formatter for the doctor section / CLI text output.
+ */
+export function formatReapReport(r: ReapReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `scanned_at=${r.scannedAt} candidates=${r.candidates} suspects=${r.suspects} orphans=${r.orphans.filter((o) => o.isOrphan).length} dry_run=${r.dryRun}`,
+  );
+  for (const o of r.orphans) {
+    lines.push(
+      `  pid=${o.pid} chain=${o.chainId} phase=${o.phaseId} status=${o.phaseStatus} age_sec=${o.ageSec} orphan=${o.isOrphan}`,
+    );
+  }
+  for (const a of r.actions) {
+    lines.push(
+      `  action pid=${a.pid} chain=${a.chainId} phase=${a.phaseId} outcome=${a.outcome}${a.error ? ` error=${a.error}` : ''}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+/** Resolve the default top-level chain-watchdog reap log path. Exported for tests. */
+export function defaultReapLogPath(): string {
+  return join(homedir(), '.caia', 'chain-watchdog', 'reap.jsonl');
+}

--- a/packages/chain-runner/tests/doctor.test.ts
+++ b/packages/chain-runner/tests/doctor.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  doctorExitCode,
   formatDoctorReport,
+  lastPhaseDoneTs,
+  parseDfOutput,
   parseLaunchctlPrint,
+  readChainHealth,
   readChainWakes,
+  runDoctor,
+  scanQuotaWarnings,
+  summariseChainHealth,
   type DoctorReport,
 } from '../src/doctor.js';
 
@@ -134,5 +141,443 @@ describe('formatDoctorReport', () => {
     expect(out).toMatch(/com\.caia\.mentor\.server/);
     expect(out).toMatch(/# chains/);
     expect(out).toMatch(/redflag-remediation/);
+  });
+});
+
+// =============================================================================
+// V2 sections (H-7, chain-runner-battle-harden phase 6, 2026-05-14)
+// =============================================================================
+
+describe('summariseChainHealth', () => {
+  it('rolls up phase counts and marks stalled when streak >= threshold', () => {
+    const h = summariseChainHealth(
+      'test',
+      {
+        schema_version: 1,
+        started_at: '2026-05-14T00:00:00Z',
+        last_wake: null,
+        paused: false,
+        budget_consumed_pct: 0,
+        budget_cap_pct: 25,
+        phase_status: {
+          '1': { status: 'done' } as never,
+          '2': { status: 'done' } as never,
+          '3': { status: 'pending' } as never,
+          '4': { status: 'blocked' } as never,
+        },
+        current_phase: null,
+        all_done: false,
+        none_eligible_streak: 3,
+      },
+      null,
+      null,
+      '2026-05-14T00:30:00Z',
+    );
+    expect(h.counts).toEqual({ done: 2, pending: 1, blocked: 1 });
+    expect(h.stalled).toBe(true);
+    expect(h.lastPhaseDone).toBe('2026-05-14T00:30:00Z');
+    expect(h.noneEligibleStreak).toBe(3);
+  });
+
+  it('marks stalled when lock age > 3 hours', () => {
+    const now = 1_700_000_000_000;
+    const fourHoursAgoMs = now - 4 * 3600 * 1000;
+    const h = summariseChainHealth(
+      'test',
+      {
+        schema_version: 1,
+        started_at: '',
+        last_wake: null,
+        paused: false,
+        budget_consumed_pct: 0,
+        budget_cap_pct: 25,
+        phase_status: {},
+        current_phase: 1,
+        all_done: false,
+      },
+      fourHoursAgoMs,
+      1,
+      null,
+      now,
+    );
+    expect(h.stalled).toBe(true);
+    expect(h.lockAgeSec).toBeGreaterThan(3 * 3600);
+  });
+
+  it('not stalled when streak < 2 and no lock', () => {
+    const h = summariseChainHealth(
+      'test',
+      {
+        schema_version: 1,
+        started_at: '',
+        last_wake: null,
+        paused: false,
+        budget_consumed_pct: 0,
+        budget_cap_pct: 25,
+        phase_status: { '1': { status: 'in_progress' } as never },
+        current_phase: 1,
+        all_done: false,
+        none_eligible_streak: 1,
+      },
+      null,
+      null,
+      null,
+    );
+    expect(h.stalled).toBe(false);
+  });
+});
+
+describe('lastPhaseDoneTs', () => {
+  it('returns the most recent phase_done ts from an audit log', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-audit-'));
+    const audit = join(root, 'audit.jsonl');
+    writeFileSync(
+      audit,
+      [
+        '{"ts":"2026-05-14T00:00:00Z","event":"phase_in_progress","phase_id":1}',
+        '{"ts":"2026-05-14T00:10:00Z","event":"phase_done","phase_id":1}',
+        '{"ts":"2026-05-14T00:20:00Z","event":"phase_in_progress","phase_id":2}',
+        '{"ts":"2026-05-14T00:30:00Z","event":"phase_done","phase_id":2}',
+        '',
+      ].join('\n'),
+    );
+    expect(lastPhaseDoneTs(audit)).toBe('2026-05-14T00:30:00Z');
+  });
+
+  it('returns null when there is no phase_done event', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-audit-'));
+    const audit = join(root, 'audit.jsonl');
+    writeFileSync(audit, '{"ts":"2026-05-14T00:00:00Z","event":"wake"}\n');
+    expect(lastPhaseDoneTs(audit)).toBeNull();
+  });
+
+  it('returns null for nonexistent files', () => {
+    expect(lastPhaseDoneTs('/tmp/definitely-not-real-xyz.jsonl')).toBeNull();
+  });
+});
+
+describe('readChainHealth', () => {
+  it('rolls up health for each chain dir found under root', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-rch-'));
+    mkdirSync(join(root, 'alpha'), { recursive: true });
+    writeFileSync(
+      join(root, 'alpha', 'state.json'),
+      JSON.stringify({
+        schema_version: 1,
+        started_at: '',
+        last_wake: null,
+        paused: false,
+        budget_consumed_pct: 0,
+        budget_cap_pct: 25,
+        phase_status: {
+          '1': { status: 'done' },
+          '2': { status: 'in_progress' },
+        },
+        current_phase: 2,
+        all_done: false,
+        none_eligible_streak: 0,
+      }),
+    );
+    writeFileSync(
+      join(root, 'alpha', 'audit.jsonl'),
+      '{"ts":"2026-05-14T00:10:00Z","event":"phase_done","phase_id":1}\n',
+    );
+    const health = readChainHealth(root, Date.now());
+    expect(health).toHaveLength(1);
+    expect(health[0]?.chainId).toBe('alpha');
+    expect(health[0]?.counts).toEqual({ done: 1, in_progress: 1 });
+    expect(health[0]?.lastPhaseDone).toBe('2026-05-14T00:10:00Z');
+    expect(health[0]?.stalled).toBe(false);
+  });
+});
+
+describe('parseDfOutput', () => {
+  it('parses macOS df -k output', () => {
+    const raw = [
+      'Filesystem    1024-blocks       Used  Available Capacity   iused      ifree %iused  Mounted on',
+      '/dev/disk3s1   976490576    420000000  556490576     43%   123456    7654321    2%   /',
+    ].join('\n');
+    const r = parseDfOutput('/', raw);
+    expect(r.availKb).toBe(556490576);
+    expect(r.total).toBe(976490576);
+    expect(r.ok).toBe(true);
+  });
+
+  it('marks ok=false when free space < 5 GB', () => {
+    const raw = [
+      'Filesystem    1024-blocks       Used  Available Capacity   Mounted on',
+      '/dev/disk3s1   976490576    972000000   1000000     99%    /',
+    ].join('\n');
+    const r = parseDfOutput('/', raw);
+    expect(r.availKb).toBeLessThan(5 * 1024 * 1024);
+    expect(r.ok).toBe(false);
+  });
+
+  it('returns availKb=0 on malformed output', () => {
+    expect(parseDfOutput('/', '')).toEqual({ mount: '/', availKb: 0, total: 0, ok: false });
+  });
+});
+
+describe('scanQuotaWarnings', () => {
+  it('returns a banner for a per-chain dispatch log with a rate-limit hit', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-quota-'));
+    const chainRoot = join(root, 'chain');
+    mkdirSync(join(chainRoot, 'alpha'), { recursive: true });
+    writeFileSync(
+      join(chainRoot, 'alpha', 'dispatch-1-sess.log'),
+      "You've hit your limit. The limit resets May 16 at 12pm (America/New_York).\n",
+    );
+    const wakeLogs = join(root, 'chain-watchdog', 'logs');
+    mkdirSync(wakeLogs, { recursive: true });
+    const r = scanQuotaWarnings(chainRoot, Date.parse('2026-05-14T20:00:00Z'), wakeLogs);
+    expect(r).toHaveLength(1);
+    expect(r[0]?.chainId).toBe('alpha');
+    expect(r[0]?.banner).toMatch(/May 16/);
+  });
+
+  it('returns [] when there are no recent banners', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-quota-empty-'));
+    mkdirSync(join(root, 'chain'), { recursive: true });
+    expect(scanQuotaWarnings(join(root, 'chain'), Date.now(), join(root, 'chain-watchdog', 'logs'))).toEqual([]);
+  });
+
+  it('sorts results by resetIso ascending', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-quota-sort-'));
+    const chainRoot = join(root, 'chain');
+    mkdirSync(join(chainRoot, 'a-later'), { recursive: true });
+    mkdirSync(join(chainRoot, 'b-earlier'), { recursive: true });
+    writeFileSync(
+      join(chainRoot, 'a-later', 'dispatch-1-x.log'),
+      "You've hit your limit. resets May 20 at 12pm (America/New_York)\n",
+    );
+    writeFileSync(
+      join(chainRoot, 'b-earlier', 'dispatch-1-x.log'),
+      "You've hit your limit. resets May 16 at 12pm (America/New_York)\n",
+    );
+    const r = scanQuotaWarnings(chainRoot, Date.parse('2026-05-14T20:00:00Z'), join(root, 'chain-watchdog', 'logs'));
+    expect(r).toHaveLength(2);
+    expect(r[0]?.chainId).toBe('b-earlier');
+  });
+});
+
+describe('doctorExitCode', () => {
+  function baseReport(): DoctorReport {
+    return {
+      nodeVersion: 'v22',
+      nodeBin: '/bin/node',
+      healthz: [{ name: 'm', url: 'u', ok: true, status: 200, error: null, elapsedMs: 1 }],
+      plists: [],
+      chains: [],
+    };
+  }
+  it('returns 0 on a clean report', () => {
+    expect(doctorExitCode(baseReport())).toBe(0);
+  });
+  it('returns 2 when any chainHealth.stalled === true', () => {
+    const r = baseReport();
+    r.chainHealth = [
+      {
+        chainId: 'x',
+        counts: {},
+        lockAgeSec: 0,
+        lockedPhase: null,
+        noneEligibleStreak: 5,
+        lastPhaseDone: null,
+        stalled: true,
+        paused: false,
+        pausedUntil: null,
+      },
+    ];
+    expect(doctorExitCode(r)).toBe(2);
+  });
+  it('returns 1 on healthz failure', () => {
+    const r = baseReport();
+    r.healthz = [{ name: 'm', url: 'u', ok: false, status: null, error: 'down', elapsedMs: 1 }];
+    expect(doctorExitCode(r)).toBe(1);
+  });
+  it('returns 1 on low disk', () => {
+    const r = baseReport();
+    r.disk = [{ mount: '/', availKb: 100, total: 1000, ok: false }];
+    expect(doctorExitCode(r)).toBe(1);
+  });
+  it('returns 1 on auth preflight nonzero', () => {
+    const r = baseReport();
+    r.auth = {
+      status: 'rate_limited',
+      exit_code: 2,
+      message: 'rate limit',
+      elapsed_ms: 100,
+      raw: '',
+    };
+    expect(doctorExitCode(r)).toBe(1);
+  });
+});
+
+describe('runDoctor V2 — composes all sections with injected deps', () => {
+  it('runs all sections + emits a full report', async () => {
+    const chainRoot = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-v2-'));
+    // Seed a chain dir so chainHealth/chains/quota all have something to find.
+    mkdirSync(join(chainRoot, 'alpha'), { recursive: true });
+    writeFileSync(
+      join(chainRoot, 'alpha', 'state.json'),
+      JSON.stringify({
+        schema_version: 1,
+        started_at: '',
+        last_wake: '2026-05-14T00:00:00Z',
+        paused: false,
+        budget_consumed_pct: 0,
+        budget_cap_pct: 25,
+        phase_status: { '1': { status: 'done' } },
+        current_phase: null,
+        all_done: false,
+        none_eligible_streak: 0,
+      }),
+    );
+    const reapStub = vi.fn(async () => ({
+      scannedAt: '2026-05-14T01:00:00Z',
+      candidates: 0,
+      suspects: 0,
+      orphans: [],
+      actions: [],
+      dryRun: true,
+    }));
+    const preflightStub = vi.fn(async () => ({
+      status: 'healthy' as const,
+      exit_code: 0,
+      message: 'ok',
+      elapsed_ms: 100,
+      raw: '',
+    }));
+    const diskStub = vi.fn((m: string) => ({ mount: m, availKb: 100 * 1024 * 1024, total: 1, ok: true }));
+    const quotaStub = vi.fn(() => []);
+    const report = await runDoctor({
+      chainRoot,
+      plistLabels: [],
+      reapFn: reapStub,
+      preflightFn: preflightStub,
+      diskFn: diskStub,
+      quotaFn: quotaStub,
+      diskMounts: ['/', '/tmp'],
+    });
+    expect(report.chainHealth).toBeDefined();
+    expect(report.orphans).toBeDefined();
+    expect(report.disk?.length).toBe(2);
+    expect(report.auth).toBeDefined();
+    expect(report.quota).toEqual([]);
+    expect(reapStub).toHaveBeenCalledWith({ dryRun: true });
+    expect(preflightStub).toHaveBeenCalled();
+  });
+
+  it('legacyOnly=true emits only V1 sections (back-compat)', async () => {
+    const chainRoot = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-legacy-'));
+    const report = await runDoctor({
+      chainRoot,
+      plistLabels: [],
+      legacyOnly: true,
+    });
+    expect(report.chainHealth).toBeUndefined();
+    expect(report.orphans).toBeUndefined();
+    expect(report.disk).toBeUndefined();
+    expect(report.auth).toBeUndefined();
+    expect(report.quota).toBeUndefined();
+  });
+
+  it('skipAuth=true does not spawn preflight', async () => {
+    const chainRoot = mkdtempSync(join(tmpdir(), 'caia-cr-doctor-noauth-'));
+    const preflightStub = vi.fn();
+    const report = await runDoctor({
+      chainRoot,
+      plistLabels: [],
+      skipAuth: true,
+      preflightFn: preflightStub as never,
+      reapFn: vi.fn(async () => ({
+        scannedAt: '',
+        candidates: 0,
+        suspects: 0,
+        orphans: [],
+        actions: [],
+        dryRun: true,
+      })),
+      diskFn: vi.fn(() => ({ mount: '/', availKb: 100 * 1024 * 1024, total: 1, ok: true })),
+      quotaFn: vi.fn(() => []),
+    });
+    expect(preflightStub).not.toHaveBeenCalled();
+    expect(report.auth).toEqual({ status: 'skipped', message: 'skipped via --skip-auth' });
+  });
+});
+
+describe('formatDoctorReport — V2 sections (snapshot-style)', () => {
+  it('renders chain-health / orphans / disk / auth / quota sections when populated', () => {
+    const r: DoctorReport = {
+      nodeVersion: 'v22.22.2',
+      nodeBin: '/bin/node',
+      healthz: [{ name: 'mentor', url: 'http://x', ok: true, status: 200, error: null, elapsedMs: 1 }],
+      plists: [],
+      chains: [],
+      chainHealth: [
+        {
+          chainId: 'alpha',
+          counts: { done: 1, in_progress: 1 },
+          lockAgeSec: 60,
+          lockedPhase: 2,
+          noneEligibleStreak: 0,
+          lastPhaseDone: '2026-05-14T00:30:00Z',
+          stalled: false,
+          paused: false,
+          pausedUntil: null,
+        },
+      ],
+      orphans: {
+        scannedAt: '2026-05-14T01:00:00Z',
+        candidates: 1,
+        suspects: 1,
+        orphans: [
+          {
+            pid: 300,
+            ppid: 200,
+            command: 'claude --print',
+            ageSec: 600,
+            chainId: 'alpha',
+            phaseId: 1,
+            runnerScript: '_chain_harden_run_phase.sh',
+            phaseStatus: 'done',
+            isOrphan: true,
+          },
+        ],
+        actions: [],
+        dryRun: true,
+      },
+      disk: [
+        { mount: '/', availKb: 100 * 1024 * 1024, total: 200 * 1024 * 1024, ok: true },
+        { mount: '/tmp', availKb: 1024, total: 1024 * 1024, ok: false },
+      ],
+      auth: {
+        status: 'rate_limited',
+        exit_code: 2,
+        message: 'rate limit reset 12pm',
+        elapsed_ms: 100,
+        raw: '',
+      },
+      quota: [
+        {
+          chainId: 'alpha',
+          logPath: '/path/dispatch-1.log',
+          resetIso: '2026-05-16T16:00:00Z',
+          banner: 'resets May 16 at 12pm',
+          detectedAt: '2026-05-14T20:00:00Z',
+        },
+      ],
+    };
+    const out = formatDoctorReport(r);
+    expect(out).toMatch(/# chain health/);
+    expect(out).toMatch(/alpha.*done=1,in_progress=1/);
+    expect(out).toMatch(/# orphans \(dry-run\)/);
+    expect(out).toMatch(/candidates=1 suspects=1 orphans=1/);
+    expect(out).toMatch(/# disk/);
+    expect(out).toMatch(/\/tmp.*1024.*no/);
+    expect(out).toMatch(/# auth/);
+    expect(out).toMatch(/status=rate_limited exit=2/);
+    expect(out).toMatch(/# quota/);
+    expect(out).toMatch(/reset_iso=2026-05-16T16:00:00Z/);
   });
 });

--- a/packages/chain-runner/tests/reap.test.ts
+++ b/packages/chain-runner/tests/reap.test.ts
@@ -1,0 +1,379 @@
+// Tests for H-6 reap-orphans. The critical safety property: live workers
+// for `in_progress` phases must NEVER be reaped. Every test exercises a
+// mocked ps snapshot + injected state reader + injected killer so the test
+// suite never touches a real process.
+
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEFAULT_RUNNER_MAP,
+  defaultReadState,
+  etimeToSeconds,
+  findRunnerAncestor,
+  formatReapReport,
+  loadRunnerMap,
+  parsePs,
+  reapOrphans,
+  type PsEntry,
+} from '../src/reap.js';
+import type { StateFile } from '../src/types.js';
+
+function ps(
+  entries: Array<Partial<PsEntry> & Pick<PsEntry, 'pid' | 'ppid' | 'command'>>,
+): PsEntry[] {
+  return entries.map((e) => ({
+    pid: e.pid,
+    ppid: e.ppid,
+    etime: e.etime ?? '00:30',
+    command: e.command,
+  }));
+}
+
+function state(phaseStatus: Record<number, string>): StateFile {
+  const phase_status: Record<string, { status: string }> = {};
+  for (const [k, v] of Object.entries(phaseStatus)) {
+    phase_status[String(k)] = { status: v };
+  }
+  return {
+    schema_version: 1,
+    started_at: '2026-05-14T00:00:00Z',
+    last_wake: null,
+    paused: false,
+    budget_consumed_pct: 0,
+    budget_cap_pct: 25,
+    phase_status: phase_status as unknown as StateFile['phase_status'],
+    current_phase: null,
+    all_done: false,
+  };
+}
+
+describe('parsePs', () => {
+  it('parses a typical ps -axo output with header', () => {
+    const raw = [
+      '  PID  PPID ELAPSED COMMAND',
+      '  100     1 00:05:00 /sbin/launchd',
+      '  500   100   00:02:00 /bin/bash _chain_harden_run_phase.sh 7 sess123 /tmp/prompt.txt',
+      '  600   500   00:01:30 /opt/claude/bin/claude --permission-mode bypassPermissions --print',
+    ].join('\n');
+    const out = parsePs(raw);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({
+      pid: 100,
+      ppid: 1,
+      etime: '00:05:00',
+      command: '/sbin/launchd',
+    });
+    expect(out[2]?.pid).toBe(600);
+    expect(out[2]?.command).toMatch(/^\/opt\/claude\/bin\/claude/);
+  });
+
+  it('skips blank lines and malformed rows', () => {
+    const raw = ['  PID  PPID ELAPSED COMMAND', '', '  not a real row', '  42 1 00:01 /bin/init'].join('\n');
+    const out = parsePs(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.pid).toBe(42);
+  });
+});
+
+describe('etimeToSeconds', () => {
+  it('parses SS form', () => expect(etimeToSeconds('45')).toBe(45));
+  it('parses MM:SS form', () => expect(etimeToSeconds('05:30')).toBe(330));
+  it('parses HH:MM:SS form', () => expect(etimeToSeconds('01:00:00')).toBe(3600));
+  it('parses D-HH:MM:SS form', () => expect(etimeToSeconds('2-03:04:05')).toBe(2 * 86400 + 3 * 3600 + 4 * 60 + 5));
+  it('returns 0 for empty / nonsense', () => {
+    expect(etimeToSeconds('')).toBe(0);
+    expect(etimeToSeconds('hello')).toBe(0);
+  });
+});
+
+describe('findRunnerAncestor', () => {
+  it('walks the parent chain and returns chain+phase from a known runner', () => {
+    const entries = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 7 sess123 /tmp/p.txt' },
+      { pid: 300, ppid: 200, command: 'claude --permission-mode bypassPermissions --print' },
+    ]);
+    const byPid = new Map(entries.map((e) => [e.pid, e]));
+    const r = findRunnerAncestor(300, byPid, { ...DEFAULT_RUNNER_MAP });
+    expect(r?.chainId).toBe('chain-runner-battle-harden');
+    expect(r?.phaseId).toBe(7);
+  });
+
+  it('returns null when no runner ancestor is found', () => {
+    const entries = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 300, ppid: 100, command: 'claude --permission-mode bypassPermissions --print' },
+    ]);
+    const byPid = new Map(entries.map((e) => [e.pid, e]));
+    expect(findRunnerAncestor(300, byPid, { ...DEFAULT_RUNNER_MAP })).toBeNull();
+  });
+
+  it('does not loop forever on a cyclic ppid chain', () => {
+    const entries = ps([
+      { pid: 100, ppid: 200, command: 'sh' },
+      { pid: 200, ppid: 100, command: 'sh' },
+    ]);
+    const byPid = new Map(entries.map((e) => [e.pid, e]));
+    expect(findRunnerAncestor(100, byPid, { ...DEFAULT_RUNNER_MAP })).toBeNull();
+  });
+
+  it('respects CAIA_REAP_RUNNER_MAP env override', () => {
+    const map = loadRunnerMap({
+      CAIA_REAP_RUNNER_MAP: JSON.stringify({ '_custom_run_phase.sh': 'custom-chain' }),
+    });
+    expect(map['_custom_run_phase.sh']).toBe('custom-chain');
+    // defaults still present
+    expect(map['_chain_harden_run_phase.sh']).toBe('chain-runner-battle-harden');
+  });
+});
+
+describe('reapOrphans — orphan detection', () => {
+  it('flags a claude child whose phase is done as an orphan, and reaps it (non-dry-run)', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 3 sess123 /tmp/p.txt' },
+      { pid: 300, ppid: 200, command: '/opt/claude/bin/claude --permission-mode bypassPermissions --print', etime: '10:00' },
+    ]);
+    const readState = vi.fn(() => state({ 3: 'done' }));
+    const kill = vi.fn(() => 'esrch' as const); // already-gone after SIGTERM — short-circuits the wait
+    const isAlive = vi.fn(() => false);
+    const sleep = vi.fn(async () => undefined);
+    const auditFn = vi.fn();
+    const r = await reapOrphans({
+      psSnapshot: snapshot,
+      readState,
+      kill,
+      isAlive,
+      sleep,
+      appendAuditFn: auditFn,
+      reapLogPath: null,
+    });
+    expect(r.candidates).toBe(1);
+    expect(r.suspects).toBe(1);
+    expect(r.orphans).toHaveLength(1);
+    expect(r.orphans[0]?.isOrphan).toBe(true);
+    expect(r.orphans[0]?.phaseStatus).toBe('done');
+    expect(r.actions).toHaveLength(1);
+    expect(r.actions[0]?.outcome).toBe('already_gone');
+    expect(kill).toHaveBeenCalledWith(300, 'SIGTERM');
+    expect(auditFn).toHaveBeenCalled();
+  });
+
+  it('NEVER reaps a claude child whose phase is in_progress (safety property)', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 3 sess123 /tmp/p.txt' },
+      { pid: 300, ppid: 200, command: 'claude --permission-mode bypassPermissions --print', etime: '10:00' },
+    ]);
+    const kill = vi.fn(() => 'sent' as const);
+    const isAlive = vi.fn(() => false);
+    const sleep = vi.fn(async () => undefined);
+    const r = await reapOrphans({
+      psSnapshot: snapshot,
+      readState: () => state({ 3: 'in_progress' }),
+      kill,
+      isAlive,
+      sleep,
+      reapLogPath: null,
+    });
+    expect(r.orphans).toHaveLength(1);
+    expect(r.orphans[0]?.isOrphan).toBe(false);
+    expect(r.actions).toHaveLength(0);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('dry-run reports orphans but never kills', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 5 s /tmp/p.txt' },
+      { pid: 300, ppid: 200, command: 'claude --permission-mode bypassPermissions --print', etime: '02:00' },
+    ]);
+    const kill = vi.fn(() => 'sent' as const);
+    const r = await reapOrphans({
+      dryRun: true,
+      psSnapshot: snapshot,
+      readState: () => state({ 5: 'blocked' }),
+      kill,
+      isAlive: () => true,
+      sleep: async () => undefined,
+      reapLogPath: null,
+    });
+    expect(r.dryRun).toBe(true);
+    expect(r.actions[0]?.outcome).toBe('skipped_dry_run');
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('SIGKILLs after grace when SIGTERM did not kill the process', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 9 s /tmp/p.txt' },
+      { pid: 300, ppid: 200, command: 'claude --permission-mode bypassPermissions --print', etime: '60:00' },
+    ]);
+    const kill = vi.fn((_pid: number, sig: NodeJS.Signals) => ('sent' as const));
+    const isAlive = vi.fn(() => true); // still alive after SIGTERM grace
+    const sleep = vi.fn(async () => undefined);
+    const r = await reapOrphans({
+      psSnapshot: snapshot,
+      readState: () => state({ 9: 'failed' }),
+      kill,
+      isAlive,
+      sleep,
+      termGraceMs: 1, // dont actually wait
+      reapLogPath: null,
+    });
+    expect(r.actions[0]?.outcome).toBe('kill');
+    expect(kill).toHaveBeenNthCalledWith(1, 300, 'SIGTERM');
+    expect(kill).toHaveBeenNthCalledWith(2, 300, 'SIGKILL');
+  });
+
+  it('respects --chain-id filter and ignores orphans from other chains', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: 'launchd' },
+      // chain A
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 1 s /tmp/p.txt' },
+      { pid: 201, ppid: 200, command: 'claude --permission-mode bypassPermissions --print', etime: '5:00' },
+      // chain B (different runner)
+      { pid: 300, ppid: 100, command: 'bash _redflag_remediation_run_phase.sh 2 s /tmp/p.txt' },
+      { pid: 301, ppid: 300, command: 'claude --permission-mode bypassPermissions --print', etime: '5:00' },
+    ]);
+    const kill = vi.fn(() => 'esrch' as const);
+    const r = await reapOrphans({
+      chainId: 'chain-runner-battle-harden',
+      psSnapshot: snapshot,
+      readState: () => state({ 1: 'done', 2: 'done' }),
+      kill,
+      isAlive: () => false,
+      sleep: async () => undefined,
+      reapLogPath: null,
+    });
+    expect(r.suspects).toBe(1);
+    expect(r.orphans[0]?.chainId).toBe('chain-runner-battle-harden');
+  });
+
+  it('returns 0 candidates when no claude --print children exist', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: '/sbin/launchd' },
+      { pid: 200, ppid: 100, command: '/usr/bin/zsh' },
+    ]);
+    const r = await reapOrphans({
+      psSnapshot: snapshot,
+      readState: () => null,
+      reapLogPath: null,
+    });
+    expect(r.candidates).toBe(0);
+    expect(r.suspects).toBe(0);
+  });
+
+  it('returns 0 suspects for a claude --print orphan with no known runner ancestor', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: 'launchd' },
+      { pid: 300, ppid: 100, command: 'claude --permission-mode bypassPermissions --print', etime: '5:00' },
+    ]);
+    const r = await reapOrphans({
+      psSnapshot: snapshot,
+      readState: () => state({ 1: 'done' }),
+      reapLogPath: null,
+    });
+    expect(r.candidates).toBe(1);
+    expect(r.suspects).toBe(0);
+  });
+
+  it('audits per-chain on reap', async () => {
+    const snapshot = ps([
+      { pid: 100, ppid: 1, command: 'launchd' },
+      { pid: 200, ppid: 100, command: 'bash _chain_harden_run_phase.sh 4 s /tmp/p.txt' },
+      { pid: 300, ppid: 200, command: 'claude --permission-mode bypassPermissions --print', etime: '8:00' },
+    ]);
+    const auditFn = vi.fn();
+    await reapOrphans({
+      psSnapshot: snapshot,
+      readState: () => state({ 4: 'done' }),
+      kill: () => 'esrch',
+      isAlive: () => false,
+      sleep: async () => undefined,
+      appendAuditFn: auditFn,
+      reapLogPath: null,
+    });
+    expect(auditFn).toHaveBeenCalled();
+    const call = auditFn.mock.calls[0]!;
+    expect(call[1]).toBe('orphan_reaped');
+    expect(call[2]).toMatchObject({ phase_id: 4, pid: 300, outcome: 'already_gone' });
+  });
+});
+
+describe('formatReapReport', () => {
+  it('renders the summary + per-orphan + per-action lines', () => {
+    const out = formatReapReport({
+      scannedAt: '2026-05-14T01:00:00Z',
+      candidates: 2,
+      suspects: 2,
+      orphans: [
+        {
+          pid: 300,
+          ppid: 200,
+          command: 'claude --print',
+          ageSec: 600,
+          chainId: 'chain-runner-battle-harden',
+          phaseId: 4,
+          runnerScript: '_chain_harden_run_phase.sh',
+          phaseStatus: 'done',
+          isOrphan: true,
+        },
+        {
+          pid: 301,
+          ppid: 200,
+          command: 'claude --print',
+          ageSec: 60,
+          chainId: 'chain-runner-battle-harden',
+          phaseId: 4,
+          runnerScript: '_chain_harden_run_phase.sh',
+          phaseStatus: 'in_progress',
+          isOrphan: false,
+        },
+      ],
+      actions: [
+        {
+          pid: 300,
+          chainId: 'chain-runner-battle-harden',
+          phaseId: 4,
+          outcome: 'term',
+          ageSec: 600,
+          command: 'claude --print',
+        },
+      ],
+      dryRun: false,
+    });
+    expect(out).toMatch(/candidates=2/);
+    expect(out).toMatch(/orphans=1/);
+    expect(out).toMatch(/pid=300.*orphan=true/);
+    expect(out).toMatch(/action pid=300.*outcome=term/);
+  });
+});
+
+describe('defaultReadState', () => {
+  it('returns null when the chain dir does not exist', () => {
+    // chainPaths requires a valid id; defaultReadState should swallow ENOENT.
+    process.env['CAIA_CHAIN_HOME'] = mkdtempSync(join(tmpdir(), 'caia-cr-reap-state-'));
+    expect(defaultReadState('definitely-does-not-exist')).toBeNull();
+    delete process.env['CAIA_CHAIN_HOME'];
+  });
+
+  it('loads a valid state.json', () => {
+    const root = mkdtempSync(join(tmpdir(), 'caia-cr-reap-state-'));
+    const chainId = 'rs-test-chain';
+    mkdirSync(join(root, chainId), { recursive: true });
+    writeFileSync(
+      join(root, chainId, 'state.json'),
+      JSON.stringify({ phase_status: { '1': { status: 'done' } } }),
+    );
+    process.env['CAIA_CHAIN_HOME'] = root;
+    try {
+      const s = defaultReadState(chainId);
+      expect(s?.phase_status['1']?.status).toBe('done');
+    } finally {
+      delete process.env['CAIA_CHAIN_HOME'];
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 6 of `chain-runner-battle-harden` (2026-05-14). Closes two P0 gaps from the gap-analysis.

### H-6 — Reap orphan worker processes
- New `src/reap.ts` walks `ps -axo pid,ppid,etime,command`, finds `claude --permission-mode bypassPermissions --print` children, walks the parent chain to a known per-chain runner shell (`_*_run_phase.sh`), and classifies as orphan when its phase is no longer `in_progress`.
- SIGTERM → 10s grace → SIGKILL. Per-chain `orphan_reaped` audit + cross-chain `~/.caia/chain-watchdog/reap.jsonl` log.
- Runner map is configurable via the `CAIA_REAP_RUNNER_MAP` env var.
- CLI: `caia-chain reap-orphans [--dry-run] [--chain-id <id>] [--json] [--term-grace-ms <n>]`.
- Wake scripts now invoke `reap_at_wake` at the top of every wake (via `_wake_helpers.sh`).
- Safety property under test: a live worker for an `in_progress` phase is NEVER reaped.

### H-7 — `caia-chain doctor v2`
- New sections: chain-health (per-status counts, lock age, none_eligible_streak, last `phase_done`), orphans (dry-run summary), disk (free space on `/` + `$TMPDIR`; degrades < 5 GB), auth (preflightDispatch result), quota (parses rate-limit banners from recent dispatch logs).
- New exit-code policy: 0 healthy / 1 degraded / 2 stalled-chain.
- New flags: `--legacy-only` (V1-only output for old consumers) and `--skip-auth` (skip the slow preflight spawn).
- JSON output preserved; V2 fields are optional in `DoctorReport` so existing JSON consumers stay green.

### Tests
- 22 new reap tests + 14 new doctor v2 tests. All 263 tests pass.
- Every section accepts injectable deps (ps snapshot, killer, state reader, preflight fn, disk fn, quota scanner) so the suite never touches a real process and never spawns claude.

## Test plan
- [x] vitest run — 263/263 pass
- [x] tsc --noEmit clean
- [x] eslint src clean
- [x] smoke test: `caia-chain reap-orphans --dry-run --json` correctly flagged the live phase-6 claude as NOT-orphan (in_progress safety property holds on real ps output)
- [x] smoke test: `caia-chain doctor --skip-auth` emits all 9 sections against the live ~/.caia/chain dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)