### PR TITLE
feat(@caia/feature-flagging-architect): ship architect #12 of 17 — Feature Flagging specialist

### DIFF
--- a/packages/feature-flagging-architect/README.md
+++ b/packages/feature-flagging-architect/README.md
@@ -1,0 +1,30 @@
+# @caia/feature-flagging-architect
+
+Architect #12 of CAIA's 17-architect EA fan-out.
+
+Owns the `featureFlags.*` slice of `tickets.architecture`:
+
+- `featureFlags.flagsSchema` — per-flag name, types, per-environment defaults, audience targeting
+- `featureFlags.rolloutStrategies` — percentage rollout, user-id rollout, canary, ring deployment
+- `featureFlags.killSwitches` — must-be-toggleable-instantly flags
+- `featureFlags.experimentationLinkage` — which flags feed which A/B tests (forward-references the A/B Testing Architect)
+- `featureFlags.auditRequirements` — who can toggle, audit-log per change
+
+Specifies **what gets toggleable, at what granularity, and what the rollout strategy is**.
+Does NOT write component code or backend logic — Frontend & Backend Architects own those.
+
+## Depends on
+
+- `@caia/frontend-architect` (reads `frontend.componentTree`, `frontend.interactionStates`)
+- `@caia/backend-architect` (reads `backend.apiEndpoints`)
+
+## Runtime
+
+- Model: Sonnet (default). 1 LLM call per flag-touching ticket.
+- Spawned via `@chiefaia/claude-spawner` (subscription-only — never sets `ANTHROPIC_API_KEY`).
+
+## Stack reminder
+
+`shadcn/ui + Tailwind` is locked. This architect emits no UI but its
+`experimentationLinkage` forward-references the A/B Testing Architect, which
+in turn drives `frontend.componentTree` variant rendering.

--- a/packages/feature-flagging-architect/eslint.config.cjs
+++ b/packages/feature-flagging-architect/eslint.config.cjs
@@ -1,0 +1,34 @@
+// @ts-check
+// ESLint v9 flat config — same shape as siblings (modelled on aiml-architect).
+// Run: pnpm lint  (== eslint src tests)
+
+const tseslint = require('typescript-eslint');
+const js = require('@eslint/js');
+
+module.exports = tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+);

--- a/packages/feature-flagging-architect/package.json
+++ b/packages/feature-flagging-architect/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@caia/feature-flagging-architect",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Feature Flagging Architect — architect #12 of CAIA's 17-architect EA fan-out. Owns the `featureFlags.*` slice of `tickets.architecture` (flagsSchema, rolloutStrategies, killSwitches, experimentationLinkage, auditRequirements). Senior platform engineer focused on feature-flagging best practices: per-environment defaults, audience targeting, percentage/canary/ring rollouts, instantly-toggleable kill switches, audit trail for every change, forward-references the A/B Testing Architect via experimentationLinkage. Specifies what gets toggleable, at what granularity, and what the rollout strategy is — does NOT write component code or backend logic. Depends on Frontend Architect's componentTree/interactionStates and Backend Architect's apiEndpoints to know what's flag-worthy. Spawns Claude via @chiefaia/claude-spawner (subscription-only). Follows the @caia/frontend-architect canonical template.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint src tests",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "@caia/architect-kit": "workspace:*",
+    "@chiefaia/claude-spawner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/feature-flagging-architect/src/architect.ts
+++ b/packages/feature-flagging-architect/src/architect.ts
@@ -1,0 +1,75 @@
+/**
+ * `FeatureFlaggingArchitect` — the `SpecialistArchitect` implementation.
+ *
+ * Per spec §1.1, the architect package exports a single class that the
+ * EA Dispatcher imports and invokes. The class:
+ *
+ *   - Holds the section contract as a readonly field.
+ *   - Returns the system prompt as a pure function (no runtime state).
+ *   - Declares empty `tools` for V1 (spec §2.12 — Feature Flagging
+ *     reads upstream Frontend/Backend output; no external tooling).
+ *   - Exposes `run(input)` which delegates to `./run.ts`.
+ *
+ * Constructor takes an optional `spawner` so tests can inject a
+ * deterministic fake. Default is `createDefaultSpawner()` which wraps
+ * `@chiefaia/claude-spawner`'s real `spawnClaude`.
+ *
+ * Note: this class does NOT extend `BaseArchitect` from `@caia/architect-kit`
+ * because the kit hasn't landed on develop yet. The interface is satisfied
+ * structurally. When the kit lands, switch to `extends BaseArchitect`.
+ */
+
+import { FeatureFlaggingArchitectContract } from './contract.js';
+import { runFeatureFlaggingArchitect } from './run.js';
+import { createDefaultSpawner, type ArchitectSpawnerFn } from './spawner.js';
+import { buildFeatureFlaggingSystemPrompt } from './system-prompt.js';
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSectionContract,
+  SpecialistArchitect,
+  ToolDefinition
+} from './types.js';
+
+/** Stable name; matches the canonical precedence ladder entry. */
+export const FEATURE_FLAGGING_ARCHITECT_NAME = 'featureFlagging' as const;
+
+/** V1: no architect-specific tools. Reads upstream FE+BE output directly. */
+export const FEATURE_FLAGGING_ARCHITECT_TOOLS: readonly ToolDefinition[] = [];
+
+export interface FeatureFlaggingArchitectConfig {
+  /** Inject a fake spawner in tests. Default: real claude-spawner-backed spawner. */
+  spawner?: ArchitectSpawnerFn;
+}
+
+export class FeatureFlaggingArchitect implements SpecialistArchitect {
+  readonly name = FEATURE_FLAGGING_ARCHITECT_NAME;
+  readonly sectionContract: ArchitectSectionContract = FeatureFlaggingArchitectContract;
+  readonly tools: readonly ToolDefinition[] = FEATURE_FLAGGING_ARCHITECT_TOOLS;
+
+  private readonly spawner: ArchitectSpawnerFn;
+
+  constructor(config: FeatureFlaggingArchitectConfig = {}) {
+    this.spawner = config.spawner ?? createDefaultSpawner();
+  }
+
+  /**
+   * Pure function; identical output every call. The Dispatcher uses this
+   * as the subagent's system prompt.
+   */
+  systemPrompt(): string {
+    return buildFeatureFlaggingSystemPrompt();
+  }
+
+  /**
+   * Runtime entry point. Idempotent given identical input — re-runs
+   * REPLACE the architect's owned fields (no append) per the task brief.
+   */
+  async run(input: ArchitectInput): Promise<ArchitectOutput> {
+    return runFeatureFlaggingArchitect(input, {
+      spawner: this.spawner,
+      systemPrompt: this.systemPrompt(),
+      architectName: this.name
+    });
+  }
+}

--- a/packages/feature-flagging-architect/src/contract.ts
+++ b/packages/feature-flagging-architect/src/contract.ts
@@ -1,0 +1,205 @@
+/**
+ * `FeatureFlaggingArchitectContract` — the canonical owned-fields
+ * declaration for architect #12 of CAIA's 17-architect EA fan-out.
+ *
+ * Sources of truth:
+ *   - spec §1.3 (ArchitectSectionContract + architectMeta)
+ *   - spec §2.12 (Feature Flagging Architect owns `featureFlags.*`)
+ *   - task brief (flagsSchema, rolloutStrategies, killSwitches,
+ *     experimentationLinkage, auditRequirements)
+ *
+ * Field disjointness with the other 16 architects is the invariant the
+ * Dispatcher enforces. All chosen keys live under the `featureFlags.*`
+ * namespace and do not collide with any sibling architect's namespace.
+ *
+ * Naming note: spec §2.12 lists fields like `flagStore`, `evalSurface`,
+ * `defaultValue`, `audienceRule`, `killSwitch`, `abVariantBinding`,
+ * `rolloutCurve`, `observabilityBinding`. The task brief consolidates
+ * these into five higher-level fields:
+ *
+ *   - `flagsSchema`            ← per-flag name/type/defaults/audience
+ *                                (subsumes flagStore, evalSurface,
+ *                                 defaultValue, audienceRule)
+ *   - `rolloutStrategies`      ← percentage/canary/ring rollout
+ *                                (subsumes rolloutCurve)
+ *   - `killSwitches`           ← must-be-toggleable-instantly flags
+ *                                (subsumes killSwitch)
+ *   - `experimentationLinkage` ← which flags feed which A/B tests
+ *                                (subsumes abVariantBinding;
+ *                                 forward-references A/B Testing Architect)
+ *   - `auditRequirements`      ← who can toggle, audit-log per change
+ *                                (new — covers observabilityBinding +
+ *                                 governance posture)
+ *
+ * Per the observability-architect precedent (and the standing rule —
+ * newer brief wins): the task brief is the binding name set; the spec
+ * outline guides the semantic content of each field. The contract id
+ * stays `v1` because no live caller is consuming it yet.
+ *
+ * Existing tooling: the architect's output is OpenFeature-compatible —
+ * `flagsSchema` produces shapes that map directly onto the OpenFeature
+ * provider interface; `rolloutStrategies` mirrors LaunchDarkly /
+ * Statsig conventions for percentage + ring rollouts. The architect
+ * does not import any provider SDK; it specifies fields the runtime
+ * will wire up.
+ */
+
+import type {
+  ArchitectMeta,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  Ticket
+} from './types.js';
+
+// ─── Owned field set ────────────────────────────────────────────────────────
+
+/**
+ * Per-field operator fix-hints. The kit's `ArchitectSectionSpec` is
+ * intentionally minimal (`path`, `description`, `required`); the fix-hint
+ * dictionary lives next to the contract so the system-prompt builder and
+ * the future EA Reviewer can surface it without changing kit shape.
+ */
+export const FEATURE_FLAGGING_FIELD_FIX_HINTS: Readonly<Record<string, string>> = {
+  'featureFlags.flagsSchema':
+    'For every flag this ticket introduces, declare: { name (kebab-case), type ("boolean"|"string"|"number"|"json"), description (≤200 chars), defaults (per-environment object — at minimum dev/staging/production), audience (targeting rule: tenant-id list, cohort id, percentage, or "everyone") }. Default flag default is "off" (boolean false / null / empty). Flag names are namespaced by the ticket id: <ticket-id>.<flag-slug>. Never invent a flag not implied by the ticket; missing motivation → omit + flag a risk.',
+  'featureFlags.rolloutStrategies':
+    'For every flag, declare a rollout strategy: { flag (must match a flagsSchema name), kind ("percentage"|"user-id"|"canary"|"ring-deployment"|"all-at-once"), steps (ordered list — e.g. [{stage:"canary", percent:1, gateMetric:"error_rate<0.5%", soakMinutes:30}, ...]), autoPromote (boolean), rollbackTrigger (metric breach that auto-rolls back) }. Defaults: canary 1% → 10% → 50% → 100% with 30-min soak between stages, auto-rollback on 5xx error_rate spike >2x baseline.',
+  'featureFlags.killSwitches':
+    'For every flag that gates a code path with material blast-radius (auth, payments, data export, AI inference, third-party API spend), mark it as a kill switch. Schema per entry: { flag, blastRadius ("auth"|"payments"|"data-export"|"ai-inference"|"third-party-spend"|"other"), instantToggle (must be true), bypassReviewQuorum (boolean — true iff incident severity warrants), notificationChannels (array of pager/Slack channels). Kill switches must be flippable in <30s without a deploy. Never gate a kill switch behind a multi-step approval flow.',
+  'featureFlags.experimentationLinkage':
+    'Forward-reference the A/B Testing Architect: for every flag that drives an experiment, declare { flag, abTestId (placeholder if A/B Testing has not run yet), variants (array of {variantKey, flagValue, allocation:0..1}), holdoutPercent (default 5), primaryMetric (must match an Analytics eventTaxonomy entry once Analytics runs), startDate, durationCapDays (default 28) }. If no experiment is planned for this flag, output an empty array entry [] — never omit the key.',
+  'featureFlags.auditRequirements':
+    'Governance posture for every flag: { flag, toggleRoles (array of role slugs — default ["operator","oncall"]), requiresChangeRecord (boolean — true for kill switches + flags with bypassReviewQuorum=false), auditLogSink ("default-cloudwatch"|"sentry-breadcrumbs"|"custom"), retentionDays (default 365), reviewCadenceDays (default 90 — stale flags get GC pinged). Every toggle event MUST log: actor, flag, oldValue, newValue, timestamp, reason, environment. Reject any audit posture that lets a flag flip without an audit log entry.'
+};
+
+/**
+ * The owned section specs in stable order.
+ */
+export const FEATURE_FLAGGING_OWNED_SECTIONS: readonly ArchitectSectionSpec[] = [
+  {
+    path: 'featureFlags.flagsSchema',
+    description:
+      'Per-flag schema: name (kebab-case, namespaced by ticket id), type (boolean|string|number|json), per-environment defaults (dev/staging/production at minimum), and audience targeting rule (tenant-id list, cohort, percentage, or "everyone"). The single source of truth for which flags exist for this ticket and how they evaluate.',
+    required: true
+  },
+  {
+    path: 'featureFlags.rolloutStrategies',
+    description:
+      'Per-flag rollout strategy: kind (percentage|user-id|canary|ring-deployment|all-at-once), ordered stages with gate metrics + soak windows, auto-promote posture, rollback trigger. Default canary curve 1% → 10% → 50% → 100% with 30-min soaks and auto-rollback on 5xx spike.',
+    required: true
+  },
+  {
+    path: 'featureFlags.killSwitches',
+    description:
+      'Flags marked as kill switches because they gate code paths with material blast-radius (auth, payments, data export, AI inference, third-party spend). Must be flippable in <30s without a deploy. Bypass-review-quorum only on incidents. Always notify pager + Slack channels on toggle.',
+    required: true
+  },
+  {
+    path: 'featureFlags.experimentationLinkage',
+    description:
+      'Forward-reference to the A/B Testing Architect: which flags drive which A/B experiments, with variant→flagValue allocation, holdout percentage, primary metric (Analytics eventTaxonomy reference), and duration cap. Empty array for flags not driving any experiment — never omit the key.',
+    required: true
+  },
+  {
+    path: 'featureFlags.auditRequirements',
+    description:
+      'Governance posture: who can toggle each flag (role allowlist), whether a change-record is required, audit-log sink, retention window, and stale-flag review cadence. Every toggle MUST emit an audit-log entry with actor + old/new value + reason + environment. Reject any posture that allows a flag to flip without audit.',
+    required: true
+  }
+];
+
+/**
+ * Flat list of owned field paths. Used by `run()` to validate the
+ * subagent's output and by the conformance test suite.
+ */
+export const FEATURE_FLAGGING_OWNED_FIELD_KEYS: readonly string[] =
+  FEATURE_FLAGGING_OWNED_SECTIONS.map(s => s.path);
+
+// ─── Apply predicate ────────────────────────────────────────────────────────
+
+/**
+ * Per spec §2.12 — Feature Flagging runs on tickets that:
+ *
+ *   1. Are explicitly tagged for flag/rollout/experimental treatment, OR
+ *   2. Touch user-facing code (Page/Widget/Story/Form/List) — because
+ *      the architect needs Frontend/Backend output to decide what's
+ *      flag-worthy, and any such ticket may need a kill switch around a
+ *      risky path.
+ *
+ * Foundation tickets only get flagged when explicitly marked
+ * (`deployment`, `experimental`, `flag`, etc.) — pure infra work
+ * usually doesn't ship behind flags.
+ */
+export function featureFlaggingArchitectAppliesPredicate(ticket: Ticket): boolean {
+  const tags = ticket.quality_tags ?? [];
+
+  // Explicit opt-in tags always trigger the architect.
+  const explicitTags = [
+    'flag',
+    'feature-flag',
+    'experimental',
+    'rollout',
+    'canary',
+    'kill-switch',
+    'ab',
+    'ab-test',
+    'ring-deployment'
+  ];
+  for (const t of explicitTags) {
+    if (tags.includes(t)) return true;
+  }
+
+  // User-facing ticket types — Frontend/Backend always produce upstream
+  // output here, so we have something to flag.
+  if (
+    ticket.type === 'Page' ||
+    ticket.type === 'Widget' ||
+    ticket.type === 'Story' ||
+    ticket.type === 'Form' ||
+    ticket.type === 'List'
+  ) {
+    return true;
+  }
+
+  // Foundation only on explicit opt-in (handled above) OR deployment tag.
+  if (ticket.type === 'Foundation' && tags.includes('deployment')) {
+    return true;
+  }
+
+  return false;
+}
+
+// ─── Architect meta ─────────────────────────────────────────────────────────
+
+/**
+ * Feature Flagging is a wave-2 architect — depends on Frontend
+ * (`componentTree`, `interactionStates`) and Backend (`apiEndpoints`)
+ * so it knows what's flag-worthy.
+ *
+ * Spec §2.12 originally put it in wave 1 (with A/B Testing as the
+ * downstream dependent). The task brief flips this: by reading Frontend
+ * + Backend output, Feature Flagging makes informed decisions about
+ * what to gate and where to place kill switches. The architect still
+ * forward-references A/B Testing via `experimentationLinkage`, which
+ * A/B Testing in turn consumes — so the precedence ladder is unchanged.
+ *
+ * Precedence rank 7 per spec §5.2 — rollout safety (between SEO/perf
+ * and API Gateway).
+ */
+export const FEATURE_FLAGGING_ARCHITECT_META: ArchitectMeta = {
+  dependsOn: ['frontend', 'backend'],
+  precedenceLevel: 7,
+  fanoutPolicy: 'always',
+  appliesPredicate: featureFlaggingArchitectAppliesPredicate,
+  runtimeModel: 'sonnet'
+};
+
+// ─── The contract ───────────────────────────────────────────────────────────
+
+export const FeatureFlaggingArchitectContract: ArchitectSectionContract = {
+  contractId: 'feature-flagging-architect.v1',
+  architectName: 'featureFlagging',
+  version: '0.1.0',
+  sections: FEATURE_FLAGGING_OWNED_SECTIONS,
+  architectMeta: FEATURE_FLAGGING_ARCHITECT_META
+};

