### PR TITLE
fix(librarian,mentor-retrieval): add require condition to exports

### DIFF
--- a/packages/librarian/package.json
+++ b/packages/librarian/package.json
@@ -15,24 +15,30 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./cli": {
       "import": "./dist/cli.js",
+      "require": "./dist/cli.js",
       "types": "./dist/cli.d.ts"
     },
     "./retrieve": {
       "import": "./dist/retrieve.js",
+      "require": "./dist/retrieve.js",
       "types": "./dist/retrieve.d.ts"
     },
     "./prepend": {
       "import": "./dist/prepend.js",
+      "require": "./dist/prepend.js",
       "types": "./dist/prepend.d.ts"
     },
     "./backends": {
       "import": "./dist/backends/index.js",
+      "require": "./dist/backends/index.js",
       "types": "./dist/backends/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist"

--- a/packages/mentor-retrieval/package.json
+++ b/packages/mentor-retrieval/package.json
@@ -18,32 +18,40 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./cli": {
       "import": "./dist/cli.js",
+      "require": "./dist/cli.js",
       "types": "./dist/cli.d.ts"
     },
     "./retrieve": {
       "import": "./dist/retrieve.js",
+      "require": "./dist/retrieve.js",
       "types": "./dist/retrieve.d.ts"
     },
     "./prepend": {
       "import": "./dist/prepend.js",
+      "require": "./dist/prepend.js",
       "types": "./dist/prepend.d.ts"
     },
     "./cluster": {
       "import": "./dist/cluster.js",
+      "require": "./dist/cluster.js",
       "types": "./dist/cluster.d.ts"
     },
     "./steward-rule-proposer": {
       "import": "./dist/steward-rule-proposer.js",
+      "require": "./dist/steward-rule-proposer.js",
       "types": "./dist/steward-rule-proposer.d.ts"
     },
     "./self-review": {
       "import": "./dist/self-review.js",
+      "require": "./dist/self-review.js",
       "types": "./dist/self-review.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- Add the `require` condition to every subpath export in `@chiefaia/librarian` and `@chiefaia/mentor-retrieval` package.json
- Both packages are `"type": "module"` with compiled-ESM dist output; without `require` in their `exports`, CJS consumers (`@chiefaia/local-llm-router` compiles to commonjs) hit `ERR_PACKAGE_PATH_NOT_EXPORTED` at runtime
- Also expose `./package.json` so tooling can read it

## Root cause

Earlier today the router daemon failed to boot:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
  .../node_modules/@chiefaia/librarian/package.json
```

A live workaround stubbed `dist/search-memory.js` in the router so the
daemon could boot for A.9.1.1 verification, but the stub is build
output — any rebuild overwrites it. This PR fixes the bug at source so
no stub is required.

`require(esm)` is supported in Node 22.12+ (the LaunchAgent uses
`/opt/homebrew/opt/node@22/bin/node`, currently v22.22.2).

## Verification

- `pnpm run build` of `local-llm-router` succeeds (no TS2307)
- `dist/search-memory.js` after build is the real compiled handler, not the stub
- `launchctl kickstart` of `com.chiefaia.local-llm-router` → healthz `ok:true` within 1s
- `POST /v1/search-memory` returns real handler response (warnings about uninitialised SQLite index, but no `search-memory-disabled-stub` error)
- `require('@chiefaia/librarian')` and `require('@chiefaia/mentor-retrieval')` from CJS both succeed (tested on Node 22.22.2)

## ROUTER-DAEMON-RELOAD-REQUIRED

After merge, the router daemon must be kickstarted to pick up the
fixed `node_modules/@chiefaia/{librarian,mentor-retrieval}/package.json`
links. (The currently running daemon was already kickstarted as part
of phase-5 verification.)

## Test plan

- [x] librarian builds cleanly
- [x] mentor-retrieval builds cleanly
- [x] local-llm-router builds cleanly without stub
- [x] daemon kickstart → healthz ok
- [x] /v1/search-memory non-stub response

🤖 Generated with [Claude Code](https://claude.com/claude-code)