### PR TITLE
feat(chain-scaffolder): scaffold-next subcommand for orchestrator atomic top-up

### DIFF
--- a/packages/chain-scaffolder/__tests__/templated.test.ts
+++ b/packages/chain-scaffolder/__tests__/templated.test.ts
@@ -23,7 +23,7 @@ import {
   renderRunnerScript,
   type BacklogItem,
 } from '../src/templated.js';
-import { parseBacklog, listPending, nextAvailable } from '../src/backlog.js';
+import { parseBacklog, listPending, nextAvailable, scaffoldNext } from '../src/backlog.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = resolve(__dirname, '..', 'tests', 'fixtures', 'sample-item.yaml');
@@ -355,5 +355,43 @@ describe('backlog discovery', () => {
     expect(idx.entries.map((e) => e.item.id)).toEqual(['good']);
     expect(idx.errors).toHaveLength(1);
     expect(idx.errors[0]?.source.endsWith('bad.yaml')).toBe(true);
+  });
+
+  it('scaffoldNext returns null when nothing is dispatchable', () => {
+    const dir = join(tmpHome, 'backlog');
+    mkdirSync(dir, { recursive: true });
+    expect(scaffoldNext(dir, { home: tmpHome })).toBeNull();
+  });
+
+  it('scaffoldNext scaffolds the first available item and skips it on subsequent calls', () => {
+    const dir = join(tmpHome, 'backlog');
+    writeItem(dir, 'a.yaml', { id: 'thing-a' });
+    writeItem(dir, 'b.yaml', { id: 'thing-b' });
+    const first = scaffoldNext(dir, { home: tmpHome });
+    expect(first?.entry.item.id).toBe('thing-a');
+    expect(existsSync(first!.scaffolded.stateFile)).toBe(true);
+
+    const second = scaffoldNext(dir, { home: tmpHome });
+    expect(second?.entry.item.id).toBe('thing-b');
+
+    const third = scaffoldNext(dir, { home: tmpHome });
+    expect(third).toBeNull();
+  });
+
+  it('scaffoldNext throws on conflict when --force is not set', () => {
+    const dir = join(tmpHome, 'backlog');
+    writeItem(dir, 'a.yaml', { id: 'thing-a' });
+    // Pre-scaffold by hand, then trip the duplicate-yaml race by re-marking
+    // it as pending (delete sentinel state.json marker only after scaffold)
+    const aSpec = yaml.load(readFileSync(join(dir, 'a.yaml'), 'utf8')) as BacklogItem;
+    const aResult = scaffoldFromBacklogItem(aSpec, { home: tmpHome });
+    // Re-create the chain dir as if it were a partial scaffold + simulate
+    // backlog item still pending by deleting only the state file's marker:
+    // simplest fixture is to point scaffoldNext at a fresh yaml that targets
+    // an already-scaffolded id.
+    writeItem(dir, 'a-dup.yaml', { id: 'thing-a', title: 'dup' });
+    // Manually remove the state.json so scaffoldNext picks the dup back up.
+    rmSync(aResult.stateFile);
+    expect(() => scaffoldNext(dir, { home: tmpHome })).toThrow(/already exists/);
   });
 });

