### PR TITLE
feat(chain-scaffolder): LLM-assisted scaffolder from loose backlog items

### DIFF
--- a/packages/chain-scaffolder/README.md
+++ b/packages/chain-scaffolder/README.md
@@ -1,0 +1,109 @@
+# @chiefaia/chain-scaffolder
+
+Chain scaffolder for [@chiefaia/chain-runner] — converts backlog items into
+chain definitions (`state.json` + `phases.yaml` + runner script) ready for
+the autonomous chain runner.
+
+Two modes:
+
+| Mode          | Input                                                     | Cost | Status               |
+| ------------- | --------------------------------------------------------- | ---- | -------------------- |
+| **LLM**       | Loose markdown line: `id :: title :: description`         | $$   | ✅ this package      |
+| **Templated** | Structured YAML backlog item with explicit fields         | free | 🚧 sibling phase     |
+
+The LLM path is for loose items where the operator has only a one-line idea;
+the scaffolder gathers codebase context (file reads + grep + optional
+[local-llm-router] semantic search) and asks an LLM to produce a fully-formed
+`phases.yaml` that round-trips through `@chiefaia/chain-runner`'s loader.
+
+## CLI
+
+```sh
+caia-scaffold from-llm "my-item :: Short title :: What this does and why" \
+  [--context-files caia/packages/foo/src/bar.ts ...] \
+  [--provider auto|claude|local|fixture] \
+  [--machine m3|m1|stolution] \
+  [--few-shot-example PATH] \
+  [--out-dir DIR] \
+  [--router-url http://127.0.0.1:7411] \
+  [--no-write] [--json]
+
+caia-scaffold validate <phases.yaml>     # schema check, read-only
+```
+
+### Backlog-line shape
+
+```
+<kebab-id> :: <title> :: <description> [machine=m1] [file=src/a.ts,src/b.ts]
+```
+
+Annotations after the third `::` are optional and forgiving:
+
+- `machine=m3|m1|stolution` — routing hint
+- `file=...,...`           — comma-separated file_paths
+- `deps=chain-a,chain-b`   — chain ids that must finish first
+
+### Provider resolution
+
+`--provider auto` (default) prefers `local` when `local-llm-router` is reachable
+at `--router-url`, otherwise falls back to the `claude` CLI on PATH. Override
+with `--provider claude` or `--provider local`.
+
+The `fixture` provider is for tests/CI and requires `--fixture-file <path>`.
+
+## Programmatic
+
+```ts
+import { scaffoldFromLlm, specToYaml } from '@chiefaia/chain-scaffolder';
+
+const result = await scaffoldFromLlm({
+  id: 'my-item',
+  title: 'Short title',
+  description: 'Long description',
+  machine: 'm3',
+});
+const yamlText = specToYaml(result.spec);
+// → write to ~/Documents/projects/agent-memory/<id>_phases.yaml
+```
+
+`scaffoldFromLlm` flow:
+
+1. Resolve provider (auto/claude/local).
+2. Load few-shot example (`sps_router_critical_fixes_phases.yaml` by default).
+3. Gather context: read explicit + item-hinted files (truncated), grep the
+   repo for keywords derived from id/title, optionally hit the local router
+   for semantic results.
+4. Build the system + user prompt; call the provider.
+5. Parse + validate the response (`parseScaffolderSpec`). On `SchemaError`,
+   retry **once** with the errors fed back into the user message.
+6. Finalise defaults (`chain_config.machine`, `alert_channels`, etc.) and
+   return `{ chain_id, spec, raw, attempts }`.
+
+## Schema
+
+The validator (`src/schema.ts`) enforces:
+
+- `phases: [...]` non-empty, sequential ids `1..N`, max 20.
+- Each phase has `name`, `prompt_template` (≥40 chars), `success_criteria.output_file`.
+- `deps` reference strictly-earlier phase ids.
+- Optional `defaults`, `chain_config`, `max_minutes`, `min_bytes`,
+  `grep_match`, `requires_merged_pr`, `enforce: warn|strict`.
+
+Output round-trips through `loadChainSpec` in `@chiefaia/chain-runner` — the
+integration test (`__tests__/integration.test.ts`) writes the scaffolded YAML
+and runs `caia-chain init` + `next-phase` to prove it dispatches.
+
+## Tests
+
+```sh
+pnpm -C packages/chain-scaffolder test
+```
+
+`__tests__/integration.test.ts` picks the first `⏳ pending [INDEPENDENT]` item
+from `~/Documents/projects/backlog/MASTER_BACKLOG.md` (falling back to a
+synthetic item when the backlog is absent), runs it through the full
+scaffolder pipeline with a fixture provider, and exercises `caia-chain init`
++ `next-phase --read-only` against the result.
+
+[@chiefaia/chain-runner]: ../chain-runner
+[local-llm-router]: ../local-llm-router

--- a/packages/chain-scaffolder/__tests__/context.test.ts
+++ b/packages/chain-scaffolder/__tests__/context.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { gatherContext, deriveKeywords } from '../src/context.js';
+
+describe('deriveKeywords', () => {
+  it('splits id and title; preserves uniqueness', () => {
+    const kws = deriveKeywords({
+      id: 'rr1-adversarial-prefilter',
+      title: 'RR-1 adversarial prefilter and ban-list',
+      description: 'mitigation',
+    });
+    expect(kws).toContain('rr1');
+    expect(kws).toContain('adversarial');
+    expect(kws).toContain('prefilter');
+    // dedupe (case-insensitive)
+    expect(new Set(kws.map((s) => s.toLowerCase())).size).toBe(kws.length);
+  });
+
+  it('drops <3-char tokens', () => {
+    const kws = deriveKeywords({ id: 'a-bc-def', title: 'a bc def', description: 'x' });
+    expect(kws.every((k) => k.length >= 3)).toBe(true);
+  });
+});
+
+describe('gatherContext', () => {
+  it('reads context files, calls grepImpl, returns summary', async () => {
+    const grepImpl = vi.fn(async (pat: string) => [`fake:${pat}:1: matched`]);
+    const readFileImpl = vi.fn(async (p: string) => `content-of:${p}`);
+    const semanticSearchImpl = vi.fn(async () => [{ path: 'x.ts', score: 0.9, snippet: 's' }]);
+    const out = await gatherContext(
+      {
+        id: 'demo',
+        title: 'Demo thing',
+        description: 'x',
+        file_paths: ['/tmp/this-file-does-not-exist-12345'],
+      },
+      {
+        cwd: '/tmp',
+        contextFiles: [],
+        grepImpl,
+        readFileImpl,
+        semanticSearchImpl,
+        routerBaseUrl: 'http://fake',
+      },
+    );
+    expect(grepImpl).toHaveBeenCalled();
+    expect(out.semantic_hits).toHaveLength(1);
+    expect(out.summary).toMatch(/Gathered/);
+  });
+
+  it('continues when semantic search throws', async () => {
+    const grepImpl = vi.fn(async () => []);
+    const semanticSearchImpl = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const out = await gatherContext(
+      { id: 'demo', title: 'Demo thing', description: 'x' },
+      { cwd: '/tmp', grepImpl, semanticSearchImpl, routerBaseUrl: 'http://fake' },
+    );
+    expect(out.semantic_hits).toHaveLength(0);
+    expect(out.summary).toMatch(/semantic-search.*failed/);
+  });
+
+  it('disables semantic search when routerBaseUrl=null', async () => {
+    const grepImpl = vi.fn(async () => []);
+    const out = await gatherContext(
+      { id: 'demo', title: 'Demo thing', description: 'x' },
+      { cwd: '/tmp', grepImpl, routerBaseUrl: null },
+    );
+    expect(out.summary).toMatch(/disabled/);
+  });
+});

--- a/packages/chain-scaffolder/__tests__/integration.test.ts
+++ b/packages/chain-scaffolder/__tests__/integration.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, writeFileSync, mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { scaffoldFromLlm } from '../src/llm.js';
+import { specToYaml, parseScaffolderSpec } from '../src/schema.js';
+import { makeFixtureProvider } from '../src/providers.js';
+import type { LooseBacklogItem } from '../src/types.js';
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const CHAIN_RUNNER_CLI = resolve(REPO_ROOT, 'packages/chain-runner/bin/caia-chain.js');
+const MASTER_BACKLOG = resolve(process.env.HOME ?? '~', 'Documents/projects/backlog/MASTER_BACKLOG.md');
+const FIXTURE_DIR = resolve(__dirname, '../tests/fixtures');
+
+/**
+ * Pull a real loose backlog item out of MASTER_BACKLOG.md. We grab the first
+ * "⏳ pending [INDEPENDENT]" line — those are the canonical "loose items"
+ * the LLM scaffolder is supposed to handle.
+ */
+function pickLooseBacklogItem(): LooseBacklogItem {
+  if (!existsSync(MASTER_BACKLOG)) {
+    // CI / fresh checkouts may not have the backlog — fall back to a synthetic
+    // loose item that exercises the same scaffolder code path.
+    return {
+      id: 'synthetic-cache-warmer',
+      title: 'Synthetic cache warmer for embeddings',
+      description: 'Warm the embedding cache at boot so cold-start latency drops below 200 ms.',
+    };
+  }
+  const text = readFileSync(MASTER_BACKLOG, 'utf8');
+  // Match: - **<TITLE>** · ... ⏳ pending [INDEPENDENT]
+  const m = text.match(/-\s+\*\*([^*]+?)\*\*[^\n]*⏳\s+pending\s+\[INDEPENDENT\]/);
+  if (!m) {
+    return {
+      id: 'synthetic-cache-warmer',
+      title: 'Synthetic cache warmer for embeddings',
+      description: 'Warm the embedding cache at boot so cold-start latency drops below 200 ms.',
+    };
+  }
+  const rawTitle = m[1].trim();
+  // Strip leading code refs like "A.5.3 " for the id
+  const id =
+    'backlog-' +
+    rawTitle
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 50);
+  return {
+    id,
+    title: rawTitle.slice(0, 100),
+    description: `Backlog-driven scaffold of "${rawTitle}". Loose item taken verbatim from ~/Documents/projects/backlog/MASTER_BACKLOG.md.`,
+  };
+}
+
+describe('integration: scaffold-from-llm → chain-runner', () => {
+  it('scaffolds a real loose backlog item, validates the chain shape, and survives caia-chain init', async () => {
+    const item = pickLooseBacklogItem();
+
+    // Provider: the bundled fixture response, which is shape-valid but mentions
+    // a different item. The shape check is what matters here — we are
+    // exercising the scaffolder + validator + emitter end-to-end, not the
+    // semantic quality of the LLM (covered separately when wired up live).
+    const provider = makeFixtureProvider(readFileSync(resolve(FIXTURE_DIR, 'loose_item_response.yaml'), 'utf8'));
+
+    const result = await scaffoldFromLlm(item, {
+      providerInstance: provider,
+      routerBaseUrl: null,
+      grepImpl: async () => [],
+      fewShotExamplePath: resolve(FIXTURE_DIR, 'example_chain.yaml'),
+      today: '2026-05-16',
+    });
+
+    expect(result.spec.phases.length).toBeGreaterThanOrEqual(1);
+
+    // Emit YAML and round-trip-parse to confirm the emitter produces valid output.
+    const yamlText = specToYaml(result.spec);
+    const reparsed = parseScaffolderSpec(yamlText);
+    expect(reparsed.phases).toEqual(result.spec.phases);
+
+    // Write to a tmpdir and have the real chain-runner load it.
+    const sandbox = mkdtempSync(join(tmpdir(), 'caia-scaffold-it-'));
+    const phasesFile = join(sandbox, `${item.id}_phases.yaml`);
+    writeFileSync(phasesFile, yamlText, 'utf8');
+
+    const env = { ...process.env, CAIA_CHAIN_HOME: join(sandbox, 'chain') };
+    // The chain-runner CLI exits 0 when init succeeds and 1 otherwise.
+    execFileSync(
+      process.execPath,
+      [CHAIN_RUNNER_CLI, 'init', '--chain-id', item.id, '--phases', phasesFile],
+      { env, stdio: 'pipe' },
+    );
+    const stateFile = join(sandbox, 'chain', item.id, 'state.json');
+    expect(existsSync(stateFile)).toBe(true);
+    const state = JSON.parse(readFileSync(stateFile, 'utf8'));
+    expect(state.schema_version).toBeGreaterThanOrEqual(1);
+    expect(state.phase_status).toBeTruthy();
+    expect(state.phase_status['1']).toBeTruthy();
+    expect(state.phase_status['1'].status).toBe('pending');
+
+    // Confirm next-phase resolves cleanly to phase 1 (read-only, no mutation).
+    const out = execFileSync(
+      process.execPath,
+      [
+        CHAIN_RUNNER_CLI,
+        'next-phase',
+        '--chain-id',
+        item.id,
+        '--phases',
+        phasesFile,
+        '--read-only',
+      ],
+      { env, stdio: ['pipe', 'pipe', 'pipe'] },
+    ).toString();
+    expect(out.trim()).toMatch(/^1\s*$/);
+  });
+});

