### PR TITLE
feat(@caia/onboarding, apps/admin): customer onboarding engine + wizard

### DIFF
--- a/apps/admin/app/api/onboarding/defer/route.ts
+++ b/apps/admin/app/api/onboarding/defer/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getEngine } from '../../../../lib/engine';
+import { authContext } from '../../../../lib/auth';
+
+const Body = z.object({
+  tenantId: z.string().min(1),
+  category: z.string().min(1),
+  reason: z.string().min(1).default('customer-skipped'),
+});
+
+export async function POST(req: NextRequest) {
+  const auth = authContext(req);
+  if (!auth) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  let body: z.infer<typeof Body>;
+  try {
+    body = Body.parse(await req.json());
+  } catch (e) {
+    return NextResponse.json(
+      { error: `invalid body: ${(e as Error).message}` },
+      { status: 400 },
+    );
+  }
+  const { engine } = getEngine();
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await engine.defer(body.tenantId, body.category as any, body.reason);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: (e as Error).message },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/admin/app/api/onboarding/log/route.ts
+++ b/apps/admin/app/api/onboarding/log/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getEngine } from '../../../../lib/engine';
+import { authContext } from '../../../../lib/auth';
+
+export async function GET(req: NextRequest) {
+  const auth = authContext(req);
+  if (!auth) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const tenantId = req.nextUrl.searchParams.get('tenantId') ?? 'dev-tenant';
+  const { store } = getEngine();
+  const entries = await store.listAudit(tenantId, 200);
+  return NextResponse.json({
+    entries: entries.map((e) => ({
+      occurredAt: e.occurredAt.toISOString(),
+      actorType: e.actorType,
+      actorId: e.actorId ?? null,
+      action: e.action,
+      category: e.category ?? null,
+      keyId: e.keyId ?? null,
+      payload: e.payload,
+    })),
+  });
+}

--- a/apps/admin/app/api/onboarding/state/route.ts
+++ b/apps/admin/app/api/onboarding/state/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getEngine } from '../../../../lib/engine';
+import { authContext } from '../../../../lib/auth';
+
+export async function GET(req: NextRequest) {
+  const auth = authContext(req);
+  if (!auth) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const tenantId = req.nextUrl.searchParams.get('tenantId') ?? 'dev-tenant';
+  const { engine } = getEngine();
+  const state = await engine.stateFor(tenantId);
+  return NextResponse.json({
+    tenantId: state.tenantId,
+    currentId: state.current?.id ?? null,
+    ready: state.ready,
+    steps: state.steps.map((s) => ({
+      category: {
+        id: s.category.id,
+        label: s.category.label,
+        ordinal: s.category.ordinal,
+        required: s.category.required,
+      },
+      status: s.status,
+      attemptCount: s.attemptCount,
+      ...(s.failureReason ? { failureReason: s.failureReason } : {}),
+    })),
+  });
+}

