### PR TITLE
fix(local-llm-router): RR-3 cold-start timeout — per-model warm tracking + /admin/warmup

### DIFF
--- a/packages/local-llm-router/src/bin/router-daemon.ts
+++ b/packages/local-llm-router/src/bin/router-daemon.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 
 import { serve } from '@hono/node-server';
 import { buildApp, DEFAULT_ROUTER_PORT } from '../server.js';
+import { getRouterOllamaAdapter } from '../router.js';
 
 // Phase A2 --health-check shortcut. The post-merge gate (A1) invokes
 // `<bin> --health-check` after `launchctl kickstart` and expects exit 0
@@ -100,6 +101,32 @@ serve({ fetch: app.fetch, port, hostname: '0.0.0.0' }, (info) => {
   console.log(`caia-llm-router-daemon listening on http://${info.address}:${info.port}`);
   console.log(`  ollama_url=${args.ollamaUrl ?? process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434'}`);
   console.log(`  classifier_model=${args.classifierModel ?? process.env['ROUTER_CLASSIFIER_MODEL'] ?? 'qwen2.5-coder:7b'}`);
+
+  // RR-3 (2026-05-16): daemon-start async warmup. Comma-separated list of
+  // ollama tags in env ROUTER_WARMUP_MODELS gets fired-and-forgotten as
+  // soon as the listener is up. We do NOT await — the daemon stays
+  // responsive while warmup happens in the background. Per-model failures
+  // are logged but never crash the daemon (a missing weight should be an
+  // operator alert, not a service outage).
+  const warmupRaw = process.env['ROUTER_WARMUP_MODELS'] ?? '';
+  const warmupModels = warmupRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+  if (warmupModels.length > 0) {
+    const adapter = getRouterOllamaAdapter();
+    console.log(`[router] daemon-start warmup queued for: ${warmupModels.join(', ')}`);
+    for (const model of warmupModels) {
+      adapter
+        .warmup(model)
+        .then(({ warmedMs }) => {
+          console.log(`[router] daemon-start warmup ok model=${model} warmed_ms=${warmedMs}`);
+        })
+        .catch((err: Error) => {
+          console.warn(`[router] daemon-start warmup FAILED model=${model} error=${err.message}`);
+        });
+    }
+  }
 });
 
 // Graceful exit handlers

--- a/packages/local-llm-router/src/ollama-adapter.ts
+++ b/packages/local-llm-router/src/ollama-adapter.ts
@@ -29,16 +29,77 @@ const OLLAMA_BASE_URL =
  */
 const OLLAMA_KEEP_ALIVE = process.env['OLLAMA_KEEP_ALIVE'] ?? '10m';
 
