### PR TITLE
feat(atlas-design-snapshotter): versioned snapshot capture + Time Machine

### DIFF
--- a/packages/atlas-design-snapshotter/README.md
+++ b/packages/atlas-design-snapshotter/README.md
@@ -1,0 +1,119 @@
+# `@chiefaia/atlas-design-snapshotter`
+
+Captures a **versioned, immutable snapshot of every `RenderableDesign`** at every upload — the Time-Machine and UX-Version-Control primitive that lets architects revert to any prior design state.
+
+**Anchor docs:**
+- `research/atlas_module_spec_2026.md` §2 (DOM-ID model), §4 (ticket-versioning analogue)
+- `research/step5_design_ingest_spec_2026.md` §1 (`RenderableDesign` shape), §4 (`design_versions` + `ux_uploads` schemas), §5.2 (diff JSON shape), §5.3 (revert SQL)
+
+## What this package does
+
+1. **`snapshot(input)`** — given a freshly-uploaded `RenderableDesign` and the `ux_uploads` row pointer, inserts an immutable `design_versions` row with monotonically increasing `version_number`, `parent_version_id` linked to the prior version, and the `RenderableDesign` JSON. Asset blobs are uploaded via the BYOC adapter with **SHA-256 content-hash dedup** — the same blob across N versions = one upload, N references.
+2. **Diff-from-parent** — once a snapshot is created, runs the injected `diffDesigns` (from `@chiefaia/atlas-mapper`) against the parent and persists the result in `design_versions.diff_from_parent` (jsonb) + `design_versions.diff_summary` (jsonb).
+3. **`revertToVersion(uxUploadId, versionNumber)`** — the Time-Machine primitive. Creates a new snapshot v(N+1) whose payload equals v(versionNumber). Restoration is always a **forward** operation; prior rows are never mutated.
+4. **`deleteAllForTenant(tenantId)`** — GDPR right-to-erasure. Drops all `design_versions` rows + their blobs for the tenant. Idempotent — safe to re-run.
+5. **Read APIs.** `getSnapshot`, `listVersions`, `getDiff`.
+
+**Out of scope.** This package does not run agents, does not render iframes, does not call LLMs, does not own the dashboard. It is the pure capture + storage spine that everything else composes around.
+
+## Public API
+
+```typescript
+import {
+  createDesignSnapshotter,
+  type DesignSnapshotter,
+  type RenderableDesign,
+  type Diff,
+  type DesignVersionRow,
+  type BlobStorage,
+  type PgQueryable,
+  type DiffDesignsFn,
+} from '@chiefaia/atlas-design-snapshotter';
+
+const snap: DesignSnapshotter = createDesignSnapshotter({
+  pg,                          // any node-postgres-compatible client (or fake)
+  blobStorage,                 // BYOC adapter: put / get / delete / head
+  diffDesigns,                 // injected from @chiefaia/atlas-mapper
+  schema: 'caia_pt_dev',       // per-tenant schema name
+  tenantId: 'pt-dev',          // tenant identifier
+  blobPathPrefix: 'design-assets', // optional; default 'design-assets'
+});
+
+// 1. Snapshot on upload
+const v = await snap.snapshot({
+  uxUploadId: '...',
+  design: renderableDesign,
+  notes: 'optional commit message',
+});
+// → { id, versionNumber, parentVersionId, diffSummary, ... }
+
+// 2. Revert
+const restored = await snap.revertToVersion({
+  uxUploadId: '...',
+  versionNumber: 3,
+});
+// Creates v(N+1) with content from v(3). v(3) is untouched.
+
+// 3. GDPR
+const result = await snap.deleteAllForTenant('tenant-id-uuid');
+// → { deletedVersionCount, deletedBlobCount }   idempotent
+
+// 4. Reads
+const renderable = await snap.getSnapshot(designVersionId);
+const versions   = await snap.listVersions(uxUploadId);
+const diff       = await snap.getDiff(fromVersionId, toVersionId);
+```
+
+## Content-hash dedup
+
+Asset blobs are keyed by `sha256(bytes)`. Before each upload we `head()` the
+target path. A hit short-circuits the upload but still inserts a
+`design_assets` row pointing at the existing blob. Same image across 50
+versions = 1 blob + 50 references.
+
+Blob paths follow the spec §4 convention:
+`<blobPathPrefix>/<sha256>` under the tenant's configured prefix. The BYOC
+adapter is responsible for tenant isolation (one bucket per tenant in the
+default deployment).
+
+## Dependency injection (parameterised public API)
+
+Per the CAIA Option-E shape (AGENTS.md), every external coupling is a
+constructor parameter:
+
+| Parameter      | Default in production               | Injected in tests |
+| -------------- | ----------------------------------- | ----------------- |
+| `pg`           | `new pg.Client(...)`                | `FakePg`          |
+| `blobStorage`  | BYOC adapter from `@chiefaia/cloud` | `FakeBlobStorage` |
+| `diffDesigns`  | `@chiefaia/atlas-mapper`            | `fakeDiff`        |
+| `clock`        | `() => new Date()`                  | frozen clock      |
+| `idGen`        | `() => crypto.randomUUID()`         | counter           |
+
+This is what lets us cover every branch with pure in-memory tests and still
+share one code path with the integration test against real Postgres + R2.
+
+## Schema migrations
+
+This package **does not own the migration** — `@chiefaia/meta-schema` ships
+the per-tenant schema template (step-5 spec §4). For convenience, the
+canonical DDL ships at `src/sql.ts`'s `SCHEMA_SQL` constant so a test can
+bootstrap a fresh schema by running it.
+
+## Testing
+
+```bash
+pnpm --filter @chiefaia/atlas-design-snapshotter test          # all
+pnpm --filter @chiefaia/atlas-design-snapshotter test:unit     # in-memory only
+pnpm --filter @chiefaia/atlas-design-snapshotter test:integration  # PG + S3
+```
+
+The integration test is skipped automatically unless both
+`DATABASE_URL` and `S3_ENDPOINT` (plus `S3_BUCKET`, `S3_ACCESS_KEY_ID`,
+`S3_SECRET_ACCESS_KEY`) are present in the environment.
+
+## Reuse, not invention
+
+- **`RenderableDesign`** — exact shape from `step5_design_ingest_spec_2026.md` §1; type-equivalent to `@chiefaia/atlas-mapper`'s projection.
+- **`Diff`** — exact shape from atlas-mapper's `DesignDiff` (flat ID-level: `{added, removed, modified}`).
+- **`SecretsAdapter`** — credentials for the BYOC adapter resolve via `@chiefaia/secrets-adapter` at construction time in production. The snapshotter itself never holds secrets.
+- **Postgres** — no Drizzle/Prisma coupling. Raw `$1`-style queries against any `PgQueryable` (node-postgres `Client` / `Pool` / our `FakePg`).

