### PR TITLE
chiefaia.com: scaffold Next.js app skeleton

### DIFF
--- a/apps/chiefaia-site/.gitignore
+++ b/apps/chiefaia-site/.gitignore
@@ -1,0 +1,28 @@
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# next.js
+.next
+out
+
+# production
+build
+dist
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# typescript
+*.tsbuildinfo

--- a/apps/chiefaia-site/README.md
+++ b/apps/chiefaia-site/README.md
@@ -1,0 +1,69 @@
+# @caia-app/chiefaia-site
+
+Public-facing marketing site for CAIA (Chief AI Agent) — served at
+**www.chiefaia.com**.
+
+## Status
+
+**Scaffold only.** Pages are intentional placeholders until the operator
+confirms which mockups in `apps/website-mockups/` are final. The scaffold
+exists so the deploy plumbing (DNS, SSL, CI, hosting) can be wired up in
+parallel with content sign-off.
+
+## Deploy target
+
+**Cloudflare Pages** (free tier). Picked over Vercel hobby and Caddy-on-stolution
+because (a) zero ongoing $, (b) unmetered bandwidth, (c) free SSL via universal
+cert, (d) per-PR preview deployments, (e) instant rollback, (f) edge-fast, and
+(g) no servers for ops to babysit. See
+`~/Documents/projects/agent-memory/decisions/chiefaia_deploy_runbook_2026_05_16.md`.
+
+Build command: `pnpm --filter @caia-app/chiefaia-site build`
+Output dir: `apps/chiefaia-site/.next`
+
+## Routes
+
+| Route | File | Mockup source |
+| --- | --- | --- |
+| `/` | `app/page.tsx` | `apps/website-mockups/home.html` |
+| `/architecture` | `app/architecture/page.tsx` | `apps/website-mockups/architecture.html` |
+| `/packages` | `app/packages/page.tsx` | `apps/website-mockups/packages.html` |
+| `/login` | `app/login/page.tsx` | `apps/website-mockups/login.html` |
+| `/dashboard-preview` | `app/dashboard-preview/page.tsx` | `apps/website-mockups/dashboard-preview.html` |
+
+> The spec asked for `app/(dashboard-preview)/page.tsx` (route group), but route
+> groups don't add URL segments in Next.js App Router — that would collide with
+> the home page. Using a regular segment `/dashboard-preview` instead.
+
+## Relationship to website-mockups
+
+The mockups in `apps/website-mockups/` are high-fidelity HTML+Tailwind-CDN
+prototypes (PR #489). They are NOT imported at runtime — each Next.js page is
+an empty stub. When the operator approves a mockup, port its markup into the
+matching `page.tsx`, swap the Tailwind CDN for the local Tailwind setup (already
+configured with the same design tokens), and ship.
+
+## Design tokens
+
+`tailwind.config.js` mirrors the theme from the mockups (ink/chalk/brand/
+accent/mint/amber/rose/sky scales + Inter/JetBrains Mono fonts). If we later
+introduce a shared `@caia-app/design-tokens` package, swap to that.
+
+`apps/dashboard/` does NOT currently use Tailwind (plain CSS); sharing tokens
+with it would require migrating the dashboard or extracting tokens into a
+framework-neutral package. Out of scope for this scaffold.
+
+## Local development
+
+```bash
+pnpm install
+pnpm --filter @caia-app/chiefaia-site dev    # http://localhost:7780
+pnpm --filter @caia-app/chiefaia-site build  # production build
+pnpm --filter @caia-app/chiefaia-site typecheck
+```
+
+## CI / CD
+
+To be wired up after operator approves hosting + content. Recommended:
+Cloudflare Pages auto-deploys from `main` (production) and from every PR
+(previews) using the build command above.

--- a/apps/chiefaia-site/app/architecture/page.tsx
+++ b/apps/chiefaia-site/app/architecture/page.tsx
@@ -1,0 +1,9 @@
+// TODO: Promote apps/website-mockups/architecture.html once operator confirms.
+export default function ArchitecturePage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-12 text-center">
+      <h1 className="text-3xl font-semibold text-chalk-50 mb-4">Architecture</h1>
+      <p className="text-chalk-400">Placeholder. Source: apps/website-mockups/architecture.html</p>
+    </main>
+  );
+}

