### PR TITLE
feat(@caia/ea-reviewer): critic-style audit for composed tickets.architecture

### DIFF
--- a/packages/ea-reviewer/README.md
+++ b/packages/ea-reviewer/README.md
@@ -1,0 +1,26 @@
+# @caia/ea-reviewer
+
+Critic-style audit for the composed `tickets.architecture` JSONB. Drives the third stage of the EA fan-out phase: the dispatcher produces composed architecture; the reviewer either passes it (ticket → `ea-complete-verified` → Test Author) or rejects it with a per-architect rerun list (ticket → `ea-rejected` → dispatcher re-runs only the named architects, max 3 iterations).
+
+## Three audit lenses
+
+- **Completeness** — every required `SectionContract.section` path must be populated non-null. Missing fields surface as P1 rerun directives on the owning architect.
+- **Consistency** — ~15 cross-architect invariants (every endpoint has a rate limit, every interactive widget has a keyboard spec, every A/B variant binds to a real flag, …). Each invariant names the architect to blame.
+- **Correctness** — acceptance-criteria alignment via a `CriticAdapter` (DI seam). Three adapters ship: `NullCriticAdapter` (test), `HeuristicCriticAdapter` (deterministic keyword-overlap heuristic), and `FixedCriticAdapter` (canned findings). Production wires this to a Claude subagent via `@chiefaia/claude-spawner`.
+
+## Decision envelope
+
+```ts
+{
+  decision: 'pass' | 'fail',
+  finalState: 'ea-complete-verified' | 'ea-rejected',
+  rerunArchitects: RerunDirective[],   // ← dispatcher consumes this
+  advisories: Advisory[],              // ← dashboard surfaces these
+  findings: { completeness, consistency, correctness },
+  summary: string,
+}
+```
+
+## Spec
+
+Sourced from `research/17_architect_framework_spec_2026.md` §6.

--- a/packages/ea-reviewer/package.json
+++ b/packages/ea-reviewer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@caia/ea-reviewer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Critic-style audit for the composed tickets.architecture JSONB. Runs three deterministic lenses (completeness, consistency, correctness) plus an LLM-judge for acceptance-criteria correctness. Emits {decision: 'ea-complete-verified' | 'ea-rejected', rerunArchitects, advisories}. The dispatcher consumes rerunArchitects to re-run only the named subset (max 3 iterations per ticket).",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/ea-reviewer/src/completeness.ts
+++ b/packages/ea-reviewer/src/completeness.ts
@@ -1,0 +1,68 @@
+/**
+ * @caia/ea-reviewer — completeness lens.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §6.2.
+ *
+ * For each architect that applied, every required `SectionContract.section`
+ * key must be populated non-null in the composed architecture. Missing
+ * keys are reported with the owning architect and a configurable severity.
+ */
+
+import type { ArchitectSectionContract } from '@caia/architect-kit';
+import type {
+  ArchitectAuditRow,
+  CompletenessFinding,
+  Severity,
+} from './types.js';
+
+export interface CompletenessInput {
+  composedArchitecture: Record<string, unknown>;
+  auditRows: readonly ArchitectAuditRow[];
+  contracts: readonly ArchitectSectionContract[];
+  /** Severity to attach to missing-required findings. Default: 'P1'. */
+  missingRequiredSeverity?: Severity;
+}
+
+/**
+ * Run the completeness lens. Returns one finding per missing required path
+ * across every architect that ran (status != failed). Architects with
+ * status==failed are skipped — their absence is already represented in
+ * the audit row.
+ */
+export function runCompletenessLens(
+  input: CompletenessInput,
+): readonly CompletenessFinding[] {
+  const severity: Severity = input.missingRequiredSeverity ?? 'P1';
+  const ranByName = new Map(
+    input.auditRows.map((r) => [r.architectName, r]),
+  );
+
+  const findings: CompletenessFinding[] = [];
+  for (const contract of input.contracts) {
+    const audit = ranByName.get(contract.architectName);
+    // The architect didn't run (skipped or not registered for this ticket)
+    if (!audit) continue;
+    // Failed architects — the dispatcher already marks them as such. No
+    // need to flag every one of their missing paths individually.
+    if (audit.status === 'failed') {
+      findings.push({
+        architect: contract.architectName,
+        missingPath: '<all>',
+        severity,
+      });
+      continue;
+    }
+    for (const section of contract.sections) {
+      if (!section.required) continue;
+      const value = input.composedArchitecture[section.path];
+      if (value == null || value === '') {
+        findings.push({
+          architect: contract.architectName,
+          missingPath: section.path,
+          severity,
+        });
+      }
+    }
+  }
+  return findings;
+}

--- a/packages/ea-reviewer/src/critic.ts
+++ b/packages/ea-reviewer/src/critic.ts
@@ -1,0 +1,165 @@
+/**
+ * @caia/ea-reviewer — critic adapter (correctness lens).
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §6.2 (lens 3).
+ *
+ * The correctness lens audits acceptance-criteria alignment. In production
+ * this calls a Claude subagent ("critic-style Sonnet subagent running ~1
+ * call per ticket" per spec §6). In tests, we want determinism and zero
+ * LLM calls — so the production path is behind a `CriticAdapter` DI seam
+ * and the default in-process impl is a keyword-overlap heuristic.
+ *
+ * The keyword adapter:
+ *   - tokenizes each acceptance criterion
+ *   - searches the composed architecture for any token overlap
+ *   - emits a P1 finding for any criterion with zero overlap
+ *
+ * This isn't *correct* in the LLM-judgment sense — it's a deterministic
+ * placeholder that fails closed (flags missing coverage) and is cheap to
+ * test. Production callers inject a Claude-backed adapter that does the
+ * real correctness check.
+ */
+
+import type {
+  ArchitectAuditRow,
+  CorrectnessFinding,
+  CriticAdapter,
+} from './types.js';
+
+/**
+ * Tokenize a string into lowercased word stems for heuristic matching.
+ */
+function tokenize(s: string): readonly string[] {
+  return s
+    .toLowerCase()
+    .split(/[\s,.;:!?()/\\"'`<>{}[\]|&^%$#@~+=*-]+/)
+    .filter((t) => t.length >= 4)
+    .filter((t) => !STOPWORDS.has(t));
+}
+
+const STOPWORDS = new Set([
+  'this',
+  'that',
+  'with',
+  'from',
+  'when',
+  'where',
+  'which',
+  'they',
+  'their',
+  'them',
+  'have',
+  'been',
+  'must',
+  'will',
+  'shall',
+  'should',
+  'would',
+  'into',
+  'than',
+  'then',
+  'also',
+  'such',
+  'each',
+  'some',
+  'more',
+  'less',
+  'over',
+  'under',
+  'page',
+  'load',
+  'site',
+  'user',
+  'data',
+]);
+
+/**
+ * Recursively gather every string value in the composed architecture
+ * into a single search corpus.
+ */
+function gatherStrings(value: unknown, out: string[] = []): readonly string[] {
+  if (value == null) return out;
+  if (typeof value === 'string') {
+    out.push(value);
+    return out;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    out.push(String(value));
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) gatherStrings(v, out);
+    return out;
+  }
+  if (typeof value === 'object') {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      gatherStrings(v, out);
+    }
+    for (const k of Object.keys(value as Record<string, unknown>)) {
+      out.push(k);
+    }
+    return out;
+  }
+  return out;
+}
+
+/**
+ * Heuristic critic — emits a finding for each acceptance criterion whose
+ * tokens don't appear in the composed architecture. Cheap, deterministic,
+ * fails closed.
+ */
+export class HeuristicCriticAdapter implements CriticAdapter {
+  async judge(input: {
+    composedArchitecture: Record<string, unknown>;
+    acceptanceCriteria: readonly string[];
+    auditRows: readonly ArchitectAuditRow[];
+  }): Promise<readonly CorrectnessFinding[]> {
+    const corpus = gatherStrings(input.composedArchitecture).join(' ').toLowerCase();
+    const findings: CorrectnessFinding[] = [];
+    for (const criterion of input.acceptanceCriteria) {
+      const tokens = tokenize(criterion);
+      if (tokens.length === 0) continue;
+      const matched = tokens.filter((t) => corpus.includes(t));
+      const matchRatio = matched.length / tokens.length;
+      if (matchRatio < 0.25) {
+        // Less than 25% of the criterion's tokens appear in the architecture.
+        findings.push({
+          acceptanceCriterion: criterion,
+          blameArchitect: 'global',
+          reason: `architecture does not appear to address the criterion (only ${matched.length}/${tokens.length} tokens matched)`,
+          severity: 'P2',
+        });
+      }
+    }
+    return findings;
+  }
+}
+
+/**
+ * No-op critic — returns no findings. Used by tests that want to assert
+ * the reviewer's other lenses in isolation.
+ */
+export class NullCriticAdapter implements CriticAdapter {
+  async judge(_input: {
+    composedArchitecture: Record<string, unknown>;
+    acceptanceCriteria: readonly string[];
+    auditRows: readonly ArchitectAuditRow[];
+  }): Promise<readonly CorrectnessFinding[]> {
+    return [];
+  }
+}
+
+/**
+ * Fixed-output critic — useful for tests that want to assert the reviewer
+ * handles correctness findings correctly without running the heuristic.
+ */
+export class FixedCriticAdapter implements CriticAdapter {
+  constructor(private readonly findings: readonly CorrectnessFinding[]) {}
+  async judge(_input: {
+    composedArchitecture: Record<string, unknown>;
+    acceptanceCriteria: readonly string[];
+    auditRows: readonly ArchitectAuditRow[];
+  }): Promise<readonly CorrectnessFinding[]> {
+    return this.findings;
+  }
+}

