### PR TITLE
feat(adoption-enforcement): ast-based new-exports detector (scan p2)

### DIFF
--- a/packages/adoption-enforcement/src/index.ts
+++ b/packages/adoption-enforcement/src/index.ts
@@ -2,3 +2,4 @@ export * as verify from './verify/index.js';
 export * as pr from './pr/index.js';
 export * as crossref from './crossref/index.js';
 export * as cli from './cli/index.js';
+export * as scan from './scan/index.js';

--- a/packages/adoption-enforcement/src/scan/detect-new-exports.ts
+++ b/packages/adoption-enforcement/src/scan/detect-new-exports.ts
@@ -1,0 +1,55 @@
+import { dirname, isAbsolute, resolve } from 'node:path';
+
+import { parseExports } from './parse-exports.js';
+import { diffExports, readSnapshot, writeSnapshotAtomic } from './snapshot.js';
+import type { DetectNewExportsOptions, DetectNewExportsResult, ExportsSnapshot } from './types.js';
+
+/**
+ * Detect newly added top-level exports in a workspace package's entry file.
+ *
+ * Resolves the snapshot at `<pkgRoot>/.adoption/exports-snapshot.json` where
+ * `<pkgRoot>` is the directory two levels above the index file
+ * (`packages/<pkg>/src/index.ts` ⇒ `packages/<pkg>/.adoption/...`).
+ *
+ * On first run (snapshot missing), every parsed export is considered new and
+ * a fresh snapshot is persisted. Subsequent runs return only the rows that
+ * appeared since the last snapshot, then atomically rewrite the snapshot.
+ */
+export function detectNewExports(
+  indexPath: string,
+  options: DetectNewExportsOptions = {},
+): DetectNewExportsResult {
+  if (!isAbsolute(indexPath)) {
+    throw new Error(`detectNewExports: indexPath must be absolute, got ${indexPath}`);
+  }
+
+  const snapshotPath = options.snapshotPath ?? defaultSnapshotPath(indexPath);
+  const exports = parseExports(indexPath);
+  const prior = readSnapshot(snapshotPath);
+  const firstRun = prior === null;
+  const newExports = firstRun ? exports.slice() : diffExports(prior.exports, exports);
+
+  const writeSnapshot = options.writeSnapshot ?? true;
+  if (writeSnapshot) {
+    const snapshot: ExportsSnapshot = {
+      version: 1,
+      indexPath,
+      capturedAt: new Date().toISOString(),
+      exports,
+    };
+    writeSnapshotAtomic(snapshotPath, snapshot);
+  }
+
+  return {
+    exports,
+    newExports,
+    snapshotPath,
+    firstRun,
+  };
+}
+
+export function defaultSnapshotPath(indexPath: string): string {
+  // packages/<pkg>/src/index.ts → packages/<pkg>/.adoption/exports-snapshot.json
+  const pkgRoot = resolve(dirname(indexPath), '..');
+  return resolve(pkgRoot, '.adoption', 'exports-snapshot.json');
+}

--- a/packages/adoption-enforcement/src/scan/index.ts
+++ b/packages/adoption-enforcement/src/scan/index.ts
@@ -1,0 +1,10 @@
+export { detectNewExports, defaultSnapshotPath } from './detect-new-exports.js';
+export { parseExports, parseExportsFromSource } from './parse-exports.js';
+export { diffExports, readSnapshot, writeSnapshotAtomic, rowKey } from './snapshot.js';
+export type {
+  DeclKind,
+  DetectNewExportsOptions,
+  DetectNewExportsResult,
+  ExportRow,
+  ExportsSnapshot,
+} from './types.js';

