### PR TITLE
feat(@caia/architect-kit): SpecialistArchitect interface, BaseArchitect, registry, CLI scaffolder

### DIFF
--- a/packages/architect-kit/README.md
+++ b/packages/architect-kit/README.md
@@ -1,0 +1,61 @@
+# @caia/architect-kit
+
+The interface kit every one of CAIA's 17 specialist architects implements.
+
+## What's here
+
+- **`SpecialistArchitect` interface** — the polymorphic contract the EA Dispatcher consumes (`name`, `sectionContract`, `systemPrompt()`, `tools`, `run()`).
+- **`BaseArchitect` abstract class** — reduces per-architect boilerplate (`okOutput`, `partialOutput`, `failedOutput`, `missingPaths`, `extraPaths`, `zeroSpend`).
+- **`ArchitectSectionContract`** — disjoint-write contract over `tickets.architecture` JSONB. Each contract declares the JSON paths it owns, its precedence rank, its `dependsOn` set, and an `appliesPredicate(ticket)` filter.
+- **`ArchitectRegistry`** — process-local store of all registered architects. Validates path-disjointness on every register. The dispatcher iterates `applicableTo(ticket)` to derive the active set.
+- **`computeWaves()`** — Kahn's algorithm over the `dependsOn` graph. Returns wave layers the dispatcher fans out in parallel.
+- **`CANONICAL_PRECEDENCE_LADDER`** — the 17-element ranking used by the dispatcher's semantic-conflict resolver.
+- **`caia-architect-new` CLI** — scaffolds a new `<name>-architect` package with a working stub and tests.
+
+## Quick scaffold
+
+```bash
+pnpm caia-architect-new \
+  --name analytics \
+  --depends-on frontend \
+  --precedence 10 \
+  --writes "analytics.provider,analytics.eventTaxonomy" \
+  --runtime-model sonnet
+```
+
+Generates `packages/analytics-architect/` with `package.json`, `tsconfig.json`, `vitest.config.ts`, `README.md`, `src/{index,contract,architect,system-prompt.md}.ts`, and passing tests under `tests/`.
+
+## Implementing a custom architect
+
+```ts
+import { BaseArchitect, type ArchitectSectionContract } from '@caia/architect-kit';
+
+const MyContract: ArchitectSectionContract = {
+  contractId: 'my-architect.v1',
+  architectName: 'my',
+  version: '0.1.0',
+  sections: [
+    { path: 'my.foo', description: 'the foo field', required: true },
+  ],
+  architectMeta: {
+    dependsOn: [],
+    precedenceLevel: 50,
+    fanoutPolicy: 'always',
+    appliesPredicate: (ticket) => ticket.type === 'Page',
+    runtimeModel: 'sonnet',
+  },
+};
+
+export class MyArchitect extends BaseArchitect {
+  readonly name = 'my';
+  readonly sectionContract = MyContract;
+  async run(input) {
+    // Call your LLM here. Return ok/partial/failed output.
+    return this.okOutput({ 'my.foo': 'bar' }, { confidence: 0.9 });
+  }
+}
+```
+
+## Spec
+
+Sourced from `research/17_architect_framework_spec_2026.md` (§1 Interface, §2 Roster + Waves, §5 Conflict Resolution, §8 CLI).