--- a/packages/atlas-design-snapshotter/package.json
+++ b/packages/atlas-design-snapshotter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@chiefaia/atlas-design-snapshotter",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Captures a versioned, immutable snapshot of every RenderableDesign (DOM + assets + tokens) at every upload. The Time-Machine + UX-Version-Control primitive. Computes diff-from-parent via @chiefaia/atlas-mapper. Stores blobs via a BYOC adapter with content-hash dedup.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:unit": "vitest run --exclude tests/integration.test.ts",
+    "test:integration": "vitest run tests/integration.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/atlas-design-snapshotter/src/capture.ts
+++ b/packages/atlas-design-snapshotter/src/capture.ts
@@ -1,0 +1,342 @@
+/**
+ * Snapshot capture — the write-path for the snapshotter.
+ *
+ * Lifecycle of one snapshot:
+ *
+ *   1. Load the prior version (if any) for the same ux_upload_id.
+ *   2. Upload every asset whose `storageUrl` is empty. Content-hash dedup:
+ *      `head()` the target path; on hit, skip upload but still record the
+ *      design_assets row. On miss, `put()` and record.
+ *   3. Insert a `design_versions` row with `version_number = prior + 1`,
+ *      `parent_version_id` = prior.id (or NULL for v1), and a snapshot of the
+ *      `RenderableDesign` (assets list now carries `storageUrl`).
+ *   4. Compute diff-from-parent via the injected `diffDesigns`. Persist into
+ *      `diff_from_parent` and `diff_summary`.
+ *
+ * Everything happens in a single Postgres transaction so a mid-flight failure
+ * leaves no half-committed `design_versions` row.
+ */
+
+import { sha256 } from './content-hash.js';
+import { emptyDiff, summarise } from './diff.js';
+import { assertSafeSchemaName, q } from './sql.js';
+import {
+  type AssetByteReader,
+  type BlobStorage,
+  type DesignVersionRow,
+  type Diff,
+  type DiffDesignsFn,
+  type DiffSummary,
+  type PgQueryable,
+  type RenderableAsset,
+  type RenderableDesign,
+  SnapshotterError,
+  type SnapshotInput,
+} from './types.js';
+
+export interface CaptureDeps {
+  pg: PgQueryable;
+  blobStorage: BlobStorage;
+  diffDesigns: DiffDesignsFn;
+  schema: string;
+  blobPathPrefix: string;
+  assetByteReader?: AssetByteReader;
+  idGen: () => string;
+  clock: () => Date;
+}
+
+export async function captureSnapshot(
+  input: SnapshotInput,
+  deps: CaptureDeps,
+): Promise<DesignVersionRow> {
+  validateInput(input);
+  assertSafeSchemaName(deps.schema);
+
+  const prior = await loadPriorVersion(input.uxUploadId, deps);
+  const versionNumber = prior ? prior.versionNumber + 1 : 1;
+  const parentVersionId = prior?.id ?? null;
+  const newVersionId = deps.idGen();
+  const createdAt = deps.clock();
+
+  // 1. Materialise the design with storageUrls populated for every asset.
+  const materialised = await materialiseAssets({
+    design: input.design,
+    blobStorage: deps.blobStorage,
+    blobPathPrefix: deps.blobPathPrefix,
+    ...(deps.assetByteReader ? { assetByteReader: deps.assetByteReader } : {}),
+  });
+
+  // 2. Compute diff before insert so we can write it in one round-trip.
+  let diff: Diff;
+  let diffSummary: DiffSummary;
+  if (prior) {
+    try {
+      diff = deps.diffDesigns(prior.renderableDesign!, materialised);
+    } catch (err) {
+      throw new SnapshotterError('diff_failed', 'diffDesigns threw', {
+        cause: err instanceof Error ? err.message : String(err),
+      });
+    }
+    diffSummary = summarise(diff);
+  } else {
+    diff = emptyDiff();
+    diffSummary = summarise(diff);
+  }
+
+  // 3. Stamp designVersionId into the snapshot itself so the persisted
+  //    payload is self-describing. Atlas's iframe renderers rely on this.
+  const stampedDesign: RenderableDesign = {
+    ...materialised,
+    designVersionId: newVersionId,
+  };
+
+  // 4. Persist everything in a transaction. Manual BEGIN/COMMIT because the
+  //    `PgQueryable` shape is intentionally narrow.
+  await deps.pg.query('BEGIN');
+  try {
+    await deps.pg.query(
+      `INSERT INTO ${q(deps.schema, 'design_versions')}
+         (id, ux_upload_id, version_number, parent_version_id, created_at,
+          diff_from_parent, diff_summary, notes, rendered_design)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        newVersionId,
+        input.uxUploadId,
+        versionNumber,
+        parentVersionId,
+        createdAt,
+        prior ? JSON.stringify(diff) : null,
+        JSON.stringify(diffSummary),
+        input.notes ?? null,
+        JSON.stringify(stampedDesign),
+      ],
+    );
+
+    // Asset rows — one per logical path in the design, pointing at the
+    // (possibly deduped) storage_url.
+    for (const a of stampedDesign.assets ?? []) {
+      if (!a.contentHash || !a.storageUrl) {
+        // Defensive: materialiseAssets guarantees these but in case of a
+        // mis-supplied placeholder asset we skip it rather than crash.
+        if (a.isPlaceholder) continue;
+        throw new SnapshotterError('asset_bytes_missing', 'Asset lacks contentHash/storageUrl after materialise', {
+          path: a.path,
+        });
+      }
+      await deps.pg.query(
+        `INSERT INTO ${q(deps.schema, 'design_assets')}
+           (id, ux_upload_id, design_version_id, path, kind, content_hash,
+            storage_url, size_bytes, alt_text, intrinsic_w, intrinsic_h, is_placeholder)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+         ON CONFLICT (design_version_id, path) DO NOTHING`,
+        [
+          deps.idGen(),
+          input.uxUploadId,
+          newVersionId,
+          a.path,
+          a.kind ?? 'image',
+          a.contentHash,
+          a.storageUrl,
+          a.byteSize ?? 0,
+          a.alt ?? null,
+          a.intrinsicSize?.w ?? null,
+          a.intrinsicSize?.h ?? null,
+          a.isPlaceholder ?? false,
+        ],
+      );
+    }
+
+    // Mirror onto ux_uploads.rendered_design so the latest design is one
+    // join away from the upload row (step5 §4 keeps this convenience copy).
+    await deps.pg.query(
+      `UPDATE ${q(deps.schema, 'ux_uploads')}
+         SET rendered_design = $1, status = 'parsed'
+       WHERE id = $2`,
+      [JSON.stringify(stampedDesign), input.uxUploadId],
+    );
+
+    await deps.pg.query('COMMIT');
+  } catch (err) {
+    await deps.pg.query('ROLLBACK').catch(() => undefined);
+    throw err;
+  }
+
+  return {
+    id: newVersionId,
+    uxUploadId: input.uxUploadId,
+    versionNumber,
+    parentVersionId,
+    createdAt,
+    diffFromParent: prior ? diff : null,
+    diffSummary,
+    notes: input.notes ?? null,
+    renderableDesign: stampedDesign,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function validateInput(input: SnapshotInput): void {
+  if (!input.uxUploadId || typeof input.uxUploadId !== 'string') {
+    throw new SnapshotterError('invalid_renderable_design', 'snapshot requires uxUploadId');
+  }
+  if (!input.design || typeof input.design !== 'object') {
+    throw new SnapshotterError('invalid_renderable_design', 'snapshot requires design payload');
+  }
+  if (!input.design.componentTrees || typeof input.design.componentTrees !== 'object') {
+    throw new SnapshotterError('invalid_renderable_design', 'design.componentTrees is required');
+  }
+  if (!Array.isArray(input.design.routes)) {
+    throw new SnapshotterError('invalid_renderable_design', 'design.routes is required');
+  }
+}
+
+interface PriorVersion {
+  id: string;
+  versionNumber: number;
+  renderableDesign: RenderableDesign;
+}
+
+async function loadPriorVersion(
+  uxUploadId: string,
+  deps: CaptureDeps,
+): Promise<PriorVersion | null> {
+  const res = await deps.pg.query<{ id: string; version_number: number; rendered_design: unknown }>(
+    `SELECT id, version_number, rendered_design
+       FROM ${q(deps.schema, 'design_versions')}
+      WHERE ux_upload_id = $1
+   ORDER BY version_number DESC
+      LIMIT 1`,
+    [uxUploadId],
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  const design = parseJsonbColumn(row.rendered_design);
+  if (!design) {
+    throw new SnapshotterError('invalid_renderable_design', 'prior version is missing rendered_design', {
+      designVersionId: row.id,
+    });
+  }
+  return {
+    id: row.id,
+    versionNumber: row.version_number,
+    renderableDesign: design as RenderableDesign,
+  };
+}
+
+/**
+ * Walk the design's `assets[]` and ensure every entry has a `contentHash` +
+ * `storageUrl`. Uploads bytes via the BYOC adapter, with `head()`-based dedup
+ * keyed on the SHA path.
+ */
+async function materialiseAssets(args: {
+  design: RenderableDesign;
+  blobStorage: BlobStorage;
+  blobPathPrefix: string;
+  assetByteReader?: AssetByteReader;
+}): Promise<RenderableDesign> {
+  const out: RenderableAsset[] = [];
+  for (const asset of args.design.assets ?? []) {
+    out.push(await materialiseAsset(asset, args));
+  }
+  return { ...args.design, assets: out };
+}
+
+async function materialiseAsset(
+  asset: RenderableAsset,
+  args: {
+    blobStorage: BlobStorage;
+    blobPathPrefix: string;
+    assetByteReader?: AssetByteReader;
+  },
+): Promise<RenderableAsset> {
+  // Already-stored asset: trust its storageUrl/contentHash and pass through.
+  if (asset.storageUrl && asset.contentHash) {
+    return asset;
+  }
+  if (asset.isPlaceholder) {
+    // Placeholder assets carry no bytes; record only.
+    return {
+      ...asset,
+      contentHash: asset.contentHash ?? 'sha256:placeholder',
+      storageUrl: asset.storageUrl ?? '',
+    };
+  }
+  if (!args.assetByteReader) {
+    throw new SnapshotterError(
+      'asset_bytes_missing',
+      `Asset ${asset.path} has no storageUrl and no assetByteReader was provided`,
+      { path: asset.path },
+    );
+  }
+  const bytes = await args.assetByteReader(asset);
+  const contentHash = asset.contentHash ?? sha256(bytes);
+  const blobPath = `${args.blobPathPrefix}/${stripShaPrefix(contentHash)}`;
+
+  const head = await args.blobStorage.head(blobPath);
+  let storageUrl: string;
+  if (head.exists) {
+    // Dedup hit. We still trust the existing blob — `head` returns the
+    // adapter's recorded URL via the `put` short-circuit below.
+    const put = await args.blobStorage.put({
+      path: blobPath,
+      bytes,
+      contentHash,
+      ...(asset.kind ? { contentType: kindToMime(asset.kind) } : {}),
+    });
+    storageUrl = put.storageUrl;
+  } else {
+    const put = await args.blobStorage.put({
+      path: blobPath,
+      bytes,
+      contentHash,
+      ...(asset.kind ? { contentType: kindToMime(asset.kind) } : {}),
+    });
+    storageUrl = put.storageUrl;
+  }
+  return {
+    ...asset,
+    contentHash,
+    byteSize: asset.byteSize ?? bytes.byteLength,
+    storageUrl,
+  };
+}
+
+function stripShaPrefix(h: string): string {
+  return h.startsWith('sha256:') ? h.slice('sha256:'.length) : h;
+}
+
+function kindToMime(kind: string): string {
+  switch (kind) {
+    case 'image':
+      return 'image/octet-stream';
+    case 'svg':
+      return 'image/svg+xml';
+    case 'font':
+      return 'font/otf';
+    case 'video':
+      return 'video/mp4';
+    case 'icon':
+      return 'image/png';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+/**
+ * node-postgres returns `JSONB` columns as already-parsed objects. Some
+ * fake clients (and migrations) return strings instead. Accept both.
+ */
+function parseJsonbColumn(v: unknown): unknown {
+  if (v == null) return null;
+  if (typeof v === 'string') {
+    try {
+      return JSON.parse(v);
+    } catch {
+      return null;
+    }
+  }
+  return v;
+}

--- a/packages/atlas-design-snapshotter/src/content-hash.ts
+++ b/packages/atlas-design-snapshotter/src/content-hash.ts
@@ -1,0 +1,42 @@
+/**
+ * Content-hash helpers — the dedup spine.
+ *
+ * SHA-256 is the only algorithm — chosen because step5 §4 uses
+ * `sha256:<hex>` prefixed strings in the `design_assets.content_hash`
+ * column and because Node ships a streaming SHA-256 in the standard library
+ * (`crypto`). No external deps.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Returns `sha256:<hex>` to match step5 §4's stored format. */
+export function sha256(bytes: Uint8Array): string {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+/** Stable hash of a JSON-serialisable object. Used to fingerprint design
+ *  payloads, design tokens, etc. Object keys are sorted so insertion-order
+ *  changes don't move the hash.
+ */
+export function sha256Of(obj: unknown): string {
+  const canonical = canonicalJsonStringify(obj);
+  return sha256(Buffer.from(canonical, 'utf8'));
+}
+
+/**
+ * Deterministic JSON serialiser. Sorts object keys recursively. Arrays are
+ * preserved in source order (arrays carry meaning — sorting them would lose
+ * information).
+ */
+export function canonicalJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJsonStringify).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${canonicalJsonStringify(obj[k])}`);
+  return `{${parts.join(',')}}`;
+}

--- a/packages/atlas-design-snapshotter/src/diff.ts
+++ b/packages/atlas-design-snapshotter/src/diff.ts
@@ -1,0 +1,53 @@
+/**
+ * Diff utilities — summarisation of the structural `Diff` produced by the
+ * injected `diffDesigns` function (from @chiefaia/atlas-mapper).
+ *
+ * The `Diff` itself is opaque to this package — it's whatever atlas-mapper
+ * returns. We add a deterministic `summarise()` so the version-picker can
+ * render counts cheaply without parsing the full diff jsonb.
+ */
+
+import type { Diff, DiffReason, DiffSummary } from './types.js';
+
+const REASON_KEYS: ReadonlyArray<DiffReason> = [
+  'attrs_changed',
+  'position_changed',
+  'token_changed',
+  'copy_changed',
+  'asset_changed',
+];
+
+/**
+ * Produces a flat, JSON-serialisable summary of a `Diff`. Used as the
+ * `design_versions.diff_summary` value so the dashboard can render a one-liner
+ * per version without loading the full diff jsonb.
+ */
+export function summarise(diff: Diff): DiffSummary {
+  const reasonCounts: Record<DiffReason, number> = {
+    attrs_changed: 0,
+    position_changed: 0,
+    token_changed: 0,
+    copy_changed: 0,
+    asset_changed: 0,
+  };
+  for (const m of diff.modified) {
+    for (const r of m.reasons) {
+      // Defensive: a future diff producer could add a new reason; ignore
+      // unknown reasons so we never crash on a forward-compatible payload.
+      if (REASON_KEYS.includes(r)) {
+        reasonCounts[r] += 1;
+      }
+    }
+  }
+  return {
+    addedCount: diff.added.length,
+    removedCount: diff.removed.length,
+    modifiedCount: diff.modified.length,
+    reasonCounts,
+  };
+}
+
+/** Empty diff sentinel — used when there is no parent (v1) or no change. */
+export function emptyDiff(): Diff {
+  return { added: [], removed: [], modified: [] };
+}

--- a/packages/atlas-design-snapshotter/src/gdpr.ts
+++ b/packages/atlas-design-snapshotter/src/gdpr.ts
@@ -1,0 +1,128 @@
+/**
+ * GDPR delete — `deleteAllForTenant(tenantId)`.
+ *
+ * Drops every `design_versions` + `design_assets` row plus every blob for
+ * the tenant. Idempotent: re-running on an already-empty tenant returns
+ * `{ deletedVersionCount: 0, deletedBlobCount: 0 }` and never throws.
+ *
+ * Strategy:
+ *   1. Enumerate every `ux_uploads.id` belonging to the tenant.
+ *   2. Enumerate every `design_assets.storage_url` for those uploads.
+ *      Convert URLs to blob paths (the segment after the bucket root) so
+ *      the BYOC adapter can address them.
+ *   3. `DELETE FROM design_versions WHERE ux_upload_id IN (...)` —
+ *      cascades to `design_assets` via the ON DELETE CASCADE FK.
+ *   4. `DELETE FROM ux_uploads WHERE tenant_id = $1`.
+ *   5. For every collected blob path, `blobStorage.delete(path)` (idempotent
+ *      in the adapter contract).
+ *
+ * Step 5 is best-effort: a transient blob-delete failure is logged but does
+ * not roll back the DB delete — the row-level erasure is the legal
+ * requirement; orphan blobs are GC'd by the cross-tenant cleanup job.
+ */
+
+import { assertSafeSchemaName, q } from './sql.js';
+import { type BlobStorage, type PgQueryable, SnapshotterError } from './types.js';
+
+export interface GdprDeleteDeps {
+  pg: PgQueryable;
+  blobStorage: BlobStorage;
+  schema: string;
+  blobPathPrefix: string;
+}
+
+export async function deleteAllForTenant(
+  tenantId: string,
+  deps: GdprDeleteDeps,
+): Promise<{ deletedVersionCount: number; deletedBlobCount: number }> {
+  if (!tenantId || typeof tenantId !== 'string') {
+    throw new SnapshotterError('tenant_mismatch', 'deleteAllForTenant requires a tenantId');
+  }
+  assertSafeSchemaName(deps.schema);
+
+  // Find every upload for the tenant.
+  const uploadRes = await deps.pg.query<{ id: string }>(
+    `SELECT id FROM ${q(deps.schema, 'ux_uploads')} WHERE tenant_id = $1`,
+    [tenantId],
+  );
+  const uploadIds = uploadRes.rows.map((r) => r.id);
+  if (uploadIds.length === 0) {
+    return { deletedVersionCount: 0, deletedBlobCount: 0 };
+  }
+
+  // Snapshot every storage_url before the cascade wipes the rows.
+  const assetRes = await deps.pg.query<{ storage_url: string }>(
+    `SELECT DISTINCT storage_url
+       FROM ${q(deps.schema, 'design_assets')}
+      WHERE ux_upload_id = ANY($1::uuid[])`,
+    [uploadIds],
+  );
+  const blobPaths = assetRes.rows
+    .map((r) => storageUrlToBlobPath(r.storage_url, deps.blobPathPrefix))
+    .filter((p): p is string => p !== null);
+
+  // Cascade-delete versions first, then uploads. Wrapped in a transaction so
+  // a partial failure doesn't leave dangling rows.
+  await deps.pg.query('BEGIN');
+  let deletedVersionCount = 0;
+  try {
+    const versionDel = await deps.pg.query(
+      `DELETE FROM ${q(deps.schema, 'design_versions')}
+        WHERE ux_upload_id = ANY($1::uuid[])`,
+      [uploadIds],
+    );
+    deletedVersionCount = versionDel.rowCount ?? 0;
+    // design_assets cascades from design_versions via FK ON DELETE CASCADE.
+    // Belt-and-braces: nuke them explicitly too in case the FK is absent on
+    // this deployment.
+    await deps.pg.query(
+      `DELETE FROM ${q(deps.schema, 'design_assets')}
+        WHERE ux_upload_id = ANY($1::uuid[])`,
+      [uploadIds],
+    );
+    await deps.pg.query(
+      `DELETE FROM ${q(deps.schema, 'ux_uploads')} WHERE id = ANY($1::uuid[])`,
+      [uploadIds],
+    );
+    await deps.pg.query('COMMIT');
+  } catch (err) {
+    await deps.pg.query('ROLLBACK').catch(() => undefined);
+    throw err;
+  }
+
+  // Delete blobs best-effort. Failure here is logged but not fatal — the
+  // row-level erasure is what GDPR requires; orphan blobs are GC'd by the
+  // cross-tenant cleanup job.
+  let deletedBlobCount = 0;
+  for (const p of new Set(blobPaths)) {
+    try {
+      await deps.blobStorage.delete(p);
+      deletedBlobCount += 1;
+    } catch {
+      // intentionally swallowed — see comment above.
+    }
+  }
+  return { deletedVersionCount, deletedBlobCount };
+}
+
+/**
+ * Maps a `storage_url` (e.g. `s3://bucket/design-assets/<sha>`) back to the
+ * bucket-relative path the BYOC adapter expects. Returns `null` if the URL
+ * isn't recognisable so the caller can skip it without failing the wipe.
+ */
+function storageUrlToBlobPath(url: string, prefix: string): string | null {
+  if (!url) return null;
+  // Strip scheme.
+  const noScheme = url.replace(/^[a-z0-9+.-]+:\/\//, '');
+  // Strip bucket (first path segment).
+  const slash = noScheme.indexOf('/');
+  if (slash === -1) return null;
+  const path = noScheme.slice(slash + 1);
+  // Sanity-check the prefix.
+  if (!path.startsWith(prefix)) {
+    // Not one of ours — caller's responsibility (e.g. cross-tenant URLs).
+    // Return as-is and let the adapter no-op.
+    return path;
+  }
+  return path;
+}

--- a/packages/atlas-design-snapshotter/src/index.ts
+++ b/packages/atlas-design-snapshotter/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Public entry point for @chiefaia/atlas-design-snapshotter.
+ *
+ * Re-exports the factory, types, and the SQL/dedup helpers. Add future
+ * versions as parallel exports — never mutate v1.
+ */
+
+export { createDesignSnapshotter } from './snapshotter.js';
+
+export type {
+  AssetByteReader,
+  BlobStorage,
+  DesignAssetRow,
+  DesignSnapshotter,
+  DesignVersionRow,
+  Diff,
+  DiffDesignsFn,
+  DiffReason,
+  DiffSummary,
+  DomIdEntry,
+  ModifiedEntry,
+  NodeLevel,
+  NodeRole,
+  PgQueryable,
+  RenderableAsset,
+  RenderableComponentTree,
+  RenderableCopy,
+  RenderableDesign,
+  RenderableDesignTokens,
+  RenderableInteractivity,
+  RenderableNode,
+  RenderableRoute,
+  RenderableSharedComponent,
+  RevertInput,
+  SnapshotInput,
+  SnapshotterErrorCode,
+  SnapshotterOptions,
+} from './types.js';
+
+export { SnapshotterError } from './types.js';
+export { summarise, emptyDiff } from './diff.js';
+export { sha256, sha256Of, canonicalJsonStringify } from './content-hash.js';
+export { schemaDDL, assertSafeSchemaName } from './sql.js';

--- a/packages/atlas-design-snapshotter/src/read.ts
+++ b/packages/atlas-design-snapshotter/src/read.ts
@@ -1,0 +1,141 @@
+/**
+ * Read APIs — `getSnapshot`, `listVersions`, `getDiff`.
+ *
+ * These are pure-read; no mutation. All three accept opaque IDs (UUIDs) and
+ * return the persisted shape verbatim — including the JSONB columns, which
+ * we re-parse if the driver returns them as strings.
+ */
+
+import { emptyDiff } from './diff.js';
+import { assertSafeSchemaName, q } from './sql.js';
+import {
+  type Diff,
+  type DiffSummary,
+  type PgQueryable,
+  type RenderableDesign,
+  SnapshotterError,
+} from './types.js';
+
+export interface ReadDeps {
+  pg: PgQueryable;
+  schema: string;
+}
+
+export async function getSnapshot(designVersionId: string, deps: ReadDeps): Promise<RenderableDesign> {
+  assertSafeSchemaName(deps.schema);
+  const res = await deps.pg.query<{ rendered_design: unknown }>(
+    `SELECT rendered_design
+       FROM ${q(deps.schema, 'design_versions')}
+      WHERE id = $1
+      LIMIT 1`,
+    [designVersionId],
+  );
+  const row = res.rows[0];
+  if (!row) {
+    throw new SnapshotterError('design_version_not_found', `design_versions.id=${designVersionId}`);
+  }
+  const design = parseJsonbColumn(row.rendered_design);
+  if (!design) {
+    throw new SnapshotterError('design_version_not_found', `design_versions.id=${designVersionId} has no rendered_design`);
+  }
+  return design as RenderableDesign;
+}
+
+export async function listVersions(
+  uxUploadId: string,
+  deps: ReadDeps,
+): Promise<Array<{
+  designVersionId: string;
+  versionNumber: number;
+  parentVersionId: string | null;
+  createdAt: Date;
+  diffSummary: DiffSummary | null;
+  notes: string | null;
+}>> {
+  assertSafeSchemaName(deps.schema);
+  const res = await deps.pg.query<{
+    id: string;
+    version_number: number;
+    parent_version_id: string | null;
+    created_at: Date | string;
+    diff_summary: unknown;
+    notes: string | null;
+  }>(
+    `SELECT id, version_number, parent_version_id, created_at, diff_summary, notes
+       FROM ${q(deps.schema, 'design_versions')}
+      WHERE ux_upload_id = $1
+   ORDER BY version_number DESC`,
+    [uxUploadId],
+  );
+  return res.rows.map((r) => ({
+    designVersionId: r.id,
+    versionNumber: r.version_number,
+    parentVersionId: r.parent_version_id,
+    createdAt: typeof r.created_at === 'string' ? new Date(r.created_at) : r.created_at,
+    diffSummary: parseJsonbColumn(r.diff_summary) as DiffSummary | null,
+    notes: r.notes,
+  }));
+}
+
+/**
+ * Returns the diff between two arbitrary design versions. If `from` is the
+ * direct parent of `to`, returns the persisted `diff_from_parent` (cheap).
+ * Otherwise re-runs `diffDesigns` on the two payloads (expensive — only
+ * happens when the dashboard asks for a non-adjacent comparison).
+ */
+export async function getDiff(
+  fromVersionId: string,
+  toVersionId: string,
+  deps: ReadDeps & { diffDesigns: (a: RenderableDesign, b: RenderableDesign) => Diff },
+): Promise<Diff> {
+  assertSafeSchemaName(deps.schema);
+  if (fromVersionId === toVersionId) return emptyDiff();
+
+  // Fast path: `to`'s parent IS `from`. Pull the persisted diff.
+  const toRow = await loadVersionRow(toVersionId, deps);
+  if (!toRow) {
+    throw new SnapshotterError('design_version_not_found', `to=${toVersionId}`);
+  }
+  if (toRow.parent_version_id === fromVersionId && toRow.diff_from_parent) {
+    const persisted = parseJsonbColumn(toRow.diff_from_parent) as Diff | null;
+    if (persisted) return persisted;
+  }
+
+  // Slow path: pull both payloads, recompute.
+  const fromRow = await loadVersionRow(fromVersionId, deps);
+  if (!fromRow) {
+    throw new SnapshotterError('design_version_not_found', `from=${fromVersionId}`);
+  }
+  const fromDesign = parseJsonbColumn(fromRow.rendered_design) as RenderableDesign | null;
+  const toDesign = parseJsonbColumn(toRow.rendered_design) as RenderableDesign | null;
+  if (!fromDesign || !toDesign) {
+    throw new SnapshotterError('design_version_not_found', 'rendered_design missing on one of the two versions');
+  }
+  return deps.diffDesigns(fromDesign, toDesign);
+}
+
+interface VersionRow {
+  id: string;
+  parent_version_id: string | null;
+  diff_from_parent: unknown;
+  rendered_design: unknown;
+}
+
+async function loadVersionRow(id: string, deps: ReadDeps): Promise<VersionRow | null> {
+  const res = await deps.pg.query<VersionRow>(
+    `SELECT id, parent_version_id, diff_from_parent, rendered_design
+       FROM ${q(deps.schema, 'design_versions')}
+      WHERE id = $1
+      LIMIT 1`,
+    [id],
+  );
+  return res.rows[0] ?? null;
+}
+
+function parseJsonbColumn(v: unknown): unknown {
+  if (v == null) return null;
+  if (typeof v === 'string') {
+    try { return JSON.parse(v); } catch { return null; }
+  }
+  return v;
+}

--- a/packages/atlas-design-snapshotter/src/revert.ts
+++ b/packages/atlas-design-snapshotter/src/revert.ts
@@ -1,0 +1,103 @@
+/**
+ * Revert — the Time-Machine primitive.
+ *
+ * `revertToVersion(uxUploadId, versionNumber)` creates a new snapshot
+ * v(N+1) whose content equals v(versionNumber). Restoration is always a
+ * **forward** operation: we never mutate prior `design_versions` rows.
+ *
+ * This mirrors the SQL pattern from step5 spec §5.3 — INSERT a new row that
+ * copies the target version's `rendered_design`, with the new row's
+ * `parent_version_id` set to the current latest. The diff is computed from
+ * the current-latest to the target (i.e. how the design will visibly change).
+ */
+
+import { captureSnapshot, type CaptureDeps } from './capture.js';
+import { assertSafeSchemaName, q } from './sql.js';
+import {
+  type DesignVersionRow,
+  type PgQueryable,
+  type RenderableDesign,
+  type RevertInput,
+  SnapshotterError,
+} from './types.js';
+
+export async function revertToVersion(
+  input: RevertInput,
+  deps: CaptureDeps,
+): Promise<DesignVersionRow> {
+  assertSafeSchemaName(deps.schema);
+  if (!input.uxUploadId || typeof input.uxUploadId !== 'string') {
+    throw new SnapshotterError('invalid_revert_target', 'revertToVersion requires uxUploadId');
+  }
+  if (!Number.isInteger(input.versionNumber) || input.versionNumber < 1) {
+    throw new SnapshotterError('invalid_revert_target', 'versionNumber must be a positive integer', {
+      versionNumber: input.versionNumber,
+    });
+  }
+
+  const target = await loadVersion(input.uxUploadId, input.versionNumber, deps);
+  if (!target) {
+    throw new SnapshotterError(
+      'invalid_revert_target',
+      `No design_versions row for ux_upload_id=${input.uxUploadId} version_number=${input.versionNumber}`,
+      { uxUploadId: input.uxUploadId, versionNumber: input.versionNumber },
+    );
+  }
+
+  // Run captureSnapshot with the target design payload — this gives us
+  //   - automatic version_number bump
+  //   - automatic parent_version_id linkage
+  //   - diff vs. *current* latest (not the target)
+  //   - asset rows mirrored onto the new version
+  //   - a refreshed ux_uploads.rendered_design
+  // …all in one transaction, so we get the same audit trail as a fresh upload.
+  //
+  // The assets carry storageUrl already (they came from the prior persisted
+  // version), so no blob uploads happen on revert — it's pure metadata.
+  return captureSnapshot(
+    {
+      uxUploadId: input.uxUploadId,
+      design: stripStaleVersionId(target.renderableDesign),
+      notes: input.notes ?? `Revert to v${input.versionNumber}`,
+    },
+    deps,
+  );
+}
+
+async function loadVersion(
+  uxUploadId: string,
+  versionNumber: number,
+  deps: { pg: PgQueryable; schema: string },
+): Promise<{ id: string; renderableDesign: RenderableDesign } | null> {
+  const res = await deps.pg.query<{ id: string; rendered_design: unknown }>(
+    `SELECT id, rendered_design
+       FROM ${q(deps.schema, 'design_versions')}
+      WHERE ux_upload_id = $1 AND version_number = $2
+      LIMIT 1`,
+    [uxUploadId, versionNumber],
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  const design = parseJsonbColumn(row.rendered_design);
+  if (!design) {
+    throw new SnapshotterError('invalid_revert_target', 'target version has no rendered_design', {
+      designVersionId: row.id,
+    });
+  }
+  return { id: row.id, renderableDesign: design as RenderableDesign };
+}
+
+function stripStaleVersionId(d: RenderableDesign): RenderableDesign {
+  // captureSnapshot will stamp the new versionId; clear the old one so the
+  // payload is self-consistent on disk.
+  const { designVersionId: _ignored, ...rest } = d;
+  return rest;
+}
+
+function parseJsonbColumn(v: unknown): unknown {
+  if (v == null) return null;
+  if (typeof v === 'string') {
+    try { return JSON.parse(v); } catch { return null; }
+  }
+  return v;
+}

--- a/packages/atlas-design-snapshotter/src/snapshotter.ts
+++ b/packages/atlas-design-snapshotter/src/snapshotter.ts
@@ -1,0 +1,64 @@
+/**
+ * `createDesignSnapshotter` — the public entry point.
+ *
+ * Returns a `DesignSnapshotter` that wires the capture / revert / GDPR /
+ * read modules around a common set of injected dependencies. Construction
+ * never touches the network and never throws on missing data — it just
+ * builds a closure. The first `await` from any method is when DB or blob
+ * I/O happens.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { captureSnapshot } from './capture.js';
+import { deleteAllForTenant } from './gdpr.js';
+import { getDiff, getSnapshot, listVersions } from './read.js';
+import { revertToVersion } from './revert.js';
+import { assertSafeSchemaName } from './sql.js';
+import {
+  type DesignSnapshotter,
+  type SnapshotterOptions,
+} from './types.js';
+
+export function createDesignSnapshotter(opts: SnapshotterOptions): DesignSnapshotter {
+  assertSafeSchemaName(opts.schema);
+
+  const idGen = opts.idGen ?? (() => randomUUID());
+  const clock = opts.clock ?? (() => new Date());
+  const blobPathPrefix = opts.blobPathPrefix ?? 'design-assets';
+
+  const captureDeps = {
+    pg: opts.pg,
+    blobStorage: opts.blobStorage,
+    diffDesigns: opts.diffDesigns,
+    schema: opts.schema,
+    blobPathPrefix,
+    ...(opts.assetByteReader ? { assetByteReader: opts.assetByteReader } : {}),
+    idGen,
+    clock,
+  } as const;
+
+  const readDeps = {
+    pg: opts.pg,
+    schema: opts.schema,
+  };
+
+  return {
+    snapshot: (input) => captureSnapshot(input, captureDeps),
+    revertToVersion: (input) => revertToVersion(input, captureDeps),
+    deleteAllForTenant: (tenantId) =>
+      deleteAllForTenant(tenantId, {
+        pg: opts.pg,
+        blobStorage: opts.blobStorage,
+        schema: opts.schema,
+        blobPathPrefix,
+      }),
+    getSnapshot: (designVersionId) => getSnapshot(designVersionId, readDeps),
+    listVersions: (uxUploadId) => listVersions(uxUploadId, readDeps),
+    getDiff: (fromVersionId, toVersionId) =>
+      getDiff(fromVersionId, toVersionId, {
+        ...readDeps,
+        diffDesigns: opts.diffDesigns,
+      }),
+  };
+}

--- a/packages/atlas-design-snapshotter/src/sql.ts
+++ b/packages/atlas-design-snapshotter/src/sql.ts
@@ -1,0 +1,88 @@
+/**
+ * SQL fragments used by the snapshotter.
+ *
+ * Single source of truth so the per-tenant schema name is interpolated in
+ * exactly one place. We bind the schema name with a quoted identifier (not
+ * a `$1` parameter — Postgres doesn't allow parameterising schema names)
+ * after validating it through `assertSafeSchemaName` so injection is
+ * impossible.
+ *
+ * The DDL block (`SCHEMA_SQL`) is shipped here for test bootstrap +
+ * documentation. The owning package for the migration is
+ * `@chiefaia/meta-schema` per step5 spec §4.
+ */
+
+const SAFE_IDENT = /^[a-z_][a-z0-9_]*$/;
+
+export function assertSafeSchemaName(name: string): void {
+  if (!SAFE_IDENT.test(name)) {
+    throw new Error(
+      `Unsafe schema name: ${JSON.stringify(name)}. Must match /^[a-z_][a-z0-9_]*$/.`,
+    );
+  }
+}
+
+/**
+ * Returns a fully-qualified table name. `assertSafeSchemaName` MUST be called
+ * upstream — this helper does not re-check.
+ */
+export function q(schema: string, table: string): string {
+  return `"${schema}"."${table}"`;
+}
+
+// ---------------------------------------------------------------------------
+// DDL — verbatim from step5 spec §4, with column types kept identical.
+// ---------------------------------------------------------------------------
+
+export function schemaDDL(schema: string): string {
+  assertSafeSchemaName(schema);
+  return `
+CREATE SCHEMA IF NOT EXISTS "${schema}";
+
+CREATE TABLE IF NOT EXISTS "${schema}"."ux_uploads" (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            UUID NOT NULL,
+  business_proposal_id UUID NOT NULL,
+  source               TEXT NOT NULL,
+  source_metadata      JSONB NOT NULL,
+  uploaded_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rendered_design      JSONB,
+  status               TEXT NOT NULL DEFAULT 'uploading',
+  parse_diagnostics    JSONB,
+  parse_duration_ms    INT,
+  failure_reason       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "${schema}"."design_versions" (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ux_upload_id        UUID NOT NULL REFERENCES "${schema}"."ux_uploads"(id),
+  version_number      INT NOT NULL,
+  parent_version_id   UUID REFERENCES "${schema}"."design_versions"(id),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  diff_from_parent    JSONB,
+  diff_summary        JSONB,
+  notes               TEXT,
+  rendered_design     JSONB,
+  UNIQUE (ux_upload_id, version_number)
+);
+
+CREATE TABLE IF NOT EXISTS "${schema}"."design_assets" (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ux_upload_id        UUID NOT NULL REFERENCES "${schema}"."ux_uploads"(id) ON DELETE CASCADE,
+  design_version_id   UUID NOT NULL REFERENCES "${schema}"."design_versions"(id) ON DELETE CASCADE,
+  path                TEXT NOT NULL,
+  kind                TEXT NOT NULL,
+  content_hash        TEXT NOT NULL,
+  storage_url         TEXT NOT NULL,
+  size_bytes          BIGINT NOT NULL,
+  alt_text            TEXT,
+  intrinsic_w         INT,
+  intrinsic_h         INT,
+  is_placeholder      BOOLEAN NOT NULL DEFAULT false,
+  UNIQUE (design_version_id, path)
+);
+
+CREATE INDEX IF NOT EXISTS design_assets_hash_idx ON "${schema}"."design_assets"(content_hash);
+CREATE INDEX IF NOT EXISTS design_versions_upload_idx ON "${schema}"."design_versions"(ux_upload_id);
+`;
+}

--- a/packages/atlas-design-snapshotter/src/types.ts
+++ b/packages/atlas-design-snapshotter/src/types.ts
@@ -1,0 +1,336 @@
+/**
+ * @chiefaia/atlas-design-snapshotter — public types.
+ *
+ * Reference: research/step5_design_ingest_spec_2026.md §1 (RenderableDesign),
+ * §4 (design_versions/ux_uploads/design_assets schemas), §5.2 (Diff JSON
+ * shape), §5.3 (revert mechanic). See also research/atlas_module_spec_2026.md
+ * §2 (DOM-ID model).
+ *
+ * The shapes here mirror — but do NOT import from — @chiefaia/atlas-mapper.
+ * Decoupling at the type level keeps this package buildable while atlas-mapper
+ * is being authored, and respects the Option-E "parameterised public API"
+ * rule (AGENTS.md): every external coupling is a constructor parameter.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ---------------------------------------------------------------------------
+// RenderableDesign (the snapshot payload). Mirrors step5 §1 + the atlas-mapper
+// type projection. Only the fields the snapshotter actually reads are required;
+// everything else is optional pass-through so adapters can round-trip a full
+// payload without losing data.
+// ---------------------------------------------------------------------------
+
+export type NodeRole = 'page' | 'section' | 'widget' | 'story-host' | 'leaf' | 'shared-ref';
+export type NodeLevel = 'page' | 'section' | 'widget' | 'leaf';
+
+export interface RenderableNode {
+  domId?: string;
+  tag: string;
+  role: NodeRole;
+  level?: NodeLevel;
+  attrs?: Record<string, any>;
+  resolvedStyle?: Record<string, any>;
+  copyRefs?: string[];
+  assetRefs?: string[];
+  interactivityRefs?: string[];
+  sharedRef?: string | null;
+  bounds?: { x: number; y: number; w: number; h: number };
+  provenance?: Record<string, any>;
+  children?: RenderableNode[];
+}
+
+export interface RenderableComponentTree {
+  rootDomId?: string;
+  node: RenderableNode;
+}
+
+export interface RenderableCopy {
+  domId: string;
+  text: string;
+  locale?: string;
+  richText?: boolean;
+}
+
+/**
+ * Asset entry — exactly as it appears on `RenderableDesign.assets[]`. The
+ * snapshotter walks this list to upload + dedup blobs; on the way out it
+ * stamps `storageUrl` so consumers can render directly without a join.
+ */
+export interface RenderableAsset {
+  /** Logical path within the design (e.g. '/headshot.jpg'). */
+  path: string;
+  /** Adapter-side temporary upload path (e.g. /tmp/xyz.png). */
+  uploadedSourcePath?: string;
+  kind?: string;
+  alt?: string;
+  /** SHA-256 of the asset bytes. If absent on input, the snapshotter computes it. */
+  contentHash?: string;
+  byteSize?: number;
+  intrinsicSize?: { w: number; h: number };
+  /** Filled in by the snapshotter after blob upload. Format: e.g. `s3://...`. */
+  storageUrl?: string;
+  isPlaceholder?: boolean;
+}
+
+export interface RenderableDesignTokens {
+  colors?: Record<string, string>;
+  fonts?: Record<string, string>;
+  spacing?: Record<string, string>;
+  radii?: Record<string, string>;
+  shadows?: Record<string, string>;
+  rawSource?: string;
+}
+
+export interface RenderableRoute {
+  path: string;
+  title?: string;
+  componentTreeId: string;
+  breakpoints?: string[];
+  metadata?: Record<string, any>;
+}
+
+export interface RenderableInteractivity {
+  domId: string;
+  kind: string;
+  target?: string;
+  ariaLabel?: string;
+  rolesFromSource?: string[];
+}
+
+export interface RenderableSharedComponent {
+  id: string;
+  domIdPrefix?: string;
+  node: RenderableNode;
+  usedByDomIds?: string[];
+}
+
+export interface RenderableDesign {
+  /** Set on persisted snapshots; may be undefined on the in-flight payload. */
+  designVersionId?: string;
+  source?: string;
+  routes: RenderableRoute[];
+  componentTrees: Record<string, RenderableComponentTree>;
+  sharedComponents?: RenderableSharedComponent[];
+  copy?: RenderableCopy[];
+  assets?: RenderableAsset[];
+  interactivity?: RenderableInteractivity[];
+  designTokens?: RenderableDesignTokens;
+  sourceMetadata?: Record<string, any>;
+  site?: Record<string, any>;
+  rawSourceArtifacts?: Record<string, any>;
+  ingestDiagnostics?: Record<string, any>;
+  tenantId?: string;
+  businessProposalId?: string;
+  uploadedAt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Diff (the value that lands in design_versions.diff_from_parent).
+//
+// Mirrors @chiefaia/atlas-mapper's `DesignDiff` documented shape:
+//   { added: DomIdEntry[], removed: DomIdEntry[], modified: ModifiedEntry[] }
+//
+// We additionally project a compact `DiffSummary` (counts only) that the
+// dashboard's version-picker reads — it's expensive to render the full diff
+// for a 600-node design, but the summary is one row.
+// ---------------------------------------------------------------------------
+
+export type DiffReason =
+  | 'attrs_changed'
+  | 'position_changed'
+  | 'token_changed'
+  | 'copy_changed'
+  | 'asset_changed';
+
+export interface DomIdEntry {
+  domId: string;
+  parentDomId?: string | null;
+  role?: NodeRole;
+  tag?: string;
+  bounds?: { x: number; y: number; w: number; h: number };
+  attrs?: Record<string, any>;
+}
+
+export interface ModifiedEntry {
+  domId: string;
+  reasons: DiffReason[];
+  before?: DomIdEntry;
+  after?: DomIdEntry;
+}
+
+export interface Diff {
+  added: DomIdEntry[];
+  removed: DomIdEntry[];
+  modified: ModifiedEntry[];
+}
+
+export interface DiffSummary {
+  addedCount: number;
+  removedCount: number;
+  modifiedCount: number;
+  reasonCounts: Record<DiffReason, number>;
+}
+
+export type DiffDesignsFn = (parent: RenderableDesign, child: RenderableDesign) => Diff;
+
+// ---------------------------------------------------------------------------
+// Persisted row shapes.
+// ---------------------------------------------------------------------------
+
+export interface DesignVersionRow {
+  id: string;
+  uxUploadId: string;
+  versionNumber: number;
+  parentVersionId: string | null;
+  createdAt: Date;
+  diffFromParent: Diff | null;
+  diffSummary: DiffSummary | null;
+  notes: string | null;
+  /** Hydrated from ux_uploads.rendered_design on read APIs that ask for it. */
+  renderableDesign?: RenderableDesign;
+}
+
+export interface DesignAssetRow {
+  id: string;
+  uxUploadId: string;
+  designVersionId: string;
+  path: string;
+  kind: string;
+  contentHash: string;
+  storageUrl: string;
+  sizeBytes: number;
+  altText: string | null;
+  intrinsicW: number | null;
+  intrinsicH: number | null;
+  isPlaceholder: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Injection contracts.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal node-postgres-compatible client interface. `pg.Client`, `pg.Pool`,
+ * and our `FakePg` all satisfy this. The shape is intentionally narrow so
+ * implementations don't need to support cursors, COPY, or notifications.
+ *
+ * `query` must support the `$1, $2, ...` parameterisation node-postgres uses.
+ */
+export interface PgQueryable {
+  query<R = any>(text: string, params?: ReadonlyArray<unknown>): Promise<{ rows: R[]; rowCount?: number | null }>;
+}
+
+/**
+ * Pluggable per-tenant blob storage — the BYOC adapter interface. The default
+ * production adapter wraps S3 / R2 / GCS; tests inject `FakeBlobStorage`.
+ *
+ * Paths are tenant-bucket-relative — the adapter is responsible for tenant
+ * isolation (one bucket per tenant in the default deployment).
+ */
+export interface BlobStorage {
+  /**
+   * Idempotent. If a blob already exists at `path` and its sha matches the
+   * caller's hash, the adapter returns the existing URL without re-uploading.
+   * Returning `deduped: true` lets the snapshotter record the hit for metrics.
+   */
+  put(args: {
+    path: string;
+    bytes: Uint8Array;
+    contentHash: string;
+    contentType?: string;
+  }): Promise<{ storageUrl: string; deduped: boolean }>;
+
+  /** Returns metadata only — no body. Used to short-circuit dedup checks. */
+  head(path: string): Promise<{ exists: boolean; contentHash?: string; sizeBytes?: number }>;
+
+  /** Returns the bytes. */
+  get(path: string): Promise<Uint8Array>;
+
+  /** Idempotent — deleting a missing path is a no-op. */
+  delete(path: string): Promise<void>;
+
+  /** Lists paths under a prefix. Used by GDPR delete to enumerate per-tenant blobs. */
+  list(prefix: string): Promise<string[]>;
+}
+
+/** Function used to source raw bytes for an asset. */
+export type AssetByteReader = (asset: RenderableAsset) => Promise<Uint8Array>;
+
+// ---------------------------------------------------------------------------
+// Constructor + API arg shapes.
+// ---------------------------------------------------------------------------
+
+export interface SnapshotterOptions {
+  pg: PgQueryable;
+  blobStorage: BlobStorage;
+  diffDesigns: DiffDesignsFn;
+  /** Per-tenant Postgres schema — e.g. `caia_pt_dev`. */
+  schema: string;
+  /** Tenant identifier — used by GDPR delete + audit. */
+  tenantId: string;
+  /** Reads raw bytes for assets that don't already have `storageUrl`. */
+  assetByteReader?: AssetByteReader;
+  /** Default 'design-assets'. */
+  blobPathPrefix?: string;
+  /** Default `crypto.randomUUID`. */
+  idGen?: () => string;
+  /** Default `() => new Date()`. */
+  clock?: () => Date;
+}
+
+export interface SnapshotInput {
+  uxUploadId: string;
+  design: RenderableDesign;
+  notes?: string;
+}
+
+export interface RevertInput {
+  uxUploadId: string;
+  versionNumber: number;
+  notes?: string;
+}
+
+export interface DesignSnapshotter {
+  snapshot(input: SnapshotInput): Promise<DesignVersionRow>;
+  revertToVersion(input: RevertInput): Promise<DesignVersionRow>;
+  deleteAllForTenant(tenantId: string): Promise<{ deletedVersionCount: number; deletedBlobCount: number }>;
+  getSnapshot(designVersionId: string): Promise<RenderableDesign>;
+  listVersions(uxUploadId: string): Promise<Array<{
+    designVersionId: string;
+    versionNumber: number;
+    parentVersionId: string | null;
+    createdAt: Date;
+    diffSummary: DiffSummary | null;
+    notes: string | null;
+  }>>;
+  getDiff(fromVersionId: string, toVersionId: string): Promise<Diff>;
+}
+
+// ---------------------------------------------------------------------------
+// Errors.
+// ---------------------------------------------------------------------------
+
+export type SnapshotterErrorCode =
+  | 'ux_upload_not_found'
+  | 'design_version_not_found'
+  | 'invalid_renderable_design'
+  | 'invalid_revert_target'
+  | 'asset_bytes_missing'
+  | 'diff_failed'
+  | 'tenant_mismatch';
+
+export class SnapshotterError extends Error {
+  public readonly code: SnapshotterErrorCode;
+  public readonly context: Record<string, unknown>;
+
+  constructor(code: SnapshotterErrorCode, message: string, context: Record<string, unknown> = {}) {
+    super(message);
+    this.name = 'SnapshotterError';
+    this.code = code;
+    this.context = context;
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, SnapshotterError);
+    }
+  }
+}

--- a/packages/atlas-design-snapshotter/tests/content-hash.test.ts
+++ b/packages/atlas-design-snapshotter/tests/content-hash.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalJsonStringify, sha256, sha256Of } from '../src/index.js';
+
+describe('content-hash helpers', () => {
+  it('sha256 returns a sha256: prefixed hex string', () => {
+    const h = sha256(new Uint8Array([1, 2, 3]));
+    expect(h).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it('sha256 is deterministic on identical bytes', () => {
+    const b = new Uint8Array([9, 9, 9, 9]);
+    expect(sha256(b)).toBe(sha256(b));
+  });
+
+  it('sha256 differs across different bytes', () => {
+    expect(sha256(new Uint8Array([1]))).not.toBe(sha256(new Uint8Array([2])));
+  });
+
+  it('canonicalJsonStringify sorts keys', () => {
+    expect(canonicalJsonStringify({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  it('canonicalJsonStringify preserves array order', () => {
+    expect(canonicalJsonStringify([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('canonicalJsonStringify is recursive', () => {
+    const s = canonicalJsonStringify({ z: { b: 1, a: 2 }, a: [{ y: 1, x: 2 }] });
+    expect(s).toBe('{"a":[{"x":2,"y":1}],"z":{"a":2,"b":1}}');
+  });
+
+  it('sha256Of yields the same hash regardless of insertion order', () => {
+    expect(sha256Of({ a: 1, b: 2 })).toBe(sha256Of({ b: 2, a: 1 }));
+  });
+
+  it('sha256Of differs across different payloads', () => {
+    expect(sha256Of({ a: 1 })).not.toBe(sha256Of({ a: 2 }));
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/dedup.test.ts
+++ b/packages/atlas-design-snapshotter/tests/dedup.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter, sha256 } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeAssetBytes,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+const TENANT = 'tenant-a';
+
+function setup(opts: { bytes?: Uint8Array } = {}) {
+  const pg = new FakePg();
+  const blob = new FakeBlobStorage();
+  const bytes = opts.bytes ?? makeAssetBytes('photo');
+  pg.seedUxUpload({ id: 'u-1', tenant_id: TENANT });
+  pg.seedUxUpload({ id: 'u-2', tenant_id: TENANT });
+  const snap = createDesignSnapshotter({
+    pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+    idGen: counterIdGen(), clock: frozenClock(),
+    assetByteReader: async () => bytes,
+  });
+  return { pg, blob, snap, bytes };
+}
+
+describe('content-hash dedup', () => {
+  it('uploads the blob on the first reference', async () => {
+    const { blob, snap } = setup();
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/headshot.jpg', kind: 'image' }] }),
+    });
+    expect(blob.size()).toBe(1);
+  });
+
+  it('does NOT re-upload identical bytes across versions of the same upload', async () => {
+    const { blob, snap } = setup();
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/headshot.jpg', kind: 'image' }] }),
+    });
+    const putsAfterV1 = blob.putCalls;
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/headshot.jpg', kind: 'image' }] }),
+    });
+    expect(blob.size()).toBe(1);
+    expect(blob.dedupHits).toBeGreaterThanOrEqual(1);
+    // put still happens (the adapter short-circuits internally), but only one blob is materialised.
+    expect(blob.putCalls).toBeGreaterThan(putsAfterV1);
+  });
+
+  it('does NOT re-upload identical bytes across different ux_uploads (cross-version dedup spine)', async () => {
+    const { blob, snap } = setup();
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+    });
+    await snap.snapshot({
+      uxUploadId: 'u-2',
+      design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+    });
+    expect(blob.size()).toBe(1);
+    expect(blob.dedupHits).toBeGreaterThanOrEqual(1);
+  });
+
+  it('inserts one design_assets row per (designVersionId, path) reference', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+    });
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+    });
+    expect(pg.designAssets.length).toBe(2);
+    expect(pg.designAssets.map((r) => r.content_hash).every((h) => h === pg.designAssets[0]!.content_hash)).toBe(true);
+  });
+
+  it('different bytes produce different SHAs and different blobs', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u', tenant_id: TENANT });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+      idGen: counterIdGen(), clock: frozenClock(),
+      assetByteReader: async (a) => makeAssetBytes(a.path),
+    });
+    await snap.snapshot({
+      uxUploadId: 'u',
+      design: makeDesign({ assets: [
+        { path: '/a.jpg', kind: 'image' },
+        { path: '/b.jpg', kind: 'image' },
+      ] }),
+    });
+    expect(blob.size()).toBe(2);
+  });
+
+  it('content_hash matches sha256() applied to the input bytes', async () => {
+    const bytes = makeAssetBytes('photo');
+    const expected = sha256(bytes);
+    const { pg, snap } = setup({ bytes });
+    await snap.snapshot({
+      uxUploadId: 'u-1',
+      design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+    });
+    expect(pg.designAssets[0]!.content_hash).toBe(expected);
+  });
+
+  it('throws asset_bytes_missing when no assetByteReader is provided', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u', tenant_id: TENANT });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+      idGen: counterIdGen(), clock: frozenClock(),
+      // no assetByteReader
+    });
+    await expect(
+      snap.snapshot({
+        uxUploadId: 'u',
+        design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+      }),
+    ).rejects.toMatchObject({ code: 'asset_bytes_missing' });
+  });
+
+  it('skips asset upload when the design already carries storageUrl + contentHash', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u', tenant_id: TENANT });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    await snap.snapshot({
+      uxUploadId: 'u',
+      design: makeDesign({ assets: [
+        { path: '/h.jpg', kind: 'image', contentHash: 'sha256:abc', storageUrl: 's3://b/x', byteSize: 5 },
+      ] }),
+    });
+    expect(blob.putCalls).toBe(0);
+    expect(pg.designAssets[0]!.storage_url).toBe('s3://b/x');
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/diff.test.ts
+++ b/packages/atlas-design-snapshotter/tests/diff.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter, emptyDiff, summarise } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+const TENANT = 'tenant-a';
+
+function setup() {
+  const pg = new FakePg();
+  const blob = new FakeBlobStorage();
+  const snap = createDesignSnapshotter({
+    pg,
+    blobStorage: blob,
+    diffDesigns: fakeDiff,
+    schema: SCHEMA,
+    tenantId: TENANT,
+    idGen: counterIdGen(),
+    clock: frozenClock(),
+  });
+  pg.seedUxUpload({ id: 'upload-1', tenant_id: TENANT });
+  return { pg, blob, snap };
+}
+
+describe('diff-from-parent', () => {
+  it('summarises an empty diff with all-zero counts', () => {
+    const s = summarise(emptyDiff());
+    expect(s.addedCount).toBe(0);
+    expect(s.modifiedCount).toBe(0);
+    expect(s.reasonCounts.attrs_changed).toBe(0);
+  });
+
+  it('counts every reason on every modified entry', () => {
+    const s = summarise({
+      added: [],
+      removed: [],
+      modified: [
+        { domId: 'a', reasons: ['attrs_changed', 'copy_changed'] },
+        { domId: 'b', reasons: ['copy_changed'] },
+      ],
+    });
+    expect(s.reasonCounts.attrs_changed).toBe(1);
+    expect(s.reasonCounts.copy_changed).toBe(2);
+  });
+
+  it('ignores unknown reasons (forward-compatible)', () => {
+    const s = summarise({
+      added: [],
+      removed: [],
+      modified: [{ domId: 'a', reasons: ['something_new' as any] }],
+    });
+    expect(s.modifiedCount).toBe(1);
+    expect(Object.values(s.reasonCounts).every((n) => n === 0)).toBe(true);
+  });
+
+  it('persists the full diff on v2 and exposes it via getDiff(v1, v2)', async () => {
+    const { snap } = setup();
+    const v1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v2 = await snap.snapshot({
+      uxUploadId: 'upload-1',
+      design: makeDesign({
+        componentTrees: {
+          home: {
+            rootDomId: 'page-home',
+            node: {
+              domId: 'page-home',
+              tag: 'main',
+              role: 'page',
+              children: [
+                { domId: 'page-home>section-newhero', tag: 'section', role: 'section' },
+              ],
+            },
+          },
+        },
+      }),
+    });
+    const diff = await snap.getDiff(v1.id, v2.id);
+    expect(diff.added.some((e) => e.domId === 'page-home>section-newhero')).toBe(true);
+    expect(diff.removed.some((e) => e.domId === 'page-home>section-hero')).toBe(true);
+  });
+
+  it('getDiff between non-adjacent versions falls back to recompute', async () => {
+    const { snap } = setup();
+    const v1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v3 = await snap.snapshot({
+      uxUploadId: 'upload-1',
+      design: makeDesign({
+        componentTrees: {
+          home: {
+            rootDomId: 'page-home',
+            node: { domId: 'page-home', tag: 'main', role: 'page', children: [] },
+          },
+        },
+      }),
+    });
+    const diff = await snap.getDiff(v1.id, v3.id);
+    expect(diff.removed.length).toBeGreaterThan(0);
+  });
+
+  it('getDiff between identical versions returns empty', async () => {
+    const { snap } = setup();
+    const v = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const diff = await snap.getDiff(v.id, v.id);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.modified).toEqual([]);
+  });
+
+  it('wraps a thrown diffDesigns in SnapshotterError diff_failed', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'upload-1', tenant_id: TENANT });
+    const snap = createDesignSnapshotter({
+      pg,
+      blobStorage: blob,
+      diffDesigns: () => { throw new Error('boom'); },
+      schema: SCHEMA,
+      tenantId: TENANT,
+      idGen: counterIdGen(),
+      clock: frozenClock(),
+    });
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await expect(
+      snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() }),
+    ).rejects.toMatchObject({ code: 'diff_failed' });
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/fakes.ts
+++ b/packages/atlas-design-snapshotter/tests/fakes.ts
@@ -1,0 +1,448 @@
+/**
+ * In-memory fakes for the snapshotter's three injection points: Postgres,
+ * BlobStorage, and `diffDesigns`. Each is intentionally small — just enough
+ * to exercise every branch of the production code paths.
+ *
+ * The fake Postgres parses the SQL the snapshotter emits via a regex match
+ * (we own the SQL strings, so we can keep the matcher tight). Real
+ * production code runs against node-postgres; the integration test covers
+ * that path.
+ */
+
+import type {
+  BlobStorage,
+  Diff,
+  DiffDesignsFn,
+  PgQueryable,
+  RenderableDesign,
+} from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// FakeBlobStorage
+// ---------------------------------------------------------------------------
+
+export class FakeBlobStorage implements BlobStorage {
+  private readonly blobs = new Map<string, { bytes: Uint8Array; contentHash: string; storageUrl: string; contentType?: string }>();
+  public putCalls = 0;
+  public dedupHits = 0;
+  public deleteCalls = 0;
+  public urlScheme: string;
+  public bucket: string;
+
+  constructor(opts: { urlScheme?: string; bucket?: string } = {}) {
+    this.urlScheme = opts.urlScheme ?? 's3';
+    this.bucket = opts.bucket ?? 'caia-tenant-test';
+  }
+
+  async put(args: { path: string; bytes: Uint8Array; contentHash: string; contentType?: string }): Promise<{ storageUrl: string; deduped: boolean }> {
+    this.putCalls += 1;
+    const existing = this.blobs.get(args.path);
+    if (existing && existing.contentHash === args.contentHash) {
+      this.dedupHits += 1;
+      return { storageUrl: existing.storageUrl, deduped: true };
+    }
+    const storageUrl = `${this.urlScheme}://${this.bucket}/${args.path}`;
+    this.blobs.set(args.path, {
+      bytes: args.bytes,
+      contentHash: args.contentHash,
+      storageUrl,
+      ...(args.contentType ? { contentType: args.contentType } : {}),
+    });
+    return { storageUrl, deduped: false };
+  }
+
+  async head(path: string): Promise<{ exists: boolean; contentHash?: string; sizeBytes?: number }> {
+    const b = this.blobs.get(path);
+    if (!b) return { exists: false };
+    return { exists: true, contentHash: b.contentHash, sizeBytes: b.bytes.byteLength };
+  }
+
+  async get(path: string): Promise<Uint8Array> {
+    const b = this.blobs.get(path);
+    if (!b) throw new Error(`blob not found: ${path}`);
+    return b.bytes;
+  }
+
+  async delete(path: string): Promise<void> {
+    this.deleteCalls += 1;
+    this.blobs.delete(path);
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    return [...this.blobs.keys()].filter((k) => k.startsWith(prefix));
+  }
+
+  size(): number {
+    return this.blobs.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FakePg — in-memory Postgres surrogate.
+//
+// Maintains tables for ux_uploads / design_versions / design_assets keyed by
+// (schema, tableName). Parses the queries the snapshotter emits via simple
+// regex matchers. Throws on unrecognised SQL — that's a signal a new SQL
+// shape was added and the fake needs updating.
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+interface UxUploadRow {
+  id: string;
+  tenant_id: string;
+  rendered_design: unknown;
+  status: string;
+}
+
+interface DesignVersionRow {
+  id: string;
+  ux_upload_id: string;
+  version_number: number;
+  parent_version_id: string | null;
+  created_at: Date;
+  diff_from_parent: unknown;
+  diff_summary: unknown;
+  notes: string | null;
+  rendered_design: unknown;
+}
+
+interface DesignAssetRow {
+  id: string;
+  ux_upload_id: string;
+  design_version_id: string;
+  path: string;
+  kind: string;
+  content_hash: string;
+  storage_url: string;
+  size_bytes: number;
+  alt_text: string | null;
+  intrinsic_w: number | null;
+  intrinsic_h: number | null;
+  is_placeholder: boolean;
+}
+
+export class FakePg implements PgQueryable {
+  public uxUploads = new Map<string, UxUploadRow>();
+  public designVersions: DesignVersionRow[] = [];
+  public designAssets: DesignAssetRow[] = [];
+  public txDepth = 0;
+  public committedAt = 0;
+  public rolledBack = 0;
+  public queriesSeen: string[] = [];
+  /** When true, the next non-control query throws. Used to test rollback. */
+  public failNextQuery: Error | null = null;
+  /** Fail on the next INSERT statement (post-BEGIN). Used for rollback tests. */
+  public failNextInsert: Error | null = null;
+
+  // Per-spec test seeding helper. Lets each test set up an upload row in one
+  // line rather than constructing the SQL inline.
+  seedUxUpload(row: Partial<UxUploadRow> & { id: string; tenant_id: string }): void {
+    this.uxUploads.set(row.id, {
+      id: row.id,
+      tenant_id: row.tenant_id,
+      rendered_design: row.rendered_design ?? null,
+      status: row.status ?? 'parsing',
+    });
+  }
+
+  async query<R = any>(text: string, params: ReadonlyArray<unknown> = []): Promise<{ rows: R[]; rowCount: number | null }> {
+    this.queriesSeen.push(text);
+    const trimmed = text.trim();
+    const upper = trimmed.toUpperCase();
+
+    // Tx controls — never throw, never count toward failNextQuery.
+    if (upper === 'BEGIN') {
+      this.txDepth += 1;
+      return { rows: [], rowCount: null };
+    }
+    if (upper === 'COMMIT') {
+      this.txDepth = Math.max(0, this.txDepth - 1);
+      this.committedAt += 1;
+      return { rows: [], rowCount: null };
+    }
+    if (upper === 'ROLLBACK') {
+      this.txDepth = Math.max(0, this.txDepth - 1);
+      this.rolledBack += 1;
+      return { rows: [], rowCount: null };
+    }
+
+    if (this.failNextQuery) {
+      const err = this.failNextQuery;
+      this.failNextQuery = null;
+      throw err;
+    }
+    if (this.failNextInsert && upper.startsWith('INSERT')) {
+      const err = this.failNextInsert;
+      this.failNextInsert = null;
+      throw err;
+    }
+
+    // SELECT id, version_number, rendered_design FROM ...design_versions WHERE ux_upload_id=$1 ORDER BY version_number DESC LIMIT 1
+    if (/SELECT id, version_number, rendered_design[\s\S]*FROM[\s\S]*"design_versions"[\s\S]*ORDER BY version_number DESC[\s\S]*LIMIT 1/i.test(text)) {
+      const uxUploadId = String(params[0]);
+      const candidates = this.designVersions
+        .filter((r) => r.ux_upload_id === uxUploadId)
+        .sort((a, b) => b.version_number - a.version_number);
+      const row = candidates[0];
+      return { rows: row ? ([{ id: row.id, version_number: row.version_number, rendered_design: row.rendered_design }] as R[]) : [], rowCount: row ? 1 : 0 };
+    }
+
+    // SELECT id, rendered_design FROM ...design_versions WHERE ux_upload_id=$1 AND version_number=$2 LIMIT 1
+    if (/SELECT id, rendered_design[\s\S]*FROM[\s\S]*"design_versions"[\s\S]*WHERE ux_upload_id = \$1 AND version_number = \$2/i.test(text)) {
+      const uxUploadId = String(params[0]);
+      const versionNumber = Number(params[1]);
+      const row = this.designVersions.find((r) => r.ux_upload_id === uxUploadId && r.version_number === versionNumber);
+      return { rows: row ? ([{ id: row.id, rendered_design: row.rendered_design }] as R[]) : [], rowCount: row ? 1 : 0 };
+    }
+
+    // SELECT rendered_design FROM ...design_versions WHERE id=$1 LIMIT 1
+    if (/SELECT rendered_design[\s\S]*FROM[\s\S]*"design_versions"[\s\S]*WHERE id = \$1[\s\S]*LIMIT 1/i.test(text)) {
+      const id = String(params[0]);
+      const row = this.designVersions.find((r) => r.id === id);
+      return { rows: row ? ([{ rendered_design: row.rendered_design }] as R[]) : [], rowCount: row ? 1 : 0 };
+    }
+
+    // SELECT id, version_number, parent_version_id, created_at, diff_summary, notes FROM ... ORDER BY version_number DESC
+    if (/SELECT id, version_number, parent_version_id, created_at, diff_summary, notes/i.test(text)) {
+      const uxUploadId = String(params[0]);
+      const rows = this.designVersions
+        .filter((r) => r.ux_upload_id === uxUploadId)
+        .sort((a, b) => b.version_number - a.version_number)
+        .map((r) => ({
+          id: r.id,
+          version_number: r.version_number,
+          parent_version_id: r.parent_version_id,
+          created_at: r.created_at,
+          diff_summary: r.diff_summary,
+          notes: r.notes,
+        }));
+      return { rows: rows as R[], rowCount: rows.length };
+    }
+
+    // SELECT id, parent_version_id, diff_from_parent, rendered_design FROM ... WHERE id=$1
+    if (/SELECT id, parent_version_id, diff_from_parent, rendered_design/i.test(text)) {
+      const id = String(params[0]);
+      const row = this.designVersions.find((r) => r.id === id);
+      return { rows: row ? ([{
+        id: row.id,
+        parent_version_id: row.parent_version_id,
+        diff_from_parent: row.diff_from_parent,
+        rendered_design: row.rendered_design,
+      }] as R[]) : [], rowCount: row ? 1 : 0 };
+    }
+
+    // SELECT id FROM ...ux_uploads WHERE tenant_id=$1
+    if (/SELECT id FROM[\s\S]*"ux_uploads"[\s\S]*WHERE tenant_id = \$1/i.test(text)) {
+      const tenantId = String(params[0]);
+      const rows = [...this.uxUploads.values()]
+        .filter((u) => u.tenant_id === tenantId)
+        .map((u) => ({ id: u.id }));
+      return { rows: rows as R[], rowCount: rows.length };
+    }
+
+    // SELECT DISTINCT storage_url FROM ...design_assets WHERE ux_upload_id = ANY($1::uuid[])
+    if (/SELECT DISTINCT storage_url/i.test(text)) {
+      const ids = (params[0] as string[]) ?? [];
+      const set = new Set<string>();
+      for (const a of this.designAssets) {
+        if (ids.includes(a.ux_upload_id)) set.add(a.storage_url);
+      }
+      return { rows: [...set].map((s) => ({ storage_url: s })) as R[], rowCount: set.size };
+    }
+
+    // INSERT INTO ...design_versions
+    if (/INSERT INTO[\s\S]*"design_versions"/i.test(text)) {
+      const [id, uxUploadId, versionNumber, parentVersionId, createdAt, diffFromParent, diffSummary, notes, renderedDesign] = params;
+      this.designVersions.push({
+        id: String(id),
+        ux_upload_id: String(uxUploadId),
+        version_number: Number(versionNumber),
+        parent_version_id: parentVersionId == null ? null : String(parentVersionId),
+        created_at: createdAt as Date,
+        diff_from_parent: diffFromParent,
+        diff_summary: diffSummary,
+        notes: notes == null ? null : String(notes),
+        rendered_design: renderedDesign,
+      });
+      return { rows: [] as R[], rowCount: 1 };
+    }
+
+    // INSERT INTO ...design_assets
+    if (/INSERT INTO[\s\S]*"design_assets"/i.test(text)) {
+      const [id, uxUploadId, designVersionId, path, kind, contentHash, storageUrl, sizeBytes, altText, intrinsicW, intrinsicH, isPlaceholder] = params;
+      const dvId = String(designVersionId);
+      const p = String(path);
+      // ON CONFLICT DO NOTHING — skip duplicates.
+      const dup = this.designAssets.find((a) => a.design_version_id === dvId && a.path === p);
+      if (dup) return { rows: [] as R[], rowCount: 0 };
+      this.designAssets.push({
+        id: String(id),
+        ux_upload_id: String(uxUploadId),
+        design_version_id: dvId,
+        path: p,
+        kind: String(kind),
+        content_hash: String(contentHash),
+        storage_url: String(storageUrl),
+        size_bytes: Number(sizeBytes),
+        alt_text: altText == null ? null : String(altText),
+        intrinsic_w: intrinsicW == null ? null : Number(intrinsicW),
+        intrinsic_h: intrinsicH == null ? null : Number(intrinsicH),
+        is_placeholder: Boolean(isPlaceholder),
+      });
+      return { rows: [] as R[], rowCount: 1 };
+    }
+
+    // UPDATE ...ux_uploads SET rendered_design=$1, status='parsed' WHERE id=$2
+    if (/UPDATE[\s\S]*"ux_uploads"[\s\S]*SET rendered_design/i.test(text)) {
+      const [renderedDesign, id] = params;
+      const row = this.uxUploads.get(String(id));
+      if (row) {
+        row.rendered_design = renderedDesign;
+        row.status = 'parsed';
+      }
+      return { rows: [] as R[], rowCount: row ? 1 : 0 };
+    }
+
+    // DELETE FROM ...design_versions WHERE ux_upload_id = ANY($1::uuid[])
+    if (/DELETE FROM[\s\S]*"design_versions"/i.test(text)) {
+      const ids = (params[0] as string[]) ?? [];
+      const before = this.designVersions.length;
+      this.designVersions = this.designVersions.filter((r) => !ids.includes(r.ux_upload_id));
+      return { rows: [] as R[], rowCount: before - this.designVersions.length };
+    }
+
+    // DELETE FROM ...design_assets WHERE ux_upload_id = ANY($1::uuid[])
+    if (/DELETE FROM[\s\S]*"design_assets"/i.test(text)) {
+      const ids = (params[0] as string[]) ?? [];
+      const before = this.designAssets.length;
+      this.designAssets = this.designAssets.filter((r) => !ids.includes(r.ux_upload_id));
+      return { rows: [] as R[], rowCount: before - this.designAssets.length };
+    }
+
+    // DELETE FROM ...ux_uploads WHERE id = ANY($1::uuid[])
+    if (/DELETE FROM[\s\S]*"ux_uploads"/i.test(text)) {
+      const ids = (params[0] as string[]) ?? [];
+      let removed = 0;
+      for (const id of ids) {
+        if (this.uxUploads.delete(id)) removed += 1;
+      }
+      return { rows: [] as R[], rowCount: removed };
+    }
+
+    throw new Error(`FakePg: unrecognised query:\n${text}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// fakeDiff — deterministic, structural diff over componentTrees.
+//
+// Mirrors the documented atlas-mapper shape: { added, removed, modified[] }.
+// Production code injects the real atlas-mapper.diffDesigns; tests use this
+// stand-in so we don't depend on atlas-mapper's source being finished.
+// ---------------------------------------------------------------------------
+
+export const fakeDiff: DiffDesignsFn = (parent, child) => {
+  const parentIds = collectDomIds(parent);
+  const childIds = collectDomIds(child);
+
+  const added: Diff['added'] = [];
+  const removed: Diff['removed'] = [];
+  const modified: Diff['modified'] = [];
+
+  for (const [id, node] of childIds) {
+    if (!parentIds.has(id)) {
+      added.push({ domId: id, tag: node.tag, role: node.role });
+    }
+  }
+  for (const [id, node] of parentIds) {
+    if (!childIds.has(id)) {
+      removed.push({ domId: id, tag: node.tag, role: node.role });
+    } else {
+      const after = childIds.get(id)!;
+      const reasons: Diff['modified'][number]['reasons'] = [];
+      if (JSON.stringify(node.attrs ?? {}) !== JSON.stringify(after.attrs ?? {})) {
+        reasons.push('attrs_changed');
+      }
+      if (reasons.length > 0) {
+        modified.push({ domId: id, reasons, before: { domId: id, tag: node.tag }, after: { domId: id, tag: after.tag } });
+      }
+    }
+  }
+  return { added, removed, modified };
+};
+
+function collectDomIds(d: RenderableDesign): Map<string, { tag: string; role: any; attrs?: any }> {
+  const out = new Map<string, { tag: string; role: any; attrs?: any }>();
+  for (const tree of Object.values(d.componentTrees ?? {})) {
+    walk(tree.node, out);
+  }
+  return out;
+}
+
+function walk(node: any, out: Map<string, { tag: string; role: any; attrs?: any }>): void {
+  if (node?.domId) {
+    out.set(node.domId, { tag: node.tag, role: node.role, attrs: node.attrs });
+  }
+  for (const c of node?.children ?? []) walk(c, out);
+}
+
+// ---------------------------------------------------------------------------
+// Sample-payload builders
+// ---------------------------------------------------------------------------
+
+export function makeDesign(overrides: Partial<RenderableDesign> = {}): RenderableDesign {
+  return {
+    source: 'cd-zip',
+    routes: [{ path: '/', componentTreeId: 'home' }],
+    componentTrees: {
+      home: {
+        rootDomId: 'page-home',
+        node: {
+          domId: 'page-home',
+          tag: 'main',
+          role: 'page',
+          children: [
+            {
+              domId: 'page-home>section-hero',
+              tag: 'section',
+              role: 'section',
+              children: [
+                {
+                  domId: 'page-home>section-hero>widget-headline',
+                  tag: 'h1',
+                  role: 'widget',
+                  attrs: { className: 'text-3xl' },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    designTokens: { colors: { '--brand': '#222' } },
+    assets: [],
+    copy: [],
+    interactivity: [],
+    ...overrides,
+  };
+}
+
+export function makeAssetBytes(seed: string): Uint8Array {
+  // Deterministic bytes so SHA matches across tests.
+  const out = new Uint8Array(32);
+  for (let i = 0; i < seed.length && i < 32; i++) out[i] = seed.charCodeAt(i);
+  return out;
+}
+
+/** Deterministic id generator — yields 'id-1', 'id-2', ... */
+export function counterIdGen(): () => string {
+  let n = 0;
+  return () => `id-${++n}`;
+}
+
+/** Frozen clock — always returns the same Date instance. */
+export function frozenClock(at: string = '2026-05-23T00:00:00Z'): () => Date {
+  const d = new Date(at);
+  return () => d;
+}

--- a/packages/atlas-design-snapshotter/tests/gdpr.test.ts
+++ b/packages/atlas-design-snapshotter/tests/gdpr.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeAssetBytes,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+
+describe('deleteAllForTenant — GDPR right-to-erasure', () => {
+  it('is idempotent on an empty tenant', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: 'empty',
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    const r = await snap.deleteAllForTenant('empty');
+    expect(r.deletedVersionCount).toBe(0);
+    expect(r.deletedBlobCount).toBe(0);
+  });
+
+  it('drops all design_versions rows for the tenant', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u-a', tenant_id: 'tenant-a' });
+    pg.seedUxUpload({ id: 'u-a2', tenant_id: 'tenant-a' });
+    pg.seedUxUpload({ id: 'u-b', tenant_id: 'tenant-b' });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: 'tenant-a',
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    await snap.snapshot({ uxUploadId: 'u-a', design: makeDesign() });
+    await snap.snapshot({ uxUploadId: 'u-a2', design: makeDesign() });
+    await snap.snapshot({ uxUploadId: 'u-b', design: makeDesign() });
+
+    const r = await snap.deleteAllForTenant('tenant-a');
+    expect(r.deletedVersionCount).toBe(2);
+    expect(pg.designVersions.map((v) => v.ux_upload_id)).toEqual(['u-b']);
+    expect(pg.uxUploads.has('u-a')).toBe(false);
+    expect(pg.uxUploads.has('u-a2')).toBe(false);
+    expect(pg.uxUploads.has('u-b')).toBe(true);
+  });
+
+  it('deletes blobs via the BYOC adapter', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u-a', tenant_id: 'tenant-a' });
+    const bytes = makeAssetBytes('photo');
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: 'tenant-a',
+      idGen: counterIdGen(), clock: frozenClock(),
+      assetByteReader: async () => bytes,
+    });
+    await snap.snapshot({
+      uxUploadId: 'u-a',
+      design: makeDesign({ assets: [{ path: '/p.png', kind: 'image' }] }),
+    });
+    expect(blob.size()).toBe(1);
+
+    const r = await snap.deleteAllForTenant('tenant-a');
+    expect(r.deletedBlobCount).toBeGreaterThanOrEqual(1);
+    expect(blob.size()).toBe(0);
+  });
+
+  it('is safe to re-run (still idempotent after one successful wipe)', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u-a', tenant_id: 'tenant-a' });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: 'tenant-a',
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    await snap.snapshot({ uxUploadId: 'u-a', design: makeDesign() });
+    await snap.deleteAllForTenant('tenant-a');
+    const again = await snap.deleteAllForTenant('tenant-a');
+    expect(again.deletedVersionCount).toBe(0);
+    expect(again.deletedBlobCount).toBe(0);
+  });
+
+  it('rejects an empty tenantId', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: 'tenant-a',
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    await expect(snap.deleteAllForTenant('')).rejects.toMatchObject({ code: 'tenant_mismatch' });
+  });
+
+  it('swallows blob-delete errors so DB delete is final', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    blob.delete = async () => { throw new Error('s3 unreachable'); };
+    pg.seedUxUpload({ id: 'u-a', tenant_id: 'tenant-a' });
+    const bytes = makeAssetBytes('photo');
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: 'tenant-a',
+      idGen: counterIdGen(), clock: frozenClock(),
+      assetByteReader: async () => bytes,
+    });
+    await snap.snapshot({
+      uxUploadId: 'u-a',
+      design: makeDesign({ assets: [{ path: '/p.png', kind: 'image' }] }),
+    });
+    const r = await snap.deleteAllForTenant('tenant-a');
+    // Versions deleted; blob delete count is 0 because every call errored.
+    expect(r.deletedVersionCount).toBe(1);
+    expect(r.deletedBlobCount).toBe(0);
+    expect(pg.uxUploads.has('u-a')).toBe(false);
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/integration.test.ts
+++ b/packages/atlas-design-snapshotter/tests/integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration test — runs ONLY when a real Postgres + S3-compatible blob
+ * store are available via environment variables. The local-dev rule of
+ * thumb (matches step5 spec §9.4's regression harness):
+ *
+ *   DATABASE_URL=postgres://user:pw@localhost:5432/caia_dev \
+ *   S3_ENDPOINT=http://localhost:9000 \
+ *   S3_BUCKET=caia-test-bucket \
+ *   S3_ACCESS_KEY_ID=minioadmin \
+ *   S3_SECRET_ACCESS_KEY=minioadmin \
+ *   pnpm --filter @chiefaia/atlas-design-snapshotter test:integration
+ *
+ * When the env is incomplete the suite skips itself — CI without these set
+ * still passes green. The Cloudflare R2 deployment uses the same shape via
+ * S3-compatible endpoint, so this one test covers both real backends.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter, schemaDDL, type BlobStorage, type PgQueryable } from '../src/index.js';
+import { fakeDiff, makeAssetBytes, makeDesign } from './fakes.js';
+
+const HAS_PG = !!process.env['DATABASE_URL'];
+const HAS_S3 =
+  !!process.env['S3_ENDPOINT'] &&
+  !!process.env['S3_BUCKET'] &&
+  !!process.env['S3_ACCESS_KEY_ID'] &&
+  !!process.env['S3_SECRET_ACCESS_KEY'];
+
+const RUN = HAS_PG && HAS_S3;
+
+describe.skipIf(!RUN)('integration: real Postgres + S3-compatible store', () => {
+  it('captures a snapshot, dedups across versions, then deletes for GDPR', async () => {
+    const { pg, dispose: disposePg } = await openPg();
+    const { blobStorage, dispose: disposeBlob, bucket } = await openS3();
+    const schema = `caia_test_${Date.now()}`;
+    try {
+      await pg.query(schemaDDL(schema));
+      const uxUploadId = (await pg.query<{ id: string }>(
+        `INSERT INTO "${schema}"."ux_uploads"(tenant_id, business_proposal_id, source, source_metadata)
+         VALUES ($1, gen_random_uuid(), 'cd-zip', '{}'::jsonb) RETURNING id`,
+        ['00000000-0000-0000-0000-000000000001'],
+      )).rows[0]!.id;
+
+      const snap = createDesignSnapshotter({
+        pg, blobStorage, diffDesigns: fakeDiff, schema, tenantId: '00000000-0000-0000-0000-000000000001',
+        assetByteReader: async () => makeAssetBytes('photo-int'),
+      });
+
+      const v1 = await snap.snapshot({
+        uxUploadId,
+        design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+      });
+      const v2 = await snap.snapshot({
+        uxUploadId,
+        design: makeDesign({ assets: [{ path: '/h.jpg', kind: 'image' }] }),
+      });
+      expect(v1.versionNumber).toBe(1);
+      expect(v2.versionNumber).toBe(2);
+      expect(v2.parentVersionId).toBe(v1.id);
+
+      const versions = await snap.listVersions(uxUploadId);
+      expect(versions.map((v) => v.versionNumber)).toEqual([2, 1]);
+
+      const restored = await snap.revertToVersion({ uxUploadId, versionNumber: 1 });
+      expect(restored.versionNumber).toBe(3);
+      expect(restored.parentVersionId).toBe(v2.id);
+
+      const wipe = await snap.deleteAllForTenant('00000000-0000-0000-0000-000000000001');
+      expect(wipe.deletedVersionCount).toBeGreaterThanOrEqual(3);
+    } finally {
+      await pg.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`).catch(() => undefined);
+      await disposePg();
+      await disposeBlob(bucket);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// thin connector helpers — node-postgres + S3 are imported dynamically so the
+// suite stays importable in any environment.
+// ---------------------------------------------------------------------------
+
+async function openPg(): Promise<{ pg: PgQueryable; dispose: () => Promise<void> }> {
+  const mod = await import('pg' as any).catch(() => null);
+  if (!mod) throw new Error('pg module not installed; integration test cannot run');
+  const ClientCtor = (mod as any).Client ?? (mod as any).default?.Client;
+  const client = new ClientCtor({ connectionString: process.env['DATABASE_URL']! });
+  await client.connect();
+  const wrapped: PgQueryable = {
+    query: (text, params) => client.query(text, params ?? []),
+  };
+  return { pg: wrapped, dispose: async () => { await client.end(); } };
+}
+
+async function openS3(): Promise<{ blobStorage: BlobStorage; bucket: string; dispose: (bucket: string) => Promise<void> }> {
+  const mod = await import('@aws-sdk/client-s3' as any).catch(() => null);
+  if (!mod) throw new Error('@aws-sdk/client-s3 not installed; integration test cannot run');
+  const S3Client = (mod as any).S3Client;
+  const PutObjectCommand = (mod as any).PutObjectCommand;
+  const HeadObjectCommand = (mod as any).HeadObjectCommand;
+  const GetObjectCommand = (mod as any).GetObjectCommand;
+  const DeleteObjectCommand = (mod as any).DeleteObjectCommand;
+  const ListObjectsV2Command = (mod as any).ListObjectsV2Command;
+
+  const s3 = new S3Client({
+    endpoint: process.env['S3_ENDPOINT']!,
+    region: 'us-east-1',
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: process.env['S3_ACCESS_KEY_ID']!,
+      secretAccessKey: process.env['S3_SECRET_ACCESS_KEY']!,
+    },
+  });
+  const bucket = process.env['S3_BUCKET']!;
+  const urlScheme = 's3';
+
+  const blobStorage: BlobStorage = {
+    async put({ path, bytes, contentHash, contentType }) {
+      await s3.send(new PutObjectCommand({
+        Bucket: bucket, Key: path, Body: Buffer.from(bytes), ContentType: contentType, Metadata: { 'content-sha256': contentHash },
+      }));
+      return { storageUrl: `${urlScheme}://${bucket}/${path}`, deduped: false };
+    },
+    async head(path) {
+      try {
+        const out = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: path }));
+        return {
+          exists: true,
+          contentHash: out.Metadata?.['content-sha256'],
+          sizeBytes: out.ContentLength ?? 0,
+        };
+      } catch {
+        return { exists: false };
+      }
+    },
+    async get(path) {
+      const out = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: path }));
+      const body = await out.Body!.transformToByteArray();
+      return body;
+    },
+    async delete(path) {
+      await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: path }));
+    },
+    async list(prefix) {
+      const out = await s3.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }));
+      return (out.Contents ?? []).map((o: any) => o.Key as string);
+    },
+  };
+
+  return {
+    blobStorage,
+    bucket,
+    dispose: async (b: string) => {
+      // best-effort cleanup
+      const keys = await blobStorage.list('design-assets/');
+      for (const k of keys) await blobStorage.delete(k).catch(() => undefined);
+      void b;
+    },
+  };
+}

