### PR TITLE
feat(infra): a.9.17 headroom learn weekly cron

### DIFF
--- a/infra/cron/headroom-learn-weekly.plist
+++ b/infra/cron/headroom-learn-weekly.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.chiefaia.headroom-learn-weekly
+
+  Weekly run of `headroom learn` to extract failure-mode corrections from
+  the previous week's spawner-claude / Claude Code sessions and write them
+  into CLAUDE.md / per-project memory. Closes A.9.17 / GC-5 from the
+  SPS-Prompting #2 priority campaign.
+
+  Schedule: Sundays at 03:00 LOCAL (StartCalendarInterval is local time
+  on macOS — operator brief specified UTC, but launchd does not support
+  TZ-aware schedules; 03:00 local is the universal "off-hours weekly"
+  expression that the operator can re-template if a strict UTC slot is
+  required).
+
+  Install:
+    mkdir -p ~/.caia/headroom-learn
+    cp infra/cron/headroom-learn-weekly.sh ~/.caia/headroom-learn/learn.sh
+    chmod +x ~/.caia/headroom-learn/learn.sh
+    cp infra/cron/headroom-learn-weekly.plist ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
+    launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
+
+  Uninstall:
+    launchctl bootout gui/$UID/com.chiefaia.headroom-learn-weekly
+
+  Logs:
+    out  -> ~/.caia/headroom-learn/launchd.out.log
+    err  -> ~/.caia/headroom-learn/launchd.err.log
+    weekly run log -> ~/.caia/headroom-learn/run-YYYY-MM-DD.log
+    weekly report  -> ~/Documents/projects/reports/headroom_learn_weekly_YYYY-MM-DD.md
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>com.chiefaia.headroom-learn-weekly</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>-lc</string>
+      <string>$HOME/.caia/headroom-learn/learn.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+      <!-- 0 = Sunday (launchd numbering: Sun=0, Mon=1, ..., Sat=6) -->
+      <key>Weekday</key><integer>0</integer>
+      <key>Hour</key><integer>3</integer>
+      <key>Minute</key><integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/macbook32/.caia/headroom-learn/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/macbook32/.caia/headroom-learn/launchd.err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <key>HOME</key><string>/Users/macbook32</string>
+      <!-- Pin node@22 to dodge the better-sqlite3 ABI footgun (caia_pnpm_node_abi memory). -->
+      <key>CAIA_NODE_BIN</key><string>/opt/homebrew/opt/node@22/bin/node</string>
+    </dict>
+
+    <key>Nice</key><integer>10</integer>
+    <key>ProcessType</key><string>Background</string>
+    <key>RunAtLoad</key><false/>
+    <key>KeepAlive</key><false/>
+  </dict>
+</plist>