--- a/packages/architect-kit/bin/caia-architect-new.mjs
+++ b/packages/architect-kit/bin/caia-architect-new.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+/**
+ * caia-architect-new — scaffold a new specialist-architect package.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §8.
+ *
+ * Usage:
+ *   pnpm caia-architect-new \
+ *     --name analytics \
+ *     --depends-on frontend \
+ *     --precedence 10 \
+ *     --writes "analytics.provider,analytics.eventTaxonomy" \
+ *     --runtime-model sonnet
+ *
+ * Creates packages/<name>-architect/ with a working stub: contract + class
+ * extending BaseArchitect + tests that pass on a fresh scaffold.
+ */
+
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: caia-architect-new --name <name> --writes <comma-paths> [options]',
+      '',
+      'Required:',
+      '  --name <name>           Architect role name (e.g. analytics).',
+      '  --writes <paths>        Comma-separated JSON paths the architect owns.',
+      '',
+      'Options:',
+      '  --depends-on <names>    Comma-separated architect names. Default: empty.',
+      '  --precedence <int>      Precedence rank (1..N). Default: 99 (low).',
+      '  --runtime-model <m>     haiku|sonnet|opus. Default: sonnet.',
+      '  --fanout <policy>       always|conditional|gated. Default: always.',
+      '  --out-dir <dir>         Output directory. Default: ./packages.',
+      '  --dry-run               Print planned files without writing.',
+      '  --help                  Show this help.',
+      '',
+    ].join('\n'),
+  );
+}
+
+function pascalCase(s) {
+  return s
+    .split(/[-_\s]+/)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join('');
+}
+
+function packageJson(name) {
+  return (
+    JSON.stringify(
+      {
+        name: `@caia/${name}-architect`,
+        version: '0.1.0',
+        private: true,
+        description: `${name} specialist architect — populates the ${name}.* slice of tickets.architecture during the EA fan-out phase.`,
+        main: 'src/index.ts',
+        types: 'src/index.ts',
+        scripts: {
+          test: 'vitest run',
+          typecheck: 'tsc --noEmit',
+        },
+        dependencies: {
+          '@caia/architect-kit': 'workspace:*',
+        },
+        devDependencies: {
+          '@types/node': '^20',
+          typescript: '^5.4.5',
+          vitest: '^1.6.0',
+        },
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+function tsconfig() {
+  return (
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          esModuleInterop: true,
+          strict: true,
+          exactOptionalPropertyTypes: true,
+          noUncheckedIndexedAccess: true,
+          skipLibCheck: true,
+          resolveJsonModule: true,
+          noEmit: true,
+          lib: ['ES2022'],
+        },
+        include: ['src/**/*', 'tests/**/*'],
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}
+
+function vitestConfig() {
+  return [
+    "import { defineConfig } from 'vitest/config';",
+    '',
+    'export default defineConfig({',
+    "  test: { include: ['tests/**/*.test.ts', 'src/**/*.test.ts'] },",
+    '});',
+    '',
+  ].join('\n');
+}
+
+function readme(name, opts) {
+  return [
+    `# @caia/${name}-architect`,
+    '',
+    `Specialist architect for the **${name}** slice of \`tickets.architecture\`.`,
+    '',
+    `Owned JSON paths: ${opts.writes.map((w) => '`' + w + '`').join(', ')}.`,
+    `Depends on: ${opts.dependsOn.length === 0 ? '_(no upstream architects)_' : opts.dependsOn.join(', ')}.`,
+    `Precedence: ${opts.precedence}.`,
+    `Runtime model: ${opts.runtimeModel}.`,
+    `Fan-out policy: ${opts.fanoutPolicy}.`,
+    '',
+    '## How to run',
+    '',
+    'Spawned by `@caia/ea-dispatcher` during the EA fan-out phase. Not invoked directly.',
+    '',
+    '## Contract',
+    '',
+    'See [`src/contract.ts`](./src/contract.ts) for the section contract declaration.',
+    '',
+  ].join('\n');
+}
+
+function contractTs(name, opts) {
+  const className = pascalCase(name);
+  return [
+    "import type { ArchitectSectionContract } from '@caia/architect-kit';",
+    '',
+    `export const ${className}Contract: ArchitectSectionContract = {`,
+    `  contractId: '${name}-architect.v1',`,
+    `  architectName: '${name}',`,
+    `  version: '0.1.0',`,
+    `  sections: [`,
+    ...opts.writes.map(
+      (p) =>
+        `    { path: '${p}', description: 'TODO: describe the ${p} field', required: true },`,
+    ),
+    `  ],`,
+    `  architectMeta: {`,
+    `    dependsOn: ${JSON.stringify(opts.dependsOn)},`,
+    `    precedenceLevel: ${opts.precedence},`,
+    `    fanoutPolicy: '${opts.fanoutPolicy}',`,
+    `    appliesPredicate: () => true,`,
+    `    runtimeModel: '${opts.runtimeModel}',`,
+    `  },`,
+    `};`,
+    '',
+  ].join('\n');
+}
+
+function architectTs(name) {
+  const className = pascalCase(name);
+  return [
+    "import { BaseArchitect } from '@caia/architect-kit';",
+    "import type { ArchitectInput, ArchitectOutput } from '@caia/architect-kit';",
+    `import { ${className}Contract } from './contract.js';`,
+    '',
+    `export class ${className}Architect extends BaseArchitect {`,
+    `  readonly name = '${name}';`,
+    `  readonly sectionContract = ${className}Contract;`,
+    '',
+    `  async run(input: ArchitectInput): Promise<ArchitectOutput> {`,
+    `    void input;`,
+    `    return this.partialOutput({}, {`,
+    `      confidence: 0,`,
+    `      notes: 'stub ${name} architect — replace run() with the real implementation',`,
+    `      spend: this.zeroSpend('${name}-stub'),`,
+    `    });`,
+    `  }`,
+    `}`,
+    '',
+  ].join('\n');
+}
+
+function indexTs(name) {
+  const className = pascalCase(name);
+  return [
+    `export { ${className}Architect } from './architect.js';`,
+    `export { ${className}Contract } from './contract.js';`,
+    '',
+  ].join('\n');
+}
+
+function contractTest(name) {
+  const className = pascalCase(name);
+  return [
+    "import { describe, it, expect } from 'vitest';",
+    `import { ${className}Contract } from '../src/contract.js';`,
+    "import { contractPaths } from '@caia/architect-kit';",
+    '',
+    `describe('${className}Contract', () => {`,
+    `  it('declares at least one section', () => {`,
+    `    expect(contractPaths(${className}Contract).length).toBeGreaterThan(0);`,
+    `  });`,
+    `  it('declares unique section paths', () => {`,
+    `    const paths = contractPaths(${className}Contract);`,
+    `    expect(new Set(paths).size).toBe(paths.length);`,
+    `  });`,
+    `  it('has architectName matching contract id prefix', () => {`,
+    `    expect(${className}Contract.architectName).toBe('${name}');`,
+    `  });`,
+    `});`,
+    '',
+  ].join('\n');
+}
+
+function architectTest(name) {
+  const className = pascalCase(name);
+  return [
+    "import { describe, it, expect } from 'vitest';",
+    `import { ${className}Architect } from '../src/architect.js';`,
+    "import type { ArchitectInput } from '@caia/architect-kit';",
+    '',
+    'function stubInput(): ArchitectInput {',
+    '  return {',
+    "    ticket: { id: 't1', type: 'Page' },",
+    '    upstream: { outputs: {} },',
+    "    businessPlan: { ventureName: 'Test', oneLiner: 'x', audience: 'y', goals: [] },",
+    "    designVersion: { versionId: 'v1', anchors: [] },",
+    '    tenantContext: {',
+    "      tenantId: 'tnt-1',",
+    "      schemaName: 's1',",
+    "      vaultNamespace: 'ns1',",
+    "      billingPosture: 'subscription',",
+    '      creditBalance: { usdAvailable: 100 },',
+    '    },',
+    '    budget: {',
+    '      maxInputTokens: 60_000,',
+    '      maxOutputTokens: 8_000,',
+    '      maxWallClockMs: 60_000,',
+    "      preferredModel: 'sonnet',",
+    '      hardCostCeilingUsd: 1,',
+    '    },',
+    '  };',
+    '}',
+    '',
+    `describe('${className}Architect', () => {`,
+    `  it('returns an output keyed by the architect name', async () => {`,
+    `    const a = new ${className}Architect();`,
+    `    const out = await a.run(stubInput());`,
+    `    expect(out.architectName).toBe('${name}');`,
+    `  });`,
+    `});`,
+    '',
+  ].join('\n');
+}
+
+function systemPromptMd(name, opts) {
+  return [
+    `# ${name} architect — system prompt`,
+    '',
+    `You are the ${name} specialist architect for the CAIA EA fan-out phase.`,
+    '',
+    `Your job is to populate the following JSON paths under tickets.architecture:`,
+    ...opts.writes.map((p) => `  - \`${p}\``),
+    '',
+    'Return ONLY valid JSON. Do not add keys outside the contract. Do not omit',
+    'required keys. Be concise — every byte costs.',
+    '',
+  ].join('\n');
+}
+
+export function scaffold(args) {
+  const name = args.name;
+  if (!name || typeof name !== 'string') {
+    throw new Error('missing required --name argument');
+  }
+  if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+    throw new Error(
+      `--name '${name}' must be kebab-case alphanum (e.g. 'analytics', 'api-gateway')`,
+    );
+  }
+  if (!args.writes || typeof args.writes !== 'string') {
+    throw new Error('missing required --writes argument (comma-separated paths)');
+  }
+
+  const opts = {
+    writes: args.writes.split(',').map((s) => s.trim()).filter(Boolean),
+    dependsOn:
+      typeof args['depends-on'] === 'string'
+        ? args['depends-on'].split(',').map((s) => s.trim()).filter(Boolean)
+        : [],
+    precedence: Number.isFinite(Number(args.precedence)) ? Number(args.precedence) : 99,
+    runtimeModel: ['haiku', 'sonnet', 'opus'].includes(args['runtime-model'])
+      ? args['runtime-model']
+      : 'sonnet',
+    fanoutPolicy: ['always', 'conditional', 'gated'].includes(args.fanout)
+      ? args.fanout
+      : 'always',
+  };
+
+  const outDir = args['out-dir'] ?? './packages';
+  const pkgDir = resolve(outDir, `${name}-architect`);
+
+  const files = [
+    { rel: 'package.json', content: packageJson(name) },
+    { rel: 'tsconfig.json', content: tsconfig() },
+    { rel: 'vitest.config.ts', content: vitestConfig() },
+    { rel: 'README.md', content: readme(name, opts) },
+    { rel: 'src/index.ts', content: indexTs(name) },
+    { rel: 'src/contract.ts', content: contractTs(name, opts) },
+    { rel: 'src/architect.ts', content: architectTs(name) },
+    { rel: 'src/system-prompt.md', content: systemPromptMd(name, opts) },
+    { rel: 'tests/contract.test.ts', content: contractTest(name) },
+    { rel: 'tests/architect.test.ts', content: architectTest(name) },
+  ];
+
+  if (args['dry-run']) {
+    process.stdout.write(`[caia-architect-new] (dry-run) would create ${pkgDir} with:\n`);
+    for (const f of files) {
+      process.stdout.write(`  - ${f.rel} (${f.content.length} bytes)\n`);
+    }
+    return { dryRun: true, pkgDir, files };
+  }
+
+  if (existsSync(pkgDir)) {
+    throw new Error(`package dir already exists: ${pkgDir}`);
+  }
+
+  for (const f of files) {
+    const abs = join(pkgDir, f.rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, f.content, 'utf8');
+  }
+  return { dryRun: false, pkgDir, files };
+}
+
+const isCli =
+  import.meta.url === `file://${process.argv[1]}` ||
+  (typeof process.argv[1] === 'string' &&
+    import.meta.url.endsWith(process.argv[1].split('/').pop() ?? ''));
+
+if (isCli) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  try {
+    const result = scaffold(args);
+    if (result.dryRun) process.exit(0);
+    process.stdout.write(`[caia-architect-new] scaffolded ${result.pkgDir}\n`);
+    for (const f of result.files) {
+      process.stdout.write(`  + ${f.rel}\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`[caia-architect-new] ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+void SCRIPT_DIR;

--- a/packages/architect-kit/package.json
+++ b/packages/architect-kit/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@caia/architect-kit",
+  "version": "0.1.0",
+  "private": true,
+  "description": "SpecialistArchitect interface, BaseArchitect abstract class, shared types (ArchitectInput/Output, Ticket, BusinessPlan, RenderableDesign, TenantContext), precedence ladder, ArchitectRegistry with dependency-graph helpers, and the `caia-architect-new` scaffolder CLI. Every one of the 17 EA-phase architect packages depends on this kit.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "bin": {
+    "caia-architect-new": "./bin/caia-architect-new.mjs"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/architect-kit/src/architect-registry.ts
+++ b/packages/architect-kit/src/architect-registry.ts
@@ -1,0 +1,241 @@
+/**
+ * @caia/architect-kit — ArchitectRegistry
+ *
+ * The dispatcher reads from this registry. Every architect package's
+ * `index.ts` calls `registerArchitect(specialistArchitect)` on import,
+ * populating the registry at boot. Like `@chiefaia/agent-contract-registry`,
+ * this is process-local, in-memory, and mutable at startup but immutable
+ * at steady-state.
+ *
+ * The registry's central responsibilities:
+ *   - Validate disjoint section-path ownership across all registered
+ *     architects (the §5.1 invariant).
+ *   - Build the dependency graph for wave-sorting (the §3.3 Kahn's input).
+ *   - Resolve `appliesPredicate(ticket)` filters to the active subset for
+ *     a given ticket (the §3.2 filter step).
+ */
+
+import type { SpecialistArchitect } from './specialist-architect.js';
+import type {
+  ArchitectName,
+  ArchitectSectionContract,
+} from './architect-section-contract.js';
+import {
+  contractPaths,
+  findDuplicatePaths,
+  findOverlappingPaths,
+} from './architect-section-contract.js';
+import type { Ticket } from './types.js';
+
+export interface RegistryEntry {
+  architect: SpecialistArchitect;
+  /** Order of registration — deterministic ordering on ties. */
+  registrationIndex: number;
+}
+
+/**
+ * Thrown when a registration would violate the disjoint-write invariant
+ * or duplicate an architect name.
+ */
+export class ArchitectRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArchitectRegistryError';
+  }
+}
+
+export class ArchitectRegistry {
+  private entries: Map<ArchitectName, RegistryEntry> = new Map();
+  private nextIndex = 0;
+  /** path → architectName that owns it. */
+  private pathOwnership: Map<string, ArchitectName> = new Map();
+
+  /**
+   * Register an architect. Throws:
+   *  - If the architect name is already registered.
+   *  - If the contract has duplicate paths within itself.
+   *  - If any path overlaps with another already-registered architect.
+   */
+  register(architect: SpecialistArchitect): void {
+    if (this.entries.has(architect.name)) {
+      throw new ArchitectRegistryError(
+        `architect '${architect.name}' is already registered`,
+      );
+    }
+    const contract = architect.sectionContract;
+    if (contract.architectName !== architect.name) {
+      throw new ArchitectRegistryError(
+        `architect '${architect.name}' has sectionContract.architectName='${contract.architectName}'; must match`,
+      );
+    }
+    const intra = findDuplicatePaths(contract);
+    if (intra.length > 0) {
+      throw new ArchitectRegistryError(
+        `architect '${architect.name}' declares duplicate paths: ${intra.join(', ')}`,
+      );
+    }
+    for (const path of contractPaths(contract)) {
+      const owner = this.pathOwnership.get(path);
+      if (owner) {
+        throw new ArchitectRegistryError(
+          `architect '${architect.name}' claims path '${path}' already owned by '${owner}'`,
+        );
+      }
+    }
+    // All checks passed — install.
+    this.entries.set(architect.name, {
+      architect,
+      registrationIndex: this.nextIndex++,
+    });
+    for (const path of contractPaths(contract)) {
+      this.pathOwnership.set(path, architect.name);
+    }
+  }
+
+  /** Remove an architect. Returns true if removed, false if absent. */
+  unregister(name: ArchitectName): boolean {
+    const entry = this.entries.get(name);
+    if (!entry) return false;
+    this.entries.delete(name);
+    for (const path of contractPaths(entry.architect.sectionContract)) {
+      if (this.pathOwnership.get(path) === name) {
+        this.pathOwnership.delete(path);
+      }
+    }
+    return true;
+  }
+
+  /** Empty the registry. Test-only. */
+  clear(): void {
+    this.entries.clear();
+    this.pathOwnership.clear();
+    this.nextIndex = 0;
+  }
+
+  /** All registered architects in registration order. */
+  list(): readonly SpecialistArchitect[] {
+    return [...this.entries.values()]
+      .sort((a, b) => a.registrationIndex - b.registrationIndex)
+      .map((e) => e.architect);
+  }
+
+  /** Look up by name. */
+  get(name: ArchitectName): SpecialistArchitect | undefined {
+    return this.entries.get(name)?.architect;
+  }
+
+  /** Architect count. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Owner of a section path, or `undefined` if no architect claims it. */
+  ownerOf(path: string): ArchitectName | undefined {
+    return this.pathOwnership.get(path);
+  }
+
+  /** All section paths claimed across every registered architect. */
+  allPaths(): readonly string[] {
+    return [...this.pathOwnership.keys()];
+  }
+
+  /**
+   * Architects that apply to the given ticket — filters via each
+   * architect's `appliesPredicate`. Output is in registration order.
+   */
+  applicableTo(ticket: Ticket): readonly SpecialistArchitect[] {
+    return this.list().filter((a) =>
+      a.sectionContract.architectMeta.appliesPredicate(ticket),
+    );
+  }
+
+  /**
+   * All section contracts. Convenience for the dispatcher's composer.
+   */
+  contracts(): readonly ArchitectSectionContract[] {
+    return this.list().map((a) => a.sectionContract);
+  }
+
+  /** Validate global invariants. Returns an array of error messages (empty if OK). */
+  validate(): readonly string[] {
+    const errors: string[] = [];
+    // Disjointness — also tracked incrementally on register, but check from scratch.
+    const seen = new Map<string, ArchitectName>();
+    for (const arch of this.list()) {
+      for (const path of contractPaths(arch.sectionContract)) {
+        const prior = seen.get(path);
+        if (prior && prior !== arch.name) {
+          errors.push(
+            `path '${path}' claimed by both '${prior}' and '${arch.name}'`,
+          );
+        }
+        seen.set(path, arch.name);
+      }
+    }
+    // Dependency graph soundness — every dependsOn name resolves.
+    for (const arch of this.list()) {
+      for (const dep of arch.sectionContract.architectMeta.dependsOn) {
+        if (!this.entries.has(dep)) {
+          errors.push(
+            `architect '${arch.name}' depends on '${dep}' which is not registered`,
+          );
+        }
+      }
+    }
+    return errors;
+  }
+}
+
+// ─── Default singleton ──────────────────────────────────────────────────────
+
+let defaultRegistry: ArchitectRegistry | null = null;
+
+export function getDefaultArchitectRegistry(): ArchitectRegistry {
+  if (!defaultRegistry) defaultRegistry = new ArchitectRegistry();
+  return defaultRegistry;
+}
+
+export function resetDefaultArchitectRegistry(): void {
+  defaultRegistry = null;
+}
+
+/**
+ * Convenience: register on the default singleton. Mirrors the
+ * `@chiefaia/agent-contract-registry` `register()` top-level helper.
+ */
+export function registerArchitect(architect: SpecialistArchitect): void {
+  getDefaultArchitectRegistry().register(architect);
+}
+
+/**
+ * Build a quick disjointness sanity check across a snapshot of contracts —
+ * useful in tests that don't want to mutate the global registry. Returns
+ * the set of conflicting paths (empty if disjoint).
+ */
+export function disjointness(
+  contracts: readonly ArchitectSectionContract[],
+): readonly { path: string; claimedBy: readonly ArchitectName[] }[] {
+  const owners = new Map<string, ArchitectName[]>();
+  for (const c of contracts) {
+    for (const path of contractPaths(c)) {
+      const arr = owners.get(path) ?? [];
+      arr.push(c.architectName);
+      owners.set(path, arr);
+    }
+  }
+  const conflicts: { path: string; claimedBy: ArchitectName[] }[] = [];
+  for (const [path, names] of owners) {
+    if (names.length > 1) conflicts.push({ path, claimedBy: names });
+  }
+  return conflicts;
+}
+
+/**
+ * Pairwise contract-overlap check — useful in tests.
+ */
+export function overlapBetween(
+  a: ArchitectSectionContract,
+  b: ArchitectSectionContract,
+): readonly string[] {
+  return findOverlappingPaths(a, b);
+}

--- a/packages/architect-kit/src/architect-section-contract.ts
+++ b/packages/architect-kit/src/architect-section-contract.ts
@@ -1,0 +1,140 @@
+/**
+ * @caia/architect-kit — ArchitectSectionContract
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §1.3 + §9.
+ *
+ * Why a NEW interface (parallel to `@chiefaia/ticket-template`'s SectionContract):
+ * - The base SectionContract is keyed on PO/BA/EA/Test-Design agent roles
+ *   and integrates with the Story Validator's rubric pipeline (Zod schemas,
+ *   relevance prompts, fix hints).
+ * - Architect contracts are different beasts: they declare disjoint JSONB
+ *   field ownership over `tickets.architecture`, dependency edges to other
+ *   architects, a precedence-ladder rank, an `appliesPredicate(ticket)`
+ *   filter, and a fan-out policy. They don't participate in rubric scoring.
+ *
+ * Strict-additive design: the spec §9 originally suggested extending the
+ * base SectionContract with an optional `architectMeta` field. We instead
+ * make ArchitectSectionContract its own type to avoid forcing changes on
+ * `@chiefaia/ticket-template`. The dispatcher accepts both shapes via duck
+ * typing — anything with a `sections: { name: string }[]` array and an
+ * `architectMeta` block is treated as an architect contract.
+ */
+
+import type { Ticket } from './types.js';
+
+/** Architect role name. By convention, matches the package name minus `-architect`. */
+export type ArchitectName = string;
+
+/**
+ * Fan-out policy controls when the dispatcher invokes the architect.
+ *  - `always`       — runs on every ticket that matches `appliesPredicate`.
+ *  - `conditional`  — runs only when an upstream architect signals demand
+ *                     (e.g. A/B Testing runs only when Analytics flags a
+ *                     candidate metric).
+ *  - `gated`        — runs only when an operator explicitly enables it on
+ *                     the ticket (e.g. heavyweight AI/ML on a non-AI page).
+ */
+export type FanoutPolicy = 'always' | 'conditional' | 'gated';
+
+/**
+ * One JSONB section the architect owns. The `path` is the dotted key under
+ * `tickets.architecture` (e.g. `'frontend.componentTree'`). Disjointness
+ * across architects is verified at registration time.
+ */
+export interface ArchitectSectionSpec {
+  /** Dotted JSON path under `tickets.architecture`. Globally unique. */
+  path: string;
+  /** Short, operator-facing description. */
+  description: string;
+  /**
+   * Whether this path is required to be populated for the architect's
+   * output to be considered `ok` (vs `partial`). The reviewer's
+   * completeness lens checks this.
+   */
+  required: boolean;
+}
+
+/**
+ * Architect-specific metadata: the wave-orchestration knobs that the
+ * dispatcher reads to compute the dependency graph, precedence ordering,
+ * and per-ticket filtering.
+ */
+export interface ArchitectMeta {
+  /** Other architect names this architect must run after. May be empty. */
+  dependsOn: readonly ArchitectName[];
+  /**
+   * Precedence rank (1..N, lower = higher precedence). Used for semantic
+   * conflict resolution. The canonical 17-architect ladder lives in
+   * `precedence.ts` — bespoke architects should pick a rank that doesn't
+   * collide with the canonical set.
+   */
+  precedenceLevel: number;
+  fanoutPolicy: FanoutPolicy;
+  /**
+   * Per-ticket gate: returns true iff the architect applies to this ticket.
+   * Pure function — must be deterministic given the input.
+   */
+  appliesPredicate: (ticket: Ticket) => boolean;
+  /** Preferred model for budget defaults. */
+  runtimeModel: 'haiku' | 'sonnet' | 'opus';
+}
+
+/**
+ * The architect's section contract — the disjoint-write declaration plus
+ * metadata. The dispatcher reads this at registration time to build the
+ * dependency graph and validate field-disjointness across the roster.
+ */
+export interface ArchitectSectionContract {
+  /** Stable contract ID. Convention: `<name>-architect.v<major>`. */
+  contractId: string;
+  /** Architect role name (matches the SpecialistArchitect's `name`). */
+  architectName: ArchitectName;
+  /** Human-readable semver-ish version. */
+  version: string;
+  /** Sections this architect owns. */
+  sections: readonly ArchitectSectionSpec[];
+  /** Wave/precedence metadata. */
+  architectMeta: ArchitectMeta;
+}
+
+// ─── Utilities ─────────────────────────────────────────────────────────────
+
+/**
+ * Set of section paths the contract claims. Helpful for disjointness checks
+ * and composition.
+ */
+export function contractPaths(
+  contract: ArchitectSectionContract,
+): readonly string[] {
+  return contract.sections.map((s) => s.path);
+}
+
+/**
+ * Validate that all paths within a single contract are unique (a contract
+ * declaring `frontend.tokens` twice is a bug — catch at registration).
+ *
+ * Returns the duplicate paths, or an empty array if none.
+ */
+export function findDuplicatePaths(
+  contract: ArchitectSectionContract,
+): readonly string[] {
+  const seen = new Set<string>();
+  const dups: string[] = [];
+  for (const spec of contract.sections) {
+    if (seen.has(spec.path)) dups.push(spec.path);
+    seen.add(spec.path);
+  }
+  return dups;
+}
+
+/**
+ * Validate that two contracts' section paths are disjoint. Returns the
+ * intersecting paths (empty array if disjoint as required).
+ */
+export function findOverlappingPaths(
+  a: ArchitectSectionContract,
+  b: ArchitectSectionContract,
+): readonly string[] {
+  const aSet = new Set(contractPaths(a));
+  return contractPaths(b).filter((p) => aSet.has(p));
+}

--- a/packages/architect-kit/src/base-architect.ts
+++ b/packages/architect-kit/src/base-architect.ts
@@ -1,0 +1,187 @@
+/**
+ * @caia/architect-kit — BaseArchitect abstract class.
+ *
+ * Reduces per-architect boilerplate. Concrete architects extend this and
+ * implement only `run()`, optionally overriding `systemPrompt()` and `tools`.
+ *
+ * Goals:
+ *  - Centralise the spend-accounting + output-validation discipline so every
+ *    architect treats failures the same way.
+ *  - Make tests cheap to write — test a concrete architect by constructing
+ *    it with a mock input and asserting on the output shape.
+ *  - Stay free of runtime deps — this class doesn't import claude-spawner;
+ *    sub-classes wire their own spawner via constructor injection. Keeps
+ *    architect-kit a pure-types package and decouples LLM-call mechanics
+ *    from the interface contract.
+ */
+
+import type { SpecialistArchitect } from './specialist-architect.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ToolDefinition,
+} from './types.js';
+import type { ArchitectSectionContract } from './architect-section-contract.js';
+import { contractPaths } from './architect-section-contract.js';
+
+export abstract class BaseArchitect implements SpecialistArchitect {
+  abstract readonly name: string;
+  abstract readonly sectionContract: ArchitectSectionContract;
+
+  /** Default: empty tool list. Override per-architect when needed. */
+  readonly tools: readonly ToolDefinition[] = [];
+
+  /**
+   * Default system prompt — a sensible boilerplate that incorporates the
+   * architect's name + owned paths. Override for production architects.
+   * Keeping this in BaseArchitect lets the dispatcher's smoke tests spawn
+   * a "stub" architect without writing a prompt.
+   */
+  systemPrompt(): string {
+    const paths = contractPaths(this.sectionContract).join(', ');
+    return [
+      `You are the ${this.name} specialist architect for the CAIA EA fan-out phase.`,
+      `Your job is to populate the following JSON paths under tickets.architecture:`,
+      `  ${paths}`,
+      ``,
+      `Return ONLY valid JSON conforming to the section contract. Do not add`,
+      `keys outside the contract. Do not omit required keys. If you can't`,
+      `complete a section, set its value to null and mention the gap in`,
+      `your `,
+      `\`notes\` field.`,
+    ].join('\n');
+  }
+
+  abstract run(input: ArchitectInput): Promise<ArchitectOutput>;
+
+  // ─── Helpers — sub-classes may use these to avoid boilerplate ────────────
+
+  /**
+   * Empty-but-valid spend record. Useful for stub/test architects that
+   * don't actually invoke an LLM.
+   */
+  protected zeroSpend(model = 'none'): ArchitectSpend {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model,
+    };
+  }
+
+  /**
+   * Construct a `failed` output with the supplied reason. Used by retry
+   * paths and exception handlers to avoid throwing across the dispatcher
+   * boundary.
+   */
+  protected failedOutput(
+    reason: string,
+    opts?: { confidence?: number; risks?: readonly string[] },
+  ): ArchitectOutput {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: opts?.confidence ?? 0,
+      notes: '',
+      dependencies: [],
+      risks: opts?.risks ?? [],
+      toolCalls: [],
+      spend: this.zeroSpend(),
+      status: 'failed',
+      failureReason: reason,
+    };
+  }
+
+  /**
+   * Construct a `partial` output — used when some declared sections could
+   * not be populated but the architect still has useful content.
+   */
+  protected partialOutput(
+    architectureFields: Record<string, unknown>,
+    opts: {
+      confidence: number;
+      notes?: string;
+      risks?: readonly string[];
+      spend?: ArchitectSpend;
+      toolCalls?: readonly ArchitectToolCall[];
+    },
+  ): ArchitectOutput {
+    return {
+      architectName: this.name,
+      architectureFields,
+      confidence: opts.confidence,
+      notes: opts.notes ?? '',
+      dependencies: [],
+      risks: opts.risks ?? [],
+      toolCalls: opts.toolCalls ?? [],
+      spend: opts.spend ?? this.zeroSpend(),
+      status: 'partial',
+    };
+  }
+
+  /**
+   * Construct an `ok` output. Validates that the supplied
+   * architectureFields covers every required path in the contract; if not,
+   * downgrades to `partial`.
+   */
+  protected okOutput(
+    architectureFields: Record<string, unknown>,
+    opts: {
+      confidence: number;
+      notes?: string;
+      risks?: readonly string[];
+      spend?: ArchitectSpend;
+      toolCalls?: readonly ArchitectToolCall[];
+      dependencies?: readonly string[];
+    },
+  ): ArchitectOutput {
+    const missingRequired = this.sectionContract.sections
+      .filter((s) => s.required)
+      .map((s) => s.path)
+      .filter((p) => !(p in architectureFields) || architectureFields[p] == null);
+
+    const status: 'ok' | 'partial' = missingRequired.length === 0 ? 'ok' : 'partial';
+
+    return {
+      architectName: this.name,
+      architectureFields,
+      confidence: opts.confidence,
+      notes: opts.notes ?? '',
+      dependencies: opts.dependencies ?? [],
+      risks: opts.risks ?? [],
+      toolCalls: opts.toolCalls ?? [],
+      spend: opts.spend ?? this.zeroSpend(),
+      status,
+      ...(status === 'partial'
+        ? { failureReason: `missing required paths: ${missingRequired.join(', ')}` }
+        : {}),
+    };
+  }
+
+  /**
+   * Returns the set of paths from the contract NOT present in the supplied
+   * architectureFields. Used by the dispatcher's retry-with-corrected-prompt
+   * fragment ("your last output was missing key X").
+   */
+  static missingPaths(
+    contract: ArchitectSectionContract,
+    architectureFields: Record<string, unknown>,
+  ): readonly string[] {
+    return contractPaths(contract).filter((p) => !(p in architectureFields));
+  }
+
+  /**
+   * Returns the set of paths in architectureFields that are NOT declared
+   * by the contract (extras the architect shouldn't have written).
+   */
+  static extraPaths(
+    contract: ArchitectSectionContract,
+    architectureFields: Record<string, unknown>,
+  ): readonly string[] {
+    const declared = new Set(contractPaths(contract));
+    return Object.keys(architectureFields).filter((p) => !declared.has(p));
+  }
+}

--- a/packages/architect-kit/src/dependency-graph.ts
+++ b/packages/architect-kit/src/dependency-graph.ts
@@ -1,0 +1,166 @@
+/**
+ * @caia/architect-kit — dependency graph helpers.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §3.3.
+ *
+ * The dispatcher topo-sorts the active architect set into waves via Kahn's
+ * algorithm. Architects with `dependsOn: []` form wave 1; the second wave
+ * contains everything whose deps are entirely in wave 1; and so on.
+ *
+ * The algorithm lives here (not in `@caia/ea-dispatcher`) because:
+ *   - It's pure / no-IO and useful in architect-package tests too.
+ *   - The shape stays close to the type definitions it operates on.
+ *   - It makes the dispatcher unit testable against the contract layer
+ *     without bringing in the spawner.
+ */
+
+import type { ArchitectName } from './architect-section-contract.js';
+import type { SpecialistArchitect } from './specialist-architect.js';
+
+/**
+ * One layer of architects that may all run in parallel. The dispatcher
+ * iterates these waves in order, awaiting each before fanning the next.
+ */
+export interface Wave {
+  /** 1-indexed wave number. */
+  index: number;
+  /** Architect names — sorted alphabetically for deterministic logs. */
+  members: readonly ArchitectName[];
+}
+
+export class CycleDetectedError extends Error {
+  constructor(
+    public readonly remaining: readonly ArchitectName[],
+    message?: string,
+  ) {
+    super(
+      message ??
+        `dependency cycle detected; unresolved architects: ${remaining.join(', ')}`,
+    );
+    this.name = 'CycleDetectedError';
+  }
+}
+
+export class UnknownDependencyError extends Error {
+  constructor(
+    public readonly architect: ArchitectName,
+    public readonly missing: ArchitectName,
+  ) {
+    super(
+      `architect '${architect}' depends on '${missing}' which is not in the supplied set`,
+    );
+    this.name = 'UnknownDependencyError';
+  }
+}
+
+interface NodeMeta {
+  name: ArchitectName;
+  dependsOn: readonly ArchitectName[];
+}
+
+/**
+ * Topo-sort an architect set into waves via Kahn's algorithm.
+ *
+ *  - Throws `UnknownDependencyError` if any `dependsOn` name is missing
+ *    from the input set.
+ *  - Throws `CycleDetectedError` if the dependency graph has a cycle.
+ *  - Returns an empty array on empty input.
+ */
+export function computeWaves(
+  architects: readonly SpecialistArchitect[],
+): readonly Wave[] {
+  const nodes: NodeMeta[] = architects.map((a) => ({
+    name: a.name,
+    dependsOn: a.sectionContract.architectMeta.dependsOn,
+  }));
+  return computeWavesFromMeta(nodes);
+}
+
+/**
+ * The metadata-only flavour — useful for tests that don't want to build
+ * full SpecialistArchitect instances. Pure data in, waves out.
+ */
+export function computeWavesFromMeta(
+  nodes: readonly { name: ArchitectName; dependsOn: readonly ArchitectName[] }[],
+): readonly Wave[] {
+  if (nodes.length === 0) return [];
+
+  const known = new Set(nodes.map((n) => n.name));
+  // Validate every dependency exists.
+  for (const node of nodes) {
+    for (const dep of node.dependsOn) {
+      if (!known.has(dep)) {
+        throw new UnknownDependencyError(node.name, dep);
+      }
+    }
+  }
+
+  // Build in-degree + reverse adjacency.
+  const inDegree = new Map<ArchitectName, number>();
+  const dependents = new Map<ArchitectName, ArchitectName[]>();
+  for (const node of nodes) {
+    inDegree.set(node.name, node.dependsOn.length);
+    for (const dep of node.dependsOn) {
+      const arr = dependents.get(dep) ?? [];
+      arr.push(node.name);
+      dependents.set(dep, arr);
+    }
+  }
+
+  const waves: Wave[] = [];
+  let waveIdx = 0;
+  let frontier: ArchitectName[] = nodes
+    .filter((n) => (inDegree.get(n.name) ?? 0) === 0)
+    .map((n) => n.name);
+
+  const resolved = new Set<ArchitectName>();
+
+  while (frontier.length > 0) {
+    waveIdx += 1;
+    const members = [...frontier].sort();
+    waves.push({ index: waveIdx, members });
+    frontier.forEach((m) => resolved.add(m));
+
+    const nextFrontier: ArchitectName[] = [];
+    for (const member of frontier) {
+      for (const dep of dependents.get(member) ?? []) {
+        const newDeg = (inDegree.get(dep) ?? 0) - 1;
+        inDegree.set(dep, newDeg);
+        if (newDeg === 0) nextFrontier.push(dep);
+      }
+    }
+    frontier = nextFrontier;
+  }
+
+  if (resolved.size !== nodes.length) {
+    const remaining = nodes
+      .map((n) => n.name)
+      .filter((name) => !resolved.has(name))
+      .sort();
+    throw new CycleDetectedError(remaining);
+  }
+
+  return waves;
+}
+
+/**
+ * Flatten a wave list to a deterministic execution order — useful in
+ * tests and in logging the planned plan before fan-out.
+ */
+export function flattenWaves(waves: readonly Wave[]): readonly ArchitectName[] {
+  return waves.flatMap((w) => w.members);
+}
+
+/**
+ * Returns the wave index of a given architect within the given waves, or
+ * -1 if absent.
+ */
+export function waveOf(
+  waves: readonly Wave[],
+  architectName: ArchitectName,
+): number {
+  for (const w of waves) {
+    if (w.members.includes(architectName)) return w.index;
+  }
+  return -1;
+}

--- a/packages/architect-kit/src/index.ts
+++ b/packages/architect-kit/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * @caia/architect-kit — public surface.
+ *
+ * The 17 specialist-architect packages depend on this kit. The EA Dispatcher
+ * also depends on it (it reads the registry + computes waves + composes
+ * fields). The EA Reviewer reads SectionContracts off this kit to compute
+ * completeness coverage.
+ */
+
+export type {
+  // Upstream artifacts
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+
+  // Runtime inputs
+  ArchitectBudget,
+  ArchitectInput,
+  ArchitectUpstreamContext,
+  ReviewerFeedback,
+
+  // Runtime outputs
+  ArchitectOutput,
+  ArchitectSpend,
+  ArchitectToolCall,
+
+  // Tool definition
+  ToolDefinition,
+} from './types.js';
+
+export type {
+  ArchitectName,
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  FanoutPolicy,
+} from './architect-section-contract.js';
+
+export {
+  contractPaths,
+  findDuplicatePaths,
+  findOverlappingPaths,
+} from './architect-section-contract.js';
+
+export type { SpecialistArchitect } from './specialist-architect.js';
+
+export { BaseArchitect } from './base-architect.js';
+
+export {
+  CANONICAL_PRECEDENCE_LADDER,
+  CANONICAL_ARCHITECT_COUNT,
+  precedenceRank,
+  comparePrecedence,
+  higherPrecedence,
+  assertLadderShape,
+} from './precedence.js';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  getDefaultArchitectRegistry,
+  resetDefaultArchitectRegistry,
+  registerArchitect,
+  disjointness,
+  overlapBetween,
+} from './architect-registry.js';
+export type { RegistryEntry } from './architect-registry.js';
+
+export {
+  computeWaves,
+  computeWavesFromMeta,
+  flattenWaves,
+  waveOf,
+  CycleDetectedError,
+  UnknownDependencyError,
+} from './dependency-graph.js';
+export type { Wave } from './dependency-graph.js';