+// RR-3 (2026-05-16) — cold-start timeout budget.
+//
+// Bug: cross-host cold-start failure rate was 80% with the historical 10 s
+// caller budget and dropped to 0% at 60 s. Root cause is Ollama's
+// model-load latency — qwen2.5-coder:14b alone takes ~12 s on M1 Pro the
+// first time it's pulled into VRAM after an idle period; 32b/70b models
+// can take 30-45 s. The adapter previously applied a flat 180 s ceiling,
+// but callers above it (canonical-suite-v2, prompt-optimizer Stage 2/3,
+// MCP shims) set their own 10–30 s socket timeouts so the round-trip was
+// killed long before Ollama's spinning-up reply landed.
+//
+// Fix: track per-model warm state inside the adapter and split the
+// outbound `fetch` timeout into a *cold* budget (default 60 s — the
+// observed 0%-failure point) and a *warm* budget (default 30 s — covers
+// generation time on a loaded model with comfortable headroom).
+// Successful generate / chat calls mark the model warm; explicit
+// `warmup()` / `POST /admin/warmup` does the same without serving a
+// real prompt. Warm state TTL matches keep_alive (10 min default).
+const COLD_TIMEOUT_MS = numericEnv('ROUTER_OLLAMA_COLD_TIMEOUT_MS', 60_000);
+const WARM_TIMEOUT_MS = numericEnv('ROUTER_OLLAMA_WARM_TIMEOUT_MS', 30_000);
+const WARM_TTL_MS = numericEnv('ROUTER_OLLAMA_WARM_TTL_MS', 600_000);
+
+function numericEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export interface OllamaAdapterOptions {
+  baseUrl?: string;
+  keepAlive?: string;
+  /** Cold-start request timeout, ms. Defaults to ROUTER_OLLAMA_COLD_TIMEOUT_MS or 60s. */
+  coldTimeoutMs?: number;
+  /** Warm-model request timeout, ms. Defaults to ROUTER_OLLAMA_WARM_TIMEOUT_MS or 30s. */
+  warmTimeoutMs?: number;
+  /** How long a model stays "warm" after last successful use, ms. Defaults to 10 min. */
+  warmTtlMs?: number;
+  /** Test seam: clock function returning epoch ms. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
 export class OllamaAdapter {
   private readonly baseUrl: string;
   private readonly keepAlive: string;
+  private readonly coldTimeoutMs: number;
+  private readonly warmTimeoutMs: number;
+  private readonly warmTtlMs: number;
+  private readonly now: () => number;
+  /** model tag → epoch-ms of last successful request (or warmup) */
+  private readonly warmAt: Map<string, number> = new Map();
 
   constructor(
-    baseUrl: string = OLLAMA_BASE_URL,
+    baseUrlOrOptions: string | OllamaAdapterOptions = OLLAMA_BASE_URL,
     keepAlive: string = OLLAMA_KEEP_ALIVE,
   ) {
-    this.baseUrl = baseUrl;
-    this.keepAlive = keepAlive;
+    if (typeof baseUrlOrOptions === 'string') {
+      this.baseUrl = baseUrlOrOptions;
+      this.keepAlive = keepAlive;
+      this.coldTimeoutMs = COLD_TIMEOUT_MS;
+      this.warmTimeoutMs = WARM_TIMEOUT_MS;
+      this.warmTtlMs = WARM_TTL_MS;
+      this.now = Date.now;
+    } else {
+      this.baseUrl = baseUrlOrOptions.baseUrl ?? OLLAMA_BASE_URL;
+      this.keepAlive = baseUrlOrOptions.keepAlive ?? OLLAMA_KEEP_ALIVE;
+      this.coldTimeoutMs = baseUrlOrOptions.coldTimeoutMs ?? COLD_TIMEOUT_MS;
+      this.warmTimeoutMs = baseUrlOrOptions.warmTimeoutMs ?? WARM_TIMEOUT_MS;
+      this.warmTtlMs = baseUrlOrOptions.warmTtlMs ?? WARM_TTL_MS;
+      this.now = baseUrlOrOptions.now ?? Date.now;
+    }
   }
 
   /**
@@ -53,6 +114,51 @@ export class OllamaAdapter {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * RR-3 — returns true when the adapter has a fresh (≤warmTtlMs) success
+   * recorded for `model`. The router uses this in /admin/warmup responses
+   * and tests assert on it directly.
+   */
+  isModelWarm(model: string): boolean {
+    const ts = this.warmAt.get(model);
+    if (ts === undefined) return false;
+    return this.now() - ts <= this.warmTtlMs;
+  }
+
+  /**
+   * RR-3 — list of currently-warm model tags, freshest first. Snapshot;
+   * caller may mutate freely.
+   */
+  getWarmModels(): string[] {
+    const cutoff = this.now() - this.warmTtlMs;
+    return [...this.warmAt.entries()]
+      .filter(([, ts]) => ts >= cutoff)
+      .sort((a, b) => b[1] - a[1])
+      .map(([m]) => m);
+  }
+
+  /**
+   * RR-3 — explicitly warm a model. Posts a zero-prompt `/api/generate`
+   * with the configured keep_alive so Ollama loads the weights into VRAM
+   * but doesn't burn tokens on a synthetic prompt. On success the model
+   * is marked warm; the next `generate()` call will use the warm-timeout
+   * budget. Failure throws (so the operator/admin endpoint can surface
+   * it). Always uses the cold-timeout budget.
+   */
+  async warmup(model: string): Promise<{ model: string; warmedMs: number }> {
+    const start = this.now();
+    const body: OllamaGenerateRequest = {
+      model,
+      prompt: '',
+      stream: false,
+      keep_alive: this.keepAlive,
+      options: { temperature: 0 },
+    };
+    await this.postJson('/api/generate', body, this.coldTimeoutMs);
+    this.markWarm(model);
+    return { model, warmedMs: this.now() - start };
   }
 
   /**
@@ -86,7 +192,7 @@ export class OllamaAdapter {
     model: string,
     request: LLMRequest,
   ): Promise<LLMResponse> {
-    const start = Date.now();
+    const start = this.now();
 
     const body: OllamaGenerateRequest = {
       model,
@@ -100,14 +206,15 @@ export class OllamaAdapter {
       },
     };
 
-    const res = await this.postJson('/api/generate', body);
+    const res = await this.postJson('/api/generate', body, this.timeoutFor(model));
     const data = (await res.json()) as OllamaGenerateResponse;
 
+    this.markWarm(model);
     return {
       response: data.response,
       model: data.model,
       provider: 'local',
-      durationMs: Date.now() - start,
+      durationMs: this.now() - start,
       usage: this.usageFrom(data.prompt_eval_count, data.eval_count),
     };
   }
@@ -116,7 +223,7 @@ export class OllamaAdapter {
     model: string,
     request: LLMRequest,
   ): Promise<LLMResponse> {
-    const start = Date.now();
+    const start = this.now();
 
     const body: OllamaChatRequest = {
       model,
@@ -137,27 +244,38 @@ export class OllamaAdapter {
       },
     };
 
-    const res = await this.postJson('/api/chat', body);
+    const res = await this.postJson('/api/chat', body, this.timeoutFor(model));
     const data = (await res.json()) as OllamaChatResponse;
 
+    this.markWarm(model);
     return {
       response: data.message?.content ?? '',
       model: data.model,
       provider: 'local',
-      durationMs: Date.now() - start,
+      durationMs: this.now() - start,
       usage: this.usageFrom(data.prompt_eval_count, data.eval_count),
     };
   }
 
-  private async postJson(path: string, body: unknown): Promise<Response> {
+  private timeoutFor(model: string): number {
+    return this.isModelWarm(model) ? this.warmTimeoutMs : this.coldTimeoutMs;
+  }
+
+  private markWarm(model: string): void {
+    this.warmAt.set(model, this.now());
+  }
+
+  private async postJson(path: string, body: unknown, timeoutMs: number): Promise<Response> {
     let res: Response;
     try {
       res = await fetch(`${this.baseUrl}${path}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-        // 3-minute hard timeout — large models can be slow on first load
-        signal: AbortSignal.timeout(180_000),
+        // RR-3 — cold vs warm budget. Cold (default 60 s) covers Ollama
+        // model-load on M1 Pro; warm (default 30 s) covers generation
+        // time on an already-loaded model.
+        signal: AbortSignal.timeout(timeoutMs),
       });
     } catch (err) {
       throw new Error(

--- a/packages/local-llm-router/src/router.ts
+++ b/packages/local-llm-router/src/router.ts
@@ -74,6 +74,18 @@ function getOllama(): OllamaAdapter {
   return _ollama;
 }
 
+/**
+ * RR-3 (2026-05-16): expose the router's singleton OllamaAdapter so the
+ * HTTP daemon's /admin/warmup endpoint and the daemon-start prewarm hook
+ * touch the same warm-state Map that real /v1/chat/completions dispatch
+ * reads. Returning the singleton (not a fresh instance) is load-bearing:
+ * a separate adapter would have its own warmAt map and the warmup
+ * wouldn't actually affect production timeouts.
+ */
+export function getRouterOllamaAdapter(): OllamaAdapter {
+  return getOllama();
+}
+
 function getClaude(): ClaudeAdapter {
   _claude ??= new ClaudeAdapter();
   return _claude;

--- a/packages/local-llm-router/src/server.ts
+++ b/packages/local-llm-router/src/server.ts
@@ -20,7 +20,7 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { optimize } from '@chiefaia/prompt-optimizer';
-import { route as routerRoute } from './router.js';
+import { route as routerRoute, getRouterOllamaAdapter } from './router.js';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { classify, type IntentResult as _IntentResultRef } from './classifier.js';
 import { classifyV2, loadRoutingRules } from './classifier-v2.js';
@@ -468,6 +468,70 @@ export function buildApp(opts: ServerOptions = {}): Hono {
     } catch (e) {
       return c.json({ error: 'optimize-failed', message: (e as Error).message }, 500);
     }
+  });
+
+  // ─── /admin/warmup (RR-3 — cold-start mitigation) ────────────────────
+  // POST body: { models: string[] }  → warm each tag, returns per-model status.
+  //            { model: string }     → single-tag convenience form.
+  //            (omitted)              → no-op; returns the currently-warm set.
+  //
+  // The endpoint touches the SAME OllamaAdapter singleton that /v1/chat/completions
+  // uses (via getRouterOllamaAdapter), so subsequent /v1/chat/completions calls to
+  // a freshly-warmed tag get the warm-timeout budget (default 30 s) instead of the
+  // cold one (60 s). On failure a per-model `error` is returned but the request
+  // doesn't 500 — partial warmup is still useful to the caller.
+  app.post('/admin/warmup', async (c: Context) => {
+    let body: { models?: string[]; model?: string } | undefined;
+    try {
+      const raw = await c.req.text();
+      body = raw === '' ? undefined : (JSON.parse(raw) as { models?: string[]; model?: string });
+    } catch {
+      return c.json({ error: 'invalid-json' }, 400);
+    }
+
+    const adapter = getRouterOllamaAdapter();
+
+    const requested: string[] = (() => {
+      if (body === undefined) return [];
+      if (Array.isArray(body.models)) {
+        return body.models.filter(m => typeof m === 'string' && m.length > 0);
+      }
+      if (typeof body.model === 'string' && body.model.length > 0) {
+        return [body.model];
+      }
+      return [];
+    })();
+
+    if (requested.length === 0) {
+      return c.json({
+        warmed: [],
+        already_warm: adapter.getWarmModels(),
+        currently_warm: adapter.getWarmModels(),
+      });
+    }
+
+    const results = await Promise.all(
+      requested.map(async (model) => {
+        if (adapter.isModelWarm(model)) {
+          return { model, status: 'already_warm' as const, warmed_ms: 0 };
+        }
+        try {
+          const { warmedMs } = await adapter.warmup(model);
+          return { model, status: 'warmed' as const, warmed_ms: warmedMs };
+        } catch (e) {
+          return {
+            model,
+            status: 'error' as const,
+            error: (e as Error).message,
+          };
+        }
+      }),
+    );
+
+    return c.json({
+      results,
+      currently_warm: adapter.getWarmModels(),
+    });
   });
 
   // ─── /v1/embeddings (OpenAI-compatible) ──────────────────────────────

