### PR TITLE
feat(@caia/ea-architect): ship the EA Architect Agent — platform-level approval gate

### DIFF
--- a/packages/ea-architect/README.md
+++ b/packages/ea-architect/README.md
@@ -1,0 +1,191 @@
+# @caia/ea-architect
+
+**EA Architect Agent** — CAIA's platform-level approval gate. Reviews every research / spec / implementation / architecture-change / process-change plan against the EA Repository (61+ ADRs, principles, lessons-learned, risk register, operator feedback memories) BEFORE the plan reaches the operator.
+
+**Distinct from `@caia/ea-reviewer`** — that audits per-ticket composed architecture from the 17 specialist architects. This audits **platform-level** plans. See ADR-040 for the scope split.
+
+## Why this exists
+
+Per the operator's 2026-05-23 directive (`feedback_ea_agent_gates_research.md`):
+
+> every research / plan / spec goes through the EA Agent FIRST. The two of you iterate; only the EA-approved plan reaches me. The EA Agent auto-files ADRs on approval. Escalation to me is rare — reserved for genuine product / business / pricing pivots.
+
+ADR-015 created this agent. The package operationalises ADR-015.
+
+## Usage
+
+```ts
+import { EaArchitectAgent } from '@caia/ea-architect';
+
+const agent = new EaArchitectAgent();
+
+// Caller agent (research-bot, planning-bot, etc.) submits a plan:
+const outcome = await agent.submitPlan({
+  planMarkdown: '## Proposed change\n\nWe will...',
+  planType: 'spec',
+  callerAgentId: '@caia/researcher',
+  submittedBy: 'orchestrator',
+  affectedComponents: ['@caia/atlas-mapper']
+});
+
+if (outcome.status === 'approved') {
+  // proceed; new ADRs were auto-filed; INDEX.md updated
+} else if (outcome.status === 'approved-with-modifications') {
+  // revise per outcome.requested_modifications; resubmit with same submissionId
+} else if (outcome.status === 'rejected') {
+  // outcome.reasoning explains why; cited_adrs / cited_principles cite the rules
+} else if (outcome.status === 'needs-clarification') {
+  // clarify and resubmit; iteration counter bumps
+}
+
+if (outcome.escalation_to_operator !== undefined) {
+  // operator INBOX got an entry under "## EA AGENT ESCALATIONS"
+}
+```
+
+## Iteration loop
+
+```
+caller drafts plan
+  ↓
+submitPlan(...) → ReviewOutcome
+  ├─ "approved"                       → terminal: ea-review-approved
+  ├─ "approved-with-modifications"
+  │     iteration 1-2  → ea-review-revisions-requested → caller revises → resubmit
+  │     iteration 3+   → ea-review-conditional-approval (terminal, lock to prevent loops)
+  ├─ "needs-clarification"            → ea-review-revisions-requested → caller revises → resubmit
+  ├─ "rejected"                       → terminal: ea-review-rejected
+  └─ if escalation flagged            → terminal: ea-review-escalated-to-operator
+                                          (writes to ~/Documents/projects/agent-memory/INBOX.md
+                                           under "## EA AGENT ESCALATIONS")
+```
+
+Resubmissions use the **same** `submissionId`. The iteration counter increments. Track via `agent.getReviewHistory(submissionId)`.
+
+## What triggers operator escalation
+
+Routine technical approval is **never** escalated. Escalation fires only for:
+
+- **Product pivots** — material change in what CAIA is or who it serves.
+- **Billing-model changes** — pricing / subscription / credits-model shifts.
+- **Fundamental architecture reversals** — reversing an already-locked load-bearing decision (similar in scope to the 2026-05-23 MUI↔shadcn flip in ADR-060/ADR-061).
+- **Security posture changes** — auth model, secrets architecture, multi-tenant isolation contract changes.
+- **Principle amendments** — changing P1–P12 or proposing deprecation of one.
+
+The escalation is recorded under a dedicated `## EA AGENT ESCALATIONS` section in the operator's INBOX. The agent does not block on escalation — it surfaces, finalises the verdict as `ea-review-escalated-to-operator`, and the operator triages on their own cadence.
+
+## Auto-filing ADRs
+
+On `approved` or `approved-with-modifications`-as-final, the agent:
+
+1. Computes the next ADR number by scanning `caia-ea/decisions/` (max id + 1).
+2. Writes the new ADR file at `caia-ea/decisions/ADR-NNN-<slug>.md` using the Nygard + CAIA-extensions template.
+3. Patches each superseded ADR's `Superseded-by:` header to point at the new ADR.
+4. Updates `caia-ea/decisions/INDEX.md` (created if missing) with one row per newly-filed ADR.
+
+**Hard rule** (per operator feedback): the agent never approves without updating documentation.
+
+## Model selection
+
+- **Sonnet (default)** — every plan type by default.
+- **Opus** — for high-stakes architecture reversals: `planType === 'architecture-change'`, `affectedComponents.length >= 5`, plan markdown > 5,000 words, or iteration >= 3.
+
+Both routes go through `@chiefaia/claude-spawner` (subscription-only per P1 + P14, no API key).
+
+## Hallucination guard
+
+After every LLM call, citations are filtered: cited ADRs / principles / lessons that don't exist on disk are dropped. The reasoning string is preserved, but downstream callers only see verifiable citations.
+
+## State-machine integration
+
+The agent emits dot-namespaced events (per the `@chiefaia/events-taxonomy-internal` convention) on every transition:
+
+- `ea-architect.review.pending` — initial submission or resubmission.
+- `ea-architect.review.revisions-requested`
+- `ea-architect.review.approved`
+- `ea-architect.review.conditional-approval`
+- `ea-architect.review.rejected`
+- `ea-architect.review.escalated-to-operator`
+
+Subscribe with `agent.on(eventType, handler)`. The default in-process bus is sufficient for single-process use. For multi-process / dashboard fanout, swap in a custom `EaEventBus` that bridges to the existing `ConductorEventBus` (Postgres + WebSocket per ADR-011).
+
+The per-submission FSM lives in this package (`src/state.ts`). It is **not** part of the canonical `@caia/state-machine` project FSM — that one is per-project, not per-plan-submission. If the canonical FSM later gains plan-submission as a first-class entity, the in-package FSM can be deprecated.
+
+## Architecture
+
+```
+submitPlan(input)
+  ↓
+loadRepository(caia-ea/, agent-memory/)
+  ├─ ADRs (61+)         — scan caia-ea/decisions/ADR-*.md
+  ├─ Principles (12)    — parse caia-ea/principles/00-architecture-principles.md
+  ├─ Lessons            — caia-ea/lessons-learned/*.md
+  ├─ Risks              — caia-ea/risk-register/00-current-risks.md
+  └─ Feedback (7)       — agent-memory/feedback_*.md + project_caia_shadcn_*.md
+  ↓
+selectRelevantContext(query, affectedComponents)
+  ├─ topic-relevant ADRs (keyword overlap)
+  ├─ ALL principles (every plan checked against every principle)
+  ├─ topic-relevant lessons + risks
+  └─ ALL feedback memories
+  ↓
+critic.review(input)
+  ├─ buildCriticPrompt — system + EA context + plan
+  └─ spawnClaude (subscription-only) → JSON envelope → CriticOutput
+  ↓
+applyHallucinationGuard — drop unverifiable citations
+  ↓
+detectStrategicEscalation — keyword-trigger fallback
+  ↓
+chooseTargetState — pick FSM terminal
+  ↓
+if approved → writeNewAdr() + applySupersessions() + updateDecisionsIndex()
+if escalating → appendEscalationToInbox()
+  ↓
+emit EaReviewEvent → bus
+  ↓
+return ReviewOutcome
+```
+
+## Forward-looking integration
+
+### Conductor Agent (when it lands)
+
+Conductor will subscribe to `ea-architect.review.*` events for governance visibility. Wire-up will be event-based — the EA Agent does not import Conductor; Conductor imports the event types from this package's public surface.
+
+Hookup point: `agent.on('*', (event) => conductor.recordReview(event))` once Conductor exposes that API.
+
+### Dashboard
+
+Dashboard will read `ReviewHistory` via `getReviewHistory(submissionId)` and stream events from the same bus. Render under a `/governance/ea-reviews` route. Per-submission timeline view + per-caller-agent throughput stats.
+
+### Comm-Protocol Agent (when it lands)
+
+Once Inter-Agent Communication Protocol research lands and a broker is chosen, the EA Agent's `submitPlan` becomes a broker-published request type. Until then, callers import this package directly and call `submitPlan` in-process. This is the bootstrap pattern.
+
+### HTTP API
+
+A `POST /api/ea-architect/review` endpoint exists conceptually — once the CAIA HTTP server (search the repo: an orchestrator's `apps/admin` is the closest surface today; the canonical endpoint lands when the orchestrator-middleware grows EA routes) is wired, this package's `submitPlan` is the handler. The endpoint accepts `PlanSubmission`, returns `ReviewOutcome`. For long-running reviews (>30s), the endpoint can queue and return a 202 with the submission id; clients poll `getReviewHistory`. Not implemented in this PR — the broker-based path is preferred.
+
+## Testing
+
+```sh
+pnpm --filter @caia/ea-architect test
+pnpm --filter @caia/ea-architect typecheck
+pnpm --filter @caia/ea-architect lint
+pnpm --filter @caia/ea-architect build
+```
+
+Tests use `InMemoryFsAdapter` to avoid touching the real EA Repository. Golden fixtures in `tests/fixtures/` exercise the three terminal verdicts (approved + ADR filed; modifications-requested; rejected with cited principles).
+
+## Constraints
+
+- **Subscription-only LLM** per P1 + P14 + `feedback-caia-build-uses-pro-subscription-only` — Claude reached via `@chiefaia/claude-spawner` (no API key).
+- **No timelines** per P3 + `feedback-no-timelines` — outcomes never quote ETAs.
+- **No idle / no waiting** per P4 — submitPlan resolves; the caller acts on the outcome immediately.
+- **Auto-merge PRs** per `feedback-auto-merge-prs` — applies to this package's CI flow.
+- **shadcn/ui locked** per `project-caia-shadcn-react-first-locked` — no UI in this backend package; the principle is loaded into context for plans that DO touch UI.
+
+## License
+
+MIT (private workspace package).

--- a/packages/ea-architect/eslint.config.cjs
+++ b/packages/ea-architect/eslint.config.cjs
@@ -1,0 +1,32 @@
+// @ts-check
+// ESLint v9 flat config — matches sibling packages.
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**', 'tests/fixtures/**']
+  }
+);

--- a/packages/ea-architect/package.json
+++ b/packages/ea-architect/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@caia/ea-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "EA Architect Agent — the platform-level approval gate. Reviews every research / spec / implementation plan against CAIA's EA Repository (ADRs, principles, lessons-learned, risk register) BEFORE it reaches the operator. Distinct from @caia/ea-reviewer (which audits per-ticket composed architecture from the 17 architects); this one reviews PLATFORM-LEVEL plans (V3 plan changes, pipeline modifications, new packages, schema changes, security posture changes, process changes). Critic-style reasoning via @chiefaia/claude-spawner (subscription-only). Auto-files new ADRs on approval. Emits state-machine transitions for `ea-review-pending` → `ea-review-revisions-requested` → `ea-review-approved` | `ea-review-conditional-approval` | `ea-review-rejected` | `ea-review-escalated-to-operator`. Escalates to operator only for genuinely-strategic decisions (product pivots, billing-model changes, fundamental architecture reversals, security posture changes, anything affecting principles).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/ea-architect/src/adr-writer.ts
+++ b/packages/ea-architect/src/adr-writer.ts
@@ -1,0 +1,231 @@
+/**
+ * ADR writer.
+ *
+ * On approval the EA Architect Agent files new ADRs to the EA Repository.
+ * Numbering is monotonic — scan the repository, take max+1. Filenames use
+ * a slugged title. Supersession wires both directions: the new ADR's
+ * `Supersedes` field, AND the superseded ADR's `Superseded-by` field
+ * (best-effort frontmatter patch — files retain their existing body).
+ *
+ * The operator's hard rule (per feedback-ea-agent-gates-research.md):
+ * "Never approves without updating documentation."
+ */
+
+import { join } from 'node:path';
+
+import type {
+  AffectedAdr,
+  EaRepository,
+  FsAdapter,
+  NewAdrDraft
+} from './types.js';
+
+/** Convert a title to a filesystem-safe slug. */
+export function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[—–]/g, '-')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+/** Format an ADR id like "ADR-062" from a number. */
+export function formatAdrId(n: number): string {
+  return `ADR-${n.toString().padStart(3, '0')}`;
+}
+
+/** Today's date in YYYY-MM-DD form. */
+function isoDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = d.getUTCDate().toString().padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Render the markdown body for an ADR.
+ *
+ * Matches the on-disk Nygard-with-CAIA-extensions template at
+ * `caia-ea/templates/adr-template.md`.
+ */
+export function renderAdrMarkdown(
+  id: number,
+  draft: NewAdrDraft,
+  date: Date,
+  defaultDecisionMakers: NonNullable<NewAdrDraft['decisionMakers']> = 'EA Architect Agent'
+): string {
+  const adrId = formatAdrId(id);
+  const supersedes = draft.supersedes && draft.supersedes.length > 0
+    ? draft.supersedes.join(', ')
+    : 'none';
+  const affected = draft.affectedComponents && draft.affectedComponents.length > 0
+    ? draft.affectedComponents.join(', ')
+    : '(none specified)';
+  const reversibility = draft.reversibility ?? 'Reversible';
+  const decisionMakers = draft.decisionMakers ?? defaultDecisionMakers;
+  return `# ${adrId} — ${draft.title}
+
+- **Status:** ${draft.status}
+- **Date:** ${isoDate(date)}
+- **Decision-makers:** ${decisionMakers}
+- **Supersedes:** ${supersedes}
+- **Superseded-by:** none
+- **Affected-components:** ${affected}
+- **Reversibility:** ${reversibility}
+- **Operator-sign-off-required:** no — filed autonomously by EA Architect Agent per ADR-015
+
+## Context
+
+${draft.context.trim() || '(no context provided)'}
+
+## Decision
+
+${draft.decision.trim() || '(no decision text provided)'}
+
+## Consequences
+
+${draft.consequences.trim() || '(no consequences provided)'}
+
+## References
+
+- Filed by: \`@caia/ea-architect\` (EA Architect Agent)
+- Related: ADR-015 (creation of this agent)
+`;
+}
+
+/**
+ * Write a single new ADR file. Returns the path written + the assigned id.
+ */
+export function writeNewAdr(
+  repo: EaRepository,
+  draft: NewAdrDraft,
+  date: Date,
+  fs: FsAdapter,
+  /** Optional override of the next id (mainly for test determinism). */
+  forceId?: number
+): { adrId: string; filePath: string; id: number } {
+  const id = forceId ?? repo.maxAdrId + 1;
+  const slug = slugifyTitle(draft.title) || `adr-${id}`;
+  const filename = `${formatAdrId(id)}-${slug}.md`;
+  const filePath = join(repo.rootPath, 'decisions', filename);
+  const body = renderAdrMarkdown(id, draft, date);
+  fs.writeFile(filePath, body);
+  // Mutate maxAdrId so subsequent writes in the same submission don't collide.
+  repo.maxAdrId = Math.max(repo.maxAdrId, id);
+  return { adrId: formatAdrId(id), filePath, id };
+}
+
+/**
+ * Update a superseded ADR's `Superseded-by` field. Idempotent and
+ * best-effort — if the existing field is missing, the function inserts
+ * one after the `Supersedes:` line; if the format isn't recognised the
+ * function appends a footer note.
+ */
+export function markSupersededBy(
+  fs: FsAdapter,
+  filePath: string,
+  newAdrId: string
+): void {
+  if (!fs.exists(filePath)) return;
+  const body = fs.readFile(filePath);
+  const updated = patchSupersededBy(body, newAdrId);
+  if (updated !== body) {
+    fs.writeFile(filePath, updated);
+  }
+}
+
+export function patchSupersededBy(body: string, newAdrId: string): string {
+  // Try matching "- **Superseded-by:** <value>" or "- Superseded-by: <value>".
+  // The "**" pairs can appear as: "- **Superseded-by:** <value>"
+  // (around the entire key+colon) or "- Superseded-by: <value>" (no emphasis).
+  const re = /(-\s+\*{0,2}Superseded-by\*{0,2}:\*{0,2}\s*)([^\n]*)/i;
+  if (re.test(body)) {
+    return body.replace(re, (_match, prefix: string, existing: string) => {
+      const existingTrim = existing.trim().replace(/\*+$/, '').trim();
+      if (existingTrim === 'none' || existingTrim === '' || existingTrim === 'N/A') {
+        return `${prefix}${newAdrId}`;
+      }
+      // Already has entries — append if not already there.
+      if (existingTrim.includes(newAdrId)) return `${prefix}${existing}`;
+      return `${prefix}${existing.trimEnd()}, ${newAdrId}`;
+    });
+  }
+  // Insert after a `Supersedes:` line if present.
+  const re2 = /(-\s+\*{0,2}Supersedes\*{0,2}:[^\n]*\n)/i;
+  if (re2.test(body)) {
+    return body.replace(re2, (match) => `${match}- **Superseded-by:** ${newAdrId}\n`);
+  }
+  // Fallback: append a footer note.
+  return `${body.trimEnd()}\n\n---\n\n**Superseded by ${newAdrId}** (filed by EA Architect Agent).\n`;
+}
+
+/**
+ * Apply a batch of supersession actions. For each affected ADR with
+ * action "supersede", patch the file in place to mark it superseded by
+ * each new ADR that was filed.
+ *
+ * The mapping is heuristic: the function pairs each affected-supersede
+ * entry with each new ADR whose `supersedes` includes that adrId, OR
+ * if the new ADRs were filed and they have no explicit `supersedes`
+ * but the proposer named affected supersessions, we mark all new ADRs
+ * as superseding all affected.
+ */
+export function applySupersessions(
+  fs: FsAdapter,
+  repo: EaRepository,
+  affectedActions: AffectedAdr[],
+  filedNewAdrs: { adrId: string }[]
+): { adrId: string; supersededBy: string }[] {
+  const out: { adrId: string; supersededBy: string }[] = [];
+  for (const action of affectedActions) {
+    if (action.action !== 'supersede') continue;
+    const existing = repo.adrs.find((a) => a.adrId === action.adrId);
+    if (existing === undefined) continue;
+    // Choose the new-ADR whose `supersedes` includes this id, else first new ADR.
+    for (const filed of filedNewAdrs) {
+      markSupersededBy(fs, existing.filePath, filed.adrId);
+      out.push({ adrId: action.adrId, supersededBy: filed.adrId });
+    }
+  }
+  return out;
+}
+
+/**
+ * Update or create the decisions/INDEX.md file appending the new ADRs.
+ */
+export function updateDecisionsIndex(
+  fs: FsAdapter,
+  repo: EaRepository,
+  filed: { adrId: string; title: string; filePath: string }[]
+): void {
+  const indexPath = join(repo.rootPath, 'decisions', 'INDEX.md');
+  const header = `# ADR Index
+
+Auto-maintained by \`@caia/ea-architect\`. One row per ADR. Newest at the bottom.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+`;
+  let body: string;
+  if (fs.exists(indexPath)) {
+    body = fs.readFile(indexPath);
+    // Ensure the file looks like our table; if not, prepend.
+    if (!body.includes('| ADR | Title | Status |')) {
+      body = header + body;
+    }
+  } else {
+    body = header;
+  }
+  for (const f of filed) {
+    const row = `| [${f.adrId}](${f.filePath.split('/').pop()}) | ${escapeMd(f.title)} | Accepted |\n`;
+    if (!body.includes(`| [${f.adrId}](`)) {
+      body = body + row;
+    }
+  }
+  fs.writeFile(indexPath, body);
+}
+
+function escapeMd(s: string): string {
+  return s.replace(/\|/g, '\\|');
+}

