### PR TITLE
refactor(adoption): consolidate ollama /api/embeddings via @chiefaia/local-llm-router

### DIFF
--- a/packages/llm-cache/package.json
+++ b/packages/llm-cache/package.json
@@ -21,6 +21,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/local-llm-router": "workspace:*",
     "better-sqlite3": "^12.6.2"
   },
   "devDependencies": {

--- a/packages/llm-cache/src/embedders/nomic.ts
+++ b/packages/llm-cache/src/embedders/nomic.ts
@@ -1,15 +1,15 @@
 // Nomic-embed-text embedder factory.
 //
-// Returns an EmbeddingFn that hits a local Ollama instance at
-// `/api/embeddings`. The cache stays embedder-agnostic — this is just one
-// concrete implementation, kept in-package because nomic + ollama is the
-// canonical local pairing across the CAIA stack (mirrors the router's
-// rag/embed.ts but without that package's internals leaking into the cache).
+// P3 ADOPTION (2026-05-18, Audit v2 Section 5 #4): the raw
+// `/api/embeddings` POST is now delegated to
+// `@chiefaia/local-llm-router#embedText`. The cache still owns its own
+// embedder-factory shape, but the wire-level Ollama call is shared with
+// every other consumer in the stack.
 
+import { embedText, type EmbedTextOptions } from '@chiefaia/local-llm-router';
 import type { EmbeddingFn } from '../types.js';
 
 const DEFAULT_MODEL = 'nomic-embed-text';
-const DEFAULT_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 export interface NomicEmbedderOptions {
@@ -40,30 +40,32 @@ export function createNomicEmbedder(
   opts: NomicEmbedderOptions = {},
 ): EmbeddingFn {
   const model = opts.model ?? DEFAULT_MODEL;
-  const baseUrl =
-    opts.baseUrl ?? process.env['OLLAMA_BASE_URL'] ?? DEFAULT_BASE_URL;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   return async (text: string): Promise<Float32Array> => {
-    const res = await fetch(`${baseUrl}/api/embeddings`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, prompt: text }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!res.ok) {
+    const embedOpts: EmbedTextOptions = { model, timeoutMs };
+    if (opts.baseUrl !== undefined) embedOpts.baseUrl = opts.baseUrl;
+
+    let result: { vector: readonly number[]; model: string };
+    try {
+      result = await embedText(text, embedOpts);
+    } catch (err) {
+      // The shared helper throws plain Errors with descriptive messages;
+      // wrap to preserve the NomicEmbedError contract callers depend on.
+      // We try to recover the HTTP status from the message when present.
+      const msg = (err as Error).message;
+      const statusMatch = msg.match(/Embed call failed: (\d+)/);
+      const status = statusMatch ? Number(statusMatch[1]) : undefined;
       throw new NomicEmbedError(
-        `ollama /api/embeddings returned ${res.status} for model ${model}`,
-        res.status,
+        `ollama /api/embeddings failed for model ${model}: ${msg}`,
+        status,
       );
     }
-    const body = (await res.json()) as { embedding?: number[] };
-    const v = body.embedding;
-    if (!Array.isArray(v) || v.length === 0) {
+    if (result.vector.length === 0) {
       throw new NomicEmbedError(
         `ollama /api/embeddings returned empty vector for model ${model}`,
       );
     }
-    return Float32Array.from(v);
+    return Float32Array.from(result.vector);
   };
 }

--- a/packages/local-llm-router/src/embed-client.ts
+++ b/packages/local-llm-router/src/embed-client.ts
@@ -1,0 +1,153 @@
+/**
+ * Canonical Ollama-embeddings client for the CAIA stack.
+ *
+ * Lifted from the ad-hoc `/api/embeddings` POSTs that were duplicated
+ * across feature-registry, dspy-bridge, llm-cache, local-rag, apprentice-eval,
+ * and apps/orchestrator/scripts (P3 Adoption Audit v2 Section 5 #4).
+ * Consumer sites that don't have an upstream-dep cycle with
+ * @chiefaia/local-llm-router should adopt this helper rather than rolling
+ * their own fetch loop.
+ *
+ * `embedText()` posts to the configured Ollama daemon's `/api/embeddings`
+ * endpoint and returns the raw `number[]` vector + the model name the
+ * daemon echoed back. Callers that want a `Float32Array` should wrap the
+ * return value themselves (kept out of this helper so it stays trivial to
+ * stub in tests).
+ *
+ * NOTE on the librarian / mentor-retrieval circular case:
+ *   @chiefaia/local-llm-router already depends on @chiefaia/librarian +
+ *   @chiefaia/mentor-retrieval (see package.json). Those two packages
+ *   therefore cannot import from this module without forming a cycle.
+ *   Their own embed.ts modules (`packages/librarian/src/embed.ts`,
+ *   `packages/mentor-retrieval/src/embed.ts`) remain the canonical
+ *   primitive implementations for that tier — this helper mirrors their
+ *   contract so consumers downstream of either tier see identical
+ *   behaviour. A future PR may invert the dep edge so this helper
+ *   becomes the single source of truth across the whole repo; that's
+ *   out of scope here.
+ */
+
+/** Default Ollama HTTP endpoint. The daemon listens on 11434 by default;
+ *  we pin IPv4 explicitly because macOS resolves `localhost` to ::1 first
+ *  and a stray IPv6 listener silently routes to the wrong daemon. Same
+ *  reasoning as in `ollama-adapter.ts` and the leaf-package embedders. */
+export const DEFAULT_OLLAMA_URL =
+  process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+
+/** Default embedding model. `nomic-embed-text` returns 768-dim vectors;
+ *  used as the canonical default across librarian, mentor-retrieval,
+ *  llm-cache, local-rag, feature-registry — kept aligned here. */
+export const DEFAULT_EMBED_MODEL = 'nomic-embed-text';
+
+/** Default per-call wall-clock timeout. 5s is the median of what the
+ *  consumer sites used pre-consolidation (some used 5s, some 15s, some
+ *  unbounded). Keep it short — embeddings should be fast; if the daemon
+ *  is slow that's a signal worth propagating, not absorbing. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface EmbedTextOptions {
+  /** Override the Ollama HTTP base URL. */
+  baseUrl?: string;
+  /** Override the embedding model. */
+  model?: string;
+  /** Per-call wall-clock timeout (ms). */
+  timeoutMs?: number;
+  /** Ollama `keep_alive` parameter (string like '10m' or seconds as number).
+   *  Default: unset (Ollama uses its daemon-wide default). Set this to keep
+   *  the embedding model warm between calls; matches the contract of the
+   *  pre-consolidation per-package embedders that exposed this option. */
+  keepAlive?: string | number;
+  /** Test seam — replace `fetch`. */
+  fetchFn?: typeof fetch;
+}
+
+export interface EmbedTextResult {
+  /** The raw embedding vector. Callers that want Float32Array should
+   *  wrap themselves (Float32Array.from(result.vector)). */
+  readonly vector: readonly number[];
+  /** The model the daemon used (echoed back from the request). */
+  readonly model: string;
+}
+
+/**
+ * Ollama HTTP `/api/embeddings` POST body shape (well-defined; the daemon
+ * accepts both `{ model, prompt }` and the OpenAI-compatible
+ * `{ model, input }` variants but we standardise on the native shape
+ * since that's what every consumer site we're consolidating uses).
+ */
+interface OllamaEmbeddingsRequest {
+  model: string;
+  prompt: string;
+  keep_alive?: string | number;
+}
+
+interface OllamaEmbeddingsResponse {
+  embedding?: number[];
+}
+
+/**
+ * Embed `text` using the local Ollama daemon.
+ *
+ * Throws on:
+ *   - HTTP non-2xx (`Embed call failed: <status> <body>`)
+ *   - missing `embedding` field in the JSON response
+ *   - request timeout (AbortError surfaced as `Embed call timed out after Nms`)
+ *
+ * Every thrown Error carries the original `cause` so eslint's
+ * `preserve-caught-error` rule is satisfied.
+ */
+export async function embedText(
+  text: string,
+  opts: EmbedTextOptions = {},
+): Promise<EmbedTextResult> {
+  const baseUrl = (opts.baseUrl ?? DEFAULT_OLLAMA_URL).replace(/\/$/, '');
+  const model = opts.model ?? DEFAULT_EMBED_MODEL;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = opts.fetchFn ?? fetch;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let res: Response;
+  try {
+    const body: OllamaEmbeddingsRequest = { model, prompt: text };
+    if (opts.keepAlive !== undefined) body.keep_alive = opts.keepAlive;
+    res = await fetchImpl(`${baseUrl}/api/embeddings`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    clearTimeout(timer);
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new Error(`Embed call timed out after ${timeoutMs}ms`, { cause: e });
+    }
+    throw new Error(
+      `Embed call to ${baseUrl}/api/embeddings failed: ${(e as Error).message}`,
+      { cause: e },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Embed call failed: ${res.status} ${text.slice(0, 200)}`);
+  }
+
+  let json: OllamaEmbeddingsResponse;
+  try {
+    json = (await res.json()) as OllamaEmbeddingsResponse;
+  } catch (e) {
+    throw new Error(`Embed response parse failed: ${(e as Error).message}`, { cause: e });
+  }
+
+  if (!json.embedding || !Array.isArray(json.embedding)) {
+    throw new Error(
+      `Embed response missing 'embedding' field (got keys: ${Object.keys(json).join(',') || '<none>'})`,
+    );
+  }
+
+  return { vector: json.embedding, model };
+}

--- a/packages/local-llm-router/src/index.ts
+++ b/packages/local-llm-router/src/index.ts
@@ -65,3 +65,13 @@ export type {
   LlmMetricsSnapshot,
   LlmMetricsSnapshotTask,
 } from './llm-metrics.js';
+
+// P3 Adoption Audit v2 Section 5 #4 — canonical Ollama embeddings client
+// for the CAIA stack. Consumers downstream of librarian/mentor-retrieval
+// should adopt this rather than rolling their own /api/embeddings POST.
+export {
+  embedText,
+  DEFAULT_OLLAMA_URL as EMBED_DEFAULT_OLLAMA_URL,
+  DEFAULT_EMBED_MODEL,
+} from './embed-client.js';
+export type { EmbedTextOptions, EmbedTextResult } from './embed-client.js';

--- a/packages/local-llm-router/src/rag/embed.ts
+++ b/packages/local-llm-router/src/rag/embed.ts
@@ -1,12 +1,15 @@
 // embed.ts — thin wrapper around Ollama's /api/embeddings endpoint.
 //
-// We hard-code `nomic-embed-text` as the default since (a) it's already
-// pulled on the dev box (verified via /healthz) and (b) the file index is
-// embedded with the same model — querying with a different one would yield
-// useless distances. The env override exists for experiment runs.
+// P3 ADOPTION (2026-05-18, Audit v2 Section 5 #4): the wire-level POST is
+// now delegated to `../embed-client.js#embedText` so this internal helper
+// shares the canonical implementation with downstream consumers
+// (feature-registry, llm-cache, local-rag). The exported function shape
+// (`embedOne`, `embedMany`, `cosineSim`) is kept so the existing internal
+// callers don't need to change.
+
+import { embedText } from '../embed-client.js';
 
 const DEFAULT_MODEL = process.env['ROUTER_RAG_EMBED_MODEL'] ?? 'nomic-embed-text';
-const DEFAULT_OLLAMA_URL = process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
 const DEFAULT_TIMEOUT_MS = Number(process.env['ROUTER_RAG_EMBED_TIMEOUT_MS'] ?? 15_000);
 
 export interface EmbedOptions {
@@ -27,24 +30,28 @@ export async function embedOne(
   opts: EmbedOptions = {},
 ): Promise<number[]> {
   const model = opts.model ?? DEFAULT_MODEL;
-  const baseUrl = opts.ollamaBaseUrl ?? DEFAULT_OLLAMA_URL;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  const res = await fetch(`${baseUrl}/api/embeddings`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model, prompt: text }),
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!res.ok) {
-    throw new EmbedError(`ollama embeddings returned ${res.status}`, res.status);
+  let result: { vector: readonly number[]; model: string };
+  try {
+    result = await embedText(text, {
+      model,
+      timeoutMs,
+      ...(opts.ollamaBaseUrl !== undefined ? { baseUrl: opts.ollamaBaseUrl } : {}),
+    });
+  } catch (err) {
+    const msg = (err as Error).message;
+    const statusMatch = msg.match(/Embed call failed: (\d+)/);
+    const status = statusMatch ? Number(statusMatch[1]) : undefined;
+    throw new EmbedError(
+      `ollama embeddings failed: ${msg}`,
+      status,
+    );
   }
-  const body = (await res.json()) as { embedding?: number[] };
-  const v = body.embedding;
-  if (!Array.isArray(v) || v.length === 0) {
+  if (result.vector.length === 0) {
     throw new EmbedError('ollama embeddings returned empty vector');
   }
-  return v;
+  return Array.from(result.vector);
 }
 
 // Convenience for the index-builder (sequential — Ollama serializes anyway

--- a/packages/local-rag/package.json
+++ b/packages/local-rag/package.json
@@ -21,6 +21,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@chiefaia/local-llm-router": "workspace:*",
     "better-sqlite3": "^12.6.2"
   },
   "devDependencies": {

--- a/packages/local-rag/src/embedder.ts
+++ b/packages/local-rag/src/embedder.ts
@@ -1,18 +1,16 @@
 // Ollama embeddings client.
 //
-// Calls /api/embeddings on the local Ollama daemon and returns a Float32Array.
-// We pin IPv4 explicitly (same reason as @chiefaia/local-llm-router):
-// macOS resolves `localhost` to ::1 first, and a stray IPv6 listener on
-// :11434 will silently route to the wrong daemon.
+// P3 ADOPTION (2026-05-18, Audit v2 Section 5 #4): the raw
+// `/api/embeddings` POST is now delegated to
+// `@chiefaia/local-llm-router#embedText` so this package shares the
+// canonical client implementation with feature-registry, llm-cache,
+// dspy-bridge, and apprentice-eval. Behaviour is identical (same
+// endpoint, same body shape, `keep_alive` preserved). The class shape
+// is kept so existing consumers don't need to change.
 
-const DEFAULT_BASE_URL =
-  process.env['OLLAMA_BASE_URL'] ?? 'http://127.0.0.1:11434';
+import { embedText } from '@chiefaia/local-llm-router';
 
 const DEFAULT_KEEP_ALIVE = process.env['OLLAMA_KEEP_ALIVE'] ?? '10m';
-
-interface OllamaEmbeddingsResponse {
-  embedding: number[];
-}
 
 export interface EmbedderOptions {
   /** Ollama tag of the embedding model (default: nomic-embed-text) */
@@ -24,12 +22,12 @@ export interface EmbedderOptions {
 }
 
 export class Embedder {
-  private readonly baseUrl: string;
+  private readonly baseUrl: string | undefined;
   private readonly model: string;
   private readonly keepAlive: string;
 
   constructor(options: EmbedderOptions = {}) {
-    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.baseUrl = options.baseUrl;
     this.model = options.model ?? 'nomic-embed-text';
     this.keepAlive = options.keepAlive ?? DEFAULT_KEEP_ALIVE;
   }
@@ -41,35 +39,31 @@ export class Embedder {
   /**
    * Embed a single text. Returns a Float32Array (typed for storage; we
    * persist as a BLOB in the SQLite store).
+   *
+   * Embedding requests are quick once the model is warm (~20ms on M1 Pro
+   * for nomic-embed-text); 30s is plenty including cold load.
    */
   async embed(text: string): Promise<Float32Array> {
-    const res = await fetch(`${this.baseUrl}/api/embeddings`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    let result: { vector: readonly number[]; model: string };
+    try {
+      result = await embedText(text, {
+        ...(this.baseUrl !== undefined ? { baseUrl: this.baseUrl } : {}),
         model: this.model,
-        prompt: text,
-        keep_alive: this.keepAlive,
-      }),
-      // Embedding requests are quick once the model is warm (~20ms on M1
-      // Pro for nomic-embed-text); 30s is plenty including cold load.
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => '');
+        timeoutMs: 30_000,
+        keepAlive: this.keepAlive,
+      });
+    } catch (err) {
       throw new Error(
-        `Ollama embeddings ${this.model} failed (${res.status}): ${body}`,
+        `Ollama embeddings ${this.model} failed: ${(err as Error).message}`,
+        { cause: err },
       );
     }
-
-    const data = (await res.json()) as OllamaEmbeddingsResponse;
-    if (!Array.isArray(data.embedding) || data.embedding.length === 0) {
+    if (result.vector.length === 0) {
       throw new Error(
         `Ollama returned an empty embedding for model "${this.model}"`,
       );
     }
-    return Float32Array.from(data.embedding);
+    return Float32Array.from(result.vector);
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1545,6 +1545,9 @@ importers:
 
   packages/llm-cache:
     dependencies:
+      '@chiefaia/local-llm-router':
+        specifier: workspace:*
+        version: link:../local-llm-router
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.9.0
@@ -1652,6 +1655,9 @@ importers:
 
   packages/local-rag:
     dependencies:
+      '@chiefaia/local-llm-router':
+        specifier: workspace:*
+        version: link:../local-llm-router
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.9.0


### PR DESCRIPTION
## Summary

Introduces the canonical `embedText()` helper on `@chiefaia/local-llm-router` and migrates the consolidatable subset of the ~18 ad-hoc Ollama HTTP sites identified in **P3 Adoption Audit v2 Section 5 #4**. The audit itself anticipated this would split across 3 PRs; this is the embeddings portion.

## Canonical helper (new)

`packages/local-llm-router/src/embed-client.ts` (~150 LOC):

```ts
export async function embedText(
  text: string,
  opts?: { baseUrl?, model?, timeoutMs?, keepAlive?, fetchFn? },
): Promise<{ vector: readonly number[]; model: string }>;
```

Re-exported from the package root as `embedText`, `DEFAULT_EMBED_MODEL`, `EMBED_DEFAULT_OLLAMA_URL`.

## Sites migrated (3)

| File | Pattern collapsed |
|------|-------------------|
| `packages/local-llm-router/src/rag/embed.ts` | Internal `embedOne` now uses the canonical client |
| `packages/local-rag/src/embedder.ts` | `class Embedder.embed()` |
| `packages/llm-cache/src/embedders/nomic.ts` | `createNomicEmbedder()` factory |

All three preserve their existing public class/function shape — only the wire-level POST collapses onto the shared implementation.

## Sites NOT migrated (with reasons)

- **Circular dep** (router depends on these — they remain canonical primitives for their tier): `packages/librarian/src/embed.ts`, `packages/mentor-retrieval/src/embed.ts`. Future PR can invert the dep edge.
- **Different endpoint shape** (`/api/embed` with OpenAI-compatible `input`, batch, dim-validation, keep-alive HTTP agent): `packages/feature-registry/src/embedding-client.ts`. Worth its own follow-up extending `embedText`.
- **Config-pass-through** (not direct fetch — the 11434 URL is passed to a Python sub-process or separate adapter): `packages/dspy-bridge/src/bridge.ts`, `packages/apprentice-eval/src/{cli,config}.ts`.
- **`/api/tags` (model listing, not embeddings/chat/generate)**: `apps/orchestrator/scripts/e2e-llm-route.ts` and two scripts under `packages/local-llm-router/scripts/`. Out of scope.

## Counts

| Bucket | Count |
|--------|-------|
| Audit-claimed | ~18 |
| Truly-ad-hoc `/api/embeddings` in production code | 5 |
| **Migrated this PR** | **3** |
| Circular (cannot migrate from this PR) | 2 |
| `/api/embed` (deferred — needs helper extension) | 1 |
| Config pass-through (not fetch sites) | 3 |
| `/api/tags` (out of scope) | 3 |

## Tests

- `pnpm --filter @chiefaia/local-llm-router vitest run tests/router.test.ts __tests__/rag.test.ts` → **32/32 pass**
- `pnpm --filter @chiefaia/llm-cache vitest run tests/embedders.nomic.test.ts` → **5/5 pass**
- `pnpm --filter @chiefaia/local-rag vitest run tests/embedder.test.ts` → **5/5 pass**
- Typecheck clean across all three packages.

The `better-sqlite3` NODE_MODULE_VERSION 127 vs 147 native binding failure on unrelated tests is the **pre-existing build issue the P3 audit flagged in Section 6** (mentor server runtime break). Not introduced here.

## Operator note

Operator is away. Standing autonomy rule applies — admin-squash merge if develop CI is red on pre-existing failure.