--- a/packages/architect-kit/src/precedence.ts
+++ b/packages/architect-kit/src/precedence.ts
@@ -1,0 +1,115 @@
+/**
+ * @caia/architect-kit — canonical precedence ladder.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §5.2.
+ *
+ * When the dispatcher detects a *semantic* conflict between two architects
+ * (e.g. SEO wants to preload an image that Performance wants to lazy-load),
+ * it resolves by precedence: the higher-precedence architect's decision
+ * survives unmodified; the lower-precedence field gets a `_dissent`
+ * annotation pointing at the rule that fired.
+ *
+ * Field-level conflicts are impossible by construction (the SectionContract
+ * disjointness invariant) — this ladder applies only to semantic conflicts
+ * the dispatcher's rule registry detects post-composition.
+ *
+ * Note: the user-facing prompt described the ladder as
+ *   `Security > A11y > SEO > Performance > Frontend visual > Analytics > others`
+ * but the spec puts DevOps at #2 (operator-on-hook for a bad deploy beats
+ * a11y legal exposure). We follow the spec; the operator can override per
+ * site if needed by re-registering the architect with a different rank.
+ */
+
+import type { ArchitectName } from './architect-section-contract.js';
+
+/**
+ * Ordered list — lower index = higher precedence. The dispatcher uses
+ * `precedenceRank(name)` to compare two architects.
+ *
+ * 17 entries. Any architect-kit roster change must update this array.
+ */
+export const CANONICAL_PRECEDENCE_LADDER: readonly ArchitectName[] = [
+  'security', // legal & compliance veto — highest
+  'devops', // operator-on-hook for a bad deploy
+  'a11y', // legal exposure WCAG 2.2 AA
+  'seo', // locked playbook non-negotiable
+  'performance', // Lighthouse ≥95 gate
+  'abTesting', // statistical correctness
+  'featureFlagging', // rollout safety
+  'apiGateway', // boundary integrity
+  'observability', // operability (read-only — sits below safety/perf)
+  'analytics', // compliance-sensitive (consent gating)
+  'database', // schema correctness
+  'backend', // functional correctness
+  'aiml', // cost/quality tradeoffs
+  'frontend', // visual fidelity — below a11y/seo/perf
+  'timeMachine', // operator-facing; not safety-critical
+  'uxVersionControl', // operator-facing; not safety-critical
+  'testing', // advisory strategy
+] as const;
+
+/** Total number of architects in the canonical ladder. */
+export const CANONICAL_ARCHITECT_COUNT = CANONICAL_PRECEDENCE_LADDER.length;
+
+/**
+ * Look up the rank of an architect (1..N). Lower = higher precedence.
+ * Returns `Infinity` if the architect is not in the canonical ladder
+ * (bespoke architects can register with their own rank).
+ */
+export function precedenceRank(
+  architectName: ArchitectName,
+  ladder: readonly ArchitectName[] = CANONICAL_PRECEDENCE_LADDER,
+): number {
+  const idx = ladder.indexOf(architectName);
+  return idx === -1 ? Infinity : idx + 1;
+}
+
+/**
+ * Total comparator over architect names — sortable into precedence order.
+ * Higher precedence (lower rank) comes first.
+ */
+export function comparePrecedence(
+  a: ArchitectName,
+  b: ArchitectName,
+  ladder: readonly ArchitectName[] = CANONICAL_PRECEDENCE_LADDER,
+): number {
+  return precedenceRank(a, ladder) - precedenceRank(b, ladder);
+}
+
+/**
+ * Returns the higher-precedence architect of the two. On tie (both at
+ * Infinity, both at same rank), returns `null` — caller should surface the
+ * conflict as `requiresEscalation`.
+ */
+export function higherPrecedence(
+  a: ArchitectName,
+  b: ArchitectName,
+  ladder: readonly ArchitectName[] = CANONICAL_PRECEDENCE_LADDER,
+): ArchitectName | null {
+  const ra = precedenceRank(a, ladder);
+  const rb = precedenceRank(b, ladder);
+  if (ra === rb) return null;
+  return ra < rb ? a : b;
+}
+
+/**
+ * Asserts the ladder is unique-by-name and has the expected count.
+ * Throws on violation. Used in tests and at registry-boot to catch typos.
+ */
+export function assertLadderShape(
+  ladder: readonly ArchitectName[],
+  expectedCount = CANONICAL_ARCHITECT_COUNT,
+): void {
+  if (ladder.length !== expectedCount) {
+    throw new Error(
+      `[architect-kit] precedence ladder has ${ladder.length} entries; expected ${expectedCount}.`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const name of ladder) {
+    if (seen.has(name)) {
+      throw new Error(`[architect-kit] precedence ladder has duplicate entry '${name}'.`);
+    }
+    seen.add(name);
+  }
+}

--- a/packages/architect-kit/src/specialist-architect.ts
+++ b/packages/architect-kit/src/specialist-architect.ts
@@ -1,0 +1,73 @@
+/**
+ * @caia/architect-kit — SpecialistArchitect interface.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §1.1.
+ *
+ * Every one of the 17 EA-phase architect packages exports a class that
+ * implements this interface. The EA Dispatcher consumes the interface
+ * polymorphically — it doesn't know or care which architect it's running,
+ * only that it can call `systemPrompt()`, read `tools`, and `await run()`.
+ *
+ * Implementations should be:
+ *  - Idempotent — calling `run()` twice with identical inputs returns
+ *    identical outputs (modulo wall-clock time / non-deterministic LLM
+ *    sampling, which the dispatcher handles via retry-with-corrected-prompt).
+ *  - Stateless — no instance state survives between `run()` invocations.
+ *    Architects are spawned per-ticket, so any cross-ticket cache lives
+ *    outside the architect.
+ *  - Pure prompt-builders — `systemPrompt()` returns the same string given
+ *    no input, every time, per process. Test it by snapshotting.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ToolDefinition,
+} from './types.js';
+import type { ArchitectSectionContract } from './architect-section-contract.js';
+
+export interface SpecialistArchitect {
+  /**
+   * Stable architect identifier. Matches the package name minus the
+   * `-architect` suffix (e.g. `'frontend'`, `'a11y'`, `'security'`).
+   * The dispatcher uses this to key the dependency graph and the audit
+   * row's `architect_name` column.
+   */
+  readonly name: string;
+
+  /**
+   * The disjoint-write contract: which JSONB paths this architect owns
+   * under `tickets.architecture`, plus its wave/precedence metadata. The
+   * dispatcher registers this with the global architect registry at boot.
+   */
+  readonly sectionContract: ArchitectSectionContract;
+
+  /**
+   * Pure function — returns the system prompt for the spawned Claude
+   * subagent. Must be stable per process; tested via snapshot. Architects
+   * that template their prompt (e.g. inject roster names or contract
+   * versions) should do so deterministically.
+   */
+  systemPrompt(): string;
+
+  /**
+   * Architect-specific tools to expose to the spawned subagent. May be
+   * empty. The dispatcher merges these with the global read-only tool
+   * allowlist (Read, filtered Bash, …).
+   */
+  readonly tools: readonly ToolDefinition[];
+
+  /**
+   * The actual architect logic. Implementations typically:
+   *   1. Compose a user-message prompt from the ArchitectInput.
+   *   2. Call `claude-spawner` via the injected spawner adapter.
+   *   3. Parse the response into `ArchitectOutput.architectureFields`.
+   *   4. Compute confidence, spend, and risks.
+   *
+   * The dispatcher invokes this with a wall-clock timeout from
+   * `input.budget.maxWallClockMs`. Implementations should respect that
+   * deadline and return a `failed`/`partial` output rather than throw,
+   * unless the failure is truly catastrophic.
+   */
+  run(input: ArchitectInput): Promise<ArchitectOutput>;
+}

