### PR TITLE
feat(chain-runner): h-38 + h-39 + h-40 cluster C — watchdog consolidation (p11c)

### DIFF
--- a/packages/chain-runner/bin/watchdog.cjs
+++ b/packages/chain-runner/bin/watchdog.cjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// Belt-and-suspenders watchdog for the chain-runner.
+//
+// H-38 (chain-runner-battle-harden phase 11, 2026-05-14). Pre-H-38 this
+// file owned a duplicate of the stall-detection / alert-emit logic that
+// also lived in src/watchdog.ts and src/alerting.ts (the TS check-stall +
+// emit-alert verbs). Two writers, one signal — drift across them was the
+// source of two confusing past incidents. Post-H-38 this file is a thin
+// shim: it iterates ~/.caia/chain/* directories, looks each chain up in
+// the per-chain registry (~/.caia/chain-watchdog/<chain-id>.phases for the
+// YAML and <chain-id>.runner for the optional poke command), and forks
+// `caia-chain check-stall` per chain. The TS owns alert dedupe, channel
+// fan-out, and audit recording.
+//
+// H-39 (phase 11, 2026-05-14). pokeChain semantics preserved. Wake scripts
+// live as <chain-id>.runner files in this directory; their contents is a
+// single shell command run on stall (typically the per-chain wake script).
+//
+// H-40 (phase 11, 2026-05-14). Once per UTC day the shim also runs
+// `caia-chain prune-inbox --inbox INBOX.md --days 7` so the live INBOX
+// stays small. The state cookie .last_prune.json records when it last ran
+// to avoid re-pruning on every wake.
+//
+// Logs land in ~/.caia/chain-watchdog/watchdog.scan.log (script-internal,
+// verbose) and ~/.caia/chain-watchdog/watchdog.out.log (launchd stdout —
+// one summary line per scan). H-41 (cluster B of phase 11).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const cp = require('node:child_process');
+
+const CHAIN_ROOT = process.env.CAIA_CHAIN_HOME || path.join(os.homedir(), '.caia', 'chain');
+// H-38: WATCHDOG_HOME also honors an env override so the tests + sandbox
+// setups can point the shim at a tmpdir without having to spoof HOME.
+const WATCHDOG_HOME =
+  process.env.CAIA_WATCHDOG_HOME || path.join(os.homedir(), '.caia', 'chain-watchdog');
+const INBOX_PATH = path.join(WATCHDOG_HOME, 'INBOX.md');
+const LOG_PATH = path.join(WATCHDOG_HOME, 'watchdog.scan.log');
+const PRUNE_COOKIE = path.join(WATCHDOG_HOME, '.last_prune.json');
+const STALL_THRESHOLD_SEC = Number(process.env.CAIA_WATCHDOG_THRESHOLD_SEC || 3600);
+const RETENTION_DAYS = Number(process.env.CAIA_WATCHDOG_INBOX_DAYS || 7);
+const CAIA_CHAIN_BIN =
+  process.env.CAIA_CHAIN_BIN ||
+  path.join(
+    os.homedir(),
+    'Documents',
+    'projects',
+    'caia',
+    'packages',
+    'chain-runner',
+    'bin',
+    'caia-chain.js',
+  );
+const NODE_BIN = process.env.NODE_BIN || process.execPath;
+
+function log(...parts) {
+  const line = `[${new Date().toISOString()}] ${parts.join(' ')}\n`;
+  try {
+    fs.mkdirSync(WATCHDOG_HOME, { recursive: true });
+    fs.appendFileSync(LOG_PATH, line);
+  } catch {}
+}
+
+function emitStdoutSummary(parts) {
+  process.stdout.write(`[${new Date().toISOString()}] ${parts.join(' ')}\n`);
+}
+
+function readJsonSafe(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+}
+
+// H-38: per-chain registry lookup. Returns the path to the phases YAML for
+// `chainId` if a `<chain-id>.phases` file exists in WATCHDOG_HOME and points
+// to a readable file. Otherwise returns null and the chain is skipped.
+function findPhasesYaml(chainId) {
+  const reg = path.join(WATCHDOG_HOME, `${chainId}.phases`);
+  if (!fs.existsSync(reg)) return null;
+  let p;
+  try {
+    p = fs.readFileSync(reg, 'utf8').trim();
+  } catch (err) {
+    log('phases_registry_read_failed', chainId, err.message);
+    return null;
+  }
+  if (!p) return null;
+  // Expand ~ if present.
+  if (p.startsWith('~')) p = path.join(os.homedir(), p.slice(1));
+  if (!fs.existsSync(p)) {
+    log('phases_yaml_missing', chainId, p);
+    return null;
+  }
+  return p;
+}
+
+// H-39: optional re-register/poke command. Same convention as pre-H-38 — the
+// chain id maps to a single shell command line in <chain-id>.runner. Forwarded
+// to `caia-chain check-stall --reregister-cmd` so the TS owns the actual exec.
+function findRunnerCmd(chainId) {
+  const reg = path.join(WATCHDOG_HOME, `${chainId}.runner`);
+  if (!fs.existsSync(reg)) return null;
+  try {
+    const txt = fs.readFileSync(reg, 'utf8').trim();
+    return txt || null;
+  } catch {
+    return null;
+  }
+}
+
+// H-38: invoke `caia-chain check-stall`. The TS owns:
+//   - the actual stall threshold computation
+//   - audit-event emission (cron_stall_detected via emit-alert)
+//   - INBOX append + handoff JSONL append + osascript notification
+//   - 6h fingerprint dedupe across all those channels
+function runCheckStall(chainId, phasesPath, runnerCmd) {
+  if (!fs.existsSync(CAIA_CHAIN_BIN)) {
+    log('check_stall_skipped_no_bin', chainId, CAIA_CHAIN_BIN);
+    return { ran: false, reason: 'no_bin' };
+  }
+  const args = [
+    CAIA_CHAIN_BIN,
+    'check-stall',
+    '--chain-id', chainId,
+    '--phases', phasesPath,
+    '--wake-interval-sec', '900',
+    '--multiplier', String(Math.ceil(STALL_THRESHOLD_SEC / 900)),
+    '--inbox', INBOX_PATH,
+    '--alert-on-streak', '2',
+  ];
+  if (runnerCmd) {
+    args.push('--reregister-cmd', runnerCmd);
+  }
+  try {
+    const out = cp.spawnSync(NODE_BIN, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+    });
+    const stdoutStr = (out.stdout || '').toString('utf8').trim();
+    const stderrStr = (out.stderr || '').toString('utf8').trim();
+    log('check_stall', chainId, 'exit=', out.status, 'out=', stdoutStr);
+    if (stderrStr) log('check_stall_stderr', chainId, stderrStr);
+    return { ran: true, exit: out.status, out: stdoutStr };
+  } catch (err) {
+    log('check_stall_failed', chainId, err.message);
+    return { ran: false, reason: err.message };
+  }
+}
+
+// H-40: daily INBOX prune. Reads .last_prune.json; if today's UTC date is
+// past the cookie, runs `caia-chain prune-inbox` and refreshes the cookie.
+function maybePruneInbox() {
+  if (!fs.existsSync(CAIA_CHAIN_BIN)) return { ran: false, reason: 'no_bin' };
+  const todayKey = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
+  const cookie = readJsonSafe(PRUNE_COOKIE);
+  if (cookie && cookie.last_run === todayKey) {
+    return { ran: false, reason: 'already_today' };
+  }
+  if (!fs.existsSync(INBOX_PATH)) {
+    // Mark cookie anyway so we don't re-check on every wake.
+    try {
+      fs.writeFileSync(PRUNE_COOKIE, JSON.stringify({ last_run: todayKey }));
+    } catch {}
+    return { ran: false, reason: 'no_inbox' };
+  }
+  const args = [
+    CAIA_CHAIN_BIN,
+    'prune-inbox',
+    '--inbox', INBOX_PATH,
+    '--days', String(RETENTION_DAYS),
+  ];
+  try {
+    const out = cp.spawnSync(NODE_BIN, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+    });
+    const stdoutStr = (out.stdout || '').toString('utf8').trim();
+    log('prune_inbox', 'exit=', out.status, 'out=', stdoutStr);
+    try {
+      fs.writeFileSync(PRUNE_COOKIE, JSON.stringify({ last_run: todayKey, summary: stdoutStr }));
+    } catch {}
+    return { ran: true, exit: out.status, out: stdoutStr };
+  } catch (err) {
+    log('prune_inbox_failed', err.message);
+    return { ran: false, reason: err.message };
+  }
+}
+
+function listChains() {
+  if (!fs.existsSync(CHAIN_ROOT)) return [];
+  return fs.readdirSync(CHAIN_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+}
+
+function scanAndDelegate() {
+  const chains = listChains();
+  let scanned = 0;
+  let delegated = 0;
+  let skipped = 0;
+  for (const chainId of chains) {
+    const stateFile = path.join(CHAIN_ROOT, chainId, 'state.json');
+    if (!fs.existsSync(stateFile)) continue;
+    scanned += 1;
+    const state = readJsonSafe(stateFile);
+    if (!state) {
+      log('unparseable_state', chainId);
+      continue;
+    }
+    if (state.all_done) continue;
+    if (state.paused) continue;
+    const phasesPath = findPhasesYaml(chainId);
+    if (!phasesPath) {
+      log('skipping_no_phases_yaml', chainId);
+      skipped += 1;
+      continue;
+    }
+    const runnerCmd = findRunnerCmd(chainId);
+    runCheckStall(chainId, phasesPath, runnerCmd);
+    delegated += 1;
+  }
+  const pruneResult = maybePruneInbox();
+  log('scan_complete', 'scanned=', scanned, 'delegated=', delegated, 'skipped=', skipped, 'prune_ran=', pruneResult.ran);
+  emitStdoutSummary([
+    `scan_complete scanned=${scanned} delegated=${delegated} skipped=${skipped} prune_ran=${pruneResult.ran}`,
+  ]);
+}
+
+scanAndDelegate();

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -74,6 +74,10 @@ import {
   preflightDispatch,
 } from './preflight.js';
 import { spawnSync } from 'node:child_process';
+import {
+  DEFAULT_RETENTION_DAYS as INBOX_RETENTION_DEFAULT,
+  pruneInbox,
+} from './inbox-retention.js';
 
 interface BaseOptions {
   chainId: string;
@@ -1317,6 +1321,55 @@ export function buildProgram(): Command {
           if (lastStderr) process.stderr.write(lastStderr);
           process.stderr.write(`RETRY_EXHAUSTED ${(err as Error).message}\n`);
           process.exit(lastCode ?? 5);
+        }
+      },
+    );
+
+  // H-40 (chain-runner-battle-harden phase 11, 2026-05-14). prune-inbox —
+  // archive H2 alert blocks older than `--days` from the chain-watchdog
+  // INBOX.md into per-month files under `<archive-dir>/<yyyy-mm>.md`. The
+  // watchdog shim (bin/watchdog.js) wakes once per UTC day and invokes this
+  // verb so the live INBOX stays scannable. Operator can also run it
+  // ad-hoc; the verb is idempotent.
+  program
+    .command('prune-inbox')
+    .description(
+      'Archive alerts older than --days from a chain-watchdog INBOX.md into <archive-dir>/<yyyy-mm>.md (default 7d retention).',
+    )
+    .requiredOption('--inbox <path>', 'path to INBOX.md')
+    .option(
+      '--days <n>',
+      `retention window in days (default ${INBOX_RETENTION_DEFAULT})`,
+      String(INBOX_RETENTION_DEFAULT),
+    )
+    .option(
+      '--archive-dir <path>',
+      'archive output directory (default <dirname(inbox)>/INBOX_archive)',
+    )
+    .option('--json', 'emit machine-readable JSON instead of the text summary')
+    .action(
+      (cmdOpts: {
+        inbox: string;
+        days?: string;
+        archiveDir?: string;
+        json?: boolean;
+      }) => {
+        const opts: Parameters<typeof pruneInbox>[0] = {
+          inboxPath: cmdOpts.inbox,
+          days: Number(cmdOpts.days ?? INBOX_RETENTION_DEFAULT),
+        };
+        if (cmdOpts.archiveDir) opts.archiveDir = cmdOpts.archiveDir;
+        const r = pruneInbox(opts);
+        if (cmdOpts.json) {
+          process.stdout.write(`${JSON.stringify(r, null, 2)}\n`);
+        } else {
+          const archived =
+            Object.entries(r.archived)
+              .map(([f, n]) => `${f}=${n}`)
+              .join(',') || 'none';
+          process.stdout.write(
+            `INBOX_PRUNED scanned=${r.scanned} kept=${r.kept} archived=${archived} bytes=${r.archive_bytes} rewrote=${r.rewrote_inbox}\n`,
+          );
         }
       },
     );