--- a/packages/ea-reviewer/src/index.ts
+++ b/packages/ea-reviewer/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @caia/ea-reviewer — public surface.
+ */
+
+export { Reviewer, review, REVIEWER_AGENT_ID } from './reviewer.js';
+export type { ReviewerDeps } from './reviewer.js';
+
+export type {
+  Advisory,
+  ArchitectAuditRow,
+  CompletenessFinding,
+  ConsistencyFinding,
+  CorrectnessFinding,
+  CriticAdapter,
+  EscalationEntry,
+  RerunDirective,
+  ReviewerDecision,
+  ReviewerFindings,
+  ReviewerInput,
+  ReviewerOptions,
+  Severity,
+} from './types.js';
+export { DEFAULT_REVIEWER_OPTIONS } from './types.js';
+
+export {
+  HeuristicCriticAdapter,
+  NullCriticAdapter,
+  FixedCriticAdapter,
+} from './critic.js';
+
+export { runCompletenessLens } from './completeness.js';
+export type { CompletenessInput } from './completeness.js';
+
+export { REVIEWER_INVARIANTS, runConsistencyLens } from './invariants.js';
+export type { Invariant } from './invariants.js';

--- a/packages/ea-reviewer/src/invariants.ts
+++ b/packages/ea-reviewer/src/invariants.ts
@@ -1,0 +1,302 @@
+/**
+ * @caia/ea-reviewer — cross-architect invariants (consistency lens).
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §6.2.
+ *
+ * Roughly 10-15 deterministic predicates that look across the composed
+ * architecture and flag inconsistencies. Each invariant declares the
+ * architect(s) responsible so the reviewer's `rerunArchitects` directive
+ * names them specifically.
+ *
+ * Each invariant is a small pure function — no LLM, no IO.
+ */
+
+import type {
+  ArchitectName,
+} from '@caia/architect-kit';
+import type {
+  ConsistencyFinding,
+  Severity,
+} from './types.js';
+
+export interface Invariant {
+  id: string;
+  description: string;
+  /** Architects to name in the rerun directive when this invariant fails. */
+  blameArchitects: readonly ArchitectName[];
+  /** Predicate — returns true iff the invariant HOLDS (no finding). */
+  holds: (composed: Record<string, unknown>) => boolean;
+  /** Severity used for findings (default attached at registration). */
+  severity?: Severity;
+}
+
+function asArray<T = unknown>(v: unknown): readonly T[] {
+  return Array.isArray(v) ? (v as T[]) : [];
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function getField(composed: Record<string, unknown>, path: string): unknown {
+  return composed[path];
+}
+
+// ─── Invariant registry ────────────────────────────────────────────────────
+
+export const REVIEWER_INVARIANTS: readonly Invariant[] = [
+  {
+    id: 'every-endpoint-has-gateway-policy',
+    description:
+      'Every backend endpoint has a corresponding apiGateway.rateLimit + errorEnvelope entry.',
+    blameArchitects: ['apiGateway'],
+    holds: (c) => {
+      const endpoints = asArray<{ path?: string }>(
+        getField(c, 'backend.endpointEnumeration'),
+      )
+        .map((e) => e.path)
+        .filter(Boolean) as string[];
+      const limits = asArray<{ path?: string }>(getField(c, 'apiGateway.rateLimit'))
+        .map((l) => l.path)
+        .filter(Boolean) as string[];
+      if (endpoints.length === 0) return true;
+      return endpoints.every((e) => limits.includes(e));
+    },
+  },
+  {
+    id: 'every-event-has-metric',
+    description:
+      'Every analytics event has a corresponding observability.metricsExport entry.',
+    blameArchitects: ['observability'],
+    holds: (c) => {
+      const events = asArray<{ name?: string }>(getField(c, 'analytics.eventTaxonomy'))
+        .map((e) => e.name)
+        .filter(Boolean) as string[];
+      const metrics = new Set(
+        asArray<{ event?: string }>(getField(c, 'observability.metricsExport'))
+          .map((m) => m.event)
+          .filter(Boolean),
+      );
+      return events.every((e) => metrics.has(e));
+    },
+  },
+  {
+    id: 'interactive-widgets-have-keyboard-spec',
+    description:
+      'Every interactive widget in frontend.componentTree has an a11y.keyboardSpec entry.',
+    blameArchitects: ['a11y'],
+    holds: (c) => {
+      const tree = asArray<{ id?: string; interactive?: boolean }>(
+        getField(c, 'frontend.componentTree'),
+      );
+      const interactiveIds = tree
+        .filter((n) => n.interactive)
+        .map((n) => n.id)
+        .filter(Boolean) as string[];
+      const keys = new Set(
+        asArray<{ componentId?: string }>(getField(c, 'a11y.keyboardSpec'))
+          .map((k) => k.componentId)
+          .filter(Boolean),
+      );
+      return interactiveIds.every((id) => keys.has(id));
+    },
+  },
+  {
+    id: 'csp-allows-iframes-if-tree-has-them',
+    description:
+      "If frontend.componentTree contains iframe-embed widgets, security.cspPolicy.frameSrc must not be 'none'.",
+    blameArchitects: ['security'],
+    holds: (c) => {
+      const tree = asArray<{ kind?: string }>(getField(c, 'frontend.componentTree'));
+      const hasIframe = tree.some((n) => n?.kind === 'iframe-embed');
+      if (!hasIframe) return true;
+      const csp = getField(c, 'security.cspPolicy');
+      const frameSrc = isObject(csp) ? csp['frameSrc'] : undefined;
+      return frameSrc !== "'none'";
+    },
+  },
+  {
+    id: 'every-feature-flag-has-killswitch',
+    description:
+      'Every featureFlags.flagStore entry has a corresponding killSwitch entry.',
+    blameArchitects: ['featureFlagging'],
+    holds: (c) => {
+      const flags = asArray<{ name?: string }>(getField(c, 'featureFlags.flagStore'))
+        .map((f) => f.name)
+        .filter(Boolean) as string[];
+      const switches = new Set(
+        asArray<{ name?: string }>(getField(c, 'featureFlags.killSwitch'))
+          .map((s) => s.name)
+          .filter(Boolean),
+      );
+      return flags.every((f) => switches.has(f));
+    },
+  },
+  {
+    id: 'ab-test-variants-bind-to-flags',
+    description: 'Every A/B test variantRouter entry references an existing flag.',
+    blameArchitects: ['abTesting'],
+    holds: (c) => {
+      const variants = asArray<{ flag?: string }>(getField(c, 'abTesting.variantRouter'));
+      if (variants.length === 0) return true;
+      const flags = new Set(
+        asArray<{ name?: string }>(getField(c, 'featureFlags.flagStore'))
+          .map((f) => f.name)
+          .filter(Boolean),
+      );
+      return variants.every((v) => !!v.flag && flags.has(v.flag));
+    },
+  },
+  {
+    id: 'preload-and-lazy-load-are-disjoint',
+    description:
+      'No image appears in both seo.preloadHints and performance.lazyLoadList.',
+    blameArchitects: ['seo', 'performance'],
+    holds: (c) => {
+      const preload = new Set(
+        asArray<{ href?: string }>(getField(c, 'seo.preloadHints'))
+          .map((p) => p.href)
+          .filter(Boolean),
+      );
+      const lazy = asArray<{ src?: string }>(getField(c, 'performance.lazyLoadList'))
+        .map((l) => l.src)
+        .filter(Boolean) as string[];
+      return !lazy.some((s) => preload.has(s));
+    },
+  },
+  {
+    id: 'database-schema-references-only-known-engines',
+    description:
+      'database.engine is one of the supported set (postgres, mysql, sqlite, mongodb).',
+    blameArchitects: ['database'],
+    holds: (c) => {
+      const engine = asString(getField(c, 'database.engine'));
+      if (engine === undefined) return true; // missing handled by completeness
+      return ['postgres', 'mysql', 'sqlite', 'mongodb'].includes(engine);
+    },
+  },
+  {
+    id: 'devops-blue-green-implies-time-machine-revert',
+    description: 'Blue-green deploys require a time-machine revert command.',
+    blameArchitects: ['timeMachine'],
+    holds: (c) => {
+      if (getField(c, 'devops.deployStrategy') !== 'blue-green') return true;
+      const revert = getField(c, 'timeMachine.revertCommand');
+      return typeof revert === 'string' && revert.length > 0;
+    },
+  },
+  {
+    id: 'pii-data-requires-deny-by-default-consent',
+    description:
+      'When security.dataClassification is PII or confidential, analytics.consentMode must be deny-by-default.',
+    blameArchitects: ['analytics'],
+    holds: (c) => {
+      const cls = getField(c, 'security.dataClassification');
+      if (cls !== 'PII' && cls !== 'confidential') return true;
+      return getField(c, 'analytics.consentMode') === 'deny-by-default';
+    },
+  },
+  {
+    id: 'every-endpoint-has-fixture',
+    description:
+      'testing.fixtures covers at least one of every endpoint declared in backend.endpointEnumeration.',
+    blameArchitects: ['testing'],
+    holds: (c) => {
+      const endpoints = asArray<{ path?: string }>(
+        getField(c, 'backend.endpointEnumeration'),
+      )
+        .map((e) => e.path)
+        .filter(Boolean) as string[];
+      if (endpoints.length === 0) return true;
+      const fixtures = asArray<{ path?: string }>(getField(c, 'testing.fixtures'))
+        .map((f) => f.path)
+        .filter(Boolean) as string[];
+      return endpoints.some((e) => fixtures.includes(e));
+    },
+  },
+  {
+    id: 'observability-logs-are-non-empty-when-backend-present',
+    description:
+      'observability.logShape must be non-empty when a backend section is present.',
+    blameArchitects: ['observability'],
+    holds: (c) => {
+      const hasBackend = getField(c, 'backend.framework') != null;
+      if (!hasBackend) return true;
+      const logs = getField(c, 'observability.logShape');
+      if (logs == null) return false;
+      if (typeof logs === 'string') return logs.length > 0;
+      if (Array.isArray(logs)) return logs.length > 0;
+      if (typeof logs === 'object') return Object.keys(logs as object).length > 0;
+      return false;
+    },
+  },
+  {
+    id: 'a11y-wcag-level-is-aa-or-aaa',
+    description: 'a11y.wcagLevel must be AA or AAA (per CAIA policy).',
+    blameArchitects: ['a11y'],
+    holds: (c) => {
+      const level = asString(getField(c, 'a11y.wcagLevel'));
+      if (level === undefined) return true; // handled by completeness
+      return ['AA', 'AAA'].includes(level);
+    },
+  },
+  {
+    id: 'performance-lighthouse-targets-are-numeric',
+    description: 'performance.lighthouseTargets values are numeric and ≤100.',
+    blameArchitects: ['performance'],
+    holds: (c) => {
+      const targets = getField(c, 'performance.lighthouseTargets');
+      if (!isObject(targets)) return targets === undefined;
+      for (const v of Object.values(targets)) {
+        if (typeof v !== 'number' || v > 100 || v < 0) return false;
+      }
+      return true;
+    },
+  },
+  {
+    id: 'seo-canonical-is-https',
+    description: 'seo.canonical (if set) is an https URL.',
+    blameArchitects: ['seo'],
+    holds: (c) => {
+      const canonical = asString(getField(c, 'seo.canonical'));
+      if (canonical === undefined) return true;
+      return canonical.startsWith('https://');
+    },
+  },
+];
+
+// ─── Runner ────────────────────────────────────────────────────────────────
+
+export function runConsistencyLens(
+  composed: Record<string, unknown>,
+  opts: {
+    invariants?: readonly Invariant[];
+    severity?: Severity;
+  } = {},
+): readonly ConsistencyFinding[] {
+  const severity: Severity = opts.severity ?? 'P1';
+  const invariants = opts.invariants ?? REVIEWER_INVARIANTS;
+  const findings: ConsistencyFinding[] = [];
+  for (const inv of invariants) {
+    let held = true;
+    try {
+      held = inv.holds(composed);
+    } catch {
+      // Buggy invariant — treat as held (don't crash the audit on a bad rule).
+      held = true;
+    }
+    if (!held) {
+      findings.push({
+        invariantId: inv.id,
+        description: inv.description,
+        blameArchitects: inv.blameArchitects,
+        severity: inv.severity ?? severity,
+      });
+    }
+  }
+  return findings;
+}

--- a/packages/ea-reviewer/src/reviewer.ts
+++ b/packages/ea-reviewer/src/reviewer.ts
@@ -1,0 +1,211 @@
+/**
+ * @caia/ea-reviewer — reviewer.ts
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §6.
+ *
+ * Drives the three audit lenses, rolls findings into a single decision,
+ * builds rerun directives for the dispatcher, and emits the final state
+ * the orchestrator should transition to.
+ *
+ * The reviewer is intentionally DI-heavy: the critic adapter is injected,
+ * the option set is injected, so tests can exercise every code path
+ * deterministically without spawning an LLM.
+ */
+
+import {
+  DEFAULT_REVIEWER_OPTIONS,
+  type Advisory,
+  type ArchitectAuditRow,
+  type CorrectnessFinding,
+  type CriticAdapter,
+  type ReviewerDecision,
+  type ReviewerFindings,
+  type ReviewerInput,
+  type ReviewerOptions,
+  type RerunDirective,
+  type Severity,
+} from './types.js';
+import { runCompletenessLens } from './completeness.js';
+import { runConsistencyLens } from './invariants.js';
+import { NullCriticAdapter } from './critic.js';
+
+export interface ReviewerDeps {
+  critic?: CriticAdapter;
+}
+
+export class Reviewer {
+  private readonly opts: Required<ReviewerOptions>;
+  private readonly critic: CriticAdapter;
+
+  constructor(deps: ReviewerDeps = {}, opts: ReviewerOptions = {}) {
+    this.opts = { ...DEFAULT_REVIEWER_OPTIONS, ...opts };
+    this.critic = deps.critic ?? new NullCriticAdapter();
+  }
+
+  async review(input: ReviewerInput): Promise<ReviewerDecision> {
+    // 1. Run the three lenses.
+    const completeness = runCompletenessLens({
+      composedArchitecture: input.composedArchitecture,
+      auditRows: input.auditRows,
+      contracts: input.contracts,
+      missingRequiredSeverity: this.opts.missingRequiredSeverity,
+    });
+    const consistency = runConsistencyLens(input.composedArchitecture, {
+      severity: this.opts.invariantViolationSeverity,
+    });
+    const correctness = input.acceptanceCriteria?.length
+      ? await this.critic.judge({
+          composedArchitecture: input.composedArchitecture,
+          acceptanceCriteria: input.acceptanceCriteria,
+          auditRows: input.auditRows,
+        })
+      : ([] as readonly CorrectnessFinding[]);
+
+    const findings: ReviewerFindings = { completeness, consistency, correctness };
+
+    // 2. Roll escalations into rerun directives.
+    const escalationDirectives: RerunDirective[] = (input.escalations ?? []).flatMap(
+      (e) =>
+        e.architects.map((arch) => ({
+          architect: arch,
+          reason: `escalation: ${e.reason}`,
+          severity: 'P0' as Severity,
+        })),
+    );
+
+    // 3. Roll findings into rerun directives.
+    const completenessRerun: RerunDirective[] = completeness.map((f) => ({
+      architect: f.architect,
+      reason: `missing required path '${f.missingPath}'`,
+      severity: f.severity,
+    }));
+    const consistencyRerun: RerunDirective[] = consistency.flatMap((f) =>
+      f.blameArchitects.map((arch) => ({
+        architect: arch,
+        reason: `invariant '${f.invariantId}' failed: ${f.description}`,
+        severity: f.severity,
+      })),
+    );
+    const correctnessRerun: RerunDirective[] = correctness
+      .filter((f) => f.blameArchitect !== 'global')
+      .map((f) => ({
+        architect: f.blameArchitect as string,
+        reason: `acceptance criterion not satisfied: ${f.reason}`,
+        severity: f.severity,
+      }));
+
+    const allDirectives = [
+      ...escalationDirectives,
+      ...completenessRerun,
+      ...consistencyRerun,
+      ...correctnessRerun,
+    ];
+
+    // Dedup + take highest severity per architect.
+    const blocking = new Set<Severity>(this.opts.blockingSeverities);
+    const rerunByArch = new Map<string, RerunDirective>();
+    for (const d of allDirectives) {
+      if (!blocking.has(d.severity)) continue;
+      const existing = rerunByArch.get(d.architect);
+      if (!existing) {
+        rerunByArch.set(d.architect, d);
+      } else if (severityRank(d.severity) < severityRank(existing.severity)) {
+        rerunByArch.set(d.architect, d);
+      } else if (
+        severityRank(d.severity) === severityRank(existing.severity) &&
+        !existing.reason.includes(d.reason)
+      ) {
+        // Concatenate reasons so the architect sees all issues at once.
+        rerunByArch.set(d.architect, {
+          ...existing,
+          reason: `${existing.reason}; ${d.reason}`,
+        });
+      }
+    }
+    const rerunArchitects = [...rerunByArch.values()];
+
+    // 4. Build advisories — non-blocking, lower-severity issues.
+    const advisories: Advisory[] = [];
+    // Low-confidence advisories
+    for (const a of input.auditRows) {
+      if (a.confidence < this.opts.confidenceFloor && a.status !== 'failed') {
+        advisories.push({
+          architect: a.architectName,
+          advisory: `confidence ${a.confidence.toFixed(2)} below floor ${this.opts.confidenceFloor}`,
+          severity: 'P2',
+        });
+      }
+    }
+    // Global correctness findings (no specific architect) → advisory
+    for (const f of correctness) {
+      if (f.blameArchitect === 'global') {
+        advisories.push({
+          architect: 'global',
+          advisory: f.reason,
+          severity: f.severity,
+        });
+      }
+    }
+    // Non-blocking severity findings → advisories
+    for (const d of allDirectives) {
+      if (!blocking.has(d.severity)) {
+        advisories.push({
+          architect: d.architect,
+          advisory: d.reason,
+          severity: d.severity,
+        });
+      }
+    }
+
+    // 5. Decide.
+    const decision: ReviewerDecision['decision'] =
+      rerunArchitects.length > 0 ? 'fail' : 'pass';
+    const finalState =
+      decision === 'pass' ? 'ea-complete-verified' : 'ea-rejected';
+
+    const summary = buildSummary(decision, findings, rerunArchitects);
+
+    return {
+      decision,
+      finalState,
+      rerunArchitects,
+      advisories,
+      findings,
+      summary,
+    };
+  }
+}
+
+function severityRank(s: Severity): number {
+  // Lower number = more severe
+  return s === 'P0' ? 0 : s === 'P1' ? 1 : 2;
+}
+
+function buildSummary(
+  decision: 'pass' | 'fail',
+  findings: ReviewerFindings,
+  rerunArchitects: readonly RerunDirective[],
+): string {
+  if (decision === 'pass') {
+    const c = findings.consistency.length;
+    const m = findings.completeness.length;
+    if (c === 0 && m === 0) {
+      return 'Audit passed: completeness, consistency, and correctness lenses all clean.';
+    }
+    return `Audit passed with ${m + c} non-blocking advisories.`;
+  }
+  const names = rerunArchitects.map((r) => r.architect).join(', ');
+  return `Audit failed: re-run ${rerunArchitects.length} architect(s) — ${names}.`;
+}
+
+/** Functional flavour for tests + scripts. */
+export async function review(
+  input: ReviewerInput,
+  deps: ReviewerDeps = {},
+  opts: ReviewerOptions = {},
+): Promise<ReviewerDecision> {
+  return new Reviewer(deps, opts).review(input);
+}
+
+/** Agent id used in state-machine transitions. */
+export const REVIEWER_AGENT_ID = 'ea-reviewer';

--- a/packages/ea-reviewer/src/types.ts
+++ b/packages/ea-reviewer/src/types.ts
@@ -1,0 +1,164 @@
+/**
+ * @caia/ea-reviewer — types.
+ *
+ * Sourced from research/17_architect_framework_spec_2026.md §6.
+ *
+ * The reviewer audits the composed `tickets.architecture` blob via three
+ * deterministic lenses (completeness, consistency, correctness) plus an
+ * optional LLM-judge for acceptance-criteria alignment. It emits a single
+ * decision envelope the dispatcher consumes to either:
+ *
+ *   - pass → transition `ea-complete-verified` (ticket → Test Author).
+ *   - fail → transition `ea-rejected` + per-architect rerun list.
+ *
+ * The reviewer CANNOT write to `tickets.architecture` directly (§6.4). It
+ * writes only to `tickets.review_status` and `tickets.review_feedback`.
+ */
+
+import type {
+  ArchitectName,
+  ArchitectSectionContract,
+  Ticket,
+} from '@caia/architect-kit';
+
+/** Per-architect audit record (one per architect that ran). */
+export interface ArchitectAuditRow {
+  architectName: ArchitectName;
+  status: 'ok' | 'partial' | 'failed';
+  confidence: number;
+  notes: string;
+  risks: readonly string[];
+}
+
+export interface ReviewerInput {
+  ticket: Ticket;
+  /** The composed jsonb blob (disjoint-key merge from the dispatcher). */
+  composedArchitecture: Record<string, unknown>;
+  /** Audit rows from `tickets_architect_calls`. */
+  auditRows: readonly ArchitectAuditRow[];
+  /**
+   * Architect contracts — needed so the completeness lens knows which
+   * paths SHOULD exist for each architect.
+   */
+  contracts: readonly ArchitectSectionContract[];
+  /**
+   * `requiresEscalation` records from the dispatcher's same-rank conflict
+   * resolutions. The reviewer surfaces these as P0 rerun directives.
+   */
+  escalations?: readonly EscalationEntry[];
+  /** Acceptance criteria from the ticket; drives the correctness lens. */
+  acceptanceCriteria?: readonly string[];
+}
+
+export interface EscalationEntry {
+  ruleId: string;
+  architects: readonly [ArchitectName, ArchitectName];
+  reason: string;
+}
+
+export type Severity = 'P0' | 'P1' | 'P2';
+
+export interface RerunDirective {
+  architect: ArchitectName;
+  reason: string;
+  severity: Severity;
+}
+
+export interface Advisory {
+  architect: ArchitectName | 'global';
+  advisory: string;
+  severity: Severity;
+}
+
+/** Decision envelope — output of the reviewer. */
+export interface ReviewerDecision {
+  /**
+   * `pass` → orchestrator transitions ticket to `ea-complete-verified`.
+   * `fail` → orchestrator transitions to `ea-rejected` + dispatches reruns.
+   */
+  decision: 'pass' | 'fail';
+  /** Architects the dispatcher should re-run on the next iteration. Empty on pass. */
+  rerunArchitects: readonly RerunDirective[];
+  /** Non-blocking advisories surfaced on the dashboard. */
+  advisories: readonly Advisory[];
+  /** Per-lens findings — exposed for dashboard + drill-down. */
+  findings: ReviewerFindings;
+  /** Final state the orchestrator should transition to. */
+  finalState: 'ea-complete-verified' | 'ea-rejected';
+  /** Human-readable summary of why the decision was made. */
+  summary: string;
+}
+
+export interface ReviewerFindings {
+  completeness: readonly CompletenessFinding[];
+  consistency: readonly ConsistencyFinding[];
+  correctness: readonly CorrectnessFinding[];
+}
+
+export interface CompletenessFinding {
+  architect: ArchitectName;
+  missingPath: string;
+  severity: Severity;
+}
+
+export interface ConsistencyFinding {
+  invariantId: string;
+  description: string;
+  /** Architect(s) whose work would need to change to satisfy the invariant. */
+  blameArchitects: readonly ArchitectName[];
+  severity: Severity;
+}
+
+export interface CorrectnessFinding {
+  acceptanceCriterion: string;
+  /** Which architect's section appears to violate the AC. */
+  blameArchitect: ArchitectName | 'global';
+  reason: string;
+  severity: Severity;
+}
+
+// ─── Critic adapter for the LLM-judge correctness lens (DI seam) ───────────
+
+/**
+ * The reviewer delegates the optional LLM-judge for correctness to an
+ * adapter so tests can swap in a mock. Default impl uses a deterministic
+ * keyword-overlap heuristic (no LLM); production wires this to a
+ * `@chiefaia/claude-spawner` call.
+ */
+export interface CriticAdapter {
+  judge(input: {
+    composedArchitecture: Record<string, unknown>;
+    acceptanceCriteria: readonly string[];
+    auditRows: readonly ArchitectAuditRow[];
+  }): Promise<readonly CorrectnessFinding[]>;
+}
+
+// ─── Reviewer options ──────────────────────────────────────────────────────
+
+export interface ReviewerOptions {
+  /**
+   * Severities that count as "blocking" — any finding at or above this
+   * level forces `decision: 'fail'`. Default: ['P0', 'P1'].
+   */
+  blockingSeverities?: readonly Severity[];
+  /**
+   * Severity for a missing required path. Default: 'P1'.
+   */
+  missingRequiredSeverity?: Severity;
+  /**
+   * Severity assigned to consistency invariant violations. Default: 'P1'.
+   */
+  invariantViolationSeverity?: Severity;
+  /**
+   * Confidence floor below which the reviewer adds a P2 advisory. Default: 0.6.
+   * (Per spec §6.2: "Sub-0.6 confidence triggers EA Reviewer scrutiny.")
+   */
+  confidenceFloor?: number;
+}
+
+export const DEFAULT_REVIEWER_OPTIONS: Required<ReviewerOptions> = {
+  blockingSeverities: ['P0', 'P1'],
+  missingRequiredSeverity: 'P1',
+  invariantViolationSeverity: 'P1',
+  confidenceFloor: 0.6,
+};

--- a/packages/ea-reviewer/tests/completeness.test.ts
+++ b/packages/ea-reviewer/tests/completeness.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { runCompletenessLens } from '../src/completeness.js';
+import {
+  audit,
+  cleanComposedArchitecture,
+  cleanContracts,
+  makeContract,
+} from './fixtures.js';
+
+describe('completeness lens', () => {
+  it('passes on a clean composed architecture', () => {
+    const findings = runCompletenessLens({
+      composedArchitecture: cleanComposedArchitecture(),
+      auditRows: cleanContracts().map((c) => audit(c.architectName)),
+      contracts: cleanContracts(),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags missing required paths', () => {
+    const composed = { ...cleanComposedArchitecture() };
+    delete composed['a11y.wcagLevel'];
+    const findings = runCompletenessLens({
+      composedArchitecture: composed,
+      auditRows: cleanContracts().map((c) => audit(c.architectName)),
+      contracts: cleanContracts(),
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0]).toMatchObject({
+      architect: 'a11y',
+      missingPath: 'a11y.wcagLevel',
+    });
+  });
+
+  it('treats null and empty-string values as missing', () => {
+    const composed = { ...cleanComposedArchitecture(), 'a11y.wcagLevel': null };
+    const findings = runCompletenessLens({
+      composedArchitecture: composed,
+      auditRows: cleanContracts().map((c) => audit(c.architectName)),
+      contracts: cleanContracts(),
+    });
+    expect(findings.length).toBe(1);
+  });
+
+  it("skips architects that didn't run (no audit row)", () => {
+    const findings = runCompletenessLens({
+      composedArchitecture: {},
+      auditRows: [],
+      contracts: [makeContract('ghost', ['ghost.a'])],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('reports failed architects with a single <all> placeholder', () => {
+    const findings = runCompletenessLens({
+      composedArchitecture: {},
+      auditRows: [audit('bad', { status: 'failed' })],
+      contracts: [makeContract('bad', ['bad.a', 'bad.b', 'bad.c'])],
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.missingPath).toBe('<all>');
+  });
+
+  it('honors a custom severity', () => {
+    const composed = { ...cleanComposedArchitecture() };
+    delete composed['a11y.wcagLevel'];
+    const findings = runCompletenessLens({
+      composedArchitecture: composed,
+      auditRows: cleanContracts().map((c) => audit(c.architectName)),
+      contracts: cleanContracts(),
+      missingRequiredSeverity: 'P0',
+    });
+    expect(findings[0]?.severity).toBe('P0');
+  });
+
+  it('ignores non-required paths', () => {
+    const contract = {
+      contractId: 'foo.v1',
+      architectName: 'foo',
+      version: '0.1.0',
+      sections: [
+        { path: 'foo.req', description: 'r', required: true },
+        { path: 'foo.opt', description: 'o', required: false },
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 99,
+        fanoutPolicy: 'always' as const,
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet' as const,
+      },
+    };
+    const findings = runCompletenessLens({
+      composedArchitecture: { 'foo.req': 1 }, // opt is missing but not required
+      auditRows: [audit('foo')],
+      contracts: [contract],
+    });
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/ea-reviewer/tests/critic.test.ts
+++ b/packages/ea-reviewer/tests/critic.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HeuristicCriticAdapter,
+  NullCriticAdapter,
+  FixedCriticAdapter,
+} from '../src/critic.js';
+
+describe('HeuristicCriticAdapter', () => {
+  it('returns no findings when criteria tokens appear in composed corpus', async () => {
+    const adapter = new HeuristicCriticAdapter();
+    const findings = await adapter.judge({
+      composedArchitecture: {
+        'frontend.componentTree': [{ id: 'signup-form', kind: 'form' }],
+      },
+      acceptanceCriteria: ['user can sign up via signup form'],
+      auditRows: [],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('flags criteria with no architecture overlap', async () => {
+    const adapter = new HeuristicCriticAdapter();
+    const findings = await adapter.judge({
+      composedArchitecture: { 'frontend.tokens': { colors: {} } },
+      acceptanceCriteria: ['quantum entanglement protocols enable telepathy'],
+      auditRows: [],
+    });
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.blameArchitect).toBe('global');
+  });
+
+  it('handles empty acceptance criteria', async () => {
+    const adapter = new HeuristicCriticAdapter();
+    expect(
+      await adapter.judge({
+        composedArchitecture: {},
+        acceptanceCriteria: [],
+        auditRows: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it('ignores criteria with only short / stop-word tokens', async () => {
+    const adapter = new HeuristicCriticAdapter();
+    const findings = await adapter.judge({
+      composedArchitecture: {},
+      acceptanceCriteria: ['this is a', 'with from when'], // all stop / short
+      auditRows: [],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('recursively gathers strings from nested objects', async () => {
+    const adapter = new HeuristicCriticAdapter();
+    const findings = await adapter.judge({
+      composedArchitecture: {
+        'security.cspPolicy': { frameSrc: 'authentication-required-policy' },
+      },
+      acceptanceCriteria: ['authentication required'],
+      auditRows: [],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('NullCriticAdapter', () => {
+  it('returns no findings regardless of input', async () => {
+    const adapter = new NullCriticAdapter();
+    expect(
+      await adapter.judge({
+        composedArchitecture: {},
+        acceptanceCriteria: ['a'],
+        auditRows: [],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('FixedCriticAdapter', () => {
+  it('returns the canned findings', async () => {
+    const canned = [
+      {
+        acceptanceCriterion: 'x',
+        blameArchitect: 'analytics' as const,
+        reason: 'forced',
+        severity: 'P0' as const,
+      },
+    ];
+    const adapter = new FixedCriticAdapter(canned);
+    expect(
+      await adapter.judge({
+        composedArchitecture: {},
+        acceptanceCriteria: [],
+        auditRows: [],
+      }),
+    ).toEqual(canned);
+  });
+});

--- a/packages/ea-reviewer/tests/dispatcher-reviewer.e2e.test.ts
+++ b/packages/ea-reviewer/tests/dispatcher-reviewer.e2e.test.ts
@@ -1,0 +1,224 @@
+/**
+ * End-to-end cross-package integration:
+ *   architect-kit → ea-dispatcher → ea-reviewer
+ *
+ * Wires a real Dispatcher around 3 mock architects, feeds the result into
+ * a real Reviewer, and asserts the full pass/fail decision loop works.
+ *
+ * Lives in ea-reviewer/tests/ because the reviewer is the terminal step;
+ * it avoids any new cross-package dep beyond what each package already
+ * declares.
+ */
+import { describe, it, expect } from 'vitest';
+import { BaseArchitect } from '@caia/architect-kit';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+} from '@caia/architect-kit';
+
+import { Reviewer } from '../src/reviewer.js';
+import { NullCriticAdapter } from '../src/critic.js';
+
+// Local minimal dispatcher port to keep this test in @caia/ea-reviewer
+// without taking a dep on @caia/ea-dispatcher (which would create a
+// circular review-time dep — dispatcher already tests against reviewer
+// would). The "dispatcher port" here is the public composer + plan
+// computation surface from architect-kit. We're not testing the full
+// dispatcher class here; the dispatcher's own integration test exercises
+// the rest.
+
+import { computeWaves } from '@caia/architect-kit';
+
+function makeContract(
+  name: string,
+  paths: readonly string[],
+  deps: readonly string[] = [],
+): ArchitectSectionContract {
+  return {
+    contractId: `${name}.v1`,
+    architectName: name,
+    version: '0.1.0',
+    sections: paths.map((p) => ({ path: p, description: p, required: true })),
+    architectMeta: {
+      dependsOn: deps,
+      precedenceLevel: 99,
+      fanoutPolicy: 'always',
+      appliesPredicate: () => true,
+      runtimeModel: 'sonnet',
+    },
+  };
+}
+
+class Mock extends BaseArchitect {
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract,
+    private fields: Record<string, unknown>,
+  ) {
+    super();
+  }
+  async run(_: ArchitectInput): Promise<ArchitectOutput> {
+    return this.okOutput(this.fields, { confidence: 0.9 });
+  }
+}
+
+async function runFanout(architects: readonly Mock[]) {
+  const waves = computeWaves(architects);
+  const outputs: ArchitectOutput[] = [];
+  const composed: Record<string, unknown> = {};
+  const stubInput: ArchitectInput = {
+    ticket: { id: 't-1', type: 'Page', acceptance_criteria: ['user signs up'] },
+    upstream: { outputs: {} },
+    businessPlan: {
+      ventureName: 'Acme',
+      oneLiner: 'x',
+      audience: 'y',
+      goals: [],
+    },
+    designVersion: { versionId: 'v1', anchors: [] },
+    tenantContext: {
+      tenantId: 'tnt-1',
+      schemaName: 's1',
+      vaultNamespace: 'ns1',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 100 },
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 1,
+    },
+  };
+  for (const wave of waves) {
+    const members = wave.members
+      .map((n) => architects.find((a) => a.name === n))
+      .filter((x): x is Mock => !!x);
+    const waveOuts = await Promise.all(members.map((m) => m.run(stubInput)));
+    for (const out of waveOuts) {
+      outputs.push(out);
+      for (const [k, v] of Object.entries(out.architectureFields)) {
+        composed[k] = v;
+      }
+    }
+  }
+  return { outputs, composed };
+}
+
+describe('E2E — architect-kit fan-out → reviewer audit (pass path)', () => {
+  it('3 architects → clean compose → reviewer passes', async () => {
+    const frontend = new Mock(
+      'frontend',
+      makeContract('frontend', ['frontend.framework', 'frontend.tokens']),
+      { 'frontend.framework': 'next', 'frontend.tokens': {} },
+    );
+    const a11y = new Mock(
+      'a11y',
+      makeContract('a11y', ['a11y.wcagLevel'], ['frontend']),
+      { 'a11y.wcagLevel': 'AA' },
+    );
+    const performance = new Mock(
+      'performance',
+      makeContract('performance', ['performance.lighthouseTargets'], ['frontend']),
+      { 'performance.lighthouseTargets': { perf: 95 } },
+    );
+    const archs = [frontend, a11y, performance];
+
+    const { outputs, composed } = await runFanout(archs);
+    expect(outputs.length).toBe(3);
+
+    const reviewer = new Reviewer({ critic: new NullCriticAdapter() });
+    const decision = await reviewer.review({
+      ticket: { id: 't-1', type: 'Page' },
+      composedArchitecture: composed,
+      auditRows: outputs.map((o) => ({
+        architectName: o.architectName,
+        status: o.status,
+        confidence: o.confidence,
+        notes: o.notes,
+        risks: o.risks,
+      })),
+      contracts: archs.map((a) => a.sectionContract),
+    });
+
+    expect(decision.decision).toBe('pass');
+    expect(decision.finalState).toBe('ea-complete-verified');
+    expect(decision.rerunArchitects).toEqual([]);
+  });
+});
+
+describe('E2E — fan-out → reviewer rejects (fail → rerun) → re-fan-out passes', () => {
+  it('models the dispatcher ↔ reviewer iteration loop', async () => {
+    // Iteration 1: a11y "forgets" wcagLevel.
+    const frontend = new Mock(
+      'frontend',
+      makeContract('frontend', ['frontend.framework']),
+      { 'frontend.framework': 'next' },
+    );
+    const a11yBad = new Mock(
+      'a11y',
+      makeContract('a11y', ['a11y.wcagLevel'], ['frontend']),
+      {}, // empty — required path missing
+    );
+    const archs1 = [frontend, a11yBad];
+    const r1 = await runFanout(archs1);
+
+    const reviewer = new Reviewer({ critic: new NullCriticAdapter() });
+    const decision1 = await reviewer.review({
+      ticket: { id: 't-1', type: 'Page' },
+      composedArchitecture: r1.composed,
+      auditRows: r1.outputs.map((o) => ({
+        architectName: o.architectName,
+        status: o.status,
+        confidence: o.confidence,
+        notes: o.notes,
+        risks: o.risks,
+      })),
+      contracts: archs1.map((a) => a.sectionContract),
+    });
+    expect(decision1.decision).toBe('fail');
+    expect(decision1.rerunArchitects.map((d) => d.architect)).toEqual(['a11y']);
+
+    // Iteration 2: dispatcher re-runs only the named architects. We
+    // simulate that by re-running a11y with the missing field populated.
+    // Note: in a real re-run, the dispatcher selects a SUBSET of architects
+    // by name (selectByName) and re-computes waves on that subset only —
+    // since frontend isn't in the rerun set, a11y is at the root.
+    const a11yFixed = new Mock(
+      'a11y',
+      makeContract('a11y', ['a11y.wcagLevel'], []),
+      { 'a11y.wcagLevel': 'AA' },
+    );
+    const r2 = await runFanout([a11yFixed]);
+    // Merge with the original frontend contribution
+    const composed2 = { ...r1.composed, ...r2.composed };
+
+    const decision2 = await reviewer.review({
+      ticket: { id: 't-1', type: 'Page' },
+      composedArchitecture: composed2,
+      auditRows: [
+        ...r1.outputs
+          .filter((o) => o.architectName !== 'a11y')
+          .map((o) => ({
+            architectName: o.architectName,
+            status: o.status,
+            confidence: o.confidence,
+            notes: o.notes,
+            risks: o.risks,
+          })),
+        ...r2.outputs.map((o) => ({
+          architectName: o.architectName,
+          status: o.status,
+          confidence: o.confidence,
+          notes: o.notes,
+          risks: o.risks,
+        })),
+      ],
+      contracts: archs1.map((a) => a.sectionContract),
+    });
+    expect(decision2.decision).toBe('pass');
+    expect(decision2.finalState).toBe('ea-complete-verified');
+  });
+});

--- a/packages/ea-reviewer/tests/fixtures.ts
+++ b/packages/ea-reviewer/tests/fixtures.ts
@@ -1,0 +1,117 @@
+/**
+ * Reviewer test fixtures — composed architectures + audit rows.
+ */
+import type { ArchitectSectionContract, Ticket } from '@caia/architect-kit';
+import type { ArchitectAuditRow, ReviewerInput } from '../src/types.js';
+
+export function makeContract(
+  name: string,
+  paths: readonly string[],
+): ArchitectSectionContract {
+  return {
+    contractId: `${name}-architect.v1`,
+    architectName: name,
+    version: '0.1.0',
+    sections: paths.map((p) => ({ path: p, description: p, required: true })),
+    architectMeta: {
+      dependsOn: [],
+      precedenceLevel: 99,
+      fanoutPolicy: 'always',
+      appliesPredicate: () => true,
+      runtimeModel: 'sonnet',
+    },
+  };
+}
+
+export function audit(
+  name: string,
+  overrides: Partial<ArchitectAuditRow> = {},
+): ArchitectAuditRow {
+  return {
+    architectName: name,
+    status: 'ok',
+    confidence: 0.9,
+    notes: '',
+    risks: [],
+    ...overrides,
+  };
+}
+
+export function stubTicket(): Ticket {
+  return {
+    id: 't-1',
+    type: 'Page',
+    acceptance_criteria: ['user can sign up via form'],
+  };
+}
+
+/**
+ * A fully clean composed architecture — every invariant holds, every
+ * required path populated. The completeness lens and consistency lens
+ * should both pass.
+ */
+export function cleanComposedArchitecture(): Record<string, unknown> {
+  return {
+    'frontend.framework': 'next',
+    'frontend.componentTree': [
+      { id: 'btn-1', interactive: true },
+    ],
+    'frontend.tokens': { colors: {} },
+    'backend.framework': 'express',
+    'backend.endpointEnumeration': [{ path: '/api/signup' }],
+    'database.engine': 'postgres',
+    'database.schemaDDL': 'CREATE TABLE users (...);',
+    'a11y.wcagLevel': 'AA',
+    'a11y.keyboardSpec': [{ componentId: 'btn-1' }],
+    'performance.lighthouseTargets': { perf: 95, a11y: 100 },
+    'analytics.eventTaxonomy': [{ name: 'signup' }],
+    'analytics.consentMode': 'deny-by-default',
+    'observability.logShape': { format: 'json' },
+    'observability.metricsExport': [{ event: 'signup' }],
+    'security.cspPolicy': { frameSrc: "'self'" },
+    'security.dataClassification': 'public',
+    'apiGateway.rateLimit': [{ path: '/api/signup', perMinute: 60 }],
+    'featureFlags.flagStore': [{ name: 'newSignup' }],
+    'featureFlags.killSwitch': [{ name: 'newSignup' }],
+    'abTesting.variantRouter': [{ flag: 'newSignup' }],
+    'devops.deployStrategy': 'canary',
+    'timeMachine.revertCommand': 'git revert HEAD',
+    'testing.fixtures': [{ path: '/api/signup' }],
+    'seo.canonical': 'https://example.com/signup',
+  };
+}
+
+export function cleanContracts(): readonly ArchitectSectionContract[] {
+  return [
+    makeContract('frontend', ['frontend.framework', 'frontend.componentTree', 'frontend.tokens']),
+    makeContract('backend', ['backend.framework', 'backend.endpointEnumeration']),
+    makeContract('database', ['database.engine', 'database.schemaDDL']),
+    makeContract('a11y', ['a11y.wcagLevel', 'a11y.keyboardSpec']),
+    makeContract('performance', ['performance.lighthouseTargets']),
+    makeContract('analytics', ['analytics.eventTaxonomy', 'analytics.consentMode']),
+    makeContract('observability', ['observability.logShape', 'observability.metricsExport']),
+    makeContract('security', ['security.cspPolicy', 'security.dataClassification']),
+    makeContract('apiGateway', ['apiGateway.rateLimit']),
+    makeContract('featureFlagging', ['featureFlags.flagStore', 'featureFlags.killSwitch']),
+    makeContract('abTesting', ['abTesting.variantRouter']),
+    makeContract('devops', ['devops.deployStrategy']),
+    makeContract('timeMachine', ['timeMachine.revertCommand']),
+    makeContract('testing', ['testing.fixtures']),
+    makeContract('seo', ['seo.canonical']),
+  ];
+}
+
+export function cleanAudit(): readonly ArchitectAuditRow[] {
+  return cleanContracts().map((c) => audit(c.architectName));
+}
+
+export function cleanReviewerInput(): ReviewerInput {
+  const ac = stubTicket().acceptance_criteria;
+  return {
+    ticket: stubTicket(),
+    composedArchitecture: cleanComposedArchitecture(),
+    auditRows: cleanAudit(),
+    contracts: cleanContracts(),
+    ...(ac ? { acceptanceCriteria: ac } : {}),
+  };
+}

--- a/packages/ea-reviewer/tests/integration.test.ts
+++ b/packages/ea-reviewer/tests/integration.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Integration test — exercises the full pass → fail → rerun → pass cycle.
+ */
+import { describe, it, expect } from 'vitest';
+import { Reviewer } from '../src/reviewer.js';
+import { NullCriticAdapter } from '../src/critic.js';
+import {
+  cleanReviewerInput,
+} from './fixtures.js';
+
+describe('reviewer integration — full audit cycle', () => {
+  it('clean pass produces ea-complete-verified, no reruns, no advisories', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const decision = await r.review(cleanReviewerInput());
+    expect(decision.decision).toBe('pass');
+    expect(decision.finalState).toBe('ea-complete-verified');
+    expect(decision.rerunArchitects).toEqual([]);
+    expect(decision.advisories).toEqual([]);
+  });
+
+  it('one bad input → fail → rerun list specific → fixed → pass', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+
+    // First pass: break the a11y wcagLevel.
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    delete broken['a11y.wcagLevel'];
+    const fail = await r.review({ ...input, composedArchitecture: broken });
+    expect(fail.decision).toBe('fail');
+    expect(fail.rerunArchitects.length).toBe(1);
+    expect(fail.rerunArchitects[0]?.architect).toBe('a11y');
+
+    // Second pass: a11y re-ran and provided the missing field.
+    const fixed = { ...broken, 'a11y.wcagLevel': 'AAA' };
+    const pass = await r.review({ ...input, composedArchitecture: fixed });
+    expect(pass.decision).toBe('pass');
+  });
+
+  it('findings expose all three lenses separately', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const decision = await r.review(cleanReviewerInput());
+    expect(decision.findings).toHaveProperty('completeness');
+    expect(decision.findings).toHaveProperty('consistency');
+    expect(decision.findings).toHaveProperty('correctness');
+  });
+
+  it('multiple-architect-rerun: reviewer dedups + sums severity', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    // Trigger multiple unrelated invariants
+    broken['backend.endpointEnumeration'] = [{ path: '/a' }, { path: '/b' }];
+    broken['apiGateway.rateLimit'] = [{ path: '/a' }]; // /b uncovered
+    broken['featureFlags.flagStore'] = [{ name: 'A' }, { name: 'B' }];
+    broken['featureFlags.killSwitch'] = [{ name: 'A' }]; // B uncovered
+    const decision = await r.review({ ...input, composedArchitecture: broken });
+    expect(decision.decision).toBe('fail');
+    const names = decision.rerunArchitects.map((d) => d.architect);
+    expect(names).toContain('apiGateway');
+    expect(names).toContain('featureFlagging');
+  });
+});

--- a/packages/ea-reviewer/tests/invariants.test.ts
+++ b/packages/ea-reviewer/tests/invariants.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import {
+  REVIEWER_INVARIANTS,
+  runConsistencyLens,
+  type Invariant,
+} from '../src/invariants.js';
+import { cleanComposedArchitecture } from './fixtures.js';
+
+describe('REVIEWER_INVARIANTS registry', () => {
+  it('exports a non-empty invariant set', () => {
+    expect(REVIEWER_INVARIANTS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every invariant has id, description, blame, and predicate', () => {
+    for (const inv of REVIEWER_INVARIANTS) {
+      expect(inv.id).toBeTruthy();
+      expect(inv.description).toBeTruthy();
+      expect(inv.blameArchitects.length).toBeGreaterThan(0);
+      expect(typeof inv.holds).toBe('function');
+    }
+  });
+
+  it('invariant ids are unique', () => {
+    const ids = REVIEWER_INVARIANTS.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('runConsistencyLens — clean fixture', () => {
+  it('produces zero findings on a fully-clean composed architecture', () => {
+    const findings = runConsistencyLens(cleanComposedArchitecture());
+    expect(findings).toEqual([]);
+  });
+
+  it('returns empty array on empty architecture (vacuously true)', () => {
+    expect(runConsistencyLens({})).toEqual([]);
+  });
+});
+
+describe('individual invariants — failure cases', () => {
+  function only(id: string): readonly Invariant[] {
+    return REVIEWER_INVARIANTS.filter((i) => i.id === id);
+  }
+
+  it('every-endpoint-has-gateway-policy fires for uncovered endpoint', () => {
+    const findings = runConsistencyLens(
+      {
+        'backend.endpointEnumeration': [{ path: '/a' }, { path: '/b' }],
+        'apiGateway.rateLimit': [{ path: '/a' }],
+      },
+      { invariants: only('every-endpoint-has-gateway-policy') },
+    );
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.invariantId).toBe('every-endpoint-has-gateway-policy');
+    expect(findings[0]?.blameArchitects).toContain('apiGateway');
+  });
+
+  it('every-event-has-metric fires for orphan event', () => {
+    const findings = runConsistencyLens(
+      {
+        'analytics.eventTaxonomy': [{ name: 'a' }, { name: 'b' }],
+        'observability.metricsExport': [{ event: 'a' }],
+      },
+      { invariants: only('every-event-has-metric') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('interactive-widgets-have-keyboard-spec fires when keyboard missing', () => {
+    const findings = runConsistencyLens(
+      {
+        'frontend.componentTree': [{ id: 'b1', interactive: true }],
+        'a11y.keyboardSpec': [],
+      },
+      { invariants: only('interactive-widgets-have-keyboard-spec') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('csp-allows-iframes-if-tree-has-them fires when CSP forbids', () => {
+    const findings = runConsistencyLens(
+      {
+        'frontend.componentTree': [{ kind: 'iframe-embed' }],
+        'security.cspPolicy': { frameSrc: "'none'" },
+      },
+      { invariants: only('csp-allows-iframes-if-tree-has-them') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('every-feature-flag-has-killswitch fires for unguarded flag', () => {
+    const findings = runConsistencyLens(
+      {
+        'featureFlags.flagStore': [{ name: 'a' }, { name: 'b' }],
+        'featureFlags.killSwitch': [{ name: 'a' }],
+      },
+      { invariants: only('every-feature-flag-has-killswitch') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('ab-test-variants-bind-to-flags fires for missing flag', () => {
+    const findings = runConsistencyLens(
+      {
+        'abTesting.variantRouter': [{ flag: 'ghost' }],
+        'featureFlags.flagStore': [{ name: 'real' }],
+      },
+      { invariants: only('ab-test-variants-bind-to-flags') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('preload-and-lazy-load-are-disjoint fires on overlap', () => {
+    const findings = runConsistencyLens(
+      {
+        'seo.preloadHints': [{ href: 'hero.jpg' }],
+        'performance.lazyLoadList': [{ src: 'hero.jpg' }],
+      },
+      { invariants: only('preload-and-lazy-load-are-disjoint') },
+    );
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.blameArchitects).toEqual(['seo', 'performance']);
+  });
+
+  it('database-schema-references-only-known-engines fires on unknown', () => {
+    const findings = runConsistencyLens(
+      { 'database.engine': 'cassandra' },
+      { invariants: only('database-schema-references-only-known-engines') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('devops-blue-green-implies-time-machine-revert fires on missing revert', () => {
+    const findings = runConsistencyLens(
+      {
+        'devops.deployStrategy': 'blue-green',
+        'timeMachine.revertCommand': '',
+      },
+      { invariants: only('devops-blue-green-implies-time-machine-revert') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('pii-data-requires-deny-by-default-consent fires on permissive consent', () => {
+    const findings = runConsistencyLens(
+      {
+        'security.dataClassification': 'PII',
+        'analytics.consentMode': 'opt-in',
+      },
+      { invariants: only('pii-data-requires-deny-by-default-consent') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('every-endpoint-has-fixture fires when no fixture matches', () => {
+    const findings = runConsistencyLens(
+      {
+        'backend.endpointEnumeration': [{ path: '/api/x' }],
+        'testing.fixtures': [{ path: '/api/y' }],
+      },
+      { invariants: only('every-endpoint-has-fixture') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('observability-logs-are-non-empty-when-backend-present fires on empty logs', () => {
+    const findings = runConsistencyLens(
+      {
+        'backend.framework': 'express',
+        'observability.logShape': '',
+      },
+      { invariants: only('observability-logs-are-non-empty-when-backend-present') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('a11y-wcag-level-is-aa-or-aaa fires on level A', () => {
+    const findings = runConsistencyLens(
+      { 'a11y.wcagLevel': 'A' },
+      { invariants: only('a11y-wcag-level-is-aa-or-aaa') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('performance-lighthouse-targets-are-numeric fires on string value', () => {
+    const findings = runConsistencyLens(
+      { 'performance.lighthouseTargets': { perf: 'fast' } },
+      { invariants: only('performance-lighthouse-targets-are-numeric') },
+    );
+    expect(findings.length).toBe(1);
+  });
+
+  it('seo-canonical-is-https fires on http URL', () => {
+    const findings = runConsistencyLens(
+      { 'seo.canonical': 'http://example.com' },
+      { invariants: only('seo-canonical-is-https') },
+    );
+    expect(findings.length).toBe(1);
+  });
+});
+
+describe('runConsistencyLens — runner behavior', () => {
+  it('survives a buggy invariant predicate', () => {
+    const buggy: Invariant = {
+      id: 'boom',
+      description: 'always throws',
+      blameArchitects: ['frontend'],
+      holds: () => {
+        throw new Error('boom');
+      },
+    };
+    const findings = runConsistencyLens({}, { invariants: [buggy] });
+    expect(findings).toEqual([]);
+  });
+
+  it('honors a custom severity', () => {
+    const findings = runConsistencyLens(
+      {
+        'backend.endpointEnumeration': [{ path: '/a' }],
+        'apiGateway.rateLimit': [],
+      },
+      { severity: 'P0' },
+    );
+    expect(findings[0]?.severity).toBe('P0');
+  });
+});

--- a/packages/ea-reviewer/tests/reviewer.test.ts
+++ b/packages/ea-reviewer/tests/reviewer.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { Reviewer, review } from '../src/reviewer.js';
+import {
+  FixedCriticAdapter,
+  NullCriticAdapter,
+} from '../src/critic.js';
+import type { ArchitectAuditRow } from '../src/types.js';
+import {
+  audit,
+  cleanComposedArchitecture,
+  cleanContracts,
+  cleanReviewerInput,
+  makeContract,
+  stubTicket,
+} from './fixtures.js';
+
+describe('Reviewer.review — pass path', () => {
+  it('passes a clean composed architecture', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const decision = await r.review(cleanReviewerInput());
+    expect(decision.decision).toBe('pass');
+    expect(decision.finalState).toBe('ea-complete-verified');
+    expect(decision.rerunArchitects).toEqual([]);
+  });
+
+  it('summary describes a clean pass', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const decision = await r.review(cleanReviewerInput());
+    expect(decision.summary).toMatch(/passed/i);
+  });
+
+  it('emits low-confidence advisories for sub-floor architects', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const mutatedAudit: ArchitectAuditRow[] = input.auditRows.map((a) =>
+      a.architectName === 'a11y' ? { ...a, confidence: 0.3 } : a,
+    );
+    const decision = await r.review({ ...input, auditRows: mutatedAudit });
+    expect(decision.advisories.some((a) => a.architect === 'a11y')).toBe(true);
+  });
+});
+
+describe('Reviewer.review — fail path', () => {
+  it('fails when a required path is missing → rerun the owning architect', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    delete broken['a11y.wcagLevel'];
+    const decision = await r.review({ ...input, composedArchitecture: broken });
+    expect(decision.decision).toBe('fail');
+    expect(decision.finalState).toBe('ea-rejected');
+    expect(decision.rerunArchitects.map((d) => d.architect)).toContain('a11y');
+  });
+
+  it('fails when a consistency invariant is violated → blames the named architect', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    // Add an endpoint without rate-limit coverage
+    broken['backend.endpointEnumeration'] = [
+      { path: '/api/signup' },
+      { path: '/api/admin' },
+    ];
+    const decision = await r.review({ ...input, composedArchitecture: broken });
+    expect(decision.decision).toBe('fail');
+    expect(decision.rerunArchitects.map((d) => d.architect)).toContain('apiGateway');
+  });
+
+  it('escalations become P0 rerun directives', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const decision = await r.review({
+      ...input,
+      escalations: [
+        {
+          ruleId: 'same-rank-conflict',
+          architects: ['security', 'devops'],
+          reason: 'both want different secrets stores',
+        },
+      ],
+    });
+    expect(decision.decision).toBe('fail');
+    expect(decision.rerunArchitects.length).toBeGreaterThanOrEqual(2);
+    expect(decision.rerunArchitects.every((d) => d.severity === 'P0')).toBe(true);
+  });
+
+  it('correctness findings with a specific architect drive a rerun', async () => {
+    const fixed = new FixedCriticAdapter([
+      {
+        acceptanceCriterion: 'AC',
+        blameArchitect: 'analytics',
+        reason: 'consent flow does not cover EU users',
+        severity: 'P1',
+      },
+    ]);
+    const r = new Reviewer({ critic: fixed });
+    const decision = await r.review(cleanReviewerInput());
+    expect(decision.decision).toBe('fail');
+    expect(decision.rerunArchitects.map((d) => d.architect)).toContain('analytics');
+  });
+
+  it('correctness findings blaming global become advisories, not reruns', async () => {
+    const fixed = new FixedCriticAdapter([
+      {
+        acceptanceCriterion: 'AC',
+        blameArchitect: 'global',
+        reason: 'no clear owner',
+        severity: 'P1',
+      },
+    ]);
+    const r = new Reviewer({ critic: fixed });
+    const decision = await r.review(cleanReviewerInput());
+    // Without a specific architect to blame, this doesn't force a rerun
+    expect(decision.rerunArchitects).toEqual([]);
+    // It IS an advisory
+    expect(decision.advisories.some((a) => a.architect === 'global')).toBe(true);
+  });
+});
+
+describe('Reviewer.review — deduplication + severity', () => {
+  it('takes the highest severity per architect across multiple findings', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    delete broken['a11y.wcagLevel']; // P1 missing-required (default)
+    broken['a11y.keyboardSpec'] = []; // breaks interactive-widget invariant
+    // Add escalation that names a11y at P0
+    const decision = await r.review({
+      ...input,
+      composedArchitecture: broken,
+      escalations: [
+        {
+          ruleId: 'esc',
+          architects: ['a11y', 'frontend'],
+          reason: 'see ya',
+        },
+      ],
+    });
+    const a11yEntry = decision.rerunArchitects.find((d) => d.architect === 'a11y');
+    expect(a11yEntry?.severity).toBe('P0');
+  });
+
+  it('concatenates reasons for same-severity entries on the same architect', async () => {
+    const r = new Reviewer({ critic: new NullCriticAdapter() });
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    delete broken['a11y.wcagLevel'];
+    broken['a11y.keyboardSpec'] = []; // breaks invariant
+    broken['frontend.componentTree'] = [{ id: 'btn-1', interactive: true }];
+    const decision = await r.review({ ...input, composedArchitecture: broken });
+    const a11yEntry = decision.rerunArchitects.find((d) => d.architect === 'a11y');
+    // Multiple reasons concatenated with `;`
+    expect(a11yEntry?.reason).toMatch(/;/);
+  });
+
+  it('honors a custom blocking-severity set', async () => {
+    const r = new Reviewer(
+      { critic: new NullCriticAdapter() },
+      { blockingSeverities: ['P0'] },
+    );
+    const input = cleanReviewerInput();
+    const broken = { ...input.composedArchitecture };
+    delete broken['a11y.wcagLevel']; // P1 default
+    const decision = await r.review({ ...input, composedArchitecture: broken });
+    // P1 missing-required no longer blocks
+    expect(decision.decision).toBe('pass');
+    // It DOES surface as an advisory
+    expect(decision.advisories.some((a) => a.architect === 'a11y')).toBe(true);
+  });
+});
+
+describe('Reviewer functional flavour', () => {
+  it('review(input) without deps still works (default null critic)', async () => {
+    const decision = await review(cleanReviewerInput());
+    expect(decision.decision).toBe('pass');
+  });
+});
+
+describe('Reviewer + escalation tie cases', () => {
+  it('escalation with no architect names produces no rerun directives', async () => {
+    const decision = await review({
+      ticket: stubTicket(),
+      composedArchitecture: cleanComposedArchitecture(),
+      auditRows: cleanContracts().map((c) => audit(c.architectName)),
+      contracts: cleanContracts(),
+      escalations: [],
+    });
+    expect(decision.decision).toBe('pass');
+  });
+
+  it('handles a no-architects ticket (empty contracts / audit)', async () => {
+    const decision = await review({
+      ticket: stubTicket(),
+      composedArchitecture: {},
+      auditRows: [],
+      contracts: [],
+    });
+    expect(decision.decision).toBe('pass');
+    expect(decision.findings.completeness).toEqual([]);
+  });
+
+  it('failed architect → completeness finding for <all>', async () => {
+    const decision = await review({
+      ticket: stubTicket(),
+      composedArchitecture: {},
+      auditRows: [audit('failed-arch', { status: 'failed' })],
+      contracts: [makeContract('failed-arch', ['failed-arch.x'])],
+    });
+    expect(decision.decision).toBe('fail');
+    expect(decision.findings.completeness[0]?.missingPath).toBe('<all>');
+  });
+});

--- a/packages/ea-reviewer/tsconfig.json
+++ b/packages/ea-reviewer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/ea-reviewer/vitest.config.ts
+++ b/packages/ea-reviewer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1369,6 +1369,22 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/ea-reviewer:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/errors:
     devDependencies:
       '@chiefaia/eslint-config':


### PR DESCRIPTION
Critic-style audit for the composed tickets.architecture JSONB. Runs three deterministic lenses (completeness, consistency, correctness) plus an optional LLM-judge for acceptance-criteria correctness. Emits a decision envelope the orchestrator consumes:

- pass → ticket transitions to ea-complete-verified → Test Author
- fail → ticket transitions to ea-rejected, with rerunArchitects naming only the specific architects to re-run (not the full roster). Capped at 3 iterations per §6.3.

Sourced from research/17_architect_framework_spec_2026.md §6.

**Ships:** Reviewer class + review(), completeness lens (every required SectionContract.path populated), consistency lens (15 cross-architect invariants), correctness lens via CriticAdapter DI seam (NullCriticAdapter, HeuristicCriticAdapter, FixedCriticAdapter — production wires Claude via @chiefaia/claude-spawner), per-architect deduplication + severity escalation, escalations → P0 rerun directives, low-confidence advisories.

**Tests: 57 vitest passing** — completeness, invariants (one fail-case per invariant + clean fixture), critic adapters, reviewer (pass/fail/rerun loop/severity merge/custom blocking), integration (end-to-end iteration loop), cross-package E2E (compute-waves + audit). tsc --noEmit clean under strict + exactOptionalPropertyTypes.

Reviewer cannot write to tickets.architecture (§6.4) — emits decision envelope only.

Stacked on #535. Diff shrinks to ea-reviewer only after #535 lands.
