### PR TITLE
feat(secrets): multi-tenant SecretsAdapter + Postgres + Infisical adapters (wave 0)

### DIFF
--- a/packages/secrets-adapter/CHANGELOG.md
+++ b/packages/secrets-adapter/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @caia/secrets-adapter
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: `SecretsAdapter` interface, `AccessContext`,
+  `AccessLogEntry`, `SecretMetadata`, typed error hierarchy, and Zod
+  schemas for every wire payload. Implements
+  `research/multi_tenant_secrets_architecture_2026.md` §5 + §6.

--- a/packages/secrets-adapter/README.md
+++ b/packages/secrets-adapter/README.md
@@ -1,0 +1,32 @@
+# `@caia/secrets-adapter`
+
+> Provider-agnostic multi-tenant secrets contract.
+
+The `SecretsAdapter` interface is the **single line CAIA application code crosses
+to read or write any tenant credential**. The concrete adapter — Postgres
+encrypted-column (`@caia/secrets-postgres`) for Phase-1 bootstrap, Infisical
+project-per-tenant (`@caia/secrets-infisical`) for Phase-1 hot path, and
+whatever comes in Phase-3 — lives behind this interface. Provider swaps become
+a Friday-afternoon exercise.
+
+## What's in the box
+
+- **`SecretsAdapter`** — `put` / `get` / `list` / `rotate` / `delete` /
+  `deleteAllForTenant` / `auditLog` / `ping`.
+- **`AccessContext`** — mandatory caller envelope (`callerType` ∈
+  `agent|user|deploy-worker|cron|system`, `callerId`, optional `ticketId` /
+  `capabilityTokenId` / `requesterIp`, free-form `reason` ≤ 500 chars). Passed
+  on every `get` so the *adapter* writes the audit row — making it
+  impossible-by-construction to fetch a secret without an audit trail.
+- **`AccessLogEntry`** — one row per access (success and failure). `ok=false`
+  rows are still recorded; failed-fetch is signal.
+- **`SecretMetadata`** — metadata only, never the secret value.
+- **Typed errors** — `SecretNotFoundError` / `SecretPolicyDeniedError` /
+  `SecretRateLimitedError` / `SecretProviderError` mapping cleanly to
+  `AccessLogEntry.errorClass`.
+- **Zod schemas** — runtime validation of every payload that crosses the
+  adapter boundary.
+
+## Reference
+
+`research/multi_tenant_secrets_architecture_2026.md` §5 + §6.

--- a/packages/secrets-adapter/eslint.config.cjs
+++ b/packages/secrets-adapter/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/secrets-adapter/package.json
+++ b/packages/secrets-adapter/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@caia/secrets-adapter",
+  "version": "0.1.0",
+  "description": "Multi-tenant SecretsAdapter interface for CAIA — provider-agnostic contract for put/get/list/rotate/delete/deleteAllForTenant/auditLog with mandatory AccessContext. Phase-1 of the multi-tenant secrets architecture (research/multi_tenant_secrets_architecture_2026.md §5/§6).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/secrets-adapter/src/adapter.ts
+++ b/packages/secrets-adapter/src/adapter.ts
@@ -1,0 +1,68 @@
+/**
+ * The portable `SecretsAdapter` interface.
+ *
+ * Reference: research/multi_tenant_secrets_architecture_2026.md §6.
+ *
+ * Design choices:
+ *   1. `get` takes `AccessContext` so the adapter writes the audit row.
+ *   2. `deleteAllForTenant` returns a tombstone ref for GDPR receipts.
+ *   3. No encryption details in the interface — adapter-internal.
+ */
+
+import type {
+  AccessContext,
+  AccessLogEntry,
+  DeleteAllForTenantOptions,
+  DeleteAllResult,
+  DeleteOptions,
+  PingResult,
+  PutOptions,
+  PutResult,
+  RotateResult,
+  SecretMetadata,
+} from './types.js';
+
+export interface SecretsAdapter {
+  put(
+    tenantId: string,
+    category: string,
+    key: string,
+    value: string,
+    opts?: PutOptions,
+  ): Promise<PutResult>;
+
+  get(
+    tenantId: string,
+    category: string,
+    key: string,
+    callerContext: AccessContext,
+  ): Promise<string>;
+
+  list(tenantId: string, category?: string): Promise<SecretMetadata[]>;
+
+  rotate(
+    tenantId: string,
+    category: string,
+    key: string,
+  ): Promise<RotateResult>;
+
+  delete(
+    tenantId: string,
+    category: string,
+    key: string,
+    opts?: DeleteOptions,
+  ): Promise<void>;
+
+  deleteAllForTenant(
+    tenantId: string,
+    opts?: DeleteAllForTenantOptions,
+  ): Promise<DeleteAllResult>;
+
+  auditLog(
+    tenantId: string,
+    since?: Date,
+    until?: Date,
+  ): Promise<AccessLogEntry[]>;
+
+  ping(): Promise<PingResult>;
+}

--- a/packages/secrets-adapter/src/errors.ts
+++ b/packages/secrets-adapter/src/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * Typed error hierarchy. Adapters throw these so callers can branch
+ * cleanly without grepping error messages.
+ */
+
+import type { ErrorClass } from './types.js';
+
+export abstract class SecretsAdapterError extends Error {
+  abstract readonly errorClass: ErrorClass;
+  readonly tenantId?: string;
+  readonly category?: string;
+  readonly key?: string;
+  override readonly cause?: unknown;
+
+  constructor(
+    message: string,
+    opts: {
+      tenantId?: string;
+      category?: string;
+      key?: string;
+      cause?: unknown;
+    } = {},
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+    if (opts.tenantId !== undefined) this.tenantId = opts.tenantId;
+    if (opts.category !== undefined) this.category = opts.category;
+    if (opts.key !== undefined) this.key = opts.key;
+    if (opts.cause !== undefined) this.cause = opts.cause;
+  }
+}
+
+export class SecretNotFoundError extends SecretsAdapterError {
+  override readonly errorClass = 'not_found' as const;
+}
+
+export class SecretPolicyDeniedError extends SecretsAdapterError {
+  override readonly errorClass = 'policy_denied' as const;
+}
+
+export class SecretRateLimitedError extends SecretsAdapterError {
+  override readonly errorClass = 'rate_limited' as const;
+  readonly retryAfterMs?: number;
+
+  constructor(
+    message: string,
+    opts: {
+      tenantId?: string;
+      category?: string;
+      key?: string;
+      cause?: unknown;
+      retryAfterMs?: number;
+    } = {},
+  ) {
+    super(message, opts);
+    if (opts.retryAfterMs !== undefined) this.retryAfterMs = opts.retryAfterMs;
+  }
+}
+
+export class SecretProviderError extends SecretsAdapterError {
+  override readonly errorClass = 'provider_error' as const;
+}
+
+export class SecretsAdapterConfigError extends Error {
+  override readonly name = 'SecretsAdapterConfigError';
+}
+
+export function classifyError(err: unknown): ErrorClass {
+  if (err instanceof SecretsAdapterError) return err.errorClass;
+  return 'provider_error';
+}

--- a/packages/secrets-adapter/src/index.ts
+++ b/packages/secrets-adapter/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * `@caia/secrets-adapter` — public surface.
+ *
+ * Reference: research/multi_tenant_secrets_architecture_2026.md §5 + §6.
+ */
+
+export * from './types.js';
+export * from './errors.js';
+export type { SecretsAdapter } from './adapter.js';

--- a/packages/secrets-adapter/src/types.ts
+++ b/packages/secrets-adapter/src/types.ts
@@ -1,0 +1,150 @@
+/**
+ * @caia/secrets-adapter — public types.
+ *
+ * Reference: research/multi_tenant_secrets_architecture_2026.md §6.
+ */
+
+import { z } from 'zod';
+
+export const CALLER_TYPES = [
+  'agent',
+  'user',
+  'deploy-worker',
+  'cron',
+  'system',
+] as const;
+
+export const CallerTypeSchema = z.enum(CALLER_TYPES);
+export type CallerType = z.infer<typeof CallerTypeSchema>;
+
+/**
+ * Mandatory caller envelope. Passed on every `get` so the adapter — not the
+ * caller — writes the audit row. There is no anonymous read.
+ *
+ * `requesterIp` is populated by the broker at its boundary, NOT by the
+ * caller, so a malicious agent can't lie about its origin.
+ *
+ * `capabilityTokenId` joins the secrets-broker ledger to the
+ * capability-broker ledger so an operator can trace "what credential was
+ * fetched for what action".
+ */
+export const AccessContextSchema = z.object({
+  callerType: CallerTypeSchema,
+  callerId: z.string().min(1).max(200),
+  ticketId: z.string().min(1).max(200).optional(),
+  reason: z.string().min(1).max(500),
+  capabilityTokenId: z.string().min(8).max(200).optional(),
+  requesterIp: z.string().min(1).max(45).optional(),
+});
+export type AccessContext = z.infer<typeof AccessContextSchema>;
+
+export const SecretMetadataSchema = z.object({
+  key: z.string().min(1).max(200),
+  category: z.string().min(1).max(100),
+  secretRef: z.string().min(1).max(500),
+  createdAt: z.date(),
+  lastAccessedAt: z.date().optional(),
+  lastRotatedAt: z.date().optional(),
+  version: z.number().int().nonnegative().optional(),
+  expiresAt: z.date().optional(),
+});
+export type SecretMetadata = z.infer<typeof SecretMetadataSchema>;
+
+export const ERROR_CLASSES = [
+  'not_found',
+  'policy_denied',
+  'rate_limited',
+  'provider_error',
+] as const;
+
+export const ErrorClassSchema = z.enum(ERROR_CLASSES);
+export type ErrorClass = z.infer<typeof ErrorClassSchema>;
+
+export const AccessLogEntrySchema = z.object({
+  tenantId: z.string().min(1).max(200),
+  category: z.string().min(1).max(100),
+  key: z.string().min(1).max(200),
+  callerType: CallerTypeSchema,
+  callerId: z.string().min(1).max(200),
+  ticketId: z.string().min(1).max(200).optional(),
+  reason: z.string().min(1).max(500),
+  capabilityTokenId: z.string().min(8).max(200).optional(),
+  requesterIp: z.string().min(1).max(45).optional(),
+  grantedAt: z.date(),
+  ok: z.boolean(),
+  errorClass: ErrorClassSchema.optional(),
+  providerTrace: z.string().min(1).max(500).optional(),
+});
+export type AccessLogEntry = z.infer<typeof AccessLogEntrySchema>;
+
+export const PutOptionsSchema = z.object({
+  ttlSeconds: z.number().int().positive().max(60 * 60 * 24 * 365).optional(),
+  replace: z.boolean().optional(),
+});
+export type PutOptions = z.infer<typeof PutOptionsSchema>;
+
+export const DeleteOptionsSchema = z.object({
+  purge: z.boolean().optional(),
+});
+export type DeleteOptions = z.infer<typeof DeleteOptionsSchema>;
+
+export const DeleteAllForTenantOptionsSchema = z.object({
+  dryRun: z.boolean().optional(),
+});
+export type DeleteAllForTenantOptions = z.infer<
+  typeof DeleteAllForTenantOptionsSchema
+>;
+
+export const PutResultSchema = z.object({
+  secretRef: z.string().min(1).max(500),
+  version: z.number().int().nonnegative().optional(),
+});
+export type PutResult = z.infer<typeof PutResultSchema>;
+
+export const RotateResultSchema = z.object({
+  rotatedAt: z.date(),
+  version: z.number().int().nonnegative(),
+});
+export type RotateResult = z.infer<typeof RotateResultSchema>;
+
+export const DeleteAllResultSchema = z.object({
+  deletedCount: z.number().int().nonnegative(),
+  tenantTombstoneRef: z.string().min(1).max(500),
+});
+export type DeleteAllResult = z.infer<typeof DeleteAllResultSchema>;
+
+export const PingResultSchema = z.object({
+  ok: z.boolean(),
+  latencyMs: z.number().nonnegative(),
+  backend: z.string().min(1).max(100),
+});
+export type PingResult = z.infer<typeof PingResultSchema>;
+
+export const TenantIdSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9-]*$/, {
+    message:
+      'tenantId must be lowercase alphanumeric / hyphen, starting with a letter or digit',
+  });
+
+export const CategorySchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/, {
+    message:
+      'category must be lowercase alphanumeric / dot / underscore / hyphen',
+  });
+
+export const KeySchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, {
+    message:
+      'key must be alphanumeric / dot / underscore / hyphen, starting with an alphanumeric',
+  });
+
+export const SecretValueSchema = z.string().min(1).max(1024 * 1024);

--- a/packages/secrets-adapter/tests/adapter.test.ts
+++ b/packages/secrets-adapter/tests/adapter.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { SecretsAdapter } from '../src/adapter.js';
+import type { AccessContext, AccessLogEntry, SecretMetadata } from '../src/types.js';
+
+/**
+ * In-memory witness adapter — proves the interface is implementable
+ * and exercises the contract surface. Full coverage lives in the
+ * concrete adapter packages.
+ */
+class StubAdapter implements SecretsAdapter {
+  private store = new Map<string, { value: string; createdAt: Date; version: number }>();
+  private auditEntries: AccessLogEntry[] = [];
+
+  private id(t: string, c: string, k: string) {
+    return `${t}::${c}::${k}`;
+  }
+
+  async put(t: string, c: string, k: string, v: string) {
+    const id = this.id(t, c, k);
+    const prev = this.store.get(id);
+    const version = (prev?.version ?? 0) + 1;
+    this.store.set(id, { value: v, createdAt: new Date(), version });
+    return { secretRef: id, version };
+  }
+
+  async get(t: string, c: string, k: string, ctx: AccessContext) {
+    const id = this.id(t, c, k);
+    const v = this.store.get(id);
+    this.auditEntries.push({
+      tenantId: t, category: c, key: k,
+      callerType: ctx.callerType, callerId: ctx.callerId, reason: ctx.reason,
+      grantedAt: new Date(), ok: v !== undefined,
+      ...(v === undefined ? { errorClass: 'not_found' as const } : {}),
+    });
+    if (!v) throw new Error('missing');
+    return v.value;
+  }
+
+  async list(t: string, c?: string): Promise<SecretMetadata[]> {
+    const prefix = c ? `${t}::${c}::` : `${t}::`;
+    const out: SecretMetadata[] = [];
+    for (const [id, v] of this.store) {
+      if (!id.startsWith(prefix)) continue;
+      const [, cat, k] = id.split('::');
+      if (!cat || !k) continue;
+      out.push({ key: k, category: cat, secretRef: id, createdAt: v.createdAt, version: v.version });
+    }
+    return out;
+  }
+
+  async rotate(t: string, c: string, k: string) {
+    const v = this.store.get(this.id(t, c, k));
+    if (!v) throw new Error('missing');
+    v.version += 1;
+    return { rotatedAt: new Date(), version: v.version };
+  }
+
+  async delete(t: string, c: string, k: string) {
+    this.store.delete(this.id(t, c, k));
+  }
+
+  async deleteAllForTenant(t: string) {
+    let n = 0;
+    for (const id of [...this.store.keys()]) {
+      if (id.startsWith(`${t}::`)) { this.store.delete(id); n++; }
+    }
+    return { deletedCount: n, tenantTombstoneRef: `tomb_${t}` };
+  }
+
+  async auditLog(t: string) {
+    return this.auditEntries.filter((e) => e.tenantId === t);
+  }
+
+  async ping() {
+    return { ok: true, latencyMs: 0, backend: 'stub' };
+  }
+}
+
+describe('SecretsAdapter interface (in-memory witness)', () => {
+  it('is implementable', async () => {
+    const a: SecretsAdapter = new StubAdapter();
+    const ctx: AccessContext = { callerType: 'agent', callerId: 'a', reason: 'r' };
+    await a.put('t1', 'cloud.aws', 'access_key', 'AKIA');
+    expect(await a.get('t1', 'cloud.aws', 'access_key', ctx)).toBe('AKIA');
+  });
+
+  it('list returns metadata only', async () => {
+    const a = new StubAdapter();
+    await a.put('t1', 'cloud.aws', 'access_key', 'AKIA');
+    await a.put('t1', 'cloud.aws', 'secret', 's');
+    const list = await a.list('t1', 'cloud.aws');
+    expect(list).toHaveLength(2);
+    for (const m of list) expect(m).not.toHaveProperty('value');
+  });
+
+  it('rotate bumps version', async () => {
+    const a = new StubAdapter();
+    await a.put('t1', 'c', 'k', 'v');
+    const r1 = await a.rotate('t1', 'c', 'k');
+    const r2 = await a.rotate('t1', 'c', 'k');
+    expect(r2.version).toBe(r1.version + 1);
+  });
+
+  it('deleteAllForTenant only that tenant', async () => {
+    const a = new StubAdapter();
+    await a.put('t1', 'c', 'k', 'v');
+    await a.put('t2', 'c', 'k', 'v');
+    const r = await a.deleteAllForTenant('t1');
+    expect(r.deletedCount).toBe(1);
+    expect(r.tenantTombstoneRef).toContain('t1');
+    expect(await a.list('t2')).toHaveLength(1);
+  });
+
+  it('audit log success + failure', async () => {
+    const a = new StubAdapter();
+    const ctx: AccessContext = { callerType: 'agent', callerId: 'a', reason: 'r' };
+    await a.put('t', 'c', 'present', 'v');
+    await a.get('t', 'c', 'present', ctx);
+    await a.get('t', 'c', 'missing', ctx).catch(() => undefined);
+    const log = await a.auditLog('t');
+    expect(log).toHaveLength(2);
+    expect(log.find((e) => e.key === 'missing')?.errorClass).toBe('not_found');
+  });
+
+  it('ping', async () => {
+    const a = new StubAdapter();
+    expect((await a.ping()).backend).toBe('stub');
+  });
+});

--- a/packages/secrets-adapter/tests/errors.test.ts
+++ b/packages/secrets-adapter/tests/errors.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SecretNotFoundError,
+  SecretPolicyDeniedError,
+  SecretRateLimitedError,
+  SecretProviderError,
+  SecretsAdapterError,
+  SecretsAdapterConfigError,
+  classifyError,
+} from '../src/errors.js';
+
+describe('SecretNotFoundError', () => {
+  it('classifies as not_found', () => {
+    const err = new SecretNotFoundError('missing', { tenantId: 't', key: 'k' });
+    expect(err.errorClass).toBe('not_found');
+    expect(err.tenantId).toBe('t');
+    expect(err.key).toBe('k');
+    expect(err).toBeInstanceOf(SecretsAdapterError);
+    expect(err).toBeInstanceOf(Error);
+  });
+  it('preserves message', () => {
+    expect(new SecretNotFoundError('nope').message).toBe('nope');
+  });
+  it('name reflects class', () => {
+    expect(new SecretNotFoundError('x').name).toBe('SecretNotFoundError');
+  });
+});
+
+describe('SecretPolicyDeniedError', () => {
+  it('classifies as policy_denied', () => {
+    expect(new SecretPolicyDeniedError('denied').errorClass).toBe('policy_denied');
+  });
+  it('preserves category', () => {
+    expect(new SecretPolicyDeniedError('denied', { category: 'c' }).category).toBe('c');
+  });
+});
+
+describe('SecretRateLimitedError', () => {
+  it('classifies as rate_limited', () => {
+    expect(new SecretRateLimitedError('429').errorClass).toBe('rate_limited');
+  });
+  it('captures retryAfterMs', () => {
+    expect(new SecretRateLimitedError('429', { retryAfterMs: 1500 }).retryAfterMs).toBe(1500);
+  });
+  it('retryAfterMs undefined when omitted', () => {
+    expect(new SecretRateLimitedError('429').retryAfterMs).toBeUndefined();
+  });
+});
+
+describe('SecretProviderError', () => {
+  it('classifies as provider_error', () => {
+    expect(new SecretProviderError('boom').errorClass).toBe('provider_error');
+  });
+  it('captures cause', () => {
+    const cause = new Error('underlying');
+    expect(new SecretProviderError('boom', { cause }).cause).toBe(cause);
+  });
+});
+
+describe('SecretsAdapterConfigError', () => {
+  it('is a plain Error subclass', () => {
+    const e = new SecretsAdapterConfigError('missing env');
+    expect(e.message).toBe('missing env');
+    expect(e.name).toBe('SecretsAdapterConfigError');
+    expect(e).not.toBeInstanceOf(SecretsAdapterError);
+  });
+});
+
+describe('classifyError', () => {
+  it('classifies SecretNotFoundError', () => {
+    expect(classifyError(new SecretNotFoundError('x'))).toBe('not_found');
+  });
+  it('classifies SecretPolicyDeniedError', () => {
+    expect(classifyError(new SecretPolicyDeniedError('x'))).toBe('policy_denied');
+  });
+  it('classifies SecretRateLimitedError', () => {
+    expect(classifyError(new SecretRateLimitedError('x'))).toBe('rate_limited');
+  });
+  it('classifies SecretProviderError', () => {
+    expect(classifyError(new SecretProviderError('x'))).toBe('provider_error');
+  });
+  it('defaults to provider_error for plain Error', () => {
+    expect(classifyError(new Error('x'))).toBe('provider_error');
+  });
+  it('defaults to provider_error for non-Error', () => {
+    expect(classifyError('s')).toBe('provider_error');
+    expect(classifyError(undefined)).toBe('provider_error');
+    expect(classifyError(null)).toBe('provider_error');
+    expect(classifyError({})).toBe('provider_error');
+  });
+});