--- a/packages/chain-runner/src/inbox-retention.ts
+++ b/packages/chain-runner/src/inbox-retention.ts
@@ -1,0 +1,186 @@
+// H-40 (chain-runner-battle-harden phase 11, 2026-05-14). INBOX retention.
+// The chain-watchdog INBOX.md grows unboundedly as alerts are appended over
+// time. This helper splits it: alerts older than `--days` are moved into
+// a per-month archive file (INBOX_archive/<yyyy-mm>.md) so the live INBOX
+// stays small enough for an operator to scan.
+//
+// Format expected: each alert is a markdown H2 block led by an ISO-8601
+// timestamp inside the heading text. The detection pattern matches both
+// formats currently emitted:
+//   "## YYYY-MM-DDTHH:MM:SSZ — <title>"            (wake_emit_alert)
+//   "## [YYYY-MM-DDTHH:MM:SS.<ms>Z] <type> — ..."  (watchdog.js inbox fallback)
+// Any block whose heading lacks a parseable ISO timestamp is preserved
+// in the live INBOX (better safe than archive-and-lose-context).
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export const DEFAULT_RETENTION_DAYS = 7;
+
+// Any H2 heading is a candidate alert block. We separately try to parse an
+// ISO timestamp out of the heading — a heading without a parseable
+// timestamp still becomes a block (so its body isn't accidentally folded
+// into the next block), and pruneInbox preserves it in the live INBOX.
+const H2_HEADING = /^##\s/;
+const TS_IN_HEADING = /\[?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\]?/;
+
+export interface PruneInboxOptions {
+  /** Path to the INBOX.md file. */
+  inboxPath: string;
+  /** Days of retention. Alerts older than this are archived. */
+  days?: number;
+  /**
+   * Directory where archive files are written. Defaults to
+   * `<dirname(inboxPath)>/INBOX_archive`.
+   */
+  archiveDir?: string;
+  /** Override "now" for tests — defaults to Date.now(). */
+  now?: Date;
+}
+
+export interface AlertBlock {
+  /** First line (the heading). */
+  heading: string;
+  /** Timestamp parsed from the heading; null when unparseable. */
+  ts: Date | null;
+  /** Full text (heading + following lines until next H2). */
+  body: string;
+}
+
+export interface PruneInboxResult {
+  inbox_path: string;
+  /** Total H2 alert blocks scanned. */
+  scanned: number;
+  /** Blocks kept in INBOX.md. */
+  kept: number;
+  /** Blocks archived (by archive file path). */
+  archived: Record<string, number>;
+  /** Bytes written to archive files (sum). */
+  archive_bytes: number;
+  /** Whether INBOX.md was rewritten (false when nothing pruned). */
+  rewrote_inbox: boolean;
+}
+
+/**
+ * Parse an INBOX.md file into discrete alert blocks. Any preamble before
+ * the first H2 heading (e.g. "# Chain-Watchdog INBOX") is returned via
+ * `preamble` and preserved verbatim on rewrite.
+ */
+export function parseInbox(text: string): { preamble: string; blocks: AlertBlock[] } {
+  const lines = text.split('\n');
+  const blocks: AlertBlock[] = [];
+  const preambleLines: string[] = [];
+  let current: AlertBlock | null = null;
+  let inPreamble = true;
+  for (const line of lines) {
+    if (H2_HEADING.test(line)) {
+      if (current) {
+        blocks.push(current);
+      }
+      const m = TS_IN_HEADING.exec(line);
+      const tsRaw = m?.[1] ?? null;
+      let ts: Date | null = null;
+      if (tsRaw) {
+        const iso = tsRaw.endsWith('Z') ? tsRaw : `${tsRaw}Z`;
+        const d = new Date(iso);
+        ts = Number.isFinite(d.getTime()) ? d : null;
+      }
+      current = { heading: line, ts, body: line };
+      inPreamble = false;
+      continue;
+    }
+    if (current) {
+      current.body += `\n${line}`;
+    } else if (inPreamble) {
+      preambleLines.push(line);
+    }
+  }
+  if (current) blocks.push(current);
+  // Trim trailing blank lines from preamble for cleaner rewrites.
+  while (
+    preambleLines.length > 0 &&
+    preambleLines[preambleLines.length - 1]!.trim() === ''
+  ) {
+    preambleLines.pop();
+  }
+  const preamble =
+    preambleLines.length > 0 ? `${preambleLines.join('\n')}\n` : '';
+  return { preamble, blocks };
+}
+
+function archiveFilenameFor(date: Date): string {
+  const yyyy = date.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  return `${yyyy}-${mm}.md`;
+}
+
+export function pruneInbox(opts: PruneInboxOptions): PruneInboxResult {
+  const days = opts.days ?? DEFAULT_RETENTION_DAYS;
+  const now = opts.now ?? new Date();
+  const archiveDir = opts.archiveDir ?? join(dirname(opts.inboxPath), 'INBOX_archive');
+  const result: PruneInboxResult = {
+    inbox_path: opts.inboxPath,
+    scanned: 0,
+    kept: 0,
+    archived: {},
+    archive_bytes: 0,
+    rewrote_inbox: false,
+  };
+  if (!existsSync(opts.inboxPath)) return result;
+  const text = readFileSync(opts.inboxPath, 'utf8');
+  const { preamble, blocks } = parseInbox(text);
+  result.scanned = blocks.length;
+  if (blocks.length === 0) return result;
+  const cutoffMs = now.getTime() - days * 86400 * 1000;
+  const keep: AlertBlock[] = [];
+  const archive: AlertBlock[] = [];
+  for (const block of blocks) {
+    if (block.ts && block.ts.getTime() < cutoffMs) {
+      archive.push(block);
+    } else {
+      keep.push(block);
+    }
+  }
+  result.kept = keep.length;
+  if (archive.length === 0) return result;
+  // Group archived blocks by month (UTC).
+  const byMonth = new Map<string, AlertBlock[]>();
+  for (const block of archive) {
+    if (!block.ts) continue;
+    const key = archiveFilenameFor(block.ts);
+    const arr = byMonth.get(key) ?? [];
+    arr.push(block);
+    byMonth.set(key, arr);
+  }
+  mkdirSync(archiveDir, { recursive: true });
+  for (const [filename, monthBlocks] of byMonth) {
+    const path = join(archiveDir, filename);
+    const existingPreamble = existsSync(path) ? '' : `# INBOX archive — ${filename.replace('.md', '')}\n\n`;
+    const append = monthBlocks.map((b) => b.body.trimEnd()).join('\n\n') + '\n';
+    const writeText = existingPreamble + append;
+    if (existsSync(path)) {
+      // Append to existing archive — read + concat preserves headers.
+      const prev = readFileSync(path, 'utf8');
+      const sep = prev.endsWith('\n') ? '' : '\n';
+      writeFileSync(path, `${prev}${sep}${append}`);
+    } else {
+      writeFileSync(path, writeText);
+    }
+    result.archived[filename] = monthBlocks.length;
+    result.archive_bytes += Buffer.byteLength(writeText, 'utf8');
+  }
+  // Rewrite INBOX.md with preamble + kept blocks only.
+  const rewrite =
+    preamble +
+    (keep.length > 0
+      ? keep.map((b) => b.body.trimEnd()).join('\n\n') + '\n'
+      : '');
+  writeFileSync(opts.inboxPath, rewrite);
+  result.rewrote_inbox = true;
+  return result;
+}

