### PR TITLE
feat(@caia/state-machine): typed pipeline FSM with Postgres store + realtime SSE

### DIFF
--- a/packages/state-machine/README.md
+++ b/packages/state-machine/README.md
@@ -1,0 +1,75 @@
+# @caia/state-machine
+
+A typed pipeline-status finite-state machine for CAIA projects.
+
+* Strict enum of ~40 project states (happy, failed, control).
+* Statically-enumerated valid transitions; invalid moves throw a typed `InvalidTransitionError`.
+* Optimistic-locked atomic transitions with retry budget and payload-hash idempotency.
+* Postgres-backed durable store **and** an in-memory store for tests.
+* Distributed worker assignment (`tryAssignWork` / `recordWorkerHeartbeat` / `completeWork` / `expireInactiveWorkers`) backed by Postgres advisory upserts.
+* LISTEN/NOTIFY → SSE realtime feed.
+* `whatsNext(projectId)` — idempotent next-step helper used by the orchestrator.
+
+This package is consumed by the CAIA orchestrator chain (`@chiefaia/chain-runner`,
+`@chiefaia/capability-broker`). See the
+[`state_machine_handoff_spec_2026.md`](../../../research/state_machine_handoff_spec_2026.md)
+for the source-of-truth design.
+
+## Usage
+
+```ts
+import { Pool } from 'pg';
+import {
+  StateMachine,
+  PgStateStore,
+  InMemoryStateStore,
+  whatsNext,
+} from '@caia/state-machine';
+
+const pool = new Pool({ connectionString: process.env.PG_DSN });
+const sm = new StateMachine(new PgStateStore(pool));
+await sm.init(); // runs migration
+
+const project = await sm.createProject({
+  tenantId: 't1',
+  slug: 'my-project',
+  displayName: 'My Project',
+});
+
+await sm.transition(project.id, 'idea-captured', {
+  reason: 'onboarding-complete',
+  triggeredBy: { kind: 'system', id: 'orchestrator' },
+});
+
+const next = await whatsNext(sm, project.id);
+// { hasWork: true, agent: { type: '@caia/idea-capture', ... } }
+
+const unsub = await sm.subscribeToProject(project.id, (evt) => {
+  console.log('state transition:', evt);
+});
+```
+
+## Stores
+
+Use `InMemoryStateStore` for unit tests. Use `PgStateStore` for everything else.
+
+```ts
+const sm = new StateMachine(new InMemoryStateStore());
+```
+
+## States
+
+The canonical state enum lives in `src/states.ts` and the valid-transition table
+in `src/transitions.ts`. Both are sourced from the spec.
+
+## Scripts
+
+```sh
+pnpm --filter @caia/state-machine test       # vitest
+pnpm --filter @caia/state-machine typecheck  # tsc --noEmit
+pnpm --filter @caia/state-machine build      # tsc → dist/
+```
+
+## License
+
+MIT.

