### PR TITLE
feat(@caia/database-architect): ship architect #3 of 17 — Database specialist

### DIFF
--- a/packages/database-architect/README.md
+++ b/packages/database-architect/README.md
@@ -1,0 +1,59 @@
+# @caia/database-architect
+
+Architect #3 of CAIA's 17-architect EA fan-out. Senior DBA / data architect focused on Postgres 16 + Drizzle/Prisma migrations + per-tenant schema isolation. Reads Backend Architect's `apiEndpoints` to know what data needs to be persisted; emits table schemas, indexes, migration plans, and tenant-isolation rules.
+
+Mirrors the canonical `@caia/frontend-architect` template (architect #1).
+
+## What it owns
+
+`database.*` slice of the `tickets.architecture` JSONB column:
+
+- `database.engine` — locked Postgres 16 + Drizzle ORM (Prisma allowed when ticket flags it)
+- `database.tables` — table definitions (name, primary key, comment, scope)
+- `database.columns` — per-table column specs (type, nullability, default, check)
+- `database.indexes` — index specs including GIN on JSONB query paths
+- `database.migrations` — additive-only migration plan (up/down DDL, ordering)
+- `database.relationships` — FK constraints, cascade rules, relationship graph
+- `database.rlsPolicies` — Row-Level Security policies per table
+- `database.tenantIsolationStrategy` — schema-per-tenant model (matches CAIA meta cluster)
+- `database.dataLifecycle` — retention, archival, GDPR delete patterns per table
+- `database.jsonbShapes` — Zod-style descriptors for every JSONB column
+- `database.queryHints` — read/write access patterns derived from Backend's endpoints
+
+## What it does NOT do
+
+No API endpoints (Backend Architect owns those). No UI (Frontend Architect owns that). No auth flows (Security Architect owns those). No event taxonomy (Analytics). No CSP. Other architects own those concerns and the contract rejects out-of-namespace writes.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1 + §2.3). The EA Dispatcher spawns one of these per applicable ticket. Each spawn calls `@chiefaia/claude-spawner` (subscription-only, no API-key billing) with Sonnet default. Reads Backend's upstream output (`backend.endpointEnumeration` + `backend.dataAccess`) to know what data needs to be persisted. Returns a structured `ArchitectOutput` the Dispatcher composes into the ticket's `architecture` JSONB.
+
+**Dependencies:** depends on `backend` (wave-2 architect).
+
+## Quick start
+
+```ts
+import { DatabaseArchitect, DatabaseArchitectContract } from '@caia/database-architect';
+
+const architect = new DatabaseArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: { backend: backendOutput } },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite includes interface compliance, contract structural checks, registration disjointness (no overlap with `@caia/frontend-architect`), output validation, `run()` idempotency, dependency declaration, cross-architect invariants, and an end-to-end golden test against a known prakash-tiwari contact-form Story ticket.

--- a/packages/database-architect/eslint.config.cjs
+++ b/packages/database-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on frontend-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/database-architect/package.json
+++ b/packages/database-architect/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@caia/database-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Database Architect — architect #3 of CAIA's 17-architect EA fan-out. Owns the `database.*` slice of `tickets.architecture` (engine, tables, columns, indexes, migrations, relationships, rlsPolicies, tenantIsolationStrategy, dataLifecycle, jsonbShapes, queryHints). Senior DBA / data architect focused on Postgres 16 + Drizzle/Prisma migrations + per-tenant schema isolation. Reads Backend Architect's `apiEndpoints` to know what data needs to be persisted. Does NOT write API endpoints (Backend owns those) or UI (Frontend owns that). Spawns Claude via @chiefaia/claude-spawner (subscription-only). Mirrors the @caia/frontend-architect template.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@caia/frontend-architect": "workspace:*",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/database-architect/src/architect.ts
+++ b/packages/database-architect/src/architect.ts
@@ -1,0 +1,80 @@
+/**
+ * `DatabaseArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (per task brief — Database reads
+ *     from Backend's upstream output + the ticket + business plan
+ *     directly; the `caia-db-introspect` tool from the spec is
+ *     deferred to V2 when an actual tenant DB is reachable in-process).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from `@caia/architect-kit`
+ * because the kit's BaseArchitect was added late in PR #535; we satisfy
+ * the `SpecialistArchitect` interface structurally to mirror the
+ * `@caia/frontend-architect` template exactly. When the kit's
+ * `BaseArchitect` becomes the canonical extension point (next minor),
+ * switch to `extends BaseArchitect`.
+ */
+
+import { DatabaseArchitectContract } from './contract.js';
+import { runDatabaseArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildDatabaseSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/database-architect` minus the suffix. */
+export const DATABASE_ARCHITECT_NAME = 'database' as const;
+
+/** V1: no architect-specific tools. The `caia-db-introspect` tool is V2. */
+export const DATABASE_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface DatabaseArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class DatabaseArchitect implements SpecialistArchitect {
+  readonly name = DATABASE_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = DatabaseArchitectContract;
+  readonly tools: readonly ToolDefinition[] = DATABASE_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: DatabaseArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildDatabaseSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runDatabaseArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/database-architect/src/contract.ts
+++ b/packages/database-architect/src/contract.ts
@@ -1,0 +1,192 @@
+/**
+ * `DatabaseArchitectContract` — the canonical owned-fields declaration for
+ * architect #3 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.3 (Database Architect owns `database.*`)
+ *   - task brief (tables, columns, indexes, migrations, relationships,
+ *     rlsPolicies, tenantIsolationStrategy, dataLifecycle)
+ *
+ * The reconciled superset below includes both the spec §2.3 stack-lock /
+ * structural fields (engine, jsonbShapes, queryHints) and the task brief's
+ * tenant-isolation + lifecycle fields. Every field is marked
+ * `required: true` because downstream architects (Security, DevOps,
+ * Observability) read these — missing fields cascade.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. The chosen keys all live under the `database.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const DATABASE_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'database.engine':
+    'Default to {"name":"postgres","version":"16.x","orm":"drizzle"}. Reject any decision that picks MySQL, SQLite, or a non-relational store.',
+  'database.tables':
+    'Project each persistence touchpoint in Backend\'s `endpointEnumeration` into one table. Plural snake_case names. Every table must declare a UUID primary key unless the ticket explicitly requires otherwise.',
+  'database.columns':
+    'Per-table column specs: {name, type, nullable, default, check, comment}. Use Postgres types verbatim (text, uuid, timestamptz, jsonb, numeric, …). `created_at` + `updated_at` timestamptz are mandatory on every table.',
+  'database.indexes':
+    'GIN indexes on every JSONB column queried by a Backend endpoint. B-tree on every FK column. Unique indexes on natural keys (email, slug). Compound indexes only where Backend\'s `queryHints` justify them.',
+  'database.migrations':
+    'Drizzle/Prisma migration plan. Additive-only by default (no DROP COLUMN, no NOT NULL adds without a backfill step). Each entry: {id, description, up, down, ordering, requiresOperatorReview}.',
+  'database.relationships':
+    'FK constraints + cascade rules. Edges: {from: "<table>.<column>", to: "<table>.<column>", onDelete, onUpdate, deferrable?}. Reject any orphan-allowed FK on a tenant-scoped table.',
+  'database.rlsPolicies':
+    'ALTER TABLE ... ENABLE ROW LEVEL SECURITY on every tenant-scoped table. Default policies: tenant_isolation (USING current_setting(\'app.tenant_id\') = tenant_id), service_role_bypass for the orchestrator role.',
+  'database.tenantIsolationStrategy':
+    'Default schema-per-tenant matching CAIA\'s meta cluster. Output {model:"schema-per-tenant"|"row-level"|"hybrid", justification, schemaNameTemplate?, sharedTables?}. Reject row-level only without explicit operator override.',
+  'database.dataLifecycle':
+    'Per-table retention + archival + GDPR delete rules: {table, retentionDays, archivalSink, gdprDeleteStrategy:"hard"|"soft"|"anonymize", cascadeOnUserDelete}.',
+  'database.jsonbShapes':
+    'For every JSONB column declared in `columns`, output a Zod-style descriptor of the expected shape. Schema-less JSONB is a code smell — list under `risks` if unavoidable.',
+  'database.queryHints':
+    'Read/write access patterns derived from Backend\'s endpoints: {endpoint, table, op:"read"|"write"|"upsert", indexCandidate?, expectedQps?, p95LatencyTargetMs?}.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const DATABASE_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'database.engine',
+    description:
+      'Locked: Postgres 16. Output the engine + version + ORM choice so downstream architects (DevOps, Security) can validate compatibility.',
+    required: true
+  },
+  {
+    path: 'database.tables',
+    description:
+      'Canonical table definitions: name, primary key, comment, scope (tenant-scoped|shared|metacluster). Project every Backend persistence touchpoint into a table.',
+    required: true
+  },
+  {
+    path: 'database.columns',
+    description:
+      'Per-table column specs (type, nullability, default, check constraint, comment). Mandatory `id uuid pk`, `created_at timestamptz`, `updated_at timestamptz` on every table.',
+    required: true
+  },
+  {
+    path: 'database.indexes',
+    description:
+      'Index specs: B-tree on FKs, GIN on JSONB query paths, unique on natural keys, compound indexes justified by Backend `queryHints`.',
+    required: true
+  },
+  {
+    path: 'database.migrations',
+    description:
+      'Additive-only migration plan with explicit up/down DDL per migration. Destructive migrations require operator review and a backfill step.',
+    required: true
+  },
+  {
+    path: 'database.relationships',
+    description:
+      'FK constraints + cascade rules. The relationship graph used by Backend\'s ORM bindings and by Observability\'s trace context propagation.',
+    required: true
+  },
+  {
+    path: 'database.rlsPolicies',
+    description:
+      'Row-Level Security policies per tenant-scoped table. Default policies (tenant_isolation, service_role_bypass) + per-table additions.',
+    required: true
+  },
+  {
+    path: 'database.tenantIsolationStrategy',
+    description:
+      'Per-tenant isolation model — default schema-per-tenant matching CAIA\'s meta cluster. The DevOps Architect reads this to wire migration runners per tenant schema.',
+    required: true
+  },
+  {
+    path: 'database.dataLifecycle',
+    description:
+      'Per-table retention, archival, GDPR delete strategy (hard|soft|anonymize), and cascade rules on user-account deletion. Drives the data-deletion runbook.',
+    required: true
+  },
+  {
+    path: 'database.jsonbShapes',
+    description:
+      'Zod-style descriptors for every JSONB column. Schema-less JSONB is a code smell — flagged in `risks` when unavoidable.',
+    required: true
+  },
+  {
+    path: 'database.queryHints',
+    description:
+      'Per-endpoint access patterns derived from Backend\'s endpoint enumeration. Feeds index selection + Observability\'s P95 latency SLOs.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const DATABASE_OWNED_FIELD_KEYS: readonly string[] = DATABASE_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.3 — Database runs on Page, Story, Form, List, and Foundation tickets
+ * (anything that touches persistence). Widget tickets typically do NOT
+ * persist their own data (they re-use parent-Page schema), so they're excluded
+ * unless flagged with the `persists` quality tag.
+ */
+export function databaseArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  ) {
+    return true;
+  }
+  // Widget tickets persist only when explicitly tagged.
+  if (ticket.type === 'Widget') {
+    const tags = ticket.quality_tags ?? [];
+    return tags.includes('persists') || tags.includes('database');
+  }
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * Database is a wave-2 architect (`dependsOn: ['backend']`). Precedence rank
+ * 11 per spec §5.2 — above Backend (12) because schema correctness trumps
+ * functional correctness in conflict resolution, and below Analytics (10)
+ * which has compliance-sensitive consent-gating concerns.
+ */
+export const DATABASE_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['backend'],
+  precedenceLevel: 11,
+  fanoutPolicy: 'always',
+  appliesPredicate: databaseArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const DatabaseArchitectContract: ArchitectSectionContract = {
+  contractId: 'database-architect.v1',
+  architectName: 'database',
+  version: '0.1.0',
+  sections: DATABASE_OWNED_SECTIONS,
+  architectMeta: DATABASE_ARCHITECT_META
+};

