### PR TITLE
feat(adoption-enforcement): caia-adoption-run xref CLI (xref P3)

### DIFF
--- a/packages/adoption-enforcement/bin/caia-adoption-run.mjs
+++ b/packages/adoption-enforcement/bin/caia-adoption-run.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/**
+ * caia-adoption-run — adoption-enforcement substrate runner.
+ *
+ * Subcommands:
+ *   xref --work-dir <dir>   Read scan.json from work-dir, write xref.json beside it.
+ *
+ * Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.
+ */
+import { dispatch } from '../dist/cli/index.js';
+
+const result = dispatch(process.argv.slice(2));
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+process.exit(result.exitCode);

--- a/packages/adoption-enforcement/package.json
+++ b/packages/adoption-enforcement/package.json
@@ -19,7 +19,8 @@
   },
   "files": ["dist", "README.md"],
   "bin": {
-    "caia-adoption-verify": "./bin/caia-adoption-verify.mjs"
+    "caia-adoption-verify": "./bin/caia-adoption-verify.mjs",
+    "caia-adoption-run": "./bin/caia-adoption-run.mjs"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/adoption-enforcement/src/cli/index.ts
+++ b/packages/adoption-enforcement/src/cli/index.ts
@@ -1,0 +1,10 @@
+export { dispatch } from './run.js';
+export type { CliResult } from './xref.js';
+export {
+  runXref,
+  runXrefCli,
+  type ArtefactXref,
+  type RunXrefResult,
+  type XrefOptions,
+  type XrefReport,
+} from './xref.js';

--- a/packages/adoption-enforcement/src/cli/run.ts
+++ b/packages/adoption-enforcement/src/cli/run.ts
@@ -1,0 +1,36 @@
+// `caia-adoption-run` — top-level dispatcher.
+//
+// Subcommands are listed below. v1 ships only `xref`; `scan`, `pr`, and
+// `verify` will land in their respective MVP chains.
+//
+// Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md (§2).
+
+import { type CliResult, runXrefCli } from './xref.js';
+
+const TOP_HELP = `caia-adoption-run — adoption-enforcement substrate runner.
+
+Usage:
+  caia-adoption-run <subcommand> [options]
+
+Subcommands:
+  xref     Read scan.json and emit xref.json (L1 cross-reference + scoring).
+
+Run \`caia-adoption-run <subcommand> --help\` for subcommand options.
+`;
+
+export function dispatch(argv: ReadonlyArray<string>): CliResult {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    return { exitCode: argv.length === 0 ? 2 : 0, stdout: argv.length === 0 ? '' : TOP_HELP, stderr: argv.length === 0 ? TOP_HELP : '' };
+  }
+  const [sub, ...rest] = argv;
+  switch (sub) {
+    case 'xref':
+      return runXrefCli(rest);
+    default:
+      return {
+        exitCode: 2,
+        stdout: '',
+        stderr: `unknown subcommand: ${sub}\n\n${TOP_HELP}`,
+      };
+  }
+}