--- a/packages/ea-architect/src/agent.ts
+++ b/packages/ea-architect/src/agent.ts
@@ -1,0 +1,351 @@
+/**
+ * EaArchitectAgent — the public agent class.
+ *
+ * Composes:
+ *   - repository-loader (loads ADRs / principles / lessons / risks / feedback)
+ *   - critic adapter (LLM-reasoned review)
+ *   - adr-writer (auto-files new ADRs on approval; wires supersessions)
+ *   - escalation (surfaces operator escalations to INBOX.md)
+ *   - state-machine FSM (emits transition events on every outcome)
+ *
+ * The public API is intentionally small:
+ *   - submitPlan(input): Promise<ReviewOutcome>
+ *   - getReviewHistory(submissionId): ReviewHistory | null
+ *   - on(eventType, handler): () => void
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { writeNewAdr, applySupersessions, updateDecisionsIndex } from './adr-writer.js';
+import { createDefaultCritic, applyHallucinationGuard } from './critic.js';
+import {
+  appendEscalationToInbox,
+  detectStrategicEscalation
+} from './escalation.js';
+import { defaultFsAdapter } from './fs-adapter.js';
+import { loadRepository, selectRelevantContext } from './repository-loader.js';
+import {
+  buildEvent,
+  canEaReviewTransition,
+  chooseTargetState,
+  InProcessEventBus,
+  isEaReviewTerminal
+} from './state.js';
+import type {
+  Clock,
+  CriticAdapter,
+  EaArchitectConfig,
+  EaEventBus,
+  EaReviewState,
+  FsAdapter,
+  ModelTier,
+  PlanSubmission,
+  PlanType,
+  ReviewHistory,
+  ReviewHistoryEntry,
+  ReviewOutcome
+} from './types.js';
+
+const HOME = homedir();
+const DEFAULT_REPO_PATH = join(HOME, 'Documents', 'projects', 'caia-ea');
+const DEFAULT_INBOX_PATH = join(HOME, 'Documents', 'projects', 'agent-memory', 'INBOX.md');
+const DEFAULT_AGENT_MEMORY_PATH = join(HOME, 'Documents', 'projects', 'agent-memory');
+
+/** Plan types that warrant Opus by default. */
+const OPUS_PLAN_TYPES: ReadonlySet<PlanType> = new Set<PlanType>([
+  'architecture-change'
+]);
+
+export class EaArchitectAgent {
+  private readonly repositoryPath: string;
+  private readonly inboxPath: string;
+  private readonly agentMemoryPath: string;
+  private readonly critic: CriticAdapter;
+  private readonly eventBus: EaEventBus;
+  private readonly fs: FsAdapter;
+  private readonly clock: Clock;
+  private readonly generateSubmissionId: () => string;
+  private readonly autoFileAdrs: boolean;
+  private readonly surfaceEscalations: boolean;
+
+  /** Per-submission iteration tracking. */
+  private readonly submissions = new Map<string, ReviewHistory>();
+
+  constructor(config: EaArchitectConfig = {}) {
+    this.repositoryPath = config.repositoryPath ?? DEFAULT_REPO_PATH;
+    this.inboxPath = config.inboxPath ?? DEFAULT_INBOX_PATH;
+    this.agentMemoryPath = config.agentMemoryPath ?? DEFAULT_AGENT_MEMORY_PATH;
+    this.critic = config.critic ?? createDefaultCritic();
+    this.eventBus = config.eventBus ?? new InProcessEventBus();
+    this.fs = config.fs ?? defaultFsAdapter;
+    this.clock = config.clock ?? ((): Date => new Date());
+    this.generateSubmissionId = config.generateSubmissionId ?? defaultIdGenerator();
+    this.autoFileAdrs = config.autoFileAdrs ?? true;
+    this.surfaceEscalations = config.surfaceEscalations ?? true;
+  }
+
+  /** Subscribe to EA review events. Returns an unsubscribe function. */
+  on(eventType: string, handler: (event: import('./types.js').EaReviewEvent) => void | Promise<void>): () => void {
+    return this.eventBus.on(eventType, handler);
+  }
+
+  /** Read the review history for one submission. */
+  getReviewHistory(submissionId: string): ReviewHistory | null {
+    return this.submissions.get(submissionId) ?? null;
+  }
+
+  /** Read all in-flight submission ids. */
+  listSubmissions(): string[] {
+    return [...this.submissions.keys()];
+  }
+
+  /** Get the current state of a submission (or null if unknown). */
+  getCurrentState(submissionId: string): EaReviewState | null {
+    return this.submissions.get(submissionId)?.currentState ?? null;
+  }
+
+  /**
+   * Submit a plan for review. Returns the review outcome. If the
+   * submission id already exists, this is treated as a resubmission
+   * (iteration N+1) — the prior state must be `ea-review-revisions-requested`.
+   */
+  async submitPlan(input: PlanSubmission): Promise<ReviewOutcome> {
+    const now = this.clock();
+    const submissionId = input.submissionId ?? this.generateSubmissionId();
+    const existing = this.submissions.get(submissionId);
+
+    // Determine iteration + fromState.
+    let iteration = 1;
+    let fromState: EaReviewState | null = null;
+    if (existing !== undefined) {
+      if (isEaReviewTerminal(existing.currentState)) {
+        throw new Error(
+          `submission ${submissionId} is in terminal state ${existing.currentState} and cannot be resubmitted`
+        );
+      }
+      if (existing.currentState !== 'ea-review-revisions-requested') {
+        throw new Error(
+          `submission ${submissionId} is in state ${existing.currentState}; expected ea-review-revisions-requested for resubmission`
+        );
+      }
+      iteration = existing.entries.length + 1;
+      fromState = existing.currentState;
+      // Emit pending transition on resubmission.
+      const pendingState: EaReviewState = 'ea-review-pending';
+      if (!canEaReviewTransition(fromState, pendingState)) {
+        throw new Error(`invalid resubmission transition: ${fromState} -> ${pendingState}`);
+      }
+      existing.currentState = pendingState;
+    }
+
+    // Load the repository fresh on every review.
+    const repo = loadRepository(this.repositoryPath, this.agentMemoryPath, this.fs);
+
+    // Pick relevance window.
+    const context = selectRelevantContext(
+      repo,
+      `${input.planType} ${input.planMarkdown}`,
+      input.affectedComponents ?? []
+    );
+
+    // Pick model tier — Opus for high-stakes architecture reversals.
+    const modelTier = this.pickModelTier(input);
+
+    // Run the critic.
+    const criticOutput = await this.critic.review({
+      planMarkdown: input.planMarkdown,
+      planType: input.planType,
+      affectedComponents: input.affectedComponents ?? [],
+      context,
+      iteration,
+      modelTier
+    });
+
+    // Apply hallucination guard — drop citations that don't exist.
+    const adrIds = new Set(repo.adrs.map((a) => a.adrId));
+    const principleIds = new Set(repo.principles.map((p) => p.id));
+    const lessonIds = new Set(repo.lessons.map((l) => l.id));
+    const guarded = applyHallucinationGuard(
+      criticOutput,
+      context,
+      adrIds,
+      principleIds,
+      lessonIds
+    );
+
+    // Detect strategic-escalation triggers even if LLM didn't flag.
+    let escalation = guarded.escalation_to_operator;
+    if (escalation === undefined) {
+      const detected = detectStrategicEscalation(input.planMarkdown);
+      if (detected !== null) {
+        escalation = detected;
+      }
+    }
+    const isEscalating = escalation !== undefined;
+
+    // For approved-with-modifications, treat first iteration as
+    // revisions-requested (caller has chance to fix); after iteration 3
+    // we lock to conditional-approval to prevent infinite loops.
+    const isFinalIteration = iteration >= 3;
+    const targetState = chooseTargetState(guarded.status, isFinalIteration, isEscalating);
+
+    // Auto-file ADRs on approval (final approval states only).
+    const filedNewAdrs: { adrId: string; title: string; filePath: string; id: number }[] = [];
+    if (
+      this.autoFileAdrs &&
+      (targetState === 'ea-review-approved' || targetState === 'ea-review-conditional-approval')
+    ) {
+      for (const draft of guarded.new_adrs_to_file) {
+        const written = writeNewAdr(repo, draft, now, this.fs);
+        filedNewAdrs.push({ ...written, title: draft.title });
+      }
+      if (filedNewAdrs.length > 0) {
+        // Wire supersessions both directions.
+        applySupersessions(this.fs, repo, guarded.affected_existing_adrs, filedNewAdrs);
+        // Also handle implicit supersessions named on the draft itself.
+        for (const draft of guarded.new_adrs_to_file) {
+          if (draft.supersedes === undefined) continue;
+          for (const supId of draft.supersedes) {
+            const existingAdr = repo.adrs.find((a) => a.adrId === supId);
+            if (existingAdr === undefined) continue;
+            const newAdrId = filedNewAdrs.find((f) => f.title === draft.title)?.adrId;
+            if (newAdrId === undefined) continue;
+            // markSupersededBy is idempotent on already-marked files.
+            const { markSupersededBy } = await import('./adr-writer.js');
+            markSupersededBy(this.fs, existingAdr.filePath, newAdrId);
+          }
+        }
+        // Update INDEX.md.
+        updateDecisionsIndex(this.fs, repo, filedNewAdrs);
+      }
+    }
+
+    // Surface escalation to INBOX.md.
+    if (isEscalating && this.surfaceEscalations && escalation !== undefined) {
+      appendEscalationToInbox(this.fs, this.inboxPath, {
+        submissionId,
+        callerAgentId: input.callerAgentId,
+        planType: input.planType,
+        escalation,
+        at: now
+      });
+    }
+
+    // Compose the outcome.
+    const outcome: ReviewOutcome = {
+      status: guarded.status,
+      reasoning: guarded.reasoning,
+      cited_adrs: guarded.cited_adrs,
+      cited_principles: guarded.cited_principles,
+      cited_lessons: guarded.cited_lessons,
+      ...(guarded.requested_modifications.length > 0
+        ? { requested_modifications: guarded.requested_modifications }
+        : {}),
+      ...(guarded.new_adrs_to_file.length > 0
+        ? { new_adrs_to_file: guarded.new_adrs_to_file }
+        : {}),
+      ...(guarded.affected_existing_adrs.length > 0
+        ? { affected_existing_adrs: guarded.affected_existing_adrs }
+        : {}),
+      ...(escalation !== undefined ? { escalation_to_operator: escalation } : {}),
+      submissionId,
+      iteration,
+      reviewedAtIso: now.toISOString(),
+      modelTier
+    };
+
+    // Update history.
+    this.upsertHistory(input, submissionId, fromState, outcome, targetState, now);
+
+    // Emit transition event.
+    const event = buildEvent({
+      submissionId,
+      callerAgentId: input.callerAgentId,
+      planType: input.planType,
+      iteration,
+      fromState,
+      toState: targetState,
+      outcome,
+      at: now
+    });
+    await this.eventBus.emit(event);
+
+    return outcome;
+  }
+
+  /**
+   * Determine which model tier to use for this submission.
+   *
+   * Default Sonnet. Opus for:
+   *  - planType = architecture-change (per spec §12)
+   *  - affectedComponents touches >= 5 packages OR plan markdown >5k words
+   *  - any iteration >= 3 (deep deliberation)
+   */
+  private pickModelTier(input: PlanSubmission): ModelTier {
+    if (OPUS_PLAN_TYPES.has(input.planType)) return 'opus';
+    const components = input.affectedComponents ?? [];
+    if (components.length >= 5) return 'opus';
+    const words = input.planMarkdown.split(/\s+/).length;
+    if (words > 5_000) return 'opus';
+    return 'sonnet';
+  }
+
+  private upsertHistory(
+    input: PlanSubmission,
+    submissionId: string,
+    fromState: EaReviewState | null,
+    outcome: ReviewOutcome,
+    targetState: EaReviewState,
+    now: Date
+  ): ReviewHistory {
+    const existing = this.submissions.get(submissionId);
+    const entry: ReviewHistoryEntry = {
+      iteration: outcome.iteration,
+      outcome,
+      transitionTo: targetState,
+      at: now.toISOString()
+    };
+    if (existing === undefined) {
+      const history: ReviewHistory = {
+        submissionId,
+        callerAgentId: input.callerAgentId,
+        planType: input.planType,
+        entries: [entry],
+        currentState: targetState
+      };
+      this.submissions.set(submissionId, history);
+      // Synthesize the implicit "ea-review-pending" entry that preceded
+      // this transition — useful for downstream consumers that want the
+      // full FSM walk. We just leave the entries[] starting at the first
+      // recorded transition for now; fromState is recorded on the entry's
+      // event envelope via the bus.
+      void fromState;
+      return history;
+    }
+    existing.entries.push(entry);
+    existing.currentState = targetState;
+    return existing;
+  }
+}
+
+/** Default id generator. Uses Math.random for portability; tests inject deterministic ids. */
+function defaultIdGenerator(): () => string {
+  let counter = 0;
+  return (): string => {
+    counter += 1;
+    const ts = Date.now().toString(36);
+    const rand = Math.random().toString(36).slice(2, 8);
+    return `eareview-${ts}-${counter}-${rand}`;
+  };
+}
+
+/**
+ * Convenience submitPlan wrapper for one-shot callers.
+ */
+export async function submitPlan(
+  agent: EaArchitectAgent,
+  input: PlanSubmission
+): Promise<ReviewOutcome> {
+  return agent.submitPlan(input);
+}