--- a/packages/adoption-enforcement/src/scan/parse-exports.ts
+++ b/packages/adoption-enforcement/src/scan/parse-exports.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'node:fs';
+
+import ts from 'typescript';
+
+import type { DeclKind, ExportRow } from './types.js';
+
+/**
+ * Parse the top-level exports of an `index.ts`-style entry file using the
+ * TypeScript compiler API.
+ *
+ * Handles:
+ *   - `export function|class|const|let|var|interface|type|enum X ...`
+ *   - `export default function|class|<expr>`
+ *   - `export { foo, bar as baz, type Quux }` (local export list)
+ *   - `export { foo, bar as baz, type Quux } from './m'` (re-export list)
+ *   - `export type { Foo } from './m'` (whole-clause type-only re-export)
+ *   - `export * as ns from './m'` (namespace re-export)
+ *   - destructuring binding patterns in `export const { a, b } = ...`
+ *
+ * Wildcard `export * from './m'` is intentionally NOT emitted as a row — it
+ * has no identifier and is a transparent pass-through.
+ */
+export function parseExports(indexPath: string): ExportRow[] {
+  const source = readFileSync(indexPath, 'utf8');
+  return parseExportsFromSource(source, indexPath);
+}
+
+export function parseExportsFromSource(source: string, fileName = 'index.ts'): ExportRow[] {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, /*setParents*/ true, ts.ScriptKind.TS);
+  const rows: ExportRow[] = [];
+
+  for (const stmt of sf.statements) {
+    visitTopLevel(stmt, rows);
+  }
+  return rows;
+}
+
+function visitTopLevel(node: ts.Statement, rows: ExportRow[]): void {
+  if (ts.isFunctionDeclaration(node) && hasExportModifier(node)) {
+    if (hasDefaultModifier(node)) {
+      rows.push({ identifier: 'default', decl_kind: 'default', isTypeOnly: false });
+    } else if (node.name) {
+      rows.push({ identifier: node.name.text, decl_kind: 'function', isTypeOnly: false });
+    }
+    return;
+  }
+
+  if (ts.isClassDeclaration(node) && hasExportModifier(node)) {
+    if (hasDefaultModifier(node)) {
+      rows.push({ identifier: 'default', decl_kind: 'default', isTypeOnly: false });
+    } else if (node.name) {
+      rows.push({ identifier: node.name.text, decl_kind: 'class', isTypeOnly: false });
+    }
+    return;
+  }
+
+  if (ts.isInterfaceDeclaration(node) && hasExportModifier(node)) {
+    rows.push({ identifier: node.name.text, decl_kind: 'interface', isTypeOnly: true });
+    return;
+  }
+
+  if (ts.isTypeAliasDeclaration(node) && hasExportModifier(node)) {
+    rows.push({ identifier: node.name.text, decl_kind: 'type', isTypeOnly: true });
+    return;
+  }
+
+  if (ts.isEnumDeclaration(node) && hasExportModifier(node)) {
+    rows.push({ identifier: node.name.text, decl_kind: 'enum', isTypeOnly: false });
+    return;
+  }
+
+  if (ts.isVariableStatement(node) && hasExportModifier(node)) {
+    const kind = variableKind(node.declarationList);
+    for (const decl of node.declarationList.declarations) {
+      collectBindingNames(decl.name, kind, rows);
+    }
+    return;
+  }
+
+  if (ts.isExportAssignment(node)) {
+    // `export default <expr>` (export = is CommonJS, ignored).
+    if (node.isExportEquals !== true) {
+      rows.push({ identifier: 'default', decl_kind: 'default', isTypeOnly: false });
+    }
+    return;
+  }
+
+  if (ts.isExportDeclaration(node)) {
+    visitExportDeclaration(node, rows);
+    return;
+  }
+}
+
+function visitExportDeclaration(node: ts.ExportDeclaration, rows: ExportRow[]): void {
+  const isFrom = node.moduleSpecifier !== undefined;
+  const clauseTypeOnly = node.isTypeOnly === true;
+
+  if (node.exportClause === undefined) {
+    // `export * from './m'` — no identifier rows.
+    return;
+  }
+
+  if (ts.isNamespaceExport(node.exportClause)) {
+    // `export * as ns from './m'`
+    rows.push({
+      identifier: node.exportClause.name.text,
+      decl_kind: 'namespace-re-export',
+      isTypeOnly: clauseTypeOnly,
+    });
+    return;
+  }
+
+  // NamedExports: `export { a, b as c, type D } [from '...']`
+  for (const spec of node.exportClause.elements) {
+    const isTypeOnly = clauseTypeOnly || spec.isTypeOnly === true;
+    const identifier = spec.name.text;
+    const decl_kind: DeclKind = isFrom ? 're-export' : 're-export';
+    rows.push({ identifier, decl_kind, isTypeOnly });
+  }
+}
+
+function hasExportModifier(node: ts.HasModifiers): boolean {
+  const mods = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return mods?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+function hasDefaultModifier(node: ts.HasModifiers): boolean {
+  const mods = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return mods?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword) ?? false;
+}
+
+function variableKind(list: ts.VariableDeclarationList): 'const' | 'let' | 'var' {
+  if ((list.flags & ts.NodeFlags.Const) !== 0) return 'const';
+  if ((list.flags & ts.NodeFlags.Let) !== 0) return 'let';
+  return 'var';
+}
+
+function collectBindingNames(
+  name: ts.BindingName,
+  kind: 'const' | 'let' | 'var',
+  rows: ExportRow[],
+): void {
+  if (ts.isIdentifier(name)) {
+    rows.push({ identifier: name.text, decl_kind: kind, isTypeOnly: false });
+    return;
+  }
+  if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element)) {
+        collectBindingNames(element.name, kind, rows);
+      }
+      // OmittedExpression (e.g. `[, b]`) contributes nothing.
+    }
+  }
+}