--- a/packages/chain-scaffolder/__tests__/llm.test.ts
+++ b/packages/chain-scaffolder/__tests__/llm.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { scaffoldFromLlm } from '../src/llm.js';
+import { makeFixtureProvider } from '../src/providers.js';
+import { SchemaError } from '../src/schema.js';
+import type { LlmProvider } from '../src/types.js';
+
+const FIXTURE_DIR = resolve(__dirname, '../tests/fixtures');
+
+function fixtureProviderFromFile(path: string): LlmProvider {
+  return makeFixtureProvider(readFileSync(resolve(FIXTURE_DIR, path), 'utf8'));
+}
+
+describe('scaffoldFromLlm', () => {
+  it('parses a fenced YAML response and finalises chain_config', async () => {
+    const result = await scaffoldFromLlm(
+      {
+        id: 'loose-demo',
+        title: 'Loose demo item',
+        description: 'Add an LRU cache for widget lookups in the demo package.',
+      },
+      {
+        providerInstance: fixtureProviderFromFile('loose_item_response.yaml'),
+        routerBaseUrl: null,
+        cwd: '/tmp',
+        grepImpl: async () => [],
+        fewShotExamplePath: resolve(FIXTURE_DIR, 'example_chain.yaml'),
+      },
+    );
+
+    expect(result.chain_id).toBe('loose-demo');
+    expect(result.spec.phases).toHaveLength(1);
+    expect(result.spec.phases[0].name).toBe('implement_widget_cache');
+    expect(result.spec.chain_config?.machine).toBe('m3'); // finalised default
+    expect(result.attempts).toEqual([{ n: 1, ok: true }]);
+  });
+
+  it('retries once with corrections when the first response is malformed', async () => {
+    const responses = JSON.parse(readFileSync(resolve(FIXTURE_DIR, 'malformed_then_correct.json'), 'utf8')) as {
+      first: string;
+      second: string;
+    };
+    let call = 0;
+    const provider: LlmProvider = {
+      name: 'fixture',
+      async complete() {
+        call++;
+        return { raw: call === 1 ? responses.first : responses.second, provider: 'fixture' };
+      },
+    };
+    const result = await scaffoldFromLlm(
+      { id: 'retry-demo', title: 'Retry demo', description: 'Validate the retry path.' },
+      {
+        providerInstance: provider,
+        routerBaseUrl: null,
+        cwd: '/tmp',
+        grepImpl: async () => [],
+        fewShotExamplePath: resolve(FIXTURE_DIR, 'example_chain.yaml'),
+      },
+    );
+    expect(call).toBe(2);
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0].ok).toBe(false);
+    expect(result.attempts[1].ok).toBe(true);
+    expect(result.spec.phases[0].name).toBe('fixed_phase');
+  });
+
+  it('throws SchemaError when both attempts fail validation', async () => {
+    const bad = '```yaml\nphases: []\n```';
+    const provider: LlmProvider = {
+      name: 'fixture',
+      complete: vi.fn(async () => ({ raw: bad, provider: 'fixture' as const })),
+    };
+    await expect(
+      scaffoldFromLlm(
+        { id: 'twice-bad', title: 'Twice bad', description: 'Both attempts will fail.' },
+        {
+          providerInstance: provider,
+          routerBaseUrl: null,
+          cwd: '/tmp',
+          grepImpl: async () => [],
+          fewShotExamplePath: resolve(FIXTURE_DIR, 'example_chain.yaml'),
+        },
+      ),
+    ).rejects.toBeInstanceOf(SchemaError);
+    expect(provider.complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects malformed LooseBacklogItem upfront', async () => {
+    const provider = makeFixtureProvider('');
+    await expect(
+      scaffoldFromLlm(
+        { id: 'BadId!', title: 'x', description: 'y' },
+        { providerInstance: provider, routerBaseUrl: null, cwd: '/tmp', grepImpl: async () => [] },
+      ),
+    ).rejects.toThrowError(/kebab-case|match/);
+  });
+});

