### PR TITLE
feat(adoption-enforcement): new-package detector (scan p3)

### DIFF
--- a/packages/adoption-enforcement/src/scan/detect-new-packages.ts
+++ b/packages/adoption-enforcement/src/scan/detect-new-packages.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+import { detectNewExports } from './detect-new-exports.js';
+import type {
+  DetectNewPackagesOptions,
+  DetectNewPackagesResult,
+  GhPrFile,
+  GhPrFilesResponse,
+  NewExportRow,
+  NewPackageDetail,
+  NewPackageRow,
+  ScanRow,
+} from './types.js';
+
+const DEFAULT_PREFIX = '@chiefaia/';
+const PACKAGE_JSON_PATTERN = /^packages\/([^/]+)\/package\.json$/;
+
+/**
+ * Identify any top-level `packages/<X>/package.json` that the PR *added*
+ * (not modified) whose `name` field begins with the configured prefix
+ * (defaults to `@chiefaia/`).
+ *
+ * For each such package, parse `src/index.ts` via the phase-2 exports
+ * detector. New packages have no prior snapshot on disk, so every export
+ * comes back as "new" — that's the intended semantic.
+ *
+ * Returns flat `ScanRow[]` for downstream emit, plus a `newPackages` array
+ * carrying the per-package detail (handy for tests and richer reports).
+ */
+export function detectNewPackages(
+  pr: number,
+  options: DetectNewPackagesOptions = {},
+): DetectNewPackagesResult {
+  if (!Number.isInteger(pr) || pr <= 0) {
+    throw new Error(`pr must be a positive integer, got ${pr}`);
+  }
+
+  const repoRoot = options.repoRoot ?? process.cwd();
+  if (!isAbsolute(repoRoot)) {
+    throw new Error(`repoRoot must be an absolute path, got ${repoRoot}`);
+  }
+
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  const runGh = options.runGh ?? defaultRunGh;
+
+  const response = runGh(pr);
+  const addedPackageJsons = filterAddedPackageJsons(response.files);
+
+  const newPackages: NewPackageDetail[] = [];
+  const rows: ScanRow[] = [];
+
+  for (const file of addedPackageJsons) {
+    const detail = collectPackageDetail(file, repoRoot, prefix);
+    if (detail === null) continue;
+
+    newPackages.push(detail);
+
+    const packageRow: NewPackageRow = {
+      kind: 'new_package',
+      packagePath: detail.packagePath,
+      name: detail.name,
+    };
+    rows.push(packageRow);
+
+    for (const exportRow of detail.exports) {
+      const row: NewExportRow = {
+        kind: 'new_export',
+        packagePath: detail.packagePath,
+        packageName: detail.name,
+        identifier: exportRow.identifier,
+        decl_kind: exportRow.decl_kind,
+        isTypeOnly: exportRow.isTypeOnly,
+      };
+      rows.push(row);
+    }
+  }
+
+  return { rows, newPackages };
+}
+
+function filterAddedPackageJsons(files: readonly GhPrFile[]): readonly GhPrFile[] {
+  return files.filter(
+    (f) => f.changeType === 'ADDED' && PACKAGE_JSON_PATTERN.test(f.path),
+  );
+}
+
+function collectPackageDetail(
+  file: GhPrFile,
+  repoRoot: string,
+  prefix: string,
+): NewPackageDetail | null {
+  const match = PACKAGE_JSON_PATTERN.exec(file.path);
+  if (match === null) return null;
+
+  const packagePath = `packages/${match[1]}`;
+  const pkgJsonAbs = resolve(repoRoot, file.path);
+  if (!existsSync(pkgJsonAbs)) {
+    // PR is merged; package.json should exist on the working tree. If it
+    // doesn't, the caller is scanning a checkout that doesn't include this
+    // PR's tree — skip silently rather than emitting a half-filled row.
+    return null;
+  }
+
+  const name = readPackageName(pkgJsonAbs);
+  if (name === null || !name.startsWith(prefix)) {
+    return null;
+  }
+
+  const indexAbs = resolve(repoRoot, packagePath, 'src', 'index.ts');
+  if (!existsSync(indexAbs)) {
+    return { packagePath, name, indexPath: null, exports: [] };
+  }
+
+  // New packages have no prior snapshot, so detectNewExports returns every
+  // export as new on first run. We intentionally do NOT write the snapshot
+  // here — that side-effect belongs to the scan-orchestrator (phase 5),
+  // which decides when and whether to persist scan state.
+  const result = detectNewExports(indexAbs, { writeSnapshot: false });
+  return { packagePath, name, indexPath: indexAbs, exports: result.newExports };
+}
+
+function readPackageName(pkgJsonAbs: string): string | null {
+  const raw = readFileSync(pkgJsonAbs, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const name = (parsed as { name?: unknown }).name;
+  return typeof name === 'string' && name.length > 0 ? name : null;
+}
+
+function defaultRunGh(pr: number): GhPrFilesResponse {
+  const out = execFileSync('gh', ['pr', 'view', String(pr), '--json', 'files'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const parsed = JSON.parse(out) as unknown;
+  if (!isGhPrFilesResponse(parsed)) {
+    throw new Error(`gh pr view returned unexpected shape for PR ${pr}: ${out.slice(0, 200)}`);
+  }
+  return parsed;
+}
+
+function isGhPrFilesResponse(value: unknown): value is GhPrFilesResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { files?: unknown };
+  if (!Array.isArray(v.files)) return false;
+  return v.files.every(isGhPrFile);
+}
+
+function isGhPrFile(value: unknown): value is GhPrFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<GhPrFile>;
+  return (
+    typeof v.path === 'string' &&
+    typeof v.changeType === 'string' &&
+    typeof v.additions === 'number' &&
+    typeof v.deletions === 'number'
+  );
+}

--- a/packages/adoption-enforcement/src/scan/index.ts
+++ b/packages/adoption-enforcement/src/scan/index.ts
@@ -1,10 +1,19 @@
 export { detectNewExports, defaultSnapshotPath } from './detect-new-exports.js';
+export { detectNewPackages } from './detect-new-packages.js';
 export { parseExports, parseExportsFromSource } from './parse-exports.js';
 export { diffExports, readSnapshot, writeSnapshotAtomic, rowKey } from './snapshot.js';
 export type {
   DeclKind,
   DetectNewExportsOptions,
   DetectNewExportsResult,
+  DetectNewPackagesOptions,
+  DetectNewPackagesResult,
   ExportRow,
   ExportsSnapshot,
+  GhPrFile,
+  GhPrFilesResponse,
+  NewExportRow,
+  NewPackageDetail,
+  NewPackageRow,
+  ScanRow,
 } from './types.js';

--- a/packages/adoption-enforcement/src/scan/types.ts
+++ b/packages/adoption-enforcement/src/scan/types.ts
@@ -57,3 +57,70 @@ export interface ExportsSnapshot {
   readonly capturedAt: string;
   readonly exports: readonly ExportRow[];
 }
+
+/**
+ * One row in a `gh pr view <pr> --json files` response. Only the fields the
+ * scan layer consumes are typed — extra fields are tolerated.
+ */
+export interface GhPrFile {
+  readonly path: string;
+  readonly additions: number;
+  readonly deletions: number;
+  /** `ADDED` | `MODIFIED` | `RENAMED` | `REMOVED` | `COPIED` — exact set varies by gh version. */
+  readonly changeType: string;
+}
+
+export interface GhPrFilesResponse {
+  readonly files: readonly GhPrFile[];
+}
+
+export interface DetectNewPackagesOptions {
+  /** Repo root the gh paths are relative to. Defaults to `process.cwd()`. */
+  readonly repoRoot?: string;
+  /** Package-name prefix that qualifies a "@chiefaia/" workspace. Defaults to `@chiefaia/`. */
+  readonly prefix?: string;
+  /**
+   * Injection point for tests. When supplied, replaces the real
+   * `gh pr view <pr> --json files` invocation. Receives the PR number,
+   * must return a parsed `GhPrFilesResponse`.
+   */
+  readonly runGh?: (pr: number) => GhPrFilesResponse;
+}
+
+/**
+ * Detector output row tagged for the post-merge `caia-adoption-run scan`
+ * pipeline. Two row kinds share the discriminator `kind`.
+ */
+export type ScanRow = NewPackageRow | NewExportRow;
+
+export interface NewPackageRow {
+  readonly kind: 'new_package';
+  /** Repo-root-relative dir, e.g. `packages/foo`. */
+  readonly packagePath: string;
+  /** `name` field from the added `package.json`. */
+  readonly name: string;
+}
+
+export interface NewExportRow {
+  readonly kind: 'new_export';
+  /** Repo-root-relative dir, e.g. `packages/foo`. */
+  readonly packagePath: string;
+  /** Owning package name (the `name` field from `package.json`). */
+  readonly packageName: string;
+  readonly identifier: string;
+  readonly decl_kind: DeclKind;
+  readonly isTypeOnly: boolean;
+}
+
+export interface NewPackageDetail {
+  readonly packagePath: string;
+  readonly name: string;
+  /** Absolute path to the package's `src/index.ts` — `null` if missing. */
+  readonly indexPath: string | null;
+  readonly exports: readonly ExportRow[];
+}
+
+export interface DetectNewPackagesResult {
+  readonly rows: readonly ScanRow[];
+  readonly newPackages: readonly NewPackageDetail[];
+}

--- a/packages/adoption-enforcement/tests/scan/detect-new-packages.test.ts
+++ b/packages/adoption-enforcement/tests/scan/detect-new-packages.test.ts
@@ -1,0 +1,364 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { detectNewPackages } from '../../src/scan/detect-new-packages.js';
+import type {
+  GhPrFilesResponse,
+  NewExportRow,
+  NewPackageRow,
+  ScanRow,
+} from '../../src/scan/types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, 'fixtures', 'new-packages');
+
+function loadFixture(name: string): GhPrFilesResponse {
+  const raw = readFileSync(join(FIXTURES, name), 'utf8');
+  return JSON.parse(raw) as GhPrFilesResponse;
+}
+
+interface WritePackageOptions {
+  /** Repo-root-relative dir, e.g. `packages/foo`. */
+  readonly packagePath: string;
+  readonly name: string;
+  readonly indexSource?: string;
+}
+
+function writePackage(repoRoot: string, options: WritePackageOptions): void {
+  const pkgDir = join(repoRoot, options.packagePath);
+  const srcDir = join(pkgDir, 'src');
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    `${JSON.stringify({ name: options.name, version: '0.0.0' }, null, 2)}\n`,
+  );
+  if (options.indexSource !== undefined) {
+    writeFileSync(join(srcDir, 'index.ts'), options.indexSource);
+  }
+}
+
+function rowsByKind<K extends ScanRow['kind']>(
+  rows: readonly ScanRow[],
+  kind: K,
+): readonly Extract<ScanRow, { kind: K }>[] {
+  return rows.filter((r): r is Extract<ScanRow, { kind: K }> => r.kind === kind);
+}
+
+describe('scan/detect-new-packages', () => {
+  let repoRoot: string;
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'detect-new-packages-'));
+  });
+
+  afterEach(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('rejects non-positive pr numbers', () => {
+    expect(() => detectNewPackages(0, { repoRoot, runGh: () => ({ files: [] }) })).toThrow(
+      /pr must be a positive integer/,
+    );
+    expect(() => detectNewPackages(-3, { repoRoot, runGh: () => ({ files: [] }) })).toThrow(
+      /pr must be a positive integer/,
+    );
+    expect(() =>
+      detectNewPackages(1.5 as unknown as number, { repoRoot, runGh: () => ({ files: [] }) }),
+    ).toThrow(/pr must be a positive integer/);
+  });
+
+  it('rejects relative repoRoot', () => {
+    expect(() =>
+      detectNewPackages(1, { repoRoot: 'relative/path', runGh: () => ({ files: [] }) }),
+    ).toThrow(/repoRoot must be an absolute path/);
+  });
+
+  it('emits one new_package row plus new_export rows for an added @chiefaia/ package', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/widget',
+      name: '@chiefaia/widget',
+      indexSource: [
+        "export const PI = 3.14;",
+        "export function spin(): void {}",
+        "export type WidgetId = string;",
+        "export default class Widget {}",
+        '',
+      ].join('\n'),
+    });
+
+    const result = detectNewPackages(101, {
+      repoRoot,
+      runGh: () => loadFixture('pr-adds-one.json'),
+    });
+
+    expect(result.newPackages).toHaveLength(1);
+    expect(result.newPackages[0]).toMatchObject({
+      packagePath: 'packages/widget',
+      name: '@chiefaia/widget',
+    });
+    expect(result.newPackages[0]?.indexPath).toBe(
+      resolve(repoRoot, 'packages/widget/src/index.ts'),
+    );
+
+    const pkgRows = rowsByKind(result.rows, 'new_package');
+    const expRows = rowsByKind(result.rows, 'new_export');
+
+    expect(pkgRows).toHaveLength(1);
+    expect(pkgRows[0]).toEqual<NewPackageRow>({
+      kind: 'new_package',
+      packagePath: 'packages/widget',
+      name: '@chiefaia/widget',
+    });
+
+    expect(expRows.map((r) => `${r.identifier}:${r.decl_kind}${r.isTypeOnly ? ':T' : ''}`).sort())
+      .toEqual(['PI:const', 'WidgetId:type:T', 'default:default', 'spin:function'].sort());
+
+    for (const r of expRows) {
+      expect(r.packageName).toBe('@chiefaia/widget');
+      expect(r.packagePath).toBe('packages/widget');
+    }
+  });
+
+  it('handles multiple added @chiefaia/ packages and ignores MODIFIED entries', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/alpha',
+      name: '@chiefaia/alpha',
+      indexSource: 'export const A = 1;\nexport const B = 2;\n',
+    });
+    writePackage(repoRoot, {
+      packagePath: 'packages/beta',
+      name: '@chiefaia/beta',
+      indexSource: 'export function go(): boolean { return true; }\n',
+    });
+    // The "existing" package only has a MODIFIED file in the PR — must be ignored.
+    writePackage(repoRoot, {
+      packagePath: 'packages/existing',
+      name: '@chiefaia/existing',
+      indexSource: 'export const stale = true;\n',
+    });
+
+    const result = detectNewPackages(202, {
+      repoRoot,
+      runGh: () => loadFixture('pr-adds-multiple.json'),
+    });
+
+    const pkgNames = rowsByKind(result.rows, 'new_package').map((r) => r.name).sort();
+    expect(pkgNames).toEqual(['@chiefaia/alpha', '@chiefaia/beta']);
+
+    const alphaExports = rowsByKind(result.rows, 'new_export')
+      .filter((r) => r.packagePath === 'packages/alpha')
+      .map((r) => r.identifier)
+      .sort();
+    expect(alphaExports).toEqual(['A', 'B']);
+
+    const betaExports = rowsByKind(result.rows, 'new_export')
+      .filter((r) => r.packagePath === 'packages/beta')
+      .map((r) => r.identifier);
+    expect(betaExports).toEqual(['go']);
+
+    // Sanity: the existing package contributed nothing.
+    expect(
+      result.rows.some(
+        (r) =>
+          (r.kind === 'new_package' && r.packagePath === 'packages/existing') ||
+          (r.kind === 'new_export' && r.packagePath === 'packages/existing'),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns empty rows when the PR only modifies existing packages', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/existing',
+      name: '@chiefaia/existing',
+      indexSource: 'export const v = 1;\n',
+    });
+
+    const result = detectNewPackages(303, {
+      repoRoot,
+      runGh: () => loadFixture('pr-modifies-only.json'),
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.newPackages).toEqual([]);
+  });
+
+  it('skips added packages whose name does not start with the configured prefix', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/random',
+      name: 'just-random',
+      indexSource: 'export const x = 1;\n',
+    });
+
+    const result = detectNewPackages(404, {
+      repoRoot,
+      runGh: () => loadFixture('pr-non-chiefaia.json'),
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.newPackages).toEqual([]);
+  });
+
+  it('respects a custom prefix', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/random',
+      name: '@example/random',
+      indexSource: 'export const x = 1;\n',
+    });
+
+    const result = detectNewPackages(404, {
+      repoRoot,
+      prefix: '@example/',
+      runGh: () => loadFixture('pr-non-chiefaia.json'),
+    });
+
+    expect(result.newPackages).toHaveLength(1);
+    expect(result.newPackages[0]?.name).toBe('@example/random');
+  });
+
+  it('emits a new_package row with zero exports when src/index.ts is missing', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/scaffold-only',
+      name: '@chiefaia/scaffold-only',
+    });
+
+    const result = detectNewPackages(505, {
+      repoRoot,
+      runGh: () => loadFixture('pr-no-src-index.json'),
+    });
+
+    expect(result.newPackages).toHaveLength(1);
+    expect(result.newPackages[0]).toMatchObject({
+      packagePath: 'packages/scaffold-only',
+      name: '@chiefaia/scaffold-only',
+      indexPath: null,
+    });
+
+    const pkgRows = rowsByKind(result.rows, 'new_package');
+    const expRows = rowsByKind(result.rows, 'new_export');
+    expect(pkgRows).toHaveLength(1);
+    expect(expRows).toHaveLength(0);
+  });
+
+  it('mixed PR: separates chiefaia adds from non-chiefaia, nested, and MODIFIED entries', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/chiefaia-thing',
+      name: '@chiefaia/thing',
+      indexSource: 'export const ok = true;\n',
+    });
+    writePackage(repoRoot, {
+      packagePath: 'packages/external-tool',
+      name: 'external-tool',
+      indexSource: 'export const nope = false;\n',
+    });
+    writePackage(repoRoot, {
+      packagePath: 'packages/already-here',
+      name: '@chiefaia/already-here',
+      indexSource: 'export const here = 1;\n',
+    });
+    // Nested package.json is NOT top-level — must be ignored even if added.
+    mkdirSync(join(repoRoot, 'packages/nested/sub'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, 'packages/nested/sub/package.json'),
+      `${JSON.stringify({ name: '@chiefaia/nested-sub' })}\n`,
+    );
+
+    const result = detectNewPackages(606, {
+      repoRoot,
+      runGh: () => loadFixture('pr-mixed.json'),
+    });
+
+    expect(result.newPackages).toHaveLength(1);
+    expect(result.newPackages[0]?.name).toBe('@chiefaia/thing');
+
+    const pkgRows = rowsByKind(result.rows, 'new_package');
+    expect(pkgRows.map((r) => r.packagePath)).toEqual(['packages/chiefaia-thing']);
+
+    const expRows = rowsByKind(result.rows, 'new_export');
+    expect(expRows).toHaveLength(1);
+    expect(expRows[0]).toEqual<NewExportRow>({
+      kind: 'new_export',
+      packagePath: 'packages/chiefaia-thing',
+      packageName: '@chiefaia/thing',
+      identifier: 'ok',
+      decl_kind: 'const',
+      isTypeOnly: false,
+    });
+  });
+
+  it('skips added package.json paths whose working-tree file is missing (sparse checkout)', () => {
+    // pr-adds-one references packages/widget — we deliberately do NOT write it.
+    const result = detectNewPackages(707, {
+      repoRoot,
+      runGh: () => loadFixture('pr-adds-one.json'),
+    });
+    expect(result.rows).toEqual([]);
+    expect(result.newPackages).toEqual([]);
+  });
+
+  it('emits row order: new_package first, then its new_export rows, per package', () => {
+    writePackage(repoRoot, {
+      packagePath: 'packages/alpha',
+      name: '@chiefaia/alpha',
+      indexSource: 'export const A = 1;\nexport const B = 2;\n',
+    });
+    writePackage(repoRoot, {
+      packagePath: 'packages/beta',
+      name: '@chiefaia/beta',
+      indexSource: 'export function go(): boolean { return true; }\n',
+    });
+
+    const result = detectNewPackages(808, {
+      repoRoot,
+      runGh: () => loadFixture('pr-adds-multiple.json'),
+    });
+
+    // First row must be the new_package for the first added @chiefaia pkg
+    // discovered (alpha — comes before beta in the gh response).
+    expect(result.rows[0]?.kind).toBe('new_package');
+    expect((result.rows[0] as NewPackageRow).packagePath).toBe('packages/alpha');
+
+    // All new_export rows for alpha must follow before beta's new_package row.
+    const betaPkgIdx = result.rows.findIndex(
+      (r) => r.kind === 'new_package' && r.packagePath === 'packages/beta',
+    );
+    for (let i = 1; i < betaPkgIdx; i += 1) {
+      expect(result.rows[i]?.kind).toBe('new_export');
+      expect((result.rows[i] as NewExportRow).packagePath).toBe('packages/alpha');
+    }
+  });
+
+  it('tolerates unknown changeType values without crashing', () => {
+    // gh occasionally emits "RENAMED" or "COPIED". Filter logic must reject
+    // anything that is not exactly "ADDED" rather than throwing.
+    const result = detectNewPackages(909, {
+      repoRoot,
+      runGh: () => ({
+        files: [
+          {
+            path: 'packages/renamed/package.json',
+            additions: 0,
+            deletions: 0,
+            changeType: 'RENAMED',
+          },
+        ],
+      }),
+    });
+    expect(result.rows).toEqual([]);
+  });
+
+  it('rejects empty package.json name field', () => {
+    const pkgDir = join(repoRoot, 'packages/widget');
+    mkdirSync(join(pkgDir, 'src'), { recursive: true });
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: '' }));
+    writeFileSync(join(pkgDir, 'src/index.ts'), 'export const x = 1;\n');
+
+    const result = detectNewPackages(1010, {
+      repoRoot,
+      runGh: () => loadFixture('pr-adds-one.json'),
+    });
+    expect(result.rows).toEqual([]);
+  });
+});