--- a/packages/adoption-enforcement/src/scan/snapshot.ts
+++ b/packages/adoption-enforcement/src/scan/snapshot.ts
@@ -1,0 +1,70 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { ExportRow, ExportsSnapshot } from './types.js';
+
+/**
+ * Read a previously written exports snapshot. Returns `null` if the file is
+ * missing — caller should treat that as a first-time run (all exports are new).
+ * Malformed snapshots throw, so corruption surfaces loudly instead of
+ * silently re-flagging every export.
+ */
+export function readSnapshot(snapshotPath: string): ExportsSnapshot | null {
+  if (!existsSync(snapshotPath)) return null;
+  const raw = readFileSync(snapshotPath, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isSnapshot(parsed)) {
+    throw new Error(`malformed exports snapshot at ${snapshotPath}`);
+  }
+  return parsed;
+}
+
+/**
+ * Write a snapshot atomically (write to sibling tmp file, then rename).
+ * Creates the containing directory if it does not exist.
+ */
+export function writeSnapshotAtomic(snapshotPath: string, snapshot: ExportsSnapshot): void {
+  mkdirSync(dirname(snapshotPath), { recursive: true });
+  const tmp = `${snapshotPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+  renameSync(tmp, snapshotPath);
+}
+
+/**
+ * Compute the rows that are present in `current` but absent from `prior`.
+ * Identity is the (identifier, decl_kind, isTypeOnly) triple — a row that
+ * flips type-only or changes decl kind counts as new.
+ */
+export function diffExports(
+  prior: readonly ExportRow[],
+  current: readonly ExportRow[],
+): ExportRow[] {
+  const priorKeys = new Set(prior.map(rowKey));
+  return current.filter((row) => !priorKeys.has(rowKey(row)));
+}
+
+export function rowKey(row: ExportRow): string {
+  return `${row.identifier} ${row.decl_kind} ${row.isTypeOnly ? 't' : 'v'}`;
+}
+
+function isSnapshot(value: unknown): value is ExportsSnapshot {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<ExportsSnapshot> & { exports?: unknown };
+  return (
+    v.version === 1 &&
+    typeof v.indexPath === 'string' &&
+    typeof v.capturedAt === 'string' &&
+    Array.isArray(v.exports) &&
+    v.exports.every(isExportRow)
+  );
+}
+
+function isExportRow(value: unknown): value is ExportRow {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<ExportRow>;
+  return (
+    typeof v.identifier === 'string' &&
+    typeof v.decl_kind === 'string' &&
+    typeof v.isTypeOnly === 'boolean'
+  );
+}

--- a/packages/adoption-enforcement/src/scan/types.ts
+++ b/packages/adoption-enforcement/src/scan/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Public types for the adoption-enforcement scan subsystem.
+ *
+ * Phase 2 (new-exports detector) — feeds the post-merge adoption scan stage.
+ * Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.
+ */
+
+export type DeclKind =
+  | 'function'
+  | 'class'
+  | 'const'
+  | 'let'
+  | 'var'
+  | 'interface'
+  | 'type'
+  | 'enum'
+  | 'default'
+  | 're-export'
+  | 'namespace-re-export';
+
+export interface ExportRow {
+  /** The exported identifier as seen by consumers (the `baz` in `export { bar as baz }`). */
+  readonly identifier: string;
+  /** Kind of declaration that introduced the export. */
+  readonly decl_kind: DeclKind;
+  /** True if this export carries no runtime value (interface/type/`export type` re-export). */
+  readonly isTypeOnly: boolean;
+}
+
+export interface DetectNewExportsResult {
+  /** Every top-level export found in the index.ts. */
+  readonly exports: readonly ExportRow[];
+  /** Subset of `exports` that did not appear in the prior snapshot (or all, on first run). */
+  readonly newExports: readonly ExportRow[];
+  /** Absolute path to the snapshot file (read and rewritten). */
+  readonly snapshotPath: string;
+  /** True when no snapshot existed before this call — every export is treated as new. */
+  readonly firstRun: boolean;
+}
+
+export interface DetectNewExportsOptions {
+  /**
+   * Override the default snapshot path (`<pkgRoot>/.adoption/exports-snapshot.json`).
+   * Useful for tests.
+   */
+  readonly snapshotPath?: string;
+  /**
+   * When false, skip writing the snapshot back. Defaults to true.
+   * Useful for dry-runs and tests that want to inspect repeatedly.
+   */
+  readonly writeSnapshot?: boolean;
+}
+
+export interface ExportsSnapshot {
+  readonly version: 1;
+  readonly indexPath: string;
+  readonly capturedAt: string;
+  readonly exports: readonly ExportRow[];
+}

--- a/packages/adoption-enforcement/tests/scan/detect-new-exports.test.ts
+++ b/packages/adoption-enforcement/tests/scan/detect-new-exports.test.ts
@@ -1,0 +1,193 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultSnapshotPath,
+  detectNewExports,
+} from '../../src/scan/detect-new-exports.js';
+import { parseExports, parseExportsFromSource } from '../../src/scan/parse-exports.js';
+import { diffExports, rowKey } from '../../src/scan/snapshot.js';
+import type { ExportRow, ExportsSnapshot } from '../../src/scan/types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, 'fixtures', 'exports');
+
+function fixture(name: string): string {
+  return join(FIXTURES, name);
+}
+
+function names(rows: readonly ExportRow[]): string[] {
+  return rows.map((r) => `${r.identifier}:${r.decl_kind}${r.isTypeOnly ? ':T' : ''}`);
+}
+
+describe('scan/parse-exports', () => {
+  it('extracts every declaration kind from a simple fixture', () => {
+    expect(names(parseExports(fixture('simple.ts')))).toEqual([
+      'helloFn:function',
+      'HelloClass:class',
+      'HELLO_CONST:const',
+      'helloLet:let',
+      'helloVar:var',
+      'HelloShape:interface:T',
+      'HelloAlias:type:T',
+      'HelloEnum:enum',
+    ]);
+  });
+
+  it('flags `export default function` as a single "default" row', () => {
+    expect(names(parseExports(fixture('default-fn.ts')))).toEqual(['default:default']);
+  });
+
+  it('flags `export default class` as a single "default" row', () => {
+    expect(names(parseExports(fixture('default-class.ts')))).toEqual(['default:default']);
+  });
+
+  it('flags `export default <expr>` as "default"', () => {
+    expect(names(parseExports(fixture('default-expr.ts')))).toEqual(['default:default']);
+  });
+
+  it('parses a re-export list with rename + per-specifier type-only', () => {
+    expect(parseExports(fixture('re-export-list.ts'))).toEqual([
+      { identifier: 'foo', decl_kind: 're-export', isTypeOnly: false },
+      { identifier: 'baz', decl_kind: 're-export', isTypeOnly: false },
+      { identifier: 'Quux', decl_kind: 're-export', isTypeOnly: true },
+    ]);
+  });
+
+  it('parses a whole-clause type-only re-export (`export type { ... }`)', () => {
+    expect(parseExports(fixture('type-only-clause.ts'))).toEqual([
+      { identifier: 'Alpha', decl_kind: 're-export', isTypeOnly: true },
+      { identifier: 'Gamma', decl_kind: 're-export', isTypeOnly: true },
+    ]);
+  });
+
+  it('does NOT emit rows for export-looking text inside string literals or comments', () => {
+    expect(parseExports(fixture('string-literal-decoys.ts'))).toEqual([
+      { identifier: 'realOne', decl_kind: 'const', isTypeOnly: false },
+    ]);
+  });
+
+  it('emits a namespace-re-export row and skips bare `export * from`', () => {
+    expect(parseExports(fixture('namespace-and-star.ts'))).toEqual([
+      { identifier: 'nsThing', decl_kind: 'namespace-re-export', isTypeOnly: false },
+    ]);
+  });
+
+  it('flattens destructured binding patterns in `export const { a, b }`', () => {
+    expect(names(parseExports(fixture('destructured.ts')))).toEqual([
+      'a:const',
+      'b:const',
+      'first:const',
+      'third:const',
+    ]);
+  });
+
+  it('also parses from raw source (no file I/O)', () => {
+    expect(names(parseExportsFromSource('export const a = 1; export function b() {}'))).toEqual([
+      'a:const',
+      'b:function',
+    ]);
+  });
+});
+
+describe('scan/snapshot helpers', () => {
+  const a: ExportRow = { identifier: 'a', decl_kind: 'const', isTypeOnly: false };
+  const b: ExportRow = { identifier: 'b', decl_kind: 'function', isTypeOnly: false };
+  const bType: ExportRow = { identifier: 'b', decl_kind: 're-export', isTypeOnly: true };
+
+  it('diffs by (identifier, decl_kind, isTypeOnly) triple', () => {
+    expect(diffExports([a], [a, b])).toEqual([b]);
+    expect(diffExports([a, b], [a, b])).toEqual([]);
+    expect(diffExports([b], [b, bType])).toEqual([bType]);
+  });
+
+  it('produces stable row keys', () => {
+    expect(rowKey(a)).toBe('a const v');
+    expect(rowKey(bType)).toBe('b re-export t');
+  });
+});
+
+describe('scan/detect-new-exports', () => {
+  it('rejects relative indexPath', () => {
+    expect(() => detectNewExports('packages/foo/src/index.ts')).toThrow(/must be absolute/);
+  });
+
+  it('treats every export as new on first run and writes a snapshot', () => {
+    const pkg = mkdtempSync(join(tmpdir(), 'detect-new-exports-'));
+    try {
+      const srcDir = join(pkg, 'src');
+      mkdirSync(srcDir, { recursive: true });
+      const indexPath = join(srcDir, 'index.ts');
+      writeFileSync(indexPath, 'export const a = 1;\nexport function b() {}\n');
+
+      const first = detectNewExports(indexPath);
+      expect(first.firstRun).toBe(true);
+      expect(first.exports).toHaveLength(2);
+      expect(first.newExports).toEqual(first.exports);
+      expect(first.snapshotPath).toBe(defaultSnapshotPath(indexPath));
+
+      const persisted = JSON.parse(readFileSync(first.snapshotPath, 'utf8')) as ExportsSnapshot;
+      expect(persisted.version).toBe(1);
+      expect(persisted.exports).toEqual(first.exports);
+      expect(persisted.indexPath).toBe(indexPath);
+
+      // Idempotent second pass.
+      const second = detectNewExports(indexPath);
+      expect(second.firstRun).toBe(false);
+      expect(second.newExports).toEqual([]);
+
+      // Add a new export → only that one is new.
+      writeFileSync(
+        indexPath,
+        'export const a = 1;\nexport function b() {}\nexport class C {}\n',
+      );
+      const third = detectNewExports(indexPath);
+      expect(third.firstRun).toBe(false);
+      expect(third.newExports).toEqual([
+        { identifier: 'C', decl_kind: 'class', isTypeOnly: false },
+      ]);
+    } finally {
+      rmSync(pkg, { recursive: true, force: true });
+    }
+  });
+
+  it('honours a custom snapshot path and writeSnapshot=false', () => {
+    const pkg = mkdtempSync(join(tmpdir(), 'detect-new-exports-'));
+    try {
+      const indexPath = join(pkg, 'index.ts');
+      writeFileSync(indexPath, 'export const z = 1;\n');
+      const snapshotPath = join(pkg, 'custom-snapshot.json');
+
+      const result = detectNewExports(indexPath, { snapshotPath, writeSnapshot: false });
+      expect(result.snapshotPath).toBe(snapshotPath);
+      expect(result.firstRun).toBe(true);
+      expect(existsSync(snapshotPath)).toBe(false);
+    } finally {
+      rmSync(pkg, { recursive: true, force: true });
+    }
+  });
+
+  it('computes the default snapshot path two levels up from the index file', () => {
+    const indexPath = '/repo/packages/foo/src/index.ts';
+    expect(defaultSnapshotPath(indexPath)).toBe(
+      '/repo/packages/foo/.adoption/exports-snapshot.json',
+    );
+  });
+
+  it('throws on a malformed pre-existing snapshot', () => {
+    const pkg = mkdtempSync(join(tmpdir(), 'detect-new-exports-'));
+    try {
+      const indexPath = join(pkg, 'index.ts');
+      writeFileSync(indexPath, 'export const a = 1;\n');
+      const snapshotPath = join(pkg, 'bad-snapshot.json');
+      writeFileSync(snapshotPath, '{ "not": "a valid snapshot" }');
+      expect(() => detectNewExports(indexPath, { snapshotPath })).toThrow(/malformed/);
+    } finally {
+      rmSync(pkg, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/default-class.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/default-class.ts
@@ -1,0 +1,2 @@
+// Fixture: default export of a named class.
+export default class NamedDefault {}

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/default-expr.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/default-expr.ts
@@ -1,0 +1,3 @@
+// Fixture: default export of an expression.
+const value = { kind: 'thing' as const };
+export default value;

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/default-fn.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/default-fn.ts
@@ -1,0 +1,4 @@
+// Fixture: default export of a named function.
+export default function namedDefault(): number {
+  return 42;
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/destructured.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/destructured.ts
@@ -1,0 +1,4 @@
+// Fixture: destructured `export const { a, b } = ...`.
+const src = { a: 1, b: 2, c: 3 };
+export const { a, b } = src;
+export const [first, , third] = [10, 20, 30];

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/donor.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/donor.ts
@@ -1,0 +1,12 @@
+// Donor module imported by fixtures with re-export lists.
+export const foo = 'foo';
+export const bar = 'bar';
+export interface Quux {
+  readonly q: number;
+}
+export interface Alpha {
+  readonly a: number;
+}
+export interface Beta {
+  readonly b: number;
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/namespace-and-star.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/namespace-and-star.ts
@@ -1,0 +1,3 @@
+// Fixture: namespace re-export + bare wildcard re-export.
+export * as nsThing from './donor.js';
+export * from './another-donor.js';

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/re-export-list.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/re-export-list.ts
@@ -1,0 +1,2 @@
+// Fixture: re-export list with rename, plus a per-specifier type-only.
+export { foo, bar as baz, type Quux } from './donor.js';

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/simple.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/simple.ts
@@ -1,0 +1,14 @@
+// Fixture: simple declaration exports.
+export function helloFn(): void {}
+export class HelloClass {}
+export const HELLO_CONST = 1;
+export let helloLet = 2;
+export var helloVar = 3;
+export interface HelloShape {
+  readonly id: string;
+}
+export type HelloAlias = HelloShape['id'];
+export enum HelloEnum {
+  A,
+  B,
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/string-literal-decoys.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/string-literal-decoys.ts
@@ -1,0 +1,10 @@
+// Fixture: comments and string literals that look like exports but are not.
+// export function shouldBeIgnoredFromComment() {}
+/* export class ShouldBeIgnoredFromBlockComment {} */
+
+const decoy1 = 'export function fakeFromString() {}';
+const decoy2 = `export const fakeFromTemplate = 1;`;
+const decoy3 = "export interface FakeFromDoubleQuoted {}";
+
+// The only real export in this fixture:
+export const realOne = decoy1.length + decoy2.length + decoy3.length;

--- a/packages/adoption-enforcement/tests/scan/fixtures/exports/type-only-clause.ts
+++ b/packages/adoption-enforcement/tests/scan/fixtures/exports/type-only-clause.ts
@@ -1,0 +1,2 @@
+// Fixture: whole-clause type-only re-export (`export type { ... }`).
+export type { Alpha, Beta as Gamma } from './donor.js';


### PR DESCRIPTION
## Summary

- Implements `src/scan/detect-new-exports.ts` — phase 2 of the p3-adoption-scan-engine chain.
- Uses the typescript compiler API (`ts.createSourceFile` + node walk) to extract every top-level export from a `packages/*/src/index.ts`. No regex on raw source, so comments and string literals that look like exports are correctly ignored.
- Compares against a snapshot at `packages/<pkg>/.adoption/exports-snapshot.json`; missing snapshot ⇒ all exports treated as new (first-run mode). Snapshot is atomically rewritten via temp-file + rename.
- Wires `scan` into the package root barrel so consumers can reach the detector via `@chiefaia/adoption-enforcement` namespace exports.

Covers all decl kinds requested by the phase brief:

- `export function|class|const|let|var|interface|type|enum X`
- `export default function|class|<expr>` (single `default` row each)
- Local + re-export named-specifier lists, including per-spec `type Foo`
- Whole-clause `export type { Foo } from '...'`
- `export * as ns from '...'` (namespace re-export)
- Destructured `export const { a, b }` / `export const [a, , c]`
- Bare `export * from '...'` is intentionally skipped (no identifier)

## Test plan

- [x] `pnpm --filter @chiefaia/adoption-enforcement typecheck`
- [x] `pnpm --filter @chiefaia/adoption-enforcement test` — 104/104 (+17 new in `tests/scan/`)
- [x] `pnpm --filter @chiefaia/adoption-enforcement build`
- [x] `pnpm --filter @chiefaia/adoption-enforcement lint`
- [x] Fixture coverage: simple, default-fn, default-class, default-expr, re-export list with rename + per-spec type, whole-clause type-only, namespace+star, destructured, string-literal decoys
- [x] Snapshot lifecycle: first-run emits all; second-run with same source emits none; third-run with new export emits only the delta; malformed snapshot raises

## Phase chain

- chain: `p3-adoption-scan-engine`, phase 2 of 5
- design: `agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md`
- next: phase 3 (`detect-new-packages.ts`) composes on `parseExports` (no snapshot) for added `packages/*/package.json` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)