--- a/packages/local-llm-router/tests/ollama-adapter-warmup.test.ts
+++ b/packages/local-llm-router/tests/ollama-adapter-warmup.test.ts
@@ -1,0 +1,406 @@
+// RR-3 (2026-05-16) — cold-start timeout fix tests.
+//
+// What's covered:
+//   - Per-model is_warm tracking (Map<string, lastUsedAt>).
+//   - Cold-vs-warm timeout budget selection in postJson.
+//   - warmup() explicit pre-load; success marks warm, failure does NOT.
+//   - Successful generate() / chat() marks the model warm.
+//   - Warm TTL expiry transitions a model back to cold.
+//   - getWarmModels() snapshot ordered by freshness.
+//
+// Test seam: OllamaAdapter accepts a `now()` clock and we spy on
+// AbortSignal.timeout to capture which budget was passed for each call.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OllamaAdapter } from '../src/ollama-adapter.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ABORT_TIMEOUT = AbortSignal.timeout.bind(AbortSignal);
+
+interface CapturedCall {
+  url: string;
+  body: Record<string, unknown>;
+  timeoutMs: number | undefined;
+}
+
+function mockFetchAndCaptureTimeout(
+  responses: Record<string, () => unknown>,
+  captured: CapturedCall[],
+): void {
+  // Capture which timeout AbortSignal.timeout was called with by snapshotting
+  // the most recent argument before each fetch resolves.
+  let lastTimeoutMs: number | undefined;
+  AbortSignal.timeout = ((ms: number): AbortSignal => {
+    lastTimeoutMs = ms;
+    return ORIGINAL_ABORT_TIMEOUT(ms);
+  }) as typeof AbortSignal.timeout;
+
+  globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    const body =
+      typeof init?.body === 'string'
+        ? (JSON.parse(init.body) as Record<string, unknown>)
+        : {};
+    captured.push({ url, body, timeoutMs: lastTimeoutMs });
+    lastTimeoutMs = undefined;
+
+    const path = new URL(url).pathname;
+    const handler = responses[path];
+    if (!handler) {
+      return new Response('not mocked', { status: 500 });
+    }
+    return {
+      ok: true,
+      json: async () => handler(),
+    } as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe('OllamaAdapter — RR-3 cold-start timeout', () => {
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    AbortSignal.timeout = ORIGINAL_ABORT_TIMEOUT as typeof AbortSignal.timeout;
+    vi.restoreAllMocks();
+  });
+
+  it('isModelWarm returns false for a never-seen model', () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    expect(adapter.isModelWarm('qwen2.5-coder:14b')).toBe(false);
+    expect(adapter.getWarmModels()).toEqual([]);
+  });
+
+  it('first generate() call uses the cold-timeout budget', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:14b',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      coldTimeoutMs: 60_000,
+      warmTimeoutMs: 30_000,
+    });
+    await adapter.generate('qwen2.5-coder:14b', {
+      taskType: 'medium-code',
+      prompt: 'hi',
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.timeoutMs).toBe(60_000);
+    // The successful call marked the model warm.
+    expect(adapter.isModelWarm('qwen2.5-coder:14b')).toBe(true);
+  });
+
+  it('second generate() call on a warm model uses the warm-timeout budget', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:14b',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      coldTimeoutMs: 60_000,
+      warmTimeoutMs: 30_000,
+    });
+    await adapter.generate('qwen2.5-coder:14b', {
+      taskType: 'medium-code',
+      prompt: 'hi',
+    });
+    await adapter.generate('qwen2.5-coder:14b', {
+      taskType: 'medium-code',
+      prompt: 'hi again',
+    });
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0]!.timeoutMs).toBe(60_000);
+    expect(captured[1]!.timeoutMs).toBe(30_000);
+  });
+
+  it('warm state expires after warmTtlMs and the next call is cold again', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:14b',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    let clock = 1_000_000;
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      coldTimeoutMs: 60_000,
+      warmTimeoutMs: 30_000,
+      warmTtlMs: 60_000, // 1-min TTL for the test
+      now: () => clock,
+    });
+
+    await adapter.generate('qwen2.5-coder:14b', {
+      taskType: 'medium-code',
+      prompt: 'first',
+    });
+    expect(captured[0]!.timeoutMs).toBe(60_000);
+    expect(adapter.isModelWarm('qwen2.5-coder:14b')).toBe(true);
+
+    // Advance 90 s — past the TTL.
+    clock += 90_000;
+    expect(adapter.isModelWarm('qwen2.5-coder:14b')).toBe(false);
+
+    await adapter.generate('qwen2.5-coder:14b', {
+      taskType: 'medium-code',
+      prompt: 'second',
+    });
+    // Stale warm record → cold budget again.
+    expect(captured[1]!.timeoutMs).toBe(60_000);
+  });
+
+  it('warmup() POSTs zero-prompt /api/generate with keep_alive and marks the model warm', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:14b',
+          response: '',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      keepAlive: '12m',
+      coldTimeoutMs: 60_000,
+      warmTimeoutMs: 30_000,
+    });
+    const result = await adapter.warmup('qwen2.5-coder:14b');
+
+    expect(result.model).toBe('qwen2.5-coder:14b');
+    expect(result.warmedMs).toBeGreaterThanOrEqual(0);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.url).toBe('http://localhost:11434/api/generate');
+    expect(captured[0]!.body['prompt']).toBe('');
+    expect(captured[0]!.body['keep_alive']).toBe('12m');
+    // Warmup always uses cold-timeout budget.
+    expect(captured[0]!.timeoutMs).toBe(60_000);
+    expect(adapter.isModelWarm('qwen2.5-coder:14b')).toBe(true);
+  });
+
+  it('warmup() throws on Ollama error and does NOT mark the model warm', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => 'model not found',
+    } as Response)) as unknown as typeof globalThis.fetch;
+
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    await expect(adapter.warmup('does-not-exist:99b')).rejects.toThrow(
+      /Ollama API error 500/,
+    );
+    expect(adapter.isModelWarm('does-not-exist:99b')).toBe(false);
+  });
+
+  it('getWarmModels() returns freshly-warmed models ordered by recency', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'mock',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    let clock = 1_000_000;
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      now: () => clock,
+    });
+    await adapter.warmup('qwen2.5-coder:7b');
+    clock += 1_000;
+    await adapter.warmup('qwen2.5-coder:14b');
+    clock += 1_000;
+    await adapter.warmup('qwen2.5-coder:32b');
+
+    expect(adapter.getWarmModels()).toEqual([
+      'qwen2.5-coder:32b', // freshest first
+      'qwen2.5-coder:14b',
+      'qwen2.5-coder:7b',
+    ]);
+  });
+
+  it('chat-mode generate (qwen3 family) also marks the model warm', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/chat': () => ({
+          model: 'qwen3:14b',
+          message: { role: 'assistant', content: 'ok' },
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    await adapter.generate('qwen3:14b', {
+      taskType: 'classify',
+      prompt: 'hi',
+    });
+
+    expect(adapter.isModelWarm('qwen3:14b')).toBe(true);
+  });
+
+  it('different models do not share warm state', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'mock',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      coldTimeoutMs: 60_000,
+      warmTimeoutMs: 30_000,
+    });
+    await adapter.generate('qwen2.5-coder:7b', {
+      taskType: 'classify',
+      prompt: 'hi',
+    });
+
+    expect(adapter.isModelWarm('qwen2.5-coder:7b')).toBe(true);
+    expect(adapter.isModelWarm('qwen2.5-coder:14b')).toBe(false);
+
+    await adapter.generate('qwen2.5-coder:14b', {
+      taskType: 'medium-code',
+      prompt: 'hi',
+    });
+    // qwen2.5-coder:14b was COLD even though qwen2.5-coder:7b is warm.
+    expect(captured[1]!.timeoutMs).toBe(60_000);
+  });
+
+  it('reads timeout budgets from env when no options are supplied (string ctor)', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:7b',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const origCold = process.env['ROUTER_OLLAMA_COLD_TIMEOUT_MS'];
+    const origWarm = process.env['ROUTER_OLLAMA_WARM_TIMEOUT_MS'];
+    try {
+      // Re-import the module so the module-scope numericEnv() re-runs.
+      // Easier: just verify the default cold path (string ctor uses module
+      // constants).
+      const adapter = new OllamaAdapter('http://localhost:11434');
+      await adapter.generate('qwen2.5-coder:7b', {
+        taskType: 'classify',
+        prompt: 'hi',
+      });
+      // Default cold budget = 60 s.
+      expect(captured[0]!.timeoutMs).toBe(60_000);
+    } finally {
+      if (origCold !== undefined) process.env['ROUTER_OLLAMA_COLD_TIMEOUT_MS'] = origCold;
+      if (origWarm !== undefined) process.env['ROUTER_OLLAMA_WARM_TIMEOUT_MS'] = origWarm;
+    }
+  });
+
+  it('warmup is a no-op result shape when called twice in a row (second is already_warm via /admin/warmup logic, but adapter.warmup itself always re-pings)', async () => {
+    // This test pins the adapter contract: warmup() ALWAYS hits Ollama.
+    // The "skip if already warm" optimization lives in the HTTP handler so
+    // operators can force a refresh on demand by calling warmup() directly.
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:7b',
+          response: '',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    await adapter.warmup('qwen2.5-coder:7b');
+    await adapter.warmup('qwen2.5-coder:7b');
+    expect(captured).toHaveLength(2);
+  });
+
+  it('options-form constructor sets keepAlive correctly', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/generate': () => ({
+          model: 'qwen2.5-coder:7b',
+          response: 'ok',
+          done: true,
+        }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      keepAlive: '42m',
+    });
+    await adapter.generate('qwen2.5-coder:7b', {
+      taskType: 'classify',
+      prompt: 'hi',
+    });
+
+    expect(captured[0]!.body['keep_alive']).toBe('42m');
+  });
+
+  it('isAvailable still uses a fixed 2 s probe timeout regardless of warm state', async () => {
+    const captured: CapturedCall[] = [];
+    mockFetchAndCaptureTimeout(
+      {
+        '/api/tags': () => ({ models: [] }),
+      },
+      captured,
+    );
+
+    const adapter = new OllamaAdapter({
+      baseUrl: 'http://localhost:11434',
+      coldTimeoutMs: 60_000,
+      warmTimeoutMs: 30_000,
+    });
+    await adapter.isAvailable();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.url).toBe('http://localhost:11434/api/tags');
+    expect(captured[0]!.timeoutMs).toBe(2_000);
+  });
+});

