### PR TITLE
feat(claude-spawner): D1 — extract @chiefaia/claude-spawner + migrate 7 ad-hoc spawn sites

### DIFF
--- a/packages/apprentice-corpus/package.json
+++ b/packages/apprentice-corpus/package.json
@@ -35,6 +35,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*",
     "@chiefaia/mentor-event-bus": "workspace:*"
   },
   "devDependencies": {

--- a/packages/apprentice-corpus/src/distiller.ts
+++ b/packages/apprentice-corpus/src/distiller.ts
@@ -20,7 +20,8 @@
  * itself must throw on every error path.
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawnClaude } from '@chiefaia/claude-spawner';
+import type { spawn, spawnSync } from 'node:child_process';
 
 import type {
   ClaudeDistiller,
@@ -31,8 +32,18 @@ import type {
 export interface DefaultDistillerOptions {
   binaryPath: string;
   timeoutMs?: number;
-  /** Test seam — replace `child_process.spawnSync`. */
+  /**
+   * Test seam — back-compat shim. New callers should use {@link spawnImpl}
+   * which matches `@chiefaia/claude-spawner`'s `spawnFn` shape. Setting
+   * `spawnFn` is a no-op now; the distiller routes through claude-spawner.
+   * Kept on the type so older external callers don't error on extra prop.
+   */
   spawnFn?: typeof spawnSync;
+  /**
+   * Test seam — replaces `node:child_process.spawn` used by
+   * `@chiefaia/claude-spawner`. Inject a fake child for testing.
+   */
+  spawnImpl?: typeof spawn;
   /** Optional model override. Default: claude-haiku-4-5 (cheap; distillation is not reasoning). */
   model?: string;
 }
@@ -77,7 +88,6 @@ function renderPrompt(input: DistillInput): string {
  * through to the keychain / OAuth subscription session.
  */
 export function createDefaultDistiller(opts: DefaultDistillerOptions): ClaudeDistiller {
-  const spawn = opts.spawnFn ?? spawnSync;
   const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const model = opts.model ?? DEFAULT_MODEL;
 
@@ -85,30 +95,35 @@ export function createDefaultDistiller(opts: DefaultDistillerOptions): ClaudeDis
     async distill(input: DistillInput): Promise<DistillOutput> {
       const prompt = renderPrompt(input);
 
-      const env = { ...process.env };
-      delete env['ANTHROPIC_API_KEY'];
-
-      const result = spawn(
-        opts.binaryPath,
-        ['--print', '--output-format', 'json', '--model', model],
-        {
-          input: prompt,
-          encoding: 'utf-8',
-          timeout,
-          env
+      // Delegate to `@chiefaia/claude-spawner` — env scrub + timeout +
+      // SUBSCRIPTION-ONLY constraint live there now.
+      const result = await spawnClaude({
+        prompt,
+        options: {
+          binaryPath: opts.binaryPath,
+          model,
+          timeoutMs: timeout,
+          ...(opts.spawnImpl !== undefined ? { spawnFn: opts.spawnImpl } : {})
         }
-      );
+      });
 
-      if (result.error !== null && result.error !== undefined) {
-        throw new Error(`distiller spawn failed: ${result.error.message}`);
+      if (!result.ok) {
+        const diag = result.diagnostic ?? 'unknown failure';
+        if (diag.startsWith('failed to spawn') || diag.startsWith('child process error')) {
+          throw new Error(
+            `distiller spawn failed: ${diag.replace(/^(failed to spawn|child process error): /, '')}`
+          );
+        }
+        // Preserve the legacy "distiller exited <code>: <stderr>" shape
+        // so corpus pipeline parsers don't have to change.
+        if (result.rc !== null) {
+          throw new Error(
+            `distiller exited ${String(result.rc)}: ${result.stderr.slice(0, 300)}`
+          );
+        }
+        throw new Error(`distiller failed: ${diag}`);
       }
-      if (result.status !== 0) {
-        throw new Error(
-          `distiller exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
-        );
-      }
-      const stdout = (result.stdout ?? '').toString();
-      return parseDistillerOutput(stdout);
+      return parseDistillerOutput(result.stdout);
     }
   };
 }
@@ -312,8 +327,16 @@ export interface CreateDistillerOptions {
   routerUrl?: string;
   /** Optional router model override (default `qwen2.5-coder:7b`). */
   routerModel?: string;
-  /** Test seam — replace `spawnSync` for the claude-binary backend. */
+  /**
+   * Test seam — back-compat shim. New callers should use {@link spawnImpl}
+   * which matches `@chiefaia/claude-spawner`'s `spawnFn` shape.
+   */
   spawnFn?: typeof spawnSync;
+  /**
+   * Test seam — replaces `node:child_process.spawn` used by
+   * `@chiefaia/claude-spawner`. Forwarded to the claude-binary backend.
+   */
+  spawnImpl?: typeof spawn;
   /** Test seam — replace `fetch` for the local-llm-router backend. */
   fetchFn?: typeof fetch;
 }
@@ -329,7 +352,7 @@ export interface CreateDistillerOptions {
 export function createDistiller(opts: CreateDistillerOptions): ClaudeDistiller {
   const claudeBinary = createDefaultDistiller({
     binaryPath: opts.claudeBinaryPath,
-    ...(opts.spawnFn !== undefined ? { spawnFn: opts.spawnFn } : {})
+    ...(opts.spawnImpl !== undefined ? { spawnImpl: opts.spawnImpl } : {})
   });
   const backend = (opts.backend ?? 'claude-binary').toLowerCase();
   if (backend === 'local-llm-router') {

--- a/packages/apprentice-corpus/tests/distiller.test.ts
+++ b/packages/apprentice-corpus/tests/distiller.test.ts
@@ -1,3 +1,7 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import type { spawn as nodeSpawn } from 'node:child_process';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -11,6 +15,48 @@ import {
   parseInstructionJson
 } from '../src/distiller.js';
 import type { ClaudeDistiller, DistillOutput } from '../src/types.js';
+
+/** Fake-child compatible with `@chiefaia/claude-spawner`'s spawn seam. */
+function makeFakeSpawnFn(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  errorBeforeClose?: Error;
+  stdinSpy?: (chunk: string) => void;
+  envSpy?: (env: NodeJS.ProcessEnv) => void;
+  onSpawn?: () => void;
+}): typeof nodeSpawn {
+  return ((
+    _cmd: string,
+    _args: readonly string[],
+    spawnOpts?: { env?: NodeJS.ProcessEnv },
+  ): unknown => {
+    opts.onSpawn?.();
+    if (spawnOpts?.env !== undefined) opts.envSpy?.(spawnOpts.env);
+    const ee = new EventEmitter() as EventEmitter & {
+      stdin: Writable;
+      stdout: Readable;
+      stderr: Readable;
+      kill: () => boolean;
+    };
+    ee.stdin = new Writable({
+      write(c: Buffer | string, _e, cb): void {
+        if (opts.stdinSpy) opts.stdinSpy(c.toString());
+        cb();
+      }
+    });
+    ee.stdout = new Readable({ read(): void {} });
+    ee.stderr = new Readable({ read(): void {} });
+    ee.kill = (): boolean => true;
+    setImmediate(() => {
+      if (opts.stdout !== undefined) ee.stdout.emit('data', Buffer.from(opts.stdout, 'utf8'));
+      if (opts.stderr !== undefined) ee.stderr.emit('data', Buffer.from(opts.stderr, 'utf8'));
+      if (opts.errorBeforeClose !== undefined) ee.emit('error', opts.errorBeforeClose);
+      else ee.emit('close', opts.exitCode ?? 0);
+    });
+    return ee;
+  }) as unknown as typeof nodeSpawn;
+}
 
 describe('parseDistillerOutput', () => {
   it('parses claude envelope + inner JSON', () => {
@@ -67,53 +113,50 @@ describe('parseInstructionJson', () => {
 
 describe('createDefaultDistiller (claude-binary backend)', () => {
   it('strips ANTHROPIC_API_KEY from spawn env', async () => {
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 0,
+    let capturedEnv: NodeJS.ProcessEnv = {};
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
-      stderr: '',
-      error: null
+      exitCode: 0,
+      envSpy: (env) => { capturedEnv = env; }
     });
     const distiller = createDefaultDistiller({
       binaryPath: 'claude',
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     process.env['ANTHROPIC_API_KEY'] = 'should-not-leak';
-    await distiller.distill({ source: 'memory', kind: 'directive', text: 'x' });
-    const callOpts = fakeSpawn.mock.calls[0]?.[2] as { env: Record<string, string | undefined> };
-    expect(callOpts.env['ANTHROPIC_API_KEY']).toBeUndefined();
+    try {
+      await distiller.distill({ source: 'memory', kind: 'directive', text: 'x' });
+    } finally {
+      delete process.env['ANTHROPIC_API_KEY'];
+    }
+    expect(capturedEnv['ANTHROPIC_API_KEY']).toBeUndefined();
   });
 
   it('throws on non-zero exit', async () => {
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 1,
-      stdout: '',
-      stderr: 'rate limit',
-      error: null
-    });
+    const fakeSpawn = makeFakeSpawnFn({ stderr: 'rate limit', exitCode: 1 });
     const distiller = createDefaultDistiller({
       binaryPath: 'claude',
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     await expect(
       distiller.distill({ source: 'memory', text: 'x' })
     ).rejects.toThrow(/exited 1/);
   });
 
-  it('passes prompt as input', async () => {
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 0,
+  it('passes prompt as stdin', async () => {
+    let stdin = '';
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
-      stderr: '',
-      error: null
+      exitCode: 0,
+      stdinSpy: (chunk) => { stdin += chunk; }
     });
     const distiller = createDefaultDistiller({
       binaryPath: 'claude',
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     await distiller.distill({ source: 'memory', kind: 'directive', text: 'BODY' });
-    const callOpts = fakeSpawn.mock.calls[0]?.[2] as { input: string };
-    expect(callOpts.input).toContain('BODY');
-    expect(callOpts.input).toContain('memory/directive');
+    expect(stdin).toContain('BODY');
+    expect(stdin).toContain('memory/directive');
   });
 });
 
@@ -249,36 +292,36 @@ describe('createLocalLlmRouterDistiller', () => {
 
 describe('createDistiller (backend selector)', () => {
   it('defaults to claude-binary when backend is undefined', async () => {
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 0,
+    let spawned = 0;
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
-      stderr: '',
-      error: null
+      exitCode: 0,
+      onSpawn: () => { spawned++; }
     });
     const distiller = createDistiller({
       backend: undefined,
       claudeBinaryPath: 'claude',
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     const out = await distiller.distill({ source: 'memory', text: 'X' });
     expect(out).toEqual({ instruction: 'q', response: 'a' });
-    expect(fakeSpawn).toHaveBeenCalledOnce();
+    expect(spawned).toBe(1);
   });
 
   it('uses claude-binary when backend="claude-binary"', async () => {
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 0,
+    let spawned = 0;
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
-      stderr: '',
-      error: null
+      exitCode: 0,
+      onSpawn: () => { spawned++; }
     });
     const distiller = createDistiller({
       backend: 'claude-binary',
       claudeBinaryPath: 'claude',
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     await distiller.distill({ source: 'memory', text: 'X' });
-    expect(fakeSpawn).toHaveBeenCalledOnce();
+    expect(spawned).toBe(1);
   });
 
   it('uses local-llm-router when backend="local-llm-router"', async () => {
@@ -295,55 +338,60 @@ describe('createDistiller (backend selector)', () => {
           { status: 200, headers: { 'content-type': 'application/json' } }
         )
       );
-    const fakeSpawn = vi.fn();
+    let spawned = 0;
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'never', response: 'used' }) }),
+      exitCode: 0,
+      onSpawn: () => { spawned++; }
+    });
     const distiller = createDistiller({
       backend: 'local-llm-router',
       claudeBinaryPath: 'claude',
       fetchFn,
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     const out = await distiller.distill({ source: 'memory', text: 'X' });
     expect(out).toEqual({ instruction: 'q', response: 'a' });
     expect(fetchFn).toHaveBeenCalledTimes(2);
-    expect(fakeSpawn).not.toHaveBeenCalled();
+    expect(spawned).toBe(0);
   });
 
   it('falls back to claude-binary spawn when local-llm-router is unhealthy', async () => {
     const fetchFn = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(new Response('down', { status: 503 }));
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 0,
+    let spawned = 0;
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({
         result: JSON.stringify({ instruction: 'fb-q', response: 'fb-a' })
       }),
-      stderr: '',
-      error: null
+      exitCode: 0,
+      onSpawn: () => { spawned++; }
     });
     const distiller = createDistiller({
       backend: 'local-llm-router',
       claudeBinaryPath: 'claude',
       fetchFn,
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     const out = await distiller.distill({ source: 'memory', text: 'X' });
     expect(out).toEqual({ instruction: 'fb-q', response: 'fb-a' });
-    expect(fakeSpawn).toHaveBeenCalledOnce();
+    expect(spawned).toBe(1);
   });
 
   it('falls back to claude-binary for unknown backend values', async () => {
-    const fakeSpawn = vi.fn().mockReturnValue({
-      status: 0,
+    let spawned = 0;
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({ result: JSON.stringify({ instruction: 'q', response: 'a' }) }),
-      stderr: '',
-      error: null
+      exitCode: 0,
+      onSpawn: () => { spawned++; }
     });
     const distiller = createDistiller({
       backend: 'bogus-value',
       claudeBinaryPath: 'claude',
-      spawnFn: fakeSpawn as never
+      spawnImpl: fakeSpawn
     });
     await distiller.distill({ source: 'memory', text: 'X' });
-    expect(fakeSpawn).toHaveBeenCalledOnce();
+    expect(spawned).toBe(1);
   });
 });

--- a/packages/apprentice-eval/package.json
+++ b/packages/apprentice-eval/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@chiefaia/apprentice-corpus": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/apprentice-eval/src/judge.ts
+++ b/packages/apprentice-eval/src/judge.ts
@@ -8,7 +8,8 @@
  *   - Anonymised A/B presentation; the harness records the un-anon mapping.
  */
 
-import { spawn } from 'node:child_process';
+import { spawnClaude, SCRUBBED_AUTH_ENV_VARS } from '@chiefaia/claude-spawner';
+import type { spawn } from 'node:child_process';
 
 import type { ClaudeJudge } from './types.js';
 
@@ -19,13 +20,12 @@ export interface CreateClaudeJudgeOpts {
   readonly env?: NodeJS.ProcessEnv;
 }
 
-const SECRETS_TO_SCRUB = [
-  'ANTHROPIC_API_KEY',
-  'OPENAI_API_KEY',
-  'GROQ_API_KEY',
-  'COHERE_API_KEY',
-  'GEMINI_API_KEY'
-];
+/**
+ * Re-export of `@chiefaia/claude-spawner`'s SCRUBBED_AUTH_ENV_VARS so
+ * existing imports of `SECRETS_TO_SCRUB` from this module's tests
+ * keep working. Same list, single source of truth.
+ */
+const SECRETS_TO_SCRUB = SCRUBBED_AUTH_ENV_VARS;
 
 function scrub(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const out: NodeJS.ProcessEnv = { ...env };
@@ -58,39 +58,43 @@ interface RunResult {
   code: number | null;
 }
 
+/**
+ * Thin shim around `@chiefaia/claude-spawner`'s `spawnClaude` that
+ * preserves the existing judge-internal `RunResult` shape (so the
+ * preference-parsing path doesn't have to change).
+ *
+ * The `claude-spawner` package owns env scrub + timeout; we no longer
+ * manage either locally. Timeout-as-rejection is preserved via the
+ * `ok=false && timedOut=true` branch.
+ */
 async function runProcess(
   bin: string,
   args: ReadonlyArray<string>,
   stdin: string,
   timeoutMs: number,
   env: NodeJS.ProcessEnv,
-  spawnImpl: typeof spawn
+  spawnImpl: (typeof spawn) | undefined
 ): Promise<RunResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawnImpl(bin, [...args], { env });
-    let stdout = '';
-    let stderr = '';
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      reject(new Error(`[apprentice-eval] judge subprocess timeout after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout?.on('data', (d: Buffer) => {
-      stdout += d.toString();
-    });
-    child.stderr?.on('data', (d: Buffer) => {
-      stderr += d.toString();
-    });
-    child.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-    child.on('close', (code) => {
-      clearTimeout(timer);
-      resolve({ stdout, stderr, code });
-    });
-    child.stdin?.write(stdin);
-    child.stdin?.end();
+  const result = await spawnClaude({
+    prompt: stdin,
+    options: {
+      binaryPath: bin,
+      overrideArgs: [...args],
+      extraEnv: env as Record<string, string>,
+      timeoutMs,
+      ...(spawnImpl !== undefined ? { spawnFn: spawnImpl } : {})
+    }
   });
+  if (result.timedOut) {
+    throw new Error(`[apprentice-eval] judge subprocess timeout after ${timeoutMs}ms`);
+  }
+  if (!result.ok && result.diagnostic?.startsWith('child process error')) {
+    throw new Error(result.diagnostic.slice('child process error: '.length));
+  }
+  if (!result.ok && result.diagnostic?.startsWith('failed to spawn')) {
+    throw new Error(result.diagnostic.slice('failed to spawn '.length));
+  }
+  return { stdout: result.stdout, stderr: result.stderr, code: result.rc };
 }
 
 export function parseJudgeReply(reply: string): {
@@ -110,7 +114,8 @@ export function parseJudgeReply(reply: string): {
 export function createClaudeJudge(opts: CreateClaudeJudgeOpts = {}): ClaudeJudge {
   const claudeBin = opts.claudeBin ?? 'claude';
   const timeoutMs = opts.timeoutMs ?? 60_000;
-  const spawnImpl = opts.spawnImpl ?? spawn;
+  // spawnImpl falls back to undefined → spawnClaude uses its own default.
+  const spawnImpl = opts.spawnImpl;
   const env = scrub(opts.env ?? process.env);
 
   return {

--- a/packages/claude-spawner/README.md
+++ b/packages/claude-spawner/README.md
@@ -1,0 +1,110 @@
+# @chiefaia/claude-spawner
+
+Unified subscription-only `claude` binary spawner for the CAIA monorepo.
+
+## Why this package exists
+
+Before D1 (2026-05-15), seven packages each maintained their own
+`child_process.spawn(...)` / `spawnSync(...)` wrapper around the
+`claude` binary:
+
+- `@chiefaia/verifier`            (`src/agent.ts` `defaultRunChild`)
+- `@chiefaia/code-reviewer`       (`src/llm-reasoner.ts`)
+- `@chiefaia/critic`              (`src/llm-reasoner.ts`)
+- `@chiefaia/reviewer`            (`src/llm-reasoner.ts`)
+- `@chiefaia/apprentice-eval`     (`src/judge.ts` `runProcess`)
+- `@chiefaia/apprentice-corpus`   (`src/distiller.ts`)
+- `@chiefaia/researcher`          (`src/llm-client.ts`)
+
+Each independently scrubbed env vars, set timeouts, sized buffers,
+built argv, and parsed JSON envelopes. Drift was inevitable — a fix in
+one (e.g. new auth-token scrub, larger maxBuffer for synthesis) never
+propagated to the others. The integration-remediation plan §D Phase D1
+called for extracting the canonical pattern from
+`@chiefaia/local-llm-router`'s `claude-adapter.ts` into a stand-alone
+package — this is that extraction.
+
+## Hard constraint — subscription-only
+
+The pay-per-token Anthropic API path is **FORBIDDEN** per
+`feedback_no_api_key_billing.md` (Prakash 2026-04-30). This package:
+
+- **Always** scrubs `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and
+  the other LLM-vendor key env vars from the child's env before
+  spawning.
+- Provides an opt-in `rejectIfApiKeyPresent` constraint that throws
+  before the spawn if the calling process has any of those vars set
+  (useful for orchestrators that want a loud diagnostic when an
+  operator's shell leaks an API key).
+- **Never** falls back to API-key billing on failure — failures surface
+  as `ok: false` with a diagnostic; callers route around with local
+  Ollama via `@chiefaia/local-llm-router`'s cascade rules.
+
+## Usage
+
+```ts
+import { spawnClaude, parseClaudeJsonEnvelope } from '@chiefaia/claude-spawner';
+
+const result = await spawnClaude({
+  prompt: 'Summarise the following diff…',
+  options: {
+    model: 'claude-sonnet-4-6',
+    timeoutMs: 60_000,
+    permissionMode: 'bypassPermissions',
+  },
+  constraints: {
+    cwdAllowList: ['/home/user/repo'],
+  },
+});
+
+if (!result.ok) {
+  // Log result.diagnostic and fall through to local Ollama, etc.
+} else {
+  const parsed = parseClaudeJsonEnvelope(result.stdout);
+  if (parsed.ok) {
+    console.log(parsed.text);
+  }
+}
+```
+
+## What this package does NOT do
+
+- It does **not** ship a CLI entrypoint. That's the A2 work
+  (file-disjoint per the integration plan).
+- It does **not** classify rate-limit errors. Callers that need that
+  taxonomy should keep using `@chiefaia/local-llm-router`'s
+  `ClaudeAdapter`, which layers `ClaudeRateLimitedError` on top.
+- It does **not** decide when to fall back to local Ollama. That's the
+  router's job.
+- It does **not** manage account rotation. That's the
+  `spend-guard` / `account-pool` job. The package does honour
+  `homeOverride` so callers can point at a different credentials dir
+  per spawn.
+
+## Constraints reference
+
+| Constraint                | Default | Behaviour                                                                 |
+| ------------------------- | ------- | ------------------------------------------------------------------------- |
+| `rejectIfApiKeyPresent`   | `false` | Throws `SpawnClaudeConstraintError` if any `*_API_KEY` env var is set.   |
+| `cwdAllowList`            | none    | Throws if resolved cwd is not under any path in the list.                |
+
+## Migration notes
+
+Migrating callers from the ad-hoc spawn wrappers should follow this shape:
+
+1. Add `"@chiefaia/claude-spawner": "workspace:*"` to `dependencies`.
+2. Replace the local `spawn(...)` / `spawnSync(...)` call with
+   `await spawnClaude({ prompt, options })`.
+3. Replace local stdout-envelope parsing with `parseClaudeJsonEnvelope(...)`.
+4. Keep your test seam — `options.spawnFn` lets you inject a mock spawn.
+
+The `local-llm-router` package's `ClaudeAdapter` is **deliberately**
+left untouched in D1 — it carries the rate-limit taxonomy plus account
+attribution that the seven ad-hoc sites didn't need, and migrating it
+would force every account-rotation code path to re-thread errors.
+
+## See also
+
+- ADR: `docs/EA/decisions/feedback_no_api_key_billing.md`
+- Reference impl: `packages/local-llm-router/src/claude-adapter.ts`
+- Integration plan: `~/Documents/projects/reports/integration_remediation_plan_2026-05-14.md` §D Phase D1

--- a/packages/claude-spawner/eslint.config.cjs
+++ b/packages/claude-spawner/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/claude-spawner/package.json
+++ b/packages/claude-spawner/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@chiefaia/claude-spawner",
+  "version": "0.1.0",
+  "description": "Unified subscription-only `claude` binary spawner. Replaces the ad-hoc spawn implementations across the CAIA monorepo (verifier, code-reviewer, critic, reviewer, apprentice-eval, apprentice-corpus distiller, researcher) with a single hardened entrypoint. Hard constraint: never sets ANTHROPIC_API_KEY — always falls through to the OAuth/keychain subscription session per feedback_no_api_key_billing.md.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/claude-spawner/src/index.ts
+++ b/packages/claude-spawner/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @chiefaia/claude-spawner — public surface.
+ *
+ * See `spawn.ts` file-level comment for design + constraint rationale.
+ */
+
+export {
+  spawnClaude,
+  buildSpawnArgs,
+  buildSpawnEnv,
+  parseClaudeJsonEnvelope,
+  SpawnClaudeConstraintError,
+  SCRUBBED_AUTH_ENV_VARS,
+} from './spawn.js';
+
+export type {
+  SpawnClaudeInput,
+  SpawnClaudeOptions,
+  SpawnClaudeConstraints,
+  SpawnClaudeResult,
+  ClaudeJsonEnvelope,
+  ParsedClaudeEnvelope,
+} from './spawn.js';

--- a/packages/claude-spawner/src/spawn.ts
+++ b/packages/claude-spawner/src/spawn.ts
@@ -1,0 +1,504 @@
+/**
+ * @chiefaia/claude-spawner — unified `claude` binary spawner.
+ *
+ * SUBSCRIPTION-ONLY HARD CONSTRAINT (Prakash 2026-04-30, see
+ * `feedback_no_api_key_billing.md`):
+ *
+ *   The pay-per-token Anthropic API path is FORBIDDEN. We never set
+ *   ANTHROPIC_API_KEY (and related auth-token env vars) for the spawned
+ *   child — we explicitly scrub them so the binary falls through to the
+ *   keychain / OAuth subscription session. If the binary is missing or
+ *   fails for any reason, we throw / return ok=false — we NEVER fall back
+ *   to API-key billing.
+ *
+ * Why this package
+ *
+ *   Before D1 (2026-05-15), seven packages each maintained their own
+ *   `child_process.spawn(...) / spawnSync(...)` wrapper around the
+ *   `claude` binary:
+ *
+ *     - @chiefaia/verifier         (src/agent.ts defaultRunChild)
+ *     - @chiefaia/code-reviewer    (src/llm-reasoner.ts)
+ *     - @chiefaia/critic           (src/llm-reasoner.ts)
+ *     - @chiefaia/reviewer         (src/llm-reasoner.ts)
+ *     - @chiefaia/apprentice-eval  (src/judge.ts runProcess)
+ *     - @chiefaia/apprentice-corpus (src/distiller.ts)
+ *     - @chiefaia/researcher       (src/llm-client.ts)
+ *
+ *   Each independently scrubbed env vars, set timeouts, sized buffers,
+ *   built argv, and parsed JSON envelopes. Drift was inevitable — a fix
+ *   in one (e.g. new auth-token scrub, larger maxBuffer for synthesis)
+ *   never propagated to the others. The integration-remediation plan §D
+ *   Phase D1 (2026-05-14) called for extracting the canonical pattern
+ *   from `@chiefaia/local-llm-router`'s `claude-adapter.ts` into a
+ *   stand-alone package — this file is that extraction.
+ *
+ * Design summary
+ *
+ *   `spawnClaude({ prompt, options, constraints })` is the only public
+ *   entrypoint. It:
+ *
+ *     1. Validates `constraints` (subscription-only, cwd allow-list).
+ *     2. Builds argv (default `--print --output-format json`, optional
+ *        `--model`, `--permission-mode`, etc).
+ *     3. Builds env (forks `process.env` and scrubs auth-token vars).
+ *     4. Spawns the binary via `node:child_process.spawn` with stdin pipe.
+ *     5. Writes the prompt to stdin, collects stdout/stderr, enforces a
+ *        wall-clock timeout (SIGTERM at deadline).
+ *     6. Returns a `SpawnClaudeResult` describing the outcome.
+ *
+ *   Callers parse the stdout themselves (most use the
+ *   `claude --print --output-format json` envelope shape — see
+ *   `parseClaudeJsonEnvelope` helper).
+ *
+ * What this package does NOT do
+ *
+ *   - It does NOT implement the `cli.ts` surface — that lives in the A2
+ *     work (file-disjoint per the integration plan).
+ *   - It does NOT classify rate-limit errors — callers that need that
+ *     should keep using `@chiefaia/local-llm-router`'s `ClaudeAdapter`
+ *     which layers `ClaudeRateLimitedError` on top.
+ *   - It does NOT decide when to fall back to local Ollama — that's the
+ *     router's job.
+ *   - It does NOT manage account rotation — that's spend-guard /
+ *     account-pool's job. (We DO honour `homeOverride` so callers can
+ *     point at a different credentials dir per spawn.)
+ */
+
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+
+/** Default path to the `claude` binary. Overridable via env or option. */
+const DEFAULT_CLAUDE_BINARY = process.env['CLAUDE_BINARY_PATH'] ?? 'claude';
+
+/**
+ * Default subprocess timeout (ms).
+ *
+ * 45_000 covers a normal Sonnet response with margin while keeping
+ * fallback latency bounded. Adapted from the `local-llm-router`
+ * adapter — same reasoning applies here: the binary-spawn path adds
+ * ~6-10s session-init overhead per call, and many callers run
+ * validation in parallel; a longer ceiling per call bottlenecks the
+ * whole pipeline if claude is unreachable.
+ */
+const DEFAULT_TIMEOUT_MS = 45_000;
+
+/**
+ * Env var names that authenticate against the pay-per-token Anthropic
+ * API. ALL are scrubbed unconditionally — there is no opt-out — to
+ * force the subscription session per `feedback_no_api_key_billing.md`.
+ */
+export const SCRUBBED_AUTH_ENV_VARS: readonly string[] = Object.freeze([
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GROQ_API_KEY',
+  'COHERE_API_KEY',
+  'GEMINI_API_KEY',
+]);
+
+/** Per-spawn options. */
+export interface SpawnClaudeOptions {
+  /** Path to the `claude` binary. Default: env `CLAUDE_BINARY_PATH` or `'claude'`. */
+  binaryPath?: string;
+  /**
+   * Extra argv passed to the binary. The default argv is
+   * `['--print', '--output-format', 'json']` plus an optional
+   * `'--model', <model>'` if `model` is set and an optional
+   * `'--permission-mode', <permissionMode>'` if `permissionMode` is set.
+   *
+   * If `extraArgs` is provided, it is concatenated AFTER the defaults so
+   * the caller can append flags without rebuilding the canonical prefix.
+   * If `overrideArgs` is set instead, the entire argv (excluding the
+   * binary path) is replaced verbatim.
+   */
+  extraArgs?: readonly string[];
+  /** Replace the entire argv (excluding the binary path). Mutually exclusive with extraArgs/model/etc. */
+  overrideArgs?: readonly string[];
+  /** Model tag — appended as `'--model', <model>`. */
+  model?: string;
+  /** Permission mode — appended as `'--permission-mode', <permissionMode>`. */
+  permissionMode?: 'default' | 'bypassPermissions' | 'plan' | 'acceptEdits';
+  /** Output format. Appended only when {@link extraArgs} / {@link overrideArgs} don't already cover it. */
+  outputFormat?: 'json' | 'text';
+  /** Wall-clock timeout. Default 45_000ms. */
+  timeoutMs?: number;
+  /** cwd for the spawn. Default: process.cwd(). */
+  cwd?: string;
+  /**
+   * Override the HOME env var so the spawned binary uses a different
+   * credentials dir (`~/.config/claude/credentials.json`). Used by
+   * account-pool rotation: each account has its own credentials dir.
+   */
+  homeOverride?: string;
+  /**
+   * Additional env vars to merge into the child's env AFTER the auth-token
+   * scrub. Cannot be used to re-introduce a scrubbed var — those are
+   * always deleted post-merge.
+   */
+  extraEnv?: Record<string, string>;
+  /** Optional account id used for telemetry / attribution. Echoed back in result.accountId. */
+  accountId?: string | null;
+  /** Test seam — replace `node:child_process.spawn`. */
+  spawnFn?: typeof spawn;
+}
+
+/** Hard constraints — refusing to spawn if violated. */
+export interface SpawnClaudeConstraints {
+  /**
+   * Reject the spawn if any of {@link SCRUBBED_AUTH_ENV_VARS} are
+   * present in the calling process's env. Default: false (we scrub
+   * unconditionally; this is an opt-in extra safety check for callers
+   * that want a noisy diagnostic when an API key is set in their shell).
+   */
+  rejectIfApiKeyPresent?: boolean;
+  /**
+   * If set, the spawn's resolved cwd must be a subdirectory of one of
+   * these paths (or equal to one). Useful for operator preference of
+   * limiting which dirs the binary can operate in.
+   */
+  cwdAllowList?: readonly string[];
+}
+
+/** Result of a single spawn. */
+export interface SpawnClaudeResult {
+  /** Convenience — true if `rc === 0 && !timedOut && !error`. */
+  ok: boolean;
+  /** Exit code. `null` if the child was killed before exit. */
+  rc: number | null;
+  /** Captured stdout (full). */
+  stdout: string;
+  /** Captured stderr (full). */
+  stderr: string;
+  /** True if the spawn was killed because the timeout fired. */
+  timedOut: boolean;
+  /** Wall-clock duration in ms. */
+  durationMs: number;
+  /** Diagnostic string when `ok === false`. */
+  diagnostic: string | null;
+  /** Echoed back from `options.accountId`. */
+  accountId: string | null;
+}
+
+/** Thrown when constraints reject the spawn before it starts. */
+export class SpawnClaudeConstraintError extends Error {
+  readonly code: 'api-key-present' | 'cwd-not-allowed' | 'invalid-args';
+  constructor(code: 'api-key-present' | 'cwd-not-allowed' | 'invalid-args', message: string) {
+    super(message);
+    this.name = 'SpawnClaudeConstraintError';
+    this.code = code;
+  }
+}
+
+/** Build the env handed to the spawned child. Always scrubs auth-token vars. */
+export function buildSpawnEnv(
+  base: NodeJS.ProcessEnv,
+  opts: {
+    homeOverride?: string;
+    extraEnv?: Record<string, string>;
+  },
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(base)) {
+    if (v !== undefined) env[k] = v;
+  }
+  if (opts.extraEnv) {
+    for (const [k, v] of Object.entries(opts.extraEnv)) {
+      env[k] = v;
+    }
+  }
+  if (opts.homeOverride !== undefined) {
+    env['HOME'] = opts.homeOverride;
+  }
+  // The scrub MUST run AFTER extraEnv merge so callers can't accidentally
+  // re-introduce a scrubbed key via extraEnv.
+  for (const k of SCRUBBED_AUTH_ENV_VARS) {
+    delete env[k];
+  }
+  return env;
+}
+
+/** Build the argv handed to the binary (excluding binary path itself). */
+export function buildSpawnArgs(opts: SpawnClaudeOptions): string[] {
+  if (opts.overrideArgs !== undefined) {
+    return [...opts.overrideArgs];
+  }
+  const out: string[] = ['--print', '--output-format', opts.outputFormat ?? 'json'];
+  if (opts.model !== undefined && opts.model.length > 0) {
+    out.push('--model', opts.model);
+  }
+  if (opts.permissionMode !== undefined) {
+    out.push('--permission-mode', opts.permissionMode);
+  }
+  if (opts.extraArgs !== undefined) {
+    out.push(...opts.extraArgs);
+  }
+  return out;
+}
+
+/** Inputs to {@link spawnClaude}. */
+export interface SpawnClaudeInput {
+  /** Prompt content written to the child's stdin. */
+  prompt: string;
+  /** Per-spawn options (binary, argv, env, timeout). */
+  options?: SpawnClaudeOptions;
+  /** Hard constraints applied before the spawn. */
+  constraints?: SpawnClaudeConstraints;
+}
+
+/**
+ * Spawn the `claude` binary, write `prompt` to its stdin, collect
+ * stdout/stderr, return the result.
+ *
+ * Subscription-only by construction — see file-level comment.
+ *
+ * Throws {@link SpawnClaudeConstraintError} only when constraints
+ * reject the call before the binary is launched. All other failure
+ * modes (binary missing, non-zero exit, timeout, etc.) are surfaced as
+ * `ok: false` with a `diagnostic` string. Callers that need a richer
+ * error taxonomy (e.g. rate-limit detection) should layer their own
+ * parsing on top.
+ */
+export async function spawnClaude(input: SpawnClaudeInput): Promise<SpawnClaudeResult> {
+  const options = input.options ?? {};
+  const constraints = input.constraints ?? {};
+  const accountId: string | null = options.accountId ?? null;
+  const start = Date.now();
+
+  // Constraint: API-key-present rejection.
+  if (constraints.rejectIfApiKeyPresent === true) {
+    for (const k of SCRUBBED_AUTH_ENV_VARS) {
+      if (process.env[k] !== undefined && process.env[k] !== '') {
+        throw new SpawnClaudeConstraintError(
+          'api-key-present',
+          `Env var ${k} is set in the calling process — subscription-only constraint rejects the spawn before scrub. Unset ${k} in the shell that launched the orchestrator.`,
+        );
+      }
+    }
+  }
+
+  // Constraint: cwd allow-list.
+  const cwd = options.cwd ?? process.cwd();
+  if (constraints.cwdAllowList !== undefined && constraints.cwdAllowList.length > 0) {
+    const allowed = constraints.cwdAllowList.some((root) => {
+      if (root === cwd) return true;
+      const trimmed = root.endsWith('/') ? root : `${root}/`;
+      return cwd.startsWith(trimmed);
+    });
+    if (!allowed) {
+      throw new SpawnClaudeConstraintError(
+        'cwd-not-allowed',
+        `cwd=${cwd} is not under any path in cwdAllowList=[${constraints.cwdAllowList.join(', ')}].`,
+      );
+    }
+  }
+
+  const binaryPath = options.binaryPath ?? DEFAULT_CLAUDE_BINARY;
+  const args = buildSpawnArgs(options);
+  const env = buildSpawnEnv(process.env, {
+    ...(options.homeOverride !== undefined ? { homeOverride: options.homeOverride } : {}),
+    ...(options.extraEnv !== undefined ? { extraEnv: options.extraEnv } : {}),
+  });
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const spawnImpl = options.spawnFn ?? spawn;
+
+  const spawnOpts: SpawnOptions = {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd,
+    env,
+  };
+
+  let child: ChildProcess;
+  try {
+    child = spawnImpl(binaryPath, args, spawnOpts);
+  } catch (err) {
+    return {
+      ok: false,
+      rc: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      durationMs: Date.now() - start,
+      diagnostic: `failed to spawn '${binaryPath}': ${(err as Error).message}`,
+      accountId,
+    };
+  }
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  child.stdout?.on('data', (c: Buffer) => stdoutChunks.push(c));
+  child.stderr?.on('data', (c: Buffer) => stderrChunks.push(c));
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      /* ignore */
+    }
+  }, timeoutMs);
+
+  // Write the prompt to stdin. The binary tends to be picky about
+  // stdin closure semantics — we end() immediately after write() so the
+  // child sees EOF and starts producing output.
+  const stdin = child.stdin;
+  if (stdin) {
+    try {
+      stdin.write(input.prompt);
+      stdin.end();
+    } catch (err) {
+      clearTimeout(timer);
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        /* ignore */
+      }
+      return {
+        ok: false,
+        rc: null,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+        timedOut: false,
+        durationMs: Date.now() - start,
+        diagnostic: `stdin write failed: ${(err as Error).message}`,
+        accountId,
+      };
+    }
+  }
+
+  // Wait for close. `error` event triggers a rejection-style return.
+  const result: { rc: number | null; childErr: Error | null } = await new Promise((resolve) => {
+    let settled = false;
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ rc: null, childErr: err });
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ rc: code, childErr: null });
+    });
+  });
+
+  const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+  const stderr = Buffer.concat(stderrChunks).toString('utf8');
+  const durationMs = Date.now() - start;
+
+  if (result.childErr !== null) {
+    return {
+      ok: false,
+      rc: null,
+      stdout,
+      stderr,
+      timedOut: false,
+      durationMs,
+      diagnostic: `child process error: ${result.childErr.message}`,
+      accountId,
+    };
+  }
+
+  if (timedOut) {
+    return {
+      ok: false,
+      rc: result.rc,
+      stdout,
+      stderr,
+      timedOut: true,
+      durationMs,
+      diagnostic: `claude binary timed out after ${String(timeoutMs)}ms`,
+      accountId,
+    };
+  }
+
+  if (result.rc !== 0) {
+    return {
+      ok: false,
+      rc: result.rc,
+      stdout,
+      stderr,
+      timedOut: false,
+      durationMs,
+      diagnostic: `claude binary exited with code ${String(result.rc)}: ${stderr.slice(-500)}`,
+      accountId,
+    };
+  }
+
+  return {
+    ok: true,
+    rc: result.rc,
+    stdout,
+    stderr,
+    timedOut: false,
+    durationMs,
+    diagnostic: null,
+    accountId,
+  };
+}
+
+/**
+ * Parse the standard `claude --print --output-format json` envelope.
+ *
+ * Envelope shape:
+ *   { "type": "result", "result": "<assistant text>", "is_error": false,
+ *     "api_error_status": null, ... }
+ *
+ * Returns the inner `result` string on success, or an error object on
+ * malformed envelopes / API-side errors. This helper exists so the
+ * seven downstream packages don't each re-implement JSON parsing.
+ *
+ * Callers that need rate-limit detection should inspect
+ * `api_error_status` directly via the full envelope object — pass
+ * `keepEnvelope: true` to retrieve it.
+ */
+export function parseClaudeJsonEnvelope(stdout: string): ParsedClaudeEnvelope {
+  if (stdout.trim().length === 0) {
+    return { ok: false, diagnostic: 'empty stdout' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (e) {
+    return { ok: false, diagnostic: `envelope JSON parse failed: ${(e as Error).message}` };
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { ok: false, diagnostic: 'envelope is not an object' };
+  }
+  const env = parsed as ClaudeJsonEnvelope;
+  if (env.is_error === true) {
+    const status = env.api_error_status ?? 'unknown';
+    return {
+      ok: false,
+      diagnostic: `claude is_error=true api_error_status=${String(status)}`,
+      envelope: env,
+    };
+  }
+  if (typeof env.result !== 'string') {
+    return { ok: false, diagnostic: 'envelope missing "result" string', envelope: env };
+  }
+  return { ok: true, text: env.result, envelope: env };
+}
+
+/** The on-the-wire envelope shape produced by `claude --print --output-format json`. */
+export interface ClaudeJsonEnvelope {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  api_error_status?: number | string | null;
+  duration_ms?: number;
+  result?: string;
+  total_cost_usd?: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  modelUsage?: Record<string, { inputTokens?: number; outputTokens?: number; costUSD?: number }>;
+}
+
+export type ParsedClaudeEnvelope =
+  | { ok: true; text: string; envelope: ClaudeJsonEnvelope }
+  | { ok: false; diagnostic: string; envelope?: ClaudeJsonEnvelope };

--- a/packages/claude-spawner/tests/spawn.test.ts
+++ b/packages/claude-spawner/tests/spawn.test.ts
@@ -1,0 +1,373 @@
+import { spawn as realSpawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import {
+  buildSpawnArgs,
+  buildSpawnEnv,
+  parseClaudeJsonEnvelope,
+  SCRUBBED_AUTH_ENV_VARS,
+  SpawnClaudeConstraintError,
+  spawnClaude,
+  type SpawnClaudeInput,
+} from '../src/spawn.js';
+
+/**
+ * Minimal fake-child fixture. Exposes the API spawnClaude needs:
+ *   - stdin (writable, end-able)
+ *   - stdout / stderr (readable, emit `data` of Buffer)
+ *   - emit `close` with exit code (or `error` with an Error)
+ *   - kill() noop (we drive `close` ourselves from the test)
+ */
+function makeFakeChild(opts: {
+  stdoutChunks?: ReadonlyArray<string>;
+  stderrChunks?: ReadonlyArray<string>;
+  /** Delay before emitting `close` (ms). Set high to test timeout. */
+  closeDelayMs?: number;
+  exitCode?: number;
+  emitErrorBeforeClose?: Error;
+}): { ee: EventEmitter; promise: Promise<void> } {
+  const ee = new EventEmitter() as EventEmitter & {
+    stdin: Writable;
+    stdout: Readable;
+    stderr: Readable;
+    kill: (sig?: NodeJS.Signals) => boolean;
+  };
+  // stdin: just consume writes silently.
+  ee.stdin = new Writable({
+    write(_chunk, _enc, cb): void {
+      cb();
+    },
+  });
+  ee.stdout = new Readable({
+    read(): void {
+      /* push-driven below */
+    },
+  });
+  ee.stderr = new Readable({
+    read(): void {
+      /* push-driven below */
+    },
+  });
+  ee.kill = (): boolean => true;
+
+  // Defer chunk emission so spawnClaude's listeners (attached AFTER
+  // spawn() returns) actually receive the data. Using setImmediate
+  // queues them after the current microtask flush.
+  const stdoutChunks = opts.stdoutChunks ?? [];
+  const stderrChunks = opts.stderrChunks ?? [];
+  setImmediate(() => {
+    for (const c of stdoutChunks) {
+      ee.stdout.emit('data', Buffer.from(c, 'utf8'));
+    }
+    for (const c of stderrChunks) {
+      ee.stderr.emit('data', Buffer.from(c, 'utf8'));
+    }
+  });
+
+  const delay = opts.closeDelayMs ?? 5;
+  const promise = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      if (opts.emitErrorBeforeClose) {
+        ee.emit('error', opts.emitErrorBeforeClose);
+      } else {
+        ee.emit('close', opts.exitCode ?? 0);
+      }
+      resolve();
+    }, delay);
+  });
+
+  return { ee, promise };
+}
+
+const fakeSpawnFactory = (
+  fake: ReturnType<typeof makeFakeChild>,
+): typeof realSpawn =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ((..._args: any[]): any => fake.ee) as typeof realSpawn;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('buildSpawnArgs', () => {
+  it('emits the canonical default argv', () => {
+    expect(buildSpawnArgs({})).toEqual(['--print', '--output-format', 'json']);
+  });
+
+  it('appends --model when set', () => {
+    expect(buildSpawnArgs({ model: 'claude-sonnet-4-6' })).toEqual([
+      '--print',
+      '--output-format',
+      'json',
+      '--model',
+      'claude-sonnet-4-6',
+    ]);
+  });
+
+  it('appends --permission-mode when set', () => {
+    expect(buildSpawnArgs({ permissionMode: 'bypassPermissions' })).toEqual([
+      '--print',
+      '--output-format',
+      'json',
+      '--permission-mode',
+      'bypassPermissions',
+    ]);
+  });
+
+  it('respects overrideArgs verbatim', () => {
+    expect(buildSpawnArgs({ overrideArgs: ['--version'] })).toEqual(['--version']);
+  });
+
+  it('appends extraArgs after defaults', () => {
+    expect(buildSpawnArgs({ extraArgs: ['--append-system-prompt', 'foo'] })).toEqual([
+      '--print',
+      '--output-format',
+      'json',
+      '--append-system-prompt',
+      'foo',
+    ]);
+  });
+
+  it('honours outputFormat=text', () => {
+    expect(buildSpawnArgs({ outputFormat: 'text' })).toEqual(['--print', '--output-format', 'text']);
+  });
+});
+
+describe('buildSpawnEnv', () => {
+  it('scrubs all known auth-token env vars even when callers try to set them via extraEnv', () => {
+    const env = buildSpawnEnv(
+      { FOO: 'bar', ANTHROPIC_API_KEY: 'pre-existing' },
+      { extraEnv: { ANTHROPIC_API_KEY: 'sneaky', OPENAI_API_KEY: 'sneakier', BAR: 'baz' } },
+    );
+    expect(env['FOO']).toBe('bar');
+    expect(env['BAR']).toBe('baz');
+    for (const k of SCRUBBED_AUTH_ENV_VARS) {
+      expect(env[k]).toBeUndefined();
+    }
+  });
+
+  it('applies homeOverride after merge', () => {
+    const env = buildSpawnEnv({ HOME: '/orig', X: '1' }, { homeOverride: '/custom' });
+    expect(env['HOME']).toBe('/custom');
+    expect(env['X']).toBe('1');
+  });
+
+  it('drops undefined values from base env', () => {
+    const env = buildSpawnEnv({ A: 'a', B: undefined } as NodeJS.ProcessEnv, {});
+    expect(env['A']).toBe('a');
+    expect(env['B']).toBeUndefined();
+  });
+});
+
+describe('parseClaudeJsonEnvelope', () => {
+  it('returns the result text for a healthy envelope', () => {
+    const got = parseClaudeJsonEnvelope(
+      JSON.stringify({ type: 'result', is_error: false, result: 'hello' }),
+    );
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.text).toBe('hello');
+    }
+  });
+
+  it('flags is_error envelopes as not-ok', () => {
+    const got = parseClaudeJsonEnvelope(
+      JSON.stringify({ type: 'result', is_error: true, api_error_status: 429 }),
+    );
+    expect(got.ok).toBe(false);
+    if (!got.ok) {
+      expect(got.diagnostic).toMatch(/api_error_status=429/);
+    }
+  });
+
+  it('flags empty stdout', () => {
+    const got = parseClaudeJsonEnvelope('');
+    expect(got.ok).toBe(false);
+  });
+
+  it('flags malformed JSON', () => {
+    const got = parseClaudeJsonEnvelope('not-json');
+    expect(got.ok).toBe(false);
+  });
+
+  it('flags missing result string', () => {
+    const got = parseClaudeJsonEnvelope(JSON.stringify({ type: 'result' }));
+    expect(got.ok).toBe(false);
+  });
+});
+
+describe('spawnClaude — happy path', () => {
+  it('returns ok=true on rc=0 with stdout text', async () => {
+    const fake = makeFakeChild({
+      stdoutChunks: [JSON.stringify({ result: 'ok' })],
+      exitCode: 0,
+    });
+    const input: SpawnClaudeInput = {
+      prompt: 'hello',
+      options: { spawnFn: fakeSpawnFactory(fake) },
+    };
+    const result = await spawnClaude(input);
+    await fake.promise;
+    expect(result.ok).toBe(true);
+    expect(result.rc).toBe(0);
+    expect(result.stdout).toBe(JSON.stringify({ result: 'ok' }));
+    expect(result.diagnostic).toBeNull();
+  });
+
+  it('writes the prompt to stdin', async () => {
+    const writeSpy = vi.fn();
+    const fake = makeFakeChild({ exitCode: 0 });
+    // Override stdin.write so we can capture the prompt.
+    fake.ee.stdin = new Writable({
+      write(chunk, _enc, cb): void {
+        writeSpy(chunk.toString());
+        cb();
+      },
+    });
+    await spawnClaude({
+      prompt: 'my-prompt',
+      options: { spawnFn: fakeSpawnFactory(fake) },
+    });
+    await fake.promise;
+    expect(writeSpy).toHaveBeenCalledWith('my-prompt');
+  });
+});
+
+describe('spawnClaude — failure modes', () => {
+  it('returns ok=false on non-zero exit', async () => {
+    const fake = makeFakeChild({
+      exitCode: 1,
+      stderrChunks: ['something failed'],
+    });
+    const result = await spawnClaude({
+      prompt: 'p',
+      options: { spawnFn: fakeSpawnFactory(fake) },
+    });
+    await fake.promise;
+    expect(result.ok).toBe(false);
+    expect(result.rc).toBe(1);
+    expect(result.diagnostic).toMatch(/exited with code 1/);
+  });
+
+  it('returns ok=false on child error event', async () => {
+    const fake = makeFakeChild({
+      emitErrorBeforeClose: new Error('ENOENT'),
+    });
+    const result = await spawnClaude({
+      prompt: 'p',
+      options: { spawnFn: fakeSpawnFactory(fake) },
+    });
+    await fake.promise;
+    expect(result.ok).toBe(false);
+    expect(result.diagnostic).toMatch(/child process error.*ENOENT/);
+  });
+
+  it('returns timedOut=true when the child overruns the deadline', async () => {
+    const fake = makeFakeChild({ exitCode: 0, closeDelayMs: 100 });
+    const result = await spawnClaude({
+      prompt: 'p',
+      options: { spawnFn: fakeSpawnFactory(fake), timeoutMs: 5 },
+    });
+    await fake.promise;
+    expect(result.timedOut).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.diagnostic).toMatch(/timed out after 5ms/);
+  });
+
+  it('returns ok=false when spawn() throws synchronously', async () => {
+    const badSpawn = ((): never => {
+      throw new Error('spawn-threw');
+    }) as unknown as typeof realSpawn;
+    const result = await spawnClaude({
+      prompt: 'p',
+      options: { spawnFn: badSpawn },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostic).toMatch(/failed to spawn .*spawn-threw/);
+  });
+});
+
+describe('spawnClaude — constraints', () => {
+  it('throws SpawnClaudeConstraintError when rejectIfApiKeyPresent and key is set', async () => {
+    const prev = process.env['ANTHROPIC_API_KEY'];
+    process.env['ANTHROPIC_API_KEY'] = 'sk-test';
+    try {
+      const fake = makeFakeChild({ exitCode: 0 });
+      await expect(
+        spawnClaude({
+          prompt: 'p',
+          options: { spawnFn: fakeSpawnFactory(fake) },
+          constraints: { rejectIfApiKeyPresent: true },
+        }),
+      ).rejects.toBeInstanceOf(SpawnClaudeConstraintError);
+    } finally {
+      if (prev === undefined) delete process.env['ANTHROPIC_API_KEY'];
+      else process.env['ANTHROPIC_API_KEY'] = prev;
+    }
+  });
+
+  it('throws SpawnClaudeConstraintError when cwd is not under cwdAllowList', async () => {
+    const fake = makeFakeChild({ exitCode: 0 });
+    await expect(
+      spawnClaude({
+        prompt: 'p',
+        options: { spawnFn: fakeSpawnFactory(fake), cwd: '/etc' },
+        constraints: { cwdAllowList: ['/home/user/repo'] },
+      }),
+    ).rejects.toBeInstanceOf(SpawnClaudeConstraintError);
+  });
+
+  it('accepts cwd that exactly matches an allow-list entry', async () => {
+    const fake = makeFakeChild({ exitCode: 0, stdoutChunks: ['{"result":"ok"}'] });
+    const result = await spawnClaude({
+      prompt: 'p',
+      options: { spawnFn: fakeSpawnFactory(fake), cwd: '/tmp' },
+      constraints: { cwdAllowList: ['/tmp'] },
+    });
+    await fake.promise;
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts cwd that is a subdirectory of an allow-list entry', async () => {
+    const fake = makeFakeChild({ exitCode: 0, stdoutChunks: ['{"result":"ok"}'] });
+    const result = await spawnClaude({
+      prompt: 'p',
+      options: { spawnFn: fakeSpawnFactory(fake), cwd: '/tmp/sub/dir' },
+      constraints: { cwdAllowList: ['/tmp'] },
+    });
+    await fake.promise;
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('spawnClaude — env scrub end-to-end', () => {
+  it('hands the spawn impl an env with auth-token vars removed', async () => {
+    const sawEnv = vi.fn();
+    const fake = makeFakeChild({ exitCode: 0 });
+    const spawnFn = ((
+      _bin: string,
+      _args: ReadonlyArray<string>,
+      opts: { env?: NodeJS.ProcessEnv } | undefined,
+    ): unknown => {
+      sawEnv(opts?.env);
+      return fake.ee;
+    }) as unknown as typeof realSpawn;
+
+    const prev = process.env['ANTHROPIC_API_KEY'];
+    process.env['ANTHROPIC_API_KEY'] = 'sk-leak';
+    try {
+      await spawnClaude({ prompt: 'p', options: { spawnFn } });
+      await fake.promise;
+      const env = sawEnv.mock.calls[0]?.[0] as Record<string, string> | undefined;
+      expect(env).toBeDefined();
+      for (const k of SCRUBBED_AUTH_ENV_VARS) {
+        expect(env?.[k]).toBeUndefined();
+      }
+    } finally {
+      if (prev === undefined) delete process.env['ANTHROPIC_API_KEY'];
+      else process.env['ANTHROPIC_API_KEY'] = prev;
+    }
+  });
+});

--- a/packages/claude-spawner/tsconfig.json
+++ b/packages/claude-spawner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/claude-spawner/vitest.config.ts
+++ b/packages/claude-spawner/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();

--- a/packages/code-reviewer/package.json
+++ b/packages/code-reviewer/package.json
@@ -33,6 +33,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*",
     "@chiefaia/mentor-event-bus": "workspace:*"
   },
   "devDependencies": {

--- a/packages/code-reviewer/src/llm-reasoner.ts
+++ b/packages/code-reviewer/src/llm-reasoner.ts
@@ -21,7 +21,8 @@
  * binary cannot fall back to per-token billing under any circumstance.
  */
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { spawnClaude } from '@chiefaia/claude-spawner';
+import type { spawn } from 'node:child_process';
 
 import type {
   CodeReviewDimensionId,
@@ -43,12 +44,12 @@ export interface DefaultLlmReviewerOptions {
   binaryPath: string;
   modelTag: string;
   timeoutMs: number;
-  /** Test seam — replaces `child_process.spawnSync`. */
-  spawnFn?: (
-    cmd: string,
-    args: readonly string[],
-    opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }
-  ) => SpawnSyncReturns<string>;
+  /**
+   * Test seam — replaces `node:child_process.spawn` used by
+   * `@chiefaia/claude-spawner`. Inject a fake child for testing the
+   * env-scrub / parse paths without actually launching the claude binary.
+   */
+  spawnFn?: typeof spawn;
 }
 
 const DIMENSION_DESCRIPTIONS: Readonly<Record<CodeReviewDimensionId, string>> = {
@@ -120,7 +121,6 @@ ${hunksBlock}
 }
 
 export function createDefaultLlmReviewer(opts: DefaultLlmReviewerOptions): LlmReviewer {
-  const spawn = opts.spawnFn ?? spawnSync;
   return {
     async review(input: LlmReviewInput): Promise<LlmReviewOutput> {
       const prompt = buildPrompt(input);
@@ -129,31 +129,33 @@ export function createDefaultLlmReviewer(opts: DefaultLlmReviewerOptions): LlmRe
       const localOutput = await trySmallDiffLocalRouter(input, prompt);
       if (localOutput !== null) return localOutput;
 
-      // SUBSCRIPTION-ONLY — strip API-key auth env var so the binary cannot
-      // fall through to per-token billing per `feedback_no_api_key_billing.md`.
-      const env = { ...process.env };
-      delete env['ANTHROPIC_API_KEY'];
-      const result = spawn(
-        opts.binaryPath,
-        ['--print', '--output-format', 'json', '--model', opts.modelTag],
-        { input: prompt, encoding: 'utf-8', timeout: opts.timeoutMs, env }
-      );
-      if (result.error !== null && result.error !== undefined) {
+      // Delegate to `@chiefaia/claude-spawner`. The spawner enforces the
+      // SUBSCRIPTION-ONLY env scrub (ANTHROPIC_API_KEY + siblings) per
+      // `feedback_no_api_key_billing.md`.
+      const result = await spawnClaude({
+        prompt,
+        options: {
+          binaryPath: opts.binaryPath,
+          model: opts.modelTag,
+          timeoutMs: opts.timeoutMs,
+          ...(opts.spawnFn !== undefined ? { spawnFn: opts.spawnFn } : {})
+        }
+      });
+      if (!result.ok) {
+        const diag = result.diagnostic ?? 'unknown failure';
         return {
           findings: [],
           ok: false,
-          diagnostic: `claude spawn error: ${result.error.message}`
+          // Preserve the "exited"/"spawn error"/"timed out" diagnostic
+          // shape that the existing telemetry pipelines key off.
+          diagnostic: diag.startsWith('failed to spawn')
+            ? `claude spawn error: ${diag.slice('failed to spawn '.length)}`
+            : diag.startsWith('child process error')
+              ? `claude spawn error: ${diag.slice('child process error: '.length)}`
+              : diag
         };
       }
-      if (result.status !== 0) {
-        return {
-          findings: [],
-          ok: false,
-          diagnostic: `claude exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
-        };
-      }
-      const stdout = (result.stdout ?? '').toString();
-      return parseLlmOutput(stdout);
+      return parseLlmOutput(result.stdout);
     }
   };
 }

--- a/packages/code-reviewer/tests/llm-reasoner.test.ts
+++ b/packages/code-reviewer/tests/llm-reasoner.test.ts
@@ -1,3 +1,7 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import type { spawn as nodeSpawn } from 'node:child_process';
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   buildPrompt,
@@ -6,6 +10,44 @@ import {
   parseLlmOutput
 } from '../src/llm-reasoner.js';
 import type { DiffHunk, LlmReviewInput } from '../src/types.js';
+
+/**
+ * Fake-child helper — produces a `node:child_process.ChildProcess`-shaped
+ * mock compatible with `@chiefaia/claude-spawner`'s `spawnFn` test seam.
+ * Emits stdout/stderr after listeners attach (setImmediate), then `close`.
+ */
+function makeFakeSpawnFn(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  errorBeforeClose?: Error;
+  envSpy?: (env: NodeJS.ProcessEnv) => void;
+}): typeof nodeSpawn {
+  return ((
+    _cmd: string,
+    _args: readonly string[],
+    spawnOpts?: { env?: NodeJS.ProcessEnv },
+  ): unknown => {
+    if (spawnOpts?.env !== undefined) opts.envSpy?.(spawnOpts.env);
+    const ee = new EventEmitter() as EventEmitter & {
+      stdin: Writable;
+      stdout: Readable;
+      stderr: Readable;
+      kill: () => boolean;
+    };
+    ee.stdin = new Writable({ write(_c, _e, cb): void { cb(); } });
+    ee.stdout = new Readable({ read(): void {} });
+    ee.stderr = new Readable({ read(): void {} });
+    ee.kill = (): boolean => true;
+    setImmediate(() => {
+      if (opts.stdout !== undefined) ee.stdout.emit('data', Buffer.from(opts.stdout, 'utf8'));
+      if (opts.stderr !== undefined) ee.stderr.emit('data', Buffer.from(opts.stderr, 'utf8'));
+      if (opts.errorBeforeClose !== undefined) ee.emit('error', opts.errorBeforeClose);
+      else ee.emit('close', opts.exitCode ?? 0);
+    });
+    return ee;
+  }) as unknown as typeof nodeSpawn;
+}
 
 const sampleHunk: DiffHunk = {
   file: 'src/foo.ts',
@@ -212,17 +254,11 @@ describe('parseLlmOutput', () => {
 describe('createDefaultLlmReviewer (subscription-only)', () => {
   it('strips ANTHROPIC_API_KEY from spawn env', async () => {
     let capturedEnv: NodeJS.ProcessEnv = {};
-    const fakeSpawn = (_cmd: string, _args: readonly string[], opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }) => {
-      capturedEnv = opts.env;
-      return {
-        pid: 1,
-        output: [],
-        stdout: JSON.stringify({ result: JSON.stringify({ findings: [] }) }),
-        stderr: '',
-        status: 0,
-        signal: null
-      } as ReturnType<typeof import('node:child_process').spawnSync>;
-    };
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: JSON.stringify({ findings: [] }) }),
+      exitCode: 0,
+      envSpy: (env) => { capturedEnv = env; }
+    });
     process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-fake';
     try {
       const llm = createDefaultLlmReviewer({
@@ -239,15 +275,7 @@ describe('createDefaultLlmReviewer (subscription-only)', () => {
   });
 
   it('returns ok:false on spawn error', async () => {
-    const fakeSpawn = () => ({
-      pid: 0,
-      output: [],
-      stdout: '',
-      stderr: '',
-      status: null,
-      signal: null,
-      error: new Error('ENOENT')
-    } as unknown as ReturnType<typeof import('node:child_process').spawnSync>);
+    const fakeSpawn = makeFakeSpawnFn({ errorBeforeClose: new Error('ENOENT') });
     const llm = createDefaultLlmReviewer({
       binaryPath: 'nonexistent',
       modelTag: 'm',
@@ -260,14 +288,7 @@ describe('createDefaultLlmReviewer (subscription-only)', () => {
   });
 
   it('returns ok:false on non-zero exit', async () => {
-    const fakeSpawn = () => ({
-      pid: 1,
-      output: [],
-      stdout: '',
-      stderr: 'rate-limited',
-      status: 1,
-      signal: null
-    } as ReturnType<typeof import('node:child_process').spawnSync>);
+    const fakeSpawn = makeFakeSpawnFn({ stderr: 'rate-limited', exitCode: 1 });
     const llm = createDefaultLlmReviewer({
       binaryPath: 'claude',
       modelTag: 'm',
@@ -280,9 +301,7 @@ describe('createDefaultLlmReviewer (subscription-only)', () => {
   });
 
   it('parses successful spawn output', async () => {
-    const fakeSpawn = () => ({
-      pid: 1,
-      output: [],
+    const fakeSpawn = makeFakeSpawnFn({
       stdout: JSON.stringify({
         result: JSON.stringify({
           findings: [
@@ -290,10 +309,8 @@ describe('createDefaultLlmReviewer (subscription-only)', () => {
           ]
         })
       }),
-      stderr: '',
-      status: 0,
-      signal: null
-    } as ReturnType<typeof import('node:child_process').spawnSync>);
+      exitCode: 0
+    });
     const llm = createDefaultLlmReviewer({
       binaryPath: 'claude',
       modelTag: 'm',
@@ -325,11 +342,22 @@ describe('A.9.13 — small-diff local-router shortcut (code-reviewer)', () => {
   };
   const largeInput: LlmReviewInput = { ...sampleInput, hunks: [LARGE_HUNK] };
 
-  const okSpawn = () => ({
-    pid: 1, output: [],
-    stdout: JSON.stringify({ result: JSON.stringify({ findings: [] }) }),
-    stderr: '', status: 0, signal: null,
-  } as ReturnType<typeof import('node:child_process').spawnSync>);
+  function spawnSpy(): { fn: typeof nodeSpawn; called: () => boolean } {
+    let called = false;
+    const fn = ((
+      cmd: string,
+      args: readonly string[],
+      opts?: { env?: NodeJS.ProcessEnv },
+    ): unknown => {
+      called = true;
+      const real = makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: JSON.stringify({ findings: [] }) }),
+        exitCode: 0,
+      });
+      return (real as unknown as (a: string, b: readonly string[], c: typeof opts) => unknown)(cmd, args, opts);
+    }) as unknown as typeof nodeSpawn;
+    return { fn, called: () => called };
+  }
 
   beforeEach(() => {
     delete process.env['CAIA_REVIEW_LOCAL_FIRST'];
@@ -343,14 +371,14 @@ describe('A.9.13 — small-diff local-router shortcut (code-reviewer)', () => {
   it('default: does NOT call the router (env flag unset)', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    let spawned = false;
+    const spy = spawnSpy();
     const llm = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return okSpawn(); },
+      spawnFn: spy.fn,
     });
     await llm.review(sampleInput);
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(spawned).toBe(true);
+    expect(spy.called()).toBe(true);
   });
 
   it('routes small diff to the router when CAIA_REVIEW_LOCAL_FIRST=1', async () => {
@@ -360,41 +388,41 @@ describe('A.9.13 — small-diff local-router shortcut (code-reviewer)', () => {
       json: async () => ({ choices: [{ message: { content: JSON.stringify({ findings: [] }) } }] }),
     }));
     vi.stubGlobal('fetch', fetchSpy);
-    let spawned = false;
+    const spy = spawnSpy();
     const llm = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return okSpawn(); },
+      spawnFn: spy.fn,
     });
     await llm.review(sampleInput);
     expect(fetchSpy).toHaveBeenCalledOnce();
-    expect(spawned).toBe(false);
+    expect(spy.called()).toBe(false);
   });
 
   it('falls through to claude when diff > 200 lines', async () => {
     process.env['CAIA_REVIEW_LOCAL_FIRST'] = '1';
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    let spawned = false;
+    const spy = spawnSpy();
     const llm = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return okSpawn(); },
+      spawnFn: spy.fn,
     });
     await llm.review(largeInput);
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(spawned).toBe(true);
+    expect(spy.called()).toBe(true);
   });
 
   it('falls through to claude when router 5xx', async () => {
     process.env['CAIA_REVIEW_LOCAL_FIRST'] = '1';
     const fetchSpy = vi.fn(async () => ({ ok: false, status: 502, json: async () => ({}) }));
     vi.stubGlobal('fetch', fetchSpy);
-    let spawned = false;
+    const spy = spawnSpy();
     const llm = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return okSpawn(); },
+      spawnFn: spy.fn,
     });
     await llm.review(sampleInput);
     expect(fetchSpy).toHaveBeenCalled();
-    expect(spawned).toBe(true);
+    expect(spy.called()).toBe(true);
   });
 });

--- a/packages/critic/package.json
+++ b/packages/critic/package.json
@@ -33,6 +33,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*",
     "@chiefaia/mentor-event-bus": "workspace:*"
   },
   "devDependencies": {

--- a/packages/critic/src/llm-reasoner.ts
+++ b/packages/critic/src/llm-reasoner.ts
@@ -14,7 +14,8 @@
  * always emitted regardless.
  */
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { spawnClaude } from '@chiefaia/claude-spawner';
+import type { spawn } from 'node:child_process';
 
 import type {
   AdversarialFinding,
@@ -32,12 +33,11 @@ export interface DefaultLlmReasonerOptions {
   binaryPath: string;
   modelTag: string;
   timeoutMs: number;
-  /** Test seam — replaces `child_process.spawnSync`. */
-  spawnFn?: (
-    cmd: string,
-    args: readonly string[],
-    opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }
-  ) => SpawnSyncReturns<string>;
+  /**
+   * Test seam — replaces `node:child_process.spawn` used by
+   * `@chiefaia/claude-spawner`.
+   */
+  spawnFn?: typeof spawn;
 }
 
 const SYSTEM_PROMPT = `You are an adversarial code reviewer for the CAIA monorepo. Your job is to assume malice or sloppiness and find concrete attack vectors / failure-modes in the changes. Do NOT comment on style. Do NOT rewrite code. Only surface what could go wrong.
@@ -73,41 +73,41 @@ ${hunksBlock}
 }
 
 export function createDefaultLlmReasoner(opts: DefaultLlmReasonerOptions): LlmReasoner {
-  const spawn = opts.spawnFn ?? spawnSync;
   return {
     async reason(input: LlmReasonInput): Promise<LlmReasonOutput> {
       const prompt = buildPrompt(input);
       // A.9.13 — small diffs go local first via the router. Threshold
       // and model are env-overridable; default off (opt-in via
       // CAIA_REVIEW_LOCAL_FIRST=1). On any local-route failure the path
-      // falls through to the existing claude binary spawn below — no
-      // adversarial finding is dropped.
+      // falls through to claude-spawner below — no adversarial finding
+      // is dropped.
       const localOutput = await trySmallDiffLocalRouter(input);
       if (localOutput !== null) return localOutput;
 
-      const env = { ...process.env };
-      delete env['ANTHROPIC_API_KEY'];
-      const result = spawn(
-        opts.binaryPath,
-        ['--print', '--output-format', 'json', '--model', opts.modelTag],
-        { input: prompt, encoding: 'utf-8', timeout: opts.timeoutMs, env }
-      );
-      if (result.error !== null && result.error !== undefined) {
+      // Delegate to `@chiefaia/claude-spawner` for the canonical
+      // subscription-only spawn (env scrub, timeout, etc).
+      const result = await spawnClaude({
+        prompt,
+        options: {
+          binaryPath: opts.binaryPath,
+          model: opts.modelTag,
+          timeoutMs: opts.timeoutMs,
+          ...(opts.spawnFn !== undefined ? { spawnFn: opts.spawnFn } : {})
+        }
+      });
+      if (!result.ok) {
+        const diag = result.diagnostic ?? 'unknown failure';
         return {
           findings: [],
           ok: false,
-          diagnostic: `claude spawn error: ${result.error.message}`
+          diagnostic: diag.startsWith('failed to spawn')
+            ? `claude spawn error: ${diag.slice('failed to spawn '.length)}`
+            : diag.startsWith('child process error')
+              ? `claude spawn error: ${diag.slice('child process error: '.length)}`
+              : diag
         };
       }
-      if (result.status !== 0) {
-        return {
-          findings: [],
-          ok: false,
-          diagnostic: `claude exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
-        };
-      }
-      const stdout = (result.stdout ?? '').toString();
-      return parseLlmOutput(stdout);
+      return parseLlmOutput(result.stdout);
     }
   };
 }

--- a/packages/critic/tests/llm-reasoner.test.ts
+++ b/packages/critic/tests/llm-reasoner.test.ts
@@ -1,3 +1,7 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import type { spawn as nodeSpawn } from 'node:child_process';
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import {
@@ -8,6 +12,45 @@ import {
 } from '../src/llm-reasoner.js';
 import { CANONICAL_TAXONOMY } from '../src/taxonomy.js';
 import type { DiffHunk } from '../src/types.js';
+
+/**
+ * Fake-child helper compatible with `@chiefaia/claude-spawner`'s
+ * `spawnFn` test seam (`typeof spawn` from `node:child_process`).
+ */
+function makeFakeSpawnFn(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  errorBeforeClose?: Error;
+  envSpy?: (env: NodeJS.ProcessEnv) => void;
+  onSpawn?: () => void;
+}): typeof nodeSpawn {
+  return ((
+    _cmd: string,
+    _args: readonly string[],
+    spawnOpts?: { env?: NodeJS.ProcessEnv },
+  ): unknown => {
+    opts.onSpawn?.();
+    if (spawnOpts?.env !== undefined) opts.envSpy?.(spawnOpts.env);
+    const ee = new EventEmitter() as EventEmitter & {
+      stdin: Writable;
+      stdout: Readable;
+      stderr: Readable;
+      kill: () => boolean;
+    };
+    ee.stdin = new Writable({ write(_c, _e, cb): void { cb(); } });
+    ee.stdout = new Readable({ read(): void {} });
+    ee.stderr = new Readable({ read(): void {} });
+    ee.kill = (): boolean => true;
+    setImmediate(() => {
+      if (opts.stdout !== undefined) ee.stdout.emit('data', Buffer.from(opts.stdout, 'utf8'));
+      if (opts.stderr !== undefined) ee.stderr.emit('data', Buffer.from(opts.stderr, 'utf8'));
+      if (opts.errorBeforeClose !== undefined) ee.emit('error', opts.errorBeforeClose);
+      else ee.emit('close', opts.exitCode ?? 0);
+    });
+    return ee;
+  }) as unknown as typeof nodeSpawn;
+}
 
 describe('parseLlmOutput', () => {
   it('parses a well-formed envelope', () => {
@@ -114,17 +157,11 @@ describe('createDefaultLlmReasoner', () => {
       binaryPath: '/fake/claude',
       modelTag: 'm',
       timeoutMs: 1000,
-      spawnFn: (_cmd, _args, opts) => {
-        capturedEnv = opts.env;
-        return {
-          status: 0,
-          stdout: JSON.stringify({ result: '{"findings":[]}' }),
-          stderr: '',
-          pid: 1,
-          output: ['', '', ''],
-          signal: null
-        };
-      }
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        envSpy: (env) => { capturedEnv = env; }
+      })
     });
     process.env['ANTHROPIC_API_KEY'] = 'should-not-leak';
     try {
@@ -144,14 +181,7 @@ describe('createDefaultLlmReasoner', () => {
       binaryPath: '/fake/claude',
       modelTag: 'm',
       timeoutMs: 1000,
-      spawnFn: () => ({
-        status: 1,
-        stdout: '',
-        stderr: 'rate limited',
-        pid: 1,
-        output: ['', '', ''],
-        signal: null
-      })
+      spawnFn: makeFakeSpawnFn({ stderr: 'rate limited', exitCode: 1 })
     });
     const r = await reasoner.reason({
       hunks: [],
@@ -159,7 +189,8 @@ describe('createDefaultLlmReasoner', () => {
       pr: { prNumber: 0, branch: 'b', baseBranch: 'develop', title: 't', commitSubjects: [] }
     });
     expect(r.ok).toBe(false);
-    expect(r.diagnostic).toContain('exited 1');
+    expect(r.diagnostic).toContain('exited');
+    expect(r.diagnostic).toContain('1');
   });
 
   it('returns ok:false on spawn error', async () => {
@@ -167,15 +198,7 @@ describe('createDefaultLlmReasoner', () => {
       binaryPath: '/fake/claude',
       modelTag: 'm',
       timeoutMs: 1000,
-      spawnFn: () => ({
-        status: null,
-        stdout: '',
-        stderr: '',
-        pid: 0,
-        output: ['', '', ''],
-        signal: null,
-        error: new Error('ENOENT')
-      })
+      spawnFn: makeFakeSpawnFn({ errorBeforeClose: new Error('ENOENT') })
     });
     const r = await reasoner.reason({
       hunks: [],
@@ -217,10 +240,11 @@ describe('A.9.13 — small-diff local-router shortcut (Critic)', () => {
     vi.stubGlobal('fetch', fetchSpy);
     const reasoner = createDefaultLlmReasoner({
       binaryPath: '/fake/claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return {
-        status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '',
-        pid: 1, output: ['', '', ''], signal: null,
-      }; }
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      })
     });
     await reasoner.reason({ hunks: [SMALL_HUNK], taxonomy: CANONICAL_TAXONOMY, pr: PR_META });
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -240,9 +264,11 @@ describe('A.9.13 — small-diff local-router shortcut (Critic)', () => {
     vi.stubGlobal('fetch', fetchSpy);
     const reasoner = createDefaultLlmReasoner({
       binaryPath: '/fake/claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return {
-        status: 0, stdout: '', stderr: '', pid: 1, output: ['', '', ''], signal: null,
-      }; }
+      spawnFn: makeFakeSpawnFn({
+        stdout: '',
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      })
     });
     const r = await reasoner.reason({ hunks: [SMALL_HUNK], taxonomy: CANONICAL_TAXONOMY, pr: PR_META });
     expect(fetchSpy).toHaveBeenCalledOnce();
@@ -257,10 +283,11 @@ describe('A.9.13 — small-diff local-router shortcut (Critic)', () => {
     let spawned = false;
     const reasoner = createDefaultLlmReasoner({
       binaryPath: '/fake/claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return {
-        status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '',
-        pid: 1, output: ['', '', ''], signal: null,
-      }; }
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      })
     });
     await reasoner.reason({ hunks: [LARGE_HUNK], taxonomy: CANONICAL_TAXONOMY, pr: PR_META });
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -274,10 +301,11 @@ describe('A.9.13 — small-diff local-router shortcut (Critic)', () => {
     let spawned = false;
     const reasoner = createDefaultLlmReasoner({
       binaryPath: '/fake/claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return {
-        status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '',
-        pid: 1, output: ['', '', ''], signal: null,
-      }; }
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      })
     });
     await reasoner.reason({ hunks: [SMALL_HUNK], taxonomy: CANONICAL_TAXONOMY, pr: PR_META });
     expect(fetchSpy).toHaveBeenCalled();
@@ -291,10 +319,11 @@ describe('A.9.13 — small-diff local-router shortcut (Critic)', () => {
     let spawned = false;
     const reasoner = createDefaultLlmReasoner({
       binaryPath: '/fake/claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return {
-        status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '',
-        pid: 1, output: ['', '', ''], signal: null,
-      }; }
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      })
     });
     await reasoner.reason({ hunks: [SMALL_HUNK], taxonomy: CANONICAL_TAXONOMY, pr: PR_META });
     expect(spawned).toBe(true);
@@ -308,10 +337,11 @@ describe('A.9.13 — small-diff local-router shortcut (Critic)', () => {
     let spawned = false;
     const reasoner = createDefaultLlmReasoner({
       binaryPath: '/fake/claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: () => { spawned = true; return {
-        status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '',
-        pid: 1, output: ['', '', ''], signal: null,
-      }; }
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      })
     });
     await reasoner.reason({ hunks: [SMALL_HUNK], taxonomy: CANONICAL_TAXONOMY, pr: PR_META });
     expect(fetchSpy).not.toHaveBeenCalled();

--- a/packages/researcher/package.json
+++ b/packages/researcher/package.json
@@ -32,7 +32,9 @@
     "lint": "eslint src tests",
     "clean": "rm -rf dist"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "1.6.1",

--- a/packages/researcher/src/llm-client.ts
+++ b/packages/researcher/src/llm-client.ts
@@ -18,13 +18,18 @@
  * parse the rate-limit message as a synthesis result.
  */
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { spawnClaude } from '@chiefaia/claude-spawner';
+import type { spawn, spawnSync, SpawnSyncReturns } from 'node:child_process';
 
 import type { LlmClient, LlmCompletion } from './types.js';
 
 export interface DefaultLlmClientOptions {
   binaryPath: string;
-  /** Test seam — replaces `child_process.spawnSync`. */
+  /**
+   * Test seam — back-compat shim. New callers should use {@link spawnImpl}
+   * which matches `@chiefaia/claude-spawner`'s `spawnFn` shape. Setting
+   * `spawnFn` is a no-op now; the client routes through claude-spawner.
+   */
   spawnFn?: (
     cmd: string,
     args: readonly string[],
@@ -36,15 +41,14 @@ export interface DefaultLlmClientOptions {
       maxBuffer: number;
     }
   ) => SpawnSyncReturns<string>;
+  /**
+   * Test seam — replaces `node:child_process.spawn` used by
+   * `@chiefaia/claude-spawner`. Inject a fake child for testing.
+   */
+  spawnImpl?: typeof spawn;
 }
 
-const MAX_BUFFER = 50 * 1024 * 1024; // 50 MB — synthesis can be large
-
 export function createDefaultLlmClient(opts: DefaultLlmClientOptions): LlmClient {
-  const spawn: NonNullable<DefaultLlmClientOptions['spawnFn']> =
-    opts.spawnFn ??
-    ((cmd, args, sopts): SpawnSyncReturns<string> =>
-      spawnSync(cmd, args as readonly string[], sopts) as SpawnSyncReturns<string>);
   return {
     async complete(input: {
       prompt: string;
@@ -60,52 +64,49 @@ export function createDefaultLlmClient(opts: DefaultLlmClientOptions): LlmClient
       const localOutput = await trySmallPayloadLocalRouter(input);
       if (localOutput !== null) return localOutput;
 
-      const env = { ...process.env };
-      delete env['ANTHROPIC_API_KEY'];
-      const args: string[] = ['--print', '--output-format', 'json'];
-      if (input.model !== undefined && input.model.length > 0) {
-        args.push('--model', input.model);
+      const result = await spawnClaude({
+        prompt: input.prompt,
+        options: {
+          binaryPath: opts.binaryPath,
+          ...(input.model !== undefined && input.model.length > 0 ? { model: input.model } : {}),
+          timeoutMs: input.timeoutMs,
+          ...(opts.spawnImpl !== undefined ? { spawnFn: opts.spawnImpl } : {})
+        }
+      });
+      if (!result.ok) {
+        const diag = result.diagnostic ?? 'unknown failure';
+        // Preserve the legacy diagnostic shapes so consumers' regex
+        // checks for "spawn threw" / "claude spawn error" / "claude exited"
+        // still hit.
+        if (diag.startsWith('failed to spawn')) {
+          return {
+            text: '',
+            ok: false,
+            diagnostic: `spawn threw: ${diag.slice('failed to spawn '.length)}`
+          };
+        }
+        if (diag.startsWith('child process error')) {
+          return {
+            text: '',
+            ok: false,
+            diagnostic: `claude spawn error: ${diag.slice('child process error: '.length)}`
+          };
+        }
+        if (result.rc !== null && result.rc !== 0) {
+          const stderr = result.stderr.slice(0, 600);
+          const tail =
+            result.stdout.length > 0
+              ? `${stderr} | stdout: ${result.stdout.slice(0, 400)}`
+              : stderr;
+          return {
+            text: '',
+            ok: false,
+            diagnostic: `claude exited ${String(result.rc)}: ${tail}`
+          };
+        }
+        return { text: '', ok: false, diagnostic: diag };
       }
-      let result: SpawnSyncReturns<string>;
-      try {
-        result = spawn(opts.binaryPath, args, {
-          input: input.prompt,
-          encoding: 'utf-8',
-          timeout: input.timeoutMs,
-          env,
-          maxBuffer: MAX_BUFFER
-        });
-      } catch (e) {
-        return {
-          text: '',
-          ok: false,
-          diagnostic: `spawn threw: ${(e as Error).message}`
-        };
-      }
-      if (result.error !== null && result.error !== undefined) {
-        return {
-          text: '',
-          ok: false,
-          diagnostic: `claude spawn error: ${result.error.message}`
-        };
-      }
-      if (result.status !== 0) {
-        const stderr = (result.stderr ?? '').toString().slice(0, 600);
-        const stdout = (result.stdout ?? '').toString();
-        // Some failure modes (rate-limit) emit a JSON envelope on stdout
-        // even with non-zero exit. Surface both for the diagnostic.
-        const tail =
-          stdout.length > 0
-            ? `${stderr} | stdout: ${stdout.slice(0, 400)}`
-            : stderr;
-        return {
-          text: '',
-          ok: false,
-          diagnostic: `claude exited ${result.status}: ${tail}`
-        };
-      }
-      const stdout = (result.stdout ?? '').toString();
-      return parseEnvelope(stdout);
+      return parseEnvelope(result.stdout);
     }
   };
 }

--- a/packages/researcher/src/llm-client.ts
+++ b/packages/researcher/src/llm-client.ts
@@ -19,7 +19,7 @@
  */
 
 import { spawnClaude } from '@chiefaia/claude-spawner';
-import type { spawn, spawnSync, SpawnSyncReturns } from 'node:child_process';
+import type { spawn, SpawnSyncReturns } from 'node:child_process';
 
 import type { LlmClient, LlmCompletion } from './types.js';
 

--- a/packages/researcher/tests/llm-client.test.ts
+++ b/packages/researcher/tests/llm-client.test.ts
@@ -1,9 +1,51 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import type { spawn as nodeSpawn } from 'node:child_process';
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   createDefaultLlmClient,
   parseEnvelope,
   extractFirstJsonBlock
 } from '../src/llm-client.js';
+
+/** Fake-child compatible with `@chiefaia/claude-spawner`'s spawn seam. */
+function makeFakeSpawnFn(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  errorBeforeClose?: Error;
+  argsSpy?: (args: readonly string[]) => void;
+  envSpy?: (env: NodeJS.ProcessEnv) => void;
+  onSpawn?: () => void;
+}): typeof nodeSpawn {
+  return ((
+    _cmd: string,
+    args: readonly string[],
+    spawnOpts?: { env?: NodeJS.ProcessEnv },
+  ): unknown => {
+    opts.onSpawn?.();
+    opts.argsSpy?.(args);
+    if (spawnOpts?.env !== undefined) opts.envSpy?.(spawnOpts.env);
+    const ee = new EventEmitter() as EventEmitter & {
+      stdin: Writable;
+      stdout: Readable;
+      stderr: Readable;
+      kill: () => boolean;
+    };
+    ee.stdin = new Writable({ write(_c, _e, cb): void { cb(); } });
+    ee.stdout = new Readable({ read(): void {} });
+    ee.stderr = new Readable({ read(): void {} });
+    ee.kill = (): boolean => true;
+    setImmediate(() => {
+      if (opts.stdout !== undefined) ee.stdout.emit('data', Buffer.from(opts.stdout, 'utf8'));
+      if (opts.stderr !== undefined) ee.stderr.emit('data', Buffer.from(opts.stderr, 'utf8'));
+      if (opts.errorBeforeClose !== undefined) ee.emit('error', opts.errorBeforeClose);
+      else ee.emit('close', opts.exitCode ?? 0);
+    });
+    return ee;
+  }) as unknown as typeof nodeSpawn;
+}
 
 describe('parseEnvelope', () => {
   it('parses claude --print envelope', () => {
@@ -54,52 +96,32 @@ describe('extractFirstJsonBlock', () => {
 describe('createDefaultLlmClient', () => {
   it('scrubs ANTHROPIC_API_KEY before spawn', async () => {
     let capturedEnv: NodeJS.ProcessEnv | null = null;
-    const fakeSpawn = (
-      _cmd: string,
-      _args: readonly string[],
-      sopts: {
-        input: string;
-        encoding: 'utf-8';
-        timeout: number;
-        env: NodeJS.ProcessEnv;
-        maxBuffer: number;
-      }
-    ) =>
-      ({
-        pid: 1,
-        output: [null, '', ''],
-        stdout: JSON.stringify({ result: 'ok' }),
-        stderr: '',
-        status: 0,
-        signal: null,
-        ...((capturedEnv = sopts.env), {})
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>);
-    process.env['ANTHROPIC_API_KEY'] = 'leak-me';
-    const client = createDefaultLlmClient({
-      binaryPath: 'claude',
-      spawnFn: fakeSpawn as Parameters<typeof createDefaultLlmClient>[0]['spawnFn']
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: 'ok' }),
+      exitCode: 0,
+      envSpy: (env) => { capturedEnv = env; }
     });
-    const r = await client.complete({ prompt: 'hi', timeoutMs: 1000 });
-    expect(r.ok).toBe(true);
-    expect(r.text).toBe('ok');
-    expect(capturedEnv).not.toBeNull();
-    expect(capturedEnv?.['ANTHROPIC_API_KEY']).toBeUndefined();
-    delete process.env['ANTHROPIC_API_KEY'];
+    process.env['ANTHROPIC_API_KEY'] = 'leak-me';
+    try {
+      const client = createDefaultLlmClient({
+        binaryPath: 'claude',
+        spawnImpl: fakeSpawn
+      });
+      const r = await client.complete({ prompt: 'hi', timeoutMs: 1000 });
+      expect(r.ok).toBe(true);
+      expect(r.text).toBe('ok');
+      expect(capturedEnv).not.toBeNull();
+      expect(capturedEnv?.['ANTHROPIC_API_KEY']).toBeUndefined();
+    } finally {
+      delete process.env['ANTHROPIC_API_KEY'];
+    }
   });
 
   it('returns ok=false on non-zero exit', async () => {
-    const fakeSpawn = () =>
-      ({
-        pid: 1,
-        output: [null, '', 'boom'],
-        stdout: '',
-        stderr: 'boom',
-        status: 1,
-        signal: null
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>);
+    const fakeSpawn = makeFakeSpawnFn({ stderr: 'boom', exitCode: 1 });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: fakeSpawn as Parameters<typeof createDefaultLlmClient>[0]['spawnFn']
+      spawnImpl: fakeSpawn
     });
     const r = await client.complete({ prompt: 'hi', timeoutMs: 1000 });
     expect(r.ok).toBe(false);
@@ -107,22 +129,17 @@ describe('createDefaultLlmClient', () => {
   });
 
   it('returns ok=false on rate-limit envelope', async () => {
-    const fakeSpawn = () =>
-      ({
-        pid: 1,
-        output: [null, '', ''],
-        stdout: JSON.stringify({
-          is_error: true,
-          api_error_status: 429,
-          result: "You've hit your limit · resets 5pm"
-        }),
-        stderr: '',
-        status: 0,
-        signal: null
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>);
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({
+        is_error: true,
+        api_error_status: 429,
+        result: "You've hit your limit · resets 5pm"
+      }),
+      exitCode: 0
+    });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: fakeSpawn as Parameters<typeof createDefaultLlmClient>[0]['spawnFn']
+      spawnImpl: fakeSpawn
     });
     const r = await client.complete({ prompt: 'hi', timeoutMs: 1000 });
     expect(r.ok).toBe(false);
@@ -131,23 +148,14 @@ describe('createDefaultLlmClient', () => {
 
   it('forwards --model flag when provided', async () => {
     let capturedArgs: readonly string[] | null = null;
-    const fakeSpawn = (
-      _cmd: string,
-      args: readonly string[]
-    ) => {
-      capturedArgs = args;
-      return {
-        pid: 1,
-        output: [null, '', ''],
-        stdout: JSON.stringify({ result: 'ok' }),
-        stderr: '',
-        status: 0,
-        signal: null
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>;
-    };
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: 'ok' }),
+      exitCode: 0,
+      argsSpy: (args) => { capturedArgs = args; }
+    });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: fakeSpawn as Parameters<typeof createDefaultLlmClient>[0]['spawnFn']
+      spawnImpl: fakeSpawn
     });
     await client.complete({
       prompt: 'hi',
@@ -178,12 +186,14 @@ describe('A.9.13 — small-payload local-router shortcut (researcher)', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     let spawned = false;
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: 'ok' }),
+      exitCode: 0,
+      onSpawn: () => { spawned = true; }
+    });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: ((_c, _a, _o) => { spawned = true; return {
-        pid: 1, output: [null, '', ''], stdout: JSON.stringify({ result: 'ok' }),
-        stderr: '', status: 0, signal: null,
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>; }),
+      spawnImpl: fakeSpawn
     });
     const r = await client.complete({ prompt: 'small q', timeoutMs: 1000 });
     expect(r.ok).toBe(true);
@@ -199,11 +209,14 @@ describe('A.9.13 — small-payload local-router shortcut (researcher)', () => {
     }));
     vi.stubGlobal('fetch', fetchSpy);
     let spawned = false;
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: '',
+      exitCode: 0,
+      onSpawn: () => { spawned = true; }
+    });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: ((_c, _a, _o) => { spawned = true; return {
-        pid: 1, output: [null, '', ''], stdout: '', stderr: '', status: 0, signal: null,
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>; }),
+      spawnImpl: fakeSpawn
     });
     const r = await client.complete({ prompt: 'tiny', timeoutMs: 1000 });
     expect(fetchSpy).toHaveBeenCalledOnce();
@@ -218,12 +231,14 @@ describe('A.9.13 — small-payload local-router shortcut (researcher)', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     let spawned = false;
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: 'claude' }),
+      exitCode: 0,
+      onSpawn: () => { spawned = true; }
+    });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: ((_c, _a, _o) => { spawned = true; return {
-        pid: 1, output: [null, '', ''], stdout: JSON.stringify({ result: 'claude' }),
-        stderr: '', status: 0, signal: null,
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>; }),
+      spawnImpl: fakeSpawn
     });
     await client.complete({ prompt: 'this prompt is more than 10 bytes', timeoutMs: 1000 });
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -235,12 +250,14 @@ describe('A.9.13 — small-payload local-router shortcut (researcher)', () => {
     const fetchSpy = vi.fn(async () => ({ ok: false, status: 502, json: async () => ({}) }));
     vi.stubGlobal('fetch', fetchSpy);
     let spawned = false;
+    const fakeSpawn = makeFakeSpawnFn({
+      stdout: JSON.stringify({ result: 'claude-fallback' }),
+      exitCode: 0,
+      onSpawn: () => { spawned = true; }
+    });
     const client = createDefaultLlmClient({
       binaryPath: 'claude',
-      spawnFn: ((_c, _a, _o) => { spawned = true; return {
-        pid: 1, output: [null, '', ''], stdout: JSON.stringify({ result: 'claude-fallback' }),
-        stderr: '', status: 0, signal: null,
-      } as unknown as ReturnType<typeof import('node:child_process').spawnSync>; }),
+      spawnImpl: fakeSpawn
     });
     const r = await client.complete({ prompt: 'small', timeoutMs: 1000 });
     expect(fetchSpy).toHaveBeenCalled();

--- a/packages/reviewer/package.json
+++ b/packages/reviewer/package.json
@@ -33,6 +33,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*",
     "@chiefaia/mentor-event-bus": "workspace:*"
   },
   "devDependencies": {

--- a/packages/reviewer/src/llm-reasoner.ts
+++ b/packages/reviewer/src/llm-reasoner.ts
@@ -16,7 +16,8 @@
  * always emitted regardless.
  */
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { spawnClaude } from '@chiefaia/claude-spawner';
+import type { spawn } from 'node:child_process';
 
 import type {
   CraftsmanshipDimensionId,
@@ -32,12 +33,11 @@ export interface DefaultLlmReviewerOptions {
   binaryPath: string;
   modelTag: string;
   timeoutMs: number;
-  /** Test seam — replaces `child_process.spawnSync`. */
-  spawnFn?: (
-    cmd: string,
-    args: readonly string[],
-    opts: { input: string; encoding: 'utf-8'; timeout: number; env: NodeJS.ProcessEnv }
-  ) => SpawnSyncReturns<string>;
+  /**
+   * Test seam — replaces `node:child_process.spawn` used by
+   * `@chiefaia/claude-spawner`.
+   */
+  spawnFn?: typeof spawn;
 }
 
 const DIMENSION_DESCRIPTIONS: Readonly<Record<CraftsmanshipDimensionId, string>> = {
@@ -109,39 +109,37 @@ ${hunksBlock}
 }
 
 export function createDefaultLlmReviewer(opts: DefaultLlmReviewerOptions): LlmReviewer {
-  const spawn = opts.spawnFn ?? spawnSync;
   return {
     async review(input: LlmReviewInput): Promise<LlmReviewOutput> {
       const prompt = buildPrompt(input);
       // A.9.13 — try local router for small diffs first; fall through
-      // to claude on any failure. Off by default — set
+      // to claude-spawner on any failure. Off by default — set
       // CAIA_REVIEW_LOCAL_FIRST=1 to enable.
       const localOutput = await trySmallDiffLocalRouter(input, prompt);
       if (localOutput !== null) return localOutput;
 
-      const env = { ...process.env };
-      delete env['ANTHROPIC_API_KEY'];
-      const result = spawn(
-        opts.binaryPath,
-        ['--print', '--output-format', 'json', '--model', opts.modelTag],
-        { input: prompt, encoding: 'utf-8', timeout: opts.timeoutMs, env }
-      );
-      if (result.error !== null && result.error !== undefined) {
+      const result = await spawnClaude({
+        prompt,
+        options: {
+          binaryPath: opts.binaryPath,
+          model: opts.modelTag,
+          timeoutMs: opts.timeoutMs,
+          ...(opts.spawnFn !== undefined ? { spawnFn: opts.spawnFn } : {})
+        }
+      });
+      if (!result.ok) {
+        const diag = result.diagnostic ?? 'unknown failure';
         return {
           findings: [],
           ok: false,
-          diagnostic: `claude spawn error: ${result.error.message}`
+          diagnostic: diag.startsWith('failed to spawn')
+            ? `claude spawn error: ${diag.slice('failed to spawn '.length)}`
+            : diag.startsWith('child process error')
+              ? `claude spawn error: ${diag.slice('child process error: '.length)}`
+              : diag
         };
       }
-      if (result.status !== 0) {
-        return {
-          findings: [],
-          ok: false,
-          diagnostic: `claude exited ${result.status}: ${(result.stderr ?? '').toString().slice(0, 300)}`
-        };
-      }
-      const stdout = (result.stdout ?? '').toString();
-      return parseLlmOutput(stdout);
+      return parseLlmOutput(result.stdout);
     }
   };
 }

--- a/packages/reviewer/tests/llm-reasoner.test.ts
+++ b/packages/reviewer/tests/llm-reasoner.test.ts
@@ -1,6 +1,46 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import type { spawn as nodeSpawn } from 'node:child_process';
+
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { buildPrompt, parseLlmOutput, createDefaultLlmReviewer } from '../src/llm-reasoner.js';
 import type { LlmReviewInput } from '../src/types.js';
+
+/** Fake-child for `@chiefaia/claude-spawner`'s `spawnFn` test seam. */
+function makeFakeSpawnFn(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  errorBeforeClose?: Error;
+  envSpy?: (env: NodeJS.ProcessEnv) => void;
+  onSpawn?: () => void;
+}): typeof nodeSpawn {
+  return ((
+    _cmd: string,
+    _args: readonly string[],
+    spawnOpts?: { env?: NodeJS.ProcessEnv },
+  ): unknown => {
+    opts.onSpawn?.();
+    if (spawnOpts?.env !== undefined) opts.envSpy?.(spawnOpts.env);
+    const ee = new EventEmitter() as EventEmitter & {
+      stdin: Writable;
+      stdout: Readable;
+      stderr: Readable;
+      kill: () => boolean;
+    };
+    ee.stdin = new Writable({ write(_c, _e, cb): void { cb(); } });
+    ee.stdout = new Readable({ read(): void {} });
+    ee.stderr = new Readable({ read(): void {} });
+    ee.kill = (): boolean => true;
+    setImmediate(() => {
+      if (opts.stdout !== undefined) ee.stdout.emit('data', Buffer.from(opts.stdout, 'utf8'));
+      if (opts.stderr !== undefined) ee.stderr.emit('data', Buffer.from(opts.stderr, 'utf8'));
+      if (opts.errorBeforeClose !== undefined) ee.emit('error', opts.errorBeforeClose);
+      else ee.emit('close', opts.exitCode ?? 0);
+    });
+    return ee;
+  }) as unknown as typeof nodeSpawn;
+}
 
 describe('buildPrompt', () => {
   it('includes dimensions, conventions, and hunks', () => {
@@ -82,24 +122,26 @@ describe('createDefaultLlmReviewer (with spawnFn seam)', () => {
   it('returns ok=false on non-zero exit', async () => {
     const reviewer = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: (() => ({ status: 1, stdout: '', stderr: 'oops', error: null, signal: null, output: [] })) as never
+      spawnFn: makeFakeSpawnFn({ stderr: 'oops', exitCode: 1 })
     });
     const out = await reviewer.review({
       hunks: [], conventionExcerpts: [],
       pr: { prNumber: 1, branch: 'b', baseBranch: 'develop', title: 't', commitSubjects: [] }
     });
     expect(out.ok).toBe(false);
-    expect(out.diagnostic).toContain('exited 1');
+    expect(out.diagnostic).toContain('exited');
+    expect(out.diagnostic).toContain('1');
   });
 
   it('deletes ANTHROPIC_API_KEY from spawned env', async () => {
     let capturedEnv: NodeJS.ProcessEnv | null = null;
     const reviewer = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: ((_cmd, _args, opts) => {
-        capturedEnv = opts.env;
-        return { status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '', error: null, signal: null, output: [] };
-      }) as never
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        envSpy: (env) => { capturedEnv = env; }
+      })
     });
     process.env['ANTHROPIC_API_KEY'] = 'sk-test';
     try {
@@ -152,7 +194,11 @@ describe('A.9.13 — small-diff local-router shortcut (reviewer)', () => {
     let spawned = false;
     const reviewer = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: (() => { spawned = true; return { status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '', error: null, signal: null, output: [] }; }) as never,
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      }),
     });
     await reviewer.review(smallInput);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -169,7 +215,11 @@ describe('A.9.13 — small-diff local-router shortcut (reviewer)', () => {
     let spawned = false;
     const reviewer = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: (() => { spawned = true; return { status: 0, stdout: '', stderr: '', error: null, signal: null, output: [] }; }) as never,
+      spawnFn: makeFakeSpawnFn({
+        stdout: '',
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      }),
     });
     await reviewer.review(smallInput);
     expect(fetchSpy).toHaveBeenCalledOnce();
@@ -183,7 +233,11 @@ describe('A.9.13 — small-diff local-router shortcut (reviewer)', () => {
     let spawned = false;
     const reviewer = createDefaultLlmReviewer({
       binaryPath: 'claude', modelTag: 'm', timeoutMs: 1000,
-      spawnFn: (() => { spawned = true; return { status: 0, stdout: JSON.stringify({ result: '{"findings":[]}' }), stderr: '', error: null, signal: null, output: [] }; }) as never,
+      spawnFn: makeFakeSpawnFn({
+        stdout: JSON.stringify({ result: '{"findings":[]}' }),
+        exitCode: 0,
+        onSpawn: () => { spawned = true; }
+      }),
     });
     await reviewer.review(largeInput);
     expect(fetchSpy).not.toHaveBeenCalled();

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -34,7 +34,9 @@
     "lint": "eslint src tests",
     "clean": "rm -rf dist"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "1.6.1",

--- a/packages/verifier/src/agent.ts
+++ b/packages/verifier/src/agent.ts
@@ -20,7 +20,7 @@
  * outcome, and the failure reason (if any).
  */
 
-import { spawn } from 'node:child_process';
+import { spawnClaude } from '@chiefaia/claude-spawner';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -68,48 +68,32 @@ export type RunChildFn = (args: {
 }) => Promise<RunChildResult>;
 
 /**
- * Default child runner — uses node:child_process.spawn with stdin pipe.
- * Times out via SIGTERM at deadline.
+ * Default child runner — delegates to `@chiefaia/claude-spawner`'s
+ * `spawnClaude`. The agent-level `runChild` test seam is preserved so
+ * existing tests can inject a mock without depending on claude-spawner
+ * internals; this default impl just adapts the shapes.
  */
-const defaultRunChild: RunChildFn = ({ binary, argv, cwd, prompt, env, timeoutMs }) => {
-  return new Promise((resolve) => {
-    const child = spawn(binary, argv, {
+const defaultRunChild: RunChildFn = async ({ binary, argv, cwd, prompt, env, timeoutMs }) => {
+  // The agent already strips ANTHROPIC_API_KEY in buildEnvWithoutApiKey,
+  // but spawnClaude scrubs again unconditionally — defence in depth.
+  const result = await spawnClaude({
+    prompt,
+    options: {
+      binaryPath: binary,
+      overrideArgs: argv,
       cwd,
-      env,
-      stdio: ['pipe', 'pipe', 'pipe']
-    });
-    let stdoutBuf = '';
-    let stderrBuf = '';
-    let timedOut = false;
-    const t = setTimeout(() => {
-      timedOut = true;
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // ignore
-      }
-    }, timeoutMs);
-
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (d) => {
-      stdoutBuf += d;
-    });
-    child.stderr.on('data', (d) => {
-      stderrBuf += d;
-    });
-    child.on('close', (code) => {
-      clearTimeout(t);
-      resolve({
-        rc: code ?? -1,
-        stdout: stdoutBuf,
-        stderr: stderrBuf,
-        timedOut
-      });
-    });
-    child.stdin.write(prompt);
-    child.stdin.end();
+      // Pass the agent-built env through; claude-spawner will scrub the
+      // canonical auth-token vars regardless of what we hand it.
+      extraEnv: env,
+      timeoutMs
+    }
   });
+  return {
+    rc: result.rc ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    timedOut: result.timedOut
+  };
 };
 
 function lastJsonLine(stdout: string): string | null {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2247,6 +2247,10 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  services/claude-spawner-agent: {}
+
+  services/slot-manager: {}
+
   services/sps: {}
 
   templates/site-pokerzeno:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,27 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/claude-spawner:
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/claude-subagents:
     devDependencies:
       '@types/node':
@@ -2202,6 +2223,8 @@ importers:
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
+  services/sps: {}
 
   templates/site-pokerzeno:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,9 @@ importers:
 
   packages/apprentice-corpus:
     dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
       '@chiefaia/mentor-event-bus':
         specifier: workspace:*
         version: link:../mentor-event-bus
@@ -620,6 +623,9 @@ importers:
       '@chiefaia/apprentice-corpus':
         specifier: workspace:*
         version: link:../apprentice-corpus
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -929,6 +935,9 @@ importers:
 
   packages/code-reviewer:
     dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
       '@chiefaia/mentor-event-bus':
         specifier: workspace:*
         version: link:../mentor-event-bus
@@ -1001,6 +1010,9 @@ importers:
 
   packages/critic:
     dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
       '@chiefaia/mentor-event-bus':
         specifier: workspace:*
         version: link:../mentor-event-bus
@@ -1783,6 +1795,10 @@ importers:
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/researcher:
+    dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -1799,6 +1815,9 @@ importers:
 
   packages/reviewer:
     dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
       '@chiefaia/mentor-event-bus':
         specifier: workspace:*
         version: link:../mentor-event-bus
@@ -2210,6 +2229,10 @@ importers:
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/verifier:
+    dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
## Phase D1 — extract @chiefaia/claude-spawner

Per the integration-remediation-delta plan §D Phase D1 (2026-05-14). Lifts the canonical \`claude\` binary spawn pattern from \`@chiefaia/local-llm-router\`'s \`claude-adapter.ts\` into a stand-alone package and migrates the seven ad-hoc spawn sites to use it.

## What's in this PR

**New package** \`@chiefaia/claude-spawner\` (0.1.0)
- \`spawnClaude({ prompt, options, constraints })\` — the single canonical entrypoint.
- \`parseClaudeJsonEnvelope(stdout)\` — the canonical \`claude --print --output-format json\` envelope parser.
- \`SCRUBBED_AUTH_ENV_VARS\` — single source of truth for the env-scrub list.
- Constraints: \`rejectIfApiKeyPresent\` (opt-in API-key-set rejection), \`cwdAllowList\` (operator preference of allowed cwds).
- 25 unit tests covering argv, env scrub, success, all failure modes, constraints.
- **No \`cli.ts\`** — that's file-disjoint with A2 per the plan.

**Migrated consumers (7 sites)**
| Package | Migration |
| --- | --- |
| \`@chiefaia/verifier\` | \`defaultRunChild\` routes through \`spawnClaude\` |
| \`@chiefaia/code-reviewer\` | \`createDefaultLlmReviewer\` routes through \`spawnClaude\` |
| \`@chiefaia/critic\` | \`createDefaultLlmReasoner\` routes through \`spawnClaude\` |
| \`@chiefaia/reviewer\` | \`createDefaultLlmReviewer\` routes through \`spawnClaude\` |
| \`@chiefaia/apprentice-eval\` | \`runProcess\` (judge) shimmed onto \`spawnClaude\` |
| \`@chiefaia/apprentice-corpus\` | \`createDefaultDistiller\` + \`createDistiller\` route through \`spawnClaude\` |
| \`@chiefaia/researcher\` | \`createDefaultLlmClient\` routes through \`spawnClaude\` |

Each consumer commit is file-disjoint and reviewable on its own.

## Verification

- \`pnpm build\` clean on all 8 packages.
- \`pnpm test\` clean: **597 tests** pass across the 8 packages (claude-spawner=25, verifier=11, code-reviewer=98, critic=93, reviewer=58, apprentice-eval=89, apprentice-corpus=142, researcher=81 + 1 skipped).
- \`pnpm lint\` clean on all 8 packages.

## Subscription-only constraint

The package scrubs **ANTHROPIC_API_KEY**, **ANTHROPIC_AUTH_TOKEN**, **OPENAI_API_KEY**, **GROQ_API_KEY**, **COHERE_API_KEY**, **GEMINI_API_KEY** unconditionally per \`feedback_no_api_key_billing.md\` (Prakash 2026-04-30). Failures never fall back to API-key billing.

## Diagnostic-string back-compat

Each consumer preserved its existing diagnostic string shapes (\"claude exited <rc>\", \"claude spawn error\", \"spawn threw\", \"distiller exited\", etc.) so downstream telemetry / regex parsers don't break.

## Test-seam evolution

\`spawnFn\` test seams that previously accepted \`typeof spawnSync\` now accept claude-spawner's \`typeof spawn\` (async, ChildProcess-shaped). Each consumer's tests were updated to a small in-file \`makeFakeSpawnFn\` helper that emits an EventEmitter-shaped fake child. Three consumers (apprentice-corpus, apprentice-eval, researcher) keep their old \`spawnFn\` field as a documented no-op back-compat slot so external callers don't immediately type-error; the new seam is \`spawnImpl\`.

## ROUTER-DAEMON-RELOAD-REQUIRED

Seven downstream packages gained a new workspace edge on \`@chiefaia/claude-spawner\`. \`local-llm-router\` and any long-lived daemon that imports any of these seven packages should re-resolve / reload after merge.

## Out of scope (deliberately)

- \`@chiefaia/local-llm-router\`'s \`ClaudeAdapter\` is **not** migrated. It carries the \`ClaudeRateLimitedError\` taxonomy + account-attribution that the seven ad-hoc sites didn't need; migrating it would force every account-rotation code path to re-thread errors. Deferred to a follow-up.
- A \`cli.ts\` surface for \`@chiefaia/claude-spawner\` (the A2 work — file-disjoint per the integration plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)