### PR TITLE
feat(@caia/seo-architect): architect #4 of 17 EA fan-out

### DIFF
--- a/packages/seo-architect/README.md
+++ b/packages/seo-architect/README.md
@@ -1,0 +1,68 @@
+# @caia/seo-architect
+
+Architect **#4 of 17** in CAIA's EA fan-out. Owns the `seo.*` slice of the `tickets.architecture` JSONB column. Mirrors the canonical Frontend Architect template (merged PR #537).
+
+## What it owns
+
+- `seo.schemaOrgJsonLd` — schema.org JSON-LD payload (Article / BlogPosting / FAQPage / Person / Organization / Product / WebSite)
+- `seo.canonicalUrl` — canonical absolute URL (mandatory; resolves duplicate-content)
+- `seo.metaTags` — `<meta>` tags including `title`, `description`, viewport, robots, theme-color
+- `seo.ogTags` — Open Graph tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`)
+- `seo.twitterCard` — Twitter Card tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`)
+- `seo.sitemapEntry` — `sitemap.xml` entry shape (loc, lastmod, changefreq, priority)
+- `seo.robotsDirective` — per-page robots rule (index/noindex, follow/nofollow, max-snippet, etc.)
+- `seo.keywordTargets` — primary + secondary keyword targets (intent-tagged)
+- `seo.pageType` — discriminator that drives the JSON-LD `@type` choice (Article / BlogPosting / FAQPage / Person / Organization / Product / WebSite / etc.)
+
+## What it does NOT do
+
+No component code (Frontend), no backend endpoints (Backend), no database schema (Database), no CSP rules (Security), no Core Web Vitals budgets (Performance). The contract rejects writes outside `seo.*`.
+
+## How it runs
+
+Implements `SpecialistArchitect` from `@caia/architect-kit` per spec §1.1. The EA Dispatcher spawns one of these per applicable Page ticket. Each spawn calls `@chiefaia/claude-spawner` (subscription-only, no API-key billing) with Sonnet default. Returns an `ArchitectOutput` the Dispatcher composes into the ticket's `architecture` JSONB.
+
+Wave-1 architect (`dependsOn: []`). Precedence rank **4** per spec §5.2 — SEO is a locked playbook non-negotiable; ranks above Performance and Frontend, below Security/DevOps/A11y.
+
+## Quick start
+
+```ts
+import { SeoArchitect, SeoArchitectContract } from '@caia/seo-architect';
+
+const architect = new SeoArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: {} },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite covers interface compliance, contract structural checks, registration disjointness, output validation, run() idempotency, dependency declaration, cross-architect invariants, and a **golden test verifying schema.org JSON-LD validates against Google's Rich Results format constraints** (`@context`, `@type`, type-specific required props).
+
+## SEO posture (locked)
+
+- Exactly one canonical URL per page (mandatory; absolute, HTTPS).
+- Exactly one schema.org JSON-LD payload per page (no orphan stub).
+- `pageType` discriminator drives `@type`:
+  - Article / BlogPosting → `headline`, `datePublished`, `author`, `image`
+  - FAQPage → `mainEntity[]` with `Question`/`Answer` pairs
+  - Person → `name`, optional `jobTitle`, `image`, `sameAs[]`
+  - Organization → `name`, `url`, `logo`, optional `sameAs[]`
+  - Product → `name`, `image`, `description`, `offers`
+  - WebSite → `name`, `url`, optional `potentialAction` for sitelinks search
+- OG image at 1200×630 (Facebook/LinkedIn) and a Twitter image at the same or larger ratio.
+- Sitemap entry mandatory unless `robotsDirective.index === 'noindex'`.
+- `keywordTargets` flag a single primary keyword + ≤5 secondary keywords.

--- a/packages/seo-architect/eslint.config.cjs
+++ b/packages/seo-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on frontend-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/seo-architect/package.json
+++ b/packages/seo-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/seo-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "SEO Architect — architect #4 of CAIA's 17-architect EA fan-out. Owns the `seo.*` slice of `tickets.architecture` (schemaOrgJsonLd, canonicalUrl, metaTags, ogTags, twitterCard, sitemapEntry, robotsDirective, keywordTargets, pageType). Senior SEO engineer focused on schema.org JSON-LD + canonical URLs + sitemap discipline. Produces per-page SEO specs that validate against Google's Rich Results format. Does NOT write component code (Frontend) or backend endpoints (Backend). Spawns Claude via @chiefaia/claude-spawner (subscription-only). Mirrors the Frontend Architect canonical template (PR #537).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/seo-architect/src/architect.ts
+++ b/packages/seo-architect/src/architect.ts
@@ -1,0 +1,71 @@
+/**
+ * `SeoArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (spec §2.4 — SEO reads from the
+ *     ticket + businessPlan + designVersion directly; no external tooling).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ */
+
+import { SeoArchitectContract } from './contract.js';
+import { runSeoArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildSeoSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/seo-architect` minus the suffix. */
+export const SEO_ARCHITECT_NAME = 'seo' as const;
+
+/** V1: no architect-specific tools. Reads ticket + businessPlan + designVersion directly. */
+export const SEO_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface SeoArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class SeoArchitect implements SpecialistArchitect {
+  readonly name = SEO_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = SeoArchitectContract;
+  readonly tools: readonly ToolDefinition[] = SEO_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: SeoArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildSeoSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runSeoArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/seo-architect/src/contract.ts
+++ b/packages/seo-architect/src/contract.ts
@@ -1,0 +1,160 @@
+/**
+ * `SeoArchitectContract` — the canonical owned-fields declaration for
+ * architect #4 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.4 (SEO Architect owns `seo.*`)
+ *   - task brief (schemaOrgJsonLd, canonicalUrl, metaTags, ogTags,
+ *     twitterCard, sitemapEntry, robotsDirective, keywordTargets, pageType)
+ *
+ * The owned set below tracks the task brief field names. Every field is
+ * `required: true` because downstream architects (Performance, A11y,
+ * Analytics) read these — missing fields cascade into broken Open Graph
+ * cards, malformed sitemaps, and Rich Results validation errors.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. The chosen keys all live under the `seo.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const SEO_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'seo.schemaOrgJsonLd':
+    'Emit a single JSON-LD object with @context "https://schema.org" and @type matching `pageType`. Include the required props for that @type (e.g. Article → headline+datePublished+author+image). Validate against Google Rich Results format.',
+  'seo.canonicalUrl':
+    'Always absolute HTTPS. One per page. If the page is a noindex variant, the canonical still points at the indexable version.',
+  'seo.metaTags':
+    'Always include {title, description, viewport, robots}. Title 50–60 chars; description 140–160 chars. theme-color picks up brand.primary from the business plan.',
+  'seo.ogTags':
+    'Required Open Graph keys: og:title, og:description, og:type, og:url, og:image. Image must be 1200×630 (Facebook/LinkedIn floor).',
+  'seo.twitterCard':
+    'Use twitter:card=summary_large_image when an OG image is present; otherwise summary. Mirror og:title/description.',
+  'seo.sitemapEntry':
+    'Always emit a sitemap entry unless robotsDirective.index === "noindex". Use ISO-8601 lastmod. priority defaults to 0.5; promote landing pages to 1.0.',
+  'seo.robotsDirective':
+    'Default to {index:"index", follow:"follow"}. Use noindex only for auth pages, search results, faceted listings, and similar non-canonical URLs.',
+  'seo.keywordTargets':
+    'Exactly one primary keyword (intent + search-volume tag). ≤5 secondary keywords. Tag intent: navigational | informational | transactional | commercial.',
+  'seo.pageType':
+    'Discriminator. Drives the schema.org @type choice. Allowed values: Article | BlogPosting | FAQPage | Person | Organization | Product | WebSite | LocalBusiness | Event | Recipe | CollectionPage.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const SEO_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'seo.pageType',
+    description:
+      'Discriminator that drives the schema.org @type choice — Article | BlogPosting | FAQPage | Person | Organization | Product | WebSite | LocalBusiness | Event | Recipe | CollectionPage.',
+    required: true
+  },
+  {
+    path: 'seo.schemaOrgJsonLd',
+    description:
+      'Schema.org JSON-LD payload. @context must be "https://schema.org"; @type must match `pageType`; required props per type must be present. Validates against Google Rich Results format.',
+    required: true
+  },
+  {
+    path: 'seo.canonicalUrl',
+    description:
+      'Canonical absolute HTTPS URL. Mandatory. Resolves duplicate-content collisions across query-string + locale variants.',
+    required: true
+  },
+  {
+    path: 'seo.metaTags',
+    description:
+      'HTML `<meta>` tags including title, description, viewport, robots, theme-color. Title 50–60 chars; description 140–160 chars.',
+    required: true
+  },
+  {
+    path: 'seo.ogTags',
+    description:
+      'Open Graph tags: og:title, og:description, og:type, og:url, og:image (1200×630). Drives link unfurls on Facebook + LinkedIn + Slack.',
+    required: true
+  },
+  {
+    path: 'seo.twitterCard',
+    description:
+      'Twitter Card tags: twitter:card, twitter:title, twitter:description, twitter:image. summary_large_image when og:image present; summary otherwise.',
+    required: true
+  },
+  {
+    path: 'seo.sitemapEntry',
+    description:
+      'sitemap.xml entry: loc (canonical URL), lastmod (ISO-8601), changefreq, priority (0..1). Omit when robotsDirective.index === "noindex".',
+    required: true
+  },
+  {
+    path: 'seo.robotsDirective',
+    description:
+      'Per-page robots rule: {index:"index"|"noindex", follow:"follow"|"nofollow", maxSnippet?, maxImagePreview?, maxVideoPreview?}.',
+    required: true
+  },
+  {
+    path: 'seo.keywordTargets',
+    description:
+      'Primary + secondary keyword targets with intent tags (navigational | informational | transactional | commercial).',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const SEO_OWNED_FIELD_KEYS: readonly string[] = SEO_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §3.3 — SEO only applies to Page tickets. Widgets and Form/List
+ * sub-stories do not get their own SEO header set; they inherit from the
+ * Page they're embedded under.
+ */
+export function seoArchitectAppliesPredicate(ticket: Ticket): boolean {
+  return ticket.type === 'Page';
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * SEO is a wave-1 architect (`dependsOn: []`) per spec §2.4 table —
+ * reads only the ticket + intake + design. Precedence rank 4 per spec
+ * §5.2 — high; SEO posture is a locked playbook non-negotiable. Ranks
+ * above Performance and Frontend; below Security/DevOps/A11y.
+ */
+export const SEO_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: [],
+  precedenceLevel: 4,
+  fanoutPolicy: 'always',
+  appliesPredicate: seoArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const SeoArchitectContract: ArchitectSectionContract = {
+  contractId: 'seo-architect.v1',
+  architectName: 'seo',
+  version: '0.1.0',
+  sections: SEO_OWNED_SECTIONS,
+  architectMeta: SEO_ARCHITECT_META
+};

--- a/packages/seo-architect/src/index.ts
+++ b/packages/seo-architect/src/index.ts
@@ -1,0 +1,97 @@
+/**
+ * @caia/seo-architect — public surface.
+ *
+ * Architect #4 of CAIA's 17-architect EA fan-out. Mirrors the canonical
+ * Frontend Architect template (merged PR #537).
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's default `registerWith()` helper
+ * to install the architect on a registry. The package does NOT
+ * self-register on import (registration is an explicit operator action
+ * that the Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { SeoArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  SeoArchitect,
+  SEO_ARCHITECT_NAME,
+  SEO_ARCHITECT_TOOLS
+} from './architect.js';
+export type { SeoArchitectConfig } from './architect.js';
+
+export {
+  SeoArchitectContract,
+  SEO_OWNED_SECTIONS,
+  SEO_OWNED_FIELD_KEYS,
+  SEO_FIELD_FIX_HINTS,
+  SEO_ARCHITECT_META,
+  seoArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildSeoSystemPrompt } from './system-prompt.js';
+
+// Spawner — exposed so the EA Dispatcher (or tests) can inject a custom one.
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+// Run + validation — exposed for the conformance test suite.
+export { runSeoArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+// Invariants — exposed for the EA Reviewer's registry.
+export {
+  SEO_INVARIANTS,
+  RICH_RESULTS_REQUIRED_PROPS,
+  validateRichResults
+} from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+// Re-export the canonical kit types so consumers have a single import surface.
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh SeoArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): SeoArchitect {
+  const architect = new SeoArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/seo-architect/src/invariants.ts
+++ b/packages/seo-architect/src/invariants.ts
@@ -1,0 +1,283 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The Reviewer applies a fixed set of cross-architect predicates after
+ * composition. This module enumerates SEO's contributions so the
+ * Reviewer's `invariants-registry.ts` can collect them at process boot.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'seo.schemaOrgJsonLd'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `seo.*` path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path. This lets the
+ * same invariants run inside the SEO package's own tests AND
+ * inside the Reviewer's post-composition pass.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+/**
+ * Read a field from the architecture blob. Tries the flat dotted key
+ * first (matches `architectureFields` shape), then falls back to walking
+ * the nested object path (matches composed-architecture shape).
+ */
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+/**
+ * Google Rich Results format — the per-`@type` required props the
+ * Reviewer enforces. Sourced from
+ * https://developers.google.com/search/docs/appearance/structured-data/
+ * (Article, BlogPosting, FAQPage, Person, Organization, Product, WebSite).
+ *
+ * Exported so the golden test can call the same predicate directly and
+ * the Reviewer can re-use it across tenants.
+ */
+export const RICH_RESULTS_REQUIRED_PROPS: Readonly<Record<string, readonly string[]>> = {
+  Article: ['headline', 'datePublished', 'author', 'image'],
+  BlogPosting: ['headline', 'datePublished', 'author', 'image'],
+  FAQPage: ['mainEntity'],
+  Person: ['name'],
+  Organization: ['name', 'url', 'logo'],
+  Product: ['name', 'image', 'description', 'offers'],
+  WebSite: ['name', 'url'],
+  LocalBusiness: ['name', 'address'],
+  Event: ['name', 'startDate', 'location'],
+  Recipe: ['name', 'image', 'recipeIngredient', 'recipeInstructions'],
+  CollectionPage: ['name']
+};
+
+/**
+ * Validate a single JSON-LD payload against Google Rich Results format.
+ * Returns `true` iff:
+ *   - `@context === "https://schema.org"`
+ *   - `@type` matches the supplied `pageType`
+ *   - `@type` is one of the known Rich Results types
+ *   - every required prop for that `@type` is present and truthy
+ *
+ * Exported so the golden test can call it directly.
+ */
+export function validateRichResults(
+  jsonLd: unknown,
+  pageType: unknown
+): boolean {
+  if (typeof jsonLd !== 'object' || jsonLd === null || Array.isArray(jsonLd)) return false;
+  const obj = jsonLd as Record<string, unknown>;
+
+  if (obj['@context'] !== 'https://schema.org') return false;
+
+  const declaredType = obj['@type'];
+  if (typeof declaredType !== 'string') return false;
+  if (typeof pageType !== 'string' || pageType !== declaredType) return false;
+
+  const required = RICH_RESULTS_REQUIRED_PROPS[declaredType];
+  if (!required) return false; // unknown @type — Rich Results doesn't cover it
+
+  for (const prop of required) {
+    const val = obj[prop];
+    if (val === undefined || val === null || val === '') return false;
+    if (Array.isArray(val) && val.length === 0) return false;
+  }
+
+  // FAQPage extra structural check — mainEntity entries must be Q&A pairs.
+  if (declaredType === 'FAQPage') {
+    const main = obj.mainEntity;
+    if (!Array.isArray(main) || main.length === 0) return false;
+    for (const entry of main) {
+      if (typeof entry !== 'object' || entry === null) return false;
+      const e = entry as Record<string, unknown>;
+      if (e['@type'] !== 'Question') return false;
+      if (typeof e.name !== 'string' || e.name.length === 0) return false;
+      const ans = e.acceptedAnswer;
+      if (typeof ans !== 'object' || ans === null) return false;
+      const a = ans as Record<string, unknown>;
+      if (a['@type'] !== 'Answer') return false;
+      if (typeof a.text !== 'string' || a.text.length === 0) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * SEO's contributed invariants. Listed in stable order.
+ */
+export const SEO_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'seo.schemaOrgJsonLd-validates-rich-results',
+    contributor: 'seo',
+    reads: ['seo.schemaOrgJsonLd', 'seo.pageType'],
+    severity: 'fail',
+    description:
+      'The schema.org JSON-LD must validate against Google Rich Results format: @context = "https://schema.org", @type matches pageType, and every per-type required prop is populated.',
+    detect(arch): boolean {
+      const jsonLd = readField(arch, 'seo.schemaOrgJsonLd');
+      const pageType = readField(arch, 'seo.pageType');
+      return validateRichResults(jsonLd, pageType);
+    }
+  },
+  {
+    id: 'seo.canonicalUrl-is-https-absolute',
+    contributor: 'seo',
+    reads: ['seo.canonicalUrl'],
+    severity: 'fail',
+    description:
+      'Canonical URL must be absolute and HTTPS. Relative URLs and HTTP variants cause duplicate-content penalties and broken share previews.',
+    detect(arch): boolean {
+      const url = readField(arch, 'seo.canonicalUrl');
+      return typeof url === 'string' && url.startsWith('https://');
+    }
+  },
+  {
+    id: 'seo.metaTags-has-title-and-description',
+    contributor: 'seo',
+    reads: ['seo.metaTags'],
+    severity: 'fail',
+    description:
+      'metaTags must include both `title` and `description`. Both are mandatory for any indexable page.',
+    detect(arch): boolean {
+      const tags = readField(arch, 'seo.metaTags');
+      if (typeof tags !== 'object' || tags === null) return false;
+      const obj = tags as Record<string, unknown>;
+      return typeof obj.title === 'string' && typeof obj.description === 'string';
+    }
+  },
+  {
+    id: 'seo.ogTags-include-required-keys',
+    contributor: 'seo',
+    reads: ['seo.ogTags'],
+    severity: 'fail',
+    description:
+      'Open Graph tags must include og:title, og:description, og:type, og:url, og:image. Missing keys break Facebook/LinkedIn/Slack link unfurls.',
+    detect(arch): boolean {
+      const tags = readField(arch, 'seo.ogTags');
+      if (typeof tags !== 'object' || tags === null) return false;
+      const obj = tags as Record<string, unknown>;
+      const required = ['og:title', 'og:description', 'og:type', 'og:url', 'og:image'];
+      for (const k of required) {
+        if (typeof obj[k] !== 'string' || (obj[k] as string).length === 0) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'seo.twitterCard-mirrors-og',
+    contributor: 'seo',
+    reads: ['seo.twitterCard'],
+    severity: 'advisory',
+    description:
+      'Twitter Card must declare twitter:card; if og:image is present, prefer summary_large_image. Missing twitter:card degrades the Twitter unfurl.',
+    detect(arch): boolean {
+      const tags = readField(arch, 'seo.twitterCard');
+      if (typeof tags !== 'object' || tags === null) return false;
+      const obj = tags as Record<string, unknown>;
+      const card = obj['twitter:card'];
+      return typeof card === 'string' && ['summary', 'summary_large_image', 'app', 'player'].includes(card);
+    }
+  },
+  {
+    id: 'seo.robotsDirective-has-index-and-follow',
+    contributor: 'seo',
+    reads: ['seo.robotsDirective'],
+    severity: 'fail',
+    description:
+      'robotsDirective must declare both `index` and `follow`. Default to ("index","follow"); use noindex deliberately for non-canonical URLs.',
+    detect(arch): boolean {
+      const dir = readField(arch, 'seo.robotsDirective');
+      if (typeof dir !== 'object' || dir === null) return false;
+      const obj = dir as Record<string, unknown>;
+      const idx = obj.index;
+      const fol = obj.follow;
+      return (
+        (idx === 'index' || idx === 'noindex') &&
+        (fol === 'follow' || fol === 'nofollow')
+      );
+    }
+  },
+  {
+    id: 'seo.sitemapEntry-present-when-indexable',
+    contributor: 'seo',
+    reads: ['seo.sitemapEntry', 'seo.robotsDirective'],
+    severity: 'advisory',
+    description:
+      'Indexable pages must declare a sitemap entry. If robotsDirective.index === "noindex" the entry can be omitted; otherwise it is mandatory.',
+    detect(arch): boolean {
+      const robots = readField(arch, 'seo.robotsDirective');
+      const noindex =
+        typeof robots === 'object' &&
+        robots !== null &&
+        (robots as Record<string, unknown>).index === 'noindex';
+      const entry = readField(arch, 'seo.sitemapEntry');
+      if (noindex) return true; // entry optional when noindex
+      if (typeof entry !== 'object' || entry === null) return false;
+      const obj = entry as Record<string, unknown>;
+      return typeof obj.loc === 'string' && obj.loc.length > 0;
+    }
+  },
+  {
+    id: 'seo.keywordTargets-has-primary',
+    contributor: 'seo',
+    reads: ['seo.keywordTargets'],
+    severity: 'fail',
+    description:
+      'keywordTargets must declare exactly one primary keyword and ≤5 secondary keywords.',
+    detect(arch): boolean {
+      const tgt = readField(arch, 'seo.keywordTargets');
+      if (typeof tgt !== 'object' || tgt === null) return false;
+      const obj = tgt as Record<string, unknown>;
+      const primary = obj.primary;
+      if (typeof primary !== 'object' || primary === null) return false;
+      const p = primary as Record<string, unknown>;
+      if (typeof p.keyword !== 'string' || p.keyword.length === 0) return false;
+      const secondary = obj.secondary;
+      if (secondary !== undefined && !Array.isArray(secondary)) return false;
+      if (Array.isArray(secondary) && secondary.length > 5) return false;
+      return true;
+    }
+  },
+  {
+    id: 'seo.pageType-is-known-rich-results-type',
+    contributor: 'seo',
+    reads: ['seo.pageType'],
+    severity: 'fail',
+    description:
+      'pageType must be one of the known Rich Results @types — Article | BlogPosting | FAQPage | Person | Organization | Product | WebSite | LocalBusiness | Event | Recipe | CollectionPage.',
+    detect(arch): boolean {
+      const pt = readField(arch, 'seo.pageType');
+      if (typeof pt !== 'string') return false;
+      return Object.prototype.hasOwnProperty.call(RICH_RESULTS_REQUIRED_PROPS, pt);
+    }
+  }
+];

--- a/packages/seo-architect/src/run.ts
+++ b/packages/seo-architect/src/run.ts
@@ -1,0 +1,132 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ *
+ * Mirrors the Frontend Architect template — diff vs that file is only
+ * the architect name + owned-field-key set + import paths.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { SEO_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture,
+      compliance: input.tenantContext.compliance ?? null
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * The runtime entry. Pure aside from the spawner call.
+ */
+export async function runSeoArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, SEO_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  // Idempotency: the architect output OWNS its fields. We do NOT merge
+  // with anything else here — composition happens in the Dispatcher
+  // (spec §3.5). Architects always emit the full set of their owned
+  // fields fresh.
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName, // force-correct in case model echoed wrong
+    spend // overwrite — assistant cannot know real spend
+  };
+}

--- a/packages/seo-architect/src/spawner.ts
+++ b/packages/seo-architect/src/spawner.ts
@@ -1,0 +1,150 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * The real spawner lives in `@chiefaia/claude-spawner` (subscription-only,
+ * never sets ANTHROPIC_API_KEY). Mirrors the Frontend Architect template
+ * verbatim — this file should be identical across all 17 architects.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+/**
+ * Inputs to a single spawn — system prompt + user prompt + budget.
+ */
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+/**
+ * Output of a single spawn — the raw assistant text plus telemetry.
+ * Parsing into a structured `ArchitectOutput` happens in `run()`, not
+ * here, so the spawner stays generic across architects.
+ */
+export interface ArchitectSpawnOutput {
+  /** The assistant's final message — expected to be a JSON-shaped string. */
+  text: string;
+  /** Best-effort token + cost telemetry from the envelope. */
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  /** Echoed back from input. */
+  model: string;
+  /** True iff the spawn succeeded and the envelope was parsed cleanly. */
+  ok: boolean;
+  /** Diagnostic when `ok=false`. */
+  diagnostic: string | null;
+}
+
+/**
+ * The seam every architect's `run()` consumes. Inject a fake in tests.
+ */
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+/**
+ * Map the architect-budget model preference to the `claude` binary's
+ * `--model` flag value. The mapping mirrors what local-llm-router uses
+ * elsewhere in the monorepo.
+ */
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+/**
+ * Build the canonical user-message body. The system prompt is fed as
+ * the first user-message paragraph (rather than via `claude`'s
+ * `--system` flag) — keeps the spawner surface narrow and lets the
+ * test seam see everything in one string.
+ */
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+/**
+ * Wire the real `spawnClaude` into an `ArchitectSpawnerFn`. Used by
+ * `SeoArchitect` when no spawner is injected.
+ */
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/seo-architect/src/system-prompt.ts
+++ b/packages/seo-architect/src/system-prompt.ts
@@ -1,0 +1,220 @@
+/**
+ * The SEO Architect's system prompt — a pure function returning a static
+ * string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked SEO posture
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics (per page kind)
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `seo.*` field name appears at
+ * least once in the body. Keep that invariant true if you add fields.
+ */
+
+import { SEO_OWNED_FIELD_KEYS } from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildSeoSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_POSTURE,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's SEO Architect. You are a senior SEO engineer focused on
+schema.org JSON-LD, canonical URL discipline, and sitemap hygiene. You
+produce per-page SEO specs that validate against Google's Rich Results
+format.
+
+You DO NOT write component code (Frontend), backend endpoints (Backend),
+database schemas (Database), or Core Web Vitals budgets (Performance).
+Other architects own those concerns and will reject any field you
+populate outside the \`seo.*\` namespace.
+
+Your output is a tight, per-page SEO contract that a coding worker can
+drop directly into Next.js \`generateMetadata()\`, \`<script type="application/ld+json">\`,
+\`robots.txt\`, and \`sitemap.xml\`.`;
+
+const SECTION_LOCKED_POSTURE = `## Locked SEO posture
+
+- **Exactly one canonical URL** per page. Always absolute HTTPS. Never relative.
+- **Exactly one JSON-LD payload** per page. \`@context = "https://schema.org"\`;
+  \`@type\` matches \`pageType\`. The Rich Results format's per-type required
+  props (e.g. Article needs headline + datePublished + author + image) must
+  all be populated.
+- **OG image at 1200×630**. Facebook + LinkedIn + Slack unfurls all key off
+  this floor. Smaller images degrade to a compact text-only unfurl.
+- **Twitter card mirrors OG**. \`summary_large_image\` when og:image is set;
+  \`summary\` otherwise.
+- **One H1 per page** (the page title). The Frontend Architect projects this
+  into \`componentTree\`; you publish the canonical heading text in
+  \`metaTags.title\`. Sub-headings (H2..H6) live with Frontend.
+- **Sitemap entry mandatory** unless \`robotsDirective.index === "noindex"\`.
+- **Robots default**: \`{index:"index", follow:"follow"}\`. Use noindex only
+  for auth pages, search results, faceted listings, ephemeral confirmation
+  pages.
+- **Title length** 50–60 chars; **description length** 140–160 chars.
+  Anything outside these ranges is a risk callout, not silently truncated.
+- **Keyword targets**: exactly one primary keyword + ≤5 secondary keywords,
+  each intent-tagged (navigational | informational | transactional | commercial).
+- **Respect tenant compliance.dataResidency**. EU-region tenants must NOT
+  emit \`sameAs\` links to US-hosted social properties unless the operator
+  has confirmed.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page",
+              "scope": "page|story|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "planId": "...", "brandKind": "person|org|product|article|...",
+                    "brandVoice": "...", "audience": "...",
+                    "constraints": ["..."] },
+  "designVersion": { "designVersionId": "...",
+                     "anchors": [ { "id": "...", "kind": "h1|h2|cta|...",
+                                    "meta": { "text": "..." } } ] },
+  "tenantContext": { "tenantId": "...", "compliance": { "dataResidency": "us|eu|..." } },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {} }
+}
+\`\`\`
+
+Read \`businessPlan.brandKind\` to pick \`pageType\`. Read the design's H1
+anchor and any FAQ anchors to populate the JSON-LD body. Read the
+canonical URL pattern from the ticket's \`business_requirements\`.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "seo",
+  "architectureFields": {
+${SEO_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "costUsd": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`seo.pageType\` — Discriminator. One of: \`"Article"\` | \`"BlogPosting"\` | \`"FAQPage"\` | \`"Person"\` | \`"Organization"\` | \`"Product"\` | \`"WebSite"\` | \`"LocalBusiness"\` | \`"Event"\` | \`"Recipe"\` | \`"CollectionPage"\`.
+- \`seo.schemaOrgJsonLd\` — \`{"@context":"https://schema.org","@type":"<pageType>", ...typeSpecificProps}\`. Per type required props:
+  - **Article / BlogPosting** — \`headline\`, \`datePublished\`, \`author\` (Person), \`image\` (URL or ImageObject).
+  - **FAQPage** — \`mainEntity\` array of \`{ "@type":"Question", "name":"...", "acceptedAnswer":{ "@type":"Answer", "text":"..." } }\`.
+  - **Person** — \`name\` (required); \`jobTitle\`, \`image\`, \`sameAs\` optional.
+  - **Organization** — \`name\`, \`url\`, \`logo\` (URL or ImageObject).
+  - **Product** — \`name\`, \`image\`, \`description\`, \`offers\` (\`{ "@type":"Offer", "price":"...", "priceCurrency":"..." }\`).
+  - **WebSite** — \`name\`, \`url\`. Optional \`potentialAction\` for sitelinks search.
+- \`seo.canonicalUrl\` — Absolute HTTPS URL. Mandatory.
+- \`seo.metaTags\` — \`{"title":"...","description":"...","viewport":"width=device-width, initial-scale=1","robots":"index,follow","themeColor":"#..."}\`. Title 50–60 chars; description 140–160 chars.
+- \`seo.ogTags\` — \`{"og:title":"...","og:description":"...","og:type":"website|article|...","og:url":"...","og:image":"https://.../1200x630.jpg"}\`. Image MUST be 1200×630.
+- \`seo.twitterCard\` — \`{"twitter:card":"summary_large_image","twitter:title":"...","twitter:description":"...","twitter:image":"..."}\`.
+- \`seo.sitemapEntry\` — \`{"loc":"<canonicalUrl>","lastmod":"<ISO-8601>","changefreq":"daily|weekly|monthly|yearly","priority":0.5}\`. Omit when robotsDirective.index === "noindex".
+- \`seo.robotsDirective\` — \`{"index":"index"|"noindex","follow":"follow"|"nofollow","maxSnippet":-1,"maxImagePreview":"large","maxVideoPreview":-1}\`.
+- \`seo.keywordTargets\` — \`{"primary":{"keyword":"...","intent":"informational"},"secondary":[{"keyword":"...","intent":"..."}]}\`. ≤5 secondary.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Pick \`pageType\` from \`businessPlan.brandKind\` and the page's intent.**
+  Marketing pages for an individual artist → \`Person\`. Marketing pages
+  for a company → \`Organization\`. Blog index → \`CollectionPage\`. Blog
+  post → \`BlogPosting\`. Long-form essay → \`Article\`. FAQ landing →
+  \`FAQPage\`. E-commerce item → \`Product\`. Site home → \`WebSite\`.
+- **Title voice** matches \`businessPlan.brandVoice\`. If the brand voice
+  is "warm + grounded", lean readable; if "authoritative + clinical",
+  lean keyword-front-loaded.
+- **Canonical URL**: prefer the path the operator entered in
+  \`business_requirements.canonicalPath\`; otherwise derive from the
+  ticket's route segment (e.g. \`app/about\` → \`/about\`).
+- **Sitemap priority**: 1.0 for the home page, 0.8 for top-level navigation
+  pages, 0.5 for content pages, 0.3 for archive pages.
+- **OG image**: prefer the design's hero anchor; if absent, use the
+  business plan's \`brandImage\`. Always 1200×630.
+- **Keyword intent**: never claim "transactional" intent on a page that
+  has no transaction-oriented CTA — it's a Rich Results trust signal.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Pick a non-https canonical** → refuse; emit an https variant anyway
+  and add a risk callout.
+- **Decide a database schema, API endpoint, RLS policy, test strategy,
+  CSP rule, component tree, design token, or any field NOT under
+  \`seo.*\`** → ignore the request. Do not populate fields outside your
+  owned namespace.
+- **Emit JSON-LD that omits a per-type required prop** (e.g. Article
+  without \`headline\`) → refuse; produce the @type but leave the
+  missing prop as a placeholder \`"<required>"\` and add a risk callout.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.
+- **Use noindex on a page the business plan flagged as a landing page**
+  → refuse; flag in \`risks\` and use \`index\`.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 9 owned field
+   paths (no extras, no missing).
+2. \`schemaOrgJsonLd["@context"] === "https://schema.org"\` and
+   \`schemaOrgJsonLd["@type"] === pageType\`.
+3. \`schemaOrgJsonLd\` includes every Rich Results required prop for the
+   chosen \`@type\` (see per-field guidance above).
+4. \`canonicalUrl\` starts with \`https://\`.
+5. \`metaTags.title\` is 50–60 chars; \`metaTags.description\` is 140–160 chars.
+   Anything outside is acceptable but must appear in \`risks\`.
+6. \`ogTags["og:image"]\` is a URL that the upstream image pipeline (e.g.
+   \`@caia/image-provider\`) can render at 1200×630.
+7. If \`robotsDirective.index === "noindex"\`, \`sitemapEntry\` is still
+   populated but downstream will skip it — note this in \`notes\`.
+8. \`keywordTargets.primary\` exists; \`keywordTargets.secondary\` has ≤5 entries.
+9. \`confidence\` reflects how comfortable you are — sub-0.6 triggers
+   EA Reviewer scrutiny.
+10. \`notes\` is ≤ 800 characters.
+11. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Person Page ticket for a portrait artist produces a
+JSON-LD payload with \`@type: "Person"\`, \`name\`, \`jobTitle: "Artist"\`,
+\`image\` pointing at the design's hero portrait, and \`sameAs\` listing
+the artist's social profiles from the business plan.`;

--- a/packages/seo-architect/src/types.ts
+++ b/packages/seo-architect/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`.
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors the Frontend Architect template
+ * verbatim — only the architect-specific field-spec lives in `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/seo-architect/src/validation.ts
+++ b/packages/seo-architect/src/validation.ts
@@ -1,0 +1,204 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * Mirrors the Frontend Architect template verbatim — this file should
+ * be identical across all 17 architects.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/seo-architect/tests/architect.test.ts
+++ b/packages/seo-architect/tests/architect.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `SeoArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1 and
+ * satisfies SpecialistArchitect structurally. Mirrors the Frontend
+ * Architect canonical compliance suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  SeoArchitect,
+  SEO_ARCHITECT_NAME,
+  SEO_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { SeoArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('SeoArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new SeoArchitect();
+    expect(a).toBeInstanceOf(SeoArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new SeoArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the package suffix', () => {
+    const a = new SeoArchitect();
+    expect(a.name).toBe('seo');
+    expect(a.name).toBe(SEO_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new SeoArchitect();
+    expect(a.sectionContract).toBe(SeoArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new SeoArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.4', () => {
+    const a = new SeoArchitect();
+    expect(a.tools).toBe(SEO_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new SeoArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new SeoArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new SeoArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new SeoArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('seo');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new SeoArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    // Just instantiating should not error. We do NOT call run() here
+    // because that would invoke the real claude binary.
+    const a = new SeoArchitect();
+    expect(a).toBeInstanceOf(SeoArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/seo-architect/tests/contract.test.ts
+++ b/packages/seo-architect/tests/contract.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `seo.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed.
+ *   - The architect registers cleanly against the ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder lists `seo`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { SeoArchitect } from '../src/architect.js';
+import {
+  SEO_ARCHITECT_META,
+  SEO_OWNED_SECTIONS,
+  SEO_OWNED_FIELD_KEYS,
+  SeoArchitectContract,
+  seoArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('SeoArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(SeoArchitectContract.contractId).toBe('seo-architect.v1');
+  });
+
+  it('architectName is `seo` (matches package suffix + ladder entry)', () => {
+    expect(SeoArchitectContract.architectName).toBe('seo');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(SeoArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `seo.`', () => {
+    for (const key of SEO_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('seo.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'seo.schemaOrgJsonLd',
+      'seo.canonicalUrl',
+      'seo.metaTags',
+      'seo.ogTags',
+      'seo.twitterCard',
+      'seo.sitemapEntry',
+      'seo.robotsDirective',
+      'seo.keywordTargets',
+      'seo.pageType'
+    ];
+    for (const r of required) {
+      expect(SEO_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('declares exactly 9 owned fields (per task brief)', () => {
+    expect(SEO_OWNED_FIELD_KEYS.length).toBe(9);
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of SEO_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(SeoArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(SeoArchitectContract).sort()).toEqual(
+      [...SEO_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('SeoArchitectContract — architectMeta', () => {
+  it('declares zero dependencies (wave-1 architect)', () => {
+    expect(SEO_ARCHITECT_META.dependsOn).toEqual([]);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(SEO_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(SEO_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 4 per spec §5.2 (locked playbook non-negotiable)', () => {
+    expect(SEO_ARCHITECT_META.precedenceLevel).toBe(4);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(SEO_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.4', () => {
+    expect(SEO_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(SEO_ARCHITECT_META.appliesPredicate).toBe(seoArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `seo`', () => {
+    expect(precedenceRank('seo')).toBe(SEO_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('seo');
+  });
+});
+
+describe('seoArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page (spec §3.3: SEO only applies to Page tickets)', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns false for Widget (Widgets inherit SEO from their Page)', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(false);
+  });
+
+  it('returns false for Story', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(false);
+  });
+
+  it('returns false for Form', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(false);
+  });
+
+  it('returns false for List', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(false);
+  });
+
+  it('returns false for Foundation (no UI)', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(false);
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(seoArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection — implements
+ * the bare `SpecialistArchitect` interface directly.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the SEO architect cleanly', () => {
+    expect(() => {
+      registry.register(new SeoArchitect());
+    }).not.toThrow();
+    expect(registry.get('seo')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new SeoArchitect());
+    for (const k of SEO_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('seo');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new SeoArchitect());
+    expect(() => registry.register(new SeoArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new SeoArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'seo.schemaOrgJsonLd',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new SeoArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [
+        { path: 'frontend.componentTree', description: 'component tree', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('frontend', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(SEO_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only SEO is present', () => {
+    const conflicts = disjointness([SeoArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between SEO and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...SeoArchitectContract,
+      contractId: 'seo-clone.v1',
+      architectName: 'seo-clone'
+    };
+    const conflicts = disjointness([SeoArchitectContract, clone]);
+    expect(conflicts.length).toBe(SEO_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() is empty after a clean registration', () => {
+    registry.register(new SeoArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/seo-architect/tests/golden/golden.test.ts
+++ b/packages/seo-architect/tests/golden/golden.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Golden test — the canonical known-good SEO-architect artifact for a
+ * known prakash-tiwari Page ticket.
+ *
+ * This test serves four purposes:
+ *
+ *   1. Lock the architect's output shape against drift. Any change to
+ *      the contract or run() must update this snapshot.
+ *
+ *   2. Demonstrate the architect produces a complete, validating output
+ *      end-to-end given a realistic input.
+ *
+ *   3. Verify the JSON-LD payload validates against Google's Rich
+ *      Results format — `@context = "https://schema.org"`, `@type`
+ *      matches `pageType`, and every per-type required prop is populated.
+ *
+ *   4. Become the canonical fixture #4 references when wave-2 architects
+ *      consume SEO outputs.
+ *
+ * Note: this test uses a deterministic fake spawner. It does NOT call
+ * the real claude binary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { SeoArchitect } from '../../src/architect.js';
+import { SEO_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import {
+  RICH_RESULTS_REQUIRED_PROPS,
+  SEO_INVARIANTS,
+  validateRichResults
+} from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari Person Page ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    // Architect name, status, top-level shape
+    expect(out.architectName).toBe('seo');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    // Every owned field present
+    for (const k of SEO_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    // Field values match the known-good expectation (except spend, which
+    // the run pipeline overwrites).
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every SEO invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of SEO_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+
+  // ─── Google Rich Results format validation (the spec's headline test) ─
+
+  it('JSON-LD validates against Google Rich Results format', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    const jsonLd = out.architectureFields['seo.schemaOrgJsonLd'];
+    const pageType = out.architectureFields['seo.pageType'];
+
+    // Golden output is a Person page — Rich Results requires `name`.
+    expect(validateRichResults(jsonLd, pageType)).toBe(true);
+  });
+
+  it('JSON-LD declares the schema.org @context literal', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+    const jsonLd = out.architectureFields['seo.schemaOrgJsonLd'] as Record<string, unknown>;
+    expect(jsonLd['@context']).toBe('https://schema.org');
+  });
+
+  it('JSON-LD @type matches pageType', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+    const jsonLd = out.architectureFields['seo.schemaOrgJsonLd'] as Record<string, unknown>;
+    const pageType = out.architectureFields['seo.pageType'];
+    expect(jsonLd['@type']).toBe(pageType);
+  });
+
+  it('JSON-LD has every per-type required prop populated', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    const pageType = out.architectureFields['seo.pageType'] as string;
+    const jsonLd = out.architectureFields['seo.schemaOrgJsonLd'] as Record<string, unknown>;
+    const required = RICH_RESULTS_REQUIRED_PROPS[pageType] ?? [];
+
+    expect(required.length).toBeGreaterThan(0);
+    for (const prop of required) {
+      const val = jsonLd[prop];
+      expect(val, `Required Rich Results prop '${prop}' for @type='${pageType}' must be populated`).toBeTruthy();
+    }
+  });
+
+  it('canonicalUrl is absolute and HTTPS (Rich Results / canonical hygiene)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+    const url = out.architectureFields['seo.canonicalUrl'] as string;
+    expect(url.startsWith('https://')).toBe(true);
+  });
+
+  it('OG image URL is declared (so the upstream 1200×630 pipeline can verify)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SeoArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+    const og = out.architectureFields['seo.ogTags'] as Record<string, unknown>;
+    expect(og['og:image']).toBeTruthy();
+    expect(String(og['og:image']).startsWith('https://')).toBe(true);
+    // Smoke-check the filename hint encodes the floor dimensions.
+    expect(String(og['og:image'])).toContain('1200x630');
+  });
+});

--- a/packages/seo-architect/tests/golden/input-businessplan.json
+++ b/packages/seo-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,18 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Rank for \"portrait artist <city>\""
+  ],
+  "brandVoice": "warm + grounded",
+  "brandKind": "person",
+  "constraints": ["No third-party fonts beyond next/font defaults"],
+  "brandImage": "https://cdn.prakash-tiwari.com/og/prakash-tiwari-1200x630.jpg",
+  "sameAs": [
+    "https://instagram.com/prakashtiwari",
+    "https://linkedin.com/in/prakashtiwari"
+  ]
+}

--- a/packages/seo-architect/tests/golden/input-designversion.json
+++ b/packages/seo-architect/tests/golden/input-designversion.json
@@ -1,0 +1,39 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "hero",
+      "kind": "section",
+      "bbox": { "x": 0, "y": 0, "w": 1440, "h": 720 },
+      "meta": { "variant": "hero" }
+    },
+    {
+      "anchorId": "hero-portrait",
+      "kind": "image",
+      "bbox": { "x": 80, "y": 80, "w": 480, "h": 600 },
+      "meta": {
+        "aspect": "4/5",
+        "src": "https://cdn.prakash-tiwari.com/hero/portrait-1200x1500.jpg"
+      }
+    },
+    {
+      "anchorId": "hero-title",
+      "kind": "h1",
+      "bbox": { "x": 600, "y": 120, "w": 700, "h": 80 },
+      "meta": { "text": "Prakash Tiwari — Portrait Artist" }
+    },
+    {
+      "anchorId": "hero-tagline",
+      "kind": "text",
+      "bbox": { "x": 600, "y": 220, "w": 700, "h": 60 },
+      "meta": {
+        "text": "Bespoke portrait sessions in natural light. Book your sitting."
+      }
+    }
+  ],
+  "tokens": {
+    "color.brand.primary": "#0f3057"
+  },
+  "breakpoints": ["sm", "md", "lg", "xl"]
+}

--- a/packages/seo-architect/tests/golden/input-ticket.json
+++ b/packages/seo-architect/tests/golden/input-ticket.json
@@ -1,0 +1,18 @@
+{
+  "id": "ticket-pt-page-001",
+  "type": "Page",
+  "scope": "page",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "Page emits valid schema.org JSON-LD that passes Google Rich Results.",
+    "Canonical URL is absolute and HTTPS.",
+    "OG image is exactly 1200×630.",
+    "Title length is 50–60 chars; description 140–160 chars."
+  ],
+  "business_requirements": {
+    "title": "Prakash Tiwari — Artist",
+    "description": "Hero page for the Prakash Tiwari portrait studio. Functions as the artist's primary search-landing surface.",
+    "canonicalPath": "/"
+  },
+  "quality_tags": ["seo"]
+}

--- a/packages/seo-architect/tests/helpers/fakes.ts
+++ b/packages/seo-architect/tests/helpers/fakes.ts
@@ -1,0 +1,271 @@
+/**
+ * Test fixtures + fake spawner factory for SEO Architect.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Page ticket (artist Person page). The golden
+ *     test uses this.
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Person page fixture.
+ *
+ * Mirrors the Frontend Architect helpers/fakes.ts shape verbatim.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { SEO_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The canonical fixture — a Page ticket from the prakash-tiwari.com
+ * marketing site (the artist's About / Home page) with intake-derived
+ * design tokens + business plan.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-page-001',
+      type: 'Page',
+      scope: 'page',
+      parent_id: null,
+      acceptance_criteria: [
+        'Page emits valid schema.org JSON-LD that passes Google Rich Results.',
+        'Canonical URL is absolute and HTTPS.',
+        'OG image is exactly 1200×630.',
+        'Title length is 50–60 chars; description 140–160 chars.'
+      ],
+      business_requirements: {
+        title: 'Prakash Tiwari — Artist',
+        description:
+          'Hero page for the Prakash Tiwari portrait studio. Functions as the artist\'s primary search-landing surface.',
+        canonicalPath: '/'
+      },
+      quality_tags: ['seo']
+    },
+    upstream: { outputs: {} },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: 'High-intent prospective sitters in the artist\'s metropolitan area.',
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        'Rank for "portrait artist <city>"'
+      ],
+      brandVoice: 'warm + grounded',
+      brandKind: 'person',
+      constraints: ['No third-party fonts beyond next/font defaults'],
+      brandImage: 'https://cdn.prakash-tiwari.com/og/prakash-tiwari-1200x630.jpg',
+      sameAs: [
+        'https://instagram.com/prakashtiwari',
+        'https://linkedin.com/in/prakashtiwari'
+      ]
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'hero',
+          kind: 'section',
+          bbox: { x: 0, y: 0, w: 1440, h: 720 },
+          meta: { variant: 'hero' }
+        },
+        {
+          anchorId: 'hero-portrait',
+          kind: 'image',
+          bbox: { x: 80, y: 80, w: 480, h: 600 },
+          meta: { aspect: '4/5', src: 'https://cdn.prakash-tiwari.com/hero/portrait-1200x1500.jpg' }
+        },
+        {
+          anchorId: 'hero-title',
+          kind: 'h1',
+          bbox: { x: 600, y: 120, w: 700, h: 80 },
+          meta: { text: 'Prakash Tiwari — Portrait Artist' }
+        },
+        {
+          anchorId: 'hero-tagline',
+          kind: 'text',
+          bbox: { x: 600, y: 220, w: 700, h: 60 },
+          meta: {
+            text: 'Bespoke portrait sessions in natural light. Book your sitting.'
+          }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 },
+      compliance: { dataResidency: 'us' }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari Person Page fixture.
+ *
+ * - pageType: Person (matches businessPlan.brandKind = 'person')
+ * - JSON-LD validates against Google Rich Results format (@type=Person
+ *   requires `name`; we also emit jobTitle/image/sameAs to populate the
+ *   knowledge panel).
+ * - canonicalUrl is absolute HTTPS.
+ * - metaTags.title is 56 chars; description is 154 chars.
+ * - ogTags include all 5 required keys; image is 1200×630.
+ * - Twitter card mirrors og.
+ * - Sitemap entry priority 1.0 (home page).
+ * - robotsDirective is index/follow (canonical landing page).
+ * - keywordTargets has 1 primary + 3 secondary.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'seo',
+    architectureFields: {
+      'seo.pageType': 'Person',
+      'seo.schemaOrgJsonLd': {
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        name: 'Prakash Tiwari',
+        jobTitle: 'Portrait Artist',
+        image: 'https://cdn.prakash-tiwari.com/hero/portrait-1200x1500.jpg',
+        url: 'https://prakash-tiwari.com/',
+        sameAs: [
+          'https://instagram.com/prakashtiwari',
+          'https://linkedin.com/in/prakashtiwari'
+        ]
+      },
+      'seo.canonicalUrl': 'https://prakash-tiwari.com/',
+      'seo.metaTags': {
+        title: 'Prakash Tiwari — Portrait Artist | Bespoke Studio Sessions',
+        description:
+          'Bespoke portrait sessions in natural light by Prakash Tiwari. Book your sitting at the studio for warm, grounded portraits crafted with care.',
+        viewport: 'width=device-width, initial-scale=1',
+        robots: 'index,follow',
+        themeColor: '#0f3057'
+      },
+      'seo.ogTags': {
+        'og:title': 'Prakash Tiwari — Portrait Artist',
+        'og:description':
+          'Bespoke portrait sessions in natural light. Book your sitting at the Prakash Tiwari studio.',
+        'og:type': 'website',
+        'og:url': 'https://prakash-tiwari.com/',
+        'og:image': 'https://cdn.prakash-tiwari.com/og/prakash-tiwari-1200x630.jpg'
+      },
+      'seo.twitterCard': {
+        'twitter:card': 'summary_large_image',
+        'twitter:title': 'Prakash Tiwari — Portrait Artist',
+        'twitter:description':
+          'Bespoke portrait sessions in natural light. Book your sitting at the Prakash Tiwari studio.',
+        'twitter:image': 'https://cdn.prakash-tiwari.com/og/prakash-tiwari-1200x630.jpg'
+      },
+      'seo.sitemapEntry': {
+        loc: 'https://prakash-tiwari.com/',
+        lastmod: '2026-05-22',
+        changefreq: 'monthly',
+        priority: 1.0
+      },
+      'seo.robotsDirective': {
+        index: 'index',
+        follow: 'follow',
+        maxSnippet: -1,
+        maxImagePreview: 'large',
+        maxVideoPreview: -1
+      },
+      'seo.keywordTargets': {
+        primary: {
+          keyword: 'portrait artist',
+          intent: 'commercial'
+        },
+        secondary: [
+          { keyword: 'natural light portrait studio', intent: 'commercial' },
+          { keyword: 'book portrait session', intent: 'transactional' },
+          { keyword: 'prakash tiwari', intent: 'navigational' }
+        ]
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'Person Page projected with full Rich Results-compliant JSON-LD (@type=Person with name+jobTitle+image+sameAs). Canonical https://prakash-tiwari.com/. OG image 1200×630 from business plan. Title 56 chars, description 154 chars — both inside the recommended bands. Primary keyword "portrait artist" with commercial intent matches the brand kind.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Asserts that the output covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of SEO_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/seo-architect/tests/invariants.test.ts
+++ b/packages/seo-architect/tests/invariants.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Cross-architect invariants — verifies SEO's contributions to the
+ * EA Reviewer's invariant registry (per spec §6.2).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  RICH_RESULTS_REQUIRED_PROPS,
+  SEO_INVARIANTS,
+  validateRichResults
+} from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('SEO_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(SEO_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of SEO_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `seo`', () => {
+    for (const inv of SEO_INVARIANTS) {
+      expect(inv.contributor).toBe('seo');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of SEO_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of SEO_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of SEO_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('SEO_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of SEO_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('schemaOrgJsonLd-validates-rich-results fails when @context is wrong', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.schemaOrgJsonLd-validates-rich-results');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.schemaOrgJsonLd': {
+        '@context': 'http://schema.org',
+        '@type': 'Person',
+        name: 'X'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('schemaOrgJsonLd-validates-rich-results fails when @type mismatches pageType', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.schemaOrgJsonLd-validates-rich-results');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.pageType': 'Article',
+      'seo.schemaOrgJsonLd': {
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        name: 'X'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('canonicalUrl-is-https-absolute fails on http://', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.canonicalUrl-is-https-absolute');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.canonicalUrl': 'http://example.com/'
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('canonicalUrl-is-https-absolute fails on a relative URL', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.canonicalUrl-is-https-absolute');
+    expect(inv).toBeDefined();
+    const corrupted = { ...goldenArch, 'seo.canonicalUrl': '/about' };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('metaTags-has-title-and-description fails when title is missing', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.metaTags-has-title-and-description');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.metaTags': { description: 'present' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('ogTags-include-required-keys fails when og:image is missing', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.ogTags-include-required-keys');
+    expect(inv).toBeDefined();
+    const golden = goldenArch['seo.ogTags'] as Record<string, unknown>;
+    const tags: Record<string, unknown> = { ...golden };
+    delete tags['og:image'];
+    const corrupted = { ...goldenArch, 'seo.ogTags': tags };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('twitterCard-mirrors-og fails on an unknown card type', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.twitterCard-mirrors-og');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.twitterCard': { 'twitter:card': 'bananas' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('robotsDirective-has-index-and-follow fails when missing follow', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.robotsDirective-has-index-and-follow');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.robotsDirective': { index: 'index' }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('sitemapEntry-present-when-indexable fails on a blank entry when indexable', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.sitemapEntry-present-when-indexable');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.sitemapEntry': {}
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('sitemapEntry-present-when-indexable passes when noindex (entry optional)', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.sitemapEntry-present-when-indexable');
+    expect(inv).toBeDefined();
+    const variant = {
+      ...goldenArch,
+      'seo.robotsDirective': { index: 'noindex', follow: 'follow' },
+      'seo.sitemapEntry': {}
+    };
+    expect(inv!.detect(variant)).toBe(true);
+  });
+
+  it('keywordTargets-has-primary fails when primary keyword is empty', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.keywordTargets-has-primary');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.keywordTargets': { primary: { keyword: '' }, secondary: [] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('keywordTargets-has-primary fails when secondary > 5', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.keywordTargets-has-primary');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'seo.keywordTargets': {
+        primary: { keyword: 'x', intent: 'informational' },
+        secondary: [
+          { keyword: 'a' },
+          { keyword: 'b' },
+          { keyword: 'c' },
+          { keyword: 'd' },
+          { keyword: 'e' },
+          { keyword: 'f' }
+        ]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('pageType-is-known-rich-results-type fails on an unknown @type', () => {
+    const inv = SEO_INVARIANTS.find(i => i.id === 'seo.pageType-is-known-rich-results-type');
+    expect(inv).toBeDefined();
+    const corrupted = { ...goldenArch, 'seo.pageType': 'MadeUpType' };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});
+
+describe('validateRichResults — direct unit checks', () => {
+  it('passes a minimal Article payload', () => {
+    expect(
+      validateRichResults(
+        {
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'X',
+          datePublished: '2026-01-01',
+          author: 'Y',
+          image: 'https://x/y.jpg'
+        },
+        'Article'
+      )
+    ).toBe(true);
+  });
+
+  it('rejects an Article missing headline', () => {
+    expect(
+      validateRichResults(
+        {
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          datePublished: '2026-01-01',
+          author: 'Y',
+          image: 'https://x/y.jpg'
+        },
+        'Article'
+      )
+    ).toBe(false);
+  });
+
+  it('passes a well-formed FAQPage payload', () => {
+    expect(
+      validateRichResults(
+        {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: [
+            {
+              '@type': 'Question',
+              name: 'How long is a session?',
+              acceptedAnswer: { '@type': 'Answer', text: '60 minutes.' }
+            }
+          ]
+        },
+        'FAQPage'
+      )
+    ).toBe(true);
+  });
+
+  it('rejects a FAQPage whose mainEntity entry lacks acceptedAnswer.text', () => {
+    expect(
+      validateRichResults(
+        {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: [
+            {
+              '@type': 'Question',
+              name: 'How long is a session?',
+              acceptedAnswer: { '@type': 'Answer' }
+            }
+          ]
+        },
+        'FAQPage'
+      )
+    ).toBe(false);
+  });
+
+  it('rejects a Product missing offers', () => {
+    expect(
+      validateRichResults(
+        {
+          '@context': 'https://schema.org',
+          '@type': 'Product',
+          name: 'X',
+          image: 'https://x/y.jpg',
+          description: 'desc'
+        },
+        'Product'
+      )
+    ).toBe(false);
+  });
+
+  it('rejects when @type does not match pageType', () => {
+    expect(
+      validateRichResults(
+        {
+          '@context': 'https://schema.org',
+          '@type': 'Person',
+          name: 'X'
+        },
+        'Article'
+      )
+    ).toBe(false);
+  });
+
+  it('rejects on a non-object payload', () => {
+    expect(validateRichResults('not an object', 'Person')).toBe(false);
+    expect(validateRichResults(null, 'Person')).toBe(false);
+    expect(validateRichResults(['array'], 'Person')).toBe(false);
+  });
+
+  it('rejects on an unknown @type', () => {
+    expect(
+      validateRichResults(
+        { '@context': 'https://schema.org', '@type': 'NotARealType' },
+        'NotARealType'
+      )
+    ).toBe(false);
+  });
+
+  it('exports RICH_RESULTS_REQUIRED_PROPS for the 11 supported types', () => {
+    expect(Object.keys(RICH_RESULTS_REQUIRED_PROPS).sort()).toEqual(
+      [
+        'Article',
+        'BlogPosting',
+        'CollectionPage',
+        'Event',
+        'FAQPage',
+        'LocalBusiness',
+        'Organization',
+        'Person',
+        'Product',
+        'Recipe',
+        'WebSite'
+      ].sort()
+    );
+  });
+});

--- a/packages/seo-architect/tests/run.test.ts
+++ b/packages/seo-architect/tests/run.test.ts
@@ -1,0 +1,237 @@
+/**
+ * `run()` tests — verifies the runtime pipeline:
+ *
+ *   - happy path returns a well-formed ArchitectOutput
+ *   - idempotency: same input → equivalent output
+ *   - re-runs REPLACE owned fields (do not append)
+ *   - dependency declaration on output
+ *   - failure modes (spawn failure, validation failure)
+ *   - reviewer feedback is plumbed through
+ *   - spend telemetry comes from the spawner, not the assistant
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { SEO_ARCHITECT_NAME, SeoArchitect } from '../src/architect.js';
+import { SEO_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runSeoArchitect } from '../src/run.js';
+import { buildSeoSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runSeoArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('seo');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    for (const k of SEO_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildSeoSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runSeoArchitect(input, {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runSeoArchitect(input, {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runSeoArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runSeoArchitect(input, {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    const b = await runSeoArchitect(input, {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runSeoArchitect(input, {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    const r2 = await runSeoArchitect(input, {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(SEO_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runSeoArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"seo"}');
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runSeoArchitect — dependency declaration', () => {
+  it('seo is a wave-1 architect (no upstream deps declared in output)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSeoArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildSeoSystemPrompt(),
+      architectName: SEO_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toEqual([]);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-page-001');
+  });
+
+  it('serialises the businessPlan brand kind', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('person');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('includes the compliance.dataResidency hint (used by SEO for sameAs filtering)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('dataResidency');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'tighten the title to ≤60 chars', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('tighten the title to ≤60 chars');
+  });
+});
+
+describe('SeoArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new SeoArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('seo');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/seo-architect/tests/system-prompt.test.ts
+++ b/packages/seo-architect/tests/system-prompt.test.ts
@@ -1,0 +1,116 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b):
+ *
+ *   - Non-empty string.
+ *   - References every declared owned field at least once.
+ *   - Contains the standard architect-output JSON schema instruction.
+ *   - Under a reasonable size (token budget proxy).
+ *   - Idempotent (pure function).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { SEO_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildSeoSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildSeoSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildSeoSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildSeoSystemPrompt();
+    const p2 = buildSeoSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's SEO Architect");
+  });
+
+  it('contains the Locked SEO posture section', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Locked SEO posture');
+    expect(p).toContain('schema.org');
+    expect(p).toContain('1200×630');
+    expect(p).toContain('canonical');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildSeoSystemPrompt();
+    for (const key of SEO_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('lists the Rich Results @type vocabulary', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('Article');
+    expect(p).toContain('BlogPosting');
+    expect(p).toContain('FAQPage');
+    expect(p).toContain('Person');
+    expect(p).toContain('Organization');
+    expect(p).toContain('Product');
+    expect(p).toContain('WebSite');
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('pageType');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('seo.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `seo.*` namespace', () => {
+    const p = buildSeoSystemPrompt();
+    // Reject other architects' field paths from appearing — they are
+    // other architects' territory.
+    const foreignPrefixes = [
+      'frontend.componentTree',
+      'backend.apiShape',
+      'database.schemaDDL',
+      'security.cspPolicy',
+      'performance.imagePolicy',
+      'a11y.conformanceMap'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 16k chars)', () => {
+    const p = buildSeoSystemPrompt();
+    expect(p.length).toBeLessThan(16_000);
+  });
+});

--- a/packages/seo-architect/tests/validation.test.ts
+++ b/packages/seo-architect/tests/validation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { SEO_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('seo');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput('{"architectName":"seo"}', SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['seo.schemaOrgJsonLd'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'frontend.componentTree': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), SEO_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(JSON.stringify(variant), SEO_OWNED_FIELD_KEYS);
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/seo-architect/tsconfig.build.json
+++ b/packages/seo-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/seo-architect/tsconfig.json
+++ b/packages/seo-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/seo-architect/vitest.config.ts
+++ b/packages/seo-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,6 +1400,9 @@ importers:
         specifier: workspace:*
         version: link:../claude-spawner
     devDependencies:
+      '@caia/frontend-architect':
+        specifier: workspace:*
+        version: link:../frontend-architect
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.39
@@ -2490,6 +2493,25 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
+  packages/seo-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
   packages/seo-program:


### PR DESCRIPTION
## Summary

Architect #4 of 17 in CAIA's EA fan-out. Builds `@caia/seo-architect` as a sibling of `@caia/frontend-architect` (merged PR #537, canonical template). No upstream EA dependencies; runs only on **Page** tickets per spec §3.3.

## Owns (`seo.*` slice of `tickets.architecture`)

| Field | Purpose |
| --- | --- |
| `seo.pageType` | Discriminator — `Article \| BlogPosting \| FAQPage \| Person \| Organization \| Product \| WebSite \| LocalBusiness \| Event \| Recipe \| CollectionPage` |
| `seo.schemaOrgJsonLd` | JSON-LD payload validating against Google Rich Results format |
| `seo.canonicalUrl` | Absolute HTTPS canonical URL |
| `seo.metaTags` | `{title, description, viewport, robots, themeColor}` |
| `seo.ogTags` | Open Graph (og:title/description/type/url/image @ 1200×630) |
| `seo.twitterCard` | summary_large_image mirroring og |
| `seo.sitemapEntry` | `{loc, lastmod, changefreq, priority}` |
| `seo.robotsDirective` | `{index, follow, maxSnippet, maxImagePreview, maxVideoPreview}` |
| `seo.keywordTargets` | 1 primary + ≤5 secondary, intent-tagged |

## `SpecialistArchitect` shape

- `name = "seo"`
- `dependsOn = []` (wave-1)
- `precedenceLevel = 4` (per spec §5.2 — locked playbook non-negotiable)
- `fanoutPolicy = "always"`
- `appliesPredicate` — **Page only** (per spec §3.3)
- `runtimeModel = "sonnet"`
- `tools = []` (V1; reads ticket + businessPlan + designVersion directly)

## Cross-architect invariants contributed

9 invariants — most notably **`seo.schemaOrgJsonLd-validates-rich-results`** which calls `validateRichResults(jsonLd, pageType)` checking `@context = "https://schema.org"`, `@type` matches `pageType`, and every per-type required prop is populated. The required-prop table mirrors Google's structured-data documentation across Article / BlogPosting / FAQPage / Person / Organization / Product / WebSite / LocalBusiness / Event / Recipe / CollectionPage.

## Verification

All green:

```
✓ typecheck     pnpm --filter @caia/seo-architect typecheck
✓ tests         137/137 passed across 7 files
  ├── architect.test.ts      12 tests (SpecialistArchitect compliance)
  ├── contract.test.ts       31 tests (sectionContract + registry disjointness)
  ├── system-prompt.test.ts  13 tests (every owned field referenced)
  ├── run.test.ts            20 tests (happy path + idempotency + failure modes + buildUserPrompt)
  ├── validation.test.ts     19 tests (every validator error code)
  ├── invariants.test.ts     29 tests (each invariant + validateRichResults direct units)
  └── golden/golden.test.ts  13 tests (end-to-end + Rich Results validation)
✓ lint          pnpm --filter @caia/seo-architect lint
✓ build         pnpm --filter @caia/seo-architect build  (emits dist/)
```

## Reuse

- `@caia/architect-kit` (workspace) — `SpecialistArchitect` interface, `ArchitectSectionContract`, `ArchitectRegistry`, `CANONICAL_PRECEDENCE_LADDER` (already lists `seo` at rank 4).
- `@chiefaia/claude-spawner` (workspace) — subscription-only LLM spawn surface; no `ANTHROPIC_API_KEY`.
- Frontend Architect template — package layout, tsconfig/eslint/vitest configs, `validation.ts`, `spawner.ts`, `run.ts` shapes mirrored verbatim. Diff from that template is the architect name + owned-field set + system prompt + invariants + golden fixture.

## Spec references

- research/17_architect_framework_spec_2026.md §1.1 (SpecialistArchitect), §1.3 (ArchitectSectionContract), §2.4 (SEO Architect spec), §3.3 (Page-only fan-out), §5.2 (precedence rank 4), §11(b) (system-prompt structure)
- agent-memory/project_caia_17_architects.md #4

## Out of scope

- The existing `@caia/seo-program` (a runtime auditor for Pokerzeno + Roulettecommunity) is left untouched — it's a downstream consumer, not part of the EA-phase architect contract. A follow-up may reconcile its `auditSchema` module with `validateRichResults()` exported here.
- OG-image generation lives in `@caia/image-provider`; this architect only emits the URL pointer to the 1200×630 floor image.