--- a/packages/local-llm-router/tests/server-warmup.test.ts
+++ b/packages/local-llm-router/tests/server-warmup.test.ts
@@ -1,0 +1,204 @@
+// RR-3 (2026-05-16) — /admin/warmup endpoint tests.
+//
+// Mounts the Hono app via buildApp() and exercises the endpoint against the
+// router-singleton OllamaAdapter (wired via __setAdapters). We don't talk to
+// a real Ollama; the adapter's fetch is mocked.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { buildApp } from '../src/server.js';
+import { __setAdapters } from '../src/router.js';
+import { OllamaAdapter } from '../src/ollama-adapter.js';
+import type { ClaudeAdapter } from '../src/claude-adapter.js';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function fakeClaude(): ClaudeAdapter {
+  return {
+    generate: vi.fn(),
+  } as unknown as ClaudeAdapter;
+}
+
+describe('/admin/warmup', () => {
+  beforeEach(() => {
+    __setAdapters(null, null);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    __setAdapters(null, null);
+    vi.restoreAllMocks();
+  });
+
+  it('with no body, returns the currently-warm set without calling ollama', async () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    __setAdapters(adapter, fakeClaude());
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('should not call ollama for no-op warmup');
+    }) as unknown as typeof globalThis.fetch;
+
+    const app = buildApp();
+    const res = await app.request('/admin/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      warmed?: string[];
+      currently_warm?: string[];
+    };
+    expect(body.warmed).toEqual([]);
+    expect(body.currently_warm).toEqual([]);
+  });
+
+  it('warms each requested model and reports per-model status', async () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    __setAdapters(adapter, fakeClaude());
+
+    globalThis.fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        json: async () => ({ model: 'mock', response: '', done: true }),
+      } as Response;
+    }) as unknown as typeof globalThis.fetch;
+
+    const app = buildApp();
+    const res = await app.request('/admin/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        models: ['qwen2.5-coder:7b', 'qwen2.5-coder:14b'],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ model: string; status: string }>;
+      currently_warm: string[];
+    };
+    expect(body.results).toHaveLength(2);
+    expect(body.results.map(r => r.status)).toEqual(['warmed', 'warmed']);
+    expect(body.currently_warm).toContain('qwen2.5-coder:7b');
+    expect(body.currently_warm).toContain('qwen2.5-coder:14b');
+  });
+
+  it('reports already_warm for models that are already warm', async () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    __setAdapters(adapter, fakeClaude());
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ model: 'mock', response: '', done: true }),
+    } as Response)) as unknown as typeof globalThis.fetch;
+
+    // Pre-warm one of the models.
+    await adapter.warmup('qwen2.5-coder:7b');
+    const fetchCallsAfterPrewarm = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    const app = buildApp();
+    const res = await app.request('/admin/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        models: ['qwen2.5-coder:7b', 'qwen2.5-coder:14b'],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ model: string; status: string }>;
+    };
+    const byModel = Object.fromEntries(body.results.map(r => [r.model, r.status]));
+    expect(byModel['qwen2.5-coder:7b']).toBe('already_warm');
+    expect(byModel['qwen2.5-coder:14b']).toBe('warmed');
+
+    // Only ONE additional fetch should have happened (for qwen2.5-coder:14b).
+    const fetchCallsAfter = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(fetchCallsAfter - fetchCallsAfterPrewarm).toBe(1);
+  });
+
+  it('supports the single-model convenience form (body.model)', async () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    __setAdapters(adapter, fakeClaude());
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ model: 'mock', response: '', done: true }),
+    } as Response)) as unknown as typeof globalThis.fetch;
+
+    const app = buildApp();
+    const res = await app.request('/admin/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'qwen2.5-coder:32b' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ model: string; status: string }>;
+    };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]!.model).toBe('qwen2.5-coder:32b');
+    expect(body.results[0]!.status).toBe('warmed');
+  });
+
+  it('returns error status per model on Ollama failure, without 500-ing the request', async () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    __setAdapters(adapter, fakeClaude());
+
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          json: async () => ({ model: 'mock', response: '', done: true }),
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 500,
+        text: async () => 'model not found',
+      } as Response;
+    }) as unknown as typeof globalThis.fetch;
+
+    const app = buildApp();
+    const res = await app.request('/admin/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        models: ['qwen2.5-coder:7b', 'does-not-exist:99b'],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ model: string; status: string; error?: string }>;
+      currently_warm: string[];
+    };
+    const byModel = Object.fromEntries(body.results.map(r => [r.model, r]));
+    expect(byModel['qwen2.5-coder:7b']!.status).toBe('warmed');
+    expect(byModel['does-not-exist:99b']!.status).toBe('error');
+    expect(byModel['does-not-exist:99b']!.error).toMatch(/Ollama API error 500/);
+    // Only the successful model appears in currently_warm.
+    expect(body.currently_warm).toContain('qwen2.5-coder:7b');
+    expect(body.currently_warm).not.toContain('does-not-exist:99b');
+  });
+
+  it('400s on invalid JSON', async () => {
+    const adapter = new OllamaAdapter({ baseUrl: 'http://localhost:11434' });
+    __setAdapters(adapter, fakeClaude());
+
+    const app = buildApp();
+    const res = await app.request('/admin/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json {{{',
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('invalid-json');
+  });
+});


