### PR TITLE
feat(post-merge): INT.1.A1 — Guardrail #7 deployment signal pipeline

### DIFF
--- a/.github/workflows/post-merge-signal.yml
+++ b/.github/workflows/post-merge-signal.yml
@@ -1,0 +1,91 @@
+# INT.1.A1 — Guardrail #7 post-merge deployment signal (DoD v2)
+#
+# On every merged PR, append a JSON-Lines row to `queue.jsonl` on the orphan
+# branch `post-merge-queue`. A local launchd watcher
+# (`com.caia.post-merge-watcher`) polls this branch every 60s and invokes
+# `~/.caia/post-merge/post-merge-deploy.sh <row>` per new row.
+#
+# Pull model — see reports/integration_remediation_plan_2026-05-14.md AR-2.
+# Uses GITHUB_TOKEN; no operator PAT required.
+
+name: post-merge-signal
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop, main]
+
+permissions:
+  contents: write
+
+concurrency:
+  # Serialize all writes to the post-merge-queue branch to avoid push races.
+  group: post-merge-queue
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (or create) post-merge-queue branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global user.email "actions@github.com"
+          git config --global user.name "github-actions[bot]"
+          git init queue-work
+          cd queue-work
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Try to fetch existing queue branch; fall back to fresh orphan.
+          if git fetch --depth=1 origin post-merge-queue 2>/dev/null; then
+            git checkout post-merge-queue
+          else
+            git checkout --orphan post-merge-queue
+            git rm -rf . 2>/dev/null || true
+            : > queue.jsonl
+            git add queue.jsonl
+            git commit -m "post-merge-queue: init"
+          fi
+
+      - name: Append row
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd queue-work
+          # Build row with jq to escape correctly.
+          ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          row="$(jq -nc \
+            --arg pr "$PR_NUMBER" \
+            --arg repo "$REPO_FULL_NAME" \
+            --arg sha "$MERGE_SHA" \
+            --arg base "$BASE_BRANCH" \
+            --arg ts "$ts" \
+            --arg title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR" \
+            '{schema_version:1, pr_number:($pr|tonumber), repo:$repo, merge_sha:$sha, base_branch:$base, ts:$ts, pr_title:$title, pr_author:$author}')"
+          # Append + push. Concurrency group serializes; safe pull-rebase + push.
+          for attempt in 1 2 3 4 5; do
+            git fetch --depth=1 origin post-merge-queue || true
+            git reset --hard origin/post-merge-queue 2>/dev/null || true
+            printf '%s\n' "$row" >> queue.jsonl
+            git add queue.jsonl
+            git commit -m "post-merge: ${REPO_FULL_NAME} PR #${PR_NUMBER} (${MERGE_SHA:0:8})"
+            if git push origin HEAD:post-merge-queue; then
+              echo "enqueued on attempt ${attempt}"
+              exit 0
+            fi
+            echo "push attempt ${attempt} failed, retrying"
+            sleep $((attempt * 2))
+          done
+          echo "FAILED to enqueue after 5 attempts" >&2
+          exit 1

--- a/launchd/com.caia.post-merge-watcher.plist.template
+++ b/launchd/com.caia.post-merge-watcher.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>{{HOME}}</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.caia.post-merge-watcher</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-c</string>
+		<string>{{HOME}}/.caia/post-merge/post-merge-watcher.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardErrorPath</key>
+	<string>{{HOME}}/.caia/post-merge/launchd.err</string>
+	<key>StandardOutPath</key>
+	<string>{{HOME}}/.caia/post-merge/launchd.out</string>
+	<key>StartInterval</key>
+	<integer>60</integer>
+	<key>WorkingDirectory</key>
+	<string>{{HOME}}</string>
+</dict>
+</plist>

