### PR TITLE
feat(local-llm-router): r-2 reject caller-supplied model overrides

### DIFF
--- a/packages/local-llm-router/__tests__/server-model-bypass.test.ts
+++ b/packages/local-llm-router/__tests__/server-model-bypass.test.ts
@@ -1,0 +1,135 @@
+// R-2 — model-override bypass guard.
+//
+// /v1/chat/completions used to accept `model: "claude-opus-4-7"` (or any
+// other hard provider model name) and silently route through whatever the
+// router picked, while the caller believed they had pinned. This test
+// pins the new contract: hard model names → 400; advisory hints → pass
+// through; omitted/empty → pass through.
+
+import { describe, it, expect } from 'vitest';
+import { buildApp, ADVISORY_MODEL_HINTS } from '../src/server.js';
+
+describe('R-2: /v1/chat/completions caller-supplied model field', () => {
+  it('rejects a Claude model NAME with 400 model-pinning-not-allowed', async () => {
+    const app = buildApp();
+    const res = await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'hello' }],
+        caia_task_type: 'commit-message',
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as {
+      error: string;
+      allowed_hints: string[];
+      rejected_value: string;
+    };
+    expect(body.error).toBe('model-pinning-not-allowed');
+    expect(body.rejected_value).toBe('claude-opus-4-7');
+    expect(body.allowed_hints).toEqual(expect.arrayContaining(['prefer-fast', 'prefer-local']));
+  });
+
+  it('rejects a local model NAME (qwen2.5-coder:32b) with 400', async () => {
+    const app = buildApp();
+    const res = await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen2.5-coder:32b',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('model-pinning-not-allowed');
+  });
+
+  it('rejects gibberish model strings with 400', async () => {
+    const app = buildApp();
+    const res = await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'totally-made-up-model-name-7000',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('model-pinning-not-allowed');
+  });
+
+  it('treats empty-string model as omitted (no 400)', { timeout: 30000 }, async () => {
+    const app = buildApp();
+    const res = await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: '',
+        messages: [{ role: 'user', content: 'hi' }],
+        caia_task_type: 'commit-message',
+      }),
+    });
+    expect(res.status).not.toBe(400);
+    const body = await res.json() as { error?: string };
+    expect(body.error).not.toBe('model-pinning-not-allowed');
+  });
+
+  it('accepts every advisory hint in ADVISORY_MODEL_HINTS without 400', { timeout: 30000 }, async () => {
+    const app = buildApp();
+    for (const hint of ADVISORY_MODEL_HINTS) {
+      const res = await app.request('/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: hint,
+          messages: [{ role: 'user', content: 'hi' }],
+          caia_task_type: 'commit-message',
+        }),
+      });
+      // Either 200 (router executed against a live Ollama) or 502 (no
+      // Ollama in CI). Both prove the validation path didn't reject.
+      expect([200, 502]).toContain(res.status);
+      const body = await res.json() as { error?: string };
+      expect(body.error).not.toBe('model-pinning-not-allowed');
+    }
+  });
+
+  it('omitting model entirely is fine (pre-R-2 behavior preserved)', { timeout: 30000 }, async () => {
+    const app = buildApp();
+    const res = await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: 'hi' }],
+        caia_task_type: 'commit-message',
+      }),
+    });
+    expect([200, 502]).toContain(res.status);
+    const body = await res.json() as { error?: string };
+    expect(body.error).not.toBe('model-pinning-not-allowed');
+  });
+
+  it('echoes validated advisory_hint back in response.caia (when router succeeds)', { timeout: 30000 }, async () => {
+    // Best-effort: if Ollama isn't available the router throws and we get
+    // 502 with no `caia` block — that's CI-acceptable. When Ollama IS up,
+    // we expect `caia.advisory_hint === 'prefer-fast'`.
+    const app = buildApp();
+    const res = await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'prefer-fast',
+        messages: [{ role: 'user', content: 'hi' }],
+        caia_task_type: 'commit-message',
+      }),
+    });
+    if (res.status === 200) {
+      const body = await res.json() as { caia: { advisory_hint: string } };
+      expect(body.caia.advisory_hint).toBe('prefer-fast');
+    }
+  });
+});

