### PR TITLE
feat(apprentice-retrainer): APP.2 — gate retrainer on corpus quality

### DIFF
--- a/packages/apprentice-retrainer/src/config.ts
+++ b/packages/apprentice-retrainer/src/config.ts
@@ -9,6 +9,7 @@ import { DefaultFsAccess } from './fs-access.js';
 const DEFAULT_RUN_STATE = '~/Documents/projects/apprentice/retrainer-state.json';
 const DEFAULT_DIGEST = '~/Documents/projects/reports/apprentice-retrainer-digest.md';
 const DEFAULT_LOCKFILE = '~/Documents/projects/apprentice/retrainer.lock';
+const DEFAULT_AUDIT = '~/.chiefaia/apprentice-retrainer/audit.jsonl';
 
 export function expandHome(p: string): string {
   if (p.startsWith('~/')) return path.join(homedir(), p.slice(2));
@@ -23,11 +24,14 @@ export function resolveConfig(cfg: ApprenticeRetrainerConfig = {}): ResolvedRetr
     runStatePath: expandHome(cfg.runStatePath ?? DEFAULT_RUN_STATE),
     digestPath: expandHome(cfg.digestPath ?? DEFAULT_DIGEST),
     lockfilePath: expandHome(cfg.lockfilePath ?? DEFAULT_LOCKFILE),
+    auditPath: expandHome(cfg.auditPath ?? DEFAULT_AUDIT),
     retrainThreshold: cfg.retrainThreshold ?? 500,
     retrainMaxAgeMs: cfg.retrainMaxAgeMs ?? 7 * 24 * 60 * 60 * 1000,
     evalWinRateGate: cfg.evalWinRateGate ?? 0.6,
     defaultCanaryPercent: cfg.defaultCanaryPercent ?? 10,
     canaryHoldDays: cfg.canaryHoldDays ?? 3,
+    qualityFloorAvg: cfg.qualityFloorAvg ?? 0.55,
+    qualityFloorCount: cfg.qualityFloorCount ?? 300,
     fs,
     clock
   };

--- a/packages/apprentice-retrainer/src/digest.ts
+++ b/packages/apprentice-retrainer/src/digest.ts
@@ -74,6 +74,8 @@ function humanLabel(o: RetrainerOutcome): string {
       return 'trained + promoted to canary';
     case 'canary-held-prompting-operator':
       return 'CANARY HELD — operator action required';
+    case 'gated-pending-quality':
+      return 'gated (corpus below quality floor)';
     case 'failed':
       return 'FAILED';
   }