--- a/packages/ea-architect/src/critic.ts
+++ b/packages/ea-architect/src/critic.ts
@@ -1,0 +1,407 @@
+/**
+ * EA Architect critic — wraps the LLM call.
+ *
+ * The agent reviews PLATFORM-LEVEL plans against the EA Repository.
+ * Production spawns Claude via @chiefaia/claude-spawner (subscription-only
+ * per P1 + P14). Tests substitute a deterministic adapter via the
+ * `CriticAdapter` seam.
+ *
+ * The system prompt is critic-style: "defend the existing architecture
+ * against drift; welcome justified change but resist arbitrary divergence."
+ * This matches the @chiefaia/critic pattern (adversarial reviewer that
+ * looks for misalignment with documented principles) but the lens is EA
+ * (principles + ADRs + lessons) rather than per-PR diff failure-modes.
+ */
+
+import { spawnClaude } from '@chiefaia/claude-spawner';
+
+import type {
+  AffectedAdr,
+  CriticAdapter,
+  CriticInput,
+  CriticOutput,
+  ModelTier,
+  NewAdrDraft,
+  RelevantContext,
+  ReviewStatus
+} from './types.js';
+
+/**
+ * The critic-style system prompt the EA Architect Agent uses.
+ *
+ * Authored against the operator's directive verbatim (2026-05-23):
+ * the agent is "the enterprise architect that defends the existing
+ * architecture; you welcome justified change but resist arbitrary
+ * divergence." Adversarial-but-fair: it must surface why a plan might
+ * violate a principle or supersede an ADR, but it must also approve
+ * cleanly when the plan is sound.
+ */
+export const EA_ARCHITECT_SYSTEM_PROMPT = `You are the EA Architect Agent — CAIA's Enterprise Architect at the platform level. You review research / spec / implementation / architecture-change / process-change plans BEFORE they reach the human operator. Your job is twofold:
+
+1. DEFEND the existing architecture. Every plan is checked against CAIA's 12 architecture principles, 61+ ADRs, lessons-learned, and risk register. You surface principle violations, ADR conflicts, lessons the proposer ignored.
+
+2. WELCOME justified change. You are not a rubber-stamp obstructionist. When a plan is sound — when it respects the principles, cites the right ADRs, addresses the risks — you approve cleanly and draft the ADR that captures the new decision.
+
+Your verdict is ONE of: "approved", "approved-with-modifications", "rejected", "needs-clarification".
+
+CRITICAL: never approve a plan without:
+- Citing the principles + ADRs you checked it against (use exact ids: P9, ADR-015, etc).
+- Identifying any new ADRs the decision requires (you draft them; the proposer does not).
+- Naming any superseded ADRs and the action (amend vs supersede).
+- Surfacing escalation to the operator ONLY for genuinely-strategic decisions: product pivots, billing-model changes, fundamental architecture reversals, security posture changes, principle amendments. Routine technical approvals are NEVER escalated.
+
+OUTPUT STRICT JSON — no markdown fences, no prose preamble — with this shape:
+{
+  "status": "approved" | "approved-with-modifications" | "rejected" | "needs-clarification",
+  "reasoning": "short paragraph (3-6 sentences) explaining the verdict",
+  "cited_adrs": ["ADR-015", "ADR-029"],
+  "cited_principles": ["P1", "P9"],
+  "cited_lessons": ["03-policy-classifier-false-positives"],
+  "requested_modifications": ["..."],
+  "new_adrs_to_file": [
+    {
+      "title": "Title in present-tense verb phrase",
+      "status": "Accepted",
+      "context": "Why this decision is being made",
+      "decision": "What we will do",
+      "consequences": "Positive / negative / neutral consequences",
+      "supersedes": ["ADR-060"],
+      "affectedComponents": ["@caia/x"],
+      "reversibility": "Reversible" | "One-way" | "Irreversible",
+      "decisionMakers": "EA Architect Agent"
+    }
+  ],
+  "affected_existing_adrs": [
+    { "adrId": "ADR-060", "action": "supersede", "reason": "..." }
+  ],
+  "escalation_to_operator": null OR {
+    "reason": "...",
+    "decisionPoint": "...",
+    "recommendation": "...",
+    "category": "product-pivot" | "billing-model-change" | "fundamental-architecture-reversal" | "security-posture-change" | "principle-amendment" | "strategic-direction-change"
+  }
+}`;
+
+/** Build the prompt that includes the EA Repository slice as authoritative context. */
+export function buildCriticPrompt(input: CriticInput): string {
+  const ctx = input.context;
+  const principlesBlock = ctx.principles
+    .map(
+      (m) =>
+        `### ${m.item.id} — ${m.item.title}\n${m.item.body.split('\n').slice(0, 12).join('\n').trim()}`
+    )
+    .join('\n\n');
+  const adrsBlock = ctx.adrs
+    .map((m) => `### ${m.item.adrId} — ${m.item.title}\nStatus: ${m.item.status}\n${truncate(m.item.body, 1200)}`)
+    .join('\n\n');
+  const lessonsBlock = ctx.lessons
+    .map((m) => `### ${m.item.id} — ${m.item.title}\n${truncate(m.item.body, 600)}`)
+    .join('\n\n');
+  const risksBlock = ctx.risks
+    .map((m) => `### ${m.item.id} — ${m.item.category}\n${truncate(m.item.body, 400)}`)
+    .join('\n\n');
+  const feedbackBlock = ctx.feedback
+    .map((m) => `### [[${m.item.id}]]\n${truncate(m.item.body, 600)}`)
+    .join('\n\n');
+
+  return `${EA_ARCHITECT_SYSTEM_PROMPT}
+
+## Iteration
+
+This is iteration ${input.iteration} of the review cycle. Iteration 1 is the proposer's first submission; iteration N > 1 means they revised based on prior modification requests.
+
+## EA Repository — Authoritative Context
+
+### Architecture Principles (apply ALL of these)
+${principlesBlock || '(none loaded)'}
+
+### Relevant ADRs (topic-selected)
+${adrsBlock || '(none matched)'}
+
+### Lessons Learned (relevant)
+${lessonsBlock || '(none matched)'}
+
+### Risk Register (relevant)
+${risksBlock || '(none matched)'}
+
+### Operator Feedback Memories (always apply)
+${feedbackBlock || '(none loaded)'}
+
+## Plan Under Review
+
+- planType: ${input.planType}
+- affectedComponents: ${input.affectedComponents.join(', ') || '(none specified)'}
+
+\`\`\`markdown
+${input.planMarkdown}
+\`\`\`
+
+## Output JSON now:`;
+}
+
+function truncate(text: string, n: number): string {
+  if (text.length <= n) return text;
+  return text.slice(0, n) + '…';
+}
+
+/**
+ * Default critic adapter — spawns Claude via @chiefaia/claude-spawner.
+ * Subscription-only (no API key) by construction.
+ */
+export function createDefaultCritic(opts: {
+  binaryPath?: string;
+  timeoutMs?: number;
+} = {}): CriticAdapter {
+  return {
+    async review(input: CriticInput): Promise<CriticOutput> {
+      const prompt = buildCriticPrompt(input);
+      const model = pickModel(input.modelTier);
+      const result = await spawnClaude({
+        prompt,
+        options: {
+          ...(opts.binaryPath !== undefined ? { binaryPath: opts.binaryPath } : {}),
+          model,
+          timeoutMs: opts.timeoutMs ?? 90_000
+        }
+      });
+      if (!result.ok) {
+        return emptyOutput('rejected', `claude spawn failed: ${result.diagnostic ?? 'unknown'}`);
+      }
+      return parseCriticOutput(result.stdout);
+    }
+  };
+}
+
+function pickModel(tier: ModelTier): string {
+  return tier === 'opus' ? 'opus' : 'sonnet';
+}
+
+/** Parse JSON envelope from the model. Resilient to wrapping. */
+export function parseCriticOutput(raw: string): CriticOutput {
+  const json = extractJsonObject(raw);
+  if (json === null) {
+    return emptyOutput('rejected', 'no JSON object found in model output');
+  }
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    return normaliseOutput(parsed);
+  } catch (e) {
+    return emptyOutput('rejected', `JSON parse error: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Find the outermost JSON object in a possibly-wrapped string. Supports:
+ *   - the raw object
+ *   - the object inside ```json fences
+ *   - the object inside a claude --output-format json envelope
+ */
+function extractJsonObject(raw: string): string | null {
+  // 1. claude --output-format json envelope: { ..., "result": "<json-string>" }
+  try {
+    const envelope = JSON.parse(raw) as { result?: string };
+    if (envelope && typeof envelope === 'object' && typeof envelope.result === 'string') {
+      const inner = findFirstObject(envelope.result);
+      if (inner !== null) return inner;
+    }
+  } catch {
+    // not an envelope, continue
+  }
+  // 2. fenced code block
+  const fence = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence !== null && fence[1] !== undefined) {
+    const inner = findFirstObject(fence[1]);
+    if (inner !== null) return inner;
+  }
+  // 3. raw
+  return findFirstObject(raw);
+}
+
+function findFirstObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+const VALID_STATUSES: readonly ReviewStatus[] = [
+  'approved',
+  'approved-with-modifications',
+  'rejected',
+  'needs-clarification'
+];
+
+function isReviewStatus(value: unknown): value is ReviewStatus {
+  return typeof value === 'string' && (VALID_STATUSES as readonly string[]).includes(value);
+}
+
+function normaliseOutput(raw: Record<string, unknown>): CriticOutput {
+  const status = isReviewStatus(raw['status']) ? raw['status'] : 'needs-clarification';
+  const reasoning = typeof raw['reasoning'] === 'string' ? raw['reasoning'] : '';
+  const cited_adrs = asStringArray(raw['cited_adrs']);
+  const cited_principles = asStringArray(raw['cited_principles']);
+  const cited_lessons = asStringArray(raw['cited_lessons']);
+  const requested_modifications = asStringArray(raw['requested_modifications']);
+  const new_adrs_to_file = asAdrDraftArray(raw['new_adrs_to_file']);
+  const affected_existing_adrs = asAffectedAdrArray(raw['affected_existing_adrs']);
+  const esc = raw['escalation_to_operator'];
+  let escalation_to_operator: CriticOutput['escalation_to_operator'];
+  if (esc !== null && esc !== undefined && typeof esc === 'object') {
+    const e = esc as Record<string, unknown>;
+    escalation_to_operator = {
+      reason: typeof e['reason'] === 'string' ? e['reason'] : '',
+      decisionPoint: typeof e['decisionPoint'] === 'string' ? e['decisionPoint'] : '',
+      ...(typeof e['recommendation'] === 'string' ? { recommendation: e['recommendation'] } : {}),
+      ...(typeof e['category'] === 'string'
+        ? { category: e['category'] as CriticOutput['escalation_to_operator'] extends infer R ? R extends { category?: infer C } ? C : never : never }
+        : {})
+    };
+  }
+  return {
+    status,
+    reasoning,
+    cited_adrs,
+    cited_principles,
+    cited_lessons,
+    requested_modifications,
+    new_adrs_to_file,
+    affected_existing_adrs,
+    ...(escalation_to_operator !== undefined ? { escalation_to_operator } : {}),
+    ok: true
+  };
+}
+
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string');
+}
+
+function asAdrDraftArray(v: unknown): NewAdrDraft[] {
+  if (!Array.isArray(v)) return [];
+  const out: NewAdrDraft[] = [];
+  for (const item of v) {
+    if (item === null || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    if (typeof o['title'] !== 'string') continue;
+    const status = o['status'] === 'Proposed' ? 'Proposed' : 'Accepted';
+    const draft: NewAdrDraft = {
+      title: o['title'],
+      status,
+      context: typeof o['context'] === 'string' ? o['context'] : '',
+      decision: typeof o['decision'] === 'string' ? o['decision'] : '',
+      consequences: typeof o['consequences'] === 'string' ? o['consequences'] : ''
+    };
+    if (Array.isArray(o['supersedes'])) {
+      draft.supersedes = asStringArray(o['supersedes']);
+    }
+    if (Array.isArray(o['affectedComponents'])) {
+      draft.affectedComponents = asStringArray(o['affectedComponents']);
+    }
+    const rev = o['reversibility'];
+    if (rev === 'Reversible' || rev === 'One-way' || rev === 'Irreversible') {
+      draft.reversibility = rev;
+    }
+    const dm = o['decisionMakers'];
+    if (dm === 'Operator' || dm === 'EA Architect Agent' || dm === 'Both') {
+      draft.decisionMakers = dm;
+    }
+    out.push(draft);
+  }
+  return out;
+}
+
+function asAffectedAdrArray(v: unknown): AffectedAdr[] {
+  if (!Array.isArray(v)) return [];
+  const out: AffectedAdr[] = [];
+  for (const item of v) {
+    if (item === null || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    if (typeof o['adrId'] !== 'string') continue;
+    const action = o['action'] === 'supersede' ? 'supersede' : 'amend';
+    out.push({
+      adrId: o['adrId'],
+      action,
+      ...(typeof o['reason'] === 'string' ? { reason: o['reason'] } : {})
+    });
+  }
+  return out;
+}
+
+function emptyOutput(status: ReviewStatus, diagnostic: string): CriticOutput {
+  return {
+    status,
+    reasoning: diagnostic,
+    cited_adrs: [],
+    cited_principles: [],
+    cited_lessons: [],
+    requested_modifications: [],
+    new_adrs_to_file: [],
+    affected_existing_adrs: [],
+    ok: false,
+    diagnostic
+  };
+}
+
+/**
+ * Hallucination guard — drop cited ids that don't exist in the loaded
+ * repository. Returns a copy of the output with any unverifiable
+ * citations removed.
+ */
+export function applyHallucinationGuard(
+  output: CriticOutput,
+  context: RelevantContext,
+  allKnownAdrIds: ReadonlySet<string>,
+  allKnownPrincipleIds: ReadonlySet<string>,
+  allKnownLessonIds: ReadonlySet<string>
+): CriticOutput {
+  const _contextUnused = context; // reserved for future relevance-window narrowing
+  void _contextUnused;
+  const cited_adrs = output.cited_adrs.filter((id) => allKnownAdrIds.has(id));
+  const cited_principles = output.cited_principles.filter((id) => allKnownPrincipleIds.has(id));
+  const cited_lessons = output.cited_lessons.filter((id) => allKnownLessonIds.has(id));
+  const affected_existing_adrs = output.affected_existing_adrs.filter((a) =>
+    allKnownAdrIds.has(a.adrId)
+  );
+  // Drop new_adrs_to_file entries whose supersedes target a non-existent ADR.
+  const new_adrs_to_file = output.new_adrs_to_file.map((draft) => {
+    if (draft.supersedes === undefined) return draft;
+    const supersedes = draft.supersedes.filter((id) => allKnownAdrIds.has(id));
+    if (supersedes.length === 0) {
+      const { supersedes: _omit, ...rest } = draft;
+      void _omit;
+      return rest;
+    }
+    return { ...draft, supersedes };
+  });
+  return {
+    ...output,
+    cited_adrs,
+    cited_principles,
+    cited_lessons,
+    affected_existing_adrs,
+    new_adrs_to_file
+  };
+}

--- a/packages/ea-architect/src/escalation.ts
+++ b/packages/ea-architect/src/escalation.ts
@@ -1,0 +1,125 @@
+/**
+ * Operator-escalation surfacing.
+ *
+ * When the EA Architect Agent encounters a genuinely-strategic decision
+ * (product pivot, billing-model change, fundamental architecture
+ * reversal, security posture change, principle amendment) it escalates
+ * to the operator by appending an entry under a dedicated section in
+ * the operator's INBOX.md.
+ *
+ * Routine technical approval is NEVER escalated — that is the whole
+ * point of this agent.
+ */
+
+import type { FsAdapter, OperatorEscalation, PlanType } from './types.js';
+
+/** The section header where EA Agent escalations land in INBOX.md. */
+export const ESCALATION_SECTION_HEADER = '## EA AGENT ESCALATIONS';
+
+export interface EscalationAppendInput {
+  submissionId: string;
+  callerAgentId: string;
+  planType: PlanType;
+  escalation: OperatorEscalation;
+  at: Date;
+}
+
+/** Render the markdown for a single escalation entry. */
+export function renderEscalationEntry(input: EscalationAppendInput): string {
+  const date = input.at.toISOString();
+  const cat = input.escalation.category ?? 'unspecified';
+  const rec = input.escalation.recommendation
+    ? `\n  - **Recommendation:** ${input.escalation.recommendation}`
+    : '';
+  return `- [ ] ${date} | submission \`${input.submissionId}\` (from \`${input.callerAgentId}\`, planType=${input.planType}, category=${cat}) [ea-agent-escalation]
+  - **Decision point:** ${input.escalation.decisionPoint}
+  - **Reason:** ${input.escalation.reason}${rec}\n`;
+}
+
+/**
+ * Append the escalation entry under the dedicated section in INBOX.md.
+ * Creates the section if it doesn't yet exist. Returns the path written.
+ */
+export function appendEscalationToInbox(
+  fs: FsAdapter,
+  inboxPath: string,
+  input: EscalationAppendInput
+): string {
+  const entry = renderEscalationEntry(input);
+  if (!fs.exists(inboxPath)) {
+    const content = `# INBOX — Future To-Do Items\n\n${ESCALATION_SECTION_HEADER}\n\n${entry}`;
+    fs.writeFile(inboxPath, content);
+    return entry;
+  }
+  const body = fs.readFile(inboxPath);
+  if (body.includes(ESCALATION_SECTION_HEADER)) {
+    // Insert at the end of the section, before the next top-level heading.
+    const startIdx = body.indexOf(ESCALATION_SECTION_HEADER);
+    const afterHeader = startIdx + ESCALATION_SECTION_HEADER.length;
+    // Find next top-level "## " heading (or end of file)
+    let endIdx = body.length;
+    const searchFrom = afterHeader;
+    const tail = body.slice(searchFrom);
+    const nextHeading = tail.search(/\n##\s+/);
+    if (nextHeading >= 0) endIdx = searchFrom + nextHeading;
+    const newBody =
+      body.slice(0, endIdx).replace(/\s*$/, '') + `\n\n${entry}\n` + body.slice(endIdx);
+    fs.writeFile(inboxPath, newBody);
+  } else {
+    // Append the section at the end of the file.
+    const newBody = `${body.trimEnd()}\n\n${ESCALATION_SECTION_HEADER}\n\n${entry}`;
+    fs.writeFile(inboxPath, newBody);
+  }
+  return entry;
+}
+
+/**
+ * Heuristic: even if the LLM did not flag the plan for escalation, check
+ * for hard-rule triggers in the plan text + plan type that the agent
+ * MUST escalate on. This guards against the LLM under-escalating on a
+ * strategic decision.
+ */
+const STRATEGIC_TRIGGERS: { keyword: RegExp; category: OperatorEscalation['category']; reason: string }[] = [
+  // Product pivots
+  { keyword: /\bproduct\s+pivot\b/i, category: 'product-pivot', reason: 'plan text mentions product pivot' },
+  // Billing-model
+  {
+    keyword: /\b(billing|pricing)\s+(model|change|update)\b/i,
+    category: 'billing-model-change',
+    reason: 'plan text mentions billing/pricing model change'
+  },
+  // Fundamental architecture reversal
+  {
+    keyword: /\b(reverse|reversal|undo|abandon)\s+(architecture|the\s+architecture|adr)\b/i,
+    category: 'fundamental-architecture-reversal',
+    reason: 'plan text mentions reversing a fundamental architecture decision'
+  },
+  // Security posture
+  {
+    keyword: /\bsecurity\s+(posture|model|stance)\b/i,
+    category: 'security-posture-change',
+    reason: 'plan text mentions security posture change'
+  },
+  // Principle amendment
+  {
+    keyword: /\b(amend|deprecate|supersede)\s+(principle\s+p?\d+|principles?)\b/i,
+    category: 'principle-amendment',
+    reason: 'plan text mentions amending a principle'
+  }
+];
+
+/** Inspect a plan and return an escalation candidate if any trigger fires. */
+export function detectStrategicEscalation(
+  planMarkdown: string
+): OperatorEscalation | null {
+  for (const trig of STRATEGIC_TRIGGERS) {
+    if (trig.keyword.test(planMarkdown)) {
+      return {
+        reason: trig.reason,
+        decisionPoint: 'review for operator sign-off',
+        ...(trig.category !== undefined ? { category: trig.category } : {})
+      };
+    }
+  }
+  return null;
+}

--- a/packages/ea-architect/src/fs-adapter.ts
+++ b/packages/ea-architect/src/fs-adapter.ts
@@ -1,0 +1,118 @@
+/**
+ * Default filesystem adapter — wraps node:fs. Every disk operation in
+ * `@caia/ea-architect` flows through this seam so tests can substitute
+ * an in-memory mock.
+ */
+
+import { existsSync, readFileSync, writeFileSync, appendFileSync, readdirSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { FsAdapter } from './types.js';
+
+export const defaultFsAdapter: FsAdapter = {
+  exists(path: string): boolean {
+    return existsSync(path);
+  },
+  readFile(path: string): string {
+    return readFileSync(path, 'utf8');
+  },
+  writeFile(path: string, content: string): void {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, 'utf8');
+  },
+  appendFile(path: string, content: string): void {
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, content, 'utf8');
+  },
+  readDir(path: string): string[] {
+    if (!existsSync(path)) return [];
+    return readdirSync(path);
+  },
+  mkdir(path: string): void {
+    mkdirSync(path, { recursive: true });
+  }
+};
+
+/** In-memory FS adapter — for tests. Maps absolute path → content. */
+export class InMemoryFsAdapter implements FsAdapter {
+  private readonly files = new Map<string, string>();
+  private readonly dirs = new Set<string>();
+
+  constructor(seed: Record<string, string> = {}) {
+    for (const [path, content] of Object.entries(seed)) {
+      this.writeFile(path, content);
+    }
+  }
+
+  exists(path: string): boolean {
+    return this.files.has(path) || this.dirs.has(path);
+  }
+
+  readFile(path: string): string {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      throw new Error(`InMemoryFsAdapter: file not found: ${path}`);
+    }
+    return content;
+  }
+
+  writeFile(path: string, content: string): void {
+    this.files.set(path, content);
+    // Track parent dirs so readDir works.
+    let parent = path;
+    while (parent.includes('/')) {
+      const idx = parent.lastIndexOf('/');
+      parent = parent.slice(0, idx);
+      if (parent === '') break;
+      this.dirs.add(parent);
+    }
+  }
+
+  appendFile(path: string, content: string): void {
+    const existing = this.files.get(path) ?? '';
+    this.writeFile(path, existing + content);
+  }
+
+  readDir(path: string): string[] {
+    const out = new Set<string>();
+    const prefix = path.endsWith('/') ? path : path + '/';
+    for (const file of this.files.keys()) {
+      if (file.startsWith(prefix)) {
+        const rest = file.slice(prefix.length);
+        const segment = rest.split('/')[0];
+        if (segment !== undefined && segment !== '') {
+          out.add(segment);
+        }
+      }
+    }
+    for (const dir of this.dirs) {
+      if (dir.startsWith(prefix)) {
+        const rest = dir.slice(prefix.length);
+        const segment = rest.split('/')[0];
+        if (segment !== undefined && segment !== '') {
+          out.add(segment);
+        }
+      }
+    }
+    return [...out].sort();
+  }
+
+  mkdir(path: string): void {
+    this.dirs.add(path);
+  }
+
+  /** Snapshot all written files — used by tests. */
+  snapshot(): Record<string, string> {
+    return Object.fromEntries(this.files.entries());
+  }
+
+  /** Direct accessor for tests. */
+  has(path: string): boolean {
+    return this.files.has(path);
+  }
+
+  /** Direct accessor for tests. */
+  get(path: string): string | undefined {
+    return this.files.get(path);
+  }
+}

--- a/packages/ea-architect/src/index.ts
+++ b/packages/ea-architect/src/index.ts
@@ -1,0 +1,134 @@
+/**
+ * @caia/ea-architect — public surface.
+ *
+ * The EA Architect Agent is CAIA's platform-level approval gate. Every
+ * future research / spec / implementation / architecture-change /
+ * process-change plan goes through this agent BEFORE reaching the
+ * operator. The agent reviews against the full EA Repository (ADRs,
+ * principles, lessons, risk register, operator feedback memories) and
+ * issues a structured ReviewOutcome.
+ *
+ * Distinct from `@caia/ea-reviewer`: that one audits per-ticket composed
+ * architecture from the 17 specialist architects; this one audits
+ * platform plans. See ADR-040 for the scope split.
+ *
+ * Subscription-only LLM use per P1 + P14 (no API key); reaches Claude
+ * via `@chiefaia/claude-spawner`.
+ */
+
+export { EaArchitectAgent, submitPlan } from './agent.js';
+
+// Types — the contract callers depend on.
+export type {
+  PlanSubmission,
+  PlanType,
+  ReviewOutcome,
+  ReviewStatus,
+  ReviewHistory,
+  ReviewHistoryEntry,
+  EaReviewState,
+  EaReviewEvent,
+  EaReviewEventHandler,
+  EaEventBus,
+  EscalationReason,
+  OperatorEscalation,
+  NewAdrDraft,
+  AffectedAdr,
+  ModelTier,
+  EaArchitectConfig,
+  CriticAdapter,
+  CriticInput,
+  CriticOutput,
+  FsAdapter,
+  Clock,
+  AdrRecord,
+  PrincipleRecord,
+  LessonRecord,
+  RiskRecord,
+  FeedbackRecord,
+  EaRepository,
+  RelevanceMatch,
+  RelevantContext
+} from './types.js';
+
+// Sub-module exports for callers that want lower-level access.
+export {
+  loadRepository,
+  selectRelevantContext,
+  tokenise,
+  extractAdrIds
+} from './repository-loader.js';
+
+export {
+  EA_ARCHITECT_SYSTEM_PROMPT,
+  buildCriticPrompt,
+  createDefaultCritic,
+  parseCriticOutput,
+  applyHallucinationGuard
+} from './critic.js';
+
+export {
+  slugifyTitle,
+  formatAdrId,
+  renderAdrMarkdown,
+  writeNewAdr,
+  markSupersededBy,
+  patchSupersededBy,
+  applySupersessions,
+  updateDecisionsIndex
+} from './adr-writer.js';
+
+export {
+  ESCALATION_SECTION_HEADER,
+  renderEscalationEntry,
+  appendEscalationToInbox,
+  detectStrategicEscalation
+} from './escalation.js';
+
+export {
+  EA_REVIEW_VALID_TRANSITIONS,
+  EA_REVIEW_TERMINAL_STATES,
+  canEaReviewTransition,
+  isEaReviewTerminal,
+  chooseTargetState,
+  eventTypeFor,
+  buildEvent,
+  InProcessEventBus
+} from './state.js';
+
+export { defaultFsAdapter, InMemoryFsAdapter } from './fs-adapter.js';
+
+/**
+ * Agent contract — register with @chiefaia/agent-contract-registry to
+ * declare which sections the EA Architect Agent owns. Plan-submission
+ * objects are not ticket sections per se (the registry's primary
+ * consumer), but this declaration documents the API for the orchestrator.
+ *
+ * Format intentionally minimal to avoid coupling to the registry's
+ * exact shape, which may evolve. Adapters can map this to the registry
+ * format when integration lands.
+ */
+export const EA_ARCHITECT_CONTRACT = Object.freeze({
+  agentId: '@caia/ea-architect' as const,
+  role: 'platform-approval-gate' as const,
+  consumesEvents: ['ea-architect.submit-plan'] as const,
+  emitsEvents: [
+    'ea-architect.review.pending',
+    'ea-architect.review.revisions-requested',
+    'ea-architect.review.approved',
+    'ea-architect.review.conditional-approval',
+    'ea-architect.review.rejected',
+    'ea-architect.review.escalated-to-operator'
+  ] as const,
+  artifacts: {
+    reads: [
+      'caia-ea/decisions/**',
+      'caia-ea/principles/**',
+      'caia-ea/lessons-learned/**',
+      'caia-ea/risk-register/**',
+      'agent-memory/feedback_*.md',
+      'agent-memory/project_caia_*.md'
+    ],
+    writes: ['caia-ea/decisions/ADR-NNN-*.md', 'caia-ea/decisions/INDEX.md', 'agent-memory/INBOX.md']
+  }
+});

--- a/packages/ea-architect/src/repository-loader.ts
+++ b/packages/ea-architect/src/repository-loader.ts
@@ -1,0 +1,381 @@
+/**
+ * EA Repository loader.
+ *
+ * Reads the on-disk EA Repository at the configured root (default
+ * `~/Documents/projects/caia-ea/`) and builds an in-memory index of all
+ * ADRs, principles, lessons-learned, and risks. Also reads the seven
+ * feedback memories the operator named as agent context. The loader is
+ * pure-disk + pure-CPU; no network, no LLM. It runs on every review so
+ * the repository stays the source of truth — there is no cached stale
+ * copy.
+ *
+ * The relevance index is a simple keyword + section-based score; that is
+ * sufficient for the EA Repository at v1 (<100 ADRs, <30k words total).
+ * If the repository scales past that, switch the index to query the
+ * `@chiefaia/architecture-registry` AKG (which already does
+ * embeddings-augmented search).
+ */
+
+import { join } from 'node:path';
+
+import { defaultFsAdapter } from './fs-adapter.js';
+import type {
+  AdrRecord,
+  EaRepository,
+  FeedbackRecord,
+  FsAdapter,
+  LessonRecord,
+  PrincipleRecord,
+  RelevanceMatch,
+  RelevantContext,
+  RiskRecord
+} from './types.js';
+
+const ADR_FILENAME_RE = /^ADR-(\d+)-(.+)\.md$/;
+
+/** Tokenise text into lowercase keywords, dropping stopwords. */
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'or', 'but', 'the', 'is', 'are', 'was', 'were', 'be',
+  'been', 'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will',
+  'would', 'shall', 'should', 'can', 'could', 'may', 'might', 'must',
+  'to', 'of', 'in', 'on', 'at', 'by', 'for', 'with', 'about', 'as',
+  'from', 'into', 'through', 'during', 'this', 'that', 'these', 'those',
+  'we', 'our', 'they', 'their', 'it', 'its', 'not', 'no', 'so', 'too',
+  'very', 'just', 'than', 'then', 'now', 'also', 'only', 'any', 'all',
+  'each', 'every', 'some', 'such', 'one', 'two', 'three', 'first',
+  'last', 'next', 'per', 'via', 'when', 'where', 'while', 'because',
+  'if', 'else', 'how', 'what', 'which', 'who', 'whom', 'why', 'has',
+  'i', 'me', 'my', 'you', 'your', 'he', 'him', 'his', 'she', 'her',
+  's', 't', 'd', 'll', 're', 've', 'm', 'between'
+]);
+
+export function tokenise(text: string): string[] {
+  const out: string[] = [];
+  const lowered = text.toLowerCase();
+  const matches = lowered.match(/[a-z][a-z0-9-]*/g) ?? [];
+  for (const m of matches) {
+    if (m.length < 3) continue;
+    if (STOPWORDS.has(m)) continue;
+    out.push(m);
+  }
+  return out;
+}
+
+/** Parse the ADR header block into a small lookup map. */
+function parseAdrHeader(body: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const headerLines = body.split('\n').slice(0, 25);
+  for (const line of headerLines) {
+    // Match "- **Status:** value" or "- Status: value".
+    // The key sits between "- " (and optional "**") and "**: " / ": ".
+    const m = line.match(/^-\s+(?:\*\*)?([A-Za-z][A-Za-z0-9 -]*?)(?:\*\*)?:\s*(.+?)\s*$/);
+    if (m !== null && m[1] !== undefined && m[2] !== undefined) {
+      // Strip stray leading/trailing markdown emphasis from the value.
+      const value = m[2].replace(/^\*+\s*/, '').replace(/\s*\*+$/, '').trim();
+      headers[m[1].trim().toLowerCase()] = value;
+    }
+  }
+  return headers;
+}
+
+/** Best-effort extract of "ADR-NNN" tokens from text. */
+export function extractAdrIds(text: string): string[] {
+  const matches = text.match(/ADR-\d{3}/g) ?? [];
+  return [...new Set(matches)];
+}
+
+/** Read one ADR file. */
+function readAdr(fs: FsAdapter, filePath: string, id: number): AdrRecord {
+  const body = fs.readFile(filePath);
+  const headers = parseAdrHeader(body);
+  const titleMatch = body.match(/^#\s*ADR-\d+\s*[—\-:]\s*(.+)$/m);
+  const title = (titleMatch?.[1] ?? '').trim();
+  const adrId = `ADR-${id.toString().padStart(3, '0')}`;
+  const status = headers['status'] ?? 'Unknown';
+  const affected = (headers['affected-components'] ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const keywords = tokenise(`${title} ${body}`);
+  return {
+    id,
+    adrId,
+    filePath,
+    title,
+    status,
+    affectedComponents: affected,
+    body,
+    keywords
+  };
+}
+
+/** Parse principles file into one record per "## P<N>" section. */
+function parsePrinciples(body: string): PrincipleRecord[] {
+  const out: PrincipleRecord[] = [];
+  // Match "## P1 — Title" headings (em-dash or hyphen).
+  const sections = body.split(/^##\s+/m).slice(1);
+  for (const section of sections) {
+    const headerEnd = section.indexOf('\n');
+    if (headerEnd < 0) continue;
+    const headerLine = section.slice(0, headerEnd).trim();
+    const idMatch = headerLine.match(/^(P\d+)\s*[—\-:]\s*(.+)$/);
+    if (idMatch === null) continue;
+    const id = idMatch[1] ?? '';
+    const title = (idMatch[2] ?? '').trim();
+    const sectionBody = section.slice(headerEnd + 1);
+    // Stop before "## Amendment process" footer or the next "##".
+    const stopIdx = sectionBody.search(/\n##\s+/);
+    const body = stopIdx >= 0 ? sectionBody.slice(0, stopIdx) : sectionBody;
+    const keywords = tokenise(`${title} ${body}`);
+    out.push({ id, title, body, keywords });
+  }
+  return out;
+}
+
+/** Parse a single lesson markdown file. */
+function readLesson(fs: FsAdapter, filePath: string, basename: string): LessonRecord {
+  const body = fs.readFile(filePath);
+  const titleMatch = body.match(/^#\s+(.+)$/m);
+  const title = (titleMatch?.[1] ?? basename).trim();
+  // Lesson id = filename without extension, e.g. "01-pixel-perfect-calibration"
+  const id = basename.replace(/\.md$/, '');
+  return {
+    id,
+    filePath,
+    title,
+    body,
+    keywords: tokenise(`${title} ${body}`)
+  };
+}
+
+/**
+ * Parse the risk register markdown (best-effort).
+ *
+ * Looks for "### <Category>" or "## <Category>" headers and aggregates
+ * their contents into one record per heading.
+ */
+function parseRisks(body: string): RiskRecord[] {
+  const out: RiskRecord[] = [];
+  const sections = body.split(/^##\s+/m).slice(1);
+  let idx = 1;
+  for (const section of sections) {
+    const headerEnd = section.indexOf('\n');
+    if (headerEnd < 0) continue;
+    const heading = section.slice(0, headerEnd).trim();
+    const sectionBody = section.slice(headerEnd + 1);
+    const stopIdx = sectionBody.search(/\n##\s+/);
+    const txt = stopIdx >= 0 ? sectionBody.slice(0, stopIdx) : sectionBody;
+    out.push({
+      id: `RISK-${idx.toString().padStart(2, '0')}`,
+      category: heading,
+      description: heading,
+      body: txt,
+      keywords: tokenise(`${heading} ${txt}`)
+    });
+    idx += 1;
+  }
+  return out;
+}
+
+/** Parse a feedback memory file into a FeedbackRecord. */
+function readFeedback(fs: FsAdapter, filePath: string, basename: string): FeedbackRecord | null {
+  const body = fs.readFile(filePath);
+  // Frontmatter name field.
+  const fm = body.match(/^---\s*\nname:\s*([^\n]+)/);
+  const id = (fm?.[1] ?? basename.replace(/\.md$/, '')).trim();
+  const titleMatch = body.match(/description:\s*([^\n]+)/);
+  const title = (titleMatch?.[1] ?? basename).trim();
+  return {
+    id,
+    filePath,
+    title,
+    body,
+    keywords: tokenise(`${title} ${body}`)
+  };
+}
+
+/**
+ * Load the EA Repository from disk.
+ *
+ * @param rootPath the repository root (e.g. `~/Documents/projects/caia-ea`)
+ * @param agentMemoryPath the agent-memory dir for feedback memory files
+ */
+export function loadRepository(
+  rootPath: string,
+  agentMemoryPath: string,
+  fs: FsAdapter = defaultFsAdapter
+): EaRepository {
+  // ADRs
+  const decisionsDir = join(rootPath, 'decisions');
+  const adrFiles = fs
+    .readDir(decisionsDir)
+    .filter((name) => ADR_FILENAME_RE.test(name))
+    .sort();
+  const adrs: AdrRecord[] = [];
+  let maxAdrId = 0;
+  for (const name of adrFiles) {
+    const match = name.match(ADR_FILENAME_RE);
+    if (match === null || match[1] === undefined) continue;
+    const id = Number.parseInt(match[1], 10);
+    if (Number.isNaN(id)) continue;
+    const filePath = join(decisionsDir, name);
+    adrs.push(readAdr(fs, filePath, id));
+    if (id > maxAdrId) maxAdrId = id;
+  }
+
+  // Principles
+  const principlesFile = join(rootPath, 'principles', '00-architecture-principles.md');
+  let principles: PrincipleRecord[] = [];
+  if (fs.exists(principlesFile)) {
+    principles = parsePrinciples(fs.readFile(principlesFile));
+  }
+
+  // Lessons-learned
+  const lessonsDir = join(rootPath, 'lessons-learned');
+  const lessonFiles = fs.readDir(lessonsDir).filter((n) => n.endsWith('.md')).sort();
+  const lessons: LessonRecord[] = [];
+  for (const name of lessonFiles) {
+    lessons.push(readLesson(fs, join(lessonsDir, name), name));
+  }
+
+  // Risk register
+  const riskFile = join(rootPath, 'risk-register', '00-current-risks.md');
+  let risks: RiskRecord[] = [];
+  if (fs.exists(riskFile)) {
+    risks = parseRisks(fs.readFile(riskFile));
+  }
+
+  // Feedback memories — the seven the operator named.
+  const FEEDBACK_FILES = [
+    'feedback_no_timelines.md',
+    'feedback_no_idle_no_waiting.md',
+    'feedback_auto_merge_prs.md',
+    'feedback_action_research_outputs.md',
+    'feedback_ea_agent_gates_research.md',
+    'feedback_caia_build_uses_pro_subscription_only.md',
+    'project_caia_shadcn_react_first_locked.md'
+  ];
+  const feedback: FeedbackRecord[] = [];
+  for (const name of FEEDBACK_FILES) {
+    const fp = join(agentMemoryPath, name);
+    if (!fs.exists(fp)) continue;
+    const rec = readFeedback(fs, fp, name);
+    if (rec !== null) feedback.push(rec);
+  }
+
+  return {
+    rootPath,
+    adrs,
+    principles,
+    lessons,
+    risks,
+    feedback,
+    maxAdrId
+  };
+}
+
+/**
+ * Score an item by keyword overlap with the query tokens.
+ *
+ * Simple TF-style score: per matched keyword, count the keyword
+ * occurrences in the item's keyword list. The list is bounded by
+ * `topN`. Returns the matches sorted descending by score.
+ */
+function scoreItems<T extends { keywords: string[] }>(
+  items: T[],
+  queryTokens: string[],
+  topN: number,
+  /** Minimum score floor; anything below gets dropped. */
+  floor = 1
+): RelevanceMatch<T>[] {
+  const out: RelevanceMatch<T>[] = [];
+  const querySet = new Set(queryTokens);
+  for (const item of items) {
+    let score = 0;
+    const matched: string[] = [];
+    const seen = new Set<string>();
+    for (const kw of item.keywords) {
+      if (querySet.has(kw)) {
+        score += 1;
+        if (!seen.has(kw)) {
+          matched.push(kw);
+          seen.add(kw);
+        }
+      }
+    }
+    if (score >= floor) {
+      out.push({ item, score, matchedKeywords: matched });
+    }
+  }
+  out.sort((a, b) => b.score - a.score);
+  return out.slice(0, topN);
+}
+
+export interface RelevanceOptions {
+  maxAdrs?: number;
+  maxPrinciples?: number;
+  maxLessons?: number;
+  maxRisks?: number;
+  maxFeedback?: number;
+  /** Always-included ADR ids (forced even if not matched). */
+  forceAdrIds?: string[];
+}
+
+/**
+ * Pick the topic-relevant slice of the repository for context injection
+ * into the critic prompt.
+ *
+ * Tokenises the query (plan markdown + affected components + plan type)
+ * and ranks every item by keyword overlap. Principles are special-cased
+ * — by default ALL principles are returned, since every plan is checked
+ * against every principle (P9 demands this).
+ */
+export function selectRelevantContext(
+  repo: EaRepository,
+  query: string,
+  affectedComponents: string[],
+  opts: RelevanceOptions = {}
+): RelevantContext {
+  const maxAdrs = opts.maxAdrs ?? 12;
+  const maxLessons = opts.maxLessons ?? 4;
+  const maxRisks = opts.maxRisks ?? 5;
+  const maxFeedback = opts.maxFeedback ?? 7;
+
+  const tokens = [
+    ...tokenise(query),
+    ...affectedComponents.flatMap((c) => tokenise(c))
+  ];
+
+  // Force-include any ADRs cited by id in the query text. The plan
+  // markdown may name ADRs that are not keyword-matched but that the
+  // proposer believes are relevant.
+  const citedIds = new Set([...extractAdrIds(query), ...(opts.forceAdrIds ?? [])]);
+
+  const adrMatches = scoreItems(repo.adrs, tokens, maxAdrs, 1);
+  // Ensure cited ADRs are always present.
+  const presentIds = new Set(adrMatches.map((m) => m.item.adrId));
+  for (const id of citedIds) {
+    if (presentIds.has(id)) continue;
+    const adr = repo.adrs.find((a) => a.adrId === id);
+    if (adr === undefined) continue;
+    adrMatches.push({ item: adr, score: 1, matchedKeywords: ['forced'] });
+  }
+
+  // ALL principles — every plan must be checked against every principle.
+  const principles: RelevanceMatch<PrincipleRecord>[] = repo.principles.map((p) => ({
+    item: p,
+    score: 1,
+    matchedKeywords: []
+  }));
+
+  const lessons = scoreItems(repo.lessons, tokens, maxLessons, 1);
+  const risks = scoreItems(repo.risks, tokens, maxRisks, 1);
+  // Feedback memories: all of them, since they're operator-mandated lenses.
+  const feedback: RelevanceMatch<FeedbackRecord>[] = repo.feedback.slice(0, maxFeedback).map((f) => ({
+    item: f,
+    score: 1,
+    matchedKeywords: []
+  }));
+
+  return { adrs: adrMatches, principles, lessons, risks, feedback };
+}

--- a/packages/ea-architect/src/state.ts
+++ b/packages/ea-architect/src/state.ts
@@ -1,0 +1,148 @@
+/**
+ * State-machine integration.
+ *
+ * The EA Architect Agent emits transitions during the review cycle:
+ *
+ *   ea-review-pending
+ *   → ea-review-revisions-requested  (status="approved-with-modifications" | "needs-clarification")
+ *   → ea-review-pending              (caller resubmits)
+ *   → ea-review-approved             (status="approved")
+ *   → ea-review-conditional-approval (status="approved-with-modifications", no further iteration)
+ *   → ea-review-rejected             (status="rejected")
+ *   → ea-review-escalated-to-operator (escalation_to_operator set)
+ *
+ * These states are not part of the canonical @caia/state-machine project
+ * FSM (that FSM is project-level; this is per-submission EA review state).
+ * We model them as an in-package mini-FSM that emits events on every
+ * transition. The bridge to @caia/state-machine is event-based: every
+ * transition emits an `ea-architect.review.<state>` event that callers
+ * subscribe to.
+ *
+ * If the @caia/state-machine package later gains plan-submission as a
+ * first-class entity, this module's `EaReviewStateMachine` can be
+ * deprecated in favour of registering the new states + transitions
+ * upstream.
+ */
+
+import type {
+  EaEventBus,
+  EaReviewEvent,
+  EaReviewEventHandler,
+  EaReviewState,
+  PlanType,
+  ReviewOutcome,
+  ReviewStatus
+} from './types.js';
+
+/** Valid transitions inside the per-submission EA review FSM. */
+export const EA_REVIEW_VALID_TRANSITIONS: Record<EaReviewState, readonly EaReviewState[]> = {
+  'ea-review-pending': [
+    'ea-review-revisions-requested',
+    'ea-review-approved',
+    'ea-review-conditional-approval',
+    'ea-review-rejected',
+    'ea-review-escalated-to-operator'
+  ],
+  'ea-review-revisions-requested': ['ea-review-pending', 'ea-review-rejected'],
+  // Terminal states (no further transitions inside this FSM).
+  'ea-review-approved': [],
+  'ea-review-conditional-approval': [],
+  'ea-review-rejected': [],
+  'ea-review-escalated-to-operator': []
+};
+
+export function canEaReviewTransition(from: EaReviewState, to: EaReviewState): boolean {
+  return EA_REVIEW_VALID_TRANSITIONS[from].includes(to);
+}
+
+export const EA_REVIEW_TERMINAL_STATES: readonly EaReviewState[] = [
+  'ea-review-approved',
+  'ea-review-conditional-approval',
+  'ea-review-rejected',
+  'ea-review-escalated-to-operator'
+];
+
+export function isEaReviewTerminal(state: EaReviewState): boolean {
+  return EA_REVIEW_TERMINAL_STATES.includes(state);
+}
+
+/** Pick the target state given a review outcome. */
+export function chooseTargetState(
+  status: ReviewStatus,
+  isFinalIteration: boolean,
+  escalating: boolean
+): EaReviewState {
+  if (escalating) return 'ea-review-escalated-to-operator';
+  if (status === 'approved') return 'ea-review-approved';
+  if (status === 'rejected') return 'ea-review-rejected';
+  if (status === 'needs-clarification') return 'ea-review-revisions-requested';
+  // approved-with-modifications: if the caller wants a final verdict (no
+  // more iterations) we land on conditional-approval; otherwise revisions.
+  if (status === 'approved-with-modifications') {
+    return isFinalIteration ? 'ea-review-conditional-approval' : 'ea-review-revisions-requested';
+  }
+  return 'ea-review-revisions-requested';
+}
+
+/**
+ * Build the event-type identifier for a transition.
+ *
+ * Format: `ea-architect.review.<state>` — dot-namespaced per the
+ * `@chiefaia/events-taxonomy-internal` convention (57 event types
+ * across 15 namespaces; this is the new "ea-architect.review" namespace).
+ */
+export function eventTypeFor(state: EaReviewState): string {
+  return `ea-architect.review.${state.replace(/^ea-review-/, '')}`;
+}
+
+export interface EmitTransitionInput {
+  submissionId: string;
+  callerAgentId: string;
+  planType: PlanType;
+  iteration: number;
+  fromState: EaReviewState | null;
+  toState: EaReviewState;
+  outcome: ReviewOutcome;
+  at: Date;
+}
+
+/** Compose the event envelope. */
+export function buildEvent(input: EmitTransitionInput): EaReviewEvent {
+  return {
+    type: eventTypeFor(input.toState),
+    submissionId: input.submissionId,
+    callerAgentId: input.callerAgentId,
+    planType: input.planType,
+    iteration: input.iteration,
+    fromState: input.fromState,
+    toState: input.toState,
+    outcome: input.outcome,
+    at: input.at.toISOString()
+  };
+}
+
+/** Minimal in-process event bus. */
+export class InProcessEventBus implements EaEventBus {
+  private readonly handlers = new Map<string, Set<EaReviewEventHandler>>();
+  private readonly wildcard = new Set<EaReviewEventHandler>();
+
+  on(type: string, handler: EaReviewEventHandler): () => void {
+    if (type === '*' || type === '') {
+      this.wildcard.add(handler);
+      return () => this.wildcard.delete(handler);
+    }
+    let set = this.handlers.get(type);
+    if (set === undefined) {
+      set = new Set();
+      this.handlers.set(type, set);
+    }
+    set.add(handler);
+    return () => set?.delete(handler);
+  }
+
+  async emit(event: EaReviewEvent): Promise<void> {
+    const exact = this.handlers.get(event.type) ?? new Set();
+    const all = [...exact, ...this.wildcard];
+    await Promise.all(all.map((h) => h(event)));
+  }
+}

--- a/packages/ea-architect/src/types.ts
+++ b/packages/ea-architect/src/types.ts
@@ -1,0 +1,318 @@
+/**
+ * @caia/ea-architect — public type surface.
+ *
+ * Types describe the plan → review → outcome contract that callers of
+ * the EA Architect Agent rely on. The agent reviews PLATFORM-LEVEL plans
+ * (research, spec, implementation, architecture-change, process-change)
+ * against the EA Repository (ADRs, principles, lessons, risk register).
+ *
+ * Distinct from `@caia/ea-reviewer`: that audits per-ticket composed
+ * architecture from the 17 architects; this audits platform plans.
+ */
+
+/** The five plan types the agent reviews. */
+export type PlanType =
+  | 'research'
+  | 'spec'
+  | 'implementation'
+  | 'architecture-change'
+  | 'process-change';
+
+/** Outcome status for a single review pass. */
+export type ReviewStatus =
+  | 'approved'
+  | 'approved-with-modifications'
+  | 'rejected'
+  | 'needs-clarification';
+
+/** State-machine states emitted as transitions during the review cycle. */
+export type EaReviewState =
+  | 'ea-review-pending'
+  | 'ea-review-revisions-requested'
+  | 'ea-review-approved'
+  | 'ea-review-conditional-approval'
+  | 'ea-review-rejected'
+  | 'ea-review-escalated-to-operator';
+
+/** Reasons the agent escalates to the operator. */
+export type EscalationReason =
+  | 'product-pivot'
+  | 'billing-model-change'
+  | 'fundamental-architecture-reversal'
+  | 'security-posture-change'
+  | 'principle-amendment'
+  | 'strategic-direction-change';
+
+/** The model tier picked for a given review. */
+export type ModelTier = 'sonnet' | 'opus';
+
+/** Input every caller must pass to submitPlan. */
+export interface PlanSubmission {
+  planMarkdown: string;
+  planType: PlanType;
+  callerAgentId: string;
+  submittedBy: string;
+  /** Optional list of affected components, used for blast-radius calc. */
+  affectedComponents?: string[];
+  /** Optional pre-assigned submission id; one is generated otherwise. */
+  submissionId?: string;
+}
+
+/** A proposed new ADR the agent drafts when the plan introduces a decision. */
+export interface NewAdrDraft {
+  title: string;
+  status: 'Accepted' | 'Proposed';
+  context: string;
+  decision: string;
+  consequences: string;
+  /** ADR ids this new ADR supersedes (e.g. "ADR-060"). */
+  supersedes?: string[];
+  /** Affected components, comma-separated in the rendered ADR. */
+  affectedComponents?: string[];
+  /** Reversibility classification. */
+  reversibility?: 'Reversible' | 'One-way' | 'Irreversible';
+  /** Decision-makers field. */
+  decisionMakers?: 'Operator' | 'EA Architect Agent' | 'Both';
+}
+
+/** Existing ADR the plan affects. */
+export interface AffectedAdr {
+  adrId: string;
+  action: 'amend' | 'supersede';
+  reason?: string;
+}
+
+/** Escalation envelope surfaced to the operator's INBOX. */
+export interface OperatorEscalation {
+  reason: string;
+  decisionPoint: string;
+  recommendation?: string;
+  category?: EscalationReason;
+}
+
+/** Result of a single review pass. */
+export interface ReviewOutcome {
+  status: ReviewStatus;
+  reasoning: string;
+  cited_adrs: string[];
+  cited_principles: string[];
+  cited_lessons: string[];
+  requested_modifications?: string[];
+  new_adrs_to_file?: NewAdrDraft[];
+  affected_existing_adrs?: AffectedAdr[];
+  escalation_to_operator?: OperatorEscalation;
+  /** Submission id (echo of input or freshly-generated). */
+  submissionId: string;
+  /** Iteration number — increments each time the caller resubmits. */
+  iteration: number;
+  /** ISO timestamp of when this outcome was produced. */
+  reviewedAtIso: string;
+  /** Model tier used. */
+  modelTier: ModelTier;
+}
+
+/** One entry in the iteration history of a submission. */
+export interface ReviewHistoryEntry {
+  iteration: number;
+  outcome: ReviewOutcome;
+  transitionTo: EaReviewState;
+  at: string;
+}
+
+/** Full history for a submission. */
+export interface ReviewHistory {
+  submissionId: string;
+  callerAgentId: string;
+  planType: PlanType;
+  entries: ReviewHistoryEntry[];
+  /** Current state. */
+  currentState: EaReviewState;
+}
+
+/**
+ * A loaded ADR record from the repository — used by the loader and the
+ * relevance index.
+ */
+export interface AdrRecord {
+  /** Numeric id, e.g. 15 for ADR-015. */
+  id: number;
+  /** Canonical "ADR-015" form. */
+  adrId: string;
+  /** File path on disk. */
+  filePath: string;
+  /** Title (first heading without the prefix). */
+  title: string;
+  /** Status — Accepted | Proposed | Deprecated | Superseded by ADR-XXX. */
+  status: string;
+  /** Affected components list (best-effort parse). */
+  affectedComponents: string[];
+  /** Body text for relevance scoring. */
+  body: string;
+  /** Tokenised keywords for the index. */
+  keywords: string[];
+}
+
+/** A principle entry loaded from the repository. */
+export interface PrincipleRecord {
+  /** Canonical id like "P9". */
+  id: string;
+  /** Short title. */
+  title: string;
+  /** Body (statement + rationale + implications). */
+  body: string;
+  /** Tokenised keywords. */
+  keywords: string[];
+}
+
+/** A lessons-learned entry. */
+export interface LessonRecord {
+  /** File-derived id like "L01" or "lesson-01". */
+  id: string;
+  filePath: string;
+  title: string;
+  body: string;
+  keywords: string[];
+}
+
+/** A risk register entry (parsed best-effort). */
+export interface RiskRecord {
+  id: string;
+  category: string;
+  description: string;
+  body: string;
+  keywords: string[];
+}
+
+/** Feedback memory entry. */
+export interface FeedbackRecord {
+  /** Canonical id from frontmatter name field (e.g. "feedback-no-timelines"). */
+  id: string;
+  filePath: string;
+  title: string;
+  body: string;
+  keywords: string[];
+}
+
+/** The fully-loaded EA Repository. */
+export interface EaRepository {
+  rootPath: string;
+  adrs: AdrRecord[];
+  principles: PrincipleRecord[];
+  lessons: LessonRecord[];
+  risks: RiskRecord[];
+  feedback: FeedbackRecord[];
+  /** Max ADR id observed; the next ADR is maxAdrId + 1. */
+  maxAdrId: number;
+}
+
+/** A relevance score for an item against a query. */
+export interface RelevanceMatch<T> {
+  item: T;
+  score: number;
+  /** Which terms matched. */
+  matchedKeywords: string[];
+}
+
+/** Topic-selected slice of the repository for context injection. */
+export interface RelevantContext {
+  adrs: RelevanceMatch<AdrRecord>[];
+  principles: RelevanceMatch<PrincipleRecord>[];
+  lessons: RelevanceMatch<LessonRecord>[];
+  risks: RelevanceMatch<RiskRecord>[];
+  feedback: RelevanceMatch<FeedbackRecord>[];
+}
+
+/** Emitted event envelope for state transitions. */
+export interface EaReviewEvent {
+  /** Dotted event type, e.g. "ea-architect.review.approved". */
+  type: string;
+  submissionId: string;
+  callerAgentId: string;
+  planType: PlanType;
+  iteration: number;
+  fromState: EaReviewState | null;
+  toState: EaReviewState;
+  outcome: ReviewOutcome;
+  at: string;
+}
+
+/** Event handler. */
+export type EaReviewEventHandler = (event: EaReviewEvent) => void | Promise<void>;
+
+/** Event bus contract used by the agent. */
+export interface EaEventBus {
+  on(type: string, handler: EaReviewEventHandler): () => void;
+  emit(event: EaReviewEvent): Promise<void>;
+}
+
+/**
+ * Critic adapter — wraps the LLM call. Swappable for tests.
+ * Production wires this to @chiefaia/claude-spawner via the default impl.
+ */
+export interface CriticAdapter {
+  review(input: CriticInput): Promise<CriticOutput>;
+}
+
+export interface CriticInput {
+  planMarkdown: string;
+  planType: PlanType;
+  affectedComponents: string[];
+  context: RelevantContext;
+  /** Iteration in the conversation (>=1). */
+  iteration: number;
+  /** Model tier requested. */
+  modelTier: ModelTier;
+}
+
+export interface CriticOutput {
+  /** Raw status emitted by the model. */
+  status: ReviewStatus;
+  reasoning: string;
+  cited_adrs: string[];
+  cited_principles: string[];
+  cited_lessons: string[];
+  requested_modifications: string[];
+  new_adrs_to_file: NewAdrDraft[];
+  affected_existing_adrs: AffectedAdr[];
+  escalation_to_operator?: OperatorEscalation;
+  /** True if the LLM call succeeded and emitted parseable JSON. */
+  ok: boolean;
+  diagnostic?: string;
+}
+
+/** Filesystem abstraction. */
+export interface FsAdapter {
+  exists(path: string): boolean;
+  readFile(path: string): string;
+  writeFile(path: string, content: string): void;
+  appendFile(path: string, content: string): void;
+  readDir(path: string): string[];
+  mkdir(path: string): void;
+}
+
+/** Clock abstraction. */
+export type Clock = () => Date;
+
+/** Agent configuration. */
+export interface EaArchitectConfig {
+  /** Path to the EA Repository root. Defaults to ~/Documents/projects/caia-ea. */
+  repositoryPath?: string;
+  /** Path to the operator's INBOX. Defaults to ~/Documents/projects/agent-memory/INBOX.md. */
+  inboxPath?: string;
+  /** Path to the agent-memory directory (for feedback memories). */
+  agentMemoryPath?: string;
+  /** Critic adapter override. Production uses the default Claude one. */
+  critic?: CriticAdapter;
+  /** Event bus override. Defaults to an in-process bus. */
+  eventBus?: EaEventBus;
+  /** Filesystem override (tests). */
+  fs?: FsAdapter;
+  /** Clock override (tests). */
+  clock?: Clock;
+  /** UUID-like submission-id generator. */
+  generateSubmissionId?: () => string;
+  /** Whether to write ADRs on approval. Default true. */
+  autoFileAdrs?: boolean;
+  /** Whether to escalate to INBOX on escalation. Default true. */
+  surfaceEscalations?: boolean;
+}

--- a/packages/ea-architect/tests/adr-writer.test.ts
+++ b/packages/ea-architect/tests/adr-writer.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applySupersessions,
+  formatAdrId,
+  patchSupersededBy,
+  renderAdrMarkdown,
+  slugifyTitle,
+  updateDecisionsIndex,
+  writeNewAdr
+} from '../src/adr-writer.js';
+import { InMemoryFsAdapter } from '../src/fs-adapter.js';
+import { loadRepository } from '../src/repository-loader.js';
+import type { NewAdrDraft } from '../src/types.js';
+
+import {
+  AGENT_MEMORY_ROOT,
+  REPO_ROOT,
+  sampleRepoFiles
+} from './fixtures/sample-repository.js';
+
+const SAMPLE_DRAFT: NewAdrDraft = {
+  title: 'Adopt event bus emission for EA review transitions',
+  status: 'Accepted',
+  context: 'EA Architect Agent needs to emit transitions.',
+  decision: 'Emit dot-namespaced events on every transition.',
+  consequences: 'Positive: dashboard visibility. Negative: small overhead.',
+  affectedComponents: ['@caia/ea-architect'],
+  reversibility: 'Reversible',
+  decisionMakers: 'EA Architect Agent'
+};
+
+describe('adr-writer', () => {
+  it('slugifyTitle: kebab-cases and strips em-dashes', () => {
+    expect(slugifyTitle('EA Architect — review pipeline')).toBe('ea-architect-review-pipeline');
+  });
+
+  it('slugifyTitle: collapses multiple separators', () => {
+    expect(slugifyTitle('  foo!! bar?  baz  ')).toBe('foo-bar-baz');
+  });
+
+  it('formatAdrId: zero-pads to 3 digits', () => {
+    expect(formatAdrId(7)).toBe('ADR-007');
+    expect(formatAdrId(62)).toBe('ADR-062');
+    expect(formatAdrId(123)).toBe('ADR-123');
+  });
+
+  it('renderAdrMarkdown: includes header fields and body sections', () => {
+    const body = renderAdrMarkdown(62, SAMPLE_DRAFT, new Date('2026-05-23T00:00:00Z'));
+    expect(body).toContain('# ADR-062');
+    expect(body).toContain('- **Status:** Accepted');
+    expect(body).toContain('- **Date:** 2026-05-23');
+    expect(body).toContain('- **Affected-components:** @caia/ea-architect');
+    expect(body).toContain('## Context');
+    expect(body).toContain('## Decision');
+    expect(body).toContain('## Consequences');
+    expect(body).toContain('EA Architect Agent needs to emit transitions.');
+  });
+
+  it('renderAdrMarkdown: handles missing optional fields with defaults', () => {
+    const minimal: NewAdrDraft = {
+      title: 'Minimal',
+      status: 'Accepted',
+      context: '',
+      decision: 'do X',
+      consequences: ''
+    };
+    const body = renderAdrMarkdown(99, minimal, new Date('2026-05-23T00:00:00Z'));
+    expect(body).toContain('- **Reversibility:** Reversible');
+    expect(body).toContain('- **Supersedes:** none');
+    expect(body).toContain('- **Affected-components:** (none specified)');
+  });
+
+  it('writeNewAdr: writes file at next id and slug', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.maxAdrId).toBe(61);
+    const result = writeNewAdr(repo, SAMPLE_DRAFT, new Date('2026-05-23T00:00:00Z'), fs);
+    expect(result.adrId).toBe('ADR-062');
+    expect(result.filePath).toBe(
+      `${REPO_ROOT}/decisions/ADR-062-adopt-event-bus-emission-for-ea-review-transitions.md`
+    );
+    expect(fs.has(result.filePath)).toBe(true);
+    expect(repo.maxAdrId).toBe(62);
+  });
+
+  it('writeNewAdr: subsequent writes increment monotonically', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const r1 = writeNewAdr(repo, SAMPLE_DRAFT, new Date('2026-05-23T00:00:00Z'), fs);
+    const r2 = writeNewAdr(
+      repo,
+      { ...SAMPLE_DRAFT, title: 'Second decision' },
+      new Date('2026-05-23T00:00:00Z'),
+      fs
+    );
+    expect(r1.adrId).toBe('ADR-062');
+    expect(r2.adrId).toBe('ADR-063');
+  });
+
+  it('writeNewAdr: forceId override works for deterministic tests', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const result = writeNewAdr(repo, SAMPLE_DRAFT, new Date('2026-05-23T00:00:00Z'), fs, 200);
+    expect(result.adrId).toBe('ADR-200');
+  });
+
+  it('patchSupersededBy: updates "none" to the new ADR id', () => {
+    const body = `- **Supersedes:** ADR-060\n- **Superseded-by:** none\n\n## Context\n`;
+    const patched = patchSupersededBy(body, 'ADR-062');
+    expect(patched).toContain('- **Superseded-by:** ADR-062');
+  });
+
+  it('patchSupersededBy: idempotent if already pointing at the new id', () => {
+    const body = `- **Superseded-by:** ADR-062\n`;
+    const patched = patchSupersededBy(body, 'ADR-062');
+    expect(patched).toBe(body);
+  });
+
+  it('patchSupersededBy: appends to existing list if multi-supersede', () => {
+    const body = `- **Superseded-by:** ADR-099\n`;
+    const patched = patchSupersededBy(body, 'ADR-100');
+    expect(patched).toContain('ADR-099, ADR-100');
+  });
+
+  it('patchSupersededBy: fallback footer when no field exists', () => {
+    const body = `# ADR-001\n\nbody only\n`;
+    const patched = patchSupersededBy(body, 'ADR-200');
+    expect(patched).toContain('**Superseded by ADR-200**');
+  });
+
+  it('applySupersessions: marks the existing ADR superseded-by the new one', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const newAdr = { adrId: 'ADR-062' };
+    const adr009Path = `${REPO_ROOT}/decisions/ADR-009-bypass-cd-direct-build-for-caia-dashboard.md`;
+    expect(fs.readFile(adr009Path)).not.toContain('ADR-062');
+    const out = applySupersessions(
+      fs,
+      repo,
+      [{ adrId: 'ADR-009', action: 'supersede' }],
+      [newAdr]
+    );
+    expect(out).toEqual([{ adrId: 'ADR-009', supersededBy: 'ADR-062' }]);
+    expect(fs.readFile(adr009Path)).toContain('ADR-062');
+  });
+
+  it('applySupersessions: ignores amend actions', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const out = applySupersessions(
+      fs,
+      repo,
+      [{ adrId: 'ADR-009', action: 'amend' }],
+      [{ adrId: 'ADR-062' }]
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('updateDecisionsIndex: creates INDEX.md when missing', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    updateDecisionsIndex(fs, repo, [
+      { adrId: 'ADR-062', title: 'Test', filePath: `${REPO_ROOT}/decisions/ADR-062-test.md` }
+    ]);
+    const indexPath = `${REPO_ROOT}/decisions/INDEX.md`;
+    expect(fs.has(indexPath)).toBe(true);
+    expect(fs.readFile(indexPath)).toContain('ADR-062');
+    expect(fs.readFile(indexPath)).toContain('| ADR | Title | Status |');
+  });
+
+  it('updateDecisionsIndex: appends new rows to an existing file', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    updateDecisionsIndex(fs, repo, [
+      { adrId: 'ADR-062', title: 'First', filePath: `${REPO_ROOT}/decisions/ADR-062-first.md` }
+    ]);
+    updateDecisionsIndex(fs, repo, [
+      { adrId: 'ADR-063', title: 'Second', filePath: `${REPO_ROOT}/decisions/ADR-063-second.md` }
+    ]);
+    const body = fs.readFile(`${REPO_ROOT}/decisions/INDEX.md`);
+    expect(body).toContain('ADR-062');
+    expect(body).toContain('ADR-063');
+  });
+
+  it('updateDecisionsIndex: does not duplicate the same ADR row on re-call', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    updateDecisionsIndex(fs, repo, [
+      { adrId: 'ADR-062', title: 'First', filePath: `${REPO_ROOT}/decisions/ADR-062-first.md` }
+    ]);
+    updateDecisionsIndex(fs, repo, [
+      { adrId: 'ADR-062', title: 'First', filePath: `${REPO_ROOT}/decisions/ADR-062-first.md` }
+    ]);
+    const body = fs.readFile(`${REPO_ROOT}/decisions/INDEX.md`);
+    // The "| [ADR-062](" row anchor appears at most once.
+    const rowOccurrences = body.split('| [ADR-062](').length - 1;
+    expect(rowOccurrences).toBe(1);
+  });
+});