--- a/apps/chiefaia-site/app/dashboard-preview/page.tsx
+++ b/apps/chiefaia-site/app/dashboard-preview/page.tsx
@@ -1,0 +1,12 @@
+// TODO: Promote apps/website-mockups/dashboard-preview.html once operator confirms.
+// NOTE: spec called for a route group "(dashboard-preview)", but in Next.js App
+// Router route groups don't add URL segments — that would collide with the
+// home page. Using a regular segment `/dashboard-preview` instead.
+export default function DashboardPreviewPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-12 text-center">
+      <h1 className="text-3xl font-semibold text-chalk-50 mb-4">Dashboard Preview</h1>
+      <p className="text-chalk-400">Placeholder. Source: apps/website-mockups/dashboard-preview.html</p>
+    </main>
+  );
+}

--- a/apps/chiefaia-site/app/globals.css
+++ b/apps/chiefaia-site/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html { color-scheme: dark; }
+body {
+  background: #0f1117;
+  color: #e2e8f0;
+  font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}

--- a/apps/chiefaia-site/app/layout.tsx
+++ b/apps/chiefaia-site/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'CAIA — The Chief AI Architect, automated.',
+  description:
+    'CAIA is an AI-first development platform — autonomous chains, local-first models, and a multi-agent ecosystem that ships code while you sleep.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="dark">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/chiefaia-site/app/login/page.tsx
+++ b/apps/chiefaia-site/app/login/page.tsx
@@ -1,0 +1,9 @@
+// TODO: Promote apps/website-mockups/login.html once operator confirms.
+export default function LoginPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-12 text-center">
+      <h1 className="text-3xl font-semibold text-chalk-50 mb-4">Login</h1>
+      <p className="text-chalk-400">Placeholder. Source: apps/website-mockups/login.html</p>
+    </main>
+  );
+}

--- a/apps/chiefaia-site/app/packages/page.tsx
+++ b/apps/chiefaia-site/app/packages/page.tsx
@@ -1,0 +1,9 @@
+// TODO: Promote apps/website-mockups/packages.html once operator confirms.
+export default function PackagesPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-12 text-center">
+      <h1 className="text-3xl font-semibold text-chalk-50 mb-4">Packages</h1>
+      <p className="text-chalk-400">Placeholder. Source: apps/website-mockups/packages.html</p>
+    </main>
+  );
+}

--- a/apps/chiefaia-site/app/page.tsx
+++ b/apps/chiefaia-site/app/page.tsx
@@ -1,0 +1,15 @@
+// TODO: Promote apps/website-mockups/home.html once operator confirms final mockup.
+// Until then this is an intentional placeholder so the deploy pipeline can ship
+// the site end-to-end (DNS, SSL, CI) before content is finalized.
+export default function HomePage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-12 text-center">
+      <h1 className="text-4xl font-semibold text-chalk-50 mb-4">chiefaia.com</h1>
+      <p className="text-chalk-400 max-w-xl">
+        The Chief AI Architect — coming soon. This scaffold exists so the deploy
+        plumbing (DNS, SSL, CI) can be wired up while final content is being
+        approved. See <code className="text-brand-400">apps/website-mockups/home.html</code>.
+      </p>
+    </main>
+  );
+}

--- a/apps/chiefaia-site/next-env.d.ts
+++ b/apps/chiefaia-site/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/chiefaia-site/next.config.js
+++ b/apps/chiefaia-site/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // Cloudflare Pages prefers static export when possible; we keep the default
+  // Node runtime for now so we can add server actions / API routes later.
+  // To deploy to Pages with adapter, see: https://developers.cloudflare.com/pages/framework-guides/nextjs/
+};
+
+module.exports = nextConfig;

--- a/apps/chiefaia-site/package.json
+++ b/apps/chiefaia-site/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@caia-app/chiefaia-site",
+  "private": true,
+  "description": "Public-facing marketing site for CAIA (Chief AI Agent) — www.chiefaia.com",
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev -p 7780",
+    "lint": "next lint",
+    "start": "next start -p 7780",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.5.15",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5"
+  }
+}

