### PR TITLE
feat(observability): a.10.6 + a.10.9 router/optimizer/audit-cron emit-points

### DIFF
--- a/infra/stolution/sps/scripts/audit_recent_done.py
+++ b/infra/stolution/sps/scripts/audit_recent_done.py
@@ -39,11 +39,16 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import hmac
 import json
 import os
+import socket
 import sqlite3
 import sys
 import time
+import urllib.error
+import urllib.request
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -57,6 +62,100 @@ SYNTHETIC_NODE_PREFIXES    = ('test::',)  # methodology §4 Class D — exclude
 
 DEFAULT_DB    = Path.home() / '.sps' / 'sps.db'
 DEFAULT_INBOX = Path.home() / 'Documents' / 'projects' / 'agent-memory' / 'INBOX.md'
+
+# Mentor event-bus HTTP defaults (override via env CAIA_MENTOR_EVENT_BUS_URL).
+DEFAULT_MENTOR_BASE_URL = 'http://127.0.0.1:5180'
+MENTOR_EMIT_TIMEOUT_SEC = 2.0
+
+
+# ---- Mentor event-bus emit (fire-and-forget) --------------------------------
+
+def _load_event_bus_secret() -> str | None:
+    """Resolve the shared HMAC secret used by the mentor-event-bus HTTP API.
+
+    Mirrors packages/mentor-event-bus/src/auth.ts loadSecret(): prefer
+    CAIA_EVENT_BUS_SECRET_PATH (file), fall back to CAIA_EVENT_BUS_SECRET.
+    Returns None when not configured — emits become no-ops in that case so
+    the audit-cron remains functional on hosts without mentor provisioning.
+    """
+    path = os.environ.get('CAIA_EVENT_BUS_SECRET_PATH')
+    if path:
+        try:
+            raw = Path(path).read_text(encoding='utf-8').strip()
+            if len(raw) >= 32:
+                return raw
+        except OSError:
+            pass
+    env_secret = os.environ.get('CAIA_EVENT_BUS_SECRET')
+    if env_secret and len(env_secret) >= 32:
+        return env_secret
+    return None
+
+
+def _emit_mentor_event(event_type: str,
+                       payload: dict[str, Any],
+                       *,
+                       correlation_id: str | None = None,
+                       process_name: str = 'audit_recent_done',
+                       base_url_override: str | None = None,
+                       secret_override: str | None = None) -> bool:
+    """Fire-and-forget HTTP POST of a single mentor event.
+
+    Returns True iff the event was successfully ingested (HTTP 2xx).
+    Returns False for any failure path — but NEVER raises. The audit-cron
+    must keep running even when the event-bus is down.
+
+    Auth matches packages/mentor-event-bus/src/auth.ts:
+        X-Caia-Timestamp: <ms-since-epoch>
+        X-Caia-Signature: hex(hmac-sha256(secret, "<ts>:<body>"))
+    """
+    try:
+        secret = secret_override if secret_override is not None else _load_event_bus_secret()
+        if secret is None:
+            return False
+        base_url = (base_url_override
+                    or os.environ.get('CAIA_MENTOR_EVENT_BUS_URL')
+                    or DEFAULT_MENTOR_BASE_URL)
+        now_ms = int(time.time() * 1000)
+        emitted_at = datetime.fromtimestamp(now_ms / 1000.0, tz=timezone.utc) \
+            .strftime('%Y-%m-%dT%H:%M:%SZ')
+        event = {
+            'id': f'ev_{now_ms:x}_{uuid.uuid4().hex[:16]}',
+            'event_type': event_type,
+            'schema_version': 1,
+            'correlation_id': correlation_id,
+            'parent_event_id': None,
+            'emitted_at': emitted_at,
+            'hostname': socket.gethostname(),
+            'process_name': process_name,
+            'payload_json': json.dumps(payload, default=str),
+            'validation_failed': 0,
+        }
+        body = json.dumps({'events': [event]})
+        body_bytes = body.encode('utf-8')
+        ts = str(now_ms)
+        sig = hmac.new(
+            secret.encode('utf-8'),
+            f'{ts}:{body}'.encode('utf-8'),
+            hashlib.sha256,
+        ).hexdigest()
+        req = urllib.request.Request(
+            url=base_url.rstrip('/') + '/v1/events',
+            data=body_bytes,
+            method='POST',
+            headers={
+                'content-type': 'application/json; charset=utf-8',
+                'content-length': str(len(body_bytes)),
+                'x-caia-timestamp': ts,
+                'x-caia-signature': sig,
+            },
+        )
+        with urllib.request.urlopen(req, timeout=MENTOR_EMIT_TIMEOUT_SEC) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, OSError, socket.timeout, ValueError):
+        return False
+    except Exception:  # noqa: BLE001 — emit MUST be silent on any failure
+        return False
 
 # ---- Bucket helpers ---------------------------------------------------------
 
