### PR TITLE
feat(chain-runner): adoption-everywhere gate module (G10 phase 1)

### DIFF
--- a/packages/chain-runner/src/gates/adoption-everywhere.ts
+++ b/packages/chain-runner/src/gates/adoption-everywhere.ts
@@ -1,0 +1,261 @@
+// DoD v2 Guardrail #10 — adoption-everywhere gate.
+//
+// Companion: reports/dod_v2_guardrail_10_adoption_everywhere_2026-05-16.md (PR #492).
+// Companion: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.
+//
+// Sits next to gate-mark-done.sh: G2 checks "open PR for the chain's branch?",
+// G10 checks "any adoption opportunity for the chain's deliverable still
+// pending?". Same chokepoint (caia-chain mark-done), different question.
+//
+// V1 scope (this phase): the programmatic gate + tests. The shell wiring
+// (gate-mark-done.sh extension + mark-done --adoption-pending-ok flag) and
+// the audit-event emission land in phase 2.
+//
+// Lifecycle states the gate sees (from substrate §5):
+//   discovered -> proposed -> opened -> verifying -> verified -> merged | failed | deferred | dropped
+//
+// Pass set (G10 §1 of the addendum):    {merged, deferred}
+// Block set (explicit per addendum):    {discovered, proposed, opened, verifying, failed, dropped}
+// Stuck-opened: state=opened AND (now - opened_at) > 14d -> block (independent of pass/block set).
+//
+// 'verified' is the only transitional state not in either set. Treat it as
+// block (conservative — substrate v1 produces 'merged' once the adoption PR
+// lands; 'verified' is an in-flight state and a chain should not be 'done'
+// while opportunities are still in verification).
+//
+// Empty ledger -> {ok:true, blockers:[]}. This is the v1 no-op mode that lets
+// the gate ship before scan/xref/generate populate the ledger (addendum §6).
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Pass states. An opportunity in one of these does NOT block the gate.
+ */
+export const ADOPTION_PASS_STATES = new Set<string>(['merged', 'deferred']);
+
+/**
+ * Block states explicitly listed in the addendum. Any state not in
+ * ADOPTION_PASS_STATES also blocks (defensive default), but these are the
+ * states we expect to see and surface with their own reason.
+ */
+export const ADOPTION_BLOCK_STATES = new Set<string>([
+  'discovered',
+  'proposed',
+  'opened',
+  'verifying',
+  'failed',
+  'dropped',
+]);
+
+/**
+ * Default age threshold for the stuck-opened check. Opportunities that have
+ * been in `opened` state longer than this without progressing are blockers
+ * even though `opened` is already in the block set — the separate reason
+ * makes operator triage easier.
+ */
+export const DEFAULT_STUCK_OPENED_DAYS = 14;
+
+export interface CheckAdoptionGateOptions {
+  /** Override ledger path. Defaults to <home>/.caia/adoption/ledger.jsonl. */
+  ledgerPath?: string;
+  /** Override $HOME (test injection). Ignored when ledgerPath is set. */
+  homeDir?: string;
+  /** Override "now" for deterministic stuck-opened tests. Defaults to Date(). */
+  now?: Date;
+  /** Override the stuck-opened threshold. */
+  stuckOpenedDays?: number;
+}
+
+export type BlockerReason = 'pending_state' | 'stuck_opened' | 'unknown_state';
+
+export interface AdoptionGateBlocker {
+  /** Stable id from the ledger row if present (substrate emits one). */
+  opportunity_id?: string;
+  /** Lifecycle state observed. */
+  state: string;
+  /** Why this row blocks. */
+  reason: BlockerReason;
+  /** Diagnostic fields, copied through best-effort. */
+  target_utility?: string;
+  target_export?: string;
+  call_site_file?: string;
+  call_site_line?: number;
+  /** ISO timestamp when state moved to `opened` (for stuck-opened). */
+  opened_at?: string;
+  /** Age in days at gate-check time (only set for stuck-opened). */
+  age_days?: number;
+}
+
+export interface AdoptionGateResult {
+  /** True when no row blocks the chain from being marked done. */
+  ok: boolean;
+  /** One entry per blocking ledger row, in ledger-file order. */
+  blockers: AdoptionGateBlocker[];
+  /** Total rows in the ledger matching this chain_id. */
+  total_rows: number;
+  /** Rows in ADOPTION_PASS_STATES (merged/deferred). */
+  passing_rows: number;
+  /** Absolute path the gate actually consulted. */
+  ledger_path: string;
+  /** True when the ledger file did not exist or was empty. */
+  empty_ledger: boolean;
+  /** Lines that failed to parse — surfaced for operator visibility. */
+  malformed_lines: number;
+}
+
+interface LedgerRow {
+  chain_id?: string;
+  state?: string;
+  opportunity_id?: string;
+  target_utility?: string;
+  target_export?: string;
+  call_site_file?: string;
+  call_site_line?: number;
+  opened_at?: string;
+  [k: string]: unknown;
+}
+
+function defaultLedgerPath(opts: CheckAdoptionGateOptions): string {
+  if (opts.ledgerPath) return opts.ledgerPath;
+  const home = opts.homeDir ?? homedir();
+  return join(home, '.caia', 'adoption', 'ledger.jsonl');
+}
+
+function parseLedger(
+  path: string,
+): { rows: LedgerRow[]; malformed: number } {
+  if (!existsSync(path)) return { rows: [], malformed: 0 };
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return { rows: [], malformed: 0 };
+  }
+  if (raw.length === 0) return { rows: [], malformed: 0 };
+  const rows: LedgerRow[] = [];
+  let malformed = 0;
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (parsed && typeof parsed === 'object') {
+        rows.push(parsed as LedgerRow);
+      } else {
+        malformed += 1;
+      }
+    } catch {
+      malformed += 1;
+    }
+  }
+  return { rows, malformed };
+}
+
+function ageDays(openedAt: string, now: Date): number | null {
+  const t = Date.parse(openedAt);
+  if (Number.isNaN(t)) return null;
+  return (now.getTime() - t) / (1000 * 60 * 60 * 24);
+}
+
+function rowToBlocker(
+  row: LedgerRow,
+  reason: BlockerReason,
+  ageDaysVal?: number,
+): AdoptionGateBlocker {
+  const b: AdoptionGateBlocker = {
+    state: typeof row.state === 'string' ? row.state : '<missing>',
+    reason,
+  };
+  if (typeof row.opportunity_id === 'string') b.opportunity_id = row.opportunity_id;
+  if (typeof row.target_utility === 'string') b.target_utility = row.target_utility;
+  if (typeof row.target_export === 'string') b.target_export = row.target_export;
+  if (typeof row.call_site_file === 'string') b.call_site_file = row.call_site_file;
+  if (typeof row.call_site_line === 'number') b.call_site_line = row.call_site_line;
+  if (typeof row.opened_at === 'string') b.opened_at = row.opened_at;
+  if (ageDaysVal !== undefined) b.age_days = ageDaysVal;
+  return b;
+}
+
+/**
+ * Check whether the given chain is clear to be marked done w.r.t. the
+ * adoption-everywhere guardrail.
+ *
+ * Empty / missing ledger -> ok=true (v1 no-op mode). This is intentional:
+ * the gate ships before the scan/xref/generate substrate, and an empty
+ * ledger means "we have no opportunities recorded, therefore none to block
+ * on" rather than "the substrate is broken." Operator-facing observability
+ * for "no rows for any chain in N days" lives outside this function.
+ *
+ * Pass criteria (per addendum §1):
+ *   - every row for this chain_id is in {merged, deferred}
+ *   - AND no row in 'opened' state is older than stuckOpenedDays.
+ */
+export function checkAdoptionGate(
+  chainId: string,
+  opts: CheckAdoptionGateOptions = {},
+): AdoptionGateResult {
+  if (typeof chainId !== 'string' || chainId.length === 0) {
+    throw new Error('checkAdoptionGate: chainId is required');
+  }
+
+  const ledger_path = defaultLedgerPath(opts);
+  const { rows, malformed } = parseLedger(ledger_path);
+  const now = opts.now ?? new Date();
+  const stuckDays = opts.stuckOpenedDays ?? DEFAULT_STUCK_OPENED_DAYS;
+
+  const myRows = rows.filter((r) => r.chain_id === chainId);
+
+  if (myRows.length === 0) {
+    return {
+      ok: true,
+      blockers: [],
+      total_rows: 0,
+      passing_rows: 0,
+      ledger_path,
+      empty_ledger: rows.length === 0,
+      malformed_lines: malformed,
+    };
+  }
+
+  const blockers: AdoptionGateBlocker[] = [];
+  let passing = 0;
+
+  for (const row of myRows) {
+    const state = typeof row.state === 'string' ? row.state : '';
+
+    if (ADOPTION_PASS_STATES.has(state)) {
+      passing += 1;
+      continue;
+    }
+
+    if (state === 'opened' && typeof row.opened_at === 'string') {
+      const age = ageDays(row.opened_at, now);
+      if (age !== null && age > stuckDays) {
+        blockers.push(rowToBlocker(row, 'stuck_opened', age));
+        continue;
+      }
+    }
+
+    if (ADOPTION_BLOCK_STATES.has(state)) {
+      blockers.push(rowToBlocker(row, 'pending_state'));
+      continue;
+    }
+
+    // Defensive: any state outside the pass + known-block sets (including
+    // 'verified' and any future state) blocks until promoted. Keeps the gate
+    // safe under substrate schema drift.
+    blockers.push(rowToBlocker(row, 'unknown_state'));
+  }
+
+  return {
+    ok: blockers.length === 0,
+    blockers,
+    total_rows: myRows.length,
+    passing_rows: passing,
+    ledger_path,
+    empty_ledger: false,
+    malformed_lines: malformed,
+  };
+}