--- a/packages/adoption-enforcement/src/cli/xref.ts
+++ b/packages/adoption-enforcement/src/cli/xref.ts
@@ -1,0 +1,356 @@
+// `caia-adoption-run xref` — read scan.json, run L1 cross-ref + scoring per
+// artefact, write xref.json beside scan.json.
+//
+// Wired into the post-merge pipeline (phase 4); also invocable on demand for
+// historical PRs or test fixtures.
+//
+// Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md (§2.3, §5).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  type ArtefactRow,
+  findLiteralCandidates,
+} from '../crossref/literal-pattern.js';
+import {
+  type ArtefactScoring,
+  type ScoredCandidate,
+  DEFAULT_MAX_CANDIDATES,
+  DEFAULT_PACKAGE_SCOPE,
+  DEFAULT_PACKAGES_DIRS,
+  scoreCandidates,
+} from '../crossref/score.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface XrefOptions {
+  /** Work directory containing scan.json; xref.json is written here. */
+  workDir: string;
+  /** Repository root to scan against. Default: process.cwd(). */
+  repoRoot?: string;
+  /** Regenerate even if xref.json already exists. Default false. */
+  force?: boolean;
+  /** Per-artefact candidate cap. Default 5. Pass 0 / Infinity to disable. */
+  maxCandidates?: number;
+  /** Workspace-package scope. Default "@chiefaia". */
+  packageScope?: string;
+  /** Sub-directories searched for workspace packages. Default ["packages"]. */
+  packagesDirs?: ReadonlyArray<string>;
+  /** Identifier min-length cutoff. Default 6 (matches literal-pattern default). */
+  minLength?: number;
+  /** Override of the identifier-overrides YAML path (defaults to <repoRoot>/.adoption/identifier-overrides.yaml). */
+  overridesPath?: string;
+}
+
+export interface ArtefactXref {
+  /** Echo of the artefact row from scan.json. */
+  artefact: ArtefactRow;
+  scoring: ArtefactScoring;
+  candidates: ScoredCandidate[];
+  /** Candidates dropped by the per-artefact cap. */
+  truncated: number;
+}
+
+export interface XrefReport {
+  version: 1;
+  /** Originating commit, if scan.json supplied one. */
+  sha: string | null;
+  generated_at: string;
+  options: {
+    repoRoot: string;
+    maxCandidates: number;
+    packageScope: string;
+    packagesDirs: ReadonlyArray<string>;
+    minLength: number;
+  };
+  artefacts: ArtefactXref[];
+  summary: {
+    artefact_count: number;
+    candidate_count: number;
+    truncated_total: number;
+  };
+}
+
+export interface RunXrefResult {
+  /** Absolute path to xref.json. */
+  outPath: string;
+  /** True when xref.json was newly written; false when skipped (idempotent). */
+  written: boolean;
+  /** Loaded or freshly-computed report. */
+  report: XrefReport;
+}
+
+// ---------------------------------------------------------------------------
+// scan.json parsing — accept a few shapes so we are robust to upstream churn
+// ---------------------------------------------------------------------------
+
+interface ScanFile {
+  sha: string | null;
+  artefacts: ArtefactRow[];
+}
+
+function parseScanFile(raw: unknown): ScanFile {
+  if (Array.isArray(raw)) {
+    return { sha: null, artefacts: raw.map(coerceArtefact).filter(isArtefact) };
+  }
+  if (raw && typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    const sha = typeof obj.sha === 'string' ? obj.sha : null;
+    const list = (obj.artefacts ?? obj.rows ?? obj.items);
+    if (Array.isArray(list)) {
+      return { sha, artefacts: list.map(coerceArtefact).filter(isArtefact) };
+    }
+  }
+  throw new Error(
+    'scan.json: expected an array of artefact rows or an object with an "artefacts" array',
+  );
+}
+
+function coerceArtefact(row: unknown): ArtefactRow | null {
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const kind = typeof r.kind === 'string' ? r.kind : '';
+  const pkg = typeof r.package === 'string' ? r.package : '';
+  const identifier = typeof r.identifier === 'string' ? r.identifier : '';
+  if (!identifier || !pkg) return null;
+  // `file` is the design-doc shape; `source_path` is what literal-pattern.ts reads.
+  const sourcePath = typeof r.source_path === 'string'
+    ? r.source_path
+    : (typeof r.file === 'string' ? r.file : undefined);
+  return {
+    kind: kind || 'new_export',
+    package: pkg,
+    identifier,
+    ...(sourcePath ? { source_path: sourcePath } : {}),
+  };
+}
+
+function isArtefact(r: ArtefactRow | null): r is ArtefactRow {
+  return r !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export function runXref(opts: XrefOptions): RunXrefResult {
+  const workDir = path.resolve(opts.workDir);
+  if (!fs.existsSync(workDir) || !fs.statSync(workDir).isDirectory()) {
+    throw new Error(`xref: --work-dir is not a directory: ${workDir}`);
+  }
+
+  const scanPath = path.join(workDir, 'scan.json');
+  const outPath = path.join(workDir, 'xref.json');
+
+  if (!opts.force && fs.existsSync(outPath)) {
+    const existingRaw = fs.readFileSync(outPath, 'utf8');
+    const existing = JSON.parse(existingRaw) as XrefReport;
+    return { outPath, written: false, report: existing };
+  }
+
+  if (!fs.existsSync(scanPath)) {
+    throw new Error(`xref: scan.json not found at ${scanPath}`);
+  }
+
+  const scanRaw = JSON.parse(fs.readFileSync(scanPath, 'utf8'));
+  const scan = parseScanFile(scanRaw);
+
+  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const maxCandidates = opts.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+  const packageScope = opts.packageScope ?? DEFAULT_PACKAGE_SCOPE;
+  const packagesDirs = opts.packagesDirs ?? DEFAULT_PACKAGES_DIRS;
+  const minLength = opts.minLength ?? 6;
+
+  const artefacts: ArtefactXref[] = [];
+  let candidateTotal = 0;
+  let truncatedTotal = 0;
+
+  for (const row of scan.artefacts) {
+    const literal = findLiteralCandidates(row, {
+      repoRoot,
+      minLength,
+      ...(opts.overridesPath ? { overridesPath: opts.overridesPath } : {}),
+    });
+    const scored = scoreCandidates(row, literal, {
+      repoRoot,
+      maxCandidates,
+      packageScope,
+      packagesDirs,
+    });
+    artefacts.push({
+      artefact: row,
+      scoring: scored.scoring,
+      candidates: scored.candidates,
+      truncated: scored.truncated,
+    });
+    candidateTotal += scored.candidates.length;
+    truncatedTotal += scored.truncated;
+  }
+
+  const report: XrefReport = {
+    version: 1,
+    sha: scan.sha,
+    generated_at: new Date().toISOString(),
+    options: {
+      repoRoot,
+      maxCandidates,
+      packageScope,
+      packagesDirs,
+      minLength,
+    },
+    artefacts,
+    summary: {
+      artefact_count: artefacts.length,
+      candidate_count: candidateTotal,
+      truncated_total: truncatedTotal,
+    },
+  };
+
+  fs.writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+  return { outPath, written: true, report };
+}
+
+// ---------------------------------------------------------------------------
+// CLI plumbing (used by bin/caia-adoption-run.mjs)
+// ---------------------------------------------------------------------------
+
+export interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const HELP = `caia-adoption-run xref — L1 cross-reference for adoption candidates.
+
+Usage:
+  caia-adoption-run xref --work-dir <dir> [options]
+
+Required:
+  --work-dir <dir>          Directory containing scan.json; xref.json is written here.
+
+Options:
+  --repo <dir>              Repository root to search. Default: cwd.
+  --force                   Regenerate xref.json even if it exists.
+  --max-candidates <n>      Per-artefact candidate cap. Default: 5. 0 disables.
+  --scope <name>            Workspace package scope. Default: @chiefaia.
+  --min-length <n>          Identifier min-length cutoff. Default: 6.
+  --overrides <path>        Identifier-overrides YAML path. Default: <repo>/.adoption/identifier-overrides.yaml.
+  -h, --help                Show this help.
+`;
+
+interface ParsedArgs {
+  help: boolean;
+  workDir: string | null;
+  repoRoot: string | null;
+  force: boolean;
+  maxCandidates: number | null;
+  packageScope: string | null;
+  minLength: number | null;
+  overridesPath: string | null;
+  error: string | null;
+}
+
+function parseXrefArgs(argv: ReadonlyArray<string>): ParsedArgs {
+  const out: ParsedArgs = {
+    help: false,
+    workDir: null,
+    repoRoot: null,
+    force: false,
+    maxCandidates: null,
+    packageScope: null,
+    minLength: null,
+    overridesPath: null,
+    error: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '-h':
+      case '--help':
+        out.help = true;
+        return out;
+      case '--work-dir':
+        if (next === undefined) { out.error = '--work-dir requires a value'; return out; }
+        out.workDir = next;
+        i += 1;
+        break;
+      case '--repo':
+        if (next === undefined) { out.error = '--repo requires a value'; return out; }
+        out.repoRoot = next;
+        i += 1;
+        break;
+      case '--force':
+        out.force = true;
+        break;
+      case '--max-candidates': {
+        if (next === undefined) { out.error = '--max-candidates requires a value'; return out; }
+        const n = Number.parseInt(next, 10);
+        if (!Number.isFinite(n) || n < 0) { out.error = `--max-candidates: invalid number "${next}"`; return out; }
+        out.maxCandidates = n;
+        i += 1;
+        break;
+      }
+      case '--scope':
+        if (next === undefined) { out.error = '--scope requires a value'; return out; }
+        out.packageScope = next;
+        i += 1;
+        break;
+      case '--min-length': {
+        if (next === undefined) { out.error = '--min-length requires a value'; return out; }
+        const n = Number.parseInt(next, 10);
+        if (!Number.isFinite(n) || n < 1) { out.error = `--min-length: invalid number "${next}"`; return out; }
+        out.minLength = n;
+        i += 1;
+        break;
+      }
+      case '--overrides':
+        if (next === undefined) { out.error = '--overrides requires a value'; return out; }
+        out.overridesPath = next;
+        i += 1;
+        break;
+      default:
+        out.error = `unknown arg: ${arg}`;
+        return out;
+    }
+  }
+  return out;
+}
+
+export function runXrefCli(argv: ReadonlyArray<string>): CliResult {
+  const args = parseXrefArgs(argv);
+  if (args.help) {
+    return { exitCode: 0, stdout: HELP, stderr: '' };
+  }
+  if (args.error) {
+    return { exitCode: 2, stdout: '', stderr: `${args.error}\n\n${HELP}` };
+  }
+  if (!args.workDir) {
+    return { exitCode: 2, stdout: '', stderr: `--work-dir is required\n\n${HELP}` };
+  }
+
+  try {
+    const opts: XrefOptions = {
+      workDir: args.workDir,
+      force: args.force,
+      ...(args.repoRoot ? { repoRoot: args.repoRoot } : {}),
+      ...(args.maxCandidates !== null ? { maxCandidates: args.maxCandidates } : {}),
+      ...(args.packageScope ? { packageScope: args.packageScope } : {}),
+      ...(args.minLength !== null ? { minLength: args.minLength } : {}),
+      ...(args.overridesPath ? { overridesPath: args.overridesPath } : {}),
+    };
+    const result = runXref(opts);
+    const action = result.written ? 'wrote' : 'skipped (already present)';
+    const { artefact_count, candidate_count, truncated_total } = result.report.summary;
+    const stdout =
+      `xref: ${action} ${result.outPath}\n` +
+      `  artefacts=${artefact_count} candidates=${candidate_count} truncated=${truncated_total}\n`;
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { exitCode: 1, stdout: '', stderr: `xref: ${msg}\n` };
+  }
+}