--- a/apps/admin/app/api/onboarding/submit/route.ts
+++ b/apps/admin/app/api/onboarding/submit/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { getEngine } from '../../../../lib/engine';
+import { authContext } from '../../../../lib/auth';
+
+const Body = z.object({
+  tenantId: z.string().min(1),
+  category: z.string().min(1),
+  providerId: z.string().min(1),
+  choices: z.record(z.unknown()).default({}),
+  credentials: z.record(z.string()).default({}),
+});
+
+export async function POST(req: NextRequest) {
+  const auth = authContext(req);
+  if (!auth) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  let body: z.infer<typeof Body>;
+  try {
+    const json = await req.json();
+    body = Body.parse(json);
+  } catch (e) {
+    return NextResponse.json(
+      { error: `invalid body: ${(e as Error).message}` },
+      { status: 400 },
+    );
+  }
+  const { engine } = getEngine();
+  try {
+    const result = await engine.submitStep({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tenantId: body.tenantId,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      category: body.category as any,
+      providerId: body.providerId,
+      choices: body.choices,
+      credentials: body.credentials,
+      actor: {
+        actorType: 'customer',
+        actorId: auth.subject,
+        userAgent: req.headers.get('user-agent') ?? undefined,
+      },
+    });
+    return NextResponse.json(result);
+  } catch (e) {
+    return NextResponse.json(
+      { error: (e as Error).message },
+      { status: 400 },
+    );
+  }
+}

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'CAIA — Onboarding',
+  description: 'Connect every tool CAIA will use to ship your product',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          margin: 0,
+          background: '#f6f7f9',
+          color: '#0f172a',
+        }}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/admin/app/onboarding/[category]/page.tsx
+++ b/apps/admin/app/onboarding/[category]/page.tsx
@@ -1,0 +1,64 @@
+import { notFound, redirect } from 'next/navigation';
+import { getCategory } from '@caia/onboarding';
+import { Wizard } from '../../../components/Wizard';
+import { getEngine } from '../../../lib/engine';
+
+interface PageProps {
+  params: Promise<{ category: string }>;
+}
+
+export default async function OnboardingCategoryPage({ params }: PageProps) {
+  const { category } = await params;
+  const def = getCategory(category);
+  if (!def) notFound();
+
+  const { engine, store } = getEngine();
+  let tenant = await store.getTenant('dev-tenant');
+  if (!tenant) {
+    tenant = await store.createTenant({
+      id: 'dev-tenant',
+      slug: 'dev',
+      name: 'Dev Tenant',
+      ownerEmail: 'dev@caia.local',
+      billingEmail: 'dev@caia.local',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+  }
+  const state = await engine.stateFor(tenant.id);
+
+  if (state.ready && def.required) {
+    redirect('/onboarding/complete');
+  }
+
+  return (
+    <Wizard
+      tenantId={tenant.id}
+      category={def}
+      initialState={{
+        tenantId: state.tenantId,
+        currentId: state.current?.id,
+        ready: state.ready,
+        steps: state.steps.map((s) => {
+          const o: {
+            category: { id: string; label: string; ordinal: number; required: boolean };
+            status: typeof s.status;
+            attemptCount: number;
+            failureReason?: string;
+          } = {
+            category: {
+              id: s.category.id,
+              label: s.category.label,
+              ordinal: s.category.ordinal,
+              required: s.category.required,
+            },
+            status: s.status,
+            attemptCount: s.attemptCount,
+          };
+          if (s.failureReason) o.failureReason = s.failureReason;
+          return o;
+        }),
+      }}
+    />
+  );
+}

--- a/apps/admin/app/onboarding/complete/page.tsx
+++ b/apps/admin/app/onboarding/complete/page.tsx
@@ -1,0 +1,22 @@
+export default function OnboardingComplete() {
+  return (
+    <main
+      data-testid="onboarding-complete"
+      style={{
+        maxWidth: 720,
+        margin: '80px auto',
+        padding: 32,
+        background: 'white',
+        borderRadius: 12,
+        textAlign: 'center',
+      }}
+    >
+      <h1>You&apos;re all set</h1>
+      <p style={{ color: '#475569' }}>
+        CAIA has captured every provider choice and validated every key.
+        The pipeline can now spin up your first deployment without
+        re-prompting you.
+      </p>
+    </main>
+  );
+}

--- a/apps/admin/app/page.tsx
+++ b/apps/admin/app/page.tsx
@@ -1,0 +1,27 @@
+import { redirect } from 'next/navigation';
+import { getEngine } from '../lib/engine';
+
+/**
+ * Landing — creates a default tenant (dev only) and routes to the
+ * first uncomplete category. In prod, a tenant row is inserted via
+ * the signup form (out of scope for the wizard package).
+ */
+export default async function Home() {
+  const { engine, store } = getEngine();
+  // Dev tenant — production reads tenantId from a session cookie.
+  let tenant = await store.getTenant('dev-tenant');
+  if (!tenant) {
+    tenant = await store.createTenant({
+      id: 'dev-tenant',
+      slug: 'dev',
+      name: 'Dev Tenant',
+      ownerEmail: 'dev@caia.local',
+      billingEmail: 'dev@caia.local',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+  }
+  const state = await engine.stateFor(tenant.id);
+  const next = state.current?.id ?? 'identity';
+  redirect(`/onboarding/${next}`);
+}

--- a/apps/admin/components/Wizard.tsx
+++ b/apps/admin/components/Wizard.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+/**
+ * Wizard — one screen per category. Renders the provider dropdown,
+ * the credential fields per descriptor, and an inline validator log.
+ *
+ * Server work flows through the JSON API routes under
+ * `/api/onboarding/*` rather than server-actions so that the same
+ * surface can be hit by the CLI mirror (`@caia/cli onboard`) and by
+ * Playwright E2E.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import type { CategoryDefinition, ProviderOption } from '@caia/onboarding';
+
+interface WizardStateStep {
+  category: { id: string; label: string; ordinal: number; required: boolean };
+  status: 'pending' | 'probing' | 'passed' | 'failed' | 'deferred';
+  attemptCount: number;
+  failureReason?: string;
+}
+
+interface WizardState {
+  tenantId: string;
+  currentId?: string;
+  steps: WizardStateStep[];
+  ready: boolean;
+}
+
+interface WizardProps {
+  tenantId: string;
+  category: CategoryDefinition;
+  initialState: WizardState;
+}
+
+export function Wizard({ tenantId, category, initialState }: WizardProps) {
+  const [state, setState] = useState<WizardState>(initialState);
+  const [providerId, setProviderId] = useState<string>(category.providers[0]?.id ?? '');
+  const [creds, setCreds] = useState<Record<string, string>>({});
+  const [choices, setChoices] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{
+    status: string;
+    message?: string;
+  } | null>(null);
+
+  const provider: ProviderOption | undefined = useMemo(
+    () => category.providers.find((p) => p.id === providerId),
+    [category, providerId],
+  );
+
+  useEffect(() => {
+    setCreds({});
+    setChoices({});
+    setResult(null);
+  }, [providerId, category.id]);
+
+  async function submit(): Promise<void> {
+    setSubmitting(true);
+    setResult({ status: 'probing' });
+    try {
+      const res = await fetch('/api/onboarding/submit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          tenantId,
+          category: category.id,
+          providerId,
+          choices,
+          credentials: creds,
+        }),
+      });
+      const body = await res.json();
+      setResult({
+        status: body.status,
+        message: body.validator?.message ?? body.error ?? '',
+      });
+      const sres = await fetch(`/api/onboarding/state?tenantId=${tenantId}`);
+      if (sres.ok) {
+        setState(await sres.json());
+      }
+    } catch (e) {
+      setResult({ status: 'failed', message: (e as Error).message });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function defer(): Promise<void> {
+    await fetch('/api/onboarding/defer', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        tenantId,
+        category: category.id,
+        reason: 'customer-skipped',
+      }),
+    });
+    const sres = await fetch(`/api/onboarding/state?tenantId=${tenantId}`);
+    if (sres.ok) {
+      setState(await sres.json());
+    }
+  }
+
+  const completedCount = state.steps.filter(
+    (s) => s.category.required && (s.status === 'passed' || s.status === 'deferred'),
+  ).length;
+  const progressPercent = Math.round((completedCount / 15) * 100);
+
+  return (
+    <main
+      style={{
+        maxWidth: 960,
+        margin: '40px auto',
+        padding: 24,
+        background: 'white',
+        borderRadius: 12,
+        boxShadow: '0 1px 2px rgba(0,0,0,.06)',
+      }}
+      data-testid="wizard"
+    >
+      <header style={{ marginBottom: 24 }}>
+        <h1 style={{ margin: 0 }}>Onboarding</h1>
+        <div
+          aria-label="overall progress"
+          data-testid="progress"
+          style={{
+            marginTop: 8,
+            height: 6,
+            background: '#e2e8f0',
+            borderRadius: 3,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${progressPercent}%`,
+              background: '#10b981',
+              transition: 'width .2s',
+            }}
+          />
+        </div>
+        <p style={{ marginTop: 6, fontSize: 13, color: '#475569' }}>
+          {completedCount} of 15 required categories complete.
+          {state.ready ? ' ✅ Ready to finalize.' : ''}
+        </p>
+      </header>
+
+      <section style={{ display: 'flex', gap: 24 }}>
+        <aside style={{ flex: '0 0 240px' }}>
+          <ol style={{ paddingLeft: 0, listStyle: 'none' }} data-testid="step-list">
+            {state.steps.map((s) => (
+              <li
+                key={s.category.id}
+                data-testid={`step-${s.category.id}`}
+                data-status={s.status}
+                style={{
+                  padding: '6px 8px',
+                  borderRadius: 4,
+                  background:
+                    s.category.id === category.id ? '#eef2ff' : 'transparent',
+                  fontSize: 13,
+                  color: s.status === 'passed' ? '#065f46' : '#0f172a',
+                }}
+              >
+                <a
+                  href={`/onboarding/${s.category.id}`}
+                  style={{ color: 'inherit', textDecoration: 'none' }}
+                >
+                  {s.category.ordinal}. {s.category.label}
+                  {s.status === 'passed' ? ' ✅' : ''}
+                  {s.status === 'failed' ? ' ❌' : ''}
+                  {s.status === 'deferred' ? ' ⏭' : ''}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </aside>
+
+        <section style={{ flex: 1 }}>
+          <h2 style={{ marginTop: 0 }}>
+            {category.ordinal}. {category.label}
+          </h2>
+          <p style={{ color: '#475569' }}>{category.description}</p>
+
+          <label style={{ display: 'block', marginTop: 16, fontWeight: 600 }}>
+            Provider
+          </label>
+          <select
+            data-testid="provider-select"
+            value={providerId}
+            onChange={(e) => setProviderId(e.target.value)}
+            style={{
+              padding: 8,
+              borderRadius: 6,
+              border: '1px solid #cbd5e1',
+              width: '100%',
+              fontSize: 14,
+            }}
+          >
+            {category.providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+
+          {provider && !provider.noCredentials &&
+            provider.credentialDescriptors.map((d) => (
+              <div key={d.keyId} style={{ marginTop: 12 }}>
+                <label style={{ display: 'block', fontWeight: 600, fontSize: 13 }}>
+                  {d.keyId}
+                </label>
+                <input
+                  type="password"
+                  data-testid={`cred-${d.keyId}`}
+                  value={creds[d.keyId] ?? ''}
+                  onChange={(e) =>
+                    setCreds((c) => ({ ...c, [d.keyId]: e.target.value }))
+                  }
+                  style={{
+                    padding: 8,
+                    borderRadius: 6,
+                    border: '1px solid #cbd5e1',
+                    width: '100%',
+                    fontSize: 14,
+                  }}
+                />
+              </div>
+            ))}
+
+          {/* category-specific choice fields (free-form) */}
+          {category.id === 'identity' && (
+            <>
+              {(['ownerEmail', 'timezone', 'locale'] as const).map((k) => (
+                <div key={k} style={{ marginTop: 12 }}>
+                  <label style={{ display: 'block', fontWeight: 600, fontSize: 13 }}>
+                    {k}
+                  </label>
+                  <input
+                    data-testid={`choice-${k}`}
+                    value={choices[k] ?? ''}
+                    onChange={(e) =>
+                      setChoices((c) => ({ ...c, [k]: e.target.value }))
+                    }
+                    style={{
+                      padding: 8,
+                      borderRadius: 6,
+                      border: '1px solid #cbd5e1',
+                      width: '100%',
+                      fontSize: 14,
+                    }}
+                  />
+                </div>
+              ))}
+            </>
+          )}
+
+          <div style={{ marginTop: 24, display: 'flex', gap: 12 }}>
+            <button
+              data-testid="submit"
+              onClick={submit}
+              disabled={submitting}
+              style={{
+                padding: '10px 16px',
+                background: '#1e293b',
+                color: 'white',
+                borderRadius: 6,
+                border: 'none',
+                cursor: 'pointer',
+                fontWeight: 600,
+              }}
+            >
+              {submitting ? 'Validating…' : 'Validate & continue'}
+            </button>
+            {!category.required && (
+              <button
+                data-testid="skip"
+                onClick={defer}
+                style={{
+                  padding: '10px 16px',
+                  background: 'transparent',
+                  color: '#475569',
+                  border: '1px solid #cbd5e1',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                }}
+              >
+                Skip for now
+              </button>
+            )}
+          </div>
+
+          {result && (
+            <div
+              data-testid="result"
+              data-status={result.status}
+              style={{
+                marginTop: 16,
+                padding: 12,
+                background:
+                  result.status === 'passed' ? '#dcfce7' : '#fef2f2',
+                color: result.status === 'passed' ? '#065f46' : '#991b1b',
+                borderRadius: 6,
+                fontSize: 13,
+              }}
+            >
+              {result.status.toUpperCase()}: {result.message ?? ''}
+            </div>
+          )}
+        </section>
+      </section>
+
+      {state.ready && (
+        <section
+          data-testid="ready-banner"
+          style={{
+            marginTop: 24,
+            padding: 16,
+            background: '#ecfdf5',
+            borderRadius: 8,
+          }}
+        >
+          <strong>All required categories complete.</strong>{' '}
+          Your CAIA tenant is ready — onboarding is now <em>finalized</em>.
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/admin/lib/auth.ts
+++ b/apps/admin/lib/auth.ts
@@ -1,0 +1,52 @@
+/**
+ * Cloudflare-Access cookie gate borrowed from packages/cms.
+ *
+ * In production the upstream Cloudflare Access edge sets a
+ * `CF_Authorization` cookie that proxies a signed JWT. We don't verify
+ * the signature here (the edge already did); we just extract the
+ * subject + email for audit purposes. Bypass mode (env var
+ * `CAIA_AUTH_BYPASS=1`) is used by local-dev + Playwright E2E.
+ */
+
+import type { NextRequest } from 'next/server';
+
+export interface AuthContext {
+  email: string;
+  subject: string;
+  /** True when the bypass env var is set. */
+  bypass: boolean;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const payload = parts[1];
+    if (!payload) return null;
+    const buf = Buffer.from(
+      payload.replace(/-/g, '+').replace(/_/g, '/'),
+      'base64',
+    );
+    return JSON.parse(buf.toString('utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function authContext(req: NextRequest): AuthContext | null {
+  if (process.env['CAIA_AUTH_BYPASS'] === '1') {
+    return {
+      email: process.env['CAIA_AUTH_BYPASS_EMAIL'] ?? 'dev@caia.local',
+      subject: 'dev-bypass',
+      bypass: true,
+    };
+  }
+  const cookie = req.cookies.get('CF_Authorization')?.value;
+  if (!cookie) return null;
+  const claims = decodeJwtPayload(cookie);
+  if (!claims) return null;
+  const email = (claims['email'] as string) || (claims['custom']?.toString() ?? '');
+  const subject = (claims['sub'] as string) || '';
+  if (!email || !subject) return null;
+  return { email, subject, bypass: false };
+}

--- a/apps/admin/lib/engine.ts
+++ b/apps/admin/lib/engine.ts
@@ -1,0 +1,62 @@
+/**
+ * Server-side engine singleton.
+ *
+ * Production wires a Postgres-backed store + the Infisical secrets
+ * adapter; dev / e2e wires the in-memory store + a no-op secrets
+ * adapter that returns a synthetic secretRef.
+ *
+ * The singleton is stashed on `globalThis` so Next's dev-mode HMR
+ * (which sometimes re-instantiates module-level state) doesn't wipe
+ * onboarding progress across requests.
+ */
+
+import {
+  InMemoryOnboardingStore,
+  OnboardingEngine,
+  type SecretsPutter,
+} from '@caia/onboarding';
+
+class StubSecretsPutter implements SecretsPutter {
+  async put(
+    tenantId: string,
+    category: string,
+    key: string,
+  ): Promise<{ secretRef: string; version: number }> {
+    return {
+      secretRef: `infisical://tenants/${tenantId}/${category}/${key}@v1`,
+      version: 1,
+    };
+  }
+}
+
+interface EngineGlobals {
+  __caiaOnboardingStore?: InMemoryOnboardingStore;
+  __caiaOnboardingEngine?: OnboardingEngine;
+}
+
+function globalState(): EngineGlobals {
+  return globalThis as unknown as EngineGlobals;
+}
+
+export function getEngine(): { engine: OnboardingEngine; store: InMemoryOnboardingStore } {
+  const g = globalState();
+  if (!g.__caiaOnboardingEngine || !g.__caiaOnboardingStore) {
+    g.__caiaOnboardingStore = new InMemoryOnboardingStore();
+    g.__caiaOnboardingEngine = new OnboardingEngine({
+      store: g.__caiaOnboardingStore,
+      secrets: new StubSecretsPutter(),
+      infisicalBaseUrl:
+        process.env['INFISICAL_BASE_URL'] ?? 'https://infisical.chiefaia.com',
+    });
+  }
+  return {
+    engine: g.__caiaOnboardingEngine,
+    store: g.__caiaOnboardingStore,
+  };
+}
+
+export function _resetEngineForTest(): void {
+  const g = globalState();
+  delete g.__caiaOnboardingEngine;
+  delete g.__caiaOnboardingStore;
+}

--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: { allowedOrigins: ['*'] },
+  },
+  // The onboarding engine lives in a workspace package compiled to ESM;
+  // Next handles it via transpilePackages.
+  transpilePackages: ['@caia/onboarding'],
+};

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@caia-app/admin",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev -p 7776",
+    "start": "next start -p 7776",
+    "test": "echo \"no vitest unit tests in apps/admin; see test:e2e\" && exit 0",
+    "test:e2e": "playwright test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@caia/onboarding": "workspace:*",
+    "next": "15.5.15",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5",
+    "vitest": "^1.6.1"
+  }
+}

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  reporter: 'line',
+  use: {
+    baseURL: 'http://localhost:7776',
+    trace: 'retain-on-failure',
+    extraHTTPHeaders: {
+      // bypass the cf-access cookie check; the underlying lib/auth.ts
+      // honours `CAIA_AUTH_BYPASS=1`.
+    },
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'CAIA_AUTH_BYPASS=1 pnpm dev',
+    url: 'http://localhost:7776',
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/apps/admin/tests/onboarding.e2e.spec.ts
+++ b/apps/admin/tests/onboarding.e2e.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Full happy-path E2E: starting at /, the wizard auto-creates the dev
+ * tenant, walks through all 15 mandatory categories using the
+ * `caia-managed` / `none` / `email-magic-link` providers (no real
+ * external creds needed), and lands on the completion banner.
+ *
+ * Identity and pricing categories need a tiny bit of input — we drive
+ * those via the JSON API to keep the test fast + hermetic.
+ */
+
+const MANDATORY = [
+  'identity',
+  'auth',
+  'pricing',
+  'repo',
+  'ci',
+  'cloud',
+  'domain',
+  'dns',
+  'cdn',
+  'database',
+  'email',
+  'analytics',
+  'errors',
+  'observability',
+  'pm',
+] as const;
+
+const PROVIDER_BY_CATEGORY: Record<
+  string,
+  { providerId: string; choices?: Record<string, unknown>; credentials?: Record<string, string> }
+> = {
+  identity: {
+    providerId: 'self',
+    choices: { ownerEmail: 'p@example.com', timezone: 'UTC', locale: 'en-US' },
+  },
+  auth: { providerId: 'email-magic-link' },
+  pricing: { providerId: 'credits', credentials: { stripe_payment_method_id: 'pm_test123' } },
+  repo: { providerId: 'caia-managed' },
+  ci: { providerId: 'caia-managed' },
+  cloud: { providerId: 'caia-managed' },
+  domain: { providerId: 'manual' },
+  dns: { providerId: 'none' },
+  cdn: { providerId: 'caia-managed' },
+  database: { providerId: 'caia-managed' },
+  email: { providerId: 'caia-managed' },
+  analytics: { providerId: 'none' },
+  errors: { providerId: 'cloudflare-logpush' },
+  observability: { providerId: 'none' },
+  pm: { providerId: 'caia-managed' },
+};
+
+test.describe.configure({ mode: 'serial' });
+
+test('signup → 15 categories → onboarding-complete', async ({ page, request }) => {
+  // landing page redirects to /onboarding/<next>
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/onboarding\//);
+
+  for (const cat of MANDATORY) {
+    const spec = PROVIDER_BY_CATEGORY[cat];
+    const res = await request.post('/api/onboarding/submit', {
+      data: {
+        tenantId: 'dev-tenant',
+        category: cat,
+        providerId: spec!.providerId,
+        choices: spec!.choices ?? {},
+        credentials: spec!.credentials ?? {},
+      },
+    });
+    expect(res.status(), `submit ${cat}`).toBe(200);
+    const body = await res.json();
+    expect(body.status, `${cat} status (msg: ${body.validator?.message})`).toBe(
+      'passed',
+    );
+  }
+
+  // Final state must mark every required step passed.
+  const stateRes = await request.get('/api/onboarding/state?tenantId=dev-tenant');
+  expect(stateRes.status()).toBe(200);
+  const state = await stateRes.json();
+  const mandatorySteps = state.steps.filter(
+    (s: { category: { required: boolean } }) => s.category.required,
+  );
+  const pending = mandatorySteps
+    .filter((s: { status: string }) => !['passed', 'deferred'].includes(s.status))
+    .map((s: { category: { id: string }; status: string }) =>
+      `${s.category.id}=${s.status}`,
+    );
+  expect(pending, `pending steps: ${pending.join(', ')}`).toEqual([]);
+  expect(state.ready).toBe(true);
+
+  // Reload the page — landing should now redirect to /onboarding/complete
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/onboarding\/complete/);
+  await expect(page.getByTestId('onboarding-complete')).toBeVisible();
+});
+
+test('audit log contains credential.put for every storable cred', async ({ request }) => {
+  const res = await request.get('/api/onboarding/log?tenantId=dev-tenant');
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  const actions = new Set<string>(body.entries.map((e: { action: string }) => e.action));
+  expect(actions.has('onboarding.step.passed')).toBe(true);
+  expect(actions.has('onboarding.completed')).toBe(true);
+});
+
+test('rejects unknown provider', async ({ request }) => {
+  const res = await request.post('/api/onboarding/submit', {
+    data: {
+      tenantId: 'dev-tenant',
+      category: 'repo',
+      providerId: 'fictional',
+      choices: {},
+      credentials: {},
+    },
+  });
+  expect(res.status()).toBe(400);
+});

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules", ".next", "tests"]
+}

--- a/packages/onboarding/eslint.config.cjs
+++ b/packages/onboarding/eslint.config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const { createConfig } = require('@chiefaia/eslint-config');
+
+module.exports = createConfig('./tsconfig.json');

--- a/packages/onboarding/migrations/0001_caia_meta_init.sql
+++ b/packages/onboarding/migrations/0001_caia_meta_init.sql
@@ -1,0 +1,180 @@
+-- ============================================================
+-- @caia/onboarding — 0001_caia_meta_init.sql
+--
+-- Initial schema for the cross-tenant control plane that the
+-- onboarding wizard writes to. All tables live in the
+-- `caia_meta` schema. Reference: research/step1_onboarding_spec_2026.md §5.
+--
+-- Run idempotently — every CREATE uses IF NOT EXISTS.
+-- ============================================================
+
+CREATE SCHEMA IF NOT EXISTS caia_meta;
+
+-- ------------------------------------------------------------
+-- caia_meta.tenants — root row, cross-tenant
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS caia_meta.tenants (
+  id                       UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug                     TEXT         NOT NULL UNIQUE,
+  name                     TEXT         NOT NULL,
+  owner_email              TEXT         NOT NULL,
+  billing_email            TEXT         NOT NULL,
+  timezone                 TEXT         NOT NULL DEFAULT 'UTC',
+  locale                   TEXT         NOT NULL DEFAULT 'en-US',
+  jurisdiction             TEXT,
+  data_residency           TEXT         CHECK (data_residency IN ('us','eu','apac','multi')),
+  status                   TEXT         NOT NULL DEFAULT 'created'
+                            CHECK (status IN ('created','onboarding','onboarded','suspended','deleted')),
+  onboarding_complete      BOOLEAN      NOT NULL DEFAULT false,
+  onboarding_started_at    TIMESTAMPTZ,
+  onboarding_completed_at  TIMESTAMPTZ,
+  pricing_tier_id          TEXT,
+  schema_name              TEXT,
+  vault_namespace          TEXT,
+  credit_balance_cents     BIGINT       NOT NULL DEFAULT 0,
+  created_at               TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_tenants_status      ON caia_meta.tenants(status);
+CREATE INDEX IF NOT EXISTS idx_tenants_owner_email ON caia_meta.tenants(owner_email);
+
+-- ------------------------------------------------------------
+-- caia_meta.onboarding_steps — one row per (tenant, category)
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS caia_meta.onboarding_steps (
+  id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id           UUID         NOT NULL REFERENCES caia_meta.tenants(id) ON DELETE CASCADE,
+  category            TEXT         NOT NULL,
+  status              TEXT         NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending','probing','passed','failed','deferred')),
+  required            BOOLEAN      NOT NULL,
+  attempt_count       INT          NOT NULL DEFAULT 0,
+  last_probe_at       TIMESTAMPTZ,
+  last_validated_at   TIMESTAMPTZ,
+  validation_payload  JSONB,
+  failure_reason      TEXT,
+  deferred_reason     TEXT,
+  override_reason     TEXT,
+  created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, category)
+);
+CREATE INDEX IF NOT EXISTS idx_steps_tenant_status
+  ON caia_meta.onboarding_steps(tenant_id, status);
+
+-- ------------------------------------------------------------
+-- caia_meta.onboarding_drafts — autosave between submits
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS caia_meta.onboarding_drafts (
+  tenant_id   UUID         NOT NULL REFERENCES caia_meta.tenants(id) ON DELETE CASCADE,
+  category    TEXT         NOT NULL,
+  form_state  JSONB        NOT NULL,
+  updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, category)
+);
+
+-- ------------------------------------------------------------
+-- caia_meta.customer_choices — provider selections (non-secret)
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS caia_meta.customer_choices (
+  tenant_id    UUID         NOT NULL REFERENCES caia_meta.tenants(id) ON DELETE CASCADE,
+  category     TEXT         NOT NULL,
+  choice_key   TEXT         NOT NULL,
+  choice_value JSONB        NOT NULL,
+  source       TEXT         NOT NULL DEFAULT 'wizard'
+                CHECK (source IN ('wizard','cli','operator_override','default')),
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, category, choice_key)
+);
+CREATE INDEX IF NOT EXISTS idx_choices_tenant_category
+  ON caia_meta.customer_choices(tenant_id, category);
+
+-- ------------------------------------------------------------
+-- caia_meta.credentials — Vault pointer + metadata
+-- Never stores the raw secret value.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS caia_meta.credentials (
+  id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID         NOT NULL REFERENCES caia_meta.tenants(id) ON DELETE CASCADE,
+  category        TEXT         NOT NULL,
+  key_id          TEXT         NOT NULL,
+  secret_ref      TEXT         NOT NULL,
+  archetype       TEXT         NOT NULL
+                   CHECK (archetype IN ('oauth','api_token','dns','webhook','endpoint')),
+  provider        TEXT         NOT NULL,
+  scopes_granted  TEXT[],
+  scopes_required TEXT[],
+  expires_at      TIMESTAMPTZ,
+  last_used_at    TIMESTAMPTZ,
+  last_rotated_at TIMESTAMPTZ,
+  status          TEXT         NOT NULL DEFAULT 'active'
+                   CHECK (status IN ('active','rotating','deprecated','revoked')),
+  validated_at    TIMESTAMPTZ  NOT NULL,
+  metadata        JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, category, key_id, status)
+);
+CREATE INDEX IF NOT EXISTS idx_creds_tenant_category
+  ON caia_meta.credentials(tenant_id, category);
+CREATE INDEX IF NOT EXISTS idx_creds_expires_at
+  ON caia_meta.credentials(expires_at) WHERE expires_at IS NOT NULL;
+
+-- ------------------------------------------------------------
+-- caia_meta.audit_log — append-only event log
+-- Partitioned by month; root table created here, first partition below.
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS caia_meta.audit_log (
+  id           UUID         NOT NULL DEFAULT gen_random_uuid(),
+  tenant_id    UUID         NOT NULL,
+  occurred_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  actor_type   TEXT         NOT NULL,
+  actor_id     TEXT,
+  action       TEXT         NOT NULL,
+  category     TEXT,
+  key_id       TEXT,
+  ticket_id    UUID,
+  request_ip   INET,
+  user_agent   TEXT,
+  payload      JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  CHECK (action ~ '^[a-z_.]+$'),
+  PRIMARY KEY (id, occurred_at)
+) PARTITION BY RANGE (occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_audit_tenant_time
+  ON caia_meta.audit_log(tenant_id, occurred_at DESC);
+
+-- Seed: a permissive default partition that covers all timestamps.
+-- Production operators replace this with monthly partitions and a
+-- nightly rotator job.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class
+    WHERE relname = 'audit_log_default'
+      AND relnamespace = 'caia_meta'::regnamespace
+  ) THEN
+    EXECUTE 'CREATE TABLE caia_meta.audit_log_default
+             PARTITION OF caia_meta.audit_log DEFAULT';
+  END IF;
+END
+$$;
+
+-- ------------------------------------------------------------
+-- Trigger: bump updated_at on tenants + steps
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION caia_meta._bump_updated_at() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tenants_updated_at      ON caia_meta.tenants;
+CREATE TRIGGER trg_tenants_updated_at
+  BEFORE UPDATE ON caia_meta.tenants
+  FOR EACH ROW EXECUTE FUNCTION caia_meta._bump_updated_at();
+
+DROP TRIGGER IF EXISTS trg_steps_updated_at        ON caia_meta.onboarding_steps;
+CREATE TRIGGER trg_steps_updated_at
+  BEFORE UPDATE ON caia_meta.onboarding_steps
+  FOR EACH ROW EXECUTE FUNCTION caia_meta._bump_updated_at();

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@caia/onboarding",
+  "version": "0.1.0",
+  "description": "Customer onboarding engine — 15 mandatory + 4 optional category modules with per-credential validators, idempotent state persistence in caia_meta, and secret_ref-only storage via the SecretsPutter interface (implemented downstream by @caia/secrets-infisical). Step 1 of the CAIA pipeline (research/step1_onboarding_spec_2026.md).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./categories": {
+      "types": "./dist/categories/index.d.ts",
+      "default": "./dist/categories/index.js"
+    },
+    "./validators": {
+      "types": "./dist/validators/index.d.ts",
+      "default": "./dist/validators/index.js"
+    },
+    "./store": {
+      "types": "./dist/store/index.d.ts",
+      "default": "./dist/store/index.js"
+    },
+    "./engine": {
+      "types": "./dist/engine/index.d.ts",
+      "default": "./dist/engine/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "migrations"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@chiefaia/eslint-config": "workspace:*",
+    "@chiefaia/tsconfig": "workspace:*",
+    "@chiefaia/vitest-config": "workspace:*",
+    "@types/node": "^20",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/onboarding/src/categories/index.ts
+++ b/packages/onboarding/src/categories/index.ts
@@ -1,0 +1,936 @@
+/**
+ * `@caia/onboarding/categories` — the static catalog of all 19 categories.
+ *
+ * Each entry is the canonical description of one wizard screen: its
+ * provider menu, the credential descriptors per provider, and whether
+ * the category is required vs. optional. The wizard UI and the
+ * validators both read this catalog.
+ *
+ * Reference: research/step1_onboarding_spec_2026.md §1.
+ */
+
+import type { CategoryDefinition, ProviderOption } from '../types.js';
+import { CategoryDefinitionSchema } from '../types.js';
+
+const noCredOption = (id: string, label: string): {
+  id: string;
+  label: string;
+  archetype: 'api_token';
+  credentialDescriptors: never[];
+  metadata: Record<string, unknown>;
+  noCredentials: true;
+} => ({
+  id,
+  label,
+  archetype: 'api_token',
+  credentialDescriptors: [],
+  metadata: {},
+  noCredentials: true,
+});
+
+export const IDENTITY: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'identity',
+  ordinal: 1,
+  required: true,
+  label: 'Identity & contact',
+  description:
+    "Full name, primary email, org, billing email, time zone, locale. The owner's email domain is DNS-MX-checked and disposable-email providers are rejected.",
+  providers: [noCredOption('self', 'Customer-provided identity')],
+});
+
+export const AUTH: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'auth',
+  ordinal: 2,
+  required: true,
+  label: 'Authentication provider',
+  description:
+    'Which identity provider does the customer use to sign into the CAIA dashboard?',
+  providers: [
+    {
+      id: 'google',
+      label: 'Google',
+      archetype: 'oauth',
+      credentialDescriptors: [
+        {
+          keyId: 'oauth_refresh_token',
+          archetype: 'oauth',
+          scopesRequired: ['openid', 'email', 'profile'],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'github',
+      label: 'GitHub',
+      archetype: 'oauth',
+      credentialDescriptors: [
+        {
+          keyId: 'oauth_refresh_token',
+          archetype: 'oauth',
+          scopesRequired: ['read:user', 'user:email'],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'apple',
+      label: 'Apple',
+      archetype: 'oauth',
+      credentialDescriptors: [
+        {
+          keyId: 'oauth_refresh_token',
+          archetype: 'oauth',
+          scopesRequired: ['name', 'email'],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'microsoft',
+      label: 'Microsoft',
+      archetype: 'oauth',
+      credentialDescriptors: [
+        {
+          keyId: 'oauth_refresh_token',
+          archetype: 'oauth',
+          scopesRequired: ['openid', 'email', 'profile'],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'email-magic-link',
+      label: 'Email magic-link (CAIA-hosted)',
+      archetype: 'api_token',
+      credentialDescriptors: [],
+      metadata: {},
+      noCredentials: true,
+    },
+  ],
+});
+
+export const PRICING: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'pricing',
+  ordinal: 3,
+  required: true,
+  label: 'Pricing tier & LLM billing mode',
+  description:
+    'Choose tier and how Anthropic usage is billed: BYOK (bring your Anthropic key) or credits.',
+  providers: [
+    {
+      id: 'byok',
+      label: 'Bring your own Anthropic API key',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'anthropic_api_key',
+          archetype: 'api_token',
+          scopesRequired: ['messages'],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'credits',
+      label: 'Buy CAIA credits',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'stripe_payment_method_id',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+  ],
+});
+
+export const REPO: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'repo',
+  ordinal: 4,
+  required: true,
+  label: 'Code repository',
+  description:
+    'Where will CAIA push generated code? Bring your own host or pick CAIA-managed.',
+  providers: [
+    {
+      id: 'github',
+      label: 'GitHub',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['repo', 'workflow'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user' },
+      noCredentials: false,
+    },
+    {
+      id: 'gitlab',
+      label: 'GitLab',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['api', 'write_repository'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user' },
+      noCredentials: false,
+    },
+    {
+      id: 'bitbucket',
+      label: 'Bitbucket',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['repository'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user' },
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA-managed repo (default)'),
+  ],
+});
+
+export const CI: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'ci',
+  ordinal: 5,
+  required: true,
+  label: 'CI/CD provider',
+  description:
+    "Where will CI run? GitHub Actions, CircleCI, Buildkite, self-hosted Jenkins, or CAIA-managed.",
+  providers: [
+    {
+      id: 'github-actions',
+      label: 'GitHub Actions',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['actions:read'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user' },
+      noCredentials: false,
+    },
+    {
+      id: 'circleci',
+      label: 'CircleCI',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/me' },
+      noCredentials: false,
+    },
+    {
+      id: 'buildkite',
+      label: 'Buildkite',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['read_user'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user' },
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA-managed CI'),
+  ],
+});
+
+export const CLOUD: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'cloud',
+  ordinal: 6,
+  required: true,
+  label: 'Cloud provider for application runtime',
+  description:
+    'Where will the app run? Pages workers, AWS, GCP, Azure, Fly, Render, self-hosted.',
+  providers: [
+    {
+      id: 'cloudflare-pages',
+      label: 'Cloudflare Pages / Workers',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['Account:Read'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user/tokens/verify' },
+      noCredentials: false,
+    },
+    {
+      id: 'aws',
+      label: 'AWS',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'access_key_id',
+          archetype: 'api_token',
+          scopesRequired: ['sts:GetCallerIdentity'],
+          storeSecret: true,
+        },
+        {
+          keyId: 'secret_access_key',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyAction: 'sts:GetCallerIdentity' },
+      noCredentials: false,
+    },
+    {
+      id: 'vercel',
+      label: 'Vercel',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/v2/user' },
+      noCredentials: false,
+    },
+    {
+      id: 'fly',
+      label: 'Fly.io',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/graphql' },
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA-managed (k3s pool)'),
+  ],
+});
+
+export const DOMAIN: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'domain',
+  ordinal: 7,
+  required: true, // promoted to required per the operator's BYO directive
+  label: 'Domain registrar',
+  description:
+    'Registrar of record for apex domains. Cloudflare / Namecheap / Porkbun have programmatic APIs; others are manual.',
+  providers: [
+    {
+      id: 'cloudflare-registrar',
+      label: 'Cloudflare Registrar',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['Account:Read'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user/tokens/verify' },
+      noCredentials: false,
+    },
+    {
+      id: 'namecheap',
+      label: 'Namecheap',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    noCredOption('manual', 'Other registrar (manual)'),
+    noCredOption('none', 'No custom domain (CAIA subdomain)'),
+  ],
+});
+
+export const DNS: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'dns',
+  ordinal: 8,
+  required: true,
+  label: 'DNS provider',
+  description:
+    'Authoritative DNS for the zones above. CAIA places a TXT record to prove control.',
+  providers: [
+    {
+      id: 'cloudflare-dns',
+      label: 'Cloudflare DNS',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['Zone:DNS:Edit'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user/tokens/verify' },
+      noCredentials: false,
+    },
+    {
+      id: 'route53',
+      label: 'AWS Route 53',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'access_key_id',
+          archetype: 'api_token',
+          scopesRequired: ['sts:GetCallerIdentity'],
+          storeSecret: true,
+        },
+        {
+          keyId: 'secret_access_key',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyAction: 'sts:GetCallerIdentity' },
+      noCredentials: false,
+    },
+    {
+      id: 'manual-dns-proof',
+      label: 'Customer-controlled NS (TXT proof)',
+      archetype: 'dns',
+      credentialDescriptors: [
+        {
+          keyId: 'dns_proof_token',
+          archetype: 'dns',
+          scopesRequired: [],
+          storeSecret: false,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    noCredOption('none', 'CAIA-managed DNS'),
+  ],
+});
+
+export const CDN: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'cdn',
+  ordinal: 9,
+  required: true,
+  label: 'CDN + asset/image hosting',
+  description:
+    'Where static assets + images live. R2, CloudFront, Cloudinary, Imgix, or self-hosted.',
+  providers: [
+    {
+      id: 'cloudflare-r2',
+      label: 'Cloudflare R2',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'access_key_id',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+        {
+          keyId: 'secret_access_key',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'aws-cloudfront-s3',
+      label: 'AWS CloudFront + S3',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'access_key_id',
+          archetype: 'api_token',
+          scopesRequired: ['sts:GetCallerIdentity'],
+          storeSecret: true,
+        },
+        {
+          keyId: 'secret_access_key',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'cloudinary',
+      label: 'Cloudinary',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_key',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+        {
+          keyId: 'api_secret',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA-managed R2'),
+  ],
+});
+
+export const DATABASE: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'database',
+  ordinal: 10,
+  required: true,
+  label: 'Database provider',
+  description:
+    'Postgres-flavoured DB for the app. Self-hosted, Supabase, Neon, RDS, or CAIA-managed.',
+  providers: [
+    {
+      id: 'self-hosted-postgres',
+      label: 'Self-hosted Postgres (DSN)',
+      archetype: 'endpoint',
+      credentialDescriptors: [
+        {
+          keyId: 'dsn',
+          archetype: 'endpoint',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'supabase',
+      label: 'Supabase',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'service_role_key',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: {},
+      noCredentials: false,
+    },
+    {
+      id: 'neon',
+      label: 'Neon',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/users/me' },
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA-managed Postgres'),
+  ],
+});
+
+export const EMAIL: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'email',
+  ordinal: 11,
+  required: true,
+  label: 'Email transactional provider',
+  description:
+    'Who sends magic-links and notification email. Resend, Postmark, SES, SendGrid, Mailgun, or customer SMTP.',
+  providers: [
+    {
+      id: 'resend',
+      label: 'Resend',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/domains' },
+      noCredentials: false,
+    },
+    {
+      id: 'postmark',
+      label: 'Postmark',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/server' },
+      noCredentials: false,
+    },
+    {
+      id: 'sendgrid',
+      label: 'SendGrid',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/scopes' },
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA bootstrap mail'),
+  ],
+});
+
+export const ANALYTICS: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'analytics',
+  ordinal: 12,
+  required: true, // promoted: required + caia-managed default per operator
+  label: 'Analytics provider',
+  description:
+    'Plausible, GA4, Mixpanel, PostHog, Cloudflare Web Analytics, or none.',
+  providers: [
+    {
+      id: 'plausible-cloud',
+      label: 'Plausible (cloud)',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/api/v1/sites' },
+      noCredentials: false,
+    },
+    {
+      id: 'posthog-cloud',
+      label: 'PostHog (cloud)',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/api/users/@me' },
+      noCredentials: false,
+    },
+    noCredOption('none', 'No analytics'),
+  ],
+});
+
+export const ERRORS: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'errors',
+  ordinal: 13,
+  required: true,
+  label: 'Error tracking provider',
+  description:
+    "Sentry, Rollbar, Datadog Errors, Bugsnag, Cloudflare Logpush, or none.",
+  providers: [
+    {
+      id: 'sentry',
+      label: 'Sentry',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['org:read'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/api/0/organizations/' },
+      noCredentials: false,
+    },
+    noCredOption('cloudflare-logpush', 'Cloudflare Logpush (default)'),
+  ],
+});
+
+export const OBSERVABILITY: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'observability',
+  ordinal: 14,
+  required: true, // promoted to required
+  label: 'Observability / APM',
+  description:
+    'Datadog, Grafana Cloud, Honeycomb, Axiom, or none.',
+  providers: [
+    {
+      id: 'honeycomb',
+      label: 'Honeycomb',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/1/auth' },
+      noCredentials: false,
+    },
+    {
+      id: 'axiom',
+      label: 'Axiom',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/v1/user' },
+      noCredentials: false,
+    },
+    noCredOption('none', 'No APM'),
+  ],
+});
+
+export const PM: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'pm',
+  ordinal: 15,
+  required: true,
+  label: 'Issue tracker / project management',
+  description:
+    'Linear, Jira, GitHub Issues, GitLab Issues, Notion, Asana, ClickUp, etc.',
+  providers: [
+    {
+      id: 'linear',
+      label: 'Linear',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: 'https://api.linear.app/graphql' },
+      noCredentials: false,
+    },
+    {
+      id: 'jira-cloud',
+      label: 'Jira Cloud',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/rest/api/3/myself' },
+      noCredentials: false,
+    },
+    {
+      id: 'github-issues',
+      label: 'GitHub Issues',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: ['repo'],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: '/user' },
+      noCredentials: false,
+    },
+    noCredOption('caia-managed', 'CAIA-managed tracker'),
+  ],
+});
+
+// ============================================================
+// Optional categories (4)
+// ============================================================
+export const DOCS: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'docs',
+  ordinal: 16,
+  required: false,
+  label: 'Documentation host',
+  description: 'Notion, GitBook, Confluence, ReadMe.io, Docusaurus, or none.',
+  providers: [
+    {
+      id: 'notion',
+      label: 'Notion',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'api_token',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: 'https://api.notion.com/v1/users/me' },
+      noCredentials: false,
+    },
+    noCredOption('docusaurus-in-repo', 'Docusaurus inside the repo'),
+    noCredOption('none', 'No docs host'),
+  ],
+});
+
+export const DESIGN: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'design',
+  ordinal: 17,
+  required: false,
+  label: 'Design source',
+  description: 'Figma, v0, Lovable, Bolt, Builder.io, or CAIA default.',
+  providers: [
+    {
+      id: 'figma',
+      label: 'Figma',
+      archetype: 'api_token',
+      credentialDescriptors: [
+        {
+          keyId: 'pat',
+          archetype: 'api_token',
+          scopesRequired: [],
+          storeSecret: true,
+        },
+      ],
+      metadata: { verifyEndpoint: 'https://api.figma.com/v1/me' },
+      noCredentials: false,
+    },
+    noCredOption('claude-design', 'Claude Design (default)'),
+  ],
+});
+
+export const COMPLIANCE: CategoryDefinition = CategoryDefinitionSchema.parse({
+  id: 'compliance',
+  ordinal: 18,
+  required: false,
+  label: 'Compliance / legal posture',
+  description:
+    'Jurisdiction, data-residency, regulatory scope flags, cookie consent strictness, DPA signed, incident contact.',
+  providers: [noCredOption('self', 'Customer-declared posture')],
+});
+
+export const ANTHROPIC_PREFS: CategoryDefinition =
+  CategoryDefinitionSchema.parse({
+    id: 'anthropic_prefs',
+    ordinal: 19,
+    required: false,
+    label: 'Anthropic model preferences',
+    description:
+      'Preferred Sonnet/Opus/Haiku ratio, hourly rate-limit cap, zero-retention flag.',
+    providers: [noCredOption('preferences', 'Preferences only')],
+  });
+
+// ============================================================
+// Catalog — ordered list, exported for the wizard + engine.
+// ============================================================
+export const ALL_CATEGORIES: readonly CategoryDefinition[] = [
+  IDENTITY,
+  AUTH,
+  PRICING,
+  REPO,
+  CI,
+  CLOUD,
+  DOMAIN,
+  DNS,
+  CDN,
+  DATABASE,
+  EMAIL,
+  ANALYTICS,
+  ERRORS,
+  OBSERVABILITY,
+  PM,
+  DOCS,
+  DESIGN,
+  COMPLIANCE,
+  ANTHROPIC_PREFS,
+];
+
+export function getCategory(id: string): CategoryDefinition | undefined {
+  return ALL_CATEGORIES.find((c) => c.id === id);
+}
+
+export function getProvider(
+  categoryId: string,
+  providerId: string,
+): ProviderOption | undefined {
+  const cat = getCategory(categoryId);
+  if (!cat) return undefined;
+  return cat.providers.find((p) => p.id === providerId);
+}
+
+// Re-export the ID constants so callers don't have to import from types.
+export {
+  MANDATORY_CATEGORY_IDS,
+  OPTIONAL_CATEGORY_IDS,
+  CATEGORY_IDS,
+} from '../types.js';

