### PR TITLE
feat(post-merge): a1 router kickstart + schema-v2 pr_body dispatch

### DIFF
--- a/.github/workflows/post-merge-signal.yml
+++ b/.github/workflows/post-merge-signal.yml
@@ -58,12 +58,18 @@ jobs:
           REPO_FULL_NAME: ${{ github.repository }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           cd queue-work
           # Build row with jq to escape correctly.
+          # PR body is truncated to 4 KB so the queue stays small but still
+          # carries institutionalized deploy tags (e.g.
+          # ROUTER-DAEMON-RELOAD-REQUIRED) inline — saves the local watcher
+          # an extra `gh pr view` round-trip per row.
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          body_trunc="${PR_BODY:0:4096}"
           row="$(jq -nc \
             --arg pr "$PR_NUMBER" \
             --arg repo "$REPO_FULL_NAME" \
@@ -72,7 +78,8 @@ jobs:
             --arg ts "$ts" \
             --arg title "$PR_TITLE" \
             --arg author "$PR_AUTHOR" \
-            '{schema_version:1, pr_number:($pr|tonumber), repo:$repo, merge_sha:$sha, base_branch:$base, ts:$ts, pr_title:$title, pr_author:$author}')"
+            --arg body "$body_trunc" \
+            '{schema_version:2, pr_number:($pr|tonumber), repo:$repo, merge_sha:$sha, base_branch:$base, ts:$ts, pr_title:$title, pr_author:$author, pr_body:$body}')"
           # Append + push. Concurrency group serializes; safe pull-rebase + push.
           for attempt in 1 2 3 4 5; do
             git fetch --depth=1 origin post-merge-queue || true

--- a/scripts/post-merge/README.md
+++ b/scripts/post-merge/README.md
@@ -28,16 +28,33 @@ GitHub: <repo>/post-merge-queue/queue.jsonl
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "pr_number": 451,
   "repo": "prakashgbid/caia",
   "merge_sha": "5c077f4...",
   "base_branch": "develop",
   "ts": "2026-05-15T00:00:00Z",
   "pr_title": "feat(observability): a.10.6 + a.10.9 router/optimizer/audit-cron emit-points",
