### PR TITLE
feat(adoption-enforcement): L1 cross-ref scoring + --max-candidates cap (xref P2)

### DIFF
--- a/packages/adoption-enforcement/src/crossref/index.ts
+++ b/packages/adoption-enforcement/src/crossref/index.ts
@@ -9,3 +9,22 @@ export type {
   LiteralConfidence,
   LiteralPatternOptions,
 } from './literal-pattern.js';
+
+export {
+  scoreCandidates,
+  computeUniqueness,
+  computeFrequencyWeight,
+  computeScore,
+  applyMaxCandidates,
+  countExportingPackages,
+  countTotalHits,
+  DEFAULT_MAX_CANDIDATES,
+  DEFAULT_PACKAGE_SCOPE,
+  DEFAULT_PACKAGES_DIRS,
+} from './score.js';
+export type {
+  ScoredCandidate,
+  ArtefactScoring,
+  ScoreCandidatesResult,
+  ScoreCandidatesOptions,
+} from './score.js';

--- a/packages/adoption-enforcement/src/crossref/score.ts
+++ b/packages/adoption-enforcement/src/crossref/score.ts
@@ -1,0 +1,279 @@
+// L1 cross-ref candidate scoring + per-artefact cap.
+//
+// score = uniqueness × frequency_weight
+//
+//   uniqueness         = 1 / max(1, # @chiefaia/* packages that export this identifier).
+//                        A name exported in only one place is a stronger signal than a
+//                        name exported in many places (collision-prone).
+//   frequency_weight   = 1 / log2(2 + total git-grep hits across repo).
+//                        Rarely-used identifiers score higher (less likely coincidental).
+//
+// Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md (§5).
+//
+// The score is per-artefact (one identifier ⇒ one score). It is attached to every
+// candidate so downstream consumers can sort artefacts by confidence without needing
+// to recombine. `--max-candidates` then caps per-artefact fan-out (default 5).
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { ArtefactRow, LiteralCandidate } from './literal-pattern.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ScoredCandidate extends LiteralCandidate {
+  /** Per-artefact score: uniqueness × frequencyWeight. Same value for every candidate of the artefact. */
+  score: number;
+}
+
+export interface ArtefactScoring {
+  uniqueness: number;
+  frequencyWeight: number;
+  score: number;
+  exportingPackagesCount: number;
+  totalHits: number;
+}
+
+export interface ScoreCandidatesResult {
+  scoring: ArtefactScoring;
+  /** Capped at maxCandidates. Sorted desc by score (stable; per-artefact ties preserve input order). */
+  candidates: ScoredCandidate[];
+  /** Count of candidates dropped by the cap (0 when uncapped or under-cap). */
+  truncated: number;
+}
+
+export interface ScoreCandidatesOptions {
+  /** Absolute path to the repository working tree. */
+  repoRoot: string;
+  /** Per-artefact cap on candidate count. Default 5. Pass Infinity / 0 to disable. */
+  maxCandidates?: number;
+  /** Scope used to filter workspace packages when counting exports. Default "@chiefaia". */
+  packageScope?: string;
+  /** Directories to scan for workspace packages. Default ["packages"]. */
+  packagesDirs?: ReadonlyArray<string>;
+  /** Test override: forced count of @scope/* packages exporting the identifier. */
+  exportingPackagesCount?: number;
+  /** Test override: forced total raw git-grep hit count for the identifier. */
+  totalHits?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_MAX_CANDIDATES = 5;
+export const DEFAULT_PACKAGE_SCOPE = '@chiefaia';
+export const DEFAULT_PACKAGES_DIRS: ReadonlyArray<string> = ['packages'];
+
+// ---------------------------------------------------------------------------
+// Pure scoring math
+// ---------------------------------------------------------------------------
+
+export function computeUniqueness(exportingPackagesCount: number): number {
+  const n = Math.max(1, Math.floor(exportingPackagesCount));
+  return 1 / n;
+}
+
+export function computeFrequencyWeight(totalHits: number): number {
+  const hits = Math.max(0, totalHits);
+  return 1 / Math.log2(2 + hits);
+}
+
+export function computeScore(uniqueness: number, frequencyWeight: number): number {
+  return uniqueness * frequencyWeight;
+}
+
+// ---------------------------------------------------------------------------
+// Cap helper (exposed for unit-level coverage)
+// ---------------------------------------------------------------------------
+
+export function applyMaxCandidates<T extends { score: number }>(
+  items: ReadonlyArray<T>,
+  maxCandidates: number,
+): { kept: T[]; truncated: number } {
+  // Stable sort desc by score — Array.prototype.sort is stable in modern Node.
+  const sorted = [...items].sort((a, b) => b.score - a.score);
+  const limit = !Number.isFinite(maxCandidates) || maxCandidates <= 0
+    ? sorted.length
+    : Math.floor(maxCandidates);
+  if (sorted.length <= limit) return { kept: sorted, truncated: 0 };
+  return { kept: sorted.slice(0, limit), truncated: sorted.length - limit };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export function scoreCandidates(
+  artefact: ArtefactRow,
+  candidates: ReadonlyArray<LiteralCandidate>,
+  opts: ScoreCandidatesOptions,
+): ScoreCandidatesResult {
+  const repoRoot = opts.repoRoot;
+  const scope = opts.packageScope ?? DEFAULT_PACKAGE_SCOPE;
+  const packagesDirs = opts.packagesDirs ?? DEFAULT_PACKAGES_DIRS;
+  const max = opts.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+  const identifier = (artefact?.identifier ?? '').trim();
+
+  const exportingPackagesCount = opts.exportingPackagesCount ?? (
+    identifier ? countExportingPackages(identifier, repoRoot, scope, packagesDirs) : 0
+  );
+  const totalHits = opts.totalHits ?? (
+    identifier ? countTotalHits(identifier, repoRoot) : 0
+  );
+
+  const uniqueness = computeUniqueness(exportingPackagesCount);
+  const frequencyWeight = computeFrequencyWeight(totalHits);
+  const score = computeScore(uniqueness, frequencyWeight);
+
+  const scored: ScoredCandidate[] = candidates.map((c) => ({ ...c, score }));
+  const { kept, truncated } = applyMaxCandidates(scored, max);
+
+  return {
+    scoring: {
+      uniqueness,
+      frequencyWeight,
+      score,
+      exportingPackagesCount,
+      totalHits,
+    },
+    candidates: kept,
+    truncated,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Frequency: total raw git-grep hits across the repo (no filtering)
+// ---------------------------------------------------------------------------
+
+export function countTotalHits(identifier: string, repoRoot: string): number {
+  if (!identifier) return 0;
+  // -c emits "<file>:<count>" for each file that has at least one match. Sum the counts.
+  let stdout: string;
+  try {
+    stdout = execFileSync(
+      'git',
+      ['grep', '-c', '-I', '-F', '--', identifier],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        maxBuffer: 128 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { status?: number };
+    if (e && (e.status === 1 || (e as unknown as { code?: number }).code === 1)) {
+      return 0;
+    }
+    throw err;
+  }
+
+  let total = 0;
+  for (const raw of stdout.split('\n')) {
+    if (!raw) continue;
+    const colon = raw.lastIndexOf(':');
+    if (colon < 0) continue;
+    const n = Number.parseInt(raw.slice(colon + 1), 10);
+    if (Number.isFinite(n)) total += n;
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Uniqueness: count @scope/* packages whose source exports the identifier
+// ---------------------------------------------------------------------------
+
+// Matches `export function|class|interface|type|enum|const|let|var|async function` followed by the identifier.
+// Also accepts `export default function|class` followed by the identifier. Word-boundary anchored.
+function exportRegexFor(identifier: string): RegExp {
+  const id = escapeRegex(identifier);
+  return new RegExp(
+    [
+      // export <kind> <id>
+      `^\\s*export\\s+(?:async\\s+)?(?:function|class|interface|type|enum|const|let|var)\\s+${id}\\b`,
+      // export default function|class <id>
+      `^\\s*export\\s+default\\s+(?:async\\s+)?(?:function|class)\\s+${id}\\b`,
+      // export { ..., id, ... } [from '...']
+      `^\\s*export\\s*\\{[^}]*\\b${id}\\b[^}]*\\}`,
+    ].join('|'),
+    'm',
+  );
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function countExportingPackages(
+  identifier: string,
+  repoRoot: string,
+  scope: string = DEFAULT_PACKAGE_SCOPE,
+  packagesDirs: ReadonlyArray<string> = DEFAULT_PACKAGES_DIRS,
+): number {
+  if (!identifier) return 0;
+  const re = exportRegexFor(identifier);
+  let count = 0;
+
+  for (const sub of packagesDirs) {
+    const root = path.join(repoRoot, sub);
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(root);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const pkgDir = path.join(root, name);
+      const pkgJson = path.join(pkgDir, 'package.json');
+      let manifest: { name?: string };
+      try {
+        manifest = JSON.parse(fs.readFileSync(pkgJson, 'utf8')) as { name?: string };
+      } catch {
+        continue;
+      }
+      if (!manifest.name) continue;
+      if (scope && !manifest.name.startsWith(scope + '/')) continue;
+      if (packageExportsIdentifier(pkgDir, re)) count++;
+    }
+  }
+  return count;
+}
+
+function packageExportsIdentifier(pkgDir: string, re: RegExp): boolean {
+  const srcDir = path.join(pkgDir, 'src');
+  // Walk pkgDir/src/**/*.ts (no node_modules, dist, build). Fallback to pkgDir
+  // when src/ is absent (some workspaces keep entry at root).
+  const root = fs.existsSync(srcDir) ? srcDir : pkgDir;
+  return walkMatch(root, re);
+}
+
+function walkMatch(dir: string, re: RegExp): boolean {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const ent of entries) {
+    const name = ent.name;
+    if (ent.isDirectory()) {
+      if (name === 'node_modules' || name === 'dist' || name === 'build' || name === '.next') continue;
+      if (walkMatch(path.join(dir, name), re)) return true;
+      continue;
+    }
+    if (!ent.isFile()) continue;
+    if (!/\.(?:ts|tsx|mts|cts|js|mjs|cjs|jsx)$/.test(name)) continue;
+    let text: string;
+    try {
+      text = fs.readFileSync(path.join(dir, name), 'utf8');
+    } catch {
+      continue;
+    }
+    if (re.test(text)) return true;
+  }
+  return false;
+}

--- a/packages/adoption-enforcement/tests/crossref/score.test.ts
+++ b/packages/adoption-enforcement/tests/crossref/score.test.ts
@@ -1,0 +1,433 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  applyMaxCandidates,
+  computeFrequencyWeight,
+  computeScore,
+  computeUniqueness,
+  countExportingPackages,
+  countTotalHits,
+  DEFAULT_MAX_CANDIDATES,
+  scoreCandidates,
+} from '../../src/crossref/score.js';
+import type { LiteralCandidate } from '../../src/crossref/literal-pattern.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers — throwaway git repo on disk per test (parallels literal-pattern.test).
+// ---------------------------------------------------------------------------
+
+interface FixtureFile {
+  path: string;
+  content: string;
+}
+
+function mkRepo(files: ReadonlyArray<FixtureFile>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-score-test-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+  for (const f of files) {
+    const abs = path.join(dir, f.path);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, f.content, 'utf8');
+  }
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  return dir;
+}
+
+function rmRepo(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function candidate(file: string, line = 1): LiteralCandidate {
+  return {
+    file,
+    line,
+    match: 'someLine',
+    confidence: 'literal',
+    reason: 'identifier match outside its own package',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure math
+// ---------------------------------------------------------------------------
+
+describe('computeUniqueness', () => {
+  it('returns 1 for a single exporting package', () => {
+    expect(computeUniqueness(1)).toBe(1);
+  });
+  it('returns 0.5 for two exporting packages', () => {
+    expect(computeUniqueness(2)).toBe(0.5);
+  });
+  it('floors at 1 for zero (artefact source always counts at minimum)', () => {
+    expect(computeUniqueness(0)).toBe(1);
+  });
+  it('floors at 1 for negative inputs', () => {
+    expect(computeUniqueness(-3)).toBe(1);
+  });
+  it('floors fractional counts', () => {
+    expect(computeUniqueness(3.9)).toBeCloseTo(1 / 3, 12);
+  });
+});
+
+describe('computeFrequencyWeight', () => {
+  it('returns 1 for zero hits (1 / log2(2))', () => {
+    expect(computeFrequencyWeight(0)).toBe(1);
+  });
+  it('is strictly monotonically decreasing in hits', () => {
+    expect(computeFrequencyWeight(2)).toBeGreaterThan(computeFrequencyWeight(10));
+    expect(computeFrequencyWeight(10)).toBeGreaterThan(computeFrequencyWeight(100));
+    expect(computeFrequencyWeight(100)).toBeGreaterThan(computeFrequencyWeight(1000));
+  });
+  it('matches the closed-form 1 / log2(2 + hits)', () => {
+    expect(computeFrequencyWeight(6)).toBeCloseTo(1 / Math.log2(8), 12);
+    expect(computeFrequencyWeight(14)).toBeCloseTo(1 / Math.log2(16), 12);
+  });
+  it('treats negative hits as zero', () => {
+    expect(computeFrequencyWeight(-5)).toBe(1);
+  });
+});
+
+describe('computeScore', () => {
+  it('multiplies the two factors', () => {
+    expect(computeScore(0.5, 0.25)).toBe(0.125);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cap
+// ---------------------------------------------------------------------------
+
+describe('applyMaxCandidates', () => {
+  it('keeps everything when under the cap', () => {
+    const out = applyMaxCandidates([{ score: 1 }, { score: 2 }], 5);
+    expect(out.kept.map((x) => x.score)).toEqual([2, 1]);
+    expect(out.truncated).toBe(0);
+  });
+  it('keeps top N by score desc', () => {
+    const out = applyMaxCandidates(
+      [{ score: 1 }, { score: 5 }, { score: 3 }, { score: 4 }, { score: 2 }],
+      3,
+    );
+    expect(out.kept.map((x) => x.score)).toEqual([5, 4, 3]);
+    expect(out.truncated).toBe(2);
+  });
+  it('is stable for equal scores (preserves input order)', () => {
+    const out = applyMaxCandidates(
+      [
+        { score: 1, tag: 'a' },
+        { score: 1, tag: 'b' },
+        { score: 1, tag: 'c' },
+        { score: 1, tag: 'd' },
+      ],
+      2,
+    );
+    expect(out.kept.map((x) => x.tag)).toEqual(['a', 'b']);
+    expect(out.truncated).toBe(2);
+  });
+  it('treats Infinity / 0 / negative as "no cap"', () => {
+    const items = [{ score: 1 }, { score: 2 }];
+    expect(applyMaxCandidates(items, Infinity).kept.length).toBe(2);
+    expect(applyMaxCandidates(items, 0).kept.length).toBe(2);
+    expect(applyMaxCandidates(items, -1).kept.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreCandidates — composite using overrides (no repo I/O required)
+// ---------------------------------------------------------------------------
+
+describe('scoreCandidates (with overrides)', () => {
+  it('attaches per-artefact score to every candidate', () => {
+    const cands = [candidate('a.ts', 1), candidate('b.ts', 2), candidate('c.ts', 3)];
+    const out = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: 'doSomethingRare' },
+      cands,
+      { repoRoot: '/nonexistent', exportingPackagesCount: 1, totalHits: 0 },
+    );
+    expect(out.scoring.uniqueness).toBe(1);
+    expect(out.scoring.frequencyWeight).toBe(1);
+    expect(out.scoring.score).toBe(1);
+    expect(out.candidates.length).toBe(3);
+    expect(out.candidates.every((c) => c.score === 1)).toBe(true);
+  });
+
+  it('applies default cap of 5', () => {
+    const cands = Array.from({ length: 9 }, (_, i) => candidate(`f${i}.ts`, i + 1));
+    const out = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: 'doSomethingRare' },
+      cands,
+      { repoRoot: '/nonexistent', exportingPackagesCount: 1, totalHits: 4 },
+    );
+    expect(out.candidates.length).toBe(DEFAULT_MAX_CANDIDATES);
+    expect(out.truncated).toBe(9 - DEFAULT_MAX_CANDIDATES);
+  });
+
+  it('honours an explicit --max-candidates override', () => {
+    const cands = Array.from({ length: 9 }, (_, i) => candidate(`f${i}.ts`, i + 1));
+    const out = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: 'doSomethingRare' },
+      cands,
+      { repoRoot: '/nonexistent', maxCandidates: 2, exportingPackagesCount: 1, totalHits: 4 },
+    );
+    expect(out.candidates.length).toBe(2);
+    expect(out.candidates.map((c) => c.file)).toEqual(['f0.ts', 'f1.ts']);
+    expect(out.truncated).toBe(7);
+  });
+
+  it('disables cap when maxCandidates=Infinity', () => {
+    const cands = Array.from({ length: 9 }, (_, i) => candidate(`f${i}.ts`, i + 1));
+    const out = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: 'doSomethingRare' },
+      cands,
+      { repoRoot: '/nonexistent', maxCandidates: Infinity, exportingPackagesCount: 1, totalHits: 0 },
+    );
+    expect(out.candidates.length).toBe(9);
+    expect(out.truncated).toBe(0);
+  });
+
+  it('rare-uniquely-exported identifier scores higher than common-multiply-exported one', () => {
+    const rare = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: 'scanPii' },
+      [candidate('x.ts')],
+      { repoRoot: '/nonexistent', exportingPackagesCount: 1, totalHits: 3 },
+    );
+    const common = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: 'Logger' },
+      [candidate('x.ts')],
+      { repoRoot: '/nonexistent', exportingPackagesCount: 4, totalHits: 150 },
+    );
+    expect(rare.scoring.score).toBeGreaterThan(common.scoring.score);
+  });
+
+  it('empty identifier yields zero-hit baseline and empty candidates pass through', () => {
+    const out = scoreCandidates(
+      { kind: 'new_export', package: 'foo', identifier: '   ' },
+      [],
+      { repoRoot: '/nonexistent' },
+    );
+    expect(out.scoring.exportingPackagesCount).toBe(0);
+    expect(out.scoring.totalHits).toBe(0);
+    expect(out.scoring.uniqueness).toBe(1);
+    expect(out.scoring.frequencyWeight).toBe(1);
+    expect(out.candidates).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countTotalHits + countExportingPackages — real git+fs against a fixture repo
+// ---------------------------------------------------------------------------
+
+describe('countTotalHits + countExportingPackages', () => {
+  const created: string[] = [];
+  afterEach(() => {
+    while (created.length) {
+      const d = created.pop();
+      if (d) rmRepo(d);
+    }
+  });
+  function repo(files: ReadonlyArray<FixtureFile>): string {
+    const d = mkRepo(files);
+    created.push(d);
+    return d;
+  }
+
+  it('counts total raw hits across the repo (no filtering)', () => {
+    const root = repo([
+      { path: 'a.ts', content: 'scanPii(x); scanPii(y);\n' },
+      { path: 'b.ts', content: 'scanPii(z);\n' },
+      { path: 'c.ts', content: 'noMatch();\n' },
+    ]);
+    // 2 matches in a.ts (separate occurrences on one line → git grep -c counts the line once),
+    // 1 in b.ts → expect 2.
+    expect(countTotalHits('scanPii', root)).toBe(2);
+  });
+
+  it('returns 0 when nothing matches', () => {
+    const root = repo([{ path: 'a.ts', content: 'nothing here\n' }]);
+    expect(countTotalHits('scanPii', root)).toBe(0);
+  });
+
+  it('returns 0 for empty identifier', () => {
+    const root = repo([{ path: 'a.ts', content: 'nothing\n' }]);
+    expect(countTotalHits('', root)).toBe(0);
+  });
+
+  it('counts one @chiefaia/* package that exports the identifier', () => {
+    const root = repo([
+      {
+        path: 'packages/guardrails-validator/package.json',
+        content: JSON.stringify({ name: '@chiefaia/guardrails-validator', version: '0.0.0' }),
+      },
+      {
+        path: 'packages/guardrails-validator/src/index.ts',
+        content: 'export function scanPii(input: string) { return input; }\n',
+      },
+      // Consumer — not an exporter, must not be counted.
+      {
+        path: 'packages/worker-coding/package.json',
+        content: JSON.stringify({ name: '@chiefaia/worker-coding', version: '0.0.0' }),
+      },
+      {
+        path: 'packages/worker-coding/src/index.ts',
+        content: "import { scanPii } from '@chiefaia/guardrails-validator';\nscanPii('x');\n",
+      },
+    ]);
+    expect(countExportingPackages('scanPii', root)).toBe(1);
+  });
+
+  it('counts multiple @chiefaia/* packages on a name collision', () => {
+    const root = repo([
+      {
+        path: 'packages/a/package.json',
+        content: JSON.stringify({ name: '@chiefaia/a' }),
+      },
+      {
+        path: 'packages/a/src/index.ts',
+        content: 'export class Tracer {}\n',
+      },
+      {
+        path: 'packages/b/package.json',
+        content: JSON.stringify({ name: '@chiefaia/b' }),
+      },
+      {
+        path: 'packages/b/src/index.ts',
+        content: 'export class Tracer {}\n',
+      },
+      {
+        path: 'packages/c/package.json',
+        content: JSON.stringify({ name: '@chiefaia/c' }),
+      },
+      {
+        path: 'packages/c/src/index.ts',
+        content: 'export const unrelated = 1;\n',
+      },
+    ]);
+    expect(countExportingPackages('Tracer', root)).toBe(2);
+  });
+
+  it('honours the export-list re-export syntax', () => {
+    const root = repo([
+      {
+        path: 'packages/a/package.json',
+        content: JSON.stringify({ name: '@chiefaia/a' }),
+      },
+      {
+        path: 'packages/a/src/index.ts',
+        content: "export { generateCaiaPrimer } from './primer.js';\n",
+      },
+      {
+        path: 'packages/a/src/primer.ts',
+        content: 'function generateCaiaPrimer() { return ""; }\n',
+      },
+    ]);
+    expect(countExportingPackages('generateCaiaPrimer', root)).toBe(1);
+  });
+
+  it('ignores non-@chiefaia packages', () => {
+    const root = repo([
+      {
+        path: 'packages/external-thing/package.json',
+        content: JSON.stringify({ name: 'external-thing' }),
+      },
+      {
+        path: 'packages/external-thing/src/index.ts',
+        content: 'export function scanPii() {}\n',
+      },
+    ]);
+    expect(countExportingPackages('scanPii', root)).toBe(0);
+  });
+
+  it('respects custom packageScope override', () => {
+    const root = repo([
+      {
+        path: 'packages/foo/package.json',
+        content: JSON.stringify({ name: '@acme/foo' }),
+      },
+      {
+        path: 'packages/foo/src/index.ts',
+        content: 'export const customThing = 1;\n',
+      },
+    ]);
+    expect(countExportingPackages('customThing', root, '@chiefaia')).toBe(0);
+    expect(countExportingPackages('customThing', root, '@acme')).toBe(1);
+  });
+
+  it('skips node_modules / dist / build when scanning sources', () => {
+    const root = repo([
+      {
+        path: 'packages/foo/package.json',
+        content: JSON.stringify({ name: '@chiefaia/foo' }),
+      },
+      {
+        path: 'packages/foo/src/index.ts',
+        content: 'export const realThing = 1;\n',
+      },
+      // The fake export sitting in dist/ MUST NOT inflate the count.
+      {
+        path: 'packages/foo/dist/index.js',
+        content: 'export const ghostThing = 1;\n',
+      },
+      {
+        path: 'packages/foo/node_modules/leftover/index.ts',
+        content: 'export const ghostThing = 1;\n',
+      },
+    ]);
+    expect(countExportingPackages('realThing', root)).toBe(1);
+    expect(countExportingPackages('ghostThing', root)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreCandidates end-to-end against a real fixture repo
+// ---------------------------------------------------------------------------
+
+describe('scoreCandidates (real repo)', () => {
+  const created: string[] = [];
+  afterEach(() => {
+    while (created.length) {
+      const d = created.pop();
+      if (d) rmRepo(d);
+    }
+  });
+  function repo(files: ReadonlyArray<FixtureFile>): string {
+    const d = mkRepo(files);
+    created.push(d);
+    return d;
+  }
+
+  it('computes uniqueness=1 and a finite frequency weight for a single-exporter identifier', () => {
+    const root = repo([
+      {
+        path: 'packages/guardrails-validator/package.json',
+        content: JSON.stringify({ name: '@chiefaia/guardrails-validator' }),
+      },
+      {
+        path: 'packages/guardrails-validator/src/index.ts',
+        content: 'export function scanPii(input: string) { return input; }\n',
+      },
+      {
+        path: 'apps/worker-coding/src/safety/pii.ts',
+        content: "import { scanPii } from '@chiefaia/guardrails-validator';\nscanPii('x');\n",
+      },
+    ]);
+    const cands = [candidate('apps/worker-coding/src/safety/pii.ts', 2)];
+    const out = scoreCandidates(
+      { kind: 'new_export', package: '@chiefaia/guardrails-validator', identifier: 'scanPii' },
+      cands,
+      { repoRoot: root },
+    );
+    expect(out.scoring.exportingPackagesCount).toBe(1);
+    expect(out.scoring.uniqueness).toBe(1);
+    expect(out.scoring.totalHits).toBeGreaterThan(0);
+    expect(out.scoring.frequencyWeight).toBeGreaterThan(0);
+    expect(out.scoring.frequencyWeight).toBeLessThanOrEqual(1);
+    expect(out.scoring.score).toBe(out.scoring.uniqueness * out.scoring.frequencyWeight);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/crossref/score.ts`: per-artefact confidence score = `uniqueness × frequency_weight`, where uniqueness = `1 / max(1, # @chiefaia/* packages exporting the identifier)` and frequency_weight = `1 / log2(2 + total git-grep hits)`. Rarely-used, uniquely-exported identifiers score highest — they're the strongest signal that a cross-ref hit is a real adoption site rather than a coincidence.
- Adds `--max-candidates N` (default 5, exposed as `ScoreCandidatesOptions.maxCandidates`) per-artefact cap to bound PR fan-out. Cap sorts desc by score with stable tie-break; equal-score input order is preserved.
- Wires the new symbols into `src/crossref/index.ts` so callers can import `scoreCandidates`, `applyMaxCandidates`, and the math helpers from one entry point.
- Phase 2 of the `p3-adoption-cross-ref` chain (companion design: `agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md` §5).

## Design notes
- Score is per-artefact, not per-candidate — every candidate of one identifier gets the same score. That keeps the formula meaningful (it tells you confidence in the identifier as an adoption signal) and lets downstream consumers rank artefact rows directly.
- `ScoreCandidatesOptions` exposes `exportingPackagesCount` and `totalHits` overrides so unit tests can skip the repo-scan step. Real-fs counters (`countExportingPackages`, `countTotalHits`) are also exported and have their own fixture-repo coverage.
- `countExportingPackages` matches `export <kind> <id>`, `export default <kind> <id>`, and `export { ..., id, ... }` re-exports, and only counts packages whose `package.json` name starts with the configured scope (default `@chiefaia`). It skips `node_modules`, `dist`, `build`, `.next` when walking sources.

## Test plan
- [x] `pnpm test` — 58 passed (28 prior + 30 new across pure math, cap behaviour, score composition, real-fs counters)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)