--- a/packages/chain-runner/tests/inbox-retention.test.ts
+++ b/packages/chain-runner/tests/inbox-retention.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DEFAULT_RETENTION_DAYS,
+  parseInbox,
+  pruneInbox,
+} from '../src/inbox-retention.js';
+
+// H-40 tests (chain-runner-battle-harden phase 11, 2026-05-14).
+
+describe('H-40 INBOX retention', () => {
+  let dir: string;
+  let inboxPath: string;
+  let archiveDir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'caia-inbox-'));
+    inboxPath = join(dir, 'INBOX.md');
+    archiveDir = join(dir, 'INBOX_archive');
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('parseInbox separates preamble from H2 alert blocks', () => {
+    const text = `# Chain-Watchdog INBOX\n\n## 2026-05-13T10:00:00Z — alert one\n- chain: x\n\n## 2026-05-14T11:00:00Z — alert two\n- chain: y\n`;
+    const { preamble, blocks } = parseInbox(text);
+    expect(preamble.startsWith('# Chain-Watchdog INBOX')).toBe(true);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]!.ts?.toISOString()).toBe('2026-05-13T10:00:00.000Z');
+    expect(blocks[0]!.body).toContain('alert one');
+    expect(blocks[1]!.ts?.toISOString()).toBe('2026-05-14T11:00:00.000Z');
+  });
+
+  it('parseInbox handles bracketed timestamps and milliseconds', () => {
+    const text = `## [2026-05-13T10:00:00.123Z] cron_stall_detected — chain-x\n- detail: foo\n`;
+    const { blocks } = parseInbox(text);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]!.ts?.toISOString()).toBe('2026-05-13T10:00:00.123Z');
+  });
+
+  it('pruneInbox is a no-op on a missing INBOX', () => {
+    const r = pruneInbox({ inboxPath, days: 7 });
+    expect(r.scanned).toBe(0);
+    expect(r.kept).toBe(0);
+    expect(r.rewrote_inbox).toBe(false);
+  });
+
+  it('pruneInbox is a no-op when nothing is past retention', () => {
+    const now = new Date('2026-05-14T12:00:00Z');
+    const recent = new Date(now.getTime() - 86400 * 1000)
+      .toISOString()
+      .replace(/\.\d+Z$/, 'Z');
+    const text = `# INBOX\n\n## ${recent} — recent alert\n- detail: hi\n`;
+    writeFileSync(inboxPath, text);
+    const r = pruneInbox({ inboxPath, days: 7, now });
+    expect(r.scanned).toBe(1);
+    expect(r.kept).toBe(1);
+    expect(r.rewrote_inbox).toBe(false);
+    expect(existsSync(archiveDir)).toBe(false);
+  });
+
+  it('pruneInbox archives old alerts to <yyyy-mm>.md and rewrites INBOX', () => {
+    const now = new Date('2026-05-14T12:00:00Z');
+    const old1 = '2026-04-01T00:00:00Z';
+    const old2 = '2026-04-15T00:00:00Z';
+    const new1 = '2026-05-13T00:00:00Z';
+    const text =
+      `# INBOX\n\n` +
+      `## ${old1} — april alert one\n- chain: a\n\n` +
+      `## ${old2} — april alert two\n- chain: b\n\n` +
+      `## ${new1} — may recent alert\n- chain: c\n`;
+    writeFileSync(inboxPath, text);
+    const r = pruneInbox({ inboxPath, days: 7, now });
+    expect(r.scanned).toBe(3);
+    expect(r.kept).toBe(1);
+    expect(r.archived['2026-04.md']).toBe(2);
+    expect(r.rewrote_inbox).toBe(true);
+    // Archive file exists with both april alerts.
+    const aprilPath = join(archiveDir, '2026-04.md');
+    expect(existsSync(aprilPath)).toBe(true);
+    const archive = readFileSync(aprilPath, 'utf8');
+    expect(archive).toContain('april alert one');
+    expect(archive).toContain('april alert two');
+    // INBOX retains preamble + may alert only.
+    const newInbox = readFileSync(inboxPath, 'utf8');
+    expect(newInbox).toContain('# INBOX');
+    expect(newInbox).toContain('may recent alert');
+    expect(newInbox).not.toContain('april alert one');
+  });
+
+  it('pruneInbox appends to an existing archive file (idempotent across runs)', () => {
+    const now = new Date('2026-05-14T12:00:00Z');
+    const old = '2026-04-01T00:00:00Z';
+    writeFileSync(
+      inboxPath,
+      `# INBOX\n\n## ${old} — first old alert\n- chain: a\n`,
+    );
+    const r1 = pruneInbox({ inboxPath, days: 7, now });
+    expect(r1.kept).toBe(0);
+    // Re-add another old alert and prune again.
+    writeFileSync(
+      inboxPath,
+      `# INBOX\n\n## ${old} — second old alert\n- chain: b\n`,
+    );
+    const r2 = pruneInbox({ inboxPath, days: 7, now });
+    expect(r2.kept).toBe(0);
+    const archive = readFileSync(join(archiveDir, '2026-04.md'), 'utf8');
+    expect(archive).toContain('first old alert');
+    expect(archive).toContain('second old alert');
+    // No duplicate header.
+    const headerCount = (archive.match(/^# INBOX archive — 2026-04$/m) ?? []).length;
+    expect(headerCount).toBe(1);
+  });
+
+  it('pruneInbox preserves blocks with unparseable timestamps', () => {
+    const now = new Date('2026-05-14T12:00:00Z');
+    const text =
+      `# INBOX\n\n` +
+      `## not-a-timestamp — weird block\n- chain: ?\n\n` +
+      `## 2026-04-01T00:00:00Z — old alert\n- chain: a\n`;
+    writeFileSync(inboxPath, text);
+    const r = pruneInbox({ inboxPath, days: 7, now });
+    expect(r.kept).toBe(1); // the unparseable one survives
+    const newInbox = readFileSync(inboxPath, 'utf8');
+    expect(newInbox).toContain('weird block');
+    expect(newInbox).not.toContain('old alert');
+  });
+
+  it('uses DEFAULT_RETENTION_DAYS=7 by default', () => {
+    expect(DEFAULT_RETENTION_DAYS).toBe(7);
+  });
+
+  it('groups archived alerts spanning multiple months', () => {
+    const now = new Date('2026-05-14T12:00:00Z');
+    const text =
+      `## 2026-03-15T00:00:00Z — march alert\n- chain: a\n\n` +
+      `## 2026-04-15T00:00:00Z — april alert\n- chain: b\n\n` +
+      `## 2026-05-13T00:00:00Z — may alert\n- chain: c\n`;
+    writeFileSync(inboxPath, text);
+    const r = pruneInbox({ inboxPath, days: 7, now });
+    expect(Object.keys(r.archived).sort()).toEqual([
+      '2026-03.md',
+      '2026-04.md',
+    ]);
+    expect(readdirSync(archiveDir).sort()).toEqual([
+      '2026-03.md',
+      '2026-04.md',
+    ]);
+  });
+});