--- a/apps/chiefaia-site/postcss.config.js
+++ b/apps/chiefaia-site/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/chiefaia-site/tailwind.config.js
+++ b/apps/chiefaia-site/tailwind.config.js
@@ -1,0 +1,50 @@
+/** @type {import('tailwindcss').Config} */
+// Theme mirrors the design tokens used in apps/website-mockups/*.html so
+// promoting a mockup is mostly a copy/paste once content is final.
+// If/when a shared @caia-app/design-tokens package lands, swap to import from there.
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        ink: {
+          950: '#0a0c12',
+          900: '#0f1117',
+          850: '#141823',
+          800: '#1a1f2e',
+          700: '#252a3a',
+          600: '#2d3748',
+        },
+        chalk: {
+          50: '#f8fafc',
+          100: '#f0f4f8',
+          300: '#cbd5e1',
+          400: '#a0aec0',
+          500: '#64748b',
+        },
+        brand: {
+          50: '#eef2ff',
+          100: '#e0e7ff',
+          400: '#818cf8',
+          500: '#6366f1',
+          600: '#4f46e5',
+          700: '#4338ca',
+        },
+        accent: { 400: '#a78bfa', 500: '#8b5cf6', 600: '#7c3aed' },
+        mint: { 400: '#34d399', 500: '#10b981' },
+        amber: { 400: '#fbbf24', 500: '#f59e0b' },
+        rose: { 400: '#fb7185', 500: '#ef4444' },
+        sky: { 400: '#63b3ed' },
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+      },
+      boxShadow: {
+        glow: '0 0 0 1px rgba(99,102,241,0.35), 0 8px 32px -8px rgba(99,102,241,0.45)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/apps/chiefaia-site/tsconfig.json
+++ b/apps/chiefaia-site/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,40 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
 
+  apps/chiefaia-site:
+    dependencies:
+      next:
+        specifier: 15.5.15
+        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.14)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.14
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   apps/completeness-sentinel:
     dependencies:
       nanoid:
@@ -11865,7 +11899,7 @@ snapshots:
   autoprefixer@10.5.0(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001790
+      caniuse-lite: 1.0.30001792
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.14
@@ -14251,6 +14285,31 @@ snapshots:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001790
+      postcss: 8.4.31
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.59.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 15.5.15
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001792
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)


### PR DESCRIPTION
## What

Scaffolds `apps/chiefaia-site/` — a Next.js 15.5.15 + React 19 app skeleton for the public-facing **www.chiefaia.com** site (CAIA v1 sub-track 3).

Five empty App Router pages matching the merged mockups (PR #489):
- `/` → home
- `/architecture` → architecture
- `/packages` → packages
- `/login` → login
- `/dashboard-preview` → dashboard-preview

## Why now (and why empty pages)

The operator hasn't yet confirmed which mockups in `apps/website-mockups/` are final. Rather than promote markup that might get reshuffled, this PR sets up just the deploy plumbing — Next app, Tailwind config with matching design tokens, workspace registration, build wiring — so DNS, SSL, and CI can be wired up **in parallel** with content sign-off. Once a mockup is approved, promotion is mostly copy-paste of its body markup into the matching `page.tsx`.

## Deploy target

**Cloudflare Pages free tier.** Rationale (zero \$, zero servers, free SSL, per-PR previews, instant rollback) and DNS plan documented in:

\`~/Documents/projects/agent-memory/decisions/chiefaia_deploy_runbook_2026_05_16.md\`

## Verified

\`\`\`
pnpm --filter @caia-app/chiefaia-site build
\`\`\`

Produces 5 statically prerendered routes (~102 kB First Load JS each):
\`\`\`
Route (app)                                 Size  First Load JS
┌ ○ /                                      137 B         102 kB
├ ○ /_not-found                            997 B         103 kB
├ ○ /architecture                          137 B         102 kB
├ ○ /dashboard-preview                     137 B         102 kB
├ ○ /login                                 137 B         102 kB
└ ○ /packages                              137 B         102 kB
\`\`\`

## Notable deviations from spec

- Spec called for `app/(dashboard-preview)/page.tsx` (route group). Route groups don't add URL segments in App Router, so that would collide with `app/page.tsx`. Using `/dashboard-preview` as a regular segment instead. Documented in README.
- Tailwind config is local (not shared with \`apps/dashboard/\`) because the dashboard currently uses plain CSS, not Tailwind. Sharing tokens with it would require migrating the dashboard or extracting tokens into a framework-neutral package — out of scope for this scaffold. README documents the intent to consolidate later via a \`@caia-app/design-tokens\` package.

## Blocked downstream work

- **DNS execution** — blocked on operator hosting approval + GoDaddy creds (currently NOT in stolution vault; see runbook)
- **Mockup promotion** — blocked on operator picking final mockups
- **CI/CD wiring** — blocked on Cloudflare Pages account / project creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched Chief AI Architect marketing site with core pages (home, login, packages, architecture, dashboard preview)
  * Implemented dark theme with custom design tokens and typography

* **Chores**
  * Configured Next.js, Tailwind CSS, and TypeScript infrastructure for the site

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prakashgbid/caia/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->