### PR TITLE
feat(local-llm-router): b1 silent tier-collapse fix

### DIFF
--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -32,7 +32,7 @@ import {
   withSpan,
   type RouteDecision,
 } from './otel.js';
-import { getRoute, type RoutingRule } from './routing-config.js';
+import { getRoute, ROUTING_RULES, type RoutingRule } from './routing-config.js';
 import { resolveApprenticeOverride } from './apprentice-override.js';
 import { emitMentorEvent, newDecisionId } from './mentor-emit.js';
 import {
@@ -158,6 +158,26 @@ export async function route(
   const initialModel = preferredProvider === 'local'
     ? localModelForRequest
     : rule.claudeModel ?? 'claude-sonnet-4-6';
+
+  // B1 (2026-05-15) — structured dispatch log. Before this, only the
+  // RouterDecision telemetry recorded WHICH model was chosen; nothing
+  // surfaced WHY. The silent-tier-collapse audit found that the dispatcher
+  // was serving 7b for intents whose cascade design said 14b/32b, but the
+  // metrics couldn't distinguish "rule-says-7b" from "rule-missing-default-7b".
+  // The structured log makes the decision path observable in real time so
+  // a follow-up regression is visible in `tail -f` without restarting.
+  // Format is single-line key=value for cheap grep / jq pipelines.
+  emitDispatchLog({
+    taskType,
+    rule,
+    preferredProvider,
+    chosenModel: initialModel,
+    adversarialBlocked: adversarial.blocked,
+    adversarialMatched: adversarial.matched ?? null,
+    forceLocal: options.forceLocal === true,
+    forceClaude: options.forceClaude === true,
+    apprenticeSlot,
+  });
 
   return withSpan(
     `llm.route ${taskType}`,
@@ -474,6 +494,68 @@ function responseAttrs(
   }
   return attrs;
 }
+
+// B1 (2026-05-15) — structured dispatch log. Single-line key=value emit so
+// `tail -f stderr | grep '\[router\] dispatch'` shows intent=X chose model=Y
+// reason=Z without restart. Reason is one of:
+//   - adversarial-rejected         (RR-1 prefilter forced claude)
+//   - force-local / force-claude   (caller override)
+//   - rule-local / rule-claude     (routing-config decision)
+//   - rule-default-local           (unknown task type → 7b default — the
+//                                   silent-tier-collapse smoking gun, kept
+//                                   warn-level so it's visible by default)
+function emitDispatchLog(args: {
+  taskType: string;
+  rule: RoutingRule;
+  preferredProvider: LLMProvider;
+  chosenModel: string;
+  adversarialBlocked: boolean;
+  adversarialMatched: string | null;
+  forceLocal: boolean;
+  forceClaude: boolean;
+  apprenticeSlot: 'production' | 'canary' | null;
+}): void {
+  try {
+    const hasExplicitRule = ROUTING_RULES_INDEX.has(args.taskType);
+    let reason: string;
+    if (args.adversarialBlocked) {
+      reason = args.adversarialMatched
+        ? `adversarial-rejected:${args.adversarialMatched}`
+        : 'adversarial-rejected';
+    } else if (args.forceLocal) {
+      reason = 'force-local';
+    } else if (args.forceClaude) {
+      reason = 'force-claude';
+    } else if (!hasExplicitRule) {
+      reason = 'rule-default-local';
+    } else if (args.preferredProvider === 'local') {
+      reason = args.rule.useLocal ? 'rule-local' : 'rule-local-override';
+    } else {
+      reason = args.rule.useLocal ? 'rule-claude-override' : 'rule-claude';
+    }
+    const apprentice = args.apprenticeSlot
+      ? ` apprentice=${args.apprenticeSlot}`
+      : '';
+    const ruleStatus = hasExplicitRule ? 'registered' : 'unregistered';
+    // intent= is the taxonomy key (== taskType when the caller routes by
+    // classifier-v2 intent name). model= is what the dispatcher will hand
+    // to ollama/claude. reason= is one of the labels above.
+    console.warn(
+      `[router] dispatch intent=${args.taskType} model=${args.chosenModel} ` +
+        `provider=${args.preferredProvider} reason=${reason} ` +
+        `rule=${ruleStatus} useLocal=${args.rule.useLocal}${apprentice}`,
+    );
+  } catch {
+    /* logging must never break dispatch */
+  }
+}
+
+// Static index over ROUTING_RULES so the dispatch log can detect whether a
+// taskType has an explicit rule without re-scanning the array on every call.
+// Built at module load; routing-config is a static const.
+const ROUTING_RULES_INDEX: Set<string> = new Set(
+  ROUTING_RULES.map((r) => r.taskType),
+);
 
 async function dispatchLocal(
   model: string,

--- a/packages/local-llm-router/src/routing-config.ts
+++ b/packages/local-llm-router/src/routing-config.ts
@@ -391,7 +391,503 @@ export const ROUTING_RULES: RoutingRule[] = [
     estimatedCostLocal: '$0.00',
     estimatedCostClaude: '$0.30',
   },
+
+  // ─── B1 (2026-05-15) — classifier-v2 intent aliases ──────────────────────
+  // Silent tier-collapse fix: classifier-v2 emits intent names (medium-code,
+  // hard-code, code-review, ...) but the dispatcher used to hand those to
+  // getRoute() which fell through to the unknown-task default (qwen2.5-coder:7b).
+  // Cross-host validation found 3/5 codebases silently served 7b when the
+  // cascade design said 14b/32b. Each intent is registered here as a taskType
+  // backed by the model that matches its `default_tier` in routing-rules.yaml:
+  //   local-7b  → qwen2.5-coder:7b
+  //   local-14b → qwen2.5-coder:14b
+  //   local-32b → qwen2.5-coder:14b (M1 Pro 16GB can't host a 32B model; the
+  //               cascade-escalation post-dispatch trigger promotes weak
+  //               14b output to Claude — see cascade-escalation.ts)
+  //   claude    → useLocal:false
+  //   stolution-batch → useLocal:false (batch dispatch path not yet wired
+  //               into router.ts; Claude is the conservative fallback)
+  // The verifyTierRouting() unit test guards these against silent regression.
+  {
+    taskType: 'classify',
+    description: 'classifier-v2 intent: lightweight classification call (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.05',
+  },
+  {
+    taskType: 'summarize',
+    description: 'classifier-v2 intent: short summary (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.30',
+  },
+  {
+    taskType: 'doc-summarize',
+    description: 'classifier-v2 intent: summarize a single doc (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 2000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.30',
+  },
+  {
+    taskType: 'draft-prose',
+    description: 'classifier-v2 intent: write a short prose blurb (local-14b tier).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 2000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.30',
+  },
+  {
+    taskType: 'prose-rewrite',
+    description: 'classifier-v2 intent: tighten/clarify a paragraph (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'format',
+    description: 'classifier-v2 intent: format / reformat / prettify (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.10',
+  },
+  {
+    taskType: 'format-convert',
+    description: 'classifier-v2 intent: convert between data formats (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 2000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'lint-fix',
+    description: 'classifier-v2 intent: apply lint fix / style cleanup (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'rename',
+    description: 'classifier-v2 intent: rename symbol / variable / function (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.10',
+  },
+  {
+    taskType: 'fill-template',
+    description: 'classifier-v2 intent: scaffold / boilerplate fill (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'memory-search',
+    description: 'classifier-v2 intent: lookup in agent-memory (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'small-code-edit',
+    description: 'classifier-v2 intent: one-line / few-line code edit (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'code-explain',
+    description: 'classifier-v2 intent: explain a snippet (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 2000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.30',
+  },
+  {
+    taskType: 'doc-update',
+    description: 'classifier-v2 intent: small docs/README edit (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 2000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.20',
+  },
+  {
+    taskType: 'extract',
+    description: 'classifier-v2 intent: extract structured data from prose (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'error-recovery',
+    description: 'classifier-v2 intent: salvage malformed JSON / repair input (local-7b tier).',
+    localModel: 'qwen2.5-coder:7b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 1500,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.15',
+  },
+  {
+    taskType: 'medium-code',
+    description:
+      'classifier-v2 intent: medium-stakes coding work — implement a function, ' +
+      'add an endpoint, write a class (local-14b tier). 14B-class for context ' +
+      'tracking across the edit; cascade-escalation promotes on weak output.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'doc-write',
+    description: 'classifier-v2 intent: write docs / runbook / ADR (local-14b tier).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'spec-check',
+    description: 'classifier-v2 intent: validate spec / acceptance criteria (local-14b tier).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 3000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.75',
+  },
+  {
+    taskType: 'review-prose',
+    description: 'classifier-v2 intent: copyedit / proofread / review prose (local-14b tier).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-haiku-4-5-20251001',
+    useLocal: true,
+    maxTokens: 3000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.30',
+  },
+  {
+    taskType: 'code-review',
+    description:
+      'classifier-v2 intent: review a diff / PR (local-14b tier). Distinct ' +
+      'from `code-review-light` which is a first-pass smell check.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'test-gen',
+    description: 'classifier-v2 intent: generate unit/integration tests (local-14b tier).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'schema-design',
+    description: 'classifier-v2 intent: design a JSON/Zod/Postgres schema (local-14b tier).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 4000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.00',
+  },
+  {
+    taskType: 'hard-code',
+    description:
+      'classifier-v2 intent: hard-code (complex algorithm, large refactor) — ' +
+      'cascade says local-32b, but M1 Pro 16GB cannot host a 32B model so the ' +
+      'local path uses qwen2.5-coder:14b and cascade-escalation promotes weak ' +
+      'output to Claude. Future hardware-tier work may swap this for a true 32B.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'refactor-complex',
+    description:
+      'classifier-v2 intent: multi-file refactor preserving public contracts. ' +
+      'Cascade tier=claude — too risky for local even at 14b.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'architecture',
+    description:
+      'classifier-v2 intent: propose module boundaries / sketch architecture. ' +
+      'Cascade tier=local-32b — local 14b first-pass + Claude cascade fallback.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 6000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.50',
+  },
+  {
+    taskType: 'reason-over-context',
+    description: 'classifier-v2 intent: deep reasoning over given context. Cascade tier=claude.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'new-design',
+    description:
+      'classifier-v2 intent: propose a new design from scratch. Cascade tier=local-32b — ' +
+      'local 14b first-pass + Claude cascade fallback.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: true,
+    maxTokens: 6000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$1.50',
+  },
+  {
+    taskType: 'architect',
+    description: 'classifier-v2 intent: whole-system / blueprint design. Cascade tier=claude.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-opus-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$3.00',
+  },
+  {
+    taskType: 'research-synthesis',
+    description:
+      'classifier-v2 intent: synthesize across many research artifacts. ' +
+      'Cascade tier=stolution-batch, but batch dispatch is not yet wired — ' +
+      'route to Claude as the conservative fallback.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'batch-summarize',
+    description:
+      'classifier-v2 intent: bulk / corpus summary. Cascade tier=stolution-batch ' +
+      '— Claude fallback until batch dispatch lands.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'corpus-distill',
+    description:
+      'classifier-v2 intent: distill themes across a corpus. ' +
+      'Cascade tier=stolution-batch — Claude fallback until batch dispatch lands.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'long-context-reason',
+    description:
+      'classifier-v2 intent: 200k-token long-context analysis. ' +
+      'Cascade tier=stolution-batch — Claude fallback until batch dispatch lands.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 16000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$4.00',
+  },
+  {
+    taskType: 'embedding-generate',
+    description:
+      'classifier-v2 intent: generate text embeddings. Routes to the local ' +
+      'nomic-embed-text model regardless of tier (no claude analogue).',
+    localModel: 'nomic-embed-text',
+    useLocal: true,
+    maxTokens: 2000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$0.20',
+  },
 ];
+
+// ─── B1 (2026-05-15) — tier-routing invariants ───────────────────────────
+// Each classifier-v2 intent name is expected to be backed by a routing-config
+// taskType whose localModel matches the tier. Exported for verifyTierRouting()
+// (test/routing-config.test.ts) so regressions in EITHER routing-config or the
+// classifier-v2 YAML break the build instead of silently serving 7b.
+//
+// Tier → expected local model on this host (M1 Pro 16GB):
+//   local-7b        → qwen2.5-coder:7b
+//   local-14b       → qwen2.5-coder:14b
+//   local-32b       → qwen2.5-coder:14b  (32B doesn't fit; cascade-escalation
+//                                          handles the promotion to Claude)
+//   stolution-batch → qwen2.5-coder:14b  (useLocal:false; Claude fallback
+//                                          until batch dispatch is wired)
+//   claude          → qwen2.5-coder:14b  (useLocal:false)
+//
+// The `useLocal` expectation is also enforced where it differs from the
+// tier-name default. embedding-generate is whitelisted (uses nomic-embed-text).
+export interface TierExpectation {
+  /** local Ollama model the rule must reference */
+  localModel: string;
+  /** whether the rule should prefer the local path */
+  useLocal: boolean;
+}
+
+export const TIER_EXPECTATIONS: Record<string, TierExpectation> = {
+  'local-7b':        { localModel: 'qwen2.5-coder:7b',  useLocal: true  },
+  'local-14b':       { localModel: 'qwen2.5-coder:14b', useLocal: true  },
+  'local-32b':       { localModel: 'qwen2.5-coder:14b', useLocal: true  },
+  'stolution-batch': { localModel: 'qwen2.5-coder:14b', useLocal: false },
+  'claude':          { localModel: 'qwen2.5-coder:14b', useLocal: false },
+};
+
+/** intents whose model is intentionally NOT the tier default. */
+const TIER_ROUTING_WHITELIST = new Set<string>([
+  'embedding-generate', // uses nomic-embed-text regardless of tier
+  // `architecture-review` predates the B1 intent-aliases pass — A.9.7
+  // (2026-05-14) deliberately routes it to qwen3:14b (the strongest 14B
+  // generalist on M1 Pro) rather than qwen2.5-coder:14b because the
+  // critique-an-existing-design task is generalist-shaped, not coder-shaped.
+  // Both are 14B-class so the tier intent is preserved; the model choice is
+  // a deliberate quality call.
+  'architecture-review',
+]);
+
+export interface TierRoutingViolation {
+  intent: string;
+  expectedTier: string;
+  expectedModel: string;
+  expectedUseLocal: boolean;
+  /** undefined when no routing-config rule exists for this intent (the
+   *  primary silent-tier-collapse cause — getRoute() falls through to the
+   *  unknown-task default at qwen2.5-coder:7b). */
+  actualModel?: string;
+  actualUseLocal?: boolean;
+  reason: 'no-rule' | 'wrong-model' | 'wrong-useLocal';
+}
+
+/**
+ * Cross-validate routing-config against the classifier-v2 intent taxonomy.
+ *
+ * For each `{ intent, default_tier }` pair, asserts that:
+ *   - ROUTING_RULES contains a rule with `taskType === intent`
+ *   - the rule's `localModel` matches TIER_EXPECTATIONS[tier].localModel
+ *   - the rule's `useLocal` matches TIER_EXPECTATIONS[tier].useLocal
+ *
+ * Returns an array of violations (empty on success). The unit test asserts
+ * the array is empty so silent tier-collapse regressions break CI.
+ */
+export function verifyTierRouting(
+  intents: ReadonlyArray<{ name: string; default_tier: string }>,
+): TierRoutingViolation[] {
+  const violations: TierRoutingViolation[] = [];
+  for (const intent of intents) {
+    if (TIER_ROUTING_WHITELIST.has(intent.name)) continue;
+    const expected = TIER_EXPECTATIONS[intent.default_tier];
+    if (expected === undefined) continue; // unknown tier → ignore
+    const rule = ROUTING_RULES.find((r) => r.taskType === intent.name);
+    if (rule === undefined) {
+      violations.push({
+        intent: intent.name,
+        expectedTier: intent.default_tier,
+        expectedModel: expected.localModel,
+        expectedUseLocal: expected.useLocal,
+        reason: 'no-rule',
+      });
+      continue;
+    }
+    if (rule.localModel !== expected.localModel) {
+      violations.push({
+        intent: intent.name,
+        expectedTier: intent.default_tier,
+        expectedModel: expected.localModel,
+        expectedUseLocal: expected.useLocal,
+        actualModel: rule.localModel,
+        actualUseLocal: rule.useLocal,
+        reason: 'wrong-model',
+      });
+      continue;
+    }
+    if (rule.useLocal !== expected.useLocal) {
+      violations.push({
+        intent: intent.name,
+        expectedTier: intent.default_tier,
+        expectedModel: expected.localModel,
+        expectedUseLocal: expected.useLocal,
+        actualModel: rule.localModel,
+        actualUseLocal: rule.useLocal,
+        reason: 'wrong-useLocal',
+      });
+    }
+  }
+  return violations;
+}
 
 export function getRoute(taskType: string): RoutingRule {
   const rule = ROUTING_RULES.find((r) => r.taskType === taskType);

--- a/packages/local-llm-router/tests/routing-config.test.ts
+++ b/packages/local-llm-router/tests/routing-config.test.ts
@@ -1,8 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, it, expect } from 'vitest';
 import {
   getRoute,
   ROUTING_RULES,
   COST_ANALYSIS,
+  TIER_EXPECTATIONS,
+  verifyTierRouting,
 } from '../src/routing-config.js';
 import { getModel } from '../src/model-catalog.js';
 
@@ -130,6 +135,134 @@ describe('routing-config', () => {
     });
   });
 
