### PR TITLE
feat(@caia/ea-dispatcher): deterministic orchestrator for EA fan-out phase

### DIFF
--- a/packages/ea-dispatcher/package.json
+++ b/packages/ea-dispatcher/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@caia/ea-dispatcher",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Deterministic Node orchestrator for the EA fan-out phase. Reads ticket + upstream context, computes the architect dependency graph (Kahn's algorithm), fans out each wave in parallel via @chiefaia/claude-spawner, composes outputs into tickets.architecture via disjoint-key SectionContract merge, resolves semantic conflicts by precedence ladder, emits per-call telemetry, and drives state-machine transitions through ea-dispatching → ea-complete (or ea-dispatching-failed on a hard fault). No LLM in the dispatcher itself — only deterministic compute.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/ea-dispatcher/src/applies.ts
+++ b/packages/ea-dispatcher/src/applies.ts
@@ -1,0 +1,55 @@
+/**
+ * @caia/ea-dispatcher — applies.ts
+ *
+ * Per §3.2: the dispatcher filters the architect set to those whose
+ * `appliesPredicate(ticket)` returns true. This module is a thin adapter
+ * over that predicate so callers can ergonomically check + collect skipped
+ * names for telemetry.
+ */
+
+import type {
+  SpecialistArchitect,
+  Ticket,
+  ArchitectName,
+} from '@caia/architect-kit';
+
+export interface AppliesPartition {
+  applicable: readonly SpecialistArchitect[];
+  skipped: readonly ArchitectName[];
+}
+
+/**
+ * Partition an architect set into "applies to this ticket" and "skipped".
+ * `appliesPredicate` exceptions count as "skipped" (defensive — a buggy
+ * predicate shouldn't block the entire fan-out).
+ */
+export function partitionByApplies(
+  architects: readonly SpecialistArchitect[],
+  ticket: Ticket,
+): AppliesPartition {
+  const applicable: SpecialistArchitect[] = [];
+  const skipped: ArchitectName[] = [];
+  for (const a of architects) {
+    let pass = false;
+    try {
+      pass = a.sectionContract.architectMeta.appliesPredicate(ticket);
+    } catch {
+      pass = false;
+    }
+    if (pass) applicable.push(a);
+    else skipped.push(a.name);
+  }
+  return { applicable, skipped };
+}
+
+/**
+ * Subset to only the architects in `names`. Used for re-run cycles when the
+ * EA Reviewer names a specific subset to recompute.
+ */
+export function selectByName(
+  architects: readonly SpecialistArchitect[],
+  names: readonly ArchitectName[],
+): readonly SpecialistArchitect[] {
+  const want = new Set(names);
+  return architects.filter((a) => want.has(a.name));
+}

--- a/packages/ea-dispatcher/src/composer.ts
+++ b/packages/ea-dispatcher/src/composer.ts
@@ -1,0 +1,134 @@
+/**
+ * @caia/ea-dispatcher — composer.ts
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §3.5 + §5.1.
+ *
+ * Field-level conflicts are impossible by construction (the SectionContract
+ * disjointness invariant — enforced by ArchitectRegistry at registration
+ * time). Composition is therefore a deterministic disjoint-key merge:
+ *
+ *     architecture = ⋃ architectOutputs[i].architectureFields
+ *
+ * Matches the Postgres `||` (jsonb concat) the orchestrator uses to
+ * actually write the result.
+ *
+ * We still defensively detect collisions here — registries can be bypassed
+ * in tests or by misconfiguration — and surface them as a `CollisionError`
+ * the dispatcher converts into a hard failure (don't silently overwrite
+ * fields, ever).
+ */
+
+import type { ArchitectOutput } from '@caia/architect-kit';
+
+export interface ComposeCollision {
+  path: string;
+  claimedBy: readonly string[];
+}
+
+export class CompositionError extends Error {
+  constructor(
+    public readonly collisions: readonly ComposeCollision[],
+    message?: string,
+  ) {
+    const lines = collisions.map(
+      (c) => `  - '${c.path}' claimed by ${c.claimedBy.join(' AND ')}`,
+    );
+    super(
+      message ??
+        `composition collision detected:\n${lines.join('\n')}\nField-level conflicts are forbidden by the SectionContract disjointness invariant (§5.1).`,
+    );
+    this.name = 'CompositionError';
+  }
+}
+
+export interface ComposeResult {
+  composed: Record<string, unknown>;
+  /** Architects whose output was skipped because `status: 'failed'`. */
+  skippedFailed: readonly string[];
+  /**
+   * Architects whose output was a `partial` — we still merge their fields
+   * (the reviewer's completeness lens will flag the missing required paths).
+   */
+  partialContributors: readonly string[];
+}
+
+/**
+ * Compose architect outputs into a single tickets.architecture blob.
+ *
+ *  - Failed outputs (`status === 'failed'`) are skipped entirely.
+ *  - Partial outputs contribute their populated paths.
+ *  - Collisions (any path claimed by ≥2 contributors) throw `CompositionError`.
+ *
+ * Returns a fresh object — the result is safe to mutate downstream.
+ */
+export function composeArchitectOutputs(
+  outputs: readonly ArchitectOutput[],
+): ComposeResult {
+  const composed: Record<string, unknown> = {};
+  /** path → architect names that have written it. */
+  const owners = new Map<string, string[]>();
+  const skippedFailed: string[] = [];
+  const partialContributors: string[] = [];
+
+  for (const out of outputs) {
+    if (out.status === 'failed') {
+      skippedFailed.push(out.architectName);
+      continue;
+    }
+    if (out.status === 'partial') {
+      partialContributors.push(out.architectName);
+    }
+    for (const [path, value] of Object.entries(out.architectureFields)) {
+      const existingOwners = owners.get(path) ?? [];
+      existingOwners.push(out.architectName);
+      owners.set(path, existingOwners);
+      composed[path] = value;
+    }
+  }
+
+  const collisions: ComposeCollision[] = [];
+  for (const [path, names] of owners) {
+    if (names.length > 1) {
+      collisions.push({ path, claimedBy: [...new Set(names)] });
+    }
+  }
+  if (collisions.length > 0) throw new CompositionError(collisions);
+
+  return { composed, skippedFailed, partialContributors };
+}
+
+/**
+ * Variant of compose that DOES NOT throw on collision — instead returns the
+ * collision list alongside the composed (with last-write-wins on conflict).
+ * Used by tests that want to inspect collision detection without aborting.
+ */
+export function composeArchitectOutputsLenient(
+  outputs: readonly ArchitectOutput[],
+): ComposeResult & { collisions: readonly ComposeCollision[] } {
+  const composed: Record<string, unknown> = {};
+  const owners = new Map<string, string[]>();
+  const skippedFailed: string[] = [];
+  const partialContributors: string[] = [];
+
+  for (const out of outputs) {
+    if (out.status === 'failed') {
+      skippedFailed.push(out.architectName);
+      continue;
+    }
+    if (out.status === 'partial') partialContributors.push(out.architectName);
+    for (const [path, value] of Object.entries(out.architectureFields)) {
+      const existingOwners = owners.get(path) ?? [];
+      existingOwners.push(out.architectName);
+      owners.set(path, existingOwners);
+      composed[path] = value;
+    }
+  }
+
+  const collisions: ComposeCollision[] = [];
+  for (const [path, names] of owners) {
+    if (names.length > 1) {
+      collisions.push({ path, claimedBy: [...new Set(names)] });
+    }
+  }
+  return { composed, skippedFailed, partialContributors, collisions };
+}