--- a/packages/feature-flagging-architect/src/index.ts
+++ b/packages/feature-flagging-architect/src/index.ts
@@ -1,0 +1,93 @@
+/**
+ * @caia/feature-flagging-architect — public surface.
+ *
+ * Architect #12 of CAIA's 17-architect EA fan-out. Follows the
+ * @caia/frontend-architect canonical template.
+ *
+ * Two-layer surface:
+ *   - The class + contract — what the EA Dispatcher consumes.
+ *   - Re-exports of run/spawner/validation/invariants for tests + the
+ *     conformance suite.
+ *
+ * Registration: import this package's default `registerWith()` helper
+ * to install the architect on a registry. The package does NOT
+ * self-register on import (registration is an explicit operator action
+ * that the Dispatcher's boot wires up).
+ */
+
+import type { ArchitectRegistry } from './types.js';
+
+import { FeatureFlaggingArchitect } from './architect.js';
+
+// Main exports — the Dispatcher imports these.
+export {
+  FeatureFlaggingArchitect,
+  FEATURE_FLAGGING_ARCHITECT_NAME,
+  FEATURE_FLAGGING_ARCHITECT_TOOLS
+} from './architect.js';
+export type { FeatureFlaggingArchitectConfig } from './architect.js';
+
+export {
+  FeatureFlaggingArchitectContract,
+  FEATURE_FLAGGING_OWNED_SECTIONS,
+  FEATURE_FLAGGING_OWNED_FIELD_KEYS,
+  FEATURE_FLAGGING_FIELD_FIX_HINTS,
+  FEATURE_FLAGGING_ARCHITECT_META,
+  featureFlaggingArchitectAppliesPredicate
+} from './contract.js';
+
+export { buildFeatureFlaggingSystemPrompt } from './system-prompt.js';
+
+// Spawner — exposed so the EA Dispatcher (or tests) can inject a custom one.
+export {
+  createDefaultSpawner,
+  buildSpawnPrompt,
+  modelTagFor
+} from './spawner.js';
+export type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from './spawner.js';
+
+// Run + validation — exposed for the conformance test suite.
+export { runFeatureFlaggingArchitect, buildUserPrompt } from './run.js';
+export type { RunDeps } from './run.js';
+
+export { validateArchitectOutput, stripFences } from './validation.js';
+export type { ValidationError, ValidationResult } from './validation.js';
+
+// Invariants — exposed for the EA Reviewer's registry.
+export { FEATURE_FLAGGING_INVARIANTS } from './invariants.js';
+export type { ArchitectInvariant, InvariantSeverity } from './invariants.js';
+
+// Re-export the canonical kit types so consumers have a single import surface.
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from './types.js';
+
+/**
+ * Register a fresh FeatureFlaggingArchitect on the given registry. The
+ * Dispatcher's boot wiring calls this in its `registry.ts` per spec §7.1.
+ */
+export function registerWith(registry: ArchitectRegistry): FeatureFlaggingArchitect {
+  const architect = new FeatureFlaggingArchitect();
+  registry.register(architect);
+  return architect;
+}

