### PR TITLE
feat(@caia/backend-architect): ship architect #2 of 17 — Backend specialist

### DIFF
--- a/packages/backend-architect/README.md
+++ b/packages/backend-architect/README.md
@@ -1,0 +1,62 @@
+# @caia/backend-architect
+
+Architect #2 of CAIA's 17-architect EA fan-out. Senior backend engineer focused on Next.js 15 App Router Route Handlers + Server Actions + TypeScript + Zod v3 + Cloudflare Access + Drizzle ORM. Produces tight API endpoint specs the coding worker can implement directly. Wave-1 architect (no upstream deps); Database/Security/API-Gateway/Observability/DevOps Architects all depend on Backend's output downstream.
+
+Mirrors the canonical `@caia/frontend-architect` template (architect #1).
+
+## What it owns
+
+`backend.*` slice of the `tickets.architecture` JSONB column:
+
+- `backend.framework` — locked Next.js 15 App Router (Route Handlers + Server Actions), hybrid edge+node runtime
+- `backend.serviceBoundaries` — module decomposition (default monolith-with-modules)
+- `backend.apiEndpoints` — per-ticket endpoint specs (method, path, schemas, persistence, auth, rate limit)
+- `backend.endpointEnumeration` — flat `{route, table, op}` enumeration consumed by Database Architect
+- `backend.requestSchemas` — Zod v3 request body / query schemas keyed by ref
+- `backend.responseSchemas` — Zod v3 response body schemas keyed by ref
+- `backend.errorEnvelope` — canonical error envelope shape + examples + class-to-status mapping
+- `backend.validationRules` — cross-cutting validation invariants beyond Zod
+- `backend.authRequirements` — per-endpoint auth (default Cloudflare Access for tenant routes)
+- `backend.rateLimits` — per-endpoint rate limits (per-tenant/per-IP)
+- `backend.dataAccess` — ORM choice + per-table query plan (consumed by Database Architect)
+- `backend.businessRules` — cross-cutting business invariants surfaced to downstream architects
+
+## What it does NOT do
+
+No frontend components (Frontend Architect owns those — merged PR #537). No database migrations (Database Architect owns those — merged PR #549). No CSP/authN/authZ (Security). No event taxonomies (Analytics). No CI/CD (DevOps). Other architects own those concerns and the contract rejects out-of-namespace writes.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1 + §2.2). The EA Dispatcher spawns one of these per applicable ticket. Each spawn calls `@chiefaia/claude-spawner` (subscription-only, no API-key billing) with Sonnet default. Reads `ticket`, `businessPlan`, `designVersion` directly; Backend is wave-1 so `upstream.outputs` is empty on first run. Returns a structured `ArchitectOutput` the Dispatcher composes into the ticket's `architecture` JSONB.
+
+**Dependencies:** none (wave-1 architect).
+**Precedence rank:** 12 per spec §5.2.
+**Applies to:** Page, Story, Form, List, Foundation tickets; Widget tickets only when tagged `api`/`backend`/`persists`.
+
+## Quick start
+
+```ts
+import { BackendArchitect, BackendArchitectContract } from '@caia/backend-architect';
+
+const architect = new BackendArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: {} },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite includes interface compliance, contract structural checks, registration disjointness (no overlap with `@caia/frontend-architect` or `@caia/database-architect`), output validation, `run()` idempotency, dependency declaration, cross-architect invariants, and an end-to-end golden test against a known prakash-tiwari ArtistContactForm Widget ticket.

--- a/packages/backend-architect/eslint.config.cjs
+++ b/packages/backend-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on frontend/database-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/backend-architect/package.json
+++ b/packages/backend-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/backend-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Backend Architect — architect #2 of CAIA's 17-architect EA fan-out. Owns the `backend.*` slice of `tickets.architecture` (framework, serviceBoundaries, apiEndpoints, requestSchemas, responseSchemas, errorEnvelope, validationRules, authRequirements, rateLimits, dataAccess, businessRules). Senior backend engineer focused on Next.js Route Handlers + Server Actions + TypeScript + Zod + REST/RPC patterns + OpenAPI specs. Produces tight API endpoint specs the coding worker can implement. Does NOT write frontend components or database migrations. Spawns Claude via @chiefaia/claude-spawner (subscription-only). Mirrors the @caia/frontend-architect template.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/backend-architect/src/architect.ts
+++ b/packages/backend-architect/src/architect.ts
@@ -1,0 +1,79 @@
+/**
+ * `BackendArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (per spec §2.2 — Backend reads tenant
+ *     Cloudflare Access JWT issuer config via `tenantContext`; the
+ *     `caia-backend-introspect` tool is deferred to V2).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from `@caia/architect-kit`
+ * because the kit's BaseArchitect was added late in PR #535; we satisfy
+ * the `SpecialistArchitect` interface structurally to mirror the
+ * `@caia/frontend-architect` template exactly. When the kit's
+ * `BaseArchitect` becomes the canonical extension point (next minor),
+ * switch to `extends BaseArchitect`.
+ */
+
+import { BackendArchitectContract } from './contract.js';
+import { runBackendArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildBackendSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/backend-architect` minus the suffix. */
+export const BACKEND_ARCHITECT_NAME = 'backend' as const;
+
+/** V1: no architect-specific tools. The `caia-backend-introspect` tool is V2. */
+export const BACKEND_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface BackendArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class BackendArchitect implements SpecialistArchitect {
+  readonly name = BACKEND_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = BackendArchitectContract;
+  readonly tools: readonly ToolDefinition[] = BACKEND_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: BackendArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildBackendSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runBackendArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/backend-architect/src/contract.ts
+++ b/packages/backend-architect/src/contract.ts
@@ -1,0 +1,212 @@
+/**
+ * `BackendArchitectContract` — the canonical owned-fields declaration for
+ * architect #2 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.2 (Backend Architect owns `backend.*`)
+ *   - task brief (apiEndpoints, requestSchemas, responseSchemas,
+ *     errorEnvelope, validationRules, authRequirements, rateLimits,
+ *     serviceBoundaries)
+ *
+ * The reconciled superset below merges spec §2.2's stack-lock fields
+ * (framework, endpointEnumeration, dataAccess, businessRules) with the
+ * task brief's per-endpoint structural fields (apiEndpoints with full
+ * Zod request/response schemas, error envelope, validation rules, auth
+ * requirements, rate limits, and service boundaries). Every field is
+ * marked `required: true` because downstream architects (Database,
+ * Security, API-Gateway, Observability, DevOps) read these — missing
+ * fields cascade.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. The chosen keys all live under the `backend.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ *
+ * The Database Architect (merged PR #549) already consumes
+ * `backend.apiEndpoints`, `backend.endpointEnumeration`, `backend.dataAccess`,
+ * and `backend.businessRules` from this architect's upstream output —
+ * keep these names stable.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const BACKEND_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'backend.framework':
+    'Default to {"name":"next","version":"15.x","runtime":"edge+node","handlerStyle":"app-router-route-handlers+server-actions"}. Reject any decision that picks Express, Fastify, NestJS, or a non-Next.js stack.',
+  'backend.serviceBoundaries':
+    'Default to {"style":"monolith-with-modules","modules":[...]} keyed by domain. Reject any decision that proposes microservices for a CAIA-scale ticket without explicit operator override.',
+  'backend.apiEndpoints':
+    'Per-ticket-type rules: Form Story → one POST endpoint; List Story → one paginated GET; CRUD Story → POST/GET-list/GET-by-id/PATCH/DELETE. Each entry: {method, path, op, requestSchemaRef?, responseSchemaRef?, persistsTo?, readsFrom?, deletesFrom?, auth, rateLimit}.',
+  'backend.endpointEnumeration':
+    'Flat enumeration of every {route, table, op} touchpoint derived from `apiEndpoints`. Database Architect reads this verbatim to enumerate persistence touchpoints. Keep `route` formatted as `METHOD /path`.',
+  'backend.requestSchemas':
+    'Zod-style descriptors keyed by ref (e.g. `ContactCreate`). For each endpoint with a body or query, emit one entry. Use Zod v3 syntax (z.object, z.string, z.email, z.uuid, refinements, etc.).',
+  'backend.responseSchemas':
+    'Zod-style descriptors keyed by ref (e.g. `Contact`, `ContactList`). Every endpoint MUST declare a responseSchemaRef even for 204-No-Content (use `z.void()`). List endpoints emit `{ items, nextCursor }`.',
+  'backend.errorEnvelope':
+    'Canonical error envelope shape: {schema, examples, mapping}. Default: `{ error: { code: string, message: string, details?: object, requestId: string } }`. The mapping table maps thrown error classes → HTTP status + envelope code.',
+  'backend.validationRules':
+    'Per-endpoint validation invariants beyond Zod (cross-field rules, tenant-scoped uniqueness checks, business-logic preconditions). Output: [{endpoint, rule, source: "zod"|"business"|"database", failureMode}].',
+  'backend.authRequirements':
+    'Per-endpoint auth policy. Default Cloudflare Access for tenant-scoped routes, service-token for orchestrator-internal routes, public for marketing. Output: {default, perEndpoint: {endpoint: {scheme, issuer?, scopes?, claims?}}}.',
+  'backend.rateLimits':
+    'Per-endpoint rate limits keyed by auth tier. Output: {default: {windowMs, max, scope: "ip"|"tenant"|"user"}, perEndpoint: {endpoint: {windowMs, max, scope, burst?}}}. Marketing endpoints get stricter limits.',
+  'backend.dataAccess':
+    'ORM choice + per-table query plan derived from `apiEndpoints`. Output: {orm: "drizzle"|"prisma", tables: [...], queries: {table: ["by-id","by-tenant-paginated",...]}}. Database Architect reads this.',
+  'backend.businessRules':
+    'Free-form list of cross-cutting business invariants surfaced to downstream architects (Database for CHECK constraints, Testing for assertion seeds). E.g. "Contact email unique within tenant", "Order total must equal sum of line items".'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const BACKEND_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'backend.framework',
+    description:
+      'Locked: Next.js 15 App Router Route Handlers + Server Actions on a hybrid edge+node runtime. Output the framework + version + runtime + handler style so downstream architects (Database, DevOps, API-Gateway, Security) can validate compatibility.',
+    required: true
+  },
+  {
+    path: 'backend.serviceBoundaries',
+    description:
+      'Service decomposition style + module boundaries. Default monolith-with-modules keyed by domain. Drives the API-Gateway Architect\'s routing config and the DevOps Architect\'s deployment unit choice.',
+    required: true
+  },
+  {
+    path: 'backend.apiEndpoints',
+    description:
+      'Per-ticket endpoint specs: method, path, op, request/response schema refs, persistence touchpoints, auth, rate limit. The canonical declaration of every HTTP/RPC surface this ticket exposes.',
+    required: true
+  },
+  {
+    path: 'backend.endpointEnumeration',
+    description:
+      'Flat enumeration of every {route, table, op} touchpoint derived from `apiEndpoints`. Database Architect reads this verbatim to enumerate persistence touchpoints; route format `METHOD /path`.',
+    required: true
+  },
+  {
+    path: 'backend.requestSchemas',
+    description:
+      'Zod-style descriptors for every endpoint\'s request body / query params, keyed by ref (e.g. `ContactCreate`). Endpoints without a body omit their entry.',
+    required: true
+  },
+  {
+    path: 'backend.responseSchemas',
+    description:
+      'Zod-style descriptors for every endpoint\'s response body, keyed by ref. Every endpoint MUST declare a ref even for 204-No-Content (`z.void()`).',
+    required: true
+  },
+  {
+    path: 'backend.errorEnvelope',
+    description:
+      'Canonical error envelope shape + examples + class-to-status mapping. The single source of truth every endpoint conforms to. The Observability Architect reads `errorEnvelope.mapping` to wire metric tags.',
+    required: true
+  },
+  {
+    path: 'backend.validationRules',
+    description:
+      'Per-endpoint validation invariants beyond Zod schema (cross-field rules, tenant-scoped uniqueness, business preconditions). Feeds Testing Architect\'s assertion seeds and Database Architect\'s CHECK constraints.',
+    required: true
+  },
+  {
+    path: 'backend.authRequirements',
+    description:
+      'Per-endpoint auth policy: scheme, issuer, scopes, claims. Default Cloudflare Access for tenant-scoped routes, service-token for orchestrator-internal, public for marketing. Security Architect cross-validates.',
+    required: true
+  },
+  {
+    path: 'backend.rateLimits',
+    description:
+      'Per-endpoint rate limits keyed by auth tier. The API-Gateway Architect reads this to wire WAF rules; the Observability Architect reads it to emit utilisation metrics.',
+    required: true
+  },
+  {
+    path: 'backend.dataAccess',
+    description:
+      'ORM choice + per-table query plan derived from `apiEndpoints`. The Database Architect reads this to choose indexes and migration ordering.',
+    required: true
+  },
+  {
+    path: 'backend.businessRules',
+    description:
+      'Free-form list of cross-cutting business invariants surfaced to downstream architects. Database lifts these into CHECK constraints; Testing lifts them into property-based test seeds.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const BACKEND_OWNED_FIELD_KEYS: readonly string[] = BACKEND_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.2 — Backend runs on every ticket type that exposes an API
+ * surface or persistence touchpoint: Page (data-loading server
+ * components), Story / Form / List (CRUD endpoints), Foundation
+ * (cross-cutting service modules). Widget tickets typically do NOT have
+ * their own endpoints (they re-use parent-Page handlers), so they're
+ * excluded unless flagged with the `api` quality tag.
+ */
+export function backendArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  ) {
+    return true;
+  }
+  // Widget tickets only get their own endpoints when explicitly tagged.
+  if (ticket.type === 'Widget') {
+    const tags = ticket.quality_tags ?? [];
+    return tags.includes('api') || tags.includes('backend') || tags.includes('persists');
+  }
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * Backend is a wave-1 architect (`dependsOn: []`). Precedence rank 12
+ * per spec §5.2 — below Database (11, schema correctness trumps
+ * functional correctness in conflict resolution) and below the
+ * security/devops/a11y/seo/perf/abTesting/featureFlagging/apiGateway/
+ * observability/analytics critics.
+ */
+export const BACKEND_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: [],
+  precedenceLevel: 12,
+  fanoutPolicy: 'always',
+  appliesPredicate: backendArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const BackendArchitectContract: ArchitectSectionContract = {
+  contractId: 'backend-architect.v1',
+  architectName: 'backend',
+  version: '0.1.0',
+  sections: BACKEND_OWNED_SECTIONS,
+  architectMeta: BACKEND_ARCHITECT_META
+};

--- a/packages/backend-architect/src/index.ts
+++ b/packages/backend-architect/src/index.ts
@@ -1,0 +1,99 @@
+/**
+ * @caia/backend-architect — public surface.
+ *
+ * Architect #2 of CAIA's 17-architect EA fan-out. Senior backend engineer
+ * focused on Next.js 15 App Router Route Handlers + Server Actions +
+ * TypeScript + Zod v3 + Cloudflare Access + Drizzle. Produces tight API
+ * endpoint specs the coding worker can implement directly. Does NOT
+ * write frontend components or database migrations.
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template (architect
+ * #1, PR #537).
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's default `registerWith()` helper
+ * to install the architect on a registry. The package does NOT
+ * self-register on import (registration is an explicit operator action
+ * that the Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { BackendArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  BackendArchitect,
+  BACKEND_ARCHITECT_NAME,
+  BACKEND_ARCHITECT_TOOLS
+} from './architect.js';
+export type { BackendArchitectConfig } from './architect.js';
+
+export {
+  BackendArchitectContract,
+  BACKEND_OWNED_SECTIONS,
+  BACKEND_OWNED_FIELD_KEYS,
+  BACKEND_FIELD_FIX_HINTS,
+  BACKEND_ARCHITECT_META,
+  backendArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildBackendSystemPrompt } from './system-prompt.js';
+
+// Spawner — exposed so the EA Dispatcher (or tests) can inject a custom one.
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+// Run + validation — exposed for the conformance test suite.
+export { runBackendArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+// Invariants — exposed for the EA Reviewer's registry.
+export { BACKEND_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+// Re-export the canonical kit types so consumers have a single import surface.
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh BackendArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): BackendArchitect {
+  const architect = new BackendArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/backend-architect/src/invariants.ts
+++ b/packages/backend-architect/src/invariants.ts
@@ -1,0 +1,289 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The Reviewer applies a fixed set of cross-architect predicates after
+ * composition. This module enumerates Backend's contributions so the
+ * Reviewer's `invariants-registry.ts` (which doesn't exist yet — sibling
+ * brief F2) can collect them at process boot.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'backend.apiEndpoints'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `backend.*` path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path. This lets the
+ * same invariants run inside the Backend package's own tests AND
+ * inside the Reviewer's post-composition pass.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+/**
+ * Read a field from the architecture blob. Tries the flat dotted key
+ * first (matches `architectureFields` shape), then falls back to walking
+ * the nested object path (matches composed-architecture shape).
+ */
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function asArray(v: unknown): readonly unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+
+function asObject(v: unknown): Readonly<Record<string, unknown>> | null {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return null;
+  return v as Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Backend's contributed invariants. Listed in stable order.
+ */
+export const BACKEND_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'backend.apiEndpoints-nonempty',
+    contributor: 'backend',
+    reads: ['backend.apiEndpoints'],
+    severity: 'fail',
+    description:
+      'Every Backend output must declare at least one entry in `apiEndpoints`. An empty list means the architect failed to project the ticket\'s API surface.',
+    detect(arch): boolean {
+      const endpoints = asArray(readField(arch, 'backend.apiEndpoints'));
+      return endpoints !== null && endpoints.length > 0;
+    }
+  },
+  {
+    id: 'backend.framework-is-next',
+    contributor: 'backend',
+    reads: ['backend.framework'],
+    severity: 'fail',
+    description:
+      'The locked stack mandates Next.js 15 App Router. Any framework decision other than Next.js is a hard violation.',
+    detect(arch): boolean {
+      const fw = asObject(readField(arch, 'backend.framework'));
+      if (!fw) return false;
+      return fw.name === 'next';
+    }
+  },
+  {
+    id: 'backend.serviceBoundaries-declared',
+    contributor: 'backend',
+    reads: ['backend.serviceBoundaries'],
+    severity: 'fail',
+    description:
+      'Every Backend output must declare a `serviceBoundaries.style` (monolith-with-modules|microservices|hybrid). The API-Gateway Architect reads this to choose routing config.',
+    detect(arch): boolean {
+      const sb = asObject(readField(arch, 'backend.serviceBoundaries'));
+      if (!sb) return false;
+      const style = sb.style;
+      return (
+        style === 'monolith-with-modules' ||
+        style === 'microservices' ||
+        style === 'hybrid' ||
+        style === 'monolith'
+      );
+    }
+  },
+  {
+    id: 'backend.endpoint-enumeration-matches-api-endpoints',
+    contributor: 'backend',
+    reads: ['backend.apiEndpoints', 'backend.endpointEnumeration'],
+    severity: 'fail',
+    description:
+      'Every entry in `apiEndpoints` must have a matching `route` entry in `endpointEnumeration` (formatted `METHOD /path`). Database Architect reads `endpointEnumeration` verbatim — drift breaks downstream.',
+    detect(arch): boolean {
+      const endpoints = asArray(readField(arch, 'backend.apiEndpoints'));
+      const enumeration = asArray(readField(arch, 'backend.endpointEnumeration'));
+      if (!endpoints || !enumeration) return false;
+      const enumeratedRoutes = new Set<string>();
+      for (const e of enumeration) {
+        const obj = asObject(e);
+        if (obj && typeof obj.route === 'string') enumeratedRoutes.add(obj.route);
+      }
+      for (const ep of endpoints) {
+        const obj = asObject(ep);
+        if (!obj) return false;
+        const method = typeof obj.method === 'string' ? obj.method : null;
+        const path = typeof obj.path === 'string' ? obj.path : null;
+        if (!method || !path) return false;
+        const route = `${method} ${path}`;
+        if (!enumeratedRoutes.has(route)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'backend.every-endpoint-has-response-schema',
+    contributor: 'backend',
+    reads: ['backend.apiEndpoints', 'backend.responseSchemas'],
+    severity: 'fail',
+    description:
+      'Every endpoint must declare a `responseSchemaRef` that resolves in `responseSchemas`. Endpoints without typed responses break the OpenAPI export.',
+    detect(arch): boolean {
+      const endpoints = asArray(readField(arch, 'backend.apiEndpoints'));
+      const schemas = asObject(readField(arch, 'backend.responseSchemas'));
+      if (!endpoints || !schemas) return false;
+      const knownRefs = new Set(Object.keys(schemas));
+      for (const ep of endpoints) {
+        const obj = asObject(ep);
+        if (!obj) return false;
+        const ref = obj.responseSchemaRef;
+        if (typeof ref !== 'string' || !knownRefs.has(ref)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'backend.request-schemas-resolve',
+    contributor: 'backend',
+    reads: ['backend.apiEndpoints', 'backend.requestSchemas'],
+    severity: 'fail',
+    description:
+      'Every endpoint that declares `requestSchemaRef` must have a matching entry in `requestSchemas`. Dangling refs break Zod runtime validation.',
+    detect(arch): boolean {
+      const endpoints = asArray(readField(arch, 'backend.apiEndpoints'));
+      const schemas = asObject(readField(arch, 'backend.requestSchemas'));
+      if (!endpoints) return false;
+      const knownRefs = new Set(schemas ? Object.keys(schemas) : []);
+      for (const ep of endpoints) {
+        const obj = asObject(ep);
+        if (!obj) return false;
+        const ref = obj.requestSchemaRef;
+        if (ref === undefined || ref === null) continue;
+        if (typeof ref !== 'string' || !knownRefs.has(ref)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'backend.error-envelope-declared',
+    contributor: 'backend',
+    reads: ['backend.errorEnvelope'],
+    severity: 'fail',
+    description:
+      'The Backend output must declare a canonical error envelope with at least `schema` + `mapping`. Per-endpoint error shapes are a hard violation of the locked stack.',
+    detect(arch): boolean {
+      const env = asObject(readField(arch, 'backend.errorEnvelope'));
+      if (!env) return false;
+      if (typeof env.schema !== 'string') return false;
+      const mapping = asObject(env.mapping);
+      if (!mapping) return false;
+      return Object.keys(mapping).length > 0;
+    }
+  },
+  {
+    id: 'backend.auth-requirements-declared',
+    contributor: 'backend',
+    reads: ['backend.authRequirements'],
+    severity: 'fail',
+    description:
+      'Backend output must declare an `authRequirements.default` entry with a recognised scheme (cloudflare-access|service-token|public|bearer).',
+    detect(arch): boolean {
+      const auth = asObject(readField(arch, 'backend.authRequirements'));
+      if (!auth) return false;
+      const def = asObject(auth.default);
+      if (!def) return false;
+      const scheme = def.scheme;
+      return (
+        scheme === 'cloudflare-access' ||
+        scheme === 'service-token' ||
+        scheme === 'public' ||
+        scheme === 'bearer'
+      );
+    }
+  },
+  {
+    id: 'backend.rate-limits-declared',
+    contributor: 'backend',
+    reads: ['backend.rateLimits'],
+    severity: 'advisory',
+    description:
+      'Backend output should declare a `rateLimits.default` entry with `windowMs` + `max` + `scope`. Missing defaults force the API-Gateway Architect to invent values.',
+    detect(arch): boolean {
+      const rl = asObject(readField(arch, 'backend.rateLimits'));
+      if (!rl) return false;
+      const def = asObject(rl.default);
+      if (!def) return false;
+      return (
+        typeof def.windowMs === 'number' &&
+        typeof def.max === 'number' &&
+        typeof def.scope === 'string'
+      );
+    }
+  },
+  {
+    id: 'backend.data-access-tables-cover-endpoint-touchpoints',
+    contributor: 'backend',
+    reads: ['backend.apiEndpoints', 'backend.dataAccess'],
+    severity: 'fail',
+    description:
+      'Every table referenced in `apiEndpoints` (`persistsTo`, `readsFrom`, `deletesFrom`) must appear in `dataAccess.tables`. Missing entries mean the Database Architect won\'t emit a table for it.',
+    detect(arch): boolean {
+      const endpoints = asArray(readField(arch, 'backend.apiEndpoints'));
+      const da = asObject(readField(arch, 'backend.dataAccess'));
+      if (!endpoints || !da) return false;
+      const tables = asArray(da.tables);
+      if (!tables) return false;
+      const known = new Set<string>();
+      for (const t of tables) if (typeof t === 'string') known.add(t);
+      for (const ep of endpoints) {
+        const obj = asObject(ep);
+        if (!obj) return false;
+        for (const key of ['persistsTo', 'readsFrom', 'deletesFrom'] as const) {
+          const v = obj[key];
+          if (typeof v === 'string' && !known.has(v)) return false;
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'backend.endpoints-have-auth-and-rate-limit',
+    contributor: 'backend',
+    reads: ['backend.apiEndpoints'],
+    severity: 'advisory',
+    description:
+      'Every endpoint should declare an `auth` value and a `rateLimit` value (even if those just reference the defaults). Missing entries make per-endpoint overrides ambiguous.',
+    detect(arch): boolean {
+      const endpoints = asArray(readField(arch, 'backend.apiEndpoints'));
+      if (!endpoints) return false;
+      for (const ep of endpoints) {
+        const obj = asObject(ep);
+        if (!obj) return false;
+        if (typeof obj.auth !== 'string') return false;
+        if (typeof obj.rateLimit !== 'string') return false;
+      }
+      return true;
+    }
+  }
+];

--- a/packages/backend-architect/src/run.ts
+++ b/packages/backend-architect/src/run.ts
@@ -1,0 +1,134 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ *
+ * Mirrors `@caia/frontend-architect`'s `run.ts`. Backend has no upstream
+ * deps in the EA dependency graph; the user prompt still surfaces
+ * `upstream.outputs` so reviewer-feedback re-runs can read the prior
+ * iteration's data.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { BACKEND_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them — schema selection is the
+ * Database Architect's concern.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * The runtime entry. Pure aside from the spawner call.
+ */
+export async function runBackendArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, BACKEND_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  // Idempotency: the architect output OWNS its fields. We do NOT merge
+  // with anything else here — composition happens in the Dispatcher
+  // (spec §3.5). Architects always emit the full set of their owned
+  // fields fresh.
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName, // force-correct in case model echoed wrong
+    spend // overwrite — assistant cannot know real spend
+  };
+}

--- a/packages/backend-architect/src/spawner.ts
+++ b/packages/backend-architect/src/spawner.ts
@@ -1,0 +1,162 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * The real spawner lives in `@chiefaia/claude-spawner` (subscription-only,
+ * never sets ANTHROPIC_API_KEY — see that package's file-level comment).
+ * This module:
+ *
+ *   - Defines the `ArchitectSpawnerFn` type — the seam every architect's
+ *     run() consumes.
+ *   - Provides `createDefaultSpawner()` — wires up the real
+ *     `spawnClaude` with the appropriate model + timeout + system prompt.
+ *
+ * Per spec §4 the EA Dispatcher itself runs in the operator's existing
+ * orchestrator process; only the architect subagent spawns issue LLM
+ * calls. This module is the per-architect spawn surface.
+ *
+ * Mirrors `@caia/frontend-architect`'s `spawner.ts` verbatim — only the
+ * architect-specific bits are in `run.ts` + `contract.ts`.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+/**
+ * Inputs to a single spawn — system prompt + user prompt + budget.
+ */
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+/**
+ * Output of a single spawn — the raw assistant text plus telemetry.
+ * Parsing into a structured `ArchitectOutput` happens in `run()`, not
+ * here, so the spawner stays generic across architects.
+ */
+export interface ArchitectSpawnOutput {
+  /** The assistant's final message — expected to be a JSON-shaped string. */
+  text: string;
+  /** Best-effort token + cost telemetry from the envelope. */
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  /** Echoed back from input. */
+  model: string;
+  /** True iff the spawn succeeded and the envelope was parsed cleanly. */
+  ok: boolean;
+  /** Diagnostic when `ok=false`. */
+  diagnostic: string | null;
+}
+
+/**
+ * The seam every architect's `run()` consumes. Inject a fake in tests.
+ */
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+/**
+ * Map the architect-budget model preference to the `claude` binary's
+ * `--model` flag value. The mapping mirrors what local-llm-router uses
+ * elsewhere in the monorepo.
+ */
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+/**
+ * Build the canonical user-message body. The system prompt is fed as
+ * the first user-message paragraph (rather than via `claude`'s
+ * `--system` flag) — keeps the spawner surface narrow and lets the
+ * test seam see everything in one string.
+ */
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+/**
+ * Wire the real `spawnClaude` into an `ArchitectSpawnerFn`. Used by
+ * `BackendArchitect` when no spawner is injected.
+ */
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/backend-architect/src/system-prompt.ts
+++ b/packages/backend-architect/src/system-prompt.ts
@@ -1,0 +1,271 @@
+/**
+ * The Backend Architect's system prompt — a pure function returning a
+ * static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `backend.*` field name appears at
+ * least once in the body. Keep that invariant true if you add fields.
+ *
+ * Mirrors `@caia/frontend-architect`'s `system-prompt.ts` shape per the
+ * canonical template.
+ */
+
+import { BACKEND_OWNED_FIELD_KEYS } from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildBackendSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Backend Architect. You are a senior backend engineer focused
+on Next.js 15 App Router Route Handlers + Server Actions + TypeScript +
+Zod v3 + Cloudflare Access + Drizzle ORM, on a hybrid edge+node runtime.
+You produce API endpoint specs that match the ticket's data needs:
+per-endpoint request/response Zod schemas, error envelope, validation
+rules, auth requirements, rate limits, service boundaries, and the
+\`dataAccess\` plan that the Database Architect lifts into table schemas.
+
+You DO NOT write frontend components (Frontend Architect owns those) or
+database migrations (Database Architect owns those — merged PR #549).
+Other architects own those concerns and will reject any field you
+populate outside the \`backend.*\` namespace.
+
+Output tight specs the coding worker can implement directly: Zod schemas
+the worker can paste into \`schemas/\`, Route Handler stubs the worker
+can paste into \`app/api/.../route.ts\`, and a clean enumeration of
+persistence touchpoints the Database Architect can read verbatim.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Framework**: Next.js 15, App Router. Route Handlers (\`app/api/.../route.ts\`)
+  for REST + Server Actions (\`'use server'\` functions) for form
+  submissions. Reject Express, Fastify, NestJS, or non-Next.js stacks.
+- **Runtime**: Hybrid \`edge+node\` — default to the edge runtime for
+  read endpoints + auth checks; fall back to the node runtime for
+  endpoints that need Node-only APIs (Buffer, fs, native crypto).
+- **Language**: TypeScript strict mode. No \`any\`. Explicit return
+  types on exported functions.
+- **Validation**: Zod v3 for every request body, query, and response.
+  No ad-hoc \`typeof\` / \`instanceof\` validation.
+- **Auth**: Cloudflare Access JWT for tenant-scoped routes (issuer
+  pinned per-tenant via \`tenantContext.cloud\`); short-lived
+  service-token for orchestrator-internal routes; public for marketing
+  routes.
+- **ORM (declared, not implemented)**: Drizzle by default; Prisma
+  allowed only when the ticket explicitly flags \`orm:prisma\` in
+  \`quality_tags\`. The actual schemas live with the Database Architect;
+  you only declare which tables you read/write in \`dataAccess\`.
+- **Error envelope**: Single canonical shape
+  \`{ error: { code, message, details?, requestId } }\`. Every endpoint
+  conforms.
+- **Service boundaries**: Default \`monolith-with-modules\` keyed by
+  domain — reject microservices for CAIA-scale tickets without explicit
+  operator override.
+- **Rate limits**: Per-tenant default; stricter on marketing/public
+  endpoints; configurable per-endpoint override.
+
+Reject any decision that violates the locked stack. If a ticket asks for
+an off-stack tool (e.g. Express, JWT-without-Cloudflare-Access),
+surface this in \`risks[]\` and pick the on-stack alternative anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "oneLiner": "...",
+                    "audience": "...", "goals": ["..."] },
+  "designVersion": { "designVersionId": "...", "tokens": { ... } },
+  "tenantContext": { "tenantId": "...", "billingPosture": "subscription|byok" },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": { /* empty for wave-1 architects */ } }
+}
+\`\`\`
+
+Backend is a wave-1 architect — \`upstream.outputs\` is empty on the
+first run. On reviewer re-runs, \`reviewerFeedback\` is populated with
+the prior iteration's diagnostics; address them in the new output.
+
+Read \`ticket.type\` to choose endpoint shape:
+- **Form Story** → one POST endpoint that validates + persists.
+- **List Story** → one paginated GET endpoint.
+- **CRUD Story** → POST + GET-list + GET-by-id + PATCH + DELETE.
+- **Page** → server-side data loading via Server Component fetches; may
+  add zero or more JSON endpoints if the page needs client-side data.
+- **Foundation** → cross-cutting service module (e.g. webhooks, auth
+  callbacks, internal RPC); enumerate every endpoint the module exposes.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "backend",
+  "architectureFields": {
+${BACKEND_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`backend.framework\` — \`{"name":"next","version":"15.x","runtime":"edge+node","handlerStyle":"app-router-route-handlers+server-actions"}\`. Lock; do not change.
+- \`backend.serviceBoundaries\` — \`{"style":"monolith-with-modules","modules":[{"name":"contacts","routes":["/api/contacts","/api/contacts/:id"],"owns":["contacts"]}]}\`. Default monolith-with-modules.
+- \`backend.apiEndpoints\` — \`[{"method":"POST","path":"/api/contacts","op":"create","runtime":"node","requestSchemaRef":"ContactCreate","responseSchemaRef":"Contact","persistsTo":"contacts","auth":"cloudflare-access","rateLimit":"tenant-default"}]\`. One entry per HTTP/RPC surface.
+- \`backend.endpointEnumeration\` — \`[{"route":"POST /api/contacts","table":"contacts","op":"insert"}, ...]\`. Flat enumeration; route format \`METHOD /path\`. Database Architect reads this verbatim.
+- \`backend.requestSchemas\` — \`{"ContactCreate":{"shape":"z.object({ name: z.string().min(1).max(200), email: z.string().email(), message: z.string().min(1).max(5000) })"}}\`. Zod v3 syntax.
+- \`backend.responseSchemas\` — \`{"Contact":{"shape":"z.object({ id: z.string().uuid(), tenantId: z.string().uuid(), name: z.string(), email: z.string().email(), createdAt: z.string().datetime() })"},"ContactList":{"shape":"z.object({ items: z.array(Contact), nextCursor: z.string().nullable() })"}}\`. Every endpoint declares one.
+- \`backend.errorEnvelope\` — \`{"schema":"z.object({ error: z.object({ code: z.string(), message: z.string(), details: z.record(z.unknown()).optional(), requestId: z.string().uuid() }) })","examples":[{"status":400,"body":{"error":{"code":"VALIDATION_ERROR","message":"Invalid email","requestId":"..."}}}],"mapping":{"ValidationError":{"status":400,"code":"VALIDATION_ERROR"},"AuthError":{"status":401,"code":"UNAUTHORIZED"},"NotFoundError":{"status":404,"code":"NOT_FOUND"}}}\`.
+- \`backend.validationRules\` — \`[{"endpoint":"POST /api/contacts","rule":"email unique within tenant","source":"database","failureMode":"409 CONFLICT"}]\`. Cross-cutting invariants beyond Zod.
+- \`backend.authRequirements\` — \`{"default":{"scheme":"cloudflare-access","issuer":"tenant-jwt-issuer","scopes":["tenant:rw"]},"perEndpoint":{"GET /api/healthz":{"scheme":"public"}}}\`.
+- \`backend.rateLimits\` — \`{"default":{"windowMs":60000,"max":120,"scope":"tenant"},"perEndpoint":{"POST /api/contacts":{"windowMs":60000,"max":10,"scope":"ip","burst":3}}}\`.
+- \`backend.dataAccess\` — \`{"orm":"drizzle","tables":["contacts"],"queries":{"contacts":["by-id","by-tenant-paginated","by-email"]}}\`. Database Architect reads this.
+- \`backend.businessRules\` — \`["Contact email must be unique within tenant","Contact submission emits a contact.created domain event"]\`. Free-form list.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **One ticket → one cohesive endpoint set.** Form Story → one POST;
+  List Story → one GET; CRUD Story → five endpoints; Page → zero or more
+  data endpoints depending on whether the page renders server-side
+  only or needs client interactivity.
+- **Edge runtime by default.** Stick to the edge runtime for reads,
+  auth checks, and simple writes. Drop to node only when you need
+  Node-only APIs (file I/O, native crypto, Buffer-heavy parsing).
+- **Every endpoint declares a Zod request + response schema.** No
+  exceptions. Endpoints with no body still declare a void request
+  schema (\`z.object({})\`). 204-No-Content endpoints declare
+  \`z.void()\` response.
+- **One canonical error envelope.** Never invent per-endpoint error
+  shapes. Map every thrown error class to a \`{status, code}\` pair in
+  \`errorEnvelope.mapping\`.
+- **Auth defaults derive from ticket context.** Tenant-scoped routes →
+  Cloudflare Access (issuer = \`tenantContext.cloud.accessIssuer\` if
+  present). Orchestrator-internal routes (\`/api/_internal/*\`) →
+  service-token. Marketing/public routes → public, but with stricter
+  rate limits.
+- **Rate limits scale with auth tier.** Public endpoints get
+  per-IP limits; authenticated endpoints get per-tenant + per-user
+  limits. Default windows: 60-second windows, 120 requests/minute
+  authenticated, 30 requests/minute public.
+- **\`endpointEnumeration\` is derived from \`apiEndpoints\` and the
+  persistence touchpoints**. The Database Architect consumes it
+  directly — keep route formatting consistent (\`METHOD /path\` with
+  literal \`:param\` placeholders for path parameters).
+- **\`dataAccess\` is a declaration, not an implementation.** List
+  every table this ticket reads/writes; enumerate the query shapes
+  (\`by-id\`, \`by-tenant-paginated\`, \`by-email\`) the Database
+  Architect needs to index. Don't write SQL.
+- **\`businessRules\` are first-class.** If the spec says "Order total
+  must equal sum of line items", that's a business rule the Database
+  Architect lifts into a CHECK constraint and the Testing Architect
+  lifts into a property-based test. Surface every such rule explicitly.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Pick a non-Next.js framework** (Express, Fastify, NestJS, Hono on
+  raw Cloudflare Workers) → use Next.js Route Handlers anyway, list the
+  override request under \`risks[]\`, set \`confidence\` to 0.5.
+- **Skip Zod and use \`any\`/manual validation** → refuse. Every
+  endpoint MUST declare Zod request + response schemas.
+- **Skip the canonical error envelope** → refuse. Every endpoint
+  conforms to the single envelope shape.
+- **Skip Cloudflare Access on a tenant-scoped route** → refuse unless
+  the operator has explicitly overridden via a quality_tag like
+  \`auth:public\`. Default to Cloudflare Access.
+- **Propose microservices for a CAIA-scale ticket** → refuse unless
+  the operator has explicitly overridden via a quality_tag like
+  \`serviceStyle:microservices\`. Default to \`monolith-with-modules\`.
+- **Decide a database schema, UI component, CSP rule, event taxonomy,
+  CI/CD pipeline, or any field NOT under \`backend.*\`** → ignore the
+  request. Do not populate fields outside your owned namespace.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.
+- **Invent an endpoint not implied by the ticket** → never. Map the
+  ticket's acceptance criteria to endpoints 1-to-1.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the ${BACKEND_OWNED_FIELD_KEYS.length} owned field
+   paths (no extras, no missing).
+2. Every endpoint in \`apiEndpoints\` has a matching entry in
+   \`endpointEnumeration\` (route format \`METHOD /path\`).
+3. Every endpoint with a body or query has a \`requestSchemaRef\` that
+   resolves in \`requestSchemas\`.
+4. Every endpoint has a \`responseSchemaRef\` that resolves in
+   \`responseSchemas\`.
+5. Every endpoint declares \`auth\` and \`rateLimit\` (either inheriting
+   defaults or overriding).
+6. Every table mentioned in \`apiEndpoints\` (\`persistsTo\`,
+   \`readsFrom\`, \`deletesFrom\`) appears in \`dataAccess.tables\`.
+7. \`errorEnvelope.mapping\` covers at least the standard 400/401/403/
+   404/409/422/500 cases.
+8. \`framework.name\` is \`"next"\`; \`serviceBoundaries.style\` is
+   \`"monolith-with-modules"\` unless ticket explicitly overrides.
+9. \`confidence\` reflects how comfortable you are with the decision —
+   sub-0.6 triggers the EA Reviewer to scrutinize.
+10. \`notes\` is ≤ 800 characters.
+11. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Form Story ticket for "contact-form submission"
+produces \`apiEndpoints: [{method:"POST",path:"/api/contacts",op:"create",
+runtime:"node",requestSchemaRef:"ContactCreate",responseSchemaRef:"Contact",
+persistsTo:"contacts",auth:"cloudflare-access",rateLimit:"public-strict"}]\`,
+a \`ContactCreate\` Zod schema with name/email/message fields and length
+bounds, a \`Contact\` Zod response schema with id/tenantId/createdAt,
+a tenant-isolation validation rule, Cloudflare Access default auth,
+a stricter 10-req/min rate limit on the POST route, a \`dataAccess\`
+plan listing the \`contacts\` table with \`by-id\`/\`by-tenant-paginated\`/
+\`by-email\` query shapes, and a single business rule "Contact email
+unique within tenant".`;

--- a/packages/backend-architect/src/types.ts
+++ b/packages/backend-architect/src/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors `@caia/frontend-architect/src/types.ts`
+ * verbatim — only the architect-specific field-spec lives in `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/backend-architect/src/validation.ts
+++ b/packages/backend-architect/src/validation.ts
@@ -1,0 +1,207 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ *
+ * Mirrors `@caia/frontend-architect`'s `validation.ts` verbatim.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/backend-architect/tests/architect.test.ts
+++ b/packages/backend-architect/tests/architect.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `BackendArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1 and
+ * satisfies SpecialistArchitect structurally (will extend BaseArchitect
+ * when the kit lands on develop). These tests mirror the canonical
+ * `@caia/frontend-architect` compliance suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  BackendArchitect,
+  BACKEND_ARCHITECT_NAME,
+  BACKEND_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { BackendArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('BackendArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new BackendArchitect();
+    expect(a).toBeInstanceOf(BackendArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally (will extend BaseArchitect once the kit lands on develop)', () => {
+    const a = new BackendArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the package suffix', () => {
+    const a = new BackendArchitect();
+    expect(a.name).toBe('backend');
+    expect(a.name).toBe(BACKEND_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new BackendArchitect();
+    expect(a.sectionContract).toBe(BackendArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new BackendArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.2', () => {
+    const a = new BackendArchitect();
+    expect(a.tools).toBe(BACKEND_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new BackendArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new BackendArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new BackendArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new BackendArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('backend');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new BackendArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    // Just instantiating should not error. We do NOT call run() here
+    // because that would invoke the real claude binary.
+    const a = new BackendArchitect();
+    expect(a).toBeInstanceOf(BackendArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/backend-architect/tests/contract.test.ts
+++ b/packages/backend-architect/tests/contract.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `backend.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed (precedence in [1,17], etc).
+ *   - The architect registers cleanly against the local ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder lists `backend`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { BackendArchitect } from '../src/architect.js';
+import {
+  BACKEND_ARCHITECT_META,
+  BACKEND_OWNED_SECTIONS,
+  BACKEND_OWNED_FIELD_KEYS,
+  BackendArchitectContract,
+  backendArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('BackendArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(BackendArchitectContract.contractId).toBe('backend-architect.v1');
+  });
+
+  it('architectName is `backend` (matches package suffix + ladder entry)', () => {
+    expect(BackendArchitectContract.architectName).toBe('backend');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(BackendArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `backend.`', () => {
+    for (const key of BACKEND_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('backend.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'backend.apiEndpoints',
+      'backend.requestSchemas',
+      'backend.responseSchemas',
+      'backend.errorEnvelope',
+      'backend.validationRules',
+      'backend.authRequirements',
+      'backend.rateLimits',
+      'backend.serviceBoundaries'
+    ];
+    for (const r of required) {
+      expect(BACKEND_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owned-field set covers spec §2.2 mandatory fields (framework, dataAccess, businessRules, endpointEnumeration, errorEnvelope)', () => {
+    const specMandatory = [
+      'backend.framework',
+      'backend.dataAccess',
+      'backend.businessRules',
+      'backend.endpointEnumeration',
+      'backend.errorEnvelope'
+    ];
+    for (const k of specMandatory) {
+      expect(BACKEND_OWNED_FIELD_KEYS).toContain(k);
+    }
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of BACKEND_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(BackendArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(BackendArchitectContract).sort()).toEqual(
+      [...BACKEND_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('BackendArchitectContract — architectMeta', () => {
+  it('declares zero dependencies (wave-1 architect)', () => {
+    expect(BACKEND_ARCHITECT_META.dependsOn).toEqual([]);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(BACKEND_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(BACKEND_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 12 per spec §5.2', () => {
+    expect(BACKEND_ARCHITECT_META.precedenceLevel).toBe(12);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(BACKEND_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.2', () => {
+    expect(BACKEND_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(BACKEND_ARCHITECT_META.appliesPredicate).toBe(backendArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `backend`', () => {
+    expect(precedenceRank('backend')).toBe(BACKEND_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('backend');
+  });
+});
+
+describe('backendArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page (server-side data loading)', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns true for Foundation (cross-cutting service modules)', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(true);
+  });
+
+  it('returns false for Widget by default (re-uses parent-Page handlers)', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(false);
+  });
+
+  it('returns true for Widget when tagged `api`', () => {
+    expect(
+      backendArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['api']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for Widget when tagged `backend`', () => {
+    expect(
+      backendArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['backend']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for Widget when tagged `persists`', () => {
+    expect(
+      backendArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Widget',
+        quality_tags: ['persists']
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(backendArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection — implements
+ * the bare `SpecialistArchitect` interface directly.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Backend architect cleanly', () => {
+    expect(() => {
+      registry.register(new BackendArchitect());
+    }).not.toThrow();
+    expect(registry.get('backend')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new BackendArchitect());
+    for (const k of BACKEND_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('backend');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new BackendArchitect());
+    expect(() => registry.register(new BackendArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new BackendArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'backend.apiEndpoints',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields (frontend simulation)', () => {
+    registry.register(new BackendArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [
+        { path: 'frontend.componentTree', description: 'Component tree', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('frontend', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(BACKEND_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only Backend is present', () => {
+    const conflicts = disjointness([BackendArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Backend and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...BackendArchitectContract,
+      contractId: 'backend-clone.v1',
+      architectName: 'backend-clone'
+    };
+    const conflicts = disjointness([BackendArchitectContract, clone]);
+    expect(conflicts.length).toBe(BACKEND_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() is empty after a clean registration', () => {
+    registry.register(new BackendArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+
+  it('coexists with the merged database-architect contract (no field overlap)', () => {
+    // The merged @caia/database-architect owns database.* — disjoint from backend.*.
+    // We simulate it here without importing it (avoid cross-package test coupling).
+    const databaseContract: ArchitectSectionContract = {
+      contractId: 'database-architect.v1',
+      architectName: 'database',
+      version: '0.1.0',
+      sections: [
+        { path: 'database.tables', description: 'Tables', required: true },
+        { path: 'database.columns', description: 'Columns', required: true }
+      ],
+      architectMeta: {
+        dependsOn: ['backend'],
+        precedenceLevel: 11,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    registry.register(new BackendArchitect());
+    expect(() => {
+      registry.register(new StubArchitect('database', databaseContract));
+    }).not.toThrow();
+  });
+});

--- a/packages/backend-architect/tests/golden/golden.test.ts
+++ b/packages/backend-architect/tests/golden/golden.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Golden test — the canonical known-good Backend-architect artifact for
+ * a known prakash-tiwari Widget ticket (an `ArtistContactForm` widget
+ * tagged `api`+`backend`+`persists` so Backend's `appliesPredicate`
+ * admits it).
+ *
+ * This test serves three purposes:
+ *
+ *   1. Lock the architect's output shape against drift. Any change to
+ *      the contract or run() must update this snapshot.
+ *
+ *   2. Demonstrate the architect produces a complete, validating output
+ *      end-to-end given a realistic input.
+ *
+ *   3. Become the canonical fixture downstream architect packages
+ *      (Database, Security, API-Gateway, etc.) reference when writing
+ *      their own golden tests that depend on Backend's upstream output.
+ *
+ * Note: this test uses a deterministic fake spawner. It does NOT call
+ * the real claude binary. The "golden" here is the expected
+ * deterministic projection of the input through the run() pipeline,
+ * given a fixed assistant text. A nightly LLM-judge variant is the
+ * sibling test the conformance suite will add later (per spec §11(c)).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { BackendArchitect } from '../../src/architect.js';
+import { BACKEND_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { BACKEND_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  assertCoversAllOwnedFields,
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari ArtistContactForm Widget ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new BackendArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    // Architect name, status, top-level shape
+    expect(out.architectName).toBe('backend');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    // Every owned field present
+    for (const k of BACKEND_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    // Field values match the known-good expectation (except spend, which
+    // the run pipeline overwrites).
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every Backend invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new BackendArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of BACKEND_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new BackendArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+
+  it('the goldenExpectedOutput fixture covers every owned field', () => {
+    // Sanity check — guards against the fixture drifting out of sync
+    // with the contract when fields are added.
+    expect(() => assertCoversAllOwnedFields(goldenExpectedOutput())).not.toThrow();
+  });
+});

--- a/packages/backend-architect/tests/golden/input-businessplan.json
+++ b/packages/backend-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/backend-architect/tests/golden/input-designversion.json
+++ b/packages/backend-architect/tests/golden/input-designversion.json
@@ -1,0 +1,16 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "contact-form",
+      "kind": "form",
+      "bbox": { "x": 0, "y": 800, "w": 1440, "h": 480 },
+      "meta": { "fields": ["name", "email", "message"] }
+    }
+  ],
+  "tokens": {
+    "color.brand.primary": "#0f3057"
+  },
+  "breakpoints": ["sm", "md", "lg", "xl"]
+}

--- a/packages/backend-architect/tests/golden/input-ticket.json
+++ b/packages/backend-architect/tests/golden/input-ticket.json
@@ -1,0 +1,19 @@
+{
+  "id": "ticket-pt-bk-001",
+  "type": "Widget",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "POST /api/contacts persists a contacts row in the tenant schema.",
+    "Request body validated with Zod (name 1-200 chars, RFC-5321 email, message 1-5000 chars).",
+    "Response is the canonical Contact JSON with id, tenantId, createdAt.",
+    "Validation failures return 422 with the canonical error envelope.",
+    "Tenant-scoped routes require a Cloudflare Access JWT issued by the tenant's configured issuer.",
+    "Rate-limited at 10 req/min per IP for the public submit path."
+  ],
+  "business_requirements": {
+    "title": "Contact form submission API",
+    "description": "POST endpoint that accepts a name/email/message contact submission from the public Artist profile page, validates it with Zod, persists to the contacts table, and returns the canonical Contact response. Includes paginated list + by-id read + delete for the operator dashboard."
+  },
+  "quality_tags": ["api", "backend", "persists"]
+}

--- a/packages/backend-architect/tests/helpers/fakes.ts
+++ b/packages/backend-architect/tests/helpers/fakes.ts
@@ -1,0 +1,378 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Widget ticket (an `ArtistContactForm`
+ *     widget — a hero-adjacent contact form that exposes its own POST
+ *     endpoint, so Backend Architect applies). The golden test uses
+ *     this. Backend is a wave-1 architect, so `upstream.outputs` is
+ *     empty.
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Widget fixture.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { BACKEND_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The canonical fixture — a Widget ticket from the prakash-tiwari.com
+ * marketing site (an `ArtistContactForm` widget — a hero-adjacent
+ * contact form that exposes its own POST endpoint). Tagged with `api`
+ * + `persists` so the Backend `appliesPredicate` admits it.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-bk-001',
+      type: 'Widget',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'POST /api/contacts persists a contacts row in the tenant schema.',
+        'Request body validated with Zod (name 1-200 chars, RFC-5321 email, message 1-5000 chars).',
+        'Response is the canonical Contact JSON with id, tenantId, createdAt.',
+        'Validation failures return 422 with the canonical error envelope.',
+        'Tenant-scoped routes require a Cloudflare Access JWT issued by the tenant\'s configured issuer.',
+        'Rate-limited at 10 req/min per IP for the public submit path.'
+      ],
+      business_requirements: {
+        title: 'Contact form submission API',
+        description:
+          'POST endpoint that accepts a name/email/message contact submission from the public Artist profile page, validates it with Zod, persists to the contacts table, and returns the canonical Contact response. Includes paginated list + by-id read + delete for the operator dashboard.'
+      },
+      quality_tags: ['api', 'backend', 'persists']
+    },
+    upstream: { outputs: {} },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: 'High-intent prospective sitters in the artist\'s metropolitan area.',
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        'Make the booking CTA the page\'s primary action'
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'contact-form',
+          kind: 'form',
+          bbox: { x: 0, y: 800, w: 1440, h: 480 },
+          meta: { fields: ['name', 'email', 'message'] }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari Widget fixture.
+ *
+ * Every Backend invariant in `src/invariants.ts` must pass against this
+ * output. If you change the invariants, update this fixture too.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'backend',
+    architectureFields: {
+      'backend.framework': {
+        name: 'next',
+        version: '15.x',
+        runtime: 'edge+node',
+        handlerStyle: 'app-router-route-handlers+server-actions'
+      },
+      'backend.serviceBoundaries': {
+        style: 'monolith-with-modules',
+        modules: [
+          {
+            name: 'contacts',
+            routes: [
+              '/api/contacts',
+              '/api/contacts/[id]'
+            ],
+            owns: ['contacts']
+          }
+        ]
+      },
+      'backend.apiEndpoints': [
+        {
+          method: 'POST',
+          path: '/api/contacts',
+          op: 'create',
+          runtime: 'node',
+          requestSchemaRef: 'ContactCreate',
+          responseSchemaRef: 'Contact',
+          persistsTo: 'contacts',
+          auth: 'public',
+          rateLimit: 'public-strict'
+        },
+        {
+          method: 'GET',
+          path: '/api/contacts/:id',
+          op: 'read',
+          runtime: 'edge',
+          requestSchemaRef: 'ContactReadParams',
+          responseSchemaRef: 'Contact',
+          readsFrom: 'contacts',
+          auth: 'cloudflare-access',
+          rateLimit: 'tenant-default'
+        },
+        {
+          method: 'GET',
+          path: '/api/contacts',
+          op: 'list',
+          runtime: 'edge',
+          requestSchemaRef: 'ContactListQuery',
+          responseSchemaRef: 'ContactList',
+          readsFrom: 'contacts',
+          auth: 'cloudflare-access',
+          rateLimit: 'tenant-default'
+        },
+        {
+          method: 'DELETE',
+          path: '/api/contacts/:id',
+          op: 'delete',
+          runtime: 'node',
+          requestSchemaRef: 'ContactDeleteParams',
+          responseSchemaRef: 'ContactDeleted',
+          deletesFrom: 'contacts',
+          auth: 'cloudflare-access',
+          rateLimit: 'tenant-default'
+        }
+      ],
+      'backend.endpointEnumeration': [
+        { route: 'POST /api/contacts', table: 'contacts', op: 'insert' },
+        { route: 'GET /api/contacts/:id', table: 'contacts', op: 'select-by-pk' },
+        { route: 'GET /api/contacts', table: 'contacts', op: 'select-by-tenant' },
+        { route: 'DELETE /api/contacts/:id', table: 'contacts', op: 'delete-by-pk' }
+      ],
+      'backend.requestSchemas': {
+        ContactCreate: {
+          shape:
+            'z.object({ name: z.string().min(1).max(200), email: z.string().email().max(320), message: z.string().min(1).max(5000) })'
+        },
+        ContactReadParams: {
+          shape: 'z.object({ id: z.string().uuid() })'
+        },
+        ContactListQuery: {
+          shape:
+            'z.object({ cursor: z.string().uuid().optional(), limit: z.coerce.number().int().min(1).max(100).default(20) })'
+        },
+        ContactDeleteParams: {
+          shape: 'z.object({ id: z.string().uuid() })'
+        }
+      },
+      'backend.responseSchemas': {
+        Contact: {
+          shape:
+            'z.object({ id: z.string().uuid(), tenantId: z.string().uuid(), name: z.string(), email: z.string().email(), message: z.string(), createdAt: z.string().datetime(), updatedAt: z.string().datetime() })'
+        },
+        ContactList: {
+          shape: 'z.object({ items: z.array(Contact), nextCursor: z.string().uuid().nullable() })'
+        },
+        ContactDeleted: {
+          shape: 'z.object({ id: z.string().uuid(), deletedAt: z.string().datetime() })'
+        }
+      },
+      'backend.errorEnvelope': {
+        schema:
+          'z.object({ error: z.object({ code: z.string(), message: z.string(), details: z.record(z.unknown()).optional(), requestId: z.string().uuid() }) })',
+        examples: [
+          {
+            status: 422,
+            body: {
+              error: {
+                code: 'VALIDATION_ERROR',
+                message: 'Request body failed Zod validation.',
+                details: { email: 'Invalid email format' },
+                requestId: '00000000-0000-0000-0000-000000000000'
+              }
+            }
+          },
+          {
+            status: 401,
+            body: {
+              error: {
+                code: 'UNAUTHORIZED',
+                message: 'Missing or invalid Cloudflare Access JWT.',
+                requestId: '00000000-0000-0000-0000-000000000000'
+              }
+            }
+          }
+        ],
+        mapping: {
+          ValidationError: { status: 422, code: 'VALIDATION_ERROR' },
+          AuthError: { status: 401, code: 'UNAUTHORIZED' },
+          ForbiddenError: { status: 403, code: 'FORBIDDEN' },
+          NotFoundError: { status: 404, code: 'NOT_FOUND' },
+          ConflictError: { status: 409, code: 'CONFLICT' },
+          RateLimitError: { status: 429, code: 'RATE_LIMITED' },
+          InternalError: { status: 500, code: 'INTERNAL' }
+        }
+      },
+      'backend.validationRules': [
+        {
+          endpoint: 'POST /api/contacts',
+          rule: 'email unique within tenant',
+          source: 'database',
+          failureMode: '409 CONFLICT'
+        },
+        {
+          endpoint: 'POST /api/contacts',
+          rule: 'message must not contain control characters',
+          source: 'zod',
+          failureMode: '422 VALIDATION_ERROR'
+        },
+        {
+          endpoint: 'GET /api/contacts/:id',
+          rule: 'requester must belong to the contact\'s tenant',
+          source: 'business',
+          failureMode: '403 FORBIDDEN'
+        },
+        {
+          endpoint: 'DELETE /api/contacts/:id',
+          rule: 'requester must hold contacts:delete scope',
+          source: 'business',
+          failureMode: '403 FORBIDDEN'
+        }
+      ],
+      'backend.authRequirements': {
+        default: {
+          scheme: 'cloudflare-access',
+          issuer: 'tenant-jwt-issuer',
+          scopes: ['tenant:rw']
+        },
+        perEndpoint: {
+          'POST /api/contacts': {
+            scheme: 'public'
+          }
+        }
+      },
+      'backend.rateLimits': {
+        default: {
+          windowMs: 60_000,
+          max: 120,
+          scope: 'tenant'
+        },
+        perEndpoint: {
+          'POST /api/contacts': {
+            windowMs: 60_000,
+            max: 10,
+            scope: 'ip',
+            burst: 3
+          }
+        }
+      },
+      'backend.dataAccess': {
+        orm: 'drizzle',
+        tables: ['contacts'],
+        queries: {
+          contacts: ['by-id', 'by-tenant-paginated', 'by-email']
+        }
+      },
+      'backend.businessRules': [
+        'Contact email must be unique within tenant',
+        'Contact submission emits a contact.created domain event',
+        'Contact rows are soft-deleted (deleted_at timestamp) before hard-delete after 30 days',
+        'POST /api/contacts is public + IP rate-limited; all other routes require tenant auth'
+      ]
+    },
+    confidence: 0.86,
+    notes:
+      'Four endpoints for the contacts module: public POST for the marketing form (IP rate-limited 10/min), tenant-auth GET/list/delete for the operator dashboard. Canonical error envelope with mapping for the 7 standard error classes. Drizzle ORM declared; Database Architect will lift `dataAccess.tables` into table schemas. Public submit path is the only auth-override; defaults to Cloudflare Access otherwise.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Asserts that the input covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of BACKEND_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/backend-architect/tests/invariants.test.ts
+++ b/packages/backend-architect/tests/invariants.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Cross-architect invariants — verifies Backend's contributions to the
+ * EA Reviewer's invariant registry (per spec §6.2).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { BACKEND_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('BACKEND_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(BACKEND_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of BACKEND_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `backend`', () => {
+    for (const inv of BACKEND_INVARIANTS) {
+      expect(inv.contributor).toBe('backend');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of BACKEND_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant `reads` only `backend.*` paths (no cross-architect reads)', () => {
+    for (const inv of BACKEND_INVARIANTS) {
+      for (const r of inv.reads) {
+        expect(r.startsWith('backend.')).toBe(true);
+      }
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of BACKEND_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of BACKEND_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('BACKEND_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of BACKEND_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('apiEndpoints-nonempty fails on an empty list', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.apiEndpoints-nonempty');
+    expect(inv).toBeDefined();
+    const empty = { ...goldenArch, 'backend.apiEndpoints': [] };
+    expect(inv!.detect(empty)).toBe(false);
+  });
+
+  it('framework-is-next fails on Express', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.framework-is-next');
+    expect(inv).toBeDefined();
+    const wrong = { ...goldenArch, 'backend.framework': { name: 'express' } };
+    expect(inv!.detect(wrong)).toBe(false);
+  });
+
+  it('serviceBoundaries-declared fails on missing style', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.serviceBoundaries-declared');
+    expect(inv).toBeDefined();
+    const wrong = { ...goldenArch, 'backend.serviceBoundaries': { foo: 'bar' } };
+    expect(inv!.detect(wrong)).toBe(false);
+  });
+
+  it('endpoint-enumeration-matches-api-endpoints fails when a route is missing from enumeration', () => {
+    const inv = BACKEND_INVARIANTS.find(
+      i => i.id === 'backend.endpoint-enumeration-matches-api-endpoints'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.endpointEnumeration': [
+        { route: 'POST /api/contacts', table: 'contacts', op: 'insert' }
+        // Missing the GET/GET-list/DELETE entries.
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('every-endpoint-has-response-schema fails when a ref is dangling', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.every-endpoint-has-response-schema');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.responseSchemas': {} // none of the refs resolve
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('request-schemas-resolve fails when a referenced schema is missing', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.request-schemas-resolve');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.requestSchemas': {} // every referenced schema becomes dangling
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('error-envelope-declared fails when mapping is empty', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.error-envelope-declared');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.errorEnvelope': {
+        schema: 'z.object({})',
+        mapping: {}
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('auth-requirements-declared fails on an unknown scheme', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.auth-requirements-declared');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.authRequirements': { default: { scheme: 'magic' } }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('rate-limits-declared fails when default is missing fields', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.rate-limits-declared');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.rateLimits': { default: { windowMs: 1000 } } // missing max + scope
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('data-access-tables-cover-endpoint-touchpoints fails when a table is missing', () => {
+    const inv = BACKEND_INVARIANTS.find(
+      i => i.id === 'backend.data-access-tables-cover-endpoint-touchpoints'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'backend.dataAccess': { orm: 'drizzle', tables: [], queries: {} }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('endpoints-have-auth-and-rate-limit fails when an endpoint omits auth', () => {
+    const inv = BACKEND_INVARIANTS.find(i => i.id === 'backend.endpoints-have-auth-and-rate-limit');
+    expect(inv).toBeDefined();
+    const goldenEndpoints = goldenArch['backend.apiEndpoints'] as Array<Record<string, unknown>>;
+    const corruptedEndpoints = goldenEndpoints.map((ep, idx) =>
+      idx === 0 ? { ...ep, auth: undefined } : ep
+    );
+    const corrupted = { ...goldenArch, 'backend.apiEndpoints': corruptedEndpoints };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('predicates also work against a composed (nested) architecture blob', () => {
+    // Simulate what the EA Dispatcher composes — fields nested under
+    // backend.* rather than flat dotted keys.
+    const nested = {
+      backend: {
+        apiEndpoints: goldenArch['backend.apiEndpoints'],
+        framework: goldenArch['backend.framework']
+      }
+    };
+    const nonempty = BACKEND_INVARIANTS.find(i => i.id === 'backend.apiEndpoints-nonempty');
+    const isNext = BACKEND_INVARIANTS.find(i => i.id === 'backend.framework-is-next');
+    expect(nonempty!.detect(nested)).toBe(true);
+    expect(isNext!.detect(nested)).toBe(true);
+  });
+});

--- a/packages/backend-architect/tests/run.test.ts
+++ b/packages/backend-architect/tests/run.test.ts
@@ -1,0 +1,242 @@
+/**
+ * `run()` tests — verifies the runtime pipeline:
+ *
+ *   - happy path returns a well-formed ArchitectOutput
+ *   - idempotency: same input → equivalent output
+ *   - re-runs REPLACE owned fields (do not append)
+ *   - dependency declaration on output
+ *   - failure modes (spawn failure, validation failure)
+ *   - reviewer feedback is plumbed through
+ *   - spend telemetry comes from the spawner, not the assistant
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { BACKEND_ARCHITECT_NAME, BackendArchitect } from '../src/architect.js';
+import { BACKEND_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runBackendArchitect } from '../src/run.js';
+import { buildBackendSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runBackendArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('backend');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    for (const k of BACKEND_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildBackendSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runBackendArchitect(input, {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runBackendArchitect(input, {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runBackendArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runBackendArchitect(input, {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    const b = await runBackendArchitect(input, {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runBackendArchitect(input, {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    const r2 = await runBackendArchitect(input, {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(BACKEND_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runBackendArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"backend"}');
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runBackendArchitect — dependency declaration', () => {
+  it('backend is a wave-1 architect (no upstream deps declared in output)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runBackendArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildBackendSystemPrompt(),
+      architectName: BACKEND_ARCHITECT_NAME
+    });
+    expect(out.dependencies).toEqual([]);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket id', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-bk-001');
+  });
+
+  it('includes the ticket type', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('"type": "Widget"');
+  });
+
+  it('serialises the businessPlan ventureName', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('Prakash Tiwari Studio');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'fix the rate limit', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('fix the rate limit');
+  });
+
+  it('uses null for reviewerFeedback when absent', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('"reviewerFeedback": null');
+  });
+});
+
+describe('BackendArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new BackendArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('backend');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/backend-architect/tests/system-prompt.test.ts
+++ b/packages/backend-architect/tests/system-prompt.test.ts
@@ -1,0 +1,110 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b):
+ *
+ *   - Parses cleanly as text (non-empty, no obvious corruption).
+ *   - References every declared owned field at least once.
+ *   - Contains the standard architect-output JSON schema instruction.
+ *   - Under a reasonable size (token budget proxy).
+ *   - Idempotent (pure function).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { BACKEND_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildBackendSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildBackendSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildBackendSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildBackendSystemPrompt();
+    const p2 = buildBackendSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Backend Architect");
+  });
+
+  it('contains the Locked stack section', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Next.js 15');
+    expect(p).toContain('Zod');
+    expect(p).toContain('Cloudflare Access');
+    expect(p).toContain('Drizzle');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildBackendSystemPrompt();
+    for (const key of BACKEND_OWNED_FIELD_KEYS) {
+      expect(p, `system prompt should mention ${key}`).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Edge runtime by default');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('backend.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildBackendSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `backend.*` namespace', () => {
+    const p = buildBackendSystemPrompt();
+    // Reject other architects' field paths appearing in the prompt body.
+    const foreignPaths = [
+      'frontend.componentTree',
+      'database.tables',
+      'database.migrations',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape',
+      'seo.title',
+      'a11y.wcagLevel'
+    ];
+    for (const path of foreignPaths) {
+      expect(p, `prompt should not refer to foreign field ${path}`).not.toContain(path);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 16k chars)', () => {
+    // Token estimate: ~4 chars per token, so 16k chars ≈ 4000 tokens —
+    // safely under the spec §11(b) 2000-token ceiling for typical
+    // prompts but generous for the embedded schema.
+    const p = buildBackendSystemPrompt();
+    expect(p.length).toBeLessThan(16_000);
+  });
+});

--- a/packages/backend-architect/tests/validation.test.ts
+++ b/packages/backend-architect/tests/validation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { BACKEND_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('backend');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ``` fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput('{"architectName":"backend"}', BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['backend.apiEndpoints'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'frontend.componentTree': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), BACKEND_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(JSON.stringify(variant), BACKEND_OWNED_FIELD_KEYS);
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/backend-architect/tsconfig.build.json
+++ b/packages/backend-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/backend-architect/tsconfig.json
+++ b/packages/backend-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/backend-architect/vitest.config.ts
+++ b/packages/backend-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Architect #2 of CAIA's 17-architect EA fan-out. Senior backend engineer focused on **Next.js 15 App Router Route Handlers + Server Actions + TypeScript + Zod v3 + Cloudflare Access + Drizzle ORM**. Produces tight API endpoint specs the coding worker can implement directly.

Mirrors the canonical [@caia/frontend-architect](https://github.com/prakashgbid/caia/pull/537) template and the [@caia/database-architect](https://github.com/prakashgbid/caia/pull/549) package shape.

## What it owns

\`backend.*\` slice of \`tickets.architecture\` (12 fields):

| Field | Description |
|---|---|
| \`framework\` | Locked Next.js 15 App Router (Route Handlers + Server Actions), hybrid edge+node runtime |
| \`serviceBoundaries\` | Module decomposition (default \`monolith-with-modules\`) |
| \`apiEndpoints\` | Per-ticket endpoint specs (method, path, schemas, persistence, auth, rate limit) |
| \`endpointEnumeration\` | Flat \`{route, table, op}\` enumeration consumed by Database Architect |
| \`requestSchemas\` | Zod v3 request body / query schemas keyed by ref |
| \`responseSchemas\` | Zod v3 response body schemas keyed by ref |
| \`errorEnvelope\` | Canonical error envelope shape + examples + class-to-status mapping |
| \`validationRules\` | Cross-cutting validation invariants beyond Zod |
| \`authRequirements\` | Per-endpoint auth (default Cloudflare Access for tenant routes) |
| \`rateLimits\` | Per-endpoint rate limits (per-tenant/per-IP) |
| \`dataAccess\` | ORM choice + per-table query plan (consumed by Database Architect) |
| \`businessRules\` | Cross-cutting business invariants surfaced to downstream architects |

## Wave & precedence

- **Wave-1 architect** — no upstream deps. \`appliesPredicate\` admits Page/Story/Form/List/Foundation tickets, plus Widget tickets tagged \`api\`/\`backend\`/\`persists\`.
- **Precedence rank: 12** per spec §5.2 (functional correctness — below Database's 11 schema correctness).
- **Runtime model: Sonnet** per spec §2.2.

Downstream architects (Database/Security/API-Gateway/Observability/DevOps) consume Backend's \`apiEndpoints\` + \`endpointEnumeration\` + \`dataAccess\` + \`businessRules\` to enumerate persistence touchpoints, auth surfaces, and gateway routing.

## Test suite (127 tests)

| File | Tests | Coverage |
|---|---:|---|
| \`tests/architect.test.ts\` | 12 | Interface compliance, class instantiation, system-prompt purity |
| \`tests/contract.test.ts\` | 35 | Contract structural checks, architectMeta, appliesPredicate, registration & disjointness |
| \`tests/system-prompt.test.ts\` | 12 | Briefing structure per spec §11(b), namespace hygiene, size bounds |
| \`tests/validation.test.ts\` | 19 | Output validator happy + error paths, fence stripping |
| \`tests/run.test.ts\` | 21 | Pipeline + idempotency + failure modes + user-prompt projection |
| \`tests/invariants.test.ts\` | 20 | Cross-architect invariant predicates against golden + corrupted inputs |
| \`tests/golden/golden.test.ts\` | 8 | End-to-end golden test against prakash-tiwari ArtistContactForm Widget |

\`tsc --noEmit\` clean. \`tsc -p tsconfig.build.json\` emits clean dist.

## Constraints honoured

- **Subscription-only build** per \`feedback-caia-build-uses-pro-subscription-only\`: uses \`@chiefaia/claude-spawner\` which never sets \`ANTHROPIC_API_KEY\`.
- **No timelines** per \`feedback-no-timelines\`: quality > schedule.
- **mac-mcp** used for all \`/Users\` path operations.

## What it does NOT do

No frontend components (Frontend Architect — merged PR #537). No database migrations (Database Architect — merged PR #549). No CSP/authN/authZ (Security). No event taxonomies (Analytics). No CI/CD (DevOps). The contract rejects out-of-namespace writes.

## Files touched

26 new files under \`packages/backend-architect/\`: \`src/{index,architect,contract,system-prompt,run,spawner,types,validation,invariants}.ts\`, \`tests/{architect,contract,system-prompt,validation,run,invariants}.test.ts\`, \`tests/helpers/fakes.ts\`, \`tests/golden/{golden.test.ts,input-{ticket,businessplan,designversion}.json}\`, plus README, eslint config.