--- a/packages/chain-scaffolder/__tests__/parse-backlog-line.test.ts
+++ b/packages/chain-scaffolder/__tests__/parse-backlog-line.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { parseBacklogLine } from '../src/parse-backlog-line.js';
+
+describe('parseBacklogLine', () => {
+  it('parses the simple three-segment shape', () => {
+    const item = parseBacklogLine('my-item :: Add foo :: Need foo for bar reasons');
+    expect(item.id).toBe('my-item');
+    expect(item.title).toBe('Add foo');
+    expect(item.description).toBe('Need foo for bar reasons');
+    expect(item.machine).toBeUndefined();
+  });
+
+  it('extracts machine= annotation', () => {
+    const item = parseBacklogLine('my-item :: t :: desc with machine=m1 hint');
+    expect(item.machine).toBe('m1');
+  });
+
+  it('extracts file= annotation as comma-separated paths', () => {
+    const item = parseBacklogLine('my-item :: t :: desc file=src/a.ts,src/b.ts');
+    expect(item.file_paths).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('throws on too few segments', () => {
+    expect(() => parseBacklogLine('only :: two')).toThrowError(/three segments|got 2/);
+  });
+
+  it('ignores unknown annotations', () => {
+    const item = parseBacklogLine('id :: title :: desc fnord=42');
+    expect(item.description).toContain('fnord=42');
+  });
+});

--- a/packages/chain-scaffolder/__tests__/schema.test.ts
+++ b/packages/chain-scaffolder/__tests__/schema.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseScaffolderSpec, validateScaffolderSpec, extractYamlBlock, specToYaml, SchemaError } from '../src/schema.js';
+
+const FIXTURE_DIR = resolve(__dirname, '../tests/fixtures');
+
+describe('schema.extractYamlBlock', () => {
+  it('strips ```yaml fences', () => {
+    const text = 'Here is the result:\n```yaml\nphases:\n  - id: 1\n```\nDone.';
+    expect(extractYamlBlock(text)).toBe('phases:\n  - id: 1');
+  });
+
+  it('returns input unchanged when no fence', () => {
+    const text = 'phases:\n  - id: 1\n';
+    expect(extractYamlBlock(text)).toBe(text);
+  });
+});
+
+describe('schema.validateScaffolderSpec', () => {
+  it('accepts a well-formed minimal spec', () => {
+    const ok = validateScaffolderSpec({
+      phases: [
+        {
+          id: 1,
+          name: 'p1',
+          prompt_template: 'Phase 1 — concrete enough prompt template to exceed forty characters.',
+          success_criteria: { output_file: '~/Documents/projects/reports/x.md' },
+        },
+      ],
+    });
+    expect(ok.phases).toHaveLength(1);
+    expect(ok.phases[0].name).toBe('p1');
+  });
+
+  it('rejects missing prompt_template', () => {
+    expect(() =>
+      validateScaffolderSpec({
+        phases: [
+          {
+            id: 1,
+            name: 'p1',
+            success_criteria: { output_file: '~/x.md' },
+          },
+        ],
+      }),
+    ).toThrowError(SchemaError);
+  });
+
+  it('rejects non-sequential phase ids', () => {
+    let caught: SchemaError | null = null;
+    try {
+      validateScaffolderSpec({
+        phases: [
+          {
+            id: 1,
+            name: 'p1',
+            prompt_template: 'x'.repeat(50),
+            success_criteria: { output_file: '~/x.md' },
+          },
+          {
+            id: 3,
+            name: 'p3',
+            prompt_template: 'x'.repeat(50),
+            success_criteria: { output_file: '~/x.md' },
+          },
+        ],
+      });
+    } catch (e) {
+      caught = e as SchemaError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.errors.join('|')).toMatch(/sequential/);
+  });
+
+  it('rejects deps referencing later phases', () => {
+    let caught: SchemaError | null = null;
+    try {
+      validateScaffolderSpec({
+        phases: [
+          {
+            id: 1,
+            name: 'p1',
+            deps: [2],
+            prompt_template: 'x'.repeat(50),
+            success_criteria: { output_file: '~/x.md' },
+          },
+          {
+            id: 2,
+            name: 'p2',
+            prompt_template: 'x'.repeat(50),
+            success_criteria: { output_file: '~/x.md' },
+          },
+        ],
+      });
+    } catch (e) {
+      caught = e as SchemaError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.errors.join('|')).toMatch(/strictly-earlier/);
+  });
+
+  it('round-trips: specToYaml → parseScaffolderSpec', () => {
+    const original = validateScaffolderSpec({
+      defaults: { max_retries: 2 },
+      chain_config: { alert_channels: ['handoff'], max_concurrent: 1, machine: 'm3' },
+      phases: [
+        {
+          id: 1,
+          name: 'p1',
+          description: 'A description.',
+          deps: [],
+          max_minutes: 90,
+          prompt_template:
+            'Phase 1 — long enough prompt template to satisfy the schema validator minimum of forty characters.',
+          success_criteria: { output_file: '~/r/p1.md', min_bytes: 800, requires_merged_pr: true },
+        },
+      ],
+    });
+    const yamlText = specToYaml(original);
+    const reparsed = parseScaffolderSpec(yamlText);
+    expect(reparsed.phases).toHaveLength(1);
+    expect(reparsed.phases[0].success_criteria.min_bytes).toBe(800);
+    expect(reparsed.chain_config?.machine).toBe('m3');
+  });
+});
+
+describe('schema fixture', () => {
+  it('accepts the bundled few-shot example', () => {
+    const text = readFileSync(resolve(FIXTURE_DIR, 'example_chain.yaml'), 'utf8');
+    const spec = parseScaffolderSpec(text);
+    expect(spec.phases.length).toBeGreaterThanOrEqual(1);
+    expect(spec.chain_config?.machine).toBe('m3');
+  });
+
+  it('round-trips the fenced loose_item_response fixture', () => {
+    const text = readFileSync(resolve(FIXTURE_DIR, 'loose_item_response.yaml'), 'utf8');
+    const spec = parseScaffolderSpec(text);
+    expect(spec.phases).toHaveLength(1);
+    expect(spec.phases[0].name).toBe('implement_widget_cache');
+  });
+});

--- a/packages/chain-scaffolder/bin/caia-scaffold.js
+++ b/packages/chain-scaffolder/bin/caia-scaffold.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/cli.js';

--- a/packages/chain-scaffolder/eslint.config.cjs
+++ b/packages/chain-scaffolder/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/chain-scaffolder/package.json
+++ b/packages/chain-scaffolder/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@chiefaia/chain-scaffolder",
+  "version": "0.1.0",
+  "description": "Chain scaffolder for @chiefaia/chain-runner — converts backlog items (structured YAML or loose markdown lines) into chain definitions (state.json + phases.yaml + runner script). LLM-assisted path uses claude or local-llm-router with schema-validated retry.",
+  "type": "module",
+  "bin": {
+    "caia-scaffold": "./bin/caia-scaffold.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./llm": {
+      "import": "./dist/llm.js",
+      "types": "./dist/llm.d.ts"
+    },
+    "./schema": {
+      "import": "./dist/schema.js",
+      "types": "./dist/schema.d.ts"
+    },
+    "./context": {
+      "import": "./dist/context.js",
+      "types": "./dist/context.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "bin"
+  ],
+  "scripts": {
+    "build": "tsc && node -e \"import('node:fs').then(fs=>fs.chmodSync('bin/caia-scaffold.js','755'))\"",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@chiefaia/chain-runner": "workspace:*",
+    "commander": "^12.0.0",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/chain-scaffolder/src/cli.ts
+++ b/packages/chain-scaffolder/src/cli.ts
@@ -1,0 +1,148 @@
+import { Command } from 'commander';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { scaffoldFromLlm } from './llm.js';
+import { specToYaml } from './schema.js';
+import { parseBacklogLine } from './parse-backlog-line.js';
+import type { Machine } from './types.js';
+
+const DEFAULT_AGENT_MEMORY_DIR = resolve(homedir(), 'Documents/projects/agent-memory');
+const DEFAULT_CHAIN_BASE_DIR = resolve(homedir(), '.caia/chain');
+
+interface FromLlmCliOptions {
+  contextFiles?: string[];
+  provider?: 'auto' | 'claude' | 'local' | 'fixture';
+  machine?: Machine;
+  fewShotExample?: string;
+  outDir?: string;
+  routerUrl?: string;
+  claudeBin?: string;
+  /** Commander maps `--no-write` to `opts.write = false`. */
+  write?: boolean;
+  json?: boolean;
+  fixtureFile?: string;
+}
+
+export function buildCli(): Command {
+  const program = new Command();
+  program
+    .name('caia-scaffold')
+    .description('Scaffold caia-chain definitions from backlog items')
+    .version('0.1.0');
+
+  program
+    .command('from-llm')
+    .description('Generate a chain definition from a loose backlog line via an LLM')
+    .argument(
+      '<backlog-line...>',
+      'Backlog line: "<id> :: <title> :: <description>". Joined with spaces if passed as multiple args.',
+    )
+    .option('-c, --context-files <files...>', 'Extra file(s) to include verbatim as context')
+    .option('-p, --provider <p>', 'Provider: auto | claude | local | fixture', 'auto')
+    .option('-m, --machine <m>', 'Machine routing hint: m3 | m1 | stolution')
+    .option('--few-shot-example <path>', 'Path to few-shot example YAML (defaults to sps_router_critical_fixes_phases.yaml)')
+    .option('--out-dir <dir>', `Directory to write phases.yaml (default: ${DEFAULT_AGENT_MEMORY_DIR})`)
+    .option('--router-url <url>', 'local-llm-router base URL', 'http://127.0.0.1:7411')
+    .option('--claude-bin <bin>', 'claude CLI binary', 'claude')
+    .option('--no-write', 'Print the YAML to stdout instead of writing to disk')
+    .option('--json', 'Emit a JSON envelope with metadata (chain_id, path, attempts, raw)')
+    .option('--fixture-file <path>', '(testing) read provider response from this file instead of calling the LLM')
+    .action(async (backlogLineParts: string[], opts: FromLlmCliOptions) => {
+      const backlogLine = backlogLineParts.join(' ');
+      const item = parseBacklogLine(backlogLine);
+      if (opts.machine) item.machine = opts.machine;
+
+      let fixtureResponse: string | undefined;
+      if (opts.provider === 'fixture' || opts.fixtureFile) {
+        if (!opts.fixtureFile) {
+          throw new Error('--provider fixture requires --fixture-file <path>');
+        }
+        const fs = await import('node:fs/promises');
+        fixtureResponse = await fs.readFile(opts.fixtureFile, 'utf8');
+      }
+
+      const scaffoldOpts: Parameters<typeof scaffoldFromLlm>[1] = {
+        provider: opts.provider === 'fixture' ? 'fixture' : (opts.provider ?? 'auto'),
+      };
+      if (fixtureResponse !== undefined) scaffoldOpts.fixtureResponse = fixtureResponse;
+      if (opts.contextFiles !== undefined) scaffoldOpts.contextFiles = opts.contextFiles;
+      if (opts.routerUrl !== undefined) scaffoldOpts.routerBaseUrl = opts.routerUrl;
+      if (opts.claudeBin !== undefined) scaffoldOpts.claudeBin = opts.claudeBin;
+      if (opts.fewShotExample !== undefined) scaffoldOpts.fewShotExamplePath = opts.fewShotExample;
+      const result = await scaffoldFromLlm(item, scaffoldOpts);
+
+      const yaml = specToYaml(result.spec);
+      const outDir = opts.outDir ?? DEFAULT_AGENT_MEMORY_DIR;
+      const outFile = resolve(outDir, `${item.id.replace(/-/g, '_')}_phases.yaml`);
+
+      const shouldWrite = opts.write !== false;
+      if (shouldWrite) {
+        if (!existsSync(dirname(outFile))) mkdirSync(dirname(outFile), { recursive: true });
+        writeFileSync(outFile, yaml, 'utf8');
+      }
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify(
+            {
+              chain_id: result.chain_id,
+              phases_yaml_path: shouldWrite ? outFile : null,
+              attempts: result.attempts,
+              provider: result.raw.provider,
+              usage: result.raw.usage ?? null,
+              phase_count: result.spec.phases.length,
+            },
+            null,
+            2,
+          ) + '\n',
+        );
+      } else if (!shouldWrite) {
+        process.stdout.write(yaml);
+      } else {
+        process.stdout.write(`✔ scaffolded ${result.chain_id} → ${outFile}\n`);
+        process.stdout.write(`  phases: ${result.spec.phases.length}  provider: ${result.raw.provider}  attempts: ${result.attempts.length}\n`);
+      }
+    });
+
+  program
+    .command('validate')
+    .description('Parse a phases YAML and report schema errors (read-only)')
+    .argument('<path>', 'phases YAML file')
+    .action(async (path: string) => {
+      const fs = await import('node:fs/promises');
+      const yamlText = await fs.readFile(resolve(path), 'utf8');
+      const { parseScaffolderSpec } = await import('./schema.js');
+      try {
+        const spec = parseScaffolderSpec(yamlText);
+        process.stdout.write(`✔ ${path} is valid — ${spec.phases.length} phase(s)\n`);
+      } catch (e) {
+        process.stderr.write(`✘ ${path} is invalid:\n${(e as Error).message}\n`);
+        process.exit(1);
+      }
+    });
+
+  return program;
+}
+
+export async function main(argv: string[]): Promise<void> {
+  const program = buildCli();
+  await program.parseAsync(argv);
+}
+
+const isDirect =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  (process.argv[1].endsWith('/caia-scaffold.js') || process.argv[1].endsWith('/cli.js'));
+if (isDirect) {
+  main(process.argv).catch((e) => {
+    process.stderr.write(`caia-scaffold: ${(e as Error).message}\n`);
+    process.exit(1);
+  });
+}
+
+// keep referenced for d.ts emit
+export const DEFAULTS = {
+  DEFAULT_AGENT_MEMORY_DIR,
+  DEFAULT_CHAIN_BASE_DIR,
+};

--- a/packages/chain-scaffolder/src/context.ts
+++ b/packages/chain-scaffolder/src/context.ts
@@ -1,0 +1,240 @@
+import { readFile, stat } from 'node:fs/promises';
+import { resolve, isAbsolute } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { LooseBacklogItem } from './types.js';
+
+const pExecFile = promisify(execFile);
+
+export interface GatheredContext {
+  /** Inline file snippets for the LLM (truncated to keep prompt size small). */
+  files: Array<{ path: string; snippet: string; truncated: boolean }>;
+  /** Lines from grep against the backlog item's title/id keywords. */
+  grep_hits: Array<{ pattern: string; lines: string[] }>;
+  /** Optional semantic-search results from local-llm-router (:7411). */
+  semantic_hits: Array<{ path: string; score?: number; snippet?: string }>;
+  /** Soft summary of what was tried — written into the LLM prompt as breadcrumbs. */
+  summary: string;
+}
+
+export interface GatherOptions {
+  /** Repo root for grep + readFile resolution. Defaults to CWD. */
+  cwd?: string;
+  /** Explicit files to include verbatim (caller-provided via --context-files). */
+  contextFiles?: string[];
+  /** Max bytes per file snippet (truncate beyond). */
+  maxFileBytes?: number;
+  /** Total cap on context payload (rough char budget). */
+  maxTotalBytes?: number;
+  /** Base URL for local-llm-router semantic-search. Null disables. */
+  routerBaseUrl?: string | null;
+  /** Override the default grep impl (for tests). */
+  grepImpl?: (pattern: string, cwd: string) => Promise<string[]>;
+  /** Override the default file reader (for tests). */
+  readFileImpl?: (path: string) => Promise<string>;
+  /** Override the default semantic-search impl (for tests). */
+  semanticSearchImpl?: (
+    query: string,
+    routerBaseUrl: string,
+  ) => Promise<Array<{ path: string; score?: number; snippet?: string }>>;
+}
+
+const DEFAULT_MAX_FILE_BYTES = 4000;
+const DEFAULT_MAX_TOTAL_BYTES = 16_000;
+const DEFAULT_ROUTER_BASE_URL = 'http://127.0.0.1:7411';
+
+/**
+ * Gather codebase context for a backlog item:
+ *   1. read explicit context files (--context-files), truncated.
+ *   2. read file_paths from the item (if any), truncated.
+ *   3. grep the repo for keywords derived from id/title.
+ *   4. optionally hit local-llm-router :7411 for semantic results.
+ *
+ * Each step is best-effort: failures are caught and recorded into `summary`
+ * rather than thrown, because the LLM scaffolder can still produce a useful
+ * chain from partial context.
+ */
+export async function gatherContext(
+  item: LooseBacklogItem,
+  opts: GatherOptions = {},
+): Promise<GatheredContext> {
+  const cwd = opts.cwd ?? process.cwd();
+  const maxFileBytes = opts.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const maxTotalBytes = opts.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES;
+  const routerBaseUrl = opts.routerBaseUrl === null
+    ? null
+    : (opts.routerBaseUrl ?? DEFAULT_ROUTER_BASE_URL);
+  const readImpl = opts.readFileImpl ?? ((p: string) => readFile(p, 'utf8'));
+  const grepImpl = opts.grepImpl ?? defaultGrep;
+  const semanticImpl = opts.semanticSearchImpl ?? defaultSemanticSearch;
+
+  const breadcrumbs: string[] = [];
+  let bytesUsed = 0;
+  const files: GatheredContext['files'] = [];
+  const grep_hits: GatheredContext['grep_hits'] = [];
+  const semantic_hits: GatheredContext['semantic_hits'] = [];
+
+  const addFile = async (rawPath: string, source: string) => {
+    if (bytesUsed >= maxTotalBytes) return;
+    const path = isAbsolute(rawPath) ? rawPath : resolve(cwd, rawPath);
+    try {
+      const s = await stat(path);
+      if (!s.isFile()) {
+        breadcrumbs.push(`skip ${source} ${rawPath}: not a regular file`);
+        return;
+      }
+    } catch (e) {
+      breadcrumbs.push(`skip ${source} ${rawPath}: ${(e as Error).message}`);
+      return;
+    }
+    try {
+      const content = await readImpl(path);
+      const cap = Math.min(maxFileBytes, Math.max(0, maxTotalBytes - bytesUsed));
+      const truncated = content.length > cap;
+      const snippet = truncated ? content.slice(0, cap) : content;
+      files.push({ path: rawPath, snippet, truncated });
+      bytesUsed += snippet.length;
+    } catch (e) {
+      breadcrumbs.push(`read failed ${rawPath}: ${(e as Error).message}`);
+    }
+  };
+
+  for (const cf of opts.contextFiles ?? []) {
+    await addFile(cf, 'context-file');
+  }
+  for (const fp of item.file_paths ?? []) {
+    await addFile(fp, 'item-file_paths');
+  }
+
+  // ── grep step ──────────────────────────────────────────────────────
+  const keywords = deriveKeywords(item);
+  for (const kw of keywords) {
+    if (bytesUsed >= maxTotalBytes) break;
+    try {
+      const lines = await grepImpl(kw, cwd);
+      const trimmed = lines.slice(0, 12);
+      if (trimmed.length > 0) {
+        grep_hits.push({ pattern: kw, lines: trimmed });
+        bytesUsed += trimmed.join('\n').length;
+      }
+    } catch (e) {
+      breadcrumbs.push(`grep '${kw}' failed: ${(e as Error).message}`);
+    }
+  }
+
+  // ── semantic search step ────────────────────────────────────────────
+  if (routerBaseUrl && bytesUsed < maxTotalBytes) {
+    try {
+      const query = `${item.title}. ${item.description}`.slice(0, 600);
+      const hits = await semanticImpl(query, routerBaseUrl);
+      const trimmed = hits.slice(0, 5);
+      semantic_hits.push(...trimmed);
+      bytesUsed += JSON.stringify(trimmed).length;
+      breadcrumbs.push(`semantic-search: ${trimmed.length} hit(s) from ${routerBaseUrl}`);
+    } catch (e) {
+      breadcrumbs.push(`semantic-search at ${routerBaseUrl} failed (continuing without): ${(e as Error).message}`);
+    }
+  } else if (!routerBaseUrl) {
+    breadcrumbs.push('semantic-search: disabled (routerBaseUrl=null)');
+  }
+
+  const summary =
+    `Gathered ${files.length} file snippet(s), ${grep_hits.length} grep hit-set(s), ` +
+    `${semantic_hits.length} semantic hit(s). Budget used ~${bytesUsed}/${maxTotalBytes} bytes. ` +
+    (breadcrumbs.length > 0 ? `Notes: ${breadcrumbs.join(' | ')}` : '');
+
+  return { files, grep_hits, semantic_hits, summary };
+}
+
+/** Derive grep keywords from a backlog item: id segments + capitalised title words. */
+export function deriveKeywords(item: LooseBacklogItem): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (s: string) => {
+    const t = s.trim();
+    if (t.length < 3) return;
+    if (seen.has(t.toLowerCase())) return;
+    seen.add(t.toLowerCase());
+    out.push(t);
+  };
+  // id segments split on - and _
+  for (const seg of item.id.split(/[-_]/)) push(seg);
+  // title words 4+ chars
+  for (const w of item.title.split(/[\s,./()[\]]+/)) {
+    if (w.length >= 4) push(w);
+  }
+  // explicit file_paths basenames
+  for (const fp of item.file_paths ?? []) {
+    const base = fp.split('/').pop() ?? '';
+    push(base.replace(/\.\w+$/, ''));
+  }
+  return out.slice(0, 6);
+}
+
+async function defaultGrep(pattern: string, cwd: string): Promise<string[]> {
+  // Use git grep when inside a repo (fast + respects .gitignore); fall back to
+  // plain grep otherwise. Both are tolerant of zero matches (rc=1).
+  try {
+    const { stdout } = await pExecFile('git', ['grep', '-n', '-I', '--max-count', '4', pattern], {
+      cwd,
+      maxBuffer: 1_000_000,
+    });
+    return stdout.split('\n').filter((l) => l.length > 0).slice(0, 20);
+  } catch (e: unknown) {
+    const err = e as { code?: number; stdout?: string };
+    // rc=1 = no matches, normal — return empty
+    if (err.code === 1) return [];
+    // Outside a repo? Fall through to bare grep.
+    try {
+      const { stdout } = await pExecFile('grep', ['-rn', '--max-count=4', '--include=*.ts', '--include=*.md', pattern, '.'], {
+        cwd,
+        maxBuffer: 1_000_000,
+      });
+      return stdout.split('\n').filter((l) => l.length > 0).slice(0, 20);
+    } catch (e2: unknown) {
+      const err2 = e2 as { code?: number };
+      if (err2.code === 1) return [];
+      throw e2;
+    }
+  }
+}
+
+async function defaultSemanticSearch(
+  query: string,
+  routerBaseUrl: string,
+): Promise<Array<{ path: string; score?: number; snippet?: string }>> {
+  const url = `${routerBaseUrl.replace(/\/$/, '')}/v1/search-memory`;
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 3000);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, top_k: 5 }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      // The endpoint is broken in some local-llm-router builds (see CAIA memory:
+      // librarian exports gap). Treat any non-2xx as "no hits" silently so the
+      // scaffolder remains usable even when the router has a partial outage.
+      return [];
+    }
+    const data = (await res.json()) as { hits?: unknown[]; results?: unknown[] };
+    const rawHits = Array.isArray(data.hits) ? data.hits : Array.isArray(data.results) ? data.results : [];
+    const out: Array<{ path: string; score?: number; snippet?: string }> = [];
+    for (const h of rawHits) {
+      if (!h || typeof h !== 'object') continue;
+      const obj = h as Record<string, unknown>;
+      const path = (obj.path ?? obj.file ?? obj.source) as string | undefined;
+      if (!path) continue;
+      const hit: { path: string; score?: number; snippet?: string } = { path };
+      if (typeof obj.score === 'number') hit.score = obj.score;
+      if (typeof obj.snippet === 'string') hit.snippet = obj.snippet;
+      else if (typeof obj.text === 'string') hit.snippet = obj.text;
+      out.push(hit);
+    }
+    return out;
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/packages/chain-scaffolder/src/index.ts
+++ b/packages/chain-scaffolder/src/index.ts
@@ -1,0 +1,28 @@
+export { scaffoldFromLlm } from './llm.js';
+export type { ScaffoldFromLlmOptions } from './llm.js';
+export {
+  parseScaffolderSpec,
+  validateScaffolderSpec,
+  extractYamlBlock,
+  specToYaml,
+  SchemaError,
+} from './schema.js';
+export { gatherContext, deriveKeywords } from './context.js';
+export type { GatheredContext, GatherOptions } from './context.js';
+export {
+  resolveProvider,
+  makeClaudeProvider,
+  makeLocalProvider,
+  makeFixtureProvider,
+} from './providers.js';
+export type { ProviderResolveOpts } from './providers.js';
+export type {
+  LooseBacklogItem,
+  Machine,
+  ScaffolderChainSpec,
+  ScaffolderPhase,
+  ScaffolderSuccessCriteria,
+  LlmScaffoldResult,
+  LlmProvider,
+  RawLlmScaffold,
+} from './types.js';