--- a/packages/chain-scaffolder/src/backlog.ts
+++ b/packages/chain-scaffolder/src/backlog.ts
@@ -22,8 +22,12 @@ import {
 import { homedir } from 'node:os';
 import { dirname, extname, join, resolve } from 'node:path';
 import yaml from 'js-yaml';
-import type { BacklogItem } from './templated.js';
-import { validateBacklogItem, chainPaths } from './templated.js';
+import type { BacklogItem, ScaffoldOptions, ScaffoldResult } from './templated.js';
+import {
+  scaffoldFromBacklogItem,
+  validateBacklogItem,
+  chainPaths,
+} from './templated.js';
 
 export interface BacklogIndexEntry {
   source: string;
@@ -153,4 +157,31 @@ export function nextAvailable(
 ): BacklogIndexEntry | null {
   const pending = listPending(backlogPath, opts);
   return pending.find((e) => e.depsResolved) ?? null;
+}
+
+export interface ScaffoldNextResult {
+  entry: BacklogIndexEntry;
+  scaffolded: ScaffoldResult;
+}
+
+/**
+ * Combined `nextAvailable` + `scaffoldFromBacklogItem` for the orchestrator's
+ * top-up loop. Returns null when there is no dispatchable item; throws
+ * `Error("…already exists…")` on scaffold conflicts (caller handles exit-3
+ * mapping in the CLI layer).
+ */
+export function scaffoldNext(
+  backlogPath: string,
+  opts: ParseOpts & ScaffoldOptions = {},
+): ScaffoldNextResult | null {
+  const parseOpts: ParseOpts = {};
+  if (opts.home !== undefined) parseOpts.home = opts.home;
+  const next = nextAvailable(backlogPath, parseOpts);
+  if (!next) return null;
+  const scaffoldOpts: ScaffoldOptions = {};
+  if (opts.home !== undefined) scaffoldOpts.home = opts.home;
+  if (opts.generatedAt !== undefined) scaffoldOpts.generatedAt = opts.generatedAt;
+  if (opts.force !== undefined) scaffoldOpts.force = opts.force;
+  const result = scaffoldFromBacklogItem(next.item, scaffoldOpts);
+  return { entry: next, scaffolded: result };
 }

--- a/packages/chain-scaffolder/src/cli.ts
+++ b/packages/chain-scaffolder/src/cli.ts
@@ -12,7 +12,7 @@ import {
   validateBacklogItem,
   type BacklogItem,
 } from './templated.js';
-import { listPending, nextAvailable } from './backlog.js';
+import { listPending, nextAvailable, scaffoldNext } from './backlog.js';
 
 const DEFAULT_AGENT_MEMORY_DIR = resolve(homedir(), 'Documents/projects/agent-memory');
 const DEFAULT_CHAIN_BASE_DIR = resolve(homedir(), '.caia/chain');
@@ -197,6 +197,51 @@ export function buildCli(): Command {
       else
         process.stdout.write(
           `${out.id}\t${out.machine}\tphases=${out.phase_count}\t${out.source}\n  ${out.title}\n`,
+        );
+    });
+
+  program
+    .command('scaffold-next')
+    .description(
+      'Atomically claim and scaffold the next dispatchable structured item (templated path); exit 1 if none, exit 3 if conflict',
+    )
+    .requiredOption('--backlog <path>', 'directory or file containing structured backlog items')
+    .option('--force', 'overwrite existing chain artifacts', false)
+    .option('--json', 'emit machine-readable output', false)
+    .action((opts: { backlog: string; force?: boolean; json?: boolean }) => {
+      let result;
+      try {
+        const scaffoldOpts: { force?: boolean } = {};
+        if (opts.force) scaffoldOpts.force = true;
+        result = scaffoldNext(opts.backlog, scaffoldOpts);
+      } catch (e) {
+        const msg = (e as Error).message;
+        process.stderr.write(`error: ${msg}\n`);
+        process.exit(msg.includes('already exists') ? 3 : 1);
+      }
+      if (!result) {
+        if (opts.json) process.stdout.write(`null\n`);
+        else process.stderr.write('no dispatchable item available\n');
+        process.exit(1);
+      }
+      const out = {
+        id: result.entry.item.id,
+        title: result.entry.item.title,
+        machine: result.entry.item.machine,
+        source: result.entry.source,
+        phase_count: result.entry.item.phase_count,
+        scaffolded: result.scaffolded,
+      };
+      if (opts.json) process.stdout.write(`${JSON.stringify(out)}\n`);
+      else
+        process.stdout.write(
+          `scaffolded chain=${out.id}\n` +
+            `  machine: ${out.machine}\n` +
+            `  source:  ${out.source}\n` +
+            `  state:   ${result.scaffolded.stateFile}\n` +
+            `  phases:  ${result.scaffolded.phasesYaml}\n` +
+            `  runner:  ${result.scaffolded.runnerScript}\n` +
+            `chain is paused — orchestrator unpauses on next tick.\n`,
         );
     });
 


### PR DESCRIPTION
## Summary
- Adds `caia-scaffold scaffold-next --backlog <path>` — atomically claims and scaffolds the next dispatchable structured backlog item.
- Closes the race between separate `next-available` + `from-template` calls in the v2 fleet orchestrator's top-up loop.
- Exports `scaffoldNext(path, opts)` helper from `backlog.ts` for direct use.

## Why
The v2 orchestrator (~/.caia/chain-watchdog/caia_fleet_orchestrator.py, local-only) needs to query for the next available templated backlog item and scaffold it on the same tick when active phases drop below floor. Doing it in two CLI calls leaves a window where two ticks could both observe the same pending item before either has written `state.json`. One atomic command removes the window and shaves a round-trip.

## Test plan
- [x] `pnpm test` — 52 tests pass (6 files, including 3 new scaffoldNext cases: null path, success path with two-item walk, conflict-throws path).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm build` clean.
- [x] End-to-end smoke from the orchestrator side: dropped a fixture in `~/Documents/projects/backlog/structured/`, ran one orchestrator tick — saw `SCAFFOLDED:` and `DISPATCHED:` lines plus matching `scaffold_audit.jsonl` entry.

## Exit-code contract
- `0` — scaffolded; result on stdout (--json: object, otherwise human summary)
- `1` — nothing dispatchable (idle backlog)
- `3` — artifact conflict (state.json/phases.yaml already exists; pass `--force` or move aside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)