### PR TITLE
feat(local-llm-router): GB-12 stolution-batch tier — qwen2.5-coder pulls + tier wiring

### DIFF
--- a/packages/local-llm-router/__tests__/classifier-v2.test.ts
+++ b/packages/local-llm-router/__tests__/classifier-v2.test.ts
@@ -35,6 +35,7 @@ const TEST_RULES: RoutingRules = {
     { name: 'embedding-generate', default_tier: 'stolution-batch', min_confidence: 0.5, keywords: ['vectorize'] },
     { name: 'unknown', default_tier: 'claude', min_confidence: 0.0, keywords: [] },
   ],
+  tier_models: {},
 };
 
 describe('classifier-v2', () => {

--- a/packages/local-llm-router/__tests__/router-policy.test.ts
+++ b/packages/local-llm-router/__tests__/router-policy.test.ts
@@ -1,0 +1,167 @@
+// GB-12 (2026-05-15) — tier-model resolver tests.
+//
+// Verifies:
+//   1. `tier_models` is parsed from the on-disk routing-rules.yaml.
+//   2. `resolveTierModel` returns the per-intent override when present.
+//   3. Returns the tier default when an intent is unmapped.
+//   4. Returns null/null when the tier has no `tier_models` entry.
+//   5. The stolution-batch tier is non-empty for `batch-summarize` (the
+//      directive's acceptance criterion).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  __resetRulesCache,
+  loadRoutingRules,
+  parseRoutingRulesYaml,
+  type RoutingRules,
+} from '../src/classifier-v2.js';
+import { resolveTierModel } from '../src/router-policy.js';
+
+describe('router-policy: resolveTierModel (GB-12)', () => {
+  describe('against the shipped routing-rules.yaml', () => {
+    it('stolution-batch tier is non-empty for batch-summarize intent', () => {
+      // Reset the YAML cache so we read the freshly-edited file from disk.
+      __resetRulesCache();
+      const rules = loadRoutingRules();
+      const res = resolveTierModel(rules, 'stolution-batch', 'batch-summarize');
+      // Directive: qwen2.5-coder:14b for batch-summarize / corpus-distill.
+      expect(res.model).toBe('qwen2.5-coder:14b');
+      expect(res.intent_override).toBe(true);
+      // 5-min CPU latency budget per the directive.
+      expect(res.timeout_ms).toBe(300_000);
+    });
+
+    it('stolution-batch tier maps corpus-distill to qwen2.5-coder:14b', () => {
+      __resetRulesCache();
+      const rules = loadRoutingRules();
+      const res = resolveTierModel(rules, 'stolution-batch', 'corpus-distill');
+      expect(res.model).toBe('qwen2.5-coder:14b');
+      expect(res.intent_override).toBe(true);
+    });
+
+    it('stolution-batch tier maps long-context-reason to qwen2.5-coder:32b', () => {
+      __resetRulesCache();
+      const rules = loadRoutingRules();
+      const res = resolveTierModel(rules, 'stolution-batch', 'long-context-reason');
+      expect(res.model).toBe('qwen2.5-coder:32b');
+      expect(res.intent_override).toBe(true);
+    });
+
+    it('stolution-batch tier maps complex-review to llama3.3:70b', () => {
+      __resetRulesCache();
+      const rules = loadRoutingRules();
+      const res = resolveTierModel(rules, 'stolution-batch', 'complex-review');
+      expect(res.model).toBe('llama3.3:70b');
+      expect(res.intent_override).toBe(true);
+    });
+
+    it('stolution-batch falls back to the tier default for unmapped intents', () => {
+      __resetRulesCache();
+      const rules = loadRoutingRules();
+      // `summarize` is a local-7b intent — it has no stolution-batch override,
+      // but the resolver still returns the tier default (llama3.3:70b) so a
+      // forced-route-to-stolution-batch path has a valid model to dispatch to.
+      const res = resolveTierModel(rules, 'stolution-batch', 'summarize');
+      expect(res.model).toBe('llama3.3:70b');
+      expect(res.intent_override).toBe(false);
+      expect(res.timeout_ms).toBe(300_000);
+    });
+
+    it('returns null/null for tiers with no tier_models entry', () => {
+      __resetRulesCache();
+      const rules = loadRoutingRules();
+      // `local-7b` has no `tier_models` entry — the routing-config.ts task-type
+      // path picks the model. Verify resolveTierModel returns nulls (and the
+      // caller is expected to fall through to ROUTING_RULES).
+      const res = resolveTierModel(rules, 'local-7b', 'summarize');
+      expect(res.model).toBeNull();
+      expect(res.timeout_ms).toBeNull();
+      expect(res.intent_override).toBe(false);
+    });
+  });
+
+  describe('against an in-memory rules document', () => {
+    const RULES: RoutingRules = {
+      version: 2,
+      default_confidence_threshold: 0.6,
+      escalation_threshold: 0.5,
+      cascade_thresholds: { 'stolution-batch': 0.5, claude: 0.0 },
+      tier_order: ['stolution-batch', 'claude'],
+      intents: [],
+      tier_models: {
+        'stolution-batch': {
+          timeout_ms: 300_000,
+          default_model: 'llama3.3:70b',
+          per_intent: {
+            'batch-summarize': 'qwen2.5-coder:14b',
+          },
+        },
+      },
+    };
+
+    it('passes intent=null to skip the per-intent lookup', () => {
+      const res = resolveTierModel(RULES, 'stolution-batch', null);
+      expect(res.model).toBe('llama3.3:70b');
+      expect(res.intent_override).toBe(false);
+    });
+
+    it('parser tolerates an empty tier_models block', () => {
+      const yaml = `
+version: 2
+default_confidence_threshold: 0.6
+escalation_threshold: 0.5
+cascade_thresholds:
+  claude: 0.0
+tier_order:
+  - claude
+tier_models:
+intents:
+  - name: unknown
+    default_tier: claude
+    min_confidence: 0.0
+    keywords: []
+`;
+      const parsed = parseRoutingRulesYaml(yaml);
+      expect(parsed.tier_models).toEqual({});
+    });
+
+    it('parser captures the per_intent map from YAML', () => {
+      const yaml = `
+version: 2
+default_confidence_threshold: 0.6
+escalation_threshold: 0.5
+cascade_thresholds:
+  stolution-batch: 0.5
+  claude: 0.0
+tier_order:
+  - stolution-batch
+  - claude
+tier_models:
+  stolution-batch:
+    timeout_ms: 300000
+    default_model: llama3.3:70b
+    per_intent:
+      batch-summarize: qwen2.5-coder:14b
+      corpus-distill: qwen2.5-coder:14b
+intents:
+  - name: batch-summarize
+    default_tier: stolution-batch
+    min_confidence: 0.5
+    keywords:
+      - batch summarize
+  - name: unknown
+    default_tier: claude
+    min_confidence: 0.0
+    keywords: []
+`;
+      const parsed = parseRoutingRulesYaml(yaml);
+      const sb = parsed.tier_models['stolution-batch'];
+      expect(sb).toBeDefined();
+      expect(sb?.timeout_ms).toBe(300_000);
+      expect(sb?.default_model).toBe('llama3.3:70b');
+      expect(sb?.per_intent['batch-summarize']).toBe('qwen2.5-coder:14b');
+      expect(sb?.per_intent['corpus-distill']).toBe('qwen2.5-coder:14b');
+    });
+  });
+});

--- a/packages/local-llm-router/config/routing-rules.yaml
+++ b/packages/local-llm-router/config/routing-rules.yaml
@@ -39,6 +39,31 @@ tier_order:
   - stolution-batch
   - claude
 
+# GB-12 (2026-05-15): per-tier model + timeout mapping.
+# Previously the tier→model relationship lived in code comments only; the runtime
+# had no way to pick which ollama tag to dispatch to per intent. This block
+# externalises it so the router daemon can resolve {tier, intent} → {model, timeout_ms}
+# without a code change for tag rotations.
+#
+# `timeout_ms` is the per-request CPU latency budget — set deliberately high for
+# stolution-batch (5 min) because the host is CPU-bound and would otherwise time
+# out on legitimately long completions; it also protects against accidental
+# interactive routing falling onto this tier (no caller waiting 5 min in a UI).
+#
+# `default_model` is used when no `per_intent` override applies.
+# `per_intent` maps an intent name → ollama tag served by that tier.
+tier_models:
+  stolution-batch:
+    timeout_ms: 300000
+    default_model: llama3.3:70b
+    per_intent:
+      batch-summarize: qwen2.5-coder:14b
+      corpus-distill: qwen2.5-coder:14b
+      long-context-reason: qwen2.5-coder:32b
+      research-synthesis: llama3.3:70b
+      complex-review: llama3.3:70b
+      embedding-generate: nomic-embed-text
+
 # Intent taxonomy. The `keywords` field powers the lightweight rule-based prepass
 # in classifier-v2 — if a task spec contains ≥1 keyword for exactly one intent, we
 # skip the LLM call entirely and emit that intent at confidence 0.92.
@@ -47,7 +72,7 @@ tier_order:
 #   local-7b        → qwen2.5:7b-instruct (general) / qwen2.5-coder:7b (code)
 #   local-14b       → qwen2.5-coder:14b
 #   local-32b       → qwen2.5-coder:32b / qwen2.5:32b-instruct
-#   stolution-batch → llama3.3:70b (long-context, CPU-OK batch tier on stolution)
+#   stolution-batch → see `tier_models` block above for per-intent mapping (GB-12)
 #   claude          → cloud escalation
 intents:
   - name: classify
@@ -492,6 +517,22 @@ intents:
       - embedding
       - vectorize
       - generate embeddings
+
+  # GB-12 (2026-05-15): distinct from `code-review` (local-14b first-pass) and
+  # `architecture-review` (local-32b design critique). `complex-review` is a
+  # batched deep multi-file review that benefits from llama3.3:70b's long
+  # context on the stolution-batch tier — caller is willing to wait minutes.
+  - name: complex-review
+    default_tier: stolution-batch
+    min_confidence: 0.5
+    keywords:
+      - full repo review
+      - whole-codebase review
+      - deep multi-file review
+      - thorough code review
+      - exhaustive review
+      - cross-module review
+      - batched review of
 
   - name: unknown
     default_tier: claude

--- a/packages/local-llm-router/src/classifier-v2.ts
+++ b/packages/local-llm-router/src/classifier-v2.ts
@@ -35,6 +35,19 @@ export interface IntentRule {
   keywords: string[];
 }
 
+/**
+ * GB-12 (2026-05-15) — per-tier model + timeout config. Lets the runtime resolve
+ * `{tier, intent} → {model, timeout_ms}` without a code change for tag rotations.
+ */
+export interface TierModelConfig {
+  /** Per-request CPU latency budget in ms. */
+  timeout_ms: number;
+  /** Fallback model when no per_intent override applies. */
+  default_model: string;
+  /** Intent name → ollama tag served by this tier. */
+  per_intent: Record<string, string>;
+}
+
 export interface RoutingRules {
   version: number;
   default_confidence_threshold: number;
@@ -42,6 +55,8 @@ export interface RoutingRules {
   cascade_thresholds: Record<string, number>;
   tier_order: RecommendedTier[];
   intents: IntentRule[];
+  /** GB-12 (2026-05-15) — optional per-tier model+timeout block. */
+  tier_models: Record<string, TierModelConfig>;
 }
 
 export interface IntentResultV2 {
@@ -276,7 +291,38 @@ export function parseRoutingRulesYaml(text: string): RoutingRules {
     }
   }
 
-  return { version, default_confidence_threshold, escalation_threshold, cascade_thresholds, tier_order, intents };
+  // GB-12 (2026-05-15) — optional `tier_models` block. Shape:
+  //   tier_models:
+  //     <tier-name>:
+  //       timeout_ms: <int>
+  //       default_model: <string>
+  //       per_intent:
+  //         <intent>: <model-tag>
+  // Unknown tiers are accepted (forward-compat); invalid scalar types are dropped.
+  const tier_models: Record<string, TierModelConfig> = {};
+  const tmRaw = root['tier_models'];
+  if (typeof tmRaw === 'object' && tmRaw !== null && !Array.isArray(tmRaw)) {
+    for (const [tier, cfgRaw] of Object.entries(tmRaw)) {
+      if (typeof cfgRaw !== 'object' || cfgRaw === null || Array.isArray(cfgRaw)) continue;
+      const cfg = cfgRaw as Record<string, YamlNode>;
+      const timeout_ms = typeof cfg['timeout_ms'] === 'number' ? cfg['timeout_ms'] as number : 0;
+      const default_model = typeof cfg['default_model'] === 'string' ? cfg['default_model'] as string : '';
+      const per_intent: Record<string, string> = {};
+      const piRaw = cfg['per_intent'];
+      if (typeof piRaw === 'object' && piRaw !== null && !Array.isArray(piRaw)) {
+        for (const [intent, model] of Object.entries(piRaw)) {
+          if (typeof model === 'string' && model.length > 0) per_intent[intent] = model;
+        }
+      }
+      // Require at least timeout_ms or default_model to register the tier;
+      // an empty block is treated as absent.
+      if (timeout_ms > 0 || default_model !== '' || Object.keys(per_intent).length > 0) {
+        tier_models[tier] = { timeout_ms, default_model, per_intent };
+      }
+    }
+  }
+
+  return { version, default_confidence_threshold, escalation_threshold, cascade_thresholds, tier_order, intents, tier_models };
 }
 
 function numberAt(obj: Record<string, YamlNode>, key: string, fallback: number): number {

--- a/packages/local-llm-router/src/classifier.ts
+++ b/packages/local-llm-router/src/classifier.ts
@@ -49,6 +49,8 @@ export type Intent =
   | 'corpus-distill'
   | 'long-context-reason'
   | 'embedding-generate'
+  // GB-12 (2026-05-15) — deep multi-file review at stolution-batch tier.
+  | 'complex-review'
   | 'unknown';
 
 export type RecommendedTier = 'local-7b' | 'local-14b' | 'local-32b' | 'claude' | 'stolution-batch';
@@ -71,7 +73,10 @@ export const INTENT_VALUES: ReadonlyArray<Intent> = [
   'architecture-review', 'research-summary',
   'reason-over-context', 'new-design', 'architect', 'research-synthesis',
   'batch-summarize', 'corpus-distill', 'long-context-reason',
-  'embedding-generate', 'unknown',
+  'embedding-generate',
+  // GB-12 (2026-05-15).
+  'complex-review',
+  'unknown',
 ];
 
 export const TIER_VALUES: ReadonlyArray<RecommendedTier> = [
@@ -96,7 +101,7 @@ Tier guidance:
 - local-14b: medium-code, doc-write, spec-check, review-prose
 - local-32b: hard-code requiring deep reasoning over multiple files
 - claude: reason-over-context, new-design, architect, or anything where confidence < 0.6 on a non-code task
-- stolution-batch: batch-summarize, corpus-distill, embedding-generate (CPU-OK batch work)
+- stolution-batch: batch-summarize, corpus-distill, embedding-generate, complex-review, long-context-reason (CPU-OK batch work)
 
 If the task is ambiguous, pick "unknown" with confidence < 0.5 and needs_escalation: true.
 

--- a/packages/local-llm-router/src/router-policy.ts
+++ b/packages/local-llm-router/src/router-policy.ts
@@ -1,0 +1,79 @@
+// Router policy resolvers (GB-12, 2026-05-15).
+//
+// Lifts the {tier, intent} → {model, timeout_ms} lookup out of the HTTP server
+// so that:
+//   1. The race between this phase (GB-12) and sps-router-critical-fixes R-2
+//      is bounded to ONE import line in server.ts. Heavy logic lives here.
+//   2. The mapping is driven purely from `config/routing-rules.yaml`'s
+//      `tier_models` block — no code edit is needed when an ollama tag rotates.
+//   3. Tests can import the resolver directly without standing up a Hono app.
+//
+// The resolver is intentionally tolerant of partial config:
+//   - tier absent from `tier_models` → returns null model + null timeout
+//   - intent absent from `per_intent` → falls back to `default_model`
+//   - all blank → null/null
+//
+// Callers MUST handle a null model (a `tier_models` block was never loaded /
+// was malformed / the recommended tier is one with no configured backend).
+
+import type {
+  IntentResultV2,
+  RoutingRules,
+  TierModelConfig,
+} from './classifier-v2.js';
+import type { Intent, IntentResult, RecommendedTier } from './classifier.js';
+
+export interface TierResolution {
+  /** Ollama tag selected for this tier+intent, or null if the tier has no model config. */
+  model: string | null;
+  /** Per-request CPU latency budget in ms, or null if the tier has no timeout config. */
+  timeout_ms: number | null;
+  /** True when the model came from a `per_intent` override (vs the tier default). */
+  intent_override: boolean;
+}
+
+const EMPTY: TierResolution = {
+  model: null,
+  timeout_ms: null,
+  intent_override: false,
+};
+
+/**
+ * Resolve `{tier, intent}` → `{model, timeout_ms}` against the loaded
+ * `tier_models` block in routing-rules.yaml.
+ *
+ * Pass `intent = null` to skip the per-intent lookup entirely (caller wants
+ * the tier default, e.g. for a /healthz-style probe).
+ */
+export function resolveTierModel(
+  rules: RoutingRules,
+  tier: RecommendedTier,
+  intent: Intent | null,
+): TierResolution {
+  const cfg: TierModelConfig | undefined = rules.tier_models[tier];
+  if (cfg === undefined) return EMPTY;
+
+  let model: string | null = null;
+  let intent_override = false;
+  if (intent !== null) {
+    const override = cfg.per_intent[intent];
+    if (override !== undefined && override.length > 0) {
+      model = override;
+      intent_override = true;
+    }
+  }
+  if (model === null && cfg.default_model.length > 0) {
+    model = cfg.default_model;
+  }
+
+  const timeout_ms = cfg.timeout_ms > 0 ? cfg.timeout_ms : null;
+  return { model, timeout_ms, intent_override };
+}
+
+/** Convenience: resolve directly from a classifier result. */
+export function resolveFromIntent(
+  rules: RoutingRules,
+  result: IntentResult | IntentResultV2,
+): TierResolution {
+  return resolveTierModel(rules, result.recommended_tier, result.intent);
+}

--- a/packages/local-llm-router/src/server.ts
+++ b/packages/local-llm-router/src/server.ts
@@ -23,7 +23,10 @@ import { optimize } from '@chiefaia/prompt-optimizer';
 import { route as routerRoute } from './router.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { classify, type IntentResult as _IntentResultRef } from './classifier.js';
-import { classifyV2 } from './classifier-v2.js';
+import { classifyV2, loadRoutingRules } from './classifier-v2.js';
+// GB-12 (2026-05-15) — tier-model resolver, lives in router-policy.ts so the
+// merge surface with sps-router-critical-fixes R-2 is the single import line.
+import { resolveTierModel } from './router-policy.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { OllamaAdapter as _OllamaAdapterRef2 } from './ollama-adapter.js';
 import { llmMetrics } from './llm-metrics.js';
@@ -247,11 +250,18 @@ export function buildApp(opts: ServerOptions = {}): Hono {
     if (rule === undefined) {
       // No rule → ask the classifier
       const intent = await classify(prompt, { model: classifierModel, ollamaBaseUrl });
+      // GB-12 (2026-05-15) — resolve the tier's ollama tag + CPU timeout from
+      // routing-rules.yaml's tier_models block. Returns nulls for unconfigured
+      // tiers (forward-compat with tiers that have no batch-host backend).
+      const tier = resolveTierModel(loadRoutingRules(), intent.recommended_tier, intent.intent);
       return c.json({
         task_type: taskType, has_routing_rule: false,
         recommended_tier: intent.recommended_tier,
         intent: intent.intent, confidence: intent.confidence,
         reasoning: intent.reasoning,
+        tier_model: tier.model,
+        tier_timeout_ms: tier.timeout_ms,
+        tier_intent_override: tier.intent_override,
       });
     }
     return c.json({


### PR DESCRIPTION
GB-12 (S3 gap item) — wire stolution-batch tier with qwen2.5-coder:14b/:32b. 9 new vitest cases. ROUTER-DAEMON-RELOAD-REQUIRED. From sps-prompting-batch-and-budget chain.