### PR TITLE
feat(spawner): SPS-α A.9.3 headroom-wrap + A.9.6 KV-cache prefix stabilization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ agent-memory/
 outputs/
 # Legacy claude worktree path (live spawner uses .spawn-worktrees/ — see WORKTREE_SUBDIR_NAME in claude_spawner_agent.py)
 .claude/
+
+# Python bytecode caches (from python -m unittest in py-client and similar)
+__pycache__/
+*.pyc

--- a/packages/local-llm-router-py-client/README.md
+++ b/packages/local-llm-router-py-client/README.md
@@ -86,3 +86,51 @@ Eighteen tests cover template rendering, env-driven version dispatch,
 the strict schema validator (positive + 6 negatives), and an end-to-end
 fixture task ("add SPDX header to file X") that renders the v2 prompt
 and validates a simulated spawn output against the schema.
+
+## SPS-Prompting phase α — claude-argv builder (A.9.3 + A.9.6)
+
+`src/spawner_argv.py` is a zero-dep helper that builds the subprocess argv
+the spawner feeds to `subprocess.Popen`. Reference patch
+`src/spawner_patch_v4.diff` wires it into `run_claude()` and adds six new
+env knobs that the operator can flip without redeploying:
+
+| Var | Default | Description |
+|---|---|---|
+| `HEADROOM_BINARY` | `/opt/homebrew/bin/headroom` | Headroom CLI path |
+| `HEADROOM_WRAP_DISABLE` | `` | Set to `1` to bypass the wrap (kill-switch) |
+| `HEADROOM_PROXY_PORT` | `8787` | Base proxy port |
+| `HEADROOM_PROXY_OFFSET` | `0` | Add to port (use when cap > 1 spawns concurrently) |
+| `HEADROOM_REUSE_PROXY` | `` | Set to `1` if a long-lived `headroom proxy` daemon is running |
+| `STABILIZE_PREFIX_DISABLE` | `` | Set to `1` to drop `--exclude-dynamic-system-prompt-sections` |
+
+When `HEADROOM_BINARY` exists on disk and the kill-switch is off, the spawn
+argv is prefixed with:
+
+```text
+<HEADROOM_BINARY> wrap claude --port <port> --no-mcp --no-serena --no-context-tool --
+```
+
+so every Anthropic API call routes through the local compression proxy
+(target: 30–50 % input-token reduction with ≥97 % accuracy per published
+headroom benchmarks). When the binary is missing — e.g. stolution today —
+the wrap is silently skipped (fail-open) so a single code path covers both
+hosts.
+
+Independently, the claude argv always carries
+`--exclude-dynamic-system-prompt-sections` (unless `STABILIZE_PREFIX_DISABLE=1`)
+so cwd/env/memory/git-status moves out of the cached system prefix into
+the first user message — the precondition for Anthropic's 90 % prompt-cache
+discount to hit the standing-rules prefix every spawn shares.
+
+### Tests
+
+```bash
+cd packages/local-llm-router-py-client
+python3 -m unittest tests.test_spawner_argv -v
+```
+
+Twelve tests pin the decision tree: wrap-on/off (kill-switch, missing
+binary, empty binary), prefix-on/off, port offset, reuse-proxy flag,
+allow-list expansion, permission-mode + max-turns threading, and the
+`--print` long-form requirement (avoids the `-p` ↔ `--port` collision
+in `headroom wrap claude`).

--- a/packages/local-llm-router-py-client/package.json
+++ b/packages/local-llm-router-py-client/package.json
@@ -1,21 +1,25 @@
 {
   "name": "@chiefaia/local-llm-router-py-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
-  "description": "Python client + B15.C v2 spawn prompt template (with strict-JSON output schema + DoD self-cert). Vendored into claude-spawner-agent on M1+M3+stolution. Pure stdlib (no pip deps); HTTP via urllib; schema validation via stdlib re/json.",
+  "description": "Python client + B15.C v2 spawn prompt template + SPS-α claude-argv builder (headroom-wrap + KV-cache prefix stabilization). Vendored into claude-spawner-agent on M1+M3+stolution. Pure stdlib (no pip deps); HTTP via urllib; schema validation via stdlib re/json.",
   "files": [
     "src/local_llm_router_client.py",
     "src/spawn_prompt_loader.py",
+    "src/spawner_argv.py",
     "src/spawner_patch.diff",
     "src/spawner_patch_v2.diff",
     "src/spawner_patch_v3.diff",
+    "src/spawner_patch_v4.diff",
+    "templates/com.caia.claude-spawner-agent.plist.template",
     "templates/spawn_prompt_v2.md",
     "templates/spawn_prompt_v1.md.archived",
     "templates/spawn_output_schema.v2.json",
     "tests/test_spawn_prompt_v2.py",
+    "tests/test_spawner_argv.py",
     "README.md"
   ],
   "scripts": {
-    "test:py": "python3 -m unittest tests.test_spawn_prompt_v2 -v"
+    "test:py": "python3 -m unittest tests.test_spawn_prompt_v2 tests.test_spawner_argv -v"
   }
 }