--- a/packages/chain-runner/tests/watchdog_shim.test.ts
+++ b/packages/chain-runner/tests/watchdog_shim.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// H-38 / H-39 / H-40 (chain-runner-battle-harden phase 11, 2026-05-14).
+// End-to-end smoke test for bin/watchdog.js — the chain-watchdog shim.
+//
+// The shim replaced a duplicate stall-detection path that previously lived
+// inside the watchdog itself. Now it iterates ~/.caia/chain/* (via
+// CAIA_CHAIN_HOME), per-chain looks up <chain-id>.phases for the YAML and
+// optionally <chain-id>.runner for a poke command (H-39), then forks
+// `caia-chain check-stall` per chain. INBOX retention (H-40) runs once
+// per UTC day. Audit / alerting / dedupe stay in the TS owner.
+
+const REPO_ROOT = join(__dirname, '..');
+const WATCHDOG_BIN = join(REPO_ROOT, 'bin', 'watchdog.cjs');
+const CHAIN_CLI = join(REPO_ROOT, 'bin', 'caia-chain.js');
+
+const NODE_BIN = process.execPath;
+
+function writeYamlSpec(dir: string): string {
+  const p = join(dir, 'phases.yaml');
+  writeFileSync(
+    p,
+    `defaults:\n  max_minutes: 10\n  heartbeat_interval_sec: 60\nphases:\n  - id: 1\n    name: smoke\n`,
+  );
+  return p;
+}
+
+describe('H-38/H-39/H-40 chain-watchdog shim (bin/watchdog.js)', () => {
+  let baseDir: string;
+  let chainHome: string;
+  let watchdogHome: string;
+  let chainDir: string;
+  let inboxPath: string;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'caia-watchdog-shim-'));
+    chainHome = join(baseDir, 'chain');
+    watchdogHome = join(baseDir, 'chain-watchdog');
+    mkdirSync(chainHome, { recursive: true });
+    mkdirSync(watchdogHome, { recursive: true });
+    inboxPath = join(watchdogHome, 'INBOX.md');
+
+    // Create a single chain folder under CAIA_CHAIN_HOME with a state.json.
+    chainDir = join(chainHome, 'shim-test-chain');
+    mkdirSync(chainDir, { recursive: true });
+    writeFileSync(
+      join(chainDir, 'state.json'),
+      JSON.stringify({
+        schema_version: 2,
+        started_at: '2026-05-14T00:00:00Z',
+        last_wake: new Date().toISOString(),
+        paused: false,
+        budget_consumed_pct: 0,
+        budget_cap_pct: 100,
+        phase_status: {
+          '1': {
+            status: 'pending',
+            attempts: 0,
+            max_retries: 2,
+            max_minutes: 10,
+            started_at: null,
+            completed_at: null,
+            session_id: null,
+            error: null,
+          },
+        },
+        current_phase: null,
+        all_done: false,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  function spawnWatchdog(env: NodeJS.ProcessEnv = {}) {
+    return spawnSync(NODE_BIN, [WATCHDOG_BIN], {
+      env: {
+        ...process.env,
+        CAIA_CHAIN_HOME: chainHome,
+        CAIA_WATCHDOG_HOME: watchdogHome,
+        CAIA_CHAIN_BIN: CHAIN_CLI,
+        ...env,
+      },
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+  }
+
+  it('emits one stdout summary line per scan and writes watchdog.scan.log', () => {
+    const phasesPath = writeYamlSpec(baseDir);
+    writeFileSync(join(watchdogHome, 'shim-test-chain.phases'), phasesPath);
+
+    const r = spawnWatchdog();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/scan_complete scanned=1 delegated=1/);
+    // scan.log gets a per-event log (multiline).
+    const scanLog = readFileSync(join(watchdogHome, 'watchdog.scan.log'), 'utf8');
+    expect(scanLog).toMatch(/scan_complete/);
+    expect(scanLog).toMatch(/check_stall/);
+  });
+
+  it('skips chains without a <chain-id>.phases registry file', () => {
+    // No registry file written — chain should be skipped.
+    const r = spawnWatchdog();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/scanned=1 delegated=0 skipped=1/);
+    const scanLog = readFileSync(join(watchdogHome, 'watchdog.scan.log'), 'utf8');
+    expect(scanLog).toMatch(/skipping_no_phases_yaml/);
+  });
+
+  it('skips paused and all_done chains entirely (not even scanned)', () => {
+    const phasesPath = writeYamlSpec(baseDir);
+    writeFileSync(join(watchdogHome, 'shim-test-chain.phases'), phasesPath);
+    // Flip the chain to paused.
+    const state = JSON.parse(
+      readFileSync(join(chainDir, 'state.json'), 'utf8'),
+    );
+    state.paused = true;
+    state.paused_reason = 'unit test';
+    writeFileSync(join(chainDir, 'state.json'), JSON.stringify(state));
+    const r = spawnWatchdog();
+    expect(r.status).toBe(0);
+    // scanned counts only chains with a parseable state.json; paused chains
+    // are scanned-but-not-delegated.
+    expect(r.stdout).toMatch(/delegated=0/);
+  });
+
+  it('H-39: forwards <chain-id>.runner contents as --reregister-cmd', () => {
+    const phasesPath = writeYamlSpec(baseDir);
+    writeFileSync(join(watchdogHome, 'shim-test-chain.phases'), phasesPath);
+    writeFileSync(
+      join(watchdogHome, 'shim-test-chain.runner'),
+      'echo "fake re-register"',
+    );
+    const r = spawnWatchdog();
+    expect(r.status).toBe(0);
+    // The runner cmd shows up in scan.log when check_stall was invoked.
+    const scanLog = readFileSync(join(watchdogHome, 'watchdog.scan.log'), 'utf8');
+    expect(scanLog).toMatch(/check_stall shim-test-chain/);
+  });
+
+  it('H-40: prunes INBOX once per UTC day and writes .last_prune cookie', () => {
+    const phasesPath = writeYamlSpec(baseDir);
+    writeFileSync(join(watchdogHome, 'shim-test-chain.phases'), phasesPath);
+
+    // Seed INBOX with one stale alert (well past 7-day retention).
+    writeFileSync(
+      inboxPath,
+      `# INBOX\n\n## 2026-01-01T00:00:00Z — old alert\n- chain: x\n`,
+    );
+
+    const r1 = spawnWatchdog();
+    expect(r1.status).toBe(0);
+    expect(r1.stdout).toMatch(/prune_ran=true/);
+    // Cookie written.
+    const cookiePath = join(watchdogHome, '.last_prune.json');
+    expect(existsSync(cookiePath)).toBe(true);
+    // Archive file landed under INBOX_archive/.
+    const archive = join(watchdogHome, 'INBOX_archive', '2026-01.md');
+    expect(existsSync(archive)).toBe(true);
+    expect(readFileSync(archive, 'utf8')).toMatch(/old alert/);
+    // Live INBOX no longer contains that block.
+    expect(readFileSync(inboxPath, 'utf8')).not.toMatch(/old alert/);
+
+    // Second invocation same UTC day → prune_ran=false (cookie wins).
+    const r2 = spawnWatchdog();
+    expect(r2.status).toBe(0);
+    expect(r2.stdout).toMatch(/prune_ran=false/);
+  });
+
+  it('survives a missing CAIA_CHAIN_HOME (no chains, no crash)', () => {
+    rmSync(chainHome, { recursive: true, force: true });
+    const r = spawnWatchdog();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/scanned=0/);
+  });
+
+  it('survives unparseable state.json (logged, not throwing)', () => {
+    writeFileSync(join(chainDir, 'state.json'), 'not-json{');
+    const phasesPath = writeYamlSpec(baseDir);
+    writeFileSync(join(watchdogHome, 'shim-test-chain.phases'), phasesPath);
+    const r = spawnWatchdog();
+    expect(r.status).toBe(0);
+    const scanLog = readFileSync(join(watchdogHome, 'watchdog.scan.log'), 'utf8');
+    expect(scanLog).toMatch(/unparseable_state/);
+  });
+});


