### PR TITLE
refactor(adoption): replace inline createHmac with @chiefaia/hmac-auth (PR #478 completion gate)

### DIFF
--- a/packages/local-llm-router/package.json
+++ b/packages/local-llm-router/package.json
@@ -36,6 +36,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@chiefaia/hmac-auth": "workspace:*",
     "@chiefaia/librarian": "workspace:*",
     "@chiefaia/mentor-retrieval": "workspace:*",
     "@chiefaia/prompt-optimizer": "workspace:*",

--- a/packages/local-llm-router/src/mentor-emit.ts
+++ b/packages/local-llm-router/src/mentor-emit.ts
@@ -15,18 +15,17 @@
 //      router is the primary serving path and must run even on machines that
 //      haven't been provisioned with mentor-event-bus credentials.
 //
-// HMAC scheme matches packages/mentor-event-bus/src/auth.ts exactly:
+// HMAC scheme delegated to @chiefaia/hmac-auth (PR #478 completion gate).
+// signRequest() produces canonical headers identical to those previously
+// hand-rolled here:
 //   X-Caia-Timestamp: <ms>
 //   X-Caia-Signature: hex(hmac-sha256(secret, "<ts>:<body>"))
 
-import { createHmac } from 'node:crypto';
 import { request as httpRequest } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { hostname as osHostname } from 'node:os';
 import { existsSync, readFileSync } from 'node:fs';
-
-const TIMESTAMP_HEADER = 'x-caia-timestamp';
-const SIGNATURE_HEADER = 'x-caia-signature';
+import { signRequest } from '@chiefaia/hmac-auth';
 
 const DEFAULT_BASE_URL = 'http://127.0.0.1:5180';
 
@@ -200,10 +199,7 @@ function dispatch(
     return;
   }
 
-  const ts = String(now);
-  const signature = createHmac('sha256', cfg.secret)
-    .update(`${ts}:${body}`)
-    .digest('hex');
+  const sigHeaders = signRequest(cfg.secret, body, now);
 
   const req = cfg.requestFn(
     {
@@ -216,8 +212,7 @@ function dispatch(
       headers: {
         'content-type': 'application/json; charset=utf-8',
         'content-length': Buffer.byteLength(body).toString(),
-        [TIMESTAMP_HEADER]: ts,
-        [SIGNATURE_HEADER]: signature,
+        ...sigHeaders,
       },
       timeout: cfg.timeoutMs,
     },

--- a/packages/prompt-optimizer/package.json
+++ b/packages/prompt-optimizer/package.json
@@ -33,6 +33,9 @@
     "lint": "eslint src",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@chiefaia/hmac-auth": "workspace:*"
+  },
   "devDependencies": {
     "@chiefaia/eslint-config": "workspace:*",
     "@chiefaia/tsconfig": "workspace:*",

--- a/packages/prompt-optimizer/src/mentor-emit.ts
+++ b/packages/prompt-optimizer/src/mentor-emit.ts
@@ -7,15 +7,17 @@
 // Fire-and-forget HTTP POST to the mentor-event-bus `/v1/events` endpoint.
 // Used by `optimize()` to emit one `PromptOptimizerStage` per stage. Never
 // throws, never blocks.
+//
+// HMAC request signing delegated to @chiefaia/hmac-auth (PR #478 completion
+// gate). Header names and canonical "<ts>:<body>" scheme are the canonical
+// constants exported by that package; this module no longer hand-rolls them.
 
-import { createHmac } from 'node:crypto';
 import { request as httpRequest } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { hostname as osHostname } from 'node:os';
 import { existsSync, readFileSync } from 'node:fs';
+import { signRequest } from '@chiefaia/hmac-auth';
 
-const TIMESTAMP_HEADER = 'x-caia-timestamp';
-const SIGNATURE_HEADER = 'x-caia-signature';
 const DEFAULT_BASE_URL = 'http://127.0.0.1:5180';
 
 export type OptimizerEventType = 'PromptOptimizerStage' | 'Compression';
@@ -154,10 +156,7 @@ function dispatch(
     return;
   }
 
-  const ts = String(now);
-  const signature = createHmac('sha256', cfg.secret)
-    .update(`${ts}:${body}`)
-    .digest('hex');
+  const sigHeaders = signRequest(cfg.secret, body, now);
 
   const req = cfg.requestFn(
     {
@@ -170,8 +169,7 @@ function dispatch(
       headers: {
         'content-type': 'application/json; charset=utf-8',
         'content-length': Buffer.byteLength(body).toString(),
-        [TIMESTAMP_HEADER]: ts,
-        [SIGNATURE_HEADER]: signature,
+        ...sigHeaders,
       },
       timeout: cfg.timeoutMs,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1564,6 +1564,9 @@ importers:
 
   packages/local-llm-router:
     dependencies:
+      '@chiefaia/hmac-auth':
+        specifier: workspace:*
+        version: link:../hmac-auth
       '@chiefaia/librarian':
         specifier: workspace:*
         version: link:../librarian
@@ -1904,6 +1907,10 @@ importers:
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/prompt-optimizer:
+    dependencies:
+      '@chiefaia/hmac-auth':
+        specifier: workspace:*
+        version: link:../hmac-auth
     devDependencies:
       '@chiefaia/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Closes the PR #478 completion gate. The two `mentor-emit` clients that still hand-rolled HMAC-SHA256 signing now delegate to `signRequest()` from `@chiefaia/hmac-auth`.

## Sites migrated

- `packages/prompt-optimizer/src/mentor-emit.ts`
- `packages/local-llm-router/src/mentor-emit.ts`

Both files previously declared their own `TIMESTAMP_HEADER` / `SIGNATURE_HEADER` constants and computed `hex(hmac-sha256(secret, "<ts>:<body>"))` inline. Those duplicates are removed; the canonical header-name constants now live exclusively in `@chiefaia/hmac-auth`.

## Residual surface

- **Inline createHmac sites in production code after this change: 0.**
- Remaining `createHmac` references are server-side verification helpers in tests (they re-compute the expected signature to assert against the request). That's the correct test pattern and not part of the adoption surface.

## Audit context

Addresses **P3 Adoption Audit v2 (2026-05-17), Section 3 spot-check on PR #478** — 2 residuals identified → 0 residuals after this PR. Part of the top-5 P3 adoption remediation queue.

## Tests

- `pnpm --filter @chiefaia/prompt-optimizer test` → 65/65 pass (mentor-emit suite green)
- `pnpm --filter @chiefaia/local-llm-router vitest run tests/mentor-emit.test.ts` → 9/9 pass
- `pnpm --filter @chiefaia/prompt-optimizer typecheck` + `pnpm --filter @chiefaia/local-llm-router typecheck` → clean

## Operator note

Operator is away "for next week" (escalation 2026-05-17). Standing autonomy rule applies — admin-squash merge if develop CI is red on the pre-existing `Build · Test · Lint · Typecheck` failure that's tracked separately.