### PR TITLE
feat(adoption-enforcement): V1+V2+V3 verifier substrate for adopt/* PRs

### DIFF
--- a/packages/adoption-enforcement/README.md
+++ b/packages/adoption-enforcement/README.md
@@ -1,0 +1,30 @@
+# @chiefaia/adoption-enforcement
+
+Adoption enforcement substrate for CAIA. Detects newly-exported workspace artefacts at merge time, cross-references the codebase for adoption sites, generates adoption PRs, verifies them, and gates DoD v2 on the result.
+
+Design: `agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md`.
+
+## Verify subsystem (V1+V2+V3)
+
+`src/verify/` runs the per-PR gauntlet defined in §7 of the design doc:
+
+| Check | Module | Command |
+|---|---|---|
+| V1 typecheck | `verify/typecheck.ts` | `pnpm --filter <pkg> typecheck` |
+| V2 unit tests | `verify/tests.ts` | `pnpm --filter <pkg> test` |
+| V3 build | `verify/build.ts` | `pnpm --filter <pkg>... build` |
+
+Entrypoint: `bin/caia-adoption-verify.mjs` — discovers open `adopt/*` PRs, runs each in a `/tmp/adopt-verify-<sha>` worktree, upserts a `<!-- adoption-verify -->` PR comment with `verification.md`, and toggles `adoption-verified` / `adoption-failed` labels idempotently. 15-min wall-clock cap per PR.
+
+## CLI
+
+```bash
+# Verify every open adopt/* PR
+caia-adoption-verify
+
+# Verify a single PR by number
+caia-adoption-verify --pr 123
+
+# Dry-run (no comment, no labels)
+caia-adoption-verify --dry-run
+```

--- a/packages/adoption-enforcement/bin/caia-adoption-verify.mjs
+++ b/packages/adoption-enforcement/bin/caia-adoption-verify.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * caia-adoption-verify — discover open adopt/* PRs, run V1+V2+V3 in a
+ * /tmp/adopt-verify-<sha> worktree, upsert a verification.md PR comment, and
+ * apply adoption-verified / adoption-failed labels idempotently.
+ *
+ * Usage:
+ *   caia-adoption-verify [--pr <num>] [--repo <dir>] [--dry-run]
+ *                        [--wall-clock-ms <n>]
+ */
+import { runAll } from '../dist/pr/orchestrator.js';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '--pr':
+        out.prNumber = Number(next);
+        i += 1;
+        break;
+      case '--repo':
+        out.repoCwd = next;
+        i += 1;
+        break;
+      case '--dry-run':
+        out.dryRun = true;
+        break;
+      case '--wall-clock-ms':
+        out.perPrWallClockMs = Number(next);
+        i += 1;
+        break;
+      case '--help':
+      case '-h':
+        process.stdout.write(
+          'Usage: caia-adoption-verify [--pr <num>] [--repo <dir>] [--dry-run] [--wall-clock-ms <n>]\n',
+        );
+        process.exit(0);
+        break;
+      default:
+        process.stderr.write(`unknown arg: ${arg}\n`);
+        process.exit(2);
+    }
+  }
+  if (!out.repoCwd) out.repoCwd = process.cwd();
+  return out;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+const outcomes = await runAll(opts);
+
+let failed = 0;
+for (const o of outcomes) {
+  const tag = o.verdict.toUpperCase();
+  process.stdout.write(
+    `[${tag}] #${o.pr.number} ${o.pr.headRefName} — comment:${o.commentAction ?? 'n/a'} label:${o.labelAction ?? 'n/a'} (${o.durationMs}ms)\n`,
+  );
+  if (o.setupErrors.length > 0) {
+    for (const err of o.setupErrors) process.stdout.write(`    setup-error: ${err}\n`);
+  }
+  if (o.verdict !== 'pass') failed += 1;
+}
+
+process.stdout.write(
+  `\nSummary: ${outcomes.length} PR(s) verified, ${failed} non-pass.\n`,
+);
+
+process.exit(failed === 0 ? 0 : 1);

--- a/packages/adoption-enforcement/eslint.config.cjs
+++ b/packages/adoption-enforcement/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/adoption-enforcement/package.json
+++ b/packages/adoption-enforcement/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@chiefaia/adoption-enforcement",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Adoption enforcement substrate: scan new artefacts from a merged PR, cross-reference adoption sites, generate adoption PRs, verify them, and gate DoD v2. See agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./verify": {
+      "types": "./dist/verify/index.d.ts",
+      "default": "./dist/verify/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "bin": {
+    "caia-adoption-verify": "./bin/caia-adoption-verify.mjs"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT"
+}

--- a/packages/adoption-enforcement/src/index.ts
+++ b/packages/adoption-enforcement/src/index.ts
@@ -1,0 +1,2 @@
+export * as verify from './verify/index.js';
+export * as pr from './pr/index.js';