### PR DESCRIPTION
## Summary

Implements RR-3 from the m1-router-high-bugs-design backlog (HIGH severity).

- Cross-host cold-start failure rate was **80% at 10 s caller budget; 0% at 60 s** because Ollama's model-load can take 12–45 s and the adapter's flat 180 s ceiling was larger than every caller's socket timeout above it (canonical-suite-v2 30 s, prompt-optimizer 10 s, MCP shims 10–30 s) — so the round-trip got killed before Ollama's reply landed.
- Fix is three coordinated changes inside the router daemon:
  1. **Per-model warm tracking** inside `OllamaAdapter` — a `Map<model, lastUsedAt>` populated on every successful generate/chat/warmup, expiring after `ROUTER_OLLAMA_WARM_TTL_MS` (default 10 min).
  2. **Split per-call timeout budget** — `ROUTER_OLLAMA_COLD_TIMEOUT_MS` (default 60 s, the 0%-failure point) for first/expired calls, `ROUTER_OLLAMA_WARM_TIMEOUT_MS` (default 30 s) for warm calls. Replaces the prior flat 180 s ceiling so the budget is actually load-bearing.
  3. **`POST /admin/warmup` endpoint + daemon-start prewarm** — endpoint accepts `{models: string[]}` or `{model: string}` and returns `warmed | already_warm | error` per model. `ROUTER_WARMUP_MODELS=<csv>` env var fires async warmups at daemon boot (failures logged, never crashes the daemon).