--- a/packages/adoption-enforcement/src/index.ts
+++ b/packages/adoption-enforcement/src/index.ts
@@ -1,3 +1,4 @@
 export * as verify from './verify/index.js';
 export * as pr from './pr/index.js';
 export * as crossref from './crossref/index.js';
+export * as cli from './cli/index.js';

--- a/packages/adoption-enforcement/tests/cli/run.test.ts
+++ b/packages/adoption-enforcement/tests/cli/run.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { dispatch } from '../../src/cli/run.js';
+
+describe('dispatch — top-level subcommand router', () => {
+  it('shows top-level help on --help (exit 0)', () => {
+    const result = dispatch(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('caia-adoption-run');
+    expect(result.stdout).toContain('xref');
+  });
+
+  it('prints top-level help to stderr (exit 2) when no subcommand is given', () => {
+    const result = dispatch([]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('caia-adoption-run');
+  });
+
+  it('returns exit 2 for an unknown subcommand', () => {
+    const result = dispatch(['hypothetical-future-thing']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('unknown subcommand');
+  });
+
+  it('delegates to xref subcommand', () => {
+    const result = dispatch(['xref', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('caia-adoption-run xref');
+  });
+});

--- a/packages/adoption-enforcement/tests/cli/xref.test.ts
+++ b/packages/adoption-enforcement/tests/cli/xref.test.ts
@@ -1,0 +1,366 @@
+// End-to-end smoke test for `caia-adoption-run xref`.
+//
+// Builds a synthetic monorepo + a synthetic scan.json that names the three
+// concrete adoption examples from the design doc (§1.5):
+//   - @chiefaia/guardrails-validator/scanPii
+//   - @chiefaia/tracing/Tracer
+//   - @chiefaia/system-prompt-block/generateCaiaPrimer
+// Runs xref, asserts each artefact finds at least one candidate at the
+// expected adoption site (per design doc §5), then re-runs to verify
+// idempotency and --force behaviour.
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runXref, runXrefCli, type XrefReport } from '../../src/cli/xref.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — write a tmp git repo + a work dir holding scan.json.
+// ---------------------------------------------------------------------------
+
+interface FixtureFile {
+  path: string;
+  content: string;
+}
+
+function mkRepo(files: ReadonlyArray<FixtureFile>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-cli-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+  for (const f of files) {
+    const abs = path.join(dir, f.path);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, f.content, 'utf8');
+  }
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  return dir;
+}
+
+function rmDir(d: string): void {
+  fs.rmSync(d, { recursive: true, force: true });
+}
+
+// Three concrete examples from the design doc §1.5 — exporter package + the
+// site where an adoption PR should be generated.
+function designDocFixture(): FixtureFile[] {
+  return [
+    // ── @chiefaia/guardrails-validator → scanPii ────────────────────────────
+    {
+      path: 'packages/guardrails-validator/package.json',
+      content: JSON.stringify({ name: '@chiefaia/guardrails-validator', version: '0.1.0' }) + '\n',
+    },
+    {
+      path: 'packages/guardrails-validator/src/index.ts',
+      content: 'export function scanPii(input: string): string { return input; }\n',
+    },
+    {
+      path: 'apps/orchestrator/src/safety/tool-result-sanitizer-bridge.ts',
+      content:
+        "// Custom PII/secret/injection scanning duplicated here; should call @chiefaia/guardrails-validator.scanPii.\n" +
+        "export function sanitizeToolResult(text: string): string {\n" +
+        "  // TODO: replace this hand-rolled regex with scanPii from the validator package.\n" +
+        "  return text.replace(/\\b\\d{3}-\\d{2}-\\d{4}\\b/g, '[ssn-redacted]');\n" +
+        "}\n",
+    },
+
+    // ── @chiefaia/tracing → Tracer ──────────────────────────────────────────
+    {
+      path: 'packages/tracing/package.json',
+      content: JSON.stringify({ name: '@chiefaia/tracing', version: '0.1.0' }) + '\n',
+    },
+    {
+      path: 'packages/tracing/src/index.ts',
+      content: 'export class Tracer { startSpan(_name: string): void {} }\n',
+    },
+    {
+      path: 'apps/orchestrator/src/observability/agent-otel.ts',
+      content:
+        "import { trace } from '@opentelemetry/api';\n" +
+        "// FIXME: switch to @chiefaia/tracing.Tracer wrapper once the helper is stable.\n" +
+        "export function startAgentSpan(name: string): void {\n" +
+        "  const tracer = trace.getTracer('agent');\n" +
+        "  tracer.startSpan(name).end();\n" +
+        "}\n",
+    },
+
+    // ── @chiefaia/system-prompt-block → generateCaiaPrimer ──────────────────
+    {
+      path: 'packages/system-prompt-block/package.json',
+      content: JSON.stringify({ name: '@chiefaia/system-prompt-block', version: '0.1.0' }) + '\n',
+    },
+    {
+      path: 'packages/system-prompt-block/src/index.ts',
+      content: 'export function generateCaiaPrimer(): string { return ""; }\n',
+    },
+    {
+      path: 'apps/orchestrator/src/api/routes/agents.ts',
+      content:
+        "// TODO: prepend generateCaiaPrimer() output instead of hand-built block.\n" +
+        "export const systemPrompt = 'You are an agent. Follow CAIA rules...';\n",
+    },
+    {
+      path: 'apps/worker-coding/src/implementation-engine.ts',
+      content:
+        "// generateCaiaPrimer is not yet wired into worker-coding's system prompt.\n" +
+        "export const systemPrompt = 'You are a coder. Implement the spec...';\n",
+    },
+  ];
+}
+
+function writeScanJson(workDir: string, sha: string): void {
+  const scan = {
+    sha,
+    artefacts: [
+      {
+        kind: 'new_export',
+        package: '@chiefaia/guardrails-validator',
+        identifier: 'scanPii',
+        decl_kind: 'function',
+        file: 'packages/guardrails-validator/src/index.ts',
+      },
+      {
+        kind: 'new_export',
+        package: '@chiefaia/tracing',
+        identifier: 'Tracer',
+        decl_kind: 'class',
+        file: 'packages/tracing/src/index.ts',
+      },
+      {
+        kind: 'new_export',
+        package: '@chiefaia/system-prompt-block',
+        identifier: 'generateCaiaPrimer',
+        decl_kind: 'function',
+        file: 'packages/system-prompt-block/src/index.ts',
+      },
+    ],
+  };
+  fs.writeFileSync(path.join(workDir, 'scan.json'), JSON.stringify(scan, null, 2) + '\n', 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runXref — end-to-end against design-doc §1.5 examples', () => {
+  const trash: string[] = [];
+  afterEach(() => {
+    while (trash.length) {
+      const d = trash.pop();
+      if (d) rmDir(d);
+    }
+  });
+
+  function setup(): { repoRoot: string; workDir: string } {
+    const repoRoot = mkRepo(designDocFixture());
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-work-'));
+    trash.push(repoRoot, workDir);
+    writeScanJson(workDir, 'deadbeefcafe');
+    return { repoRoot, workDir };
+  }
+
+  it('finds at least one candidate per design-doc artefact at the expected file', () => {
+    const { repoRoot, workDir } = setup();
+
+    const result = runXref({ workDir, repoRoot });
+
+    expect(result.written).toBe(true);
+    expect(result.outPath).toBe(path.join(workDir, 'xref.json'));
+    expect(fs.existsSync(result.outPath)).toBe(true);
+
+    const report = result.report;
+    expect(report.version).toBe(1);
+    expect(report.sha).toBe('deadbeefcafe');
+    expect(report.summary.artefact_count).toBe(3);
+
+    const byIdent = new Map(report.artefacts.map((a) => [a.artefact.identifier, a]));
+
+    // ── scanPii ──
+    const scanPii = byIdent.get('scanPii');
+    expect(scanPii, 'expected an artefact entry for scanPii').toBeDefined();
+    const scanPiiFiles = scanPii!.candidates.map((c) => c.file);
+    expect(scanPiiFiles.length).toBeGreaterThanOrEqual(1);
+    expect(scanPiiFiles).toContain(
+      'apps/orchestrator/src/safety/tool-result-sanitizer-bridge.ts',
+    );
+    expect(scanPii!.candidates.every((c) => c.confidence === 'literal')).toBe(true);
+    expect(scanPii!.scoring.score).toBeGreaterThan(0);
+
+    // ── Tracer ──
+    const tracer = byIdent.get('Tracer');
+    expect(tracer, 'expected an artefact entry for Tracer').toBeDefined();
+    const tracerFiles = tracer!.candidates.map((c) => c.file);
+    expect(tracerFiles.length).toBeGreaterThanOrEqual(1);
+    expect(tracerFiles).toContain(
+      'apps/orchestrator/src/observability/agent-otel.ts',
+    );
+
+    // ── generateCaiaPrimer ──
+    const primer = byIdent.get('generateCaiaPrimer');
+    expect(primer, 'expected an artefact entry for generateCaiaPrimer').toBeDefined();
+    const primerFiles = primer!.candidates.map((c) => c.file);
+    expect(primerFiles.length).toBeGreaterThanOrEqual(1);
+    expect(primerFiles).toContain('apps/orchestrator/src/api/routes/agents.ts');
+    // Two candidates land in the orchestrator's prompt sites.
+    expect(primerFiles).toContain('apps/worker-coding/src/implementation-engine.ts');
+
+    // Own-package hits must be excluded across every artefact.
+    for (const a of report.artefacts) {
+      for (const c of a.candidates) {
+        expect(c.file.startsWith('packages/')).toBe(false);
+      }
+    }
+  });
+
+  it('is idempotent: a second run without --force skips work and returns the existing report', () => {
+    const { repoRoot, workDir } = setup();
+
+    const first = runXref({ workDir, repoRoot });
+    expect(first.written).toBe(true);
+
+    // Mutate the existing xref.json so we can prove the second call returned
+    // it untouched instead of overwriting.
+    const sentinel: XrefReport = {
+      ...first.report,
+      sha: 'sentinel-not-overwritten',
+    };
+    fs.writeFileSync(first.outPath, JSON.stringify(sentinel, null, 2) + '\n', 'utf8');
+
+    const second = runXref({ workDir, repoRoot });
+    expect(second.written).toBe(false);
+    expect(second.report.sha).toBe('sentinel-not-overwritten');
+  });
+
+  it('overwrites the existing xref.json when --force is set', () => {
+    const { repoRoot, workDir } = setup();
+
+    runXref({ workDir, repoRoot });
+    fs.writeFileSync(
+      path.join(workDir, 'xref.json'),
+      JSON.stringify({ sentinel: true }, null, 2) + '\n',
+      'utf8',
+    );
+
+    const forced = runXref({ workDir, repoRoot, force: true });
+    expect(forced.written).toBe(true);
+    expect(forced.report.summary.artefact_count).toBe(3);
+  });
+
+  it('respects --max-candidates: capping to 1 leaves each artefact with at most one candidate', () => {
+    const { repoRoot, workDir } = setup();
+
+    const result = runXref({ workDir, repoRoot, maxCandidates: 1 });
+
+    for (const a of result.report.artefacts) {
+      expect(a.candidates.length).toBeLessThanOrEqual(1);
+      // generateCaiaPrimer originally has two candidates → one must be truncated.
+      if (a.artefact.identifier === 'generateCaiaPrimer') {
+        expect(a.truncated).toBeGreaterThanOrEqual(1);
+      }
+    }
+    expect(result.report.options.maxCandidates).toBe(1);
+  });
+
+  it('emits an empty report (no artefacts) when scan.json has zero rows', () => {
+    const repoRoot = mkRepo([{ path: 'README.md', content: 'noop\n' }]);
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-empty-'));
+    trash.push(repoRoot, workDir);
+    fs.writeFileSync(
+      path.join(workDir, 'scan.json'),
+      JSON.stringify({ sha: 'noop', artefacts: [] }, null, 2) + '\n',
+      'utf8',
+    );
+
+    const result = runXref({ workDir, repoRoot });
+    expect(result.report.summary.artefact_count).toBe(0);
+    expect(result.report.summary.candidate_count).toBe(0);
+    expect(result.report.artefacts).toEqual([]);
+  });
+
+  it('accepts a bare-array scan.json shape', () => {
+    const { repoRoot } = setup();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-arr-'));
+    trash.push(workDir);
+    const arr = [
+      {
+        kind: 'new_export',
+        package: '@chiefaia/guardrails-validator',
+        identifier: 'scanPii',
+        file: 'packages/guardrails-validator/src/index.ts',
+      },
+    ];
+    fs.writeFileSync(path.join(workDir, 'scan.json'), JSON.stringify(arr) + '\n', 'utf8');
+    const result = runXref({ workDir, repoRoot });
+    expect(result.report.summary.artefact_count).toBe(1);
+    expect(result.report.sha).toBeNull();
+  });
+
+  it('throws when scan.json is missing', () => {
+    const repoRoot = mkRepo([{ path: 'README.md', content: 'noop\n' }]);
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-missing-'));
+    trash.push(repoRoot, workDir);
+    expect(() => runXref({ workDir, repoRoot })).toThrowError(/scan\.json not found/);
+  });
+
+  it('throws when work-dir does not exist', () => {
+    const bogus = path.join(os.tmpdir(), 'adopt-xref-does-not-exist-' + Date.now());
+    expect(() => runXref({ workDir: bogus })).toThrowError(/--work-dir/);
+  });
+});
+
+describe('runXrefCli — argument parsing + exit codes', () => {
+  const trash: string[] = [];
+  afterEach(() => {
+    while (trash.length) {
+      const d = trash.pop();
+      if (d) rmDir(d);
+    }
+  });
+
+  it('runs end-to-end through the CLI surface and exits 0', () => {
+    const repoRoot = mkRepo(designDocFixture());
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-cli-run-'));
+    trash.push(repoRoot, workDir);
+    writeScanJson(workDir, 'cli-sha');
+
+    const result = runXrefCli(['--work-dir', workDir, '--repo', repoRoot]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('artefacts=3');
+    expect(fs.existsSync(path.join(workDir, 'xref.json'))).toBe(true);
+
+    // Second invocation hits the idempotent skip path.
+    const second = runXrefCli(['--work-dir', workDir, '--repo', repoRoot]);
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain('skipped');
+  });
+
+  it('returns exit-code 2 with help text on missing --work-dir', () => {
+    const result = runXrefCli([]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('--work-dir');
+  });
+
+  it('returns exit-code 2 on unknown flag', () => {
+    const result = runXrefCli(['--what']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('unknown arg');
+  });
+
+  it('returns exit-code 0 for --help', () => {
+    const result = runXrefCli(['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('caia-adoption-run xref');
+  });
+
+  it('returns exit-code 1 when scan.json is missing', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adopt-xref-cli-missing-'));
+    trash.push(workDir);
+    const result = runXrefCli(['--work-dir', workDir]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('scan.json not found');
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 3 of `p3-adoption-cross-ref`. Wires `caia-adoption-run xref --work-dir <dir>` to read scan.json and write xref.json beside it.
- For each artefact row, runs the L1 literal-pattern cross-ref (P1) + scoring/max-candidates cap (P2). Idempotent — re-runs skip unless `--force`.
- Adds `bin/caia-adoption-run.mjs` (thin shim matching `caia-adoption-verify.mjs` convention), `src/cli/{xref,run,index}.ts`, and 17 new tests including an end-to-end smoke against the three design-doc §1.5 examples.

## Design context
- `agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md` §2.3 (wiring), §5 (xref logic).
- `caia-adoption-run` is the entrypoint that `post-merge-deploy.sh` will invoke from phase 4 of this chain. Today only the `xref` subcommand is wired; `scan`, `pr`, `verify` slots are reserved for their MVP chains.

## xref.json schema (versioned)
```jsonc
{
  "version": 1,
  "sha": "<from-scan-or-null>",
  "generated_at": "<iso>",
  "options": { "repoRoot", "maxCandidates", "packageScope", "packagesDirs", "minLength" },
  "artefacts": [
    { "artefact": {...}, "scoring": {...}, "candidates": [...], "truncated": 0 }
  ],
  "summary": { "artefact_count", "candidate_count", "truncated_total" }
}
```

scan.json reader accepts:
- canonical `{ sha?, artefacts: [...] }` (design doc §4.a)
- bare array of artefact rows
- `{ rows: [...] }` / `{ items: [...] }`

Coerces the design-doc `file` field onto `literal-pattern.ts`'s `source_path` so the own-dir filter still excludes the artefact's own package.

## End-to-end smoke test
`tests/cli/xref.test.ts` builds a synthetic git fixture containing the three §1.5 packages and their expected adoption sites, then writes a synthetic scan.json with `scanPii`, `Tracer`, and `generateCaiaPrimer`. Assertions:
- each artefact finds ≥ 1 candidate
- `scanPii` → `apps/orchestrator/src/safety/tool-result-sanitizer-bridge.ts`
- `Tracer` → `apps/orchestrator/src/observability/agent-otel.ts`
- `generateCaiaPrimer` → both `apps/orchestrator/src/api/routes/agents.ts` and `apps/worker-coding/src/implementation-engine.ts`
- no own-package leakage (no `packages/...` paths)
- scoring populated per artefact

Plus: idempotency (second call returns existing untouched), `--force` overwrite, `--max-candidates 1` cap (generateCaiaPrimer truncated), empty scan, bare-array scan shape, missing scan.json / work-dir errors, CLI exit-code paths (0/1/2).

## Test plan
- [x] `pnpm --filter @chiefaia/adoption-enforcement test` — 7 files, **75 tests pass** (+17 new vs P2's 58).
- [x] `pnpm --filter @chiefaia/adoption-enforcement typecheck` — clean.
- [x] `pnpm --filter @chiefaia/adoption-enforcement lint` — clean.
- [x] `pnpm --filter @chiefaia/adoption-enforcement build` — clean; emits `dist/cli/*`.
- [x] Manual probe of `bin/caia-adoption-run.mjs` against a tmp git fixture — `wrote` / `skipped (already present)` / `--force` / `--help` all behave.

## Report
`~/Documents/projects/reports/p3_xref_p3_cli_2026-05-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)