### PR TITLE
feat(post-merge): wire caia-adoption-run xref into post-merge-deploy

### DIFF
--- a/scripts/post-merge/post-merge-deploy.sh
+++ b/scripts/post-merge/post-merge-deploy.sh
@@ -10,6 +10,11 @@
 #                        router LaunchAgent so the new binary is loaded.
 #                        (Closes the "stale binary" gap from 2026-05-15
 #                        — see reports/integration_a1_post_merge_signal_2026-05-15.md.)
+#                        Then fires `dispatch_adoption_xref`, which runs
+#                        `caia-adoption-run xref` in the background if
+#                        scan.json exists in ~/.caia/post-merge/work/<sha>/
+#                        and xref.json doesn't (p3-adoption-cross-ref
+#                        phase 4 — Adoption Enforcement Substrate MVP-A).
 #   - prakashgbid/stolution : stub (extend with K3s rollout / ssh deploy).
 #
 # Operator extension point: add a new `case "$repo" in` branch, or add
@@ -87,6 +92,69 @@ kickstart_daemon() {
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$label" "$rc" "${before_pid:-none}" "${after_pid:-none}" "$pr" "$repo"
 }
 
+# Adoption-enforcement xref stage. Runs `caia-adoption-run xref` after the
+# scan stage (p3-adoption-scan-engine, future MVP-A) has produced scan.json
+# in the per-sha work dir. Background, hard-capped at 60 s. Idempotent —
+# skips when xref.json is already present. Until the scan stage lands,
+# scan.json never exists and this is a no-op.
+#
+# On a successful xref the ledger gets one append:
+#   { ts, event:"xref_done", sha, artefact_count, candidate_count }
+# Ledger schema lands fully in p3-dod-v2-adoption-gate phase 1; this is the
+# minimum-viable append that the gate's reader will see.
+dispatch_adoption_xref() {
+  local work_dir="$POSTMERGE_HOME/work/$sha"
+  local scan_path="$work_dir/scan.json"
+  local xref_path="$work_dir/xref.json"
+  local log_path="$work_dir/xref.log"
+  local ledger_path="$POSTMERGE_HOME/adoption.jsonl"
+  local repo_root="${CAIA_REPO_ROOT:-$HOME/Documents/projects/caia}"
+  local run_bin="$repo_root/packages/adoption-enforcement/bin/caia-adoption-run.mjs"
+  local node_bin="${NODE_BIN:-/opt/homebrew/opt/node@22/bin/node}"
+  [[ -x "$node_bin" ]] || node_bin="$(command -v node 2>/dev/null || echo /opt/homebrew/bin/node)"
+
+  if [[ "$sha" == "unknown" || "$sha" == "null" || -z "$sha" ]]; then return 0; fi
+  if [[ ! -f "$scan_path" ]]; then
+    printf '{"ts":"%s","level":"info","event":"adoption_xref_skipped","sha":"%s","reason":"scan_missing"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha"
+    return 0
+  fi
+  if [[ -f "$xref_path" ]]; then
+    printf '{"ts":"%s","level":"info","event":"adoption_xref_skipped","sha":"%s","reason":"xref_present"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha"
+    return 0
+  fi
+  if [[ ! -x "$node_bin" || ! -f "$run_bin" ]]; then
+    printf '{"ts":"%s","level":"warn","event":"adoption_xref_skipped","sha":"%s","reason":"runner_unavailable","node":"%s","bin":"%s"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$node_bin" "$run_bin"
+    return 0
+  fi
+
+  mkdir -p "$work_dir"
+  (
+    set +e
+    perl -e 'alarm shift; exec @ARGV' 60 \
+      "$node_bin" "$run_bin" xref --work-dir "$work_dir" --repo "$repo_root" \
+      >> "$log_path" 2>&1
+    local_rc=$?
+    if [[ $local_rc -eq 0 && -f "$xref_path" ]]; then
+      a=$(jq -r '.summary.artefact_count // 0' "$xref_path" 2>/dev/null)
+      c=$(jq -r '.summary.candidate_count // 0' "$xref_path" 2>/dev/null)
+      [[ -z "$a" ]] && a=0
+      [[ -z "$c" ]] && c=0
+      printf '{"ts":"%s","event":"xref_done","sha":"%s","artefact_count":%s,"candidate_count":%s}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$a" "$c" >> "$ledger_path"
+    else
+      printf '{"ts":"%s","event":"xref_failed","sha":"%s","rc":%d}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$local_rc" >> "$ledger_path"
+    fi
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+
+  printf '{"ts":"%s","level":"info","event":"adoption_xref_dispatched","sha":"%s","work_dir":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$work_dir"
+}
+
 # --- per-repo deploy plug-in points ----------------------------------------
 case "$repo" in
   prakashgbid/caia)