--- a/packages/atlas-design-snapshotter/tests/read.test.ts
+++ b/packages/atlas-design-snapshotter/tests/read.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter, SnapshotterError } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+const TENANT = 'tenant-a';
+
+function setup() {
+  const pg = new FakePg();
+  const blob = new FakeBlobStorage();
+  const snap = createDesignSnapshotter({
+    pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+    idGen: counterIdGen(), clock: frozenClock(),
+  });
+  pg.seedUxUpload({ id: 'upload-1', tenant_id: TENANT });
+  return { pg, blob, snap };
+}
+
+describe('read APIs', () => {
+  describe('getSnapshot', () => {
+    it('returns the persisted RenderableDesign', async () => {
+      const { snap } = setup();
+      const v1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      const got = await snap.getSnapshot(v1.id);
+      expect(got.routes[0]!.path).toBe('/');
+    });
+
+    it('roundtrips the stamped designVersionId', async () => {
+      const { snap } = setup();
+      const v = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      const got = await snap.getSnapshot(v.id);
+      expect(got.designVersionId).toBe(v.id);
+    });
+
+    it('throws design_version_not_found for an unknown id', async () => {
+      const { snap } = setup();
+      await expect(snap.getSnapshot('does-not-exist')).rejects.toBeInstanceOf(SnapshotterError);
+    });
+  });
+
+  describe('listVersions', () => {
+    it('returns versions newest-first', async () => {
+      const { snap } = setup();
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      const list = await snap.listVersions('upload-1');
+      expect(list.map((v) => v.versionNumber)).toEqual([3, 2, 1]);
+    });
+
+    it('returns empty for a brand-new upload', async () => {
+      const { snap } = setup();
+      const list = await snap.listVersions('upload-1');
+      expect(list).toEqual([]);
+    });
+
+    it('exposes the diff_summary jsonb', async () => {
+      const { snap } = setup();
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      const list = await snap.listVersions('upload-1');
+      expect(list[0]!.diffSummary).toBeTruthy();
+      expect(list[0]!.diffSummary!.modifiedCount).toBe(0);
+    });
+
+    it('exposes parentVersionId per row', async () => {
+      const { snap } = setup();
+      const v1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      const list = await snap.listVersions('upload-1');
+      expect(list.find((v) => v.versionNumber === 2)!.parentVersionId).toBe(v1.id);
+      expect(list.find((v) => v.versionNumber === 1)!.parentVersionId).toBeNull();
+    });
+  });
+
+  describe('getDiff', () => {
+    it('throws design_version_not_found when an id is missing', async () => {
+      const { snap } = setup();
+      await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+      await expect(snap.getDiff('missing-1', 'missing-2')).rejects.toBeInstanceOf(SnapshotterError);
+    });
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/revert.test.ts
+++ b/packages/atlas-design-snapshotter/tests/revert.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter, SnapshotterError } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+const TENANT = 'tenant-a';
+
+function setup() {
+  const pg = new FakePg();
+  const blob = new FakeBlobStorage();
+  const snap = createDesignSnapshotter({
+    pg,
+    blobStorage: blob,
+    diffDesigns: fakeDiff,
+    schema: SCHEMA,
+    tenantId: TENANT,
+    idGen: counterIdGen(),
+    clock: frozenClock(),
+  });
+  pg.seedUxUpload({ id: 'upload-1', tenant_id: TENANT });
+  return { pg, blob, snap };
+}
+
+describe('revertToVersion — Time Machine primitive', () => {
+  it('creates v(N+1) whose content equals v(target)', async () => {
+    const { snap } = setup();
+    const v1Design = makeDesign();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: v1Design });
+    await snap.snapshot({
+      uxUploadId: 'upload-1',
+      design: makeDesign({ designTokens: { colors: { '--brand': '#999' } } }),
+    });
+    const reverted = await snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 1 });
+    expect(reverted.versionNumber).toBe(3);
+    const restored = await snap.getSnapshot(reverted.id);
+    expect(restored.designTokens?.colors?.['--brand']).toBe('#222');
+  });
+
+  it('does NOT mutate the targeted prior row', async () => {
+    const { pg, snap } = setup();
+    const v1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v1RowBefore = JSON.stringify(pg.designVersions[0]);
+    await snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 1 });
+    const v1RowAfter = JSON.stringify(pg.designVersions.find((r) => r.id === v1.id));
+    expect(v1RowAfter).toBe(v1RowBefore);
+  });
+
+  it('records the parent as the CURRENT latest, not the target', async () => {
+    const { snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v2 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const reverted = await snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 1 });
+    expect(reverted.parentVersionId).toBe(v2.id);
+  });
+
+  it('default notes mention the target version', async () => {
+    const { snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const reverted = await snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 1 });
+    expect(reverted.notes).toMatch(/Revert to v1/);
+  });
+
+  it('honours explicit notes on revert', async () => {
+    const { snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const reverted = await snap.revertToVersion({
+      uxUploadId: 'upload-1',
+      versionNumber: 1,
+      notes: 'rollback per ticket SUP-91',
+    });
+    expect(reverted.notes).toBe('rollback per ticket SUP-91');
+  });
+
+  it('throws invalid_revert_target for a non-existent version_number', async () => {
+    const { snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await expect(
+      snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 99 }),
+    ).rejects.toBeInstanceOf(SnapshotterError);
+  });
+
+  it('rejects a non-integer versionNumber', async () => {
+    const { snap } = setup();
+    await expect(
+      snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 1.5 }),
+    ).rejects.toBeInstanceOf(SnapshotterError);
+  });
+
+  it('rejects a versionNumber < 1', async () => {
+    const { snap } = setup();
+    await expect(
+      snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 0 }),
+    ).rejects.toBeInstanceOf(SnapshotterError);
+  });
+
+  it('after revert, ux_uploads.rendered_design carries the reverted payload', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await snap.snapshot({
+      uxUploadId: 'upload-1',
+      design: makeDesign({ designTokens: { colors: { '--brand': '#999' } } }),
+    });
+    await snap.revertToVersion({ uxUploadId: 'upload-1', versionNumber: 1 });
+    const stored = JSON.parse(pg.uxUploads.get('upload-1')!.rendered_design as string);
+    expect(stored.designTokens.colors['--brand']).toBe('#222');
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/snapshot.test.ts
+++ b/packages/atlas-design-snapshotter/tests/snapshot.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter, SnapshotterError } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+const TENANT = 'tenant-a';
+
+function setup() {
+  const pg = new FakePg();
+  const blob = new FakeBlobStorage();
+  const snap = createDesignSnapshotter({
+    pg,
+    blobStorage: blob,
+    diffDesigns: fakeDiff,
+    schema: SCHEMA,
+    tenantId: TENANT,
+    idGen: counterIdGen(),
+    clock: frozenClock(),
+  });
+  pg.seedUxUpload({ id: 'upload-1', tenant_id: TENANT });
+  return { pg, blob, snap };
+}
+
+describe('snapshot — first version (v1)', () => {
+  it('creates a row with version_number=1 and no parent', async () => {
+    const { pg, snap } = setup();
+    const row = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    expect(row.versionNumber).toBe(1);
+    expect(row.parentVersionId).toBeNull();
+    expect(pg.designVersions).toHaveLength(1);
+    expect(pg.designVersions[0]!.version_number).toBe(1);
+  });
+
+  it('persists rendered_design as a JSON-serialisable column', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const stored = pg.designVersions[0]!.rendered_design;
+    expect(typeof stored).toBe('string');
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.routes[0].path).toBe('/');
+  });
+
+  it('stamps the new designVersionId into the persisted design payload', async () => {
+    const { pg, snap } = setup();
+    const row = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const stored = JSON.parse(pg.designVersions[0]!.rendered_design as string);
+    expect(stored.designVersionId).toBe(row.id);
+  });
+
+  it('writes diff_from_parent=NULL for v1 (no parent)', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    expect(pg.designVersions[0]!.diff_from_parent).toBeNull();
+  });
+
+  it('still writes a non-null diff_summary for v1 (zero counts)', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const summary = JSON.parse(pg.designVersions[0]!.diff_summary as string);
+    expect(summary.addedCount).toBe(0);
+    expect(summary.removedCount).toBe(0);
+    expect(summary.modifiedCount).toBe(0);
+  });
+
+  it('flips ux_uploads.status to "parsed" and stores the latest design', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const upload = pg.uxUploads.get('upload-1');
+    expect(upload?.status).toBe('parsed');
+    expect(upload?.rendered_design).toBeTruthy();
+  });
+
+  it('honours an explicit notes message', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign(), notes: 'initial' });
+    expect(pg.designVersions[0]!.notes).toBe('initial');
+  });
+
+  it('throws invalid_renderable_design when componentTrees is missing', async () => {
+    const { snap } = setup();
+    await expect(
+      snap.snapshot({ uxUploadId: 'upload-1', design: { routes: [] } as any }),
+    ).rejects.toBeInstanceOf(SnapshotterError);
+  });
+
+  it('throws invalid_renderable_design when routes is missing', async () => {
+    const { snap } = setup();
+    await expect(
+      snap.snapshot({ uxUploadId: 'upload-1', design: { componentTrees: {} } as any }),
+    ).rejects.toBeInstanceOf(SnapshotterError);
+  });
+
+  it('rejects an empty uxUploadId', async () => {
+    const { snap } = setup();
+    await expect(
+      snap.snapshot({ uxUploadId: '', design: makeDesign() }),
+    ).rejects.toBeInstanceOf(SnapshotterError);
+  });
+});
+
+describe('snapshot — parent linkage (v2, v3, ...)', () => {
+  it('v2 links parent_version_id to v1', async () => {
+    const { pg, snap } = setup();
+    const v1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v2 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    expect(v2.versionNumber).toBe(2);
+    expect(v2.parentVersionId).toBe(v1.id);
+    expect(pg.designVersions).toHaveLength(2);
+  });
+
+  it('v3 links parent_version_id to v2', async () => {
+    const { snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v2 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const v3 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    expect(v3.versionNumber).toBe(3);
+    expect(v3.parentVersionId).toBe(v2.id);
+  });
+
+  it('different ux_uploads have independent version numbering', async () => {
+    const { pg, snap } = setup();
+    pg.seedUxUpload({ id: 'upload-2', tenant_id: TENANT });
+    const aV1 = await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    const bV1 = await snap.snapshot({ uxUploadId: 'upload-2', design: makeDesign() });
+    expect(aV1.versionNumber).toBe(1);
+    expect(bV1.versionNumber).toBe(1);
+    expect(aV1.parentVersionId).toBeNull();
+    expect(bV1.parentVersionId).toBeNull();
+  });
+
+  it('persists diff_from_parent on v2 onwards', async () => {
+    const { pg, snap } = setup();
+    await snap.snapshot({ uxUploadId: 'upload-1', design: makeDesign() });
+    await snap.snapshot({
+      uxUploadId: 'upload-1',
+      design: makeDesign({
+        componentTrees: {
+          home: {
+            rootDomId: 'page-home',
+            node: { domId: 'page-home', tag: 'main', role: 'page', children: [] },
+          },
+        },
+      }),
+    });
+    const v2 = pg.designVersions[1]!;
+    const diff = JSON.parse(v2.diff_from_parent as string);
+    // The hero section + headline were removed in the v2 design.
+    expect(diff.removed.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/sql.test.ts
+++ b/packages/atlas-design-snapshotter/tests/sql.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertSafeSchemaName, schemaDDL } from '../src/index.js';
+
+describe('sql identifier safety', () => {
+  it('accepts a lowercase snake_case schema name', () => {
+    expect(() => assertSafeSchemaName('caia_pt_dev')).not.toThrow();
+  });
+
+  it('rejects uppercase characters', () => {
+    expect(() => assertSafeSchemaName('Caia')).toThrow();
+  });
+
+  it('rejects whitespace', () => {
+    expect(() => assertSafeSchemaName('caia foo')).toThrow();
+  });
+
+  it('rejects a leading digit', () => {
+    expect(() => assertSafeSchemaName('1caia')).toThrow();
+  });
+
+  it('rejects an injection attempt', () => {
+    expect(() => assertSafeSchemaName('foo"; DROP TABLE x;--')).toThrow();
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => assertSafeSchemaName('')).toThrow();
+  });
+
+  it('schemaDDL embeds the schema only after asserting safety', () => {
+    expect(() => schemaDDL('drop_me; --')).toThrow();
+    const ddl = schemaDDL('caia_test');
+    expect(ddl).toContain('CREATE SCHEMA IF NOT EXISTS "caia_test"');
+    expect(ddl).toContain('"caia_test"."ux_uploads"');
+    expect(ddl).toContain('"caia_test"."design_versions"');
+    expect(ddl).toContain('"caia_test"."design_assets"');
+  });
+});

--- a/packages/atlas-design-snapshotter/tests/transaction.test.ts
+++ b/packages/atlas-design-snapshotter/tests/transaction.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Transaction semantics — snapshot must roll back cleanly if any of the
+ * mid-flight DML fails. Asserted via FakePg's BEGIN/COMMIT/ROLLBACK counters.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createDesignSnapshotter } from '../src/index.js';
+import {
+  FakeBlobStorage,
+  FakePg,
+  counterIdGen,
+  fakeDiff,
+  frozenClock,
+  makeDesign,
+} from './fakes.js';
+
+const SCHEMA = 'caia_test';
+const TENANT = 'tenant-a';
+
+describe('transactional semantics', () => {
+  it('happy path COMMITs exactly once', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u', tenant_id: TENANT });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    await snap.snapshot({ uxUploadId: 'u', design: makeDesign() });
+    expect(pg.committedAt).toBe(1);
+    expect(pg.rolledBack).toBe(0);
+    expect(pg.txDepth).toBe(0);
+  });
+
+  it('rolls back when an INSERT mid-flight throws', async () => {
+    const pg = new FakePg();
+    const blob = new FakeBlobStorage();
+    pg.seedUxUpload({ id: 'u', tenant_id: TENANT });
+    const snap = createDesignSnapshotter({
+      pg, blobStorage: blob, diffDesigns: fakeDiff, schema: SCHEMA, tenantId: TENANT,
+      idGen: counterIdGen(), clock: frozenClock(),
+    });
+    // Land a successful v1 first so loadPriorVersion has a row to return.
+    await snap.snapshot({ uxUploadId: 'u', design: makeDesign() });
+    // Now arm a failure that fires on the next non-control query (the v2 INSERT).
+    pg.failNextInsert = new Error('FK violation simulated');
+    await expect(
+      snap.snapshot({ uxUploadId: 'u', design: makeDesign() }),
+    ).rejects.toThrow();
+    // v1 committed once before; v2 rolled back; v2's COMMIT never ran.
+    expect(pg.rolledBack).toBe(1);
+    expect(pg.committedAt).toBe(1);
+    // No new design_versions row appeared from the failed snapshot.
+    expect(pg.designVersions).toHaveLength(1);
+  });
+});

--- a/packages/atlas-design-snapshotter/tsconfig.json
+++ b/packages/atlas-design-snapshotter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/atlas-design-snapshotter/vitest.config.ts
+++ b/packages/atlas-design-snapshotter/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});


### PR DESCRIPTION
Adds `@chiefaia/atlas-design-snapshotter` — captures a versioned, immutable snapshot of every `RenderableDesign` at every upload. The Time-Machine + UX Version-Control primitive.

## What this does
1. **`snapshot(input)`** — inserts an immutable `design_versions` row with monotonic `version_number`, parent linkage, and the `RenderableDesign` JSON. Asset blobs uploaded via BYOC adapter with **SHA-256 content-hash dedup** — same blob across N versions = one upload, N references.
2. **Diff-from-parent** — runs injected `diffDesigns` (from `@chiefaia/atlas-mapper`) and persists into `design_versions.diff_from_parent` + `design_versions.diff_summary` for cheap dashboard rendering.
3. **`revertToVersion(uxUploadId, versionNumber)`** — creates v(N+1) whose payload equals v(target). Forward operation; prior rows never mutated.
4. **`deleteAllForTenant(tenantId)`** — GDPR right-to-erasure. Idempotent.
5. **Read APIs** — `getSnapshot`, `listVersions`, `getDiff`.

## Tests
- 69 vitest unit tests (snapshot, parent linkage, diff, revert, GDPR, dedup, read APIs, content-hash, SQL safety, transaction rollback).
- 1 integration test against real Postgres + S3-compatible blob store; auto-skips without `DATABASE_URL` and `S3_ENDPOINT` env.
- TypeScript strict + `exactOptionalPropertyTypes` clean.

## References
- `research/atlas_module_spec_2026.md` §2 + §4
- `research/step5_design_ingest_spec_2026.md` §1, §4, §5.2, §5.3