### PR TITLE
feat(chain-runner): h-8 adjudication cli + h-21 pure next-phase

### DIFF
--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -1,7 +1,10 @@
 import { Command } from 'commander';
 import { existsSync, unlinkSync } from 'node:fs';
 import {
+  adjudicate,
   computeNextPhase,
+  evaluateNextPhase,
+  forceFail,
   initState,
   loadContext,
   loadState,
@@ -9,12 +12,15 @@ import {
   markFailed,
   markInProgress,
   pause,
+  promoteFailedToBlocked,
+  reArm,
   recordWake,
   resume,
   saveState,
   setBudget,
   tryLoadState,
 } from './state.js';
+import type { PhaseStatus } from './types.js';
 import {
   HEARTBEAT_GRACE_SEC,
   acquireLock,
@@ -147,11 +153,20 @@ export function buildProgram(): Command {
     });
 
   attachCommonOptions(program.command('next-phase'))
-    .description('Print the id of the next dispatchable phase')
-    .action((opts: BaseOptions) => {
+    .description(
+      'Print the id of the next dispatchable phase. H-21: --read-only skips the failed→blocked promotion (use `promote-blocked` first for the explicit two-step contract).',
+    )
+    .option(
+      '--read-only',
+      'evaluate without mutating state.json (no promote, no streak update, no audit emit). Equivalent to evaluateNextPhase(state, spec).',
+    )
+    .action((cmdOpts: { readOnly?: boolean }, cmd: Command) => {
+      const opts = cmd.optsWithGlobals() as BaseOptions;
       const ctx = ctxFromOpts(opts);
       const state = loadState(ctx);
-      const result = computeNextPhase(ctx, state);
+      const result = cmdOpts.readOnly
+        ? evaluateNextPhase(state, ctx.spec)
+        : computeNextPhase(ctx, state);
       switch (result.kind) {
         case 'paused':
           process.stdout.write('PAUSED\n');
@@ -178,6 +193,27 @@ export function buildProgram(): Command {
         case 'phase_id':
           process.stdout.write(`${result.id}\n`);
           break;
+      }
+    });
+
+  // H-21 (chain-runner-battle-harden phase 7, 2026-05-14). promote-blocked is
+  // the explicit mutation half of the next-phase decision: walks every failed
+  // phase, applies the H-9 retry policy, and flips to `blocked` (with a
+  // phase_blocked audit event) when retries are exhausted or the policy
+  // action is terminal. Wake scripts call this between check-lock-staleness
+  // and next-phase so the read-only next-phase no longer needs to mutate.
+  attachCommonOptions(program.command('promote-blocked'))
+    .description(
+      'Promote every failed phase whose retry policy is exhausted to `blocked`. Wake-script step between check-lock-staleness and next-phase.',
+    )
+    .action((opts: BaseOptions) => {
+      const ctx = ctxFromOpts(opts);
+      const state = loadState(ctx);
+      const promoted = promoteFailedToBlocked(ctx, state);
+      if (promoted.length === 0) {
+        process.stdout.write('PROMOTE_BLOCKED none\n');
+      } else {
+        process.stdout.write(`PROMOTE_BLOCKED ${promoted.join(',')}\n`);
       }
     });
 
@@ -254,6 +290,126 @@ export function buildProgram(): Command {
           markFailed(ctx, phaseId, r);
         }
         clearLock(ctx);
+      },
+    );
+
+  // H-8 (chain-runner-battle-harden phase 7, 2026-05-14). Adjudication verbs.
+  // Replace operator hand-edits of state.json with sanctioned, audited
+  // transitions. See state.ts:adjudicate / reArm / forceFail for semantics.
+  //
+  // Reason is REQUIRED non-empty. Backups land in <chain-dir>/.backups/.
+  // Every transition emits a structured audit event and fires the
+  // SESSION_HANDOFF refresh hook.
+  attachCommonOptions(program.command('adjudicate'))
+    .argument('<phase-id>')
+    .requiredOption(
+      '--to <state>',
+      'target state: pending | in_progress | failed | blocked | done',
+    )
+    .requiredOption('--reason <text>', 'operator-supplied reason (required, non-empty)')
+    .option(
+      '--evidence <kv>',
+      'key=value evidence pair (repeatable, e.g. --evidence pr=https://...)',
+      (val: string, acc: string[]) => acc.concat(val),
+      [] as string[],
+    )
+    .option(
+      '--strict',
+      'refuse adjudicate --to done when no pr/artifact/verification evidence supplied',
+    )
+    .description(
+      'Adjudicate a phase to an arbitrary state. Writes a state.json backup, validates the transition, emits a phase_adjudicated audit event, and refreshes SESSION_HANDOFF.',
+    )
+    .action(
+      (
+        phaseId: string,
+        cmdOpts: {
+          to: string;
+          reason: string;
+          evidence?: string[];
+          strict?: boolean;
+        },
+        cmd: Command,
+      ) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions;
+        const ctx = ctxFromOpts(opts);
+        const evidence: Record<string, unknown> = {};
+        for (const kv of cmdOpts.evidence ?? []) {
+          // Use only the first '=' so URLs (which contain '=') survive intact.
+          const eq = kv.indexOf('=');
+          if (eq > 0) {
+            evidence[kv.slice(0, eq).trim()] = kv.slice(eq + 1).trim();
+          }
+        }
+        const adjudicateOpts: Parameters<typeof adjudicate>[4] = {
+          evidence,
+        };
+        if (cmdOpts.strict) adjudicateOpts.strict = true;
+        try {
+          const r = adjudicate(
+            ctx,
+            phaseId,
+            cmdOpts.to as PhaseStatus,
+            cmdOpts.reason,
+            adjudicateOpts,
+          );
+          process.stdout.write(
+            `ADJUDICATED phase=${phaseId} from=${r.from} to=${r.to} backup=${r.backup}\n`,
+          );
+        } catch (err) {
+          fail((err as Error).message);
+        }
+      },
+    );
+
+  attachCommonOptions(program.command('re-arm'))
+    .argument('<phase-id>')
+    .requiredOption('--reason <text>', 'operator-supplied reason (required, non-empty)')
+    .option('--reset-attempts', 'set ps.attempts back to 0 alongside the status flip')
+    .option('--force', 'lift the blocked-only guard (allow re-arm from non-blocked states)')
+    .description(
+      'Lift a phase from `blocked` back to `pending`. Writes a state.json backup, emits phase_rearmed, refreshes SESSION_HANDOFF.',
+    )
+    .action(
+      (
+        phaseId: string,
+        cmdOpts: { reason: string; resetAttempts?: boolean; force?: boolean },
+        cmd: Command,
+      ) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions;
+        const ctx = ctxFromOpts(opts);
+        const reArmOpts: Parameters<typeof reArm>[3] = {};
+        if (cmdOpts.resetAttempts) reArmOpts.resetAttempts = true;
+        if (cmdOpts.force) reArmOpts.force = true;
+        try {
+          const r = reArm(ctx, phaseId, cmdOpts.reason, reArmOpts);
+          process.stdout.write(
+            `REARMED phase=${phaseId} from=${r.from} attempts=${r.attemptsBefore}->${r.attemptsAfter} backup=${r.backup}\n`,
+          );
+        } catch (err) {
+          fail((err as Error).message);
+        }
+      },
+    );
+
+  attachCommonOptions(program.command('force-fail'))
+    .argument('<phase-id>')
+    .requiredOption('--reason <text>', 'operator-supplied reason (required, non-empty)')
+    .description(
+      'Operator-mark a phase as failed (class=unknown, source=operator_force_fail). Writes a backup, emits phase_force_failed, refreshes SESSION_HANDOFF.',
+    )
+    .action(
+      (phaseId: string, cmdOpts: { reason: string }, cmd: Command) => {
+        const opts = cmd.optsWithGlobals() as BaseOptions;
+        const ctx = ctxFromOpts(opts);
+        try {
+          const r = forceFail(ctx, phaseId, cmdOpts.reason);
+          process.stdout.write(
+            `FORCE_FAILED phase=${phaseId} from=${r.from} backup=${r.backup}\n`,
+          );
+        } catch (err) {
+          fail((err as Error).message);
+        }
       },
     );
 

