### PR TITLE
feat(@caia/performance-architect): ship architect #6 of 17 — Performance specialist

### DIFF
--- a/packages/performance-architect/README.md
+++ b/packages/performance-architect/README.md
@@ -1,0 +1,60 @@
+# @caia/performance-architect
+
+Architect #6 of CAIA's 17-architect EA fan-out. Senior frontend performance engineer focused on Core Web Vitals (LCP/INP/CLS), Lighthouse budgets, JavaScript bundle analysis, and image/font optimization.
+
+## What it owns
+
+`performance.*` slice of the `tickets.architecture` JSONB column:
+
+- `performance.coreWebVitalsBudgets` — per-page-type LCP/INP/CLS/TTFB targets (mobile + desktop)
+- `performance.bundleSizeBudget` — per-route gzip + brotli JavaScript budget
+- `performance.imageOptimizationPlan` — `next/image` config (AVIF→WebP→fallback, breakpoints, LCP candidate)
+- `performance.fontOptimizationPlan` — `next/font` config (display=swap, preload, subsetting, self-host)
+- `performance.lazyLoadStrategy` — per-component eager/lazy/dynamic decisions
+- `performance.cacheStrategy` — three-tier cache plan (CDN + browser + server)
+- `performance.criticalRenderPath` — above-the-fold render priorities (preload, defer, inline-CSS)
+- `performance.lighthouseBudgets` — Lighthouse category floors (Perf ≥ 90, SEO ≥ 95, A11y ≥ 95, BP ≥ 90)
+
+## What it does NOT do
+
+No component code. No database. No API endpoints. No CSS authoring. No test specs. Other architects own those concerns and the contract rejects out-of-namespace writes. This architect SPECIFIES the perf budgets the build must enforce — the Frontend coding worker and DevOps' `lighthouse-ci` gate are what enforce them.
+
+## Depends on
+
+Frontend Architect (`@caia/frontend-architect`, PR #537 — merged). Reads `frontend.framework`, `frontend.componentTree`, and `frontend.tokens` from the upstream output. If the Frontend upstream is absent, surfaces a `risks[]` callout and emits best-effort budgets from the design + ticket alone.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1). The EA Dispatcher spawns one of these per applicable ticket (Page, Widget, Story, Form, List). Each spawn calls `@chiefaia/claude-spawner` (subscription-only, no API-key billing) with Sonnet default. Returns a structured `ArchitectOutput` the Dispatcher composes into the ticket's `architecture` JSONB.
+
+## Quick start
+
+```ts
+import { PerformanceArchitect } from '@caia/performance-architect';
+
+const architect = new PerformanceArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: { frontend: frontendArchitectOutput } },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite includes interface compliance, contract structural checks, registration disjointness, output validation, run() idempotency, dependency declaration, cross-architect invariants, and an end-to-end golden test against a known prakash-tiwari Widget ticket. The golden test verifies that Core Web Vitals budgets stay at the "Good" thresholds per page type (e.g., article-page LCP target ≤ 2.5s).
+
+## Future tools
+
+V1 has empty `tools = []`. A future Lighthouse-CI MCP tool will let the architect run lighthouse-ci against a synthesised preview at architect-spawn time (deterministic budget pre-check before the full build gate).

--- a/packages/performance-architect/eslint.config.cjs
+++ b/packages/performance-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on accessibility-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/performance-architect/package.json
+++ b/packages/performance-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/performance-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Performance Architect — architect #6 of CAIA's 17-architect EA fan-out. Owns the `performance.*` slice of `tickets.architecture` (coreWebVitalsBudgets, bundleSizeBudget, imageOptimizationPlan, fontOptimizationPlan, lazyLoadStrategy, cacheStrategy, criticalRenderPath, lighthouseBudgets). Senior frontend performance engineer focused on Core Web Vitals (LCP/FID/CLS/INP), Lighthouse budgets, bundle analysis, image/font optimization, and cache strategy. Produces per-ticket performance specs. Does NOT write component code (Frontend Architect's job) but DOES specify perf budgets the build must enforce. Depends on Frontend Architect's `componentTree` + `tokens` + `framework`. Spawns Claude via @chiefaia/claude-spawner (subscription-only).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/performance-architect/src/architect.ts
+++ b/packages/performance-architect/src/architect.ts
@@ -1,0 +1,79 @@
+/**
+ * `PerformanceArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (spec §2.6 — Performance reads from
+ *     the Frontend upstream output directly; no external tooling. A
+ *     future `caia-lighthouse-budget-check` / Lighthouse-CI MCP tool
+ *     will let the architect run lighthouse-ci against a synthesised
+ *     preview).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from `@caia/architect-kit`
+ * because the kit hasn't landed on develop yet (the dispatcher's
+ * registration path uses structural typing). The interface is satisfied
+ * structurally. When the kit lands, switch to `extends BaseArchitect`.
+ */
+
+import { PerformanceArchitectContract } from './contract.js';
+import { runPerformanceArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildPerformanceSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/performance-architect` minus the suffix. */
+export const PERFORMANCE_ARCHITECT_NAME = 'performance' as const;
+
+/** V1: no architect-specific tools. Reads Frontend upstream + designVersion directly. */
+export const PERFORMANCE_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface PerformanceArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class PerformanceArchitect implements SpecialistArchitect {
+  readonly name = PERFORMANCE_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = PerformanceArchitectContract;
+  readonly tools: readonly ToolDefinition[] = PERFORMANCE_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: PerformanceArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildPerformanceSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runPerformanceArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/performance-architect/src/contract.ts
+++ b/packages/performance-architect/src/contract.ts
@@ -1,0 +1,170 @@
+/**
+ * `PerformanceArchitectContract` — the canonical owned-fields declaration
+ * for architect #6 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.6 (Performance Architect owns `performance.*`)
+ *   - task brief (coreWebVitalsBudgets, bundleSizeBudget,
+ *     imageOptimizationPlan, fontOptimizationPlan, lazyLoadStrategy,
+ *     cacheStrategy, criticalRenderPath, lighthouseBudgets)
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. All chosen keys live under the `performance.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ *
+ * Note: the task brief field set replaces the older spec §2.6
+ * enumeration (lighthouseTargets, bundleBudget, lcpCandidate, inpBudgetMs,
+ * clsBudget, cacheStrategy, imagePolicy, fontPolicy, prefetchHints,
+ * preloadHints). The brief's `coreWebVitalsBudgets` rolls up the
+ * LCP/INP/CLS targets, `bundleSizeBudget` rolls up `bundleBudget` (with
+ * gzip thresholds), and `lazyLoadStrategy` rolls up prefetch/preload
+ * hints. `criticalRenderPath` is a new sibling concern not in the older
+ * spec but listed in the task brief — it documents above-the-fold render
+ * priorities (preload, font-display, deferred JS, etc.).
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const PERFORMANCE_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'performance.coreWebVitalsBudgets':
+    'Per-page-type LCP/INP/CLS targets. Mobile thresholds (the gating bar): LCP <2.5s, INP <200ms, CLS <0.1. Desktop matches mobile. Reject any target that exceeds Google "Good" thresholds without a documented justification under risks.',
+  'performance.bundleSizeBudget':
+    'Total JavaScript shipped to the route, in gzip. Default 170KB gzipped / route (per spec §2.6). Stricter for marketing pages (130KB), more permissive for admin tools (250KB). Reject values without gzip + brotli figures.',
+  'performance.imageOptimizationPlan':
+    'next/image config: formats=AVIF→WebP→fallback, 4 size breakpoints, eager-load only for above-fold LCP candidate, sizes attribute per breakpoint. No raw <img> tags for content images.',
+  'performance.fontOptimizationPlan':
+    'next/font usage: display=swap, preload only the primary face, subset to needed glyphs, self-host (no third-party CDN fonts unless explicitly tenant-overridden). List the variable axes used.',
+  'performance.lazyLoadStrategy':
+    'Per-component lazy/eager decision. Above-fold = eager. Below-fold images, modals, charts, third-party iframes = lazy with intersection observer. Use next/dynamic for client-only heavy components.',
+  'performance.cacheStrategy':
+    'Three tiers: cdn (edge), browser (Cache-Control), server (Next.js fetch revalidate). Static assets: 1 year immutable. HTML: short s-maxage with stale-while-revalidate. API data: per-route revalidation window.',
+  'performance.criticalRenderPath':
+    'Above-the-fold render plan: which resources preload, font-display, render-blocking JS deferred, inline critical CSS. The LCP candidate component is the anchor.',
+  'performance.lighthouseBudgets':
+    'Lighthouse category floors: Performance ≥90, SEO ≥95, Accessibility ≥95, Best Practices ≥90. The build gate runs lighthouse-ci against these floors. Reject any sub-90 Perf floor without a risk callout.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const PERFORMANCE_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'performance.coreWebVitalsBudgets',
+    description:
+      'Per-page-type Core Web Vitals targets — LCP (Largest Contentful Paint), INP (Interaction to Next Paint, replaces FID), CLS (Cumulative Layout Shift), TTFB (Time to First Byte). Mobile and desktop thresholds.',
+    required: true
+  },
+  {
+    path: 'performance.bundleSizeBudget',
+    description:
+      'Per-route JavaScript bundle budget in gzip + brotli bytes. Includes route-level chunk + shared baseline. Page-type-aware defaults (marketing stricter than admin).',
+    required: true
+  },
+  {
+    path: 'performance.imageOptimizationPlan',
+    description:
+      'next/image strategy: format preference (AVIF→WebP→fallback), responsive breakpoints, eager-vs-lazy per anchor, sizes attribute per breakpoint, LCP candidate flagged for priority.',
+    required: true
+  },
+  {
+    path: 'performance.fontOptimizationPlan',
+    description:
+      'next/font configuration: display strategy, preload list, subset coverage, self-hosting policy, variable-axis declarations, FOUT/FOIT mitigation.',
+    required: true
+  },
+  {
+    path: 'performance.lazyLoadStrategy',
+    description:
+      'Per-component lazy/eager loading decisions. next/dynamic boundaries for heavy client components. Intersection-observer thresholds for below-fold media.',
+    required: true
+  },
+  {
+    path: 'performance.cacheStrategy',
+    description:
+      'Three-tier cache plan: CDN (Cloudflare edge cache rules), browser (Cache-Control headers per asset class), server (Next.js fetch revalidation windows). Stale-while-revalidate posture per route.',
+    required: true
+  },
+  {
+    path: 'performance.criticalRenderPath',
+    description:
+      'Above-the-fold render path: preload hints, render-blocking JS deferred via next/script strategy, inline critical CSS slice, LCP candidate identified, layout-shift prevention measures.',
+    required: true
+  },
+  {
+    path: 'performance.lighthouseBudgets',
+    description:
+      'Lighthouse category floors — Performance ≥90, SEO ≥95, Accessibility ≥95, Best Practices ≥90. The build gate runs lighthouse-ci against these floors.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const PERFORMANCE_OWNED_FIELD_KEYS: readonly string[] =
+  PERFORMANCE_OWNED_SECTIONS.map(s => s.path);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.6 — Performance runs on every ticket that produces UI (Page,
+ * Widget, Story, Form, List). It does NOT apply to pure Foundation
+ * tickets (no UI) or pure backend tickets. Matches Frontend's predicate.
+ */
+export function performanceArchitectAppliesPredicate(ticket: Ticket): boolean {
+  return (
+    ticket.type === 'Page' ||
+    ticket.type === 'Widget' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List'
+  );
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * Performance is a wave-2 architect — depends on Frontend's
+ * `componentTree` + `tokens` + `framework`. Precedence rank 5 per spec
+ * §5.2 (performance in CANONICAL_PRECEDENCE_LADDER) — Lighthouse ≥95
+ * gate is a hard build floor, ranks above Frontend (#14) and Backend
+ * (#12), below Security (#1), DevOps (#2), A11y (#3), and SEO (#4).
+ *
+ * Runtime model: Sonnet (per task brief — "calls Claude (Sonnet
+ * default)"). The older spec §2.6 anticipated a fully deterministic
+ * path; the brief's superset of fields (criticalRenderPath, page-type-
+ * aware budgets) requires LLM reasoning over the Frontend componentTree
+ * and the page-type taxonomy.
+ */
+export const PERFORMANCE_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['frontend'],
+  precedenceLevel: 5,
+  fanoutPolicy: 'always',
+  appliesPredicate: performanceArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const PerformanceArchitectContract: ArchitectSectionContract = {
+  contractId: 'performance-architect.v1',
+  architectName: 'performance',
+  version: '0.1.0',
+  sections: PERFORMANCE_OWNED_SECTIONS,
+  architectMeta: PERFORMANCE_ARCHITECT_META
+};

--- a/packages/performance-architect/src/index.ts
+++ b/packages/performance-architect/src/index.ts
@@ -1,0 +1,97 @@
+/**
+ * @caia/performance-architect — public surface.
+ *
+ * Architect #6 of CAIA's 17-architect EA fan-out. Owns the `performance.*`
+ * slice of `tickets.architecture`. Depends on Frontend Architect upstream.
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's default `registerWith()` helper
+ * to install the architect on a registry. The package does NOT
+ * self-register on import (registration is an explicit operator action
+ * that the Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { PerformanceArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  PerformanceArchitect,
+  PERFORMANCE_ARCHITECT_NAME,
+  PERFORMANCE_ARCHITECT_TOOLS
+} from './architect.js';
+export type { PerformanceArchitectConfig } from './architect.js';
+
+export {
+  PerformanceArchitectContract,
+  PERFORMANCE_OWNED_SECTIONS,
+  PERFORMANCE_OWNED_FIELD_KEYS,
+  PERFORMANCE_FIELD_FIX_HINTS,
+  PERFORMANCE_ARCHITECT_META,
+  performanceArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildPerformanceSystemPrompt } from './system-prompt.js';
+
+// Spawner — exposed so the EA Dispatcher (or tests) can inject a custom one.
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+// Run + validation — exposed for the conformance test suite.
+export { runPerformanceArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+// Invariants — exposed for the EA Reviewer's registry.
+export {
+  PERFORMANCE_INVARIANTS,
+  CWV_GOOD_THRESHOLDS,
+  LIGHTHOUSE_FLOORS
+} from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+// Re-export the canonical kit types so consumers have a single import surface.
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh PerformanceArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): PerformanceArchitect {
+  const architect = new PerformanceArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/performance-architect/src/invariants.ts
+++ b/packages/performance-architect/src/invariants.ts
@@ -1,0 +1,310 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The Reviewer applies a fixed set of cross-architect predicates after
+ * composition. This module enumerates Performance's contributions so
+ * the Reviewer's `invariants-registry.ts` (which doesn't exist yet —
+ * sibling brief F2) can collect them at process boot.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'performance.coreWebVitalsBudgets'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `performance.*`
+ *     path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path. This lets the
+ * same invariants run inside the Performance package's own tests AND
+ * inside the Reviewer's post-composition pass.
+ *
+ * Cross-architect invariants (those that read fields owned by another
+ * architect) treat absent foreign data as "cannot verify" and pass
+ * trivially. The Reviewer's composed-output pass will exercise the
+ * real check; the per-architect test pass exercises only the local
+ * checks. This keeps unit tests on the Performance output green even
+ * though frontend.* fields aren't present.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+/**
+ * Core Web Vitals "Good" thresholds per Google's official guidance.
+ * Exported for tests + future Reviewer evidence ladders.
+ */
+export const CWV_GOOD_THRESHOLDS = {
+  lcpMs: 2500,
+  inpMs: 200,
+  cls: 0.1,
+  ttfbMs: 800
+} as const;
+
+/**
+ * Lighthouse category floors locked by the playbook (spec §2.6).
+ */
+export const LIGHTHOUSE_FLOORS = {
+  performance: 90,
+  seo: 95,
+  accessibility: 95,
+  bestPractices: 90
+} as const;
+
+/**
+ * Read a field from the architecture blob. Tries the flat dotted key
+ * first (matches `architectureFields` shape), then falls back to walking
+ * the nested object path (matches composed-architecture shape).
+ */
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+/**
+ * Performance's contributed invariants. Listed in stable order.
+ */
+export const PERFORMANCE_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'performance.coreWebVitalsBudgets-mobile-lcp-good',
+    contributor: 'performance',
+    reads: ['performance.coreWebVitalsBudgets'],
+    severity: 'fail',
+    description:
+      'Mobile LCP target must be at or below the Google "Good" threshold of 2500ms. Marketing/article pages MUST hit this floor; admin tools may relax with a documented risk.',
+    detect(arch): boolean {
+      const cwv = readField(arch, 'performance.coreWebVitalsBudgets');
+      if (typeof cwv !== 'object' || cwv === null) return false;
+      const mobile = (cwv as Record<string, unknown>).mobile;
+      if (typeof mobile !== 'object' || mobile === null) return false;
+      const lcp = (mobile as Record<string, unknown>).lcpMs;
+      if (typeof lcp !== 'number') return false;
+      // Hard ceiling at 4000ms (boundary of "needs-improvement").
+      // Most pages should hit the 2500ms Good threshold.
+      return lcp <= 4000;
+    }
+  },
+  {
+    id: 'performance.coreWebVitalsBudgets-mobile-inp-good',
+    contributor: 'performance',
+    reads: ['performance.coreWebVitalsBudgets'],
+    severity: 'fail',
+    description:
+      'Mobile INP target must be at or below the Google "Good" threshold of 200ms. Above 500ms is failing per CWV docs.',
+    detect(arch): boolean {
+      const cwv = readField(arch, 'performance.coreWebVitalsBudgets');
+      if (typeof cwv !== 'object' || cwv === null) return false;
+      const mobile = (cwv as Record<string, unknown>).mobile;
+      if (typeof mobile !== 'object' || mobile === null) return false;
+      const inp = (mobile as Record<string, unknown>).inpMs;
+      if (typeof inp !== 'number') return false;
+      return inp <= 500;
+    }
+  },
+  {
+    id: 'performance.coreWebVitalsBudgets-mobile-cls-good',
+    contributor: 'performance',
+    reads: ['performance.coreWebVitalsBudgets'],
+    severity: 'fail',
+    description:
+      'Mobile CLS target must be at or below the Google "Good" threshold of 0.1. Above 0.25 is failing per CWV docs.',
+    detect(arch): boolean {
+      const cwv = readField(arch, 'performance.coreWebVitalsBudgets');
+      if (typeof cwv !== 'object' || cwv === null) return false;
+      const mobile = (cwv as Record<string, unknown>).mobile;
+      if (typeof mobile !== 'object' || mobile === null) return false;
+      const cls = (mobile as Record<string, unknown>).cls;
+      if (typeof cls !== 'number') return false;
+      return cls <= 0.25;
+    }
+  },
+  {
+    id: 'performance.lighthouseBudgets-performance-at-least-90',
+    contributor: 'performance',
+    reads: ['performance.lighthouseBudgets'],
+    severity: 'fail',
+    description:
+      'Lighthouse Performance category floor must be ≥ 90 per the locked playbook (spec §2.6). Sub-90 floors require an operator override.',
+    detect(arch): boolean {
+      const lb = readField(arch, 'performance.lighthouseBudgets');
+      if (typeof lb !== 'object' || lb === null) return false;
+      const p = (lb as Record<string, unknown>).performance;
+      return typeof p === 'number' && p >= 90;
+    }
+  },
+  {
+    id: 'performance.lighthouseBudgets-categories-at-locked-floors',
+    contributor: 'performance',
+    reads: ['performance.lighthouseBudgets'],
+    severity: 'fail',
+    description:
+      'Lighthouse category floors must meet the locked playbook minimums: Performance ≥ 90, SEO ≥ 95, Accessibility ≥ 95, Best Practices ≥ 90.',
+    detect(arch): boolean {
+      const lb = readField(arch, 'performance.lighthouseBudgets');
+      if (typeof lb !== 'object' || lb === null) return false;
+      const o = lb as Record<string, unknown>;
+      const checks = [
+        ['performance', LIGHTHOUSE_FLOORS.performance],
+        ['seo', LIGHTHOUSE_FLOORS.seo],
+        ['accessibility', LIGHTHOUSE_FLOORS.accessibility],
+        ['bestPractices', LIGHTHOUSE_FLOORS.bestPractices]
+      ] as const;
+      for (const [key, min] of checks) {
+        const v = o[key];
+        if (typeof v !== 'number' || v < min) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'performance.bundleSizeBudget-route-under-250kb-gzip',
+    contributor: 'performance',
+    reads: ['performance.bundleSizeBudget'],
+    severity: 'fail',
+    description:
+      'Route-chunk JavaScript budget (gzip) must be ≤ 250KB. Above this the route is unlikely to hit Lighthouse Performance ≥ 90 on mobile.',
+    detect(arch): boolean {
+      const bb = readField(arch, 'performance.bundleSizeBudget');
+      if (typeof bb !== 'object' || bb === null) return false;
+      const route = (bb as Record<string, unknown>).routeChunkKb;
+      if (typeof route !== 'object' || route === null) return false;
+      const gz = (route as Record<string, unknown>).gzip;
+      return typeof gz === 'number' && gz > 0 && gz <= 250;
+    }
+  },
+  {
+    id: 'performance.imagePlan-formats-include-avif-or-webp',
+    contributor: 'performance',
+    reads: ['performance.imageOptimizationPlan'],
+    severity: 'fail',
+    description:
+      'imageOptimizationPlan.formats must include at least one of `avif` or `webp`. Raw JPEG/PNG without a modern format is locked-stack non-compliant.',
+    detect(arch): boolean {
+      const ip = readField(arch, 'performance.imageOptimizationPlan');
+      if (typeof ip !== 'object' || ip === null) return false;
+      const formats = (ip as Record<string, unknown>).formats;
+      if (!Array.isArray(formats)) return false;
+      return formats.includes('avif') || formats.includes('webp');
+    }
+  },
+  {
+    id: 'performance.fontPlan-display-swap-or-optional',
+    contributor: 'performance',
+    reads: ['performance.fontOptimizationPlan'],
+    severity: 'fail',
+    description:
+      'fontOptimizationPlan.display must be one of "swap" or "optional" to avoid FOIT / invisible-text periods.',
+    detect(arch): boolean {
+      const fp = readField(arch, 'performance.fontOptimizationPlan');
+      if (typeof fp !== 'object' || fp === null) return false;
+      const display = (fp as Record<string, unknown>).display;
+      return display === 'swap' || display === 'optional';
+    }
+  },
+  {
+    id: 'performance.fontPlan-self-hosted',
+    contributor: 'performance',
+    reads: ['performance.fontOptimizationPlan'],
+    severity: 'fail',
+    description:
+      'fontOptimizationPlan.selfHosted must be true. Third-party CDN fonts violate the locked stack.',
+    detect(arch): boolean {
+      const fp = readField(arch, 'performance.fontOptimizationPlan');
+      if (typeof fp !== 'object' || fp === null) return false;
+      return (fp as Record<string, unknown>).selfHosted === true;
+    }
+  },
+  {
+    id: 'performance.lazyLoad-references-real-components',
+    contributor: 'performance',
+    reads: ['performance.lazyLoadStrategy', 'frontend.componentTree'],
+    severity: 'advisory',
+    description:
+      'Every component referenced in `performance.lazyLoadStrategy` should exist in Frontend `componentTree`. Trivially passes if the Frontend output is absent.',
+    detect(arch): boolean {
+      const lazy = readField(arch, 'performance.lazyLoadStrategy');
+      const tree = readField(arch, 'frontend.componentTree');
+      if (typeof lazy !== 'object' || lazy === null) return true;
+      if (!Array.isArray(tree)) return true; // foreign data absent ⇒ trivial pass
+      const ids = new Set<string>();
+      const walk = (nodes: unknown): void => {
+        if (!Array.isArray(nodes)) return;
+        for (const n of nodes) {
+          if (typeof n !== 'object' || n === null) continue;
+          const node = n as Record<string, unknown>;
+          if (typeof node.id === 'string') ids.add(node.id);
+          if (Array.isArray(node.children)) walk(node.children);
+        }
+      };
+      walk(tree);
+      for (const compId of Object.keys(lazy as Record<string, unknown>)) {
+        if (!ids.has(compId)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'performance.criticalRenderPath-lcp-anchor-matches-image-plan',
+    contributor: 'performance',
+    reads: ['performance.criticalRenderPath', 'performance.imageOptimizationPlan'],
+    severity: 'fail',
+    description:
+      'If both `criticalRenderPath.lcpAnchor` and `imageOptimizationPlan.lcpCandidate` are set, they must agree on the same component ID. Disagreement means the build wires wrong asset as priority.',
+    detect(arch): boolean {
+      const crp = readField(arch, 'performance.criticalRenderPath');
+      const ip = readField(arch, 'performance.imageOptimizationPlan');
+      if (typeof crp !== 'object' || crp === null) return true;
+      if (typeof ip !== 'object' || ip === null) return true;
+      const anchor = (crp as Record<string, unknown>).lcpAnchor;
+      const candidate = (ip as Record<string, unknown>).lcpCandidate;
+      if (typeof anchor !== 'string' || typeof candidate !== 'string') return true;
+      return anchor === candidate;
+    }
+  },
+  {
+    id: 'performance.cacheStrategy-tri-tier-populated',
+    contributor: 'performance',
+    reads: ['performance.cacheStrategy'],
+    severity: 'fail',
+    description:
+      'cacheStrategy must populate all three tiers: cdn, browser, server. Missing any tier means an asset class has no caching guidance.',
+    detect(arch): boolean {
+      const cs = readField(arch, 'performance.cacheStrategy');
+      if (typeof cs !== 'object' || cs === null) return false;
+      const o = cs as Record<string, unknown>;
+      return (
+        typeof o.cdn === 'object' &&
+        o.cdn !== null &&
+        typeof o.browser === 'object' &&
+        o.browser !== null &&
+        typeof o.server === 'object' &&
+        o.server !== null
+      );
+    }
+  }
+];

--- a/packages/performance-architect/src/run.ts
+++ b/packages/performance-architect/src/run.ts
@@ -1,0 +1,145 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input
+ *      (including the upstream Frontend output that Performance depends
+ *      on).
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ *
+ * Dependency note: Performance depends on Frontend's `componentTree` +
+ * `tokens` + `framework`. If `upstream.outputs.frontend` is absent we
+ * still call the spawner — the system prompt instructs the model to
+ * emit best-effort budgets and surface the missing-upstream condition
+ * under `risks[]`. The contract declaration (`dependsOn: ['frontend']`)
+ * plus the EA Dispatcher's wave scheduler should make this case rare in
+ * practice.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { PERFORMANCE_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them.
+ *
+ * The full `upstream.outputs` is passed through — Performance reads
+ * `upstream.outputs.frontend.architectureFields["frontend.componentTree"]`,
+ * `["frontend.tokens"]`, and `["frontend.framework"]`. The Frontend
+ * Architect's full output may be large; we accept the cost because
+ * Performance needs the tree to identify the LCP candidate and the
+ * eager-vs-lazy decisions.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * The runtime entry. Pure aside from the spawner call.
+ */
+export async function runPerformanceArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, PERFORMANCE_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  // Idempotency: the architect output OWNS its fields. We do NOT merge
+  // with anything else here — composition happens in the Dispatcher
+  // (spec §3.5). Architects always emit the full set of their owned
+  // fields fresh.
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName, // force-correct in case model echoed wrong
+    spend // overwrite — assistant cannot know real spend
+  };
+}

--- a/packages/performance-architect/src/spawner.ts
+++ b/packages/performance-architect/src/spawner.ts
@@ -1,0 +1,161 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * The real spawner lives in `@chiefaia/claude-spawner` (subscription-only,
+ * never sets ANTHROPIC_API_KEY — see that package's file-level comment).
+ * This module:
+ *
+ *   - Defines the `ArchitectSpawnerFn` type — the seam every architect's
+ *     run() consumes.
+ *   - Provides `createDefaultSpawner()` — wires up the real
+ *     `spawnClaude` with the appropriate model + timeout + system prompt.
+ *
+ * Per spec §4 the EA Dispatcher itself runs in the operator's existing
+ * orchestrator process; only the architect subagent spawns issue LLM
+ * calls. This module is the per-architect spawn surface.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+/**
+ * Inputs to a single spawn — system prompt + user prompt + budget.
+ */
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+/**
+ * Output of a single spawn — the raw assistant text plus telemetry.
+ * Parsing into a structured `ArchitectOutput` happens in `run()`, not
+ * here, so the spawner stays generic across architects.
+ */
+export interface ArchitectSpawnOutput {
+  /** The assistant's final message — expected to be a JSON-shaped string. */
+  text: string;
+  /** Best-effort token + cost telemetry from the envelope. */
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  /** Echoed back from input. */
+  model: string;
+  /** True iff the spawn succeeded and the envelope was parsed cleanly. */
+  ok: boolean;
+  /** Diagnostic when `ok=false`. */
+  diagnostic: string | null;
+}
+
+/**
+ * The seam every architect's `run()` consumes. Inject a fake in tests.
+ */
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+/**
+ * Map the architect-budget model preference to the `claude` binary's
+ * `--model` flag value. The mapping mirrors what local-llm-router uses
+ * elsewhere in the monorepo.
+ */
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+/**
+ * Build the canonical user-message body. The system prompt is fed as
+ * the first user-message paragraph (rather than via `claude`'s
+ * `--system` flag) — keeps the spawner surface narrow and lets the
+ * test seam see everything in one string.
+ */
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+/**
+ * Wire the real `spawnClaude` into an `ArchitectSpawnerFn`. Used by
+ * `PerformanceArchitect` when no spawner is injected.
+ */
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/performance-architect/src/system-prompt.ts
+++ b/packages/performance-architect/src/system-prompt.ts
@@ -1,0 +1,262 @@
+/**
+ * The Performance Architect's system prompt — a pure function returning
+ * a static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack (Core Web Vitals "Good" thresholds; Lighthouse floors)
+ *   3. Input format (depends on Frontend upstream)
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics (page-type-aware budgets, LCP candidate selection)
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `performance.*` field name appears
+ * at least once in the body. Keep that invariant true if you add fields.
+ */
+
+import { PERFORMANCE_OWNED_FIELD_KEYS } from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildPerformanceSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Performance Architect. You are a senior frontend performance
+engineer focused on Core Web Vitals (LCP, INP, CLS), Lighthouse budgets,
+JavaScript bundle analysis, and image + font optimization.
+
+You produce per-ticket performance specs. You DO NOT write component code —
+that is the Frontend Architect's job (PR #537 — merged). You DO specify the
+exact perf budgets the build must enforce: Core Web Vitals targets per page
+type, bundle-size ceilings in gzip + brotli bytes, image/font optimization
+plans, cache strategy across CDN + browser + server, critical-render-path
+priorities, and Lighthouse category floors.
+
+Your output is consumed by (a) the Frontend coding worker that implements
+the components (it must respect lazy-load decisions + image config), (b) the
+DevOps Architect that wires lighthouse-ci into the build gate, and (c) the
+EA Reviewer's perf-conformance lens. Any field outside the \`performance.*\`
+namespace is another architect's territory and will be rejected.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Core Web Vitals targets** (Google "Good" thresholds, mobile-first):
+  - **LCP** (Largest Contentful Paint): < 2.5s (good), < 4.0s (needs-improvement boundary)
+  - **INP** (Interaction to Next Paint, replaces FID): < 200ms (good), < 500ms (boundary)
+  - **CLS** (Cumulative Layout Shift): < 0.1 (good), < 0.25 (boundary)
+  - **TTFB** (Time to First Byte): < 800ms (good)
+- **Lighthouse floors**: Performance ≥ 90, SEO ≥ 95, Accessibility ≥ 95,
+  Best Practices ≥ 90. The build gate (lighthouse-ci, future MCP tool)
+  enforces these. Sub-90 Perf without a documented risk callout is a
+  hard fail.
+- **Bundle budget** (gzip, route-level chunk + shared baseline):
+  - Marketing/Page: 130KB gzip / route (≈ 350KB raw)
+  - Story/Widget: 170KB gzip / route (spec §2.6 default)
+  - Admin/internal: 250KB gzip / route (operator override required)
+- **Image policy**: \`next/image\` with AVIF→WebP→fallback, 4 size
+  breakpoints (640/750/1080/1920 default), \`priority\` only on the LCP
+  candidate, eager-load only above-the-fold images, sizes attribute per
+  breakpoint. No raw \`<img>\` tags for content images.
+- **Font policy**: \`next/font\` with \`display=swap\`, \`preload\` for the
+  primary face only, subset to required glyphs, self-hosted (no Google
+  Fonts CDN unless tenant-overrides).
+- **Cache strategy**: three tiers always populated.
+  - CDN: \`Cache-Control: public, s-maxage=<n>, stale-while-revalidate=<m>\`
+  - Browser: \`Cache-Control: public, max-age=<n>\` (immutable for hashed
+    assets, short for HTML)
+  - Server: Next.js \`fetch\` revalidation per route data freshness need.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "planId": "...", "brandKind": "...",
+                    "businessRequirements": "..." },
+  "designVersion": { "designVersionId": "...",
+                     "tokens": { "color.brand.primary": "#0066cc", ... },
+                     "breakpoints": ["sm", "md", "lg", "xl"],
+                     "anchors": [ { "anchorId": "...", "kind": "...",
+                                    "meta": { ... } } ] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "..." },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "frontend": {
+      "architectureFields": {
+        "frontend.framework": {...},
+        "frontend.componentTree": [...],
+        "frontend.tokens": {...},
+        "frontend.routeConfig": {...},
+        ...
+      }
+    }
+  } }
+}
+\`\`\`
+
+You MUST read \`upstream.outputs.frontend.architectureFields\` first. The
+\`frontend.componentTree\` is your authoritative list of components — use it
+to identify the LCP candidate (usually the hero image or heading), decide
+which components are above-the-fold (eager) vs below-fold (lazy), and
+infer route-level chunk weight. The \`frontend.framework\` confirms
+Next.js 15 App Router (your image/font decisions assume this). The
+\`frontend.tokens\` lets you size font payloads. If
+\`upstream.outputs.frontend\` is absent, list "frontend upstream missing"
+under \`risks[]\` and emit best-effort budgets from the design + ticket
+alone.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "performance",
+  "architectureFields": {
+${PERFORMANCE_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "costUsd": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`performance.coreWebVitalsBudgets\` — \`{"pageType":"<marketing|story|admin>","mobile":{"lcpMs":2500,"inpMs":200,"cls":0.1,"ttfbMs":800},"desktop":{"lcpMs":2500,"inpMs":200,"cls":0.1,"ttfbMs":600}}\`.
+  Numbers are upper bounds (the budget). Mobile thresholds gate; desktop
+  is informational. Article/marketing pages stay at the "Good" floor;
+  admin tools may relax LCP to 4s with a documented risk.
+- \`performance.bundleSizeBudget\` — \`{"routeChunkKb":{"gzip":<num>,"brotli":<num>},"sharedBaselineKb":{"gzip":<num>,"brotli":<num>},"thirdPartyBudgetKb":<num>,"perAssetCeilingKb":<num>}\`.
+  All sizes in KB. Marketing default 130KB gzip route; Story default 170KB
+  gzip; admin 250KB.
+- \`performance.imageOptimizationPlan\` — \`{"formats":["avif","webp","jpeg"],"breakpoints":[640,750,1080,1920],"lcpCandidate":"<componentId>","priorityComponents":["<id>"],"lazyComponents":["<id>"],"defaultSizes":"<sizes attribute>","placeholder":"blur"|"empty"}\`.
+- \`performance.fontOptimizationPlan\` — \`{"loader":"next/font","display":"swap","preload":["<face>"],"subset":["latin","latin-ext"],"variableAxes":["wght"],"selfHosted":true,"thirdPartyAllow":[]}\`.
+- \`performance.lazyLoadStrategy\` — \`{"<componentId>":{"strategy":"eager"|"lazy"|"intersection"|"dynamic","rootMargin":"<px>"|null,"reason":"<above-fold|below-fold|heavy-client>"}}\`.
+  Use \`next/dynamic\` for heavy client components (charts, editors).
+- \`performance.cacheStrategy\` — \`{"cdn":{"cacheControl":"public, s-maxage=...","staleWhileRevalidate":<sec>},"browser":{"static":"public, max-age=31536000, immutable","html":"public, max-age=0, must-revalidate"},"server":{"revalidateSec":<num>,"isr":true}}\`.
+- \`performance.criticalRenderPath\` — \`{"preload":["<asset>"],"prefetch":["<route>"],"deferredScripts":["<src>"],"inlineCriticalCssKb":<num>,"lcpAnchor":"<componentId>","renderBlocking":[]}\`.
+- \`performance.lighthouseBudgets\` — \`{"performance":90,"seo":95,"accessibility":95,"bestPractices":90,"pwa":<num|null>}\`.
+  All floors are minimums (>=).`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **LCP candidate selection.** Walk \`frontend.componentTree\` for the
+  first above-the-fold image or heading. Image LCP candidates get
+  \`priority\` + AVIF preload. Heading LCP candidates need a preloaded
+  font face. If both compete (hero image AND large heading), prefer the
+  image — heading text renders fast even without font preload.
+- **Page-type-aware budgets.** Identify the ticket's effective page type
+  from \`ticket.type\` + business signals:
+  - \`Page\` with marketing-style description → "marketing": 130KB / 2.5s LCP
+  - \`Story\`/\`Widget\` → "story": 170KB / 2.5s LCP
+  - Admin-tagged tickets → "admin": 250KB / 4s LCP allowed with risk
+- **Image format ladder.** AVIF first (best compression), WebP fallback,
+  then format requested in source (JPEG/PNG). Browsers negotiate via the
+  picture/source mechanism that next/image emits.
+- **Lazy-load below-fold media.** Anything below the initial 720px-ish
+  viewport gets \`loading="lazy"\` (the default in next/image except for
+  \`priority\`). Modals, charts, editors get \`next/dynamic({ssr: false})\`.
+- **Bundle-size analyser logic.** Heavy client components (chart libs,
+  rich-text editors, code editors) drive bundle bloat. Flag them in
+  \`lazyLoadStrategy\` as \`strategy: "dynamic"\` so the route chunk stays
+  under budget.
+- **Cache freshness vs staleness.** Marketing HTML can be heavily
+  cached with SWR; user-data routes need short revalidation; static
+  assets (immutable, hashed) cache 1 year.
+- **Critical CSS slice.** Inline only what's needed for above-the-fold
+  paint — typically < 14KB. Below-fold CSS loads via the standard
+  Next.js link mechanism.
+- **Font subsetting.** Default to \`latin\` only. Add \`latin-ext\` if the
+  copy contains accented characters per the business plan's audience.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Relax Lighthouse Performance below 90** without a documented business
+  reason → refuse. Emit floor=90, list the relaxation request under
+  \`risks[]\`, set \`confidence\` to 0.6.
+- **Set LCP target above 4s** → refuse. The "needs-improvement" boundary
+  is the absolute ceiling. Emit a Good or boundary value and surface the
+  request under \`risks[]\`.
+- **Use a third-party font CDN** (Google Fonts, Adobe Fonts, etc.) →
+  refuse. Self-host via \`next/font\`. List the request under \`risks[]\`.
+- **Skip image optimization for "speed of implementation"** → refuse.
+  AVIF/WebP via next/image is the locked stack.
+- **Decide a frontend componentTree, route, or props contract** → ignore.
+  Those are Frontend's territory. You only annotate which components are
+  eager/lazy/dynamic.
+- **Write CSP rules, RLS policies, API endpoints, a11y conformance maps,
+  or any field NOT under \`performance.*\`** → ignore the request. Do not
+  populate fields outside your owned namespace.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated, even if the value is a documented default.`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 8 owned field
+   paths (no extras, no missing).
+2. \`performance.coreWebVitalsBudgets\` mobile targets are at or below
+   the "Good" thresholds: LCP ≤ 2500ms, INP ≤ 200ms, CLS ≤ 0.1.
+3. \`performance.lighthouseBudgets.performance\` ≥ 90 (or risk noted).
+4. \`performance.bundleSizeBudget.routeChunkKb.gzip\` matches the page
+   type budget (130 marketing / 170 story / 250 admin).
+5. \`performance.imageOptimizationPlan.lcpCandidate\` references a real
+   component ID from \`frontend.componentTree\` (or null if no image LCP).
+6. \`performance.criticalRenderPath.lcpAnchor\` matches the LCP candidate
+   chosen above.
+7. Every component referenced in \`performance.lazyLoadStrategy\` exists
+   in \`frontend.componentTree\` (or surface as a risk).
+8. \`confidence\` reflects how comfortable you are with the decision —
+   sub-0.6 triggers the EA Reviewer to scrutinize.
+9. \`notes\` is ≤ 800 characters.
+10. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: an article-page Page ticket produces a
+\`coreWebVitalsBudgets\` with mobile LCP=2500ms, INP=200ms, CLS=0.1; a
+\`bundleSizeBudget\` of 130KB gzip route chunk; an \`imageOptimizationPlan\`
+with the hero image as \`lcpCandidate\` and \`priority=true\`; a
+\`fontOptimizationPlan\` with display=swap + latin subset only; a
+\`lazyLoadStrategy\` marking below-fold images as lazy; a tri-tier
+\`cacheStrategy\`; a \`criticalRenderPath\` preloading the hero AVIF +
+primary font face; and Lighthouse floors at the locked 90/95/95/90.`;

--- a/packages/performance-architect/src/types.ts
+++ b/packages/performance-architect/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. The other architect packages mirror
+ * this file verbatim — only the architect-specific field-spec lives in
+ * `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/performance-architect/src/validation.ts
+++ b/packages/performance-architect/src/validation.ts
@@ -1,0 +1,205 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/performance-architect/tests/architect.test.ts
+++ b/packages/performance-architect/tests/architect.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `PerformanceArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1 and
+ * satisfies SpecialistArchitect structurally (will extend BaseArchitect
+ * when the kit lands on develop). These tests mirror the Frontend +
+ * Accessibility Architect compliance suites — the same shape every
+ * architect package uses.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  PerformanceArchitect,
+  PERFORMANCE_ARCHITECT_NAME,
+  PERFORMANCE_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { PerformanceArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('PerformanceArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new PerformanceArchitect();
+    expect(a).toBeInstanceOf(PerformanceArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally (will extend BaseArchitect once the kit lands on develop)', () => {
+    const a = new PerformanceArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the package suffix', () => {
+    const a = new PerformanceArchitect();
+    expect(a.name).toBe('performance');
+    expect(a.name).toBe(PERFORMANCE_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new PerformanceArchitect();
+    expect(a.sectionContract).toBe(PerformanceArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new PerformanceArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.6', () => {
+    const a = new PerformanceArchitect();
+    expect(a.tools).toBe(PERFORMANCE_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('declares Frontend as an upstream dependency', () => {
+    const a = new PerformanceArchitect();
+    expect(a.sectionContract.architectMeta.dependsOn).toEqual(['frontend']);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new PerformanceArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new PerformanceArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new PerformanceArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new PerformanceArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('performance');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new PerformanceArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    // Just instantiating should not error. We do NOT call run() here
+    // because that would invoke the real claude binary.
+    const a = new PerformanceArchitect();
+    expect(a).toBeInstanceOf(PerformanceArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/performance-architect/tests/contract.test.ts
+++ b/packages/performance-architect/tests/contract.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `performance.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed (precedence in [1,17], dependsOn declared).
+ *   - The architect registers cleanly against the shared ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder accounts for performance.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { PerformanceArchitect } from '../src/architect.js';
+import {
+  PERFORMANCE_ARCHITECT_META,
+  PERFORMANCE_OWNED_SECTIONS,
+  PERFORMANCE_OWNED_FIELD_KEYS,
+  PerformanceArchitectContract,
+  performanceArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('PerformanceArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(PerformanceArchitectContract.contractId).toBe('performance-architect.v1');
+  });
+
+  it('architectName is `performance` (matches package suffix)', () => {
+    expect(PerformanceArchitectContract.architectName).toBe('performance');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(PerformanceArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `performance.`', () => {
+    for (const key of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('performance.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'performance.coreWebVitalsBudgets',
+      'performance.bundleSizeBudget',
+      'performance.imageOptimizationPlan',
+      'performance.fontOptimizationPlan',
+      'performance.lazyLoadStrategy',
+      'performance.cacheStrategy',
+      'performance.criticalRenderPath',
+      'performance.lighthouseBudgets'
+    ];
+    for (const r of required) {
+      expect(PERFORMANCE_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owns exactly 8 fields per the task brief', () => {
+    expect(PERFORMANCE_OWNED_FIELD_KEYS.length).toBe(8);
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of PERFORMANCE_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(PerformanceArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(PerformanceArchitectContract).sort()).toEqual(
+      [...PERFORMANCE_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('PerformanceArchitectContract — architectMeta', () => {
+  it('declares Frontend as an upstream dependency (wave-2 architect)', () => {
+    expect(PERFORMANCE_ARCHITECT_META.dependsOn).toEqual(['frontend']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 5 per spec §5.2 (Lighthouse ≥95 gate)', () => {
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBe(5);
+  });
+
+  it('precedence ranks above Frontend (Lighthouse perf gate overrides visual decisions)', () => {
+    // 'frontend' is rank 14 in the canonical ladder; performance is rank 5.
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeLessThan(
+      precedenceRank('frontend')
+    );
+  });
+
+  it('precedence ranks below Security, DevOps, A11y, and SEO', () => {
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeGreaterThan(
+      precedenceRank('security')
+    );
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeGreaterThan(
+      precedenceRank('devops')
+    );
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeGreaterThan(
+      precedenceRank('a11y')
+    );
+    expect(PERFORMANCE_ARCHITECT_META.precedenceLevel).toBeGreaterThan(
+      precedenceRank('seo')
+    );
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(PERFORMANCE_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per task brief', () => {
+    expect(PERFORMANCE_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(PERFORMANCE_ARCHITECT_META.appliesPredicate).toBe(
+      performanceArchitectAppliesPredicate
+    );
+  });
+
+  it('canonical precedence ladder includes `performance`', () => {
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('performance');
+    expect(precedenceRank('performance')).toBe(PERFORMANCE_ARCHITECT_META.precedenceLevel);
+  });
+});
+
+describe('performanceArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Widget', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form (Story sub-type)', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List (Story sub-type)', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns false for Foundation (no UI)', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(
+      false
+    );
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(performanceArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection — implements
+ * the bare `SpecialistArchitect` interface directly.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Performance architect cleanly', () => {
+    expect(() => {
+      registry.register(new PerformanceArchitect());
+    }).not.toThrow();
+    expect(registry.get('performance')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new PerformanceArchitect());
+    for (const k of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('performance');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new PerformanceArchitect());
+    expect(() => registry.register(new PerformanceArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new PerformanceArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'performance.lighthouseBudgets',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new PerformanceArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1',
+      architectName: 'backend',
+      version: '0.1.0',
+      sections: [{ path: 'backend.apiShape', description: 'API shape', required: true }],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 12,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('backend', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(PERFORMANCE_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it("is disjoint with Frontend's namespace (no overlap with `frontend.*`)", () => {
+    for (const k of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(k.startsWith('frontend.')).toBe(false);
+    }
+  });
+
+  it("is disjoint with A11y's namespace (no overlap with `a11y.*`)", () => {
+    for (const k of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(k.startsWith('a11y.')).toBe(false);
+    }
+  });
+
+  it('disjointness() detects no conflicts when only Performance is present', () => {
+    const conflicts = disjointness([PerformanceArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Performance and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...PerformanceArchitectContract,
+      contractId: 'performance-clone.v1',
+      architectName: 'performance-clone'
+    };
+    const conflicts = disjointness([PerformanceArchitectContract, clone]);
+    expect(conflicts.length).toBe(PERFORMANCE_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() reports an unmet dependsOn when frontend is not registered', () => {
+    registry.register(new PerformanceArchitect());
+    const errors = registry.validate();
+    expect(errors.some(e => e.includes("'frontend'"))).toBe(true);
+  });
+});

--- a/packages/performance-architect/tests/golden/golden.test.ts
+++ b/packages/performance-architect/tests/golden/golden.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Golden test — the canonical known-good Performance-architect artifact
+ * for a known prakash-tiwari Widget ticket.
+ *
+ * This test serves four purposes:
+ *
+ *   1. Lock the architect's output shape against drift. Any change to
+ *      the contract or run() must update this snapshot.
+ *
+ *   2. Demonstrate the architect produces a complete, validating output
+ *      end-to-end given a realistic input (including the upstream
+ *      Frontend output that Performance depends on).
+ *
+ *   3. Verify Core Web Vitals budgets are reasonable per page-type —
+ *      article/story pages MUST hit the "Good" thresholds (LCP ≤ 2.5s,
+ *      INP ≤ 200ms, CLS ≤ 0.1). This is the canonical assertion the task
+ *      brief calls out.
+ *
+ *   4. Become the canonical fixture the other 14 specialist architect
+ *      packages reference when writing their own golden tests.
+ *
+ * Note: this test uses a deterministic fake spawner. It does NOT call
+ * the real claude binary. The "golden" here is the expected
+ * deterministic projection of the input through the run() pipeline,
+ * given a fixed assistant text. A nightly LLM-judge variant is the
+ * sibling test the conformance suite will add later (per spec §11(c)).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { PerformanceArchitect } from '../../src/architect.js';
+import { PERFORMANCE_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import {
+  CWV_GOOD_THRESHOLDS,
+  LIGHTHOUSE_FLOORS,
+  PERFORMANCE_INVARIANTS
+} from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  composedArchitectureForInvariants,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari Artist hero bio Widget ticket (performance)', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-upstream-frontend.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-upstream-frontend.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().upstream.outputs.frontend;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new PerformanceArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    // Architect name, status, top-level shape
+    expect(out.architectName).toBe('performance');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    // Every owned field present
+    for (const k of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    // Field values match the known-good expectation (except spend, which
+    // the run pipeline overwrites).
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every Performance invariant on the Perf-only view', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new PerformanceArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden Perf output`).toBe(true);
+    }
+  });
+
+  it('output passes every Performance invariant on the composed (Perf + Frontend) view', () => {
+    const composed = composedArchitectureForInvariants();
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      const ok = inv.detect(composed);
+      expect(ok, `invariant ${inv.id} should pass on the composed view`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new PerformanceArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+});
+
+/**
+ * Page-type CWV reasonableness — the task brief calls this out
+ * specifically: "verify Core Web Vitals budgets are reasonable per
+ * page-type (e.g., article page LCP target < 2.5s)".
+ *
+ * Article/marketing/story pages must hit the Google "Good" thresholds.
+ * Admin tools may relax with a documented risk (we exercise that case
+ * here as a counter-example).
+ */
+describe('Core Web Vitals budgets are reasonable per page-type', () => {
+  const golden = goldenExpectedOutput();
+
+  it('article/story page LCP target is at or below the "Good" 2.5s threshold', () => {
+    const cwv = golden.architectureFields[
+      'performance.coreWebVitalsBudgets'
+    ] as Record<string, unknown>;
+    const mobile = cwv.mobile as Record<string, number>;
+    expect(mobile.lcpMs).toBeLessThanOrEqual(CWV_GOOD_THRESHOLDS.lcpMs);
+    expect(mobile.lcpMs).toBeLessThanOrEqual(2500);
+  });
+
+  it('article/story page INP target is at or below the "Good" 200ms threshold', () => {
+    const cwv = golden.architectureFields[
+      'performance.coreWebVitalsBudgets'
+    ] as Record<string, unknown>;
+    const mobile = cwv.mobile as Record<string, number>;
+    expect(mobile.inpMs).toBeLessThanOrEqual(CWV_GOOD_THRESHOLDS.inpMs);
+    expect(mobile.inpMs).toBeLessThanOrEqual(200);
+  });
+
+  it('article/story page CLS target is at or below the "Good" 0.1 threshold', () => {
+    const cwv = golden.architectureFields[
+      'performance.coreWebVitalsBudgets'
+    ] as Record<string, unknown>;
+    const mobile = cwv.mobile as Record<string, number>;
+    expect(mobile.cls).toBeLessThanOrEqual(CWV_GOOD_THRESHOLDS.cls);
+    expect(mobile.cls).toBeLessThanOrEqual(0.1);
+  });
+
+  it('article/story page TTFB target is at or below the "Good" 800ms threshold', () => {
+    const cwv = golden.architectureFields[
+      'performance.coreWebVitalsBudgets'
+    ] as Record<string, unknown>;
+    const mobile = cwv.mobile as Record<string, number>;
+    expect(mobile.ttfbMs).toBeLessThanOrEqual(CWV_GOOD_THRESHOLDS.ttfbMs);
+  });
+
+  it('mobile and desktop have matching LCP/INP/CLS budgets (mobile is the gating bar)', () => {
+    const cwv = golden.architectureFields[
+      'performance.coreWebVitalsBudgets'
+    ] as Record<string, unknown>;
+    const mobile = cwv.mobile as Record<string, number>;
+    const desktop = cwv.desktop as Record<string, number>;
+    // Desktop can be tighter than mobile but never looser on these
+    // user-experience metrics.
+    expect(desktop.lcpMs).toBeLessThanOrEqual(mobile.lcpMs);
+    expect(desktop.inpMs).toBeLessThanOrEqual(mobile.inpMs);
+    expect(desktop.cls).toBeLessThanOrEqual(mobile.cls);
+  });
+
+  it('pageType is declared explicitly (story/marketing/admin)', () => {
+    const cwv = golden.architectureFields[
+      'performance.coreWebVitalsBudgets'
+    ] as Record<string, unknown>;
+    expect(typeof cwv.pageType).toBe('string');
+    expect(['marketing', 'story', 'admin']).toContain(cwv.pageType);
+  });
+
+  it('Lighthouse Performance floor is ≥ 90 per locked playbook', () => {
+    const lb = golden.architectureFields['performance.lighthouseBudgets'] as Record<
+      string,
+      number
+    >;
+    expect(lb.performance).toBeGreaterThanOrEqual(LIGHTHOUSE_FLOORS.performance);
+  });
+
+  it('Lighthouse SEO floor is ≥ 95 per locked playbook', () => {
+    const lb = golden.architectureFields['performance.lighthouseBudgets'] as Record<
+      string,
+      number
+    >;
+    expect(lb.seo).toBeGreaterThanOrEqual(LIGHTHOUSE_FLOORS.seo);
+  });
+
+  it('Lighthouse Accessibility floor is ≥ 95 per locked playbook', () => {
+    const lb = golden.architectureFields['performance.lighthouseBudgets'] as Record<
+      string,
+      number
+    >;
+    expect(lb.accessibility).toBeGreaterThanOrEqual(LIGHTHOUSE_FLOORS.accessibility);
+  });
+
+  it('Lighthouse Best Practices floor is ≥ 90 per locked playbook', () => {
+    const lb = golden.architectureFields['performance.lighthouseBudgets'] as Record<
+      string,
+      number
+    >;
+    expect(lb.bestPractices).toBeGreaterThanOrEqual(LIGHTHOUSE_FLOORS.bestPractices);
+  });
+
+  it('bundle budget stays at or below the 250KB gzip hard ceiling', () => {
+    const bb = golden.architectureFields['performance.bundleSizeBudget'] as Record<
+      string,
+      unknown
+    >;
+    const route = bb.routeChunkKb as Record<string, number>;
+    expect(route.gzip).toBeGreaterThan(0);
+    expect(route.gzip).toBeLessThanOrEqual(250);
+  });
+
+  it('story-page bundle budget matches the locked 170KB gzip default', () => {
+    const bb = golden.architectureFields['performance.bundleSizeBudget'] as Record<
+      string,
+      unknown
+    >;
+    const route = bb.routeChunkKb as Record<string, number>;
+    // Story = 170KB per locked playbook.
+    expect(route.gzip).toBe(170);
+  });
+
+  it('image plan declares AVIF or WebP (not raw JPEG/PNG only)', () => {
+    const ip = golden.architectureFields[
+      'performance.imageOptimizationPlan'
+    ] as Record<string, unknown>;
+    const formats = ip.formats as string[];
+    const modern = formats.some(f => f === 'avif' || f === 'webp');
+    expect(modern).toBe(true);
+  });
+
+  it('font plan uses display=swap or display=optional (no FOIT)', () => {
+    const fp = golden.architectureFields[
+      'performance.fontOptimizationPlan'
+    ] as Record<string, unknown>;
+    expect(['swap', 'optional']).toContain(fp.display);
+  });
+
+  it('font plan is self-hosted (no third-party CDN fonts)', () => {
+    const fp = golden.architectureFields[
+      'performance.fontOptimizationPlan'
+    ] as Record<string, unknown>;
+    expect(fp.selfHosted).toBe(true);
+  });
+
+  it('LCP candidate is the hero image (largest above-fold element)', () => {
+    const ip = golden.architectureFields[
+      'performance.imageOptimizationPlan'
+    ] as Record<string, unknown>;
+    expect(ip.lcpCandidate).toBe('hero-portrait');
+  });
+
+  it('criticalRenderPath.lcpAnchor matches imageOptimizationPlan.lcpCandidate', () => {
+    const ip = golden.architectureFields[
+      'performance.imageOptimizationPlan'
+    ] as Record<string, unknown>;
+    const crp = golden.architectureFields[
+      'performance.criticalRenderPath'
+    ] as Record<string, unknown>;
+    expect(crp.lcpAnchor).toBe(ip.lcpCandidate);
+  });
+
+  it('cache strategy populates all three tiers (CDN + browser + server)', () => {
+    const cs = golden.architectureFields['performance.cacheStrategy'] as Record<
+      string,
+      unknown
+    >;
+    expect(cs.cdn).toBeTruthy();
+    expect(cs.browser).toBeTruthy();
+    expect(cs.server).toBeTruthy();
+  });
+});

--- a/packages/performance-architect/tests/golden/input-businessplan.json
+++ b/packages/performance-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/performance-architect/tests/golden/input-designversion.json
+++ b/packages/performance-architect/tests/golden/input-designversion.json
@@ -1,0 +1,55 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "hero",
+      "kind": "section",
+      "bbox": { "x": 0, "y": 0, "w": 1440, "h": 720 },
+      "meta": { "variant": "hero", "breakpoints": ["sm", "md", "lg", "xl"] }
+    },
+    {
+      "anchorId": "hero-portrait",
+      "kind": "image",
+      "bbox": { "x": 80, "y": 80, "w": 480, "h": 600 },
+      "meta": { "aspect": "4/5" }
+    },
+    {
+      "anchorId": "hero-title",
+      "kind": "heading",
+      "bbox": { "x": 600, "y": 120, "w": 700, "h": 80 },
+      "meta": { "level": 1 }
+    },
+    {
+      "anchorId": "hero-tagline",
+      "kind": "text",
+      "bbox": { "x": 600, "y": 220, "w": 700, "h": 60 }
+    },
+    {
+      "anchorId": "hero-cta-primary",
+      "kind": "button",
+      "bbox": { "x": 600, "y": 320, "w": 200, "h": 56 },
+      "meta": { "variant": "primary" }
+    },
+    {
+      "anchorId": "hero-cta-secondary",
+      "kind": "button",
+      "bbox": { "x": 820, "y": 320, "w": 200, "h": 56 },
+      "meta": { "variant": "secondary" }
+    }
+  ],
+  "tokens": {
+    "color.brand.primary": "#0f3057",
+    "color.brand.accent": "#e8c547",
+    "color.text.body": "#1f1f1f",
+    "color.bg.canvas": "#f7f5ef",
+    "space.4": "16px",
+    "space.8": "32px",
+    "space.16": "64px",
+    "radius.md": "8px",
+    "radius.lg": "12px",
+    "type.display.size": "48px",
+    "type.body.size": "16px"
+  },
+  "breakpoints": ["sm", "md", "lg", "xl"]
+}

--- a/packages/performance-architect/tests/golden/input-ticket.json
+++ b/packages/performance-architect/tests/golden/input-ticket.json
@@ -1,0 +1,17 @@
+{
+  "id": "ticket-pt-001",
+  "type": "Widget",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "Hero CTA \"Book session\" is keyboard-reachable in <2 Tab presses from page load.",
+    "On <640px viewports, portrait stacks above bio text.",
+    "All design tokens trace back to the intake IR; no invented values.",
+    "Reduced-motion users see no animation on hover."
+  ],
+  "business_requirements": {
+    "title": "Artist hero bio widget",
+    "description": "Above-the-fold hero block for the artist profile page — portrait photo, name, tagline, primary CTA (\"Book session\"), secondary CTA (\"View portfolio\")."
+  },
+  "quality_tags": ["ui", "performance"]
+}

--- a/packages/performance-architect/tests/golden/input-upstream-frontend.json
+++ b/packages/performance-architect/tests/golden/input-upstream-frontend.json
@@ -1,0 +1,101 @@
+{
+  "architectName": "frontend",
+  "architectureFields": {
+    "frontend.framework": { "name": "next", "version": "15.x", "router": "app" },
+    "frontend.componentLibrary": {
+      "name": "shadcn/ui",
+      "tailwindVersion": "3.x",
+      "radixVersion": "1.x"
+    },
+    "frontend.stateMgmt": {
+      "default": "server",
+      "clientStore": "zustand",
+      "forms": "react-hook-form"
+    },
+    "frontend.routeConfig": {
+      "segment": "app/artists/[slug]",
+      "layoutSegment": "app/artists",
+      "loadingBoundary": true,
+      "errorBoundary": true,
+      "dynamicSegments": ["[slug]"]
+    },
+    "frontend.tokens": {
+      "color.brand.primary": "#0f3057",
+      "color.brand.accent": "#e8c547",
+      "color.text.body": "#1f1f1f",
+      "color.bg.canvas": "#f7f5ef",
+      "space.4": "16px",
+      "space.8": "32px",
+      "space.16": "64px",
+      "radius.md": "8px",
+      "radius.lg": "12px",
+      "type.display.size": "48px",
+      "type.body.size": "16px"
+    },
+    "frontend.breakpoints": ["sm", "md", "lg", "xl"],
+    "frontend.a11yFloor": {
+      "hero-cta-primary": { "element": "button", "tabOrder": 1, "focusTrap": false },
+      "hero-cta-secondary": { "element": "button", "tabOrder": 2, "focusTrap": false }
+    },
+    "frontend.motionPreference": {
+      "reducedMotionGate": true,
+      "gateThresholdMs": 200,
+      "alwaysOnAnimations": []
+    },
+    "frontend.componentTree": [
+      {
+        "id": "hero",
+        "kind": "section",
+        "propsContractRef": "hero",
+        "children": [
+          { "id": "hero-portrait", "kind": "Image", "propsContractRef": "hero-portrait" },
+          { "id": "hero-title", "kind": "h1", "propsContractRef": "hero-title" },
+          { "id": "hero-tagline", "kind": "p", "propsContractRef": "hero-tagline" },
+          {
+            "id": "hero-cta-primary",
+            "kind": "Button",
+            "propsContractRef": "hero-cta-primary"
+          },
+          {
+            "id": "hero-cta-secondary",
+            "kind": "Button",
+            "propsContractRef": "hero-cta-secondary"
+          }
+        ]
+      }
+    ],
+    "frontend.interactionStates": {
+      "hero-cta-primary": {
+        "hover": "darker brand fill",
+        "focus": "visible ring",
+        "active": "inset shadow",
+        "error": "n/a",
+        "empty": "n/a",
+        "loading": "inline spinner replacing label",
+        "disabled": "50% opacity, no pointer events"
+      },
+      "hero-cta-secondary": {
+        "hover": "darker accent fill",
+        "focus": "visible ring",
+        "active": "inset shadow",
+        "error": "n/a",
+        "empty": "n/a",
+        "loading": "inline spinner replacing label",
+        "disabled": "50% opacity, no pointer events"
+      }
+    }
+  },
+  "confidence": 0.88,
+  "notes": "Frontend golden output for prakash-tiwari hero widget.",
+  "dependencies": [],
+  "risks": [],
+  "toolCalls": [],
+  "spend": {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "usdCost": 0,
+    "wallClockMs": 0,
+    "model": "sonnet"
+  },
+  "status": "ok"
+}

--- a/packages/performance-architect/tests/helpers/fakes.ts
+++ b/packages/performance-architect/tests/helpers/fakes.ts
@@ -1,0 +1,432 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Widget ticket WITH a synthesised Frontend
+ *     upstream output (since Performance is wave-2 and depends on
+ *     Frontend).
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Widget fixture.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { PERFORMANCE_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The known-good Frontend upstream output for the prakash-tiwari hero
+ * widget. Pinned here so the Performance architect's tests don't depend
+ * on the Frontend package being importable from tests (the workspace
+ * symlink would work, but pinning is cheaper to maintain).
+ *
+ * Shape mirrors `frontend-architect`'s goldenExpectedOutput() exactly.
+ * The component IDs must match: `hero`, `hero-portrait`, `hero-title`,
+ * `hero-tagline`, `hero-cta-primary`, `hero-cta-secondary`. The image
+ * `hero-portrait` is the LCP candidate for an article-style hero block.
+ */
+function buildFrontendUpstreamOutput(): ArchitectOutput {
+  return {
+    architectName: 'frontend',
+    architectureFields: {
+      'frontend.framework': { name: 'next', version: '15.x', router: 'app' },
+      'frontend.componentLibrary': {
+        name: 'shadcn/ui',
+        tailwindVersion: '3.x',
+        radixVersion: '1.x'
+      },
+      'frontend.stateMgmt': {
+        default: 'server',
+        clientStore: 'zustand',
+        forms: 'react-hook-form'
+      },
+      'frontend.routeConfig': {
+        segment: 'app/artists/[slug]',
+        layoutSegment: 'app/artists',
+        loadingBoundary: true,
+        errorBoundary: true,
+        dynamicSegments: ['[slug]']
+      },
+      'frontend.tokens': {
+        'color.brand.primary': '#0f3057',
+        'color.brand.accent': '#e8c547',
+        'color.text.body': '#1f1f1f',
+        'color.bg.canvas': '#f7f5ef',
+        'space.4': '16px',
+        'space.8': '32px',
+        'space.16': '64px',
+        'radius.md': '8px',
+        'radius.lg': '12px',
+        'type.display.size': '48px',
+        'type.body.size': '16px'
+      },
+      'frontend.breakpoints': ['sm', 'md', 'lg', 'xl'],
+      'frontend.a11yFloor': {
+        'hero-cta-primary': { element: 'button', tabOrder: 1, focusTrap: false },
+        'hero-cta-secondary': { element: 'button', tabOrder: 2, focusTrap: false }
+      },
+      'frontend.motionPreference': {
+        reducedMotionGate: true,
+        gateThresholdMs: 200,
+        alwaysOnAnimations: []
+      },
+      'frontend.componentTree': [
+        {
+          id: 'hero',
+          kind: 'section',
+          propsContractRef: 'hero',
+          children: [
+            { id: 'hero-portrait', kind: 'Image', propsContractRef: 'hero-portrait' },
+            { id: 'hero-title', kind: 'h1', propsContractRef: 'hero-title' },
+            { id: 'hero-tagline', kind: 'p', propsContractRef: 'hero-tagline' },
+            {
+              id: 'hero-cta-primary',
+              kind: 'Button',
+              propsContractRef: 'hero-cta-primary'
+            },
+            {
+              id: 'hero-cta-secondary',
+              kind: 'Button',
+              propsContractRef: 'hero-cta-secondary'
+            }
+          ]
+        }
+      ],
+      'frontend.interactionStates': {
+        'hero-cta-primary': {
+          hover: 'darker brand fill',
+          focus: 'visible ring',
+          active: 'inset shadow',
+          error: 'n/a',
+          empty: 'n/a',
+          loading: 'inline spinner replacing label',
+          disabled: '50% opacity, no pointer events'
+        },
+        'hero-cta-secondary': {
+          hover: 'darker accent fill',
+          focus: 'visible ring',
+          active: 'inset shadow',
+          error: 'n/a',
+          empty: 'n/a',
+          loading: 'inline spinner replacing label',
+          disabled: '50% opacity, no pointer events'
+        }
+      }
+    },
+    confidence: 0.88,
+    notes: 'Frontend golden output for prakash-tiwari hero widget.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/**
+ * The canonical fixture — a Widget ticket from the prakash-tiwari.com
+ * marketing site (an `ArtistHeroBio` widget) with the Frontend upstream
+ * output already populated.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-001',
+      type: 'Widget',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Hero CTA "Book session" is keyboard-reachable in <2 Tab presses from page load.',
+        'On <640px viewports, portrait stacks above bio text.',
+        'All design tokens trace back to the intake IR; no invented values.',
+        'Reduced-motion users see no animation on hover.'
+      ],
+      business_requirements: {
+        title: 'Artist hero bio widget',
+        description:
+          'Above-the-fold hero block for the artist profile page — portrait photo, name, tagline, primary CTA ("Book session"), secondary CTA ("View portfolio").'
+      },
+      quality_tags: ['ui', 'performance']
+    },
+    upstream: {
+      outputs: {
+        frontend: buildFrontendUpstreamOutput()
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        "Make the booking CTA the page's primary action"
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'hero',
+          kind: 'section',
+          bbox: { x: 0, y: 0, w: 1440, h: 720 },
+          meta: { variant: 'hero', breakpoints: ['sm', 'md', 'lg', 'xl'] }
+        },
+        {
+          anchorId: 'hero-portrait',
+          kind: 'image',
+          bbox: { x: 80, y: 80, w: 480, h: 600 },
+          meta: { aspect: '4/5' }
+        },
+        {
+          anchorId: 'hero-title',
+          kind: 'heading',
+          bbox: { x: 600, y: 120, w: 700, h: 80 },
+          meta: { level: 1 }
+        },
+        {
+          anchorId: 'hero-tagline',
+          kind: 'text',
+          bbox: { x: 600, y: 220, w: 700, h: 60 }
+        },
+        {
+          anchorId: 'hero-cta-primary',
+          kind: 'button',
+          bbox: { x: 600, y: 320, w: 200, h: 56 },
+          meta: { variant: 'primary' }
+        },
+        {
+          anchorId: 'hero-cta-secondary',
+          kind: 'button',
+          bbox: { x: 820, y: 320, w: 200, h: 56 },
+          meta: { variant: 'secondary' }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057',
+        'color.brand.accent': '#e8c547',
+        'color.text.body': '#1f1f1f',
+        'color.bg.canvas': '#f7f5ef',
+        'space.4': '16px',
+        'space.8': '32px',
+        'space.16': '64px',
+        'radius.md': '8px',
+        'radius.lg': '12px',
+        'type.display.size': '48px',
+        'type.body.size': '16px'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari Widget fixture. Covers
+ * exactly the 8 owned `performance.*` fields with Core Web Vitals
+ * budgets at the "Good" thresholds for a marketing/story page type.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'performance',
+    architectureFields: {
+      'performance.coreWebVitalsBudgets': {
+        pageType: 'story',
+        mobile: {
+          lcpMs: 2500,
+          inpMs: 200,
+          cls: 0.1,
+          ttfbMs: 800
+        },
+        desktop: {
+          lcpMs: 2500,
+          inpMs: 200,
+          cls: 0.1,
+          ttfbMs: 600
+        }
+      },
+      'performance.bundleSizeBudget': {
+        routeChunkKb: { gzip: 170, brotli: 145 },
+        sharedBaselineKb: { gzip: 80, brotli: 68 },
+        thirdPartyBudgetKb: 0,
+        perAssetCeilingKb: 50
+      },
+      'performance.imageOptimizationPlan': {
+        formats: ['avif', 'webp', 'jpeg'],
+        breakpoints: [640, 750, 1080, 1920],
+        lcpCandidate: 'hero-portrait',
+        priorityComponents: ['hero-portrait'],
+        lazyComponents: [],
+        defaultSizes: '(max-width: 768px) 100vw, 480px',
+        placeholder: 'blur'
+      },
+      'performance.fontOptimizationPlan': {
+        loader: 'next/font',
+        display: 'swap',
+        preload: ['primary-display'],
+        subset: ['latin'],
+        variableAxes: ['wght'],
+        selfHosted: true,
+        thirdPartyAllow: []
+      },
+      'performance.lazyLoadStrategy': {
+        hero: { strategy: 'eager', rootMargin: null, reason: 'above-fold' },
+        'hero-portrait': {
+          strategy: 'eager',
+          rootMargin: null,
+          reason: 'above-fold'
+        },
+        'hero-title': { strategy: 'eager', rootMargin: null, reason: 'above-fold' },
+        'hero-tagline': {
+          strategy: 'eager',
+          rootMargin: null,
+          reason: 'above-fold'
+        },
+        'hero-cta-primary': {
+          strategy: 'eager',
+          rootMargin: null,
+          reason: 'above-fold'
+        },
+        'hero-cta-secondary': {
+          strategy: 'eager',
+          rootMargin: null,
+          reason: 'above-fold'
+        }
+      },
+      'performance.cacheStrategy': {
+        cdn: {
+          cacheControl: 'public, s-maxage=300, stale-while-revalidate=86400',
+          staleWhileRevalidate: 86400
+        },
+        browser: {
+          static: 'public, max-age=31536000, immutable',
+          html: 'public, max-age=0, must-revalidate'
+        },
+        server: {
+          revalidateSec: 300,
+          isr: true
+        }
+      },
+      'performance.criticalRenderPath': {
+        preload: ['/fonts/primary-display.woff2', '/_next/image/hero-portrait.avif'],
+        prefetch: [],
+        deferredScripts: [],
+        inlineCriticalCssKb: 8,
+        lcpAnchor: 'hero-portrait',
+        renderBlocking: []
+      },
+      'performance.lighthouseBudgets': {
+        performance: 90,
+        seo: 95,
+        accessibility: 95,
+        bestPractices: 90,
+        pwa: null
+      }
+    },
+    confidence: 0.88,
+    notes:
+      'Hero widget performance spec — story page type, mobile-first CWV budgets at the Good thresholds (LCP 2500ms, INP 200ms, CLS 0.1). LCP candidate is the hero-portrait image: AVIF preload + priority. next/font swap + latin subset. All hero components eager (above-fold). 170KB gzip route chunk budget. CDN: s-maxage 300s + SWR 24h. Lighthouse floors at the locked 90/95/95/90.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Compose the Performance output's architectureFields with a synthesised
+ * Frontend slice so the cross-architect invariants can be exercised
+ * against a "composed" view. Used by the invariants test pass.
+ */
+export function composedArchitectureForInvariants(): Readonly<Record<string, unknown>> {
+  const perf = goldenExpectedOutput().architectureFields;
+  const frontend = buildFrontendUpstreamOutput().architectureFields;
+  return { ...perf, ...frontend };
+}
+
+/**
+ * Asserts that the input covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of PERFORMANCE_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/performance-architect/tests/invariants.test.ts
+++ b/packages/performance-architect/tests/invariants.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Cross-architect invariants — verifies Performance's contributions
+ * to the EA Reviewer's invariant registry (per spec §6.2).
+ *
+ * Each invariant is exercised against:
+ *   1. The pure Performance output (cross-arch invariants pass trivially
+ *      when foreign data is absent).
+ *   2. A composed view (Performance + Frontend fields) — the realistic
+ *      Reviewer shape. Cross-arch invariants are fully exercised here.
+ *   3. Corruption variants — each invariant must fail on its known-bad
+ *      input shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  CWV_GOOD_THRESHOLDS,
+  LIGHTHOUSE_FLOORS,
+  PERFORMANCE_INVARIANTS
+} from '../src/invariants.js';
+import {
+  composedArchitectureForInvariants,
+  goldenExpectedOutput
+} from './helpers/fakes.js';
+
+describe('PERFORMANCE_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(PERFORMANCE_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `performance`', () => {
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      expect(inv.contributor).toBe('performance');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('PERFORMANCE_INVARIANTS — locked constants', () => {
+  it('CWV "Good" thresholds match Google guidance', () => {
+    expect(CWV_GOOD_THRESHOLDS.lcpMs).toBe(2500);
+    expect(CWV_GOOD_THRESHOLDS.inpMs).toBe(200);
+    expect(CWV_GOOD_THRESHOLDS.cls).toBe(0.1);
+    expect(CWV_GOOD_THRESHOLDS.ttfbMs).toBe(800);
+  });
+
+  it('Lighthouse floors match the locked playbook', () => {
+    expect(LIGHTHOUSE_FLOORS.performance).toBe(90);
+    expect(LIGHTHOUSE_FLOORS.seo).toBe(95);
+    expect(LIGHTHOUSE_FLOORS.accessibility).toBe(95);
+    expect(LIGHTHOUSE_FLOORS.bestPractices).toBe(90);
+  });
+});
+
+describe('PERFORMANCE_INVARIANTS — predicate behaviour on the golden Perf output', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output (cross-arch checks trivially pass without Frontend data)', () => {
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden Perf output`).toBe(true);
+    }
+  });
+});
+
+describe('PERFORMANCE_INVARIANTS — predicate behaviour on the composed (Perf + Frontend) view', () => {
+  const composed = composedArchitectureForInvariants();
+
+  it('every invariant passes against the composed view', () => {
+    for (const inv of PERFORMANCE_INVARIANTS) {
+      const ok = inv.detect(composed);
+      expect(ok, `invariant ${inv.id} should pass on the composed view`).toBe(true);
+    }
+  });
+});
+
+describe('PERFORMANCE_INVARIANTS — corruption variants', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+  const composed = composedArchitectureForInvariants();
+
+  it('coreWebVitalsBudgets-mobile-lcp-good fails when LCP exceeds 4000ms', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.coreWebVitalsBudgets-mobile-lcp-good'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.coreWebVitalsBudgets': {
+        pageType: 'admin',
+        mobile: { lcpMs: 5000, inpMs: 200, cls: 0.1, ttfbMs: 800 },
+        desktop: { lcpMs: 5000, inpMs: 200, cls: 0.1, ttfbMs: 600 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('coreWebVitalsBudgets-mobile-inp-good fails when INP exceeds 500ms', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.coreWebVitalsBudgets-mobile-inp-good'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.coreWebVitalsBudgets': {
+        pageType: 'story',
+        mobile: { lcpMs: 2500, inpMs: 700, cls: 0.1, ttfbMs: 800 },
+        desktop: { lcpMs: 2500, inpMs: 700, cls: 0.1, ttfbMs: 600 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('coreWebVitalsBudgets-mobile-cls-good fails when CLS exceeds 0.25', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.coreWebVitalsBudgets-mobile-cls-good'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.coreWebVitalsBudgets': {
+        pageType: 'story',
+        mobile: { lcpMs: 2500, inpMs: 200, cls: 0.3, ttfbMs: 800 },
+        desktop: { lcpMs: 2500, inpMs: 200, cls: 0.3, ttfbMs: 600 }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('lighthouseBudgets-performance-at-least-90 fails when Perf < 90', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.lighthouseBudgets-performance-at-least-90'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.lighthouseBudgets': {
+        performance: 85,
+        seo: 95,
+        accessibility: 95,
+        bestPractices: 90,
+        pwa: null
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('lighthouseBudgets-categories-at-locked-floors fails when SEO drops to 90', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.lighthouseBudgets-categories-at-locked-floors'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.lighthouseBudgets': {
+        performance: 90,
+        seo: 90, // below the 95 floor
+        accessibility: 95,
+        bestPractices: 90,
+        pwa: null
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('bundleSizeBudget-route-under-250kb-gzip fails when route exceeds 250KB', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.bundleSizeBudget-route-under-250kb-gzip'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.bundleSizeBudget': {
+        routeChunkKb: { gzip: 400, brotli: 320 },
+        sharedBaselineKb: { gzip: 80, brotli: 68 },
+        thirdPartyBudgetKb: 0,
+        perAssetCeilingKb: 50
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('imagePlan-formats-include-avif-or-webp fails when only JPEG is declared', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.imagePlan-formats-include-avif-or-webp'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.imageOptimizationPlan': {
+        formats: ['jpeg'],
+        breakpoints: [640, 750, 1080, 1920],
+        lcpCandidate: 'hero-portrait',
+        priorityComponents: [],
+        lazyComponents: [],
+        defaultSizes: '',
+        placeholder: 'empty'
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('fontPlan-display-swap-or-optional fails on `block`', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.fontPlan-display-swap-or-optional'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.fontOptimizationPlan': {
+        loader: 'next/font',
+        display: 'block',
+        preload: [],
+        subset: ['latin'],
+        variableAxes: [],
+        selfHosted: true,
+        thirdPartyAllow: []
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('fontPlan-self-hosted fails when selfHosted is false', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.fontPlan-self-hosted'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.fontOptimizationPlan': {
+        loader: 'next/font',
+        display: 'swap',
+        preload: [],
+        subset: ['latin'],
+        variableAxes: [],
+        selfHosted: false,
+        thirdPartyAllow: ['Google Fonts']
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('lazyLoad-references-real-components fails when a referenced id is missing from componentTree', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.lazyLoad-references-real-components'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...composed,
+      'performance.lazyLoadStrategy': {
+        'phantom-component': {
+          strategy: 'eager',
+          rootMargin: null,
+          reason: 'above-fold'
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('criticalRenderPath-lcp-anchor-matches-image-plan fails when anchors diverge', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.criticalRenderPath-lcp-anchor-matches-image-plan'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.criticalRenderPath': {
+        preload: [],
+        prefetch: [],
+        deferredScripts: [],
+        inlineCriticalCssKb: 8,
+        lcpAnchor: 'hero-title', // different from imagePlan lcpCandidate
+        renderBlocking: []
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('cacheStrategy-tri-tier-populated fails when the CDN tier is missing', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.cacheStrategy-tri-tier-populated'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'performance.cacheStrategy': {
+        // cdn missing
+        browser: { static: 'x', html: 'y' },
+        server: { revalidateSec: 60, isr: true }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('coreWebVitalsBudgets-mobile-lcp-good passes when LCP is exactly 2500ms (Good threshold)', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.coreWebVitalsBudgets-mobile-lcp-good'
+    );
+    const ok = {
+      ...goldenArch,
+      'performance.coreWebVitalsBudgets': {
+        pageType: 'marketing',
+        mobile: { lcpMs: 2500, inpMs: 200, cls: 0.1, ttfbMs: 800 },
+        desktop: { lcpMs: 2500, inpMs: 200, cls: 0.1, ttfbMs: 600 }
+      }
+    };
+    expect(inv!.detect(ok)).toBe(true);
+  });
+
+  it('fontPlan-display-swap-or-optional accepts `optional`', () => {
+    const inv = PERFORMANCE_INVARIANTS.find(
+      i => i.id === 'performance.fontPlan-display-swap-or-optional'
+    );
+    const ok = {
+      ...goldenArch,
+      'performance.fontOptimizationPlan': {
+        loader: 'next/font',
+        display: 'optional',
+        preload: [],
+        subset: ['latin'],
+        variableAxes: [],
+        selfHosted: true,
+        thirdPartyAllow: []
+      }
+    };
+    expect(inv!.detect(ok)).toBe(true);
+  });
+});

--- a/packages/performance-architect/tests/run.test.ts
+++ b/packages/performance-architect/tests/run.test.ts
@@ -1,0 +1,252 @@
+/**
+ * `run()` tests — verifies the runtime pipeline:
+ *
+ *   - happy path returns a well-formed ArchitectOutput
+ *   - idempotency: same input → equivalent output
+ *   - re-runs REPLACE owned fields (do not append)
+ *   - dependency declaration on output (depends on frontend)
+ *   - failure modes (spawn failure, validation failure)
+ *   - reviewer feedback is plumbed through
+ *   - spend telemetry comes from the spawner, not the assistant
+ *   - upstream Frontend output is plumbed into the user prompt
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { PERFORMANCE_ARCHITECT_NAME, PerformanceArchitect } from '../src/architect.js';
+import { PERFORMANCE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runPerformanceArchitect } from '../src/run.js';
+import { buildPerformanceSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runPerformanceArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('performance');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    for (const k of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildPerformanceSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runPerformanceArchitect(input, {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runPerformanceArchitect(input, {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runPerformanceArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runPerformanceArchitect(input, {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    const b = await runPerformanceArchitect(input, {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runPerformanceArchitect(input, {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    const r2 = await runPerformanceArchitect(input, {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(
+      PERFORMANCE_OWNED_FIELD_KEYS.length
+    );
+  });
+});
+
+describe('runPerformanceArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"performance"}');
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runPerformanceArchitect — dependency declaration', () => {
+  it('performance declares Frontend as an upstream architect-meta dependency', () => {
+    const a = new PerformanceArchitect();
+    expect(a.sectionContract.architectMeta.dependsOn).toEqual(['frontend']);
+  });
+
+  it('performance output reports zero per-ticket sibling dependencies on the golden fixture', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runPerformanceArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildPerformanceSystemPrompt(),
+      architectName: PERFORMANCE_ARCHITECT_NAME
+    });
+    // Per-ticket sibling deps (`output.dependencies`) is a separate
+    // concept from architect-meta `dependsOn`. The hero widget has no
+    // sibling ticket prerequisites.
+    expect(out.dependencies).toEqual([]);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-001');
+  });
+
+  it('serialises the designVersion tokens', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('color.brand.primary');
+    expect(p).toContain('#0f3057');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('includes the upstream Frontend output (componentTree + framework)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('frontend.componentTree');
+    expect(p).toContain('frontend.framework');
+    expect(p).toContain('hero-portrait');
+    expect(p).toContain('hero-cta-primary');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'tighten LCP target', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('tighten LCP target');
+  });
+});
+
+describe('PerformanceArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new PerformanceArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('performance');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/performance-architect/tests/system-prompt.test.ts
+++ b/packages/performance-architect/tests/system-prompt.test.ts
@@ -1,0 +1,144 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b):
+ *
+ *   - Parses cleanly as text (non-empty, no obvious corruption).
+ *   - References every declared owned field at least once.
+ *   - Contains the standard architect-output JSON schema instruction.
+ *   - Under a reasonable size (token budget proxy).
+ *   - Idempotent (pure function).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { PERFORMANCE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildPerformanceSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildPerformanceSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildPerformanceSystemPrompt();
+    const p2 = buildPerformanceSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Performance Architect");
+  });
+
+  it('contains the Locked stack section anchoring Core Web Vitals + Lighthouse', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('LCP');
+    expect(p).toContain('INP');
+    expect(p).toContain('CLS');
+    expect(p).toContain('Lighthouse');
+  });
+
+  it('declares the CWV "Good" thresholds explicitly', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('2.5s');
+    expect(p).toContain('200ms');
+    expect(p).toContain('0.1');
+  });
+
+  it('declares the Lighthouse floors (90/95/95/90)', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('≥ 90');
+    expect(p).toContain('≥ 95');
+  });
+
+  it('declares the bundle budget defaults (130 / 170 / 250 KB gzip)', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('130KB');
+    expect(p).toContain('170KB');
+    expect(p).toContain('250KB');
+  });
+
+  it('declares the next/image + next/font locked stack', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('next/image');
+    expect(p).toContain('next/font');
+    expect(p).toContain('AVIF');
+    expect(p).toContain('WebP');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('declares the Frontend upstream dependency in the Input format section', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Input format');
+    expect(p).toContain('upstream.outputs.frontend');
+    expect(p).toContain('frontend.componentTree');
+    expect(p).toContain('frontend.framework');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildPerformanceSystemPrompt();
+    for (const key of PERFORMANCE_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('LCP candidate');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('performance.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildPerformanceSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `performance.*` owned namespace', () => {
+    const p = buildPerformanceSystemPrompt();
+    // The prompt references `frontend.*` fields as INPUT, so those are
+    // allowed. We reject other architects' owned-output fields appearing
+    // as if they were Performance's to write.
+    const foreignOwnedPrefixes = [
+      'backend.apiShape',
+      'database.schemaDDL',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape',
+      'a11y.wcagLevel'
+    ];
+    for (const prefix of foreignOwnedPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 20k chars)', () => {
+    // Token estimate: ~4 chars per token, so 20k chars ≈ 5000 tokens.
+    const p = buildPerformanceSystemPrompt();
+    expect(p.length).toBeLessThan(20_000);
+  });
+});

--- a/packages/performance-architect/tests/validation.test.ts
+++ b/packages/performance-architect/tests/validation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { PERFORMANCE_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('performance');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, PERFORMANCE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, PERFORMANCE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', PERFORMANCE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', PERFORMANCE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', PERFORMANCE_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"performance"}',
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['performance.coreWebVitalsBudgets'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'frontend.componentTree': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence (too high)', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      PERFORMANCE_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(
+        JSON.stringify(variant),
+        PERFORMANCE_OWNED_FIELD_KEYS
+      );
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/performance-architect/tsconfig.build.json
+++ b/packages/performance-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/performance-architect/tsconfig.json
+++ b/packages/performance-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/performance-architect/vitest.config.ts
+++ b/packages/performance-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2240,6 +2240,25 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/performance-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/playwright-config:
     dependencies:
       '@playwright/test':


### PR DESCRIPTION
## Summary

Architect #6 of 17 in CAIA's EA fan-out — **Performance Architect**. Senior frontend performance engineer focused on Core Web Vitals (LCP/INP/CLS), Lighthouse budgets, bundle analysis, and image/font optimization.

Fresh build from the Frontend Architect template (PR #537 — merged). Mirrors the structural pattern established by Frontend (#1), SEO (#4), A11y (#5), Database (#3), Backend (#2).

## What it owns — `performance.*` slice of `tickets.architecture`

| Field | Description |
| --- | --- |
| `coreWebVitalsBudgets` | LCP / INP / CLS / TTFB targets, mobile + desktop |
| `bundleSizeBudget` | gzip + brotli, page-type aware (130 / 170 / 250 KB) |
| `imageOptimizationPlan` | AVIF→WebP→fallback, breakpoints, LCP candidate |
| `fontOptimizationPlan` | next/font swap + preload + subset + self-host |
| `lazyLoadStrategy` | per-component eager/lazy/dynamic decisions |
| `cacheStrategy` | CDN + browser + server, three tiers |
| `criticalRenderPath` | preload, defer, inline-CSS, LCP anchor |
| `lighthouseBudgets` | Perf ≥ 90, SEO ≥ 95, A11y ≥ 95, BP ≥ 90 |

## Interface — implements `SpecialistArchitect` from `@caia/architect-kit`

- `name = 'performance'`
- `dependsOn = ['frontend']` (reads `componentTree` + `tokens` + `framework`)
- `precedenceLevel = 5` (above Frontend #14, below Security/DevOps/A11y/SEO)
- `runtimeModel = 'sonnet'`
- `tools = []` for V1; future Lighthouse-CI MCP planned
- Applies to Page, Widget, Story, Form, List ticket types

## What it does NOT do

No component code (Frontend Architect's job — merged PR #537). DOES specify the exact perf budgets the build must enforce.

## Test coverage — 156 vitest tests across 7 files

Well above the 30-test floor from the task brief:

- **architect.test.ts** (13) — interface compliance with `SpecialistArchitect`
- **contract.test.ts** (35) — contract structural + registration disjointness + apply predicate
- **system-prompt.test.ts** (17) — every owned field referenced + locked stack + CWV / Lighthouse floors
- **validation.test.ts** (19) — every documented error class
- **run.test.ts** (21) — happy path, idempotency, failure modes, dependency declaration, user-prompt projection
- **invariants.test.ts** (24) — 12 cross-architect invariants + structural + locked constants + corruption variants
- **golden/golden.test.ts** (27) — prakash-tiwari Artist hero bio Widget ticket + **page-type-aware CWV reasonableness** (verifies article/story page LCP target ≤ 2.5s — the canonical task-brief assertion)

## Quality gates

- `pnpm typecheck` — clean
- `pnpm build` — clean
- `pnpm lint` — clean
- `pnpm test` — **156/156 pass**

## Reuse

- `@caia/architect-kit` (workspace) — `SpecialistArchitect`, `ArchitectRegistry`, `CANONICAL_PRECEDENCE_LADDER`, `BaseArchitect`
- `@chiefaia/claude-spawner` (workspace) — subscription-only, no API-key billing
- `@caia/frontend-architect` template structure (verbatim file layout)

## Refs

- `research/17_architect_framework_spec_2026.md` §2.6
- `agent-memory/project_caia_17_architects.md` #6