--- a/packages/chain-runner/src/index.ts
+++ b/packages/chain-runner/src/index.ts
@@ -34,3 +34,15 @@ export type {
 } from './pr-merge/index.js';
 export { createSafe } from './pr-create/index.js';
 export type { CreateSafeOpts, CreateSafeOutcome } from './pr-create/index.js';
+export {
+  checkAdoptionGate,
+  ADOPTION_PASS_STATES,
+  ADOPTION_BLOCK_STATES,
+  DEFAULT_STUCK_OPENED_DAYS,
+} from './gates/adoption-everywhere.js';
+export type {
+  AdoptionGateBlocker,
+  AdoptionGateResult,
+  BlockerReason,
+  CheckAdoptionGateOptions,
+} from './gates/adoption-everywhere.js';

--- a/packages/chain-runner/tests/gates/adoption-everywhere.test.ts
+++ b/packages/chain-runner/tests/gates/adoption-everywhere.test.ts
@@ -1,0 +1,353 @@
+// Tests for src/gates/adoption-everywhere.ts (DoD v2 Guardrail #10).
+//
+// Coverage matrix (per phase-1 prompt + addendum §1):
+//   - empty ledger (file missing)            -> ok=true (no-op mode)
+//   - empty ledger (file exists, zero rows)  -> ok=true
+//   - all rows for chain are 'merged'         -> ok=true
+//   - all rows for chain are 'deferred'       -> ok=true
+//   - one row in 'opened' (recent)            -> ok=false, reason=pending_state
+//   - one row in 'opened' > stuckOpenedDays   -> ok=false, reason=stuck_opened, age_days set
+//   - one row in 'failed'                     -> ok=false, reason=pending_state
+//   - one row in 'verified' (unknown state)   -> ok=false, reason=unknown_state (defensive)
+//   - rows for other chain_id ignored        -> ok=true when own rows are clear
+//   - mixed: merged + deferred + opened      -> ok=false (the opened blocks)
+//   - malformed JSON lines                    -> counted, do not crash
+//   - missing chainId                         -> throws
+//   - homeDir override resolves to ~/.caia/adoption/ledger.jsonl
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ADOPTION_BLOCK_STATES,
+  ADOPTION_PASS_STATES,
+  DEFAULT_STUCK_OPENED_DAYS,
+  checkAdoptionGate,
+  type AdoptionGateResult,
+} from '../../src/gates/adoption-everywhere.js';
+
+let root: string;
+let ledgerDir: string;
+let ledgerPath: string;
+
+const CHAIN = 'p3-test-chain';
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'caia-adopt-gate-'));
+  ledgerDir = join(root, '.caia', 'adoption');
+  mkdirSync(ledgerDir, { recursive: true });
+  ledgerPath = join(ledgerDir, 'ledger.jsonl');
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+function writeLedger(rows: Array<Record<string, unknown> | string>): void {
+  const lines = rows.map((r) => (typeof r === 'string' ? r : JSON.stringify(r)));
+  writeFileSync(ledgerPath, lines.join('\n') + '\n');
+}
+
+function row(extra: Record<string, unknown>): Record<string, unknown> {
+  return { chain_id: CHAIN, ...extra };
+}
+
+describe('checkAdoptionGate — passing constants', () => {
+  it('exports the expected pass set', () => {
+    expect(new Set(ADOPTION_PASS_STATES)).toEqual(new Set(['merged', 'deferred']));
+  });
+  it('exports the expected block set', () => {
+    expect(new Set(ADOPTION_BLOCK_STATES)).toEqual(
+      new Set(['discovered', 'proposed', 'opened', 'verifying', 'failed', 'dropped']),
+    );
+  });
+  it('default stuck-opened threshold is 14 days (addendum §1)', () => {
+    expect(DEFAULT_STUCK_OPENED_DAYS).toBe(14);
+  });
+});
+
+describe('checkAdoptionGate — empty ledger (v1 no-op mode)', () => {
+  it('returns ok=true when the ledger file does not exist', () => {
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.blockers).toEqual([]);
+    expect(r.empty_ledger).toBe(true);
+    expect(r.total_rows).toBe(0);
+    expect(r.ledger_path).toBe(ledgerPath);
+  });
+
+  it('returns ok=true when the ledger file exists but is empty', () => {
+    writeFileSync(ledgerPath, '');
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.empty_ledger).toBe(true);
+  });
+
+  it('returns ok=true when the ledger only has rows for other chains', () => {
+    writeLedger([
+      { chain_id: 'some-other-chain', state: 'opened' },
+      { chain_id: 'yet-another-chain', state: 'failed' },
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.total_rows).toBe(0);
+    expect(r.empty_ledger).toBe(false);
+  });
+});
+
+describe('checkAdoptionGate — all-pass states', () => {
+  it('ok=true when every chain row is merged', () => {
+    writeLedger([
+      row({ opportunity_id: 'op-1', state: 'merged' }),
+      row({ opportunity_id: 'op-2', state: 'merged' }),
+      row({ opportunity_id: 'op-3', state: 'merged' }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.passing_rows).toBe(3);
+    expect(r.blockers).toEqual([]);
+  });
+
+  it('ok=true when every chain row is deferred (per-site deferral)', () => {
+    writeLedger([
+      row({ opportunity_id: 'op-d1', state: 'deferred' }),
+      row({ opportunity_id: 'op-d2', state: 'deferred' }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.passing_rows).toBe(2);
+  });
+
+  it('ok=true with mixed merged + deferred', () => {
+    writeLedger([
+      row({ state: 'merged' }),
+      row({ state: 'deferred' }),
+      row({ state: 'merged' }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.passing_rows).toBe(3);
+  });
+});
+
+describe('checkAdoptionGate — one pending row blocks', () => {
+  it('rejects on opened (recent — pending_state, not stuck)', () => {
+    const now = new Date('2026-05-16T12:00:00Z');
+    writeLedger([
+      row({
+        opportunity_id: 'op-pend',
+        target_utility: '@chiefaia/hmac-auth',
+        target_export: 'sign',
+        call_site_file: 'apps/web/server.ts',
+        call_site_line: 42,
+        state: 'opened',
+        opened_at: '2026-05-15T12:00:00Z', // 1d old
+      }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root, now });
+    expect(r.ok).toBe(false);
+    expect(r.blockers).toHaveLength(1);
+    expect(r.blockers[0]).toMatchObject({
+      opportunity_id: 'op-pend',
+      state: 'opened',
+      reason: 'pending_state',
+      target_utility: '@chiefaia/hmac-auth',
+      target_export: 'sign',
+      call_site_file: 'apps/web/server.ts',
+      call_site_line: 42,
+      opened_at: '2026-05-15T12:00:00Z',
+    });
+    expect(r.blockers[0]!.age_days).toBeUndefined();
+    expect(r.passing_rows).toBe(0);
+    expect(r.total_rows).toBe(1);
+  });
+
+  it('rejects on discovered / proposed / verifying / failed / dropped', () => {
+    const blockingStates = ['discovered', 'proposed', 'verifying', 'failed', 'dropped'];
+    for (const state of blockingStates) {
+      writeLedger([row({ opportunity_id: `op-${state}`, state })]);
+      const r = checkAdoptionGate(CHAIN, { homeDir: root });
+      expect(r.ok, `state=${state} should block`).toBe(false);
+      expect(r.blockers[0]!.reason).toBe('pending_state');
+      expect(r.blockers[0]!.state).toBe(state);
+    }
+  });
+
+  it('still passes other chains when this chain has one pending row', () => {
+    writeLedger([
+      row({ state: 'opened', opened_at: '2026-05-16T00:00:00Z' }),
+      { chain_id: 'other', state: 'merged' },
+    ]);
+    const r = checkAdoptionGate(CHAIN, {
+      homeDir: root,
+      now: new Date('2026-05-16T01:00:00Z'),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.total_rows).toBe(1);
+    expect(r.blockers).toHaveLength(1);
+  });
+});
+
+describe('checkAdoptionGate — stuck-opened (>14d)', () => {
+  it('blocks with reason=stuck_opened when opened_at > 14d ago', () => {
+    const now = new Date('2026-05-16T12:00:00Z');
+    writeLedger([
+      row({
+        opportunity_id: 'op-stuck',
+        state: 'opened',
+        opened_at: '2026-04-15T12:00:00Z', // 31d old
+      }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root, now });
+    expect(r.ok).toBe(false);
+    expect(r.blockers).toHaveLength(1);
+    expect(r.blockers[0]!.reason).toBe('stuck_opened');
+    expect(r.blockers[0]!.opportunity_id).toBe('op-stuck');
+    expect(r.blockers[0]!.age_days).toBeGreaterThan(14);
+    expect(r.blockers[0]!.age_days).toBeLessThan(32);
+  });
+
+  it('right at the boundary (14.0d) is still pending_state, just over is stuck_opened', () => {
+    const now = new Date('2026-05-16T12:00:00Z');
+    // exactly 14d old -> NOT stuck (age > 14, strictly)
+    writeLedger([row({ state: 'opened', opened_at: '2026-05-02T12:00:00Z' })]);
+    const exactly14 = checkAdoptionGate(CHAIN, { homeDir: root, now });
+    expect(exactly14.blockers[0]!.reason).toBe('pending_state');
+
+    // 14.01d old -> stuck
+    writeLedger([row({ state: 'opened', opened_at: '2026-05-02T11:45:00Z' })]);
+    const justOver = checkAdoptionGate(CHAIN, { homeDir: root, now });
+    expect(justOver.blockers[0]!.reason).toBe('stuck_opened');
+  });
+
+  it('honors stuckOpenedDays override', () => {
+    const now = new Date('2026-05-16T12:00:00Z');
+    writeLedger([row({ state: 'opened', opened_at: '2026-05-10T12:00:00Z' })]); // 6d old
+    const def = checkAdoptionGate(CHAIN, { homeDir: root, now });
+    expect(def.blockers[0]!.reason).toBe('pending_state'); // not stuck @ 14d
+    const tight = checkAdoptionGate(CHAIN, { homeDir: root, now, stuckOpenedDays: 5 });
+    expect(tight.blockers[0]!.reason).toBe('stuck_opened'); // stuck @ 5d
+  });
+
+  it('opened without opened_at degrades to pending_state (no crash)', () => {
+    writeLedger([row({ state: 'opened' /* no opened_at */ })]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(false);
+    expect(r.blockers[0]!.reason).toBe('pending_state');
+  });
+
+  it('unparseable opened_at degrades to pending_state', () => {
+    writeLedger([row({ state: 'opened', opened_at: 'not-a-date' })]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.blockers[0]!.reason).toBe('pending_state');
+  });
+});
+
+describe('checkAdoptionGate — defensive states (substrate drift)', () => {
+  it('verified is treated as unknown_state (blocks)', () => {
+    writeLedger([row({ state: 'verified' })]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(false);
+    expect(r.blockers[0]!.reason).toBe('unknown_state');
+  });
+
+  it('any future state not in pass set blocks', () => {
+    writeLedger([row({ state: 'a-future-state' })]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(false);
+    expect(r.blockers[0]!.reason).toBe('unknown_state');
+  });
+
+  it('row with no state at all blocks as unknown_state', () => {
+    writeLedger([row({ opportunity_id: 'op-no-state' })]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(false);
+    expect(r.blockers[0]!.reason).toBe('unknown_state');
+    expect(r.blockers[0]!.state).toBe('<missing>');
+  });
+});
+
+describe('checkAdoptionGate — mixed states', () => {
+  it('one block dominates many passes', () => {
+    writeLedger([
+      row({ opportunity_id: 'a', state: 'merged' }),
+      row({ opportunity_id: 'b', state: 'merged' }),
+      row({ opportunity_id: 'c', state: 'deferred' }),
+      row({
+        opportunity_id: 'd',
+        state: 'opened',
+        opened_at: '2026-05-16T00:00:00Z',
+      }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, {
+      homeDir: root,
+      now: new Date('2026-05-16T06:00:00Z'),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.total_rows).toBe(4);
+    expect(r.passing_rows).toBe(3);
+    expect(r.blockers).toHaveLength(1);
+    expect(r.blockers[0]!.opportunity_id).toBe('d');
+  });
+
+  it('preserves blocker order from ledger', () => {
+    writeLedger([
+      row({ opportunity_id: 'first-block', state: 'failed' }),
+      row({ opportunity_id: 'pass', state: 'merged' }),
+      row({ opportunity_id: 'second-block', state: 'proposed' }),
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.blockers.map((b) => b.opportunity_id)).toEqual([
+      'first-block',
+      'second-block',
+    ]);
+  });
+});
+
+describe('checkAdoptionGate — malformed / robustness', () => {
+  it('skips malformed JSON lines and counts them', () => {
+    writeLedger([
+      'not-json',
+      JSON.stringify(row({ state: 'merged' })),
+      '{"chain_id":', // truncated
+      JSON.stringify(row({ state: 'merged' })),
+      '"a-string-not-an-object"',
+    ]);
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.total_rows).toBe(2);
+    expect(r.malformed_lines).toBe(3);
+  });
+
+  it('tolerates blank lines', () => {
+    writeFileSync(
+      ledgerPath,
+      '\n\n' + JSON.stringify(row({ state: 'merged' })) + '\n\n\n',
+    );
+    const r = checkAdoptionGate(CHAIN, { homeDir: root });
+    expect(r.ok).toBe(true);
+    expect(r.total_rows).toBe(1);
+  });
+
+  it('throws when chainId is missing or empty', () => {
+    expect(() => checkAdoptionGate('', { homeDir: root })).toThrow();
+    // @ts-expect-error — runtime guard for non-string callers
+    expect(() => checkAdoptionGate(undefined)).toThrow();
+  });
+
+  it('ledgerPath override wins over homeDir', () => {
+    const otherPath = join(root, 'custom-ledger.jsonl');
+    writeFileSync(otherPath, JSON.stringify(row({ state: 'opened', opened_at: '2026-05-16T00:00:00Z' })) + '\n');
+    const r: AdoptionGateResult = checkAdoptionGate(CHAIN, {
+      ledgerPath: otherPath,
+      now: new Date('2026-05-16T01:00:00Z'),
+    });
+    expect(r.ledger_path).toBe(otherPath);
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of 3 of the **p3-dod-v2-adoption-gate** chain — builds the programmatic gate behind DoD v2 Guardrail #10 (PR #492).

- `packages/chain-runner/src/gates/adoption-everywhere.ts` — exports `checkAdoptionGate(chainId, opts) -> { ok, blockers[] }`
- Reads `~/.caia/adoption/ledger.jsonl`, filters to rows for the given chain, returns the pass/block verdict per addendum §1
- Tests: 26 cases covering empty ledger, all-merged, all-deferred, one-pending (per state), stuck-opened (>14d) with threshold boundary + override, unknown_state defensive path, mixed states, blocker order, malformed JSON, missing chainId, ledgerPath override
- Empty / missing ledger -> `{ok:true}` (v1 no-op so the gate ships before the scan/xref/generate substrate populates the ledger — per addendum §6)

## Pass / block matrix
| State | Treatment | Reason |
|---|---|---|
| `merged` | pass | addendum §1 |
| `deferred` | pass | addendum §1 (per-site `adoption-deferrals.md`) |
| `discovered` / `proposed` / `opened` / `verifying` / `failed` / `dropped` | block | `pending_state` |
| `opened` with age > 14d | block | `stuck_opened` (separate reason for triage) |
| `verified` / future / unknown | block | `unknown_state` (defensive — substrate v1 promotes 'verified' -> 'merged'; staying in 'verified' isn't 'done') |

## Companion docs
- `reports/dod_v2_guardrail_10_adoption_everywhere_2026-05-16.md` (PR #492) — §1 (rule), §2 (where it lives), §6 (effort)
- `agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md` — lifecycle states (§5)

## Out of scope (phase 2 / 3)
- `scripts/gate-mark-done.sh` extension
- `caia-chain mark-done --adoption-pending-ok` flag
- `adoption_gate_check` audit event emission
- `~/.caia/adoption/gate-policy.json` (advisory-mode toggle, addendum §10)
- `caia/docs/adoption-deferrals.md` template

## Test plan
- [x] `pnpm test -- adoption-everywhere` — 26/26 pass
- [x] `pnpm typecheck` clean
- [x] Pre-existing failures (plist-health-check, bootstrap-chain, lifecycle_p11b) confirmed unrelated — they fail on `develop` HEAD too

🤖 Generated with [Claude Code](https://claude.com/claude-code)