### PR TITLE
feat(services): b2 migrate slot-manager + claude-spawner-agent into caia/services/

### DIFF
--- a/services/claude-spawner-agent/.gitignore
+++ b/services/claude-spawner-agent/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.db
+*.db-shm
+*.db-wal
+*.bak-*
+spawner.db

--- a/services/claude-spawner-agent/README.md
+++ b/services/claude-spawner-agent/README.md
@@ -1,0 +1,83 @@
+# claude-spawner-agent — Host-Side Spawner Daemon (Phase 5)
+
+Canonical source for the claude-spawner-agent service. Python 3.11 / FastAPI; runs as a
+launchd-managed daemon on each M1/Mac host that hosts a claude-binary spawn capacity.
+Slot-manager (this repo, sibling service) dispatches spawn payloads here; the daemon
+validates `permission_mode` + `allow_list`, invokes the local `claude` CLI in the spawn's
+working branch, and (optionally) auto-PRs the result.
+
+## Layout
+
+| File                                           | Role                                                                       |
+|------------------------------------------------|----------------------------------------------------------------------------|
+| `claude_spawner_agent.py`                      | FastAPI app — spawn validation, claude-CLI invocation, auto-PR             |
+| `local_llm_router_client.py`                   | HTTP client for the optional local LLM router gate                         |
+| `spawner_argv.py`                              | Pure `argv` builder for the `claude` CLI (testable; no I/O)                |
+| `spawner_patch_v2.diff`                        | Reference patch (v2 router gate) — kept for audit traceability             |
+| `com.caia.claude-spawner-agent.plist.template` | macOS launchd plist template (placeholders substituted at install time)    |
+| `requirements.txt`                             | Python dependencies (pinned to minor)                                      |
+| `smoke.sh`                                     | Smoke test: syntax + plist-xml-parse + import                              |
+| `package.json`                                 | `pnpm -F @caia/services-claude-spawner-agent run smoke` wrapper            |
+| `m1-deployment-bundle/`                        | Placeholder — see `m1-deployment-bundle/README.md` for OPERATOR action     |
+
+## Runtime contract
+
+- Listens on `127.0.0.1:7780` by default (per the launchd plist).
+- Validates `--add-dir` paths against `${ALLOWED_ROOT}` (default `~/Documents/projects`).
+  Blocklist includes `/etc`, `/var`, `/System`, `/usr`, `/Library`, `/boot`.
+- Strips `ANTHROPIC_API_KEY` from the spawn subprocess env on every call. The zero-dollar
+  rule (`feedback_no_api_key_billing.md`) is non-negotiable.
+- `permission_mode ∈ {"plan","acceptEdits","bypassPermissions"}`. Default is `plan`
+  (read-only, `--max-turns 1`). Slot-manager never auto-promotes to `bypassPermissions`.
+- Auto-PR enabled only when `auto_pr: true` AND the spawn returns ok AND new commits exist
+  on the spawn's working branch since spawn-start. `risk_tier == "high"` NEVER gets
+  auto-merge regardless of `auto_merge` flag.
+
+## Source-history continuity
+
+Before 2026-05-15 the Phase 5 source lived outside the caia monorepo at:
+
+    ~/Documents/projects/reports/claude-spawner-agent/        (M3)
+    /home/s903/apps/claude-spawner/                           (stolution worker)
+
+Both directories remain intact for historical reference; this directory is the live source
+from B2 migration (PR `feat/b2-slot-manager-spawner-migrate-2026-05-15`) onward. The
+migration was source-relocate only — no code edits, no re-architecture. See
+`reports/integration_b2_slot_manager_migrate_2026-05-15.md` for the migration report.
+
+## Sibling service
+
+`services/slot-manager/` is the dispatcher that calls this daemon. The two co-evolved
+(slot-manager defines the wire contract; claude-spawner-agent is the host-side executor).
+They are migrated together in B2.
+
+## Installation on an M1 host
+
+See `m1-deployment-bundle/README.md`. Manual steps until the bundle is staged:
+
+```bash
+git clone https://github.com/prakashgbid/caia.git ~/caia
+cd ~/caia/services/claude-spawner-agent
+python3 -m venv ~/.caia/spawner-venv
+source ~/.caia/spawner-venv/bin/activate
+pip install -r requirements.txt
+
+# Render plist (substitute placeholders — see the .template's comment block):
+sed -e "s|CLAUDE_SPAWNER_VENV|$HOME/.caia/spawner-venv|g" \
+    -e "s|CLAUDE_SPAWNER_REPO|$HOME/caia|g" \
+    -e "s|CLAUDE_SPAWNER_LOG_DIR|$HOME/Documents/conductor-logs|g" \
+    -e "s|SLOT_MANAGER_BASE_URL|http://stolution.local:8081|g" \
+    -e "s|CLAUDE_BINARY|/opt/homebrew/bin/claude|g" \
+    -e "s|ALLOWED_ROOT|$HOME/Documents/projects|g" \
+    -e "s|NODE_BIN_PATH|/opt/homebrew/bin|g" \
+  com.caia.claude-spawner-agent.plist.template \
+  > ~/Library/LaunchAgents/com.caia.claude-spawner-agent.plist
+
+launchctl load ~/Library/LaunchAgents/com.caia.claude-spawner-agent.plist
+```
+
+## CI
+
+A path-filtered smoke workflow at `.github/workflows/services-smoke.yml` runs on every PR
+that touches `services/claude-spawner-agent/**`. The workflow invokes `bash smoke.sh` in
+this directory.

--- a/services/claude-spawner-agent/claude_spawner_agent.py
+++ b/services/claude-spawner-agent/claude_spawner_agent.py
@@ -1,0 +1,2080 @@
+"""
+claude-spawner-agent — Phase 5 (real-work mode + auto-PR)
+
+Phase 5 deltas vs Phase 3
+-------------------------
+1. permission_mode parameter
+   - The spawn payload may now carry `permission_mode` ∈
+     {"plan","acceptEdits","bypassPermissions"}. Default: "plan" (preserves
+     Phase 3 behaviour exactly — read-only, --max-turns 1).
+   - "acceptEdits" → no max-turns cap, --permission-mode acceptEdits.
+   - "bypassPermissions" → no max-turns cap, --permission-mode
+     bypassPermissions. Reserved for highest-trust internal flows; never
+     auto-promoted by slot-manager.
+
+2. --add-dir allow-list pass-through
+   - The spawn payload may carry `allow_list: list[str]`. Each path is
+     validated against ALLOWED_ROOT (default: ~/Documents/projects) and a
+     blocklist (no /etc, /var, /System, /usr, /Library, /boot). Surviving
+     paths are passed verbatim as `--add-dir <path>` flags to the claude
+     binary so the spawned agent can only write inside its bucket's
+     declared scope. If any path fails validation, the spawn is rejected
+     with outcome=`rejected_path_escape` (HTTP 451).
+
+3. Auto-PR on completion
+   - If `auto_pr: true` is in the payload AND the spawn returns ok AND
+     commits exist on the spawn's working branch since spawn-start, the
+     spawner:
+       a. amends each new commit to ensure the `Spawned-By:
+          caia-autonomous-loop` trailer is present (uses git filter to
+          add the trailer non-destructively).
+       b. pushes the branch to origin.
+       c. opens a PR via `gh pr create --base develop --label autonomous`.
+       d. if `risk_tier` ∈ {"low","medium"} AND `auto_merge: true`:
+          enables `gh pr merge --auto --squash`. evidence-gate ("required
+          checks all green") is enforced by GitHub's auto-merge
+          machinery — it does not merge until checks pass.
+       e. high-risk specs (`risk_tier == "high"`) NEVER get auto-merge,
+          regardless of `auto_merge` flag.
+
+4. Real-edit prompt builder
+   - When permission_mode != "plan", the spawner emits a different prompt
+     that instructs claude to actually do the work, commit with the
+     mandatory footer, and stop.
+
+5. Subscription guard preserved
+   - All four layers (slot-manager startup + per-call, spawner startup +
+     per-call) remain non-negotiable. ANTHROPIC_API_KEY is stripped from
+     subprocess env regardless of permission_mode. Phase 5 only changes
+     the EXECUTION permission, not the SPEND permission.
+
+Authoring discharges agent-memory/slot_manager_phase5_brief.md (operator-
+amended scope: permission_mode tri-state + allow_list pass-through +
+auto-PR; M3/lineage/dashboard deferred to Phase 6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import logging
+import os
+import re
+import shlex
+import signal
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+# LAI phase 7: pre-spawn classify-and-maybe-route gate + optimizer pre-pass.
+# Aliased `health` -> `router_health` because the spawner has its own
+# /health FastAPI endpoint named `health` below.
+from local_llm_router_client import (
+    classify_and_maybe_route,
+    health as router_health,
+    optimize_prompt,
+)
+# SPS-Prompting phase α (A.9.3 + A.9.6): claude-argv builder.
+# Vendored alongside local_llm_router_client.py as a standalone module so
+# the py-client test suite can exercise the wrap/stabilize decision tree
+# without dragging in fastapi/sqlite.
+from spawner_argv import build_claude_argv as _build_claude_argv
+
+
+# --- Configuration ---------------------------------------------------------
+
+VERSION       = "1.2.0-phase6-worktree"
+PORT          = int(os.environ.get("PORT", "8090"))
+HOST_NAME     = os.environ.get("HOST_NAME", "mac-m1")
+CLAUDE_BINARY = os.environ.get("CLAUDE_BINARY", "/Users/MAC/.local/bin/claude")
+
+# LAI phase 7: local-llm-router gate + 3-stage prompt-optimizer pre-pass.
+# Both gates are independent so operators can disable one without losing the
+# other (e.g. keep optimizer on if classifier model gets flaky).
+ROUTER_URL          = os.environ.get("LOCAL_LLM_ROUTER_URL", "http://100.68.247.58:7411")
+ROUTER_GATE_ENABLED = os.environ.get("ROUTER_GATE_ENABLED", "true").lower() in ("1", "true", "yes")
+OPTIMIZER_ENABLED   = os.environ.get("OPTIMIZER_ENABLED", "true").lower() in ("1", "true", "yes")
+OPTIMIZER_TIMEOUT_S = float(os.environ.get("OPTIMIZER_TIMEOUT_S", "30.0"))
+
+# SPS-Prompting phase α (A.9.3): headroom wrap on the claude binary call.
+# Kill-switch HEADROOM_WRAP_DISABLE=1 bypasses the wrap. Also bypassed if
+# HEADROOM_BINARY does not exist on disk (fail-open) — keeps stolution
+# (no headroom yet) working without code-divergence from M-series boxes.
+HEADROOM_BINARY        = os.environ.get("HEADROOM_BINARY", "/opt/homebrew/bin/headroom")
+HEADROOM_WRAP_DISABLE  = os.environ.get("HEADROOM_WRAP_DISABLE", "").lower() in ("1", "true", "yes")
+HEADROOM_PROXY_PORT    = int(os.environ.get("HEADROOM_PROXY_PORT", "8787"))
+HEADROOM_PROXY_OFFSET  = int(os.environ.get("HEADROOM_PROXY_OFFSET", "0"))
+# SPS-Prompting phase α (A.9.6): KV-cache prefix stabilization. Adds
+# --exclude-dynamic-system-prompt-sections to the claude argv so per-host
+# bits (cwd, env, memory paths, git status) move out of the cached system
+# prefix. Precondition for Anthropic's 90% prompt-cache discount.
+STABILIZE_PREFIX_DISABLE = os.environ.get("STABILIZE_PREFIX_DISABLE", "").lower() in ("1", "true", "yes")
+
+LOG_LEVEL     = os.environ.get("LOG_LEVEL", "INFO").upper()
+DB_PATH       = Path(os.environ.get(
+    "SPAWNER_DB",
+    str(Path.home() / ".cache/claude-spawner-agent/spawner.db")
+))
+DEFAULT_TIMEOUT_S = float(os.environ.get("DEFAULT_TIMEOUT_S", "1200.0"))  # Phase 6 fix: 20-min default; matches slot-manager SPAWN_TIMEOUT_SEC
+SLOT_MANAGER_URL  = os.environ.get(
+    "SLOT_MANAGER_URL",
+    "http://10.43.173.170:8081"
+)
+SELF_SPAWNER_URL  = os.environ.get(
+    "SELF_SPAWNER_URL",
+    f"http://100.90.12.37:{PORT}"
+)
+AUTO_REGISTER     = os.environ.get("AUTO_REGISTER", "1") not in ("0", "false", "no")
+
+# Phase 5: allowed roots and blocklist for --add-dir flags.
+# Anything outside ALLOWED_ROOT or matching PATH_BLOCKLIST_RE is rejected.
+ALLOWED_ROOT  = Path(os.environ.get(
+    "ALLOWED_ROOT",
+    str(Path.home() / "Documents" / "projects")
+)).resolve()
+PATH_BLOCKLIST_RE = re.compile(
+    os.environ.get("PATH_BLOCKLIST_RE",
+                   r"^/etc(/|$)|^/var(/|$)|^/System(/|$)|^/usr(/|$)|"
+                   r"^/Library(/|$)|^/boot(/|$)|^/private/etc(/|$)|"
+                   r"^/private/var(/|$)|^/private/tmp(/|$)")
+)
+
+# Phase 5: permission modes accepted from the dispatch payload.
+VALID_PERMISSION_MODES = {"plan", "acceptEdits", "bypassPermissions"}
+DEFAULT_PERMISSION_MODE = "plan"
+
+# Phase 5: max-turns budget per mode. plan-mode keeps the old 1-turn cap;
+# real-edit modes get a much larger budget (claude usually finishes well
+# within this for low/medium-risk doc edits).
+PERMISSION_MODE_MAX_TURNS = {
+    "plan":              1,
+    "acceptEdits":       None,   # unbounded — let timeout enforce
+    "bypassPermissions": None,
+}
+
+# Phase 5: footer added to every autonomous commit.
+SPAWNED_BY_TRAILER = "Spawned-By: caia-autonomous-loop"
+
+# Phase 5: PR labels and base branch.
+DEFAULT_PR_BASE_BRANCH = os.environ.get("DEFAULT_PR_BASE_BRANCH", "develop")
+DEFAULT_PR_LABEL       = os.environ.get("DEFAULT_PR_LABEL", "autonomous")
+
+# Phase 6: per-spawn git worktree isolation.
+# When WORKTREE_PER_SPAWN is on (default), every real-edit spawn runs inside
+# its own `<repo_root>/.spawn-worktrees/<task_id>-<short>` worktree, branched
+# off WORKTREE_BASE_BRANCH (default `develop`, falls back to `master`/`main`/
+# the local HEAD if the configured base ref is missing). The worktree is
+# torn down on every outcome (ok, crashed, timeout, spawner_error) so disk
+# leaks are bounded; stale worktrees > WORKTREE_STALE_HOURS old are pruned
+# at spawner startup as a safety net for crashed workers.
+#
+# This unblocks cap > 1 per host: parallel spawns no longer share a working
+# tree (which corrupted per-task audit and clobbered each other's `auto/`
+# branch via the Phase-5 "reuse if already on auto/" path — bug #4 in
+# agent-memory/mock_backlog_reliability_pass_2026-05-10.md).
+WORKTREE_PER_SPAWN   = os.environ.get("WORKTREE_PER_SPAWN", "1") not in ("0", "false", "no")
+WORKTREE_BASE_BRANCH = os.environ.get("WORKTREE_BASE_BRANCH", "develop")
+WORKTREE_STALE_HOURS = float(os.environ.get("WORKTREE_STALE_HOURS", "1"))
+WORKTREE_SUBDIR_NAME = os.environ.get("WORKTREE_SUBDIR_NAME", ".spawn-worktrees")
+# Phase-7: bounded parallelism for `git worktree add`. Phase-6 used a
+# single-permit threading.Lock (effectively serial); the 2026-05-10 burst
+# test showed that 4 concurrent worktree-adds is the safe ceiling on this
+# host. Higher values fork-fail (EAGAIN). Override via WORKTREE_ADD_PARALLEL.
+WORKTREE_ADD_PARALLEL = int(os.environ.get("WORKTREE_ADD_PARALLEL", "4"))
+
+# Module-wide bounded semaphore that caps parallel `git worktree add`
+# invocations at WORKTREE_ADD_PARALLEL (default 4). Replaces Phase-6's
+# threading.Lock(). Same `with _worktree_add_lock:` call-site contract.
+# Raising above 4 risks fork() EAGAIN on this host (RLIMIT_NPROC pressure
+# from concurrent claude subprocesses); do not raise without re-verifying.
+_worktree_add_lock = threading.BoundedSemaphore(WORKTREE_ADD_PARALLEL)
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("claude-spawner-agent")
+
+
+# --- Subscription guard ----------------------------------------------------
+
+def subscription_guard_message() -> str | None:
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return ("ANTHROPIC_API_KEY is set in spawner env; refusing per "
+                "zero-dollar rule (agent-memory/feedback_no_api_key_billing.md).")
+    return None
+
+
+# --- Path allow-list validation -------------------------------------------
+
+def validate_allow_list(paths: list[str]) -> tuple[list[str], list[str]]:
+    """Return (accepted, rejected_with_reason).
+
+    A path is accepted iff:
+      1. It does NOT match PATH_BLOCKLIST_RE.
+      2. After resolution, it is under ALLOWED_ROOT (or equal to it).
+      3. The resolved path exists OR is a child of an existing dir under
+         ALLOWED_ROOT (so we can pass paths to repos that may not exist
+         yet on this Mac — gh-checked-out branches etc).
+    """
+    accepted: list[str] = []
+    rejected: list[str] = []
+    for raw in (paths or []):
+        if not isinstance(raw, str) or not raw.strip():
+            rejected.append(f"{raw!r}: empty")
+            continue
+        # Expand ~
+        expanded = os.path.expanduser(raw.strip())
+        if PATH_BLOCKLIST_RE.match(expanded):
+            rejected.append(f"{raw!r}: matches blocklist")
+            continue
+        try:
+            resolved = Path(expanded).resolve(strict=False)
+        except Exception as e:
+            rejected.append(f"{raw!r}: resolve failed {e}")
+            continue
+        try:
+            resolved.relative_to(ALLOWED_ROOT)
+        except ValueError:
+            # If the path doesn't exist yet, also accept if its first
+            # existing ancestor is under ALLOWED_ROOT.
+            anc = resolved
+            ok = False
+            for _ in range(20):
+                if anc.exists():
+                    try:
+                        anc.relative_to(ALLOWED_ROOT)
+                        ok = True
+                    except ValueError:
+                        pass
+                    break
+                anc = anc.parent
+            if not ok:
+                rejected.append(f"{raw!r}: outside ALLOWED_ROOT={ALLOWED_ROOT}")
+                continue
+        accepted.append(str(resolved))
+    return accepted, rejected
+
+
+# --- Binary digest (cached) ------------------------------------------------
+
+_BINARY_CACHE: tuple[str, str] | None = None
+_BINARY_CACHE_LOCK = threading.Lock()
+
+
+def binary_path_and_sha256() -> tuple[str, str]:
+    global _BINARY_CACHE
+    with _BINARY_CACHE_LOCK:
+        if _BINARY_CACHE is not None:
+            return _BINARY_CACHE
+        p = Path(CLAUDE_BINARY)
+        try:
+            resolved = p.resolve()
+        except Exception:
+            resolved = p
+        if resolved.exists() and resolved.is_file():
+            h = hashlib.sha256()
+            with resolved.open("rb") as f:
+                for chunk in iter(lambda: f.read(64 * 1024), b""):
+                    h.update(chunk)
+            _BINARY_CACHE = (str(resolved), h.hexdigest())
+        else:
+            h = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()
+            _BINARY_CACHE = (str(resolved), f"path:{h}")
+        log.info("binary_path=%s binary_sha256=%s",
+                 _BINARY_CACHE[0], _BINARY_CACHE[1][:16])
+        return _BINARY_CACHE
+
+
+def claude_version_str() -> str:
+    try:
+        out = subprocess.check_output(
+            [CLAUDE_BINARY, "--version"],
+            text=True, timeout=5,
+            env={**os.environ, "ANTHROPIC_API_KEY": ""},
+        )
+        return out.strip().splitlines()[0]
+    except Exception as e:
+        return f"<error:{e}>"
+
+
+# --- Persistent state ------------------------------------------------------
+
+DB_SCHEMA = """
+CREATE TABLE IF NOT EXISTS claude_sessions (
+    spawn_id            TEXT PRIMARY KEY,
+    slot_id             TEXT,
+    task_id             TEXT,
+    bucket              TEXT,
+    host                TEXT,
+    pid                 INTEGER,
+    status              TEXT NOT NULL,
+    started_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at        TIMESTAMP,
+    duration_ms         INTEGER,
+    exit_code           INTEGER,
+    session_id          TEXT,
+    model               TEXT,
+    binary_path         TEXT,
+    binary_sha256       TEXT,
+    spawn_callback_url  TEXT,
+    release_url         TEXT,
+    heartbeat_url       TEXT,
+    error               TEXT,
+    task_spec_json      TEXT,
+    permission_mode     TEXT,
+    allow_list_json     TEXT,
+    risk_tier           TEXT,
+    cwd                 TEXT,
+    initial_sha         TEXT,
+    final_sha           TEXT,
+    branch              TEXT,
+    files_touched       INTEGER,
+    commits_made        INTEGER,
+    pr_url              TEXT,
+    auto_merge_enabled  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_claude_sessions_status ON claude_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_claude_sessions_started_at ON claude_sessions(started_at);
+
+CREATE TABLE IF NOT EXISTS spawner_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    spawn_id    TEXT,
+    event       TEXT NOT NULL,
+    detail      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_spawner_events_ts ON spawner_events(ts);
+"""
+
+PHASE5_MIGRATIONS = [
+    "ALTER TABLE claude_sessions ADD COLUMN permission_mode TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN allow_list_json TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN risk_tier TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN cwd TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN initial_sha TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN final_sha TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN branch TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN files_touched INTEGER",
+    "ALTER TABLE claude_sessions ADD COLUMN commits_made INTEGER",
+    "ALTER TABLE claude_sessions ADD COLUMN pr_url TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN auto_merge_enabled INTEGER NOT NULL DEFAULT 0",
+]
+
+# LAI phase 7: router-gate + optimizer columns. Idempotent (db() skips ALTERs
+# whose column already exists). claude_invoked is the headline boolean for
+# spawn-record analytics; the rest are optimizer telemetry per the v2 patch.
+PHASE7_MIGRATIONS = [
+    "ALTER TABLE claude_sessions ADD COLUMN claude_invoked INTEGER",
+    "ALTER TABLE claude_sessions ADD COLUMN router_tier TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN router_intent TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN router_confidence REAL",
+    "ALTER TABLE claude_sessions ADD COLUMN response_preview TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_backend TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_pre_tokens INTEGER",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_post_tokens INTEGER",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_compression REAL",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_stages_run TEXT",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_wall_ms INTEGER",
+    "ALTER TABLE claude_sessions ADD COLUMN optimizer_error TEXT",
+]
+
+
+_db_conn: sqlite3.Connection | None = None
+_db_lock = threading.Lock()
+
+
+def db() -> sqlite3.Connection:
+    global _db_conn
+    if _db_conn is None:
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(DB_PATH), check_same_thread=False, timeout=30)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.executescript(DB_SCHEMA)
+        # Phase 5 + Phase 7 idempotent migrations
+        existing_cols = {r["name"] for r in conn.execute("PRAGMA table_info(claude_sessions)").fetchall()}
+        for stmt in PHASE5_MIGRATIONS + PHASE7_MIGRATIONS:
+            col_name = stmt.split("ADD COLUMN ")[1].split()[0]
+            if col_name in existing_cols:
+                continue
+            try:
+                conn.execute(stmt)
+                existing_cols.add(col_name)
+            except sqlite3.OperationalError as e:
+                log.warning("migration %r skipped: %s", stmt, e)
+        conn.commit()
+        _db_conn = conn
+    return _db_conn
+
+
+def journal_event(spawn_id: str | None, event: str, detail: str | None = None) -> None:
+    with _db_lock:
+        c = db()
+        c.execute("INSERT INTO spawner_events (spawn_id, event, detail) VALUES (?, ?, ?)",
+                  (spawn_id, event, detail))
+        c.commit()
+
+
+def journal_insert_starting(payload: dict[str, Any], *,
+                            permission_mode: str,
+                            allow_list: list[str],
+                            risk_tier: str | None,
+                            cwd: str | None) -> None:
+    with _db_lock:
+        c = db()
+        c.execute(
+            "INSERT INTO claude_sessions (spawn_id, slot_id, task_id, bucket, host, "
+            "  status, spawn_callback_url, release_url, heartbeat_url, task_spec_json, "
+            "  permission_mode, allow_list_json, risk_tier, cwd) "
+            "VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                payload["spawn_id"],
+                payload.get("slot_id"),
+                payload.get("task_id"),
+                payload.get("bucket"),
+                payload.get("host"),
+                payload.get("spawn_callback_url"),
+                payload.get("release_url"),
+                payload.get("heartbeat_url"),
+                json.dumps(payload.get("task_spec") or {}),
+                permission_mode,
+                json.dumps(allow_list),
+                risk_tier,
+                cwd,
+            )
+        )
+        c.commit()
+
+
+def journal_set_running(spawn_id: str, pid: int, *,
+                        initial_sha: str | None = None,
+                        branch: str | None = None) -> None:
+    with _db_lock:
+        c = db()
+        c.execute("UPDATE claude_sessions SET status='running', pid=?, "
+                  "  initial_sha=COALESCE(?, initial_sha), "
+                  "  branch=COALESCE(?, branch) "
+                  "WHERE spawn_id=?",
+                  (pid, initial_sha, branch, spawn_id))
+        c.commit()
+
+
+def journal_finalize(spawn_id: str, status: str, *,
+                     exit_code: int | None = None,
+                     duration_ms: int | None = None,
+                     session_id: str | None = None,
+                     model: str | None = None,
+                     binary_path: str | None = None,
+                     binary_sha256: str | None = None,
+                     error: str | None = None,
+                     final_sha: str | None = None,
+                     files_touched: int | None = None,
+                     commits_made: int | None = None,
+                     pr_url: str | None = None,
+                     auto_merge_enabled: bool = False,
+                     # LAI phase 7: router-gate + optimizer telemetry.
+                     # All optional + COALESCEd so existing call-sites that
+                     # don't pass them leave the columns intact.
+                     claude_invoked: bool | None = None,
+                     router_tier: str | None = None,
+                     router_intent: str | None = None,
+                     router_confidence: float | None = None,
+                     response_preview: str | None = None,
+                     optimizer_backend: str | None = None,
+                     optimizer_pre_tokens: int | None = None,
+                     optimizer_post_tokens: int | None = None,
+                     optimizer_compression: float | None = None,
+                     optimizer_stages_run: list[str] | None = None,
+                     optimizer_wall_ms: int | None = None,
+                     optimizer_error: str | None = None) -> None:
+    claude_invoked_db = (None if claude_invoked is None
+                         else (1 if claude_invoked else 0))
+    stages_db = (None if optimizer_stages_run is None
+                 else json.dumps(optimizer_stages_run))
+    with _db_lock:
+        c = db()
+        c.execute(
+            "UPDATE claude_sessions SET status=?, completed_at=CURRENT_TIMESTAMP, "
+            "  duration_ms=?, exit_code=?, session_id=?, model=?, "
+            "  binary_path=?, binary_sha256=?, error=?, "
+            "  final_sha=COALESCE(?, final_sha), "
+            "  files_touched=COALESCE(?, files_touched), "
+            "  commits_made=COALESCE(?, commits_made), "
+            "  pr_url=COALESCE(?, pr_url), "
+            "  auto_merge_enabled=?, "
+            "  claude_invoked=COALESCE(?, claude_invoked), "
+            "  router_tier=COALESCE(?, router_tier), "
+            "  router_intent=COALESCE(?, router_intent), "
+            "  router_confidence=COALESCE(?, router_confidence), "
+            "  response_preview=COALESCE(?, response_preview), "
+            "  optimizer_backend=COALESCE(?, optimizer_backend), "
+            "  optimizer_pre_tokens=COALESCE(?, optimizer_pre_tokens), "
+            "  optimizer_post_tokens=COALESCE(?, optimizer_post_tokens), "
+            "  optimizer_compression=COALESCE(?, optimizer_compression), "
+            "  optimizer_stages_run=COALESCE(?, optimizer_stages_run), "
+            "  optimizer_wall_ms=COALESCE(?, optimizer_wall_ms), "
+            "  optimizer_error=COALESCE(?, optimizer_error) "
+            "WHERE spawn_id=?",
+            (status, duration_ms, exit_code, session_id, model,
+             binary_path, binary_sha256, error,
+             final_sha, files_touched, commits_made, pr_url,
+             1 if auto_merge_enabled else 0,
+             claude_invoked_db, router_tier, router_intent, router_confidence,
+             response_preview,
+             optimizer_backend, optimizer_pre_tokens, optimizer_post_tokens,
+             optimizer_compression, stages_db, optimizer_wall_ms,
+             optimizer_error,
+             spawn_id)
+        )
+        c.commit()
+
+
+def journal_lookup(spawn_id: str) -> dict[str, Any] | None:
+    with _db_lock:
+        row = db().execute(
+            "SELECT * FROM claude_sessions WHERE spawn_id=?",
+            (spawn_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+
+# --- Recovery on startup ---------------------------------------------------
+
+def _pid_is_alive(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except Exception:
+        return False
+
+
+def reconcile_inflight() -> dict[str, int]:
+    counts = {"alive_orphans": 0, "dead": 0, "starting_only": 0}
+    with _db_lock:
+        rows = db().execute(
+            "SELECT spawn_id, pid, status, slot_id, spawn_callback_url, "
+            "  bucket, host, task_id "
+            "FROM claude_sessions WHERE status IN ('starting','running')"
+        ).fetchall()
+    if not rows:
+        log.info("recovery: 0 in-flight rows")
+        return counts
+
+    log.warning("recovery: found %d in-flight rows from previous spawner run", len(rows))
+    for r in rows:
+        spawn_id = r["spawn_id"]
+        pid      = r["pid"]
+        if r["status"] == "starting" and not pid:
+            counts["starting_only"] += 1
+            error = "spawner restarted before subprocess was launched"
+        elif _pid_is_alive(pid):
+            counts["alive_orphans"] += 1
+            try:
+                os.kill(pid, signal.SIGTERM)
+                for _ in range(20):
+                    time.sleep(0.1)
+                    if not _pid_is_alive(pid):
+                        break
+                if _pid_is_alive(pid):
+                    os.kill(pid, signal.SIGKILL)
+            except Exception as e:
+                log.warning("recovery: kill pid=%s failed: %s", pid, e)
+            error = f"spawner restarted; orphan claude pid={pid} killed"
+        else:
+            counts["dead"] += 1
+            error = f"spawner restarted; claude pid={pid} was already gone"
+
+        journal_finalize(
+            spawn_id, "interrupted",
+            exit_code=-99, error=error,
+        )
+        journal_event(spawn_id, "recovery-interrupted", error)
+        log.warning("recovery: spawn_id=%s slot=%s pid=%s -> interrupted (%s)",
+                    spawn_id, r["slot_id"], pid, error)
+
+        cb = r["spawn_callback_url"]
+        if cb:
+            asyncio.run(_safe_callback(cb, {
+                "spawn_id":          spawn_id,
+                "slot_id":           r["slot_id"],
+                "bucket":            r["bucket"],
+                "host":              r["host"],
+                "task_id":           r["task_id"],
+                "outcome":           "interrupted",
+                "exit_code":         -99,
+                "subscription_only": True,
+                "error":             error,
+            }))
+
+    log.warning("recovery summary: %s", counts)
+    return counts
+
+
+async def _safe_callback(url: str, body: dict[str, Any]) -> None:
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.post(url, json=body)
+            log.info("callback %s -> HTTP %d", url, r.status_code)
+    except Exception as e:
+        log.warning("callback %s failed (non-fatal): %s", url, e)
+
+
+# --- Self-registration on startup ------------------------------------------
+
+async def self_register() -> None:
+    if not AUTO_REGISTER:
+        log.info("AUTO_REGISTER disabled — skipping self-register")
+        return
+    body = {
+        "name":        HOST_NAME,
+        "spawner_url": SELF_SPAWNER_URL,
+        "hostname":    os.uname().nodename,
+        "version":     VERSION,
+        "notes":       f"real Mac claude-spawner-agent (Phase 5: real-edit mode + auto-PR)",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.post(
+                f"{SLOT_MANAGER_URL}/admin/host/register",
+                json=body,
+            )
+            log.info("self-register %s/%s -> HTTP %d body=%s",
+                     SLOT_MANAGER_URL, HOST_NAME, r.status_code, r.text[:200])
+    except Exception as e:
+        log.warning("self-register %s failed (non-fatal): %s", SLOT_MANAGER_URL, e)
+
+
+async def heartbeat_forever(interval_s: float = 60.0) -> None:
+    if not AUTO_REGISTER:
+        return
+    while True:
+        await asyncio.sleep(interval_s)
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                r = await client.post(
+                    f"{SLOT_MANAGER_URL}/admin/host/heartbeat",
+                    json={"name": HOST_NAME},
+                )
+                if r.status_code != 200:
+                    log.warning("heartbeat -> HTTP %d body=%s", r.status_code, r.text[:200])
+        except Exception as e:
+            log.warning("heartbeat failed (non-fatal): %s", e)
+
+
+# --- Prompt builders -------------------------------------------------------
+
+def build_prompt_plan_only(task_spec: dict[str, Any]) -> str:
+    """Phase 3 ack-only prompt — kept for permission_mode=plan."""
+    nid    = task_spec.get("id", "<unknown>")
+    title  = task_spec.get("title", "<no title>")
+    bucket = task_spec.get("target_bucket") or task_spec.get("resolved_bucket") or "<no bucket>"
+    pm     = task_spec.get("prompt_material", {}) or {}
+    refs   = pm.get("must_read_first") or []
+    scope  = pm.get("scope_tag") or task_spec.get("scope_tag") or "?"
+    item   = pm.get("item_code") or task_spec.get("item_code") or "?"
+
+    refs_block = "\n".join(f"- {r}" for r in refs) if refs else "(none provided)"
+    return (
+        "You are spawned by the slot-manager autonomous loop in PLAN-ONLY mode.\n"
+        "DO NOT begin executing the backlog work. Confirm readiness only.\n"
+        "\n"
+        f"Task spec:\n"
+        f"  id          : {nid}\n"
+        f"  item_code   : {item}\n"
+        f"  scope_tag   : {scope}\n"
+        f"  bucket      : {bucket}\n"
+        f"  title       : {title}\n"
+        f"\n"
+        f"Must-read-first refs (acknowledge only — do not actually read):\n"
+        f"{refs_block}\n"
+        "\n"
+        "Reply with ONE compact line of JSON, no prose:\n"
+        '  {"ack": true, "task_id": "<the id above>", "ready": true, "model": "<your model>"}\n'
+    )
+
+
+def build_prompt_real_edit(task_spec: dict[str, Any], *,
+                           permission_mode: str,
+                           cwd: str,
+                           branch: str,
+                           spawn_id: str,
+                           risk_tier: str | None) -> str:
+    """Real-edit prompt for permission_mode in {acceptEdits, bypassPermissions}.
+
+    Tells claude:
+      - The task to perform (from task_spec.prompt_material).
+      - The branch to commit to.
+      - Required commit footer.
+      - When to stop.
+    """
+    nid    = task_spec.get("id", "<unknown>")
+    title  = task_spec.get("title", "<no title>")
+    bucket = task_spec.get("target_bucket") or task_spec.get("resolved_bucket") or "<no bucket>"
+    pm     = task_spec.get("prompt_material", {}) or {}
+    refs   = pm.get("must_read_first") or []
+    work   = pm.get("work_directive") or task_spec.get("work_directive") or pm.get("description") or task_spec.get("description") or title
+    scope  = pm.get("scope_tag") or task_spec.get("scope_tag") or "?"
+    item   = pm.get("item_code") or task_spec.get("item_code") or "?"
+    files  = pm.get("file_scope") or task_spec.get("file_scope")
+
+    refs_block = "\n".join(f"- {r}" for r in refs) if refs else "(none provided)"
+    files_block = (f"\nFile scope (only edit these unless absolutely necessary):\n  {files}\n"
+                   if files else "")
+    return (
+        "You are spawned by the slot-manager autonomous loop in REAL-EDIT mode.\n"
+        f"  permission_mode : {permission_mode}\n"
+        f"  risk_tier       : {risk_tier or 'low'}\n"
+        f"  spawn_id        : {spawn_id}\n"
+        f"  working dir     : {cwd}\n"
+        f"  branch          : {branch} (already checked out for you)\n"
+        "\n"
+        "TASK:\n"
+        f"  id        : {nid}\n"
+        f"  item_code : {item}\n"
+        f"  scope_tag : {scope}\n"
+        f"  bucket    : {bucket}\n"
+        f"  title     : {title}\n"
+        f"  directive : {work}\n"
+        f"{files_block}"
+        "\n"
+        "Must-read-first refs:\n"
+        f"{refs_block}\n"
+        "\n"
+        "RULES:\n"
+        f"1. Stay inside {cwd}. Do not edit files outside this tree.\n"
+        f"2. Commit in small, focused chunks. Every commit message MUST include the footer\n"
+        f"   `{SPAWNED_BY_TRAILER}` (it can be the only line if needed). The spawner appends\n"
+        f"   it for you if you forget, but your messages are clearer if you include it.\n"
+        "3. Do NOT push, do NOT open PRs, do NOT touch git remotes. The spawner handles\n"
+        "   push + PR + auto-merge after you exit.\n"
+        "4. If the directive is impossible or already done, leave the branch unchanged\n"
+        "   and exit with a brief explanation. Empty branches will not produce a PR.\n"
+        "5. When done, output ONE final compact line of JSON to summarise:\n"
+        '   {"ok": true, "task_id": "<id>", "files_touched": <int>, "commits_made": <int>, "summary": "<one-line>"}\n'
+        "\n"
+        "Begin."
+    )
+
+
+# --- Git helpers (used for cwd capture, branch prep, auto-PR) -------------
+
+def _git(cmd: list[str], cwd: str, *, check: bool = True,
+         timeout: float = 15.0) -> subprocess.CompletedProcess:
+    """Run a git subcommand. Returns CompletedProcess. Raises on failure if check."""
+    return subprocess.run(
+        ["git", "-C", cwd, *cmd],
+        text=True, capture_output=True, timeout=timeout, check=check,
+    )
+
+
+def capture_git_state(cwd: str) -> dict[str, Any]:
+    try:
+        sha = _git(["rev-parse", "HEAD"], cwd).stdout.strip()
+    except Exception as e:
+        return {"ok": False, "error": f"rev-parse: {e}"}
+    try:
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd).stdout.strip()
+    except Exception:
+        branch = ""
+    try:
+        dirty = bool(_git(["status", "--porcelain"], cwd).stdout.strip())
+    except Exception:
+        dirty = False
+    return {"ok": True, "sha": sha, "branch": branch, "dirty": dirty}
+
+
+def _safe_branch_name(task_id: str, spawn_id: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", task_id).strip("-")[:60]
+    short = spawn_id.split("-")[0][:8]
+    return f"auto/{safe}-{short}"
+
+
+def _resolve_worktree_base_ref(repo_root: str) -> tuple[str, str]:
+    """Pick the freshest known base for a new worktree.
+
+    Tries (in order): origin/<WORKTREE_BASE_BRANCH>, origin/master, origin/main,
+    refs/heads/master, HEAD. Returns (ref, source-tag) where source-tag indicates
+    which fallback fired (for journaling).
+    """
+    # Best-effort fetch so worktree branches off the freshest tip. Never block.
+    try:
+        subprocess.run(
+            ["git", "-C", repo_root, "fetch", "origin",
+             WORKTREE_BASE_BRANCH, "--quiet"],
+            text=True, capture_output=True, timeout=20, check=False,
+        )
+    except Exception:
+        pass
+    candidates = [
+        (f"origin/{WORKTREE_BASE_BRANCH}", f"origin/{WORKTREE_BASE_BRANCH}"),
+        (f"refs/remotes/origin/{WORKTREE_BASE_BRANCH}", f"origin/{WORKTREE_BASE_BRANCH}"),
+        ("origin/master",                "origin/master"),
+        ("origin/main",                  "origin/main"),
+        ("refs/heads/master",            "local/master"),
+        ("refs/heads/main",              "local/main"),
+        ("HEAD",                         "HEAD"),
+    ]
+    for ref, tag in candidates:
+        r = subprocess.run(
+            ["git", "-C", repo_root, "rev-parse", "--verify", ref],
+            text=True, capture_output=True, timeout=10, check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return ref, tag
+    return "HEAD", "HEAD-fallback-final"
+
+
+def _spawn_worktree_path(repo_root: str, task_id: str, spawn_id: str) -> Path:
+    safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", task_id).strip("-")[:60]
+    short = (spawn_id.split("-")[0] or "")[:8] or uuid.uuid4().hex[:8]
+    subdir = f"{safe}-{short}"
+    return Path(repo_root) / WORKTREE_SUBDIR_NAME / subdir
+
+
+def prepare_branch_for_spawn(cwd: str, task_id: str, spawn_id: str) -> dict[str, Any]:
+    """Phase 6: create a per-spawn git worktree under
+    `<cwd>/.spawn-worktrees/<task_id>-<short>` branched off origin/develop.
+
+    The returned dict has `worktree_path` set to the new working directory,
+    which the caller MUST use as the effective cwd for the claude subprocess
+    AND every subsequent git/auto-PR helper. The original `cwd` (the main
+    checkout) is untouched and remains the orchestrator's working tree.
+
+    If WORKTREE_PER_SPAWN is disabled, falls back to the Phase-5 in-place
+    behaviour (mutates the main checkout's HEAD; cap > 1 unsafe).
+    """
+    if not WORKTREE_PER_SPAWN:
+        return _legacy_prepare_branch_for_spawn(cwd, task_id, spawn_id)
+
+    # Validate cwd is a git repo (capture_git_state will fail if not).
+    state = capture_git_state(cwd)
+    if not state.get("ok"):
+        return state
+
+    repo_root = cwd
+    base_ref, base_tag = _resolve_worktree_base_ref(repo_root)
+    branch = _safe_branch_name(task_id, spawn_id)
+    worktree_path = _spawn_worktree_path(repo_root, task_id, spawn_id)
+
+    # Make parent dir; harmless if exists.
+    try:
+        worktree_path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        return {"ok": False, "error": f"mkdir {worktree_path.parent}: {e}"}
+
+    # If the path already exists (crashed prior spawn left it), nuke it
+    # cleanly via `git worktree remove --force` (then prune) before recreating.
+    if worktree_path.exists():
+        subprocess.run(
+            ["git", "-C", repo_root, "worktree", "remove", "--force", str(worktree_path)],
+            text=True, capture_output=True, timeout=30, check=False,
+        )
+        subprocess.run(
+            ["git", "-C", repo_root, "worktree", "prune"],
+            text=True, capture_output=True, timeout=15, check=False,
+        )
+        if worktree_path.exists():
+            import shutil
+            shutil.rmtree(worktree_path, ignore_errors=True)
+
+    # Create worktree with a fresh branch. Serialise via _worktree_add_lock
+    # to avoid racing on git's `.git/worktrees/` index (observed: parallel
+    # `worktree add` invocations occasionally hit "cannot lock ref"). The
+    # lock is module-wide; per-repo would be marginally finer but the
+    # critical section is short enough that it doesn't matter.
+    #
+    # If the branch ref already exists (collision on truncated spawn-id
+    # prefix, or a crashed prior spawn left it), retry with a uniquified
+    # name including a microsecond+random suffix.
+    with _worktree_add_lock:
+        add_res = subprocess.run(
+            ["git", "-C", repo_root, "worktree", "add", "-b", branch,
+             str(worktree_path), base_ref],
+            text=True, capture_output=True, timeout=60, check=False,
+        )
+        if add_res.returncode != 0:
+            unique_branch = (f"{branch}-{int(time.time() * 1000) % 10**9}"
+                             f"-{uuid.uuid4().hex[:6]}")
+            add_res = subprocess.run(
+                ["git", "-C", repo_root, "worktree", "add", "-b", unique_branch,
+                 str(worktree_path), base_ref],
+                text=True, capture_output=True, timeout=60, check=False,
+            )
+            if add_res.returncode != 0:
+                return {
+                    "ok": False,
+                    "error": (f"git worktree add failed (base_ref={base_ref}): "
+                              f"{add_res.stderr[:400]}"),
+                }
+            branch = unique_branch
+
+    # Capture initial sha from inside the worktree.
+    sha_res = subprocess.run(
+        ["git", "-C", str(worktree_path), "rev-parse", "HEAD"],
+        text=True, capture_output=True, timeout=10, check=False,
+    )
+    if sha_res.returncode != 0:
+        # Try to clean up the worktree we just created.
+        subprocess.run(
+            ["git", "-C", repo_root, "worktree", "remove", "--force", str(worktree_path)],
+            text=True, capture_output=True, timeout=30, check=False,
+        )
+        return {"ok": False, "error": f"rev-parse in worktree: {sha_res.stderr[:300]}"}
+
+    return {
+        "ok":            True,
+        "sha":           sha_res.stdout.strip(),
+        "branch":        branch,
+        "worktree_path": str(worktree_path),
+        "worktree_used": True,
+        "base_ref":      base_ref,
+        "base_tag":      base_tag,
+        "reused":        False,
+    }
+
+
+def _legacy_prepare_branch_for_spawn(cwd: str, task_id: str, spawn_id: str) -> dict[str, Any]:
+    """Phase-5 in-place branch prep. Kept for emergency rollback only —
+    NOT safe with cap > 1 (parallel spawns share auto/ branch on same tree).
+    """
+    state = capture_git_state(cwd)
+    if not state.get("ok"):
+        return state
+    if state.get("dirty"):
+        return {"ok": False, "error": f"working tree dirty in {cwd}"}
+    if state.get("branch", "").startswith("auto/"):
+        return {"ok": True, "sha": state["sha"], "branch": state["branch"], "reused": True}
+    branch = _safe_branch_name(task_id, spawn_id)
+    try:
+        _git(["checkout", "-B", branch], cwd)
+    except subprocess.CalledProcessError as e:
+        return {"ok": False, "error": f"checkout -B {branch}: {e.stderr or e.stdout}"}
+    return {"ok": True, "sha": state["sha"], "branch": branch, "reused": False,
+            "worktree_used": False}
+
+
+def cleanup_worktree(repo_root: str, worktree_path: str) -> dict[str, Any]:
+    """Remove a per-spawn worktree. Force-removes even if dirty so we never
+    leak disk after a crashed spawn. The branch ref persists locally (it's
+    been pushed to origin during auto-PR) — that's intentional, it lets the
+    PR keep its base.
+    """
+    try:
+        if not worktree_path:
+            return {"ok": True, "skipped": True}
+        r = subprocess.run(
+            ["git", "-C", repo_root, "worktree", "remove", "--force", worktree_path],
+            text=True, capture_output=True, timeout=30, check=False,
+        )
+        ok = r.returncode == 0
+        # Always prune to clean up any orphaned metadata.
+        subprocess.run(
+            ["git", "-C", repo_root, "worktree", "prune"],
+            text=True, capture_output=True, timeout=15, check=False,
+        )
+        # Last-resort filesystem cleanup if git still left bytes behind.
+        if Path(worktree_path).exists():
+            import shutil
+            shutil.rmtree(worktree_path, ignore_errors=True)
+        return {"ok": True, "git_remove_ok": ok,
+                "stderr": r.stderr[:200] if not ok else None}
+    except Exception as e:
+        return {"ok": False, "error": f"cleanup_worktree: {e}"}
+
+
+def prune_stale_worktrees(repo_root: str, max_age_seconds: float) -> dict[str, Any]:
+    """At startup: scan `git worktree list` and prune any
+    `.spawn-worktrees/*` entries whose dir mtime is older than max_age_seconds.
+    Prevents disk leak from crashed spawns.
+    """
+    try:
+        if not Path(repo_root).is_dir() or not (Path(repo_root) / ".git").exists():
+            return {"ok": True, "skipped": "not a git repo", "repo_root": repo_root}
+        r = subprocess.run(
+            ["git", "-C", repo_root, "worktree", "list", "--porcelain"],
+            text=True, capture_output=True, timeout=15, check=False,
+        )
+        if r.returncode != 0:
+            return {"ok": False, "error": f"worktree list: {r.stderr[:200]}"}
+
+        worktrees: list[dict] = []
+        cur: dict = {}
+        for line in r.stdout.splitlines():
+            if not line.strip():
+                if cur:
+                    worktrees.append(cur)
+                    cur = {}
+                continue
+            if line.startswith("worktree "):
+                cur["path"] = line[len("worktree "):].strip()
+            elif line.startswith("HEAD "):
+                cur["head"] = line[len("HEAD "):].strip()
+            elif line.startswith("branch "):
+                cur["branch"] = line[len("branch "):].strip()
+        if cur:
+            worktrees.append(cur)
+
+        marker = f"{os.sep}{WORKTREE_SUBDIR_NAME}{os.sep}"
+        pruned: list[str] = []
+        kept: list[str] = []
+        now = time.time()
+        for w in worktrees:
+            p = w.get("path") or ""
+            if marker not in p:
+                continue
+            try:
+                mtime = Path(p).stat().st_mtime
+                age = now - mtime
+            except FileNotFoundError:
+                # Dir already gone — git just has stale metadata. Prune.
+                pruned.append(p)
+                continue
+            except Exception:
+                continue
+            if age >= max_age_seconds:
+                subprocess.run(
+                    ["git", "-C", repo_root, "worktree", "remove", "--force", p],
+                    text=True, capture_output=True, timeout=30, check=False,
+                )
+                if Path(p).exists():
+                    import shutil
+                    shutil.rmtree(p, ignore_errors=True)
+                pruned.append(p)
+            else:
+                kept.append(p)
+        # Final prune to drop any orphaned metadata.
+        subprocess.run(
+            ["git", "-C", repo_root, "worktree", "prune"],
+            text=True, capture_output=True, timeout=15, check=False,
+        )
+        return {"ok": True, "repo_root": repo_root,
+                "pruned": pruned, "kept": kept,
+                "max_age_seconds": max_age_seconds}
+    except Exception as e:
+        return {"ok": False, "error": f"prune_stale_worktrees: {e}"}
+
+
+def prune_stale_worktrees_under_allowed_root() -> list[dict[str, Any]]:
+    """Walk top-level dirs under ALLOWED_ROOT and prune stale worktrees in
+    every git repo we find. Plus ALLOWED_ROOT itself if it's a repo.
+    """
+    results: list[dict[str, Any]] = []
+    max_age = WORKTREE_STALE_HOURS * 3600.0
+    candidates: list[Path] = []
+    if (ALLOWED_ROOT / ".git").exists():
+        candidates.append(ALLOWED_ROOT)
+    try:
+        for child in ALLOWED_ROOT.iterdir():
+            if child.is_dir() and (child / ".git").exists():
+                candidates.append(child)
+    except Exception as e:
+        log.warning("startup worktree scan: iterdir(%s) failed: %s", ALLOWED_ROOT, e)
+    for repo in candidates:
+        try:
+            res = prune_stale_worktrees(str(repo), max_age)
+            results.append(res)
+        except Exception as e:
+            results.append({"ok": False, "repo_root": str(repo), "error": str(e)})
+    return results
+
+
+def detect_commits_made(cwd: str, initial_sha: str) -> dict[str, Any]:
+    try:
+        head = _git(["rev-parse", "HEAD"], cwd).stdout.strip()
+    except Exception as e:
+        return {"ok": False, "error": f"rev-parse: {e}"}
+    if head == initial_sha:
+        return {"ok": True, "head": head, "count": 0, "commits": [], "files_touched": 0}
+    try:
+        commits = _git(["log", "--format=%H%x09%s", f"{initial_sha}..{head}"], cwd).stdout
+        commit_lines = [ln for ln in commits.splitlines() if ln.strip()]
+    except Exception as e:
+        return {"ok": False, "error": f"log: {e}"}
+    try:
+        files = _git(["diff", "--name-only", f"{initial_sha}..{head}"], cwd).stdout
+        files_touched = len([ln for ln in files.splitlines() if ln.strip()])
+    except Exception:
+        files_touched = 0
+    return {"ok": True, "head": head, "count": len(commit_lines),
+            "commits": commit_lines, "files_touched": files_touched}
+
+
+def ensure_spawned_by_trailer(cwd: str, initial_sha: str) -> dict[str, Any]:
+    """Rewrite commits in initial_sha..HEAD to ensure each has the
+    Spawned-By trailer. We do this with `git rebase --exec` calling
+    `git commit --amend --no-edit --trailer ...` on each commit.
+
+    `git interpret-trailers` (used internally by --trailer) is idempotent
+    when ifExists=addIfDifferent (default), so commits that already have
+    the trailer (because claude obeyed the prompt) are not duplicated.
+    """
+    try:
+        # First check: are any commits missing the trailer?
+        log_out = _git(
+            ["log", f"{initial_sha}..HEAD", "--format=%H%x09%B%x00"],
+            cwd,
+        ).stdout
+        # Split commits by NUL
+        commits_missing = []
+        for chunk in log_out.split("\x00"):
+            if not chunk.strip():
+                continue
+            sha, _, msg = chunk.partition("\t")
+            if SPAWNED_BY_TRAILER not in msg:
+                commits_missing.append(sha.strip())
+
+        if not commits_missing:
+            return {"ok": True, "skipped": True, "amended": 0}
+
+        # Use rebase --exec to amend each commit with --trailer.
+        # The --trailer option was added in git 2.32 (we're on 2.45+).
+        exec_cmd = f"git commit --amend --no-edit --no-verify --trailer '{SPAWNED_BY_TRAILER}'"
+        result = subprocess.run(
+            ["git", "-C", cwd,
+             "-c", "advice.detachedHead=false",
+             "rebase", "--exec", exec_cmd, initial_sha],
+            text=True, capture_output=True, timeout=60, check=False,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0",
+                 "GIT_SEQUENCE_EDITOR": ":", "GIT_EDITOR": ":"},
+        )
+        if result.returncode != 0:
+            # Abort the rebase if it left us mid-flight, then fall back
+            # to amending HEAD only (best-effort).
+            subprocess.run(["git", "-C", cwd, "rebase", "--abort"],
+                           text=True, capture_output=True, timeout=10, check=False)
+            log.warning("ensure_spawned_by_trailer: rebase failed, "
+                        "falling back to amend-HEAD only: %s",
+                        result.stderr[:500])
+            head_msg = _git(["log", "-1", "--format=%B"], cwd).stdout.rstrip()
+            if SPAWNED_BY_TRAILER not in head_msg:
+                new_msg = head_msg + "\n\n" + SPAWNED_BY_TRAILER + "\n"
+                amend = subprocess.run(
+                    ["git", "-C", cwd, "commit", "--amend",
+                     "--no-verify", "-m", new_msg],
+                    text=True, capture_output=True, timeout=30, check=False,
+                )
+                if amend.returncode != 0:
+                    return {"ok": False,
+                            "error": f"amend HEAD: {amend.stderr[:300]}"}
+                return {"ok": True, "fallback": "head-only", "amended": 1}
+            return {"ok": True, "fallback": "head-already-has-trailer"}
+        return {"ok": True, "amended": len(commits_missing)}
+    except Exception as e:
+        return {"ok": False, "error": f"trailer rewrite: {e}"}
+
+
+def push_branch(cwd: str, branch: str) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "push", "-u", "origin", branch],
+            text=True, capture_output=True, timeout=60, check=False,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        if result.returncode != 0:
+            return {"ok": False, "error": f"push: {result.stderr[:500]}"}
+        return {"ok": True, "stdout": result.stdout[:500]}
+    except Exception as e:
+        return {"ok": False, "error": f"push: {e}"}
+
+
+def create_pr(cwd: str, branch: str, base: str, title: str, body: str,
+              labels: list[str]) -> dict[str, Any]:
+    try:
+        cmd = ["gh", "pr", "create",
+               "--head", branch,
+               "--base", base,
+               "--title", title,
+               "--body", body]
+        for lab in labels:
+            cmd += ["--label", lab]
+        result = subprocess.run(
+            cmd, text=True, capture_output=True, timeout=45, check=False, cwd=cwd,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        if result.returncode != 0:
+            return {"ok": False, "error": f"gh pr create: {result.stderr[:500]}"}
+        url = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+        return {"ok": True, "url": url}
+    except Exception as e:
+        return {"ok": False, "error": f"gh pr create: {e}"}
+
+
+def enable_auto_merge(cwd: str, pr_url: str) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "merge", pr_url, "--auto", "--squash"],
+            text=True, capture_output=True, timeout=30, check=False, cwd=cwd,
+        )
+        if result.returncode != 0:
+            return {"ok": False, "error": f"gh pr merge --auto: {result.stderr[:500]}"}
+        return {"ok": True}
+    except Exception as e:
+        return {"ok": False, "error": f"gh pr merge --auto: {e}"}
+
+
+# --- The actual claude spawn -----------------------------------------------
+
+def run_claude(spawn_id: str,
+               prompt: str,
+               timeout_s: float,
+               *,
+               permission_mode: str,
+               allow_list: list[str],
+               cwd: str | None) -> dict[str, Any]:
+    """Synchronously invoke the claude binary in subscription mode.
+
+    Phase 5: builds argv based on permission_mode, attaches --add-dir
+    for each allow_list entry, and chdir's into cwd if provided so
+    claude's tool-use is rooted there.
+    """
+    if subscription_guard_message():
+        raise RuntimeError("subscription guard violation")
+
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")}
+    env["PYTHONUNBUFFERED"] = "1"
+    env["ANTHROPIC_API_KEY"] = ""
+
+    cmd, headroom_wrapped, prefix_stabilized = _build_claude_argv(
+        prompt,
+        permission_mode=permission_mode,
+        allow_list=allow_list,
+        claude_binary=CLAUDE_BINARY,
+        permission_mode_max_turns=PERMISSION_MODE_MAX_TURNS,
+        headroom_binary=HEADROOM_BINARY,
+        headroom_wrap_disable=HEADROOM_WRAP_DISABLE,
+        headroom_proxy_port=HEADROOM_PROXY_PORT,
+        headroom_proxy_offset=HEADROOM_PROXY_OFFSET,
+        headroom_reuse_proxy=os.environ.get("HEADROOM_REUSE_PROXY", "").lower()
+                              in ("1", "true", "yes"),
+        stabilize_prefix_disable=STABILIZE_PREFIX_DISABLE,
+    )
+
+    started = time.time()
+    log.info("spawn_id=%s mode=%s allow_list=%d cwd=%s "
+             "headroom_wrap=%s prefix_stabilized=%s invoking claude...",
+             spawn_id, permission_mode, len(allow_list), cwd or "<inherit>",
+             headroom_wrapped, prefix_stabilized)
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=cwd,
+    )
+    pid = proc.pid
+
+    stdout = stderr = ""
+    rc: int | None = None
+    timed_out = False
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_s)
+        rc = proc.returncode
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        log.warning("spawn_id=%s claude TIMEOUT after %.1fs — sending SIGTERM",
+                    spawn_id, timeout_s)
+        proc.terminate()
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            log.warning("spawn_id=%s claude refused SIGTERM — SIGKILL", spawn_id)
+            proc.kill()
+            try:
+                stdout, stderr = proc.communicate(timeout=5)
+            except Exception:
+                stdout = stdout or ""
+                stderr = stderr or ""
+        rc = proc.returncode
+    duration_ms = int((time.time() - started) * 1000)
+
+    parsed = None
+    session_id: str | None = None
+    model: str | None      = None
+    if stdout:
+        try:
+            parsed = json.loads(stdout)
+            session_id = parsed.get("session_id") or parsed.get("conversation_id")
+            model      = parsed.get("model")
+            if not model:
+                mu = parsed.get("modelUsage") or {}
+                if isinstance(mu, dict) and mu:
+                    model = next(iter(mu.keys()))
+        except Exception as e:
+            log.warning("spawn_id=%s could not parse stdout JSON: %s", spawn_id, e)
+
+    return {
+        "ok":           (rc == 0 and not timed_out),
+        "pid":          pid,
+        "rc":           rc,
+        "timed_out":    timed_out,
+        "duration_ms":  duration_ms,
+        "session_id":   session_id,
+        "model":        model,
+        "parsed":       parsed,
+        "stdout_head":  (stdout or "")[:2000],
+        "stderr_head":  (stderr or "")[:2000],
+        "headroom_wrapped":    headroom_wrapped,
+        "prefix_stabilized":   prefix_stabilized,
+    }
+
+
+# --- FastAPI app -----------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    guard = subscription_guard_message()
+    if guard:
+        log.error("STARTUP REFUSED: %s", guard)
+        raise SystemExit(2)
+    log.info("claude-spawner-agent %s starting on :%d host_name=%s claude=%s",
+             VERSION, PORT, HOST_NAME, CLAUDE_BINARY)
+    log.info("subscription-guard OK at startup (ANTHROPIC_API_KEY unset)")
+    log.info("ALLOWED_ROOT=%s PATH_BLOCKLIST_RE=%s",
+             ALLOWED_ROOT, PATH_BLOCKLIST_RE.pattern)
+    log.info("WORKTREE_PER_SPAWN=%s base_branch=%s stale_hours=%s subdir=%s",
+             WORKTREE_PER_SPAWN, WORKTREE_BASE_BRANCH,
+             WORKTREE_STALE_HOURS, WORKTREE_SUBDIR_NAME)
+    log.info("LAI phase 7: ROUTER_GATE_ENABLED=%s OPTIMIZER_ENABLED=%s "
+             "router_url=%s optimizer_timeout_s=%.1f",
+             ROUTER_GATE_ENABLED, OPTIMIZER_ENABLED, ROUTER_URL, OPTIMIZER_TIMEOUT_S)
+    headroom_present = bool(HEADROOM_BINARY) and os.path.exists(HEADROOM_BINARY)
+    headroom_wrap_active = headroom_present and not HEADROOM_WRAP_DISABLE
+    log.info("SPS-α: HEADROOM_BINARY=%s present=%s wrap_disable=%s wrap_active=%s "
+             "proxy_port=%d offset=%d stabilize_prefix_disable=%s",
+             HEADROOM_BINARY, headroom_present, HEADROOM_WRAP_DISABLE,
+             headroom_wrap_active, HEADROOM_PROXY_PORT, HEADROOM_PROXY_OFFSET,
+             STABILIZE_PREFIX_DISABLE)
+    log.info("claude --version: %s", claude_version_str())
+    binary_path_and_sha256()
+    journal_event(None, "startup",
+                  f"version={VERSION} host={HOST_NAME} "
+                  f"worktree_per_spawn={WORKTREE_PER_SPAWN}")
+
+    try:
+        reconcile_inflight()
+    except Exception as e:
+        log.exception("reconciliation failed: %s", e)
+
+    # Phase 6: scrub stale spawn worktrees (older than WORKTREE_STALE_HOURS)
+    # left by crashed prior workers. Bounded disk leak.
+    if WORKTREE_PER_SPAWN:
+        try:
+            results = prune_stale_worktrees_under_allowed_root()
+            total_pruned = sum(len(r.get("pruned") or []) for r in results)
+            total_kept   = sum(len(r.get("kept") or [])   for r in results)
+            log.info("worktree pruner: scanned=%d pruned=%d kept=%d",
+                     len(results), total_pruned, total_kept)
+            for r in results:
+                if r.get("pruned"):
+                    log.info("worktree pruner: %s pruned=%s",
+                             r.get("repo_root"), r.get("pruned"))
+            journal_event(None, "worktree-prune-startup",
+                          f"scanned={len(results)} pruned={total_pruned} "
+                          f"kept={total_kept}")
+        except Exception as e:
+            log.warning("worktree pruner failed (non-fatal): %s", e)
+
+    if AUTO_REGISTER:
+        try:
+            await self_register()
+        except Exception as e:
+            log.warning("self-register error: %s", e)
+        hb_task = asyncio.create_task(heartbeat_forever())
+    else:
+        hb_task = None
+
+    try:
+        yield
+    finally:
+        log.info("claude-spawner-agent shutting down")
+        journal_event(None, "shutdown", None)
+        if hb_task:
+            hb_task.cancel()
+            with contextlib.suppress(Exception):
+                await hb_task
+
+
+app = FastAPI(title="Claude Spawner Agent (Mac)", version=VERSION, lifespan=lifespan)
+
+
+@app.get("/health", response_class=PlainTextResponse)
+def health() -> str:
+    return "OK"
+
+
+@app.get("/version")
+def version() -> dict[str, Any]:
+    bp, sha = binary_path_and_sha256()
+    return {
+        "service":            "claude-spawner-agent",
+        "version":            VERSION,
+        "host_name":          HOST_NAME,
+        "binary_path":        bp,
+        "binary_sha256":      sha,
+        "claude_version":     claude_version_str(),
+        "subscription_only":  subscription_guard_message() is None,
+        "slot_manager_url":   SLOT_MANAGER_URL,
+        "self_spawner_url":   SELF_SPAWNER_URL,
+        "auto_register":      AUTO_REGISTER,
+        "allowed_root":       str(ALLOWED_ROOT),
+        "valid_permission_modes": sorted(VALID_PERMISSION_MODES),
+        "default_permission_mode": DEFAULT_PERMISSION_MODE,
+        "default_pr_base_branch":  DEFAULT_PR_BASE_BRANCH,
+        "default_pr_label":        DEFAULT_PR_LABEL,
+        "worktree_per_spawn":      WORKTREE_PER_SPAWN,
+        "worktree_base_branch":    WORKTREE_BASE_BRANCH,
+        "worktree_stale_hours":    WORKTREE_STALE_HOURS,
+        "worktree_subdir_name":    WORKTREE_SUBDIR_NAME,
+        "router_gate_enabled":     ROUTER_GATE_ENABLED,
+        "optimizer_enabled":       OPTIMIZER_ENABLED,
+        "headroom_binary":         HEADROOM_BINARY,
+        "headroom_present":        bool(HEADROOM_BINARY) and os.path.exists(HEADROOM_BINARY),
+        "headroom_wrap_disable":   HEADROOM_WRAP_DISABLE,
+        "headroom_proxy_port":     HEADROOM_PROXY_PORT,
+        "headroom_proxy_offset":   HEADROOM_PROXY_OFFSET,
+        "stabilize_prefix_disable": STABILIZE_PREFIX_DISABLE,
+    }
+
+
+@app.get("/")
+def root():
+    return {
+        "service":   "claude-spawner-agent",
+        "version":   VERSION,
+        "endpoints": ["/health", "/version", "/spawn", "/admin/sessions",
+                      "/admin/sessions/{spawn_id}", "/admin/events",
+                      "/admin/validate-allow-list"],
+    }
+
+
+@app.post("/admin/validate-allow-list")
+async def admin_validate_allow_list(req: Request) -> JSONResponse:
+    """Operator-side helper: dry-run path validation without spawning."""
+    body = await req.json()
+    paths = body.get("paths") or []
+    accepted, rejected = validate_allow_list(paths)
+    return JSONResponse({"accepted": accepted, "rejected": rejected,
+                         "allowed_root": str(ALLOWED_ROOT),
+                         "blocklist_regex": PATH_BLOCKLIST_RE.pattern})
+
+
+@app.post("/spawn")
+async def spawn(request: Request) -> JSONResponse:
+    t0 = time.time()
+    raw = await request.body()
+    payload: dict[str, Any] = await request.json() if raw else {}
+
+    spawn_id  = payload.get("spawn_id") or str(uuid.uuid4())
+    task_spec = payload.get("task_spec") or {}
+    task_id   = (payload.get("task_id")
+                 or task_spec.get("id")
+                 or task_spec.get("item_code")
+                 or "unknown")
+    slot_id   = payload.get("slot_id")
+    bucket    = payload.get("bucket")
+    host      = payload.get("host")
+    heartbeat_url = payload.get("heartbeat_url")
+    timeout_s     = float(payload.get("timeout_sec") or DEFAULT_TIMEOUT_S)
+
+    # Phase 5: read new fields with defaults that preserve Phase 3 behaviour.
+    permission_mode = (payload.get("permission_mode")
+                       or task_spec.get("permission_mode")
+                       or DEFAULT_PERMISSION_MODE)
+    if permission_mode not in VALID_PERMISSION_MODES:
+        permission_mode = DEFAULT_PERMISSION_MODE  # silently fall back
+
+    allow_list_raw = (payload.get("allow_list")
+                      or task_spec.get("allow_list")
+                      or [])
+    risk_tier = (payload.get("risk_tier")
+                 or task_spec.get("risk_tier"))
+    cwd = (payload.get("cwd")
+           or task_spec.get("cwd"))
+    auto_pr = bool(payload.get("auto_pr") or task_spec.get("auto_pr"))
+    auto_merge = bool(payload.get("auto_merge") or task_spec.get("auto_merge"))
+
+    # Validate allow-list (always — spawner is the last line of defence).
+    accepted_paths, rejected_paths = validate_allow_list(allow_list_raw)
+
+    journal_insert_starting({
+        "spawn_id": spawn_id,
+        "slot_id":  slot_id,
+        "task_id":  task_id,
+        "bucket":   bucket,
+        "host":     host,
+        "spawn_callback_url": payload.get("spawn_callback_url"),
+        "release_url":        payload.get("release_url"),
+        "heartbeat_url":      heartbeat_url,
+        "task_spec":          task_spec,
+    }, permission_mode=permission_mode,
+       allow_list=accepted_paths,
+       risk_tier=risk_tier,
+       cwd=cwd)
+    journal_event(spawn_id, "spawn-received",
+                  f"slot={slot_id} bucket={bucket} task={task_id} "
+                  f"mode={permission_mode} risk={risk_tier} "
+                  f"allow={len(accepted_paths)} rejected={len(rejected_paths)}")
+
+    # 1. Subscription guard.
+    guard = subscription_guard_message()
+    if guard:
+        bp, sha = binary_path_and_sha256()
+        journal_finalize(spawn_id, "rejected_guard",
+                         duration_ms=int((time.time() - t0) * 1000),
+                         binary_path=bp, binary_sha256=sha, error=guard)
+        return JSONResponse(status_code=451, content={
+            "ok":                False,
+            "outcome":           "rejected_guard",
+            "subscription_only": False,
+            "error":             guard,
+            "spawn_id":          spawn_id,
+            "binary_path":       bp,
+            "binary_sha256":     sha,
+        })
+
+    # 2. Path-escape guard (Phase 5).
+    if rejected_paths:
+        bp, sha = binary_path_and_sha256()
+        err = f"allow_list rejected: {rejected_paths}"
+        journal_finalize(spawn_id, "rejected_path_escape",
+                         duration_ms=int((time.time() - t0) * 1000),
+                         binary_path=bp, binary_sha256=sha, error=err)
+        return JSONResponse(status_code=451, content={
+            "ok":                False,
+            "outcome":           "rejected_path_escape",
+            "subscription_only": True,
+            "error":             err,
+            "spawn_id":          spawn_id,
+            "rejected_paths":    rejected_paths,
+            "allowed_root":      str(ALLOWED_ROOT),
+        })
+
+    # 3. Sanity check the dispatch payload.
+    require_sub = payload.get("require_subscription", False)
+    if not require_sub:
+        bp, sha = binary_path_and_sha256()
+        journal_finalize(spawn_id, "spawner_error",
+                         duration_ms=int((time.time() - t0) * 1000),
+                         binary_path=bp, binary_sha256=sha,
+                         error="dispatch payload missing require_subscription=true")
+        return JSONResponse(status_code=400, content={
+            "ok":                False,
+            "outcome":           "spawner_error",
+            "subscription_only": True,
+            "error":             "dispatch payload missing require_subscription=true",
+            "spawn_id":          spawn_id,
+        })
+
+    # 4. Fire-and-forget heartbeat.
+    if heartbeat_url and slot_id:
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                await client.post(heartbeat_url, json={
+                    "slot_id": slot_id,
+                    "task_id": task_id,
+                })
+        except Exception as e:
+            log.warning("heartbeat to %s failed (non-fatal): %s", heartbeat_url, e)
+
+    # ─── LAI phase 7: pre-spawn classify-and-maybe-route gate ───────────────
+    # Only fires for plan-mode (read-only ack) tasks; real-edit modes always
+    # go to the claude binary because the local qwen models can't manipulate
+    # worktrees/git. If local handles the task we finalize the spawn with
+    # outcome=local_completed, claude_invoked=False, and return early.
+    router_decision: dict[str, Any] = {"tier": "claude", "reason": "gate-not-evaluated"}
+    if ROUTER_GATE_ENABLED and permission_mode == "plan":
+        try:
+            router_up = router_health(ROUTER_URL)
+        except Exception as e:
+            router_up = False
+            log.warning("router_health(%s) raised %s", ROUTER_URL, e)
+        if router_up:
+            pm = (task_spec.get("prompt_material") or {})
+            spec_text = " ".join(filter(None, [
+                task_spec.get("title"),
+                pm.get("work_directive") or task_spec.get("work_directive"),
+                pm.get("description") or task_spec.get("description"),
+            ])) or json.dumps(task_spec)
+            try:
+                local_response, route_meta = classify_and_maybe_route(
+                    spec_text, base_url=ROUTER_URL,
+                )
+            except Exception as e:
+                local_response, route_meta = None, {
+                    "tier": "claude",
+                    "reason": f"router-call-raised:{type(e).__name__}:{e}",
+                }
+            router_decision = dict(route_meta)
+            journal_event(spawn_id, "router-gate-decision",
+                          f"tier={route_meta.get('tier')} "
+                          f"reason={str(route_meta.get('reason') or '')[:200]} "
+                          f"intent={route_meta.get('intent')} "
+                          f"conf={route_meta.get('confidence')}")
+            if local_response is not None:
+                bp, sha = binary_path_and_sha256()
+                preview = (local_response or "")[:200]
+                journal_finalize(
+                    spawn_id, "local_completed",
+                    duration_ms=int((time.time() - t0) * 1000),
+                    model=route_meta.get("model"),
+                    binary_path=bp, binary_sha256=sha,
+                    claude_invoked=False,
+                    router_tier=route_meta.get("tier"),
+                    router_intent=route_meta.get("intent"),
+                    router_confidence=route_meta.get("confidence"),
+                    response_preview=preview,
+                )
+                journal_event(spawn_id, "spawn-local_completed",
+                              f"tier={route_meta.get('tier')} "
+                              f"model={route_meta.get('model')} "
+                              f"intent={route_meta.get('intent')} "
+                              f"conf={route_meta.get('confidence')}")
+                return JSONResponse(status_code=200, content={
+                    "ok":                True,
+                    "outcome":           "local_completed",
+                    "subscription_only": True,
+                    "spawn_id":          spawn_id,
+                    "model":             route_meta.get("model"),
+                    "tier":              route_meta.get("tier"),
+                    "claude_invoked":    False,
+                    "response":          local_response,
+                })
+        else:
+            router_decision = {"tier": "claude", "reason": "router-unhealthy"}
+            journal_event(spawn_id, "router-gate-skipped",
+                          "router /healthz down — falling through to claude")
+    elif not ROUTER_GATE_ENABLED:
+        router_decision = {"tier": "claude", "reason": "gate-disabled-by-env"}
+    else:
+        router_decision = {"tier": "claude",
+                           "reason": f"gate-skipped-permission_mode={permission_mode}"}
+
+    # 5. If real-edit mode AND cwd provided, prepare branch + capture HEAD.
+    #    Phase 6: this also creates a per-spawn git worktree under
+    #    `<cwd>/.spawn-worktrees/<task_id>-<short>` and swaps the effective
+    #    cwd to that worktree for the rest of the spawn — so cap > 1 spawns
+    #    on the same host no longer share `auto/...` branch on the same tree.
+    initial_sha: str | None = None
+    branch: str | None = None
+    repo_root: str | None = cwd  # the orchestrator-owned main checkout
+    worktree_path: str | None = None
+    worktree_used: bool = False
+    if permission_mode in ("acceptEdits", "bypassPermissions") and cwd:
+        prep = prepare_branch_for_spawn(cwd, task_id, spawn_id)
+        if not prep.get("ok"):
+            bp, sha = binary_path_and_sha256()
+            err = f"branch prep failed: {prep.get('error')}"
+            journal_finalize(spawn_id, "spawner_error",
+                             duration_ms=int((time.time() - t0) * 1000),
+                             binary_path=bp, binary_sha256=sha, error=err)
+            return JSONResponse(status_code=409, content={
+                "ok":                False,
+                "outcome":           "spawner_error",
+                "subscription_only": True,
+                "error":             err,
+                "spawn_id":          spawn_id,
+            })
+        initial_sha = prep["sha"]
+        branch = prep["branch"]
+        worktree_used = bool(prep.get("worktree_used"))
+        if worktree_used:
+            worktree_path = prep["worktree_path"]
+            # Phase 6: SWAP effective cwd to the worktree. Every downstream
+            # operation (claude subprocess, commit detection, trailer rewrite,
+            # push, gh pr create, auto-merge) MUST run inside the worktree
+            # so parallel spawns don't trample each other's HEAD.
+            cwd = worktree_path
+            # Replace any allow_list entry that pointed at the main checkout
+            # with the worktree path (keep other entries intact). Worktree
+            # is a child of repo_root so it's already under ALLOWED_ROOT.
+            new_accepted: list[str] = []
+            for p in accepted_paths:
+                try:
+                    if Path(p).resolve() == Path(repo_root).resolve():
+                        new_accepted.append(worktree_path)
+                        continue
+                except Exception:
+                    pass
+                new_accepted.append(p)
+            if worktree_path not in new_accepted:
+                new_accepted.insert(0, worktree_path)
+            accepted_paths = new_accepted
+        journal_event(spawn_id, "branch-prepared",
+                      f"branch={branch} initial_sha={initial_sha[:10]} "
+                      f"reused={prep.get('reused')} worktree={worktree_used} "
+                      f"path={worktree_path or '<n/a>'} "
+                      f"base_ref={prep.get('base_ref') or '<n/a>'} "
+                      f"base_tag={prep.get('base_tag') or '<n/a>'}")
+
+    # 6. Build prompt.
+    if permission_mode == "plan":
+        prompt = build_prompt_plan_only(task_spec)
+    else:
+        prompt = build_prompt_real_edit(
+            task_spec,
+            permission_mode=permission_mode,
+            cwd=cwd or "(unset)",
+            branch=branch or "(unset)",
+            spawn_id=spawn_id,
+            risk_tier=risk_tier,
+        )
+
+    # ─── LAI phase 7: 3-stage prompt optimizer pre-pass ──────────────────
+    # Runs regardless of the router-gate outcome (we're now on the claude
+    # path either way). Best-effort: optimize_prompt() never raises, but the
+    # `except Exception` is belt-and-suspenders. On any failure the original
+    # `prompt` is reused unchanged.
+    optimizer_meta: dict[str, Any] = {"backend": "skipped"}
+    if OPTIMIZER_ENABLED:
+        try:
+            optimized_prompt, opt_meta = optimize_prompt(
+                prompt, system_prompt=None,
+                base_url=ROUTER_URL, timeout=OPTIMIZER_TIMEOUT_S,
+            )
+            optimizer_meta = opt_meta
+            journal_event(spawn_id, "optimizer-applied",
+                          f"backend={opt_meta.get('backend')} "
+                          f"pre={opt_meta.get('pre_token_count')} "
+                          f"post={opt_meta.get('post_token_count')} "
+                          f"stages={','.join(opt_meta.get('stages_run') or [])} "
+                          f"wall_ms={opt_meta.get('wall_ms')}")
+            prompt = optimized_prompt
+        except Exception as e:
+            optimizer_meta = {
+                "backend": "noop",
+                "error": f"{type(e).__name__}: {e}",
+            }
+            journal_event(spawn_id, "optimizer-failed", str(e)[:300])
+
+    # 7. Update journal with initial_sha + branch BEFORE invoking claude
+    #    (so reconciliation has the info if we crash mid-spawn).
+    if initial_sha or branch:
+        journal_set_running(spawn_id, pid=0, initial_sha=initial_sha, branch=branch)
+
+    # 8. Run claude.
+    record = await asyncio.to_thread(
+        run_claude, spawn_id, prompt, timeout_s,
+        permission_mode=permission_mode,
+        allow_list=accepted_paths,
+        cwd=cwd,
+    )
+    # PID is set inside run_claude via subprocess.Popen.pid; we update
+    # the journal with the real PID for forensics.
+    journal_set_running(spawn_id, record["pid"])
+
+    # 9. Decide outcome.
+    rc = record["rc"]
+    timed_out = record["timed_out"]
+    if rc == 0 and not timed_out:
+        outcome = "ok"
+    elif timed_out:
+        outcome = "timeout"
+    elif rc is not None and rc < 0:
+        outcome = "crashed"
+    else:
+        outcome = "spawner_error"
+
+    bp, sha = binary_path_and_sha256()
+    duration_ms = int((time.time() - t0) * 1000)
+
+    error_field: str | None = None
+    if outcome != "ok":
+        head = (record.get("stderr_head") or "")[:200].strip()
+        error_field = f"outcome={outcome} rc={rc} stderr_head={head!r}"
+
+    # 10. Auto-PR (only on ok + real-edit + cwd + initial_sha known).
+    pr_url: str | None = None
+    auto_merge_enabled = False
+    files_touched: int | None = None
+    commits_made: int | None = None
+    final_sha: str | None = None
+
+    if (outcome == "ok"
+            and auto_pr
+            and cwd
+            and initial_sha
+            and branch
+            and permission_mode != "plan"):
+        det = detect_commits_made(cwd, initial_sha)
+        if det.get("ok"):
+            commits_made = det["count"]
+            files_touched = det["files_touched"]
+            final_sha = det["head"]
+            if commits_made > 0:
+                journal_event(spawn_id, "auto-pr-start",
+                              f"branch={branch} commits={commits_made} files={files_touched}")
+                # Ensure trailer on commits
+                trailer_res = ensure_spawned_by_trailer(cwd, initial_sha)
+                if not trailer_res.get("ok"):
+                    journal_event(spawn_id, "auto-pr-trailer-warning",
+                                  trailer_res.get("error", "")[:300])
+                # Push
+                push_res = push_branch(cwd, branch)
+                if not push_res.get("ok"):
+                    journal_event(spawn_id, "auto-pr-push-failed",
+                                  push_res.get("error", "")[:300])
+                else:
+                    # Build PR title + body
+                    title_seed = (task_spec.get("title")
+                                  or task_id
+                                  or "autonomous-loop change")
+                    pr_title = f"[autonomous] {title_seed}"[:120]
+                    pr_body = (
+                        f"Auto-PR opened by the slot-manager autonomous loop.\n\n"
+                        f"- spawn_id: `{spawn_id}`\n"
+                        f"- task_id: `{task_id}`\n"
+                        f"- bucket: `{bucket}`\n"
+                        f"- host: `{HOST_NAME}`\n"
+                        f"- permission_mode: `{permission_mode}`\n"
+                        f"- risk_tier: `{risk_tier or 'low'}`\n"
+                        f"- model: `{record.get('model') or 'unknown'}`\n"
+                        f"- session_id: `{record.get('session_id') or 'n/a'}`\n"
+                        f"- commits: {commits_made}\n"
+                        f"- files_touched: {files_touched}\n"
+                        f"- initial_sha: `{initial_sha[:10]}`\n"
+                        f"- final_sha: `{final_sha[:10]}`\n\n"
+                        f"This PR was created by Phase 5 of the slot-manager auto-PR pipeline.\n"
+                        f"Auto-merge is gated on the standard required CI checks (DoD evidence-gate);\n"
+                        f"high-risk specs ({{`risk_tier=high`}}) NEVER auto-merge.\n\n"
+                        f"References:\n"
+                        f"- [Slot Manager Phase 5 brief](agent-memory/slot_manager_phase5_brief.md)\n"
+                        f"- [Definition of Done](agent-memory/feedback_definition_of_done.md)\n"
+                        f"- [Zero-dollar rule](agent-memory/feedback_no_api_key_billing.md)\n\n"
+                        f"{SPAWNED_BY_TRAILER}\n"
+                    )
+                    pr_res = create_pr(cwd, branch,
+                                       DEFAULT_PR_BASE_BRANCH, pr_title, pr_body,
+                                       [DEFAULT_PR_LABEL])
+                    if pr_res.get("ok"):
+                        pr_url = pr_res["url"]
+                        journal_event(spawn_id, "auto-pr-opened",
+                                      f"url={pr_url}")
+                        # Auto-merge?
+                        if auto_merge and (risk_tier or "low") != "high":
+                            am = enable_auto_merge(cwd, pr_url)
+                            if am.get("ok"):
+                                auto_merge_enabled = True
+                                journal_event(spawn_id, "auto-pr-auto-merge-enabled", pr_url)
+                            else:
+                                journal_event(spawn_id, "auto-pr-auto-merge-failed",
+                                              am.get("error", "")[:300])
+                    else:
+                        journal_event(spawn_id, "auto-pr-create-failed",
+                                      pr_res.get("error", "")[:300])
+            else:
+                journal_event(spawn_id, "auto-pr-skipped-no-commits",
+                              f"branch={branch} clean")
+        else:
+            journal_event(spawn_id, "auto-pr-detect-failed",
+                          det.get("error", "")[:300])
+
+    # 11. Phase 6: tear down the per-spawn worktree no matter what the
+    #     outcome was. Branch lives on origin via the auto-PR push above
+    #     (if commits were made); the local working dir is scratch.
+    worktree_cleanup_status: str | None = None
+    if worktree_used and worktree_path and repo_root:
+        cw_res = cleanup_worktree(repo_root, worktree_path)
+        if cw_res.get("ok"):
+            worktree_cleanup_status = "ok"
+            journal_event(spawn_id, "worktree-cleaned",
+                          f"path={worktree_path}")
+        else:
+            worktree_cleanup_status = f"failed: {cw_res.get('error', '')[:200]}"
+            journal_event(spawn_id, "worktree-cleanup-failed",
+                          f"path={worktree_path} err={cw_res.get('error', '')[:200]}")
+
+    journal_finalize(spawn_id, outcome,
+                     duration_ms=duration_ms,
+                     exit_code=rc,
+                     session_id=record["session_id"],
+                     model=record["model"],
+                     binary_path=bp, binary_sha256=sha,
+                     error=error_field,
+                     final_sha=final_sha,
+                     files_touched=files_touched,
+                     commits_made=commits_made,
+                     pr_url=pr_url,
+                     auto_merge_enabled=auto_merge_enabled,
+                     # LAI phase 7 telemetry: this spawn went to claude
+                     # (we'd have returned early in the router-gate block
+                     # otherwise), so claude_invoked=True.
+                     claude_invoked=True,
+                     router_tier=router_decision.get("tier"),
+                     router_intent=router_decision.get("intent"),
+                     router_confidence=router_decision.get("confidence"),
+                     optimizer_backend=optimizer_meta.get("backend"),
+                     optimizer_pre_tokens=optimizer_meta.get("pre_token_count"),
+                     optimizer_post_tokens=optimizer_meta.get("post_token_count"),
+                     optimizer_compression=optimizer_meta.get("compression_ratio"),
+                     optimizer_stages_run=optimizer_meta.get("stages_run"),
+                     optimizer_wall_ms=optimizer_meta.get("wall_ms"),
+                     optimizer_error=optimizer_meta.get("error"))
+    # SPS-α telemetry: emit per-spawn substrate state as a journal event so the
+    # displacement metric can distinguish wrapped/stabilized runs without
+    # requiring a schema migration on the claude_sessions table.
+    journal_event(spawn_id, "claude-invocation-mode",
+                  f"headroom_wrapped={record.get('headroom_wrapped', False)} "
+                  f"prefix_stabilized={record.get('prefix_stabilized', False)}")
+    journal_event(spawn_id, f"spawn-{outcome}",
+                  f"rc={rc} dur_ms={duration_ms} session={record.get('session_id')} "
+                  f"mode={permission_mode} commits={commits_made} pr={pr_url} "
+                  f"worktree_cleanup={worktree_cleanup_status}")
+
+    parsed = record.get("parsed") or {}
+    log.info("spawn served: spawn_id=%s slot=%s bucket=%s task=%s outcome=%s rc=%s "
+             "sha=%s session=%s model=%s dur_ms=%d mode=%s commits=%s pr=%s",
+             spawn_id, slot_id, bucket, task_id, outcome, rc, sha[:16],
+             (record.get("session_id") or "")[:8], record.get("model"),
+             duration_ms, permission_mode, commits_made, pr_url)
+
+    body = {
+        "ok":                outcome == "ok",
+        "outcome":           outcome,
+        "exit_code":         rc,
+        "rc":                rc,
+        "subscription_only": True,
+        "binary_path":       bp,
+        "binary_sha256":     sha,
+        "session_id":        record["session_id"],
+        "model":             record["model"],
+        "duration_ms":       duration_ms,
+        "spawn_id":          spawn_id,
+        "ack":               {"task_id": task_id, "ready": True},
+        "host_name":         HOST_NAME,
+        "parsed":            parsed,
+        "error":             error_field,
+        # Phase 5 fields:
+        "permission_mode":   permission_mode,
+        "allow_list":        accepted_paths,
+        "risk_tier":         risk_tier,
+        "cwd":               cwd,
+        "initial_sha":       initial_sha,
+        "final_sha":         final_sha,
+        "branch":            branch,
+        "files_touched":     files_touched,
+        "commits_made":      commits_made,
+        "pr_url":            pr_url,
+        "auto_merge_enabled": auto_merge_enabled,
+        # Phase 6 fields:
+        "worktree_used":     worktree_used,
+        "worktree_path":     worktree_path,
+        "worktree_cleanup":  worktree_cleanup_status,
+        "repo_root":         repo_root,
+    }
+    return JSONResponse(status_code=200, content=body)
+
+
+# --- Admin / introspection -------------------------------------------------
+
+@app.get("/admin/sessions")
+def list_sessions(limit: int = 50, status: str | None = None):
+    sql = "SELECT * FROM claude_sessions"
+    args: list[Any] = []
+    if status:
+        sql += " WHERE status=?"
+        args.append(status)
+    sql += " ORDER BY started_at DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"sessions": [dict(r) for r in rows]}
+
+
+@app.get("/admin/sessions/{spawn_id}")
+def get_session(spawn_id: str):
+    row = journal_lookup(spawn_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="not found")
+    return row
+
+
+@app.get("/admin/events")
+def list_events(limit: int = 100, spawn_id: str | None = None):
+    sql = "SELECT * FROM spawner_events"
+    args: list[Any] = []
+    if spawn_id:
+        sql += " WHERE spawn_id=?"
+        args.append(spawn_id)
+    sql += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"events": [dict(r) for r in rows]}
+
+
+@app.get("/metrics", response_class=PlainTextResponse)
+def metrics():
+    with _db_lock:
+        rows = db().execute(
+            "SELECT status, COUNT(*) AS c FROM claude_sessions GROUP BY status"
+        ).fetchall()
+        mode_rows = db().execute(
+            "SELECT permission_mode, COUNT(*) AS c FROM claude_sessions "
+            "WHERE permission_mode IS NOT NULL GROUP BY permission_mode"
+        ).fetchall()
+        pr_rows = db().execute(
+            "SELECT COUNT(*) AS c FROM claude_sessions WHERE pr_url IS NOT NULL"
+        ).fetchall()
+    lines = [
+        "# HELP claude_spawner_sessions_total claude_sessions rows by status",
+        "# TYPE claude_spawner_sessions_total counter",
+    ]
+    for r in rows:
+        lines.append(f'claude_spawner_sessions_total{{status="{r["status"]}"}} {r["c"]}')
+    lines += [
+        "# HELP claude_spawner_sessions_by_mode_total claude_sessions rows by permission_mode",
+        "# TYPE claude_spawner_sessions_by_mode_total counter",
+    ]
+    for r in mode_rows:
+        lines.append(f'claude_spawner_sessions_by_mode_total{{mode="{r["permission_mode"]}"}} {r["c"]}')
+    lines += [
+        "# HELP claude_spawner_auto_prs_total claude_sessions that produced an auto-PR",
+        "# TYPE claude_spawner_auto_prs_total counter",
+        f'claude_spawner_auto_prs_total {pr_rows[0]["c"] if pr_rows else 0}',
+    ]
+    bp, sha = binary_path_and_sha256()
+    lines += [
+        "# HELP claude_spawner_subscription_only 1 if guard passing",
+        "# TYPE claude_spawner_subscription_only gauge",
+        f"claude_spawner_subscription_only 1" if subscription_guard_message() is None
+        else "claude_spawner_subscription_only 0",
+        f'claude_spawner_info{{version="{VERSION}",host_name="{HOST_NAME}",binary_sha256="{sha[:16]}"}} 1',
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# --- Main ------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(
+        "claude_spawner_agent:app",
+        host="0.0.0.0",
+        port=PORT,
+        log_level=LOG_LEVEL.lower(),
+        access_log=True,
+    )

--- a/services/claude-spawner-agent/com.caia.claude-spawner-agent.plist.template
+++ b/services/claude-spawner-agent/com.caia.claude-spawner-agent.plist.template
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  claude-spawner-agent launchd plist template (M1 host-side daemon).
+  Render with sed/envsubst (substituting the placeholders below), then install:
+    launchctl load   ~/Library/LaunchAgents/com.caia.claude-spawner-agent.plist
+    launchctl unload ~/Library/LaunchAgents/com.caia.claude-spawner-agent.plist
+
+  Placeholders (substituted at install time — see services/claude-spawner-agent/README.md):
+    CLAUDE_SPAWNER_VENV    absolute path to the python venv (e.g. ~/.caia/spawner-venv)
+    CLAUDE_SPAWNER_REPO    absolute path to a checkout of the caia repo on this host
+                           (so the daemon resolves services/claude-spawner-agent/claude_spawner_agent.py)
+    CLAUDE_SPAWNER_LOG_DIR absolute path to the log directory (e.g. ~/Documents/conductor-logs)
+    SLOT_MANAGER_BASE_URL  http://STOLUTION-HOST:PORT  (slot-manager API URL)
+    CLAUDE_BINARY          absolute path to the `claude` CLI (e.g. /opt/homebrew/bin/claude)
+    ALLOWED_ROOT           absolute path that bounds the add-dir allowlist (e.g. ~/Documents/projects)
+    NODE_BIN_PATH          PATH prefix that includes node (homebrew/local)
+
+  Subscription guard:
+    ANTHROPIC_API_KEY is INTENTIONALLY NOT set here. The spawner strips it from
+    the subprocess env on every call. The zero-dollar rule is non-negotiable.
+
+  Process control:
+    KeepAlive: true        — restart on crash.
+    RunAtLoad: true        — start on user login.
+    ThrottleInterval: 10   — minimum 10s between restarts to prevent crash loops.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.caia.claude-spawner-agent</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>CLAUDE_SPAWNER_VENV/bin/python</string>
+    <string>-m</string>
+    <string>uvicorn</string>
+    <string>claude_spawner_agent:app</string>
+    <string>--host</string>
+    <string>127.0.0.1</string>
+    <string>--port</string>
+    <string>7780</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>CLAUDE_SPAWNER_REPO/services/claude-spawner-agent</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>NODE_BIN_PATH:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    <key>SLOT_MANAGER_BASE_URL</key>
+    <string>SLOT_MANAGER_BASE_URL</string>
+    <key>CLAUDE_BINARY</key>
+    <string>CLAUDE_BINARY</string>
+    <key>ALLOWED_ROOT</key>
+    <string>ALLOWED_ROOT</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>CLAUDE_SPAWNER_LOG_DIR/claude-spawner-agent.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>CLAUDE_SPAWNER_LOG_DIR/claude-spawner-agent.err.log</string>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+</dict>
+</plist>

--- a/services/claude-spawner-agent/local_llm_router_client.py
+++ b/services/claude-spawner-agent/local_llm_router_client.py
@@ -1,0 +1,301 @@
+"""
+Python client for the local-llm-router HTTP daemon.
+
+Vendored copy lives next to claude_spawner_agent.py on each spawner host:
+  - M3 spawner:        ~/Documents/projects/reports/claude-spawner-agent/
+  - stolution spawner: /home/s903/apps/claude-spawner/
+
+Pure stdlib (urllib.request) — no pip deps to add to the spawner venv.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_BASE_URL = os.environ.get("LOCAL_LLM_ROUTER_URL", "http://100.68.247.58:7411")
+DEFAULT_TIMEOUT = float(os.environ.get("LOCAL_LLM_ROUTER_TIMEOUT", "10.0"))
+
+
+@dataclass
+class IntentResult:
+    intent: str
+    confidence: float
+    needs_escalation: bool
+    recommended_tier: str  # 'local-7b' | 'local-14b' | 'local-32b' | 'claude' | 'stolution-batch'
+    reasoning: str
+    latency_ms: int
+    classifier_model: str
+
+    @property
+    def use_local(self) -> bool:
+        return self.recommended_tier.startswith("local-")
+
+    @property
+    def passthrough_to_claude(self) -> bool:
+        return self.recommended_tier == "claude"
+
+
+def classify(task_spec: str, base_url: str = DEFAULT_BASE_URL,
+             timeout: float = DEFAULT_TIMEOUT) -> Optional[IntentResult]:
+    """Classify a task spec via the router daemon. Returns None on any failure
+    (caller should default to claude path on None)."""
+    body = json.dumps({"task_spec": task_spec}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/intent",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+        return None
+    return IntentResult(
+        intent=payload.get("intent", "unknown"),
+        confidence=float(payload.get("confidence", 0.0)),
+        needs_escalation=bool(payload.get("needs_escalation", True)),
+        recommended_tier=payload.get("recommended_tier", "claude"),
+        reasoning=payload.get("reasoning", ""),
+        latency_ms=int(payload.get("latency_ms", 0)),
+        classifier_model=payload.get("classifier_model", "unknown"),
+    )
+
+
+def execute_local(task_spec: str, recommended_tier: str,
+                  base_url: str = DEFAULT_BASE_URL,
+                  timeout: float = 60.0) -> Optional[str]:
+    """Execute a task on the local model via /v1/chat/completions. Returns the
+    response string, or None on failure (caller falls back to claude binary)."""
+    # Map tier to model
+    model = {
+        "local-7b": "qwen2.5-coder:7b",
+        "local-14b": "qwen2.5-coder:14b",
+        "local-32b": "qwen2.5-coder:32b",
+    }.get(recommended_tier, "qwen2.5-coder:7b")
+    body = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": task_spec}],
+        "caia_task_type": "spawner-routed",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError):
+        return None
+    choices = payload.get("choices", [])
+    if not choices:
+        return None
+    return choices[0].get("message", {}).get("content")
+
+
+def health(base_url: str = DEFAULT_BASE_URL, timeout: float = 3.0) -> bool:
+    """Quick health probe — returns True if daemon is reachable + healthy."""
+    try:
+        with urllib.request.urlopen(f"{base_url}/healthz", timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+            return bool(payload.get("ok") and payload.get("ollama", {}).get("ok"))
+    except Exception:
+        return False
+
+
+# ───────────────────────── prompt optimizer ───────────────────────────────
+# LAI phase 7: spawner escalation path must run the prompt through the
+# 3-stage optimizer (rule-prepass → tool-output-summarize → token-prune)
+# before invoking the claude binary. We try the router daemon's
+# /v1/optimize endpoint first (it dispatches the TS @chiefaia/prompt-optimizer
+# pipeline). If the endpoint isn't deployed yet — older router versions —
+# we fall back to a pure-Python rule-based prepass that mirrors stage 1.
+# The fallback never reaches stage 2/3, so compression is modest (~10-25%)
+# but the path stays unblocked and the spawn record honestly tags the
+# `backend` so dashboards can distinguish full-pipeline vs prepass-only.
+
+_WHITESPACE_RUN_RE = re.compile(r"[ \t]{2,}")
+_BLANK_LINES_RE = re.compile(r"\n{3,}")
+_TRAILING_WS_RE = re.compile(r"[ \t]+\n")
+
+
+def _estimate_tokens(text: str) -> int:
+    """Cheap ~4-chars-per-token estimate. Matches the TS optimizer's
+    `estimateTokens()` so spawn-record numbers line up with router metrics."""
+    if not text:
+        return 0
+    return max(1, (len(text) + 3) // 4)
+
+
+def _stage1_prepass_inline(text: str) -> str:
+    """Pure-Python mirror of @chiefaia/prompt-optimizer stage1Prepass for the
+    fallback path. Collapses runs of whitespace and blank lines; strips
+    trailing space. Intentionally does NOT touch fenced code blocks or
+    backticked spans heuristically — we accept slightly lower compression
+    for safety in the fallback (the real optimizer has protected-span logic
+    we don't try to reproduce here)."""
+    if not text:
+        return text
+    out = _TRAILING_WS_RE.sub("\n", text)
+    out = _WHITESPACE_RUN_RE.sub(" ", out)
+    out = _BLANK_LINES_RE.sub("\n\n", out)
+    return out.strip()
+
+
+def optimize_prompt(prompt: str,
+                    system_prompt: Optional[str] = None,
+                    base_url: str = DEFAULT_BASE_URL,
+                    timeout: float = 30.0) -> tuple[str, dict]:
+    """Run a prompt through the optimizer before claude escalation.
+
+    Returns (optimized_prompt, metrics) where `metrics` always contains:
+      - backend:        'router-v1-optimize' | 'inline-stage1' | 'noop'
+      - pre_token_count, post_token_count, compression_ratio
+      - stages_run:     list[str] (e.g. ['stage1','stage2','stage3'] or ['stage1'])
+      - wall_ms:        wall-clock duration
+      - error:          str | None  (set on partial failure; result still safe to use)
+
+    The function never raises — on any failure, returns the original prompt
+    with backend='noop'. This is critical: the spawner must always have a
+    runnable prompt to hand to the claude binary."""
+    t0 = time.time()
+    pre_tokens = _estimate_tokens(prompt) + _estimate_tokens(system_prompt or "")
+
+    # Path 1 — router daemon's /v1/optimize endpoint (preferred).
+    body = json.dumps({
+        "prompt": prompt,
+        "system_prompt": system_prompt or "",
+        "caller": "claude-spawner",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/optimize",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.loads(r.read().decode("utf-8"))
+        optimized = payload.get("optimized_prompt") or payload.get("prompt") or prompt
+        m = payload.get("metrics", {})
+        post_tokens = int(m.get("post_token_count") or _estimate_tokens(optimized))
+        return optimized, {
+            "backend": "router-v1-optimize",
+            "pre_token_count": int(m.get("pre_token_count") or pre_tokens),
+            "post_token_count": post_tokens,
+            "compression_ratio": (post_tokens / pre_tokens) if pre_tokens else 1.0,
+            "stages_run": m.get("stages_run") or ["stage1", "stage2", "stage3"],
+            "wall_ms": int((time.time() - t0) * 1000),
+            "error": None,
+        }
+    except (urllib.error.HTTPError, urllib.error.URLError,
+            TimeoutError, json.JSONDecodeError):
+        # 404 = endpoint not deployed yet (older router); URLError = router
+        # offline; JSON errors = malformed response. All fall through to
+        # the pure-Python stage-1 path below.
+        pass
+    except Exception:
+        pass
+
+    # Path 2 — inline pure-Python stage 1 prepass (fallback).
+    try:
+        opt_system = _stage1_prepass_inline(system_prompt or "")
+        opt_user = _stage1_prepass_inline(prompt)
+        optimized = (opt_system + "\n\n" + opt_user).strip() if opt_system else opt_user
+        post_tokens = _estimate_tokens(optimized)
+        return optimized, {
+            "backend": "inline-stage1",
+            "pre_token_count": pre_tokens,
+            "post_token_count": post_tokens,
+            "compression_ratio": (post_tokens / pre_tokens) if pre_tokens else 1.0,
+            "stages_run": ["stage1"],
+            "wall_ms": int((time.time() - t0) * 1000),
+            "error": None,
+        }
+    except Exception as e:
+        # Path 3 — true no-op. Hand the original prompt back unchanged.
+        return prompt, {
+            "backend": "noop",
+            "pre_token_count": pre_tokens,
+            "post_token_count": pre_tokens,
+            "compression_ratio": 1.0,
+            "stages_run": [],
+            "wall_ms": int((time.time() - t0) * 1000),
+            "error": f"{type(e).__name__}: {e}",
+        }
+
+
+def classify_and_maybe_route(task_spec: str,
+                              base_url: str = DEFAULT_BASE_URL,
+                              max_local_latency_s: float = 90.0) -> tuple[Optional[str], dict]:
+    """High-level helper for spawners.
+
+    Returns (local_response, metadata):
+      - If local can handle: (response_text, {model: ..., tier: ..., classifier_latency_ms: ..., exec_latency_ms: ...})
+      - If must escalate to claude: (None, {tier: 'claude', reason: ...})
+
+    Metadata is always populated for spawn-record write-through.
+    """
+    t0 = time.time()
+    intent = classify(task_spec, base_url=base_url)
+    if intent is None:
+        return None, {"tier": "claude", "reason": "router-unreachable"}
+    if intent.passthrough_to_claude or intent.needs_escalation:
+        return None, {
+            "tier": "claude",
+            "reason": f"router-recommends-claude (intent={intent.intent}, conf={intent.confidence:.2f})",
+            "classifier_latency_ms": intent.latency_ms,
+            "classifier_model": intent.classifier_model,
+        }
+    if not intent.use_local:
+        return None, {"tier": intent.recommended_tier, "reason": "non-local-non-claude-tier"}
+    # Try local execution
+    response = execute_local(task_spec, intent.recommended_tier,
+                              base_url=base_url, timeout=max_local_latency_s)
+    if response is None:
+        return None, {
+            "tier": "claude",
+            "reason": "local-execute-failed",
+            "intended_tier": intent.recommended_tier,
+            "classifier_latency_ms": intent.latency_ms,
+        }
+    return response, {
+        "tier": intent.recommended_tier,
+        "model": {
+            "local-7b": "qwen2.5-coder:7b",
+            "local-14b": "qwen2.5-coder:14b",
+            "local-32b": "qwen2.5-coder:32b",
+        }.get(intent.recommended_tier, "qwen2.5-coder:7b"),
+        "classifier_latency_ms": intent.latency_ms,
+        "exec_latency_ms": int((time.time() - t0) * 1000) - intent.latency_ms,
+        "intent": intent.intent,
+        "confidence": intent.confidence,
+        "claude_invoked": False,
+    }
+
+
+if __name__ == "__main__":
+    # CLI smoke test
+    import sys
+    spec = sys.argv[1] if len(sys.argv) > 1 else "Rename foo to bar in helpers.ts"
+    print(f"healthz: {health()}")
+    intent = classify(spec)
+    print(f"intent: {intent}")
+    response, meta = classify_and_maybe_route(spec)
+    print(f"response: {response}")
+    print(f"meta: {meta}")
+    # LAI phase 7: exercise the optimizer path even when classify routes
+    # to claude — this is the spawner escalation flow.
+    opt_text, opt_meta = optimize_prompt(spec)
+    print(f"optimize backend: {opt_meta['backend']} "
+          f"pre={opt_meta['pre_token_count']} post={opt_meta['post_token_count']} "
+          f"ratio={opt_meta['compression_ratio']:.3f}")

--- a/services/claude-spawner-agent/m1-deployment-bundle/README.md
+++ b/services/claude-spawner-agent/m1-deployment-bundle/README.md
@@ -1,0 +1,35 @@
+# m1-deployment-bundle (placeholder)
+
+This directory is reserved for the full M1-host deployment bundle of `claude-spawner-agent`
+(install.sh, uninstall.sh, version.txt, signed-launchd helpers, etc.).
+
+## Why a placeholder?
+
+B2 migrated from a stolution (Linux) worker because the parallel B-chain on M3 had not
+yet reached this phase. The full M1-side deployment bundle lives on M3 at
+`~/Documents/projects/reports/claude-spawner-agent/m1-deployment-bundle/` and could not
+be relocated byte-for-byte from a stolution worker without a stolution-readable mirror
+of the bundle. Filing this README to mark the slot for the operator follow-up.
+
+## OPERATOR_ACTION_REQUIRED
+
+After this PR merges, the operator must:
+
+1. On M3, copy the existing `m1-deployment-bundle/` contents into
+   `services/claude-spawner-agent/m1-deployment-bundle/` and commit a follow-up PR.
+2. Until that PR lands, M1 hosts install `claude-spawner-agent` via the manual steps
+   documented in the parent `README.md` (clone → venv → pip → render plist → launchctl
+   load). The manual path is fully functional; the deployment bundle is a convenience
+   wrapper, not a runtime dependency.
+
+## What is intentionally NOT in this bundle
+
+- `ANTHROPIC_API_KEY` — the spawner strips it from subprocess env on every call. The
+  zero-dollar rule (`feedback_no_api_key_billing.md`) is non-negotiable.
+- Any subscription-cost dependency (paid SaaS, paid API, paid hosting).
+
+## Tracking
+
+Filed against integration-remediation plan §B Phase B2, AR-3 invariant. This placeholder
+is gated by the operator follow-up listed in the PR description's `OPERATOR_ACTION_REQUIRED`
+section.

--- a/services/claude-spawner-agent/package.json
+++ b/services/claude-spawner-agent/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@caia/services-claude-spawner-agent",
+  "version": "0.5.0",
+  "private": true,
+  "description": "claude-spawner-agent — Host-Side Spawner Daemon (Phase 5). Python/FastAPI daemon installed on each M1/Mac host that hosts a claude-binary spawn capacity. Sibling to services/slot-manager/.",
+  "scripts": {
+    "smoke": "bash smoke.sh"
+  }
+}

--- a/services/claude-spawner-agent/requirements.txt
+++ b/services/claude-spawner-agent/requirements.txt
@@ -1,0 +1,5 @@
+# claude-spawner-agent (Phase 5) — Python service dependencies
+# Pin minor versions; allow patch upgrades for security fixes.
+fastapi==0.115.*
+uvicorn[standard]==0.32.*
+httpx==0.28.*

--- a/services/claude-spawner-agent/smoke.sh
+++ b/services/claude-spawner-agent/smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# claude-spawner-agent smoke test.
+#
+# Runs:
+#   1. python -m py_compile on every source module.
+#   2. com.caia.claude-spawner-agent.plist.template parses as XML.
+#   3. each module imports (spawner_argv → local_llm_router_client → claude_spawner_agent).
+#
+# Used by .github/workflows/services-smoke.yml on every PR that touches
+# services/claude-spawner-agent/**.
+#
+# Local invocation:
+#   cd services/claude-spawner-agent
+#   pip install -r requirements.txt
+#   bash smoke.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "==> py_compile sources"
+for f in claude_spawner_agent.py local_llm_router_client.py spawner_argv.py; do
+  python3 -m py_compile "$f"
+  echo "    ✓ $f"
+done
+
+echo "==> plist template XML sanity"
+test -s com.caia.claude-spawner-agent.plist.template || {
+  echo "    ✗ plist template missing or empty"; exit 1; }
+python3 - <<'PY'
+import xml.etree.ElementTree as ET
+ET.parse("com.caia.claude-spawner-agent.plist.template")
+print("    ✓ plist template parses as XML")
+PY
+
+echo "==> import smoke"
+# claude_spawner_agent imports `from spawner_argv import build_claude_argv`
+# and `from local_llm_router_client import (…)`. cwd-based PYTHONPATH lets the
+# imports resolve against the sibling files in this directory.
+PYTHONPATH=".:${PYTHONPATH:-}" python3 -c "
+import spawner_argv
+import local_llm_router_client
+import claude_spawner_agent
+print('    ✓ spawner_argv imports')
+print('    ✓ local_llm_router_client imports')
+print('    ✓ claude_spawner_agent imports')
+"
+
+echo ""
+echo "claude-spawner-agent smoke: PASS"

--- a/services/claude-spawner-agent/spawner_argv.py
+++ b/services/claude-spawner-agent/spawner_argv.py
@@ -1,0 +1,87 @@
+"""Build the subprocess argv for invoking the claude binary.
+
+Standalone module (zero non-stdlib deps) so the unit-test suite under
+`packages/local-llm-router-py-client/tests/` can exercise the argv logic
+without dragging in fastapi / sqlite / the rest of the spawner agent.
+
+SPS-Prompting phase α (2026-05-14) wires two substrate-level optimizations
+onto every spawn:
+
+  * A.9.3  headroom wrap → routes Anthropic API calls through a local
+           compression proxy when ``HEADROOM_BINARY`` exists on disk.
+           Bypassed (fail-open) if ``HEADROOM_WRAP_DISABLE=1`` is set or
+           the binary is missing — keeps stolution (no headroom yet)
+           working without a code-divergence between the two boxes.
+
+  * A.9.6  KV-cache prefix stabilization → adds
+           ``--exclude-dynamic-system-prompt-sections`` to the claude
+           argv so per-machine sections (cwd, env, memory paths, git
+           status) move out of the cached system prefix into the first
+           user message. Required for Anthropic's 90% prompt-cache
+           discount to apply across spawns. Bypassed if
+           ``STABILIZE_PREFIX_DISABLE=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Sequence
+
+
+def build_claude_argv(
+    prompt: str,
+    *,
+    permission_mode: str,
+    allow_list: Sequence[str],
+    claude_binary: str,
+    permission_mode_max_turns: Mapping[str, int],
+    headroom_binary: str = "",
+    headroom_wrap_disable: bool = False,
+    headroom_proxy_port: int = 8787,
+    headroom_proxy_offset: int = 0,
+    headroom_reuse_proxy: bool = False,
+    stabilize_prefix_disable: bool = False,
+    binary_exists: "callable" = os.path.exists,
+) -> tuple[list[str], bool, bool]:
+    """Return ``(argv, headroom_wrapped, prefix_stabilized)``.
+
+    All knobs are passed as parameters so the unit tests can drive the
+    decision tree deterministically; ``binary_exists`` is injectable so
+    the headroom-present check is testable without touching the
+    filesystem.
+    """
+    base_args: list[str] = [
+        "--print",
+        prompt,
+        "--output-format", "json",
+        "--permission-mode", permission_mode,
+    ]
+    max_turns = permission_mode_max_turns.get(permission_mode)
+    if max_turns is not None:
+        base_args += ["--max-turns", str(max_turns)]
+    for p in allow_list:
+        base_args += ["--add-dir", p]
+
+    prefix_stabilized = not stabilize_prefix_disable
+    if prefix_stabilized:
+        base_args.append("--exclude-dynamic-system-prompt-sections")
+
+    use_wrap = (
+        not headroom_wrap_disable
+        and bool(headroom_binary)
+        and binary_exists(headroom_binary)
+    )
+    if use_wrap:
+        port = headroom_proxy_port + headroom_proxy_offset
+        wrap_args = [
+            headroom_binary, "wrap", "claude",
+            "--port", str(port),
+            "--no-mcp",
+            "--no-serena",
+            "--no-context-tool",
+        ]
+        if headroom_reuse_proxy:
+            wrap_args.append("--no-proxy")
+        return [*wrap_args, "--", *base_args], True, prefix_stabilized
+
+    return [claude_binary, *base_args], False, prefix_stabilized

--- a/services/claude-spawner-agent/spawner_patch_v2.diff
+++ b/services/claude-spawner-agent/spawner_patch_v2.diff
@@ -1,0 +1,170 @@
+# Reference patch v2 for claude_spawner_agent.py
+#
+# Supersedes spawner_patch.diff (v1). v2 adds the LAI phase 7 change:
+# when the pre-spawn classifier routes a task to claude (local can't or
+# shouldn't handle it), the prompt is run through @chiefaia/prompt-optimizer
+# *before* the claude binary is invoked. The optimizer cuts prompt tokens
+# (Stage 1 prepass / Stage 2 tool-output summarize / Stage 3 token-importance
+# prune) and the spawn record captures pre/post token counts so we can
+# verify the savings show up downstream.
+#
+# v2 changes from v1:
+#   - Import `optimize_prompt` from local_llm_router_client (alongside
+#     existing classify_and_maybe_route + health imports).
+#   - In the /spawn handler, after the v1 classify-and-maybe-route gate
+#     falls through to claude (`local_response is None`), run the prompt
+#     through `optimize_prompt(task_spec_str, system_prompt=None,
+#     base_url=ROUTER_URL)` IF the router is healthy. The optimizer never
+#     raises — worst case it returns the original prompt with
+#     backend='noop', so the claude path stays unblocked.
+#   - The subprocess invocation receives the optimized prompt (stdin to
+#     `claude --print`) instead of the original `task_spec`.
+#   - Spawn record gains:
+#         optimizer_backend         'router-v1-optimize' | 'inline-stage1' | 'noop' | 'skipped'
+#         optimizer_pre_tokens      int — estimated tokens before optimize
+#         optimizer_post_tokens     int — estimated tokens after optimize
+#         optimizer_compression     float — post/pre (≤1.0 is win)
+#         optimizer_stages_run      list[str] — e.g. ['stage1','stage2','stage3']
+#         optimizer_wall_ms         int — wall-clock the optimizer took
+#         optimizer_error           str | None
+#     Existing fields are unchanged. A new env knob `OPTIMIZER_ENABLED`
+#     (default true) lets us disable the optimizer step independently of
+#     the router gate.
+#
+# DO NOT auto-apply — operator review required. This is a reference patch.
+# The real spawner is ~1800 lines; the hunks below show the intent and
+# exact lines to add against the v1-patched source tree. Apply by hand or
+# adapt as a code-review checklist.
+#
+# Apply (after v1 is already applied) with:
+#   cd <spawner-dir>
+#   patch -p0 < spawner_patch_v2.diff
+# Or, if applying fresh on top of unpatched upstream, apply v1 first then v2.
+#
+# Smoke test post-deploy:
+#   1. Restart spawner: systemctl --user restart claude-spawner-agent
+#   2. Send synthetic escalating /spawn (see deploy_v2.sh in same dir).
+#   3. Verify the spawn DB row has optimizer_* fields populated AND
+#      `model_used` is the claude binary (not local). pre_tokens should
+#      be > post_tokens (or equal, for the inline-stage1 fallback path).
+
+--- claude_spawner_agent.py
++++ claude_spawner_agent.py
+@@ -1,7 +1,7 @@
+ #!/usr/bin/env python3
+ import asyncio
+ import json
+ import os
+ import subprocess
+ import time
+ import uuid
+-from local_llm_router_client import classify_and_maybe_route, health
++from local_llm_router_client import classify_and_maybe_route, health, optimize_prompt
+@@ -10,8 +10,11 @@ CLAUDE_BINARY = os.environ.get("CLAUDE_BINARY", "/opt/homebrew/bin/claude")
+ ROUTER_URL = os.environ.get("LOCAL_LLM_ROUTER_URL", "http://100.68.247.58:7411")
+ ROUTER_GATE_ENABLED = os.environ.get("ROUTER_GATE_ENABLED", "true").lower() in ("1", "true", "yes")
++# LAI phase 7: optimizer pre-pass on escalation path. Independent of the
++# router gate so operators can disable it without losing local routing.
++OPTIMIZER_ENABLED = os.environ.get("OPTIMIZER_ENABLED", "true").lower() in ("1", "true", "yes")
++OPTIMIZER_TIMEOUT_S = float(os.environ.get("OPTIMIZER_TIMEOUT_S", "30.0"))
+
+@@ -120,6 +123,7 @@ async def handle_spawn(body: SpawnRequest) -> SpawnResponse:
+     """Spawn a claude subprocess for the given task."""
+     spawn_id = str(uuid.uuid4())
++    optimizer_meta: dict = {"optimizer_backend": "skipped"}
+
+     # ── L9/L10 pre-spawn classify-and-maybe-route gate ─────────────────
+     if ROUTER_GATE_ENABLED and health(ROUTER_URL):
+@@ -148,14 +152,49 @@ async def handle_spawn(body: SpawnRequest) -> SpawnResponse:
+                 output=local_response,
+                 model=route_meta.get("model"),
+             )
+-        # else: route_meta tells us why we're falling through to claude
+-        # (router unreachable, recommends-claude, local-execute-failed, ...)
+-        # The metadata is logged but spawn proceeds to claude as before.
++        # Falling through to claude. v2: run the prompt through the optimizer
++        # so the claude binary sees a tighter context. Optimizer is best-effort
++        # — on any error it returns the original prompt with backend='noop'.
++        # We still hit it even when the router is unhealthy, because
++        # optimize_prompt has its own pure-Python stage-1 fallback path.
++
++    # ── LAI phase 7 optimizer pre-pass ─────────────────────────────────
++    # Run regardless of router gate outcome, as long as the operator hasn't
++    # turned the optimizer off. The /v1/optimize endpoint (if deployed)
++    # returns full 3-stage results; otherwise we degrade to inline stage 1.
++    prompt_for_claude = body.task_spec
++    if OPTIMIZER_ENABLED:
++        try:
++            optimized, opt_meta = optimize_prompt(
++                body.task_spec,
++                system_prompt=getattr(body, "system_prompt", None),
++                base_url=ROUTER_URL,
++                timeout=OPTIMIZER_TIMEOUT_S,
++            )
++            prompt_for_claude = optimized
++            optimizer_meta = {
++                "optimizer_backend": opt_meta.get("backend"),
++                "optimizer_pre_tokens": opt_meta.get("pre_token_count"),
++                "optimizer_post_tokens": opt_meta.get("post_token_count"),
++                "optimizer_compression": opt_meta.get("compression_ratio"),
++                "optimizer_stages_run": opt_meta.get("stages_run"),
++                "optimizer_wall_ms": opt_meta.get("wall_ms"),
++                "optimizer_error": opt_meta.get("error"),
++            }
++        except Exception as e:
++            # optimize_prompt should never raise, but belt-and-suspenders:
++            # never let an optimizer bug kill a spawn.
++            optimizer_meta = {
++                "optimizer_backend": "noop",
++                "optimizer_error": f"{type(e).__name__}: {e}",
++            }
+
+     # ── Existing claude binary spawn (now feeding the optimized prompt) ─
+     proc = subprocess.Popen(
+         [CLAUDE_BINARY, "--print", "--output-format", "json"],
+         stdin=subprocess.PIPE,
+         stdout=subprocess.PIPE,
+         stderr=subprocess.PIPE,
+     )
+-    stdout, stderr = proc.communicate(input=body.task_spec.encode("utf-8"))
++    stdout, stderr = proc.communicate(input=prompt_for_claude.encode("utf-8"))
+@@ -180,6 +219,8 @@ async def handle_spawn(body: SpawnRequest) -> SpawnResponse:
+         "claude_invoked": True,
+         "ts_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+     }
++    # LAI phase 7: merge optimizer metrics into the spawn record.
++    record.update(optimizer_meta)
+     await write_spawn_record(record)
+     return SpawnResponse(
+         spawn_id=spawn_id,
+@@ -201,3 +242,29 @@ async def handle_spawn(body: SpawnRequest) -> SpawnResponse:
+         status="completed",
+         output=stdout.decode("utf-8", errors="replace"),
+         model="claude",
+     )
++
++
++# ────────────────────────────────────────────────────────────────────────
++# Notes on schema migration:
++#
++# The journal/spawner.db schema needs to gain the optimizer_* columns. Two
++# options the operator can pick from at deploy time:
++#
++#   (a) ALTER TABLE on first restart — add a startup hook that runs:
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_backend TEXT;
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_pre_tokens INTEGER;
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_post_tokens INTEGER;
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_compression REAL;
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_stages_run TEXT;
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_wall_ms INTEGER;
++#       ALTER TABLE spawn_records ADD COLUMN optimizer_error TEXT;
++#       (Each guarded by a "column already exists" check.)
++#
++#   (b) Stash the whole optimizer_meta blob into a single existing
++#       `extras_json TEXT` column if one exists, and parse downstream.
++#
++# The reference patch above uses `record.update(optimizer_meta)` which
++# accommodates either approach — the on-disk writer is responsible for
++# matching dict keys to columns. For stolution's spawner this maps via
++# the existing `journal_finalize()` helper; verify it accepts unknown
++# keys (it does today, as kwargs into a dict) before flipping the env knob.

--- a/services/slot-manager/.gitignore
+++ b/services/slot-manager/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.db
+*.db-shm
+*.db-wal
+data/

--- a/services/slot-manager/README.md
+++ b/services/slot-manager/README.md
@@ -1,0 +1,57 @@
+# slot-manager — Self-Driving Slot Allocator (Phase 4)
+
+Canonical source for the slot-manager service. Python 3.11 / FastAPI; deployed in the K3s
+`caia-orchestrator` namespace. The autonomous loop polls SPS for ready work, claims slots
+up to per-bucket capacity, dispatches the spec to a registered claude-spawner-agent host,
+and releases the slot when the spawn returns — all without operator triggers.
+
+## Layout
+
+| File              | Role                                                                                                  |
+|-------------------|-------------------------------------------------------------------------------------------------------|
+| `slot_manager.py` | FastAPI app — autonomous loop, /spawn-task, admin endpoints, lineage, retry/dead-letter, circuit-break |
+| `schema.sql`      | SQLite WAL schema (Phases 0/1/2/4/5; idempotent hot-rollout)                                          |
+| `requirements.txt`| Python dependencies (pinned to minor)                                                                 |
+| `smoke.sh`        | Smoke test: syntax-check + schema-apply (in-memory SQLite) + import-test                              |
+| `package.json`    | `pnpm -F @caia/services-slot-manager run smoke` wrapper                                               |
+
+## Runtime contract
+
+- SQLite WAL DB at `${SLOT_MANAGER_DB_PATH}` (default `/app/data/slot-manager.db`).
+- Schema applied from `${SCHEMA_PATH}` (default `/app/src/schema.sql`).
+- Per-bucket autonomy defaults to **OFF** (operator opts in via `/admin/autonomy`).
+- Global autonomy defaults to **ON**.
+- Subscription guard non-negotiable (zero-dollar rule, `feedback_no_api_key_billing.md`).
+  All four layers (slot-manager startup + per-call, spawner startup + per-call) are
+  active; `ANTHROPIC_API_KEY` is treated as a red flag.
+
+## Source-history continuity
+
+Before 2026-05-15 the Phase 4/5 source lived outside the caia monorepo at:
+
+    ~/Documents/projects/reports-from-m1/slot-manager-artifacts/phase5/
+
+That directory remains intact on M3 for historical reference; this directory is the live
+source from B2 migration (PR `feat/b2-slot-manager-spawner-migrate-2026-05-15`) onward.
+The migration was source-relocate only — no code edits, no re-architecture. See
+`reports/integration_b2_slot_manager_migrate_2026-05-15.md` for the migration report.
+
+## Sibling service
+
+`services/claude-spawner-agent/` is the M1-side daemon that this slot-manager dispatches
+to. The two co-evolved (slot-manager defines the wire contract; claude-spawner-agent is
+the host-side executor). They are migrated together in B2.
+
+## K3s
+
+K3s ConfigMap continues to mount the canonical schema + source from this directory
+(`slot-manager-src` ConfigMap). The deploy manifest will land in a follow-up B-chain phase
+(per integration-remediation plan §B Phase B3 / B4). Until then, the existing manifest
+sources from the prior path and operator must update the ConfigMap reference in step
+with the merge of this PR.
+
+## CI
+
+A path-filtered smoke workflow at `.github/workflows/services-smoke.yml` runs on every PR
+that touches `services/slot-manager/**`. The workflow invokes `bash smoke.sh` in this
+directory.

--- a/services/slot-manager/package.json
+++ b/services/slot-manager/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@caia/services-slot-manager",
+  "version": "0.4.0",
+  "private": true,
+  "description": "slot-manager — Self-Driving Slot Allocator (Phase 4). Python/FastAPI service deployed to the K3s caia-orchestrator namespace. This directory is the canonical source; the K3s ConfigMap `slot-manager-src` mounts slot_manager.py + schema.sql from here.",
+  "scripts": {
+    "smoke": "bash smoke.sh"
+  }
+}

--- a/services/slot-manager/requirements.txt
+++ b/services/slot-manager/requirements.txt
@@ -1,0 +1,6 @@
+# Slot Manager (Phase 4) — Python service dependencies
+# Pin minor versions; allow patch upgrades for security fixes.
+fastapi==0.115.*
+uvicorn[standard]==0.32.*
+httpx==0.28.*
+PyYAML==6.0.*

--- a/services/slot-manager/schema.sql
+++ b/services/slot-manager/schema.sql
@@ -1,0 +1,294 @@
+-- Slot Manager SQLite Schema (Phase 0 + 1 + 2 + 4 + 5)
+-- WAL mode for durability and concurrency.
+-- Phase 1/2/4/5 deltas are also applied idempotently in
+-- slot_manager._ensure_phase{1,2,4,5}_schema() so a hot rollout against
+-- an existing DB is non-destructive.
+
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA temp_store = MEMORY;
+
+CREATE TABLE IF NOT EXISTS slots (
+  slot_id TEXT PRIMARY KEY,
+  bucket TEXT NOT NULL,
+  index_in_bucket INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  current_task_id TEXT,
+  current_assignment_id TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (bucket, index_in_bucket),
+  CHECK (status IN ('free', 'claimed', 'occupied', 'draining', 'disabled'))
+);
+
+CREATE TABLE IF NOT EXISTS assignments (
+  assignment_id TEXT PRIMARY KEY,
+  slot_id TEXT NOT NULL REFERENCES slots(slot_id),
+  task_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  started_at TIMESTAMP NOT NULL,
+  last_heartbeat_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  exit_status INTEGER,
+  error_message TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (slot_id, assignment_id)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+  event_id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  slot_id TEXT,
+  task_id TEXT,
+  assignment_id TEXT,
+  bucket TEXT,
+  payload TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS spawn_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slot_id TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  task_id TEXT,
+  node_id TEXT,
+  dispatch_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  dispatch_status TEXT NOT NULL,
+  latency_ms INTEGER,
+  sps_latency_ms INTEGER,
+  error_message TEXT,
+  CHECK (dispatch_status IN ('success','error_dispatch','error_sps','timeout','quota_exceeded'))
+);
+
+CREATE TABLE IF NOT EXISTS bucket_health (
+  bucket TEXT PRIMARY KEY,
+  state TEXT NOT NULL,
+  failure_count INTEGER DEFAULT 0,
+  last_failure_at TIMESTAMP,
+  last_recovery_at TIMESTAMP,
+  cool_down_until TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CHECK (state IN ('closed', 'open', 'half-open'))
+);
+
+CREATE TABLE IF NOT EXISTS capacity_changes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  bucket TEXT NOT NULL,
+  old_capacity INTEGER NOT NULL,
+  new_capacity INTEGER NOT NULL,
+  actor TEXT NOT NULL DEFAULT 'unknown',
+  reason TEXT,
+  changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS hosts (
+  name TEXT PRIMARY KEY,
+  spawner_url TEXT NOT NULL,
+  hostname TEXT,
+  version TEXT,
+  state TEXT NOT NULL DEFAULT 'active',
+  registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_heartbeat_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_state_change_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  notes TEXT,
+  CHECK (state IN ('active', 'drain', 'offline', 'disabled'))
+);
+
+CREATE TABLE IF NOT EXISTS spawn_budget (
+  bucket TEXT PRIMARY KEY,
+  max_per_minute INTEGER NOT NULL DEFAULT 4,
+  tokens_remaining REAL NOT NULL DEFAULT 4.0,
+  last_refill_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS spawn_budget_changes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  bucket TEXT NOT NULL,
+  old_max_per_minute INTEGER,
+  new_max_per_minute INTEGER NOT NULL,
+  actor TEXT NOT NULL DEFAULT 'unknown',
+  reason TEXT,
+  changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS spawn_telemetry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  spawn_id TEXT NOT NULL UNIQUE,
+  started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  completed_at TIMESTAMP,
+  duration_ms INTEGER,
+  bucket TEXT,
+  host TEXT,
+  slot_id TEXT,
+  task_id TEXT,
+  spawner_url TEXT,
+  exit_code INTEGER,
+  outcome TEXT NOT NULL DEFAULT 'pending',
+  api_key_guard_passed INTEGER NOT NULL DEFAULT 0,
+  binary_sha256 TEXT,
+  binary_path TEXT,
+  session_id TEXT,
+  model TEXT,
+  error TEXT,
+  CHECK (outcome IN ('pending','ok','dispatch_error','spawner_error','rejected_guard','rejected_budget','rejected_no_host','rejected_drained','timeout','parse_error','interrupted','cap_throttled'))
+);
+
+CREATE TABLE IF NOT EXISTS spawn_lineage (
+  child_spawn_id  TEXT PRIMARY KEY,
+  parent_spawn_id TEXT,
+  parent_task_id  TEXT,
+  child_task_id   TEXT,
+  relation        TEXT NOT NULL,
+  created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  payload         TEXT,
+  CHECK (relation IN ('decomposed-into','retry-of','replay-of','continuation','autonomous-claim'))
+);
+
+CREATE TABLE IF NOT EXISTS spawn_retry_budget (
+  bucket       TEXT NOT NULL,
+  host         TEXT NOT NULL,
+  max_retries  INTEGER NOT NULL DEFAULT 3,
+  backoff_s_csv TEXT NOT NULL DEFAULT '1,2,4',
+  updated_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (bucket, host)
+);
+
+CREATE TABLE IF NOT EXISTS spawn_dead_letter (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  original_spawn_id TEXT NOT NULL,
+  bucket    TEXT,
+  host      TEXT,
+  task_id   TEXT,
+  attempts  INTEGER NOT NULL DEFAULT 1,
+  last_outcome TEXT NOT NULL,
+  last_error TEXT,
+  payload   TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  replayed_at TIMESTAMP,
+  replay_spawn_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS autonomy_state (
+  scope        TEXT PRIMARY KEY,
+  state        TEXT NOT NULL,
+  reason       TEXT,
+  last_tick_at TIMESTAMP,
+  last_claim_at TIMESTAMP,
+  last_changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  actor        TEXT,
+  CHECK (state IN ('on','off','circuit-broken','cap-throttled'))
+);
+
+CREATE TABLE IF NOT EXISTS loop_changes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  scope     TEXT NOT NULL,
+  old_state TEXT,
+  new_state TEXT NOT NULL,
+  actor     TEXT NOT NULL DEFAULT 'unknown',
+  reason    TEXT,
+  changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS host_throttle_state (
+  host          TEXT PRIMARY KEY,
+  cap_event_count INTEGER NOT NULL DEFAULT 0,
+  first_event_at TIMESTAMP,
+  last_event_at  TIMESTAMP,
+  throttled_until TIMESTAMP,
+  updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS loop_tick (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  iterations INTEGER NOT NULL DEFAULT 1,
+  claims INTEGER NOT NULL DEFAULT 0,
+  skips_no_work INTEGER NOT NULL DEFAULT 0,
+  skips_no_slot INTEGER NOT NULL DEFAULT 0,
+  skips_budget INTEGER NOT NULL DEFAULT 0,
+  skips_throttled INTEGER NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_assignments_slot ON assignments(slot_id);
+CREATE INDEX IF NOT EXISTS idx_assignments_task ON assignments(task_id);
+CREATE INDEX IF NOT EXISTS idx_assignments_bucket ON assignments(bucket);
+CREATE INDEX IF NOT EXISTS idx_assignments_heartbeat ON assignments(last_heartbeat_at)
+  WHERE completed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_events_slot ON events(slot_id);
+CREATE INDEX IF NOT EXISTS idx_events_bucket ON events(bucket);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at);
+CREATE INDEX IF NOT EXISTS idx_spawn_log_bucket ON spawn_log(bucket);
+CREATE INDEX IF NOT EXISTS idx_spawn_log_task ON spawn_log(task_id);
+CREATE INDEX IF NOT EXISTS idx_spawn_log_dispatch_time ON spawn_log(dispatch_time);
+CREATE INDEX IF NOT EXISTS idx_capacity_changes_bucket ON capacity_changes(bucket);
+CREATE INDEX IF NOT EXISTS idx_capacity_changes_at ON capacity_changes(changed_at);
+CREATE INDEX IF NOT EXISTS idx_hosts_state ON hosts(state);
+CREATE INDEX IF NOT EXISTS idx_spawn_budget_changes_bucket ON spawn_budget_changes(bucket);
+CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_started ON spawn_telemetry(started_at);
+CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_bucket  ON spawn_telemetry(bucket);
+CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_host    ON spawn_telemetry(host);
+CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_outcome ON spawn_telemetry(outcome);
+CREATE INDEX IF NOT EXISTS idx_lineage_parent ON spawn_lineage(parent_spawn_id);
+CREATE INDEX IF NOT EXISTS idx_lineage_relation ON spawn_lineage(relation);
+CREATE INDEX IF NOT EXISTS idx_dead_letter_bucket ON spawn_dead_letter(bucket);
+CREATE INDEX IF NOT EXISTS idx_dead_letter_host ON spawn_dead_letter(host);
+CREATE INDEX IF NOT EXISTS idx_loop_tick_ts ON loop_tick(ts);
+CREATE INDEX IF NOT EXISTS idx_loop_changes_at ON loop_changes(changed_at);
+
+-- ===================================================================
+-- Phase 5: real-edit mode + path allow-list + risk-tier approval gate.
+-- ===================================================================
+
+CREATE TABLE IF NOT EXISTS bucket_permissions (
+  bucket           TEXT PRIMARY KEY,
+  permission_mode  TEXT NOT NULL DEFAULT 'plan',
+  updated_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  actor            TEXT,
+  reason           TEXT,
+  CHECK (permission_mode IN ('plan','acceptEdits','bypassPermissions'))
+);
+
+CREATE TABLE IF NOT EXISTS bucket_path_allowlists (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  bucket      TEXT NOT NULL,
+  path        TEXT NOT NULL,
+  active      INTEGER NOT NULL DEFAULT 1,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  actor       TEXT,
+  reason      TEXT,
+  UNIQUE (bucket, path)
+);
+
+CREATE TABLE IF NOT EXISTS task_approvals (
+  task_id     TEXT PRIMARY KEY,
+  approved_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at  TIMESTAMP NOT NULL,
+  actor       TEXT NOT NULL DEFAULT 'unknown',
+  reason      TEXT,
+  used_at     TIMESTAMP,
+  used_spawn_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dispatch_risk_log (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  spawn_id        TEXT NOT NULL,
+  task_id         TEXT,
+  bucket          TEXT,
+  risk_tier       TEXT NOT NULL,
+  permission_mode TEXT NOT NULL,
+  classifier      TEXT NOT NULL,
+  approval_used   TEXT,
+  allow_list_json TEXT,
+  created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (risk_tier IN ('low','medium','high'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_bucket_path_allowlists_bucket ON bucket_path_allowlists(bucket);
+CREATE INDEX IF NOT EXISTS idx_task_approvals_expires_at ON task_approvals(expires_at);
+CREATE INDEX IF NOT EXISTS idx_dispatch_risk_log_spawn ON dispatch_risk_log(spawn_id);
+CREATE INDEX IF NOT EXISTS idx_dispatch_risk_log_task ON dispatch_risk_log(task_id);
+CREATE INDEX IF NOT EXISTS idx_dispatch_risk_log_tier ON dispatch_risk_log(risk_tier);

--- a/services/slot-manager/slot_manager.py
+++ b/services/slot-manager/slot_manager.py
@@ -1,0 +1,4023 @@
+"""
+Slot Manager — Phase 4
+======================
+Phase 4 makes slot-manager self-driving. The autonomous loop polls SPS for
+ready work, self-claims slots up to per-bucket capacity, dispatches the
+spec to the registered host, and releases the slot when the spawn returns
+— all without operator triggers. The full backlog drains without anyone
+tapping `curl`.
+
+Phase 4 deltas vs Phase 2
+-------------------------
+1.  Autonomous spawn loop. New background task `autonomous_loop_task` runs
+    every LOOP_INTERVAL_SEC. Per tick, for each bucket whose autonomy
+    state is 'on' AND has free slots AND has spawn-budget tokens AND has
+    an active host: pull a spec from SPS, claim a slot internally,
+    dispatch via the refactored /spawn-task code path, post completion
+    to SPS, release the slot internally. asyncio.gather per bucket so a
+    slow Mac spawn (real-work prompts can be 5+ min) does not starve
+    other buckets. Default per-bucket state: OFF (operator opts in).
+    Default global state: ON.
+
+2.  /admin/spawn-completion callback. Idempotent on `spawn_id`. Closes
+    the loop on spawner-side restarts.
+
+3.  Spawn lineage. New `spawn_lineage` table + GET /spawn-lineage/{spawn_id}.
+
+4.  Spawn retry budget + dead-letter. Autonomous loop auto-retries
+    transient outcomes with exponential backoff. On exhaustion, writes
+    `spawn_dead_letter` rows. Replay endpoint surfaces them.
+
+5.  Subscription cap awareness. Per-host throttle counter. 3+ cap events
+    in 5 min → host marked `cap-throttled` for the reset window.
+
+6.  Loop instrumentation + circuit breaker.
+
+7.  /admin/autonomy admin surface, audited via `loop_changes`.
+
+Stop conditions
+---------------
+* Subscription guard tripped on any layer → ABORT loop globally, record
+  `circuit-broken`. The zero-dollar rule (feedback_no_api_key_billing.md)
+  is non-negotiable.
+* Loop claim rate > LOOP_CIRCUIT_BREAK_PER_SEC sustained for
+  LOOP_CIRCUIT_BREAK_WINDOW_SEC → global loop circuit-broken.
+* All hosts simultaneously cap-throttled → loop pauses, surfaces.
+* SPS returns malformed task spec → outcome=`parse_error`, surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import sqlite3
+import sys
+import threading
+import time
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+LOG_LEVEL              = os.environ.get("LOG_LEVEL", "INFO").upper()
+SQLITE_PATH            = os.environ.get("SQLITE_PATH", "/data/slot-manager.db")
+SCHEMA_PATH            = os.environ.get("SCHEMA_PATH", "/app/src/schema.sql")
+CONFIG_PATH            = os.environ.get("CONFIG_PATH", "/app/config/slot-config.yaml")
+
+HEARTBEAT_TIMEOUT_SEC  = int(os.environ.get("HEARTBEAT_TIMEOUT_SEC", "900"))
+WATCHDOG_INTERVAL_SEC  = int(os.environ.get("WATCHDOG_INTERVAL_SEC", "60"))
+LEASE_TTL_SEC          = int(os.environ.get("LEASE_TTL_SEC", "3600"))
+HOST_OFFLINE_AFTER_SEC = int(os.environ.get("HOST_OFFLINE_AFTER_SEC", "300"))
+
+SPS_BASE_URL           = os.environ.get(
+    "SPS_BASE_URL", "http://sps.caia-orchestrator.svc.cluster.local:8080")
+SPS_TIMEOUT_SEC        = float(os.environ.get("SPS_TIMEOUT_SEC", "5"))
+SPS_ENABLED            = os.environ.get("SPS_ENABLED", "1") not in ("0", "false", "False", "")
+
+SPAWN_TIMEOUT_SEC      = float(os.environ.get("SPAWN_TIMEOUT_SEC", "1200"))  # Phase 6 fix: 20-min default to allow real-edit dispatches to commit + push before SIGTERM
+DEFAULT_SPAWN_MAX_PER_MIN = int(os.environ.get("DEFAULT_SPAWN_MAX_PER_MIN", "4"))
+
+# Phase 4: autonomous loop knobs.
+LOOP_INTERVAL_SEC               = float(os.environ.get("LOOP_INTERVAL_SEC", "10"))
+LOOP_GLOBAL_DEFAULT             = os.environ.get("LOOP_GLOBAL_DEFAULT", "on")
+LOOP_PER_BUCKET_DEFAULT         = os.environ.get("LOOP_PER_BUCKET_DEFAULT", "off")
+LOOP_CIRCUIT_BREAK_PER_SEC      = float(os.environ.get("LOOP_CIRCUIT_BREAK_PER_SEC", "1.0"))
+LOOP_CIRCUIT_BREAK_WINDOW_SEC   = int(os.environ.get("LOOP_CIRCUIT_BREAK_WINDOW_SEC", "60"))
+LOOP_QUIET_LOG_INTERVAL_SEC     = int(os.environ.get("LOOP_QUIET_LOG_INTERVAL_SEC", "60"))
+LOOP_RECENT_TICKS_FOR_RATE      = int(os.environ.get("LOOP_RECENT_TICKS_FOR_RATE", "12"))
+LOOP_AUDIT_TRIM_AFTER           = int(os.environ.get("LOOP_AUDIT_TRIM_AFTER", "5000"))
+LOOP_FANOUT_CAP_PER_BUCKET      = int(os.environ.get("LOOP_FANOUT_CAP_PER_BUCKET", "16"))
+
+# Phase 4: subscription cap throttle.
+CAP_EVENT_THRESHOLD  = int(os.environ.get("CAP_EVENT_THRESHOLD", "3"))
+CAP_EVENT_WINDOW_SEC = int(os.environ.get("CAP_EVENT_WINDOW_SEC", "300"))
+CAP_RESET_WINDOW_SEC = int(os.environ.get("CAP_RESET_WINDOW_SEC", "1800"))
+
+# Phase 4: retry budget + dead-letter.
+DEFAULT_RETRY_MAX        = int(os.environ.get("DEFAULT_RETRY_MAX", "3"))
+DEFAULT_RETRY_BACKOFF_S  = os.environ.get("DEFAULT_RETRY_BACKOFF_S", "1,2,4")
+
+# Histogram buckets in seconds for slot_spawn_duration_seconds.
+SPAWN_DURATION_BUCKETS_S = [0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0]
+
+# slot-manager bucket → SPS bucket aliases (Phase 2 absorbs these)
+SPS_BUCKET_ALIASES: dict[str, str] = {
+    "M1":        os.environ.get("SPS_ALIAS_M1",        "M1-cowork"),
+    "M3":        os.environ.get("SPS_ALIAS_M3",        "M3-cowork"),
+    "stolution": os.environ.get("SPS_ALIAS_STOLUTION", "stolution-claude"),
+}
+
+# Default host name per bucket. Configurable via slot-config.yaml `buckets.<b>.host`.
+DEFAULT_HOST_FOR_BUCKET = {
+    "M1":        "M1",
+    "M3":        "M3",
+    "stolution": "stolution",
+}
+
+# Phase 4: known buckets used to seed default per-bucket autonomy_state rows.
+KNOWN_BUCKETS = list(DEFAULT_HOST_FOR_BUCKET.keys())
+
+# Phase 4: regex used by the dispatch-result classifier to recognise a
+# "subscription rate-limit" / cap-exceeded signal from the spawner's stderr.
+CAP_THROTTLE_PATTERNS = [
+    re.compile(r"(?i)rate.?limit"),
+    re.compile(r"(?i)5-?hour"),
+    re.compile(r"(?i)usage limit"),
+    re.compile(r"(?i)quota exhausted"),
+    re.compile(r"(?i)Anthropic.*rate"),
+    re.compile(r"(?i)try again later"),
+    re.compile(r"(?i)retry.*later"),
+]
+
+SERVICE_NAME           = os.environ.get("SERVICE_NAME", "slot-manager")
+SERVICE_PORT           = int(os.environ.get("PORT", "8081"))
+VERSION                = "0.5.0-phase5"
+
+# ---------------------------------------------------------------------------
+# Phase 5: real-edit mode + allow-list + risk_tier
+# ---------------------------------------------------------------------------
+
+VALID_PERMISSION_MODES = {"plan", "acceptEdits", "bypassPermissions"}
+DEFAULT_PERMISSION_MODE = os.environ.get("DEFAULT_PERMISSION_MODE", "plan")
+
+DEFAULT_BUCKET_PERMISSIONS = {
+    "M1":        os.environ.get("BUCKET_PERMISSION_M1",        "acceptEdits"),
+    "M3":        os.environ.get("BUCKET_PERMISSION_M3",        "acceptEdits"),
+    "stolution": os.environ.get("BUCKET_PERMISSION_STOLUTION", "acceptEdits"),
+}
+
+DEFAULT_BUCKET_PATH_ALLOWLIST = [
+    os.environ.get("DEFAULT_ALLOWLIST_PATH",
+                   "/Users/MAC/Documents/projects"),
+]
+
+APPROVAL_TTL_SEC = int(os.environ.get("APPROVAL_TTL_SEC", "3600"))
+
+HIGH_RISK_PATTERNS = [
+    re.compile(r"(?i)--admin\b"),
+    re.compile(r"(?i)\brm\s+-rf\b"),
+    re.compile(r"(?i)\bforce-?push\b"),
+    re.compile(r"(?i)\bsecret\s+rotation\b"),
+    re.compile(r"(?i)\brotate.*secret"),
+    re.compile(r"(?i)\bprod(uction)?\s+deploy"),
+    re.compile(r"(?i)\bdeploy.*prod"),
+    re.compile(r"(?i)\bDROP\s+(TABLE|DATABASE)"),
+    re.compile(r"(?i)\bsudo\b"),
+    re.compile(r"(?i)\boverride\s+safety"),
+    re.compile(r"(?i)\bdisable.*guard"),
+]
+
+MEDIUM_RISK_PATTERNS = [
+    re.compile(r"(?i)\.github/workflows/"),
+    re.compile(r"(?i)/charts?/"),
+    re.compile(r"(?i)kustomize"),
+    re.compile(r"(?i)terraform"),
+    re.compile(r"(?i)package\.json\b"),
+    re.compile(r"(?i)pnpm-lock\.yaml"),
+    re.compile(r"(?i)Dockerfile"),
+    re.compile(r"(?i)\bmigration"),
+]
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("slot-manager")
+
+
+def utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Subscription guard
+# ---------------------------------------------------------------------------
+
+def _slot_manager_subscription_guard() -> str | None:
+    """Return error string if ANTHROPIC_API_KEY is set in slot-manager env."""
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return ("ANTHROPIC_API_KEY is set in slot-manager env; "
+                "refusing per zero-dollar rule (feedback_no_api_key_billing.md).")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DB
+# ---------------------------------------------------------------------------
+
+_db_lock = threading.RLock()
+_db: sqlite3.Connection | None = None
+
+
+def db() -> sqlite3.Connection:
+    global _db
+    if _db is None:
+        Path(SQLITE_PATH).parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            SQLITE_PATH,
+            isolation_level=None,
+            check_same_thread=False,
+            timeout=30.0,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL;")
+        conn.execute("PRAGMA synchronous = NORMAL;")
+        conn.execute("PRAGMA temp_store = MEMORY;")
+        conn.execute("PRAGMA cache_size = -65536;")
+        conn.execute("PRAGMA foreign_keys = ON;")
+        _db = conn
+    return _db
+
+
+def apply_schema() -> None:
+    schema_sql = Path(SCHEMA_PATH).read_text()
+    with _db_lock:
+        cur = db().cursor()
+        cur.executescript(schema_sql)
+    log.info("schema applied from %s", SCHEMA_PATH)
+    _ensure_phase1_schema()
+    _ensure_phase2_schema()
+    _ensure_phase4_schema()
+    _ensure_phase5_schema()
+
+
+def _ensure_phase1_schema() -> None:
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        existing_cols = {r["name"] for r in cur.execute("PRAGMA table_info(slots)").fetchall()}
+        if "lease_seconds" not in existing_cols:
+            cur.execute(
+                f"ALTER TABLE slots ADD COLUMN lease_seconds INTEGER NOT NULL DEFAULT {LEASE_TTL_SEC}"
+            )
+            log.info("phase1 migration: added slots.lease_seconds default=%d", LEASE_TTL_SEC)
+        if "lease_started_at" not in existing_cols:
+            cur.execute("ALTER TABLE slots ADD COLUMN lease_started_at TIMESTAMP")
+            log.info("phase1 migration: added slots.lease_started_at")
+
+
+def _ensure_phase2_schema() -> None:
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        existing_cols = {r["name"] for r in cur.execute("PRAGMA table_info(slots)").fetchall()}
+        if "host" not in existing_cols:
+            cur.execute("ALTER TABLE slots ADD COLUMN host TEXT NOT NULL DEFAULT ''")
+            cur.execute("UPDATE slots SET host = bucket WHERE host = ''")
+            log.info("phase2 migration: added slots.host (defaulted to bucket name)")
+
+
+def _ensure_phase4_schema() -> None:
+    """Idempotent Phase 4 migrations.
+
+    1. Rebuild `spawn_telemetry` to relax the CHECK constraint so we can
+       store the new outcome values (`parse_error`, `interrupted`,
+       `cap_throttled`).
+    2. Create new tables (handled by schema.sql IF NOT EXISTS, but kept
+       here for hot-rollout DBs that don't have them yet).
+    3. Seed default `autonomy_state` rows.
+    4. Seed default `spawn_retry_budget` rows.
+    """
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        # 1. Detect old narrow CHECK on spawn_telemetry.outcome and rebuild.
+        try:
+            sql_row = cur.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='spawn_telemetry'"
+            ).fetchone()
+            old_sql = (sql_row["sql"] if sql_row else "") or ""
+        except Exception:
+            old_sql = ""
+        needs_rebuild = (
+            "outcome IN" in old_sql
+            and "'parse_error'" not in old_sql
+        )
+        if needs_rebuild:
+            log.info("phase4 migration: rebuilding spawn_telemetry to widen outcome CHECK")
+            cur.execute("BEGIN IMMEDIATE;")
+            try:
+                cur.execute("ALTER TABLE spawn_telemetry RENAME TO spawn_telemetry_old")
+                cur.execute("""
+                    CREATE TABLE spawn_telemetry (
+                      id INTEGER PRIMARY KEY AUTOINCREMENT,
+                      spawn_id TEXT NOT NULL UNIQUE,
+                      started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                      completed_at TIMESTAMP,
+                      duration_ms INTEGER,
+                      bucket TEXT,
+                      host TEXT,
+                      slot_id TEXT,
+                      task_id TEXT,
+                      spawner_url TEXT,
+                      exit_code INTEGER,
+                      outcome TEXT NOT NULL DEFAULT 'pending',
+                      api_key_guard_passed INTEGER NOT NULL DEFAULT 0,
+                      binary_sha256 TEXT,
+                      binary_path TEXT,
+                      session_id TEXT,
+                      model TEXT,
+                      error TEXT,
+                      CHECK (outcome IN (
+                        'pending','ok','dispatch_error','spawner_error',
+                        'rejected_guard','rejected_budget','rejected_no_host',
+                        'rejected_drained','timeout','parse_error','interrupted',
+                        'cap_throttled'))
+                    )
+                """)
+                cur.execute("""
+                    INSERT INTO spawn_telemetry
+                    (id, spawn_id, started_at, completed_at, duration_ms,
+                     bucket, host, slot_id, task_id, spawner_url, exit_code,
+                     outcome, api_key_guard_passed, binary_sha256, binary_path,
+                     session_id, model, error)
+                    SELECT id, spawn_id, started_at, completed_at, duration_ms,
+                           bucket, host, slot_id, task_id, spawner_url, exit_code,
+                           outcome, api_key_guard_passed, binary_sha256, binary_path,
+                           session_id, model, error
+                      FROM spawn_telemetry_old
+                """)
+                cur.execute("DROP TABLE spawn_telemetry_old")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_started ON spawn_telemetry(started_at)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_bucket  ON spawn_telemetry(bucket)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_host    ON spawn_telemetry(host)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_spawn_telemetry_outcome ON spawn_telemetry(outcome)")
+                cur.execute("COMMIT;")
+                log.info("phase4 migration: spawn_telemetry rebuilt")
+            except Exception:
+                cur.execute("ROLLBACK;")
+                raise
+
+        # 2. New tables (schema.sql also creates these; the IF NOT EXISTS
+        # below is a belt-and-braces for hot rollouts).
+        cur.executescript("""
+            CREATE TABLE IF NOT EXISTS spawn_lineage (
+              child_spawn_id  TEXT PRIMARY KEY,
+              parent_spawn_id TEXT,
+              parent_task_id  TEXT,
+              child_task_id   TEXT,
+              relation        TEXT NOT NULL,
+              created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              payload         TEXT,
+              CHECK (relation IN ('decomposed-into','retry-of','replay-of','continuation','autonomous-claim'))
+            );
+            CREATE TABLE IF NOT EXISTS spawn_retry_budget (
+              bucket       TEXT NOT NULL,
+              host         TEXT NOT NULL,
+              max_retries  INTEGER NOT NULL DEFAULT 3,
+              backoff_s_csv TEXT NOT NULL DEFAULT '1,2,4',
+              updated_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              PRIMARY KEY (bucket, host)
+            );
+            CREATE TABLE IF NOT EXISTS spawn_dead_letter (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              original_spawn_id TEXT NOT NULL,
+              bucket    TEXT,
+              host      TEXT,
+              task_id   TEXT,
+              attempts  INTEGER NOT NULL DEFAULT 1,
+              last_outcome TEXT NOT NULL,
+              last_error TEXT,
+              payload   TEXT,
+              created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              replayed_at TIMESTAMP,
+              replay_spawn_id TEXT
+            );
+            CREATE TABLE IF NOT EXISTS autonomy_state (
+              scope        TEXT PRIMARY KEY,
+              state        TEXT NOT NULL,
+              reason       TEXT,
+              last_tick_at TIMESTAMP,
+              last_claim_at TIMESTAMP,
+              last_changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              actor        TEXT,
+              CHECK (state IN ('on','off','circuit-broken','cap-throttled'))
+            );
+            CREATE TABLE IF NOT EXISTS loop_changes (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              scope     TEXT NOT NULL,
+              old_state TEXT,
+              new_state TEXT NOT NULL,
+              actor     TEXT NOT NULL DEFAULT 'unknown',
+              reason    TEXT,
+              changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS host_throttle_state (
+              host          TEXT PRIMARY KEY,
+              cap_event_count INTEGER NOT NULL DEFAULT 0,
+              first_event_at TIMESTAMP,
+              last_event_at  TIMESTAMP,
+              throttled_until TIMESTAMP,
+              updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS loop_tick (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              iterations INTEGER NOT NULL DEFAULT 1,
+              claims INTEGER NOT NULL DEFAULT 0,
+              skips_no_work INTEGER NOT NULL DEFAULT 0,
+              skips_no_slot INTEGER NOT NULL DEFAULT 0,
+              skips_budget INTEGER NOT NULL DEFAULT 0,
+              skips_throttled INTEGER NOT NULL DEFAULT 0,
+              duration_ms INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_lineage_parent ON spawn_lineage(parent_spawn_id);
+            CREATE INDEX IF NOT EXISTS idx_lineage_relation ON spawn_lineage(relation);
+            CREATE INDEX IF NOT EXISTS idx_dead_letter_bucket ON spawn_dead_letter(bucket);
+            CREATE INDEX IF NOT EXISTS idx_dead_letter_host ON spawn_dead_letter(host);
+            CREATE INDEX IF NOT EXISTS idx_loop_tick_ts ON loop_tick(ts);
+            CREATE INDEX IF NOT EXISTS idx_loop_changes_at ON loop_changes(changed_at);
+        """)
+
+        # 3. Seed default autonomy_state rows (idempotent).
+        cur.execute("INSERT OR IGNORE INTO autonomy_state (scope, state, reason, actor) VALUES (?, ?, ?, ?)",
+                    ("global", LOOP_GLOBAL_DEFAULT, "default-on-startup", "phase4-init"))
+        for b in KNOWN_BUCKETS:
+            cur.execute("INSERT OR IGNORE INTO autonomy_state (scope, state, reason, actor) VALUES (?, ?, ?, ?)",
+                        (f"bucket:{b}", LOOP_PER_BUCKET_DEFAULT,
+                         "default-off-startup-operator-must-opt-in", "phase4-init"))
+
+        # 4. Seed default retry budgets for known (bucket, host) pairs.
+        for b, h in DEFAULT_HOST_FOR_BUCKET.items():
+            cur.execute(
+                "INSERT OR IGNORE INTO spawn_retry_budget (bucket, host, max_retries, backoff_s_csv) "
+                "VALUES (?, ?, ?, ?)",
+                (b, h, DEFAULT_RETRY_MAX, DEFAULT_RETRY_BACKOFF_S),
+            )
+        log.info("phase4 schema/migration: tables ready, defaults seeded")
+
+
+
+
+def _ensure_phase5_schema() -> None:
+    """Idempotent Phase 5 migrations.
+
+    1. New tables: bucket_permissions, bucket_path_allowlists,
+       task_approvals, dispatch_risk_log.
+    2. Seed default rows in bucket_permissions and
+       bucket_path_allowlists for known buckets.
+    """
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.executescript("""
+            CREATE TABLE IF NOT EXISTS bucket_permissions (
+              bucket           TEXT PRIMARY KEY,
+              permission_mode  TEXT NOT NULL DEFAULT 'plan',
+              updated_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              actor            TEXT,
+              reason           TEXT,
+              CHECK (permission_mode IN ('plan','acceptEdits','bypassPermissions'))
+            );
+            CREATE TABLE IF NOT EXISTS bucket_path_allowlists (
+              id          INTEGER PRIMARY KEY AUTOINCREMENT,
+              bucket      TEXT NOT NULL,
+              path        TEXT NOT NULL,
+              active      INTEGER NOT NULL DEFAULT 1,
+              created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              actor       TEXT,
+              reason      TEXT,
+              UNIQUE (bucket, path)
+            );
+            CREATE TABLE IF NOT EXISTS task_approvals (
+              task_id     TEXT PRIMARY KEY,
+              approved_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              expires_at  TIMESTAMP NOT NULL,
+              actor       TEXT NOT NULL DEFAULT 'unknown',
+              reason      TEXT,
+              used_at     TIMESTAMP,
+              used_spawn_id TEXT
+            );
+            CREATE TABLE IF NOT EXISTS dispatch_risk_log (
+              id              INTEGER PRIMARY KEY AUTOINCREMENT,
+              spawn_id        TEXT NOT NULL,
+              task_id         TEXT,
+              bucket          TEXT,
+              risk_tier       TEXT NOT NULL,
+              permission_mode TEXT NOT NULL,
+              classifier      TEXT NOT NULL,
+              approval_used   TEXT,
+              allow_list_json TEXT,
+              created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              CHECK (risk_tier IN ('low','medium','high'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_bucket_path_allowlists_bucket ON bucket_path_allowlists(bucket);
+            CREATE INDEX IF NOT EXISTS idx_task_approvals_expires_at ON task_approvals(expires_at);
+            CREATE INDEX IF NOT EXISTS idx_dispatch_risk_log_spawn ON dispatch_risk_log(spawn_id);
+            CREATE INDEX IF NOT EXISTS idx_dispatch_risk_log_task ON dispatch_risk_log(task_id);
+            CREATE INDEX IF NOT EXISTS idx_dispatch_risk_log_tier ON dispatch_risk_log(risk_tier);
+        """)
+        for b, mode in DEFAULT_BUCKET_PERMISSIONS.items():
+            cur.execute(
+                "INSERT OR IGNORE INTO bucket_permissions (bucket, permission_mode, actor, reason) "
+                "VALUES (?, ?, ?, ?)",
+                (b, mode, "phase5-init", "Phase 5 default — operator-confirmed"),
+            )
+        for b in KNOWN_BUCKETS:
+            # Phase 6 fix: only seed defaults for buckets that have no
+            # existing path allowlist row. Otherwise restarts re-add the
+            # Mac default path to non-Mac buckets like stolution.
+            existing = cur.execute(
+                "SELECT 1 FROM bucket_path_allowlists WHERE bucket = ? LIMIT 1", (b,)
+            ).fetchone()
+            if existing:
+                continue
+            for p in DEFAULT_BUCKET_PATH_ALLOWLIST:
+                cur.execute(
+                    "INSERT OR IGNORE INTO bucket_path_allowlists "
+                    "(bucket, path, actor, reason) VALUES (?, ?, ?, ?)",
+                    (b, p, "phase5-init", "Phase 5 default"),
+                )
+        log.info("phase5 schema/migration: tables ready, defaults seeded")
+
+
+def _bucket_permission_mode(bucket: str) -> str:
+    with _db_lock:
+        row = db().execute(
+            "SELECT permission_mode FROM bucket_permissions WHERE bucket = ?",
+            (bucket,),
+        ).fetchone()
+    if row and row["permission_mode"] in VALID_PERMISSION_MODES:
+        return row["permission_mode"]
+    return DEFAULT_PERMISSION_MODE
+
+
+def _bucket_allow_list(bucket: str, *, repo_scope: str | None = None) -> list[str]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT path FROM bucket_path_allowlists "
+            "WHERE bucket = ? AND active = 1 ORDER BY id",
+            (bucket,),
+        ).fetchall()
+    paths = [r["path"] for r in rows]
+    if repo_scope:
+        cand = f"/Users/MAC/Documents/projects/{repo_scope.strip('/')}"
+        if cand not in paths:
+            paths.append(cand)
+    return paths
+
+
+def _classify_risk_tier(task_spec: dict[str, Any]) -> tuple[str, str]:
+    explicit = (task_spec.get("risk_tier") or "").strip().lower()
+    if explicit in ("low", "medium", "high"):
+        return explicit, f"explicit:{explicit}"
+    haystack_parts: list[str] = []
+    haystack_parts.append(str(task_spec.get("title") or ""))
+    haystack_parts.append(str(task_spec.get("file_scope") or ""))
+    haystack_parts.append(str(task_spec.get("repo_scope") or ""))
+    pm = task_spec.get("prompt_material") or {}
+    if isinstance(pm, dict):
+        for k in ("description", "work_directive", "must_read_first",
+                  "scope_tag", "item_code", "file_scope"):
+            v = pm.get(k)
+            if v is None:
+                continue
+            if isinstance(v, list):
+                haystack_parts.append(" ".join(str(x) for x in v))
+            else:
+                haystack_parts.append(str(v))
+    haystack = " \n ".join(haystack_parts)
+    for rx in HIGH_RISK_PATTERNS:
+        if rx.search(haystack):
+            return "high", f"auto:high:{rx.pattern[:40]}"
+    for rx in MEDIUM_RISK_PATTERNS:
+        if rx.search(haystack):
+            return "medium", f"auto:medium:{rx.pattern[:40]}"
+    return "low", "auto:low-default"
+
+
+def _check_approval(task_id: str) -> dict[str, Any]:
+    with _db_lock:
+        row = db().execute(
+            "SELECT task_id, approved_at, expires_at, actor, reason, used_at "
+            "FROM task_approvals WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()
+    if not row:
+        return {"ok": False, "error": "no approval"}
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    if row["expires_at"] <= now_iso:
+        return {"ok": False, "error": "approval expired",
+                "expires_at": row["expires_at"]}
+    if row["used_at"] is not None:
+        return {"ok": False, "error": "approval already used",
+                "used_at": row["used_at"]}
+    return {"ok": True, "approval_id": row["task_id"],
+            "approved_at": row["approved_at"],
+            "expires_at": row["expires_at"]}
+
+
+def _consume_approval(task_id: str, spawn_id: str) -> None:
+    with _db_lock:
+        db().execute(
+            "UPDATE task_approvals SET used_at = CURRENT_TIMESTAMP, "
+            "  used_spawn_id = ? WHERE task_id = ? AND used_at IS NULL",
+            (spawn_id, task_id),
+        )
+
+
+def _record_dispatch_risk(*, spawn_id: str, task_id: str | None,
+                          bucket: str | None, risk_tier: str,
+                          permission_mode: str, classifier: str,
+                          approval_used: str | None,
+                          allow_list: list[str]) -> None:
+    with _db_lock:
+        db().execute(
+            "INSERT INTO dispatch_risk_log "
+            "(spawn_id, task_id, bucket, risk_tier, permission_mode, "
+            " classifier, approval_used, allow_list_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (spawn_id, task_id, bucket, risk_tier, permission_mode,
+             classifier, approval_used, json.dumps(allow_list)),
+        )
+
+
+def load_config() -> dict[str, Any]:
+    if not Path(CONFIG_PATH).exists():
+        log.warning("config file %s not found; using Phase-0 defaults", CONFIG_PATH)
+        return {
+            "buckets": {
+                "M1":        {"capacity": 8},
+                "M3":        {"capacity": 16},
+                "stolution": {"capacity": 8},
+            }
+        }
+    return yaml.safe_load(Path(CONFIG_PATH).read_text()) or {}
+
+
+def seed_slots(config: dict[str, Any]) -> None:
+    buckets = (config.get("buckets") or {})
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN;")
+        try:
+            for bucket, cfg in buckets.items():
+                capacity = int(cfg.get("capacity", 0))
+                lease = int(cfg.get("lease_seconds", LEASE_TTL_SEC))
+                host = cfg.get("host") or DEFAULT_HOST_FOR_BUCKET.get(bucket, bucket)
+                cur.execute(
+                    "SELECT COALESCE(MAX(index_in_bucket), 0) AS m FROM slots WHERE bucket = ?",
+                    (bucket,),
+                )
+                existing_max = cur.fetchone()["m"]
+                for idx in range(existing_max + 1, capacity + 1):
+                    slot_id = f"{bucket}-{idx}"
+                    cur.execute(
+                        "INSERT OR IGNORE INTO slots (slot_id, bucket, index_in_bucket, status, lease_seconds, host) "
+                        "VALUES (?, ?, ?, 'free', ?, ?)",
+                        (slot_id, bucket, idx, lease, host),
+                    )
+                cur.execute(
+                    "INSERT OR IGNORE INTO bucket_health (bucket, state) VALUES (?, 'closed')",
+                    (bucket,),
+                )
+                cur.execute("SELECT 1 FROM spawn_budget WHERE bucket = ?", (bucket,))
+                if cur.fetchone() is None:
+                    max_per_min = int(cfg.get("spawn_budget_max_per_minute", DEFAULT_SPAWN_MAX_PER_MIN))
+                    cur.execute(
+                        "INSERT INTO spawn_budget (bucket, max_per_minute, tokens_remaining) VALUES (?, ?, ?)",
+                        (bucket, max_per_min, float(max_per_min)),
+                    )
+                # Seed autonomy_state for any extra bucket discovered in config.
+                cur.execute(
+                    "INSERT OR IGNORE INTO autonomy_state (scope, state, reason, actor) VALUES (?, ?, ?, ?)",
+                    (f"bucket:{bucket}", LOOP_PER_BUCKET_DEFAULT,
+                     "default-off-from-config-load", "phase4-init"),
+                )
+                cur.execute(
+                    "INSERT OR IGNORE INTO spawn_retry_budget (bucket, host, max_retries, backoff_s_csv) "
+                    "VALUES (?, ?, ?, ?)",
+                    (bucket, host, DEFAULT_RETRY_MAX, DEFAULT_RETRY_BACKOFF_S),
+                )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    log.info("seed_slots done; buckets=%s", list(buckets))
+
+
+def slot_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    keys = row.keys()
+    out = {
+        "slot_id":               row["slot_id"],
+        "bucket":                row["bucket"],
+        "status":                row["status"],
+        "current_task_id":       row["current_task_id"],
+        "current_assignment_id": row["current_assignment_id"],
+        "last_updated_at":       row["last_updated_at"],
+    }
+    if "lease_seconds" in keys:
+        out["lease_seconds"]    = row["lease_seconds"]
+    if "lease_started_at" in keys:
+        out["lease_started_at"] = row["lease_started_at"]
+    if "host" in keys:
+        out["host"]             = row["host"]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Watchdog (Phase 1+2)
+# ---------------------------------------------------------------------------
+
+async def heartbeat_watchdog() -> None:
+    log.info("watchdog: starting; interval=%ds heartbeat-timeout=%ds default-lease=%ds host-offline=%ds",
+             WATCHDOG_INTERVAL_SEC, HEARTBEAT_TIMEOUT_SEC, LEASE_TTL_SEC, HOST_OFFLINE_AFTER_SEC)
+    while True:
+        try:
+            await asyncio.sleep(WATCHDOG_INTERVAL_SEC)
+            hb_released = _watchdog_sweep_heartbeat()
+            lease_released = _watchdog_sweep_lease()
+            host_offlined = _watchdog_sweep_hosts()
+            cap_cleared = _watchdog_clear_expired_throttles()
+            if hb_released:
+                log.warning("watchdog: heartbeat-timeout auto-released %d slots", hb_released)
+            if lease_released:
+                log.warning("watchdog: lease-expired auto-released %d slots", lease_released)
+            if host_offlined:
+                log.warning("watchdog: marked %d hosts offline (no heartbeat)", host_offlined)
+            if cap_cleared:
+                log.info("watchdog: cleared %d expired host cap-throttles", cap_cleared)
+        except asyncio.CancelledError:
+            log.info("watchdog: cancelled")
+            return
+        except Exception:
+            log.exception("watchdog: sweep failed (continuing)")
+
+
+def _watchdog_sweep_heartbeat() -> int:
+    timeout = HEARTBEAT_TIMEOUT_SEC
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN;")
+        try:
+            cur.execute(
+                """
+                SELECT a.assignment_id, a.slot_id, a.task_id, a.bucket,
+                       COALESCE(a.last_heartbeat_at, a.started_at) AS last_seen
+                FROM assignments a
+                WHERE a.completed_at IS NULL
+                  AND (
+                      strftime('%s','now') -
+                      strftime('%s', COALESCE(a.last_heartbeat_at, a.started_at))
+                  ) > ?
+                """,
+                (timeout,),
+            )
+            stalled = cur.fetchall()
+            for row in stalled:
+                _force_release_locked(cur,
+                    slot_id=row["slot_id"], task_id=row["task_id"],
+                    assignment_id=row["assignment_id"], bucket=row["bucket"],
+                    exit_status=124,
+                    error_message="heartbeat timeout (watchdog)",
+                    event_type="heartbeat_timeout",
+                    payload={"timeout_sec": timeout, "last_seen": row["last_seen"]},
+                )
+            cur.execute("COMMIT;")
+            return len(stalled)
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+
+
+def _watchdog_sweep_lease() -> int:
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN;")
+        try:
+            cur.execute(
+                """
+                SELECT a.assignment_id, a.slot_id, a.task_id, a.bucket,
+                       a.started_at, s.lease_seconds
+                FROM assignments a
+                JOIN slots s ON s.slot_id = a.slot_id
+                WHERE a.completed_at IS NULL
+                  AND s.lease_seconds IS NOT NULL
+                  AND (
+                      strftime('%s','now') -
+                      strftime('%s', a.started_at)
+                  ) > s.lease_seconds
+                """,
+            )
+            expired = cur.fetchall()
+            for row in expired:
+                _force_release_locked(cur,
+                    slot_id=row["slot_id"], task_id=row["task_id"],
+                    assignment_id=row["assignment_id"], bucket=row["bucket"],
+                    exit_status=125,
+                    error_message="lease expired (watchdog)",
+                    event_type="lease_expired",
+                    payload={"lease_seconds": row["lease_seconds"], "started_at": row["started_at"]},
+                )
+            cur.execute("COMMIT;")
+            return len(expired)
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+
+
+def _watchdog_sweep_hosts() -> int:
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN;")
+        try:
+            cur.execute(
+                """
+                SELECT name FROM hosts
+                 WHERE state IN ('active','drain')
+                   AND (strftime('%s','now') - strftime('%s', last_heartbeat_at)) > ?
+                """,
+                (HOST_OFFLINE_AFTER_SEC,),
+            )
+            stale = [r["name"] for r in cur.fetchall()]
+            for name in stale:
+                cur.execute(
+                    "UPDATE hosts SET state='offline', last_state_change_at=CURRENT_TIMESTAMP WHERE name = ?",
+                    (name,),
+                )
+                cur.execute(
+                    "INSERT INTO events (event_id, event_type, payload) VALUES (?, 'host_offline', ?)",
+                    (str(uuid.uuid4()), json.dumps({"host": name, "reason": "no heartbeat"})),
+                )
+            cur.execute("COMMIT;")
+            return len(stale)
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+
+
+def _watchdog_clear_expired_throttles() -> int:
+    """Phase 4: clear host_throttle_state rows whose throttled_until has passed."""
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "SELECT host FROM host_throttle_state "
+            " WHERE throttled_until IS NOT NULL "
+            "   AND strftime('%s','now') >= strftime('%s', throttled_until)"
+        )
+        cleared = [r["host"] for r in cur.fetchall()]
+        for h in cleared:
+            cur.execute(
+                "UPDATE host_throttle_state "
+                "   SET cap_event_count = 0, first_event_at = NULL, last_event_at = NULL, "
+                "       throttled_until = NULL, updated_at = CURRENT_TIMESTAMP "
+                " WHERE host = ?",
+                (h,),
+            )
+        return len(cleared)
+
+
+def _force_release_locked(cur, *, slot_id, task_id, assignment_id, bucket,
+                          exit_status, error_message, event_type, payload):
+    cur.execute(
+        "UPDATE assignments SET completed_at = CURRENT_TIMESTAMP, exit_status = ?, error_message = ? WHERE assignment_id = ?",
+        (exit_status, error_message, assignment_id),
+    )
+    cur.execute(
+        "UPDATE slots SET status = 'free', current_task_id = NULL, current_assignment_id = NULL, lease_started_at = NULL, last_updated_at = CURRENT_TIMESTAMP WHERE slot_id = ?",
+        (slot_id,),
+    )
+    cur.execute(
+        "INSERT INTO events (event_id, event_type, slot_id, task_id, assignment_id, bucket, payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (str(uuid.uuid4()), event_type, slot_id, task_id, assignment_id, bucket, json.dumps(payload)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPS client
+# ---------------------------------------------------------------------------
+
+async def sps_request_next_spawn(bucket: str, slot_id: str) -> dict[str, Any] | None:
+    if not SPS_ENABLED:
+        return None
+    sps_bucket = SPS_BUCKET_ALIASES.get(bucket, bucket)
+    url = f"{SPS_BASE_URL.rstrip('/')}/spawn"
+    payload = {"bucket": sps_bucket, "slot_id": slot_id}
+    try:
+        async with httpx.AsyncClient(timeout=SPS_TIMEOUT_SEC) as client:
+            resp = await client.post(url, json=payload)
+    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.RemoteProtocolError) as e:
+        log.warning("sps unreachable for bucket=%s alias=%s: %s — returning null next_task_spec",
+                    bucket, sps_bucket, e)
+        return None
+    except Exception:
+        log.exception("sps call failed; returning null next_task_spec")
+        return None
+    if resp.status_code == 204:
+        return None
+    if resp.status_code != 200:
+        log.warning("sps /spawn returned %d for bucket=%s alias=%s body=%s",
+                    resp.status_code, bucket, sps_bucket, resp.text[:200])
+        return None
+    try:
+        body = resp.json()
+    except Exception:
+        log.warning("sps /spawn returned non-JSON 200; body=%s", resp.text[:200])
+        return None
+    if not isinstance(body, dict):
+        return {"raw": body}
+    return body
+
+
+async def sps_post_completion(*, node_id: str, bucket_alias: str, outcome: str,
+                               outcome_detail: str | None = None) -> bool:
+    """POST {SPS}/completion — best-effort, non-fatal on failure."""
+    if not SPS_ENABLED:
+        return False
+    url = f"{SPS_BASE_URL.rstrip('/')}/completion"
+    body = {"node_id": node_id, "bucket": bucket_alias,
+            "outcome": outcome, "outcome_detail": outcome_detail}
+    try:
+        async with httpx.AsyncClient(timeout=SPS_TIMEOUT_SEC) as client:
+            resp = await client.post(url, json=body)
+    except Exception as e:
+        log.warning("sps completion POST failed node=%s outcome=%s: %s",
+                    node_id, outcome, e)
+        return False
+    if resp.status_code != 200:
+        log.warning("sps completion non-200 node=%s outcome=%s status=%d body=%s",
+                    node_id, outcome, resp.status_code, resp.text[:200])
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Spawn budget (Phase 2)
+# ---------------------------------------------------------------------------
+
+def _budget_refill_locked(cur, bucket: str) -> dict[str, Any] | None:
+    cur.execute(
+        "SELECT bucket, max_per_minute, tokens_remaining, last_refill_at, "
+        "       strftime('%s','now') AS now_s, "
+        "       strftime('%s', last_refill_at) AS last_s "
+        "  FROM spawn_budget WHERE bucket = ?",
+        (bucket,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    elapsed_s = max(0.0, float(row["now_s"]) - float(row["last_s"]))
+    rate_per_s = row["max_per_minute"] / 60.0
+    refill = elapsed_s * rate_per_s
+    new_tokens = min(float(row["max_per_minute"]), float(row["tokens_remaining"]) + refill)
+    cur.execute(
+        "UPDATE spawn_budget SET tokens_remaining = ?, last_refill_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+        " WHERE bucket = ?",
+        (new_tokens, bucket),
+    )
+    return {
+        "bucket":           row["bucket"],
+        "max_per_minute":   row["max_per_minute"],
+        "tokens_remaining": new_tokens,
+        "last_refill_at":   utcnow_iso(),
+    }
+
+
+def _budget_take_locked(cur, bucket: str) -> tuple[bool, dict[str, Any] | None]:
+    state = _budget_refill_locked(cur, bucket)
+    if state is None:
+        cur.execute(
+            "INSERT INTO spawn_budget (bucket, max_per_minute, tokens_remaining) VALUES (?, ?, ?)",
+            (bucket, DEFAULT_SPAWN_MAX_PER_MIN, float(DEFAULT_SPAWN_MAX_PER_MIN)),
+        )
+        state = _budget_refill_locked(cur, bucket)
+        if state is None:
+            return False, None
+    if state["tokens_remaining"] < 1.0:
+        return False, state
+    new_tokens = state["tokens_remaining"] - 1.0
+    cur.execute(
+        "UPDATE spawn_budget SET tokens_remaining = ?, updated_at = CURRENT_TIMESTAMP WHERE bucket = ?",
+        (new_tokens, bucket),
+    )
+    state["tokens_remaining"] = new_tokens
+    return True, state
+
+
+def _budget_peek_locked(cur, bucket: str) -> dict[str, Any] | None:
+    """Phase 4: refill-only peek used by the loop's pre-claim guard."""
+    return _budget_refill_locked(cur, bucket)
+
+
+# ---------------------------------------------------------------------------
+# Spawn dispatch + telemetry (Phase 2)
+# ---------------------------------------------------------------------------
+
+async def _dispatch_to_spawner(
+    *,
+    spawner_url: str,
+    payload: dict[str, Any],
+    timeout_s: float,
+) -> tuple[int, dict[str, Any] | str]:
+    url = f"{spawner_url.rstrip('/')}/spawn"
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            resp = await client.post(url, json=payload)
+    except httpx.TimeoutException as e:
+        return 599, f"timeout: {e}"
+    except (httpx.ConnectError, httpx.RemoteProtocolError) as e:
+        return 598, f"connect_error: {e}"
+    except Exception as e:
+        return 597, f"unexpected: {e}"
+    try:
+        body = resp.json()
+    except Exception:
+        body = resp.text
+    return resp.status_code, body
+
+
+def _record_spawn(
+    *,
+    spawn_id: str,
+    bucket: str | None = None,
+    host: str | None = None,
+    slot_id: str | None = None,
+    task_id: str | None = None,
+    spawner_url: str | None = None,
+    outcome: str = "pending",
+    api_key_guard_passed: bool = False,
+    started_at_iso: str | None = None,
+) -> None:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "INSERT INTO spawn_telemetry (spawn_id, started_at, bucket, host, slot_id, task_id, "
+            "                             spawner_url, outcome, api_key_guard_passed) "
+            "VALUES (?, COALESCE(?, CURRENT_TIMESTAMP), ?, ?, ?, ?, ?, ?, ?)",
+            (spawn_id, started_at_iso, bucket, host, slot_id, task_id, spawner_url,
+             outcome, 1 if api_key_guard_passed else 0),
+        )
+
+
+def _complete_spawn(
+    *,
+    spawn_id: str,
+    duration_ms: int,
+    outcome: str,
+    exit_code: int | None = None,
+    binary_sha256: str | None = None,
+    binary_path: str | None = None,
+    session_id: str | None = None,
+    model: str | None = None,
+    error: str | None = None,
+) -> None:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE spawn_telemetry "
+            "   SET completed_at = CURRENT_TIMESTAMP, duration_ms = ?, outcome = ?, "
+            "       exit_code = ?, binary_sha256 = ?, binary_path = ?, "
+            "       session_id = ?, model = ?, error = ? "
+            " WHERE spawn_id = ?",
+            (duration_ms, outcome, exit_code, binary_sha256, binary_path,
+             session_id, model, error, spawn_id),
+        )
+
+
+def _get_spawn_telemetry(spawn_id: str) -> dict[str, Any] | None:
+    with _db_lock:
+        row = db().execute(
+            "SELECT * FROM spawn_telemetry WHERE spawn_id = ?", (spawn_id,)
+        ).fetchone()
+    return dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 helpers: lineage, retry, throttle, autonomy
+# ---------------------------------------------------------------------------
+
+def _record_lineage(
+    *,
+    child_spawn_id: str,
+    parent_spawn_id: str | None,
+    relation: str,
+    parent_task_id: str | None = None,
+    child_task_id: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Insert a spawn_lineage row (idempotent on child_spawn_id)."""
+    if not parent_spawn_id and relation == "autonomous-claim":
+        # Lineage of an autonomous root claim — record without parent_spawn_id.
+        pass
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "INSERT OR IGNORE INTO spawn_lineage "
+            "(child_spawn_id, parent_spawn_id, parent_task_id, child_task_id, relation, payload) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (child_spawn_id, parent_spawn_id, parent_task_id, child_task_id,
+             relation, json.dumps(payload or {})),
+        )
+
+
+def _spawn_lineage_walk(spawn_id: str) -> dict[str, Any]:
+    """Recursive ancestor walk + immediate children for a given spawn_id."""
+    ancestors: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    cur_id: str | None = spawn_id
+    with _db_lock:
+        cur = db().cursor()
+        # Ancestors (parent chain).
+        while cur_id and cur_id not in seen:
+            seen.add(cur_id)
+            row = cur.execute(
+                "SELECT child_spawn_id, parent_spawn_id, relation, parent_task_id, child_task_id, payload, created_at "
+                "  FROM spawn_lineage WHERE child_spawn_id = ?",
+                (cur_id,),
+            ).fetchone()
+            if row is None:
+                break
+            ancestors.append({
+                "child_spawn_id":  row["child_spawn_id"],
+                "parent_spawn_id": row["parent_spawn_id"],
+                "relation":        row["relation"],
+                "parent_task_id":  row["parent_task_id"],
+                "child_task_id":   row["child_task_id"],
+                "created_at":      row["created_at"],
+            })
+            cur_id = row["parent_spawn_id"]
+            if cur_id is None:
+                break
+        # Immediate children.
+        kids = cur.execute(
+            "SELECT child_spawn_id, parent_spawn_id, relation, parent_task_id, child_task_id, payload, created_at "
+            "  FROM spawn_lineage WHERE parent_spawn_id = ? ORDER BY created_at",
+            (spawn_id,),
+        ).fetchall()
+    return {
+        "spawn_id": spawn_id,
+        "ancestors": ancestors[1:] if ancestors and ancestors[0]["child_spawn_id"] == spawn_id else ancestors,
+        "children": [dict(r) for r in kids],
+    }
+
+
+def _resolve_retry_budget(bucket: str, host: str) -> tuple[int, list[float]]:
+    """Return (max_retries, backoff_s_list). Falls back to defaults."""
+    with _db_lock:
+        row = db().execute(
+            "SELECT max_retries, backoff_s_csv FROM spawn_retry_budget "
+            " WHERE bucket = ? AND host = ?",
+            (bucket, host),
+        ).fetchone()
+    if row is None:
+        max_retries = DEFAULT_RETRY_MAX
+        csv_s = DEFAULT_RETRY_BACKOFF_S
+    else:
+        max_retries = int(row["max_retries"])
+        csv_s = row["backoff_s_csv"]
+    backoff_list: list[float] = []
+    for tok in (csv_s or "").split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        try:
+            backoff_list.append(float(tok))
+        except ValueError:
+            continue
+    if not backoff_list:
+        backoff_list = [1.0, 2.0, 4.0]
+    return max_retries, backoff_list
+
+
+def _retryable_outcome(outcome: str) -> bool:
+    """Phase 4: which terminal outcomes are eligible for an autonomous retry?
+
+    Non-retryable:
+    - rejected_guard: subscription guard tripped — HALT, do not retry.
+    - rejected_budget: token bucket will refill — wait.
+    - rejected_no_host / rejected_drained: host state must change — wait.
+    - cap_throttled: handled separately (host-level throttle).
+    - parse_error: surfaces; operator must triage.
+    """
+    return outcome in ("spawner_error", "dispatch_error", "timeout", "interrupted")
+
+
+def _is_cap_throttle_signal(error_text: str | None) -> bool:
+    if not error_text:
+        return False
+    for p in CAP_THROTTLE_PATTERNS:
+        if p.search(error_text):
+            return True
+    return False
+
+
+def _record_cap_event(host: str) -> dict[str, Any]:
+    """Record a cap-exceeded event for `host` and possibly mark it throttled."""
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            row = cur.execute(
+                "SELECT cap_event_count, first_event_at, throttled_until FROM host_throttle_state WHERE host = ?",
+                (host,),
+            ).fetchone()
+            if row is None:
+                cur.execute(
+                    "INSERT INTO host_throttle_state (host, cap_event_count, first_event_at, last_event_at) "
+                    "VALUES (?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                    (host,),
+                )
+                event_count = 1
+                first_at = utcnow_iso()
+            else:
+                # Decay window: if first_event_at older than CAP_EVENT_WINDOW_SEC, reset.
+                first_at = row["first_event_at"]
+                cur.execute(
+                    "SELECT strftime('%s','now') AS now_s, "
+                    "       COALESCE(strftime('%s', ?), 0) AS first_s",
+                    (first_at,),
+                )
+                ts_row = cur.fetchone()
+                age_s = float(ts_row["now_s"]) - float(ts_row["first_s"])
+                if age_s > CAP_EVENT_WINDOW_SEC:
+                    cur.execute(
+                        "UPDATE host_throttle_state "
+                        "   SET cap_event_count = 1, first_event_at = CURRENT_TIMESTAMP, "
+                        "       last_event_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+                        " WHERE host = ?",
+                        (host,),
+                    )
+                    event_count = 1
+                else:
+                    event_count = int(row["cap_event_count"]) + 1
+                    cur.execute(
+                        "UPDATE host_throttle_state "
+                        "   SET cap_event_count = ?, last_event_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+                        " WHERE host = ?",
+                        (event_count, host),
+                    )
+
+            throttled = False
+            if event_count >= CAP_EVENT_THRESHOLD:
+                cur.execute(
+                    "UPDATE host_throttle_state "
+                    "   SET throttled_until = datetime('now', ? || ' seconds'), updated_at = CURRENT_TIMESTAMP "
+                    " WHERE host = ?",
+                    (f"+{CAP_RESET_WINDOW_SEC}", host),
+                )
+                # Audit + autonomy state surfacing.
+                cur.execute(
+                    "INSERT INTO loop_changes (scope, old_state, new_state, actor, reason) VALUES (?, ?, ?, ?, ?)",
+                    (f"host:{host}", None, "cap-throttled", "cap-watcher",
+                     f"{event_count} cap events in <{CAP_EVENT_WINDOW_SEC}s"),
+                )
+                throttled = True
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    return {"host": host, "event_count": event_count, "throttled": throttled}
+
+
+def _is_host_cap_throttled(host: str) -> bool:
+    with _db_lock:
+        row = db().execute(
+            "SELECT throttled_until, "
+            "       (strftime('%s', throttled_until) - strftime('%s','now')) AS sec_left "
+            "  FROM host_throttle_state WHERE host = ?",
+            (host,),
+        ).fetchone()
+    if row is None or row["throttled_until"] is None:
+        return False
+    return float(row["sec_left"] or 0) > 0
+
+
+def _read_autonomy(scope: str) -> dict[str, Any] | None:
+    with _db_lock:
+        row = db().execute(
+            "SELECT scope, state, reason, last_tick_at, last_claim_at, last_changed_at, actor "
+            "  FROM autonomy_state WHERE scope = ?",
+            (scope,),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def _set_autonomy(scope: str, new_state: str, *, actor: str = "operator",
+                   reason: str | None = None) -> dict[str, Any]:
+    if new_state not in ("on", "off", "circuit-broken", "cap-throttled"):
+        raise ValueError(f"invalid autonomy state {new_state!r}")
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            existing = cur.execute(
+                "SELECT state FROM autonomy_state WHERE scope = ?", (scope,),
+            ).fetchone()
+            old_state = existing["state"] if existing else None
+            if existing is None:
+                cur.execute(
+                    "INSERT INTO autonomy_state (scope, state, reason, actor, last_changed_at) "
+                    "VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                    (scope, new_state, reason, actor),
+                )
+            else:
+                cur.execute(
+                    "UPDATE autonomy_state "
+                    "   SET state = ?, reason = ?, actor = ?, last_changed_at = CURRENT_TIMESTAMP "
+                    " WHERE scope = ?",
+                    (new_state, reason, actor, scope),
+                )
+            cur.execute(
+                "INSERT INTO loop_changes (scope, old_state, new_state, actor, reason) VALUES (?, ?, ?, ?, ?)",
+                (scope, old_state, new_state, actor, reason),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    log.info("autonomy: %s -> %s actor=%s reason=%s", scope, new_state, actor, reason)
+    return {"scope": scope, "old_state": old_state, "new_state": new_state,
+            "actor": actor, "reason": reason}
+
+
+def _list_autonomy() -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT scope, state, reason, last_tick_at, last_claim_at, last_changed_at, actor "
+            "  FROM autonomy_state ORDER BY scope"
+        ).fetchall()
+    states = [dict(r) for r in rows]
+    by_scope = {r["scope"]: r["state"] for r in states}
+    return {
+        "global": by_scope.get("global", LOOP_GLOBAL_DEFAULT),
+        "buckets": {s["scope"][len("bucket:"):]: dict(s)
+                    for s in states if s["scope"].startswith("bucket:")},
+        "all": states,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 internal helpers: claim/release/spawn-task without HTTP roundtrips
+# ---------------------------------------------------------------------------
+
+def _claim_internal(bucket: str, *, task_id: str, node_id: str = "autonomous-loop",
+                     event_type: str = "task_spawned") -> dict[str, Any] | None:
+    """Atomically claim a free slot in `bucket`. Returns slot dict or None."""
+    assignment_id = str(uuid.uuid4())
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            cur.execute(
+                "SELECT slot_id, host FROM slots WHERE bucket = ? AND status = 'free' "
+                "ORDER BY index_in_bucket LIMIT 1",
+                (bucket,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                cur.execute("ROLLBACK;")
+                return None
+            slot_id = row["slot_id"]
+            host    = row["host"] if "host" in row.keys() else None
+            cur.execute(
+                "UPDATE slots SET status = 'occupied', current_task_id = ?, current_assignment_id = ?, "
+                "                lease_started_at = CURRENT_TIMESTAMP, last_updated_at = CURRENT_TIMESTAMP "
+                " WHERE slot_id = ? AND status = 'free'",
+                (task_id, assignment_id, slot_id),
+            )
+            if cur.rowcount != 1:
+                cur.execute("ROLLBACK;")
+                return None
+            cur.execute(
+                "INSERT INTO assignments (assignment_id, slot_id, task_id, node_id, bucket, started_at, last_heartbeat_at) "
+                "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                (assignment_id, slot_id, task_id, node_id, bucket),
+            )
+            cur.execute(
+                "INSERT INTO events (event_id, event_type, slot_id, task_id, assignment_id, bucket) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), event_type, slot_id, task_id, assignment_id, bucket),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    return {"slot_id": slot_id, "host": host, "assignment_id": assignment_id,
+            "task_id": task_id, "bucket": bucket}
+
+
+def _release_internal(slot_id: str, task_id: str, *, exit_status: int = 0,
+                       artifacts: list[str] | None = None,
+                       error_message: str | None = None) -> dict[str, Any] | None:
+    """Internal release used by the autonomous loop. Doesn't fetch a new spec."""
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            row = cur.execute(
+                "SELECT slot_id, status, current_task_id, current_assignment_id, bucket FROM slots WHERE slot_id = ?",
+                (slot_id,),
+            ).fetchone()
+            if row is None:
+                cur.execute("ROLLBACK;")
+                return None
+            assignment_id = row["current_assignment_id"]
+            bucket = row["bucket"]
+            current_task = row["current_task_id"]
+            if row["status"] != "occupied":
+                cur.execute("ROLLBACK;")
+                return None
+            if current_task != task_id:
+                cur.execute("ROLLBACK;")
+                return None
+            cur.execute(
+                "UPDATE assignments SET completed_at = CURRENT_TIMESTAMP, exit_status = ?, error_message = ? WHERE assignment_id = ?",
+                (exit_status, error_message, assignment_id),
+            )
+            cur.execute(
+                "UPDATE slots SET status = 'free', current_task_id = NULL, current_assignment_id = NULL, lease_started_at = NULL, last_updated_at = CURRENT_TIMESTAMP WHERE slot_id = ?",
+                (slot_id,),
+            )
+            cur.execute(
+                "INSERT INTO events (event_id, event_type, slot_id, task_id, assignment_id, bucket, payload) VALUES (?, 'slot_released', ?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), slot_id, task_id, assignment_id, bucket,
+                 json.dumps({"exit_status": exit_status, "artifacts": artifacts or [],
+                             "actor": "autonomous-loop"})),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    return {"slot_id": slot_id, "task_id": task_id, "bucket": bucket,
+            "exit_status": exit_status}
+
+
+async def _spawn_task_internal(
+    *,
+    slot_id: str,
+    task_id: str,
+    task_spec: dict[str, Any],
+    force: bool = False,
+    parent_spawn_id: str | None = None,
+    lineage_relation: str = "autonomous-claim",
+) -> dict[str, Any]:
+    """The Phase 2 spawn_task body without HTTPException wrappers.
+
+    Returns a dict with shape:
+       {ok, status_code, spawn_id, outcome, exit_code, duration_ms,
+        binary_sha256, binary_path, session_id, model, error,
+        spawner_response, host, bucket, spawner_url}
+    HTTPException-style errors are returned as ok=false with status_code
+    and outcome populated.
+    """
+    spawn_id = str(uuid.uuid4())
+    started_iso = utcnow_iso()
+    t_start = time.time()
+
+    # Lineage row goes in regardless of outcome (so retries link cleanly).
+    _record_lineage(child_spawn_id=spawn_id, parent_spawn_id=parent_spawn_id,
+                    relation=lineage_relation,
+                    parent_task_id=None, child_task_id=task_id,
+                    payload={"slot_id": slot_id, "spec_id": task_spec.get("id")})
+
+    # 1. Subscription guard
+    guard = _slot_manager_subscription_guard()
+    if guard:
+        _record_spawn(spawn_id=spawn_id, slot_id=slot_id, task_id=task_id,
+                      outcome="rejected_guard", api_key_guard_passed=False,
+                      started_at_iso=started_iso)
+        _complete_spawn(spawn_id=spawn_id,
+                        duration_ms=int((time.time() - t_start) * 1000),
+                        outcome="rejected_guard", error=guard)
+        return {"ok": False, "status_code": 451, "spawn_id": spawn_id,
+                "outcome": "rejected_guard", "error": guard,
+                "duration_ms": int((time.time() - t_start) * 1000)}
+
+    # 2. Look up slot
+    with _db_lock:
+        row = db().execute(
+            "SELECT s.slot_id, s.bucket, s.host, s.status, s.current_task_id, "
+            "       s.current_assignment_id "
+            "  FROM slots s WHERE s.slot_id = ?",
+            (slot_id,),
+        ).fetchone()
+    if row is None:
+        return {"ok": False, "status_code": 404, "spawn_id": spawn_id,
+                "outcome": "parse_error",
+                "error": f"unknown slot {slot_id!r}",
+                "duration_ms": int((time.time() - t_start) * 1000)}
+    if row["status"] != "occupied":
+        return {"ok": False, "status_code": 409, "spawn_id": spawn_id,
+                "outcome": "parse_error",
+                "error": f"slot {slot_id} not occupied (status={row['status']})",
+                "duration_ms": int((time.time() - t_start) * 1000)}
+
+    bucket = row["bucket"]
+    host_name = row["host"] or DEFAULT_HOST_FOR_BUCKET.get(bucket, bucket)
+    assignment_id = row["current_assignment_id"]
+    effective_task_id = task_id or row["current_task_id"]
+
+    # 3. Host registry
+    with _db_lock:
+        host_row = db().execute(
+            "SELECT name, spawner_url, state FROM hosts WHERE name = ?",
+            (host_name,),
+        ).fetchone()
+    if host_row is None:
+        _record_spawn(spawn_id=spawn_id, slot_id=slot_id, bucket=bucket,
+                      host=host_name, task_id=effective_task_id,
+                      outcome="rejected_no_host", api_key_guard_passed=True,
+                      started_at_iso=started_iso)
+        _complete_spawn(spawn_id=spawn_id,
+                        duration_ms=int((time.time() - t_start) * 1000),
+                        outcome="rejected_no_host",
+                        error=f"host {host_name!r} not registered")
+        return {"ok": False, "status_code": 503, "spawn_id": spawn_id,
+                "outcome": "rejected_no_host", "host": host_name,
+                "error": f"host {host_name!r} not registered",
+                "duration_ms": int((time.time() - t_start) * 1000)}
+    if host_row["state"] not in ("active",):
+        _record_spawn(spawn_id=spawn_id, slot_id=slot_id, bucket=bucket,
+                      host=host_name, task_id=effective_task_id,
+                      spawner_url=host_row["spawner_url"],
+                      outcome="rejected_drained", api_key_guard_passed=True,
+                      started_at_iso=started_iso)
+        _complete_spawn(spawn_id=spawn_id,
+                        duration_ms=int((time.time() - t_start) * 1000),
+                        outcome="rejected_drained",
+                        error=f"host {host_name!r} state={host_row['state']!r}")
+        return {"ok": False, "status_code": 503, "spawn_id": spawn_id,
+                "outcome": "rejected_drained", "host": host_name,
+                "error": f"host state={host_row['state']!r}",
+                "duration_ms": int((time.time() - t_start) * 1000)}
+
+    # 4. Budget
+    if not force:
+        with _db_lock:
+            cur = db().cursor()
+            cur.execute("BEGIN IMMEDIATE;")
+            try:
+                ok, state = _budget_take_locked(cur, bucket)
+                cur.execute("COMMIT;")
+            except Exception:
+                cur.execute("ROLLBACK;")
+                raise
+        if not ok:
+            _record_spawn(spawn_id=spawn_id, slot_id=slot_id, bucket=bucket,
+                          host=host_name, task_id=effective_task_id,
+                          spawner_url=host_row["spawner_url"],
+                          outcome="rejected_budget", api_key_guard_passed=True,
+                          started_at_iso=started_iso)
+            _complete_spawn(spawn_id=spawn_id,
+                            duration_ms=int((time.time() - t_start) * 1000),
+                            outcome="rejected_budget",
+                            error=f"bucket {bucket!r} budget exhausted")
+            return {"ok": False, "status_code": 429, "spawn_id": spawn_id,
+                    "outcome": "rejected_budget", "host": host_name,
+                    "tokens_remaining": (state or {}).get("tokens_remaining"),
+                    "duration_ms": int((time.time() - t_start) * 1000)}
+
+    _record_spawn(spawn_id=spawn_id, slot_id=slot_id, bucket=bucket,
+                  host=host_name, task_id=effective_task_id,
+                  spawner_url=host_row["spawner_url"],
+                  outcome="pending", api_key_guard_passed=True,
+                  started_at_iso=started_iso)
+
+    # ---------------------------------------------------------------
+    # Phase 5: resolve permission_mode + allow_list + risk_tier and
+    # gate high-risk dispatches on a fresh operator approval.
+    # ---------------------------------------------------------------
+    permission_mode = (task_spec.get("permission_mode")
+                       or _bucket_permission_mode(bucket))
+    if permission_mode not in VALID_PERMISSION_MODES:
+        permission_mode = DEFAULT_PERMISSION_MODE
+
+    repo_scope = task_spec.get("repo_scope")
+    allow_list = _bucket_allow_list(bucket, repo_scope=repo_scope)
+
+    risk_tier, classifier = _classify_risk_tier(task_spec)
+
+    approval_used: str | None = None
+    if risk_tier == "high":
+        appr = _check_approval(effective_task_id)
+        if not appr.get("ok"):
+            err = (f"high-risk task {effective_task_id!r} requires fresh "
+                   f"operator approval ({appr.get('error')}); "
+                   f"POST /admin/approve/{effective_task_id} to grant "
+                   f"(1h TTL). classifier={classifier}")
+            _complete_spawn(spawn_id=spawn_id,
+                            duration_ms=int((time.time() - t_start) * 1000),
+                            outcome="rejected_guard", error=err)
+            _record_dispatch_risk(spawn_id=spawn_id,
+                                  task_id=effective_task_id,
+                                  bucket=bucket, risk_tier=risk_tier,
+                                  permission_mode=permission_mode,
+                                  classifier=classifier,
+                                  approval_used=None,
+                                  allow_list=allow_list)
+            log.warning("phase5: rejected_guard high-risk no-approval task=%s classifier=%s",
+                        effective_task_id, classifier)
+            return {"ok": False, "status_code": 451, "spawn_id": spawn_id,
+                    "outcome": "approval_required", "host": host_name,
+                    "bucket": bucket, "task_id": effective_task_id,
+                    "risk_tier": risk_tier, "classifier": classifier,
+                    "error": err,
+                    "duration_ms": int((time.time() - t_start) * 1000)}
+        approval_used = appr.get("approval_id")
+
+    _record_dispatch_risk(spawn_id=spawn_id,
+                          task_id=effective_task_id,
+                          bucket=bucket, risk_tier=risk_tier,
+                          permission_mode=permission_mode,
+                          classifier=classifier,
+                          approval_used=approval_used,
+                          allow_list=allow_list)
+
+    auto_pr = bool(task_spec.get("auto_pr",
+                                 permission_mode in ("acceptEdits", "bypassPermissions")))
+    auto_merge_default = (risk_tier == "low"
+                          and permission_mode in ("acceptEdits", "bypassPermissions"))
+    auto_merge = bool(task_spec.get("auto_merge", auto_merge_default))
+    if risk_tier == "high":
+        auto_merge = False
+
+    cwd = task_spec.get("cwd")
+    # Phase 6 fix: cwd default is host-aware via the bucket allow-list root.
+    # M1 -> /Users/MAC/Documents/projects; stolution -> /home/s903/stolution.
+    _allow_root = (allow_list[0] if allow_list else "/Users/MAC/Documents/projects").rstrip("/")
+    if not cwd and repo_scope:
+        cwd = f"{_allow_root}/{repo_scope.strip('/')}"
+    elif not cwd and permission_mode in ("acceptEdits", "bypassPermissions"):
+        cwd = _allow_root
+
+    base_url = (
+        os.environ.get("SLOT_MANAGER_PUBLIC_URL")
+        or f"http://{os.environ.get('POD_IP') or os.environ.get('SERVICE_NAME', 'slot-manager')}:{SERVICE_PORT}"
+    )
+    dispatch_payload: dict[str, Any] = {
+        "spawn_id":           spawn_id,
+        "slot_id":            slot_id,
+        "task_id":            effective_task_id,
+        "assignment_id":      assignment_id,
+        "task_spec":          task_spec,
+        "bucket":             bucket,
+        "host":               host_name,
+        "heartbeat_url":      f"{base_url.rstrip('/')}/heartbeat",
+        "release_url":        f"{base_url.rstrip('/')}/release",
+        "spawn_callback_url": f"{base_url.rstrip('/')}/admin/spawn-completion",
+        "require_subscription": True,
+        "timeout_sec":        SPAWN_TIMEOUT_SEC,
+        "parent_spawn_id":    parent_spawn_id,
+        "permission_mode":    permission_mode,
+        "allow_list":         allow_list,
+        "risk_tier":          risk_tier,
+        "cwd":                cwd,
+        "auto_pr":            auto_pr,
+        "auto_merge":         auto_merge,
+    }
+
+    if approval_used:
+        _consume_approval(effective_task_id, spawn_id)
+
+    status_code, body_resp = await _dispatch_to_spawner(
+        spawner_url=host_row["spawner_url"],
+        payload=dispatch_payload,
+        timeout_s=SPAWN_TIMEOUT_SEC,
+    )
+    duration_ms = int((time.time() - t_start) * 1000)
+
+    if status_code == 599:
+        _complete_spawn(spawn_id=spawn_id, duration_ms=duration_ms,
+                        outcome="timeout", error=str(body_resp))
+        return {"ok": False, "status_code": 504, "spawn_id": spawn_id,
+                "outcome": "timeout", "host": host_name, "bucket": bucket,
+                "error": str(body_resp), "duration_ms": duration_ms}
+    if status_code in (598, 597):
+        _complete_spawn(spawn_id=spawn_id, duration_ms=duration_ms,
+                        outcome="dispatch_error", error=str(body_resp))
+        return {"ok": False, "status_code": 502, "spawn_id": spawn_id,
+                "outcome": "dispatch_error", "host": host_name, "bucket": bucket,
+                "error": str(body_resp), "duration_ms": duration_ms}
+    if status_code != 200:
+        err_str = (body_resp if isinstance(body_resp, str)
+                   else json.dumps(body_resp)[:1000])
+        exc = (body_resp.get("exit_code") if isinstance(body_resp, dict) else None)
+        _complete_spawn(spawn_id=spawn_id, duration_ms=duration_ms,
+                        outcome="spawner_error", exit_code=exc, error=err_str)
+        return {"ok": False, "status_code": 502, "spawn_id": spawn_id,
+                "outcome": "spawner_error", "host": host_name, "bucket": bucket,
+                "exit_code": exc, "error": err_str, "duration_ms": duration_ms}
+
+    if not isinstance(body_resp, dict):
+        _complete_spawn(spawn_id=spawn_id, duration_ms=duration_ms,
+                        outcome="spawner_error",
+                        error=f"non-JSON 200 body: {str(body_resp)[:200]}")
+        return {"ok": False, "status_code": 502, "spawn_id": spawn_id,
+                "outcome": "spawner_error", "host": host_name, "bucket": bucket,
+                "error": "non-JSON 200", "duration_ms": duration_ms}
+
+    if not body_resp.get("subscription_only", False):
+        _complete_spawn(spawn_id=spawn_id, duration_ms=duration_ms,
+                        outcome="rejected_guard",
+                        error="spawner did not confirm subscription_only=true",
+                        binary_sha256=body_resp.get("binary_sha256"),
+                        binary_path=body_resp.get("binary_path"))
+        return {"ok": False, "status_code": 451, "spawn_id": spawn_id,
+                "outcome": "rejected_guard", "host": host_name, "bucket": bucket,
+                "error": "spawner did not confirm subscription-only",
+                "duration_ms": duration_ms}
+
+    spawner_outcome = body_resp.get("outcome") or ("ok" if body_resp.get("ok") else "spawner_error")
+    exit_code = body_resp.get("exit_code")
+    if exit_code is None and "rc" in body_resp:
+        exit_code = body_resp.get("rc")
+    binary_sha256 = body_resp.get("binary_sha256")
+    binary_path   = body_resp.get("binary_path")
+    session_id    = (body_resp.get("session_id")
+                     or (body_resp.get("parsed") or {}).get("session_id"))
+    model         = (body_resp.get("model")
+                     or (body_resp.get("parsed") or {}).get("model"))
+
+    final_outcome = "ok" if (spawner_outcome == "ok" and (exit_code in (None, 0))) else "spawner_error"
+
+    # Phase 4: classify cap-throttle signal in the spawner's error blob.
+    err_blob = body_resp.get("error") or body_resp.get("stderr") or ""
+    if final_outcome != "ok" and _is_cap_throttle_signal(err_blob):
+        final_outcome = "cap_throttled"
+
+    err_field = None
+    if final_outcome != "ok":
+        err_field = f"spawner outcome={spawner_outcome} exit_code={exit_code} err={str(err_blob)[:240]}"
+
+    _complete_spawn(spawn_id=spawn_id, duration_ms=duration_ms,
+                    outcome=final_outcome, exit_code=exit_code,
+                    binary_sha256=binary_sha256, binary_path=binary_path,
+                    session_id=session_id, model=model, error=err_field)
+
+    log.info(
+        "spawn-task ok=%s spawn_id=%s slot=%s host=%s bucket=%s outcome=%s exit=%s dur_ms=%d session=%s",
+        final_outcome == "ok", spawn_id, slot_id, host_name, bucket,
+        final_outcome, exit_code, duration_ms, session_id,
+    )
+
+    return {
+        "ok":                  final_outcome == "ok",
+        "status_code":         200,
+        "spawn_id":            spawn_id,
+        "slot_id":             slot_id,
+        "task_id":             effective_task_id,
+        "bucket":              bucket,
+        "host":                host_name,
+        "spawner_url":         host_row["spawner_url"],
+        "outcome":             final_outcome,
+        "exit_code":           exit_code,
+        "duration_ms":         duration_ms,
+        "binary_sha256":       binary_sha256,
+        "binary_path":         binary_path,
+        "session_id":          session_id,
+        "model":               model,
+        "subscription_only":   True,
+        "started_at":          started_iso,
+        "completed_at":        utcnow_iso(),
+        "spawner_response":    body_resp,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 autonomous loop
+# ---------------------------------------------------------------------------
+
+# Process-local rolling window of recent claim timestamps (for the circuit
+# breaker). Each entry is a UNIX float seconds.
+_recent_claim_ts: list[float] = []
+_recent_claim_lock = threading.Lock()
+
+
+def _record_recent_claim() -> None:
+    now = time.time()
+    with _recent_claim_lock:
+        _recent_claim_ts.append(now)
+        # Trim entries older than the window.
+        cutoff = now - LOOP_CIRCUIT_BREAK_WINDOW_SEC
+        while _recent_claim_ts and _recent_claim_ts[0] < cutoff:
+            _recent_claim_ts.pop(0)
+
+
+def _claim_rate_per_sec() -> float:
+    now = time.time()
+    cutoff = now - LOOP_CIRCUIT_BREAK_WINDOW_SEC
+    with _recent_claim_lock:
+        # Trim
+        while _recent_claim_ts and _recent_claim_ts[0] < cutoff:
+            _recent_claim_ts.pop(0)
+        n = len(_recent_claim_ts)
+    return n / max(1.0, float(LOOP_CIRCUIT_BREAK_WINDOW_SEC))
+
+
+def _list_eligible_buckets() -> list[dict[str, Any]]:
+    """Return buckets with autonomy=on, in order. Each entry has:
+       {bucket, free_slots, host, host_state, sps_alias, tokens, max_per_minute}.
+    """
+    out: list[dict[str, Any]] = []
+    with _db_lock:
+        cur = db().cursor()
+        states = {r["scope"]: r["state"]
+                  for r in cur.execute("SELECT scope, state FROM autonomy_state").fetchall()}
+        gstate = states.get("global", LOOP_GLOBAL_DEFAULT)
+        if gstate != "on":
+            return []
+        slot_rows = cur.execute(
+            "SELECT bucket, host, COUNT(*) AS free_n FROM slots WHERE status = 'free' GROUP BY bucket, host"
+        ).fetchall()
+        host_rows = {r["name"]: r["state"]
+                     for r in cur.execute("SELECT name, state FROM hosts").fetchall()}
+        # Phase 6 fix: refill spawn-budget tokens for each bucket with free
+        # slots BEFORE reading them, so eligibility reflects time-elapsed
+        # refill instead of a stale snapshot. Without this, the budget skip
+        # reason became a permanent stall when tokens dipped below 1.0
+        # (per slot_manager_budget_throttle_unblock_2026-05-10.md).
+        budget_rows: dict[str, dict[str, Any]] = {}
+        seen_buckets: set[str] = set()
+        for _r in slot_rows:
+            _b = _r["bucket"]
+            if _b in seen_buckets:
+                continue
+            seen_buckets.add(_b)
+            _state = _budget_peek_locked(cur, _b)
+            if _state is not None:
+                budget_rows[_b] = {
+                    "bucket":           _state["bucket"],
+                    "max_per_minute":   _state["max_per_minute"],
+                    "tokens_remaining": _state["tokens_remaining"],
+                }
+
+    for r in slot_rows:
+        bucket = r["bucket"]
+        scope = f"bucket:{bucket}"
+        bstate = states.get(scope, LOOP_PER_BUCKET_DEFAULT)
+        if bstate != "on":
+            continue
+        host = r["host"] or DEFAULT_HOST_FOR_BUCKET.get(bucket, bucket)
+        host_state = host_rows.get(host, "unregistered")
+        budget = budget_rows.get(bucket, {})
+        out.append({
+            "bucket": bucket,
+            "host": host,
+            "host_state": host_state,
+            "free_slots": int(r["free_n"]),
+            "sps_alias": SPS_BUCKET_ALIASES.get(bucket, bucket),
+            "tokens_remaining": float(budget.get("tokens_remaining", 0.0)),
+            "max_per_minute": int(budget.get("max_per_minute", DEFAULT_SPAWN_MAX_PER_MIN)),
+        })
+    out.sort(key=lambda e: (e["bucket"], e["host"]))
+    return out
+
+
+def _record_loop_tick(*, claims: int, skips: dict[str, int], duration_ms: int) -> None:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "INSERT INTO loop_tick (claims, skips_no_work, skips_no_slot, "
+            "                       skips_budget, skips_throttled, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (claims, skips.get("no_work", 0), skips.get("no_slot", 0),
+             skips.get("budget", 0), skips.get("throttled", 0), duration_ms),
+        )
+        # Trim retention.
+        cur.execute(
+            "DELETE FROM loop_tick WHERE id IN ("
+            "  SELECT id FROM loop_tick ORDER BY id DESC LIMIT -1 OFFSET ?)",
+            (LOOP_AUDIT_TRIM_AFTER,),
+        )
+
+
+def _circuit_break_if_runaway() -> bool:
+    """If recent claim rate > LOOP_CIRCUIT_BREAK_PER_SEC sustained for the
+    full window, flip global autonomy to circuit-broken.
+
+    Returns True if the breaker fired.
+    """
+    rate = _claim_rate_per_sec()
+    if rate > LOOP_CIRCUIT_BREAK_PER_SEC:
+        glob = _read_autonomy("global")
+        if glob and glob["state"] == "on":
+            _set_autonomy("global", "circuit-broken", actor="circuit-breaker",
+                          reason=f"claim-rate {rate:.3f}/s > {LOOP_CIRCUIT_BREAK_PER_SEC}/s "
+                                 f"sustained for {LOOP_CIRCUIT_BREAK_WINDOW_SEC}s")
+            log.error("CIRCUIT BREAKER: claim rate %.3f/s exceeded threshold; loop paused", rate)
+            return True
+    return False
+
+
+def _check_all_hosts_throttled() -> bool:
+    """If every registered active host is cap-throttled, surface and pause."""
+    with _db_lock:
+        cur = db().cursor()
+        host_states = cur.execute(
+            "SELECT name FROM hosts WHERE state = 'active'"
+        ).fetchall()
+        if not host_states:
+            return False
+        active_names = [r["name"] for r in host_states]
+        throttled = []
+        for n in active_names:
+            tr = cur.execute(
+                "SELECT throttled_until, "
+                "       (strftime('%s', throttled_until) - strftime('%s','now')) AS sec_left "
+                "  FROM host_throttle_state WHERE host = ?",
+                (n,),
+            ).fetchone()
+            if tr and tr["throttled_until"] and float(tr["sec_left"] or 0) > 0:
+                throttled.append(n)
+    if active_names and len(throttled) == len(active_names):
+        glob = _read_autonomy("global")
+        if glob and glob["state"] == "on":
+            _set_autonomy("global", "cap-throttled", actor="cap-watcher",
+                          reason=f"all active hosts cap-throttled: {throttled}")
+            log.error("ALL HOSTS THROTTLED: %s; loop paused", throttled)
+            return True
+    return False
+
+
+async def autonomous_loop_task() -> None:
+    """Phase 4 main loop. Runs until cancelled."""
+    log.info("autonomy: starting loop interval=%.1fs global_default=%s per_bucket_default=%s",
+             LOOP_INTERVAL_SEC, LOOP_GLOBAL_DEFAULT, LOOP_PER_BUCKET_DEFAULT)
+    quiet_since = 0.0
+    while True:
+        t_start = time.time()
+        try:
+            await asyncio.sleep(LOOP_INTERVAL_SEC)
+            # Subscription guard re-check at top of every tick.
+            guard = _slot_manager_subscription_guard()
+            if guard:
+                log.error("autonomy: subscription guard tripped mid-loop: %s", guard)
+                _set_autonomy("global", "circuit-broken", actor="subscription-guard",
+                              reason=guard)
+                continue
+
+            # Read global autonomy.
+            glob = _read_autonomy("global")
+            gstate = (glob or {}).get("state", LOOP_GLOBAL_DEFAULT)
+            if gstate != "on":
+                # Quiet-log once per minute.
+                if time.time() - quiet_since > LOOP_QUIET_LOG_INTERVAL_SEC:
+                    log.info("autonomy: global state=%s — loop quiescent", gstate)
+                    quiet_since = time.time()
+                continue
+
+            # Iterate eligible buckets in parallel.
+            eligible = _list_eligible_buckets()
+            if not eligible:
+                if time.time() - quiet_since > LOOP_QUIET_LOG_INTERVAL_SEC:
+                    log.info("autonomy: no eligible buckets (autonomy off OR no free slots) — sleeping")
+                    quiet_since = time.time()
+                _record_loop_tick(claims=0, skips={}, duration_ms=int((time.time() - t_start) * 1000))
+                continue
+
+            results = await asyncio.gather(
+                *[_loop_tick_for_bucket(b) for b in eligible],
+                return_exceptions=True,
+            )
+
+            claims = 0
+            skips = {"no_work": 0, "no_slot": 0, "budget": 0, "throttled": 0}
+            # Phase-7: _loop_tick_for_bucket returns a LIST of per-claim dicts.
+            flat: list[dict[str, Any]] = []
+            for r in results:
+                if isinstance(r, Exception):
+                    log.exception("autonomy: per-bucket tick raised: %r", r)
+                    continue
+                if isinstance(r, list):
+                    flat.extend(x for x in r if isinstance(x, dict))
+                elif isinstance(r, dict):
+                    flat.append(r)
+            for r in flat:
+                action = r.get("action")
+                if action == "claim":
+                    claims += 1
+                elif action == "skip":
+                    reason = r.get("reason", "unknown")
+                    skips[reason] = skips.get(reason, 0) + 1
+
+            duration_ms = int((time.time() - t_start) * 1000)
+            _record_loop_tick(claims=claims, skips=skips, duration_ms=duration_ms)
+
+            # Update global last_tick_at marker.
+            with _db_lock:
+                db().execute(
+                    "UPDATE autonomy_state SET last_tick_at = CURRENT_TIMESTAMP WHERE scope = 'global'"
+                )
+
+            if claims:
+                quiet_since = 0.0
+                log.info("autonomy: tick — claims=%d skips=%s duration_ms=%d", claims, skips, duration_ms)
+            else:
+                if time.time() - quiet_since > LOOP_QUIET_LOG_INTERVAL_SEC:
+                    log.info("autonomy: tick — no claims (skips=%s) eligible_buckets=%d duration_ms=%d",
+                             skips, len(eligible), duration_ms)
+                    quiet_since = time.time()
+
+            # Check stop conditions.
+            _circuit_break_if_runaway()
+            _check_all_hosts_throttled()
+
+        except asyncio.CancelledError:
+            log.info("autonomy: loop cancelled")
+            return
+        except Exception:
+            log.exception("autonomy: loop iteration raised; sleeping and continuing")
+
+
+async def _loop_tick_for_bucket(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """One tick of the autonomous loop for a single bucket.
+
+    Phase-7 fan-out: instead of one claim+dispatch per tick per bucket,
+    fans out up to min(free_slots, floor(tokens_remaining),
+    LOOP_FANOUT_CAP_PER_BUCKET) parallel claim+dispatch coroutines so the
+    loop can ramp toward bucket cap quickly. The token-bucket budget
+    (`spawn_budget`) still gates the sustained spawn rate; this only
+    changes the per-tick burst-up shape.
+
+    Returns a list of per-claim result dicts (each with action="claim" or "skip").
+    """
+    bucket = spec["bucket"]
+    host   = spec["host"]
+
+    # Bucket-level skip preconditions — no point fanning out.
+    if spec["free_slots"] <= 0:
+        return [{"action": "skip", "reason": "no_slot", "bucket": bucket}]
+    if spec["host_state"] != "active":
+        return [{"action": "skip", "reason": "throttled", "bucket": bucket,
+                 "detail": f"host_state={spec['host_state']!r}"}]
+    if _is_host_cap_throttled(host):
+        return [{"action": "skip", "reason": "throttled", "bucket": bucket,
+                 "detail": f"host {host} cap-throttled"}]
+    if spec["tokens_remaining"] < 1.0:
+        return [{"action": "skip", "reason": "budget", "bucket": bucket,
+                 "tokens_remaining": spec["tokens_remaining"]}]
+
+    fanout = min(int(spec["free_slots"]),
+                 int(spec["tokens_remaining"]),
+                 LOOP_FANOUT_CAP_PER_BUCKET)
+    if fanout <= 0:
+        return [{"action": "skip", "reason": "no_slot", "bucket": bucket}]
+
+    inner = await asyncio.gather(
+        *[_single_claim_and_dispatch_for_bucket(spec) for _ in range(fanout)],
+        return_exceptions=True,
+    )
+    out: list[dict[str, Any]] = []
+    for r in inner:
+        if isinstance(r, Exception):
+            log.exception("autonomy: fan-out claim raised for bucket=%s: %r", bucket, r)
+            out.append({"action": "skip", "reason": "no_work", "bucket": bucket,
+                        "detail": f"exception: {r!r}"})
+        elif isinstance(r, dict):
+            out.append(r)
+    return out
+
+
+async def _single_claim_and_dispatch_for_bucket(spec: dict[str, Any]) -> dict[str, Any]:
+    """Phase-7 helper: a single claim+dispatch attempt for the bucket described in spec.
+
+    Contains the original body of _loop_tick_for_bucket from the SPS pull onward.
+    The fan-out wrapper enforces bucket-level preconditions before calling this,
+    so we only do per-attempt races here (SPS spec pull, _claim_internal,
+    _spawn_task_internal). Concurrent racers safely lose to _db_lock and
+    bounce through SPS as ``cancelled``/``no_slot``.
+    """
+    bucket = spec["bucket"]
+    host = spec["host"]
+    sps_alias = spec["sps_alias"]
+
+    # Skip if no free slots.
+    if spec["free_slots"] <= 0:
+        return {"action": "skip", "reason": "no_slot", "bucket": bucket}
+
+    # Skip if host inactive or cap-throttled.
+    if spec["host_state"] != "active":
+        return {"action": "skip", "reason": "throttled", "bucket": bucket,
+                "detail": f"host_state={spec['host_state']!r}"}
+    if _is_host_cap_throttled(host):
+        return {"action": "skip", "reason": "throttled", "bucket": bucket,
+                "detail": f"host {host} cap-throttled"}
+
+    # Skip if budget < 1.
+    if spec["tokens_remaining"] < 1.0:
+        return {"action": "skip", "reason": "budget", "bucket": bucket,
+                "tokens_remaining": spec["tokens_remaining"]}
+
+    # Pull a spec from SPS — use a synthetic slot_id that flags it as a peek
+    # (slot-manager will claim its own real slot below). We pass a unique
+    # placeholder so SPS records spawn-via-slot history.
+    placeholder_slot = f"auto:{bucket}:{uuid.uuid4().hex[:8]}"
+    sps_spec = await sps_request_next_spawn(bucket, placeholder_slot)
+    if sps_spec is None:
+        return {"action": "skip", "reason": "no_work", "bucket": bucket}
+
+    # Validate spec shape (parse_error).
+    spec_id = sps_spec.get("id")
+    if not spec_id:
+        log.warning("autonomy: SPS returned malformed spec for bucket=%s: %s",
+                    bucket, json.dumps(sps_spec)[:240])
+        # Best-effort completion: tell SPS the work failed to parse.
+        await sps_post_completion(node_id=sps_spec.get("id") or "unknown",
+                                   bucket_alias=sps_alias, outcome="failed",
+                                   outcome_detail="parse_error: missing id")
+        return {"action": "skip", "reason": "no_work", "bucket": bucket,
+                "detail": "parse_error"}
+
+    # Internal claim.
+    claimed = _claim_internal(bucket, task_id=spec_id, node_id=spec_id,
+                              event_type="autonomous_claim")
+    if claimed is None:
+        # Race: race lost — release the SPS-side claim by completing as cancelled.
+        await sps_post_completion(node_id=spec_id, bucket_alias=sps_alias,
+                                   outcome="cancelled",
+                                   outcome_detail="slot-manager claim race")
+        return {"action": "skip", "reason": "no_slot", "bucket": bucket}
+
+    _record_recent_claim()
+
+    # Dispatch.
+    try:
+        result = await _spawn_task_internal(
+            slot_id=claimed["slot_id"],
+            task_id=spec_id,
+            task_spec=sps_spec,
+            parent_spawn_id=None,
+            lineage_relation="autonomous-claim",
+        )
+    except Exception as e:
+        log.exception("autonomy: dispatch raised for bucket=%s id=%s", bucket, spec_id)
+        result = {"ok": False, "spawn_id": None, "outcome": "dispatch_error",
+                  "host": host, "bucket": bucket, "error": str(e), "duration_ms": 0}
+
+    # Surface cap-throttle signal.
+    if result.get("outcome") == "cap_throttled":
+        _record_cap_event(host)
+
+    # Map slot-manager outcome → SPS outcome.
+    sm_outcome = result.get("outcome", "spawner_error")
+    if sm_outcome == "ok":
+        sps_outcome = "done"
+    elif sm_outcome in ("rejected_guard",):
+        sps_outcome = "failed"
+    elif sm_outcome in ("cap_throttled", "rejected_budget", "rejected_drained", "rejected_no_host"):
+        sps_outcome = "cancelled"  # bounce back to ready when SPS resolves
+    else:
+        sps_outcome = "failed"
+
+    detail = f"sm_outcome={sm_outcome} spawn_id={result.get('spawn_id')} dur_ms={result.get('duration_ms')}"
+    await sps_post_completion(node_id=spec_id, bucket_alias=sps_alias,
+                               outcome=sps_outcome, outcome_detail=detail)
+
+    # Release the slot.
+    _release_internal(claimed["slot_id"], spec_id,
+                       exit_status=int(result.get("exit_code") or 0),
+                       error_message=result.get("error"))
+
+    # Phase 4 retry path (transient outcomes).
+    retry_attempt_no = None
+    if _retryable_outcome(sm_outcome):
+        max_retries, backoff = _resolve_retry_budget(bucket, host)
+        # Walk lineage to count prior retry-of attempts in this chain.
+        attempt = 1
+        cur_id = result.get("spawn_id")
+        with _db_lock:
+            cur = db().cursor()
+            while cur_id:
+                row = cur.execute(
+                    "SELECT parent_spawn_id, relation FROM spawn_lineage WHERE child_spawn_id = ?",
+                    (cur_id,),
+                ).fetchone()
+                if row is None or row["relation"] != "retry-of":
+                    break
+                attempt += 1
+                cur_id = row["parent_spawn_id"]
+        retry_attempt_no = attempt
+        if attempt < max_retries:
+            backoff_idx = min(attempt - 1, len(backoff) - 1)
+            delay = backoff[backoff_idx]
+            log.info("autonomy: scheduling retry attempt=%d/%d for spec_id=%s after %.1fs",
+                     attempt + 1, max_retries, spec_id, delay)
+            asyncio.create_task(_schedule_retry(
+                bucket=bucket, host=host, sps_alias=sps_alias,
+                spec=sps_spec, parent_spawn_id=result.get("spawn_id"),
+                delay_s=delay, attempt=attempt + 1, max_retries=max_retries,
+            ))
+        else:
+            # Exhausted — write to dead-letter.
+            log.warning("autonomy: retries exhausted for spec_id=%s after %d attempts; dead-letter",
+                        spec_id, attempt)
+            with _db_lock:
+                db().execute(
+                    "INSERT INTO spawn_dead_letter "
+                    "(original_spawn_id, bucket, host, task_id, attempts, last_outcome, last_error, payload) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (result.get("spawn_id"), bucket, host, spec_id, attempt, sm_outcome,
+                     result.get("error"), json.dumps(sps_spec)[:8000]),
+                )
+
+    # Update last_claim_at on the autonomy_state row.
+    with _db_lock:
+        db().execute(
+            "UPDATE autonomy_state SET last_claim_at = CURRENT_TIMESTAMP WHERE scope = ?",
+            (f"bucket:{bucket}",),
+        )
+
+    return {"action": "claim", "bucket": bucket, "outcome": sm_outcome,
+            "spawn_id": result.get("spawn_id"), "task_id": spec_id,
+            "retry_attempt": retry_attempt_no}
+
+
+async def _schedule_retry(*, bucket: str, host: str, sps_alias: str,
+                           spec: dict[str, Any], parent_spawn_id: str | None,
+                           delay_s: float, attempt: int, max_retries: int) -> None:
+    """Phase 4: scheduled retry. Fires after delay_s, claims a slot,
+    dispatches with lineage='retry-of'.
+    """
+    try:
+        await asyncio.sleep(delay_s)
+    except asyncio.CancelledError:
+        return
+    spec_id = spec.get("id")
+    if not spec_id:
+        return
+    # Re-acquire a slot.
+    claimed = _claim_internal(bucket, task_id=spec_id, node_id=spec_id,
+                              event_type="autonomous_retry")
+    if claimed is None:
+        log.info("autonomy: retry — no free slot for bucket=%s spec_id=%s; will be re-handled by next tick",
+                 bucket, spec_id)
+        return
+    _record_recent_claim()
+    try:
+        result = await _spawn_task_internal(
+            slot_id=claimed["slot_id"],
+            task_id=spec_id,
+            task_spec=spec,
+            parent_spawn_id=parent_spawn_id,
+            lineage_relation="retry-of",
+        )
+    except Exception as e:
+        result = {"ok": False, "outcome": "dispatch_error",
+                  "spawn_id": None, "error": str(e), "duration_ms": 0}
+
+    sm_outcome = result.get("outcome", "spawner_error")
+    sps_outcome = "done" if sm_outcome == "ok" else (
+        "failed" if sm_outcome in ("rejected_guard",)
+        else "cancelled" if sm_outcome in ("cap_throttled","rejected_budget","rejected_drained","rejected_no_host")
+        else "failed")
+    await sps_post_completion(node_id=spec_id, bucket_alias=sps_alias,
+                               outcome=sps_outcome,
+                               outcome_detail=f"retry attempt={attempt}/{max_retries} sm_outcome={sm_outcome}")
+    _release_internal(claimed["slot_id"], spec_id,
+                       exit_status=int(result.get("exit_code") or 0),
+                       error_message=result.get("error"))
+
+    # Recursive retry / dead-letter.
+    if _retryable_outcome(sm_outcome) and attempt < max_retries:
+        _, backoff = _resolve_retry_budget(bucket, host)
+        idx = min(attempt - 1, len(backoff) - 1)
+        asyncio.create_task(_schedule_retry(
+            bucket=bucket, host=host, sps_alias=sps_alias, spec=spec,
+            parent_spawn_id=result.get("spawn_id"),
+            delay_s=backoff[idx], attempt=attempt + 1, max_retries=max_retries,
+        ))
+    elif _retryable_outcome(sm_outcome):
+        with _db_lock:
+            db().execute(
+                "INSERT INTO spawn_dead_letter "
+                "(original_spawn_id, bucket, host, task_id, attempts, last_outcome, last_error, payload) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (result.get("spawn_id"), bucket, host, spec_id, attempt, sm_outcome,
+                 result.get("error"), json.dumps(spec)[:8000]),
+            )
+
+
+# ---------------------------------------------------------------------------
+# FastAPI lifespan
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    log.info("slot-manager %s starting; sqlite=%s sps=%s sps_enabled=%s",
+             VERSION, SQLITE_PATH, SPS_BASE_URL, SPS_ENABLED)
+    guard = _slot_manager_subscription_guard()
+    if guard:
+        log.error("STARTUP REFUSED: %s", guard)
+        raise SystemExit(2)
+    log.info("subscription-guard OK at startup (ANTHROPIC_API_KEY unset)")
+    apply_schema()
+    seed_slots(load_config())
+
+    watchdog_task = asyncio.create_task(heartbeat_watchdog())
+    auto_task     = asyncio.create_task(autonomous_loop_task())
+    log.info("slot-manager ready on port %d (watchdog + autonomous loop running)", SERVICE_PORT)
+    try:
+        yield
+    finally:
+        for t in (auto_task, watchdog_task):
+            t.cancel()
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+        if _db is not None:
+            _db.close()
+
+
+app = FastAPI(
+    title="Slot Manager",
+    description="Phase 4 — autonomous loop polls SPS, self-claims slots, dispatches "
+                "to host spawners, releases. Subscription-only at every layer.",
+    version=VERSION,
+    lifespan=lifespan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Read endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/health", response_class=PlainTextResponse)
+@app.get("/healthz", response_class=PlainTextResponse)
+def health() -> str:
+    with _db_lock:
+        db().execute("SELECT 1").fetchone()
+    return "OK"
+
+
+@app.get("/version")
+def version() -> dict[str, Any]:
+    return {
+        "service":             SERVICE_NAME,
+        "version":             VERSION,
+        "phase":               5,
+        "sps_base_url":        SPS_BASE_URL,
+        "sps_enabled":         SPS_ENABLED,
+        "sps_bucket_aliases":  SPS_BUCKET_ALIASES,
+        "default_host_for_bucket": DEFAULT_HOST_FOR_BUCKET,
+        "lease_ttl_sec":       LEASE_TTL_SEC,
+        "heartbeat_timeout":   HEARTBEAT_TIMEOUT_SEC,
+        "watchdog_interval":   WATCHDOG_INTERVAL_SEC,
+        "host_offline_after":  HOST_OFFLINE_AFTER_SEC,
+        "spawn_timeout_sec":   SPAWN_TIMEOUT_SEC,
+        "default_spawn_max_per_minute": DEFAULT_SPAWN_MAX_PER_MIN,
+        "subscription_guard_at_startup": True,
+        "loop_interval_sec":   LOOP_INTERVAL_SEC,
+        "loop_global_default": LOOP_GLOBAL_DEFAULT,
+        "loop_per_bucket_default": LOOP_PER_BUCKET_DEFAULT,
+        "loop_circuit_break_per_sec": LOOP_CIRCUIT_BREAK_PER_SEC,
+        "loop_circuit_break_window_sec": LOOP_CIRCUIT_BREAK_WINDOW_SEC,
+        "cap_event_threshold": CAP_EVENT_THRESHOLD,
+        "cap_event_window_sec": CAP_EVENT_WINDOW_SEC,
+        "cap_reset_window_sec": CAP_RESET_WINDOW_SEC,
+        "default_retry_max":   DEFAULT_RETRY_MAX,
+        "default_retry_backoff_s": DEFAULT_RETRY_BACKOFF_S,
+        "valid_permission_modes":  sorted(VALID_PERMISSION_MODES),
+        "default_permission_mode": DEFAULT_PERMISSION_MODE,
+        "default_bucket_permissions": DEFAULT_BUCKET_PERMISSIONS,
+        "default_bucket_path_allowlist": DEFAULT_BUCKET_PATH_ALLOWLIST,
+        "approval_ttl_sec":  APPROVAL_TTL_SEC,
+        "high_risk_pattern_count":   len(HIGH_RISK_PATTERNS),
+        "medium_risk_pattern_count": len(MEDIUM_RISK_PATTERNS),
+    }
+
+
+@app.get("/slots")
+def list_slots() -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute("SELECT * FROM slots ORDER BY bucket, index_in_bucket").fetchall()
+    slots = [slot_to_dict(r) for r in rows]
+    by_bucket: dict[str, dict[str, int]] = {}
+    by_host:   dict[str, dict[str, int]] = {}
+    for s in slots:
+        b = by_bucket.setdefault(s["bucket"], {"total": 0, "free": 0, "occupied": 0,
+                                               "claimed": 0, "draining": 0, "disabled": 0})
+        b["total"] += 1
+        b[s["status"]] = b.get(s["status"], 0) + 1
+        h = by_host.setdefault(s.get("host") or "<unset>", {"total": 0, "free": 0, "occupied": 0,
+                                                            "claimed": 0, "draining": 0, "disabled": 0})
+        h["total"] += 1
+        h[s["status"]] = h.get(s["status"], 0) + 1
+    return {
+        "slots":          slots,
+        "total_count":    len(slots),
+        "free_count":     sum(1 for s in slots if s["status"] == "free"),
+        "occupied_count": sum(1 for s in slots if s["status"] == "occupied"),
+        "claimed_count":  sum(1 for s in slots if s["status"] == "claimed"),
+        "disabled_count": sum(1 for s in slots if s["status"] == "disabled"),
+        "by_bucket":      by_bucket,
+        "by_host":        by_host,
+    }
+
+
+@app.get("/slots/{machine}")
+def slots_by_machine(machine: str) -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT * FROM slots WHERE bucket = ? ORDER BY index_in_bucket",
+            (machine,),
+        ).fetchall()
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"unknown bucket {machine!r}")
+    return {"machine": machine, "slots": [slot_to_dict(r) for r in rows]}
+
+
+# ---------------------------------------------------------------------------
+# Claim
+# ---------------------------------------------------------------------------
+
+@app.post("/claim")
+async def claim_slot(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    bucket  = body.get("bucket")
+    task_id = body.get("task_id")
+    node_id = body.get("node_id") or "phase1-smoke"
+    if not bucket:
+        raise HTTPException(status_code=400, detail="missing 'bucket'")
+    assignment_id = str(uuid.uuid4())
+    task_id = task_id or f"phase1-{assignment_id[:8]}"
+    claimed = _claim_internal(bucket, task_id=task_id, node_id=node_id)
+    if claimed is None:
+        with _db_lock:
+            row = db().execute("SELECT 1 FROM slots WHERE bucket = ? LIMIT 1", (bucket,)).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"unknown bucket {bucket!r}")
+        return JSONResponse(status_code=503, content={"detail": "no free slots in bucket; retry"})
+    log.info("claim: bucket=%s host=%s slot=%s task=%s assignment=%s",
+             bucket, claimed.get("host"), claimed["slot_id"],
+             claimed["task_id"], claimed["assignment_id"])
+    return JSONResponse(status_code=200, content={
+        "slot_id":       claimed["slot_id"],
+        "bucket":        bucket,
+        "host":          claimed.get("host"),
+        "assignment_id": claimed["assignment_id"],
+        "task_id":       claimed["task_id"],
+        "claimed_at":    utcnow_iso(),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Release (with SPS spec fetch — Phase 1 contract)
+# ---------------------------------------------------------------------------
+
+async def _do_release(slot_id: str, task_id: str, exit_status: int = 0,
+                      artifacts: list[str] | None = None,
+                      error_message: str | None = None) -> dict[str, Any]:
+    bucket: str | None = None
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            cur.execute(
+                "SELECT slot_id, status, current_task_id, current_assignment_id, bucket FROM slots WHERE slot_id = ?",
+                (slot_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                cur.execute("ROLLBACK;")
+                raise HTTPException(status_code=404, detail=f"unknown slot {slot_id!r}")
+            assignment_id = row["current_assignment_id"]
+            bucket = row["bucket"]
+            current_task = row["current_task_id"]
+            if row["status"] != "occupied":
+                cur.execute("ROLLBACK;")
+                raise HTTPException(status_code=409,
+                    detail=f"slot {slot_id} not occupied (status={row['status']})")
+            if current_task != task_id:
+                cur.execute("ROLLBACK;")
+                raise HTTPException(status_code=409,
+                    detail=f"task_id mismatch: slot has {current_task!r}, got {task_id!r}")
+            cur.execute(
+                "UPDATE assignments SET completed_at = CURRENT_TIMESTAMP, exit_status = ?, error_message = ? WHERE assignment_id = ?",
+                (exit_status, error_message, assignment_id),
+            )
+            cur.execute(
+                "UPDATE slots SET status = 'free', current_task_id = NULL, current_assignment_id = NULL, lease_started_at = NULL, last_updated_at = CURRENT_TIMESTAMP WHERE slot_id = ?",
+                (slot_id,),
+            )
+            cur.execute(
+                "INSERT INTO events (event_id, event_type, slot_id, task_id, assignment_id, bucket, payload) VALUES (?, 'slot_released', ?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), slot_id, task_id, assignment_id, bucket,
+                 json.dumps({"exit_status": exit_status, "artifacts": artifacts or []})),
+            )
+            cur.execute("COMMIT;")
+        except HTTPException:
+            raise
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+
+    log.info("release: slot=%s task=%s exit=%d", slot_id, task_id, exit_status)
+
+    next_task_spec: dict[str, Any] | None = None
+    if bucket:
+        t0 = time.time()
+        next_task_spec = await sps_request_next_spawn(bucket, slot_id)
+        latency_ms = int((time.time() - t0) * 1000)
+        try:
+            with _db_lock:
+                db().execute(
+                    "INSERT INTO spawn_log (slot_id, bucket, task_id, dispatch_status, sps_latency_ms) VALUES (?, ?, ?, ?, ?)",
+                    (slot_id, bucket,
+                     (next_task_spec or {}).get("item_code")
+                     or (next_task_spec or {}).get("id")
+                     or None,
+                     "success" if next_task_spec else "error_sps",
+                     latency_ms),
+                )
+        except Exception:
+            log.exception("spawn_log insert failed (non-fatal)")
+
+    return {
+        "slot_id":         slot_id,
+        "task_id":         task_id,
+        "released_at":     utcnow_iso(),
+        "exit_status":     exit_status,
+        "next_task_spec":  next_task_spec,
+    }
+
+
+@app.post("/release")
+async def release_slot_body(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    slot_id = body.get("slot_id")
+    task_id = body.get("task_id")
+    exit_status = int(body.get("exit_status", 0))
+    artifacts = body.get("artifacts") or []
+    error_message = body.get("error_message")
+    if not slot_id or not task_id:
+        raise HTTPException(status_code=400, detail="missing 'slot_id' or 'task_id'")
+    return JSONResponse(status_code=200,
+        content=await _do_release(slot_id, task_id, exit_status, artifacts, error_message))
+
+
+@app.post("/release/{slot_id}/{task_id}")
+async def release_slot_path(slot_id: str, task_id: str, request: Request) -> JSONResponse:
+    body = await _json_body(request, allow_empty=True)
+    exit_status = int(body.get("exit_status", 0))
+    artifacts = body.get("artifacts") or []
+    error_message = body.get("error_message")
+    return JSONResponse(status_code=200,
+        content=await _do_release(slot_id, task_id, exit_status, artifacts, error_message))
+
+
+# ---------------------------------------------------------------------------
+# /spawn-task — HTTP wrapper around _spawn_task_internal
+# ---------------------------------------------------------------------------
+
+@app.post("/spawn-task")
+async def spawn_task(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    slot_id   = body.get("slot_id")
+    task_spec = body.get("task_spec")
+    force     = bool(body.get("force", False))
+    explicit_task_id = body.get("task_id")
+    parent_spawn_id  = body.get("parent_spawn_id")
+    lineage_relation = body.get("lineage_relation") or (
+        "decomposed-into" if parent_spawn_id else "autonomous-claim"
+    )
+    if not slot_id or not isinstance(task_spec, dict):
+        raise HTTPException(status_code=400,
+            detail="missing 'slot_id' or 'task_spec' (must be object)")
+
+    # Resolve task_id from slot if not given (Phase 2 behaviour).
+    effective_task_id = explicit_task_id
+    if effective_task_id is None:
+        with _db_lock:
+            row = db().execute("SELECT current_task_id FROM slots WHERE slot_id = ?", (slot_id,)).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"unknown slot {slot_id!r}")
+        effective_task_id = row["current_task_id"]
+    if not effective_task_id:
+        raise HTTPException(status_code=409, detail=f"slot {slot_id!r} has no current_task_id")
+
+    result = await _spawn_task_internal(
+        slot_id=slot_id, task_id=effective_task_id, task_spec=task_spec,
+        force=force, parent_spawn_id=parent_spawn_id,
+        lineage_relation=lineage_relation,
+    )
+    if result["ok"] or result.get("status_code") == 200:
+        return JSONResponse(status_code=200, content=result)
+    sc = result.get("status_code", 502)
+    if sc == 429:
+        return JSONResponse(status_code=429,
+            headers={"Retry-After": "15"},
+            content={**result, "retry_after_sec": 15})
+    if sc == 451:
+        raise HTTPException(status_code=451, detail=result.get("error", "subscription guard"))
+    if sc in (502, 504):
+        raise HTTPException(status_code=sc, detail=result)
+    if sc == 503:
+        raise HTTPException(status_code=503, detail=result.get("error"))
+    if sc in (404, 409):
+        raise HTTPException(status_code=sc, detail=result.get("error"))
+    return JSONResponse(status_code=sc, content=result)
+
+
+@app.get("/spawn-telemetry")
+def spawn_telemetry_list(limit: int = Query(50, le=500),
+                         bucket: str | None = Query(None),
+                         host: str | None = Query(None),
+                         outcome: str | None = Query(None)) -> dict[str, Any]:
+    sql = "SELECT * FROM spawn_telemetry"
+    args: list[Any] = []
+    where: list[str] = []
+    if bucket:
+        where.append("bucket = ?"); args.append(bucket)
+    if host:
+        where.append("host = ?"); args.append(host)
+    if outcome:
+        where.append("outcome = ?"); args.append(outcome)
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"telemetry": [dict(r) for r in rows]}
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat
+# ---------------------------------------------------------------------------
+
+def _do_heartbeat(slot_id: str, task_id: str) -> dict[str, Any]:
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            cur.execute(
+                "UPDATE assignments SET last_heartbeat_at = CURRENT_TIMESTAMP WHERE slot_id = ? AND task_id = ? AND completed_at IS NULL",
+                (slot_id, task_id),
+            )
+            updated = cur.rowcount
+            if updated:
+                cur.execute(
+                    "INSERT INTO events (event_id, event_type, slot_id, task_id, bucket) "
+                    "SELECT ?, 'heartbeat', slot_id, task_id, bucket FROM assignments "
+                    "WHERE slot_id = ? AND task_id = ? AND completed_at IS NULL",
+                    (str(uuid.uuid4()), slot_id, task_id),
+                )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    if updated == 0:
+        raise HTTPException(status_code=404, detail="no active assignment for slot/task")
+    return {"slot_id": slot_id, "task_id": task_id, "ack_at": utcnow_iso()}
+
+
+@app.post("/heartbeat")
+async def heartbeat_body(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    slot_id = body.get("slot_id")
+    task_id = body.get("task_id")
+    if not slot_id or not task_id:
+        raise HTTPException(status_code=400, detail="missing 'slot_id' or 'task_id'")
+    return JSONResponse(content=_do_heartbeat(slot_id, task_id))
+
+
+@app.post("/heartbeat/{slot_id}/{task_id}")
+async def heartbeat_path(slot_id: str, task_id: str) -> JSONResponse:
+    return JSONResponse(content=_do_heartbeat(slot_id, task_id))
+
+
+@app.post("/webhooks/completion")
+async def webhook_completion(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    slot_id = body.get("slot_id")
+    task_id = body.get("task_id")
+    exit_status = int(body.get("exit_status", 0))
+    artifacts = body.get("artifacts") or []
+    error_message = body.get("error_message")
+    if not slot_id or not task_id:
+        raise HTTPException(status_code=400, detail="missing 'slot_id' or 'task_id'")
+    return JSONResponse(content=await _do_release(slot_id, task_id, exit_status, artifacts, error_message))
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: /admin/spawn-completion (idempotent on spawn_id)
+# ---------------------------------------------------------------------------
+
+@app.post("/admin/spawn-completion")
+async def admin_spawn_completion(request: Request) -> JSONResponse:
+    """Mac spawner posts here on terminal states (incl. interrupted/recovery).
+
+    Body shape (lifted from the spawner):
+        {spawn_id, outcome, exit_code?, session_id?, model?, error?,
+         binary_sha256?, binary_path?, slot_id?, task_id?}
+    Idempotent: if the spawn_telemetry row is already terminal, returns 200
+    with the existing record.
+    """
+    body = await _json_body(request)
+    spawn_id = body.get("spawn_id")
+    if not spawn_id:
+        raise HTTPException(status_code=400, detail="missing 'spawn_id'")
+
+    existing = _get_spawn_telemetry(spawn_id)
+    if existing is None:
+        # Spawner POSTed a callback for a spawn we never recorded.
+        # Surface — likely a bug — but accept idempotently.
+        log.warning("/admin/spawn-completion: unknown spawn_id=%s body=%s",
+                    spawn_id, json.dumps(body)[:240])
+        # Insert a stub so we have lineage.
+        _record_spawn(spawn_id=spawn_id,
+                      slot_id=body.get("slot_id"), task_id=body.get("task_id"),
+                      bucket=body.get("bucket"), host=body.get("host"),
+                      outcome="pending", api_key_guard_passed=True)
+        existing = _get_spawn_telemetry(spawn_id)
+
+    # Idempotency: if already completed, return existing record without mutation.
+    if existing and existing.get("completed_at"):
+        return JSONResponse(content={"ok": True, "idempotent": True, "telemetry": existing})
+
+    # Map spawner outcome → slot-manager outcome.
+    spawner_outcome = (body.get("outcome") or "").strip()
+    exit_code       = body.get("exit_code")
+    error           = body.get("error")
+    if spawner_outcome == "ok" and exit_code in (None, 0):
+        sm_outcome = "ok"
+    elif spawner_outcome == "interrupted":
+        sm_outcome = "interrupted"
+    elif spawner_outcome == "timeout":
+        sm_outcome = "timeout"
+    elif spawner_outcome == "rejected_guard":
+        sm_outcome = "rejected_guard"
+    elif _is_cap_throttle_signal(error):
+        sm_outcome = "cap_throttled"
+    elif spawner_outcome in ("crashed", "failed", "spawner_error"):
+        sm_outcome = "spawner_error"
+    elif spawner_outcome == "":
+        sm_outcome = "spawner_error"
+    else:
+        sm_outcome = "spawner_error"
+
+    # Compute duration from started_at if present.
+    duration_ms = None
+    started_at = (existing or {}).get("started_at")
+    if started_at:
+        try:
+            with _db_lock:
+                row = db().execute(
+                    "SELECT (strftime('%s','now') - strftime('%s', ?)) * 1000 AS d", (started_at,),
+                ).fetchone()
+                duration_ms = int(row["d"] or 0)
+        except Exception:
+            duration_ms = None
+    if duration_ms is None:
+        duration_ms = int(body.get("duration_ms") or 0)
+
+    _complete_spawn(
+        spawn_id=spawn_id,
+        duration_ms=duration_ms,
+        outcome=sm_outcome,
+        exit_code=exit_code,
+        binary_sha256=body.get("binary_sha256"),
+        binary_path=body.get("binary_path"),
+        session_id=body.get("session_id"),
+        model=body.get("model"),
+        error=error,
+    )
+
+    if sm_outcome == "cap_throttled":
+        host = (existing or {}).get("host") or body.get("host")
+        if host:
+            _record_cap_event(host)
+
+    # Best-effort: free the slot if it's still occupied for that spawn.
+    slot_id = (existing or {}).get("slot_id") or body.get("slot_id")
+    task_id = (existing or {}).get("task_id") or body.get("task_id")
+    released = None
+    if slot_id and task_id:
+        released = _release_internal(slot_id, task_id,
+                                      exit_status=int(exit_code or 0),
+                                      error_message=error)
+
+    log.info("/admin/spawn-completion: spawn_id=%s outcome=%s released_slot=%s",
+             spawn_id, sm_outcome, bool(released))
+    return JSONResponse(content={
+        "ok": True, "idempotent": False,
+        "spawn_id": spawn_id, "outcome": sm_outcome,
+        "released_slot": bool(released),
+        "telemetry": _get_spawn_telemetry(spawn_id),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: lineage endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/spawn-lineage/{spawn_id}")
+def spawn_lineage(spawn_id: str) -> dict[str, Any]:
+    return _spawn_lineage_walk(spawn_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: dead-letter endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/admin/spawn-dead-letter")
+def admin_dead_letter_list(
+    bucket: str | None = Query(None),
+    host: str | None = Query(None),
+    limit: int = Query(100, le=500),
+) -> dict[str, Any]:
+    sql = "SELECT * FROM spawn_dead_letter WHERE replayed_at IS NULL"
+    args: list[Any] = []
+    if bucket:
+        sql += " AND bucket = ?"; args.append(bucket)
+    if host:
+        sql += " AND host = ?"; args.append(host)
+    sql += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"dead_letter": [dict(r) for r in rows]}
+
+
+@app.post("/admin/spawn-dead-letter/{dl_id}/replay")
+async def admin_dead_letter_replay(dl_id: int,
+                                    actor: str = Query("operator"),
+                                    reason: str = Query("")) -> JSONResponse:
+    with _db_lock:
+        row = db().execute(
+            "SELECT * FROM spawn_dead_letter WHERE id = ? AND replayed_at IS NULL", (dl_id,),
+        ).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"dead-letter id={dl_id} not found or already replayed")
+    bucket = row["bucket"]
+    host = row["host"]
+    try:
+        spec = json.loads(row["payload"]) if row["payload"] else {}
+    except Exception:
+        spec = {}
+    spec_id = spec.get("id") or row["task_id"]
+    if not spec_id:
+        raise HTTPException(status_code=400, detail="dead-letter row has no recoverable task_id")
+
+    claimed = _claim_internal(bucket, task_id=spec_id, node_id=spec_id, event_type="dead_letter_replay")
+    if claimed is None:
+        raise HTTPException(status_code=503, detail="no free slot to replay into")
+    _record_recent_claim()
+    result = await _spawn_task_internal(
+        slot_id=claimed["slot_id"], task_id=spec_id, task_spec=spec,
+        parent_spawn_id=row["original_spawn_id"], lineage_relation="replay-of",
+    )
+    sm_outcome = result.get("outcome", "spawner_error")
+    sps_alias = SPS_BUCKET_ALIASES.get(bucket, bucket)
+    sps_outcome = ("done" if sm_outcome == "ok"
+                   else "failed" if sm_outcome in ("rejected_guard",)
+                   else "cancelled")
+    await sps_post_completion(node_id=spec_id, bucket_alias=sps_alias,
+                               outcome=sps_outcome,
+                               outcome_detail=f"replay-of dl_id={dl_id} sm_outcome={sm_outcome}")
+    _release_internal(claimed["slot_id"], spec_id,
+                       exit_status=int(result.get("exit_code") or 0),
+                       error_message=result.get("error"))
+    with _db_lock:
+        db().execute(
+            "UPDATE spawn_dead_letter SET replayed_at = CURRENT_TIMESTAMP, replay_spawn_id = ? WHERE id = ?",
+            (result.get("spawn_id"), dl_id),
+        )
+    log.info("dead-letter replay: dl_id=%d new_spawn_id=%s outcome=%s actor=%s",
+             dl_id, result.get("spawn_id"), sm_outcome, actor)
+    return JSONResponse(content={"ok": True, "dl_id": dl_id, "result": result, "actor": actor, "reason": reason})
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: autonomy admin
+# ---------------------------------------------------------------------------
+
+@app.get("/admin/autonomy")
+def admin_autonomy_get() -> dict[str, Any]:
+    return _list_autonomy()
+
+
+@app.post("/admin/autonomy/{bucket}")
+def admin_autonomy_set(bucket: str,
+                        state: str = Query(...),
+                        actor: str = Query("operator"),
+                        reason: str = Query("")) -> dict[str, Any]:
+    if state not in ("on", "off"):
+        raise HTTPException(status_code=400, detail="state must be on|off")
+    return _set_autonomy(f"bucket:{bucket}", state, actor=actor, reason=reason)
+
+
+@app.post("/admin/autonomy/global")
+def admin_autonomy_global(state: str = Query(...),
+                           actor: str = Query("operator"),
+                           reason: str = Query("")) -> dict[str, Any]:
+    if state not in ("on", "off"):
+        raise HTTPException(status_code=400, detail="state must be on|off")
+    return _set_autonomy("global", state, actor=actor, reason=reason)
+
+
+# Operator-friendly aliases per the user's leg-prompt §5: /admin/loop/{enable,disable,status}.
+@app.post("/admin/loop/enable")
+def admin_loop_enable(actor: str = Query("operator"), reason: str = Query("")) -> dict[str, Any]:
+    return _set_autonomy("global", "on", actor=actor, reason=reason)
+
+
+@app.post("/admin/loop/disable")
+def admin_loop_disable(actor: str = Query("operator"), reason: str = Query("")) -> dict[str, Any]:
+    return _set_autonomy("global", "off", actor=actor, reason=reason)
+
+
+@app.get("/admin/loop/status")
+def admin_loop_status() -> dict[str, Any]:
+    state = _list_autonomy()
+    with _db_lock:
+        recent = db().execute(
+            "SELECT id, ts, claims, skips_no_work, skips_no_slot, skips_budget, skips_throttled, duration_ms "
+            "  FROM loop_tick ORDER BY id DESC LIMIT 20"
+        ).fetchall()
+        ticks_total = db().execute("SELECT COUNT(*) AS n FROM loop_tick").fetchone()["n"]
+        claims_total = db().execute("SELECT COALESCE(SUM(claims),0) AS n FROM loop_tick").fetchone()["n"]
+        throttle_rows = db().execute(
+            "SELECT host, cap_event_count, throttled_until FROM host_throttle_state"
+        ).fetchall()
+    return {
+        "autonomy":          state,
+        "loop_tick_total":   ticks_total,
+        "loop_claims_total": claims_total,
+        "loop_recent_ticks": [dict(r) for r in recent],
+        "claim_rate_per_sec": _claim_rate_per_sec(),
+        "host_throttle":     [dict(r) for r in throttle_rows],
+    }
+
+
+@app.get("/admin/loop/changes")
+def admin_loop_changes(limit: int = Query(100, le=500)) -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT id, scope, old_state, new_state, actor, reason, changed_at FROM loop_changes "
+            " ORDER BY id DESC LIMIT ?", (limit,),
+        ).fetchall()
+    return {"changes": [dict(r) for r in rows]}
+
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: bucket_permissions / bucket_path_allowlists / approvals admin
+# ---------------------------------------------------------------------------
+
+@app.get("/admin/bucket-permissions")
+def admin_bucket_permissions_list() -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT bucket, permission_mode, updated_at, actor, reason "
+            "  FROM bucket_permissions ORDER BY bucket"
+        ).fetchall()
+    return {"permissions": [dict(r) for r in rows],
+            "valid_modes": sorted(VALID_PERMISSION_MODES),
+            "default_mode": DEFAULT_PERMISSION_MODE}
+
+
+@app.post("/admin/bucket-permissions/{bucket}")
+def admin_bucket_permissions_set(bucket: str,
+                                 permission_mode: str = Query(...),
+                                 actor: str = Query("operator"),
+                                 reason: str = Query("")) -> dict[str, Any]:
+    if permission_mode not in VALID_PERMISSION_MODES:
+        raise HTTPException(status_code=400,
+                            detail=f"permission_mode must be one of "
+                                   f"{sorted(VALID_PERMISSION_MODES)}")
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "INSERT INTO bucket_permissions (bucket, permission_mode, actor, reason) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(bucket) DO UPDATE SET "
+            "  permission_mode = excluded.permission_mode, "
+            "  updated_at = CURRENT_TIMESTAMP, "
+            "  actor = excluded.actor, "
+            "  reason = excluded.reason",
+            (bucket, permission_mode, actor, reason),
+        )
+    log.info("admin: bucket_permissions[%s] = %s (actor=%s reason=%s)",
+             bucket, permission_mode, actor, reason)
+    return {"bucket": bucket, "permission_mode": permission_mode,
+            "actor": actor, "reason": reason}
+
+
+@app.get("/admin/bucket-path-allowlists")
+def admin_bucket_path_allowlists_list(bucket: str | None = None) -> dict[str, Any]:
+    with _db_lock:
+        if bucket:
+            rows = db().execute(
+                "SELECT id, bucket, path, active, created_at, actor, reason "
+                "  FROM bucket_path_allowlists WHERE bucket = ? ORDER BY id",
+                (bucket,),
+            ).fetchall()
+        else:
+            rows = db().execute(
+                "SELECT id, bucket, path, active, created_at, actor, reason "
+                "  FROM bucket_path_allowlists ORDER BY bucket, id"
+            ).fetchall()
+    return {"allowlists": [dict(r) for r in rows]}
+
+
+@app.post("/admin/bucket-path-allowlists")
+def admin_bucket_path_allowlists_add(bucket: str = Query(...),
+                                     path: str = Query(...),
+                                     actor: str = Query("operator"),
+                                     reason: str = Query("")) -> dict[str, Any]:
+    bad = re.compile(r"^/etc(/|$)|^/var(/|$)|^/System(/|$)|^/usr(/|$)|"
+                     r"^/Library(/|$)|^/boot(/|$)")
+    if bad.match(path):
+        raise HTTPException(status_code=400,
+                            detail=f"path {path!r} matches blocklist")
+    if not path.startswith("/"):
+        raise HTTPException(status_code=400, detail="path must be absolute")
+    with _db_lock:
+        cur = db().cursor()
+        try:
+            cur.execute(
+                "INSERT INTO bucket_path_allowlists "
+                "  (bucket, path, actor, reason) VALUES (?, ?, ?, ?)",
+                (bucket, path, actor, reason),
+            )
+            new_id = cur.lastrowid
+        except sqlite3.IntegrityError:
+            raise HTTPException(status_code=409,
+                                detail=f"path already in allowlist for bucket={bucket!r}")
+    return {"id": new_id, "bucket": bucket, "path": path}
+
+
+@app.delete("/admin/bucket-path-allowlists/{row_id}")
+def admin_bucket_path_allowlists_delete(row_id: int,
+                                        actor: str = Query("operator"),
+                                        reason: str = Query("")) -> dict[str, Any]:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("DELETE FROM bucket_path_allowlists WHERE id = ?", (row_id,))
+        if cur.rowcount != 1:
+            raise HTTPException(status_code=404, detail=f"id {row_id} not found")
+    log.info("admin: bucket_path_allowlists DELETE id=%s actor=%s reason=%s",
+             row_id, actor, reason)
+    return {"id": row_id, "deleted": True}
+
+
+@app.post("/admin/approve/{task_id}")
+def admin_approve_task(task_id: str,
+                       actor: str = Query(...),
+                       reason: str = Query(...),
+                       ttl_seconds: int = Query(APPROVAL_TTL_SEC,
+                                                ge=60, le=86400),
+                       ) -> dict[str, Any]:
+    expires_at = (datetime.now(timezone.utc)
+                  + timedelta(seconds=ttl_seconds)).strftime("%Y-%m-%d %H:%M:%S")
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "INSERT INTO task_approvals "
+            "  (task_id, expires_at, actor, reason, used_at, used_spawn_id) "
+            "VALUES (?, ?, ?, ?, NULL, NULL) "
+            "ON CONFLICT(task_id) DO UPDATE SET "
+            "  approved_at = CURRENT_TIMESTAMP, "
+            "  expires_at = excluded.expires_at, "
+            "  actor = excluded.actor, "
+            "  reason = excluded.reason, "
+            "  used_at = NULL, "
+            "  used_spawn_id = NULL",
+            (task_id, expires_at, actor, reason),
+        )
+    log.warning("admin: APPROVAL granted task=%s actor=%s reason=%s expires=%s",
+                task_id, actor, reason, expires_at)
+    return {"task_id": task_id, "expires_at": expires_at,
+            "ttl_seconds": ttl_seconds, "actor": actor, "reason": reason}
+
+
+@app.delete("/admin/approve/{task_id}")
+def admin_revoke_task(task_id: str,
+                      actor: str = Query("operator"),
+                      reason: str = Query("")) -> dict[str, Any]:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("DELETE FROM task_approvals WHERE task_id = ?", (task_id,))
+        deleted = cur.rowcount
+    log.warning("admin: APPROVAL revoked task=%s actor=%s reason=%s deleted=%d",
+                task_id, actor, reason, deleted)
+    return {"task_id": task_id, "deleted": deleted}
+
+
+@app.get("/admin/approvals")
+def admin_approvals_list(include_used: bool = False) -> dict[str, Any]:
+    sql = ("SELECT task_id, approved_at, expires_at, actor, reason, "
+           "       used_at, used_spawn_id FROM task_approvals ")
+    if not include_used:
+        sql += " WHERE used_at IS NULL "
+    sql += " ORDER BY approved_at DESC LIMIT 200"
+    with _db_lock:
+        rows = db().execute(sql).fetchall()
+    return {"approvals": [dict(r) for r in rows],
+            "ttl_seconds_default": APPROVAL_TTL_SEC}
+
+
+@app.post("/admin/risk-classify")
+async def admin_risk_classify(req: Request) -> dict[str, Any]:
+    body = await req.json()
+    task_spec = body.get("task_spec") or body
+    bucket = body.get("bucket") or task_spec.get("target_bucket") or task_spec.get("bucket") or "M1"
+    for short, alias in SPS_BUCKET_ALIASES.items():
+        if bucket == alias:
+            bucket = short
+            break
+    permission_mode = (task_spec.get("permission_mode")
+                       or _bucket_permission_mode(bucket))
+    allow_list = _bucket_allow_list(bucket, repo_scope=task_spec.get("repo_scope"))
+    risk_tier, classifier = _classify_risk_tier(task_spec)
+    approved = _check_approval(task_spec.get("id") or task_spec.get("task_id") or "")
+    return {
+        "bucket": bucket,
+        "permission_mode": permission_mode,
+        "allow_list": allow_list,
+        "risk_tier": risk_tier,
+        "classifier": classifier,
+        "approval_status": approved,
+    }
+
+
+@app.get("/admin/dispatch-risk-log")
+def admin_dispatch_risk_log(limit: int = Query(100, ge=1, le=1000),
+                             tier: str | None = None) -> dict[str, Any]:
+    sql = ("SELECT id, spawn_id, task_id, bucket, risk_tier, "
+           "       permission_mode, classifier, approval_used, "
+           "       allow_list_json, created_at "
+           "  FROM dispatch_risk_log ")
+    args: list[Any] = []
+    if tier:
+        sql += " WHERE risk_tier = ? "
+        args.append(tier)
+    sql += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"dispatches": [dict(r) for r in rows]}
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: spawn-retry-budget admin
+# ---------------------------------------------------------------------------
+
+@app.get("/spawn-retry-budget")
+def spawn_retry_budget_list() -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT bucket, host, max_retries, backoff_s_csv, updated_at FROM spawn_retry_budget"
+        ).fetchall()
+    return {"retry_budgets": [dict(r) for r in rows]}
+
+
+@app.post("/spawn-retry-budget")
+def spawn_retry_budget_set(bucket: str = Query(...),
+                            host: str = Query(...),
+                            max_retries: int = Query(..., ge=0, le=20),
+                            backoff_s_csv: str = Query("1,2,4")) -> dict[str, Any]:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "INSERT INTO spawn_retry_budget (bucket, host, max_retries, backoff_s_csv) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(bucket, host) DO UPDATE SET max_retries = excluded.max_retries, "
+            "                                       backoff_s_csv = excluded.backoff_s_csv, "
+            "                                       updated_at = CURRENT_TIMESTAMP",
+            (bucket, host, max_retries, backoff_s_csv),
+        )
+    return {"bucket": bucket, "host": host, "max_retries": max_retries, "backoff_s_csv": backoff_s_csv}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1/2 admin endpoints (capacity, budget, host federation) — unchanged
+# ---------------------------------------------------------------------------
+
+@app.post("/capacity")
+def capacity_admin(
+    bucket: str = Query(...),
+    value: int  = Query(..., ge=0, le=256),
+    actor: str  = Query("operator"),
+    reason: str = Query(""),
+) -> JSONResponse:
+    new_capacity = int(value)
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            existing = cur.execute(
+                "SELECT slot_id, index_in_bucket, status FROM slots WHERE bucket = ? ORDER BY index_in_bucket",
+                (bucket,),
+            ).fetchall()
+            old_capacity = sum(1 for r in existing if r["status"] != "disabled")
+            old_max_idx  = max((r["index_in_bucket"] for r in existing), default=0)
+            disabled_now: list[str] = []
+            added_now:    list[str] = []
+            host_for_new = DEFAULT_HOST_FOR_BUCKET.get(bucket, bucket)
+            cfg = load_config()
+            buckets_cfg = cfg.get("buckets") or {}
+            if bucket in buckets_cfg and "host" in buckets_cfg[bucket]:
+                host_for_new = buckets_cfg[bucket]["host"]
+            if new_capacity > old_max_idx:
+                lease = LEASE_TTL_SEC
+                for idx in range(old_max_idx + 1, new_capacity + 1):
+                    sid = f"{bucket}-{idx}"
+                    cur.execute(
+                        "INSERT OR IGNORE INTO slots (slot_id, bucket, index_in_bucket, status, lease_seconds, host) VALUES (?, ?, ?, 'free', ?, ?)",
+                        (sid, bucket, idx, lease, host_for_new),
+                    )
+                    added_now.append(sid)
+                for r in existing:
+                    if r["status"] == "disabled" and r["index_in_bucket"] <= new_capacity:
+                        cur.execute(
+                            "UPDATE slots SET status='free', last_updated_at = CURRENT_TIMESTAMP WHERE slot_id = ?",
+                            (r["slot_id"],),
+                        )
+                        added_now.append(r["slot_id"])
+            elif new_capacity < old_capacity:
+                free_above = [r for r in reversed(existing)
+                              if r["index_in_bucket"] > new_capacity and r["status"] == "free"]
+                for r in free_above:
+                    cur.execute(
+                        "UPDATE slots SET status='disabled', last_updated_at = CURRENT_TIMESTAMP WHERE slot_id = ?",
+                        (r["slot_id"],),
+                    )
+                    disabled_now.append(r["slot_id"])
+            cur.execute(
+                "INSERT INTO capacity_changes (bucket, old_capacity, new_capacity, actor, reason) VALUES (?, ?, ?, ?, ?)",
+                (bucket, old_capacity, new_capacity, actor, reason),
+            )
+            cur.execute(
+                "INSERT INTO events (event_id, event_type, bucket, payload) VALUES (?, 'capacity_change', ?, ?)",
+                (str(uuid.uuid4()), bucket,
+                 json.dumps({"old": old_capacity, "new": new_capacity,
+                             "added": added_now, "disabled": disabled_now,
+                             "actor": actor, "reason": reason})),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    with _db_lock:
+        effective = db().execute(
+            "SELECT COUNT(*) AS n FROM slots WHERE bucket = ? AND status != 'disabled'",
+            (bucket,),
+        ).fetchone()["n"]
+    log.info("capacity: bucket=%s old=%d new=%d effective=%d added=%d disabled=%d actor=%s reason=%s",
+             bucket, old_capacity, new_capacity, effective,
+             len(added_now), len(disabled_now), actor, reason)
+    return JSONResponse(content={
+        "bucket": bucket, "old_capacity": old_capacity, "new_capacity": new_capacity,
+        "effective_capacity": effective, "added": added_now, "disabled": disabled_now,
+        "actor": actor, "reason": reason, "changed_at": utcnow_iso(),
+    })
+
+
+@app.get("/capacity/history")
+def capacity_history(bucket: str | None = Query(None), limit: int = Query(100, le=500)):
+    sql = "SELECT id, bucket, old_capacity, new_capacity, actor, reason, changed_at FROM capacity_changes"
+    args: list[Any] = []
+    if bucket:
+        sql += " WHERE bucket = ?"
+        args.append(bucket)
+    sql += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"history": [dict(r) for r in rows]}
+
+
+@app.get("/spawn-budget")
+def spawn_budget_get(bucket: str = Query(...)) -> dict[str, Any]:
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("BEGIN;")
+        try:
+            state = _budget_refill_locked(cur, bucket)
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    if state is None:
+        raise HTTPException(status_code=404, detail=f"no spawn-budget row for bucket {bucket!r}")
+    return state
+
+
+@app.post("/spawn-budget")
+def spawn_budget_set(bucket: str = Query(...),
+                      max_per_minute: int = Query(..., ge=0, le=600),
+                      actor: str = Query("operator"),
+                      reason: str = Query("")) -> dict[str, Any]:
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            old = cur.execute(
+                "SELECT max_per_minute FROM spawn_budget WHERE bucket = ?", (bucket,),
+            ).fetchone()
+            old_max = old["max_per_minute"] if old else None
+            if old is None:
+                cur.execute(
+                    "INSERT INTO spawn_budget (bucket, max_per_minute, tokens_remaining) VALUES (?, ?, ?)",
+                    (bucket, max_per_minute, float(max_per_minute)),
+                )
+            else:
+                cur.execute(
+                    "UPDATE spawn_budget "
+                    "   SET max_per_minute = ?, "
+                    "       tokens_remaining = MIN(tokens_remaining, ?), "
+                    "       updated_at = CURRENT_TIMESTAMP "
+                    " WHERE bucket = ?",
+                    (max_per_minute, float(max_per_minute), bucket),
+                )
+            cur.execute(
+                "INSERT INTO spawn_budget_changes (bucket, old_max_per_minute, new_max_per_minute, actor, reason) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (bucket, old_max, max_per_minute, actor, reason),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    log.info("spawn-budget: bucket=%s old=%s new=%d actor=%s reason=%s",
+             bucket, old_max, max_per_minute, actor, reason)
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("BEGIN;")
+        try:
+            state = _budget_refill_locked(cur, bucket)
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    return {"changed_at": utcnow_iso(), "old_max_per_minute": old_max, **(state or {})}
+
+
+@app.get("/spawn-budget/history")
+def spawn_budget_history(bucket: str | None = Query(None), limit: int = Query(100, le=500)) -> dict[str, Any]:
+    sql = "SELECT id, bucket, old_max_per_minute, new_max_per_minute, actor, reason, changed_at FROM spawn_budget_changes"
+    args: list[Any] = []
+    if bucket:
+        sql += " WHERE bucket = ?"; args.append(bucket)
+    sql += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    with _db_lock:
+        rows = db().execute(sql, args).fetchall()
+    return {"history": [dict(r) for r in rows]}
+
+
+@app.post("/admin/host/register")
+async def host_register(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    name        = body.get("name")
+    spawner_url = body.get("spawner_url")
+    hostname    = body.get("hostname")
+    version_str = body.get("version")
+    notes       = body.get("notes")
+    if not name or not spawner_url:
+        raise HTTPException(status_code=400, detail="missing 'name' or 'spawner_url'")
+    with _db_lock:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            existed = cur.execute("SELECT 1 FROM hosts WHERE name = ?", (name,)).fetchone()
+            if existed:
+                cur.execute(
+                    "UPDATE hosts SET spawner_url = ?, hostname = ?, version = ?, notes = ?, "
+                    "                 state = 'active', last_heartbeat_at = CURRENT_TIMESTAMP, "
+                    "                 last_state_change_at = CURRENT_TIMESTAMP "
+                    " WHERE name = ?",
+                    (spawner_url, hostname, version_str, notes, name),
+                )
+            else:
+                cur.execute(
+                    "INSERT INTO hosts (name, spawner_url, hostname, version, notes, state) "
+                    "VALUES (?, ?, ?, ?, ?, 'active')",
+                    (name, spawner_url, hostname, version_str, notes),
+                )
+            cur.execute(
+                "INSERT INTO events (event_id, event_type, payload) VALUES (?, 'host_register', ?)",
+                (str(uuid.uuid4()),
+                 json.dumps({"name": name, "spawner_url": spawner_url, "version": version_str})),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    log.info("host register: name=%s spawner_url=%s version=%s", name, spawner_url, version_str)
+    return JSONResponse(content={
+        "name": name, "spawner_url": spawner_url, "state": "active",
+        "registered_at": utcnow_iso(),
+    })
+
+
+@app.post("/admin/host/heartbeat")
+async def host_heartbeat(request: Request) -> JSONResponse:
+    body = await _json_body(request)
+    name = body.get("name")
+    if not name:
+        raise HTTPException(status_code=400, detail="missing 'name'")
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            row = cur.execute("SELECT state FROM hosts WHERE name = ?", (name,)).fetchone()
+            if row is None:
+                cur.execute("ROLLBACK;")
+                raise HTTPException(status_code=404, detail=f"host {name!r} not registered")
+            new_state = "active" if row["state"] == "offline" else row["state"]
+            cur.execute(
+                "UPDATE hosts SET last_heartbeat_at = CURRENT_TIMESTAMP, "
+                "                 state = ?, last_state_change_at = "
+                "                       CASE WHEN state = ? THEN last_state_change_at "
+                "                            ELSE CURRENT_TIMESTAMP END "
+                " WHERE name = ?",
+                (new_state, new_state, name),
+            )
+            cur.execute("COMMIT;")
+        except HTTPException:
+            raise
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    return JSONResponse(content={"name": name, "state": new_state, "ack_at": utcnow_iso()})
+
+
+@app.get("/admin/hosts")
+def hosts_list() -> dict[str, Any]:
+    with _db_lock:
+        rows = db().execute(
+            "SELECT name, spawner_url, hostname, version, state, "
+            "       registered_at, last_heartbeat_at, last_state_change_at, notes "
+            "  FROM hosts ORDER BY name"
+        ).fetchall()
+    return {"hosts": [dict(r) for r in rows]}
+
+
+@app.get("/admin/host/{name}")
+def host_get(name: str) -> dict[str, Any]:
+    with _db_lock:
+        row = db().execute(
+            "SELECT name, spawner_url, hostname, version, state, "
+            "       registered_at, last_heartbeat_at, last_state_change_at, notes "
+            "  FROM hosts WHERE name = ?",
+            (name,),
+        ).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"host {name!r} not registered")
+    return dict(row)
+
+
+@app.post("/admin/host/{name}/state")
+def host_set_state(name: str,
+                    state: str = Query(...),
+                    actor: str = Query("operator"),
+                    reason: str = Query("")) -> dict[str, Any]:
+    if state not in ("active", "drain", "disabled", "offline"):
+        raise HTTPException(status_code=400,
+            detail="state must be one of active|drain|disabled|offline")
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("BEGIN IMMEDIATE;")
+        try:
+            row = cur.execute("SELECT state FROM hosts WHERE name = ?", (name,)).fetchone()
+            if row is None:
+                cur.execute("ROLLBACK;")
+                raise HTTPException(status_code=404, detail=f"host {name!r} not registered")
+            old_state = row["state"]
+            cur.execute(
+                "UPDATE hosts SET state = ?, last_state_change_at = CURRENT_TIMESTAMP WHERE name = ?",
+                (state, name),
+            )
+            cur.execute(
+                "INSERT INTO events (event_id, event_type, payload) VALUES (?, 'host_state_change', ?)",
+                (str(uuid.uuid4()),
+                 json.dumps({"host": name, "old": old_state, "new": state, "actor": actor, "reason": reason})),
+            )
+            cur.execute("COMMIT;")
+        except HTTPException:
+            raise
+        except Exception:
+            cur.execute("ROLLBACK;")
+            raise
+    log.info("host state change: name=%s %s -> %s actor=%s reason=%s",
+             name, old_state, state, actor, reason)
+    return {"name": name, "old_state": old_state, "new_state": state, "actor": actor,
+            "reason": reason, "changed_at": utcnow_iso()}
+
+
+# ---------------------------------------------------------------------------
+# Metrics (Phase 4 expanded)
+# ---------------------------------------------------------------------------
+
+def _gather_metrics() -> dict[str, Any]:
+    with _db_lock:
+        conn = db()
+        rows = conn.execute(
+            "SELECT bucket, status, COUNT(*) AS n FROM slots GROUP BY bucket, status"
+        ).fetchall()
+        active = conn.execute(
+            "SELECT bucket, COUNT(*) AS n FROM assignments WHERE completed_at IS NULL GROUP BY bucket"
+        ).fetchall()
+        claims_by_bucket = conn.execute(
+            "SELECT bucket, COUNT(*) AS n FROM events "
+            "WHERE event_type IN ('task_spawned','autonomous_claim') "
+            "  AND strftime('%s','now') - strftime('%s', created_at) < 3600 "
+            "GROUP BY bucket"
+        ).fetchall()
+        releases_by_bucket = conn.execute(
+            "SELECT bucket, COUNT(*) AS n FROM events "
+            "WHERE event_type = 'slot_released' "
+            "  AND strftime('%s','now') - strftime('%s', created_at) < 3600 "
+            "GROUP BY bucket"
+        ).fetchall()
+        watchdog_by_bucket = conn.execute(
+            "SELECT bucket, event_type, COUNT(*) AS n FROM events "
+            "WHERE event_type IN ('heartbeat_timeout','lease_expired') "
+            "  AND strftime('%s','now') - strftime('%s', created_at) < 3600 "
+            "GROUP BY bucket, event_type"
+        ).fetchall()
+        started = conn.execute(
+            "SELECT bucket, host, COUNT(*) AS n FROM spawn_telemetry "
+            "GROUP BY bucket, host"
+        ).fetchall()
+        completed = conn.execute(
+            "SELECT bucket, host, outcome, COALESCE(exit_code,-1) AS exit_code, COUNT(*) AS n "
+            "  FROM spawn_telemetry WHERE completed_at IS NOT NULL "
+            "GROUP BY bucket, host, outcome, exit_code"
+        ).fetchall()
+        duration_rows = conn.execute(
+            "SELECT bucket, host, duration_ms FROM spawn_telemetry "
+            "WHERE duration_ms IS NOT NULL AND outcome NOT IN ('rejected_guard','rejected_budget')"
+        ).fetchall()
+        budget_rows = conn.execute(
+            "SELECT bucket, max_per_minute, tokens_remaining FROM spawn_budget"
+        ).fetchall()
+        host_rows = conn.execute("SELECT name, state FROM hosts").fetchall()
+        # Phase 4 — autonomy + loop metrics.
+        autonomy_rows = conn.execute(
+            "SELECT scope, state FROM autonomy_state"
+        ).fetchall()
+        tick_total = conn.execute("SELECT COUNT(*) AS n FROM loop_tick").fetchone()["n"]
+        claim_total = conn.execute("SELECT COALESCE(SUM(claims),0) AS n FROM loop_tick").fetchone()["n"]
+        skip_totals = conn.execute(
+            "SELECT COALESCE(SUM(skips_no_work),0) AS no_work, "
+            "       COALESCE(SUM(skips_no_slot),0) AS no_slot, "
+            "       COALESCE(SUM(skips_budget),0) AS budget, "
+            "       COALESCE(SUM(skips_throttled),0) AS throttled "
+            "  FROM loop_tick"
+        ).fetchone()
+        tick_dur = conn.execute(
+            "SELECT COALESCE(SUM(duration_ms),0) AS sum_ms, "
+            "       COALESCE(MAX(duration_ms),0) AS max_ms, "
+            "       COUNT(*) AS n "
+            "  FROM loop_tick"
+        ).fetchone()
+        dl_total = conn.execute(
+            "SELECT COUNT(*) AS n FROM spawn_dead_letter WHERE replayed_at IS NULL"
+        ).fetchone()["n"]
+        host_throttle_rows = conn.execute(
+            "SELECT host, cap_event_count, throttled_until FROM host_throttle_state"
+        ).fetchall()
+
+    by_bucket: dict[str, dict[str, int]] = {}
+    for r in rows:
+        st = by_bucket.setdefault(r["bucket"], {})
+        st[r["status"]] = r["n"]
+    summary: dict[str, dict[str, int]] = {}
+    for bucket, statuses in by_bucket.items():
+        total      = sum(statuses.values())
+        free       = statuses.get("free", 0)
+        occupied   = statuses.get("occupied", 0)
+        claimed    = statuses.get("claimed", 0)
+        disabled   = statuses.get("disabled", 0)
+        in_use     = occupied + claimed
+        summary[bucket] = {"total": total, "free": free, "in_use": in_use,
+                           "occupied": occupied, "claimed": claimed, "disabled": disabled}
+    active_map = {r["bucket"]: r["n"] for r in active}
+    claim_rate = {r["bucket"]: r["n"] for r in claims_by_bucket}
+    release_rate = {r["bucket"]: r["n"] for r in releases_by_bucket}
+    watchdog_rate: dict[str, dict[str, int]] = {}
+    for r in watchdog_by_bucket:
+        watchdog_rate.setdefault(r["bucket"], {})[r["event_type"]] = r["n"]
+    spawn_started: dict[tuple[str, str], int] = {}
+    for r in started:
+        spawn_started[(r["bucket"] or "", r["host"] or "")] = r["n"]
+    spawn_completed: list[dict[str, Any]] = [
+        {"bucket": r["bucket"] or "", "host": r["host"] or "",
+         "outcome": r["outcome"], "exit_code": r["exit_code"], "n": r["n"]}
+        for r in completed
+    ]
+    histogram: dict[tuple[str, str], dict[str, Any]] = {}
+    for r in duration_rows:
+        key = (r["bucket"] or "", r["host"] or "")
+        h = histogram.setdefault(key, {"count": 0, "sum_s": 0.0,
+                                       "buckets": {b: 0 for b in SPAWN_DURATION_BUCKETS_S}})
+        s = (r["duration_ms"] or 0) / 1000.0
+        h["count"] += 1
+        h["sum_s"] += s
+        for b in SPAWN_DURATION_BUCKETS_S:
+            if s <= b:
+                h["buckets"][b] += 1
+    spawn_budget = {r["bucket"]: {"max_per_minute": r["max_per_minute"],
+                                  "tokens_remaining": r["tokens_remaining"]}
+                    for r in budget_rows}
+    hosts = [{"name": r["name"], "state": r["state"]} for r in host_rows]
+    autonomy = {r["scope"]: r["state"] for r in autonomy_rows}
+    return {
+        "summary":                summary,
+        "active_assignments":     active_map,
+        "claims_per_hour":        claim_rate,
+        "releases_per_hour":      release_rate,
+        "watchdog_releases_per_hour": watchdog_rate,
+        "spawn_started":          spawn_started,
+        "spawn_completed":        spawn_completed,
+        "spawn_duration_hist":    histogram,
+        "spawn_budget":           spawn_budget,
+        "hosts":                  hosts,
+        "autonomy":               autonomy,
+        "loop_tick_total":        tick_total,
+        "loop_claims_total":      claim_total,
+        "loop_skip_totals":       dict(skip_totals) if skip_totals else {},
+        "loop_duration_sum_ms":   int((tick_dur or {})["sum_ms"] or 0) if tick_dur else 0,
+        "loop_duration_count":    int((tick_dur or {})["n"] or 0) if tick_dur else 0,
+        "loop_duration_max_ms":   int((tick_dur or {})["max_ms"] or 0) if tick_dur else 0,
+        "dead_letter_open":       dl_total,
+        "host_throttle":          [dict(r) for r in host_throttle_rows],
+        "claim_rate_per_sec":     _claim_rate_per_sec(),
+    }
+
+
+@app.get("/metrics", response_class=PlainTextResponse)
+def metrics() -> str:
+    m = _gather_metrics()
+    lines: list[str] = []
+    lines += [
+        "# HELP slot_capacity_total Total slots per bucket",
+        "# TYPE slot_capacity_total gauge",
+    ]
+    for bucket, s in m["summary"].items():
+        lines.append(f'slot_capacity_total{{bucket="{bucket}"}} {s["total"]}')
+    lines += [
+        "# HELP slot_status_total Slots per bucket per status",
+        "# TYPE slot_status_total gauge",
+    ]
+    for bucket, s in m["summary"].items():
+        for status in ("free", "claimed", "occupied", "draining", "disabled"):
+            lines.append(f'slot_status_total{{bucket="{bucket}",status="{status}"}} {s.get(status, 0)}')
+    lines += [
+        "# HELP slot_in_use_total In-use slots (occupied+claimed)",
+        "# TYPE slot_in_use_total gauge",
+    ]
+    for bucket, s in m["summary"].items():
+        lines.append(f'slot_in_use_total{{bucket="{bucket}"}} {s["in_use"]}')
+    lines += [
+        "# HELP slot_free_total Free slots",
+        "# TYPE slot_free_total gauge",
+    ]
+    for bucket, s in m["summary"].items():
+        lines.append(f'slot_free_total{{bucket="{bucket}"}} {s["free"]}')
+    lines += [
+        "# HELP active_assignments_total Currently-running assignments per bucket",
+        "# TYPE active_assignments_total gauge",
+    ]
+    for bucket, n in m["active_assignments"].items():
+        lines.append(f'active_assignments_total{{bucket="{bucket}"}} {n}')
+    lines += [
+        "# HELP slot_claims_per_hour Claims observed in the last 1h",
+        "# TYPE slot_claims_per_hour gauge",
+    ]
+    for bucket, n in m["claims_per_hour"].items():
+        lines.append(f'slot_claims_per_hour{{bucket="{bucket}"}} {n}')
+    lines += [
+        "# HELP slot_releases_per_hour Releases observed in the last 1h",
+        "# TYPE slot_releases_per_hour gauge",
+    ]
+    for bucket, n in m["releases_per_hour"].items():
+        lines.append(f'slot_releases_per_hour{{bucket="{bucket}"}} {n}')
+    lines += [
+        "# HELP watchdog_releases_per_hour Watchdog auto-releases in the last 1h",
+        "# TYPE watchdog_releases_per_hour gauge",
+    ]
+    for bucket, et_map in m["watchdog_releases_per_hour"].items():
+        for ev, n in et_map.items():
+            lines.append(f'watchdog_releases_per_hour{{bucket="{bucket}",reason="{ev}"}} {n}')
+    lines += [
+        "# HELP slot_spawn_started_total Total /spawn-task calls accepted past guard",
+        "# TYPE slot_spawn_started_total counter",
+    ]
+    for (bucket, host), n in m["spawn_started"].items():
+        lines.append(f'slot_spawn_started_total{{bucket="{bucket}",host="{host}"}} {n}')
+    lines += [
+        "# HELP slot_spawn_completed_total /spawn-task outcomes (terminal).",
+        "# TYPE slot_spawn_completed_total counter",
+    ]
+    for r in m["spawn_completed"]:
+        lines.append(
+            f'slot_spawn_completed_total{{bucket="{r["bucket"]}",host="{r["host"]}",'
+            f'outcome="{r["outcome"]}",exit_code="{r["exit_code"]}"}} {r["n"]}'
+        )
+    lines += [
+        "# HELP slot_spawn_duration_seconds Spawn end-to-end duration (slot-manager view).",
+        "# TYPE slot_spawn_duration_seconds histogram",
+    ]
+    for (bucket, host), h in m["spawn_duration_hist"].items():
+        for b in SPAWN_DURATION_BUCKETS_S:
+            lines.append(
+                f'slot_spawn_duration_seconds_bucket{{bucket="{bucket}",host="{host}",le="{b}"}} {h["buckets"][b]}'
+            )
+        lines.append(
+            f'slot_spawn_duration_seconds_bucket{{bucket="{bucket}",host="{host}",le="+Inf"}} {h["count"]}'
+        )
+        lines.append(
+            f'slot_spawn_duration_seconds_sum{{bucket="{bucket}",host="{host}"}} {h["sum_s"]:.6f}'
+        )
+        lines.append(
+            f'slot_spawn_duration_seconds_count{{bucket="{bucket}",host="{host}"}} {h["count"]}'
+        )
+    lines += [
+        "# HELP spawn_budget_max_per_minute Configured spawn budget per bucket",
+        "# TYPE spawn_budget_max_per_minute gauge",
+    ]
+    for bucket, s in m["spawn_budget"].items():
+        lines.append(f'spawn_budget_max_per_minute{{bucket="{bucket}"}} {s["max_per_minute"]}')
+    lines += [
+        "# HELP spawn_budget_tokens_remaining Live token bucket reservoir",
+        "# TYPE spawn_budget_tokens_remaining gauge",
+    ]
+    for bucket, s in m["spawn_budget"].items():
+        lines.append(f'spawn_budget_tokens_remaining{{bucket="{bucket}"}} {s["tokens_remaining"]:.4f}')
+    state_counts: dict[str, int] = {}
+    for h in m["hosts"]:
+        state_counts[h["state"]] = state_counts.get(h["state"], 0) + 1
+    lines += [
+        "# HELP slot_manager_hosts_total Registered spawner hosts by state",
+        "# TYPE slot_manager_hosts_total gauge",
+    ]
+    for state, n in state_counts.items():
+        lines.append(f'slot_manager_hosts_total{{state="{state}"}} {n}')
+
+    # Phase 4 — autonomy + loop metrics.
+    lines += [
+        "# HELP slot_manager_autonomy_state 0/1 boolean per scope (1=on, 0=off, 2=circuit-broken, 3=cap-throttled)",
+        "# TYPE slot_manager_autonomy_state gauge",
+    ]
+    state_value = {"on": 1, "off": 0, "circuit-broken": 2, "cap-throttled": 3}
+    for scope, st in m["autonomy"].items():
+        v = state_value.get(st, -1)
+        lines.append(f'slot_manager_autonomy_state{{scope="{scope}",state="{st}"}} {v}')
+    lines += [
+        "# HELP slot_loop_iterations_total Total autonomous-loop ticks",
+        "# TYPE slot_loop_iterations_total counter",
+        f'slot_loop_iterations_total {m["loop_tick_total"]}',
+        "# HELP slot_loop_claims_total Total autonomous claims dispatched",
+        "# TYPE slot_loop_claims_total counter",
+        f'slot_loop_claims_total {m["loop_claims_total"]}',
+        "# HELP slot_loop_skips_total Total autonomous-loop skips by reason",
+        "# TYPE slot_loop_skips_total counter",
+    ]
+    for reason, n in (m.get("loop_skip_totals") or {}).items():
+        lines.append(f'slot_loop_skips_total{{reason="{reason}"}} {n}')
+    lines += [
+        "# HELP slot_loop_duration_seconds Autonomous-loop tick duration (seconds; sum/count)",
+        "# TYPE slot_loop_duration_seconds histogram",
+        f'slot_loop_duration_seconds_sum {m["loop_duration_sum_ms"]/1000.0:.3f}',
+        f'slot_loop_duration_seconds_count {m["loop_duration_count"]}',
+        f'slot_loop_duration_seconds_max {m["loop_duration_max_ms"]/1000.0:.3f}',
+        "# HELP slot_manager_claim_rate_per_sec Rolling claim rate over the circuit-breaker window",
+        "# TYPE slot_manager_claim_rate_per_sec gauge",
+        f'slot_manager_claim_rate_per_sec {m["claim_rate_per_sec"]:.6f}',
+        "# HELP slot_manager_dead_letter_open Open (un-replayed) dead-letter rows",
+        "# TYPE slot_manager_dead_letter_open gauge",
+        f'slot_manager_dead_letter_open {m["dead_letter_open"]}',
+    ]
+    for h in m["host_throttle"]:
+        lines.append(f'slot_manager_host_cap_event_count{{host="{h["host"]}"}} {h["cap_event_count"]}')
+    lines += [
+        "# HELP slot_manager_up Liveness sentinel",
+        "# TYPE slot_manager_up gauge",
+        "slot_manager_up 1",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+@app.get("/metrics.json")
+def metrics_json() -> dict[str, Any]:
+    m = _gather_metrics()
+    return {
+        **{k: v for k, v in m.items() if k not in ("spawn_started", "spawn_duration_hist")},
+        "spawn_started": [
+            {"bucket": k[0], "host": k[1], "n": v} for k, v in m["spawn_started"].items()
+        ],
+        "spawn_duration_hist": [
+            {"bucket": k[0], "host": k[1],
+             "count": v["count"], "sum_s": v["sum_s"],
+             "buckets": v["buckets"]}
+            for k, v in m["spawn_duration_hist"].items()
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _json_body(request: Request, *, allow_empty: bool = False) -> dict[str, Any]:
+    try:
+        raw = await request.body()
+        if not raw:
+            return {}
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise HTTPException(status_code=400, detail="body must be a JSON object")
+        return data
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"invalid JSON: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Test hooks
+# ---------------------------------------------------------------------------
+
+@app.post("/admin/test/expire-heartbeat")
+def admin_expire_heartbeat(slot_id: str = Query(...), seconds_ago: int = Query(...)):
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE assignments SET last_heartbeat_at = datetime('now', ? || ' seconds') "
+            "WHERE slot_id = ? AND completed_at IS NULL",
+            (f"-{int(seconds_ago)}", slot_id),
+        )
+        updated = cur.rowcount
+    return {"slot_id": slot_id, "updated": updated, "seconds_ago": seconds_ago}
+
+
+@app.post("/admin/test/expire-lease")
+def admin_expire_lease(slot_id: str = Query(...), seconds_ago: int = Query(...)):
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE assignments SET started_at = datetime('now', ? || ' seconds'), "
+            "last_heartbeat_at = CURRENT_TIMESTAMP "
+            "WHERE slot_id = ? AND completed_at IS NULL",
+            (f"-{int(seconds_ago)}", slot_id),
+        )
+        updated = cur.rowcount
+    return {"slot_id": slot_id, "updated": updated, "seconds_ago": seconds_ago}
+
+
+@app.post("/admin/test/set-lease")
+def admin_set_lease(slot_id: str = Query(...), lease_seconds: int = Query(..., ge=1)):
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute("UPDATE slots SET lease_seconds = ? WHERE slot_id = ?",
+                    (lease_seconds, slot_id))
+        updated = cur.rowcount
+    return {"slot_id": slot_id, "lease_seconds": lease_seconds, "updated": updated}
+
+
+@app.post("/admin/test/run-watchdog")
+def admin_run_watchdog():
+    hb = _watchdog_sweep_heartbeat()
+    le = _watchdog_sweep_lease()
+    ho = _watchdog_sweep_hosts()
+    cap = _watchdog_clear_expired_throttles()
+    return {"heartbeat_released": hb, "lease_released": le,
+            "hosts_offlined": ho, "cap_cleared": cap}
+
+
+@app.post("/admin/test/expire-host")
+def admin_expire_host(name: str = Query(...), seconds_ago: int = Query(...)):
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE hosts SET last_heartbeat_at = datetime('now', ? || ' seconds') WHERE name = ?",
+            (f"-{int(seconds_ago)}", name),
+        )
+        updated = cur.rowcount
+    return {"name": name, "updated": updated, "seconds_ago": seconds_ago}
+
+
+@app.post("/admin/test/set-budget-tokens")
+def admin_set_budget_tokens(bucket: str = Query(...), tokens: float = Query(..., ge=0)):
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE spawn_budget SET tokens_remaining = ?, last_refill_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP "
+            " WHERE bucket = ?",
+            (float(tokens), bucket),
+        )
+        updated = cur.rowcount
+    return {"bucket": bucket, "tokens_remaining": float(tokens), "updated": updated}
+
+
+@app.post("/admin/test/set-slot-host")
+def admin_set_slot_host(slot_id: str = Query(...), host: str = Query(...)):
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE slots SET host = ?, last_updated_at = CURRENT_TIMESTAMP WHERE slot_id = ?",
+            (host, slot_id),
+        )
+        updated = cur.rowcount
+    return {"slot_id": slot_id, "host": host, "updated": updated}
+
+
+@app.post("/admin/test/clear-host-throttle")
+def admin_clear_throttle(host: str = Query(...)):
+    """Phase 4: operator override — clear cap-throttle on a host immediately."""
+    with _db_lock:
+        cur = db().cursor()
+        cur.execute(
+            "UPDATE host_throttle_state SET cap_event_count = 0, throttled_until = NULL, "
+            "                              first_event_at = NULL, last_event_at = NULL, "
+            "                              updated_at = CURRENT_TIMESTAMP "
+            " WHERE host = ?",
+            (host,),
+        )
+        updated = cur.rowcount
+    return {"host": host, "updated": updated}
+
+
+@app.post("/admin/test/run-loop-tick")
+async def admin_run_loop_tick():
+    """Phase 4: force one autonomous-loop iteration (smoke-test affordance)."""
+    eligible = _list_eligible_buckets()
+    if not eligible:
+        return {"action": "skip", "reason": "no_eligible_buckets"}
+    results = await asyncio.gather(
+        *[_loop_tick_for_bucket(b) for b in eligible],
+        return_exceptions=True,
+    )
+    flat: list[dict[str, Any]] = []
+    for r in results:
+        if isinstance(r, Exception):
+            continue
+        if isinstance(r, list):
+            flat.extend(x for x in r if isinstance(x, dict))
+        elif isinstance(r, dict):
+            flat.append(r)
+    claims = sum(1 for x in flat if x.get("action") == "claim")
+    return {"results": [str(r) if isinstance(r, Exception) else r for r in results],
+            "claims": claims,
+            "flat": flat,
+            "eligible": eligible}
+
+
+@app.get("/")
+def root():
+    return {
+        "service":  SERVICE_NAME,
+        "version":  VERSION,
+        "phase":    4,
+        "endpoints": [
+            "/health", "/healthz", "/version",
+            "/slots", "/slots/{bucket}",
+            "/claim", "/release", "/heartbeat",
+            "/spawn-task", "/spawn-telemetry",
+            "/spawn-budget", "/spawn-budget/history",
+            "/spawn-retry-budget", "/spawn-lineage/{spawn_id}",
+            "/capacity", "/capacity/history",
+            "/admin/host/register", "/admin/host/heartbeat",
+            "/admin/hosts", "/admin/host/{name}", "/admin/host/{name}/state",
+            "/admin/spawn-completion",
+            "/admin/spawn-dead-letter", "/admin/spawn-dead-letter/{id}/replay",
+            "/admin/autonomy", "/admin/autonomy/{bucket}", "/admin/autonomy/global",
+            "/admin/loop/enable", "/admin/loop/disable", "/admin/loop/status", "/admin/loop/changes",
+            "/metrics", "/metrics.json",
+            "/webhooks/completion",
+            "/admin/test/expire-heartbeat",
+            "/admin/test/expire-lease",
+            "/admin/test/expire-host",
+            "/admin/test/set-lease",
+            "/admin/test/set-budget-tokens",
+            "/admin/test/set-slot-host",
+            "/admin/test/clear-host-throttle",
+            "/admin/test/run-watchdog",
+            "/admin/test/run-loop-tick",
+        ],
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("slot_manager:app", host="0.0.0.0", port=SERVICE_PORT, log_level=LOG_LEVEL.lower(), access_log=True)

--- a/services/slot-manager/smoke.sh
+++ b/services/slot-manager/smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# slot-manager smoke test.
+#
+# Runs:
+#   1. python -m py_compile on slot_manager.py
+#   2. schema.sql applies to an empty SQLite (in-memory) DB; required tables present.
+#   3. module import (uses cwd-resident schema.sql + tmp DB so apply_schema can run).
+#
+# Used by .github/workflows/services-smoke.yml on every PR that touches
+# services/slot-manager/**.
+#
+# Local invocation:
+#   cd services/slot-manager
+#   pip install -r requirements.txt
+#   bash smoke.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "==> py_compile slot_manager.py"
+python3 -m py_compile slot_manager.py
+echo "    ✓ syntax ok"
+
+echo "==> schema sanity"
+test -s schema.sql || { echo "    ✗ schema.sql missing or empty"; exit 1; }
+python3 - <<'PY'
+import sqlite3, pathlib
+sql = pathlib.Path("schema.sql").read_text()
+conn = sqlite3.connect(":memory:")
+conn.executescript(sql)
+tables = sorted(r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'"))
+required = {"slots", "assignments", "events", "spawn_log"}
+missing = required - set(tables)
+assert not missing, f"missing required tables: {missing} (have {tables})"
+print(f"    ✓ schema applies; tables: {tables}")
+PY
+
+echo "==> import smoke"
+TMP_DB=$(mktemp --suffix=.db)
+trap 'rm -f "$TMP_DB"' EXIT
+SCHEMA_PATH="$(pwd)/schema.sql" \
+SLOT_MANAGER_DB_PATH="$TMP_DB" \
+  python3 -c "import slot_manager; print('    ✓ slot_manager imports')"
+
+echo ""
+echo "slot-manager smoke: PASS"


### PR DESCRIPTION
## Summary

Relocates two long-lived out-of-monorepo Python services into `caia/services/` per
integration-remediation plan **§B Phase B2**, **AR-3 invariant** (`services/` not
`packages/` — distinguishes deployable python services from npm-distributed packages).
This is the parallel companion to the B-chain on M3; this PR was filed by the stolution
B2 worker because the M3 sibling hadn't yet reached this phase.

The migration is **source-relocate only** — no code edits, no re-architecture.

## What lands

### `services/slot-manager/` (self-driving Phase 4 slot allocator)
- `slot_manager.py` — autonomous loop + FastAPI app (Phases 4 & 5)
- `schema.sql` — SQLite WAL schema (Phases 0/1/2/4/5, idempotent hot-rollout)
- `requirements.txt` — fastapi / uvicorn / httpx / PyYAML, pinned to minor
- `README.md` — purpose, provenance (M3 source path), runtime contract, sibling link
- `smoke.sh` — py_compile + in-memory schema apply (verifies required tables) + import
- `package.json` — `@caia/services-slot-manager` (pnpm smoke wrapper)
- `.gitignore` — pyc / db artefacts

### `services/claude-spawner-agent/` (Phase 5 M1-side spawn daemon)
- `claude_spawner_agent.py` — FastAPI daemon: spawn validation, claude-CLI invocation, auto-PR
- `local_llm_router_client.py` — optional router-gate HTTP client
- `spawner_argv.py` — pure argv-builder for the `claude` CLI (testable, no I/O)
- `spawner_patch_v2.diff` — reference patch (audit trail)
- `com.caia.claude-spawner-agent.plist.template` — macOS launchd template (placeholder substitution at install time)
- `requirements.txt` — fastapi / uvicorn / httpx, pinned to minor
- `README.md` — purpose, provenance, full manual install procedure
- `smoke.sh` — py_compile + plist XML parse + module import
- `package.json` — `@caia/services-claude-spawner-agent` (pnpm smoke wrapper)
- `.gitignore` — pyc / db / bak artefacts
- `m1-deployment-bundle/README.md` — placeholder + OPERATOR_ACTION_REQUIRED for the M3
  side to copy the full bundle in a follow-up PR

## Source provenance (history continuity)

| Source path (pre-2026-05-15)                                                                  | Destination (this PR)                |
|-----------------------------------------------------------------------------------------------|--------------------------------------|
| `~/Documents/projects/reports-from-m1/slot-manager-artifacts/phase5/slot_manager.py`          | `services/slot-manager/slot_manager.py` |
| `~/Documents/projects/reports-from-m1/slot-manager-artifacts/phase5/schema.sql`               | `services/slot-manager/schema.sql`       |
| `~/Documents/projects/reports/claude-spawner-agent/claude_spawner_agent.py`                   | `services/claude-spawner-agent/claude_spawner_agent.py` |
| `~/Documents/projects/reports/claude-spawner-agent/local_llm_router_client.py`                | `services/claude-spawner-agent/local_llm_router_client.py` |
| `~/Documents/projects/reports/claude-spawner-agent/spawner_patch_v2.diff`                     | `services/claude-spawner-agent/spawner_patch_v2.diff` |
| `/home/s903/apps/claude-spawner/spawner_argv.py` (the stolution worker)                       | `services/claude-spawner-agent/spawner_argv.py` |

Both original directories remain intact on M3 / stolution for historical reference. This
directory is the live source from merge onward.

## Convention adopted

This PR adopts the layout established by the **sibling B1 PR #468**
(`feat(services/sps): b1 migrate SPS phase-2 source into caia/services/sps/`):
- per-service `README.md` with "Source-history continuity" section
- per-service `smoke.sh` as the canonical smoke entrypoint
- per-service `package.json` declaring `@caia/services-<name>` with a `smoke` script
- per-service `.gitignore` for runtime artefacts

## Subscription guard preserved

- `ANTHROPIC_API_KEY` is **intentionally not set** in the launchd plist template.
- The spawner strips it from subprocess env on every call (Phase 5 invariant).
- All four layers (slot-manager startup + per-call, spawner startup + per-call) remain
  active. The zero-dollar rule (`feedback_no_api_key_billing.md`) is non-negotiable.

## K3s ConfigMap operator step

The K3s `slot-manager-src` ConfigMap (and the equivalent for claude-spawner-agent
when it lands in K3s in a follow-up B-phase) should continue to mount the canonical
schema and source from this directory after this PR merges. Operator step:

```bash
# update the source reference in the K3s caia-orchestrator namespace
kubectl -n caia-orchestrator create configmap slot-manager-src \
  --from-file=slot_manager.py=services/slot-manager/slot_manager.py \
  --from-file=schema.sql=services/slot-manager/schema.sql \
  --dry-run=client -o yaml | kubectl apply -f -
```

(This is documented in the integration-remediation plan §B Phase B2; the actual K3s
deploy manifest update lands in a later B-chain phase.)

## OPERATOR_ACTION_REQUIRED

Two follow-ups gated outside this PR's autonomous worker scope:

### 1. CI smoke workflow

A `.github/workflows/services-smoke.yml` was prepared on the local branch but **could
not be pushed**: the OAuth token on the stolution worker has scopes `gist, read:org,
repo, write:packages` — no `workflow` scope. The workflow file is staged locally and
attached below for operator to add via web UI (Settings → Branch protection / Web edit)
or via a token with `workflow` scope. **Until the workflow is added, manual `bash
services/slot-manager/smoke.sh` and `bash services/claude-spawner-agent/smoke.sh` are
the only gates.** Both pass locally on python 3.10 / 3.11.

<details>
<summary>Staged workflow content (one-click web-add ready)</summary>

```yaml
name: services-smoke

on:
  pull_request:
    paths:
      - 'services/slot-manager/**'
      - 'services/claude-spawner-agent/**'
      - '.github/workflows/services-smoke.yml'
  push:
    branches: [main, develop]
    paths:
      - 'services/slot-manager/**'
      - 'services/claude-spawner-agent/**'
      - '.github/workflows/services-smoke.yml'

concurrency:
  group: services-smoke-${{ github.ref }}
  cancel-in-progress: true

jobs:
  detect-changes:
    name: detect-changes
    runs-on: ubuntu-latest
    outputs:
      slot_manager: ${{ steps.filter.outputs.slot_manager }}
      claude_spawner_agent: ${{ steps.filter.outputs.claude_spawner_agent }}
    steps:
      - uses: actions/checkout@v4
      - uses: dorny/paths-filter@v3
        id: filter
        with:
          filters: |
            slot_manager:
              - 'services/slot-manager/**'
              - '.github/workflows/services-smoke.yml'
            claude_spawner_agent:
              - 'services/claude-spawner-agent/**'
              - '.github/workflows/services-smoke.yml'

  slot-manager-smoke:
    name: slot-manager · smoke
    needs: detect-changes
    if: needs.detect-changes.outputs.slot_manager == 'true'
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.11'
          cache: 'pip'
          cache-dependency-path: services/slot-manager/requirements.txt
      - name: Install deps
        working-directory: services/slot-manager
        run: pip install -r requirements.txt
      - name: Smoke
        working-directory: services/slot-manager
        run: bash smoke.sh

  claude-spawner-agent-smoke:
    name: claude-spawner-agent · smoke
    needs: detect-changes
    if: needs.detect-changes.outputs.claude_spawner_agent == 'true'
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.11'
          cache: 'pip'
          cache-dependency-path: services/claude-spawner-agent/requirements.txt
      - name: Install deps
        working-directory: services/claude-spawner-agent
        run: pip install -r requirements.txt
      - name: Smoke
        working-directory: services/claude-spawner-agent
        run: bash smoke.sh
```
</details>

### 2. M1 deployment bundle

The full `m1-deployment-bundle/` (install.sh, uninstall.sh, version.txt, signed-launchd
helpers) lives on M3 at `~/Documents/projects/reports/claude-spawner-agent/
m1-deployment-bundle/` and could not be relocated byte-for-byte from a stolution worker
(no stolution-readable mirror at this dispatch time). The directory is staged with a
placeholder README inviting operator to copy bytes in a follow-up PR. Manual install
remains fully functional via the procedure documented in the service README.

## Local smoke (both pass on python 3.10+ + python 3.11)

```
$ bash services/slot-manager/smoke.sh
==> py_compile slot_manager.py
    ✓ syntax ok
==> schema sanity
    ✓ schema applies; tables: ['assignments', 'autonomy_state', 'bucket_health',
       'bucket_path_allowlists', 'bucket_permissions', 'capacity_changes',
       'dispatch_risk_log', 'events', 'host_throttle_state', 'hosts', 'loop_changes',
       'loop_tick', 'slots', 'spawn_budget', 'spawn_budget_changes',
       'spawn_dead_letter', 'spawn_lineage', 'spawn_log', 'spawn_retry_budget',
       'spawn_telemetry', 'sqlite_sequence', 'task_approvals']
==> import smoke
    ✓ slot_manager imports
slot-manager smoke: PASS

$ bash services/claude-spawner-agent/smoke.sh
==> py_compile sources
    ✓ claude_spawner_agent.py
    ✓ local_llm_router_client.py
    ✓ spawner_argv.py
==> plist template XML sanity
    ✓ plist template parses as XML
==> import smoke
    ✓ spawner_argv imports
    ✓ local_llm_router_client imports
    ✓ claude_spawner_agent imports
claude-spawner-agent smoke: PASS
```

## Test plan

- [ ] CI smoke workflow added by operator (or via a token with `workflow` scope)
- [ ] Both `slot-manager · smoke` and `claude-spawner-agent · smoke` jobs pass green
- [ ] `pnpm -F @caia/services-slot-manager run smoke` works locally
- [ ] `pnpm -F @caia/services-claude-spawner-agent run smoke` works locally
- [ ] K3s `slot-manager-src` ConfigMap reference updated post-merge (operator step)

Filed by integration-remediation plan §B Phase B2, parallel companion to the M3
sibling chain. See companion report at `reports/integration_b2_slot_manager_migrate_2026-05-15.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Spawned-By: caia-autonomous-loop