--- a/packages/architect-kit/src/types.ts
+++ b/packages/architect-kit/src/types.ts
@@ -1,0 +1,202 @@
+/**
+ * @caia/architect-kit — shared types for every specialist architect.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §1.
+ *
+ * These types are deliberately framework-agnostic. They reference upstream
+ * artifacts (Ticket, BusinessPlan, RenderableDesign, TenantContext) as
+ * opaque shapes — each architect package only consumes the fields it needs,
+ * so we keep the surface narrow and structural (not nominal). Real
+ * implementations in @chiefaia/ticket-template, @caia/intake, @caia/atlas,
+ * and @caia/tenant-provisioner can extend these shapes; consumers don't
+ * have to import those packages just to use architect-kit.
+ */
+
+// ─── Upstream artifacts (structural shapes — extend in producer packages) ──
+
+/**
+ * The canonical phase-1 ticket. Architects read everything they need from
+ * this object plus the upstream context. The full Zod-validated shape lives
+ * in `@chiefaia/ticket-template`; this declaration captures the fields the
+ * architect framework actually depends on. Cast or import the producer's
+ * type at the call site if you need the full shape.
+ */
+export interface Ticket {
+  id: string;
+  /** Discriminator used by `appliesPredicate` (Page / Widget / Story / etc.). */
+  type: string;
+  /** Story / module / epic / initiative / task / subtask. */
+  scope?: string;
+  parent_id?: string | null;
+  /** Composed JSONB output filled by architects (key = section path). */
+  architecture?: Record<string, unknown>;
+  /** Acceptance criteria — drives the EA Reviewer's correctness lens. */
+  acceptance_criteria?: readonly string[];
+  /** Business-requirements blob (free-form, from intake). */
+  business_requirements?: Record<string, unknown>;
+  /** Quality tags — drives `appliesPredicate` (a11y, seo, performance, ...). */
+  quality_tags?: readonly string[];
+  /** Optional extension surface — architects may read additional fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * The interviewer/intake step-3 output. Architects use this for "why" — the
+ * goals, audience, brand-voice, constraints that shape every section.
+ */
+export interface BusinessPlan {
+  ventureName: string;
+  oneLiner: string;
+  audience: string;
+  goals: readonly string[];
+  brandVoice?: string;
+  constraints?: readonly string[];
+  /** Free-form passthrough for additional interviewer outputs. */
+  [key: string]: unknown;
+}
+
+/**
+ * The Atlas step-6 RenderableDesign — version-pinned IR + anchor map for the
+ * UX uploaded by the operator. Architects use anchor IDs to refer to design
+ * regions (frontend wires its component tree to anchors; a11y annotates
+ * landmarks at anchors; seo emits OG/title tags pinned to page anchors).
+ */
+export interface RenderableDesign {
+  versionId: string;
+  /** Optional URI of the snapshot blob (PNG/PDF) the IR was extracted from. */
+  snapshotUri?: string;
+  /** Anchor map (anchorId → IR node ref). */
+  anchors: ReadonlyArray<{
+    anchorId: string;
+    kind: string;
+    bbox?: { x: number; y: number; w: number; h: number };
+    /** Architect-readable metadata (text content, role, breakpoint, ...). */
+    meta?: Record<string, unknown>;
+  }>;
+  /** Free-form passthrough — atlas may emit more fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * Per-tenant context propagated through the dispatcher to every architect.
+ * Drives credential resolution, billing posture, data-residency selection,
+ * and BYOK overrides.
+ */
+export interface TenantContext {
+  tenantId: string;
+  schemaName: string;
+  vaultNamespace: string;
+  billingPosture: 'subscription' | 'byok';
+  creditBalance: { usdAvailable: number };
+  /** Optional BYOK credentials handle — not the secret itself; an opaque ref. */
+  byok?: { credentialRef?: string };
+  compliance?: { dataResidency: string };
+}
+
+// ─── Per-architect runtime inputs ──────────────────────────────────────────
+
+/**
+ * Per-architect token / wall-clock / cost budget. The dispatcher derives
+ * default budgets from the architect's `architectMeta.runtimeModel` plus
+ * the tenant's billing posture, then per-call lowers them based on observed
+ * spend trends.
+ */
+export interface ArchitectBudget {
+  maxInputTokens: number;
+  maxOutputTokens: number;
+  maxWallClockMs: number;
+  preferredModel: 'haiku' | 'sonnet' | 'opus';
+  hardCostCeilingUsd: number;
+}
+
+/**
+ * Reviewer feedback returned to a re-run architect. Populated only on
+ * iterations 2..N of an EA Reviewer cycle; absent on first run.
+ */
+export interface ReviewerFeedback {
+  reason: string;
+  severity: 'P0' | 'P1' | 'P2';
+  /** Reviewer-suggested fields/values that should change. Free-form. */
+  hints?: Record<string, unknown>;
+}
+
+/**
+ * The bundle of upstream outputs an architect may read. Populated by the
+ * dispatcher: wave-1 architects see an empty bag; wave-2 architects see
+ * their wave-1 dependencies; wave-3 sees both.
+ */
+export interface ArchitectUpstreamContext {
+  /** Map architect name → its ArchitectOutput. Read-only. */
+  readonly outputs: Readonly<Record<string, ArchitectOutput>>;
+}
+
+/**
+ * The single input every architect's `run()` consumes.
+ */
+export interface ArchitectInput {
+  ticket: Ticket;
+  upstream: ArchitectUpstreamContext;
+  businessPlan: BusinessPlan;
+  designVersion: RenderableDesign;
+  tenantContext: TenantContext;
+  budget: ArchitectBudget;
+  reviewerFeedback?: ReviewerFeedback;
+}
+
+// ─── Per-architect runtime outputs ─────────────────────────────────────────
+
+export interface ArchitectToolCall {
+  toolName: string;
+  argsHash: string;
+  durationMs: number;
+  ok: boolean;
+}
+
+export interface ArchitectSpend {
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+}
+
+/**
+ * Per-architect output. The dispatcher composes `architectureFields` from
+ * each architect into a single disjoint-key JSONB blob, then writes to
+ * `tickets.architecture`.
+ */
+export interface ArchitectOutput {
+  architectName: string;
+  /**
+   * JSONB fields keyed by the architect's `SectionContract.sections` keys.
+   * The set of keys must match the contract's declared set exactly (the
+   * dispatcher validates this and triggers a retry on mismatch).
+   */
+  architectureFields: Record<string, unknown>;
+  /** 0..1. Sub-0.6 confidence triggers EA Reviewer scrutiny. */
+  confidence: number;
+  notes: string;
+  /** Sibling ticket IDs this output depends on. */
+  dependencies: readonly string[];
+  /** ≤5 short risk descriptors surfaced to the reviewer + dashboard. */
+  risks: readonly string[];
+  toolCalls: readonly ArchitectToolCall[];
+  spend: ArchitectSpend;
+  status: 'ok' | 'partial' | 'failed';
+  failureReason?: string;
+}
+
+// ─── Tool definition (placeholder until @caia/claude-spawner exports it) ──
+
+/**
+ * An architect-specific tool the dispatcher allows in the spawned subagent.
+ * Mirrors the Anthropic tool-use schema. We declare it here (instead of
+ * importing from `@caia/claude-spawner`) so architect-kit has zero runtime
+ * deps and remains independently PR-able.
+ */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  /** Anthropic tool input schema (JSON Schema). Opaque to architect-kit. */
+  inputSchema: unknown;
+}

--- a/packages/architect-kit/tests/architect-registry.test.ts
+++ b/packages/architect-kit/tests/architect-registry.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  disjointness,
+  getDefaultArchitectRegistry,
+  registerArchitect,
+  resetDefaultArchitectRegistry,
+} from '../src/architect-registry.js';
+import {
+  StubArchitect,
+  makeContract,
+  canonicalArchitectSet,
+  stubTicket,
+} from './fixtures.js';
+
+describe('ArchitectRegistry', () => {
+  let r: ArchitectRegistry;
+  beforeEach(() => {
+    r = new ArchitectRegistry();
+  });
+
+  it('registers a single architect', () => {
+    r.register(new StubArchitect('foo', makeContract('foo', ['foo.x'])));
+    expect(r.size()).toBe(1);
+    expect(r.get('foo')).toBeDefined();
+  });
+
+  it('throws on duplicate architect name', () => {
+    r.register(new StubArchitect('foo', makeContract('foo', ['foo.x'])));
+    expect(() =>
+      r.register(new StubArchitect('foo', makeContract('foo', ['foo.y']))),
+    ).toThrow(ArchitectRegistryError);
+  });
+
+  it('throws when sectionContract.architectName does not match the architect name', () => {
+    expect(() =>
+      r.register(new StubArchitect('foo', makeContract('mismatch', ['x']))),
+    ).toThrow(/must match/);
+  });
+
+  it('throws when a contract has duplicate paths within itself', () => {
+    expect(() =>
+      r.register(new StubArchitect('foo', makeContract('foo', ['foo.a', 'foo.a']))),
+    ).toThrow(/duplicate paths/);
+  });
+
+  it('throws on inter-architect path collision', () => {
+    r.register(new StubArchitect('a', makeContract('a', ['shared.x'])));
+    expect(() =>
+      r.register(new StubArchitect('b', makeContract('b', ['shared.x']))),
+    ).toThrow(/already owned by 'a'/);
+  });
+
+  it('unregister removes the architect and frees its paths', () => {
+    r.register(new StubArchitect('a', makeContract('a', ['p'])));
+    expect(r.unregister('a')).toBe(true);
+    expect(r.ownerOf('p')).toBeUndefined();
+    // path now available for a new architect
+    r.register(new StubArchitect('b', makeContract('b', ['p'])));
+    expect(r.ownerOf('p')).toBe('b');
+  });
+
+  it('unregister returns false for unknown architects', () => {
+    expect(r.unregister('nope')).toBe(false);
+  });
+
+  it('list returns architects in registration order', () => {
+    r.register(new StubArchitect('a', makeContract('a', ['a.x'])));
+    r.register(new StubArchitect('b', makeContract('b', ['b.x'])));
+    r.register(new StubArchitect('c', makeContract('c', ['c.x'])));
+    expect(r.list().map((x) => x.name)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('applicableTo filters by appliesPredicate', () => {
+    r.register(
+      new StubArchitect(
+        'always',
+        makeContract('always', ['a.x'], { appliesPredicate: () => true }),
+      ),
+    );
+    r.register(
+      new StubArchitect(
+        'never',
+        makeContract('never', ['n.x'], { appliesPredicate: () => false }),
+      ),
+    );
+    const apps = r.applicableTo(stubTicket());
+    expect(apps.map((a) => a.name)).toEqual(['always']);
+  });
+
+  it('applicableTo can switch behavior by ticket type', () => {
+    r.register(
+      new StubArchitect(
+        'pageOnly',
+        makeContract('pageOnly', ['p.x'], {
+          appliesPredicate: (t) => t.type === 'Page',
+        }),
+      ),
+    );
+    expect(r.applicableTo(stubTicket({ type: 'Page' })).map((a) => a.name)).toEqual([
+      'pageOnly',
+    ]);
+    expect(r.applicableTo(stubTicket({ type: 'Widget' })).map((a) => a.name)).toEqual([]);
+  });
+
+  it('validate reports unmet dependencies', () => {
+    r.register(
+      new StubArchitect(
+        'orphan',
+        makeContract('orphan', ['o.x'], { dependsOn: ['ghost'] }),
+      ),
+    );
+    const errs = r.validate();
+    expect(errs.length).toBe(1);
+    expect(errs[0]).toMatch(/'orphan' depends on 'ghost'/);
+  });
+
+  it('clear empties the registry', () => {
+    r.register(new StubArchitect('a', makeContract('a', ['a'])));
+    r.clear();
+    expect(r.size()).toBe(0);
+  });
+
+  it('handles the full 17-architect canonical set with no validation errors', () => {
+    for (const a of canonicalArchitectSet()) r.register(a);
+    expect(r.size()).toBe(17);
+    expect(r.validate()).toEqual([]);
+    // 17 architects × ~2 paths each = the path count from the fixtures
+    expect(r.allPaths().length).toBeGreaterThan(20);
+    expect(new Set(r.allPaths()).size).toBe(r.allPaths().length);
+  });
+});
+
+describe('disjointness helper', () => {
+  it('returns empty for disjoint contracts', () => {
+    expect(disjointness([makeContract('a', ['x']), makeContract('b', ['y'])])).toEqual([]);
+  });
+
+  it('returns the conflicting paths and claimants', () => {
+    const conflicts = disjointness([
+      makeContract('a', ['shared']),
+      makeContract('b', ['shared']),
+    ]);
+    expect(conflicts).toEqual([{ path: 'shared', claimedBy: ['a', 'b'] }]);
+  });
+});
+
+describe('default singleton', () => {
+  beforeEach(() => resetDefaultArchitectRegistry());
+
+  it('registerArchitect uses the singleton', () => {
+    registerArchitect(new StubArchitect('one', makeContract('one', ['o'])));
+    expect(getDefaultArchitectRegistry().size()).toBe(1);
+  });
+
+  it('resetDefaultArchitectRegistry clears between processes (logical resets)', () => {
+    registerArchitect(new StubArchitect('one', makeContract('one', ['o'])));
+    resetDefaultArchitectRegistry();
+    expect(getDefaultArchitectRegistry().size()).toBe(0);
+  });
+});

--- a/packages/architect-kit/tests/architect-section-contract.test.ts
+++ b/packages/architect-kit/tests/architect-section-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  contractPaths,
+  findDuplicatePaths,
+  findOverlappingPaths,
+} from '../src/architect-section-contract.js';
+import { makeContract, canonicalContractSet } from './fixtures.js';
+
+describe('ArchitectSectionContract — path helpers', () => {
+  it('contractPaths returns every declared section path', () => {
+    const c = makeContract('foo', ['foo.a', 'foo.b', 'foo.c']);
+    expect(contractPaths(c)).toEqual(['foo.a', 'foo.b', 'foo.c']);
+  });
+
+  it('findDuplicatePaths returns intra-contract duplicates', () => {
+    const c = makeContract('foo', ['foo.a', 'foo.b', 'foo.a']);
+    expect(findDuplicatePaths(c)).toEqual(['foo.a']);
+  });
+
+  it('findDuplicatePaths returns empty for a clean contract', () => {
+    const c = makeContract('foo', ['foo.a', 'foo.b']);
+    expect(findDuplicatePaths(c)).toEqual([]);
+  });
+
+  it('findOverlappingPaths surfaces inter-contract path conflicts', () => {
+    const a = makeContract('a', ['x', 'y']);
+    const b = makeContract('b', ['y', 'z']);
+    expect(findOverlappingPaths(a, b)).toEqual(['y']);
+  });
+
+  it('findOverlappingPaths returns empty for disjoint contracts', () => {
+    const a = makeContract('a', ['x']);
+    const b = makeContract('b', ['y']);
+    expect(findOverlappingPaths(a, b)).toEqual([]);
+  });
+
+  it('canonical 17-architect set has disjoint paths globally', () => {
+    const contracts = canonicalContractSet();
+    const allPaths = contracts.flatMap((c) => contractPaths(c));
+    expect(new Set(allPaths).size).toBe(allPaths.length);
+  });
+
+  it('canonical 17-architect set contains exactly 17 architects', () => {
+    expect(canonicalContractSet().length).toBe(17);
+  });
+});

--- a/packages/architect-kit/tests/base-architect.test.ts
+++ b/packages/architect-kit/tests/base-architect.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { BaseArchitect } from '../src/base-architect.js';
+import type { ArchitectInput, ArchitectOutput } from '../src/types.js';
+import { makeContract, stubInput } from './fixtures.js';
+
+class TestArchitect extends BaseArchitect {
+  readonly name = 'test';
+  readonly sectionContract = makeContract('test', ['test.a', 'test.b']);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return this.okOutput({ 'test.a': 1, 'test.b': 2 }, { confidence: 0.9 });
+  }
+}
+
+describe('BaseArchitect', () => {
+  it('provides a default system prompt mentioning the architect name', () => {
+    const a = new TestArchitect();
+    const p = a.systemPrompt();
+    expect(p).toContain('test');
+    expect(p).toContain('test.a');
+    expect(p).toContain('test.b');
+  });
+
+  it('defaults to empty tools', () => {
+    const a = new TestArchitect();
+    expect(a.tools).toEqual([]);
+  });
+
+  it('okOutput downgrades to partial when required paths are missing', async () => {
+    class HalfArchitect extends BaseArchitect {
+      readonly name = 'half';
+      readonly sectionContract = makeContract('half', ['half.a', 'half.b']);
+      async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+        return this.okOutput({ 'half.a': 1 }, { confidence: 0.5 });
+      }
+    }
+    const out = await new HalfArchitect().run(stubInput());
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toMatch(/missing required paths.*half\.b/);
+  });
+
+  it('okOutput stays "ok" when all required paths are present', async () => {
+    const out = await new TestArchitect().run(stubInput());
+    expect(out.status).toBe('ok');
+    expect(out.architectName).toBe('test');
+    expect(out.architectureFields).toEqual({ 'test.a': 1, 'test.b': 2 });
+  });
+
+  it('failedOutput returns a failed status with reason', () => {
+    class FailingArchitect extends BaseArchitect {
+      readonly name = 'fail';
+      readonly sectionContract = makeContract('fail', ['fail.a']);
+      async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+        return this.failedOutput('LLM timed out');
+      }
+    }
+    return new FailingArchitect().run(stubInput()).then((out) => {
+      expect(out.status).toBe('failed');
+      expect(out.failureReason).toBe('LLM timed out');
+      expect(out.architectureFields).toEqual({});
+    });
+  });
+
+  it('partialOutput returns a partial status', async () => {
+    class PartialArchitect extends BaseArchitect {
+      readonly name = 'p';
+      readonly sectionContract = makeContract('p', ['p.a']);
+      async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+        return this.partialOutput({ 'p.a': 'x' }, { confidence: 0.4, notes: 'low conf' });
+      }
+    }
+    const out = await new PartialArchitect().run(stubInput());
+    expect(out.status).toBe('partial');
+    expect(out.notes).toBe('low conf');
+  });
+
+  it('missingPaths surfaces undeclared shortfalls', () => {
+    const c = makeContract('m', ['m.a', 'm.b', 'm.c']);
+    expect(BaseArchitect.missingPaths(c, { 'm.a': 1 })).toEqual(['m.b', 'm.c']);
+  });
+
+  it('extraPaths surfaces fields the architect declared but contract did not own', () => {
+    const c = makeContract('m', ['m.a']);
+    expect(BaseArchitect.extraPaths(c, { 'm.a': 1, 'rogue': 2 })).toEqual(['rogue']);
+  });
+
+  it('zeroSpend uses the named model', () => {
+    const a = new TestArchitect();
+    const spend = (a as unknown as { zeroSpend: (m?: string) => { model: string } }).zeroSpend('haiku');
+    expect(spend.model).toBe('haiku');
+  });
+});