--- a/packages/ea-architect/tests/agent.test.ts
+++ b/packages/ea-architect/tests/agent.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { EaArchitectAgent } from '../src/agent.js';
+import { InMemoryFsAdapter } from '../src/fs-adapter.js';
+import { ESCALATION_SECTION_HEADER } from '../src/escalation.js';
+import type { EaReviewEvent, PlanSubmission, PlanType } from '../src/types.js';
+
+import {
+  AGENT_MEMORY_ROOT,
+  INBOX_PATH,
+  REPO_ROOT,
+  sampleRepoFiles
+} from './fixtures/sample-repository.js';
+import { FixedCritic, makeOutput, StubCritic } from './fixtures/stub-critic.js';
+
+const PLAN_TYPES: PlanType[] = [
+  'research',
+  'spec',
+  'implementation',
+  'architecture-change',
+  'process-change'
+];
+
+function makeAgent(opts: { critic?: import('../src/types.js').CriticAdapter; fs?: InMemoryFsAdapter } = {}) {
+  const fs = opts.fs ?? new InMemoryFsAdapter(sampleRepoFiles());
+  const critic = opts.critic ?? new FixedCritic(makeOutput({ status: 'approved' }));
+  let counter = 0;
+  const agent = new EaArchitectAgent({
+    repositoryPath: REPO_ROOT,
+    inboxPath: INBOX_PATH,
+    agentMemoryPath: AGENT_MEMORY_ROOT,
+    critic,
+    fs,
+    clock: () => new Date('2026-05-23T12:00:00Z'),
+    generateSubmissionId: () => {
+      counter += 1;
+      return `sub-${counter}`;
+    }
+  });
+  return { agent, fs };
+}
+
+function makePlan(overrides: Partial<PlanSubmission> = {}): PlanSubmission {
+  return {
+    planMarkdown: 'We propose adding a small adapter.',
+    planType: 'spec',
+    callerAgentId: '@caia/researcher',
+    submittedBy: 'orchestrator',
+    affectedComponents: ['@caia/atlas-mapper'],
+    ...overrides
+  };
+}
+
+describe('EaArchitectAgent — basic flow', () => {
+  it('approves a sound plan with no new ADRs', async () => {
+    const { agent } = makeAgent();
+    const out = await agent.submitPlan(makePlan());
+    expect(out.status).toBe('approved');
+    expect(out.submissionId).toBe('sub-1');
+    expect(out.iteration).toBe(1);
+    expect(out.modelTier).toBe('sonnet');
+    expect(agent.getCurrentState('sub-1')).toBe('ea-review-approved');
+  });
+
+  it('rejects a plan and emits the rejected event', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'rejected',
+        reasoning: 'violates P1 — proposes API key billing',
+        cited_principles: ['P1']
+      })
+    );
+    const { agent } = makeAgent({ critic });
+    const events: EaReviewEvent[] = [];
+    agent.on('*', (e) => {
+      events.push(e);
+    });
+    const out = await agent.submitPlan(makePlan());
+    expect(out.status).toBe('rejected');
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('ea-architect.review.rejected');
+    expect(events[0]?.toState).toBe('ea-review-rejected');
+  });
+
+  it('emits a "needs-clarification" plan as revisions-requested', async () => {
+    const critic = new FixedCritic(
+      makeOutput({ status: 'needs-clarification', reasoning: 'plan unclear' })
+    );
+    const { agent } = makeAgent({ critic });
+    const out = await agent.submitPlan(makePlan());
+    expect(out.status).toBe('needs-clarification');
+    expect(agent.getCurrentState('sub-1')).toBe('ea-review-revisions-requested');
+  });
+
+  it('honors caller-provided submissionId', async () => {
+    const { agent } = makeAgent();
+    const out = await agent.submitPlan(
+      makePlan({ submissionId: 'my-custom-id' })
+    );
+    expect(out.submissionId).toBe('my-custom-id');
+  });
+
+  it('escalates with an INBOX entry when LLM flags strategic escalation', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved',
+        reasoning: 'pivot detected',
+        escalation_to_operator: {
+          reason: 'product pivot',
+          decisionPoint: 'pivot to B2C',
+          category: 'product-pivot'
+        }
+      })
+    );
+    const { agent, fs } = makeAgent({ critic });
+    const out = await agent.submitPlan(makePlan());
+    expect(out.escalation_to_operator?.category).toBe('product-pivot');
+    expect(agent.getCurrentState(out.submissionId)).toBe('ea-review-escalated-to-operator');
+    expect(fs.has(INBOX_PATH)).toBe(true);
+    const inbox = fs.readFile(INBOX_PATH);
+    expect(inbox).toContain(ESCALATION_SECTION_HEADER);
+    expect(inbox).toContain('product-pivot');
+  });
+
+  it('escalates via keyword fallback when LLM did not flag', async () => {
+    const critic = new FixedCritic(makeOutput({ status: 'approved' }));
+    const { agent, fs } = makeAgent({ critic });
+    const out = await agent.submitPlan(
+      makePlan({ planMarkdown: 'We propose a product pivot to B2C.' })
+    );
+    expect(out.escalation_to_operator).toBeDefined();
+    expect(out.escalation_to_operator?.category).toBe('product-pivot');
+    expect(fs.has(INBOX_PATH)).toBe(true);
+  });
+
+  it('does NOT escalate routine technical plans', async () => {
+    const { agent, fs } = makeAgent();
+    const out = await agent.submitPlan(
+      makePlan({ planMarkdown: 'Add a new endpoint /api/health.' })
+    );
+    expect(out.escalation_to_operator).toBeUndefined();
+    expect(fs.has(INBOX_PATH)).toBe(false);
+  });
+});
+
+describe('EaArchitectAgent — plan types', () => {
+  for (const planType of PLAN_TYPES) {
+    it(`accepts planType="${planType}" and processes it`, async () => {
+      const { agent } = makeAgent();
+      const out = await agent.submitPlan(makePlan({ planType }));
+      expect(out.status).toBe('approved');
+    });
+  }
+
+  it('picks Opus tier for architecture-change planType', async () => {
+    const { agent } = makeAgent();
+    const out = await agent.submitPlan(makePlan({ planType: 'architecture-change' }));
+    expect(out.modelTier).toBe('opus');
+  });
+
+  it('picks Opus when 5+ affected components', async () => {
+    const { agent } = makeAgent();
+    const out = await agent.submitPlan(
+      makePlan({ affectedComponents: ['a', 'b', 'c', 'd', 'e', 'f'] })
+    );
+    expect(out.modelTier).toBe('opus');
+  });
+
+  it('picks Opus for very long plans', async () => {
+    const big = 'word '.repeat(6000);
+    const { agent } = makeAgent();
+    const out = await agent.submitPlan(makePlan({ planMarkdown: big }));
+    expect(out.modelTier).toBe('opus');
+  });
+});
+
+describe('EaArchitectAgent — ADR auto-filing', () => {
+  it('files a new ADR on approval and gives it next number', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved',
+        new_adrs_to_file: [
+          {
+            title: 'Adopt the X pattern',
+            status: 'Accepted',
+            context: 'context',
+            decision: 'decision',
+            consequences: 'consequences',
+            affectedComponents: ['@caia/x']
+          }
+        ]
+      })
+    );
+    const { agent, fs } = makeAgent({ critic });
+    await agent.submitPlan(makePlan());
+    // Sample repo has 61 ADRs so next is ADR-062.
+    const expectedPath = `${REPO_ROOT}/decisions/ADR-062-adopt-the-x-pattern.md`;
+    expect(fs.has(expectedPath)).toBe(true);
+    const body = fs.readFile(expectedPath);
+    expect(body).toContain('# ADR-062 — Adopt the X pattern');
+    expect(body).toContain('- **Affected-components:** @caia/x');
+  });
+
+  it('wires supersession on both sides', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved',
+        new_adrs_to_file: [
+          {
+            title: 'Replace MUI with shadcn',
+            status: 'Accepted',
+            context: 'c',
+            decision: 'd',
+            consequences: 'e',
+            supersedes: ['ADR-060']
+          }
+        ],
+        affected_existing_adrs: [{ adrId: 'ADR-060', action: 'supersede' }]
+      })
+    );
+    const { agent, fs } = makeAgent({ critic });
+    await agent.submitPlan(makePlan());
+    const adr060Path = `${REPO_ROOT}/decisions/ADR-060-mui-react-first-stack.md`;
+    const body = fs.readFile(adr060Path);
+    expect(body).toContain('ADR-062');
+  });
+
+  it('updates INDEX.md after filing', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved',
+        new_adrs_to_file: [
+          {
+            title: 'Trivial decision',
+            status: 'Accepted',
+            context: 'c',
+            decision: 'd',
+            consequences: 'e'
+          }
+        ]
+      })
+    );
+    const { agent, fs } = makeAgent({ critic });
+    await agent.submitPlan(makePlan());
+    expect(fs.has(`${REPO_ROOT}/decisions/INDEX.md`)).toBe(true);
+    expect(fs.readFile(`${REPO_ROOT}/decisions/INDEX.md`)).toContain('ADR-062');
+  });
+
+  it('does NOT file ADRs on rejection', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'rejected',
+        new_adrs_to_file: [
+          {
+            title: 'Should not be filed',
+            status: 'Accepted',
+            context: 'c',
+            decision: 'd',
+            consequences: 'e'
+          }
+        ]
+      })
+    );
+    const { agent, fs } = makeAgent({ critic });
+    await agent.submitPlan(makePlan());
+    expect(fs.has(`${REPO_ROOT}/decisions/ADR-062-should-not-be-filed.md`)).toBe(false);
+  });
+});
+
+describe('EaArchitectAgent — iteration loop', () => {
+  it('approved-with-modifications goes to revisions-requested on iteration 1', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved-with-modifications',
+        requested_modifications: ['fix X', 'document Y']
+      })
+    );
+    const { agent } = makeAgent({ critic });
+    const out = await agent.submitPlan(makePlan());
+    expect(out.requested_modifications).toEqual(['fix X', 'document Y']);
+    expect(agent.getCurrentState(out.submissionId)).toBe('ea-review-revisions-requested');
+  });
+
+  it('caller can resubmit with same submissionId; iteration bumps', async () => {
+    const critic = new StubCritic([
+      makeOutput({ status: 'approved-with-modifications', requested_modifications: ['fix X'] }),
+      makeOutput({ status: 'approved' })
+    ]);
+    const { agent } = makeAgent({ critic });
+    const out1 = await agent.submitPlan(makePlan({ submissionId: 'shared' }));
+    expect(out1.iteration).toBe(1);
+    expect(agent.getCurrentState('shared')).toBe('ea-review-revisions-requested');
+    const out2 = await agent.submitPlan(makePlan({ submissionId: 'shared' }));
+    expect(out2.iteration).toBe(2);
+    expect(out2.status).toBe('approved');
+    expect(agent.getCurrentState('shared')).toBe('ea-review-approved');
+  });
+
+  it('throws when resubmitting a terminal submission', async () => {
+    const { agent } = makeAgent();
+    await agent.submitPlan(makePlan({ submissionId: 'terminal' }));
+    expect(agent.getCurrentState('terminal')).toBe('ea-review-approved');
+    await expect(agent.submitPlan(makePlan({ submissionId: 'terminal' }))).rejects.toThrow(
+      /terminal state/
+    );
+  });
+
+  it('locks to conditional-approval at iteration 3 if still modifications-requested', async () => {
+    const critic = new FixedCritic(
+      makeOutput({ status: 'approved-with-modifications', requested_modifications: ['x'] })
+    );
+    const { agent } = makeAgent({ critic });
+    await agent.submitPlan(makePlan({ submissionId: 'loop' }));
+    await agent.submitPlan(makePlan({ submissionId: 'loop' }));
+    const out3 = await agent.submitPlan(makePlan({ submissionId: 'loop' }));
+    expect(out3.iteration).toBe(3);
+    expect(agent.getCurrentState('loop')).toBe('ea-review-conditional-approval');
+  });
+});
+
+describe('EaArchitectAgent — history + events', () => {
+  it('getReviewHistory: returns null for unknown submission', () => {
+    const { agent } = makeAgent();
+    expect(agent.getReviewHistory('not-real')).toBeNull();
+  });
+
+  it('getReviewHistory: returns the entries with transition state', async () => {
+    const critic = new StubCritic([
+      makeOutput({ status: 'approved-with-modifications', requested_modifications: ['fix'] }),
+      makeOutput({ status: 'approved' })
+    ]);
+    const { agent } = makeAgent({ critic });
+    await agent.submitPlan(makePlan({ submissionId: 'hist' }));
+    await agent.submitPlan(makePlan({ submissionId: 'hist' }));
+    const hist = agent.getReviewHistory('hist');
+    expect(hist?.entries.length).toBe(2);
+    expect(hist?.entries[0]?.transitionTo).toBe('ea-review-revisions-requested');
+    expect(hist?.entries[1]?.transitionTo).toBe('ea-review-approved');
+    expect(hist?.currentState).toBe('ea-review-approved');
+  });
+
+  it('listSubmissions: returns all known submission ids', async () => {
+    const { agent } = makeAgent();
+    await agent.submitPlan(makePlan());
+    await agent.submitPlan(makePlan());
+    expect(agent.listSubmissions().length).toBe(2);
+  });
+
+  it('emits state-transition events on every review pass', async () => {
+    const critic = new StubCritic([
+      makeOutput({ status: 'approved-with-modifications', requested_modifications: ['x'] }),
+      makeOutput({ status: 'rejected', reasoning: 'no' })
+    ]);
+    const { agent } = makeAgent({ critic });
+    const events: EaReviewEvent[] = [];
+    agent.on('*', (e) => {
+      events.push(e);
+    });
+    await agent.submitPlan(makePlan({ submissionId: 'evts' }));
+    await agent.submitPlan(makePlan({ submissionId: 'evts' }));
+    expect(events.length).toBe(2);
+    expect(events[0]?.type).toBe('ea-architect.review.revisions-requested');
+    expect(events[1]?.type).toBe('ea-architect.review.rejected');
+  });
+
+  it('event subscribers can filter by exact type', async () => {
+    const { agent } = makeAgent();
+    const approvedHandler = vi.fn();
+    agent.on('ea-architect.review.approved', approvedHandler);
+    await agent.submitPlan(makePlan());
+    expect(approvedHandler).toHaveBeenCalledOnce();
+  });
+});
+
+describe('EaArchitectAgent — hallucination guard', () => {
+  it('drops fabricated ADR citations before returning to caller', async () => {
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved',
+        cited_adrs: ['ADR-001', 'ADR-999', 'ADR-9999'],
+        cited_principles: ['P1', 'P999']
+      })
+    );
+    const { agent } = makeAgent({ critic });
+    const out = await agent.submitPlan(makePlan());
+    expect(out.cited_adrs).toEqual(['ADR-001']);
+    expect(out.cited_principles).toEqual(['P1']);
+  });
+});

