### PR TITLE
feat(chain-runner,adoption-enforcement): g10 shell wiring + mark-done override (gate p2)

### DIFF
--- a/packages/adoption-enforcement/bin/caia-adopt.mjs
+++ b/packages/adoption-enforcement/bin/caia-adopt.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// caia-adopt — adoption-enforcement substrate CLI.
+//
+// Sub-command dispatcher (verb after the binary name). v1 ships a single
+// verb, `gate-check`, used by scripts/gate-mark-done.sh as the final
+// chokepoint for DoD v2 Guardrail #10 (adoption-everywhere).
+//
+//   caia-adopt gate-check --chain <chain-id> [--ledger <path>]
+//                         [--stuck-opened-days <n>] [--json]
+//
+// Exit codes (matched to scripts/gate-mark-done.sh contract):
+//   0  gate passes (ok=true) — no blockers, safe to mark-done
+//   1  gate blocks (ok=false) — one or more pending opportunities; abort
+//   2  argument / usage error
+//
+// The verb is intentionally thin: it delegates to checkAdoptionGate() from
+// @chiefaia/chain-runner so the gate's logic stays in one place (the
+// programmatic gate is the source of truth; this CLI just renders it).
+
+import { checkAdoptionGate } from '@chiefaia/chain-runner';
+
+const USAGE = `Usage: caia-adopt <verb> [options]
+
+Verbs:
+  gate-check    Check the adoption-everywhere gate for a chain.
+
+Run 'caia-adopt <verb> --help' for verb-specific options.
+`;
+
+const GATE_CHECK_USAGE = `Usage: caia-adopt gate-check --chain <chain-id> [options]
+
+Options:
+  --chain <id>              chain identifier (required)
+  --ledger <path>           override ledger path (default: ~/.caia/adoption/ledger.jsonl)
+  --stuck-opened-days <n>   override stuck-opened threshold (default: 14)
+  --json                    print machine-readable JSON result
+  -h, --help                print this help
+
+Exit codes: 0 = gate passes, 1 = gate blocks, 2 = usage error.
+`;
+
+function die(msg, code = 2) {
+  process.stderr.write(`caia-adopt: ${msg}\n`);
+  process.exit(code);
+}
+
+function parseGateCheckArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '--chain':
+        if (!next) die('--chain requires a value');
+        out.chain = next;
+        i += 1;
+        break;
+      case '--ledger':
+        if (!next) die('--ledger requires a value');
+        out.ledger = next;
+        i += 1;
+        break;
+      case '--stuck-opened-days':
+        if (!next) die('--stuck-opened-days requires a value');
+        out.stuckOpenedDays = Number(next);
+        if (!Number.isFinite(out.stuckOpenedDays) || out.stuckOpenedDays < 0) {
+          die('--stuck-opened-days must be a non-negative number');
+        }
+        i += 1;
+        break;
+      case '--json':
+        out.json = true;
+        break;
+      case '--help':
+      case '-h':
+        process.stdout.write(GATE_CHECK_USAGE);
+        process.exit(0);
+        break;
+      default:
+        die(`unknown gate-check option: ${arg}`);
+    }
+  }
+  if (!out.chain) die('--chain <chain-id> is required');
+  return out;
+}
+
+function formatHumanResult(chain, result) {
+  const lines = [];
+  if (result.ok) {
+    lines.push(`PASS chain=${chain} blockers=0 passing=${result.passing_rows}/${result.total_rows} ledger=${result.ledger_path}`);
+    if (result.empty_ledger) {
+      lines.push('  (empty ledger — v1 no-op mode; gate clears by default)');
+    }
+    if (result.malformed_lines > 0) {
+      lines.push(`  warn: ${result.malformed_lines} malformed line(s) in ledger`);
+    }
+    return lines.join('\n') + '\n';
+  }
+  lines.push(`BLOCK chain=${chain} blockers=${result.blockers.length} passing=${result.passing_rows}/${result.total_rows} ledger=${result.ledger_path}`);
+  for (const b of result.blockers) {
+    const id = b.opportunity_id ?? '<no-id>';
+    const target = [b.target_utility, b.target_export].filter(Boolean).join('/');
+    const site = b.call_site_file ? `${b.call_site_file}:${b.call_site_line ?? '?'}` : '';
+    const age = b.age_days !== undefined ? ` age=${b.age_days.toFixed(1)}d` : '';
+    const targetPart = target ? ` target=${target}` : '';
+    const sitePart = site ? ` site=${site}` : '';
+    lines.push(`  - ${id} state=${b.state} reason=${b.reason}${age}${targetPart}${sitePart}`);
+  }
+  if (result.malformed_lines > 0) {
+    lines.push(`  warn: ${result.malformed_lines} malformed line(s) in ledger`);
+  }
+  lines.push(`  override: caia-chain mark-done <phase> --adoption-pending-ok --reason "<why>"`);
+  return lines.join('\n') + '\n';
+}
+
+function runGateCheck(argv) {
+  const opts = parseGateCheckArgs(argv);
+  const gateOpts = {};
+  if (opts.ledger) gateOpts.ledgerPath = opts.ledger;
+  if (opts.stuckOpenedDays !== undefined) gateOpts.stuckOpenedDays = opts.stuckOpenedDays;
+  const result = checkAdoptionGate(opts.chain, gateOpts);
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ chain: opts.chain, ...result }, null, 2) + '\n');
+  } else {
+    process.stdout.write(formatHumanResult(opts.chain, result));
+  }
+  process.exit(result.ok ? 0 : 1);
+}
+
+function main() {
+  const [, , verb, ...rest] = process.argv;
+  if (!verb || verb === '--help' || verb === '-h') {
+    process.stdout.write(USAGE);
+    process.exit(verb ? 0 : 2);
+  }
+  switch (verb) {
+    case 'gate-check':
+      runGateCheck(rest);
+      break;
+    default:
+      die(`unknown verb: ${verb}\n\n${USAGE}`);
+  }
+}
+
+main();