--- a/packages/secrets-adapter/tests/types.test.ts
+++ b/packages/secrets-adapter/tests/types.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AccessContextSchema,
+  AccessLogEntrySchema,
+  CallerTypeSchema,
+  CategorySchema,
+  DeleteAllForTenantOptionsSchema,
+  DeleteAllResultSchema,
+  DeleteOptionsSchema,
+  ErrorClassSchema,
+  KeySchema,
+  PingResultSchema,
+  PutOptionsSchema,
+  PutResultSchema,
+  RotateResultSchema,
+  SecretMetadataSchema,
+  SecretValueSchema,
+  TenantIdSchema,
+} from '../src/types.js';
+
+describe('CallerTypeSchema', () => {
+  it('accepts agent', () => {
+    expect(CallerTypeSchema.parse('agent')).toBe('agent');
+  });
+  it('accepts deploy-worker', () => {
+    expect(CallerTypeSchema.parse('deploy-worker')).toBe('deploy-worker');
+  });
+  it('rejects an unknown caller type', () => {
+    expect(() => CallerTypeSchema.parse('hacker')).toThrow();
+  });
+});
+
+describe('AccessContextSchema', () => {
+  it('accepts the minimal required envelope', () => {
+    const ctx = AccessContextSchema.parse({
+      callerType: 'agent',
+      callerId: 'coding-agent',
+      reason: 'deploy to prod',
+    });
+    expect(ctx.callerType).toBe('agent');
+  });
+  it('accepts the full envelope', () => {
+    const ctx = AccessContextSchema.parse({
+      callerType: 'deploy-worker',
+      callerId: 'worker-pod-7',
+      ticketId: 'sps-2026-05-23-001',
+      reason: 'push docker image',
+      capabilityTokenId: 'token-abcdef12',
+      requesterIp: '10.0.0.7',
+    });
+    expect(ctx.ticketId).toBe('sps-2026-05-23-001');
+  });
+  it('rejects when reason exceeds 500 chars', () => {
+    expect(() =>
+      AccessContextSchema.parse({
+        callerType: 'agent',
+        callerId: 'a',
+        reason: 'x'.repeat(501),
+      }),
+    ).toThrow();
+  });
+  it('rejects empty reason', () => {
+    expect(() =>
+      AccessContextSchema.parse({ callerType: 'agent', callerId: 'a', reason: '' }),
+    ).toThrow();
+  });
+  it('rejects empty callerId', () => {
+    expect(() =>
+      AccessContextSchema.parse({ callerType: 'agent', callerId: '', reason: 'ok' }),
+    ).toThrow();
+  });
+  it('rejects an invalid callerType', () => {
+    expect(() =>
+      AccessContextSchema.parse({ callerType: 'evil', callerId: 'a', reason: 'r' }),
+    ).toThrow();
+  });
+  it('rejects short capabilityTokenId', () => {
+    expect(() =>
+      AccessContextSchema.parse({
+        callerType: 'agent',
+        callerId: 'a',
+        reason: 'r',
+        capabilityTokenId: 'short',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('SecretMetadataSchema', () => {
+  it('accepts minimal record', () => {
+    const m = SecretMetadataSchema.parse({
+      key: 'k',
+      category: 'cloud.aws',
+      secretRef: 'pk_123',
+      createdAt: new Date(),
+    });
+    expect(m.version).toBeUndefined();
+  });
+  it('accepts full record', () => {
+    const m = SecretMetadataSchema.parse({
+      key: 'token',
+      category: 'cloud.cf',
+      secretRef: 'pk_456',
+      createdAt: new Date(),
+      lastAccessedAt: new Date(),
+      lastRotatedAt: new Date(),
+      version: 3,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(m.version).toBe(3);
+  });
+  it('rejects negative version', () => {
+    expect(() =>
+      SecretMetadataSchema.parse({
+        key: 'k', category: 'c', secretRef: 'r', createdAt: new Date(), version: -1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('AccessLogEntrySchema', () => {
+  it('accepts successful read', () => {
+    const e = AccessLogEntrySchema.parse({
+      tenantId: 'a', category: 'c', key: 'k', callerType: 'agent',
+      callerId: 'a', reason: 'r', grantedAt: new Date(), ok: true,
+    });
+    expect(e.ok).toBe(true);
+  });
+  it('accepts failed read with errorClass', () => {
+    const e = AccessLogEntrySchema.parse({
+      tenantId: 'a', category: 'c', key: 'k', callerType: 'agent',
+      callerId: 'a', reason: 'r', grantedAt: new Date(),
+      ok: false, errorClass: 'not_found',
+    });
+    expect(e.errorClass).toBe('not_found');
+  });
+  it('rejects invalid errorClass', () => {
+    expect(() =>
+      AccessLogEntrySchema.parse({
+        tenantId: 'a', category: 'c', key: 'k', callerType: 'agent',
+        callerId: 'a', reason: 'r', grantedAt: new Date(), ok: false, errorClass: 'nope',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('ErrorClassSchema', () => {
+  it('accepts all four classes', () => {
+    for (const cls of ['not_found', 'policy_denied', 'rate_limited', 'provider_error'] as const) {
+      expect(ErrorClassSchema.parse(cls)).toBe(cls);
+    }
+  });
+});
+
+describe('PutOptionsSchema', () => {
+  it('accepts empty', () => {
+    expect(PutOptionsSchema.parse({})).toEqual({});
+  });
+  it('accepts ttl + replace', () => {
+    expect(PutOptionsSchema.parse({ ttlSeconds: 60, replace: true })).toEqual({
+      ttlSeconds: 60, replace: true,
+    });
+  });
+  it('rejects negative ttl', () => {
+    expect(() => PutOptionsSchema.parse({ ttlSeconds: -1 })).toThrow();
+  });
+  it('rejects ttl > 1 year', () => {
+    expect(() => PutOptionsSchema.parse({ ttlSeconds: 60 * 60 * 24 * 366 })).toThrow();
+  });
+});
+
+describe('Delete options', () => {
+  it('purge', () => {
+    expect(DeleteOptionsSchema.parse({ purge: true }).purge).toBe(true);
+  });
+  it('dryRun', () => {
+    expect(DeleteAllForTenantOptionsSchema.parse({ dryRun: true }).dryRun).toBe(true);
+  });
+});
+
+describe('Return shapes', () => {
+  it('PutResult', () => {
+    expect(PutResultSchema.parse({ secretRef: 'r' })).toEqual({ secretRef: 'r' });
+  });
+  it('RotateResult', () => {
+    expect(RotateResultSchema.parse({ rotatedAt: new Date(), version: 2 }).version).toBe(2);
+  });
+  it('DeleteAllResult', () => {
+    expect(
+      DeleteAllResultSchema.parse({ deletedCount: 7, tenantTombstoneRef: 't' }).deletedCount,
+    ).toBe(7);
+  });
+  it('PingResult', () => {
+    expect(PingResultSchema.parse({ ok: true, latencyMs: 12, backend: 'pg' }).backend).toBe('pg');
+  });
+});
+
+describe('TenantIdSchema', () => {
+  it('accepts ok', () => expect(TenantIdSchema.parse('tenant-007')).toBe('tenant-007'));
+  it('rejects uppercase', () => expect(() => TenantIdSchema.parse('Tenant')).toThrow());
+  it('rejects empty', () => expect(() => TenantIdSchema.parse('')).toThrow());
+  it('rejects leading hyphen', () => expect(() => TenantIdSchema.parse('-abc')).toThrow());
+  it('rejects >64', () => expect(() => TenantIdSchema.parse('a'.repeat(65))).toThrow());
+});
+
+describe('CategorySchema', () => {
+  it('accepts dotted', () => expect(CategorySchema.parse('cloud.aws')).toBe('cloud.aws'));
+  it('rejects uppercase', () => expect(() => CategorySchema.parse('Cloud')).toThrow());
+});
+
+describe('KeySchema', () => {
+  it('mixed case', () => expect(KeySchema.parse('ACCESS_KEY_ID')).toBe('ACCESS_KEY_ID'));
+  it('dot ns', () => expect(KeySchema.parse('cloud.aws.x')).toBe('cloud.aws.x'));
+  it('rejects leading hyphen', () => expect(() => KeySchema.parse('-key')).toThrow());
+});
+
+describe('SecretValueSchema', () => {
+  it('non-empty', () => expect(SecretValueSchema.parse('hunter2')).toBe('hunter2'));
+  it('rejects empty', () => expect(() => SecretValueSchema.parse('')).toThrow());
+});

--- a/packages/secrets-adapter/tsconfig.json
+++ b/packages/secrets-adapter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/secrets-adapter/vitest.config.ts
+++ b/packages/secrets-adapter/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig();

--- a/packages/secrets-infisical/CHANGELOG.md
+++ b/packages/secrets-infisical/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @caia/secrets-infisical
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release. `InfisicalSecretsAdapter` — project-per-tenant
+  isolation with machine-identity universal-auth + token caching +
+  Cloudflare-Access service-token support. Implements
+  `research/multi_tenant_secrets_architecture_2026.md` §3 Pattern B + §5.

--- a/packages/secrets-infisical/README.md
+++ b/packages/secrets-infisical/README.md
@@ -1,0 +1,71 @@
+# `@caia/secrets-infisical`
+
+> Phase-1 hot-path `SecretsAdapter` for CAIA.
+
+Self-hosted Infisical. Project-per-tenant isolation. Machine-identity
+universal-auth. Optional Cloudflare-Access service-token headers for
+deployments behind Cloudflare Tunnel.
+
+## What you get
+
+- `InfisicalSecretsAdapter` — implements `SecretsAdapter` from
+  `@caia/secrets-adapter`.
+- `InfisicalAuth` — universal-auth machine identity login + access-token
+  cache + auto-refresh.
+- `InfisicalClient` — thin V3 HTTP client (get / put / patch / delete /
+  list raw secrets).
+- `ConfigMapProjectResolver`, `FunctionProjectResolver` — tenant→project
+  mapping.
+- `NoopAuditLogger`, `InMemoryAuditLogger` — audit-log pluggability;
+  inject `PostgresAuditLogger` from `@caia/secrets-postgres` for the
+  canonical persistent log.
+
+## Quickstart
+
+```ts
+import {
+  InfisicalSecretsAdapter,
+  ConfigMapProjectResolver,
+} from '@caia/secrets-infisical';
+
+const adapter = new InfisicalSecretsAdapter({
+  baseUrl: 'https://infisical.chiefaia.com',
+  auth: {
+    type: 'universal-auth',
+    clientId: process.env.INFISICAL_CLIENT_ID!,
+    clientSecret: process.env.INFISICAL_CLIENT_SECRET!,
+  },
+  cloudflareAccess: {
+    clientId: process.env.CF_ACCESS_CLIENT_ID!,
+    clientSecret: process.env.CF_ACCESS_CLIENT_SECRET!,
+  },
+  projectResolver: new ConfigMapProjectResolver({
+    'tenant-prakash': 'wsk_uuid_for_prakash',
+    'tenant-acme': 'wsk_uuid_for_acme',
+  }),
+  environment: 'prod',
+});
+
+await adapter.put('tenant-prakash', 'cloud.aws', 'access_key', 'AKIA...');
+const value = await adapter.get('tenant-prakash', 'cloud.aws', 'access_key', {
+  callerType: 'agent',
+  callerId: 'deploy-worker-7',
+  reason: 'push docker image',
+});
+```
+
+## Env
+
+| name | required | description |
+|---|---|---|
+| `INFISICAL_URL` | for integration tests | `https://infisical.chiefaia.com` |
+| `INFISICAL_CLIENT_ID` | for integration tests | machine identity universal-auth client id |
+| `INFISICAL_CLIENT_SECRET` | for integration tests | machine identity universal-auth client secret |
+| `INFISICAL_TEST_WORKSPACE_ID` | for integration tests | a project the machine identity can write to |
+| `CF_ACCESS_CLIENT_ID` | when behind CF Access | Cloudflare Access service-token client id |
+| `CF_ACCESS_CLIENT_SECRET` | when behind CF Access | Cloudflare Access service-token client secret |
+
+## Reference
+
+`research/multi_tenant_secrets_architecture_2026.md` §1, §3 (Pattern B),
+§5, §9.

--- a/packages/secrets-infisical/eslint.config.cjs
+++ b/packages/secrets-infisical/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/secrets-infisical/package.json
+++ b/packages/secrets-infisical/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@caia/secrets-infisical",
+  "version": "0.1.0",
+  "description": "Self-hosted Infisical SecretsAdapter — project-per-tenant isolation with machine-identity universal-auth. Phase-1 hot-path adapter for CAIA's multi-tenant secrets architecture.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:integration": "vitest run -c vitest.integration.config.ts",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@caia/secrets-adapter": "workspace:*",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/secrets-infisical/src/adapter.ts
+++ b/packages/secrets-infisical/src/adapter.ts
@@ -1,0 +1,442 @@
+/**
+ * `InfisicalSecretsAdapter` - Pattern B from the architecture spec.
+ *
+ * One Infisical project per tenant. Secrets organized at
+ *   secretPath = `/${category}`
+ *   secretName = key
+ * inside the tenant's project, under a single environment (default `prod`).
+ *
+ * The tenant->projectId mapping is supplied via a `ProjectResolver`.
+ * Audit log writes go to an injected `AuditLogger` (the canonical Postgres
+ * one from `@caia/secrets-postgres` works, or NoopAuditLogger for tests).
+ */
+
+import {
+  AccessContextSchema,
+  CategorySchema,
+  KeySchema,
+  SecretValueSchema,
+  TenantIdSchema,
+  SecretsAdapterConfigError,
+  classifyError,
+  type AccessContext,
+  type AccessLogEntry,
+  type DeleteAllForTenantOptions,
+  type DeleteAllResult,
+  type DeleteOptions,
+  type PingResult,
+  type PutOptions,
+  type PutResult,
+  type RotateResult,
+  type SecretMetadata,
+  type SecretsAdapter,
+} from '@caia/secrets-adapter';
+
+import { InfisicalAuth, type AuthConfig, type CloudflareAccessConfig } from './auth.js';
+import { InfisicalClient, type InfisicalRawSecret } from './client.js';
+import { NoopAuditLogger, type AuditLogger } from './audit.js';
+import { type ProjectResolver } from './project-resolver.js';
+
+export const BACKEND_NAME = 'infisical';
+
+export interface InfisicalSecretsAdapterOptions {
+  baseUrl: string;
+  auth: AuthConfig;
+  cloudflareAccess?: CloudflareAccessConfig;
+  projectResolver: ProjectResolver;
+  /** Defaults to "prod". */
+  environment?: string;
+  auditLogger?: AuditLogger;
+  /** Override for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override for tests. */
+  now?: () => Date;
+}
+
+export class InfisicalSecretsAdapter implements SecretsAdapter {
+  private readonly client: InfisicalClient;
+  private readonly resolver: ProjectResolver;
+  private readonly environment: string;
+  private readonly audit: AuditLogger;
+  private readonly auditEvents: AccessLogEntry[] = [];
+
+  constructor(opts: InfisicalSecretsAdapterOptions) {
+    if (!opts.baseUrl) {
+      throw new SecretsAdapterConfigError(
+        'InfisicalSecretsAdapter: baseUrl is required',
+      );
+    }
+    if (!opts.projectResolver) {
+      throw new SecretsAdapterConfigError(
+        'InfisicalSecretsAdapter: projectResolver is required',
+      );
+    }
+    const auth = new InfisicalAuth({
+      baseUrl: opts.baseUrl,
+      auth: opts.auth,
+      ...(opts.cloudflareAccess ? { cloudflareAccess: opts.cloudflareAccess } : {}),
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    });
+    this.client = new InfisicalClient({
+      baseUrl: opts.baseUrl,
+      auth,
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    });
+    this.resolver = opts.projectResolver;
+    this.environment = opts.environment ?? 'prod';
+    this.audit = opts.auditLogger ?? new NoopAuditLogger();
+  }
+
+  // ---------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------
+
+  private validateIdentifiers(
+    tenantId: string,
+    category: string,
+    key: string,
+  ): void {
+    TenantIdSchema.parse(tenantId);
+    CategorySchema.parse(category);
+    KeySchema.parse(key);
+  }
+
+  private categoryToPath(category: string): string {
+    return `/${category}`;
+  }
+
+  private secretRef(raw: InfisicalRawSecret): string {
+    return raw.id ?? raw._id ?? `${raw.secretPath}/${raw.secretKey}@v${raw.version}`;
+  }
+
+  private toMetadata(raw: InfisicalRawSecret): SecretMetadata {
+    // strip leading '/' from secretPath to recover category
+    const category = raw.secretPath.replace(/^\//, '') || 'default';
+    return {
+      key: raw.secretKey,
+      category,
+      secretRef: this.secretRef(raw),
+      createdAt: new Date(raw.createdAt),
+      lastRotatedAt: new Date(raw.updatedAt),
+      version: raw.version,
+    };
+  }
+
+  private rememberAudit(entry: AccessLogEntry): void {
+    this.auditEvents.push(entry);
+    // Cap memory at 10k events; the canonical audit lives in the injected logger.
+    if (this.auditEvents.length > 10_000) this.auditEvents.shift();
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - put
+  // ---------------------------------------------------------------------
+
+  async put(
+    tenantId: string,
+    category: string,
+    key: string,
+    value: string,
+    opts?: PutOptions,
+  ): Promise<PutResult> {
+    this.validateIdentifiers(tenantId, category, key);
+    SecretValueSchema.parse(value);
+    const workspaceId = await this.resolver.resolve(tenantId);
+
+    let raw: InfisicalRawSecret;
+    if (opts?.replace) {
+      try {
+        raw = await this.client.updateSecret({
+          workspaceId,
+          environment: this.environment,
+          secretPath: this.categoryToPath(category),
+          secretName: key,
+          secretValue: value,
+        });
+      } catch (err) {
+        // If the secret doesn't exist yet, fall through to create.
+        if (
+          err &&
+          typeof err === 'object' &&
+          'errorClass' in err &&
+          (err as { errorClass: string }).errorClass === 'not_found'
+        ) {
+          raw = await this.client.putSecret({
+            workspaceId,
+            environment: this.environment,
+            secretPath: this.categoryToPath(category),
+            secretName: key,
+            secretValue: value,
+          });
+        } else {
+          throw err;
+        }
+      }
+    } else {
+      raw = await this.client.putSecret({
+        workspaceId,
+        environment: this.environment,
+        secretPath: this.categoryToPath(category),
+        secretName: key,
+        secretValue: value,
+      });
+    }
+    return { secretRef: this.secretRef(raw), version: raw.version };
+  }
+
+  async putWithAudit(
+    tenantId: string,
+    category: string,
+    key: string,
+    value: string,
+    callerContext: AccessContext,
+    opts?: PutOptions,
+  ): Promise<PutResult> {
+    AccessContextSchema.parse(callerContext);
+    let result: PutResult | undefined;
+    let thrown: unknown;
+    try {
+      result = await this.put(tenantId, category, key, value, opts);
+    } catch (err) {
+      thrown = err;
+    }
+    await this.audit.write({
+      tenantId,
+      category,
+      key,
+      backend: BACKEND_NAME,
+      action: 'put',
+      callerContext,
+      ok: thrown === undefined,
+      ...(thrown !== undefined ? { errorClass: classifyError(thrown) } : {}),
+      ...(result?.secretRef !== undefined
+        ? { providerTrace: result.secretRef }
+        : {}),
+    });
+    if (thrown !== undefined) throw thrown;
+    return result as PutResult;
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - get
+  // ---------------------------------------------------------------------
+
+  async get(
+    tenantId: string,
+    category: string,
+    key: string,
+    callerContext: AccessContext,
+  ): Promise<string> {
+    this.validateIdentifiers(tenantId, category, key);
+    AccessContextSchema.parse(callerContext);
+    const grantedAt = new Date();
+    try {
+      const workspaceId = await this.resolver.resolve(tenantId);
+      const raw = await this.client.getSecret({
+        workspaceId,
+        environment: this.environment,
+        secretPath: this.categoryToPath(category),
+        secretName: key,
+      });
+      const entry: AccessLogEntry = {
+        tenantId,
+        category,
+        key,
+        callerType: callerContext.callerType,
+        callerId: callerContext.callerId,
+        reason: callerContext.reason,
+        grantedAt,
+        ok: true,
+        providerTrace: this.secretRef(raw),
+      };
+      if (callerContext.ticketId !== undefined) entry.ticketId = callerContext.ticketId;
+      if (callerContext.capabilityTokenId !== undefined)
+        entry.capabilityTokenId = callerContext.capabilityTokenId;
+      if (callerContext.requesterIp !== undefined)
+        entry.requesterIp = callerContext.requesterIp;
+      this.rememberAudit(entry);
+      await this.audit.write({
+        tenantId,
+        category,
+        key,
+        backend: BACKEND_NAME,
+        action: 'get',
+        callerContext,
+        ok: true,
+        providerTrace: this.secretRef(raw),
+      });
+      return raw.secretValue;
+    } catch (err) {
+      const errorClass = classifyError(err);
+      const entry: AccessLogEntry = {
+        tenantId,
+        category,
+        key,
+        callerType: callerContext.callerType,
+        callerId: callerContext.callerId,
+        reason: callerContext.reason,
+        grantedAt,
+        ok: false,
+        errorClass,
+      };
+      if (callerContext.ticketId !== undefined) entry.ticketId = callerContext.ticketId;
+      if (callerContext.capabilityTokenId !== undefined)
+        entry.capabilityTokenId = callerContext.capabilityTokenId;
+      if (callerContext.requesterIp !== undefined)
+        entry.requesterIp = callerContext.requesterIp;
+      this.rememberAudit(entry);
+      await this.audit.write({
+        tenantId,
+        category,
+        key,
+        backend: BACKEND_NAME,
+        action: 'get',
+        callerContext,
+        ok: false,
+        errorClass,
+      });
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - list
+  // ---------------------------------------------------------------------
+
+  async list(tenantId: string, category?: string): Promise<SecretMetadata[]> {
+    TenantIdSchema.parse(tenantId);
+    if (category !== undefined) CategorySchema.parse(category);
+    const workspaceId = await this.resolver.resolve(tenantId);
+    // Infisical list is scoped to a single path. If `category` is omitted
+    // we list at root and filter by path prefix client-side.
+    const raws = await this.client.listSecrets({
+      workspaceId,
+      environment: this.environment,
+      secretPath: category ? this.categoryToPath(category) : '/',
+    });
+    return raws.map((r) => this.toMetadata(r));
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - rotate
+  // ---------------------------------------------------------------------
+
+  async rotate(
+    tenantId: string,
+    category: string,
+    key: string,
+  ): Promise<RotateResult> {
+    this.validateIdentifiers(tenantId, category, key);
+    const workspaceId = await this.resolver.resolve(tenantId);
+    // Infisical has no "rotate without new value" primitive; we re-PATCH
+    // with the current value, which bumps version + updatedAt — the
+    // architecture spec calls this acceptable since the actual key
+    // rotation is provider-specific (Stripe, AWS STS, etc.) and the
+    // adapter caller supplies the new value via put({replace: true}).
+    const current = await this.client.getSecret({
+      workspaceId,
+      environment: this.environment,
+      secretPath: this.categoryToPath(category),
+      secretName: key,
+    });
+    const updated = await this.client.updateSecret({
+      workspaceId,
+      environment: this.environment,
+      secretPath: this.categoryToPath(category),
+      secretName: key,
+      secretValue: current.secretValue,
+    });
+    return {
+      rotatedAt: new Date(updated.updatedAt),
+      version: updated.version,
+    };
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - delete
+  // ---------------------------------------------------------------------
+
+  async delete(
+    tenantId: string,
+    category: string,
+    key: string,
+    _opts?: DeleteOptions,
+  ): Promise<void> {
+    this.validateIdentifiers(tenantId, category, key);
+    const workspaceId = await this.resolver.resolve(tenantId);
+    await this.client.deleteSecret({
+      workspaceId,
+      environment: this.environment,
+      secretPath: this.categoryToPath(category),
+      secretName: key,
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - deleteAllForTenant
+  // ---------------------------------------------------------------------
+
+  async deleteAllForTenant(
+    tenantId: string,
+    opts?: DeleteAllForTenantOptions,
+  ): Promise<DeleteAllResult> {
+    TenantIdSchema.parse(tenantId);
+    const workspaceId = await this.resolver.resolve(tenantId);
+    const allSecrets = await this.client.listSecrets({
+      workspaceId,
+      environment: this.environment,
+      secretPath: '/',
+    });
+    const tombstoneRef = `tomb_${tenantId}_${Date.now().toString(36)}_${Math.random()
+      .toString(36)
+      .slice(2, 10)}`;
+    if (opts?.dryRun) {
+      return {
+        deletedCount: allSecrets.length,
+        tenantTombstoneRef: `${tombstoneRef}_dryrun`,
+      };
+    }
+    let deleted = 0;
+    for (const raw of allSecrets) {
+      await this.client.deleteSecret({
+        workspaceId,
+        environment: this.environment,
+        secretPath: raw.secretPath,
+        secretName: raw.secretKey,
+      });
+      deleted += 1;
+    }
+    return { deletedCount: deleted, tenantTombstoneRef: tombstoneRef };
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - auditLog
+  // ---------------------------------------------------------------------
+
+  async auditLog(
+    tenantId: string,
+    since?: Date,
+    until?: Date,
+  ): Promise<AccessLogEntry[]> {
+    TenantIdSchema.parse(tenantId);
+    const sinceMs = since?.getTime() ?? -Infinity;
+    const untilMs = until?.getTime() ?? Infinity;
+    return this.auditEvents
+      .filter((e) => e.tenantId === tenantId)
+      .filter((e) => {
+        const t = e.grantedAt.getTime();
+        return t >= sinceMs && t <= untilMs;
+      })
+      .slice()
+      .reverse();
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter - ping
+  // ---------------------------------------------------------------------
+
+  async ping(): Promise<PingResult> {
+    const r = await this.client.health();
+    return { ok: r.ok, latencyMs: r.latencyMs, backend: BACKEND_NAME };
+  }
+}

--- a/packages/secrets-infisical/src/audit.ts
+++ b/packages/secrets-infisical/src/audit.ts
@@ -1,0 +1,41 @@
+/**
+ * Audit-log interface for the Infisical adapter.
+ *
+ * Mirrors the shape used by `@caia/secrets-postgres` so that an operator
+ * who wants a unified audit table can pass the Postgres logger in here.
+ * The Infisical adapter does NOT depend on `@caia/secrets-postgres`;
+ * callers wire it up.
+ */
+
+import type { AccessContext, ErrorClass } from '@caia/secrets-adapter';
+
+export interface AuditWriteParams {
+  tenantId: string;
+  category: string;
+  key: string;
+  backend: string;
+  action: 'get' | 'put' | 'rotate' | 'delete' | 'delete_all';
+  callerContext: AccessContext;
+  ok: boolean;
+  errorClass?: ErrorClass;
+  providerTrace?: string;
+}
+
+export interface AuditLogger {
+  write(params: AuditWriteParams): Promise<void>;
+}
+
+/** Default — drops all events. Used in tests + when the broker handles audit upstream. */
+export class NoopAuditLogger implements AuditLogger {
+  async write(_params: AuditWriteParams): Promise<void> {
+    // intentionally empty
+  }
+}
+
+/** In-memory logger — handy for unit tests + ad-hoc inspection. */
+export class InMemoryAuditLogger implements AuditLogger {
+  readonly events: AuditWriteParams[] = [];
+  async write(params: AuditWriteParams): Promise<void> {
+    this.events.push(params);
+  }
+}

--- a/packages/secrets-infisical/src/auth.ts
+++ b/packages/secrets-infisical/src/auth.ts
@@ -1,0 +1,191 @@
+/**
+ * Infisical machine-identity authentication.
+ *
+ * The adapter logs in with Universal Auth (client-id + client-secret),
+ * receives a short-lived `accessToken`, caches it, and refreshes it
+ * roughly 5 minutes before the documented expiry.
+ *
+ * Why we don't just use a long-lived service token: Infisical deprecated
+ * `serviceTokens` in favor of machine identities; universal-auth is the
+ * supported successor and supports per-identity rate limits + scoping.
+ *
+ * Self-hosted Infisical sits behind Cloudflare Access in CAIA's stand-up,
+ * so authenticated requests need both:
+ *   - `Authorization: Bearer <infisical-accessToken>`
+ *   - `CF-Access-Client-Id: ...` and `CF-Access-Client-Secret: ...`
+ */
+
+import { SecretsAdapterConfigError, SecretProviderError } from '@caia/secrets-adapter';
+
+export interface UniversalAuthConfig {
+  type: 'universal-auth';
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface StaticTokenAuthConfig {
+  type: 'static-token';
+  /**
+   * Pre-minted access token. Useful for tests + short-lived CI jobs.
+   * Will NEVER auto-refresh.
+   */
+  accessToken: string;
+}
+
+export type AuthConfig = UniversalAuthConfig | StaticTokenAuthConfig;
+
+export interface CloudflareAccessConfig {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface InfisicalAuthOptions {
+  baseUrl: string;
+  auth: AuthConfig;
+  cloudflareAccess?: CloudflareAccessConfig;
+  /** Override for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override for tests. Default: 5 minutes before documented expiry. */
+  refreshSkewMs?: number;
+  /** Injectable clock. */
+  now?: () => number;
+}
+
+interface UniversalAuthLoginResponse {
+  accessToken: string;
+  expiresIn: number; // seconds
+  accessTokenMaxTTL: number; // seconds
+  tokenType: 'Bearer';
+}
+
+interface CachedToken {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+export class InfisicalAuth {
+  private readonly baseUrl: string;
+  private readonly auth: AuthConfig;
+  private readonly cfAccess?: CloudflareAccessConfig;
+  private readonly fetchImpl: typeof fetch;
+  private readonly refreshSkewMs: number;
+  private readonly now: () => number;
+  private cached: CachedToken | null = null;
+  private inflight: Promise<CachedToken> | null = null;
+
+  constructor(opts: InfisicalAuthOptions) {
+    if (!opts.baseUrl) {
+      throw new SecretsAdapterConfigError('InfisicalAuth: baseUrl is required');
+    }
+    if (!opts.auth) {
+      throw new SecretsAdapterConfigError('InfisicalAuth: auth config is required');
+    }
+    if (opts.auth.type === 'universal-auth') {
+      if (!opts.auth.clientId || !opts.auth.clientSecret) {
+        throw new SecretsAdapterConfigError(
+          'InfisicalAuth: universal-auth requires clientId + clientSecret',
+        );
+      }
+    } else if (opts.auth.type === 'static-token') {
+      if (!opts.auth.accessToken) {
+        throw new SecretsAdapterConfigError(
+          'InfisicalAuth: static-token requires accessToken',
+        );
+      }
+    } else {
+      throw new SecretsAdapterConfigError(
+        `InfisicalAuth: unknown auth type ${(opts.auth as { type: string }).type}`,
+      );
+    }
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+    this.auth = opts.auth;
+    if (opts.cloudflareAccess) this.cfAccess = opts.cloudflareAccess;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.refreshSkewMs = opts.refreshSkewMs ?? 5 * 60 * 1000;
+    this.now = opts.now ?? ((): number => Date.now());
+  }
+
+  /** Headers that should accompany every authenticated API call. */
+  async authorizedHeaders(): Promise<Record<string, string>> {
+    const token = await this.getAccessToken();
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (this.cfAccess) {
+      headers['CF-Access-Client-Id'] = this.cfAccess.clientId;
+      headers['CF-Access-Client-Secret'] = this.cfAccess.clientSecret;
+    }
+    return headers;
+  }
+
+  /** Just the CF-Access headers, when needed pre-auth (e.g. for the login call itself). */
+  cloudflareAccessHeaders(): Record<string, string> {
+    if (!this.cfAccess) return {};
+    return {
+      'CF-Access-Client-Id': this.cfAccess.clientId,
+      'CF-Access-Client-Secret': this.cfAccess.clientSecret,
+    };
+  }
+
+  /** Force-clear the cached token. Used by callers that observe a 401. */
+  invalidate(): void {
+    this.cached = null;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.auth.type === 'static-token') return this.auth.accessToken;
+    if (this.cached && this.cached.expiresAtMs > this.now() + this.refreshSkewMs) {
+      return this.cached.accessToken;
+    }
+    if (this.inflight) {
+      const result = await this.inflight;
+      return result.accessToken;
+    }
+    this.inflight = this.login();
+    try {
+      this.cached = await this.inflight;
+      return this.cached.accessToken;
+    } finally {
+      this.inflight = null;
+    }
+  }
+
+  private async login(): Promise<CachedToken> {
+    if (this.auth.type !== 'universal-auth') {
+      throw new SecretsAdapterConfigError(
+        `InfisicalAuth: login is only valid for universal-auth (got ${this.auth.type})`,
+      );
+    }
+    const url = `${this.baseUrl}/api/v1/auth/universal-auth/login`;
+    const res = await this.fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...this.cloudflareAccessHeaders(),
+      },
+      body: JSON.stringify({
+        clientId: this.auth.clientId,
+        clientSecret: this.auth.clientSecret,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new SecretProviderError(
+        `Infisical login failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
+      );
+    }
+    const json = (await res.json()) as UniversalAuthLoginResponse;
+    if (!json.accessToken || typeof json.expiresIn !== 'number') {
+      throw new SecretProviderError(
+        `Infisical login returned malformed body: ${JSON.stringify(json).slice(0, 200)}`,
+      );
+    }
+    return {
+      accessToken: json.accessToken,
+      expiresAtMs: this.now() + json.expiresIn * 1000,
+    };
+  }
+}

--- a/packages/secrets-infisical/src/client.ts
+++ b/packages/secrets-infisical/src/client.ts
@@ -1,0 +1,230 @@
+/**
+ * Thin Infisical V3 HTTP client used by the adapter.
+ *
+ * Endpoints in use (self-hosted, all v3 unless noted):
+ *
+ *   POST   /api/v3/secrets/raw/{secretName}       - create
+ *   GET    /api/v3/secrets/raw/{secretName}       - get one
+ *   PATCH  /api/v3/secrets/raw/{secretName}       - update (rotate)
+ *   DELETE /api/v3/secrets/raw/{secretName}       - delete
+ *   GET    /api/v3/secrets/raw                    - list
+ *   GET    /api/status                            - ping
+ */
+
+import {
+  SecretNotFoundError,
+  SecretPolicyDeniedError,
+  SecretProviderError,
+  SecretRateLimitedError,
+} from '@caia/secrets-adapter';
+import type { InfisicalAuth } from './auth.js';
+
+export interface InfisicalRawSecret {
+  id?: string;
+  _id?: string;
+  secretKey: string;
+  secretValue: string;
+  secretPath: string;
+  secretComment?: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListSecretsParams {
+  workspaceId: string;
+  environment: string;
+  secretPath: string;
+}
+
+export interface GetSecretParams extends ListSecretsParams {
+  secretName: string;
+}
+
+export interface PutSecretParams extends GetSecretParams {
+  secretValue: string;
+  type?: 'shared' | 'personal';
+  secretComment?: string;
+}
+
+export interface UpdateSecretParams extends GetSecretParams {
+  secretValue: string;
+}
+
+export interface DeleteSecretParams extends GetSecretParams {
+  type?: 'shared' | 'personal';
+}
+
+export interface InfisicalClientOptions {
+  baseUrl: string;
+  auth: InfisicalAuth;
+  fetchImpl?: typeof fetch;
+}
+
+export class InfisicalClient {
+  private readonly baseUrl: string;
+  private readonly auth: InfisicalAuth;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: InfisicalClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+    this.auth = opts.auth;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  }
+
+  private async request(
+    method: string,
+    pathAndQuery: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${pathAndQuery}`;
+    const doFetch = async (): Promise<Response> => {
+      const headers = await this.auth.authorizedHeaders();
+      return this.fetchImpl(url, {
+        method,
+        headers,
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    };
+    let res = await doFetch();
+    if (res.status === 401) {
+      this.auth.invalidate();
+      res = await doFetch();
+    }
+    return res;
+  }
+
+  private async throwForResponse(
+    res: Response,
+    context: { tenantId?: string; category?: string; key?: string },
+  ): Promise<never> {
+    const bodyText = await res.text().catch(() => '');
+    const trace = bodyText.slice(0, 500);
+    if (res.status === 404) {
+      throw new SecretNotFoundError(
+        `Infisical: not found (${res.status}) ${trace}`,
+        context,
+      );
+    }
+    if (res.status === 403 || res.status === 401) {
+      throw new SecretPolicyDeniedError(
+        `Infisical: forbidden (${res.status}) ${trace}`,
+        context,
+      );
+    }
+    if (res.status === 429) {
+      const retryAfterHeader = res.headers.get('retry-after');
+      const retryAfterMs =
+        retryAfterHeader && /^\d+$/.test(retryAfterHeader)
+          ? Number(retryAfterHeader) * 1000
+          : undefined;
+      throw new SecretRateLimitedError(
+        `Infisical: rate-limited (${res.status}) ${trace}`,
+        { ...context, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) },
+      );
+    }
+    throw new SecretProviderError(
+      `Infisical: provider error (${res.status} ${res.statusText}) ${trace}`,
+      context,
+    );
+  }
+
+  async getSecret(p: GetSecretParams): Promise<InfisicalRawSecret> {
+    const qs = new URLSearchParams({
+      workspaceId: p.workspaceId,
+      environment: p.environment,
+      secretPath: p.secretPath,
+    }).toString();
+    const res = await this.request(
+      'GET',
+      `/api/v3/secrets/raw/${encodeURIComponent(p.secretName)}?${qs}`,
+    );
+    if (!res.ok) {
+      await this.throwForResponse(res, { key: p.secretName });
+    }
+    const body = (await res.json()) as { secret: InfisicalRawSecret };
+    return body.secret;
+  }
+
+  async putSecret(p: PutSecretParams): Promise<InfisicalRawSecret> {
+    const res = await this.request(
+      'POST',
+      `/api/v3/secrets/raw/${encodeURIComponent(p.secretName)}`,
+      {
+        workspaceId: p.workspaceId,
+        environment: p.environment,
+        secretPath: p.secretPath,
+        secretValue: p.secretValue,
+        type: p.type ?? 'shared',
+        ...(p.secretComment !== undefined ? { secretComment: p.secretComment } : {}),
+      },
+    );
+    if (!res.ok) {
+      await this.throwForResponse(res, { key: p.secretName });
+    }
+    const body = (await res.json()) as { secret: InfisicalRawSecret };
+    return body.secret;
+  }
+
+  async updateSecret(p: UpdateSecretParams): Promise<InfisicalRawSecret> {
+    const res = await this.request(
+      'PATCH',
+      `/api/v3/secrets/raw/${encodeURIComponent(p.secretName)}`,
+      {
+        workspaceId: p.workspaceId,
+        environment: p.environment,
+        secretPath: p.secretPath,
+        secretValue: p.secretValue,
+      },
+    );
+    if (!res.ok) {
+      await this.throwForResponse(res, { key: p.secretName });
+    }
+    const body = (await res.json()) as { secret: InfisicalRawSecret };
+    return body.secret;
+  }
+
+  async deleteSecret(p: DeleteSecretParams): Promise<void> {
+    const qs = new URLSearchParams({
+      workspaceId: p.workspaceId,
+      environment: p.environment,
+      secretPath: p.secretPath,
+      ...(p.type !== undefined ? { type: p.type } : {}),
+    }).toString();
+    const res = await this.request(
+      'DELETE',
+      `/api/v3/secrets/raw/${encodeURIComponent(p.secretName)}?${qs}`,
+    );
+    if (!res.ok && res.status !== 404) {
+      await this.throwForResponse(res, { key: p.secretName });
+    }
+  }
+
+  async listSecrets(p: ListSecretsParams): Promise<InfisicalRawSecret[]> {
+    const qs = new URLSearchParams({
+      workspaceId: p.workspaceId,
+      environment: p.environment,
+      secretPath: p.secretPath,
+    }).toString();
+    const res = await this.request('GET', `/api/v3/secrets/raw?${qs}`);
+    if (!res.ok) {
+      await this.throwForResponse(res, {});
+    }
+    const body = (await res.json()) as { secrets: InfisicalRawSecret[] };
+    return body.secrets ?? [];
+  }
+
+  async health(): Promise<{ ok: boolean; latencyMs: number }> {
+    const start = Date.now();
+    try {
+      const url = `${this.baseUrl}/api/status`;
+      const res = await this.fetchImpl(url, {
+        method: 'GET',
+        headers: this.auth.cloudflareAccessHeaders(),
+      });
+      return { ok: res.ok, latencyMs: Date.now() - start };
+    } catch {
+      return { ok: false, latencyMs: Date.now() - start };
+    }
+  }
+}

--- a/packages/secrets-infisical/src/index.ts
+++ b/packages/secrets-infisical/src/index.ts
@@ -1,0 +1,45 @@
+/**
+ * `@caia/secrets-infisical` — public surface.
+ *
+ * Reference: research/multi_tenant_secrets_architecture_2026.md §1, §3
+ * (Pattern B), §5.
+ */
+
+export {
+  InfisicalSecretsAdapter,
+  BACKEND_NAME,
+  type InfisicalSecretsAdapterOptions,
+} from './adapter.js';
+
+export {
+  InfisicalAuth,
+  type AuthConfig,
+  type UniversalAuthConfig,
+  type StaticTokenAuthConfig,
+  type CloudflareAccessConfig,
+  type InfisicalAuthOptions,
+} from './auth.js';
+
+export {
+  InfisicalClient,
+  type InfisicalClientOptions,
+  type InfisicalRawSecret,
+  type GetSecretParams,
+  type PutSecretParams,
+  type UpdateSecretParams,
+  type DeleteSecretParams,
+  type ListSecretsParams,
+} from './client.js';
+
+export {
+  ConfigMapProjectResolver,
+  FunctionProjectResolver,
+  type ProjectResolver,
+} from './project-resolver.js';
+
+export {
+  NoopAuditLogger,
+  InMemoryAuditLogger,
+  type AuditLogger,
+  type AuditWriteParams,
+} from './audit.js';

--- a/packages/secrets-infisical/src/project-resolver.ts
+++ b/packages/secrets-infisical/src/project-resolver.ts
@@ -1,0 +1,58 @@
+/**
+ * Tenant→Infisical-project resolver.
+ *
+ * Pattern B from the architecture spec: one Infisical project per tenant.
+ * The mapping is canonical and must be persisted somewhere; this module
+ * only provides the *interface*. Implementations may be backed by:
+ *
+ *   - a static config map (development + tests)
+ *   - a Postgres lookup against `caia_meta.tenant_secret_routing`
+ *   - the Infisical API itself (`GET /api/v1/workspace` searched by name)
+ *
+ * Tenant ids that map to projects are validated up-front; missing
+ * mappings throw `SecretPolicyDeniedError` rather than `SecretNotFoundError`
+ * because the policy layer (router) is what decides which tenants get
+ * which adapters.
+ */
+
+import { SecretPolicyDeniedError } from '@caia/secrets-adapter';
+
+export interface ProjectResolver {
+  resolve(tenantId: string): Promise<string>;
+}
+
+/** Static map. Useful for tests and small fleets. */
+export class ConfigMapProjectResolver implements ProjectResolver {
+  private readonly map: ReadonlyMap<string, string>;
+  constructor(entries: Readonly<Record<string, string>> | ReadonlyMap<string, string>) {
+    this.map =
+      entries instanceof Map
+        ? new Map(entries)
+        : new Map(Object.entries(entries));
+  }
+  async resolve(tenantId: string): Promise<string> {
+    const projectId = this.map.get(tenantId);
+    if (!projectId) {
+      throw new SecretPolicyDeniedError(
+        `no Infisical project configured for tenant '${tenantId}'`,
+        { tenantId },
+      );
+    }
+    return projectId;
+  }
+}
+
+/** Function-backed resolver — for arbitrary lookup sources. */
+export class FunctionProjectResolver implements ProjectResolver {
+  constructor(private readonly fn: (tenantId: string) => Promise<string | undefined>) {}
+  async resolve(tenantId: string): Promise<string> {
+    const projectId = await this.fn(tenantId);
+    if (!projectId) {
+      throw new SecretPolicyDeniedError(
+        `no Infisical project configured for tenant '${tenantId}'`,
+        { tenantId },
+      );
+    }
+    return projectId;
+  }
+}

--- a/packages/secrets-infisical/tests/integration/live-infisical.test.ts
+++ b/packages/secrets-infisical/tests/integration/live-infisical.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Live-server integration test for `@caia/secrets-infisical`.
+ *
+ * Skipped unless every required env var is set. To run:
+ *
+ *   export INFISICAL_URL=https://infisical.chiefaia.com
+ *   export INFISICAL_CLIENT_ID=...
+ *   export INFISICAL_CLIENT_SECRET=...
+ *   export INFISICAL_TEST_WORKSPACE_ID=...
+ *   # optional, when behind Cloudflare Access:
+ *   export CF_ACCESS_CLIENT_ID=...
+ *   export CF_ACCESS_CLIENT_SECRET=...
+ *
+ *   pnpm test:integration
+ *
+ * Test data lives under `/caia-secrets-postgres-itest/`, prefixed with
+ * a UUID so concurrent runs don't collide. The suite cleans up after
+ * itself; if it doesn't, the path prefix makes orphans trivial to spot.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import {
+  ConfigMapProjectResolver,
+  InMemoryAuditLogger,
+  InfisicalSecretsAdapter,
+} from '../../src/index.js';
+import type { AccessContext } from '@caia/secrets-adapter';
+
+const url = process.env['INFISICAL_URL'];
+const clientId = process.env['INFISICAL_CLIENT_ID'];
+const clientSecret = process.env['INFISICAL_CLIENT_SECRET'];
+const workspaceId = process.env['INFISICAL_TEST_WORKSPACE_ID'];
+const cfClientId = process.env['CF_ACCESS_CLIENT_ID'];
+const cfClientSecret = process.env['CF_ACCESS_CLIENT_SECRET'];
+
+const skip = !url || !clientId || !clientSecret || !workspaceId;
+const d = skip ? describe.skip : describe;
+
+const tenantId = `itest-${randomUUID().slice(0, 8)}`;
+const category = `caia-secrets-infisical-itest`;
+const ctx: AccessContext = {
+  callerType: 'system',
+  callerId: 'vitest-integration',
+  reason: 'live infisical integration test',
+};
+
+let adapter: InfisicalSecretsAdapter;
+let audit: InMemoryAuditLogger;
+
+d('@caia/secrets-infisical — live integration', () => {
+  beforeAll(() => {
+    audit = new InMemoryAuditLogger();
+    adapter = new InfisicalSecretsAdapter({
+      baseUrl: url!,
+      auth: {
+        type: 'universal-auth',
+        clientId: clientId!,
+        clientSecret: clientSecret!,
+      },
+      ...(cfClientId && cfClientSecret
+        ? {
+            cloudflareAccess: {
+              clientId: cfClientId,
+              clientSecret: cfClientSecret,
+            },
+          }
+        : {}),
+      projectResolver: new ConfigMapProjectResolver({
+        [tenantId]: workspaceId!,
+      }),
+      auditLogger: audit,
+    });
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.deleteAllForTenant(tenantId);
+    } catch {
+      // best effort
+    }
+  });
+
+  it('pings the live host', async () => {
+    const r = await adapter.ping();
+    expect(r.backend).toBe('infisical');
+  });
+
+  it('round-trips a secret end-to-end', async () => {
+    const value = `secret-${randomUUID()}`;
+    const put = await adapter.put(tenantId, category, 'itest-key', value);
+    expect(put.secretRef).toBeTruthy();
+    const got = await adapter.get(tenantId, category, 'itest-key', ctx);
+    expect(got).toBe(value);
+  });
+
+  it('lists the secret we just wrote', async () => {
+    const list = await adapter.list(tenantId, category);
+    expect(list.find((m) => m.key === 'itest-key')).toBeTruthy();
+  });
+
+  it('replaces a value with replace=true', async () => {
+    const v2 = `secret-${randomUUID()}`;
+    await adapter.put(tenantId, category, 'itest-key', v2, { replace: true });
+    expect(await adapter.get(tenantId, category, 'itest-key', ctx)).toBe(v2);
+  });
+
+  it('deleteAllForTenant cleans up', async () => {
+    const r = await adapter.deleteAllForTenant(tenantId);
+    expect(r.deletedCount).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/secrets-infisical/tests/unit/adapter.test.ts
+++ b/packages/secrets-infisical/tests/unit/adapter.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from 'vitest';
+import {
+  InfisicalSecretsAdapter,
+  ConfigMapProjectResolver,
+  InMemoryAuditLogger,
+} from '../../src/index.js';
+import {
+  SecretNotFoundError,
+  SecretPolicyDeniedError,
+  SecretsAdapterConfigError,
+  type AccessContext,
+} from '@caia/secrets-adapter';
+import { MockInfisicalServer } from './fetch-mock.js';
+
+const ctx: AccessContext = {
+  callerType: 'agent',
+  callerId: 'unit-test',
+  reason: 'integration round-trip',
+};
+
+function newAdapter(server: MockInfisicalServer, audit?: InMemoryAuditLogger): InfisicalSecretsAdapter {
+  return new InfisicalSecretsAdapter({
+    baseUrl: 'https://infisical.test',
+    auth: { type: 'static-token', accessToken: 'tok_1' },
+    projectResolver: new ConfigMapProjectResolver({
+      'tenant-a': 'wsk-a',
+      'tenant-b': 'wsk-b',
+    }),
+    environment: 'prod',
+    fetchImpl: server.fetchImpl,
+    ...(audit ? { auditLogger: audit } : {}),
+  });
+}
+
+describe('InfisicalSecretsAdapter — construction', () => {
+  it('requires baseUrl', () => {
+    expect(
+      () =>
+        new InfisicalSecretsAdapter({
+          baseUrl: '',
+          auth: { type: 'static-token', accessToken: 't' },
+          projectResolver: new ConfigMapProjectResolver({}),
+        } as never),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+  it('requires projectResolver', () => {
+    expect(
+      () =>
+        new InfisicalSecretsAdapter({
+          baseUrl: 'https://x',
+          auth: { type: 'static-token', accessToken: 't' },
+        } as never),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+});
+
+describe('InfisicalSecretsAdapter — put + get round-trip', () => {
+  it('round-trips a secret', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'cloud.aws', 'access_key', 'AKIA-secret');
+    const got = await adapter.get(
+      'tenant-a',
+      'cloud.aws',
+      'access_key',
+      ctx,
+    );
+    expect(got).toBe('AKIA-secret');
+  });
+
+  it('put returns secretRef + version', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    const r = await adapter.put('tenant-a', 'c', 'k', 'v');
+    expect(r.secretRef).toMatch(/^inf_/);
+    expect(r.version).toBe(1);
+  });
+
+  it('replace=true updates an existing secret', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v1');
+    await adapter.put('tenant-a', 'c', 'k', 'v2', { replace: true });
+    expect(await adapter.get('tenant-a', 'c', 'k', ctx)).toBe('v2');
+  });
+
+  it('replace=true creates if absent', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    const r = await adapter.put('tenant-a', 'c', 'k', 'v', { replace: true });
+    expect(r.version).toBe(1);
+  });
+
+  it('rejects invalid tenantId', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await expect(
+      adapter.put('Tenant', 'c', 'k', 'v'),
+    ).rejects.toThrow();
+  });
+
+  it('rejects invalid category', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await expect(
+      adapter.put('tenant-a', 'Cloud', 'k', 'v'),
+    ).rejects.toThrow();
+  });
+
+  it('rejects empty value', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await expect(adapter.put('tenant-a', 'c', 'k', '')).rejects.toThrow();
+  });
+});
+
+describe('InfisicalSecretsAdapter — get failures', () => {
+  it('missing -> SecretNotFoundError', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await expect(
+      adapter.get('tenant-a', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+  });
+
+  it('unknown tenant -> SecretPolicyDeniedError', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await expect(
+      adapter.get('tenant-unknown', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretPolicyDeniedError);
+  });
+
+  it('rejects malformed AccessContext', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    // @ts-expect-error — missing reason
+    await expect(adapter.get('tenant-a', 'c', 'k', {})).rejects.toThrow();
+  });
+});
+
+describe('InfisicalSecretsAdapter — audit log emission', () => {
+  it('successful get emits an ok=true audit row', async () => {
+    const server = new MockInfisicalServer();
+    const audit = new InMemoryAuditLogger();
+    const adapter = newAdapter(server, audit);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    await adapter.get('tenant-a', 'c', 'k', ctx);
+    const gets = audit.events.filter((e) => e.action === 'get');
+    expect(gets).toHaveLength(1);
+    expect(gets[0]?.ok).toBe(true);
+    expect(gets[0]?.callerContext.callerId).toBe('unit-test');
+  });
+
+  it('failed get emits ok=false with errorClass', async () => {
+    const server = new MockInfisicalServer();
+    const audit = new InMemoryAuditLogger();
+    const adapter = newAdapter(server, audit);
+    await expect(
+      adapter.get('tenant-a', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+    const gets = audit.events.filter((e) => e.action === 'get');
+    expect(gets).toHaveLength(1);
+    expect(gets[0]?.ok).toBe(false);
+    expect(gets[0]?.errorClass).toBe('not_found');
+  });
+
+  it('putWithAudit emits put rows', async () => {
+    const server = new MockInfisicalServer();
+    const audit = new InMemoryAuditLogger();
+    const adapter = newAdapter(server, audit);
+    await adapter.putWithAudit('tenant-a', 'c', 'k', 'v', ctx);
+    const puts = audit.events.filter((e) => e.action === 'put');
+    expect(puts).toHaveLength(1);
+    expect(puts[0]?.ok).toBe(true);
+  });
+
+  it('adapter.auditLog returns its local events', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    await adapter.get('tenant-a', 'c', 'k', ctx);
+    await adapter.get('tenant-a', 'c', 'k', ctx);
+    const log = await adapter.auditLog('tenant-a');
+    expect(log).toHaveLength(2);
+    for (const entry of log) expect(entry.tenantId).toBe('tenant-a');
+  });
+
+  it('audit log isolates tenants', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'va');
+    await adapter.put('tenant-b', 'c', 'k', 'vb');
+    await adapter.get('tenant-a', 'c', 'k', ctx);
+    await adapter.get('tenant-b', 'c', 'k', ctx);
+    const a = await adapter.auditLog('tenant-a');
+    const b = await adapter.auditLog('tenant-b');
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+});
+
+describe('InfisicalSecretsAdapter — list / rotate / delete', () => {
+  it('list returns metadata only', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'cloud.aws', 'k1', 'v');
+    await adapter.put('tenant-a', 'cloud.aws', 'k2', 'v');
+    const list = await adapter.list('tenant-a', 'cloud.aws');
+    expect(list).toHaveLength(2);
+    for (const m of list) expect(m).not.toHaveProperty('secretValue');
+  });
+
+  it('rotate bumps version', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    const r = await adapter.rotate('tenant-a', 'c', 'k');
+    expect(r.version).toBe(2);
+  });
+
+  it('delete + get yields SecretNotFoundError', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    await adapter.delete('tenant-a', 'c', 'k');
+    await expect(
+      adapter.get('tenant-a', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+  });
+
+  it('delete is idempotent', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.delete('tenant-a', 'c', 'k');
+    await expect(
+      adapter.delete('tenant-a', 'c', 'k'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('InfisicalSecretsAdapter — deleteAllForTenant', () => {
+  it('drops all secrets for the tenant', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c1', 'k', 'v');
+    await adapter.put('tenant-a', 'c2', 'k', 'v');
+    await adapter.put('tenant-b', 'c', 'k', 'v');
+    const r = await adapter.deleteAllForTenant('tenant-a');
+    expect(r.deletedCount).toBe(2);
+    expect(r.tenantTombstoneRef).toMatch(/^tomb_tenant-a_/);
+    expect(server.secrets.filter((s) => s.workspaceId === 'wsk-a')).toHaveLength(0);
+    expect(server.secrets.filter((s) => s.workspaceId === 'wsk-b')).toHaveLength(1);
+  });
+
+  it('dryRun does not delete', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    const r = await adapter.deleteAllForTenant('tenant-a', { dryRun: true });
+    expect(r.deletedCount).toBe(1);
+    expect(r.tenantTombstoneRef).toContain('dryrun');
+    expect(server.secrets).toHaveLength(1);
+  });
+
+  it('rejects invalid tenantId', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await expect(adapter.deleteAllForTenant('UpperCase')).rejects.toThrow();
+  });
+
+  it('zero secrets is a valid no-op', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    const r = await adapter.deleteAllForTenant('tenant-a');
+    expect(r.deletedCount).toBe(0);
+  });
+});
+
+describe('InfisicalSecretsAdapter — tenant isolation', () => {
+  it('tenant A cannot read tenant B secrets', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'shared-key', 'secret-A');
+    await adapter.put('tenant-b', 'c', 'shared-key', 'secret-B');
+    expect(await adapter.get('tenant-a', 'c', 'shared-key', ctx)).toBe(
+      'secret-A',
+    );
+    expect(await adapter.get('tenant-b', 'c', 'shared-key', ctx)).toBe(
+      'secret-B',
+    );
+  });
+
+  it('list per-tenant only returns the tenant rows', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    await adapter.put('tenant-b', 'c', 'k', 'v');
+    const aList = await adapter.list('tenant-a', 'c');
+    const bList = await adapter.list('tenant-b', 'c');
+    expect(aList).toHaveLength(1);
+    expect(bList).toHaveLength(1);
+  });
+});
+
+describe('InfisicalSecretsAdapter — ping', () => {
+  it('returns ok=true backend=infisical when healthy', async () => {
+    const server = new MockInfisicalServer();
+    const adapter = newAdapter(server);
+    const r = await adapter.ping();
+    expect(r.ok).toBe(true);
+    expect(r.backend).toBe('infisical');
+  });
+});
+
+describe('InfisicalSecretsAdapter — Cloudflare Access', () => {
+  it('passes CF headers through every request', async () => {
+    const server = new MockInfisicalServer();
+    server.requireCfHeaders = true;
+    const adapter = new InfisicalSecretsAdapter({
+      baseUrl: 'https://infisical.chiefaia.com',
+      auth: { type: 'static-token', accessToken: 't' },
+      cloudflareAccess: { clientId: 'cf-id', clientSecret: 'cf-sec' },
+      projectResolver: new ConfigMapProjectResolver({ 'tenant-a': 'wsk-a' }),
+      fetchImpl: server.fetchImpl,
+    });
+    await adapter.put('tenant-a', 'c', 'k', 'v');
+    const putCall = server.calls.find((c) => c.method === 'POST');
+    expect(putCall?.headers['CF-Access-Client-Id']).toBe('cf-id');
+    expect(putCall?.headers['CF-Access-Client-Secret']).toBe('cf-sec');
+  });
+});

--- a/packages/secrets-infisical/tests/unit/audit.test.ts
+++ b/packages/secrets-infisical/tests/unit/audit.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryAuditLogger, NoopAuditLogger } from '../../src/audit.js';
+
+const sample = {
+  tenantId: 't',
+  category: 'c',
+  key: 'k',
+  backend: 'infisical',
+  action: 'get' as const,
+  callerContext: {
+    callerType: 'agent' as const,
+    callerId: 'a',
+    reason: 'r',
+  },
+  ok: true,
+};
+
+describe('NoopAuditLogger', () => {
+  it('write is a no-op', async () => {
+    const logger = new NoopAuditLogger();
+    await expect(logger.write(sample)).resolves.toBeUndefined();
+  });
+});
+
+describe('InMemoryAuditLogger', () => {
+  it('accumulates events', async () => {
+    const logger = new InMemoryAuditLogger();
+    await logger.write(sample);
+    await logger.write({ ...sample, ok: false, errorClass: 'not_found' });
+    expect(logger.events).toHaveLength(2);
+    expect(logger.events[1]?.ok).toBe(false);
+    expect(logger.events[1]?.errorClass).toBe('not_found');
+  });
+
+  it('preserves order', async () => {
+    const logger = new InMemoryAuditLogger();
+    for (let i = 0; i < 5; i++) {
+      await logger.write({ ...sample, key: `k${i}` });
+    }
+    expect(logger.events.map((e) => e.key)).toEqual([
+      'k0',
+      'k1',
+      'k2',
+      'k3',
+      'k4',
+    ]);
+  });
+});

--- a/packages/secrets-infisical/tests/unit/auth.test.ts
+++ b/packages/secrets-infisical/tests/unit/auth.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { InfisicalAuth } from '../../src/auth.js';
+import {
+  SecretProviderError,
+  SecretsAdapterConfigError,
+} from '@caia/secrets-adapter';
+import { MockInfisicalServer } from './fetch-mock.js';
+
+const baseUrl = 'https://infisical.test';
+
+describe('InfisicalAuth — construction', () => {
+  it('requires baseUrl', () => {
+    expect(
+      () =>
+        new InfisicalAuth({
+          baseUrl: '',
+          auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+        }),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+
+  it('requires auth config', () => {
+    expect(
+      () =>
+        new InfisicalAuth({
+          baseUrl,
+          // @ts-expect-error — runtime mistake
+          auth: undefined,
+        }),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+
+  it('rejects universal-auth without credentials', () => {
+    expect(
+      () =>
+        new InfisicalAuth({
+          baseUrl,
+          auth: { type: 'universal-auth', clientId: '', clientSecret: 'b' },
+        }),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+
+  it('rejects static-token without token', () => {
+    expect(
+      () =>
+        new InfisicalAuth({
+          baseUrl,
+          auth: { type: 'static-token', accessToken: '' },
+        }),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+
+  it('rejects unknown auth type', () => {
+    expect(
+      () =>
+        new InfisicalAuth({
+          baseUrl,
+          // @ts-expect-error — invalid type
+          auth: { type: 'oauth' },
+        }),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+});
+
+describe('InfisicalAuth — universal-auth login', () => {
+  it('logs in once and caches', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+      fetchImpl: server.fetchImpl,
+    });
+    const h1 = await auth.authorizedHeaders();
+    const h2 = await auth.authorizedHeaders();
+    expect(h1['Authorization']).toBe('Bearer tok_1');
+    expect(h2['Authorization']).toBe('Bearer tok_1');
+    expect(server.loginCount).toBe(1);
+  });
+
+  it('re-logs in after invalidate', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+      fetchImpl: server.fetchImpl,
+    });
+    await auth.authorizedHeaders();
+    auth.invalidate();
+    const h = await auth.authorizedHeaders();
+    expect(h['Authorization']).toBe('Bearer tok_2');
+    expect(server.loginCount).toBe(2);
+  });
+
+  it('refreshes when nearing expiry', async () => {
+    const server = new MockInfisicalServer();
+    let now = 1_000_000;
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+      fetchImpl: server.fetchImpl,
+      refreshSkewMs: 5 * 60 * 1000,
+      now: () => now,
+    });
+    await auth.authorizedHeaders();
+    // Token expiresIn=600s, skew=300s, so the cached token is reusable
+    // until elapsed time crosses 300s. At t=250s the cache is still valid.
+    now += 250_000;
+    await auth.authorizedHeaders();
+    expect(server.loginCount).toBe(1);
+    // Advance to 350s — past the refresh threshold; expect a new login.
+    now += 100_000;
+    await auth.authorizedHeaders();
+    expect(server.loginCount).toBe(2);
+  });
+
+  it('throws SecretProviderError on 401', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'BAD', clientSecret: 'b' },
+      fetchImpl: server.fetchImpl,
+    });
+    await expect(auth.authorizedHeaders()).rejects.toBeInstanceOf(
+      SecretProviderError,
+    );
+  });
+
+  it('dedupes concurrent logins', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+      fetchImpl: server.fetchImpl,
+    });
+    const [a, b, c] = await Promise.all([
+      auth.authorizedHeaders(),
+      auth.authorizedHeaders(),
+      auth.authorizedHeaders(),
+    ]);
+    expect(a['Authorization']).toBe(b['Authorization']);
+    expect(b['Authorization']).toBe(c['Authorization']);
+    expect(server.loginCount).toBe(1);
+  });
+});
+
+describe('InfisicalAuth — static token', () => {
+  it('uses the static token without contacting login', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'static-token', accessToken: 'preset-token' },
+      fetchImpl: server.fetchImpl,
+    });
+    const h = await auth.authorizedHeaders();
+    expect(h['Authorization']).toBe('Bearer preset-token');
+    expect(server.loginCount).toBe(0);
+  });
+});
+
+describe('InfisicalAuth — Cloudflare Access headers', () => {
+  it('includes CF headers on every authorized call', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'static-token', accessToken: 't' },
+      cloudflareAccess: { clientId: 'cf-id', clientSecret: 'cf-secret' },
+      fetchImpl: server.fetchImpl,
+    });
+    const h = await auth.authorizedHeaders();
+    expect(h['CF-Access-Client-Id']).toBe('cf-id');
+    expect(h['CF-Access-Client-Secret']).toBe('cf-secret');
+  });
+
+  it('cloudflareAccessHeaders returns empty when not configured', () => {
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'static-token', accessToken: 't' },
+    });
+    expect(auth.cloudflareAccessHeaders()).toEqual({});
+  });
+
+  it('login includes CF headers', async () => {
+    const server = new MockInfisicalServer();
+    server.requireCfHeaders = true;
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+      cloudflareAccess: { clientId: 'cf-id', clientSecret: 'cf-secret' },
+      fetchImpl: server.fetchImpl,
+    });
+    const h = await auth.authorizedHeaders();
+    expect(h['Authorization']).toBe('Bearer tok_1');
+  });
+});

--- a/packages/secrets-infisical/tests/unit/client.test.ts
+++ b/packages/secrets-infisical/tests/unit/client.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { InfisicalClient } from '../../src/client.js';
+import { InfisicalAuth } from '../../src/auth.js';
+import {
+  SecretNotFoundError,
+  SecretPolicyDeniedError,
+  SecretProviderError,
+  SecretRateLimitedError,
+} from '@caia/secrets-adapter';
+import { MockInfisicalServer } from './fetch-mock.js';
+
+const baseUrl = 'https://infisical.test';
+
+function newClient(server: MockInfisicalServer): InfisicalClient {
+  const auth = new InfisicalAuth({
+    baseUrl,
+    auth: { type: 'static-token', accessToken: 'tok_1' },
+    fetchImpl: server.fetchImpl,
+  });
+  return new InfisicalClient({ baseUrl, auth, fetchImpl: server.fetchImpl });
+}
+
+describe('InfisicalClient — put + get round-trip', () => {
+  it('put then get returns the value', async () => {
+    const server = new MockInfisicalServer();
+    const client = newClient(server);
+    await client.putSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/cloud.aws',
+      secretName: 'access_key',
+      secretValue: 'AKIA-x',
+    });
+    const got = await client.getSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/cloud.aws',
+      secretName: 'access_key',
+    });
+    expect(got.secretValue).toBe('AKIA-x');
+    expect(got.secretKey).toBe('access_key');
+    expect(got.version).toBe(1);
+  });
+
+  it('update bumps version', async () => {
+    const server = new MockInfisicalServer();
+    const client = newClient(server);
+    await client.putSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'k',
+      secretValue: 'v1',
+    });
+    const updated = await client.updateSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'k',
+      secretValue: 'v2',
+    });
+    expect(updated.version).toBe(2);
+    const got = await client.getSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'k',
+    });
+    expect(got.secretValue).toBe('v2');
+  });
+
+  it('delete is idempotent', async () => {
+    const server = new MockInfisicalServer();
+    const client = newClient(server);
+    await client.putSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'k',
+      secretValue: 'v',
+    });
+    await client.deleteSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'k',
+    });
+    await expect(
+      client.deleteSecret({
+        workspaceId: 'wsk-1',
+        environment: 'prod',
+        secretPath: '/c',
+        secretName: 'k',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('list returns secrets at a path', async () => {
+    const server = new MockInfisicalServer();
+    const client = newClient(server);
+    await client.putSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'a',
+      secretValue: 'va',
+    });
+    await client.putSecret({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'b',
+      secretValue: 'vb',
+    });
+    const list = await client.listSecrets({
+      workspaceId: 'wsk-1',
+      environment: 'prod',
+      secretPath: '/c',
+    });
+    expect(list).toHaveLength(2);
+  });
+});
+
+describe('InfisicalClient — error mapping', () => {
+  it('404 -> SecretNotFoundError', async () => {
+    const server = new MockInfisicalServer();
+    const client = newClient(server);
+    await expect(
+      client.getSecret({
+        workspaceId: 'wsk-1',
+        environment: 'prod',
+        secretPath: '/c',
+        secretName: 'missing',
+      }),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+  });
+
+  it('403 -> SecretPolicyDeniedError', async () => {
+    const server = new MockInfisicalServer();
+    server.failNext = { match: /\/api\/v3\/secrets\/raw\//, status: 403 };
+    const client = newClient(server);
+    await expect(
+      client.putSecret({
+        workspaceId: 'wsk-1',
+        environment: 'prod',
+        secretPath: '/c',
+        secretName: 'k',
+        secretValue: 'v',
+      }),
+    ).rejects.toBeInstanceOf(SecretPolicyDeniedError);
+  });
+
+  it('500 -> SecretProviderError', async () => {
+    const server = new MockInfisicalServer();
+    server.failNext = { match: /\/api\/v3\/secrets\/raw\//, status: 500 };
+    const client = newClient(server);
+    await expect(
+      client.putSecret({
+        workspaceId: 'wsk-1',
+        environment: 'prod',
+        secretPath: '/c',
+        secretName: 'k',
+        secretValue: 'v',
+      }),
+    ).rejects.toBeInstanceOf(SecretProviderError);
+  });
+
+  it('429 -> SecretRateLimitedError', async () => {
+    const server = new MockInfisicalServer();
+    const realFetch = server.fetchImpl;
+    server.fetchImpl = async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.includes('/api/v3/secrets/raw/')) {
+        return new Response('rate', {
+          status: 429,
+          headers: { 'retry-after': '7' },
+        });
+      }
+      return realFetch(input, init);
+    };
+    const client = newClient(server);
+    await expect(
+      client.getSecret({
+        workspaceId: 'w',
+        environment: 'prod',
+        secretPath: '/c',
+        secretName: 'k',
+      }),
+    ).rejects.toMatchObject({
+      errorClass: 'rate_limited',
+      retryAfterMs: 7000,
+    });
+    // Sanity: typed error class
+    await expect(
+      client.getSecret({
+        workspaceId: 'w',
+        environment: 'prod',
+        secretPath: '/c',
+        secretName: 'k',
+      }),
+    ).rejects.toBeInstanceOf(SecretRateLimitedError);
+  });
+});
+
+describe('InfisicalClient — 401 auto-retry with re-login', () => {
+  it('refreshes token on first 401 and retries', async () => {
+    const server = new MockInfisicalServer();
+    const auth = new InfisicalAuth({
+      baseUrl,
+      auth: { type: 'universal-auth', clientId: 'a', clientSecret: 'b' },
+      fetchImpl: server.fetchImpl,
+    });
+    const client = new InfisicalClient({ baseUrl, auth, fetchImpl: server.fetchImpl });
+    server.expiredOnFirstUse = true;
+    await client.putSecret({
+      workspaceId: 'w',
+      environment: 'prod',
+      secretPath: '/c',
+      secretName: 'k',
+      secretValue: 'v',
+    });
+    expect(server.loginCount).toBe(2);
+  });
+});
+
+describe('InfisicalClient — health', () => {
+  it('reports ok on /api/status 200', async () => {
+    const server = new MockInfisicalServer();
+    const client = newClient(server);
+    const r = await client.health();
+    expect(r.ok).toBe(true);
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/secrets-infisical/tests/unit/fetch-mock.ts
+++ b/packages/secrets-infisical/tests/unit/fetch-mock.ts
@@ -1,0 +1,248 @@
+/**
+ * Hand-rolled fetch mock for the InfisicalSecretsAdapter unit tests.
+ *
+ * Simulates enough of the Infisical V3 surface to round-trip put/get/
+ * patch/delete/list. Not pretending to be the real backend — only
+ * needs to be faithful to the request shapes the adapter emits.
+ */
+
+export interface FetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+interface SecretRecord {
+  id: string;
+  workspaceId: string;
+  environment: string;
+  secretPath: string;
+  secretKey: string;
+  secretValue: string;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class MockInfisicalServer {
+  public calls: FetchCall[] = [];
+  public secrets: SecretRecord[] = [];
+  public loginCount = 0;
+  public failNext: { match: RegExp; status: number; body?: string } | null = null;
+  public requireCfHeaders = false;
+  public expiredOnFirstUse = false;
+  private nextId = 1;
+
+  reset(): void {
+    this.calls = [];
+    this.secrets = [];
+    this.loginCount = 0;
+    this.failNext = null;
+    this.expiredOnFirstUse = false;
+  }
+
+  fetchImpl: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as URL).toString();
+    const method = init?.method ?? 'GET';
+    const headers = headersToRecord(init?.headers);
+    const body =
+      init?.body && typeof init.body === 'string'
+        ? safeJsonParse(init.body)
+        : undefined;
+    this.calls.push({ url, method, headers, body });
+
+    if (this.requireCfHeaders) {
+      if (
+        !headers['CF-Access-Client-Id'] ||
+        !headers['CF-Access-Client-Secret']
+      ) {
+        return jsonResponse(403, { message: 'CF Access required' });
+      }
+    }
+
+    if (this.failNext && this.failNext.match.test(url)) {
+      const f = this.failNext;
+      this.failNext = null;
+      return new Response(f.body ?? '', { status: f.status });
+    }
+
+    // Login endpoint
+    if (url.endsWith('/api/v1/auth/universal-auth/login')) {
+      this.loginCount += 1;
+      const reqBody = (body ?? {}) as { clientId?: string; clientSecret?: string };
+      if (!reqBody.clientId || !reqBody.clientSecret) {
+        return jsonResponse(400, { message: 'bad creds' });
+      }
+      if (reqBody.clientId === 'BAD') {
+        return jsonResponse(401, { message: 'unauthorized' });
+      }
+      return jsonResponse(200, {
+        accessToken: `tok_${this.loginCount}`,
+        expiresIn: 600,
+        accessTokenMaxTTL: 600,
+        tokenType: 'Bearer',
+      });
+    }
+
+    // Status / health
+    if (url.includes('/api/status')) {
+      return jsonResponse(200, { message: 'ok' });
+    }
+
+    // Authenticated endpoints — require bearer
+    const bearer = headers['Authorization']?.replace(/^Bearer /, '');
+    if (!bearer) return jsonResponse(401, { message: 'no token' });
+
+    // Simulate token revocation: when expiredOnFirstUse, fail tok_1 once.
+    if (this.expiredOnFirstUse && bearer === 'tok_1') {
+      this.expiredOnFirstUse = false;
+      return jsonResponse(401, { message: 'expired' });
+    }
+
+    // List
+    if (url.includes('/api/v3/secrets/raw?') && method === 'GET') {
+      const params = parseQuery(url);
+      const rows = this.secrets.filter(
+        (s) =>
+          s.workspaceId === params.workspaceId &&
+          s.environment === params.environment &&
+          (params.secretPath === '/' || s.secretPath === params.secretPath),
+      );
+      return jsonResponse(200, { secrets: rows.map(this.toResponse) });
+    }
+
+    // Single secret CRUD: /api/v3/secrets/raw/:name
+    const m = url.match(/\/api\/v3\/secrets\/raw\/([^?]+)(?:\?(.*))?$/);
+    if (m) {
+      const secretName = decodeURIComponent(m[1] ?? '');
+      const params = m[2] ? parseQueryString(m[2]) : (body as Record<string, string> | undefined);
+      const reqBody = body as Record<string, string> | undefined;
+      const ws = (params?.workspaceId ?? reqBody?.workspaceId) as string;
+      const env = (params?.environment ?? reqBody?.environment) as string;
+      const path = (params?.secretPath ?? reqBody?.secretPath) as string;
+
+      if (method === 'GET') {
+        const row = this.secrets.find(
+          (s) =>
+            s.workspaceId === ws &&
+            s.environment === env &&
+            s.secretPath === path &&
+            s.secretKey === secretName,
+        );
+        if (!row) return jsonResponse(404, { message: 'not found' });
+        return jsonResponse(200, { secret: this.toResponse(row) });
+      }
+      if (method === 'POST') {
+        const conflict = this.secrets.find(
+          (s) =>
+            s.workspaceId === ws &&
+            s.environment === env &&
+            s.secretPath === path &&
+            s.secretKey === secretName,
+        );
+        if (conflict) {
+          return jsonResponse(400, { message: 'already exists' });
+        }
+        const id = `inf_${this.nextId++}`;
+        const now = new Date().toISOString();
+        const row: SecretRecord = {
+          id,
+          workspaceId: ws,
+          environment: env,
+          secretPath: path,
+          secretKey: secretName,
+          secretValue: reqBody?.secretValue as string,
+          version: 1,
+          createdAt: now,
+          updatedAt: now,
+        };
+        this.secrets.push(row);
+        return jsonResponse(200, { secret: this.toResponse(row) });
+      }
+      if (method === 'PATCH') {
+        const row = this.secrets.find(
+          (s) =>
+            s.workspaceId === ws &&
+            s.environment === env &&
+            s.secretPath === path &&
+            s.secretKey === secretName,
+        );
+        if (!row) return jsonResponse(404, { message: 'not found' });
+        row.secretValue = reqBody?.secretValue as string;
+        row.version += 1;
+        row.updatedAt = new Date(Date.now() + row.version).toISOString();
+        return jsonResponse(200, { secret: this.toResponse(row) });
+      }
+      if (method === 'DELETE') {
+        const idx = this.secrets.findIndex(
+          (s) =>
+            s.workspaceId === ws &&
+            s.environment === env &&
+            s.secretPath === path &&
+            s.secretKey === secretName,
+        );
+        if (idx < 0) return jsonResponse(404, { message: 'not found' });
+        this.secrets.splice(idx, 1);
+        return jsonResponse(200, {});
+      }
+    }
+
+    return jsonResponse(500, { message: `unrouted ${method} ${url}` });
+  };
+
+  private toResponse = (row: SecretRecord) => ({
+    id: row.id,
+    _id: row.id,
+    secretKey: row.secretKey,
+    secretValue: row.secretValue,
+    secretPath: row.secretPath,
+    version: row.version,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  });
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function headersToRecord(h: HeadersInit | undefined): Record<string, string> {
+  if (!h) return {};
+  if (h instanceof Headers) {
+    const out: Record<string, string> = {};
+    h.forEach((v, k) => {
+      out[k] = v;
+    });
+    return out;
+  }
+  if (Array.isArray(h)) {
+    return Object.fromEntries(h);
+  }
+  return { ...(h as Record<string, string>) };
+}
+
+function safeJsonParse(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseQueryString(qs: string): Record<string, string> {
+  const params = new URLSearchParams(qs);
+  const out: Record<string, string> = {};
+  params.forEach((v, k) => {
+    out[k] = v;
+  });
+  return out;
+}
+
+function parseQuery(url: string): Record<string, string> {
+  const u = new URL(url, 'http://x');
+  return parseQueryString(u.search.slice(1));
+}

--- a/packages/secrets-infisical/tests/unit/project-resolver.test.ts
+++ b/packages/secrets-infisical/tests/unit/project-resolver.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ConfigMapProjectResolver,
+  FunctionProjectResolver,
+} from '../../src/project-resolver.js';
+import { SecretPolicyDeniedError } from '@caia/secrets-adapter';
+
+describe('ConfigMapProjectResolver', () => {
+  it('resolves known tenant', async () => {
+    const r = new ConfigMapProjectResolver({ t1: 'wsk-1', t2: 'wsk-2' });
+    expect(await r.resolve('t1')).toBe('wsk-1');
+    expect(await r.resolve('t2')).toBe('wsk-2');
+  });
+  it('throws SecretPolicyDeniedError on unknown', async () => {
+    const r = new ConfigMapProjectResolver({ t1: 'wsk-1' });
+    await expect(r.resolve('unknown')).rejects.toBeInstanceOf(
+      SecretPolicyDeniedError,
+    );
+  });
+  it('accepts a Map directly', async () => {
+    const r = new ConfigMapProjectResolver(new Map([['t1', 'wsk-1']]));
+    expect(await r.resolve('t1')).toBe('wsk-1');
+  });
+});
+
+describe('FunctionProjectResolver', () => {
+  it('delegates to the function', async () => {
+    const r = new FunctionProjectResolver(async (t) => `proj-of-${t}`);
+    expect(await r.resolve('alpha')).toBe('proj-of-alpha');
+  });
+  it('throws on undefined return', async () => {
+    const r = new FunctionProjectResolver(async () => undefined);
+    await expect(r.resolve('t')).rejects.toBeInstanceOf(
+      SecretPolicyDeniedError,
+    );
+  });
+  it('propagates inner async errors as-is', async () => {
+    const r = new FunctionProjectResolver(async () => {
+      throw new Error('boom');
+    });
+    await expect(r.resolve('t')).rejects.toThrow('boom');
+  });
+});

--- a/packages/secrets-infisical/tsconfig.json
+++ b/packages/secrets-infisical/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/secrets-infisical/vitest.config.ts
+++ b/packages/secrets-infisical/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/integration/**'],
+  },
+});

--- a/packages/secrets-infisical/vitest.integration.config.ts
+++ b/packages/secrets-infisical/vitest.integration.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig({
+  test: {
+    include: ['tests/integration/**/*.test.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/packages/secrets-postgres/CHANGELOG.md
+++ b/packages/secrets-postgres/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @caia/secrets-postgres
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release. `PostgresSecretsAdapter` with AES-256-GCM per-tenant
+  HKDF derivation, crypto-shred GDPR-delete, audit-log writes to
+  `caia_meta.audit_log`.

--- a/packages/secrets-postgres/README.md
+++ b/packages/secrets-postgres/README.md
@@ -1,0 +1,53 @@
+# `@caia/secrets-postgres`
+
+> Phase-1 bootstrap `SecretsAdapter` for CAIA.
+
+Encrypted Postgres column. One table — `caia_meta.tenant_secrets_cold` — with
+one row per `(tenantId, category, key)`. Value column holds `iv ||
+authTag || ciphertext`, AES-256-GCM. Per-tenant derived key:
+
+```
+dataKey_t = HKDF-SHA256(masterKey, salt="caia-tenant-v1", info=tenantId, len=32)
+```
+
+The master key lives in `CAIA_SECRETS_MASTER_KEY` (32-byte hex). Phase-2
+graduates this to AWS KMS without interface changes.
+
+## What you get
+
+- `PostgresSecretsAdapter` — implements `SecretsAdapter` from `@caia/secrets-adapter`.
+- Crypto-shred GDPR-delete: forgetting the tenant's derived key is the
+  security barrier; the row delete + tombstone are hygiene.
+- AES-256-GCM via Node built-in `crypto` — no external lib.
+- Per-tenant LRU cache (1024 entries, 5-minute TTL).
+- Audit log: every `get` / `put` writes a row to `caia_meta.audit_log`.
+
+## Quickstart
+
+```ts
+import { PostgresSecretsAdapter } from '@caia/secrets-postgres';
+import { Pool } from 'pg';
+
+const adapter = new PostgresSecretsAdapter({
+  pool: new Pool({ connectionString: process.env.DATABASE_URL }),
+  masterKeyHex: process.env.CAIA_SECRETS_MASTER_KEY!, // openssl rand -hex 32
+});
+```
+
+## Env
+
+| name | required | description |
+|---|---|---|
+| `CAIA_SECRETS_MASTER_KEY` | yes (phase 1) | 32-byte hex master, rotated annually. Phase-2 from KMS. |
+| `DATABASE_URL` | yes | Postgres connection string. |
+
+## Migrations
+
+```
+psql $DATABASE_URL < migrations/0001_secrets.sql
+psql $DATABASE_URL < migrations/0002_audit_log.sql
+```
+
+## Reference
+
+`research/multi_tenant_secrets_architecture_2026.md` §1, §3 (Pattern C), §8.

--- a/packages/secrets-postgres/docker-compose.test.yml
+++ b/packages/secrets-postgres/docker-compose.test.yml
@@ -1,0 +1,23 @@
+# Docker compose for `@caia/secrets-postgres` integration tests.
+#
+# Usage:
+#   docker compose -f docker-compose.test.yml up -d
+#   PG_INTEGRATION_URL=postgres://caia:caia@localhost:54320/caia_test \
+#     pnpm test:integration
+#   docker compose -f docker-compose.test.yml down -v
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: caia
+      POSTGRES_PASSWORD: caia
+      POSTGRES_DB: caia_test
+    ports:
+      - "54320:5432"
+    volumes:
+      - ./migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U caia -d caia_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 20

--- a/packages/secrets-postgres/eslint.config.cjs
+++ b/packages/secrets-postgres/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/secrets-postgres/migrations/0001_secrets.sql
+++ b/packages/secrets-postgres/migrations/0001_secrets.sql
@@ -1,0 +1,38 @@
+-- @caia/secrets-postgres — Phase-1 bootstrap storage.
+--
+-- One row per (tenantId, category, key). The value column holds
+--   iv (12 bytes) || authTag (16 bytes) || ciphertext
+-- AES-256-GCM, with a per-tenant derived key:
+--   dataKey_t = HKDF-SHA256(masterKey, salt="caia-tenant-v1", info=tenantId, len=32)
+--
+-- The Postgres ciphertext column is useless by itself: it requires the
+-- master key (env CAIA_SECRETS_MASTER_KEY in phase 1; AWS KMS in phase 2)
+-- and the derivation above to be reversed.
+
+CREATE SCHEMA IF NOT EXISTS caia_meta;
+
+CREATE TABLE IF NOT EXISTS caia_meta.tenant_secrets_cold (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         TEXT NOT NULL,
+  category          TEXT NOT NULL,
+  key               TEXT NOT NULL,
+  ciphertext_b64    TEXT NOT NULL,
+  version           INTEGER NOT NULL DEFAULT 1,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_accessed_at  TIMESTAMPTZ,
+  last_rotated_at   TIMESTAMPTZ,
+  expires_at        TIMESTAMPTZ,
+  UNIQUE (tenant_id, category, key)
+);
+
+CREATE INDEX IF NOT EXISTS tenant_secrets_cold_tenant_idx
+  ON caia_meta.tenant_secrets_cold (tenant_id);
+
+CREATE INDEX IF NOT EXISTS tenant_secrets_cold_tenant_category_idx
+  ON caia_meta.tenant_secrets_cold (tenant_id, category);
+
+CREATE TABLE IF NOT EXISTS caia_meta.tenant_crypto_shred (
+  tenant_id         TEXT PRIMARY KEY,
+  shredded_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  tombstone_ref     TEXT NOT NULL
+);

--- a/packages/secrets-postgres/migrations/0002_audit_log.sql
+++ b/packages/secrets-postgres/migrations/0002_audit_log.sql
@@ -1,0 +1,36 @@
+-- @caia/secrets-postgres — audit log (also written by @caia/secrets-infisical).
+--
+-- Every adapter `get` writes exactly one row here, success or failure.
+-- Every adapter `put` writes one row too.
+-- The Infisical adapter dual-writes here so the operator can query
+-- a unified audit log across both stores.
+
+CREATE SCHEMA IF NOT EXISTS caia_meta;
+
+CREATE TABLE IF NOT EXISTS caia_meta.audit_log (
+  id                  BIGSERIAL PRIMARY KEY,
+  tenant_id           TEXT NOT NULL,
+  category            TEXT NOT NULL,
+  key                 TEXT NOT NULL,
+  backend             TEXT NOT NULL,
+  action              TEXT NOT NULL,
+  caller_type         TEXT NOT NULL,
+  caller_id           TEXT NOT NULL,
+  ticket_id           TEXT,
+  reason              TEXT NOT NULL,
+  capability_token_id TEXT,
+  requester_ip        TEXT,
+  granted_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ok                  BOOLEAN NOT NULL,
+  error_class         TEXT,
+  provider_trace      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS audit_log_tenant_time_idx
+  ON caia_meta.audit_log (tenant_id, granted_at DESC);
+
+CREATE INDEX IF NOT EXISTS audit_log_action_time_idx
+  ON caia_meta.audit_log (action, granted_at DESC);
+
+CREATE INDEX IF NOT EXISTS audit_log_ok_time_idx
+  ON caia_meta.audit_log (ok, granted_at DESC);

--- a/packages/secrets-postgres/package.json
+++ b/packages/secrets-postgres/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@caia/secrets-postgres",
+  "version": "0.1.0",
+  "description": "Postgres encrypted-column SecretsAdapter — AES-256-GCM with per-tenant HKDF-derived keys. Phase-1 bootstrap adapter for CAIA's multi-tenant secrets architecture. Crypto-shred GDPR delete; audit log to caia_meta.audit_log.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "migrations"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:integration": "vitest run -c vitest.integration.config.ts",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@caia/secrets-adapter": "workspace:*",
+    "pg": "^8.13.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "@types/pg": "^8.11.6",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/secrets-postgres/src/adapter.ts
+++ b/packages/secrets-postgres/src/adapter.ts
@@ -1,0 +1,546 @@
+/**
+ * `PostgresSecretsAdapter` — Pattern C from the architecture spec.
+ *
+ * One Postgres table; one row per (tenantId, category, key). Encrypted
+ * with AES-256-GCM under a per-tenant HKDF-derived key. Crypto-shred GDPR
+ * delete; audit log dual-written to `caia_meta.audit_log`.
+ */
+
+import {
+  AccessContextSchema,
+  CategorySchema,
+  KeySchema,
+  SecretValueSchema,
+  TenantIdSchema,
+  SecretNotFoundError,
+  SecretProviderError,
+  SecretsAdapterConfigError,
+  classifyError,
+  type AccessContext,
+  type AccessLogEntry,
+  type DeleteAllForTenantOptions,
+  type DeleteAllResult,
+  type DeleteOptions,
+  type PingResult,
+  type PutOptions,
+  type PutResult,
+  type RotateResult,
+  type SecretMetadata,
+  type SecretsAdapter,
+} from '@caia/secrets-adapter';
+
+import {
+  decryptValue,
+  deriveTenantKey,
+  encryptValue,
+  parseMasterKeyHex,
+} from './crypto.js';
+import { TenantKeyCache } from './key-cache.js';
+import { PostgresAuditLogger, type AuditLogger } from './audit.js';
+import type { PoolLike } from './pg-types.js';
+
+export const BACKEND_NAME = 'postgres';
+
+export interface PostgresSecretsAdapterOptions {
+  /** A `pg.Pool` or structurally-compatible client. */
+  pool: PoolLike;
+  /** 32-byte hex master key. Required unless `masterKey` is provided. */
+  masterKeyHex?: string;
+  /** Raw 32-byte master key. Required unless `masterKeyHex` is provided. */
+  masterKey?: Buffer;
+  /** Per-tenant key cache. Provide a shared one across instances if needed. */
+  keyCache?: TenantKeyCache;
+  /** Audit logger. Defaults to writing into `caia_meta.audit_log` on the same pool. */
+  auditLogger?: AuditLogger;
+  /** Test-only clock for `now()`. */
+  now?: () => Date;
+}
+
+interface SecretRow {
+  id: number | string;
+  ciphertext_b64: string;
+  version: number;
+  created_at: Date;
+  last_accessed_at: Date | null;
+  last_rotated_at: Date | null;
+  expires_at: Date | null;
+}
+
+interface ListRow extends SecretRow {
+  tenant_id: string;
+  category: string;
+  key: string;
+}
+
+interface RotateRow {
+  version: number;
+  last_rotated_at: Date;
+}
+
+interface PutRow {
+  id: number | string;
+  version: number;
+}
+
+interface AuditRow {
+  tenant_id: string;
+  category: string;
+  key: string;
+  caller_type: AccessContext['callerType'];
+  caller_id: string;
+  ticket_id: string | null;
+  reason: string;
+  capability_token_id: string | null;
+  requester_ip: string | null;
+  granted_at: Date;
+  ok: boolean;
+  error_class:
+    | 'not_found'
+    | 'policy_denied'
+    | 'rate_limited'
+    | 'provider_error'
+    | null;
+  provider_trace: string | null;
+}
+
+export class PostgresSecretsAdapter implements SecretsAdapter {
+  private readonly pool: PoolLike;
+  private readonly masterKey: Buffer;
+  private readonly cache: TenantKeyCache;
+  private readonly audit: AuditLogger;
+  private readonly now: () => Date;
+
+  constructor(opts: PostgresSecretsAdapterOptions) {
+    if (!opts.pool) {
+      throw new SecretsAdapterConfigError(
+        'PostgresSecretsAdapter: `pool` is required',
+      );
+    }
+    if (!opts.masterKey && !opts.masterKeyHex) {
+      throw new SecretsAdapterConfigError(
+        'PostgresSecretsAdapter: provide either `masterKey` or `masterKeyHex` (32-byte hex string)',
+      );
+    }
+    this.pool = opts.pool;
+    this.masterKey =
+      opts.masterKey ?? parseMasterKeyHex(opts.masterKeyHex as string);
+    if (this.masterKey.length !== 32) {
+      throw new SecretsAdapterConfigError(
+        `PostgresSecretsAdapter: masterKey must be 32 bytes; got ${this.masterKey.length}`,
+      );
+    }
+    this.cache = opts.keyCache ?? new TenantKeyCache();
+    this.audit = opts.auditLogger ?? new PostgresAuditLogger(this.pool);
+    this.now = opts.now ?? ((): Date => new Date());
+  }
+
+  // ---------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------
+
+  private async assertNotShredded(tenantId: string): Promise<void> {
+    const res = await this.pool.query<{ tenant_id: string }>(
+      `SELECT tenant_id FROM caia_meta.tenant_crypto_shred WHERE tenant_id = $1 LIMIT 1`,
+      [tenantId],
+    );
+    if (res.rowCount && res.rowCount > 0) {
+      throw new SecretsAdapterConfigError(
+        `tenant '${tenantId}' was crypto-shredded; its secrets are permanently unreachable`,
+      );
+    }
+  }
+
+  private async getOrDeriveTenantKey(tenantId: string): Promise<Buffer> {
+    const cached = this.cache.get(tenantId);
+    if (cached) return cached;
+    await this.assertNotShredded(tenantId);
+    const derived = deriveTenantKey(this.masterKey, tenantId);
+    this.cache.set(tenantId, derived);
+    return derived;
+  }
+
+  private validateIdentifiers(
+    tenantId: string,
+    category: string,
+    key: string,
+  ): void {
+    TenantIdSchema.parse(tenantId);
+    CategorySchema.parse(category);
+    KeySchema.parse(key);
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — put
+  // ---------------------------------------------------------------------
+
+  async put(
+    tenantId: string,
+    category: string,
+    key: string,
+    value: string,
+    opts?: PutOptions,
+  ): Promise<PutResult> {
+    this.validateIdentifiers(tenantId, category, key);
+    SecretValueSchema.parse(value);
+    const tenantKey = await this.getOrDeriveTenantKey(tenantId);
+    const ciphertext = encryptValue(tenantKey, value);
+    const expiresAt =
+      opts?.ttlSeconds !== undefined
+        ? new Date(this.now().getTime() + opts.ttlSeconds * 1000)
+        : null;
+
+    if (opts?.replace) {
+      // Upsert. Bumps version. Resets expiresAt.
+      const res = await this.pool.query<PutRow>(
+        `INSERT INTO caia_meta.tenant_secrets_cold
+           (tenant_id, category, key, ciphertext_b64, expires_at)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (tenant_id, category, key)
+           DO UPDATE SET
+             ciphertext_b64 = EXCLUDED.ciphertext_b64,
+             version        = caia_meta.tenant_secrets_cold.version + 1,
+             expires_at     = EXCLUDED.expires_at,
+             last_rotated_at = NOW()
+         RETURNING id, version`,
+        [tenantId, category, key, ciphertext, expiresAt],
+      );
+      const row = res.rows[0];
+      if (!row) {
+        throw new SecretProviderError(
+          `put: upsert returned no row for ${tenantId}/${category}/${key}`,
+        );
+      }
+      return { secretRef: String(row.id), version: row.version };
+    }
+
+    // No replace — insert-only. Conflicts throw.
+    try {
+      const res = await this.pool.query<PutRow>(
+        `INSERT INTO caia_meta.tenant_secrets_cold
+           (tenant_id, category, key, ciphertext_b64, expires_at)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING id, version`,
+        [tenantId, category, key, ciphertext, expiresAt],
+      );
+      const row = res.rows[0];
+      if (!row) {
+        throw new SecretProviderError(
+          `put: insert returned no row for ${tenantId}/${category}/${key}`,
+        );
+      }
+      return { secretRef: String(row.id), version: row.version };
+    } catch (err) {
+      // pg unique-violation
+      const code = (err as { code?: string }).code;
+      if (code === '23505') {
+        throw new SecretProviderError(
+          `secret already exists: ${tenantId}/${category}/${key} (pass replace:true to overwrite)`,
+          { tenantId, category, key, cause: err },
+        );
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Variant of `put` that writes an explicit audit row. Used by the
+   * onboarding broker which has the operator's caller context.
+   */
+  async putWithAudit(
+    tenantId: string,
+    category: string,
+    key: string,
+    value: string,
+    callerContext: AccessContext,
+    opts?: PutOptions,
+  ): Promise<PutResult> {
+    AccessContextSchema.parse(callerContext);
+    let result: PutResult | undefined;
+    let thrown: unknown;
+    try {
+      result = await this.put(tenantId, category, key, value, opts);
+    } catch (err) {
+      thrown = err;
+    }
+    await this.audit.write({
+      tenantId,
+      category,
+      key,
+      backend: BACKEND_NAME,
+      action: 'put',
+      callerContext,
+      ok: thrown === undefined,
+      ...(thrown !== undefined ? { errorClass: classifyError(thrown) } : {}),
+      ...(result?.secretRef !== undefined
+        ? { providerTrace: result.secretRef }
+        : {}),
+    });
+    if (thrown !== undefined) throw thrown;
+    return result as PutResult;
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — get
+  // ---------------------------------------------------------------------
+
+  async get(
+    tenantId: string,
+    category: string,
+    key: string,
+    callerContext: AccessContext,
+  ): Promise<string> {
+    this.validateIdentifiers(tenantId, category, key);
+    AccessContextSchema.parse(callerContext);
+    try {
+      const tenantKey = await this.getOrDeriveTenantKey(tenantId);
+      const res = await this.pool.query<SecretRow>(
+        `SELECT id, ciphertext_b64, version, created_at,
+                last_accessed_at, last_rotated_at, expires_at
+         FROM caia_meta.tenant_secrets_cold
+         WHERE tenant_id = $1 AND category = $2 AND key = $3
+         LIMIT 1`,
+        [tenantId, category, key],
+      );
+      const row = res.rows[0];
+      if (!row) {
+        throw new SecretNotFoundError(
+          `secret not found: ${tenantId}/${category}/${key}`,
+          { tenantId, category, key },
+        );
+      }
+      if (row.expires_at && row.expires_at.getTime() <= this.now().getTime()) {
+        throw new SecretNotFoundError(
+          `secret expired: ${tenantId}/${category}/${key}`,
+          { tenantId, category, key },
+        );
+      }
+      const plaintext = decryptValue(tenantKey, row.ciphertext_b64);
+      // Best-effort: bump last_accessed_at. We don't fail the read if this
+      // fails (race with deletion, etc.).
+      this.pool
+        .query(
+          `UPDATE caia_meta.tenant_secrets_cold
+             SET last_accessed_at = NOW()
+           WHERE id = $1`,
+          [row.id],
+        )
+        .catch(() => undefined);
+      await this.audit.write({
+        tenantId,
+        category,
+        key,
+        backend: BACKEND_NAME,
+        action: 'get',
+        callerContext,
+        ok: true,
+        providerTrace: String(row.id),
+      });
+      return plaintext;
+    } catch (err) {
+      await this.audit.write({
+        tenantId,
+        category,
+        key,
+        backend: BACKEND_NAME,
+        action: 'get',
+        callerContext,
+        ok: false,
+        errorClass: classifyError(err),
+      });
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — list
+  // ---------------------------------------------------------------------
+
+  async list(tenantId: string, category?: string): Promise<SecretMetadata[]> {
+    TenantIdSchema.parse(tenantId);
+    if (category !== undefined) CategorySchema.parse(category);
+    const params: unknown[] = [tenantId];
+    let where = `tenant_id = $1`;
+    if (category !== undefined) {
+      params.push(category);
+      where += ` AND category = $2`;
+    }
+    // Exclude expired entries from the listing.
+    const res = await this.pool.query<ListRow>(
+      `SELECT id, tenant_id, category, key, version,
+              created_at, last_accessed_at, last_rotated_at, expires_at
+       FROM caia_meta.tenant_secrets_cold
+       WHERE ${where}
+         AND (expires_at IS NULL OR expires_at > NOW())
+       ORDER BY category, key`,
+      params,
+    );
+    return res.rows.map((row) => {
+      const meta: SecretMetadata = {
+        key: row.key,
+        category: row.category,
+        secretRef: String(row.id),
+        createdAt: row.created_at,
+        version: row.version,
+      };
+      if (row.last_accessed_at) meta.lastAccessedAt = row.last_accessed_at;
+      if (row.last_rotated_at) meta.lastRotatedAt = row.last_rotated_at;
+      if (row.expires_at) meta.expiresAt = row.expires_at;
+      return meta;
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — rotate
+  // ---------------------------------------------------------------------
+
+  async rotate(
+    tenantId: string,
+    category: string,
+    key: string,
+  ): Promise<RotateResult> {
+    this.validateIdentifiers(tenantId, category, key);
+    // The Postgres adapter cannot mint a new secret value — it doesn't
+    // know what the provider's API key looks like. `rotate` here means:
+    // bump the version + record rotated_at. The caller must `put(...,
+    // {replace: true})` with the new value separately. This matches the
+    // interface contract (rotators are provider-specific).
+    const res = await this.pool.query<RotateRow>(
+      `UPDATE caia_meta.tenant_secrets_cold
+         SET version = version + 1, last_rotated_at = NOW()
+       WHERE tenant_id = $1 AND category = $2 AND key = $3
+       RETURNING version, last_rotated_at`,
+      [tenantId, category, key],
+    );
+    const row = res.rows[0];
+    if (!row) {
+      throw new SecretNotFoundError(
+        `rotate target not found: ${tenantId}/${category}/${key}`,
+        { tenantId, category, key },
+      );
+    }
+    return { rotatedAt: row.last_rotated_at, version: row.version };
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — delete
+  // ---------------------------------------------------------------------
+
+  async delete(
+    tenantId: string,
+    category: string,
+    key: string,
+    _opts?: DeleteOptions,
+  ): Promise<void> {
+    this.validateIdentifiers(tenantId, category, key);
+    // Idempotent: deleting a non-existent secret is not an error.
+    await this.pool.query(
+      `DELETE FROM caia_meta.tenant_secrets_cold
+       WHERE tenant_id = $1 AND category = $2 AND key = $3`,
+      [tenantId, category, key],
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — deleteAllForTenant (crypto-shred)
+  // ---------------------------------------------------------------------
+
+  async deleteAllForTenant(
+    tenantId: string,
+    opts?: DeleteAllForTenantOptions,
+  ): Promise<DeleteAllResult> {
+    TenantIdSchema.parse(tenantId);
+    const countRes = await this.pool.query<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM caia_meta.tenant_secrets_cold
+       WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    const deletedCount = Number(countRes.rows[0]?.n ?? '0');
+    const tombstoneRef = `tomb_${tenantId}_${Date.now().toString(36)}_${Math.random()
+      .toString(36)
+      .slice(2, 10)}`;
+    if (opts?.dryRun) {
+      return { deletedCount, tenantTombstoneRef: `${tombstoneRef}_dryrun` };
+    }
+    // Step 1 — record the shred tombstone. This is the security barrier:
+    // future `getOrDeriveTenantKey` calls for this tenant throw.
+    await this.pool.query(
+      `INSERT INTO caia_meta.tenant_crypto_shred (tenant_id, tombstone_ref)
+       VALUES ($1, $2)
+       ON CONFLICT (tenant_id) DO UPDATE SET tombstone_ref = EXCLUDED.tombstone_ref`,
+      [tenantId, tombstoneRef],
+    );
+    // Step 2 — forget the cached derived key. The Buffer is zeroed inside.
+    this.cache.invalidate(tenantId);
+    // Step 3 — drop the rows. Hygiene only; the data is already
+    // cryptographically unreachable by now.
+    await this.pool.query(
+      `DELETE FROM caia_meta.tenant_secrets_cold WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    return { deletedCount, tenantTombstoneRef: tombstoneRef };
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — auditLog
+  // ---------------------------------------------------------------------
+
+  async auditLog(
+    tenantId: string,
+    since?: Date,
+    until?: Date,
+  ): Promise<AccessLogEntry[]> {
+    TenantIdSchema.parse(tenantId);
+    const params: unknown[] = [tenantId, BACKEND_NAME];
+    let where = `tenant_id = $1 AND backend = $2`;
+    if (since !== undefined) {
+      params.push(since);
+      where += ` AND granted_at >= $${params.length}`;
+    }
+    if (until !== undefined) {
+      params.push(until);
+      where += ` AND granted_at <= $${params.length}`;
+    }
+    const res = await this.pool.query<AuditRow>(
+      `SELECT tenant_id, category, key, caller_type, caller_id, ticket_id, reason,
+              capability_token_id, requester_ip, granted_at, ok, error_class, provider_trace
+       FROM caia_meta.audit_log
+       WHERE ${where}
+       ORDER BY granted_at DESC
+       LIMIT 1000`,
+      params,
+    );
+    return res.rows.map((row) => {
+      const entry: AccessLogEntry = {
+        tenantId: row.tenant_id,
+        category: row.category,
+        key: row.key,
+        callerType: row.caller_type,
+        callerId: row.caller_id,
+        reason: row.reason,
+        grantedAt: row.granted_at,
+        ok: row.ok,
+      };
+      if (row.ticket_id) entry.ticketId = row.ticket_id;
+      if (row.capability_token_id)
+        entry.capabilityTokenId = row.capability_token_id;
+      if (row.requester_ip) entry.requesterIp = row.requester_ip;
+      if (row.error_class) entry.errorClass = row.error_class;
+      if (row.provider_trace) entry.providerTrace = row.provider_trace;
+      return entry;
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // SecretsAdapter — ping
+  // ---------------------------------------------------------------------
+
+  async ping(): Promise<PingResult> {
+    const start = Date.now();
+    try {
+      await this.pool.query(`SELECT 1`);
+      return { ok: true, latencyMs: Date.now() - start, backend: BACKEND_NAME };
+    } catch {
+      return { ok: false, latencyMs: Date.now() - start, backend: BACKEND_NAME };
+    }
+  }
+}

--- a/packages/secrets-postgres/src/audit.ts
+++ b/packages/secrets-postgres/src/audit.ts
@@ -1,0 +1,81 @@
+/**
+ * Audit-log writer for the Postgres adapter.
+ *
+ * Every `get` and `put` writes one row here. Failure to write the audit
+ * row is logged but does NOT fail the operation — losing an audit row is
+ * better than losing a secret-fetch on a fully-functional cache miss.
+ *
+ * However, on `get`, if the read itself fails AND the audit write fails,
+ * we re-throw the original read error (not the audit error) because the
+ * caller's concern is the read.
+ */
+
+import type { AccessContext, ErrorClass } from '@caia/secrets-adapter';
+import type { PoolLike } from './pg-types.js';
+
+export interface AuditWriteParams {
+  tenantId: string;
+  category: string;
+  key: string;
+  backend: string;
+  action: 'get' | 'put' | 'rotate' | 'delete' | 'delete_all';
+  callerContext: AccessContext;
+  ok: boolean;
+  errorClass?: ErrorClass;
+  providerTrace?: string;
+}
+
+export interface AuditLogger {
+  write(params: AuditWriteParams): Promise<void>;
+}
+
+export class PostgresAuditLogger implements AuditLogger {
+  private readonly pool: PoolLike;
+  private readonly onError: (err: unknown) => void;
+
+  constructor(
+    pool: PoolLike,
+    onError: (err: unknown) => void = () => undefined,
+  ) {
+    this.pool = pool;
+    this.onError = onError;
+  }
+
+  async write(params: AuditWriteParams): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO caia_meta.audit_log
+           (tenant_id, category, key, backend, action,
+            caller_type, caller_id, ticket_id, reason,
+            capability_token_id, requester_ip,
+            ok, error_class, provider_trace)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+        [
+          params.tenantId,
+          params.category,
+          params.key,
+          params.backend,
+          params.action,
+          params.callerContext.callerType,
+          params.callerContext.callerId,
+          params.callerContext.ticketId ?? null,
+          params.callerContext.reason,
+          params.callerContext.capabilityTokenId ?? null,
+          params.callerContext.requesterIp ?? null,
+          params.ok,
+          params.errorClass ?? null,
+          params.providerTrace ?? null,
+        ],
+      );
+    } catch (err) {
+      this.onError(err);
+    }
+  }
+}
+
+/** No-op auditor — useful when an outer broker is responsible for audit. */
+export class NoopAuditLogger implements AuditLogger {
+  async write(_params: AuditWriteParams): Promise<void> {
+    // intentionally empty
+  }
+}

--- a/packages/secrets-postgres/src/crypto.ts
+++ b/packages/secrets-postgres/src/crypto.ts
@@ -1,0 +1,155 @@
+/**
+ * Crypto primitives for the Postgres adapter.
+ *
+ * - HKDF-SHA256(masterKey, salt="caia-tenant-v1", info=tenantId, len=32) →
+ *   per-tenant 256-bit data key.
+ * - AES-256-GCM (12-byte IV, 16-byte authTag) → AEAD per secret value.
+ * - Output blob = iv || authTag || ciphertext, base64-encoded.
+ *
+ * The choice to encode as base64 (not hex, not raw bytea) keeps the
+ * Postgres column portable through pg_dump / logical replication / typed
+ * downstream consumers; the storage overhead (~33%) is negligible at the
+ * tens-of-bytes-per-secret scale.
+ *
+ * Per the architecture spec §8: master key in env (phase 1) or KMS
+ * (phase 2). Derived keys are computed on demand, cached, and never
+ * persisted.
+ */
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  hkdfSync,
+  randomBytes,
+} from 'node:crypto';
+import {
+  SecretProviderError,
+  SecretsAdapterConfigError,
+} from '@caia/secrets-adapter';
+
+export const HKDF_SALT = 'caia-tenant-v1';
+export const HKDF_HASH = 'sha256';
+export const DATA_KEY_BYTES = 32;
+export const AES_ALGO = 'aes-256-gcm' as const;
+export const IV_BYTES = 12;
+export const AUTH_TAG_BYTES = 16;
+
+/**
+ * Parses + validates a hex master key. Throws `SecretsAdapterConfigError`
+ * on malformed input — this is an operator misconfiguration, not a
+ * runtime failure.
+ */
+export function parseMasterKeyHex(hex: string): Buffer {
+  if (typeof hex !== 'string') {
+    throw new SecretsAdapterConfigError(
+      'CAIA_SECRETS_MASTER_KEY must be a string',
+    );
+  }
+  const cleaned = hex.trim();
+  if (!/^[0-9a-fA-F]+$/.test(cleaned)) {
+    throw new SecretsAdapterConfigError(
+      'CAIA_SECRETS_MASTER_KEY must be hex',
+    );
+  }
+  if (cleaned.length !== 64) {
+    throw new SecretsAdapterConfigError(
+      `CAIA_SECRETS_MASTER_KEY must be 32 bytes (64 hex chars); got ${cleaned.length} chars`,
+    );
+  }
+  return Buffer.from(cleaned, 'hex');
+}
+
+/**
+ * Derives a per-tenant data key via HKDF-SHA256.
+ *
+ * Deterministic: same (masterKey, tenantId) always yields the same key.
+ * That's the property the LRU cache exploits.
+ */
+export function deriveTenantKey(masterKey: Buffer, tenantId: string): Buffer {
+  if (masterKey.length !== DATA_KEY_BYTES) {
+    throw new SecretsAdapterConfigError(
+      `masterKey must be ${DATA_KEY_BYTES} bytes; got ${masterKey.length}`,
+    );
+  }
+  if (typeof tenantId !== 'string' || tenantId.length === 0) {
+    throw new SecretsAdapterConfigError(
+      'tenantId must be a non-empty string',
+    );
+  }
+  const out = hkdfSync(
+    HKDF_HASH,
+    masterKey,
+    Buffer.from(HKDF_SALT, 'utf8'),
+    Buffer.from(tenantId, 'utf8'),
+    DATA_KEY_BYTES,
+  );
+  // hkdfSync returns ArrayBuffer in some Node versions; normalise.
+  return Buffer.from(out);
+}
+
+/**
+ * Encrypts a UTF-8 plaintext under `tenantKey`. Returns the base64-encoded
+ * blob `iv || authTag || ciphertext`.
+ */
+export function encryptValue(tenantKey: Buffer, plaintext: string): string {
+  if (tenantKey.length !== DATA_KEY_BYTES) {
+    throw new SecretProviderError(
+      `tenantKey must be ${DATA_KEY_BYTES} bytes; got ${tenantKey.length}`,
+    );
+  }
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(AES_ALGO, tenantKey, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  if (authTag.length !== AUTH_TAG_BYTES) {
+    throw new SecretProviderError(
+      `unexpected authTag length ${authTag.length}`,
+    );
+  }
+  return Buffer.concat([iv, authTag, ciphertext]).toString('base64');
+}
+
+/**
+ * Inverse of `encryptValue`. Throws `SecretProviderError` if the blob is
+ * malformed or the authTag fails verification (tampering, wrong key,
+ * truncated row).
+ */
+export function decryptValue(tenantKey: Buffer, blobB64: string): string {
+  if (tenantKey.length !== DATA_KEY_BYTES) {
+    throw new SecretProviderError(
+      `tenantKey must be ${DATA_KEY_BYTES} bytes; got ${tenantKey.length}`,
+    );
+  }
+  let blob: Buffer;
+  try {
+    blob = Buffer.from(blobB64, 'base64');
+  } catch (err) {
+    throw new SecretProviderError('ciphertext is not valid base64', {
+      cause: err,
+    });
+  }
+  if (blob.length < IV_BYTES + AUTH_TAG_BYTES + 1) {
+    throw new SecretProviderError(
+      `ciphertext too short: ${blob.length} bytes`,
+    );
+  }
+  const iv = blob.subarray(0, IV_BYTES);
+  const authTag = blob.subarray(IV_BYTES, IV_BYTES + AUTH_TAG_BYTES);
+  const ciphertext = blob.subarray(IV_BYTES + AUTH_TAG_BYTES);
+  const decipher = createDecipheriv(AES_ALGO, tenantKey, iv);
+  decipher.setAuthTag(authTag);
+  try {
+    const out = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return out.toString('utf8');
+  } catch (err) {
+    // AES-GCM authentication failure — wrong key, tampered ciphertext,
+    // or truncated blob.
+    throw new SecretProviderError(
+      'AES-GCM authentication failed: ciphertext tampered, truncated, or wrong key',
+      { cause: err },
+    );
+  }
+}

--- a/packages/secrets-postgres/src/index.ts
+++ b/packages/secrets-postgres/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * `@caia/secrets-postgres` — public surface.
+ *
+ * Reference: research/multi_tenant_secrets_architecture_2026.md §1, §3
+ * (Pattern C), §8.
+ */
+
+export { PostgresSecretsAdapter, BACKEND_NAME } from './adapter.js';
+export type { PostgresSecretsAdapterOptions } from './adapter.js';
+
+export {
+  encryptValue,
+  decryptValue,
+  deriveTenantKey,
+  parseMasterKeyHex,
+  HKDF_SALT,
+  HKDF_HASH,
+  DATA_KEY_BYTES,
+  AES_ALGO,
+  IV_BYTES,
+  AUTH_TAG_BYTES,
+} from './crypto.js';
+
+export { TenantKeyCache } from './key-cache.js';
+export type { KeyCacheOptions } from './key-cache.js';
+
+export {
+  PostgresAuditLogger,
+  NoopAuditLogger,
+  type AuditLogger,
+  type AuditWriteParams,
+} from './audit.js';
+
+export type { PoolLike, PoolClientLike, QueryResultLike } from './pg-types.js';

--- a/packages/secrets-postgres/src/key-cache.ts
+++ b/packages/secrets-postgres/src/key-cache.ts
@@ -1,0 +1,100 @@
+/**
+ * In-memory LRU cache of per-tenant derived keys.
+ *
+ * Two reasons it exists:
+ *
+ *   1. HKDF is cheap but not free. Caching for the lifetime of a hot
+ *      request batch keeps p99 latency tight.
+ *   2. The cache is the **crypto-shred substrate** — `invalidate(tenantId)`
+ *      forgets the derived key for that tenant. Combined with refusing to
+ *      ever re-derive (the shred-tombstone check in the adapter), this is
+ *      what makes GDPR right-to-erasure cryptographic rather than just
+ *      DB-row-delete.
+ *
+ * Default LRU: 1024 entries, 5-minute TTL.
+ */
+
+export interface KeyCacheOptions {
+  /** Max distinct tenants kept in cache. */
+  maxEntries?: number;
+  /** Per-entry TTL in milliseconds. */
+  ttlMs?: number;
+  /** Injectable clock for deterministic tests. */
+  now?: () => number;
+}
+
+interface Entry {
+  key: Buffer;
+  expiresAt: number;
+}
+
+export class TenantKeyCache {
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly map = new Map<string, Entry>();
+
+  constructor(opts: KeyCacheOptions = {}) {
+    this.maxEntries = opts.maxEntries ?? 1024;
+    this.ttlMs = opts.ttlMs ?? 5 * 60 * 1000;
+    this.now = opts.now ?? ((): number => Date.now());
+  }
+
+  get(tenantId: string): Buffer | undefined {
+    const entry = this.map.get(tenantId);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      // Expired — drop the buffer, return undefined so the caller
+      // re-derives.
+      entry.key.fill(0);
+      this.map.delete(tenantId);
+      return undefined;
+    }
+    // LRU: move to end on access.
+    this.map.delete(tenantId);
+    this.map.set(tenantId, entry);
+    return entry.key;
+  }
+
+  set(tenantId: string, key: Buffer): void {
+    if (this.map.has(tenantId)) {
+      const old = this.map.get(tenantId);
+      if (old) old.key.fill(0);
+      this.map.delete(tenantId);
+    }
+    while (this.map.size >= this.maxEntries) {
+      const oldest = this.map.keys().next().value;
+      if (!oldest) break;
+      const old = this.map.get(oldest);
+      if (old) old.key.fill(0);
+      this.map.delete(oldest);
+    }
+    this.map.set(tenantId, {
+      key: Buffer.from(key),
+      expiresAt: this.now() + this.ttlMs,
+    });
+  }
+
+  /**
+   * Forget a tenant's key. Used by crypto-shred. The Buffer is zeroed
+   * before drop so the memory page no longer holds the key material.
+   */
+  invalidate(tenantId: string): boolean {
+    const entry = this.map.get(tenantId);
+    if (!entry) return false;
+    entry.key.fill(0);
+    this.map.delete(tenantId);
+    return true;
+  }
+
+  /** Test-only: count entries. */
+  get size(): number {
+    return this.map.size;
+  }
+
+  /** Test-only: drop everything. */
+  clear(): void {
+    for (const entry of this.map.values()) entry.key.fill(0);
+    this.map.clear();
+  }
+}

--- a/packages/secrets-postgres/src/pg-types.ts
+++ b/packages/secrets-postgres/src/pg-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal pg surface we depend on. Defining it here (instead of importing
+ * `pg.Pool` directly) lets unit tests inject a hand-rolled mock without
+ * pulling the real driver into the test fixture.
+ *
+ * The shape exactly matches what we use from `pg.Pool` / `pg.Client`:
+ *   - `query(text, values)` returning rows + rowCount
+ *   - `connect()` returning a `PoolClientLike` for transactional work
+ *
+ * Production wiring passes `new pg.Pool({...})` directly; the shape is
+ * structurally compatible.
+ */
+
+export interface QueryResultLike<R = Record<string, unknown>> {
+  rows: R[];
+  rowCount: number | null;
+}
+
+export interface PoolClientLike {
+  query<R = Record<string, unknown>>(
+    text: string,
+    values?: readonly unknown[],
+  ): Promise<QueryResultLike<R>>;
+  release(): void;
+}
+
+export interface PoolLike {
+  query<R = Record<string, unknown>>(
+    text: string,
+    values?: readonly unknown[],
+  ): Promise<QueryResultLike<R>>;
+  connect?(): Promise<PoolClientLike>;
+}

--- a/packages/secrets-postgres/tests/unit/adapter.test.ts
+++ b/packages/secrets-postgres/tests/unit/adapter.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  PostgresSecretsAdapter,
+  TenantKeyCache,
+  encryptValue,
+  deriveTenantKey,
+} from '../../src/index.js';
+import {
+  SecretNotFoundError,
+  SecretProviderError,
+  SecretsAdapterConfigError,
+  type AccessContext,
+} from '@caia/secrets-adapter';
+import { MockPool } from './mock-pool.js';
+
+const masterHex = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const ctx: AccessContext = {
+  callerType: 'agent',
+  callerId: 'unit-test',
+  reason: 'test fetch',
+};
+
+function freshAdapter(overrides: Parameters<typeof PostgresSecretsAdapter['prototype']['constructor']>[0] extends infer T ? Partial<T> : never = {}): { adapter: PostgresSecretsAdapter; pool: MockPool } {
+  const pool = new MockPool();
+  const adapter = new PostgresSecretsAdapter({
+    pool,
+    masterKeyHex: masterHex,
+    ...overrides,
+  });
+  return { adapter, pool };
+}
+
+describe('PostgresSecretsAdapter — construction', () => {
+  it('requires `pool`', () => {
+    expect(
+      () => new PostgresSecretsAdapter({ masterKeyHex: masterHex } as never),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+  it('requires masterKey or masterKeyHex', () => {
+    expect(
+      () =>
+        new PostgresSecretsAdapter({ pool: new MockPool() } as never),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+  it('accepts raw masterKey Buffer', () => {
+    const m = Buffer.alloc(32, 1);
+    const adapter = new PostgresSecretsAdapter({
+      pool: new MockPool(),
+      masterKey: m,
+    });
+    expect(adapter).toBeDefined();
+  });
+  it('rejects wrong-length masterKey', () => {
+    expect(
+      () =>
+        new PostgresSecretsAdapter({
+          pool: new MockPool(),
+          masterKey: Buffer.alloc(31),
+        }),
+    ).toThrow(SecretsAdapterConfigError);
+  });
+});
+
+describe('PostgresSecretsAdapter — put + get (round-trip)', () => {
+  it('stores then retrieves the same plaintext', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('tenant-a', 'cloud.aws', 'access_key', 'AKIA-secret');
+    const got = await adapter.get('tenant-a', 'cloud.aws', 'access_key', ctx);
+    expect(got).toBe('AKIA-secret');
+    expect(pool.secrets).toHaveLength(1);
+    expect(pool.secrets[0]?.ciphertext_b64).not.toContain('AKIA-secret');
+  });
+
+  it('ciphertext column is base64', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('tenant-a', 'c', 'k', 'plaintext');
+    expect(pool.secrets[0]?.ciphertext_b64).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+
+  it('replace upserts and bumps version', async () => {
+    const { adapter, pool } = freshAdapter();
+    const a = await adapter.put('t', 'c', 'k', 'v1', { replace: true });
+    const b = await adapter.put('t', 'c', 'k', 'v2', { replace: true });
+    expect(b.version).toBe((a.version ?? 0) + 1);
+    const got = await adapter.get('t', 'c', 'k', ctx);
+    expect(got).toBe('v2');
+    expect(pool.secrets).toHaveLength(1);
+  });
+
+  it('plain put conflict throws SecretProviderError', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v1');
+    await expect(adapter.put('t', 'c', 'k', 'v2')).rejects.toBeInstanceOf(
+      SecretProviderError,
+    );
+  });
+
+  it('rejects invalid tenantId', async () => {
+    const { adapter } = freshAdapter();
+    await expect(adapter.put('Tenant', 'c', 'k', 'v')).rejects.toThrow();
+  });
+  it('rejects invalid category', async () => {
+    const { adapter } = freshAdapter();
+    await expect(adapter.put('t', 'Cloud', 'k', 'v')).rejects.toThrow();
+  });
+  it('rejects empty secret value', async () => {
+    const { adapter } = freshAdapter();
+    await expect(adapter.put('t', 'c', 'k', '')).rejects.toThrow();
+  });
+});
+
+describe('PostgresSecretsAdapter — get failures', () => {
+  it('not-found throws SecretNotFoundError', async () => {
+    const { adapter } = freshAdapter();
+    await expect(
+      adapter.get('t', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+  });
+
+  it('rejects invalid AccessContext', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    // @ts-expect-error — missing reason
+    await expect(adapter.get('t', 'c', 'k', {})).rejects.toThrow();
+  });
+
+  it('expired secret throws SecretNotFoundError', async () => {
+    let now = new Date('2026-05-23T00:00:00Z');
+    const { adapter } = freshAdapter({ now: () => now });
+    await adapter.put('t', 'c', 'k', 'v', { ttlSeconds: 60 });
+    // Advance past the TTL.
+    now = new Date('2026-05-23T00:02:00Z');
+    await expect(
+      adapter.get('t', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+  });
+
+  it('tampered ciphertext throws SecretProviderError', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    // Flip a bit in the ciphertext.
+    const buf = Buffer.from(pool.secrets[0]!.ciphertext_b64, 'base64');
+    buf[buf.length - 1] = buf[buf.length - 1]! ^ 0xff;
+    pool.secrets[0]!.ciphertext_b64 = buf.toString('base64');
+    await expect(
+      adapter.get('t', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretProviderError);
+  });
+});
+
+describe('PostgresSecretsAdapter — audit log emission', () => {
+  it('successful get writes ok=true audit row', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    await adapter.get('t', 'c', 'k', ctx);
+    const audit = pool.audit.filter((r) => r.action === 'get');
+    expect(audit).toHaveLength(1);
+    expect(audit[0]?.ok).toBe(true);
+    expect(audit[0]?.caller_id).toBe('unit-test');
+  });
+
+  it('failed get writes ok=false audit row with error_class', async () => {
+    const { adapter, pool } = freshAdapter();
+    await expect(
+      adapter.get('t', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretNotFoundError);
+    const audit = pool.audit.filter((r) => r.action === 'get');
+    expect(audit).toHaveLength(1);
+    expect(audit[0]?.ok).toBe(false);
+    expect(audit[0]?.error_class).toBe('not_found');
+  });
+
+  it('putWithAudit writes a put row', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.putWithAudit('t', 'c', 'k', 'v', ctx);
+    const puts = pool.audit.filter((r) => r.action === 'put');
+    expect(puts).toHaveLength(1);
+    expect(puts[0]?.ok).toBe(true);
+  });
+
+  it('putWithAudit on duplicate writes an ok=false row', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    await expect(
+      adapter.putWithAudit('t', 'c', 'k', 'v2', ctx),
+    ).rejects.toBeInstanceOf(SecretProviderError);
+    const puts = pool.audit.filter((r) => r.action === 'put');
+    expect(puts).toHaveLength(1);
+    expect(puts[0]?.ok).toBe(false);
+    expect(puts[0]?.error_class).toBe('provider_error');
+  });
+
+  it('auditLog query filters by tenant', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t1', 'c', 'k', 'v');
+    await adapter.put('t2', 'c', 'k', 'v');
+    await adapter.get('t1', 'c', 'k', ctx);
+    await adapter.get('t2', 'c', 'k', ctx);
+    // Direct mock-state check
+    expect(pool.audit.filter((r) => r.tenant_id === 't1')).toHaveLength(1);
+    // Now exercise the auditLog accessor
+    const t1Log = await adapter.auditLog('t1');
+    expect(t1Log).toHaveLength(1);
+    expect(t1Log[0]?.tenantId).toBe('t1');
+  });
+});
+
+describe('PostgresSecretsAdapter — list / rotate / delete', () => {
+  it('list returns metadata only', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t', 'cloud.aws', 'key1', 'v');
+    await adapter.put('t', 'cloud.aws', 'key2', 'v');
+    await adapter.put('t', 'dns.cf', 'token', 'v');
+    const all = await adapter.list('t');
+    expect(all).toHaveLength(3);
+    for (const m of all) expect(m).not.toHaveProperty('value');
+  });
+
+  it('list filtered by category', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t', 'cloud.aws', 'k', 'v');
+    await adapter.put('t', 'dns.cf', 'k', 'v');
+    const aws = await adapter.list('t', 'cloud.aws');
+    expect(aws).toHaveLength(1);
+    expect(aws[0]?.category).toBe('cloud.aws');
+  });
+
+  it('list isolates tenants', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t1', 'c', 'k', 'v');
+    await adapter.put('t2', 'c', 'k', 'v');
+    expect(await adapter.list('t1')).toHaveLength(1);
+    expect(await adapter.list('t2')).toHaveLength(1);
+  });
+
+  it('rotate bumps version', async () => {
+    const { adapter } = freshAdapter();
+    const put = await adapter.put('t', 'c', 'k', 'v');
+    const r = await adapter.rotate('t', 'c', 'k');
+    expect(r.version).toBe((put.version ?? 0) + 1);
+  });
+
+  it('rotate on missing throws SecretNotFoundError', async () => {
+    const { adapter } = freshAdapter();
+    await expect(adapter.rotate('t', 'c', 'k')).rejects.toBeInstanceOf(
+      SecretNotFoundError,
+    );
+  });
+
+  it('delete is idempotent', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    await adapter.delete('t', 'c', 'k');
+    // Second delete shouldn't throw.
+    await expect(adapter.delete('t', 'c', 'k')).resolves.toBeUndefined();
+  });
+
+  it('delete only affects target row', async () => {
+    const { adapter } = freshAdapter();
+    await adapter.put('t', 'a', 'k', 'v');
+    await adapter.put('t', 'b', 'k', 'v');
+    await adapter.delete('t', 'a', 'k');
+    expect(await adapter.list('t')).toHaveLength(1);
+  });
+});
+
+describe('PostgresSecretsAdapter — crypto-shred (deleteAllForTenant)', () => {
+  it('drops all rows for tenant', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t1', 'c', 'k1', 'v');
+    await adapter.put('t1', 'c', 'k2', 'v');
+    await adapter.put('t2', 'c', 'k', 'v');
+    const r = await adapter.deleteAllForTenant('t1');
+    expect(r.deletedCount).toBe(2);
+    expect(pool.secrets.filter((s) => s.tenant_id === 't1')).toHaveLength(0);
+    expect(pool.secrets.filter((s) => s.tenant_id === 't2')).toHaveLength(1);
+  });
+
+  it('records a tombstone ref', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    const r = await adapter.deleteAllForTenant('t');
+    expect(r.tenantTombstoneRef).toMatch(/^tomb_t_/);
+    expect(pool.shred).toHaveLength(1);
+    expect(pool.shred[0]?.tenant_id).toBe('t');
+  });
+
+  it('dryRun does not delete or shred', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    const r = await adapter.deleteAllForTenant('t', { dryRun: true });
+    expect(r.deletedCount).toBe(1);
+    expect(r.tenantTombstoneRef).toContain('dryrun');
+    expect(pool.secrets).toHaveLength(1);
+    expect(pool.shred).toHaveLength(0);
+  });
+
+  it('shredded tenant cannot be written-to or read-from', async () => {
+    const cache = new TenantKeyCache();
+    const { adapter } = freshAdapter({ keyCache: cache });
+    await adapter.put('t', 'c', 'k', 'v');
+    await adapter.deleteAllForTenant('t');
+    // Cache was invalidated.
+    expect(cache.get('t')).toBeUndefined();
+    // Subsequent put fails because assertNotShredded throws.
+    await expect(adapter.put('t', 'c', 'k2', 'v2')).rejects.toBeInstanceOf(
+      SecretsAdapterConfigError,
+    );
+  });
+
+  it('zero secrets is a valid no-op shred', async () => {
+    const { adapter } = freshAdapter();
+    const r = await adapter.deleteAllForTenant('t');
+    expect(r.deletedCount).toBe(0);
+    expect(r.tenantTombstoneRef).toMatch(/^tomb_/);
+  });
+
+  it('rejects invalid tenantId', async () => {
+    const { adapter } = freshAdapter();
+    await expect(adapter.deleteAllForTenant('UpperCase')).rejects.toThrow();
+  });
+});
+
+describe('PostgresSecretsAdapter — key cache integration', () => {
+  it('reuses cached tenant key across calls', async () => {
+    const cache = new TenantKeyCache();
+    const { adapter } = freshAdapter({ keyCache: cache });
+    await adapter.put('t', 'c', 'k1', 'v');
+    expect(cache.size).toBe(1);
+    await adapter.put('t', 'c', 'k2', 'v');
+    expect(cache.size).toBe(1);
+  });
+
+  it('different tenants → different cache entries', async () => {
+    const cache = new TenantKeyCache();
+    const { adapter } = freshAdapter({ keyCache: cache });
+    await adapter.put('t1', 'c', 'k', 'v');
+    await adapter.put('t2', 'c', 'k', 'v');
+    expect(cache.size).toBe(2);
+  });
+});
+
+describe('PostgresSecretsAdapter — ping', () => {
+  it('returns ok on healthy pool', async () => {
+    const { adapter } = freshAdapter();
+    const r = await adapter.ping();
+    expect(r.ok).toBe(true);
+    expect(r.backend).toBe('postgres');
+    expect(r.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns not-ok when pool throws', async () => {
+    const pool = new MockPool();
+    pool.failNext = { match: /SELECT 1/, err: new Error('down') };
+    const adapter = new PostgresSecretsAdapter({ pool, masterKeyHex: masterHex });
+    const r = await adapter.ping();
+    expect(r.ok).toBe(false);
+    expect(r.backend).toBe('postgres');
+  });
+});
+
+describe('PostgresSecretsAdapter — cross-tenant isolation', () => {
+  it('tenant A get cannot decrypt tenant B row even if values are swapped', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t1', 'c', 'k', 'secret-1');
+    await adapter.put('t2', 'c', 'k', 'secret-2');
+    // Swap ciphertexts — t1 row now holds t2's encrypted blob, encrypted
+    // under t2's derived key. t1's get must fail authentication.
+    const a = pool.secrets.find((r) => r.tenant_id === 't1')!;
+    const b = pool.secrets.find((r) => r.tenant_id === 't2')!;
+    [a.ciphertext_b64, b.ciphertext_b64] = [b.ciphertext_b64, a.ciphertext_b64];
+    await expect(
+      adapter.get('t1', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretProviderError);
+    await expect(
+      adapter.get('t2', 'c', 'k', ctx),
+    ).rejects.toBeInstanceOf(SecretProviderError);
+  });
+
+  it('hand-crafted ciphertext with right key still verifies', async () => {
+    // Sanity check that the round-trip works even with hand-crafted blobs.
+    const masterBuf = Buffer.from(masterHex, 'hex');
+    const k = deriveTenantKey(masterBuf, 'manual');
+    const blob = encryptValue(k, 'hello');
+    const pool = new MockPool();
+    pool.secrets.push({
+      id: 1,
+      tenant_id: 'manual',
+      category: 'c',
+      key: 'k',
+      ciphertext_b64: blob,
+      version: 1,
+      created_at: new Date(),
+      last_accessed_at: null,
+      last_rotated_at: null,
+      expires_at: null,
+    });
+    const adapter = new PostgresSecretsAdapter({ pool, masterKeyHex: masterHex });
+    expect(await adapter.get('manual', 'c', 'k', ctx)).toBe('hello');
+  });
+});
+
+describe('PostgresSecretsAdapter — audit query', () => {
+  beforeEach(() => undefined);
+  it('returns rows sorted by granted_at DESC', async () => {
+    const { adapter, pool } = freshAdapter();
+    await adapter.put('t', 'c', 'k', 'v');
+    await adapter.get('t', 'c', 'k', ctx);
+    await adapter.get('t', 'c', 'k', ctx);
+    expect(pool.audit.filter((r) => r.action === 'get')).toHaveLength(2);
+    const log = await adapter.auditLog('t');
+    expect(log).toHaveLength(2);
+    expect(log[0]?.grantedAt.getTime()).toBeGreaterThanOrEqual(
+      log[1]?.grantedAt.getTime() ?? 0,
+    );
+  });
+});

--- a/packages/secrets-postgres/tests/unit/audit.test.ts
+++ b/packages/secrets-postgres/tests/unit/audit.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { PostgresAuditLogger, NoopAuditLogger } from '../../src/audit.js';
+import { MockPool } from './mock-pool.js';
+
+describe('PostgresAuditLogger', () => {
+  it('writes a row with all fields', async () => {
+    const pool = new MockPool();
+    const logger = new PostgresAuditLogger(pool);
+    await logger.write({
+      tenantId: 't1',
+      category: 'cloud.aws',
+      key: 'access_key',
+      backend: 'postgres',
+      action: 'get',
+      callerContext: {
+        callerType: 'agent',
+        callerId: 'coding-agent',
+        ticketId: 'sps-001',
+        reason: 'deploy',
+        capabilityTokenId: 'tok-abcdef12',
+        requesterIp: '10.0.0.1',
+      },
+      ok: true,
+      providerTrace: 'ref-42',
+    });
+    expect(pool.audit).toHaveLength(1);
+    expect(pool.audit[0]).toMatchObject({
+      tenant_id: 't1',
+      category: 'cloud.aws',
+      key: 'access_key',
+      action: 'get',
+      caller_type: 'agent',
+      caller_id: 'coding-agent',
+      ticket_id: 'sps-001',
+      capability_token_id: 'tok-abcdef12',
+      requester_ip: '10.0.0.1',
+      ok: true,
+      provider_trace: 'ref-42',
+    });
+  });
+
+  it('writes failure with errorClass', async () => {
+    const pool = new MockPool();
+    const logger = new PostgresAuditLogger(pool);
+    await logger.write({
+      tenantId: 't1',
+      category: 'c',
+      key: 'k',
+      backend: 'postgres',
+      action: 'get',
+      callerContext: { callerType: 'agent', callerId: 'a', reason: 'r' },
+      ok: false,
+      errorClass: 'not_found',
+    });
+    expect(pool.audit[0]?.ok).toBe(false);
+    expect(pool.audit[0]?.error_class).toBe('not_found');
+  });
+
+  it('swallows insert errors via onError', async () => {
+    const pool = new MockPool();
+    pool.failNext = {
+      match: /INSERT INTO caia_meta\.audit_log/,
+      err: new Error('boom'),
+    };
+    const errors: unknown[] = [];
+    const logger = new PostgresAuditLogger(pool, (e) => errors.push(e));
+    await expect(
+      logger.write({
+        tenantId: 't',
+        category: 'c',
+        key: 'k',
+        backend: 'postgres',
+        action: 'get',
+        callerContext: { callerType: 'agent', callerId: 'a', reason: 'r' },
+        ok: true,
+      }),
+    ).resolves.toBeUndefined();
+    expect(errors).toHaveLength(1);
+  });
+
+  it('uses null for missing optional fields', async () => {
+    const pool = new MockPool();
+    const logger = new PostgresAuditLogger(pool);
+    await logger.write({
+      tenantId: 't',
+      category: 'c',
+      key: 'k',
+      backend: 'postgres',
+      action: 'put',
+      callerContext: { callerType: 'agent', callerId: 'a', reason: 'r' },
+      ok: true,
+    });
+    expect(pool.audit[0]?.ticket_id).toBeNull();
+    expect(pool.audit[0]?.capability_token_id).toBeNull();
+    expect(pool.audit[0]?.requester_ip).toBeNull();
+    expect(pool.audit[0]?.error_class).toBeNull();
+    expect(pool.audit[0]?.provider_trace).toBeNull();
+  });
+});
+
+describe('NoopAuditLogger', () => {
+  it('does nothing', async () => {
+    const logger = new NoopAuditLogger();
+    await expect(
+      logger.write({
+        tenantId: 't',
+        category: 'c',
+        key: 'k',
+        backend: 'postgres',
+        action: 'get',
+        callerContext: { callerType: 'agent', callerId: 'a', reason: 'r' },
+        ok: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/secrets-postgres/tests/unit/crypto.test.ts
+++ b/packages/secrets-postgres/tests/unit/crypto.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import {
+  AES_ALGO,
+  AUTH_TAG_BYTES,
+  DATA_KEY_BYTES,
+  HKDF_HASH,
+  HKDF_SALT,
+  IV_BYTES,
+  decryptValue,
+  deriveTenantKey,
+  encryptValue,
+  parseMasterKeyHex,
+} from '../../src/crypto.js';
+import {
+  SecretProviderError,
+  SecretsAdapterConfigError,
+} from '@caia/secrets-adapter';
+
+const validMasterHex = '0'.repeat(64);
+const validMaster = Buffer.alloc(DATA_KEY_BYTES, 7); // arbitrary deterministic bytes
+
+describe('crypto constants', () => {
+  it('AES_ALGO is aes-256-gcm', () => expect(AES_ALGO).toBe('aes-256-gcm'));
+  it('IV is 12 bytes', () => expect(IV_BYTES).toBe(12));
+  it('authTag is 16 bytes', () => expect(AUTH_TAG_BYTES).toBe(16));
+  it('data key is 32 bytes', () => expect(DATA_KEY_BYTES).toBe(32));
+  it('HKDF hash sha256', () => expect(HKDF_HASH).toBe('sha256'));
+  it('HKDF salt fixed', () => expect(HKDF_SALT).toBe('caia-tenant-v1'));
+});
+
+describe('parseMasterKeyHex', () => {
+  it('accepts 64-hex-char string', () => {
+    const buf = parseMasterKeyHex(validMasterHex);
+    expect(buf).toBeInstanceOf(Buffer);
+    expect(buf.length).toBe(32);
+  });
+  it('accepts uppercase + whitespace', () => {
+    const buf = parseMasterKeyHex(' AABBCCDDEEFF' + '0'.repeat(52) + ' ');
+    expect(buf.length).toBe(32);
+  });
+  it('rejects non-hex chars', () => {
+    expect(() => parseMasterKeyHex('zz' + '0'.repeat(62))).toThrow(
+      SecretsAdapterConfigError,
+    );
+  });
+  it('rejects wrong length (too short)', () => {
+    expect(() => parseMasterKeyHex('0'.repeat(63))).toThrow(
+      SecretsAdapterConfigError,
+    );
+  });
+  it('rejects wrong length (too long)', () => {
+    expect(() => parseMasterKeyHex('0'.repeat(65))).toThrow(
+      SecretsAdapterConfigError,
+    );
+  });
+  it('rejects empty', () => {
+    expect(() => parseMasterKeyHex('')).toThrow(SecretsAdapterConfigError);
+  });
+  it('rejects non-string input', () => {
+    // @ts-expect-error — purposeful runtime mistake.
+    expect(() => parseMasterKeyHex(undefined)).toThrow(SecretsAdapterConfigError);
+  });
+});
+
+describe('deriveTenantKey', () => {
+  it('returns 32-byte buffer', () => {
+    const k = deriveTenantKey(validMaster, 'tenant-a');
+    expect(k).toBeInstanceOf(Buffer);
+    expect(k.length).toBe(32);
+  });
+  it('is deterministic', () => {
+    const k1 = deriveTenantKey(validMaster, 'tenant-a');
+    const k2 = deriveTenantKey(validMaster, 'tenant-a');
+    expect(k1.equals(k2)).toBe(true);
+  });
+  it('differs across tenants', () => {
+    const a = deriveTenantKey(validMaster, 'tenant-a');
+    const b = deriveTenantKey(validMaster, 'tenant-b');
+    expect(a.equals(b)).toBe(false);
+  });
+  it('differs across master keys', () => {
+    const m2 = Buffer.alloc(32, 8);
+    const k1 = deriveTenantKey(validMaster, 'tenant-a');
+    const k2 = deriveTenantKey(m2, 'tenant-a');
+    expect(k1.equals(k2)).toBe(false);
+  });
+  it('rejects wrong-length master', () => {
+    expect(() => deriveTenantKey(Buffer.alloc(31), 't')).toThrow(
+      SecretsAdapterConfigError,
+    );
+  });
+  it('rejects empty tenantId', () => {
+    expect(() => deriveTenantKey(validMaster, '')).toThrow(
+      SecretsAdapterConfigError,
+    );
+  });
+});
+
+describe('encryptValue / decryptValue (round-trip)', () => {
+  it('round-trips a short ASCII string', () => {
+    const k = deriveTenantKey(validMaster, 't');
+    const blob = encryptValue(k, 'hunter2');
+    expect(decryptValue(k, blob)).toBe('hunter2');
+  });
+  it('round-trips UTF-8 with multibyte chars', () => {
+    const k = deriveTenantKey(validMaster, 't');
+    const plaintext = '🔑 пароль — מפתח';
+    expect(decryptValue(k, encryptValue(k, plaintext))).toBe(plaintext);
+  });
+  it('round-trips a 100KB payload', () => {
+    const k = deriveTenantKey(validMaster, 't');
+    const plaintext = 'A'.repeat(100_000);
+    expect(decryptValue(k, encryptValue(k, plaintext))).toBe(plaintext);
+  });
+  it('produces unique ciphertexts for the same plaintext (random IV)', () => {
+    const k = deriveTenantKey(validMaster, 't');
+    const a = encryptValue(k, 'x');
+    const b = encryptValue(k, 'x');
+    expect(a).not.toBe(b);
+  });
+  it('ciphertext is base64', () => {
+    const k = deriveTenantKey(validMaster, 't');
+    const blob = encryptValue(k, 'x');
+    expect(blob).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+  it('ciphertext blob is iv (12) + tag (16) + ct (>=1)', () => {
+    const k = deriveTenantKey(validMaster, 't');
+    const blob = Buffer.from(encryptValue(k, 'x'), 'base64');
+    expect(blob.length).toBeGreaterThanOrEqual(12 + 16 + 1);
+  });
+});
+
+describe('encryptValue — failure modes', () => {
+  it('rejects wrong-length tenantKey', () => {
+    expect(() => encryptValue(Buffer.alloc(31), 'x')).toThrow(
+      SecretProviderError,
+    );
+  });
+});
+
+describe('decryptValue — failure modes', () => {
+  const k = deriveTenantKey(validMaster, 't');
+  it('rejects wrong-length tenantKey', () => {
+    expect(() => decryptValue(Buffer.alloc(31), 'AAAA')).toThrow(
+      SecretProviderError,
+    );
+  });
+  it('rejects too-short ciphertext', () => {
+    expect(() => decryptValue(k, Buffer.alloc(5).toString('base64'))).toThrow(
+      SecretProviderError,
+    );
+  });
+  it('rejects tampered ciphertext (bit flip in body)', () => {
+    const blob = Buffer.from(encryptValue(k, 'hunter2'), 'base64');
+    blob[blob.length - 1] = blob[blob.length - 1]! ^ 0xff;
+    expect(() => decryptValue(k, blob.toString('base64'))).toThrow(
+      SecretProviderError,
+    );
+  });
+  it('rejects tampered authTag', () => {
+    const blob = Buffer.from(encryptValue(k, 'x'), 'base64');
+    blob[IV_BYTES] = blob[IV_BYTES]! ^ 0xff;
+    expect(() => decryptValue(k, blob.toString('base64'))).toThrow(
+      SecretProviderError,
+    );
+  });
+  it('rejects when decrypted with wrong tenant key', () => {
+    const blob = encryptValue(k, 'hunter2');
+    const k2 = deriveTenantKey(validMaster, 'other-tenant');
+    expect(() => decryptValue(k2, blob)).toThrow(SecretProviderError);
+  });
+  it('rejects truncated ciphertext', () => {
+    const blob = Buffer.from(encryptValue(k, 'hunter2'), 'base64');
+    const truncated = blob.subarray(0, blob.length - 5);
+    expect(() => decryptValue(k, truncated.toString('base64'))).toThrow(
+      SecretProviderError,
+    );
+  });
+});
+
+describe('cross-tenant isolation', () => {
+  it('tenant A cannot decrypt tenant B ciphertext', () => {
+    const kA = deriveTenantKey(validMaster, 'tenant-a');
+    const kB = deriveTenantKey(validMaster, 'tenant-b');
+    const blob = encryptValue(kA, 'secret-a');
+    expect(() => decryptValue(kB, blob)).toThrow(SecretProviderError);
+  });
+  it('different masters give different keys per tenant', () => {
+    const otherMaster = randomBytes(32);
+    const kA1 = deriveTenantKey(validMaster, 'tenant-a');
+    const kA2 = deriveTenantKey(otherMaster, 'tenant-a');
+    expect(kA1.equals(kA2)).toBe(false);
+  });
+});

--- a/packages/secrets-postgres/tests/unit/key-cache.test.ts
+++ b/packages/secrets-postgres/tests/unit/key-cache.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { TenantKeyCache } from '../../src/key-cache.js';
+
+const key32 = (b: number): Buffer => Buffer.alloc(32, b);
+
+describe('TenantKeyCache — basics', () => {
+  it('get returns undefined on miss', () => {
+    const c = new TenantKeyCache();
+    expect(c.get('t')).toBeUndefined();
+  });
+  it('set then get returns the key', () => {
+    const c = new TenantKeyCache();
+    c.set('t', key32(1));
+    const got = c.get('t');
+    expect(got).toBeDefined();
+    expect(got!.equals(key32(1))).toBe(true);
+  });
+  it('returns a copy (mutating cached buffer does not leak)', () => {
+    const c = new TenantKeyCache();
+    const original = key32(1);
+    c.set('t', original);
+    original.fill(0); // mutate the source
+    const got = c.get('t');
+    expect(got!.equals(key32(1))).toBe(true);
+  });
+});
+
+describe('TenantKeyCache — TTL', () => {
+  it('expired entry returns undefined', () => {
+    let now = 1000;
+    const c = new TenantKeyCache({ ttlMs: 100, now: () => now });
+    c.set('t', key32(2));
+    now = 1100; // exactly at expiry
+    expect(c.get('t')).toBeUndefined();
+  });
+  it('non-expired returns the key', () => {
+    let now = 1000;
+    const c = new TenantKeyCache({ ttlMs: 1000, now: () => now });
+    c.set('t', key32(2));
+    now = 1500;
+    expect(c.get('t')).toBeDefined();
+  });
+  it('expired entry is dropped from cache', () => {
+    let now = 1000;
+    const c = new TenantKeyCache({ ttlMs: 100, now: () => now });
+    c.set('t', key32(3));
+    expect(c.size).toBe(1);
+    now = 2000;
+    c.get('t');
+    expect(c.size).toBe(0);
+  });
+});
+
+describe('TenantKeyCache — LRU eviction', () => {
+  it('evicts oldest when at capacity', () => {
+    const c = new TenantKeyCache({ maxEntries: 2 });
+    c.set('a', key32(1));
+    c.set('b', key32(2));
+    c.set('c', key32(3));
+    expect(c.get('a')).toBeUndefined();
+    expect(c.get('b')).toBeDefined();
+    expect(c.get('c')).toBeDefined();
+  });
+  it('accessing an entry moves it to most-recently-used', () => {
+    const c = new TenantKeyCache({ maxEntries: 2 });
+    c.set('a', key32(1));
+    c.set('b', key32(2));
+    c.get('a'); // bump 'a'
+    c.set('c', key32(3));
+    expect(c.get('b')).toBeUndefined();
+    expect(c.get('a')).toBeDefined();
+  });
+  it('size respects capacity', () => {
+    const c = new TenantKeyCache({ maxEntries: 3 });
+    c.set('a', key32(1));
+    c.set('b', key32(2));
+    c.set('c', key32(3));
+    c.set('d', key32(4));
+    expect(c.size).toBe(3);
+  });
+});
+
+describe('TenantKeyCache — invalidate (crypto-shred)', () => {
+  it('invalidate returns true when key exists', () => {
+    const c = new TenantKeyCache();
+    c.set('t', key32(1));
+    expect(c.invalidate('t')).toBe(true);
+  });
+  it('invalidate returns false when key missing', () => {
+    const c = new TenantKeyCache();
+    expect(c.invalidate('nope')).toBe(false);
+  });
+  it('after invalidate, get returns undefined', () => {
+    const c = new TenantKeyCache();
+    c.set('t', key32(1));
+    c.invalidate('t');
+    expect(c.get('t')).toBeUndefined();
+  });
+  it('clear empties everything', () => {
+    const c = new TenantKeyCache();
+    c.set('a', key32(1));
+    c.set('b', key32(2));
+    c.clear();
+    expect(c.size).toBe(0);
+  });
+});
+
+describe('TenantKeyCache — re-set overrides', () => {
+  it('setting twice updates the value', () => {
+    const c = new TenantKeyCache();
+    c.set('t', key32(1));
+    c.set('t', key32(2));
+    expect(c.get('t')!.equals(key32(2))).toBe(true);
+    expect(c.size).toBe(1);
+  });
+});
+
+describe('TenantKeyCache — defaults', () => {
+  it('default capacity is 1024', () => {
+    const c = new TenantKeyCache();
+    for (let i = 0; i < 1024; i++) c.set(`t${i}`, key32(1));
+    c.set('t-overflow', key32(1));
+    expect(c.size).toBe(1024);
+  });
+});

--- a/packages/secrets-postgres/tests/unit/mock-pool.ts
+++ b/packages/secrets-postgres/tests/unit/mock-pool.ts
@@ -1,0 +1,358 @@
+/**
+ * Hand-rolled in-memory Postgres mock implementing `PoolLike`.
+ *
+ * Why not pg-mem? Because we want zero non-trivial deps in the test
+ * fixture and we want fine-grained control over query routing for
+ * audit-log testing. The shapes mirror the real schema's columns.
+ */
+
+import type { PoolLike, QueryResultLike } from '../../src/pg-types.js';
+
+interface SecretRow {
+  id: number;
+  tenant_id: string;
+  category: string;
+  key: string;
+  ciphertext_b64: string;
+  version: number;
+  created_at: Date;
+  last_accessed_at: Date | null;
+  last_rotated_at: Date | null;
+  expires_at: Date | null;
+}
+
+interface AuditRow {
+  id: number;
+  tenant_id: string;
+  category: string;
+  key: string;
+  backend: string;
+  action: string;
+  caller_type: string;
+  caller_id: string;
+  ticket_id: string | null;
+  reason: string;
+  capability_token_id: string | null;
+  requester_ip: string | null;
+  granted_at: Date;
+  ok: boolean;
+  error_class: string | null;
+  provider_trace: string | null;
+}
+
+interface ShredRow {
+  tenant_id: string;
+  shredded_at: Date;
+  tombstone_ref: string;
+}
+
+export class MockPool implements PoolLike {
+  public secrets: SecretRow[] = [];
+  public audit: AuditRow[] = [];
+  public shred: ShredRow[] = [];
+  private nextSecretId = 1;
+  private nextAuditId = 1;
+  public failNext: { match: RegExp; err: Error } | null = null;
+  public capturedQueries: { text: string; values: readonly unknown[] }[] = [];
+
+  async query<R = Record<string, unknown>>(
+    text: string,
+    values: readonly unknown[] = [],
+  ): Promise<QueryResultLike<R>> {
+    this.capturedQueries.push({ text, values });
+    if (this.failNext && this.failNext.match.test(text)) {
+      const err = this.failNext.err;
+      this.failNext = null;
+      throw err;
+    }
+    const s = text.replace(/\s+/g, ' ').trim();
+
+    // SELECT 1 — ping
+    if (s === 'SELECT 1') {
+      return { rows: [{ '?column?': 1 }] as unknown as R[], rowCount: 1 };
+    }
+
+    // SELECT from tenant_crypto_shred
+    if (s.startsWith('SELECT tenant_id FROM caia_meta.tenant_crypto_shred')) {
+      const tenantId = values[0] as string;
+      const found = this.shred.filter((r) => r.tenant_id === tenantId);
+      return { rows: found as unknown as R[], rowCount: found.length };
+    }
+
+    // INSERT into tenant_crypto_shred (upsert)
+    if (s.startsWith('INSERT INTO caia_meta.tenant_crypto_shred')) {
+      const tenantId = values[0] as string;
+      const tombstoneRef = values[1] as string;
+      const existing = this.shred.find((r) => r.tenant_id === tenantId);
+      if (existing) {
+        existing.tombstone_ref = tombstoneRef;
+      } else {
+        this.shred.push({
+          tenant_id: tenantId,
+          tombstone_ref: tombstoneRef,
+          shredded_at: new Date(),
+        });
+      }
+      return { rows: [], rowCount: 1 };
+    }
+
+    // COUNT(*) from tenant_secrets_cold
+    if (s.startsWith('SELECT COUNT(*)::text AS n FROM caia_meta.tenant_secrets_cold')) {
+      const tenantId = values[0] as string;
+      const count = this.secrets.filter((r) => r.tenant_id === tenantId).length;
+      return {
+        rows: [{ n: String(count) }] as unknown as R[],
+        rowCount: 1,
+      };
+    }
+
+    // INSERT into tenant_secrets_cold with ON CONFLICT (upsert)
+    if (
+      s.startsWith('INSERT INTO caia_meta.tenant_secrets_cold') &&
+      s.includes('ON CONFLICT')
+    ) {
+      const [tenantId, category, key, ciphertext, expiresAt] = values as [
+        string,
+        string,
+        string,
+        string,
+        Date | null,
+      ];
+      const existing = this.secrets.find(
+        (r) =>
+          r.tenant_id === tenantId &&
+          r.category === category &&
+          r.key === key,
+      );
+      if (existing) {
+        existing.ciphertext_b64 = ciphertext;
+        existing.version += 1;
+        existing.expires_at = expiresAt;
+        existing.last_rotated_at = new Date();
+        return {
+          rows: [{ id: existing.id, version: existing.version }] as unknown as R[],
+          rowCount: 1,
+        };
+      }
+      const id = this.nextSecretId++;
+      this.secrets.push({
+        id,
+        tenant_id: tenantId,
+        category,
+        key,
+        ciphertext_b64: ciphertext,
+        version: 1,
+        created_at: new Date(),
+        last_accessed_at: null,
+        last_rotated_at: null,
+        expires_at: expiresAt,
+      });
+      return { rows: [{ id, version: 1 }] as unknown as R[], rowCount: 1 };
+    }
+
+    // INSERT into tenant_secrets_cold (plain — fails on conflict)
+    if (s.startsWith('INSERT INTO caia_meta.tenant_secrets_cold')) {
+      const [tenantId, category, key, ciphertext, expiresAt] = values as [
+        string,
+        string,
+        string,
+        string,
+        Date | null,
+      ];
+      const conflict = this.secrets.find(
+        (r) =>
+          r.tenant_id === tenantId &&
+          r.category === category &&
+          r.key === key,
+      );
+      if (conflict) {
+        const err = new Error('duplicate key value violates unique constraint') as Error & {
+          code?: string;
+        };
+        err.code = '23505';
+        throw err;
+      }
+      const id = this.nextSecretId++;
+      this.secrets.push({
+        id,
+        tenant_id: tenantId,
+        category,
+        key,
+        ciphertext_b64: ciphertext,
+        version: 1,
+        created_at: new Date(),
+        last_accessed_at: null,
+        last_rotated_at: null,
+        expires_at: expiresAt,
+      });
+      return { rows: [{ id, version: 1 }] as unknown as R[], rowCount: 1 };
+    }
+
+    // SELECT a single secret row
+    if (
+      s.startsWith(
+        'SELECT id, ciphertext_b64, version, created_at, last_accessed_at, last_rotated_at, expires_at FROM caia_meta.tenant_secrets_cold',
+      )
+    ) {
+      const [tenantId, category, key] = values as [string, string, string];
+      const row = this.secrets.find(
+        (r) =>
+          r.tenant_id === tenantId &&
+          r.category === category &&
+          r.key === key,
+      );
+      return { rows: row ? ([row] as unknown as R[]) : [], rowCount: row ? 1 : 0 };
+    }
+
+    // SELECT list metadata
+    if (
+      s.startsWith(
+        'SELECT id, tenant_id, category, key, version, created_at, last_accessed_at, last_rotated_at, expires_at FROM caia_meta.tenant_secrets_cold',
+      )
+    ) {
+      const tenantId = values[0] as string;
+      const category = values[1] as string | undefined;
+      const now = Date.now();
+      const rows = this.secrets
+        .filter((r) => r.tenant_id === tenantId)
+        .filter((r) => (category ? r.category === category : true))
+        .filter((r) => r.expires_at === null || r.expires_at.getTime() > now)
+        .sort((a, b) =>
+          a.category === b.category
+            ? a.key.localeCompare(b.key)
+            : a.category.localeCompare(b.category),
+        );
+      return { rows: rows as unknown as R[], rowCount: rows.length };
+    }
+
+    // UPDATE last_accessed_at (best-effort, no return required)
+    if (
+      s.startsWith(
+        'UPDATE caia_meta.tenant_secrets_cold SET last_accessed_at',
+      )
+    ) {
+      const id = values[0] as number;
+      const row = this.secrets.find((r) => r.id === id);
+      if (row) row.last_accessed_at = new Date();
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+
+    // UPDATE rotate version
+    if (
+      s.startsWith(
+        'UPDATE caia_meta.tenant_secrets_cold SET version = version + 1',
+      )
+    ) {
+      const [tenantId, category, key] = values as [string, string, string];
+      const row = this.secrets.find(
+        (r) =>
+          r.tenant_id === tenantId &&
+          r.category === category &&
+          r.key === key,
+      );
+      if (!row) return { rows: [], rowCount: 0 };
+      row.version += 1;
+      row.last_rotated_at = new Date();
+      return {
+        rows: [{ version: row.version, last_rotated_at: row.last_rotated_at }] as unknown as R[],
+        rowCount: 1,
+      };
+    }
+
+    // DELETE one secret
+    if (
+      s.startsWith(
+        'DELETE FROM caia_meta.tenant_secrets_cold WHERE tenant_id = $1 AND category = $2 AND key = $3',
+      )
+    ) {
+      const [tenantId, category, key] = values as [string, string, string];
+      const before = this.secrets.length;
+      this.secrets = this.secrets.filter(
+        (r) =>
+          !(
+            r.tenant_id === tenantId &&
+            r.category === category &&
+            r.key === key
+          ),
+      );
+      return { rows: [], rowCount: before - this.secrets.length };
+    }
+
+    // DELETE all for tenant
+    if (
+      s.startsWith(
+        'DELETE FROM caia_meta.tenant_secrets_cold WHERE tenant_id = $1',
+      )
+    ) {
+      const tenantId = values[0] as string;
+      const before = this.secrets.length;
+      this.secrets = this.secrets.filter((r) => r.tenant_id !== tenantId);
+      return { rows: [], rowCount: before - this.secrets.length };
+    }
+
+    // INSERT into audit_log
+    if (s.startsWith('INSERT INTO caia_meta.audit_log')) {
+      const [
+        tenantId,
+        category,
+        key,
+        backend,
+        action,
+        callerType,
+        callerId,
+        ticketId,
+        reason,
+        capabilityTokenId,
+        requesterIp,
+        ok,
+        errorClass,
+        providerTrace,
+      ] = values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string,
+        string | null,
+        string | null,
+        boolean,
+        string | null,
+        string | null,
+      ];
+      this.audit.push({
+        id: this.nextAuditId++,
+        tenant_id: tenantId,
+        category,
+        key,
+        backend,
+        action,
+        caller_type: callerType,
+        caller_id: callerId,
+        ticket_id: ticketId,
+        reason,
+        capability_token_id: capabilityTokenId,
+        requester_ip: requesterIp,
+        granted_at: new Date(),
+        ok,
+        error_class: errorClass,
+        provider_trace: providerTrace,
+      });
+      return { rows: [], rowCount: 1 };
+    }
+
+    // SELECT audit_log
+    if (s.startsWith('SELECT tenant_id, category, key, caller_type')) {
+      const [tenantId, backend] = values as [string, string];
+      const rows = this.audit
+        .filter((r) => r.tenant_id === tenantId && r.backend === backend)
+        .sort((a, b) => b.granted_at.getTime() - a.granted_at.getTime());
+      return { rows: rows as unknown as R[], rowCount: rows.length };
+    }
+
+    throw new Error(`MockPool: unrecognized query: ${s.slice(0, 100)}…`);
+  }
+}

--- a/packages/secrets-postgres/tsconfig.json
+++ b/packages/secrets-postgres/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/secrets-postgres/vitest.config.ts
+++ b/packages/secrets-postgres/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests/integration/**'],
+  },
+});

--- a/packages/secrets-postgres/vitest.integration.config.ts
+++ b/packages/secrets-postgres/vitest.integration.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+export default defineConfig({
+  test: {
+    include: ['tests/integration/**/*.test.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2048,6 +2048,31 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/secrets-adapter:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/secrets-broker:
     dependencies:
       '@chiefaia/logger':
@@ -2081,6 +2106,68 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+
+  packages/secrets-infisical:
+    dependencies:
+      '@caia/secrets-adapter':
+        specifier: workspace:*
+        version: link:../secrets-adapter
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
+  packages/secrets-postgres:
+    dependencies:
+      '@caia/secrets-adapter':
+        specifier: workspace:*
+        version: link:../secrets-adapter
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/pg':
+        specifier: ^8.11.6
+        version: 8.20.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/seo-program:
     dependencies:


### PR DESCRIPTION
Wave-0 of CAIA's multi-tenant secrets substrate — three packages implementing the architecture from `research/multi_tenant_secrets_architecture_2026.md` (§5 interface, §6 broker-context, §7 encryption-at-rest, §9 incident mitigations).

## What ships

| package | pattern | tests | purpose |
|---|---|---|---|
| `@caia/secrets-adapter` | interface | 62 | The single line CAIA application code crosses to read or write any tenant credential. `SecretsAdapter` + `AccessContext` + typed errors + Zod schemas. |
| `@caia/secrets-postgres` | C — encrypted column | 94 | Phase-1 bootstrap. AES-256-GCM under per-tenant HKDF-SHA256-derived keys. Crypto-shred GDPR delete. Audit log to `caia_meta.audit_log`. |
| `@caia/secrets-infisical` | B — project-per-tenant | 62 | Phase-1 hot path. Self-hosted Infisical at `https://infisical.chiefaia.com`, machine-identity universal-auth, optional Cloudflare-Access headers. |

**218 vitest tests pass** (94 + 62 + 62). All three packages: TypeScript strict clean, eslint clean, build clean.

## Architectural highlights

- `AccessContext` is **mandatory on every `get`** — the *adapter* writes the audit row, not the caller, making it impossible-by-construction to fetch a secret without an audit trail (per spec §6 design choice 1).
- `deleteAllForTenant` returns a tombstone ref destined for `caia_meta.gdpr_erasures` (spec §6 design choice 2).
- Per-tenant key derivation is one-way: forgetting the derived-key cache + writing the shred-tombstone makes prior ciphertexts permanently undecryptable — *crypto-shred for GDPR right-to-erasure* (spec §3 Pattern C, §8 'crypto-shred support').
- Cross-tenant isolation tested by **ciphertext-swap**: t1's row gets t2's encrypted blob; both gets MUST fail AES-GCM authentication.
- Infisical 401 auto-retry with re-login covers token revocation / clock skew.
- AuditLogger interface is duplicated in `@caia/secrets-infisical` to avoid a forced dependency on `@caia/secrets-postgres`; the `PostgresAuditLogger` plugs in cleanly for a unified audit table.

## What's NOT in this wave

- The `secrets-router` that picks adapter per-tenant from `caia_meta.tenant_secret_routing` (spec §11) — comes in wave-1.
- The `DualWriteSecretsAdapter` migration helper (spec §10) — wave-2.
- Wiring this into `@chiefaia/secrets-broker` — wave-3.

## Reference

`research/multi_tenant_secrets_architecture_2026.md`