--- a/packages/ea-architect/tests/critic.test.ts
+++ b/packages/ea-architect/tests/critic.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyHallucinationGuard,
+  buildCriticPrompt,
+  EA_ARCHITECT_SYSTEM_PROMPT,
+  parseCriticOutput
+} from '../src/critic.js';
+import { InMemoryFsAdapter } from '../src/fs-adapter.js';
+import { loadRepository, selectRelevantContext } from '../src/repository-loader.js';
+import type { CriticOutput } from '../src/types.js';
+
+import { AGENT_MEMORY_ROOT, REPO_ROOT, sampleRepoFiles } from './fixtures/sample-repository.js';
+
+describe('buildCriticPrompt', () => {
+  function makeInput() {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const context = selectRelevantContext(repo, 'subscription claude', []);
+    return {
+      planMarkdown: '## Plan\n\nWe will route Claude via spawner.',
+      planType: 'spec' as const,
+      affectedComponents: ['@caia/x'],
+      context,
+      iteration: 1,
+      modelTier: 'sonnet' as const
+    };
+  }
+
+  it('includes the system prompt header', () => {
+    const prompt = buildCriticPrompt(makeInput());
+    expect(prompt).toContain('EA Architect Agent');
+    expect(prompt).toContain('CRITICAL: never approve');
+  });
+
+  it('includes Architecture Principles section', () => {
+    const prompt = buildCriticPrompt(makeInput());
+    expect(prompt).toContain('### Architecture Principles');
+    expect(prompt).toContain('P1');
+  });
+
+  it('includes Relevant ADRs section', () => {
+    const prompt = buildCriticPrompt(makeInput());
+    expect(prompt).toContain('### Relevant ADRs');
+  });
+
+  it('includes Operator Feedback Memories section', () => {
+    const prompt = buildCriticPrompt(makeInput());
+    expect(prompt).toContain('### Operator Feedback Memories');
+  });
+
+  it('includes the plan markdown verbatim', () => {
+    const prompt = buildCriticPrompt(makeInput());
+    expect(prompt).toContain('We will route Claude via spawner.');
+  });
+
+  it('includes the affected components', () => {
+    const prompt = buildCriticPrompt(makeInput());
+    expect(prompt).toContain('@caia/x');
+  });
+
+  it('includes iteration counter', () => {
+    const prompt = buildCriticPrompt({ ...makeInput(), iteration: 3 });
+    expect(prompt).toContain('iteration 3');
+  });
+
+  it('system prompt declares strict JSON output requirement', () => {
+    expect(EA_ARCHITECT_SYSTEM_PROMPT).toContain('OUTPUT STRICT JSON');
+  });
+});
+
+describe('parseCriticOutput', () => {
+  it('parses a clean JSON envelope', () => {
+    const raw = JSON.stringify({
+      status: 'approved',
+      reasoning: 'looks good',
+      cited_adrs: ['ADR-001'],
+      cited_principles: ['P1'],
+      cited_lessons: [],
+      requested_modifications: [],
+      new_adrs_to_file: [],
+      affected_existing_adrs: []
+    });
+    const out = parseCriticOutput(raw);
+    expect(out.ok).toBe(true);
+    expect(out.status).toBe('approved');
+    expect(out.cited_adrs).toEqual(['ADR-001']);
+  });
+
+  it('parses JSON wrapped in a markdown code fence', () => {
+    const raw =
+      '```json\n' +
+      JSON.stringify({ status: 'rejected', reasoning: 'no' }) +
+      '\n```';
+    const out = parseCriticOutput(raw);
+    expect(out.status).toBe('rejected');
+  });
+
+  it('parses JSON inside a claude --output-format json envelope', () => {
+    const inner = JSON.stringify({
+      status: 'approved-with-modifications',
+      reasoning: 'fix X',
+      cited_adrs: ['ADR-009'],
+      cited_principles: [],
+      cited_lessons: [],
+      requested_modifications: ['drop the timeline section'],
+      new_adrs_to_file: [],
+      affected_existing_adrs: []
+    });
+    const envelope = JSON.stringify({ type: 'result', result: inner });
+    const out = parseCriticOutput(envelope);
+    expect(out.status).toBe('approved-with-modifications');
+    expect(out.requested_modifications).toEqual(['drop the timeline section']);
+  });
+
+  it('handles malformed JSON gracefully (returns ok=false)', () => {
+    const out = parseCriticOutput('not json at all');
+    expect(out.ok).toBe(false);
+    expect(out.status).toBe('rejected');
+  });
+
+  it('normalises unknown status to needs-clarification', () => {
+    const raw = JSON.stringify({ status: 'maybe', reasoning: 'unclear' });
+    const out = parseCriticOutput(raw);
+    expect(out.status).toBe('needs-clarification');
+  });
+
+  it('strips invalid new_adrs entries (missing title)', () => {
+    const raw = JSON.stringify({
+      status: 'approved',
+      reasoning: 'ok',
+      new_adrs_to_file: [
+        { title: 'Valid one', context: 'c', decision: 'd', consequences: 'e' },
+        { context: 'no title' }
+      ]
+    });
+    const out = parseCriticOutput(raw);
+    expect(out.new_adrs_to_file.length).toBe(1);
+    expect(out.new_adrs_to_file[0]?.title).toBe('Valid one');
+  });
+
+  it('parses escalation_to_operator block', () => {
+    const raw = JSON.stringify({
+      status: 'approved',
+      reasoning: 'pivot',
+      escalation_to_operator: {
+        reason: 'product direction',
+        decisionPoint: 'pivot?',
+        recommendation: 'no',
+        category: 'product-pivot'
+      }
+    });
+    const out = parseCriticOutput(raw);
+    expect(out.escalation_to_operator?.category).toBe('product-pivot');
+    expect(out.escalation_to_operator?.recommendation).toBe('no');
+  });
+});
+
+describe('applyHallucinationGuard', () => {
+  function makeOutput(overrides: Partial<CriticOutput> = {}): CriticOutput {
+    return {
+      status: 'approved',
+      reasoning: '',
+      cited_adrs: ['ADR-001', 'ADR-999'],
+      cited_principles: ['P1', 'P99'],
+      cited_lessons: ['01-pixel-perfect-calibration', 'bogus-lesson'],
+      requested_modifications: [],
+      new_adrs_to_file: [],
+      affected_existing_adrs: [
+        { adrId: 'ADR-001', action: 'amend' },
+        { adrId: 'ADR-999', action: 'supersede' }
+      ],
+      ok: true,
+      ...overrides
+    };
+  }
+
+  it('drops cited ADRs that do not exist', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const context = selectRelevantContext(repo, 'x', []);
+    const knownAdr = new Set(repo.adrs.map((a) => a.adrId));
+    const knownPrinc = new Set(repo.principles.map((p) => p.id));
+    const knownLesson = new Set(repo.lessons.map((l) => l.id));
+    const guarded = applyHallucinationGuard(
+      makeOutput(),
+      context,
+      knownAdr,
+      knownPrinc,
+      knownLesson
+    );
+    expect(guarded.cited_adrs).toEqual(['ADR-001']);
+    expect(guarded.cited_principles).toEqual(['P1']);
+    expect(guarded.cited_lessons).toEqual(['01-pixel-perfect-calibration']);
+    expect(guarded.affected_existing_adrs.length).toBe(1);
+    expect(guarded.affected_existing_adrs[0]?.adrId).toBe('ADR-001');
+  });
+
+  it('drops bogus supersedes target from a new ADR draft', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const context = selectRelevantContext(repo, 'x', []);
+    const out = makeOutput({
+      new_adrs_to_file: [
+        {
+          title: 'New decision',
+          status: 'Accepted',
+          context: 'c',
+          decision: 'd',
+          consequences: 'e',
+          supersedes: ['ADR-999']
+        }
+      ]
+    });
+    const guarded = applyHallucinationGuard(
+      out,
+      context,
+      new Set(repo.adrs.map((a) => a.adrId)),
+      new Set(repo.principles.map((p) => p.id)),
+      new Set(repo.lessons.map((l) => l.id))
+    );
+    expect(guarded.new_adrs_to_file[0]?.supersedes).toBeUndefined();
+  });
+
+  it('keeps valid supersedes target', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const context = selectRelevantContext(repo, 'x', []);
+    const out = makeOutput({
+      new_adrs_to_file: [
+        {
+          title: 'New decision',
+          status: 'Accepted',
+          context: 'c',
+          decision: 'd',
+          consequences: 'e',
+          supersedes: ['ADR-060', 'ADR-bogus']
+        }
+      ]
+    });
+    const guarded = applyHallucinationGuard(
+      out,
+      context,
+      new Set(repo.adrs.map((a) => a.adrId)),
+      new Set(repo.principles.map((p) => p.id)),
+      new Set(repo.lessons.map((l) => l.id))
+    );
+    expect(guarded.new_adrs_to_file[0]?.supersedes).toEqual(['ADR-060']);
+  });
+});

