### PR TITLE
feat(mentor-event-bus): a.10.4 add 8 new event schemas

### DIFF
--- a/packages/mentor-event-bus/src/index.ts
+++ b/packages/mentor-event-bus/src/index.ts
@@ -54,7 +54,15 @@ export {
   type DecisionClassifierTripPayload,
   type ToolMisuseFlaggedPayload,
   type SubscriptionBucketSpikePayload,
-  type CapabilityBrokerOverridePayload
+  type CapabilityBrokerOverridePayload,
+  type RouterDecisionPayload,
+  type CompressionPayload,
+  type ClaudeRequestPayload,
+  type ClaudeResponsePayload,
+  type ClaudeDurationPayload,
+  type ChainPhasePayload,
+  type SpawnerOutcomePayload,
+  type PromptOptimizerStagePayload
 } from './types.js';
 
 export {

--- a/packages/mentor-event-bus/src/schemas.ts
+++ b/packages/mentor-event-bus/src/schemas.ts
@@ -149,6 +149,120 @@ export const CapabilityBrokerOverrideSchema = z.object({
   approver: z.string().min(1)
 });
 
+// ─── A.10.4 — router / claude-adapter / chain / spawner / optimizer ───────
+
+export const RouterDecisionSchema = z.object({
+  decisionId: z.string().min(1),
+  modelChosen: z.string().min(1),
+  provider: z.enum(['ollama', 'apprentice', 'claude', 'cache', 'other']),
+  displacementClass: z.enum([
+    'local',
+    'apprentice-canary',
+    'claude',
+    'cached',
+    'fallback'
+  ]),
+  latencyMs: z.number().nonnegative(),
+  caiaTaskType: z.string().optional(),
+  reason: z.string().optional(),
+  estimatedCostUsd: z.number().nonnegative().optional(),
+  baselineCostUsd: z.number().nonnegative().optional()
+});
+
+export const CompressionSchema = z.object({
+  stage: z.string().min(1),
+  inputChars: z.number().int().nonnegative(),
+  outputChars: z.number().int().nonnegative(),
+  ratio: z.number().nonnegative(),
+  method: z.enum(['passthrough', 'headroom', 'summarize', 'dedupe', 'other']),
+  durationMs: z.number().nonnegative().optional(),
+  modelUsed: z.string().optional()
+});
+
+export const ClaudeRequestSchema = z.object({
+  requestId: z.string().min(1),
+  model: z.string().min(1),
+  systemPromptHash: z.string().regex(/^[0-9a-f]{8,64}$/),
+  messageCount: z.number().int().nonnegative(),
+  estimatedInputTokens: z.number().int().nonnegative().optional(),
+  maxTokens: z.number().int().positive().optional(),
+  cachingEnabled: z.boolean().optional(),
+  thinkingEnabled: z.boolean().optional(),
+  caller: z.string().optional()
+});
+
+export const ClaudeResponseSchema = z.object({
+  requestId: z.string().min(1),
+  tokenCount: z.number().int().nonnegative(),
+  inputTokens: z.number().int().nonnegative().optional(),
+  outputTokens: z.number().int().nonnegative().optional(),
+  cacheReadInputTokens: z.number().int().nonnegative().optional(),
+  cacheCreationInputTokens: z.number().int().nonnegative().optional(),
+  finishReason: z.enum([
+    'end_turn',
+    'max_tokens',
+    'stop_sequence',
+    'tool_use',
+    'error'
+  ]),
+  errorCode: z.string().optional(),
+  httpStatus: z.number().int().min(100).max(599).optional()
+});
+
+export const ClaudeDurationSchema = z.object({
+  requestId: z.string().min(1),
+  startTs: z.string().datetime({ offset: true }),
+  endTs: z.string().datetime({ offset: true }),
+  wallMs: z.number().nonnegative(),
+  ok: z.boolean()
+});
+
+export const ChainPhaseSchema = z.object({
+  chainId: z.string().min(1),
+  phaseId: z.number().int().nonnegative(),
+  status: z.enum([
+    'pending',
+    'in_progress',
+    'done',
+    'failed',
+    'blocked',
+    'aborted'
+  ]),
+  sessionId: z.string().optional(),
+  attempt: z.number().int().nonnegative().optional(),
+  durationMs: z.number().nonnegative().optional(),
+  failureClass: z.string().optional(),
+  reason: z.string().optional()
+});
+
+export const SpawnerOutcomeSchema = z.object({
+  host: z.string().min(1),
+  taskId: z.string().min(1),
+  outcome: z.enum([
+    'completed',
+    'failed',
+    'aborted',
+    'timeout',
+    'pr-opened',
+    'pr-merged'
+  ]),
+  durationMs: z.number().nonnegative(),
+  exitCode: z.number().int().optional(),
+  worktreePath: z.string().optional(),
+  prNumber: z.number().int().positive().optional(),
+  reason: z.string().optional()
+});
+
+export const PromptOptimizerStageSchema = z.object({
+  runId: z.string().min(1),
+  stageNumber: z.number().int().positive(),
+  transform: z.string().min(1),
+  tokensIn: z.number().int().nonnegative(),
+  tokensOut: z.number().int().nonnegative(),
+  durationMs: z.number().nonnegative().optional(),
+  noop: z.boolean().optional()
+});
+
 // ─── Registry ─────────────────────────────────────────────────────────────
 
 export const EVENT_SCHEMAS: { [K in EventType]: z.ZodTypeAny } = {
@@ -173,7 +287,15 @@ export const EVENT_SCHEMAS: { [K in EventType]: z.ZodTypeAny } = {
   DecisionClassifierTrip: DecisionClassifierTripSchema,
   ToolMisuseFlagged: ToolMisuseFlaggedSchema,
   SubscriptionBucketSpike: SubscriptionBucketSpikeSchema,
-  CapabilityBrokerOverride: CapabilityBrokerOverrideSchema
+  CapabilityBrokerOverride: CapabilityBrokerOverrideSchema,
+  RouterDecision: RouterDecisionSchema,
+  Compression: CompressionSchema,
+  ClaudeRequest: ClaudeRequestSchema,
+  ClaudeResponse: ClaudeResponseSchema,
+  ClaudeDuration: ClaudeDurationSchema,
+  ChainPhase: ChainPhaseSchema,
+  SpawnerOutcome: SpawnerOutcomeSchema,
+  PromptOptimizerStage: PromptOptimizerStageSchema
 };
 
 /**

--- a/packages/mentor-event-bus/src/types.ts
+++ b/packages/mentor-event-bus/src/types.ts
@@ -2,9 +2,12 @@
  * Mentor event-bus types.
  *
  * The event taxonomy is per `agent/memory/mentor_agent_directive.md`
- * (Phase 0 — Event-substrate prerequisites). 22 event types initially;
+ * (Phase 0 — Event-substrate prerequisites). 22 base + 8 A.10.4 = 30 types;
  * the taxonomy is extensible — add a new EventType + corresponding Zod
  * schema in schemas.ts and a payload type below.
+ *
+ * Append-only: never reorder or remove members of EVENT_TYPES. Consumers
+ * persist the string literally; renames break historical events.
  */
 
 /** All Mentor event types. */
@@ -30,7 +33,16 @@ export const EVENT_TYPES = [
   'DecisionClassifierTrip',
   'ToolMisuseFlagged',
   'SubscriptionBucketSpike',
-  'CapabilityBrokerOverride'
+  'CapabilityBrokerOverride',
+  // ── A.10.4 — router / claude-adapter / chain-runner / spawner / optimizer ──
+  'RouterDecision',
+  'Compression',
+  'ClaudeRequest',
+  'ClaudeResponse',
+  'ClaudeDuration',
+  'ChainPhase',
+  'SpawnerOutcome',
+  'PromptOptimizerStage'
 ] as const;
 
 export type EventType = (typeof EVENT_TYPES)[number];
@@ -197,6 +209,195 @@ export interface CapabilityBrokerOverridePayload {
   approver: string;
 }
 
+// ─── A.10.4 — router / claude-adapter / chain / spawner / optimizer ───────
+
+/**
+ * RouterDecision — emitted on every routing call inside local-llm-router.
+ *
+ * `displacementClass` is the operator-visible answer to "did this stay local?":
+ *   - `local`              served by an Ollama model
+ *   - `apprentice-canary`  served by a LoRA adapter via apprentice-override
+ *   - `claude`             escalated to Anthropic Claude
+ *   - `cached`             served from router output cache (no LLM call)
+ *   - `fallback`           local intended → claude fallback after local error
+ */
+export interface RouterDecisionPayload {
+  /** Router-internal decision id. Correlates Compression + Claude* siblings. */
+  decisionId: string;
+  /** Concrete model id chosen (e.g. `qwen2.5-coder:7b`, `claude-opus-4-7`). */
+  modelChosen: string;
+  /** Provider tier — keep stable, used as a cardinality-safe label. */
+  provider: 'ollama' | 'apprentice' | 'claude' | 'cache' | 'other';
+  displacementClass:
+    | 'local'
+    | 'apprentice-canary'
+    | 'claude'
+    | 'cached'
+    | 'fallback';
+  /** Wall-clock latency of the routing decision itself (not the LLM call). */
+  latencyMs: number;
+  /** Optional caia task-type label passed through the OpenAI-compat shim. */
+  caiaTaskType?: string;
+  /** Optional reason text (e.g. "below confidence threshold"). */
+  reason?: string;
+  /** Estimated cost in USD for this call. 0 for local. */
+  estimatedCostUsd?: number;
+  /** Cost the baseline (always-Claude) path would have charged — for displacement. */
+  baselineCostUsd?: number;
+}
+
+/**
+ * Compression — emitted by prompt-compaction / output-compaction passes.
+ * One event per pass; the pass name identifies which stage compressed what.
+ */
+export interface CompressionPayload {
+  /** Free-form stage label: `router.output`, `optimizer.stage2`, etc. */
+  stage: string;
+  inputChars: number;
+  outputChars: number;
+  /** outputChars / inputChars; 1.0 = no-op; <1 = shrinkage; >1 = expansion. */
+  ratio: number;
+  /** Compression algorithm: `passthrough`, `headroom`, `summarize`, `dedupe`. */
+  method: 'passthrough' | 'headroom' | 'summarize' | 'dedupe' | 'other';
+  /** Wall-clock cost of the compression itself. */
+  durationMs?: number;
+  /** If routed through an LLM-based compressor, the model used. */
+  modelUsed?: string;
+}
+
+/**
+ * ClaudeRequest — emitted *before* posting a request to api.anthropic.com.
+ * Paired with ClaudeResponse + ClaudeDuration via `requestId`.
+ *
+ * `systemPromptHash` is sha256(systemPrompt).slice(0,16) — short enough for
+ * the SQLite TEXT column, long enough that collisions are negligible per day.
+ */
+export interface ClaudeRequestPayload {
+  requestId: string;
+  model: string;
+  /** sha256-prefix of the system prompt; collision-resistant in-day. */
+  systemPromptHash: string;
+  messageCount: number;
+  /** Approximate input token count (estimated client-side, no /count call). */
+  estimatedInputTokens?: number;
+  /** Max output tokens requested. */
+  maxTokens?: number;
+  /** Whether prompt-cache headers (`cache_control`) are attached. */
+  cachingEnabled?: boolean;
+  /** Whether extended thinking is enabled. */
+  thinkingEnabled?: boolean;
+  /** Free-form label identifying the call site (e.g. `router`, `chain-runner`). */
+  caller?: string;
+}
+
+/**
+ * ClaudeResponse — emitted *after* a response is parsed from the API.
+ * `tokenCount` is the canonical billed total (input + output + cached).
+ */
+export interface ClaudeResponsePayload {
+  requestId: string;
+  /** Total billed tokens (input + output + cache reads/writes). */
+  tokenCount: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Cache-read input tokens (existing cache hit). */
+  cacheReadInputTokens?: number;
+  /** Cache-creation tokens (new cache entry). */
+  cacheCreationInputTokens?: number;
+  finishReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | 'error';
+  /** Top-level Anthropic error code if `finishReason === 'error'`. */
+  errorCode?: string;
+  /** HTTP status code of the underlying call. */
+  httpStatus?: number;
+}
+
+/**
+ * ClaudeDuration — wall-clock pairing emitted at the end of every
+ * ClaudeRequest/ClaudeResponse pair (success OR error). One per requestId.
+ */
+export interface ClaudeDurationPayload {
+  requestId: string;
+  /** ISO 8601 UTC at request start. */
+  startTs: string;
+  /** ISO 8601 UTC at response close (or error capture). */
+  endTs: string;
+  /** endTs - startTs in milliseconds. */
+  wallMs: number;
+  /** Whether the call ultimately succeeded (true) or errored (false). */
+  ok: boolean;
+}
+
+/**
+ * ChainPhase — emitted by chain-runner on every phase transition.
+ * One event per state change (start, completion, failure, blocked, …).
+ */
+export interface ChainPhasePayload {
+  chainId: string;
+  /** Numeric phase id (per phases YAML). */
+  phaseId: number;
+  /** Phase status post-transition. */
+  status:
+    | 'pending'
+    | 'in_progress'
+    | 'done'
+    | 'failed'
+    | 'blocked'
+    | 'aborted';
+  /** Session id that owns this transition (matches lockfile owner). */
+  sessionId?: string;
+  /** Retry attempt number for this phase. */
+  attempt?: number;
+  /** Wall-clock duration if the phase ended (done/failed/aborted). */
+  durationMs?: number;
+  /** Failure classification (e.g. `rate_limited`, `auth_failure`, `timeout`). */
+  failureClass?: string;
+  /** Free-form reason text. */
+  reason?: string;
+}
+
+/**
+ * SpawnerOutcome — emitted by claude-spawner-agent at end of every spawn.
+ * Cross-machine: `host` lets the mentor demux M1 vs M3 vs stolution-remote.
+ */
+export interface SpawnerOutcomePayload {
+  /** Hostname of the spawning machine (`m3-prakash`, `stolution-remote`, …). */
+  host: string;
+  taskId: string;
+  outcome:
+    | 'completed'
+    | 'failed'
+    | 'aborted'
+    | 'timeout'
+    | 'pr-opened'
+    | 'pr-merged';
+  durationMs: number;
+  exitCode?: number;
+  /** Worktree path (helpful for forensics, optional). */
+  worktreePath?: string;
+  /** PR number if outcome ∈ {pr-opened, pr-merged}. */
+  prNumber?: number;
+  /** Free-form failure reason. */
+  reason?: string;
+}
+
+/**
+ * PromptOptimizerStage — emitted once per stage of the prompt-optimizer pipeline.
+ * Stages run 1..N in order; each rewrites the prompt with a named transform.
+ */
+export interface PromptOptimizerStagePayload {
+  /** Optimizer run id; groups all stages for one prompt. */
+  runId: string;
+  stageNumber: number;
+  /** Transform applied at this stage (e.g. `claude-md-merge`, `dedupe`). */
+  transform: string;
+  tokensIn: number;
+  tokensOut: number;
+  /** Wall-clock cost of this stage. */
+  durationMs?: number;
+  /** True if the stage was a no-op (tokensIn === tokensOut and no rewrite). */
+  noop?: boolean;
+}
+
 /** Maps EventType → its payload contract. */
 export interface EventPayloadMap {
   PromptReceived: PromptReceivedPayload;
@@ -221,6 +422,14 @@ export interface EventPayloadMap {
   ToolMisuseFlagged: ToolMisuseFlaggedPayload;
   SubscriptionBucketSpike: SubscriptionBucketSpikePayload;
   CapabilityBrokerOverride: CapabilityBrokerOverridePayload;
+  RouterDecision: RouterDecisionPayload;
+  Compression: CompressionPayload;
+  ClaudeRequest: ClaudeRequestPayload;
+  ClaudeResponse: ClaudeResponsePayload;
+  ClaudeDuration: ClaudeDurationPayload;
+  ChainPhase: ChainPhasePayload;
+  SpawnerOutcome: SpawnerOutcomePayload;
+  PromptOptimizerStage: PromptOptimizerStagePayload;
 }
 
 /** Type-safe payload for a given EventType. */

--- a/packages/mentor-event-bus/tests/client.test.ts
+++ b/packages/mentor-event-bus/tests/client.test.ts
@@ -130,8 +130,8 @@ describe('Client schema registration', () => {
     const c = makeClient();
     const db = c.unsafeGetDb();
     const rows = db.prepare('SELECT COUNT(*) AS n FROM schema_definitions').get() as { n: number };
-    // 22 event types, all registered at init time
-    expect(rows.n).toBe(22);
+    // 30 event types (22 base + 8 A.10.4), all registered at init time
+    expect(rows.n).toBe(30);
     c.close();
   });
 

--- a/packages/mentor-event-bus/tests/schemas.a104.test.ts
+++ b/packages/mentor-event-bus/tests/schemas.a104.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Unit tests for the 8 A.10.4 event schemas. Each schema gets:
+ *   - one round-trip parse test (valid → parsed equals input on required fields)
+ *   - one reject-invalid test (missing required field or out-of-enum value)
+ *
+ * Coverage check at the bottom: every A.10.4 type appears in the registry
+ * AND in EVENT_TYPES (so adding the 9th schema next quarter can't drift).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validatePayload, EVENT_SCHEMAS } from '../src/schemas';
+import { EVENT_TYPES, type EventType } from '../src/types';
+
+const A104_TYPES: EventType[] = [
+  'RouterDecision',
+  'Compression',
+  'ClaudeRequest',
+  'ClaudeResponse',
+  'ClaudeDuration',
+  'ChainPhase',
+  'SpawnerOutcome',
+  'PromptOptimizerStage'
+];
+
+// ─── RouterDecision ───────────────────────────────────────────────────────
+
+describe('RouterDecision', () => {
+  it('round-trips a fully-populated payload', () => {
+    const payload = {
+      decisionId: 'rd-001',
+      modelChosen: 'qwen2.5-coder:7b',
+      provider: 'ollama' as const,
+      displacementClass: 'local' as const,
+      latencyMs: 12.5,
+      caiaTaskType: 'routing-classify',
+      reason: 'high-confidence-local',
+      estimatedCostUsd: 0,
+      baselineCostUsd: 0.0042
+    };
+    const result = validatePayload('RouterDecision', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(payload);
+    }
+  });
+
+  it('accepts the minimum required fields', () => {
+    const result = validatePayload('RouterDecision', {
+      decisionId: 'rd-002',
+      modelChosen: 'claude-opus-4-7',
+      provider: 'claude',
+      displacementClass: 'claude',
+      latencyMs: 0
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an unknown displacementClass', () => {
+    const result = validatePayload('RouterDecision', {
+      decisionId: 'rd-003',
+      modelChosen: 'claude-opus-4-7',
+      provider: 'claude',
+      displacementClass: 'mystery-tier',
+      latencyMs: 100
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects negative latency', () => {
+    const result = validatePayload('RouterDecision', {
+      decisionId: 'rd-004',
+      modelChosen: 'qwen2.5-coder:7b',
+      provider: 'ollama',
+      displacementClass: 'local',
+      latencyMs: -1
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── Compression ──────────────────────────────────────────────────────────
+
+describe('Compression', () => {
+  it('round-trips a typical shrink', () => {
+    const payload = {
+      stage: 'router.output',
+      inputChars: 4096,
+      outputChars: 1024,
+      ratio: 0.25,
+      method: 'summarize' as const,
+      durationMs: 7,
+      modelUsed: 'qwen2.5-coder:7b'
+    };
+    const result = validatePayload('Compression', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('rejects an unknown method', () => {
+    const result = validatePayload('Compression', {
+      stage: 'router.output',
+      inputChars: 100,
+      outputChars: 50,
+      ratio: 0.5,
+      method: 'magic-pixie-dust'
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a missing required field (ratio)', () => {
+    const result = validatePayload('Compression', {
+      stage: 'router.output',
+      inputChars: 100,
+      outputChars: 50,
+      method: 'passthrough'
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── ClaudeRequest ────────────────────────────────────────────────────────
+
+describe('ClaudeRequest', () => {
+  it('round-trips with caching + thinking flags', () => {
+    const payload = {
+      requestId: 'cr-001',
+      model: 'claude-opus-4-7',
+      systemPromptHash: 'a1b2c3d4e5f60718',
+      messageCount: 3,
+      estimatedInputTokens: 4096,
+      maxTokens: 8192,
+      cachingEnabled: true,
+      thinkingEnabled: false,
+      caller: 'router'
+    };
+    const result = validatePayload('ClaudeRequest', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('rejects a malformed systemPromptHash', () => {
+    const result = validatePayload('ClaudeRequest', {
+      requestId: 'cr-002',
+      model: 'claude-opus-4-7',
+      systemPromptHash: 'NOT_HEX!',
+      messageCount: 1
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── ClaudeResponse ───────────────────────────────────────────────────────
+
+describe('ClaudeResponse', () => {
+  it('round-trips a successful response', () => {
+    const payload = {
+      requestId: 'cr-001',
+      tokenCount: 5432,
+      inputTokens: 4000,
+      outputTokens: 1000,
+      cacheReadInputTokens: 432,
+      cacheCreationInputTokens: 0,
+      finishReason: 'end_turn' as const,
+      httpStatus: 200
+    };
+    const result = validatePayload('ClaudeResponse', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('accepts an error response with errorCode', () => {
+    const result = validatePayload('ClaudeResponse', {
+      requestId: 'cr-002',
+      tokenCount: 0,
+      finishReason: 'error',
+      errorCode: 'rate_limited',
+      httpStatus: 429
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an out-of-range httpStatus', () => {
+    const result = validatePayload('ClaudeResponse', {
+      requestId: 'cr-003',
+      tokenCount: 0,
+      finishReason: 'end_turn',
+      httpStatus: 42
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an unknown finishReason', () => {
+    const result = validatePayload('ClaudeResponse', {
+      requestId: 'cr-004',
+      tokenCount: 0,
+      finishReason: 'aborted-by-vibes'
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── ClaudeDuration ───────────────────────────────────────────────────────
+
+describe('ClaudeDuration', () => {
+  it('round-trips a paired duration', () => {
+    const payload = {
+      requestId: 'cr-001',
+      startTs: '2026-05-14T23:10:00.000Z',
+      endTs: '2026-05-14T23:10:02.500Z',
+      wallMs: 2500,
+      ok: true
+    };
+    const result = validatePayload('ClaudeDuration', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('rejects a non-iso startTs', () => {
+    const result = validatePayload('ClaudeDuration', {
+      requestId: 'cr-002',
+      startTs: 'yesterday',
+      endTs: '2026-05-14T23:10:02.500Z',
+      wallMs: 2500,
+      ok: false
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── ChainPhase ───────────────────────────────────────────────────────────
+
+describe('ChainPhase', () => {
+  it('round-trips a typical transition', () => {
+    const payload = {
+      chainId: 'apprentice-pull-forward',
+      phaseId: 3,
+      status: 'in_progress' as const,
+      sessionId: 'phase3-20260514T231008-95682',
+      attempt: 1
+    };
+    const result = validatePayload('ChainPhase', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('accepts terminal status with duration + failureClass', () => {
+    const result = validatePayload('ChainPhase', {
+      chainId: 'chain-runner-battle-harden',
+      phaseId: 11,
+      status: 'failed',
+      attempt: 2,
+      durationMs: 600_000,
+      failureClass: 'timeout',
+      reason: 'phase exceeded max_minutes'
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an unknown status', () => {
+    const result = validatePayload('ChainPhase', {
+      chainId: 'x',
+      phaseId: 1,
+      status: 'kinda-running'
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a negative phaseId', () => {
+    const result = validatePayload('ChainPhase', {
+      chainId: 'x',
+      phaseId: -1,
+      status: 'pending'
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── SpawnerOutcome ───────────────────────────────────────────────────────
+
+describe('SpawnerOutcome', () => {
+  it('round-trips a pr-merged outcome', () => {
+    const payload = {
+      host: 'm3-prakash',
+      taskId: 'spawn-001',
+      outcome: 'pr-merged' as const,
+      durationMs: 123_456,
+      exitCode: 0,
+      worktreePath: '/tmp/spawn-001',
+      prNumber: 449
+    };
+    const result = validatePayload('SpawnerOutcome', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('rejects an unknown outcome', () => {
+    const result = validatePayload('SpawnerOutcome', {
+      host: 'm3-prakash',
+      taskId: 'spawn-002',
+      outcome: 'half-completed',
+      durationMs: 1000
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a non-positive prNumber', () => {
+    const result = validatePayload('SpawnerOutcome', {
+      host: 'm3-prakash',
+      taskId: 'spawn-003',
+      outcome: 'pr-opened',
+      durationMs: 1000,
+      prNumber: 0
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── PromptOptimizerStage ─────────────────────────────────────────────────
+
+describe('PromptOptimizerStage', () => {
+  it('round-trips a typical stage', () => {
+    const payload = {
+      runId: 'opt-001',
+      stageNumber: 2,
+      transform: 'claude-md-merge',
+      tokensIn: 12_000,
+      tokensOut: 8_400,
+      durationMs: 45,
+      noop: false
+    };
+    const result = validatePayload('PromptOptimizerStage', payload);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual(payload);
+  });
+
+  it('accepts a no-op stage', () => {
+    const result = validatePayload('PromptOptimizerStage', {
+      runId: 'opt-002',
+      stageNumber: 4,
+      transform: 'dedupe',
+      tokensIn: 1024,
+      tokensOut: 1024,
+      noop: true
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects stageNumber = 0', () => {
+    const result = validatePayload('PromptOptimizerStage', {
+      runId: 'opt-003',
+      stageNumber: 0,
+      transform: 'dedupe',
+      tokensIn: 100,
+      tokensOut: 100
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an empty transform', () => {
+    const result = validatePayload('PromptOptimizerStage', {
+      runId: 'opt-004',
+      stageNumber: 1,
+      transform: '',
+      tokensIn: 100,
+      tokensOut: 90
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── Coverage guard ───────────────────────────────────────────────────────
+
+describe('A.10.4 coverage', () => {
+  it('every A.10.4 type appears in EVENT_TYPES', () => {
+    for (const t of A104_TYPES) {
+      expect(EVENT_TYPES).toContain(t);
+    }
+  });
+
+  it('every A.10.4 type has a registered Zod schema', () => {
+    for (const t of A104_TYPES) {
+      expect(EVENT_SCHEMAS[t]).toBeDefined();
+    }
+  });
+
+  it('EVENT_TYPES has exactly the 22 base + 8 A.10.4 = 30 entries', () => {
+    expect(EVENT_TYPES.length).toBe(30);
+  });
+});

--- a/packages/mentor-event-bus/tests/types.test.ts
+++ b/packages/mentor-event-bus/tests/types.test.ts
@@ -3,8 +3,8 @@ import { EVENT_TYPES } from '../src/types';
 import { EVENT_SCHEMAS, assertEverySchemaPresent } from '../src/schemas';
 
 describe('event taxonomy', () => {
-  it('declares 22 event types', () => {
-    expect(EVENT_TYPES.length).toBe(22);
+  it('declares 30 event types (22 base + 8 A.10.4)', () => {
+    expect(EVENT_TYPES.length).toBe(30);
   });
 
   it('event type names are unique', () => {


### PR DESCRIPTION
## Summary

A.10.4 — adds 8 new mentor event schemas (the foundation for A.10.5-A.10.9 emit-points):

- **RouterDecision** — `modelChosen`, `provider`, `displacementClass`, `latencyMs`, costs
- **Compression** — `stage`, `inputChars`, `outputChars`, `ratio`, `method`
- **ClaudeRequest** — `requestId`, `model`, `systemPromptHash`, `messageCount`, token estimates
- **ClaudeResponse** — `requestId`, `tokenCount`, `finishReason`, cache token fields
- **ClaudeDuration** — `requestId`, `startTs`, `endTs`, `wallMs`, `ok`
- **ChainPhase** — `chainId`, `phaseId`, `status`, `sessionId`, `failureClass`
- **SpawnerOutcome** — `host`, `taskId`, `outcome`, `durationMs`, `prNumber`
- **PromptOptimizerStage** — `runId`, `stageNumber`, `transform`, `tokensIn`, `tokensOut`

Append-only: `EVENT_TYPES` extended at the tail; no existing schema or payload contract modified. SQLite `events` table is generic (`TEXT event_type`), so **no migration is required**. `schema_definitions` is populated at `Client` init via existing `registerSchemaDefinition` path.

## Files

- `packages/mentor-event-bus/src/types.ts` — 8 new payload interfaces + `EventPayloadMap` entries.
- `packages/mentor-event-bus/src/schemas.ts` — 8 new Zod schemas + `EVENT_SCHEMAS` registry entries.
- `packages/mentor-event-bus/src/index.ts` — 8 new payload type re-exports.
- `packages/mentor-event-bus/tests/schemas.a104.test.ts` — 29 round-trip + reject-invalid cases + coverage guard.
- `packages/mentor-event-bus/tests/types.test.ts` + `tests/client.test.ts` — count assertion bumped 22 → 30.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm build` green
- [x] `pnpm lint` green
- [x] `pnpm test` — 126 passed / 7 skipped (29 new in `schemas.a104.test.ts`)
- [ ] CI green
- [ ] `caia-pr-merge-or-fail` drives to merged

## Phase context

Phase 3 of `apprentice-pull-forward` chain. Phase report at `~/Documents/projects/reports/a104_mentor_schemas_2026-05-14.md`.

Concurrency guardrail honored: no edits under `packages/chain-runner/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)