--- a/scripts/post-merge/README.md
+++ b/scripts/post-merge/README.md
@@ -1,0 +1,84 @@
+# post-merge deployment signal — INT.1.A1 / Guardrail #7
+
+Closes the "merged but not deployed" gap from DoD v2 (`reports/definition_of_done_v2_2026-05-14.md` §3.a Guardrail 7).
+
+## Pipeline
+
+```
+PR merged on develop|main
+        │
+        ▼
+.github/workflows/post-merge-signal.yml      (in caia + stolution)
+        │  appends one JSON-Lines row to queue.jsonl
+        │  on the orphan branch `post-merge-queue`
+        ▼
+GitHub: <repo>/post-merge-queue/queue.jsonl
+        │  read via `gh api repos/<repo>/contents/queue.jsonl?ref=post-merge-queue`
+        ▼
+~/.caia/post-merge/post-merge-watcher.sh     (launchd, 60 s)
+        │  pops new rows (deduped by merge_sha against ~/.caia/post-merge/seen.jsonl)
+        ▼
+~/.caia/post-merge/post-merge-deploy.sh <row>
+        │  per-repo deploy actions (today: stub, just records "saw merge $sha")
+        ▼
+~/.caia/post-merge/log.jsonl + ~/.caia/post-merge/<repo>.deploy.log
+```
+
+## Queue row format (JSON-Lines)
+
+```json
+{
+  "schema_version": 1,
+  "pr_number": 451,
+  "repo": "prakashgbid/caia",
+  "merge_sha": "5c077f4...",
+  "base_branch": "develop",
+  "ts": "2026-05-15T00:00:00Z",
+  "pr_title": "feat(observability): a.10.6 + a.10.9 router/optimizer/audit-cron emit-points",
+  "pr_author": "claude-spawned"
+}
+```
+
+## Install (one-shot, idempotent)
+
+```bash
+~/Documents/projects/caia/scripts/post-merge/install.sh
+```
+
+This copies `post-merge-watcher.sh` + `post-merge-deploy.sh` into `~/.caia/post-merge/`, renders the plist template into `~/Library/LaunchAgents/com.caia.post-merge-watcher.plist`, and bootstraps the launchd label.
+
+Re-running is safe: each step bootouts before bootstrap.
+
+## Verify
+
+```bash
+launchctl print gui/$(id -u)/com.caia.post-merge-watcher
+~/.caia/post-merge/post-merge-watcher.sh --health-check
+~/.caia/post-merge/post-merge-deploy.sh   --health-check
+tail -n 20 ~/.caia/post-merge/log.jsonl
+```
+
+## Why pull (not push)
+
+GHA cloud runners cannot reach the operator's Mac directly (no public ingress). Two options were on the table:
+
+1. **Push:** GHA runner SSHes to a Tailscale-reachable host using a runner-side SSH key.
+2. **Pull (chosen):** GHA writes a row to the `post-merge-queue` branch via `GITHUB_TOKEN`; the local watcher pulls.
+
+Pull wins because:
+
+- No SSH key on GHA → no key to rotate/revoke.
+- No Tailscale exposure of the Mac → no surface for runners to abuse.
+- `GITHUB_TOKEN` is auto-scoped per workflow; no operator PAT.
+- Replay-safe: the queue is append-only and the watcher dedupes on `merge_sha`.
+
+## Operator extension points
+
+- **Per-repo deploy command:** edit the `case "$repo" in` block in `post-merge-deploy.sh` to invoke the right deploy command (e.g. `kubectl rollout restart`, `ssh stolution …/deploy.sh`, `pnpm -C packages/<x> install:postmerge`).
+- **Per-package install scripts:** when a `caia/packages/<x>/scripts/install-postmerge.sh` exists, invoke it from the `prakashgbid/caia` branch of the case statement, gated on whether the merge touched that package (see `git diff <merge_sha>^..<merge_sha> --name-only`).
+- **Add a tracked repo:** prepend it to `POSTMERGE_REPOS` in `post-merge-watcher.sh` (or set the env var in the plist).
+
+## Tracked repos (today)
+
+- `prakashgbid/caia`
+- `prakashgbid/stolution`