## ROUTER-DAEMON-RELOAD-REQUIRED

This fix is dark until the running daemon picks up the new bin/dist. After merge, the post-merge gate (`com.chiefaia.local-llm-router` LaunchAgent) will kickstart automatically; for manual reload:

\`\`\`
launchctl kickstart -k gui/\$(id -u)/com.chiefaia.local-llm-router
\`\`\`

After kickstart, verify the new endpoint:
\`\`\`
curl -sS http://127.0.0.1:7411/admin/warmup -X POST -H 'content-type: application/json' \\
  -d '{\"models\": [\"qwen2.5-coder:7b\", \"qwen2.5-coder:14b\"]}' | jq .
\`\`\`

To enable daemon-start prewarm, add to `~/Library/LaunchAgents/com.chiefaia.local-llm-router.plist`:
\`\`\`xml
<key>EnvironmentVariables</key>
<dict>
  <key>ROUTER_WARMUP_MODELS</key>
  <string>qwen2.5-coder:7b,qwen2.5-coder:14b</string>
</dict>
\`\`\`

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm vitest run tests/ollama-adapter-warmup.test.ts tests/server-warmup.test.ts\` — **19/19 pass**
  - 13 cases: per-model warm tracking, cold-vs-warm budget selection (asserted via \`AbortSignal.timeout\` spy), TTL expiry, warmup() success + failure semantics, chat-mode path, per-model isolation, env-default budget, isAvailable() unaffected.
  - 6 cases: \`/admin/warmup\` HTTP — no-body returns currently-warm; multi-model warmup; \`already_warm\` short-circuit; single-model \`body.model\` form; per-model error reporting without 500-ing; invalid-JSON 400.
- [x] Existing \`ollama-adapter.test.ts\` (10) + \`router.test.ts\` (20) — **30/30 pass** (no regression).
- [ ] Post-merge: live smoke — \`launchctl kickstart\` daemon, POST /admin/warmup with the 7b+14b set, then \`/v1/chat/completions\` cold-call qwen2.5-coder:14b and verify <60 s latency on the first request from a fresh boot. The canonical-suite-v2 re-run (\`sps-canonical-eval-rerun-postfix\` chain) will validate displacement-floor recovery.

Pre-existing test failures unchanged from develop: 1 live-Ollama integration test (needs \`ollama serve\`), 2 routing-config \`complex-review\` rule-coverage assertions (regression from GB-12, unrelated to RR-3).

## Backward compatibility

\`OllamaAdapter\` ctor still accepts the \`(baseUrl, keepAlive)\` positional form used by all existing callers. The new options-object form layers in \`coldTimeoutMs\` / \`warmTimeoutMs\` / \`warmTtlMs\` / \`now\` (test seam). No public API broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)