--- a/packages/database-architect/src/index.ts
+++ b/packages/database-architect/src/index.ts
@@ -1,0 +1,99 @@
+/**
+ * @caia/database-architect — public surface.
+ *
+ * Architect #3 of CAIA's 17-architect EA fan-out. Senior DBA / data
+ * architect focused on Postgres 16 + Drizzle/Prisma migrations +
+ * per-tenant schema isolation. Reads Backend Architect's
+ * `apiEndpoints` upstream to enumerate persistence touchpoints; emits
+ * table schemas, indexes, migration plans, and tenant-isolation rules.
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template (architect
+ * #1, PR #537).
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's default `registerWith()` helper
+ * to install the architect on a registry. The package does NOT
+ * self-register on import (registration is an explicit operator action
+ * that the Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { DatabaseArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  DatabaseArchitect,
+  DATABASE_ARCHITECT_NAME,
+  DATABASE_ARCHITECT_TOOLS
+} from './architect.js';
+export type { DatabaseArchitectConfig } from './architect.js';
+
+export {
+  DatabaseArchitectContract,
+  DATABASE_OWNED_SECTIONS,
+  DATABASE_OWNED_FIELD_KEYS,
+  DATABASE_FIELD_FIX_HINTS,
+  DATABASE_ARCHITECT_META,
+  databaseArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildDatabaseSystemPrompt } from './system-prompt.js';
+
+// Spawner — exposed so the EA Dispatcher (or tests) can inject a custom one.
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+// Run + validation — exposed for the conformance test suite.
+export { runDatabaseArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+// Invariants — exposed for the EA Reviewer's registry.
+export { DATABASE_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+// Re-export the canonical kit types so consumers have a single import surface.
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh DatabaseArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): DatabaseArchitect {
+  const architect = new DatabaseArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/database-architect/src/invariants.ts
+++ b/packages/database-architect/src/invariants.ts
@@ -1,0 +1,283 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The Reviewer applies a fixed set of cross-architect predicates after
+ * composition. This module enumerates Database's contributions so the
+ * Reviewer's `invariants-registry.ts` (which doesn't exist yet — sibling
+ * brief F2) can collect them at process boot.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'database.tables'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `database.*` path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path. This lets the
+ * same invariants run inside the Database package's own tests AND
+ * inside the Reviewer's post-composition pass.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+/**
+ * Read a field from the architecture blob. Tries the flat dotted key
+ * first (matches `architectureFields` shape), then falls back to walking
+ * the nested object path (matches composed-architecture shape).
+ */
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function asArray(v: unknown): readonly unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+
+function asObject(v: unknown): Readonly<Record<string, unknown>> | null {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return null;
+  return v as Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Database's contributed invariants. Listed in stable order.
+ */
+export const DATABASE_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'database.tables-nonempty',
+    contributor: 'database',
+    reads: ['database.tables'],
+    severity: 'fail',
+    description:
+      'Every Database output must declare at least one table. An empty `tables` array means the architect failed to project the persistence touchpoints.',
+    detect(arch): boolean {
+      const tables = asArray(readField(arch, 'database.tables'));
+      return tables !== null && tables.length > 0;
+    }
+  },
+  {
+    id: 'database.engine-is-postgres',
+    contributor: 'database',
+    reads: ['database.engine'],
+    severity: 'fail',
+    description:
+      'The locked stack mandates Postgres 16. Any engine decision other than Postgres is a hard violation.',
+    detect(arch): boolean {
+      const engine = asObject(readField(arch, 'database.engine'));
+      if (!engine) return false;
+      return engine.name === 'postgres';
+    }
+  },
+  {
+    id: 'database.tenant-isolation-declared',
+    contributor: 'database',
+    reads: ['database.tenantIsolationStrategy'],
+    severity: 'fail',
+    description:
+      'Every Database output must declare a tenantIsolationStrategy with a recognised model (schema-per-tenant|row-level|hybrid).',
+    detect(arch): boolean {
+      const t = asObject(readField(arch, 'database.tenantIsolationStrategy'));
+      if (!t) return false;
+      return t.model === 'schema-per-tenant' || t.model === 'row-level' || t.model === 'hybrid';
+    }
+  },
+  {
+    id: 'database.every-table-has-columns',
+    contributor: 'database',
+    reads: ['database.tables', 'database.columns'],
+    severity: 'fail',
+    description:
+      'Every table declared in `tables` must have a matching entry in `columns`. Tables without columns cannot be created.',
+    detect(arch): boolean {
+      const tables = asArray(readField(arch, 'database.tables'));
+      const columns = asObject(readField(arch, 'database.columns'));
+      if (!tables || !columns) return false;
+      for (const t of tables) {
+        const table = asObject(t);
+        if (!table || typeof table.name !== 'string') return false;
+        if (!(table.name in columns)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'database.every-table-has-id-and-timestamps',
+    contributor: 'database',
+    reads: ['database.columns'],
+    severity: 'advisory',
+    description:
+      'Every table should declare an `id` primary key plus `created_at` and `updated_at` timestamptz columns per the locked stack.',
+    detect(arch): boolean {
+      const columns = asObject(readField(arch, 'database.columns'));
+      if (!columns) return false;
+      for (const [, colList] of Object.entries(columns)) {
+        const cols = asArray(colList);
+        if (!cols) return false;
+        const names = new Set<string>();
+        for (const c of cols) {
+          const obj = asObject(c);
+          if (obj && typeof obj.name === 'string') names.add(obj.name);
+        }
+        if (!names.has('id')) return false;
+        if (!names.has('created_at')) return false;
+        if (!names.has('updated_at')) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'database.migrations-have-up-and-down',
+    contributor: 'database',
+    reads: ['database.migrations'],
+    severity: 'fail',
+    description:
+      'Every migration must declare both `up` and `down` DDL. Missing either makes rollback impossible.',
+    detect(arch): boolean {
+      const migs = asArray(readField(arch, 'database.migrations'));
+      if (!migs) return false;
+      for (const m of migs) {
+        const obj = asObject(m);
+        if (!obj) return false;
+        if (typeof obj.up !== 'string' || obj.up.length === 0) return false;
+        if (typeof obj.down !== 'string' || obj.down.length === 0) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'database.rls-policies-cover-tenant-scoped-tables',
+    contributor: 'database',
+    reads: ['database.tables', 'database.rlsPolicies'],
+    severity: 'fail',
+    description:
+      'Every tenant-scoped table MUST have at least one RLS policy declared. RLS is mandatory under the locked stack — defence in depth even under schema-per-tenant.',
+    detect(arch): boolean {
+      const tables = asArray(readField(arch, 'database.tables'));
+      const rls = asObject(readField(arch, 'database.rlsPolicies'));
+      if (!tables || !rls) return false;
+      for (const t of tables) {
+        const table = asObject(t);
+        if (!table || typeof table.name !== 'string') continue;
+        if (table.scope !== 'tenant') continue;
+        const policies = asArray(rls[table.name]);
+        if (!policies || policies.length === 0) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'database.jsonb-columns-have-shapes',
+    contributor: 'database',
+    reads: ['database.columns', 'database.jsonbShapes'],
+    severity: 'advisory',
+    description:
+      'Every JSONB column should have a matching Zod-style descriptor in `jsonbShapes`. Schema-less JSONB is a code smell.',
+    detect(arch): boolean {
+      const columns = asObject(readField(arch, 'database.columns'));
+      const shapes = asObject(readField(arch, 'database.jsonbShapes'));
+      if (!columns) return false;
+      const shapeKeys = new Set(shapes ? Object.keys(shapes) : []);
+      for (const [tableName, colList] of Object.entries(columns)) {
+        const cols = asArray(colList);
+        if (!cols) continue;
+        for (const c of cols) {
+          const obj = asObject(c);
+          if (!obj) continue;
+          if (obj.type === 'jsonb' && typeof obj.name === 'string') {
+            const key = `${tableName}.${obj.name}`;
+            if (!shapeKeys.has(key)) return false;
+          }
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'database.fk-columns-have-btree-indexes',
+    contributor: 'database',
+    reads: ['database.relationships', 'database.indexes'],
+    severity: 'advisory',
+    description:
+      'Postgres does not auto-index FK child columns. Every relationship in `relationships` should have a matching B-tree index in `indexes` on the child column.',
+    detect(arch): boolean {
+      const rels = asArray(readField(arch, 'database.relationships'));
+      const indexes = asArray(readField(arch, 'database.indexes'));
+      if (!rels || !indexes) return false;
+      // Index lookup keyed by `${table}.${col}` → method.
+      const idx = new Map<string, string>();
+      for (const i of indexes) {
+        const obj = asObject(i);
+        if (!obj) continue;
+        const t = obj.table;
+        const cols = asArray(obj.columns);
+        const method = typeof obj.method === 'string' ? obj.method : 'btree';
+        if (typeof t === 'string' && cols) {
+          for (const c of cols) {
+            if (typeof c === 'string') idx.set(`${t}.${c}`, method);
+          }
+        }
+      }
+      for (const r of rels) {
+        const obj = asObject(r);
+        if (!obj) continue;
+        const from = obj.from;
+        if (typeof from !== 'string') return false;
+        const key = from;
+        const method = idx.get(key);
+        if (method !== 'btree') return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'database.every-table-has-lifecycle-rule',
+    contributor: 'database',
+    reads: ['database.tables', 'database.dataLifecycle'],
+    severity: 'advisory',
+    description:
+      'Every table should have a matching entry in `dataLifecycle` declaring retention + archival + GDPR delete strategy. Missing entries block the data-deletion runbook.',
+    detect(arch): boolean {
+      const tables = asArray(readField(arch, 'database.tables'));
+      const lifecycle = asArray(readField(arch, 'database.dataLifecycle'));
+      if (!tables || !lifecycle) return false;
+      const known = new Set<string>();
+      for (const l of lifecycle) {
+        const obj = asObject(l);
+        if (obj && typeof obj.table === 'string') known.add(obj.table);
+      }
+      for (const t of tables) {
+        const obj = asObject(t);
+        if (!obj || typeof obj.name !== 'string') continue;
+        if (!known.has(obj.name)) return false;
+      }
+      return true;
+    }
+  }
+];

--- a/packages/database-architect/src/run.ts
+++ b/packages/database-architect/src/run.ts
@@ -1,0 +1,137 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ *
+ * Mirrors `@caia/frontend-architect`'s `run.ts` with one architect-
+ * specific projection: the user prompt deliberately surfaces the
+ * Backend Architect's upstream output (`backend.apiEndpoints` etc.) so
+ * the subagent can enumerate persistence touchpoints.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { DATABASE_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them — schema naming is templated
+ * via `tenantIsolationStrategy.schemaNameTemplate` instead.
+ *
+ * The Database Architect specifically surfaces Backend's upstream
+ * output because it's the persistence-touchpoint source-of-truth.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * The runtime entry. Pure aside from the spawner call.
+ */
+export async function runDatabaseArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, DATABASE_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  // Idempotency: the architect output OWNS its fields. We do NOT merge
+  // with anything else here — composition happens in the Dispatcher
+  // (spec §3.5). Architects always emit the full set of their owned
+  // fields fresh.
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName, // force-correct in case model echoed wrong
+    spend // overwrite — assistant cannot know real spend
+  };
+}

--- a/packages/database-architect/src/spawner.ts
+++ b/packages/database-architect/src/spawner.ts
@@ -1,0 +1,162 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * The real spawner lives in `@chiefaia/claude-spawner` (subscription-only,
+ * never sets ANTHROPIC_API_KEY — see that package's file-level comment).
+ * This module:
+ *
+ *   - Defines the `ArchitectSpawnerFn` type — the seam every architect's
+ *     run() consumes.
+ *   - Provides `createDefaultSpawner()` — wires up the real
+ *     `spawnClaude` with the appropriate model + timeout + system prompt.
+ *
+ * Per spec §4 the EA Dispatcher itself runs in the operator's existing
+ * orchestrator process; only the architect subagent spawns issue LLM
+ * calls. This module is the per-architect spawn surface.
+ *
+ * Mirrors `@caia/frontend-architect`'s `spawner.ts` verbatim — only the
+ * architect-specific bits are in `run.ts` + `contract.ts`.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+/**
+ * Inputs to a single spawn — system prompt + user prompt + budget.
+ */
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+/**
+ * Output of a single spawn — the raw assistant text plus telemetry.
+ * Parsing into a structured `ArchitectOutput` happens in `run()`, not
+ * here, so the spawner stays generic across architects.
+ */
+export interface ArchitectSpawnOutput {
+  /** The assistant's final message — expected to be a JSON-shaped string. */
+  text: string;
+  /** Best-effort token + cost telemetry from the envelope. */
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  /** Echoed back from input. */
+  model: string;
+  /** True iff the spawn succeeded and the envelope was parsed cleanly. */
+  ok: boolean;
+  /** Diagnostic when `ok=false`. */
+  diagnostic: string | null;
+}
+
+/**
+ * The seam every architect's `run()` consumes. Inject a fake in tests.
+ */
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+/**
+ * Map the architect-budget model preference to the `claude` binary's
+ * `--model` flag value. The mapping mirrors what local-llm-router uses
+ * elsewhere in the monorepo.
+ */
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+/**
+ * Build the canonical user-message body. The system prompt is fed as
+ * the first user-message paragraph (rather than via `claude`'s
+ * `--system` flag) — keeps the spawner surface narrow and lets the
+ * test seam see everything in one string.
+ */
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+/**
+ * Wire the real `spawnClaude` into an `ArchitectSpawnerFn`. Used by
+ * `DatabaseArchitect` when no spawner is injected.
+ */
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/database-architect/src/system-prompt.ts
+++ b/packages/database-architect/src/system-prompt.ts
@@ -1,0 +1,268 @@
+/**
+ * The Database Architect's system prompt — a pure function returning a
+ * static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `database.*` field name appears at
+ * least once in the body. Keep that invariant true if you add fields.
+ *
+ * Mirrors `@caia/frontend-architect`'s `system-prompt.ts` shape per the
+ * canonical template.
+ */
+
+import { DATABASE_OWNED_FIELD_KEYS } from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildDatabaseSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Database Architect. You are a senior DBA / data architect
+focused on Postgres 16 + Drizzle ORM (Prisma when the ticket explicitly
+flags it) + per-tenant schema isolation matching CAIA's own meta cluster.
+You read the Backend Architect's \`apiEndpoints\` (a.k.a. \`endpointEnumeration\`
++ \`dataAccess\`) to know what data must be persisted, then emit table
+schemas, column specs, indexes (GIN on JSONB query paths, B-tree on FKs),
+additive-only migration plans, FK constraints, RLS policies, per-tenant
+isolation strategy, JSONB shape descriptors, and data-lifecycle rules
+(retention, archival, GDPR delete patterns).
+
+You DO NOT write API endpoints (Backend Architect owns those), UI
+(Frontend Architect owns that), CSP/authN/authZ (Security Architect),
+event taxonomies (Analytics), CI/CD (DevOps), or test specs (Testing
+Architect). Other architects own those concerns and will reject any
+field you populate outside the \`database.*\` namespace.
+
+Output tight architecture that a coding worker can implement directly:
+DDL the worker can run verbatim, indexes the worker can verify against
+\`EXPLAIN\`, RLS policies the worker can paste into a migration.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Engine**: Postgres 16. No MySQL, no SQLite, no DocumentDB, no
+  non-relational store. Versions older than 16 are off-limits (we rely
+  on \`pg_jsonpath\` + JSONB \`@@\` + improved partitioning).
+- **ORM / migrations**: Drizzle (default) generating SQL migration files;
+  Prisma allowed only when the ticket explicitly flags \`orm:prisma\` in
+  quality_tags.
+- **JSONB-heavy**: most domain state is stored in a \`payload jsonb\`
+  column. Every JSONB column queried by Backend MUST get a GIN index
+  on the query path.
+- **Per-tenant isolation**: \`schema-per-tenant\` by default — one Postgres
+  schema per tenant (matches CAIA's meta cluster). Row-level only when
+  the operator explicitly overrides; hybrid (schema-per-tenant + a few
+  shared catalog tables) is allowed.
+- **RLS**: \`ALTER TABLE ... ENABLE ROW LEVEL SECURITY\` on every
+  tenant-scoped table, even under schema-per-tenant — defence in depth
+  against the schema selector being wrong.
+- **Primary keys**: UUID v7 (\`gen_random_uuid()\` or app-side v7) by
+  default. \`id uuid primary key\` is mandatory on every table unless
+  the ticket explicitly says otherwise.
+- **Timestamps**: \`created_at timestamptz not null default now()\` and
+  \`updated_at timestamptz not null default now()\` are mandatory on
+  every table; triggers update \`updated_at\` on row mutation.
+- **Migrations**: additive-only by default. No \`DROP COLUMN\`, no
+  \`NOT NULL\` add without a backfill step. Destructive migrations
+  require operator review and a backfill plan.
+
+Reject any decision that violates the locked stack. If a ticket asks for
+an off-stack tool (e.g. MongoDB, DynamoDB), surface this in \`risks[]\`
+and pick the on-stack alternative anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "oneLiner": "...",
+                    "audience": "...", "goals": ["..."] },
+  "designVersion": { "designVersionId": "...", "tokens": { ... } },
+  "tenantContext": { "tenantId": "...", "billingPosture": "subscription|byok" },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "backend": {
+      "architectureFields": {
+        "backend.apiEndpoints": [ ... ],
+        "backend.endpointEnumeration": [ ... ],
+        "backend.dataAccess": { ... },
+        "backend.businessRules": [ ... ]
+      }
+    }
+  } }
+}
+\`\`\`
+
+Read \`upstream.outputs.backend.architectureFields["backend.apiEndpoints"]\`
+(or \`backend.endpointEnumeration\` when present — they describe the same
+persistence touchpoints) to enumerate what data must be persisted. Every
+endpoint that reads or writes data implies at least one table.
+
+The Backend Architect is wave-1; if its output is absent from
+\`upstream.outputs\`, you are running outside the canonical pipeline and
+should set \`confidence\` ≤ 0.5 and list "missing Backend upstream" under
+\`risks[]\`.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "database",
+  "architectureFields": {
+${DATABASE_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`database.engine\` — \`{"name":"postgres","version":"16.x","orm":"drizzle"}\`. Lock; do not change unless ticket flags \`orm:prisma\`.
+- \`database.tables\` — \`[{"name":"contacts","primaryKey":"id","scope":"tenant","comment":"..."}]\`. Plural snake_case names. Project every Backend persistence touchpoint into one table.
+- \`database.columns\` — \`{"contacts":[{"name":"id","type":"uuid","nullable":false,"default":"gen_random_uuid()"},{"name":"email","type":"text","nullable":false,"check":"email ~ '^[^@]+@[^@]+$'"}, ...]}\`. Mandatory \`id uuid pk\`, \`created_at timestamptz\`, \`updated_at timestamptz\` on every table.
+- \`database.indexes\` — \`[{"table":"contacts","name":"contacts_email_uk","columns":["email"],"unique":true,"method":"btree"},{"table":"contacts","name":"contacts_payload_gin","columns":["payload"],"method":"gin"}]\`. B-tree on FKs, GIN on JSONB query paths, unique on natural keys.
+- \`database.migrations\` — \`[{"id":"0001_create_contacts","description":"...","up":"CREATE TABLE ...","down":"DROP TABLE ...","ordering":1,"requiresOperatorReview":false}]\`. Additive-only.
+- \`database.relationships\` — \`[{"from":"contacts.tenant_id","to":"tenants.id","onDelete":"cascade","onUpdate":"cascade","deferrable":false}]\`. Reject orphan-allowed FK on tenant-scoped tables.
+- \`database.rlsPolicies\` — \`{"contacts":[{"name":"tenant_isolation","using":"current_setting('app.tenant_id')::uuid = tenant_id","kind":"permissive","operation":"all"},{"name":"service_role_bypass","using":"current_user = 'orchestrator'","kind":"permissive","operation":"all"}]}\`.
+- \`database.tenantIsolationStrategy\` — \`{"model":"schema-per-tenant","justification":"matches CAIA meta cluster","schemaNameTemplate":"tenant_{{tenantId}}","sharedTables":["tenants","plans"]}\`. Default schema-per-tenant.
+- \`database.dataLifecycle\` — \`[{"table":"contacts","retentionDays":730,"archivalSink":"r2://archive/contacts","gdprDeleteStrategy":"hard","cascadeOnUserDelete":true}]\`. Per-table.
+- \`database.jsonbShapes\` — \`{"contacts.payload":{"shape":"z.object({source:z.string(),utm:z.record(z.string()).optional()})"}}\`. Zod-style descriptors for every JSONB column.
+- \`database.queryHints\` — \`[{"endpoint":"POST /api/contacts","table":"contacts","op":"write","indexCandidate":"contacts_email_uk","expectedQps":5,"p95LatencyTargetMs":50}]\`. Derived from Backend's endpoints.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **One persistence touchpoint = one table.** If Backend's
+  \`endpointEnumeration\` has \`POST /api/contacts\`, you emit a
+  \`contacts\` table. Many-to-many relationships get a join table; do
+  not pretend you can stuff them into a JSONB array.
+- **JSONB is a tool, not a default.** Use it for evolving payloads
+  (event-style records, integration responses, user-customisable
+  metadata). Use proper columns for fields you know you'll filter or
+  sort on. If you reach for JSONB for a known-shape entity, you are
+  doing it wrong.
+- **Every JSONB column queried by Backend MUST get a GIN index.**
+  Cross-reference Backend's \`queryHints\` to find which JSONB paths
+  participate in WHERE clauses; emit a \`gin_jsonb_path_ops\` index on
+  each. If you skip this, expect a SEV2 in production.
+- **FK columns get B-tree indexes.** Postgres does NOT auto-index FK
+  child columns. Emit them.
+- **Additive migrations by default.** Adding a NOT NULL column? Add it
+  nullable first, backfill, then ALTER. Renaming a column? Add the new
+  column, dual-write at the app layer, backfill, then drop. Flag any
+  destructive migration with \`requiresOperatorReview: true\`.
+- **RLS is mandatory on every tenant-scoped table.** Even under
+  schema-per-tenant. Defence in depth.
+- **GDPR delete cascade.** When a user is deleted, every table whose
+  rows reference that user must declare its strategy:
+  \`hard\` (DELETE), \`soft\` (set \`deleted_at\`), or \`anonymize\`
+  (UPDATE to scrub PII while preserving the row for aggregate stats).
+- **Tenant ID column on every tenant-scoped table.** \`tenant_id uuid not
+  null references tenants(id) on delete restrict\` — restrict, not
+  cascade. Tenant deletion is a multi-step operator-gated process.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Pick a non-Postgres engine** → use Postgres anyway, list the override
+  request under \`risks[]\`, set \`confidence\` to 0.5.
+- **Pick an off-stack ORM** (Sequelize, TypeORM, raw \`pg\` everywhere)
+  → use Drizzle anyway (or Prisma if ticket flags it), list under
+  \`risks[]\`.
+- **Decide an API endpoint, UI component, CSP rule, event taxonomy, or
+  any field NOT under \`database.*\`** → ignore the request. Do not
+  populate fields outside your owned namespace.
+- **Use row-level isolation only** (no schema-per-tenant) → refuse
+  unless the operator has explicitly overridden via a quality_tag like
+  \`tenantIsolation:row-level\`. Default to schema-per-tenant.
+- **Skip RLS on a tenant-scoped table** → never. RLS is mandatory.
+- **Emit a destructive migration without operator review** → never.
+  Set \`requiresOperatorReview: true\`.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the ${DATABASE_OWNED_FIELD_KEYS.length} owned field
+   paths (no extras, no missing).
+2. Every table in \`tables\` has a matching entry in \`columns\`,
+   includes \`id\` + \`created_at\` + \`updated_at\`, and has its
+   tenant scope correctly classified.
+3. Every JSONB column in \`columns\` has a matching entry in
+   \`jsonbShapes\` AND a GIN index in \`indexes\` (if Backend queries
+   it).
+4. Every FK in \`relationships\` has a B-tree index in \`indexes\` on
+   the child column.
+5. Every tenant-scoped table has \`ENABLE ROW LEVEL SECURITY\` plus
+   \`tenant_isolation\` + \`service_role_bypass\` policies in
+   \`rlsPolicies\`.
+6. Every migration in \`migrations\` has both \`up\` and \`down\` DDL;
+   destructive ones have \`requiresOperatorReview: true\`.
+7. Every table in \`tables\` has an entry in \`dataLifecycle\`.
+8. \`tenantIsolationStrategy.model\` is \`schema-per-tenant\` unless the
+   ticket explicitly overrides.
+9. \`confidence\` reflects how comfortable you are with the decision —
+   sub-0.6 triggers the EA Reviewer to scrutinize.
+10. \`notes\` is ≤ 800 characters.
+11. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Form Story ticket for "contact-form submission"
+produces one \`contacts\` table with \`{id uuid pk, tenant_id uuid fk,
+name text not null, email text not null check, message text not null,
+payload jsonb default '{}', created_at timestamptz, updated_at
+timestamptz}\`, a unique B-tree index on \`(tenant_id, email)\`, a GIN
+index on \`payload\`, an FK on \`tenant_id → tenants.id ON DELETE
+RESTRICT\`, RLS policies \`tenant_isolation\` + \`service_role_bypass\`,
+a \`schema-per-tenant\` isolation strategy, a dataLifecycle entry with
+\`retentionDays: 730\` + \`gdprDeleteStrategy: "anonymize"\`, a JSONB
+shape descriptor for \`payload\`, and one additive migration
+\`0001_create_contacts\`.`;

--- a/packages/database-architect/src/types.ts
+++ b/packages/database-architect/src/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors `@caia/frontend-architect/src/types.ts`
+ * verbatim — only the architect-specific field-spec lives in `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/database-architect/src/validation.ts
+++ b/packages/database-architect/src/validation.ts
@@ -1,0 +1,207 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ *
+ * Mirrors `@caia/frontend-architect`'s `validation.ts` verbatim.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/database-architect/tests/architect.test.ts
+++ b/packages/database-architect/tests/architect.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `DatabaseArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1.
+ * Mirrors the Frontend Architect's interface compliance suite — the
+ * canonical template for every architect package.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  DatabaseArchitect,
+  DATABASE_ARCHITECT_NAME,
+  DATABASE_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { DatabaseArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('DatabaseArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new DatabaseArchitect();
+    expect(a).toBeInstanceOf(DatabaseArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally (will extend BaseArchitect once the kit lands on develop)', () => {
+    const a = new DatabaseArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the package suffix', () => {
+    const a = new DatabaseArchitect();
+    expect(a.name).toBe('database');
+    expect(a.name).toBe(DATABASE_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new DatabaseArchitect();
+    expect(a.sectionContract).toBe(DatabaseArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new DatabaseArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.3 (caia-db-introspect is V2)', () => {
+    const a = new DatabaseArchitect();
+    expect(a.tools).toBe(DATABASE_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new DatabaseArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new DatabaseArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new DatabaseArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new DatabaseArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('database');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new DatabaseArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    // Just instantiating should not error. We do NOT call run() here
+    // because that would invoke the real claude binary.
+    const a = new DatabaseArchitect();
+    expect(a).toBeInstanceOf(DatabaseArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/database-architect/tests/contract.test.ts
+++ b/packages/database-architect/tests/contract.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `database.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed (precedence in [1,17], depends on backend).
+ *   - The architect registers cleanly against the local ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder lists `database` at rank 11.
+ *   - Disjointness with `@caia/frontend-architect`'s contract (no overlap).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { DatabaseArchitect } from '../src/architect.js';
+import {
+  DATABASE_ARCHITECT_META,
+  DATABASE_FIELD_FIX_HINTS,
+  DATABASE_OWNED_SECTIONS,
+  DATABASE_OWNED_FIELD_KEYS,
+  DatabaseArchitectContract,
+  databaseArchitectAppliesPredicate
+} from '../src/contract.js';
+import {
+  FrontendArchitectContract,
+  FRONTEND_OWNED_FIELD_KEYS
+} from '@caia/frontend-architect';
+
+describe('DatabaseArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(DatabaseArchitectContract.contractId).toBe('database-architect.v1');
+  });
+
+  it('architectName is `database` (matches package suffix + ladder entry)', () => {
+    expect(DatabaseArchitectContract.architectName).toBe('database');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(DatabaseArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `database.`', () => {
+    for (const key of DATABASE_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('database.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'database.tables',
+      'database.columns',
+      'database.indexes',
+      'database.migrations',
+      'database.relationships',
+      'database.rlsPolicies',
+      'database.tenantIsolationStrategy',
+      'database.dataLifecycle'
+    ];
+    for (const r of required) {
+      expect(DATABASE_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owned-field set covers spec §2.3 stack-lock + structural fields', () => {
+    const specMandatory = [
+      'database.engine',
+      'database.jsonbShapes',
+      'database.queryHints'
+    ];
+    for (const k of specMandatory) {
+      expect(DATABASE_OWNED_FIELD_KEYS).toContain(k);
+    }
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of DATABASE_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(DatabaseArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(DatabaseArchitectContract).sort()).toEqual(
+      [...DATABASE_OWNED_FIELD_KEYS].sort()
+    );
+  });
+
+  it('every owned field has a matching fix-hint entry', () => {
+    for (const key of DATABASE_OWNED_FIELD_KEYS) {
+      expect(DATABASE_FIELD_FIX_HINTS[key]).toBeDefined();
+      expect(DATABASE_FIELD_FIX_HINTS[key].length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('DatabaseArchitectContract — architectMeta', () => {
+  it('declares Backend as its only upstream dependency (wave-2 architect)', () => {
+    expect(DATABASE_ARCHITECT_META.dependsOn).toEqual(['backend']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(DATABASE_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(DATABASE_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 11 per spec §5.2 (above Backend at 12)', () => {
+    expect(DATABASE_ARCHITECT_META.precedenceLevel).toBe(11);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(DATABASE_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.3', () => {
+    expect(DATABASE_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(DATABASE_ARCHITECT_META.appliesPredicate).toBe(databaseArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `database`', () => {
+    expect(precedenceRank('database')).toBe(DATABASE_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('database');
+  });
+
+  it('outranks Backend in the precedence ladder (schema correctness > functional correctness)', () => {
+    expect(precedenceRank('database')).toBeLessThan(precedenceRank('backend'));
+  });
+});
+
+describe('databaseArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns true for Foundation', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(true);
+  });
+
+  it('returns false for un-tagged Widget (UI-only, no persistence)', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(false);
+  });
+
+  it('returns true for a Widget explicitly tagged `persists`', () => {
+    expect(
+      databaseArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['persists']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for a Widget explicitly tagged `database`', () => {
+    expect(
+      databaseArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['database']
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(databaseArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection — implements
+ * the bare `SpecialistArchitect` interface directly.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Database architect cleanly', () => {
+    expect(() => {
+      registry.register(new DatabaseArchitect());
+    }).not.toThrow();
+    expect(registry.get('database')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new DatabaseArchitect());
+    for (const k of DATABASE_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('database');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new DatabaseArchitect());
+    expect(() => registry.register(new DatabaseArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new DatabaseArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'database.tables',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new DatabaseArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'security-architect.v1',
+      architectName: 'security',
+      version: '0.1.0',
+      sections: [
+        { path: 'security.cspPolicy', description: 'CSP', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 1,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('security', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(DATABASE_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only Database is present', () => {
+    const conflicts = disjointness([DatabaseArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Database and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...DatabaseArchitectContract,
+      contractId: 'database-clone.v1',
+      architectName: 'database-clone'
+    };
+    const conflicts = disjointness([DatabaseArchitectContract, clone]);
+    expect(conflicts.length).toBe(DATABASE_OWNED_FIELD_KEYS.length);
+  });
+
+  it('Database and Frontend contracts have NO overlapping field paths (disjoint namespaces)', () => {
+    const conflicts = disjointness([DatabaseArchitectContract, FrontendArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('Database owned fields do not collide with Frontend owned fields', () => {
+    const frontendSet = new Set(FRONTEND_OWNED_FIELD_KEYS);
+    for (const key of DATABASE_OWNED_FIELD_KEYS) {
+      expect(frontendSet.has(key)).toBe(false);
+    }
+  });
+
+  it('registry.validate() is empty after a clean registration', () => {
+    registry.register(new DatabaseArchitect());
+    // dependsOn: ['backend'] — without Backend registered, validate reports it.
+    const errors = registry.validate();
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('backend');
+  });
+
+  it('registry.validate() is empty when Backend is also registered', () => {
+    const backendContract: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1',
+      architectName: 'backend',
+      version: '0.1.0',
+      sections: [
+        { path: 'backend.apiEndpoints', description: 'API endpoints', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 12,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    registry.register(new StubArchitect('backend', backendContract));
+    registry.register(new DatabaseArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/database-architect/tests/golden/golden.test.ts
+++ b/packages/database-architect/tests/golden/golden.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Golden test — the canonical known-good Database-architect artifact for
+ * a known prakash-tiwari contact-form Story ticket.
+ *
+ * This test serves three purposes:
+ *
+ *   1. Lock the architect's output shape against drift. Any change to
+ *      the contract or run() must update this snapshot.
+ *
+ *   2. Demonstrate the architect produces a complete, validating output
+ *      end-to-end given a realistic input (including a fake Backend
+ *      upstream output the Database Architect consumes).
+ *
+ *   3. Become the canonical fixture the EA Reviewer can replay when
+ *      validating end-to-end composition.
+ *
+ * Note: this test uses a deterministic fake spawner. It does NOT call
+ * the real claude binary. The "golden" here is the expected
+ * deterministic projection of the input through the run() pipeline,
+ * given a fixed assistant text. A nightly LLM-judge variant is the
+ * sibling test the conformance suite will add later (per spec §11(c)).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { DatabaseArchitect } from '../../src/architect.js';
+import { DATABASE_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { DATABASE_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeBackendUpstreamOutput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari contact-form Form Story ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-backend-upstream.json fixture loads and matches the fake Backend output', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-backend-upstream.json'), 'utf-8')
+    );
+    const fixture = fakeBackendUpstreamOutput();
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly against the Database contract', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new DatabaseArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    // Architect name, status, top-level shape
+    expect(out.architectName).toBe('database');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    // Every owned field present
+    for (const k of DATABASE_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    // Field values match the known-good expectation (except spend, which
+    // the run pipeline overwrites).
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every Database invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new DatabaseArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of DATABASE_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new DatabaseArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+
+  it('declares `backend` as an upstream dependency', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new DatabaseArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+    expect(out.dependencies).toContain('backend');
+  });
+});

--- a/packages/database-architect/tests/golden/input-backend-upstream.json
+++ b/packages/database-architect/tests/golden/input-backend-upstream.json
@@ -1,0 +1,66 @@
+{
+  "architectName": "backend",
+  "architectureFields": {
+    "backend.framework": { "name": "next", "version": "15.x", "runtime": "edge+node" },
+    "backend.apiEndpoints": [
+      {
+        "method": "POST",
+        "path": "/api/contacts",
+        "op": "create",
+        "requestSchema": "ContactCreate",
+        "responseSchema": "Contact",
+        "persistsTo": "contacts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/contacts/:id",
+        "op": "read",
+        "responseSchema": "Contact",
+        "readsFrom": "contacts"
+      },
+      {
+        "method": "GET",
+        "path": "/api/contacts",
+        "op": "list",
+        "responseSchema": "ContactList",
+        "readsFrom": "contacts"
+      },
+      {
+        "method": "DELETE",
+        "path": "/api/contacts/:id",
+        "op": "delete",
+        "deletesFrom": "contacts"
+      }
+    ],
+    "backend.endpointEnumeration": [
+      { "route": "POST /api/contacts", "table": "contacts", "op": "insert" },
+      { "route": "GET /api/contacts/:id", "table": "contacts", "op": "select-by-pk" },
+      { "route": "GET /api/contacts", "table": "contacts", "op": "select-by-tenant" },
+      { "route": "DELETE /api/contacts/:id", "table": "contacts", "op": "delete-by-pk" }
+    ],
+    "backend.dataAccess": {
+      "orm": "drizzle",
+      "tables": ["contacts"],
+      "queries": {
+        "contacts": ["by-id", "by-tenant-paginated", "by-email"]
+      }
+    },
+    "backend.businessRules": [
+      "Contact email must be unique within tenant",
+      "Contact submission emits a contact.created domain event"
+    ]
+  },
+  "confidence": 0.85,
+  "notes": "Fake Backend upstream for Database Architect golden test.",
+  "dependencies": [],
+  "risks": [],
+  "toolCalls": [],
+  "spend": {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "usdCost": 0,
+    "wallClockMs": 0,
+    "model": "sonnet"
+  },
+  "status": "ok"
+}

--- a/packages/database-architect/tests/golden/input-businessplan.json
+++ b/packages/database-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/database-architect/tests/golden/input-designversion.json
+++ b/packages/database-architect/tests/golden/input-designversion.json
@@ -1,0 +1,16 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "contact-form",
+      "kind": "form",
+      "bbox": { "x": 0, "y": 800, "w": 1440, "h": 480 },
+      "meta": { "fields": ["name", "email", "message"] }
+    }
+  ],
+  "tokens": {
+    "color.brand.primary": "#0f3057"
+  },
+  "breakpoints": ["sm", "md", "lg", "xl"]
+}

--- a/packages/database-architect/tests/golden/input-ticket.json
+++ b/packages/database-architect/tests/golden/input-ticket.json
@@ -1,0 +1,18 @@
+{
+  "id": "ticket-pt-002",
+  "type": "Form",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "Submitting the contact form persists a contacts row in the tenant schema.",
+    "Tenant isolation: tenant A cannot read tenant B's contacts even with SQL injection.",
+    "GDPR delete: when a user account is deleted, their contacts rows are anonymised within 30 days.",
+    "Email uniqueness is enforced per tenant.",
+    "A Postgres GIN index exists on the contacts.payload JSONB column."
+  ],
+  "business_requirements": {
+    "title": "Contact form persistence",
+    "description": "Schema, indexes, and RLS for the contact form on the artist profile page. One row per submission; tenant-scoped; queryable by id, by tenant (paginated), and by email."
+  },
+  "quality_tags": ["persists", "database", "gdpr"]
+}

--- a/packages/database-architect/tests/helpers/fakes.ts
+++ b/packages/database-architect/tests/helpers/fakes.ts
@@ -1,0 +1,439 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari contact-form Story ticket. The golden test
+ *     uses this. Includes a fake Backend Architect upstream output
+ *     keyed at `upstream.outputs.backend` (since Backend Architect is
+ *     not yet merged at the time of this PR, the upstream is fabricated
+ *     to the contract shape Backend's PR will land).
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari contact-form fixture.
+ *
+ *   - `fakeBackendUpstreamOutput()` — the upstream Backend output the
+ *     Database Architect consumes. This is the contract Backend will
+ *     publish when its PR lands; see `research/17_architect_framework_spec_2026.md`
+ *     §2.2 for the field list.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { DATABASE_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * Fabricated Backend Architect upstream output. Mirrors the contract
+ * Backend's `@caia/backend-architect` PR will publish; the Database
+ * Architect reads this to enumerate persistence touchpoints.
+ */
+export function fakeBackendUpstreamOutput(): ArchitectOutput {
+  return {
+    architectName: 'backend',
+    architectureFields: {
+      'backend.framework': { name: 'next', version: '15.x', runtime: 'edge+node' },
+      'backend.apiEndpoints': [
+        {
+          method: 'POST',
+          path: '/api/contacts',
+          op: 'create',
+          requestSchema: 'ContactCreate',
+          responseSchema: 'Contact',
+          persistsTo: 'contacts'
+        },
+        {
+          method: 'GET',
+          path: '/api/contacts/:id',
+          op: 'read',
+          responseSchema: 'Contact',
+          readsFrom: 'contacts'
+        },
+        {
+          method: 'GET',
+          path: '/api/contacts',
+          op: 'list',
+          responseSchema: 'ContactList',
+          readsFrom: 'contacts'
+        },
+        {
+          method: 'DELETE',
+          path: '/api/contacts/:id',
+          op: 'delete',
+          deletesFrom: 'contacts'
+        }
+      ],
+      'backend.endpointEnumeration': [
+        { route: 'POST /api/contacts', table: 'contacts', op: 'insert' },
+        { route: 'GET /api/contacts/:id', table: 'contacts', op: 'select-by-pk' },
+        { route: 'GET /api/contacts', table: 'contacts', op: 'select-by-tenant' },
+        { route: 'DELETE /api/contacts/:id', table: 'contacts', op: 'delete-by-pk' }
+      ],
+      'backend.dataAccess': {
+        orm: 'drizzle',
+        tables: ['contacts'],
+        queries: {
+          contacts: ['by-id', 'by-tenant-paginated', 'by-email']
+        }
+      },
+      'backend.businessRules': [
+        'Contact email must be unique within tenant',
+        'Contact submission emits a contact.created domain event'
+      ]
+    },
+    confidence: 0.85,
+    notes: 'Fake Backend upstream for Database Architect golden test.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/**
+ * The canonical fixture — a Form Story ticket from the prakash-tiwari.com
+ * marketing site (a contact form) with intake-derived design tokens +
+ * business plan + a fake Backend upstream output.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-002',
+      type: 'Form',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Submitting the contact form persists a contacts row in the tenant schema.',
+        'Tenant isolation: tenant A cannot read tenant B\'s contacts even with SQL injection.',
+        'GDPR delete: when a user account is deleted, their contacts rows are anonymised within 30 days.',
+        'Email uniqueness is enforced per tenant.',
+        'A Postgres GIN index exists on the contacts.payload JSONB column.'
+      ],
+      business_requirements: {
+        title: 'Contact form persistence',
+        description:
+          'Schema, indexes, and RLS for the contact form on the artist profile page. One row per submission; tenant-scoped; queryable by id, by tenant (paginated), and by email.'
+      },
+      quality_tags: ['persists', 'database', 'gdpr']
+    },
+    upstream: { outputs: { backend: fakeBackendUpstreamOutput() } },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: 'High-intent prospective sitters in the artist\'s metropolitan area.',
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        'Make the booking CTA the page\'s primary action'
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'contact-form',
+          kind: 'form',
+          bbox: { x: 0, y: 800, w: 1440, h: 480 },
+          meta: { fields: ['name', 'email', 'message'] }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari contact-form fixture.
+ *
+ * Every Database invariant in `src/invariants.ts` must pass against this
+ * output. If you change the invariants, update this fixture too.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'database',
+    architectureFields: {
+      'database.engine': { name: 'postgres', version: '16.x', orm: 'drizzle' },
+      'database.tables': [
+        {
+          name: 'tenants',
+          primaryKey: 'id',
+          scope: 'shared',
+          comment: 'Shared catalog of tenants. Owned by the meta cluster.'
+        },
+        {
+          name: 'contacts',
+          primaryKey: 'id',
+          scope: 'tenant',
+          comment: 'Per-tenant contact-form submissions.'
+        }
+      ],
+      'database.columns': {
+        tenants: [
+          { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+          { name: 'slug', type: 'text', nullable: false },
+          { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+          { name: 'updated_at', type: 'timestamptz', nullable: false, default: 'now()' }
+        ],
+        contacts: [
+          { name: 'id', type: 'uuid', nullable: false, default: 'gen_random_uuid()' },
+          { name: 'tenant_id', type: 'uuid', nullable: false },
+          {
+            name: 'name',
+            type: 'text',
+            nullable: false,
+            check: "char_length(name) between 1 and 200"
+          },
+          {
+            name: 'email',
+            type: 'text',
+            nullable: false,
+            check: "email ~ '^[^@]+@[^@]+\\.[^@]+$'"
+          },
+          {
+            name: 'message',
+            type: 'text',
+            nullable: false,
+            check: "char_length(message) between 1 and 5000"
+          },
+          { name: 'payload', type: 'jsonb', nullable: false, default: "'{}'::jsonb" },
+          { name: 'created_at', type: 'timestamptz', nullable: false, default: 'now()' },
+          { name: 'updated_at', type: 'timestamptz', nullable: false, default: 'now()' }
+        ]
+      },
+      'database.indexes': [
+        {
+          table: 'tenants',
+          name: 'tenants_slug_uk',
+          columns: ['slug'],
+          unique: true,
+          method: 'btree'
+        },
+        {
+          table: 'contacts',
+          name: 'contacts_tenant_id_idx',
+          columns: ['tenant_id'],
+          unique: false,
+          method: 'btree'
+        },
+        {
+          table: 'contacts',
+          name: 'contacts_tenant_email_uk',
+          columns: ['tenant_id', 'email'],
+          unique: true,
+          method: 'btree'
+        },
+        {
+          table: 'contacts',
+          name: 'contacts_payload_gin',
+          columns: ['payload'],
+          unique: false,
+          method: 'gin'
+        }
+      ],
+      'database.migrations': [
+        {
+          id: '0001_create_tenants',
+          description: 'Create shared tenants catalog table.',
+          up: 'CREATE TABLE tenants (id uuid primary key default gen_random_uuid(), slug text not null, created_at timestamptz not null default now(), updated_at timestamptz not null default now()); CREATE UNIQUE INDEX tenants_slug_uk ON tenants (slug);',
+          down: 'DROP TABLE tenants;',
+          ordering: 1,
+          requiresOperatorReview: false
+        },
+        {
+          id: '0002_create_contacts',
+          description:
+            'Create per-tenant contacts table with email uniqueness + JSONB payload + RLS.',
+          up: 'CREATE TABLE contacts (id uuid primary key default gen_random_uuid(), tenant_id uuid not null references tenants(id) on delete restrict, name text not null check (char_length(name) between 1 and 200), email text not null check (email ~ \'^[^@]+@[^@]+\\.[^@]+$\'), message text not null check (char_length(message) between 1 and 5000), payload jsonb not null default \'{}\'::jsonb, created_at timestamptz not null default now(), updated_at timestamptz not null default now()); CREATE INDEX contacts_tenant_id_idx ON contacts (tenant_id); CREATE UNIQUE INDEX contacts_tenant_email_uk ON contacts (tenant_id, email); CREATE INDEX contacts_payload_gin ON contacts USING GIN (payload); ALTER TABLE contacts ENABLE ROW LEVEL SECURITY; CREATE POLICY tenant_isolation ON contacts USING (current_setting(\'app.tenant_id\')::uuid = tenant_id); CREATE POLICY service_role_bypass ON contacts USING (current_user = \'orchestrator\');',
+          down: 'DROP TABLE contacts;',
+          ordering: 2,
+          requiresOperatorReview: false
+        }
+      ],
+      'database.relationships': [
+        {
+          from: 'contacts.tenant_id',
+          to: 'tenants.id',
+          onDelete: 'restrict',
+          onUpdate: 'cascade',
+          deferrable: false
+        }
+      ],
+      'database.rlsPolicies': {
+        contacts: [
+          {
+            name: 'tenant_isolation',
+            using: "current_setting('app.tenant_id')::uuid = tenant_id",
+            kind: 'permissive',
+            operation: 'all'
+          },
+          {
+            name: 'service_role_bypass',
+            using: "current_user = 'orchestrator'",
+            kind: 'permissive',
+            operation: 'all'
+          }
+        ]
+      },
+      'database.tenantIsolationStrategy': {
+        model: 'schema-per-tenant',
+        justification:
+          'Matches CAIA meta cluster. One Postgres schema per tenant; shared catalog tables live in the public schema.',
+        schemaNameTemplate: 'tenant_{{tenantId}}',
+        sharedTables: ['tenants']
+      },
+      'database.dataLifecycle': [
+        {
+          table: 'tenants',
+          retentionDays: -1,
+          archivalSink: 'r2://archive/tenants',
+          gdprDeleteStrategy: 'soft',
+          cascadeOnUserDelete: false
+        },
+        {
+          table: 'contacts',
+          retentionDays: 730,
+          archivalSink: 'r2://archive/contacts',
+          gdprDeleteStrategy: 'anonymize',
+          cascadeOnUserDelete: true
+        }
+      ],
+      'database.jsonbShapes': {
+        'contacts.payload': {
+          shape:
+            'z.object({ source: z.string().optional(), utm: z.record(z.string()).optional(), userAgent: z.string().optional() })'
+        }
+      },
+      'database.queryHints': [
+        {
+          endpoint: 'POST /api/contacts',
+          table: 'contacts',
+          op: 'write',
+          indexCandidate: 'contacts_tenant_email_uk',
+          expectedQps: 2,
+          p95LatencyTargetMs: 80
+        },
+        {
+          endpoint: 'GET /api/contacts/:id',
+          table: 'contacts',
+          op: 'read',
+          indexCandidate: 'contacts_pkey',
+          expectedQps: 5,
+          p95LatencyTargetMs: 20
+        },
+        {
+          endpoint: 'GET /api/contacts',
+          table: 'contacts',
+          op: 'read',
+          indexCandidate: 'contacts_tenant_id_idx',
+          expectedQps: 1,
+          p95LatencyTargetMs: 60
+        },
+        {
+          endpoint: 'DELETE /api/contacts/:id',
+          table: 'contacts',
+          op: 'write',
+          indexCandidate: 'contacts_pkey',
+          expectedQps: 0.1,
+          p95LatencyTargetMs: 40
+        }
+      ]
+    },
+    confidence: 0.87,
+    notes:
+      'Two tables: shared `tenants` catalog + per-tenant `contacts`. Composite unique index on (tenant_id, email) enforces per-tenant email uniqueness. GIN index on payload JSONB. RLS enabled on contacts with tenant_isolation + service_role_bypass policies. Schema-per-tenant matches CAIA meta cluster. GDPR delete strategy is anonymize for contacts (retain 730 days, then anonymize PII).',
+    dependencies: ['backend'],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Asserts that the input covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of DATABASE_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/database-architect/tests/invariants.test.ts
+++ b/packages/database-architect/tests/invariants.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Cross-architect invariants — verifies Database's contributions to the
+ * EA Reviewer's invariant registry (per spec §6.2).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { DATABASE_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('DATABASE_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(DATABASE_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable, unique id', () => {
+    const seen = new Set<string>();
+    for (const inv of DATABASE_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `database`', () => {
+    for (const inv of DATABASE_INVARIANTS) {
+      expect(inv.contributor).toBe('database');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of DATABASE_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of DATABASE_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of DATABASE_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('every invariant reads only `database.*` paths', () => {
+    for (const inv of DATABASE_INVARIANTS) {
+      for (const path of inv.reads) {
+        expect(path.startsWith('database.')).toBe(true);
+      }
+    }
+  });
+});
+
+describe('DATABASE_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of DATABASE_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('tables-nonempty fails on an empty tables array', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.tables-nonempty');
+    expect(inv).toBeDefined();
+    const empty = { ...goldenArch, 'database.tables': [] };
+    expect(inv!.detect(empty)).toBe(false);
+  });
+
+  it('engine-is-postgres fails on MySQL', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.engine-is-postgres');
+    expect(inv).toBeDefined();
+    const wrong = { ...goldenArch, 'database.engine': { name: 'mysql', version: '8.x' } };
+    expect(inv!.detect(wrong)).toBe(false);
+  });
+
+  it('engine-is-postgres passes on postgres', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.engine-is-postgres');
+    expect(inv).toBeDefined();
+    expect(inv!.detect(goldenArch)).toBe(true);
+  });
+
+  it('tenant-isolation-declared fails on an unknown model', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.tenant-isolation-declared');
+    expect(inv).toBeDefined();
+    const wrong = {
+      ...goldenArch,
+      'database.tenantIsolationStrategy': { model: 'shared-everything' }
+    };
+    expect(inv!.detect(wrong)).toBe(false);
+  });
+
+  it('every-table-has-columns fails when a table is missing its column entries', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.every-table-has-columns');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.columns': { tenants: [] } // missing contacts
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('every-table-has-id-and-timestamps fails when a table omits updated_at', () => {
+    const inv = DATABASE_INVARIANTS.find(
+      i => i.id === 'database.every-table-has-id-and-timestamps'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.columns': {
+        tenants: [
+          { name: 'id', type: 'uuid' },
+          { name: 'created_at', type: 'timestamptz' }
+        ],
+        contacts: [
+          { name: 'id', type: 'uuid' },
+          { name: 'created_at', type: 'timestamptz' },
+          { name: 'updated_at', type: 'timestamptz' }
+        ]
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('migrations-have-up-and-down fails when down is missing', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.migrations-have-up-and-down');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.migrations': [
+        { id: '0001', up: 'CREATE TABLE x();', down: '' }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('rls-policies-cover-tenant-scoped-tables fails when a tenant table has no policies', () => {
+    const inv = DATABASE_INVARIANTS.find(
+      i => i.id === 'database.rls-policies-cover-tenant-scoped-tables'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.rlsPolicies': {} // contacts is tenant-scoped, no policies
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('jsonb-columns-have-shapes fails when payload has no shape descriptor', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.jsonb-columns-have-shapes');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.jsonbShapes': {} // contacts.payload is jsonb but no shape
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('fk-columns-have-btree-indexes fails when an FK lacks a btree index', () => {
+    const inv = DATABASE_INVARIANTS.find(i => i.id === 'database.fk-columns-have-btree-indexes');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.indexes': [
+        // contacts_tenant_id_idx removed → FK contacts.tenant_id has no btree idx
+        {
+          table: 'tenants',
+          name: 'tenants_slug_uk',
+          columns: ['slug'],
+          unique: true,
+          method: 'btree'
+        },
+        {
+          table: 'contacts',
+          name: 'contacts_payload_gin',
+          columns: ['payload'],
+          unique: false,
+          method: 'gin'
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('every-table-has-lifecycle-rule fails when a table lacks a lifecycle entry', () => {
+    const inv = DATABASE_INVARIANTS.find(
+      i => i.id === 'database.every-table-has-lifecycle-rule'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'database.dataLifecycle': [
+        { table: 'tenants', retentionDays: -1 }
+        // contacts missing
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});

--- a/packages/database-architect/tests/run.test.ts
+++ b/packages/database-architect/tests/run.test.ts
@@ -1,0 +1,252 @@
+/**
+ * `run()` tests — verifies the runtime pipeline:
+ *
+ *   - happy path returns a well-formed ArchitectOutput
+ *   - idempotency: same input → output
+ *   - re-runs REPLACE owned fields (do not append)
+ *   - dependency declaration on output (database depends on backend)
+ *   - failure modes (spawn failure, validation failure)
+ *   - reviewer feedback is plumbed through
+ *   - spend telemetry comes from the spawner, not the assistant
+ *   - Backend's upstream output is surfaced in the user prompt
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { DATABASE_ARCHITECT_NAME, DatabaseArchitect } from '../src/architect.js';
+import { DATABASE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runDatabaseArchitect } from '../src/run.js';
+import { buildDatabaseSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runDatabaseArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('database');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    for (const k of DATABASE_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildDatabaseSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runDatabaseArchitect(input, {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runDatabaseArchitect(input, {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runDatabaseArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runDatabaseArchitect(input, {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    const b = await runDatabaseArchitect(input, {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runDatabaseArchitect(input, {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    const r2 = await runDatabaseArchitect(input, {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(DATABASE_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runDatabaseArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"database"}');
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runDatabaseArchitect — dependency declaration', () => {
+  it('database is a wave-2 architect; declares Backend dependency in output', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runDatabaseArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildDatabaseSystemPrompt(),
+      architectName: DATABASE_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toEqual(['backend']);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-002');
+  });
+
+  it('surfaces Backend\'s upstream apiEndpoints (Database\'s primary input)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('backend.apiEndpoints');
+    expect(p).toContain('/api/contacts');
+  });
+
+  it('surfaces Backend\'s upstream endpointEnumeration', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('backend.endpointEnumeration');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('"pt_001"');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'add GIN index on payload', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('add GIN index on payload');
+  });
+
+  it('renders reviewerFeedback as null when absent', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('"reviewerFeedback": null');
+  });
+});
+
+describe('DatabaseArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new DatabaseArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('database');
+    expect(out.status).toBe('ok');
+  });
+
+  it('preserves the assistant-declared confidence on success', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new DatabaseArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.confidence).toBeGreaterThan(0.5);
+    expect(out.confidence).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/database-architect/tests/system-prompt.test.ts
+++ b/packages/database-architect/tests/system-prompt.test.ts
@@ -1,0 +1,116 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b):
+ *
+ *   - Parses cleanly as text (non-empty, no obvious corruption).
+ *   - References every declared owned field at least once.
+ *   - Contains the standard architect-output JSON schema instruction.
+ *   - Under a reasonable size (token budget proxy).
+ *   - Idempotent (pure function).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { DATABASE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildDatabaseSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildDatabaseSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildDatabaseSystemPrompt();
+    const p2 = buildDatabaseSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Database Architect");
+  });
+
+  it('contains the Locked stack section with Postgres + Drizzle + per-tenant isolation', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Postgres');
+    expect(p).toContain('Drizzle');
+    expect(p).toContain('schema-per-tenant');
+    expect(p).toContain('GIN');
+    expect(p).toContain('RLS');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildDatabaseSystemPrompt();
+    for (const key of DATABASE_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('JSONB');
+    expect(p).toContain('GIN');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('database.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('mentions reading Backend\'s upstream output (Database\'s primary input)', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p).toContain('Backend');
+    expect(p).toContain('apiEndpoints');
+  });
+
+  it('does not refer to fields outside the `database.*` namespace', () => {
+    const p = buildDatabaseSystemPrompt();
+    // Reject other architects' fields appearing — they are someone
+    // else's territory. (Allow casual mentions of "Backend" the role,
+    // but not e.g. backend.apiShape which would imply Database is
+    // emitting that field.)
+    const foreignFields = [
+      'frontend.componentTree',
+      'frontend.tokens',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape',
+      'a11y.wcagLevel'
+    ];
+    for (const field of foreignFields) {
+      expect(p).not.toContain(field);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 16k chars)', () => {
+    const p = buildDatabaseSystemPrompt();
+    expect(p.length).toBeLessThan(16_000);
+  });
+});

--- a/packages/database-architect/tests/validation.test.ts
+++ b/packages/database-architect/tests/validation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { DATABASE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('database');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"database"}',
+      DATABASE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['database.tables'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'frontend.componentTree': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags a backend.* field as out of namespace (Database does NOT own Backend\'s slots)', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiEndpoints': []
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(
+      result.errors.some(e => e.code === 'unexpected-field' && e.field === 'backend.apiEndpoints')
+    ).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), DATABASE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(JSON.stringify(variant), DATABASE_OWNED_FIELD_KEYS);
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/database-architect/tsconfig.build.json
+++ b/packages/database-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/database-architect/tsconfig.json
+++ b/packages/database-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/database-architect/vitest.config.ts
+++ b/packages/database-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});


### PR DESCRIPTION
Architect #3 of CAIA's 17-architect EA fan-out. Senior DBA / data architect focused on Postgres 16 + Drizzle/Prisma migrations + per-tenant schema isolation matching CAIA's meta cluster.

## What ships

- \`DatabaseArchitect\` class implementing \`SpecialistArchitect\` (\`name = 'database'\`).
- Owned \`database.*\` slice of \`tickets.architecture\` (11 fields, all \`required\`):
  - \`engine\`, \`tables\`, \`columns\`, \`indexes\`, \`migrations\`, \`relationships\`, \`rlsPolicies\`, \`tenantIsolationStrategy\`, \`dataLifecycle\`, \`jsonbShapes\`, \`queryHints\`.
- Deterministic \`systemPrompt()\` covering Role, Locked stack, Input format, Output JSON schema (per-field guidance), Decision heuristics, Refusal patterns, Self-check, Examples — references every owned field; <16k chars.
- \`tools: []\` for V1 (spec's \`caia-db-introspect\` is V2).
- \`run(input)\` reads Backend Architect's upstream output (\`backend.apiEndpoints\` / \`backend.endpointEnumeration\`) to enumerate persistence touchpoints. Spawns Claude (Sonnet default) via \`@chiefaia/claude-spawner\` (subscription-only). Validates against contract. Returns \`ArchitectOutput\` with \`dependencies: ['backend']\`.
- 10 cross-architect invariants exported for the EA Reviewer's registry.

## Contract (\`architectMeta\`)

- \`dependsOn: ['backend']\` (wave-2)
- \`precedenceLevel: 11\` — above Backend at 12 per spec §5.2
- \`fanoutPolicy: 'always'\`
- \`runtimeModel: 'sonnet'\`
- \`appliesPredicate\`: Page | Story | Form | List | Foundation; Widget only when \`quality_tag\` contains \`persists\` or \`database\`.

## Backend Architect upstream

Backend is also wave-1 and not yet merged. The Database runtime is wired to consume \`upstream.outputs.backend.architectureFields['backend.apiEndpoints']\` per the contract Backend's PR will publish — see \`fakeBackendUpstreamOutput()\` in \`tests/helpers/fakes.ts\`. When Backend lands, no Database changes are needed.

## Tests

133 tests across 7 files; all green. \`tsc --noEmit\` clean. \`eslint src tests\` clean. \`tsc -p tsconfig.build.json\` emits \`dist/\`.

- \`architect.test.ts\` (12) — \`SpecialistArchitect\` interface compliance.
- \`contract.test.ts\` (38) — structural + \`architectMeta\` + \`appliesPredicate\` + \`ArchitectRegistry\` registration + disjointness vs \`@caia/frontend-architect\` (no field overlap; ladder rank 11; outranks Backend at 12).
- \`run.test.ts\` (22) — happy path, idempotency, re-run REPLACES fields, dependency declaration, failure modes, reviewer feedback passthrough, Backend upstream surfaced in user prompt.
- \`validation.test.ts\` (20) — every error class covered; lenient \`stripFences\`; \`backend.*\` flagged as unexpected-field.
- \`invariants.test.ts\` (19) — all 10 invariants pass the golden fixture; each fails its targeted corruption.
- \`system-prompt.test.ts\` (13) — determinism, owned-field coverage, foreign-field exclusion, size cap.
- \`golden/golden.test.ts\` (9) — end-to-end with a prakash-tiwari contact-form Form Story; emits 2 tables, GIN index on \`contacts.payload\`, RLS policies, schema-per-tenant, GDPR anonymize, 4 query hints.

## Spec sources

- \`research/17_architect_framework_spec_2026.md\` §2.3 (Database owns \`database.*\`), §5.2 (precedence rank 11), §7.1 (registration).
- Architect brief A3 (Postgres + Drizzle + JSONB-heavy + GIN indexes + RLS template).
- Roster: \`agent-memory/project_caia_17_architects.md\` #3.

## Constraints met

- Subscription-only build (no \`ANTHROPIC_API_KEY\` path) — spawner goes through \`@chiefaia/claude-spawner\`.
- Mirrors \`@caia/frontend-architect\` (PR #537) verbatim in shape — spawner, validator, run/invariants/index all parallel the canonical template.
- mac-mcp used end-to-end for inspection / build / test / commit.