### PR TITLE
feat(local-llm-router): R-1 cascade fall-through fix

### DIFF
--- a/packages/local-llm-router/__tests__/cascade-escalation.test.ts
+++ b/packages/local-llm-router/__tests__/cascade-escalation.test.ts
@@ -1,0 +1,171 @@
+// R-1 (2026-05-15): cascade-escalation unit tests. Covers the four trigger
+// families (empty/short, explicit-needs-escalation, json-parse-fail, refusal)
+// plus the happy path (non-empty, well-formed, no refusal).
+
+import { describe, it, expect } from 'vitest';
+import {
+  shouldEscalate,
+  __refusalPatternCount,
+} from '../src/cascade-escalation.js';
+import type { LLMResponse } from '../src/types.js';
+
+function res(text: string): LLMResponse {
+  return {
+    response: text,
+    model: 'qwen2.5-coder:7b',
+    provider: 'local',
+    durationMs: 42,
+  };
+}
+
+describe('cascade-escalation — shouldEscalate', () => {
+  // ── happy path ────────────────────────────────────────────────────────
+  it('does not escalate on a well-formed prose answer', () => {
+    const r = shouldEscalate(
+      res('The function reads bytes from the file and returns them.'),
+    );
+    expect(r.shouldEscalate).toBe(false);
+  });
+
+  it('does not escalate on a well-formed JSON object', () => {
+    const r = shouldEscalate(
+      res(
+        '{"intent":"rename","confidence":0.92,"needs_escalation":false,"recommended_tier":"local-7b","reasoning":"single-file symbol rename"}',
+      ),
+    );
+    expect(r.shouldEscalate).toBe(false);
+  });
+
+  // ── trigger 1: empty / too-short ─────────────────────────────────────
+  it('escalates when response is empty', () => {
+    const r = shouldEscalate(res(''));
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('empty-or-short');
+  });
+
+  it('escalates when response is whitespace only', () => {
+    const r = shouldEscalate(res('   \n  \t  '));
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('empty-or-short');
+  });
+
+  it('escalates when response is too short', () => {
+    const r = shouldEscalate(res('huh.'));
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('empty-or-short');
+  });
+
+  // ── trigger 2: explicit needs_escalation ─────────────────────────────
+  it('escalates when classifier sets needs_escalation:true', () => {
+    const r = shouldEscalate(
+      res(
+        '{"intent":"unknown","confidence":0.3,"needs_escalation":true,"recommended_tier":"claude","reasoning":"beyond 7B scope"}',
+      ),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('explicit-needs-escalation');
+  });
+
+  it('escalates on needs_escalation:true with whitespace variants', () => {
+    const r = shouldEscalate(
+      res('{"needs_escalation" : true, "other":"x"}'),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('explicit-needs-escalation');
+  });
+
+  it('does NOT escalate on needs_escalation:false', () => {
+    const r = shouldEscalate(
+      res('{"intent":"rename","needs_escalation":false,"confidence":0.92}'),
+    );
+    expect(r.shouldEscalate).toBe(false);
+  });
+
+  // ── trigger 3: JSON parse fail ───────────────────────────────────────
+  it('escalates when JSON-shaped output fails to parse', () => {
+    const r = shouldEscalate(res('{"intent":"rename","confidence":0.92,'));
+    // Doesn't end with } so this is actually empty-or-short OR refusal — re-target:
+    const r2 = shouldEscalate(res('{"intent":"rename","confidence":}'));
+    expect(r2.shouldEscalate).toBe(true);
+    expect(r2.trigger).toBe('json-parse-fail');
+    // The truncated one above: starts with { but ends with , — doesn't match
+    // the visual-shape guard, so it falls through to refusal (no match) and
+    // ultimately to no-escalate. That's expected by design — we ONLY parse
+    // when the brackets visually align, to keep false-positives near zero.
+    expect(r.shouldEscalate).toBe(false);
+  });
+
+  it('escalates when JSON-array-shaped output fails to parse', () => {
+    const r = shouldEscalate(res('[1, 2, 3, oops]'));
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('json-parse-fail');
+  });
+
+  it('does NOT escalate on prose that happens to contain braces', () => {
+    const r = shouldEscalate(
+      res('Use ${variable} to interpolate. The output is fine.'),
+    );
+    expect(r.shouldEscalate).toBe(false);
+  });
+
+  // ── trigger 4: refusal / low-confidence phrases ──────────────────────
+  it('escalates on "i don\'t know"', () => {
+    const r = shouldEscalate(
+      res("I don't know how to answer that question."),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('refusal');
+    expect(r.reason).toBe('i-dont-know');
+  });
+
+  it('escalates on "sorry, i cannot help"', () => {
+    const r = shouldEscalate(
+      res("Sorry, I cannot help with that request."),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('refusal');
+    expect(r.reason).toBe('sorry-i-cannot');
+  });
+
+  it('escalates on "as an AI language model"', () => {
+    const r = shouldEscalate(
+      res("As an AI language model, I cannot make personal decisions for you."),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('refusal');
+  });
+
+  it('escalates on "insufficient information"', () => {
+    const r = shouldEscalate(
+      res("There is insufficient information to answer this question precisely."),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('refusal');
+    expect(r.reason).toBe('insufficient-information');
+  });
+
+  it('escalates on "unable to determine"', () => {
+    const r = shouldEscalate(
+      res("Based on the input I am unable to determine the correct answer."),
+    );
+    expect(r.shouldEscalate).toBe(true);
+    expect(r.trigger).toBe('refusal');
+    expect(r.reason).toBe('unable-to-determine');
+  });
+
+  it('does NOT escalate when refusal-shape text appears INSIDE a quoted code block', () => {
+    // false-positive guard: we accept that this fires; documenting the
+    // current behavior. If this becomes a problem, widen with code-fence
+    // exclusion. For now the apprentice training corpus is the gate.
+    const r = shouldEscalate(
+      res('The error message says "I don\'t know what to do" — handle it.'),
+    );
+    // We *do* expect this to fire today; flip if we add a code-fence guard.
+    expect(r.shouldEscalate).toBe(true);
+  });
+
+  // ── guard: pattern count shouldn't accidentally shrink ───────────────
+  it('keeps at least 5 refusal patterns', () => {
+    expect(__refusalPatternCount()).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/packages/local-llm-router/src/cascade-escalation.ts
+++ b/packages/local-llm-router/src/cascade-escalation.ts
@@ -1,0 +1,134 @@
+// R-1 fix (2026-05-15): post-dispatch cascade escalation. After the local
+// model returns, decide whether the response itself signals that the call
+// should have gone to claude. The pre-classifier adversarial-prefilter only
+// catches injection-shaped prompts; this module catches the other half — the
+// local model accepted a benign prompt but produced low-confidence or
+// schema-broken output.
+//
+// Triggers (in order of detection):
+//   1. Empty / too-short: trimmed response < MIN_RESPONSE_CHARS. Usually
+//      indicates a hard refusal that bottomed out as ".", "\n", or "I" or
+//      a generation budget that hit a stop token immediately.
+//   2. Explicit `needs_escalation: true`: classifier-style tasks emit this
+//      flag in their JSON output (see classifier.ts / classifier-v2.ts). When
+//      the local model itself recommends escalation, honor it.
+//   3. JSON-parse failure on JSON-shaped output: if the response looks like
+//      a JSON object/array (starts and ends with matching brackets) but
+//      JSON.parse throws, the schema contract is broken. Escalate.
+//   4. Refusal / low-confidence prose: small set of strict regexes for the
+//      canonical refusal openers ("i don't know", "sorry, i cannot", "as an
+//      ai language model", "insufficient information", "unable to
+//      determine"). Patterns are intentionally narrow — false-positive risk
+//      on legitimate prose; widen via eval corpus, not by intuition.
+//
+// On match the router routes the prompt to claude and stamps a
+// RouterDecision with reason=cascade-escalation:<trigger> so the dashboard
+// surfaces the rate. Mirrors the adversarial-prefilter ergonomics on
+// purpose — same result shape, same emit contract.
+
+import type { LLMResponse } from './types.js';
+
+export interface CascadeEscalationResult {
+  shouldEscalate: boolean;
+  reason?: string;
+  trigger?: 'empty-or-short' | 'explicit-needs-escalation' | 'json-parse-fail' | 'refusal';
+}
+
+const MIN_RESPONSE_CHARS = 8;
+
+interface RefusalPattern {
+  name: string;
+  test: RegExp;
+}
+
+const REFUSAL_PATTERNS: RefusalPattern[] = [
+  {
+    name: 'i-dont-know',
+    test: /\bi\s+(?:do\s+not|don'?t)\s+know\b/i,
+  },
+  {
+    name: 'sorry-i-cannot',
+    test: /\b(?:sorry,?\s+)?i\s+(?:can'?t|cannot|am\s+unable|'?m\s+unable)\s+(?:help|assist|do\s+that|provide|answer|complete|fulfill)\b/i,
+  },
+  {
+    name: 'as-an-ai',
+    test: /\b(?:as\s+an?\s+ai(?:\s+language\s+model)?|i'?m\s+just\s+an\s+ai|as\s+a\s+language\s+model)\b/i,
+  },
+  {
+    name: 'insufficient-information',
+    test: /\b(?:insufficient|not\s+enough)\s+(?:information|context|data|detail)\b/i,
+  },
+  {
+    name: 'unable-to-determine',
+    test: /\bunable\s+to\s+(?:determine|answer|provide|complete|generate)\b/i,
+  },
+];
+
+/**
+ * Decide whether a local-model response should be re-dispatched to claude.
+ *
+ * Returns `{ shouldEscalate: false }` on the happy path. When true, the
+ * caller (router) should re-dispatch the same request to claude and emit a
+ * RouterDecision with reason=cascade-escalation:<trigger>.
+ *
+ * Pure function, no side effects. Safe to call on every dispatch.
+ */
+export function shouldEscalate(response: LLMResponse): CascadeEscalationResult {
+  const raw = typeof response.response === 'string' ? response.response : '';
+  const text = raw.trim();
+
+  // 1) Empty / too-short
+  if (text.length < MIN_RESPONSE_CHARS) {
+    return {
+      shouldEscalate: true,
+      trigger: 'empty-or-short',
+      reason: `length=${text.length}`,
+    };
+  }
+
+  // 2) Explicit needs_escalation signal — the classifier emits this in its
+  //    JSON output when it thinks the task is beyond a 7B coder's capability.
+  if (/"needs_escalation"\s*:\s*true/i.test(text)) {
+    return {
+      shouldEscalate: true,
+      trigger: 'explicit-needs-escalation',
+      reason: 'classifier-flagged',
+    };
+  }
+
+  // 3) JSON-parse failure on JSON-shaped output. Only attempt the parse when
+  //    the response visually looks like JSON to avoid false positives on
+  //    legitimate prose that happens to contain stray braces.
+  const first = text.charAt(0);
+  const last = text.charAt(text.length - 1);
+  if ((first === '{' && last === '}') || (first === '[' && last === ']')) {
+    try {
+      JSON.parse(text);
+    } catch (e) {
+      return {
+        shouldEscalate: true,
+        trigger: 'json-parse-fail',
+        reason: (e as Error).message.slice(0, 80),
+      };
+    }
+  }
+
+  // 4) Refusal / low-confidence phrases
+  for (const p of REFUSAL_PATTERNS) {
+    if (p.test.test(text)) {
+      return {
+        shouldEscalate: true,
+        trigger: 'refusal',
+        reason: p.name,
+      };
+    }
+  }
+
+  return { shouldEscalate: false };
+}
+
+/** Test-only: expose refusal-pattern count for tests that guard against
+ *  accidental shrinkage of the rule set. */
+export function __refusalPatternCount(): number {
+  return REFUSAL_PATTERNS.length;
+}

--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -24,6 +24,7 @@ import {
 } from './claude-adapter.js';
 import { OllamaAdapter } from './ollama-adapter.js';
 import { screenForInjection } from './adversarial-prefilter.js';
+import { shouldEscalate as cascadeShouldEscalate } from './cascade-escalation.js';
 import {
   CAIA_ATTR,
   GEN_AI,
@@ -239,6 +240,37 @@ export async function route(
             result = await dispatchClaude(rule.claudeModel, request);
           } else {
             throw localErr;
+          }
+        }
+
+        // R-1 (2026-05-15): cascade fall-through. The local model returned
+        // without throwing, but the response itself may signal that the
+        // call should have gone to claude — empty/short output, explicit
+        // needs_escalation flag, JSON-parse failure on JSON-shaped output,
+        // or canonical refusal openers. Re-dispatch to claude when a
+        // claudeModel is configured, fallback is enabled, and the caller
+        // didn't force-pin to local. forceLocal callers accept the local
+        // result regardless of confidence (caller opted out of cascade).
+        if (
+          !usedFallback &&
+          fallbackEnabled &&
+          rule.claudeModel &&
+          !options.forceLocal
+        ) {
+          const cascade = cascadeShouldEscalate(result);
+          if (cascade.shouldEscalate) {
+            const triggerLabel = cascade.trigger ?? 'unknown';
+            const reasonLabel = cascade.reason ?? 'unknown';
+            usedFallback = true;
+            fallbackFrom = 'local';
+            fallbackReason = `cascade-escalation:${triggerLabel}:${reasonLabel}`.slice(0, 200);
+            console.warn(
+              `[local-llm-router] Local model "${rule.localModel}" returned ` +
+                `low-confidence output for task "${taskType}" ` +
+                `(trigger=${triggerLabel}, reason=${reasonLabel}); ` +
+                `escalating to Claude binary (${rule.claudeModel}).`,
+            );
+            result = await dispatchClaude(rule.claudeModel, request);
           }
         }
       } else {

--- a/packages/local-llm-router/tests/mentor-emit.test.ts
+++ b/packages/local-llm-router/tests/mentor-emit.test.ts
@@ -281,7 +281,10 @@ describe('mentor-emit', () => {
         {
           isAvailable: vi.fn().mockResolvedValue(true),
           generate: vi.fn().mockResolvedValue({
-            response: 'ok',
+            // R-1 cascade-escalation guard fires on <8-char responses; keep
+            // the fixture long enough to bypass it so this test exercises
+            // the happy-path RouterDecision emit, not the escalation path.
+            response: 'classification: domain=auth, confidence=high',
             model: 'qwen2.5-coder:7b',
             provider: 'local',
             durationMs: 5,

--- a/packages/local-llm-router/tests/router.test.ts
+++ b/packages/local-llm-router/tests/router.test.ts
@@ -198,3 +198,128 @@ describe('route — llmMetrics wiring (A.9.1.1)', () => {
     expect(snap.savedUsd).toBeGreaterThan(0);
   });
 });
+
+// R-1 (2026-05-15): cascade-escalation post-dispatch fallthrough.
+// Verifies that a successful-but-low-confidence local response is re-dispatched
+// to claude when the response signals refusal / empty / schema-fail /
+// explicit-needs-escalation. Mirrors the existing error-path fallback tests.
+describe('route — cascade escalation (R-1)', () => {
+  beforeEach(() => {
+    __setAdapters(null, null);
+    llmMetrics.reset();
+  });
+
+  it('escalates to claude when local returns "i don\'t know"', async () => {
+    const ollama = fakeOllama({
+      response: { response: "I don't know how to classify this." },
+    });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('domain-classification', 'classify this');
+
+    expect(ollama.generate).toHaveBeenCalledOnce();
+    expect(claude.generate).toHaveBeenCalledOnce();
+    expect(res.provider).toBe('claude');
+  });
+
+  it('escalates to claude when local returns an empty response', async () => {
+    const ollama = fakeOllama({ response: { response: '' } });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('domain-classification', 'classify this');
+
+    expect(claude.generate).toHaveBeenCalledOnce();
+    expect(res.provider).toBe('claude');
+  });
+
+  it('escalates to claude when local emits needs_escalation:true', async () => {
+    const ollama = fakeOllama({
+      response: {
+        response:
+          '{"intent":"unknown","confidence":0.3,"needs_escalation":true,"recommended_tier":"claude","reasoning":"beyond scope"}',
+      },
+    });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('domain-classification', 'classify this');
+
+    expect(claude.generate).toHaveBeenCalledOnce();
+    expect(res.provider).toBe('claude');
+  });
+
+  it('escalates to claude when local returns malformed JSON', async () => {
+    const ollama = fakeOllama({
+      response: { response: '{"intent":"rename","confidence":}' },
+    });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('domain-classification', 'classify this');
+
+    expect(claude.generate).toHaveBeenCalledOnce();
+    expect(res.provider).toBe('claude');
+  });
+
+  it('does NOT escalate when local returns a well-formed response', async () => {
+    const ollama = fakeOllama({
+      response: {
+        response:
+          '{"intent":"rename","confidence":0.92,"needs_escalation":false,"recommended_tier":"local-7b","reasoning":"clear single-file rename"}',
+      },
+    });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('domain-classification', 'classify this');
+
+    expect(ollama.generate).toHaveBeenCalledOnce();
+    expect(claude.generate).not.toHaveBeenCalled();
+    expect(res.provider).toBe('local');
+  });
+
+  it('respects forceLocal — does NOT escalate even on refusal', async () => {
+    const ollama = fakeOllama({
+      response: { response: "I don't know how to classify this." },
+    });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('hierarchy-decomposition', 'decompose this', {
+      forceLocal: true,
+    });
+
+    expect(claude.generate).not.toHaveBeenCalled();
+    expect(res.provider).toBe('local');
+  });
+
+  it('does NOT escalate when fallbackOnError=false (caller opted out)', async () => {
+    const ollama = fakeOllama({ response: { response: '' } });
+    const claude = fakeClaude();
+    __setAdapters(ollama, claude);
+
+    const res = await route('domain-classification', 'classify this', {
+      fallbackOnError: false,
+    });
+
+    expect(claude.generate).not.toHaveBeenCalled();
+    expect(res.provider).toBe('local');
+  });
+
+  it('records the cascade-escalation as a fallback in llmMetrics', async () => {
+    __setAdapters(
+      fakeOllama({ response: { response: "I don't know." } }),
+      fakeClaude(),
+    );
+    await route('domain-classification', 'classify this');
+    const snap = llmMetrics.snapshot();
+    // The final dispatch is claude; the local call doesn't get its own
+    // metrics row (single dispatch = single record, matching the existing
+    // fallback-from-error behavior).
+    expect(snap.totalCalls).toBe(1);
+    expect(snap.claudeCalls).toBe(1);
+    expect(snap.localCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- R-1 critical fix: dispatcher now escalates to claude when local returns low-confidence output (refusal phrases, empty response, malformed JSON, or explicit `needs_escalation:true`).
- Previously escalation only fired on a thrown error from local dispatch, so the overnight cross-test saw 100% local routing with no fall-through on bad output (sps-hardening-cascade-stress + sps-batch-tier-validation).
- New module: `packages/local-llm-router/src/cascade-escalation.ts` (134 lines, 18 unit tests).
- Router wires it in after a successful local dispatch; respects `forceLocal` and `fallbackOnError:false` (same gates as the existing error-path fallback).
- 20 router tests (12 pre-existing + 8 new) and 18 cascade-escalation unit tests pass. `tsc` + `eslint` clean.

## Triggers
1. Empty / too-short output (`<8` chars after trim).
2. Explicit `"needs_escalation":true` in the JSON output (classifier-style tasks).
3. JSON-parse failure on JSON-shaped responses (must look visually like JSON to avoid prose false-positives).
4. Canonical refusal openers: `i don't know`, `sorry, i cannot`, `as an AI language model`, `insufficient information`, `unable to determine`.

## ROUTER-DAEMON-RELOAD-REQUIRED
This change is in-process; it does NOT take effect until the daemon reloads:
```
launchctl kickstart -k gui/$(id -u)/com.chiefaia.local-llm-router
```

## Test plan
- [x] `vitest run` — 246/246 pass (full local-llm-router suite)
- [x] `tsc --noEmit` — clean
- [x] `eslint src/cascade-escalation.ts src/router.ts` — clean
- [x] Build artifacts: `dist/cascade-escalation.{js,d.ts}` generated
- [ ] Post-merge: kickstart daemon, then re-run cross-test corpus and verify cascade-escalation rate > 0 in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)