--- a/packages/chain-runner/src/state.ts
+++ b/packages/chain-runner/src/state.ts
@@ -1,10 +1,17 @@
-import { existsSync, readFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
 import { atomicWriteJson } from './atomic.js';
 import { appendAudit } from './audit.js';
 import { ensureChainDir } from './paths.js';
 import { isoNow } from './time.js';
 import { loadChainSpec } from './spec.js';
 import { failureFromReason } from './classify.js';
+import { fireHandoffRefresh } from './handoff-refresh.js';
 import { resolveRetryPolicy } from './retry-policy.js';
 import type {
   ChainPaths,
@@ -12,6 +19,7 @@ import type {
   FailureClass,
   PhaseFailure,
   PhaseState,
+  PhaseStatus,
   StateFile,
 } from './types.js';
 
@@ -140,20 +148,27 @@ function _applyNoneEligibleStreak(
   return result;
 }
 
-export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhaseResult {
-  if (state.paused) {
-    return _applyNoneEligibleStreak(ctx, state, { kind: 'paused' });
-  }
+// H-21 (chain-runner-battle-harden phase 7, 2026-05-14). evaluateNextPhase is
+// the PURE half of the next-phase decision: no mutation, no audit emit, no
+// state.json writes. Safe to call from `next-phase --read-only` and from tests
+// that want to probe the decision without side-effects.
+//
+// A phase in `failed` that would be promoted to `blocked` by the retry policy
+// is skipped here (treated as not-dispatchable) — the actual promotion lives
+// in `promoteFailedToBlocked` and is called explicitly by wake scripts before
+// next-phase.
+export function evaluateNextPhase(
+  state: StateFile,
+  spec: ChainSpec,
+): NextPhaseResult {
+  if (state.paused) return { kind: 'paused' };
   if (state.budget_consumed_pct >= state.budget_cap_pct) {
-    return _applyNoneEligibleStreak(ctx, state, { kind: 'budget_exhausted' });
+    return { kind: 'budget_exhausted' };
   }
-  if (state.all_done) {
-    return _applyNoneEligibleStreak(ctx, state, { kind: 'all_done' });
-  }
+  if (state.all_done) return { kind: 'all_done' };
 
   const nowMs = Date.now();
-  let mutated = false;
-  for (const p of ctx.spec.phases) {
+  for (const p of spec.phases) {
     const pid = String(p.id);
     const ps = state.phase_status[pid];
     if (!ps) continue;
@@ -166,22 +181,13 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
     if (!depsMet) continue;
 
     if (ps.status === 'pending' || ps.status === 'failed') {
-      // H-9: class-aware retry decision. Falls back to max_retries when the
-      // phase has no recorded failure class (legacy state files, fresh
-      // phases, or a `pending`-from-init). When the failure came in via the
-      // legacy string-reason CLI shim (evidence.legacy_string_reason=true,
-      // class=unknown), we honor the *legacy* ps.max_retries bound instead
-      // of the H-9 default policy to keep the pre-H-9 regression suite
-      // green; typed failures (with --class on mark-failed or via the
-      // classifier) get class-aware policy.
       if (ps.status === 'failed') {
         const cls = ps.last_failure_class ?? ps.failure?.class ?? null;
         const isLegacyShim =
           ps.failure?.evidence?.['legacy_string_reason'] === true;
         const policy =
-          cls && !isLegacyShim ? resolveRetryPolicy(ctx.spec, cls) : null;
+          cls && !isLegacyShim ? resolveRetryPolicy(spec, cls) : null;
         const policyMax = policy?.max_attempts ?? ps.max_retries;
-        // pause_until_* / adjudicate / alert / block all imply no more retries.
         const policyTerminal =
           policy?.action === 'pause_until_reset' ||
           policy?.action === 'pause_until_operator' ||
@@ -190,63 +196,117 @@ export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhase
           policy?.action === 'block';
         const retriesExhausted = ps.attempts >= policyMax;
         if (policyTerminal || retriesExhausted) {
-          ps.status = 'blocked';
-          mutated = true;
-          appendAudit(ctx.paths.auditFile, 'phase_blocked', {
-            phase_id: p.id,
-            reason: policyTerminal
-              ? `policy_action_${policy?.action ?? 'unknown'}`
-              : 'retries_exhausted',
-            class: cls,
-            policy_action: policy?.action ?? null,
-            attempts: ps.attempts,
-            policy_max_attempts: policyMax,
-          });
+          // Read-only view of "this phase is on the failed→blocked path";
+          // promoteFailedToBlocked is where the mutation happens.
           continue;
         }
-        // Backoff active: return BACKOFF for this phase so wake script
-        // noops without consuming a retry. Surface only if the backoff
-        // timestamp is in the future.
         if (ps.backoff_until) {
           const bt = new Date(ps.backoff_until).getTime();
           if (Number.isFinite(bt) && bt > nowMs) {
-            if (mutated) saveState(ctx, state);
-            return _applyNoneEligibleStreak(ctx, state, {
+            return {
               kind: 'backoff',
               id: p.id,
               seconds: Math.max(0, Math.ceil((bt - nowMs) / 1000)),
               until: ps.backoff_until,
-            });
+            };
           }
         }
       }
-      if (mutated) saveState(ctx, state);
-      return _applyNoneEligibleStreak(ctx, state, { kind: 'phase_id', id: p.id });
+      return { kind: 'phase_id', id: p.id };
     }
     if (ps.status === 'in_progress') {
-      if (mutated) saveState(ctx, state);
-      return _applyNoneEligibleStreak(ctx, state, { kind: 'in_progress', id: p.id });
+      return { kind: 'in_progress', id: p.id };
     }
   }
 
-  // Nothing dispatchable found — promote to all_done if all are done.
-  const allDone = ctx.spec.phases.every(
+  // Nothing dispatchable — pure check for all_done.
+  const allDone = spec.phases.every(
     (p) => state.phase_status[String(p.id)]?.status === 'done',
   );
-  if (allDone) {
+  if (allDone) return { kind: 'all_done' };
+  return { kind: 'none_eligible' };
+}
+
+// H-21. promoteFailedToBlocked is the IMPURE half: walks every `failed` phase,
+// applies the H-9 retry policy, and flips the phase to `blocked` (with a
+// phase_blocked audit event) when retries are exhausted or the policy action
+// is terminal. Returns the list of promoted phase ids so callers can audit
+// the per-tick delta.
+//
+// Wake-script call order (H-21 contract):
+//   wake-observed → check-lock-staleness → promote-blocked → next-phase
+//
+// `promote-blocked` runs this on disk-backed state and persists; `next-phase`
+// then becomes a (mostly) read-only operation backed by `evaluateNextPhase`.
+export function promoteFailedToBlocked(
+  ctx: StateContext,
+  state: StateFile,
+): number[] {
+  const promoted: number[] = [];
+  for (const p of ctx.spec.phases) {
+    const pid = String(p.id);
+    const ps = state.phase_status[pid];
+    if (!ps) continue;
+    if (ps.status !== 'failed') continue;
+
+    const cls = ps.last_failure_class ?? ps.failure?.class ?? null;
+    const isLegacyShim =
+      ps.failure?.evidence?.['legacy_string_reason'] === true;
+    const policy =
+      cls && !isLegacyShim ? resolveRetryPolicy(ctx.spec, cls) : null;
+    const policyMax = policy?.max_attempts ?? ps.max_retries;
+    const policyTerminal =
+      policy?.action === 'pause_until_reset' ||
+      policy?.action === 'pause_until_operator' ||
+      policy?.action === 'adjudicate' ||
+      policy?.action === 'alert' ||
+      policy?.action === 'block';
+    const retriesExhausted = ps.attempts >= policyMax;
+    if (policyTerminal || retriesExhausted) {
+      ps.status = 'blocked';
+      promoted.push(p.id);
+      appendAudit(ctx.paths.auditFile, 'phase_blocked', {
+        phase_id: p.id,
+        reason: policyTerminal
+          ? `policy_action_${policy?.action ?? 'unknown'}`
+          : 'retries_exhausted',
+        class: cls,
+        policy_action: policy?.action ?? null,
+        attempts: ps.attempts,
+        policy_max_attempts: policyMax,
+      });
+    }
+  }
+  if (promoted.length > 0) saveState(ctx, state);
+  return promoted;
+}
+
+// computeNextPhase keeps the pre-H-21 contract for back-compat: it runs the
+// promotion + the all_done bookkeeping + the none_eligible streak + audit
+// emit, then returns the evaluation result. Wake scripts that call
+// `next-phase` continue to work unchanged.
+//
+// Callers wanting the read-only flavor (the H-21 split) should use
+// `evaluateNextPhase(state, spec)` directly.
+export function computeNextPhase(ctx: StateContext, state: StateFile): NextPhaseResult {
+  promoteFailedToBlocked(ctx, state);
+  const result = evaluateNextPhase(state, ctx.spec);
+
+  // all_done promotion: pure evaluator says all_done but state hasn't been
+  // stamped yet. Stamp + audit.
+  if (result.kind === 'all_done' && !state.all_done) {
     state.all_done = true;
     saveState(ctx, state);
     appendAudit(ctx.paths.auditFile, 'all_done', {});
-    return _applyNoneEligibleStreak(ctx, state, { kind: 'all_done' });
   }
-  if (mutated) saveState(ctx, state);
-  // H-5: emit a structured audit entry on every none_eligible result so
-  // operators have first-class telemetry of stalls (not just inferred from
-  // wake-script logs). The stall-root-cause CLI consumes this.
-  appendAudit(ctx.paths.auditFile, 'none_eligible', {
-    streak_before: state.none_eligible_streak ?? 0,
-  });
-  return _applyNoneEligibleStreak(ctx, state, { kind: 'none_eligible' });
+
+  // H-5: emit none_eligible audit + streak bookkeeping.
+  if (result.kind === 'none_eligible') {
+    appendAudit(ctx.paths.auditFile, 'none_eligible', {
+      streak_before: state.none_eligible_streak ?? 0,
+    });
+  }
+  return _applyNoneEligibleStreak(ctx, state, result);
 }
 
 // H-2 (chain-runner-battle-harden phase 3, 2026-05-14). markInProgress emits
@@ -508,4 +568,236 @@ export function recordWake(ctx: StateContext): void {
   state.last_wake = isoNow();
   saveState(ctx, state);
   appendAudit(ctx.paths.auditFile, 'wake', {});
+}
+
+// H-8 (chain-runner-battle-harden phase 7, 2026-05-14). Adjudication helpers
+// replace operator hand-edits of state.json with sanctioned, audited verbs.
+//
+// Pattern motivated by the 2026-05-14T07:13:59Z incident: phase 3 of
+// redflag-remediation was hand-flipped from `blocked` → `done` via a
+// state.json edit + a state.json.bak-pre-mark-done-2026-05-14 sidecar. That
+// path leaves no audit event and no validation. The adjudicate / re-arm /
+// force-fail trio replaces it: every operator intervention now writes a
+// timestamped backup, validates the transition, emits a structured audit
+// event, and fires the SESSION_HANDOFF refresh hook so other agents see the
+// new state immediately.
+//
+// Backup placement: `<chain-dir>/.backups/state.json.bak.<suffix>.<isoNow>`.
+// H-13 (phase 9) will fold this into a shared backup helper; for now each
+// helper writes directly here so the audit log entries already carry a
+// `backup` field pointing at the right path.
+
+/** Allowed target states for `adjudicate`. */
+const ADJUDICATE_VALID_TARGETS: ReadonlyArray<PhaseStatus> = [
+  'pending',
+  'in_progress',
+  'failed',
+  'blocked',
+  'done',
+];
+
+function requireNonEmptyReason(reason: string | undefined | null): string {
+  const trimmed = (reason ?? '').trim();
+  if (trimmed.length === 0) {
+    throw new Error('reason is required and must be non-empty');
+  }
+  return trimmed;
+}
+
+function backupsDir(ctx: StateContext): string {
+  return join(ctx.paths.baseDir, '.backups');
+}
+
+// Writes a timestamped snapshot of state.json under .backups/ before any
+// adjudication-class mutation. Returns the absolute backup path so the audit
+// event can record where the pre-edit state went. Idempotent if the state
+// file is missing (returns empty string — caller still mutates fresh state).
+export function writeStateBackup(ctx: StateContext, suffix: string): string {
+  if (!existsSync(ctx.paths.stateFile)) return '';
+  const dir = backupsDir(ctx);
+  mkdirSync(dir, { recursive: true });
+  const iso = isoNow().replace(/:/g, '-');
+  const filename = `state.json.bak.${suffix}.${iso}`;
+  const fullPath = join(dir, filename);
+  copyFileSync(ctx.paths.stateFile, fullPath);
+  return fullPath;
+}
+
+export interface AdjudicateOptions {
+  /**
+   * Structured evidence (PR URL, artifact path, doctor report, etc.) that
+   * documents the operator's decision. Persisted into the
+   * `phase_adjudicated` audit event verbatim.
+   */
+  evidence?: Record<string, unknown>;
+  /**
+   * When true, refuse `adjudicate --to done` if the phase's
+   * `success_criteria` cannot be verified from evidence. The full
+   * success-criteria validator lands in a later phase; for now strict-mode
+   * just requires SOME evidence (pr / artifact / verification) to be
+   * present so a `--strict --to done` adjudication can't be totally bare.
+   */
+  strict?: boolean;
+}
+
+export function adjudicate(
+  ctx: StateContext,
+  phaseId: string,
+  toState: PhaseStatus,
+  reason: string,
+  opts: AdjudicateOptions = {},
+): { backup: string; from: PhaseStatus; to: PhaseStatus } {
+  const cleanReason = requireNonEmptyReason(reason);
+  if (!ADJUDICATE_VALID_TARGETS.includes(toState)) {
+    throw new Error(
+      `invalid target state '${toState}': expected one of ${ADJUDICATE_VALID_TARGETS.join(', ')}`,
+    );
+  }
+  const state = loadState(ctx);
+  const ps = ensurePhaseEntry(state, phaseId);
+  const fromState = ps.status;
+  if (opts.strict && toState === 'done') {
+    const ev = opts.evidence ?? {};
+    const hasArtifact =
+      typeof ev['pr'] === 'string' ||
+      typeof ev['artifact'] === 'string' ||
+      typeof ev['verification'] === 'string' ||
+      typeof ev['session_id'] === 'string';
+    if (!hasArtifact) {
+      throw new Error(
+        `strict adjudicate --to done refused: no pr/artifact/verification evidence supplied`,
+      );
+    }
+  }
+  const backup = writeStateBackup(ctx, `pre-adjudicate-${phaseId}-to-${toState}`);
+
+  ps.status = toState;
+  if (toState === 'done') {
+    ps.completed_at = isoNow();
+    ps.error = null;
+    ps.backoff_until = null;
+  } else if (toState === 'pending') {
+    ps.error = null;
+    ps.failure = null;
+    ps.last_failure_class = null;
+    ps.backoff_until = null;
+    ps.session_id = null;
+    ps.started_at = null;
+    ps.completed_at = null;
+  } else if (toState === 'blocked') {
+    ps.error = ps.error ?? cleanReason.slice(0, 500);
+  }
+  // If we just adjudicated the in-progress phase out of in_progress, clear
+  // current_phase too (it would otherwise lie to status callers).
+  if (
+    state.current_phase === Number(phaseId) &&
+    toState !== 'in_progress'
+  ) {
+    state.current_phase = null;
+  }
+  saveState(ctx, state);
+  appendAudit(ctx.paths.auditFile, 'phase_adjudicated', {
+    phase_id: Number(phaseId),
+    from: fromState,
+    to: toState,
+    reason: cleanReason.slice(0, 500),
+    evidence: opts.evidence ?? {},
+    strict: opts.strict ?? false,
+    backup,
+  });
+  fireHandoffRefresh({
+    triggeredBy: `chain-phase-adjudicated-${phaseId}-to-${toState}`,
+  });
+  return { backup, from: fromState, to: toState };
+}
+
+export interface ReArmOptions {
+  /** When true, set ps.attempts back to 0 alongside the status flip. */
+  resetAttempts?: boolean;
+  /** Lift the blocked-only guard. Used when re-arming an in_progress / failed phase. */
+  force?: boolean;
+}
+
+export function reArm(
+  ctx: StateContext,
+  phaseId: string,
+  reason: string,
+  opts: ReArmOptions = {},
+): { backup: string; from: PhaseStatus; attemptsBefore: number; attemptsAfter: number } {
+  const cleanReason = requireNonEmptyReason(reason);
+  const state = loadState(ctx);
+  const ps = ensurePhaseEntry(state, phaseId);
+  const fromState = ps.status;
+  if (fromState !== 'blocked' && !opts.force) {
+    throw new Error(
+      `re-arm refused: phase ${phaseId} is '${fromState}', not 'blocked' (pass force=true to override)`,
+    );
+  }
+  const backup = writeStateBackup(ctx, `pre-rearm-${phaseId}`);
+  const attemptsBefore = ps.attempts;
+  ps.status = 'pending';
+  ps.error = null;
+  ps.backoff_until = null;
+  if (opts.resetAttempts) {
+    ps.attempts = 0;
+  }
+  saveState(ctx, state);
+  appendAudit(ctx.paths.auditFile, 'phase_rearmed', {
+    phase_id: Number(phaseId),
+    from: fromState,
+    reset_attempts: opts.resetAttempts ?? false,
+    attempts_before: attemptsBefore,
+    attempts_after: ps.attempts,
+    reason: cleanReason.slice(0, 500),
+    backup,
+  });
+  fireHandoffRefresh({
+    triggeredBy: `chain-phase-rearmed-${phaseId}`,
+  });
+  return {
+    backup,
+    from: fromState,
+    attemptsBefore,
+    attemptsAfter: ps.attempts,
+  };
+}
+
+export function forceFail(
+  ctx: StateContext,
+  phaseId: string,
+  reason: string,
+): { backup: string; from: PhaseStatus } {
+  const cleanReason = requireNonEmptyReason(reason);
+  const state = loadState(ctx);
+  const ps = ensurePhaseEntry(state, phaseId);
+  const fromState = ps.status;
+  const backup = writeStateBackup(ctx, `pre-force-fail-${phaseId}`);
+  ps.status = 'failed';
+  ps.error = cleanReason.slice(0, 500);
+  const detectedAt = new Date()
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+  const failure: PhaseFailure = {
+    class: 'unknown',
+    reason: cleanReason.slice(0, 500),
+    detected_at: detectedAt,
+    evidence: { source: 'operator_force_fail' },
+  };
+  ps.failure = failure;
+  ps.last_failure_class = 'unknown';
+  ps.backoff_until = null;
+  if (state.current_phase === Number(phaseId)) {
+    state.current_phase = null;
+  }
+  saveState(ctx, state);
+  appendAudit(ctx.paths.auditFile, 'phase_force_failed', {
+    phase_id: Number(phaseId),
+    from: fromState,
+    reason: cleanReason.slice(0, 500),
+    backup,
+  });
+  fireHandoffRefresh({
+    triggeredBy: `chain-phase-force-failed-${phaseId}`,
+  });
+  return { backup, from: fromState };
 }

--- a/packages/chain-runner/tests/adjudicate.test.ts
+++ b/packages/chain-runner/tests/adjudicate.test.ts
@@ -1,0 +1,419 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { makeFixture, type FixtureBundle } from './fixtures.js';
+import {
+  adjudicate,
+  computeNextPhase,
+  evaluateNextPhase,
+  forceFail,
+  initState,
+  loadContext,
+  loadState,
+  markFailed,
+  markInProgress,
+  promoteFailedToBlocked,
+  reArm,
+  type StateContext,
+} from '../src/state.js';
+import type { AuditEvent } from '../src/types.js';
+
+// H-8 / H-21 (chain-runner-battle-harden phase 7, 2026-05-14).
+//
+// Verbs under test:
+//   - adjudicate(ctx, phaseId, toState, reason, opts)
+//   - reArm(ctx, phaseId, reason, opts)
+//   - forceFail(ctx, phaseId, reason)
+//   - promoteFailedToBlocked(ctx, state)
+//   - evaluateNextPhase(state, spec) — pure
+//
+// Coverage:
+//   A01 adjudicate done — round-trip + audit shape + backup written
+//   A02 adjudicate pending — clears error/failure/backoff
+//   A03 adjudicate blocked — keeps error, fires audit
+//   A04 adjudicate validates target state (rejects bogus)
+//   A05 adjudicate requires non-empty reason
+//   A06 adjudicate strict --to done refuses without evidence
+//   A07 adjudicate strict --to done accepts with pr evidence
+//   A08 reArm from blocked → pending (no resetAttempts)
+//   A09 reArm with resetAttempts zeros ps.attempts
+//   A10 reArm refuses non-blocked without force
+//   A11 reArm with force from failed works
+//   A12 reArm requires non-empty reason
+//   A13 forceFail any state → failed, class=unknown, source=operator_force_fail
+//   A14 forceFail requires non-empty reason
+//   A15 backups land under .backups/ with isoNow suffix
+//   A16 evaluateNextPhase is pure (no state mutation, no audit emit)
+//   A17 promoteFailedToBlocked walks failed phases and promotes when retries exhausted
+//   A18 computeNextPhase post-H21 still matches pre-H21 contract for happy path
+//   A19 incident-replay: phase 3 blocked → adjudicate done with pr evidence (the
+//       2026-05-14T07:13:59Z hand-edit pattern, replaced with a sanctioned verb)
+
+let fx: FixtureBundle;
+let ctx: StateContext;
+
+function readAuditEvents(): AuditEvent[] {
+  if (!existsSync(ctx.paths.auditFile)) return [];
+  const raw = readFileSync(ctx.paths.auditFile, 'utf8').trimEnd();
+  if (raw.length === 0) return [];
+  return raw.split('\n').map((line) => JSON.parse(line) as AuditEvent);
+}
+
+function lastAuditOfType(event: string): AuditEvent | undefined {
+  const events = readAuditEvents();
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]?.event === event) return events[i];
+  }
+  return undefined;
+}
+
+function listBackups(): string[] {
+  const dir = join(ctx.paths.baseDir, '.backups');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir);
+}
+
+beforeEach(() => {
+  fx = makeFixture(`adjudicate-${Math.random().toString(36).slice(2, 8)}`);
+  ctx = loadContext(fx.chainId, fx.specPath);
+  initState(ctx);
+  // Disable the handoff refresh hook — test harness should not spawn shells.
+  process.env['CAIA_DISABLE_HANDOFF_REFRESH'] = '1';
+});
+
+afterEach(() => {
+  delete process.env['CAIA_DISABLE_HANDOFF_REFRESH'];
+  fx.cleanup();
+});
+
+describe('A01_adjudicate_to_done', () => {
+  it('round-trips to done + writes audit + writes backup', () => {
+    markInProgress(ctx, '1', 'sess-1');
+    const r = adjudicate(ctx, '1', 'done', 'PR #434 merged; worker hung; verified manually', {
+      evidence: { pr: 'https://github.com/prakashgbid/caia/pull/434' },
+    });
+    expect(r.from).toBe('in_progress');
+    expect(r.to).toBe('done');
+    expect(existsSync(r.backup)).toBe(true);
+
+    const state = loadState(ctx);
+    expect(state.phase_status['1']?.status).toBe('done');
+    expect(state.phase_status['1']?.completed_at).toBeTruthy();
+    expect(state.current_phase).toBeNull();
+
+    const ev = lastAuditOfType('phase_adjudicated');
+    expect(ev).toBeDefined();
+    expect(ev?.['phase_id']).toBe(1);
+    expect(ev?.['from']).toBe('in_progress');
+    expect(ev?.['to']).toBe('done');
+    expect(ev?.['reason']).toContain('PR #434');
+    expect((ev?.['evidence'] as Record<string, unknown>)['pr']).toBe(
+      'https://github.com/prakashgbid/caia/pull/434',
+    );
+    expect(ev?.['backup']).toBeTruthy();
+  });
+});
+
+describe('A02_adjudicate_to_pending_clears_failure_fields', () => {
+  it('clears error/failure/backoff/session/started/completed', () => {
+    markInProgress(ctx, '1', 'sess-1');
+    markFailed(ctx, '1', {
+      class: 'worker_crashed',
+      reason: 'segfault',
+      detected_at: new Date().toISOString(),
+      evidence: {},
+    });
+    adjudicate(ctx, '1', 'pending', 'manual retry after segfault investigation');
+    const ps = loadState(ctx).phase_status['1']!;
+    expect(ps.status).toBe('pending');
+    expect(ps.error).toBeNull();
+    expect(ps.failure).toBeNull();
+    expect(ps.last_failure_class).toBeNull();
+    expect(ps.backoff_until).toBeNull();
+    expect(ps.session_id).toBeNull();
+    expect(ps.started_at).toBeNull();
+    expect(ps.completed_at).toBeNull();
+  });
+});
+
+describe('A03_adjudicate_to_blocked', () => {
+  it('flips to blocked + records reason as error if blank', () => {
+    adjudicate(ctx, '2', 'blocked', 'deps changed upstream — needs rework');
+    const ps = loadState(ctx).phase_status['2']!;
+    expect(ps.status).toBe('blocked');
+    expect(ps.error).toContain('deps changed upstream');
+  });
+});
+
+describe('A04_adjudicate_validates_target', () => {
+  it('rejects an invalid target state', () => {
+    expect(() => adjudicate(ctx, '1', 'banana' as never, 'no')).toThrow(
+      /invalid target state/,
+    );
+  });
+});
+
+describe('A05_adjudicate_requires_reason', () => {
+  it('rejects empty reason', () => {
+    expect(() => adjudicate(ctx, '1', 'done', '')).toThrow(/reason is required/);
+    expect(() => adjudicate(ctx, '1', 'done', '   ')).toThrow(/reason is required/);
+  });
+});
+
+describe('A06_adjudicate_strict_done_refuses_without_evidence', () => {
+  it('strict to done with no pr/artifact/verification throws', () => {
+    expect(() =>
+      adjudicate(ctx, '1', 'done', 'ok', { strict: true, evidence: {} }),
+    ).toThrow(/strict adjudicate --to done refused/);
+  });
+});
+
+describe('A07_adjudicate_strict_done_accepts_with_pr', () => {
+  it('strict to done with pr= evidence succeeds', () => {
+    expect(() =>
+      adjudicate(ctx, '1', 'done', 'verified merged', {
+        strict: true,
+        evidence: { pr: 'https://github.com/x/y/pull/1' },
+      }),
+    ).not.toThrow();
+    expect(loadState(ctx).phase_status['1']?.status).toBe('done');
+  });
+});
+
+describe('A08_reArm_from_blocked', () => {
+  it('flips blocked → pending and emits phase_rearmed', () => {
+    // Drive phase 1 to blocked via markFailed past max_retries
+    markInProgress(ctx, '1', 's');
+    markFailed(ctx, '1', 'first');
+    markFailed(ctx, '1', 'second');
+    markFailed(ctx, '1', 'third');
+    // computeNextPhase will promote it
+    let state = loadState(ctx);
+    computeNextPhase(ctx, state);
+    state = loadState(ctx);
+    expect(state.phase_status['1']?.status).toBe('blocked');
+
+    const r = reArm(ctx, '1', 'operator: third failure was transient');
+    expect(r.from).toBe('blocked');
+    expect(r.attemptsBefore).toBeGreaterThan(0);
+    expect(r.attemptsAfter).toBe(r.attemptsBefore);
+
+    const ps = loadState(ctx).phase_status['1']!;
+    expect(ps.status).toBe('pending');
+    expect(ps.error).toBeNull();
+    expect(ps.backoff_until).toBeNull();
+    const ev = lastAuditOfType('phase_rearmed');
+    expect(ev?.['phase_id']).toBe(1);
+    expect(ev?.['reset_attempts']).toBe(false);
+    expect(ev?.['backup']).toBeTruthy();
+  });
+});
+
+describe('A09_reArm_with_resetAttempts', () => {
+  it('zeros ps.attempts when resetAttempts=true', () => {
+    markInProgress(ctx, '1', 's');
+    markFailed(ctx, '1', 'one');
+    markFailed(ctx, '1', 'two');
+    markFailed(ctx, '1', 'three');
+    computeNextPhase(ctx, loadState(ctx));
+    const r = reArm(ctx, '1', 'reset retry counter for clean slate', {
+      resetAttempts: true,
+    });
+    expect(r.attemptsAfter).toBe(0);
+    expect(loadState(ctx).phase_status['1']?.attempts).toBe(0);
+  });
+});
+
+describe('A10_reArm_refuses_non_blocked', () => {
+  it('refuses to re-arm from in_progress without force', () => {
+    markInProgress(ctx, '1', 's');
+    expect(() => reArm(ctx, '1', 'try anyway')).toThrow(/re-arm refused/);
+  });
+});
+
+describe('A11_reArm_with_force', () => {
+  it('--force lifts the blocked-only guard', () => {
+    markInProgress(ctx, '1', 's');
+    markFailed(ctx, '1', 'transient');
+    expect(() =>
+      reArm(ctx, '1', 'forcing a re-arm from failed', { force: true }),
+    ).not.toThrow();
+    expect(loadState(ctx).phase_status['1']?.status).toBe('pending');
+  });
+});
+
+describe('A12_reArm_requires_reason', () => {
+  it('rejects empty reason', () => {
+    expect(() => reArm(ctx, '1', '')).toThrow(/reason is required/);
+  });
+});
+
+describe('A13_forceFail_flips_to_failed_with_unknown_class', () => {
+  it('any state → failed with source=operator_force_fail', () => {
+    const r = forceFail(ctx, '2', 'operator override: phase outputs invalidated');
+    expect(r.from).toBe('pending');
+    const ps = loadState(ctx).phase_status['2']!;
+    expect(ps.status).toBe('failed');
+    expect(ps.last_failure_class).toBe('unknown');
+    expect(ps.failure?.evidence?.['source']).toBe('operator_force_fail');
+    const ev = lastAuditOfType('phase_force_failed');
+    expect(ev?.['phase_id']).toBe(2);
+    expect(ev?.['from']).toBe('pending');
+  });
+});
+
+describe('A14_forceFail_requires_reason', () => {
+  it('rejects empty reason', () => {
+    expect(() => forceFail(ctx, '1', '')).toThrow(/reason is required/);
+  });
+});
+
+describe('A15_backup_path_shape', () => {
+  it('backup files live under .backups/ with the right prefix', () => {
+    adjudicate(ctx, '1', 'done', 'manual close', {
+      evidence: { pr: 'https://x/pull/1' },
+    });
+    const backups = listBackups();
+    expect(backups.length).toBe(1);
+    expect(backups[0]).toMatch(
+      /^state\.json\.bak\.pre-adjudicate-1-to-done\.\d{4}-\d{2}-\d{2}T/,
+    );
+  });
+});
+
+describe('A16_evaluateNextPhase_is_pure', () => {
+  it('does not mutate state.json, does not append to audit, and matches computeNextPhase for the happy path', () => {
+    const beforeAuditExists = existsSync(ctx.paths.auditFile);
+    const beforeAuditSize = beforeAuditExists
+      ? readFileSync(ctx.paths.auditFile, 'utf8').length
+      : 0;
+    const beforeState = readFileSync(ctx.paths.stateFile, 'utf8');
+
+    const state = loadState(ctx);
+    const r1 = evaluateNextPhase(state, ctx.spec);
+    const r2 = evaluateNextPhase(state, ctx.spec);
+    expect(r1).toEqual(r2);
+    expect(r1.kind).toBe('phase_id');
+    if (r1.kind === 'phase_id') expect(r1.id).toBe(1);
+
+    // No state.json write, no audit append.
+    expect(readFileSync(ctx.paths.stateFile, 'utf8')).toBe(beforeState);
+    const afterAuditSize = existsSync(ctx.paths.auditFile)
+      ? readFileSync(ctx.paths.auditFile, 'utf8').length
+      : 0;
+    expect(afterAuditSize).toBe(beforeAuditSize);
+  });
+
+  it('skips a "would-be-promoted" failed phase (returns next eligible)', () => {
+    // Fail phase 1 past max_retries — without calling promoteFailedToBlocked,
+    // evaluateNextPhase should still treat it as "not dispatchable" (returning
+    // none_eligible if no other phase is eligible).
+    markInProgress(ctx, '1', 's');
+    markFailed(ctx, '1', 'a');
+    markFailed(ctx, '1', 'b');
+    markFailed(ctx, '1', 'c');
+    const state = loadState(ctx);
+    // Phase 1 is still 'failed' in state — promoteFailedToBlocked hasn't run.
+    expect(state.phase_status['1']?.status).toBe('failed');
+    const r = evaluateNextPhase(state, ctx.spec);
+    // Phase 2 depends on 1, so it should not be dispatchable; result should be
+    // none_eligible (the H-21 read-only contract: failed-to-be-blocked is
+    // skipped without mutation).
+    expect(r.kind).toBe('none_eligible');
+    // And state.phase_status[1].status is still 'failed' — no side effect.
+    const after = loadState(ctx);
+    expect(after.phase_status['1']?.status).toBe('failed');
+  });
+});
+
+describe('A17_promoteFailedToBlocked', () => {
+  it('walks failed phases and promotes when retries exhausted', () => {
+    markInProgress(ctx, '1', 's');
+    markFailed(ctx, '1', 'a');
+    markFailed(ctx, '1', 'b');
+    markFailed(ctx, '1', 'c');
+    const state = loadState(ctx);
+    const promoted = promoteFailedToBlocked(ctx, state);
+    expect(promoted).toContain(1);
+    const reloaded = loadState(ctx);
+    expect(reloaded.phase_status['1']?.status).toBe('blocked');
+    const evs = readAuditEvents();
+    const lastBlocked = evs.reverse().find((e) => e.event === 'phase_blocked');
+    expect(lastBlocked?.['phase_id']).toBe(1);
+    expect(lastBlocked?.['reason']).toBe('retries_exhausted');
+  });
+
+  it('is a no-op when no failed phases', () => {
+    const state = loadState(ctx);
+    const promoted = promoteFailedToBlocked(ctx, state);
+    expect(promoted).toEqual([]);
+  });
+});
+
+describe('A18_computeNextPhase_back_compat', () => {
+  it('happy path matches pre-H21 contract: returns phase_id=1 from a fresh init', () => {
+    const r = computeNextPhase(ctx, loadState(ctx));
+    expect(r.kind).toBe('phase_id');
+    if (r.kind === 'phase_id') expect(r.id).toBe(1);
+  });
+
+  it('failed-past-retries still ends in blocked via the combined call', () => {
+    markInProgress(ctx, '1', 's');
+    markFailed(ctx, '1', 'a');
+    markFailed(ctx, '1', 'b');
+    markFailed(ctx, '1', 'c');
+    computeNextPhase(ctx, loadState(ctx));
+    expect(loadState(ctx).phase_status['1']?.status).toBe('blocked');
+  });
+});
+
+describe('A19_incident_replay_phase3_blocked_to_done', () => {
+  it('mirrors the 2026-05-14T07:13:59Z phase-3 hand-edit as a sanctioned adjudicate', () => {
+    // Drive phase 1 + 2 to done so phase 3 is eligible.
+    markInProgress(ctx, '1', 's1');
+    // Force phase 1 done via adjudicate so we don't need real lifecycle.
+    adjudicate(ctx, '1', 'done', 'fast-forward for test setup', {
+      evidence: { test: 'setup' },
+    });
+    adjudicate(ctx, '2', 'done', 'fast-forward for test setup', {
+      evidence: { test: 'setup' },
+    });
+    // Phase 3 starts in_progress, gets stuck, lock goes stale, retries exhaust → blocked.
+    markInProgress(ctx, '3', 'phase3-session');
+    markFailed(ctx, '3', 'stale_lock heartbeat_age_sec=4497');
+    markFailed(ctx, '3', 'stale_lock heartbeat_age_sec=4497');
+    markFailed(ctx, '3', 'stale_lock heartbeat_age_sec=4497');
+    computeNextPhase(ctx, loadState(ctx));
+    expect(loadState(ctx).phase_status['3']?.status).toBe('blocked');
+
+    // The sanctioned recovery: a single adjudicate verb.
+    const r = adjudicate(
+      ctx,
+      '3',
+      'done',
+      'PR #434 merged; worker hung post-success; verified manually',
+      {
+        evidence: {
+          pr: 'https://github.com/prakashgbid/caia/pull/434',
+          incident: '2026-05-14T07:13:59Z',
+        },
+      },
+    );
+    expect(r.from).toBe('blocked');
+    expect(r.to).toBe('done');
+    const ps = loadState(ctx).phase_status['3']!;
+    expect(ps.status).toBe('done');
+    expect(ps.completed_at).toBeTruthy();
+    // Audit shape is phase_adjudicated (NOT a hand-typed phase_done note).
+    const ev = lastAuditOfType('phase_adjudicated');
+    expect(ev?.['from']).toBe('blocked');
+    expect(ev?.['to']).toBe('done');
+    expect((ev?.['evidence'] as Record<string, unknown>)['pr']).toContain('pull/434');
+    expect((ev?.['evidence'] as Record<string, unknown>)['incident']).toBe(
+      '2026-05-14T07:13:59Z',
+    );
+    expect(ev?.['backup']).toBeTruthy();
+    // Backup file exists on disk.
+    expect(existsSync(String(ev?.['backup']))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **H-8**: replaces operator hand-edits of `state.json` with three sanctioned, audited CLI verbs (`adjudicate`, `re-arm`, `force-fail`). Each writes a timestamped backup under `<chain-dir>/.backups/`, validates the transition, emits a structured audit event, and refreshes `SESSION_HANDOFF.md`.
- **H-21**: splits `computeNextPhase` into a pure `evaluateNextPhase(state, spec)` + an explicit `promoteFailedToBlocked(ctx, state)`. New `caia-chain promote-blocked` CLI verb; wake scripts updated to call it between `check-lock-staleness` and `next-phase`. `next-phase --read-only` now skips mutation.
- Incident replay: the 2026-05-14T07:13:59Z phase-3 hand-edit pattern is now expressible as a single `caia-chain adjudicate 3 --to done --reason '...' --evidence pr=...`.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 285 tests pass (22 new in `tests/adjudicate.test.ts`, 263 existing; 79-case regression suite green)
- [x] End-to-end smoke: `init` → `next-phase` (write) → `next-phase --read-only` → `adjudicate 1 --to done --evidence pr=...` → `promote-blocked` → `force-fail` → `re-arm --force` → audit + backup inspection
- [x] Validation guards verified: empty `--reason` rejected; `re-arm` without `--force` from non-blocked rejected; `--strict --to done` without evidence rejected; bogus target state rejected
- [x] Wake scripts (`chain_harden_wake`, `redflag_remediation_wake`, `stability_completion_wake`, `tier25_wake`) updated to call `promote-blocked` between `check-lock-staleness` and `next-phase`

## Command reference
| Verb | Audit event | Backup |
|---|---|---|
| `adjudicate <id> --to <state> --reason <text> [--evidence k=v]* [--strict]` | `phase_adjudicated` | `pre-adjudicate-<id>-to-<state>.<isoNow>` |
| `re-arm <id> --reason <text> [--reset-attempts] [--force]` | `phase_rearmed` | `pre-rearm-<id>.<isoNow>` |
| `force-fail <id> --reason <text>` | `phase_force_failed` | `pre-force-fail-<id>.<isoNow>` |
| `promote-blocked` (H-21) | `phase_blocked` (existing) | n/a |
| `next-phase --read-only` (H-21) | n/a (pure) | n/a |

Part of `chain-runner-battle-harden` phase 7/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)