@@ -397,6 +496,42 @@ def run_audit(db_path: Path,
                 except OSError as exc:
                     return {'ok': False, 'inbox_error': str(exc), **payload,
                             'flip': flip, 'per_node_scores': per_node_scores}
+
+            # Emit one mentor event per low-scoring finding so the apprentice
+            # corpus / dashboards can see audit results in real time. Schema:
+            # DoDViolation already exists in mentor-event-bus and fits the
+            # shape "this node failed the methodology rubric".
+            for entry in per_node_scores:
+                if entry['score'] <= 2:
+                    _emit_mentor_event(
+                        'DoDViolation',
+                        {
+                            'taskId': str(entry['node_id']),
+                            'rule': f"audit-rubric:score<=2:{entry['score']}",
+                            'description': (
+                                f"node={entry['item_code']} "
+                                f"score={entry['score']} reason={entry['reason']}"
+                            )[:500],
+                        },
+                        correlation_id=audit_run_id,
+                    )
+            # And one summary event per audit run (per phase prompt). We piggy-
+            # back the existing HallucinationFlagged schema: the audit run is
+            # the "source" and the description carries the aggregate counts.
+            _emit_mentor_event(
+                'HallucinationFlagged',
+                {
+                    'description': (
+                        f"audit_run={audit_run_id} bucket={bucket_start}/{bucket_end} "
+                        f"audited={nodes_audited} passing={nodes_passing} "
+                        f"score_le_2={nodes_score_le_2} "
+                        f"reliability_pct={reliability_pct} "
+                        f"breached={1 if breached else 0} flip={flip}"
+                    )[:500],
+                    'source': 'audit_recent_done',
+                },
+                correlation_id=audit_run_id,
+            )
 
         return {
             'ok': True, 'flip': flip,

--- a/infra/stolution/sps/scripts/audit_recent_done.py
+++ b/infra/stolution/sps/scripts/audit_recent_done.py
@@ -41,18 +41,18 @@ from __future__ import annotations
 import argparse
 import hashlib
 import hmac
+import http.client
 import json
 import os
 import socket
 import sqlite3
 import sys
 import time
-import urllib.error
-import urllib.request
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 # ---- Constants --------------------------------------------------------------
 
@@ -105,6 +105,11 @@ def _emit_mentor_event(event_type: str,
     Returns False for any failure path — but NEVER raises. The audit-cron
     must keep running even when the event-bus is down.
 
+    Implementation note: uses `http.client` rather than `urllib.request`
+    so the call surface cannot be coerced into reading a `file://` URL
+    even if `CAIA_MENTOR_EVENT_BUS_URL` is somehow poisoned. The scheme
+    is also explicitly allowlisted below.
+
     Auth matches packages/mentor-event-bus/src/auth.ts:
         X-Caia-Timestamp: <ms-since-epoch>
         X-Caia-Signature: hex(hmac-sha256(secret, "<ts>:<body>"))
@@ -116,6 +121,12 @@ def _emit_mentor_event(event_type: str,
         base_url = (base_url_override
                     or os.environ.get('CAIA_MENTOR_EVENT_BUS_URL')
                     or DEFAULT_MENTOR_BASE_URL)
+        parts = urlsplit(base_url)
+        if parts.scheme not in ('http', 'https'):
+            return False
+        if not parts.hostname:
+            return False
+
         now_ms = int(time.time() * 1000)
         emitted_at = datetime.fromtimestamp(now_ms / 1000.0, tz=timezone.utc) \
             .strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -139,20 +150,27 @@ def _emit_mentor_event(event_type: str,
             f'{ts}:{body}'.encode('utf-8'),
             hashlib.sha256,
         ).hexdigest()
-        req = urllib.request.Request(
-            url=base_url.rstrip('/') + '/v1/events',
-            data=body_bytes,
-            method='POST',
-            headers={
-                'content-type': 'application/json; charset=utf-8',
-                'content-length': str(len(body_bytes)),
-                'x-caia-timestamp': ts,
-                'x-caia-signature': sig,
-            },
-        )
-        with urllib.request.urlopen(req, timeout=MENTOR_EMIT_TIMEOUT_SEC) as resp:
+        port = parts.port or (443 if parts.scheme == 'https' else 80)
+        path_q = (parts.path.rstrip('/') if parts.path else '') + '/v1/events'
+        headers = {
+            'content-type': 'application/json; charset=utf-8',
+            'content-length': str(len(body_bytes)),
+            'x-caia-timestamp': ts,
+            'x-caia-signature': sig,
+        }
+        conn_cls = (http.client.HTTPSConnection
+                    if parts.scheme == 'https'
+                    else http.client.HTTPConnection)
+        conn = conn_cls(parts.hostname, port, timeout=MENTOR_EMIT_TIMEOUT_SEC)
+        try:
+            conn.request('POST', path_q, body=body_bytes, headers=headers)
+            resp = conn.getresponse()
+            # Drain the body so the connection can be cleanly closed.
+            resp.read()
             return 200 <= resp.status < 300
-    except (urllib.error.URLError, OSError, socket.timeout, ValueError):
+        finally:
+            conn.close()
+    except (OSError, socket.timeout, ValueError, http.client.HTTPException):
         return False
     except Exception:  # noqa: BLE001 — emit MUST be silent on any failure
         return False

--- a/infra/stolution/sps/tests/test_audit_mentor_emit.py
+++ b/infra/stolution/sps/tests/test_audit_mentor_emit.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Unit tests for the mentor-event-bus emit helper added in A.10.9
+(infra/stolution/sps/scripts/audit_recent_done.py).
+
+We don't actually run the full audit pipeline here — those flows are
+covered by test_b15e_audit_recent_done.sh — instead we drive the inline
+`_emit_mentor_event` helper directly and assert on:
+
+  1. No-op return when CAIA_EVENT_BUS_SECRET is unset.
+  2. Successful POST with the expected HMAC signature when configured.
+  3. Silent failure on server 500.
+  4. Silent failure on connection refused (server down).
+
+Run from infra/stolution/sps/tests directory:
+    python3 test_audit_mentor_emit.py
+Exits non-zero on any failure.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.util
+import json
+import os
+import socket
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE.parent / 'scripts' / 'audit_recent_done.py'
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location('audit_recent_done', SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _CapturingHandler(BaseHTTPRequestHandler):
+    received: list[dict[str, Any]] = []
+    response_status: int = 200
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get('content-length', 0) or 0)
+        body = self.rfile.read(length).decode('utf-8') if length else ''
+        # http.client preserves the case it was sent in; the emit helper
+        # uses lowercase, but normalise here so tests don't depend on it.
+        norm_headers = {k.lower(): v for k, v in self.headers.items()}
+        type(self).received.append({
+            'path': self.path,
+            'body': body,
+            'headers': norm_headers,
+        })
+        self.send_response(type(self).response_status)
+        self.send_header('content-type', 'application/json')
+        self.end_headers()
+        self.wfile.write(b'{"ingested":1,"offsets":[1]}')
+
+    def log_message(self, *_a: Any, **_k: Any) -> None:  # noqa: D401
+        """Quiet the default access-log spam."""
+
+
+def _start_server(status: int = 200) -> tuple[HTTPServer, threading.Thread, int]:
+    _CapturingHandler.received = []
+    _CapturingHandler.response_status = status
+    srv = HTTPServer(('127.0.0.1', 0), _CapturingHandler)
+    port = srv.server_address[1]
+    th = threading.Thread(target=srv.serve_forever, daemon=True)
+    th.start()
+    return srv, th, port
+
+
+class TestAuditMentorEmit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = _load_module()  # type: ignore[attr-defined]
+
+    def setUp(self) -> None:
+        # Clean env so no test leaks credentials into the next.
+        for k in ('CAIA_EVENT_BUS_SECRET',
+                  'CAIA_EVENT_BUS_SECRET_PATH',
+                  'CAIA_MENTOR_EVENT_BUS_URL'):
+            os.environ.pop(k, None)
+
+    def test_noop_when_secret_unset(self) -> None:
+        ok = self.module._emit_mentor_event(
+            'DoDViolation',
+            {'taskId': 't1', 'rule': 'r', 'description': 'd'},
+        )
+        self.assertFalse(ok)
+
+    def test_post_signed_event(self) -> None:
+        srv, _th, port = _start_server()
+        try:
+            secret = 'x' * 40
+            os.environ['CAIA_EVENT_BUS_SECRET'] = secret
+            os.environ['CAIA_MENTOR_EVENT_BUS_URL'] = f'http://127.0.0.1:{port}'
+
+            ok = self.module._emit_mentor_event(
+                'DoDViolation',
+                {
+                    'taskId': 'node-42',
+                    'rule': 'audit-rubric:score<=2:1',
+                    'description': 'verifier verdict=fail',
+                },
+                correlation_id='audit-abc',
+            )
+            self.assertTrue(ok)
+            self.assertEqual(len(_CapturingHandler.received), 1)
+            req = _CapturingHandler.received[0]
+            self.assertEqual(req['path'], '/v1/events')
+            parsed = json.loads(req['body'])
+            self.assertEqual(len(parsed['events']), 1)
+            event = parsed['events'][0]
+            self.assertEqual(event['event_type'], 'DoDViolation')
+            self.assertEqual(event['correlation_id'], 'audit-abc')
+            payload = json.loads(event['payload_json'])
+            self.assertEqual(payload['taskId'], 'node-42')
+
+            ts = req['headers']['x-caia-timestamp']
+            sig = req['headers']['x-caia-signature']
+            expected = hmac.new(
+                secret.encode('utf-8'),
+                f"{ts}:{req['body']}".encode('utf-8'),
+                hashlib.sha256,
+            ).hexdigest()
+            self.assertEqual(sig, expected)
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_silent_on_server_500(self) -> None:
+        srv, _th, port = _start_server(status=500)
+        try:
+            os.environ['CAIA_EVENT_BUS_SECRET'] = 'x' * 40
+            os.environ['CAIA_MENTOR_EVENT_BUS_URL'] = f'http://127.0.0.1:{port}'
+            ok = self.module._emit_mentor_event(
+                'HallucinationFlagged',
+                {'description': 'x', 'source': 's'},
+            )
+            # Server returns 500 → emit returns False but does NOT raise.
+            self.assertFalse(ok)
+        finally:
+            srv.shutdown()
+            srv.server_close()
+
+    def test_silent_on_connection_refused(self) -> None:
+        # Bind a socket on an ephemeral port, immediately close it, then
+        # point the emitter at that port to guarantee a refusal.
+        s = socket.socket()
+        s.bind(('127.0.0.1', 0))
+        port = s.getsockname()[1]
+        s.close()
+        os.environ['CAIA_EVENT_BUS_SECRET'] = 'x' * 40
+        os.environ['CAIA_MENTOR_EVENT_BUS_URL'] = f'http://127.0.0.1:{port}'
+        ok = self.module._emit_mentor_event(
+            'DoDViolation', {'taskId': 't', 'rule': 'r', 'description': 'd'},
+        )
+        self.assertFalse(ok)
+
+    def test_short_secret_rejected(self) -> None:
+        # Secret must be at least 32 chars (matches the TS auth.ts contract).
+        os.environ['CAIA_EVENT_BUS_SECRET'] = 'short'
+        ok = self.module._emit_mentor_event(
+            'DoDViolation', {'taskId': 't', 'rule': 'r', 'description': 'd'},
+        )
+        self.assertFalse(ok)
+
+
+if __name__ == '__main__':
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)

--- a/packages/local-llm-router/src/claude-adapter.ts
+++ b/packages/local-llm-router/src/claude-adapter.ts
@@ -33,8 +33,10 @@
 // goes through; only the savings are reduced.
 
 import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { join, dirname } from 'node:path';
 import { stage1Prepass, estimateTokens } from '@chiefaia/prompt-optimizer';
+import { emitMentorEvent, newClaudeRequestId } from './mentor-emit.js';
 import type {
   LLMRequest,
   LLMResponse,
@@ -260,6 +262,8 @@ export class ClaudeAdapter {
    */
   async generate(model: string, request: LLMRequest): Promise<LLMResponse> {
     const start = Date.now();
+    const startIso = new Date(start).toISOString();
+    const claudeRequestId = newClaudeRequestId();
 
     // Run Stage 1 prepass + Headroom sidecar. Failure-mode for the
     // compression pipeline is best-effort: any error inside degrades to
@@ -268,6 +272,130 @@ export class ClaudeAdapter {
       request,
     );
 
+    // --- Emit ClaudeRequest (pre-call) ---------------------------------
+    // systemPromptHash is sha256(systemPrompt).slice(0,16). The schema also
+    // accepts an empty system prompt — keep the hash deterministic.
+    const systemPromptHash = createHash('sha256')
+      .update(request.systemPrompt ?? '')
+      .digest('hex')
+      .slice(0, 16);
+    emitMentorEvent('ClaudeRequest', {
+      requestId: claudeRequestId,
+      model,
+      systemPromptHash,
+      messageCount: 1,
+      estimatedInputTokens: estimateTokens(promptForBinary),
+      maxTokens: request.maxTokens,
+      cachingEnabled: false,
+      thinkingEnabled: false,
+      caller: 'local-llm-router',
+    });
+
+    // emitClaudeOutcome fires ClaudeResponse + ClaudeDuration; called on
+    // both success and error paths (single source of truth so we can't
+    // accidentally drop a pair).
+    const emitClaudeOutcome = (
+      outcome:
+        | {
+            ok: true;
+            tokenCount: number;
+            inputTokens?: number;
+            outputTokens?: number;
+            finishReason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use';
+          }
+        | {
+            ok: false;
+            errorCode: string;
+            httpStatus?: number;
+          },
+    ): void => {
+      const endMs = Date.now();
+      const endIso = new Date(endMs).toISOString();
+      if (outcome.ok) {
+        const respPayload: Record<string, unknown> = {
+          requestId: claudeRequestId,
+          tokenCount: outcome.tokenCount,
+          finishReason: outcome.finishReason,
+        };
+        if (outcome.inputTokens !== undefined) respPayload['inputTokens'] = outcome.inputTokens;
+        if (outcome.outputTokens !== undefined) respPayload['outputTokens'] = outcome.outputTokens;
+        emitMentorEvent('ClaudeResponse', respPayload);
+      } else {
+        const respPayload: Record<string, unknown> = {
+          requestId: claudeRequestId,
+          tokenCount: 0,
+          finishReason: 'error',
+          errorCode: outcome.errorCode,
+        };
+        if (outcome.httpStatus !== undefined) respPayload['httpStatus'] = outcome.httpStatus;
+        emitMentorEvent('ClaudeResponse', respPayload);
+      }
+      emitMentorEvent('ClaudeDuration', {
+        requestId: claudeRequestId,
+        startTs: startIso,
+        endTs: endIso,
+        wallMs: endMs - start,
+        ok: outcome.ok,
+      });
+    };
+
+    let outcomeEmitted = false;
+    const ensureErrorOutcomeEmitted = (errorCode: string, httpStatus?: number): void => {
+      if (outcomeEmitted) return;
+      outcomeEmitted = true;
+      emitClaudeOutcome(
+        httpStatus !== undefined
+          ? { ok: false, errorCode, httpStatus }
+          : { ok: false, errorCode },
+      );
+    };
+
+    let resp: LLMResponse;
+    try {
+      resp = await this.runBinary({
+        model,
+        request,
+        promptForBinary,
+        optimizerMetrics,
+        start,
+      });
+      const ftokens = resp.usage?.completionTokens ?? 0;
+      const ptokens = resp.usage?.promptTokens ?? 0;
+      outcomeEmitted = true;
+      emitClaudeOutcome({
+        ok: true,
+        tokenCount: ftokens + ptokens,
+        inputTokens: ptokens,
+        outputTokens: ftokens,
+        finishReason: 'end_turn',
+      });
+      return resp;
+    } catch (err) {
+      if (err instanceof ClaudeRateLimitedError) {
+        ensureErrorOutcomeEmitted('rate_limited', 429);
+      } else if (err instanceof ClaudeBinaryError) {
+        ensureErrorOutcomeEmitted(
+          err.exitCode !== null ? `binary_exit_${err.exitCode}` : 'binary_error',
+        );
+      } else {
+        ensureErrorOutcomeEmitted('unknown');
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Spawn the `claude` binary and return the parsed response. Pure adapter
+   * logic — emit hooks are attached by the public `generate()` wrapper.
+   */
+  private async runBinary(opts: {
+    model: string;
+    request: LLMRequest;
+    promptForBinary: string;
+    optimizerMetrics: RouterOptimizerMetrics | null;
+    start: number;
+  }): Promise<LLMResponse> {
+    const { model, request, promptForBinary, optimizerMetrics, start } = opts;
     const args = ['--print', '--output-format', 'json', '--model', model];
     if (request.systemPrompt) {
       args.push('--append-system-prompt', request.systemPrompt);
@@ -437,6 +565,17 @@ export class ClaudeAdapter {
     optimizerMetrics: RouterOptimizerMetrics | null;
   }> {
     if (this.optimizerDisabled) {
+      // Still emit a single passthrough Compression event so downstream
+      // observability sees that compression ran (no-op) for every Claude
+      // call. inputChars === outputChars; ratio = 1.
+      emitMentorEvent('Compression', {
+        stage: 'router.prompt',
+        inputChars: request.prompt.length,
+        outputChars: request.prompt.length,
+        ratio: 1,
+        method: 'passthrough',
+        durationMs: 0,
+      });
       return { promptForBinary: request.prompt, optimizerMetrics: null };
     }
 
@@ -450,6 +589,7 @@ export class ClaudeAdapter {
     // compression by default, so any in-turn duplication (dedupe of
     // repeated blocks, ANSI stripping, long file-read folding, base64
     // truncation) has to happen before Headroom sees the messages.
+    const stage1StartMs = Date.now();
     let stage1Text: string;
     let protectedSpans: number;
     try {
@@ -461,10 +601,22 @@ export class ClaudeAdapter {
       stage1Text = rawPrompt;
       protectedSpans = 0;
     }
+    const stage1DurationMs = Date.now() - stage1StartMs;
+    const stage1InputChars = rawPrompt.length;
+    const stage1OutputChars = stage1Text.length;
+    emitMentorEvent('Compression', {
+      stage: 'router.prompt.stage1',
+      inputChars: stage1InputChars,
+      outputChars: stage1OutputChars,
+      ratio: stage1InputChars > 0 ? stage1OutputChars / stage1InputChars : 1,
+      method: 'dedupe',
+      durationMs: stage1DurationMs,
+    });
 
     // ─── Stage 2: Headroom sidecar ────────────────────────────────────
     const messages: HeadroomMessage[] = [{ role: 'user', content: stage1Text }];
 
+    const stage2StartMs = Date.now();
     // eslint-disable-next-line no-useless-assignment
     let sidecarOut: HeadroomSidecarResponse | null = null;
     try {
@@ -486,6 +638,14 @@ export class ClaudeAdapter {
         headroom_ratio: 0,
       };
       this.emitOptimizerMetrics(fallback);
+      emitMentorEvent('Compression', {
+        stage: 'router.prompt.headroom',
+        inputChars: stage1OutputChars,
+        outputChars: stage1OutputChars,
+        ratio: 1,
+        method: 'passthrough',
+        durationMs: Date.now() - stage2StartMs,
+      });
       return { promptForBinary: stage1Text, optimizerMetrics: fallback };
     }
 
@@ -510,6 +670,18 @@ export class ClaudeAdapter {
       headroom_ratio: sidecarOut.compression_ratio,
     };
     this.emitOptimizerMetrics(metrics);
+
+    emitMentorEvent('Compression', {
+      stage: 'router.prompt.headroom',
+      inputChars: stage1OutputChars,
+      outputChars: finalPrompt.length,
+      ratio:
+        stage1OutputChars > 0 ? finalPrompt.length / stage1OutputChars : 1,
+      method: 'headroom',
+      durationMs: Date.now() - stage2StartMs,
+      modelUsed: this.headroomModel,
+    });
+
     return { promptForBinary: finalPrompt, optimizerMetrics: metrics };
   }
 

--- a/packages/local-llm-router/src/mentor-emit.ts
+++ b/packages/local-llm-router/src/mentor-emit.ts
@@ -1,0 +1,259 @@
+// Mentor event-bus emit helper for @chiefaia/local-llm-router.
+//
+// Fire-and-forget HTTP POST to the mentor-event-bus `/v1/events` endpoint.
+// Used by router.ts (RouterDecision, Compression) and claude-adapter.ts
+// (ClaudeRequest, ClaudeResponse, ClaudeDuration) to feed the observability
+// substrate without taking a workspace dependency on the full mentor-event-bus
+// package (which transitively pulls in better-sqlite3 + chokidar).
+//
+// Invariants:
+//   1. NEVER throw. Every error path is swallowed; emit must not break the
+//      router request.
+//   2. NEVER block. Emits are dispatched via setImmediate so the caller's
+//      `void emit(...)` returns synchronously.
+//   3. Auto-no-op when the mentor base URL or shared secret is unset. The
+//      router is the primary serving path and must run even on machines that
+//      haven't been provisioned with mentor-event-bus credentials.
+//
+// HMAC scheme matches packages/mentor-event-bus/src/auth.ts exactly:
+//   X-Caia-Timestamp: <ms>
+//   X-Caia-Signature: hex(hmac-sha256(secret, "<ts>:<body>"))
+
+import { createHmac } from 'node:crypto';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { hostname as osHostname } from 'node:os';
+import { existsSync, readFileSync } from 'node:fs';
+
+const TIMESTAMP_HEADER = 'x-caia-timestamp';
+const SIGNATURE_HEADER = 'x-caia-signature';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:5180';
+
+/** Event types this module knows how to emit. Kept in sync with the
+ *  mentor-event-bus literal-tuple but intentionally a string here so the
+ *  router doesn't take a hard type dependency. */
+export type RouterEventType =
+  | 'RouterDecision'
+  | 'Compression'
+  | 'ClaudeRequest'
+  | 'ClaudeResponse'
+  | 'ClaudeDuration';
+
+export interface EmitterOptions {
+  /** Base URL of the mentor-event-bus HTTP server. Default reads
+   *  CAIA_MENTOR_EVENT_BUS_URL, then falls back to 127.0.0.1:5180. */
+  baseUrl?: string;
+  /** Override the shared secret. Default reads CAIA_EVENT_BUS_SECRET_PATH
+   *  (file path) then CAIA_EVENT_BUS_SECRET (raw). Refuses too-short. */
+  secret?: string;
+  /** Hostname recorded on the emitted event. Default os.hostname(). */
+  hostname?: string;
+  /** Process name recorded on the emitted event. */
+  processName?: string;
+  /** Per-request timeout in ms. Default 2000 (kept short — emit is
+   *  fire-and-forget; we don't want the router request to wait). */
+  timeoutMs?: number;
+  /** Inject a request function (test seam). */
+  requestFn?: typeof httpRequest;
+  /** Inject `now()` (test seam). */
+  now?: () => number;
+}
+
+interface ResolvedConfig {
+  baseUrl: URL;
+  secret: string;
+  hostname: string;
+  processName: string | null;
+  timeoutMs: number;
+  requestFn: typeof httpRequest;
+  now: () => number;
+}
+
+let cachedConfig: ResolvedConfig | null | undefined;
+
+/** Resolve config lazily. Returns null when not configured — emits become no-ops. */
+function getConfig(opts: EmitterOptions = {}): ResolvedConfig | null {
+  if (Object.keys(opts).length === 0 && cachedConfig !== undefined) {
+    return cachedConfig;
+  }
+
+  const baseUrlStr =
+    opts.baseUrl ?? process.env['CAIA_MENTOR_EVENT_BUS_URL'] ?? DEFAULT_BASE_URL;
+
+  let secret: string | null = null;
+  if (opts.secret !== undefined) {
+    secret = opts.secret;
+  } else {
+    const path = process.env['CAIA_EVENT_BUS_SECRET_PATH'];
+    if (path && existsSync(path)) {
+      try {
+        const raw = readFileSync(path, 'utf-8').trim();
+        if (raw.length >= 32) secret = raw;
+      } catch {
+        /* swallow — emit is best-effort */
+      }
+    }
+    if (secret === null) {
+      const envSecret = process.env['CAIA_EVENT_BUS_SECRET'];
+      if (envSecret && envSecret.length >= 32) secret = envSecret;
+    }
+  }
+
+  let resolved: ResolvedConfig | null;
+  if (secret === null) {
+    resolved = null;
+  } else {
+    let url: URL;
+    try {
+      url = new URL(baseUrlStr);
+    } catch {
+      resolved = null;
+      if (Object.keys(opts).length === 0) cachedConfig = resolved;
+      return resolved;
+    }
+    resolved = {
+      baseUrl: url,
+      secret,
+      hostname: opts.hostname ?? osHostname(),
+      processName: opts.processName ?? 'local-llm-router',
+      timeoutMs: opts.timeoutMs ?? 2_000,
+      requestFn:
+        opts.requestFn ?? (url.protocol === 'https:' ? httpsRequest : httpRequest),
+      now: opts.now ?? Date.now,
+    };
+  }
+
+  if (Object.keys(opts).length === 0) cachedConfig = resolved;
+  return resolved;
+}
+
+/** Test-only: clear the resolved-config cache. */
+export function __resetEmitterConfig(): void {
+  cachedConfig = undefined;
+}
+
+/** Test-only: install a config (bypasses env lookup). */
+export function __setEmitterConfigForTests(opts: EmitterOptions): void {
+  const resolved = getConfig(opts);
+  cachedConfig = resolved;
+}
+
+function makeEventId(now: number): string {
+  return `ev_${now.toString(36)}_${Math.random().toString(36).slice(2, 18)}`;
+}
+
+/**
+ * Emit a single mentor event. Returns immediately; the actual HTTP POST
+ * happens asynchronously. ANY error (config missing, network down, server
+ * 500) is swallowed. This is the public surface used by router.ts +
+ * claude-adapter.ts.
+ *
+ * The `correlationId` is the prompt-level correlation id (usually inherited
+ * via AsyncLocalStorage upstream); the router-level sibling correlator is
+ * the `decisionId` baked into the payload.
+ */
+export function emitMentorEvent(
+  type: RouterEventType,
+  payload: Record<string, unknown>,
+  meta: { correlationId?: string | null; parentEventId?: string | null } = {},
+): void {
+  // The setImmediate guarantees we never run inside the caller's
+  // synchronous frame — any throw from `dispatch` lands on the next tick
+  // where our top-level catch absorbs it.
+  setImmediate(() => {
+    try {
+      dispatch(type, payload, meta);
+    } catch {
+      /* swallow */
+    }
+  });
+}
+
+function dispatch(
+  type: RouterEventType,
+  payload: Record<string, unknown>,
+  meta: { correlationId?: string | null; parentEventId?: string | null },
+): void {
+  const cfg = getConfig();
+  if (!cfg) return;
+
+  const now = cfg.now();
+  const emittedAt = new Date(now).toISOString();
+  const event = {
+    id: makeEventId(now),
+    event_type: type,
+    schema_version: 1,
+    correlation_id: meta.correlationId ?? null,
+    parent_event_id: meta.parentEventId ?? null,
+    emitted_at: emittedAt,
+    hostname: cfg.hostname,
+    process_name: cfg.processName,
+    payload_json: JSON.stringify(payload),
+    validation_failed: 0,
+  };
+
+  let body: string;
+  try {
+    body = JSON.stringify({ events: [event] });
+  } catch {
+    return;
+  }
+
+  const ts = String(now);
+  const signature = createHmac('sha256', cfg.secret)
+    .update(`${ts}:${body}`)
+    .digest('hex');
+
+  const req = cfg.requestFn(
+    {
+      method: 'POST',
+      protocol: cfg.baseUrl.protocol,
+      hostname: cfg.baseUrl.hostname,
+      port:
+        cfg.baseUrl.port || (cfg.baseUrl.protocol === 'https:' ? 443 : 80),
+      path: '/v1/events',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'content-length': Buffer.byteLength(body).toString(),
+        [TIMESTAMP_HEADER]: ts,
+        [SIGNATURE_HEADER]: signature,
+      },
+      timeout: cfg.timeoutMs,
+    },
+    (resp) => {
+      // Drain the response body so the socket can be re-used; ignore content.
+      resp.resume();
+    },
+  );
+  req.on('error', () => {
+    /* swallow */
+  });
+  req.on('timeout', () => {
+    try {
+      req.destroy();
+    } catch {
+      /* swallow */
+    }
+  });
+  try {
+    req.write(body);
+    req.end();
+  } catch {
+    /* swallow */
+  }
+}
+
+/**
+ * Mint a fresh router-decision id. Used by router.ts to correlate the
+ * RouterDecision event with its sibling Compression / ClaudeRequest /
+ * ClaudeResponse / ClaudeDuration events.
+ */
+export function newDecisionId(): string {
+  return `dec_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Mint a fresh claude-call request id. */
+export function newClaudeRequestId(): string {
+  return `creq_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -32,12 +32,31 @@ import {
 } from './otel.js';
 import { getRoute } from './routing-config.js';
 import { resolveApprenticeOverride } from './apprentice-override.js';
+import { emitMentorEvent, newDecisionId } from './mentor-emit.js';
 import type {
   LLMProvider,
   LLMRequest,
   LLMResponse,
   RouterOptions,
 } from './types.js';
+
+type DisplacementClass =
+  | 'local'
+  | 'apprentice-canary'
+  | 'claude'
+  | 'cached'
+  | 'fallback';
+
+type RouterEventProvider = 'ollama' | 'apprentice' | 'claude' | 'cache' | 'other';
+
+function providerForEvent(
+  llmProvider: LLMProvider,
+  apprenticeSlot: 'production' | 'canary' | null,
+): RouterEventProvider {
+  if (llmProvider === 'claude') return 'claude';
+  if (apprenticeSlot !== null) return 'apprentice';
+  return 'ollama';
+}
 
 // Singleton adapters -- created lazily so tests can import without side effects.
 let _ollama: OllamaAdapter | null = null;
@@ -137,6 +156,9 @@ export async function route(
       [CAIA_ATTR.ROUTER_VERSION]: '0.2.0',
     },
     async (ctx) => {
+      const decisionId = newDecisionId();
+      const routeStartMs = Date.now();
+
       // --- Cache short-circuit -------------------------------------
       if (options.cacheLookup) {
         const cached = await options.cacheLookup(taskType, prompt);
@@ -148,6 +170,14 @@ export async function route(
             [CAIA_ATTR.CACHE_HIT]: true,
           });
           ctx.recordSuccess(responseAttrs(cached));
+          emitMentorEvent('RouterDecision', {
+            decisionId,
+            modelChosen: cached.model,
+            provider: 'cache',
+            displacementClass: 'cached',
+            latencyMs: Date.now() - routeStartMs,
+            caiaTaskType: taskType,
+          });
           return cached;
         }
       }
@@ -251,6 +281,34 @@ export async function route(
           result.provider === 'local' ? 'local' : 'claude';
       }
       ctx.recordSuccess(successAttrs);
+
+      // --- Emit RouterDecision (fire-and-forget) -------------------
+      let displacementClass: DisplacementClass;
+      if (usedFallback) {
+        displacementClass = 'fallback';
+      } else if (result.provider === 'claude') {
+        displacementClass = 'claude';
+      } else if (apprenticeSlot !== null) {
+        displacementClass = 'apprentice-canary';
+      } else {
+        displacementClass = 'local';
+      }
+      const routerEventProvider = providerForEvent(result.provider, apprenticeSlot);
+      const payload: Record<string, unknown> = {
+        decisionId,
+        modelChosen: result.model,
+        provider: routerEventProvider,
+        displacementClass,
+        latencyMs: Date.now() - routeStartMs,
+        caiaTaskType: taskType,
+      };
+      if (usedFallback && fallbackFrom !== null) {
+        payload['reason'] =
+          `fallback from ${fallbackFrom}${fallbackReason ? ': ' + fallbackReason : ''}`
+            .slice(0, 200);
+      }
+      emitMentorEvent('RouterDecision', payload);
+
       return result;
     },
   );

--- a/packages/local-llm-router/tests/mentor-emit.test.ts
+++ b/packages/local-llm-router/tests/mentor-emit.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit + integration coverage for src/mentor-emit.ts.
+ *
+ * Strategy: stand up a tiny in-process HTTP server that records every POST,
+ * point the emitter at it via the test-only config seam, and verify the
+ * emit path produces a correctly-signed request. Then exercise the failure
+ * modes (no config, server down, server 500) and assert that emit never
+ * throws and never blocks the caller.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import {
+  emitMentorEvent,
+  newClaudeRequestId,
+  newDecisionId,
+  __resetEmitterConfig,
+  __setEmitterConfigForTests,
+} from '../src/mentor-emit.js';
+
+interface RecordedRequest {
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+async function startCapturingServer(opts: {
+  status?: number;
+  delayMs?: number;
+} = {}): Promise<{
+  port: number;
+  close: () => Promise<void>;
+  requests: RecordedRequest[];
+  resolveNextRequest: () => Promise<RecordedRequest>;
+}> {
+  const requests: RecordedRequest[] = [];
+  const waiters: Array<(r: RecordedRequest) => void> = [];
+
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      const recorded: RecordedRequest = { body, headers: req.headers };
+      requests.push(recorded);
+      const waiter = waiters.shift();
+      if (waiter) waiter(recorded);
+      const respond = (): void => {
+        res.statusCode = opts.status ?? 200;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ingested: 1, offsets: [1] }));
+      };
+      if (opts.delayMs) {
+        setTimeout(respond, opts.delayMs);
+      } else {
+        respond();
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, '127.0.0.1', () => resolve()),
+  );
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    requests,
+    resolveNextRequest: () =>
+      new Promise<RecordedRequest>((resolve) => waiters.push(resolve)),
+  };
+}
+
+const TEST_SECRET = 'a'.repeat(40);
+
+describe('mentor-emit', () => {
+  let server: Awaited<ReturnType<typeof startCapturingServer>> | null = null;
+
+  beforeEach(() => {
+    __resetEmitterConfig();
+  });
+
+  afterEach(async () => {
+    // Drain any in-flight setImmediate dispatches BEFORE we tear down the
+    // server / config — otherwise a queued emit from this test would race
+    // into the next test's freshly-configured server.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    if (server) {
+      await server.close();
+      server = null;
+    }
+    __resetEmitterConfig();
+  });
+
+  describe('newDecisionId / newClaudeRequestId', () => {
+    it('mints unique decision ids', () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 50; i++) ids.add(newDecisionId());
+      expect(ids.size).toBe(50);
+      for (const id of ids) expect(id).toMatch(/^dec_[a-z0-9]+_[a-z0-9]+$/);
+    });
+
+    it('mints unique claude-request ids', () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 50; i++) ids.add(newClaudeRequestId());
+      expect(ids.size).toBe(50);
+      for (const id of ids) expect(id).toMatch(/^creq_[a-z0-9]+_[a-z0-9]+$/);
+    });
+  });
+
+  describe('emitMentorEvent', () => {
+    it('no-ops silently when secret is unset', async () => {
+      // No config set at all — explicit __setEmitterConfigForTests omitted.
+      // Force the env to have no secret so the resolved config is `null`
+      // (otherwise a stray CAIA_EVENT_BUS_SECRET in the dev machine env
+      // would make this test reach the network).
+      const savedSecret = process.env['CAIA_EVENT_BUS_SECRET'];
+      const savedPath = process.env['CAIA_EVENT_BUS_SECRET_PATH'];
+      delete process.env['CAIA_EVENT_BUS_SECRET'];
+      delete process.env['CAIA_EVENT_BUS_SECRET_PATH'];
+      try {
+        expect(() =>
+          emitMentorEvent('RouterDecision', {
+            decisionId: 'dec_test',
+            modelChosen: 'qwen2.5-coder:7b',
+            provider: 'ollama',
+            displacementClass: 'local',
+            latencyMs: 5,
+          }),
+        ).not.toThrow();
+        // Drain the setImmediate queue so this test's dispatch resolves
+        // BEFORE the next test reconfigures the emitter — otherwise the
+        // queued setImmediate would fire with the next test's server URL.
+        await new Promise((r) => setImmediate(r));
+      } finally {
+        if (savedSecret !== undefined) process.env['CAIA_EVENT_BUS_SECRET'] = savedSecret;
+        if (savedPath !== undefined) process.env['CAIA_EVENT_BUS_SECRET_PATH'] = savedPath;
+      }
+    });
+
+    it('POSTs a signed event to the configured base URL', async () => {
+      server = await startCapturingServer();
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+        timeoutMs: 1_000,
+      });
+
+      const captured = server.resolveNextRequest();
+      emitMentorEvent('RouterDecision', {
+        decisionId: 'dec_abc',
+        modelChosen: 'qwen2.5-coder:7b',
+        provider: 'ollama',
+        displacementClass: 'local',
+        latencyMs: 42,
+      });
+      const req = await captured;
+
+      // The wrapper must wrap the event into { events: [...] }.
+      const parsed = JSON.parse(req.body) as { events: Array<Record<string, unknown>> };
+      expect(parsed.events).toHaveLength(1);
+      const event = parsed.events[0]!;
+      expect(event['event_type']).toBe('RouterDecision');
+      const payload = JSON.parse(event['payload_json'] as string) as Record<string, unknown>;
+      expect(payload['decisionId']).toBe('dec_abc');
+      expect(payload['provider']).toBe('ollama');
+      expect(payload['displacementClass']).toBe('local');
+      expect(payload['latencyMs']).toBe(42);
+
+      // Signature must match the HMAC over `${ts}:${body}`.
+      const ts = req.headers['x-caia-timestamp'];
+      const sig = req.headers['x-caia-signature'];
+      expect(typeof ts).toBe('string');
+      expect(typeof sig).toBe('string');
+      const expected = createHmac('sha256', TEST_SECRET)
+        .update(`${ts as string}:${req.body}`)
+        .digest('hex');
+      expect(sig).toBe(expected);
+    });
+
+    it('swallows server errors and never throws', async () => {
+      server = await startCapturingServer({ status: 500 });
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+        timeoutMs: 1_000,
+      });
+
+      expect(() =>
+        emitMentorEvent('Compression', {
+          stage: 'router.prompt',
+          inputChars: 100,
+          outputChars: 80,
+          ratio: 0.8,
+          method: 'headroom',
+        }),
+      ).not.toThrow();
+
+      // Yield once to let setImmediate dispatch fire.
+      await new Promise((r) => setImmediate(r));
+      // We don't get a strong assertion that the request was made (server
+      // counts may race the test), but the absence of a throw is the
+      // contract.
+    });
+
+    it('swallows connection-refused (server down) without throwing', () => {
+      // Point at a port nothing is listening on.
+      __setEmitterConfigForTests({
+        baseUrl: 'http://127.0.0.1:1',
+        secret: TEST_SECRET,
+        timeoutMs: 100,
+      });
+
+      expect(() =>
+        emitMentorEvent('ClaudeRequest', {
+          requestId: 'creq_x',
+          model: 'claude-sonnet-4-6',
+          systemPromptHash: 'deadbeef',
+          messageCount: 1,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not block the caller (returns synchronously)', async () => {
+      server = await startCapturingServer({ delayMs: 200 });
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+        timeoutMs: 1_000,
+      });
+
+      const start = Date.now();
+      emitMentorEvent('ClaudeDuration', {
+        requestId: 'creq_x',
+        startTs: new Date().toISOString(),
+        endTs: new Date().toISOString(),
+        wallMs: 0,
+        ok: true,
+      });
+      const elapsed = Date.now() - start;
+      // The HTTP call adds at least 200ms server-side, but the emit call
+      // itself must return in well under 50ms.
+      expect(elapsed).toBeLessThan(50);
+    });
+
+    it('respects override base URL via setEmitterConfigForTests', async () => {
+      server = await startCapturingServer();
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+      });
+      const captured = server.resolveNextRequest();
+      emitMentorEvent('Compression', {
+        stage: 'router.prompt.stage1',
+        inputChars: 1000,
+        outputChars: 500,
+        ratio: 0.5,
+        method: 'dedupe',
+      });
+      await captured;
+      expect(server.requests.length).toBe(1);
+    });
+  });
+
+  describe('integration with the router (route() → emit path)', () => {
+    it('emits a RouterDecision when route() finishes', async () => {
+      // Lazy import inside the test so the module-load side effects don't
+      // run before __setEmitterConfigForTests.
+      server = await startCapturingServer();
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+      });
+
+      const { route, __setAdapters } = await import('../src/router.js');
+      __setAdapters(
+        {
+          isAvailable: vi.fn().mockResolvedValue(true),
+          generate: vi.fn().mockResolvedValue({
+            response: 'ok',
+            model: 'qwen2.5-coder:7b',
+            provider: 'local',
+            durationMs: 5,
+          }),
+        } as never,
+        null,
+      );
+
+      const waiter = server.resolveNextRequest();
+      await route('domain-classification', 'hello world');
+      const req = await waiter;
+
+      const parsed = JSON.parse(req.body) as { events: Array<{ event_type: string; payload_json: string }> };
+      expect(parsed.events[0]!.event_type).toBe('RouterDecision');
+      const payload = JSON.parse(parsed.events[0]!.payload_json) as Record<string, unknown>;
+      expect(payload['caiaTaskType']).toBe('domain-classification');
+      expect(payload['displacementClass']).toBe('local');
+      expect(payload['provider']).toBe('ollama');
+      expect(typeof payload['decisionId']).toBe('string');
+      expect(typeof payload['latencyMs']).toBe('number');
+    });
+  });
+});

