### PR TITLE
feat(@caia/analytics-architect): ship architect #8 of 17 — Analytics specialist

### DIFF
--- a/packages/analytics-architect/README.md
+++ b/packages/analytics-architect/README.md
@@ -1,0 +1,67 @@
+# @caia/analytics-architect
+
+Architect #8 of CAIA's 17-architect EA fan-out. Senior analytics engineer focused on **privacy-compliant tracking**, cookieless analytics, event-taxonomy design, and consent gating.
+
+## What it owns
+
+`analytics.*` slice of the `tickets.architecture` JSONB column:
+
+- `analytics.provider` — analytics vendor stack (Plausible / GA4 / PostHog / customer's choice). Default: Plausible (cookieless, no-consent) + GA4 (consent-gated).
+- `analytics.eventTaxonomy` — typed event names + payload schemas keyed by stable IDs, with explicit no-PII attestation per event.
+- `analytics.userIdentificationStrategy` — anonymous / pseudonymous / authenticated tier policy; how userId/sessionId derive; identity-stitching rules.
+- `analytics.funnelDefinitions` — named conversion funnels (sequences of event IDs) for the EA Reviewer + dashboards.
+- `analytics.consentMode` — Google Consent Mode v2 / IAB TCF binding + default state (deny until granted).
+- `analytics.consentGatingRules` — per-event-category consent prerequisite map (analytics_storage, ad_storage, functionality_storage, …).
+- `analytics.noPiiRule` — explicit attestation + per-payload regex assertions that no PII (email/phone/name/IP/precise-geo) appears in any event.
+- `analytics.privacyCompliance` — GDPR / CCPA / cookie-consent posture, DNT/GPC respect, EU/CA data-residency notes.
+- `analytics.conversionGoals` — primary + secondary metric IDs the A/B Testing Architect consumes downstream.
+- `analytics.dashboardLinks` — Plausible/GA4/PostHog dashboard URLs scoped per environment.
+- `analytics.dataTrackAttributes` — `data-track-*` HTML attribute conventions for the Frontend Architect's components.
+- `analytics.sessionStrategy` — session-stitching window, identity tier, cross-domain rules.
+- `analytics.customDimensions` — per-tenant custom dimensions / event params (tenantId, planTier, persona, locale).
+- `analytics.dataResidencyRequirements` — EU/CA/US residency selection per provider, sub-processor list, transfer mechanism.
+
+## What it does NOT do
+
+**No component code.** Frontend Architect writes JSX. This architect specifies which events fire from which components and what they capture. **No backend logic.** Backend Architect owns API endpoints; Analytics declares what is tracked, not how it's persisted. **No funnels SQL.** Funnel definitions are stable IDs the dashboarding tier interprets. Out-of-namespace writes are rejected.
+
+## How it runs
+
+Implements `SpecialistArchitect` (per spec `research/17_architect_framework_spec_2026.md` §1 + §2.8). **Wave 2** — depends on Frontend Architect's `componentTree` + `interactionStates` to know which surfaces should emit events. Sonnet by default. Tools empty for V1.
+
+The architect leverages patterns from the existing `@chiefaia/analytics` wrapper (Plausible + GA4 + consent banner) — see V2 §2 "wrap" verdict. The wrapper is the runtime; this architect is the design surface.
+
+## Quick start
+
+```ts
+import { AnalyticsArchitect, AnalyticsArchitectContract } from '@caia/analytics-architect';
+
+const architect = new AnalyticsArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: { frontend: frontendOutput } }, // REQUIRED for analytics
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (≥30 tests including golden privacy-compliance test)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite includes interface compliance, contract structural checks, registration disjointness, output validation, run() idempotency, dependency declaration (`depends on frontend`), cross-architect invariants, and an end-to-end **golden privacy-compliance test** that locks the no-PII-without-consent invariant for a known prakash-tiwari Widget ticket.
+
+## Notes
+
+- Architect name is `"analytics"`. The owned-field namespace is `analytics.*` (matches the canonical precedence ladder entry).
+- Precedence rank **10** — analytics is compliance-sensitive (consent gating, residency). Above observability (#9), below API gateway (#8) / observability operability. Below Security (#1) / DevOps (#2) / A11y (#3) / SEO (#4) / Perf (#5) / A/B Testing (#6) / Feature Flags (#7).
+- V1 ships with **zero tools**. The architect reads the upstream Frontend componentTree directly and emits per-component event specifications. A future `caia-event-schema-validator` MCP will let the architect statically verify event payloads against a typed registry.
+- **Privacy by default.** Every event must declare a `consent` prerequisite (`none` only for cookieless / first-party-only providers like Plausible). PII fields (email, phone, name, IP, precise-geo) are forbidden in event payloads unless `consent.level === 'authenticated'` AND the field is `consent.fields[<field>] === true`.

--- a/packages/analytics-architect/eslint.config.cjs
+++ b/packages/analytics-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on accessibility-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/analytics-architect/package.json
+++ b/packages/analytics-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/analytics-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Analytics Architect — architect #8 of CAIA's 17-architect EA fan-out. Owns the `analytics.*` slice of `tickets.architecture` (provider, eventTaxonomy, userIdentificationStrategy, funnelDefinitions, consentMode, consentGatingRules, noPiiRule, privacyCompliance, conversionGoals, dashboardLinks, dataTrackAttributes, sessionStrategy, customDimensions, dataResidencyRequirements). Senior analytics engineer focused on privacy-compliant tracking, cookieless analytics, and event-taxonomy design. Produces per-ticket analytics specs. Does NOT write component code or backend logic. DOES specify which events fire from each component and what they capture. Depends on Frontend Architect's `componentTree` + `interactionStates`. Spawns Claude via @chiefaia/claude-spawner (subscription-only).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/analytics-architect/src/architect.ts
+++ b/packages/analytics-architect/src/architect.ts
@@ -1,0 +1,80 @@
+/**
+ * `AnalyticsArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (spec §2.8 — Analytics reads the
+ *     Frontend upstream output + designVersion directly; no external
+ *     tooling. A future `caia-event-schema-validator` MCP tool will
+ *     let the architect statically verify payloads against a typed
+ *     registry.).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from `@caia/architect-kit`
+ * because the dispatcher's registration path uses structural typing.
+ * The interface is satisfied structurally. When the dispatcher switches
+ * to `instanceof BaseArchitect` checks, this class will swap to
+ * `extends BaseArchitect` — strict-additive at that point.
+ */
+
+import { AnalyticsArchitectContract } from './contract.js';
+import { runAnalyticsArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildAnalyticsSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/analytics-architect` minus the suffix. */
+export const ANALYTICS_ARCHITECT_NAME = 'analytics' as const;
+
+/** V1: no architect-specific tools. Reads Frontend upstream + designVersion directly. */
+export const ANALYTICS_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface AnalyticsArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class AnalyticsArchitect implements SpecialistArchitect {
+  readonly name = ANALYTICS_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = AnalyticsArchitectContract;
+  readonly tools: readonly ToolDefinition[] = ANALYTICS_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: AnalyticsArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildAnalyticsSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runAnalyticsArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/analytics-architect/src/contract.ts
+++ b/packages/analytics-architect/src/contract.ts
@@ -1,0 +1,213 @@
+/**
+ * `AnalyticsArchitectContract` — the canonical owned-fields declaration
+ * for architect #8 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.8 (Analytics Architect owns `analytics.*`)
+ *   - task brief (analyticsProvider, eventTaxonomy, userIdentificationStrategy,
+ *     funnelDefinitions, consentGatingRules, customDimensions,
+ *     dataResidencyRequirements, privacyCompliance)
+ *
+ * The reconciled superset below combines both the spec §2.8 fields and
+ * the task brief's per-ticket-structure fields. Every field is
+ * `required: true` because downstream consumers (A/B Testing reads
+ * `eventTaxonomy` + `conversionGoals`; EA Reviewer reads `noPiiRule`
+ * + `consentGatingRules` for the privacy-compliance lens) cascade on
+ * missing fields.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. The chosen keys all live under the `analytics.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const ANALYTICS_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'analytics.provider':
+    'Default to {"primary":"plausible","secondary":"ga4"}. Plausible is cookieless (no consent gate); GA4 is consent-gated. Customer-chosen alternatives (PostHog, Mixpanel, Snowplow) override.',
+  'analytics.eventTaxonomy':
+    'For every interactive component in Frontend `interactionStates`, emit one event entry with {eventId, eventName, trigger, payloadSchema, consentRequired, noPii: true}. Stable snake_case event names.',
+  'analytics.userIdentificationStrategy':
+    'Default: anonymous (no userId fields). Pseudonymous (clientId hash) requires consent. Authenticated (userId from auth) requires authenticated session AND explicit consent. Never derive userId from PII (email hash, phone hash).',
+  'analytics.funnelDefinitions':
+    'Named conversion funnels: ordered sequences of event IDs from `eventTaxonomy`. Every funnel step ID must exist in the taxonomy. Default to one signup/conversion funnel + one engagement funnel per Page.',
+  'analytics.consentMode':
+    'Google Consent Mode v2 with default = {analytics_storage: denied, ad_storage: denied, functionality_storage: granted, security_storage: granted}. Update on consent grant.',
+  'analytics.consentGatingRules':
+    'Per-event-category prerequisite map: {category: requiredConsent}. Default cookieless events require none; cross-session/identified events require analytics_storage=granted.',
+  'analytics.noPiiRule':
+    'Explicit attestation that NO PII fields (email, phone, name, IP, precise-geo, full-userAgent) appear in any event payload. Provide regex denylist + per-event audit notes.',
+  'analytics.privacyCompliance':
+    'Posture object: {gdpr, ccpa, cookieBanner, dntRespect, gpcRespect, dataMinimisation, retentionDays}. Default: GDPR-compliant, CCPA-compliant, DNT respected (auto-deny), GPC respected (auto-deny), 14-month max retention.',
+  'analytics.conversionGoals':
+    'Primary metric ID + secondary metric IDs. Each must be a valid eventId from `eventTaxonomy`. A/B Testing Architect reads these to pick the experiment primary metric.',
+  'analytics.dashboardLinks':
+    'Per-environment dashboard URLs for each provider in `provider`. Example: {plausible:"https://plausible.io/<site>", ga4:"https://analytics.google.com/analytics/web/#/p<id>"}. Use placeholders if not yet provisioned.',
+  'analytics.dataTrackAttributes':
+    'HTML attribute conventions for the Frontend Architect: which `data-track-*` attributes encode {event, props, payload}. Per-component map keyed by Frontend componentId.',
+  'analytics.sessionStrategy':
+    'Session-stitching: {windowMinutes, identityTier, crossDomain, crossDevice}. Default: 30-min idle window, anonymous tier, no cross-domain, no cross-device.',
+  'analytics.customDimensions':
+    'Per-tenant dimensions / event params: {tenantId, planTier, persona, locale}. These are NEVER PII. Locale capped at 2-letter region code.',
+  'analytics.dataResidencyRequirements':
+    'Per-provider residency selection: {plausible:"eu", ga4:"<region>", posthog:"eu"}. Plausible defaults EU. GA4 inherits tenant residency. Document sub-processors + transfer mechanism.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const ANALYTICS_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'analytics.provider',
+    description:
+      'Analytics vendor stack: primary + secondary providers. Default: Plausible (cookieless) + GA4 (consent-gated). PostHog/Mixpanel/Snowplow accepted on customer request.',
+    required: true
+  },
+  {
+    path: 'analytics.eventTaxonomy',
+    description:
+      'Typed event names + payload schemas keyed by stable IDs. One entry per event-firing surface in Frontend `componentTree`. Every entry declares consent prerequisite + no-PII attestation.',
+    required: true
+  },
+  {
+    path: 'analytics.userIdentificationStrategy',
+    description:
+      'Anonymous / pseudonymous / authenticated tier policy. How userId/sessionId derive. Identity-stitching rules. PII is NEVER hashed into a userId.',
+    required: true
+  },
+  {
+    path: 'analytics.funnelDefinitions',
+    description:
+      'Named conversion funnels — ordered sequences of event IDs from `eventTaxonomy`. Consumed by the EA Reviewer + dashboards. A/B Testing references these for primary-metric eligibility.',
+    required: true
+  },
+  {
+    path: 'analytics.consentMode',
+    description:
+      'Google Consent Mode v2 binding + IAB TCF mapping (when applicable). Default state and grant/deny update rules.',
+    required: true
+  },
+  {
+    path: 'analytics.consentGatingRules',
+    description:
+      'Per-event-category consent prerequisite map (analytics_storage, ad_storage, functionality_storage, security_storage). Cookieless events allow `none`.',
+    required: true
+  },
+  {
+    path: 'analytics.noPiiRule',
+    description:
+      'Explicit no-PII attestation: regex denylist for email/phone/name/IP/precise-geo + per-event audit notes. Verified by the EA Reviewer privacy lens.',
+    required: true
+  },
+  {
+    path: 'analytics.privacyCompliance',
+    description:
+      'GDPR / CCPA / cookie-consent posture + DNT/GPC respect + data-minimisation + retention days. Drives the consent banner + footer disclosure.',
+    required: true
+  },
+  {
+    path: 'analytics.conversionGoals',
+    description:
+      'Primary + secondary conversion metric IDs. A/B Testing Architect consumes these for experiment design. Each must be a valid eventId.',
+    required: true
+  },
+  {
+    path: 'analytics.dashboardLinks',
+    description:
+      'Per-environment dashboard URLs for each provider. Operator-facing; surfaces in the EA dashboard widget.',
+    required: true
+  },
+  {
+    path: 'analytics.dataTrackAttributes',
+    description:
+      'HTML `data-track-*` attribute conventions per Frontend componentId. Frontend coding worker emits these literally; runtime tracker reads them.',
+    required: true
+  },
+  {
+    path: 'analytics.sessionStrategy',
+    description:
+      'Session-stitching window + identity tier + cross-domain/device rules. Default: 30-min idle window, anonymous tier.',
+    required: true
+  },
+  {
+    path: 'analytics.customDimensions',
+    description:
+      'Per-tenant custom dimensions / event params (tenantId, planTier, persona, locale). NEVER PII.',
+    required: true
+  },
+  {
+    path: 'analytics.dataResidencyRequirements',
+    description:
+      'Per-provider residency selection (EU/CA/US) + sub-processor list + transfer mechanism (SCC, adequacy decision).',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const ANALYTICS_OWNED_FIELD_KEYS: readonly string[] = ANALYTICS_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.8 — Analytics runs on every ticket that produces UI (so it can
+ * spec the events that fire from interactive widgets). The set matches
+ * Frontend's `appliesPredicate` because Analytics is a per-UI
+ * specialisation downstream of Frontend.
+ */
+export function analyticsArchitectAppliesPredicate(ticket: Ticket): boolean {
+  return (
+    ticket.type === 'Page' ||
+    ticket.type === 'Widget' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List'
+  );
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * Analytics is a wave-2 architect — depends on Frontend's
+ * `componentTree` + `interactionStates`. Precedence rank 10 per the
+ * canonical ladder in `@caia/architect-kit` (analytics is
+ * compliance-sensitive because of consent gating). Above database (#11),
+ * backend (#12), aiml (#13), frontend (#14); below security (#1),
+ * devops (#2), a11y (#3), seo (#4), performance (#5), abTesting (#6),
+ * featureFlagging (#7), apiGateway (#8), observability (#9).
+ */
+export const ANALYTICS_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['frontend'],
+  precedenceLevel: 10,
+  fanoutPolicy: 'always',
+  appliesPredicate: analyticsArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const AnalyticsArchitectContract: ArchitectSectionContract = {
+  contractId: 'analytics-architect.v1',
+  architectName: 'analytics',
+  version: '0.1.0',
+  sections: ANALYTICS_OWNED_SECTIONS,
+  architectMeta: ANALYTICS_ARCHITECT_META
+};

--- a/packages/analytics-architect/src/index.ts
+++ b/packages/analytics-architect/src/index.ts
@@ -1,0 +1,95 @@
+/**
+ * @caia/analytics-architect — public surface.
+ *
+ * Architect #8 of CAIA's 17-architect EA fan-out. Senior analytics
+ * engineer focused on privacy-compliant tracking, cookieless analytics,
+ * event-taxonomy design, and consent gating. Wave-2 architect —
+ * depends on Frontend's `componentTree` + `interactionStates`.
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's default `registerWith()` helper
+ * to install the architect on a registry. The package does NOT
+ * self-register on import (registration is an explicit operator action
+ * that the Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { AnalyticsArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  AnalyticsArchitect,
+  ANALYTICS_ARCHITECT_NAME,
+  ANALYTICS_ARCHITECT_TOOLS
+} from './architect.js';
+export type { AnalyticsArchitectConfig } from './architect.js';
+
+export {
+  AnalyticsArchitectContract,
+  ANALYTICS_OWNED_SECTIONS,
+  ANALYTICS_OWNED_FIELD_KEYS,
+  ANALYTICS_FIELD_FIX_HINTS,
+  ANALYTICS_ARCHITECT_META,
+  analyticsArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildAnalyticsSystemPrompt } from './system-prompt.js';
+
+// Spawner — exposed so the EA Dispatcher (or tests) can inject a custom one.
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+// Run + validation — exposed for the conformance test suite.
+export { runAnalyticsArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+// Invariants — exposed for the EA Reviewer's registry.
+export { ANALYTICS_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+// Re-export the canonical kit types so consumers have a single import surface.
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh AnalyticsArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): AnalyticsArchitect {
+  const architect = new AnalyticsArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/analytics-architect/src/invariants.ts
+++ b/packages/analytics-architect/src/invariants.ts
@@ -1,0 +1,342 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The Reviewer applies a fixed set of cross-architect predicates after
+ * composition. This module enumerates Analytics's contributions so the
+ * Reviewer's `invariants-registry.ts` (which doesn't exist yet — sibling
+ * brief F2) can collect them at process boot.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'analytics.eventTaxonomy'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `analytics.*` path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path. This lets the
+ * same invariants run inside the Analytics package's own tests AND
+ * inside the Reviewer's post-composition pass.
+ *
+ * Cross-architect invariants (those that read fields owned by another
+ * architect) treat absent foreign data as "cannot verify" and pass
+ * trivially. The Reviewer's composed-output pass will exercise the
+ * real check; the per-architect test pass exercises only the local
+ * checks. This keeps unit tests on the Analytics output green even
+ * though frontend.* fields aren't present.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+/**
+ * Read a field from the architecture blob. Tries the flat dotted key
+ * first (matches `architectureFields` shape), then falls back to walking
+ * the nested object path (matches composed-architecture shape).
+ */
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+/**
+ * PII denylist — fields whose name OR value pattern suggests PII.
+ * Used by the no-PII-without-consent invariant. The system prompt
+ * carries the literal regex set; this invariant enforces field-name
+ * checks because most PII leaks come from naming a field `email` or
+ * `phoneNumber` and forgetting to redact.
+ */
+const PII_FIELD_NAME_PATTERNS: readonly RegExp[] = [
+  /email/i,
+  /phone/i,
+  /firstname|first_name/i,
+  /lastname|last_name/i,
+  /\bname\b/i,
+  /\bssn\b/i,
+  /passport/i,
+  /address/i,
+  /^ip$|ipv4|ipv6|ip_addr/i,
+  /precise.?geo|lat|lng|longitude|latitude/i,
+  /full.?user.?agent/i,
+  /credit.?card|card.?number/i,
+  /\bdob\b|date.?of.?birth/i
+];
+
+/**
+ * Check whether a payloadSchema (object map of fieldName → typeDescriptor)
+ * contains any field whose NAME matches a PII pattern.
+ */
+function payloadSchemaHasPii(schema: unknown): boolean {
+  if (typeof schema !== 'object' || schema === null) return false;
+  for (const key of Object.keys(schema as Record<string, unknown>)) {
+    for (const pat of PII_FIELD_NAME_PATTERNS) {
+      if (pat.test(key)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Analytics's contributed invariants. Listed in stable order.
+ */
+export const ANALYTICS_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'analytics.consentMode-default-denied',
+    contributor: 'analytics',
+    reads: ['analytics.consentMode'],
+    severity: 'fail',
+    description:
+      'Google Consent Mode v2 default state MUST deny `analytics_storage` until the user grants. Allowing analytics_storage by default violates GDPR + CCPA.',
+    detect(arch): boolean {
+      const mode = readField(arch, 'analytics.consentMode');
+      if (typeof mode !== 'object' || mode === null) return false;
+      const def = (mode as Record<string, unknown>).default;
+      if (typeof def !== 'object' || def === null) return false;
+      return (def as Record<string, unknown>).analytics_storage === 'denied';
+    }
+  },
+  {
+    id: 'analytics.noPii-attested',
+    contributor: 'analytics',
+    reads: ['analytics.noPiiRule'],
+    severity: 'fail',
+    description:
+      'The analytics output MUST explicitly attest noPiiRule.attested === true. Absent attestation blocks the EA Reviewer privacy lens.',
+    detect(arch): boolean {
+      const rule = readField(arch, 'analytics.noPiiRule');
+      if (typeof rule !== 'object' || rule === null) return false;
+      return (rule as Record<string, unknown>).attested === true;
+    }
+  },
+  {
+    id: 'analytics.eventTaxonomy-no-pii-payloads',
+    contributor: 'analytics',
+    reads: ['analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'No event in `analytics.eventTaxonomy` may carry PII field names (email, phone, name, ip, precise-geo, ...) in its payloadSchema. Hashed PII is still PII.',
+    detect(arch): boolean {
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof tax !== 'object' || tax === null) return true;
+      for (const entry of Object.values(tax as Record<string, unknown>)) {
+        if (typeof entry !== 'object' || entry === null) continue;
+        const schema = (entry as Record<string, unknown>).payloadSchema;
+        if (payloadSchemaHasPii(schema)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.eventTaxonomy-every-event-attests-noPii',
+    contributor: 'analytics',
+    reads: ['analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Every event in `analytics.eventTaxonomy` MUST set `noPii: true`. Per-event attestation is the contract the runtime tracker honours.',
+    detect(arch): boolean {
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof tax !== 'object' || tax === null) return true;
+      for (const entry of Object.values(tax as Record<string, unknown>)) {
+        if (typeof entry !== 'object' || entry === null) return false;
+        if ((entry as Record<string, unknown>).noPii !== true) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.eventTaxonomy-consentRequired-allowlist',
+    contributor: 'analytics',
+    reads: ['analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Every event must declare consentRequired ∈ {"none","analytics_storage","ad_storage","functionality_storage"}. Other values are not Consent-Mode-v2 buckets.',
+    detect(arch): boolean {
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof tax !== 'object' || tax === null) return true;
+      const allowed = new Set([
+        'none',
+        'analytics_storage',
+        'ad_storage',
+        'functionality_storage'
+      ]);
+      for (const entry of Object.values(tax as Record<string, unknown>)) {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const c = (entry as Record<string, unknown>).consentRequired;
+        if (typeof c !== 'string' || !allowed.has(c)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.funnelDefinitions-steps-exist-in-taxonomy',
+    contributor: 'analytics',
+    reads: ['analytics.funnelDefinitions', 'analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Every step ID in `analytics.funnelDefinitions[*].steps` must exist in `analytics.eventTaxonomy`. Dangling references break funnel analysis.',
+    detect(arch): boolean {
+      const funnels = readField(arch, 'analytics.funnelDefinitions');
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof funnels !== 'object' || funnels === null) return true;
+      if (typeof tax !== 'object' || tax === null) return false;
+      const eventIds = new Set(Object.keys(tax as Record<string, unknown>));
+      for (const f of Object.values(funnels as Record<string, unknown>)) {
+        if (typeof f !== 'object' || f === null) continue;
+        const steps = (f as Record<string, unknown>).steps;
+        if (!Array.isArray(steps)) return false;
+        for (const s of steps) {
+          if (typeof s !== 'string' || !eventIds.has(s)) return false;
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.conversionGoals-exist-in-taxonomy',
+    contributor: 'analytics',
+    reads: ['analytics.conversionGoals', 'analytics.eventTaxonomy'],
+    severity: 'fail',
+    description:
+      'Primary + secondary conversion goal IDs must exist in `analytics.eventTaxonomy`. Otherwise the A/B Testing Architect cannot bind to them.',
+    detect(arch): boolean {
+      const goals = readField(arch, 'analytics.conversionGoals');
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof goals !== 'object' || goals === null) return true;
+      if (typeof tax !== 'object' || tax === null) return false;
+      const eventIds = new Set(Object.keys(tax as Record<string, unknown>));
+      const g = goals as Record<string, unknown>;
+      if (typeof g.primary !== 'string' || !eventIds.has(g.primary)) return false;
+      const secondary = g.secondary;
+      if (!Array.isArray(secondary)) return true;
+      for (const s of secondary) {
+        if (typeof s !== 'string' || !eventIds.has(s)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.privacy-dnt-and-gpc-respected',
+    contributor: 'analytics',
+    reads: ['analytics.privacyCompliance'],
+    severity: 'fail',
+    description:
+      '`analytics.privacyCompliance` MUST set both dntRespect=true and gpcRespect=true. Auto-deny for DNT/GPC signals is non-negotiable.',
+    detect(arch): boolean {
+      const pc = readField(arch, 'analytics.privacyCompliance');
+      if (typeof pc !== 'object' || pc === null) return false;
+      const o = pc as Record<string, unknown>;
+      return o.dntRespect === true && o.gpcRespect === true;
+    }
+  },
+  {
+    id: 'analytics.privacy-retention-under-425d',
+    contributor: 'analytics',
+    reads: ['analytics.privacyCompliance'],
+    severity: 'fail',
+    description:
+      'Retention ceiling is 14 months (≈425 days). Higher values violate GDPR data-minimisation defaults.',
+    detect(arch): boolean {
+      const pc = readField(arch, 'analytics.privacyCompliance');
+      if (typeof pc !== 'object' || pc === null) return true;
+      const r = (pc as Record<string, unknown>).retentionDays;
+      if (typeof r !== 'number') return false;
+      return r <= 425;
+    }
+  },
+  {
+    id: 'analytics.dataTrackAttributes-cover-interactive-components',
+    contributor: 'analytics',
+    reads: ['analytics.dataTrackAttributes', 'frontend.interactionStates'],
+    severity: 'fail',
+    description:
+      'Every interactive component declared in Frontend `interactionStates` must have a matching entry in `analytics.dataTrackAttributes`. Trivially passes if the Frontend output is absent (cross-arch invariant — Reviewer runs against the composed output).',
+    detect(arch): boolean {
+      const attrs = readField(arch, 'analytics.dataTrackAttributes');
+      const interactives = readField(arch, 'frontend.interactionStates');
+      if (typeof interactives !== 'object' || interactives === null) return true;
+      if (typeof attrs !== 'object' || attrs === null) return false;
+      const attrKeys = new Set(Object.keys(attrs as Record<string, unknown>));
+      for (const compId of Object.keys(interactives as Record<string, unknown>)) {
+        if (!attrKeys.has(compId)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.eventTaxonomy-covers-interactive-components',
+    contributor: 'analytics',
+    reads: ['analytics.eventTaxonomy', 'analytics.dataTrackAttributes', 'frontend.interactionStates'],
+    severity: 'advisory',
+    description:
+      'Every dataTrackAttributes entry should reference an eventId that exists in eventTaxonomy. Mismatches mean the runtime tracker dispatches an unknown event.',
+    detect(arch): boolean {
+      const attrs = readField(arch, 'analytics.dataTrackAttributes');
+      const tax = readField(arch, 'analytics.eventTaxonomy');
+      if (typeof attrs !== 'object' || attrs === null) return true;
+      if (typeof tax !== 'object' || tax === null) return false;
+      const eventIds = new Set(Object.keys(tax as Record<string, unknown>));
+      for (const entry of Object.values(attrs as Record<string, unknown>)) {
+        if (typeof entry !== 'object' || entry === null) continue;
+        const ref = (entry as Record<string, unknown>)['data-track-event'];
+        if (typeof ref !== 'string') continue;
+        if (!eventIds.has(ref)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.customDimensions-no-pii',
+    contributor: 'analytics',
+    reads: ['analytics.customDimensions'],
+    severity: 'fail',
+    description:
+      'Every entry in `analytics.customDimensions` MUST set `pii: false`. Custom dimensions become permanent per-user attributes; PII contamination is irreversible.',
+    detect(arch): boolean {
+      const dims = readField(arch, 'analytics.customDimensions');
+      if (typeof dims !== 'object' || dims === null) return true;
+      for (const entry of Object.values(dims as Record<string, unknown>)) {
+        if (typeof entry !== 'object' || entry === null) return false;
+        if ((entry as Record<string, unknown>).pii !== false) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'analytics.userId-strategy-default-anonymous',
+    contributor: 'analytics',
+    reads: ['analytics.userIdentificationStrategy'],
+    severity: 'fail',
+    description:
+      'Default identification tier MUST be "anonymous". Pseudonymous/authenticated tiers require explicit consent grants.',
+    detect(arch): boolean {
+      const s = readField(arch, 'analytics.userIdentificationStrategy');
+      if (typeof s !== 'object' || s === null) return false;
+      return (s as Record<string, unknown>).defaultTier === 'anonymous';
+    }
+  }
+];

--- a/packages/analytics-architect/src/run.ts
+++ b/packages/analytics-architect/src/run.ts
@@ -1,0 +1,144 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input
+ *      (including the upstream Frontend output that Analytics depends on).
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ *
+ * Dependency note: Analytics depends on Frontend's `componentTree` +
+ * `interactionStates`. If `upstream.outputs.frontend` is absent we still
+ * call the spawner — the system prompt instructs the model to emit best-
+ * effort specs and surface the missing-upstream condition under `risks[]`.
+ * The contract declaration (`dependsOn: ['frontend']`) plus the EA
+ * Dispatcher's wave scheduler should make this case rare in practice.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { ANALYTICS_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them — and Analytics is the LAST
+ * architect that should ever see PII in a prompt body.
+ *
+ * The full `upstream.outputs` is passed through — Analytics reads
+ * `upstream.outputs.frontend.architectureFields["frontend.componentTree"]`
+ * and `["frontend.interactionStates"]` to know which surfaces emit
+ * events. The downstream Frontend output may be large; we accept the
+ * cost because Analytics needs every interactive-component id.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture,
+      compliance: input.tenantContext.compliance ?? null
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * The runtime entry. Pure aside from the spawner call.
+ */
+export async function runAnalyticsArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, ANALYTICS_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  // Idempotency: the architect output OWNS its fields. We do NOT merge
+  // with anything else here — composition happens in the Dispatcher
+  // (spec §3.5). Architects always emit the full set of their owned
+  // fields fresh.
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName, // force-correct in case model echoed wrong
+    spend // overwrite — assistant cannot know real spend
+  };
+}

--- a/packages/analytics-architect/src/spawner.ts
+++ b/packages/analytics-architect/src/spawner.ts
@@ -1,0 +1,163 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * The real spawner lives in `@chiefaia/claude-spawner` (subscription-only,
+ * never sets ANTHROPIC_API_KEY — see that package's file-level comment).
+ * This module:
+ *
+ *   - Defines the `ArchitectSpawnerFn` type — the seam every architect's
+ *     run() consumes.
+ *   - Provides `createDefaultSpawner()` — wires up the real
+ *     `spawnClaude` with the appropriate model + timeout + system prompt.
+ *
+ * Per spec §4 the EA Dispatcher itself runs in the operator's existing
+ * orchestrator process; only the architect subagent spawns issue LLM
+ * calls. This module is the per-architect spawn surface.
+ *
+ * Mirrors `@caia/frontend-architect`'s spawner.ts verbatim — the shape
+ * is intentionally identical across all 17 architects so the Dispatcher
+ * can inject a single shared spawner factory.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+/**
+ * Inputs to a single spawn — system prompt + user prompt + budget.
+ */
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+/**
+ * Output of a single spawn — the raw assistant text plus telemetry.
+ * Parsing into a structured `ArchitectOutput` happens in `run()`, not
+ * here, so the spawner stays generic across architects.
+ */
+export interface ArchitectSpawnOutput {
+  /** The assistant's final message — expected to be a JSON-shaped string. */
+  text: string;
+  /** Best-effort token + cost telemetry from the envelope. */
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  /** Echoed back from input. */
+  model: string;
+  /** True iff the spawn succeeded and the envelope was parsed cleanly. */
+  ok: boolean;
+  /** Diagnostic when `ok=false`. */
+  diagnostic: string | null;
+}
+
+/**
+ * The seam every architect's `run()` consumes. Inject a fake in tests.
+ */
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+/**
+ * Map the architect-budget model preference to the `claude` binary's
+ * `--model` flag value. The mapping mirrors what local-llm-router uses
+ * elsewhere in the monorepo.
+ */
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+/**
+ * Build the canonical user-message body. The system prompt is fed as
+ * the first user-message paragraph (rather than via `claude`'s
+ * `--system` flag) — keeps the spawner surface narrow and lets the
+ * test seam see everything in one string.
+ */
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+/**
+ * Wire the real `spawnClaude` into an `ArchitectSpawnerFn`. Used by
+ * `AnalyticsArchitect` when no spawner is injected.
+ */
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/analytics-architect/src/system-prompt.ts
+++ b/packages/analytics-architect/src/system-prompt.ts
@@ -1,0 +1,260 @@
+/**
+ * The Analytics Architect's system prompt — a pure function returning
+ * a static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack (Plausible + GA4 default; Consent Mode v2; no-PII)
+ *   3. Input format (depends on Frontend upstream)
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `analytics.*` field name appears
+ * at least once in the body. Keep that invariant true if you add fields.
+ */
+
+import { ANALYTICS_OWNED_FIELD_KEYS } from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildAnalyticsSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Analytics Architect. You are a senior analytics engineer
+focused on privacy-compliant tracking, cookieless analytics, event-
+taxonomy design, and consent gating.
+
+You produce per-ticket analytics specs. You DO NOT write component code
+or backend logic. You DO specify exactly what events fire from each
+component and what they capture, plus the privacy + consent posture
+that wraps every event.
+
+Your output is consumed by (a) the Frontend coding worker that wires up
+\`data-track-*\` attributes and dispatches events, (b) the EA Reviewer's
+privacy-compliance lens (no-PII-without-consent invariant), (c) the A/B
+Testing Architect (reads \`conversionGoals\` + \`eventTaxonomy\`), and (d)
+the dashboards keyed by your provider URLs. Any field outside the
+\`analytics.*\` namespace is another architect's territory and will be
+rejected.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Default providers**: Plausible (cookieless, consent-free, EU-hosted)
+  for baseline pageviews + Core Web Vitals; GA4 (consent-gated) for
+  deep events, funnels, attribution. Customer-chosen alternatives
+  (PostHog, Mixpanel, Snowplow) supersede the default.
+- **Consent gate**: Google Consent Mode v2. Default state = all storage
+  buckets denied. Transition to granted only on explicit user consent.
+  IAB TCF v2.2 mapping where applicable.
+- **DNT + GPC**: \`navigator.doNotTrack === '1'\` OR
+  \`navigator.globalPrivacyControl === true\` ⇒ auto-deny, no banner,
+  no GA4 load.
+- **No-PII rule**: event payloads NEVER contain email, phone, name, IP,
+  precise-geo, or full user-agent. \`userId\` is anonymous or pseudonymous
+  unless the session is authenticated AND the user has granted
+  \`analytics_storage\`. PII fields hashed into \`userId\` are still PII.
+- **Data minimisation**: each event captures the minimum payload needed
+  to answer a stated business question. No "log everything" patterns.
+- **Retention**: 14-month default ceiling (GDPR data-minimisation).
+  Customer can lower; cannot raise without operator review.
+- **Residency**: EU-hosted by default (Plausible EU, GA4 \`europe-west\`).
+  Override per tenant compliance.dataResidency.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."] },
+  "businessPlan": { "planId": "...", "ventureName": "...",
+                    "goals": [...], "brandVoice": "..." },
+  "designVersion": { "designVersionId": "...",
+                     "tokens": {...},
+                     "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "...",
+                     "compliance": { "dataResidency": "EU|US|CA|..." } },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "frontend": {
+      "architectureFields": {
+        "frontend.componentTree": [...],
+        "frontend.interactionStates": {...},
+        "frontend.tokens": {...},
+        ...
+      }
+    }
+  } }
+}
+\`\`\`
+
+You MUST read \`upstream.outputs.frontend.architectureFields\` first. The
+\`frontend.componentTree\` is your authoritative list of components. The
+\`frontend.interactionStates\` enumerates the interactive ones — these
+are the surfaces that emit events. Read the businessPlan's \`goals\` +
+\`growth strategy\` notes to pick conversion-worthy events from the
+broader event surface. If \`upstream.outputs.frontend\` is absent, list
+"frontend upstream missing" under \`risks[]\` and emit best-effort
+specs from the design + ticket alone.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "analytics",
+  "architectureFields": {
+${ANALYTICS_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "costUsd": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`analytics.provider\` — \`{"primary":"plausible","secondary":"ga4","cookielessBaseline":true,"consentGatedAdvanced":true}\`. Override on explicit customer ask (PostHog, Mixpanel, Snowplow).
+- \`analytics.eventTaxonomy\` — \`{"<eventId>": {"eventName":"snake_case","trigger":"componentId:event","payloadSchema":{<field>:<type>},"consentRequired":"none"|"analytics_storage"|"ad_storage","noPii":true,"category":"page|engagement|conversion|content|commerce|community|cta"}}\`. ONE entry per event-firing surface in Frontend \`interactionStates\`. \`noPii\` MUST be \`true\` for every entry; payloads with PII fields are rejected.
+- \`analytics.userIdentificationStrategy\` — \`{"defaultTier":"anonymous","tiers":{"anonymous":{"idSource":"none","scope":"session"},"pseudonymous":{"idSource":"clientId","consentRequired":"analytics_storage","scope":"persistent-30d"},"authenticated":{"idSource":"authUserId","consentRequired":"analytics_storage","scope":"persistent","piiAllowedFields":[]}}}\`. \`piiAllowedFields\` MUST be empty by default.
+- \`analytics.funnelDefinitions\` — \`{"<funnelId>": {"name":"...","steps":["<eventId>","<eventId>",...],"window":"24h|7d|30d"}}\`. Every step must exist in \`eventTaxonomy\`. Default to ONE conversion funnel per Page that has a CTA.
+- \`analytics.consentMode\` — \`{"version":"v2","default":{"analytics_storage":"denied","ad_storage":"denied","ad_user_data":"denied","ad_personalization":"denied","functionality_storage":"granted","security_storage":"granted"},"updatePolicy":"on-user-grant","iabTcf":false}\`. \`iabTcf:true\` only for AdTech-heavy customers.
+- \`analytics.consentGatingRules\` — \`{"page":"none","engagement":"none","conversion":"analytics_storage","content":"none","commerce":"analytics_storage","community":"analytics_storage","cta":"none"}\`. Customer can tighten; cannot loosen.
+- \`analytics.noPiiRule\` — \`{"attested":true,"denylistRegex":["@\\\\S+\\\\.\\\\S+","\\\\+?\\\\d{7,}","ip:.*","geo:precise","userAgent:full"],"perEventNotes":"each event payload audited against denylist before emit"}\`.
+- \`analytics.privacyCompliance\` — \`{"gdpr":true,"ccpa":true,"cookieBanner":true,"dntRespect":true,"gpcRespect":true,"dataMinimisation":true,"retentionDays":425,"subjectAccessRequestEndpoint":"/api/privacy/sar"}\`. retentionDays MUST be ≤ 425 (≈14 months).
+- \`analytics.conversionGoals\` — \`{"primary":"<eventId>","secondary":["<eventId>","<eventId>"]}\`. Each ID must exist in \`eventTaxonomy\`.
+- \`analytics.dashboardLinks\` — \`{"plausible":"https://plausible.io/<site>","ga4":"https://analytics.google.com/analytics/web/#/p<propertyId>","posthog":"<url>"}\`. Use placeholders if not yet provisioned (e.g. \`"https://plausible.io/<tenant-slug>"\`).
+- \`analytics.dataTrackAttributes\` — \`{"<componentId>": {"data-track-event":"<eventId>","data-track-payload":"<JSON-encoded keys>"}}\`. ONE entry per interactive component.
+- \`analytics.sessionStrategy\` — \`{"windowMinutes":30,"identityTier":"anonymous","crossDomain":false,"crossDevice":false,"reattributionWindow":"24h"}\`. Defaults; override on customer request.
+- \`analytics.customDimensions\` — \`{"tenantId":{"scope":"event-or-user","pii":false},"planTier":{"scope":"user","pii":false},"persona":{"scope":"user","pii":false},"locale":{"scope":"user","pii":false}}\`. NEVER PII.
+- \`analytics.dataResidencyRequirements\` — \`{"plausible":{"region":"eu","subProcessors":["plausible-eu"]},"ga4":{"region":"<tenant-region>","subProcessors":["google-llc"],"transferMechanism":"SCC|adequacy"}}\`. Inherit from \`tenantContext.compliance.dataResidency\` when set.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Cookieless first.** Plausible runs immediately on every page load —
+  no consent needed under GDPR (no PII, no fingerprinting, no
+  cross-session identity). GA4 (and any other cookie-based provider)
+  loads only AFTER consent grant.
+- **Event surface = interactive surface.** Every entry in
+  \`frontend.interactionStates\` gets one taxonomy entry. Non-interactive
+  components (heading, image, layout) get NO taxonomy entries —
+  page-level pageview suffices.
+- **Stable IDs over labels.** Event IDs are snake_case
+  (\`cta_clicked\`, \`form_submitted\`, \`lesson_started\`). Display labels
+  live in the dashboard, never in the taxonomy.
+- **Consent prerequisites by category.** Page + engagement events fire
+  cookielessly. Conversion + commerce + community events require
+  \`analytics_storage\`. CTA clicks fire cookielessly (no identity needed
+  to count clicks).
+- **Funnels are sequences of event IDs.** Funnel definitions reference
+  taxonomy entries, never literal event names — keeps the taxonomy
+  the source of truth.
+- **PII denylist is a regex set, not a check at write-time.** Audit the
+  payloadSchema against the denylist at design time; reject events whose
+  fields could carry email/phone/name/IP. Hashed PII is still PII.
+- **Custom dimensions are slow-changing.** \`tenantId\`, \`planTier\`,
+  \`persona\`, \`locale\` — never per-event values. Per-event values are
+  payload fields.
+- **Residency follows the tenant.** EU customer ⇒ EU hosts.
+  US customer ⇒ US hosts with SCC for any EU sub-processor. Document
+  the transfer mechanism explicitly.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Capture email/phone/name in an event payload** → refuse. List the
+  request under \`risks[]\`, leave the field out of the payloadSchema,
+  set \`confidence\` to 0.5.
+- **Bypass consent for "internal" analytics** → refuse. Cookieless events
+  fire without consent because they have no consent-bearing surface
+  (no cookies, no fingerprint). Anything that touches \`navigator\`,
+  \`localStorage\`, or any persistent identity goes through Consent
+  Mode v2.
+- **Use Google Analytics without Consent Mode** → refuse. Emit GA4
+  config with default-denied storage, list the request under \`risks\`.
+- **Skip DNT/GPC respect** → refuse. \`navigator.doNotTrack === '1'\`
+  and \`navigator.globalPrivacyControl === true\` are both auto-deny.
+- **Retention > 425 days** → refuse. Surface the request under
+  \`risks\`, set retentionDays to 425.
+- **Decide a frontend componentTree, route, or props contract** →
+  ignore. Those are Frontend's territory. You only annotate the
+  components Frontend declared.
+- **Write CSP rules, RLS policies, API endpoints, or any field NOT
+  under \`analytics.*\`** → ignore the request. Do not populate fields
+  outside your owned namespace.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated, even if the value is an empty object (e.g. no
+  CTAs ⇒ \`analytics.dataTrackAttributes: {}\`).`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 14 owned field
+   paths (no extras, no missing).
+2. Every interactive component in
+   \`upstream.outputs.frontend.architectureFields["frontend.interactionStates"]\`
+   has matching entries in \`analytics.eventTaxonomy\` AND
+   \`analytics.dataTrackAttributes\`.
+3. Every event in \`analytics.eventTaxonomy\` has \`noPii: true\` and a
+   \`consentRequired\` value drawn from
+   \`{"none","analytics_storage","ad_storage","functionality_storage"}\`.
+4. Every event payload field is regex-safe against the denylist in
+   \`analytics.noPiiRule\` (no email, phone, name, IP, precise-geo).
+5. Every step ID in \`analytics.funnelDefinitions\` exists in
+   \`analytics.eventTaxonomy\`.
+6. Every conversion goal ID exists in \`analytics.eventTaxonomy\`.
+7. \`analytics.privacyCompliance.retentionDays\` ≤ 425.
+8. \`analytics.consentMode.default.analytics_storage\` === \`"denied"\`.
+9. \`analytics.privacyCompliance.dntRespect\` === \`true\` AND
+   \`gpcRespect\` === \`true\`.
+10. \`confidence\` reflects how comfortable you are with the decision —
+    sub-0.6 triggers the EA Reviewer to scrutinize.
+11. \`notes\` is ≤ 800 characters.
+12. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a hero-widget ticket with two CTAs produces TWO
+\`eventTaxonomy\` entries (one per CTA), each \`category: "cta"\`,
+\`consentRequired: "none"\` (cookieless click counting), \`noPii: true\`,
+plus \`dataTrackAttributes\` per CTA encoding the event ID + payload
+keys, plus a single conversion funnel (\`page_view\` →
+\`cta_clicked\` → \`booking_started\`) with the primary conversion
+goal set to the \`booking_started\` event.`;

--- a/packages/analytics-architect/src/types.ts
+++ b/packages/analytics-architect/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors the frontend-architect template
+ * verbatim — only the architect-specific field-spec lives in
+ * `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/analytics-architect/src/validation.ts
+++ b/packages/analytics-architect/src/validation.ts
@@ -1,0 +1,208 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ *
+ * Mirrors the frontend-architect template verbatim. The contract and
+ * field-keys differ; the validator logic does not.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/analytics-architect/tests/architect.test.ts
+++ b/packages/analytics-architect/tests/architect.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `AnalyticsArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  AnalyticsArchitect,
+  ANALYTICS_ARCHITECT_NAME,
+  ANALYTICS_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { AnalyticsArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('AnalyticsArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new AnalyticsArchitect();
+    expect(a).toBeInstanceOf(AnalyticsArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new AnalyticsArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the architect-kit canonical entry', () => {
+    const a = new AnalyticsArchitect();
+    expect(a.name).toBe('analytics');
+    expect(a.name).toBe(ANALYTICS_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new AnalyticsArchitect();
+    expect(a.sectionContract).toBe(AnalyticsArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new AnalyticsArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.8', () => {
+    const a = new AnalyticsArchitect();
+    expect(a.tools).toBe(ANALYTICS_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new AnalyticsArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new AnalyticsArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new AnalyticsArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new AnalyticsArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('analytics');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new AnalyticsArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    // Just instantiating should not error. We do NOT call run() here
+    // because that would invoke the real claude binary.
+    const a = new AnalyticsArchitect();
+    expect(a).toBeInstanceOf(AnalyticsArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/analytics-architect/tests/contract.test.ts
+++ b/packages/analytics-architect/tests/contract.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `analytics.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed (precedence in [1,17], etc).
+ *   - The architect registers cleanly against the ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder lists `analytics`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { AnalyticsArchitect } from '../src/architect.js';
+import {
+  ANALYTICS_ARCHITECT_META,
+  ANALYTICS_OWNED_SECTIONS,
+  ANALYTICS_OWNED_FIELD_KEYS,
+  AnalyticsArchitectContract,
+  analyticsArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('AnalyticsArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(AnalyticsArchitectContract.contractId).toBe('analytics-architect.v1');
+  });
+
+  it('architectName is `analytics` (matches package suffix + ladder entry)', () => {
+    expect(AnalyticsArchitectContract.architectName).toBe('analytics');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(AnalyticsArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `analytics.`', () => {
+    for (const key of ANALYTICS_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('analytics.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'analytics.provider',
+      'analytics.eventTaxonomy',
+      'analytics.userIdentificationStrategy',
+      'analytics.funnelDefinitions',
+      'analytics.consentGatingRules',
+      'analytics.customDimensions',
+      'analytics.dataResidencyRequirements',
+      'analytics.privacyCompliance'
+    ];
+    for (const r of required) {
+      expect(ANALYTICS_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owned-field set covers spec §2.8 mandatory fields', () => {
+    const specMandatory = [
+      'analytics.provider',
+      'analytics.eventTaxonomy',
+      'analytics.consentMode',
+      'analytics.noPiiRule',
+      'analytics.conversionGoals',
+      'analytics.dashboardLinks',
+      'analytics.dataTrackAttributes',
+      'analytics.sessionStrategy'
+    ];
+    for (const k of specMandatory) {
+      expect(ANALYTICS_OWNED_FIELD_KEYS).toContain(k);
+    }
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of ANALYTICS_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(AnalyticsArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(AnalyticsArchitectContract).slice().sort()).toEqual(
+      [...ANALYTICS_OWNED_FIELD_KEYS].sort()
+    );
+  });
+});
+
+describe('AnalyticsArchitectContract — architectMeta', () => {
+  it('declares Frontend as the upstream dependency (wave-2 architect)', () => {
+    expect(ANALYTICS_ARCHITECT_META.dependsOn).toEqual(['frontend']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(ANALYTICS_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(ANALYTICS_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 10 per spec §2.8 + canonical ladder', () => {
+    expect(ANALYTICS_ARCHITECT_META.precedenceLevel).toBe(10);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(ANALYTICS_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.8', () => {
+    expect(ANALYTICS_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(ANALYTICS_ARCHITECT_META.appliesPredicate).toBe(analyticsArchitectAppliesPredicate);
+  });
+
+  it('matches the canonical precedence ladder for `analytics`', () => {
+    expect(precedenceRank('analytics')).toBe(ANALYTICS_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('analytics');
+  });
+});
+
+describe('analyticsArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Page' };
+
+  it('returns true for Page', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(true);
+  });
+
+  it('returns true for Widget', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'Widget' })).toBe(true);
+  });
+
+  it('returns true for Story', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'Story' })).toBe(true);
+  });
+
+  it('returns true for Form (Story sub-type)', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'Form' })).toBe(true);
+  });
+
+  it('returns true for List (Story sub-type)', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'List' })).toBe(true);
+  });
+
+  it('returns false for Foundation (no UI surfaces)', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'Foundation' })).toBe(false);
+  });
+
+  it('returns false for an unrecognised type', () => {
+    expect(analyticsArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Analytics architect cleanly', () => {
+    expect(() => {
+      registry.register(new AnalyticsArchitect());
+    }).not.toThrow();
+    expect(registry.get('analytics')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new AnalyticsArchitect());
+    for (const k of ANALYTICS_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('analytics');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new AnalyticsArchitect());
+    expect(() => registry.register(new AnalyticsArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new AnalyticsArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'analytics.eventTaxonomy',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new AnalyticsArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [
+        { path: 'frontend.componentTree', description: 'component tree', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('frontend', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(ANALYTICS_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only Analytics is present', () => {
+    const conflicts = disjointness([AnalyticsArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Analytics and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...AnalyticsArchitectContract,
+      contractId: 'analytics-clone.v1',
+      architectName: 'analytics-clone'
+    };
+    const conflicts = disjointness([AnalyticsArchitectContract, clone]);
+    expect(conflicts.length).toBe(ANALYTICS_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() reports the missing frontend dependency when alone', () => {
+    registry.register(new AnalyticsArchitect());
+    const errors = registry.validate();
+    // Analytics depends on frontend; with no frontend registered, the
+    // dependency soundness check fires.
+    expect(errors.some(e => e.includes('frontend'))).toBe(true);
+  });
+
+  it('registry.validate() is clean when frontend is also registered', () => {
+    registry.register(new AnalyticsArchitect());
+    const frontendContract: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [
+        { path: 'frontend.componentTree', description: 'component tree', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    registry.register(new StubArchitect('frontend', frontendContract));
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/analytics-architect/tests/golden/golden.test.ts
+++ b/packages/analytics-architect/tests/golden/golden.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Golden test — the canonical known-good Analytics-architect artifact
+ * for a known prakash-tiwari Widget ticket. Includes the
+ * **golden privacy-compliance test** (no PII in events without consent).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { AnalyticsArchitect } from '../../src/architect.js';
+import { ANALYTICS_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { ANALYTICS_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const PII_FIELD_PATTERNS = [
+  /email/i,
+  /phone/i,
+  /firstname|first_name/i,
+  /lastname|last_name/i,
+  /\bname\b/i,
+  /\bssn\b/i,
+  /passport/i,
+  /address/i,
+  /^ip$|ipv4|ipv6|ip_addr/i,
+  /precise.?geo|\blat\b|\blng\b|longitude|latitude/i,
+  /full.?user.?agent/i,
+  /credit.?card|card.?number/i,
+  /\bdob\b|date.?of.?birth/i
+];
+
+function containsPiiFieldName(obj: unknown): string | null {
+  if (typeof obj !== 'object' || obj === null) return null;
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    for (const pat of PII_FIELD_PATTERNS) {
+      if (pat.test(key)) return key;
+    }
+  }
+  return null;
+}
+
+describe('golden — prakash-tiwari Artist hero bio Widget ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8'));
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-designversion.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-designversion.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().designVersion;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new AnalyticsArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    expect(out.architectName).toBe('analytics');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    for (const k of ANALYTICS_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every Analytics invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new AnalyticsArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of ANALYTICS_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new AnalyticsArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+});
+
+/**
+ * Golden privacy-compliance lens — locks the EA Reviewer's no-PII-
+ * without-consent invariant against the canonical fixture. This is the
+ * test the operator referenced in the task brief ("golden test
+ * verifying privacy-compliance posture (no PII in events without
+ * consent)").
+ */
+describe('GOLDEN PRIVACY-COMPLIANCE LENS — no PII in events without consent', () => {
+  const arch = goldenExpectedOutput().architectureFields;
+  const taxonomy = arch['analytics.eventTaxonomy'] as Record<string, Record<string, unknown>>;
+  const consentMode = arch['analytics.consentMode'] as Record<string, unknown>;
+  const privacyCompliance = arch['analytics.privacyCompliance'] as Record<string, unknown>;
+  const noPiiRule = arch['analytics.noPiiRule'] as Record<string, unknown>;
+  const customDimensions = arch['analytics.customDimensions'] as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const userIdStrategy = arch['analytics.userIdentificationStrategy'] as Record<string, unknown>;
+
+  it('Consent Mode v2 default state denies analytics_storage', () => {
+    const def = consentMode.default as Record<string, unknown>;
+    expect(def.analytics_storage).toBe('denied');
+  });
+
+  it('Consent Mode v2 default state denies ad_storage', () => {
+    const def = consentMode.default as Record<string, unknown>;
+    expect(def.ad_storage).toBe('denied');
+  });
+
+  it('Consent Mode v2 default state grants functionality_storage (necessary cookies only)', () => {
+    const def = consentMode.default as Record<string, unknown>;
+    expect(def.functionality_storage).toBe('granted');
+  });
+
+  it('every event in the taxonomy attests noPii=true', () => {
+    for (const [eventId, event] of Object.entries(taxonomy)) {
+      expect(event.noPii, `event ${eventId} must attest noPii=true`).toBe(true);
+    }
+  });
+
+  it('no event payloadSchema contains a PII field name', () => {
+    for (const [eventId, event] of Object.entries(taxonomy)) {
+      const piiField = containsPiiFieldName(event.payloadSchema);
+      expect(piiField, `event ${eventId} payload contains PII field: ${piiField ?? ''}`).toBeNull();
+    }
+  });
+
+  it('cookieless events (consentRequired=none) carry no user-identifying fields', () => {
+    for (const [eventId, event] of Object.entries(taxonomy)) {
+      if (event.consentRequired !== 'none') continue;
+      const schema = event.payloadSchema as Record<string, unknown>;
+      expect(schema, `event ${eventId} schema must exist`).toBeDefined();
+      expect(
+        Object.keys(schema).some(k => /^userId$|clientId|sessionId|deviceId/.test(k)),
+        `cookieless event ${eventId} carries an identifier field`
+      ).toBe(false);
+    }
+  });
+
+  it('DNT and GPC signals are both respected (auto-deny)', () => {
+    expect(privacyCompliance.dntRespect).toBe(true);
+    expect(privacyCompliance.gpcRespect).toBe(true);
+  });
+
+  it('retention ceiling is GDPR-compliant (≤ 14 months ≈ 425 days)', () => {
+    expect(privacyCompliance.retentionDays).toBeLessThanOrEqual(425);
+  });
+
+  it('noPiiRule is explicitly attested with a non-empty regex denylist', () => {
+    expect(noPiiRule.attested).toBe(true);
+    expect(Array.isArray(noPiiRule.denylistRegex)).toBe(true);
+    expect((noPiiRule.denylistRegex as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it('customDimensions never carry PII (every dimension has pii=false)', () => {
+    for (const [dimName, dim] of Object.entries(customDimensions)) {
+      expect(dim.pii, `custom dimension ${dimName} must set pii=false`).toBe(false);
+    }
+  });
+
+  it('default identification tier is anonymous (no clientId until consent)', () => {
+    expect(userIdStrategy.defaultTier).toBe('anonymous');
+  });
+
+  it('authenticated tier declares an empty piiAllowedFields list (no PII allowed even on consent)', () => {
+    const tiers = userIdStrategy.tiers as Record<string, Record<string, unknown>>;
+    expect(tiers.authenticated.piiAllowedFields).toEqual([]);
+  });
+
+  it('GDPR and CCPA compliance are both asserted true', () => {
+    expect(privacyCompliance.gdpr).toBe(true);
+    expect(privacyCompliance.ccpa).toBe(true);
+  });
+
+  it('data residency selects EU for EU-resident tenants', () => {
+    const residency = arch['analytics.dataResidencyRequirements'] as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(residency.plausible.region).toBe('eu');
+    expect(['europe-west', 'eu', 'EU']).toContain(residency.ga4.region);
+  });
+
+  it('every IAB TCF integration is explicitly opt-in (default off)', () => {
+    expect(consentMode.iabTcf).toBe(false);
+  });
+});

--- a/packages/analytics-architect/tests/golden/input-businessplan.json
+++ b/packages/analytics-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive contact-form submissions",
+    "Project warm + grounded brand voice",
+    "Make the booking CTA the page's primary action"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["No third-party fonts beyond next/font defaults"]
+}

--- a/packages/analytics-architect/tests/golden/input-designversion.json
+++ b/packages/analytics-architect/tests/golden/input-designversion.json
@@ -1,0 +1,29 @@
+{
+  "versionId": "design-pt-v3-2026-05-22",
+  "snapshotUri": "s3://atlas/designs/design-pt-v3-2026-05-22.png",
+  "anchors": [
+    {
+      "anchorId": "hero",
+      "kind": "section",
+      "bbox": { "x": 0, "y": 0, "w": 1440, "h": 720 },
+      "meta": { "variant": "hero", "breakpoints": ["sm", "md", "lg", "xl"] }
+    },
+    {
+      "anchorId": "hero-cta-primary",
+      "kind": "button",
+      "bbox": { "x": 600, "y": 320, "w": 200, "h": 56 },
+      "meta": { "variant": "primary" }
+    },
+    {
+      "anchorId": "hero-cta-secondary",
+      "kind": "button",
+      "bbox": { "x": 820, "y": 320, "w": 200, "h": 56 },
+      "meta": { "variant": "secondary" }
+    }
+  ],
+  "tokens": {
+    "color.brand.primary": "#0f3057",
+    "color.brand.accent": "#e8c547"
+  },
+  "breakpoints": ["sm", "md", "lg", "xl"]
+}

--- a/packages/analytics-architect/tests/golden/input-ticket.json
+++ b/packages/analytics-architect/tests/golden/input-ticket.json
@@ -1,0 +1,17 @@
+{
+  "id": "ticket-pt-001",
+  "type": "Widget",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "CTA clicks emit cookieless events captured without consent gate.",
+    "No PII (email, phone, name) appears in any event payload.",
+    "Conversion funnel from page_view → cta_clicked → booking_started is defined.",
+    "DNT + GPC signals trigger auto-deny with no banner shown."
+  ],
+  "business_requirements": {
+    "title": "Artist hero bio widget",
+    "description": "Above-the-fold hero block for the artist profile page — portrait photo, name, tagline, primary CTA (\"Book session\"), secondary CTA (\"View portfolio\"). Primary goal: drive booking conversions."
+  },
+  "quality_tags": ["ui", "analytics", "privacy"]
+}

--- a/packages/analytics-architect/tests/helpers/fakes.ts
+++ b/packages/analytics-architect/tests/helpers/fakes.ts
@@ -1,0 +1,467 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Widget ticket WITH a synthesised Frontend
+ *     upstream output (since Analytics is wave-2 and depends on Frontend).
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Widget fixture.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { ANALYTICS_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The known-good Frontend upstream output for the prakash-tiwari hero
+ * widget. Pinned here so the Analytics architect's tests don't depend
+ * on the Frontend package being importable from tests (the workspace
+ * symlink would work, but pinning is cheaper to maintain).
+ *
+ * Shape mirrors `frontend-architect`'s goldenExpectedOutput() exactly.
+ * The component IDs must match: `hero`, `hero-portrait`, `hero-title`,
+ * `hero-tagline`, `hero-cta-primary`, `hero-cta-secondary`. Of these,
+ * only `hero-cta-primary` and `hero-cta-secondary` are interactive.
+ */
+function buildFrontendUpstreamOutput(): ArchitectOutput {
+  return {
+    architectName: 'frontend',
+    architectureFields: {
+      'frontend.framework': { name: 'next', version: '15.x', router: 'app' },
+      'frontend.componentLibrary': {
+        name: 'shadcn/ui',
+        tailwindVersion: '3.x',
+        radixVersion: '1.x'
+      },
+      'frontend.stateMgmt': {
+        default: 'server',
+        clientStore: 'zustand',
+        forms: 'react-hook-form'
+      },
+      'frontend.routeConfig': {
+        segment: 'app/artists/[slug]',
+        layoutSegment: 'app/artists',
+        loadingBoundary: true,
+        errorBoundary: true,
+        dynamicSegments: ['[slug]']
+      },
+      'frontend.tokens': {
+        'color.brand.primary': '#0f3057',
+        'color.brand.accent': '#e8c547',
+        'color.text.body': '#1f1f1f',
+        'color.bg.canvas': '#f7f5ef',
+        'space.4': '16px',
+        'space.8': '32px',
+        'space.16': '64px',
+        'radius.md': '8px',
+        'radius.lg': '12px',
+        'type.display.size': '48px',
+        'type.body.size': '16px'
+      },
+      'frontend.breakpoints': ['sm', 'md', 'lg', 'xl'],
+      'frontend.componentTree': [
+        {
+          id: 'hero',
+          kind: 'section',
+          propsContractRef: 'hero',
+          children: [
+            { id: 'hero-portrait', kind: 'Image', propsContractRef: 'hero-portrait' },
+            { id: 'hero-title', kind: 'h1', propsContractRef: 'hero-title' },
+            { id: 'hero-tagline', kind: 'p', propsContractRef: 'hero-tagline' },
+            {
+              id: 'hero-cta-primary',
+              kind: 'Button',
+              propsContractRef: 'hero-cta-primary'
+            },
+            {
+              id: 'hero-cta-secondary',
+              kind: 'Button',
+              propsContractRef: 'hero-cta-secondary'
+            }
+          ]
+        }
+      ],
+      'frontend.interactionStates': {
+        'hero-cta-primary': {
+          hover: 'darker brand fill',
+          focus: 'visible ring',
+          active: 'inset shadow',
+          error: 'n/a',
+          empty: 'n/a',
+          loading: 'inline spinner replacing label',
+          disabled: '50% opacity, no pointer events'
+        },
+        'hero-cta-secondary': {
+          hover: 'darker accent fill',
+          focus: 'visible ring',
+          active: 'inset shadow',
+          error: 'n/a',
+          empty: 'n/a',
+          loading: 'inline spinner replacing label',
+          disabled: '50% opacity, no pointer events'
+        }
+      }
+    },
+    confidence: 0.88,
+    notes: 'Frontend golden output for prakash-tiwari hero widget.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/**
+ * The canonical fixture — a Widget ticket from the prakash-tiwari.com
+ * marketing site (an `ArtistHeroBio` widget) with the Frontend upstream
+ * output already populated.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-001',
+      type: 'Widget',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'CTA clicks emit cookieless events captured without consent gate.',
+        'No PII (email, phone, name) appears in any event payload.',
+        'Conversion funnel from page_view → cta_clicked → booking_started is defined.',
+        'DNT + GPC signals trigger auto-deny with no banner shown.'
+      ],
+      business_requirements: {
+        title: 'Artist hero bio widget',
+        description:
+          'Above-the-fold hero block for the artist profile page — portrait photo, name, tagline, primary CTA ("Book session"), secondary CTA ("View portfolio"). Primary goal: drive booking conversions.'
+      },
+      quality_tags: ['ui', 'analytics', 'privacy']
+    },
+    upstream: {
+      outputs: {
+        frontend: buildFrontendUpstreamOutput()
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: [
+        'Drive contact-form submissions',
+        'Project warm + grounded brand voice',
+        "Make the booking CTA the page's primary action"
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['No third-party fonts beyond next/font defaults']
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      snapshotUri: 's3://atlas/designs/design-pt-v3-2026-05-22.png',
+      anchors: [
+        {
+          anchorId: 'hero',
+          kind: 'section',
+          bbox: { x: 0, y: 0, w: 1440, h: 720 },
+          meta: { variant: 'hero', breakpoints: ['sm', 'md', 'lg', 'xl'] }
+        },
+        {
+          anchorId: 'hero-cta-primary',
+          kind: 'button',
+          bbox: { x: 600, y: 320, w: 200, h: 56 },
+          meta: { variant: 'primary' }
+        },
+        {
+          anchorId: 'hero-cta-secondary',
+          kind: 'button',
+          bbox: { x: 820, y: 320, w: 200, h: 56 },
+          meta: { variant: 'secondary' }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057',
+        'color.brand.accent': '#e8c547'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 },
+      compliance: { dataResidency: 'EU' }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari Widget fixture. Covers
+ * exactly the 14 owned `analytics.*` fields, scoped to the two
+ * interactive components (the CTAs) + a single conversion funnel.
+ *
+ * IMPORTANT: this fixture is the golden "what good looks like" for the
+ * no-PII-without-consent invariant. The privacy-compliance test reads
+ * it and asserts no email/phone/name fields appear in any event
+ * payload AND that consentMode.default.analytics_storage === 'denied'.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'analytics',
+    architectureFields: {
+      'analytics.provider': {
+        primary: 'plausible',
+        secondary: 'ga4',
+        cookielessBaseline: true,
+        consentGatedAdvanced: true
+      },
+      'analytics.eventTaxonomy': {
+        page_view: {
+          eventName: 'page_view',
+          trigger: 'router:navigate',
+          payloadSchema: { path: 'string', referrer: 'string?' },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'page'
+        },
+        cta_clicked_primary: {
+          eventName: 'cta_clicked',
+          trigger: 'hero-cta-primary:click',
+          payloadSchema: {
+            componentId: 'string',
+            variant: 'string',
+            destination: 'string'
+          },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'cta'
+        },
+        cta_clicked_secondary: {
+          eventName: 'cta_clicked',
+          trigger: 'hero-cta-secondary:click',
+          payloadSchema: {
+            componentId: 'string',
+            variant: 'string',
+            destination: 'string'
+          },
+          consentRequired: 'none',
+          noPii: true,
+          category: 'cta'
+        },
+        booking_started: {
+          eventName: 'booking_started',
+          trigger: 'hero-cta-primary:downstream-route-loaded',
+          payloadSchema: { entrySurface: 'string' },
+          consentRequired: 'analytics_storage',
+          noPii: true,
+          category: 'conversion'
+        }
+      },
+      'analytics.userIdentificationStrategy': {
+        defaultTier: 'anonymous',
+        tiers: {
+          anonymous: { idSource: 'none', scope: 'session' },
+          pseudonymous: {
+            idSource: 'clientId',
+            consentRequired: 'analytics_storage',
+            scope: 'persistent-30d'
+          },
+          authenticated: {
+            idSource: 'authUserId',
+            consentRequired: 'analytics_storage',
+            scope: 'persistent',
+            piiAllowedFields: []
+          }
+        }
+      },
+      'analytics.funnelDefinitions': {
+        booking_funnel: {
+          name: 'Booking conversion',
+          steps: ['page_view', 'cta_clicked_primary', 'booking_started'],
+          window: '7d'
+        }
+      },
+      'analytics.consentMode': {
+        version: 'v2',
+        default: {
+          analytics_storage: 'denied',
+          ad_storage: 'denied',
+          ad_user_data: 'denied',
+          ad_personalization: 'denied',
+          functionality_storage: 'granted',
+          security_storage: 'granted'
+        },
+        updatePolicy: 'on-user-grant',
+        iabTcf: false
+      },
+      'analytics.consentGatingRules': {
+        page: 'none',
+        engagement: 'none',
+        conversion: 'analytics_storage',
+        content: 'none',
+        commerce: 'analytics_storage',
+        community: 'analytics_storage',
+        cta: 'none'
+      },
+      'analytics.noPiiRule': {
+        attested: true,
+        denylistRegex: [
+          '@\\S+\\.\\S+',
+          '\\+?\\d{7,}',
+          'ip:.*',
+          'geo:precise',
+          'userAgent:full'
+        ],
+        perEventNotes:
+          'each event payload audited against denylist before emit; CI gate enforces in @chiefaia/analytics test suite'
+      },
+      'analytics.privacyCompliance': {
+        gdpr: true,
+        ccpa: true,
+        cookieBanner: true,
+        dntRespect: true,
+        gpcRespect: true,
+        dataMinimisation: true,
+        retentionDays: 425,
+        subjectAccessRequestEndpoint: '/api/privacy/sar'
+      },
+      'analytics.conversionGoals': {
+        primary: 'booking_started',
+        secondary: ['cta_clicked_primary']
+      },
+      'analytics.dashboardLinks': {
+        plausible: 'https://plausible.io/prakash-tiwari',
+        ga4: 'https://analytics.google.com/analytics/web/#/p<propertyId>'
+      },
+      'analytics.dataTrackAttributes': {
+        'hero-cta-primary': {
+          'data-track-event': 'cta_clicked_primary',
+          'data-track-payload':
+            '{"componentId":"hero-cta-primary","variant":"primary","destination":"/book"}'
+        },
+        'hero-cta-secondary': {
+          'data-track-event': 'cta_clicked_secondary',
+          'data-track-payload':
+            '{"componentId":"hero-cta-secondary","variant":"secondary","destination":"/portfolio"}'
+        }
+      },
+      'analytics.sessionStrategy': {
+        windowMinutes: 30,
+        identityTier: 'anonymous',
+        crossDomain: false,
+        crossDevice: false,
+        reattributionWindow: '24h'
+      },
+      'analytics.customDimensions': {
+        tenantId: { scope: 'event-or-user', pii: false },
+        planTier: { scope: 'user', pii: false },
+        persona: { scope: 'user', pii: false },
+        locale: { scope: 'user', pii: false }
+      },
+      'analytics.dataResidencyRequirements': {
+        plausible: { region: 'eu', subProcessors: ['plausible-eu'] },
+        ga4: {
+          region: 'europe-west',
+          subProcessors: ['google-llc'],
+          transferMechanism: 'SCC'
+        }
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'Analytics spec for hero widget. Plausible (cookieless, EU) + GA4 (consent-gated). 4 events: page_view, two cta_clicked variants (cookieless), booking_started (consent-gated). Conversion funnel page_view → cta_clicked_primary → booking_started. EU residency. DNT + GPC respected. 14-month retention ceiling. Zero PII fields across every payload.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Compose the Analytics output's architectureFields with a synthesised
+ * Frontend slice so the cross-architect invariants can be exercised
+ * against a "composed" view. Used by the invariants test pass.
+ */
+export function composedArchitectureForInvariants(): Readonly<Record<string, unknown>> {
+  const analytics = goldenExpectedOutput().architectureFields;
+  const frontend = buildFrontendUpstreamOutput().architectureFields;
+  return { ...analytics, ...frontend };
+}
+
+/**
+ * Asserts that the input covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of ANALYTICS_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/analytics-architect/tests/invariants.test.ts
+++ b/packages/analytics-architect/tests/invariants.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Cross-architect invariants — verifies Analytics's contributions to the
+ * EA Reviewer's invariant registry (per spec §6.2).
+ *
+ * Includes the golden privacy-compliance test: no PII in events without
+ * explicit consent grants.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ANALYTICS_INVARIANTS } from '../src/invariants.js';
+import { composedArchitectureForInvariants, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('ANALYTICS_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(ANALYTICS_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of ANALYTICS_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `analytics`', () => {
+    for (const inv of ANALYTICS_INVARIANTS) {
+      expect(inv.contributor).toBe('analytics');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of ANALYTICS_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of ANALYTICS_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of ANALYTICS_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('ANALYTICS_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of ANALYTICS_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('consentMode-default-denied fails when analytics_storage default is granted', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.consentMode-default-denied');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.consentMode': {
+        version: 'v2',
+        default: { analytics_storage: 'granted', ad_storage: 'denied' }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('noPii-attested fails when attestation is missing', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.noPii-attested');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.noPiiRule': { attested: false, denylistRegex: [] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('eventTaxonomy-no-pii-payloads fails when an event payload has an email field', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.eventTaxonomy-no-pii-payloads');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.eventTaxonomy': {
+        leaky_event: {
+          eventName: 'leaky_event',
+          trigger: 'form:submit',
+          payloadSchema: { email: 'string', planTier: 'string' },
+          consentRequired: 'analytics_storage',
+          noPii: true,
+          category: 'conversion'
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('eventTaxonomy-no-pii-payloads fails when an event payload has a phone field', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.eventTaxonomy-no-pii-payloads');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.eventTaxonomy': {
+        leaky_event: {
+          eventName: 'leaky_event',
+          trigger: 'form:submit',
+          payloadSchema: { phoneNumber: 'string' },
+          consentRequired: 'analytics_storage',
+          noPii: true,
+          category: 'conversion'
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('eventTaxonomy-no-pii-payloads fails when an event payload has a precise-geo field', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.eventTaxonomy-no-pii-payloads');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.eventTaxonomy': {
+        located_event: {
+          eventName: 'located_event',
+          trigger: 'geo:resolved',
+          payloadSchema: { latitude: 'number', longitude: 'number' },
+          consentRequired: 'analytics_storage',
+          noPii: true,
+          category: 'engagement'
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('eventTaxonomy-every-event-attests-noPii fails when noPii=false somewhere', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.eventTaxonomy-every-event-attests-noPii'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.eventTaxonomy': {
+        sketchy_event: {
+          eventName: 'sketchy_event',
+          trigger: 'x:y',
+          payloadSchema: {},
+          consentRequired: 'analytics_storage',
+          noPii: false,
+          category: 'engagement'
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('eventTaxonomy-consentRequired-allowlist fails on an unknown bucket', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.eventTaxonomy-consentRequired-allowlist'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.eventTaxonomy': {
+        wrong_bucket: {
+          eventName: 'wrong_bucket',
+          trigger: 'x:y',
+          payloadSchema: {},
+          consentRequired: 'NOT_A_BUCKET',
+          noPii: true,
+          category: 'engagement'
+        }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('funnelDefinitions-steps-exist-in-taxonomy fails on a dangling step ID', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.funnelDefinitions-steps-exist-in-taxonomy'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.funnelDefinitions': {
+        broken_funnel: { name: 'broken', steps: ['page_view', 'made_up_event'], window: '7d' }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('conversionGoals-exist-in-taxonomy fails on an unknown primary metric', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.conversionGoals-exist-in-taxonomy'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.conversionGoals': { primary: 'made_up_event', secondary: [] }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('privacy-dnt-and-gpc-respected fails when DNT respect is off', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.privacy-dnt-and-gpc-respected');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.privacyCompliance': {
+        gdpr: true,
+        ccpa: true,
+        cookieBanner: true,
+        dntRespect: false,
+        gpcRespect: true,
+        dataMinimisation: true,
+        retentionDays: 425
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('privacy-dnt-and-gpc-respected fails when GPC respect is off', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.privacy-dnt-and-gpc-respected');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.privacyCompliance': {
+        gdpr: true,
+        ccpa: true,
+        cookieBanner: true,
+        dntRespect: true,
+        gpcRespect: false,
+        dataMinimisation: true,
+        retentionDays: 425
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('privacy-retention-under-425d fails when retentionDays > 425', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.privacy-retention-under-425d');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.privacyCompliance': {
+        ...((goldenArch['analytics.privacyCompliance'] as object) ?? {}),
+        retentionDays: 730
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('customDimensions-no-pii fails when a dimension declares pii=true', () => {
+    const inv = ANALYTICS_INVARIANTS.find(i => i.id === 'analytics.customDimensions-no-pii');
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.customDimensions': {
+        tenantId: { scope: 'event-or-user', pii: false },
+        emailHash: { scope: 'user', pii: true }
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('userId-strategy-default-anonymous fails when default tier is pseudonymous', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.userId-strategy-default-anonymous'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'analytics.userIdentificationStrategy': {
+        defaultTier: 'pseudonymous',
+        tiers: {}
+      }
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+});
+
+describe('ANALYTICS_INVARIANTS — composed (with Frontend) view', () => {
+  it('dataTrackAttributes-cover-interactive-components passes when all interactive components are covered', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.dataTrackAttributes-cover-interactive-components'
+    );
+    expect(inv).toBeDefined();
+    const composed = composedArchitectureForInvariants();
+    expect(inv!.detect(composed)).toBe(true);
+  });
+
+  it('dataTrackAttributes-cover-interactive-components fails when one component is missing', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.dataTrackAttributes-cover-interactive-components'
+    );
+    expect(inv).toBeDefined();
+    const composed = { ...composedArchitectureForInvariants() };
+    composed['analytics.dataTrackAttributes'] = {
+      'hero-cta-primary': (composed['analytics.dataTrackAttributes'] as Record<string, unknown>)[
+        'hero-cta-primary'
+      ]
+    };
+    expect(inv!.detect(composed)).toBe(false);
+  });
+
+  it('eventTaxonomy-covers-interactive-components advisory fires on a dangling data-track-event reference', () => {
+    const inv = ANALYTICS_INVARIANTS.find(
+      i => i.id === 'analytics.eventTaxonomy-covers-interactive-components'
+    );
+    expect(inv).toBeDefined();
+    const composed = { ...composedArchitectureForInvariants() };
+    composed['analytics.dataTrackAttributes'] = {
+      'hero-cta-primary': { 'data-track-event': 'NONEXISTENT_EVENT', 'data-track-payload': '{}' }
+    };
+    expect(inv!.detect(composed)).toBe(false);
+  });
+});

--- a/packages/analytics-architect/tests/run.test.ts
+++ b/packages/analytics-architect/tests/run.test.ts
@@ -1,0 +1,247 @@
+/**
+ * `run()` tests — verifies the runtime pipeline:
+ *
+ *   - happy path returns a well-formed ArchitectOutput
+ *   - idempotency: same input → equivalent output
+ *   - re-runs REPLACE owned fields (do not append)
+ *   - dependency declaration on output
+ *   - failure modes (spawn failure, validation failure)
+ *   - reviewer feedback is plumbed through
+ *   - spend telemetry comes from the spawner, not the assistant
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ANALYTICS_ARCHITECT_NAME, AnalyticsArchitect } from '../src/architect.js';
+import { ANALYTICS_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runAnalyticsArchitect } from '../src/run.js';
+import { buildAnalyticsSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runAnalyticsArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('analytics');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    for (const k of ANALYTICS_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildAnalyticsSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runAnalyticsArchitect(input, {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runAnalyticsArchitect(input, {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runAnalyticsArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runAnalyticsArchitect(input, {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    const b = await runAnalyticsArchitect(input, {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runAnalyticsArchitect(input, {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    const r2 = await runAnalyticsArchitect(input, {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).slice().sort()).toEqual(
+      Object.keys(r1.architectureFields).slice().sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(ANALYTICS_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runAnalyticsArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"analytics"}');
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runAnalyticsArchitect — dependency declaration', () => {
+  it('analytics is a wave-2 architect (no sibling-ticket deps in this fixture)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runAnalyticsArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildAnalyticsSystemPrompt(),
+      architectName: ANALYTICS_ARCHITECT_NAME
+    });
+    // Output `dependencies` field is sibling TICKET ids — not architect
+    // dependencies (those live in architectMeta.dependsOn). The hero
+    // widget has no sibling-ticket dep so this is an empty array.
+    expect(out.dependencies).toEqual([]);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-001');
+  });
+
+  it('serialises the Frontend upstream componentTree', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('frontend.componentTree');
+    expect(p).toContain('hero-cta-primary');
+  });
+
+  it('serialises the Frontend upstream interactionStates', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('frontend.interactionStates');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('preserves tenantContext.compliance.dataResidency for residency decisions', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('dataResidency');
+    expect(p).toContain('EU');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'tighten consent gate on commerce events', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('tighten consent gate on commerce events');
+  });
+});
+
+describe('AnalyticsArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new AnalyticsArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('analytics');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/analytics-architect/tests/system-prompt.test.ts
+++ b/packages/analytics-architect/tests/system-prompt.test.ts
@@ -1,0 +1,110 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ANALYTICS_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildAnalyticsSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildAnalyticsSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildAnalyticsSystemPrompt();
+    const p2 = buildAnalyticsSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Analytics Architect");
+  });
+
+  it('contains the Locked stack section with privacy-first defaults', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Plausible');
+    expect(p).toContain('GA4');
+    expect(p).toContain('Consent Mode v2');
+    expect(p).toContain('No-PII');
+    expect(p).toContain('DNT');
+    expect(p).toContain('GPC');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildAnalyticsSystemPrompt();
+    for (const key of ANALYTICS_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Cookieless first');
+  });
+
+  it('contains a Refusal patterns section that rejects PII capture', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('email/phone/name');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('analytics.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains the privacy-compliance ceiling (retention ≤ 425 days)', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('425');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `analytics.*` namespace', () => {
+    const p = buildAnalyticsSystemPrompt();
+    const foreignPrefixes = [
+      'backend.apiShape',
+      'database.schemaDDL',
+      'security.cspPolicy',
+      'a11y.wcagLevel',
+      'observability.logShape'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('size is bounded (token-budget proxy: < 20k chars)', () => {
+    const p = buildAnalyticsSystemPrompt();
+    expect(p).toBeDefined();
+    expect(p.length).toBeLessThan(20_000);
+  });
+});

--- a/packages/analytics-architect/tests/validation.test.ts
+++ b/packages/analytics-architect/tests/validation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ANALYTICS_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(goldenAssistantText(), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('analytics');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput('{"architectName":"analytics"}', ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['analytics.eventTaxonomy'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiShape': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(JSON.stringify(corrupted), ANALYTICS_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(JSON.stringify(variant), ANALYTICS_OWNED_FIELD_KEYS);
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/analytics-architect/tsconfig.build.json
+++ b/packages/analytics-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/analytics-architect/tsconfig.json
+++ b/packages/analytics-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/analytics-architect/vitest.config.ts
+++ b/packages/analytics-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});


### PR DESCRIPTION
Architect #8 of 17. Senior analytics engineer focused on **privacy-compliant tracking**, cookieless analytics, event-taxonomy design, and consent gating.

## What it owns

`analytics.*` slice of `tickets.architecture`:

- `provider` — Plausible (cookieless, EU) + GA4 (consent-gated) by default; PostHog/Mixpanel/Snowplow on customer ask
- `eventTaxonomy` — typed snake_case event IDs with payloadSchema, `consentRequired`, `noPii: true` per entry
- `userIdentificationStrategy` — default anonymous; pseudonymous/authenticated tiers gate on `analytics_storage`
- `funnelDefinitions` — ordered eventId sequences for conversion analysis
- `consentMode` — Google Consent Mode v2, default-denied `analytics_storage`
- `consentGatingRules` — per-event-category consent prerequisite map
- `noPiiRule` — attested + regex denylist for email/phone/name/IP/precise-geo
- `privacyCompliance` — GDPR/CCPA/DNT/GPC posture, 425-day retention ceiling
- `conversionGoals` — primary + secondary metric IDs A/B Testing consumes
- `dashboardLinks` — per-provider per-environment URLs
- `dataTrackAttributes` — `data-track-*` conventions Frontend's shadcn components emit
- `sessionStrategy` — 30-min idle window, anonymous tier default
- `customDimensions` — tenantId/planTier/persona/locale (never PII)
- `dataResidencyRequirements` — EU default; SCC for cross-region transfers

## Architecture

- `AnalyticsArchitect implements SpecialistArchitect` from `@caia/architect-kit` (PR #535)
- Wave-2 architect — `dependsOn: ['frontend']`. Reads `componentTree` + `interactionStates` to know which surfaces emit events.
- Precedence rank **10** per canonical ladder (above database #11, backend #12, frontend #14; below security #1, devops #2, a11y #3, seo #4, perf #5, abTesting #6, featureFlags #7, apiGateway #8, observability #9).
- Sonnet by default. Tools empty for V1.
- Leverages `@chiefaia/analytics` (Plausible + GA4 + consent banner) per V2 §2 wrap verdict.

## Privacy by default

- Consent Mode v2 default-denied `analytics_storage` + `ad_storage`
- DNT (`navigator.doNotTrack`) and GPC (`navigator.globalPrivacyControl`) auto-deny
- No PII (email, phone, name, IP, precise-geo, full-userAgent) in any event payload — enforced by `ANALYTICS_INVARIANTS` regex check on payloadSchema field names
- Cookieless events carry no identifier fields
- 14-month (425-day) retention ceiling
- EU residency by default; tenant `compliance.dataResidency` override

## Tests (144 passing)

| File | Tests |
|---|---|
| architect.test.ts | 12 — SpecialistArchitect compliance |
| contract.test.ts | 32 — structural + registration + disjointness |
| system-prompt.test.ts | 14 — every owned field referenced, no foreign namespaces |
| validation.test.ts | 19 — every error class + fence stripping |
| run.test.ts | 21 — happy path, idempotency, failure modes, dep declaration |
| invariants.test.ts | 24 — 13 predicates × good + corrupt cases |
| golden/golden.test.ts | 22 — **golden privacy-compliance lens**: no PII in events without consent |

## Quality gates

- `pnpm typecheck` → 0 errors (TS strict + exactOptionalPropertyTypes + noUncheckedIndexedAccess)
- `pnpm test` → 144 / 144
- `pnpm lint` → 0 warnings
- `pnpm build` → dist/ emits cleanly

## References

- research/17_architect_framework_spec_2026.md §2.8
- agent-memory/project_caia_17_architects.md #8
- @chiefaia/analytics (existing Plausible + GA4 wrapper) — V2 §2 "wrap" verdict

True-Zero rule: zero TS errors, zero failing tests, zero lint warnings. Subscription-only spawner via @chiefaia/claude-spawner.