--- a/packages/chain-scaffolder/src/llm.ts
+++ b/packages/chain-scaffolder/src/llm.ts
@@ -1,0 +1,338 @@
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseScaffolderSpec, SchemaError } from './schema.js';
+import { gatherContext, type GatherOptions } from './context.js';
+import { resolveProvider, type ProviderResolveOpts } from './providers.js';
+import type {
+  LooseBacklogItem,
+  LlmProvider,
+  LlmScaffoldResult,
+  ScaffolderChainSpec,
+} from './types.js';
+
+/**
+ * Options for `scaffoldFromLlm`. Mirrors fields from {@link ProviderResolveOpts}
+ * and {@link GatherOptions}; we hand-merge rather than `extends` because both
+ * parents declare `routerBaseUrl` with slightly different nullability (provider
+ * options forbid null; context options allow null to disable). Hand-merging
+ * keeps strict-mode happy.
+ */
+export interface ScaffoldFromLlmOptions {
+  // ── provider resolution ────────────────────────────────────────────
+  provider?: ProviderResolveOpts['provider'];
+  claudeBin?: ProviderResolveOpts['claudeBin'];
+  claudeModel?: ProviderResolveOpts['claudeModel'];
+  localTaskType?: ProviderResolveOpts['localTaskType'];
+  fixtureResponse?: ProviderResolveOpts['fixtureResponse'];
+  /** Pre-loaded provider (skips resolveProvider). For tests. */
+  providerInstance?: LlmProvider;
+  // ── context gathering ───────────────────────────────────────────────
+  cwd?: GatherOptions['cwd'];
+  contextFiles?: GatherOptions['contextFiles'];
+  maxFileBytes?: GatherOptions['maxFileBytes'];
+  maxTotalBytes?: GatherOptions['maxTotalBytes'];
+  /** Override router base URL. Pass null to disable semantic search; pass
+   *  undefined (or omit) for the default :7411 probe. */
+  routerBaseUrl?: string | null;
+  grepImpl?: GatherOptions['grepImpl'];
+  readFileImpl?: GatherOptions['readFileImpl'];
+  semanticSearchImpl?: GatherOptions['semanticSearchImpl'];
+  // ── scaffolder ──────────────────────────────────────────────────────
+  /** Path to the few-shot example YAML the LLM should mimic.
+   *  Defaults to the bundled sps_router_critical_fixes_phases.yaml. */
+  fewShotExamplePath?: string;
+  /** Override report directory token used in success_criteria.output_file. */
+  reportsDir?: string;
+  /** Today date string injected into the prompt + report path. */
+  today?: string;
+}
+
+const FALLBACK_EXAMPLE = `defaults:
+  max_retries: 2
+  heartbeat_interval_sec: 60
+
+chain_config:
+  alert_channels: [handoff, inbox, audit]
+  max_concurrent: 1
+  acceptance_enforce_default: warn
+
+phases:
+  - id: 1
+    name: example_phase
+    description: "One-line description of what this phase does and why."
+    deps: []
+    max_minutes: 120
+    success_criteria:
+      output_file: "~/Documents/projects/reports/example_2026-05-16.md"
+      min_bytes: 800
+      grep_match: "implemented|landed"
+      requires_merged_pr: true
+    prompt_template: |
+      Phase 1 — Concrete instructions for the worker.
+
+      ## Background
+      Why this work matters; what the failure mode looks like today.
+
+      ## Implementation
+      1. File-level steps; cite paths under caia/packages/...
+      2. Wire-in points + the exact symbol names.
+      3. Unit tests covering the regression.
+
+      ## PR
+      Branch \`feat/<id>-2026-05-16\`. Open via caia-pr-create-safe, drive to MERGED.
+
+      ## Report
+      \`~/Documents/projects/reports/<id>_2026-05-16.md\`.
+      gate-mark-done.sh + caia-chain mark-done 1.
+`;
+
+const SYSTEM_PROMPT = `You are the CAIA chain-scaffolder. Your job is to turn a loose backlog item (title + 1–2 line description + some gathered codebase context) into a fully-formed phases YAML for the caia-chain runner. The output drives an autonomous worker, so it must be precise, file-cite-able, and self-contained.
+
+OUTPUT CONTRACT — must be a single YAML document, NOTHING ELSE. No prose before, no commentary after. Optionally wrap in a single \`\`\`yaml fence.
+
+The YAML must have this shape:
+
+defaults:                  # optional
+  max_retries: <int>
+  heartbeat_interval_sec: 60
+chain_config:              # optional but recommended
+  alert_channels: [handoff, inbox, audit]
+  max_concurrent: 1
+  acceptance_enforce_default: warn
+  machine: m3              # m3 | m1 | stolution — pick from item.machine, else m3
+phases:
+  - id: 1                  # ids are 1..N sequential
+    name: snake_case_name
+    description: "What this phase does."
+    deps: []               # ids of earlier phases that must finish first
+    max_minutes: 120
+    success_criteria:
+      output_file: "~/Documents/projects/reports/<chain-id>_p1_<YYYY-MM-DD>.md"
+      min_bytes: 800
+      grep_match: "<word>|<other>"
+      requires_merged_pr: true
+    prompt_template: |
+      Phase 1 — Concrete title.
+
+      ## Background … why this work, what's broken now.
+      ## Implementation … file-level steps with caia/packages/... paths.
+      ## PR … branch name, caia-pr-create-safe, drive to MERGED.
+      ## Report … the success_criteria.output_file path, gate-mark-done.sh + caia-chain mark-done <id>.
+
+RULES
+- phase_count: choose 1–3 phases. Use 1 if the work is a single landable PR, 2 if there's a natural sequence (impl → integrate), 3 only if there are real handoff seams (impl → cost-controls → integrate). Never invent ceremony.
+- Every phase MUST have prompt_template AND success_criteria.output_file.
+- success_criteria.output_file under ~/Documents/projects/reports/, date-stamped.
+- requires_merged_pr defaults to true when the phase touches code.
+- deps reference earlier ids only; first phase has deps: [] (or omitted).
+- max_minutes: 60–180 typical. Default 120.
+- The prompt_template is the entire prompt the autonomous worker will read — include enough context (file paths, current bug, what good looks like) that the worker doesn't need to re-discover the problem.
+- Reference specific file paths from the gathered context whenever you can.
+- Do not include OS-specific commands the operator must run. The worker is autonomous.
+
+Below is a representative example of well-formed output. Copy its STYLE, not its content.
+`;
+
+/**
+ * Scaffold a chain from a loose backlog item via an LLM.
+ *
+ * Flow:
+ *   1. Resolve the provider (auto/claude/local).
+ *   2. Load the few-shot example.
+ *   3. Gather codebase context (files, grep, semantic).
+ *   4. Build the system+user prompt; call the provider.
+ *   5. Parse + validate the response. On schema error, retry ONCE with the
+ *      errors fed back into the user message.
+ *   6. Return the validated spec.
+ */
+export async function scaffoldFromLlm(
+  item: LooseBacklogItem,
+  opts: ScaffoldFromLlmOptions = {},
+): Promise<LlmScaffoldResult> {
+  validateLooseItem(item);
+
+  const providerOpts: ProviderResolveOpts = {};
+  if (opts.provider !== undefined) providerOpts.provider = opts.provider;
+  if (opts.claudeBin !== undefined) providerOpts.claudeBin = opts.claudeBin;
+  if (opts.claudeModel !== undefined) providerOpts.claudeModel = opts.claudeModel;
+  if (opts.localTaskType !== undefined) providerOpts.localTaskType = opts.localTaskType;
+  if (opts.fixtureResponse !== undefined) providerOpts.fixtureResponse = opts.fixtureResponse;
+  if (opts.routerBaseUrl !== undefined && opts.routerBaseUrl !== null) {
+    providerOpts.routerBaseUrl = opts.routerBaseUrl;
+  }
+  const provider = opts.providerInstance ?? (await resolveProvider(providerOpts));
+
+  const gatherOpts: GatherOptions = {};
+  if (opts.cwd !== undefined) gatherOpts.cwd = opts.cwd;
+  if (opts.contextFiles !== undefined) gatherOpts.contextFiles = opts.contextFiles;
+  if (opts.maxFileBytes !== undefined) gatherOpts.maxFileBytes = opts.maxFileBytes;
+  if (opts.maxTotalBytes !== undefined) gatherOpts.maxTotalBytes = opts.maxTotalBytes;
+  if (opts.routerBaseUrl !== undefined) gatherOpts.routerBaseUrl = opts.routerBaseUrl;
+  if (opts.grepImpl !== undefined) gatherOpts.grepImpl = opts.grepImpl;
+  if (opts.readFileImpl !== undefined) gatherOpts.readFileImpl = opts.readFileImpl;
+  if (opts.semanticSearchImpl !== undefined) gatherOpts.semanticSearchImpl = opts.semanticSearchImpl;
+
+  const fewShot = await loadFewShot(opts.fewShotExamplePath);
+  const ctx = await gatherContext(item, gatherOpts);
+  const today = opts.today ?? new Date().toISOString().slice(0, 10);
+
+  const userMessage = buildUserMessage(item, ctx, today);
+  const system = `${SYSTEM_PROMPT}\n\nEXAMPLE (style reference only):\n\n${fewShot}\n`;
+
+  const attempts: LlmScaffoldResult['attempts'] = [];
+
+  // Attempt 1
+  const r1 = await provider.complete(system, userMessage, { maxTokens: 4000, temperature: 0.1 });
+  try {
+    const spec = parseScaffolderSpec(r1.raw);
+    finaliseSpec(spec, item);
+    attempts.push({ n: 1, ok: true });
+    return { chain_id: item.id, spec, raw: r1, attempts };
+  } catch (e) {
+    if (!(e instanceof SchemaError)) throw e;
+    attempts.push({ n: 1, ok: false, errors: e.errors });
+
+    // Attempt 2 — feed the errors back into the user message
+    const correctionMsg =
+      userMessage +
+      `\n\n---\n\nYour previous output failed schema validation with these errors:\n` +
+      e.errors.map((err) => `  • ${err}`).join('\n') +
+      `\n\nReturn ONLY the corrected YAML — no prose, no apology, no commentary. Same shape as the example.`;
+
+    const r2 = await provider.complete(system, correctionMsg, { maxTokens: 4000, temperature: 0.05 });
+    try {
+      const spec = parseScaffolderSpec(r2.raw);
+      finaliseSpec(spec, item);
+      attempts.push({ n: 2, ok: true });
+      return { chain_id: item.id, spec, raw: r2, attempts };
+    } catch (e2) {
+      if (e2 instanceof SchemaError) {
+        attempts.push({ n: 2, ok: false, errors: e2.errors });
+        throw new SchemaError([
+          `LLM scaffolder failed after retry. First attempt: ${e.errors.length} error(s). Retry: ${e2.errors.length} error(s).`,
+          ...e2.errors.map((s) => `retry: ${s}`),
+        ]);
+      }
+      throw e2;
+    }
+  }
+}
+
+/** Inject derived chain-id / machine into the spec if the LLM omitted them. */
+function finaliseSpec(spec: ScaffolderChainSpec, item: LooseBacklogItem): void {
+  spec.chain_config ??= {};
+  if (!spec.chain_config.machine) {
+    spec.chain_config.machine = item.machine ?? 'm3';
+  }
+  if (!spec.chain_config.acceptance_enforce_default) {
+    spec.chain_config.acceptance_enforce_default = 'warn';
+  }
+  if (!spec.chain_config.alert_channels) {
+    spec.chain_config.alert_channels = ['handoff', 'inbox', 'audit'];
+  }
+  if (spec.chain_config.max_concurrent === undefined) {
+    spec.chain_config.max_concurrent = 1;
+  }
+  spec.defaults ??= {};
+  if (spec.defaults.max_retries === undefined) spec.defaults.max_retries = 2;
+  if (spec.defaults.heartbeat_interval_sec === undefined) spec.defaults.heartbeat_interval_sec = 60;
+}
+
+function validateLooseItem(item: LooseBacklogItem): void {
+  if (!item.id || typeof item.id !== 'string') {
+    throw new Error('LooseBacklogItem.id is required (kebab-case)');
+  }
+  if (!/^[a-z][a-z0-9-]{2,}$/.test(item.id)) {
+    throw new Error(`LooseBacklogItem.id must match /^[a-z][a-z0-9-]{2,}$/, got '${item.id}'`);
+  }
+  if (!item.title || typeof item.title !== 'string' || item.title.trim().length < 4) {
+    throw new Error('LooseBacklogItem.title is required (>=4 chars)');
+  }
+  if (!item.description || typeof item.description !== 'string' || item.description.trim().length < 10) {
+    throw new Error('LooseBacklogItem.description is required (>=10 chars)');
+  }
+}
+
+function buildUserMessage(item: LooseBacklogItem, ctx: Awaited<ReturnType<typeof gatherContext>>, today: string): string {
+  const lines: string[] = [];
+  lines.push('# Backlog item');
+  lines.push(`id: ${item.id}`);
+  lines.push(`title: ${item.title}`);
+  lines.push(`description: ${item.description}`);
+  if (item.machine) lines.push(`machine: ${item.machine}`);
+  if (item.deps?.length) lines.push(`deps_on_chains: ${item.deps.join(', ')}`);
+  if (item.file_paths?.length) {
+    lines.push(`hinted_file_paths:`);
+    for (const fp of item.file_paths) lines.push(`  - ${fp}`);
+  }
+  lines.push('');
+  lines.push(`Today: ${today}`);
+  lines.push(`Suggested report path stem: ~/Documents/projects/reports/${item.id.replace(/-/g, '_')}_pN_${today}.md`);
+  lines.push('');
+
+  lines.push('# Gathered context');
+  lines.push(ctx.summary);
+  lines.push('');
+
+  if (ctx.files.length > 0) {
+    lines.push('## File snippets');
+    for (const f of ctx.files) {
+      lines.push(`### ${f.path}${f.truncated ? ' (truncated)' : ''}`);
+      lines.push('```');
+      lines.push(f.snippet);
+      lines.push('```');
+    }
+    lines.push('');
+  }
+  if (ctx.grep_hits.length > 0) {
+    lines.push('## Grep hits');
+    for (const g of ctx.grep_hits) {
+      lines.push(`### pattern: ${g.pattern}`);
+      lines.push('```');
+      for (const l of g.lines) lines.push(l);
+      lines.push('```');
+    }
+    lines.push('');
+  }
+  if (ctx.semantic_hits.length > 0) {
+    lines.push('## Semantic search hits (local-llm-router)');
+    for (const s of ctx.semantic_hits) {
+      lines.push(`- ${s.path}${s.score !== undefined ? ` (score=${s.score.toFixed(3)})` : ''}`);
+      if (s.snippet) lines.push(`  ${s.snippet.slice(0, 200)}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('# Task');
+  lines.push(
+    'Emit the phases YAML for this item. Follow the OUTPUT CONTRACT in the system prompt. ' +
+      'Cite paths from the gathered context whenever you can. Keep phase_count modest (1–3).',
+  );
+  return lines.join('\n');
+}
+
+async function loadFewShot(explicitPath?: string): Promise<string> {
+  const candidates: string[] = [];
+  if (explicitPath) candidates.push(explicitPath);
+  // Operator-side canonical location
+  candidates.push(resolve(process.env.HOME ?? '~', 'Documents/projects/agent-memory/sps_router_critical_fixes_phases.yaml'));
+  // Bundled fixture (for tests + zero-config scaffolds)
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    candidates.push(resolve(here, '../tests/fixtures/example_chain.yaml'));
+    candidates.push(resolve(here, '../__tests__/fixtures/example_chain.yaml'));
+    // When running from dist/, fixtures live one level up
+    candidates.push(join(here, '..', 'tests', 'fixtures', 'example_chain.yaml'));
+  } catch {
+    /* import.meta.url unavailable in some test runners — skip */
+  }
+  for (const c of candidates) {
+    try {
+      return await readFile(c, 'utf8');
+    } catch {
+      /* try next */
+    }
+  }
+  return FALLBACK_EXAMPLE;
+}

--- a/packages/chain-scaffolder/src/parse-backlog-line.ts
+++ b/packages/chain-scaffolder/src/parse-backlog-line.ts
@@ -1,0 +1,62 @@
+import type { LooseBacklogItem, Machine } from './types.js';
+
+/**
+ * Parse a "loose backlog line" — the single-line shape callers can pipe into
+ * the CLI:
+ *
+ *   <id> :: <title> :: <description>            (simple)
+ *   <id> :: <title> :: <description> [machine=m1] [file=path/a.ts,path/b.ts]
+ *
+ * Tokens after the third `::` are key=value annotations. Recognised:
+ *   - machine = m3 | m1 | stolution
+ *   - file    = comma-separated file_paths
+ *   - deps    = comma-separated chain ids
+ *
+ * Free-form annotations are ignored. The parser is forgiving — bad annotations
+ * are dropped rather than failing the parse.
+ */
+export function parseBacklogLine(line: string): LooseBacklogItem {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) throw new Error('parseBacklogLine: empty input');
+
+  // Split into [id, title, descPlusAnnots]
+  const parts = trimmed.split('::').map((s) => s.trim());
+  if (parts.length < 3) {
+    throw new Error(
+      `parseBacklogLine: expected "id :: title :: description" (got ${parts.length} segments). ` +
+        `Example: 'my-item :: Short title :: What this does and why'`,
+    );
+  }
+  const id = parts[0] ?? '';
+  const title = parts[1] ?? '';
+  // Anything after the 3rd :: is still description (so :: in description is OK)
+  const descRaw = parts.slice(2).join(' :: ');
+
+  // Extract annotations. Annotations stay embedded in the description text
+  // because grep + LLM context still benefit from the extra words; we just
+  // record their values for explicit fields.
+  const annotRe = /(\b\w+)=([^\s][^\s]*)/g;
+  const annotations: Record<string, string> = {};
+  let m: RegExpExecArray | null;
+  while ((m = annotRe.exec(descRaw)) !== null) {
+    const k = m[1];
+    const v = m[2];
+    if (k && v) annotations[k.toLowerCase()] = v;
+  }
+  const description = descRaw.trim();
+
+  const out: LooseBacklogItem = { id, title, description };
+  const machine = annotations.machine;
+  if (machine && ['m3', 'm1', 'stolution'].includes(machine)) {
+    out.machine = machine as Machine;
+  }
+  const file = annotations.file;
+  if (file) {
+    out.file_paths = file.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  const deps = annotations.deps;
+  if (deps) {
+    out.deps = deps.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  return out;
+}

--- a/packages/chain-scaffolder/src/providers.ts
+++ b/packages/chain-scaffolder/src/providers.ts
@@ -1,0 +1,171 @@
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { LlmProvider, RawLlmScaffold } from './types.js';
+
+const pExecFile = promisify(execFile);
+
+export interface ProviderResolveOpts {
+  provider?: 'claude' | 'local' | 'auto' | 'fixture';
+  /** Override claude CLI binary (defaults to 'claude' on PATH). */
+  claudeBin?: string;
+  /** Override local-llm-router base URL. */
+  routerBaseUrl?: string;
+  /** Force the model id passed to the claude CLI. */
+  claudeModel?: string;
+  /** Force the task-type passed to local-llm-router. Defaults to 'reason'. */
+  localTaskType?: string;
+  /** Optional fixture provider for tests. */
+  fixtureResponse?: string;
+}
+
+/**
+ * Resolve the configured provider. The default `auto` strategy prefers `local`
+ * when the router answers /healthz, else falls through to `claude` if the CLI
+ * is on PATH, else throws. Callers can pin with `provider: 'claude' | 'local'`.
+ */
+export async function resolveProvider(opts: ProviderResolveOpts = {}): Promise<LlmProvider> {
+  if (opts.provider === 'fixture') {
+    return makeFixtureProvider(opts.fixtureResponse ?? '');
+  }
+  if (opts.provider === 'claude') return makeClaudeProvider(opts);
+  if (opts.provider === 'local') return makeLocalProvider(opts);
+
+  // auto
+  const routerUp = await probeRouter(opts.routerBaseUrl);
+  if (routerUp) return makeLocalProvider(opts);
+  const claudeOk = await probeClaude(opts.claudeBin);
+  if (claudeOk) return makeClaudeProvider(opts);
+  throw new Error(
+    'No LLM provider available: local-llm-router unreachable and claude CLI not on PATH. ' +
+      'Set --provider claude (with a working claude binary) or start the router daemon.',
+  );
+}
+
+async function probeRouter(routerBaseUrl?: string): Promise<boolean> {
+  const url = `${(routerBaseUrl ?? 'http://127.0.0.1:7411').replace(/\/$/, '')}/healthz`;
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 1500);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    if (!res.ok) return false;
+    const j = (await res.json()) as { ok?: boolean };
+    return j.ok === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function probeClaude(claudeBin?: string): Promise<boolean> {
+  const bin = claudeBin ?? 'claude';
+  try {
+    await pExecFile(bin, ['--version'], { timeout: 2000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function makeFixtureProvider(response: string): LlmProvider {
+  return {
+    name: 'fixture',
+    async complete() {
+      return { raw: response, provider: 'fixture' } as RawLlmScaffold;
+    },
+  };
+}
+
+export function makeLocalProvider(opts: ProviderResolveOpts): LlmProvider {
+  const baseUrl = (opts.routerBaseUrl ?? 'http://127.0.0.1:7411').replace(/\/$/, '');
+  const taskType = opts.localTaskType ?? 'reason';
+  return {
+    name: 'local',
+    async complete(system, user, callOpts) {
+      const body = {
+        messages: [
+          { role: 'system', content: system },
+          { role: 'user', content: user },
+        ],
+        caia_task_type: taskType,
+        max_tokens: callOpts?.maxTokens ?? 4000,
+        temperature: callOpts?.temperature ?? 0.1,
+      };
+      const ctrl = new AbortController();
+      const t = setTimeout(() => ctrl.abort(), 120_000);
+      let res: Response;
+      try {
+        res = await fetch(`${baseUrl}/v1/chat/completions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: ctrl.signal,
+        });
+      } finally {
+        clearTimeout(t);
+      }
+      if (!res.ok) {
+        const text = await res.text().catch(() => '<unreadable>');
+        throw new Error(`local-llm-router returned ${res.status}: ${text.slice(0, 200)}`);
+      }
+      const data = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+      const content = data.choices?.[0]?.message?.content;
+      if (typeof content !== 'string' || content.length === 0) {
+        throw new Error('local-llm-router returned no content');
+      }
+      const usage: RawLlmScaffold['usage'] = {};
+      if (typeof data.usage?.prompt_tokens === 'number') usage.input_tokens = data.usage.prompt_tokens;
+      if (typeof data.usage?.completion_tokens === 'number') usage.output_tokens = data.usage.completion_tokens;
+      const out: RawLlmScaffold = { raw: content, provider: 'local' };
+      if (Object.keys(usage).length > 0) out.usage = usage;
+      return out;
+    },
+  };
+}
+
+export function makeClaudeProvider(opts: ProviderResolveOpts): LlmProvider {
+  const bin = opts.claudeBin ?? 'claude';
+  const model = opts.claudeModel ?? process.env.CAIA_SCAFFOLDER_MODEL ?? 'claude-sonnet-4-6';
+  return {
+    name: 'claude',
+    async complete(system, user, _callOpts) {
+      // Use the claude CLI in non-interactive print mode. The CLI prints the
+      // assistant message to stdout. We pipe the prompt via stdin to avoid
+      // command-line length limits; execFile's API doesn't expose stdin, so
+      // we drop to `spawn` for this provider.
+      const args = ['-p', '--model', model, '--max-turns', '1', '--output-format', 'text'];
+      const combined = `<system>\n${system}\n</system>\n\n${user}`;
+      const stdout: string = await new Promise<string>((resolveP, rejectP) => {
+        const child = spawn(bin, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+        const chunks: Buffer[] = [];
+        const errChunks: Buffer[] = [];
+        const timer = setTimeout(() => {
+          child.kill('SIGTERM');
+          rejectP(new Error('claude CLI timed out after 180s'));
+        }, 180_000);
+        child.stdout.on('data', (c) => chunks.push(Buffer.from(c)));
+        child.stderr.on('data', (c) => errChunks.push(Buffer.from(c)));
+        child.on('error', (e) => {
+          clearTimeout(timer);
+          rejectP(e);
+        });
+        child.on('close', (code) => {
+          clearTimeout(timer);
+          if (code !== 0) {
+            rejectP(new Error(`claude CLI exited ${code}: ${Buffer.concat(errChunks).toString('utf8').slice(0, 200)}`));
+            return;
+          }
+          resolveP(Buffer.concat(chunks).toString('utf8'));
+        });
+        child.stdin.write(combined);
+        child.stdin.end();
+      });
+      const trimmed = stdout.trim();
+      if (trimmed.length === 0) throw new Error('claude CLI returned empty stdout');
+      return { raw: trimmed, provider: 'claude' };
+    },
+  };
+}

--- a/packages/chain-scaffolder/src/schema.ts
+++ b/packages/chain-scaffolder/src/schema.ts
@@ -1,0 +1,232 @@
+import yaml from 'js-yaml';
+import type { ScaffolderChainSpec, ScaffolderPhase } from './types.js';
+
+export class SchemaError extends Error {
+  errors: string[];
+  constructor(errors: string[]) {
+    super(`scaffolder schema validation failed (${errors.length} error(s)): ${errors.join('; ')}`);
+    this.errors = errors;
+    this.name = 'SchemaError';
+  }
+}
+
+/**
+ * Parse a YAML string (or already-parsed object) into a ScaffolderChainSpec.
+ * Throws SchemaError with a flat list of human-readable errors when invalid.
+ *
+ * The validator is intentionally stricter than chain-runner's `loadChainSpec`:
+ * it requires `success_criteria.output_file`, a `prompt_template`, sequential
+ * phase ids starting at 1, and well-formed `deps`. Anything we emit here must
+ * still round-trip cleanly through the runner's loader (which is laxer), so
+ * the strictness is one-way.
+ */
+export function parseScaffolderSpec(input: string | unknown): ScaffolderChainSpec {
+  let parsed: unknown;
+  if (typeof input === 'string') {
+    try {
+      parsed = yaml.load(extractYamlBlock(input));
+    } catch (e) {
+      throw new SchemaError([`yaml parse error: ${(e as Error).message}`]);
+    }
+  } else {
+    parsed = input;
+  }
+  return validateScaffolderSpec(parsed);
+}
+
+/**
+ * Some LLMs wrap YAML in ```yaml ... ``` fences or add prose around it. Strip
+ * the fence if present; otherwise return the input unchanged.
+ */
+export function extractYamlBlock(text: string): string {
+  const fenceRe = /```(?:yaml|yml)?\n([\s\S]*?)\n```/i;
+  const m = text.match(fenceRe);
+  if (m && m[1]) return m[1];
+  return text;
+}
+
+export function validateScaffolderSpec(parsed: unknown): ScaffolderChainSpec {
+  const errors: string[] = [];
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new SchemaError(['root is not an object']);
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  // ── phases ──────────────────────────────────────────────────────────
+  const phasesRaw = obj.phases;
+  if (!Array.isArray(phasesRaw)) {
+    throw new SchemaError(['phases: missing or not an array']);
+  }
+  if (phasesRaw.length === 0) {
+    throw new SchemaError(['phases: at least one phase required']);
+  }
+  if (phasesRaw.length > 20) {
+    errors.push(`phases: ${phasesRaw.length} is excessive (cap at 20). Scaffolder expects 1–10.`);
+  }
+
+  const phases: ScaffolderPhase[] = [];
+  const seenIds = new Set<number>();
+  phasesRaw.forEach((p, i) => {
+    if (!p || typeof p !== 'object') {
+      errors.push(`phases[${i}]: not an object`);
+      return;
+    }
+    const ph = p as Record<string, unknown>;
+    const where = `phases[${i}]`;
+    const id = ph.id;
+    if (typeof id !== 'number' || !Number.isInteger(id) || id < 1) {
+      errors.push(`${where}.id: must be a positive integer, got ${JSON.stringify(id)}`);
+    } else if (seenIds.has(id)) {
+      errors.push(`${where}.id: duplicate id ${id}`);
+    } else {
+      seenIds.add(id);
+    }
+    if (typeof ph.name !== 'string' || ph.name.trim() === '') {
+      errors.push(`${where}.name: required non-empty string`);
+    }
+    if (ph.description !== undefined && typeof ph.description !== 'string') {
+      errors.push(`${where}.description: must be a string`);
+    }
+    if (typeof ph.prompt_template !== 'string' || ph.prompt_template.trim().length < 40) {
+      errors.push(`${where}.prompt_template: required string of at least 40 chars (got ${typeof ph.prompt_template === 'string' ? ph.prompt_template.length : typeof ph.prompt_template})`);
+    }
+
+    // deps
+    let deps: number[] | undefined;
+    if (ph.deps !== undefined) {
+      if (!Array.isArray(ph.deps)) {
+        errors.push(`${where}.deps: must be an array of phase ids`);
+      } else {
+        deps = [];
+        for (let j = 0; j < ph.deps.length; j++) {
+          const d = ph.deps[j];
+          if (typeof d !== 'number' || !Number.isInteger(d)) {
+            errors.push(`${where}.deps[${j}]: must be a phase id (integer)`);
+          } else {
+            deps.push(d);
+          }
+        }
+      }
+    }
+
+    // success_criteria
+    const sc = ph.success_criteria;
+    const scOut: ScaffolderPhase['success_criteria'] = { output_file: '' };
+    if (!sc || typeof sc !== 'object' || Array.isArray(sc)) {
+      errors.push(`${where}.success_criteria: required object`);
+    } else {
+      const scObj = sc as Record<string, unknown>;
+      if (typeof scObj.output_file !== 'string' || scObj.output_file.trim() === '') {
+        errors.push(`${where}.success_criteria.output_file: required non-empty string`);
+      } else {
+        scOut.output_file = scObj.output_file;
+      }
+      if (scObj.min_bytes !== undefined) {
+        if (typeof scObj.min_bytes !== 'number' || scObj.min_bytes < 0) {
+          errors.push(`${where}.success_criteria.min_bytes: must be a non-negative number`);
+        } else {
+          scOut.min_bytes = scObj.min_bytes;
+        }
+      }
+      if (scObj.grep_match !== undefined) {
+        if (typeof scObj.grep_match !== 'string') {
+          errors.push(`${where}.success_criteria.grep_match: must be a string regex`);
+        } else {
+          scOut.grep_match = scObj.grep_match;
+        }
+      }
+      if (scObj.requires_merged_pr !== undefined) {
+        if (typeof scObj.requires_merged_pr !== 'boolean') {
+          errors.push(`${where}.success_criteria.requires_merged_pr: must be a boolean`);
+        } else {
+          scOut.requires_merged_pr = scObj.requires_merged_pr;
+        }
+      }
+      if (scObj.enforce !== undefined) {
+        if (scObj.enforce !== 'warn' && scObj.enforce !== 'strict') {
+          errors.push(`${where}.success_criteria.enforce: must be "warn" or "strict"`);
+        } else {
+          scOut.enforce = scObj.enforce;
+        }
+      }
+    }
+
+    let max_minutes: number | undefined;
+    if (ph.max_minutes !== undefined) {
+      if (typeof ph.max_minutes !== 'number' || ph.max_minutes <= 0) {
+        errors.push(`${where}.max_minutes: must be a positive number`);
+      } else {
+        max_minutes = ph.max_minutes;
+      }
+    }
+
+    const phase: ScaffolderPhase = {
+      id: typeof id === 'number' ? id : -1,
+      name: typeof ph.name === 'string' ? ph.name : '',
+      prompt_template: typeof ph.prompt_template === 'string' ? ph.prompt_template : '',
+      success_criteria: scOut,
+    };
+    if (typeof ph.description === 'string') phase.description = ph.description;
+    if (deps !== undefined) phase.deps = deps;
+    if (max_minutes !== undefined) phase.max_minutes = max_minutes;
+    phases.push(phase);
+  });
+
+  // Cross-phase: deps must reference earlier phase ids; ids should be 1..N.
+  const sortedIds = [...seenIds].sort((a, b) => a - b);
+  for (let i = 0; i < sortedIds.length; i++) {
+    if (sortedIds[i] !== i + 1) {
+      errors.push(`phases ids should be sequential 1..${sortedIds.length}; got ${sortedIds.join(',')}`);
+      break;
+    }
+  }
+  for (const ph of phases) {
+    if (!ph.deps) continue;
+    for (const d of ph.deps) {
+      if (!seenIds.has(d)) {
+        errors.push(`phases[${ph.id}].deps: references unknown phase id ${d}`);
+      } else if (d >= ph.id) {
+        errors.push(`phases[${ph.id}].deps: ${d} must reference a strictly-earlier phase`);
+      }
+    }
+  }
+
+  // Optional chain_config / defaults pass-through (lightly validated)
+  const out: ScaffolderChainSpec = { phases };
+  if (obj.defaults !== undefined) {
+    if (typeof obj.defaults !== 'object' || obj.defaults === null) {
+      errors.push('defaults: must be an object');
+    } else {
+      out.defaults = obj.defaults as NonNullable<ScaffolderChainSpec['defaults']>;
+    }
+  }
+  if (obj.chain_config !== undefined) {
+    if (typeof obj.chain_config !== 'object' || obj.chain_config === null) {
+      errors.push('chain_config: must be an object');
+    } else {
+      out.chain_config = obj.chain_config as NonNullable<ScaffolderChainSpec['chain_config']>;
+    }
+  }
+
+  if (errors.length > 0) throw new SchemaError(errors);
+  return out;
+}
+
+/** Render a ScaffolderChainSpec back to YAML. Deterministic key order. */
+export function specToYaml(spec: ScaffolderChainSpec): string {
+  // js-yaml dump preserves object key order. We hand-build the object so the
+  // emitted YAML reads top-down: defaults → chain_config → phases.
+  const root: Record<string, unknown> = {};
+  if (spec.defaults) root.defaults = spec.defaults;
+  if (spec.chain_config) root.chain_config = spec.chain_config;
+  root.phases = spec.phases.map((p) => {
+    const r: Record<string, unknown> = { id: p.id, name: p.name };
+    if (p.description) r.description = p.description;
+    if (p.deps) r.deps = p.deps;
+    if (p.max_minutes !== undefined) r.max_minutes = p.max_minutes;
+    r.success_criteria = p.success_criteria;
+    r.prompt_template = p.prompt_template;
+    return r;
+  });
+  return yaml.dump(root, { lineWidth: 100, noRefs: true });
+}

--- a/packages/chain-scaffolder/src/types.ts
+++ b/packages/chain-scaffolder/src/types.ts
@@ -1,0 +1,98 @@
+// Scaffolder-side view of a chain spec. We intentionally keep this loose
+// (subset of @chiefaia/chain-runner's ChainSpec) so the scaffolder can
+// validate output before the runner's stricter loader sees it. Anything
+// the scaffolder emits must round-trip through `loadChainSpec` cleanly.
+
+export type Machine = 'm3' | 'm1' | 'stolution';
+
+export interface LooseBacklogItem {
+  /** Kebab-case id; becomes the chain id. */
+  id: string;
+  /** Short title. */
+  title: string;
+  /** 1-2 line free-form description — what + why. */
+  description: string;
+  /** Optional caller-supplied file_paths hints. The context gatherer
+   *  will grep these for nearby work; if absent the gatherer infers from
+   *  the description / id. */
+  file_paths?: string[];
+  /** Optional machine hint. Defaults to m3-local. */
+  machine?: Machine;
+  /** Optional explicit deps (chain ids that must be all_done first). */
+  deps?: string[];
+}
+
+export interface ScaffolderSuccessCriteria {
+  output_file: string;
+  min_bytes?: number;
+  grep_match?: string;
+  requires_merged_pr?: boolean;
+  enforce?: 'warn' | 'strict';
+}
+
+export interface ScaffolderPhase {
+  id: number;
+  name: string;
+  description?: string;
+  deps?: number[];
+  max_minutes?: number;
+  prompt_template: string;
+  success_criteria: ScaffolderSuccessCriteria;
+}
+
+export interface ScaffolderChainSpec {
+  defaults?: {
+    max_retries?: number;
+    heartbeat_interval_sec?: number;
+  };
+  chain_config?: {
+    alert_channels?: string[];
+    max_concurrent?: number;
+    acceptance_enforce_default?: 'warn' | 'strict';
+    machine?: Machine;
+  };
+  phases: ScaffolderPhase[];
+}
+
+/** Output of the LLM call before schema validation. */
+export interface RawLlmScaffold {
+  /** The raw text returned by the LLM. */
+  raw: string;
+  /** The provider that produced the response. */
+  provider: 'claude' | 'local' | 'fixture';
+  /** Optional usage stats forwarded from the provider. */
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+export interface LlmScaffoldResult {
+  /** Chain id derived from the backlog item. */
+  chain_id: string;
+  /** The validated chain spec. */
+  spec: ScaffolderChainSpec;
+  /** Provider + raw output for audit. */
+  raw: RawLlmScaffold;
+  /** Validation/retry log — first attempt, retry-with-corrections etc. */
+  attempts: Array<{
+    n: number;
+    ok: boolean;
+    errors?: string[];
+  }>;
+}
+
+/** Pluggable LLM provider. Implementations live in src/providers/. */
+export interface LlmProvider {
+  name: 'claude' | 'local' | 'fixture';
+  /**
+   * @param system  System prompt (instructions + few-shot example).
+   * @param user    User message (the backlog item + gathered context).
+   * @param opts    Provider-specific knobs.
+   */
+  complete(
+    system: string,
+    user: string,
+    opts?: { maxTokens?: number; temperature?: number },
+  ): Promise<RawLlmScaffold>;
+}

--- a/packages/chain-scaffolder/tests/fixtures/example_chain.yaml
+++ b/packages/chain-scaffolder/tests/fixtures/example_chain.yaml
@@ -1,0 +1,75 @@
+# sps-router-critical-fixes — stripped fewshot
+# Demonstrates well-formed phases YAML: 1-3 phases, deps, prompt_template
+# with Background/Implementation/PR/Report sections, success_criteria with
+# requires_merged_pr.
+
+defaults:
+  max_retries: 2
+  heartbeat_interval_sec: 60
+
+chain_config:
+  alert_channels: [handoff, inbox, audit]
+  max_concurrent: 1
+  acceptance_enforce_default: warn
+  machine: m3
+
+phases:
+  - id: 1
+    name: rr1_adversarial_prefilter
+    description: "RR-1 mitigation: adversarial prompt prefilter + ban-list at the router's classifier-input boundary."
+    deps: []
+    max_minutes: 120
+    success_criteria:
+      output_file: "~/Documents/projects/reports/rr1_adversarial_prefilter_2026-05-15.md"
+      min_bytes: 1000
+      grep_match: "RR-1|adversarial|prefilter|ban-list"
+      requires_merged_pr: true
+    prompt_template: |
+      Phase 1 — RR-1 fast mitigation: adversarial prefilter + ban-list.
+
+      ## Background
+      Cross-test surfaced 50% adversarial bypass: crafted prompts route to local-7b
+      instead of being held/escalated. Security gap — apply prefilter/ban-list now.
+
+      ## Implementation
+      1. New file: `caia/packages/local-llm-router/src/adversarial-prefilter.ts`
+         exporting `screenForInjection(prompt): {blocked, reason?, matched?}`.
+      2. Wire into `caia/packages/local-llm-router/src/router.ts` BEFORE classifier.
+      3. Unit tests in `__tests__/adversarial-prefilter.test.ts` covering the 10
+         adversarial prompts and 10 benign prompts.
+
+      ## PR
+      Branch `feat/rr1-adversarial-prefilter-2026-05-15`. caia-pr-create-safe → MERGED.
+
+      ## Report
+      `~/Documents/projects/reports/rr1_adversarial_prefilter_2026-05-15.md`.
+      gate-mark-done.sh + caia-chain mark-done 1.
+
+  - id: 2
+    name: r1_cascade_doesnt_cascade
+    description: "R-1: dispatcher doesn't fall through to claude on low-confidence local response."
+    deps: [1]
+    max_minutes: 120
+    success_criteria:
+      output_file: "~/Documents/projects/reports/r1_cascade_fallthrough_2026-05-15.md"
+      min_bytes: 1000
+      grep_match: "R-1|cascade|fallthrough|escalation"
+      requires_merged_pr: true
+    prompt_template: |
+      Phase 2 — R-1: cascade-doesn't-cascade fix.
+
+      ## Background
+      Dispatcher routes everything to local-7b. Cascade fall-through on
+      `needs_escalation:true`, low confidence, or schema-fail is broken.
+
+      ## Implementation
+      Tighten escalation logic in `caia/packages/local-llm-router/src/router.ts`:
+      explicit `needs_escalation` signal + low-confidence threshold. On escalation,
+      route to claude or stolution-batch:32b with the same prompt.
+
+      ## PR
+      Branch `feat/r1-cascade-fallthrough-2026-05-15`. Merge required.
+
+      ## Report
+      `~/Documents/projects/reports/r1_cascade_fallthrough_2026-05-15.md`.
+      gate-mark-done.sh + caia-chain mark-done 2.

--- a/packages/chain-scaffolder/tests/fixtures/loose_item_response.yaml
+++ b/packages/chain-scaffolder/tests/fixtures/loose_item_response.yaml
@@ -1,0 +1,40 @@
+```yaml
+defaults:
+  max_retries: 2
+  heartbeat_interval_sec: 60
+
+chain_config:
+  alert_channels: [handoff, inbox, audit]
+  max_concurrent: 1
+  acceptance_enforce_default: warn
+  machine: m3
+
+phases:
+  - id: 1
+    name: implement_widget_cache
+    description: "Add an in-process LRU cache for widget lookups in the demo package."
+    deps: []
+    max_minutes: 90
+    success_criteria:
+      output_file: "~/Documents/projects/reports/loose_demo_p1_2026-05-16.md"
+      min_bytes: 800
+      grep_match: "widget|cache|lru"
+      requires_merged_pr: true
+    prompt_template: |
+      Phase 1 — Add LRU cache for widget lookups.
+
+      ## Background
+      The widget-store currently scans on every call; profiling showed it's the hot path.
+
+      ## Implementation
+      1. New file `caia/packages/widget-store/src/lru.ts` — minimal LRU.
+      2. Wire into `caia/packages/widget-store/src/store.ts` getWidget().
+      3. Unit tests for hit/miss + eviction.
+
+      ## PR
+      Branch `feat/loose-demo-2026-05-16`. caia-pr-create-safe → MERGED.
+
+      ## Report
+      `~/Documents/projects/reports/loose_demo_p1_2026-05-16.md`.
+      gate-mark-done.sh + caia-chain mark-done 1.
+```

--- a/packages/chain-scaffolder/tests/fixtures/malformed_then_correct.json
+++ b/packages/chain-scaffolder/tests/fixtures/malformed_then_correct.json
@@ -1,0 +1,4 @@
+{
+  "first": "```yaml\nphases:\n  - id: 1\n    name: missing_prompt\n    success_criteria:\n      output_file: ~/Documents/projects/reports/x.md\n```\n",
+  "second": "```yaml\ndefaults:\n  max_retries: 2\nchain_config:\n  alert_channels: [handoff]\n  max_concurrent: 1\nphases:\n  - id: 1\n    name: fixed_phase\n    description: 'Now has a prompt_template.'\n    deps: []\n    max_minutes: 90\n    success_criteria:\n      output_file: '~/Documents/projects/reports/fixed_p1_2026-05-16.md'\n      min_bytes: 800\n      requires_merged_pr: true\n    prompt_template: |\n      Phase 1 — fixed. This is a long-enough prompt template to satisfy the\n      schema validator's 40-character minimum, with concrete file paths under\n      caia/packages/... and a PR / Report section.\n```\n"
+}

--- a/packages/chain-scaffolder/tsconfig.json
+++ b/packages/chain-scaffolder/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/chain-scaffolder/vitest.config.ts
+++ b/packages/chain-scaffolder/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    testTimeout: 30_000,
+    coverage: {
+      thresholds: {
+        perFile: false,
+        lines: 60,
+        functions: 60,
+        branches: 50,
+        statements: 60,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,6 +866,40 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/chain-scaffolder:
+    dependencies:
+      '@chiefaia/chain-runner':
+        specifier: workspace:*
+        version: link:../chain-runner
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/classifier:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

Adds `@chiefaia/chain-scaffolder` — turns a single-line backlog idea (`id :: title :: description`) into a fully-formed `phases.yaml` the `@chiefaia/chain-runner` can dispatch.

LLM path: gather context (file reads + grep + optional `local-llm-router /v1/search-memory` at :7411) → resolve provider (`auto | claude | local | fixture`) → call with system+user prompt and a few-shot example (`sps_router_critical_fixes_phases.yaml`) → parse + validate → retry ONCE with corrections on `SchemaError` → finalise defaults.

## Files

- `src/context.ts` — file reads + grep + semantic-search context gatherer (best-effort)
- `src/providers.ts` — provider abstraction with `auto | claude | local | fixture` modes
- `src/llm.ts` — main entry; single retry-with-corrections on schema fail
- `src/schema.ts` — strict validator + YAML emitter, round-trips through chain-runner's `loadChainSpec`
- `src/parse-backlog-line.ts` — `id :: title :: description [machine=...] [file=...] [deps=...]` parser
- `src/cli.ts` — `caia-scaffold from-llm` + `validate` subcommands
- `bin/caia-scaffold.js` — bin shim

## CLI

```
caia-scaffold from-llm "<id> :: <title> :: <description>" [--context-files ...] [--provider auto|claude|local|fixture] [--no-write] [--json]
caia-scaffold validate <phases.yaml>
```

## Test plan

- [x] `pnpm -C packages/chain-scaffolder typecheck` clean (strict + exactOptionalPropertyTypes)
- [x] `pnpm -C packages/chain-scaffolder lint` clean
- [x] `pnpm -C packages/chain-scaffolder test` — 24 tests pass across schema / parse-backlog-line / context / llm / integration
- [x] Integration test scaffolds a real `⏳ pending [INDEPENDENT]` item from `~/Documents/projects/backlog/MASTER_BACKLOG.md`, runs `caia-chain init` + `next-phase --read-only`
- [x] CLI smoke via fixture provider returns a valid JSON envelope

## Sibling work

`v2-templated-scaffolder` (separate branch) adds the structured-YAML path alongside this one. Both modes will live in the same package once both PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)