--- a/packages/prompt-optimizer/__tests__/mentor-emit.test.ts
+++ b/packages/prompt-optimizer/__tests__/mentor-emit.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for src/mentor-emit.ts (prompt-optimizer copy) — mirrors the
+ * local-llm-router suite. Verifies the HTTP signing + fire-and-forget +
+ * never-throws contract, and asserts that `optimize()` emits one
+ * `PromptOptimizerStage` event per stage.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import {
+  emitOptimizerEvent,
+  newOptimizerRunId,
+  __resetEmitterConfig,
+  __setEmitterConfigForTests,
+} from '../src/mentor-emit.js';
+import { optimize } from '../src/index.js';
+
+interface RecordedRequest {
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+async function startCapturingServer(opts: {
+  status?: number;
+  delayMs?: number;
+} = {}): Promise<{
+  port: number;
+  close: () => Promise<void>;
+  requests: RecordedRequest[];
+  waitForRequests: (n: number, timeoutMs?: number) => Promise<void>;
+}> {
+  const requests: RecordedRequest[] = [];
+  const listeners: Array<() => void> = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      requests.push({ body, headers: req.headers });
+      for (const l of listeners.splice(0)) l();
+      const respond = (): void => {
+        res.statusCode = opts.status ?? 200;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ingested: 1, offsets: [1] }));
+      };
+      if (opts.delayMs) setTimeout(respond, opts.delayMs);
+      else respond();
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+    requests,
+    waitForRequests: async (n: number, timeoutMs = 2_000) => {
+      const start = Date.now();
+      while (requests.length < n) {
+        if (Date.now() - start > timeoutMs) {
+          throw new Error(
+            `waitForRequests: expected ${n}, got ${requests.length} after ${timeoutMs}ms`,
+          );
+        }
+        await new Promise<void>((r) => {
+          const timer = setTimeout(r, 25);
+          listeners.push(() => {
+            clearTimeout(timer);
+            r();
+          });
+        });
+      }
+    },
+  };
+}
+
+async function drain(): Promise<void> {
+  // Flush microtasks + setImmediate queue + a short macrotask so that
+  // outbound HTTP writes have a chance to round-trip to the loopback
+  // server. setImmediate alone is not enough — the kernel needs a tick.
+  for (let i = 0; i < 4; i++) await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setTimeout(r, 25));
+  for (let i = 0; i < 2; i++) await new Promise((r) => setImmediate(r));
+}
+
+const TEST_SECRET = 'b'.repeat(40);
+
+describe('prompt-optimizer mentor-emit', () => {
+  let server: Awaited<ReturnType<typeof startCapturingServer>> | null = null;
+
+  beforeEach(() => {
+    __resetEmitterConfig();
+  });
+
+  afterEach(async () => {
+    await drain();
+    if (server) {
+      await server.close();
+      server = null;
+    }
+    __resetEmitterConfig();
+  });
+
+  it('newOptimizerRunId mints unique ids', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 40; i++) ids.add(newOptimizerRunId());
+    expect(ids.size).toBe(40);
+  });
+
+  it('emit no-ops silently when secret is unset', async () => {
+    const savedSecret = process.env['CAIA_EVENT_BUS_SECRET'];
+    const savedPath = process.env['CAIA_EVENT_BUS_SECRET_PATH'];
+    delete process.env['CAIA_EVENT_BUS_SECRET'];
+    delete process.env['CAIA_EVENT_BUS_SECRET_PATH'];
+    try {
+      expect(() =>
+        emitOptimizerEvent('PromptOptimizerStage', {
+          runId: 'opt_test',
+          stageNumber: 1,
+          transform: 'stage1-prepass',
+          tokensIn: 10,
+          tokensOut: 10,
+        }),
+      ).not.toThrow();
+      await drain();
+    } finally {
+      if (savedSecret !== undefined) process.env['CAIA_EVENT_BUS_SECRET'] = savedSecret;
+      if (savedPath !== undefined) process.env['CAIA_EVENT_BUS_SECRET_PATH'] = savedPath;
+    }
+  });
+
+  it('emit POSTs a correctly-signed event', async () => {
+    server = await startCapturingServer();
+    __setEmitterConfigForTests({
+      baseUrl: `http://127.0.0.1:${server.port}`,
+      secret: TEST_SECRET,
+    });
+    emitOptimizerEvent('PromptOptimizerStage', {
+      runId: 'opt_1',
+      stageNumber: 1,
+      transform: 'stage1-prepass',
+      tokensIn: 100,
+      tokensOut: 80,
+      noop: false,
+    });
+    await server.waitForRequests(1);
+    expect(server.requests.length).toBe(1);
+    const req = server.requests[0]!;
+    const parsed = JSON.parse(req.body) as { events: Array<{ payload_json: string; event_type: string }> };
+    expect(parsed.events[0]!.event_type).toBe('PromptOptimizerStage');
+    const payload = JSON.parse(parsed.events[0]!.payload_json) as Record<string, unknown>;
+    expect(payload['stageNumber']).toBe(1);
+    expect(payload['transform']).toBe('stage1-prepass');
+
+    const ts = req.headers['x-caia-timestamp'] as string;
+    const sig = req.headers['x-caia-signature'] as string;
+    const expected = createHmac('sha256', TEST_SECRET)
+      .update(`${ts}:${req.body}`)
+      .digest('hex');
+    expect(sig).toBe(expected);
+  });
+
+  it('emit swallows network errors silently (server down)', () => {
+    __setEmitterConfigForTests({
+      baseUrl: 'http://127.0.0.1:1',
+      secret: TEST_SECRET,
+      timeoutMs: 100,
+    });
+    expect(() =>
+      emitOptimizerEvent('PromptOptimizerStage', {
+        runId: 'opt_2',
+        stageNumber: 2,
+        transform: 'stage2-summarize',
+        tokensIn: 200,
+        tokensOut: 100,
+      }),
+    ).not.toThrow();
+  });
+
+  it('emit is fire-and-forget — returns synchronously', async () => {
+    server = await startCapturingServer({ delayMs: 200 });
+    __setEmitterConfigForTests({
+      baseUrl: `http://127.0.0.1:${server.port}`,
+      secret: TEST_SECRET,
+    });
+    const start = Date.now();
+    emitOptimizerEvent('PromptOptimizerStage', {
+      runId: 'opt_3',
+      stageNumber: 3,
+      transform: 'stage3-prune',
+      tokensIn: 200,
+      tokensOut: 150,
+    });
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  describe('optimize() integration', () => {
+    it('emits a stage-1 event on the short-prompt bail-out path', async () => {
+      server = await startCapturingServer();
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+      });
+
+      const res = await optimize({
+        userQuestion: 'rename Foo to Bar',
+        toolOutputs: [{ id: 't1', content: 'short blob' }],
+        budget: { skipStagesUnderTokens: 1000 },
+      });
+      expect(res.metrics.stage2.skipped).toBe(true);
+
+      // Bail-out path emits 3 events: stage 1 + skip stage 2 + skip stage 3.
+      await server.waitForRequests(3);
+      expect(server.requests.length).toBeGreaterThanOrEqual(1);
+      const stages = server.requests
+        .map((r) => JSON.parse(r.body) as { events: Array<{ event_type: string; payload_json: string }> })
+        .flatMap((p) => p.events.map((e) => JSON.parse(e.payload_json) as { stageNumber: number; transform: string }));
+      const stageNumbers = stages.map((s) => s.stageNumber).sort();
+      expect(stageNumbers).toContain(1);
+    });
+
+    it('emits stage-1, stage-2, stage-3 events on the full pipeline', async () => {
+      server = await startCapturingServer();
+      __setEmitterConfigForTests({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        secret: TEST_SECRET,
+      });
+
+      // Long-enough prompt to force stage2/stage3 to run.
+      const longBlob = 'verbose log preamble '.repeat(150) + 'rename Foo identifier';
+      const fetchSpy = vi.fn(async (url: string) => {
+        if (url.includes('/v1/chat/completions')) {
+          return new Response(
+            JSON.stringify({
+              choices: [{ message: { content: 'rename Foo identifier (preamble dropped)' } }],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        return new Response('', { status: 404 });
+      }) as unknown as typeof fetch;
+
+      const original = globalThis.fetch;
+      globalThis.fetch = fetchSpy;
+      try {
+        await optimize({
+          systemPrompt: 'You are a careful assistant.',
+          toolOutputs: [{ id: 'blob-1', content: longBlob }],
+          userQuestion: 'rename Foo to Bar',
+          budget: { skipStagesUnderTokens: 50 },
+        });
+      } finally {
+        globalThis.fetch = original;
+      }
+      // Full pipeline fires one event per stage (3 total).
+      await server.waitForRequests(3);
+
+      const stages = server.requests
+        .map((r) => JSON.parse(r.body) as { events: Array<{ event_type: string; payload_json: string }> })
+        .flatMap((p) => p.events.map((e) => JSON.parse(e.payload_json) as { stageNumber: number }));
+      const seenNumbers = new Set(stages.map((s) => s.stageNumber));
+      expect(seenNumbers.has(1)).toBe(true);
+      expect(seenNumbers.has(2)).toBe(true);
+      expect(seenNumbers.has(3)).toBe(true);
+    });
+  });
+});

--- a/packages/prompt-optimizer/src/index.ts
+++ b/packages/prompt-optimizer/src/index.ts
@@ -6,6 +6,7 @@
 //
 // Phase 5 of the Local-AI-First build chain.
 
+import { emitOptimizerEvent, newOptimizerRunId } from './mentor-emit.js';
 import { stage1Prepass } from './stage1.js';
 import { stage2Summarize } from './stage2.js';
 import {
@@ -53,6 +54,7 @@ const DEFAULT_BUDGET = {
 export async function optimize(input: OptimizerInput): Promise<OptimizerResult> {
   const startedAt = Date.now();
   const budget = { ...DEFAULT_BUDGET, ...(input.budget ?? {}) };
+  const runId = newOptimizerRunId();
 
   // ─── Stage 1: prepass on every input blob ────────────────────────
 
@@ -101,8 +103,38 @@ export async function optimize(input: OptimizerInput): Promise<OptimizerResult> 
   stage1Metrics.ratio =
     stage1Metrics.tokensIn > 0 ? stage1Metrics.tokensOut / stage1Metrics.tokensIn : 1;
 
+  emitOptimizerEvent('PromptOptimizerStage', {
+    runId,
+    stageNumber: 1,
+    transform: 'stage1-prepass',
+    tokensIn: stage1Metrics.tokensIn,
+    tokensOut: stage1Metrics.tokensOut,
+    durationMs: stage1Metrics.wallMs,
+    noop: stage1Metrics.tokensIn === stage1Metrics.tokensOut,
+  });
+
   // Cheap short-prompt bail-out: under the skip threshold, skip Stage 2/3.
   if (promptTokensRaw < budget.skipStagesUnderTokens) {
+    // Emit explicit skip events so dashboards can distinguish "stage ran but
+    // was a no-op" from "stage didn't run".
+    emitOptimizerEvent('PromptOptimizerStage', {
+      runId,
+      stageNumber: 2,
+      transform: 'stage2-summarize-skipped',
+      tokensIn: 0,
+      tokensOut: 0,
+      durationMs: 0,
+      noop: true,
+    });
+    emitOptimizerEvent('PromptOptimizerStage', {
+      runId,
+      stageNumber: 3,
+      transform: 'stage3-prune-skipped',
+      tokensIn: 0,
+      tokensOut: 0,
+      durationMs: 0,
+      noop: true,
+    });
     const totalWallMs = Date.now() - startedAt;
     return {
       optimizedPrompt: stage1Out,
@@ -164,6 +196,16 @@ export async function optimize(input: OptimizerInput): Promise<OptimizerResult> 
     error: stage2.error,
   };
 
+  emitOptimizerEvent('PromptOptimizerStage', {
+    runId,
+    stageNumber: 2,
+    transform: 'stage2-summarize',
+    tokensIn: stage2Metrics.tokensIn,
+    tokensOut: stage2Metrics.tokensOut,
+    durationMs: stage2Metrics.wallMs,
+    noop: stage2Metrics.tokensIn === stage2Metrics.tokensOut,
+  });
+
   // ─── Stage 3: question-aware prune over assembled prompt ─────────
 
   const segments: PromptSegment[] = [];
@@ -217,6 +259,17 @@ export async function optimize(input: OptimizerInput): Promise<OptimizerResult> 
     skipped: stage3.backend === 'skipped',
     error: stage3.error,
   };
+
+  emitOptimizerEvent('PromptOptimizerStage', {
+    runId,
+    stageNumber: 3,
+    transform:
+      stage3.backend === 'skipped' ? 'stage3-prune-skipped' : 'stage3-prune',
+    tokensIn: stage3Metrics.tokensIn,
+    tokensOut: stage3Metrics.tokensOut,
+    durationMs: stage3Metrics.wallMs,
+    noop: stage3Metrics.tokensIn === stage3Metrics.tokensOut,
+  });
 
   const metrics: OptimizerMetrics = {
     promptTokensRaw,

--- a/packages/prompt-optimizer/src/mentor-emit.ts
+++ b/packages/prompt-optimizer/src/mentor-emit.ts
@@ -1,0 +1,202 @@
+// Mentor event-bus emit helper for @chiefaia/prompt-optimizer.
+//
+// Mirrors packages/local-llm-router/src/mentor-emit.ts. Kept separate (rather
+// than introducing a workspace dep on local-llm-router) so that prompt-optimizer
+// stays a leaf package — the dep edge runs router → optimizer, not vice-versa.
+//
+// Fire-and-forget HTTP POST to the mentor-event-bus `/v1/events` endpoint.
+// Used by `optimize()` to emit one `PromptOptimizerStage` per stage. Never
+// throws, never blocks.
+
+import { createHmac } from 'node:crypto';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { hostname as osHostname } from 'node:os';
+import { existsSync, readFileSync } from 'node:fs';
+
+const TIMESTAMP_HEADER = 'x-caia-timestamp';
+const SIGNATURE_HEADER = 'x-caia-signature';
+const DEFAULT_BASE_URL = 'http://127.0.0.1:5180';
+
+export type OptimizerEventType = 'PromptOptimizerStage' | 'Compression';
+
+export interface EmitterOptions {
+  baseUrl?: string;
+  secret?: string;
+  hostname?: string;
+  processName?: string;
+  timeoutMs?: number;
+  requestFn?: typeof httpRequest;
+  now?: () => number;
+}
+
+interface ResolvedConfig {
+  baseUrl: URL;
+  secret: string;
+  hostname: string;
+  processName: string | null;
+  timeoutMs: number;
+  requestFn: typeof httpRequest;
+  now: () => number;
+}
+
+let cachedConfig: ResolvedConfig | null | undefined;
+
+function getConfig(opts: EmitterOptions = {}): ResolvedConfig | null {
+  if (Object.keys(opts).length === 0 && cachedConfig !== undefined) {
+    return cachedConfig;
+  }
+
+  const baseUrlStr =
+    opts.baseUrl ?? process.env['CAIA_MENTOR_EVENT_BUS_URL'] ?? DEFAULT_BASE_URL;
+
+  let secret: string | null = null;
+  if (opts.secret !== undefined) {
+    secret = opts.secret;
+  } else {
+    const path = process.env['CAIA_EVENT_BUS_SECRET_PATH'];
+    if (path && existsSync(path)) {
+      try {
+        const raw = readFileSync(path, 'utf-8').trim();
+        if (raw.length >= 32) secret = raw;
+      } catch {
+        /* swallow */
+      }
+    }
+    if (secret === null) {
+      const envSecret = process.env['CAIA_EVENT_BUS_SECRET'];
+      if (envSecret && envSecret.length >= 32) secret = envSecret;
+    }
+  }
+
+  let resolved: ResolvedConfig | null;
+  if (secret === null) {
+    resolved = null;
+  } else {
+    let url: URL;
+    try {
+      url = new URL(baseUrlStr);
+    } catch {
+      resolved = null;
+      if (Object.keys(opts).length === 0) cachedConfig = resolved;
+      return resolved;
+    }
+    resolved = {
+      baseUrl: url,
+      secret,
+      hostname: opts.hostname ?? osHostname(),
+      processName: opts.processName ?? 'prompt-optimizer',
+      timeoutMs: opts.timeoutMs ?? 2_000,
+      requestFn:
+        opts.requestFn ?? (url.protocol === 'https:' ? httpsRequest : httpRequest),
+      now: opts.now ?? Date.now,
+    };
+  }
+
+  if (Object.keys(opts).length === 0) cachedConfig = resolved;
+  return resolved;
+}
+
+export function __resetEmitterConfig(): void {
+  cachedConfig = undefined;
+}
+
+export function __setEmitterConfigForTests(opts: EmitterOptions): void {
+  const resolved = getConfig(opts);
+  cachedConfig = resolved;
+}
+
+function makeEventId(now: number): string {
+  return `ev_${now.toString(36)}_${Math.random().toString(36).slice(2, 18)}`;
+}
+
+export function emitOptimizerEvent(
+  type: OptimizerEventType,
+  payload: Record<string, unknown>,
+  meta: { correlationId?: string | null; parentEventId?: string | null } = {},
+): void {
+  setImmediate(() => {
+    try {
+      dispatch(type, payload, meta);
+    } catch {
+      /* swallow */
+    }
+  });
+}
+
+function dispatch(
+  type: OptimizerEventType,
+  payload: Record<string, unknown>,
+  meta: { correlationId?: string | null; parentEventId?: string | null },
+): void {
+  const cfg = getConfig();
+  if (!cfg) return;
+
+  const now = cfg.now();
+  const emittedAt = new Date(now).toISOString();
+  const event = {
+    id: makeEventId(now),
+    event_type: type,
+    schema_version: 1,
+    correlation_id: meta.correlationId ?? null,
+    parent_event_id: meta.parentEventId ?? null,
+    emitted_at: emittedAt,
+    hostname: cfg.hostname,
+    process_name: cfg.processName,
+    payload_json: JSON.stringify(payload),
+    validation_failed: 0,
+  };
+
+  let body: string;
+  try {
+    body = JSON.stringify({ events: [event] });
+  } catch {
+    return;
+  }
+
+  const ts = String(now);
+  const signature = createHmac('sha256', cfg.secret)
+    .update(`${ts}:${body}`)
+    .digest('hex');
+
+  const req = cfg.requestFn(
+    {
+      method: 'POST',
+      protocol: cfg.baseUrl.protocol,
+      hostname: cfg.baseUrl.hostname,
+      port:
+        cfg.baseUrl.port || (cfg.baseUrl.protocol === 'https:' ? 443 : 80),
+      path: '/v1/events',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'content-length': Buffer.byteLength(body).toString(),
+        [TIMESTAMP_HEADER]: ts,
+        [SIGNATURE_HEADER]: signature,
+      },
+      timeout: cfg.timeoutMs,
+    },
+    (resp) => {
+      resp.resume();
+    },
+  );
+  req.on('error', () => {
+    /* swallow */
+  });
+  req.on('timeout', () => {
+    try {
+      req.destroy();
+    } catch {
+      /* swallow */
+    }
+  });
+  try {
+    req.write(body);
+    req.end();
+  } catch {
+    /* swallow */
+  }
+}
+
+export function newOptimizerRunId(): string {
+  return `opt_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
## Summary

Wires every mentor-event-bus emit-point called out in the apprentice gap-analysis §G.II.1 + §G.III.3 for `local-llm-router`, `prompt-optimizer`, and the SPS audit-cron. Strictly additive; fire-and-forget; no producer is blocked or broken when the shared HMAC secret is unset.

- **A.10.6 (commits 1)** — `local-llm-router`: emit `RouterDecision` at every routing decision (cache hit + dispatch), `Compression` per Stage 1 prepass + Headroom sidecar pass, and `ClaudeRequest` / `ClaudeResponse` / `ClaudeDuration` around every claude-adapter call (success AND error paths).
- **A.10.9 (commits 2 + 3)** — `prompt-optimizer`: emit `PromptOptimizerStage` per stage (1/2/3, with explicit `noop=true` events on the short-prompt bail-out). `audit_recent_done.py`: emit one `DoDViolation` per score≤2 finding and one `HallucinationFlagged` summary per audit run.

Schemas (`RouterDecision`, `Compression`, `Claude{Request,Response,Duration}`, `PromptOptimizerStage`) landed in #450 (phase 3 of this chain).

## Files changed

- `packages/local-llm-router/src/mentor-emit.ts` (new, ~190 LOC) — inline fire-and-forget HMAC emitter. No new package dep.
- `packages/local-llm-router/src/router.ts` (+58) — RouterDecision wiring.
- `packages/local-llm-router/src/claude-adapter.ts` (+172) — Compression + Claude{Request,Response,Duration} wiring; binary spawn factored into private `runBinary()`.
- `packages/local-llm-router/tests/mentor-emit.test.ts` (new, 9 cases).
- `packages/prompt-optimizer/src/mentor-emit.ts` (new, ~190 LOC) — mirror of router emitter (kept separate so optimizer stays a leaf).
- `packages/prompt-optimizer/src/index.ts` (+53) — PromptOptimizerStage wiring.
- `packages/prompt-optimizer/__tests__/mentor-emit.test.ts` (new, 7 cases).
- `infra/stolution/sps/scripts/audit_recent_done.py` (+135) — stdlib-only urllib emit helper + per-finding + per-run emits.
- `infra/stolution/sps/tests/test_audit_mentor_emit.py` (new, 5 cases).

## Design decisions (autonomy)

Full report: `~/Documents/projects/reports/a106_a109_emit_points_2026-05-14.md` §3.

- Inline emitters in each producer package (TS + Python) instead of a new workspace dep on `@chiefaia/mentor-event-bus` — avoids dragging `better-sqlite3` + `chokidar` into the router daemon and avoids adding a `requests` dep to the audit-cron.
- Python emit uses stdlib `urllib.request` (not `requests.post` from the phase prompt) — same observability, zero new dependencies on the LaunchAgent / container image.
- audit-cron emits piggy-back the already-existing `DoDViolation` + `HallucinationFlagged` schemas instead of inventing an "AuditRun" type (the phase 3 report explicitly maps audit findings to these existing types).
- Catastrophic-throw path in `route()` does NOT emit a RouterDecision (no honest `provider` value to put in the payload; OTel span already records the failure). Fallback success path emits with `displacementClass='fallback'`.

## Test plan

- [x] `pnpm --filter @chiefaia/local-llm-router test` — 11/11 files, 141/141 tests pass.
- [x] `pnpm --filter @chiefaia/prompt-optimizer test mentor-emit` — 7/7 new tests pass. Full optimizer suite has 4 pre-existing failures on develop (verified by stashing this PR's changes), 0 new failures.
- [x] `python3 infra/stolution/sps/tests/test_audit_mentor_emit.py` — 5/5 pass.
- [x] `bash infra/stolution/sps/tests/test_b15e_audit_recent_done.sh` — 6/6 pass (existing audit suite green).
- [x] `pnpm --filter @chiefaia/local-llm-router typecheck && build` — green.
- [x] `pnpm --filter @chiefaia/prompt-optimizer typecheck && build && lint` — green.
- [x] `pnpm --filter @chiefaia/local-llm-router lint` — 0 new errors (2 errors pre-existing on `develop`).

## Concurrency guardrail

`chain-runner-battle-harden` was `current_phase=11`, `all_done=false`, `paused=false` at PR-open. `git diff origin/develop...HEAD --name-only` lists 9 paths under `packages/local-llm-router/`, `packages/prompt-optimizer/`, and `infra/stolution/sps/` — **0 paths under `packages/chain-runner/`**. Phase 4 was edit-isolated from battle-harden's work area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)