--- a/packages/architect-kit/tests/cli.test.ts
+++ b/packages/architect-kit/tests/cli.test.ts
@@ -1,0 +1,118 @@
+/**
+ * caia-architect-new scaffolder tests.
+ *
+ * The CLI's behaviour is "produce valid files for a given set of flags." We
+ * exercise the `scaffold(args)` export in dry-run mode so tests don't write
+ * to the filesystem unnecessarily.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// @ts-expect-error — bin file is a .mjs Node script, not a .ts module.
+import { scaffold } from '../bin/caia-architect-new.mjs';
+
+describe('caia-architect-new scaffolder', () => {
+  it('requires --name', () => {
+    expect(() => scaffold({ writes: 'foo.a' })).toThrow(/--name/);
+  });
+
+  it('rejects non-kebab-case names', () => {
+    expect(() => scaffold({ name: 'FooBar', writes: 'foo.a' })).toThrow(/kebab-case/);
+    expect(() => scaffold({ name: '123foo', writes: 'foo.a' })).toThrow(/kebab-case/);
+    expect(() => scaffold({ name: 'foo_bar', writes: 'foo.a' })).toThrow(/kebab-case/);
+  });
+
+  it('requires --writes', () => {
+    expect(() => scaffold({ name: 'foo' })).toThrow(/--writes/);
+  });
+
+  it('dry-run lists planned files without writing', () => {
+    const result = scaffold({
+      name: 'analytics',
+      writes: 'analytics.provider,analytics.eventTaxonomy',
+      'dry-run': true,
+    });
+    expect(result.dryRun).toBe(true);
+    const relPaths = result.files.map((f: { rel: string }) => f.rel);
+    expect(relPaths).toContain('package.json');
+    expect(relPaths).toContain('src/contract.ts');
+    expect(relPaths).toContain('src/architect.ts');
+    expect(relPaths).toContain('src/index.ts');
+    expect(relPaths).toContain('src/system-prompt.md');
+    expect(relPaths).toContain('tests/contract.test.ts');
+    expect(relPaths).toContain('README.md');
+  });
+
+  it('embeds the writes paths in the generated contract', () => {
+    const result = scaffold({
+      name: 'foo',
+      writes: 'foo.alpha,foo.beta',
+      'dry-run': true,
+    });
+    const contractFile = result.files.find((f: { rel: string }) => f.rel === 'src/contract.ts');
+    expect(contractFile?.content).toContain("path: 'foo.alpha'");
+    expect(contractFile?.content).toContain("path: 'foo.beta'");
+    expect(contractFile?.content).toContain("architectName: 'foo'");
+  });
+
+  it('honors --runtime-model', () => {
+    const result = scaffold({
+      name: 'foo',
+      writes: 'foo.a',
+      'runtime-model': 'haiku',
+      'dry-run': true,
+    });
+    const contractFile = result.files.find((f: { rel: string }) => f.rel === 'src/contract.ts');
+    expect(contractFile?.content).toContain("runtimeModel: 'haiku'");
+  });
+
+  it('honors --depends-on', () => {
+    const result = scaffold({
+      name: 'foo',
+      writes: 'foo.a',
+      'depends-on': 'backend,frontend',
+      'dry-run': true,
+    });
+    const contractFile = result.files.find((f: { rel: string }) => f.rel === 'src/contract.ts');
+    expect(contractFile?.content).toContain('dependsOn: ["backend","frontend"]');
+  });
+
+  it('writes a working package to disk on a real run', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'caia-arch-test-'));
+    try {
+      const result = scaffold({
+        name: 'demo',
+        writes: 'demo.a,demo.b',
+        'out-dir': dir,
+      });
+      expect(result.dryRun).toBe(false);
+      expect(existsSync(join(dir, 'demo-architect', 'package.json'))).toBe(true);
+      const pkg = JSON.parse(
+        readFileSync(join(dir, 'demo-architect', 'package.json'), 'utf8'),
+      );
+      expect(pkg.name).toBe('@caia/demo-architect');
+      expect(pkg.dependencies['@caia/architect-kit']).toBe('workspace:*');
+      // Architect class file references contract correctly
+      const arch = readFileSync(
+        join(dir, 'demo-architect', 'src', 'architect.ts'),
+        'utf8',
+      );
+      expect(arch).toContain('class DemoArchitect extends BaseArchitect');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite an existing package dir', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'caia-arch-test-'));
+    try {
+      scaffold({ name: 'demo', writes: 'demo.a', 'out-dir': dir });
+      expect(() => scaffold({ name: 'demo', writes: 'demo.a', 'out-dir': dir })).toThrow(
+        /already exists/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/architect-kit/tests/dependency-graph.test.ts
+++ b/packages/architect-kit/tests/dependency-graph.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeWaves,
+  computeWavesFromMeta,
+  flattenWaves,
+  waveOf,
+  CycleDetectedError,
+  UnknownDependencyError,
+} from '../src/dependency-graph.js';
+import { canonicalArchitectSet, makeContract, StubArchitect } from './fixtures.js';
+
+describe('computeWaves — Kahn topo-sort', () => {
+  it('returns empty on empty input', () => {
+    expect(computeWaves([])).toEqual([]);
+  });
+
+  it('returns a single-member single-wave for one architect', () => {
+    const arch = new StubArchitect('a', makeContract('a', ['a.x']));
+    const waves = computeWaves([arch]);
+    expect(waves).toEqual([{ index: 1, members: ['a'] }]);
+  });
+
+  it('groups architects by dependency depth into waves', () => {
+    const a = new StubArchitect('a', makeContract('a', ['a.x']));
+    const b = new StubArchitect('b', makeContract('b', ['b.x'], { dependsOn: ['a'] }));
+    const c = new StubArchitect('c', makeContract('c', ['c.x'], { dependsOn: ['a'] }));
+    const d = new StubArchitect('d', makeContract('d', ['d.x'], { dependsOn: ['b', 'c'] }));
+    const waves = computeWaves([a, b, c, d]);
+    expect(waves.map((w) => w.members)).toEqual([
+      ['a'],
+      ['b', 'c'],
+      ['d'],
+    ]);
+  });
+
+  it('sorts wave members alphabetically for deterministic logs', () => {
+    const arr = ['delta', 'beta', 'alpha', 'charlie'].map(
+      (n) => new StubArchitect(n, makeContract(n, [`${n}.x`])),
+    );
+    const waves = computeWaves(arr);
+    expect(waves[0]?.members).toEqual(['alpha', 'beta', 'charlie', 'delta']);
+  });
+
+  it('detects an unknown dependency', () => {
+    const a = new StubArchitect(
+      'a',
+      makeContract('a', ['a.x'], { dependsOn: ['ghost'] }),
+    );
+    expect(() => computeWaves([a])).toThrow(UnknownDependencyError);
+  });
+
+  it('detects a 2-cycle', () => {
+    const a = new StubArchitect('a', makeContract('a', ['a.x'], { dependsOn: ['b'] }));
+    const b = new StubArchitect('b', makeContract('b', ['b.x'], { dependsOn: ['a'] }));
+    expect(() => computeWaves([a, b])).toThrow(CycleDetectedError);
+  });
+
+  it('detects a 3-cycle', () => {
+    const a = new StubArchitect('a', makeContract('a', ['a.x'], { dependsOn: ['c'] }));
+    const b = new StubArchitect('b', makeContract('b', ['b.x'], { dependsOn: ['a'] }));
+    const c = new StubArchitect('c', makeContract('c', ['c.x'], { dependsOn: ['b'] }));
+    expect(() => computeWaves([a, b, c])).toThrow(CycleDetectedError);
+  });
+
+  it('the cycle error exposes the unresolved set', () => {
+    const a = new StubArchitect('a', makeContract('a', ['a.x'], { dependsOn: ['b'] }));
+    const b = new StubArchitect('b', makeContract('b', ['b.x'], { dependsOn: ['a'] }));
+    try {
+      computeWaves([a, b]);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CycleDetectedError);
+      expect((err as CycleDetectedError).remaining).toEqual(['a', 'b']);
+    }
+  });
+
+  it('handles the full 17-architect canonical set', () => {
+    const waves = computeWaves(canonicalArchitectSet());
+    // Wave 1 = members with no architect deps (6 per the fixture).
+    expect(waves[0]?.members).toEqual([
+      'backend',
+      'featureFlagging',
+      'frontend',
+      'seo',
+      'timeMachine',
+      'uxVersionControl',
+    ]);
+    // A/B Testing sits at wave 3 — analytics (wave 2) + featureFlagging (wave 1).
+    expect(waveOf(waves, 'abTesting')).toBe(3);
+    // The deepest chain — backend → database → security → apiGateway — pushes
+    // apiGateway into wave 4. Spec §0's "3-wave" prose is an approximation;
+    // see spec §2 per-architect deps for the canonical truth.
+    expect(waveOf(waves, 'apiGateway')).toBeGreaterThanOrEqual(3);
+  });
+
+  it('flattenWaves preserves topological order', () => {
+    const waves = computeWaves(canonicalArchitectSet());
+    const flat = flattenWaves(waves);
+    expect(flat.length).toBe(17);
+    // backend must precede everyone that depends on it
+    expect(flat.indexOf('backend')).toBeLessThan(flat.indexOf('database'));
+    expect(flat.indexOf('database')).toBeLessThan(flat.indexOf('security'));
+    expect(flat.indexOf('security')).toBeLessThan(flat.indexOf('apiGateway'));
+    expect(flat.indexOf('analytics')).toBeLessThan(flat.indexOf('abTesting'));
+    expect(flat.indexOf('featureFlagging')).toBeLessThan(flat.indexOf('abTesting'));
+  });
+
+  it('waveOf reports the wave for each architect', () => {
+    const waves = computeWaves(canonicalArchitectSet());
+    expect(waveOf(waves, 'frontend')).toBe(1);
+    expect(waveOf(waves, 'a11y')).toBe(2);
+    expect(waveOf(waves, 'abTesting')).toBeGreaterThanOrEqual(3);
+    expect(waveOf(waves, 'ghost')).toBe(-1);
+  });
+
+  it('handles a 3-wave deep linear chain', () => {
+    const waves = computeWavesFromMeta([
+      { name: 'a', dependsOn: [] },
+      { name: 'b', dependsOn: ['a'] },
+      { name: 'c', dependsOn: ['b'] },
+      { name: 'd', dependsOn: ['c'] },
+    ]);
+    expect(waves.map((w) => w.members)).toEqual([['a'], ['b'], ['c'], ['d']]);
+  });
+});

--- a/packages/architect-kit/tests/fixtures.ts
+++ b/packages/architect-kit/tests/fixtures.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared test fixtures for @caia/architect-kit.
+ *
+ * Builds the 17-architect contract set per spec §2 + a minimal
+ * SpecialistArchitect harness for tests that need polymorphic behavior.
+ */
+
+import { BaseArchitect } from '../src/base-architect.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+} from '../src/types.js';
+import type {
+  ArchitectSectionContract,
+  ArchitectMeta,
+  FanoutPolicy,
+} from '../src/architect-section-contract.js';
+
+export function stubTicket(overrides: Partial<Ticket> = {}): Ticket {
+  return {
+    id: 't-1',
+    type: 'Page',
+    scope: 'story',
+    parent_id: null,
+    architecture: {},
+    acceptance_criteria: ['user can view homepage', 'page loads in <2s'],
+    business_requirements: { goal: 'capture leads' },
+    quality_tags: ['seo', 'accessibility'],
+    ...overrides,
+  };
+}
+
+export function stubBusinessPlan(): BusinessPlan {
+  return {
+    ventureName: 'Acme Co',
+    oneLiner: 'better mousetraps',
+    audience: 'small business owners',
+    goals: ['10k visitors/month', '5% conversion'],
+    brandVoice: 'friendly-expert',
+  };
+}
+
+export function stubDesignVersion(): RenderableDesign {
+  return {
+    versionId: 'design-v1',
+    anchors: [
+      { anchorId: 'hero', kind: 'section' },
+      { anchorId: 'cta', kind: 'button' },
+    ],
+  };
+}
+
+export function stubTenantContext(): TenantContext {
+  return {
+    tenantId: 'tnt-1',
+    schemaName: 'tenant_acme',
+    vaultNamespace: 'caia/acme',
+    billingPosture: 'subscription',
+    creditBalance: { usdAvailable: 100 },
+  };
+}
+
+export function stubInput(overrides: Partial<ArchitectInput> = {}): ArchitectInput {
+  return {
+    ticket: stubTicket(),
+    upstream: { outputs: {} },
+    businessPlan: stubBusinessPlan(),
+    designVersion: stubDesignVersion(),
+    tenantContext: stubTenantContext(),
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 1,
+    },
+    ...overrides,
+  };
+}
+
+// ─── Synthetic architects for tests ──────────────────────────────────────
+
+export function makeMeta(opts: Partial<ArchitectMeta> & { dependsOn?: readonly string[] } = {}): ArchitectMeta {
+  return {
+    dependsOn: opts.dependsOn ?? [],
+    precedenceLevel: opts.precedenceLevel ?? 99,
+    fanoutPolicy: (opts.fanoutPolicy as FanoutPolicy) ?? 'always',
+    appliesPredicate: opts.appliesPredicate ?? (() => true),
+    runtimeModel: opts.runtimeModel ?? 'sonnet',
+  };
+}
+
+export function makeContract(
+  name: string,
+  paths: readonly string[],
+  meta: Partial<ArchitectMeta> = {},
+): ArchitectSectionContract {
+  return {
+    contractId: `${name}-architect.v1`,
+    architectName: name,
+    version: '0.1.0',
+    sections: paths.map((p) => ({ path: p, description: `path ${p}`, required: true })),
+    architectMeta: makeMeta(meta),
+  };
+}
+
+export class StubArchitect extends BaseArchitect {
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract,
+    private readonly impl?: (input: ArchitectInput) => Promise<ArchitectOutput>,
+  ) {
+    super();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    if (this.impl) return this.impl(input);
+    // Default: return ok with empty fields for declared paths.
+    const fields: Record<string, unknown> = {};
+    for (const s of this.sectionContract.sections) {
+      fields[s.path] = `placeholder-for-${s.path}`;
+    }
+    return this.okOutput(fields, {
+      confidence: 0.8,
+      spend: this.zeroSpend(`${this.name}-stub`),
+    });
+  }
+}
+
+// ─── The canonical 17-architect dependency graph (spec §2) ───────────────
+
+export function canonicalContractSet(): readonly ArchitectSectionContract[] {
+  return [
+    // Wave 1 — no architect deps
+    makeContract('frontend', ['frontend.framework', 'frontend.componentTree', 'frontend.tokens'], {
+      precedenceLevel: 14,
+    }),
+    makeContract('backend', ['backend.framework', 'backend.endpointEnumeration'], {
+      precedenceLevel: 12,
+    }),
+    makeContract('seo', ['seo.title', 'seo.jsonLd', 'seo.canonical'], { precedenceLevel: 4 }),
+    makeContract('featureFlagging', ['featureFlags.flagStore', 'featureFlags.killSwitch'], {
+      precedenceLevel: 7,
+    }),
+    makeContract('timeMachine', ['timeMachine.snapshotKey', 'timeMachine.revertCommand'], {
+      precedenceLevel: 15,
+    }),
+    makeContract('uxVersionControl', ['uxVersionControl.uploadVersionId', 'uxVersionControl.diffSummary'], {
+      precedenceLevel: 16,
+    }),
+    // Wave 2 — depends on wave 1
+    makeContract('database', ['database.engine', 'database.schemaDDL'], {
+      dependsOn: ['backend'],
+      precedenceLevel: 11,
+    }),
+    makeContract('a11y', ['a11y.wcagLevel', 'a11y.keyboardSpec'], {
+      dependsOn: ['frontend'],
+      precedenceLevel: 3,
+    }),
+    makeContract('performance', ['performance.lighthouseTargets', 'performance.bundleBudget'], {
+      dependsOn: ['frontend'],
+      precedenceLevel: 5,
+    }),
+    makeContract('analytics', ['analytics.provider', 'analytics.eventTaxonomy'], {
+      dependsOn: ['frontend'],
+      precedenceLevel: 10,
+    }),
+    makeContract('aiml', ['aiml.model', 'aiml.evalSuite'], {
+      dependsOn: ['backend'],
+      precedenceLevel: 13,
+    }),
+    makeContract('observability', ['observability.logShape', 'observability.metricsExport'], {
+      dependsOn: ['backend', 'frontend'],
+      precedenceLevel: 9,
+    }),
+    makeContract('security', ['security.authnFlow', 'security.cspPolicy'], {
+      dependsOn: ['backend', 'database'],
+      precedenceLevel: 1,
+    }),
+    makeContract('apiGateway', ['apiGateway.rateLimit', 'apiGateway.errorEnvelope'], {
+      dependsOn: ['backend', 'security'],
+      precedenceLevel: 8,
+    }),
+    makeContract('testing', ['testing.strategy', 'testing.pyramidRatios'], {
+      dependsOn: ['frontend', 'backend'],
+      precedenceLevel: 17,
+    }),
+    makeContract('devops', ['devops.ciPipeline', 'devops.deployStrategy'], {
+      dependsOn: ['backend', 'database'],
+      precedenceLevel: 2,
+    }),
+    // Wave 3 — depends on wave 2
+    makeContract('abTesting', ['abTesting.variantRouter', 'abTesting.allocation'], {
+      dependsOn: ['analytics', 'featureFlagging'],
+      precedenceLevel: 6,
+    }),
+  ];
+}
+
+export function canonicalArchitectSet(): readonly StubArchitect[] {
+  return canonicalContractSet().map((c) => new StubArchitect(c.architectName, c));
+}

