### PR TITLE
feat(adoption-enforcement): caia-adoption-run scan CLI + post-merge wire (scan p5)

### DIFF
--- a/packages/adoption-enforcement/bin/caia-adoption-run.mjs
+++ b/packages/adoption-enforcement/bin/caia-adoption-run.mjs
@@ -3,6 +3,7 @@
  * caia-adoption-run — adoption-enforcement substrate runner.
  *
  * Subcommands:
+ *   scan --pr <num>         Detect new artefacts from a merged PR; emit scan.json.
  *   xref --work-dir <dir>   Read scan.json from work-dir, write xref.json beside it.
  *
  * Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.

--- a/packages/adoption-enforcement/src/cli/index.ts
+++ b/packages/adoption-enforcement/src/cli/index.ts
@@ -8,3 +8,15 @@ export {
   type XrefOptions,
   type XrefReport,
 } from './xref.js';
+export {
+  runScan,
+  runScanCli,
+  type ArtefactRow,
+  type GhPrViewResult,
+  type NewExportArtefact,
+  type NewExternalAgentArtefact,
+  type NewPackageArtefact,
+  type RunScanResult,
+  type ScanFile,
+  type ScanOptions,
+} from './scan.js';

--- a/packages/adoption-enforcement/src/cli/run.ts
+++ b/packages/adoption-enforcement/src/cli/run.ts
@@ -1,10 +1,10 @@
 // `caia-adoption-run` — top-level dispatcher.
 //
-// Subcommands are listed below. v1 ships only `xref`; `scan`, `pr`, and
-// `verify` will land in their respective MVP chains.
+// Subcommands are listed below.
 //
 // Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md (§2).
 