@@ -103,6 +171,7 @@ case "$repo" in
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$pr" "$(printf '%s' "$title" | jq -Rs .)"
       kickstart_daemon "com.chiefaia.local-llm-router"
     fi
+    dispatch_adoption_xref
     ;;
   prakashgbid/stolution)
     # TODO: SSH to stolution, rsync new state, run deploy-*.sh idempotently.


### PR DESCRIPTION
## Summary
- Phase 4 (final) of `p3-adoption-cross-ref` chain. Wires `caia-adoption-run xref` into `scripts/post-merge/post-merge-deploy.sh` so every merge to `develop` in `prakashgbid/caia` triggers a background xref pass when a scan.json is present.
- Adds the first append to the adoption ledger (`~/.caia/post-merge/adoption.jsonl`): one `xref_done` line per successful run with `{ts, sha, artefact_count, candidate_count}`. Ledger schema lands fully in `p3-dod-v2-adoption-gate` phase 1 — this is the minimum-viable append the gate's reader will see.
- Until the scan stage (`p3-adoption-scan-engine`, future MVP-A) lands, scan.json is never produced and the stage is a quiet no-op (`adoption_xref_skipped reason=scan_missing`).

## Design context
- `agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md` §2.3 (wiring) + table at §2 (work dir: `~/.caia/post-merge/work/<sha>/`).
- xref runs background, hard-capped at 60 s with `perl -e 'alarm shift; exec @ARGV'` (`timeout`/`gtimeout` are not present on stock macOS, perl ships with the OS).
- Logs runner stdout/stderr to `work-dir/xref.log` (matches the report convention).
- Idempotent: skip when `xref.json` already exists, skip when scan.json missing, skip when runner unavailable. Caia repo only — non-caia repos never enter the helper.

## Smoke test (synthetic PR #492 replay)
PR #492 is docs-only and still OPEN, so a real replay isn't possible; replicated the docs-only case with an empty `{sha, artefacts:[]}` scan.json and called the deploy script with a synthetic row:
- xref.json produced gracefully with `artefacts: []`, `summary.artefact_count: 0`, `summary.candidate_count: 0`.
- adoption.jsonl received `{"ts":"…","event":"xref_done","sha":"test-p492-…","artefact_count":0,"candidate_count":0}`.
- Re-run with xref.json present → emitted `adoption_xref_skipped reason=xref_present` (idempotent).
- Different sha with no scan.json → emitted `adoption_xref_skipped reason=scan_missing`.
- stolution row → never entered the helper.

## Test plan
- [x] `bash -n scripts/post-merge/post-merge-deploy.sh` — clean
- [x] Synthetic docs-only replay (PR #492 shape): empty xref.json + ledger entry written
- [x] Idempotency: 2nd run skips with reason=xref_present
- [x] Safety: scan.json missing → skip; non-caia repo → no-op
- [x] Health check still passes (`post-merge-deploy.sh --health-check` → `{ok:true,...}`)

## Report
None — single-file integration wire, evidence captured above. Will be reflected in the chain audit log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)