--- a/packages/architect-kit/tests/precedence.test.ts
+++ b/packages/architect-kit/tests/precedence.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_PRECEDENCE_LADDER,
+  CANONICAL_ARCHITECT_COUNT,
+  precedenceRank,
+  comparePrecedence,
+  higherPrecedence,
+  assertLadderShape,
+} from '../src/precedence.js';
+
+describe('precedence ladder', () => {
+  it('contains exactly 17 architects', () => {
+    expect(CANONICAL_PRECEDENCE_LADDER.length).toBe(17);
+    expect(CANONICAL_ARCHITECT_COUNT).toBe(17);
+  });
+
+  it('has unique entries', () => {
+    const seen = new Set(CANONICAL_PRECEDENCE_LADDER);
+    expect(seen.size).toBe(CANONICAL_PRECEDENCE_LADDER.length);
+  });
+
+  it('places security at rank 1', () => {
+    expect(precedenceRank('security')).toBe(1);
+  });
+
+  it('places devops at rank 2 (spec §5.2: operator-on-hook for bad deploy)', () => {
+    expect(precedenceRank('devops')).toBe(2);
+  });
+
+  it('places a11y above seo above performance above frontend', () => {
+    const a11y = precedenceRank('a11y');
+    const seo = precedenceRank('seo');
+    const perf = precedenceRank('performance');
+    const fe = precedenceRank('frontend');
+    expect(a11y).toBeLessThan(seo);
+    expect(seo).toBeLessThan(perf);
+    expect(perf).toBeLessThan(fe);
+  });
+
+  it('places testing at the bottom (advisory)', () => {
+    expect(precedenceRank('testing')).toBe(17);
+  });
+
+  it('precedenceRank returns Infinity for unknown architects', () => {
+    expect(precedenceRank('not-a-real-architect')).toBe(Infinity);
+  });
+
+  it('comparePrecedence total-orders the ladder', () => {
+    const sorted = [...CANONICAL_PRECEDENCE_LADDER].sort((a, b) => comparePrecedence(a, b));
+    expect(sorted).toEqual([...CANONICAL_PRECEDENCE_LADDER]);
+  });
+
+  it('higherPrecedence picks the lower-ranked (higher-priority) architect', () => {
+    expect(higherPrecedence('security', 'frontend')).toBe('security');
+    expect(higherPrecedence('frontend', 'security')).toBe('security');
+  });
+
+  it('higherPrecedence returns null on tie', () => {
+    expect(higherPrecedence('mystery-1', 'mystery-2')).toBe(null);
+  });
+
+  it('assertLadderShape passes the canonical ladder', () => {
+    expect(() => assertLadderShape(CANONICAL_PRECEDENCE_LADDER)).not.toThrow();
+  });
+
+  it('assertLadderShape catches a wrong-size ladder', () => {
+    expect(() => assertLadderShape(['a', 'b'], 17)).toThrow(/17/);
+  });
+
+  it('assertLadderShape catches duplicate entries', () => {
+    expect(() => assertLadderShape(['a', 'a', ...Array(15).fill('x').map((_, i) => `n${i}`)], 17)).toThrow(
+      /duplicate/,
+    );
+  });
+});