--- a/packages/ea-dispatcher/src/conflict-rules.ts
+++ b/packages/ea-dispatcher/src/conflict-rules.ts
@@ -1,0 +1,268 @@
+/**
+ * @caia/ea-dispatcher — semantic-conflict detection.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §5.2.
+ *
+ * Field-level conflicts are impossible by construction (disjoint-key
+ * SectionContracts). Semantic conflicts — same operator intent expressed
+ * differently by different architects — are detected here by a fixed set
+ * of predicates after composition.
+ *
+ * Rules fire on the composed architecture blob (the disjoint-key union).
+ * Each rule names the two architects whose fields are in tension and the
+ * field paths involved. Conflict resolution is then a precedence-ladder
+ * lookup (see precedence-resolver.ts); the loser's field gets a `_dissent`
+ * annotation, the winner's is untouched.
+ */
+
+import type { ArchitectName } from '@caia/architect-kit';
+
+export interface SemanticConflictRule {
+  /** Stable identifier surfaced in dissent annotations and dashboard. */
+  id: string;
+  /** Short human-readable description for logs + operator UI. */
+  description: string;
+  /**
+   * The two architects whose fields the rule reconciles. Order doesn't
+   * matter — precedence is looked up at resolution time.
+   */
+  architects: readonly [ArchitectName, ArchitectName];
+  /** Field paths touched (for dissent annotation + dashboard rendering). */
+  fields: readonly string[];
+  /**
+   * Pure predicate over the composed architecture. Returns true iff the
+   * rule fires (there IS a conflict to resolve).
+   */
+  detect: (composed: Record<string, unknown>) => boolean;
+}
+
+/**
+ * Helper — read a dotted-path value from an object. Returns `undefined` if
+ * any intermediate segment is missing. Used by rule predicates.
+ */
+export function getPath(obj: Record<string, unknown>, path: string): unknown {
+  // Composed architecture uses FLAT dotted keys (matching the SectionContract
+  // path convention). So we first try the flat lookup; if absent, fall back
+  // to nested.
+  if (path in obj) return obj[path];
+  const segs = path.split('.');
+  let cur: unknown = obj;
+  for (const seg of segs) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+function asArray<T = unknown>(v: unknown): readonly T[] {
+  return Array.isArray(v) ? (v as T[]) : [];
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// ─── Rule registry ────────────────────────────────────────────────────────
+
+/**
+ * The canonical semantic-conflict rule set. ~12 rules per spec §5.2 cover
+ * the known overlap zones between architects. Each rule is a small pure
+ * predicate so the dispatcher can run them all in <1ms.
+ */
+export const SEMANTIC_CONFLICT_RULES: readonly SemanticConflictRule[] = [
+  {
+    id: 'image-lazy-vs-preload',
+    description: 'SEO preloads an image that Performance wants lazy-loaded.',
+    architects: ['seo', 'performance'],
+    fields: ['performance.lazyLoadList', 'seo.preloadHints'],
+    detect: (c) => {
+      const lazy = asArray<{ src: string }>(getPath(c, 'performance.lazyLoadList'))
+        .map((x) => x.src);
+      const preload = asArray<{ href: string }>(getPath(c, 'seo.preloadHints'))
+        .map((x) => x.href);
+      return preload.some((href) => lazy.includes(href));
+    },
+  },
+  {
+    id: 'csp-frame-vs-iframe-embed',
+    description: 'Security CSP forbids iframes; Frontend includes an iframe-embed widget.',
+    architects: ['security', 'frontend'],
+    fields: ['security.cspPolicy', 'frontend.componentTree'],
+    detect: (c) => {
+      const csp = getPath(c, 'security.cspPolicy');
+      const frameSrc = isObject(csp) ? (csp['frameSrc'] as unknown) : undefined;
+      const tree = asArray<{ kind?: string }>(getPath(c, 'frontend.componentTree'));
+      const hasIframe = tree.some((node) => node?.kind === 'iframe-embed');
+      return frameSrc === "'none'" && hasIframe;
+    },
+  },
+  {
+    id: 'analytics-event-without-observability-metric',
+    description:
+      'Analytics tracks an event that has no corresponding Observability metrics export.',
+    architects: ['analytics', 'observability'],
+    fields: ['analytics.eventTaxonomy', 'observability.metricsExport'],
+    detect: (c) => {
+      const events = asArray<{ name?: string }>(getPath(c, 'analytics.eventTaxonomy'));
+      const metrics = asArray<{ event?: string }>(getPath(c, 'observability.metricsExport'));
+      const metricEvents = new Set(metrics.map((m) => m.event).filter(Boolean));
+      return events.some((e) => e.name && !metricEvents.has(e.name));
+    },
+  },
+  {
+    id: 'endpoint-without-gateway-ratelimit',
+    description: 'Backend exposes an endpoint not covered by an apiGateway rate limit.',
+    architects: ['backend', 'apiGateway'],
+    fields: ['backend.endpointEnumeration', 'apiGateway.rateLimit'],
+    detect: (c) => {
+      const endpoints = asArray<{ path?: string }>(
+        getPath(c, 'backend.endpointEnumeration'),
+      ).map((e) => e.path).filter(Boolean) as string[];
+      const limits = asArray<{ path?: string }>(getPath(c, 'apiGateway.rateLimit'))
+        .map((l) => l.path).filter(Boolean) as string[];
+      return endpoints.some((e) => !limits.includes(e));
+    },
+  },
+  {
+    id: 'interactive-widget-without-keyboard-spec',
+    description:
+      'Frontend ships an interactive widget without an A11y keyboard spec.',
+    architects: ['frontend', 'a11y'],
+    fields: ['frontend.componentTree', 'a11y.keyboardSpec'],
+    detect: (c) => {
+      const tree = asArray<{ id?: string; kind?: string; interactive?: boolean }>(
+        getPath(c, 'frontend.componentTree'),
+      );
+      const interactive = tree
+        .filter((n) => n.interactive)
+        .map((n) => n.id)
+        .filter(Boolean) as string[];
+      const keys = asArray<{ componentId?: string }>(getPath(c, 'a11y.keyboardSpec'))
+        .map((k) => k.componentId).filter(Boolean) as string[];
+      return interactive.some((id) => !keys.includes(id));
+    },
+  },
+  {
+    id: 'flag-without-killswitch',
+    description: 'Feature flag defined without a kill-switch path.',
+    architects: ['featureFlagging', 'security'],
+    fields: ['featureFlags.flagStore', 'featureFlags.killSwitch'],
+    detect: (c) => {
+      const flags = asArray<{ name?: string }>(getPath(c, 'featureFlags.flagStore'));
+      const switches = asArray<{ name?: string }>(getPath(c, 'featureFlags.killSwitch'))
+        .map((s) => s.name);
+      return flags.some((f) => f.name && !switches.includes(f.name));
+    },
+  },
+  {
+    id: 'ab-test-without-flag-binding',
+    description: 'A/B Testing variant has no Feature Flag binding.',
+    architects: ['abTesting', 'featureFlagging'],
+    fields: ['abTesting.variantRouter', 'featureFlags.flagStore'],
+    detect: (c) => {
+      const variants = asArray<{ flag?: string }>(getPath(c, 'abTesting.variantRouter'));
+      const flagNames = new Set(
+        asArray<{ name?: string }>(getPath(c, 'featureFlags.flagStore'))
+          .map((f) => f.name)
+          .filter(Boolean),
+      );
+      return variants.some((v) => !v.flag || !flagNames.has(v.flag));
+    },
+  },
+  {
+    id: 'image-policy-vs-seo-og-image',
+    description:
+      'SEO OG image violates the Performance image policy (e.g. > size budget).',
+    architects: ['seo', 'performance'],
+    fields: ['seo.ogImage', 'performance.imagePolicy'],
+    detect: (c) => {
+      const og = getPath(c, 'seo.ogImage');
+      const policy = getPath(c, 'performance.imagePolicy');
+      if (!isObject(og) || !isObject(policy)) return false;
+      const maxKb = typeof policy['maxKb'] === 'number' ? (policy['maxKb'] as number) : Infinity;
+      const sizeKb = typeof og['sizeKb'] === 'number' ? (og['sizeKb'] as number) : 0;
+      return sizeKb > maxKb;
+    },
+  },
+  {
+    id: 'consent-vs-analytics-default',
+    description:
+      'Analytics consent mode is permissive but Security data-classification requires deny-by-default.',
+    architects: ['analytics', 'security'],
+    fields: ['analytics.consentMode', 'security.dataClassification'],
+    detect: (c) => {
+      const consent = getPath(c, 'analytics.consentMode');
+      const cls = getPath(c, 'security.dataClassification');
+      const requiresStrict = cls === 'PII' || cls === 'confidential';
+      return requiresStrict && consent !== 'deny-by-default';
+    },
+  },
+  {
+    id: 'deploy-without-rollback',
+    description: 'DevOps blue-green deploy without a Time Machine revert command.',
+    architects: ['devops', 'timeMachine'],
+    fields: ['devops.deployStrategy', 'timeMachine.revertCommand'],
+    detect: (c) => {
+      const deploy = getPath(c, 'devops.deployStrategy');
+      const revert = getPath(c, 'timeMachine.revertCommand');
+      return deploy === 'blue-green' && (revert == null || revert === '');
+    },
+  },
+  {
+    id: 'frontend-tokens-vs-design-anchors',
+    description:
+      'Frontend uses tokens that contradict the Atlas anchor metadata (mismatch on breakpoints).',
+    architects: ['frontend', 'frontend'], // intra-section but spec rule (frontend-only)
+    fields: ['frontend.tokens', 'frontend.breakpoints'],
+    detect: (c) => {
+      const tokens = getPath(c, 'frontend.tokens');
+      const breakpoints = getPath(c, 'frontend.breakpoints');
+      if (!isObject(tokens) || !isObject(breakpoints)) return false;
+      const tokenBp = tokens['breakpoints'];
+      const bpList = isObject(breakpoints) ? Object.keys(breakpoints) : [];
+      if (!Array.isArray(tokenBp)) return false;
+      return tokenBp.some((b) => !bpList.includes(String(b)));
+    },
+  },
+  {
+    id: 'testing-without-fixtures-for-endpoint',
+    description: 'Testing strategy references endpoints with no fixtures declared.',
+    architects: ['testing', 'backend'],
+    fields: ['testing.fixtures', 'backend.endpointEnumeration'],
+    detect: (c) => {
+      const endpoints = asArray<{ path?: string }>(
+        getPath(c, 'backend.endpointEnumeration'),
+      ).map((e) => e.path).filter(Boolean) as string[];
+      const fixtures = asArray<{ path?: string }>(getPath(c, 'testing.fixtures'))
+        .map((f) => f.path).filter(Boolean) as string[];
+      // A simple heuristic — at least one endpoint must have a fixture.
+      if (endpoints.length === 0) return false;
+      return !endpoints.some((e) => fixtures.includes(e));
+    },
+  },
+];
+
+// ─── Detection runner ─────────────────────────────────────────────────────
+
+export interface FiredRule {
+  rule: SemanticConflictRule;
+}
+
+/**
+ * Run every rule over the composed blob. Returns the set of rules that fired.
+ * Order matches `SEMANTIC_CONFLICT_RULES` (so logs are stable).
+ */
+export function detectConflicts(
+  composed: Record<string, unknown>,
+  rules: readonly SemanticConflictRule[] = SEMANTIC_CONFLICT_RULES,
+): readonly FiredRule[] {
+  const fired: FiredRule[] = [];
+  for (const rule of rules) {
+    try {
+      if (rule.detect(composed)) fired.push({ rule });
+    } catch {
+      // A buggy rule predicate is non-fatal — record nothing, move on.
+    }
+  }
+  return fired;
+}

--- a/packages/ea-dispatcher/src/dispatcher.ts
+++ b/packages/ea-dispatcher/src/dispatcher.ts
@@ -1,0 +1,409 @@
+/**
+ * @caia/ea-dispatcher — dispatcher.ts
+ *
+ * The orchestrator. Sourced from research/17_architect_framework_spec_2026.md §3.
+ *
+ * Flow (deterministic, no LLM):
+ *
+ *   1. Read world: ticket, business plan, design version, tenant context.
+ *   2. Filter the registered architect set by `appliesPredicate(ticket)`.
+ *   3. Topo-sort the survivors via Kahn's algorithm (computeWaves).
+ *   4. For each wave: spawn each member in parallel via the ArchitectInvoker.
+ *      - Apply the per-architect wall-clock deadline.
+ *      - Validate the output's `architectureFields` keys against the contract;
+ *        on schema mismatch, retry ONCE with a corrected prompt fragment.
+ *      - On second failure, mark the architect as `failed` and proceed.
+ *   5. Compose all `ok`/`partial` outputs into a single jsonb blob via
+ *      disjoint-key merge. Collisions (impossible-by-construction) throw.
+ *   6. Detect semantic conflicts via the rule registry; resolve via the
+ *      precedence ladder — loser fields get `_dissent` annotations.
+ *   7. Per-architect telemetry rows to the TelemetrySink.
+ *   8. Transition the project state via the StateMachineAdapter:
+ *        - >failureThreshold failed → 'ea-dispatching-failed'.
+ *        - otherwise → 'ea-complete'.
+ */
+
+import {
+  computeWaves,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectName,
+  type ArchitectUpstreamContext,
+  type SpecialistArchitect,
+  type Wave,
+} from '@caia/architect-kit';
+
+import { partitionByApplies, selectByName } from './applies.js';
+import {
+  composeArchitectOutputs,
+  CompositionError,
+} from './composer.js';
+import {
+  detectConflicts,
+  SEMANTIC_CONFLICT_RULES,
+  type SemanticConflictRule,
+} from './conflict-rules.js';
+import { resolveConflicts } from './precedence-resolver.js';
+import {
+  DefaultArchitectInvoker,
+  InMemoryTelemetrySink,
+  NoopStateMachine,
+  SystemClock,
+} from './invoker.js';
+import {
+  DEFAULT_DISPATCHER_OPTIONS,
+  type ArchitectCallRecord,
+  type ArchitectInvoker,
+  type Clock,
+  type ConflictRecord,
+  type DispatchInput,
+  type DispatchResult,
+  type DispatcherOptions,
+  type StateMachineAdapter,
+  type TelemetrySink,
+} from './types.js';
+
+/** Agent ID used in state-machine transitions + ticket claims. */
+export const DISPATCHER_AGENT_ID = 'ea-dispatcher';
+
+export interface DispatcherDeps {
+  architects: readonly SpecialistArchitect[];
+  stateMachine?: StateMachineAdapter;
+  invoker?: ArchitectInvoker;
+  telemetry?: TelemetrySink;
+  clock?: Clock;
+  /** Override the conflict rule set (tests). */
+  conflictRules?: readonly SemanticConflictRule[];
+  /** Optional project ID for state-machine transitions; defaults to ticket.id. */
+  projectIdOf?: (ticketId: string) => string;
+}
+
+export class Dispatcher {
+  private readonly architects: readonly SpecialistArchitect[];
+  private readonly stateMachine: StateMachineAdapter;
+  private readonly invoker: ArchitectInvoker;
+  private readonly telemetry: TelemetrySink;
+  private readonly clock: Clock;
+  private readonly rules: readonly SemanticConflictRule[];
+  private readonly opts: Required<DispatcherOptions>;
+  private readonly projectIdOf: (ticketId: string) => string;
+
+  constructor(deps: DispatcherDeps, opts: DispatcherOptions = {}) {
+    this.architects = deps.architects;
+    this.stateMachine = deps.stateMachine ?? new NoopStateMachine();
+    this.invoker = deps.invoker ?? new DefaultArchitectInvoker();
+    this.telemetry = deps.telemetry ?? new InMemoryTelemetrySink();
+    this.clock = deps.clock ?? new SystemClock();
+    this.rules = deps.conflictRules ?? SEMANTIC_CONFLICT_RULES;
+    this.projectIdOf = deps.projectIdOf ?? ((id) => id);
+    this.opts = { ...DEFAULT_DISPATCHER_OPTIONS, ...opts };
+  }
+
+  // ─── Public entrypoint ──────────────────────────────────────────────────
+
+  async dispatch(input: DispatchInput): Promise<DispatchResult> {
+    const iteration = input.iteration ?? 1;
+    if (iteration > this.opts.maxIterations) {
+      throw new Error(
+        `iteration ${iteration} exceeds maxIterations ${this.opts.maxIterations} — reviewer must escalate to operator`,
+      );
+    }
+
+    // Claim the ticket. Honour state-machine errors but proceed even if the
+    // claim is a no-op (some orchestrators pre-claim and pass us a context).
+    await this.stateMachine.claimTicketForAgent(input.ticket.id, DISPATCHER_AGENT_ID, {
+      ttlSeconds: this.opts.claimTtlSeconds,
+    });
+
+    let result: DispatchResult;
+    try {
+      result = await this.runFanout(input);
+    } catch (err) {
+      // Catastrophic failure path — release ticket as failed and rethrow
+      // (the orchestrator's outer catch wires the operator notification).
+      await this.stateMachine.releaseTicket(
+        input.ticket.id,
+        DISPATCHER_AGENT_ID,
+        'failed',
+      );
+      throw err;
+    }
+
+    // Transition project state per outcome.
+    await this.stateMachine.transition(
+      this.projectIdOf(input.ticket.id),
+      result.finalState,
+      {
+        reason: result.reason,
+        triggeredBy: { kind: 'agent', id: DISPATCHER_AGENT_ID },
+        payload: {
+          composedKeys: Object.keys(result.composedArchitecture),
+          conflictCount: result.conflicts.length,
+        },
+      },
+    );
+
+    await this.stateMachine.releaseTicket(
+      input.ticket.id,
+      DISPATCHER_AGENT_ID,
+      result.finalState === 'ea-complete' ? 'done' : 'failed',
+    );
+
+    return result;
+  }
+
+  // ─── Internal — pure fan-out (no state-machine I/O) ─────────────────────
+
+  private async runFanout(input: DispatchInput): Promise<DispatchResult> {
+    // 1. Filter to applicable.
+    let candidates = this.architects;
+    if (input.rerunFor && input.rerunFor.length > 0) {
+      const names = input.rerunFor.map((r) => r.architect);
+      candidates = selectByName(candidates, names);
+    }
+    const { applicable, skipped } = partitionByApplies(candidates, input.ticket);
+
+    if (applicable.length === 0) {
+      const ticketId = input.ticket.id;
+      return {
+        ticketId,
+        composedArchitecture: {},
+        outputs: [],
+        telemetry: { calls: [], skipped },
+        finalState: 'ea-complete',
+        reason: 'no architects applied to this ticket',
+        conflicts: [],
+        plan: [],
+      };
+    }
+
+    // 2. Topo-sort into waves.
+    const waves = computeWaves(applicable);
+
+    // 3. Execute waves serially; members in parallel within each wave.
+    const allOutputs: ArchitectOutput[] = [];
+    const allCalls: ArchitectCallRecord[] = [];
+    const upstream: ArchitectUpstreamContext = { outputs: {} };
+    const upstreamMut = upstream.outputs as Record<string, ArchitectOutput>;
+
+    for (const wave of waves) {
+      const waveMembers = wave.members
+        .map((n) => applicable.find((a) => a.name === n))
+        .filter((a): a is SpecialistArchitect => !!a);
+      const waveOutputs = await this.runWave(waveMembers, input, upstream, allCalls);
+      for (const out of waveOutputs) {
+        allOutputs.push(out);
+        upstreamMut[out.architectName] = out;
+      }
+    }
+
+    // 4. Telemetry — flush call rows.
+    for (const row of allCalls) {
+      await this.telemetry.recordArchitectCall(row);
+    }
+
+    // 5. Compose disjoint-key.
+    let composed: Record<string, unknown> = {};
+    let reason = '';
+    let finalState: DispatchResult['finalState'] = 'ea-complete';
+    let conflicts: readonly ConflictRecord[] = [];
+    try {
+      const compose = composeArchitectOutputs(allOutputs);
+      composed = compose.composed;
+      reason = `composed ${Object.keys(composed).length} paths across ${allOutputs.length} architects`;
+    } catch (err) {
+      if (err instanceof CompositionError) {
+        // Hard failure — disjointness invariant violated.
+        finalState = 'ea-dispatching-failed';
+        reason = err.message;
+      } else {
+        throw err;
+      }
+    }
+
+    // 6. Detect + resolve conflicts when composition succeeded.
+    if (finalState === 'ea-complete') {
+      const fired = detectConflicts(composed, this.rules);
+      if (fired.length > 0) {
+        conflicts = resolveConflicts(fired, composed);
+      }
+    }
+
+    // 7. Check failure threshold.
+    const failedCount = allOutputs.filter((o) => o.status === 'failed').length;
+    const failureRatio = applicable.length > 0 ? failedCount / applicable.length : 0;
+    if (finalState === 'ea-complete' && failureRatio > this.opts.failureThreshold) {
+      finalState = 'ea-dispatching-failed';
+      reason = `${failedCount}/${applicable.length} architects failed (>${this.opts.failureThreshold * 100}% threshold)`;
+    }
+
+    return {
+      ticketId: input.ticket.id,
+      composedArchitecture: composed,
+      outputs: allOutputs,
+      telemetry: { calls: allCalls, skipped },
+      finalState,
+      reason,
+      conflicts,
+      plan: waves.map((w) => ({ wave: w.index, members: w.members })),
+    };
+  }
+
+  /**
+   * Run a single wave in parallel — respects `maxConcurrentSpawns` by
+   * sub-batching when the wave is larger.
+   */
+  private async runWave(
+    members: readonly SpecialistArchitect[],
+    dispatch: DispatchInput,
+    upstream: ArchitectUpstreamContext,
+    callsAcc: ArchitectCallRecord[],
+  ): Promise<readonly ArchitectOutput[]> {
+    const cap = this.opts.maxConcurrentSpawns;
+    const outputs: ArchitectOutput[] = [];
+    for (let i = 0; i < members.length; i += cap) {
+      const batch = members.slice(i, i + cap);
+      const batchOutputs = await Promise.all(
+        batch.map((arch) => this.runArchitect(arch, dispatch, upstream, callsAcc)),
+      );
+      outputs.push(...batchOutputs);
+    }
+    return outputs;
+  }
+
+  /**
+   * Run a single architect — apply the deadline, validate the output's
+   * key set, retry once on schema mismatch with the missing-key hint.
+   */
+  private async runArchitect(
+    arch: SpecialistArchitect,
+    dispatch: DispatchInput,
+    upstream: ArchitectUpstreamContext,
+    callsAcc: ArchitectCallRecord[],
+  ): Promise<ArchitectOutput> {
+    const input = this.makeArchitectInput(arch, dispatch, upstream);
+    const startedAt = this.clock.isoNow();
+    const startedMs = this.clock.now();
+
+    // Heartbeat — non-fatal if it errors.
+    void this.stateMachine
+      .heartbeat(dispatch.ticket.id, DISPATCHER_AGENT_ID)
+      .catch(() => undefined);
+
+    let out = await this.invoker.invoke(arch, input, this.opts.perArchitectTimeoutMs);
+    let retries = 0;
+
+    if (
+      this.opts.retryOnSchemaMismatch &&
+      shouldRetry(arch, out)
+    ) {
+      retries = 1;
+      const missing = missingPathsFor(arch, out);
+      const retryInput: ArchitectInput = {
+        ...input,
+        reviewerFeedback: {
+          reason: `previous output was missing required keys: ${missing.join(', ')}`,
+          severity: 'P1',
+          ...(input.reviewerFeedback ? { hints: input.reviewerFeedback.hints } : {}),
+        },
+      };
+      out = await this.invoker.invoke(arch, retryInput, this.opts.perArchitectTimeoutMs);
+
+      // Even after retry, if still mismatched we mark as failed.
+      if (shouldRetry(arch, out)) {
+        out = {
+          ...out,
+          status: 'failed',
+          failureReason: `schema mismatch after retry — still missing: ${missingPathsFor(arch, out).join(', ')}`,
+        };
+      }
+    }
+
+    const endedAt = this.clock.isoNow();
+    const endedMs = this.clock.now();
+    const row: ArchitectCallRecord = {
+      ticketId: dispatch.ticket.id,
+      architectName: arch.name,
+      status: out.status,
+      confidence: out.confidence,
+      spend: { ...out.spend, wallClockMs: out.spend.wallClockMs || endedMs - startedMs },
+      toolCalls: out.toolCalls,
+      notes: out.notes,
+      risks: out.risks,
+      retries,
+      startedAt,
+      endedAt,
+      ...(out.failureReason ? { failureReason: out.failureReason } : {}),
+    };
+    callsAcc.push(row);
+    return out;
+  }
+
+  private makeArchitectInput(
+    arch: SpecialistArchitect,
+    dispatch: DispatchInput,
+    upstream: ArchitectUpstreamContext,
+  ): ArchitectInput {
+    const rerun = dispatch.rerunFor?.find((r) => r.architect === arch.name);
+    const meta = arch.sectionContract.architectMeta;
+    return {
+      ticket: dispatch.ticket,
+      upstream,
+      businessPlan: dispatch.businessPlan,
+      designVersion: dispatch.designVersion,
+      tenantContext: dispatch.tenantContext,
+      budget: {
+        maxInputTokens: 60_000,
+        maxOutputTokens: 8_000,
+        maxWallClockMs: this.opts.perArchitectTimeoutMs,
+        preferredModel: meta.runtimeModel,
+        hardCostCeilingUsd: 1.0,
+      },
+      ...(rerun
+        ? {
+            reviewerFeedback: {
+              reason: rerun.reason,
+              severity: rerun.severity ?? 'P1',
+            },
+          }
+        : {}),
+    };
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function shouldRetry(
+  arch: SpecialistArchitect,
+  out: ArchitectOutput,
+): boolean {
+  if (out.status === 'failed') return false; // can't retry a failed output usefully without new info
+  return missingPathsFor(arch, out).length > 0;
+}
+
+function missingPathsFor(
+  arch: SpecialistArchitect,
+  out: ArchitectOutput,
+): readonly string[] {
+  const required = arch.sectionContract.sections
+    .filter((s) => s.required)
+    .map((s) => s.path);
+  return required.filter(
+    (p) => !(p in out.architectureFields) || out.architectureFields[p] == null,
+  );
+}
+
+// ─── Functional entrypoint ─────────────────────────────────────────────────
+
+/**
+ * Convenience: build a Dispatcher and run a single dispatch. The class
+ * surface is the canonical form; this functional flavour is handy in tests
+ * and scripts.
+ */
+export async function dispatch(
+  deps: DispatcherDeps,
+  input: DispatchInput,
+  opts?: DispatcherOptions,
+): Promise<DispatchResult> {
+  return new Dispatcher(deps, opts).dispatch(input);
+}

--- a/packages/ea-dispatcher/src/index.ts
+++ b/packages/ea-dispatcher/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @caia/ea-dispatcher — public surface.
+ */
+
+export { Dispatcher, dispatch, DISPATCHER_AGENT_ID } from './dispatcher.js';
+export type { DispatcherDeps } from './dispatcher.js';
+
+export type {
+  DispatchInput,
+  DispatchResult,
+  DispatcherOptions,
+  DispatchTelemetry,
+  ArchitectCallRecord,
+  ConflictRecord,
+  StateMachineAdapter,
+  ArchitectInvoker,
+  TelemetrySink,
+  Clock,
+} from './types.js';
+export { DEFAULT_DISPATCHER_OPTIONS } from './types.js';
+
+export {
+  composeArchitectOutputs,
+  composeArchitectOutputsLenient,
+  CompositionError,
+} from './composer.js';
+export type { ComposeResult, ComposeCollision } from './composer.js';
+
+export {
+  SEMANTIC_CONFLICT_RULES,
+  detectConflicts,
+  getPath,
+} from './conflict-rules.js';
+export type { SemanticConflictRule, FiredRule } from './conflict-rules.js';
+
+export {
+  resolveConflicts,
+  annotateDissent,
+  fieldBelongsTo,
+  winnerOf,
+} from './precedence-resolver.js';
+
+export { partitionByApplies, selectByName } from './applies.js';
+export type { AppliesPartition } from './applies.js';
+
+export {
+  DefaultArchitectInvoker,
+  InMemoryTelemetrySink,
+  NoopStateMachine,
+  SystemClock,
+  FrozenClock,
+} from './invoker.js';

--- a/packages/ea-dispatcher/src/invoker.ts
+++ b/packages/ea-dispatcher/src/invoker.ts
@@ -1,0 +1,161 @@
+/**
+ * @caia/ea-dispatcher — invoker.ts
+ *
+ * Default `ArchitectInvoker` implementation — wraps `architect.run(input)`
+ * with a wall-clock deadline. The dispatcher passes this in via DI so tests
+ * can swap in a mock that returns canned outputs without spawning Claude.
+ *
+ * The deadline implementation uses `Promise.race` against a `setTimeout`.
+ * If the timeout fires first, the invoker returns a synthetic `failed`
+ * output rather than throwing — keeping the dispatcher's invariant that
+ * a single architect's misbehavior never crashes the whole fan-out.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  SpecialistArchitect,
+} from '@caia/architect-kit';
+import type { ArchitectInvoker } from './types.js';
+
+export class DefaultArchitectInvoker implements ArchitectInvoker {
+  async invoke(
+    architect: SpecialistArchitect,
+    input: ArchitectInput,
+    deadlineMs: number,
+  ): Promise<ArchitectOutput> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<ArchitectOutput>((resolve) => {
+      timer = setTimeout(
+        () =>
+          resolve({
+            architectName: architect.name,
+            architectureFields: {},
+            confidence: 0,
+            notes: '',
+            dependencies: [],
+            risks: [],
+            toolCalls: [],
+            spend: {
+              inputTokens: 0,
+              outputTokens: 0,
+              usdCost: 0,
+              wallClockMs: deadlineMs,
+              model: 'timeout',
+            },
+            status: 'failed',
+            failureReason: `architect '${architect.name}' exceeded deadline of ${deadlineMs}ms`,
+          }),
+        deadlineMs,
+      );
+    });
+
+    try {
+      const result = await Promise.race([architect.run(input), timeout]);
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        architectName: architect.name,
+        architectureFields: {},
+        confidence: 0,
+        notes: '',
+        dependencies: [],
+        risks: [],
+        toolCalls: [],
+        spend: {
+          inputTokens: 0,
+          outputTokens: 0,
+          usdCost: 0,
+          wallClockMs: 0,
+          model: 'exception',
+        },
+        status: 'failed',
+        failureReason: `architect '${architect.name}' threw: ${message}`,
+      };
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+// ─── In-memory telemetry + clock + state-machine for tests ─────────────────
+
+import type {
+  ArchitectCallRecord,
+  Clock,
+  StateMachineAdapter,
+  TelemetrySink,
+} from './types.js';
+
+export class InMemoryTelemetrySink implements TelemetrySink {
+  readonly rows: ArchitectCallRecord[] = [];
+  async recordArchitectCall(row: ArchitectCallRecord): Promise<void> {
+    this.rows.push(row);
+  }
+  clear(): void {
+    this.rows.length = 0;
+  }
+}
+
+export class SystemClock implements Clock {
+  now(): number {
+    return Date.now();
+  }
+  isoNow(): string {
+    return new Date().toISOString();
+  }
+}
+
+export class FrozenClock implements Clock {
+  constructor(private millis: number = Date.parse('2026-01-01T00:00:00Z')) {}
+  now(): number {
+    return this.millis;
+  }
+  isoNow(): string {
+    return new Date(this.millis).toISOString();
+  }
+  advance(by: number): void {
+    this.millis += by;
+  }
+}
+
+/** No-op state machine — tests that don't care about transitions. */
+export class NoopStateMachine implements StateMachineAdapter {
+  readonly transitions: Array<{
+    projectId: string;
+    toState: string;
+    reason: string;
+  }> = [];
+  readonly claims: Array<{ ticketId: string; agentId: string }> = [];
+  readonly heartbeats: Array<{ ticketId: string; agentId: string }> = [];
+  readonly releases: Array<{
+    ticketId: string;
+    agentId: string;
+    finalStatus: string;
+  }> = [];
+
+  async claimTicketForAgent(ticketId: string, agentId: string): Promise<{ claimed: boolean }> {
+    this.claims.push({ ticketId, agentId });
+    return { claimed: true };
+  }
+  async heartbeat(ticketId: string, agentId: string): Promise<void> {
+    this.heartbeats.push({ ticketId, agentId });
+  }
+  async releaseTicket(
+    ticketId: string,
+    agentId: string,
+    finalStatus: 'done' | 'failed' | 'aborted',
+  ): Promise<{ ok: boolean }> {
+    this.releases.push({ ticketId, agentId, finalStatus });
+    return { ok: true };
+  }
+  async transition(
+    projectId: string,
+    toState: 'ea-complete' | 'ea-dispatching-failed' | 'ea-dispatching',
+    opts: { reason: string; triggeredBy: { kind: 'agent'; id: string } },
+  ): Promise<{ applied: boolean }> {
+    this.transitions.push({ projectId, toState, reason: opts.reason });
+    return { applied: true };
+  }
+}

--- a/packages/ea-dispatcher/src/precedence-resolver.ts
+++ b/packages/ea-dispatcher/src/precedence-resolver.ts
@@ -1,0 +1,146 @@
+/**
+ * @caia/ea-dispatcher — precedence-resolver.ts
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §5.2.
+ *
+ * Given a set of fired semantic-conflict rules, resolve each one by:
+ *  1. Looking up the two architects' ranks in `CANONICAL_PRECEDENCE_LADDER`.
+ *  2. Annotating the lower-precedence architect's field with `_dissent`.
+ *  3. Leaving the higher-precedence field unmodified.
+ *  4. If both architects are at the same rank (or both unknown to the
+ *     ladder), surfacing the conflict as `escalated: true` — the reviewer
+ *     decides what to do.
+ *
+ * Mutates the composed blob in place (it's a fresh object owned by the
+ * dispatcher; this is fine).
+ */
+
+import {
+  CANONICAL_PRECEDENCE_LADDER,
+  higherPrecedence,
+  precedenceRank,
+  type ArchitectName,
+} from '@caia/architect-kit';
+import type { ConflictRecord } from './types.js';
+import type { FiredRule } from './conflict-rules.js';
+
+/**
+ * Apply the precedence ladder to the fired rules. Returns the set of
+ * resolved `ConflictRecord`s for the dispatcher's audit trail.
+ */
+export function resolveConflicts(
+  fired: readonly FiredRule[],
+  composed: Record<string, unknown>,
+  ladder: readonly ArchitectName[] = CANONICAL_PRECEDENCE_LADDER,
+): readonly ConflictRecord[] {
+  const out: ConflictRecord[] = [];
+  for (const { rule } of fired) {
+    const [a, b] = rule.architects;
+    // Same-architect rules (e.g. frontend tokens vs frontend breakpoints) —
+    // can't apply inter-precedence; surface as escalation.
+    if (a === b) {
+      out.push({
+        ruleId: rule.id,
+        winner: a,
+        loser: b,
+        fields: rule.fields,
+        escalated: true,
+      });
+      continue;
+    }
+    const winner = higherPrecedence(a, b, ladder);
+    if (winner === null) {
+      // Same rank or both unknown — escalate.
+      out.push({
+        ruleId: rule.id,
+        winner: a,
+        loser: b,
+        fields: rule.fields,
+        escalated: true,
+      });
+      continue;
+    }
+    const loser = winner === a ? b : a;
+    // Annotate the loser's field with _dissent. We only annotate fields
+    // that are owned by the loser — we identify them by prefix matching
+    // against the architect name.
+    for (const field of rule.fields) {
+      // Only annotate if this field's prefix matches the loser. The fields
+      // list in a rule includes both sides; we want to flag the loser only.
+      if (!fieldBelongsTo(field, loser)) continue;
+      annotateDissent(composed, field, {
+        conflictsWith: winner,
+        overriddenReason: rule.id,
+      });
+    }
+    out.push({
+      ruleId: rule.id,
+      winner,
+      loser,
+      fields: rule.fields,
+      escalated: false,
+    });
+  }
+  return out;
+}
+
+/**
+ * The architect that owns a path = the path's first dotted segment maps to
+ * the architect's name. e.g. `'frontend.componentTree'` → `frontend`.
+ *
+ * We use this convention everywhere; the SectionContract paths follow it.
+ */
+export function fieldBelongsTo(
+  fieldPath: string,
+  architectName: ArchitectName,
+): boolean {
+  const prefix = fieldPath.split('.')[0];
+  if (!prefix) return false;
+  // Direct match
+  if (prefix === architectName) return true;
+  // Some architects own sub-namespaces with a different prefix.
+  // e.g. featureFlagging owns `featureFlags.*`.
+  const aliasMap: Record<string, readonly string[]> = {
+    featureFlagging: ['featureFlags'],
+    accessibility: ['a11y'],
+  };
+  return (aliasMap[architectName] ?? []).includes(prefix);
+}
+
+/**
+ * Annotate a field's value with a `_dissent` block. If the value is already
+ * an object, merges `_dissent` into it; otherwise wraps it in
+ * `{ value: <original>, _dissent: {...} }` so we don't lose the original.
+ */
+export function annotateDissent(
+  composed: Record<string, unknown>,
+  path: string,
+  dissent: { conflictsWith: ArchitectName; overriddenReason: string },
+): void {
+  const original = composed[path];
+  if (original === undefined) {
+    // Field doesn't actually exist — record dissent on its own.
+    composed[path] = { _dissent: dissent };
+    return;
+  }
+  if (typeof original === 'object' && original !== null && !Array.isArray(original)) {
+    composed[path] = { ...(original as Record<string, unknown>), _dissent: dissent };
+    return;
+  }
+  composed[path] = { value: original, _dissent: dissent };
+}
+
+/**
+ * Pure helper — given two architect names, return the one that wins under
+ * the canonical ladder, or null on tie / both unknown.
+ */
+export function winnerOf(
+  a: ArchitectName,
+  b: ArchitectName,
+  ladder: readonly ArchitectName[] = CANONICAL_PRECEDENCE_LADDER,
+): { winner: ArchitectName | null; ranks: [number, number] } {
+  return {
+    winner: higherPrecedence(a, b, ladder),
+    ranks: [precedenceRank(a, ladder), precedenceRank(b, ladder)],
+  };
+}

--- a/packages/ea-dispatcher/src/types.ts
+++ b/packages/ea-dispatcher/src/types.ts
@@ -1,0 +1,216 @@
+/**
+ * @caia/ea-dispatcher — dispatcher-specific types.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §3.
+ *
+ * Design notes:
+ *  - The dispatcher is dependency-injected against its non-trivial collaborators
+ *    (state machine, spawner, telemetry sink, clock) so it stays trivial to test
+ *    and can be PR'd against develop without those packages also being merged.
+ *  - All collaborator interfaces declared here are structurally typed — the
+ *    concrete implementations in `@caia/state-machine`, `@chiefaia/claude-spawner`,
+ *    and the orchestrator's telemetry sink match by shape, not by import.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectName,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  Ticket,
+  SpecialistArchitect,
+} from '@caia/architect-kit';
+
+// ─── Inputs to the dispatcher ──────────────────────────────────────────────
+
+export interface DispatchInput {
+  ticket: Ticket;
+  businessPlan: BusinessPlan;
+  designVersion: RenderableDesign;
+  tenantContext: TenantContext;
+  /**
+   * Reviewer feedback from a prior cycle — when non-empty, the dispatcher
+   * re-runs ONLY the named architects, not the full roster.
+   */
+  rerunFor?: ReadonlyArray<{ architect: ArchitectName; reason: string; severity?: 'P0' | 'P1' | 'P2' }>;
+  /**
+   * Iteration counter for the reviewer ↔ dispatcher loop. Past `MAX_ITERATIONS`
+   * (spec §6.3 = 3) the dispatcher refuses to fan out and the orchestrator
+   * must escalate to operator.
+   */
+  iteration?: number;
+}
+
+// ─── Outputs from the dispatcher ───────────────────────────────────────────
+
+export interface ArchitectCallRecord {
+  ticketId: string;
+  architectName: ArchitectName;
+  status: ArchitectOutput['status'];
+  confidence: number;
+  spend: ArchitectOutput['spend'];
+  toolCalls: ArchitectOutput['toolCalls'];
+  notes: string;
+  risks: readonly string[];
+  /** Retries the dispatcher consumed (0 = first attempt succeeded). */
+  retries: number;
+  /** Wall-clock start, ISO-8601. */
+  startedAt: string;
+  /** Wall-clock end, ISO-8601. */
+  endedAt: string;
+  failureReason?: string;
+}
+
+export interface DispatchTelemetry {
+  /** All architects the dispatcher attempted, in finish-time order. */
+  calls: readonly ArchitectCallRecord[];
+  /** Architects the appliesPredicate filtered out (silent skip — not failures). */
+  skipped: readonly ArchitectName[];
+}
+
+export interface DispatchResult {
+  ticketId: string;
+  /** Final composed architecture blob (the value to UPDATE tickets.architecture with). */
+  composedArchitecture: Record<string, unknown>;
+  /** Per-architect outcomes, success and failure alike. */
+  outputs: readonly ArchitectOutput[];
+  /** Aggregated telemetry — used by the orchestrator to write audit rows. */
+  telemetry: DispatchTelemetry;
+  /** Final state the dispatcher transitioned the ticket to. */
+  finalState: 'ea-complete' | 'ea-dispatching-failed';
+  /** Why this state — short reason. */
+  reason: string;
+  /**
+   * Semantic conflicts the dispatcher detected, after composition. Lower-
+   * precedence architects' fields carry `_dissent` annotations; this list
+   * lets the reviewer surface them.
+   */
+  conflicts: readonly ConflictRecord[];
+  /** Wave-by-wave execution plan, for logs + dashboard rendering. */
+  plan: readonly { wave: number; members: readonly ArchitectName[] }[];
+}
+
+export interface ConflictRecord {
+  ruleId: string;
+  winner: ArchitectName;
+  loser: ArchitectName;
+  /** Field paths the conflict touched. */
+  fields: readonly string[];
+  /** Whether this conflict required escalation (same-rank tie). */
+  escalated: boolean;
+}
+
+// ─── Collaborator interfaces (DI seams) ────────────────────────────────────
+
+/**
+ * State-machine adapter — the dispatcher calls these methods to claim,
+ * heartbeat, release the ticket and transition the project state. The
+ * real implementation is the `StateMachine` class in `@caia/state-machine`;
+ * tests use the in-memory mock.
+ */
+export interface StateMachineAdapter {
+  claimTicketForAgent(
+    ticketId: string,
+    agentId: string,
+    opts?: { ttlSeconds?: number; projectId?: string },
+  ): Promise<{ claimed: boolean }>;
+  heartbeat(ticketId: string, agentId: string): Promise<void>;
+  releaseTicket(
+    ticketId: string,
+    agentId: string,
+    finalStatus: 'done' | 'failed' | 'aborted',
+  ): Promise<{ ok: boolean }>;
+  transition(
+    projectId: string,
+    toState: 'ea-complete' | 'ea-dispatching-failed' | 'ea-dispatching',
+    opts: {
+      reason: string;
+      triggeredBy: { kind: 'agent'; id: string };
+      payload?: Record<string, unknown>;
+    },
+  ): Promise<{ applied: boolean }>;
+}
+
+/**
+ * Spawner adapter — the dispatcher delegates the actual LLM call to the
+ * concrete `SpecialistArchitect.run()` of each architect. This adapter
+ * exists so the dispatcher can wrap each call with a deadline, capture
+ * spend telemetry, and inject reviewer feedback.
+ *
+ * In production, this is a thin wrapper over the architect's `run()`. In
+ * tests, this is a mock that returns canned outputs without spawning Claude.
+ */
+export interface ArchitectInvoker {
+  /**
+   * Invoke `architect.run(input)` with a wall-clock timeout. Returns the
+   * architect's output (which may itself be `failed` if the architect chose
+   * to handle the timeout internally). Throws only on truly catastrophic
+   * faults (e.g. the architect threw an uncaught exception); the dispatcher
+   * converts these into `failed` outputs.
+   */
+  invoke(
+    architect: SpecialistArchitect,
+    input: ArchitectInput,
+    deadlineMs: number,
+  ): Promise<ArchitectOutput>;
+}
+
+/**
+ * Telemetry sink — receives per-call ArchitectCallRecord rows. Implementations:
+ *  - Production: writes to `tickets_architect_calls` (Postgres) per spec §3.5
+ *    and emits an OTel span per spec §10.
+ *  - Tests: an in-memory array.
+ */
+export interface TelemetrySink {
+  recordArchitectCall(row: ArchitectCallRecord): Promise<void>;
+}
+
+/** Wall-clock for deterministic testing. */
+export interface Clock {
+  now(): number;
+  /** Returns an ISO-8601 timestamp at the current instant. */
+  isoNow(): string;
+}
+
+// ─── Configuration ─────────────────────────────────────────────────────────
+
+export interface DispatcherOptions {
+  /**
+   * Per-architect maximum wall-clock budget. Defaults to 60_000 (60s) per
+   * spec §1.1 ArchitectBudget default.
+   */
+  perArchitectTimeoutMs?: number;
+  /**
+   * Maximum number of architects to spawn concurrently within a single wave.
+   * Defaults to 30 (a comfortable upper bound for the 17-architect roster).
+   * Larger waves are sub-batched.
+   */
+  maxConcurrentSpawns?: number;
+  /**
+   * Retry-once policy: on schema-mismatch (missing required path / extra
+   * path), the dispatcher retries the architect once with a corrected
+   * prompt fragment. Defaults to true per spec §3.4.
+   */
+  retryOnSchemaMismatch?: boolean;
+  /** Hard cap on reviewer ↔ dispatcher iterations. Defaults to 3 per spec §6.3. */
+  maxIterations?: number;
+  /**
+   * Threshold for `ea-dispatching-failed`. If more than this fraction of the
+   * applicable architects fail, the dispatcher refuses to compose and
+   * transitions to `ea-dispatching-failed`. Defaults to 0.5 per spec §3.7.
+   */
+  failureThreshold?: number;
+  /** Optional ticket-claim TTL in seconds. Defaults to 600 (10 minutes). */
+  claimTtlSeconds?: number;
+}
+
+export const DEFAULT_DISPATCHER_OPTIONS: Required<DispatcherOptions> = {
+  perArchitectTimeoutMs: 60_000,
+  maxConcurrentSpawns: 30,
+  retryOnSchemaMismatch: true,
+  maxIterations: 3,
+  failureThreshold: 0.5,
+  claimTtlSeconds: 600,
+};

--- a/packages/ea-dispatcher/tests/applies.test.ts
+++ b/packages/ea-dispatcher/tests/applies.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { partitionByApplies, selectByName } from '../src/applies.js';
+import { MockArchitect, makeContract, stubTicket } from './fixtures.js';
+
+describe('partitionByApplies', () => {
+  it('passes architects whose predicate returns true', () => {
+    const arch = new MockArchitect(
+      'a',
+      makeContract('a', ['a.x'], { appliesPredicate: () => true }),
+    );
+    const { applicable, skipped } = partitionByApplies([arch], stubTicket());
+    expect(applicable.map((a) => a.name)).toEqual(['a']);
+    expect(skipped).toEqual([]);
+  });
+
+  it('skips architects whose predicate returns false', () => {
+    const arch = new MockArchitect(
+      'a',
+      makeContract('a', ['a.x'], { appliesPredicate: () => false }),
+    );
+    const { applicable, skipped } = partitionByApplies([arch], stubTicket());
+    expect(applicable).toEqual([]);
+    expect(skipped).toEqual(['a']);
+  });
+
+  it('treats a throwing predicate as skipped (defensive)', () => {
+    const arch = new MockArchitect(
+      'a',
+      makeContract('a', ['a.x'], {
+        appliesPredicate: () => {
+          throw new Error('boom');
+        },
+      }),
+    );
+    const { applicable, skipped } = partitionByApplies([arch], stubTicket());
+    expect(applicable).toEqual([]);
+    expect(skipped).toEqual(['a']);
+  });
+
+  it('routes architects by ticket type', () => {
+    const pageOnly = new MockArchitect(
+      'pageOnly',
+      makeContract('pageOnly', ['p.x'], { appliesPredicate: (t) => t.type === 'Page' }),
+    );
+    const widgetOnly = new MockArchitect(
+      'widgetOnly',
+      makeContract('widgetOnly', ['w.x'], { appliesPredicate: (t) => t.type === 'Widget' }),
+    );
+    const archs = [pageOnly, widgetOnly];
+
+    const onPage = partitionByApplies(archs, stubTicket({ type: 'Page' }));
+    expect(onPage.applicable.map((a) => a.name)).toEqual(['pageOnly']);
+    expect(onPage.skipped).toEqual(['widgetOnly']);
+
+    const onWidget = partitionByApplies(archs, stubTicket({ type: 'Widget' }));
+    expect(onWidget.applicable.map((a) => a.name)).toEqual(['widgetOnly']);
+  });
+
+  it('routes architects by quality_tags (seo, a11y, performance)', () => {
+    const seo = new MockArchitect(
+      'seo',
+      makeContract('seo', ['seo.title'], {
+        appliesPredicate: (t) => (t.quality_tags ?? []).includes('seo'),
+      }),
+    );
+    const seoTicket = stubTicket({ quality_tags: ['seo'] });
+    const noSeo = stubTicket({ quality_tags: [] });
+    expect(partitionByApplies([seo], seoTicket).applicable.length).toBe(1);
+    expect(partitionByApplies([seo], noSeo).applicable.length).toBe(0);
+  });
+});
+
+describe('selectByName', () => {
+  const a = new MockArchitect('a', makeContract('a', ['a.x']));
+  const b = new MockArchitect('b', makeContract('b', ['b.x']));
+  const c = new MockArchitect('c', makeContract('c', ['c.x']));
+
+  it('returns the named subset in input order', () => {
+    expect(selectByName([a, b, c], ['c', 'a']).map((x) => x.name)).toEqual(['a', 'c']);
+  });
+
+  it('returns empty for an empty name list', () => {
+    expect(selectByName([a, b, c], [])).toEqual([]);
+  });
+
+  it('ignores names not in the set', () => {
+    expect(selectByName([a, b], ['ghost', 'b']).map((x) => x.name)).toEqual(['b']);
+  });
+});

--- a/packages/ea-dispatcher/tests/composer.test.ts
+++ b/packages/ea-dispatcher/tests/composer.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  composeArchitectOutputs,
+  composeArchitectOutputsLenient,
+  CompositionError,
+} from '../src/composer.js';
+import type { ArchitectOutput } from '@caia/architect-kit';
+
+function out(
+  name: string,
+  fields: Record<string, unknown>,
+  status: ArchitectOutput['status'] = 'ok',
+): ArchitectOutput {
+  return {
+    architectName: name,
+    architectureFields: fields,
+    confidence: 0.9,
+    notes: '',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'mock' },
+    status,
+  };
+}
+
+describe('composeArchitectOutputs — disjoint-key merge', () => {
+  it('merges disjoint fields from multiple architects', () => {
+    const r = composeArchitectOutputs([
+      out('a', { 'a.x': 1 }),
+      out('b', { 'b.x': 2 }),
+    ]);
+    expect(r.composed).toEqual({ 'a.x': 1, 'b.x': 2 });
+  });
+
+  it('returns empty for empty input', () => {
+    expect(composeArchitectOutputs([]).composed).toEqual({});
+  });
+
+  it('skips outputs with status=failed', () => {
+    const r = composeArchitectOutputs([
+      out('a', { 'a.x': 1 }),
+      out('bad', { 'bad.x': 'IGNORED' }, 'failed'),
+    ]);
+    expect(r.composed).toEqual({ 'a.x': 1 });
+    expect(r.skippedFailed).toEqual(['bad']);
+  });
+
+  it('includes partial outputs in the composition', () => {
+    const r = composeArchitectOutputs([
+      out('a', { 'a.x': 1 }, 'partial'),
+      out('b', { 'b.x': 2 }),
+    ]);
+    expect(r.composed).toEqual({ 'a.x': 1, 'b.x': 2 });
+    expect(r.partialContributors).toEqual(['a']);
+  });
+
+  it('throws CompositionError when two architects claim the same path', () => {
+    expect(() =>
+      composeArchitectOutputs([
+        out('a', { 'shared.x': 1 }),
+        out('b', { 'shared.x': 2 }),
+      ]),
+    ).toThrow(CompositionError);
+  });
+
+  it('CompositionError carries the conflicting paths', () => {
+    try {
+      composeArchitectOutputs([
+        out('a', { 'shared.x': 1 }),
+        out('b', { 'shared.x': 2 }),
+      ]);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CompositionError);
+      const e = err as CompositionError;
+      expect(e.collisions.map((c) => c.path)).toEqual(['shared.x']);
+      expect(e.collisions[0]?.claimedBy).toEqual(['a', 'b']);
+    }
+  });
+
+  it('lenient flavour records collisions instead of throwing', () => {
+    const r = composeArchitectOutputsLenient([
+      out('a', { 'shared.x': 1 }),
+      out('b', { 'shared.x': 2 }),
+    ]);
+    expect(r.collisions).toEqual([{ path: 'shared.x', claimedBy: ['a', 'b'] }]);
+    // last-write-wins under lenient
+    expect(r.composed['shared.x']).toBe(2);
+  });
+
+  it('preserves the original value (no mutation across calls)', () => {
+    const fields = { 'a.x': { nested: 1 } };
+    const r = composeArchitectOutputs([out('a', fields)]);
+    expect(r.composed).not.toBe(fields);
+  });
+
+  it('returns a fresh object on every call', () => {
+    const r1 = composeArchitectOutputs([out('a', { x: 1 })]);
+    const r2 = composeArchitectOutputs([out('a', { x: 1 })]);
+    expect(r1.composed).not.toBe(r2.composed);
+  });
+});