--- a/packages/ea-architect/tests/escalation.test.ts
+++ b/packages/ea-architect/tests/escalation.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendEscalationToInbox,
+  detectStrategicEscalation,
+  ESCALATION_SECTION_HEADER,
+  renderEscalationEntry
+} from '../src/escalation.js';
+import { InMemoryFsAdapter } from '../src/fs-adapter.js';
+import type { OperatorEscalation } from '../src/types.js';
+
+const INBOX = '/test/agent-memory/INBOX.md';
+const SAMPLE_ESC: OperatorEscalation = {
+  reason: 'plan proposes pivot to consumer market',
+  decisionPoint: 'should we pivot or stay enterprise',
+  recommendation: 'stay enterprise',
+  category: 'product-pivot'
+};
+
+describe('escalation', () => {
+  it('renderEscalationEntry: renders the four fields', () => {
+    const entry = renderEscalationEntry({
+      submissionId: 'sub-42',
+      callerAgentId: '@caia/researcher',
+      planType: 'spec',
+      escalation: SAMPLE_ESC,
+      at: new Date('2026-05-23T12:00:00Z')
+    });
+    expect(entry).toContain('sub-42');
+    expect(entry).toContain('@caia/researcher');
+    expect(entry).toContain('product-pivot');
+    expect(entry).toContain('plan proposes pivot');
+    expect(entry).toContain('stay enterprise');
+    expect(entry).toContain('[ea-agent-escalation]');
+  });
+
+  it('renderEscalationEntry: omits recommendation cleanly when absent', () => {
+    const { recommendation: _omit, ...withoutRec } = SAMPLE_ESC;
+    void _omit;
+    const entry = renderEscalationEntry({
+      submissionId: 'sub-42',
+      callerAgentId: 'a',
+      planType: 'spec',
+      escalation: withoutRec,
+      at: new Date('2026-05-23T12:00:00Z')
+    });
+    expect(entry).not.toContain('Recommendation');
+  });
+
+  it('appendEscalationToInbox: creates INBOX with section if missing', () => {
+    const fs = new InMemoryFsAdapter({});
+    appendEscalationToInbox(fs, INBOX, {
+      submissionId: 'sub-42',
+      callerAgentId: '@caia/researcher',
+      planType: 'spec',
+      escalation: SAMPLE_ESC,
+      at: new Date('2026-05-23T12:00:00Z')
+    });
+    expect(fs.has(INBOX)).toBe(true);
+    const body = fs.readFile(INBOX);
+    expect(body).toContain(ESCALATION_SECTION_HEADER);
+    expect(body).toContain('sub-42');
+  });
+
+  it('appendEscalationToInbox: appends to existing section, preserves the rest', () => {
+    const fs = new InMemoryFsAdapter({
+      [INBOX]: `# INBOX
+
+## Items
+
+- existing entry
+
+${ESCALATION_SECTION_HEADER}
+
+- existing escalation
+
+## Older
+old body
+`
+    });
+    appendEscalationToInbox(fs, INBOX, {
+      submissionId: 'sub-99',
+      callerAgentId: '@caia/x',
+      planType: 'process-change',
+      escalation: SAMPLE_ESC,
+      at: new Date('2026-05-23T12:00:00Z')
+    });
+    const body = fs.readFile(INBOX);
+    expect(body).toContain('existing entry');
+    expect(body).toContain('existing escalation');
+    expect(body).toContain('sub-99');
+    expect(body).toContain('## Older');
+    // sub-99 lands inside the EA AGENT ESCALATIONS section, not after "## Older"
+    const escIdx = body.indexOf(ESCALATION_SECTION_HEADER);
+    const subIdx = body.indexOf('sub-99');
+    const olderIdx = body.indexOf('## Older');
+    expect(subIdx).toBeGreaterThan(escIdx);
+    expect(subIdx).toBeLessThan(olderIdx);
+  });
+
+  it('appendEscalationToInbox: creates section when INBOX exists but section missing', () => {
+    const fs = new InMemoryFsAdapter({
+      [INBOX]: `# INBOX\n\n## Items\n\n- existing entry\n`
+    });
+    appendEscalationToInbox(fs, INBOX, {
+      submissionId: 'sub-1',
+      callerAgentId: 'a',
+      planType: 'spec',
+      escalation: SAMPLE_ESC,
+      at: new Date('2026-05-23T12:00:00Z')
+    });
+    const body = fs.readFile(INBOX);
+    expect(body).toContain(ESCALATION_SECTION_HEADER);
+    expect(body).toContain('existing entry');
+    expect(body).toContain('sub-1');
+  });
+
+  it('detectStrategicEscalation: fires on product-pivot wording', () => {
+    const out = detectStrategicEscalation('We propose a product pivot to B2C.');
+    expect(out).not.toBeNull();
+    expect(out?.category).toBe('product-pivot');
+  });
+
+  it('detectStrategicEscalation: fires on billing-model wording', () => {
+    const out = detectStrategicEscalation('Change the billing model from credits to flat-fee.');
+    expect(out?.category).toBe('billing-model-change');
+  });
+
+  it('detectStrategicEscalation: fires on security posture wording', () => {
+    const out = detectStrategicEscalation('We update the security posture for tenants.');
+    expect(out?.category).toBe('security-posture-change');
+  });
+
+  it('detectStrategicEscalation: fires on principle amendment wording', () => {
+    const out = detectStrategicEscalation('Amend principle P1 to allow API keys.');
+    expect(out?.category).toBe('principle-amendment');
+  });
+
+  it('detectStrategicEscalation: returns null on routine technical text', () => {
+    const out = detectStrategicEscalation(
+      'Add a new endpoint for the dashboard. No principle changes.'
+    );
+    expect(out).toBeNull();
+  });
+});

--- a/packages/ea-architect/tests/fixtures/plans.ts
+++ b/packages/ea-architect/tests/fixtures/plans.ts
@@ -1,0 +1,80 @@
+/**
+ * Three real-shaped plans used by golden tests:
+ *  1. obviously-good plan → approved + ADR filed
+ *  2. partial plan → approved-with-modifications
+ *  3. obviously-bad plan → rejected with reasoning citing principles
+ */
+
+export const GOOD_PLAN_MD = `# Spec — Standardize EA Agent's event namespace
+
+## Context
+
+The EA Architect Agent emits events. We need a canonical namespace
+following the existing ADR-029 convention (57 event types across 15
+namespaces). Per ADR-029, new event types add via a registry update +
+type-narrowing union + regression test.
+
+## Decision
+
+Use \`ea-architect.review.<state>\` as the dotted namespace for all
+six EA review state transitions. Register the namespace in
+\`packages/events-taxonomy-internal/registry.yaml\` alongside existing
+namespaces (pipeline, story, …).
+
+## Consequences
+
+- Positive: dashboards filter consistently; downstream consumers can
+  glob \`ea-architect.*\`.
+- Negative: a small ceremony when adding a new transition type.
+
+## Affected components
+
+\`@caia/ea-architect\`, \`@chiefaia/events-taxonomy-internal\`.
+
+## Subscription path
+
+All Claude calls during build phase use the operator's Pro subscription
+via \`@chiefaia/claude-spawner\`. No API keys. (Per P1 + ADR-001.)
+`;
+
+export const MODIFICATIONS_PLAN_MD = `# Spec — Add caching layer to repository loader
+
+## Context
+
+The repository loader reads disk on every review. For low-traffic
+operation this is fine, but if review throughput grows we may want a
+cache.
+
+## Decision
+
+Add an in-memory cache keyed by repository root. TTL 60 seconds.
+
+## Affected components
+
+\`@caia/ea-architect\`.
+`;
+
+export const BAD_PLAN_MD = `# Spec — Wire the agent to Anthropic API with our key
+
+## Context
+
+We want the agent to be faster. Subscription has limits.
+
+## Decision
+
+Set ANTHROPIC_API_KEY in the process env and route all EA agent calls
+through the Anthropic API directly with our pay-per-token key. Skip
+the @chiefaia/claude-spawner subscription path.
+
+We will also remove the no-timelines rule because shipping in 4 days
+matters more than the operator's directive.
+
+## Consequences
+
+- Positive: maybe a bit faster.
+- Negative: we burn money and break P1, P3.
+
+## Affected components
+
+\`@caia/ea-architect\`.
+`;