@@ -141,6 +143,16 @@ export function renderBody(result: RetrainerRunResult, evalReport?: EvalAdapterR
         `- Canary adapter: ${result.canary.adapterName}`,
         `- Canary model: ${result.canary.ollamaModelName ?? '(unset)'}`,
         `- Canary percent: ${result.canary.canaryPercent ?? '(unset)'}`
+      ].join('\n');
+    case 'gated-pending-quality':
+      return [
+        `Corpus below quality floor; training skipped.`,
+        ``,
+        `- Avg quality: ${result.avg.toFixed(3)}`,
+        `- Final count: ${result.count}`,
+        `- Reason: ${result.reason}`,
+        ``,
+        `Cron will retry on next scheduled tick. Gate auto-opens once corpus quality lifts.`
       ].join('\n');
     case 'failed':
       return [

--- a/packages/apprentice-retrainer/src/index.ts
+++ b/packages/apprentice-retrainer/src/index.ts
@@ -19,6 +19,17 @@ export {
   shouldRetrainGivenDelta
 } from './decision.js';
 export type { Decision, PostTrainDecision, DecisionInput, PostTrainDecisionInput } from './decision.js';
+export {
+  appendAuditRow,
+  averageQualityFromHistogram,
+  decideQualityGate
+} from './quality-gate.js';
+export type {
+  AuditAppendOptions,
+  CorpusManifestLike,
+  QualityGateDecision,
+  QualityGateInput
+} from './quality-gate.js';
 
 export type {
   ApprenticeRetrainerConfig,

--- a/packages/apprentice-retrainer/src/quality-gate.ts
+++ b/packages/apprentice-retrainer/src/quality-gate.ts
@@ -1,0 +1,98 @@
+/**
+ * APP.2 / A.10.2 — pre-train corpus-quality gate.
+ *
+ * Read the corpus manifest produced by `apprentice-corpus` and decide whether
+ * the retrainer should proceed or skip with a clean `gated-pending-quality`
+ * outcome. The gate fires *before* training so the Saturday 02:00 cron does
+ * not burn M3 cycles on an obviously-underqualified corpus.
+ *
+ * Histogram → average: weighted-mean over fixed 0.2-wide bins; bin midpoints
+ * are 0.1 / 0.3 / 0.5 / 0.7 / 0.9. Empty histogram → 0.
+ */
+import type { FsAccess } from './types.js';
+
+/** Subset of CorpusManifest shape we need; kept structurally typed to avoid
+ *  a build-time dep on `@chiefaia/apprentice-corpus`. */
+export interface CorpusManifestLike {
+  totals?: { final?: number };
+  qualityHistogram?: Record<string, number>;
+}
+
+export interface QualityGateInput {
+  manifest: CorpusManifestLike;
+  qualityFloorAvg: number;
+  qualityFloorCount: number;
+}
+
+export interface QualityGateDecision {
+  pass: boolean;
+  avg: number;
+  count: number;
+  /** Empty when pass=true; human-readable cause when pass=false. */
+  reason: string;
+}
+
+const BIN_MIDPOINTS: Record<string, number> = {
+  '0.0-0.2': 0.1,
+  '0.2-0.4': 0.3,
+  '0.4-0.6': 0.5,
+  '0.6-0.8': 0.7,
+  '0.8-1.0': 0.9
+};
+
+export function averageQualityFromHistogram(
+  histogram: Record<string, number> | undefined
+): number {
+  if (histogram === undefined) return 0;
+  let weightedSum = 0;
+  let total = 0;
+  for (const [bin, count] of Object.entries(histogram)) {
+    const mid = BIN_MIDPOINTS[bin];
+    if (mid === undefined) continue;
+    const n = Number(count);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    weightedSum += mid * n;
+    total += n;
+  }
+  return total === 0 ? 0 : weightedSum / total;
+}
+
+export function decideQualityGate(input: QualityGateInput): QualityGateDecision {
+  const count = input.manifest.totals?.final ?? 0;
+  const avg = averageQualityFromHistogram(input.manifest.qualityHistogram);
+  const lowAvg = avg < input.qualityFloorAvg;
+  const lowCount = count < input.qualityFloorCount;
+  if (!lowAvg && !lowCount) {
+    return { pass: true, avg, count, reason: '' };
+  }
+  const reasons: string[] = [];
+  if (lowAvg) reasons.push(`avg=${avg.toFixed(3)} < floor=${input.qualityFloorAvg}`);
+  if (lowCount) reasons.push(`count=${count} < floor=${input.qualityFloorCount}`);
+  return { pass: false, avg, count, reason: reasons.join('; ') };
+}
+
+export interface AuditAppendOptions {
+  fs: FsAccess;
+  auditPath: string;
+  /** Already-stringified JSONL row, NO trailing newline. */
+  jsonRow: string;
+}
+
+/**
+ * Append a single JSONL row to the audit log. Creates parent dirs as needed.
+ * Append-only — never reads or truncates the existing file.
+ */
+export function appendAuditRow(opts: AuditAppendOptions): void {
+  const parentSep = opts.auditPath.lastIndexOf('/');
+  if (parentSep > 0) {
+    const dir = opts.auditPath.slice(0, parentSep);
+    if (!opts.fs.exists(dir)) opts.fs.mkdir(dir);
+  }
+  const line = opts.jsonRow + '\n';
+  if (opts.fs.appendFile !== undefined) {
+    opts.fs.appendFile(opts.auditPath, line);
+    return;
+  }
+  const existing = opts.fs.exists(opts.auditPath) ? opts.fs.readFile(opts.auditPath) : '';
+  opts.fs.writeFile(opts.auditPath, existing + line);
+}

--- a/packages/apprentice-retrainer/src/retrainer.ts
+++ b/packages/apprentice-retrainer/src/retrainer.ts
@@ -36,6 +36,11 @@ import {
   preTrainDecision,
   shouldRetrainGivenDelta
 } from './decision.js';
+import {
+  appendAuditRow,
+  decideQualityGate,
+  type CorpusManifestLike
+} from './quality-gate.js';
 
 export class ApprenticeRetrainer {
   private readonly cfg: ResolvedRetrainerConfig;
@@ -223,6 +228,13 @@ export class ApprenticeRetrainer {
       throw new CorpusFailedError((e as Error).message, { cause: (e as Error).name });
     }
 
+    // ── APP.2 quality gate ──
+    // Read the manifest the aggregator wrote and decide whether the corpus
+    // is good enough to burn an M3 training run on. A clean skip (`exit 0`
+    // at the CLI layer) — operator sees the gate fired, cron does not alarm.
+    const gateOutcome = this.evaluateQualityGate(aggregateResult.manifestPath);
+    if (gateOutcome !== null) return gateOutcome;
+
     // Delta gate — caller hasn't checked count yet at decision time.
     const isAged = state.lastSuccessfulTrain !== null
       ? this.cfg.clock().getTime() - new Date(state.lastSuccessfulTrain.at).getTime() >= this.cfg.retrainMaxAgeMs
@@ -333,6 +345,62 @@ export class ApprenticeRetrainer {
       at: this.cfg.clock().toISOString(),
       outcome: 'trained-and-rejected',
       body: renderBody(result, evalReport)
+    });
+    return result;
+  }
+
+  /**
+   * APP.2 — pre-train corpus-quality check.
+   *
+   * Returns a `gated-pending-quality` result if the corpus is under-qualified
+   * (avg histogram < floor OR final count < floor); otherwise null and the
+   * caller proceeds to training.
+   *
+   * Side-effects on the gated path: structured event written to stdout
+   * (machine-parseable for cron tail / launchd log capture) AND appended to
+   * the audit JSONL trail; state + digest record the outcome so the operator
+   * digest reflects the skip.
+   */
+  private evaluateQualityGate(manifestPath: string): RetrainerRunResult | null {
+    let manifest: CorpusManifestLike;
+    try {
+      manifest = JSON.parse(this.cfg.fs.readFile(manifestPath)) as CorpusManifestLike;
+    } catch (e) {
+      // Unreadable / malformed manifest — surface as CorpusFailedError so it
+      // routes through the normal failure path rather than silently gating.
+      throw new CorpusFailedError(`failed to read manifest at ${manifestPath}: ${(e as Error).message}`);
+    }
+    const decision = decideQualityGate({
+      manifest,
+      qualityFloorAvg: this.cfg.qualityFloorAvg,
+      qualityFloorCount: this.cfg.qualityFloorCount
+    });
+    if (decision.pass) return null;
+
+    const at = this.cfg.clock().toISOString();
+    const event = {
+      event: 'gated-pending-quality',
+      avg: Number(decision.avg.toFixed(4)),
+      count: decision.count
+    };
+    process.stdout.write(JSON.stringify(event) + '\n');
+    appendAuditRow({
+      fs: this.cfg.fs,
+      auditPath: this.cfg.auditPath,
+      jsonRow: JSON.stringify({ at, ...event, reason: decision.reason })
+    });
+
+    const result: RetrainerRunResult = {
+      kind: 'gated-pending-quality',
+      avg: event.avg,
+      count: event.count,
+      reason: decision.reason
+    };
+    this.state.recordOutcome('gated-pending-quality', { note: decision.reason });
+    this.digest.appendEntry({
+      at,
+      outcome: 'gated-pending-quality',
+      body: renderBody(result)
     });
     return result;
   }

--- a/packages/apprentice-retrainer/src/types.ts
+++ b/packages/apprentice-retrainer/src/types.ts
@@ -109,6 +109,7 @@ export type RetrainerOutcome =
   | 'trained-and-rejected'
   | 'trained-and-canary-promoted'
   | 'canary-held-prompting-operator'
+  | 'gated-pending-quality'
   | 'failed';
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -121,6 +122,7 @@ export type RetrainerRunResult =
   | { kind: 'trained-and-rejected'; adapterPath: string; reason: string; evalReport?: EvalAdapterReport }
   | { kind: 'trained-and-canary-promoted'; adapterPath: string; canaryPercent: number; evalReport?: EvalAdapterReport }
   | { kind: 'canary-held-prompting-operator'; canary: RegistryEntry; daysHeld: number }
+  | { kind: 'gated-pending-quality'; avg: number; count: number; reason: string }
   | { kind: 'failed'; error: { message: string; kind: string } };
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -148,6 +150,8 @@ export interface ApprenticeRetrainerConfig {
   digestPath?: string;
   /** Default: ~/Documents/projects/apprentice/retrainer.lock */
   lockfilePath?: string;
+  /** Default: ~/.chiefaia/apprentice-retrainer/audit.jsonl */
+  auditPath?: string;
 
   /** Default: 500 — minimum new pairs to trigger retrain. */
   retrainThreshold?: number;
@@ -159,6 +163,10 @@ export interface ApprenticeRetrainerConfig {
   defaultCanaryPercent?: number;
   /** Default: 3 — days a canary must hold before operator-prompt. */
   canaryHoldDays?: number;
+  /** Default: 0.55 — minimum corpus quality average (weighted bin midpoint) below which the retrainer gates. */
+  qualityFloorAvg?: number;
+  /** Default: 300 — minimum corpus.totals.final below which the retrainer gates. */
+  qualityFloorCount?: number;
 
   // — injected pipelines (Option E) —
   corpusAggregator?: CorpusAggregator;

--- a/packages/apprentice-retrainer/tests/helpers/fakes.ts
+++ b/packages/apprentice-retrainer/tests/helpers/fakes.ts
@@ -316,6 +316,45 @@ export function createFakeServing(
   return fake as unknown as ApprenticeServing & { fakeState: FakeServingState };
 }
 
+/**
+ * Build a corpus-manifest JSON body that PASSES the APP.2 quality gate
+ * (avg >= 0.55, count >= 300). Override `totals.final` / `qualityHistogram`
+ * to exercise the failing branch.
+ */
+export function passingManifest(
+  overrides: { totals?: { final?: number }; qualityHistogram?: Record<string, number> } = {}
+): string {
+  const totalsFinal = overrides.totals?.final ?? 600;
+  const histogram = overrides.qualityHistogram ?? {
+    '0.0-0.2': 0,
+    '0.2-0.4': 0,
+    '0.4-0.6': 200,
+    '0.6-0.8': 300,
+    '0.8-1.0': 100
+  };
+  return JSON.stringify({
+    version: 1,
+    generatedAt: '2026-05-13T00:00:00.000Z',
+    outputDir: '/c/2026-05-13',
+    elapsedMs: 1234,
+    totals: {
+      rawArtifacts: totalsFinal,
+      afterDedup: totalsFinal,
+      afterPII: totalsFinal,
+      afterQuality: totalsFinal,
+      distilled: 0,
+      dropped: 0,
+      final: totalsFinal
+    },
+    perSource: {},
+    redactedSpansHistogram: {},
+    qualityHistogram: histogram,
+    configSha256: 'cfg-sha',
+    warnings: [],
+    holdout: []
+  });
+}
+
 export function createFakeClock(start = '2026-05-06T02:00:00.000Z'): {
   clock: () => Date;
   advance(ms: number): void;

--- a/packages/apprentice-retrainer/tests/quality-gate.test.ts
+++ b/packages/apprentice-retrainer/tests/quality-gate.test.ts
@@ -1,0 +1,289 @@
+/**
+ * APP.2 quality-gate — unit tests.
+ *
+ * Two layers:
+ *   - Pure: `averageQualityFromHistogram` and `decideQualityGate` cover both
+ *     gate branches without any retrainer wiring.
+ *   - Wired: `ApprenticeRetrainer.run()` end-to-end covers
+ *       below-floor → `gated-pending-quality` (no train, audit row appended)
+ *       above-floor → train proceeds through to canary promotion.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApprenticeRetrainer } from '../src/retrainer.js';
+import {
+  averageQualityFromHistogram,
+  decideQualityGate
+} from '../src/quality-gate.js';
+import {
+  createFakeClock,
+  createFakeCorpusAggregator,
+  createFakeEvalHarness,
+  createFakeServing,
+  createFakeTrainer,
+  createInMemoryFs,
+  passingManifest
+} from './helpers/fakes.js';
+
+describe('averageQualityFromHistogram', () => {
+  it('returns 0 for empty / undefined / all-zero histograms', () => {
+    expect(averageQualityFromHistogram(undefined)).toBe(0);
+    expect(averageQualityFromHistogram({})).toBe(0);
+    expect(
+      averageQualityFromHistogram({
+        '0.0-0.2': 0,
+        '0.2-0.4': 0,
+        '0.4-0.6': 0,
+        '0.6-0.8': 0,
+        '0.8-1.0': 0
+      })
+    ).toBe(0);
+  });
+
+  it('weights bin midpoints by their counts', () => {
+    // 100 @ 0.1 + 100 @ 0.9 → mean 0.5
+    const avg = averageQualityFromHistogram({
+      '0.0-0.2': 100,
+      '0.8-1.0': 100
+    });
+    expect(avg).toBeCloseTo(0.5, 6);
+  });
+
+  it('ignores unknown bin keys', () => {
+    const avg = averageQualityFromHistogram({
+      '0.4-0.6': 100,
+      // unexpected bin — must not poison the weighted mean
+      'unknown': 9999
+    });
+    expect(avg).toBeCloseTo(0.5, 6);
+  });
+});
+
+describe('decideQualityGate', () => {
+  const floor = { qualityFloorAvg: 0.55, qualityFloorCount: 300 };
+
+  it('passes when avg + count both clear the floor', () => {
+    const d = decideQualityGate({
+      manifest: {
+        totals: { final: 600 },
+        qualityHistogram: { '0.4-0.6': 200, '0.6-0.8': 300, '0.8-1.0': 100 }
+      },
+      ...floor
+    });
+    expect(d.pass).toBe(true);
+    expect(d.avg).toBeGreaterThanOrEqual(0.55);
+    expect(d.count).toBe(600);
+  });
+
+  it('fails on low avg even when count is high', () => {
+    const d = decideQualityGate({
+      manifest: {
+        totals: { final: 1000 },
+        // mass piled in 0.2-0.4 → avg ≈ 0.3
+        qualityHistogram: { '0.0-0.2': 200, '0.2-0.4': 800 }
+      },
+      ...floor
+    });
+    expect(d.pass).toBe(false);
+    expect(d.reason).toContain('avg=');
+  });
+
+  it('fails on low count even when avg is high', () => {
+    const d = decideQualityGate({
+      manifest: {
+        totals: { final: 100 },
+        qualityHistogram: { '0.8-1.0': 100 }
+      },
+      ...floor
+    });
+    expect(d.pass).toBe(false);
+    expect(d.count).toBe(100);
+    expect(d.reason).toContain('count=');
+  });
+
+  it('reports both reasons when both floors are missed', () => {
+    const d = decideQualityGate({
+      manifest: { totals: { final: 50 }, qualityHistogram: { '0.0-0.2': 50 } },
+      ...floor
+    });
+    expect(d.pass).toBe(false);
+    expect(d.reason).toContain('avg=');
+    expect(d.reason).toContain('count=');
+  });
+
+  it('treats missing totals.final as 0', () => {
+    const d = decideQualityGate({
+      manifest: { qualityHistogram: { '0.8-1.0': 1000 } },
+      ...floor
+    });
+    expect(d.pass).toBe(false);
+    expect(d.count).toBe(0);
+  });
+});
+
+describe('ApprenticeRetrainer.run() — APP.2 wired', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[] = [];
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  });
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('below floor → gated-pending-quality (no train, audit row, exit-clean)', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fc.setNow('2026-05-16T02:00:00.000Z');
+    // Manifest: 221 final samples, mostly in the 0.2-0.4 band → avg ≈ 0.3, count 221.
+    fs.put(
+      '/corpus/2026-05-16/manifest.json',
+      passingManifest({
+        totals: { final: 221 },
+        qualityHistogram: {
+          '0.0-0.2': 40,
+          '0.2-0.4': 150,
+          '0.4-0.6': 30,
+          '0.6-0.8': 1,
+          '0.8-1.0': 0
+        }
+      })
+    );
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/corpus/2026-05-16/manifest.json',
+        corpusManifestSha256: 'sha-low',
+        totalSamples: 221,
+        newSamplesSinceLastRun: 221
+      }
+    ]);
+    const trainer = createFakeTrainer([]);
+    const evalH = createFakeEvalHarness([]);
+    const serving = createFakeServing();
+
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      auditPath: '/var/audit/audit.jsonl',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer,
+      evalHarness: evalH,
+      serving
+    });
+    const result = await r.run();
+
+    expect(result.kind).toBe('gated-pending-quality');
+    if (result.kind === 'gated-pending-quality') {
+      expect(result.count).toBe(221);
+      expect(result.avg).toBeLessThan(0.55);
+    }
+
+    // Training must NOT have been invoked — quality gate fires before train.
+    expect(trainer.invocations).toHaveLength(0);
+    expect(evalH.invocations).toHaveLength(0);
+
+    // Structured event on stdout.
+    const stdout = stdoutChunks.join('');
+    expect(stdout).toContain('"event":"gated-pending-quality"');
+    expect(stdout).toContain('"count":221');
+
+    // Audit row appended.
+    expect(fs.has('/var/audit/audit.jsonl')).toBe(true);
+    const audit = fs.readFile('/var/audit/audit.jsonl');
+    expect(audit.trim().split('\n')).toHaveLength(1);
+    const row = JSON.parse(audit.trim());
+    expect(row.event).toBe('gated-pending-quality');
+    expect(row.count).toBe(221);
+    expect(row.at).toBe('2026-05-16T02:00:00.000Z');
+
+    // State + digest reflect the skip.
+    const state = JSON.parse(fs.readFile('/data/state.json'));
+    expect(state.history.at(-1).outcome).toBe('gated-pending-quality');
+    expect(fs.readFile('/reports/d.md')).toContain('gated (corpus below quality floor)');
+  });
+
+  it('above floor → proceeds through full train + canary promotion', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fc.setNow('2026-06-06T02:00:00.000Z');
+    fs.put('/corpus/2026-06-06/manifest.json', passingManifest()); // default 600 / avg ~0.65
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/corpus/2026-06-06/manifest.json',
+        corpusManifestSha256: 'sha-good',
+        totalSamples: 600,
+        newSamplesSinceLastRun: 600
+      }
+    ]);
+    const trainer = createFakeTrainer([
+      {
+        adapterPath: '/adapters/2026-06-06-qwen',
+        configSha256: 'cfg',
+        baseModelOllamaTag: 'qwen2.5-coder:7b'
+      }
+    ]);
+    const evalH = createFakeEvalHarness([
+      { name: '2026-06-06-qwen', winRate: 0.72, decision: 'promote-canary', regressionFlags: [] }
+    ]);
+    const serving = createFakeServing();
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      auditPath: '/var/audit/audit.jsonl',
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer,
+      evalHarness: evalH,
+      serving
+    });
+    const result = await r.run();
+
+    expect(result.kind).toBe('trained-and-canary-promoted');
+    expect(trainer.invocations).toHaveLength(1);
+    expect(evalH.invocations).toHaveLength(1);
+
+    // Gate did NOT fire — no audit row, no gated-pending-quality stdout.
+    expect(fs.has('/var/audit/audit.jsonl')).toBe(false);
+    const stdout = stdoutChunks.join('');
+    expect(stdout).not.toContain('gated-pending-quality');
+  });
+
+  it('configurable floor — operator can raise the bar', async () => {
+    const fs = createInMemoryFs();
+    const fc = createFakeClock();
+    fs.put('/m', passingManifest()); // default avg ~0.65, count 600
+    const aggregator = createFakeCorpusAggregator([
+      {
+        manifestPath: '/m',
+        corpusManifestSha256: 'sha',
+        totalSamples: 600,
+        newSamplesSinceLastRun: 600
+      }
+    ]);
+    const r = new ApprenticeRetrainer({
+      runStatePath: '/data/state.json',
+      digestPath: '/reports/d.md',
+      lockfilePath: '/data/lock',
+      auditPath: '/var/audit/audit.jsonl',
+      // Raise floors above what the default passingManifest provides.
+      qualityFloorAvg: 0.85,
+      qualityFloorCount: 5000,
+      fs,
+      clock: fc.clock,
+      corpusAggregator: aggregator,
+      trainer: createFakeTrainer([]),
+      serving: createFakeServing()
+    });
+    const result = await r.run();
+    expect(result.kind).toBe('gated-pending-quality');
+  });
+});

--- a/packages/apprentice-retrainer/tests/retrainer.integration.test.ts
+++ b/packages/apprentice-retrainer/tests/retrainer.integration.test.ts
@@ -15,7 +15,8 @@ import {
   createFakeEvalHarness,
   createFakeServing,
   createFakeTrainer,
-  createInMemoryFs
+  createInMemoryFs,
+  passingManifest
 } from './helpers/fakes.js';
 
 describe('ApprenticeRetrainer integration — 5-cycle weekly cadence', () => {
@@ -47,6 +48,10 @@ describe('ApprenticeRetrainer integration — 5-cycle weekly cadence', () => {
         2
       )
     );
+
+    // Manifests with passing quality so cycles 2 + 5 clear the APP.2 gate.
+    fs.put('/c/2026-05-13/manifest.json', passingManifest({ totals: { final: 700 } }));
+    fs.put('/c/2026-05-20/manifest.json', passingManifest({ totals: { final: 1500 } }));
 
     // Scripts: cycle 2 (aged → good train), cycle 5 (aged → good train).
     const aggregator = createFakeCorpusAggregator([

--- a/packages/apprentice-retrainer/tests/retrainer.test.ts
+++ b/packages/apprentice-retrainer/tests/retrainer.test.ts
@@ -6,7 +6,8 @@ import {
   createFakeEvalHarness,
   createFakeServing,
   createFakeTrainer,
-  createInMemoryFs
+  createInMemoryFs,
+  passingManifest
 } from './helpers/fakes.js';
 
 describe('ApprenticeRetrainer.run() — orchestration', () => {
@@ -59,6 +60,7 @@ describe('ApprenticeRetrainer.run() — orchestration', () => {
     const fs = createInMemoryFs();
     const fc = createFakeClock();
     fc.setNow('2026-05-06T02:00:00.000Z');
+    fs.put('/corpus/2026-05-06/manifest.json', passingManifest());
     const aggregator = createFakeCorpusAggregator([
       {
         manifestPath: '/corpus/2026-05-06/manifest.json',
@@ -104,6 +106,7 @@ describe('ApprenticeRetrainer.run() — orchestration', () => {
   it('rejects when eval winRate below gate', async () => {
     const fs = createInMemoryFs();
     const fc = createFakeClock();
+    fs.put('/m', passingManifest());
     const aggregator = createFakeCorpusAggregator([
       {
         manifestPath: '/m',
@@ -138,6 +141,7 @@ describe('ApprenticeRetrainer.run() — orchestration', () => {
   it('rejects-no-eval when evalHarness undefined', async () => {
     const fs = createInMemoryFs();
     const fc = createFakeClock();
+    fs.put('/m', passingManifest());
     const aggregator = createFakeCorpusAggregator([
       {
         manifestPath: '/m',
@@ -171,6 +175,7 @@ describe('ApprenticeRetrainer.run() — orchestration', () => {
   it('records failed outcome on training error', async () => {
     const fs = createInMemoryFs();
     const fc = createFakeClock();
+    fs.put('/m', passingManifest());
     const aggregator = createFakeCorpusAggregator([
       {
         manifestPath: '/m',


### PR DESCRIPTION
## Summary

- Gate the `apprentice-retrainer` cron behind a corpus-quality floor so the Saturday 02:00 tick doesn't burn an M3 training run on an obviously under-qualified corpus and emit a REVERT.
- Fires after `corpusAggregator.aggregate()` and before training. Trigger: `avg(corpus.qualityHistogram) < 0.55` OR `corpus.totals.final < 300`. Effect: structured `gated-pending-quality` JSON to stdout, append to `~/.chiefaia/apprentice-retrainer/audit.jsonl`, record outcome in state + digest, return `kind: 'gated-pending-quality'` (CLI exits 0 — clean skip, not failure).
- Floors + audit path configurable via `qualityFloorAvg` / `qualityFloorCount` / `auditPath`. Default floors match the gap-analysis recommendation.

Companion to [#446](https://github.com/prakashgbid/caia/pull/446) which fixed the rubric (`APP.1`) so the gate auto-opens once corpus quality lifts above the floor.

## Test plan
- [x] `pnpm exec vitest run` — 52 / 52 pass (11 new in `quality-gate.test.ts`)
- [x] `pnpm exec eslint src tests` — clean
- [x] `pnpm exec tsc -p tsconfig.build.json` — clean
- [x] Both gate branches covered: below-floor → `gated-pending-quality` (trainer NOT invoked, audit row appended, state + digest reflect skip); above-floor → full train + canary promotion proceeds.
- [x] Configurable-floor path covered: operator can raise the bar via constructor params.

Refs: G.I.2 / APP.2 / A.10.2, `apprentice_system_gap_analysis_2026-05-14.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)