### PR TITLE
feat(adoption-enforcement): new-external-agents detector (scan p4)

### DIFF
--- a/packages/adoption-enforcement/package.json
+++ b/packages/adoption-enforcement/package.json
@@ -31,7 +31,9 @@
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
-    "@chiefaia/chain-runner": "workspace:*"
+    "@chiefaia/chain-runner": "workspace:*",
+    "yaml": "^2.4.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@chiefaia/eslint-config": "workspace:*",

--- a/packages/adoption-enforcement/src/scan/detect-new-external-agents.ts
+++ b/packages/adoption-enforcement/src/scan/detect-new-external-agents.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+
+import {
+  diffExternalAgentEntries,
+  readExternalAgentsSnapshot,
+  writeExternalAgentsSnapshotAtomic,
+} from './external-agents-snapshot.js';
+import {
+  externalAgentsFileSchema,
+  type ExternalAgentEntry,
+  type ExternalAgentKind,
+  type ExternalAgentsFile,
+} from './external-agents-schema.js';
+import type {
+  DetectNewExternalAgentsOptions,
+  DetectNewExternalAgentsResult,
+  ExternalAgentsSnapshot,
+  NewExternalAgentRow,
+} from './types.js';
+
+const DEFAULT_CONFIG_REL = '.adoption/external-agents.yaml';
+const DEFAULT_SNAPSHOT_REL = '.adoption/external-agents-snapshot.json';
+
+/**
+ * Detect newly added external-agent integrations declared in
+ * `<repoRoot>/.adoption/external-agents.yaml`.
+ *
+ * Behaviour:
+ *   - Config file missing → no-op (zero rows, `configMissing: true`). Design
+ *     §12 explicitly gates the detector on this file existing.
+ *   - First run (no snapshot) → every entry is treated as new.
+ *   - Subsequent runs → diff by entry `name` within each section; persist a
+ *     fresh snapshot atomically.
+ *   - Malformed YAML or schema-invalid content throws — the substrate refuses
+ *     to silently mis-classify rather than emit garbage downstream.
+ */
+export function detectNewExternalAgents(
+  repoRoot: string,
+  options: DetectNewExternalAgentsOptions = {},
+): DetectNewExternalAgentsResult {
+  if (!isAbsolute(repoRoot)) {
+    throw new Error(`detectNewExternalAgents: repoRoot must be absolute, got ${repoRoot}`);
+  }
+
+  const configPath = options.configPath ?? resolve(repoRoot, DEFAULT_CONFIG_REL);
+  const snapshotPath = options.snapshotPath ?? resolve(repoRoot, DEFAULT_SNAPSHOT_REL);
+
+  if (!existsSync(configPath)) {
+    return {
+      rows: [],
+      configPath,
+      snapshotPath,
+      configMissing: true,
+      firstRun: false,
+    };
+  }
+
+  const parsed = loadConfig(configPath);
+  const prior = readExternalAgentsSnapshot(snapshotPath);
+  const firstRun = prior === null;
+
+  const newMcp = firstRun
+    ? parsed.mcp_servers.slice()
+    : diffExternalAgentEntries(prior.mcp_servers, parsed.mcp_servers);
+  const newManifests = firstRun
+    ? parsed.agent_manifests.slice()
+    : diffExternalAgentEntries(prior.agent_manifests, parsed.agent_manifests);
+
+  const rows: NewExternalAgentRow[] = [
+    ...newMcp.map((e) => toRow('mcp_server', e)),
+    ...newManifests.map((e) => toRow('agent_manifest', e)),
+  ];
+
+  const writeSnapshot = options.writeSnapshot ?? true;
+  if (writeSnapshot) {
+    const snapshot: ExternalAgentsSnapshot = {
+      version: 1,
+      configPath,
+      capturedAt: new Date().toISOString(),
+      mcp_servers: parsed.mcp_servers,
+      agent_manifests: parsed.agent_manifests,
+    };
+    writeExternalAgentsSnapshotAtomic(snapshotPath, snapshot);
+  }
+
+  return { rows, configPath, snapshotPath, configMissing: false, firstRun };
+}
+
+export function defaultExternalAgentsConfigPath(repoRoot: string): string {
+  return resolve(repoRoot, DEFAULT_CONFIG_REL);
+}
+
+export function defaultExternalAgentsSnapshotPath(repoRoot: string): string {
+  return resolve(repoRoot, DEFAULT_SNAPSHOT_REL);
+}
+
+function loadConfig(configPath: string): ExternalAgentsFile {
+  const raw = readFileSync(configPath, 'utf8');
+  let doc: unknown;
+  try {
+    doc = parseYaml(raw);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to parse YAML at ${configPath}: ${reason}`, { cause: err });
+  }
+  if (doc === null || doc === undefined) {
+    // Empty file or all-comments file — treat as a valid v1 doc with no entries.
+    return externalAgentsFileSchema.parse({ version: 1 });
+  }
+  const result = externalAgentsFileSchema.safeParse(doc);
+  if (!result.success) {
+    throw new Error(
+      `invalid external-agents.yaml at ${configPath}: ${result.error.issues
+        .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+        .join('; ')}`,
+    );
+  }
+  return result.data;
+}
+
+function toRow(kind: ExternalAgentKind, entry: ExternalAgentEntry): NewExternalAgentRow {
+  return {
+    kind: 'new_external_agent',
+    agent_kind: kind,
+    name: entry.name,
+    repo: entry.repo,
+    capabilities: entry.capabilities,
+    suggested_call_sites: entry.suggested_call_sites,
+  };
+}

--- a/packages/adoption-enforcement/src/scan/external-agents-schema.ts
+++ b/packages/adoption-enforcement/src/scan/external-agents-schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+const trimmed = (label: string) =>
+  z
+    .string()
+    .min(1, { message: `${label} must be a non-empty string` })
+    .refine((s) => s.trim().length > 0, { message: `${label} must not be blank` });
+
+const externalAgentEntrySchema = z.object({
+  name: trimmed('name'),
+  repo: trimmed('repo'),
+  capabilities: z.array(trimmed('capability')).default([]),
+  suggested_call_sites: z.array(trimmed('suggested_call_site')).default([]),
+});
+
+export const externalAgentsFileSchema = z
+  .object({
+    version: z.literal(1),
+    mcp_servers: z.array(externalAgentEntrySchema).default([]),
+    agent_manifests: z.array(externalAgentEntrySchema).default([]),
+  })
+  .strict();
+
+export type ExternalAgentEntry = z.infer<typeof externalAgentEntrySchema>;
+export type ExternalAgentsFile = z.infer<typeof externalAgentsFileSchema>;
+
+export type ExternalAgentKind = 'mcp_server' | 'agent_manifest';

--- a/packages/adoption-enforcement/src/scan/external-agents-snapshot.ts
+++ b/packages/adoption-enforcement/src/scan/external-agents-snapshot.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { ExternalAgentEntry } from './external-agents-schema.js';
+import type { ExternalAgentsSnapshot } from './types.js';
+
+/**
+ * Read a previously written external-agents snapshot. Returns `null` if the
+ * file is missing — caller treats that as a first-time run (every entry is
+ * new). Malformed snapshots throw so corruption surfaces loudly instead of
+ * silently re-flagging every entry.
+ */
+export function readExternalAgentsSnapshot(snapshotPath: string): ExternalAgentsSnapshot | null {
+  if (!existsSync(snapshotPath)) return null;
+  const raw = readFileSync(snapshotPath, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isSnapshot(parsed)) {
+    throw new Error(`malformed external-agents snapshot at ${snapshotPath}`);
+  }
+  return parsed;
+}
+
+/**
+ * Write a snapshot atomically (sibling tmp then rename). Creates the
+ * containing directory if it does not exist.
+ */
+export function writeExternalAgentsSnapshotAtomic(
+  snapshotPath: string,
+  snapshot: ExternalAgentsSnapshot,
+): void {
+  mkdirSync(dirname(snapshotPath), { recursive: true });
+  const tmp = `${snapshotPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(snapshot, null, 2)}\n`, 'utf8');
+  renameSync(tmp, snapshotPath);
+}
+
+/**
+ * Compute entries present in `current` but absent from `prior`. Identity is
+ * the `name` field — adding/removing capabilities or call-site patterns to an
+ * existing entry does NOT make it new (the substrate re-scans those each run
+ * during cross-ref).
+ */
+export function diffExternalAgentEntries(
+  prior: readonly ExternalAgentEntry[],
+  current: readonly ExternalAgentEntry[],
+): ExternalAgentEntry[] {
+  const priorNames = new Set(prior.map((e) => e.name));
+  return current.filter((entry) => !priorNames.has(entry.name));
+}
+
+function isSnapshot(value: unknown): value is ExternalAgentsSnapshot {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<ExternalAgentsSnapshot>;
+  return (
+    v.version === 1 &&
+    typeof v.configPath === 'string' &&
+    typeof v.capturedAt === 'string' &&
+    Array.isArray(v.mcp_servers) &&
+    Array.isArray(v.agent_manifests) &&
+    v.mcp_servers.every(isEntry) &&
+    v.agent_manifests.every(isEntry)
+  );
+}
+
+function isEntry(value: unknown): value is ExternalAgentEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<ExternalAgentEntry>;
+  return (
+    typeof v.name === 'string' &&
+    typeof v.repo === 'string' &&
+    Array.isArray(v.capabilities) &&
+    v.capabilities.every((c) => typeof c === 'string') &&
+    Array.isArray(v.suggested_call_sites) &&
+    v.suggested_call_sites.every((c) => typeof c === 'string')
+  );
+}

--- a/packages/adoption-enforcement/src/scan/index.ts
+++ b/packages/adoption-enforcement/src/scan/index.ts
@@ -1,18 +1,38 @@
 export { detectNewExports, defaultSnapshotPath } from './detect-new-exports.js';
 export { detectNewPackages } from './detect-new-packages.js';
+export {
+  detectNewExternalAgents,
+  defaultExternalAgentsConfigPath,
+  defaultExternalAgentsSnapshotPath,
+} from './detect-new-external-agents.js';
 export { parseExports, parseExportsFromSource } from './parse-exports.js';
 export { diffExports, readSnapshot, writeSnapshotAtomic, rowKey } from './snapshot.js';
+export {
+  diffExternalAgentEntries,
+  readExternalAgentsSnapshot,
+  writeExternalAgentsSnapshotAtomic,
+} from './external-agents-snapshot.js';
+export { externalAgentsFileSchema } from './external-agents-schema.js';
+export type {
+  ExternalAgentEntry,
+  ExternalAgentKind,
+  ExternalAgentsFile,
+} from './external-agents-schema.js';
 export type {
   DeclKind,
   DetectNewExportsOptions,
   DetectNewExportsResult,
+  DetectNewExternalAgentsOptions,
+  DetectNewExternalAgentsResult,
   DetectNewPackagesOptions,
   DetectNewPackagesResult,
   ExportRow,
   ExportsSnapshot,
+  ExternalAgentsSnapshot,
   GhPrFile,
   GhPrFilesResponse,
   NewExportRow,
+  NewExternalAgentRow,
   NewPackageDetail,
   NewPackageRow,
   ScanRow,

--- a/packages/adoption-enforcement/src/scan/types.ts
+++ b/packages/adoption-enforcement/src/scan/types.ts
@@ -5,6 +5,8 @@
  * Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.
  */
 
+import type { ExternalAgentEntry, ExternalAgentKind } from './external-agents-schema.js';
+
 export type DeclKind =
   | 'function'
   | 'class'
@@ -89,9 +91,9 @@ export interface DetectNewPackagesOptions {
 
 /**
  * Detector output row tagged for the post-merge `caia-adoption-run scan`
- * pipeline. Two row kinds share the discriminator `kind`.
+ * pipeline. Row kinds share the discriminator `kind`.
  */
-export type ScanRow = NewPackageRow | NewExportRow;
+export type ScanRow = NewPackageRow | NewExportRow | NewExternalAgentRow;
 
 export interface NewPackageRow {
   readonly kind: 'new_package';
@@ -123,4 +125,56 @@ export interface NewPackageDetail {
 export interface DetectNewPackagesResult {
   readonly rows: readonly ScanRow[];
   readonly newPackages: readonly NewPackageDetail[];
+}
+
+export interface NewExternalAgentRow {
+  readonly kind: 'new_external_agent';
+  /** Distinguishes the two sections of `external-agents.yaml`. */
+  readonly agent_kind: ExternalAgentKind;
+  readonly name: string;
+  readonly repo: string;
+  readonly capabilities: readonly string[];
+  readonly suggested_call_sites: readonly string[];
+}
+
+export interface ExternalAgentsSnapshot {
+  readonly version: 1;
+  readonly configPath: string;
+  readonly capturedAt: string;
+  readonly mcp_servers: readonly ExternalAgentEntry[];
+  readonly agent_manifests: readonly ExternalAgentEntry[];
+}
+
+export interface DetectNewExternalAgentsOptions {
+  /**
+   * Override the default config path (`<repoRoot>/.adoption/external-agents.yaml`).
+   * Useful for tests.
+   */
+  readonly configPath?: string;
+  /**
+   * Override the default snapshot path
+   * (`<repoRoot>/.adoption/external-agents-snapshot.json`).
+   */
+  readonly snapshotPath?: string;
+  /** When false, skip writing the snapshot back. Defaults to true. */
+  readonly writeSnapshot?: boolean;
+}
+
+export interface DetectNewExternalAgentsResult {
+  /** Detector output rows for the scan pipeline (one per added entry). */
+  readonly rows: readonly NewExternalAgentRow[];
+  /** Absolute path to the config file the detector inspected. */
+  readonly configPath: string;
+  /** Absolute path to the snapshot file (read and rewritten). */
+  readonly snapshotPath: string;
+  /**
+   * True when `external-agents.yaml` is absent. The detector emits zero rows
+   * and is a no-op — see design §12 (priority #4 forward-compat).
+   */
+  readonly configMissing: boolean;
+  /**
+   * True when no snapshot existed before this call (every parsed entry is
+   * treated as new). Only meaningful when `configMissing` is false.
+   */
+  readonly firstRun: boolean;
 }

--- a/packages/adoption-enforcement/tests/scan/detect-new-external-agents.test.ts
+++ b/packages/adoption-enforcement/tests/scan/detect-new-external-agents.test.ts
@@ -1,0 +1,234 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  defaultExternalAgentsConfigPath,
+  defaultExternalAgentsSnapshotPath,
+  detectNewExternalAgents,
+} from '../../src/scan/detect-new-external-agents.js';
+import {
+  diffExternalAgentEntries,
+  readExternalAgentsSnapshot,
+} from '../../src/scan/external-agents-snapshot.js';
+import type {
+  ExternalAgentsSnapshot,
+  NewExternalAgentRow,
+} from '../../src/scan/types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(HERE, 'fixtures', 'external-agents');
+
+function fixturePath(name: string): string {
+  return join(FIXTURES, name);
+}
+
+interface SandboxRepo {
+  readonly repoRoot: string;
+  readonly configPath: string;
+  readonly snapshotPath: string;
+}
+
+function makeSandboxRepo(fixtureName?: string): SandboxRepo {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'ext-agents-detect-'));
+  const configPath = defaultExternalAgentsConfigPath(repoRoot);
+  const snapshotPath = defaultExternalAgentsSnapshotPath(repoRoot);
+  if (fixtureName !== undefined) {
+    mkdirSync(dirname(configPath), { recursive: true });
+    copyFileSync(fixturePath(fixtureName), configPath);
+  }
+  return { repoRoot, configPath, snapshotPath };
+}
+
+const sandboxes: string[] = [];
+
+beforeEach(() => {
+  sandboxes.length = 0;
+});
+
+afterEach(() => {
+  for (const root of sandboxes) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function track(repo: SandboxRepo): SandboxRepo {
+  sandboxes.push(repo.repoRoot);
+  return repo;
+}
+
+function rowNames(rows: readonly NewExternalAgentRow[]): string[] {
+  return rows.map((r) => `${r.agent_kind}:${r.name}`);
+}
+
+describe('scan/detect-new-external-agents', () => {
+  it('is a no-op when external-agents.yaml is missing (priority #4 not landed)', () => {
+    const repo = track(makeSandboxRepo());
+    const result = detectNewExternalAgents(repo.repoRoot);
+    expect(result.configMissing).toBe(true);
+    expect(result.rows).toEqual([]);
+    expect(result.firstRun).toBe(false);
+    expect(existsSync(repo.snapshotPath)).toBe(false);
+  });
+
+  it('treats every entry as new on first run (no prior snapshot) and persists one', () => {
+    const repo = track(makeSandboxRepo('valid.yaml'));
+    const result = detectNewExternalAgents(repo.repoRoot);
+
+    expect(result.configMissing).toBe(false);
+    expect(result.firstRun).toBe(true);
+    expect(rowNames(result.rows)).toEqual([
+      'mcp_server:filesystem-mcp',
+      'mcp_server:sqlite-mcp',
+      'agent_manifest:ext-coder',
+    ]);
+    expect(result.rows.every((r) => r.kind === 'new_external_agent')).toBe(true);
+
+    const fs = result.rows.find((r) => r.name === 'filesystem-mcp');
+    expect(fs?.capabilities).toEqual(['read_file', 'write_file', 'list_dir']);
+    expect(fs?.suggested_call_sites).toEqual([
+      '\\bfs\\.readFile(Sync)?\\b',
+      '\\bfs\\.writeFile(Sync)?\\b',
+    ]);
+    expect(fs?.repo).toBe(
+      'github.com/modelcontextprotocol/servers/tree/main/src/filesystem',
+    );
+
+    const snapshot = readExternalAgentsSnapshot(repo.snapshotPath);
+    expect(snapshot?.version).toBe(1);
+    expect(snapshot?.mcp_servers.map((e) => e.name)).toEqual([
+      'filesystem-mcp',
+      'sqlite-mcp',
+    ]);
+    expect(snapshot?.agent_manifests.map((e) => e.name)).toEqual(['ext-coder']);
+  });
+
+  it('treats an empty (comments-only) file as a valid v1 doc with no entries', () => {
+    const repo = track(makeSandboxRepo('empty.yaml'));
+    const result = detectNewExternalAgents(repo.repoRoot);
+
+    expect(result.configMissing).toBe(false);
+    expect(result.firstRun).toBe(true);
+    expect(result.rows).toEqual([]);
+    expect(existsSync(repo.snapshotPath)).toBe(true);
+
+    const snapshot = readExternalAgentsSnapshot(repo.snapshotPath);
+    expect(snapshot?.mcp_servers).toEqual([]);
+    expect(snapshot?.agent_manifests).toEqual([]);
+  });
+
+  it('emits only the freshly added entries on a follow-up run', () => {
+    const repo = track(makeSandboxRepo('valid.yaml'));
+    detectNewExternalAgents(repo.repoRoot);
+
+    // Swap in the larger fixture in place of the original config.
+    copyFileSync(fixturePath('added-second.yaml'), repo.configPath);
+    const second = detectNewExternalAgents(repo.repoRoot);
+
+    expect(second.firstRun).toBe(false);
+    expect(rowNames(second.rows)).toEqual([
+      'mcp_server:postgres-mcp',
+      'agent_manifest:ext-reviewer',
+    ]);
+  });
+
+  it('emits zero rows when the config is unchanged between runs', () => {
+    const repo = track(makeSandboxRepo('valid.yaml'));
+    detectNewExternalAgents(repo.repoRoot);
+    const second = detectNewExternalAgents(repo.repoRoot);
+
+    expect(second.firstRun).toBe(false);
+    expect(second.rows).toEqual([]);
+  });
+
+  it('does NOT write a snapshot when writeSnapshot is false', () => {
+    const repo = track(makeSandboxRepo('valid.yaml'));
+    const result = detectNewExternalAgents(repo.repoRoot, { writeSnapshot: false });
+    expect(result.rows).toHaveLength(3);
+    expect(existsSync(repo.snapshotPath)).toBe(false);
+  });
+
+  it('throws on malformed YAML, leaving snapshot untouched', () => {
+    const repo = track(makeSandboxRepo('malformed-yaml.yaml'));
+    expect(() => detectNewExternalAgents(repo.repoRoot)).toThrowError(
+      /failed to parse YAML/i,
+    );
+    expect(existsSync(repo.snapshotPath)).toBe(false);
+  });
+
+  it('throws on schema-invalid YAML (missing name / wrong version), leaving snapshot untouched', () => {
+    const repo = track(makeSandboxRepo('schema-invalid.yaml'));
+    expect(() => detectNewExternalAgents(repo.repoRoot)).toThrowError(
+      /invalid external-agents\.yaml/i,
+    );
+    expect(existsSync(repo.snapshotPath)).toBe(false);
+  });
+
+  it('throws on a malformed snapshot file rather than re-flagging every entry', () => {
+    const repo = track(makeSandboxRepo('valid.yaml'));
+    mkdirSync(dirname(repo.snapshotPath), { recursive: true });
+    writeFileSync(repo.snapshotPath, '{ "version": "wrong" }', 'utf8');
+    expect(() => detectNewExternalAgents(repo.repoRoot)).toThrowError(
+      /malformed external-agents snapshot/i,
+    );
+  });
+
+  it('rejects a relative repoRoot', () => {
+    expect(() => detectNewExternalAgents('relative/path')).toThrowError(
+      /must be absolute/i,
+    );
+  });
+
+  it('honours override configPath / snapshotPath when supplied', () => {
+    const repo = track(makeSandboxRepo());
+    const altConfig = join(repo.repoRoot, 'alt', 'agents.yaml');
+    const altSnapshot = join(repo.repoRoot, 'alt', 'snapshot.json');
+    mkdirSync(dirname(altConfig), { recursive: true });
+    copyFileSync(fixturePath('valid.yaml'), altConfig);
+
+    const result = detectNewExternalAgents(repo.repoRoot, {
+      configPath: altConfig,
+      snapshotPath: altSnapshot,
+    });
+    expect(result.configPath).toBe(altConfig);
+    expect(result.snapshotPath).toBe(altSnapshot);
+    expect(result.rows).toHaveLength(3);
+    expect(existsSync(altSnapshot)).toBe(true);
+    expect(existsSync(defaultExternalAgentsSnapshotPath(repo.repoRoot))).toBe(false);
+  });
+
+  it('diffExternalAgentEntries identifies entries by `name`', () => {
+    const prior = [
+      { name: 'a', repo: 'x', capabilities: [], suggested_call_sites: [] },
+      { name: 'b', repo: 'y', capabilities: [], suggested_call_sites: [] },
+    ];
+    const current = [
+      { name: 'a', repo: 'x', capabilities: ['changed'], suggested_call_sites: [] },
+      { name: 'c', repo: 'z', capabilities: [], suggested_call_sites: [] },
+    ];
+    expect(diffExternalAgentEntries(prior, current).map((e) => e.name)).toEqual(['c']);
+  });
+
+  it('preserves the on-disk snapshot shape end-to-end', () => {
+    const repo = track(makeSandboxRepo('valid.yaml'));
+    detectNewExternalAgents(repo.repoRoot);
+    const raw = readFileSync(repo.snapshotPath, 'utf8');
+    const parsed = JSON.parse(raw) as ExternalAgentsSnapshot;
+    expect(parsed.version).toBe(1);
+    expect(parsed.configPath).toBe(repo.configPath);
+    expect(typeof parsed.capturedAt).toBe('string');
+    expect(parsed.mcp_servers).toHaveLength(2);
+    expect(parsed.agent_manifests).toHaveLength(1);
+  });
+});

--- a/packages/adoption-enforcement/tests/scan/fixtures/external-agents/added-second.yaml
+++ b/packages/adoption-enforcement/tests/scan/fixtures/external-agents/added-second.yaml
@@ -1,0 +1,23 @@
+version: 1
+mcp_servers:
+  - name: filesystem-mcp
+    repo: github.com/modelcontextprotocol/servers/tree/main/src/filesystem
+    capabilities: [read_file, write_file, list_dir]
+    suggested_call_sites:
+      - '\bfs\.readFile(Sync)?\b'
+  - name: postgres-mcp
+    repo: github.com/modelcontextprotocol/servers/tree/main/src/postgres
+    capabilities: [query]
+    suggested_call_sites:
+      - '\bpg\.Client\b'
+agent_manifests:
+  - name: ext-coder
+    repo: github.com/paul-gauthier/aider
+    capabilities: [implement_change, review_diff]
+    suggested_call_sites:
+      - '\bworker-coding/implementation-engine\b'
+  - name: ext-reviewer
+    repo: github.com/example/reviewer
+    capabilities: [review_diff]
+    suggested_call_sites:
+      - '\bworker-review\b'

--- a/packages/adoption-enforcement/tests/scan/fixtures/external-agents/empty.yaml
+++ b/packages/adoption-enforcement/tests/scan/fixtures/external-agents/empty.yaml
@@ -1,0 +1,1 @@
+# priority #4 has not landed yet — placeholder file

--- a/packages/adoption-enforcement/tests/scan/fixtures/external-agents/malformed-yaml.yaml
+++ b/packages/adoption-enforcement/tests/scan/fixtures/external-agents/malformed-yaml.yaml
@@ -1,0 +1,5 @@
+version: 1
+mcp_servers:
+  - name: filesystem-mcp
+    repo: [unterminated
+    capabilities: : :

--- a/packages/adoption-enforcement/tests/scan/fixtures/external-agents/schema-invalid.yaml
+++ b/packages/adoption-enforcement/tests/scan/fixtures/external-agents/schema-invalid.yaml
@@ -1,0 +1,4 @@
+version: 2
+mcp_servers:
+  - repo: github.com/some/repo
+    capabilities: [foo]

--- a/packages/adoption-enforcement/tests/scan/fixtures/external-agents/valid.yaml
+++ b/packages/adoption-enforcement/tests/scan/fixtures/external-agents/valid.yaml
@@ -1,0 +1,19 @@
+version: 1
+mcp_servers:
+  - name: filesystem-mcp
+    repo: github.com/modelcontextprotocol/servers/tree/main/src/filesystem
+    capabilities: [read_file, write_file, list_dir]
+    suggested_call_sites:
+      - '\bfs\.readFile(Sync)?\b'
+      - '\bfs\.writeFile(Sync)?\b'
+  - name: sqlite-mcp
+    repo: github.com/modelcontextprotocol/servers/tree/main/src/sqlite
+    capabilities: [query, schema]
+    suggested_call_sites:
+      - '\bbetter-sqlite3\b'
+agent_manifests:
+  - name: ext-coder
+    repo: github.com/paul-gauthier/aider
+    capabilities: [implement_change, review_diff]
+    suggested_call_sites:
+      - '\bworker-coding/implementation-engine\b'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,12 @@ importers:
       '@chiefaia/chain-runner':
         specifier: workspace:*
         version: link:../chain-runner
+      yaml:
+        specifier: ^2.4.1
+        version: 2.8.3
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Implements `src/scan/detect-new-external-agents.ts` — the priority #4 forward-compat detector for the adoption-enforcement substrate.
- Reads `<repo>/.adoption/external-agents.yaml` if present (no-op when absent — design §12), Zod-validates against the §4.c shape, and diffs vs. `<repo>/.adoption/external-agents-snapshot.json`.
- Emits one `new_external_agent` row per added entry under either `mcp_servers:` or `agent_manifests:`, with an `agent_kind` discriminator.

## Why
Closes phase 4 of 5 in `p3-adoption-scan-engine`. With the substrate's three detectors (new exports / new packages / new external agents) all in place, phase 5 can wire `caia-adoption-run scan` into `post-merge-deploy.sh`. When priority #4 (external-agent re-architecture) lands, it just populates `.adoption/external-agents.yaml` — no substrate work needed.

## Shape

### New files
- `src/scan/external-agents-schema.ts` — strict Zod schema, `version: 1`, parallel `mcp_servers[]` + `agent_manifests[]` of `{name, repo, capabilities[], suggested_call_sites[]}`.
- `src/scan/external-agents-snapshot.ts` — atomic snapshot read/write + name-based diff (mirrors phase 2's `snapshot.ts`).
- `src/scan/detect-new-external-agents.ts` — the detector itself. Config missing → no-op. First run → all entries new. Subsequent runs → diff by `name`. Empty / comments-only YAML accepted; malformed YAML, schema-invalid YAML, and malformed snapshots throw rather than silently mis-classify.

### Updated files
- `src/scan/types.ts` — `ScanRow` discriminator gains `new_external_agent` (now `NewPackageRow | NewExportRow | NewExternalAgentRow`); adds `ExternalAgentsSnapshot`, `DetectNewExternalAgentsOptions`, `DetectNewExternalAgentsResult`, `NewExternalAgentRow`.
- `src/scan/index.ts` — re-exports the new detector, snapshot helpers, schema, and types.
- `package.json` — adds `yaml ^2.4.1` and `zod ^3.23.8` (both already in monorepo at these versions).

### Tests + fixtures
- `tests/scan/detect-new-external-agents.test.ts` — 13 vitest cases (missing-file no-op, valid first-run, empty-file, follow-up diff, unchanged config, suppress snapshot write, malformed-yaml throws, schema-invalid throws, malformed-snapshot throws, relative-repoRoot rejection, custom path overrides, on-disk shape, name-identity diff helper).
- `tests/scan/fixtures/external-agents/` — 5 fixtures covering each case.

## Decisions
- **Diff identity = entry `name`.** Capability / call-site churn on an existing entry is not "new"; cross-ref re-evaluates patterns every run.
- **Strict root schema** (`z.object({...}).strict()`). Typo'd top-level keys (`mcp_server:` singular) surface as schema errors instead of being silently dropped.
- **Throw, don't degrade.** Malformed YAML or schema-invalid content fails loud — same trade-off phase 2 made for malformed snapshots.
- **Default writeSnapshot=true.** Phase 5 scan-orchestrator can opt out via `writeSnapshot: false`, matching `detectNewExports`.

## Test plan
- [x] `pnpm --filter @chiefaia/adoption-enforcement build` — clean tsc.
- [x] `pnpm exec vitest run tests/scan/` — 43/43 pass (13 new + 17 phase-2 + 13 phase-3).
- [x] `pnpm exec eslint src/scan` — clean.
- [ ] Pre-existing `tests/caia-adopt-cli.test.ts` failures (12 cases) are out of scope — present on `origin/develop@21d5c95` before this branch and untouched by this PR; flagged for chain-level follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