--- a/scripts/post-merge/install.sh
+++ b/scripts/post-merge/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# INT.1.A1 — install/refresh the post-merge watcher and deploy stub on the
+# operator's Mac. Idempotent — safe to re-run after each merge.
+#
+# - Copies the watcher + deploy script into ~/.caia/post-merge/
+# - Renders the launchd plist into ~/Library/LaunchAgents/
+# - Re-bootstraps com.caia.post-merge-watcher
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SRC_DIR="$REPO_ROOT/scripts/post-merge"
+PLIST_TEMPLATE="$REPO_ROOT/launchd/com.caia.post-merge-watcher.plist.template"
+
+POSTMERGE_HOME="${POSTMERGE_HOME:-$HOME/.caia/post-merge}"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+PLIST_LABEL="com.caia.post-merge-watcher"
+PLIST_PATH="$LAUNCH_AGENTS_DIR/${PLIST_LABEL}.plist"
+
+mkdir -p "$POSTMERGE_HOME" "$LAUNCH_AGENTS_DIR"
+
+install -m 0755 "$SRC_DIR/post-merge-watcher.sh" "$POSTMERGE_HOME/post-merge-watcher.sh"
+install -m 0755 "$SRC_DIR/post-merge-deploy.sh"  "$POSTMERGE_HOME/post-merge-deploy.sh"
+
+if [[ ! -f "$PLIST_TEMPLATE" ]]; then
+  echo "FATAL: plist template missing: $PLIST_TEMPLATE" >&2
+  exit 1
+fi
+
+# Render template — one substitution: {{HOME}}
+sed "s#{{HOME}}#${HOME}#g" "$PLIST_TEMPLATE" > "$PLIST_PATH"
+
+# Re-bootstrap (bootout is best-effort if not already loaded).
+launchctl bootout "gui/$(id -u)" "$PLIST_PATH" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+launchctl enable "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true
+launchctl kickstart "gui/$(id -u)/${PLIST_LABEL}" 2>/dev/null || true
+
+echo "post-merge-watcher installed and bootstrapped."
+echo "  state dir: $POSTMERGE_HOME"
+echo "  plist:     $PLIST_PATH"
+echo "  status:    launchctl print gui/$(id -u)/${PLIST_LABEL}"

--- a/scripts/post-merge/post-merge-deploy.sh
+++ b/scripts/post-merge/post-merge-deploy.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# INT.1.A1 — post-merge deploy stub.
+#
+# Receives a queue row JSON as argv[1] from `post-merge-watcher.sh`.
+# Today: records "saw merge $sha" to a per-repo log + the central
+# log.jsonl. Per-repo deploy actions plug in here later (e.g. K3s rollout
+# for stolution, plist re-bootstrap for caia packages).
+#
+# Operator extension point: add a `case $repo in` branch with the deploy
+# command for that repo.
+
+set -euo pipefail
+
+POSTMERGE_HOME="${POSTMERGE_HOME:-$HOME/.caia/post-merge}"
+mkdir -p "$POSTMERGE_HOME"
+
+# --- health-check shortcut ---------------------------------------------------
+if [[ "${1:-}" == "--health-check" ]]; then
+  printf '{"ok":true,"name":"post-merge-deploy","home":"%s"}\n' "$POSTMERGE_HOME"
+  exit 0
+fi
+
+row="${1:-}"
+if [[ -z "$row" ]]; then
+  echo "usage: post-merge-deploy.sh <row-json>" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"ts":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","level":"error","event":"deploy_jq_missing"}'
+  exit 0
+fi
+
+repo="$(printf '%s' "$row" | jq -r '.repo // "unknown"')"
+sha="$(printf '%s' "$row" | jq -r '.merge_sha // "unknown"')"
+pr="$(printf '%s' "$row" | jq -r '.pr_number // "unknown"')"
+base="$(printf '%s' "$row" | jq -r '.base_branch // "unknown"')"
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+repo_safe="${repo//\//__}"
+per_repo_log="$POSTMERGE_HOME/${repo_safe}.deploy.log"
+mkdir -p "$(dirname "$per_repo_log")"
+
+printf '[%s] saw merge %s for %s PR #%s on %s\n' "$ts" "$sha" "$repo" "$pr" "$base" >> "$per_repo_log"
+
+# Stub log line — operator extends with per-repo actions.
+printf '{"ts":"%s","level":"info","event":"deploy_stub","repo":"%s","merge_sha":"%s","pr_number":"%s","base_branch":"%s"}\n' \
+  "$ts" "$repo" "$sha" "$pr" "$base"
+
+# --- per-repo deploy plug-in points (extend below) --------------------------
+case "$repo" in
+  prakashgbid/caia)
+    # TODO: invoke per-package install scripts when packages/<x>/scripts/install-postmerge.sh exists.
+    :
+    ;;
+  prakashgbid/stolution)
+    # TODO: SSH to stolution, rsync new state, run deploy-*.sh idempotently.
+    :
+    ;;
+  *)
+    :
+    ;;
+esac
+
+exit 0