--- a/packages/local-llm-router/src/server.ts
+++ b/packages/local-llm-router/src/server.ts
@@ -53,6 +53,23 @@ async function getSearchMemoryHandler(): Promise<typeof SearchMemoryHandlerFn> {
 const ROUTER_VERSION = '0.3.0';
 const DEFAULT_PORT = 7411;
 
+// R-2 (2026-05-15): caller-supplied `model` on /v1/chat/completions is
+// rejected with 400 unless it matches one of these advisory hints. The
+// router still picks the actual model — these hints are recorded in the
+// `caia` block of the response but do NOT pin a provider/model. Allow-list
+// is closed by default so the audit/wire contract can't drift.
+export const ADVISORY_MODEL_HINTS = [
+  'auto',
+  'prefer-local',
+  'prefer-fast',
+  'prefer-cheap',
+  'prefer-quality',
+] as const;
+export type AdvisoryModelHint = typeof ADVISORY_MODEL_HINTS[number];
+function isAdvisoryHint(s: string): s is AdvisoryModelHint {
+  return (ADVISORY_MODEL_HINTS as readonly string[]).includes(s);
+}
+
 export interface ServerOptions {
   ollamaBaseUrl?: string;
   classifierModel?: string;
@@ -266,6 +283,10 @@ export function buildApp(opts: ServerOptions = {}): Hono {
   });
 
   // ─── /v1/chat/completions (OpenAI-compatible single-turn) ────────────
+  // R-2 (2026-05-15): model-override bypass guard. Caller-supplied `model`
+  // is popped off the body and validated against ADVISORY_MODEL_HINTS.
+  // A hard model NAME (anything not in the allow-list) is rejected with
+  // HTTP 400. The router decides the actual dispatched model.
   app.post('/v1/chat/completions', async (c: Context) => {
     let body: {
       model?: string;
@@ -275,6 +296,28 @@ export function buildApp(opts: ServerOptions = {}): Hono {
       caia_task_type?: string;  // CAIA extension — picks routing rule
     };
     try { body = await c.req.json(); } catch { return c.json({ error: 'invalid-json' }, 400); }
+
+    // R-2 — pop and validate caller's `model` field BEFORE any other work.
+    // Empty string + undefined both fall through (treated as "omitted").
+    const callerModel = body.model;
+    delete body.model;
+    let advisoryHint: AdvisoryModelHint | null = null;
+    if (callerModel !== undefined && callerModel !== '') {
+      if (isAdvisoryHint(callerModel)) {
+        advisoryHint = callerModel;
+      } else {
+        return c.json({
+          error: 'model-pinning-not-allowed',
+          message:
+            `Caller-supplied 'model' is not allowed: '${callerModel}'. ` +
+            `The router decides which model to dispatch (see /v1/route). ` +
+            `If you want to nudge the router, pass one of the advisory hints.`,
+          allowed_hints: [...ADVISORY_MODEL_HINTS],
+          rejected_value: callerModel,
+        }, 400);
+      }
+    }
+
     const messages = body.messages ?? [];
     if (messages.length === 0) return c.json({ error: 'messages-required' }, 400);
 
@@ -328,6 +371,10 @@ export function buildApp(opts: ServerOptions = {}): Hono {
         caia: {
           provider: llmRes.provider,
           duration_ms: llmRes.durationMs,
+          // R-2 — surface the validated advisory hint (or null) so callers
+          // can confirm their hint was accepted. Routing decision itself
+          // is unchanged in this PR; hint is observability-only for now.
+          advisory_hint: advisoryHint,
           rag: ragDecision === null ? { injected: false, reason: 'middleware-error' } : {
             injected: ragDecision.injected,
             reason: ragDecision.reason,


### PR DESCRIPTION
## Summary

R-2 (sps-router-critical-fixes phase 4) — caller-supplied `model` on `/v1/chat/completions` was silently bypassed by the router decision. This made the wire contract (e.g. `{ model: "claude-opus-4-7" }`) lie to callers and audit logs: the request looked pinned, but the router could pick anything.

This PR closes the gap:

- **Pop** `body.model` before any work.
- **Validate** against `ADVISORY_MODEL_HINTS` (`auto`, `prefer-local`, `prefer-fast`, `prefer-cheap`, `prefer-quality`).
- **Reject** anything else with HTTP 400 + structured `{ error: 'model-pinning-not-allowed', allowed_hints, rejected_value, message }`.
- **Echo** the validated hint back in `response.caia.advisory_hint` for observability. The hint itself does not change routing in this PR (out of scope for the fast fix; routing-config refactor lands separately).
- New test file `__tests__/server-model-bypass.test.ts` covers Claude-name reject, local-name reject, gibberish reject, empty-string accept, every advisory hint accept, omitted accept, and the response echo.

Allow-list is closed by default — adding a new hint is a deliberate code change, which is what we want for an audit-relevant guard.

`ROUTER-DAEMON-RELOAD-REQUIRED` — after merge:

```
launchctl kickstart -k gui/$(id -u)/com.chiefaia.local-llm-router
```

The daemon caches the compiled handler at boot, so a kickstart is required for the new validator to take effect on the live router on this Mac.

## Test plan

- [x] new test `__tests__/server-model-bypass.test.ts` — 7 cases, all green
- [x] full `pnpm test` for `@chiefaia/local-llm-router` stays green (258 tests pass)
- [x] `pnpm build` (tsc) clean
- [ ] post-merge: kickstart daemon, then `curl -sX POST http://127.0.0.1:7411/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"claude-opus-4-7","messages":[{"role":"user","content":"x"}],"caia_task_type":"commit-message"}' | jq .` → expect HTTP 400 with `error: model-pinning-not-allowed`
- [ ] post-merge: same curl with `"model":"prefer-fast"` → expect 200 (or 502 if Ollama is down) with `caia.advisory_hint === "prefer-fast"`
- [ ] post-merge: `~/Documents/projects/caia/scripts/gate-mark-done.sh 4 sps-router-critical-fixes` and chain phase-mark-done

## Phase report

`/Users/macbook32/Documents/projects/reports/r2_model_override_bypass_2026-05-15.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)