--- a/packages/ea-architect/tests/fixtures/sample-repository.ts
+++ b/packages/ea-architect/tests/fixtures/sample-repository.ts
@@ -1,0 +1,323 @@
+/**
+ * Tiny in-memory EA Repository for tests.
+ *
+ * Mirrors the on-disk shape (decisions/ADR-NNN-*.md, principles/00-*.md,
+ * lessons-learned/*.md, risk-register/00-*.md) but stays small enough
+ * that test assertions can be exhaustive.
+ */
+
+export const REPO_ROOT = '/test/caia-ea';
+export const AGENT_MEMORY_ROOT = '/test/agent-memory';
+export const INBOX_PATH = `${AGENT_MEMORY_ROOT}/INBOX.md`;
+
+export function sampleRepoFiles(): Record<string, string> {
+  return {
+    // README so the loader's exists() checks pass
+    [`${REPO_ROOT}/README.md`]: '# CAIA EA Repository\n',
+
+    // Principles
+    [`${REPO_ROOT}/principles/00-architecture-principles.md`]: `# CAIA Architecture Principles
+
+## P1 — Subscription-only LLM during build phase
+
+**Statement.** All Claude calls use the subscription, never the API.
+
+**Rationale.** Flat fee subscription.
+
+**Implications.** Use @chiefaia/claude-spawner.
+
+## P2 — Zero-dollar budget at MVP
+
+**Statement.** No new paid SaaS.
+
+**Rationale.** Cost discipline.
+
+**Implications.** Free or self-hosted only.
+
+## P3 — No timelines, ever
+
+**Statement.** No calendar estimates.
+
+**Rationale.** Operator's directive.
+
+**Implications.** Critical path only.
+
+## P4 — No idle, no waiting
+
+**Statement.** Dispatch next step immediately.
+
+**Rationale.** Avoid bottlenecks.
+
+**Implications.** Self-perpetuating campaigns.
+
+## P9 — TOGAF-lightweight, not enterprise-heavy
+
+**Statement.** No ceremonial gates. EA Agent is the compliance check.
+
+**Rationale.** Solo founder context.
+
+**Implications.** Skip ADM ceremony. EA Agent reviews.
+`,
+
+    // ADRs
+    [`${REPO_ROOT}/decisions/ADR-001-pro-subscription-only-during-build.md`]: `# ADR-001 — Pro subscription only during build
+
+- **Status:** Accepted
+- **Date:** 2026-04-01
+- **Affected-components:** all packages
+- **Reversibility:** One-way
+- **Operator-sign-off-required:** yes
+
+## Context
+
+Subscription vs API debate.
+
+## Decision
+
+Use subscription via claude binary.
+
+## Consequences
+
+- Positive: flat fee.
+- Negative: rate limits.
+`,
+    [`${REPO_ROOT}/decisions/ADR-009-bypass-cd-direct-build-for-caia-dashboard.md`]: `# ADR-009 — Bypass CD direct build for dashboard
+
+- **Status:** Accepted
+- **Date:** 2026-05-01
+- **Affected-components:** dashboard, atlas
+- **Reversibility:** Reversible
+
+## Context
+
+Cost of CD subscription too high.
+
+## Decision
+
+Direct build skipping CD.
+
+## Consequences
+
+- Positive: lower cost.
+`,
+    [`${REPO_ROOT}/decisions/ADR-029-57-event-types-across-15-namespaces.md`]: `# ADR-029 — 57 event types across 15 namespaces
+
+- **Status:** Accepted
+- **Date:** 2026-04-28
+- **Affected-components:** events-taxonomy-internal, all event emitters
+- **Reversibility:** Reversible per event-type
+
+## Context
+
+Without a registered taxonomy, ad-hoc event names proliferate.
+
+## Decision
+
+The event taxonomy is centralised at registry.yaml. Invalidate on repository write events.
+
+## Consequences
+
+- Single source of truth.
+`,
+    [`${REPO_ROOT}/decisions/ADR-015-ea-architect-agent-for-plan-approval.md`]: `# ADR-015 — Create @caia/ea-architect for plan approval
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Affected-components:** @caia/ea-architect, @caia/state-machine
+- **Reversibility:** Reversible
+
+## Context
+
+Operator removed from per-plan approval.
+
+## Decision
+
+Build the EA Architect Agent.
+
+## Consequences
+
+- Positive: operator off the critical path.
+`,
+    [`${REPO_ROOT}/decisions/ADR-040-ea-reviewer-vs-ea-architect-scope-distinction.md`]: `# ADR-040 — EA Reviewer vs EA Architect scope
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Affected-components:** @caia/ea-reviewer, @caia/ea-architect
+
+## Context
+
+Two agents with EA in the name; need scope split.
+
+## Decision
+
+Reviewer = per-ticket. Architect = platform-level.
+
+## Consequences
+
+- Clear demarcation.
+`,
+    [`${REPO_ROOT}/decisions/ADR-060-mui-react-first-stack.md`]: `# ADR-060 — MUI React-first stack
+
+- **Status:** Superseded by ADR-061
+- **Date:** 2026-05-23
+- **Supersedes:** none
+- **Superseded-by:** ADR-061
+- **Affected-components:** all UI packages
+- **Reversibility:** Reversible
+
+## Context
+
+Component library choice.
+
+## Decision
+
+Use MUI.
+
+## Consequences
+
+- Positive: maturity.
+`,
+    [`${REPO_ROOT}/decisions/ADR-061-stay-with-shadcn-tailwind-canonical-stack.md`]: `# ADR-061 — shadcn/Tailwind canonical stack
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Supersedes:** ADR-060
+- **Superseded-by:** none
+- **Affected-components:** all UI packages
+- **Reversibility:** High cost to reverse
+
+## Context
+
+MUI was locked then unlocked same day.
+
+## Decision
+
+shadcn + Tailwind canonical.
+
+## Consequences
+
+- Better AI codegen affinity.
+`,
+
+    // Lessons learned
+    [`${REPO_ROOT}/lessons-learned/01-pixel-perfect-calibration.md`]: `# Pixel-perfect calibration
+
+Date: 2026-05-10
+Tags: design, calibration
+
+What happened: 62% pixel-perfect on first pass.
+
+What we tried: 4 rounds of calibration.
+
+Lesson: calibrate per component, not platform-wide.
+`,
+    [`${REPO_ROOT}/lessons-learned/04-local-ai-stack-teardown.md`]: `# Local AI stack teardown
+
+Date: 2026-05-20
+Tags: local-ai, teardown, ollama
+
+What happened: tore down local-AI router stack.
+
+Lesson: prefer subscription Claude until concrete evidence of cap pressure.
+`,
+
+    // Risk register
+    [`${REPO_ROOT}/risk-register/00-current-risks.md`]: `# Risk Register
+
+## Security
+
+- Secret leakage
+- Prompt injection
+
+## Vendor lock-in
+
+- Anthropic Claude dependency
+- Cloudflare API shape
+
+## Operational
+
+- Single server SPOF on stolution
+`,
+
+    // Templates
+    [`${REPO_ROOT}/templates/adr-template.md`]: `# ADR-NNN — Title
+
+- **Status:** Proposed | Accepted
+- **Date:** YYYY-MM-DD
+- **Decision-makers:** Operator | EA Architect Agent | Both
+- **Supersedes:** ADR-XXX (or none)
+- **Superseded-by:** none
+
+## Context
+
+## Decision
+
+## Consequences
+`,
+
+    // Agent memory feedback files
+    [`${AGENT_MEMORY_ROOT}/feedback_no_timelines.md`]: `---
+name: feedback-no-timelines
+description: Operator does not want timelines / day estimates discussed.
+metadata:
+  type: feedback
+---
+
+Never quote calendar days, weeks, hours-to-MVP, or ETA estimates.
+`,
+    [`${AGENT_MEMORY_ROOT}/feedback_no_idle_no_waiting.md`]: `---
+name: feedback-no-idle-no-waiting
+description: Never leave outputs idle waiting on the operator.
+metadata:
+  type: feedback
+---
+
+After every task completion, fire the next dispatch in the same message.
+`,
+    [`${AGENT_MEMORY_ROOT}/feedback_auto_merge_prs.md`]: `---
+name: feedback-auto-merge-prs
+description: Operator does NOT want to be asked to merge PRs. Admin-merge them autonomously.
+metadata:
+  type: feedback
+---
+
+Auto-merge PRs via gh pr merge admin.
+`,
+    [`${AGENT_MEMORY_ROOT}/feedback_action_research_outputs.md`]: `---
+name: feedback-action-research-outputs
+description: Research outputs must have a clear next action.
+metadata:
+  type: feedback
+---
+
+On every research/spec task completion, surface or dispatch.
+`,
+    [`${AGENT_MEMORY_ROOT}/feedback_ea_agent_gates_research.md`]: `---
+name: feedback-ea-agent-gates-research
+description: EA Agent is the gate for all research/plans before operator review.
+metadata:
+  type: feedback
+---
+
+Every research/plan goes through the EA Agent first.
+`,
+    [`${AGENT_MEMORY_ROOT}/feedback_caia_build_uses_pro_subscription_only.md`]: `---
+name: feedback-caia-build-uses-pro-subscription-only
+description: Subscription only during CAIA build phase.
+metadata:
+  type: feedback
+---
+
+Never API keys; only subscription via claude binary.
+`,
+    [`${AGENT_MEMORY_ROOT}/project_caia_shadcn_react_first_locked.md`]: `---
+name: project-caia-shadcn-react-first-locked
+description: shadcn/ui + Tailwind locked as canonical component library.
+metadata:
+  type: project
+---
+
+shadcn over MUI for AI-assisted codegen reasons.
+`
+  };
+}

--- a/packages/ea-architect/tests/fixtures/stub-critic.ts
+++ b/packages/ea-architect/tests/fixtures/stub-critic.ts
@@ -1,0 +1,47 @@
+import type { CriticAdapter, CriticInput, CriticOutput, ReviewStatus } from '../../src/types.js';
+
+/** A pre-canned critic output for tests. */
+export function makeOutput(partial: Partial<CriticOutput> & { status: ReviewStatus }): CriticOutput {
+  return {
+    status: partial.status,
+    reasoning: partial.reasoning ?? 'test',
+    cited_adrs: partial.cited_adrs ?? [],
+    cited_principles: partial.cited_principles ?? [],
+    cited_lessons: partial.cited_lessons ?? [],
+    requested_modifications: partial.requested_modifications ?? [],
+    new_adrs_to_file: partial.new_adrs_to_file ?? [],
+    affected_existing_adrs: partial.affected_existing_adrs ?? [],
+    ...(partial.escalation_to_operator !== undefined
+      ? { escalation_to_operator: partial.escalation_to_operator }
+      : {}),
+    ok: partial.ok ?? true,
+    ...(partial.diagnostic !== undefined ? { diagnostic: partial.diagnostic } : {})
+  };
+}
+
+/** A critic adapter that returns a fixed sequence of outputs (per iteration). */
+export class StubCritic implements CriticAdapter {
+  public calls: CriticInput[] = [];
+
+  constructor(private readonly outputs: CriticOutput[]) {}
+
+  async review(input: CriticInput): Promise<CriticOutput> {
+    this.calls.push(input);
+    const idx = Math.min(this.calls.length - 1, this.outputs.length - 1);
+    const out = this.outputs[idx];
+    if (out === undefined) throw new Error('StubCritic exhausted');
+    return out;
+  }
+}
+
+/** A critic that always returns the same output regardless of iteration. */
+export class FixedCritic implements CriticAdapter {
+  public calls: CriticInput[] = [];
+
+  constructor(private readonly output: CriticOutput) {}
+
+  async review(input: CriticInput): Promise<CriticOutput> {
+    this.calls.push(input);
+    return this.output;
+  }
+}

--- a/packages/ea-architect/tests/golden.test.ts
+++ b/packages/ea-architect/tests/golden.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Golden tests — three real-shaped plans exercise the end-to-end
+ * verdict pipeline.
+ *
+ * We stub the critic so the test is deterministic, but the critic
+ * outputs are hand-crafted to match what the real model would (and
+ * should) emit for each plan. The assertions verify the agent's
+ * behaviour AROUND the critic — repository loading, ADR auto-filing,
+ * supersession wiring, INDEX.md updates, hallucination guarding,
+ * state transitions, event emission, INBOX-escalation surfacing.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { EaArchitectAgent } from '../src/agent.js';
+import { InMemoryFsAdapter } from '../src/fs-adapter.js';
+import type { EaReviewEvent } from '../src/types.js';
+
+import {
+  AGENT_MEMORY_ROOT,
+  INBOX_PATH,
+  REPO_ROOT,
+  sampleRepoFiles
+} from './fixtures/sample-repository.js';
+import { BAD_PLAN_MD, GOOD_PLAN_MD, MODIFICATIONS_PLAN_MD } from './fixtures/plans.js';
+import { FixedCritic, makeOutput } from './fixtures/stub-critic.js';
+
+describe('golden: good plan → approved + ADR filed', () => {
+  it('files ADR-062 with correct numbering and updates INDEX.md', async () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved',
+        reasoning:
+          'Plan aligns with ADR-029 conventions and P1/P11 (event-first). New ADR captures the namespace decision.',
+        cited_adrs: ['ADR-001', 'ADR-015'],
+        cited_principles: ['P1', 'P11' as never],
+        cited_lessons: [],
+        new_adrs_to_file: [
+          {
+            title: 'Adopt ea-architect dot namespace for review transitions',
+            status: 'Accepted',
+            context:
+              'The EA Architect Agent emits state transitions. To match ADR-029 conventions we need a registered namespace.',
+            decision:
+              'Use ea-architect.review.<state> as the namespace and register it in events-taxonomy-internal.',
+            consequences:
+              'Positive: consistent dashboard filtering. Negative: registry ceremony.',
+            affectedComponents: ['@caia/ea-architect', '@chiefaia/events-taxonomy-internal'],
+            reversibility: 'Reversible'
+          }
+        ]
+      })
+    );
+    const events: EaReviewEvent[] = [];
+    const agent = new EaArchitectAgent({
+      repositoryPath: REPO_ROOT,
+      inboxPath: INBOX_PATH,
+      agentMemoryPath: AGENT_MEMORY_ROOT,
+      critic,
+      fs,
+      clock: () => new Date('2026-05-23T12:00:00Z'),
+      generateSubmissionId: () => 'good-plan-1'
+    });
+    agent.on('*', (e) => {
+      events.push(e);
+    });
+
+    const out = await agent.submitPlan({
+      planMarkdown: GOOD_PLAN_MD,
+      planType: 'spec',
+      callerAgentId: '@caia/researcher',
+      submittedBy: 'orchestrator',
+      affectedComponents: ['@caia/ea-architect', '@chiefaia/events-taxonomy-internal']
+    });
+
+    // Verdict shape
+    expect(out.status).toBe('approved');
+    expect(out.submissionId).toBe('good-plan-1');
+    expect(out.iteration).toBe(1);
+    expect(out.cited_adrs).toContain('ADR-001');
+    expect(out.cited_adrs).toContain('ADR-015');
+    expect(out.cited_principles).toContain('P1');
+    // P11 wasn't in fixture repo — hallucination guard drops it.
+    expect(out.cited_principles).not.toContain('P11');
+
+    // ADR filed on disk with correct number + slug
+    const expected = `${REPO_ROOT}/decisions/ADR-062-adopt-ea-architect-dot-namespace-for-review-transitions.md`;
+    expect(fs.has(expected)).toBe(true);
+    const body = fs.readFile(expected);
+    expect(body).toContain('# ADR-062');
+    expect(body).toContain('- **Status:** Accepted');
+    expect(body).toContain('- **Affected-components:** @caia/ea-architect, @chiefaia/events-taxonomy-internal');
+
+    // INDEX.md updated
+    expect(fs.has(`${REPO_ROOT}/decisions/INDEX.md`)).toBe(true);
+    expect(fs.readFile(`${REPO_ROOT}/decisions/INDEX.md`)).toContain('ADR-062');
+
+    // State transition + event
+    expect(agent.getCurrentState('good-plan-1')).toBe('ea-review-approved');
+    expect(events.length).toBe(1);
+    expect(events[0]?.type).toBe('ea-architect.review.approved');
+  });
+});
+
+describe('golden: partial plan → approved-with-modifications', () => {
+  it('returns specific modifications and transitions to revisions-requested', async () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'approved-with-modifications',
+        reasoning:
+          'Cache concept is sound but the plan omits cache invalidation. Add an invalidation hook and cite ADR-029 for event-driven invalidation.',
+        cited_adrs: ['ADR-029'],
+        cited_principles: ['P9'],
+        requested_modifications: [
+          'Specify cache invalidation policy (TTL alone is insufficient when the repository changes).',
+          'Cite ADR-029 — invalidate on repository write events.',
+          'Add a benchmark plan to verify caching actually improves throughput.'
+        ]
+      })
+    );
+    const events: EaReviewEvent[] = [];
+    const agent = new EaArchitectAgent({
+      repositoryPath: REPO_ROOT,
+      inboxPath: INBOX_PATH,
+      agentMemoryPath: AGENT_MEMORY_ROOT,
+      critic,
+      fs,
+      clock: () => new Date('2026-05-23T12:00:00Z'),
+      generateSubmissionId: () => 'mods-plan-1'
+    });
+    agent.on('*', (e) => {
+      events.push(e);
+    });
+
+    const out = await agent.submitPlan({
+      planMarkdown: MODIFICATIONS_PLAN_MD,
+      planType: 'spec',
+      callerAgentId: '@caia/researcher',
+      submittedBy: 'orchestrator',
+      affectedComponents: ['@caia/ea-architect']
+    });
+
+    expect(out.status).toBe('approved-with-modifications');
+    expect(out.requested_modifications?.length).toBe(3);
+    expect(out.requested_modifications?.[0]).toMatch(/invalidation/);
+    expect(out.cited_adrs).toContain('ADR-029');
+    // Iteration 1 → revisions-requested (not conditional-approval)
+    expect(agent.getCurrentState('mods-plan-1')).toBe('ea-review-revisions-requested');
+    expect(events[0]?.type).toBe('ea-architect.review.revisions-requested');
+
+    // Hard rule: never approves without updating documentation — verify
+    // no ADR was filed on a non-terminal approval.
+    expect(fs.has(`${REPO_ROOT}/decisions/INDEX.md`)).toBe(false);
+  });
+});
+
+describe('golden: bad plan → rejected with cited principles', () => {
+  it('cites P1 and emits rejected event without filing ADRs', async () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'rejected',
+        reasoning:
+          'Plan violates P1 (subscription-only LLM during build) by setting ANTHROPIC_API_KEY and proposing pay-per-token billing. Also violates P3 (no timelines) by quoting "4 days". ADR-001 codifies the subscription rule. No new ADRs justified by this plan.',
+        cited_adrs: ['ADR-001'],
+        cited_principles: ['P1', 'P3'],
+        cited_lessons: []
+      })
+    );
+    const events: EaReviewEvent[] = [];
+    const agent = new EaArchitectAgent({
+      repositoryPath: REPO_ROOT,
+      inboxPath: INBOX_PATH,
+      agentMemoryPath: AGENT_MEMORY_ROOT,
+      critic,
+      fs,
+      clock: () => new Date('2026-05-23T12:00:00Z'),
+      generateSubmissionId: () => 'bad-plan-1'
+    });
+    agent.on('*', (e) => {
+      events.push(e);
+    });
+
+    const out = await agent.submitPlan({
+      planMarkdown: BAD_PLAN_MD,
+      planType: 'implementation',
+      callerAgentId: '@caia/researcher',
+      submittedBy: 'orchestrator',
+      affectedComponents: ['@caia/ea-architect']
+    });
+
+    expect(out.status).toBe('rejected');
+    expect(out.reasoning).toContain('P1');
+    expect(out.cited_principles).toContain('P1');
+    expect(out.cited_principles).toContain('P3');
+    expect(out.cited_adrs).toContain('ADR-001');
+
+    // No ADR filed on rejection
+    expect(fs.has(`${REPO_ROOT}/decisions/INDEX.md`)).toBe(false);
+
+    // State transition + event
+    expect(agent.getCurrentState('bad-plan-1')).toBe('ea-review-rejected');
+    expect(events[0]?.type).toBe('ea-architect.review.rejected');
+  });
+
+  it('detects principle amendment in plan text via keyword fallback', async () => {
+    // Even if the critic missed the escalation, the keyword detector should
+    // flag "remove the no-timelines rule" as a principle amendment.
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const critic = new FixedCritic(
+      makeOutput({
+        status: 'rejected',
+        reasoning: 'no',
+        cited_principles: ['P1']
+      })
+    );
+    const agent = new EaArchitectAgent({
+      repositoryPath: REPO_ROOT,
+      inboxPath: INBOX_PATH,
+      agentMemoryPath: AGENT_MEMORY_ROOT,
+      critic,
+      fs,
+      clock: () => new Date('2026-05-23T12:00:00Z'),
+      generateSubmissionId: () => 'bad-plan-2'
+    });
+
+    const out = await agent.submitPlan({
+      planMarkdown: 'We will amend principle P1 to permit API keys.',
+      planType: 'process-change',
+      callerAgentId: '@caia/researcher',
+      submittedBy: 'orchestrator'
+    });
+    // Critic returned rejected; but the keyword fallback should add the
+    // strategic escalation.
+    expect(out.escalation_to_operator?.category).toBe('principle-amendment');
+    expect(agent.getCurrentState('bad-plan-2')).toBe('ea-review-escalated-to-operator');
+    // INBOX got the entry
+    expect(fs.has(INBOX_PATH)).toBe(true);
+    expect(fs.readFile(INBOX_PATH)).toContain('principle-amendment');
+  });
+});

