### PR TITLE
fix(local-llm-router): rr-2 close intent-vocab gap (complex-review, unknown)

### DIFF
--- a/packages/local-llm-router/src/routing-config.ts
+++ b/packages/local-llm-router/src/routing-config.ts
@@ -773,6 +773,51 @@ export const ROUTING_RULES: RoutingRule[] = [
     estimatedCostLocal: '$0.00',
     estimatedCostClaude: '$0.20',
   },
+
+  // ─── RR-2 (2026-05-16) — intent-vocab gap closers ────────────────────────
+  // Two classifier-v2 intents (`complex-review`, `unknown`) were defined in
+  // src/classifier.ts INTENT_VALUES + config/routing-rules.yaml but had no
+  // ROUTING_RULES entry. getRoute() therefore returned its unknown-task
+  // default (qwen2.5-coder:7b, useLocal:true) for both — the same silent
+  // tier-collapse pattern that B1 fixed for the 36 other intents. RR-2
+  // closes the gap so every classifier output now has an explicit rule.
+  //
+  // complex-review → stolution-batch (per YAML + classifier system prompt
+  //   tier guidance). The tier_models block in routing-rules.yaml further
+  //   pins this intent to llama3.3:70b when the batch dispatch path lands;
+  //   until then the rule follows the same 14B-fallback + Claude-fallback
+  //   shape as the other stolution-batch intents (batch-summarize etc).
+  // unknown → claude (per YAML + classifier system prompt: "intent='unknown'
+  //   means abstain / out-of-vocab / adversarial — escalate"). useLocal:false
+  //   ensures the dispatcher does NOT silently serve 7b for the abstain
+  //   bucket, which is exactly the displacement-bias smoking gun captured
+  //   in router_unknown_task_type_default_local.md.
+  {
+    taskType: 'complex-review',
+    description:
+      'classifier-v2 intent: deep multi-file review at stolution-batch tier. ' +
+      'Cascade tier=stolution-batch — Claude fallback until batch dispatch lands.',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
+  {
+    taskType: 'unknown',
+    description:
+      'classifier-v2 abstain bucket — intent could not be classified ' +
+      '(low confidence, adversarial, out-of-vocab). Escalates to Claude so ' +
+      'the displacement metric reflects the honest cost of the abstain path ' +
+      'instead of silently routing to local-7b (RR-2 fix, 2026-05-16).',
+    localModel: 'qwen2.5-coder:14b',
+    claudeModel: 'claude-sonnet-4-6',
+    useLocal: false,
+    maxTokens: 8000,
+    estimatedCostLocal: '$0.00',
+    estimatedCostClaude: '$2.00',
+  },
 ];
 
 // ─── B1 (2026-05-15) — tier-routing invariants ───────────────────────────

--- a/packages/local-llm-router/tests/routing-config.test.ts
+++ b/packages/local-llm-router/tests/routing-config.test.ts
@@ -9,6 +9,7 @@ import {
   TIER_EXPECTATIONS,
   verifyTierRouting,
 } from '../src/routing-config.js';