--- a/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-adds-multiple.json
+++ b/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-adds-multiple.json
@@ -1,0 +1,34 @@
+{
+  "files": [
+    {
+      "path": "packages/alpha/package.json",
+      "additions": 12,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/alpha/src/index.ts",
+      "additions": 3,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/beta/package.json",
+      "additions": 12,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/beta/src/index.ts",
+      "additions": 2,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/existing/src/util.ts",
+      "additions": 4,
+      "deletions": 1,
+      "changeType": "MODIFIED"
+    }
+  ]
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-adds-one.json
+++ b/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-adds-one.json
@@ -1,0 +1,22 @@
+{
+  "files": [
+    {
+      "path": "packages/widget/package.json",
+      "additions": 18,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/widget/src/index.ts",
+      "additions": 4,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/widget/tsconfig.json",
+      "additions": 6,
+      "deletions": 0,
+      "changeType": "ADDED"
+    }
+  ]
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-mixed.json
+++ b/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-mixed.json
@@ -1,0 +1,46 @@
+{
+  "files": [
+    {
+      "path": "packages/chiefaia-thing/package.json",
+      "additions": 14,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/chiefaia-thing/src/index.ts",
+      "additions": 3,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/external-tool/package.json",
+      "additions": 9,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/external-tool/src/index.ts",
+      "additions": 1,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/already-here/package.json",
+      "additions": 1,
+      "deletions": 1,
+      "changeType": "MODIFIED"
+    },
+    {
+      "path": "packages/nested/sub/package.json",
+      "additions": 5,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "README.md",
+      "additions": 1,
+      "deletions": 0,
+      "changeType": "MODIFIED"
+    }
+  ]
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-modifies-only.json
+++ b/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-modifies-only.json
@@ -1,0 +1,22 @@
+{
+  "files": [
+    {
+      "path": "packages/existing/package.json",
+      "additions": 2,
+      "deletions": 1,
+      "changeType": "MODIFIED"
+    },
+    {
+      "path": "packages/existing/src/index.ts",
+      "additions": 8,
+      "deletions": 0,
+      "changeType": "MODIFIED"
+    },
+    {
+      "path": "packages/other/src/util.ts",
+      "additions": 1,
+      "deletions": 1,
+      "changeType": "MODIFIED"
+    }
+  ]
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-no-src-index.json
+++ b/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-no-src-index.json
@@ -1,0 +1,16 @@
+{
+  "files": [
+    {
+      "path": "packages/scaffold-only/package.json",
+      "additions": 8,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/scaffold-only/README.md",
+      "additions": 3,
+      "deletions": 0,
+      "changeType": "ADDED"
+    }
+  ]
+}

--- a/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-non-chiefaia.json
+++ b/packages/adoption-enforcement/tests/scan/fixtures/new-packages/pr-non-chiefaia.json
@@ -1,0 +1,16 @@
+{
+  "files": [
+    {
+      "path": "packages/random/package.json",
+      "additions": 10,
+      "deletions": 0,
+      "changeType": "ADDED"
+    },
+    {
+      "path": "packages/random/src/index.ts",
+      "additions": 2,
+      "deletions": 0,
+      "changeType": "ADDED"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `src/scan/detect-new-packages.ts`: walks `gh pr view <pr> --json files`, keeps `packages/<X>/package.json` rows with `changeType === 'ADDED'`, filters to names starting with `@chiefaia/`, and emits one `new_package` row plus one `new_export` row per top-level export in `src/index.ts` (via phase 2's `detectNewExports` with `writeSnapshot: false`).
- `runGh` injection point + sparse-checkout safety + nested-package.json filter make it composable with the phase-5 scan orchestrator.
- 13 new tests (mkdtemp per-test repoRoot, 6 fixture JSON files); package total = 117/117 across 10 files.

Companion phase report: `~/Documents/projects/reports/p3_scan_p3_new_packages_2026-05-16.md`.

Closes phase 3 of `p3-adoption-scan-engine` chain.

## Test plan
- [x] `pnpm --filter @chiefaia/adoption-enforcement build`
- [x] `pnpm --filter @chiefaia/adoption-enforcement typecheck`
- [x] `pnpm --filter @chiefaia/adoption-enforcement test` (117/117)
- [x] `pnpm --filter @chiefaia/adoption-enforcement lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