--- a/scripts/post-merge/post-merge-watcher.sh
+++ b/scripts/post-merge/post-merge-watcher.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# INT.1.A1 — Guardrail #7 post-merge deployment signal watcher.
+#
+# Polls the `post-merge-queue` orphan branch in each tracked repo, pops new
+# rows since last seen, invokes `post-merge-deploy.sh` per row, records
+# outcomes to `~/.caia/post-merge/log.jsonl`.
+#
+# Designed for `com.caia.post-merge-watcher` (StartInterval=60). Idempotent;
+# safe to re-run.
+#
+# Tracked repos: edit POSTMERGE_REPOS to add more.
+
+set -euo pipefail
+
+POSTMERGE_HOME="${POSTMERGE_HOME:-$HOME/.caia/post-merge}"
+POSTMERGE_REPOS="${POSTMERGE_REPOS:-prakashgbid/caia prakashgbid/stolution}"
+POSTMERGE_DEPLOY="${POSTMERGE_DEPLOY:-$POSTMERGE_HOME/post-merge-deploy.sh}"
+POSTMERGE_QUEUE_BRANCH="${POSTMERGE_QUEUE_BRANCH:-post-merge-queue}"
+POSTMERGE_MAX_ROWS="${POSTMERGE_MAX_ROWS:-50}"
+
+mkdir -p "$POSTMERGE_HOME" "$POSTMERGE_HOME/work" "$POSTMERGE_HOME/seen"
+SEEN_FILE="$POSTMERGE_HOME/seen.jsonl"
+LOG_FILE="$POSTMERGE_HOME/log.jsonl"
+LOCK_FILE="$POSTMERGE_HOME/watcher.lock"
+touch "$SEEN_FILE" "$LOG_FILE"
+
+log_event() {
+  local level="$1" event="$2" extra="${3:-}"
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [[ -n "$extra" ]]; then
+    printf '{"ts":"%s","level":"%s","event":"%s",%s}\n' "$ts" "$level" "$event" "$extra" >> "$LOG_FILE"
+  else
+    printf '{"ts":"%s","level":"%s","event":"%s"}\n' "$ts" "$level" "$event" >> "$LOG_FILE"
+  fi
+}
+
+# --- health-check shortcut ---------------------------------------------------
+if [[ "${1:-}" == "--health-check" ]]; then
+  printf '{"ok":true,"name":"post-merge-watcher","home":"%s"}\n' "$POSTMERGE_HOME"
+  exit 0
+fi
+
+# --- single-instance lock (flock if available, mkdir fallback) ---------------
+acquire_lock() {
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+      log_event info skip_already_running ""
+      exit 0
+    fi
+  else
+    if ! mkdir "$LOCK_FILE.d" 2>/dev/null; then
+      log_event info skip_already_running ""
+      exit 0
+    fi
+    trap 'rmdir "$LOCK_FILE.d" 2>/dev/null || true' EXIT
+  fi
+}
+acquire_lock
+
+if ! command -v gh >/dev/null 2>&1; then
+  log_event error gh_missing ""
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  log_event error jq_missing ""
+  exit 0
+fi
+if [[ ! -x "$POSTMERGE_DEPLOY" ]]; then
+  log_event error deploy_script_missing "\"path\":\"$POSTMERGE_DEPLOY\""
+  exit 0
+fi
+
+process_row() {
+  local row="$1"
+  local sha
+  sha="$(printf '%s' "$row" | jq -r '.merge_sha // empty')"
+  if [[ -z "$sha" || "$sha" == "null" ]]; then
+    log_event warn row_missing_sha "\"row\":$(printf '%s' "$row" | jq -Rs .)"
+    return 0
+  fi
+  if grep -F -q -- "$sha" "$SEEN_FILE" 2>/dev/null; then
+    return 0
+  fi
+  log_event info dispatch "\"merge_sha\":\"$sha\""
+  local rc=0
+  "$POSTMERGE_DEPLOY" "$row" >> "$LOG_FILE" 2>&1 || rc=$?
+  printf '%s\n' "$row" >> "$SEEN_FILE"
+  log_event info dispatch_done "\"merge_sha\":\"$sha\",\"rc\":$rc"
+}
+
+for repo in $POSTMERGE_REPOS; do
+  repo_safe="${repo//\//__}"
+  raw_url="repos/${repo}/contents/queue.jsonl?ref=${POSTMERGE_QUEUE_BRANCH}"
+  tmp_queue="$POSTMERGE_HOME/work/${repo_safe}.queue.jsonl"
+  if ! gh api "$raw_url" -H "Accept: application/vnd.github.raw" > "$tmp_queue.new" 2>"$tmp_queue.err"; then
+    if grep -q "Not Found\|404" "$tmp_queue.err" 2>/dev/null; then
+      # Branch or file not yet created — first merge hasn't fired.
+      :
+    else
+      log_event warn fetch_failed "\"repo\":\"$repo\",\"err\":$(jq -Rs . < "$tmp_queue.err")"
+    fi
+    rm -f "$tmp_queue.new" "$tmp_queue.err"
+    continue
+  fi
+  rm -f "$tmp_queue.err"
+  mv "$tmp_queue.new" "$tmp_queue"
+
+  rows_processed=0
+  while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+    process_row "$row"
+    rows_processed=$((rows_processed + 1))
+    if (( rows_processed >= POSTMERGE_MAX_ROWS )); then
+      log_event info batch_cap_reached "\"repo\":\"$repo\",\"cap\":$POSTMERGE_MAX_ROWS"
+      break
+    fi
+  done < "$tmp_queue"
+done
+
+log_event info tick_done ""