+import { runScanCli } from './scan.js';
 import { type CliResult, runXrefCli } from './xref.js';
 
 const TOP_HELP = `caia-adoption-run — adoption-enforcement substrate runner.
@@ -13,6 +13,7 @@ Usage:
   caia-adoption-run <subcommand> [options]
 
 Subcommands:
+  scan     Detect new artefacts from a merged PR; emit scan.json.
   xref     Read scan.json and emit xref.json (L1 cross-reference + scoring).
 
 Run \`caia-adoption-run <subcommand> --help\` for subcommand options.
@@ -24,6 +25,8 @@ export function dispatch(argv: ReadonlyArray<string>): CliResult {
   }
   const [sub, ...rest] = argv;
   switch (sub) {
+    case 'scan':
+      return runScanCli(rest);
     case 'xref':
       return runXrefCli(rest);
     default:

--- a/packages/adoption-enforcement/src/cli/scan.ts
+++ b/packages/adoption-enforcement/src/cli/scan.ts
@@ -1,0 +1,465 @@
+// `caia-adoption-run scan` — read a merged PR, invoke phases 2/3/4 detectors,
+// emit a unified `scan.json` (artefact rows) under
+// `~/.caia/post-merge/work/<sha>/`.
+//
+// Pipeline:
+//   1. New packages (phase 3)  → detectNewPackages(pr)
+//   2. New exports  (phase 2)  → detectNewExports(indexPath) per touched
+//                                 `packages/<X>/src/index.ts`
+//   3. New external agents (phase 4) → detectNewExternalAgents(repoRoot)
+//
+// Output shape (consumed by `caia-adoption-run xref`):
+//   {
+//     version: 1,
+//     sha: "<merge-sha>",
+//     pr: <number>,
+//     generated_at: "<iso>",
+//     artefacts: [ { kind, package, identifier, source_path, ... } ]
+//   }
+//
+// Idempotent: skips if `scan.json` already exists in the work dir, unless
+// `--force` is given.
+//
+// Companion design: agent-memory/decisions/p3_adoption_enforcement_substrate_2026_05_16.md.
+// Companion chain : p3-adoption-scan-engine phase 5.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+
+import {
+  detectNewExports,
+  detectNewExternalAgents,
+  detectNewPackages,
+} from '../scan/index.js';
+import type {
+  GhPrFile,
+  GhPrFilesResponse,
+  NewExportRow,
+  NewExternalAgentRow,
+  NewPackageRow,
+} from '../scan/types.js';
+
+import type { CliResult } from './xref.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ScanOptions {
+  /** PR number (positive integer). */
+  pr: number;
+  /** Merge commit SHA. When omitted, derived via `gh pr view <pr>`. */
+  sha?: string;
+  /** Output directory. Default: `~/.caia/post-merge/work/<sha>/`. */
+  outDir?: string;
+  /** Repository root the gh paths are resolved against. Default `process.cwd()`. */
+  repoRoot?: string;
+  /** Regenerate even if `scan.json` exists. Default false. */
+  force?: boolean;
+  /**
+   * Injection point for tests. Replaces the real `gh pr view <pr> --json files,mergeCommit`
+   * invocation. Receives the PR number, must return the parsed JSON.
+   */
+  runGh?: (pr: number) => GhPrViewResult;
+}
+
+/** Subset of `gh pr view --json files,mergeCommit` we consume. */
+export interface GhPrViewResult {
+  readonly files: readonly GhPrFile[];
+  readonly mergeCommit?: { oid?: string | null } | null;
+}
+
+export type ArtefactRow =
+  | NewExportArtefact
+  | NewPackageArtefact
+  | NewExternalAgentArtefact;
+
+export interface NewExportArtefact {
+  readonly kind: 'new_export';
+  readonly package: string;
+  readonly identifier: string;
+  readonly source_path: string;
+  readonly decl_kind: NewExportRow['decl_kind'];
+  readonly isTypeOnly: boolean;
+}
+
+export interface NewPackageArtefact {
+  readonly kind: 'new_package';
+  readonly package: string;
+  readonly identifier: string;
+  readonly source_path: string;
+}
+
+export interface NewExternalAgentArtefact {
+  readonly kind: 'new_external_agent';
+  readonly package: string;
+  readonly identifier: string;
+  readonly source_path: string;
+  readonly agent_kind: NewExternalAgentRow['agent_kind'];
+  readonly repo: string;
+  readonly capabilities: readonly string[];
+  readonly suggested_call_sites: readonly string[];
+}
+
+export interface ScanFile {
+  readonly version: 1;
+  readonly sha: string;
+  readonly pr: number;
+  readonly generated_at: string;
+  readonly artefacts: readonly ArtefactRow[];
+  readonly summary: {
+    readonly artefact_count: number;
+    readonly new_package_count: number;
+    readonly new_export_count: number;
+    readonly new_external_agent_count: number;
+  };
+}
+
+export interface RunScanResult {
+  readonly outPath: string;
+  /** True when scan.json was newly written; false when skipped (idempotent). */
+  readonly written: boolean;
+  readonly scan: ScanFile;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const PACKAGE_INDEX_PATTERN = /^packages\/([^/]+)\/src\/index\.ts$/;
+const PACKAGE_JSON_PATTERN = /^packages\/([^/]+)\/package\.json$/;
+
+export function runScan(opts: ScanOptions): RunScanResult {
+  if (!Number.isInteger(opts.pr) || opts.pr <= 0) {
+    throw new Error(`scan: --pr must be a positive integer, got ${opts.pr}`);
+  }
+  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const runGh = opts.runGh ?? defaultRunGh;
+
+  const ghResult = runGh(opts.pr);
+  const sha = opts.sha ?? ghResult.mergeCommit?.oid ?? null;
+  if (!sha || typeof sha !== 'string') {
+    throw new Error(
+      `scan: could not resolve merge sha (pass --sha or merge the PR first)`,
+    );
+  }
+
+  const outDir = path.resolve(opts.outDir ?? defaultOutDir(sha));
+  mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'scan.json');
+
+  if (!opts.force && existsSync(outPath)) {
+    const existing = JSON.parse(readFileSync(outPath, 'utf8')) as ScanFile;
+    return { outPath, written: false, scan: existing };
+  }
+
+  const artefacts: ArtefactRow[] = [];
+
+  // ---- phase 3 — new packages (also covers their `new_export` rows). ----
+  const packagesResult = detectNewPackages(opts.pr, {
+    repoRoot,
+    runGh: () => ({ files: ghResult.files }),
+  });
+
+  // Tracks `packages/<X>` we already covered via the new-packages branch so
+  // we don't double-emit when phase 2 would otherwise re-walk the same index.
+  const coveredPackagePaths = new Set<string>();
+
+  for (const row of packagesResult.rows) {
+    if (row.kind === 'new_package') {
+      coveredPackagePaths.add(row.packagePath);
+      artefacts.push(toPackageArtefact(row));
+    } else if (row.kind === 'new_export') {
+      artefacts.push(toExportArtefact(row));
+    }
+  }
+
+  // ---- phase 2 — new exports for *modified* (not added) packages. ----
+  const modifiedIndexFiles = ghResult.files.filter(
+    (f) =>
+      f.changeType !== 'ADDED' &&
+      f.changeType !== 'REMOVED' &&
+      PACKAGE_INDEX_PATTERN.test(f.path),
+  );
+
+  for (const file of modifiedIndexFiles) {
+    const m = PACKAGE_INDEX_PATTERN.exec(file.path);
+    if (m === null) continue;
+    const packagePath = `packages/${m[1]}`;
+    if (coveredPackagePaths.has(packagePath)) continue;
+
+    const indexAbs = path.resolve(repoRoot, file.path);
+    if (!existsSync(indexAbs)) continue;
+
+    const pkgJsonAbs = path.resolve(repoRoot, packagePath, 'package.json');
+    if (!existsSync(pkgJsonAbs)) continue;
+    const packageName = readPackageName(pkgJsonAbs);
+    if (packageName === null) continue;
+
+    // Phase-2 detector compares against the per-package snapshot, then
+    // rewrites the snapshot atomically. First scan of a package treats every
+    // export as new — by design.
+    const result = detectNewExports(indexAbs);
+    for (const exportRow of result.newExports) {
+      artefacts.push({
+        kind: 'new_export',
+        package: packageName,
+        identifier: exportRow.identifier,
+        source_path: `${packagePath}/src/index.ts`,
+        decl_kind: exportRow.decl_kind,
+        isTypeOnly: exportRow.isTypeOnly,
+      });
+    }
+  }
+
+  // ---- phase 4 — new external agents (whole-repo). ----
+  // Only fires when `.adoption/external-agents.yaml` was touched in the PR;
+  // otherwise the snapshot is up-to-date and the detector still no-ops, but
+  // we skip the call to avoid writing a snapshot on every scan.
+  const externalAgentsTouched = ghResult.files.some(
+    (f) =>
+      f.path === '.adoption/external-agents.yaml' ||
+      f.path.endsWith('/.adoption/external-agents.yaml'),
+  );
+  if (externalAgentsTouched) {
+    const externalResult = detectNewExternalAgents(repoRoot);
+    if (!externalResult.configMissing) {
+      const sourcePath = path.relative(repoRoot, externalResult.configPath);
+      for (const row of externalResult.rows) {
+        artefacts.push({
+          kind: 'new_external_agent',
+          package: row.name,
+          identifier: row.name,
+          source_path: sourcePath,
+          agent_kind: row.agent_kind,
+          repo: row.repo,
+          capabilities: row.capabilities,
+          suggested_call_sites: row.suggested_call_sites,
+        });
+      }
+    }
+  }
+
+  const summary = summarize(artefacts);
+  const scan: ScanFile = {
+    version: 1,
+    sha,
+    pr: opts.pr,
+    generated_at: new Date().toISOString(),
+    artefacts,
+    summary,
+  };
+
+  writeFileSync(outPath, `${JSON.stringify(scan, null, 2)}\n`, 'utf8');
+  return { outPath, written: true, scan };
+}
+
+function toPackageArtefact(row: NewPackageRow): NewPackageArtefact {
+  return {
+    kind: 'new_package',
+    package: row.name,
+    identifier: row.name,
+    source_path: `${row.packagePath}/package.json`,
+  };
+}
+
+function toExportArtefact(row: NewExportRow): NewExportArtefact {
+  return {
+    kind: 'new_export',
+    package: row.packageName,
+    identifier: row.identifier,
+    source_path: `${row.packagePath}/src/index.ts`,
+    decl_kind: row.decl_kind,
+    isTypeOnly: row.isTypeOnly,
+  };
+}
+
+function summarize(artefacts: readonly ArtefactRow[]): ScanFile['summary'] {
+  let pkg = 0;
+  let exp = 0;
+  let ext = 0;
+  for (const a of artefacts) {
+    if (a.kind === 'new_package') pkg += 1;
+    else if (a.kind === 'new_export') exp += 1;
+    else if (a.kind === 'new_external_agent') ext += 1;
+  }
+  return {
+    artefact_count: artefacts.length,
+    new_package_count: pkg,
+    new_export_count: exp,
+    new_external_agent_count: ext,
+  };
+}
+
+function defaultOutDir(sha: string): string {
+  return path.join(homedir(), '.caia', 'post-merge', 'work', sha);
+}
+
+function readPackageName(pkgJsonAbs: string): string | null {
+  try {
+    const raw = readFileSync(pkgJsonAbs, 'utf8');
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === 'string' && parsed.name.length > 0 ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultRunGh(pr: number): GhPrViewResult {
+  const out = execFileSync(
+    'gh',
+    ['pr', 'view', String(pr), '--json', 'files,mergeCommit'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const parsed = JSON.parse(out) as unknown;
+  if (!isGhPrViewResult(parsed)) {
+    throw new Error(
+      `gh pr view returned unexpected shape for PR ${pr}: ${out.slice(0, 200)}`,
+    );
+  }
+  return parsed;
+}
+
+function isGhPrViewResult(value: unknown): value is GhPrViewResult {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { files?: unknown };
+  if (!Array.isArray(v.files)) return false;
+  if (!v.files.every(isGhPrFile)) return false;
+  return true;
+}
+
+function isGhPrFile(value: unknown): value is GhPrFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<GhPrFile>;
+  return (
+    typeof v.path === 'string' &&
+    typeof v.changeType === 'string' &&
+    typeof v.additions === 'number' &&
+    typeof v.deletions === 'number'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI plumbing
+// ---------------------------------------------------------------------------
+
+const HELP = `caia-adoption-run scan — detect new artefacts from a merged PR.
+
+Usage:
+  caia-adoption-run scan --pr <num> [options]
+
+Required:
+  --pr <num>                PR number to scan.
+
+Options:
+  --sha <sha>               Merge commit SHA. Default: looked up via \`gh pr view\`.
+  --out <dir>               Output directory. Default: ~/.caia/post-merge/work/<sha>/.
+  --repo <dir>              Repository root the gh paths resolve against. Default: cwd.
+  --force                   Regenerate scan.json even if it already exists.
+  -h, --help                Show this help.
+
+Output: <out>/scan.json — { version, sha, pr, generated_at, artefacts[], summary }.
+Idempotent: re-running with an existing scan.json is a no-op unless --force.
+`;
+
+interface ParsedScanArgs {
+  help: boolean;
+  pr: number | null;
+  sha: string | null;
+  outDir: string | null;
+  repoRoot: string | null;
+  force: boolean;
+  error: string | null;
+}
+
+function parseScanArgs(argv: ReadonlyArray<string>): ParsedScanArgs {
+  const out: ParsedScanArgs = {
+    help: false,
+    pr: null,
+    sha: null,
+    outDir: null,
+    repoRoot: null,
+    force: false,
+    error: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '-h':
+      case '--help':
+        out.help = true;
+        return out;
+      case '--pr': {
+        if (next === undefined) { out.error = '--pr requires a value'; return out; }
+        const n = Number.parseInt(next, 10);
+        if (!Number.isFinite(n) || n <= 0) {
+          out.error = `--pr: invalid number "${next}"`;
+          return out;
+        }
+        out.pr = n;
+        i += 1;
+        break;
+      }
+      case '--sha':
+        if (next === undefined) { out.error = '--sha requires a value'; return out; }
+        out.sha = next;
+        i += 1;
+        break;
+      case '--out':
+        if (next === undefined) { out.error = '--out requires a value'; return out; }
+        out.outDir = next;
+        i += 1;
+        break;
+      case '--repo':
+        if (next === undefined) { out.error = '--repo requires a value'; return out; }
+        out.repoRoot = next;
+        i += 1;
+        break;
+      case '--force':
+        out.force = true;
+        break;
+      default:
+        out.error = `unknown arg: ${arg}`;
+        return out;
+    }
+  }
+  return out;
+}
+
+export function runScanCli(argv: ReadonlyArray<string>): CliResult {
+  const args = parseScanArgs(argv);
+  if (args.help) {
+    return { exitCode: 0, stdout: HELP, stderr: '' };
+  }
+  if (args.error) {
+    return { exitCode: 2, stdout: '', stderr: `${args.error}\n\n${HELP}` };
+  }
+  if (args.pr === null) {
+    return { exitCode: 2, stdout: '', stderr: `--pr is required\n\n${HELP}` };
+  }
+
+  try {
+    const opts: ScanOptions = {
+      pr: args.pr,
+      force: args.force,
+      ...(args.sha ? { sha: args.sha } : {}),
+      ...(args.outDir ? { outDir: args.outDir } : {}),
+      ...(args.repoRoot ? { repoRoot: args.repoRoot } : {}),
+    };
+    const result = runScan(opts);
+    const action = result.written ? 'wrote' : 'skipped (already present)';
+    const { artefact_count, new_package_count, new_export_count, new_external_agent_count } =
+      result.scan.summary;
+    const stdout =
+      `scan: ${action} ${result.outPath}\n` +
+      `  artefacts=${artefact_count} new_packages=${new_package_count} ` +
+      `new_exports=${new_export_count} new_external_agents=${new_external_agent_count}\n`;
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { exitCode: 1, stdout: '', stderr: `scan: ${msg}\n` };
+  }
+}