--- a/packages/ea-dispatcher/tests/concurrency.test.ts
+++ b/packages/ea-dispatcher/tests/concurrency.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Concurrency tests — assert the dispatcher fans architects out in parallel
+ * within a wave (not serially) and respects `maxConcurrentSpawns`.
+ */
+import { describe, it, expect } from 'vitest';
+import { dispatch } from '../src/dispatcher.js';
+import {
+  MockArchitect,
+  makeContract,
+  seventeenArchitectSet,
+  stubDispatch,
+} from './fixtures.js';
+
+describe('dispatcher concurrency', () => {
+  it('runs wave-1 architects in parallel (total wall-clock ≈ slowest, not sum)', async () => {
+    // Three architects with 100ms latency. Parallel ≈ 100ms; serial ≈ 300ms.
+    const archs = [
+      new MockArchitect('a', makeContract('a', ['a.x']), { latencyMs: 100 }),
+      new MockArchitect('b', makeContract('b', ['b.x']), { latencyMs: 100 }),
+      new MockArchitect('c', makeContract('c', ['c.x']), { latencyMs: 100 }),
+    ];
+    const start = Date.now();
+    await dispatch({ architects: archs }, stubDispatch());
+    const elapsed = Date.now() - start;
+    // Generous upper bound — far less than 3 * 100ms = 300ms (serial baseline).
+    expect(elapsed).toBeLessThan(250);
+    expect(elapsed).toBeGreaterThanOrEqual(95);
+  });
+
+  it('serializes waves but parallelizes within (so 100ms + 100ms wave ≈ 200ms)', async () => {
+    // wave 1 has one architect; wave 2 has one architect that depends on wave 1.
+    const w1 = new MockArchitect('w1', makeContract('w1', ['w1.x']), { latencyMs: 100 });
+    const w2 = new MockArchitect(
+      'w2',
+      makeContract('w2', ['w2.x'], { dependsOn: ['w1'] }),
+      { latencyMs: 100 },
+    );
+    const start = Date.now();
+    await dispatch({ architects: [w1, w2] }, stubDispatch());
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(190);
+    expect(elapsed).toBeLessThan(350);
+  });
+
+  it('handles 17 architects in <= ~5 latency-units when graph is shallow', async () => {
+    // Each architect has 50ms latency. The 17-architect graph has depth ~4.
+    // Parallel sum should be roughly 4 * 50 = 200ms (plus dispatcher overhead).
+    const archs = seventeenArchitectSet().map(
+      (a) =>
+        new MockArchitect(a.name, a.sectionContract, {
+          latencyMs: 50,
+          fields: Object.fromEntries(
+            a.sectionContract.sections.map((s) => [s.path, 'x']),
+          ),
+        }),
+    );
+    const start = Date.now();
+    const result = await dispatch({ architects: archs }, stubDispatch());
+    const elapsed = Date.now() - start;
+    expect(result.outputs.length).toBe(17);
+    expect(elapsed).toBeLessThan(600); // generous — 4 waves of 50ms parallel
+  });
+
+  it('respects maxConcurrentSpawns by sub-batching a wide wave', async () => {
+    const concurrencyHits: number[] = [];
+    let active = 0;
+    const wide = Array.from({ length: 10 }, (_, i) => {
+      return new MockArchitect(
+        `w${i}`,
+        makeContract(`w${i}`, [`w${i}.x`]),
+        {
+          latencyMs: 30,
+          onRun: () => {
+            active += 1;
+            concurrencyHits.push(active);
+            setTimeout(() => {
+              active -= 1;
+            }, 30);
+          },
+        },
+      );
+    });
+    await dispatch({ architects: wide }, stubDispatch(), { maxConcurrentSpawns: 3 });
+    // We should observe waves of ≤3 concurrent runs, not 10.
+    expect(Math.max(...concurrencyHits)).toBeLessThanOrEqual(3);
+  });
+
+  it('all 17 architects compose into 17 union of section paths', async () => {
+    const archs = seventeenArchitectSet();
+    const result = await dispatch({ architects: archs }, stubDispatch());
+    const allDeclared = archs.flatMap((a) =>
+      a.sectionContract.sections.map((s) => s.path),
+    );
+    // Every declared path appears in the composed architecture
+    for (const p of allDeclared) {
+      expect(result.composedArchitecture).toHaveProperty(p);
+    }
+    expect(Object.keys(result.composedArchitecture).length).toBe(allDeclared.length);
+  });
+
+  it('cap=1 forces serial execution (≈ sum of latencies)', async () => {
+    const archs = [
+      new MockArchitect('a', makeContract('a', ['a.x']), { latencyMs: 60 }),
+      new MockArchitect('b', makeContract('b', ['b.x']), { latencyMs: 60 }),
+      new MockArchitect('c', makeContract('c', ['c.x']), { latencyMs: 60 }),
+    ];
+    const start = Date.now();
+    await dispatch({ architects: archs }, stubDispatch(), { maxConcurrentSpawns: 1 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(170);
+  });
+});

--- a/packages/ea-dispatcher/tests/conflict-rules.test.ts
+++ b/packages/ea-dispatcher/tests/conflict-rules.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectConflicts,
+  SEMANTIC_CONFLICT_RULES,
+  getPath,
+} from '../src/conflict-rules.js';
+
+describe('semantic conflict rules', () => {
+  it('exports a non-empty rule set', () => {
+    expect(SEMANTIC_CONFLICT_RULES.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every rule declares fields and architects', () => {
+    for (const r of SEMANTIC_CONFLICT_RULES) {
+      expect(r.id).toBeTruthy();
+      expect(r.architects.length).toBe(2);
+      expect(r.fields.length).toBeGreaterThan(0);
+      expect(typeof r.detect).toBe('function');
+    }
+  });
+
+  it('rule ids are unique', () => {
+    const ids = SEMANTIC_CONFLICT_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('detect returns empty array for an empty composed blob', () => {
+    expect(detectConflicts({})).toEqual([]);
+  });
+
+  it('image-lazy-vs-preload fires when SEO preloads a lazy-loaded image', () => {
+    const composed = {
+      'performance.lazyLoadList': [{ src: 'hero.jpg' }],
+      'seo.preloadHints': [{ href: 'hero.jpg' }],
+    };
+    const fired = detectConflicts(composed).map((f) => f.rule.id);
+    expect(fired).toContain('image-lazy-vs-preload');
+  });
+
+  it('image-lazy-vs-preload does NOT fire when sets are disjoint', () => {
+    const composed = {
+      'performance.lazyLoadList': [{ src: 'a.jpg' }],
+      'seo.preloadHints': [{ href: 'b.jpg' }],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).not.toContain(
+      'image-lazy-vs-preload',
+    );
+  });
+
+  it('csp-frame-vs-iframe-embed fires when CSP forbids iframes but tree has one', () => {
+    const composed = {
+      'security.cspPolicy': { frameSrc: "'none'" },
+      'frontend.componentTree': [{ kind: 'iframe-embed' }],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'csp-frame-vs-iframe-embed',
+    );
+  });
+
+  it('csp-frame-vs-iframe-embed does NOT fire when no iframe widget', () => {
+    const composed = {
+      'security.cspPolicy': { frameSrc: "'none'" },
+      'frontend.componentTree': [{ kind: 'button' }],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).not.toContain(
+      'csp-frame-vs-iframe-embed',
+    );
+  });
+
+  it('analytics-event-without-observability-metric fires for orphan event', () => {
+    const composed = {
+      'analytics.eventTaxonomy': [{ name: 'signup' }],
+      'observability.metricsExport': [{ event: 'login' }],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'analytics-event-without-observability-metric',
+    );
+  });
+
+  it('endpoint-without-gateway-ratelimit fires for unprotected endpoint', () => {
+    const composed = {
+      'backend.endpointEnumeration': [{ path: '/api/users' }],
+      'apiGateway.rateLimit': [{ path: '/api/posts' }],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'endpoint-without-gateway-ratelimit',
+    );
+  });
+
+  it('interactive-widget-without-keyboard-spec fires when keyboard missing', () => {
+    const composed = {
+      'frontend.componentTree': [{ id: 'btn-1', interactive: true }],
+      'a11y.keyboardSpec': [],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'interactive-widget-without-keyboard-spec',
+    );
+  });
+
+  it('flag-without-killswitch fires for unguarded flag', () => {
+    const composed = {
+      'featureFlags.flagStore': [{ name: 'newCheckout' }],
+      'featureFlags.killSwitch': [],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'flag-without-killswitch',
+    );
+  });
+
+  it('ab-test-without-flag-binding fires for missing flag', () => {
+    const composed = {
+      'abTesting.variantRouter': [{ flag: 'missing' }],
+      'featureFlags.flagStore': [{ name: 'other' }],
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'ab-test-without-flag-binding',
+    );
+  });
+
+  it('image-policy-vs-seo-og-image fires when OG image exceeds budget', () => {
+    const composed = {
+      'seo.ogImage': { sizeKb: 500 },
+      'performance.imagePolicy': { maxKb: 200 },
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'image-policy-vs-seo-og-image',
+    );
+  });
+
+  it('consent-vs-analytics-default fires on permissive consent + PII data', () => {
+    const composed = {
+      'analytics.consentMode': 'opt-in',
+      'security.dataClassification': 'PII',
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'consent-vs-analytics-default',
+    );
+  });
+
+  it('deploy-without-rollback fires when blue-green has no revert', () => {
+    const composed = {
+      'devops.deployStrategy': 'blue-green',
+      'timeMachine.revertCommand': '',
+    };
+    expect(detectConflicts(composed).map((f) => f.rule.id)).toContain(
+      'deploy-without-rollback',
+    );
+  });
+
+  it('does not fire when fields are absent', () => {
+    expect(detectConflicts({}).length).toBe(0);
+  });
+
+  it('a buggy rule predicate does not crash the detector', () => {
+    const buggy = [
+      ...SEMANTIC_CONFLICT_RULES,
+      {
+        id: 'boom',
+        description: 'always throws',
+        architects: ['a', 'b'] as [string, string],
+        fields: ['x'],
+        detect: () => {
+          throw new Error('nope');
+        },
+      },
+    ];
+    // The buggy rule is silently dropped; the rest still run.
+    const fired = detectConflicts(
+      { 'performance.lazyLoadList': [{ src: 'x' }], 'seo.preloadHints': [{ href: 'x' }] },
+      buggy,
+    );
+    expect(fired.map((f) => f.rule.id)).toContain('image-lazy-vs-preload');
+    expect(fired.map((f) => f.rule.id)).not.toContain('boom');
+  });
+});
+
+describe('getPath', () => {
+  it('reads a flat dotted-key', () => {
+    expect(getPath({ 'a.b': 1 }, 'a.b')).toBe(1);
+  });
+
+  it('falls back to nested lookup', () => {
+    expect(getPath({ a: { b: 1 } }, 'a.b')).toBe(1);
+  });
+
+  it('returns undefined for missing paths', () => {
+    expect(getPath({}, 'a.b')).toBeUndefined();
+  });
+});

--- a/packages/ea-dispatcher/tests/dispatcher.test.ts
+++ b/packages/ea-dispatcher/tests/dispatcher.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import { Dispatcher, dispatch } from '../src/dispatcher.js';
+import {
+  InMemoryTelemetrySink,
+  NoopStateMachine,
+  FrozenClock,
+} from '../src/invoker.js';
+import {
+  MockArchitect,
+  makeContract,
+  stubDispatch,
+  stubTicket,
+  threeArchitectSet,
+} from './fixtures.js';
+
+describe('Dispatcher.dispatch — end-to-end', () => {
+  it('runs a single architect and composes its output', async () => {
+    const arch = new MockArchitect(
+      'frontend',
+      makeContract('frontend', ['frontend.framework']),
+    );
+    const result = await dispatch({ architects: [arch] }, stubDispatch());
+    expect(result.finalState).toBe('ea-complete');
+    expect(result.composedArchitecture).toEqual({
+      'frontend.framework': 'val-frontend.framework',
+    });
+    expect(result.outputs.length).toBe(1);
+    expect(result.outputs[0]?.status).toBe('ok');
+  });
+
+  it('produces a deterministic execution plan reflecting the wave order', async () => {
+    const archs = threeArchitectSet();
+    const result = await dispatch({ architects: archs }, stubDispatch());
+    expect(result.plan.length).toBe(2);
+    expect(result.plan[0]?.members).toEqual(['frontend']);
+    expect(result.plan[1]?.members).toEqual(['a11y', 'performance']);
+  });
+
+  it('makes upstream outputs visible to wave-2 architects', async () => {
+    let seenUpstream: Record<string, unknown> = {};
+    const frontend = new MockArchitect(
+      'frontend',
+      makeContract('frontend', ['frontend.x']),
+    );
+    const a11y = new MockArchitect(
+      'a11y',
+      makeContract('a11y', ['a11y.x'], { dependsOn: ['frontend'] }),
+      {
+        onRun: (input) => {
+          seenUpstream = { ...input.upstream.outputs };
+        },
+      },
+    );
+    await dispatch({ architects: [frontend, a11y] }, stubDispatch());
+    expect(seenUpstream).toHaveProperty('frontend');
+  });
+
+  it('emits one telemetry row per architect call', async () => {
+    const telemetry = new InMemoryTelemetrySink();
+    const archs = threeArchitectSet();
+    await dispatch({ architects: archs, telemetry }, stubDispatch());
+    expect(telemetry.rows.length).toBe(3);
+    expect(telemetry.rows.map((r) => r.architectName).sort()).toEqual([
+      'a11y',
+      'frontend',
+      'performance',
+    ]);
+  });
+
+  it('records 0 retries when first attempt is correct', async () => {
+    const telemetry = new InMemoryTelemetrySink();
+    const arch = new MockArchitect('a', makeContract('a', ['a.x']));
+    await dispatch({ architects: [arch], telemetry }, stubDispatch());
+    expect(telemetry.rows[0]?.retries).toBe(0);
+  });
+
+  it('retries once when the architect omits a required path', async () => {
+    let attempt = 0;
+    const arch = new MockArchitect('a', makeContract('a', ['a.x', 'a.y']));
+    arch['opts'] = {
+      output: 'ok',
+      fields: { 'a.x': 1 }, // missing a.y
+    };
+    // Override run so the second attempt succeeds
+    const orig = arch.run.bind(arch);
+    arch.run = async (input) => {
+      attempt += 1;
+      if (attempt === 1) return orig(input);
+      // 2nd attempt — full
+      return (arch as unknown as { okOutput: Function }).okOutput(
+        { 'a.x': 1, 'a.y': 2 },
+        { confidence: 0.9 },
+      );
+    };
+    const telemetry = new InMemoryTelemetrySink();
+    const result = await dispatch({ architects: [arch], telemetry }, stubDispatch());
+    expect(attempt).toBe(2);
+    expect(telemetry.rows[0]?.retries).toBe(1);
+    expect(result.composedArchitecture).toEqual({ 'a.x': 1, 'a.y': 2 });
+  });
+
+  it('marks the architect as failed if the second attempt still mismatches', async () => {
+    const arch = new MockArchitect('a', makeContract('a', ['a.x', 'a.y']), {
+      output: 'ok',
+      fields: { 'a.x': 1 }, // permanently missing a.y
+    });
+    const result = await dispatch({ architects: [arch] }, stubDispatch());
+    expect(result.outputs[0]?.status).toBe('failed');
+    expect(result.outputs[0]?.failureReason).toMatch(/schema mismatch after retry/);
+  });
+
+  it('treats a failed architect as skipped in composition but still proceeds', async () => {
+    const ok = new MockArchitect('ok', makeContract('ok', ['ok.x']));
+    const bad = new MockArchitect('bad', makeContract('bad', ['bad.x']), { output: 'failed' });
+    const result = await dispatch({ architects: [ok, bad] }, stubDispatch());
+    expect(result.finalState).toBe('ea-complete');
+    expect(result.composedArchitecture).toEqual({ 'ok.x': 'val-ok.x' });
+  });
+
+  it('transitions to ea-dispatching-failed when >50% architects fail', async () => {
+    const a = new MockArchitect('a', makeContract('a', ['a.x']), { output: 'failed' });
+    const b = new MockArchitect('b', makeContract('b', ['b.x']), { output: 'failed' });
+    const c = new MockArchitect('c', makeContract('c', ['c.x']));
+    const sm = new NoopStateMachine();
+    const result = await dispatch({ architects: [a, b, c], stateMachine: sm }, stubDispatch());
+    expect(result.finalState).toBe('ea-dispatching-failed');
+    expect(sm.transitions.map((t) => t.toState)).toContain('ea-dispatching-failed');
+  });
+
+  it('claims, heartbeats, and releases the ticket', async () => {
+    const sm = new NoopStateMachine();
+    const arch = new MockArchitect('a', makeContract('a', ['a.x']));
+    await dispatch({ architects: [arch], stateMachine: sm }, stubDispatch());
+    expect(sm.claims.length).toBe(1);
+    expect(sm.claims[0]).toMatchObject({ ticketId: 't-1', agentId: 'ea-dispatcher' });
+    expect(sm.releases.length).toBe(1);
+    expect(sm.releases[0]).toMatchObject({ finalStatus: 'done' });
+  });
+
+  it('skips architects whose appliesPredicate returns false', async () => {
+    const apply = new MockArchitect('apply', makeContract('apply', ['apply.x']));
+    const skip = new MockArchitect(
+      'skip',
+      makeContract('skip', ['skip.x'], { appliesPredicate: () => false }),
+    );
+    const result = await dispatch({ architects: [apply, skip] }, stubDispatch());
+    expect(result.composedArchitecture).toEqual({ 'apply.x': 'val-apply.x' });
+    expect(result.telemetry.skipped).toEqual(['skip']);
+  });
+
+  it('returns ea-complete and an empty composition when no architects apply', async () => {
+    const all = new MockArchitect(
+      'all',
+      makeContract('all', ['all.x'], { appliesPredicate: () => false }),
+    );
+    const result = await dispatch({ architects: [all] }, stubDispatch());
+    expect(result.finalState).toBe('ea-complete');
+    expect(result.composedArchitecture).toEqual({});
+    expect(result.outputs).toEqual([]);
+  });
+
+  it('rerunFor restricts the dispatch to only the named architects', async () => {
+    const a = new MockArchitect('a', makeContract('a', ['a.x']));
+    const b = new MockArchitect('b', makeContract('b', ['b.x']));
+    const c = new MockArchitect('c', makeContract('c', ['c.x']));
+    const result = await dispatch(
+      { architects: [a, b, c] },
+      stubDispatch({
+        rerunFor: [{ architect: 'b', reason: 'reviewer rejected b', severity: 'P0' }],
+      }),
+    );
+    expect(result.outputs.map((o) => o.architectName)).toEqual(['b']);
+    // Composition only includes b
+    expect(Object.keys(result.composedArchitecture)).toEqual(['b.x']);
+  });
+
+  it('refuses to dispatch past maxIterations', async () => {
+    const arch = new MockArchitect('a', makeContract('a', ['a.x']));
+    await expect(
+      dispatch({ architects: [arch] }, stubDispatch({ iteration: 4 }), { maxIterations: 3 }),
+    ).rejects.toThrow(/iteration 4 exceeds/);
+  });
+
+  it('detects + annotates a semantic conflict (iframe vs CSP)', async () => {
+    const frontend = new MockArchitect(
+      'frontend',
+      makeContract('frontend', ['frontend.componentTree'], { precedenceLevel: 14 }),
+      { fields: { 'frontend.componentTree': [{ kind: 'iframe-embed' }] } },
+    );
+    const security = new MockArchitect(
+      'security',
+      makeContract('security', ['security.cspPolicy'], {
+        dependsOn: ['frontend'],
+        precedenceLevel: 1,
+      }),
+      { fields: { 'security.cspPolicy': { frameSrc: "'none'" } } },
+    );
+    const result = await dispatch({ architects: [frontend, security] }, stubDispatch());
+    expect(result.conflicts.length).toBeGreaterThanOrEqual(1);
+    const iframeConflict = result.conflicts.find(
+      (c) => c.ruleId === 'csp-frame-vs-iframe-embed',
+    );
+    expect(iframeConflict?.winner).toBe('security');
+    expect(iframeConflict?.loser).toBe('frontend');
+    expect(result.composedArchitecture['frontend.componentTree']).toHaveProperty('_dissent');
+  });
+
+  it('uses a frozen clock for deterministic telemetry timestamps', async () => {
+    const clock = new FrozenClock();
+    const telemetry = new InMemoryTelemetrySink();
+    const arch = new MockArchitect('a', makeContract('a', ['a.x']));
+    await dispatch({ architects: [arch], telemetry, clock }, stubDispatch());
+    expect(telemetry.rows[0]?.startedAt).toMatch(/^2026-/);
+  });
+
+  it('Dispatcher class is reusable across dispatches', async () => {
+    const arch = new MockArchitect('a', makeContract('a', ['a.x']));
+    const d = new Dispatcher({ architects: [arch] });
+    const r1 = await d.dispatch(stubDispatch({ ticket: stubTicket({ id: 't-A' }) }));
+    const r2 = await d.dispatch(stubDispatch({ ticket: stubTicket({ id: 't-B' }) }));
+    expect(r1.ticketId).toBe('t-A');
+    expect(r2.ticketId).toBe('t-B');
+  });
+});

--- a/packages/ea-dispatcher/tests/fixtures.ts
+++ b/packages/ea-dispatcher/tests/fixtures.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared dispatcher test fixtures.
+ */
+
+import { BaseArchitect } from '@caia/architect-kit';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  SpecialistArchitect,
+  FanoutPolicy,
+} from '@caia/architect-kit';
+import type { DispatchInput } from '../src/types.js';
+
+export function makeContract(
+  name: string,
+  paths: readonly string[],
+  meta: {
+    dependsOn?: readonly string[];
+    precedenceLevel?: number;
+    fanoutPolicy?: FanoutPolicy;
+    appliesPredicate?: (ticket: Ticket) => boolean;
+    runtimeModel?: 'haiku' | 'sonnet' | 'opus';
+  } = {},
+): ArchitectSectionContract {
+  return {
+    contractId: `${name}-architect.v1`,
+    architectName: name,
+    version: '0.1.0',
+    sections: paths.map((p) => ({ path: p, description: `${p}`, required: true })),
+    architectMeta: {
+      dependsOn: meta.dependsOn ?? [],
+      precedenceLevel: meta.precedenceLevel ?? 99,
+      fanoutPolicy: meta.fanoutPolicy ?? 'always',
+      appliesPredicate: meta.appliesPredicate ?? (() => true),
+      runtimeModel: meta.runtimeModel ?? 'sonnet',
+    },
+  };
+}
+
+/**
+ * A configurable mock architect — pick which fields to populate, how long
+ * to "take", whether to fail. Tests construct one per scenario.
+ */
+export class MockArchitect extends BaseArchitect implements SpecialistArchitect {
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract,
+    private opts: {
+      output?: 'ok' | 'partial' | 'failed' | 'missing-required';
+      fields?: Record<string, unknown>;
+      latencyMs?: number;
+      confidence?: number;
+      throws?: boolean;
+      onRun?: (input: ArchitectInput) => void;
+    } = {},
+  ) {
+    super();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    this.opts.onRun?.(input);
+    if (this.opts.throws) throw new Error(`mock ${this.name} threw`);
+    if (this.opts.latencyMs && this.opts.latencyMs > 0) {
+      await new Promise((r) => setTimeout(r, this.opts.latencyMs));
+    }
+    const mode = this.opts.output ?? 'ok';
+    const fields =
+      this.opts.fields ??
+      Object.fromEntries(
+        this.sectionContract.sections.map((s) => [s.path, `val-${s.path}`]),
+      );
+    const confidence = this.opts.confidence ?? 0.85;
+
+    switch (mode) {
+      case 'ok':
+        return this.okOutput(fields, { confidence, spend: this.zeroSpend('mock') });
+      case 'partial':
+        return this.partialOutput(fields, { confidence, spend: this.zeroSpend('mock') });
+      case 'failed':
+        return this.failedOutput('mock-fail-by-config');
+      case 'missing-required': {
+        // Strip one required path.
+        const requiredPaths = this.sectionContract.sections
+          .filter((s) => s.required)
+          .map((s) => s.path);
+        if (requiredPaths.length > 0) {
+          const stripped = { ...fields };
+          delete stripped[requiredPaths[0]!];
+          return this.okOutput(stripped, { confidence, spend: this.zeroSpend('mock') });
+        }
+        return this.okOutput(fields, { confidence });
+      }
+    }
+  }
+}
+
+export function stubTicket(overrides: Partial<Ticket> = {}): Ticket {
+  return {
+    id: 't-1',
+    type: 'Page',
+    scope: 'story',
+    parent_id: null,
+    acceptance_criteria: ['user opens the page', 'page renders in <2s'],
+    quality_tags: ['seo', 'accessibility', 'performance'],
+    ...overrides,
+  };
+}
+
+export function stubBusinessPlan(): BusinessPlan {
+  return {
+    ventureName: 'Acme Co',
+    oneLiner: 'better widgets',
+    audience: 'SMB owners',
+    goals: ['10k mrr', '5% conv'],
+  };
+}
+
+export function stubDesignVersion(): RenderableDesign {
+  return { versionId: 'd-1', anchors: [{ anchorId: 'hero', kind: 'section' }] };
+}
+
+export function stubTenant(): TenantContext {
+  return {
+    tenantId: 'tnt-1',
+    schemaName: 's1',
+    vaultNamespace: 'caia/acme',
+    billingPosture: 'subscription',
+    creditBalance: { usdAvailable: 100 },
+  };
+}
+
+export function stubDispatch(overrides: Partial<DispatchInput> = {}): DispatchInput {
+  return {
+    ticket: stubTicket(),
+    businessPlan: stubBusinessPlan(),
+    designVersion: stubDesignVersion(),
+    tenantContext: stubTenant(),
+    iteration: 1,
+    ...overrides,
+  };
+}
+
+// ─── A 3-architect tri-wave fixture used in the integration test ──────────
+
+export function threeArchitectSet(): readonly MockArchitect[] {
+  const frontend = new MockArchitect(
+    'frontend',
+    makeContract('frontend', ['frontend.framework', 'frontend.tokens'], {
+      precedenceLevel: 14,
+    }),
+    { confidence: 0.9 },
+  );
+  const a11y = new MockArchitect(
+    'a11y',
+    makeContract('a11y', ['a11y.wcagLevel'], {
+      dependsOn: ['frontend'],
+      precedenceLevel: 3,
+    }),
+    { confidence: 0.85 },
+  );
+  const performance = new MockArchitect(
+    'performance',
+    makeContract('performance', ['performance.lighthouseTargets'], {
+      dependsOn: ['frontend'],
+      precedenceLevel: 5,
+    }),
+    { confidence: 0.8 },
+  );
+  return [frontend, a11y, performance];
+}
+
+// ─── Full 17-architect mock set ────────────────────────────────────────────
+
+export function seventeenArchitectSet(): readonly MockArchitect[] {
+  const specs: Array<{
+    name: string;
+    paths: readonly string[];
+    deps?: readonly string[];
+    prec: number;
+  }> = [
+    { name: 'frontend', paths: ['frontend.framework', 'frontend.tokens'], prec: 14 },
+    { name: 'backend', paths: ['backend.framework', 'backend.endpointEnumeration'], prec: 12 },
+    { name: 'seo', paths: ['seo.title', 'seo.jsonLd'], prec: 4 },
+    { name: 'featureFlagging', paths: ['featureFlags.flagStore', 'featureFlags.killSwitch'], prec: 7 },
+    { name: 'timeMachine', paths: ['timeMachine.snapshotKey'], prec: 15 },
+    { name: 'uxVersionControl', paths: ['uxVersionControl.uploadVersionId'], prec: 16 },
+    { name: 'database', paths: ['database.engine', 'database.schemaDDL'], deps: ['backend'], prec: 11 },
+    { name: 'a11y', paths: ['a11y.wcagLevel', 'a11y.keyboardSpec'], deps: ['frontend'], prec: 3 },
+    { name: 'performance', paths: ['performance.lighthouseTargets'], deps: ['frontend'], prec: 5 },
+    { name: 'analytics', paths: ['analytics.provider', 'analytics.eventTaxonomy'], deps: ['frontend'], prec: 10 },
+    { name: 'aiml', paths: ['aiml.model'], deps: ['backend'], prec: 13 },
+    { name: 'observability', paths: ['observability.logShape', 'observability.metricsExport'], deps: ['backend', 'frontend'], prec: 9 },
+    { name: 'security', paths: ['security.authnFlow', 'security.cspPolicy'], deps: ['backend', 'database'], prec: 1 },
+    { name: 'apiGateway', paths: ['apiGateway.rateLimit', 'apiGateway.errorEnvelope'], deps: ['backend', 'security'], prec: 8 },
+    { name: 'testing', paths: ['testing.strategy', 'testing.fixtures'], deps: ['frontend', 'backend'], prec: 17 },
+    { name: 'devops', paths: ['devops.ciPipeline', 'devops.deployStrategy'], deps: ['backend', 'database'], prec: 2 },
+    { name: 'abTesting', paths: ['abTesting.variantRouter'], deps: ['analytics', 'featureFlagging'], prec: 6 },
+  ];
+  return specs.map(
+    (s) =>
+      new MockArchitect(
+        s.name,
+        makeContract(s.name, s.paths, {
+          ...(s.deps ? { dependsOn: s.deps } : {}),
+          precedenceLevel: s.prec,
+        }),
+      ),
+  );
+}

--- a/packages/ea-dispatcher/tests/integration.test.ts
+++ b/packages/ea-dispatcher/tests/integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration test — 3 mock architects → dispatcher.dispatch() → composed
+ * architecture. Exercises the full E2E path: filter → topo-sort → fan-out →
+ * compose → conflict detection → telemetry → state-machine transitions.
+ */
+import { describe, it, expect } from 'vitest';
+import { Dispatcher } from '../src/dispatcher.js';
+import {
+  InMemoryTelemetrySink,
+  NoopStateMachine,
+  FrozenClock,
+} from '../src/invoker.js';
+import {
+  MockArchitect,
+  makeContract,
+  stubDispatch,
+  threeArchitectSet,
+} from './fixtures.js';
+
+describe('integration: 3 mock architects end-to-end', () => {
+  it('runs the canonical 3-arch fixture with a real DispatcherDeps', async () => {
+    const telemetry = new InMemoryTelemetrySink();
+    const sm = new NoopStateMachine();
+    const clock = new FrozenClock();
+    const d = new Dispatcher({
+      architects: threeArchitectSet(),
+      telemetry,
+      stateMachine: sm,
+      clock,
+    });
+
+    const result = await d.dispatch(stubDispatch());
+
+    // 1. Final state.
+    expect(result.finalState).toBe('ea-complete');
+
+    // 2. Composition includes every declared path from every architect.
+    expect(result.composedArchitecture).toEqual({
+      'frontend.framework': 'val-frontend.framework',
+      'frontend.tokens': 'val-frontend.tokens',
+      'a11y.wcagLevel': 'val-a11y.wcagLevel',
+      'performance.lighthouseTargets': 'val-performance.lighthouseTargets',
+    });
+
+    // 3. Telemetry — one row per architect.
+    expect(telemetry.rows.length).toBe(3);
+
+    // 4. State machine — claimed, transitioned, released.
+    expect(sm.claims.length).toBe(1);
+    expect(sm.transitions.map((t) => t.toState)).toContain('ea-complete');
+    expect(sm.releases.length).toBe(1);
+    expect(sm.releases[0]?.finalStatus).toBe('done');
+
+    // 5. Plan reflects the two waves.
+    expect(result.plan).toEqual([
+      { wave: 1, members: ['frontend'] },
+      { wave: 2, members: ['a11y', 'performance'] },
+    ]);
+
+    // 6. No conflicts on this clean fixture.
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('end-to-end on the same fixture with one architect failing', async () => {
+    const [frontend, a11y, _performance] = threeArchitectSet();
+    const perfFail = new MockArchitect(
+      'performance',
+      makeContract('performance', ['performance.lighthouseTargets'], {
+        dependsOn: ['frontend'],
+        precedenceLevel: 5,
+      }),
+      { output: 'failed' },
+    );
+    const d = new Dispatcher({ architects: [frontend!, a11y!, perfFail] });
+    const result = await d.dispatch(stubDispatch());
+    expect(result.finalState).toBe('ea-complete'); // 1/3 = 33% under threshold
+    expect(result.outputs.find((o) => o.architectName === 'performance')?.status).toBe(
+      'failed',
+    );
+    // Composition still has frontend + a11y contributions
+    expect(result.composedArchitecture).toHaveProperty('frontend.framework');
+    expect(result.composedArchitecture).toHaveProperty('a11y.wcagLevel');
+    expect(result.composedArchitecture).not.toHaveProperty('performance.lighthouseTargets');
+  });
+
+  it('end-to-end with a semantic conflict gets dissent annotation', async () => {
+    const frontend = new MockArchitect(
+      'frontend',
+      makeContract('frontend', ['frontend.componentTree'], { precedenceLevel: 14 }),
+      { fields: { 'frontend.componentTree': [{ id: 'btn-1', interactive: true }] } },
+    );
+    const a11y = new MockArchitect(
+      'a11y',
+      makeContract('a11y', ['a11y.keyboardSpec'], {
+        dependsOn: ['frontend'],
+        precedenceLevel: 3,
+      }),
+      { fields: { 'a11y.keyboardSpec': [] } },
+    );
+    const d = new Dispatcher({ architects: [frontend, a11y] });
+    const result = await d.dispatch(stubDispatch());
+    // The rule "interactive-widget-without-keyboard-spec" should fire.
+    const fired = result.conflicts.map((c) => c.ruleId);
+    expect(fired).toContain('interactive-widget-without-keyboard-spec');
+    // a11y outranks frontend so the loser is frontend
+    const conflict = result.conflicts.find(
+      (c) => c.ruleId === 'interactive-widget-without-keyboard-spec',
+    );
+    expect(conflict?.winner).toBe('a11y');
+    expect(conflict?.loser).toBe('frontend');
+  });
+});

--- a/packages/ea-dispatcher/tests/precedence-resolver.test.ts
+++ b/packages/ea-dispatcher/tests/precedence-resolver.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  annotateDissent,
+  fieldBelongsTo,
+  resolveConflicts,
+  winnerOf,
+} from '../src/precedence-resolver.js';
+import type { FiredRule } from '../src/conflict-rules.js';
+import type { SemanticConflictRule } from '../src/conflict-rules.js';
+
+function mockRule(
+  id: string,
+  architects: [string, string],
+  fields: readonly string[],
+): SemanticConflictRule {
+  return { id, description: id, architects, fields, detect: () => true };
+}
+
+function fired(rule: SemanticConflictRule): FiredRule {
+  return { rule };
+}
+
+describe('resolveConflicts — precedence ladder', () => {
+  it('annotates the lower-precedence architect with _dissent', () => {
+    const composed: Record<string, unknown> = {
+      'frontend.componentTree': [{ kind: 'iframe-embed' }],
+      'security.cspPolicy': { frameSrc: "'none'" },
+    };
+    const records = resolveConflicts(
+      [fired(mockRule('iframe', ['security', 'frontend'], ['security.cspPolicy', 'frontend.componentTree']))],
+      composed,
+    );
+    expect(records.length).toBe(1);
+    expect(records[0]?.winner).toBe('security');
+    expect(records[0]?.loser).toBe('frontend');
+    // Loser field gets _dissent
+    const lost = composed['frontend.componentTree'];
+    expect(lost).toHaveProperty('_dissent');
+    // Winner stays untouched
+    expect(composed['security.cspPolicy']).toEqual({ frameSrc: "'none'" });
+  });
+
+  it('orders security > frontend regardless of rule.architects order', () => {
+    const c1: Record<string, unknown> = { 'security.x': 1, 'frontend.x': 2 };
+    const c2: Record<string, unknown> = { 'security.x': 1, 'frontend.x': 2 };
+    resolveConflicts([fired(mockRule('r', ['security', 'frontend'], ['security.x', 'frontend.x']))], c1);
+    resolveConflicts([fired(mockRule('r', ['frontend', 'security'], ['security.x', 'frontend.x']))], c2);
+    expect(c1['frontend.x']).toHaveProperty('_dissent');
+    expect(c2['frontend.x']).toHaveProperty('_dissent');
+  });
+
+  it('orders a11y > seo > performance > frontend', () => {
+    const composed: Record<string, unknown> = {
+      'a11y.x': 'a',
+      'seo.x': 's',
+      'performance.x': 'p',
+      'frontend.x': 'f',
+    };
+    resolveConflicts(
+      [
+        fired(mockRule('1', ['a11y', 'frontend'], ['a11y.x', 'frontend.x'])),
+        fired(mockRule('2', ['seo', 'frontend'], ['seo.x', 'frontend.x'])),
+        fired(mockRule('3', ['performance', 'frontend'], ['performance.x', 'frontend.x'])),
+      ],
+      composed,
+    );
+    expect(composed['a11y.x']).toBe('a'); // unmodified
+    expect(composed['seo.x']).toBe('s');
+    expect(composed['performance.x']).toBe('p');
+    // frontend.x was annotated multiple times (the last write wins inside _dissent)
+    expect(composed['frontend.x']).toHaveProperty('_dissent');
+  });
+
+  it('escalates same-architect conflicts', () => {
+    const composed: Record<string, unknown> = { 'frontend.x': 1, 'frontend.y': 2 };
+    const records = resolveConflicts(
+      [fired(mockRule('intra', ['frontend', 'frontend'], ['frontend.x', 'frontend.y']))],
+      composed,
+    );
+    expect(records[0]?.escalated).toBe(true);
+  });
+
+  it('escalates when both architects are unknown to the ladder', () => {
+    const composed: Record<string, unknown> = { 'foo.x': 1, 'bar.x': 2 };
+    const records = resolveConflicts(
+      [fired(mockRule('r', ['foo', 'bar'], ['foo.x', 'bar.x']))],
+      composed,
+    );
+    expect(records[0]?.escalated).toBe(true);
+  });
+
+  it('handles an empty fired list', () => {
+    expect(resolveConflicts([], {})).toEqual([]);
+  });
+});
+
+describe('fieldBelongsTo', () => {
+  it('matches by direct prefix', () => {
+    expect(fieldBelongsTo('frontend.componentTree', 'frontend')).toBe(true);
+    expect(fieldBelongsTo('frontend.componentTree', 'backend')).toBe(false);
+  });
+
+  it('honors the featureFlagging→featureFlags alias', () => {
+    expect(fieldBelongsTo('featureFlags.flagStore', 'featureFlagging')).toBe(true);
+  });
+
+  it('honors the accessibility→a11y alias', () => {
+    expect(fieldBelongsTo('a11y.wcagLevel', 'accessibility')).toBe(true);
+  });
+
+  it('returns false for empty paths', () => {
+    expect(fieldBelongsTo('', 'frontend')).toBe(false);
+  });
+});
+
+describe('annotateDissent', () => {
+  it('merges dissent into an existing object', () => {
+    const c: Record<string, unknown> = { 'a.x': { foo: 1 } };
+    annotateDissent(c, 'a.x', { conflictsWith: 'b', overriddenReason: 'r1' });
+    expect(c['a.x']).toEqual({
+      foo: 1,
+      _dissent: { conflictsWith: 'b', overriddenReason: 'r1' },
+    });
+  });
+
+  it('wraps a scalar value', () => {
+    const c: Record<string, unknown> = { 'a.x': 42 };
+    annotateDissent(c, 'a.x', { conflictsWith: 'b', overriddenReason: 'r' });
+    expect(c['a.x']).toEqual({
+      value: 42,
+      _dissent: { conflictsWith: 'b', overriddenReason: 'r' },
+    });
+  });
+
+  it('handles an absent field — records dissent on its own', () => {
+    const c: Record<string, unknown> = {};
+    annotateDissent(c, 'a.x', { conflictsWith: 'b', overriddenReason: 'r' });
+    expect(c['a.x']).toEqual({
+      _dissent: { conflictsWith: 'b', overriddenReason: 'r' },
+    });
+  });
+});
+
+describe('winnerOf', () => {
+  it('returns the higher-precedence architect', () => {
+    expect(winnerOf('security', 'frontend').winner).toBe('security');
+  });
+
+  it('returns null on tie', () => {
+    expect(winnerOf('mystery-1', 'mystery-2').winner).toBe(null);
+  });
+
+  it('exposes the rank pair for diagnostics', () => {
+    const { ranks } = winnerOf('security', 'frontend');
+    expect(ranks[0]).toBe(1);
+    expect(ranks[1]).toBe(14);
+  });
+});

--- a/packages/ea-dispatcher/tsconfig.json
+++ b/packages/ea-dispatcher/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/ea-dispatcher/vitest.config.ts
+++ b/packages/ea-dispatcher/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+    testTimeout: 15_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1353,6 +1353,22 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/ea-dispatcher:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/errors:
     devDependencies:
       '@chiefaia/eslint-config':


### PR DESCRIPTION
Reads ticket + upstream context, computes the architect dependency graph (Kahn), fans each wave out in parallel, composes via disjoint-key SectionContract merge, resolves semantic conflicts by precedence ladder, emits telemetry, and drives state-machine transitions ea-dispatching → ea-complete (or ea-dispatching-failed on hard fault). No LLM in the dispatcher itself — pure deterministic compute. ArchitectInvoker / StateMachineAdapter / TelemetrySink / Clock are dependency-injected.

Sourced from research/17_architect_framework_spec_2026.md §3 + §5.

**Ships:** Dispatcher class + dispatch(), composeArchitectOutputs with CompositionError, SEMANTIC_CONFLICT_RULES (12 rules) + resolveConflicts() with precedence ladder + _dissent annotation, partitionByApplies / selectByName, DefaultArchitectInvoker (Promise.race deadline), retry-once on schema mismatch, >50%-fail threshold, in-memory mocks.

**Tests: 80 vitest passing** — composer, conflict-rules, precedence-resolver, applies, dispatcher E2E (single + multi-wave, retries, failure threshold, state machine), concurrency (parallel wall-clock, full 17-arch graph, cap=1 serial baseline), integration (3-mock). tsc --noEmit clean under strict + exactOptionalPropertyTypes.

Stacked on #535. Diff shrinks to ea-dispatcher only after #535 lands.