--- a/packages/adoption-enforcement/src/pr/affected-packages.ts
+++ b/packages/adoption-enforcement/src/pr/affected-packages.ts
@@ -1,0 +1,79 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { PullRequest } from './types.js';
+
+interface PackageJsonShape {
+  name?: string;
+}
+
+/**
+ * Infer (target, consumer) workspace packages from the PR diff.
+ *
+ * Heuristic:
+ * - A changed file at `packages/<dir>/...` whose package.json declares a
+ *   `@chiefaia/*` name and whose adoption PR title hints at "adopt <pkg>"
+ *   is treated as the *target* (the artefact being adopted).
+ * - Every other changed-file package is a *consumer* (a place adopting the
+ *   artefact).
+ *
+ * If the title heuristic fails (no `@chiefaia/<x>` token in the PR title),
+ * we leave `target` empty and fall back to "every changed package is a
+ * consumer." V3 then runs the repo-wide build.
+ */
+export async function inferPackages(opts: {
+  readonly worktreeDir: string;
+  readonly pr: PullRequest;
+}): Promise<{ targetPackages: string[]; consumerPackages: string[] }> {
+  const changedPkgDirs = new Set<string>();
+  for (const f of opts.pr.files) {
+    const m = /^packages\/([^/]+)\//.exec(f.path);
+    if (m && m[1]) {
+      changedPkgDirs.add(m[1]);
+    }
+  }
+
+  const pkgNames = new Map<string, string>();
+  for (const dir of changedPkgDirs) {
+    const name = await readPackageName(path.join(opts.worktreeDir, 'packages', dir));
+    if (name) pkgNames.set(dir, name);
+  }
+
+  const titleTarget = extractTargetFromTitle(opts.pr.title, opts.pr.headRefName);
+
+  const targetPackages: string[] = [];
+  const consumerPackages: string[] = [];
+  for (const [, name] of pkgNames) {
+    if (titleTarget && name === titleTarget) {
+      targetPackages.push(name);
+    } else {
+      consumerPackages.push(name);
+    }
+  }
+
+  if (targetPackages.length === 0 && titleTarget) {
+    targetPackages.push(titleTarget);
+  }
+
+  return { targetPackages, consumerPackages };
+}
+
+async function readPackageName(pkgDir: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(pkgDir, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as PackageJsonShape;
+    return typeof parsed.name === 'string' ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+const TITLE_RE = /(@chiefaia\/[a-z0-9][a-z0-9-]*)/i;
+const BRANCH_RE = /^adopt\/([a-z0-9][a-z0-9-]*?)(?:-[0-9a-f]{7,})?$/i;
+
+function extractTargetFromTitle(title: string, branch: string): string | null {
+  const titleMatch = TITLE_RE.exec(title);
+  if (titleMatch && titleMatch[1]) return titleMatch[1];
+  const branchMatch = BRANCH_RE.exec(branch);
+  if (branchMatch && branchMatch[1]) return `@chiefaia/${branchMatch[1]}`;
+  return null;
+}

--- a/packages/adoption-enforcement/src/pr/comment.ts
+++ b/packages/adoption-enforcement/src/pr/comment.ts
@@ -1,0 +1,115 @@
+import { COMMENT_MARKER } from './types.js';
+import type { VerificationResult } from '../verify/types.js';
+
+export interface RenderOptions {
+  readonly pr: { readonly number: number; readonly headRefOid: string };
+  readonly targetPackages: readonly string[];
+  readonly consumerPackages: readonly string[];
+  readonly result: VerificationResult;
+  readonly worktreeDir: string;
+  readonly startedAt: string;
+  readonly finishedAt: string;
+  readonly setupErrors?: readonly string[];
+}
+
+const STATUS_EMOJI: Record<string, string> = {
+  pass: '✅',
+  fail: '❌',
+  timeout: '⏱',
+  skipped: '⏭',
+};
+
+export function renderVerificationComment(opts: RenderOptions): string {
+  const header = opts.result.pass
+    ? '## Adoption verification — PASS'
+    : '## Adoption verification — FAIL';
+
+  const summary = [
+    `**PR**: #${opts.pr.number} @ \`${opts.pr.headRefOid.slice(0, 12)}\``,
+    `**Worktree**: \`${opts.worktreeDir}\``,
+    `**Target**: ${formatPkgs(opts.targetPackages)}`,
+    `**Consumers**: ${formatPkgs(opts.consumerPackages)}`,
+    `**Started**: ${opts.startedAt}`,
+    `**Finished**: ${opts.finishedAt}`,
+    `**Wall-clock**: ${formatMs(opts.result.durationMs)}`,
+  ].join('  \n');
+
+  const table = renderTable(opts.result);
+  const details = renderFailureDetails(opts.result);
+  const setup = (opts.setupErrors && opts.setupErrors.length > 0)
+    ? `\n\n### Setup errors\n${opts.setupErrors.map((e) => `- ${e}`).join('\n')}\n`
+    : '';
+
+  return [
+    COMMENT_MARKER,
+    header,
+    '',
+    summary,
+    setup,
+    '',
+    table,
+    '',
+    details,
+  ].filter((s) => s.length > 0).join('\n');
+}
+
+function formatPkgs(pkgs: readonly string[]): string {
+  if (pkgs.length === 0) return '_none inferred_';
+  return pkgs.map((p) => `\`${p}\``).join(', ');
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  const seconds = Math.round(ms / 100) / 10;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = (seconds - m * 60).toFixed(1);
+  return `${m}m ${s}s`;
+}
+
+function renderTable(result: VerificationResult): string {
+  const rows = result.checks.map((c) => {
+    const status = `${STATUS_EMOJI[c.status] ?? ''} ${c.status}`;
+    const exit = c.exitCode === null ? '—' : String(c.exitCode);
+    return `| ${c.id} | ${c.label} | ${status} | ${exit} | ${formatMs(c.durationMs)} |`;
+  });
+  return [
+    '| Check | Label | Status | Exit | Duration |',
+    '|-------|-------|--------|------|----------|',
+    ...rows,
+  ].join('\n');
+}
+
+function renderFailureDetails(result: VerificationResult): string {
+  const failures = result.checks.filter(
+    (c) => c.status === 'fail' || c.status === 'timeout',
+  );
+  if (failures.length === 0) return '';
+  return failures
+    .map((c) => {
+      const stderr = c.stderrTail.trim();
+      const stdout = c.stdoutTail.trim();
+      return [
+        `### ${c.id} ${c.label} — ${c.status}`,
+        '',
+        `Command: \`${c.command}\``,
+        '',
+        '<details><summary>stderr (tail)</summary>',
+        '',
+        '```',
+        stderr || '(empty)',
+        '```',
+        '',
+        '</details>',
+        '',
+        '<details><summary>stdout (tail)</summary>',
+        '',
+        '```',
+        stdout || '(empty)',
+        '```',
+        '',
+        '</details>',
+      ].join('\n');
+    })
+    .join('\n\n');
+}

--- a/packages/adoption-enforcement/src/pr/gh.ts
+++ b/packages/adoption-enforcement/src/pr/gh.ts
@@ -1,0 +1,265 @@
+import { runCommand } from '../verify/runner.js';
+import {
+  ADOPTION_BRANCH_PREFIX,
+  ADOPTION_FAILED_LABEL,
+  ADOPTION_VERIFIED_LABEL,
+  COMMENT_MARKER,
+  type PullRequest,
+} from './types.js';
+
+const GH_TIMEOUT_MS = 60 * 1000;
+
+interface RawPrListItem {
+  number: number;
+  headRefName: string;
+  headRefOid: string;
+  baseRefName: string;
+  url: string;
+  title: string;
+  isDraft: boolean;
+  mergeable: string;
+  labels: Array<{ name: string }>;
+  files?: Array<{ path: string }>;
+}
+
+interface ListOptions {
+  readonly repoCwd: string;
+  readonly state?: 'open' | 'closed' | 'all';
+  readonly limit?: number;
+}
+
+export async function listAdoptionPRs(options: ListOptions): Promise<PullRequest[]> {
+  const state = options.state ?? 'open';
+  const limit = options.limit ?? 50;
+  const args = [
+    'pr',
+    'list',
+    '--state',
+    state,
+    '--limit',
+    String(limit),
+    '--json',
+    'number,headRefName,headRefOid,baseRefName,url,title,isDraft,mergeable,labels',
+  ];
+  const result = await runCommand('gh', args, {
+    cwd: options.repoCwd,
+    timeoutMs: GH_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `gh pr list failed (exit ${result.exitCode}): ${result.stderrTail.slice(-500)}`,
+    );
+  }
+  const parsed = JSON.parse(result.stdoutTail || '[]') as RawPrListItem[];
+  const adoption = parsed.filter((row) => row.headRefName.startsWith(ADOPTION_BRANCH_PREFIX));
+
+  const enriched: PullRequest[] = [];
+  for (const row of adoption) {
+    const files = await listFiles(options.repoCwd, row.number);
+    enriched.push({
+      number: row.number,
+      headRefName: row.headRefName,
+      headRefOid: row.headRefOid,
+      baseRefName: row.baseRefName,
+      url: row.url,
+      title: row.title,
+      isDraft: row.isDraft,
+      mergeable: normalizeMergeable(row.mergeable),
+      labels: row.labels.map((l) => ({ name: l.name })),
+      files,
+    });
+  }
+  return enriched;
+}
+
+export async function getPR(
+  repoCwd: string,
+  prNumber: number,
+): Promise<PullRequest> {
+  const args = [
+    'pr',
+    'view',
+    String(prNumber),
+    '--json',
+    'number,headRefName,headRefOid,baseRefName,url,title,isDraft,mergeable,labels',
+  ];
+  const result = await runCommand('gh', args, {
+    cwd: repoCwd,
+    timeoutMs: GH_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `gh pr view ${prNumber} failed (exit ${result.exitCode}): ${result.stderrTail.slice(-500)}`,
+    );
+  }
+  const row = JSON.parse(result.stdoutTail) as RawPrListItem;
+  const files = await listFiles(repoCwd, prNumber);
+  return {
+    number: row.number,
+    headRefName: row.headRefName,
+    headRefOid: row.headRefOid,
+    baseRefName: row.baseRefName,
+    url: row.url,
+    title: row.title,
+    isDraft: row.isDraft,
+    mergeable: normalizeMergeable(row.mergeable),
+    labels: row.labels.map((l) => ({ name: l.name })),
+    files,
+  };
+}
+
+async function listFiles(
+  repoCwd: string,
+  prNumber: number,
+): Promise<Array<{ path: string }>> {
+  const args = ['pr', 'view', String(prNumber), '--json', 'files'];
+  const result = await runCommand('gh', args, {
+    cwd: repoCwd,
+    timeoutMs: GH_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0) {
+    return [];
+  }
+  const parsed = JSON.parse(result.stdoutTail) as { files?: Array<{ path: string }> };
+  return parsed.files ?? [];
+}
+
+function normalizeMergeable(value: string): PullRequest['mergeable'] {
+  if (value === 'MERGEABLE' || value === 'CONFLICTING' || value === 'UNKNOWN') return value;
+  return 'UNKNOWN';
+}
+
+export interface UpsertCommentOptions {
+  readonly repoCwd: string;
+  readonly prNumber: number;
+  readonly body: string;
+  readonly marker?: string;
+}
+
+/**
+ * Idempotent comment upsert: if a comment with the marker already exists, edit
+ * it; otherwise create a new one. The marker is appended automatically if not
+ * already present in `body`.
+ */
+export async function upsertVerificationComment(
+  options: UpsertCommentOptions,
+): Promise<{ action: 'created' | 'updated'; commentId?: string }> {
+  const marker = options.marker ?? COMMENT_MARKER;
+  const body = options.body.includes(marker) ? options.body : `${marker}\n${options.body}`;
+
+  const existingId = await findCommentId(options.repoCwd, options.prNumber, marker);
+
+  if (existingId !== null) {
+    const editArgs = [
+      'api',
+      '--method',
+      'PATCH',
+      `repos/{owner}/{repo}/issues/comments/${existingId}`,
+      '-f',
+      `body=${body}`,
+    ];
+    const result = await runCommand('gh', editArgs, {
+      cwd: options.repoCwd,
+      timeoutMs: GH_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `gh api PATCH comment failed (exit ${result.exitCode}): ${result.stderrTail.slice(-500)}`,
+      );
+    }
+    return { action: 'updated', commentId: existingId };
+  }
+
+  const createArgs = [
+    'pr',
+    'comment',
+    String(options.prNumber),
+    '--body',
+    body,
+  ];
+  const result = await runCommand('gh', createArgs, {
+    cwd: options.repoCwd,
+    timeoutMs: GH_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `gh pr comment failed (exit ${result.exitCode}): ${result.stderrTail.slice(-500)}`,
+    );
+  }
+  return { action: 'created' };
+}
+
+async function findCommentId(
+  repoCwd: string,
+  prNumber: number,
+  marker: string,
+): Promise<string | null> {
+  const args = [
+    'api',
+    `repos/{owner}/{repo}/issues/${prNumber}/comments`,
+    '--paginate',
+  ];
+  const result = await runCommand('gh', args, {
+    cwd: repoCwd,
+    timeoutMs: GH_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  try {
+    const comments = JSON.parse(result.stdoutTail) as Array<{ id: number; body: string }>;
+    const hit = comments.find((c) => typeof c.body === 'string' && c.body.includes(marker));
+    return hit ? String(hit.id) : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SetLabelOptions {
+  readonly repoCwd: string;
+  readonly prNumber: number;
+  readonly addLabels?: readonly string[];
+  readonly removeLabels?: readonly string[];
+}
+
+export async function setLabels(options: SetLabelOptions): Promise<void> {
+  const args = ['pr', 'edit', String(options.prNumber)];
+  for (const label of options.addLabels ?? []) {
+    args.push('--add-label', label);
+  }
+  for (const label of options.removeLabels ?? []) {
+    args.push('--remove-label', label);
+  }
+  if (args.length === 3) return;
+  const result = await runCommand('gh', args, {
+    cwd: options.repoCwd,
+    timeoutMs: GH_TIMEOUT_MS,
+  });
+  if (result.exitCode !== 0 && !result.stderrTail.includes('not found')) {
+    throw new Error(
+      `gh pr edit labels failed (exit ${result.exitCode}): ${result.stderrTail.slice(-500)}`,
+    );
+  }
+}
+
+export async function applyVerdictLabels(
+  repoCwd: string,
+  prNumber: number,
+  passed: boolean,
+): Promise<void> {
+  if (passed) {
+    await setLabels({
+      repoCwd,
+      prNumber,
+      addLabels: [ADOPTION_VERIFIED_LABEL],
+      removeLabels: [ADOPTION_FAILED_LABEL],
+    });
+  } else {
+    await setLabels({
+      repoCwd,
+      prNumber,
+      addLabels: [ADOPTION_FAILED_LABEL],
+      removeLabels: [ADOPTION_VERIFIED_LABEL],
+    });
+  }
+}

--- a/packages/adoption-enforcement/src/pr/index.ts
+++ b/packages/adoption-enforcement/src/pr/index.ts
@@ -1,0 +1,19 @@
+export {
+  ADOPTION_BRANCH_PREFIX,
+  ADOPTION_FAILED_LABEL,
+  ADOPTION_VERIFIED_LABEL,
+  COMMENT_MARKER,
+} from './types.js';
+export type { PullRequest } from './types.js';
+export {
+  listAdoptionPRs,
+  getPR,
+  upsertVerificationComment,
+  applyVerdictLabels,
+  setLabels,
+} from './gh.js';
+export { prepareWorktree, pnpmInstall } from './worktree.js';
+export { inferPackages } from './affected-packages.js';
+export { renderVerificationComment } from './comment.js';
+export { runAll, runOne } from './orchestrator.js';
+export type { RunOptions, PrVerificationOutcome } from './orchestrator.js';

--- a/packages/adoption-enforcement/src/pr/orchestrator.ts
+++ b/packages/adoption-enforcement/src/pr/orchestrator.ts
@@ -1,0 +1,185 @@
+import { runGauntlet } from '../verify/gauntlet.js';
+import { inferPackages } from './affected-packages.js';
+import { renderVerificationComment } from './comment.js';
+import {
+  applyVerdictLabels,
+  upsertVerificationComment,
+  listAdoptionPRs,
+  getPR,
+} from './gh.js';
+import { pnpmInstall, prepareWorktree } from './worktree.js';
+import type { PullRequest } from './types.js';
+
+export interface RunOptions {
+  readonly repoCwd: string;
+  readonly prNumber?: number;
+  readonly dryRun?: boolean;
+  /** Per-PR wall-clock cap (default 15 min, per task spec). */
+  readonly perPrWallClockMs?: number;
+}
+
+export interface PrVerificationOutcome {
+  readonly pr: PullRequest;
+  readonly verdict: 'pass' | 'fail' | 'error';
+  readonly setupErrors: string[];
+  readonly commentAction?: 'created' | 'updated' | 'skipped';
+  readonly labelAction?: 'verified' | 'failed' | 'skipped';
+  readonly durationMs: number;
+}
+
+const DEFAULT_PER_PR_WALL_CLOCK_MS = 15 * 60 * 1000;
+
+export async function runAll(options: RunOptions): Promise<PrVerificationOutcome[]> {
+  const prs = options.prNumber !== undefined
+    ? [await getPR(options.repoCwd, options.prNumber)]
+    : await listAdoptionPRs({ repoCwd: options.repoCwd });
+
+  const outcomes: PrVerificationOutcome[] = [];
+  for (const pr of prs) {
+    outcomes.push(await runOne(pr, options));
+  }
+  return outcomes;
+}
+
+export async function runOne(
+  pr: PullRequest,
+  options: RunOptions,
+): Promise<PrVerificationOutcome> {
+  const startedAtIso = new Date().toISOString();
+  const started = Date.now();
+  const wallClock = options.perPrWallClockMs ?? DEFAULT_PER_PR_WALL_CLOCK_MS;
+  const setupErrors: string[] = [];
+
+  let worktree: { dir: string; cleanup: () => Promise<void> } | null = null;
+  try {
+    worktree = await prepareWorktree({
+      repoCwd: options.repoCwd,
+      headSha: pr.headRefOid,
+      headRef: pr.headRefName,
+    });
+  } catch (err) {
+    setupErrors.push(`prepareWorktree: ${describe(err)}`);
+  }
+
+  if (worktree === null) {
+    const finishedAtIso = new Date().toISOString();
+    const commentBody = renderVerificationComment({
+      pr,
+      targetPackages: [],
+      consumerPackages: [],
+      result: { pass: false, checks: [], durationMs: 0 },
+      worktreeDir: '(setup failed)',
+      startedAt: startedAtIso,
+      finishedAt: finishedAtIso,
+      setupErrors,
+    });
+    await postAndLabel(options, pr, commentBody, false, setupErrors);
+    return {
+      pr,
+      verdict: 'error',
+      setupErrors,
+      commentAction: options.dryRun === true ? 'skipped' : 'created',
+      labelAction: options.dryRun === true ? 'skipped' : 'failed',
+      durationMs: Date.now() - started,
+    };
+  }
+
+  try {
+    const install = await pnpmInstall(worktree.dir);
+    if (install.exitCode !== 0) {
+      setupErrors.push(
+        `pnpm install exit ${install.exitCode}: ${install.stderrTail.slice(-300)}`,
+      );
+    }
+
+    const { targetPackages, consumerPackages } = await inferPackages({
+      worktreeDir: worktree.dir,
+      pr,
+    });
+
+    const remainingMs = Math.max(60_000, wallClock - (Date.now() - started));
+    const result = await runGauntlet({
+      cwd: worktree.dir,
+      targetPackages,
+      consumerPackages,
+      wallClockMs: remainingMs,
+    });
+
+    const finishedAtIso = new Date().toISOString();
+    const commentBody = renderVerificationComment({
+      pr,
+      targetPackages,
+      consumerPackages,
+      result,
+      worktreeDir: worktree.dir,
+      startedAt: startedAtIso,
+      finishedAt: finishedAtIso,
+      setupErrors,
+    });
+
+    const passed = result.pass && setupErrors.length === 0;
+    const { commentAction, labelAction } = await postAndLabel(
+      options,
+      pr,
+      commentBody,
+      passed,
+      setupErrors,
+    );
+
+    return {
+      pr,
+      verdict: passed ? 'pass' : 'fail',
+      setupErrors,
+      commentAction,
+      labelAction,
+      durationMs: Date.now() - started,
+    };
+  } finally {
+    if (worktree) {
+      await worktree.cleanup().catch(() => undefined);
+    }
+  }
+}
+
+async function postAndLabel(
+  options: RunOptions,
+  pr: PullRequest,
+  commentBody: string,
+  passed: boolean,
+  setupErrors: string[],
+): Promise<{
+  commentAction: 'created' | 'updated' | 'skipped';
+  labelAction: 'verified' | 'failed' | 'skipped';
+}> {
+  if (options.dryRun === true) {
+    return { commentAction: 'skipped', labelAction: 'skipped' };
+  }
+
+  let commentAction: 'created' | 'updated' = 'created';
+  try {
+    const res = await upsertVerificationComment({
+      repoCwd: options.repoCwd,
+      prNumber: pr.number,
+      body: commentBody,
+    });
+    commentAction = res.action;
+  } catch (err) {
+    setupErrors.push(`upsertComment: ${describe(err)}`);
+  }
+
+  try {
+    await applyVerdictLabels(options.repoCwd, pr.number, passed);
+  } catch (err) {
+    setupErrors.push(`applyLabels: ${describe(err)}`);
+  }
+
+  return {
+    commentAction,
+    labelAction: passed ? 'verified' : 'failed',
+  };
+}
+
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/adoption-enforcement/src/pr/types.ts
+++ b/packages/adoption-enforcement/src/pr/types.ts
@@ -1,0 +1,17 @@
+export interface PullRequest {
+  readonly number: number;
+  readonly headRefName: string;
+  readonly headRefOid: string;
+  readonly baseRefName: string;
+  readonly url: string;
+  readonly title: string;
+  readonly isDraft: boolean;
+  readonly mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
+  readonly labels: ReadonlyArray<{ name: string }>;
+  readonly files: ReadonlyArray<{ path: string }>;
+}
+
+export const ADOPTION_BRANCH_PREFIX = 'adopt/';
+export const ADOPTION_VERIFIED_LABEL = 'adoption-verified';
+export const ADOPTION_FAILED_LABEL = 'adoption-failed';
+export const COMMENT_MARKER = '<!-- adoption-verify -->';

--- a/packages/adoption-enforcement/src/pr/worktree.ts
+++ b/packages/adoption-enforcement/src/pr/worktree.ts
@@ -1,0 +1,82 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runCommand } from '../verify/runner.js';
+
+const GIT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface WorktreePrep {
+  readonly dir: string;
+  readonly cleanup: () => Promise<void>;
+}
+
+/**
+ * Materialise a git worktree at /tmp/adopt-verify-<sha> pinned to the PR head.
+ * Caller is responsible for invoking `cleanup()` (idempotent — silently
+ * tolerates already-removed worktrees).
+ */
+export async function prepareWorktree(opts: {
+  readonly repoCwd: string;
+  readonly headSha: string;
+  readonly headRef: string;
+}): Promise<WorktreePrep> {
+  const dir = path.join(os.tmpdir(), `adopt-verify-${opts.headSha}`);
+
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+
+  const fetchResult = await runCommand(
+    'git',
+    ['fetch', 'origin', opts.headRef, '--quiet'],
+    { cwd: opts.repoCwd, timeoutMs: GIT_TIMEOUT_MS },
+  );
+  if (fetchResult.exitCode !== 0) {
+    throw new Error(
+      `git fetch ${opts.headRef} failed: ${fetchResult.stderrTail.slice(-500)}`,
+    );
+  }
+
+  const addResult = await runCommand(
+    'git',
+    ['worktree', 'add', '--detach', dir, opts.headSha],
+    { cwd: opts.repoCwd, timeoutMs: GIT_TIMEOUT_MS },
+  );
+  if (addResult.exitCode !== 0) {
+    throw new Error(
+      `git worktree add failed: ${addResult.stderrTail.slice(-500)}`,
+    );
+  }
+
+  const cleanup = async (): Promise<void> => {
+    await runCommand('git', ['worktree', 'remove', '--force', dir], {
+      cwd: opts.repoCwd,
+      timeoutMs: GIT_TIMEOUT_MS,
+    });
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  };
+
+  return { dir, cleanup };
+}
+
+/**
+ * Best-effort pnpm install in the worktree. Long-timeout (10 min) because
+ * a cold store can take a while on the first hit.
+ */
+export async function pnpmInstall(cwd: string): Promise<{
+  exitCode: number | null;
+  stderrTail: string;
+}> {
+  const result = await runCommand(
+    'pnpm',
+    ['install', '--frozen-lockfile', '--prefer-offline'],
+    { cwd, timeoutMs: 10 * 60 * 1000 },
+  );
+  return { exitCode: result.exitCode, stderrTail: result.stderrTail };
+}

--- a/packages/adoption-enforcement/src/verify/build.ts
+++ b/packages/adoption-enforcement/src/verify/build.ts
@@ -1,0 +1,51 @@
+import { runCommand } from './runner.js';
+import type { CheckOptions, CheckResult } from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * V3 — build.
+ *
+ * Per §7, V3 is "build all" — but `all` in a 71-package monorepo would blow
+ * the per-PR 15-minute wall-clock cap. We narrow to `pnpm --filter <pkg>...`
+ * with the trailing `...` (downstream dependents) so transitive consumers of
+ * the target package are exercised without rebuilding every leaf in the repo.
+ *
+ * If `targetPackages` is empty we fall back to the repo-wide `pnpm build` so
+ * the gauntlet never trivially passes on a misconfigured invocation.
+ */
+export async function runBuild(options: CheckOptions): Promise<CheckResult> {
+  const args = buildArgs(options);
+  const command = `pnpm ${args.join(' ')}`;
+
+  const result = await runCommand('pnpm', args, {
+    cwd: options.cwd,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ...(options.env !== undefined ? { env: options.env } : {}),
+  });
+
+  return {
+    id: 'V3',
+    label: 'build',
+    command,
+    status: classify(result.exitCode, result.timedOut),
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+    stdoutTail: result.stdoutTail,
+    stderrTail: result.stderrTail,
+  };
+}
+
+function buildArgs(options: CheckOptions): string[] {
+  if (options.targetPackages.length === 0) {
+    return ['-w', 'build'];
+  }
+  const filters = options.targetPackages.flatMap((pkg) => ['--filter', `${pkg}...`]);
+  return [...filters, 'build'];
+}
+
+function classify(exitCode: number | null, timedOut: boolean): CheckResult['status'] {
+  if (timedOut) return 'timeout';
+  if (exitCode === 0) return 'pass';
+  return 'fail';
+}

--- a/packages/adoption-enforcement/src/verify/gauntlet.ts
+++ b/packages/adoption-enforcement/src/verify/gauntlet.ts
@@ -1,0 +1,112 @@
+import { runTypecheck } from './typecheck.js';
+import { runTests } from './tests.js';
+import { runBuild } from './build.js';
+import type { CheckOptions, CheckResult, VerificationResult } from './types.js';
+
+export interface GauntletOptions extends CheckOptions {
+  /**
+   * Wall-clock cap for the entire V1+V2+V3 gauntlet. Once exceeded, the
+   * currently-running check is allowed to finish but no further checks start.
+   */
+  readonly wallClockMs?: number;
+  /** Skip V2 if V1 fails (default true). */
+  readonly shortCircuit?: boolean;
+}
+
+const DEFAULT_WALL_CLOCK_MS = 15 * 60 * 1000;
+
+/**
+ * Run V1 → V2 → V3. Short-circuits on failure unless explicitly disabled.
+ * Returns a structured VerificationResult ready for comment rendering.
+ */
+export async function runGauntlet(options: GauntletOptions): Promise<VerificationResult> {
+  const wallClockMs = options.wallClockMs ?? DEFAULT_WALL_CLOCK_MS;
+  const shortCircuit = options.shortCircuit ?? true;
+  const started = Date.now();
+  const results: CheckResult[] = [];
+
+  const steps: ReadonlyArray<{
+    id: 'V1' | 'V2' | 'V3';
+    run: () => Promise<CheckResult>;
+  }> = [
+    { id: 'V1', run: () => runTypecheck(remainingOptions(options, wallClockMs, started)) },
+    { id: 'V2', run: () => runTests(remainingOptions(options, wallClockMs, started)) },
+    { id: 'V3', run: () => runBuild(remainingOptions(options, wallClockMs, started)) },
+  ];
+
+  for (const step of steps) {
+    if (Date.now() - started >= wallClockMs) {
+      results.push({
+        id: step.id,
+        label: labelFor(step.id),
+        command: '(skipped — gauntlet wall-clock budget exhausted)',
+        status: 'timeout',
+        exitCode: null,
+        durationMs: 0,
+        stdoutTail: '',
+        stderrTail: '',
+      });
+      continue;
+    }
+
+    const result = await step.run();
+    results.push(result);
+
+    if (shortCircuit && result.status !== 'pass' && result.status !== 'skipped') {
+      for (const remaining of steps.slice(steps.indexOf(step) + 1)) {
+        results.push({
+          id: remaining.id,
+          label: labelFor(remaining.id),
+          command: `(skipped — ${step.id} ${result.status})`,
+          status: 'skipped',
+          exitCode: null,
+          durationMs: 0,
+          stdoutTail: '',
+          stderrTail: '',
+        });
+      }
+      break;
+    }
+  }
+
+  const pass = results.every((r) => r.status === 'pass' || r.status === 'skipped') &&
+    results.some((r) => r.status === 'pass');
+
+  return {
+    pass,
+    checks: results,
+    durationMs: Date.now() - started,
+  };
+}
+
+function remainingOptions(
+  options: GauntletOptions,
+  wallClockMs: number,
+  started: number,
+): CheckOptions {
+  const remaining = Math.max(1, wallClockMs - (Date.now() - started));
+  const perCheckTimeout = Math.min(
+    options.timeoutMs ?? Number.POSITIVE_INFINITY,
+    remaining,
+  );
+  return {
+    cwd: options.cwd,
+    targetPackages: options.targetPackages,
+    ...(options.consumerPackages !== undefined
+      ? { consumerPackages: options.consumerPackages }
+      : {}),
+    timeoutMs: perCheckTimeout,
+    ...(options.env !== undefined ? { env: options.env } : {}),
+  };
+}
+
+function labelFor(id: 'V1' | 'V2' | 'V3'): string {
+  switch (id) {
+    case 'V1':
+      return 'typecheck';
+    case 'V2':
+      return 'tests';
+    case 'V3':
+      return 'build';
+  }
+}

--- a/packages/adoption-enforcement/src/verify/index.ts
+++ b/packages/adoption-enforcement/src/verify/index.ts
@@ -1,0 +1,11 @@
+export { runTypecheck } from './typecheck.js';
+export { runTests } from './tests.js';
+export { runBuild } from './build.js';
+export { runGauntlet } from './gauntlet.js';
+export type {
+  CheckId,
+  CheckOptions,
+  CheckResult,
+  VerificationResult,
+} from './types.js';
+export type { GauntletOptions } from './gauntlet.js';

--- a/packages/adoption-enforcement/src/verify/runner.ts
+++ b/packages/adoption-enforcement/src/verify/runner.ts
@@ -1,0 +1,82 @@
+import { spawn } from 'node:child_process';
+import { STDOUT_TAIL_LIMIT } from './types.js';
+
+export interface SpawnRunResult {
+  exitCode: number | null;
+  durationMs: number;
+  stdoutTail: string;
+  stderrTail: string;
+  timedOut: boolean;
+}
+
+export interface SpawnRunOptions {
+  readonly cwd: string;
+  readonly timeoutMs?: number;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Spawn a command, capture tails of stdout/stderr, enforce a wall-clock timeout.
+ * No shell interpolation — args are passed as an argv array.
+ */
+export async function runCommand(
+  command: string,
+  args: readonly string[],
+  options: SpawnRunOptions,
+): Promise<SpawnRunResult> {
+  const started = Date.now();
+  return await new Promise<SpawnRunResult>((resolve) => {
+    const child = spawn(command, args.slice(), {
+      cwd: options.cwd,
+      env: { ...process.env, ...(options.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    let timedOut = false;
+
+    const appendTail = (existing: string, chunk: string): string => {
+      const combined = existing + chunk;
+      if (combined.length <= STDOUT_TAIL_LIMIT) return combined;
+      return combined.slice(combined.length - STDOUT_TAIL_LIMIT);
+    };
+
+    child.stdout?.on('data', (data: Buffer) => {
+      stdoutBuf = appendTail(stdoutBuf, data.toString('utf8'));
+    });
+    child.stderr?.on('data', (data: Buffer) => {
+      stderrBuf = appendTail(stderrBuf, data.toString('utf8'));
+    });
+
+    let killTimer: NodeJS.Timeout | undefined;
+    if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, options.timeoutMs);
+    }
+
+    child.on('error', (err) => {
+      if (killTimer) clearTimeout(killTimer);
+      resolve({
+        exitCode: null,
+        durationMs: Date.now() - started,
+        stdoutTail: stdoutBuf,
+        stderrTail: appendTail(stderrBuf, `\n[spawn error] ${err.message}`),
+        timedOut,
+      });
+    });
+
+    child.on('close', (code) => {
+      if (killTimer) clearTimeout(killTimer);
+      resolve({
+        exitCode: code,
+        durationMs: Date.now() - started,
+        stdoutTail: stdoutBuf,
+        stderrTail: stderrBuf,
+        timedOut,
+      });
+    });
+  });
+}

--- a/packages/adoption-enforcement/src/verify/tests.ts
+++ b/packages/adoption-enforcement/src/verify/tests.ts
@@ -1,0 +1,59 @@
+import { runCommand } from './runner.js';
+import type { CheckOptions, CheckResult } from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * V2 — unit tests.
+ *
+ * Runs `pnpm --filter <pkg> test` for every consumer package whose source was
+ * touched by the adoption PR, plus target packages (which usually have their
+ * own integration tests of the adopted surface).
+ */
+export async function runTests(options: CheckOptions): Promise<CheckResult> {
+  const packages = uniq([...(options.consumerPackages ?? []), ...options.targetPackages]);
+
+  if (packages.length === 0) {
+    return {
+      id: 'V2',
+      label: 'tests',
+      command: 'pnpm test (no packages selected)',
+      status: 'skipped',
+      exitCode: 0,
+      durationMs: 0,
+      stdoutTail: '',
+      stderrTail: '',
+    };
+  }
+
+  const filterArgs = packages.flatMap((pkg) => ['--filter', pkg]);
+  const args = [...filterArgs, 'test'];
+  const command = `pnpm ${args.join(' ')}`;
+
+  const result = await runCommand('pnpm', args, {
+    cwd: options.cwd,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ...(options.env !== undefined ? { env: options.env } : {}),
+  });
+
+  return {
+    id: 'V2',
+    label: 'tests',
+    command,
+    status: classify(result.exitCode, result.timedOut),
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+    stdoutTail: result.stdoutTail,
+    stderrTail: result.stderrTail,
+  };
+}
+
+function uniq<T>(items: readonly T[]): T[] {
+  return Array.from(new Set(items));
+}
+
+function classify(exitCode: number | null, timedOut: boolean): CheckResult['status'] {
+  if (timedOut) return 'timeout';
+  if (exitCode === 0) return 'pass';
+  return 'fail';
+}

--- a/packages/adoption-enforcement/src/verify/typecheck.ts
+++ b/packages/adoption-enforcement/src/verify/typecheck.ts
@@ -1,0 +1,62 @@
+import { runCommand } from './runner.js';
+import type { CheckOptions, CheckResult } from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * V1 — typecheck.
+ *
+ * Runs `pnpm --filter <pkg> typecheck` for each target + consumer package.
+ * Aggregates into a single pass/fail CheckResult; first non-zero exit short-circuits.
+ *
+ * Per §7 of the adoption-enforcement design, V1 is the cheapest gate and must
+ * pass before V2/V3 are even attempted by the orchestrator (though this module
+ * does not enforce that ordering — the orchestrator does).
+ */
+export async function runTypecheck(options: CheckOptions): Promise<CheckResult> {
+  const packages = uniq([...options.targetPackages, ...(options.consumerPackages ?? [])]);
+
+  if (packages.length === 0) {
+    return {
+      id: 'V1',
+      label: 'typecheck',
+      command: 'pnpm typecheck (no packages selected)',
+      status: 'skipped',
+      exitCode: 0,
+      durationMs: 0,
+      stdoutTail: '',
+      stderrTail: '',
+    };
+  }
+
+  const filterArgs = packages.flatMap((pkg) => ['--filter', pkg]);
+  const args = [...filterArgs, 'typecheck'];
+  const command = `pnpm ${args.join(' ')}`;
+
+  const result = await runCommand('pnpm', args, {
+    cwd: options.cwd,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ...(options.env !== undefined ? { env: options.env } : {}),
+  });
+
+  return {
+    id: 'V1',
+    label: 'typecheck',
+    command,
+    status: classify(result.exitCode, result.timedOut),
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+    stdoutTail: result.stdoutTail,
+    stderrTail: result.stderrTail,
+  };
+}
+
+function uniq<T>(items: readonly T[]): T[] {
+  return Array.from(new Set(items));
+}
+
+function classify(exitCode: number | null, timedOut: boolean): CheckResult['status'] {
+  if (timedOut) return 'timeout';
+  if (exitCode === 0) return 'pass';
+  return 'fail';
+}

--- a/packages/adoption-enforcement/src/verify/types.ts
+++ b/packages/adoption-enforcement/src/verify/types.ts
@@ -1,0 +1,28 @@
+export type CheckId = 'V1' | 'V2' | 'V3';
+
+export interface CheckOptions {
+  readonly cwd: string;
+  readonly targetPackages: readonly string[];
+  readonly consumerPackages?: readonly string[];
+  readonly timeoutMs?: number;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export interface CheckResult {
+  readonly id: CheckId;
+  readonly label: string;
+  readonly command: string;
+  readonly status: 'pass' | 'fail' | 'timeout' | 'skipped';
+  readonly exitCode: number | null;
+  readonly durationMs: number;
+  readonly stdoutTail: string;
+  readonly stderrTail: string;
+}
+
+export interface VerificationResult {
+  readonly pass: boolean;
+  readonly checks: readonly CheckResult[];
+  readonly durationMs: number;
+}
+
+export const STDOUT_TAIL_LIMIT = 4000;

--- a/packages/adoption-enforcement/tests/pr/affected-packages.test.ts
+++ b/packages/adoption-enforcement/tests/pr/affected-packages.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { inferPackages } from '../../src/pr/affected-packages.js';
+
+async function fixture(layout: Record<string, { name: string }>): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'adopt-test-'));
+  for (const [pkgDir, contents] of Object.entries(layout)) {
+    const full = path.join(dir, 'packages', pkgDir);
+    await fs.mkdir(full, { recursive: true });
+    await fs.writeFile(
+      path.join(full, 'package.json'),
+      JSON.stringify({ name: contents.name }),
+    );
+  }
+  return dir;
+}
+
+describe('inferPackages', () => {
+  it('maps changed files to workspace package names', async () => {
+    const dir = await fixture({
+      'guardrails-validator': { name: '@chiefaia/guardrails-validator' },
+      'orchestrator':         { name: '@chiefaia/orchestrator' },
+    });
+
+    const result = await inferPackages({
+      worktreeDir: dir,
+      pr: {
+        number: 1,
+        headRefName: 'adopt/guardrails-validator-abc1234',
+        headRefOid: 'abc1234deadbeef',
+        baseRefName: 'develop',
+        url: '',
+        title: 'chore(adopt): use @chiefaia/guardrails-validator in orchestrator',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        labels: [],
+        files: [
+          { path: 'packages/orchestrator/src/safety/bridge.ts' },
+        ],
+      },
+    });
+
+    expect(result.targetPackages).toContain('@chiefaia/guardrails-validator');
+    expect(result.consumerPackages).toContain('@chiefaia/orchestrator');
+  });
+
+  it('falls back to branch when title lacks the target', async () => {
+    const dir = await fixture({
+      'tracing': { name: '@chiefaia/tracing' },
+    });
+
+    const result = await inferPackages({
+      worktreeDir: dir,
+      pr: {
+        number: 2,
+        headRefName: 'adopt/tracing-feed1234',
+        headRefOid: 'feed1234',
+        baseRefName: 'develop',
+        url: '',
+        title: 'chore(adopt): wire tracing across orchestrator',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        labels: [],
+        files: [
+          { path: 'packages/tracing/src/index.ts' },
+        ],
+      },
+    });
+
+    expect(result.targetPackages).toContain('@chiefaia/tracing');
+  });
+});

--- a/packages/adoption-enforcement/tests/pr/comment.test.ts
+++ b/packages/adoption-enforcement/tests/pr/comment.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { renderVerificationComment } from '../../src/pr/comment.js';
+import { COMMENT_MARKER } from '../../src/pr/types.js';
+
+describe('renderVerificationComment', () => {
+  const baseArgs = {
+    pr: { number: 542, headRefOid: 'abcdef1234567890' },
+    targetPackages: ['@chiefaia/guardrails-validator'],
+    consumerPackages: ['@chiefaia/orchestrator'],
+    worktreeDir: '/tmp/adopt-verify-abcdef12',
+    startedAt: '2026-05-16T20:00:00Z',
+    finishedAt: '2026-05-16T20:05:00Z',
+  };
+
+  it('embeds the upsert marker on PASS', () => {
+    const body = renderVerificationComment({
+      ...baseArgs,
+      result: {
+        pass: true,
+        durationMs: 300_000,
+        checks: [
+          { id: 'V1', label: 'typecheck', command: 'pnpm typecheck', status: 'pass', exitCode: 0, durationMs: 1000, stdoutTail: '', stderrTail: '' },
+          { id: 'V2', label: 'tests',     command: 'pnpm test',      status: 'pass', exitCode: 0, durationMs: 2000, stdoutTail: '', stderrTail: '' },
+          { id: 'V3', label: 'build',     command: 'pnpm build',     status: 'pass', exitCode: 0, durationMs: 3000, stdoutTail: '', stderrTail: '' },
+        ],
+      },
+    });
+    expect(body.startsWith(COMMENT_MARKER)).toBe(true);
+    expect(body).toContain('Adoption verification — PASS');
+    expect(body).toContain('| V1 | typecheck |');
+    expect(body).toContain('@chiefaia/orchestrator');
+  });
+
+  it('includes failure details on FAIL', () => {
+    const body = renderVerificationComment({
+      ...baseArgs,
+      result: {
+        pass: false,
+        durationMs: 60_000,
+        checks: [
+          { id: 'V1', label: 'typecheck', command: 'pnpm typecheck', status: 'fail', exitCode: 1, durationMs: 1000, stdoutTail: 'last stdout', stderrTail: 'TS2304: Cannot find name "doTheThing"' },
+          { id: 'V2', label: 'tests',     command: '(skipped)',      status: 'skipped', exitCode: null, durationMs: 0, stdoutTail: '', stderrTail: '' },
+          { id: 'V3', label: 'build',     command: '(skipped)',      status: 'skipped', exitCode: null, durationMs: 0, stdoutTail: '', stderrTail: '' },
+        ],
+      },
+    });
+    expect(body).toContain('Adoption verification — FAIL');
+    expect(body).toContain('TS2304');
+    expect(body).toContain('### V1 typecheck — fail');
+    expect(body).toContain('<details><summary>stderr (tail)');
+  });
+
+  it('renders setup errors when supplied', () => {
+    const body = renderVerificationComment({
+      ...baseArgs,
+      setupErrors: ['pnpm install exit 1: cold-store EPERM'],
+      result: { pass: false, durationMs: 0, checks: [] },
+    });
+    expect(body).toContain('### Setup errors');
+    expect(body).toContain('pnpm install exit 1');
+  });
+});

--- a/packages/adoption-enforcement/tests/verify/typecheck.test.ts
+++ b/packages/adoption-enforcement/tests/verify/typecheck.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { runTypecheck } from '../../src/verify/typecheck.js';
+import { runTests } from '../../src/verify/tests.js';
+import { runBuild } from '../../src/verify/build.js';
+import { runGauntlet } from '../../src/verify/gauntlet.js';
+
+describe('verify/typecheck', () => {
+  it('returns skipped when no packages provided', async () => {
+    const result = await runTypecheck({ cwd: process.cwd(), targetPackages: [] });
+    expect(result.id).toBe('V1');
+    expect(result.label).toBe('typecheck');
+    expect(result.status).toBe('skipped');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('builds the expected command for a single target package', async () => {
+    // We pin timeout to 1ms so the spawn times out fast — we only care about
+    // the command string, not the actual pnpm exit.
+    const result = await runTypecheck({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: ['@chiefaia/foo'],
+      timeoutMs: 1,
+    });
+    expect(result.command).toContain('--filter @chiefaia/foo');
+    expect(result.command).toContain('typecheck');
+    expect(['fail', 'timeout']).toContain(result.status);
+  });
+
+  it('deduplicates target/consumer overlap', async () => {
+    const result = await runTypecheck({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: ['@chiefaia/foo'],
+      consumerPackages: ['@chiefaia/foo', '@chiefaia/bar'],
+      timeoutMs: 1,
+    });
+    const filterMatches = (result.command.match(/--filter @chiefaia\/foo/g) ?? []).length;
+    expect(filterMatches).toBe(1);
+    expect(result.command).toContain('--filter @chiefaia/bar');
+  });
+});
+
+describe('verify/tests', () => {
+  it('returns skipped when no consumer or target packages', async () => {
+    const result = await runTests({ cwd: process.cwd(), targetPackages: [] });
+    expect(result.id).toBe('V2');
+    expect(result.status).toBe('skipped');
+  });
+
+  it('emits the test command for consumer packages', async () => {
+    const result = await runTests({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: [],
+      consumerPackages: ['@chiefaia/quux'],
+      timeoutMs: 1,
+    });
+    expect(result.command).toContain('--filter @chiefaia/quux');
+    expect(result.command).toContain('test');
+  });
+});
+
+describe('verify/build', () => {
+  it('falls back to repo-wide build when no targets', async () => {
+    const result = await runBuild({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: [],
+      timeoutMs: 1,
+    });
+    expect(result.command).toContain('-w');
+    expect(result.command).toContain('build');
+  });
+
+  it('uses --filter <pkg>... for targets', async () => {
+    const result = await runBuild({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: ['@chiefaia/foo'],
+      timeoutMs: 1,
+    });
+    expect(result.command).toContain('--filter @chiefaia/foo...');
+  });
+});
+
+describe('verify/gauntlet', () => {
+  it('returns pass=false when no checks could run', async () => {
+    const result = await runGauntlet({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: [],
+      wallClockMs: 100,
+      shortCircuit: false,
+    });
+    // V1 + V2 skip (no packages); V3 hits repo-wide build which fast-fails.
+    expect(result.checks.length).toBe(3);
+    expect(result.pass).toBe(false);
+  });
+
+  it('short-circuits subsequent checks after a failure', async () => {
+    const result = await runGauntlet({
+      cwd: '/nonexistent-dir-for-fast-fail',
+      targetPackages: ['@chiefaia/foo'],
+      consumerPackages: ['@chiefaia/bar'],
+      wallClockMs: 500,
+      shortCircuit: true,
+    });
+    expect(result.checks[0]?.id).toBe('V1');
+    // V1 fails => V2 and V3 should be 'skipped'
+    const v2 = result.checks.find((c) => c.id === 'V2');
+    const v3 = result.checks.find((c) => c.id === 'V3');
+    expect(v2?.status).toBe('skipped');
+    expect(v3?.status).toBe('skipped');
+    expect(result.pass).toBe(false);
+  });
+});

--- a/packages/adoption-enforcement/tsconfig.json
+++ b/packages/adoption-enforcement/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adoption-enforcement/vitest.config.ts
+++ b/packages/adoption-enforcement/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();


### PR DESCRIPTION
## Summary

Phase 1 of `p3-adoption-verification` — ships the verification gauntlet that runs against every `adopt/*` PR generated by the (parallel-running) `p3-adoption-pr-generator` chain.

- `packages/adoption-enforcement/` workspace package (`@chiefaia/adoption-enforcement`)
- **V1+V2+V3** per §7 of [agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md](https://github.com/prakashgbid/caia/blob/develop/../agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md): `src/verify/{typecheck,tests,build}.ts` + `gauntlet.ts` sequencer
- **Per-PR runner** at `src/pr/orchestrator.ts`: lists open PRs filtered by `adopt/*` head, prepares `/tmp/adopt-verify-<sha>` worktree, runs `pnpm install` + V1+V2+V3, enforces 15-min wall-clock cap per PR
- **Idempotent comment upsert** with `<!-- adoption-verify -->` marker (edits in place on subsequent runs)
- **Idempotent label toggle** — `adoption-verified` on pass, `adoption-failed` on fail
- **CLI**: `bin/caia-adoption-verify.mjs` — discovery + per-PR or all-PRs invocation, `--dry-run` for visibility
- **14 unit tests** across verify/* and pr/* (all pass; typecheck + lint also clean)

Out-of-scope per §9 of the design (deferred to MVP+1 / later chains): V4 smoke, V5 diff sanity, V6 lint/format, LLM-assisted xref, per-site / per-package PR modes, DoD-v2 gate wiring.

## Test plan

- [x] `pnpm --filter @chiefaia/adoption-enforcement typecheck` — clean
- [x] `pnpm --filter @chiefaia/adoption-enforcement test` — 14/14 pass
- [x] `pnpm --filter @chiefaia/adoption-enforcement build` — clean
- [x] `pnpm --filter @chiefaia/adoption-enforcement lint` — clean
- [ ] First real `adopt/*` PR will be the live integration test once `p3-adoption-pr-generator` ships its phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)