### PR TITLE
fix(chain-runner): rate_limited precedes auth in preflight (P10 regression)

### DIFF
--- a/packages/chain-runner/src/preflight.ts
+++ b/packages/chain-runner/src/preflight.ts
@@ -291,7 +291,7 @@ export async function preflightDispatch(
         raw,
       });
     });
-    child.once('exit', (code) => {
+    child.once('close', (code) => {
       const elapsed = Date.now() - t0;
       // Decision tree: rate-limit FIRST (banner is the most specific), then
       // auth, then healthy, then everything else → unknown.


### PR DESCRIPTION
## What

Switches the preflight classification listener from the child's \`exit\` event to \`close\`.

\`exit\` fires when the child process ends but BEFORE stdio pipes flush all queued data. On macOS the pipes drain before \`exit\` fires so the classifier sees the full output; on Linux CI the race surfaces and \`raw\` is empty when the if-chain runs, so every banner check misses and the result classifies as \`unknown\`.

\`close\` fires only after stdio streams are fully drained — guarantees \`raw\` contains all output before classification runs.

## Why

CI on develop fails with two preflight tests:

- \`P10_preflight_rate_limit_precedes_auth\` — expected \`rate_limited\`, got \`unknown\`
- \`P12_preflight_log_path\`             — expected \`healthy\`,      got \`unknown\`

Per the P5 M0 worker handoff: \"looks like a one-line reorder.\" Investigation showed the decision-tree order (rate_limit → auth → healthy → unknown) is already correct — the bug was a stale-buffer issue on the listener event choice, not an if-chain reorder. Still a one-line change.

## Unblocks

PR #514 (P5 mesh-supervisor M0+M1) — the \`chain-runner\` test job is currently red on this exact regression.

## Verification

\`\`\`
$ pnpm --filter @chiefaia/chain-runner test
 ✓ tests/preflight.test.ts  (15 tests) 1676ms
\`\`\`

All 15 preflight tests pass locally (previously P10 + P12 failed on Linux CI).

## Diff

\`\`\`diff
-    child.once('exit', (code) => {
+    child.once('close', (code) => {
\`\`\`