--- a/packages/feature-flagging-architect/src/invariants.ts
+++ b/packages/feature-flagging-architect/src/invariants.ts
@@ -1,0 +1,236 @@
+/**
+ * This architect's contributions to the EA Reviewer's cross-architect
+ * invariants registry (per spec §6.2).
+ *
+ * The Reviewer applies a fixed set of cross-architect predicates after
+ * composition. This module enumerates Feature Flagging's contributions
+ * so the Reviewer's `invariants-registry.ts` (which doesn't exist yet)
+ * can collect them at process boot.
+ *
+ * Each invariant is a pure predicate over either:
+ *   - the per-architect `architectureFields` dict (where keys are FLAT
+ *     dotted strings like `'featureFlags.flagsSchema'`), or
+ *   - the composed `tickets.architecture` JSONB blob (where the
+ *     Dispatcher will nest the same fields under the `featureFlags.*`
+ *     path).
+ *
+ * Both views are accepted — we look up via `readField()` which checks
+ * the flat key first, then falls back to the nested path. This lets the
+ * same invariants run inside the Feature Flagging package's own tests
+ * AND inside the Reviewer's post-composition pass.
+ *
+ * True ⇒ pass; false ⇒ a Reviewer advisory or fail (driven by `severity`).
+ */
+
+export type InvariantSeverity = 'fail' | 'advisory';
+
+export interface ArchitectInvariant {
+  id: string;
+  /** Architect that contributed this invariant. */
+  contributor: string;
+  /** Other architects whose fields this invariant reads. */
+  reads: readonly string[];
+  /** Severity if the predicate returns false. */
+  severity: InvariantSeverity;
+  /** Operator-facing description for the Reviewer's audit log. */
+  description: string;
+  /**
+   * The predicate. Receives the JSONB blob (flat-keyed
+   * `architectureFields` view OR nested composed-architecture view).
+   * Pure + synchronous.
+   */
+  detect(architecture: Readonly<Record<string, unknown>>): boolean;
+}
+
+/**
+ * Read a field from the architecture blob. Tries the flat dotted key
+ * first (matches `architectureFields` shape), then falls back to walking
+ * the nested object path (matches composed-architecture shape).
+ */
+function readField(arch: Readonly<Record<string, unknown>>, path: string): unknown {
+  if (path in arch) return arch[path];
+  const parts = path.split('.');
+  let cursor: unknown = arch;
+  for (const part of parts) {
+    if (typeof cursor !== 'object' || cursor === null) return undefined;
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}
+
+/** Material-blast-radius categories that mandate a kill switch. */
+const BLAST_RADIUS_REQUIRING_KILL_SWITCH = new Set([
+  'auth',
+  'payments',
+  'data-export',
+  'ai-inference',
+  'third-party-spend'
+]);
+
+/**
+ * Feature Flagging's contributed invariants. Listed in stable order.
+ */
+export const FEATURE_FLAGGING_INVARIANTS: readonly ArchitectInvariant[] = [
+  {
+    id: 'featureFlags.flagsSchema-is-array',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.flagsSchema'],
+    severity: 'fail',
+    description:
+      'flagsSchema must be an array. A ticket with zero flags is represented as `[]`; the key must never be omitted or scalar.',
+    detect(arch): boolean {
+      const schema = readField(arch, 'featureFlags.flagsSchema');
+      return Array.isArray(schema);
+    }
+  },
+  {
+    id: 'featureFlags.every-flag-has-rollout',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.flagsSchema', 'featureFlags.rolloutStrategies'],
+    severity: 'fail',
+    description:
+      'Every flag declared in flagsSchema must have a matching entry in rolloutStrategies (referenced by `flag` field). Flags without rollout strategies cannot ship safely.',
+    detect(arch): boolean {
+      const schema = readField(arch, 'featureFlags.flagsSchema');
+      const rollouts = readField(arch, 'featureFlags.rolloutStrategies');
+      if (!Array.isArray(schema) || !Array.isArray(rollouts)) return false;
+      const rolloutFlags = new Set(
+        rollouts
+          .map(r =>
+            typeof r === 'object' && r !== null
+              ? (r as Record<string, unknown>).flag
+              : undefined
+          )
+          .filter(f => typeof f === 'string')
+      );
+      for (const f of schema) {
+        if (typeof f !== 'object' || f === null) return false;
+        const name = (f as Record<string, unknown>).name;
+        if (typeof name !== 'string') return false;
+        if (!rolloutFlags.has(name)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'featureFlags.every-flag-has-audit',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.flagsSchema', 'featureFlags.auditRequirements'],
+    severity: 'fail',
+    description:
+      'Every flag declared in flagsSchema must have a matching entry in auditRequirements. Audit is non-negotiable — no flag flips without an audit trail.',
+    detect(arch): boolean {
+      const schema = readField(arch, 'featureFlags.flagsSchema');
+      const audits = readField(arch, 'featureFlags.auditRequirements');
+      if (!Array.isArray(schema) || !Array.isArray(audits)) return false;
+      const auditedFlags = new Set(
+        audits
+          .map(a =>
+            typeof a === 'object' && a !== null
+              ? (a as Record<string, unknown>).flag
+              : undefined
+          )
+          .filter(f => typeof f === 'string')
+      );
+      for (const f of schema) {
+        if (typeof f !== 'object' || f === null) return false;
+        const name = (f as Record<string, unknown>).name;
+        if (typeof name !== 'string') return false;
+        if (!auditedFlags.has(name)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'featureFlags.kill-switches-are-instant',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.killSwitches'],
+    severity: 'fail',
+    description:
+      'Every entry in killSwitches must have `instantToggle: true`. A kill switch behind multi-step approval is not a kill switch.',
+    detect(arch): boolean {
+      const switches = readField(arch, 'featureFlags.killSwitches');
+      if (!Array.isArray(switches)) return false;
+      for (const s of switches) {
+        if (typeof s !== 'object' || s === null) return false;
+        if ((s as Record<string, unknown>).instantToggle !== true) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'featureFlags.experimentationLinkage-references-known-flags',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.flagsSchema', 'featureFlags.experimentationLinkage'],
+    severity: 'advisory',
+    description:
+      'Every flag referenced in experimentationLinkage should exist in flagsSchema. A linkage to an unknown flag is dead config.',
+    detect(arch): boolean {
+      const schema = readField(arch, 'featureFlags.flagsSchema');
+      const linkage = readField(arch, 'featureFlags.experimentationLinkage');
+      if (!Array.isArray(schema) || !Array.isArray(linkage)) return true; // missing is handled by other invariants
+      const knownFlags = new Set(
+        schema
+          .map(f =>
+            typeof f === 'object' && f !== null
+              ? (f as Record<string, unknown>).name
+              : undefined
+          )
+          .filter(n => typeof n === 'string')
+      );
+      for (const entry of linkage) {
+        if (typeof entry !== 'object' || entry === null) continue;
+        const flag = (entry as Record<string, unknown>).flag;
+        if (typeof flag !== 'string') continue;
+        if (!knownFlags.has(flag)) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'featureFlags.audit-retention-bounded',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.auditRequirements'],
+    severity: 'advisory',
+    description:
+      'Every auditRequirements entry must have `retentionDays >= 1` and `auditLogSink` set. Zero retention or missing sink defeats the audit trail.',
+    detect(arch): boolean {
+      const audits = readField(arch, 'featureFlags.auditRequirements');
+      if (!Array.isArray(audits)) return true;
+      for (const a of audits) {
+        if (typeof a !== 'object' || a === null) return false;
+        const sink = (a as Record<string, unknown>).auditLogSink;
+        const retention = (a as Record<string, unknown>).retentionDays;
+        if (typeof sink !== 'string' || sink.length === 0) return false;
+        if (typeof retention !== 'number' || retention < 1) return false;
+      }
+      return true;
+    }
+  },
+  {
+    id: 'featureFlags.material-blast-radius-has-kill-switch',
+    contributor: 'featureFlagging',
+    reads: ['featureFlags.flagsSchema', 'featureFlags.killSwitches'],
+    severity: 'advisory',
+    description:
+      'If flagsSchema declares a flag whose name/description hints at auth/payments/data-export/ai-inference/third-party-spend, AND killSwitches declares a kill switch with one of those blastRadius values, the flag should be marked. Otherwise the architect missed a required kill switch.',
+    detect(arch): boolean {
+      const switches = readField(arch, 'featureFlags.killSwitches');
+      if (!Array.isArray(switches)) return true;
+      // Sanity: every kill-switch declares one of the canonical
+      // blast-radius categories (or "other"). We don't try to detect
+      // missing kill switches here (that would require name/description
+      // heuristics on flagsSchema, which is brittle) — we just enforce
+      // the schema invariant.
+      for (const s of switches) {
+        if (typeof s !== 'object' || s === null) return false;
+        const br = (s as Record<string, unknown>).blastRadius;
+        if (typeof br !== 'string') return false;
+        if (br !== 'other' && !BLAST_RADIUS_REQUIRING_KILL_SWITCH.has(br)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+];

--- a/packages/feature-flagging-architect/src/run.ts
+++ b/packages/feature-flagging-architect/src/run.ts
@@ -1,0 +1,136 @@
+/**
+ * `run()` — the architect's runtime entry point. Idempotent given
+ * identical input (per spec §1.1).
+ *
+ * Flow:
+ *   1. Build the user prompt by serialising relevant slices of the input.
+ *   2. Call the spawner with the system prompt + user prompt.
+ *   3. Validate the output against the contract.
+ *   4. Return the `ArchitectOutput` with spend telemetry filled in.
+ *
+ * Re-runs REPLACE owned fields (no append) — the architect always emits
+ * the full set of its owned fields fresh.
+ *
+ * Failure handling:
+ *   - Spawner errored → return `status='failed'` with diagnostic.
+ *   - Validator errored → return `status='partial'` with the validation
+ *     errors stitched into `risks[]`.
+ *
+ * Identical in shape to @caia/frontend-architect/src/run.ts. The only
+ * functional difference: this architect's user prompt includes the
+ * Frontend + Backend upstream output (it depends on them).
+ */
+
+import type {
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectSpend
+} from './types.js';
+
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from './contract.js';
+import type { ArchitectSpawnerFn } from './spawner.js';
+import { validateArchitectOutput } from './validation.js';
+
+export interface RunDeps {
+  spawner: ArchitectSpawnerFn;
+  systemPrompt: string;
+  architectName: string;
+}
+
+/**
+ * Project the input down to the JSON body the architect prompt expects.
+ * Privacy-sensitive tenant fields (schemaName, vaultNamespace) are
+ * omitted; the architect doesn't need them.
+ *
+ * Upstream output is included verbatim — Feature Flagging depends on
+ * Frontend (componentTree/interactionStates) and Backend (apiEndpoints)
+ * to know what's flag-worthy.
+ */
+export function buildUserPrompt(input: ArchitectInput): string {
+  const projection = {
+    ticket: input.ticket,
+    businessPlan: input.businessPlan,
+    designVersion: input.designVersion,
+    tenantContext: {
+      tenantId: input.tenantContext.tenantId,
+      billingPosture: input.tenantContext.billingPosture
+    },
+    upstreamOutputs: input.upstream.outputs,
+    reviewerFeedback: input.reviewerFeedback ?? null,
+    budget: {
+      model: input.budget.preferredModel,
+      maxOutputTokens: input.budget.maxOutputTokens
+    }
+  };
+  return JSON.stringify(projection, null, 2);
+}
+
+/**
+ * The runtime entry. Pure aside from the spawner call.
+ */
+export async function runFeatureFlaggingArchitect(
+  input: ArchitectInput,
+  deps: RunDeps
+): Promise<ArchitectOutput> {
+  const userPrompt = buildUserPrompt(input);
+
+  const spawn = await deps.spawner({
+    systemPrompt: deps.systemPrompt,
+    userPrompt,
+    budget: input.budget
+  });
+
+  const spend: ArchitectSpend = {
+    inputTokens: spawn.inputTokens,
+    outputTokens: spawn.outputTokens,
+    usdCost: spawn.usdCost,
+    wallClockMs: spawn.wallClockMs,
+    model: spawn.model
+  };
+
+  if (!spawn.ok) {
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'Spawn failed before any architecture was produced.',
+      dependencies: [],
+      risks: [`spawn failure: ${spawn.diagnostic ?? 'unknown'}`],
+      toolCalls: [],
+      spend,
+      status: 'failed',
+      failureReason: spawn.diagnostic ?? 'spawner returned ok=false'
+    };
+  }
+
+  const validation = validateArchitectOutput(spawn.text, FEATURE_FLAGGING_OWNED_FIELD_KEYS);
+  if (!validation.ok || !validation.parsed) {
+    const errorSummary = validation.errors
+      .slice(0, 5)
+      .map(e => `${e.code}${e.field ? `:${e.field}` : ''}`)
+      .join('; ');
+    return {
+      architectName: deps.architectName,
+      architectureFields: {},
+      confidence: 0,
+      notes: `Validation failed: ${errorSummary}`,
+      dependencies: [],
+      risks: validation.errors.slice(0, 5).map(e => e.message),
+      toolCalls: [],
+      spend,
+      status: 'partial',
+      failureReason: errorSummary
+    };
+  }
+
+  // Idempotency: the architect output OWNS its fields. We do NOT merge
+  // with anything else here — composition happens in the Dispatcher
+  // (spec §3.5). Architects always emit the full set of their owned
+  // fields fresh.
+  const parsed = validation.parsed;
+  return {
+    ...parsed,
+    architectName: deps.architectName, // force-correct in case model echoed wrong
+    spend // overwrite — assistant cannot know real spend
+  };
+}

--- a/packages/feature-flagging-architect/src/spawner.ts
+++ b/packages/feature-flagging-architect/src/spawner.ts
@@ -1,0 +1,161 @@
+/**
+ * Spawner abstraction — wraps `@chiefaia/claude-spawner`'s `spawnClaude`
+ * behind a function-typed seam so the architect's `run()` can be tested
+ * with a deterministic fake.
+ *
+ * The real spawner lives in `@chiefaia/claude-spawner` (subscription-only,
+ * never sets ANTHROPIC_API_KEY — see that package's file-level comment).
+ * This module:
+ *
+ *   - Defines the `ArchitectSpawnerFn` type — the seam every architect's
+ *     run() consumes.
+ *   - Provides `createDefaultSpawner()` — wires up the real
+ *     `spawnClaude` with the appropriate model + timeout + system prompt.
+ *
+ * Per spec §4 the EA Dispatcher itself runs in the operator's existing
+ * orchestrator process; only the architect subagent spawns issue LLM
+ * calls. This module is the per-architect spawn surface.
+ *
+ * Identical in shape to @caia/frontend-architect/src/spawner.ts.
+ */
+
+import {
+  spawnClaude,
+  parseClaudeJsonEnvelope,
+  type SpawnClaudeResult
+} from '@chiefaia/claude-spawner';
+
+import type { ArchitectBudget } from './types.js';
+
+/**
+ * Inputs to a single spawn — system prompt + user prompt + budget.
+ */
+export interface ArchitectSpawnInput {
+  systemPrompt: string;
+  userPrompt: string;
+  budget: ArchitectBudget;
+}
+
+/**
+ * Output of a single spawn — the raw assistant text plus telemetry.
+ * Parsing into a structured `ArchitectOutput` happens in `run()`, not
+ * here, so the spawner stays generic across architects.
+ */
+export interface ArchitectSpawnOutput {
+  /** The assistant's final message — expected to be a JSON-shaped string. */
+  text: string;
+  /** Best-effort token + cost telemetry from the envelope. */
+  inputTokens: number;
+  outputTokens: number;
+  usdCost: number;
+  wallClockMs: number;
+  /** Echoed back from input. */
+  model: string;
+  /** True iff the spawn succeeded and the envelope was parsed cleanly. */
+  ok: boolean;
+  /** Diagnostic when `ok=false`. */
+  diagnostic: string | null;
+}
+
+/**
+ * The seam every architect's `run()` consumes. Inject a fake in tests.
+ */
+export type ArchitectSpawnerFn = (input: ArchitectSpawnInput) => Promise<ArchitectSpawnOutput>;
+
+/**
+ * Map the architect-budget model preference to the `claude` binary's
+ * `--model` flag value. The mapping mirrors what local-llm-router uses
+ * elsewhere in the monorepo.
+ */
+export function modelTagFor(preferred: 'haiku' | 'sonnet' | 'opus'): string {
+  switch (preferred) {
+    case 'haiku':
+      return 'claude-haiku-4-5';
+    case 'opus':
+      return 'claude-opus-4-6';
+    case 'sonnet':
+    default:
+      return 'claude-sonnet-4-6';
+  }
+}
+
+/**
+ * Build the canonical user-message body. The system prompt is fed as
+ * the first user-message paragraph (rather than via `claude`'s
+ * `--system` flag) — keeps the spawner surface narrow and lets the
+ * test seam see everything in one string.
+ */
+export function buildSpawnPrompt(input: ArchitectSpawnInput): string {
+  return [
+    '# System briefing',
+    '',
+    input.systemPrompt,
+    '',
+    '# Task input',
+    '',
+    input.userPrompt,
+    '',
+    '# Response contract',
+    '',
+    'Respond with a SINGLE JSON object matching the schema in the system briefing.',
+    'No prose outside the JSON. No code fences. Just the JSON.'
+  ].join('\n');
+}
+
+/**
+ * Wire the real `spawnClaude` into an `ArchitectSpawnerFn`. Used by
+ * `FeatureFlaggingArchitect` when no spawner is injected.
+ */
+export function createDefaultSpawner(): ArchitectSpawnerFn {
+  return async function defaultSpawner(input: ArchitectSpawnInput): Promise<ArchitectSpawnOutput> {
+    const prompt = buildSpawnPrompt(input);
+    const t0 = Date.now();
+    const result: SpawnClaudeResult = await spawnClaude({
+      prompt,
+      options: {
+        model: modelTagFor(input.budget.preferredModel),
+        timeoutMs: input.budget.maxWallClockMs,
+        outputFormat: 'json'
+      }
+    });
+    const wallClockMs = Date.now() - t0;
+
+    if (!result.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: result.diagnostic ?? 'spawnClaude returned ok=false'
+      };
+    }
+
+    const parsed = parseClaudeJsonEnvelope(result.stdout);
+    if (!parsed.ok) {
+      return {
+        text: '',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 0,
+        wallClockMs,
+        model: modelTagFor(input.budget.preferredModel),
+        ok: false,
+        diagnostic: parsed.diagnostic
+      };
+    }
+
+    return {
+      text: parsed.text,
+      inputTokens: parsed.envelope.usage?.input_tokens ?? 0,
+      outputTokens: parsed.envelope.usage?.output_tokens ?? 0,
+      usdCost: parsed.envelope.total_cost_usd ?? 0,
+      wallClockMs,
+      model: modelTagFor(input.budget.preferredModel),
+      ok: true,
+      diagnostic: null
+    };
+  };
+}

--- a/packages/feature-flagging-architect/src/system-prompt.md
+++ b/packages/feature-flagging-architect/src/system-prompt.md
@@ -1,0 +1,41 @@
+# Feature Flagging Architect — system briefing (markdown source)
+
+This file is the markdown-rendered source of truth for the architect's
+system prompt. The TypeScript `system-prompt.ts` builds the runtime
+prompt by composing the same sections programmatically (so test fixtures
+can assert exact substrings). When you update the prompt, update both —
+the tests catch drift.
+
+## Role
+
+You are CAIA's Feature Flagging Architect. You are a senior platform
+engineer focused on feature-flagging best practices.
+
+You produce per-ticket feature-flag specs. You DO NOT write component
+code or backend logic. You DO specify what gets toggleable, at what
+granularity, and what the rollout strategy is.
+
+## Locked stack (rollout posture)
+
+- OpenFeature-compatible flag schemas.
+- Per-environment defaults (dev, staging, production at minimum).
+- Canary rollouts default: 1% → 10% → 50% → 100%, 30-min soak per stage.
+- Auto-rollback on 5xx spike >2x baseline.
+- Audit log: every toggle event MUST log actor, flag, old/new value,
+  reason, timestamp, environment.
+
+## Owned fields
+
+- `featureFlags.flagsSchema`
+- `featureFlags.rolloutStrategies`
+- `featureFlags.killSwitches`
+- `featureFlags.experimentationLinkage`
+- `featureFlags.auditRequirements`
+
+## Refusal patterns
+
+- Never invent a flag not implied by the ticket.
+- Never gate a kill switch behind multi-step approval.
+- Never allow a flag to flip without an audit log entry.
+- Never write component code or backend logic — those belong to the
+  Frontend Architect and Backend Architect.

--- a/packages/feature-flagging-architect/src/system-prompt.ts
+++ b/packages/feature-flagging-architect/src/system-prompt.ts
@@ -1,0 +1,217 @@
+/**
+ * The Feature Flagging Architect's system prompt — a pure function
+ * returning a static string. No runtime state.
+ *
+ * Per spec §1.1, `systemPrompt()` is a method on `SpecialistArchitect`
+ * and must be deterministic; the briefing is what turns generic Claude
+ * into this specialist.
+ *
+ * Structure follows spec §11(b):
+ *   1. Role
+ *   2. Locked rollout posture
+ *   3. Input format
+ *   4. Output JSON schema (field-by-field)
+ *   5. Decision heuristics
+ *   6. Refusal patterns
+ *   7. Self-check
+ *   8. Examples (terse — golden test fixture is the canonical example)
+ *
+ * The system-prompt test asserts each `featureFlags.*` field name appears
+ * at least once in the body. Keep that invariant true if you add fields.
+ *
+ * Sibling source-of-truth: `./system-prompt.md` keeps a markdown
+ * rendering of the same content for human reviewers; the tests compare
+ * substrings between the two to catch drift.
+ */
+
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from './contract.js';
+
+/**
+ * Build the system prompt. Pure function; identical output every call.
+ */
+export function buildFeatureFlaggingSystemPrompt(): string {
+  return [
+    SECTION_ROLE,
+    SECTION_LOCKED_POSTURE,
+    SECTION_INPUT_FORMAT,
+    SECTION_OUTPUT_SCHEMA,
+    SECTION_DECISION_HEURISTICS,
+    SECTION_REFUSAL_PATTERNS,
+    SECTION_SELF_CHECK,
+    SECTION_EXAMPLES
+  ].join('\n\n');
+}
+
+// ─── Section bodies ─────────────────────────────────────────────────────────
+
+const SECTION_ROLE = `## Role
+
+You are CAIA's Feature Flagging Architect. You are a senior platform
+engineer focused on feature-flagging best practices. You produce
+per-ticket feature-flag specs.
+
+You DO NOT write component code or backend logic.
+You DO specify what gets toggleable, at what granularity, and what the rollout strategy is.
+
+Other architects own component code (Frontend Architect) and backend
+logic (Backend Architect); they will reject any field you populate
+outside the \`featureFlags.*\` namespace.`;
+
+const SECTION_LOCKED_POSTURE = `## Locked rollout posture
+
+- **Schema**: OpenFeature-compatible. Flag types are \`boolean\`, \`string\`,
+  \`number\`, or \`json\`. Names are kebab-case, namespaced by ticket id:
+  \`<ticket-id>.<flag-slug>\`.
+- **Environments**: every flag declares defaults for \`dev\`, \`staging\`,
+  and \`production\` at minimum. Default default is "off" (\`false\` / \`null\` /
+  empty).
+- **Rollout default**: canary curve 1% → 10% → 50% → 100% with a 30-min soak per stage, auto-rollback on 5xx error_rate spike >2x baseline.
+- **Kill switches**: anything gating auth, payments, data export, AI
+  inference, or third-party API spend MUST be a kill switch — flippable
+  in <30s, no multi-step approval.
+- **Audit**: every toggle event logs actor, flag, old/new value, reason,
+  timestamp, environment. Default retention 365 days. Stale-flag review
+  every 90 days.
+- **Experimentation**: experiment-driving flags forward-reference the
+  A/B Testing Architect via \`experimentationLinkage\`.
+
+Reject any decision that violates the locked posture. If a ticket
+explicitly asks for an off-posture choice (e.g. "skip the audit log"),
+surface it under \`risks[]\` and apply the locked default anyway.`;
+
+const SECTION_INPUT_FORMAT = `## Input format
+
+You receive a JSON object with this shape:
+
+\`\`\`json
+{
+  "ticket": { "id": "...", "type": "Page|Widget|Story|Form|List|Foundation",
+              "scope": "story|task|module", "title": "...",
+              "description": "...", "acceptanceCriteria": ["..."],
+              "quality_tags": ["flag", "experimental", "rollout", ...] },
+  "businessPlan": { "ventureName": "...", "oneLiner": "...",
+                    "audience": "...", "goals": ["..."], "constraints": ["..."] },
+  "designVersion": { "versionId": "...", "tokens": { ... }, "anchors": [...] },
+  "tenantContext": { "tenantId": "...", "billingPosture": "subscription|..." },
+  "budget": { "preferredModel": "sonnet|opus", ... },
+  "upstream": { "outputs": {
+    "frontend": { "architectureFields": { "frontend.componentTree": [...],
+                                          "frontend.interactionStates": {...},
+                                          ... } },
+    "backend":  { "architectureFields": { "backend.apiEndpoints": [...],
+                                          ... } }
+  } }
+}
+\`\`\`
+
+Read \`upstream.outputs.frontend\` and \`upstream.outputs.backend\` to know
+what's flag-worthy. The Frontend componentTree tells you which UI
+surfaces could vary by variant; the Backend apiEndpoints tells you
+which write/auth/payment paths need kill switches.`;
+
+const SECTION_OUTPUT_SCHEMA = `## Output JSON schema
+
+You MUST output a single JSON object matching this exact shape. No prose
+outside the JSON. No code fences. Just the JSON.
+
+\`\`\`json
+{
+  "architectName": "featureFlagging",
+  "architectureFields": {
+${FEATURE_FLAGGING_OWNED_FIELD_KEYS.map(k => `    "${k}": <see below>`).join(',\n')}
+  },
+  "confidence": <number 0..1>,
+  "notes": "<= 800 chars human-readable rationale",
+  "dependencies": ["<sibling ticket ids>"],
+  "risks": ["<= 5 risk callouts"],
+  "toolCalls": [],
+  "spend": { "inputTokens": 0, "outputTokens": 0, "costUsd": 0,
+             "wallClockMs": 0, "model": "sonnet" },
+  "status": "ok"
+}
+\`\`\`
+
+### Per-field guidance
+
+- \`featureFlags.flagsSchema\` — \`[{"name":"ticket-001.new-checkout","type":"boolean","description":"Gates the new checkout flow","defaults":{"dev":true,"staging":false,"production":false},"audience":{"kind":"percentage","value":0}}]\`. Flag names kebab-case, namespaced by ticket id.
+- \`featureFlags.rolloutStrategies\` — \`[{"flag":"ticket-001.new-checkout","kind":"canary","steps":[{"stage":"canary","percent":1,"gateMetric":"error_rate<0.5%","soakMinutes":30},{"stage":"early","percent":10,"gateMetric":"error_rate<0.5%","soakMinutes":60},{"stage":"broad","percent":50,"gateMetric":"error_rate<0.5%","soakMinutes":120},{"stage":"ga","percent":100}],"autoPromote":true,"rollbackTrigger":"5xx_rate>2x_baseline"}]\`.
+- \`featureFlags.killSwitches\` — \`[{"flag":"ticket-001.checkout-payments-on","blastRadius":"payments","instantToggle":true,"bypassReviewQuorum":true,"notificationChannels":["pager:oncall","slack:#payments-incidents"]}]\`. Required only for flags whose code path has material blast radius.
+- \`featureFlags.experimentationLinkage\` — \`[{"flag":"ticket-001.new-checkout","abTestId":"abtest-pending","variants":[{"variantKey":"control","flagValue":false,"allocation":0.5},{"variantKey":"treatment","flagValue":true,"allocation":0.5}],"holdoutPercent":5,"primaryMetric":"checkout_completed","startDate":"2026-06-01","durationCapDays":28}]\`. Empty array for flags not driving any experiment — never omit the key.
+- \`featureFlags.auditRequirements\` — \`[{"flag":"ticket-001.new-checkout","toggleRoles":["operator","oncall"],"requiresChangeRecord":true,"auditLogSink":"default-cloudwatch","retentionDays":365,"reviewCadenceDays":90}]\`. Every flag must have an entry. Every toggle event logs actor+flag+oldValue+newValue+timestamp+reason+environment.`;
+
+const SECTION_DECISION_HEURISTICS = `## Decision heuristics
+
+- **Read upstream before deciding what to flag.** The Frontend
+  componentTree's interactive widgets are the canonical "flag-worthy UI
+  surfaces". The Backend apiEndpoints' write/auth/payment routes are the
+  canonical kill-switch candidates.
+- **Default to "off" in production.** Every new flag ships closed.
+  Operators flip it on after rollout-gate metrics are clean.
+- **Kill switches are required for material blast radius.** Auth,
+  payments, data export, AI inference, third-party API spend → kill
+  switch is mandatory. Trivial UI tweaks don't need one.
+- **Canary by default.** Use \`all-at-once\` only when the change is
+  reversible without user impact (a copy tweak, a layout shift).
+- **Experiments require holdout + duration cap.** Default 5% holdout,
+  28-day cap. The actual stats live in the A/B Testing Architect's
+  output — this architect declares the binding.
+- **Audit is non-negotiable.** Every toggle, every environment, every
+  flag. No exceptions.
+- **Stale-flag GC.** Default 90-day review cadence — flags older than
+  that get pinged for cleanup. Operator can opt out per flag, but the
+  cadence field is always present.`;
+
+const SECTION_REFUSAL_PATTERNS = `## Refusal patterns
+
+If the input asks you to:
+
+- **Invent a flag not implied by the ticket** → refuse, omit the flag,
+  list the missing motivation under \`risks[]\`.
+- **Skip a kill switch on a material-blast-radius code path** → refuse,
+  add the kill switch anyway, list the request under \`risks[]\`,
+  set \`confidence\` to 0.5.
+- **Allow a flag to flip without an audit log entry** → refuse, always
+  emit \`auditRequirements\` with audit log enabled, list the request
+  under \`risks[]\`.
+- **Write component code, JSX, API handlers, database queries, or any
+  field NOT under \`featureFlags.*\`** → ignore the request. Do not
+  populate fields outside your owned namespace.
+- **Gate a kill switch behind a multi-step approval flow** → refuse.
+  Kill switches MUST be flippable in <30s.
+- **Skip an owned field** → never. Every key in \`architectureFields\`
+  must be populated even if the value is an empty array (for tickets
+  that introduce no flags, all five fields are empty arrays).`;
+
+const SECTION_SELF_CHECK = `## Self-check before output
+
+Verify in order:
+
+1. Every key under \`architectureFields\` is one of the 5 owned field
+   paths (no extras, no missing).
+2. Every flag in \`flagsSchema\` has a matching entry in
+   \`rolloutStrategies\` and \`auditRequirements\`.
+3. Every material-blast-radius flag (auth/payments/data-export/
+   ai-inference/third-party-spend) appears in \`killSwitches\`.
+4. Every entry in \`killSwitches\` has \`instantToggle: true\`.
+5. Every entry in \`experimentationLinkage\` references a flag that
+   exists in \`flagsSchema\` (or the array is empty).
+6. Every audit-requirements entry has \`auditLogSink\` set and
+   \`retentionDays >= 1\`.
+7. \`confidence\` reflects how comfortable you are with the rollout
+   posture — sub-0.6 triggers the EA Reviewer to scrutinize.
+8. \`notes\` is ≤ 800 characters.
+9. Output is a single JSON object. No prose. No code fences.`;
+
+const SECTION_EXAMPLES = `## Examples
+
+A canonical input → output pair lives in the package's
+\`tests/golden/\` directory and is the source of truth for "what good
+looks like". When in doubt, mirror its shape.
+
+For brevity here: a new-checkout-flow ticket with one boolean flag
+\`ticket-001.new-checkout\` produces (a) flagsSchema with a single entry
+defaulting off in production, (b) a canary rollout strategy with the
+1/10/50/100 curve, (c) one kill switch (blastRadius="payments"), (d) an
+experimentationLinkage entry with control+treatment variants and 5%
+holdout, (e) an auditRequirements entry with the default
+cloudwatch sink and 365-day retention.`;

--- a/packages/feature-flagging-architect/src/types.ts
+++ b/packages/feature-flagging-architect/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Type re-exports — the canonical defs live in `@caia/architect-kit`
+ * (sibling package; landed on develop via PR #535).
+ *
+ * This module exists as a thin re-export so the rest of this package
+ * has a single import surface. Mirrors the @caia/frontend-architect
+ * template verbatim — only the architect-specific field-spec lives in
+ * `./contract.ts`.
+ */
+
+export type {
+  SpecialistArchitect,
+  ArchitectInput,
+  ArchitectOutput,
+  ArchitectUpstreamContext,
+  ArchitectBudget,
+  ArchitectSpend,
+  ArchitectToolCall,
+  ReviewerFeedback,
+  Ticket,
+  BusinessPlan,
+  RenderableDesign,
+  TenantContext,
+  ToolDefinition,
+  ArchitectName,
+  ArchitectSectionContract,
+  ArchitectSectionSpec,
+  ArchitectMeta,
+  FanoutPolicy
+} from '@caia/architect-kit';
+
+export {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  BaseArchitect,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  findOverlappingPaths,
+  precedenceRank
+} from '@caia/architect-kit';

--- a/packages/feature-flagging-architect/src/validation.ts
+++ b/packages/feature-flagging-architect/src/validation.ts
@@ -1,0 +1,207 @@
+/**
+ * Output validation — defensive checks on what the subagent returns
+ * before we hand the `ArchitectOutput` back to the Dispatcher.
+ *
+ * Two layers:
+ *
+ *   1. **Structural** — does the JSON parse, and does it have the
+ *      required top-level keys (`architectName`, `architectureFields`,
+ *      `confidence`, `notes`, `dependencies`, `risks`, `toolCalls`,
+ *      `spend`, `status`)?
+ *
+ *   2. **Contract** — does `architectureFields` contain exactly the keys
+ *      this architect owns (no extras, no missing)? This is the
+ *      Dispatcher's first invariant per spec §3.4.
+ *
+ * The validator is pure + synchronous. Failures return a structured
+ * `ValidationResult.errors[]` array — the architect's `run()` decides
+ * whether to retry, mark partial, or mark failed.
+ *
+ * Identical in shape to @caia/frontend-architect/src/validation.ts.
+ */
+
+import type { ArchitectOutput } from './types.js';
+
+export interface ValidationError {
+  code:
+    | 'invalid-json'
+    | 'missing-top-level-key'
+    | 'wrong-top-level-type'
+    | 'missing-owned-field'
+    | 'unexpected-field'
+    | 'confidence-out-of-range'
+    | 'notes-too-long'
+    | 'too-many-risks'
+    | 'invalid-status';
+  message: string;
+  field?: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: readonly ValidationError[];
+  parsed?: ArchitectOutput;
+}
+
+const TOP_LEVEL_KEYS = [
+  'architectName',
+  'architectureFields',
+  'confidence',
+  'notes',
+  'dependencies',
+  'risks',
+  'toolCalls',
+  'spend',
+  'status'
+] as const;
+
+const ALLOWED_STATUSES: readonly string[] = ['ok', 'partial', 'failed'];
+const MAX_NOTES_CHARS = 800;
+const MAX_RISKS = 5;
+
+export function validateArchitectOutput(
+  text: string,
+  ownedFieldKeys: readonly string[]
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripFences(text));
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'invalid-json',
+          message: `Failed to JSON.parse: ${(err as Error).message}`
+        }
+      ]
+    };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errors: [
+        {
+          code: 'wrong-top-level-type',
+          message: 'Top-level value must be a JSON object.'
+        }
+      ]
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in obj)) {
+      errors.push({
+        code: 'missing-top-level-key',
+        message: `Missing required top-level key: '${key}'.`,
+        field: key
+      });
+    }
+  }
+
+  if ('architectureFields' in obj) {
+    const fields = obj.architectureFields;
+    if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
+      errors.push({
+        code: 'wrong-top-level-type',
+        message: '`architectureFields` must be a JSON object.',
+        field: 'architectureFields'
+      });
+    } else {
+      const present = new Set(Object.keys(fields as Record<string, unknown>));
+      for (const owned of ownedFieldKeys) {
+        if (!present.has(owned)) {
+          errors.push({
+            code: 'missing-owned-field',
+            message: `architectureFields is missing owned field '${owned}'.`,
+            field: owned
+          });
+        }
+      }
+      for (const got of present) {
+        if (!ownedFieldKeys.includes(got)) {
+          errors.push({
+            code: 'unexpected-field',
+            message: `architectureFields contains '${got}' which is not owned by this architect.`,
+            field: got
+          });
+        }
+      }
+    }
+  }
+
+  if ('confidence' in obj) {
+    const c = obj.confidence;
+    if (typeof c !== 'number' || c < 0 || c > 1 || Number.isNaN(c)) {
+      errors.push({
+        code: 'confidence-out-of-range',
+        message: 'confidence must be a number in [0, 1].',
+        field: 'confidence'
+      });
+    }
+  }
+
+  if ('notes' in obj) {
+    const n = obj.notes;
+    if (typeof n === 'string' && n.length > MAX_NOTES_CHARS) {
+      errors.push({
+        code: 'notes-too-long',
+        message: `notes must be <= ${MAX_NOTES_CHARS} chars; got ${n.length}.`,
+        field: 'notes'
+      });
+    }
+  }
+
+  if ('risks' in obj) {
+    const r = obj.risks;
+    if (Array.isArray(r) && r.length > MAX_RISKS) {
+      errors.push({
+        code: 'too-many-risks',
+        message: `risks must have <= ${MAX_RISKS} entries; got ${r.length}.`,
+        field: 'risks'
+      });
+    }
+  }
+
+  if ('status' in obj) {
+    const s = obj.status;
+    if (typeof s !== 'string' || !ALLOWED_STATUSES.includes(s)) {
+      errors.push({
+        code: 'invalid-status',
+        message: `status must be one of ${ALLOWED_STATUSES.join('|')}; got '${String(s)}'.`,
+        field: 'status'
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    parsed: obj as unknown as ArchitectOutput
+  };
+}
+
+/**
+ * Strip ``` fences if the assistant slipped them around its JSON.
+ */
+export function stripFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const lines = trimmed.split('\n');
+    lines.shift();
+    if (lines[lines.length - 1]?.trim() === '```') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+  return trimmed;
+}

--- a/packages/feature-flagging-architect/tests/architect.test.ts
+++ b/packages/feature-flagging-architect/tests/architect.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `FeatureFlaggingArchitect` — interface compliance tests.
+ *
+ * Verifies the class adheres to `SpecialistArchitect` per spec §1.1 and
+ * satisfies SpecialistArchitect structurally (will extend BaseArchitect
+ * when the kit lands on develop).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { SpecialistArchitect } from '../src/types.js';
+
+import {
+  FeatureFlaggingArchitect,
+  FEATURE_FLAGGING_ARCHITECT_NAME,
+  FEATURE_FLAGGING_ARCHITECT_TOOLS
+} from '../src/architect.js';
+import { FeatureFlaggingArchitectContract } from '../src/contract.js';
+import { buildFakeInput, fakeGoldenSpawner } from './helpers/fakes.js';
+
+describe('FeatureFlaggingArchitect — SpecialistArchitect interface compliance', () => {
+  it('exports a class that can be instantiated without args', () => {
+    const a = new FeatureFlaggingArchitect();
+    expect(a).toBeInstanceOf(FeatureFlaggingArchitect);
+  });
+
+  it('satisfies SpecialistArchitect structurally', () => {
+    const a = new FeatureFlaggingArchitect();
+    expect(typeof a.run).toBe('function');
+    expect(typeof a.systemPrompt).toBe('function');
+    expect(a.sectionContract).toBeTruthy();
+  });
+
+  it('exposes a stable `name` matching the canonical ladder entry', () => {
+    const a = new FeatureFlaggingArchitect();
+    expect(a.name).toBe('featureFlagging');
+    expect(a.name).toBe(FEATURE_FLAGGING_ARCHITECT_NAME);
+  });
+
+  it('exposes `sectionContract` that equals the exported contract', () => {
+    const a = new FeatureFlaggingArchitect();
+    expect(a.sectionContract).toBe(FeatureFlaggingArchitectContract);
+  });
+
+  it('sectionContract.architectName matches `name` (registry-invariant)', () => {
+    const a = new FeatureFlaggingArchitect();
+    expect(a.sectionContract.architectName).toBe(a.name);
+  });
+
+  it('exposes empty `tools` array per V1 spec §2.12', () => {
+    const a = new FeatureFlaggingArchitect();
+    expect(a.tools).toBe(FEATURE_FLAGGING_ARCHITECT_TOOLS);
+    expect(a.tools).toEqual([]);
+    expect(a.tools.length).toBe(0);
+  });
+
+  it('`systemPrompt()` is a pure function (identical output every call)', () => {
+    const a = new FeatureFlaggingArchitect();
+    const p1 = a.systemPrompt();
+    const p2 = a.systemPrompt();
+    const p3 = a.systemPrompt();
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+  });
+
+  it('`systemPrompt()` returns a non-empty string', () => {
+    const a = new FeatureFlaggingArchitect();
+    const p = a.systemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(100);
+  });
+
+  it('satisfies the `SpecialistArchitect` interface (structural)', () => {
+    const a = new FeatureFlaggingArchitect();
+    const view: SpecialistArchitect = a;
+    expect(view.name).toBeTruthy();
+    expect(view.sectionContract).toBeTruthy();
+    expect(typeof view.systemPrompt).toBe('function');
+    expect(typeof view.run).toBe('function');
+    expect(Array.isArray(view.tools)).toBe(true);
+  });
+
+  it('`run()` returns a Promise<ArchitectOutput>', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new FeatureFlaggingArchitect({ spawner });
+    const result = a.run(buildFakeInput());
+    expect(result).toBeInstanceOf(Promise);
+    const out = await result;
+    expect(out.architectName).toBe('featureFlagging');
+  });
+
+  it('constructor accepts an injected spawner (test seam)', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    const a = new FeatureFlaggingArchitect({ spawner });
+    await a.run(buildFakeInput());
+    expect(calls.length).toBe(1);
+  });
+
+  it('constructor with no spawner falls back to the default (smoke check, no real spawn)', () => {
+    // Just instantiating should not error. We do NOT call run() here
+    // because that would invoke the real claude binary.
+    const a = new FeatureFlaggingArchitect();
+    expect(a).toBeInstanceOf(FeatureFlaggingArchitect);
+    expect(typeof a.systemPrompt).toBe('function');
+  });
+});

--- a/packages/feature-flagging-architect/tests/contract.test.ts
+++ b/packages/feature-flagging-architect/tests/contract.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Section contract structural + registration tests.
+ *
+ * Verifies per spec §1.3:
+ *   - All declared fields use the `featureFlags.*` namespace.
+ *   - Every owned field has a non-empty description and is required.
+ *   - `architectMeta` is well-formed (precedence in [1,17], etc).
+ *   - The architect registers cleanly against the ArchitectRegistry.
+ *   - A second architect with overlapping paths is rejected.
+ *   - The canonical precedence ladder lists `featureFlagging`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  ArchitectRegistry,
+  ArchitectRegistryError,
+  CANONICAL_PRECEDENCE_LADDER,
+  contractPaths,
+  disjointness,
+  findDuplicatePaths,
+  precedenceRank,
+  type ArchitectInput,
+  type ArchitectOutput,
+  type ArchitectSectionContract,
+  type SpecialistArchitect,
+  type ToolDefinition
+} from '../src/types.js';
+
+import { FeatureFlaggingArchitect } from '../src/architect.js';
+import {
+  FEATURE_FLAGGING_ARCHITECT_META,
+  FEATURE_FLAGGING_FIELD_FIX_HINTS,
+  FEATURE_FLAGGING_OWNED_FIELD_KEYS,
+  FEATURE_FLAGGING_OWNED_SECTIONS,
+  FeatureFlaggingArchitectContract,
+  featureFlaggingArchitectAppliesPredicate
+} from '../src/contract.js';
+
+describe('FeatureFlaggingArchitectContract — structural', () => {
+  it('contractId follows the canonical `<name>-architect.v<major>` form', () => {
+    expect(FeatureFlaggingArchitectContract.contractId).toBe('feature-flagging-architect.v1');
+  });
+
+  it('architectName is `featureFlagging` (matches ladder entry)', () => {
+    expect(FeatureFlaggingArchitectContract.architectName).toBe('featureFlagging');
+  });
+
+  it('version follows semver-ish shape', () => {
+    expect(FeatureFlaggingArchitectContract.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('all owned field paths begin with `featureFlags.`', () => {
+    for (const key of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+      expect(key.startsWith('featureFlags.')).toBe(true);
+    }
+  });
+
+  it('owned-field set covers the task-brief mandatory fields', () => {
+    const required = [
+      'featureFlags.flagsSchema',
+      'featureFlags.rolloutStrategies',
+      'featureFlags.killSwitches',
+      'featureFlags.experimentationLinkage',
+      'featureFlags.auditRequirements'
+    ];
+    for (const r of required) {
+      expect(FEATURE_FLAGGING_OWNED_FIELD_KEYS).toContain(r);
+    }
+  });
+
+  it('owns exactly 5 fields (the task brief target)', () => {
+    expect(FEATURE_FLAGGING_OWNED_FIELD_KEYS.length).toBe(5);
+  });
+
+  it('every owned section has a non-empty description and is required', () => {
+    for (const spec of FEATURE_FLAGGING_OWNED_SECTIONS) {
+      expect(spec.description.trim().length).toBeGreaterThan(10);
+      expect(spec.required).toBe(true);
+      expect(spec.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('field keys are globally unique within the contract', () => {
+    expect(findDuplicatePaths(FeatureFlaggingArchitectContract)).toEqual([]);
+  });
+
+  it('contractPaths() returns the full owned field set', () => {
+    expect(contractPaths(FeatureFlaggingArchitectContract).sort()).toEqual(
+      [...FEATURE_FLAGGING_OWNED_FIELD_KEYS].sort()
+    );
+  });
+
+  it('every owned field has a fix-hint entry', () => {
+    for (const key of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+      expect(FEATURE_FLAGGING_FIELD_FIX_HINTS[key]).toBeTruthy();
+      expect(FEATURE_FLAGGING_FIELD_FIX_HINTS[key].length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('FeatureFlaggingArchitectContract — architectMeta', () => {
+  it('declares Frontend + Backend dependencies (wave-2 architect per task brief)', () => {
+    expect(FEATURE_FLAGGING_ARCHITECT_META.dependsOn).toEqual(['frontend', 'backend']);
+  });
+
+  it('precedence level is in the legal [1, 17] range', () => {
+    expect(FEATURE_FLAGGING_ARCHITECT_META.precedenceLevel).toBeGreaterThanOrEqual(1);
+    expect(FEATURE_FLAGGING_ARCHITECT_META.precedenceLevel).toBeLessThanOrEqual(17);
+  });
+
+  it('precedence level is 7 per spec §5.2', () => {
+    expect(FEATURE_FLAGGING_ARCHITECT_META.precedenceLevel).toBe(7);
+  });
+
+  it('fanoutPolicy is `always`', () => {
+    expect(FEATURE_FLAGGING_ARCHITECT_META.fanoutPolicy).toBe('always');
+  });
+
+  it('runtimeModel is `sonnet` per spec §2.12', () => {
+    expect(FEATURE_FLAGGING_ARCHITECT_META.runtimeModel).toBe('sonnet');
+  });
+
+  it('appliesPredicate is the exported function reference', () => {
+    expect(FEATURE_FLAGGING_ARCHITECT_META.appliesPredicate).toBe(
+      featureFlaggingArchitectAppliesPredicate
+    );
+  });
+
+  it('matches the canonical precedence ladder for `featureFlagging`', () => {
+    expect(precedenceRank('featureFlagging')).toBe(
+      FEATURE_FLAGGING_ARCHITECT_META.precedenceLevel
+    );
+    expect(CANONICAL_PRECEDENCE_LADDER).toContain('featureFlagging');
+  });
+});
+
+describe('featureFlaggingArchitectAppliesPredicate', () => {
+  const baseTicket = { id: 't1', type: 'Story' };
+
+  it('returns true for any ticket tagged `flag`', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['flag']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for `feature-flag` tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['feature-flag']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for `experimental` tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['experimental']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for `rollout` tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['rollout']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for `canary` tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['canary']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for `kill-switch` tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['kill-switch']
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for `ab` / `ab-test` / `ring-deployment` tags', () => {
+    for (const tag of ['ab', 'ab-test', 'ring-deployment']) {
+      expect(
+        featureFlaggingArchitectAppliesPredicate({
+          ...baseTicket,
+          type: 'Foundation',
+          quality_tags: [tag]
+        })
+      ).toBe(true);
+    }
+  });
+
+  it('returns true for Page tickets (user-facing default)', () => {
+    expect(featureFlaggingArchitectAppliesPredicate({ ...baseTicket, type: 'Page' })).toBe(
+      true
+    );
+  });
+
+  it('returns true for Widget, Story, Form, List tickets', () => {
+    for (const t of ['Widget', 'Story', 'Form', 'List']) {
+      expect(featureFlaggingArchitectAppliesPredicate({ ...baseTicket, type: t })).toBe(true);
+    }
+  });
+
+  it('returns false for plain Foundation tickets without any opt-in tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['infra']
+      })
+    ).toBe(false);
+  });
+
+  it('returns true for Foundation with `deployment` tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Foundation',
+        quality_tags: ['deployment']
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for an unrecognised type with no tags', () => {
+    expect(featureFlaggingArchitectAppliesPredicate({ ...baseTicket, type: 'Cron' })).toBe(
+      false
+    );
+  });
+
+  it('returns false for tickets with neither type match nor opt-in tag', () => {
+    expect(
+      featureFlaggingArchitectAppliesPredicate({
+        ...baseTicket,
+        type: 'Unknown',
+        quality_tags: []
+      })
+    ).toBe(false);
+  });
+});
+
+/**
+ * Minimal stub architect used to test disjointness rejection.
+ */
+class StubArchitect implements SpecialistArchitect {
+  readonly tools: readonly ToolDefinition[] = [];
+  constructor(
+    readonly name: string,
+    readonly sectionContract: ArchitectSectionContract
+  ) {}
+  systemPrompt(): string {
+    return 'stub';
+  }
+  async run(_input: ArchitectInput): Promise<ArchitectOutput> {
+    return {
+      architectName: this.name,
+      architectureFields: {},
+      confidence: 0,
+      notes: 'stub does not implement run',
+      dependencies: [],
+      risks: [],
+      toolCalls: [],
+      spend: { inputTokens: 0, outputTokens: 0, usdCost: 0, wallClockMs: 0, model: 'none' },
+      status: 'failed',
+      failureReason: 'stub'
+    };
+  }
+}
+
+describe('ArchitectRegistry — registration & disjointness', () => {
+  let registry: ArchitectRegistry;
+
+  beforeEach(() => {
+    registry = new ArchitectRegistry();
+  });
+
+  it('registers the Feature Flagging architect cleanly', () => {
+    expect(() => {
+      registry.register(new FeatureFlaggingArchitect());
+    }).not.toThrow();
+    expect(registry.get('featureFlagging')).toBeDefined();
+  });
+
+  it('claims every owned field path on the registry', () => {
+    registry.register(new FeatureFlaggingArchitect());
+    for (const k of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+      expect(registry.ownerOf(k)).toBe('featureFlagging');
+    }
+  });
+
+  it('rejects a duplicate registration of the same architect name', () => {
+    registry.register(new FeatureFlaggingArchitect());
+    expect(() => registry.register(new FeatureFlaggingArchitect())).toThrowError(
+      ArchitectRegistryError
+    );
+  });
+
+  it('rejects a second architect that overlaps owned field paths', () => {
+    registry.register(new FeatureFlaggingArchitect());
+
+    const collidingContract: ArchitectSectionContract = {
+      contractId: 'colliding.v1',
+      architectName: 'colliding',
+      version: '0.1.0',
+      sections: [
+        {
+          path: 'featureFlags.flagsSchema',
+          description: 'colliding owner',
+          required: true
+        }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 15,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('colliding', collidingContract));
+    }).toThrowError(ArchitectRegistryError);
+  });
+
+  it('accepts a second architect with disjoint owned fields', () => {
+    registry.register(new FeatureFlaggingArchitect());
+    const disjointContract: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [
+        { path: 'frontend.componentTree', description: 'frontend tree', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    expect(() => {
+      registry.register(new StubArchitect('frontend', disjointContract));
+    }).not.toThrow();
+    expect(registry.size()).toBe(2);
+    expect(registry.allPaths().length).toBe(FEATURE_FLAGGING_OWNED_FIELD_KEYS.length + 1);
+  });
+
+  it('disjointness() detects no conflicts when only Feature Flagging is present', () => {
+    const conflicts = disjointness([FeatureFlaggingArchitectContract]);
+    expect(conflicts).toEqual([]);
+  });
+
+  it('disjointness() detects a conflict between Feature Flagging and a clone', () => {
+    const clone: ArchitectSectionContract = {
+      ...FeatureFlaggingArchitectContract,
+      contractId: 'feature-flagging-clone.v1',
+      architectName: 'feature-flagging-clone'
+    };
+    const conflicts = disjointness([FeatureFlaggingArchitectContract, clone]);
+    expect(conflicts.length).toBe(FEATURE_FLAGGING_OWNED_FIELD_KEYS.length);
+  });
+
+  it('registry.validate() reports the unregistered upstream deps (frontend + backend) when this architect is the only one registered', () => {
+    registry.register(new FeatureFlaggingArchitect());
+    const errs = registry.validate();
+    // Feature Flagging depends on frontend + backend; with neither
+    // registered the validator should surface both as missing-dep errors.
+    expect(errs.length).toBe(2);
+    expect(errs.join(' ')).toMatch(/frontend/);
+    expect(errs.join(' ')).toMatch(/backend/);
+  });
+
+  it('registry.validate() is empty once both upstream architects are registered', () => {
+    const stubFrontend: ArchitectSectionContract = {
+      contractId: 'frontend-architect.v1',
+      architectName: 'frontend',
+      version: '0.1.0',
+      sections: [
+        { path: 'frontend.componentTree', description: 'tree', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 14,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    const stubBackend: ArchitectSectionContract = {
+      contractId: 'backend-architect.v1',
+      architectName: 'backend',
+      version: '0.1.0',
+      sections: [
+        { path: 'backend.apiEndpoints', description: 'endpoints', required: true }
+      ],
+      architectMeta: {
+        dependsOn: [],
+        precedenceLevel: 12,
+        fanoutPolicy: 'always',
+        appliesPredicate: () => true,
+        runtimeModel: 'sonnet'
+      }
+    };
+    registry.register(new StubArchitect('frontend', stubFrontend));
+    registry.register(new StubArchitect('backend', stubBackend));
+    registry.register(new FeatureFlaggingArchitect());
+    expect(registry.validate()).toEqual([]);
+  });
+});

--- a/packages/feature-flagging-architect/tests/golden/golden.test.ts
+++ b/packages/feature-flagging-architect/tests/golden/golden.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Golden test — the canonical known-good Feature-Flagging-architect
+ * artifact for a known prakash-tiwari Story ticket.
+ *
+ * This test serves three purposes:
+ *
+ *   1. Lock the architect's output shape against drift. Any change to
+ *      the contract or run() must update this snapshot.
+ *
+ *   2. Demonstrate the architect produces a complete, validating output
+ *      end-to-end given a realistic input (with upstream FE+BE).
+ *
+ *   3. Verify the depends-on plumbing: upstream Frontend + Backend
+ *      output flows into the user prompt unmodified.
+ *
+ * Note: this test uses a deterministic fake spawner. It does NOT call
+ * the real claude binary. The "golden" here is the expected
+ * deterministic projection of the input through the run() pipeline,
+ * given a fixed assistant text.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { FeatureFlaggingArchitect } from '../../src/architect.js';
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import { FEATURE_FLAGGING_INVARIANTS } from '../../src/invariants.js';
+import { validateArchitectOutput } from '../../src/validation.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  goldenAssistantText,
+  goldenExpectedOutput
+} from '../helpers/fakes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('golden — prakash-tiwari new-booking-flow Story ticket', () => {
+  it('input-ticket.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-ticket.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().ticket;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-businessplan.json fixture loads and matches buildFakeInput()', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-businessplan.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().businessPlan;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-upstream-frontend.json fixture loads and matches the upstream FE output', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-upstream-frontend.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().upstream.outputs?.frontend;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('input-upstream-backend.json fixture loads and matches the upstream BE output', () => {
+    const raw = JSON.parse(
+      readFileSync(resolve(__dirname, 'input-upstream-backend.json'), 'utf-8')
+    );
+    const fixture = buildFakeInput().upstream.outputs?.backend;
+    expect(raw).toEqual(fixture);
+  });
+
+  it('assistant text validates cleanly', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('end-to-end produces the canonical ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new FeatureFlaggingArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    // Architect name, status, top-level shape
+    expect(out.architectName).toBe('featureFlagging');
+    expect(out.status).toBe('ok');
+    expect(out.confidence).toBeGreaterThan(0.5);
+
+    // Every owned field present
+    for (const k of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+
+    // Field values match the known-good expectation (except spend, which
+    // the run pipeline overwrites).
+    const expected = goldenExpectedOutput();
+    expect(out.architectureFields).toEqual(expected.architectureFields);
+    expect(out.confidence).toBe(expected.confidence);
+    expect(out.notes).toBe(expected.notes);
+    expect(out.dependencies).toEqual(expected.dependencies);
+    expect(out.risks).toEqual(expected.risks);
+  });
+
+  it('output passes every Feature Flagging invariant', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new FeatureFlaggingArchitect({ spawner });
+    const out = await arch.run(buildFakeInput());
+
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      const ok = inv.detect(out.architectureFields);
+      expect(ok, `invariant ${inv.id} should pass on the golden output`).toBe(true);
+    }
+  });
+
+  it('idempotent — running twice yields equivalent ArchitectOutput', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const arch = new FeatureFlaggingArchitect({ spawner });
+    const a = await arch.run(buildFakeInput());
+    const b = await arch.run(buildFakeInput());
+    expect(a).toEqual(b);
+  });
+
+  it('golden output contains a kill switch with blastRadius=payments', () => {
+    const switches = (goldenExpectedOutput().architectureFields[
+      'featureFlags.killSwitches'
+    ] ?? []) as Array<{ blastRadius: string }>;
+    expect(switches.length).toBeGreaterThan(0);
+    expect(switches.some(s => s.blastRadius === 'payments')).toBe(true);
+  });
+
+  it('golden output forward-references A/B Testing via experimentationLinkage', () => {
+    const linkage = (goldenExpectedOutput().architectureFields[
+      'featureFlags.experimentationLinkage'
+    ] ?? []) as Array<{ abTestId: string }>;
+    expect(linkage.length).toBeGreaterThan(0);
+    for (const entry of linkage) {
+      expect(entry.abTestId).toBeTruthy();
+    }
+  });
+
+  it('golden output declares per-environment defaults (dev/staging/production) for every flag', () => {
+    const schema = (goldenExpectedOutput().architectureFields[
+      'featureFlags.flagsSchema'
+    ] ?? []) as Array<{ defaults: Record<string, unknown> }>;
+    for (const flag of schema) {
+      expect(flag.defaults).toHaveProperty('dev');
+      expect(flag.defaults).toHaveProperty('staging');
+      expect(flag.defaults).toHaveProperty('production');
+    }
+  });
+});

--- a/packages/feature-flagging-architect/tests/golden/input-businessplan.json
+++ b/packages/feature-flagging-architect/tests/golden/input-businessplan.json
@@ -1,0 +1,12 @@
+{
+  "ventureName": "Prakash Tiwari Studio",
+  "oneLiner": "Bespoke artist session booking for the Prakash Tiwari portrait studio.",
+  "audience": "High-intent prospective sitters in the artist's metropolitan area.",
+  "goals": [
+    "Drive booking completions",
+    "Reduce drop-off in the booking funnel",
+    "Validate the streamlined three-step variant via A/B test"
+  ],
+  "brandVoice": "warm + grounded",
+  "constraints": ["Must not break legacy booking links in customer emails"]
+}

--- a/packages/feature-flagging-architect/tests/golden/input-ticket.json
+++ b/packages/feature-flagging-architect/tests/golden/input-ticket.json
@@ -1,0 +1,17 @@
+{
+  "id": "ticket-pt-042",
+  "type": "Story",
+  "scope": "story",
+  "parent_id": null,
+  "acceptance_criteria": [
+    "New booking flow ships behind a flag, default off in production.",
+    "Operator can roll out canary → 10% → 50% → 100% with auto-promote on clean error rate.",
+    "Kill switch flips in <30 seconds without a deploy.",
+    "Every flag toggle emits an audit log entry to default Cloudwatch sink."
+  ],
+  "business_requirements": {
+    "title": "New booking flow with A/B test",
+    "description": "Replace the legacy booking form with a streamlined three-step flow. Ship behind a feature flag; canary to 10% of tenants, observe completion rate vs. control, promote to 100% on win."
+  },
+  "quality_tags": ["flag", "rollout", "ab-test", "payments"]
+}

--- a/packages/feature-flagging-architect/tests/golden/input-upstream-backend.json
+++ b/packages/feature-flagging-architect/tests/golden/input-upstream-backend.json
@@ -1,0 +1,30 @@
+{
+  "architectName": "backend",
+  "architectureFields": {
+    "backend.apiEndpoints": [
+      {
+        "method": "POST",
+        "path": "/api/v1/bookings",
+        "purpose": "Create a booking — drives payment authorization."
+      },
+      {
+        "method": "GET",
+        "path": "/api/v1/bookings/[id]",
+        "purpose": "Fetch a booking by id."
+      }
+    ]
+  },
+  "confidence": 0.85,
+  "notes": "Two endpoints: POST creates + auths payment, GET reads.",
+  "dependencies": [],
+  "risks": [],
+  "toolCalls": [],
+  "spend": {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "usdCost": 0,
+    "wallClockMs": 0,
+    "model": "sonnet"
+  },
+  "status": "ok"
+}

--- a/packages/feature-flagging-architect/tests/golden/input-upstream-frontend.json
+++ b/packages/feature-flagging-architect/tests/golden/input-upstream-frontend.json
@@ -1,0 +1,41 @@
+{
+  "architectName": "frontend",
+  "architectureFields": {
+    "frontend.componentTree": [
+      {
+        "id": "booking-shell",
+        "kind": "section",
+        "children": [
+          { "id": "booking-step-1", "kind": "Form" },
+          { "id": "booking-step-2", "kind": "Form" },
+          { "id": "booking-step-3", "kind": "Form" },
+          { "id": "booking-submit", "kind": "Button" }
+        ]
+      }
+    ],
+    "frontend.interactionStates": {
+      "booking-submit": {
+        "hover": "darker brand fill",
+        "focus": "visible ring",
+        "active": "inset shadow",
+        "error": "inline error message",
+        "empty": "n/a",
+        "loading": "spinner replacing label",
+        "disabled": "50% opacity"
+      }
+    }
+  },
+  "confidence": 0.9,
+  "notes": "Booking shell projected as a single section.",
+  "dependencies": [],
+  "risks": [],
+  "toolCalls": [],
+  "spend": {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "usdCost": 0,
+    "wallClockMs": 0,
+    "model": "sonnet"
+  },
+  "status": "ok"
+}

--- a/packages/feature-flagging-architect/tests/helpers/fakes.ts
+++ b/packages/feature-flagging-architect/tests/helpers/fakes.ts
@@ -1,0 +1,354 @@
+/**
+ * Test fixtures + fake spawner factory.
+ *
+ *   - `buildFakeInput()` — produces a deterministic `ArchitectInput` for
+ *     a known prakash-tiwari Story ticket with upstream Frontend +
+ *     Backend output. The golden test uses this.
+ *
+ *   - `fakeSpawnerReturning(text)` — fabricates an `ArchitectSpawnerFn`
+ *     that returns the given text deterministically.
+ *
+ *   - `goldenExpectedOutput()` — the canonical known-good
+ *     `ArchitectOutput` for the prakash-tiwari Story fixture.
+ */
+
+import type { ArchitectInput, ArchitectOutput } from '../../src/types.js';
+
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from '../../src/contract.js';
+import type {
+  ArchitectSpawnerFn,
+  ArchitectSpawnInput,
+  ArchitectSpawnOutput
+} from '../../src/spawner.js';
+
+/**
+ * The canonical fixture — a Story ticket ("New booking flow") from the
+ * prakash-tiwari.com marketing site. Includes upstream Frontend +
+ * Backend output so the architect has something to flag.
+ */
+export function buildFakeInput(): ArchitectInput {
+  return {
+    ticket: {
+      id: 'ticket-pt-042',
+      type: 'Story',
+      scope: 'story',
+      parent_id: null,
+      acceptance_criteria: [
+        'New booking flow ships behind a flag, default off in production.',
+        'Operator can roll out canary → 10% → 50% → 100% with auto-promote on clean error rate.',
+        'Kill switch flips in <30 seconds without a deploy.',
+        'Every flag toggle emits an audit log entry to default Cloudwatch sink.'
+      ],
+      business_requirements: {
+        title: 'New booking flow with A/B test',
+        description:
+          'Replace the legacy booking form with a streamlined three-step flow. Ship behind a feature flag; canary to 10% of tenants, observe completion rate vs. control, promote to 100% on win.'
+      },
+      quality_tags: ['flag', 'rollout', 'ab-test', 'payments']
+    },
+    upstream: {
+      outputs: {
+        frontend: {
+          architectName: 'frontend',
+          architectureFields: {
+            'frontend.componentTree': [
+              {
+                id: 'booking-shell',
+                kind: 'section',
+                children: [
+                  { id: 'booking-step-1', kind: 'Form' },
+                  { id: 'booking-step-2', kind: 'Form' },
+                  { id: 'booking-step-3', kind: 'Form' },
+                  { id: 'booking-submit', kind: 'Button' }
+                ]
+              }
+            ],
+            'frontend.interactionStates': {
+              'booking-submit': {
+                hover: 'darker brand fill',
+                focus: 'visible ring',
+                active: 'inset shadow',
+                error: 'inline error message',
+                empty: 'n/a',
+                loading: 'spinner replacing label',
+                disabled: '50% opacity'
+              }
+            }
+          },
+          confidence: 0.9,
+          notes: 'Booking shell projected as a single section.',
+          dependencies: [],
+          risks: [],
+          toolCalls: [],
+          spend: {
+            inputTokens: 0,
+            outputTokens: 0,
+            usdCost: 0,
+            wallClockMs: 0,
+            model: 'sonnet'
+          },
+          status: 'ok'
+        },
+        backend: {
+          architectName: 'backend',
+          architectureFields: {
+            'backend.apiEndpoints': [
+              {
+                method: 'POST',
+                path: '/api/v1/bookings',
+                purpose: 'Create a booking — drives payment authorization.'
+              },
+              {
+                method: 'GET',
+                path: '/api/v1/bookings/[id]',
+                purpose: 'Fetch a booking by id.'
+              }
+            ]
+          },
+          confidence: 0.85,
+          notes: 'Two endpoints: POST creates + auths payment, GET reads.',
+          dependencies: [],
+          risks: [],
+          toolCalls: [],
+          spend: {
+            inputTokens: 0,
+            outputTokens: 0,
+            usdCost: 0,
+            wallClockMs: 0,
+            model: 'sonnet'
+          },
+          status: 'ok'
+        }
+      }
+    },
+    businessPlan: {
+      ventureName: 'Prakash Tiwari Studio',
+      oneLiner: 'Bespoke artist session booking for the Prakash Tiwari portrait studio.',
+      audience: "High-intent prospective sitters in the artist's metropolitan area.",
+      goals: [
+        'Drive booking completions',
+        'Reduce drop-off in the booking funnel',
+        'Validate the streamlined three-step variant via A/B test'
+      ],
+      brandVoice: 'warm + grounded',
+      constraints: ['Must not break legacy booking links in customer emails']
+    },
+    designVersion: {
+      versionId: 'design-pt-v4-2026-05-23',
+      snapshotUri: 's3://atlas/designs/design-pt-v4-2026-05-23.png',
+      anchors: [
+        {
+          anchorId: 'booking-shell',
+          kind: 'section',
+          bbox: { x: 0, y: 0, w: 1440, h: 900 }
+        }
+      ],
+      tokens: {
+        'color.brand.primary': '#0f3057',
+        'space.4': '16px'
+      },
+      breakpoints: ['sm', 'md', 'lg', 'xl']
+    },
+    tenantContext: {
+      tenantId: 'tenant-prakash-tiwari',
+      schemaName: 'pt_001',
+      vaultNamespace: 'tenant/prakash-tiwari',
+      billingPosture: 'subscription',
+      creditBalance: { usdAvailable: 25 }
+    },
+    budget: {
+      maxInputTokens: 60_000,
+      maxOutputTokens: 8_000,
+      maxWallClockMs: 60_000,
+      preferredModel: 'sonnet',
+      hardCostCeilingUsd: 0.5
+    }
+  };
+}
+
+/**
+ * The known-good output for the prakash-tiwari Story fixture.
+ *
+ * Two flags:
+ *   - `ticket-pt-042.new-booking-flow` (boolean) — gates the new UI shell;
+ *     canary rollout; kill switch (blast radius: payments); drives A/B
+ *     test.
+ *   - `ticket-pt-042.payment-auth-on` (boolean) — kill switch for
+ *     payment authorization itself (blast radius: payments); all-at-once
+ *     rollout (it's always on by default; the switch exists for
+ *     incident response).
+ */
+export function goldenExpectedOutput(): ArchitectOutput {
+  return {
+    architectName: 'featureFlagging',
+    architectureFields: {
+      'featureFlags.flagsSchema': [
+        {
+          name: 'ticket-pt-042.new-booking-flow',
+          type: 'boolean',
+          description: 'Gates the new three-step booking flow UI.',
+          defaults: {
+            dev: true,
+            staging: false,
+            production: false
+          },
+          audience: {
+            kind: 'percentage',
+            value: 0
+          }
+        },
+        {
+          name: 'ticket-pt-042.payment-auth-on',
+          type: 'boolean',
+          description: 'Kill switch for payment authorization in the booking flow.',
+          defaults: {
+            dev: true,
+            staging: true,
+            production: true
+          },
+          audience: {
+            kind: 'everyone'
+          }
+        }
+      ],
+      'featureFlags.rolloutStrategies': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          kind: 'canary',
+          steps: [
+            { stage: 'canary', percent: 1, gateMetric: 'error_rate<0.5%', soakMinutes: 30 },
+            { stage: 'early', percent: 10, gateMetric: 'error_rate<0.5%', soakMinutes: 60 },
+            {
+              stage: 'broad',
+              percent: 50,
+              gateMetric: 'error_rate<0.5%',
+              soakMinutes: 120
+            },
+            { stage: 'ga', percent: 100 }
+          ],
+          autoPromote: true,
+          rollbackTrigger: '5xx_rate>2x_baseline'
+        },
+        {
+          flag: 'ticket-pt-042.payment-auth-on',
+          kind: 'all-at-once',
+          steps: [{ stage: 'ga', percent: 100 }],
+          autoPromote: false,
+          rollbackTrigger: 'manual-only'
+        }
+      ],
+      'featureFlags.killSwitches': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          blastRadius: 'payments',
+          instantToggle: true,
+          bypassReviewQuorum: true,
+          notificationChannels: ['pager:oncall', 'slack:#payments-incidents']
+        },
+        {
+          flag: 'ticket-pt-042.payment-auth-on',
+          blastRadius: 'payments',
+          instantToggle: true,
+          bypassReviewQuorum: true,
+          notificationChannels: ['pager:oncall', 'slack:#payments-incidents']
+        }
+      ],
+      'featureFlags.experimentationLinkage': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          abTestId: 'abtest-pending',
+          variants: [
+            { variantKey: 'control', flagValue: false, allocation: 0.5 },
+            { variantKey: 'treatment', flagValue: true, allocation: 0.5 }
+          ],
+          holdoutPercent: 5,
+          primaryMetric: 'booking_completed',
+          startDate: '2026-06-01',
+          durationCapDays: 28
+        }
+      ],
+      'featureFlags.auditRequirements': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          toggleRoles: ['operator', 'oncall'],
+          requiresChangeRecord: true,
+          auditLogSink: 'default-cloudwatch',
+          retentionDays: 365,
+          reviewCadenceDays: 90
+        },
+        {
+          flag: 'ticket-pt-042.payment-auth-on',
+          toggleRoles: ['operator', 'oncall'],
+          requiresChangeRecord: true,
+          auditLogSink: 'default-cloudwatch',
+          retentionDays: 365,
+          reviewCadenceDays: 90
+        }
+      ]
+    },
+    confidence: 0.86,
+    notes:
+      'Two flags: the booking-flow gate (canary 1/10/50/100 with auto-promote on clean 5xx) and a payment-auth kill switch (always-on, manual flip only on incident). Both have kill switches because blast radius is "payments". Forward-references A/B Testing via experimentationLinkage with a 5% holdout. Audit posture: default Cloudwatch sink, 365-day retention, 90-day stale review.',
+    dependencies: ['ticket-pt-041'],
+    risks: [],
+    toolCalls: [],
+    spend: {
+      inputTokens: 0,
+      outputTokens: 0,
+      usdCost: 0,
+      wallClockMs: 0,
+      model: 'sonnet'
+    },
+    status: 'ok'
+  };
+}
+
+/** The canonical assistant text — `JSON.stringify(goldenExpectedOutput())`. */
+export function goldenAssistantText(): string {
+  return JSON.stringify(goldenExpectedOutput());
+}
+
+/**
+ * Fabricate an `ArchitectSpawnerFn` that returns the given text on every
+ * call. Records every call for assertions.
+ */
+export interface FakeSpawner {
+  fn: ArchitectSpawnerFn;
+  calls: ArchitectSpawnInput[];
+}
+
+export function fakeSpawnerReturning(text: string, ok = true): FakeSpawner {
+  const calls: ArchitectSpawnInput[] = [];
+  const fn: ArchitectSpawnerFn = async (
+    input: ArchitectSpawnInput
+  ): Promise<ArchitectSpawnOutput> => {
+    calls.push(input);
+    return {
+      text,
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.01,
+      wallClockMs: 1234,
+      model: input.budget.preferredModel,
+      ok,
+      diagnostic: ok ? null : 'forced failure'
+    };
+  };
+  return { fn, calls };
+}
+
+/** Fabricate a spawner that returns the canonical golden assistant text. */
+export function fakeGoldenSpawner(): FakeSpawner {
+  return fakeSpawnerReturning(goldenAssistantText());
+}
+
+/**
+ * Asserts that the input covers every required owned field. Sanity check
+ * for fixtures.
+ */
+export function assertCoversAllOwnedFields(output: ArchitectOutput): void {
+  const have = new Set(Object.keys(output.architectureFields));
+  for (const k of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+    if (!have.has(k)) throw new Error(`fixture missing owned field: ${k}`);
+  }
+}

--- a/packages/feature-flagging-architect/tests/invariants.test.ts
+++ b/packages/feature-flagging-architect/tests/invariants.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Cross-architect invariants — verifies Feature Flagging's contributions
+ * to the EA Reviewer's invariant registry (per spec §6.2).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { FEATURE_FLAGGING_INVARIANTS } from '../src/invariants.js';
+import { goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('FEATURE_FLAGGING_INVARIANTS — structural', () => {
+  it('declares at least one invariant', () => {
+    expect(FEATURE_FLAGGING_INVARIANTS.length).toBeGreaterThan(0);
+  });
+
+  it('every invariant has a stable id', () => {
+    const seen = new Set<string>();
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      expect(inv.id.length).toBeGreaterThan(0);
+      expect(seen.has(inv.id)).toBe(false);
+      seen.add(inv.id);
+    }
+  });
+
+  it('every invariant is contributed by `featureFlagging`', () => {
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      expect(inv.contributor).toBe('featureFlagging');
+    }
+  });
+
+  it('every invariant declares a non-empty `reads` list', () => {
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      expect(inv.reads.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every invariant has a valid severity', () => {
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      expect(['fail', 'advisory']).toContain(inv.severity);
+    }
+  });
+
+  it('every invariant has a non-empty description', () => {
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      expect(inv.description.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('FEATURE_FLAGGING_INVARIANTS — predicate behaviour against the golden fixture', () => {
+  const goldenArch = goldenExpectedOutput().architectureFields;
+
+  it('every invariant passes against the canonical good output', () => {
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      const ok = inv.detect(goldenArch);
+      expect(ok, `invariant ${inv.id} should pass on the golden fixture`).toBe(true);
+    }
+  });
+
+  it('flagsSchema-is-array fails when flagsSchema is not an array', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.flagsSchema-is-array'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = { ...goldenArch, 'featureFlags.flagsSchema': { not: 'an-array' } };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('flagsSchema-is-array passes on empty array (no flags is OK)', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.flagsSchema-is-array'
+    );
+    expect(inv!.detect({ ...goldenArch, 'featureFlags.flagsSchema': [] })).toBe(true);
+  });
+
+  it('every-flag-has-rollout fails when a flag has no rollout entry', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.every-flag-has-rollout'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.rolloutStrategies': [
+        // Only the first flag has a rollout; the second is missing.
+        { flag: 'ticket-pt-042.new-booking-flow', kind: 'canary', steps: [] }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('every-flag-has-audit fails when a flag has no audit entry', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.every-flag-has-audit'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.auditRequirements': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          toggleRoles: ['operator'],
+          requiresChangeRecord: true,
+          auditLogSink: 'default-cloudwatch',
+          retentionDays: 365,
+          reviewCadenceDays: 90
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('kill-switches-are-instant fails when instantToggle is false', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.kill-switches-are-instant'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.killSwitches': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          blastRadius: 'payments',
+          instantToggle: false,
+          bypassReviewQuorum: true,
+          notificationChannels: []
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('kill-switches-are-instant passes on empty array (no kill switches)', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.kill-switches-are-instant'
+    );
+    expect(inv!.detect({ ...goldenArch, 'featureFlags.killSwitches': [] })).toBe(true);
+  });
+
+  it('experimentationLinkage-references-known-flags fails on unknown flag reference', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.experimentationLinkage-references-known-flags'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.experimentationLinkage': [
+        {
+          flag: 'never-declared-flag',
+          abTestId: 'abtest-foo',
+          variants: [],
+          holdoutPercent: 5,
+          primaryMetric: 'x',
+          startDate: '2026-06-01',
+          durationCapDays: 28
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('experimentationLinkage-references-known-flags passes on empty linkage', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.experimentationLinkage-references-known-flags'
+    );
+    expect(inv!.detect({ ...goldenArch, 'featureFlags.experimentationLinkage': [] })).toBe(
+      true
+    );
+  });
+
+  it('audit-retention-bounded fails when retentionDays is 0', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.audit-retention-bounded'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.auditRequirements': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          toggleRoles: ['operator'],
+          requiresChangeRecord: true,
+          auditLogSink: 'default-cloudwatch',
+          retentionDays: 0,
+          reviewCadenceDays: 90
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('audit-retention-bounded fails when auditLogSink is empty', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.audit-retention-bounded'
+    );
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.auditRequirements': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          toggleRoles: ['operator'],
+          requiresChangeRecord: true,
+          auditLogSink: '',
+          retentionDays: 365,
+          reviewCadenceDays: 90
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('material-blast-radius-has-kill-switch rejects unknown blastRadius value', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.material-blast-radius-has-kill-switch'
+    );
+    expect(inv).toBeDefined();
+    const corrupted = {
+      ...goldenArch,
+      'featureFlags.killSwitches': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          blastRadius: 'banana-radius',
+          instantToggle: true,
+          bypassReviewQuorum: true,
+          notificationChannels: []
+        }
+      ]
+    };
+    expect(inv!.detect(corrupted)).toBe(false);
+  });
+
+  it('material-blast-radius-has-kill-switch accepts "other" as a valid category', () => {
+    const inv = FEATURE_FLAGGING_INVARIANTS.find(
+      i => i.id === 'featureFlags.material-blast-radius-has-kill-switch'
+    );
+    const ok = {
+      ...goldenArch,
+      'featureFlags.killSwitches': [
+        {
+          flag: 'ticket-pt-042.new-booking-flow',
+          blastRadius: 'other',
+          instantToggle: true,
+          bypassReviewQuorum: false,
+          notificationChannels: ['slack:#general']
+        }
+      ]
+    };
+    expect(inv!.detect(ok)).toBe(true);
+  });
+});
+
+describe('FEATURE_FLAGGING_INVARIANTS — nested-architecture view', () => {
+  it('every invariant also works against the nested composed-architecture shape', () => {
+    // Build a nested view as the Dispatcher would compose it.
+    const flat = goldenExpectedOutput().architectureFields;
+    const nested: Record<string, unknown> = {
+      featureFlags: {
+        flagsSchema: flat['featureFlags.flagsSchema'],
+        rolloutStrategies: flat['featureFlags.rolloutStrategies'],
+        killSwitches: flat['featureFlags.killSwitches'],
+        experimentationLinkage: flat['featureFlags.experimentationLinkage'],
+        auditRequirements: flat['featureFlags.auditRequirements']
+      }
+    };
+    for (const inv of FEATURE_FLAGGING_INVARIANTS) {
+      const ok = inv.detect(nested);
+      expect(ok, `invariant ${inv.id} should pass on the nested view`).toBe(true);
+    }
+  });
+});

--- a/packages/feature-flagging-architect/tests/run.test.ts
+++ b/packages/feature-flagging-architect/tests/run.test.ts
@@ -1,0 +1,233 @@
+/**
+ * `run()` tests — verifies the runtime pipeline:
+ *
+ *   - happy path returns a well-formed ArchitectOutput
+ *   - idempotency: same input → equivalent output
+ *   - re-runs REPLACE owned fields (do not append)
+ *   - upstream FE+BE output is plumbed into the user prompt
+ *   - failure modes (spawn failure, validation failure)
+ *   - reviewer feedback is plumbed through
+ *   - spend telemetry comes from the spawner, not the assistant
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { FEATURE_FLAGGING_ARCHITECT_NAME, FeatureFlaggingArchitect } from '../src/architect.js';
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildUserPrompt, runFeatureFlaggingArchitect } from '../src/run.js';
+import { buildFeatureFlaggingSystemPrompt } from '../src/system-prompt.js';
+import {
+  buildFakeInput,
+  fakeGoldenSpawner,
+  fakeSpawnerReturning,
+  goldenAssistantText
+} from './helpers/fakes.js';
+
+describe('runFeatureFlaggingArchitect — happy path', () => {
+  it('produces an ArchitectOutput with the right architectName', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(out.architectName).toBe('featureFlagging');
+  });
+
+  it('output covers every owned field key', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    for (const k of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+      expect(out.architectureFields).toHaveProperty(k);
+    }
+  });
+
+  it('output status is `ok` on the canonical golden text', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('ok');
+  });
+
+  it('spend telemetry comes from the spawner, not the assistant', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(goldenAssistantText());
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(out.spend.inputTokens).toBe(1000);
+    expect(out.spend.outputTokens).toBe(500);
+    expect(out.spend.usdCost).toBe(0.01);
+    expect(out.spend.wallClockMs).toBe(1234);
+    expect(out.spend.model).toBe('sonnet');
+  });
+
+  it('passes the system prompt to the spawner', async () => {
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.systemPrompt).toBe(buildFeatureFlaggingSystemPrompt());
+  });
+
+  it('passes the projected user prompt to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runFeatureFlaggingArchitect(input, {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.userPrompt).toBe(buildUserPrompt(input));
+  });
+
+  it('passes the budget through to the spawner', async () => {
+    const input = buildFakeInput();
+    const { fn: spawner, calls } = fakeGoldenSpawner();
+    await runFeatureFlaggingArchitect(input, {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(calls[0]?.budget).toEqual(input.budget);
+  });
+});
+
+describe('runFeatureFlaggingArchitect — idempotency', () => {
+  it('same input → same output (deterministic spawner)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const a = await runFeatureFlaggingArchitect(input, {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    const b = await runFeatureFlaggingArchitect(input, {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('re-run REPLACES the architectureFields (no append)', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const input = buildFakeInput();
+    const r1 = await runFeatureFlaggingArchitect(input, {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    const r2 = await runFeatureFlaggingArchitect(input, {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(Object.keys(r2.architectureFields).sort()).toEqual(
+      Object.keys(r1.architectureFields).sort()
+    );
+    expect(Object.keys(r2.architectureFields).length).toBe(
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS.length
+    );
+  });
+});
+
+describe('runFeatureFlaggingArchitect — failure modes', () => {
+  it('returns status=failed when the spawner fails', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('', false);
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('failed');
+    expect(out.failureReason).toBeTruthy();
+    expect(Object.keys(out.architectureFields)).toEqual([]);
+  });
+
+  it('returns status=partial when validation fails (missing owned fields)', async () => {
+    const { fn: spawner } = fakeSpawnerReturning(
+      '{"architectName":"featureFlagging"}'
+    );
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+    expect(out.failureReason).toBeTruthy();
+    expect(out.risks.length).toBeGreaterThan(0);
+  });
+
+  it('returns status=partial when the assistant text is not JSON', async () => {
+    const { fn: spawner } = fakeSpawnerReturning('not json at all');
+    const out = await runFeatureFlaggingArchitect(buildFakeInput(), {
+      spawner,
+      systemPrompt: buildFeatureFlaggingSystemPrompt(),
+      architectName: FEATURE_FLAGGING_ARCHITECT_NAME
+    });
+    expect(out.status).toBe('partial');
+  });
+});
+
+describe('runFeatureFlaggingArchitect — depends-on plumbing', () => {
+  it('user prompt includes upstream Frontend componentTree (depends-on signal)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('booking-shell');
+    expect(p).toContain('booking-submit');
+  });
+
+  it('user prompt includes upstream Backend apiEndpoints (depends-on signal)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('/api/v1/bookings');
+    expect(p).toContain('POST');
+  });
+});
+
+describe('buildUserPrompt', () => {
+  it('serialises the ticket', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('ticket-pt-042');
+  });
+
+  it('omits privacy-sensitive tenant fields (schemaName, vaultNamespace)', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).not.toContain('pt_001');
+    expect(p).not.toContain('"vault/');
+  });
+
+  it('includes the tenantId for attribution', () => {
+    const p = buildUserPrompt(buildFakeInput());
+    expect(p).toContain('tenant-prakash-tiwari');
+  });
+
+  it('passes through reviewer feedback when present', () => {
+    const input = buildFakeInput();
+    const withFeedback = {
+      ...input,
+      reviewerFeedback: { reason: 'add a payments kill switch', severity: 'P1' as const }
+    };
+    const p = buildUserPrompt(withFeedback);
+    expect(p).toContain('add a payments kill switch');
+  });
+});
+
+describe('FeatureFlaggingArchitect — class-level integration', () => {
+  it('uses the architect class with a fake spawner', async () => {
+    const { fn: spawner } = fakeGoldenSpawner();
+    const a = new FeatureFlaggingArchitect({ spawner });
+    const out = await a.run(buildFakeInput());
+    expect(out.architectName).toBe('featureFlagging');
+    expect(out.status).toBe('ok');
+  });
+});

--- a/packages/feature-flagging-architect/tests/system-prompt.test.ts
+++ b/packages/feature-flagging-architect/tests/system-prompt.test.ts
@@ -1,0 +1,118 @@
+/**
+ * System-prompt tests — verifies the briefing satisfies spec §11(b).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { buildFeatureFlaggingSystemPrompt } from '../src/system-prompt.js';
+
+describe('buildFeatureFlaggingSystemPrompt', () => {
+  it('returns a non-empty string', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(typeof p).toBe('string');
+    expect(p.length).toBeGreaterThan(500);
+  });
+
+  it('is deterministic across calls', () => {
+    const p1 = buildFeatureFlaggingSystemPrompt();
+    const p2 = buildFeatureFlaggingSystemPrompt();
+    expect(p1).toBe(p2);
+  });
+
+  it('contains the Role section', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Role');
+    expect(p).toContain("CAIA's Feature Flagging Architect");
+  });
+
+  it('explicitly disclaims component code and backend logic responsibilities', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('DO NOT write component code or backend logic');
+    expect(p).toContain('DO specify what gets toggleable');
+  });
+
+  it('contains the Locked rollout posture section', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Locked rollout posture');
+    expect(p).toContain('OpenFeature');
+    expect(p).toContain('canary');
+    expect(p).toContain('30-min soak');
+    expect(p).toContain('Audit');
+  });
+
+  it('contains the Output JSON schema section', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Output JSON schema');
+    expect(p).toContain('architectName');
+    expect(p).toContain('architectureFields');
+    expect(p).toContain('confidence');
+    expect(p).toContain('notes');
+    expect(p).toContain('risks');
+    expect(p).toContain('status');
+    expect(p).toContain('featureFlagging');
+  });
+
+  it('references every declared owned field at least once', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    for (const key of FEATURE_FLAGGING_OWNED_FIELD_KEYS) {
+      expect(p).toContain(key);
+    }
+  });
+
+  it('contains the Decision heuristics section', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Decision heuristics');
+    expect(p).toContain('Read upstream before deciding what to flag');
+    expect(p).toContain('Default to "off" in production');
+  });
+
+  it('contains a Refusal patterns section that rejects out-of-namespace writes', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Refusal patterns');
+    expect(p).toContain('featureFlags.*');
+  });
+
+  it('contains a Self-check section', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Self-check');
+  });
+
+  it('contains an Examples section pointing at golden fixture', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('## Examples');
+    expect(p).toContain('tests/golden');
+  });
+
+  it('does not refer to fields outside the `featureFlags.*` namespace', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    const foreignPrefixes = [
+      'database.schemaDDL',
+      'security.cspPolicy',
+      'analytics.eventTaxonomy',
+      'observability.logShape',
+      'seo.canonicalUrl'
+    ];
+    for (const prefix of foreignPrefixes) {
+      expect(p).not.toContain(prefix);
+    }
+  });
+
+  it('references upstream Frontend componentTree + Backend apiEndpoints (depends-on signal)', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('frontend.componentTree');
+    expect(p).toContain('backend.apiEndpoints');
+  });
+
+  it('size is bounded (token-budget proxy: < 16k chars)', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p.length).toBeLessThan(16_000);
+  });
+
+  it('mentions material-blast-radius categories (auth, payments, ai-inference)', () => {
+    const p = buildFeatureFlaggingSystemPrompt();
+    expect(p).toContain('auth');
+    expect(p).toContain('payments');
+    expect(p).toContain('ai-inference');
+  });
+});

--- a/packages/feature-flagging-architect/tests/validation.test.ts
+++ b/packages/feature-flagging-architect/tests/validation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Output validation tests — verifies the contract validator catches
+ * every documented error class and accepts well-formed outputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { FEATURE_FLAGGING_OWNED_FIELD_KEYS } from '../src/contract.js';
+import { stripFences, validateArchitectOutput } from '../src/validation.js';
+import { goldenAssistantText, goldenExpectedOutput } from './helpers/fakes.js';
+
+describe('validateArchitectOutput — happy path', () => {
+  it('accepts the canonical golden output', () => {
+    const result = validateArchitectOutput(
+      goldenAssistantText(),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.parsed?.architectName).toBe('featureFlagging');
+    expect(result.parsed?.status).toBe('ok');
+  });
+
+  it('accepts JSON wrapped in ```json fences (lenient parser)', () => {
+    const fenced = '```json\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, FEATURE_FLAGGING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts JSON wrapped in plain ``` fences', () => {
+    const fenced = '```\n' + goldenAssistantText() + '\n```';
+    const result = validateArchitectOutput(fenced, FEATURE_FLAGGING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('validateArchitectOutput — error paths', () => {
+  it('rejects invalid JSON', () => {
+    const result = validateArchitectOutput('{not json', FEATURE_FLAGGING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('invalid-json');
+  });
+
+  it('rejects a top-level array', () => {
+    const result = validateArchitectOutput('[1,2,3]', FEATURE_FLAGGING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('rejects null top-level', () => {
+    const result = validateArchitectOutput('null', FEATURE_FLAGGING_OWNED_FIELD_KEYS);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]?.code).toBe('wrong-top-level-type');
+  });
+
+  it('flags missing top-level keys', () => {
+    const result = validateArchitectOutput(
+      '{"architectName":"featureFlagging"}',
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    const codes = result.errors.map(e => e.code);
+    expect(codes).toContain('missing-top-level-key');
+  });
+
+  it('flags a missing owned field', () => {
+    const golden = goldenExpectedOutput();
+    const fields = { ...golden.architectureFields } as Record<string, unknown>;
+    delete fields['featureFlags.killSwitches'];
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'missing-owned-field')).toBe(true);
+  });
+
+  it('flags an unexpected field outside the owned namespace', () => {
+    const golden = goldenExpectedOutput();
+    const fields = {
+      ...golden.architectureFields,
+      'backend.apiShape': 'not yours to declare'
+    };
+    const corrupted = { ...golden, architectureFields: fields };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'unexpected-field')).toBe(true);
+  });
+
+  it('flags out-of-range confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: 1.5 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags negative confidence', () => {
+    const corrupted = { ...goldenExpectedOutput(), confidence: -0.1 };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'confidence-out-of-range')).toBe(true);
+  });
+
+  it('flags overly long notes', () => {
+    const corrupted = { ...goldenExpectedOutput(), notes: 'x'.repeat(801) };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'notes-too-long')).toBe(true);
+  });
+
+  it('flags too many risk entries', () => {
+    const corrupted = {
+      ...goldenExpectedOutput(),
+      risks: ['a', 'b', 'c', 'd', 'e', 'f']
+    };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'too-many-risks')).toBe(true);
+  });
+
+  it('flags invalid status', () => {
+    const corrupted = { ...goldenExpectedOutput(), status: 'bananas' };
+    const result = validateArchitectOutput(
+      JSON.stringify(corrupted),
+      FEATURE_FLAGGING_OWNED_FIELD_KEYS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.code === 'invalid-status')).toBe(true);
+  });
+
+  it('accepts every legal status value', () => {
+    for (const s of ['ok', 'partial', 'failed']) {
+      const variant = { ...goldenExpectedOutput(), status: s };
+      const result = validateArchitectOutput(
+        JSON.stringify(variant),
+        FEATURE_FLAGGING_OWNED_FIELD_KEYS
+      );
+      expect(result.ok).toBe(true);
+    }
+  });
+});
+
+describe('stripFences', () => {
+  it('strips ```json fences', () => {
+    const out = stripFences('```json\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('strips plain ``` fences', () => {
+    const out = stripFences('```\n{"x":1}\n```');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('passes plain JSON through unchanged', () => {
+    const out = stripFences('{"x":1}');
+    expect(out).toBe('{"x":1}');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripFences('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});

--- a/packages/feature-flagging-architect/tsconfig.build.json
+++ b/packages/feature-flagging-architect/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["tests", "node_modules"]
+}

--- a/packages/feature-flagging-architect/tsconfig.json
+++ b/packages/feature-flagging-architect/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/feature-flagging-architect/vitest.config.ts
+++ b/packages/feature-flagging-architect/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', 'node_modules']
+    }
+  },
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1666,6 +1666,25 @@ importers:
 
   packages/events-taxonomy-internal: {}
 
+  packages/feature-flagging-architect:
+    dependencies:
+      '@caia/architect-kit':
+        specifier: workspace:*
+        version: link:../architect-kit
+      '@chiefaia/claude-spawner':
+        specifier: workspace:*
+        version: link:../claude-spawner
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.19.39)(jsdom@26.1.0)
+
   packages/feature-registry:
     dependencies:
       '@chiefaia/ticket-template':


### PR DESCRIPTION
## Summary

Ships **architect #12 of 17** — the **Feature Flagging specialist** — implementing `SpecialistArchitect` from `@caia/architect-kit` (PR #535). Owns the `featureFlags.*` slice of `tickets.architecture`.

## Owned fields

| Path | Purpose |
|---|---|
| `featureFlags.flagsSchema` | Per-flag name + type + per-env defaults + audience targeting |
| `featureFlags.rolloutStrategies` | percentage / user-id / canary / ring-deployment / all-at-once |
| `featureFlags.killSwitches` | Must-be-toggleable-instantly flags (auth, payments, etc.) |
| `featureFlags.experimentationLinkage` | Forward-reference to the A/B Testing Architect (#13) |
| `featureFlags.auditRequirements` | Who can toggle, audit-log per change |

## Key decisions

- **Name** = \`'featureFlagging'\` — matches the canonical \`CANONICAL_PRECEDENCE_LADDER\` entry from \`@caia/architect-kit\`.
- **dependsOn** = \`['frontend', 'backend']\` — reads upstream \`componentTree\` + \`apiEndpoints\` to know what's flag-worthy and where kill switches belong (wave-2 architect per task brief; spec §2.12 originally put it in wave 1; brief wins per the standing newer-brief-wins rule).
- **Precedence level** = **7** (between SEO/perf and API Gateway — rollout safety sits high).
- **5 owned fields** — reconciled superset of spec §2.12's eight sub-fields into the task brief's five higher-level fields.
- **No tools (V1)** — reads upstream FE+BE output directly.
- **Runtime model**: Sonnet (default), 1 LLM call per flag-touching ticket.

## Locked rollout posture (codified in the system prompt)

- OpenFeature-compatible schemas; types \`boolean\` / \`string\` / \`number\` / \`json\`.
- Default 'off' in production for every new flag.
- Canary curve: 1% → 10% → 50% → 100% with 30-min soak per stage.
- Auto-rollback on 5xx spike > 2× baseline.
- Kill switches **mandatory** for auth / payments / data-export / ai-inference / third-party-spend blast radius.
- Every toggle event audit-logged: actor + flag + old/new value + reason + timestamp + environment. 365-day retention default.
- Stale-flag review cadence: 90 days.

## 7 cross-architect invariants (for the EA Reviewer's registry)

1. \`flagsSchema-is-array\` (fail)
2. \`every-flag-has-rollout\` (fail)
3. \`every-flag-has-audit\` (fail)
4. \`kill-switches-are-instant\` (fail)
5. \`experimentationLinkage-references-known-flags\` (advisory)
6. \`audit-retention-bounded\` (advisory)
7. \`material-blast-radius-has-kill-switch\` (advisory)

## Tests

\`\`\`
contract.test.ts        39 tests
invariants.test.ts      20 tests
validation.test.ts      19 tests
run.test.ts             19 tests
system-prompt.test.ts   15 tests
architect.test.ts       12 tests
golden/golden.test.ts   11 tests
─────────────────────────────────
Total                  135 tests, all passing
\`\`\`

TypeScript strict clean; ESLint clean; \`pnpm build\` clean.

## Golden fixture

\`tests/golden/\` ships a canonical prakash-tiwari Story ticket (\`ticket-pt-042\` — new booking flow) with realistic upstream Frontend + Backend output. The architect produces two flags:

1. **\`ticket-pt-042.new-booking-flow\`** — boolean, default off in production, canary rollout (1/10/50/100 with auto-promote on clean error rate), payments-radius kill switch, drives an A/B test with 5% holdout.
2. **\`ticket-pt-042.payment-auth-on\`** — boolean kill switch for payment authorization itself (always-on, manual flip on incident).

## Template fidelity

Mirrors the \`@caia/frontend-architect\` canonical template module-for-module:

\`\`\`
src/
  architect.ts        (class + name + tools)
  contract.ts         (owned fields + meta + apply predicate + fix-hints)
  index.ts            (public surface)
  invariants.ts       (cross-architect invariants for EA Reviewer)
  run.ts              (runtime entry + buildUserPrompt)
  spawner.ts          (claude-spawner seam)
  system-prompt.md    (human-reviewable markdown)
  system-prompt.ts    (runtime composition)
  types.ts            (kit re-exports)
  validation.ts       (output contract checks)
tests/
  architect.test.ts
  contract.test.ts
  invariants.test.ts
  run.test.ts
  system-prompt.test.ts
  validation.test.ts
  helpers/fakes.ts
  golden/
    golden.test.ts
    input-ticket.json
    input-businessplan.json
    input-upstream-frontend.json
    input-upstream-backend.json
\`\`\`

## Stack reminder

shadcn/ui + Tailwind locked. This architect emits no UI but its \`experimentationLinkage\` forward-references the A/B Testing Architect, which in turn drives \`frontend.componentTree\` variant rendering.

## Constraints honored

- Subscription-only build (spawner wraps \`@chiefaia/claude-spawner\` — never sets \`ANTHROPIC_API_KEY\`).
- True-Zero rule: no real LLM calls in tests (deterministic fake spawner).
- Quality > timeline: 135 tests including a golden end-to-end fixture.

## References

- Spec: \`research/17_architect_framework_spec_2026.md\` §2.12
- Roster: \`agent-memory/project_caia_17_architects.md\` (#12)
- Template: \`@caia/frontend-architect\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)