### PR TITLE
feat(chain-runner): h-11 per-phase heartbeat_grace + h-12 worker-level heartbeat

### DIFF
--- a/packages/chain-runner/src/lock.ts
+++ b/packages/chain-runner/src/lock.ts
@@ -12,7 +12,13 @@ import {
 import { checkArtifact, classifyStaleLock } from './classify.js';
 import type { LockFile, PhaseFailure } from './types.js';
 
-export const HEARTBEAT_GRACE_SEC = 3600; // 60 min
+// H-11 (chain-runner-battle-harden phase 8, 2026-05-14). Legacy fallback used
+// when a PhaseState predates the per-phase `heartbeat_grace_sec` field (i.e.
+// an older state.json loaded after upgrade). New state files resolve the
+// effective grace at buildInitialState — phase override → chain default →
+// DEFAULT_HEARTBEAT_GRACE_SEC (1800s). The CLI `state` command also reads
+// this constant for the at-a-glance "stale" marker on the lock summary line.
+export const HEARTBEAT_GRACE_SEC = 1800; // 30 min
 
 // H-2 (chain-runner-battle-harden phase 3, 2026-05-14). A worker is counted
 // as having run "substantively" if any of these are true at staleness-detect
@@ -150,7 +156,11 @@ export function checkLockStaleness(
   const ranSubstantively =
     hbFired || logBytes > SUBSTANTIVE_LOG_BYTES || art.exists;
 
-  if (ageSec > HEARTBEAT_GRACE_SEC) {
+  // H-11 (phase 8, 2026-05-14). Per-phase grace lives on PhaseState; fall
+  // back to the exported constant only when the state file predates the
+  // field (older chain dirs loaded after upgrade).
+  const graceSec = ps.heartbeat_grace_sec ?? HEARTBEAT_GRACE_SEC;
+  if (ageSec > graceSec) {
     const failure = classifyStaleLock(ctx, lock, {
       trigger: 'heartbeat',
       hb_age_sec: ageSec,

--- a/packages/chain-runner/src/runner.ts
+++ b/packages/chain-runner/src/runner.ts
@@ -95,6 +95,25 @@ You are a spawned worker — operate fully autonomously. Decide-and-act, do NOT 
 - For everything else: pick a path, execute, document the decision in the phase report.
 `;
 
+// H-12 (chain-runner-battle-harden phase 8, 2026-05-14). Worker-level
+// heartbeat instruction. The bash wrapper still fires its own background
+// subshell heartbeat — this is belt-and-suspenders. If the subshell dies
+// (parent shell exits, signal-handler bug, host suspend/resume) the worker
+// itself still reports liveness between tool turns, and the staleness path
+// won't kill it spuriously. Cadence numbers are filled in below from the
+// chain spec so legit-slow phases can stretch the interval to match their
+// per-phase `heartbeat_grace_sec`.
+const HEARTBEAT_INSTRUCTION_TEMPLATE = (
+  cadenceSec: number,
+  cadenceMin: number,
+): string => `## Worker-level heartbeat (H-12, 2026-05-14)
+The chain runner now expects you to emit a liveness heartbeat between tool turns. The bash dispatcher also fires one in the background — your in-prompt heartbeats are the belt-and-suspenders that survive if the background subshell dies.
+
+Cadence: invoke \`caia-chain heartbeat <session>\` **once every 5 tool calls, or every ${cadenceMin} minutes of wall-clock work, whichever comes first** (recommended interval: ~${cadenceSec}s). \`<session>\` is the session id passed to this prompt's dispatch. The call is cheap (single state.json write) and idempotent.
+
+If you skip heartbeats and the worker stalls past the phase's \`heartbeat_grace_sec\` window, the next wake will classify the lock as stale and the phase will fail. Heartbeating loudly is the cheapest insurance against a false-stale.
+`;
+
 export function buildPromptFile(
   ctx: StateContext,
   phaseId: number,
@@ -103,6 +122,14 @@ export function buildPromptFile(
   const phase = findPhase(ctx.spec, phaseId);
   const maxMinutes =
     phase.max_minutes ?? ctx.spec.defaults?.max_minutes ?? 45;
+  // H-12. Cadence advice in the prompt header. Resolution order matches
+  // buildInitialState's H-11 grace resolution one step removed:
+  //   chain defaults.heartbeat_interval_sec → 600s (10 min) fallback.
+  // Per-phase override of cadence is not currently supported; the
+  // single-knob design keeps the prompt readable and the worker's
+  // mental model simple.
+  const cadenceSec = ctx.spec.defaults?.heartbeat_interval_sec ?? 600;
+  const cadenceMin = Math.max(1, Math.round(cadenceSec / 60));
   const header = `# PHASE ${phaseId} OF ${totalPhases} — autonomous run
 
 You are running phase ${phaseId} of the chain. The orchestrator dispatched you with all context.
@@ -111,6 +138,7 @@ Operate fully autonomously:
 - DO NOT return for clarification. Make best informed decisions and document them.
 - Stay within budget: max ${maxMinutes} minutes wall-clock.
 
+${HEARTBEAT_INSTRUCTION_TEMPLATE(cadenceSec, cadenceMin)}
 ${AUTONOMY_DIRECTIVE}
 Your task starts below:
 ---

--- a/packages/chain-runner/src/state.ts
+++ b/packages/chain-runner/src/state.ts
@@ -26,6 +26,15 @@ import type {
 export const SCHEMA_VERSION = 1;
 export const DEFAULT_BUDGET_CAP_PCT = 25;
 
+// H-11 (chain-runner-battle-harden phase 8, 2026-05-14). Default heartbeat
+// staleness grace in seconds. Reduced from the pre-H-11 60-minute constant
+// to 30 minutes: observed worker wakes fire every 15 min, so two missed
+// heartbeats is sufficient evidence of a hung worker. Phases can widen the
+// window via `phases[].heartbeat_grace_sec`; chains can widen via
+// `defaults.heartbeat_grace_sec`. lock.ts:HEARTBEAT_GRACE_SEC remains as the
+// final fallback for unmigrated state files.
+export const DEFAULT_HEARTBEAT_GRACE_SEC = 1800;
+
 export interface StateContext {
   paths: ChainPaths;
   spec: ChainSpec;
@@ -53,6 +62,14 @@ export function buildInitialState(spec: ChainSpec): StateFile {
       failure: null,
       last_failure_class: null,
       backoff_until: null,
+      // H-11 (phase 8, 2026-05-14). Resolution order:
+      //   phase override → chain default → DEFAULT_HEARTBEAT_GRACE_SEC.
+      // Resolved once at init so checkLockStaleness can read it off
+      // PhaseState without re-walking the spec on every staleness check.
+      heartbeat_grace_sec:
+        p.heartbeat_grace_sec ??
+        defaults.heartbeat_grace_sec ??
+        DEFAULT_HEARTBEAT_GRACE_SEC,
     };
   }
   return {

--- a/packages/chain-runner/src/types.ts
+++ b/packages/chain-runner/src/types.ts
@@ -13,6 +13,15 @@ export interface PhaseDefinition {
   max_minutes?: number;
   prompt_template?: string;
   success_criteria?: Record<string, unknown>;
+  /**
+   * H-11 (chain-runner-battle-harden phase 8, 2026-05-14). Per-phase override
+   * for the staleness grace window (seconds). When omitted the phase inherits
+   * `defaults.heartbeat_grace_sec` from the spec, which itself falls back to
+   * the `DEFAULT_HEARTBEAT_GRACE_SEC = 1800` constant in state.ts.
+   * Legit-slow phases (Phase 11 of self-hosting chains often take >30 min) can
+   * widen the window; impatient detection phases can narrow it.
+   */
+  heartbeat_grace_sec?: number;
   [k: string]: unknown;
 }
 
@@ -41,6 +50,12 @@ export interface ChainDefaults {
   max_retries?: number;
   max_minutes?: number;
   heartbeat_interval_sec?: number;
+  /**
+   * H-11 (chain-runner-battle-harden phase 8, 2026-05-14). Chain-wide
+   * heartbeat staleness grace (seconds). Per-phase overrides win; this is
+   * the second-tier fallback. Omitted → DEFAULT_HEARTBEAT_GRACE_SEC (1800).
+   */
+  heartbeat_grace_sec?: number;
   /** H-9: per-FailureClass retry policy. Missing classes inherit DEFAULT_RETRY_POLICY. */
   retry_policy?: Partial<Record<FailureClass, RetryPolicyEntry>>;
 }
@@ -113,6 +128,15 @@ export interface PhaseState {
    * retry policy for the class has a `backoff_sec` schedule.
    */
   backoff_until?: string | null;
+  /**
+   * H-11 (chain-runner-battle-harden phase 8, 2026-05-14). Resolved at
+   * buildInitialState from (phase override → chain default → 1800s) and
+   * frozen into state so checkLockStaleness reads the per-phase grace
+   * without re-walking the spec. Optional in the schema so older state
+   * files load without a migration; lock.checkLockStaleness falls back to
+   * DEFAULT_HEARTBEAT_GRACE_SEC when undefined.
+   */
+  heartbeat_grace_sec?: number;
 }
 
 export interface StateFile {

--- a/packages/chain-runner/tests/heartbeat-config.test.ts
+++ b/packages/chain-runner/tests/heartbeat-config.test.ts
@@ -1,0 +1,173 @@
+// H-11 (chain-runner-battle-harden phase 8, 2026-05-14). Per-phase
+// configurable heartbeat grace. Cases verify the resolution order
+//   phase override → chain default → DEFAULT_HEARTBEAT_GRACE_SEC (1800s).
+//
+// Each case acquires a lock, backdates its heartbeat by a chosen number of
+// seconds, and asserts that checkLockStaleness either fires staleness or
+// keeps the lock live based on the effective grace for that phase.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildInitialState,
+  DEFAULT_HEARTBEAT_GRACE_SEC,
+  loadContext,
+  markInProgress,
+  type StateContext,
+} from '../src/state.js';
+import {
+  acquireLock,
+  checkLockStaleness,
+  loadLock,
+  saveLock,
+} from '../src/lock.js';
+import type { LockFile } from '../src/types.js';
+
+interface MiniFixture {
+  ctx: StateContext;
+  cleanup: () => void;
+}
+
+function makeSpecFixture(specYaml: string): MiniFixture {
+  const root = mkdtempSync(join(tmpdir(), `caia-hb-cfg-`));
+  const chainHome = join(root, 'chain');
+  mkdirSync(chainHome, { recursive: true });
+  const specPath = join(root, 'phases.yaml');
+  writeFileSync(specPath, specYaml);
+  process.env['CAIA_CHAIN_HOME'] = chainHome;
+  process.env['CAIA_ALERT_INBOX_PATH'] = join(root, 'INBOX.md');
+  process.env['CAIA_ALERT_HANDOFF_JSONL_PATH'] = join(root, 'active_alerts.jsonl');
+  process.env['CAIA_ALERT_DEDUPE_PATH'] = join(root, '.alert-dedupe.json');
+  process.env['CAIA_DISABLE_NOTIFICATIONS'] = '1';
+  const chainId = `hb-cfg-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const ctx = loadContext(chainId, specPath);
+  return {
+    ctx,
+    cleanup: () => {
+      delete process.env['CAIA_CHAIN_HOME'];
+      delete process.env['CAIA_ALERT_INBOX_PATH'];
+      delete process.env['CAIA_ALERT_HANDOFF_JSONL_PATH'];
+      delete process.env['CAIA_ALERT_DEDUPE_PATH'];
+      delete process.env['CAIA_DISABLE_NOTIFICATIONS'];
+    },
+  };
+}
+
+function isoSecondsAgo(sec: number): string {
+  return new Date(Date.now() - sec * 1000)
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+}
+
+let fx: MiniFixture | null = null;
+afterEach(() => {
+  fx?.cleanup();
+  fx = null;
+});
+
+describe('H-11 per-phase heartbeat_grace_sec', () => {
+  // Case 1: default (no phase override, no chain default) → 1800s.
+  // Heartbeat backdated 2000s → exceeds 1800s default → staleness fires.
+  it('case 1: no override → DEFAULT_HEARTBEAT_GRACE_SEC=1800; 2000s-old hb is stale', () => {
+    fx = makeSpecFixture(`defaults:
+  max_minutes: 60
+phases:
+  - id: 1
+    name: phase_default
+    deps: []
+    prompt_template: |
+      x
+`);
+    const { ctx } = fx;
+    // Sanity-check buildInitialState wrote the resolved grace.
+    const initial = buildInitialState(ctx.spec);
+    expect(initial.phase_status['1']?.heartbeat_grace_sec).toBe(
+      DEFAULT_HEARTBEAT_GRACE_SEC,
+    );
+    markInProgress(ctx, '1', 'sess-c1');
+    acquireLock(ctx, 1, 'sess-c1');
+    const lock = loadLock(ctx) as LockFile;
+    saveLock(ctx, { ...lock, heartbeat: isoSecondsAgo(2000) });
+    const r = checkLockStaleness(ctx);
+    expect(r.kind).toBe('cleared');
+    if (r.kind === 'cleared') expect(r.reason).toBe('heartbeat');
+  });
+
+  // Case 2: per-phase override of 4h (14400s). A 90-min-old heartbeat is
+  // stale under the old 3600s default and the new 1800s default — but the
+  // override widens the grace, so the lock must remain live. This is the
+  // legit-slow-phase scenario (e.g. a long bake / training step).
+  it('case 2: phase override widens grace → 90-min-old hb stays live', () => {
+    fx = makeSpecFixture(`defaults:
+  max_minutes: 600
+phases:
+  - id: 1
+    name: phase_slow
+    deps: []
+    heartbeat_grace_sec: 14400
+    prompt_template: |
+      x
+`);
+    const { ctx } = fx;
+    const initial = buildInitialState(ctx.spec);
+    expect(initial.phase_status['1']?.heartbeat_grace_sec).toBe(14400);
+    markInProgress(ctx, '1', 'sess-c2');
+    acquireLock(ctx, 1, 'sess-c2');
+    const lock = loadLock(ctx) as LockFile;
+    saveLock(ctx, { ...lock, heartbeat: isoSecondsAgo(90 * 60) });
+    const r = checkLockStaleness(ctx);
+    expect(r.kind).toBe('live');
+  });
+
+  // Case 3: chain default 900s; a 1000s-old heartbeat trips it. Proves the
+  // chain default applies when the phase has no override.
+  it('case 3: chain default 900s narrows grace → 1000s-old hb fires staleness', () => {
+    fx = makeSpecFixture(`defaults:
+  max_minutes: 60
+  heartbeat_grace_sec: 900
+phases:
+  - id: 1
+    name: phase_tight
+    deps: []
+    prompt_template: |
+      x
+`);
+    const { ctx } = fx;
+    const initial = buildInitialState(ctx.spec);
+    expect(initial.phase_status['1']?.heartbeat_grace_sec).toBe(900);
+    markInProgress(ctx, '1', 'sess-c3');
+    acquireLock(ctx, 1, 'sess-c3');
+    const lock = loadLock(ctx) as LockFile;
+    saveLock(ctx, { ...lock, heartbeat: isoSecondsAgo(1000) });
+    const r = checkLockStaleness(ctx);
+    expect(r.kind).toBe('cleared');
+    if (r.kind === 'cleared') expect(r.reason).toBe('heartbeat');
+  });
+
+  // Case 4: phase override beats chain default. Chain default is 600s,
+  // phase widens to 7200s, and a 30-min-old heartbeat stays live.
+  it('case 4: phase override beats chain default — phase wins', () => {
+    fx = makeSpecFixture(`defaults:
+  max_minutes: 600
+  heartbeat_grace_sec: 600
+phases:
+  - id: 1
+    name: phase_overrides
+    deps: []
+    heartbeat_grace_sec: 7200
+    prompt_template: |
+      x
+`);
+    const { ctx } = fx;
+    const initial = buildInitialState(ctx.spec);
+    expect(initial.phase_status['1']?.heartbeat_grace_sec).toBe(7200);
+    markInProgress(ctx, '1', 'sess-c4');
+    acquireLock(ctx, 1, 'sess-c4');
+    const lock = loadLock(ctx) as LockFile;
+    saveLock(ctx, { ...lock, heartbeat: isoSecondsAgo(30 * 60) });
+    const r = checkLockStaleness(ctx);
+    expect(r.kind).toBe('live');
+  });
+});

--- a/packages/chain-runner/tests/regression.test.ts
+++ b/packages/chain-runner/tests/regression.test.ts
@@ -33,7 +33,7 @@ import type { LockFile } from '../src/types.js';
 //   P01_fresh_init                  — fresh state returns phase 1 in 5 boot orders
 //   P02_next_phase_advancement      — mark-done N advances to N+1 for N in {1..5}
 //   P03_lock_live                   — lock present, age < 60min, returns IN_PROGRESS
-//   P04_stale_heartbeat             — heartbeat older than 60min triggers staleness recovery
+//   P04_stale_heartbeat             — heartbeat older than the per-phase grace (default 30min after H-11) triggers staleness recovery
 //   P05_runtime_timeout             — runtime > max_minutes triggers staleness recovery
 //   P06_retries_exhausted           — phase failed > max_retries → blocked, skipped
 //   P07_paused                      — paused state suppresses dispatch
@@ -115,15 +115,20 @@ describe('P03_lock_live', () => {
 });
 
 describe('P04_stale_heartbeat', () => {
-  // Heartbeats older than 60min ago should trigger staleness clearing.
+  // H-11 (phase 8, 2026-05-14). The default grace is now 1800s (30 min);
+  // ages used here [1, 2, 4, 12, 25]h all comfortably exceed it. The 4h case
+  // is retained as an above-old-default-3600s anchor so this suite still
+  // proves we haven't regressed into a >1h-grace surprise. The 1h case is
+  // the tight-margin probe just past the new 30-min default.
+  const ageHours = [1, 2, 4, 12, 25];
   for (let i = 1; i <= 5; i++) {
-    it(`case ${i}: heartbeat aged ${[2, 3, 6, 12, 25][i - 1]}h → cleared`, () => {
+    it(`case ${i}: heartbeat aged ${ageHours[i - 1]}h → cleared`, () => {
       freshInit();
       markInProgress(ctx, '1', `sess-stale-${i}`);
       acquireLock(ctx, 1, `sess-stale-${i}`);
       const lock = loadLock(ctx);
       expect(lock).not.toBeNull();
-      const hoursAgo = [2, 3, 6, 12, 25][i - 1] ?? 2;
+      const hoursAgo = ageHours[i - 1] ?? 2;
       const past = new Date(Date.now() - hoursAgo * 3600 * 1000)
         .toISOString()
         .replace(/\.\d{3}Z$/, 'Z');
@@ -379,7 +384,10 @@ describe('regression coverage gates', () => {
     expect(s.phase_status['13']).toBeDefined();
   });
 
-  it('HEARTBEAT_GRACE_SEC is 60 minutes', () => {
-    expect(HEARTBEAT_GRACE_SEC).toBe(3600);
+  it('HEARTBEAT_GRACE_SEC fallback constant is 30 minutes (H-11 default)', () => {
+    // H-11 (phase 8, 2026-05-14). The exported constant is now only the
+    // legacy fallback for unmigrated PhaseStates. New chains resolve grace
+    // from phase override → chain default → DEFAULT_HEARTBEAT_GRACE_SEC.
+    expect(HEARTBEAT_GRACE_SEC).toBe(1800);
   });
 });


### PR DESCRIPTION
## Summary
- **H-11**: per-phase configurable heartbeat staleness grace; default reduced from 3600s → 1800s. Resolution order at `buildInitialState`: phase override → chain default → `DEFAULT_HEARTBEAT_GRACE_SEC`. `checkLockStaleness` reads from `PhaseState` so legacy state files still degrade gracefully via the `HEARTBEAT_GRACE_SEC` fallback constant (also bumped to 1800).
- **H-12**: prompt header instructs the spawned worker to invoke `caia-chain heartbeat <session>` every 5 tool calls / 10 min of wall-clock work. Cadence taken from `defaults.heartbeat_interval_sec`. Belt-and-suspenders to the bash dispatcher's background subshell.

## Files
- `src/types.ts` — `PhaseDefinition.heartbeat_grace_sec?`, `ChainDefaults.heartbeat_grace_sec?`, `PhaseState.heartbeat_grace_sec?`.
- `src/state.ts` — `DEFAULT_HEARTBEAT_GRACE_SEC = 1800`; `buildInitialState` stamps resolved grace per phase.
- `src/lock.ts` — `HEARTBEAT_GRACE_SEC = 1800` (legacy fallback); `checkLockStaleness` reads `ps.heartbeat_grace_sec`.
- `src/runner.ts` — `buildPromptFile` emits the H-12 heartbeat instruction block.
- `tests/regression.test.ts` — P04 ages reworked around the 1800s default (1h..25h, with a 4h anchor for >1h coverage); `HEARTBEAT_GRACE_SEC` assertion updated.
- `tests/heartbeat-config.test.ts` (new) — 4 cases covering the override matrix.

## Default-reduction safety
The change is a tightening of detection. Verified before merge: the only chain currently using this code path is `chain-runner-battle-harden` itself, which does **not** set `defaults.heartbeat_grace_sec` and currently runs under the constant. Worker wakes are 15 min, so two missed heartbeats (1800s) is sufficient evidence of a hung worker.

## Test plan
- [x] vitest run — **289 tests pass** (15 files, +4 new heartbeat-config cases)
- [x] tsc --noEmit clean
- [x] eslint src clean
- [x] manual buildPromptFile smoke test — heartbeat block + cadence values rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)