--- a/packages/adoption-enforcement/package.json
+++ b/packages/adoption-enforcement/package.json
@@ -20,7 +20,8 @@
   "files": ["dist", "README.md"],
   "bin": {
     "caia-adoption-verify": "./bin/caia-adoption-verify.mjs",
-    "caia-adoption-run": "./bin/caia-adoption-run.mjs"
+    "caia-adoption-run": "./bin/caia-adoption-run.mjs",
+    "caia-adopt": "./bin/caia-adopt.mjs"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
@@ -29,7 +30,9 @@
     "lint": "eslint src",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
   },
-  "dependencies": {},
+  "dependencies": {
+    "@chiefaia/chain-runner": "workspace:*"
+  },
   "devDependencies": {
     "@chiefaia/eslint-config": "workspace:*",
     "@chiefaia/tsconfig": "workspace:*",

--- a/packages/adoption-enforcement/tests/caia-adopt-cli.test.ts
+++ b/packages/adoption-enforcement/tests/caia-adopt-cli.test.ts
@@ -1,0 +1,214 @@
+// Golden-output tests for the `caia-adopt gate-check` CLI verb (DoD v2 G10
+// phase 2). Spawns the bin script with vetted ledger fixtures and asserts on
+// stdout, stderr, and exit code so the script's interface contract with
+// scripts/gate-mark-done.sh (and any future caller) is preserved.
+//
+// Three flows are covered:
+//   - pass     : ledger has no blockers for the chain → exit 0, "PASS" line
+//   - block    : ledger has a pending row for the chain → exit 1, "BLOCK" line
+//   - override : --json output (machine surface used by override workflows
+//                to print the diagnostic before invoking
+//                `caia-chain mark-done --adoption-pending-ok`).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const BIN = resolve(__dirname, '..', 'bin', 'caia-adopt.mjs');
+
+let root: string;
+let ledgerPath: string;
+
+const CHAIN = 'p3-cli-test-chain';
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'caia-adopt-cli-'));
+  mkdirSync(root, { recursive: true });
+  ledgerPath = join(root, 'ledger.jsonl');
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+function writeLedger(rows: Array<Record<string, unknown>>): void {
+  writeFileSync(ledgerPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function run(args: string[]): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [BIN, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+describe('caia-adopt — usage', () => {
+  it('prints the top-level usage with no verb and exits 2', () => {
+    const r = run([]);
+    expect(r.status).toBe(2);
+    expect(r.stdout).toContain('Usage: caia-adopt <verb>');
+    expect(r.stdout).toContain('gate-check');
+  });
+
+  it('exits 0 on --help', () => {
+    const r = run(['--help']);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('Usage: caia-adopt <verb>');
+  });
+
+  it('rejects an unknown verb with exit 2', () => {
+    const r = run(['frobnicate']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('unknown verb: frobnicate');
+  });
+});
+
+describe('caia-adopt gate-check — pass flow', () => {
+  it('exits 0 and prints PASS when the ledger is empty (v1 no-op)', () => {
+    // Don't write a ledger — empty/missing is the v1 no-op.
+    const r = run(['gate-check', '--chain', CHAIN, '--ledger', ledgerPath]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/^PASS chain=p3-cli-test-chain blockers=0 passing=0\/0 ledger=/);
+    expect(r.stdout).toContain('empty ledger — v1 no-op mode');
+  });
+
+  it('exits 0 and prints PASS when every row is merged/deferred', () => {
+    writeLedger([
+      { chain_id: CHAIN, state: 'merged', opportunity_id: 'opp-1' },
+      { chain_id: CHAIN, state: 'deferred', opportunity_id: 'opp-2' },
+      { chain_id: 'other-chain', state: 'opened', opportunity_id: 'noise' },
+    ]);
+    const r = run(['gate-check', '--chain', CHAIN, '--ledger', ledgerPath]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/^PASS chain=p3-cli-test-chain blockers=0 passing=2\/2 ledger=/);
+    // Rows belonging to other chains never appear in the count.
+    expect(r.stdout).not.toContain('noise');
+  });
+});
+
+describe('caia-adopt gate-check — block flow', () => {
+  it('exits 1 and lists each blocker with state + reason', () => {
+    writeLedger([
+      {
+        chain_id: CHAIN,
+        state: 'opened',
+        opportunity_id: 'opp-open',
+        target_utility: 'utilA',
+        target_export: 'foo',
+        call_site_file: 'a.ts',
+        call_site_line: 42,
+      },
+      {
+        chain_id: CHAIN,
+        state: 'failed',
+        opportunity_id: 'opp-fail',
+        target_utility: 'utilB',
+      },
+      {
+        chain_id: CHAIN,
+        state: 'merged',
+        opportunity_id: 'opp-ok',
+      },
+    ]);
+    const r = run(['gate-check', '--chain', CHAIN, '--ledger', ledgerPath]);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/^BLOCK chain=p3-cli-test-chain blockers=2 passing=1\/3 ledger=/);
+    expect(r.stdout).toContain('opp-open state=opened reason=pending_state');
+    expect(r.stdout).toContain('target=utilA/foo');
+    expect(r.stdout).toContain('site=a.ts:42');
+    expect(r.stdout).toContain('opp-fail state=failed reason=pending_state');
+    expect(r.stdout).toContain('override: caia-chain mark-done <phase> --adoption-pending-ok --reason "<why>"');
+  });
+
+  it('exits 1 and surfaces stuck_opened separately', () => {
+    // opened_at is 30 days before "now". The default threshold is 14d so this
+    // row must surface as reason=stuck_opened with the override hint visible.
+    const openedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    writeLedger([
+      {
+        chain_id: CHAIN,
+        state: 'opened',
+        opportunity_id: 'opp-stuck',
+        opened_at: openedAt,
+      },
+    ]);
+    const r = run(['gate-check', '--chain', CHAIN, '--ledger', ledgerPath]);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('opp-stuck state=opened reason=stuck_opened');
+    expect(r.stdout).toMatch(/age=\d+\.\d+d/);
+  });
+});
+
+describe('caia-adopt gate-check — override (machine-readable) flow', () => {
+  it('emits JSON the override workflow can parse, ok=false', () => {
+    writeLedger([
+      {
+        chain_id: CHAIN,
+        state: 'opened',
+        opportunity_id: 'opp-1',
+      },
+    ]);
+    const r = run(['gate-check', '--chain', CHAIN, '--ledger', ledgerPath, '--json']);
+    expect(r.status).toBe(1);
+    const parsed = JSON.parse(r.stdout) as {
+      chain: string;
+      ok: boolean;
+      blockers: Array<{ opportunity_id?: string; state: string; reason: string }>;
+      total_rows: number;
+      passing_rows: number;
+      ledger_path: string;
+    };
+    expect(parsed.chain).toBe(CHAIN);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.blockers).toHaveLength(1);
+    expect(parsed.blockers[0]?.opportunity_id).toBe('opp-1');
+    expect(parsed.blockers[0]?.reason).toBe('pending_state');
+    expect(parsed.passing_rows).toBe(0);
+    expect(parsed.total_rows).toBe(1);
+    expect(parsed.ledger_path).toBe(ledgerPath);
+  });
+
+  it('emits JSON with ok=true on the empty-ledger pass path', () => {
+    const r = run(['gate-check', '--chain', CHAIN, '--ledger', ledgerPath, '--json']);
+    expect(r.status).toBe(0);
+    const parsed = JSON.parse(r.stdout) as {
+      ok: boolean;
+      empty_ledger: boolean;
+      blockers: unknown[];
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.empty_ledger).toBe(true);
+    expect(parsed.blockers).toEqual([]);
+  });
+});
+
+describe('caia-adopt gate-check — argument validation', () => {
+  it('exits 2 when --chain is missing', () => {
+    const r = run(['gate-check']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('--chain <chain-id> is required');
+  });
+
+  it('exits 2 on unknown options', () => {
+    const r = run(['gate-check', '--chain', CHAIN, '--bogus']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('unknown gate-check option: --bogus');
+  });
+
+  it('exits 2 when --stuck-opened-days is non-numeric', () => {
+    const r = run(['gate-check', '--chain', CHAIN, '--stuck-opened-days', 'lots']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('--stuck-opened-days must be a non-negative number');
+  });
+});

--- a/packages/chain-runner/bin/gate-mark-done.sh
+++ b/packages/chain-runner/bin/gate-mark-done.sh
@@ -1,21 +1,41 @@
 #!/bin/bash
-# gate-mark-done.sh — guardrail #2 of the 2026-05-13 PR-merge-enforcement set.
+# gate-mark-done.sh — guardrail #2 of the 2026-05-13 PR-merge-enforcement set,
+# now also the chokepoint for guardrail #10 (adoption-everywhere).
 #
-# A chain phase MUST NOT call `mark-done` while a PR it produced is still open.
+# A chain phase MUST NOT call `mark-done` while either:
+#   G2  — a PR it produced is still open / closed-unmerged, OR
+#   G10 — an adoption opportunity recorded for the chain is still pending
+#         (any non-{merged,deferred} state, or stuck in 'opened' > 14d).
+#
 # This helper scans a phase log file for PR URLs, verifies each one is merged
-# (or merges it via `caia-pr-merge-or-fail`), and only then exits 0 so the
-# caller can proceed to `mark-done`.
+# (or merges it via `caia-pr-merge-or-fail`), then runs `caia-adopt gate-check
+# --chain $CHAIN_ID` for the adoption check, and only exits 0 if every gate
+# passes.
 #
 # Invocation:
 #   gate-mark-done.sh PHASE_LOG_FILE [TIMEOUT_SECONDS]
 #
+# Environment:
+#   CAIA_CHAIN_ID         (optional) chain id used by the adoption-everywhere
+#                         gate (G10). When set, the script runs
+#                         `caia-adopt gate-check --chain "$CAIA_CHAIN_ID"`
+#                         as a final step. When unset, the script tries to
+#                         derive it from LOG_FILE's path (~/.caia/chain/<id>/).
+#                         If neither yields a chain id, the adoption gate is
+#                         skipped with a warning (graceful degradation while
+#                         the substrate is still being adopted everywhere).
+#   CAIA_ADOPT_BIN        (optional) path to the caia-adopt CLI. Defaults to
+#                         the packages/adoption-enforcement/bin/caia-adopt.mjs
+#                         in this repo.
+#
 # Exit codes:
-#   0  no PRs found, or every PR is verified merged
-#   1  one or more PRs could not be merged (substantive conflicts/failures)
+#   0  no PRs found (or every PR verified merged) AND adoption gate ok
+#   1  one or more PRs could not be merged, OR adoption gate refused
 #   2  argument error
 #
 # Standing rule (memory_2026-05-13): NO chain phase marks itself done with an
-# open PR for its branch.
+# open PR for its branch. The G10 extension (2026-05-16) adds the same
+# refusal contract for open adoption opportunities.
 #
 # DEPRECATION (chain-runner-battle-harden phase 9, 2026-05-14, H-15).
 # The PR-merge guardrail is now FIRST-CLASS inside `caia-chain mark-done` via
@@ -37,56 +57,84 @@ if [ -z "$LOG_FILE" ] || [ ! -r "$LOG_FILE" ]; then
   exit 2
 fi
 
-# Find PR refs in the log. Match github.com/<owner>/<repo>/pull/<N>.
-# Accept both prakashgbid and any other owner (chains may push elsewhere).
-PR_REFS=$(grep -oE 'github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+' "$LOG_FILE" \
-          | sort -u)
-
-if [ -z "$PR_REFS" ]; then
-  # No PRs referenced — nothing to gate.
-  exit 0
-fi
-
 CAIA_PR_MERGE_BIN="${CAIA_PR_MERGE_BIN:-$HOME/Documents/projects/caia/packages/chain-runner/bin/caia-pr-merge-or-fail.js}"
 NODE_BIN="${NODE_BIN:-/opt/homebrew/bin/node}"
 
 ANY_FAILED=0
 
-while IFS= read -r ref; do
-  # ref = github.com/OWNER/REPO/pull/N
-  owner=$(echo "$ref" | awk -F/ '{print $2}')
-  repo=$(echo "$ref" | awk -F/ '{print $3}')
-  pr=$(echo  "$ref" | awk -F/ '{print $5}')
-  full="${owner}/${repo}"
-  if [ -z "$pr" ] || [ -z "$full" ]; then continue; fi
+# G10: resolve chain id once. Caller may set CAIA_CHAIN_ID; otherwise derive
+# from LOG_FILE's path when it sits under ~/.caia/chain/<id>/.
+CHAIN_ID="${CAIA_CHAIN_ID:-}"
+if [ -z "$CHAIN_ID" ]; then
+  case "$LOG_FILE" in
+    *"/.caia/chain/"*)
+      CHAIN_ID=$(echo "$LOG_FILE" | sed -E 's#.*/\.caia/chain/([^/]+)/.*#\1#')
+      ;;
+  esac
+fi
 
-  # Check current state
-  state=$(gh pr view "$pr" --repo "$full" --json state -q '.state' 2>/dev/null || echo "")
-  if [ "$state" = "MERGED" ]; then
-    echo "gate-mark-done: $full#$pr already MERGED — ok" >&2
-    continue
-  fi
-  if [ "$state" = "CLOSED" ]; then
-    echo "gate-mark-done: $full#$pr CLOSED (unmerged) — refusing to mark-done" >&2
-    ANY_FAILED=1
-    continue
-  fi
-  if [ -z "$state" ]; then
-    # Could be a PR in another repo we don't have access to. Skip with note.
-    echo "gate-mark-done: $full#$pr state-unknown — skipping" >&2
-    continue
-  fi
+# Find PR refs in the log. Match github.com/<owner>/<repo>/pull/<N>.
+# Accept both prakashgbid and any other owner (chains may push elsewhere).
+PR_REFS=$(grep -oE 'github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+' "$LOG_FILE" \
+          | sort -u)
 
-  # state is OPEN — attempt merge via the helper
-  echo "gate-mark-done: $full#$pr is OPEN, invoking caia-pr-merge-or-fail" >&2
-  if "$NODE_BIN" "$CAIA_PR_MERGE_BIN" \
-        --repo "$full" --pr "$pr" \
-        --timeout-seconds "$TIMEOUT_SECONDS"; then
-    echo "gate-mark-done: $full#$pr merged ok" >&2
+if [ -n "$PR_REFS" ]; then
+  while IFS= read -r ref; do
+    # ref = github.com/OWNER/REPO/pull/N
+    owner=$(echo "$ref" | awk -F/ '{print $2}')
+    repo=$(echo "$ref" | awk -F/ '{print $3}')
+    pr=$(echo  "$ref" | awk -F/ '{print $5}')
+    full="${owner}/${repo}"
+    if [ -z "$pr" ] || [ -z "$full" ]; then continue; fi
+
+    # Check current state
+    state=$(gh pr view "$pr" --repo "$full" --json state -q '.state' 2>/dev/null || echo "")
+    if [ "$state" = "MERGED" ]; then
+      echo "gate-mark-done: $full#$pr already MERGED — ok" >&2
+      continue
+    fi
+    if [ "$state" = "CLOSED" ]; then
+      echo "gate-mark-done: $full#$pr CLOSED (unmerged) — refusing to mark-done" >&2
+      ANY_FAILED=1
+      continue
+    fi
+    if [ -z "$state" ]; then
+      # Could be a PR in another repo we don't have access to. Skip with note.
+      echo "gate-mark-done: $full#$pr state-unknown — skipping" >&2
+      continue
+    fi
+
+    # state is OPEN — attempt merge via the helper
+    echo "gate-mark-done: $full#$pr is OPEN, invoking caia-pr-merge-or-fail" >&2
+    if "$NODE_BIN" "$CAIA_PR_MERGE_BIN" \
+          --repo "$full" --pr "$pr" \
+          --timeout-seconds "$TIMEOUT_SECONDS"; then
+      echo "gate-mark-done: $full#$pr merged ok" >&2
+    else
+      echo "gate-mark-done: $full#$pr could not be merged — refusing to mark-done" >&2
+      ANY_FAILED=1
+    fi
+  done <<< "$PR_REFS"
+fi
+
+# Final step: adoption-everywhere gate (DoD v2 G10). Same exit-code semantics
+# as the PR-merge loop above — a block here means "refusing to mark-done"
+# with exit 1. Override path is `caia-chain mark-done --adoption-pending-ok
+# --reason "<why>"` invoked directly (bypassing this wrapper).
+if [ -n "$CHAIN_ID" ]; then
+  CAIA_ADOPT_BIN="${CAIA_ADOPT_BIN:-$HOME/Documents/projects/caia/packages/adoption-enforcement/bin/caia-adopt.mjs}"
+  if [ -r "$CAIA_ADOPT_BIN" ]; then
+    if "$NODE_BIN" "$CAIA_ADOPT_BIN" gate-check --chain "$CHAIN_ID" >&2; then
+      echo "gate-mark-done: adoption gate ok for chain=$CHAIN_ID" >&2
+    else
+      echo "gate-mark-done: adoption gate BLOCKED chain=$CHAIN_ID — refusing to mark-done" >&2
+      ANY_FAILED=1
+    fi
   else
-    echo "gate-mark-done: $full#$pr could not be merged — refusing to mark-done" >&2
-    ANY_FAILED=1
+    echo "gate-mark-done: caia-adopt bin not found at $CAIA_ADOPT_BIN — adoption gate SKIPPED" >&2
   fi
-done <<< "$PR_REFS"
+else
+  echo "gate-mark-done: no CAIA_CHAIN_ID resolved — adoption gate SKIPPED" >&2
+fi
 
 exit $ANY_FAILED

--- a/packages/chain-runner/src/audit-schema.ts
+++ b/packages/chain-runner/src/audit-schema.ts
@@ -150,6 +150,20 @@ export const AUDIT_EVENTS = {
     required: [{ name: 'phase_id', type: 'number' }],
     description: 'success_criteria failed in strict mode — mark-done refused.',
   },
+  // DoD v2 Guardrail #10 — operator-issued override of the adoption-everywhere
+  // gate. Recorded when `caia-chain mark-done --adoption-pending-ok --reason
+  // <text>` is invoked. The override does NOT change the gate's verdict; the
+  // event is the audit-trail proof that an operator (or automated escape
+  // hatch) consciously bypassed an open adoption opportunity.
+  adoption_gate_override: {
+    category: 'operator',
+    required: [
+      { name: 'phase_id', type: 'number' },
+      { name: 'reason', type: 'string' },
+    ],
+    description:
+      'mark-done invoked with --adoption-pending-ok; adoption gate verdict ignored.',
+  },
 
   // Attempts (sub-phase loop counters)
   attempt_started: {

--- a/packages/chain-runner/src/cli.ts
+++ b/packages/chain-runner/src/cli.ts
@@ -305,13 +305,21 @@ export function buildProgram(): Command {
       '--skip-acceptance',
       'H-15: skip success_criteria enforcement (escape hatch for adjudication tooling)',
     )
+    .option(
+      '--adoption-pending-ok',
+      'G10: explicitly override the adoption-everywhere gate. Records an adoption_gate_override audit event with the supplied --reason.',
+    )
+    .option(
+      '--reason <text>',
+      'G10: human-readable justification for --adoption-pending-ok. Required when that flag is set.',
+    )
     .description(
-      'Transition a phase to done and clear the lock. H-15: validates success_criteria per phase/chain enforce mode (default warn).',
+      'Transition a phase to done and clear the lock. H-15: validates success_criteria per phase/chain enforce mode (default warn). G10: --adoption-pending-ok + --reason record an audit-only override of the adoption gate.',
     )
     .action(
       (
         phaseId: string,
-        cmdOpts: { skipAcceptance?: boolean },
+        cmdOpts: { skipAcceptance?: boolean; adoptionPendingOk?: boolean; reason?: string },
         cmd: Command,
       ) => {
         const opts = cmd.optsWithGlobals() as BaseOptions;
@@ -319,6 +327,25 @@ export function buildProgram(): Command {
         // H-13 (phase 9, 2026-05-14). Snapshot state.json before the mutation
         // so a botched mark-done can be rolled back from .backups/.
         takeStateBackup(ctx);
+        // G10 override: emit the audit event BEFORE markDone so a downstream
+        // acceptance refusal still leaves the override trail. The mark-done
+        // itself proceeds normally — the override is purely an audit-only
+        // acknowledgement that an open adoption opportunity was knowingly
+        // bypassed (the shell-level gate-mark-done.sh is the enforcement
+        // chokepoint; this flag is for the worker that consciously skipped it).
+        if (cmdOpts.adoptionPendingOk) {
+          const reason = (cmdOpts.reason ?? '').trim();
+          if (reason === '') {
+            fail(
+              '--adoption-pending-ok requires --reason "<justification>" (G10 audit-trail contract)',
+              2,
+            );
+          }
+          appendAudit(ctx.paths.auditFile, 'adoption_gate_override', {
+            phase_id: Number(phaseId),
+            reason,
+          });
+        }
         const markDoneOpts: Parameters<typeof markDone>[2] = {};
         if (cmdOpts.skipAcceptance) markDoneOpts.skipAcceptance = true;
         try {

--- a/packages/chain-runner/tests/adoption-gate-override.test.ts
+++ b/packages/chain-runner/tests/adoption-gate-override.test.ts
@@ -1,0 +1,149 @@
+// Golden-output tests for `caia-chain mark-done --adoption-pending-ok --reason
+// <text>` — the audit-only override side of DoD v2 Guardrail #10 (phase 2 of
+// the adoption gate, 2026-05-16).
+//
+// The shell wrapper scripts/gate-mark-done.sh is the enforcement chokepoint
+// (its golden behavior is covered by the bash CLI in caia-adopt-cli.test.ts).
+// This file covers the override path that runs INSTEAD of (i.e. bypassing)
+// the shell wrapper: a worker that consciously skipped gate-mark-done.sh and
+// is recording why in the chain audit log.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { makeFixture, type FixtureBundle } from './fixtures.js';
+import {
+  acquireLock,
+} from '../src/lock.js';
+import {
+  initState,
+  loadContext,
+  markInProgress,
+  type StateContext,
+} from '../src/state.js';
+
+const CLI_BIN = resolve(__dirname, '..', 'bin', 'caia-chain.js');
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function runCli(
+  bundle: FixtureBundle,
+  args: string[],
+): CliResult {
+  // Commander requires per-subcommand options to follow the verb, so we
+  // splice --chain-id / --phases in AFTER args[0] (the verb).
+  if (args.length === 0) throw new Error('runCli: args must include the verb');
+  const [verb, ...rest] = args;
+  const r = spawnSync(
+    process.execPath,
+    [
+      CLI_BIN,
+      verb!,
+      '--chain-id',
+      bundle.chainId,
+      '--phases',
+      bundle.specPath,
+      ...rest,
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CAIA_CHAIN_HOME: bundle.chainHome,
+        CAIA_DISABLE_NOTIFICATIONS: '1',
+      },
+    },
+  );
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function readAuditEvents(ctx: StateContext): Array<Record<string, unknown>> {
+  if (!existsSync(ctx.paths.auditFile)) return [];
+  return readFileSync(ctx.paths.auditFile, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe('caia-chain mark-done — G10 adoption-pending-ok override', () => {
+  let bundle: FixtureBundle;
+  let ctx: StateContext;
+
+  beforeEach(() => {
+    bundle = makeFixture('g10-override');
+    ctx = loadContext(bundle.chainId, bundle.specPath);
+    initState(ctx);
+    // Get phase 1 into in_progress with a lock so mark-done has work to do.
+    const sessionId = 'sess-g10-override';
+    markInProgress(ctx, '1', sessionId);
+    acquireLock(ctx, 1, sessionId);
+  });
+
+  afterEach(() => {
+    bundle.cleanup();
+  });
+
+  it('pass flow — no override flag → phase_done audit, no override event', () => {
+    const r = runCli(bundle, ['mark-done', '1']);
+    expect(r.status).toBe(0);
+    const events = readAuditEvents(ctx);
+    const names = events.map((e) => e['event']);
+    expect(names).toContain('phase_done');
+    expect(names).not.toContain('adoption_gate_override');
+  });
+
+  it('override flow — --adoption-pending-ok --reason "<text>" appends the override audit AND completes mark-done', () => {
+    const r = runCli(bundle, [
+      'mark-done',
+      '1',
+      '--adoption-pending-ok',
+      '--reason',
+      'p3-substrate-empty-2026-05-16',
+    ]);
+    expect(r.status).toBe(0);
+    const events = readAuditEvents(ctx);
+    const names = events.map((e) => e['event']);
+    expect(names).toContain('adoption_gate_override');
+    expect(names).toContain('phase_done');
+    // The override event MUST come first (we record the intent before
+    // mutating state) — preserves the audit trail even if mark-done blows up
+    // later in the call chain.
+    const overrideIdx = names.indexOf('adoption_gate_override');
+    const doneIdx = names.indexOf('phase_done');
+    expect(overrideIdx).toBeLessThan(doneIdx);
+
+    const overrideEvt = events.find((e) => e['event'] === 'adoption_gate_override');
+    expect(overrideEvt).toBeDefined();
+    expect(overrideEvt?.['phase_id']).toBe(1);
+    expect(overrideEvt?.['reason']).toBe('p3-substrate-empty-2026-05-16');
+  });
+
+  it('block flow — --adoption-pending-ok without --reason exits 2 and writes no override event', () => {
+    const r = runCli(bundle, ['mark-done', '1', '--adoption-pending-ok']);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('--adoption-pending-ok requires --reason');
+    const events = readAuditEvents(ctx);
+    const names = events.map((e) => e['event']);
+    expect(names).not.toContain('adoption_gate_override');
+    expect(names).not.toContain('phase_done');
+  });
+
+  it('block flow — --adoption-pending-ok with empty --reason "  " is rejected', () => {
+    const r = runCli(bundle, [
+      'mark-done',
+      '1',
+      '--adoption-pending-ok',
+      '--reason',
+      '   ',
+    ]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('--adoption-pending-ok requires --reason');
+    const events = readAuditEvents(ctx);
+    expect(events.map((e) => e['event'])).not.toContain('adoption_gate_override');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,10 @@ importers:
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
   packages/adoption-enforcement:
+    dependencies:
+      '@chiefaia/chain-runner':
+        specifier: workspace:*
+        version: link:../chain-runner
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Phase 2 of DoD v2 Guardrail #10 (adoption-everywhere). Wires the programmatic `checkAdoptionGate()` shipped in phase 1 (#503) into the mark-done chokepoint.

- **`scripts/gate-mark-done.sh`** runs `caia-adopt gate-check --chain $CAIA_CHAIN_ID` as a final step. Chain id resolved from `$CAIA_CHAIN_ID` or derived from a `LOG_FILE` under `~/.caia/chain/<id>/`. Same exit-code semantics as the existing PR-merge gate (`0` ok / `1` block / `2` usage). Graceful degradation when neither is set or the bin is missing (skip with warn).
- **`caia-chain mark-done`** gains `--adoption-pending-ok` + `--reason` flags. The override REQUIRES `--reason "<text>"` (audit-trail contract). When supplied, an `adoption_gate_override` audit event is appended BEFORE the markDone mutation so the override trail survives even if a downstream acceptance refusal fires. New event registered in `src/audit-schema.ts` (category=operator).
- **New CLI verb** `caia-adopt gate-check --chain <id>` in adoption-enforcement (with optional `--ledger` / `--stuck-opened-days` / `--json`). Delegates to `checkAdoptionGate()` so the gate logic stays single-sourced. `caia-adopt` is a subcommand dispatcher — future substrate verbs (scan, xref, verify) plug in alongside `gate-check`.

## Tests

16 new tests, all passing:

- `packages/adoption-enforcement/tests/caia-adopt-cli.test.ts` (12) — golden-output for pass / block (pending_state + stuck_opened) / \`--json\` (override path's machine surface) + arg validation.
- `packages/chain-runner/tests/adoption-gate-override.test.ts` (4) — pass / override-with-reason / override-missing-reason / override-empty-reason flows, asserting audit event ordering and exit codes.

Phase-1 gate module tests still pass (26/26) and audit-schema registry test picks up the new event (17/17).

## Out of scope

Substrate scan / xref / generate (separate chains, addendum §6). The gate remains in v1 no-op mode while the ledger is empty.

## Test plan

- [x] typecheck + lint clean
- [x] adoption-enforcement test suite (70 pass)
- [x] chain-runner gates+override+audit-schema (47 pass)
- [x] Manual smoke: gate-mark-done.sh end-to-end pass + block

## Companion

`agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md` — substrate addendum §1 (G10 pass/block sets).

Chain tracker: `p3-dod-v2-adoption-gate` phase 2 (state.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)