--- a/packages/architect-kit/tsconfig.json
+++ b/packages/architect-kit/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*", "tests/**/*", "bin/**/*"]
+}

--- a/packages/architect-kit/vitest.config.ts
+++ b/packages/architect-kit/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -786,6 +786,18 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/architect-kit:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/architecture-registry:
     dependencies:
       '@chiefaia/feature-registry':


### PR DESCRIPTION
Foundational kit every one of the 17 EA-phase specialist-architect packages
depends on. Sourced from `research/17_architect_framework_spec_2026.md` §1, §2, §5, §8.

## What ships

- `SpecialistArchitect` interface (`name`, `sectionContract`, `systemPrompt`, `tools`, `run`)
- `BaseArchitect` abstract class — `okOutput` / `partialOutput` / `failedOutput` / `missingPaths` / `extraPaths` / `zeroSpend` helpers reduce per-architect boilerplate
- `ArchitectSectionContract` — disjoint-write JSONB contract over `tickets.architecture`, with `architectMeta` (`dependsOn`, `precedenceLevel`, `fanoutPolicy`, `appliesPredicate`, `runtimeModel`)
- `ArchitectRegistry` — process-singleton with path-disjointness invariant enforced at registration time + dependency-soundness validation
- `computeWaves()` — Kahn's algorithm topo-sort over `dependsOn`
- `CANONICAL_PRECEDENCE_LADDER` — 17-architect rank ordering for semantic conflict resolution
- `caia-architect-new` CLI — scaffolds a new `<name>-architect` package with contract + class + system prompt + passing tests
- Types: `Ticket`, `BusinessPlan`, `RenderableDesign`, `TenantContext`, `ArchitectInput / Output / Spend / ToolCall`, `ArchitectBudget`, `ToolDefinition`

## Test summary

**67 vitest tests passing**, covering:
- contract path helpers + global disjointness
- precedence ladder total-ordering
- registry disjointness invariants
- dep-graph Kahn correctness (cycle detection + unknown-dep detection + waves on full 17-arch graph)
- BaseArchitect output helpers
- CLI scaffolder (dry-run + real-write + idempotence)

\`tsc --noEmit\` clean under \`strict\` + \`exactOptionalPropertyTypes\` + \`noUncheckedIndexedAccess\`.

## Constraints honoured

- Subscription-only build (no runtime LLM deps in this kit).
- Zero hard runtime deps — kit is pure types + small pure helpers. Downstream architect packages add their own LLM machinery.
- True-Zero — admin-merge.