--- a/packages/onboarding/src/engine/engine.ts
+++ b/packages/onboarding/src/engine/engine.ts
@@ -1,0 +1,357 @@
+/**
+ * `@caia/onboarding` engine — the orchestrator that the wizard UI and
+ * CLI both call. Responsibilities:
+ *
+ *  1. Hold the canonical ordered list of 19 categories.
+ *  2. Compute "what's next" for a tenant (resume + idempotent reentry).
+ *  3. Validate a submitted step via the provider validator.
+ *  4. Persist secret_ref (not value) into Infisical via the secrets
+ *     adapter, write credential row + choices + step status into the
+ *     store, and audit-log everything.
+ *  5. Mark the tenant onboarded when all mandatory categories pass /
+ *     are deferred.
+ *
+ * Reference: research/step1_onboarding_spec_2026.md §2, §3, §5.
+ */
+
+import type {
+  AuditLogEntry,
+  CategoryDefinition,
+  CategoryId,
+  ProviderOption,
+  ValidatorContext,
+  ValidatorResult,
+} from '../types.js';
+import { ALL_CATEGORIES, getCategory, getProvider } from '../categories/index.js';
+import { defaultContext } from '../validators/util.js';
+import { validate } from '../validators/index.js';
+import type { OnboardingStore } from '../store/types.js';
+
+import {
+  AUDIT_ACTIONS,
+  type AuditAction,
+  type EngineState,
+  type SubmitStepInput,
+  type SubmitStepResult,
+} from './types.js';
+
+/**
+ * Minimal subset of `@caia/secrets-adapter#SecretsAdapter` the engine
+ * actually uses. We declare it locally to avoid a runtime dependency
+ * pulling the full @caia/secrets-adapter type-graph into the engine's
+ * compile surface.
+ */
+export interface SecretsPutter {
+  put(
+    tenantId: string,
+    category: string,
+    key: string,
+    value: string,
+    opts?: { replace?: boolean },
+  ): Promise<{ secretRef: string; version?: number }>;
+}
+
+export interface OnboardingEngineOptions {
+  store: OnboardingStore;
+  secrets: SecretsPutter;
+  /** Used in audit rows for cross-system correlation. */
+  infisicalBaseUrl?: string;
+  /** Injected so tests can stub fetch/clock. */
+  validatorCtx?: ValidatorContext;
+}
+
+export class OnboardingEngine {
+  private readonly store: OnboardingStore;
+  private readonly secrets: SecretsPutter;
+  private readonly validatorCtx: ValidatorContext;
+  private readonly infisicalBaseUrl: string;
+
+  constructor(opts: OnboardingEngineOptions) {
+    this.store = opts.store;
+    this.secrets = opts.secrets;
+    this.validatorCtx = opts.validatorCtx ?? defaultContext();
+    this.infisicalBaseUrl = opts.infisicalBaseUrl ?? 'https://infisical.chiefaia.com';
+  }
+
+  /** The static category catalog, in display order. */
+  categories(): readonly CategoryDefinition[] {
+    return ALL_CATEGORIES;
+  }
+
+  /** Read engine state for a tenant; resume cursor is the lowest-ordinal
+   *  mandatory step that's not yet `passed` or `deferred`. */
+  async stateFor(tenantId: string): Promise<EngineState> {
+    const rows = await this.store.listSteps(tenantId);
+    const byCat = new Map<CategoryId, (typeof rows)[number]>(
+      rows.map((r) => [r.category, r]),
+    );
+    const steps = ALL_CATEGORIES.map((c) => {
+      const row = byCat.get(c.id);
+      const item: EngineState['steps'][number] = {
+        category: c,
+        status: row?.status ?? 'pending',
+        attemptCount: row?.attemptCount ?? 0,
+      };
+      if (row?.failureReason) item.failureReason = row.failureReason;
+      return item;
+    });
+    const next = steps.find(
+      (s) => s.category.required && !['passed', 'deferred'].includes(s.status),
+    );
+    const ready = steps
+      .filter((s) => s.category.required)
+      .every((s) => ['passed', 'deferred'].includes(s.status));
+    const out: EngineState = {
+      tenantId,
+      steps,
+      ready,
+    };
+    if (next) out.current = next.category;
+    return out;
+  }
+
+  /** Mark a category deferred (only allowed for optional categories,
+   *  or a required category whose provider supports a "skip" option). */
+  async defer(
+    tenantId: string,
+    category: CategoryId,
+    reason: string,
+  ): Promise<void> {
+    const cat = getCategory(category);
+    if (!cat) throw new Error(`unknown category: ${category}`);
+    if (cat.required) {
+      throw new Error(`cannot defer required category: ${category}`);
+    }
+    await this.store.setStepStatus(tenantId, category, 'deferred', {
+      required: cat.required,
+      deferredReason: reason,
+      lastValidatedAt: this.validatorCtx.now(),
+    });
+    await this.audit({
+      tenantId,
+      actorType: 'customer',
+      action: AUDIT_ACTIONS.STEP_DEFERRED,
+      category,
+      payload: { reason },
+      occurredAt: this.validatorCtx.now(),
+    });
+  }
+
+  /**
+   * The big one: validate a step submission, persist secrets, write
+   * rows, audit, optionally finalize the tenant.
+   *
+   * Idempotency: re-submitting the same (tenantId, category, providerId,
+   * credentials) is safe — secrets are PUT with replace:true, credential
+   * row is upserted, step row is upserted.
+   */
+  async submitStep(input: SubmitStepInput): Promise<SubmitStepResult> {
+    const cat = getCategory(input.category);
+    if (!cat) {
+      throw new Error(`unknown category: ${input.category}`);
+    }
+    const provider = getProvider(input.category, input.providerId);
+    if (!provider) {
+      throw new Error(
+        `unknown provider for ${input.category}: ${input.providerId}`,
+      );
+    }
+    // mark probing — increments attempt_count
+    await this.store.setStepStatus(input.tenantId, input.category, 'probing', {
+      required: cat.required,
+      lastProbeAt: this.validatorCtx.now(),
+    });
+    await this.audit({
+      tenantId: input.tenantId,
+      actorType: input.actor?.actorType ?? 'customer',
+      action: AUDIT_ACTIONS.STEP_STARTED,
+      category: input.category,
+      payload: { providerId: input.providerId },
+      occurredAt: this.validatorCtx.now(),
+      ...(input.actor?.actorId ? { actorId: input.actor.actorId } : {}),
+      ...(input.actor?.requestIp ? { requestIp: input.actor.requestIp } : {}),
+      ...(input.actor?.userAgent ? { userAgent: input.actor.userAgent } : {}),
+    });
+
+    let result: ValidatorResult;
+    try {
+      result = await validate(
+        {
+          tenantId: input.tenantId,
+          category: input.category,
+          providerId: input.providerId,
+          choices: input.choices,
+          credentials: input.credentials,
+        },
+        this.validatorCtx,
+      );
+    } catch (e) {
+      result = {
+        ok: false,
+        providerId: input.providerId,
+        errorCode: 'provider_error',
+        message: `validator threw: ${(e as Error).message}`,
+      };
+    }
+
+    // Persist choice rows regardless of success — the customer made
+    // them, the operator will want them for forensics either way.
+    await this.persistChoices(input);
+
+    if (!result.ok) {
+      await this.store.setStepStatus(input.tenantId, input.category, 'failed', {
+        required: cat.required,
+        failureReason: result.message,
+        validationPayload: { errorCode: result.errorCode, message: result.message },
+        lastValidatedAt: this.validatorCtx.now(),
+      });
+      await this.audit({
+        tenantId: input.tenantId,
+        actorType: input.actor?.actorType ?? 'customer',
+        action: AUDIT_ACTIONS.STEP_FAILED,
+        category: input.category,
+        payload: { providerId: input.providerId, errorCode: result.errorCode, message: result.message },
+        occurredAt: this.validatorCtx.now(),
+        ...(input.actor?.actorId ? { actorId: input.actor.actorId } : {}),
+      });
+      return { status: 'failed', validator: result, credentialRefs: [] };
+    }
+
+    // Success — PUT each storable credential into Infisical, write
+    // credential rows pointing at the secret_ref.
+    const refs = await this.persistCredentials(input, provider, result);
+
+    await this.store.setStepStatus(input.tenantId, input.category, 'passed', {
+      required: cat.required,
+      validationPayload: { providerId: result.providerId, metadata: result.metadata },
+      lastValidatedAt: this.validatorCtx.now(),
+    });
+    await this.audit({
+      tenantId: input.tenantId,
+      actorType: input.actor?.actorType ?? 'customer',
+      action: AUDIT_ACTIONS.STEP_PASSED,
+      category: input.category,
+      payload: { providerId: result.providerId, credentialRefs: refs },
+      occurredAt: this.validatorCtx.now(),
+      ...(input.actor?.actorId ? { actorId: input.actor.actorId } : {}),
+    });
+
+    // Finalize when every mandatory step is passed / deferred.
+    const stateAfter = await this.stateFor(input.tenantId);
+    if (stateAfter.ready) {
+      const tenant = await this.store.getTenant(input.tenantId);
+      if (tenant && !tenant.onboardingComplete) {
+        await this.store.markTenantOnboarded(input.tenantId);
+        await this.audit({
+          tenantId: input.tenantId,
+          actorType: 'system',
+          action: AUDIT_ACTIONS.TENANT_ONBOARDED,
+          payload: {},
+          occurredAt: this.validatorCtx.now(),
+        });
+      }
+    }
+
+    return { status: 'passed', validator: result, credentialRefs: refs };
+  }
+
+  private async persistChoices(input: SubmitStepInput): Promise<void> {
+    await this.store.putChoice({
+      tenantId: input.tenantId,
+      category: input.category,
+      choiceKey: 'provider',
+      choiceValue: input.providerId,
+      source: 'wizard',
+    });
+    for (const [k, v] of Object.entries(input.choices)) {
+      if (k === 'provider') continue;
+      await this.store.putChoice({
+        tenantId: input.tenantId,
+        category: input.category,
+        choiceKey: k,
+        choiceValue: v,
+        source: 'wizard',
+      });
+    }
+  }
+
+  private async persistCredentials(
+    input: SubmitStepInput,
+    provider: ProviderOption,
+    result: ValidatorResult,
+  ): Promise<string[]> {
+    if (!result.ok) return [];
+    const refs: string[] = [];
+    for (const desc of provider.credentialDescriptors) {
+      const value = input.credentials[desc.keyId];
+      if (!value) continue;
+      if (!desc.storeSecret) {
+        // DNS proof tokens and the like: validated but not persisted.
+        await this.audit({
+          tenantId: input.tenantId,
+          actorType: input.actor?.actorType ?? 'customer',
+          action: AUDIT_ACTIONS.CREDENTIAL_VALIDATED,
+          category: input.category,
+          keyId: desc.keyId,
+          payload: { providerId: input.providerId, stored: false },
+          occurredAt: this.validatorCtx.now(),
+        });
+        continue;
+      }
+      const put = await this.secrets.put(
+        input.tenantId,
+        input.category,
+        desc.keyId,
+        value,
+        { replace: true },
+      );
+      await this.audit({
+        tenantId: input.tenantId,
+        actorType: input.actor?.actorType ?? 'customer',
+        action: AUDIT_ACTIONS.CREDENTIAL_PUT,
+        category: input.category,
+        keyId: desc.keyId,
+        payload: {
+          providerId: input.providerId,
+          secretRef: put.secretRef,
+          backend: 'infisical',
+          baseUrl: this.infisicalBaseUrl,
+        },
+        occurredAt: this.validatorCtx.now(),
+      });
+      await this.store.putCredential({
+        tenantId: input.tenantId,
+        category: input.category,
+        keyId: desc.keyId,
+        secretRef: put.secretRef,
+        archetype: desc.archetype,
+        provider: input.providerId,
+        scopesGranted: result.scopesGranted,
+        scopesRequired: desc.scopesRequired,
+        status: 'active',
+        validatedAt: this.validatorCtx.now(),
+        metadata: result.metadata,
+      });
+      refs.push(put.secretRef);
+    }
+    return refs;
+  }
+
+  private async audit(
+    entry: Omit<AuditLogEntry, 'occurredAt'> & { occurredAt?: Date },
+  ): Promise<void> {
+    const e: AuditLogEntry = {
+      tenantId: entry.tenantId,
+      actorType: entry.actorType,
+      action: entry.action as AuditAction,
+      payload: entry.payload ?? {},
+      occurredAt: entry.occurredAt ?? this.validatorCtx.now(),
+    };
+    if (entry.actorId) e.actorId = entry.actorId;
+    if (entry.category) e.category = entry.category;
+    if (entry.keyId) e.keyId = entry.keyId;
+    if (entry.requestIp) e.requestIp = entry.requestIp;
+    if (entry.userAgent) e.userAgent = entry.userAgent;
+    await this.store.appendAudit(e);
+  }
+}

--- a/packages/onboarding/src/engine/index.ts
+++ b/packages/onboarding/src/engine/index.ts
@@ -1,0 +1,12 @@
+export {
+  OnboardingEngine,
+  type OnboardingEngineOptions,
+  type SecretsPutter,
+} from './engine.js';
+export {
+  AUDIT_ACTIONS,
+  type AuditAction,
+  type EngineState,
+  type SubmitStepInput,
+  type SubmitStepResult,
+} from './types.js';

--- a/packages/onboarding/src/engine/types.ts
+++ b/packages/onboarding/src/engine/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Engine-facing shapes — what the wizard server hands to the engine
+ * and what the engine hands back. Re-exported via the package barrel.
+ */
+
+import type {
+  CategoryDefinition,
+  CategoryId,
+  StepStatus,
+  ValidatorResult,
+} from '../types.js';
+
+/** What the wizard submits when the customer finishes one screen. */
+export interface SubmitStepInput {
+  tenantId: string;
+  category: CategoryId;
+  providerId: string;
+  /** Choice values (provider, region, …) — non-secret. */
+  choices: Record<string, unknown>;
+  /** Raw credential values, keyed by descriptor.keyId. */
+  credentials: Record<string, string>;
+  /** Operator-supplied actor context for audit. */
+  actor?: {
+    actorType: 'customer' | 'operator' | 'agent' | 'system';
+    actorId?: string;
+    requestIp?: string;
+    userAgent?: string;
+  };
+}
+
+export interface SubmitStepResult {
+  status: StepStatus;
+  validator: ValidatorResult;
+  credentialRefs: string[];
+}
+
+export interface EngineState {
+  tenantId: string;
+  current?: CategoryDefinition;
+  steps: Array<{
+    category: CategoryDefinition;
+    status: StepStatus;
+    attemptCount: number;
+    failureReason?: string;
+  }>;
+  /** When true, every mandatory category is passed or deferred. */
+  ready: boolean;
+}
+
+/** Audit action vocabulary used by the engine. */
+export const AUDIT_ACTIONS = {
+  STEP_STARTED: 'onboarding.step.started',
+  STEP_PASSED: 'onboarding.step.passed',
+  STEP_FAILED: 'onboarding.step.failed',
+  STEP_DEFERRED: 'onboarding.step.deferred',
+  CREDENTIAL_PUT: 'credential.put',
+  CREDENTIAL_VALIDATED: 'credential.validated',
+  TENANT_ONBOARDED: 'onboarding.completed',
+} as const;
+export type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * `@caia/onboarding` — public surface.
+ *
+ * The engine is the primary entry point; the wizard server and CLI
+ * both instantiate `new OnboardingEngine({ store, secrets })` and
+ * call `submitStep` / `stateFor` / `defer`.
+ *
+ * Re-exports the static category catalog, validator dispatch, and
+ * store implementations for direct use from tests + tooling.
+ */
+
+export * from './types.js';
+export * from './categories/index.js';
+export * from './validators/index.js';
+export * from './store/index.js';
+export * from './engine/index.js';