+  describe('B1 silent tier-collapse fix (2026-05-15)', () => {
+    // Minimal YAML loader scoped to the intent/default_tier pairs we need.
+    // Mirrors the parser in classifier-v2 but trimmed to the two fields the
+    // verifyTierRouting() contract cares about.
+    function loadIntentsFromYaml(): { name: string; default_tier: string }[] {
+      const yamlPath = resolve(
+        new URL('.', import.meta.url).pathname,
+        '..',
+        'config',
+        'routing-rules.yaml',
+      );
+      const text = readFileSync(yamlPath, 'utf8');
+      const intents: { name: string; default_tier: string }[] = [];
+      let cur: { name?: string; default_tier?: string } = {};
+      for (const line of text.split('\n')) {
+        const mName = line.match(/^\s*-\s*name:\s*(.+)$/);
+        if (mName) {
+          if (cur.name && cur.default_tier) {
+            intents.push({ name: cur.name, default_tier: cur.default_tier });
+          }
+          cur = { name: mName[1].trim() };
+          continue;
+        }
+        const mTier = line.match(/^\s*default_tier:\s*(.+)$/);
+        if (mTier && cur.name) cur.default_tier = mTier[1].trim();
+      }
+      if (cur.name && cur.default_tier) {
+        intents.push({ name: cur.name, default_tier: cur.default_tier });
+      }
+      return intents;
+    }
+
+    it('every classifier-v2 intent is registered as a routing-config taskType', () => {
+      const intents = loadIntentsFromYaml();
+      // Sanity: YAML parsed something (drift guard).
+      expect(intents.length).toBeGreaterThan(20);
+      const missing = intents
+        .filter((i) => i.name !== 'unknown') // `unknown` is the fall-through, not a real intent
+        .filter((i) => ROUTING_RULES.find((r) => r.taskType === i.name) === undefined);
+      expect(
+        missing,
+        `classifier-v2 intents missing routing-config rules (silent tier-collapse risk): ` +
+          missing.map((m) => `${m.name} (tier=${m.default_tier})`).join(', '),
+      ).toEqual([]);
+    });
+
+    it('verifyTierRouting() returns no violations for the current taxonomy', () => {
+      const intents = loadIntentsFromYaml().filter((i) => i.name !== 'unknown');
+      const violations = verifyTierRouting(intents);
+      // Format the failure message so a regression names the exact intent
+      // and the model it silently collapsed to.
+      expect(
+        violations,
+        violations.length === 0
+          ? 'ok'
+          : 'tier-routing violations:\n' +
+              violations
+                .map(
+                  (v) =>
+                    `  - ${v.intent} (tier=${v.expectedTier}, reason=${v.reason}): ` +
+                    `expected ${v.expectedModel}/${v.expectedUseLocal ? 'local' : 'claude'}, ` +
+                    `got ${v.actualModel ?? '<no-rule>'}/${
+                      v.actualUseLocal === undefined ? '?' : v.actualUseLocal ? 'local' : 'claude'
+                    }`,
+                )
+                .join('\n'),
+      ).toEqual([]);
+    });
+
+    it('per-tier asserts: every local-14b intent serves 14b (no silent collapse to 7b)', () => {
+      const intents = loadIntentsFromYaml();
+      const fourteenB = intents.filter((i) => i.default_tier === 'local-14b');
+      // Sanity: there are some local-14b intents in the taxonomy.
+      expect(fourteenB.length).toBeGreaterThan(0);
+      for (const intent of fourteenB) {
+        const rule = ROUTING_RULES.find((r) => r.taskType === intent.name);
+        expect(
+          rule,
+          `local-14b intent "${intent.name}" has no routing-config rule — ` +
+            `getRoute() will fall through to qwen2.5-coder:7b (silent tier-collapse)`,
+        ).toBeDefined();
+        expect(
+          rule?.localModel,
+          `local-14b intent "${intent.name}" routes to ${rule?.localModel} ` +
+            `instead of qwen2.5-coder:14b (silent tier-collapse)`,
+        ).toBe('qwen2.5-coder:14b');
+      }
+    });
+
+    it('per-tier asserts: every local-32b intent serves a 14B-class model (32b doesn\'t fit on M1 Pro)', () => {
+      const intents = loadIntentsFromYaml();
+      const thirtyTwoB = intents.filter((i) => i.default_tier === 'local-32b');
+      expect(thirtyTwoB.length).toBeGreaterThan(0);
+      // 14B-class models accepted for local-32b fallback. qwen3:14b is a
+      // deliberate generalist choice for `architecture-review`; the cascade
+      // tier (local-32b) is preserved by the model size class even though
+      // the tag differs from TIER_EXPECTATIONS['local-32b'].
+      const fourteenBFallbacks = new Set([
+        'qwen2.5-coder:14b',
+        'qwen3:14b',
+        'phi4',
+      ]);
+      for (const intent of thirtyTwoB) {
+        const rule = ROUTING_RULES.find((r) => r.taskType === intent.name);
+        expect(rule, `local-32b intent "${intent.name}" missing rule`).toBeDefined();
+        expect(
+          fourteenBFallbacks.has(rule!.localModel),
+          `local-32b intent "${intent.name}" routes to ${rule!.localModel} — ` +
+            `expected a 14B-class fallback (32B doesn't fit on M1 Pro 16GB)`,
+        ).toBe(true);
+        expect(rule?.useLocal).toBe(true);
+        expect(rule?.claudeModel).toBeDefined();
+      }
+    });
+
+    it('TIER_EXPECTATIONS covers every tier the classifier-v2 YAML uses', () => {
+      const intents = loadIntentsFromYaml();
+      const tiers = new Set(intents.map((i) => i.default_tier));
+      for (const tier of tiers) {
+        expect(
+          TIER_EXPECTATIONS[tier],
+          `classifier-v2 tier "${tier}" has no TIER_EXPECTATIONS entry — ` +
+            `verifyTierRouting() will silently skip it`,
+        ).toBeDefined();
+      }
+    });
+  });
+
   describe('local-share invariants (LAI-005)', () => {
     it('at least 70% of rules route to local by default', () => {
       const total = ROUTING_RULES.length;
@@ -142,10 +275,16 @@ describe('routing-config', () => {
     });
 
     it('every local-default rule has a Claude fallback for resilience', () => {
+      // Embedding rules have no Claude analogue (we never call Anthropic for
+      // text-embedding generation); every other local-first rule does.
+      // `embedding-generate` is the B1 classifier-v2 intent alias for the
+      // pre-existing `embedding-generation` taskType.
+      const noClaudeAnalogue = new Set([
+        'embedding-generation',
+        'embedding-generate',
+      ]);
       for (const rule of ROUTING_RULES) {
-        if (rule.useLocal && rule.taskType !== 'embedding-generation') {
-          // Embedding has no Claude analogue (we never call Anthropic for
-          // text-embedding generation); every other local-first rule does.
+        if (rule.useLocal && !noClaudeAnalogue.has(rule.taskType)) {
           expect(
             rule.claudeModel,
             `local-first rule "${rule.taskType}" missing Claude fallback`,


### PR DESCRIPTION
## Summary

Fix the silent tier-collapse where the dispatcher served `qwen2.5-coder:7b`
for prompts that the cascade design said should hit `local-14b` or
`local-32b`. Cross-host validation (sps-batch-tier-validation +
sps-docs-runbook) found **3 of 5 codebases** wrongly served 7b.

**Root cause:** classifier-v2 emits 37 intent names (`medium-code`, `hard-code`,
`code-review`, ...), but only 2 of them (`architecture-review`, `research-summary`,
both added in A.9.7) were registered as taskTypes in `routing-config.ts`.
Every other intent fell through `getRoute()` to the unknown-task default at
`qwen2.5-coder:7b` — with no warning log.

## Changes

- **`routing-config.ts`**: 32 new intent-aliased rules covering every
  classifier-v2 intent in `config/routing-rules.yaml`. Each rule's
  `localModel` matches its cascade tier:
  | tier | model | useLocal |
  |---|---|---|
  | `local-7b` | `qwen2.5-coder:7b` | ✅ |
  | `local-14b` | `qwen2.5-coder:14b` | ✅ |
  | `local-32b` | `qwen2.5-coder:14b` + cascade-escalation to Claude | ✅ |
  | `stolution-batch` | `qwen2.5-coder:14b` | ❌ (Claude until batch dispatch lands) |
  | `claude` | `qwen2.5-coder:14b` | ❌ |

  `local-32b` falls back to 14B because the M1 Pro 16GB host cannot run
  a 32B model — `cascade-escalation.ts` already promotes weak 14B output
  to Claude, preserving the tier intent.

- **`routing-config.ts`**: export `verifyTierRouting()` +
  `TIER_EXPECTATIONS`. The helper takes the YAML intent list and reports
  every violation: missing rule, wrong model, or wrong `useLocal`. Drift
  between the YAML taxonomy and the routing-config rules now surfaces as
  a unit-test failure instead of silent 7b service.

- **`router.ts`**: emit a structured single-line log on every dispatch:
  ```
  [router] dispatch intent=hard-code model=qwen2.5-coder:14b provider=local reason=rule-local rule=registered useLocal=true
  ```
  Reason labels: `adversarial-rejected`, `force-local`, `force-claude`,
  `rule-local`, `rule-claude`, `rule-local-override`, `rule-claude-override`,
  `rule-default-local` (the smoking-gun label when a caller passes an
  unregistered taskType — visible in `tail -f stderr | grep '\[router\] dispatch'`).

- **`tests/routing-config.test.ts`**: 5 new b1 tests
  * every classifier-v2 intent has a routing-config rule
  * `verifyTierRouting()` returns no violations on the current taxonomy
  * per-tier asserts for `local-14b` and `local-32b` intents (catch silent collapse to 7b)
  * `TIER_EXPECTATIONS` covers every tier the YAML uses

## Test plan

- [x] `pnpm build` — clean tsc
- [x] `pnpm test` — 251/251 pass (17 files); 20/20 routing-config tests pass
- [x] Structured dispatch log fires in test output (see otel + mentor-emit + integration test logs)
- [ ] Reload the local-llm-router LaunchAgent and confirm `[router] dispatch` lines appear in the daemon stderr on real traffic

## Notes

- `architecture-review` keeps its pre-existing `qwen3:14b` model — that
  was a deliberate A.9.7 generalist choice. Whitelisted in
  `TIER_ROUTING_WHITELIST` (same 14B size class, different family).
- The unknown-task default (`qwen2.5-coder:7b`) is preserved for back-compat
  but is now visible in dispatch logs as `reason=rule-default-local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)