--- a/packages/local-llm-router-py-client/src/spawner_argv.py
+++ b/packages/local-llm-router-py-client/src/spawner_argv.py
@@ -1,0 +1,87 @@
+"""Build the subprocess argv for invoking the claude binary.
+
+Standalone module (zero non-stdlib deps) so the unit-test suite under
+`packages/local-llm-router-py-client/tests/` can exercise the argv logic
+without dragging in fastapi / sqlite / the rest of the spawner agent.
+
+SPS-Prompting phase α (2026-05-14) wires two substrate-level optimizations
+onto every spawn:
+
+  * A.9.3  headroom wrap → routes Anthropic API calls through a local
+           compression proxy when ``HEADROOM_BINARY`` exists on disk.
+           Bypassed (fail-open) if ``HEADROOM_WRAP_DISABLE=1`` is set or
+           the binary is missing — keeps stolution (no headroom yet)
+           working without a code-divergence between the two boxes.
+
+  * A.9.6  KV-cache prefix stabilization → adds
+           ``--exclude-dynamic-system-prompt-sections`` to the claude
+           argv so per-machine sections (cwd, env, memory paths, git
+           status) move out of the cached system prefix into the first
+           user message. Required for Anthropic's 90% prompt-cache
+           discount to apply across spawns. Bypassed if
+           ``STABILIZE_PREFIX_DISABLE=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Sequence
+
+
+def build_claude_argv(
+    prompt: str,
+    *,
+    permission_mode: str,
+    allow_list: Sequence[str],
+    claude_binary: str,
+    permission_mode_max_turns: Mapping[str, int],
+    headroom_binary: str = "",
+    headroom_wrap_disable: bool = False,
+    headroom_proxy_port: int = 8787,
+    headroom_proxy_offset: int = 0,
+    headroom_reuse_proxy: bool = False,
+    stabilize_prefix_disable: bool = False,
+    binary_exists: "callable" = os.path.exists,
+) -> tuple[list[str], bool, bool]:
+    """Return ``(argv, headroom_wrapped, prefix_stabilized)``.
+
+    All knobs are passed as parameters so the unit tests can drive the
+    decision tree deterministically; ``binary_exists`` is injectable so
+    the headroom-present check is testable without touching the
+    filesystem.
+    """
+    base_args: list[str] = [
+        "--print",
+        prompt,
+        "--output-format", "json",
+        "--permission-mode", permission_mode,
+    ]
+    max_turns = permission_mode_max_turns.get(permission_mode)
+    if max_turns is not None:
+        base_args += ["--max-turns", str(max_turns)]
+    for p in allow_list:
+        base_args += ["--add-dir", p]
+
+    prefix_stabilized = not stabilize_prefix_disable
+    if prefix_stabilized:
+        base_args.append("--exclude-dynamic-system-prompt-sections")
+
+    use_wrap = (
+        not headroom_wrap_disable
+        and bool(headroom_binary)
+        and binary_exists(headroom_binary)
+    )
+    if use_wrap:
+        port = headroom_proxy_port + headroom_proxy_offset
+        wrap_args = [
+            headroom_binary, "wrap", "claude",
+            "--port", str(port),
+            "--no-mcp",
+            "--no-serena",
+            "--no-context-tool",
+        ]
+        if headroom_reuse_proxy:
+            wrap_args.append("--no-proxy")
+        return [*wrap_args, "--", *base_args], True, prefix_stabilized
+
+    return [claude_binary, *base_args], False, prefix_stabilized

--- a/packages/local-llm-router-py-client/src/spawner_patch_v4.diff
+++ b/packages/local-llm-router-py-client/src/spawner_patch_v4.diff
@@ -1,0 +1,241 @@
+# Reference patch v4 for claude_spawner_agent.py — SPS-Prompting phase α
+#
+# Supersedes spawner_patch_v3.diff (B15.C strict-JSON gate); v4 wires the
+# substrate-level local-AI substrate items A.9.3 (headroom-wrap-claude) and
+# A.9.6 (KV-cache prefix stabilization) onto every spawn.
+#
+# v4 changes from v3:
+#   - Vendor a new standalone module `spawner_argv.py` alongside
+#     local_llm_router_client.py. Holds `build_claude_argv` (zero non-stdlib
+#     deps so the py-client unit tests can exercise the decision tree
+#     without dragging fastapi/sqlite).
+#   - Import `_build_claude_argv` from `spawner_argv` at the top of
+#     claude_spawner_agent.py.
+#   - Add six new module-level config constants:
+#         HEADROOM_BINARY            default /opt/homebrew/bin/headroom
+#         HEADROOM_WRAP_DISABLE      env "1"/"true"/"yes" → bypass wrap
+#         HEADROOM_PROXY_PORT        default 8787
+#         HEADROOM_PROXY_OFFSET      default 0 (cap > 1 → vary per spawn)
+#         HEADROOM_REUSE_PROXY       env → adds `--no-proxy` to wrap argv
+#                                    (lets operator run a long-lived
+#                                    `headroom proxy` daemon)
+#         STABILIZE_PREFIX_DISABLE   env → reverts to dynamic system prefix
+#   - Replace the inline argv-build inside `run_claude()` with a call to
+#     the thin `build_claude_argv()` adapter that threads the config into
+#     the standalone helper. Argv now uses `--print` (long form) instead
+#     of `-p` to avoid the option collision with `headroom wrap claude`'s
+#     `-p, --port` flag.
+#   - Always append `--exclude-dynamic-system-prompt-sections` to the
+#     claude argv (unless STABILIZE_PREFIX_DISABLE=1) so per-machine
+#     sections (cwd, env info, memory paths, git status) move out of the
+#     cached system prefix into the first user message. Anthropic 90 %
+#     prompt-cache discount precondition.
+#   - When HEADROOM_BINARY exists on disk AND the kill-switch is off,
+#     prefix the argv with
+#         <HEADROOM_BINARY> wrap claude --port <port> --no-mcp --no-serena
+#         --no-context-tool --
+#     so every spawn routes Anthropic API calls through the headroom
+#     compression proxy. Fail-open: if the binary is missing (e.g.
+#     stolution today) the wrap is silently skipped — keeps a single
+#     code path across hosts.
+#   - The spawn record gains `headroom_wrapped: bool` and
+#     `prefix_stabilized: bool` fields. These are emitted as a
+#     `claude-invocation-mode` journal event (not new DB columns) so no
+#     schema migration is required to ship.
+#   - The lifespan startup banner gains an SPS-α line that logs
+#     HEADROOM_BINARY / present / wrap_disable / wrap_active /
+#     proxy_port / offset / stabilize_prefix_disable.
+#   - `/version` response gains 8 new fields:
+#         router_gate_enabled, optimizer_enabled, headroom_binary,
+#         headroom_present, headroom_wrap_disable, headroom_proxy_port,
+#         headroom_proxy_offset, stabilize_prefix_disable
+#     so the operator can curl the live state.
+#
+# DO NOT auto-apply — operator review required. This is a reference patch.
+# The real spawner is ~2000 lines; the hunks below show the intent + exact
+# lines to add against the v3-patched source tree. Apply by hand or adapt
+# as a code-review checklist.
+#
+# Pre-req: vendor `spawner_argv.py` in the spawner-agent directory (it
+# imports from a sibling file, not a package).
+#
+# Apply (after v2 + v3 are already applied, or directly on top of v2 if
+# the v3 prompt-version dispatch isn't yet shipped on this host):
+#   cd <spawner-dir>
+#   cp /path/to/local-llm-router-py-client/src/spawner_argv.py .
+#   patch -p0 < spawner_patch_v4.diff
+#
+# Smoke test post-deploy (Mac, where headroom is installed):
+#   1. Restart spawner: launchctl kickstart -k gui/$UID/com.caia.claude-spawner-agent
+#   2. curl -s http://127.0.0.1:8090/version | jq '.headroom_present,
+#      .headroom_wrap_disable, .stabilize_prefix_disable' → true, false, false
+#   3. Send a trivial /spawn (plan mode, read-only). Tail the spawner log;
+#      a `headroom_wrap=True prefix_stabilized=True` line appears at
+#      invocation time, AND a `claude-invocation-mode` row lands in the
+#      events table.
+#   4. Run `headroom perf --since 5m` and confirm the compression layer
+#      saw traffic (cache hits + token reduction).
+#   5. Verify the spawn rc=0 + parsed JSON populated (compression must be
+#      lossless w.r.t. claude's output contract).
+#
+# Smoke test post-deploy (stolution, no headroom installed):
+#   1. patch -p0 < spawner_patch_v4.diff && systemctl --user restart claude-spawner.service
+#   2. curl http://127.0.0.1:8090/version | jq '.headroom_present' → false
+#   3. Send trivial /spawn → spawner log shows `headroom_wrap=False
+#      prefix_stabilized=True` (fail-open). Spawn completes normally.
+#   4. (Operator-only) `pipx install headroom` to activate the wrap layer
+#      on stolution too.
+#
+# Rollback:
+#   - HEADROOM_WRAP_DISABLE=1 in the plist + restart → reverts wrap only.
+#   - STABILIZE_PREFIX_DISABLE=1 → reverts prefix flag only.
+#   - Both → equivalent to pre-v4 behaviour.
+
+--- claude_spawner_agent.py
++++ claude_spawner_agent.py
+@@ -83,6 +83,11 @@
+ from local_llm_router_client import (
+     classify_and_maybe_route,
+     health as router_health,
+     optimize_prompt,
+ )
++# SPS-Prompting phase α (A.9.3 + A.9.6): claude-argv builder.
++# Vendored alongside local_llm_router_client.py as a standalone module so
++# the py-client test suite can exercise the wrap/stabilize decision tree
++# without dragging in fastapi/sqlite.
++from spawner_argv import build_claude_argv as _build_claude_argv
+@@ -118,6 +123,40 @@
+ OPTIMIZER_ENABLED   = os.environ.get("OPTIMIZER_ENABLED", "true").lower() in ("1", "true", "yes")
+ OPTIMIZER_TIMEOUT_S = float(os.environ.get("OPTIMIZER_TIMEOUT_S", "30.0"))
+
++# SPS-Prompting phase α (A.9.3): headroom wrap on the claude binary call.
++# When enabled, the claude argv is prefixed with `<HEADROOM_BINARY> wrap
++# claude --no-mcp --no-serena --no-context-tool --port <port> -- ...`
++# so every spawn routes Anthropic API calls through the headroom proxy for
++# input-side compression. The MCP/Serena/context-tool subsystems are
++# disabled — spawns are headless print-mode and we want minimum wrapper
++# overhead; only the proxy compression layer is load-bearing here.
++#
++# Kill-switch: HEADROOM_WRAP_DISABLE=1 (operator can flip without redeploy)
++# bypasses the wrap entirely. Also bypassed if HEADROOM_BINARY doesn't
++# exist on disk — fail-open so a missing headroom never blocks a spawn.
++HEADROOM_BINARY        = os.environ.get("HEADROOM_BINARY", "/opt/homebrew/bin/headroom")
++HEADROOM_WRAP_DISABLE  = os.environ.get("HEADROOM_WRAP_DISABLE", "").lower() in ("1", "true", "yes")
++HEADROOM_PROXY_PORT    = int(os.environ.get("HEADROOM_PROXY_PORT", "8787"))
++HEADROOM_PROXY_OFFSET  = int(os.environ.get("HEADROOM_PROXY_OFFSET", "0"))
++# SPS-Prompting phase α (A.9.6): KV-cache prefix stabilization.
++# Passes `--exclude-dynamic-system-prompt-sections` to the claude binary so
++# per-machine bits (cwd, env info, memory paths, git status) move out of
++# the cached system prefix into the first user message. This makes the
++# system-prompt bytes byte-identical across spawns and across hosts, which
++# is the precondition for Anthropic's 90% prompt-cache discount to apply
++# to the standing-rules prefix every spawn shares.
++#
++# Kill-switch: STABILIZE_PREFIX_DISABLE=1 reverts to the dynamic prefix
++# behaviour if a regression surfaces.
++STABILIZE_PREFIX_DISABLE = os.environ.get("STABILIZE_PREFIX_DISABLE", "").lower() in ("1", "true", "yes")
++
+@@ -1245,38 +1284,28 @@ def run_claude(spawn_id: str,
++def build_claude_argv(prompt: str,
++                      *,
++                      permission_mode: str,
++                      allow_list: list[str]) -> tuple[list[str], bool, bool]:
++    """Thin adapter around :func:`spawner_argv.build_claude_argv`.
++
++    Threads the spawner's module-level config (CLAUDE_BINARY, the
++    headroom + prefix-stabilization knobs) into the standalone helper so
++    the helper stays unit-testable in isolation.
++    """
++    return _build_claude_argv(
++        prompt,
++        permission_mode=permission_mode,
++        allow_list=allow_list,
++        claude_binary=CLAUDE_BINARY,
++        permission_mode_max_turns=PERMISSION_MODE_MAX_TURNS,
++        headroom_binary=HEADROOM_BINARY,
++        headroom_wrap_disable=HEADROOM_WRAP_DISABLE,
++        headroom_proxy_port=HEADROOM_PROXY_PORT,
++        headroom_proxy_offset=HEADROOM_PROXY_OFFSET,
++        headroom_reuse_proxy=os.environ.get("HEADROOM_REUSE_PROXY", "").lower()
++                              in ("1", "true", "yes"),
++        stabilize_prefix_disable=STABILIZE_PREFIX_DISABLE,
++    )
++
++
+ def run_claude(spawn_id: str,
+                prompt: str,
+                timeout_s: float,
+                *,
+                permission_mode: str,
+                allow_list: list[str],
+                cwd: str | None) -> dict[str, Any]:
+     ...
+     env = {k: v for k, v in os.environ.items()
+            if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")}
+     env["PYTHONUNBUFFERED"] = "1"
+     env["ANTHROPIC_API_KEY"] = ""
+
+-    # Build argv
+-    cmd = [
+-        CLAUDE_BINARY, "-p", prompt,
+-        "--output-format", "json",
+-        "--permission-mode", permission_mode,
+-    ]
+-    max_turns = PERMISSION_MODE_MAX_TURNS.get(permission_mode)
+-    if max_turns is not None:
+-        cmd += ["--max-turns", str(max_turns)]
+-    for p in allow_list:
+-        cmd += ["--add-dir", p]
++    cmd, headroom_wrapped, prefix_stabilized = build_claude_argv(
++        prompt,
++        permission_mode=permission_mode,
++        allow_list=allow_list,
++    )
+
+     started = time.time()
+-    log.info("spawn_id=%s mode=%s allow_list=%d cwd=%s invoking claude...",
+-             spawn_id, permission_mode, len(allow_list), cwd or "<inherit>")
++    log.info("spawn_id=%s mode=%s allow_list=%d cwd=%s "
++             "headroom_wrap=%s prefix_stabilized=%s invoking claude...",
++             spawn_id, permission_mode, len(allow_list), cwd or "<inherit>",
++             headroom_wrapped, prefix_stabilized)
+@@ -1340,7 +1370,9 @@ def run_claude(spawn_id: str,
+     return {
+         ...
+         "stdout_head":  (stdout or "")[:2000],
+         "stderr_head":  (stderr or "")[:2000],
++        "headroom_wrapped":    headroom_wrapped,
++        "prefix_stabilized":   prefix_stabilized,
+     }
+@@ -1437,6 +1469,16 @@ async def lifespan(app: FastAPI):
+     log.info("LAI phase 7: ROUTER_GATE_ENABLED=%s OPTIMIZER_ENABLED=%s "
+              "router_url=%s optimizer_timeout_s=%.1f",
+              ROUTER_GATE_ENABLED, OPTIMIZER_ENABLED, ROUTER_URL, OPTIMIZER_TIMEOUT_S)
++    headroom_present = bool(HEADROOM_BINARY) and os.path.exists(HEADROOM_BINARY)
++    headroom_wrap_active = headroom_present and not HEADROOM_WRAP_DISABLE
++    log.info("SPS-α: HEADROOM_BINARY=%s present=%s wrap_disable=%s wrap_active=%s "
++             "proxy_port=%d offset=%d stabilize_prefix_disable=%s",
++             HEADROOM_BINARY, headroom_present, HEADROOM_WRAP_DISABLE,
++             headroom_wrap_active, HEADROOM_PROXY_PORT, HEADROOM_PROXY_OFFSET,
++             STABILIZE_PREFIX_DISABLE)
+     log.info("claude --version: %s", claude_version_str())
+@@ -1524,4 +1566,12 @@ def version() -> dict[str, Any]:
+         "worktree_subdir_name":    WORKTREE_SUBDIR_NAME,
++        "router_gate_enabled":     ROUTER_GATE_ENABLED,
++        "optimizer_enabled":       OPTIMIZER_ENABLED,
++        "headroom_binary":         HEADROOM_BINARY,
++        "headroom_present":        bool(HEADROOM_BINARY) and os.path.exists(HEADROOM_BINARY),
++        "headroom_wrap_disable":   HEADROOM_WRAP_DISABLE,
++        "headroom_proxy_port":     HEADROOM_PROXY_PORT,
++        "headroom_proxy_offset":   HEADROOM_PROXY_OFFSET,
++        "stabilize_prefix_disable": STABILIZE_PREFIX_DISABLE,
+     }
+@@ -2010,4 +2060,10 @@ async def spawn(request: Request) -> JSONResponse:
+                      optimizer_wall_ms=optimizer_meta.get("wall_ms"),
+                      optimizer_error=optimizer_meta.get("error"))
++    # SPS-α telemetry: emit per-spawn substrate state as a journal event so the
++    # displacement metric can distinguish wrapped/stabilized runs without
++    # requiring a schema migration on the claude_sessions table.
++    journal_event(spawn_id, "claude-invocation-mode",
++                  f"headroom_wrapped={record.get('headroom_wrapped', False)} "
++                  f"prefix_stabilized={record.get('prefix_stabilized', False)}")

--- a/packages/local-llm-router-py-client/templates/com.caia.claude-spawner-agent.plist.template
+++ b/packages/local-llm-router-py-client/templates/com.caia.claude-spawner-agent.plist.template
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.caia.claude-spawner-agent</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/macbook32/.cache/claude-spawner-agent/venv/bin/python</string>
+        <string>/Users/macbook32/Documents/projects/reports/claude-spawner-agent/claude_spawner_agent.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/macbook32/Documents/projects/reports/claude-spawner-agent</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/macbook32/.local/bin</string>
+        <key>PORT</key>
+        <string>8090</string>
+        <key>HOST_NAME</key>
+        <string>mac-m3</string>
+        <key>CLAUDE_BINARY</key>
+        <string>/Users/macbook32/.local/bin/claude</string>
+        <key>SLOT_MANAGER_URL</key>
+        <string>http://10.43.173.170:8081</string>
+        <key>SELF_SPAWNER_URL</key>
+        <string>http://__TAILSCALE_IP__:8090</string>
+        <key>AUTO_REGISTER</key>
+        <string>0</string>
+        <key>LOG_LEVEL</key>
+        <string>INFO</string>
+        <key>HOME</key>
+        <string>/Users/macbook32</string>
+        <!-- LAI phase 7: pre-spawn router-gate + 3-stage prompt-optimizer pre-pass. -->
+        <key>LOCAL_LLM_ROUTER_URL</key>
+        <string>http://100.68.247.58:7411</string>
+        <key>ROUTER_GATE_ENABLED</key>
+        <string>true</string>
+        <key>OPTIMIZER_ENABLED</key>
+        <string>true</string>
+        <key>OPTIMIZER_TIMEOUT_S</key>
+        <string>30.0</string>
+        <!-- SPS-Prompting phase α (A.9.3): wrap the claude binary call in
+             `headroom wrap claude` so every spawn routes Anthropic API
+             calls through the local compression proxy. The wrap is fail-
+             open: if HEADROOM_BINARY is missing on disk OR the kill-switch
+             is set, the spawner reverts to direct claude invocation. -->
+        <key>HEADROOM_BINARY</key>
+        <string>/opt/homebrew/bin/headroom</string>
+        <key>HEADROOM_WRAP_DISABLE</key>
+        <string></string>
+        <key>HEADROOM_PROXY_PORT</key>
+        <string>8787</string>
+        <key>HEADROOM_PROXY_OFFSET</key>
+        <string>0</string>
+        <!-- HEADROOM_REUSE_PROXY=1 tells `headroom wrap` not to start its
+             own short-lived proxy; useful once the operator runs a long-
+             lived `headroom proxy` daemon. Leave empty for the per-spawn
+             proxy startup default. -->
+        <key>HEADROOM_REUSE_PROXY</key>
+        <string></string>
+        <!-- SPS-Prompting phase α (A.9.6): pass `--exclude-dynamic-system-
+             prompt-sections` to claude so per-machine context (cwd, env,
+             memory paths, git status) moves out of the cached system
+             prefix into the first user message. Required precondition for
+             Anthropic's 90% prompt-cache discount to apply across spawns.
+             Flip STABILIZE_PREFIX_DISABLE=1 to revert. -->
+        <key>STABILIZE_PREFIX_DISABLE</key>
+        <string></string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/macbook32/Library/Logs/claude-spawner-agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/macbook32/Library/Logs/claude-spawner-agent.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/packages/local-llm-router-py-client/tests/test_spawner_argv.py
+++ b/packages/local-llm-router-py-client/tests/test_spawner_argv.py
@@ -1,0 +1,201 @@
+"""Unit tests for ``spawner_argv.build_claude_argv``.
+
+The helper builds the subprocess argv that the spawner agent feeds to
+``subprocess.Popen``. SPS-Prompting phase α (2026-05-14) wires two
+substrate-level optimizations through it (A.9.3 headroom-wrap and A.9.6
+KV-cache prefix stabilization); these tests pin the decision tree so the
+wrap/stabilize state can't silently regress.
+"""
+
+import os
+import sys
+import unittest
+from typing import Mapping, Sequence
+
+# The src/ layout mirrors the on-disk layout of the deployed spawner
+# (spawner_argv.py is vendored next to local_llm_router_client.py). The
+# helper has zero non-stdlib deps so importing it here costs nothing.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+
+from spawner_argv import build_claude_argv  # noqa: E402
+
+
+# Sane defaults that mirror the production plist; individual tests
+# override what they're exercising.
+DEFAULT_KW = dict(
+    claude_binary="/opt/homebrew/bin/claude",
+    permission_mode_max_turns={"plan": 1},
+    headroom_binary="/opt/homebrew/bin/headroom",
+    binary_exists=lambda p: True,  # pretend everything exists
+)
+
+
+class BuildClaudeArgvTest(unittest.TestCase):
+    # ── A.9.3 wrap behaviour ─────────────────────────────────────────────
+    def test_wraps_with_headroom_when_binary_present(self) -> None:
+        argv, wrapped, stab = build_claude_argv(
+            "HELLO",
+            permission_mode="plan",
+            allow_list=[],
+            **DEFAULT_KW,
+        )
+        self.assertTrue(wrapped)
+        self.assertTrue(stab)
+        self.assertEqual(argv[0], "/opt/homebrew/bin/headroom")
+        self.assertEqual(argv[1:3], ["wrap", "claude"])
+        self.assertIn("--no-mcp", argv)
+        self.assertIn("--no-serena", argv)
+        self.assertIn("--no-context-tool", argv)
+        self.assertIn("--", argv)
+        # the prompt + claude flags sit after ``--``
+        sep = argv.index("--")
+        self.assertEqual(argv[sep + 1], "--print")
+        self.assertEqual(argv[sep + 2], "HELLO")
+
+    def test_kill_switch_bypasses_wrap(self) -> None:
+        argv, wrapped, stab = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            headroom_wrap_disable=True,
+            **{k: v for k, v in DEFAULT_KW.items()
+               if k not in {"headroom_binary"}},
+            headroom_binary="/opt/homebrew/bin/headroom",
+        )
+        self.assertFalse(wrapped)
+        # direct claude invocation, NOT through headroom
+        self.assertEqual(argv[0], "/opt/homebrew/bin/claude")
+        self.assertNotIn("headroom", " ".join(argv))
+
+    def test_missing_headroom_binary_fails_open(self) -> None:
+        # stolution today: HEADROOM_BINARY set but doesn't exist on disk
+        argv, wrapped, _ = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            **{k: v for k, v in DEFAULT_KW.items()
+               if k not in {"headroom_binary", "binary_exists"}},
+            headroom_binary="/opt/homebrew/bin/headroom",
+            binary_exists=lambda p: False,
+        )
+        self.assertFalse(wrapped)
+        self.assertEqual(argv[0], "/opt/homebrew/bin/claude")
+
+    def test_empty_headroom_binary_fails_open(self) -> None:
+        argv, wrapped, _ = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            **{k: v for k, v in DEFAULT_KW.items()
+               if k not in {"headroom_binary"}},
+            headroom_binary="",
+        )
+        self.assertFalse(wrapped)
+
+    def test_proxy_port_offset_applied(self) -> None:
+        argv, wrapped, _ = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            headroom_proxy_port=8800,
+            headroom_proxy_offset=4,
+            **DEFAULT_KW,
+        )
+        self.assertTrue(wrapped)
+        port_ix = argv.index("--port")
+        self.assertEqual(argv[port_ix + 1], "8804")
+
+    def test_reuse_proxy_adds_no_proxy_flag(self) -> None:
+        argv, wrapped, _ = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            headroom_reuse_proxy=True,
+            **DEFAULT_KW,
+        )
+        self.assertTrue(wrapped)
+        self.assertIn("--no-proxy", argv[: argv.index("--")])
+
+    # ── A.9.6 KV-cache prefix stabilization ─────────────────────────────
+    def test_stabilize_flag_added_by_default(self) -> None:
+        argv, _, stab = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            **DEFAULT_KW,
+        )
+        self.assertTrue(stab)
+        self.assertIn("--exclude-dynamic-system-prompt-sections", argv)
+
+    def test_stabilize_disabled(self) -> None:
+        argv, _, stab = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            stabilize_prefix_disable=True,
+            **DEFAULT_KW,
+        )
+        self.assertFalse(stab)
+        self.assertNotIn("--exclude-dynamic-system-prompt-sections", argv)
+
+    # ── orthogonal: existing claude flags still appear correctly ────────
+    def test_permission_mode_threaded_through(self) -> None:
+        argv, _, _ = build_claude_argv(
+            "X",
+            permission_mode="acceptEdits",
+            allow_list=[],
+            **DEFAULT_KW,
+        )
+        pm_ix = argv.index("--permission-mode")
+        self.assertEqual(argv[pm_ix + 1], "acceptEdits")
+
+    def test_max_turns_only_for_plan_default(self) -> None:
+        argv, _, _ = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            **DEFAULT_KW,
+        )
+        self.assertIn("--max-turns", argv)
+        mt_ix = argv.index("--max-turns")
+        self.assertEqual(argv[mt_ix + 1], "1")
+        # acceptEdits is not in the max_turns mapping → flag absent
+        argv2, _, _ = build_claude_argv(
+            "X",
+            permission_mode="acceptEdits",
+            allow_list=[],
+            **DEFAULT_KW,
+        )
+        self.assertNotIn("--max-turns", argv2)
+
+    def test_allow_list_emits_add_dir_per_path(self) -> None:
+        argv, _, _ = build_claude_argv(
+            "X",
+            permission_mode="acceptEdits",
+            allow_list=["/a", "/b", "/c"],
+            **DEFAULT_KW,
+        )
+        # --add-dir appears exactly three times
+        self.assertEqual(argv.count("--add-dir"), 3)
+        for p in ("/a", "/b", "/c"):
+            self.assertIn(p, argv)
+
+    def test_print_flag_uses_long_form_not_short_p(self) -> None:
+        # Avoids the headroom-wrap option collision: `headroom wrap claude`
+        # interprets `-p` as `--port`, which would corrupt the proxy port.
+        argv, wrapped, _ = build_claude_argv(
+            "X",
+            permission_mode="plan",
+            allow_list=[],
+            **DEFAULT_KW,
+        )
+        self.assertTrue(wrapped)
+        # `-p` must NOT appear among the claude flags (after ``--``)
+        sep = argv.index("--")
+        self.assertNotIn("-p", argv[sep + 1:])
+        self.assertIn("--print", argv[sep + 1:])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wires two substrate-level local-AI optimizations onto every spawner-mediated `claude` invocation, both with operator kill-switches:

- **A.9.3 — headroom-wrap-claude.** When `HEADROOM_BINARY` exists on disk and `HEADROOM_WRAP_DISABLE` is unset, the claude argv is prefixed with `<headroom> wrap claude --port <port> --no-mcp --no-serena --no-context-tool --` so every Anthropic API call routes through the local headroom compression proxy. Target: 30–50% input-token reduction with ≥97% accuracy per published headroom benchmarks. Fail-open: if the binary is missing (stolution today), the wrap is silently skipped — single code path across hosts, no code divergence.

- **A.9.6 — KV-cache prefix stabilization.** Always append `--exclude-dynamic-system-prompt-sections` to the claude argv (unless `STABILIZE_PREFIX_DISABLE=1`) so per-machine sections (cwd, env info, memory paths, git status) move out of the cached system prefix into the first user message. Precondition for Anthropic's 90% prompt-cache discount to apply to the standing-rules prefix every spawn shares.

The argv builder is extracted to `src/spawner_argv.py` — a zero-dep standalone module so the py-client test suite can exercise the decision tree without dragging in fastapi / sqlite. Reference patch `src/spawner_patch_v4.diff` documents the inline edits applied against the v3-baselined `claude_spawner_agent.py`.

## What ships

- \`src/spawner_argv.py\` — standalone \`build_claude_argv()\` helper (zero non-stdlib deps).
- \`src/spawner_patch_v4.diff\` — reference patch documenting the edits to be applied on each spawner-agent deploy.
- \`templates/com.caia.claude-spawner-agent.plist.template\` — adds 6 new env knobs (\`HEADROOM_BINARY\`, \`HEADROOM_WRAP_DISABLE\`, \`HEADROOM_PROXY_PORT\`, \`HEADROOM_PROXY_OFFSET\`, \`HEADROOM_REUSE_PROXY\`, \`STABILIZE_PREFIX_DISABLE\`).
- \`tests/test_spawner_argv.py\` — 12 unit tests pinning the wrap/stabilize decision tree.
- \`README.md\` — operator-facing doc for the new env knobs + smoke-test instructions.
- \`package.json\` — bump to 0.3.0, expand \`files\` list, run both test modules from \`npm run test:py\`.

## Test plan

- [x] \`cd packages/local-llm-router-py-client && python3 -m unittest tests.test_spawn_prompt_v2 tests.test_spawner_argv -v\` — 30 tests pass (18 existing + 12 new).
- [x] Applied v4 edits via \`/tmp/apply_spsalpha_to_spawner.py\` to the local Mac copy at \`~/Documents/projects/reports/claude-spawner-agent/claude_spawner_agent.py\` — \`python3 -c \"import ast; ast.parse(open(...).read())\"\` SYNTAX OK; module loads via venv python; \`build_claude_argv\` produces the expected wrap argv with all four kill-switch combinations.
- [x] Shipped \`spawner_argv.py\` + applier to **stolution**; \`systemctl --user restart claude-spawner.service\` — service active; \`curl /version\` returns the 8 new fields; lifespan banner logs \`SPS-α: HEADROOM_BINARY=/opt/homebrew/bin/headroom present=False wrap_disable=False wrap_active=False ... stabilize_prefix_disable=False\`. Wrap fails open (no headroom on Linux); prefix-stabilization active.
- [ ] M3 spawner reload to activate the headroom-wrap layer (operator follow-up via launchctl kickstart). Code is in place; the plist edit + reload is intentionally deferred from this PR to avoid disrupting an in-flight spawner.

## Notes

- Phase α is the dark-plumbing layer of the SPS-Prompting completion campaign. Phase γ+η (semantic cache L6 / memory compression / batch-tier models on stolution / headroom-learn weekly cron) lands in a follow-on PR per the 2-phase plan in \`agent-memory/sps_prompting_completion_phases.yaml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)