-  "pr_author": "claude-spawned"
+  "pr_author": "claude-spawned",
+  "pr_body": "...PR body, truncated to 4 KB..."
 }
 ```
+
+`schema_version: 2` adds `pr_body` (4 KB max) so the deploy stub can scan
+for institutionalized deploy tags (e.g. `ROUTER-DAEMON-RELOAD-REQUIRED`)
+without an extra `gh pr view` round-trip. v1 rows still parse — body
+just resolves to empty.
+
+## Institutionalized deploy tags
+
+| Tag | Effect |
+|-----|--------|
+| `ROUTER-DAEMON-RELOAD-REQUIRED` | After merge, `launchctl kickstart -k com.chiefaia.local-llm-router` so the operator's Mac picks up the new binary. Also auto-fires when the PR title matches `local-llm-router` or `router-daemon`. |
+
+Add a tag in the PR body when an explicit deploy action must run that
+isn't obvious from the title (e.g. a config change in another package
+that nonetheless mandates a router restart). Tags are matched
+case-sensitively as substrings of `pr_body`.
 
 ## Install (one-shot, idempotent)
 

--- a/scripts/post-merge/post-merge-deploy.sh
+++ b/scripts/post-merge/post-merge-deploy.sh
@@ -2,12 +2,19 @@
 # INT.1.A1 — post-merge deploy stub.
 #
 # Receives a queue row JSON as argv[1] from `post-merge-watcher.sh`.
-# Today: records "saw merge $sha" to a per-repo log + the central
-# log.jsonl. Per-repo deploy actions plug in here later (e.g. K3s rollout
-# for stolution, plist re-bootstrap for caia packages).
+# Logs the merge + dispatches per-repo deploy actions. Today's deploy
+# actions:
+#   - prakashgbid/caia : when the merge touches local-llm-router (title
+#                        regex) or carries ROUTER-DAEMON-RELOAD-REQUIRED
+#                        in its PR body, `launchctl kickstart -k` the
+#                        router LaunchAgent so the new binary is loaded.
+#                        (Closes the "stale binary" gap from 2026-05-15
+#                        — see reports/integration_a1_post_merge_signal_2026-05-15.md.)
+#   - prakashgbid/stolution : stub (extend with K3s rollout / ssh deploy).
 #
-# Operator extension point: add a `case $repo in` branch with the deploy
-# command for that repo.
+# Operator extension point: add a new `case "$repo" in` branch, or add
+# a new entry to the DAEMON_KICKSTART_RULES table for "PR touches X →
+# kickstart Y" wiring.
 
 set -euo pipefail
 
@@ -35,6 +42,8 @@ repo="$(printf '%s' "$row" | jq -r '.repo // "unknown"')"
 sha="$(printf '%s' "$row" | jq -r '.merge_sha // "unknown"')"
 pr="$(printf '%s' "$row" | jq -r '.pr_number // "unknown"')"
 base="$(printf '%s' "$row" | jq -r '.base_branch // "unknown"')"
+title="$(printf '%s' "$row" | jq -r '.pr_title // ""')"
+body_inline="$(printf '%s' "$row" | jq -r '.pr_body // ""')"
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 repo_safe="${repo//\//__}"
@@ -47,11 +56,53 @@ printf '[%s] saw merge %s for %s PR #%s on %s\n' "$ts" "$sha" "$repo" "$pr" "$ba
 printf '{"ts":"%s","level":"info","event":"deploy_stub","repo":"%s","merge_sha":"%s","pr_number":"%s","base_branch":"%s"}\n' \
   "$ts" "$repo" "$sha" "$pr" "$base"
 
-# --- per-repo deploy plug-in points (extend below) --------------------------
+# --- helpers ---------------------------------------------------------------
+
+# Resolve PR body. Prefer the inline copy from the queue row (zero API
+# hop); fall back to `gh pr view` for older schema_version=1 rows.
+resolve_pr_body() {
+  if [[ -n "$body_inline" && "$body_inline" != "null" ]]; then
+    printf '%s' "$body_inline"
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ "$pr" == "unknown" || "$pr" == "null" ]]; then
+    return 0
+  fi
+  gh pr view "$pr" --repo "$repo" --json body --jq '.body // ""' 2>/dev/null || true
+}
+
+kickstart_daemon() {
+  local label="$1"
+  local rc=0
+  local before_pid after_pid
+  before_pid="$(launchctl list 2>/dev/null | awk -v L="$label" '$3==L {print $1}')"
+  launchctl kickstart -k "gui/$(id -u)/$label" >/dev/null 2>&1 || rc=$?
+  # Brief settle so the new PID is observable in the log.
+  sleep 1
+  after_pid="$(launchctl list 2>/dev/null | awk -v L="$label" '$3==L {print $1}')"
+  printf '{"ts":"%s","level":"info","event":"daemon_kickstart","label":"%s","rc":%d,"pid_before":"%s","pid_after":"%s","trigger_pr":"%s","trigger_repo":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$label" "$rc" "${before_pid:-none}" "${after_pid:-none}" "$pr" "$repo"
+}
+
+# --- per-repo deploy plug-in points ----------------------------------------
 case "$repo" in
   prakashgbid/caia)
-    # TODO: invoke per-package install scripts when packages/<x>/scripts/install-postmerge.sh exists.
-    :
+    # Router-daemon-reload wiring (institutionalized 2026-05-15).
+    # Triggers on either signal:
+    #   1) PR title matches `local-llm-router` or `router-daemon` (auto, zero-friction)
+    #   2) PR body contains `ROUTER-DAEMON-RELOAD-REQUIRED` (explicit override
+    #      for non-obvious changes — e.g. a config change in another package
+    #      that nonetheless mandates a router restart)
+    body="$(resolve_pr_body)"
+    if [[ "$title" =~ (local-llm-router|router-daemon) ]] || \
+       [[ "$body" == *"ROUTER-DAEMON-RELOAD-REQUIRED"* ]]; then
+      printf '{"ts":"%s","level":"info","event":"router_reload_triggered","reason":"title_or_tag_match","pr_number":"%s","title":%s}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$pr" "$(printf '%s' "$title" | jq -Rs .)"
+      kickstart_daemon "com.chiefaia.local-llm-router"
+    fi
     ;;
   prakashgbid/stolution)
     # TODO: SSH to stolution, rsync new state, run deploy-*.sh idempotently.


### PR DESCRIPTION
## Summary

Closes the structural "stale binary" gap from 2026-05-15: the router daemon was running yesterday's binary because the post-merge pipeline (PR #452) only logged merges — no deploy action was wired in. This PR institutionalizes the deploy step.

ROUTER-DAEMON-RELOAD-REQUIRED

(Tag is here mostly as a self-test of the new dispatch path — this PR's title also matches the regex, so kickstart will fire either way.)

## What changes

**Workflow → schema_version 2** (`.github/workflows/post-merge-signal.yml`)
- Queue rows now carry `pr_body` (truncated to 4 KB).
- Lets the local deploy stub scan inline for institutionalized deploy tags without an extra \`gh pr view\` round-trip per row.
- v1 rows still parse — body resolves to \`\"\"\`.

**Deploy stub → ROUTER-DAEMON-RELOAD wiring** (`scripts/post-merge/post-merge-deploy.sh`)
When a \`prakashgbid/caia\` merge satisfies either signal:
1. PR title matches \`local-llm-router|router-daemon\` (auto, zero-friction)
2. PR body contains \`ROUTER-DAEMON-RELOAD-REQUIRED\` (explicit opt-in for non-obvious changes — e.g. a config change in another package that nonetheless mandates a router restart)

…the stub runs \`launchctl kickstart -k gui/<uid>/com.chiefaia.local-llm-router\` and logs \`pid_before\`/\`pid_after\` for evidence.

**README** (`scripts/post-merge/README.md`)
- Documents schema v2 + the institutionalized tag table (extensible for future daemons).

## Smoke-test evidence (local)

Fake row dispatched directly to \`~/.caia/post-merge/post-merge-deploy.sh\`:
\`\`\`
{\"event\":\"router_reload_triggered\",\"reason\":\"title_or_tag_match\",\"pr_number\":\"99999\",\"title\":\"feat(local-llm-router): smoke-test fake row\"}
{\"event\":\"daemon_kickstart\",\"label\":\"com.chiefaia.local-llm-router\",\"rc\":0,\"pid_before\":\"30027\",\"pid_after\":\"37842\",\"trigger_pr\":\"99999\",\"trigger_repo\":\"prakashgbid/caia\"}
\`\`\`

End-to-end (watcher → deploy) is already proven by 10 PRs that flowed through the live pipeline since PR #452 merged — see \`~/.caia/post-merge/prakashgbid__caia.deploy.log\`. The new wiring just adds the kickstart action; the watcher → stub plumbing is unchanged.

## Sister change

\`prakashgbid/stolution#759\` — same schema-v2 upgrade in stolution. Stolution doesn't need a router branch (no router daemon there); same workflow shape keeps both repos' rows uniform so the single watcher / deploy stub handles both transparently.

## Refs

- reports/integration_a1_post_merge_signal_2026-05-15.md (this phase)
- reports/integration_remediation_plan_2026-05-14.md §A Phase A1
- DoD v2 §3.a Guardrail 7
- caia#452 (original cloud-side scaffold)