### PR TITLE
refactor(adoption): expand tool-output-sanitizer to all tool-handling sites

### DIFF
--- a/apps/executor/completion-hook.ts
+++ b/apps/executor/completion-hook.ts
@@ -11,6 +11,17 @@ import { checkAndBreak } from './breaker';
 import { publishEvent } from './publish-event';
 import { parseClaudeOutputRich } from './parse-claude-output-rich';
 import { logger } from './logger';
+import { sanitizeToolResult } from '@chiefaia/tool-output-sanitizer';
+
+/** SAFETY-003 expansion (P3 audit Section 5 #5): centralised redaction
+ *  helper used before any claude-produced string leaves the executor on
+ *  the user-visible publish/persist surface. Claude's output is an
+ *  untrusted source from the sanitizer's perspective (the model can be
+ *  prompt-injected into echoing secrets it saw in tool outputs), so we
+ *  default to 'paranoid' strictness on the executor boundary. */
+function redactClaude(s: string): string {
+  return sanitizeToolResult(s, { strictness: 'paranoid' }).payload;
+}
 
 const log = logger.child({ component: 'completion-hook' });
 
@@ -157,15 +168,17 @@ export async function handleCompletion(
     // ── Success path ──────────────────────────────────────────────────────────
     taskLog.info('task completed successfully', { duration_ms: durationMs });
 
+    const sanitizedSummary = redactClaude(parsed.summary);
+
     await finalizeExecutorRun(
       handle.executorRunId, parsed.sessionId, 'done',
-      parsed.summary, null, parsed.costUsd, parsed.turnCount,
+      sanitizedSummary, null, parsed.costUsd, parsed.turnCount,
     );
 
     await markTaskDone(handle.taskId, parsed.sessionId);
 
     // Legacy events (retained for existing consumers)
-    await publishEvent('task.completed', { task_id: handle.taskId, duration_ms: durationMs, result_summary: parsed.summary }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
+    await publishEvent('task.completed', { task_id: handle.taskId, duration_ms: durationMs, result_summary: sanitizedSummary }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
     await publishEvent('worker.completed', { executor_run_id: handle.executorRunId, task_id: handle.taskId, exit_code: outcome.exitCode ?? 0, turn_count: parsed.turnCount }, { correlationId: task.rootPromptId, entityType: 'task', entityId: handle.taskId });
 
     // Per-tool-call events (fire-and-forget — no await)
@@ -174,7 +187,7 @@ export async function handleCompletion(
         taskId: handle.taskId,
         executorRunId: handle.executorRunId,
         toolName: tc.name,
-        inputSummary: tc.inputSummary,
+        inputSummary: redactClaude(tc.inputSummary),
         sequenceIndex: tc.sequenceIndex,
       });
     }
@@ -271,17 +284,19 @@ export async function handleCompletion(
 
   } else {
     // ── Failure path ──────────────────────────────────────────────────────────
+    const sanitizedSummary = redactClaude(parsed.summary);
+    const sanitizedReasonTail = redactClaude(parsed.summary.slice(0, 200));
     const reason = outcome.kind === 'stalled'
       ? `stalled (no output for ${Math.round(outcome.lastOutputAge / 60000)}min)`
       : outcome.kind === 'dead'
       ? `process died (exit code: ${outcome.exitCode})`
-      : `exit code ${(outcome as { exitCode: number }).exitCode}: ${parsed.summary.slice(0, 200)}`;
+      : `exit code ${(outcome as { exitCode: number }).exitCode}: ${sanitizedReasonTail}`;
 
     taskLog.error('task failed', { reason, attempt_n: newAttemptCount });
 
     await finalizeExecutorRun(
       handle.executorRunId, parsed.sessionId, 'failed',
-      parsed.summary, reason, parsed.costUsd, parsed.turnCount,
+      sanitizedSummary, reason, parsed.costUsd, parsed.turnCount,
     );
 
     // Always update task status + attempt count first (moves out of 'running')

--- a/apps/executor/package.json
+++ b/apps/executor/package.json
@@ -16,6 +16,7 @@
     "@chiefaia/claude-spawner": "workspace:*",
     "@chiefaia/event-bus-internal": "workspace:*",
     "@chiefaia/logger": "workspace:*",
+    "@chiefaia/tool-output-sanitizer": "workspace:*",
     "nanoid": "^5.0.0"
   },
   "devDependencies": {

--- a/apps/orchestrator/scripts/build-runner.ts
+++ b/apps/orchestrator/scripts/build-runner.ts
@@ -9,6 +9,7 @@
 import { execSync, spawnSync } from 'child_process';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { sanitizeToolResult } from '@chiefaia/tool-output-sanitizer';
 
 const API = process.env['CONDUCTOR_API'] ?? 'http://localhost:7776';
 const TRIGGER = (() => {
@@ -76,7 +77,13 @@ async function runStep(name: string, command: string, order: number): Promise<St
   const exitCode = result.status ?? 1;
   const durationMs = Date.now() - start;
   const output = (result.stdout ?? '') + (result.stderr ?? '');
-  const stderrTail = output.split('\n').slice(-10).join('\n');
+  // SAFETY-003 expansion (P3 audit Section 5 #5): the last 10 lines of
+  // build-step stderr are persisted via PATCH and emitted as a bus event;
+  // they can contain CI env-bleed secrets (npm tokens, GH PATs). Redact
+  // known secret-shaped strings before surfacing. Lenient because the
+  // source (build subprocess) is first-party but env-leakable.
+  const rawStderrTail = output.split('\n').slice(-10).join('\n');
+  const stderrTail = sanitizeToolResult(rawStderrTail, { strictness: 'lenient' }).payload;
   const errorSignature = output.match(/(error TS\d+|Error:|FAIL |FAILED)/g)?.slice(0, 3).join(', ') ?? '';
   const status = exitCode === 0 ? 'success' : 'failed';
 

--- a/apps/orchestrator/src/api/routes/task-runs.ts
+++ b/apps/orchestrator/src/api/routes/task-runs.ts
@@ -6,6 +6,18 @@ import { taskRuns, taskSubtasks, taskRunEvents, promptPipelineStages } from '../
 import { bus } from '../../ws/bus';
 import { nanoid } from 'nanoid';
 import { eventBus } from '../../events/bus-adapter';
+import { sanitizeToolResult } from '@chiefaia/tool-output-sanitizer';
+
+/** SAFETY-003 expansion (P3 audit Section 5 #5): inbound completion
+ *  summaries / excerpts from executors are written to a SQLite column
+ *  the dashboard reads back. Treat them as untrusted (the body is
+ *  attacker-controlled if the executor's claude run was prompt-injected)
+ *  and redact known secret-shaped strings before persisting. Paranoid
+ *  strictness because the dashboard renders these to the human operator. */
+function sanitizeInbound(s: unknown): unknown {
+  if (typeof s !== 'string') return s;
+  return sanitizeToolResult(s, { strictness: 'paranoid' }).payload;
+}
 
 function subtaskProgress(db: Db, taskRunId: number): { done: number; total: number } {
   const sqlite = getSqliteRaw();
@@ -125,7 +137,7 @@ export function registerTaskRunRoutes(app: Hono, db: Db): void {
     if (body['status'] !== undefined) update['status'] = body['status'];
     if (body['turn_count'] !== undefined) update['turnCount'] = body['turn_count'];
     if (body['last_activity_at'] !== undefined) update['lastActivityAt'] = body['last_activity_at'];
-    if (body['completion_summary'] !== undefined) update['completionSummary'] = body['completion_summary'];
+    if (body['completion_summary'] !== undefined) update['completionSummary'] = sanitizeInbound(body['completion_summary']);
     if (body['ended_at'] !== undefined) update['endedAt'] = body['ended_at'];
     if (body['result_ok'] !== undefined) update['resultOk'] = body['result_ok'];
 
@@ -137,7 +149,7 @@ export function registerTaskRunRoutes(app: Hono, db: Db): void {
     if (body['output_tokens'] !== undefined) update['outputTokens'] = body['output_tokens'];
     if (body['files_changed'] !== undefined) update['filesChanged'] = body['files_changed'];
     if (body['duration_ms'] !== undefined) update['durationMs'] = body['duration_ms'];
-    if (body['raw_claude_output'] !== undefined) update['rawClaudeOutput'] = body['raw_claude_output'];
+    if (body['raw_claude_output'] !== undefined) update['rawClaudeOutput'] = sanitizeInbound(body['raw_claude_output']);
 
     if (!update['lastActivityAt']) update['lastActivityAt'] = now;
 
@@ -338,7 +350,7 @@ export function registerTaskRunRoutes(app: Hono, db: Db): void {
       at: now,
       turnCount: body['turn_count'] as number | undefined,
       eventKind: body['event_kind'] as string,
-      excerpt: body['excerpt'] ? String(body['excerpt']).slice(0, 500) : undefined,
+      excerpt: body['excerpt'] ? (sanitizeInbound(String(body['excerpt']).slice(0, 500)) as string) : undefined,
       payload: JSON.stringify(body['payload'] ?? {}),
     };
     db.insert(taskRunEvents).values(row).run();

--- a/apps/worker-coding/jest.config.ts
+++ b/apps/worker-coding/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
     // never crosses the ESM boundary.
     '^@chiefaia/hmac-auth$': '<rootDir>/../../packages/hmac-auth/src/index.ts',
     '^@chiefaia/logger$': '<rootDir>/../../packages/logger/src/index.ts',
+    '^@chiefaia/tool-output-sanitizer$': '<rootDir>/../../packages/tool-output-sanitizer/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {

--- a/apps/worker-coding/package.json
+++ b/apps/worker-coding/package.json
@@ -2,7 +2,7 @@
   "name": "@caia-app/worker-coding",
   "version": "0.1.0",
   "private": true,
-  "description": "Phase 2 Coding Agent worker \u2014 picks ready tickets from the orchestrator, claims a worktree, implements per EA's architecturalInstructions, opens a PR.",
+  "description": "Phase 2 Coding Agent worker — picks ready tickets from the orchestrator, claims a worktree, implements per EA's architecturalInstructions, opens a PR.",
   "main": "dist/src/main.js",
   "bin": {
     "worker-coding": "dist/src/main.js"
@@ -16,6 +16,7 @@
     "@chiefaia/capability-broker": "workspace:*",
     "@chiefaia/logger": "workspace:*",
     "@chiefaia/ticket-template": "workspace:*",
+    "@chiefaia/tool-output-sanitizer": "workspace:*",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apps/worker-coding/src/local-test-runner.ts
+++ b/apps/worker-coding/src/local-test-runner.ts
@@ -19,6 +19,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { spawnSync, type SpawnSyncOptions } from 'child_process';
+import { sanitizeToolResult } from '@chiefaia/tool-output-sanitizer';
 import type { Worktree } from './worktree-manager';
 import type { Bundle } from './bundle-reader';
 
@@ -202,8 +203,19 @@ export class LocalTestRunner {
   }
 
   private tail(s: string): string {
-    if (Buffer.byteLength(s, 'utf8') <= this.tailBytes) return s;
-    return '...[truncated]...\n' + s.slice(-this.tailBytes);
+    const truncated =
+      Buffer.byteLength(s, 'utf8') <= this.tailBytes
+        ? s
+        : '...[truncated]...\n' + s.slice(-this.tailBytes);
+    // SAFETY-003 expansion (P3 audit Section 5 #5): run captured test
+    // stdout/stderr through the sanitizer before surfacing it back to
+    // the orchestrator. Test runs spawn arbitrary user code with the
+    // worker's env (which may include CONDUCTOR_API tokens, npm tokens,
+    // etc.); the sanitizer redacts known secret-shaped strings and
+    // prompt-injection markers. Lenient strictness because the source
+    // (test runner under our control) is first-party but its output
+    // shape isn't constrained.
+    return sanitizeToolResult(truncated, { strictness: 'lenient' }).payload;
   }
 
   private writeLog(filePath: string, contents: string): void {

--- a/apps/worker-fix-it/jest.config.ts
+++ b/apps/worker-fix-it/jest.config.ts
@@ -8,6 +8,8 @@ const config: Config = {
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '\\.bench\\.ts$'],
   moduleNameMapper: {
     '^@chiefaia/ticket-template$': '<rootDir>/../../packages/ticket-template/src/index.ts',
+    // tool-output-sanitizer is ESM-only; redirect to src so ts-jest (CJS) can parse it.
+    '^@chiefaia/tool-output-sanitizer$': '<rootDir>/../../packages/tool-output-sanitizer/src/index.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {

--- a/apps/worker-fix-it/package.json
+++ b/apps/worker-fix-it/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@chiefaia/ticket-template": "workspace:*",
+    "@chiefaia/tool-output-sanitizer": "workspace:*",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apps/worker-fix-it/src/test-runner.ts
+++ b/apps/worker-fix-it/src/test-runner.ts
@@ -37,6 +37,7 @@
 
 import { spawn } from 'child_process';
 import { readFileSync } from 'fs';
+import { sanitizeToolResult } from '@chiefaia/tool-output-sanitizer';
 
 import type {
   GeneratedSpec,
@@ -423,5 +424,9 @@ export class SubprocessTestRunner implements TestRunner {
 }
 
 function tail(s: string, n: number): string {
-  return s.length <= n ? s : s.slice(-n);
+  const truncated = s.length <= n ? s : s.slice(-n);
+  // SAFETY-003 expansion (P3 audit Section 5 #5): captured stdout/stderr
+  // from spawned test runners can contain env-bleed secrets; redact known
+  // patterns before storing as run-artefacts that the dashboard renders.
+  return sanitizeToolResult(truncated, { strictness: 'lenient' }).payload;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@chiefaia/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@chiefaia/tool-output-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/tool-output-sanitizer
       nanoid:
         specifier: ^5.0.0
         version: 5.1.9
@@ -465,6 +468,9 @@ importers:
       '@chiefaia/ticket-template':
         specifier: workspace:*
         version: link:../../packages/ticket-template
+      '@chiefaia/tool-output-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/tool-output-sanitizer
       zod:
         specifier: ^4.1.12
         version: 4.3.6
@@ -490,6 +496,9 @@ importers:
       '@chiefaia/ticket-template':
         specifier: workspace:*
         version: link:../../packages/ticket-template
+      '@chiefaia/tool-output-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/tool-output-sanitizer
       zod:
         specifier: ^4.1.12
         version: 4.3.6


### PR DESCRIPTION
## Summary

`@chiefaia/tool-output-sanitizer` was used at 3 sites pre-PR. This expands adoption to **5 additional production files spanning ~10 new wrap-points** across the claude / tool / shell output surface. Per **P3 Adoption Audit v2 Section 5 #5** (3 → ~10 sites).

## Sites added

| File | Wrap-points |
|------|-------------|
| `apps/worker-coding/src/local-test-runner.ts` | `tail()` — stdoutTail/stderrTail of spawned test runs |
| `apps/worker-fix-it/src/test-runner.ts` | `tail()` — same pattern, fix-it side |
| `apps/executor/completion-hook.ts` | `redactClaude()` helper applied at: finalizeExecutorRun success, `task.completed` event, `executor.claude.tool_call` event (inputSummary), finalizeExecutorRun failure, failure-reason exit-code tail (5 wrap-points) |
| `apps/orchestrator/src/api/routes/task-runs.ts` | `sanitizeInbound()` helper applied at: PATCH completion_summary, PATCH raw_claude_output, POST events excerpt (3 wrap-points) |
| `apps/orchestrator/scripts/build-runner.ts` | stderrTail before PATCH + bus event |

**Total: ~10 wrap-points across 5 files.**

## Strictness

- **`paranoid`** for claude output (untrusted — the model can be prompt-injected into echoing secrets it saw in tool outputs) and for inbound API payloads the dashboard renders to humans.
- **`lenient`** for spawned test/build subprocess output (first-party but env-leakable — CI secrets, npm tokens, GH PATs in stdout during failed builds).

Aligns with the SAFETY-003 spec already encoded in `apps/orchestrator/src/safety/tool-result-sanitizer-bridge.ts`.

## Jest config wiring

`@chiefaia/tool-output-sanitizer` is `"type": "module"` (ESM only). Two of the migrated apps (worker-coding, worker-fix-it) test with ts-jest in CJS mode, which can't `require()` the ESM build. Added `moduleNameMapper` entries redirecting to the package's `src/index.ts` — mirrors the existing pattern worker-coding already uses for `@chiefaia/logger` and `@chiefaia/hmac-auth`.

## Deps added

`@chiefaia/tool-output-sanitizer: workspace:*` to:
- `@caia-app/executor`
- `@caia-app/worker-coding`
- `@caia-app/worker-fix-it`

(orchestrator + guardrails-validator + capability-broker already had it.)

## Tests

- `pnpm --filter @caia-app/executor test` → **28/28 pass**
- `pnpm --filter @caia-app/worker-coding test` → **123/123 pass**
- `pnpm --filter @caia-app/worker-fix-it test` → **112/112 pass**
- Typecheck clean across all 5 packages.

## Operator note

Operator is away. Standing autonomy rule applies — admin-squash merge if develop CI is red on pre-existing failure.