### PR TITLE
feat(@caia/security-architect): ship architect #10 of 17 — Security specialist

### DIFF
--- a/packages/security-architect/README.md
+++ b/packages/security-architect/README.md
@@ -1,0 +1,65 @@
+# @caia/security-architect
+
+Architect #10 of CAIA's 17-architect EA fan-out. Senior security engineer focused on OWASP top-10 mitigations, authentication (Cloudflare Access / OAuth / JWT), authorization (RBAC + ABAC), secrets handling (forward-reference to `@caia/secrets-adapter`), and multi-tenant isolation (per-tenant Postgres schema isolation + scoped credentials).
+
+## Position in the architect fan-out
+
+- **Wave**: 2 (depends on Backend Architect + Database Architect).
+- **Precedence rank**: **1 (highest)** per spec §5.2.
+- **Runtime model**: Sonnet.
+
+## What it owns
+
+`security.*` slice of the `tickets.architecture` JSONB column:
+
+- `security.authenticationStrategy`
+- `security.authorizationRules`
+- `security.secretsHandling`
+- `security.owaspMitigations` (covers ALL OWASP Top-10 2021 categories)
+- `security.securityHeaders`
+- `security.inputValidation`
+- `security.rateLimitingRules`
+- `security.auditLogRequirements`
+- `security.tenantIsolationGuarantees`
+
+## What it does NOT do
+
+No component code, no API endpoint implementations, no SQL DDL, no CI/CD, no UI. Security specifies how every endpoint is authenticated, authorized, rate-limited, and audited.
+
+## Quick start
+
+```ts
+import { SecurityArchitect, SecurityArchitectContract } from '@caia/security-architect';
+
+const architect = new SecurityArchitect();
+const output = await architect.run({
+  ticket, businessPlan, designVersion, tenantContext,
+  upstream: { outputs: { backend, database } },
+  budget: {
+    maxInputTokens: 60_000, maxOutputTokens: 8_000,
+    maxWallClockMs: 60_000, preferredModel: 'sonnet',
+    hardCostCeilingUsd: 0.5,
+  }
+});
+```
+
+## Testing
+
+```bash
+pnpm test        # full Vitest suite (>=30 tests, including OWASP top-10 golden)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # emit dist/
+pnpm lint        # eslint src tests
+```
+
+The test suite includes interface compliance, contract structural checks, registration disjointness vs frontend + backend + database, output validation, run() idempotency, dependency declaration (`['backend','database']`), cross-architect invariants (OWASP coverage, CSP strict-dynamic, HSTS preload, deny-by-default, defence-in-depth tenant isolation, never-log secrets, required audit events), and an end-to-end golden test against a known prakash-tiwari contact-form Story ticket.
+
+## Why precedence rank 1
+
+Security holds rank 1 in the canonical precedence ladder (spec §5.2). When two architects disagree semantically (e.g. Frontend wants a Calendly embed, Security wants `frame-src 'none'`), the Dispatcher resolves by precedence — Security's field survives, the loser's field carries a `_dissent` annotation. Operator override is the only escape valve, and it requires Reviewer acknowledgement.
+
+## Forward references
+
+- `@caia/secrets-adapter` — runtime implementation of `secretsHandling.provider: "vault"`.
+- `@chiefaia/capability-broker` — irreversible-action gating for operator-elevated cross-tenant break-glass.
+- `@chiefaia/secrets-broker` — older sibling; the adapter supersedes it.