--- a/packages/onboarding/src/store/in-memory.ts
+++ b/packages/onboarding/src/store/in-memory.ts
@@ -1,0 +1,177 @@
+/**
+ * In-memory `OnboardingStore` — used by tests and dev. Mirrors the
+ * `caia_meta.*` schema's UNIQUE constraints (tenant+category for steps,
+ * tenant+category+key+status for credentials).
+ */
+
+import type {
+  AuditLogEntry,
+  CategoryId,
+  CredentialRow,
+  CustomerChoiceRow,
+  OnboardingStepRow,
+  StepStatus,
+  TenantRow,
+} from '../types.js';
+import type { OnboardingStore } from './types.js';
+
+function nowIso(): Date {
+  return new Date();
+}
+
+function uuid(): string {
+  // Tests don't need RFC-4122 compliance, just uniqueness.
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`
+  );
+}
+
+export class InMemoryOnboardingStore implements OnboardingStore {
+  private readonly tenants = new Map<string, TenantRow>();
+  private readonly steps = new Map<string, OnboardingStepRow>();
+  private readonly choices = new Map<string, CustomerChoiceRow>();
+  private readonly creds = new Map<string, CredentialRow>();
+  private readonly audit: AuditLogEntry[] = [];
+
+  private stepKey(tenantId: string, category: CategoryId): string {
+    return `${tenantId}:${category}`;
+  }
+  private choiceKey(
+    tenantId: string,
+    category: CategoryId,
+    choiceKey: string,
+  ): string {
+    return `${tenantId}:${category}:${choiceKey}`;
+  }
+  private credKey(
+    tenantId: string,
+    category: CategoryId,
+    keyId: string,
+  ): string {
+    return `${tenantId}:${category}:${keyId}`;
+  }
+
+  async createTenant(
+    input: Omit<TenantRow, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'onboardingComplete'> & {
+      id?: string;
+    },
+  ): Promise<TenantRow> {
+    const id = input.id ?? uuid();
+    const row: TenantRow = {
+      id,
+      slug: input.slug,
+      name: input.name,
+      ownerEmail: input.ownerEmail,
+      billingEmail: input.billingEmail,
+      timezone: input.timezone,
+      locale: input.locale,
+      status: 'onboarding',
+      onboardingComplete: false,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    this.tenants.set(id, row);
+    return row;
+  }
+
+  async getTenant(id: string): Promise<TenantRow | undefined> {
+    return this.tenants.get(id);
+  }
+
+  async markTenantOnboarded(id: string): Promise<void> {
+    const t = this.tenants.get(id);
+    if (!t) throw new Error(`tenant not found: ${id}`);
+    this.tenants.set(id, {
+      ...t,
+      onboardingComplete: true,
+      status: 'onboarded',
+      updatedAt: nowIso(),
+    });
+  }
+
+  async upsertStep(input: OnboardingStepRow): Promise<OnboardingStepRow> {
+    const k = this.stepKey(input.tenantId, input.category);
+    const existing = this.steps.get(k);
+    const merged: OnboardingStepRow = existing
+      ? { ...existing, ...input }
+      : { ...input };
+    this.steps.set(k, merged);
+    return merged;
+  }
+
+  async setStepStatus(
+    tenantId: string,
+    category: CategoryId,
+    status: StepStatus,
+    fields: Partial<OnboardingStepRow> = {},
+  ): Promise<OnboardingStepRow> {
+    const k = this.stepKey(tenantId, category);
+    const existing = this.steps.get(k);
+    const base: OnboardingStepRow = existing ?? {
+      tenantId,
+      category,
+      status: 'pending',
+      required: true,
+      attemptCount: 0,
+    };
+    const next: OnboardingStepRow = {
+      ...base,
+      ...fields,
+      status,
+      attemptCount: (base.attemptCount ?? 0) + (status === 'probing' ? 1 : 0),
+    };
+    this.steps.set(k, next);
+    return next;
+  }
+
+  async listSteps(tenantId: string): Promise<OnboardingStepRow[]> {
+    return [...this.steps.values()].filter((r) => r.tenantId === tenantId);
+  }
+
+  async getStep(
+    tenantId: string,
+    category: CategoryId,
+  ): Promise<OnboardingStepRow | undefined> {
+    return this.steps.get(this.stepKey(tenantId, category));
+  }
+
+  async putChoice(row: CustomerChoiceRow): Promise<void> {
+    this.choices.set(
+      this.choiceKey(row.tenantId, row.category, row.choiceKey),
+      row,
+    );
+  }
+
+  async listChoices(tenantId: string): Promise<CustomerChoiceRow[]> {
+    return [...this.choices.values()].filter((r) => r.tenantId === tenantId);
+  }
+
+  async putCredential(row: CredentialRow): Promise<CredentialRow> {
+    this.creds.set(this.credKey(row.tenantId, row.category, row.keyId), row);
+    return row;
+  }
+
+  async listCredentials(tenantId: string): Promise<CredentialRow[]> {
+    return [...this.creds.values()].filter((r) => r.tenantId === tenantId);
+  }
+
+  async getCredential(
+    tenantId: string,
+    category: CategoryId,
+    keyId: string,
+  ): Promise<CredentialRow | undefined> {
+    return this.creds.get(this.credKey(tenantId, category, keyId));
+  }
+
+  async appendAudit(entry: AuditLogEntry): Promise<void> {
+    this.audit.push({ ...entry, occurredAt: entry.occurredAt ?? nowIso() });
+  }
+
+  async listAudit(tenantId: string, limit = 1000): Promise<AuditLogEntry[]> {
+    return this.audit
+      .filter((e) => e.tenantId === tenantId)
+      .slice(-limit)
+      .reverse();
+  }
+}

--- a/packages/onboarding/src/store/index.ts
+++ b/packages/onboarding/src/store/index.ts
@@ -1,0 +1,3 @@
+export type { OnboardingStore } from './types.js';
+export { InMemoryOnboardingStore } from './in-memory.js';
+export { PgOnboardingStore, type PgClient } from './pg.js';

--- a/packages/onboarding/src/store/pg.ts
+++ b/packages/onboarding/src/store/pg.ts
@@ -1,0 +1,423 @@
+/**
+ * Postgres-backed `OnboardingStore` — written against the `pg`
+ * driver's `Pool` interface; we accept a generic `PgClient` so the
+ * package doesn't have a hard dependency on `pg`.
+ *
+ * Production callers should pass a `pg.Pool` instance.
+ */
+
+import type {
+  AuditLogEntry,
+  CategoryId,
+  CredentialRow,
+  CustomerChoiceRow,
+  OnboardingStepRow,
+  StepStatus,
+  TenantRow,
+} from '../types.js';
+import type { OnboardingStore } from './types.js';
+
+export interface PgClient {
+  query<T = unknown>(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[]; rowCount: number | null }>;
+}
+
+interface TenantSqlRow {
+  id: string;
+  slug: string;
+  name: string;
+  owner_email: string;
+  billing_email: string;
+  timezone: string;
+  locale: string;
+  status: TenantRow['status'];
+  onboarding_complete: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface StepSqlRow {
+  tenant_id: string;
+  category: CategoryId;
+  status: StepStatus;
+  required: boolean;
+  attempt_count: number;
+  last_probe_at: Date | null;
+  last_validated_at: Date | null;
+  validation_payload: Record<string, unknown> | null;
+  failure_reason: string | null;
+  deferred_reason: string | null;
+  override_reason: string | null;
+}
+
+interface ChoiceSqlRow {
+  tenant_id: string;
+  category: CategoryId;
+  choice_key: string;
+  choice_value: unknown;
+  source: CustomerChoiceRow['source'];
+}
+
+interface CredSqlRow {
+  tenant_id: string;
+  category: CategoryId;
+  key_id: string;
+  secret_ref: string;
+  archetype: CredentialRow['archetype'];
+  provider: string;
+  scopes_granted: string[];
+  scopes_required: string[];
+  expires_at: Date | null;
+  status: CredentialRow['status'];
+  validated_at: Date;
+  metadata: Record<string, unknown>;
+}
+
+interface AuditSqlRow {
+  tenant_id: string;
+  actor_type: AuditLogEntry['actorType'];
+  actor_id: string | null;
+  action: string;
+  category: CategoryId | null;
+  key_id: string | null;
+  request_ip: string | null;
+  user_agent: string | null;
+  payload: Record<string, unknown>;
+  occurred_at: Date;
+}
+
+export class PgOnboardingStore implements OnboardingStore {
+  constructor(private readonly db: PgClient) {}
+
+  private mapTenant(r: TenantSqlRow): TenantRow {
+    return {
+      id: r.id,
+      slug: r.slug,
+      name: r.name,
+      ownerEmail: r.owner_email,
+      billingEmail: r.billing_email,
+      timezone: r.timezone,
+      locale: r.locale,
+      status: r.status,
+      onboardingComplete: r.onboarding_complete,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    };
+  }
+
+  private mapStep(r: StepSqlRow): OnboardingStepRow {
+    const row: OnboardingStepRow = {
+      tenantId: r.tenant_id,
+      category: r.category,
+      status: r.status,
+      required: r.required,
+      attemptCount: r.attempt_count,
+    };
+    if (r.last_probe_at) row.lastProbeAt = r.last_probe_at;
+    if (r.last_validated_at) row.lastValidatedAt = r.last_validated_at;
+    if (r.validation_payload) row.validationPayload = r.validation_payload;
+    if (r.failure_reason) row.failureReason = r.failure_reason;
+    if (r.deferred_reason) row.deferredReason = r.deferred_reason;
+    if (r.override_reason) row.overrideReason = r.override_reason;
+    return row;
+  }
+
+  async createTenant(
+    input: Omit<TenantRow, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'onboardingComplete'> & {
+      id?: string;
+    },
+  ): Promise<TenantRow> {
+    const { rows } = await this.db.query<TenantSqlRow>(
+      `INSERT INTO caia_meta.tenants
+       (slug, name, owner_email, billing_email, timezone, locale, status)
+       VALUES ($1,$2,$3,$4,$5,$6,'onboarding')
+       RETURNING *`,
+      [
+        input.slug,
+        input.name,
+        input.ownerEmail,
+        input.billingEmail,
+        input.timezone,
+        input.locale,
+      ],
+    );
+    const row = rows[0];
+    if (!row) throw new Error('createTenant returned no row');
+    return this.mapTenant(row);
+  }
+
+  async getTenant(id: string): Promise<TenantRow | undefined> {
+    const { rows } = await this.db.query<TenantSqlRow>(
+      `SELECT * FROM caia_meta.tenants WHERE id = $1`,
+      [id],
+    );
+    return rows[0] ? this.mapTenant(rows[0]) : undefined;
+  }
+
+  async markTenantOnboarded(id: string): Promise<void> {
+    await this.db.query(
+      `UPDATE caia_meta.tenants
+       SET onboarding_complete = true, status = 'onboarded',
+           onboarding_completed_at = now()
+       WHERE id = $1`,
+      [id],
+    );
+  }
+
+  async upsertStep(input: OnboardingStepRow): Promise<OnboardingStepRow> {
+    const { rows } = await this.db.query<StepSqlRow>(
+      `INSERT INTO caia_meta.onboarding_steps
+       (tenant_id, category, status, required, attempt_count)
+       VALUES ($1,$2,$3,$4,$5)
+       ON CONFLICT (tenant_id, category) DO UPDATE SET
+         status = EXCLUDED.status,
+         required = EXCLUDED.required,
+         attempt_count = EXCLUDED.attempt_count
+       RETURNING *`,
+      [
+        input.tenantId,
+        input.category,
+        input.status,
+        input.required,
+        input.attemptCount,
+      ],
+    );
+    return this.mapStep(rows[0] as StepSqlRow);
+  }
+
+  async setStepStatus(
+    tenantId: string,
+    category: CategoryId,
+    status: StepStatus,
+    fields: Partial<OnboardingStepRow> = {},
+  ): Promise<OnboardingStepRow> {
+    const required = fields.required ?? true;
+    const { rows } = await this.db.query<StepSqlRow>(
+      `INSERT INTO caia_meta.onboarding_steps
+       (tenant_id, category, status, required, attempt_count,
+        last_probe_at, last_validated_at, validation_payload,
+        failure_reason, deferred_reason, override_reason)
+       VALUES ($1,$2,$3,$4,1,
+               $5,$6,$7,$8,$9,$10)
+       ON CONFLICT (tenant_id, category) DO UPDATE SET
+         status = EXCLUDED.status,
+         required = caia_meta.onboarding_steps.required OR EXCLUDED.required,
+         attempt_count = caia_meta.onboarding_steps.attempt_count
+                       + CASE WHEN EXCLUDED.status = 'probing' THEN 1 ELSE 0 END,
+         last_probe_at = COALESCE(EXCLUDED.last_probe_at, caia_meta.onboarding_steps.last_probe_at),
+         last_validated_at = COALESCE(EXCLUDED.last_validated_at, caia_meta.onboarding_steps.last_validated_at),
+         validation_payload = COALESCE(EXCLUDED.validation_payload, caia_meta.onboarding_steps.validation_payload),
+         failure_reason = EXCLUDED.failure_reason,
+         deferred_reason = EXCLUDED.deferred_reason,
+         override_reason = EXCLUDED.override_reason
+       RETURNING *`,
+      [
+        tenantId,
+        category,
+        status,
+        required,
+        fields.lastProbeAt ?? null,
+        fields.lastValidatedAt ?? null,
+        fields.validationPayload ? JSON.stringify(fields.validationPayload) : null,
+        fields.failureReason ?? null,
+        fields.deferredReason ?? null,
+        fields.overrideReason ?? null,
+      ],
+    );
+    return this.mapStep(rows[0] as StepSqlRow);
+  }
+
+  async listSteps(tenantId: string): Promise<OnboardingStepRow[]> {
+    const { rows } = await this.db.query<StepSqlRow>(
+      `SELECT * FROM caia_meta.onboarding_steps WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    return rows.map((r) => this.mapStep(r));
+  }
+
+  async getStep(
+    tenantId: string,
+    category: CategoryId,
+  ): Promise<OnboardingStepRow | undefined> {
+    const { rows } = await this.db.query<StepSqlRow>(
+      `SELECT * FROM caia_meta.onboarding_steps
+        WHERE tenant_id = $1 AND category = $2`,
+      [tenantId, category],
+    );
+    return rows[0] ? this.mapStep(rows[0]) : undefined;
+  }
+
+  async putChoice(row: CustomerChoiceRow): Promise<void> {
+    await this.db.query(
+      `INSERT INTO caia_meta.customer_choices
+       (tenant_id, category, choice_key, choice_value, source)
+       VALUES ($1,$2,$3,$4::jsonb,$5)
+       ON CONFLICT (tenant_id, category, choice_key) DO UPDATE SET
+         choice_value = EXCLUDED.choice_value,
+         source = EXCLUDED.source`,
+      [row.tenantId, row.category, row.choiceKey, JSON.stringify(row.choiceValue), row.source],
+    );
+  }
+
+  async listChoices(tenantId: string): Promise<CustomerChoiceRow[]> {
+    const { rows } = await this.db.query<ChoiceSqlRow>(
+      `SELECT * FROM caia_meta.customer_choices WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    return rows.map((r) => ({
+      tenantId: r.tenant_id,
+      category: r.category,
+      choiceKey: r.choice_key,
+      choiceValue: r.choice_value,
+      source: r.source,
+    }));
+  }
+
+  async putCredential(row: CredentialRow): Promise<CredentialRow> {
+    const { rows } = await this.db.query<CredSqlRow>(
+      `INSERT INTO caia_meta.credentials
+       (tenant_id, category, key_id, secret_ref, archetype, provider,
+        scopes_granted, scopes_required, expires_at, status, validated_at, metadata)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)
+       ON CONFLICT (tenant_id, category, key_id, status) DO UPDATE SET
+         secret_ref = EXCLUDED.secret_ref,
+         scopes_granted = EXCLUDED.scopes_granted,
+         scopes_required = EXCLUDED.scopes_required,
+         expires_at = EXCLUDED.expires_at,
+         validated_at = EXCLUDED.validated_at,
+         metadata = EXCLUDED.metadata
+       RETURNING *`,
+      [
+        row.tenantId,
+        row.category,
+        row.keyId,
+        row.secretRef,
+        row.archetype,
+        row.provider,
+        row.scopesGranted,
+        row.scopesRequired,
+        row.expiresAt ?? null,
+        row.status,
+        row.validatedAt,
+        JSON.stringify(row.metadata),
+      ],
+    );
+    const r = rows[0] as CredSqlRow;
+    const out: CredentialRow = {
+      tenantId: r.tenant_id,
+      category: r.category,
+      keyId: r.key_id,
+      secretRef: r.secret_ref,
+      archetype: r.archetype,
+      provider: r.provider,
+      scopesGranted: r.scopes_granted,
+      scopesRequired: r.scopes_required,
+      status: r.status,
+      validatedAt: r.validated_at,
+      metadata: r.metadata,
+    };
+    if (r.expires_at) out.expiresAt = r.expires_at;
+    return out;
+  }
+
+  async listCredentials(tenantId: string): Promise<CredentialRow[]> {
+    const { rows } = await this.db.query<CredSqlRow>(
+      `SELECT * FROM caia_meta.credentials WHERE tenant_id = $1`,
+      [tenantId],
+    );
+    return rows.map((r) => {
+      const out: CredentialRow = {
+        tenantId: r.tenant_id,
+        category: r.category,
+        keyId: r.key_id,
+        secretRef: r.secret_ref,
+        archetype: r.archetype,
+        provider: r.provider,
+        scopesGranted: r.scopes_granted ?? [],
+        scopesRequired: r.scopes_required ?? [],
+        status: r.status,
+        validatedAt: r.validated_at,
+        metadata: r.metadata ?? {},
+      };
+      if (r.expires_at) out.expiresAt = r.expires_at;
+      return out;
+    });
+  }
+
+  async getCredential(
+    tenantId: string,
+    category: CategoryId,
+    keyId: string,
+  ): Promise<CredentialRow | undefined> {
+    const { rows } = await this.db.query<CredSqlRow>(
+      `SELECT * FROM caia_meta.credentials
+        WHERE tenant_id = $1 AND category = $2 AND key_id = $3 AND status = 'active'`,
+      [tenantId, category, keyId],
+    );
+    if (!rows[0]) return undefined;
+    const r = rows[0];
+    const out: CredentialRow = {
+      tenantId: r.tenant_id,
+      category: r.category,
+      keyId: r.key_id,
+      secretRef: r.secret_ref,
+      archetype: r.archetype,
+      provider: r.provider,
+      scopesGranted: r.scopes_granted ?? [],
+      scopesRequired: r.scopes_required ?? [],
+      status: r.status,
+      validatedAt: r.validated_at,
+      metadata: r.metadata ?? {},
+    };
+    if (r.expires_at) out.expiresAt = r.expires_at;
+    return out;
+  }
+
+  async appendAudit(entry: AuditLogEntry): Promise<void> {
+    await this.db.query(
+      `INSERT INTO caia_meta.audit_log
+       (tenant_id, actor_type, actor_id, action, category, key_id,
+        request_ip, user_agent, payload, occurred_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10)`,
+      [
+        entry.tenantId,
+        entry.actorType,
+        entry.actorId ?? null,
+        entry.action,
+        entry.category ?? null,
+        entry.keyId ?? null,
+        entry.requestIp ?? null,
+        entry.userAgent ?? null,
+        JSON.stringify(entry.payload),
+        entry.occurredAt ?? new Date(),
+      ],
+    );
+  }
+
+  async listAudit(tenantId: string, limit = 1000): Promise<AuditLogEntry[]> {
+    const { rows } = await this.db.query<AuditSqlRow>(
+      `SELECT * FROM caia_meta.audit_log
+        WHERE tenant_id = $1
+        ORDER BY occurred_at DESC
+        LIMIT $2`,
+      [tenantId, limit],
+    );
+    return rows.map((r) => {
+      const entry: AuditLogEntry = {
+        tenantId: r.tenant_id,
+        actorType: r.actor_type,
+        action: r.action,
+        payload: r.payload ?? {},
+        occurredAt: r.occurred_at,
+      };
+      if (r.actor_id) entry.actorId = r.actor_id;
+      if (r.category) entry.category = r.category;
+      if (r.key_id) entry.keyId = r.key_id;
+      if (r.request_ip) entry.requestIp = r.request_ip;
+      if (r.user_agent) entry.userAgent = r.user_agent;
+      return entry;
+    });
+  }
+}

--- a/packages/onboarding/src/store/types.ts
+++ b/packages/onboarding/src/store/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Onboarding store contracts — the engine talks to these interfaces;
+ * production wires a Postgres implementation, tests wire the
+ * in-memory implementation in this directory.
+ */
+
+import type {
+  AuditLogEntry,
+  CategoryId,
+  CredentialRow,
+  CustomerChoiceRow,
+  OnboardingStepRow,
+  StepStatus,
+  TenantRow,
+} from '../types.js';
+
+export interface OnboardingStore {
+  // Tenants
+  createTenant(
+    input: Omit<TenantRow, 'id' | 'createdAt' | 'updatedAt' | 'status' | 'onboardingComplete'> & {
+      id?: string;
+    },
+  ): Promise<TenantRow>;
+  getTenant(id: string): Promise<TenantRow | undefined>;
+  markTenantOnboarded(id: string): Promise<void>;
+
+  // Steps (one row per (tenant, category))
+  upsertStep(input: OnboardingStepRow): Promise<OnboardingStepRow>;
+  setStepStatus(
+    tenantId: string,
+    category: CategoryId,
+    status: StepStatus,
+    fields?: Partial<OnboardingStepRow>,
+  ): Promise<OnboardingStepRow>;
+  listSteps(tenantId: string): Promise<OnboardingStepRow[]>;
+  getStep(
+    tenantId: string,
+    category: CategoryId,
+  ): Promise<OnboardingStepRow | undefined>;
+
+  // Choices
+  putChoice(row: CustomerChoiceRow): Promise<void>;
+  listChoices(tenantId: string): Promise<CustomerChoiceRow[]>;
+
+  // Credentials (secret_ref pointers, never raw values)
+  putCredential(row: CredentialRow): Promise<CredentialRow>;
+  listCredentials(tenantId: string): Promise<CredentialRow[]>;
+  getCredential(
+    tenantId: string,
+    category: CategoryId,
+    keyId: string,
+  ): Promise<CredentialRow | undefined>;
+
+  // Audit
+  appendAudit(entry: AuditLogEntry): Promise<void>;
+  listAudit(tenantId: string, limit?: number): Promise<AuditLogEntry[]>;
+}

--- a/packages/onboarding/src/types.ts
+++ b/packages/onboarding/src/types.ts
@@ -1,0 +1,283 @@
+/**
+ * `@caia/onboarding` — public types.
+ *
+ * Reference: research/step1_onboarding_spec_2026.md §1, §2, §5.
+ */
+
+import { z } from 'zod';
+
+// ============================================================
+// Archetypes — the 5 validator archetypes from §2.
+// ============================================================
+export const ARCHETYPES = [
+  'oauth',
+  'api_token',
+  'dns',
+  'webhook',
+  'endpoint',
+] as const;
+export const ArchetypeSchema = z.enum(ARCHETYPES);
+export type Archetype = z.infer<typeof ArchetypeSchema>;
+
+// ============================================================
+// Step status — see migration 0001_caia_meta_init.sql.
+// ============================================================
+export const STEP_STATUSES = [
+  'pending',
+  'probing',
+  'passed',
+  'failed',
+  'deferred',
+] as const;
+export const StepStatusSchema = z.enum(STEP_STATUSES);
+export type StepStatus = z.infer<typeof StepStatusSchema>;
+
+// ============================================================
+// Provider modes from §1.
+// ============================================================
+export const PROVIDER_MODES = [
+  'self_hosted',
+  'byo',
+  'caia_managed',
+  'none',
+] as const;
+export const ProviderModeSchema = z.enum(PROVIDER_MODES);
+export type ProviderMode = z.infer<typeof ProviderModeSchema>;
+
+// ============================================================
+// Category — one per slot in the 15 mandatory + 4 optional list.
+// ============================================================
+export const CATEGORY_IDS = [
+  // 15 mandatory
+  'identity',
+  'auth',
+  'pricing',
+  'repo',
+  'ci',
+  'cloud',
+  'domain',
+  'dns',
+  'cdn',
+  'database',
+  'email',
+  'analytics',
+  'errors',
+  'observability',
+  'pm',
+  // 4 optional
+  'docs',
+  'design',
+  'compliance',
+  'anthropic_prefs',
+] as const;
+export const CategoryIdSchema = z.enum(CATEGORY_IDS);
+export type CategoryId = z.infer<typeof CategoryIdSchema>;
+
+export const MANDATORY_CATEGORY_IDS: readonly CategoryId[] = [
+  'identity',
+  'auth',
+  'pricing',
+  'repo',
+  'ci',
+  'cloud',
+  'domain',
+  'dns',
+  'cdn',
+  'database',
+  'email',
+  'analytics',
+  'errors',
+  'observability',
+  'pm',
+];
+export const OPTIONAL_CATEGORY_IDS: readonly CategoryId[] = [
+  'docs',
+  'design',
+  'compliance',
+  'anthropic_prefs',
+];
+
+// ============================================================
+// Credential descriptor — what the engine stores per slot.
+// ============================================================
+export const CredentialDescriptorSchema = z.object({
+  keyId: z.string().min(1).max(200),
+  archetype: ArchetypeSchema,
+  scopesRequired: z.array(z.string()).default([]),
+  /** Whether the credential goes into Infisical (true) or stays as a
+   *  validated-and-discarded probe (false — e.g. DNS proof of control). */
+  storeSecret: z.boolean().default(true),
+});
+export type CredentialDescriptor = z.infer<typeof CredentialDescriptorSchema>;
+
+// ============================================================
+// Provider option — one row in a category's provider dropdown.
+// ============================================================
+export const ProviderOptionSchema = z.object({
+  id: z.string().min(1).max(80),
+  label: z.string().min(1).max(200),
+  archetype: ArchetypeSchema,
+  credentialDescriptors: z.array(CredentialDescriptorSchema).default([]),
+  /** Free-form provider metadata that the validator inspects. */
+  metadata: z.record(z.unknown()).default({}),
+  /** When true, this option requires no credentials at all (e.g. "none"
+   *  or "caia-managed") — the wizard renders it but skips the validator. */
+  noCredentials: z.boolean().default(false),
+});
+export type ProviderOption = z.infer<typeof ProviderOptionSchema>;
+
+// ============================================================
+// Category definition — the static description of one wizard step.
+// ============================================================
+export const CategoryDefinitionSchema = z.object({
+  id: CategoryIdSchema,
+  label: z.string().min(1).max(200),
+  ordinal: z.number().int().min(1).max(50),
+  required: z.boolean(),
+  description: z.string().min(1).max(800),
+  /** Provider options the customer can pick from. */
+  providers: z.array(ProviderOptionSchema),
+});
+export type CategoryDefinition = z.infer<typeof CategoryDefinitionSchema>;
+
+// ============================================================
+// Persistence rows mirroring caia_meta.* tables.
+// ============================================================
+export const TenantRowSchema = z.object({
+  id: z.string().min(1).max(200),
+  slug: z.string().min(1).max(200),
+  name: z.string().min(1).max(400),
+  ownerEmail: z.string().email(),
+  billingEmail: z.string().email(),
+  timezone: z.string().min(1).max(80),
+  locale: z.string().min(1).max(20),
+  status: z.enum([
+    'created',
+    'onboarding',
+    'onboarded',
+    'suspended',
+    'deleted',
+  ]),
+  onboardingComplete: z.boolean(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type TenantRow = z.infer<typeof TenantRowSchema>;
+
+export const OnboardingStepRowSchema = z.object({
+  tenantId: z.string().min(1),
+  category: CategoryIdSchema,
+  status: StepStatusSchema,
+  required: z.boolean(),
+  attemptCount: z.number().int().nonnegative(),
+  lastProbeAt: z.date().optional(),
+  lastValidatedAt: z.date().optional(),
+  validationPayload: z.record(z.unknown()).optional(),
+  failureReason: z.string().optional(),
+  deferredReason: z.string().optional(),
+  overrideReason: z.string().optional(),
+});
+export type OnboardingStepRow = z.infer<typeof OnboardingStepRowSchema>;
+
+export const CustomerChoiceRowSchema = z.object({
+  tenantId: z.string().min(1),
+  category: CategoryIdSchema,
+  choiceKey: z.string().min(1),
+  choiceValue: z.unknown(),
+  source: z.enum(['wizard', 'cli', 'operator_override', 'default']),
+});
+export type CustomerChoiceRow = z.infer<typeof CustomerChoiceRowSchema>;
+
+export const CredentialRowSchema = z.object({
+  tenantId: z.string().min(1),
+  category: CategoryIdSchema,
+  keyId: z.string().min(1),
+  secretRef: z.string().min(1),
+  archetype: ArchetypeSchema,
+  provider: z.string().min(1),
+  scopesGranted: z.array(z.string()).default([]),
+  scopesRequired: z.array(z.string()).default([]),
+  expiresAt: z.date().optional(),
+  status: z.enum(['active', 'rotating', 'deprecated', 'revoked']),
+  validatedAt: z.date(),
+  metadata: z.record(z.unknown()).default({}),
+});
+export type CredentialRow = z.infer<typeof CredentialRowSchema>;
+
+export const AuditLogEntrySchema = z.object({
+  tenantId: z.string().min(1),
+  actorType: z.enum(['customer', 'operator', 'agent', 'system']),
+  actorId: z.string().optional(),
+  action: z.string().min(1).regex(/^[a-z_.]+$/),
+  category: CategoryIdSchema.optional(),
+  keyId: z.string().optional(),
+  requestIp: z.string().optional(),
+  userAgent: z.string().optional(),
+  payload: z.record(z.unknown()).default({}),
+  occurredAt: z.date().default(() => new Date()),
+});
+export type AuditLogEntry = z.infer<typeof AuditLogEntrySchema>;
+
+// ============================================================
+// Validator input/output — what the wizard server hands to the
+// engine and what the engine hands back.
+// ============================================================
+export const ValidatorInputSchema = z.object({
+  tenantId: z.string().min(1),
+  category: CategoryIdSchema,
+  providerId: z.string().min(1),
+  /** Choices the customer made on this category screen. */
+  choices: z.record(z.unknown()).default({}),
+  /** Raw credential values, keyed by `keyId`. These are passed straight
+   *  to the validator and never persisted in plaintext. */
+  credentials: z.record(z.string()).default({}),
+});
+export type ValidatorInput = z.infer<typeof ValidatorInputSchema>;
+
+export const ValidatorSuccessSchema = z.object({
+  ok: z.literal(true),
+  providerId: z.string().min(1),
+  archetype: ArchetypeSchema,
+  scopesGranted: z.array(z.string()).default([]),
+  /** Provider-specific extras (account id, org id, etc.). */
+  metadata: z.record(z.unknown()).default({}),
+});
+export type ValidatorSuccess = z.infer<typeof ValidatorSuccessSchema>;
+
+export const ValidatorFailureSchema = z.object({
+  ok: z.literal(false),
+  providerId: z.string().min(1),
+  errorCode: z.enum([
+    'scope_insufficient',
+    'token_invalid',
+    'token_expired',
+    'network_error',
+    'rate_limited',
+    'provider_error',
+    'choice_invalid',
+  ]),
+  message: z.string().min(1),
+  retryHint: z.string().optional(),
+});
+export type ValidatorFailure = z.infer<typeof ValidatorFailureSchema>;
+
+export const ValidatorResultSchema = z.discriminatedUnion('ok', [
+  ValidatorSuccessSchema,
+  ValidatorFailureSchema,
+]);
+export type ValidatorResult = z.infer<typeof ValidatorResultSchema>;
+
+// ============================================================
+// Validator strategy — one function per (category, provider).
+// ============================================================
+export type Validator = (
+  input: ValidatorInput,
+  ctx: ValidatorContext,
+) => Promise<ValidatorResult>;
+
+export interface ValidatorContext {
+  /** Injected fetch — tests pass a mock. */
+  fetch: typeof fetch;
+  /** Current wall-clock time — tests can fix this. */
+  now: () => Date;
+}

--- a/packages/onboarding/src/validators/api-tokens.ts
+++ b/packages/onboarding/src/validators/api-tokens.ts
@@ -1,0 +1,332 @@
+/**
+ * Provider-specific API-token validators that are simple GETs to a
+ * documented noop endpoint, grouped here to keep the file count sane.
+ *
+ * Naming convention: validateXxxToken — used by the dispatch map in
+ * ./index.ts.
+ */
+
+import type { Validator } from '../types.js';
+import {
+  asResult,
+  assertOkResponse,
+  fail,
+  ok,
+  probeUrl,
+  requireCredential,
+} from './util.js';
+
+function makeBearerValidator(
+  endpoint: string,
+  keyId = 'api_token',
+  extraHeaders: Record<string, string> = {},
+): Validator {
+  return async (input, ctx) => {
+    const cred = requireCredential(input, keyId);
+    if ('ok' in cred && cred.ok !== true) return cred;
+    const probe = await probeUrl(ctx, endpoint, {
+      Authorization: `Bearer ${(cred as { value: string }).value}`,
+      Accept: 'application/json',
+      ...extraHeaders,
+    });
+    if (!probe.ok) return { ...probe, providerId: input.providerId };
+    const httpFail = assertOkResponse(input.providerId, probe);
+    if (httpFail) return httpFail;
+    return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+  };
+}
+
+export const validateGitlabToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://gitlab.com/api/v4/user', {
+    'PRIVATE-TOKEN': (cred as { value: string }).value,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(
+    ok(input.providerId, 'api_token', {
+      username: probe.json?.['username'] ?? null,
+    }),
+  );
+};
+
+export const validateBitbucketToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://api.bitbucket.org/2.0/user', {
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(
+    ok(input.providerId, 'api_token', {
+      username: probe.json?.['username'] ?? null,
+    }),
+  );
+};
+
+export const validateCircleCiToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://circleci.com/api/v2/me', {
+    'Circle-Token': (cred as { value: string }).value,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+};
+
+export const validateBuildkiteToken = makeBearerValidator(
+  'https://api.buildkite.com/v2/user',
+);
+
+export const validateVercelToken = makeBearerValidator(
+  'https://api.vercel.com/v2/user',
+);
+
+export const validateFlyToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const body = JSON.stringify({ query: '{ viewer { email } }' });
+  const probe = await probeUrl(
+    ctx,
+    'https://api.fly.io/graphql',
+    {
+      Authorization: `Bearer ${(cred as { value: string }).value}`,
+      'Content-Type': 'application/json',
+    },
+    'POST',
+    body,
+  );
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const data = (probe.json?.['data'] as Record<string, unknown>) ?? null;
+  if (!data || !(data['viewer'])) {
+    return fail(input.providerId, 'token_invalid', 'fly.io did not return a viewer');
+  }
+  return asResult(ok(input.providerId, 'api_token', data));
+};
+
+export const validatePostmarkToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://api.postmarkapp.com/server', {
+    'X-Postmark-Server-Token': (cred as { value: string }).value,
+    Accept: 'application/json',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+};
+
+export const validateSendgridToken = makeBearerValidator(
+  'https://api.sendgrid.com/v3/scopes',
+);
+
+export const validateSentryToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://sentry.io/api/0/organizations/', {
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const orgs = Array.isArray(probe.json) ? probe.json : [];
+  return asResult(
+    ok(input.providerId, 'api_token', { orgCount: orgs.length }),
+  );
+};
+
+export const validateLinearToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const body = JSON.stringify({ query: '{ viewer { id name } }' });
+  const probe = await probeUrl(
+    ctx,
+    'https://api.linear.app/graphql',
+    {
+      Authorization: (cred as { value: string }).value,
+      'Content-Type': 'application/json',
+    },
+    'POST',
+    body,
+  );
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const data = (probe.json?.['data'] as Record<string, unknown>) ?? null;
+  if (!data || !(data['viewer'])) {
+    return fail(input.providerId, 'token_invalid', 'Linear did not return a viewer');
+  }
+  return asResult(ok(input.providerId, 'api_token', data));
+};
+
+export const validateJiraToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const site = (input.choices['site'] as string) ?? '';
+  if (!site) {
+    return fail(input.providerId, 'choice_invalid', 'jira site (e.g. mycorp.atlassian.net) is required');
+  }
+  const probe = await probeUrl(ctx, `https://${site}/rest/api/3/myself`, {
+    Authorization: `Basic ${(cred as { value: string }).value}`,
+    Accept: 'application/json',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(
+    ok(input.providerId, 'api_token', {
+      accountId: probe.json?.['accountId'] ?? null,
+    }),
+  );
+};
+
+export const validateNotionToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://api.notion.com/v1/users/me', {
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+    'Notion-Version': '2022-06-28',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+};
+
+export const validateFigmaToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'pat');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://api.figma.com/v1/me', {
+    'X-Figma-Token': (cred as { value: string }).value,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+};
+
+export const validateHoneycombToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, 'https://api.honeycomb.io/1/auth', {
+    'X-Honeycomb-Team': (cred as { value: string }).value,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+};
+
+export const validateAxiomToken = makeBearerValidator(
+  'https://api.axiom.co/v1/user',
+);
+
+export const validateNeonToken = makeBearerValidator(
+  'https://console.neon.tech/api/v2/users/me',
+);
+
+export const validateSupabaseKey: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'service_role_key');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const projectUrl = (input.choices['projectUrl'] as string) ?? '';
+  if (!projectUrl) {
+    return fail(input.providerId, 'choice_invalid', 'projectUrl is required');
+  }
+  const probe = await probeUrl(ctx, `${projectUrl}/rest/v1/`, {
+    apikey: (cred as { value: string }).value,
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', {}));
+};
+
+export const validatePostHogToken = makeBearerValidator(
+  'https://app.posthog.com/api/users/@me/',
+);
+
+export const validatePlausibleToken = makeBearerValidator(
+  'https://plausible.io/api/v1/sites',
+);
+
+export const validateAnthropicKey: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'anthropic_api_key');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  // Use the 1-token ping pattern from the spec — POST /v1/messages with
+  // max_tokens=1. A 400 with "invalid api key" obviously fails; a 200
+  // or 200-shaped error from the model means the key is good.
+  const probe = await probeUrl(
+    ctx,
+    'https://api.anthropic.com/v1/messages',
+    {
+      'x-api-key': (cred as { value: string }).value,
+      'anthropic-version': '2023-06-01',
+      'Content-Type': 'application/json',
+    },
+    'POST',
+    JSON.stringify({
+      model: 'claude-haiku-4-5',
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
+  );
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  // Both 200 and 200-shaped errors from the model imply the key was
+  // accepted; only 401/403 indicate a bad key.
+  if (probe.res.status === 401 || probe.res.status === 403) {
+    return fail(input.providerId, 'token_invalid', 'Anthropic rejected the API key');
+  }
+  if (probe.res.status >= 500) {
+    return fail(input.providerId, 'provider_error', `Anthropic ${probe.res.status}`);
+  }
+  return asResult(ok(input.providerId, 'api_token', {}));
+};
+
+export const validateStripePaymentMethod: Validator = async (input, ctx) => {
+  // Stripe payment method ids are validated by attaching them to a
+  // customer; here we just confirm the format (`pm_...`) before
+  // accepting. Real attachment happens at provisioning time.
+  const cred = requireCredential(input, 'stripe_payment_method_id');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const v = (cred as { value: string }).value;
+  if (!/^pm_[A-Za-z0-9_]+$/.test(v)) {
+    return fail(input.providerId, 'choice_invalid', 'not a Stripe payment_method id (expected pm_...)');
+  }
+  // No external probe — silent ok; engine still writes audit row.
+  // Use `ctx.now()` to keep the signature parameter referenced.
+  void ctx.now();
+  return asResult(ok(input.providerId, 'api_token', {}));
+};
+
+export const validateCloudinaryKey: Validator = async (input, ctx) => {
+  const ak = requireCredential(input, 'api_key');
+  if ('ok' in ak && ak.ok !== true) return ak;
+  const sk = requireCredential(input, 'api_secret');
+  if ('ok' in sk && sk.ok !== true) return sk;
+  const cloud = (input.choices['cloudName'] as string) ?? '';
+  if (!cloud) {
+    return fail(input.providerId, 'choice_invalid', 'cloudName is required');
+  }
+  const auth = Buffer.from(
+    `${(ak as { value: string }).value}:${(sk as { value: string }).value}`,
+  ).toString('base64');
+  const probe = await probeUrl(
+    ctx,
+    `https://api.cloudinary.com/v1_1/${cloud}/usage`,
+    { Authorization: `Basic ${auth}` },
+  );
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  return asResult(ok(input.providerId, 'api_token', probe.json ?? {}));
+};

--- a/packages/onboarding/src/validators/aws.ts
+++ b/packages/onboarding/src/validators/aws.ts
@@ -1,0 +1,164 @@
+/**
+ * AWS validator — STS GetCallerIdentity is the canonical noop probe.
+ * AWS Signature V4 is non-trivial; rather than re-implementing it we
+ * issue a raw HTTPS POST to the global STS endpoint with a v4 signed
+ * Authorization header constructed inline.
+ *
+ * Implementation is a faithful subset of SigV4 sufficient for the
+ * `sts:GetCallerIdentity` action, which carries no payload.
+ *
+ * Reference: https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+ */
+
+import type { Validator } from '../types.js';
+import { asResult, fail, ok, requireCredential } from './util.js';
+
+// We can't use webcrypto from inside a synchronous function reliably
+// across Node 18+ and the edge runtime, so we compute SigV4 with the
+// platform's crypto.subtle.
+async function hmac(key: ArrayBuffer | Uint8Array, data: string): Promise<ArrayBuffer> {
+  const k = await globalThis.crypto.subtle.importKey(
+    'raw',
+    key instanceof Uint8Array ? key : new Uint8Array(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  return globalThis.crypto.subtle.sign('HMAC', k, new TextEncoder().encode(data));
+}
+
+async function sha256Hex(data: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(data),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function toHex(buf: ArrayBuffer): string {
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function amzDate(d: Date): { amzDate: string; dateStamp: string } {
+  const amz = d.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  return { amzDate: amz, dateStamp: amz.slice(0, 8) };
+}
+
+async function signSts(
+  accessKey: string,
+  secretKey: string,
+  region: string,
+  now: Date,
+  body: string,
+): Promise<{ headers: Record<string, string>; url: string }> {
+  const { amzDate: amz, dateStamp } = amzDate(now);
+  const host = `sts.${region}.amazonaws.com`;
+  const service = 'sts';
+  const algorithm = 'AWS4-HMAC-SHA256';
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+
+  const canonicalUri = '/';
+  const canonicalQs = '';
+  const payloadHash = await sha256Hex(body);
+  const canonicalHeaders =
+    `content-type:application/x-www-form-urlencoded; charset=utf-8\n` +
+    `host:${host}\n` +
+    `x-amz-date:${amz}\n`;
+  const signedHeaders = 'content-type;host;x-amz-date';
+  const canonicalRequest = [
+    'POST',
+    canonicalUri,
+    canonicalQs,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+  const canonicalRequestHash = await sha256Hex(canonicalRequest);
+  const stringToSign = [algorithm, amz, credentialScope, canonicalRequestHash].join('\n');
+
+  const kDate = await hmac(new TextEncoder().encode(`AWS4${secretKey}`), dateStamp);
+  const kRegion = await hmac(kDate, region);
+  const kService = await hmac(kRegion, service);
+  const kSigning = await hmac(kService, 'aws4_request');
+  const signature = toHex(await hmac(kSigning, stringToSign));
+
+  const authorization =
+    `${algorithm} Credential=${accessKey}/${credentialScope}, ` +
+    `SignedHeaders=${signedHeaders}, ` +
+    `Signature=${signature}`;
+
+  return {
+    url: `https://${host}/`,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+      'X-Amz-Date': amz,
+      Authorization: authorization,
+    },
+  };
+}
+
+export const validateAwsSts: Validator = async (input, ctx) => {
+  const ak = requireCredential(input, 'access_key_id');
+  if ('ok' in ak && ak.ok !== true) return ak;
+  const sk = requireCredential(input, 'secret_access_key');
+  if ('ok' in sk && sk.ok !== true) return sk;
+  const region = (input.choices['region'] as string) ?? 'us-east-1';
+
+  let signed: { url: string; headers: Record<string, string> };
+  try {
+    signed = await signSts(
+      (ak as { value: string }).value,
+      (sk as { value: string }).value,
+      region,
+      ctx.now(),
+      'Action=GetCallerIdentity&Version=2011-06-15',
+    );
+  } catch (e) {
+    return fail(
+      input.providerId,
+      'provider_error',
+      `AWS signing error: ${(e as Error).message}`,
+    );
+  }
+  let res: Response;
+  try {
+    res = await ctx.fetch(signed.url, {
+      method: 'POST',
+      headers: signed.headers,
+      body: 'Action=GetCallerIdentity&Version=2011-06-15',
+    });
+  } catch (e) {
+    return fail(
+      input.providerId,
+      'network_error',
+      `AWS network error: ${(e as Error).message}`,
+    );
+  }
+  const text = await res.text();
+  if (res.status === 403) {
+    return fail(
+      input.providerId,
+      'token_invalid',
+      'AWS STS returned 403 — bad keys or insufficient policy',
+    );
+  }
+  if (res.status >= 500) {
+    return fail(input.providerId, 'provider_error', `AWS STS ${res.status}`);
+  }
+  if (res.status !== 200) {
+    return fail(input.providerId, 'provider_error', `AWS STS ${res.status}: ${text}`);
+  }
+  const accountMatch = text.match(/<Account>([^<]+)<\/Account>/);
+  const arnMatch = text.match(/<Arn>([^<]+)<\/Arn>/);
+  return asResult(
+    ok(input.providerId, 'api_token', {
+      accountId: accountMatch?.[1] ?? null,
+      arn: arnMatch?.[1] ?? null,
+      region,
+    }),
+  );
+};

--- a/packages/onboarding/src/validators/cloudflare.ts
+++ b/packages/onboarding/src/validators/cloudflare.ts
@@ -1,0 +1,53 @@
+/**
+ * Cloudflare validator — used by cloud / dns / cdn / domain categories.
+ * Hits `GET https://api.cloudflare.com/client/v4/user/tokens/verify`
+ * which returns 200 with `{ result: { status: 'active', id: ... } }`
+ * when the token is valid. Inactive / expired tokens come back 401.
+ */
+
+import type { Validator } from '../types.js';
+import {
+  asResult,
+  assertOkResponse,
+  fail,
+  ok,
+  probeUrl,
+  requireCredential,
+} from './util.js';
+
+const CF_API = 'https://api.cloudflare.com/client/v4';
+
+export const validateCloudflareToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, `${CF_API}/user/tokens/verify`, {
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+    'Content-Type': 'application/json',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const success = (probe.json?.['success'] as boolean) ?? false;
+  if (!success) {
+    return fail(
+      input.providerId,
+      'token_invalid',
+      'Cloudflare reported the token is not active',
+      'Create a new token at https://dash.cloudflare.com/profile/api-tokens',
+    );
+  }
+  const result = (probe.json?.['result'] as Record<string, unknown>) ?? {};
+  if (result['status'] !== 'active') {
+    return fail(
+      input.providerId,
+      'token_expired',
+      `Cloudflare token status: ${String(result['status'])}`,
+    );
+  }
+  return asResult(
+    ok(input.providerId, 'api_token', {
+      tokenId: result['id'] ?? null,
+      expiresOn: result['expires_on'] ?? null,
+    }),
+  );
+};

--- a/packages/onboarding/src/validators/dns.ts
+++ b/packages/onboarding/src/validators/dns.ts
@@ -1,0 +1,84 @@
+/**
+ * DNS proof-of-control validator (Archetype C from the spec).
+ * Customer is shown a `_caia-verify-<tenantId>` TXT record value;
+ * they place it; we poll authoritative nameservers (via Cloudflare's
+ * DNS-over-HTTPS resolver as a stand-in for direct authoritative dig)
+ * and pass when the record appears.
+ */
+
+import type { Validator, ValidatorContext } from '../types.js';
+import { asResult, fail, ok } from './util.js';
+
+const DOH = 'https://cloudflare-dns.com/dns-query';
+
+interface DohAnswer {
+  name: string;
+  type: number;
+  data: string;
+}
+
+async function dohQuery(
+  ctx: ValidatorContext,
+  name: string,
+  type = 'TXT',
+): Promise<DohAnswer[]> {
+  const url = `${DOH}?name=${encodeURIComponent(name)}&type=${type}`;
+  const res = await ctx.fetch(url, {
+    headers: { Accept: 'application/dns-json' },
+  });
+  if (!res.ok) return [];
+  const j = (await res.json().catch(() => null)) as
+    | { Answer?: DohAnswer[] }
+    | null;
+  return j?.Answer ?? [];
+}
+
+export const validateDnsProof: Validator = async (input, ctx) => {
+  const zone = (input.choices['zone'] as string) ?? '';
+  const expected = (input.credentials['dns_proof_token'] ?? '').trim();
+  if (!zone || !expected) {
+    return fail(input.providerId, 'choice_invalid', 'zone + dns_proof_token required');
+  }
+  const recordName = `_caia-verify-${input.tenantId}.${zone}`;
+  const answers = await dohQuery(ctx, recordName, 'TXT');
+  // TXT data comes back with surrounding quotes in JSON form
+  const seen = answers
+    .map((a) => a.data.replace(/^"|"$/g, ''))
+    .filter((d) => d.length > 0);
+  if (!seen.includes(expected)) {
+    return fail(
+      input.providerId,
+      'token_invalid',
+      `TXT record ${recordName} did not contain expected value`,
+      'Place the TXT record then re-run validation; DNS propagation can take several minutes',
+    );
+  }
+  return asResult(
+    ok(input.providerId, 'dns', { recordName, observed: seen.length }),
+  );
+};
+
+export const validateDatabaseDsn: Validator = async (input, ctx) => {
+  // Archetype E — endpoint reach. We don't open a TCP socket here
+  // (Node-only); we sanity-check the DSN format and defer real reach
+  // to the database-provisioner. The engine still records the
+  // credential securely.
+  void ctx;
+  const dsn = input.credentials['dsn'];
+  if (!dsn) {
+    return fail(input.providerId, 'choice_invalid', 'dsn is required');
+  }
+  if (!/^postgres(ql)?:\/\//.test(dsn)) {
+    return fail(
+      input.providerId,
+      'choice_invalid',
+      'DSN must start with postgres:// or postgresql://',
+    );
+  }
+  try {
+    new URL(dsn);
+  } catch {
+    return fail(input.providerId, 'choice_invalid', 'DSN is not a parseable URL');
+  }
+  return asResult(ok(input.providerId, 'endpoint', { dsnFormat: 'postgres' }));
+};

--- a/packages/onboarding/src/validators/github.ts
+++ b/packages/onboarding/src/validators/github.ts
@@ -1,0 +1,78 @@
+/**
+ * GitHub validators.
+ *
+ * Two flavours:
+ *  - `validateGithubToken` — used by repo / ci / pm-issues categories.
+ *    Hits `GET https://api.github.com/user` and reads the
+ *    `X-OAuth-Scopes` header to confirm granted scopes.
+ *  - `validateGithubOAuth` — same endpoint, treated as an OAuth refresh
+ *    token (the wizard already exchanged code for token before calling
+ *    the engine). The two are kept distinct so the audit log records the
+ *    archetype the customer chose.
+ */
+
+import type { Validator } from '../types.js';
+import {
+  asResult,
+  assertOkResponse,
+  fail,
+  ok,
+  probeUrl,
+  requireCredential,
+  scopesSatisfied,
+} from './util.js';
+
+const GITHUB_API = 'https://api.github.com';
+
+function parseScopes(header: string | null): string[] {
+  if (!header) return [];
+  return header
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export const validateGithubToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, `${GITHUB_API}/user`, {
+    Authorization: `token ${(cred as { value: string }).value}`,
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'caia-onboarding/0.1',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const scopes = parseScopes(probe.res.headers.get('X-OAuth-Scopes'));
+  const required = ['repo'];
+  if (!scopesSatisfied(required, scopes)) {
+    return fail(
+      input.providerId,
+      'scope_insufficient',
+      `missing required GitHub scopes: ${required.join(',')}`,
+      'Create a new token at https://github.com/settings/tokens/new?scopes=repo,workflow',
+    );
+  }
+  const login = (probe.json?.['login'] as string) ?? null;
+  const id = (probe.json?.['id'] as number) ?? null;
+  return asResult(
+    ok(input.providerId, 'api_token', { login, id }, scopes),
+  );
+};
+
+export const validateGithubOAuth: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'oauth_refresh_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, `${GITHUB_API}/user`, {
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'caia-onboarding/0.1',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const scopes = parseScopes(probe.res.headers.get('X-OAuth-Scopes'));
+  return asResult(
+    ok(input.providerId, 'oauth', { login: probe.json?.['login'] ?? null }, scopes),
+  );
+};

--- a/packages/onboarding/src/validators/identity.ts
+++ b/packages/onboarding/src/validators/identity.ts
@@ -1,0 +1,68 @@
+/**
+ * Identity validator — applied to category #1 (Identity & contact).
+ * Verifies the owner's email domain has at least one MX record (rejects
+ * obvious disposable-mail patterns) and validates the chosen timezone +
+ * locale strings against the IANA tables built into the runtime.
+ */
+
+import type { Validator } from '../types.js';
+import { asResult, fail, ok } from './util.js';
+
+// A short list — the production rejection list lives in a maintained
+// dataset; this is sufficient for the wizard's first-line defence.
+const DISPOSABLE_DOMAINS = new Set<string>([
+  'mailinator.com',
+  '10minutemail.com',
+  'tempmail.com',
+  'guerrillamail.com',
+  'getnada.com',
+  'yopmail.com',
+  'dispostable.com',
+]);
+
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidLocale(loc: string): boolean {
+  try {
+    return new Intl.Locale(loc).baseName.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export const validateIdentity: Validator = async (input, ctx) => {
+  void ctx;
+  const email = (input.choices['ownerEmail'] as string) ?? '';
+  if (!email || !email.includes('@')) {
+    return fail(input.providerId, 'choice_invalid', 'ownerEmail is required');
+  }
+  const domain = email.split('@')[1]?.toLowerCase() ?? '';
+  if (!domain) {
+    return fail(input.providerId, 'choice_invalid', 'email missing domain');
+  }
+  if (DISPOSABLE_DOMAINS.has(domain)) {
+    return fail(
+      input.providerId,
+      'choice_invalid',
+      `disposable email provider rejected: ${domain}`,
+    );
+  }
+  const tz = (input.choices['timezone'] as string) ?? 'UTC';
+  if (!isValidTimezone(tz)) {
+    return fail(input.providerId, 'choice_invalid', `invalid IANA timezone: ${tz}`);
+  }
+  const locale = (input.choices['locale'] as string) ?? 'en-US';
+  if (!isValidLocale(locale)) {
+    return fail(input.providerId, 'choice_invalid', `invalid locale: ${locale}`);
+  }
+  return asResult(
+    ok(input.providerId, 'api_token', { domain, timezone: tz, locale }),
+  );
+};

--- a/packages/onboarding/src/validators/index.ts
+++ b/packages/onboarding/src/validators/index.ts
@@ -1,0 +1,199 @@
+/**
+ * Validator dispatch — looks up (category, provider) → strategy.
+ *
+ * Providers with `noCredentials: true` short-circuit to a synthetic
+ * success result; the wizard still writes a `customer_choices` row but
+ * no credential row.
+ */
+
+import type {
+  CategoryId,
+  Validator,
+  ValidatorContext,
+  ValidatorInput,
+  ValidatorResult,
+} from '../types.js';
+import { getCategory, getProvider } from '../categories/index.js';
+import { defaultContext, asResult, ok } from './util.js';
+
+import {
+  validateGithubToken,
+  validateGithubOAuth,
+} from './github.js';
+import { validateCloudflareToken } from './cloudflare.js';
+import { validateAwsSts } from './aws.js';
+import { validateResendToken } from './resend.js';
+import { validateIdentity } from './identity.js';
+import { validateDnsProof, validateDatabaseDsn } from './dns.js';
+import {
+  validateAnthropicKey,
+  validateAxiomToken,
+  validateBitbucketToken,
+  validateBuildkiteToken,
+  validateCircleCiToken,
+  validateCloudinaryKey,
+  validateFigmaToken,
+  validateFlyToken,
+  validateGitlabToken,
+  validateHoneycombToken,
+  validateJiraToken,
+  validateLinearToken,
+  validateNeonToken,
+  validateNotionToken,
+  validatePlausibleToken,
+  validatePostHogToken,
+  validatePostmarkToken,
+  validateSendgridToken,
+  validateSentryToken,
+  validateStripePaymentMethod,
+  validateSupabaseKey,
+  validateVercelToken,
+} from './api-tokens.js';
+
+/** Composite key: `${categoryId}:${providerId}`. */
+type Key = `${CategoryId}:${string}`;
+
+/** Authoritative registry of validators. */
+export const VALIDATORS: Record<Key, Validator> = {
+  // Identity
+  'identity:self': validateIdentity,
+
+  // Auth
+  'auth:github': validateGithubOAuth,
+  'auth:google': validateGithubOAuth, // OAuth shape; uses bearer probe
+  'auth:apple': validateGithubOAuth,
+  'auth:microsoft': validateGithubOAuth,
+
+  // Pricing
+  'pricing:byok': validateAnthropicKey,
+  'pricing:credits': validateStripePaymentMethod,
+
+  // Repo
+  'repo:github': validateGithubToken,
+  'repo:gitlab': validateGitlabToken,
+  'repo:bitbucket': validateBitbucketToken,
+
+  // CI
+  'ci:github-actions': validateGithubToken,
+  'ci:circleci': validateCircleCiToken,
+  'ci:buildkite': validateBuildkiteToken,
+
+  // Cloud
+  'cloud:cloudflare-pages': validateCloudflareToken,
+  'cloud:aws': validateAwsSts,
+  'cloud:vercel': validateVercelToken,
+  'cloud:fly': validateFlyToken,
+
+  // Domain
+  'domain:cloudflare-registrar': validateCloudflareToken,
+  'domain:namecheap': validateCloudflareToken, // placeholder — namecheap-api shape
+
+  // DNS
+  'dns:cloudflare-dns': validateCloudflareToken,
+  'dns:route53': validateAwsSts,
+  'dns:manual-dns-proof': validateDnsProof,
+
+  // CDN
+  'cdn:cloudflare-r2': validateCloudflareToken,
+  'cdn:aws-cloudfront-s3': validateAwsSts,
+  'cdn:cloudinary': validateCloudinaryKey,
+
+  // Database
+  'database:self-hosted-postgres': validateDatabaseDsn,
+  'database:supabase': validateSupabaseKey,
+  'database:neon': validateNeonToken,
+
+  // Email
+  'email:resend': validateResendToken,
+  'email:postmark': validatePostmarkToken,
+  'email:sendgrid': validateSendgridToken,
+
+  // Analytics
+  'analytics:plausible-cloud': validatePlausibleToken,
+  'analytics:posthog-cloud': validatePostHogToken,
+
+  // Errors
+  'errors:sentry': validateSentryToken,
+
+  // Observability
+  'observability:honeycomb': validateHoneycombToken,
+  'observability:axiom': validateAxiomToken,
+
+  // PM / issue tracker
+  'pm:linear': validateLinearToken,
+  'pm:jira-cloud': validateJiraToken,
+  'pm:github-issues': validateGithubToken,
+
+  // Docs / Design / Compliance / Anthropic prefs (optional)
+  'docs:notion': validateNotionToken,
+  'design:figma': validateFigmaToken,
+  'compliance:self': async (input, ctx) => {
+    void ctx;
+    return asResult(ok(input.providerId, 'api_token', input.choices));
+  },
+  'anthropic_prefs:preferences': async (input, ctx) => {
+    void ctx;
+    return asResult(ok(input.providerId, 'api_token', input.choices));
+  },
+};
+
+export function resolveValidator(
+  categoryId: string,
+  providerId: string,
+): Validator | undefined {
+  return VALIDATORS[`${categoryId}:${providerId}` as Key];
+}
+
+/**
+ * Validate a single (category, provider) submission, dispatching via
+ * the static catalog. Returns a discriminated `ValidatorResult`.
+ *
+ * - `noCredentials: true` providers (e.g. `caia-managed`) short-circuit
+ *   to a synthetic success.
+ * - Missing dispatch entry => `choice_invalid`.
+ */
+export async function validate(
+  input: ValidatorInput,
+  ctx: ValidatorContext = defaultContext(),
+): Promise<ValidatorResult> {
+  const cat = getCategory(input.category);
+  if (!cat) {
+    return {
+      ok: false,
+      providerId: input.providerId,
+      errorCode: 'choice_invalid',
+      message: `unknown category: ${input.category}`,
+    };
+  }
+  const provider = getProvider(input.category, input.providerId);
+  if (!provider) {
+    return {
+      ok: false,
+      providerId: input.providerId,
+      errorCode: 'choice_invalid',
+      message: `unknown provider for ${input.category}: ${input.providerId}`,
+    };
+  }
+  if (provider.noCredentials) {
+    return ok(input.providerId, provider.archetype, { managed: true });
+  }
+  const validator = resolveValidator(input.category, input.providerId);
+  if (!validator) {
+    return {
+      ok: false,
+      providerId: input.providerId,
+      errorCode: 'choice_invalid',
+      message: `no validator registered for ${input.category}:${input.providerId}`,
+    };
+  }
+  return validator(input, ctx);
+}
+
+export * from './util.js';
+export * from './github.js';
+export * from './cloudflare.js';
+export * from './aws.js';
+export * from './resend.js';
+export * from './identity.js';
+export * from './dns.js';
+export * from './api-tokens.js';

--- a/packages/onboarding/src/validators/resend.ts
+++ b/packages/onboarding/src/validators/resend.ts
@@ -1,0 +1,32 @@
+/**
+ * Resend transactional-email validator.
+ * Hits `GET https://api.resend.com/domains` which lists verified sender
+ * domains; 200 confirms the token is valid, 401 invalidates.
+ */
+
+import type { Validator } from '../types.js';
+import {
+  asResult,
+  assertOkResponse,
+  ok,
+  probeUrl,
+  requireCredential,
+} from './util.js';
+
+const RESEND_API = 'https://api.resend.com';
+
+export const validateResendToken: Validator = async (input, ctx) => {
+  const cred = requireCredential(input, 'api_token');
+  if ('ok' in cred && cred.ok !== true) return cred;
+  const probe = await probeUrl(ctx, `${RESEND_API}/domains`, {
+    Authorization: `Bearer ${(cred as { value: string }).value}`,
+    'Content-Type': 'application/json',
+  });
+  if (!probe.ok) return { ...probe, providerId: input.providerId };
+  const httpFail = assertOkResponse(input.providerId, probe);
+  if (httpFail) return httpFail;
+  const data = (probe.json?.['data'] as Array<Record<string, unknown>>) ?? [];
+  return asResult(
+    ok(input.providerId, 'api_token', { domainCount: data.length }),
+  );
+};

--- a/packages/onboarding/src/validators/util.ts
+++ b/packages/onboarding/src/validators/util.ts
@@ -1,0 +1,144 @@
+/**
+ * Shared validator helpers.
+ *
+ * Each provider validator follows the same shape: take credentials,
+ * call a noop endpoint, classify the response into a ValidatorResult.
+ *
+ * Reference: research/step1_onboarding_spec_2026.md §2.
+ */
+
+import type {
+  Archetype,
+  ValidatorContext,
+  ValidatorFailure,
+  ValidatorResult,
+  ValidatorSuccess,
+} from '../types.js';
+
+export function ok(
+  providerId: string,
+  archetype: Archetype,
+  metadata: Record<string, unknown> = {},
+  scopesGranted: string[] = [],
+): ValidatorSuccess {
+  return {
+    ok: true,
+    providerId,
+    archetype,
+    scopesGranted,
+    metadata,
+  };
+}
+
+export function fail(
+  providerId: string,
+  errorCode: ValidatorFailure['errorCode'],
+  message: string,
+  retryHint?: string,
+): ValidatorFailure {
+  return retryHint === undefined
+    ? { ok: false, providerId, errorCode, message }
+    : { ok: false, providerId, errorCode, message, retryHint };
+}
+
+export function classifyHttp(status: number): ValidatorFailure['errorCode'] {
+  if (status === 401 || status === 403) return 'token_invalid';
+  if (status === 429) return 'rate_limited';
+  if (status >= 500) return 'provider_error';
+  if (status === 400 || status === 422) return 'choice_invalid';
+  return 'provider_error';
+}
+
+export async function safeJson(
+  response: Response,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const t = await response.text();
+    if (!t) return null;
+    return JSON.parse(t) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export type ProbeOk = {
+  ok: true;
+  res: Response;
+  json: Record<string, unknown> | null;
+};
+export type ProbeOutcome = ProbeOk | ValidatorFailure;
+
+export async function probeUrl(
+  ctx: ValidatorContext,
+  url: string,
+  headers: Record<string, string>,
+  method = 'GET',
+  body?: string,
+  providerId = 'unknown',
+): Promise<ProbeOutcome> {
+  let res: Response;
+  try {
+    const init: RequestInit = { method, headers };
+    if (body !== undefined) init.body = body;
+    res = await ctx.fetch(url, init);
+  } catch (e) {
+    return {
+      ok: false,
+      providerId,
+      errorCode: 'network_error',
+      message: `network error: ${(e as Error).message}`,
+    };
+  }
+  const json = await safeJson(res);
+  return { ok: true, res, json };
+}
+
+/** Verifies that every required scope appears in the granted list. */
+export function scopesSatisfied(
+  required: readonly string[],
+  granted: readonly string[],
+): boolean {
+  return required.every((s) => granted.includes(s));
+}
+
+export function requireCredential(
+  input: { credentials: Record<string, string> },
+  keyId: string,
+): { ok: true; value: string } | ValidatorFailure {
+  const v = input.credentials[keyId];
+  if (!v || v.trim().length === 0) {
+    return {
+      ok: false,
+      providerId: 'unknown',
+      errorCode: 'choice_invalid',
+      message: `missing required credential: ${keyId}`,
+    };
+  }
+  return { ok: true, value: v };
+}
+
+/** Build a default context using global fetch + system clock. */
+export function defaultContext(): ValidatorContext {
+  return {
+    fetch: globalThis.fetch.bind(globalThis),
+    now: () => new Date(),
+  };
+}
+
+/** Convenience: ensure a probe returned 2xx, else return a typed failure. */
+export function assertOkResponse(
+  providerId: string,
+  probe: ProbeOk,
+): ValidatorFailure | null {
+  if (probe.res.status >= 200 && probe.res.status < 300) return null;
+  return fail(
+    providerId,
+    classifyHttp(probe.res.status),
+    `provider returned HTTP ${probe.res.status}`,
+  );
+}
+
+/** Compose a discriminated ValidatorResult from common shapes. */
+export function asResult(r: ValidatorFailure | ValidatorSuccess): ValidatorResult {
+  return r;
+}

--- a/packages/onboarding/tests/categories.test.ts
+++ b/packages/onboarding/tests/categories.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_CATEGORIES,
+  MANDATORY_CATEGORY_IDS,
+  OPTIONAL_CATEGORY_IDS,
+  getCategory,
+  getProvider,
+} from '../src/categories/index.js';
+
+describe('category catalog', () => {
+  it('has 19 categories total', () => {
+    expect(ALL_CATEGORIES.length).toBe(19);
+  });
+
+  it('has 15 mandatory categories', () => {
+    expect(MANDATORY_CATEGORY_IDS.length).toBe(15);
+    expect(ALL_CATEGORIES.filter((c) => c.required).length).toBe(15);
+  });
+
+  it('has 4 optional categories', () => {
+    expect(OPTIONAL_CATEGORY_IDS.length).toBe(4);
+    expect(ALL_CATEGORIES.filter((c) => !c.required).length).toBe(4);
+  });
+
+  it('assigns each category a unique ordinal 1..19', () => {
+    const ords = ALL_CATEGORIES.map((c) => c.ordinal).sort((a, b) => a - b);
+    expect(ords).toEqual(Array.from({ length: 19 }, (_, i) => i + 1));
+  });
+
+  it('all category ids are unique', () => {
+    const ids = ALL_CATEGORIES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every category has at least one provider', () => {
+    for (const c of ALL_CATEGORIES) {
+      expect(c.providers.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every provider id is unique within its category', () => {
+    for (const c of ALL_CATEGORIES) {
+      const ids = c.providers.map((p) => p.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+
+  it('returns the right category via getCategory', () => {
+    expect(getCategory('repo')?.id).toBe('repo');
+    expect(getCategory('does-not-exist')).toBeUndefined();
+  });
+
+  it('returns the right provider via getProvider', () => {
+    expect(getProvider('repo', 'github')?.id).toBe('github');
+    expect(getProvider('repo', 'no-such')).toBeUndefined();
+    expect(getProvider('nope', 'github')).toBeUndefined();
+  });
+
+  it('noCredentials providers carry empty credentialDescriptors', () => {
+    for (const c of ALL_CATEGORIES) {
+      for (const p of c.providers) {
+        if (p.noCredentials) {
+          expect(p.credentialDescriptors).toEqual([]);
+        }
+      }
+    }
+  });
+
+  it('credentialDescriptors archetypes match provider archetype where storeSecret=true', () => {
+    for (const c of ALL_CATEGORIES) {
+      for (const p of c.providers) {
+        for (const d of p.credentialDescriptors) {
+          if (d.storeSecret) {
+            // archetype must be one of the 5
+            expect([
+              'oauth',
+              'api_token',
+              'dns',
+              'webhook',
+              'endpoint',
+            ]).toContain(d.archetype);
+          }
+        }
+      }
+    }
+  });
+});

--- a/packages/onboarding/tests/engine.test.ts
+++ b/packages/onboarding/tests/engine.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OnboardingEngine } from '../src/engine/engine.js';
+import { InMemoryOnboardingStore } from '../src/store/in-memory.js';
+import { mockFetch, fixedContext, fakeSecretsPutter } from './helpers.js';
+import { MANDATORY_CATEGORY_IDS } from '../src/categories/index.js';
+import type { TenantRow } from '../src/types.js';
+
+async function setup(): Promise<{
+  engine: OnboardingEngine;
+  store: InMemoryOnboardingStore;
+  tenant: TenantRow;
+  secrets: ReturnType<typeof fakeSecretsPutter>;
+}> {
+  const store = new InMemoryOnboardingStore();
+  const secrets = fakeSecretsPutter();
+  const tenant = await store.createTenant({
+    slug: 'acme',
+    name: 'Acme',
+    ownerEmail: 'p@acme.com',
+    billingEmail: 'p@acme.com',
+    timezone: 'UTC',
+    locale: 'en-US',
+  });
+  const { fetch } = mockFetch({
+    'https://api.github.com/user': {
+      status: 200,
+      body: { login: 'octo', id: 1 },
+      headers: { 'X-OAuth-Scopes': 'repo, workflow' },
+    },
+    'https://api.cloudflare.com/client/v4/user/tokens/verify': {
+      status: 200,
+      body: { success: true, result: { id: 't', status: 'active' } },
+    },
+    'https://api.resend.com/domains': {
+      status: 200,
+      body: { data: [{ id: 'd' }] },
+    },
+    'https://sentry.io/api/0/organizations/': { status: 200, body: [] },
+    'https://api.linear.app/graphql': {
+      status: 200,
+      body: { data: { viewer: { id: 'v' } } },
+    },
+    'https://app.posthog.com/api/users/@me/': { status: 200, body: { id: 'u' } },
+    'https://api.axiom.co/v1/user': { status: 200, body: { id: 'u' } },
+    'https://api.honeycomb.io/1/auth': { status: 200, body: { team: {} } },
+    'https://api.anthropic.com/v1/messages': { status: 200, body: {} },
+  });
+  const engine = new OnboardingEngine({
+    store,
+    secrets,
+    validatorCtx: fixedContext(fetch),
+  });
+  return { engine, store, tenant, secrets };
+}
+
+describe('OnboardingEngine — basic flow', () => {
+  let env: Awaited<ReturnType<typeof setup>>;
+  beforeEach(async () => {
+    env = await setup();
+  });
+
+  it('lists all 19 categories', () => {
+    expect(env.engine.categories().length).toBe(19);
+  });
+
+  it('initial state.current points to identity (first required)', async () => {
+    const st = await env.engine.stateFor(env.tenant.id);
+    expect(st.current?.id).toBe('identity');
+    expect(st.ready).toBe(false);
+  });
+
+  it('submitStep with caia-managed (no creds) marks passed', async () => {
+    const r = await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'caia-managed',
+      choices: {},
+      credentials: {},
+    });
+    expect(r.status).toBe('passed');
+    expect(r.credentialRefs).toEqual([]);
+  });
+
+  it('submitStep with GitHub PUTs secret into the secrets adapter', async () => {
+    const r = await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    expect(r.status).toBe('passed');
+    expect(env.secrets.puts.length).toBe(1);
+    expect(env.secrets.puts[0]?.value).toBe('gh_xyz');
+    expect(r.credentialRefs[0]).toMatch(/^infisical:\/\//);
+  });
+
+  it('credential row stores secret_ref only, not the raw value', async () => {
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    const creds = await env.store.listCredentials(env.tenant.id);
+    expect(creds.length).toBe(1);
+    expect(creds[0]?.secretRef).toMatch(/^infisical:\/\//);
+    const c = creds[0] as Record<string, unknown>;
+    expect(c['value']).toBeUndefined();
+  });
+
+  it('writes choice rows', async () => {
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: { defaultBranch: 'main' },
+      credentials: { api_token: 'gh_xyz' },
+    });
+    const choices = await env.store.listChoices(env.tenant.id);
+    const provider = choices.find((c) => c.choiceKey === 'provider');
+    const branch = choices.find((c) => c.choiceKey === 'defaultBranch');
+    expect(provider?.choiceValue).toBe('github');
+    expect(branch?.choiceValue).toBe('main');
+  });
+
+  it('audit log records started + passed actions', async () => {
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    const log = await env.store.listAudit(env.tenant.id);
+    const actions = log.map((e) => e.action);
+    expect(actions).toContain('onboarding.step.started');
+    expect(actions).toContain('onboarding.step.passed');
+    expect(actions).toContain('credential.put');
+  });
+
+  it('audit log records failed actions on bad credentials', async () => {
+    const store = new InMemoryOnboardingStore();
+    const { fetch } = mockFetch({
+      'https://api.github.com/user': { status: 401, body: {} },
+    });
+    const engine = new OnboardingEngine({
+      store,
+      secrets: fakeSecretsPutter(),
+      validatorCtx: fixedContext(fetch),
+    });
+    const t = await store.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    const r = await engine.submitStep({
+      tenantId: t.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'bad' },
+    });
+    expect(r.status).toBe('failed');
+    const log = await store.listAudit(t.id);
+    expect(log.some((e) => e.action === 'onboarding.step.failed')).toBe(true);
+    expect(log.some((e) => e.action === 'credential.put')).toBe(false);
+  });
+
+  it('re-submitting the same step is idempotent (no duplicate credential)', async () => {
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    const creds = await env.store.listCredentials(env.tenant.id);
+    expect(creds.length).toBe(1);
+  });
+
+  it('attempt_count rises on each probing', async () => {
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh_xyz' },
+    });
+    const step = await env.store.getStep(env.tenant.id, 'repo');
+    expect(step?.attemptCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('current step advances when previous one passes', async () => {
+    await env.engine.submitStep({
+      tenantId: env.tenant.id,
+      category: 'identity',
+      providerId: 'self',
+      choices: {
+        ownerEmail: 'p@example.com',
+        timezone: 'UTC',
+        locale: 'en-US',
+      },
+      credentials: {},
+    });
+    const st = await env.engine.stateFor(env.tenant.id);
+    expect(st.current?.id).toBe('auth');
+  });
+
+  it('defer is rejected for required categories', async () => {
+    await expect(
+      env.engine.defer(env.tenant.id, 'repo', 'too hard'),
+    ).rejects.toThrow();
+  });
+
+  it('defer is allowed for optional categories', async () => {
+    await env.engine.defer(env.tenant.id, 'docs', 'skip');
+    const step = await env.store.getStep(env.tenant.id, 'docs');
+    expect(step?.status).toBe('deferred');
+  });
+
+  it('tenant is marked onboarded only after every mandatory step is done', async () => {
+    // Use caia-managed everywhere available; sprinkle real validators
+    // where caia-managed is not an option.
+    for (const cat of MANDATORY_CATEGORY_IDS) {
+      const providerByCat: Record<string, { providerId: string; choices?: Record<string, unknown>; credentials?: Record<string, string> }> = {
+        identity: {
+          providerId: 'self',
+          choices: { ownerEmail: 'p@acme.com', timezone: 'UTC', locale: 'en-US' },
+          credentials: {},
+        },
+        auth: { providerId: 'email-magic-link', credentials: {} },
+        pricing: {
+          providerId: 'byok',
+          credentials: { anthropic_api_key: 'sk-ant-x' },
+        },
+        repo: { providerId: 'caia-managed', credentials: {} },
+        ci: { providerId: 'caia-managed', credentials: {} },
+        cloud: { providerId: 'caia-managed', credentials: {} },
+        domain: { providerId: 'none', credentials: {} },
+        dns: { providerId: 'none', credentials: {} },
+        cdn: { providerId: 'caia-managed', credentials: {} },
+        database: { providerId: 'caia-managed', credentials: {} },
+        email: { providerId: 'caia-managed', credentials: {} },
+        analytics: { providerId: 'none', credentials: {} },
+        errors: { providerId: 'cloudflare-logpush', credentials: {} },
+        observability: { providerId: 'none', credentials: {} },
+        pm: { providerId: 'caia-managed', credentials: {} },
+      };
+      const spec = providerByCat[cat];
+      if (!spec) throw new Error(`missing provider for ${cat}`);
+      await env.engine.submitStep({
+        tenantId: env.tenant.id,
+        category: cat,
+        providerId: spec.providerId,
+        choices: spec.choices ?? {},
+        credentials: spec.credentials ?? {},
+      });
+    }
+    const t = await env.store.getTenant(env.tenant.id);
+    expect(t?.onboardingComplete).toBe(true);
+    const log = await env.store.listAudit(env.tenant.id);
+    expect(log.some((e) => e.action === 'onboarding.completed')).toBe(true);
+  });
+
+  it('resume: failed step keeps current pointer on that step', async () => {
+    const store = new InMemoryOnboardingStore();
+    const { fetch } = mockFetch({
+      'https://api.github.com/user': { status: 401, body: {} },
+    });
+    const engine = new OnboardingEngine({
+      store,
+      secrets: fakeSecretsPutter(),
+      validatorCtx: fixedContext(fetch),
+    });
+    const t = await store.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    // identity first (so the next required is auth) — use self
+    await engine.submitStep({
+      tenantId: t.id,
+      category: 'identity',
+      providerId: 'self',
+      choices: { ownerEmail: 'a@b.com', timezone: 'UTC', locale: 'en-US' },
+      credentials: {},
+    });
+    // pricing fails on auth provider — leave as-is
+    const st1 = await engine.stateFor(t.id);
+    expect(st1.current?.id).toBe('auth');
+  });
+});
+
+describe('OnboardingEngine — error handling', () => {
+  it('throws on unknown category', async () => {
+    const store = new InMemoryOnboardingStore();
+    const engine = new OnboardingEngine({
+      store,
+      secrets: fakeSecretsPutter(),
+    });
+    const t = await store.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    await expect(
+      engine.submitStep({
+        tenantId: t.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        category: 'nope' as any,
+        providerId: 'x',
+        choices: {},
+        credentials: {},
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('throws on unknown provider', async () => {
+    const store = new InMemoryOnboardingStore();
+    const engine = new OnboardingEngine({
+      store,
+      secrets: fakeSecretsPutter(),
+    });
+    const t = await store.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    await expect(
+      engine.submitStep({
+        tenantId: t.id,
+        category: 'repo',
+        providerId: 'unknown',
+        choices: {},
+        credentials: {},
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('captures validator throw as provider_error failure', async () => {
+    const store = new InMemoryOnboardingStore();
+    // fetch throws → network_error from validator, not engine throw
+    const fetchImpl = (async () => {
+      throw new Error('connect ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const engine = new OnboardingEngine({
+      store,
+      secrets: fakeSecretsPutter(),
+      validatorCtx: { fetch: fetchImpl, now: () => new Date() },
+    });
+    const t = await store.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    const r = await engine.submitStep({
+      tenantId: t.id,
+      category: 'repo',
+      providerId: 'github',
+      choices: {},
+      credentials: { api_token: 'gh' },
+    });
+    expect(r.status).toBe('failed');
+  });
+
+  it('non-storable credentials (DNS proof) are not PUT into Infisical', async () => {
+    const store = new InMemoryOnboardingStore();
+    const secrets = fakeSecretsPutter();
+    const { fetch } = mockFetch({
+      'https://cloudflare-dns.com/dns-query': {
+        status: 200,
+        body: {
+          Answer: [
+            { name: '_caia-verify-t.example.com.', type: 16, data: '"tok"' },
+          ],
+        },
+      },
+    });
+    const engine = new OnboardingEngine({
+      store,
+      secrets,
+      validatorCtx: { fetch, now: () => new Date() },
+    });
+    const t = await store.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    const r = await engine.submitStep({
+      tenantId: t.id,
+      category: 'dns',
+      providerId: 'manual-dns-proof',
+      choices: { zone: 'example.com' },
+      credentials: { dns_proof_token: 'tok' },
+    });
+    expect(r.status).toBe('passed');
+    expect(secrets.puts.length).toBe(0); // dns proof not stored
+    const log = await store.listAudit(t.id);
+    expect(log.some((e) => e.action === 'credential.validated')).toBe(true);
+  });
+});

--- a/packages/onboarding/tests/helpers.ts
+++ b/packages/onboarding/tests/helpers.ts
@@ -1,0 +1,66 @@
+/**
+ * Test helpers shared across the validator + engine specs.
+ *
+ * Provides a `mockFetch` that returns canned responses keyed by URL
+ * prefix, plus a `fakeSecretsPutter` that records every put and
+ * returns a deterministic secretRef.
+ */
+
+import { vi } from 'vitest';
+import type { SecretsPutter } from '../src/engine/engine.js';
+import type { ValidatorContext } from '../src/types.js';
+
+export interface CannedResponse {
+  status: number;
+  body?: string | Record<string, unknown> | unknown[];
+  headers?: Record<string, string>;
+}
+
+export function mockFetch(
+  routes: Record<string, CannedResponse | ((url: string, init?: RequestInit) => CannedResponse)>,
+): { fetch: typeof fetch; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls.push({ url, ...(init ? { init } : {}) });
+      const route = Object.entries(routes).find(([prefix]) => url.startsWith(prefix));
+      if (!route) {
+        throw new Error(`mockFetch: no canned response for ${url}`);
+      }
+      const handler = typeof route[1] === 'function' ? route[1](url, init) : route[1];
+      const body =
+        typeof handler.body === 'string'
+          ? handler.body
+          : handler.body !== undefined
+            ? JSON.stringify(handler.body)
+            : '';
+      const headers = new Headers(handler.headers ?? {});
+      return new Response(body, { status: handler.status, headers });
+    },
+  ) as unknown as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+export function fixedContext(
+  fetchImpl: typeof fetch,
+  now = new Date('2026-05-23T12:00:00Z'),
+): ValidatorContext {
+  return { fetch: fetchImpl, now: () => now };
+}
+
+export function fakeSecretsPutter(): SecretsPutter & {
+  puts: Array<{ tenantId: string; category: string; key: string; value: string }>;
+} {
+  const puts: Array<{ tenantId: string; category: string; key: string; value: string }> = [];
+  return {
+    puts,
+    async put(tenantId, category, key, value) {
+      puts.push({ tenantId, category, key, value });
+      return {
+        secretRef: `infisical://tenants/${tenantId}/${category}/${key}@v1`,
+        version: 1,
+      };
+    },
+  };
+}

--- a/packages/onboarding/tests/store.test.ts
+++ b/packages/onboarding/tests/store.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryOnboardingStore } from '../src/store/in-memory.js';
+
+describe('InMemoryOnboardingStore', () => {
+  it('creates and retrieves tenants', async () => {
+    const s = new InMemoryOnboardingStore();
+    const t = await s.createTenant({
+      slug: 'acme',
+      name: 'Acme',
+      ownerEmail: 'a@acme.com',
+      billingEmail: 'b@acme.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    expect(t.status).toBe('onboarding');
+    expect(t.onboardingComplete).toBe(false);
+    const got = await s.getTenant(t.id);
+    expect(got?.slug).toBe('acme');
+  });
+
+  it('marks a tenant onboarded', async () => {
+    const s = new InMemoryOnboardingStore();
+    const t = await s.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    await s.markTenantOnboarded(t.id);
+    const after = await s.getTenant(t.id);
+    expect(after?.onboardingComplete).toBe(true);
+    expect(after?.status).toBe('onboarded');
+  });
+
+  it('upserts steps idempotently', async () => {
+    const s = new InMemoryOnboardingStore();
+    const t = await s.createTenant({
+      slug: 's',
+      name: 'n',
+      ownerEmail: 'a@b.com',
+      billingEmail: 'a@b.com',
+      timezone: 'UTC',
+      locale: 'en-US',
+    });
+    await s.upsertStep({
+      tenantId: t.id,
+      category: 'repo',
+      status: 'pending',
+      required: true,
+      attemptCount: 0,
+    });
+    await s.upsertStep({
+      tenantId: t.id,
+      category: 'repo',
+      status: 'passed',
+      required: true,
+      attemptCount: 1,
+    });
+    const steps = await s.listSteps(t.id);
+    expect(steps.length).toBe(1);
+    expect(steps[0]?.status).toBe('passed');
+  });
+
+  it('increments attempt_count on probing', async () => {
+    const s = new InMemoryOnboardingStore();
+    await s.setStepStatus('t', 'repo', 'probing');
+    await s.setStepStatus('t', 'repo', 'probing');
+    const step = await s.getStep('t', 'repo');
+    expect(step?.attemptCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('stores and lists customer choices', async () => {
+    const s = new InMemoryOnboardingStore();
+    await s.putChoice({
+      tenantId: 't',
+      category: 'cloud',
+      choiceKey: 'provider',
+      choiceValue: 'cloudflare-pages',
+      source: 'wizard',
+    });
+    await s.putChoice({
+      tenantId: 't',
+      category: 'cloud',
+      choiceKey: 'region',
+      choiceValue: 'auto',
+      source: 'wizard',
+    });
+    const xs = await s.listChoices('t');
+    expect(xs.length).toBe(2);
+  });
+
+  it('stores and lists credentials (secret_ref only)', async () => {
+    const s = new InMemoryOnboardingStore();
+    await s.putCredential({
+      tenantId: 't',
+      category: 'cloud',
+      keyId: 'api_token',
+      secretRef: 'infisical://tenants/t/cloud/api_token@v1',
+      archetype: 'api_token',
+      provider: 'cloudflare-pages',
+      scopesGranted: ['Account:Read'],
+      scopesRequired: ['Account:Read'],
+      status: 'active',
+      validatedAt: new Date(),
+      metadata: {},
+    });
+    const creds = await s.listCredentials('t');
+    expect(creds.length).toBe(1);
+    expect(creds[0]?.secretRef).toMatch(/^infisical:\/\//);
+    // crucially, no raw secret value stored
+    const c = creds[0] as Record<string, unknown>;
+    expect(c['value']).toBeUndefined();
+  });
+
+  it('audit log is append-only and tenant-scoped', async () => {
+    const s = new InMemoryOnboardingStore();
+    await s.appendAudit({
+      tenantId: 't1',
+      actorType: 'customer',
+      action: 'onboarding.step.passed',
+      payload: { x: 1 },
+      occurredAt: new Date(),
+    });
+    await s.appendAudit({
+      tenantId: 't2',
+      actorType: 'customer',
+      action: 'onboarding.step.passed',
+      payload: { x: 1 },
+      occurredAt: new Date(),
+    });
+    expect((await s.listAudit('t1')).length).toBe(1);
+    expect((await s.listAudit('t2')).length).toBe(1);
+  });
+
+  it('listAudit returns newest first', async () => {
+    const s = new InMemoryOnboardingStore();
+    await s.appendAudit({
+      tenantId: 't',
+      actorType: 'customer',
+      action: 'a.one',
+      payload: {},
+      occurredAt: new Date(2000, 0, 1),
+    });
+    await s.appendAudit({
+      tenantId: 't',
+      actorType: 'customer',
+      action: 'a.two',
+      payload: {},
+      occurredAt: new Date(2026, 0, 1),
+    });
+    const list = await s.listAudit('t');
+    expect(list[0]?.action).toBe('a.two');
+  });
+
+  it('credential lookup returns undefined for unknown key', async () => {
+    const s = new InMemoryOnboardingStore();
+    expect(await s.getCredential('t', 'cloud', 'nope')).toBeUndefined();
+  });
+});

--- a/packages/onboarding/tests/validators-aux.test.ts
+++ b/packages/onboarding/tests/validators-aux.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { validateAwsSts } from '../src/validators/aws.js';
+import { validateIdentity } from '../src/validators/identity.js';
+import { validateDnsProof, validateDatabaseDsn } from '../src/validators/dns.js';
+import { validate, resolveValidator, VALIDATORS } from '../src/validators/index.js';
+import { mockFetch, fixedContext } from './helpers.js';
+
+const baseInput = {
+  tenantId: 't1',
+  category: 'cloud' as const,
+  providerId: 'aws',
+  choices: {},
+  credentials: { access_key_id: 'AKIA', secret_access_key: 'secret' },
+};
+
+describe('AWS validator', () => {
+  it('passes when STS returns a 200 with Account+Arn XML', async () => {
+    const xml = `<GetCallerIdentityResponse>
+      <GetCallerIdentityResult>
+        <Account>123456789012</Account>
+        <Arn>arn:aws:iam::123456789012:user/caia</Arn>
+        <UserId>UID</UserId>
+      </GetCallerIdentityResult>
+    </GetCallerIdentityResponse>`;
+    const { fetch } = mockFetch({
+      'https://sts.us-east-1.amazonaws.com/': {
+        status: 200,
+        body: xml,
+        headers: { 'Content-Type': 'text/xml' },
+      },
+    });
+    const r = await validateAwsSts(baseInput, fixedContext(fetch));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.metadata['accountId']).toBe('123456789012');
+      expect(r.metadata['arn']).toContain('arn:aws:iam');
+    }
+  });
+
+  it('fails on 403', async () => {
+    const { fetch } = mockFetch({
+      'https://sts.us-east-1.amazonaws.com/': { status: 403, body: '' },
+    });
+    const r = await validateAwsSts(baseInput, fixedContext(fetch));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('token_invalid');
+  });
+
+  it('rejects missing keys', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateAwsSts(
+      { ...baseInput, credentials: {} },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('Identity validator', () => {
+  it('passes with a normal email + tz', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateIdentity(
+      {
+        ...baseInput,
+        category: 'identity' as const,
+        providerId: 'self',
+        choices: { ownerEmail: 'p@example.com', timezone: 'America/New_York', locale: 'en-US' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects disposable emails', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateIdentity(
+      {
+        ...baseInput,
+        category: 'identity' as const,
+        providerId: 'self',
+        choices: { ownerEmail: 'foo@mailinator.com' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects invalid timezones', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateIdentity(
+      {
+        ...baseInput,
+        category: 'identity' as const,
+        providerId: 'self',
+        choices: { ownerEmail: 'p@example.com', timezone: 'Mars/Olympus_Mons' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects missing email', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateIdentity(
+      {
+        ...baseInput,
+        category: 'identity' as const,
+        providerId: 'self',
+        choices: {},
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects invalid locales', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateIdentity(
+      {
+        ...baseInput,
+        category: 'identity' as const,
+        providerId: 'self',
+        choices: { ownerEmail: 'p@example.com', locale: '!!!' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('DNS + database validators', () => {
+  it('passes when authoritative TXT matches', async () => {
+    const { fetch } = mockFetch({
+      'https://cloudflare-dns.com/dns-query': {
+        status: 200,
+        body: {
+          Answer: [
+            { name: '_caia-verify-t1.example.com.', type: 16, data: '"caia-token-1"' },
+          ],
+        },
+      },
+    });
+    const r = await validateDnsProof(
+      {
+        tenantId: 't1',
+        category: 'dns' as const,
+        providerId: 'manual-dns-proof',
+        choices: { zone: 'example.com' },
+        credentials: { dns_proof_token: 'caia-token-1' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails when TXT does not contain expected value', async () => {
+    const { fetch } = mockFetch({
+      'https://cloudflare-dns.com/dns-query': {
+        status: 200,
+        body: { Answer: [{ name: '_x', type: 16, data: '"other"' }] },
+      },
+    });
+    const r = await validateDnsProof(
+      {
+        tenantId: 't1',
+        category: 'dns' as const,
+        providerId: 'manual-dns-proof',
+        choices: { zone: 'example.com' },
+        credentials: { dns_proof_token: 'caia-token-1' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('token_invalid');
+  });
+
+  it('rejects bad DSN format', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateDatabaseDsn(
+      {
+        tenantId: 't',
+        category: 'database' as const,
+        providerId: 'self-hosted-postgres',
+        choices: {},
+        credentials: { dsn: 'http://nope' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('passes a parseable postgres DSN', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateDatabaseDsn(
+      {
+        tenantId: 't',
+        category: 'database' as const,
+        providerId: 'self-hosted-postgres',
+        choices: {},
+        credentials: { dsn: 'postgres://u:p@h:5432/db' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Validator dispatch', () => {
+  it('returns ok for noCredentials providers', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validate(
+      {
+        tenantId: 't',
+        category: 'repo' as const,
+        providerId: 'caia-managed',
+        choices: {},
+        credentials: {},
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('returns choice_invalid for unknown category', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validate(
+      {
+        tenantId: 't',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        category: 'nope' as any,
+        providerId: 'whatever',
+        choices: {},
+        credentials: {},
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('returns choice_invalid for unknown provider', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validate(
+      {
+        tenantId: 't',
+        category: 'repo' as const,
+        providerId: 'unknown-provider',
+        choices: {},
+        credentials: {},
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('resolveValidator returns a function for a known key', () => {
+    expect(typeof resolveValidator('repo', 'github')).toBe('function');
+    expect(resolveValidator('repo', 'nope')).toBeUndefined();
+  });
+
+  it('every registered key has a function', () => {
+    for (const [k, v] of Object.entries(VALIDATORS)) {
+      expect(typeof v).toBe('function');
+      expect(k.split(':').length).toBe(2);
+    }
+  });
+});

--- a/packages/onboarding/tests/validators-http.test.ts
+++ b/packages/onboarding/tests/validators-http.test.ts
@@ -1,0 +1,594 @@
+import { describe, it, expect } from 'vitest';
+import { validateGithubToken } from '../src/validators/github.js';
+import { validateCloudflareToken } from '../src/validators/cloudflare.js';
+import { validateResendToken } from '../src/validators/resend.js';
+import {
+  validateGitlabToken,
+  validateBitbucketToken,
+  validateCircleCiToken,
+  validateBuildkiteToken,
+  validateVercelToken,
+  validateFlyToken,
+  validatePostmarkToken,
+  validateSendgridToken,
+  validateSentryToken,
+  validateLinearToken,
+  validateJiraToken,
+  validateNotionToken,
+  validateFigmaToken,
+  validateHoneycombToken,
+  validateAxiomToken,
+  validateNeonToken,
+  validateSupabaseKey,
+  validatePostHogToken,
+  validatePlausibleToken,
+  validateAnthropicKey,
+  validateStripePaymentMethod,
+  validateCloudinaryKey,
+} from '../src/validators/api-tokens.js';
+import { mockFetch, fixedContext } from './helpers.js';
+
+const baseInput = {
+  tenantId: 't1',
+  category: 'repo' as const,
+  providerId: 'github',
+  choices: {},
+  credentials: { api_token: 'gh_abc' },
+};
+
+describe('GitHub validator', () => {
+  it('passes when /user returns 200 and required scopes are granted', async () => {
+    const { fetch } = mockFetch({
+      'https://api.github.com/user': {
+        status: 200,
+        body: { login: 'octocat', id: 1 },
+        headers: { 'X-OAuth-Scopes': 'repo, workflow' },
+      },
+    });
+    const r = await validateGithubToken(baseInput, fixedContext(fetch));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.metadata['login']).toBe('octocat');
+      expect(r.scopesGranted).toContain('repo');
+    }
+  });
+
+  it('fails with scope_insufficient when repo is missing', async () => {
+    const { fetch } = mockFetch({
+      'https://api.github.com/user': {
+        status: 200,
+        body: { login: 'octocat', id: 1 },
+        headers: { 'X-OAuth-Scopes': 'read:user' },
+      },
+    });
+    const r = await validateGithubToken(baseInput, fixedContext(fetch));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('scope_insufficient');
+  });
+
+  it('fails with token_invalid on 401', async () => {
+    const { fetch } = mockFetch({
+      'https://api.github.com/user': { status: 401, body: { message: 'bad' } },
+    });
+    const r = await validateGithubToken(baseInput, fixedContext(fetch));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('token_invalid');
+  });
+
+  it('fails with network_error when fetch throws', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('boom');
+    }) as unknown as typeof fetch;
+    const r = await validateGithubToken(baseInput, fixedContext(fetchImpl));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('network_error');
+  });
+
+  it('rejects missing credential', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateGithubToken(
+      { ...baseInput, credentials: {} },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('choice_invalid');
+  });
+});
+
+describe('Cloudflare validator', () => {
+  it('passes when verify returns active', async () => {
+    const { fetch } = mockFetch({
+      'https://api.cloudflare.com/client/v4/user/tokens/verify': {
+        status: 200,
+        body: { success: true, result: { id: 'tok1', status: 'active' } },
+      },
+    });
+    const r = await validateCloudflareToken(
+      { ...baseInput, category: 'cloud' as const, providerId: 'cloudflare-pages' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails with token_expired if status is expired', async () => {
+    const { fetch } = mockFetch({
+      'https://api.cloudflare.com/client/v4/user/tokens/verify': {
+        status: 200,
+        body: { success: true, result: { id: 'tok1', status: 'expired' } },
+      },
+    });
+    const r = await validateCloudflareToken(
+      { ...baseInput, category: 'cloud' as const },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('token_expired');
+  });
+
+  it('fails with token_invalid when API returns success: false', async () => {
+    const { fetch } = mockFetch({
+      'https://api.cloudflare.com/client/v4/user/tokens/verify': {
+        status: 200,
+        body: { success: false },
+      },
+    });
+    const r = await validateCloudflareToken(
+      { ...baseInput, category: 'cloud' as const },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('token_invalid');
+  });
+
+  it('fails on 401', async () => {
+    const { fetch } = mockFetch({
+      'https://api.cloudflare.com/client/v4/user/tokens/verify': {
+        status: 401,
+        body: {},
+      },
+    });
+    const r = await validateCloudflareToken(
+      { ...baseInput, category: 'cloud' as const },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('Resend validator', () => {
+  it('passes with a domain list', async () => {
+    const { fetch } = mockFetch({
+      'https://api.resend.com/domains': {
+        status: 200,
+        body: { data: [{ id: 'd1' }, { id: 'd2' }] },
+      },
+    });
+    const r = await validateResendToken(
+      { ...baseInput, category: 'email' as const, providerId: 'resend' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.metadata['domainCount']).toBe(2);
+  });
+
+  it('fails on 401', async () => {
+    const { fetch } = mockFetch({
+      'https://api.resend.com/domains': { status: 401, body: {} },
+    });
+    const r = await validateResendToken(
+      { ...baseInput, category: 'email' as const, providerId: 'resend' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('fails on 429 rate-limited', async () => {
+    const { fetch } = mockFetch({
+      'https://api.resend.com/domains': { status: 429, body: {} },
+    });
+    const r = await validateResendToken(
+      { ...baseInput, category: 'email' as const, providerId: 'resend' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('rate_limited');
+  });
+});
+
+describe('GitLab + Bitbucket validators', () => {
+  it('GitLab passes with username', async () => {
+    const { fetch } = mockFetch({
+      'https://gitlab.com/api/v4/user': { status: 200, body: { username: 'gloria' } },
+    });
+    const r = await validateGitlabToken(
+      { ...baseInput, providerId: 'gitlab' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Bitbucket fails on 403', async () => {
+    const { fetch } = mockFetch({
+      'https://api.bitbucket.org/2.0/user': { status: 403, body: {} },
+    });
+    const r = await validateBitbucketToken(
+      { ...baseInput, providerId: 'bitbucket' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('CI validators', () => {
+  it('CircleCI passes on /me 200', async () => {
+    const { fetch } = mockFetch({
+      'https://circleci.com/api/v2/me': { status: 200, body: { id: 'u' } },
+    });
+    const r = await validateCircleCiToken(
+      { ...baseInput, providerId: 'circleci' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Buildkite passes on /user 200', async () => {
+    const { fetch } = mockFetch({
+      'https://api.buildkite.com/v2/user': { status: 200, body: { id: 'u' } },
+    });
+    const r = await validateBuildkiteToken(
+      { ...baseInput, providerId: 'buildkite' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Cloud validators', () => {
+  it('Vercel passes', async () => {
+    const { fetch } = mockFetch({
+      'https://api.vercel.com/v2/user': { status: 200, body: { user: { id: 'u' } } },
+    });
+    const r = await validateVercelToken(
+      { ...baseInput, providerId: 'vercel' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Fly.io requires a viewer in the GraphQL response', async () => {
+    const { fetch } = mockFetch({
+      'https://api.fly.io/graphql': {
+        status: 200,
+        body: { data: { viewer: { email: 'a@b' } } },
+      },
+    });
+    const r = await validateFlyToken(
+      { ...baseInput, providerId: 'fly' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Fly.io fails when GraphQL has no viewer', async () => {
+    const { fetch } = mockFetch({
+      'https://api.fly.io/graphql': { status: 200, body: { data: {} } },
+    });
+    const r = await validateFlyToken(
+      { ...baseInput, providerId: 'fly' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('Email + error tracking validators', () => {
+  it('Postmark passes', async () => {
+    const { fetch } = mockFetch({
+      'https://api.postmarkapp.com/server': { status: 200, body: { ID: 1 } },
+    });
+    const r = await validatePostmarkToken(
+      { ...baseInput, category: 'email' as const, providerId: 'postmark' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('SendGrid passes on /scopes', async () => {
+    const { fetch } = mockFetch({
+      'https://api.sendgrid.com/v3/scopes': { status: 200, body: { scopes: [] } },
+    });
+    const r = await validateSendgridToken(
+      { ...baseInput, category: 'email' as const, providerId: 'sendgrid' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Sentry passes when /organizations/ returns an array', async () => {
+    const { fetch } = mockFetch({
+      'https://sentry.io/api/0/organizations/': {
+        status: 200,
+        body: [{ slug: 'org-1' }],
+      },
+    });
+    const r = await validateSentryToken(
+      { ...baseInput, category: 'errors' as const, providerId: 'sentry' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('PM validators', () => {
+  it('Linear passes with viewer', async () => {
+    const { fetch } = mockFetch({
+      'https://api.linear.app/graphql': {
+        status: 200,
+        body: { data: { viewer: { id: 'v', name: 'A' } } },
+      },
+    });
+    const r = await validateLinearToken(
+      { ...baseInput, category: 'pm' as const, providerId: 'linear' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Jira requires a site choice', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateJiraToken(
+      { ...baseInput, category: 'pm' as const, providerId: 'jira-cloud' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('choice_invalid');
+  });
+
+  it('Jira passes when site + token resolve to /myself', async () => {
+    const { fetch } = mockFetch({
+      'https://my.atlassian.net/rest/api/3/myself': {
+        status: 200,
+        body: { accountId: '5f' },
+      },
+    });
+    const r = await validateJiraToken(
+      {
+        ...baseInput,
+        category: 'pm' as const,
+        providerId: 'jira-cloud',
+        choices: { site: 'my.atlassian.net' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Docs / Design validators', () => {
+  it('Notion passes', async () => {
+    const { fetch } = mockFetch({
+      'https://api.notion.com/v1/users/me': {
+        status: 200,
+        body: { type: 'person' },
+      },
+    });
+    const r = await validateNotionToken(
+      { ...baseInput, category: 'docs' as const, providerId: 'notion' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Figma requires the `pat` credential', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateFigmaToken(
+      {
+        ...baseInput,
+        category: 'design' as const,
+        providerId: 'figma',
+        credentials: {},
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errorCode).toBe('choice_invalid');
+  });
+
+  it('Figma passes with /v1/me', async () => {
+    const { fetch } = mockFetch({
+      'https://api.figma.com/v1/me': { status: 200, body: { email: 'x@y' } },
+    });
+    const r = await validateFigmaToken(
+      {
+        ...baseInput,
+        category: 'design' as const,
+        providerId: 'figma',
+        credentials: { pat: 'fig_xxx' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Observability + analytics validators', () => {
+  it('Honeycomb /1/auth passes', async () => {
+    const { fetch } = mockFetch({
+      'https://api.honeycomb.io/1/auth': { status: 200, body: { team: {} } },
+    });
+    const r = await validateHoneycombToken(
+      { ...baseInput, category: 'observability' as const, providerId: 'honeycomb' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Axiom /v1/user passes', async () => {
+    const { fetch } = mockFetch({
+      'https://api.axiom.co/v1/user': { status: 200, body: { id: 'u' } },
+    });
+    const r = await validateAxiomToken(
+      { ...baseInput, category: 'observability' as const, providerId: 'axiom' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('PostHog @me passes', async () => {
+    const { fetch } = mockFetch({
+      'https://app.posthog.com/api/users/@me/': { status: 200, body: { id: 'u' } },
+    });
+    const r = await validatePostHogToken(
+      { ...baseInput, category: 'analytics' as const, providerId: 'posthog-cloud' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Plausible /sites passes', async () => {
+    const { fetch } = mockFetch({
+      'https://plausible.io/api/v1/sites': { status: 200, body: [] },
+    });
+    const r = await validatePlausibleToken(
+      { ...baseInput, category: 'analytics' as const, providerId: 'plausible-cloud' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Database validators', () => {
+  it('Neon /users/me passes', async () => {
+    const { fetch } = mockFetch({
+      'https://console.neon.tech/api/v2/users/me': { status: 200, body: { id: 'u' } },
+    });
+    const r = await validateNeonToken(
+      { ...baseInput, category: 'database' as const, providerId: 'neon' },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Supabase requires projectUrl', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateSupabaseKey(
+      {
+        ...baseInput,
+        category: 'database' as const,
+        providerId: 'supabase',
+        credentials: { service_role_key: 'sb_x' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('Supabase passes with projectUrl + key', async () => {
+    const { fetch } = mockFetch({
+      'https://abc.supabase.co/rest/v1/': { status: 200, body: {} },
+    });
+    const r = await validateSupabaseKey(
+      {
+        ...baseInput,
+        category: 'database' as const,
+        providerId: 'supabase',
+        choices: { projectUrl: 'https://abc.supabase.co' },
+        credentials: { service_role_key: 'sb_x' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('Anthropic + Stripe + Cloudinary validators', () => {
+  it('Anthropic API key passes on 200', async () => {
+    const { fetch } = mockFetch({
+      'https://api.anthropic.com/v1/messages': { status: 200, body: {} },
+    });
+    const r = await validateAnthropicKey(
+      {
+        ...baseInput,
+        category: 'pricing' as const,
+        providerId: 'byok',
+        credentials: { anthropic_api_key: 'sk-ant-xx' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Anthropic 401 → token_invalid', async () => {
+    const { fetch } = mockFetch({
+      'https://api.anthropic.com/v1/messages': { status: 401, body: {} },
+    });
+    const r = await validateAnthropicKey(
+      {
+        ...baseInput,
+        category: 'pricing' as const,
+        providerId: 'byok',
+        credentials: { anthropic_api_key: 'bad' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('Stripe payment method format check', async () => {
+    const { fetch } = mockFetch({});
+    const ok = await validateStripePaymentMethod(
+      {
+        ...baseInput,
+        category: 'pricing' as const,
+        providerId: 'credits',
+        credentials: { stripe_payment_method_id: 'pm_1abc' },
+      },
+      fixedContext(fetch),
+    );
+    expect(ok.ok).toBe(true);
+    const bad = await validateStripePaymentMethod(
+      {
+        ...baseInput,
+        category: 'pricing' as const,
+        providerId: 'credits',
+        credentials: { stripe_payment_method_id: 'not-it' },
+      },
+      fixedContext(fetch),
+    );
+    expect(bad.ok).toBe(false);
+  });
+
+  it('Cloudinary needs cloudName + key + secret', async () => {
+    const { fetch } = mockFetch({});
+    const r = await validateCloudinaryKey(
+      {
+        ...baseInput,
+        category: 'cdn' as const,
+        providerId: 'cloudinary',
+        credentials: { api_key: 'a', api_secret: 'b' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it('Cloudinary passes with /usage', async () => {
+    const { fetch } = mockFetch({
+      'https://api.cloudinary.com/v1_1/my/usage': {
+        status: 200,
+        body: { used_percent: 1.2 },
+      },
+    });
+    const r = await validateCloudinaryKey(
+      {
+        ...baseInput,
+        category: 'cdn' as const,
+        providerId: 'cloudinary',
+        choices: { cloudName: 'my' },
+        credentials: { api_key: 'a', api_secret: 'b' },
+      },
+      fixedContext(fetch),
+    );
+    expect(r.ok).toBe(true);
+  });
+});

--- a/packages/onboarding/tsconfig.json
+++ b/packages/onboarding/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@chiefaia/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/onboarding/vitest.config.ts
+++ b/packages/onboarding/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@chiefaia/vitest-config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    coverage: {
+      thresholds: {
+        perFile: false,
+        lines: 70,
+        functions: 70,
+        branches: 70,
+        statements: 70,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,43 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
 
+  apps/admin:
+    dependencies:
+      '@caia/onboarding':
+        specifier: workspace:*
+        version: link:../../packages/onboarding
+      next:
+        specifier: 15.5.15
+        version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.59.1
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   apps/completeness-sentinel:
     dependencies:
       '@chiefaia/logger':
@@ -916,18 +953,36 @@ importers:
       '@axe-core/playwright':
         specifier: ^4.10.0
         version: 4.11.2(playwright-core@1.59.1)
+      '@chiefaia/tsconfig':
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
       '@playwright/test':
         specifier: ^1.48.0
         version: 1.59.1
+      '@storybook/addon-a11y':
+        specifier: ^8.3.0
+        version: 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-essentials':
+        specifier: ^8.3.0
+        version: 8.6.14(@types/react@19.2.14)(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-interactions':
+        specifier: ^8.3.0
+        version: 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/react':
+        specifier: ^8.3.0
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))(typescript@5.9.3)
+      '@storybook/react-vite':
+        specifier: ^8.3.0
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.6.18(prettier@2.8.8))(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.39))
       '@testing-library/jest-dom':
         specifier: ^6.5.0
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@testing-library/user-event':
         specifier: ^14.5.2
-        version: 14.6.1(@testing-library/dom@10.4.1)
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -940,6 +995,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@5.4.21(@types/node@20.19.39))
+      http-server:
+        specifier: ^14.1.1
+        version: 14.1.1
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -949,6 +1007,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      storybook:
+        specifier: ^8.3.0
+        version: 8.6.18(prettier@2.8.8)
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -2128,13 +2189,13 @@ importers:
 
   packages/onboarding:
     dependencies:
-      '@caia/secrets-adapter':
-        specifier: workspace:*
-        version: link:../secrets-adapter
       zod:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@chiefaia/eslint-config':
+        specifier: workspace:*
+        version: link:../../configs/eslint-config
       '@chiefaia/tsconfig':
         specifier: workspace:*
         version: link:../../configs/tsconfig
@@ -4833,6 +4894,15 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0':
+    resolution: {integrity: sha512-qYDdL7fPwLRI+bJNurVcis+tNgJmvWjH4YTBGXTA8xMuxFrnAz6E5o35iyzyKbq5J5Lr8mJGfrR5GXl+WGwhgQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -4874,6 +4944,12 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
 
   '@mistralai/mistralai@1.15.1':
     resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
@@ -5245,6 +5321,15 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -5705,6 +5790,199 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/addon-a11y@8.6.18':
+    resolution: {integrity: sha512-LFvudttdIfDTNWprA8/N1vbiWbJRrNscyt2OP9Qwi85E1d3LKLy+e8AWiqY08gpy2OUYujK7AjxfpKtNeddrxw==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/addon-actions@8.6.14':
+    resolution: {integrity: sha512-mDQxylxGGCQSK7tJPkD144J8jWh9IU9ziJMHfB84PKpI/V5ZgqMDnpr2bssTrUaGDqU5e1/z8KcRF+Melhs9pQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-backgrounds@8.6.14':
+    resolution: {integrity: sha512-l9xS8qWe5n4tvMwth09QxH2PmJbCctEvBAc1tjjRasAfrd69f7/uFK4WhwJAstzBTNgTc8VXI4w8ZR97i1sFbg==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-controls@8.6.14':
+    resolution: {integrity: sha512-IiQpkNJdiRyA4Mq9mzjZlvQugL/aE7hNgVxBBGPiIZG6wb6Ht9hNnBYpap5ZXXFKV9p2qVI0FZK445ONmAa+Cw==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-docs@8.6.14':
+    resolution: {integrity: sha512-Obpd0OhAF99JyU5pp5ci17YmpcQtMNgqW2pTXV8jAiiipWpwO++hNDeQmLmlSXB399XjtRDOcDVkoc7rc6JzdQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-essentials@8.6.14':
+    resolution: {integrity: sha512-5ZZSHNaW9mXMOFkoPyc3QkoNGdJHETZydI62/OASR0lmPlJ1065TNigEo5dJddmZNn0/3bkE8eKMAzLnO5eIdA==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-highlight@8.6.14':
+    resolution: {integrity: sha512-4H19OJlapkofiE9tM6K/vsepf4ir9jMm9T+zw5L85blJZxhKZIbJ6FO0TCG9PDc4iPt3L6+aq5B0X29s9zicNQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-highlight@8.6.18':
+    resolution: {integrity: sha512-wTFJ1DPM0C8gK6nGTJxH75byayQj7BPAz02fME4AOmT6clrBpVl1zSTFTkXaSr+k4xOfeMR/xNUfVskaXz6T9w==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/addon-interactions@8.6.14':
+    resolution: {integrity: sha512-8VmElhm2XOjh22l/dO4UmXxNOolGhNiSpBcls2pqWSraVh4a670EyYBZsHpkXqfNHo2YgKyZN3C91+9zfH79qQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-measure@8.6.14':
+    resolution: {integrity: sha512-1Tlyb72NX8aAqm6I6OICsUuGOP6hgnXcuFlXucyhKomPa6j3Eu2vKu561t/f0oGtAK2nO93Z70kVaEh5X+vaGw==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-outline@8.6.14':
+    resolution: {integrity: sha512-CW857JvN6OxGWElqjlzJO2S69DHf+xO3WsEfT5mT3ZtIjmsvRDukdWfDU9bIYUFyA2lFvYjncBGjbK+I91XR7w==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-toolbars@8.6.14':
+    resolution: {integrity: sha512-W/wEXT8h3VyZTVfWK/84BAcjAxTdtRiAkT2KAN0nbSHxxB5KEM1MjKpKu2upyzzMa3EywITqbfy4dP6lpkVTwQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/addon-viewport@8.6.14':
+    resolution: {integrity: sha512-gNzVQbMqRC+/4uQTPI2ZrWuRHGquTMZpdgB9DrD88VTEjNudP+J6r8myLfr2VvGksBbUMHkGHMXHuIhrBEnXYA==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/blocks@8.6.14':
+    resolution: {integrity: sha512-rBMHAfA39AGHgkrDze4RmsnQTMw1ND5fGWobr9pDcJdnDKWQWNRD7Nrlxj0gFlN3n4D9lEZhWGdFrCbku7FVAQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^8.6.14
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@storybook/builder-vite@8.6.18':
+    resolution: {integrity: sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==}
+    peerDependencies:
+      storybook: ^8.6.18
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@storybook/components@8.6.18':
+    resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/core@8.6.18':
+    resolution: {integrity: sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==}
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
+  '@storybook/csf-plugin@8.6.14':
+    resolution: {integrity: sha512-dErtc9teAuN+eelN8FojzFE635xlq9cNGGGEu0WEmMUQ4iJ8pingvBO1N8X3scz4Ry7KnxX++NNf3J3gpxS8qQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/csf-plugin@8.6.18':
+    resolution: {integrity: sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@1.6.0':
+    resolution: {integrity: sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+
+  '@storybook/instrumenter@8.6.14':
+    resolution: {integrity: sha512-iG4MlWCcz1L7Yu8AwgsnfVAmMbvyRSk700Mfy2g4c8y5O+Cv1ejshE1LBBsCwHgkuqU0H4R0qu4g23+6UnUemQ==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/instrumenter@8.6.18':
+    resolution: {integrity: sha512-viEC1BGlYyjAzi1Tv3LZjByh7Y3Oh04u6QKsujxdeUbr5rUOH4pa/wCKmxXmY6yWrD4WjcNtojmUvQZN/66FXQ==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/manager-api@8.6.18':
+    resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/preview-api@8.6.18':
+    resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/react-dom-shim@8.6.14':
+    resolution: {integrity: sha512-0hixr3dOy3f3M+HBofp3jtMQMS+sqzjKNgl7Arfuj3fvjmyXOks/yGjDImySR4imPtEllvPZfhiQNlejheaInw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.6.14
+
+  '@storybook/react-dom-shim@8.6.18':
+    resolution: {integrity: sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.6.18
+
+  '@storybook/react-vite@8.6.18':
+    resolution: {integrity: sha512-qpSYyH2IizlEsI95MJTdIL6xpLSgiNCMoJpHu+IEqLnyvmecRR/YEZvcHalgdtawuXlimH0bAYuwIu3l8Vo6FQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@storybook/test': 8.6.18
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.6.18
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      '@storybook/test':
+        optional: true
+
+  '@storybook/react@8.6.18':
+    resolution: {integrity: sha512-BuLpzMkKtF+UCQCbi+lYVX9cdcAMG86Lu2dDn7UFkPi5HRNFq/zHPSvlz1XDgL0OYMtcqB1aoVzFzcyzUBhhjw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@storybook/test': 8.6.18
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.6.18
+      typescript: '>= 4.2.x'
+    peerDependenciesMeta:
+      '@storybook/test':
+        optional: true
+      typescript:
+        optional: true
+
+  '@storybook/test@8.6.14':
+    resolution: {integrity: sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw==}
+    peerDependencies:
+      storybook: ^8.6.14
+
+  '@storybook/test@8.6.18':
+    resolution: {integrity: sha512-u/RwfWMyHcH0N2hqfMTw2CoZ58IXdeED3b8NmcHc8bmERB3byI5vVAkwYbcD7+WeRHIiym38ZHi0SRn+IpkO3Q==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/theming@8.6.18':
+    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@supabase/auth-helpers-nextjs@0.10.0':
     resolution: {integrity: sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==}
     deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
@@ -5747,9 +6025,17 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.5.0':
+    resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
@@ -5769,6 +6055,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.5.2':
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
@@ -5861,6 +6153,9 @@ packages:
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -5890,6 +6185,9 @@ packages:
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -5947,6 +6245,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
@@ -5958,6 +6259,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -6115,6 +6419,9 @@ packages:
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
+  '@vitest/expect@2.0.5':
+    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -6128,6 +6435,9 @@ packages:
         optional: true
       vite:
         optional: true
+
+  '@vitest/pretty-format@2.0.5':
+    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
@@ -6147,11 +6457,17 @@ packages:
   '@vitest/spy@1.6.1':
     resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
 
+  '@vitest/spy@2.0.5':
+    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@vitest/utils@2.0.5':
+    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
@@ -6337,6 +6653,10 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   async@3.2.3:
     resolution: {integrity: sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==}
 
@@ -6356,6 +6676,10 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
@@ -6466,9 +6790,17 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
+
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
+
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -6536,6 +6868,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-assert@1.2.1:
+    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -6600,6 +6935,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -6634,6 +6973,10 @@ packages:
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -6909,6 +7252,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  corser@2.0.1:
+    resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
+    engines: {node: '>= 0.4.0'}
+
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
@@ -7073,6 +7420,10 @@ packages:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
@@ -7142,6 +7493,10 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -7457,6 +7812,11 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -7573,6 +7933,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -7807,6 +8170,10 @@ packages:
       debug:
         optional: true
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   for-in@0.1.8:
     resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
     engines: {node: '>=0.10.0'}
@@ -7903,6 +8270,10 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -8050,6 +8421,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -8062,12 +8436,20 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -8090,6 +8472,15 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+
+  http-server@14.1.1:
+    resolution: {integrity: sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
@@ -8224,6 +8615,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -8236,6 +8631,10 @@ packages:
 
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -8274,6 +8673,10 @@ packages:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -8305,6 +8708,10 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -8316,6 +8723,10 @@ packages:
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -8560,6 +8971,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
+    engines: {node: '>=12.0.0'}
 
   jsdom@24.1.3:
     resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
@@ -8855,6 +9270,10 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  magic-string@0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -8874,6 +9293,9 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  map-or-similar@1.5.0:
+    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -8925,6 +9347,9 @@ packages:
   memjs@1.3.2:
     resolution: {integrity: sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==}
     engines: {node: '>=0.10.0'}
+
+  memoizerific@1.11.3:
+    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -9651,6 +10076,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  polished@4.3.1:
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
+
+  portfinder@1.0.38:
+    resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
+    engines: {node: '>= 10.12'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -9934,6 +10371,15 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@7.1.1:
+    resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
+    engines: {node: '>=16.14.0'}
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -9992,6 +10438,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -10125,8 +10575,15 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -10148,6 +10605,9 @@ packages:
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
+
+  secure-compare@3.0.1:
+    resolution: {integrity: sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==}
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
@@ -10192,6 +10652,10 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -10380,6 +10844,15 @@ packages:
     resolution: {integrity: sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==}
     engines: {node: '>=0.10.0'}
 
+  storybook@8.6.18:
+    resolution: {integrity: sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -10441,6 +10914,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -10597,6 +11074,9 @@ packages:
   tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -10703,6 +11183,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -10749,6 +11233,10 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -10873,6 +11361,10 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  union@0.5.0:
+    resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
+    engines: {node: '>= 0.8.0'}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -10893,6 +11385,10 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -10901,6 +11397,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -10918,6 +11417,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -11079,6 +11581,14 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -11100,6 +11610,10 @@ packages:
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -13838,6 +14352,15 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      glob: 10.5.0
+      magic-string: 0.27.0
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 5.4.21(@types/node@20.19.39)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -13942,6 +14465,12 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.5
 
   '@mistralai/mistralai@1.15.1':
     dependencies:
@@ -14391,6 +14920,14 @@ snapshots:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.2
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -14972,6 +15509,260 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/addon-a11y@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/addon-highlight': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/global': 5.0.0
+      '@storybook/test': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      axe-core: 4.11.3
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/addon-actions@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@types/uuid': 9.0.8
+      dequal: 2.0.3
+      polished: 4.3.1
+      storybook: 8.6.18(prettier@2.8.8)
+      uuid: 9.0.1
+
+  '@storybook/addon-backgrounds@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+
+  '@storybook/addon-controls@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      dequal: 2.0.3
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+
+  '@storybook/addon-docs@8.6.14(@types/react@19.2.14)(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@storybook/blocks': 8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@storybook/addon-essentials@8.6.14(@types/react@19.2.14)(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/addon-actions': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-controls': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.2.14)(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-highlight': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-measure': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-outline': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/addon-viewport': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@storybook/addon-highlight@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/addon-highlight@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/addon-interactions@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/test': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      polished: 4.3.1
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+
+  '@storybook/addon-measure@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 8.6.18(prettier@2.8.8)
+      tiny-invariant: 1.3.3
+
+  '@storybook/addon-outline@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+
+  '@storybook/addon-toolbars@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/addon-viewport@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      memoizerific: 1.11.3
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/blocks@8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/icons': 1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@2.8.8))(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      browser-assert: 1.2.1
+      storybook: 8.6.18(prettier@2.8.8)
+      ts-dedent: 2.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+
+  '@storybook/components@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/core@8.6.18(prettier@2.8.8)(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      better-opn: 3.0.2
+      browser-assert: 1.2.1
+      esbuild: 0.25.12
+      esbuild-register: 3.6.0(esbuild@0.25.12)
+      jsdoc-type-pratt-parser: 4.8.0
+      process: 0.11.10
+      recast: 0.23.11
+      semver: 7.7.4
+      util: 0.12.5
+      ws: 8.20.0
+    optionalDependencies:
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - bufferutil
+      - storybook
+      - supports-color
+      - utf-8-validate
+
+  '@storybook/csf-plugin@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+      unplugin: 1.16.1
+
+  '@storybook/csf-plugin@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+      unplugin: 1.16.1
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@storybook/instrumenter@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@vitest/utils': 2.1.9
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/instrumenter@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@vitest/utils': 2.1.9
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/manager-api@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/preview-api@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/react-dom-shim@8.6.18(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/react-vite@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.6.18(prettier@2.8.8))(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.39))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@2.8.8))(vite@5.4.21(@types/node@20.19.39))
+      '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))(typescript@5.9.3)
+      find-up: 5.0.0
+      magic-string: 0.30.21
+      react: 19.2.5
+      react-docgen: 7.1.1
+      react-dom: 19.2.5(react@19.2.5)
+      resolve: 1.22.12
+      storybook: 8.6.18(prettier@2.8.8)
+      tsconfig-paths: 4.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+    optionalDependencies:
+      '@storybook/test': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
+
+  '@storybook/react@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/components': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/preview-api': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/react-dom-shim': 8.6.18(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.6.18(prettier@2.8.8))
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 8.6.18(prettier@2.8.8)
+    optionalDependencies:
+      '@storybook/test': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      typescript: 5.9.3
+
+  '@storybook/test@8.6.14(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.18(prettier@2.8.8))
+      '@testing-library/dom': 10.4.0
+      '@testing-library/jest-dom': 6.5.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/expect': 2.0.5
+      '@vitest/spy': 2.0.5
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/test@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/instrumenter': 8.6.18(storybook@8.6.18(prettier@2.8.8))
+      '@testing-library/dom': 10.4.0
+      '@testing-library/jest-dom': 6.5.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/expect': 2.0.5
+      '@vitest/spy': 2.0.5
+      storybook: 8.6.18(prettier@2.8.8)
+
+  '@storybook/theming@8.6.18(storybook@8.6.18(prettier@2.8.8))':
+    dependencies:
+      storybook: 8.6.18(prettier@2.8.8)
+
   '@supabase/auth-helpers-nextjs@0.10.0(@supabase/supabase-js@2.104.1)':
     dependencies:
       '@supabase/auth-helpers-shared': 0.7.0(@supabase/supabase-js@2.104.1)
@@ -15027,6 +15818,17 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -15038,6 +15840,16 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.5.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.18.1
+      redent: 3.0.0
+
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.4.4
@@ -15046,6 +15858,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -15066,6 +15888,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -15156,6 +15986,8 @@ snapshots:
 
   '@types/diff-match-patch@1.0.36': {}
 
+  '@types/doctrine@0.0.9': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -15184,6 +16016,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/long@4.0.2': {}
+
+  '@types/mdx@2.0.13': {}
 
   '@types/ms@2.1.0': {}
 
@@ -15247,6 +16081,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/resolve@1.20.6': {}
+
   '@types/retry@0.12.0': {}
 
   '@types/stack-utils@2.0.3': {}
@@ -15254,6 +16090,8 @@ snapshots:
   '@types/tough-cookie@4.0.0': {}
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/uuid@9.0.8': {}
 
   '@types/webidl-conversions@7.0.3': {}
 
@@ -15507,6 +16345,13 @@ snapshots:
       '@vitest/utils': 1.6.1
       chai: 4.5.0
 
+  '@vitest/expect@2.0.5':
+    dependencies:
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -15521,6 +16366,10 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.0.5':
+    dependencies:
+      tinyrainbow: 1.2.0
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -15553,6 +16402,10 @@ snapshots:
     dependencies:
       tinyspy: 2.2.1
 
+  '@vitest/spy@2.0.5':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
@@ -15563,6 +16416,13 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@2.0.5':
+    dependencies:
+      '@vitest/pretty-format': 2.0.5
+      estree-walker: 3.0.3
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -15731,6 +16591,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   async@3.2.3: {}
 
   async@3.2.6: {}
@@ -15747,6 +16611,10 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   axe-core@4.11.3: {}
 
@@ -15875,7 +16743,15 @@ snapshots:
 
   baseline-browser-mapping@2.10.22: {}
 
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   basic-ftp@5.3.1: {}
+
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -15971,6 +16847,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-assert@1.2.1: {}
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.22
@@ -16036,6 +16914,13 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -16074,6 +16959,11 @@ snapshots:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -16373,6 +17263,8 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  corser@2.0.1: {}
+
   cosmiconfig-typescript-loader@6.3.0(@types/node@22.19.17)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@types/node': 22.19.17
@@ -16505,6 +17397,12 @@ snapshots:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
@@ -16551,6 +17449,10 @@ snapshots:
       path-type: 4.0.0
 
   dlv@1.1.3: {}
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -16702,6 +17604,13 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
+
+  esbuild-register@3.6.0(esbuild@0.25.12):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.25.12
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -16966,6 +17875,8 @@ snapshots:
       - utf-8-validate
 
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -17290,6 +18201,10 @@ snapshots:
     optionalDependencies:
       debug: 4.3.4
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   for-in@0.1.8: {}
 
   for-in@1.0.2: {}
@@ -17403,6 +18318,8 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -17601,6 +18518,10 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -17611,9 +18532,15 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   help-me@5.0.0: {}
 
   hono@4.12.15: {}
+
+  html-encoding-sniffer@3.0.0:
+    dependencies:
+      whatwg-encoding: 2.0.0
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -17643,6 +18570,33 @@ snapshots:
       agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
+      - supports-color
+
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.16.0(debug@4.3.4)
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+
+  http-server@14.1.1:
+    dependencies:
+      basic-auth: 2.0.1
+      chalk: 4.1.2
+      corser: 2.0.1
+      he: 1.2.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy: 1.18.1
+      mime: 1.6.0
+      minimist: 1.2.8
+      opener: 1.5.2
+      portfinder: 1.0.38
+      secure-compare: 3.0.1
+      union: 0.5.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   http-status-codes@2.3.0: {}
@@ -17796,6 +18750,11 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.4: {}
@@ -17805,6 +18764,8 @@ snapshots:
       binary-extensions: 2.3.0
 
   is-buffer@1.1.6: {}
+
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -17825,6 +18786,14 @@ snapshots:
   is-fullwidth-code-point@3.0.0: {}
 
   is-generator-fn@2.1.0: {}
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -17848,6 +18817,13 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
   is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
@@ -17855,6 +18831,10 @@ snapshots:
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
 
   is-typedarray@1.0.0: {}
 
@@ -18286,6 +19266,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@4.8.0: {}
+
   jsdom@24.1.3:
     dependencies:
       cssstyle: 4.6.0
@@ -18634,6 +19616,10 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-string@0.27.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -18657,6 +19643,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  map-or-similar@1.5.0: {}
 
   marky@1.3.0: {}
 
@@ -18715,6 +19703,10 @@ snapshots:
       - ws
 
   memjs@1.3.2: {}
+
+  memoizerific@1.11.3:
+    dependencies:
+      map-or-similar: 1.5.0
 
   memory-pager@1.5.0: {}
 
@@ -19427,6 +20419,19 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  polished@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  portfinder@1.0.38:
+    dependencies:
+      async: 3.2.6
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  possible-typed-array-names@1.1.0: {}
+
   postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
       postcss: 8.5.10
@@ -19526,8 +20531,7 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  process@0.11.10:
-    optional: true
+  process@0.11.10: {}
 
   progress@2.0.3: {}
 
@@ -19849,6 +20853,25 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-docgen-typescript@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  react-docgen@7.1.1:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -19907,6 +20930,14 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   redent@3.0.0:
     dependencies:
@@ -20054,7 +21085,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safe-stable-stringify@2.5.0: {}
 
@@ -20074,6 +21113,8 @@ snapshots:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+
+  secure-compare@3.0.1: {}
 
   secure-json-parse@2.7.0: {}
 
@@ -20142,6 +21183,15 @@ snapshots:
   set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -20414,6 +21464,16 @@ snapshots:
 
   stopwords-iso@1.1.0: {}
 
+  storybook@8.6.18(prettier@2.8.8):
+    dependencies:
+      '@storybook/core': 8.6.18(prettier@2.8.8)(storybook@8.6.18(prettier@2.8.8))
+    optionalDependencies:
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -20478,6 +21538,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
 
   strip-json-comments@2.0.1: {}
 
@@ -20699,6 +21761,8 @@ snapshots:
 
   tiny-emitter@2.1.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -20788,6 +21852,8 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-dedent@2.2.0: {}
+
   ts-interface-checker@0.1.13: {}
 
   ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.7)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3):
@@ -20851,6 +21917,12 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@1.14.1: {}
 
@@ -20974,6 +22046,10 @@ snapshots:
 
   undici@7.25.0: {}
 
+  union@0.5.0:
+    dependencies:
+      qs: 6.15.1
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
@@ -20986,6 +22062,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -20995,6 +22076,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-join@4.0.1: {}
 
   url-parse@1.5.10:
     dependencies:
@@ -21010,6 +22093,14 @@ snapshots:
       react: 19.2.5
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   utils-merge@1.0.1: {}
 
@@ -21303,6 +22394,12 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
+  webpack-virtual-modules@0.6.2: {}
+
+  whatwg-encoding@2.0.0:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -21322,6 +22419,16 @@ snapshots:
       webidl-conversions: 3.0.1
 
   which-module@2.0.1: {}
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Ships **Step 1** of the canonical CAIA pipeline (research/step1_onboarding_spec_2026.md): the onboarding engine + admin wizard that captures + validates every key the customer will ever need before the build agents kick in.

## What's in here

### `@caia/onboarding` engine (new package)

- **Catalog** of 15 mandatory + 4 optional categories (Identity, Auth, Pricing, Repo, CI, Cloud, Domain, DNS, CDN, Database, Email, Analytics, Errors, Observability, PM + Docs, Design, Compliance, Anthropic prefs) — see `src/categories/index.ts`.
- **Per-provider validators** (`src/validators/`) covering the 5 archetypes (OAuth / API token / DNS / webhook / endpoint): GitHub `/user` w/ scope check, Cloudflare `/user/tokens/verify`, AWS STS `GetCallerIdentity` with inline SigV4, Resend `/domains`, plus GitLab, Bitbucket, CircleCI, Buildkite, Vercel, Fly.io GraphQL, Postmark, SendGrid, Sentry, Linear, Jira, Notion, Figma, Honeycomb, Axiom, Neon, Supabase, PostHog, Plausible, Anthropic ping, Stripe `pm_*` format, Cloudinary `/usage`, DNS-over-HTTPS TXT proof, Postgres DSN sanity.
- **Engine** (`src/engine/`) — orchestrator: probing → validator → PUT secret_ref via `SecretsPutter` (a minimal interface; production wires `@caia/secrets-infisical` against `https://infisical.chiefaia.com`) → upsert credential row pointing at `secret_ref` only → audit row → finalize tenant when every mandatory step is `passed` / `deferred`. Idempotent on re-submit; resume points at the lowest-ordinal incomplete required step.
- **Store** (`src/store/`) — `OnboardingStore` interface with both `InMemoryOnboardingStore` (tests + dev) and `PgOnboardingStore` (Postgres against `caia_meta.*`).
- **Migrations** — `migrations/0001_caia_meta_init.sql` ships `tenants`, `onboarding_steps`, `onboarding_drafts`, `customer_choices`, `credentials`, `audit_log` (range-partitioned), trigger for `updated_at`.
- **Audit log** — every step.started / passed / failed / deferred + credential.put / credential.validated + onboarding.completed.

### `apps/admin` wizard UI (new app)

- Next.js 15 App Router. One screen per category at `/onboarding/[category]`, server-rendered provider list, password-typed credential fields, inline result banner, progress bar, skip-for-now on optionals, final completion screen at `/onboarding/complete`.
- JSON API at `/api/onboarding/{state,submit,defer,log}` — the same surface the upcoming `@caia/cli onboard` will hit, so no duplicated logic.
- **Cloudflare Access cookie gate** in `lib/auth.ts` (decodes `CF_Authorization`); `CAIA_AUTH_BYPASS=1` short-circuits in dev/E2E.

## Tests

- **96 vitest tests** in `packages/onboarding/tests/` covering catalog integrity, every HTTP validator (success / scope-insufficient / 401 / 429 / network-error), AWS SigV4 happy + failure paths, identity validation (disposable mail / bad tz / bad locale), DNS proof, dispatcher dispatch + unknown-provider rejection, in-memory store CRUD + audit ordering, engine flow (probing → passed, audit emission, idempotency, deferred only-for-optional, tenant finalize, validator throw → captured as failure).
- **3 Playwright E2E** in `apps/admin/tests/` — full happy-path (signup → 15 categories → onboarding-complete), audit-log assertion, unknown-provider 400.

Both green locally.

## Notes for the operator

- The engine deliberately does NOT take `@caia/secrets-adapter` as a hard dep; it uses a local `SecretsPutter` interface (one method: `put(tenantId, category, key, value)`). The Infisical adapter implements it without dragging the full adapter type-graph into every consumer.
- In-memory store is module-singleton'd via `globalThis` so Next dev HMR doesn't wipe state across requests — production Postgres is the obvious upgrade.