--- a/packages/adoption-enforcement/tests/cli/scan.test.ts
+++ b/packages/adoption-enforcement/tests/cli/scan.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runScan, runScanCli, type GhPrViewResult, type ScanFile } from '../../src/cli/scan.js';
+
+let root: string;
+let repoRoot: string;
+let outDir: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'caia-scan-cli-'));
+  repoRoot = join(root, 'repo');
+  outDir = join(root, 'out');
+  mkdirSync(repoRoot, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+function writePackage(name: string, indexBody: string): string {
+  const pkgDir = join(repoRoot, 'packages', name);
+  mkdirSync(join(pkgDir, 'src'), { recursive: true });
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: `@chiefaia/${name}` }, null, 2));
+  writeFileSync(join(pkgDir, 'src', 'index.ts'), indexBody);
+  return pkgDir;
+}
+
+describe('runScan — happy paths', () => {
+  it('emits new_package + new_export rows for an added @chiefaia/<x> package', () => {
+    writePackage('alpha', `export const alpha = () => 'a';\nexport function helperAlpha(): number { return 1; }\n`);
+
+    const gh: GhPrViewResult = {
+      files: [
+        { path: 'packages/alpha/package.json', changeType: 'ADDED', additions: 5, deletions: 0 },
+        { path: 'packages/alpha/src/index.ts', changeType: 'ADDED', additions: 8, deletions: 0 },
+      ],
+      mergeCommit: { oid: 'sha-alpha' },
+    };
+
+    const res = runScan({
+      pr: 100,
+      repoRoot,
+      outDir,
+      runGh: () => gh,
+    });
+
+    expect(res.written).toBe(true);
+    expect(existsSync(res.outPath)).toBe(true);
+
+    const onDisk = JSON.parse(readFileSync(res.outPath, 'utf8')) as ScanFile;
+    expect(onDisk.sha).toBe('sha-alpha');
+    expect(onDisk.pr).toBe(100);
+    expect(onDisk.version).toBe(1);
+
+    const kinds = onDisk.artefacts.map((a) => a.kind).sort();
+    expect(kinds).toEqual(['new_export', 'new_export', 'new_package']);
+
+    const pkgArt = onDisk.artefacts.find((a) => a.kind === 'new_package')!;
+    expect(pkgArt.package).toBe('@chiefaia/alpha');
+    expect(pkgArt.source_path).toBe('packages/alpha/package.json');
+
+    const exportArts = onDisk.artefacts.filter((a) => a.kind === 'new_export');
+    for (const a of exportArts) {
+      expect(a.package).toBe('@chiefaia/alpha');
+      expect(a.source_path).toBe('packages/alpha/src/index.ts');
+    }
+    expect(onDisk.summary).toEqual({
+      artefact_count: 3,
+      new_package_count: 1,
+      new_export_count: 2,
+      new_external_agent_count: 0,
+    });
+  });
+
+  it('emits zero rows for a docs-only PR', () => {
+    const gh: GhPrViewResult = {
+      files: [
+        { path: 'docs/foo.md', changeType: 'MODIFIED', additions: 3, deletions: 1 },
+        { path: 'reports/bar.md', changeType: 'ADDED', additions: 50, deletions: 0 },
+      ],
+      mergeCommit: { oid: 'sha-docs' },
+    };
+
+    const res = runScan({
+      pr: 492,
+      repoRoot,
+      outDir,
+      runGh: () => gh,
+    });
+
+    expect(res.written).toBe(true);
+    expect(res.scan.artefacts).toHaveLength(0);
+    expect(res.scan.summary.artefact_count).toBe(0);
+    expect(res.scan.sha).toBe('sha-docs');
+  });
+
+  it('emits new_export rows when an *existing* package index.ts is modified (no double-emit for added pkgs)', () => {
+    writePackage('beta', `export function brandNewBeta(): string { return 'b'; }\n`);
+
+    const gh: GhPrViewResult = {
+      files: [
+        { path: 'packages/beta/src/index.ts', changeType: 'MODIFIED', additions: 2, deletions: 0 },
+      ],
+      mergeCommit: { oid: 'sha-mod' },
+    };
+
+    const res = runScan({ pr: 101, repoRoot, outDir, runGh: () => gh });
+
+    expect(res.scan.artefacts).toHaveLength(1);
+    const row = res.scan.artefacts[0];
+    expect(row.kind).toBe('new_export');
+    expect(row.identifier).toBe('brandNewBeta');
+    expect(row.package).toBe('@chiefaia/beta');
+
+    // Snapshot now written — a second scan should treat zero exports as new.
+    const second = runScan({
+      pr: 102,
+      sha: 'sha-mod-2',
+      repoRoot,
+      outDir: join(root, 'out2'),
+      runGh: () => ({ ...gh, mergeCommit: { oid: 'sha-mod-2' } }),
+    });
+    expect(second.scan.artefacts).toHaveLength(0);
+  });
+});
+
+describe('runScan — idempotency', () => {
+  it('skips write when scan.json already exists; --force rewrites', () => {
+    const gh: GhPrViewResult = {
+      files: [{ path: 'docs/x.md', changeType: 'MODIFIED', additions: 1, deletions: 0 }],
+      mergeCommit: { oid: 'sha-id' },
+    };
+
+    const first = runScan({ pr: 200, repoRoot, outDir, runGh: () => gh });
+    expect(first.written).toBe(true);
+
+    const second = runScan({ pr: 200, repoRoot, outDir, runGh: () => gh });
+    expect(second.written).toBe(false);
+    expect(second.outPath).toBe(first.outPath);
+
+    const forced = runScan({ pr: 200, repoRoot, outDir, runGh: () => gh, force: true });
+    expect(forced.written).toBe(true);
+  });
+});
+
+describe('runScan — error paths', () => {
+  it('throws when --pr is non-positive', () => {
+    expect(() =>
+      runScan({ pr: 0, repoRoot, outDir, sha: 'x', runGh: () => ({ files: [] }) }),
+    ).toThrow(/positive integer/);
+  });
+
+  it('throws when no sha can be resolved', () => {
+    expect(() =>
+      runScan({
+        pr: 1,
+        repoRoot,
+        outDir,
+        runGh: () => ({ files: [], mergeCommit: null }),
+      }),
+    ).toThrow(/merge sha/);
+  });
+});
+
+describe('runScanCli — argument parsing', () => {
+  it('exits 0 on --help', () => {
+    const r = runScanCli(['--help']);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('caia-adoption-run scan');
+  });
+
+  it('exits 2 when --pr is missing', () => {
+    const r = runScanCli([]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('--pr is required');
+  });
+
+  it('exits 2 on an unknown arg', () => {
+    const r = runScanCli(['--pr', '5', '--bogus']);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('unknown arg: --bogus');
+  });
+
+  it('exits 2 when --pr is not a positive integer', () => {
+    const r = runScanCli(['--pr', '-3']);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('invalid number');
+  });
+});

--- a/scripts/post-merge/README.md
+++ b/scripts/post-merge/README.md
@@ -45,6 +45,97 @@ for institutionalized deploy tags (e.g. `ROUTER-DAEMON-RELOAD-REQUIRED`)
 without an extra `gh pr view` round-trip. v1 rows still parse — body
 just resolves to empty.
 
+## Adoption scan stage
+
+After the per-repo deploy hook fires for `prakashgbid/caia`, the deploy
+script also runs the **adoption-enforcement substrate** for the merge:
+
+```
+~/.caia/post-merge/post-merge-deploy.sh <row>
+    │
+    ├── (existing) router-daemon kickstart, if title/body matches
+    │
+    ├── dispatch_adoption_scan         ← p3-adoption-scan-engine phase 5
+    │     │   30 s budget, runs in background, idempotent.
+    │     │   Writes scan.json + scan.log under ~/.caia/post-merge/work/<sha>/.
+    │     │   On success, chains directly into the xref step (60 s budget)
+    │     │   so a single merge produces both scan.json and xref.json.
+    │     │
+    │     ▼
+    │   caia-adoption-run scan --pr <num> --sha <sha> \
+    │       --out ~/.caia/post-merge/work/<sha>/ \
+    │       --repo $CAIA_REPO_ROOT
+    │
+    └── dispatch_adoption_xref         ← p3-adoption-cross-ref phase 4
+          fallback path — only runs xref when scan.json was dropped
+          out-of-band (i.e. the chained xref above did not produce it).
+```
+
+`scan.json` is a small JSON document the substrate uses as its
+canonical "what's new in this merge" surface:
+
+```json
+{
+  "version": 1,
+  "sha": "5c077f4...",
+  "pr": 451,
+  "generated_at": "2026-05-17T16:50:00Z",
+  "summary": {
+    "artefact_count": 3,
+    "new_package_count": 1,
+    "new_export_count": 2,
+    "new_external_agent_count": 0
+  },
+  "artefacts": [
+    { "kind": "new_package",  "package": "@chiefaia/foo", "identifier": "@chiefaia/foo", "source_path": "packages/foo/package.json" },
+    { "kind": "new_export",   "package": "@chiefaia/foo", "identifier": "frobnicate",    "source_path": "packages/foo/src/index.ts", "decl_kind": "function", "isTypeOnly": false },
+    { "kind": "new_export",   "package": "@chiefaia/foo", "identifier": "FooConfig",     "source_path": "packages/foo/src/index.ts", "decl_kind": "interface", "isTypeOnly": true }
+  ]
+}
+```
+
+The detectors that produce these rows live in
+`packages/adoption-enforcement/src/scan/` and are stitched together by
+`src/cli/scan.ts`:
+
+| Row kind              | Detector                                  | Triggers when                                                  |
+|-----------------------|-------------------------------------------|----------------------------------------------------------------|
+| `new_package`         | `detectNewPackages(pr)`                   | PR adds `packages/<X>/package.json` with name `@chiefaia/*`.   |
+| `new_export`          | `detectNewExports(indexPath)`             | PR modifies an existing `packages/<X>/src/index.ts`, OR a new package is added (every export is then "new" by definition). |
+| `new_external_agent`  | `detectNewExternalAgents(repoRoot)`       | PR touches `<repo>/.adoption/external-agents.yaml`.            |
+
+**Idempotency.** `dispatch_adoption_scan` short-circuits when
+`scan.json` already exists in the per-sha work dir. Same for the
+chained xref step (`xref.json`). Re-runs against the same merge_sha
+are safe and cheap.
+
+**Docs-only PRs are a no-op.** A merge that doesn't touch any
+`packages/<X>/src/index.ts`, doesn't add any `packages/<X>/package.json`,
+and doesn't touch `.adoption/external-agents.yaml` produces a
+`scan.json` with `summary.artefact_count = 0` and no downstream rows
+reach the cross-reference or PR-generator stages. Hand-tested against
+PR #492 (the DoD-v2 addendum, docs-only) to confirm this behaviour.
+
+**Ledger.** Each background run appends one row to
+`~/.caia/post-merge/adoption.jsonl`:
+
+```
+{"ts":"...","event":"scan_done","sha":"...","artefact_count":3}
+{"ts":"...","event":"xref_done","sha":"...","artefact_count":3,"candidate_count":12}
+```
+
+(or `scan_failed` / `xref_failed` with `rc` on failure.) This is the
+minimum-viable surface that the future DoD-v2 adoption gate's reader
+will consume.
+
+**Environment overrides.**
+
+| Variable          | Default                                        | Used by                  |
+|-------------------|------------------------------------------------|--------------------------|
+| `CAIA_REPO_ROOT`  | `$HOME/Documents/projects/caia`                | scan + xref `--repo`     |
+| `NODE_BIN`        | `/opt/homebrew/opt/node@22/bin/node`           | runs `caia-adoption-run` |
+| `POSTMERGE_HOME`  | `$HOME/.caia/post-merge`                       | work-dir root + ledger   |
+
 ## Institutionalized deploy tags
 
 | Tag | Effect |

--- a/scripts/post-merge/post-merge-deploy.sh
+++ b/scripts/post-merge/post-merge-deploy.sh
@@ -10,11 +10,17 @@
 #                        router LaunchAgent so the new binary is loaded.
 #                        (Closes the "stale binary" gap from 2026-05-15
 #                        — see reports/integration_a1_post_merge_signal_2026-05-15.md.)
-#                        Then fires `dispatch_adoption_xref`, which runs
-#                        `caia-adoption-run xref` in the background if
-#                        scan.json exists in ~/.caia/post-merge/work/<sha>/
-#                        and xref.json doesn't (p3-adoption-cross-ref
-#                        phase 4 — Adoption Enforcement Substrate MVP-A).
+#                        Then fires `dispatch_adoption_scan` (p3-adoption-
+#                        scan-engine phase 5), which runs `caia-adoption-run
+#                        scan --pr <num>` in the background, writes
+#                        scan.json into ~/.caia/post-merge/work/<sha>/, and
+#                        chains directly into `caia-adoption-run xref` so a
+#                        single merge produces both scan.json and xref.json.
+#                        A separate `dispatch_adoption_xref` follow-up call
+#                        is a no-op when the scan-chain already produced
+#                        xref.json — it only fires when scan.json was
+#                        produced out-of-band (e.g. a manual scan dropped a
+#                        file but xref hasn't been run yet).
 #   - prakashgbid/stolution : stub (extend with K3s rollout / ssh deploy).
 #
 # Operator extension point: add a new `case "$repo" in` branch, or add
@@ -92,11 +98,96 @@ kickstart_daemon() {
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$label" "$rc" "${before_pid:-none}" "${after_pid:-none}" "$pr" "$repo"
 }
 
+# Adoption-enforcement scan stage. Runs `caia-adoption-run scan --pr <num>`
+# against the merge in the background, hard-capped at 30 s. Idempotent —
+# skips when scan.json is already present in the per-sha work dir. On a
+# successful scan, immediately chains into `caia-adoption-run xref` so a
+# single merge produces both scan.json and xref.json (no second-merge
+# round-trip required). Both legs share a 30 + 60 = 90 s outer budget.
+#
+# Ledger appends:
+#   {ts, event:"scan_done",   sha, artefact_count}
+#   {ts, event:"scan_failed", sha, rc}
+# xref ledger appends are emitted by the chained xref step (matching the
+# `dispatch_adoption_xref` semantics).
+dispatch_adoption_scan() {
+  local work_dir="$POSTMERGE_HOME/work/$sha"
+  local scan_path="$work_dir/scan.json"
+  local xref_path="$work_dir/xref.json"
+  local log_path="$work_dir/scan.log"
+  local xref_log_path="$work_dir/xref.log"
+  local ledger_path="$POSTMERGE_HOME/adoption.jsonl"
+  local repo_root="${CAIA_REPO_ROOT:-$HOME/Documents/projects/caia}"
+  local run_bin="$repo_root/packages/adoption-enforcement/bin/caia-adoption-run.mjs"
+  local node_bin="${NODE_BIN:-/opt/homebrew/opt/node@22/bin/node}"
+  [[ -x "$node_bin" ]] || node_bin="$(command -v node 2>/dev/null || echo /opt/homebrew/bin/node)"
+
+  if [[ "$sha" == "unknown" || "$sha" == "null" || -z "$sha" ]]; then return 0; fi
+  if [[ "$pr" == "unknown" || "$pr" == "null" || -z "$pr" ]]; then
+    printf '{"ts":"%s","level":"info","event":"adoption_scan_skipped","sha":"%s","reason":"pr_unknown"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha"
+    return 0
+  fi
+  if [[ -f "$scan_path" ]]; then
+    printf '{"ts":"%s","level":"info","event":"adoption_scan_skipped","sha":"%s","reason":"scan_present"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha"
+    return 0
+  fi
+  if [[ ! -x "$node_bin" || ! -f "$run_bin" ]]; then
+    printf '{"ts":"%s","level":"warn","event":"adoption_scan_skipped","sha":"%s","reason":"runner_unavailable","node":"%s","bin":"%s"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$node_bin" "$run_bin"
+    return 0
+  fi
+
+  mkdir -p "$work_dir"
+  (
+    set +e
+    perl -e 'alarm shift; exec @ARGV' 30 \
+      "$node_bin" "$run_bin" scan --pr "$pr" --sha "$sha" --out "$work_dir" --repo "$repo_root" \
+      >> "$log_path" 2>&1
+    local_rc=$?
+    if [[ $local_rc -eq 0 && -f "$scan_path" ]]; then
+      a=$(jq -r '.summary.artefact_count // 0' "$scan_path" 2>/dev/null)
+      [[ -z "$a" ]] && a=0
+      printf '{"ts":"%s","event":"scan_done","sha":"%s","artefact_count":%s}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$a" >> "$ledger_path"
+
+      # Chain into xref so a single merge produces both scan.json + xref.json.
+      if [[ ! -f "$xref_path" ]]; then
+        perl -e 'alarm shift; exec @ARGV' 60 \
+          "$node_bin" "$run_bin" xref --work-dir "$work_dir" --repo "$repo_root" \
+          >> "$xref_log_path" 2>&1
+        xref_rc=$?
+        if [[ $xref_rc -eq 0 && -f "$xref_path" ]]; then
+          xa=$(jq -r '.summary.artefact_count // 0' "$xref_path" 2>/dev/null)
+          xc=$(jq -r '.summary.candidate_count // 0' "$xref_path" 2>/dev/null)
+          [[ -z "$xa" ]] && xa=0
+          [[ -z "$xc" ]] && xc=0
+          printf '{"ts":"%s","event":"xref_done","sha":"%s","artefact_count":%s,"candidate_count":%s}\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$xa" "$xc" >> "$ledger_path"
+        else
+          printf '{"ts":"%s","event":"xref_failed","sha":"%s","rc":%d}\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$xref_rc" >> "$ledger_path"
+        fi
+      fi
+    else
+      printf '{"ts":"%s","event":"scan_failed","sha":"%s","rc":%d}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$local_rc" >> "$ledger_path"
+    fi
+  ) >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+
+  printf '{"ts":"%s","level":"info","event":"adoption_scan_dispatched","sha":"%s","pr":"%s","work_dir":"%s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sha" "$pr" "$work_dir"
+}
+
 # Adoption-enforcement xref stage. Runs `caia-adoption-run xref` after the
-# scan stage (p3-adoption-scan-engine, future MVP-A) has produced scan.json
-# in the per-sha work dir. Background, hard-capped at 60 s. Idempotent —
-# skips when xref.json is already present. Until the scan stage lands,
-# scan.json never exists and this is a no-op.
+# scan stage has produced scan.json in the per-sha work dir. Background,
+# hard-capped at 60 s. Idempotent — skips when xref.json is already
+# present. Most of the time the scan-chain in `dispatch_adoption_scan` has
+# already produced xref.json by the time we reach here and this is a
+# no-op; it remains as a fallback for the case where scan.json was dropped
+# out-of-band.
 #
 # On a successful xref the ledger gets one append:
 #   { ts, event:"xref_done", sha, artefact_count, candidate_count }
@@ -171,6 +262,7 @@ case "$repo" in
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$pr" "$(printf '%s' "$title" | jq -Rs .)"
       kickstart_daemon "com.chiefaia.local-llm-router"
     fi
+    dispatch_adoption_scan
     dispatch_adoption_xref
     ;;
   prakashgbid/stolution)