--- a/packages/security-architect/eslint.config.cjs
+++ b/packages/security-architect/eslint.config.cjs
@@ -1,0 +1,32 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on frontend-architect).
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/security-architect/package.json
+++ b/packages/security-architect/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@caia/security-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Security Architect — architect #10 of CAIA's 17-architect EA fan-out. Owns the `security.*` slice of `tickets.architecture` (authenticationStrategy, authorizationRules, secretsHandling, owaspMitigations, securityHeaders, inputValidation, rateLimitingRules, auditLogRequirements, tenantIsolationGuarantees). Senior security engineer focused on OWASP top-10 + auth (OAuth/JWT/Cloudflare Access) + secrets (forward-reference to @caia/secrets-adapter) + multi-tenant isolation (per-tenant Postgres schema isolation + scoped credentials). Depends on Backend Architect + Database Architect upstream. Per the EA Dispatcher precedence ladder Security holds rank 1 — its outputs win every semantic conflict short of operator override. Does NOT write component code or backend logic; specifies how every endpoint is authenticated, authorized, rate-limited, and audited. Spawns Claude via @chiefaia/claude-spawner (subscription-only) with Sonnet default.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@caia/backend-architect": "workspace:*",
+    "@caia/database-architect": "workspace:*",
+    "@caia/frontend-architect": "workspace:*",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/security-architect/src/architect.ts
+++ b/packages/security-architect/src/architect.ts
@@ -1,0 +1,67 @@
+/**
+ * `SecurityArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (per task brief — the spec §2.10
+ *     `caia-cspchecker` tool is V2).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from
+ * `@caia/architect-kit` — we satisfy `SpecialistArchitect`
+ * structurally to mirror the template exactly. When the kit's
+ * `BaseArchitect` becomes the canonical extension point (next minor),
+ * switch to `extends BaseArchitect`.
+ */
+
+import { SecurityArchitectContract } from './contract.js';
+import { runSecurityArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildSecuritySystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches `@caia/security-architect` minus the suffix. */
+export const SECURITY_ARCHITECT_NAME = 'security' as const;
+
+/** V1: no architect-specific tools. The `caia-cspchecker` tool is V2. */
+export const SECURITY_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface SecurityArchitectConfig {
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class SecurityArchitect implements SpecialistArchitect {
+  readonly name = SECURITY_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = SecurityArchitectContract;
+  readonly tools: readonly ToolDefinition[] = SECURITY_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: SecurityArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  systemPrompt(): string {
+    return buildSecuritySystemPrompt();
+  }
+
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runSecurityArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/security-architect/src/contract.ts
+++ b/packages/security-architect/src/contract.ts
@@ -1,0 +1,230 @@
+/**
+ * `SecurityArchitectContract` — the canonical owned-fields declaration
+ * for architect #10 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.10 (Security Architect owns `security.*`)
+ *   - task brief (authenticationStrategy, authorizationRules,
+ *     secretsHandling, owaspMitigations, securityHeaders, inputValidation,
+ *     rateLimitingRules, auditLogRequirements, tenantIsolationGuarantees)
+ *
+ * The spec §2.10 enumerated `authnFlow`/`authzModel`/`cspPolicy`/etc.;
+ * the task brief reframes those as outcome-oriented names
+ * (`authenticationStrategy`, `authorizationRules`, `securityHeaders` —
+ * CSP is one row inside `securityHeaders`). The task brief is the
+ * source of truth; field names below mirror the brief verbatim. Each
+ * owned field carries its V1 default in `SECURITY_FIELD_FIX_HINTS`.
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. Every key lives under the `security.*`
+ * namespace and does not collide with any sibling architect.
+ *
+ * Upstream dependencies (`dependsOn`): Backend Architect
+ * (`backend.apiEndpoints`, `backend.endpointEnumeration`,
+ * `backend.authRequirements`, `backend.rateLimits`) and Database
+ * Architect (`database.rlsPolicies`, `database.tenantIsolationStrategy`,
+ * `database.jsonbShapes`, `database.dataLifecycle`). Security is a
+ * **wave-2** architect.
+ *
+ * Precedence rank **1 (highest)** per spec §5.2 — Security's outputs
+ * win every semantic conflict short of a Reviewer-acknowledged operator
+ * override.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the
+ * fix-hint dictionary lives next to the contract so the system-prompt
+ * builder and the future EA Reviewer can surface it without changing
+ * kit shape.
+ */
+export const SECURITY_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'security.authenticationStrategy':
+    'Default to Cloudflare Access for tenant-scoped routes + OAuth 2.0 + JWT (RS256, 15min access TTL + 30day refresh sliding) for end-user sessions + service-token for orchestrator-internal + public for marketing. MFA required for operator + BYOK + admin. Reject API-key-as-bearer for end-user auth.',
+  'security.authorizationRules':
+    'RBAC for coarse role grants (owner|admin|member|viewer); ABAC for fine-grained per-resource checks (row.tenant_id == ctx.tenantId). Output {model:"rbac+abac",roles,permissions,resourceOwnership,denyByDefault:true}. Always deny-by-default; explicit grant required.',
+  'security.secretsHandling':
+    'Forward-reference @caia/secrets-adapter. Output {provider:"vault",namespace:"tenant/{{tenantId}}",rotationPolicy:{kind:"scheduled",intervalDays:90},perSecret,injection:"env-at-runtime",neverLog:["password","token","secret","authorization",...]}. Never persist secrets in tickets, designVersion, audit logs, error envelopes, or LLM context.',
+  'security.owaspMitigations':
+    'Required: a verdict + concrete mitigation for EACH of the OWASP Top-10 2021 categories (a01..a10). Each entry: {verdict:"mitigated"|"accepted-risk"|"not-applicable",mitigations:[...],evidenceRefs:[...]}. accepted-risk requires acceptedBy + acceptedOn.',
+  'security.securityHeaders':
+    'Locked defaults: CSP strict-dynamic + nonce; HSTS max-age 31536000 includeSubDomains preload; X-Frame-Options DENY; X-Content-Type-Options nosniff; Referrer-Policy strict-origin-when-cross-origin; Permissions-Policy minimal; COOP same-origin; COEP require-corp; CORP same-origin. Iframe embeds require explicit allowlist + operator approval.',
+  'security.inputValidation':
+    'Every endpoint with body/query/path-param MUST declare a Zod schema ref plus sanitization (trim, stripHtml, canonicalize, maxBodyBytes, allowedContentTypes). globalDefaults must set rejectUnknownKeys=true and maxBodyBytes. Cross-reference Backend\'s requestSchemas.',
+  'security.rateLimitingRules':
+    'Per-endpoint limits scoped by tenant|ip|user. perAuthTier escalates public ≤ authenticated ≤ service. onLimit defaults to 429-retry-after with optional penaltySec. Marketing endpoints strictly capped.',
+  'security.auditLogRequirements':
+    'Every auth event, authz decision (especially denies), secret access, role change, tenant-isolation breach attempt, admin action MUST log. Output {sink,retentionDays:365,perEventType:{...},redactionRules:[...]}. Required event types include auth.login.failure, authz.deny, secrets.access, tenant.isolation.breach.attempt.',
+  'security.tenantIsolationGuarantees':
+    'Per-tenant Postgres schema isolation + scoped credentials. Cross-reference Database `tenantIsolationStrategy` + `rlsPolicies`. enforcement MUST include `scoped-db-credentials` AND `rls-defence-in-depth`. crossTenantAccess: forbidden-without-operator-elevation.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const SECURITY_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'security.authenticationStrategy',
+    description:
+      'Per-endpoint authentication: Cloudflare Access default for tenant routes, OAuth + JWT for end-user sessions, service-token for orchestrator-internal, public for marketing. Includes session TTL, refresh strategy, MFA posture, OAuth provider list.',
+    required: true
+  },
+  {
+    path: 'security.authorizationRules',
+    description:
+      'RBAC + ABAC policy: coarse role grants (owner/admin/member/viewer) plus fine-grained per-resource attribute checks (row ownership, tenant scope). Deny-by-default; every grant is explicit. Cross-references Database\'s row-ownership columns.',
+    required: true
+  },
+  {
+    path: 'security.secretsHandling',
+    description:
+      'Forward-reference to `@caia/secrets-adapter` patterns: Vault namespace per tenant, AppRole short-lived tokens, per-secret rotation policy, never-log allowlist. The Security Architect declares posture; the secrets adapter implements it.',
+    required: true
+  },
+  {
+    path: 'security.owaspMitigations',
+    description:
+      'OWASP Top-10 2021 enumeration with verdict + concrete mitigations per item (A01–A10). Each verdict is `mitigated`|`accepted-risk`|`not-applicable`; accepted-risk requires operator name + date. Evidence refs link to other architects\' fields.',
+    required: true
+  },
+  {
+    path: 'security.securityHeaders',
+    description:
+      'HTTP response header policy: CSP (strict-dynamic + nonce), HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, COOP/COEP/CORP. Locked defaults; any override is operator-approved.',
+    required: true
+  },
+  {
+    path: 'security.inputValidation',
+    description:
+      'Per-endpoint input validation contract: Zod schema reference + sanitization rules (trim, strip-HTML, canonicalize, max body bytes, allowed content types, reject-unknown-keys). Cross-references Backend\'s `requestSchemas`.',
+    required: true
+  },
+  {
+    path: 'security.rateLimitingRules',
+    description:
+      'Per-endpoint rate limits scoped by tenant|ip|user with on-limit behaviour (429 + retry-after, optional penalty window). Cross-references Backend\'s `rateLimits`; Security\'s output is the binding default the API-Gateway Architect wires into Cloudflare WAF.',
+    required: true
+  },
+  {
+    path: 'security.auditLogRequirements',
+    description:
+      'Per-event-type audit-log spec: authentication events, authorization decisions (especially denies), secret access, role changes, tenant-isolation breach attempts, admin actions. Includes sink, retention, redaction rules, alert thresholds.',
+    required: true
+  },
+  {
+    path: 'security.tenantIsolationGuarantees',
+    description:
+      'Per-tenant Postgres schema isolation guarantees: schema-search-path, scoped DB credentials, RLS as defence-in-depth, tenant-id on every row, breach detection. Cross-references Database\'s `tenantIsolationStrategy` and `rlsPolicies`.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths.
+ */
+export const SECURITY_OWNED_FIELD_KEYS: readonly string[] = SECURITY_OWNED_SECTIONS.map(
+  s => s.path
+);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Spec §2.10 — Security runs on every ticket that exposes an endpoint
+ * or touches data: Page, Story, Form, List, Foundation. Widget tickets
+ * typically inherit from the parent Page's security posture; only run
+ * when explicitly flagged with `api`, `auth`, `security`, `persists`,
+ * or `backend` quality tag.
+ */
+export function securityArchitectAppliesPredicate(ticket: Ticket): boolean {
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List' ||
+    ticket.type === 'Foundation'
+  ) {
+    return true;
+  }
+  if (ticket.type === 'Widget') {
+    const tags = ticket.quality_tags ?? [];
+    return (
+      tags.includes('api') ||
+      tags.includes('auth') ||
+      tags.includes('security') ||
+      tags.includes('persists') ||
+      tags.includes('backend')
+    );
+  }
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * Security is a wave-2 architect — `dependsOn: ['backend', 'database']`.
+ * Precedence rank **1 (highest)** per spec §5.2 — Security veto wins
+ * every semantic conflict short of operator override.
+ */
+export const SECURITY_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['backend', 'database'],
+  precedenceLevel: 1,
+  fanoutPolicy: 'always',
+  appliesPredicate: securityArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const SecurityArchitectContract: ArchitectSectionContract = {
+  contractId: 'security-architect.v1',
+  architectName: 'security',
+  version: '0.1.0',
+  sections: SECURITY_OWNED_SECTIONS,
+  architectMeta: SECURITY_ARCHITECT_META
+};
+
+// ─── OWASP top-10 coverage helper ───────────────────────────────────────────
+
+/**
+ * The canonical OWASP Top-10 2021 keys the Security Architect's
+ * `owaspMitigations` field MUST cover. Order matches the OWASP
+ * publication order (A01..A10).
+ */
+export const OWASP_TOP_10_KEYS: readonly string[] = [
+  'a01_brokenAccessControl',
+  'a02_cryptographicFailures',
+  'a03_injection',
+  'a04_insecureDesign',
+  'a05_securityMisconfiguration',
+  'a06_vulnerableComponents',
+  'a07_authFailures',
+  'a08_softwareDataIntegrity',
+  'a09_loggingMonitoringFailures',
+  'a10_ssrf'
+];
+
+/**
+ * Human-readable OWASP Top-10 2021 category names.
+ */
+export const OWASP_TOP_10_NAMES: Readonly<Record<string, string>> = {
+  a01_brokenAccessControl: 'A01:2021 — Broken Access Control',
+  a02_cryptographicFailures: 'A02:2021 — Cryptographic Failures',
+  a03_injection: 'A03:2021 — Injection',
+  a04_insecureDesign: 'A04:2021 — Insecure Design',
+  a05_securityMisconfiguration: 'A05:2021 — Security Misconfiguration',
+  a06_vulnerableComponents: 'A06:2021 — Vulnerable and Outdated Components',
+  a07_authFailures: 'A07:2021 — Identification and Authentication Failures',
+  a08_softwareDataIntegrity: 'A08:2021 — Software and Data Integrity Failures',
+  a09_loggingMonitoringFailures: 'A09:2021 — Security Logging and Monitoring Failures',
+  a10_ssrf: 'A10:2021 — Server-Side Request Forgery (SSRF)'
+};

--- a/packages/security-architect/src/index.ts
+++ b/packages/security-architect/src/index.ts
@@ -1,0 +1,95 @@
+/**
+ * @caia/security-architect — public surface.
+ *
+ * Architect #10 of CAIA's 17-architect EA fan-out. Senior security
+ * engineer focused on OWASP top-10 mitigations, authentication
+ * (Cloudflare Access / OAuth / JWT), authorization (RBAC + ABAC),
+ * secrets handling (forward-reference to `@caia/secrets-adapter`),
+ * and multi-tenant isolation (per-tenant Postgres schema isolation +
+ * scoped credentials).
+ *
+ * Depends on Backend Architect + Database Architect upstream. Holds
+ * precedence rank 1 — its outputs win every semantic conflict short of
+ * a Reviewer-acknowledged operator override (spec §5.2).
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template (architect
+ * #1, PR #537) and `@caia/database-architect` template (architect #3).
+ *
+ * Registration: import this package's `registerWith()` helper to
+ * install the architect on a registry. The package does NOT
+ * self-register on import.
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { SecurityArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  SecurityArchitect,
+  SECURITY_ARCHITECT_NAME,
+  SECURITY_ARCHITECT_TOOLS
+} from './architect.js';
+export type { SecurityArchitectConfig } from './architect.js';
+
+export {
+  SecurityArchitectContract,
+  SECURITY_OWNED_SECTIONS,
+  SECURITY_OWNED_FIELD_KEYS,
+  SECURITY_FIELD_FIX_HINTS,
+  SECURITY_ARCHITECT_META,
+  OWASP_TOP_10_KEYS,
+  OWASP_TOP_10_NAMES,
+  securityArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildSecuritySystemPrompt } from './system-prompt.js';
+
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+export { runSecurityArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+export { SECURITY_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh SecurityArchitect on the given registry.
+ */
+export function registerWith(registry: ArchitectRegistry): SecurityArchitect {
+  const architect = new SecurityArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/security-architect/src/invariants.ts
+++ b/packages/security-architect/src/invariants.ts
@@ -1,0 +1,273 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'security.owaspMitigations'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `security.*` path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+import { OWASP_TOP_10_KEYS } from './contract.js';
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  contributor: string;
+  reads: readonly string[];
+  severity: InvariantSeverity;
+  description: string;
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+function asObject(v: unknown): Readonly<Record<string, unknown>> | null {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return null;
+  return v as Readonly<Record<string, unknown>>;
+}
+
+function asArray(v: unknown): readonly unknown[] | null {
+  return Array.isArray(v) ? v : null;
+}
+
+const ALLOWED_VERDICTS = new Set(['mitigated', 'accepted-risk', 'not-applicable']);
+
+export const SECURITY_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'security.owasp-top10-fully-covered',
+    contributor: 'security',
+    reads: ['security.owaspMitigations'],
+    severity: 'fail',
+    description:
+      'Every Security output must declare a verdict + mitigation for ALL OWASP Top-10 2021 categories (a01..a10). Missing categories are silent vulnerabilities.',
+    detect(arch): boolean {
+      const owasp = asObject(readField(arch, 'security.owaspMitigations'));
+      if (!owasp) return false;
+      for (const key of OWASP_TOP_10_KEYS) {
+        const entry = asObject(owasp[key]);
+        if (!entry) return false;
+        if (typeof entry.verdict !== 'string') return false;
+        if (!ALLOWED_VERDICTS.has(entry.verdict)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'security.owasp-accepted-risk-has-operator-signoff',
+    contributor: 'security',
+    reads: ['security.owaspMitigations'],
+    severity: 'fail',
+    description:
+      'Any OWASP entry with verdict `accepted-risk` MUST declare `acceptedBy` (operator name) + `acceptedOn` (date). Otherwise the accept-risk is unauditable.',
+    detect(arch): boolean {
+      const owasp = asObject(readField(arch, 'security.owaspMitigations'));
+      if (!owasp) return true;
+      for (const key of OWASP_TOP_10_KEYS) {
+        const entry = asObject(owasp[key]);
+        if (!entry) continue;
+        if (entry.verdict === 'accepted-risk') {
+          if (typeof entry.acceptedBy !== 'string' || (entry.acceptedBy as string).length === 0) return false;
+          if (typeof entry.acceptedOn !== 'string' || (entry.acceptedOn as string).length === 0) return false;
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'security.csp-strict-dynamic-no-unsafe-inline',
+    contributor: 'security',
+    reads: ['security.securityHeaders'],
+    severity: 'fail',
+    description:
+      'CSP MUST use strict-dynamic and MUST NOT contain `unsafe-inline` or `unsafe-eval` in any directive. Locked stack requirement.',
+    detect(arch): boolean {
+      const headers = asObject(readField(arch, 'security.securityHeaders'));
+      if (!headers) return false;
+      const csp = asObject(headers.csp);
+      if (!csp) return false;
+      const directive = typeof csp.directive === 'string' ? csp.directive : '';
+      if (!directive.includes('strict-dynamic')) return false;
+      for (const [, value] of Object.entries(csp)) {
+        const arr = asArray(value);
+        if (!arr) continue;
+        for (const v of arr) {
+          if (typeof v !== 'string') continue;
+          if (v.includes('unsafe-inline')) return false;
+          if (v.includes('unsafe-eval')) return false;
+        }
+      }
+      return true;
+    }
+  },
+  {
+    id: 'security.hsts-preloaded-includesubdomains',
+    contributor: 'security',
+    reads: ['security.securityHeaders'],
+    severity: 'fail',
+    description:
+      'HSTS MUST be max-age ≥ 31536000 with includeSubDomains=true and preload=true.',
+    detect(arch): boolean {
+      const headers = asObject(readField(arch, 'security.securityHeaders'));
+      if (!headers) return false;
+      const hsts = asObject(headers.hsts);
+      if (!hsts) return false;
+      if (typeof hsts.maxAgeSec !== 'number' || (hsts.maxAgeSec as number) < 31536000) return false;
+      if (hsts.includeSubDomains !== true) return false;
+      if (hsts.preload !== true) return false;
+      return true;
+    }
+  },
+  {
+    id: 'security.xframe-options-deny',
+    contributor: 'security',
+    reads: ['security.securityHeaders'],
+    severity: 'fail',
+    description:
+      'X-Frame-Options MUST be DENY. Iframe embeds require explicit allowlist + operator approval.',
+    detect(arch): boolean {
+      const headers = asObject(readField(arch, 'security.securityHeaders'));
+      if (!headers) return false;
+      return headers.xFrameOptions === 'DENY';
+    }
+  },
+  {
+    id: 'security.deny-by-default-authorization',
+    contributor: 'security',
+    reads: ['security.authorizationRules'],
+    severity: 'fail',
+    description:
+      'Authorization policy MUST set `denyByDefault: true`. Allow-by-default is a hard violation.',
+    detect(arch): boolean {
+      const authz = asObject(readField(arch, 'security.authorizationRules'));
+      if (!authz) return false;
+      return authz.denyByDefault === true;
+    }
+  },
+  {
+    id: 'security.tenant-isolation-defence-in-depth',
+    contributor: 'security',
+    reads: ['security.tenantIsolationGuarantees'],
+    severity: 'fail',
+    description:
+      'Tenant isolation guarantees MUST include both `scoped-db-credentials` and `rls-defence-in-depth`. Schema-per-tenant alone is necessary but not sufficient.',
+    detect(arch): boolean {
+      const iso = asObject(readField(arch, 'security.tenantIsolationGuarantees'));
+      if (!iso) return false;
+      const enforcement = asArray(iso.enforcement);
+      if (!enforcement) return false;
+      const set = new Set(enforcement.filter((v): v is string => typeof v === 'string'));
+      return set.has('scoped-db-credentials') && set.has('rls-defence-in-depth');
+    }
+  },
+  {
+    id: 'security.secrets-never-logged',
+    contributor: 'security',
+    reads: ['security.secretsHandling'],
+    severity: 'fail',
+    description:
+      'secretsHandling.neverLog MUST include `password`, `token`, `secret`, and `authorization`.',
+    detect(arch): boolean {
+      const sec = asObject(readField(arch, 'security.secretsHandling'));
+      if (!sec) return false;
+      const neverLog = asArray(sec.neverLog);
+      if (!neverLog) return false;
+      const set = new Set(neverLog.filter((v): v is string => typeof v === 'string'));
+      return ['password', 'token', 'secret', 'authorization'].every(k => set.has(k));
+    }
+  },
+  {
+    id: 'security.audit-required-event-types',
+    contributor: 'security',
+    reads: ['security.auditLogRequirements'],
+    severity: 'fail',
+    description:
+      'Audit-log requirements MUST cover auth.login.failure, authz.deny, secrets.access, and tenant.isolation.breach.attempt.',
+    detect(arch): boolean {
+      const audit = asObject(readField(arch, 'security.auditLogRequirements'));
+      if (!audit) return false;
+      const perEvent = asObject(audit.perEventType);
+      if (!perEvent) return false;
+      const required = [
+        'auth.login.failure',
+        'authz.deny',
+        'secrets.access',
+        'tenant.isolation.breach.attempt'
+      ];
+      return required.every(k => k in perEvent);
+    }
+  },
+  {
+    id: 'security.rate-limit-marketing-tightest',
+    contributor: 'security',
+    reads: ['security.rateLimitingRules'],
+    severity: 'advisory',
+    description:
+      'perAuthTier rate limits should escalate from public → authenticated → service.',
+    detect(arch): boolean {
+      const rl = asObject(readField(arch, 'security.rateLimitingRules'));
+      if (!rl) return false;
+      const tier = asObject(rl.perAuthTier);
+      if (!tier) return true;
+      const pub = asObject(tier.public);
+      const auth = asObject(tier.authenticated);
+      const svc = asObject(tier.service);
+      const pubMax = pub && typeof pub.max === 'number' ? (pub.max as number) : null;
+      const authMax = auth && typeof auth.max === 'number' ? (auth.max as number) : null;
+      const svcMax = svc && typeof svc.max === 'number' ? (svc.max as number) : null;
+      if (pubMax !== null && authMax !== null && pubMax > authMax) return false;
+      if (authMax !== null && svcMax !== null && authMax > svcMax) return false;
+      return true;
+    }
+  },
+  {
+    id: 'security.input-validation-global-defaults',
+    contributor: 'security',
+    reads: ['security.inputValidation'],
+    severity: 'fail',
+    description:
+      'inputValidation.globalDefaults MUST set rejectUnknownKeys=true and define maxBodyBytes.',
+    detect(arch): boolean {
+      const iv = asObject(readField(arch, 'security.inputValidation'));
+      if (!iv) return false;
+      const defaults = asObject(iv.globalDefaults);
+      if (!defaults) return false;
+      if (defaults.rejectUnknownKeys !== true) return false;
+      if (typeof defaults.maxBodyBytes !== 'number' || (defaults.maxBodyBytes as number) <= 0) return false;
+      return true;
+    }
+  },
+  {
+    id: 'security.authentication-strategy-declared',
+    contributor: 'security',
+    reads: ['security.authenticationStrategy'],
+    severity: 'fail',
+    description:
+      'authenticationStrategy MUST declare a default scheme and a session model.',
+    detect(arch): boolean {
+      const auth = asObject(readField(arch, 'security.authenticationStrategy'));
+      if (!auth) return false;
+      if (typeof auth.default !== 'string' || (auth.default as string).length === 0) return false;
+      const session = asObject(auth.sessionModel);
+      if (!session) return false;
+      if (typeof session.kind !== 'string') return false;
+      return true;
+    }
+  }
+];

--- a/packages/security-architect/src/run.ts
+++ b/packages/security-architect/src/run.ts
@@ -1,0 +1,136 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append).
+ *
+ * Architect-specific projections vs the canonical template:
+ *   - Security is wave-2; both Backend and Database run upstream.
+ *   - `dependencies` always includes ['backend', 'database'] regardless
+ *     of what the model emitted (preserving sibling-ticket IDs).
+ *   - Tenant context exposes `vaultNamespace` + `schemaName` so the
+ *     architect can declare `secretsHandling.namespace` and
+ *     cross-validate `tenantIsolationGuarantees`.
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { SECURITY_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      schemaName: input.tenantContext.schemaName,
+      vaultNamespace: input.tenantContext.vaultNamespace,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+export async function runSecurityArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: ['backend', 'database'],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, SECURITY_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: ['backend', 'database'],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  const parsed = validation.parsed;
+  const upstreamDeps = ensureUpstreamDependencies(parsed.dependencies);
+  return {
+    ...parsed,
+    architectName: deps.architectName,
+    dependencies: upstreamDeps,
+    spend
+  };
+}
+
+/**
+ * Ensure `backend` and `database` are present in the dependency list
+ * (preserving any sibling-ticket IDs the model emitted). Idempotent —
+ * does not duplicate.
+ */
+function ensureUpstreamDependencies(
+  emitted: readonly string[] | undefined
+): readonly string[] {
+  const set = new Set(emitted ?? []);
+  set.add('backend');
+  set.add('database');
+  return Array.from(set);
+}

--- a/packages/security-architect/src/spawner.ts
+++ b/packages/security-architect/src/spawner.ts
@@ -1,0 +1,118 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * Mirrors `@caia/frontend-architect`'s `spawner.ts` verbatim — only the
+ * architect-specific bits are in `run.ts` + `contract.ts`.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+export interface ArchitectSpawnOutput {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  model: string;
+  ok: boolean;
+  diagnostic: string | null;
+}
+
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/security-architect/src/system-prompt.md
+++ b/packages/security-architect/src/system-prompt.md
@@ -1,0 +1,100 @@
+# Security Architect — system prompt (human-readable mirror)
+
+This file is the **human-readable mirror** of the system prompt the
+`SecurityArchitect` ships to its spawned Claude subagent at runtime.
+The runtime source of truth is `./system-prompt.ts` — keep them in
+lockstep when editing.
+
+Architect identity: `security` (architect #10 of CAIA's 17-architect
+EA fan-out).
+
+Spec source: `research/17_architect_framework_spec_2026.md` §2.10
++ task brief reframing.
+
+Precedence rank: **1 (highest)**.
+
+Upstream dependencies: Backend Architect + Database Architect.
+
+---
+
+## Role
+
+You are CAIA's Security Architect. Senior security engineer focused on
+OWASP top-10 mitigations, authentication (Cloudflare Access / OAuth /
+JWT), authorization (RBAC + ABAC), secrets handling (forward-reference
+to `@caia/secrets-adapter`), and multi-tenant isolation.
+
+You produce per-ticket security specs. You DO NOT write component code
+or backend logic. You DO specify, for every endpoint and every data
+touchpoint: how it is authenticated, authorized, rate-limited, audited,
+and isolated across tenants.
+
+## Locked stack
+
+- **Authentication**: Cloudflare Access default; OAuth 2.0 + PKCE for
+  sign-in; JWT (RS256/EdDSA, 15min/30day sliding); service tokens
+  internal only; MFA for operator/BYOK/admin (TOTP default).
+- **Authorization**: RBAC (owner/admin/member/viewer) + ABAC (row
+  ownership, tenant scope); deny-by-default.
+- **Secrets**: `@caia/secrets-adapter` over Vault; per-tenant namespace
+  `tenant/{{tenantId}}`; short-lived AppRole tokens; 90-day rotation
+  default; never log secrets.
+- **HTTP headers**: CSP strict-dynamic + nonce; HSTS preload
+  max-age=31536000; X-Frame-Options DENY; X-Content-Type-Options
+  nosniff; Referrer-Policy strict-origin-when-cross-origin;
+  Permissions-Policy minimal; COOP/COEP/CORP same-origin.
+- **Input validation**: Zod schema per endpoint; trim + stripHtml +
+  canonicalize sanitization; 1 MB body cap default; rejectUnknownKeys.
+- **Rate limiting**: 60/min/tenant authenticated, 20/min/ip public,
+  600/min/tenant service; 429 + Retry-After.
+- **Audit logging**: central secure sink, 365-day retention; required
+  events include auth.login.failure, authz.deny, secrets.access,
+  tenant.isolation.breach.attempt.
+- **Multi-tenant isolation**: schema-per-tenant Postgres + per-tenant
+  DB credentials + RLS defence-in-depth + tenant_id column.
+- **OWASP Top-10 2021**: verdict + mitigation for every category.
+
+## Owned fields (9)
+
+- `security.authenticationStrategy`
+- `security.authorizationRules`
+- `security.secretsHandling`
+- `security.owaspMitigations`
+- `security.securityHeaders`
+- `security.inputValidation`
+- `security.rateLimitingRules`
+- `security.auditLogRequirements`
+- `security.tenantIsolationGuarantees`
+
+## OWASP Top-10 2021 — coverage required
+
+| Key                              | Category                                                 |
+|----------------------------------|----------------------------------------------------------|
+| `a01_brokenAccessControl`        | A01:2021 — Broken Access Control                         |
+| `a02_cryptographicFailures`      | A02:2021 — Cryptographic Failures                        |
+| `a03_injection`                  | A03:2021 — Injection                                     |
+| `a04_insecureDesign`             | A04:2021 — Insecure Design                               |
+| `a05_securityMisconfiguration`   | A05:2021 — Security Misconfiguration                     |
+| `a06_vulnerableComponents`       | A06:2021 — Vulnerable and Outdated Components            |
+| `a07_authFailures`               | A07:2021 — Identification and Authentication Failures    |
+| `a08_softwareDataIntegrity`      | A08:2021 — Software and Data Integrity Failures          |
+| `a09_loggingMonitoringFailures`  | A09:2021 — Security Logging and Monitoring Failures      |
+| `a10_ssrf`                       | A10:2021 — Server-Side Request Forgery (SSRF)            |
+
+Each entry must declare `verdict` (`mitigated` | `accepted-risk` |
+`not-applicable`) + `mitigations[]` + `evidenceRefs[]`.
+`accepted-risk` requires `acceptedBy` + `acceptedOn`.
+
+## Refusal patterns (summary)
+
+- API-key-as-bearer for end-user auth → refuse.
+- Disabling CSP / X-Frame-Options / HSTS → never.
+- `unsafe-inline` / `unsafe-eval` in CSP → never.
+- Iframe embeds without explicit allowlist → refuse.
+- Skipping an OWASP category → never.
+- Row-level isolation only (no schema-per-tenant) → refuse without
+  operator override; always REQUIRE RLS as defence-in-depth.
+- Storing a secret in a ticket / designVersion / businessPlan → refuse.
+- Skipping rate limiting on a public endpoint → never.
+- Plaintext logging of a secret / password / token → never.
+- Writing fields outside `security.*` → never.

--- a/packages/security-architect/src/system-prompt.ts
+++ b/packages/security-architect/src/system-prompt.ts
@@ -1,0 +1,334 @@
+/**
+ * The Security Architect's system prompt — a pure function returning a
+ * static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked stack
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples
+ *
+ * The system-prompt test asserts each `security.*` field name appears
+ * at least once AND every OWASP Top-10 key appears.
+ *
+ * Mirrors `@caia/frontend-architect`'s `system-prompt.ts` shape per the
+ * canonical template. A human-readable mirror lives in
+ * `./system-prompt.md` — keep them in lockstep when editing.
+ */
+
+import {
+  OWASP_TOP_10_KEYS,
+  OWASP_TOP_10_NAMES,
+  SECURITY_OWNED_FIELD_KEYS
+} from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildSecuritySystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_STACK,
+    SECTION_INPUT_FORMAT,
+    sectionOutputSchema(),
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    sectionSelfCheck(),
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Security Architect. You are a senior security engineer
+focused on OWASP top-10 mitigations, authentication (Cloudflare Access /
+OAuth / JWT), authorization (RBAC + ABAC), secrets handling
+(forward-reference to \`@caia/secrets-adapter\`), and multi-tenant
+isolation (per-tenant Postgres schema isolation + scoped credentials).
+
+You produce per-ticket security specs. You DO NOT write component code
+or backend logic — Frontend, Backend, Database, and DevOps architects
+own those. You DO specify, for every endpoint and every data touchpoint:
+how it is authenticated, authorized, rate-limited, audited, and isolated
+across tenants. You read the Backend Architect's \`apiEndpoints\` +
+\`authRequirements\` + \`rateLimits\` and the Database Architect's
+\`rlsPolicies\` + \`tenantIsolationStrategy\` + \`jsonbShapes\` +
+\`dataLifecycle\` as upstream input, then cross-validate and emit the
+binding security contract.
+
+You own the highest precedence rank in the EA Dispatcher (rank 1). Your
+decisions win every semantic conflict short of a Reviewer-acknowledged
+operator override. Use that authority deliberately — flag every
+deviation from a locked default in \`risks[]\` so the Reviewer can audit
+your reasoning.
+
+Output tight architecture that a coding worker can implement directly:
+header strings the worker can paste into middleware, Zod schema refs
+the worker can compose, audit-log event types the worker can emit, RLS
+predicates the worker can verify by SQL.`;
+
+const SECTION_LOCKED_STACK = `## Locked stack
+
+- **Authentication**:
+  - **Cloudflare Access** as the default outer perimeter for every
+    tenant-scoped route (browser-facing + API). Identity provider
+    federation via Cloudflare Zero Trust (Google, GitHub, OIDC).
+  - **OAuth 2.0 + PKCE** for end-user sign-in flows.
+  - **JWT** for stateless session bearer (asymmetric RS256 / EdDSA), 15
+    min access TTL + 30 day refresh with sliding rotation.
+  - **Service tokens** for orchestrator-internal RPC; never reuse a
+    service token for end-user auth.
+  - **MFA**: required for operator + BYOK-customer + any role with
+    \`admin\` grant. TOTP default; WebAuthn allowed.
+- **Authorization**: RBAC for coarse role grants (\`owner\`, \`admin\`,
+  \`member\`, \`viewer\`); ABAC for fine-grained per-row checks (must
+  own row, must be in tenant, must match attribute). Deny-by-default.
+  Every grant explicit.
+- **Secrets**: \`@caia/secrets-adapter\` over Vault. Per-tenant
+  namespace \`tenant/{{tenantId}}\`. Short-lived Vault AppRole tokens
+  (≤1h). Per-secret rotation policy with 90-day default. Never log or
+  echo a secret value (including in error envelopes, audit logs, LLM
+  context, ticket fields, designVersion blobs).
+- **HTTP headers**: CSP strict-dynamic + nonce-based; HSTS max-age
+  31536000 \`includeSubDomains preload\`; X-Frame-Options DENY;
+  X-Content-Type-Options nosniff; Referrer-Policy
+  strict-origin-when-cross-origin; Permissions-Policy minimal;
+  Cross-Origin-Opener-Policy same-origin; Cross-Origin-Embedder-Policy
+  require-corp; Cross-Origin-Resource-Policy same-origin. Any iframe
+  embed requires explicit allowlist + operator approval.
+- **Input validation**: every endpoint with a body / query / path-param
+  declares a Zod schema reference; sanitization rules applied before
+  the schema (trim, strip-html, canonicalize). \`maxBodyBytes\`
+  defaults 1 MB; \`rejectUnknownKeys: true\`; allowed content types
+  default \`application/json\`.
+- **Rate limiting**: default 60 req/min/tenant authenticated, 20
+  req/min/ip public, 600 req/min/tenant service-token. \`429
+  Retry-After\` on limit; optional penalty window on abuse. Marketing
+  endpoints strictly capped.
+- **Audit logging**: \`@caia/logger\` to the central secure sink with
+  365-day retention. Every authentication event, authorization decision
+  (especially denies), secret access, role change, tenant-isolation
+  breach attempt, and admin action MUST emit. Redaction rules drop raw
+  secrets / passwords / tokens / unredacted PII.
+- **Multi-tenant isolation**: schema-per-tenant Postgres (matches
+  Database Architect's \`tenantIsolationStrategy\`). Defence in depth:
+  per-tenant DB credential scope + RLS on every tenant-scoped table +
+  \`tenant_id\` column on every tenant-scoped row + query-fingerprint
+  audit. Cross-tenant access is forbidden without operator-elevated
+  break-glass.
+- **OWASP Top-10 2021**: enumerate every category with a verdict +
+  concrete mitigation. \`accepted-risk\` requires operator name + date.
+
+Reject any decision that violates a locked default. List violations in
+\`risks[]\`, set \`confidence\` ≤ 0.5, and pick the locked default
+anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptance_criteria": ["..."] },
+  "businessPlan": { "ventureName": "...", "oneLiner": "...",
+                    "audience": "...", "goals": ["..."] },
+  "designVersion": { "versionId": "...", "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "subscription|byok" },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "backend": {
+      "architectureFields": {
+        "backend.apiEndpoints": [ ... ],
+        "backend.endpointEnumeration": [ ... ],
+        "backend.authRequirements": { ... },
+        "backend.rateLimits": { ... },
+        "backend.errorEnvelope": { ... },
+        "backend.requestSchemas": { ... }
+      }
+    },
+    "database": {
+      "architectureFields": {
+        "database.tables": [ ... ],
+        "database.rlsPolicies": { ... },
+        "database.tenantIsolationStrategy": { ... },
+        "database.jsonbShapes": { ... },
+        "database.dataLifecycle": [ ... ]
+      }
+    }
+  } }
+}
+\`\`\`
+
+You MUST read \`upstream.outputs.backend.architectureFields\` to
+enumerate endpoints AND
+\`upstream.outputs.database.architectureFields\` to cross-validate
+tenant isolation + data classification. Security is a wave-2 architect;
+if either Backend or Database is absent from \`upstream.outputs\`, you
+are running outside the canonical pipeline — set \`confidence\` ≤ 0.5
+and list the missing upstream(s) under \`risks[]\`.`;
+
+function sectionOutputSchema(): string {
+  return `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No
+prose outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "security",
+  "architectureFields": {
+${SECURITY_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "usdCost": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`security.authenticationStrategy\` — default Cloudflare Access; per-endpoint overrides; sessionModel JWT RS256 15min/30day sliding; MFA admin/operator/BYOK TOTP; OAuth providers github+google. Cross-validate against Backend's \`authRequirements\`.
+- \`security.authorizationRules\` — RBAC + ABAC; deny-by-default; per-resource ownership conditions referencing Database row-ownership columns.
+- \`security.secretsHandling\` — Vault provider; per-tenant namespace; AppRole short-lived tokens; per-secret rotation 90d default; neverLog allowlist always includes password, token, secret, authorization.
+- \`security.owaspMitigations\` — ONE entry per OWASP Top-10 2021 category with verdict + mitigations + evidenceRefs. KEYS REQUIRED (verbatim):
+${OWASP_TOP_10_KEYS.map(k => `  - \`${k}\` — ${OWASP_TOP_10_NAMES[k]}`).join('\n')}
+- \`security.securityHeaders\` — CSP strict-dynamic + nonce; HSTS preload max-age 31536000; X-Frame-Options DENY; X-Content-Type-Options nosniff; Referrer-Policy strict-origin-when-cross-origin; Permissions-Policy minimal; COOP same-origin; COEP require-corp; CORP same-origin.
+- \`security.inputValidation\` — perEndpoint Zod schema ref + sanitization; globalDefaults rejectUnknownKeys=true + maxBodyBytes.
+- \`security.rateLimitingRules\` — perEndpoint scoped by tenant|ip|user; perAuthTier public ≤ authenticated ≤ service; 429-retry-after onLimit.
+- \`security.auditLogRequirements\` — central-secure-store sink, 365-day retention, perEventType must include auth.login.failure, authz.deny, secrets.access, tenant.isolation.breach.attempt.
+- \`security.tenantIsolationGuarantees\` — schema-per-tenant; enforcement MUST include scoped-db-credentials AND rls-defence-in-depth; crossTenantAccess forbidden-without-operator-elevation.`;
+}
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **One endpoint = one auth entry + one rate-limit entry + one
+  input-validation entry.** For every \`backend.apiEndpoints\` route,
+  emit matching entries in \`authenticationStrategy.perEndpoint\`,
+  \`rateLimitingRules.perEndpoint\`, and \`inputValidation.perEndpoint\`
+  (the latter only when the endpoint accepts a body / query). Missing
+  entries are silent vulnerabilities — flag them in \`risks[]\`.
+- **Deny-by-default.** Every authorization permission is an explicit
+  grant. Reject any policy that defaults to allow.
+- **Tenant ID is sacred.** Every authorization condition that reads
+  database rows MUST include \`row.tenant_id == ctx.tenantId\`. Every
+  rate-limit scope MUST be tenant-aware (\`tenant\` or \`user\`) unless
+  the endpoint is marketing-public.
+- **OWASP every time.** Emit a verdict for ALL 10 categories — never
+  omit one. \`not-applicable\` is a valid verdict; the reason is still
+  REQUIRED.
+- **CSP nonce-based, never \`unsafe-inline\`.** Strict-dynamic with
+  per-request nonce is the only legal posture. \`'unsafe-inline'\` and
+  \`'unsafe-eval'\` are banned regardless of how convenient a third-party
+  widget would find them.
+- **HSTS preload, never disable.** Disabling HSTS for a single embed
+  is a 6-month commitment because of browser cache. Refuse.
+- **Defence in depth on tenant isolation.** Schema-per-tenant alone is
+  necessary but not sufficient — also require per-tenant DB credentials
+  AND RLS on every tenant-scoped table AND a tenant_id column on every
+  tenant-scoped row.
+- **Audit every deny.** Every authorization deny is logged with actor +
+  attempted action + resource + reason.
+- **Secrets never in tickets.** If you ever see a secret value
+  proposed for storage in \`tickets.architecture\`, \`designVersion\`,
+  or \`businessPlan\`, REFUSE.
+- **Rate limits scale with auth tier.** Public < authenticated <
+  service.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Use API-key-as-bearer for end-user auth** → refuse, set
+  \`authenticationStrategy.default\` to Cloudflare Access + OAuth + JWT,
+  list under \`risks[]\`, set \`confidence\` to 0.5.
+- **Disable CSP / drop \`X-Frame-Options\` / disable HSTS** → never.
+- **Permit \`unsafe-inline\` or \`unsafe-eval\` in CSP** → never.
+- **Allow an iframe embed without explicit allowlist** → refuse, list
+  the embed under \`risks[]\`, set \`securityHeaders.csp.frameSrc\` to
+  \`["'none'"]\` until the operator approves.
+- **Skip an OWASP Top-10 category** → never.
+- **Allow row-level isolation only (no schema-per-tenant)** → refuse
+  unless Database Architect already selected row-level with operator
+  override. Always REQUIRE RLS as defence-in-depth.
+- **Store a secret in a ticket / designVersion / businessPlan field**
+  → refuse, list under \`risks[]\`, forward to \`secretsHandling\`.
+- **Skip rate limiting on a public endpoint** → never.
+- **Allow plaintext logging of a secret / password / token** → never.
+- **Decide a database schema, API endpoint, UI component, CSS rule,
+  CI pipeline, or any field NOT under \`security.*\`** → ignore the
+  request. Do not populate fields outside your owned namespace.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is the documented default.`;
+
+function sectionSelfCheck(): string {
+  return `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the ${SECURITY_OWNED_FIELD_KEYS.length}
+   owned field paths (no extras, no missing).
+2. \`owaspMitigations\` contains an entry for EVERY OWASP Top-10 2021
+   key (a01..a10). Missing keys = critical bug.
+3. Every endpoint in Backend's \`apiEndpoints\` has a matching entry
+   in \`authenticationStrategy.perEndpoint\` AND
+   \`rateLimitingRules.perEndpoint\`. Body/query endpoints additionally
+   have an \`inputValidation.perEndpoint\` entry.
+4. \`securityHeaders.csp\` includes \`strict-dynamic\` + a nonce source;
+   \`frameSrc\` defaults to \`["'none'"]\`.
+5. \`securityHeaders.hsts.maxAgeSec\` ≥ 31536000 with
+   \`includeSubDomains=true\` and \`preload=true\`.
+6. \`authorizationRules.denyByDefault\` is true.
+7. \`tenantIsolationGuarantees.model\` matches Database Architect's
+   \`tenantIsolationStrategy.model\` (or flag the mismatch in
+   \`risks[]\`).
+8. \`tenantIsolationGuarantees.enforcement\` includes BOTH
+   \`scoped-db-credentials\` and \`rls-defence-in-depth\`.
+9. \`secretsHandling.neverLog\` includes \`password\`, \`token\`,
+   \`secret\`, \`authorization\`.
+10. \`auditLogRequirements.perEventType\` includes at minimum
+    \`auth.login.failure\`, \`authz.deny\`, \`secrets.access\`,
+    \`tenant.isolation.breach.attempt\`.
+11. \`confidence\` reflects how comfortable you are — sub-0.6 triggers
+    the EA Reviewer to scrutinize.
+12. \`notes\` is ≤ 800 characters.
+13. Output is a single JSON object. No prose. No code fences.`;
+}
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a Form Story ticket for "contact-form submission"
+produces an \`authenticationStrategy\` defaulting to Cloudflare Access
+with a per-endpoint override for the public POST endpoint (public auth
++ IP-scoped rate limit); an \`authorizationRules\` policy denying by
+default; \`securityHeaders\` with the locked CSP + HSTS + COOP/COEP
+defaults; \`inputValidation\` referencing Backend's \`ContactCreate\`
+Zod schema with trim + stripHtml + 1 MB body cap; \`rateLimitingRules\`
+with 10 req/min/IP on the public POST + per-auth-tier defaults; an
+\`auditLogRequirements\` block emitting auth.login.failure +
+authz.deny + secrets.access + tenant.isolation.breach.attempt with
+365-day retention; a \`tenantIsolationGuarantees\` block echoing
+Database's \`schema-per-tenant\` with all four defence-in-depth
+enforcement modes; \`secretsHandling\` forwarding to
+\`@caia/secrets-adapter\` with 90-day rotation; and a full
+\`owaspMitigations\` block with a verdict + concrete mitigation for
+EVERY one of A01..A10.`;

--- a/packages/security-architect/src/types.ts
+++ b/packages/security-architect/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * Mirrors the canonical `@caia/frontend-architect` template verbatim —
+ * only the architect-specific field-spec lives in `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/security-architect/src/validation.ts
+++ b/packages/security-architect/src/validation.ts
@@ -1,0 +1,192 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Pure + synchronous. Failures return a structured `ValidationResult`.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/security-architect/tests/architect.test.ts
+++ b/packages/security-architect/tests/architect.test.ts
@@ -1,0 +1,89 @@
+/**
+ * SecurityArchitect — interface compliance tests.
+ */
+import { describe, it, expect } from 'vitest';
+import type { SpecialistArchitect } from '../src/types.js';
+import { SecurityArchitect, SECURITY_ARCHITECT_NAME, SECURITY_ARCHITECT_TOOLS } from '../src/architect.js';
+import { SecurityArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('SecurityArchitect - SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new SecurityArchitect();
+    expect(a).toBeInstanceOf(SecurityArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new SecurityArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable name matching the package suffix', () => {
+    const a = new SecurityArchitect();
+    expect(a.name).toBe('security');
+    expect(a.name).toBe(SECURITY_ARCHITECT_NAME);
+  });
+
+  it('sectionContract equals exported contract', () => {
+    const a = new SecurityArchitect();
+    expect(a.sectionContract).toBe(SecurityArchitectContract);
+  });
+
+  it('sectionContract.architectName matches name (registry-invariant)', () => {
+    const a = new SecurityArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty tools array per V1', () => {
+    const a = new SecurityArchitect();
+    expect(a.tools).toBe(SECURITY_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('systemPrompt() is pure (identical output every call)', () => {
+    const a = new SecurityArchitect();
+    expect(a.systemPrompt()).toBe(a.systemPrompt());
+  });
+
+  it('systemPrompt() returns a non-empty string', () => {
+    const a = new SecurityArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the SpecialistArchitect interface structurally', () => {
+    const a = new SecurityArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('run() returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new SecurityArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('security');
+  });
+
+  it('constructor accepts an injected spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new SecurityArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to default', () => {
+    const a = new SecurityArchitect();
+    expect(a).toBeInstanceOf(SecurityArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/security-architect/tests/contract.test.ts
+++ b/packages/security-architect/tests/contract.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Section contract structural + registration tests.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+import { SecurityArchitect } from '../src/architect.js';
+import {
+  OWASP_TOP_10_KEYS,
+  OWASP_TOP_10_NAMES,
+  SECURITY_ARCHITECT_META,
+  SECURITY_FIELD_FIX_HINTS,
+  SECURITY_OWNED_SECTIONS,
+  SECURITY_OWNED_FIELD_KEYS,
+  SecurityArchitectContract,
+  securityArchitectAppliesPredicate
+} from '../src/contract.js';
+import { FrontendArchitectContract, FRONTEND_OWNED_FIELD_KEYS } from '@caia/frontend-architect';
+import { DatabaseArchitectContract, DATABASE_OWNED_FIELD_KEYS } from '@caia/database-architect';
+
+describe('SecurityArchitectContract — structural', () => {
+  it('contractId follows the canonical form', () => {
+    expect(SecurityArchitectContract.contractId).toBe('security-architect.v1');
+  });
+  it('architectName is `security`', () => {
+    expect(SecurityArchitectContract.architectName).toBe('security');
+  });
+  it('version follows semver-ish shape', () => {
+    expect(SecurityArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+  it('all owned field paths begin with `security.`', () => {
+    for (const key of SECURITY_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('security.')).toBe(true);
+    }
+  });
+  it('owned-field set covers all 9 task-brief mandatory fields', () => {
+    const required = [
+      'security.authenticationStrategy', 'security.authorizationRules',
+      'security.secretsHandling', 'security.owaspMitigations',
+      'security.securityHeaders', 'security.inputValidation',
+      'security.rateLimitingRules', 'security.auditLogRequirements',
+      'security.tenantIsolationGuarantees'
+    ];
+    for (const r of required) expect(SECURITY_OWNED_FIELD_KEYS).toContain(r);
+  });
+  it('exposes exactly 9 owned fields', () => {
+    expect(SECURITY_OWNED_FIELD_KEYS.length).toBe(9);
+  });
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of SECURITY_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(SecurityArchitectContract)).toEqual([]);
+  });
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(SecurityArchitectContract).sort()).toEqual([...SECURITY_OWNED_FIELD_KEYS].sort());
+  });
+  it('every owned field has a matching fix-hint entry', () => {
+    for (const key of SECURITY_OWNED_FIELD_KEYS) {
+      expect(SECURITY_FIELD_FIX_HINTS[key]).toBeDefined();
+      expect(SECURITY_FIELD_FIX_HINTS[key].length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('SecurityArchitectContract — architectMeta', () => {
+  it('declares Backend AND Database as upstream dependencies (wave-2)', () => {
+    expect(SECURITY_ARCHITECT_META.dependsOn).toEqual(['backend', 'database']);
+  });
+  it('precedence level is in [1, 17]', () => {
+    expect(SECURITY_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(SECURITY_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+  it('precedence level is 1 (highest)', () => {
+    expect(SECURITY_ARCHITECT_META.precedenceLevel).toBe(1);
+  });
+  it('fanoutPolicy is `always`', () => {
+    expect(SECURITY_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+  it('runtimeModel is `sonnet`', () => {
+    expect(SECURITY_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+  it('appliesPredicate is the exported function reference', () => {
+    expect(SECURITY_ARCHITECT_META.appliesPredicate).toBe(securityArchitectAppliesPredicate);
+  });
+  it('matches canonical precedence ladder for `security`', () => {
+    expect(precedenceRank('security')).toBe(SECURITY_ARCHITECT_META.precedenceLevel);
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('security');
+    expect(CANONICAL_PRECEDENCE_LADDER[0]).toBe('security');
+  });
+  it('outranks every other architect in the ladder', () => {
+    const r = precedenceRank('security');
+    for (const other of CANONICAL_PRECEDENCE_LADDER) {
+      if (other === 'security') continue;
+      expect(r).toBeLessThan(precedenceRank(other));
+    }
+  });
+});
+
+describe('OWASP_TOP_10 constants', () => {
+  it('declares exactly 10 keys', () => {
+    expect(OWASP_TOP_10_KEYS.length).toBe(10);
+  });
+  it('keys are unique', () => {
+    expect(new Set(OWASP_TOP_10_KEYS).size).toBe(OWASP_TOP_10_KEYS.length);
+  });
+  it('every key has a matching name (A##:2021 format)', () => {
+    for (const k of OWASP_TOP_10_KEYS) {
+      expect(OWASP_TOP_10_NAMES[k]).toBeDefined();
+      expect(OWASP_TOP_10_NAMES[k]).toMatch(/^A\d{2}:2021/);
+    }
+  });
+  it('keys in canonical A01..A10 order', () => {
+    expect(OWASP_TOP_10_KEYS[0]).toBe('a01_brokenAccessControl');
+    expect(OWASP_TOP_10_KEYS[9]).toBe('a10_ssrf');
+  });
+});
+
+describe('securityArchitectAppliesPredicate', () => {
+  const base = { id: 't1', type: 'Page' };
+  it('returns true for Page', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Page' })).toBe(true); });
+  it('returns true for Story', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Story' })).toBe(true); });
+  it('returns true for Form', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Form' })).toBe(true); });
+  it('returns true for List', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'List' })).toBe(true); });
+  it('returns true for Foundation', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Foundation' })).toBe(true); });
+  it('returns false for un-tagged Widget', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Widget' })).toBe(false); });
+  it('returns true for Widget tagged api', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['api'] })).toBe(true); });
+  it('returns true for Widget tagged auth', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['auth'] })).toBe(true); });
+  it('returns true for Widget tagged security', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['security'] })).toBe(true); });
+  it('returns true for Widget tagged persists', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Widget', quality_tags: ['persists'] })).toBe(true); });
+  it('returns false for unrecognised type', () => { expect(securityArchitectAppliesPredicate({ ...base, type: 'Cron' })).toBe(false); });
+});
+
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(readonly name: string, readonly sectionContract: ArchitectSectionContract) {}
+  systemPrompt(): string { return 'stub'; }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name, architectureFields: {}, confidence: 0, notes: 'stub',
+      dependencies: [], risks: [], toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed', failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+  beforeEach(() => { registry = new ArchitectRegistry(); });
+
+  it('registers the Security architect cleanly', () => {
+    expect(() => registry.register(new SecurityArchitect())).not.toThrow();
+    expect(registry.get('security')).toBeDefined();
+  });
+  it('claims every owned field path on the registry', () => {
+    registry.register(new SecurityArchitect());
+    for (const k of SECURITY_OWNED_FIELD_KEYS) expect(registry.ownerOf(k)).toBe('security');
+  });
+  it('rejects duplicate registration of same name', () => {
+    registry.register(new SecurityArchitect());
+    expect(() => registry.register(new SecurityArchitect())).toThrowError(ArchitectRegistryError);
+  });
+  it('rejects a second architect that overlaps owned paths', () => {
+    registry.register(new SecurityArchitect());
+    const colliding: ArchitectSectionContract = {
+      contractId: 'colliding.v1', architectName: 'colliding', version: '0.1.0',
+      sections: [{ path: 'security.owaspMitigations', description: 'colliding', required: true }],
+      architectMeta: { dependsOn: [], precedenceLevel: 15, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    expect(() => registry.register(new StubArchitect('colliding', colliding))).toThrowError(ArchitectRegistryError);
+  });
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new SecurityArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'devops-architect.v1', architectName: 'devops', version: '0.1.0',
+      sections: [{ path: 'devops.cicdPipeline', description: 'CI/CD', required: true }],
+      architectMeta: { dependsOn: [], precedenceLevel: 2, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    expect(() => registry.register(new StubArchitect('devops', disjointContract))).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(SECURITY_OWNED_FIELD_KEYS.length + 1);
+  });
+  it('disjointness() returns no conflicts when only Security is present', () => {
+    expect(disjointness([SecurityArchitectContract])).toEqual([]);
+  });
+  it('disjointness() detects conflict between Security and a clone', () => {
+    const clone: ArchitectSectionContract = { ...SecurityArchitectContract, contractId: 'security-clone.v1', architectName: 'security-clone' };
+    expect(disjointness([SecurityArchitectContract, clone]).length).toBe(SECURITY_OWNED_FIELD_KEYS.length);
+  });
+  it('Security and Frontend contracts have NO overlapping paths', () => {
+    expect(disjointness([SecurityArchitectContract, FrontendArchitectContract])).toEqual([]);
+  });
+  it('Security owned fields do not collide with Frontend owned fields', () => {
+    const fset = new Set(FRONTEND_OWNED_FIELD_KEYS);
+    for (const key of SECURITY_OWNED_FIELD_KEYS) expect(fset.has(key)).toBe(false);
+  });
+  it('Security and Database contracts have NO overlapping paths', () => {
+    expect(disjointness([SecurityArchitectContract, DatabaseArchitectContract])).toEqual([]);
+  });
+  it('Security owned fields do not collide with Database owned fields', () => {
+    const dset = new Set(DATABASE_OWNED_FIELD_KEYS);
+    for (const key of SECURITY_OWNED_FIELD_KEYS) expect(dset.has(key)).toBe(false);
+  });
+  it('Security, Frontend, Database three-way disjointness', () => {
+    expect(disjointness([SecurityArchitectContract, FrontendArchitectContract, DatabaseArchitectContract])).toEqual([]);
+  });
+  it('registry.validate() reports missing upstream deps before Backend+Database register', () => {
+    registry.register(new SecurityArchitect());
+    const errors = registry.validate();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.join(' | ')).toMatch(/backend/);
+    expect(errors.join(' | ')).toMatch(/database/);
+  });
+  it('registry.validate() is empty when Backend + Database are also registered', () => {
+    const bk: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1', architectName: 'backend', version: '0.1.0',
+      sections: [{ path: 'backend.apiEndpoints', description: 'apis', required: true }],
+      architectMeta: { dependsOn: [], precedenceLevel: 12, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    const db: ArchitectSectionContract = {
+      contractId: 'database-architect.v1', architectName: 'database', version: '0.1.0',
+      sections: [{ path: 'database.tables', description: 'tables', required: true }],
+      architectMeta: { dependsOn: ['backend'], precedenceLevel: 11, fanoutPolicy: 'always', appliesPredicate: () => true, runtimeModel: 'sonnet' }
+    };
+    registry.register(new StubArchitect('backend', bk));
+    registry.register(new StubArchitect('database', db));
+    registry.register(new SecurityArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/security-architect/tests/golden/golden.test.ts
+++ b/packages/security-architect/tests/golden/golden.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Golden test — canonical Security-architect artifact for a known
+ * prakash-tiwari contact-form Story ticket.
+ *
+ * Locks output shape against drift + verifies end-to-end output +
+ * **OWASP TOP-10 GOLDEN**: every category covered with verdict +
+ * mitigations + evidence refs + idempotency + dependency declaration.
+ */
+import { describe, it, expect } from 'vitest';
+import { SecurityArchitect } from '../../src/architect.js';
+import { OWASP_TOP_10_KEYS, OWASP_TOP_10_NAMES, SECURITY_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { SECURITY_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import { buildFakeInput, fakeGoldenSpawner, goldenAssistantText, goldenExpectedOutput } from '../helpers/fakes.js';
+
+describe('golden — prakash-tiwari contact-form Form Story ticket', () => {
+  it('assistant text validates cleanly', () => {
+    expect(validateArchitectOutput(goldenAssistantText(), SECURITY_OWNED_FIELD_KEYS).ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await new SecurityArchitect({ spawner }).run(buildFakeInput());
+    expect(out.architectName).toBe('security');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+    for (const k of SECURITY_OWNED_FIELD_KEYS) expect(out.architectureFields).toHaveProperty(k);
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.risks).toEqual(expected.risks);
+    expect(out.dependencies).toEqual(expected.dependencies);
+  });
+
+  it('output passes every Security invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await new SecurityArchitect({ spawner }).run(buildFakeInput());
+    for (const inv of SECURITY_INVARIANTS) {
+      expect(inv.detect(out.architectureFields), `invariant ${inv.id}`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent output', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new SecurityArchitect({ spawner });
+    expect(await arch.run(buildFakeInput())).toEqual(await arch.run(buildFakeInput()));
+  });
+
+  it('always declares [backend, database] as dependencies', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await new SecurityArchitect({ spawner }).run(buildFakeInput());
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+  });
+});
+
+describe('golden — OWASP TOP-10 coverage (canonical assertion)', () => {
+  const arch = goldenExpectedOutput().architectureFields;
+  const owasp = arch['security.owaspMitigations'] as Record<string, unknown>;
+
+  it('declares entry for every OWASP Top-10 2021 key (A01..A10)', () => {
+    for (const k of OWASP_TOP_10_KEYS) {
+      expect(owasp, `owaspMitigations must contain ${k} (${OWASP_TOP_10_NAMES[k]})`).toHaveProperty(k);
+    }
+  });
+
+  it('every entry declares a verdict in {mitigated, accepted-risk, not-applicable}', () => {
+    const allowed = new Set(['mitigated', 'accepted-risk', 'not-applicable']);
+    for (const k of OWASP_TOP_10_KEYS) {
+      const entry = owasp[k] as Record<string, unknown>;
+      expect(entry.verdict).toBeDefined();
+      expect(allowed.has(entry.verdict as string)).toBe(true);
+    }
+  });
+
+  it('every entry declares at least one concrete mitigation', () => {
+    for (const k of OWASP_TOP_10_KEYS) {
+      const entry = owasp[k] as Record<string, unknown>;
+      const mits = entry.mitigations as unknown[];
+      expect(Array.isArray(mits)).toBe(true);
+      expect(mits.length).toBeGreaterThan(0);
+      for (const m of mits) {
+        expect(typeof m).toBe('string');
+        expect((m as string).length).toBeGreaterThan(5);
+      }
+    }
+  });
+
+  it('every entry declares at least one evidence reference', () => {
+    for (const k of OWASP_TOP_10_KEYS) {
+      const entry = owasp[k] as Record<string, unknown>;
+      const refs = entry.evidenceRefs as unknown[];
+      expect(Array.isArray(refs)).toBe(true);
+      expect(refs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all 10 verdicts in the golden are `mitigated`', () => {
+    for (const k of OWASP_TOP_10_KEYS) {
+      const entry = owasp[k] as Record<string, unknown>;
+      expect(entry.verdict).toBe('mitigated');
+    }
+  });
+
+  it('A01 cross-references authorization + RLS', () => {
+    const refs = (owasp.a01_brokenAccessControl as Record<string, unknown>).evidenceRefs as string[];
+    expect(refs.some(r => r.includes('authorization'))).toBe(true);
+    expect(refs.some(r => r.includes('rlsPolicies'))).toBe(true);
+  });
+
+  it('A03 cross-references inputValidation', () => {
+    const refs = (owasp.a03_injection as Record<string, unknown>).evidenceRefs as string[];
+    expect(refs.some(r => r.includes('inputValidation'))).toBe(true);
+  });
+
+  it('A07 cross-references authenticationStrategy + auditLog', () => {
+    const refs = (owasp.a07_authFailures as Record<string, unknown>).evidenceRefs as string[];
+    expect(refs.some(r => r.includes('authenticationStrategy'))).toBe(true);
+    expect(refs.some(r => r.includes('audit'))).toBe(true);
+  });
+
+  it('A09 cross-references auditLogRequirements', () => {
+    const refs = (owasp.a09_loggingMonitoringFailures as Record<string, unknown>).evidenceRefs as string[];
+    expect(refs.some(r => r.includes('audit'))).toBe(true);
+  });
+});
+
+describe('golden — upstream cross-validation', () => {
+  it('input includes Backend upstream output', () => {
+    const input = buildFakeInput();
+    expect(input.upstream.outputs.backend).toBeDefined();
+    expect(input.upstream.outputs.backend!.architectureFields['backend.apiEndpoints']).toBeDefined();
+  });
+
+  it('input includes Database upstream output', () => {
+    const input = buildFakeInput();
+    expect(input.upstream.outputs.database).toBeDefined();
+    expect(input.upstream.outputs.database!.architectureFields['database.rlsPolicies']).toBeDefined();
+  });
+
+  it('golden tenantIsolationGuarantees matches Database tenantIsolationStrategy', () => {
+    const input = buildFakeInput();
+    const dbModel = (input.upstream.outputs.database!.architectureFields['database.tenantIsolationStrategy'] as Record<string, unknown>).model;
+    const secModel = (goldenExpectedOutput().architectureFields['security.tenantIsolationGuarantees'] as Record<string, unknown>).model;
+    expect(secModel).toBe(dbModel);
+  });
+
+  it('golden inputValidation references Backend `ContactCreate` schema', () => {
+    const iv = goldenExpectedOutput().architectureFields['security.inputValidation'] as Record<string, unknown>;
+    const perEndpoint = iv.perEndpoint as Record<string, unknown>;
+    const endpoint = perEndpoint['POST /api/contacts'] as Record<string, unknown>;
+    expect(endpoint.requestSchemaRef).toBe('ContactCreate');
+  });
+
+  it('golden Security rate limit tightens Backend (never loosens)', () => {
+    const input = buildFakeInput();
+    const bk = (input.upstream.outputs.backend!.architectureFields['backend.rateLimits'] as Record<string, unknown>).perEndpoint as Record<string, unknown>;
+    const sec = (goldenExpectedOutput().architectureFields['security.rateLimitingRules'] as Record<string, unknown>).perEndpoint as Record<string, unknown>;
+    expect((sec['POST /api/contacts'] as Record<string, unknown>).max as number).toBeLessThanOrEqual((bk['POST /api/contacts'] as Record<string, unknown>).max as number);
+  });
+});

--- a/packages/security-architect/tests/helpers/fakes.ts
+++ b/packages/security-architect/tests/helpers/fakes.ts
@@ -1,0 +1,438 @@
+/**
+ * Test fixtures + fake spawner factory for the Security Architect.
+ *
+ * The canonical fixture is a prakash-tiwari contact-form Form Story
+ * ticket with wave-1 Backend + Database upstream outputs. The golden
+ * output covers ALL OWASP Top-10 2021 categories with verdict +
+ * mitigations + cross-architect evidenceRefs.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { SECURITY_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+function fakeBackendUpstream(): ArchitectOutput {
+  return {
+    architectName: 'backend',
+    architectureFields: {
+      'backend.framework': {
+        name: 'next', version: '15.x', runtime: 'edge+node',
+        handlerStyle: 'app-router-route-handlers+server-actions'
+      },
+      'backend.serviceBoundaries': { style: 'monolith-with-modules', modules: ['contacts'] },
+      'backend.apiEndpoints': [
+        {
+          method: 'POST', path: '/api/contacts', op: 'create',
+          requestSchemaRef: 'ContactCreate', responseSchemaRef: 'Contact',
+          persistsTo: ['contacts'], auth: 'public',
+          rateLimit: { windowSec: 60, max: 10, scope: 'ip' }
+        }
+      ],
+      'backend.endpointEnumeration': [
+        { route: 'POST /api/contacts', table: 'contacts', op: 'write' }
+      ],
+      'backend.requestSchemas': { ContactCreate: 'z.object({ name, email, message })' },
+      'backend.responseSchemas': { Contact: 'z.object({ id, createdAt })' },
+      'backend.errorEnvelope': { schema: '{ error: { code, message, requestId } }' },
+      'backend.validationRules': [
+        { endpoint: 'POST /api/contacts', rule: 'email is unique within tenant', source: 'database', failureMode: '409-conflict' }
+      ],
+      'backend.authRequirements': {
+        default: 'cloudflare-access',
+        perEndpoint: { 'POST /api/contacts': { scheme: 'public' } }
+      },
+      'backend.rateLimits': {
+        default: { windowMs: 60000, max: 60, scope: 'tenant' },
+        perEndpoint: { 'POST /api/contacts': { windowMs: 60000, max: 10, scope: 'ip' } }
+      },
+      'backend.dataAccess': { orm: 'drizzle', tables: ['contacts'], queries: { contacts: ['insert'] } },
+      'backend.businessRules': ['Contact email unique within tenant']
+    },
+    confidence: 0.9,
+    notes: 'Form Story: single POST endpoint, public auth, IP-scoped rate limit.',
+    dependencies: [],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+function fakeDatabaseUpstream(): ArchitectOutput {
+  return {
+    architectName: 'database',
+    architectureFields: {
+      'database.engine': { name: 'postgres', version: '16.x', orm: 'drizzle' },
+      'database.tables': [
+        { name: 'contacts', primaryKey: 'id', scope: 'tenant', comment: 'Contact form submissions.' }
+      ],
+      'database.columns': {
+        contacts: [
+          { name: 'id', type: 'uuid', nullable: false },
+          { name: 'tenant_id', type: 'uuid', nullable: false },
+          { name: 'created_at', type: 'timestamptz', nullable: false },
+          { name: 'updated_at', type: 'timestamptz', nullable: false }
+        ]
+      },
+      'database.indexes': [
+        { table: 'contacts', name: 'contacts_tenant_email_uk', columns: ['tenant_id', 'email'], unique: true, method: 'btree' }
+      ],
+      'database.migrations': [
+        { id: '0001_create_contacts', description: 'Create contacts table.', up: 'CREATE TABLE contacts (...);', down: 'DROP TABLE contacts;', ordering: 1, requiresOperatorReview: false }
+      ],
+      'database.relationships': [
+        { from: 'contacts.tenant_id', to: 'tenants.id', onDelete: 'restrict', onUpdate: 'cascade', deferrable: false }
+      ],
+      'database.rlsPolicies': {
+        contacts: [
+          { name: 'tenant_isolation', using: "current_setting('app.tenant_id')::uuid = tenant_id", kind: 'permissive', operation: 'all' },
+          { name: 'service_role_bypass', using: "current_user = 'orchestrator'", kind: 'permissive', operation: 'all' }
+        ]
+      },
+      'database.tenantIsolationStrategy': {
+        model: 'schema-per-tenant',
+        justification: 'matches CAIA meta cluster',
+        schemaNameTemplate: 'tenant_{{tenantId}}',
+        sharedTables: ['tenants', 'plans']
+      },
+      'database.dataLifecycle': [
+        { table: 'contacts', retentionDays: 730, archivalSink: 'r2://archive/contacts', gdprDeleteStrategy: 'anonymize', cascadeOnUserDelete: true }
+      ],
+      'database.jsonbShapes': {
+        'contacts.payload': { shape: 'z.object({ source: z.string() })' }
+      },
+      'database.queryHints': [
+        { endpoint: 'POST /api/contacts', table: 'contacts', op: 'write', indexCandidate: 'contacts_tenant_email_uk', expectedQps: 5, p95LatencyTargetMs: 50 }
+      ]
+    },
+    confidence: 0.9,
+    notes: 'Single tenant-scoped table with RLS.',
+    dependencies: ['backend'],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-sec-001',
+      type: 'Form',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'Form submission round-trips in <500ms p95.',
+        'Submissions are tenant-isolated; tenant A cannot read tenant B rows.',
+        'Rate-limited to 10 req/min per IP for public submission.',
+        'CSP allows the form to submit only to same-origin.',
+        'Failed-auth attempts trigger an alert at 5 failures in 60s.'
+      ],
+      business_requirements: {
+        title: 'Contact form submission',
+        description: 'Public marketing contact form on the artist profile page.'
+      },
+      quality_tags: ['form', 'public', 'persists']
+    },
+    upstream: { outputs: { backend: fakeBackendUpstream(), database: fakeDatabaseUpstream() } },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking.',
+      audience: 'High-intent prospective sitters.',
+      goals: ['Drive contact-form submissions'],
+      brandVoice: 'warm + grounded'
+    },
+    designVersion: {
+      versionId: 'design-pt-v3-2026-05-22',
+      anchors: [{ anchorId: 'contact-form', kind: 'form' }],
+      tokens: {}
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'tenant_prakash_tiwari',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari contact-form fixture.
+ * Covers ALL OWASP Top-10 2021 categories with verdict + mitigations + evidenceRefs.
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'security',
+    architectureFields: {
+      'security.authenticationStrategy': {
+        default: 'cloudflare-access',
+        perEndpoint: {
+          'POST /api/contacts': { scheme: 'public', reason: 'marketing contact form' }
+        },
+        sessionModel: {
+          kind: 'jwt', issuer: 'caia-auth', algorithm: 'RS256',
+          accessTtlMin: 15, refreshTtlDays: 30, rotation: 'sliding'
+        },
+        mfa: { required: 'admin', method: 'totp' },
+        oauthProviders: [
+          { name: 'github', scopes: ['user:email'] },
+          { name: 'google', scopes: ['openid', 'email', 'profile'] }
+        ]
+      },
+      'security.authorizationRules': {
+        model: 'rbac+abac',
+        roles: ['owner', 'admin', 'member', 'viewer'],
+        permissions: [
+          { role: 'admin', action: 'read', resource: 'contacts', condition: 'row.tenant_id == ctx.tenantId' },
+          { role: 'member', action: 'read', resource: 'contacts', condition: 'row.tenant_id == ctx.tenantId' }
+        ],
+        resourceOwnership: { contacts: { ownerColumn: 'created_by', tenantColumn: 'tenant_id' } },
+        denyByDefault: true
+      },
+      'security.secretsHandling': {
+        provider: 'vault',
+        namespace: 'tenant/{{tenantId}}',
+        rotationPolicy: { kind: 'scheduled', intervalDays: 90 },
+        perSecret: {
+          'db.password': { accessRole: 'app', rotationDays: 30, scope: 'per-tenant' },
+          'oauth.github.clientSecret': { accessRole: 'auth', rotationDays: 90, scope: 'global' }
+        },
+        injection: 'env-at-runtime',
+        neverLog: ['password', 'token', 'secret', 'authorization', 'cookie']
+      },
+      'security.owaspMitigations': {
+        a01_brokenAccessControl: {
+          verdict: 'mitigated',
+          mitigations: [
+            'Deny-by-default authorization with explicit per-resource grants',
+            'RLS on every tenant-scoped table',
+            'tenant_id condition on every authorization rule'
+          ],
+          evidenceRefs: ['security.authorizationRules', 'database.rlsPolicies']
+        },
+        a02_cryptographicFailures: {
+          verdict: 'mitigated',
+          mitigations: [
+            'JWT signed with RS256/EdDSA asymmetric keys',
+            'HSTS preload forces TLS for the entire eTLD+1',
+            'Secrets rotated on 90-day schedule via Vault'
+          ],
+          evidenceRefs: ['security.authenticationStrategy', 'security.securityHeaders', 'security.secretsHandling']
+        },
+        a03_injection: {
+          verdict: 'mitigated',
+          mitigations: [
+            'Zod schema validation on every endpoint body',
+            'Drizzle parameterised queries — no raw string SQL',
+            'sanitization.stripHtml on all string inputs'
+          ],
+          evidenceRefs: ['security.inputValidation', 'backend.requestSchemas']
+        },
+        a04_insecureDesign: {
+          verdict: 'mitigated',
+          mitigations: [
+            'Deny-by-default everywhere',
+            'Defence in depth on tenant isolation (schema + credentials + RLS + tenant_id column)',
+            'Locked stack defaults reviewed by EA Reviewer'
+          ],
+          evidenceRefs: ['security.tenantIsolationGuarantees', 'security.authorizationRules']
+        },
+        a05_securityMisconfiguration: {
+          verdict: 'mitigated',
+          mitigations: [
+            'Locked HTTP security headers (CSP/HSTS/XFO/COOP/COEP/CORP)',
+            'rejectUnknownKeys=true on input validation',
+            'Architect contract enforces locked defaults; overrides flagged'
+          ],
+          evidenceRefs: ['security.securityHeaders', 'security.inputValidation']
+        },
+        a06_vulnerableComponents: {
+          verdict: 'mitigated',
+          mitigations: [
+            'Pinned lockfiles (pnpm-lock.yaml)',
+            'Dependabot enabled at repo level',
+            'Renovate/Dependabot SBOM scan in CI'
+          ],
+          evidenceRefs: ['devops.cicdPipeline']
+        },
+        a07_authFailures: {
+          verdict: 'mitigated',
+          mitigations: [
+            'MFA required for admin + BYOK + operator roles',
+            'JWT 15-min access TTL with sliding refresh',
+            'Failed-login alert at 5 attempts in 60s'
+          ],
+          evidenceRefs: ['security.authenticationStrategy', 'security.auditLogRequirements']
+        },
+        a08_softwareDataIntegrity: {
+          verdict: 'mitigated',
+          mitigations: [
+            'Subresource Integrity on any external script',
+            'Signed CI artifacts (DevOps Architect owns the implementation)',
+            'Audit log captures every deploy event'
+          ],
+          evidenceRefs: ['security.securityHeaders', 'security.auditLogRequirements']
+        },
+        a09_loggingMonitoringFailures: {
+          verdict: 'mitigated',
+          mitigations: [
+            '365-day retention on the central secure audit sink',
+            'Required event types include auth.login.failure, authz.deny, secrets.access, tenant.isolation.breach.attempt',
+            'Alert thresholds defined for high-signal events'
+          ],
+          evidenceRefs: ['security.auditLogRequirements']
+        },
+        a10_ssrf: {
+          verdict: 'mitigated',
+          mitigations: [
+            'No user-controlled URL is fetched server-side from this endpoint',
+            'When server-side fetch is required, IP allowlist via egress proxy',
+            'Block RFC1918 + link-local + metadata IPs at the edge'
+          ],
+          evidenceRefs: ['security.inputValidation']
+        }
+      },
+      'security.securityHeaders': {
+        csp: {
+          directive: 'strict-dynamic',
+          nonceSource: 'middleware',
+          defaultSrc: ["'self'"],
+          frameSrc: ["'none'"],
+          scriptSrc: ["'self'", "'strict-dynamic'"],
+          styleSrc: ["'self'"],
+          connectSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:'],
+          fontSrc: ["'self'"],
+          objectSrc: ["'none'"],
+          baseUri: ["'self'"],
+          formAction: ["'self'"],
+          reportUri: '/_security/csp-report'
+        },
+        hsts: { maxAgeSec: 31536000, includeSubDomains: true, preload: true },
+        xFrameOptions: 'DENY',
+        xContentTypeOptions: 'nosniff',
+        referrerPolicy: 'strict-origin-when-cross-origin',
+        permissionsPolicy: { geolocation: '()', camera: '()', microphone: '()' },
+        coop: 'same-origin',
+        coep: 'require-corp',
+        corp: 'same-origin'
+      },
+      'security.inputValidation': {
+        perEndpoint: {
+          'POST /api/contacts': {
+            requestSchemaRef: 'ContactCreate',
+            sanitization: {
+              trim: true, stripHtml: true, canonicalize: 'NFC',
+              maxBodyBytes: 65536, allowedContentTypes: ['application/json']
+            }
+          }
+        },
+        globalDefaults: {
+          maxBodyBytes: 1048576,
+          allowedContentTypes: ['application/json'],
+          rejectUnknownKeys: true
+        }
+      },
+      'security.rateLimitingRules': {
+        default: { windowSec: 60, max: 60, scope: 'tenant', burst: 10 },
+        perEndpoint: {
+          'POST /api/contacts': {
+            windowSec: 60, max: 10, scope: 'ip', burst: 2,
+            onLimit: '429-retry-after', penaltySec: 300
+          }
+        },
+        perAuthTier: {
+          public: { windowSec: 60, max: 20, scope: 'ip' },
+          authenticated: { windowSec: 60, max: 120, scope: 'user' },
+          service: { windowSec: 60, max: 600, scope: 'tenant' }
+        }
+      },
+      'security.auditLogRequirements': {
+        sink: 'central-secure-store',
+        retentionDays: 365,
+        perEventType: {
+          'auth.login.success': { fields: ['userId', 'tenantId', 'ip', 'userAgent'], sensitivity: 'internal' },
+          'auth.login.failure': { fields: ['attemptedUser', 'ip', 'reason'], sensitivity: 'internal', alertThreshold: { count: 5, windowSec: 60 } },
+          'authz.deny': { fields: ['userId', 'tenantId', 'action', 'resource', 'reason'], sensitivity: 'internal' },
+          'secrets.access': { fields: ['actor', 'secretName', 'operation'], sensitivity: 'sensitive' },
+          'role.change': { fields: ['actor', 'target', 'fromRole', 'toRole'], sensitivity: 'internal' },
+          'tenant.isolation.breach.attempt': { fields: ['actor', 'attemptedTenantId', 'actualTenantId'], sensitivity: 'sensitive', alertThreshold: { count: 1, windowSec: 1 } }
+        },
+        redactionRules: ['password', 'token', 'secret', 'authorization', 'cookie', 'ssn', 'creditCard']
+      },
+      'security.tenantIsolationGuarantees': {
+        model: 'schema-per-tenant',
+        enforcement: [
+          'schema-search-path',
+          'scoped-db-credentials',
+          'rls-defence-in-depth',
+          'tenant-id-on-every-row',
+          'query-fingerprint-audit'
+        ],
+        credentialScope: 'per-tenant-app-role',
+        crossTenantAccess: 'forbidden-without-operator-elevation',
+        breachDetection: { queryFingerprintsLog: true, unexpectedSchemaTouchAlert: true },
+        testingHooks: [
+          'tenant-fence-property-test',
+          'cross-tenant-leak-test',
+          'rls-bypass-attempt-test'
+        ]
+      }
+    },
+    confidence: 0.9,
+    notes:
+      'Public contact-form endpoint locked to IP-scoped 10/min rate limit + CSP strict-dynamic + HSTS preload + tenant-isolated schema-per-tenant. OWASP top-10 fully covered with concrete mitigations cross-referenced to Backend + Database upstream outputs.',
+    dependencies: ['backend', 'database'],
+    risks: [],
+    toolCalls: [],
+    spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'sonnet' },
+    status: 'ok'
+  };
+}
+
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text, inputTokens: 1000, outputTokens: 500, usdCost: 0.01,
+      wallClockMs: 1234, model: input.budget.preferredModel,
+      ok, diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of SECURITY_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/security-architect/tests/invariants.test.ts
+++ b/packages/security-architect/tests/invariants.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Cross-architect invariants.
+ */
+import { describe, it, expect } from 'vitest';
+import { OWASP_TOP_10_KEYS } from '../src/contract.js';
+import { SECURITY_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('SECURITY_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => expect(SECURITY_INVARIANTS.length).toBeGreaterThan(0));
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of SECURITY_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+  it('every invariant is contributed by `security`', () => {
+    for (const inv of SECURITY_INVARIANTS) expect(inv.contributor).toBe('security');
+  });
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of SECURITY_INVARIANTS) expect(inv.reads.length).toBeGreaterThan(0);
+  });
+  it('every invariant has a valid severity', () => {
+    for (const inv of SECURITY_INVARIANTS) expect(['fail', 'advisory']).toContain(inv.severity);
+  });
+  it('every invariant has a non-empty description', () => {
+    for (const inv of SECURITY_INVARIANTS) expect(inv.description.length).toBeGreaterThan(20);
+  });
+});
+
+describe('SECURITY_INVARIANTS — predicates against the golden fixture', () => {
+  const arch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of SECURITY_INVARIANTS) expect(inv.detect(arch), `invariant ${inv.id} should pass`).toBe(true);
+  });
+
+  it('owasp-top10-fully-covered fails when a category is missing', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.owasp-top10-fully-covered')!;
+    const owasp = { ...(arch['security.owaspMitigations'] as Record<string, unknown>) };
+    delete owasp.a05_securityMisconfiguration;
+    expect(inv.detect({ ...arch, 'security.owaspMitigations': owasp })).toBe(false);
+  });
+
+  it('owasp-top10-fully-covered fails when verdict is unrecognised', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.owasp-top10-fully-covered')!;
+    const owasp = { ...(arch['security.owaspMitigations'] as Record<string, unknown>), a03_injection: { verdict: 'maybe-ok', mitigations: [], evidenceRefs: [] } };
+    expect(inv.detect({ ...arch, 'security.owaspMitigations': owasp })).toBe(false);
+  });
+
+  it('owasp-accepted-risk-has-operator-signoff fails when acceptedBy missing', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.owasp-accepted-risk-has-operator-signoff')!;
+    const owasp = { ...(arch['security.owaspMitigations'] as Record<string, unknown>), a05_securityMisconfiguration: { verdict: 'accepted-risk', mitigations: [], evidenceRefs: [] } };
+    expect(inv.detect({ ...arch, 'security.owaspMitigations': owasp })).toBe(false);
+  });
+
+  it('owasp-accepted-risk-has-operator-signoff passes when acceptedBy + acceptedOn present', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.owasp-accepted-risk-has-operator-signoff')!;
+    const owasp = { ...(arch['security.owaspMitigations'] as Record<string, unknown>), a05_securityMisconfiguration: { verdict: 'accepted-risk', mitigations: [], evidenceRefs: [], acceptedBy: 'operator@caia.dev', acceptedOn: '2026-05-23' } };
+    expect(inv.detect({ ...arch, 'security.owaspMitigations': owasp })).toBe(true);
+  });
+
+  it('csp-strict-dynamic-no-unsafe-inline fails on unsafe-inline script-src', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.csp-strict-dynamic-no-unsafe-inline')!;
+    const h = arch['security.securityHeaders'] as Record<string, unknown>;
+    const csp = { ...(h.csp as Record<string, unknown>), scriptSrc: ["'self'", "'unsafe-inline'"] };
+    expect(inv.detect({ ...arch, 'security.securityHeaders': { ...h, csp } })).toBe(false);
+  });
+
+  it('csp-strict-dynamic-no-unsafe-inline fails on unsafe-eval', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.csp-strict-dynamic-no-unsafe-inline')!;
+    const h = arch['security.securityHeaders'] as Record<string, unknown>;
+    const csp = { ...(h.csp as Record<string, unknown>), scriptSrc: ["'self'", "'unsafe-eval'"] };
+    expect(inv.detect({ ...arch, 'security.securityHeaders': { ...h, csp } })).toBe(false);
+  });
+
+  it('csp-strict-dynamic-no-unsafe-inline fails when directive is not strict-dynamic', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.csp-strict-dynamic-no-unsafe-inline')!;
+    const h = arch['security.securityHeaders'] as Record<string, unknown>;
+    const csp = { ...(h.csp as Record<string, unknown>), directive: 'self' };
+    expect(inv.detect({ ...arch, 'security.securityHeaders': { ...h, csp } })).toBe(false);
+  });
+
+  it('hsts-preloaded-includesubdomains fails when maxAge below 1y', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.hsts-preloaded-includesubdomains')!;
+    const h = arch['security.securityHeaders'] as Record<string, unknown>;
+    const hsts = { ...(h.hsts as Record<string, unknown>), maxAgeSec: 1000 };
+    expect(inv.detect({ ...arch, 'security.securityHeaders': { ...h, hsts } })).toBe(false);
+  });
+
+  it('hsts-preloaded-includesubdomains fails when preload is false', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.hsts-preloaded-includesubdomains')!;
+    const h = arch['security.securityHeaders'] as Record<string, unknown>;
+    const hsts = { ...(h.hsts as Record<string, unknown>), preload: false };
+    expect(inv.detect({ ...arch, 'security.securityHeaders': { ...h, hsts } })).toBe(false);
+  });
+
+  it('xframe-options-deny fails on SAMEORIGIN', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.xframe-options-deny')!;
+    const h = { ...(arch['security.securityHeaders'] as Record<string, unknown>), xFrameOptions: 'SAMEORIGIN' };
+    expect(inv.detect({ ...arch, 'security.securityHeaders': h })).toBe(false);
+  });
+
+  it('deny-by-default-authorization fails when denyByDefault=false', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.deny-by-default-authorization')!;
+    const a = { ...(arch['security.authorizationRules'] as Record<string, unknown>), denyByDefault: false };
+    expect(inv.detect({ ...arch, 'security.authorizationRules': a })).toBe(false);
+  });
+
+  it('tenant-isolation-defence-in-depth fails when scoped-db-credentials missing', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.tenant-isolation-defence-in-depth')!;
+    const iso = { ...(arch['security.tenantIsolationGuarantees'] as Record<string, unknown>), enforcement: ['schema-search-path', 'rls-defence-in-depth'] };
+    expect(inv.detect({ ...arch, 'security.tenantIsolationGuarantees': iso })).toBe(false);
+  });
+
+  it('tenant-isolation-defence-in-depth fails when rls-defence-in-depth missing', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.tenant-isolation-defence-in-depth')!;
+    const iso = { ...(arch['security.tenantIsolationGuarantees'] as Record<string, unknown>), enforcement: ['schema-search-path', 'scoped-db-credentials'] };
+    expect(inv.detect({ ...arch, 'security.tenantIsolationGuarantees': iso })).toBe(false);
+  });
+
+  it('secrets-never-logged fails when `password` not in neverLog', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.secrets-never-logged')!;
+    const s = { ...(arch['security.secretsHandling'] as Record<string, unknown>), neverLog: ['token', 'secret', 'authorization'] };
+    expect(inv.detect({ ...arch, 'security.secretsHandling': s })).toBe(false);
+  });
+
+  it('audit-required-event-types fails when authz.deny missing', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.audit-required-event-types')!;
+    const a = { ...(arch['security.auditLogRequirements'] as Record<string, unknown>), perEventType: { 'auth.login.failure': {}, 'secrets.access': {}, 'tenant.isolation.breach.attempt': {} } };
+    expect(inv.detect({ ...arch, 'security.auditLogRequirements': a })).toBe(false);
+  });
+
+  it('rate-limit-marketing-tightest (advisory) fails when public > authenticated', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.rate-limit-marketing-tightest')!;
+    const rl = { ...(arch['security.rateLimitingRules'] as Record<string, unknown>), perAuthTier: {
+      public: { windowSec: 60, max: 1000, scope: 'ip' },
+      authenticated: { windowSec: 60, max: 120, scope: 'user' },
+      service: { windowSec: 60, max: 600, scope: 'tenant' }
+    } };
+    expect(inv.detect({ ...arch, 'security.rateLimitingRules': rl })).toBe(false);
+  });
+
+  it('input-validation-global-defaults fails when rejectUnknownKeys is false', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.input-validation-global-defaults')!;
+    const iv = { ...(arch['security.inputValidation'] as Record<string, unknown>), globalDefaults: { maxBodyBytes: 1048576, allowedContentTypes: ['application/json'], rejectUnknownKeys: false } };
+    expect(inv.detect({ ...arch, 'security.inputValidation': iv })).toBe(false);
+  });
+
+  it('authentication-strategy-declared fails when default scheme missing', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.authentication-strategy-declared')!;
+    const a = { ...(arch['security.authenticationStrategy'] as Record<string, unknown>), default: '' };
+    expect(inv.detect({ ...arch, 'security.authenticationStrategy': a })).toBe(false);
+  });
+});
+
+describe('SECURITY_INVARIANTS — OWASP coverage check', () => {
+  it('owasp-top10-fully-covered invariant exists with severity=fail', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.owasp-top10-fully-covered')!;
+    expect(inv).toBeDefined();
+    expect(inv.severity).toBe('fail');
+  });
+  it('predicate considers all 10 OWASP keys', () => {
+    const inv = SECURITY_INVARIANTS.find(i => i.id === 'security.owasp-top10-fully-covered')!;
+    const arch = goldenExpectedOutput().architectureFields;
+    for (const k of OWASP_TOP_10_KEYS) {
+      const owasp = { ...(arch['security.owaspMitigations'] as Record<string, unknown>) };
+      delete owasp[k];
+      expect(inv.detect({ ...arch, 'security.owaspMitigations': owasp }), `dropping ${k} should fail`).toBe(false);
+    }
+  });
+});

--- a/packages/security-architect/tests/run.test.ts
+++ b/packages/security-architect/tests/run.test.ts
@@ -1,0 +1,168 @@
+/**
+ * `run()` tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { SECURITY_ARCHITECT_NAME, SecurityArchitect } from '../src/architect.js';
+import { SECURITY_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runSecurityArchitect } from '../src/run.js';
+import { buildSecuritySystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput, fakeGoldenSpawner, fakeSpawnerReturning,
+  goldenAssistantText, goldenExpectedOutput
+} from './helpers/fakes.js';
+
+const deps = () => ({
+  spawner: fakeGoldenSpawner().fn,
+  systemPrompt: buildSecuritySystemPrompt(),
+  architectName: SECURITY_ARCHITECT_NAME
+});
+
+describe('runSecurityArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.architectName).toBe('security');
+  });
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    for (const k of SECURITY_OWNED_FIELD_KEYS) expect(out.architectureFields).toHaveProperty(k);
+  });
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.status).toBe('ok');
+  });
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(calls[0]?.systemPrompt).toBe(buildSecuritySystemPrompt());
+  });
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runSecurityArchitect(input, { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runSecurityArchitect(input, { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runSecurityArchitect — idempotency', () => {
+  it('same input → same output', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    const b = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(a).toEqual(b);
+  });
+  it('re-run REPLACES architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const r1 = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    const r2 = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(Object.keys(r1.architectureFields).sort());
+    expect(Object.keys(r2.architectureFields).length).toBe(SECURITY_OWNED_FIELD_KEYS.length);
+  });
+});
+
+describe('runSecurityArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+  it('failed-spawn output still declares [backend,database] dependencies', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.dependencies).toEqual(['backend', 'database']);
+  });
+  it('returns status=partial when validation fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"security"}');
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+  it('partial-validation output still declares [backend,database] dependencies', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('{"architectName":"security"}');
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.dependencies).toEqual(['backend', 'database']);
+  });
+  it('returns status=partial when assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runSecurityArchitect — dependency declaration', () => {
+  it('always declares [backend, database] as upstream', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+  });
+  it('preserves sibling-ticket IDs alongside upstream architects', async () => {
+    const c = { ...goldenExpectedOutput(), dependencies: ['ticket-pt-001'] };
+    const { fn: spawner } = fakeSpawnerReturning(JSON.stringify(c));
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    expect(out.dependencies).toContain('backend');
+    expect(out.dependencies).toContain('database');
+    expect(out.dependencies).toContain('ticket-pt-001');
+  });
+  it('does not duplicate upstream architects in dependencies', async () => {
+    const c = { ...goldenExpectedOutput(), dependencies: ['backend', 'database', 'backend'] };
+    const { fn: spawner } = fakeSpawnerReturning(JSON.stringify(c));
+    const out = await runSecurityArchitect(buildFakeInput(), { spawner, systemPrompt: buildSecuritySystemPrompt(), architectName: SECURITY_ARCHITECT_NAME });
+    const counts = new Map<string, number>();
+    for (const d of out.dependencies) counts.set(d, (counts.get(d) ?? 0) + 1);
+    expect(counts.get('backend')).toBe(1);
+    expect(counts.get('database')).toBe(1);
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => { expect(buildUserPrompt(buildFakeInput())).toContain('ticket-pt-sec-001'); });
+  it('serialises Backend upstream (apiEndpoints)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('POST');
+    expect(p).toContain('/api/contacts');
+    expect(p).toContain('backend.apiEndpoints');
+  });
+  it('serialises Database upstream (rlsPolicies)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('database.rlsPolicies');
+    expect(p).toContain('tenant_isolation');
+  });
+  it('includes vaultNamespace', () => { expect(buildUserPrompt(buildFakeInput())).toContain('tenant/prakash-tiwari'); });
+  it('includes schemaName', () => { expect(buildUserPrompt(buildFakeInput())).toContain('tenant_prakash_tiwari'); });
+  it('includes tenantId', () => { expect(buildUserPrompt(buildFakeInput())).toContain('tenant-prakash-tiwari'); });
+  it('passes through reviewer feedback', () => {
+    const input = { ...buildFakeInput(), reviewerFeedback: { reason: 'CSP must use strict-dynamic', severity: 'P1' as const } };
+    expect(buildUserPrompt(input)).toContain('CSP must use strict-dynamic');
+  });
+});
+
+describe('SecurityArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new SecurityArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('security');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/security-architect/tests/run.test.ts
+++ b/packages/security-architect/tests/run.test.ts
@@ -11,12 +11,6 @@ import {
   goldenAssistantText, goldenExpectedOutput
 } from './helpers/fakes.js';
 
-const deps = () => ({
-  spawner: fakeGoldenSpawner().fn,
-  systemPrompt: buildSecuritySystemPrompt(),
-  architectName: SECURITY_ARCHITECT_NAME
-});
-
 describe('runSecurityArchitect — happy path', () => {
   it('produces an ArchitectOutput with the right architectName', async () => {
     const { fn: spawner } = fakeGoldenSpawner();

--- a/packages/security-architect/tests/system-prompt.test.ts
+++ b/packages/security-architect/tests/system-prompt.test.ts
@@ -1,0 +1,94 @@
+/**
+ * System-prompt tests — spec §11(b).
+ */
+import { describe, it, expect } from 'vitest';
+import { OWASP_TOP_10_KEYS, OWASP_TOP_10_NAMES, SECURITY_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildSecuritySystemPrompt } from '../src/system-prompt.js';
+
+describe('buildSecuritySystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+  it('is deterministic across calls', () => {
+    expect(buildSecuritySystemPrompt()).toBe(buildSecuritySystemPrompt());
+  });
+  it('contains Role section', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Security Architect");
+  });
+  it('contains Locked stack section with the locked tech', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('## Locked stack');
+    expect(p).toContain('Cloudflare Access');
+    expect(p).toContain('JWT');
+    expect(p).toContain('OAuth');
+    expect(p).toContain('Vault');
+    expect(p).toContain('OWASP');
+    expect(p).toContain('schema-per-tenant');
+  });
+  it('contains Output JSON schema section', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+  });
+  it('references every declared owned field at least once', () => {
+    const p = buildSecuritySystemPrompt();
+    for (const key of SECURITY_OWNED_FIELD_KEYS) expect(p).toContain(key);
+  });
+  it('references every OWASP Top-10 key at least once', () => {
+    const p = buildSecuritySystemPrompt();
+    for (const key of OWASP_TOP_10_KEYS) expect(p).toContain(key);
+  });
+  it('references every OWASP Top-10 human-readable name', () => {
+    const p = buildSecuritySystemPrompt();
+    for (const key of OWASP_TOP_10_KEYS) expect(p).toContain(OWASP_TOP_10_NAMES[key]);
+  });
+  it('contains Decision heuristics section with deny-by-default + tenant_id', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Deny-by-default');
+    expect(p).toContain('tenant_id');
+  });
+  it('contains Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('security.*');
+  });
+  it('refuses unsafe-inline and unsafe-eval', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('unsafe-inline');
+    expect(p).toContain('unsafe-eval');
+    expect(p.toLowerCase()).toContain('never');
+  });
+  it('contains Self-check section', () => {
+    expect(buildSecuritySystemPrompt()).toContain('## Self-check');
+  });
+  it('contains Examples section pointing at golden fixture', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+  it('size bounded (< 32k chars)', () => {
+    expect(buildSecuritySystemPrompt().length).toBeLessThan(32000);
+  });
+  it('mentions Cloudflare Access as auth default', () => {
+    expect(buildSecuritySystemPrompt()).toContain('Cloudflare Access');
+  });
+  it('mentions @caia/secrets-adapter as the secrets backend', () => {
+    expect(buildSecuritySystemPrompt()).toContain('@caia/secrets-adapter');
+  });
+  it('emphasises wave-2 upstream (backend + database)', () => {
+    const p = buildSecuritySystemPrompt();
+    expect(p).toContain('upstream');
+    expect(p).toContain('backend');
+    expect(p).toContain('database');
+  });
+});

--- a/packages/security-architect/tests/validation.test.ts
+++ b/packages/security-architect/tests/validation.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Output validation tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { SECURITY_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const r = validateArchitectOutput(goldenAssistantText(), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.parsed?.architectName).toBe('security');
+    expect(r.parsed?.status).toBe('ok');
+  });
+  it('accepts JSON wrapped in ```json fences', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    expect(validateArchitectOutput(fenced, SECURITY_OWNED_FIELD_KEYS).ok).toBe(true);
+  });
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    expect(validateArchitectOutput(fenced, SECURITY_OWNED_FIELD_KEYS).ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const r = validateArchitectOutput('{not json', SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]?.code).toBe('invalid-json');
+  });
+  it('rejects a top-level array', () => {
+    const r = validateArchitectOutput('[1,2,3]', SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+  it('rejects null top-level', () => {
+    const r = validateArchitectOutput('null', SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+  it('flags missing top-level keys', () => {
+    const r = validateArchitectOutput('{"architectName":"security"}', SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.map(e => e.code)).toContain('missing-top-level-key');
+  });
+  it('flags a missing owned field', () => {
+    const g = goldenExpectedOutput();
+    const fields = { ...g.architectureFields } as Record<string, unknown>;
+    delete fields['security.owaspMitigations'];
+    const corrupted = { ...g, architectureFields: fields };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+  it('flags an unexpected field outside owned namespace', () => {
+    const g = goldenExpectedOutput();
+    const fields = { ...g.architectureFields, 'backend.apiEndpoints': 'not yours' };
+    const corrupted = { ...g, architectureFields: fields };
+    const r = validateArchitectOutput(JSON.stringify(corrupted), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+  it('flags out-of-range confidence', () => {
+    const r = validateArchitectOutput(JSON.stringify({ ...goldenExpectedOutput(), confidence: 1.5 }), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+  it('flags negative confidence', () => {
+    const r = validateArchitectOutput(JSON.stringify({ ...goldenExpectedOutput(), confidence: -0.1 }), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+  it('flags overly long notes', () => {
+    const r = validateArchitectOutput(JSON.stringify({ ...goldenExpectedOutput(), notes: 'x'.repeat(801) }), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+  it('flags too many risk entries', () => {
+    const r = validateArchitectOutput(JSON.stringify({ ...goldenExpectedOutput(), risks: ['a','b','c','d','e','f'] }), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+  it('flags invalid status', () => {
+    const r = validateArchitectOutput(JSON.stringify({ ...goldenExpectedOutput(), status: 'bananas' }), SECURITY_OWNED_FIELD_KEYS);
+    expect(r.ok).toBe(false);
+    expect(r.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const r = validateArchitectOutput(JSON.stringify({ ...goldenExpectedOutput(), status: s }), SECURITY_OWNED_FIELD_KEYS);
+      expect(r.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => { expect(stripFences('```json\n{"x":1}\n```')).toBe('{"x":1}'); });
+  it('strips plain ``` fences', () => { expect(stripFences('```\n{"x":1}\n```')).toBe('{"x":1}'); });
+  it('passes plain JSON through unchanged', () => { expect(stripFences('{"x":1}')).toBe('{"x":1}'); });
+  it('trims surrounding whitespace', () => { expect(stripFences('   {"x":1}   ')).toBe('{"x":1}'); });
+});

--- a/packages/security-architect/tsconfig.build.json
+++ b/packages/security-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/security-architect/tsconfig.json
+++ b/packages/security-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/security-architect/vitest.config.ts
+++ b/packages/security-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2543,6 +2543,34 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/security-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@caia/backend-architect':
+        specifier: workspace:*
+        version: link:../backend-architect
+      '@caia/database-architect':
+        specifier: workspace:*
+        version: link:../database-architect
+      '@caia/frontend-architect':
+        specifier: workspace:*
+        version: link:../frontend-architect
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/seo-architect:
     dependencies:
       '@caia/architect-kit':


### PR DESCRIPTION
## Summary

Architect #10 of CAIA's 17-architect EA fan-out. Implements `SpecialistArchitect` from `@caia/architect-kit` (PR #535).

- **Wave**: 2 (`dependsOn: ['backend', 'database']`)
- **Precedence rank**: **1 (highest)** per spec §5.2 — Security veto wins every semantic conflict short of operator override
- **Runtime model**: Sonnet
- **Spec source**: `research/17_architect_framework_spec_2026.md` §2.10 + task brief reframing (`security-architect-2026-05-23`)

## Owned fields (9, all under `security.*`)

| Field | Owns |
|---|---|
| `authenticationStrategy` | Cloudflare Access default + OAuth/JWT sessions + service-token internal + MFA admin/operator/BYOK |
| `authorizationRules` | RBAC (owner/admin/member/viewer) + ABAC (row-ownership, tenant scope); deny-by-default |
| `secretsHandling` | Forward-reference to `@caia/secrets-adapter`; Vault per-tenant namespace; short-lived AppRole tokens; never-log allowlist |
| `owaspMitigations` | Verdict + concrete mitigation for **every** OWASP Top-10 2021 category (A01–A10); accepted-risk requires operator sign-off |
| `securityHeaders` | CSP strict-dynamic + nonce; HSTS preload max-age 31536000; X-Frame-Options DENY; XCTO nosniff; Referrer-Policy strict-origin-when-cross-origin; Permissions-Policy minimal; COOP/COEP/CORP same-origin |
| `inputValidation` | Per-endpoint Zod schema ref + sanitization + globalDefaults (rejectUnknownKeys, maxBodyBytes) |
| `rateLimitingRules` | Per-endpoint scoped by tenant\|ip\|user; perAuthTier (public ≤ authenticated ≤ service); 429+Retry-After |
| `auditLogRequirements` | central-secure-store sink, 365-day retention, required event types (auth.login.failure, authz.deny, secrets.access, tenant.isolation.breach.attempt) |
| `tenantIsolationGuarantees` | schema-per-tenant + scoped DB credentials + RLS defence-in-depth + tenant_id on every row + query-fingerprint audit; cross-references Database `tenantIsolationStrategy` |

## What it does NOT do

No component code, no API endpoint implementations, no SQL DDL, no CI/CD, no UI. Security **specifies** how every endpoint is authenticated, authorized, rate-limited, and audited — not how endpoints are built.

## Testing

166 Vitest tests pass across 7 files (≥30 requirement easily satisfied):

| File | Tests |
|---|---|
| `contract.test.ts` | 47 — structural + architectMeta + OWASP constants + applies-predicate + ArchitectRegistry disjointness vs frontend/backend/database |
| `architect.test.ts` | 12 — SpecialistArchitect interface compliance |
| `system-prompt.test.ts` | 17 — spec §11(b) shape + owned-field references + OWASP key coverage |
| `validation.test.ts` | 19 — happy path + every error code + stripFences |
| `run.test.ts` | 25 — happy + idempotency + failure modes + dependency declaration (always `['backend','database']`) + buildUserPrompt |
| `invariants.test.ts` | 27 — every cross-architect predicate validated against the golden + negative cases (CSP no-unsafe-inline, HSTS preload, deny-by-default, tenant defence-in-depth, never-log secrets, audit events, OWASP coverage) |
| `golden/golden.test.ts` | 19 — **OWASP top-10 golden** verifying every A01..A10 category has verdict + ≥1 mitigation + ≥1 evidenceRef + upstream cross-validation |

TypeScript strict typecheck clean (\`pnpm typecheck\`).

## V1 deferrals

- `tools` is empty for V1 per task brief. Spec §2.10's `caia-cspchecker` deterministic CSP composer is V2.
- Class satisfies `SpecialistArchitect` structurally; will switch to `extends BaseArchitect` when the architect-kit's BaseArchitect becomes the canonical extension point.

## Stack reminder

shadcn/ui + Tailwind locked. Subscription-only build (no `ANTHROPIC_API_KEY`). True-Zero rule observed.

## Mirrors

Built from the `@caia/frontend-architect` template (architect #1, the canonical scaffold). Pattern matches `@caia/database-architect` (architect #3) for the wave-2 upstream-consumption shape.