--- a/infra/cron/headroom-learn-weekly.sh
+++ b/infra/cron/headroom-learn-weekly.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# headroom-learn-weekly.sh
+#
+# Weekly run of `headroom learn` to extract failure-mode corrections from
+# the previous week's spawner-claude / Claude Code sessions, then write a
+# readable markdown report into ~/Documents/projects/reports/.
+#
+# Closes A.9.17 / GC-5 from the SPS-Prompting #2 priority campaign.
+#
+# Triggered by ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
+# (Sundays, off-hours).
+#
+# At runtime this lives at ~/.caia/headroom-learn/learn.sh — the canonical
+# copy is committed to caia/infra/cron/. Install with:
+#   mkdir -p ~/.caia/headroom-learn
+#   cp infra/cron/headroom-learn-weekly.sh ~/.caia/headroom-learn/learn.sh
+#   chmod +x ~/.caia/headroom-learn/learn.sh
+#   cp infra/cron/headroom-learn-weekly.plist ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
+#   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
+
+set -uo pipefail
+
+# Resolve paths
+HOME_DIR="${HOME:-/Users/macbook32}"
+HEADROOM_BIN="${HEADROOM_BIN:-/opt/homebrew/bin/headroom}"
+REPORT_DIR="${REPORT_DIR:-$HOME_DIR/Documents/projects/reports}"
+LOG_DIR="${LOG_DIR:-$HOME_DIR/.caia/headroom-learn}"
+DATE_UTC=$(date -u +%Y-%m-%d)
+TS_UTC=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+REPORT_PATH="$REPORT_DIR/headroom_learn_weekly_${DATE_UTC}.md"
+RUN_LOG="$LOG_DIR/run-${DATE_UTC}.log"
+DRY_OUT="$LOG_DIR/dry-run-${DATE_UTC}.txt"
+APPLY_OUT="$LOG_DIR/apply-${DATE_UTC}.txt"
+
+mkdir -p "$LOG_DIR" "$REPORT_DIR"
+
+echo "[$TS_UTC] starting headroom learn weekly run" | tee -a "$RUN_LOG"
+
+if [ ! -x "$HEADROOM_BIN" ]; then
+  echo "[FATAL] headroom binary not found at $HEADROOM_BIN" | tee -a "$RUN_LOG" >&2
+  exit 2
+fi
+
+HR_VERSION=$("$HEADROOM_BIN" --version 2>&1 | head -1 || echo "unknown")
+echo "[*] headroom version: $HR_VERSION" | tee -a "$RUN_LOG"
+
+# Capture the size of CLAUDE.md before apply (for diff in report)
+CLAUDE_MD="$HOME_DIR/Documents/CLAUDE.md"
+SIZE_BEFORE=0
+if [ -f "$CLAUDE_MD" ]; then
+  SIZE_BEFORE=$(wc -c < "$CLAUDE_MD")
+fi
+
+# Phase 1 — dry-run to capture recommendations for the report
+echo "[*] phase 1: dry-run scan of all projects" | tee -a "$RUN_LOG"
+"$HEADROOM_BIN" learn --all --agent claude > "$DRY_OUT" 2>&1
+DRY_RC=$?
+echo "[*] dry-run rc=$DRY_RC, $(wc -l < "$DRY_OUT") lines captured" | tee -a "$RUN_LOG"
+
+# Phase 2 — apply to write recommendations into context/memory files
+echo "[*] phase 2: apply recommendations" | tee -a "$RUN_LOG"
+"$HEADROOM_BIN" learn --all --agent claude --apply > "$APPLY_OUT" 2>&1
+APPLY_RC=$?
+echo "[*] apply rc=$APPLY_RC" | tee -a "$RUN_LOG"
+
+SIZE_AFTER=0
+if [ -f "$CLAUDE_MD" ]; then
+  SIZE_AFTER=$(wc -c < "$CLAUDE_MD")
+fi
+SIZE_DELTA=$((SIZE_AFTER - SIZE_BEFORE))
+
+# Phase 3 — write report
+{
+  echo "---"
+  echo "name: Headroom Learn Weekly Report — ${DATE_UTC}"
+  echo "type: cron-report"
+  echo "agent: headroom-learn-weekly"
+  echo "ts_utc: ${TS_UTC}"
+  echo "---"
+  echo
+  echo "# Headroom Learn Weekly Report — ${DATE_UTC}"
+  echo
+  echo "Automated by \`com.chiefaia.headroom-learn-weekly\` LaunchAgent."
+  echo "Source: A.9.17 / GC-5 from the SPS-Prompting #2 priority campaign."
+  echo
+  echo "## Run summary"
+  echo
+  echo "| Field | Value |"
+  echo "|---|---|"
+  echo "| Run timestamp | \`${TS_UTC}\` |"
+  echo "| Headroom version | \`${HR_VERSION}\` |"
+  echo "| Dry-run exit code | \`${DRY_RC}\` |"
+  echo "| Apply exit code | \`${APPLY_RC}\` |"
+  echo "| CLAUDE.md size before | ${SIZE_BEFORE} B |"
+  echo "| CLAUDE.md size after | ${SIZE_AFTER} B |"
+  echo "| CLAUDE.md size delta | ${SIZE_DELTA} B |"
+  echo "| Run log | \`${RUN_LOG}\` |"
+  echo "| Dry-run output | \`${DRY_OUT}\` |"
+  echo "| Apply output | \`${APPLY_OUT}\` |"
+  echo
+  echo "## Dry-run recommendations"
+  echo
+  echo "\`headroom learn --all --agent claude\` (dry-run):"
+  echo
+  echo '```'
+  head -200 "$DRY_OUT"
+  echo '```'
+  if [ "$(wc -l < "$DRY_OUT")" -gt 200 ]; then
+    echo
+    echo "_(truncated after 200 lines; full output at \`${DRY_OUT}\`)_"
+  fi
+  echo
+  echo "## Apply output"
+  echo
+  echo '```'
+  head -200 "$APPLY_OUT"
+  echo '```'
+  if [ "$(wc -l < "$APPLY_OUT")" -gt 200 ]; then
+    echo
+    echo "_(truncated after 200 lines; full output at \`${APPLY_OUT}\`)_"
+  fi
+  echo
+  echo "## Next steps"
+  echo
+  echo "- Review changes to CLAUDE.md and per-project memory files (\`git diff\` if tracked)."
+  echo "- If recommendations look noisy, edit \`~/.caia/headroom-learn/learn.sh\` to narrow \`--project\` or \`--agent\`."
+  echo "- Next scheduled run: next Sunday 03:00 local."
+} > "$REPORT_PATH"
+
+echo "[*] report written: $REPORT_PATH" | tee -a "$RUN_LOG"
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] done (dry_rc=$DRY_RC apply_rc=$APPLY_RC)" | tee -a "$RUN_LOG"
+
+# Exit non-zero only when both phases failed — we still want a report on partial success.
+if [ "$DRY_RC" -ne 0 ] && [ "$APPLY_RC" -ne 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

A.9.17 / GC-5 from the SPS-Prompting #2 priority campaign. Adds the weekly \`headroom learn\` LaunchAgent that mines the prior week's spawner-claude / Claude Code sessions for failure-mode corrections and writes them into CLAUDE.md / per-project memory — closing the continuous-improvement loop the gap analysis flagged at #17.

## Files

- \`infra/cron/headroom-learn-weekly.plist\` — \`com.chiefaia.headroom-learn-weekly\` LaunchAgent. Sundays 03:00 local. Pinned to node@22 via \`CAIA_NODE_BIN\` per the standing better-sqlite3 ABI rule. Plist passes \`plutil -lint\`.
- \`infra/cron/headroom-learn-weekly.sh\` — installed at \`~/.caia/headroom-learn/learn.sh\`. Two-phase run: dry-run scan (captured into the report) → apply (writes recommendations). Always emits a markdown report into \`~/Documents/projects/reports/headroom_learn_weekly_<YYYY-MM-DD>.md\` even on partial failure. Bash syntax-checked with \`bash -n\`.

## Schedule deviation

The brief specified **03:00 UTC**. macOS \`StartCalendarInterval\` is local-time only, so I used **03:00 local** as the universal off-hours expression. Operator can re-template the Hour field if a strict UTC alignment is needed (would slot at \`Hour=22\` for current EDT, but flips on DST).

## Install (manual; not run by this PR)

\`\`\`
mkdir -p ~/.caia/headroom-learn
cp infra/cron/headroom-learn-weekly.sh ~/.caia/headroom-learn/learn.sh
chmod +x ~/.caia/headroom-learn/learn.sh
cp infra/cron/headroom-learn-weekly.plist ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
launchctl bootstrap gui/\$UID ~/Library/LaunchAgents/com.chiefaia.headroom-learn-weekly.plist
\`\`\`

## Test plan

- [x] \`plutil -lint infra/cron/headroom-learn-weekly.plist\` — OK
- [x] \`bash -n infra/cron/headroom-learn-weekly.sh\` — clean
- [x] Script installed locally at \`~/.caia/headroom-learn/learn.sh\` — fixture path verified
- [ ] First scheduled run emits a non-empty report into \`~/Documents/projects/reports/\` (deferred to Sunday 2026-05-17 — manual smoke can be done by invoking \`~/.caia/headroom-learn/learn.sh\` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)