### PR DESCRIPTION
## Summary
- `caia-adoption-run scan --pr <num>` orchestrates the three scan-engine detectors (phases 2/3/4) and emits a unified `scan.json` under `~/.caia/post-merge/work/<sha>/`.
- `dispatch_adoption_scan` in `scripts/post-merge/post-merge-deploy.sh` runs the new subcommand per merge (30 s background budget) and chains directly into the existing xref step, so a single merge produces both `scan.json` and `xref.json`.
- `scripts/post-merge/README.md` gains an "Adoption scan stage" section covering pipeline, JSON shape, idempotency, and env overrides.

Closes p3-adoption-scan-engine phase 5.

## scan.json contract

```json
{
  "version": 1,
  "sha": "<merge-sha>",
  "pr": 492,
  "generated_at": "<iso>",
  "summary": { "artefact_count": 0, "new_package_count": 0, "new_export_count": 0, "new_external_agent_count": 0 },
  "artefacts": [ /* {kind, package, identifier, source_path, ...} — xref-compatible */ ]
}
```

Each row exposes the four fields `caia-adoption-run xref` already consumes (`kind/package/identifier/source_path`) plus detector-specific metadata that downstream readers can opt into.

## Idempotency
- Skips if `scan.json` already exists in the per-sha out dir, unless `--force`.
- `dispatch_adoption_scan` short-circuits on the same condition.
- Same for the chained xref step (`xref.json`).

## Hand-test
Ran against PR #492 (DoD-v2 addendum, docs-only):

```
$ caia-adoption-run scan --pr 492 --sha d7ce0ff306a58b56049ec6db2e4d21657c9be828 --out $TMP --repo $PWD
scan: wrote $TMP/scan.json
  artefacts=0 new_packages=0 new_exports=0 new_external_agents=0
```

Confirmed:
- artefact_count = 0 (docs PR → no new exports, no new packages, no external-agents change → no-op).
- Re-run printed `scan: skipped (already present)`.
- `--force` rewrote.

## Test plan
- [x] `pnpm typecheck` clean for `@chiefaia/adoption-enforcement`.
- [x] `pnpm vitest run tests/cli/scan.test.ts tests/cli/run.test.ts` — 14/14 passed (10 scan + 4 run dispatcher).
- [x] `bash -n scripts/post-merge/post-merge-deploy.sh` clean.
- [x] Hand-test against PR #492 (docs-only) — zero artefact rows.
- [x] Re-run and `--force` paths verified.

Note: pre-existing failures in `tests/caia-adopt-cli.test.ts` (gate-check CLI, unrelated to `caia-adoption-run`) are present on `origin/develop` and not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)