### PR DESCRIPTION
## Summary

Lands **INT.1.A1** (DoD v2 Guardrail #7) — the **post-merge deployment signal pipeline**. End-to-end:

```
PR merged on develop|main
       │
       ▼
.github/workflows/post-merge-signal.yml   (this PR; companion in stolution)
       │  appends one JSON-Lines row to queue.jsonl on the orphan
       │  branch `post-merge-queue` (uses GITHUB_TOKEN, no PAT)
       ▼
~/.caia/post-merge/post-merge-watcher.sh  (launchd, 60s tick)
       │  pops new rows via `gh api repos/<repo>/contents/queue.jsonl`
       │  dedupes against ~/.caia/post-merge/seen.jsonl
       ▼
~/.caia/post-merge/post-merge-deploy.sh <row-json>
       │  per-repo deploy stub today; operator extends per repo
```

## Why pull (not push)

GHA cloud runners can't reach the operator's Mac directly. Two options:

1. **Push:** runner SSHes into a Tailscale-reachable host with a runner-side key.
2. **Pull (chosen):** GHA writes a row via `GITHUB_TOKEN`; the local watcher pulls.

Pull wins: no SSH key on GHA, no Tailscale exposure, no operator PAT, and the queue is replay-safe (append-only with `merge_sha` dedupe).

## Files added

- `.github/workflows/post-merge-signal.yml` — GHA enqueuer (concurrency-grouped, retries push 5×)
- `scripts/post-merge/post-merge-watcher.sh` — launchd watcher (single-instance flock)
- `scripts/post-merge/post-merge-deploy.sh` — per-row deploy stub (operator extension point)
- `scripts/post-merge/install.sh` — idempotent install (chmods, renders plist, bootouts+bootstraps)
- `scripts/post-merge/README.md` — operator runbook
- `launchd/com.caia.post-merge-watcher.plist.template` — naming follows the existing com.caia.* cohort

## Queue row format (JSON-Lines on orphan branch \`post-merge-queue\`)

\`\`\`json
{
  \"schema_version\": 1,
  \"pr_number\": 451,
  \"repo\": \"prakashgbid/caia\",
  \"merge_sha\": \"abc12345...\",
  \"base_branch\": \"develop\",
  \"ts\": \"2026-05-15T00:00:00Z\",
  \"pr_title\": \"...\",
  \"pr_author\": \"...\"
}
\`\`\`

## Test plan

- [x] \`bash -n\` syntax check on all three scripts
- [x] \`--health-check\` shortcut returns JSON+exit 0 for watcher and deploy
- [x] PyYAML parse of the workflow file
- [x] Local smoke: deploy stub records "saw merge $sha" with synthetic row → per-repo log lines written
- [x] Dedupe shape verified (grep -F against seen.jsonl)
- [ ] CI green
- [ ] Post-merge: stolution-side workflow lands as a follow-up PR (\`prakashgbid/stolution\`)
- [ ] First real merge fires the watcher → log.jsonl entry on operator Mac

## Companion docs

- Phase report: \`reports/int1_a1_post_merge_signal_2026-05-14.md\`
- Plan: \`reports/integration_remediation_plan_2026-05-14.md\` §A1 (decision AR-2)
- DoD v2: \`reports/definition_of_done_v2_2026-05-14.md\` §3.a Guardrail 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)