+import { INTENT_VALUES } from '../src/classifier.js';
 import { getModel } from '../src/model-catalog.js';
 
 describe('routing-config', () => {
@@ -171,8 +172,12 @@ describe('routing-config', () => {
       const intents = loadIntentsFromYaml();
       // Sanity: YAML parsed something (drift guard).
       expect(intents.length).toBeGreaterThan(20);
+      // RR-2 (2026-05-16): `unknown` used to be excluded here because it had
+      // no routing rule and the dispatcher fell through to qwen2.5-coder:7b.
+      // That fall-through *was* the displacement-bias bug — closing the gap
+      // means `unknown` is now a first-class taskType (default_tier=claude)
+      // and the filter is no longer needed.
       const missing = intents
-        .filter((i) => i.name !== 'unknown') // `unknown` is the fall-through, not a real intent
         .filter((i) => ROUTING_RULES.find((r) => r.taskType === i.name) === undefined);
       expect(
         missing,
@@ -182,7 +187,7 @@ describe('routing-config', () => {
     });
 
     it('verifyTierRouting() returns no violations for the current taxonomy', () => {
-      const intents = loadIntentsFromYaml().filter((i) => i.name !== 'unknown');
+      const intents = loadIntentsFromYaml();
       const violations = verifyTierRouting(intents);
       // Format the failure message so a regression names the exact intent
       // and the model it silently collapsed to.
@@ -260,6 +265,59 @@ describe('routing-config', () => {
             `verifyTierRouting() will silently skip it`,
         ).toBeDefined();
       }
+    });
+  });
+
+  describe('RR-2 intent-vocab gap closure (2026-05-16)', () => {
+    // Asserts every entry in classifier.ts INTENT_VALUES has a corresponding
+    // ROUTING_RULES entry. This is the structural invariant the RR-2 fix
+    // institutionalises: when the classifier emits an intent name, the
+    // dispatcher MUST find a registered rule for it. The pre-RR-2 bug was
+    // that `complex-review` + `unknown` were in INTENT_VALUES but absent
+    // from ROUTING_RULES, so getRoute() returned its unknown-task default
+    // (qwen2.5-coder:7b, useLocal:true) — silently routing the abstain
+    // bucket + the heaviest review intent to local-7b. That same gap can
+    // re-open any time a new intent is added to classifier.ts without a
+    // matching ROUTING_RULES entry; this test fails when it does.
+    it('every INTENT_VALUES entry has a ROUTING_RULES rule', () => {
+      const taskTypes = new Set(ROUTING_RULES.map((r) => r.taskType));
+      const missing = INTENT_VALUES.filter((intent) => !taskTypes.has(intent));
+      expect(
+        missing,
+        `INTENT_VALUES entries missing from ROUTING_RULES (silent tier-collapse risk): ` +
+          missing.join(', '),
+      ).toEqual([]);
+    });
+
+    it('complex-review routes to claude fallback (stolution-batch tier, useLocal:false)', () => {
+      const rule = ROUTING_RULES.find((r) => r.taskType === 'complex-review');
+      expect(rule, 'complex-review rule missing — RR-2 regression').toBeDefined();
+      expect(rule?.useLocal).toBe(false);
+      expect(rule?.claudeModel).toBeDefined();
+      // Matches TIER_EXPECTATIONS['stolution-batch'].
+      expect(rule?.localModel).toBe('qwen2.5-coder:14b');
+    });
+
+    it('unknown abstain bucket routes to claude (not silent local-7b)', () => {
+      const rule = ROUTING_RULES.find((r) => r.taskType === 'unknown');
+      expect(rule, 'unknown rule missing — RR-2 regression').toBeDefined();
+      // The displacement-bias smoking gun: the abstain bucket MUST NOT
+      // silently serve qwen2.5-coder:7b. useLocal:false escalates to Claude
+      // so /metrics reflects the honest cost of the abstain path.
+      expect(rule?.useLocal).toBe(false);
+      expect(rule?.claudeModel).toBeDefined();
+      expect(rule?.localModel).toBe('qwen2.5-coder:14b');
+    });
+
+    it('classifier-emitted `unknown` no longer falls through to the unknown-task default', () => {
+      // Pre-RR-2: getRoute('unknown') returned the unknown-task fallback
+      //   (qwen2.5-coder:7b, useLocal:true).
+      // Post-RR-2: getRoute('unknown') resolves the explicit rule above.
+      const rule = getRoute('unknown');
+      expect(rule.taskType).toBe('unknown');
+      expect(rule.useLocal).toBe(false);
+      expect(rule.localModel).toBe('qwen2.5-coder:14b');
+      expect(rule.description).not.toMatch(/Unknown task type/i);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes the silent tier-collapse gap left in [B1 (#469)](https://github.com/prakashgbid/caia/pull/469) — two classifier-v2 intents (`complex-review`, `unknown`) were defined in `src/classifier.ts` `INTENT_VALUES` + `config/routing-rules.yaml` but had no `ROUTING_RULES` entry, so `getRoute()` returned the unknown-task default (qwen2.5-coder:7b, useLocal:true) for both. RR-2 closes the gap with explicit rules + a structural invariant test.

- **complex-review** — heaviest review intent (whole-codebase / multi-file reviews). YAML pins it to `stolution-batch`; rule now matches `TIER_EXPECTATIONS['stolution-batch']` (qwen2.5-coder:14b, useLocal:false, claude-sonnet-4-6 fallback).
- **unknown** — abstain bucket (low confidence / adversarial / out-of-vocab). YAML pins it to `claude`; rule routes useLocal:false → Claude so /metrics reflects the honest cost of the abstain path instead of silently logging local-7b. This is the displacement-bias smoking gun captured in [router_unknown_task_type_default_local.md](https://github.com/prakashgbid/caia/blob/develop/) (memory).
- Removed the `i.name !== 'unknown'` filter from the two existing routing-config tests (`unknown` is now first-class) and added a new RR-2 describe block:
  1. every \`INTENT_VALUES\` entry has a \`ROUTING_RULES\` rule (catches drift on either side).
  2. `complex-review` routes useLocal:false / qwen2.5-coder:14b.
  3. `unknown` routes useLocal:false / qwen2.5-coder:14b (description no longer the \"Unknown task type\" default).

## ROUTER-DAEMON-RELOAD-REQUIRED

This change is dark until the daemon is reloaded:

\`\`\`
launchctl kickstart -k gui/\$(id -u)/com.chiefaia.local-llm-router
\`\`\`

## Before / after smoke (live daemon, /v1/route)

Before fix:

\`\`\`json
{\"task_type\":\"complex-review\",\"has_routing_rule\":false,\"recommended_tier\":\"local-7b\",\"intent\":\"code-review\"...}
{\"task_type\":\"unknown\",\"has_routing_rule\":false,\"recommended_tier\":\"claude\",\"intent\":\"unknown\"...}
\`\`\`

After fix + daemon reload (expected):

\`\`\`
has_routing_rule: true for both
useLocal: false for both
\`\`\`

## Test plan

- [x] \`pnpm test routing-config router-policy\` — 33/33 pass (4 new RR-2 tests)
- [x] \`pnpm build\` — clean (after sibling \`@chiefaia/prompt-optimizer\` / \`librarian\` / \`mentor-retrieval\` build, same as develop)
- [ ] Post-merge: \`launchctl kickstart -k gui/\$(id -u)/com.chiefaia.local-llm-router\` then re-run the before-smoke commands; expect \`has_routing_rule: true\` on both
- [ ] Watch \`tail -f ~/Library/Logs/chiefaia/local-llm-router.err.log\` for \`[router] dispatch intent=complex-review ... rule=registered\` instead of \`rule=unregistered\` after a classifier-v2 fires

## Background

This is the RR-2 phase of the \`sps-rr2-intent-vocab-fix\` chain. The upstream \`m1-router-high-bugs-design\` design chain stalled with a spawner 401 ~1.5h before this worker fired, so this PR ships the obvious-from-the-evidence fix rather than waiting for the (non-arriving) design doc. The gap is mechanically reproducible from the three vocabularies (\`classifier.ts INTENT_VALUES\` ∪ \`routing-rules.yaml intents\`) ∖ \`ROUTING_RULES.taskType\` = \`{complex-review, unknown}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)