### PR TITLE
chiefaia.com: single-file placeholder landing page

### DIFF
--- a/apps/chiefaia-site/README.md
+++ b/apps/chiefaia-site/README.md
@@ -1,0 +1,39 @@
+# chiefaia-site
+
+Single-file placeholder for **www.chiefaia.com**, served from Cloudflare Pages.
+
+## What this is
+
+A static `index.html` (~5 KB, no framework, no build step, no dependencies) shown while the full site is in development. Theme follows light/dark via `prefers-color-scheme`.
+
+Public branding is "Chief AI Agent" — internal codename "CAIA" deliberately does not appear in any public content.
+
+## Why minimal
+
+A previous iteration scaffolded a Next.js app (PR #496, closed). That was reverted in favor of this placeholder because:
+
+1. The 5 high-fidelity mockups it was designed to host are being deleted (separate cleanup task).
+2. The real public site will be designed by the design-agent track later; no point baking decisions now.
+3. A single static file deploys in seconds to Cloudflare Pages and costs literally zero — perfect for a "coming soon" page.
+
+## Deploy
+
+Target: **Cloudflare Pages** (free tier).
+Project name (proposed): `chiefaia`
+Production branch: `main`
+Build command: *(none — static)*
+Output directory: `apps/chiefaia-site`
+
+Once a Cloudflare account exists and a Pages project is connected to this repo via GitHub, every push to `main` that touches this directory auto-deploys. PRs get preview URLs at `https://<sha>.<project>.pages.dev`.
+
+## Local preview
+
+```bash
+cd apps/chiefaia-site
+python3 -m http.server 7780
+# open http://localhost:7780
+```
+
+## Future evolution
+
+When the design-agent track produces a real design and content, this file gets replaced (or a Next.js / static-site-generator setup gets layered on top). Until then, keep it boring.

--- a/apps/chiefaia-site/index.html
+++ b/apps/chiefaia-site/index.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chief AI Agent</title>
+    <meta name="description" content="Chief AI Agent — building an autonomous, AI-driven platform that turns ideas into production-ready websites." />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:title" content="Chief AI Agent" />
+    <meta property="og:description" content="Building an autonomous, AI-driven platform that turns ideas into production-ready websites." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.chiefaia.com" />
+    <link rel="canonical" href="https://www.chiefaia.com" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%236366f1'/%3E%3Cstop offset='100%25' stop-color='%238b5cf6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='64' height='64' rx='14' fill='url(%23g)'/%3E%3Ctext x='32' y='42' font-family='-apple-system,Segoe UI,sans-serif' font-size='30' font-weight='600' fill='white' text-anchor='middle'%3EC%3C/text%3E%3C/svg%3E" />
+    <style>
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+        background:
+          radial-gradient(60% 50% at 50% 0%, rgba(99, 102, 241, 0.10) 0%, transparent 60%),
+          radial-gradient(50% 40% at 100% 100%, rgba(139, 92, 246, 0.08) 0%, transparent 60%),
+          #fafafa;
+        color: #1a1a1a;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+      main {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 4rem 1.5rem;
+        text-align: center;
+      }
+      .mark {
+        width: 56px;
+        height: 56px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-weight: 600;
+        font-size: 28px;
+        letter-spacing: -0.02em;
+        margin-bottom: 2rem;
+        box-shadow: 0 8px 32px -8px rgba(99, 102, 241, 0.45);
+      }
+      h1 {
+        font-size: clamp(2rem, 5vw, 2.75rem);
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        margin: 0 0 0.5rem;
+        color: #0f172a;
+      }
+      .domain {
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 0.95rem;
+        color: #64748b;
+        margin: 0 0 2rem;
+      }
+      .pitch {
+        max-width: 36rem;
+        font-size: 1.125rem;
+        color: #334155;
+        margin: 0 0 2.5rem;
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        background: rgba(99, 102, 241, 0.08);
+        color: #4f46e5;
+        font-size: 0.875rem;
+        font-weight: 500;
+        letter-spacing: 0.01em;
+      }
+      .status::before {
+        content: "";
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #6366f1;
+        animation: pulse 2.4s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50%      { opacity: 0.5; transform: scale(0.85); }
+      }
+      footer {
+        padding: 2rem 1.5rem;
+        text-align: center;
+        font-size: 0.8125rem;
+        color: #94a3b8;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background:
+            radial-gradient(60% 50% at 50% 0%, rgba(99, 102, 241, 0.18) 0%, transparent 60%),
+            radial-gradient(50% 40% at 100% 100%, rgba(139, 92, 246, 0.12) 0%, transparent 60%),
+            #0a0a0a;
+          color: #f1f5f9;
+        }
+        h1 { color: #f8fafc; }
+        .domain { color: #94a3b8; }
+        .pitch { color: #cbd5e1; }
+        .status { background: rgba(99, 102, 241, 0.15); color: #a5b4fc; }
+        footer { color: #64748b; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="mark" aria-hidden="true">C</div>
+      <h1>Chief AI Agent</h1>
+      <p class="domain">chiefaia.com</p>
+      <p class="pitch">
+        Building a fully autonomous, AI-driven platform that turns ideas into
+        production-ready websites.
+      </p>
+      <span class="status">Coming soon</span>
+    </main>
+    <footer>&copy; 2026 Chief AI Agent</footer>
+  </body>
+</html>

--- a/apps/chiefaia-site/index.html
+++ b/apps/chiefaia-site/index.html
@@ -10,7 +10,9 @@
     <meta property="og:description" content="Building an autonomous, AI-driven platform that turns ideas into production-ready websites." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.chiefaia.com" />
+    <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity --><!-- canonical link is SEO metadata, no resource fetch -->
     <link rel="canonical" href="https://www.chiefaia.com" />
+    <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity --><!-- data: URL is inline, no external fetch to integrity-check -->
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%236366f1'/%3E%3Cstop offset='100%25' stop-color='%238b5cf6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='64' height='64' rx='14' fill='url(%23g)'/%3E%3Ctext x='32' y='42' font-family='-apple-system,Segoe UI,sans-serif' font-size='30' font-weight='600' fill='white' text-anchor='middle'%3EC%3C/text%3E%3C/svg%3E" />
     <style>
       *, *::before, *::after { box-sizing: border-box; }


### PR DESCRIPTION
## What

Adds `apps/chiefaia-site/index.html` (~5 KB) — a single static landing page for **www.chiefaia.com** with `light/dark` via `prefers-color-scheme`, system fonts, subtle gradient mark, OG meta, inline SVG favicon, mobile-responsive.

Plus a brief `README.md` documenting the deploy target (Cloudflare Pages free tier) and the local-preview one-liner.

## Why this and not the Next.js scaffold from #496

Scope reduced by operator:
- The 5 high-fidelity mockups the scaffold was designed to host are being deleted (separate cleanup task).
- Real public site will be designed later by the design-agent track.
- Until then, a "Coming soon" placeholder is the right level of investment.

PR #496 closed; this is the replacement.

## Public branding

"Chief AI Agent" only — internal codename "CAIA" intentionally does not appear in any user-facing copy or metadata.

## Contact email

Not included. Operator didn't confirm chiefaia.com email is live; trivial to add later by dropping a mailto into the footer.

## Deploy

Cloudflare Pages free tier. No build step. Output dir: `apps/chiefaia-site/`. Project creation is **blocked on operator** (no Cloudflare account / API token exists yet — see runbook).

## Merge

Per new operator standing rule, self-merging once CI passes.