--- a/packages/state-machine/migrations/0001_state_machine.sql
+++ b/packages/state-machine/migrations/0001_state_machine.sql
@@ -1,0 +1,138 @@
+-- @caia/state-machine — Postgres schema.
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS, the CHECK constraint is
+-- rewritten by ALTER on every run, and indices are guarded by IF NOT
+-- EXISTS. Safe to apply repeatedly.
+--
+-- Sourced from research/state_machine_handoff_spec_2026.md §2.
+
+CREATE SCHEMA IF NOT EXISTS caia_meta;
+
+-- -- tenant_projects ---------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS caia_meta.tenant_projects (
+  id                        UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id                 TEXT         NOT NULL,
+  slug                      TEXT         NOT NULL,
+  display_name              TEXT         NOT NULL,
+  status                    TEXT         NOT NULL DEFAULT 'onboarding',
+  paused                    BOOLEAN      NOT NULL DEFAULT false,
+  paused_at                 TIMESTAMPTZ,
+  paused_by                 TEXT,
+  current_payload           JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  last_transitioned_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  last_transitioned_by      TEXT         NOT NULL DEFAULT 'system',
+  parent_project_id         UUID         REFERENCES caia_meta.tenant_projects(id),
+  fork_origin_history_id    BIGINT,
+  archived_at               TIMESTAMPTZ,
+  version                   INTEGER      NOT NULL DEFAULT 1,
+  created_at                TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, slug)
+);
+
+-- Widen / re-assert status check.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'tenant_projects_status_check'
+       AND conrelid = 'caia_meta.tenant_projects'::regclass
+  ) THEN
+    ALTER TABLE caia_meta.tenant_projects
+      DROP CONSTRAINT tenant_projects_status_check;
+  END IF;
+END$$;
+
+ALTER TABLE caia_meta.tenant_projects
+  ADD CONSTRAINT tenant_projects_status_check
+  CHECK (status IN (
+    'onboarding','idea-captured','interviewing','interview-complete',
+    'proposal-generated','awaiting-external-design','design-uploaded',
+    'ticket-tree-generated','atlas-ready','change-requested',
+    'ea-dispatching','ea-complete','tests-authored','tests-reviewed',
+    'scheduled','coding-in-progress','code-complete','per-story-tested',
+    'e2e-tested','deploying','deployed','verified','done',
+    'onboarding-failed','interviewing-failed','proposal-failed',
+    'design-ingest-failed','atlas-decompose-failed','ea-dispatching-failed',
+    'ea-review-failed','tests-authoring-failed','tests-review-failed',
+    'scheduling-failed','coding-failed','per-story-test-failed',
+    'e2e-failed','deploy-failed','verify-failed',
+    'paused','revision-pending','archived'
+  ));
+
+CREATE INDEX IF NOT EXISTS tenant_projects_paused_idx
+  ON caia_meta.tenant_projects(paused) WHERE paused = true;
+
+CREATE INDEX IF NOT EXISTS tenant_projects_state_active_idx
+  ON caia_meta.tenant_projects(status)
+  WHERE archived_at IS NULL;
+
+-- -- state_history ----------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS caia_meta.state_history (
+  id                BIGSERIAL    PRIMARY KEY,
+  project_id        UUID         NOT NULL REFERENCES caia_meta.tenant_projects(id),
+  from_state        TEXT,
+  to_state          TEXT         NOT NULL,
+  reason            TEXT         NOT NULL,
+  actor_kind        TEXT         NOT NULL CHECK (actor_kind IN ('system','operator','agent')),
+  actor_id          TEXT         NOT NULL,
+  agent_run_id      UUID,
+  payload           JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  at                TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  payload_hash      TEXT         NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS state_history_project_at_idx
+  ON caia_meta.state_history(project_id, at DESC);
+CREATE INDEX IF NOT EXISTS state_history_to_state_idx
+  ON caia_meta.state_history(to_state, at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS state_history_idempotency_idx
+  ON caia_meta.state_history(project_id, to_state, payload_hash);
+
+-- -- ticket_claims (distributed worker assignment) --------------------------
+
+CREATE TABLE IF NOT EXISTS caia_meta.ticket_claims (
+  ticket_id        TEXT         PRIMARY KEY,
+  project_id       UUID,
+  claimed_by       TEXT,
+  claimed_at       TIMESTAMPTZ,
+  heartbeat_at     TIMESTAMPTZ,
+  ttl_seconds      INTEGER      NOT NULL DEFAULT 90,
+  final_status     TEXT,
+  final_at         TIMESTAMPTZ,
+  version          INTEGER      NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS ticket_claims_claimed_by_idx
+  ON caia_meta.ticket_claims(claimed_by) WHERE claimed_by IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ticket_claims_heartbeat_idx
+  ON caia_meta.ticket_claims(heartbeat_at) WHERE claimed_by IS NOT NULL;
+
+-- -- LISTEN/NOTIFY trigger for state transitions ---------------------------
+
+CREATE OR REPLACE FUNCTION caia_meta.state_history_notify()
+RETURNS trigger AS $$
+DECLARE
+  channel TEXT := 'caia_project_' || NEW.project_id::text;
+  payload TEXT;
+BEGIN
+  payload := json_build_object(
+    'kind', 'state-transition',
+    'history_id', NEW.id,
+    'from_state', NEW.from_state,
+    'to_state', NEW.to_state,
+    'reason', NEW.reason,
+    'actor_kind', NEW.actor_kind,
+    'actor_id', NEW.actor_id,
+    'at', NEW.at
+  )::text;
+  PERFORM pg_notify(channel, payload);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS state_history_notify_trg ON caia_meta.state_history;
+CREATE TRIGGER state_history_notify_trg
+  AFTER INSERT ON caia_meta.state_history
+  FOR EACH ROW EXECUTE FUNCTION caia_meta.state_history_notify();

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@caia/state-machine",
+  "version": "0.1.0",
+  "description": "Typed pipeline-status finite-state machine for CAIA projects. Postgres-backed, with optimistic concurrency, atomic worker assignment, and LISTEN/NOTIFY → SSE realtime.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./states": {
+      "import": "./dist/states.js",
+      "types": "./dist/states.d.ts"
+    },
+    "./transitions": {
+      "import": "./dist/transitions.js",
+      "types": "./dist/transitions.d.ts"
+    },
+    "./test-support": {
+      "import": "./dist/test-support.js",
+      "types": "./dist/test-support.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "migrations"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "pg": "^8.20.0"
+  },
+  "devDependencies": {
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "@types/pg": "^8.11.10",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/state-machine/src/errors.ts
+++ b/packages/state-machine/src/errors.ts
@@ -1,0 +1,66 @@
+import type { ProjectState } from './states.js';
+
+export class InvalidTransitionError extends Error {
+  override name = 'InvalidTransitionError';
+  constructor(
+    public readonly from: ProjectState,
+    public readonly to: ProjectState,
+    public readonly reasonDetail?: string,
+  ) {
+    super(
+      reasonDetail
+        ? `invalid transition ${from} -> ${to}: ${reasonDetail}`
+        : `invalid transition ${from} -> ${to}`,
+    );
+  }
+}
+
+export class StaleProjectVersionError extends Error {
+  override name = 'StaleProjectVersionError';
+  constructor(
+    public readonly projectId: string,
+    public readonly expectedVersion: number,
+  ) {
+    super(
+      `project ${projectId} version ${expectedVersion} is stale - another writer won the race`,
+    );
+  }
+}
+
+export class ProjectNotFoundError extends Error {
+  override name = 'ProjectNotFoundError';
+  constructor(public readonly projectId: string) {
+    super(`project ${projectId} not found`);
+  }
+}
+
+export class AdvisoryLockHeldError extends Error {
+  override name = 'AdvisoryLockHeldError';
+  constructor(public readonly projectId: string) {
+    super(`advisory lock already held for project ${projectId}`);
+  }
+}
+
+export class TicketAlreadyClaimedError extends Error {
+  override name = 'TicketAlreadyClaimedError';
+  constructor(
+    public readonly ticketId: string,
+    public readonly claimedBy?: string,
+  ) {
+    super(
+      `ticket ${ticketId} already claimed${claimedBy ? ` by ${claimedBy}` : ''}`,
+    );
+  }
+}
+
+export class TransitionRetryExhaustedError extends Error {
+  override name = 'TransitionRetryExhaustedError';
+  constructor(
+    public readonly projectId: string,
+    public readonly attempts: number,
+  ) {
+    super(
+      `transition for project ${projectId} retried ${attempts} times without progress`,
+    );
+  }
+}

--- a/packages/state-machine/src/hash.ts
+++ b/packages/state-machine/src/hash.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Canonical-JSON sha256, used as the idempotency key for `state_history`.
+ *
+ * Stable key order - keys are sorted alphabetically at every depth. This
+ * means {a:1,b:2} and {b:2,a:1} hash identically. Arrays preserve order.
+ */
+export function hashPayload(payload: Record<string, unknown>): string {
+  const canonical = stableStringify(payload);
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? String(value) : 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const parts = keys.map(
+      (k) => JSON.stringify(k) + ':' + stableStringify(obj[k]),
+    );
+    return '{' + parts.join(',') + '}';
+  }
+  // undefined, function, etc. -> null per JSON semantics
+  return 'null';
+}

--- a/packages/state-machine/src/in-memory-store.ts
+++ b/packages/state-machine/src/in-memory-store.ts
@@ -1,0 +1,383 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ProjectState } from './states.js';
+import type {
+  StateStore,
+  TransitionAtomicInput,
+  TransitionAtomicResult,
+} from './store.js';
+import type {
+  ActorKind,
+  ClaimResult,
+  JanitorResult,
+  NewProjectInput,
+  ProjectRow,
+  StateTransitionRow,
+} from './types.js';
+
+interface ClaimRecord {
+  ticketId: string;
+  projectId: string | null;
+  claimedBy: string | null;
+  claimedAt: Date | null;
+  heartbeatAt: Date | null;
+  ttlSeconds: number;
+  finalStatus: string | null;
+  finalAt: Date | null;
+  version: number;
+}
+
+interface HistoryRecord extends StateTransitionRow {}
+
+/**
+ * In-process StateStore. Maps + arrays only; no SQL.
+ *
+ * Concurrency model:
+ *   - JS is single-threaded; the only contention is between async tasks
+ *     that interleave between awaits.
+ *   - `transitionAtomic` and `tryClaim` are written as single synchronous
+ *     blocks (no `await` between read and write), so they are atomic
+ *     within the event loop. Any race in tests that uses `await` between
+ *     "read" and "write" can therefore be reproduced reliably without
+ *     timing flakes.
+ */
+export class InMemoryStateStore implements StateStore {
+  private projects = new Map<string, ProjectRow>();
+  private history: HistoryRecord[] = [];
+  private historyNextId = 1;
+  private claims = new Map<string, ClaimRecord>();
+  private listeners = new Map<string, Set<(payload: string) => void>>();
+
+  async init(): Promise<void> {
+    // no-op
+  }
+
+  async reset(): Promise<void> {
+    this.projects.clear();
+    this.history = [];
+    this.historyNextId = 1;
+    this.claims.clear();
+    this.listeners.clear();
+  }
+
+  async createProject(input: NewProjectInput): Promise<ProjectRow> {
+    const id = input.id ?? randomUUID();
+    if (this.projects.has(id)) {
+      throw new Error(`project ${id} already exists`);
+    }
+    const now = new Date();
+    const rec: ProjectRow = {
+      id,
+      tenantId: input.tenantId,
+      slug: input.slug,
+      displayName: input.displayName,
+      status: input.initialState ?? 'onboarding',
+      paused: false,
+      pausedAt: null,
+      pausedBy: null,
+      currentPayload: input.initialPayload ?? {},
+      lastTransitionedAt: now,
+      lastTransitionedBy: 'system',
+      parentProjectId: input.parentProjectId ?? null,
+      archivedAt: null,
+      version: 1,
+      createdAt: now,
+    };
+    this.projects.set(id, rec);
+    return cloneProject(rec);
+  }
+
+  async getProject(projectId: string): Promise<ProjectRow | null> {
+    const rec = this.projects.get(projectId);
+    return rec ? cloneProject(rec) : null;
+  }
+
+  async listActiveProjects(): Promise<ProjectRow[]> {
+    return [...this.projects.values()]
+      .filter((p) => p.archivedAt === null)
+      .map(cloneProject);
+  }
+
+  async setPaused(
+    projectId: string,
+    paused: boolean,
+    by: string | null,
+  ): Promise<void> {
+    const rec = this.projects.get(projectId);
+    if (!rec) return;
+    rec.paused = paused;
+    if (paused) {
+      rec.pausedAt = new Date();
+      rec.pausedBy = by;
+    } else {
+      rec.pausedAt = null;
+      rec.pausedBy = null;
+    }
+  }
+
+  async transitionAtomic(
+    input: TransitionAtomicInput,
+  ): Promise<TransitionAtomicResult> {
+    const rec = this.projects.get(input.projectId);
+    if (!rec) return { applied: false, newVersion: 0, historyId: null };
+
+    // Idempotency rule 1: payload-hash unique index.
+    const dupByHash = this.history.find(
+      (h) =>
+        h.projectId === input.projectId &&
+        h.toState === input.toState &&
+        h.payloadHash === input.payloadHash,
+    );
+    if (dupByHash) {
+      return {
+        applied: false,
+        newVersion: rec.version,
+        historyId: dupByHash.id,
+      };
+    }
+
+    // Idempotency rule 2: time-window dedupe.
+    if (input.idempotencyWindowMs > 0) {
+      const cutoff = Date.now() - input.idempotencyWindowMs;
+      const dupByWindow = this.history.find(
+        (h) =>
+          h.projectId === input.projectId &&
+          h.toState === input.toState &&
+          h.payloadHash === input.payloadHash &&
+          h.at.getTime() >= cutoff,
+      );
+      if (dupByWindow) {
+        return {
+          applied: false,
+          newVersion: rec.version,
+          historyId: dupByWindow.id,
+        };
+      }
+    }
+
+    // Optimistic lock.
+    if (rec.version !== input.expectedVersion) {
+      return { applied: false, newVersion: rec.version, historyId: null };
+    }
+    if (rec.status !== input.expectedStatus) {
+      return { applied: false, newVersion: rec.version, historyId: null };
+    }
+
+    // Apply.
+    rec.status = input.toState;
+    rec.currentPayload = input.payload;
+    rec.lastTransitionedAt = new Date();
+    rec.lastTransitionedBy = input.actorId;
+    rec.version = rec.version + 1;
+    if (input.toState === 'archived') rec.archivedAt = new Date();
+
+    const id = this.historyNextId++;
+    const histRec: HistoryRecord = {
+      id,
+      projectId: input.projectId,
+      fromState: input.expectedStatus,
+      toState: input.toState,
+      reason: input.reason,
+      actorKind: input.actorKind as ActorKind,
+      actorId: input.actorId,
+      agentRunId: input.agentRunId,
+      payload: input.payload,
+      at: rec.lastTransitionedAt,
+      payloadHash: input.payloadHash,
+    };
+    this.history.push(histRec);
+
+    this.fireNotify('caia_project_' + input.projectId, {
+      kind: 'state-transition',
+      history_id: id,
+      from_state: input.expectedStatus,
+      to_state: input.toState,
+      reason: input.reason,
+      actor_kind: input.actorKind,
+      actor_id: input.actorId,
+      at: histRec.at.toISOString(),
+    });
+
+    return { applied: true, newVersion: rec.version, historyId: id };
+  }
+
+  async listHistory(
+    projectId: string,
+    opts: { limit?: number; afterId?: number; toState?: ProjectState } = {},
+  ): Promise<StateTransitionRow[]> {
+    let rows = this.history.filter((h) => h.projectId === projectId);
+    if (opts.afterId !== undefined)
+      rows = rows.filter((h) => h.id > (opts.afterId as number));
+    if (opts.toState) rows = rows.filter((h) => h.toState === opts.toState);
+    rows = rows.slice().sort((a, b) => a.id - b.id);
+    if (opts.limit !== undefined) rows = rows.slice(0, opts.limit);
+    return rows.map(cloneHistory);
+  }
+
+  async tryClaim(input: {
+    ticketId: string;
+    projectId: string | null;
+    agentId: string;
+    ttlSeconds: number;
+    now: Date;
+  }): Promise<ClaimResult> {
+    const existing = this.claims.get(input.ticketId);
+    if (existing && existing.claimedBy && existing.claimedBy !== input.agentId) {
+      // Check if the existing claim has expired.
+      const last =
+        existing.heartbeatAt?.getTime() ?? existing.claimedAt?.getTime() ?? 0;
+      const age = (input.now.getTime() - last) / 1000;
+      if (age <= existing.ttlSeconds) {
+        return { claimed: false, ttl: existing.ttlSeconds };
+      }
+      // expired - fall through to claim.
+    }
+    const rec: ClaimRecord = existing ?? {
+      ticketId: input.ticketId,
+      projectId: input.projectId,
+      claimedBy: null,
+      claimedAt: null,
+      heartbeatAt: null,
+      ttlSeconds: input.ttlSeconds,
+      finalStatus: null,
+      finalAt: null,
+      version: 0,
+    };
+    rec.projectId = input.projectId ?? rec.projectId;
+    rec.claimedBy = input.agentId;
+    rec.claimedAt = input.now;
+    rec.heartbeatAt = input.now;
+    rec.ttlSeconds = input.ttlSeconds;
+    rec.finalStatus = null;
+    rec.finalAt = null;
+    rec.version = rec.version + 1;
+    this.claims.set(input.ticketId, rec);
+
+    if (rec.projectId) {
+      this.fireNotify('caia_ticket_' + rec.projectId, {
+        kind: 'ticket-claimed',
+        ticket_id: rec.ticketId,
+        claimed_by: rec.claimedBy,
+        heartbeat_at: rec.heartbeatAt?.toISOString() ?? null,
+      });
+    }
+
+    return {
+      claimed: true,
+      ttl: rec.ttlSeconds,
+      claimedBy: input.agentId,
+      heartbeatAt: input.now,
+    };
+  }
+
+  async heartbeat(input: {
+    ticketId: string;
+    agentId: string;
+    now: Date;
+  }): Promise<{ ok: boolean; heartbeatAt: Date | null }> {
+    const rec = this.claims.get(input.ticketId);
+    if (!rec || rec.claimedBy !== input.agentId)
+      return { ok: false, heartbeatAt: null };
+    rec.heartbeatAt = input.now;
+    if (rec.projectId) {
+      this.fireNotify('caia_ticket_' + rec.projectId, {
+        kind: 'ticket-heartbeat',
+        ticket_id: rec.ticketId,
+        claimed_by: rec.claimedBy,
+        heartbeat_at: rec.heartbeatAt?.toISOString() ?? null,
+      });
+    }
+    return { ok: true, heartbeatAt: rec.heartbeatAt };
+  }
+
+  async releaseClaim(input: {
+    ticketId: string;
+    agentId: string;
+    finalStatus: string;
+    now: Date;
+  }): Promise<{ ok: boolean }> {
+    const rec = this.claims.get(input.ticketId);
+    if (!rec || rec.claimedBy !== input.agentId) return { ok: false };
+    rec.claimedBy = null;
+    rec.claimedAt = null;
+    rec.heartbeatAt = null;
+    rec.finalStatus = input.finalStatus;
+    rec.finalAt = input.now;
+    if (rec.projectId) {
+      this.fireNotify('caia_ticket_' + rec.projectId, {
+        kind: 'ticket-released',
+        ticket_id: rec.ticketId,
+        final_status: input.finalStatus,
+      });
+    }
+    return { ok: true };
+  }
+
+  async janitorSweep(now: Date): Promise<JanitorResult> {
+    const released: string[] = [];
+    for (const rec of this.claims.values()) {
+      if (!rec.claimedBy || !rec.heartbeatAt) continue;
+      const age = (now.getTime() - rec.heartbeatAt.getTime()) / 1000;
+      if (age > rec.ttlSeconds) {
+        rec.claimedBy = null;
+        rec.claimedAt = null;
+        rec.heartbeatAt = null;
+        rec.finalStatus = 'stale';
+        rec.finalAt = now;
+        released.push(rec.ticketId);
+        if (rec.projectId) {
+          this.fireNotify('caia_ticket_' + rec.projectId, {
+            kind: 'ticket-released',
+            ticket_id: rec.ticketId,
+            final_status: 'stale',
+          });
+        }
+      }
+    }
+    return { releasedClaims: released };
+  }
+
+  async subscribe(
+    channel: string,
+    handler: (payload: string) => void,
+  ): Promise<() => Promise<void>> {
+    let set = this.listeners.get(channel);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(channel, set);
+    }
+    set.add(handler);
+    return async () => {
+      const s = this.listeners.get(channel);
+      if (s) s.delete(handler);
+    };
+  }
+
+  private fireNotify(channel: string, event: Record<string, unknown>): void {
+    const set = this.listeners.get(channel);
+    if (!set) return;
+    const payload = JSON.stringify(event);
+    // Iterate over a snapshot to allow handlers to unsubscribe synchronously.
+    for (const h of [...set]) {
+      try {
+        h(payload);
+      } catch {
+        // never break notify on a misbehaving listener
+      }
+    }
+  }
+}
+
+function cloneProject(rec: ProjectRow): ProjectRow {
+  return {
+    ...rec,
+    currentPayload: { ...rec.currentPayload },
+  };
+}
+
+function cloneHistory(rec: HistoryRecord): StateTransitionRow {
+  return {
+    ...rec,
+    payload: { ...rec.payload },
+  };
+}

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * @caia/state-machine — typed pipeline status manager backed by Postgres.
+ *
+ * Public surface. Everything else stays internal.
+ */
+
+export {
+  ALL_STATES,
+  HAPPY_STATES,
+  FAILED_STATES,
+  CONTROL_STATES,
+  TERMINAL_STATES,
+  isProjectState,
+  isHappyState,
+  isFailedState,
+  isControlState,
+  isTerminal,
+} from './states.js';
+export type {
+  HappyState,
+  FailedState,
+  ControlState,
+  ProjectState,
+} from './states.js';
+
+export {
+  VALID_TRANSITIONS,
+  canTransition,
+  checkTransition,
+  availableTransitions,
+  validNextStates,
+  allEdges,
+  reachableTerminals,
+} from './transitions.js';
+export type { TransitionCheck } from './transitions.js';
+
+export {
+  InvalidTransitionError,
+  StaleProjectVersionError,
+  ProjectNotFoundError,
+  AdvisoryLockHeldError,
+  TicketAlreadyClaimedError,
+  TransitionRetryExhaustedError,
+} from './errors.js';
+
+export { hashPayload } from './hash.js';
+
+export { StateMachine } from './state-machine.js';
+export type { ProjectEvent, TicketEvent } from './state-machine.js';
+
+export { InMemoryStateStore } from './in-memory-store.js';
+export { PgStateStore } from './pg-store.js';
+export type { PgStateStoreOptions } from './pg-store.js';
+
+export type {
+  StateStore,
+  TransitionAtomicInput,
+  TransitionAtomicResult,
+} from './store.js';
+
+export type {
+  ActorKind,
+  ClaimResult,
+  JanitorResult,
+  NewProjectInput,
+  ProjectRow,
+  StateMachineOptions,
+  StateTransitionRow,
+  TransitionOpts,
+  TransitionResult,
+  TriggeredBy,
+} from './types.js';
+
+export { handleProjectSse, SseConnection } from './realtime.js';
+export type { SseHandlerOptions } from './realtime.js';
+
+export { whatsNext, resumePoint } from './whats-next.js';
+export type {
+  AgentSpec,
+  ResumePoint,
+  WaitingReason,
+  WhatsNextResult,
+} from './whats-next.js';

--- a/packages/state-machine/src/pg-store.ts
+++ b/packages/state-machine/src/pg-store.ts
@@ -1,0 +1,540 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { Client as PgClientCtor, Pool, PoolConfig } from 'pg';
+
+import { isProjectState, type ProjectState } from './states.js';
+import type {
+  StateStore,
+  TransitionAtomicInput,
+  TransitionAtomicResult,
+} from './store.js';
+import type {
+  ActorKind,
+  ClaimResult,
+  JanitorResult,
+  NewProjectInput,
+  ProjectRow,
+  StateTransitionRow,
+} from './types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function loadMigrationSql(): Promise<string> {
+  const candidates = [
+    join(__dirname, '..', 'migrations', '0001_state_machine.sql'),
+    join(__dirname, '..', '..', 'migrations', '0001_state_machine.sql'),
+    join(process.cwd(), 'migrations', '0001_state_machine.sql'),
+  ];
+  for (const path of candidates) {
+    try {
+      return await readFile(path, 'utf8');
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(
+    'cannot locate 0001_state_machine.sql - checked: ' + candidates.join(', '),
+  );
+}
+
+export interface PgStateStoreOptions {
+  /** Schema for the meta tables. Defaults to caia_meta. */
+  schema?: string;
+  /** When you already manage migrations elsewhere, pass `skipInit: true` so init() is a no-op. */
+  skipInit?: boolean;
+}
+
+/**
+ * Postgres-backed StateStore. Owns ONE `pg.Pool` for queries; a
+ * separate dedicated `Client` is opened lazily for LISTEN.
+ */
+export class PgStateStore implements StateStore {
+  private readonly pool: Pool;
+  private readonly schema: string;
+  private readonly skipInit: boolean;
+  private listenClient: InstanceType<typeof PgClientCtor> | null = null;
+  private listenHandlers = new Map<string, Set<(payload: string) => void>>();
+  private listenStarting: Promise<void> | null = null;
+
+  constructor(pool: Pool, opts: PgStateStoreOptions = {}) {
+    this.pool = pool;
+    this.schema = opts.schema ?? 'caia_meta';
+    this.skipInit = opts.skipInit ?? false;
+  }
+
+  async init(): Promise<void> {
+    if (this.skipInit) return;
+    const sql = await loadMigrationSql();
+    const final =
+      this.schema === 'caia_meta'
+        ? sql
+        : sql.replace(/caia_meta\./g, `${this.schema}.`);
+    await this.pool.query(final);
+  }
+
+  async reset(): Promise<void> {
+    await this.pool.query(`
+      TRUNCATE TABLE ${this.schema}.state_history,
+                     ${this.schema}.ticket_claims,
+                     ${this.schema}.tenant_projects
+        RESTART IDENTITY CASCADE
+    `);
+  }
+
+  async createProject(input: NewProjectInput): Promise<ProjectRow> {
+    const sql = `
+      INSERT INTO ${this.schema}.tenant_projects
+        (id, tenant_id, slug, display_name, status, current_payload, parent_project_id)
+      VALUES (COALESCE($1::uuid, gen_random_uuid()), $2, $3, $4, COALESCE($5, 'onboarding'), COALESCE($6, '{}'::jsonb), $7)
+      RETURNING *
+    `;
+    const r = await this.pool.query(sql, [
+      input.id ?? null,
+      input.tenantId,
+      input.slug,
+      input.displayName,
+      input.initialState ?? null,
+      input.initialPayload ? JSON.stringify(input.initialPayload) : null,
+      input.parentProjectId ?? null,
+    ]);
+    return rowToProject(r.rows[0]);
+  }
+
+  async getProject(projectId: string): Promise<ProjectRow | null> {
+    const r = await this.pool.query(
+      `SELECT * FROM ${this.schema}.tenant_projects WHERE id = $1`,
+      [projectId],
+    );
+    if (r.rows.length === 0) return null;
+    return rowToProject(r.rows[0]);
+  }
+
+  async listActiveProjects(): Promise<ProjectRow[]> {
+    const r = await this.pool.query(
+      `SELECT * FROM ${this.schema}.tenant_projects WHERE archived_at IS NULL`,
+    );
+    return r.rows.map(rowToProject);
+  }
+
+  async setPaused(
+    projectId: string,
+    paused: boolean,
+    by: string | null,
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE ${this.schema}.tenant_projects
+          SET paused = $2,
+              paused_at = CASE WHEN $2 THEN now() ELSE NULL END,
+              paused_by = CASE WHEN $2 THEN $3 ELSE NULL END
+        WHERE id = $1`,
+      [projectId, paused, by],
+    );
+  }
+
+  async transitionAtomic(
+    input: TransitionAtomicInput,
+  ): Promise<TransitionAtomicResult> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const lockKey = `project:${input.projectId}`;
+      const lockHash = hashToInt32(lockKey);
+      const lockRes = await client.query(
+        'SELECT pg_try_advisory_xact_lock($1) AS ok',
+        [lockHash],
+      );
+      if (!lockRes.rows[0]?.ok) {
+        await client.query('ROLLBACK');
+        return { applied: false, newVersion: 0, historyId: null };
+      }
+
+      const dup = await client.query(
+        `SELECT id FROM ${this.schema}.state_history
+          WHERE project_id = $1 AND to_state = $2 AND payload_hash = $3
+          LIMIT 1`,
+        [input.projectId, input.toState, input.payloadHash],
+      );
+      if (dup.rowCount && dup.rowCount > 0) {
+        const cur = await client.query(
+          `SELECT version FROM ${this.schema}.tenant_projects WHERE id = $1`,
+          [input.projectId],
+        );
+        await client.query('COMMIT');
+        return {
+          applied: false,
+          newVersion: cur.rows[0]?.version ?? 0,
+          historyId: dup.rows[0].id,
+        };
+      }
+
+      if (input.idempotencyWindowMs > 0) {
+        const winSec = input.idempotencyWindowMs / 1000;
+        const winDup = await client.query(
+          `SELECT id FROM ${this.schema}.state_history
+            WHERE project_id = $1
+              AND to_state = $2
+              AND payload_hash = $4
+              AND at > now() - ($3 || ' seconds')::interval
+            LIMIT 1`,
+          [input.projectId, input.toState, String(winSec), input.payloadHash],
+        );
+        if (winDup.rowCount && winDup.rowCount > 0) {
+          const cur = await client.query(
+            `SELECT version FROM ${this.schema}.tenant_projects WHERE id = $1`,
+            [input.projectId],
+          );
+          await client.query('COMMIT');
+          return {
+            applied: false,
+            newVersion: cur.rows[0]?.version ?? 0,
+            historyId: winDup.rows[0].id,
+          };
+        }
+      }
+
+      const upd = await client.query(
+        `UPDATE ${this.schema}.tenant_projects
+            SET status = $2,
+                current_payload = $3,
+                last_transitioned_at = now(),
+                last_transitioned_by = $4,
+                version = version + 1,
+                archived_at = CASE WHEN $2 = 'archived' THEN now() ELSE archived_at END
+          WHERE id = $1
+            AND version = $5
+            AND status = $6
+          RETURNING version`,
+        [
+          input.projectId,
+          input.toState,
+          JSON.stringify(input.payload),
+          input.actorId,
+          input.expectedVersion,
+          input.expectedStatus,
+        ],
+      );
+
+      if (upd.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return { applied: false, newVersion: 0, historyId: null };
+      }
+
+      const newVersion = upd.rows[0].version as number;
+
+      const ins = await client.query(
+        `INSERT INTO ${this.schema}.state_history
+           (project_id, from_state, to_state, reason, actor_kind, actor_id, agent_run_id, payload, payload_hash)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT (project_id, to_state, payload_hash) DO NOTHING
+         RETURNING id`,
+        [
+          input.projectId,
+          input.expectedStatus,
+          input.toState,
+          input.reason,
+          input.actorKind,
+          input.actorId,
+          input.agentRunId,
+          JSON.stringify(input.payload),
+          input.payloadHash,
+        ],
+      );
+
+      await client.query('COMMIT');
+      return {
+        applied: true,
+        newVersion,
+        historyId: ins.rows[0]?.id ?? null,
+      };
+    } catch (err) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listHistory(
+    projectId: string,
+    opts: { limit?: number; afterId?: number; toState?: ProjectState } = {},
+  ): Promise<StateTransitionRow[]> {
+    const conds: string[] = ['project_id = $1'];
+    const params: unknown[] = [projectId];
+    if (opts.afterId !== undefined) {
+      params.push(opts.afterId);
+      conds.push(`id > $${params.length}`);
+    }
+    if (opts.toState) {
+      params.push(opts.toState);
+      conds.push(`to_state = $${params.length}`);
+    }
+    let sql = `SELECT * FROM ${this.schema}.state_history WHERE ${conds.join(' AND ')} ORDER BY id ASC`;
+    if (opts.limit !== undefined) {
+      params.push(opts.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+    const r = await this.pool.query(sql, params);
+    return r.rows.map(rowToHistory);
+  }
+
+  async tryClaim(input: {
+    ticketId: string;
+    projectId: string | null;
+    agentId: string;
+    ttlSeconds: number;
+    now: Date;
+  }): Promise<ClaimResult> {
+    const sql = `
+      INSERT INTO ${this.schema}.ticket_claims
+        (ticket_id, project_id, claimed_by, claimed_at, heartbeat_at, ttl_seconds, version)
+      VALUES ($1, $2, $3, $4, $4, $5, 1)
+      ON CONFLICT (ticket_id) DO UPDATE
+        SET claimed_by = EXCLUDED.claimed_by,
+            claimed_at = EXCLUDED.claimed_at,
+            heartbeat_at = EXCLUDED.heartbeat_at,
+            ttl_seconds = EXCLUDED.ttl_seconds,
+            final_status = NULL,
+            final_at = NULL,
+            project_id = COALESCE(${this.schema}.ticket_claims.project_id, EXCLUDED.project_id),
+            version = ${this.schema}.ticket_claims.version + 1
+        WHERE ${this.schema}.ticket_claims.claimed_by IS NULL
+           OR ${this.schema}.ticket_claims.claimed_by = EXCLUDED.claimed_by
+           OR ${this.schema}.ticket_claims.heartbeat_at < EXCLUDED.heartbeat_at - (${this.schema}.ticket_claims.ttl_seconds || ' seconds')::interval
+      RETURNING claimed_by, heartbeat_at, ttl_seconds
+    `;
+    const r = await this.pool.query(sql, [
+      input.ticketId,
+      input.projectId,
+      input.agentId,
+      input.now.toISOString(),
+      input.ttlSeconds,
+    ]);
+    if (r.rowCount === 0 || !r.rows[0]) {
+      return { claimed: false, ttl: input.ttlSeconds };
+    }
+    const row = r.rows[0];
+    return {
+      claimed: row.claimed_by === input.agentId,
+      ttl: row.ttl_seconds,
+      claimedBy: row.claimed_by,
+      heartbeatAt: row.heartbeat_at,
+    };
+  }
+
+  async heartbeat(input: {
+    ticketId: string;
+    agentId: string;
+    now: Date;
+  }): Promise<{ ok: boolean; heartbeatAt: Date | null }> {
+    const r = await this.pool.query(
+      `UPDATE ${this.schema}.ticket_claims
+          SET heartbeat_at = $3
+        WHERE ticket_id = $1 AND claimed_by = $2
+        RETURNING heartbeat_at`,
+      [input.ticketId, input.agentId, input.now.toISOString()],
+    );
+    if (r.rowCount === 0 || !r.rows[0])
+      return { ok: false, heartbeatAt: null };
+    return { ok: true, heartbeatAt: r.rows[0].heartbeat_at };
+  }
+
+  async releaseClaim(input: {
+    ticketId: string;
+    agentId: string;
+    finalStatus: string;
+    now: Date;
+  }): Promise<{ ok: boolean }> {
+    const r = await this.pool.query(
+      `UPDATE ${this.schema}.ticket_claims
+          SET claimed_by = NULL,
+              claimed_at = NULL,
+              heartbeat_at = NULL,
+              final_status = $3,
+              final_at = $4
+        WHERE ticket_id = $1 AND claimed_by = $2
+        RETURNING 1`,
+      [input.ticketId, input.agentId, input.finalStatus, input.now.toISOString()],
+    );
+    return { ok: (r.rowCount ?? 0) > 0 };
+  }
+
+  async janitorSweep(now: Date): Promise<JanitorResult> {
+    const r = await this.pool.query(
+      `UPDATE ${this.schema}.ticket_claims
+          SET claimed_by = NULL,
+              claimed_at = NULL,
+              heartbeat_at = NULL,
+              final_status = 'stale',
+              final_at = $1
+        WHERE claimed_by IS NOT NULL
+          AND heartbeat_at < $1::timestamptz - (ttl_seconds || ' seconds')::interval
+        RETURNING ticket_id`,
+      [now.toISOString()],
+    );
+    return { releasedClaims: r.rows.map((row: { ticket_id: string }) => row.ticket_id) };
+  }
+
+  async subscribe(
+    channel: string,
+    handler: (payload: string) => void,
+  ): Promise<() => Promise<void>> {
+    let set = this.listenHandlers.get(channel);
+    if (!set) {
+      set = new Set();
+      this.listenHandlers.set(channel, set);
+    }
+    set.add(handler);
+    await this.ensureListening(channel);
+    return async () => {
+      const s = this.listenHandlers.get(channel);
+      if (s) {
+        s.delete(handler);
+        if (s.size === 0) {
+          this.listenHandlers.delete(channel);
+          if (this.listenClient) {
+            try {
+              await this.listenClient.query(`UNLISTEN ${escapeIdent(channel)}`);
+            } catch {
+              /* ignore */
+            }
+          }
+        }
+      }
+    };
+  }
+
+  async closeListenClient(): Promise<void> {
+    const client = this.listenClient;
+    if (!client) return;
+    this.listenClient = null;
+    try {
+      await client.end();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private async ensureListening(channel: string): Promise<void> {
+    if (this.listenStarting) {
+      await this.listenStarting;
+    }
+    if (!this.listenClient) {
+      this.listenStarting = this.startListenClient();
+      await this.listenStarting;
+      this.listenStarting = null;
+    }
+    if (!this.listenClient) throw new Error('listen client failed to start');
+    await this.listenClient.query(`LISTEN ${escapeIdent(channel)}`);
+  }
+
+  private async startListenClient(): Promise<void> {
+    const poolOpts = ((this.pool as unknown as { options?: PoolConfig }).options ?? {}) as PoolConfig;
+    const { Client: PgClient } = await import('pg');
+    const client = new PgClient(poolOpts);
+    client.on('notification', (msg: import('pg').Notification) => {
+      const ch = msg.channel;
+      const set = this.listenHandlers.get(ch);
+      if (!set) return;
+      for (const h of [...set]) {
+        try {
+          h(msg.payload ?? '');
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+    client.on('error', () => {
+      this.listenClient = null;
+    });
+    await client.connect();
+    this.listenClient = client;
+  }
+
+  async notify(channel: string, payload: string): Promise<void> {
+    await this.pool.query('SELECT pg_notify($1, $2)', [channel, payload]);
+  }
+}
+
+function rowToProject(row: Record<string, unknown>): ProjectRow {
+  const status = String(row.status);
+  if (!isProjectState(status)) {
+    throw new Error(`bad status from db: ${status}`);
+  }
+  return {
+    id: String(row.id),
+    tenantId: String(row.tenant_id),
+    slug: String(row.slug),
+    displayName: String(row.display_name),
+    status,
+    paused: Boolean(row.paused),
+    pausedAt:
+      row.paused_at instanceof Date
+        ? row.paused_at
+        : row.paused_at
+          ? new Date(String(row.paused_at))
+          : null,
+    pausedBy: row.paused_by != null ? String(row.paused_by) : null,
+    currentPayload: (row.current_payload as Record<string, unknown>) ?? {},
+    lastTransitionedAt:
+      row.last_transitioned_at instanceof Date
+        ? row.last_transitioned_at
+        : new Date(String(row.last_transitioned_at)),
+    lastTransitionedBy: String(row.last_transitioned_by),
+    parentProjectId:
+      row.parent_project_id != null ? String(row.parent_project_id) : null,
+    archivedAt:
+      row.archived_at instanceof Date
+        ? row.archived_at
+        : row.archived_at
+          ? new Date(String(row.archived_at))
+          : null,
+    version: Number(row.version),
+    createdAt:
+      row.created_at instanceof Date
+        ? row.created_at
+        : new Date(String(row.created_at)),
+  };
+}
+
+function rowToHistory(row: Record<string, unknown>): StateTransitionRow {
+  const toState = String(row.to_state);
+  if (!isProjectState(toState))
+    throw new Error(`bad to_state from db: ${toState}`);
+  const fromState = row.from_state != null ? String(row.from_state) : null;
+  if (fromState !== null && !isProjectState(fromState)) {
+    throw new Error(`bad from_state from db: ${fromState}`);
+  }
+  const actorKind = String(row.actor_kind);
+  if (actorKind !== 'system' && actorKind !== 'operator' && actorKind !== 'agent') {
+    throw new Error(`bad actor_kind from db: ${actorKind}`);
+  }
+  return {
+    id: Number(row.id),
+    projectId: String(row.project_id),
+    fromState: fromState as ProjectState | null,
+    toState,
+    reason: String(row.reason),
+    actorKind: actorKind as ActorKind,
+    actorId: String(row.actor_id),
+    agentRunId: row.agent_run_id != null ? String(row.agent_run_id) : null,
+    payload: (row.payload as Record<string, unknown>) ?? {},
+    at: row.at instanceof Date ? row.at : new Date(String(row.at)),
+    payloadHash: String(row.payload_hash),
+  };
+}
+
+function escapeIdent(name: string): string {
+  return '"' + name.replace(/"/g, '""') + '"';
+}
+
+function hashToInt32(s: string): number {
+  const h = createHash('sha256').update(s).digest();
+  return h.readInt32BE(0);
+}

--- a/packages/state-machine/src/realtime.ts
+++ b/packages/state-machine/src/realtime.ts
@@ -1,0 +1,132 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { ProjectEvent, StateMachine, TicketEvent } from './state-machine.js';
+
+/**
+ * Minimal SSE writer. Frame format per the EventSource spec:
+ *   - `event: <name>` (optional)
+ *   - `id: <id>` (optional)
+ *   - `data: <line>` (repeat per line)
+ *   - blank line terminator.
+ */
+export class SseConnection {
+  private closed = false;
+  private readonly keepaliveTimer: NodeJS.Timeout;
+
+  constructor(
+    private readonly res: ServerResponse,
+    keepaliveMs = 15_000,
+  ) {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders?.();
+
+    this.keepaliveTimer = setInterval(
+      () => this.sendComment('keepalive'),
+      keepaliveMs,
+    );
+    res.on('close', () => this.close());
+  }
+
+  send(event: string, data: string, id?: string): void {
+    if (this.closed) return;
+    let frame = '';
+    if (id) frame += `id: ${id}\n`;
+    if (event) frame += `event: ${event}\n`;
+    for (const line of data.split('\n')) {
+      frame += `data: ${line}\n`;
+    }
+    frame += '\n';
+    try {
+      this.res.write(frame);
+    } catch {
+      this.close();
+    }
+  }
+
+  sendJson(event: string, value: unknown, id?: string): void {
+    this.send(event, JSON.stringify(value), id);
+  }
+
+  sendComment(text: string): void {
+    if (this.closed) return;
+    try {
+      this.res.write(`: ${text}\n\n`);
+    } catch {
+      this.close();
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    clearInterval(this.keepaliveTimer);
+    try {
+      this.res.end();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  get isClosed(): boolean {
+    return this.closed;
+  }
+}
+
+export interface SseHandlerOptions {
+  keepaliveMs?: number;
+  onError?: (err: Error) => void;
+}
+
+/**
+ * Wire an SSE endpoint to a `StateMachine`. Use from any Node http
+ * framework - pass the raw `IncomingMessage`/`ServerResponse` pair.
+ */
+export async function handleProjectSse(
+  sm: StateMachine,
+  req: IncomingMessage,
+  res: ServerResponse,
+  projectId: string,
+  opts: SseHandlerOptions = {},
+): Promise<void> {
+  const conn = new SseConnection(res, opts.keepaliveMs);
+  const proj = await sm.getProject(projectId);
+  if (!proj) {
+    conn.sendJson('error', { error: 'project-not-found', project_id: projectId });
+    conn.close();
+    return;
+  }
+  conn.sendJson('snapshot', {
+    project_id: projectId,
+    status: proj.status,
+    paused: proj.paused,
+    version: proj.version,
+    last_transitioned_at: proj.lastTransitionedAt.toISOString(),
+  });
+
+  const unsubProject = await sm.subscribeToProject(projectId, (evt: ProjectEvent) => {
+    conn.sendJson('project', evt, String(evt.history_id));
+  });
+  const unsubTickets = await sm.subscribeToTickets(projectId, (evt: TicketEvent) => {
+    conn.sendJson('ticket', evt);
+  });
+
+  const onClose = async (): Promise<void> => {
+    try {
+      await unsubProject();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await unsubTickets();
+    } catch {
+      /* ignore */
+    }
+  };
+  req.on('close', () => {
+    void onClose();
+  });
+}

--- a/packages/state-machine/src/state-machine.ts
+++ b/packages/state-machine/src/state-machine.ts
@@ -1,0 +1,531 @@
+import {
+  InvalidTransitionError,
+  ProjectNotFoundError,
+  StaleProjectVersionError,
+  TransitionRetryExhaustedError,
+} from './errors.js';
+import { hashPayload } from './hash.js';
+import { isProjectState, type ProjectState } from './states.js';
+import type {
+  StateStore,
+} from './store.js';
+import {
+  availableTransitions,
+  canTransition,
+  checkTransition,
+  validNextStates,
+} from './transitions.js';
+import type {
+  ActorKind,
+  ClaimResult,
+  JanitorResult,
+  NewProjectInput,
+  ProjectRow,
+  StateMachineOptions,
+  StateTransitionRow,
+  TransitionOpts,
+  TransitionResult,
+  TriggeredBy,
+} from './types.js';
+
+export interface ProjectEvent {
+  kind: 'state-transition';
+  history_id: number;
+  from_state: ProjectState | null;
+  to_state: ProjectState;
+  reason: string;
+  actor_kind: 'system' | 'operator' | 'agent';
+  actor_id: string;
+  at: string;
+}
+
+export interface TicketEvent {
+  kind: 'ticket-claimed' | 'ticket-released' | 'ticket-heartbeat' | 'ticket-updated';
+  ticket_id: string;
+  claimed_by?: string | null;
+  heartbeat_at?: string | null;
+  final_status?: string | null;
+}
+
+/**
+ * Main entrypoint. Provides the typed API the orchestrator calls.
+ *
+ *   - `transition(projectId, to, opts)`           atomic, idempotent, retries on conflict
+ *   - `currentState(projectId)`                   read-only
+ *   - `replayHistory(projectId, opts?)`           audit
+ *   - `validNextStates(state)` / `availableTransitions(state)` picker
+ *   - `tryAssignWork(projectId, workerId)`        atomic worker assignment
+ *   - `recordWorkerHeartbeat(workerId)`           lifecycle ping
+ *   - `completeWork(workerId, finalState)`        release + optional transition
+ *   - `expireInactiveWorkers()`                   90s stale-claim sweep
+ *   - `subscribeToProject(projectId, cb)`         SSE feed
+ *   - `whatsNext(projectId)`                      next-step (re-exported in `./whats-next`)
+ */
+export class StateMachine {
+  private readonly nowFn: () => Date;
+  private readonly idempotencyWindowMs: number;
+  private readonly defaultRetries: number;
+  private readonly workerTtlSeconds: number;
+  /** worker_id -> set of ticketIds it has claimed. Used by recordWorkerHeartbeat / completeWork. */
+  private readonly workerAssignments = new Map<string, Set<string>>();
+
+  constructor(
+    private readonly store: StateStore,
+    opts: StateMachineOptions = {},
+  ) {
+    this.nowFn = opts.now ?? ((): Date => new Date());
+    this.idempotencyWindowMs = opts.idempotencyWindowMs ?? 1_000;
+    this.defaultRetries = opts.defaultRetries ?? 3;
+    this.workerTtlSeconds = opts.workerTtlSeconds ?? 90;
+  }
+
+  async init(): Promise<void> {
+    await this.store.init();
+  }
+
+  async createProject(input: NewProjectInput): Promise<ProjectRow> {
+    if (input.initialState && !isProjectState(input.initialState)) {
+      throw new InvalidTransitionError(
+        'onboarding',
+        input.initialState as ProjectState,
+        'unknown initialState',
+      );
+    }
+    return this.store.createProject(input);
+  }
+
+  async currentState(projectId: string): Promise<ProjectState> {
+    const proj = await this.store.getProject(projectId);
+    if (!proj) throw new ProjectNotFoundError(projectId);
+    return proj.status;
+  }
+
+  async getProject(projectId: string): Promise<ProjectRow | null> {
+    return this.store.getProject(projectId);
+  }
+
+  /**
+   * Atomic transition. Supports two call styles:
+   *
+   *   sm.transition(projectId, to, { reason, triggeredBy, payload?, expectedVersion? })
+   *   sm.transition(projectId, to, reason, triggeredBy)   // positional shortcut
+   */
+  async transition(
+    projectId: string,
+    toState: ProjectState,
+    opts: TransitionOpts,
+  ): Promise<TransitionResult>;
+  async transition(
+    projectId: string,
+    toState: ProjectState,
+    reason: string,
+    triggeredBy: TriggeredBy | string,
+  ): Promise<TransitionResult>;
+  async transition(
+    projectId: string,
+    toState: ProjectState,
+    optsOrReason: TransitionOpts | string,
+    maybeTriggeredBy?: TriggeredBy | string,
+  ): Promise<TransitionResult> {
+    const opts = normalizeTransitionArgs(optsOrReason, maybeTriggeredBy);
+
+    if (!isProjectState(toState)) {
+      throw new InvalidTransitionError(
+        'onboarding',
+        toState,
+        'unknown to-state',
+      );
+    }
+
+    const payload = opts.payload ?? {};
+    const payloadHash = hashPayload(payload);
+    const maxRetries = opts.retries ?? this.defaultRetries;
+
+    let attempt = 0;
+    let lastReadVersion = -1;
+    // Snapshot fromState across retries for the result's `fromState`.
+    let firstFromState: ProjectState | null = null;
+
+    while (attempt <= maxRetries) {
+      const proj = await this.store.getProject(projectId);
+      if (!proj) throw new ProjectNotFoundError(projectId);
+      if (firstFromState === null) firstFromState = proj.status;
+
+      // Idempotent self-call: status already at toState + same payload hash.
+      if (proj.status === toState) {
+        const recent = await this.store.listHistory(projectId, {
+          toState,
+          limit: 50,
+        });
+        const dup = recent.find((h) => h.payloadHash === payloadHash);
+        if (dup) {
+          return {
+            applied: false,
+            projectId,
+            fromState: proj.status,
+            toState,
+            newVersion: proj.version,
+            historyId: dup.id,
+            payloadHash,
+            retries: attempt,
+          };
+        }
+        throw new InvalidTransitionError(
+          proj.status,
+          toState,
+          'self-transition is a no-op',
+        );
+      }
+
+      const check = checkTransition(proj.status, toState);
+      if (!check.ok) {
+        throw new InvalidTransitionError(proj.status, toState, check.reason);
+      }
+
+      if (
+        opts.expectedVersion !== undefined &&
+        opts.expectedVersion !== proj.version
+      ) {
+        throw new StaleProjectVersionError(projectId, opts.expectedVersion);
+      }
+
+      if (lastReadVersion === proj.version && attempt > 0) {
+        // Unchanged after retry — caller didn't make progress, but the
+        // db reported a conflict. Treat the next loop as a fresh read.
+        lastReadVersion = -1;
+      }
+      lastReadVersion = proj.version;
+
+      const result = await this.store.transitionAtomic({
+        projectId,
+        expectedVersion: proj.version,
+        expectedStatus: proj.status,
+        toState,
+        reason: opts.reason,
+        actorKind: opts.triggeredBy.kind,
+        actorId: opts.triggeredBy.id,
+        agentRunId: opts.triggeredBy.agentRunId ?? null,
+        payload,
+        payloadHash,
+        idempotencyWindowMs: this.idempotencyWindowMs,
+      });
+
+      if (result.applied) {
+        return {
+          applied: true,
+          projectId,
+          fromState: proj.status,
+          toState,
+          newVersion: result.newVersion,
+          historyId: result.historyId,
+          payloadHash,
+          retries: attempt,
+        };
+      }
+
+      if (result.historyId !== null) {
+        // Idempotent no-op (matched existing history). The transition
+        // was already applied in a prior call; return success-shape.
+        return {
+          applied: false,
+          projectId,
+          fromState: proj.status,
+          toState,
+          newVersion: result.newVersion,
+          historyId: result.historyId,
+          payloadHash,
+          retries: attempt,
+        };
+      }
+
+      // Optimistic-concurrency conflict — retry.
+      attempt += 1;
+      if (attempt > maxRetries) {
+        throw new TransitionRetryExhaustedError(projectId, attempt);
+      }
+      // Light jitter to avoid tight-loop starvation in tests.
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(10, attempt * 2)),
+      );
+    }
+
+    throw new TransitionRetryExhaustedError(projectId, attempt);
+  }
+
+  async replayHistory(
+    projectId: string,
+    opts: { limit?: number; afterId?: number; toState?: ProjectState } = {},
+  ): Promise<StateTransitionRow[]> {
+    return this.store.listHistory(projectId, opts);
+  }
+
+  availableTransitions(currentState: ProjectState): readonly ProjectState[] {
+    return availableTransitions(currentState);
+  }
+
+  /** Spec-friendly alias for `availableTransitions`. */
+  validNextStates(currentState: ProjectState): readonly ProjectState[] {
+    return validNextStates(currentState);
+  }
+
+  canTransition(from: ProjectState, to: ProjectState): boolean {
+    return canTransition(from, to);
+  }
+
+  async pause(projectId: string, by: string): Promise<void> {
+    const proj = await this.store.getProject(projectId);
+    if (!proj) throw new ProjectNotFoundError(projectId);
+    await this.store.setPaused(projectId, true, by);
+  }
+
+  async resume(projectId: string): Promise<void> {
+    const proj = await this.store.getProject(projectId);
+    if (!proj) throw new ProjectNotFoundError(projectId);
+    await this.store.setPaused(projectId, false, null);
+  }
+
+  async abandon(
+    projectId: string,
+    by: string,
+    reason = 'operator-abandoned',
+  ): Promise<TransitionResult> {
+    const proj = await this.store.getProject(projectId);
+    if (!proj) throw new ProjectNotFoundError(projectId);
+    return this.transition(projectId, 'archived', {
+      reason,
+      triggeredBy: { kind: 'operator', id: by },
+    });
+  }
+
+  // -- Ticket-level claim API (kept for backwards compat) ------------------
+
+  async claimTicketForAgent(
+    ticketId: string,
+    agentId: string,
+    opts: { projectId?: string; ttlSeconds?: number } = {},
+  ): Promise<ClaimResult> {
+    return this.store.tryClaim({
+      ticketId,
+      projectId: opts.projectId ?? null,
+      agentId,
+      ttlSeconds: opts.ttlSeconds ?? this.workerTtlSeconds,
+      now: this.nowFn(),
+    });
+  }
+
+  async heartbeat(ticketId: string, agentId: string): Promise<void> {
+    await this.store.heartbeat({
+      ticketId,
+      agentId,
+      now: this.nowFn(),
+    });
+  }
+
+  async releaseTicket(
+    ticketId: string,
+    agentId: string,
+    finalStatus: 'done' | 'failed' | 'aborted' | string,
+  ): Promise<{ ok: boolean }> {
+    return this.store.releaseClaim({
+      ticketId,
+      agentId,
+      finalStatus,
+      now: this.nowFn(),
+    });
+  }
+
+  async janitor(): Promise<JanitorResult> {
+    return this.store.janitorSweep(this.nowFn());
+  }
+
+  // -- Spec-named job-queue helpers ----------------------------------------
+
+  /**
+   * Atomic find-and-update: tries to assign the project's work-slot to
+   * the given worker. Only one worker wins per project; concurrent
+   * losers see `claimed: false`.
+   */
+  async tryAssignWork(
+    projectId: string,
+    workerId: string,
+    opts: { ttlSeconds?: number } = {},
+  ): Promise<ClaimResult> {
+    const ttlSeconds = opts.ttlSeconds ?? this.workerTtlSeconds;
+    const result = await this.store.tryClaim({
+      ticketId: assignmentKey(projectId),
+      projectId,
+      agentId: workerId,
+      ttlSeconds,
+      now: this.nowFn(),
+    });
+    if (result.claimed) {
+      let set = this.workerAssignments.get(workerId);
+      if (!set) {
+        set = new Set();
+        this.workerAssignments.set(workerId, set);
+      }
+      set.add(projectId);
+    }
+    return result;
+  }
+
+  /**
+   * Heartbeat for an entire worker: pings every project the worker is
+   * currently assigned to. Safe to call every 30s; the janitor only
+   * unassigns work whose last heartbeat is older than 90s.
+   */
+  async recordWorkerHeartbeat(workerId: string): Promise<{
+    ok: boolean;
+    refreshed: string[];
+  }> {
+    const set = this.workerAssignments.get(workerId);
+    if (!set || set.size === 0) return { ok: false, refreshed: [] };
+    const refreshed: string[] = [];
+    for (const projectId of [...set]) {
+      const r = await this.store.heartbeat({
+        ticketId: assignmentKey(projectId),
+        agentId: workerId,
+        now: this.nowFn(),
+      });
+      if (r.ok) {
+        refreshed.push(projectId);
+      } else {
+        // worker was already kicked off this project — clean up our local
+        // bookkeeping so subsequent heartbeats are accurate.
+        set.delete(projectId);
+      }
+    }
+    if (set.size === 0) this.workerAssignments.delete(workerId);
+    return { ok: refreshed.length > 0, refreshed };
+  }
+
+  /**
+   * Complete a worker's assignment. Releases the claim on every project
+   * the worker is assigned to and, when `finalState` is provided,
+   * transitions each project to that state.
+   *
+   * `triggeredBy` defaults to `{ kind: 'agent', id: workerId }`.
+   */
+  async completeWork(
+    workerId: string,
+    finalState?: ProjectState,
+    opts: {
+      reason?: string;
+      triggeredBy?: TriggeredBy;
+      payload?: Record<string, unknown>;
+    } = {},
+  ): Promise<{
+    released: string[];
+    transitioned: TransitionResult[];
+  }> {
+    const set = this.workerAssignments.get(workerId);
+    const projects = set ? [...set] : [];
+    const released: string[] = [];
+    const transitioned: TransitionResult[] = [];
+    for (const projectId of projects) {
+      const r = await this.store.releaseClaim({
+        ticketId: assignmentKey(projectId),
+        agentId: workerId,
+        finalStatus: finalState ?? 'done',
+        now: this.nowFn(),
+      });
+      if (r.ok) released.push(projectId);
+      if (finalState) {
+        try {
+          const result = await this.transition(projectId, finalState, {
+            reason: opts.reason ?? 'work-completed',
+            triggeredBy:
+              opts.triggeredBy ?? { kind: 'agent' as ActorKind, id: workerId },
+            payload: opts.payload ?? {},
+          });
+          transitioned.push(result);
+        } catch (err) {
+          // Surface the most informative error to the caller. The
+          // claim is already released, so retry semantics are caller-
+          // owned.
+          if (projects.length === 1) throw err;
+        }
+      }
+    }
+    this.workerAssignments.delete(workerId);
+    return { released, transitioned };
+  }
+
+  /**
+   * Periodic cleanup: releases any assignment whose heartbeat is older
+   * than the worker TTL (default 90s, matching the spec).
+   *
+   * The returned `releasedAssignments` lists the projectIds that lost
+   * their assignment.
+   */
+  async expireInactiveWorkers(): Promise<{ releasedAssignments: string[] }> {
+    const result = await this.store.janitorSweep(this.nowFn());
+    const releasedAssignments = result.releasedClaims
+      .filter((k) => k.startsWith(ASSIGNMENT_PREFIX))
+      .map((k) => k.substring(ASSIGNMENT_PREFIX.length));
+    // Drop in-process bookkeeping for any worker that lost an assignment.
+    for (const [worker, set] of this.workerAssignments.entries()) {
+      for (const projectId of [...set]) {
+        if (releasedAssignments.includes(projectId)) {
+          set.delete(projectId);
+        }
+      }
+      if (set.size === 0) this.workerAssignments.delete(worker);
+    }
+    return { releasedAssignments };
+  }
+
+  // -- Real-time -----------------------------------------------------------
+
+  async subscribeToProject(
+    projectId: string,
+    handler: (event: ProjectEvent) => void,
+  ): Promise<() => Promise<void>> {
+    return this.store.subscribe('caia_project_' + projectId, (payload) => {
+      try {
+        const parsed = JSON.parse(payload) as ProjectEvent;
+        handler(parsed);
+      } catch {
+        // ignore malformed payload
+      }
+    });
+  }
+
+  async subscribeToTickets(
+    projectId: string,
+    handler: (event: TicketEvent) => void,
+  ): Promise<() => Promise<void>> {
+    return this.store.subscribe('caia_ticket_' + projectId, (payload) => {
+      try {
+        const parsed = JSON.parse(payload) as TicketEvent;
+        handler(parsed);
+      } catch {
+        // ignore
+      }
+    });
+  }
+}
+
+const ASSIGNMENT_PREFIX = 'project-assignment:';
+function assignmentKey(projectId: string): string {
+  return ASSIGNMENT_PREFIX + projectId;
+}
+
+function normalizeTransitionArgs(
+  optsOrReason: TransitionOpts | string,
+  maybeTriggeredBy: TriggeredBy | string | undefined,
+): TransitionOpts {
+  if (typeof optsOrReason === 'string') {
+    if (maybeTriggeredBy === undefined) {
+      throw new TypeError(
+        'transition(): positional form requires (projectId, toState, reason, triggeredBy)',
+      );
+    }
+    const triggeredBy: TriggeredBy =
+      typeof maybeTriggeredBy === 'string'
+        ? { kind: 'system', id: maybeTriggeredBy }
+        : maybeTriggeredBy;
+    return { reason: optsOrReason, triggeredBy };
+  }
+  return optsOrReason;
+}

--- a/packages/state-machine/src/states.ts
+++ b/packages/state-machine/src/states.ts
@@ -1,0 +1,110 @@
+/**
+ * Canonical CAIA pipeline states.
+ *
+ * Sourced from `research/state_machine_handoff_spec_2026.md` §1.2 + §1.3.
+ *
+ * Every "doing" state has an explicit `*-failed` variant. Plus `paused` and
+ * `revision-pending` as orthogonal flags-as-states. `archived` is terminal.
+ */
+
+/** Happy-path states. Linear unless commented otherwise. */
+export const HAPPY_STATES = [
+  'onboarding',
+  'idea-captured',
+  'interviewing',
+  'interview-complete',
+  'proposal-generated',
+  'awaiting-external-design',
+  'design-uploaded',
+  'ticket-tree-generated',
+  'atlas-ready',
+  'change-requested',
+  'ea-dispatching',
+  'ea-complete',
+  'tests-authored',
+  'tests-reviewed',
+  'scheduled',
+  'coding-in-progress',
+  'code-complete',
+  'per-story-tested',
+  'e2e-tested',
+  'deploying',
+  'deployed',
+  'verified',
+  'done',
+] as const;
+
+/** Failure-side variants. */
+export const FAILED_STATES = [
+  'onboarding-failed',
+  'interviewing-failed',
+  'proposal-failed',
+  'design-ingest-failed',
+  'atlas-decompose-failed',
+  'ea-dispatching-failed',
+  'ea-review-failed',
+  'tests-authoring-failed',
+  'tests-review-failed',
+  'scheduling-failed',
+  'coding-failed',
+  'per-story-test-failed',
+  'e2e-failed',
+  'deploy-failed',
+  'verify-failed',
+] as const;
+
+/** Orthogonal "control" states the operator can request. */
+export const CONTROL_STATES = [
+  // Paused is set on a doing-state; the dedicated `paused` value here
+  // exists for the rare case where a caller needs to set status to literal
+  // paused (eg fresh-from-fork projects parked until the operator nudges).
+  'paused',
+  // Revision-pending fires when an upstream artifact changed and the
+  // orchestrator is about to recompute. Sits between change-requested and
+  // the proposed-resume-state target.
+  'revision-pending',
+  'archived',
+] as const;
+
+export const ALL_STATES = [
+  ...HAPPY_STATES,
+  ...FAILED_STATES,
+  ...CONTROL_STATES,
+] as const;
+
+const HAPPY_SET = new Set<string>(HAPPY_STATES);
+const FAILED_SET = new Set<string>(FAILED_STATES);
+const CONTROL_SET = new Set<string>(CONTROL_STATES);
+const ALL_SET = new Set<string>(ALL_STATES);
+
+export type HappyState = (typeof HAPPY_STATES)[number];
+export type FailedState = (typeof FAILED_STATES)[number];
+export type ControlState = (typeof CONTROL_STATES)[number];
+export type ProjectState = HappyState | FailedState | ControlState;
+
+export function isProjectState(value: unknown): value is ProjectState {
+  return typeof value === 'string' && ALL_SET.has(value);
+}
+
+export function isHappyState(value: ProjectState): value is HappyState {
+  return HAPPY_SET.has(value);
+}
+
+export function isFailedState(value: ProjectState): value is FailedState {
+  return FAILED_SET.has(value);
+}
+
+export function isControlState(value: ProjectState): value is ControlState {
+  return CONTROL_SET.has(value);
+}
+
+/**
+ * Terminal states - no outgoing transitions. `done` is the happy terminal;
+ * `archived` is the operator-abandoned terminal.
+ */
+export const TERMINAL_STATES: readonly ProjectState[] = ['done', 'archived'];
+
+/** Set membership helper for callers that compare against literals. */
+export function isTerminal(state: ProjectState): boolean {
+  return TERMINAL_STATES.includes(state);
+}

--- a/packages/state-machine/src/store.ts
+++ b/packages/state-machine/src/store.ts
@@ -1,0 +1,104 @@
+/**
+ * The `StateStore` interface is the backend-agnostic storage shape the
+ * state-machine depends on. Two implementations ship in this package:
+ *
+ *   - `InMemoryStateStore` - fast, deterministic, used by ~all unit tests.
+ *   - `PgStateStore` - wraps a `pg.Pool`. Used by integration tests and
+ *     by orchestrators in production.
+ *
+ * Every method on this interface MUST be atomic enough that the
+ * transition API can compose them without race conditions. Specifically:
+ * `transitionAtomic()` must read current state + write history + write
+ * project in a single durable step.
+ */
+
+import type { ProjectState } from './states.js';
+import type {
+  ActorKind,
+  ClaimResult,
+  JanitorResult,
+  NewProjectInput,
+  ProjectRow,
+  StateTransitionRow,
+} from './types.js';
+
+export interface TransitionAtomicInput {
+  projectId: string;
+  expectedVersion: number;
+  expectedStatus: ProjectState;
+  toState: ProjectState;
+  reason: string;
+  actorKind: ActorKind;
+  actorId: string;
+  agentRunId: string | null;
+  payload: Record<string, unknown>;
+  payloadHash: string;
+  /** When non-null, the row is created only if no duplicate exists within this many ms. */
+  idempotencyWindowMs: number;
+}
+
+export interface TransitionAtomicResult {
+  applied: boolean;
+  newVersion: number;
+  historyId: number | null;
+}
+
+export interface StateStore {
+  /** Apply migrations (idempotent). Real driver runs the SQL file. */
+  init(): Promise<void>;
+  /** Test/admin helper - wipes all state. */
+  reset?(): Promise<void>;
+
+  createProject(input: NewProjectInput): Promise<ProjectRow>;
+  getProject(projectId: string): Promise<ProjectRow | null>;
+  listActiveProjects(): Promise<ProjectRow[]>;
+  setPaused(
+    projectId: string,
+    paused: boolean,
+    by: string | null,
+  ): Promise<void>;
+
+  /**
+   * Atomic transition: under a per-project advisory lock + optimistic
+   * lock on `version`, update the project row AND append a state_history
+   * row in a single commit. Idempotency is enforced via the unique
+   * (project_id, to_state, payload_hash) index.
+   */
+  transitionAtomic(
+    input: TransitionAtomicInput,
+  ): Promise<TransitionAtomicResult>;
+
+  listHistory(
+    projectId: string,
+    opts?: { limit?: number; afterId?: number; toState?: ProjectState },
+  ): Promise<StateTransitionRow[]>;
+
+  tryClaim(input: {
+    ticketId: string;
+    projectId: string | null;
+    agentId: string;
+    ttlSeconds: number;
+    now: Date;
+  }): Promise<ClaimResult>;
+
+  heartbeat(input: {
+    ticketId: string;
+    agentId: string;
+    now: Date;
+  }): Promise<{ ok: boolean; heartbeatAt: Date | null }>;
+
+  releaseClaim(input: {
+    ticketId: string;
+    agentId: string;
+    finalStatus: string;
+    now: Date;
+  }): Promise<{ ok: boolean }>;
+
+  /** Releases every claim whose heartbeat is older than its ttl. */
+  janitorSweep(now: Date): Promise<JanitorResult>;
+
+  subscribe(
+    channel: string,
+    handler: (payload: string) => void,
+  ): Promise<() => Promise<void>>;
+}

--- a/packages/state-machine/src/test-support.ts
+++ b/packages/state-machine/src/test-support.ts
@@ -1,0 +1,39 @@
+import { InMemoryStateStore } from './in-memory-store.js';
+import { StateMachine } from './state-machine.js';
+import type { ProjectState } from './states.js';
+import type { StateMachineOptions } from './types.js';
+
+/** Build a fresh in-memory StateMachine for tests. */
+export function buildInMemoryStateMachine(opts: StateMachineOptions = {}): {
+  sm: StateMachine;
+  store: InMemoryStateStore;
+} {
+  const store = new InMemoryStateStore();
+  const sm = new StateMachine(store, opts);
+  return { sm, store };
+}
+
+/** Helper: walk a project through the canonical happy path. */
+export const HAPPY_PATH: ReadonlyArray<[ProjectState, ProjectState]> = [
+  ['onboarding', 'idea-captured'],
+  ['idea-captured', 'interviewing'],
+  ['interviewing', 'interview-complete'],
+  ['interview-complete', 'proposal-generated'],
+  ['proposal-generated', 'awaiting-external-design'],
+  ['awaiting-external-design', 'design-uploaded'],
+  ['design-uploaded', 'ticket-tree-generated'],
+  ['ticket-tree-generated', 'atlas-ready'],
+  ['atlas-ready', 'ea-dispatching'],
+  ['ea-dispatching', 'ea-complete'],
+  ['ea-complete', 'tests-authored'],
+  ['tests-authored', 'tests-reviewed'],
+  ['tests-reviewed', 'scheduled'],
+  ['scheduled', 'coding-in-progress'],
+  ['coding-in-progress', 'code-complete'],
+  ['code-complete', 'per-story-tested'],
+  ['per-story-tested', 'e2e-tested'],
+  ['e2e-tested', 'deploying'],
+  ['deploying', 'deployed'],
+  ['deployed', 'verified'],
+  ['verified', 'done'],
+];

--- a/packages/state-machine/src/transitions.ts
+++ b/packages/state-machine/src/transitions.ts
@@ -1,0 +1,234 @@
+/**
+ * Valid transitions for the CAIA project FSM.
+ *
+ * Sourced verbatim from `state_machine_handoff_spec_2026.md` §1.1 + §1.3 +
+ * §1.4 + §1.5. Every transition is enumerated; anything else throws.
+ */
+
+import { ALL_STATES, isTerminal, type ProjectState } from './states.js';
+
+/**
+ * Map from a state to the set of states it may legally transition to.
+ * Keys cover every non-terminal state in `ALL_STATES`. `done` and
+ * `archived` have empty exits.
+ */
+const VALID_TRANSITIONS_RAW: Record<ProjectState, readonly ProjectState[]> = {
+  // -- Happy path -----------------------------------------------------------
+  onboarding: ['idea-captured', 'onboarding-failed', 'paused', 'archived'],
+  'idea-captured': ['interviewing', 'paused', 'archived'],
+  interviewing: [
+    'interview-complete',
+    'interviewing-failed',
+    'paused',
+    'archived',
+  ],
+  'interview-complete': [
+    'proposal-generated',
+    'proposal-failed',
+    'paused',
+    'archived',
+  ],
+  'proposal-generated': ['awaiting-external-design', 'paused', 'archived'],
+  'awaiting-external-design': [
+    'design-uploaded',
+    'design-ingest-failed',
+    'paused',
+    'archived',
+  ],
+  'design-uploaded': [
+    'ticket-tree-generated',
+    'atlas-decompose-failed',
+    'paused',
+    'archived',
+  ],
+  'ticket-tree-generated': [
+    'atlas-ready',
+    'ea-dispatching',
+    'paused',
+    'archived',
+  ],
+  // Atlas-ready is the pivot. From here the operator either fires the
+  // backend chain (ea-dispatching) or issues a change-request.
+  'atlas-ready': ['ea-dispatching', 'change-requested', 'paused', 'archived'],
+  // Change-requested is routed to one of several resume states by the
+  // change-router (spec §1.4). We allow any of those resume targets.
+  'change-requested': [
+    'revision-pending',
+    'ticket-tree-generated',
+    'ea-dispatching',
+    'tests-authored',
+    'coding-in-progress',
+    'idea-captured',
+    'paused',
+    'archived',
+  ],
+  // Revision-pending is the transient "router decided, orchestrator
+  // hasn't executed yet" state. It only exits to the resume target.
+  'revision-pending': [
+    'ticket-tree-generated',
+    'ea-dispatching',
+    'tests-authored',
+    'coding-in-progress',
+    'idea-captured',
+    'paused',
+    'archived',
+  ],
+  'ea-dispatching': [
+    'ea-complete',
+    'ea-dispatching-failed',
+    'paused',
+    'archived',
+  ],
+  'ea-complete': ['tests-authored', 'ea-review-failed', 'paused', 'archived'],
+  'tests-authored': [
+    'tests-reviewed',
+    'tests-authoring-failed',
+    'paused',
+    'archived',
+  ],
+  'tests-reviewed': [
+    'scheduled',
+    'tests-review-failed',
+    'paused',
+    'archived',
+  ],
+  scheduled: [
+    'coding-in-progress',
+    'scheduling-failed',
+    'paused',
+    'archived',
+  ],
+  'coding-in-progress': [
+    'code-complete',
+    'coding-failed',
+    'paused',
+    'archived',
+  ],
+  'code-complete': [
+    'per-story-tested',
+    'per-story-test-failed',
+    'paused',
+    'archived',
+  ],
+  'per-story-tested': ['e2e-tested', 'e2e-failed', 'paused', 'archived'],
+  'e2e-tested': ['deploying', 'paused', 'archived'],
+  deploying: ['deployed', 'deploy-failed', 'paused', 'archived'],
+  deployed: ['verified', 'verify-failed', 'paused', 'archived'],
+  verified: ['done', 'archived'],
+  // -- Failed-side variants -> recover or abandon (spec §1.3) ---------------
+  'onboarding-failed': ['onboarding', 'archived'],
+  'interviewing-failed': ['interviewing', 'idea-captured', 'archived'],
+  'proposal-failed': ['interview-complete', 'archived'],
+  'design-ingest-failed': ['awaiting-external-design', 'archived'],
+  'atlas-decompose-failed': ['design-uploaded', 'archived'],
+  'ea-dispatching-failed': ['ticket-tree-generated', 'ea-dispatching', 'archived'],
+  'ea-review-failed': ['ea-dispatching', 'archived'],
+  'tests-authoring-failed': ['ea-complete', 'tests-authored', 'archived'],
+  'tests-review-failed': ['tests-authored', 'archived'],
+  'scheduling-failed': ['tests-reviewed', 'archived'],
+  'coding-failed': ['scheduled', 'coding-in-progress', 'archived'],
+  'per-story-test-failed': ['coding-in-progress', 'archived'],
+  'e2e-failed': ['code-complete', 'per-story-tested', 'archived'],
+  'deploy-failed': ['e2e-tested', 'deploying', 'archived'],
+  'verify-failed': ['deployed', 'archived'],
+  // -- Control -------------------------------------------------------------
+  // Paused is structurally an in-flight state; it can resume into any
+  // state. Practically, the orchestrator only ever transitions paused ->
+  // the prior state via the `resume()` verb, but we accept any state so
+  // the operator can also `restart`/`fork`.
+  paused: ALL_STATES.filter((s) => s !== 'paused'),
+  // Terminal - no exits.
+  done: [],
+  archived: [],
+};
+
+// Sanity: every state is keyed exactly once.
+Object.freeze(VALID_TRANSITIONS_RAW);
+
+export const VALID_TRANSITIONS: Readonly<
+  Record<ProjectState, readonly ProjectState[]>
+> = VALID_TRANSITIONS_RAW;
+
+export interface TransitionCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+/** Returns `true` if `from -> to` is in the transition table. */
+export function canTransition(from: ProjectState, to: ProjectState): boolean {
+  if (from === to) return false;
+  if (isTerminal(from)) return false;
+  const allowed = VALID_TRANSITIONS[from];
+  return allowed.includes(to);
+}
+
+/**
+ * Same as `canTransition` but returns a structured reason - useful for
+ * propagating "why" into error messages and dashboard tooltips.
+ */
+export function checkTransition(
+  from: ProjectState,
+  to: ProjectState,
+): TransitionCheck {
+  if (from === to) return { ok: false, reason: 'self-transition is a no-op' };
+  if (isTerminal(from))
+    return { ok: false, reason: `${from} is a terminal state` };
+  const allowed = VALID_TRANSITIONS[from];
+  if (!allowed.includes(to)) {
+    return {
+      ok: false,
+      reason: `${from} -> ${to} is not in the transition table`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Used by the dashboard to render the "next step" picker. */
+export function availableTransitions(
+  from: ProjectState,
+): readonly ProjectState[] {
+  return VALID_TRANSITIONS[from];
+}
+
+/** Spec-named alias for `availableTransitions`. */
+export function validNextStates(
+  from: ProjectState,
+): readonly ProjectState[] {
+  return VALID_TRANSITIONS[from];
+}
+
+/**
+ * For tests / static analysis: returns every (from,to) edge in the FSM.
+ */
+export function allEdges(): { from: ProjectState; to: ProjectState }[] {
+  const out: { from: ProjectState; to: ProjectState }[] = [];
+  for (const from of ALL_STATES) {
+    for (const to of VALID_TRANSITIONS[from]) {
+      out.push({ from, to });
+    }
+  }
+  return out;
+}
+
+/**
+ * Convenience: which terminal states are reachable from `state`? Used by
+ * resume logic to decide whether a project still has work to do.
+ */
+export function reachableTerminals(state: ProjectState): ProjectState[] {
+  const visited = new Set<ProjectState>();
+  const stack: ProjectState[] = [state];
+  const out = new Set<ProjectState>();
+  while (stack.length) {
+    const cur = stack.pop() as ProjectState;
+    if (visited.has(cur)) continue;
+    visited.add(cur);
+    if (isTerminal(cur)) {
+      out.add(cur);
+      continue;
+    }
+    for (const next of VALID_TRANSITIONS[cur]) {
+      if (!visited.has(next)) stack.push(next);
+    }
+  }
+  return [...out];
+}

--- a/packages/state-machine/src/types.ts
+++ b/packages/state-machine/src/types.ts
@@ -1,0 +1,112 @@
+import type { ProjectState } from './states.js';
+
+/** Actor-kind for the audit log. */
+export type ActorKind = 'system' | 'operator' | 'agent';
+
+export interface TriggeredBy {
+  kind: ActorKind;
+  /** Agent id, operator user id, or 'system'. */
+  id: string;
+  /** Optional pointer to an agent_runs row. */
+  agentRunId?: string;
+}
+
+export interface StateTransitionRow {
+  id: number;
+  projectId: string;
+  fromState: ProjectState | null;
+  toState: ProjectState;
+  reason: string;
+  actorKind: ActorKind;
+  actorId: string;
+  agentRunId: string | null;
+  payload: Record<string, unknown>;
+  at: Date;
+  payloadHash: string;
+}
+
+export interface ProjectRow {
+  id: string;
+  tenantId: string;
+  slug: string;
+  displayName: string;
+  status: ProjectState;
+  paused: boolean;
+  pausedAt: Date | null;
+  pausedBy: string | null;
+  currentPayload: Record<string, unknown>;
+  lastTransitionedAt: Date;
+  lastTransitionedBy: string;
+  parentProjectId: string | null;
+  archivedAt: Date | null;
+  version: number;
+  createdAt: Date;
+}
+
+export interface TransitionOpts {
+  reason: string;
+  triggeredBy: TriggeredBy;
+  payload?: Record<string, unknown>;
+  /**
+   * When set, the transition is only applied if the current project
+   * version matches. Without this the API does a read-then-write inside
+   * its own transaction; provide it when the caller already has a
+   * snapshot they want to commit against.
+   */
+  expectedVersion?: number;
+  /**
+   * Override per-call retry budget. Defaults to `StateMachineOptions.defaultRetries`.
+   */
+  retries?: number;
+}
+
+export interface TransitionResult {
+  /** True if this call actually moved state; false on idempotent no-op. */
+  applied: boolean;
+  projectId: string;
+  fromState: ProjectState;
+  toState: ProjectState;
+  newVersion: number;
+  historyId: number | null;
+  payloadHash: string;
+  /** Number of optimistic-lock retries before the call resolved. */
+  retries: number;
+}
+
+export interface ClaimResult {
+  claimed: boolean;
+  /** Seconds until the claim is considered stale (and the janitor may revoke it). */
+  ttl: number;
+  claimedBy?: string;
+  heartbeatAt?: Date;
+}
+
+export interface JanitorResult {
+  releasedClaims: string[];
+}
+
+export interface NewProjectInput {
+  id?: string;
+  tenantId: string;
+  slug: string;
+  displayName: string;
+  initialState?: ProjectState;
+  initialPayload?: Record<string, unknown>;
+  parentProjectId?: string;
+}
+
+export interface StateMachineOptions {
+  /** Clock for tests. */
+  now?: () => Date;
+  /**
+   * Time window inside which an immediate duplicate transition call is
+   * a no-op. The payload-hash idempotency rule is always enforced; this
+   * is a softer rule for catching duplicate clicks with empty payloads.
+   * Defaults to 1000ms.
+   */
+  idempotencyWindowMs?: number;
+  /** Default number of optimistic-lock retries for `transition()`. Defaults to 3. */
+  defaultRetries?: number;
+  /** Worker claim TTL in seconds. Defaults to 90 (matches spec §4.3). */
+  workerTtlSeconds?: number;
+}

--- a/packages/state-machine/src/whats-next.ts
+++ b/packages/state-machine/src/whats-next.ts
@@ -1,0 +1,287 @@
+/**
+ * whatsNext - given a project's current state, return the agent type
+ * and parameters the orchestrator should fire next.
+ *
+ * Sourced from `state_machine_handoff_spec_2026.md` §3.1 (handoff
+ * table). Each non-terminal "doing" state has a producer agent; that
+ * agent runs, produces the next state's payload, and the orchestrator
+ * transitions the project on success.
+ *
+ * Idempotent: calling whatsNext twice in a row returns the same answer.
+ * After a successful transition, calling it again returns the next
+ * step (because the project's `status` has advanced).
+ */
+
+import { ProjectNotFoundError } from './errors.js';
+import { isFailedState, isHappyState, type ProjectState } from './states.js';
+import type { StateMachine } from './state-machine.js';
+
+export interface AgentSpec {
+  /** The agent identifier the orchestrator looks up in `claude-spawner`. */
+  type: string;
+  /** Artifact name the agent should produce (from handoff-contracts §3.1). */
+  producesArtifact: string;
+  /** The state to transition the project to on success. */
+  onSuccessTransitionTo: ProjectState;
+  /** State to transition to on failure. */
+  onFailureTransitionTo: ProjectState;
+}
+
+export type WaitingReason =
+  | 'project-paused'
+  | 'project-archived'
+  | 'project-done'
+  | 'waiting-for-operator'
+  | 'waiting-for-external'
+  | 'waiting-for-failure-recovery'
+  | 'waiting-for-revision-router'
+  | 'unknown';
+
+export interface WhatsNextResult {
+  hasWork: boolean;
+  currentState: ProjectState;
+  agent: AgentSpec | null;
+  parameters: Record<string, unknown>;
+  waitingOn: WaitingReason | null;
+}
+
+type HandoffEntry = AgentSpec | { waitingOn: WaitingReason };
+
+const HANDOFF_TABLE: Record<ProjectState, HandoffEntry> = {
+  // -- Happy path producers --
+  onboarding: {
+    type: '@caia/onboarding',
+    producesArtifact: 'OnboardedTenant',
+    onSuccessTransitionTo: 'idea-captured',
+    onFailureTransitionTo: 'onboarding-failed',
+  },
+  'idea-captured': {
+    type: '@caia/idea-capture',
+    producesArtifact: 'GrandIdeaBrief',
+    onSuccessTransitionTo: 'interviewing',
+    onFailureTransitionTo: 'interviewing-failed',
+  },
+  interviewing: {
+    type: '@caia/interviewer',
+    producesArtifact: 'BusinessPlan',
+    onSuccessTransitionTo: 'interview-complete',
+    onFailureTransitionTo: 'interviewing-failed',
+  },
+  'interview-complete': {
+    type: '@caia/proposal-generator',
+    producesArtifact: 'ProposalBundle',
+    onSuccessTransitionTo: 'proposal-generated',
+    onFailureTransitionTo: 'proposal-failed',
+  },
+  'proposal-generated': {
+    type: '@caia/proposal-emit',
+    producesArtifact: 'DesignAppPrompt',
+    onSuccessTransitionTo: 'awaiting-external-design',
+    onFailureTransitionTo: 'proposal-failed',
+  },
+  'awaiting-external-design': { waitingOn: 'waiting-for-external' },
+  'design-uploaded': {
+    type: '@caia/design-normalizer',
+    producesArtifact: 'RenderableDesign',
+    onSuccessTransitionTo: 'ticket-tree-generated',
+    onFailureTransitionTo: 'design-ingest-failed',
+  },
+  'ticket-tree-generated': {
+    type: '@caia/principal-po',
+    producesArtifact: 'AtlasBundle',
+    onSuccessTransitionTo: 'atlas-ready',
+    onFailureTransitionTo: 'atlas-decompose-failed',
+  },
+  'atlas-ready': { waitingOn: 'waiting-for-operator' },
+  'change-requested': {
+    type: '@caia/atlas-change-router',
+    producesArtifact: 'ResumeDirective',
+    onSuccessTransitionTo: 'revision-pending',
+    onFailureTransitionTo: 'atlas-decompose-failed',
+  },
+  'revision-pending': { waitingOn: 'waiting-for-revision-router' },
+  'ea-dispatching': {
+    type: '@caia/ea-dispatcher',
+    producesArtifact: 'ArchitectureBundle',
+    onSuccessTransitionTo: 'ea-complete',
+    onFailureTransitionTo: 'ea-dispatching-failed',
+  },
+  'ea-complete': {
+    type: '@caia/ea-reviewer',
+    producesArtifact: 'EAReviewedBundle',
+    onSuccessTransitionTo: 'tests-authored',
+    onFailureTransitionTo: 'ea-review-failed',
+  },
+  'tests-authored': {
+    type: '@caia/test-reviewer',
+    producesArtifact: 'TestCasesBundle',
+    onSuccessTransitionTo: 'tests-reviewed',
+    onFailureTransitionTo: 'tests-review-failed',
+  },
+  'tests-reviewed': {
+    type: '@caia/sps-adapter',
+    producesArtifact: 'SchedulableTree',
+    onSuccessTransitionTo: 'scheduled',
+    onFailureTransitionTo: 'scheduling-failed',
+  },
+  scheduled: {
+    type: '@caia/coding-worker',
+    producesArtifact: 'CodingResultSet',
+    onSuccessTransitionTo: 'coding-in-progress',
+    onFailureTransitionTo: 'coding-failed',
+  },
+  'coding-in-progress': {
+    type: '@caia/coding-worker',
+    producesArtifact: 'CodingResultSet',
+    onSuccessTransitionTo: 'code-complete',
+    onFailureTransitionTo: 'coding-failed',
+  },
+  'code-complete': {
+    type: '@caia/per-story-tester',
+    producesArtifact: 'StoryTestReport',
+    onSuccessTransitionTo: 'per-story-tested',
+    onFailureTransitionTo: 'per-story-test-failed',
+  },
+  'per-story-tested': {
+    type: '@caia/e2e-runner',
+    producesArtifact: 'E2EReport',
+    onSuccessTransitionTo: 'e2e-tested',
+    onFailureTransitionTo: 'e2e-failed',
+  },
+  'e2e-tested': {
+    type: '@caia/deploy-orchestrator',
+    producesArtifact: 'DeployPlan',
+    onSuccessTransitionTo: 'deploying',
+    onFailureTransitionTo: 'deploy-failed',
+  },
+  deploying: {
+    type: '@caia/deploy-orchestrator',
+    producesArtifact: 'DeployRecord',
+    onSuccessTransitionTo: 'deployed',
+    onFailureTransitionTo: 'deploy-failed',
+  },
+  deployed: {
+    type: '@caia/verifier',
+    producesArtifact: 'VerificationReport',
+    onSuccessTransitionTo: 'verified',
+    onFailureTransitionTo: 'verify-failed',
+  },
+  verified: {
+    type: '@caia/done-emitter',
+    producesArtifact: 'DoneReceipt',
+    onSuccessTransitionTo: 'done',
+    onFailureTransitionTo: 'verify-failed',
+  },
+
+  // -- Failed-side: wait for operator / auto-retry --
+  'onboarding-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'interviewing-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'proposal-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'design-ingest-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'atlas-decompose-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'ea-dispatching-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'ea-review-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'tests-authoring-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'tests-review-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'scheduling-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'coding-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'per-story-test-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'e2e-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'deploy-failed': { waitingOn: 'waiting-for-failure-recovery' },
+  'verify-failed': { waitingOn: 'waiting-for-failure-recovery' },
+
+  // -- Control --
+  paused: { waitingOn: 'project-paused' },
+  archived: { waitingOn: 'project-archived' },
+  done: { waitingOn: 'project-done' },
+};
+
+export async function whatsNext(
+  sm: StateMachine,
+  projectId: string,
+): Promise<WhatsNextResult> {
+  const proj = await sm.getProject(projectId);
+  if (!proj) throw new ProjectNotFoundError(projectId);
+  if (proj.paused) {
+    return {
+      hasWork: false,
+      currentState: proj.status,
+      agent: null,
+      parameters: { project_id: projectId },
+      waitingOn: 'project-paused',
+    };
+  }
+  if (proj.archivedAt) {
+    return {
+      hasWork: false,
+      currentState: proj.status,
+      agent: null,
+      parameters: { project_id: projectId },
+      waitingOn: 'project-archived',
+    };
+  }
+  const entry = HANDOFF_TABLE[proj.status];
+  if ('waitingOn' in entry) {
+    return {
+      hasWork: false,
+      currentState: proj.status,
+      agent: null,
+      parameters: { project_id: projectId },
+      waitingOn: entry.waitingOn,
+    };
+  }
+  return {
+    hasWork: true,
+    currentState: proj.status,
+    agent: entry,
+    parameters: {
+      project_id: projectId,
+      tenant_id: proj.tenantId,
+      input_payload: proj.currentPayload,
+      version: proj.version,
+    },
+    waitingOn: null,
+  };
+}
+
+export interface ResumePoint {
+  state: ProjectState;
+  reason: 'steady-state' | 'history-replayed' | 'parked-at-failure' | 'paused';
+  lastHistoryId: number | null;
+}
+
+export async function resumePoint(
+  sm: StateMachine,
+  projectId: string,
+): Promise<ResumePoint> {
+  const proj = await sm.getProject(projectId);
+  if (!proj) throw new ProjectNotFoundError(projectId);
+  if (proj.paused) {
+    return { state: proj.status, reason: 'paused', lastHistoryId: null };
+  }
+  if (isFailedState(proj.status)) {
+    const hist = await sm.replayHistory(projectId, {
+      limit: 1,
+      toState: proj.status,
+    });
+    return {
+      state: proj.status,
+      reason: 'parked-at-failure',
+      lastHistoryId: hist[0]?.id ?? null,
+    };
+  }
+  const all = await sm.replayHistory(projectId);
+  const last = all[all.length - 1];
+  if (last && last.toState !== proj.status && isHappyState(proj.status)) {
+    return {
+      state: proj.status,
+      reason: 'history-replayed',
+      lastHistoryId: last.id,
+    };
+  }
+  return {
+    state: proj.status,
+    reason: 'steady-state',
+    lastHistoryId: last?.id ?? null,
+  };
+}

--- a/packages/state-machine/tests/errors.test.ts
+++ b/packages/state-machine/tests/errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AdvisoryLockHeldError,
+  InvalidTransitionError,
+  ProjectNotFoundError,
+  StaleProjectVersionError,
+  TicketAlreadyClaimedError,
+  TransitionRetryExhaustedError,
+} from '../src/errors.js';
+
+describe('typed errors', () => {
+  it('InvalidTransitionError exposes from/to/reason', () => {
+    const e = new InvalidTransitionError('onboarding', 'done', 'because');
+    expect(e.from).toBe('onboarding');
+    expect(e.to).toBe('done');
+    expect(e.reasonDetail).toBe('because');
+    expect(e.name).toBe('InvalidTransitionError');
+    expect(e.message).toContain('because');
+  });
+
+  it('InvalidTransitionError without reason has a clean message', () => {
+    const e = new InvalidTransitionError('onboarding', 'done');
+    expect(e.message).toBe('invalid transition onboarding -> done');
+  });
+
+  it('StaleProjectVersionError carries projectId + expectedVersion', () => {
+    const e = new StaleProjectVersionError('pid', 7);
+    expect(e.projectId).toBe('pid');
+    expect(e.expectedVersion).toBe(7);
+    expect(e.message).toContain('7');
+  });
+
+  it('ProjectNotFoundError carries projectId', () => {
+    const e = new ProjectNotFoundError('pid');
+    expect(e.projectId).toBe('pid');
+  });
+
+  it('AdvisoryLockHeldError carries projectId', () => {
+    const e = new AdvisoryLockHeldError('pid');
+    expect(e.projectId).toBe('pid');
+  });
+
+  it('TicketAlreadyClaimedError carries ticketId + claimedBy', () => {
+    const e = new TicketAlreadyClaimedError('t1', 'agent-A');
+    expect(e.ticketId).toBe('t1');
+    expect(e.claimedBy).toBe('agent-A');
+    expect(e.message).toContain('agent-A');
+  });
+
+  it('TicketAlreadyClaimedError without claimedBy has a generic message', () => {
+    const e = new TicketAlreadyClaimedError('t1');
+    expect(e.message).toBe('ticket t1 already claimed');
+  });
+
+  it('TransitionRetryExhaustedError carries projectId + attempts', () => {
+    const e = new TransitionRetryExhaustedError('pid', 4);
+    expect(e.projectId).toBe('pid');
+    expect(e.attempts).toBe(4);
+    expect(e.message).toContain('4');
+  });
+
+  it('all errors inherit from Error', () => {
+    expect(new InvalidTransitionError('onboarding', 'done')).toBeInstanceOf(Error);
+    expect(new StaleProjectVersionError('p', 1)).toBeInstanceOf(Error);
+    expect(new ProjectNotFoundError('p')).toBeInstanceOf(Error);
+    expect(new AdvisoryLockHeldError('p')).toBeInstanceOf(Error);
+    expect(new TicketAlreadyClaimedError('t')).toBeInstanceOf(Error);
+    expect(new TransitionRetryExhaustedError('p', 1)).toBeInstanceOf(Error);
+  });
+});

--- a/packages/state-machine/tests/hash.test.ts
+++ b/packages/state-machine/tests/hash.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashPayload } from '../src/hash.js';
+
+describe('hashPayload', () => {
+  it('produces a 64-char hex digest', () => {
+    const h = hashPayload({ a: 1 });
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is stable across key order', () => {
+    expect(hashPayload({ a: 1, b: 2 })).toBe(hashPayload({ b: 2, a: 1 }));
+  });
+
+  it('differs when values differ', () => {
+    expect(hashPayload({ a: 1 })).not.toBe(hashPayload({ a: 2 }));
+  });
+
+  it('handles nested objects deterministically', () => {
+    const left = hashPayload({ outer: { y: 2, x: 1 } });
+    const right = hashPayload({ outer: { x: 1, y: 2 } });
+    expect(left).toBe(right);
+  });
+
+  it('preserves array order', () => {
+    const a = hashPayload({ list: [1, 2, 3] });
+    const b = hashPayload({ list: [3, 2, 1] });
+    expect(a).not.toBe(b);
+  });
+
+  it('treats non-finite numbers as null', () => {
+    const a = hashPayload({ v: Number.NaN });
+    const b = hashPayload({ v: null as unknown as number });
+    expect(a).toBe(b);
+  });
+
+  it('hash of empty object is fixed', () => {
+    expect(hashPayload({})).toBe(hashPayload({}));
+  });
+});

--- a/packages/state-machine/tests/in-memory-store.test.ts
+++ b/packages/state-machine/tests/in-memory-store.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { hashPayload } from '../src/hash.js';
+import { InMemoryStateStore } from '../src/in-memory-store.js';
+
+describe('InMemoryStateStore', () => {
+  let store: InMemoryStateStore;
+
+  beforeEach(async () => {
+    store = new InMemoryStateStore();
+    await store.init();
+  });
+
+  it('createProject assigns an id and version=1', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    expect(p.id).toBeTruthy();
+    expect(p.version).toBe(1);
+    expect(p.status).toBe('onboarding');
+    expect(p.paused).toBe(false);
+  });
+
+  it('rejects duplicate ids', async () => {
+    const a = await store.createProject({
+      id: '00000000-0000-0000-0000-000000000001',
+      tenantId: 't',
+      slug: 'a',
+      displayName: 'A',
+    });
+    await expect(
+      store.createProject({
+        id: a.id,
+        tenantId: 't',
+        slug: 'b',
+        displayName: 'B',
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it('getProject returns a clone (mutating it does not leak)', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    const a = await store.getProject(p.id);
+    expect(a).not.toBeNull();
+    a!.currentPayload.injected = true;
+    const b = await store.getProject(p.id);
+    expect(b!.currentPayload.injected).toBeUndefined();
+  });
+
+  it('transitionAtomic applies once', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    const result = await store.transitionAtomic({
+      projectId: p.id,
+      expectedVersion: 1,
+      expectedStatus: 'onboarding',
+      toState: 'idea-captured',
+      reason: 'r',
+      actorKind: 'system',
+      actorId: 'system',
+      agentRunId: null,
+      payload: {},
+      payloadHash: hashPayload({}),
+      idempotencyWindowMs: 1000,
+    });
+    expect(result.applied).toBe(true);
+    expect(result.newVersion).toBe(2);
+  });
+
+  it('transitionAtomic is idempotent via payload-hash uniqueness', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    const args = {
+      projectId: p.id,
+      expectedVersion: 1,
+      expectedStatus: 'onboarding' as const,
+      toState: 'idea-captured' as const,
+      reason: 'r',
+      actorKind: 'system' as const,
+      actorId: 'system',
+      agentRunId: null,
+      payload: { k: 'v' },
+      payloadHash: hashPayload({ k: 'v' }),
+      idempotencyWindowMs: 1000,
+    };
+    const first = await store.transitionAtomic(args);
+    const second = await store.transitionAtomic({
+      ...args,
+      expectedVersion: 2,
+      expectedStatus: 'idea-captured',
+    });
+    expect(first.applied).toBe(true);
+    expect(second.applied).toBe(false);
+    expect(second.historyId).toBe(first.historyId);
+  });
+
+  it('transitionAtomic rejects version mismatch', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    const r = await store.transitionAtomic({
+      projectId: p.id,
+      expectedVersion: 99,
+      expectedStatus: 'onboarding',
+      toState: 'idea-captured',
+      reason: 'r',
+      actorKind: 'system',
+      actorId: 'system',
+      agentRunId: null,
+      payload: {},
+      payloadHash: hashPayload({}),
+      idempotencyWindowMs: 0,
+    });
+    expect(r.applied).toBe(false);
+    expect(r.historyId).toBeNull();
+  });
+
+  it('listHistory returns rows in id order', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    for (const [from, to] of [
+      ['onboarding', 'idea-captured'],
+      ['idea-captured', 'interviewing'],
+    ] as const) {
+      await store.transitionAtomic({
+        projectId: p.id,
+        expectedVersion: (await store.getProject(p.id))!.version,
+        expectedStatus: from,
+        toState: to,
+        reason: 'r',
+        actorKind: 'system',
+        actorId: 'system',
+        agentRunId: null,
+        payload: { from, to },
+        payloadHash: hashPayload({ from, to }),
+        idempotencyWindowMs: 0,
+      });
+    }
+    const rows = await store.listHistory(p.id);
+    expect(rows.length).toBe(2);
+    expect(rows[0]!.toState).toBe('idea-captured');
+    expect(rows[1]!.toState).toBe('interviewing');
+  });
+
+  it('setPaused toggles paused + pausedBy', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    await store.setPaused(p.id, true, 'op-1');
+    const a = await store.getProject(p.id);
+    expect(a!.paused).toBe(true);
+    expect(a!.pausedBy).toBe('op-1');
+    await store.setPaused(p.id, false, null);
+    const b = await store.getProject(p.id);
+    expect(b!.paused).toBe(false);
+    expect(b!.pausedBy).toBeNull();
+  });
+
+  it('reset clears everything', async () => {
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    expect(await store.getProject(p.id)).not.toBeNull();
+    await store.reset();
+    expect(await store.getProject(p.id)).toBeNull();
+  });
+
+  it('tryClaim/heartbeat/release lifecycle', async () => {
+    const now = new Date('2026-01-01T00:00:00Z');
+    const claim = await store.tryClaim({
+      ticketId: 't1',
+      projectId: null,
+      agentId: 'agent-A',
+      ttlSeconds: 30,
+      now,
+    });
+    expect(claim.claimed).toBe(true);
+
+    const conflict = await store.tryClaim({
+      ticketId: 't1',
+      projectId: null,
+      agentId: 'agent-B',
+      ttlSeconds: 30,
+      now,
+    });
+    expect(conflict.claimed).toBe(false);
+
+    const hb = await store.heartbeat({
+      ticketId: 't1',
+      agentId: 'agent-A',
+      now: new Date(now.getTime() + 5_000),
+    });
+    expect(hb.ok).toBe(true);
+
+    const rel = await store.releaseClaim({
+      ticketId: 't1',
+      agentId: 'agent-A',
+      finalStatus: 'done',
+      now: new Date(now.getTime() + 6_000),
+    });
+    expect(rel.ok).toBe(true);
+  });
+
+  it('janitorSweep releases stale claims', async () => {
+    const t0 = new Date('2026-01-01T00:00:00Z');
+    await store.tryClaim({
+      ticketId: 't1',
+      projectId: null,
+      agentId: 'a',
+      ttlSeconds: 30,
+      now: t0,
+    });
+    const r = await store.janitorSweep(new Date(t0.getTime() + 60_000));
+    expect(r.releasedClaims).toEqual(['t1']);
+  });
+
+  it('subscribe + unsubscribe lifecycle', async () => {
+    const events: string[] = [];
+    const unsub = await store.subscribe('ch', (p) => events.push(p));
+    const p = await store.createProject({
+      tenantId: 't',
+      slug: 's',
+      displayName: 'd',
+    });
+    await store.transitionAtomic({
+      projectId: p.id,
+      expectedVersion: 1,
+      expectedStatus: 'onboarding',
+      toState: 'idea-captured',
+      reason: 'r',
+      actorKind: 'system',
+      actorId: 'system',
+      agentRunId: null,
+      payload: {},
+      payloadHash: hashPayload({}),
+      idempotencyWindowMs: 0,
+    });
+    expect(events.length).toBeGreaterThanOrEqual(0); // channel scoping
+    await unsub();
+  });
+});

--- a/packages/state-machine/tests/index-exports.test.ts
+++ b/packages/state-machine/tests/index-exports.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import * as mod from '../src/index.js';
+
+describe('public surface', () => {
+  it('re-exports state constants', () => {
+    expect(mod.ALL_STATES.length).toBeGreaterThan(0);
+    expect(mod.HAPPY_STATES.length).toBeGreaterThan(0);
+    expect(mod.FAILED_STATES.length).toBeGreaterThan(0);
+    expect(mod.CONTROL_STATES.length).toBeGreaterThan(0);
+    expect(mod.TERMINAL_STATES.length).toBeGreaterThan(0);
+  });
+
+  it('re-exports state classifiers', () => {
+    expect(typeof mod.isProjectState).toBe('function');
+    expect(typeof mod.isHappyState).toBe('function');
+    expect(typeof mod.isFailedState).toBe('function');
+    expect(typeof mod.isControlState).toBe('function');
+    expect(typeof mod.isTerminal).toBe('function');
+  });
+
+  it('re-exports transition helpers', () => {
+    expect(typeof mod.canTransition).toBe('function');
+    expect(typeof mod.checkTransition).toBe('function');
+    expect(typeof mod.availableTransitions).toBe('function');
+    expect(typeof mod.validNextStates).toBe('function');
+    expect(typeof mod.allEdges).toBe('function');
+    expect(typeof mod.reachableTerminals).toBe('function');
+    expect(mod.VALID_TRANSITIONS).toBeDefined();
+  });
+
+  it('re-exports errors', () => {
+    expect(typeof mod.InvalidTransitionError).toBe('function');
+    expect(typeof mod.StaleProjectVersionError).toBe('function');
+    expect(typeof mod.ProjectNotFoundError).toBe('function');
+    expect(typeof mod.AdvisoryLockHeldError).toBe('function');
+    expect(typeof mod.TicketAlreadyClaimedError).toBe('function');
+    expect(typeof mod.TransitionRetryExhaustedError).toBe('function');
+  });
+
+  it('re-exports core machinery', () => {
+    expect(typeof mod.StateMachine).toBe('function');
+    expect(typeof mod.InMemoryStateStore).toBe('function');
+    expect(typeof mod.PgStateStore).toBe('function');
+    expect(typeof mod.hashPayload).toBe('function');
+  });
+
+  it('re-exports realtime helpers', () => {
+    expect(typeof mod.handleProjectSse).toBe('function');
+    expect(typeof mod.SseConnection).toBe('function');
+  });
+
+  it('re-exports whats-next helpers', () => {
+    expect(typeof mod.whatsNext).toBe('function');
+    expect(typeof mod.resumePoint).toBe('function');
+  });
+});

--- a/packages/state-machine/tests/realtime.test.ts
+++ b/packages/state-machine/tests/realtime.test.ts
@@ -1,0 +1,143 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { handleProjectSse, SseConnection } from '../src/realtime.js';
+import { buildInMemoryStateMachine } from '../src/test-support.js';
+
+/** Minimal fake of node http's ServerResponse for SSE testing. */
+class FakeRes extends EventEmitter {
+  statusCode = 0;
+  headers = new Map<string, string>();
+  chunks: string[] = [];
+  ended = false;
+  setHeader(k: string, v: string): void {
+    this.headers.set(k, v);
+  }
+  flushHeaders(): void {
+    /* no-op */
+  }
+  write(s: string): boolean {
+    this.chunks.push(s);
+    return true;
+  }
+  end(): void {
+    this.ended = true;
+    this.emit('close');
+  }
+}
+
+class FakeReq extends EventEmitter {}
+
+describe('SseConnection', () => {
+  let res: FakeRes;
+  let conn: SseConnection;
+
+  beforeEach(() => {
+    res = new FakeRes();
+    conn = new SseConnection(res as unknown as ServerResponse, 1_000_000);
+  });
+  afterEach(() => conn.close());
+
+  it('sets the SSE headers', () => {
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toContain('no-cache');
+  });
+
+  it('writes a properly framed event', () => {
+    conn.send('hello', 'world', '42');
+    const out = res.chunks.join('');
+    expect(out).toContain('id: 42');
+    expect(out).toContain('event: hello');
+    expect(out).toContain('data: world');
+    expect(out.endsWith('\n\n')).toBe(true);
+  });
+
+  it('splits multiline data into multiple data: frames', () => {
+    conn.send('e', 'line1\nline2');
+    const out = res.chunks.join('');
+    expect(out).toMatch(/data: line1\ndata: line2/);
+  });
+
+  it('sendJson serializes the value', () => {
+    conn.sendJson('e', { a: 1 });
+    expect(res.chunks.join('')).toContain('data: {"a":1}');
+  });
+
+  it('sendComment writes a comment line', () => {
+    conn.sendComment('keepalive');
+    expect(res.chunks.join('')).toContain(': keepalive');
+  });
+
+  it('close is idempotent and silences further sends', () => {
+    conn.close();
+    conn.close();
+    expect(conn.isClosed).toBe(true);
+    conn.send('e', 'd');
+    // chunk count unchanged after close
+    const before = res.chunks.length;
+    conn.send('e', 'd');
+    expect(res.chunks.length).toBe(before);
+  });
+});
+
+describe('handleProjectSse', () => {
+  it('sends a snapshot then forwards state-transition events', async () => {
+    const { sm } = buildInMemoryStateMachine({ idempotencyWindowMs: 0 });
+    await sm.init();
+    const p = await sm.createProject({
+      tenantId: 't',
+      slug: 'sse-1',
+      displayName: 'SSE',
+    });
+
+    const req = new FakeReq();
+    const res = new FakeRes();
+    await handleProjectSse(
+      sm,
+      req as unknown as IncomingMessage,
+      res as unknown as ServerResponse,
+      p.id,
+      { keepaliveMs: 1_000_000 },
+    );
+
+    // initial snapshot
+    const snapshot = res.chunks.join('');
+    expect(snapshot).toContain('event: snapshot');
+    expect(snapshot).toContain('"status":"onboarding"');
+
+    // drive a transition; the SSE listener should append a project event
+    await sm.transition(p.id, 'idea-captured', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 't' },
+    });
+
+    // give the microtask queue time to flush the in-memory notify
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const out = res.chunks.join('');
+    expect(out).toContain('event: project');
+    expect(out).toContain('"to_state":"idea-captured"');
+
+    // simulate client disconnect — should not throw
+    req.emit('close');
+    res.end();
+  });
+
+  it('returns an error event for unknown project', async () => {
+    const { sm } = buildInMemoryStateMachine();
+    await sm.init();
+    const req = new FakeReq();
+    const res = new FakeRes();
+    await handleProjectSse(
+      sm,
+      req as unknown as IncomingMessage,
+      res as unknown as ServerResponse,
+      '00000000-0000-0000-0000-000000000099',
+      {},
+    );
+    expect(res.chunks.join('')).toContain('"error":"project-not-found"');
+  });
+});

--- a/packages/state-machine/tests/state-machine.test.ts
+++ b/packages/state-machine/tests/state-machine.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  InvalidTransitionError,
+  ProjectNotFoundError,
+  StaleProjectVersionError,
+} from '../src/errors.js';
+import {
+  buildInMemoryStateMachine,
+  HAPPY_PATH,
+} from '../src/test-support.js';
+
+describe('StateMachine', () => {
+  let sm: ReturnType<typeof buildInMemoryStateMachine>['sm'];
+  let store: ReturnType<typeof buildInMemoryStateMachine>['store'];
+
+  beforeEach(async () => {
+    ({ sm, store } = buildInMemoryStateMachine({ idempotencyWindowMs: 0 }));
+    await sm.init();
+  });
+
+  const newProject = (slug = 'p') =>
+    sm.createProject({ tenantId: 't', slug, displayName: slug.toUpperCase() });
+
+  it('createProject + currentState round-trip', async () => {
+    const p = await newProject();
+    expect(await sm.currentState(p.id)).toBe('onboarding');
+  });
+
+  it('currentState throws for missing project', async () => {
+    await expect(sm.currentState('11111111-1111-1111-1111-111111111111'))
+      .rejects.toBeInstanceOf(ProjectNotFoundError);
+  });
+
+  it('transitions through the entire happy path', async () => {
+    const p = await newProject();
+    for (const [, to] of HAPPY_PATH) {
+      await sm.transition(p.id, to, {
+        reason: 'walk',
+        triggeredBy: { kind: 'system', id: 'test' },
+        payload: { to },
+      });
+    }
+    expect(await sm.currentState(p.id)).toBe('done');
+  });
+
+  it('rejects an illegal transition with InvalidTransitionError', async () => {
+    const p = await newProject();
+    await expect(
+      sm.transition(p.id, 'done', {
+        reason: 'jump',
+        triggeredBy: { kind: 'system', id: 'test' },
+      }),
+    ).rejects.toBeInstanceOf(InvalidTransitionError);
+  });
+
+  it('rejects a transition out of a terminal state', async () => {
+    const p = await newProject();
+    for (const [, to] of HAPPY_PATH) {
+      await sm.transition(p.id, to, {
+        reason: 'walk',
+        triggeredBy: { kind: 'system', id: 'test' },
+        payload: { to },
+      });
+    }
+    await expect(
+      sm.transition(p.id, 'archived', {
+        reason: 'late',
+        triggeredBy: { kind: 'system', id: 'test' },
+      }),
+    ).rejects.toBeInstanceOf(InvalidTransitionError);
+  });
+
+  it('transition returns applied=true on first call, false on idempotent replay', async () => {
+    const p = await newProject();
+    const a = await sm.transition(p.id, 'idea-captured', {
+      reason: 'init',
+      triggeredBy: { kind: 'system', id: 'test' },
+      payload: { ping: 1 },
+    });
+    expect(a.applied).toBe(true);
+
+    // Force the project back into onboarding by direct store mutation so
+    // we can replay the same transition with the same payload-hash.
+    const rec = (await store.getProject(p.id))!;
+    // simulate replay: try the same transition again on the same state
+    // (now we're at idea-captured) — payload-hash match returns applied=false
+    const b = await sm.transition(p.id, 'idea-captured', {
+      reason: 'replay',
+      triggeredBy: { kind: 'system', id: 'test' },
+      payload: { ping: 1 },
+    });
+    expect(b.applied).toBe(false);
+    expect(b.historyId).toBe(a.historyId);
+    expect(rec.status).toBe('idea-captured');
+  });
+
+  it('positional transition form works', async () => {
+    const p = await newProject();
+    const r = await sm.transition(p.id, 'idea-captured', 'positional', 'tester');
+    expect(r.applied).toBe(true);
+  });
+
+  it('positional form requires triggeredBy', async () => {
+    const p = await newProject();
+    await expect(
+      (sm.transition as unknown as (
+        a: string,
+        b: string,
+        c: string,
+      ) => Promise<unknown>)(p.id, 'idea-captured', 'positional'),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it('honors expectedVersion to detect a stale snapshot', async () => {
+    const p = await newProject();
+    await expect(
+      sm.transition(p.id, 'idea-captured', {
+        reason: 'r',
+        triggeredBy: { kind: 'system', id: 'test' },
+        expectedVersion: 99,
+      }),
+    ).rejects.toBeInstanceOf(StaleProjectVersionError);
+  });
+
+  it('availableTransitions + validNextStates are spec-aligned', async () => {
+    const states = sm.availableTransitions('onboarding');
+    expect(states).toContain('idea-captured');
+    expect(sm.validNextStates('onboarding')).toEqual(states);
+    expect(sm.canTransition('onboarding', 'idea-captured')).toBe(true);
+  });
+
+  it('pause / resume toggle the project paused flag', async () => {
+    const p = await newProject();
+    await sm.pause(p.id, 'op-1');
+    const a = await sm.getProject(p.id);
+    expect(a!.paused).toBe(true);
+    await sm.resume(p.id);
+    const b = await sm.getProject(p.id);
+    expect(b!.paused).toBe(false);
+  });
+
+  it('pause throws for unknown project', async () => {
+    await expect(sm.pause('00000000-0000-0000-0000-000000000099', 'op'))
+      .rejects.toBeInstanceOf(ProjectNotFoundError);
+  });
+
+  it('abandon transitions the project to archived from any state', async () => {
+    const p = await newProject();
+    const r = await sm.abandon(p.id, 'operator-jane');
+    expect(r.applied).toBe(true);
+    expect(await sm.currentState(p.id)).toBe('archived');
+  });
+
+  it('replayHistory returns the audit trail in id order', async () => {
+    const p = await newProject();
+    await sm.transition(p.id, 'idea-captured', {
+      reason: 'r1',
+      triggeredBy: { kind: 'system', id: 'test' },
+      payload: { i: 1 },
+    });
+    await sm.transition(p.id, 'interviewing', {
+      reason: 'r2',
+      triggeredBy: { kind: 'system', id: 'test' },
+      payload: { i: 2 },
+    });
+    const rows = await sm.replayHistory(p.id);
+    expect(rows.map((r) => r.toState)).toEqual([
+      'idea-captured',
+      'interviewing',
+    ]);
+  });
+
+  it('replayHistory filters by toState', async () => {
+    const p = await newProject();
+    await sm.transition(p.id, 'idea-captured', {
+      reason: 'r1',
+      triggeredBy: { kind: 'system', id: 'test' },
+      payload: { i: 1 },
+    });
+    await sm.transition(p.id, 'interviewing', {
+      reason: 'r2',
+      triggeredBy: { kind: 'system', id: 'test' },
+      payload: { i: 2 },
+    });
+    const rows = await sm.replayHistory(p.id, { toState: 'idea-captured' });
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.toState).toBe('idea-captured');
+  });
+
+  it('TransitionResult carries retries (0 on first try)', async () => {
+    const p = await newProject();
+    const r = await sm.transition(p.id, 'idea-captured', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 'test' },
+    });
+    expect(r.retries).toBe(0);
+  });
+});

--- a/packages/state-machine/tests/states.test.ts
+++ b/packages/state-machine/tests/states.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_STATES,
+  CONTROL_STATES,
+  FAILED_STATES,
+  HAPPY_STATES,
+  isControlState,
+  isFailedState,
+  isHappyState,
+  isProjectState,
+  isTerminal,
+  TERMINAL_STATES,
+} from '../src/states.js';
+
+describe('states', () => {
+  it('enumerates 23 happy states', () => {
+    expect(HAPPY_STATES.length).toBe(23);
+  });
+
+  it('enumerates 15 failed states', () => {
+    expect(FAILED_STATES.length).toBe(15);
+  });
+
+  it('enumerates 3 control states', () => {
+    expect(CONTROL_STATES.length).toBe(3);
+  });
+
+  it('ALL_STATES is the concatenation of happy + failed + control', () => {
+    expect(ALL_STATES.length).toBe(
+      HAPPY_STATES.length + FAILED_STATES.length + CONTROL_STATES.length,
+    );
+    expect(new Set(ALL_STATES).size).toBe(ALL_STATES.length);
+  });
+
+  it('every failed state ends with -failed', () => {
+    for (const s of FAILED_STATES) expect(s.endsWith('-failed')).toBe(true);
+  });
+
+  it('isProjectState accepts canonical states', () => {
+    expect(isProjectState('onboarding')).toBe(true);
+    expect(isProjectState('archived')).toBe(true);
+    expect(isProjectState('done')).toBe(true);
+  });
+
+  it('isProjectState rejects garbage', () => {
+    expect(isProjectState('definitely-not-a-state')).toBe(false);
+    expect(isProjectState(42)).toBe(false);
+    expect(isProjectState(null)).toBe(false);
+    expect(isProjectState(undefined)).toBe(false);
+  });
+
+  it('classifies states correctly', () => {
+    expect(isHappyState('done')).toBe(true);
+    expect(isHappyState('onboarding-failed' as never)).toBe(false);
+    expect(isFailedState('onboarding-failed')).toBe(true);
+    expect(isFailedState('done' as never)).toBe(false);
+    expect(isControlState('paused')).toBe(true);
+    expect(isControlState('done' as never)).toBe(false);
+  });
+
+  it('only done + archived are terminal', () => {
+    expect(TERMINAL_STATES).toEqual(['done', 'archived']);
+    expect(isTerminal('done')).toBe(true);
+    expect(isTerminal('archived')).toBe(true);
+    expect(isTerminal('onboarding')).toBe(false);
+    expect(isTerminal('paused')).toBe(false);
+  });
+});

--- a/packages/state-machine/tests/transitions.test.ts
+++ b/packages/state-machine/tests/transitions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { ALL_STATES, HAPPY_STATES, isTerminal } from '../src/states.js';
+import {
+  allEdges,
+  availableTransitions,
+  canTransition,
+  checkTransition,
+  reachableTerminals,
+  validNextStates,
+  VALID_TRANSITIONS,
+} from '../src/transitions.js';
+
+describe('transitions', () => {
+  it('every state has an entry in VALID_TRANSITIONS', () => {
+    for (const s of ALL_STATES) {
+      expect(VALID_TRANSITIONS[s]).toBeDefined();
+    }
+  });
+
+  it('terminal states have zero outgoing transitions', () => {
+    expect(VALID_TRANSITIONS.done).toEqual([]);
+    expect(VALID_TRANSITIONS.archived).toEqual([]);
+  });
+
+  it('canTransition agrees with the table', () => {
+    expect(canTransition('onboarding', 'idea-captured')).toBe(true);
+    expect(canTransition('onboarding', 'done')).toBe(false);
+  });
+
+  it('canTransition rejects self-transitions', () => {
+    expect(canTransition('onboarding', 'onboarding')).toBe(false);
+  });
+
+  it('canTransition rejects exits from terminal states', () => {
+    expect(canTransition('done', 'archived')).toBe(false);
+    expect(canTransition('archived', 'done')).toBe(false);
+  });
+
+  it('checkTransition explains self-transitions', () => {
+    const r = checkTransition('onboarding', 'onboarding');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('self-transition');
+  });
+
+  it('checkTransition explains terminal exits', () => {
+    const r = checkTransition('done', 'archived');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('terminal');
+  });
+
+  it('checkTransition explains missing edges', () => {
+    const r = checkTransition('onboarding', 'deployed');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('not in the transition table');
+  });
+
+  it('validNextStates is an alias for availableTransitions', () => {
+    for (const s of ALL_STATES) {
+      expect(validNextStates(s)).toEqual(availableTransitions(s));
+    }
+  });
+
+  it('every happy state can transition to archived', () => {
+    for (const s of HAPPY_STATES) {
+      if (isTerminal(s)) continue;
+      expect(availableTransitions(s)).toContain('archived');
+    }
+  });
+
+  it('every happy doing-state can transition to paused', () => {
+    // Only `verified` is a happy-edge case: it goes to done/archived only.
+    for (const s of HAPPY_STATES) {
+      if (isTerminal(s)) continue;
+      if (s === 'verified') continue;
+      expect(availableTransitions(s)).toContain('paused');
+    }
+  });
+
+  it('every failed state can transition to archived', () => {
+    for (const s of ALL_STATES.filter((x) => x.endsWith('-failed'))) {
+      expect(availableTransitions(s)).toContain('archived');
+    }
+  });
+
+  it('happy path is contiguous', () => {
+    for (let i = 0; i < HAPPY_STATES.length - 1; i++) {
+      const from = HAPPY_STATES[i]!;
+      const to = HAPPY_STATES[i + 1]!;
+      // Some adjacencies aren't direct (e.g. atlas-ready -> change-requested
+      // is via a special path), but the spec says canonical happy-path uses
+      // the next state in the list except for change-requested.
+      if (from === 'atlas-ready' && to === 'change-requested') continue;
+      if (from === 'change-requested' && to === 'ea-dispatching') continue;
+      expect(canTransition(from, to)).toBe(true);
+    }
+  });
+
+  it('allEdges enumerates every (from,to)', () => {
+    const edges = allEdges();
+    let total = 0;
+    for (const s of ALL_STATES) total += VALID_TRANSITIONS[s].length;
+    expect(edges.length).toBe(total);
+  });
+
+  it('reachableTerminals from done returns [done]', () => {
+    expect(reachableTerminals('done')).toEqual(['done']);
+  });
+
+  it('reachableTerminals from archived returns [archived]', () => {
+    expect(reachableTerminals('archived')).toEqual(['archived']);
+  });
+
+  it('reachableTerminals from onboarding includes done and archived', () => {
+    const r = reachableTerminals('onboarding');
+    expect(r).toContain('done');
+    expect(r).toContain('archived');
+  });
+
+  it('paused can resume into any non-paused state', () => {
+    const exits = VALID_TRANSITIONS.paused;
+    expect(exits).not.toContain('paused');
+    expect(exits.length).toBe(ALL_STATES.length - 1);
+  });
+});

--- a/packages/state-machine/tests/whats-next.test.ts
+++ b/packages/state-machine/tests/whats-next.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildInMemoryStateMachine,
+  HAPPY_PATH,
+} from '../src/test-support.js';
+import { resumePoint, whatsNext } from '../src/whats-next.js';
+
+describe('whatsNext', () => {
+  let sm: ReturnType<typeof buildInMemoryStateMachine>['sm'];
+
+  beforeEach(async () => {
+    ({ sm } = buildInMemoryStateMachine({ idempotencyWindowMs: 0 }));
+    await sm.init();
+  });
+
+  const newProject = (slug = 'p') =>
+    sm.createProject({ tenantId: 't', slug, displayName: slug });
+
+  it('returns the onboarding agent for a fresh project', async () => {
+    const p = await newProject();
+    const r = await whatsNext(sm, p.id);
+    expect(r.hasWork).toBe(true);
+    expect(r.agent?.type).toBe('@caia/onboarding');
+    expect(r.agent?.onSuccessTransitionTo).toBe('idea-captured');
+  });
+
+  it('reports paused when the project is paused', async () => {
+    const p = await newProject();
+    await sm.pause(p.id, 'op');
+    const r = await whatsNext(sm, p.id);
+    expect(r.hasWork).toBe(false);
+    expect(r.waitingOn).toBe('project-paused');
+  });
+
+  it('reports project-done at terminal happy state', async () => {
+    const p = await newProject();
+    for (const [, to] of HAPPY_PATH) {
+      await sm.transition(p.id, to, {
+        reason: 'walk',
+        triggeredBy: { kind: 'system', id: 'test' },
+        payload: { to },
+      });
+    }
+    const r = await whatsNext(sm, p.id);
+    expect(r.hasWork).toBe(false);
+    expect(r.waitingOn).toBe('project-done');
+  });
+
+  it('reports waiting-for-external at awaiting-external-design', async () => {
+    const p = await newProject();
+    for (const target of [
+      'idea-captured',
+      'interviewing',
+      'interview-complete',
+      'proposal-generated',
+      'awaiting-external-design',
+    ] as const) {
+      await sm.transition(p.id, target, {
+        reason: 'walk',
+        triggeredBy: { kind: 'system', id: 'test' },
+        payload: { target },
+      });
+    }
+    const r = await whatsNext(sm, p.id);
+    expect(r.hasWork).toBe(false);
+    expect(r.waitingOn).toBe('waiting-for-external');
+  });
+
+  it('reports waiting-for-operator at atlas-ready', async () => {
+    const p = await newProject();
+    for (const target of [
+      'idea-captured',
+      'interviewing',
+      'interview-complete',
+      'proposal-generated',
+      'awaiting-external-design',
+      'design-uploaded',
+      'ticket-tree-generated',
+      'atlas-ready',
+    ] as const) {
+      await sm.transition(p.id, target, {
+        reason: 'walk',
+        triggeredBy: { kind: 'system', id: 'test' },
+        payload: { target },
+      });
+    }
+    const r = await whatsNext(sm, p.id);
+    expect(r.waitingOn).toBe('waiting-for-operator');
+  });
+
+  it('reports waiting-for-failure-recovery at a *-failed state', async () => {
+    const p = await newProject();
+    await sm.transition(p.id, 'onboarding-failed', {
+      reason: 'broke',
+      triggeredBy: { kind: 'system', id: 'test' },
+    });
+    const r = await whatsNext(sm, p.id);
+    expect(r.waitingOn).toBe('waiting-for-failure-recovery');
+  });
+
+  it('exposes parameters with project + tenant ids', async () => {
+    const p = await newProject();
+    const r = await whatsNext(sm, p.id);
+    expect(r.parameters.project_id).toBe(p.id);
+    expect(r.parameters.tenant_id).toBe('t');
+  });
+
+  it('is idempotent on the same state', async () => {
+    const p = await newProject();
+    const a = await whatsNext(sm, p.id);
+    const b = await whatsNext(sm, p.id);
+    expect(a.agent?.type).toBe(b.agent?.type);
+    expect(a.currentState).toBe(b.currentState);
+  });
+});
+
+describe('resumePoint', () => {
+  let sm: ReturnType<typeof buildInMemoryStateMachine>['sm'];
+  beforeEach(async () => {
+    ({ sm } = buildInMemoryStateMachine({ idempotencyWindowMs: 0 }));
+    await sm.init();
+  });
+  const newProject = (slug = 'p') =>
+    sm.createProject({ tenantId: 't', slug, displayName: slug });
+
+  it('reports paused for a paused project', async () => {
+    const p = await newProject();
+    await sm.pause(p.id, 'op');
+    const r = await resumePoint(sm, p.id);
+    expect(r.reason).toBe('paused');
+  });
+
+  it('reports parked-at-failure for *-failed', async () => {
+    const p = await newProject();
+    await sm.transition(p.id, 'onboarding-failed', {
+      reason: 'fail',
+      triggeredBy: { kind: 'system', id: 'test' },
+    });
+    const r = await resumePoint(sm, p.id);
+    expect(r.reason).toBe('parked-at-failure');
+  });
+
+  it('reports steady-state for a fresh project (no history)', async () => {
+    const p = await newProject();
+    const r = await resumePoint(sm, p.id);
+    expect(r.reason).toBe('steady-state');
+    expect(r.lastHistoryId).toBeNull();
+  });
+
+  it('reports steady-state after happy transitions (history matches status)', async () => {
+    const p = await newProject();
+    await sm.transition(p.id, 'idea-captured', {
+      reason: 'r',
+      triggeredBy: { kind: 'system', id: 'test' },
+    });
+    const r = await resumePoint(sm, p.id);
+    expect(r.reason).toBe('steady-state');
+    expect(r.lastHistoryId).not.toBeNull();
+  });
+});

--- a/packages/state-machine/tests/worker-assignment.test.ts
+++ b/packages/state-machine/tests/worker-assignment.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { buildInMemoryStateMachine } from '../src/test-support.js';
+
+describe('worker assignment job-queue API', () => {
+  let sm: ReturnType<typeof buildInMemoryStateMachine>['sm'];
+
+  beforeEach(async () => {
+    ({ sm } = buildInMemoryStateMachine({
+      idempotencyWindowMs: 0,
+      workerTtlSeconds: 1,
+    }));
+    await sm.init();
+  });
+
+  const newProject = (slug = 'p') =>
+    sm.createProject({ tenantId: 't', slug, displayName: slug });
+
+  it('tryAssignWork wins for the first caller and loses for concurrent callers', async () => {
+    const p = await newProject('a');
+    const a = await sm.tryAssignWork(p.id, 'worker-1');
+    const b = await sm.tryAssignWork(p.id, 'worker-2');
+    expect(a.claimed).toBe(true);
+    expect(b.claimed).toBe(false);
+  });
+
+  it('tryAssignWork is reentrant for the same worker', async () => {
+    const p = await newProject('a');
+    const a = await sm.tryAssignWork(p.id, 'worker-1');
+    const b = await sm.tryAssignWork(p.id, 'worker-1');
+    expect(a.claimed).toBe(true);
+    expect(b.claimed).toBe(true);
+  });
+
+  it('recordWorkerHeartbeat refreshes every project the worker holds', async () => {
+    const a = await newProject('a');
+    const b = await newProject('b');
+    await sm.tryAssignWork(a.id, 'w1');
+    await sm.tryAssignWork(b.id, 'w1');
+    const r = await sm.recordWorkerHeartbeat('w1');
+    expect(r.ok).toBe(true);
+    expect(r.refreshed.sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('recordWorkerHeartbeat returns ok=false for unknown worker', async () => {
+    const r = await sm.recordWorkerHeartbeat('ghost');
+    expect(r.ok).toBe(false);
+    expect(r.refreshed).toEqual([]);
+  });
+
+  it('completeWork without finalState releases without transitioning', async () => {
+    const p = await newProject('a');
+    await sm.tryAssignWork(p.id, 'w1');
+    const r = await sm.completeWork('w1');
+    expect(r.released).toContain(p.id);
+    expect(r.transitioned).toEqual([]);
+  });
+
+  it('completeWork with finalState transitions the project', async () => {
+    const p = await newProject('a');
+    await sm.tryAssignWork(p.id, 'w1');
+    const r = await sm.completeWork('w1', 'idea-captured', {
+      reason: 'work-done',
+    });
+    expect(r.released).toContain(p.id);
+    expect(r.transitioned.length).toBe(1);
+    expect(r.transitioned[0]!.toState).toBe('idea-captured');
+    expect(await sm.currentState(p.id)).toBe('idea-captured');
+  });
+
+  it('expireInactiveWorkers releases stale claims', async () => {
+    const p = await newProject('a');
+    // workerTtlSeconds=1 so a 2-second-old claim is stale.
+    const now = Date.now();
+    const past = new Date(now - 5_000);
+    const future = new Date(now);
+    // simulate an old claim by directly using the store
+    const { sm: sm2, store } = buildInMemoryStateMachine({
+      now: () => future,
+      workerTtlSeconds: 1,
+    });
+    const p2 = await sm2.createProject({
+      tenantId: 't',
+      slug: 'b',
+      displayName: 'B',
+    });
+    await store.tryClaim({
+      ticketId: 'project-assignment:' + p2.id,
+      projectId: p2.id,
+      agentId: 'w-old',
+      ttlSeconds: 1,
+      now: past,
+    });
+    const r = await sm2.expireInactiveWorkers();
+    expect(r.releasedAssignments).toContain(p2.id);
+    expect(p).toBeTruthy();
+  });
+
+  it('a worker can be re-assigned after the previous claim expires', async () => {
+    const t0 = new Date('2026-01-01T00:00:00Z');
+    let now = t0;
+    const { sm: sm2 } = buildInMemoryStateMachine({
+      now: () => now,
+      workerTtlSeconds: 1,
+    });
+    const p = await sm2.createProject({
+      tenantId: 't',
+      slug: 'x',
+      displayName: 'X',
+    });
+    const a = await sm2.tryAssignWork(p.id, 'w-1');
+    expect(a.claimed).toBe(true);
+    // advance past TTL
+    now = new Date(t0.getTime() + 10_000);
+    const b = await sm2.tryAssignWork(p.id, 'w-2');
+    expect(b.claimed).toBe(true);
+  });
+});

--- a/packages/state-machine/tsconfig.json
+++ b/packages/state-machine/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/state-machine/vitest.config.ts
+++ b/packages/state-machine/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      thresholds: {
+        perFile: false,
+        lines: 70,
+        functions: 70,
+        branches: 65,
+        statements: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,25 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  packages/accessibility-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/adoption-enforcement:
     dependencies:
       '@chiefaia/chain-runner':
@@ -886,6 +905,74 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
+  packages/atlas-ui:
+    dependencies:
+      '@chiefaia/atlas-mapper':
+        specifier: workspace:*
+        version: link:../atlas-mapper
+    devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.0
+        version: 4.11.2(playwright-core@1.59.1)
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.59.1
+      '@testing-library/jest-dom':
+        specifier: ^6.5.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.0.1
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.39))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@25.0.1)
+
+  packages/backend-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/backend-core:
@@ -1233,6 +1320,25 @@ importers:
       '@chiefaia/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
+  packages/database-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.39
@@ -2020,6 +2126,31 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)
 
+  packages/onboarding:
+    dependencies:
+      '@caia/secrets-adapter':
+        specifier: workspace:*
+        version: link:../secrets-adapter
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/orchestrator-elevate:
     dependencies:
       zod:
@@ -2381,6 +2512,31 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+
+  packages/state-machine:
+    dependencies:
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      '@chiefaia/vitest-config':
+        specifier: workspace:*
+        version: link:../../configs/vitest-config
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/steward-analyzers:
     devDependencies:


### PR DESCRIPTION
Salvage + completion of `@caia/state-machine` — a typed pipeline-status finite-state machine for CAIA projects.

## What
- ~40-state enum (happy / failed / control) sourced from `research/state_machine_handoff_spec_2026.md` §1.2 + §1.3.
- Statically enumerated valid-transitions table; invalid moves throw `InvalidTransitionError`.
- Atomic transition pipeline with optimistic concurrency (`version`-based), payload-hash idempotency, and per-call retry budget (`TransitionRetryExhaustedError`).
- Two stores:
  - `InMemoryStateStore` for unit tests.
  - `PgStateStore` wraps a `pg.Pool`, runs migrations on `init()`, owns a dedicated `LISTEN` client.
- Distributed worker-assignment API (BullMQ/Sidekiq-style): `tryAssignWork`, `recordWorkerHeartbeat`, `completeWork`, `expireInactiveWorkers`.
- `whatsNext(projectId)` — idempotent next-step helper (handoff table, §3.1).
- `resumePoint(projectId)` — resume / recovery helper.
- `handleProjectSse` + `SseConnection` — minimal SSE wiring fed from Postgres `LISTEN/NOTIFY`.

## Schema (`migrations/0001_state_machine.sql`, idempotent)
- `caia_meta.tenant_projects` (status check widened to §1.2 enum + paused/version/archived_at).
- `caia_meta.state_history` append-only audit with unique `(project_id, to_state, payload_hash)` index.
- `caia_meta.ticket_claims` with TTL + heartbeat columns.
- `state_history_notify_trg` trigger broadcasts on `caia_project_<id>`.

## Tests
**106 vitest tests, all passing**, covering states, transitions, hash determinism, in-memory store, state machine (incl. happy-path walk, idempotent replay, expectedVersion conflict, positional-arg form, pause/resume/abandon), worker assignment lifecycle, `whatsNext` + `resumePoint`, SSE framing + project subscription, typed errors, and the public surface.

`pnpm --filter @caia/state-machine typecheck` and `pnpm --filter @caia/state-machine build` are both clean.

## Reuse
Designed to slot into the orchestrator alongside `@chiefaia/chain-runner` and `@chiefaia/capability-broker` — those packages can call `whatsNext` to pick the next agent and `transition` to commit progress.
