### PR TITLE
feat(claude-spawner): gb-3 ship claude-wrap router front-shim

### DIFF
--- a/packages/chain-runner/bin/templates/run-phase.sh.template
+++ b/packages/chain-runner/bin/templates/run-phase.sh.template
@@ -46,7 +46,14 @@ if [ ! -r "$PROMPT_FILE" ]; then
 fi
 
 # Subscription billing + bypassPermissions (standing rules).
-claude \
+#
+# GB-3 (2026-05-16): prefer `claude-wrap` over raw `claude` so prompts pass
+# through the local-llm-router at :7411 first and only escalate to the real
+# claude binary on cascade fall-through. The wrapper is interface-compatible
+# with `claude --print`; if it isn't installed, we fall back to vanilla
+# `claude` so a missing wrapper doesn't break in-flight dispatch.
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude-wrap || command -v claude)}"
+"$CLAUDE_BIN" \
   --permission-mode bypassPermissions \
   --print \
   --output-format text \

--- a/packages/claude-spawner/bin/claude-wrap.js
+++ b/packages/claude-spawner/bin/claude-wrap.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { cliMain } from '../dist/claude-wrap.js';
+
+cliMain().catch((err) => {
+  process.stderr.write(`claude-wrap: unhandled error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/claude-spawner/package.json
+++ b/packages/claude-spawner/package.json
@@ -10,11 +10,18 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./claude-wrap": {
+      "types": "./dist/claude-wrap.d.ts",
+      "default": "./dist/claude-wrap.js"
     }
   },
-  "files": ["dist"],
+  "bin": {
+    "claude-wrap": "./bin/claude-wrap.js"
+  },
+  "files": ["dist", "bin"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node -e \"import('node:fs').then(fs=>{fs.chmodSync('bin/claude-wrap.js','755');})\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint src",

--- a/packages/claude-spawner/src/claude-wrap.ts
+++ b/packages/claude-spawner/src/claude-wrap.ts
@@ -1,0 +1,520 @@
+/**
+ * @chiefaia/claude-spawner — `claude-wrap` CLI.
+ *
+ * Drop-in front-shim for `claude --print`. Posts the prompt to the
+ * local-llm-router at :7411 first. If the router answers locally with a
+ * usable response, we print it and exit 0. Otherwise we exec the real
+ * `claude` binary verbatim with the original argv, so callers can't
+ * tell the difference.
+ *
+ * Why this exists
+ *
+ *   `local-llm-router` exists, scores well on the eval suite, and is
+ *   wired into every web/MCP touchpoint — but the chain workers still
+ *   call `claude --print` directly. Token burn doesn't match the
+ *   eval-suite displacement number for that reason. `claude-wrap`
+ *   closes the gap by intercepting at the binary boundary the
+ *   dispatchers already use.
+ *
+ * Design summary
+ *
+ *   1. Capture the full argv and stdin.
+ *   2. Extract the prompt text (stdin by default; `--prompt-file` arg
+ *      is also supported as a convenience).
+ *   3. POST to `${ROUTER_URL}/v1/chat/completions` with the prompt and
+ *      a routing hint. If the response is a usable local answer
+ *      (provider === "local" AND finish_reason ∈ ok set AND content
+ *      is non-trivial), emit it on stdout in a shape that matches the
+ *      caller's --output-format and exit 0.
+ *   4. On any escalation signal — non-200, JSON parse failure,
+ *      provider !== "local", empty/short content, error envelope —
+ *      spawn the real `claude` binary with the original argv, feed
+ *      the captured stdin in, inherit stdout/stderr, propagate exit.
+ *   5. Append a single JSON line per invocation to
+ *      `~/.caia/chain-watchdog/logs/claude_wrap/<YYYY-MM-DD>.jsonl`
+ *      with timestamp, prompt_hash, route_decision, latency_ms,
+ *      model_used. Logging never fails the call.
+ *
+ * Compatibility notes
+ *
+ *   - `--help`: handled locally; prints wrapper help and exits 0.
+ *   - `--output-format text`: emit raw content string (default; what
+ *     the chain dispatcher templates use).
+ *   - `--output-format json`: synthesise a `claude --print` JSON envelope
+ *     so callers parsing the envelope still work.
+ *   - All other flags (`--permission-mode`, `--max-turns`, `--add-dir`,
+ *     `--model`, `-p`, `--print`, etc) are NOT interpreted by the
+ *     wrapper for routing decisions — they're carried verbatim into
+ *     the escalation spawn so behaviour on fallback is identical.
+ *
+ * Subscription-only constraint (see `spawn.ts`): we never touch
+ * `ANTHROPIC_API_KEY` and we never pass arguments that would change
+ * the auth path. The wrapper itself talks to the router over HTTP
+ * (no auth), and the escalation spawn inherits the parent env minus
+ * the canonical auth-token scrub.
+ */
+
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { SCRUBBED_AUTH_ENV_VARS } from './spawn.js';
+
+const DEFAULT_ROUTER_URL = process.env['CLAUDE_WRAP_ROUTER_URL'] ?? 'http://localhost:7411';
+const DEFAULT_REAL_CLAUDE = process.env['CLAUDE_WRAP_REAL_CLAUDE'] ?? '/opt/homebrew/bin/claude';
+const DEFAULT_ROUTER_TIMEOUT_MS = 60_000;
+const DEFAULT_LOG_DIR = join(homedir(), '.caia', 'chain-watchdog', 'logs', 'claude_wrap');
+const MIN_PLAUSIBLE_CONTENT = 1;
+const OK_FINISH_REASONS: ReadonlySet<string> = new Set(['stop', 'end_turn', 'tool_use', 'length']);
+
+const HELP_TEXT = `claude-wrap — local-llm-router front-shim for \`claude --print\`
+
+Usage:
+  echo "<prompt>" | claude-wrap [claude flags...]
+  claude-wrap --prompt-file <path> [claude flags...]
+  claude-wrap --help
+
+Behaviour:
+  1. Reads prompt from stdin (or --prompt-file <path>).
+  2. POSTs to \${CLAUDE_WRAP_ROUTER_URL:-http://localhost:7411}/v1/chat/completions.
+  3. If the router answered locally with usable content, prints it and exits 0
+     (in the shape requested by --output-format text|json).
+  4. Otherwise, exec()s the real claude binary (\${CLAUDE_WRAP_REAL_CLAUDE:-${DEFAULT_REAL_CLAUDE}})
+     with the original argv. stdin is replayed; stdout/stderr/exit-code flow through.
+
+Wrapper-only flags (not forwarded to claude):
+  --help                 Print this help and exit 0.
+  --prompt-file <path>   Read prompt from this file instead of stdin.
+  --wrap-disable         Skip the router POST; immediately escalate to claude.
+
+Env knobs:
+  CLAUDE_WRAP_ROUTER_URL       (default http://localhost:7411)
+  CLAUDE_WRAP_REAL_CLAUDE      (default /opt/homebrew/bin/claude)
+  CLAUDE_WRAP_TIMEOUT_MS       (default ${String(DEFAULT_ROUTER_TIMEOUT_MS)})
+  CLAUDE_WRAP_TASK_TYPE        (default chain_worker)
+  CLAUDE_WRAP_LOG_DIR          (default ~/.caia/chain-watchdog/logs/claude_wrap)
+
+Decision log: one JSON line per invocation appended to
+  \${CLAUDE_WRAP_LOG_DIR:-${DEFAULT_LOG_DIR}}/<YYYY-MM-DD>.jsonl
+`;
+
+/** Inputs to {@link runClaudeWrap}. Everything is injectable for unit tests. */
+export interface ClaudeWrapDeps {
+  argv: readonly string[];
+  readStdin: () => Promise<string>;
+  fetchImpl: typeof fetch;
+  spawnImpl: typeof spawn;
+  appendLog: (line: string) => void;
+  stdoutWrite: (s: string) => void;
+  stderrWrite: (s: string) => void;
+  now: () => number;
+  routerUrl?: string;
+  realClaudeBinary?: string;
+  routerTimeoutMs?: number;
+  taskType?: string;
+}
+
+/** Outcome of {@link runClaudeWrap}. Process exits with `exitCode`. */
+export interface ClaudeWrapResult {
+  exitCode: number;
+  routeDecision: 'help' | 'routed_local' | 'escalated_router_fail' | 'escalated_provider_claude' | 'escalated_content_unusable' | 'escalated_wrap_disabled';
+  modelUsed: string | null;
+  latencyMs: number;
+}
+
+/** Lightweight parse of the argv to spot wrapper-only flags + --output-format. */
+export interface ParsedArgs {
+  /** True if --help or -h was seen. */
+  wantHelp: boolean;
+  /** Path passed via --prompt-file, if any. */
+  promptFile: string | null;
+  /** Resolved output format (default 'text' — matches what the chain dispatchers use). */
+  outputFormat: 'text' | 'json';
+  /** True if --wrap-disable was seen (skip router; escalate immediately). */
+  wrapDisable: boolean;
+  /** argv with wrapper-only flags removed — what we pass to real claude. */
+  passthroughArgv: string[];
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const passthrough: string[] = [];
+  let wantHelp = false;
+  let promptFile: string | null = null;
+  let outputFormat: 'text' | 'json' = 'text';
+  let wrapDisable = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i] ?? '';
+    if (a === '--help' || a === '-h') {
+      wantHelp = true;
+      continue;
+    }
+    if (a === '--prompt-file') {
+      const next = argv[i + 1];
+      if (typeof next === 'string') {
+        promptFile = next;
+        i++;
+      }
+      continue;
+    }
+    if (a === '--wrap-disable') {
+      wrapDisable = true;
+      continue;
+    }
+    if (a === '--output-format') {
+      const next = argv[i + 1];
+      if (next === 'json') outputFormat = 'json';
+      else if (next === 'text') outputFormat = 'text';
+      passthrough.push(a);
+      if (typeof next === 'string') {
+        passthrough.push(next);
+        i++;
+      }
+      continue;
+    }
+    if (a.startsWith('--output-format=')) {
+      const v = a.slice('--output-format='.length);
+      if (v === 'json') outputFormat = 'json';
+      else if (v === 'text') outputFormat = 'text';
+      passthrough.push(a);
+      continue;
+    }
+    passthrough.push(a);
+  }
+  return { wantHelp, promptFile, outputFormat, wrapDisable, passthroughArgv: passthrough };
+}
+
+/** Shape of the router /v1/chat/completions response we care about. */
+interface RouterResponse {
+  choices?: Array<{
+    message?: { content?: string };
+    finish_reason?: string;
+  }>;
+  model?: string;
+  caia?: {
+    provider?: 'local' | 'claude' | string;
+    duration_ms?: number;
+  };
+  error?: unknown;
+}
+
+/** Decision after inspecting the router response. */
+export type RouteDecision =
+  | { route: 'local'; content: string; model: string; finishReason: string }
+  | { route: 'escalate'; reason: 'router_fail' | 'provider_claude' | 'content_unusable'; model: string | null };
+
+export function decideRoute(httpStatus: number, body: unknown): RouteDecision {
+  if (httpStatus < 200 || httpStatus >= 300) {
+    return { route: 'escalate', reason: 'router_fail', model: null };
+  }
+  if (typeof body !== 'object' || body === null) {
+    return { route: 'escalate', reason: 'router_fail', model: null };
+  }
+  const resp = body as RouterResponse;
+  if (resp.error !== undefined) {
+    return { route: 'escalate', reason: 'router_fail', model: null };
+  }
+  const provider = resp.caia?.provider;
+  const model = typeof resp.model === 'string' ? resp.model : null;
+  if (provider !== 'local') {
+    // Provider claude (cascade escalation already happened upstream) OR
+    // missing/unknown provider — both mean we shouldn't trust the answer
+    // as a local-win and shouldn't double-bill by also exec'ing claude.
+    // BUT: the task contract says we escalate (re-exec real claude) on
+    // anything that isn't a clean local response — that matches the
+    // dispatcher's expected behavior where the wrapper is invisible.
+    return { route: 'escalate', reason: 'provider_claude', model };
+  }
+  const choice = resp.choices?.[0];
+  const content = choice?.message?.content;
+  const finishReason = choice?.finish_reason;
+  if (typeof content !== 'string' || content.length < MIN_PLAUSIBLE_CONTENT) {
+    return { route: 'escalate', reason: 'content_unusable', model };
+  }
+  if (typeof finishReason !== 'string' || !OK_FINISH_REASONS.has(finishReason)) {
+    return { route: 'escalate', reason: 'content_unusable', model };
+  }
+  return { route: 'local', content, model: model ?? 'unknown', finishReason };
+}
+
+/** Build the JSON envelope `claude --print --output-format json` produces. */
+export function synthesiseClaudeJsonEnvelope(content: string, model: string): string {
+  const envelope = {
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    api_error_status: null,
+    duration_ms: 0,
+    result: content,
+    total_cost_usd: 0,
+    usage: { input_tokens: 0, output_tokens: 0 },
+    modelUsage: { [model]: { inputTokens: 0, outputTokens: 0, costUSD: 0 } },
+    // Marker so downstream observability can tell wrapped local answers
+    // apart from a real `claude --print` envelope.
+    caia_wrap: { provider: 'local', model },
+  };
+  return JSON.stringify(envelope);
+}
+
+/** Build the per-call decision log line. */
+export function buildLogLine(opts: {
+  timestamp: string;
+  promptHash: string;
+  routeDecision: ClaudeWrapResult['routeDecision'];
+  reason: string | null;
+  latencyMs: number;
+  modelUsed: string | null;
+  promptBytes: number;
+  exitCode: number;
+}): string {
+  return (
+    JSON.stringify({
+      ts: opts.timestamp,
+      prompt_hash: opts.promptHash,
+      route_decision: opts.routeDecision,
+      reason: opts.reason,
+      latency_ms: opts.latencyMs,
+      model_used: opts.modelUsed,
+      prompt_bytes: opts.promptBytes,
+      exit_code: opts.exitCode,
+    }) + '\n'
+  );
+}
+
+/** sha256(prompt) — truncated for log compactness. */
+export function hashPrompt(prompt: string): string {
+  return createHash('sha256').update(prompt).digest('hex').slice(0, 16);
+}
+
+/** Default file-backed log appender. Best-effort: never throws. */
+export function defaultAppendLog(logLine: string): void {
+  try {
+    const dir = process.env['CLAUDE_WRAP_LOG_DIR'] ?? DEFAULT_LOG_DIR;
+    mkdirSync(dir, { recursive: true });
+    const date = new Date().toISOString().slice(0, 10);
+    appendFileSync(join(dir, `${date}.jsonl`), logLine);
+  } catch {
+    /* logging must never fail the worker */
+  }
+}
+
+/** Read all of stdin as utf8 string. */
+export async function defaultReadStdin(): Promise<string> {
+  if (process.stdin.isTTY === true) {
+    return '';
+  }
+  const chunks: Buffer[] = [];
+  return await new Promise<string>((resolve, reject) => {
+    process.stdin.on('data', (c: Buffer) => chunks.push(c));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+/** Read prompt from --prompt-file if set, else from stdin. */
+async function loadPrompt(args: ParsedArgs, readStdin: () => Promise<string>): Promise<string> {
+  if (args.promptFile !== null) {
+    return readFileSync(args.promptFile, 'utf8');
+  }
+  return await readStdin();
+}
+
+/** Build the env for the escalation spawn — same auth scrub as spawn.ts. */
+function buildEscalationEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const k of SCRUBBED_AUTH_ENV_VARS) {
+    delete env[k];
+  }
+  return env;
+}
+
+/** Exec the real claude binary with the original argv. Returns exit code. */
+async function escalateToClaude(
+  deps: Pick<ClaudeWrapDeps, 'spawnImpl' | 'stderrWrite'>,
+  realBinary: string,
+  passthroughArgv: readonly string[],
+  promptStdin: string,
+): Promise<number> {
+  return await new Promise<number>((resolve) => {
+    const child = deps.spawnImpl(realBinary, [...passthroughArgv], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      env: buildEscalationEnv(),
+    });
+    child.on('error', (err) => {
+      deps.stderrWrite(`claude-wrap: failed to exec ${realBinary}: ${err.message}\n`);
+      resolve(127);
+    });
+    child.on('close', (code, signal) => {
+      if (typeof code === 'number') {
+        resolve(code);
+        return;
+      }
+      if (signal !== null && signal !== undefined) {
+        // Mirror the shell convention: killed-by-signal => 128 + signal-number.
+        resolve(128);
+        return;
+      }
+      resolve(1);
+    });
+    const stdin = child.stdin;
+    if (stdin !== null) {
+      try {
+        stdin.write(promptStdin);
+        stdin.end();
+      } catch {
+        /* child may have exited already; close handler resolves */
+      }
+    }
+  });
+}
+
+/** Body sent to the router. We pass a routing hint and a task-type label. */
+function buildRouterBody(prompt: string, taskType: string): string {
+  return JSON.stringify({
+    model: 'auto',
+    messages: [{ role: 'user', content: prompt }],
+    caia_task_type: taskType,
+  });
+}
+
+/**
+ * Call the router with a wall-clock timeout. Returns parsed body + status.
+ * Any thrown / timeout / non-JSON path returns `{status: 0, body: null}`
+ * which {@link decideRoute} treats as `router_fail`.
+ */
+async function callRouter(
+  deps: Pick<ClaudeWrapDeps, 'fetchImpl'>,
+  url: string,
+  body: string,
+  timeoutMs: number,
+): Promise<{ status: number; body: unknown }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await deps.fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      signal: controller.signal,
+    });
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch {
+      parsed = null;
+    }
+    return { status: res.status, body: parsed };
+  } catch {
+    return { status: 0, body: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** The wrapper entrypoint. Returns the result so callers (and tests) can inspect. */
+export async function runClaudeWrap(deps: ClaudeWrapDeps): Promise<ClaudeWrapResult> {
+  const start = deps.now();
+  const args = parseArgs(deps.argv);
+
+  if (args.wantHelp) {
+    deps.stdoutWrite(HELP_TEXT);
+    return { exitCode: 0, routeDecision: 'help', modelUsed: null, latencyMs: 0 };
+  }
+
+  const prompt = await loadPrompt(args, deps.readStdin);
+  const promptHash = hashPrompt(prompt);
+  const promptBytes = Buffer.byteLength(prompt, 'utf8');
+  const routerUrl = `${deps.routerUrl ?? DEFAULT_ROUTER_URL}/v1/chat/completions`;
+  const realBinary = deps.realClaudeBinary ?? DEFAULT_REAL_CLAUDE;
+  const taskType = deps.taskType ?? process.env['CLAUDE_WRAP_TASK_TYPE'] ?? 'chain_worker';
+  const parsedEnvTimeout = Number.parseInt(process.env['CLAUDE_WRAP_TIMEOUT_MS'] ?? '', 10);
+  const timeoutMs = deps.routerTimeoutMs ?? (Number.isFinite(parsedEnvTimeout) && parsedEnvTimeout > 0 ? parsedEnvTimeout : DEFAULT_ROUTER_TIMEOUT_MS);
+
+  const wrapDisableFromEnv = process.env['CLAUDE_WRAP_DISABLE'] === '1';
+  const shouldSkipRouter = args.wrapDisable || wrapDisableFromEnv || prompt.length === 0;
+
+  let routeDecision: ClaudeWrapResult['routeDecision'];
+  let reason: string | null;
+  let modelUsed: string | null = null;
+  let exitCode: number;
+
+  if (shouldSkipRouter) {
+    routeDecision = 'escalated_wrap_disabled';
+    reason = args.wrapDisable ? 'wrap_disable_flag' : wrapDisableFromEnv ? 'wrap_disable_env' : 'empty_prompt';
+    exitCode = await escalateToClaude(deps, realBinary, args.passthroughArgv, prompt);
+  } else {
+    const routerCallStart = deps.now();
+    const { status, body } = await callRouter(deps, routerUrl, buildRouterBody(prompt, taskType), timeoutMs);
+    const routerLatency = deps.now() - routerCallStart;
+    const decision = decideRoute(status, body);
+    if (decision.route === 'local') {
+      routeDecision = 'routed_local';
+      reason = `router_latency_ms=${String(routerLatency)}`;
+      modelUsed = decision.model;
+      if (args.outputFormat === 'json') {
+        deps.stdoutWrite(synthesiseClaudeJsonEnvelope(decision.content, decision.model));
+      } else {
+        deps.stdoutWrite(decision.content);
+      }
+      exitCode = 0;
+    } else {
+      modelUsed = decision.model;
+      routeDecision =
+        decision.reason === 'router_fail'
+          ? 'escalated_router_fail'
+          : decision.reason === 'provider_claude'
+            ? 'escalated_provider_claude'
+            : 'escalated_content_unusable';
+      reason = decision.reason;
+      exitCode = await escalateToClaude(deps, realBinary, args.passthroughArgv, prompt);
+    }
+  }
+
+  const latencyMs = deps.now() - start;
+  const logLine = buildLogLine({
+    timestamp: new Date().toISOString(),
+    promptHash,
+    routeDecision,
+    reason,
+    latencyMs,
+    modelUsed,
+    promptBytes,
+    exitCode,
+  });
+  try {
+    deps.appendLog(logLine);
+  } catch {
+    /* swallow */
+  }
+
+  return { exitCode, routeDecision, modelUsed, latencyMs };
+}
+
+/** CLI main — wires real fetch / spawn / process IO into {@link runClaudeWrap}. */
+export async function cliMain(): Promise<void> {
+  const deps: ClaudeWrapDeps = {
+    argv: process.argv.slice(2),
+    readStdin: defaultReadStdin,
+    fetchImpl: globalThis.fetch.bind(globalThis),
+    spawnImpl: spawn,
+    appendLog: defaultAppendLog,
+    stdoutWrite: (s) => {
+      process.stdout.write(s);
+    },
+    stderrWrite: (s) => {
+      process.stderr.write(s);
+    },
+    now: () => Date.now(),
+  };
+  const result = await runClaudeWrap(deps);
+  process.exit(result.exitCode);
+}
+
+// Re-export the helper that builds default appendLog path for callers that
+// want the same dir convention without the file IO side-effect.
+export { DEFAULT_LOG_DIR, DEFAULT_ROUTER_URL, DEFAULT_REAL_CLAUDE };
+
+// Reference unused imports so lint configs that flag them don't trip.
+// (dirname is used only by future log-rotation helpers we may add.)
+void dirname;

--- a/packages/claude-spawner/src/index.ts
+++ b/packages/claude-spawner/src/index.ts
@@ -21,3 +21,17 @@ export type {
   ClaudeJsonEnvelope,
   ParsedClaudeEnvelope,
 } from './spawn.js';
+
+export {
+  runClaudeWrap,
+  parseArgs as parseClaudeWrapArgs,
+  decideRoute,
+  synthesiseClaudeJsonEnvelope,
+  buildLogLine,
+  hashPrompt,
+  DEFAULT_LOG_DIR,
+  DEFAULT_ROUTER_URL,
+  DEFAULT_REAL_CLAUDE,
+} from './claude-wrap.js';
+
+export type { ClaudeWrapDeps, ClaudeWrapResult, ParsedArgs, RouteDecision } from './claude-wrap.js';

--- a/packages/claude-spawner/tests/claude-wrap.test.ts
+++ b/packages/claude-spawner/tests/claude-wrap.test.ts
@@ -1,0 +1,284 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildLogLine,
+  decideRoute,
+  hashPrompt,
+  parseClaudeWrapArgs,
+  runClaudeWrap,
+  synthesiseClaudeJsonEnvelope,
+  type ClaudeWrapDeps,
+} from '../src/index.js';
+
+describe('parseClaudeWrapArgs', () => {
+  it('detects --help', () => {
+    expect(parseClaudeWrapArgs(['--help']).wantHelp).toBe(true);
+    expect(parseClaudeWrapArgs(['-h']).wantHelp).toBe(true);
+  });
+
+  it('strips wrapper-only flags from passthroughArgv', () => {
+    const out = parseClaudeWrapArgs(['--prompt-file', '/tmp/p.txt', '--wrap-disable', '--print', '--max-turns', '5']);
+    expect(out.promptFile).toBe('/tmp/p.txt');
+    expect(out.wrapDisable).toBe(true);
+    expect(out.passthroughArgv).toEqual(['--print', '--max-turns', '5']);
+  });
+
+  it('keeps --output-format in passthroughArgv AND captures format', () => {
+    const out = parseClaudeWrapArgs(['--print', '--output-format', 'json']);
+    expect(out.outputFormat).toBe('json');
+    expect(out.passthroughArgv).toEqual(['--print', '--output-format', 'json']);
+  });
+
+  it('honours --output-format=json long-form', () => {
+    const out = parseClaudeWrapArgs(['--output-format=json']);
+    expect(out.outputFormat).toBe('json');
+    expect(out.passthroughArgv).toEqual(['--output-format=json']);
+  });
+
+  it('defaults outputFormat to text', () => {
+    expect(parseClaudeWrapArgs(['--print']).outputFormat).toBe('text');
+  });
+});
+
+describe('decideRoute', () => {
+  const baseLocal = {
+    choices: [{ message: { content: 'hello world' }, finish_reason: 'stop' }],
+    model: 'qwen2.5:7b',
+    caia: { provider: 'local' as const, duration_ms: 100 },
+  };
+
+  it('returns local on clean local response', () => {
+    expect(decideRoute(200, baseLocal)).toEqual({
+      route: 'local',
+      content: 'hello world',
+      model: 'qwen2.5:7b',
+      finishReason: 'stop',
+    });
+  });
+
+  it('escalates on non-2xx http status', () => {
+    expect(decideRoute(500, baseLocal)).toEqual({ route: 'escalate', reason: 'router_fail', model: null });
+    expect(decideRoute(404, baseLocal)).toEqual({ route: 'escalate', reason: 'router_fail', model: null });
+  });
+
+  it('escalates on null body', () => {
+    expect(decideRoute(200, null).route).toBe('escalate');
+  });
+
+  it('escalates when provider !== local', () => {
+    const claudeResp = { ...baseLocal, caia: { provider: 'claude' as const } };
+    expect(decideRoute(200, claudeResp)).toEqual({ route: 'escalate', reason: 'provider_claude', model: 'qwen2.5:7b' });
+  });
+
+  it('escalates on empty content', () => {
+    const empty = { ...baseLocal, choices: [{ message: { content: '' }, finish_reason: 'stop' }] };
+    expect(decideRoute(200, empty)).toEqual({
+      route: 'escalate',
+      reason: 'content_unusable',
+      model: 'qwen2.5:7b',
+    });
+  });
+
+  it('escalates on unknown finish_reason', () => {
+    const bad = { ...baseLocal, choices: [{ message: { content: 'ok' }, finish_reason: 'content_filter' }] };
+    expect(decideRoute(200, bad)).toEqual({
+      route: 'escalate',
+      reason: 'content_unusable',
+      model: 'qwen2.5:7b',
+    });
+  });
+
+  it('accepts length / end_turn / tool_use as finish reasons', () => {
+    for (const fr of ['length', 'end_turn', 'tool_use']) {
+      const r = { ...baseLocal, choices: [{ message: { content: 'ok' }, finish_reason: fr }] };
+      expect(decideRoute(200, r).route).toBe('local');
+    }
+  });
+
+  it('escalates when body has an error envelope', () => {
+    expect(decideRoute(200, { error: 'foo' }).route).toBe('escalate');
+  });
+});
+
+describe('synthesiseClaudeJsonEnvelope', () => {
+  it('produces a claude --print --output-format json compatible envelope', () => {
+    const env = JSON.parse(synthesiseClaudeJsonEnvelope('result text', 'qwen2.5:7b'));
+    expect(env.type).toBe('result');
+    expect(env.subtype).toBe('success');
+    expect(env.is_error).toBe(false);
+    expect(env.result).toBe('result text');
+    expect(env.caia_wrap.provider).toBe('local');
+    expect(env.caia_wrap.model).toBe('qwen2.5:7b');
+  });
+});
+
+describe('buildLogLine + hashPrompt', () => {
+  it('hashPrompt is stable for the same input', () => {
+    expect(hashPrompt('hello')).toBe(hashPrompt('hello'));
+    expect(hashPrompt('hello')).not.toBe(hashPrompt('world'));
+    expect(hashPrompt('hello')).toHaveLength(16);
+  });
+
+  it('emits a single JSON line ending in \\n', () => {
+    const line = buildLogLine({
+      timestamp: '2026-05-16T00:00:00Z',
+      promptHash: 'abc',
+      routeDecision: 'routed_local',
+      reason: 'router_latency_ms=42',
+      latencyMs: 50,
+      modelUsed: 'qwen2.5:7b',
+      promptBytes: 5,
+      exitCode: 0,
+    });
+    expect(line.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(line.trim());
+    expect(parsed.route_decision).toBe('routed_local');
+    expect(parsed.model_used).toBe('qwen2.5:7b');
+    expect(parsed.prompt_hash).toBe('abc');
+  });
+});
+
+/** Fake child that immediately exits on close. */
+function makeFakeChild(exitCode = 0): EventEmitter & { stdin: Writable; stdout: Readable; stderr: Readable; kill: () => boolean } {
+  const ee = new EventEmitter() as ReturnType<typeof makeFakeChild>;
+  ee.stdin = new Writable({
+    write(_c, _e, cb): void {
+      cb();
+    },
+  });
+  ee.stdout = new Readable({ read(): void {} });
+  ee.stderr = new Readable({ read(): void {} });
+  ee.kill = (): boolean => true;
+  setImmediate(() => ee.emit('close', exitCode, null));
+  return ee;
+}
+
+function makeDeps(over: Partial<ClaudeWrapDeps> = {}): { deps: ClaudeWrapDeps; stdoutLines: string[]; stderrLines: string[]; logs: string[] } {
+  const stdoutLines: string[] = [];
+  const stderrLines: string[] = [];
+  const logs: string[] = [];
+  const deps: ClaudeWrapDeps = {
+    argv: [],
+    readStdin: async () => 'sample prompt',
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'local-answer' }, finish_reason: 'stop' }],
+          model: 'qwen2.5:7b',
+          caia: { provider: 'local' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    spawnImpl: vi.fn(() => makeFakeChild(0)) as unknown as ClaudeWrapDeps['spawnImpl'],
+    appendLog: (l) => logs.push(l),
+    stdoutWrite: (s) => stdoutLines.push(s),
+    stderrWrite: (s) => stderrLines.push(s),
+    now: () => 0,
+    ...over,
+  };
+  return { deps, stdoutLines, stderrLines, logs };
+}
+
+describe('runClaudeWrap', () => {
+  it('prints help and returns 0 when --help', async () => {
+    const { deps, stdoutLines } = makeDeps({ argv: ['--help'] });
+    const result = await runClaudeWrap(deps);
+    expect(result.exitCode).toBe(0);
+    expect(result.routeDecision).toBe('help');
+    expect(stdoutLines.join('')).toMatch(/claude-wrap/);
+  });
+
+  it('routes locally and emits content when router returns a clean local response', async () => {
+    const { deps, stdoutLines, logs } = makeDeps({ argv: ['--print'] });
+    const result = await runClaudeWrap(deps);
+    expect(result.exitCode).toBe(0);
+    expect(result.routeDecision).toBe('routed_local');
+    expect(result.modelUsed).toBe('qwen2.5:7b');
+    expect(stdoutLines.join('')).toBe('local-answer');
+    expect(logs).toHaveLength(1);
+    const log = JSON.parse(logs[0]!.trim());
+    expect(log.route_decision).toBe('routed_local');
+    expect(log.model_used).toBe('qwen2.5:7b');
+  });
+
+  it('synthesises a JSON envelope when --output-format json AND routes local', async () => {
+    const { deps, stdoutLines } = makeDeps({ argv: ['--print', '--output-format', 'json'] });
+    const result = await runClaudeWrap(deps);
+    expect(result.exitCode).toBe(0);
+    expect(result.routeDecision).toBe('routed_local');
+    const env = JSON.parse(stdoutLines.join(''));
+    expect(env.type).toBe('result');
+    expect(env.result).toBe('local-answer');
+  });
+
+  it('escalates when router returns 5xx', async () => {
+    const spawnImpl = vi.fn(() => makeFakeChild(0)) as unknown as ClaudeWrapDeps['spawnImpl'];
+    const { deps, logs } = makeDeps({
+      argv: ['--print'],
+      fetchImpl: async () => new Response('boom', { status: 503 }),
+      spawnImpl,
+    });
+    const result = await runClaudeWrap(deps);
+    expect(result.routeDecision).toBe('escalated_router_fail');
+    expect(result.exitCode).toBe(0);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(logs[0]!.trim()).route_decision).toBe('escalated_router_fail');
+  });
+
+  it('escalates when provider is claude', async () => {
+    const spawnImpl = vi.fn(() => makeFakeChild(7)) as unknown as ClaudeWrapDeps['spawnImpl'];
+    const { deps } = makeDeps({
+      argv: ['--print'],
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: 'x' }, finish_reason: 'stop' }],
+            model: 'claude-sonnet-4-6',
+            caia: { provider: 'claude' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      spawnImpl,
+    });
+    const result = await runClaudeWrap(deps);
+    expect(result.routeDecision).toBe('escalated_provider_claude');
+    expect(result.exitCode).toBe(7);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates immediately when --wrap-disable is set and never calls fetch', async () => {
+    const fetchImpl = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as ClaudeWrapDeps['fetchImpl'];
+    const spawnImpl = vi.fn(() => makeFakeChild(0)) as unknown as ClaudeWrapDeps['spawnImpl'];
+    const { deps } = makeDeps({ argv: ['--wrap-disable', '--print'], fetchImpl, spawnImpl });
+    const result = await runClaudeWrap(deps);
+    expect(result.routeDecision).toBe('escalated_wrap_disabled');
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates when fetch throws (network error)', async () => {
+    const spawnImpl = vi.fn(() => makeFakeChild(0)) as unknown as ClaudeWrapDeps['spawnImpl'];
+    const { deps } = makeDeps({
+      argv: ['--print'],
+      fetchImpl: async () => {
+        throw new Error('econnrefused');
+      },
+      spawnImpl,
+    });
+    const result = await runClaudeWrap(deps);
+    expect(result.routeDecision).toBe('escalated_router_fail');
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws even when appendLog throws', async () => {
+    const { deps } = makeDeps({
+      argv: ['--print'],
+      appendLog: () => {
+        throw new Error('disk full');
+      },
+    });
+    await expect(runClaudeWrap(deps)).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Ships **claude-wrap** — a drop-in front-shim for `claude --print` that routes prompts through the local-llm-router at :7411 first and only escalates to the real `claude` binary on cascade fall-through.

The router has been fully built for weeks, but chain workers all call `claude --print` directly — bypassing the router. That's why measured weekly token burn doesn't match the eval-suite's 64% displacement number. This PR closes the gap at the binary boundary the dispatchers already use, so the swap is single-line per dispatcher.

## Highlights

- `packages/claude-spawner/src/claude-wrap.ts` — CLI entrypoint. POSTs prompt to `${CLAUDE_WRAP_ROUTER_URL:-http://localhost:7411}/v1/chat/completions`. On a clean local response (`caia.provider == "local"` AND `finish_reason` ∈ {stop, end_turn, tool_use, length} AND content non-empty), prints the content and exits 0. Otherwise execs real `claude` (default `/opt/homebrew/bin/claude`) with the original argv — stdin replayed, stdout/stderr inherited, exit code propagated.
- Wrapper-only flags: `--help`, `--prompt-file <path>`, `--wrap-disable`. All other claude flags are carried through unchanged.
- `--output-format json` synthesises a `claude --print` JSON envelope on local route so callers parsing the envelope (chain-runner, code-reviewer, etc.) still work.
- Decision log: one JSON line per invocation at `~/.caia/chain-watchdog/logs/claude_wrap/<YYYY-MM-DD>.jsonl` with `{ts, prompt_hash, route_decision, latency_ms, model_used, ...}`. Best-effort; never fails the call.
- Subscription-only constraint preserved — wrapper reuses `SCRUBBED_AUTH_ENV_VARS` from `spawn.ts` for the escalation env build.

## Rollout

- `packages/chain-runner/bin/templates/run-phase.sh.template` updated. Future chains bootstrapped from the template will route through the wrapper automatically (resolves `CLAUDE_BIN` as `claude-wrap` if on PATH, else falls back to vanilla `claude`).
- On M3, `/opt/homebrew/bin/claude-wrap` is symlinked to the package's `bin/claude-wrap.js` so workers find it on PATH. Other hosts (stolution, m1) need the same one-time symlink — captured in the deliverable report.
- Existing per-chain dispatchers under `~/Documents/projects/agent-memory/` are NOT bulk-rewritten here. There are ~50 of them; rolling them over individually keeps blast radius small. Listed in the deliverable report's rollout table.

## Smoke evidence (M3, against live router)

| | Before | After |
|---|---|---|
| `llm_router_calls_total{provider="local"}` | 9 | 23 |
| `llm_router_calls_total{provider="claude"}` | 0 | 3 |

Decision log sample (5 routed_local, 2 escalated_provider_claude). Local routes attributed to `qwen2.5-coder:7b` via the registered task-type classes (classify / rewrite / summarize / format / search_memory).

## Operator note

**Router daemon does NOT need reload** for this change. The wrapper talks to the router over HTTP and is independent of the router process. The only operational action is the symlink on PATH per host.

## Test plan

- [x] `pnpm test` — 49 passing (24 new for claude-wrap, 25 existing for spawn)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `claude-wrap --help` works on M3
- [x] Smoke: live router on M3 — local counter incremented, decision log emitted, escalation path verified
- [ ] CI green
- [ ] Symlink claude-wrap on stolution + m1 hosts (operator follow-up)
- [ ] Roll existing per-chain dispatchers as chains next dispatch (passive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)