### PR DESCRIPTION
## Summary

P2 hardening cluster C for chain-runner-battle-harden phase 11 (2026-05-14). Consolidates the chain watchdog into a single source of truth and adds INBOX retention.

- **H-38**: Replace duplicate stall-detection logic in the chain-watchdog. `bin/watchdog.cjs` is now a thin shim — iterates `~/.caia/chain/*` and forks `caia-chain check-stall` per chain. The TS owns dedupe, channel fan-out, and audit. Honors `CAIA_CHAIN_HOME` / `CAIA_WATCHDOG_HOME` overrides.
- **H-39**: pokeChain wired via `<chain-id>.runner` registry files. Their contents are forwarded as `--reregister-cmd` to check-stall, which re-runs the per-chain wake script on stall.
- **H-40**: New `caia-chain prune-inbox` verb. Archives H2 alert blocks older than `--days` (default 7) into `<archive-dir>/<yyyy-mm>.md`. The shim invokes it once per UTC day (cookie at `.last_prune.json`). Idempotent; preserves blocks with unparseable timestamps.

## Test plan

- [x] `pnpm vitest` — 413 tests pass (including 16 new in `inbox-retention.test.ts` + `watchdog_shim.test.ts`)
- [x] `pnpm build` — typecheck clean
- [x] Manual: `node bin/watchdog.cjs` produces correct stdout summary, exit 0
- [x] Live shim deployed to `~/.caia/chain-watchdog/watchdog.js` (CJS → renamed for package ESM mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)