### PR TITLE
feat(prompt-optimizer): a.9.4 stage 3 router 404 memoization

### DIFF
--- a/packages/prompt-optimizer/__tests__/stage3.test.ts
+++ b/packages/prompt-optimizer/__tests__/stage3.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { tagProtectedSpans } from '../src/stage1.js';
 import {
   DEFAULT_SEGMENT_WEIGHTS,
+  __resetRouter404Memo,
   pruneSegment,
   scoreHeuristic,
   stage3Prune,
   type PromptSegment,
 } from '../src/stage3.js';
+
+beforeEach(() => {
+  __resetRouter404Memo();
+});
 
 describe('stage3 — scoreHeuristic', () => {
   it('scores query-term hits higher than unrelated words', () => {
@@ -210,5 +215,101 @@ describe('stage3 — router backend with fallback', () => {
     // surface as an error to the caller.
     expect(out.error).toBeUndefined();
     expect(out.tokensOut).toBeLessThan(out.tokensIn);
+  });
+});
+
+describe('stage3 — A.9.4 router 404 memoization', () => {
+  it('memoizes the 404 outcome per routerBaseUrl so the second call skips the roundtrip', async () => {
+    const segments: PromptSegment[] = [
+      {
+        kind: 'tool-output',
+        text: 'verbose '.repeat(100) + 'keyword',
+        weight: 1,
+      },
+      { kind: 'user-question', text: 'keyword', weight: 0 },
+    ];
+
+    const fetchImpl = vi.fn(async () => {
+      return new Response('', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const optsA = {
+      targetRatio: 0.5,
+      minTokensToPrune: 10,
+      fetchImpl,
+      routerBaseUrl: 'http://127.0.0.1:7411',
+    };
+
+    const first = await stage3Prune(segments, 'keyword', optsA);
+    expect(first.backend).toBe('heuristic');
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(1);
+
+    const second = await stage3Prune(segments, 'keyword', optsA);
+    expect(second.backend).toBe('heuristic');
+    // Memoized — fetch should NOT have been called again.
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(1);
+  });
+
+  it('does not cross-contaminate memoization between routerBaseUrls', async () => {
+    const segments: PromptSegment[] = [
+      {
+        kind: 'tool-output',
+        text: 'verbose '.repeat(100) + 'keyword',
+        weight: 1,
+      },
+      { kind: 'user-question', text: 'keyword', weight: 0 },
+    ];
+
+    const fetchImpl = vi.fn(async () => {
+      return new Response('', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    await stage3Prune(segments, 'keyword', {
+      targetRatio: 0.5,
+      minTokensToPrune: 10,
+      fetchImpl,
+      routerBaseUrl: 'http://127.0.0.1:7411',
+    });
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(1);
+
+    // Different baseUrl — should probe again.
+    await stage3Prune(segments, 'keyword', {
+      targetRatio: 0.5,
+      minTokensToPrune: 10,
+      fetchImpl,
+      routerBaseUrl: 'http://127.0.0.1:7412',
+    });
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(2);
+  });
+
+  it('does not memoize on non-404 errors (transient failures should be retried)', async () => {
+    const segments: PromptSegment[] = [
+      {
+        kind: 'tool-output',
+        text: 'verbose '.repeat(100) + 'keyword',
+        weight: 1,
+      },
+      { kind: 'user-question', text: 'keyword', weight: 0 },
+    ];
+
+    const fetchImpl = vi.fn(async () => {
+      return new Response('', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const optsA = {
+      targetRatio: 0.5,
+      minTokensToPrune: 10,
+      fetchImpl,
+      routerBaseUrl: 'http://127.0.0.1:7411',
+    };
+
+    const first = await stage3Prune(segments, 'keyword', optsA);
+    expect(first.backend).toBe('heuristic');
+    expect(first.error).toContain('router-status-500');
+
+    const second = await stage3Prune(segments, 'keyword', optsA);
+    expect(second.backend).toBe('heuristic');
+    // 5xx must NOT be memoized — should probe again on the next call.
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(2);
   });
 });

--- a/packages/prompt-optimizer/src/index.ts
+++ b/packages/prompt-optimizer/src/index.ts
@@ -29,6 +29,7 @@ export {
   pruneSegment,
   scoreHeuristic,
   stage3Prune,
+  __resetRouter404Memo,
 } from './stage3.js';
 export type {
   OptimizerInput,

--- a/packages/prompt-optimizer/src/stage3.ts
+++ b/packages/prompt-optimizer/src/stage3.ts
@@ -25,6 +25,15 @@
 // a protected span are force-kept regardless of score.
 //
 // Phase 5 of the Local-AI-First build chain (404-fallback hardened in phase 6).
+//
+// A.9.4 (2026-05-14) — Stage 3 was burning one HTTP roundtrip per call on
+// every request to discover the router /v1/score-tokens endpoint is missing
+// (404). At ~50ms per Stage 3 invocation that compounds across the live
+// traffic Stage 3 is now seeing post-Phase α wiring. We now memoize the
+// 404 outcome per routerBaseUrl with a TTL so subsequent calls skip the
+// roundtrip entirely; the router-upgrade path is unchanged — on TTL
+// expiry the next call will probe again and pick up the endpoint if it
+// has become available.
 
 import { findProtectedRanges, isIndexProtected } from './stage1.js';
 import { estimateTokens } from './types.js';
@@ -67,6 +76,39 @@ const DEFAULTS: Required<Omit<Stage3Options, 'fetchImpl' | 'forceHeuristic'>> = 
   minTokensToPrune: 500,
 };
 
+// ─── Missing-endpoint memo (A.9.4) ────────────────────────────────────
+//
+// Cache per routerBaseUrl: the first call to score this URL via
+// /v1/score-tokens that returns 404 records the timestamp. Subsequent
+// calls within the TTL skip the roundtrip and go straight to heuristic.
+//
+// Overridable via env STAGE3_ROUTER_404_TTL_MS (default 1 h). Tests
+// reset the memo via `__resetRouter404Memo`.
+const ROUTER_404_TTL_MS = parseInt(
+  process.env['STAGE3_ROUTER_404_TTL_MS'] ?? '3600000',
+  10,
+);
+const router404Memo = new Map<string, number>();
+
+/** Internal: reset the per-baseUrl 404 cache. Test-only seam. */
+export function __resetRouter404Memo(): void {
+  router404Memo.clear();
+}
+
+function memoKnown404(baseUrl: string): boolean {
+  const ts = router404Memo.get(baseUrl);
+  if (ts === undefined) return false;
+  if (Date.now() - ts > ROUTER_404_TTL_MS) {
+    router404Memo.delete(baseUrl);
+    return false;
+  }
+  return true;
+}
+
+function recordRouter404(baseUrl: string): void {
+  router404Memo.set(baseUrl, Date.now());
+}
+
 // Default per-segment weights from the design doc §5.3.
 export const DEFAULT_SEGMENT_WEIGHTS: Record<PromptSegment['kind'], number> = {
   system: 0,
@@ -104,19 +146,28 @@ export async function stage3Prune(
   let routerError: string | undefined;
 
   if (!opts.forceHeuristic) {
-    try {
-      scoredSegments = await scoreViaRouter(segments, userQuestion, o, fetcher);
-      backend = 'router';
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      // A 404 from the router means the optional `/v1/score-tokens` endpoint
-      // isn't implemented on this build — that's the expected v1 path. Treat
-      // it as silent fallback and don't surface it as an error. Any other
-      // failure (5xx, network, timeout, shape) is surfaced for ops.
-      if (msg !== 'router-status-404') {
-        routerError = msg;
-      }
+    // Skip the HTTP roundtrip if we already know this routerBaseUrl
+    // returns 404 for /v1/score-tokens (A.9.4).
+    if (memoKnown404(o.routerBaseUrl)) {
       scoredSegments = scoreHeuristic(segments, userQuestion);
+    } else {
+      try {
+        scoredSegments = await scoreViaRouter(segments, userQuestion, o, fetcher);
+        backend = 'router';
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // A 404 from the router means the optional `/v1/score-tokens` endpoint
+        // isn't implemented on this build — that's the expected v1 path. Treat
+        // it as silent fallback and don't surface it as an error, AND memoize
+        // so subsequent calls skip the roundtrip. Any other failure
+        // (5xx, network, timeout, shape) is surfaced for ops.
+        if (msg === 'router-status-404') {
+          recordRouter404(o.routerBaseUrl);
+        } else {
+          routerError = msg;
+        }
+        scoredSegments = scoreHeuristic(segments, userQuestion);
+      }
     }
   } else {
     scoredSegments = scoreHeuristic(segments, userQuestion);


### PR DESCRIPTION
## Summary
SPS-Prompting completion part 2 — phase 1 — A.9.4.

Stage 3 of the prompt-optimizer cascade was burning one HTTP roundtrip per call to discover that the router's `/v1/score-tokens` endpoint isn't implemented (404 is the expected v1 path per the existing source comment). At ~50ms per call this compounds across the live traffic Stage 3 is now seeing post-A.10 wiring.

Fix: per-`routerBaseUrl` 404 memoization with a 1-hour TTL (overridable via env `STAGE3_ROUTER_404_TTL_MS`). First 404 records the timestamp; subsequent calls within the TTL skip the roundtrip and go straight to heuristic. On TTL expiry the next call probes again — router-upgrade path unchanged. Non-404 errors (500, network, timeout) are NOT memoized so transient failures still surface to ops.

Closes A.9.4 from `~/Documents/projects/reports/local_ai_first_gap_analysis_2026-05-14.md`.

## Changes
- `packages/prompt-optimizer/src/stage3.ts` — `router404Memo` + `memoKnown404` / `recordRouter404` helpers + `__resetRouter404Memo` test seam
- `packages/prompt-optimizer/src/index.ts` — export the test seam
- `packages/prompt-optimizer/__tests__/stage3.test.ts` — 3 new regression tests

## Test plan
- [x] stage3 tests: 14/14 pass
- [x] memo skips second roundtrip on a 404 (same baseUrl)
- [x] different baseUrls don't cross-contaminate
- [x] non-404 (500) still retries (NOT memoized)
- [x] tsc --noEmit clean
- [x] No new lint errors
- [ ] Post-merge: confirm Stage 3 log lines no longer show repeated 404 roundtrips on the live daemon

## Chain context
- Chain: `sps-prompting-completion-part2`
- Phase: 1 / router_optimizer_fixes
- Companion PR: `feat/sps-part2-router-2026-05-14` (A.9.5 + A.9.1.1 + A.9.7 + A.9.9)
- Phase report: `~/Documents/projects/reports/sps_part2_router_optimizer_fixes_2026-05-14.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)