--- a/packages/ea-architect/tests/index-exports.test.ts
+++ b/packages/ea-architect/tests/index-exports.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import * as eaArchitect from '../src/index.js';
+
+describe('index exports', () => {
+  it('exports the agent class', () => {
+    expect(typeof eaArchitect.EaArchitectAgent).toBe('function');
+  });
+
+  it('exports submitPlan helper', () => {
+    expect(typeof eaArchitect.submitPlan).toBe('function');
+  });
+
+  it('exports the repository loader functions', () => {
+    expect(typeof eaArchitect.loadRepository).toBe('function');
+    expect(typeof eaArchitect.selectRelevantContext).toBe('function');
+    expect(typeof eaArchitect.tokenise).toBe('function');
+    expect(typeof eaArchitect.extractAdrIds).toBe('function');
+  });
+
+  it('exports the critic helpers', () => {
+    expect(typeof eaArchitect.buildCriticPrompt).toBe('function');
+    expect(typeof eaArchitect.parseCriticOutput).toBe('function');
+    expect(typeof eaArchitect.applyHallucinationGuard).toBe('function');
+    expect(typeof eaArchitect.createDefaultCritic).toBe('function');
+    expect(typeof eaArchitect.EA_ARCHITECT_SYSTEM_PROMPT).toBe('string');
+  });
+
+  it('exports the ADR writer helpers', () => {
+    expect(typeof eaArchitect.writeNewAdr).toBe('function');
+    expect(typeof eaArchitect.renderAdrMarkdown).toBe('function');
+    expect(typeof eaArchitect.slugifyTitle).toBe('function');
+    expect(typeof eaArchitect.formatAdrId).toBe('function');
+    expect(typeof eaArchitect.markSupersededBy).toBe('function');
+    expect(typeof eaArchitect.applySupersessions).toBe('function');
+    expect(typeof eaArchitect.updateDecisionsIndex).toBe('function');
+  });
+
+  it('exports the escalation helpers', () => {
+    expect(typeof eaArchitect.appendEscalationToInbox).toBe('function');
+    expect(typeof eaArchitect.detectStrategicEscalation).toBe('function');
+    expect(eaArchitect.ESCALATION_SECTION_HEADER).toBe('## EA AGENT ESCALATIONS');
+  });
+
+  it('exports the state machine helpers', () => {
+    expect(typeof eaArchitect.canEaReviewTransition).toBe('function');
+    expect(typeof eaArchitect.isEaReviewTerminal).toBe('function');
+    expect(typeof eaArchitect.chooseTargetState).toBe('function');
+    expect(typeof eaArchitect.eventTypeFor).toBe('function');
+    expect(typeof eaArchitect.InProcessEventBus).toBe('function');
+    expect(Array.isArray(eaArchitect.EA_REVIEW_TERMINAL_STATES)).toBe(true);
+  });
+
+  it('exports the FS adapters', () => {
+    expect(typeof eaArchitect.InMemoryFsAdapter).toBe('function');
+    expect(eaArchitect.defaultFsAdapter).toBeDefined();
+  });
+
+  it('exports the agent contract', () => {
+    expect(eaArchitect.EA_ARCHITECT_CONTRACT.agentId).toBe('@caia/ea-architect');
+    expect(eaArchitect.EA_ARCHITECT_CONTRACT.emitsEvents.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/packages/ea-architect/tests/repository-loader.test.ts
+++ b/packages/ea-architect/tests/repository-loader.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryFsAdapter } from '../src/fs-adapter.js';
+import {
+  extractAdrIds,
+  loadRepository,
+  selectRelevantContext,
+  tokenise
+} from '../src/repository-loader.js';
+
+import {
+  AGENT_MEMORY_ROOT,
+  REPO_ROOT,
+  sampleRepoFiles
+} from './fixtures/sample-repository.js';
+
+describe('repository-loader', () => {
+  it('tokenise: splits into lowercase keywords and drops stopwords', () => {
+    const tokens = tokenise('We will use shadcn for the UI components.');
+    expect(tokens).toContain('shadcn');
+    expect(tokens).toContain('components');
+    expect(tokens).not.toContain('we');
+    expect(tokens).not.toContain('the');
+  });
+
+  it('tokenise: drops short tokens and hyphenated tokens are kept', () => {
+    const tokens = tokenise('A multi-tenant secrets-broker is X.');
+    expect(tokens).toContain('multi-tenant');
+    expect(tokens).toContain('secrets-broker');
+    expect(tokens).not.toContain('a');
+    expect(tokens).not.toContain('x');
+  });
+
+  it('extractAdrIds: finds ADR-NNN references', () => {
+    const ids = extractAdrIds('Per ADR-015 and ADR-040 we will...');
+    expect(ids).toEqual(['ADR-015', 'ADR-040']);
+  });
+
+  it('extractAdrIds: deduplicates', () => {
+    const ids = extractAdrIds('ADR-001 then ADR-001 again');
+    expect(ids).toEqual(['ADR-001']);
+  });
+
+  it('loadRepository: finds all ADRs and computes maxAdrId', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.adrs.length).toBe(7);
+    expect(repo.maxAdrId).toBe(61);
+  });
+
+  it('loadRepository: parses ADR titles correctly', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const adr15 = repo.adrs.find((a) => a.adrId === 'ADR-015');
+    expect(adr15).toBeDefined();
+    expect(adr15?.title).toBe('Create @caia/ea-architect for plan approval');
+    expect(adr15?.status).toBe('Accepted');
+  });
+
+  it('loadRepository: parses affected-components list', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const adr15 = repo.adrs.find((a) => a.adrId === 'ADR-015');
+    expect(adr15?.affectedComponents).toContain('@caia/ea-architect');
+    expect(adr15?.affectedComponents).toContain('@caia/state-machine');
+  });
+
+  it('loadRepository: parses 5 principles from the fixture', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.principles.length).toBe(5);
+    const ids = repo.principles.map((p) => p.id).sort();
+    expect(ids).toEqual(['P1', 'P2', 'P3', 'P4', 'P9']);
+  });
+
+  it('loadRepository: principle titles parsed correctly', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const p1 = repo.principles.find((p) => p.id === 'P1');
+    expect(p1?.title).toContain('Subscription-only');
+  });
+
+  it('loadRepository: finds all lessons-learned files', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.lessons.length).toBe(2);
+    expect(repo.lessons.map((l) => l.id)).toContain('01-pixel-perfect-calibration');
+    expect(repo.lessons.map((l) => l.id)).toContain('04-local-ai-stack-teardown');
+  });
+
+  it('loadRepository: parses risk register sections', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.risks.length).toBeGreaterThanOrEqual(3);
+    const cats = repo.risks.map((r) => r.category);
+    expect(cats).toContain('Security');
+    expect(cats).toContain('Vendor lock-in');
+  });
+
+  it('loadRepository: loads all 7 feedback memory files', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.feedback.length).toBe(7);
+    const ids = repo.feedback.map((f) => f.id);
+    expect(ids).toContain('feedback-no-timelines');
+    expect(ids).toContain('feedback-ea-agent-gates-research');
+    expect(ids).toContain('feedback-caia-build-uses-pro-subscription-only');
+    expect(ids).toContain('project-caia-shadcn-react-first-locked');
+  });
+
+  it('loadRepository: handles missing principles file gracefully', () => {
+    const files = sampleRepoFiles();
+    delete files[`${REPO_ROOT}/principles/00-architecture-principles.md`];
+    const fs = new InMemoryFsAdapter(files);
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.principles).toEqual([]);
+  });
+
+  it('loadRepository: ignores non-ADR files in decisions dir', () => {
+    const files = sampleRepoFiles();
+    files[`${REPO_ROOT}/decisions/README.md`] = '# not an ADR';
+    files[`${REPO_ROOT}/decisions/INDEX.md`] = '# index';
+    const fs = new InMemoryFsAdapter(files);
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    expect(repo.adrs.length).toBe(7);
+  });
+
+  it('selectRelevantContext: returns ALL principles regardless of query', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const ctx = selectRelevantContext(repo, 'unrelated nonsense query xyzzy', []);
+    expect(ctx.principles.length).toBe(5);
+  });
+
+  it('selectRelevantContext: ranks ADRs by keyword overlap', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const ctx = selectRelevantContext(repo, 'subscription claude binary', []);
+    expect(ctx.adrs.length).toBeGreaterThan(0);
+    const topId = ctx.adrs[0]?.item.adrId;
+    expect(topId).toBe('ADR-001');
+  });
+
+  it('selectRelevantContext: force-includes cited ADRs even if not keyword-matched', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    // Query has nothing to do with ADR-060/061 but mentions them.
+    const ctx = selectRelevantContext(repo, 'Per ADR-061 we keep going.', []);
+    const ids = ctx.adrs.map((m) => m.item.adrId);
+    expect(ids).toContain('ADR-061');
+  });
+
+  it('selectRelevantContext: returns all 7 feedback memories', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const ctx = selectRelevantContext(repo, 'any query', []);
+    expect(ctx.feedback.length).toBe(7);
+  });
+
+  it('selectRelevantContext: lessons surface on tag overlap', () => {
+    const fs = new InMemoryFsAdapter(sampleRepoFiles());
+    const repo = loadRepository(REPO_ROOT, AGENT_MEMORY_ROOT, fs);
+    const ctx = selectRelevantContext(repo, 'local ollama teardown', []);
+    expect(ctx.lessons.length).toBeGreaterThan(0);
+    expect(ctx.lessons[0]?.item.id).toBe('04-local-ai-stack-teardown');
+  });
+});

--- a/packages/ea-architect/tests/state.test.ts
+++ b/packages/ea-architect/tests/state.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildEvent,
+  canEaReviewTransition,
+  chooseTargetState,
+  EA_REVIEW_TERMINAL_STATES,
+  EA_REVIEW_VALID_TRANSITIONS,
+  eventTypeFor,
+  InProcessEventBus,
+  isEaReviewTerminal
+} from '../src/state.js';
+import type { EaReviewEvent, ReviewOutcome } from '../src/types.js';
+
+describe('state-machine', () => {
+  it('declares all six EA review states', () => {
+    const states = Object.keys(EA_REVIEW_VALID_TRANSITIONS);
+    expect(states).toContain('ea-review-pending');
+    expect(states).toContain('ea-review-revisions-requested');
+    expect(states).toContain('ea-review-approved');
+    expect(states).toContain('ea-review-conditional-approval');
+    expect(states).toContain('ea-review-rejected');
+    expect(states).toContain('ea-review-escalated-to-operator');
+  });
+
+  it('canEaReviewTransition: pending → approved is valid', () => {
+    expect(canEaReviewTransition('ea-review-pending', 'ea-review-approved')).toBe(true);
+  });
+
+  it('canEaReviewTransition: approved → anything is invalid (terminal)', () => {
+    expect(canEaReviewTransition('ea-review-approved', 'ea-review-rejected')).toBe(false);
+    expect(canEaReviewTransition('ea-review-approved', 'ea-review-pending')).toBe(false);
+  });
+
+  it('canEaReviewTransition: revisions-requested → pending is valid (caller resubmits)', () => {
+    expect(canEaReviewTransition('ea-review-revisions-requested', 'ea-review-pending')).toBe(true);
+  });
+
+  it('isEaReviewTerminal: identifies terminal states', () => {
+    for (const s of EA_REVIEW_TERMINAL_STATES) {
+      expect(isEaReviewTerminal(s)).toBe(true);
+    }
+    expect(isEaReviewTerminal('ea-review-pending')).toBe(false);
+    expect(isEaReviewTerminal('ea-review-revisions-requested')).toBe(false);
+  });
+
+  it('chooseTargetState: approved → ea-review-approved', () => {
+    expect(chooseTargetState('approved', false, false)).toBe('ea-review-approved');
+  });
+
+  it('chooseTargetState: rejected → ea-review-rejected', () => {
+    expect(chooseTargetState('rejected', false, false)).toBe('ea-review-rejected');
+  });
+
+  it('chooseTargetState: approved-with-modifications → revisions-requested on early iteration', () => {
+    expect(chooseTargetState('approved-with-modifications', false, false)).toBe(
+      'ea-review-revisions-requested'
+    );
+  });
+
+  it('chooseTargetState: approved-with-modifications → conditional-approval on final iteration', () => {
+    expect(chooseTargetState('approved-with-modifications', true, false)).toBe(
+      'ea-review-conditional-approval'
+    );
+  });
+
+  it('chooseTargetState: escalation always wins', () => {
+    expect(chooseTargetState('approved', false, true)).toBe('ea-review-escalated-to-operator');
+    expect(chooseTargetState('rejected', false, true)).toBe('ea-review-escalated-to-operator');
+  });
+
+  it('eventTypeFor: dot-namespaced format', () => {
+    expect(eventTypeFor('ea-review-approved')).toBe('ea-architect.review.approved');
+    expect(eventTypeFor('ea-review-escalated-to-operator')).toBe(
+      'ea-architect.review.escalated-to-operator'
+    );
+  });
+
+  it('buildEvent: composes envelope with timestamp ISO', () => {
+    const outcome = stubOutcome();
+    const event = buildEvent({
+      submissionId: 'sub-1',
+      callerAgentId: 'tester',
+      planType: 'spec',
+      iteration: 1,
+      fromState: null,
+      toState: 'ea-review-approved',
+      outcome,
+      at: new Date('2026-05-23T12:00:00Z')
+    });
+    expect(event.type).toBe('ea-architect.review.approved');
+    expect(event.submissionId).toBe('sub-1');
+    expect(event.at).toBe('2026-05-23T12:00:00.000Z');
+    expect(event.outcome.status).toBe('approved');
+  });
+});
+
+describe('InProcessEventBus', () => {
+  it('on(type) fires for the exact type only', async () => {
+    const bus = new InProcessEventBus();
+    const approved = vi.fn();
+    const rejected = vi.fn();
+    bus.on('ea-architect.review.approved', approved);
+    bus.on('ea-architect.review.rejected', rejected);
+    await bus.emit(makeEvent('ea-architect.review.approved'));
+    expect(approved).toHaveBeenCalledOnce();
+    expect(rejected).not.toHaveBeenCalled();
+  });
+
+  it('on("*") fires for every event', async () => {
+    const bus = new InProcessEventBus();
+    const wildcard = vi.fn();
+    bus.on('*', wildcard);
+    await bus.emit(makeEvent('ea-architect.review.approved'));
+    await bus.emit(makeEvent('ea-architect.review.rejected'));
+    expect(wildcard).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribe stops further callbacks', async () => {
+    const bus = new InProcessEventBus();
+    const handler = vi.fn();
+    const unsub = bus.on('ea-architect.review.approved', handler);
+    await bus.emit(makeEvent('ea-architect.review.approved'));
+    unsub();
+    await bus.emit(makeEvent('ea-architect.review.approved'));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('emit awaits async handlers', async () => {
+    const bus = new InProcessEventBus();
+    const order: string[] = [];
+    bus.on('*', async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      order.push('handler');
+    });
+    await bus.emit(makeEvent('ea-architect.review.approved'));
+    order.push('after-emit');
+    expect(order).toEqual(['handler', 'after-emit']);
+  });
+});
+
+function stubOutcome(): ReviewOutcome {
+  return {
+    status: 'approved',
+    reasoning: 'ok',
+    cited_adrs: [],
+    cited_principles: [],
+    cited_lessons: [],
+    submissionId: 'sub-1',
+    iteration: 1,
+    reviewedAtIso: '2026-05-23T12:00:00.000Z',
+    modelTier: 'sonnet'
+  };
+}
+
+function makeEvent(type: string): EaReviewEvent {
+  return {
+    type,
+    submissionId: 'sub-1',
+    callerAgentId: 'tester',
+    planType: 'spec',
+    iteration: 1,
+    fromState: null,
+    toState: 'ea-review-approved',
+    outcome: stubOutcome(),
+    at: '2026-05-23T12:00:00.000Z'
+  };
+}

--- a/packages/ea-architect/tsconfig.build.json
+++ b/packages/ea-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/ea-architect/tsconfig.json
+++ b/packages/ea-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/ea-architect/vitest.config.ts
+++ b/packages/ea-architect/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1567,6 +1567,22 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
 
+  packages/ea-architect:
+    dependencies:
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/ea-dispatcher:
     dependencies:
       '@caia/architect-kit':


### PR DESCRIPTION
## Summary

Ships **`@caia/ea-architect`** — the platform-level approval gate the operator named on 2026-05-23 in `feedback_ea_agent_gates_research.md`. Every future research / spec / implementation / architecture-change / process-change plan now passes through this agent BEFORE reaching the operator. Operationalises ADR-015.

**Distinct from `@caia/ea-reviewer`** — that one audits per-ticket composed architecture from the 17 architects. This one audits PLATFORM-LEVEL plans. See ADR-040 for the scope split.

## What it does

- **Reviews** plans against the full EA Repository: 61+ ADRs, all 12 principles, lessons-learned, risk register, 7 operator feedback memories.
- **Cites** by id (\`P1\`, \`ADR-015\`, etc.) — hallucination-guarded so cited items must exist on disk.
- **Auto-files** new ADRs on approval (next-id numbering, slugged filename, supersession wired both ways, INDEX.md updated). Never approves without updating documentation — operator's hard rule.
- **Escalates** to operator ONLY for genuinely-strategic decisions (product pivots, billing-model changes, fundamental architecture reversals, security posture changes, principle amendments). Routine technical approval is NEVER escalated. Escalations land under \`## EA AGENT ESCALATIONS\` in INBOX.md.
- **Iterates** with the caller via state-machine transitions: \`ea-review-pending\` → \`ea-review-revisions-requested\` → \`ea-review-pending\` → \`ea-review-approved\` | \`ea-review-conditional-approval\` | \`ea-review-rejected\` | \`ea-review-escalated-to-operator\`.
- **Emits** dot-namespaced events (\`ea-architect.review.<state>\`) for downstream subscribers (Conductor + Dashboard, when they land).

## Public API

\`\`\`ts
import { EaArchitectAgent } from '@caia/ea-architect';

const agent = new EaArchitectAgent();
const outcome = await agent.submitPlan({
  planMarkdown: '...',
  planType: 'spec',
  callerAgentId: '@caia/researcher',
  submittedBy: 'orchestrator',
  affectedComponents: ['@caia/atlas-mapper']
});
// outcome.status: approved | approved-with-modifications | rejected | needs-clarification
// outcome.cited_adrs, cited_principles, cited_lessons (hallucination-filtered)
// outcome.new_adrs_to_file (auto-filed on approval)
// outcome.escalation_to_operator (rare; routed to INBOX.md)
\`\`\`

## Verification

- **TypeScript strict clean** — \`tsc --noEmit\` passes (\`exactOptionalPropertyTypes\`, \`noUncheckedIndexedAccess\`, full strict mode).
- **Lint clean** — \`eslint src tests\` passes.
- **Build clean** — \`tsc -p tsconfig.build.json\` emits dist/.
- **Tests** — 122 passing across 8 files:
  - \`repository-loader.test.ts\` (19) — loader, tokeniser, relevance index, force-include cited ADRs.
  - \`adr-writer.test.ts\` (17) — slug + id formatting, supersession wiring both ways, INDEX.md upsert/dedup.
  - \`state.test.ts\` (16) — FSM transitions, terminal detection, target-state selection, event bus.
  - \`escalation.test.ts\` (10) — INBOX rendering, section creation/append, keyword-trigger detection.
  - \`critic.test.ts\` (18) — prompt assembly, JSON parsing (raw + fenced + envelope), hallucination guard.
  - \`agent.test.ts\` (29) — end-to-end submit, all 5 plan types, iteration loop, escalation, ADR filing.
  - \`golden.test.ts\` (4) — 3 real-shaped plans + a principle-amendment fallback case.
  - \`index-exports.test.ts\` (9) — public surface assertions.
- **Real-repo smoke** — loader verified against on-disk \`caia-ea/\` (61 ADRs, 12 principles, 7 feedback memories all parse correctly).

## Subscription-only LLM

Claude calls flow through \`@chiefaia/claude-spawner\` per P1 + P14 — never API keys.

## Forward-looking

- **Conductor Agent** (when it lands) subscribes to \`ea-architect.review.*\` events for governance visibility. Wire point: \`agent.on('*', conductor.recordReview)\`.
- **Dashboard** reads \`ReviewHistory\` via \`getReviewHistory(submissionId)\`; surfaces under \`/governance/ea-reviews\`.
- **Comm-Protocol Agent** (when it lands) wraps \`submitPlan\` as a broker request type. Until then, callers import the package directly.
- **HTTP endpoint** \`POST /api/ea-architect/review\` is conceptually defined in the README. Wiring lands when orchestrator-middleware grows EA routes.

## Refs

- ADR-015 (creation of this agent) — operationalised here.
- ADR-040 (scope split vs ea-reviewer) — honoured.
- ADR-011 + ADR-029 (event-first + 57 event types) — new \`ea-architect.review.*\` namespace follows the convention.
- P1, P3, P4, P9, P11 — encoded as critic-prompt context + escalation triggers.
- \`feedback_ea_agent_gates_research.md\` — directive.

## Notes

- The per-submission FSM lives in this package (\`src/state.ts\`) and is NOT part of the canonical \`@caia/state-machine\` project FSM (that's per-project; this is per-plan-submission). If the canonical FSM later gains plan-submission as a first-class entity, the in-package FSM can be deprecated.
- Dependabot PR #524 was open at branch-time; not blocking per operator's auto-merge-prs feedback (it's automated maintenance, not new work).